### PR TITLE
Define AppId semantics

### DIFF
--- a/crates/model/src/app_id.rs
+++ b/crates/model/src/app_id.rs
@@ -1,3 +1,4 @@
+use hex_literal::hex;
 use serde::{de, Deserializer, Serializer};
 use serde_with::serde::{Deserialize, Serialize};
 use std::{
@@ -6,8 +7,16 @@ use std::{
     str::FromStr,
 };
 
+/// Binary data which gets signed with an order and holds additional information about the order.
+/// This format is extendable since there are many reserved/unused bits left.
 #[derive(Clone, Copy, Default, Eq, Hash, PartialEq)]
 pub struct AppId(pub [u8; 32]);
+// byte index increases from left to right
+// bit index increases from left to right
+// byte 0:
+//    bit 0: isLiquidityOrder
+//    bit 1-7: reserved
+// byte 1-31: reserved
 
 impl Debug for AppId {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
@@ -55,6 +64,37 @@ impl<'de> Deserialize<'de> for AppId {
     }
 }
 
+impl AppId {
+    // Those bit patterns have already been used by external integrators before it was well defined
+    // what each bit in `AppId` was supposed to mean.
+    // Until those integrators have been informed about the change and updated their implementation
+    // we can't assume bits with special meaning have been set/unset on purpose.
+    const EXCLUDED_PATTERNS: [[u8; 32]; 12] = [
+        hex!("E9F29AE547955463ED535162AEFEE525D8D309571A2B18BC26086C8C35D781EB"),
+        hex!("487B02C558D729ABAF3ECF17881A4181E5BC2446429A0995142297E897B6EB37"),
+        hex!("BAB87DF726E41C0941786CA710194982D753FBC140C6DC9951AC3450D8917699"),
+        hex!("E4D1AB10F2C9FFE7BDD23C315B03F18CFF90888D6B2BB5022BACD46AB9CDDF24"),
+        hex!("A076A100C2535DC6047C4C9940AE647D7DEAAC1729745117D19D4A63BC2F4D30"),
+        hex!("0BCAECDB9A1FDB3B207A7593EBF703836AD591D4E5E75DFDBF65E7B328F209CD"),
+        hex!("828569F802B7F8957F76996BDD875674821E41A688541A9E9EC97D5E897D44A7"),
+        hex!("A5DAE7A114F1BD6BB9B3FF976150380A95CB18856212DB555C25EF9D7801E9A4"),
+        hex!("1C727C53F8A4552B7084DB0934A9A15C06DAA0EFF7878DE31A1A22D9ED4E6112"),
+        hex!("f6a005bde820da47fdbb19bc07e56782b9ccec403a6899484cf502090627af8a"),
+        hex!("00000000000000000000000055662e225a3376759c24331a9aed764f8f0c9fbb"),
+        hex!("ACE3BC48303B96362EBCDEB46F2277C29716E832273B04C7EC528AF284061D54"),
+    ];
+
+    fn is_excluded(&self) -> bool {
+        Self::EXCLUDED_PATTERNS.contains(&self.0)
+    }
+
+    /// Order should only be executed to enable trading user orders. It should not receive any
+    /// surplus.
+    pub fn is_liquidity_order(&self) -> bool {
+        !self.is_excluded() && (self.0[0] & (1 << 7) != 0)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -94,5 +134,32 @@ mod tests {
         assert!(AppId::deserialize(json!("00")).is_err());
         assert!(AppId::deserialize(json!("asdf")).is_err());
         assert!(AppId::deserialize(json!("0x00")).is_err());
+    }
+
+    #[test]
+    fn ignores_liquidity_flag_for_exluded_patterns() {
+        for pattern in AppId::EXCLUDED_PATTERNS {
+            let liquidity_bit_set = pattern[0] & (1u8 << 7) != 0;
+            assert!(
+                !AppId(pattern).is_liquidity_order(),
+                "excluded patterns should always return the default value for the bit"
+            );
+
+            let mut excluded_pattern_with_purposeful_liquidity_bit = pattern;
+            excluded_pattern_with_purposeful_liquidity_bit[0] ^= 1u8 << 7;
+            assert_eq!(
+                AppId(excluded_pattern_with_purposeful_liquidity_bit).is_liquidity_order(),
+                !liquidity_bit_set,
+                "an excluded pattern with the bit purposfully toggled should return the actual value of the bit"
+            );
+        }
+    }
+
+    #[test]
+    fn set_and_unset_liquidity_flag() {
+        let mut app_id = AppId::default();
+        assert!(!app_id.is_liquidity_order());
+        app_id.0[0] |= 1u8 << 7;
+        assert!(app_id.is_liquidity_order());
     }
 }

--- a/crates/orderbook/src/fee.rs
+++ b/crates/orderbook/src/fee.rs
@@ -2,7 +2,10 @@ use anyhow::Result;
 use chrono::{DateTime, Duration, Utc, MAX_DATETIME};
 use futures::future::TryFutureExt;
 use gas_estimation::GasPriceEstimating;
-use model::{app_id::AppId, order::OrderKind};
+use model::{
+    app_id::{AppId, PartnerId},
+    order::OrderKind,
+};
 use primitive_types::{H160, U256};
 use serde::{Deserialize, Serialize};
 use shared::{
@@ -64,7 +67,7 @@ pub struct FeeSubsidyConfiguration {
     /// fee.
     ///
     /// Fee factors are applied **after** flat fee discounts.
-    pub partner_additional_fee_factors: HashMap<AppId, f64>,
+    pub partner_additional_fee_factors: HashMap<PartnerId, f64>,
 }
 
 impl Default for FeeSubsidyConfiguration {
@@ -151,7 +154,7 @@ impl FeeParameters {
 
         let factor = config
             .partner_additional_fee_factors
-            .get(&app_data)
+            .get(&app_data.partner_id())
             .copied()
             .unwrap_or(1.0)
             * config.fee_factor
@@ -758,7 +761,7 @@ mod tests {
             now: Box::new(Utc::now),
             bad_token_detector: Arc::new(ListBasedDetector::deny_list(vec![])),
             fee_subsidy: FeeSubsidyConfiguration {
-                partner_additional_fee_factors: hashmap! { app_data => 0.5 },
+                partner_additional_fee_factors: hashmap! { app_data.partner_id() => 0.5 },
                 ..Default::default()
             },
             native_price_estimator,
@@ -861,7 +864,7 @@ mod tests {
             bad_token_detector: Arc::new(ListBasedDetector::deny_list(vec![])),
             fee_subsidy: FeeSubsidyConfiguration {
                 fee_factor: 0.8,
-                partner_additional_fee_factors: hashmap! { app_data => 0.5 },
+                partner_additional_fee_factors: hashmap! { app_data.partner_id() => 0.5 },
                 ..Default::default()
             },
             native_price_estimator,
@@ -926,7 +929,7 @@ mod tests {
             fee_factor: 0.5,
             min_discounted_fee: 0.,
             partner_additional_fee_factors: maplit::hashmap! {
-                app_id => 0.1,
+                app_id.partner_id() => 0.1,
             },
         };
 


### PR DESCRIPTION
This work is related to enabling users to decide on an order-by-order basis whether they want to submit a liquidity order or a normal user order (add `isLiquidityOrder` flag).
Because this flag heavily influences how the order behaves (can it receive surplus?, does it incur fees?) this flag should be part of the payload the user has to sign to prevent 3rd parties messing with the flag after the user submitted the order (also [this](https://github.com/cowprotocol/custom-order-ui/pull/2#discussion_r875181883)).

This can be accomplished by making that flag part of the `app_data` field which holds the `AppId` type. This was intended as an extendable binary format for exactly such purposes.
Unfortunately this format was only loosely defined. One purpose was to let third parties create orders and get a reduced fee for their users (`partnerId`). Another purpose was to make otherwise identical orders unique (`salt`).
The problem is now that we never properly defined which bits where intended for which purpose so integrators usually used all of the bits for the `partnerId`.
This poses a problem for when we want to extend our binary format with things like the liquidity order flag. Some integrators which decided to use all of the bits for their `partnerId` would now unknowingly set the liquidity order flag because it didn't exist when they started sending their `partnerId`. For such integrators to use liquidity orders they will have to update their code.

In order to not force maintenance on our external integrators every time we come up with a new flag this PR aims to properly define the ABI of the `app_data` field such that we can add new features in the future without breaking its compatibility with existing external integrations.
This is simply done by being explicit about which bits can be used for which purpose and reserving the rest for future use.
This is my suggestion:
```
// byte index increases from left to right
// bit index increases from left to right
// byte 0:
//    bit 0: isLiquidityOrder
//    bit 1-7: reserved
// byte 1-25: reserved
// byte 26-27: salt
// byte 28-31: partner_id
```
This offers a generous amount for the existing purposes (`partnerId`, `salt`) while introducing the new desired liquidity flag and still leaves plenty of memory reserved for futures extensions to the order format. Please let me know if you think the space allocated for `partnerId` and `salt` is big enough.

### Notes on compatibility with existing integrators
I made all currently used `app_data` values "excluded". Excluded bit patterns are supposed to return default values for newly added flags/data. For liquidity order flag that means that all those known `app_data` values will result in normal user orders even if they technically have set the liquidity order flag to `true`.
I used this [list](https://docs.google.com/spreadsheets/d/19Pq_5wKuZl669N3QuvhXSkaXur6KOrpSpAF0Rf8SWWc/edit#gid=0) for that.

Also note that I used the end of the `app_data` for the current purposes (`partnerId`, `salt`) and the start for the new flags. The reason is that there is one integrator which only set the end of the data so in order to not "loose" that `partnerId` we need to read it from the back. All other integrators used all bits so it wouldn't matter for them where we defined the `partnerId` and `salt` fields.
Putting the new flag at the start does technically not cause ambiguity for this one specific integrator.

### Test Plan
Added units tests for newly defined parts of the `AppId`

### Release notes
Properly defined an ABI for the `app_data` field.
Add flag to `app_data` to create a liquidity order. This breaks the ABI compatibility for integrators using all bits of the `app_data` field.

### TODO
Update openapi spec
Update Dune bridge to only read the "correct" bytes to identify partners.