### PR TITLE
Reduce log level of noisy debug messages

### DIFF
--- a/crates/solver/src/settlement_submission/submitter.rs
+++ b/crates/solver/src/settlement_submission/submitter.rs
@@ -333,7 +333,7 @@ impl<'a> Submitter<'a> {
         let submitter_name = self.submit_api.name();
         let target_confirm_time = Instant::now() + params.target_confirm_time;
 
-        tracing::info!(
+        tracing::debug!(
             "submit_with_increasing_gas_prices_until_simulation_fails entered with submitter: {}",
             submitter_name
         );
@@ -352,7 +352,7 @@ impl<'a> Submitter<'a> {
         let mut access_list: Option<AccessList> = None;
 
         loop {
-            tracing::info!("entered loop with submitter: {}", submitter_name);
+            tracing::debug!("entered loop with submitter: {}", submitter_name);
 
             let submission_status = self
                 .submit_api
@@ -463,7 +463,7 @@ impl<'a> Submitter<'a> {
                 }
                 Err(err) => tracing::warn!("submission failed: {:?}", err),
             }
-            tracing::info!(
+            tracing::debug!(
                 "Finished sending transaction with submitter {}...",
                 submitter_name
             );


### PR DESCRIPTION
In order to make debugging and oncall activity easier, I find it nice if activating the filter `log is not 'DEBUG'` in Kibana shows me a good summary overview of what is happening in the system on each runloop. Then, if I actually want to debug a specific loop, I can select the correct time range and drill down (also by showing DEBUG logs).

I feel like generally this is the case at the moment. However, upon sending the solution submission I see a lot of noisy alerts and am not really sure these are needed to be show on every run by default (see screenshot)

<img width="1664" alt="image" src="https://user-images.githubusercontent.com/1200333/166921253-15d98aaa-6f91-4005-a69d-3fcf061e49c9.png">

I therefore propose to downgrade the verbosity of these logs to debug. cc @sunce86 if those logs are still needed (I generally don't mind verbose logs to make debugging easier, but we should make sure they don't make other maintenance harder).
