### PR TITLE
Allow driver-configured liquidity order owners

### DIFF
--- a/crates/e2e/tests/e2e/services.rs
+++ b/crates/e2e/tests/e2e/services.rs
@@ -71,6 +71,7 @@ pub fn create_orderbook_api() -> OrderBookApi {
 pub fn create_order_converter(web3: &Web3, weth_address: H160) -> OrderConverter {
     OrderConverter {
         native_token: WETH9::at(web3, weth_address),
+        additional_liquidity_order_owners: HashSet::new(),
         fee_objective_scaling_factor: 1.,
     }
 }

--- a/crates/orderbook/src/main.rs
+++ b/crates/orderbook/src/main.rs
@@ -256,7 +256,7 @@ struct Arguments {
     /// settlements objective funtion, not receiving any surplus, and being
     /// allowed to place partially fillable orders.
     #[clap(long, env, use_value_delimiter = true)]
-    pub liquidity_order_owners: Vec<H160>,
+    liquidity_order_owners: Vec<H160>,
 }
 
 pub async fn database_metrics(metrics: Arc<Metrics>, database: Postgres) -> ! {

--- a/crates/solver/src/liquidity/order_converter.rs
+++ b/crates/solver/src/liquidity/order_converter.rs
@@ -2,12 +2,13 @@ use super::{Exchange, LimitOrder, SettlementHandling};
 use crate::{interactions::UnwrapWethInteraction, settlement::SettlementEncoder};
 use anyhow::Result;
 use contracts::WETH9;
-use ethcontract::U256;
+use ethcontract::{H160, U256};
 use model::order::{Order, BUY_ETH_ADDRESS};
-use std::sync::Arc;
+use std::{collections::HashSet, sync::Arc};
 
 pub struct OrderConverter {
     pub native_token: WETH9,
+    pub additional_liquidity_order_owners: HashSet<H160>,
     pub fee_objective_scaling_factor: f64,
 }
 
@@ -15,9 +16,10 @@ impl OrderConverter {
     /// Creates a order converter with the specified WETH9 address for unit
     /// testing purposes.
     #[cfg(test)]
-    pub fn test(native_token: ethcontract::H160) -> Self {
+    pub fn test(native_token: H160) -> Self {
         Self {
             native_token: shared::dummy_contract!(WETH9, native_token),
+            additional_liquidity_order_owners: HashSet::new(),
             fee_objective_scaling_factor: 1.,
         }
     }
@@ -38,7 +40,12 @@ impl OrderConverter {
         let scaled_fee_amount = U256::from_f64_lossy(
             remaining.full_fee_amount.to_f64_lossy() * self.fee_objective_scaling_factor,
         );
-        let is_liquidity_order = order.metadata.is_liquidity_order;
+
+        let is_liquidity_order = order.metadata.is_liquidity_order
+            || self
+                .additional_liquidity_order_owners
+                .contains(&order.metadata.owner);
+
         Ok(LimitOrder {
             id: order.metadata.uid.to_string(),
             sell_token: order.creation.sell_token,

--- a/crates/solver/src/main.rs
+++ b/crates/solver/src/main.rs
@@ -308,6 +308,14 @@ struct Arguments {
     /// How pending transactions should be fetched.
     #[clap(long, env, arg_enum, default_value = "ignore")]
     pending_transaction_config: PendingTransactionConfig,
+
+    /// Additional configuration for specifying liquidity order owners at the
+    /// driver level.
+    ///
+    /// This has the effect of having these orders only be considered for COWs
+    /// instead of generally trading them against on-chain AMM liquidity.
+    #[clap(long, env, use_value_delimiter = true)]
+    additional_liquidity_order_owners: Vec<H160>,
 }
 
 #[derive(Copy, Clone, Debug, clap::ArgEnum)]
@@ -630,6 +638,10 @@ async fn main() {
     let api = OrderBookApi::new(args.orderbook_url, client.clone());
     let order_converter = OrderConverter {
         native_token: native_token_contract.clone(),
+        additional_liquidity_order_owners: args
+            .additional_liquidity_order_owners
+            .into_iter()
+            .collect(),
         fee_objective_scaling_factor: args.fee_objective_scaling_factor,
     };
     let tenderly = args

--- a/crates/solver/src/settlement_simulation.rs
+++ b/crates/solver/src/settlement_simulation.rs
@@ -414,8 +414,8 @@ mod tests {
             None,
         );
         let order_converter = OrderConverter {
-            native_token: native_token_contract.clone(),
             fee_objective_scaling_factor: 0.91_f64,
+            ..OrderConverter::test(native_token_contract.address())
         };
         let value = json!(
         {


### PR DESCRIPTION
This PR adds the ability to configure liquidity order owners at the driver level.

This used to be possible, but lost the ability since modifying orders to be created as liquidity orders at the API level - and having this information stored in the database.

### Test Plan

CI.
