### PR TITLE
Scale down in-flight partially fillable orders

### DIFF
--- a/crates/shared/src/conversions.rs
+++ b/crates/shared/src/conversions.rs
@@ -1,5 +1,7 @@
 use anyhow::{ensure, Result};
-use num::{bigint::Sign, rational::Ratio, BigInt, BigRational, ToPrimitive as _, Zero as _};
+use num::{
+    bigint::Sign, rational::Ratio, BigInt, BigRational, BigUint, ToPrimitive as _, Zero as _,
+};
 use primitive_types::U256;
 
 pub fn big_rational_to_float(ratio: &BigRational) -> Option<f64> {
@@ -18,6 +20,12 @@ pub fn u256_to_big_int(input: &U256) -> BigInt {
     let mut bytes = [0; 32];
     input.to_big_endian(&mut bytes);
     BigInt::from_bytes_be(Sign::Plus, &bytes)
+}
+
+pub fn u256_to_big_uint(input: &U256) -> BigUint {
+    let mut bytes = [0; 32];
+    input.to_big_endian(&mut bytes);
+    BigUint::from_bytes_be(&bytes)
 }
 
 pub fn u256_to_big_rational(input: &U256) -> BigRational {

--- a/crates/solver/src/driver.rs
+++ b/crates/solver/src/driver.rs
@@ -639,10 +639,6 @@ impl Driver {
                 )
                 .await
             {
-                let orders = winning_settlement
-                    .settlement
-                    .traded_orders()
-                    .map(|o| o.metadata.uid);
                 let block = match receipt.block_number {
                     Some(block) => block.as_u64(),
                     None => {
@@ -650,7 +646,10 @@ impl Driver {
                         0
                     }
                 };
-                self.in_flight_orders.mark_settled_orders(block, orders);
+
+                self.in_flight_orders
+                    .mark_settled_orders(block, &winning_settlement.settlement);
+
                 match receipt.effective_gas_price {
                     Some(price) => {
                         self.metrics.transaction_gas_price(price);

--- a/crates/solver/src/solver/naive_solver/multi_order_solver.rs
+++ b/crates/solver/src/solver/naive_solver/multi_order_solver.rs
@@ -146,7 +146,7 @@ fn solve_with_uniswap(
     // it either comes out of the fees or existing buffers. Compute that amount:
     let uniswap_out_with_rounding = big_int_to_u256(&settlement.executed_trades().fold(
         BigInt::default(),
-        |mut total, trade| {
+        |mut total, (_, trade)| {
             if trade.sell_token == uniswap_out_token {
                 total -= trade.sell_amount.to_big_int();
             } else {
@@ -932,7 +932,10 @@ mod tests {
         };
 
         let settlement = solve(orders, &pool.into()).unwrap();
-        let trades = settlement.executed_trades().collect::<Vec<_>>();
+        let trades = settlement
+            .executed_trades()
+            .map(|(_, trade)| trade)
+            .collect::<Vec<_>>();
 
         // Check the prices are set according to the expected pool swap:
         assert_eq!(settlement.clearing_prices(), &expected_prices);


### PR DESCRIPTION
Fixes #123

The driver currently filters out all solvable orders for which it knows that a trade referring to it is in-flight at the moment.
This is overly pessimistic for partially fillable orders because you could issue many trades using liquidity from that order as long as they don't exceed the executable amount from that order.

The improved approach is to sum up the executed amounts of all in-flight trades for a partially filled order and add that to the last "confirmed" executed amount of that order. "Confirmed" in this case means the `executed_(buy|sell|fee)_amount` fields from the order metadata. Data within that field gets calculated by our database and should probably be used as the source of truth in case trades for the same order show up across multiple auctions.

If a partially fillable order is actually filled completely the order gets dropped from the `Auction`.

### Test Plan

Update existing unit test and extend it.
