### PR TITLE
Add EIP-1271

### DIFF
--- a/crates/contracts/artifacts/SignatureValidator.json
+++ b/crates/contracts/artifacts/SignatureValidator.json
@@ -1,0 +1,28 @@
+{
+  "abi": [
+    {
+      "inputs": [
+        {
+          "internalType": "bytes32",
+          "name": "hash",
+          "type": "bytes32"
+        },
+        {
+          "internalType": "bytes",
+          "name": "signature",
+          "type": "bytes"
+        }
+      ],
+      "name": "isValidSignature",
+      "outputs": [
+        {
+          "internalType": "bytes4",
+          "name": "magicValue",
+          "type": "bytes4"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    }
+  ]
+}

--- a/crates/contracts/build.rs
+++ b/crates/contracts/build.rs
@@ -205,6 +205,8 @@ fn main() {
     });
     generate_contract("IUniswapLikeRouter");
     generate_contract("IUniswapLikePair");
+    // EIP-1271 contract - SignatureValidator
+    generate_contract("SignatureValidator");
     generate_contract_with_config("SushiSwapFactory", |builder| {
         builder
             .add_network_str("1", "0xC0AEe478e3658e2610c5F7A4A2E1777cE9e4f2Ac")

--- a/crates/contracts/src/lib.rs
+++ b/crates/contracts/src/lib.rs
@@ -39,6 +39,7 @@ include!(concat!(env!("OUT_DIR"), "/HoneyswapFactory.rs"));
 include!(concat!(env!("OUT_DIR"), "/HoneyswapRouter.rs"));
 include!(concat!(env!("OUT_DIR"), "/IUniswapLikePair.rs"));
 include!(concat!(env!("OUT_DIR"), "/IUniswapLikeRouter.rs"));
+include!(concat!(env!("OUT_DIR"), "/SignatureValidator.rs"));
 include!(concat!(env!("OUT_DIR"), "/SushiSwapFactory.rs"));
 include!(concat!(env!("OUT_DIR"), "/SushiSwapRouter.rs"));
 include!(concat!(env!("OUT_DIR"), "/SwaprFactory.rs"));

--- a/crates/model/src/order.rs
+++ b/crates/model/src/order.rs
@@ -86,7 +86,7 @@ impl Order {
                 is_liquidity_order,
                 ..Default::default()
             },
-            creation: *order_creation,
+            creation: order_creation.clone(),
         }
     }
 
@@ -257,7 +257,7 @@ impl OrderBuilder {
 
 /// An order as provided to the orderbook by the frontend.
 #[serde_as]
-#[derive(Eq, PartialEq, Copy, Clone, Deserialize, Debug, Serialize, Hash)]
+#[derive(Eq, PartialEq, Clone, Deserialize, Debug, Serialize, Hash)]
 #[serde(rename_all = "camelCase")]
 pub struct OrderCreation {
     pub sell_token: H160,

--- a/crates/model/src/order.rs
+++ b/crates/model/src/order.rs
@@ -395,6 +395,7 @@ impl OrderCreation {
 #[derive(Eq, PartialEq, Clone, Copy, Debug, Hash)]
 pub struct OrderCancellation {
     pub order_uid: OrderUid,
+    // todo: use `Signature` in order to allow EIP-1271 signatures
     pub signature: EcdsaSignature,
     pub signing_scheme: EcdsaSigningScheme,
 }

--- a/crates/orderbook/src/database/orders.rs
+++ b/crates/orderbook/src/database/orders.rs
@@ -143,6 +143,7 @@ impl DbBuyTokenDestination {
 #[sqlx(rename_all = "lowercase")]
 pub enum DbSigningScheme {
     Eip712,
+    Eip1271,
     EthSign,
     PreSign,
 }
@@ -151,6 +152,7 @@ impl DbSigningScheme {
     pub fn from(signing_scheme: SigningScheme) -> Self {
         match signing_scheme {
             SigningScheme::Eip712 => Self::Eip712,
+            SigningScheme::Eip1271 => Self::Eip1271,
             SigningScheme::EthSign => Self::EthSign,
             SigningScheme::PreSign => Self::PreSign,
         }
@@ -159,6 +161,7 @@ impl DbSigningScheme {
     fn into(self) -> SigningScheme {
         match self {
             Self::Eip712 => SigningScheme::Eip712,
+            Self::Eip1271 => SigningScheme::Eip1271,
             Self::EthSign => SigningScheme::EthSign,
             Self::PreSign => SigningScheme::PreSign,
         }

--- a/crates/orderbook/src/lib.rs
+++ b/crates/orderbook/src/lib.rs
@@ -10,6 +10,7 @@ pub mod metrics;
 pub mod orderbook;
 pub mod solvable_orders;
 pub mod solver_competition;
+pub mod signature_validator;
 
 use crate::{api::post_quote::OrderQuoter, orderbook::Orderbook};
 use anyhow::{anyhow, Context as _, Result};

--- a/crates/orderbook/src/orderbook.rs
+++ b/crates/orderbook/src/orderbook.rs
@@ -120,7 +120,7 @@ impl Orderbook {
                 order_creation.signature.scheme(),
                 self.enable_presign_orders
             ),
-            (SigningScheme::Eip712 | SigningScheme::EthSign, _) | (SigningScheme::PreSign, true)
+            (SigningScheme::Eip712 | SigningScheme::EthSign | SigningScheme::Eip1271, _) | (SigningScheme::PreSign, true)
         ) {
             return Err(AddOrderError::UnsupportedSignature);
         }

--- a/crates/orderbook/src/signature_validator.rs
+++ b/crates/orderbook/src/signature_validator.rs
@@ -1,26 +1,18 @@
-use anyhow::Result;
-use ethcontract::{batch::CallBatch, Bytes};
+use anyhow::{Result, Context};
+use ethcontract::Bytes;
 use primitive_types::H160;
 use shared::Web3;
-
-#[derive(Debug)]
-pub enum IsValidSignatureError {
-    ContractCallFailed,
-}
 
 #[cfg_attr(test, mockall::automock)]
 #[async_trait::async_trait]
 /// <https://eips.ethereum.org/EIPS/eip-1271>
 pub trait SignatureValidator: Send + Sync {
-    /// The Magical value as defined by EIP-1271
-    const MAGICAL_VALUE: [u8; 4] = 0x1626ba7e_u32.to_le_bytes();
-
     async fn is_valid_signature(
         &self,
         contract_address: H160,
         hash: [u8; 32],
         signature: &[u8],
-    ) -> Result<bool, IsValidSignatureError>;
+    ) -> Result<bool>;
 }
 
 pub struct Web3SignatureValidator {
@@ -28,6 +20,9 @@ pub struct Web3SignatureValidator {
 }
 
 impl Web3SignatureValidator {
+    /// The Magical value as defined by EIP-1271
+    pub const MAGICAL_VALUE: [u8; 4] = 0x1626ba7e_u32.to_le_bytes();
+
     pub fn new(web3: Web3) -> Self {
         Self { web3 }
     }
@@ -40,14 +35,14 @@ impl SignatureValidator for Web3SignatureValidator {
         contract_address: H160,
         hash: [u8; 32],
         signature: &[u8],
-    ) -> Result<bool, IsValidSignatureError> {
+    ) -> Result<bool> {
         let instance = contracts::SignatureValidator::at(&self.web3, contract_address);
 
         let is_valid_signature = instance
             .is_valid_signature(Bytes(hash), Bytes(signature.to_vec()))
             .call()
             .await
-            .map_err(|_method_err| IsValidSignatureError::ContractCallFailed)?;
+            .context("isValidSignature")?;
 
         Ok(is_valid_signature.0 == Self::MAGICAL_VALUE)
     }

--- a/crates/orderbook/src/signature_validator.rs
+++ b/crates/orderbook/src/signature_validator.rs
@@ -1,0 +1,54 @@
+use anyhow::Result;
+use ethcontract::{batch::CallBatch, Bytes};
+use primitive_types::H160;
+use shared::Web3;
+
+#[derive(Debug)]
+pub enum IsValidSignatureError {
+    ContractCallFailed,
+}
+
+#[cfg_attr(test, mockall::automock)]
+#[async_trait::async_trait]
+/// <https://eips.ethereum.org/EIPS/eip-1271>
+pub trait SignatureValidator: Send + Sync {
+    /// The Magical value as defined by EIP-1271
+    const MAGICAL_VALUE: [u8; 4] = 0x1626ba7e_u32.to_le_bytes();
+
+    async fn is_valid_signature(
+        &self,
+        contract_address: H160,
+        hash: [u8; 32],
+        signature: &[u8],
+    ) -> Result<bool, IsValidSignatureError>;
+}
+
+pub struct Web3SignatureValidator {
+    web3: Web3,
+}
+
+impl Web3SignatureValidator {
+    pub fn new(web3: Web3) -> Self {
+        Self { web3 }
+    }
+}
+
+#[async_trait::async_trait]
+impl SignatureValidator for Web3SignatureValidator {
+    async fn is_valid_signature(
+        &self,
+        contract_address: H160,
+        hash: [u8; 32],
+        signature: &[u8],
+    ) -> Result<bool, IsValidSignatureError> {
+        let instance = contracts::SignatureValidator::at(&self.web3, contract_address);
+
+        let is_valid_signature = instance
+            .is_valid_signature(Bytes(hash), Bytes(signature.to_vec()))
+            .call()
+            .await
+            .map_err(|_method_err| IsValidSignatureError::ContractCallFailed)?;
+
+        Ok(is_valid_signature.0 == Self::MAGICAL_VALUE)
+    }
+}

--- a/crates/solver/src/encoding.rs
+++ b/crates/solver/src/encoding.rs
@@ -66,6 +66,7 @@ fn order_flags(order: &OrderCreation) -> U256 {
         SigningScheme::Eip712 => 0b00,
         SigningScheme::EthSign => 0b01,
         SigningScheme::PreSign => 0b11,
+        SigningScheme::Eip1271 => 0b10,
     } << 5;
     result.into()
 }


### PR DESCRIPTION
I've started the implementation to allow EIP-1271 signature validation.

Summary of needed changes provided by the cowswap team:

- [x] Signatures will be some calldata with variable byte length.
- [x] Signature verification requires an eth_call on-chain (see `orderbook::SignatureValidator`)
- [ ] Signatures are validated on-chain, so they need to be checked per auction to see if their validity changes over time (`orderbook::singature_validator::SignatureValidator`)
- [ ] Code for encoding signature scheme (although this is the most trivial part)
- Signature verification incurs additional gas overhead (which depends on the EIP-1271 verification implementation) and needs to be computed and added to the fee quote. (will be implemented in a subsequent PR)
- OrderCancellation - should also support EIP-1271 (will be implemented in a subsequent PR)


- https://eips.ethereum.org/EIPS/eip-1271