### PR TITLE
Less error debugs for 0x api call failure

### DIFF
--- a/crates/solver/src/liquidity/zeroex.rs
+++ b/crates/solver/src/liquidity/zeroex.rs
@@ -32,17 +32,15 @@ impl ZeroExLiquidity {
 
         let zeroex_orders_results =
             futures::future::join_all(queries.iter().map(|query| self.api.get_orders(query))).await;
-        let zeroex_orders: Vec<OrderRecord> = zeroex_orders_results
+        let zeroex_orders = zeroex_orders_results
             .into_iter()
-            .map(|result| match result {
+            .flat_map(|result| match result {
                 Ok(order_record_vec) => order_record_vec,
                 Err(err) => {
                     tracing::warn!("ZeroExResponse error during liqudity fetching: {}", err);
                     vec![]
                 }
-            })
-            .flatten()
-            .collect();
+            });
 
         let user_order_pairs = user_orders
             .iter()
@@ -50,7 +48,6 @@ impl ZeroExLiquidity {
         let relevant_pairs = self.base_tokens.relevant_pairs(user_order_pairs);
 
         let filtered_zeroex_orders = zeroex_orders
-            .into_iter()
             .filter(|record| {
                 match TokenPair::new(record.order.taker_token, record.order.maker_token) {
                     Some(pair) => relevant_pairs.contains(&pair),


### PR DESCRIPTION
During oncall, it occured to me that the 0x liquidity fetching was generating noisy error messages like this:
https://cowservices.slack.com/archives/C0371SB243E/p1651405247972289

Tried to fix it with a different error handling.

### Test Plan
