### PR TITLE
Change validity check for liquidity orders

### DIFF
--- a/crates/solver/src/settlement.rs
+++ b/crates/solver/src/settlement.rs
@@ -268,17 +268,24 @@ impl Settlement {
 
     /// Returns all orders included in the settlement.
     pub fn traded_orders(&self) -> impl Iterator<Item = &Order> + '_ {
-        let user_orders = self
-            .encoder
+        self.traded_user_orders()
+            .chain(self.traded_liquidity_orders())
+    }
+
+    /// Returns only user orders included in the settlement.
+    pub fn traded_user_orders(&self) -> impl Iterator<Item = &Order> + '_ {
+        self.encoder
             .order_trades()
             .iter()
-            .map(|trade| &trade.trade.order);
-        let liquidity_orders = self
-            .encoder
+            .map(|trade| &trade.trade.order)
+    }
+
+    /// Returns only liquidity orders included in the settlement.
+    pub fn traded_liquidity_orders(&self) -> impl Iterator<Item = &Order> + '_ {
+        self.encoder
             .liquidity_order_trades()
             .iter()
-            .map(|trade| &trade.trade.order);
-        user_orders.chain(liquidity_orders)
+            .map(|trade| &trade.trade.order)
     }
 
     /// Returns an iterator of all executed trades.

--- a/crates/solver/src/solver/naive_solver/multi_order_solver.rs
+++ b/crates/solver/src/solver/naive_solver/multi_order_solver.rs
@@ -293,7 +293,7 @@ fn is_valid_solution(solution: &Settlement) -> bool {
             .clearing_price(order.sell_token)
             .expect("Solution should contain clearing price for sell token");
         let buy_token_price = if is_liquidity_order {
-            sell_token_price / order.sell_amount * order.buy_amount
+            sell_token_price / order.buy_amount * order.sell_amount
         } else {
             solution
                 .clearing_price(order.buy_token)

--- a/crates/solver/src/solver/naive_solver/multi_order_solver.rs
+++ b/crates/solver/src/solver/naive_solver/multi_order_solver.rs
@@ -279,7 +279,7 @@ fn compute_uniswap_in(
 /// Thus we ensure that `buy_token_price / sell_token_price >= limit_buy_amount / limit_sell_amount`
 ///
 fn is_valid_solution(solution: &Settlement) -> bool {
-    for order in solution.traded_orders() {
+    for order in solution.traded_user_orders() {
         let order = &order.creation;
         let buy_token_price = solution
             .clearing_price(order.buy_token)


### PR DESCRIPTION
This PR fixes Naive solver check if clearing prices are inside limit prices.

Previously, this check was done for all type of orders in a `Settlement`, including liquidity orders type. The issue is that, for liquidity orders, there is no buy_price in the `clearing_prices` map. As far as I understand, this check is unnecessary for liquidity orders, since they are traded at the limit price, therefore always respecting the limit price constraint (though not sure about this).

Edit: added check for liquidity order also, but buy token price is calculated for them instead of taken from clearing prices vector.