### PR TITLE
Update gas model

### DIFF
--- a/crates/shared/src/price_estimation/gas.rs
+++ b/crates/shared/src/price_estimation/gas.rs
@@ -54,9 +54,9 @@ pub static GAS_PER_ZEROEX_ORDER: u64 = 66_358;
 // estimated with https://dune.com/queries/639857
 pub static GAS_PER_BALANCER_SWAP: u64 = 88_892;
 
-/// Average gas used per UnwrapWethInteraction.
+/// Median gas used per UnwrapWethInteraction.
 // estimated with https://dune.com/queries/640753
-pub static GAS_PER_WETH_UNWRAP: u64 = 10_258;
+pub static GAS_PER_WETH_UNWRAP: u64 = 9_223;
 
 /// Median gas used for wrapping WETH for the first time.
 pub static GAS_PER_WETH_WRAP: u64 = 24_038;

--- a/crates/shared/src/price_estimation/gas.rs
+++ b/crates/shared/src/price_estimation/gas.rs
@@ -42,9 +42,9 @@ pub const SETTLEMENT_OVERHEAD: u64 = SETTLEMENT + TRADE + 2 * ERC20_TRANSFER;
 /// https://docs.google.com/spreadsheets/d/13UeUQ9DA4bHlcy9-i8d4nSLlCxSfjcXpTelvXYzyJzQ/edit?usp=sharing
 pub static GAS_PER_ORDER: u64 = 66_315;
 
-/// Average gas used per UniswapInteraction (v2).
+/// Median gas used per UniswapInteraction (v2).
 // estimated with https://dune.com/queries/640717
-pub static GAS_PER_UNISWAP: u64 = 104_650;
+pub static GAS_PER_UNISWAP: u64 = 90_171;
 
 /// Average gas used per ZeroExInteraction.
 // estimated with https://dune.com/queries/639669

--- a/crates/shared/src/price_estimation/gas.rs
+++ b/crates/shared/src/price_estimation/gas.rs
@@ -50,9 +50,9 @@ pub static GAS_PER_UNISWAP: u64 = 90_171;
 // estimated with https://dune.com/queries/639669
 pub static GAS_PER_ZEROEX_ORDER: u64 = 66_358;
 
-/// Average gas used per BalancerSwapGivenOutInteraction.
+/// Median gas used per BalancerSwapGivenOutInteraction.
 // estimated with https://dune.com/queries/639857
-pub static GAS_PER_BALANCER_SWAP: u64 = 89_406;
+pub static GAS_PER_BALANCER_SWAP: u64 = 88_892;
 
 /// Average gas used per UnwrapWethInteraction.
 // estimated with https://dune.com/queries/640753

--- a/crates/shared/src/price_estimation/gas.rs
+++ b/crates/shared/src/price_estimation/gas.rs
@@ -54,8 +54,9 @@ pub static GAS_PER_ZEROEX_ORDER: u64 = 73_901;
 // estimated with https://dune.com/queries/639857
 pub static GAS_PER_BALANCER_SWAP: u64 = 89_406;
 
-/// Median gas used for unwrapping portion of WETH.
-pub static GAS_PER_WETH_UNWRAP: u64 = 14_192;
+/// Average gas used per UnwrapWethInteraction.
+// estimated with https://dune.com/queries/640753
+pub static GAS_PER_WETH_UNWRAP: u64 = 10_258;
 
 /// Median gas used for wrapping WETH for the first time.
 pub static GAS_PER_WETH_WRAP: u64 = 24_038;

--- a/crates/shared/src/price_estimation/gas.rs
+++ b/crates/shared/src/price_estimation/gas.rs
@@ -46,9 +46,9 @@ pub static GAS_PER_ORDER: u64 = 66_315;
 // estimated with https://dune.com/queries/640717
 pub static GAS_PER_UNISWAP: u64 = 90_171;
 
-/// Average gas used per ZeroExInteraction.
+/// Median gas used per ZeroExInteraction.
 // estimated with https://dune.com/queries/639669
-pub static GAS_PER_ZEROEX_ORDER: u64 = 73_901;
+pub static GAS_PER_ZEROEX_ORDER: u64 = 66_358;
 
 /// Average gas used per BalancerSwapGivenOutInteraction.
 // estimated with https://dune.com/queries/639857

