### PR TITLE
Add log for order created uid

### DIFF
--- a/crates/orderbook/src/api/create_order.rs
+++ b/crates/orderbook/src/api/create_order.rs
@@ -49,6 +49,9 @@ pub fn create_order(
         let orderbook = orderbook.clone();
         async move {
             let result = orderbook.add_order(order_payload).await;
+            if let Ok(order_uid) = result {
+                tracing::debug!("order created with uid {}", order_uid);
+            }
             Result::<_, Infallible>::Ok(create_order_response(result))
         }
     })


### PR DESCRIPTION
This PR adds logging of the newly created order's `Uid`.

Using this `Uid` and the log timestamp we can connect the `orderbook::api::request_summary` log with the order logs in the solver.

Tried to find the cleaner way to add this log directly to the orderbook, but once the response is wrapped into `ApiReply` it becomes cumbersome to extract the needed `Uid`.