### PR TITLE
Allow interactions to be internal

### DIFF
--- a/crates/shared/src/http_solver/model.rs
+++ b/crates/shared/src/http_solver/model.rs
@@ -267,7 +267,7 @@ pub enum ExecutionPlan {
     /// settlement.
     Coordinates(ExecutionPlanCoordinatesModel),
 
-    /// The interacetion should **not** be included in the settlement as
+    /// The interaction should **not** be included in the settlement as
     /// internal buffers will be used instead.
     #[serde(with = "execution_plan_internal")]
     Internal,

--- a/crates/shared/src/http_solver/model.rs
+++ b/crates/shared/src/http_solver/model.rs
@@ -136,7 +136,7 @@ pub struct InteractionData {
     /// `AMM -> GPv2Settlement`
     #[serde(default)]
     pub outputs: Vec<TokenAmount>,
-    pub exec_plan: Option<ExecutionPlanCoordinatesModel>,
+    pub exec_plan: Option<ExecutionPlan>,
 }
 
 /// Module to allow for backwards compatibility with the HTTP solver API.
@@ -188,10 +188,16 @@ impl SettledBatchAuctionModel {
     pub fn has_execution_plan(&self) -> bool {
         // Its a bit weird that we expect all entries to contain an execution plan. Could make
         // execution plan required and assert that the vector of execution updates is non-empty
-        self.amms
+
+        let amm_executions = self
+            .amms
             .values()
-            .flat_map(|u| &u.execution)
-            .all(|u| u.exec_plan.is_some())
+            .flat_map(|u| u.execution.iter().map(|e| &e.exec_plan));
+        let interaction_executions = self.interaction_data.iter().map(|i| &i.exec_plan);
+
+        amm_executions
+            .chain(interaction_executions)
+            .all(|ex| ex.is_some())
     }
 }
 
@@ -218,7 +224,7 @@ pub struct ExecutedOrderModel {
     pub cost: Option<TokenAmount>,
     pub fee: Option<TokenAmount>,
     // Orders which need to be executed in a specific order have an `exec_plan` (e.g. 0x limit orders)
-    pub exec_plan: Option<ExecutionPlanCoordinatesModel>,
+    pub exec_plan: Option<ExecutionPlan>,
 }
 
 #[derive(Clone, Debug, Deserialize)]
@@ -239,7 +245,7 @@ pub struct ExecutedAmmModel {
     /// The exec plan is allowed to be optional because the http solver isn't always
     /// able to determine and order of execution. That is, solver may have a solution
     /// which it wants to share with the driver even if it couldn't derive an execution plan.
-    pub exec_plan: Option<ExecutionPlanCoordinatesModel>,
+    pub exec_plan: Option<ExecutionPlan>,
 }
 
 impl UpdatedAmmModel {
@@ -251,6 +257,42 @@ impl UpdatedAmmModel {
             .iter()
             .any(|exec| exec.exec_sell_amount.gt(zero) || exec.exec_buy_amount.gt(zero));
         !self.execution.is_empty() && has_non_trivial_execution
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq)]
+#[serde(untagged)]
+pub enum ExecutionPlan {
+    /// The coordinates at which the interaction should be included within a
+    /// settlement.
+    Coordinates(ExecutionPlanCoordinatesModel),
+
+    /// The interacetion should **not** be included in the settlement as
+    /// internal buffers will be used instead.
+    #[serde(with = "execution_plan_internal")]
+    Internal,
+}
+
+/// A module for implementing `serde` (de)serialization for the execution plan
+/// enum.
+///
+/// This is a work-around for untagged enum serialization not supporting empty
+/// variants <https://github.com/serde-rs/serde/issues/1560>.
+mod execution_plan_internal {
+    use super::*;
+
+    #[derive(Deserialize, Serialize)]
+    enum Kind {
+        #[serde(rename = "internal")]
+        Internal,
+    }
+
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<(), D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        Kind::deserialize(deserializer)?;
+        Ok(())
     }
 }
 
@@ -280,10 +322,10 @@ mod tests {
         };
 
         let trivial_execution_with_plan = ExecutedAmmModel {
-            exec_plan: Some(ExecutionPlanCoordinatesModel {
+            exec_plan: Some(ExecutionPlan::Coordinates(ExecutionPlanCoordinatesModel {
                 sequence: 0,
                 position: 0,
-            }),
+            })),
             ..Default::default()
         };
 
