### PR TITLE
Draft: Replaces MIP solver by LightQuasimodo.

### DIFF
--- a/crates/orderbook/src/main.rs
+++ b/crates/orderbook/src/main.rs
@@ -190,7 +190,7 @@ struct Arguments {
     #[clap(long, env)]
     cow_fee_factors: Option<SubsidyTiers>,
 
-    /// The API endpoint to call the mip v2 solver for price estimation
+    /// The API endpoint to call the quasimodo solver for price estimation
     #[clap(long, env)]
     quasimodo_solver_url: Option<Url>,
 
@@ -539,6 +539,7 @@ async fn main() {
                         max_nr_exec_orders: 100,
                         has_ucp_policy_parameter: false,
                         use_internal_buffers: args.shared.quasimodo_uses_internal_buffers.into(),
+                        restricted_token_set: false.into(),
                     },
                 }),
                 pool_fetcher.clone(),

--- a/crates/shared/src/arguments.rs
+++ b/crates/shared/src/arguments.rs
@@ -111,10 +111,6 @@ pub struct Arguments {
     #[clap(long, env)]
     pub quasimodo_uses_internal_buffers: bool,
 
-    /// If mipsolver should use internal buffers to improve solution quality.
-    #[clap(long, env)]
-    pub mip_uses_internal_buffers: bool,
-
     /// The Balancer V2 factories to consider for indexing liquidity. Allows
     /// specific pool kinds to be disabled via configuration. Will use all
     /// supported Balancer V2 factory kinds if not specified.

--- a/crates/shared/src/http_solver.rs
+++ b/crates/shared/src/http_solver.rs
@@ -58,6 +58,9 @@ pub struct SolverConfig {
 
     /// Controls if/how to set `use_internal_buffers`.
     pub use_internal_buffers: Option<bool>,
+
+    /// Focus on restricted set of tokens.
+    pub restricted_token_set: Option<bool>,
 }
 
 #[async_trait::async_trait]
@@ -104,6 +107,10 @@ impl HttpSolverApi for DefaultHttpSolverApi {
         if let Some(auction_id) = maybe_auction_id {
             url.query_pairs_mut()
                 .append_pair("auction_id", auction_id.to_string().as_str());
+        }
+        if let Some(restricted_token_set) = self.config.restricted_token_set {
+            url.query_pairs_mut()
+                .append_pair("conservative", restricted_token_set.to_string().as_str());
         }
         let query = url.query().map(ToString::to_string).unwrap_or_default();
         let mut request = self.client.post(url).timeout(timeout);

--- a/crates/shared/src/price_estimation/quasimodo.rs
+++ b/crates/shared/src/price_estimation/quasimodo.rs
@@ -437,6 +437,7 @@ mod tests {
                     max_nr_exec_orders: 100,
                     has_ucp_policy_parameter: false,
                     use_internal_buffers: true.into(),
+                    restricted_token_set: false.into(),
                 },
             }),
             sharing: Default::default(),

--- a/crates/solver/src/main.rs
+++ b/crates/solver/src/main.rs
@@ -54,13 +54,13 @@ struct Arguments {
     #[clap(long, env, default_value = "http://localhost:8080")]
     orderbook_url: Url,
 
-    /// The API endpoint to call the mip solver
-    #[clap(long, env, default_value = "http://localhost:8000")]
-    mip_solver_url: Url,
-
-    /// The API endpoint to call the mip v2 solver
+    /// The API endpoint to call the quasimodo solver
     #[clap(long, env, default_value = "http://localhost:8000")]
     quasimodo_solver_url: Url,
+
+    /// The API endpoint to call the light quasimodo solver
+    #[clap(long, env, default_value = "http://localhost:8000")]
+    light_quasimodo_solver_url: Url,
 
     /// The API endpoint to call the cow-dex-ag-solver solver
     #[clap(long, env, default_value = "http://localhost:8000")]
@@ -520,9 +520,9 @@ async fn main() {
         solvers,
         base_tokens.clone(),
         native_token_contract.address(),
-        args.mip_solver_url,
         args.cow_dex_ag_solver_url,
         args.quasimodo_solver_url,
+        args.light_quasimodo_solver_url,
         args.balancer_sor_url,
         &settlement_contract,
         vault_contract.as_ref(),
@@ -538,7 +538,6 @@ async fn main() {
         zeroex_api.clone(),
         args.zeroex_slippage_bps,
         args.shared.quasimodo_uses_internal_buffers,
-        args.shared.mip_uses_internal_buffers,
         args.shared.one_inch_url,
     )
     .expect("failure creating solvers");

--- a/crates/solver/src/solver/http_solver.rs
+++ b/crates/solver/src/solver/http_solver.rs
@@ -495,6 +495,7 @@ mod tests {
                     max_nr_exec_orders: 0,
                     has_ucp_policy_parameter: false,
                     use_internal_buffers: None,
+                    restricted_token_set: None,
                 },
             },
             Account::Local(Address::default(), None),


### PR DESCRIPTION
Removes MIP solver and adds LightQuasimodo in its place. 

LightQuasimodo is a different instance of the same server code as quasimodo. Differences to quasimodo is that it has less CPUs allocated to it, and is called using the new "conservative" flag that makes it consider only the orders and amms among a conservative list of tokens. 

This PR has to be deployed in tandem with https://gitlab.gnosisdev.com/devops/aws/aws-infra-staging/k8s-team-namespaces/gnosis-staging-k8s-gp/-/merge_requests/307 and also requires an edit to secrets to rename mip -> light_quasimodo.