### PR TITLE
Drop liquidity orders from matched orders metric

### DIFF
--- a/crates/e2e/tests/e2e/services.rs
+++ b/crates/e2e/tests/e2e/services.rs
@@ -190,6 +190,7 @@ impl OrderbookServices {
             solvable_orders_cache.clone(),
             Duration::from_secs(600),
             order_validator.clone(),
+            Default::default(),
         ));
         let maintenance = ServiceMaintenance {
             maintainers: vec![db.clone(), event_updater],

--- a/crates/orderbook/src/main.rs
+++ b/crates/orderbook/src/main.rs
@@ -677,7 +677,7 @@ async fn main() {
         Box::new(web3.clone()),
         native_token.clone(),
         args.banned_users.iter().copied().collect(),
-        args.shared.liquidity_order_owners.into_iter().collect(),
+        args.shared.liquidity_order_owners.iter().copied().collect(),
         args.min_order_validity_period,
         fee_calculator.clone(),
         bad_token_detector.clone(),
@@ -692,6 +692,7 @@ async fn main() {
         solvable_orders_cache.clone(),
         args.solvable_orders_max_update_age,
         order_validator.clone(),
+        args.shared.liquidity_order_owners.into_iter().collect(),
     ));
     let mut service_maintainer = ServiceMaintenance {
         maintainers: vec![


### PR DESCRIPTION
Fixes #129

The "Matched Orders" panel in Grafana currently includes liquidity orders. If there are many liquidity orders the graph for matched orders declines significantly making it seem like our service is experiencing issues.
This can be solved by introducing a metric which only tracks how many user orders have been created. If we use this metric in the Grafana panel the "Matched Orders" graph will better reflect the user experience of the service.

### Test Plan
Local test submitting 1 user order and 1 liquidity order.
New metric counting user orders:
```
# HELP gp_v2_api_orderbook_user_orders_created Number of user (non-liquidity) orders created.
# TYPE gp_v2_api_orderbook_user_orders_created counter
gp_v2_api_orderbook_user_orders_created 1
```
Metric we previously in the Grafana panel
```
# HELP gp_v2_api_api_requests_complete Number of completed API requests.
# TYPE gp_v2_api_api_requests_complete counter
gp_v2_api_api_requests_complete{method="v1/create_order",status_code="201"} 2
```
This shows that the new metrics is working and ignores liquidity orders.