@@ -601,6 +643,25 @@ mod tests {
     }
 
     #[test]
+    fn decode_execution_plan() {
+        for (json, expected) in [
+            (r#""internal""#, ExecutionPlan::Internal),
+            (
+                r#"{ "sequence": 42, "position": 1337 }"#,
+                ExecutionPlan::Coordinates(ExecutionPlanCoordinatesModel {
+                    sequence: 42,
+                    position: 1337,
+                }),
+            ),
+        ] {
+            assert_eq!(
+                serde_json::from_str::<ExecutionPlan>(json).unwrap(),
+                expected,
+            );
+        }
+    }
+
+    #[test]
     fn decode_interaction_data() {
         assert_eq!(
             serde_json::from_str::<InteractionData>(
@@ -625,10 +686,7 @@ mod tests {
                                 "amount": "3000"
                             }
                         ],
-                        "exec_plan": {
-                            "sequence": 42,
-                            "position": 1337
-                        }
+                        "exec_plan": "internal"
                     }
                 "#,
             )
@@ -651,10 +709,7 @@ mod tests {
                         amount: 3000.into(),
                     }
                 ],
-                exec_plan: Some(ExecutionPlanCoordinatesModel {
-                    sequence: 42,
-                    position: 1337,
-                }),
+                exec_plan: Some(ExecutionPlan::Internal),
             },
         );
     }

--- a/crates/solver/src/solver/http_solver.rs
+++ b/crates/solver/src/solver/http_solver.rs
@@ -558,8 +558,13 @@ mod tests {
         assert!(execution.exec_buy_amount.gt(&U256::zero()));
         assert_eq!(execution.exec_sell_amount, U256::from(base(2)));
         assert!(execution.exec_plan.is_some());
-        assert_eq!(execution.exec_plan.as_ref().unwrap().sequence, 0);
-        assert_eq!(execution.exec_plan.as_ref().unwrap().position, 0);
+        assert!(matches!(
+            execution.exec_plan.as_ref().unwrap(),
+            ExecutionPlan::Coordinates(ExecutionPlanCoordinatesModel {
+                sequence: 0,
+                position: 0,
+            }),
+        ));
 
         assert_eq!(settled.prices.len(), 2);
     }

