### PR TITLE
added toolchain

### DIFF
--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,0 +1,4 @@
+[toolchain]
+channel = "stable"
+components = ["clippy", "rustfmt"]
+profile = "minimal"


### PR DESCRIPTION
Fixes #issue.

added rust-toolchain file in order to run `cargo build` outside of docker and use the right version as the docker image would

### Test Plan

run `cargo build`and `rustup show`to view that the same settings as by the docker image are used

### Release notes

Optionally add notes, suggestions and warnings for the releaser. They will be included in the release changelog.
