### PR TITLE
Limit http solver response size

### DIFF
--- a/crates/shared/src/http_client.rs
+++ b/crates/shared/src/http_client.rs
@@ -1,0 +1,46 @@
+use anyhow::{anyhow, Result};
+use reqwest::Response;
+
+/// Extracts the bytes of the response up to some size limit.
+///
+/// Returns an error if the byte limit was exceeded.
+pub async fn response_body_with_size_limit(
+    response: &mut Response,
+    limit: usize,
+) -> Result<Vec<u8>> {
+    let mut bytes = Vec::new();
+    while let Some(chunk) = response.chunk().await? {
+        let slice: &[u8] = &chunk;
+        if bytes.len() + slice.len() > limit {
+            return Err(anyhow!("size limit exceeded"));
+        }
+        bytes.extend_from_slice(slice);
+    }
+    Ok(bytes)
+}
+
+#[cfg(test)]
+mod tests {
+    use reqwest::Client;
+
+    use super::*;
+
+    #[tokio::test]
+    #[ignore]
+    async fn real() {
+        let client = Client::default();
+
+        let mut response = client.get("https://cow.fi").send().await.unwrap();
+        let bytes = response_body_with_size_limit(&mut response, 10).await;
+        dbg!(&bytes);
+        assert!(bytes.is_err());
+
+        let mut response = client.get("https://cow.fi").send().await.unwrap();
+        let bytes = response_body_with_size_limit(&mut response, 1_000_000)
+            .await
+            .unwrap();
+        dbg!(bytes.len());
+        let text = std::str::from_utf8(&bytes).unwrap();
+        dbg!(text);
+    }
+}

--- a/crates/shared/src/lib.rs
+++ b/crates/shared/src/lib.rs
@@ -10,6 +10,7 @@ pub mod current_block;
 pub mod ethcontract_error;
 pub mod event_handling;
 pub mod gas_price_estimation;
+pub mod http_client;
 pub mod http_solver;
 pub mod maintenance;
 pub mod metrics;


### PR DESCRIPTION
Part of https://github.com/cowprotocol/services/issues/151 .

A large response could exhaust our memory. We protect against this by limiting the size of the response to 10 MB.

### Test Plan

new unit test
