### PR TITLE
Add CLA Verification Worflow

### DIFF
--- a/.github/workflows/cla.yaml
+++ b/.github/workflows/cla.yaml
@@ -1,0 +1,37 @@
+name: "cla"
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_target:
+    types: [opened,closed,synchronize]
+
+jobs:
+  cla:
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Get Team Members"
+        id: team
+        uses: actions/github-script@v6
+        with:
+          result-encoding: string
+          script: |
+            const collaborators = await github.paginate(
+              github.rest.repos.listCollaborators,
+              {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+              });
+            return collaborators.map(m => m.login).join(",");
+
+      - name: "CLA Assistant"
+        if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target'
+        uses: contributor-assistant/github-action@v2.1.3-beta
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PERSONAL_ACCESS_TOKEN : ${{ secrets.GITHUB_TOKEN }}
+        with:
+          branch: 'cla-signatures'
+          path-to-signatures: 'signatures/version1/cla.json'
+          path-to-document: 'https://github.com/cowprotocol/cla/blob/main/Cow%20Services%20CLA.md'
+          allowlist: ${{ steps.team.outputs.result }},*[bot]


### PR DESCRIPTION
This PR adds a workflow for verifying CLA signatures for external contributors.

I detailed the [steps for integrating here](https://github.com/cowprotocol/cla/blob/main/README.md#github-action-setup) for other projects to use.

Basically, this workflow will first:
- Fetch the collaborators (AFAICT team members that we have added to the repo) with the GitHub API.
- Add them and `*[bot]` to the list of "allowed" GitHub users that don't need to sign the CLA.
- Use the [`contributor-assistant/github-action`](https://github.com/contributor-assistant/github-action) action to verify the CLA is signed. I used this action as it seemed to be, by far, the most popular one in the market place and keeps the signature file in-tree.

### Test Plan

~~Checkout the CLA file that was created.~~ It turns out that the `pull_request_target` triggers, the GitHub action needs to be in `main`, so the bot will be enabled after this is already merged. I tested it in a repo before creating this PR here: https://github.com/cowprotocol/cla-test.

Also, if someone has a non-member account after this is merged (maybe @e00E), can they create a PR and check that the CLA bot flags it as CLA needed?
