### PR TITLE
Add copyright notice and fix CLA workflow

### DIFF
--- a/.github/workflows/cla.yaml
+++ b/.github/workflows/cla.yaml
@@ -4,7 +4,7 @@ on:
   issue_comment:
     types: [created]
   pull_request_target:
-    types: [opened,closed,synchronize]
+    types: [opened, closed, synchronize]
 
 jobs:
   cla:
@@ -14,24 +14,23 @@ jobs:
         id: team
         uses: actions/github-script@v6
         with:
+          github-token: ${{ secrets.ORG_TOKEN }}
           result-encoding: string
           script: |
-            const collaborators = await github.paginate(
-              github.rest.repos.listCollaborators,
-              {
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-              });
-            return collaborators.map(m => m.login).join(",");
+            const members = await github.paginate(
+              github.rest.orgs.listMembers,
+              { org: "cowprotocol" },
+            );
+            return members.map(m => m.login).join(",");
 
       - name: "CLA Assistant"
         if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target'
         uses: contributor-assistant/github-action@v2.1.3-beta
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PERSONAL_ACCESS_TOKEN : ${{ secrets.GITHUB_TOKEN }}
+          PERSONAL_ACCESS_TOKEN : ${{ secrets.ORG_TOKEN }}
         with:
           branch: 'cla-signatures'
           path-to-signatures: 'signatures/version1/cla.json'
           path-to-document: 'https://github.com/cowprotocol/cla/blob/main/Cow%20Services%20CLA.md'
-          allowlist: ${{ steps.team.outputs.result }},*[bot]
+          allowlist: '${{ steps.team.outputs.result }},*[bot]'

--- a/COPYRIGHT.md
+++ b/COPYRIGHT.md
@@ -1,0 +1,13 @@
+# Intellectual Property Notice
+
+Copyright (c) 2021 Gnosis Ltd  
+Copyright (c) 2022 Cow Services Lda
+
+Except as otherwise noted (below and/or in individual files), this project is licensed under
+the Apache License, Version 2.0 ([`LICENSE-APACHE`](LICENSE-APACHE) or <http://www.apache.org/licenses/LICENSE-2.0>) or
+the MIT license, ([`LICENSE-MIT`](LICENSE-MIT) or <http://opensource.org/licenses/MIT>), at your option.
+
+Code under the following sub-directories are licensed exclusively under
+the GNU Lesser General Public License v3.0 or later ([`LICENSE`](LICENSE) or <https://www.gnu.org/licenses/lgpl-3.0-standalone.html>):
+- [`crates/orderbook`](crates/orderbook)
+- [`crates/solver`](crates/solver)

--- a/crates/testlib/Cargo.toml
+++ b/crates/testlib/Cargo.toml
@@ -3,7 +3,7 @@ name = "testlib"
 version = "0.1.0"
 authors = ["Gnosis Developers <developers@gnosis.io>", "Cow Protocol Developers <dev@cow.fi>"]
 edition = "2018"
-license = "GPL-3.0-or-later"
+license = "MIT"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
This PR does a few things:
- It adds a `COPYRIGHT.md` notice to our repo.
- Relicenses the `testlib` to be MIT (matches our other "library" crates).
- Fixes the CLA workflow. There were some differences in the private repo I tested with and this public repo.

### Test Plan

Check the CLA bot working in another public repo: https://github.com/cowprotocol/hdnode/runs/6194783177?check_suite_focus=true for https://github.com/cowprotocol/hdnode/pull/7

Also check that the CLA workflow matches the one from the instructions https://github.com/cowprotocol/cla#github-action-setup