### PR TITLE
Add relevant help message for max_merged_settlements

### DIFF
--- a/crates/solver/src/main.rs
+++ b/crates/solver/src/main.rs
@@ -134,7 +134,7 @@ struct Arguments {
     #[clap(long, env, default_value = "9587")]
     metrics_port: u16,
 
-    /// The port at which we serve our metrics
+    /// The maximum number of settlements that can be merged for a single solver.  
     #[clap(long, env, default_value = "5")]
     max_merged_settlements: usize,
 


### PR DESCRIPTION
Fixes #144.

Updates the documentation for max_merged_settlements variable. Was incorrectly copied from the metrics port documentation. Gave best effort on the wording, may be worth an edit from the core team if I missed some context. 

### Test Plan

- N/Am - just documentation change

### Release notes

- N/A