### PR TITLE
Add `objective` Flag And use `SuplusFeesCosts` for Price Estimates

### DIFF
--- a/crates/orderbook/src/main.rs
+++ b/crates/orderbook/src/main.rs
@@ -38,7 +38,7 @@ use shared::{
     },
     baseline_solver::BaseTokens,
     current_block::current_block_stream,
-    http_solver::{DefaultHttpSolverApi, OptimizeFor, SolverConfig},
+    http_solver::{DefaultHttpSolverApi, Objective, SolverConfig},
     maintenance::ServiceMaintenance,
     metrics::{serve_metrics, setup_metrics_registry, DEFAULT_METRICS_PORT},
     network::network_name,
@@ -557,7 +557,7 @@ async fn main() {
                     client: client.clone(),
                     config: SolverConfig {
                         use_internal_buffers: Some(args.shared.quasimodo_uses_internal_buffers),
-                        optimize: Some(OptimizeFor::SurplusFeesCosts),
+                        objective: Some(Objective::SurplusFeesCosts),
                         ..Default::default()
                     },
                 }),

--- a/crates/orderbook/src/main.rs
+++ b/crates/orderbook/src/main.rs
@@ -38,7 +38,7 @@ use shared::{
     },
     baseline_solver::BaseTokens,
     current_block::current_block_stream,
-    http_solver::{DefaultHttpSolverApi, SolverConfig, OptimizeFor},
+    http_solver::{DefaultHttpSolverApi, OptimizeFor, SolverConfig},
     maintenance::ServiceMaintenance,
     metrics::{serve_metrics, setup_metrics_registry, DEFAULT_METRICS_PORT},
     network::network_name,

--- a/crates/orderbook/src/main.rs
+++ b/crates/orderbook/src/main.rs
@@ -38,7 +38,7 @@ use shared::{
     },
     baseline_solver::BaseTokens,
     current_block::current_block_stream,
-    http_solver::{DefaultHttpSolverApi, SolverConfig},
+    http_solver::{DefaultHttpSolverApi, SolverConfig, OptimizeFor},
     maintenance::ServiceMaintenance,
     metrics::{serve_metrics, setup_metrics_registry, DEFAULT_METRICS_PORT},
     network::network_name,
@@ -556,10 +556,9 @@ async fn main() {
                     ),
                     client: client.clone(),
                     config: SolverConfig {
-                        api_key: None,
-                        max_nr_exec_orders: 100,
-                        has_ucp_policy_parameter: false,
-                        use_internal_buffers: args.shared.quasimodo_uses_internal_buffers.into(),
+                        use_internal_buffers: Some(args.shared.quasimodo_uses_internal_buffers),
+                        optimize: Some(OptimizeFor::SurplusFeesCosts),
+                        ..Default::default()
                     },
                 }),
                 pool_fetcher.clone(),

