### PR TITLE
Deprecate some old APIs

### DIFF
--- a/crates/orderbook/openapi.yml
+++ b/crates/orderbook/openapi.yml
@@ -206,10 +206,12 @@ paths:
                   $ref: "#/components/schemas/Trade"
   /api/v1/solvable_orders:
     get:
+      deprecated: true
       summary: Get solvable orders.
       description: |
         The set of orders that solvers should be solving right now. These orders are determined to
         be valid at the time of the request.
+        This is deprecated in favour of '/api/v1/auction'.
       responses:
         200:
           description: the orders
@@ -221,10 +223,12 @@ paths:
                   $ref: "#/components/schemas/Order"
   /api/v2/solvable_orders:
     get:
+      deprecated: true
       summary: Get solvable orders.
       description: |
         The set of orders that solvers should be solving right now. These orders are determined to
         be valid at the time of the request.
+        This is deprecated in favour of '/api/v1/auction'.
       responses:
         200:
           description: the orders
@@ -256,10 +260,12 @@ paths:
                 $ref: "#/components/schemas/Auction"
   /api/v1/fee:
     get:
+      deprecated: true
       description: |
         The fee that is charged for placing an order.
         The fee is described by a minimum fee - in order to cover the gas costs for onchain settling - and
         a feeRatio charged to the users for using the service.
+        This is deprecated in favour of '/api/v1/quote'.
       parameters:
         - name: sellToken
           in: query
@@ -296,8 +302,10 @@ paths:
           description: Unexpected internal error while processing the request
   /api/v1/markets/{baseToken}-{quoteToken}/{kind}/{amount}:
     get:
+      deprecated: true
       description: |
         The estimated amount in quote token for either buying or selling `amount` of baseToken.
+        This is deprecated in favour of '/api/v1/quote'
       parameters:
         - name: baseToken
           in: path
@@ -334,11 +342,13 @@ paths:
           description: Unexpected internal error while processing the request
   /api/v1/feeAndQuote/sell:
     get:
+      deprecated: true
       description: |
         For a total available amount of sell_token returns the fee in the sell token and the
         resulting buy amount after the fee has been deducted.
         sellAmountBeforeFee is the total amount that is available for the order. From it the fee
         is deducted and the buy amount is calculated.
+        This is deprecated in favour of '/api/v1/quote'.
       parameters:
         - name: sellToken
           in: query
@@ -374,9 +384,11 @@ paths:
           description: Unexpected internal error while processing the request
   /api/v1/feeAndQuote/buy:
     get:
+      deprecated: true
       description: |
         For a target buy amount returns the total sell_amount that is needed and how much of it is
         the fee.
+        This is deprecated in favour of '/api/v1/quote'.
       parameters:
         - name: sellToken
           in: query


### PR DESCRIPTION
Just tag some old APIs as deprecated so we can start the process of getting rid of them and relieve some maintenance burden.

### Test Plan

CI - it tests that the OpenAPI spec is valid.

### Release notes

There are some new API deprecations that we need to communicate with the community.
