### PR TITLE
Drop liquidity owner allow list

### DIFF
--- a/crates/e2e/tests/e2e/services.rs
+++ b/crates/e2e/tests/e2e/services.rs
@@ -152,7 +152,6 @@ impl OrderbookServices {
             },
             native_price_estimator.clone(),
             Arc::new(FixedCowSubsidy(1.0)),
-            Default::default(),
         ));
         let balance_fetcher = Arc::new(Web3BalanceFetcher::new(
             web3.clone(),

--- a/crates/e2e/tests/e2e/services.rs
+++ b/crates/e2e/tests/e2e/services.rs
@@ -174,7 +174,6 @@ impl OrderbookServices {
             Box::new(web3.clone()),
             contracts.weth.clone(),
             HashSet::default(),
-            HashSet::default(),
             Duration::from_secs(120),
             fee_calculator.clone(),
             bad_token_detector.clone(),

--- a/crates/model/src/order.rs
+++ b/crates/model/src/order.rs
@@ -283,10 +283,13 @@ pub struct OrderCreation {
 }
 
 #[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct OrderCreationPayload {
     #[serde(flatten)]
     pub order_creation: OrderCreation,
     pub from: Option<H160>,
+    #[serde(default)]
+    pub is_liquidity_order: bool,
 }
 
 impl Default for OrderCreation {

--- a/crates/orderbook/openapi.yml
+++ b/crates/orderbook/openapi.yml
@@ -638,6 +638,17 @@ components:
                 any balance.
               $ref: "#/components/schemas/Address"
               nullable: true
+            isLiquidityOrder:
+              description: |
+                Liquidity orders are functionally the same as normal smart contract orders but are not
+                placed with the intent of actively getting traded. Instead they facilitate the
+                trade of normal orders by allowing them to be matched against liquidity orders which
+                uses less gas and can have better prices than external liquidity.
+                As such liquidity orders will only be used in order to improve settlement of normal
+                orders. They should not be expected to be traded otherwise and should not expect to get
+                surplus.
+              type: boolean
+              default: false
           required:
             - signingScheme
             - signature
@@ -976,6 +987,17 @@ components:
             priceQuality:
               $ref: "#/components/schemas/PriceQuality"
               default: "optimal"
+            isLiquidityOrder:
+              description: |
+                Liquidity orders are functionally the same as normal smart contract orders but are not
+                placed with the intent of actively getting traded. Instead they facilitate the
+                trade of normal orders by allowing them to be matched against liquidity orders which
+                uses less gas and can have better prices than external liquidity.
+                As such liquidity orders will only be used in order to improve settlement of normal
+                orders. They should not be expected to be traded otherwise and should not expect to get
+                surplus.
+              type: boolean
+              default: false
           required:
             - sellToken
             - buyToken

--- a/crates/orderbook/src/api/get_fee_info.rs
+++ b/crates/orderbook/src/api/get_fee_info.rs
@@ -60,6 +60,7 @@ pub fn get_fee_info(
                     },
                     Default::default(),
                     Default::default(),
+                    false,
                 )
                 .await;
             Result::<_, Infallible>::Ok(convert_json_response(result.map(

--- a/crates/orderbook/src/api/order_validation.rs
+++ b/crates/orderbook/src/api/order_validation.rs
@@ -385,6 +385,7 @@ impl OrderValidating for OrderValidator {
                 order_creation.app_data,
                 order_creation.fee_amount,
                 owner,
+                payload.is_liquidity_order,
             )
             .await
             .map_err(|err| match err {
@@ -725,7 +726,7 @@ mod tests {
         let mut balance_fetcher = MockBalanceFetching::new();
         fee_calculator
             .expect_get_unsubsidized_min_fee()
-            .returning(|_, _, _, _| Ok(Default::default()));
+            .returning(|_, _, _, _, _| Ok(Default::default()));
         bad_token_detector
             .expect_detect()
             .returning(|_| Ok(TokenQuality::Good));
@@ -766,7 +767,7 @@ mod tests {
         let mut balance_fetcher = MockBalanceFetching::new();
         fee_calculator
             .expect_get_unsubsidized_min_fee()
-            .returning(|_, _, _, _| Ok(Default::default()));
+            .returning(|_, _, _, _, _| Ok(Default::default()));
         bad_token_detector
             .expect_detect()
             .returning(|_| Ok(TokenQuality::Good));
@@ -807,7 +808,7 @@ mod tests {
         let mut balance_fetcher = MockBalanceFetching::new();
         fee_calculator
             .expect_get_unsubsidized_min_fee()
-            .returning(|_, _, _, _| Ok(Default::default()));
+            .returning(|_, _, _, _, _| Ok(Default::default()));
         bad_token_detector
             .expect_detect()
             .returning(|_| Ok(TokenQuality::Good));
@@ -848,7 +849,7 @@ mod tests {
         let mut balance_fetcher = MockBalanceFetching::new();
         fee_calculator
             .expect_get_unsubsidized_min_fee()
-            .returning(|_, _, _, _| Err(GetUnsubsidizedMinFeeError::InsufficientFee));
+            .returning(|_, _, _, _, _| Err(GetUnsubsidizedMinFeeError::InsufficientFee));
         bad_token_detector
             .expect_detect()
             .returning(|_| Ok(TokenQuality::Good));
@@ -889,7 +890,7 @@ mod tests {
         let mut balance_fetcher = MockBalanceFetching::new();
         fee_calculator
             .expect_get_unsubsidized_min_fee()
-            .returning(|_, _, _, _| Ok(Default::default()));
+            .returning(|_, _, _, _, _| Ok(Default::default()));
         bad_token_detector.expect_detect().returning(|_| {
             Ok(TokenQuality::Bad {
                 reason: Default::default(),
@@ -932,7 +933,7 @@ mod tests {
         let mut balance_fetcher = MockBalanceFetching::new();
         fee_calculator
             .expect_get_unsubsidized_min_fee()
-            .returning(|_, _, _, _| Ok(Default::default()));
+            .returning(|_, _, _, _, _| Ok(Default::default()));
         bad_token_detector
             .expect_detect()
             .returning(|_| Ok(TokenQuality::Good));
@@ -974,7 +975,7 @@ mod tests {
         let mut balance_fetcher = MockBalanceFetching::new();
         fee_calculator
             .expect_get_unsubsidized_min_fee()
-            .returning(|_, _, _, _| Ok(Default::default()));
+            .returning(|_, _, _, _, _| Ok(Default::default()));
         bad_token_detector
             .expect_detect()
             .returning(|_| Ok(TokenQuality::Good));
@@ -1017,7 +1018,7 @@ mod tests {
                 let mut balance_fetcher = MockBalanceFetching::new();
                 fee_calculator
                     .expect_get_unsubsidized_min_fee()
-                    .returning(|_, _, _, _| Ok(Default::default()));
+                    .returning(|_, _, _, _, _| Ok(Default::default()));
                 bad_token_detector
                     .expect_detect()
                     .returning(|_| Ok(TokenQuality::Good));

--- a/crates/orderbook/src/api/post_quote.rs
+++ b/crates/orderbook/src/api/post_quote.rs
@@ -39,6 +39,8 @@ pub struct OrderQuoteRequest {
     buy_token_balance: BuyTokenDestination,
     #[serde(default)]
     price_quality: PriceQuality,
+    #[serde(default)]
+    is_liquidity_order: bool,
 }
 
 impl From<&OrderQuoteRequest> for PreOrderData {
@@ -281,6 +283,7 @@ impl OrderQuoter {
                         },
                         quote_request.app_data,
                         quote_request.from,
+                        quote_request.is_liquidity_order,
                     ),
                     single_estimate(price_estimator.as_ref(), &query)
                 )
@@ -336,6 +339,7 @@ impl OrderQuoter {
                         },
                         quote_request.app_data,
                         quote_request.from,
+                        quote_request.is_liquidity_order,
                     ),
                     single_estimate(price_estimator.as_ref(), &price_estimation_query)
                 )
@@ -373,6 +377,7 @@ impl OrderQuoter {
                         },
                         quote_request.app_data,
                         quote_request.from,
+                        quote_request.is_liquidity_order,
                     ),
                     single_estimate(price_estimator.as_ref(), &price_estimation_query)
                 )
@@ -451,7 +456,8 @@ mod tests {
                 "appData": "0x9090909090909090909090909090909090909090909090909090909090909090",
                 "partiallyFillable": false,
                 "buyTokenBalance": "internal",
-                "priceQuality": "optimal"
+                "priceQuality": "optimal",
+                "isLiquidityOrder": false,
             }))
             .unwrap(),
             OrderQuoteRequest {
@@ -467,7 +473,8 @@ mod tests {
                 partially_fillable: false,
                 sell_token_balance: SellTokenSource::Erc20,
                 buy_token_balance: BuyTokenDestination::Internal,
-                price_quality: PriceQuality::Optimal
+                price_quality: PriceQuality::Optimal,
+                is_liquidity_order: false,
             }
         );
     }
@@ -485,7 +492,8 @@ mod tests {
                 "appData": "0x9090909090909090909090909090909090909090909090909090909090909090",
                 "partiallyFillable": false,
                 "sellTokenBalance": "external",
-                "priceQuality": "fast"
+                "priceQuality": "fast",
+                "isLiquidityOrder": false,
             }))
             .unwrap(),
             OrderQuoteRequest {
@@ -501,7 +509,8 @@ mod tests {
                 partially_fillable: false,
                 sell_token_balance: SellTokenSource::External,
                 buy_token_balance: BuyTokenDestination::Erc20,
-                price_quality: PriceQuality::Fast
+                price_quality: PriceQuality::Fast,
+                is_liquidity_order: false,
             }
         );
     }
@@ -519,6 +528,7 @@ mod tests {
                 "validTo": 0x12345678,
                 "appData": "0x9090909090909090909090909090909090909090909090909090909090909090",
                 "partiallyFillable": false,
+                "isLiquidityOrder": false,
             }))
             .unwrap(),
             OrderQuoteRequest {
@@ -534,7 +544,8 @@ mod tests {
                 partially_fillable: false,
                 sell_token_balance: SellTokenSource::Erc20,
                 buy_token_balance: BuyTokenDestination::Erc20,
-                price_quality: Default::default()
+                price_quality: Default::default(),
+                is_liquidity_order: false,
             }
         );
     }
@@ -618,7 +629,7 @@ mod tests {
         let expiration = Utc::now();
         fee_calculator
             .expect_compute_subsidized_min_fee()
-            .returning(move |_, _, _| Ok((3.into(), expiration)));
+            .returning(move |_, _, _, _| Ok((3.into(), expiration)));
 
         let fee_calculator = Arc::new(fee_calculator);
         let price_estimator = FakePriceEstimator(price_estimation::Estimate {
@@ -662,7 +673,7 @@ mod tests {
         let expiration = Utc::now();
         fee_calculator
             .expect_compute_subsidized_min_fee()
-            .returning(move |_, _, _| Ok((3.into(), expiration)));
+            .returning(move |_, _, _, _| Ok((3.into(), expiration)));
 
         let fee_calculator = Arc::new(fee_calculator);
         let price_estimator = FakePriceEstimator(price_estimation::Estimate {
@@ -705,7 +716,7 @@ mod tests {
         let expiration = Utc::now();
         fee_calculator
             .expect_compute_subsidized_min_fee()
-            .returning(move |_, _, _| Ok((3.into(), expiration)));
+            .returning(move |_, _, _, _| Ok((3.into(), expiration)));
 
         let fee_calculator = Arc::new(fee_calculator);
         let price_estimator = FakePriceEstimator(price_estimation::Estimate {
@@ -765,7 +776,7 @@ mod tests {
         let mut fee_calculator = MockMinFeeCalculating::new();
         fee_calculator
             .expect_compute_subsidized_min_fee()
-            .returning(move |_, _, _| Ok((3.into(), Utc::now())));
+            .returning(move |_, _, _, _| Ok((3.into(), Utc::now())));
         let price_estimator = FakePriceEstimator(price_estimation::Estimate {
             out_amount: 14.into(),
             gas: 1000,

--- a/crates/orderbook/src/api/post_quote.rs
+++ b/crates/orderbook/src/api/post_quote.rs
@@ -53,7 +53,7 @@ impl From<&OrderQuoteRequest> for PreOrderData {
             partially_fillable: quote_request.partially_fillable,
             buy_token_balance: quote_request.buy_token_balance,
             sell_token_balance: quote_request.sell_token_balance,
-            is_liquidity_order: quote_request.partially_fillable,
+            is_liquidity_order: quote_request.is_liquidity_order,
         }
     }
 }

--- a/crates/orderbook/src/main.rs
+++ b/crates/orderbook/src/main.rs
@@ -248,15 +248,6 @@ struct Arguments {
 
     #[clap(long, env, default_value = "static", arg_enum)]
     token_detector_fee_values: FeeValues,
-
-    /// The configured addresses whose orders should be considered liquidity and
-    /// not regular user orders.
-    ///
-    /// These orders have special semantics such as not being considered in the
-    /// settlements objective funtion, not receiving any surplus, and being
-    /// allowed to place partially fillable orders.
-    #[clap(long, env, use_value_delimiter = true)]
-    pub liquidity_order_owners: Vec<H160>,
 }
 
 pub async fn database_metrics(metrics: Arc<Metrics>, database: Postgres) -> ! {
@@ -663,7 +654,6 @@ async fn main() {
             },
             native_price_estimator.clone(),
             cow_subsidy.clone(),
-            args.liquidity_order_owners.iter().copied().collect(),
         ))
     };
     let fee_calculator = create_fee_calculator(price_estimator.clone());

--- a/crates/orderbook/src/main.rs
+++ b/crates/orderbook/src/main.rs
@@ -688,7 +688,6 @@ async fn main() {
         Box::new(web3.clone()),
         native_token.clone(),
         args.banned_users.iter().copied().collect(),
-        args.liquidity_order_owners.iter().copied().collect(),
         args.min_order_validity_period,
         fee_calculator.clone(),
         bad_token_detector.clone(),

--- a/crates/orderbook/src/orderbook.rs
+++ b/crates/orderbook/src/orderbook.rs
@@ -115,11 +115,10 @@ impl Orderbook {
         &self,
         payload: OrderCreationPayload,
     ) -> Result<OrderUid, AddOrderError> {
-        let order_creation = payload.order_creation;
         // Eventually we will support all Signature types and can remove this.
         if !matches!(
             (
-                order_creation.signature.scheme(),
+                payload.order_creation.signature.scheme(),
                 self.enable_presign_orders
             ),
             (SigningScheme::Eip712 | SigningScheme::EthSign, _) | (SigningScheme::PreSign, true)
@@ -129,12 +128,7 @@ impl Orderbook {
 
         let (order, fee) = self
             .order_validator
-            .validate_and_construct_order(
-                order_creation,
-                payload.from,
-                &self.domain_separator,
-                self.settlement_contract,
-            )
+            .validate_and_construct_order(payload, &self.domain_separator, self.settlement_contract)
             .await?;
 
         self.database.insert_order(&order, fee).await?;


### PR DESCRIPTION
So far we needed to allow list anyone who wanted to create liquidity orders. For that we had to maintain the allow list in the gitlab repo which is cumbersome, error prone and kind of unnecessary.
This PR allows anyone to create a liquidity order by setting the `isLiquidityOrder` flag during order creation.

To minimize breaking backwards compatiblity `isLiquidityOrder` is now an optional field in the `OrderCreationPayload` which defaults to false if it is not set. This means the frontend doesn't have to change anything since they always want to create "normal" orders. The only people which have to adapt for this change are our existing private liquidity providers. Until now all their orders were liquidity orders. Now they have to transmit the new flag during order creation.

### Test Plan
Updated existing tests with new flag.
Manual tests with [custom order ui](https://github.com/cowprotocol/custom-order-ui/pull/2) (this had to be updated to support the new flag)

### Release notes
Allow placing liquidity orders by setting `isLiquidityOrder` to `true` while quoting and order creation.