--- a/crates/solver/src/solver/http_solver/settlement.rs
+++ b/crates/solver/src/solver/http_solver/settlement.rs
@@ -41,11 +41,19 @@ enum Execution {
 }
 
 impl Execution {
-    fn coordinates(&self) -> Option<ExecutionPlanCoordinatesModel> {
+    fn execution_plan(&self) -> Option<&ExecutionPlan> {
         match self {
-            Execution::Amm(executed_amm) => executed_amm.exec_plan.clone(),
-            Execution::CustomInteraction(interaction) => interaction.exec_plan.clone(),
-            Execution::LimitOrder(order) => order.exec_plan.clone(),
+            Execution::Amm(executed_amm) => &executed_amm.exec_plan,
+            Execution::CustomInteraction(interaction) => &interaction.exec_plan,
+            Execution::LimitOrder(order) => &order.exec_plan,
+        }
+        .as_ref()
+    }
+
+    fn coordinates(&self) -> Option<ExecutionPlanCoordinatesModel> {
+        match self.execution_plan()? {
+            ExecutionPlan::Coordinates(coords) => Some(coords.clone()),
+            _ => None,
         }
     }
 
@@ -97,7 +105,7 @@ struct ExecutedLimitOrder {
     order: LimitOrder,
     executed_buy_amount: U256,
     executed_sell_amount: U256,
-    exec_plan: Option<ExecutionPlanCoordinatesModel>,
+    exec_plan: Option<ExecutionPlan>,
 }
 
 impl ExecutedLimitOrder {
@@ -115,7 +123,7 @@ struct ExecutedAmm {
     input: (H160, U256),
     output: (H160, U256),
     order: Liquidity,
-    exec_plan: Option<ExecutionPlanCoordinatesModel>,
+    exec_plan: Option<ExecutionPlan>,
 }
 
 impl Interaction for InteractionData {
@@ -160,6 +168,19 @@ impl IntermediateSettlement {
         }
 
         for execution in &self.executions {
+            if let Some(ExecutionPlan::Internal) = execution.execution_plan() {
+                // This AMM execution or interaction should be internalized and
+                // replaced with buffer trading. Ideally, we would be able to
+                // log the interaction calldata that would be equivalent to the
+                // buffer swap, but that would require a larger refactor around
+                // how we build settlements. For now, just log the execution
+                // itself which is enough to manually recontruct what the actual
+                // calldata would have been.
+                tracing::debug!(?execution, "internalized AMM execution");
+
+                continue;
+            }
+
             execution.add_to_settlement(&mut settlement)?;
         }
 
@@ -329,6 +350,7 @@ mod tests {
         }];
 
         let cp_amm_handler = CapturingSettlementHandler::arc();
+        let internal_amm_handler = CapturingSettlementHandler::arc();
         let wp_amm_handler = CapturingSettlementHandler::arc();
         let sp_amm_handler = CapturingSettlementHandler::arc();
         let liquidity = vec![
@@ -337,6 +359,12 @@ mod tests {
                 reserves: (3, 4),
                 fee: 5.into(),
                 settlement_handling: cp_amm_handler.clone(),
+            }),
+            Liquidity::ConstantProduct(ConstantProductOrder {
+                tokens: TokenPair::new(t0, t1).unwrap(),
+                reserves: (6, 7),
+                fee: 8.into(),
+                settlement_handling: internal_amm_handler.clone(),
             }),
             Liquidity::BalancerWeighted(WeightedProductOrder {
                 reserves: hashmap! {
@@ -388,10 +416,20 @@ mod tests {
                 buy_token: t0,
                 exec_sell_amount: U256::from(9),
                 exec_buy_amount: U256::from(8),
-                exec_plan: Some(ExecutionPlanCoordinatesModel {
+                exec_plan: Some(ExecutionPlan::Coordinates(ExecutionPlanCoordinatesModel {
                     sequence: 0,
                     position: 0,
-                }),
+                })),
+            }],
+            cost: Default::default(),
+        };
+        let internal_uniswap = UpdatedAmmModel {
+            execution: vec![ExecutedAmmModel {
+                sell_token: t1,
+                buy_token: t0,
+                exec_sell_amount: U256::from(1),
+                exec_buy_amount: U256::from(1),
+                exec_plan: Some(ExecutionPlan::Internal),
             }],
             cost: Default::default(),
         };
@@ -401,10 +439,10 @@ mod tests {
                 buy_token: t0,
                 exec_sell_amount: U256::from(2),
                 exec_buy_amount: U256::from(1),
-                exec_plan: Some(ExecutionPlanCoordinatesModel {
+                exec_plan: Some(ExecutionPlan::Coordinates(ExecutionPlanCoordinatesModel {
                     sequence: 1,
                     position: 0,
-                }),
+                })),
             }],
             cost: Default::default(),
         };
@@ -414,16 +452,21 @@ mod tests {
                 buy_token: t0,
                 exec_sell_amount: U256::from(6),
                 exec_buy_amount: U256::from(4),
-                exec_plan: Some(ExecutionPlanCoordinatesModel {
+                exec_plan: Some(ExecutionPlan::Coordinates(ExecutionPlanCoordinatesModel {
                     sequence: 2,
                     position: 0,
-                }),
+                })),
             }],
             cost: Default::default(),
         };
         let settled = SettledBatchAuctionModel {
             orders: hashmap! { 0 => executed_order },
-            amms: hashmap! { 0 => updated_uniswap, 1 => updated_balancer_weighted, 2 => updated_balancer_stable },
+            amms: hashmap! {
+                0 => updated_uniswap,
+                1 => internal_uniswap,
+                2 => updated_balancer_weighted,
+                3 => updated_balancer_stable,
+            },
             ref_token: Some(t0),
             prices: hashmap! { t0 => 10.into(), t1 => 11.into() },
             approvals: Vec::new(),
@@ -450,6 +493,7 @@ mod tests {
                 output: (t1, 9.into()),
             }]
         );
