### PR TITLE
Randomize Winner on Objective Value Tie

### DIFF
--- a/crates/solver/src/driver.rs
+++ b/crates/solver/src/driver.rs
@@ -658,6 +658,10 @@ impl Driver {
             self.metrics.settlement_simulation_succeeded(solver.name());
         }
 
+        // Before sorting, make sure to shuffle the settlements. This is make sure we give
+        // preference to any specific solver when there is an objective value tie.
+        rated_settlements.shuffle(&mut rand::thread_rng());
+
         rated_settlements.sort_by(|a, b| a.1.objective_value().cmp(&b.1.objective_value()));
         print_settlements(&rated_settlements, &self.fee_objective_scaling_factor);
 

--- a/crates/solver/src/driver.rs
+++ b/crates/solver/src/driver.rs
@@ -658,7 +658,7 @@ impl Driver {
             self.metrics.settlement_simulation_succeeded(solver.name());
         }
 
-        // Before sorting, make sure to shuffle the settlements. This is make sure we give
+        // Before sorting, make sure to shuffle the settlements. This is to make sure we don't give
         // preference to any specific solver when there is an objective value tie.
         rated_settlements.shuffle(&mut rand::thread_rng());
 


### PR DESCRIPTION
This PR just randomizes the rated settlements before "stable"-sorting them. This makes it so in case of a tie in the objective value, solvers are treated equally.

### Test Plan

CI and Rust compiler.
