### PR TITLE
Store `is_liquidity_order` in the database

### DIFF
--- a/crates/e2e/tests/e2e/services.rs
+++ b/crates/e2e/tests/e2e/services.rs
@@ -71,7 +71,6 @@ pub fn create_orderbook_api() -> OrderBookApi {
 pub fn create_order_converter(web3: &Web3, weth_address: H160) -> OrderConverter {
     OrderConverter {
         native_token: WETH9::at(web3, weth_address),
-        liquidity_order_owners: Default::default(),
         fee_objective_scaling_factor: 1.,
     }
 }

--- a/crates/e2e/tests/e2e/services.rs
+++ b/crates/e2e/tests/e2e/services.rs
@@ -189,7 +189,6 @@ impl OrderbookServices {
             solvable_orders_cache.clone(),
             Duration::from_secs(600),
             order_validator.clone(),
-            Default::default(),
         ));
         let maintenance = ServiceMaintenance {
             maintainers: vec![db.clone(), event_updater],

--- a/crates/model/src/order.rs
+++ b/crates/model/src/order.rs
@@ -46,7 +46,14 @@ impl Default for Order {
             .signature
             .validate(domain, &order.hash_struct())
             .unwrap();
-        Self::from_order_creation(&order, domain, H160::default(), Default::default(), owner)
+        Self::from_order_creation(
+            &order,
+            domain,
+            H160::default(),
+            Default::default(),
+            owner,
+            false,
+        )
     }
 }
 
@@ -67,6 +74,7 @@ impl Order {
         settlement_contract: H160,
         full_fee_amount: U256,
         owner: H160,
+        is_liquidity_order: bool,
     ) -> Self {
         Self {
             metadata: OrderMetadata {
@@ -75,6 +83,7 @@ impl Order {
                 uid: order_creation.uid(domain, &owner),
                 settlement_contract,
                 full_fee_amount,
+                is_liquidity_order,
                 ..Default::default()
             },
             creation: *order_creation,
@@ -452,6 +461,7 @@ pub struct OrderMetadata {
     pub settlement_contract: H160,
     #[serde(default, with = "u256_decimal")]
     pub full_fee_amount: U256,
+    pub is_liquidity_order: bool,
 }
 
 impl Default for OrderMetadata {
@@ -469,6 +479,7 @@ impl Default for OrderMetadata {
             status: OrderStatus::Open,
             settlement_contract: H160::default(),
             full_fee_amount: U256::default(),
+            is_liquidity_order: false,
         }
     }
 }
@@ -688,6 +699,7 @@ mod tests {
             "settlementContract": "0x0000000000000000000000000000000000000002",
             "sellTokenBalance": "external",
             "buyTokenBalance": "internal",
+            "isLiquidityOrder": false,
         });
         let signing_scheme = EcdsaSigningScheme::Eip712;
         let expected = Order {
@@ -704,6 +716,7 @@ mod tests {
                 status: OrderStatus::Open,
                 settlement_contract: H160::from_low_u64_be(2),
                 full_fee_amount: U256::MAX,
+                is_liquidity_order: false,
             },
             creation: OrderCreation {
                 sell_token: H160::from_low_u64_be(10),

--- a/crates/orderbook/openapi.yml
+++ b/crates/orderbook/openapi.yml
@@ -680,6 +680,16 @@ components:
         fullFeeAmount:
           description: "Amount that the signed fee would be without subsidies"
           $ref: "#/components/schemas/TokenAmount"
+        isLiquidityOrder:
+          description: |
+            Liquidity orders are functionally the same as normal smart contract orders but are not
+            placed with the intent of actively getting traded. Instead they facilitate the
+            trade of normal orders by allowing them to be matched against liquidity orders which
+            uses less gas and can have better prices than external liquidity.
+            As such liquidity orders will only be used in order to improve settlement of normal
+            orders. They should not be expected to be traded otherwise and should not expect to get
+            surplus.
+          type: boolean
       required:
         - creationTime
         - owner

--- a/crates/orderbook/src/api/post_quote.rs
+++ b/crates/orderbook/src/api/post_quote.rs
@@ -53,6 +53,7 @@ impl From<&OrderQuoteRequest> for PreOrderData {
             partially_fillable: quote_request.partially_fillable,
             buy_token_balance: quote_request.buy_token_balance,
             sell_token_balance: quote_request.sell_token_balance,
+            is_liquidity_order: quote_request.partially_fillable,
         }
     }
 }

--- a/crates/orderbook/src/main.rs
+++ b/crates/orderbook/src/main.rs
@@ -702,7 +702,6 @@ async fn main() {
         solvable_orders_cache.clone(),
         args.solvable_orders_max_update_age,
         order_validator.clone(),
-        args.liquidity_order_owners.into_iter().collect(),
     ));
     let mut service_maintainer = ServiceMaintenance {
         maintainers: vec![

--- a/crates/orderbook/src/main.rs
+++ b/crates/orderbook/src/main.rs
@@ -247,6 +247,15 @@ struct Arguments {
 
     #[clap(long, env, default_value = "static", arg_enum)]
     token_detector_fee_values: FeeValues,
+
+    /// The configured addresses whose orders should be considered liquidity and
+    /// not regular user orders.
+    ///
+    /// These orders have special semantics such as not being considered in the
+    /// settlements objective funtion, not receiving any surplus, and being
+    /// allowed to place partially fillable orders.
+    #[clap(long, env, use_value_delimiter = true)]
+    pub liquidity_order_owners: Vec<H160>,
 }
 
 pub async fn database_metrics(metrics: Arc<Metrics>, database: Postgres) -> ! {
@@ -653,7 +662,7 @@ async fn main() {
             },
             native_price_estimator.clone(),
             cow_subsidy.clone(),
-            args.shared.liquidity_order_owners.iter().copied().collect(),
+            args.liquidity_order_owners.iter().copied().collect(),
         ))
     };
     let fee_calculator = create_fee_calculator(price_estimator.clone());
