### PR TITLE
Add metrics to rate limiting

### DIFF
--- a/crates/shared/src/arguments.rs
+++ b/crates/shared/src/arguments.rs
@@ -199,6 +199,11 @@ impl FromStr for RateLimitingStrategy {
             .context("parsing back_off_growth_factor")?;
         let min_back_off = duration_from_seconds(min_back_off).context("parsing min_back_off")?;
         let max_back_off = duration_from_seconds(max_back_off).context("parsing max_back_off")?;
-        Self::try_new(back_off_growth_factor, min_back_off, max_back_off)
+        Self::try_new(
+            back_off_growth_factor,
+            min_back_off,
+            max_back_off,
+            "paraswap".into(),
+        )
     }
 }


### PR DESCRIPTION
Fixes #180

In order to see how often we need to use the back off strategy for paraswap we need to have some metrics for it.

### Test Plan
<details>
<summary>Metrics after manual test</summary>

```
# HELP gp_v2_api_rate_limiter_rate_limited_requests Number of responses indicating a rate limiting error.
# TYPE gp_v2_api_rate_limiter_rate_limited_requests counter
gp_v2_api_rate_limiter_rate_limited_requests{endpoint="paraswap"} 16
# HELP gp_v2_api_rate_limiter_requests_dropped Number of requests dropped while being rate limited.
# TYPE gp_v2_api_rate_limiter_requests_dropped counter
gp_v2_api_rate_limiter_requests_dropped{endpoint="paraswap"} 18
# HELP gp_v2_api_rate_limiter_successful_requests Number of successful requests.
# TYPE gp_v2_api_rate_limiter_successful_requests counter
gp_v2_api_rate_limiter_successful_requests{endpoint="paraswap"} 5
```
</details>