--- a/crates/shared/src/http_solver.rs
+++ b/crates/shared/src/http_solver.rs
@@ -129,11 +129,11 @@ impl HttpSolverApi for DefaultHttpSolverApi {
         match self.config.objective {
             Some(Objective::CappedSurplusFeesCosts) => {
                 url.query_pairs_mut()
-                    .append_pair("optimize", "cappedsurplusfeescosts");
+                    .append_pair("objective", "cappedsurplusfeescosts");
             }
             Some(Objective::SurplusFeesCosts) => {
                 url.query_pairs_mut()
-                    .append_pair("optimize", "surplusfeescosts");
+                    .append_pair("objective", "surplusfeescosts");
             }
             _ => {}
         }

--- a/crates/shared/src/http_solver.rs
+++ b/crates/shared/src/http_solver.rs
@@ -49,7 +49,7 @@ pub struct DefaultHttpSolverApi {
 }
 
 /// Configuration for solver requests.
-#[derive(Debug, Default)]
+#[derive(Debug)]
 pub struct SolverConfig {
     /// Optional value for the `X-API-KEY` header.
     pub api_key: Option<String>,
@@ -62,6 +62,27 @@ pub struct SolverConfig {
 
     /// Controls if/how to set `use_internal_buffers`.
     pub use_internal_buffers: Option<bool>,
+
+    /// Controls the optimization function to use.
+    pub optimize: Option<OptimizeFor>,
+}
+
+impl Default for SolverConfig {
+    fn default() -> Self {
+        Self {
+            api_key: None,
+            max_nr_exec_orders: 100,
+            has_ucp_policy_parameter: false,
+            use_internal_buffers: None,
+            optimize: None,
+        }
+    }
+}
+
+#[derive(Debug)]
+pub enum OptimizeFor {
+    CappedSurplusFeesCosts,
+    SurplusFeesCosts,
 }
 
 #[async_trait::async_trait]
@@ -104,6 +125,17 @@ impl HttpSolverApi for DefaultHttpSolverApi {
                 "use_internal_buffers",
                 use_internal_buffers.to_string().as_str(),
             );
+        }
+        match self.config.optimize {
+            Some(OptimizeFor::CappedSurplusFeesCosts) => {
+                url.query_pairs_mut()
+                    .append_pair("optimize", "cappedsurplusfeescosts");
+            }
+            Some(OptimizeFor::SurplusFeesCosts) => {
+                url.query_pairs_mut()
+                    .append_pair("optimize", "surplusfeescosts");
+            }
+            _ => {}
         }
         if let Some(auction_id) = maybe_auction_id {
             url.query_pairs_mut()

--- a/crates/shared/src/http_solver.rs
+++ b/crates/shared/src/http_solver.rs
@@ -63,8 +63,8 @@ pub struct SolverConfig {
     /// Controls if/how to set `use_internal_buffers`.
     pub use_internal_buffers: Option<bool>,
 
-    /// Controls the optimization function to use.
-    pub optimize: Option<OptimizeFor>,
+    /// Controls the objective function to optimize for.
+    pub objective: Option<Objective>,
 }
 
 impl Default for SolverConfig {
@@ -74,13 +74,13 @@ impl Default for SolverConfig {
             max_nr_exec_orders: 100,
             has_ucp_policy_parameter: false,
             use_internal_buffers: None,
-            optimize: None,
+            objective: None,
         }
     }
 }
 
 #[derive(Debug)]
-pub enum OptimizeFor {
+pub enum Objective {
     CappedSurplusFeesCosts,
     SurplusFeesCosts,
 }
@@ -126,12 +126,12 @@ impl HttpSolverApi for DefaultHttpSolverApi {
                 use_internal_buffers.to_string().as_str(),
             );
         }
-        match self.config.optimize {
-            Some(OptimizeFor::CappedSurplusFeesCosts) => {
+        match self.config.objective {
+            Some(Objective::CappedSurplusFeesCosts) => {
                 url.query_pairs_mut()
                     .append_pair("optimize", "cappedsurplusfeescosts");
             }
-            Some(OptimizeFor::SurplusFeesCosts) => {
+            Some(Objective::SurplusFeesCosts) => {
                 url.query_pairs_mut()
                     .append_pair("optimize", "surplusfeescosts");
             }

--- a/crates/shared/src/price_estimation/quasimodo.rs
+++ b/crates/shared/src/price_estimation/quasimodo.rs
@@ -433,10 +433,8 @@ mod tests {
                 base: Url::parse(&quasimodo_url).expect("failed to parse quasimodo url"),
                 client,
                 config: SolverConfig {
-                    api_key: None,
-                    max_nr_exec_orders: 100,
-                    has_ucp_policy_parameter: false,
-                    use_internal_buffers: true.into(),
+                    use_internal_buffers: Some(true),
+                    ..Default::default()
                 },
             }),
             sharing: Default::default(),

--- a/crates/solver/src/solver.rs
+++ b/crates/solver/src/solver.rs
@@ -282,32 +282,23 @@ pub fn create(
                     mip_solver_url.clone(),
                     "Mip".to_string(),
                     SolverConfig {
-                        api_key: None,
-                        max_nr_exec_orders: 100,
-                        has_ucp_policy_parameter: false,
-                        use_internal_buffers: mip_uses_internal_buffers.into(),
+                        use_internal_buffers: Some(mip_uses_internal_buffers),
+                        ..Default::default()
                     },
                 ))),
                 SolverType::CowDexAg => Ok(shared(create_http_solver(
                     account,
                     cow_dex_ag_solver_url.clone(),
                     "CowDexAg".to_string(),
-                    SolverConfig {
-                        api_key: None,
-                        max_nr_exec_orders: 100,
-                        has_ucp_policy_parameter: false,
-                        use_internal_buffers: None,
-                    },
+                    SolverConfig::default(),
                 ))),
                 SolverType::Quasimodo => Ok(shared(create_http_solver(
                     account,
                     quasimodo_solver_url.clone(),
                     "Quasimodo".to_string(),
                     SolverConfig {
-                        api_key: None,
-                        max_nr_exec_orders: 100,
-                        has_ucp_policy_parameter: true,
-                        use_internal_buffers: quasimodo_uses_internal_buffers.into(),
+                        use_internal_buffers: Some(quasimodo_uses_internal_buffers),
+                        ..Default::default()
                     },
                 ))),
                 SolverType::OneInch => Ok(shared(SingleOrderSolver::new(
@@ -389,10 +380,8 @@ pub fn create(
             solver.url,
             solver.name,
             SolverConfig {
-                api_key: None,
-                max_nr_exec_orders: 100,
-                has_ucp_policy_parameter: false,
-                use_internal_buffers: mip_uses_internal_buffers.into(),
+                use_internal_buffers: Some(mip_uses_internal_buffers),
+                ..Default::default()
             },
         ))
     });

--- a/crates/solver/src/solver/http_solver.rs
+++ b/crates/solver/src/solver/http_solver.rs
@@ -508,12 +508,7 @@ mod tests {
                 chain_id: 0,
                 base: url.parse().unwrap(),
                 client: Client::new(),
-                config: SolverConfig {
-                    api_key: None,
-                    max_nr_exec_orders: 0,
-                    has_ucp_policy_parameter: false,
-                    use_internal_buffers: None,
-                },
+                config: SolverConfig::default(),
             },
             Account::Local(Address::default(), None),
             H160::zero(),


### PR DESCRIPTION
This PR adds a new field to `SolverConfig` to allow configuring Quasimodo for different environments. Specifically, requests to Quasimodo from the solver should use a different objective then when requesting price estimates (when solving, Quasimodo defaults to optimizing with capped surplus, which we don't want for price estimates).

### Test Plan

Run the orderbook locally and see the new parameter:
```
% cargo run -p orderbook -- --price-estimators Quasimodo --log-filter shared::http_solver=trace
...
2022-05-25T13:26:42.718Z TRACE shared::http_solver: request url=https://.../solve?instance_name=2022-05-25_13%3A26%3A42.718259_UTC_Ethereum___Mainnet_1_0&time_limit=2&max_nr_exec_orders=100&use_internal_buffers=false&objective=surplusfeescosts body=...
...
```
