### PR TITLE
Enable parallel flashbots strategies

### DIFF
--- a/crates/solver/src/main.rs
+++ b/crates/solver/src/main.rs
@@ -216,6 +216,7 @@ struct Arguments {
     eden_api_url: Url,
 
     /// The API endpoint of the Flashbots network for transaction submission.
+    /// Multiple values could be defined for different Flashbots endpoints (Flashbots Protect and Flashbots fast).
     #[clap(
         long,
         env,


### PR DESCRIPTION
Fixes https://github.com/cowprotocol/services/issues/222.

Added at a `SolutionSubmitter` level rather than on a lower `Submitter` level, so we can have metrics for both strategies at the same time and evaluate success.