### PR TITLE
0x Excluded Sources Configuration

### DIFF
--- a/crates/orderbook/src/main.rs
+++ b/crates/orderbook/src/main.rs
@@ -545,7 +545,10 @@ async fn main() {
                 token_info_fetcher.clone(),
                 args.shared.disabled_paraswap_dexs.clone(),
             )),
-            PriceEstimatorType::ZeroEx => Box::new(ZeroExPriceEstimator::new(zeroex_api.clone())),
+            PriceEstimatorType::ZeroEx => Box::new(ZeroExPriceEstimator::new(
+                zeroex_api.clone(),
+                args.shared.disabled_zeroex_sources.clone(),
+            )),
             PriceEstimatorType::Quasimodo => Box::new(QuasimodoPriceEstimator::new(
                 Arc::new(DefaultHttpSolverApi {
                     name: "quasimodo-price-estimator".to_string(),

--- a/crates/shared/src/arguments.rs
+++ b/crates/shared/src/arguments.rs
@@ -140,6 +140,10 @@ pub struct Arguments {
     /// The 1Inch REST API URL to use.
     #[structopt(long, env, default_value = "https://api.1inch.exchange/")]
     pub one_inch_url: Url,
+
+    /// The list of disabled 0x sources.
+    #[clap(long, env, use_value_delimiter = true)]
+    pub disabled_zeroex_sources: Vec<String>,
 }
 
 pub fn parse_unbounded_factor(s: &str) -> Result<f64> {

--- a/crates/shared/src/price_estimation/zeroex.rs
+++ b/crates/shared/src/price_estimation/zeroex.rs
@@ -12,13 +12,15 @@ use std::sync::Arc;
 pub struct ZeroExPriceEstimator {
     api: Arc<dyn ZeroExApi>,
     sharing: RequestSharing<Query, BoxFuture<'static, Result<SwapResponse, PriceEstimationError>>>,
+    excluded_sources: Vec<String>,
 }
 
 impl ZeroExPriceEstimator {
-    pub fn new(api: Arc<dyn ZeroExApi>) -> Self {
+    pub fn new(api: Arc<dyn ZeroExApi>, excluded_sources: Vec<String>) -> Self {
         Self {
             api,
             sharing: Default::default(),
+            excluded_sources,
         }
     }
 
@@ -34,6 +36,7 @@ impl ZeroExPriceEstimator {
             sell_amount,
             buy_amount,
             slippage_percentage: Default::default(),
+            excluded_sources: self.excluded_sources.clone(),
         };
         let api = self.api.clone();
         let swap_future = async move {
@@ -108,6 +111,7 @@ mod tests {
         let estimator = ZeroExPriceEstimator {
             api: Arc::new(zeroex_api),
             sharing: Default::default(),
+            excluded_sources: Default::default(),
         };
 
         let est = estimator
@@ -154,6 +158,7 @@ mod tests {
         let estimator = ZeroExPriceEstimator {
             api: Arc::new(zeroex_api),
             sharing: Default::default(),
+            excluded_sources: Default::default(),
         };
 
         let est = estimator
@@ -179,6 +184,7 @@ mod tests {
         let estimator = ZeroExPriceEstimator {
             api: Arc::new(DefaultZeroExApi::with_default_url(Client::new())),
             sharing: Default::default(),
+            excluded_sources: Default::default(),
         };
 
         let result = estimator

--- a/crates/solver/src/main.rs
+++ b/crates/solver/src/main.rs
@@ -511,6 +511,7 @@ async fn main() {
         metrics.clone(),
         zeroex_api.clone(),
         args.zeroex_slippage_bps,
+        args.shared.disabled_zeroex_sources,
         args.oneinch_slippage_bps,
         args.shared.quasimodo_uses_internal_buffers,
         args.shared.mip_uses_internal_buffers,

--- a/crates/solver/src/solver.rs
+++ b/crates/solver/src/solver.rs
@@ -227,6 +227,7 @@ pub fn create(
     solver_metrics: Arc<dyn SolverMetrics>,
     zeroex_api: Arc<dyn ZeroExApi>,
     zeroex_slippage_bps: u32,
+    disabled_zeroex_sources: Vec<String>,
     oneinch_slippage_bps: u32,
     quasimodo_uses_internal_buffers: bool,
     mip_uses_internal_buffers: bool,
@@ -322,6 +323,7 @@ pub fn create(
                         chain_id,
                         zeroex_api.clone(),
                         zeroex_slippage_bps,
+                        disabled_zeroex_sources.clone(),
                     )
                     .unwrap();
                     Ok(shared(SingleOrderSolver::new(

--- a/crates/solver/src/solver/zeroex_solver.rs
+++ b/crates/solver/src/solver/zeroex_solver.rs
@@ -48,6 +48,7 @@ pub struct ZeroExSolver {
     api: Arc<dyn ZeroExApi>,
     allowance_fetcher: Box<dyn AllowanceManaging>,
     zeroex_slippage_bps: u32,
+    excluded_sources: Vec<String>,
 }
 
 /// Chain ID for Mainnet.
@@ -61,6 +62,7 @@ impl ZeroExSolver {
         chain_id: u64,
         api: Arc<dyn ZeroExApi>,
         zeroex_slippage_bps: u32,
+        excluded_sources: Vec<String>,
     ) -> Result<Self> {
         ensure!(
             chain_id == MAINNET_CHAIN_ID,
@@ -72,6 +74,7 @@ impl ZeroExSolver {
             allowance_fetcher: Box::new(allowance_fetcher),
             api,
             zeroex_slippage_bps,
+            excluded_sources,
         })
     }
 }
@@ -94,6 +97,7 @@ impl SingleOrderSolving for ZeroExSolver {
             buy_amount,
             slippage_percentage: Slippage::number_from_basis_points(self.zeroex_slippage_bps)
                 .unwrap(),
+            excluded_sources: self.excluded_sources.clone(),
         };
         let swap = self.api.get_swap(query).await?;
 
@@ -185,6 +189,7 @@ mod tests {
             chain_id,
             Arc::new(DefaultZeroExApi::default()),
             10u32,
+            Default::default(),
         )
         .unwrap();
         let settlement = solver
@@ -226,6 +231,7 @@ mod tests {
             chain_id,
             Arc::new(DefaultZeroExApi::default()),
             10u32,
+            Default::default(),
         )
         .unwrap();
         let settlement = solver
@@ -294,6 +300,7 @@ mod tests {
             api: Arc::new(client),
             allowance_fetcher,
             zeroex_slippage_bps: 10u32,
+            excluded_sources: Default::default(),
         };
 
         let buy_order_passing_limit = LimitOrder {
@@ -383,7 +390,8 @@ mod tests {
             settlement,
             chain_id,
             Arc::new(DefaultZeroExApi::default()),
-            10u32
+            10u32,
+            Default::default(),
         )
         .is_err())
     }
@@ -440,6 +448,7 @@ mod tests {
             api: Arc::new(client),
             allowance_fetcher,
             zeroex_slippage_bps: 10u32,
+            excluded_sources: Default::default(),
         };
 
         let order = LimitOrder {
@@ -498,6 +507,7 @@ mod tests {
             api: Arc::new(client),
             allowance_fetcher,
             zeroex_slippage_bps: 10u32,
+            excluded_sources: Default::default(),
         };
 
         let order = LimitOrder {


### PR DESCRIPTION
Fixes #243 

This PR extends the 0x API implementation to allow setting excluded sources for `/swap` and `/quote` queries and adds configuration options in the driver and orderbook for setting these excluded sources.

### Test Plan

Added a new test to see if 0x takes different routes when buying SNX for route (i.e. it doesn't use the "bad" Balancer pool):

```
% cargo test -p shared -- --ignored --nocapture zeroex_api::tests::excluded_sources
    Finished test [unoptimized + debuginfo] target(s) in 0.10s
     Running unittests src/lib.rs (target/debug/deps/shared-5653717641331484)

running 1 test
[crates/shared/src/zeroex_api.rs:526] &swap = Ok(
    SwapResponse {
        price: PriceResponse {
            sell_amount: 1000000000000000000000,
            buy_amount: 508509876034390373504047,
            allowance_target: 0xdef1c0ded9bec7f1a1670819833240f027b25eff,
            price: 508.5098760343904,
            estimated_gas: 1382394,
        },
        to: 0xdef1c0ded9bec7f1a1670819833240f027b25eff,
        data: 0x...ba12222222228d8ba445958a75a0704d566bf2c8...,
        value: 0,
    },
)
[crates/shared/src/zeroex_api.rs:535] &swap = Ok(
    SwapResponse {
        price: PriceResponse {
            sell_amount: 1000000000000000000000,
            buy_amount: 412021081473199945924709,
            allowance_target: 0xdef1c0ded9bec7f1a1670819833240f027b25eff,
            price: 412.02108147319996,
            estimated_gas: 1282394,
        },
        to: 0xdef1c0ded9bec7f1a1670819833240f027b25eff,
        data: 0x...,
        value: 0,
    },
)
test zeroex_api::tests::excluded_sources ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 254 filtered out; finished in 2.63s
```

Notice that the results are different in both cases and that when `Balancer_V2` is excluded, the calldata no longer contains the `0xba1222....` Vault address.