### PR TITLE
Minor submission logging improvements

### DIFF
--- a/crates/solver/src/settlement_submission/submitter.rs
+++ b/crates/solver/src/settlement_submission/submitter.rs
@@ -468,7 +468,6 @@ impl<'a> Submitter<'a> {
                     );
                 }
             }
-            tracing::debug!("Finished sending transaction with submitter {submitter_name}...");
             tokio::time::sleep(params.retry_interval).await;
         }
     }

--- a/crates/solver/src/settlement_submission/submitter.rs
+++ b/crates/solver/src/settlement_submission/submitter.rs
@@ -195,7 +195,7 @@ impl<'a> Submitter<'a> {
         let nonce = self.nonce().await?;
         let name = self.submit_api.name();
 
-        tracing::info!(
+        tracing::debug!(
             "starting solution submission at nonce {} with submitter {}",
             nonce,
             name
@@ -221,15 +221,15 @@ impl<'a> Submitter<'a> {
 
         let fallback_result = tokio::select! {
             method_error = submit_future.fuse() => {
-                tracing::info!("stopping submission for {} because simulation failed: {:?}", name, method_error);
+                tracing::debug!("stopping submission for {} because simulation failed: {:?}", name, method_error);
                 Err(method_error)
             },
             new_nonce = nonce_future.fuse() => {
-                tracing::info!("stopping submission for {} because account nonce changed to {}", name, new_nonce);
+                tracing::debug!("stopping submission for {} because account nonce changed to {}", name, new_nonce);
                 Ok(None)
             },
             _ = deadline_future.fuse() => {
-                tracing::info!("stopping submission for {} because deadline has been reached. cancelling last submitted transaction...", name);
+                tracing::debug!("stopping submission for {} because deadline has been reached. cancelling last submitted transaction...", name);
 
                 if let Some((transaction, gas_price)) = transactions.last() {
                     let gas_price = gas_price.bump(1.125).ceil();
@@ -261,7 +261,7 @@ impl<'a> Submitter<'a> {
             const MINED_TX_CHECK_INTERVAL: Duration = Duration::from_secs(5);
             let tx_to_propagate_deadline = Instant::now() + MINED_TX_PROPAGATE_TIME;
 
-            tracing::info!(
+            tracing::debug!(
                 "waiting up to {} seconds for {} to see if a transaction was mined",
                 MINED_TX_PROPAGATE_TIME.as_secs(),
                 name
@@ -277,7 +277,7 @@ impl<'a> Submitter<'a> {
                     find_mined_transaction(&self.contract.raw_instance().web3(), &transactions)
                         .await
                 {
-                    tracing::info!("{} found mined transaction {:?}", name, receipt);
+                    tracing::debug!("{} found mined transaction {:?}", name, receipt);
                     return status(receipt);
                 }
                 if Instant::now() + MINED_TX_CHECK_INTERVAL > tx_to_propagate_deadline {
@@ -287,7 +287,7 @@ impl<'a> Submitter<'a> {
             }
         }
 
-        tracing::info!("{} did not find any mined transaction", name);
+        tracing::debug!("{} did not find any mined transaction", name);
         fallback_result
             .transpose()
             .unwrap_or(Err(SubmissionError::Timeout))
@@ -401,7 +401,7 @@ impl<'a> Submitter<'a> {
                         method.access_list(new_access_list)
                     }
                     Err(err) => {
-                        tracing::info!("access list not created, reason: {:?}", err);
+                        tracing::debug!("access list not created, reason: {:?}", err);
                         method
                     }
                 },
@@ -442,7 +442,7 @@ impl<'a> Submitter<'a> {
                 }
             }
 
-            tracing::info!(
+            tracing::debug!(
                 "creating transaction with gas price (base_fee={}, max_fee={}, tip={}), gas estimate {}, submitter name: {}",
                 gas_price.base_fee(),
                 gas_price.cap(),
@@ -455,7 +455,7 @@ impl<'a> Submitter<'a> {
 
             match self.submit_api.submit_transaction(method.tx).await {
                 Ok(handle) => {
-                    tracing::info!(
+                    tracing::debug!(
                         submitter = %submitter_name, ?handle,
                         "submitted transaction",
                     );
@@ -695,7 +695,7 @@ mod tests {
             network_id: "1".to_string(),
         };
         let result = submitter.submit(settlement, params).await;
-        tracing::info!("finished with result {:?}", result);
+        tracing::debug!("finished with result {:?}", result);
     }
 
     #[test]

--- a/crates/solver/src/settlement_submission/submitter.rs
+++ b/crates/solver/src/settlement_submission/submitter.rs
@@ -461,12 +461,14 @@ impl<'a> Submitter<'a> {
                     );
                     transactions.push((handle, gas_price));
                 }
-                Err(err) => tracing::warn!("submission failed: {:?}", err),
+                Err(err) => {
+                    tracing::warn!(
+                        submitter = %submitter_name, ?err,
+                        "submission failed",
+                    );
+                }
             }
-            tracing::debug!(
-                "Finished sending transaction with submitter {}...",
-                submitter_name
-            );
+            tracing::debug!("Finished sending transaction with submitter {submitter_name}...");
             tokio::time::sleep(params.retry_interval).await;
         }
     }

--- a/crates/solver/src/settlement_submission/submitter/custom_nodes_api.rs
+++ b/crates/solver/src/settlement_submission/submitter/custom_nodes_api.rs
@@ -82,7 +82,6 @@ impl TransactionSubmitting for CustomNodesApi {
 
         loop {
             let ((label, result), _, rest) = futures::future::select_all(futures).await;
-            tracing::debug!(%label, "custom node loop iteration");
             match result {
                 Ok(tx_hash) => {
                     super::track_submission_success(&label, true);

--- a/crates/solver/src/settlement_submission/submitter/custom_nodes_api.rs
+++ b/crates/solver/src/settlement_submission/submitter/custom_nodes_api.rs
@@ -56,7 +56,7 @@ impl TransactionSubmitting for CustomNodesApi {
         &self,
         tx: TransactionBuilder<DynTransport>,
     ) -> Result<TransactionHandle> {
-        tracing::info!("Custom nodes submit transaction entered");
+        tracing::debug!("Custom nodes submit transaction entered");
         let transaction_request = tx.build().now_or_never().unwrap().unwrap();
         let mut futures = self
             .nodes
@@ -66,7 +66,7 @@ impl TransactionSubmitting for CustomNodesApi {
                 let label = format!("custom_nodes_{i}");
                 let transaction_request = transaction_request.clone();
                 async move {
-                    tracing::info!(%label, "sending transaction...");
+                    tracing::debug!(%label, "sending transaction...");
                     let result = match transaction_request {
                         Transaction::Request(tx) => node.eth().send_transaction(tx).await,
                         Transaction::Raw { bytes, .. } => {
@@ -82,11 +82,11 @@ impl TransactionSubmitting for CustomNodesApi {
 
         loop {
             let ((label, result), _, rest) = futures::future::select_all(futures).await;
-            tracing::info!(%label, "custom node loop iteration");
+            tracing::debug!(%label, "custom node loop iteration");
             match result {
                 Ok(tx_hash) => {
                     super::track_submission_success(&label, true);
-                    tracing::info!(%label, "created transaction with hash: {:?}", tx_hash);
+                    tracing::debug!(%label, "created transaction with hash: {:?}", tx_hash);
                     return Ok(TransactionHandle {
                         tx_hash,
                         handle: tx_hash,

--- a/crates/solver/src/settlement_submission/submitter/custom_nodes_api.rs
+++ b/crates/solver/src/settlement_submission/submitter/custom_nodes_api.rs
@@ -61,46 +61,55 @@ impl TransactionSubmitting for CustomNodesApi {
         let mut futures = self
             .nodes
             .iter()
-            .map(|node| {
-                async {
-                    tracing::info!("Sending transaction...");
-                    match transaction_request.clone() {
+            .enumerate()
+            .map(|(i, node)| {
+                let label = format!("custom_nodes_{i}");
+                let transaction_request = transaction_request.clone();
+                async move {
+                    tracing::info!(%label, "sending transaction...");
+                    let result = match transaction_request {
                         Transaction::Request(tx) => node.eth().send_transaction(tx).await,
-                        Transaction::Raw { bytes, hash: _ } => {
+                        Transaction::Raw { bytes, .. } => {
                             node.eth().send_raw_transaction(bytes.0.into()).await
                         }
-                    }
+                    };
+
+                    (label, result)
                 }
                 .boxed()
             })
             .collect::<Vec<_>>();
 
         loop {
-            let (result, index, rest) = futures::future::select_all(futures).await;
-            let lable = format!("custom_nodes_{index}");
-            tracing::info!("Loop iteration with node: {}", lable);
+            let ((label, result), _, rest) = futures::future::select_all(futures).await;
+            tracing::info!(%label, "custom node loop iteration");
             match result {
                 Ok(tx_hash) => {
-                    super::track_submission_success(lable.as_str(), true);
-                    tracing::info!("created transaction with hash: {:?}", tx_hash);
+                    super::track_submission_success(&label, true);
+                    tracing::info!(%label, "created transaction with hash: {:?}", tx_hash);
                     return Ok(TransactionHandle {
                         tx_hash,
                         handle: tx_hash,
                     });
                 }
                 Err(err) => {
-                    tracing::info!("Error on sending transaction...");
-                    // error is not real error if transaction pool responded that received transaction is already in the pool
-                    let real_error = match &err {
-                        web3::Error::Rpc(rpc_error) => !ALREADY_KNOWN_TRANSACTION
-                            .iter()
-                            .any(|message| rpc_error.message.starts_with(message)),
-                        _ => true,
-                    };
-                    if real_error {
-                        tracing::warn!(?err, ?lable, "single custom node tx failed");
-                        super::track_submission_success(lable.as_str(), false);
+                    if matches!(
+                        &err,
+                        web3::Error::Rpc(rpc_error)
+                            if ALREADY_KNOWN_TRANSACTION
+                                .iter()
+                                .any(|message| rpc_error.message.starts_with(message))
+                    ) {
+                        tracing::debug!(%label, ?transaction_request, "transaction already known");
+                        // error is not real error if transaction pool responded that received transaction is
+                        // already in the pool, meaning that the transaction was created successfully and we can
+                        // continue searching our futures for a successful node RPC response without incrementing
+                        // any error metrics...
+                    } else {
+                        tracing::warn!(?err, %label, "single custom node tx failed");
+                        super::track_submission_success(&label, false);
                     }
+
                     if rest.is_empty() {
                         return Err(anyhow::Error::from(err).context("all custom nodes tx failed"));
                     }


### PR DESCRIPTION
Some minor log changes that would have helped be debug submission errors.

Mostly just adds additional context to existing settlement submission logs.

Additionally, I demoted a bunch of `info` logs to `debug` logs to make it easier to follow over-all driver log output with `not log: "DEBUG"` filter on the logs.
