### PR TITLE
Draft: Flag to Enable Buying Ether with Smart Contracts

### DIFF
--- a/crates/e2e/tests/e2e/services.rs
+++ b/crates/e2e/tests/e2e/services.rs
@@ -179,6 +179,7 @@ impl OrderbookServices {
             HashSet::default(),
             HashSet::default(),
             Duration::from_secs(120),
+            false,
             fee_calculator.clone(),
             bad_token_detector.clone(),
             balance_fetcher,

--- a/crates/orderbook/src/main.rs
+++ b/crates/orderbook/src/main.rs
@@ -132,6 +132,12 @@ struct Arguments {
     #[clap(long, env, parse(try_from_str), default_value = "false")]
     enable_presign_orders: bool,
 
+    /// Enables SC order to buy native token. This is disabled by default since
+    /// smart contracts typically can't buy native tokens unless a solver is
+    /// submitting transactions with an access list.
+    #[clap(long, env)]
+    enable_smart_contract_buy_native_token: bool,
+
     /// If solvable orders haven't been successfully update in this time in seconds attempting
     /// to get them errors and our liveness check fails.
     #[clap(
@@ -650,6 +656,7 @@ async fn main() {
         args.banned_users.into_iter().collect(),
         args.shared.liquidity_order_owners.into_iter().collect(),
         args.min_order_validity_period,
+        args.enable_smart_contract_buy_native_token,
         fee_calculator.clone(),
         bad_token_detector.clone(),
         balance_fetcher,

--- a/crates/solver/src/driver.rs
+++ b/crates/solver/src/driver.rs
@@ -271,7 +271,7 @@ impl Driver {
             )
             .await;
 
-            for ((solver, settlement, _, _), result) in errors.iter().zip(simulations) {
+            for ((solver, settlement, access_list, _), result) in errors.iter().zip(simulations) {
                 metrics.settlement_simulation_failed_on_latest(solver.name());
                 if let Err(error_at_earlier_block) = result {
                     tracing::warn!(
@@ -281,7 +281,11 @@ impl Driver {
                         error_at_earlier_block,
                     );
                     // split warning into separate logs so that the messages aren't too long.
-                    tracing::warn!("settlement failure for: \n{:#?}", settlement);
+                    tracing::warn!(
+                        "settlement failure for: \n{:#?}\nAccess List: {:#?}",
+                        settlement,
+                        access_list
+                    );
 
                     metrics.settlement_simulation_failed(solver.name());
                 }


### PR DESCRIPTION
⚠️ Currently this PR is **in Draft** because of issues with access list generation.

This PR adds a new flag to the orderbook API to enable orders buying Ether where the receiver is a smart contract.

Because of recent gas fee schedule changes, transferring Ether to smart contracts from the Settlement contract as part of trade doesn't work without access lists. Specifically, the transfer is encoded as a `CALL` opcode with a very small gas limit. Gnosis Safes, for example, are implemented as proxy contracts that first read the "singleton" address at storage slot 0 and then do a `DELEGATECALL` to that address. The Ether transfer triggers these two things, however, the small gas stipend is not enough to actually execute them. With access lists, which would "warm up" the storage and addresses, would make it so the gas stipend would be enough.

Now that we have access list generation support, I decided to try and it out and see if we can finally buy Ether with smart contract receivers! 

### Test Plan

Added unit tests to verify new logic. Also ran a local test on Rinkeby. Unfortunately it doesn't work because the access list being generated doesn't warm up enough addresses and slots for the transfer to succeed. Specifically the Safe singleton copy address is not getting warmed up and leads to reverts like:

https://dashboard.tenderly.co/gp-v2/staging/simulator/4590f4e6-71fa-47eb-bff4-0a4f51251e77/public

I will try with Erigon access list estimation, and have contacted the Tenderly team to see if there is anything that can be done about it.