### PR TITLE
Exclude orders with low cost coverage

### DIFF
--- a/crates/e2e/tests/e2e/services.rs
+++ b/crates/e2e/tests/e2e/services.rs
@@ -163,6 +163,7 @@ impl OrderbookServices {
         let solvable_orders_cache = SolvableOrdersCache::new(
             Duration::from_secs(120),
             db.clone(),
+            Arc::new(web3.clone()),
             Default::default(),
             balance_fetcher.clone(),
             bad_token_detector.clone(),

--- a/crates/orderbook/src/database/instrumented.rs
+++ b/crates/orderbook/src/database/instrumented.rs
@@ -1,7 +1,7 @@
 use super::{orders::OrderStoring, trades::TradeRetrieving, Postgres};
 use crate::fee::{FeeParameters, MinFeeStoring};
 use ethcontract::H256;
-use model::order::Order;
+use model::order::{Order, OrderUid};
 use prometheus::Histogram;
 use shared::{event_handling::EventStoring, maintenance::Maintaining};
 use std::sync::Arc;
@@ -181,6 +181,10 @@ impl OrderStoring for Instrumented {
             .database_query_histogram("user_orders")
             .start_timer();
         self.inner.user_orders(owner, offset, limit).await
+    }
+    async fn fee_of_order(&self, uid: &OrderUid) -> anyhow::Result<FeeParameters> {
+        let _timer = self.metrics.database_query_histogram("fees").start_timer();
+        self.inner.fee_of_order(uid).await
     }
 }
 

--- a/crates/orderbook/src/database/orders.rs
+++ b/crates/orderbook/src/database/orders.rs
@@ -476,7 +476,7 @@ impl OrderStoring for Postgres {
             .bind(uid.0.as_ref())
             .fetch_one(&self.pool)
             .await?;
-        OrderFeeQueryRow::into_fee(&fee)
+        OrderFeeQueryRow::into_fee(fee)
     }
 
     async fn user_orders(
@@ -635,7 +635,7 @@ struct OrderFeeQueryRow {
 }
 
 impl OrderFeeQueryRow {
-    fn into_fee(&self) -> Result<FeeParameters> {
+    fn into_fee(self) -> Result<FeeParameters> {
         Ok(FeeParameters {
             gas_price: self.gas_price,
             gas_amount: self.gas_amount,

--- a/crates/orderbook/src/main.rs
+++ b/crates/orderbook/src/main.rs
@@ -672,6 +672,7 @@ async fn main() {
     let solvable_orders_cache = SolvableOrdersCache::new(
         args.min_order_validity_period,
         database.clone(),
+        gas_price_estimator.clone(),
         args.banned_users.iter().copied().collect(),
         balance_fetcher.clone(),
         bad_token_detector.clone(),


### PR DESCRIPTION
Hey guys

This is just a very quick handover of the current state for the task to exclude low cost coverage orders from the solvable order endpoint since I am on holiday.

I think the PR is in a reasonable state, hopefully it just needs some smoothening and polishing. It would be great if it would get a review and if then someone could actually push this PR over the finish line.

I left one todo in the code, but I am not sure it's even necessary. I think it would give a minor performance improvement that is bought with more complexity during order fetching.