--- a/crates/shared/src/price_estimation/gas.rs
+++ b/crates/shared/src/price_estimation/gas.rs
@@ -42,8 +42,9 @@ pub const SETTLEMENT_OVERHEAD: u64 = SETTLEMENT + TRADE + 2 * ERC20_TRANSFER;
 /// https://docs.google.com/spreadsheets/d/13UeUQ9DA4bHlcy9-i8d4nSLlCxSfjcXpTelvXYzyJzQ/edit?usp=sharing
 pub static GAS_PER_ORDER: u64 = 66_315;
 
-/// lower bound for executing one trade on uniswap
-pub static GAS_PER_UNISWAP: u64 = 94_696;
+/// Average gas used per UniswapInteraction (v2).
+// estimated with https://dune.com/queries/640717
+pub static GAS_PER_UNISWAP: u64 = 104_650;
 
 /// Average gas used per ZeroExInteraction.
 // estimated with https://dune.com/queries/639669

--- a/crates/shared/src/price_estimation/gas.rs
+++ b/crates/shared/src/price_estimation/gas.rs
@@ -45,9 +45,9 @@ pub static GAS_PER_ORDER: u64 = 66_315;
 /// lower bound for executing one trade on uniswap
 pub static GAS_PER_UNISWAP: u64 = 94_696;
 
-/// lower bound for execution of one trade on zeroex
-// estimated with https://dune.xyz/queries/536616
-pub static GAS_PER_ZEROEX_ORDER: u64 = 157_300;
+/// Average gas used per ZeroExInteraction.
+// estimated with https://dune.com/queries/639669
+pub static GAS_PER_ZEROEX_ORDER: u64 = 73_901;
 
 /// lower bound for executing one trade on balancer
 ///

--- a/crates/shared/src/price_estimation/gas.rs
+++ b/crates/shared/src/price_estimation/gas.rs
@@ -49,12 +49,9 @@ pub static GAS_PER_UNISWAP: u64 = 94_696;
 // estimated with https://dune.com/queries/639669
 pub static GAS_PER_ZEROEX_ORDER: u64 = 73_901;
 
-/// lower bound for executing one trade on balancer
-///
-/// Taken from a sample of two swaps
-/// https://etherscan.io/tx/0x72d234d35fd169ef497ba0a1dc23258c96f278fb688d375d135eb012e5311009
-/// https://etherscan.io/tx/0x1c345a6da1edb2bba953685a4cf85f6a0d967ac751f8c5b518578c5fd20a7c96
-pub static GAS_PER_BALANCER_SWAP: u64 = 120_000;
+/// Average gas used per BalancerSwapGivenOutInteraction.
+// estimated with https://dune.com/queries/639857
+pub static GAS_PER_BALANCER_SWAP: u64 = 89_406;
 
 /// Median gas used for unwrapping portion of WETH.
 pub static GAS_PER_WETH_UNWRAP: u64 = 14_192;


### PR DESCRIPTION
Looking into simulations of settlements with `ZeroExInteraction`s revealed that the gas model for those is way too high. Since the approach to estimate those interactions was based off of existing estimation methods for other AMM interactions I estimated them all again with the same (hopefully more accurate) approach.

AFAIK the previous approach for gas cost estimation was to find a transactions which only had a single interaction of the type we are interested in and use that. For some interactions the min over a long period of time was used for some only a few samples were looked at. Also note that the `UnwrapWethInteraction` used the median value whereas every other interaction used the minimum.

The new approach is to use the `ethereum.traces` table which contains tracks `gas_used` for each function call. This is better for our purposes since it gives us more data to look at (transaction only containing the interaction vs. every transaction containing such interaction) and also discounts any gas overhead a transaction might additionally have.

The used queries are all in the form of:
```sql
select min(gas_used) as min_gas,
       avg(gas_used) as avg_gas,
       max(gas_used) as max_gas,
       percentile_cont(0.5) WITHIN GROUP (ORDER BY gas_used) as median_gas
from ethereum.traces
where "to" = '<amm_contract_address>'
    and position('<sig hash of function our settlement contract calls>' in input) = 1
    and tx_success = true
    and success = true
    and block_time > now() - interval '3 months'
```

I decided to NOT use the lower bound anymore and instead used the median amount for our gas cost model since that seemed more appropriate.

The changes will cause our overall gas cost estimations to decrease and will make 0x and Balancer way more competitive against UniswapV2.

| Interaction         | Old Value | New Value |
|-----------------|----------|------------|
| UniswapV2        | 94_696    | 90_171        |
| 0x                       | 157_300   | 66_358      |
| Balancer            | 120_000   | 88_892      |
| UnnwrapWETH | 14_192      | 9_223        |

### Test Plan
Manual tests simulating transactions with tenderly and using the gas profiler to compare those values against values returned by each dune query.