### PR TITLE
Attach span to error reporting span

### DIFF
--- a/crates/solver/src/driver.rs
+++ b/crates/solver/src/driver.rs
@@ -439,7 +439,7 @@ impl Driver {
         let id = self.next_auction_id();
         // extra function so that we can add span information
         self.single_run_(id)
-            .instrument(tracing::debug_span!("auction", id))
+            .instrument(tracing::info_span!("auction", id))
             .await
     }
 

--- a/crates/solver/src/driver.rs
+++ b/crates/solver/src/driver.rs
@@ -34,7 +34,7 @@ use std::{
     sync::Arc,
     time::{Duration, Instant},
 };
-use tracing::Instrument;
+use tracing::{Instrument as _, Span};
 use web3::types::{AccessList, TransactionReceipt};
 
 pub struct Driver {
@@ -356,7 +356,7 @@ impl Driver {
                 }
             }
         };
-        tokio::task::spawn(task);
+        tokio::task::spawn(task.instrument(Span::current()));
     }
 
     /// Record metrics on the matched orders from a single batch. Specifically we report on


### PR DESCRIPTION
I noticed when debugging settlement failures that we weren't logging with the `auction` span when reporting errors (i.e. simulating on the original block and generating a Tenderly link with the failed simulation).

This is because we offload the simulation and reporting to a separate Tokio-rs task so that we can already start the next auction without delaying for informative error reporting (which is, IMO a very good thing). However, this makes it hard to tie the simulation errors with what auction it belongs to without looking at surrounding logs.

Luckily it is very easy to so - `Span::current()` allows us to instrument a separate task using the span of the currently executing task.

Additionally, I promoted the `auction` span to be at the `INFO` level. This makes it so filtering logs like `solver=info` still includes the span information (i.e. if we only show info logs, we still want to include the `auction{id=...}` with the logs).

### Test Plan

CI. Also, run locally in `DryRun` mode with an invalid solver so that simulations always fail, and see that we now include `auction{id=...}` span in the log message:

```
...
2022-05-21T07:16:45.331Z  WARN auction{id=0}: solver::driver: 1Inch settlement simulation failed at submission and block 14815938:
...
```
