### PR TITLE
Shorten maintenance span

### DIFF
--- a/crates/shared/src/maintenance.rs
+++ b/crates/shared/src/maintenance.rs
@@ -31,12 +31,14 @@ impl ServiceMaintenance {
     async fn run_maintenance_for_block_stream(self, block_stream: impl Stream<Item = Block>) {
         futures::pin_mut!(block_stream);
         while let Some(block) = block_stream.next().await {
+            tracing::debug!(
+                "running maintenance on block number {:?} hash {:?}",
+                block.number,
+                block.hash
+            );
+            let block = block.number.unwrap_or_default().as_u64();
             self.run_maintenance()
-                .instrument(tracing::debug_span!(
-                    "maintenance",
-                    block_number = ?block.number,
-                    block_hash = ?block.hash,
-                ))
+                .instrument(tracing::debug_span!("maintenance", block,))
                 .await
                 .expect("Service maintenance always Ok");
         }


### PR DESCRIPTION
Looking at Kibana I realized the hash adds too much visual noise for
little benefit when it is prepended to every log message so I'm changing
this to just say block=1234 and adding back the previous log message
showing the hash.

### Test Plan

observe changed output