### PR TITLE
Add HTTP headers for external solver requests

### DIFF
--- a/crates/shared/src/http_solver.rs
+++ b/crates/shared/src/http_solver.rs
@@ -110,7 +110,12 @@ impl HttpSolverApi for DefaultHttpSolverApi {
                 .append_pair("auction_id", auction_id.to_string().as_str());
         }
         let query = url.query().map(ToString::to_string).unwrap_or_default();
-        let mut request = self.client.post(url).timeout(timeout);
+        let mut request = self
+            .client
+            .post(url)
+            .timeout(timeout)
+            .header("content-type", "application/json")
+            .header("accept", "application/json");
         if let Some(api_key) = &self.config.api_key {
             let mut header = HeaderValue::from_str(api_key.as_str()).unwrap();
             header.set_sensitive(true);


### PR DESCRIPTION
This PR just adds HTTP headers indicating that external solver `/solve` requests both send and only accept JSON.

This is just to be more polite to solvers as some frameworks have friction if the header is missing or not set to `application/json`.

### Test Plan

CI.
