### PR TITLE
Additional settlement logging

### DIFF
--- a/crates/solver/src/driver.rs
+++ b/crates/solver/src/driver.rs
@@ -554,7 +554,7 @@ impl Driver {
                         if settlement_count != settlement.len() {
                             tracing::debug!(
                                 solver_name = %name,
-                                "settlement(s) filtered for violating stable price checks",
+                                "settlement(s) filtered for violating maximum external price deviation",
                             );
                         }
                     }

--- a/crates/solver/src/driver/solver_settlements.rs
+++ b/crates/solver/src/driver/solver_settlements.rs
@@ -147,6 +147,17 @@ pub fn retain_mature_settlements(
 
     let valid_settlement_indices = find_mature_settlements(min_order_age, &settlements);
 
+    for (_, (solver, settlement)) in settlements
+        .iter()
+        .enumerate()
+        .filter(|(i, _)| !valid_settlement_indices.contains(i))
+    {
+        tracing::debug!(
+            solver_name = %solver.name(), ?settlement,
+            "filtered settlement for not being mature",
+        );
+    }
+
     settlements
         .into_iter()
         .enumerate()

--- a/crates/solver/src/driver/solver_settlements.rs
+++ b/crates/solver/src/driver/solver_settlements.rs
@@ -154,7 +154,7 @@ pub fn retain_mature_settlements(
     {
         tracing::debug!(
             solver_name = %solver.name(), ?settlement,
-            "filtered settlement for not being mature",
+            "filtered settlement for not including any mature orders",
         );
     }
 

--- a/crates/solver/src/solver/http_solver.rs
+++ b/crates/solver/src/solver/http_solver.rs
@@ -416,7 +416,8 @@ impl Solver for HttpSolver {
         if !settled.has_execution_plan() {
             tracing::debug!(
                 name = %self.name(), ?settled,
-                "ignoring settlement without execution plan");
+                "ignoring settlement without execution plan",
+            );
             return Ok(Vec::new());
         }
 

--- a/crates/solver/src/solver/http_solver/settlement.rs
+++ b/crates/solver/src/solver/http_solver/settlement.rs
@@ -27,16 +27,9 @@ pub async fn convert_settlement(
     context: SettlementContext,
     allowance_manager: Arc<dyn AllowanceManaging>,
 ) -> Result<Settlement> {
-    match IntermediateSettlement::new(settled.clone(), context, allowance_manager)
-        .await
-        .and_then(|intermediate| intermediate.into_settlement())
-    {
-        Ok(settlement) => Ok(settlement),
-        Err(err) => {
-            tracing::debug!("failed to process HTTP solver result: {:?}", settled);
-            Err(err)
-        }
-    }
+    IntermediateSettlement::new(settled, context, allowance_manager)
+        .await?
+        .into_settlement()
 }
 
 #[derive(Clone, Debug)]


### PR DESCRIPTION
One small step towards #209

This PR adds some additional logging around received solutions. Specifically it will:
- Log **all** settlements from any solver before filtering
- Log settlements that are considered for the settlement competition (pre-simulation)
- Adds more context for why HTTP responses from solvers may be ignored

This is a kind of _"low effort"_ additional logging as it does not always specifically give reasons as to why specific solutions are being filtered (we just count if any solutions are being filtered per solver) and is a little brittle (boiler plate for each additional "filter" we add, doesn't solve a bit of "spaghetti" from filtering settlements at various point in the run loop). Still it is an improvement over what we have now since external solvers provide a single settlement - so we can tell for sure why an external solver settlement is being ignored.
