### PR TITLE
Support base URL with path

### DIFF
--- a/crates/alerter/Cargo.toml
+++ b/crates/alerter/Cargo.toml
@@ -12,7 +12,7 @@ reqwest = { version = "0.11", features = ["json"] }
 serde = { version = "1.0", features = ["derive"] }
 shared = { path = "../shared" }
 clap = { version = "3.1", features = ["derive", "env"] }
-tokio = { version = "1.15", features = ["macros", "time"] }
+tokio = { version = "1.15", features = ["macros", "time", "rt-multi-thread"] }
 tracing = "0.1"
 tracing-subscriber = "0.3"
 url = "2.0"

--- a/crates/alerter/src/main.rs
+++ b/crates/alerter/src/main.rs
@@ -43,8 +43,7 @@ impl OrderBookApi {
     }
 
     pub async fn solvable_orders(&self) -> reqwest::Result<Vec<Order>> {
-        let mut url = self.base.clone();
-        url.set_path("/api/v1/solvable_orders");
+        let url = self.base.join("api/v1/solvable_orders").unwrap();
         self.client
             .get(url)
             .send()
@@ -55,8 +54,7 @@ impl OrderBookApi {
     }
 
     pub async fn order(&self, uid: &OrderUid) -> reqwest::Result<Order> {
-        let mut url = self.base.clone();
-        url.set_path(&format!("/api/v1/orders/{}", uid));
+        let url = self.base.join(&format!("api/v1/orders/{}", uid)).unwrap();
         self.client
             .get(url)
             .send()
@@ -93,8 +91,7 @@ impl ZeroExApi {
     }
 
     pub async fn can_be_settled(&self, order: &Order) -> Result<bool> {
-        let mut url = self.base.clone();
-        url.set_path("/swap/v1/price");
+        let mut url = self.base.join("swap/v1/price").unwrap();
         let (amount_name, amount) = match order.kind {
             OrderKind::Buy => ("buyAmount", order.buy_amount),
             OrderKind::Sell => ("sellAmount", order.sell_amount),


### PR DESCRIPTION
#132 introduced regressions that caused the order alerter to constantly fail to retrieve orders. This is because the public API URL contains `/$network` path prefix that wasn't supported by the alerter.

This PR adds support for this. Basically, it just `join`s instead of replacing the path entirely with `set_path`.

### Test Plan

Run the alerter and see it make successful API requests:
```
% cargo run -p alerter -- --min-order-age 1 --time-without-trade 1
    Finished dev [unoptimized + debuginfo] target(s) in 0.09s
     Running `target/debug/alerter --min-order-age 1 --time-without-trade 1`
2022-04-07T11:24:09.456Z  INFO alerter: running alerter with Arguments {
    time_without_trade: 1s,
    min_order_age: 1s,
    min_alert_interval: 1799.99997952s,
    errors_in_a_row_before_alert: 5,
    orderbook_api: "https://api.cow.fi/mainnet/",
}
2022-04-07T11:24:09.701Z DEBUG alerter: found 16 open orders
2022-04-07T11:24:09.701Z DEBUG alerter: found no fulfilled orders
2022-04-07T11:24:39.747Z DEBUG alerter: found 14 open orders
2022-04-07T11:24:39.802Z DEBUG alerter: found no fulfilled orders
2022-04-07T11:24:41.905Z DEBUG alerter: 0x url="https://api.0x.org/swap/v1/price?sellToken=0x6b175474e89094c44da98b954eedeac495271d0f&buyToken=0xdac17f958d2ee523a2206206994597c13d831ec7&sellAmount=811063811362965485568" response=Response { sell_amount: 811063811362965485568, buy_amount: 810420605 }
2022-04-07T11:24:43.441Z DEBUG alerter: 0x url="https://api.0x.org/swap/v1/price?sellToken=0x6b175474e89094c44da98b954eedeac495271d0f&buyToken=0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48&sellAmount=475833914861854859264" response=Response { sell_amount: 475833914861854859264, buy_amount: 474553897 }
2022-04-07T11:24:43.952Z DEBUG alerter: 0x url="https://api.0x.org/swap/v1/price?sellToken=0xab846fb6c81370327e784ae7cbb6d6a6af6ff4bf&buyToken=0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2&sellAmount=45974334753652705821" response=Response { sell_amount: 45974334753652705821, buy_amount: 19342714737093254 }
2022-04-07T11:25:13.994Z DEBUG alerter: found 13 open orders
2022-04-07T11:25:14.084Z DEBUG alerter: found no fulfilled orders
2022-04-07T11:25:15.393Z DEBUG alerter: 0x url="https://api.0x.org/swap/v1/price?sellToken=0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48&buyToken=0xdac17f958d2ee523a2206206994597c13d831ec7&sellAmount=220029560" response=Response { sell_amount: 220029560, buy_amount: 218997589 }
...
```