@@ -678,7 +687,7 @@ async fn main() {
         Box::new(web3.clone()),
         native_token.clone(),
         args.banned_users.iter().copied().collect(),
-        args.shared.liquidity_order_owners.iter().copied().collect(),
+        args.liquidity_order_owners.iter().copied().collect(),
         args.min_order_validity_period,
         fee_calculator.clone(),
         bad_token_detector.clone(),
@@ -693,7 +702,7 @@ async fn main() {
         solvable_orders_cache.clone(),
         args.solvable_orders_max_update_age,
         order_validator.clone(),
-        args.shared.liquidity_order_owners.into_iter().collect(),
+        args.liquidity_order_owners.into_iter().collect(),
     ));
     let mut service_maintainer = ServiceMaintenance {
         maintainers: vec![

--- a/crates/orderbook/src/orderbook.rs
+++ b/crates/orderbook/src/orderbook.rs
@@ -83,7 +83,6 @@ pub struct Orderbook {
     solvable_orders: Arc<SolvableOrdersCache>,
     solvable_orders_max_update_age: Duration,
     order_validator: Arc<OrderValidator>,
-    liquidity_order_owners: HashSet<H160>,
 }
 
 impl Orderbook {
@@ -97,7 +96,6 @@ impl Orderbook {
         solvable_orders: Arc<SolvableOrdersCache>,
         solvable_orders_max_update_age: Duration,
         order_validator: Arc<OrderValidator>,
-        liquidity_order_owners: HashSet<H160>,
     ) -> Self {
         Self {
             domain_separator,
@@ -108,7 +106,6 @@ impl Orderbook {
             solvable_orders,
             solvable_orders_max_update_age,
             order_validator,
-            liquidity_order_owners,
         }
     }
 
@@ -140,7 +137,7 @@ impl Orderbook {
 
         self.database.insert_order(&order, fee).await?;
 
-        if !self.liquidity_order_owners.contains(&order.metadata.owner) {
+        if !order.metadata.is_liquidity_order {
             Metrics::instance(metrics::get_metric_storage_registry())
                 .expect("unexpected error getting metrics instance")
                 .user_orders_created

--- a/crates/shared/src/arguments.rs
+++ b/crates/shared/src/arguments.rs
@@ -140,15 +140,6 @@ pub struct Arguments {
     /// The 1Inch REST API URL to use.
     #[structopt(long, env, default_value = "https://api.1inch.exchange/")]
     pub one_inch_url: Url,
-
-    /// The configured addresses whose orders should be considered liquidity and
-    /// not regular user orders.
-    ///
-    /// These orders have special semantics such as not being considered in the
-    /// settlements objective funtion, not receiving any surplus, and being
-    /// allowed to place partially fillable orders.
-    #[clap(long, env, use_value_delimiter = true)]
-    pub liquidity_order_owners: Vec<H160>,
 }
 
 pub fn parse_unbounded_factor(s: &str) -> Result<f64> {

--- a/crates/solver/src/liquidity/order_converter.rs
+++ b/crates/solver/src/liquidity/order_converter.rs
@@ -2,13 +2,12 @@ use super::{Exchange, LimitOrder, SettlementHandling};
 use crate::{interactions::UnwrapWethInteraction, settlement::SettlementEncoder};
 use anyhow::Result;
 use contracts::WETH9;
-use ethcontract::{H160, U256};
+use ethcontract::U256;
 use model::order::{Order, BUY_ETH_ADDRESS};
-use std::{collections::HashSet, sync::Arc};
+use std::sync::Arc;
 
 pub struct OrderConverter {
     pub native_token: WETH9,
-    pub liquidity_order_owners: HashSet<H160>,
     pub fee_objective_scaling_factor: f64,
 }
 
@@ -16,10 +15,9 @@ impl OrderConverter {
     /// Creates a order converter with the specified WETH9 address for unit
     /// testing purposes.
     #[cfg(test)]
-    pub fn test(native_token: H160) -> Self {
+    pub fn test(native_token: ethcontract::H160) -> Self {
         Self {
             native_token: shared::dummy_contract!(WETH9, native_token),
-            liquidity_order_owners: HashSet::new(),
             fee_objective_scaling_factor: 1.,
         }
     }
@@ -40,7 +38,7 @@ impl OrderConverter {
         let scaled_fee_amount = U256::from_f64_lossy(
             remaining.full_fee_amount.to_f64_lossy() * self.fee_objective_scaling_factor,
         );
-        let is_liquidity_order = self.liquidity_order_owners.contains(&order.metadata.owner);
+        let is_liquidity_order = order.metadata.is_liquidity_order;
         Ok(LimitOrder {
             id: order.metadata.uid.to_string(),
             sell_token: order.creation.sell_token,

--- a/crates/solver/src/main.rs
+++ b/crates/solver/src/main.rs
@@ -625,7 +625,6 @@ async fn main() {
     let api = OrderBookApi::new(args.orderbook_url, client.clone());
     let order_converter = OrderConverter {
         native_token: native_token_contract.clone(),
-        liquidity_order_owners: args.shared.liquidity_order_owners.into_iter().collect(),
         fee_objective_scaling_factor: args.fee_objective_scaling_factor,
     };
     let tenderly = args

--- a/crates/solver/src/settlement_simulation.rs
+++ b/crates/solver/src/settlement_simulation.rs
@@ -412,11 +412,6 @@ mod tests {
         );
         let order_converter = OrderConverter {
             native_token: native_token_contract.clone(),
-            liquidity_order_owners: vec!["0xe63A13Eedd01B624958AcFe32145298788a7a7BA"
-                .parse()
-                .unwrap()]
-            .into_iter()
-            .collect(),
             fee_objective_scaling_factor: 0.91_f64,
         };
         let value = json!(
@@ -447,6 +442,7 @@ mod tests {
             "settlementContract": "0x9008d19f58aabd9ed0d60971565aa8510560ab41",
             "sellTokenBalance": "erc20",
             "buyTokenBalance": "erc20",
+            "isLiquidityOrder": false,
         });
         let order0: Order = serde_json::from_value(value).unwrap();
         let value = json!(
@@ -477,6 +473,7 @@ mod tests {
             "settlementContract": "0x9008d19f58aabd9ed0d60971565aa8510560ab41",
             "sellTokenBalance": "erc20",
             "buyTokenBalance": "erc20",
+            "isLiquidityOrder": true,
         });
         let order1: Order = serde_json::from_value(value).unwrap();
         let value = json!(
@@ -507,6 +504,7 @@ mod tests {
             "settlementContract": "0x9008d19f58aabd9ed0d60971565aa8510560ab41",
             "sellTokenBalance": "erc20",
             "buyTokenBalance": "erc20",
+            "isLiquidityOrder": false,
         });
         let order2: Order = serde_json::from_value(value).unwrap();
 

--- a/database/sql/V020__extend_orders_with_is_liquidity_order.sql
+++ b/database/sql/V020__extend_orders_with_is_liquidity_order.sql
@@ -1,5 +1,11 @@
 ALTER TABLE orders ADD is_liquidity_order boolean NOT NULL DEFAULT false;
--- So far every liquidity order was also a partially fillable order and all
--- partially fillable orders were liquidity orders.
--- We use this fact to initialize is_liquidity_order for existing orders correctly.
-UPDATE orders SET is_liquidity_order = partially_fillable WHERE is_liquidity_order = false;
+-- We know that every partially fillable order was also a liquidity order so we
+-- initialize the new column accordingly.
+-- There have been liquidity orders which were not partially fillable but there is
+-- no way to initialize the `is_liquidity_order` fields correctly for those.
+-- This is just our best effort to patch up existing orders.
+UPDATE orders SET is_liquidity_order = partially_fillable;
+-- We only wanted to have a default to make the migration easier. Ultimately
+-- we want every new insertion to supply the flag.
+ALTER TABLE orders ALTER COLUMN is_liquidity_order DROP DEFAULT;
+

--- a/database/sql/V020__extend_orders_with_is_liquidity_order.sql
+++ b/database/sql/V020__extend_orders_with_is_liquidity_order.sql
@@ -1,0 +1,5 @@
+ALTER TABLE orders ADD is_liquidity_order boolean NOT NULL DEFAULT false;
+-- So far every liquidity order was also a partially fillable order and all
+-- partially fillable orders were liquidity orders.
+-- We use this fact to initialize is_liquidity_order for existing orders correctly.
+UPDATE orders SET is_liquidity_order = partially_fillable WHERE is_liquidity_order = false;


### PR DESCRIPTION
Fixes #176

Whether an order is a liquidity order currently depends on the `--liquidity-order-owners` argument. If the owner of an order is in that list the order is considered a liquidity order. This is a bit awkward because the arguments for the order book and driver might get out of sync. This could cause the order book to consider an order a liquidity order whereas the driver considers it a user order.
To make the type of an order consistent across restarts of the order book its value needs to get stored in the database.

Eventually we should move away from allow-listing individual addresses and extending the API such that each user can decide whether to create a liquidity order or a normal order.
To not make a gigantic PR while breaking the current behavior (deciding for the user whether to create a normal or liquidity order) this PR implements that change somehow awkwardly.

Things I want to do which are outside of the scope of this PR:
Drop `--liquidity-order-owners` argument entirely.
Add `is_liquidity_order` to the `OrderCreationPayload` to allow users to decide what order type they want to create.

### Test Plan
Updated unit tests
Manual test of the migration script verifying that existing partially fillable orders get marked as liquidity orders and that no default value for `is_liquidity_order` remains.
Manual test verifying that the content of `isLiquidityOrder` in the auction endpoint does not change after restarting the order book with a new list of `--liquidity-order-owners`. This was done in both directions:
1. Start with allow-list and verify that order is still liquidity order after restarting without list
2. Start without allow-list and verify that order is still normal order after restarting with the list

