### PR TITLE
Stricter 0x liquidity order filtering

### DIFF
--- a/crates/solver/src/liquidity.rs
+++ b/crates/solver/src/liquidity.rs
@@ -6,7 +6,6 @@ pub mod zeroex;
 
 use crate::settlement::SettlementEncoder;
 use anyhow::Result;
-#[cfg(test)]
 use derivative::Derivative;
 #[cfg(test)]
 use model::order::Order;
@@ -71,9 +70,8 @@ pub enum Exchange {
 }
 
 /// Basic limit sell and buy orders
-#[derive(Clone)]
-#[cfg_attr(test, derive(Derivative))]
-#[cfg_attr(test, derivative(PartialEq))]
+#[derive(Clone, Derivative)]
+#[derivative(PartialEq)]
 pub struct LimitOrder {
     // Opaque Identifier for debugging purposes
     pub id: String,
@@ -92,7 +90,7 @@ pub struct LimitOrder {
     /// perspective.
     pub scaled_unsubsidized_fee: U256,
     pub is_liquidity_order: bool,
-    #[cfg_attr(test, derivative(PartialEq = "ignore"))]
+    #[derivative(PartialEq = "ignore")]
     pub settlement_handling: Arc<dyn SettlementHandling<Self>>,
     pub exchange: Exchange,
 }

--- a/crates/solver/src/liquidity.rs
+++ b/crates/solver/src/liquidity.rs
@@ -6,6 +6,7 @@ pub mod zeroex;
 
 use crate::settlement::SettlementEncoder;
 use anyhow::Result;
+#[cfg(test)]
 use derivative::Derivative;
 #[cfg(test)]
 use model::order::Order;
@@ -70,8 +71,9 @@ pub enum Exchange {
 }
 
 /// Basic limit sell and buy orders
-#[derive(Clone, Derivative)]
-#[derivative(PartialEq)]
+#[derive(Clone)]
+#[cfg_attr(test, derive(Derivative))]
+#[cfg_attr(test, derivative(PartialEq))]
 pub struct LimitOrder {
     // Opaque Identifier for debugging purposes
     pub id: String,
@@ -90,7 +92,7 @@ pub struct LimitOrder {
     /// perspective.
     pub scaled_unsubsidized_fee: U256,
     pub is_liquidity_order: bool,
-    #[derivative(PartialEq = "ignore")]
+    #[cfg_attr(test, derivative(PartialEq = "ignore"))]
     pub settlement_handling: Arc<dyn SettlementHandling<Self>>,
     pub exchange: Exchange,
 }

--- a/crates/solver/src/liquidity/zeroex.rs
+++ b/crates/solver/src/liquidity/zeroex.rs
@@ -6,9 +6,11 @@ use anyhow::Result;
 use contracts::{GPv2Settlement, IZeroEx};
 use model::order::OrderKind;
 use model::TokenPair;
-use primitive_types::U256;
+// use hex_literal::hex;
+use primitive_types::{H160, U256};
 use shared::baseline_solver::BaseTokens;
 use shared::zeroex_api::{Order, OrderRecord, OrdersQuery, ZeroExApi};
+use std::collections::HashMap;
 use std::sync::Arc;
 
 pub struct ZeroExLiquidity {
@@ -41,27 +43,68 @@ impl ZeroExLiquidity {
                     vec![]
                 }
             });
+        // let fake_order = [TokenPair::new(
+        //     H160(hex!("2b591e99afe9f32eaa6214f7b7629768c40eeb39")),
+        //     H160::default(),
+        // )
+        // .unwrap()]
+        // .into_iter();
 
         let user_order_pairs = user_orders
             .iter()
             .filter_map(|order| TokenPair::new(order.buy_token, order.sell_token));
         let relevant_pairs = self.base_tokens.relevant_pairs(user_order_pairs);
 
-        let filtered_zeroex_orders = zeroex_orders
+        // divide orders in buckets and choose best orders in those buckets
+        let mut order_buckets: HashMap<(H160, H160), Vec<OrderRecord>> = HashMap::default();
+
+        zeroex_orders
             .filter(|record| {
                 match TokenPair::new(record.order.taker_token, record.order.maker_token) {
                     Some(pair) => relevant_pairs.contains(&pair),
                     None => false,
                 }
             })
-            .filter_map(|record| self.record_into_liquidity(record))
+            .for_each(|order| {
+                let orders_list = order_buckets
+                    .entry((order.order.maker_token, order.order.taker_token))
+                    .or_insert(vec![]);
+                orders_list.push(order);
+            });
+        let mut limit_orders_n = vec![];
+        order_buckets.into_values().for_each(|mut order_list| {
+            order_list.sort_by(|order_1, order_2| {
+                let ratio_1 = order_1.order.taker_amount / order_1.order.maker_amount;
+                let ratio_2 = order_2.order.taker_amount / order_2.order.maker_amount;
+                ratio_1.cmp(&ratio_2)
+            });
+            let mut copy_of_list = order_list.clone();
+            limit_orders_n.extend(order_list.into_iter().take(5));
+
+            if copy_of_list.len() > 5 {
+                copy_of_list.drain(0..5);
+            }
+            copy_of_list.sort_by_key(|order| order.metadata.remaining_fillable_taker_amount);
+            copy_of_list.reverse();
+            limit_orders_n.extend(copy_of_list.iter().take(5).cloned());
+        });
+        let mut limit_orders_list: Vec<LimitOrder> = limit_orders_n
+            .into_iter()
+            .flat_map(|order| self.convert_to_limit_order(order))
             .collect();
+        limit_orders_list.sort_by_key(|order| order.id.clone());
+        limit_orders_list.dedup();
+        let filtered_zeroex_orders: Vec<Liquidity> = limit_orders_list
+            .iter()
+            .filter_map(|record| self.record_into_liquidity(record.clone()))
+            .collect();
+        println!("Number of zeroex orders {:?}", filtered_zeroex_orders.len());
 
         Ok(filtered_zeroex_orders)
     }
 
