### PR TITLE
Set Content-Type: application/json on solver post

### DIFF
--- a/crates/shared/src/http_solver.rs
+++ b/crates/shared/src/http_solver.rs
@@ -116,6 +116,7 @@ impl HttpSolverApi for DefaultHttpSolverApi {
             header.set_sensitive(true);
             request = request.header("X-API-KEY", header);
         }
+        request = request.header("Content-Type", "application/json");
         let body = serde_json::to_string(&model).context("failed to encode body")?;
         tracing::trace!("request {}", body);
         let request = request.body(body.clone());


### PR DESCRIPTION
Fixes #issue.

Sets Content-Type: application/json on solver post as it is sending a json. Some APIs expect this header when waiting for a json, like nodejs express for example. This had cost me time to figure out on the solver side.

I hope this doesn't overwrite other headers like X-API-KEY.

### Test Plan

Check if the solver receives a Content-Type: application/json header and all other headers that are already set.
