### PR TITLE
Make difference between gas saved and gas wasted

### DIFF
--- a/crates/solver/src/driver.rs
+++ b/crates/solver/src/driver.rs
@@ -235,6 +235,7 @@ impl Driver {
             transaction_hash,
         )
         .await?;
+        tracing::debug!(?gas_saved, "access list gas saved");
         if gas_saved.is_sign_positive() {
             self.metrics
                 .settlement_access_list_saved_gas(gas_saved, "positive");

--- a/crates/solver/src/driver.rs
+++ b/crates/solver/src/driver.rs
@@ -235,7 +235,14 @@ impl Driver {
             transaction_hash,
         )
         .await?;
-        self.metrics.settlement_access_list_saved_gas(gas_saved);
+        if gas_saved.is_sign_positive() {
+            self.metrics
+                .settlement_access_list_saved_gas(gas_saved, "positive");
+        } else {
+            self.metrics
+                .settlement_access_list_saved_gas(-gas_saved, "negative");
+        }
+
         Ok(())
     }
 


### PR DESCRIPTION
This PR introduces difference between positive gas saved (actual gas saved) and negative gas saved (gas wasted).

Negative gas saved happens when transaction with access lists gets reverted.

What I actually want is to work with `[metric_name]_sum` values, for which, I cant apply rate function in case of negative values.
https://prometheus.io/docs/practices/histograms/
This way I think we have the most flexibility.