+        assert_eq!(internal_amm_handler.calls(), vec![]);
         assert_eq!(
             wp_amm_handler.calls(),
             vec![AmmOrderExecution {
@@ -701,37 +745,37 @@ mod tests {
                     order: Liquidity::BalancerWeighted(wpo),
                     input: (token_c, U256::from(996570293625184642u128)),
                     output: (token_b, U256::from(354009510372384890u128)),
-                    exec_plan: Some(ExecutionPlanCoordinatesModel {
+                    exec_plan: Some(ExecutionPlan::Coordinates(ExecutionPlanCoordinatesModel {
                         sequence: 0u32,
                         position: 0u32,
-                    }),
+                    })),
                 })),
                 Execution::Amm(Box::new(ExecutedAmm {
                     order: Liquidity::ConstantProduct(cpo_0),
                     input: (token_b, U256::from(354009510372389956u128)),
                     output: (token_a, U256::from(932415220613609833982u128)),
-                    exec_plan: Some(ExecutionPlanCoordinatesModel {
+                    exec_plan: Some(ExecutionPlan::Coordinates(ExecutionPlanCoordinatesModel {
                         sequence: 0u32,
                         position: 1u32,
-                    }),
+                    })),
                 })),
                 Execution::Amm(Box::new(ExecutedAmm {
                     order: Liquidity::ConstantProduct(cpo_1),
                     input: (token_c, U256::from(2)),
                     output: (token_b, U256::from(1)),
-                    exec_plan: Some(ExecutionPlanCoordinatesModel {
+                    exec_plan: Some(ExecutionPlan::Coordinates(ExecutionPlanCoordinatesModel {
                         sequence: 0u32,
                         position: 2u32,
-                    }),
+                    })),
                 })),
                 Execution::Amm(Box::new(ExecutedAmm {
                     order: Liquidity::BalancerStable(spo),
                     input: (token_c, U256::from(4)),
                     output: (token_b, U256::from(3)),
-                    exec_plan: Some(ExecutionPlanCoordinatesModel {
+                    exec_plan: Some(ExecutionPlan::Coordinates(ExecutionPlanCoordinatesModel {
                         sequence: 0u32,
                         position: 3u32,
-                    }),
+                    })),
                 })),
             ],
         );
@@ -752,10 +796,10 @@ mod tests {
             order: Liquidity::ConstantProduct(cpo_1),
             input: (token_a, U256::from(2_u8)),
             output: (token_b, U256::from(1_u8)),
-            exec_plan: Some(ExecutionPlanCoordinatesModel {
+            exec_plan: Some(ExecutionPlan::Coordinates(ExecutionPlanCoordinatesModel {
                 sequence: 1u32,
                 position: 2u32,
-            }),
+            })),
         }];
         let interactions = vec![InteractionData {
             target: H160::zero(),
@@ -763,10 +807,10 @@ mod tests {
             call_data: Vec::new(),
             inputs: vec![],
             outputs: vec![],
-            exec_plan: Some(ExecutionPlanCoordinatesModel {
+            exec_plan: Some(ExecutionPlan::Coordinates(ExecutionPlanCoordinatesModel {
                 sequence: 1u32,
                 position: 1u32,
-            }),
+            })),
         }];
         let orders = vec![ExecutedLimitOrder {
             order: Default::default(),


### PR DESCRIPTION
Now that we have external solvers, we will start requiring them to provide execution/calldata for AMM interactions that they internalize.

This PR changes the `exec_plan` that is returned from HTTP solvers to instead use an enum to indicate whether or not it is "internal" or to be included in the execution plan. Currently, all we do with "internal" interactions is to skip them when adding them to the solution and logging a message indicating that it was internalized.

Once we start recording settlement competitions in the database, we need to make sure that these internalized AMM interactions get stored somewhere so that they can be verified at a later date. For this, some additional refactoring is necessary in order to make encoding interactions into settlements easier.

One additional point of interest is that we currently don't verify that internalized interactions are indeed over the list of "allowed buffer trading" tokens. I plan on adding this as an follow up PR to not over-complicate this one.

### Test Plan

Added a unit test that verifies that internal interactions don't get encoded.