-    /// Turns 0x OrderRecord into liquidity which solvers can use.
-    fn record_into_liquidity(&self, record: OrderRecord) -> Option<Liquidity> {
+    // Turns 0x OrderRecord into LimitOrder for sorting and deduplication
+    fn convert_to_limit_order(&self, record: OrderRecord) -> Option<LimitOrder> {
         let sell_amount: U256 = record.remaining_maker_amount().ok()?.into();
         if sell_amount.is_zero() || record.metadata.remaining_fillable_taker_amount == 0 {
             // filter out orders with 0 amounts to prevent errors in the solver
@@ -85,7 +128,12 @@ impl ZeroExLiquidity {
             }),
             exchange: Exchange::ZeroEx,
         };
-        Some(Liquidity::LimitOrder(limit_order))
+        Some(limit_order)
+    }
+
+    // Turns 0x LimitOrder into liquidity which solvers can use.
+    fn record_into_liquidity(&self, record: LimitOrder) -> Option<Liquidity> {
+        Some(Liquidity::LimitOrder(record))
     }
 }
 

--- a/crates/solver/src/liquidity/zeroex.rs
+++ b/crates/solver/src/liquidity/zeroex.rs
@@ -61,7 +61,7 @@ impl ZeroExLiquidity {
         zeroex_orders: impl Iterator<Item = OrderRecord>,
         relevant_pairs: HashSet<TokenPair>,
     ) -> OrderBuckets {
-        // divide orders in buckets and choose best orders in those buckets
+        // divide orders in buckets
         let mut buckets: OrderBuckets = Default::default();
         zeroex_orders
             .filter(|record| {
@@ -101,7 +101,7 @@ impl ZeroExLiquidity {
 
             orders.sort_by_key(|order| order.metadata.remaining_fillable_taker_amount);
             orders.reverse();
-            filtered_zeroex_orders.extend(orders.iter().take(orders_per_type).cloned());
+            filtered_zeroex_orders.extend(orders.into_iter().rev().take(orders_per_type));
         });
         let filtered_zeroex_orders: Vec<_> = filtered_zeroex_orders
             .into_iter()
@@ -110,7 +110,7 @@ impl ZeroExLiquidity {
         filtered_zeroex_orders
     }
 
-    // Turns 0x LimitOrder into liquidity which solvers can use.
+    /// Turns 0x OrderRecord into liquidity which solvers can use.
     fn record_into_liquidity(&self, record: OrderRecord) -> Option<Liquidity> {
         let sell_amount: U256 = record.remaining_maker_amount().ok()?.into();
         if sell_amount.is_zero() || record.metadata.remaining_fillable_taker_amount == 0 {

--- a/crates/solver/src/liquidity/zeroex.rs
+++ b/crates/solver/src/liquidity/zeroex.rs
@@ -180,9 +180,9 @@ pub mod tests {
             order: Order {
                 taker_token: token_b,
                 maker_token: token_a,
-                ..order.clone()
+                ..order
             },
-            metadata: metadata.clone(),
+            metadata,
         };
         let order_buckets = ZeroExLiquidity::generate_order_buckets(
             [bogous_order_1, bogous_order_2].into_iter(),
@@ -223,7 +223,7 @@ pub mod tests {
             },
         };
         let bogous_order_3 = OrderRecord {
-            order: order.clone(),
+            order,
             metadata: OrderMetadata {
                 remaining_fillable_taker_amount: 10000,
                 ..Default::default()
@@ -282,9 +282,9 @@ pub mod tests {
             order: Order {
                 taker_amount: 100000,
                 maker_amount: 100000000,
-                ..order.clone()
+                ..order
             },
-            metadata: metadata.clone(),
+            metadata,
         };
         let order_buckets = ZeroExLiquidity::generate_order_buckets(
             [bogous_order_1, bogous_order_2, bogous_order_3].into_iter(),

--- a/crates/solver/src/liquidity/zeroex.rs
+++ b/crates/solver/src/liquidity/zeroex.rs
@@ -50,8 +50,8 @@ impl ZeroExLiquidity {
             .filter_map(|order| TokenPair::new(order.buy_token, order.sell_token));
         let relevant_pairs = self.base_tokens.relevant_pairs(user_order_pairs);
 
-        let order_buckets = ZeroExLiquidity::generate_order_buckets(zeroex_orders, relevant_pairs);
-        let filtered_zeroex_orders = ZeroExLiquidity::get_useful_orders(order_buckets, 5);
+        let order_buckets = generate_order_buckets(zeroex_orders, relevant_pairs);
+        let filtered_zeroex_orders = get_useful_orders(order_buckets, 5);
 
         let zeroex_liquidity_orders: Vec<_> = filtered_zeroex_orders
             .into_iter()
@@ -59,51 +59,6 @@ impl ZeroExLiquidity {
             .collect();
 
         Ok(zeroex_liquidity_orders)
-    }
-
-    fn generate_order_buckets(
-        zeroex_orders: impl Iterator<Item = OrderRecord>,
-        relevant_pairs: HashSet<TokenPair>,
-    ) -> OrderBuckets {
-        // divide orders in buckets
-        let mut buckets = OrderBuckets::default();
-        zeroex_orders
-            .filter(|record| {
-                match TokenPair::new(record.order.taker_token, record.order.maker_token) {
-                    Some(pair) => relevant_pairs.contains(&pair),
-                    None => false,
-                }
-            })
-            .for_each(|order| {
-                let bucket = buckets
-                    .entry((order.order.taker_token, order.order.maker_token))
-                    .or_default();
-                bucket.push(order);
-            });
-        buckets
-    }
-
-    /// Get the `orders_per_type` best priced and biggest volume orders.
-    fn get_useful_orders(order_buckets: OrderBuckets, orders_per_type: usize) -> Vec<OrderRecord> {
-        let mut filtered_zeroex_orders = vec![];
-        for mut orders in order_buckets.into_values() {
-            if orders.len() <= 2 * orders_per_type {
-                filtered_zeroex_orders.extend(orders);
-                continue;
-            }
-            // Sorting to have best priced orders at the end of the vector
-            // best priced orders are those that have the maximum maker_amount / taker_amount ratio
-            orders.sort_by(|order_1, order_2| {
-                let price_1 = order_1.order.maker_amount as f64 / order_1.order.taker_amount as f64;
-                let price_2 = order_2.order.maker_amount as f64 / order_2.order.taker_amount as f64;
-                price_1.partial_cmp(&price_2).unwrap()
-            });
-            filtered_zeroex_orders.extend(orders.drain(orders.len() - orders_per_type..));
-
-            orders.sort_by_key(|order| order.metadata.remaining_fillable_taker_amount);
-            filtered_zeroex_orders.extend(orders.into_iter().rev().take(orders_per_type));
-        }
-        filtered_zeroex_orders
     }
 
     /// Turns 0x OrderRecord into liquidity which solvers can use.
@@ -133,6 +88,51 @@ impl ZeroExLiquidity {
         };
         Some(Liquidity::LimitOrder(limit_order))
     }
+}
+
+fn generate_order_buckets(
+    zeroex_orders: impl Iterator<Item = OrderRecord>,
+    relevant_pairs: HashSet<TokenPair>,
+) -> OrderBuckets {
+    // divide orders in buckets
+    let mut buckets = OrderBuckets::default();
+    zeroex_orders
+        .filter(
+            |record| match TokenPair::new(record.order.taker_token, record.order.maker_token) {
+                Some(pair) => relevant_pairs.contains(&pair),
+                None => false,
+            },
+        )
+        .for_each(|order| {
+            let bucket = buckets
+                .entry((order.order.taker_token, order.order.maker_token))
+                .or_default();
+            bucket.push(order);
+        });
+    buckets
+}
+
+/// Get the `orders_per_type` best priced and biggest volume orders.
+fn get_useful_orders(order_buckets: OrderBuckets, orders_per_type: usize) -> Vec<OrderRecord> {
+    let mut filtered_zeroex_orders = vec![];
+    for mut orders in order_buckets.into_values() {
+        if orders.len() <= 2 * orders_per_type {
+            filtered_zeroex_orders.extend(orders);
+            continue;
+        }
+        // Sorting to have best priced orders at the end of the vector
+        // best priced orders are those that have the maximum maker_amount / taker_amount ratio
+        orders.sort_by(|order_1, order_2| {
+            let price_1 = order_1.order.maker_amount as f64 / order_1.order.taker_amount as f64;
+            let price_2 = order_2.order.maker_amount as f64 / order_2.order.taker_amount as f64;
+            price_1.partial_cmp(&price_2).unwrap()
+        });
+        filtered_zeroex_orders.extend(orders.drain(orders.len() - orders_per_type..));
+
+        orders.sort_by_key(|order| order.metadata.remaining_fillable_taker_amount);
+        filtered_zeroex_orders.extend(orders.into_iter().rev().take(orders_per_type));
+    }
+    filtered_zeroex_orders
 }
 
 struct OrderSettlementHandler {
@@ -183,10 +183,8 @@ pub mod tests {
         let order_1 = order_with_tokens(token_a, token_b);
         let order_2 = order_with_tokens(token_b, token_a);
         let order_3 = order_with_tokens(token_b, token_a);
-        let order_buckets = ZeroExLiquidity::generate_order_buckets(
-            [order_1, order_2, order_3].into_iter(),
-            relevant_pairs,
-        );
+        let order_buckets =
+            generate_order_buckets([order_1, order_2, order_3].into_iter(), relevant_pairs);
         assert_eq!(order_buckets.keys().len(), 2);
         assert_eq!(order_buckets[&(token_a, token_b)].len(), 1);
         assert_eq!(order_buckets[&(token_b, token_a)].len(), 2);
@@ -211,11 +209,9 @@ pub mod tests {
         let order_1 = order_with_tokens(token_ignore, token_b);
         let order_2 = order_with_tokens(token_a, token_ignore);
         let order_3 = order_with_tokens(token_ignore, token_ignore);
-        let order_buckets = ZeroExLiquidity::generate_order_buckets(
-            [order_1, order_2, order_3].into_iter(),
-            relevant_pairs,
-        );
-        let filtered_zeroex_orders = ZeroExLiquidity::get_useful_orders(order_buckets, 1);
+        let order_buckets =
+            generate_order_buckets([order_1, order_2, order_3].into_iter(), relevant_pairs);
+        let filtered_zeroex_orders = get_useful_orders(order_buckets, 1);
         assert_eq!(filtered_zeroex_orders.len(), 0);
     }
 
@@ -240,11 +236,9 @@ pub mod tests {
         let order_1 = order_with_fillable_amount(1_000);
         let order_2 = order_with_fillable_amount(100);
         let order_3 = order_with_fillable_amount(10_000);
-        let order_buckets = ZeroExLiquidity::generate_order_buckets(
-            [order_1, order_2, order_3].into_iter(),
-            relevant_pairs,
-        );
-        let filtered_zeroex_orders = ZeroExLiquidity::get_useful_orders(order_buckets, 1);
+        let order_buckets =
+            generate_order_buckets([order_1, order_2, order_3].into_iter(), relevant_pairs);
+        let filtered_zeroex_orders = get_useful_orders(order_buckets, 1);
         assert_eq!(filtered_zeroex_orders.len(), 2);
         assert_eq!(
             filtered_zeroex_orders[0]
@@ -265,8 +259,7 @@ pub mod tests {
         let token_a = H160([0x00; 20]);
         let token_b = H160([0xff; 20]);
         let relevant_pairs = get_relevant_pairs(token_a, token_b);
-        let metadata = OrderMetadata::default();
-        let order_with_taker_amount = |taker_amount| OrderRecord {
+        let order_with_amount = |taker_amount, remaining_fillable_taker_amount| OrderRecord {
             order: Order {
                 taker_token: token_a,
                 maker_token: token_b,
@@ -274,18 +267,21 @@ pub mod tests {
                 maker_amount: 100_000_000,
                 ..Default::default()
             },
-            metadata: metadata.clone(),
+            metadata: OrderMetadata {
+                remaining_fillable_taker_amount,
+                ..Default::default()
+            },
         };
-        let order_1 = order_with_taker_amount(10_000_000);
-        let order_2 = order_with_taker_amount(1_000);
-        let order_3 = order_with_taker_amount(100_000);
-        let order_buckets = ZeroExLiquidity::generate_order_buckets(
-            [order_1, order_2, order_3].into_iter(),
-            relevant_pairs,
-        );
-        let filtered_zeroex_orders = ZeroExLiquidity::get_useful_orders(order_buckets, 1);
+        let order_1 = order_with_amount(10_000_000, 1_000_000);
+        let order_2 = order_with_amount(1_000, 100);
+        let order_3 = order_with_amount(100_000, 1_000);
+        let order_buckets =
+            generate_order_buckets([order_1, order_2, order_3].into_iter(), relevant_pairs);
+        let filtered_zeroex_orders = get_useful_orders(order_buckets, 1);
         assert_eq!(filtered_zeroex_orders.len(), 2);
+        // First item in the list will be on the basis of maker_amount/taker_amount ratio
         assert_eq!(filtered_zeroex_orders[0].order.taker_amount, 1_000);
-        assert_eq!(filtered_zeroex_orders[1].order.taker_amount, 100_000);
+        // Second item in the list will be on the basis of remaining_fillable_taker_amount
+        assert_eq!(filtered_zeroex_orders[1].order.taker_amount, 10_000_000);
     }
 }


### PR DESCRIPTION
Fixes #238 

This PR should resolve the memory issues that we face when we have too many orders by reducing the set of collected orders.

We do this by distributing our orders into buckets, where the key for each bucket is an ordered pair of tokens. We then reduce these buckets by taking only 5 best priced and 5 biggest volume orders from the list.

### Test Plan

* Apply this diff
    <details><summary>Fake Order diff</summary>
    
    ```
    diff --git a/crates/shared/src/zeroex_api.rs b/crates/shared/src/zeroex_api.rs
    index 8256ce9..aa4b8c9 100644
    --- a/crates/shared/src/zeroex_api.rs
    +++ b/crates/shared/src/zeroex_api.rs
    @@ -440,7 +440,7 @@ impl DefaultZeroExApi {
                 .text()
                 .await
                 .map_err(ZeroExResponseError::TextFetch)?;
    -        tracing::debug!("Response from 0x API: {}", response_text);
    +        // tracing::debug!("Response from 0x API: {}", response_text);
     
             match serde_json::from_str::<RawResponse<T>>(&response_text) {
                 Ok(RawResponse::ResponseOk(response)) => Ok(response),
    diff --git a/crates/solver/src/liquidity/zeroex.rs b/crates/solver/src/liquidity/zeroex.rs
    index 95db3a6..7644ea5 100644
    --- a/crates/solver/src/liquidity/zeroex.rs
    +++ b/crates/solver/src/liquidity/zeroex.rs
    @@ -4,6 +4,7 @@ use crate::liquidity::{Exchange, LimitOrder, Liquidity};
     use crate::settlement::SettlementEncoder;
     use anyhow::Result;
     use contracts::{GPv2Settlement, IZeroEx};
    +use hex_literal::hex;
     use model::order::OrderKind;
     use model::TokenPair;
     use primitive_types::{H160, U256};
    @@ -44,11 +45,17 @@ impl ZeroExLiquidity {
                         vec![]
                     }
                 });
    +        let fake_order = [TokenPair::new(
    +            H160(hex!("2b591e99afe9f32eaa6214f7b7629768c40eeb39")),
    +            H160::default(),
    +        )
    +        .unwrap()]
    +        .into_iter();
     
             let user_order_pairs = user_orders
                 .iter()
                 .filter_map(|order| TokenPair::new(order.buy_token, order.sell_token));
    -        let relevant_pairs = self.base_tokens.relevant_pairs(user_order_pairs);
    +        let relevant_pairs = self.base_tokens.relevant_pairs(fake_order);
     
             let order_buckets = self.generate_order_buckets(zeroex_orders, relevant_pairs);
             let filtered_zeroex_orders = self.get_useful_orders(order_buckets, 5);
    
    ```
    </details>

* Run docker container for postgres

    ```
    docker run -d -e POSTGRES_HOST_AUTH_METHOD=trust -e POSTGRES_USER=`whoami` -p 5432:5432 docker.io/postgres
    docker run -ti -e FLYWAY_URL="jdbc:postgresql://host.docker.internal/?user="$USER"&password=" -v $PWD/database/sql:/flyway/sql cowprotocol/services-migration migrate
    ```

* Run orderbook
    ```
    export export NODE_URL="https://mainnet.infura.io/v3/KEY"
    cargo run --bin orderbook -- --skip-trace-api true --skip-event-sync
    ```
* Run solver
    ```
    export export NODE_URL="https://mainnet.infura.io/v3/KEY"
    cargo run -p solver -- \  
      --solver-account 0xa6DDBD0dE6B310819b49f680F65871beE85f517e \
      --transaction-strategy DryRun \
      --base-tokens "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2,0x6B175474E89094C44Da98b954EedeAC495271d0F,0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48,0xdAC17F958D2ee523a2206206994597C13D831ec7,0xc00e94Cb662C3520282E6f5717214004A7f26888,0x9f8F72aA9304c8B593d555F12eF6589cC3A579A2,0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599,0x6810e776880C02933D47DB1b9fc05908e5386b96,0x2b591e99afe9f32eaa6214f7b7629768c40eeb39"
    ```

* If we print out the number of zeroex orders, we'll see that the number is now reduced significantly
    
    <img width="1171" alt="Screenshot 2022-06-03 at 1 14 36 PM" src="https://user-images.githubusercontent.com/7795956/172148698-f68ec3cf-68f4-41c8-9629-dafa17cafa83.png">


### Release notes

0x liquidity orders now keep only 5 of the biggest and 5 of the best-priced orders for each token pair.
