### PR TITLE
Order Types with Signature & EIP-1271

### DIFF
--- a/crates/e2e/tests/e2e/eth_integration.rs
+++ b/crates/e2e/tests/e2e/eth_integration.rs
@@ -155,7 +155,7 @@ async fn eth_integration(web3: Web3) {
             SecretKeyRef::from(&SecretKey::from_slice(&TRADER_BUY_ETH_A_PK).unwrap()),
         )
         .build()
-        .creation;
+        .data;
     let placement = client
         .post(&format!("{}{}", API_HOST, ORDER_PLACEMENT_ENDPOINT))
         .body(json!(order_buy_eth_a).to_string())
@@ -176,7 +176,7 @@ async fn eth_integration(web3: Web3) {
             SecretKeyRef::from(&SecretKey::from_slice(&TRADER_BUY_ETH_B_PK).unwrap()),
         )
         .build()
-        .creation;
+        .data;
     let placement = client
         .post(&format!("{}{}", API_HOST, ORDER_PLACEMENT_ENDPOINT))
         .body(json!(order_buy_eth_b).to_string())

--- a/crates/e2e/tests/e2e/onchain_settlement.rs
+++ b/crates/e2e/tests/e2e/onchain_settlement.rs
@@ -160,7 +160,7 @@ async fn onchain_settlement(web3: Web3) {
             SecretKeyRef::from(&SecretKey::from_slice(&TRADER_A_PK).unwrap()),
         )
         .build()
-        .creation;
+        .into_order_creation();
     let placement = client
         .post(&format!("{}{}", API_HOST, ORDER_PLACEMENT_ENDPOINT))
         .body(json!(order_a).to_string())
@@ -182,7 +182,7 @@ async fn onchain_settlement(web3: Web3) {
             SecretKeyRef::from(&SecretKey::from_slice(&TRADER_B_PK).unwrap()),
         )
         .build()
-        .creation;
+        .into_order_creation();
     let placement = client
         .post(&format!("{}{}", API_HOST, ORDER_PLACEMENT_ENDPOINT))
         .body(json!(order_b).to_string())

--- a/crates/e2e/tests/e2e/settlement_without_onchain_liquidity.rs
+++ b/crates/e2e/tests/e2e/settlement_without_onchain_liquidity.rs
@@ -162,7 +162,7 @@ async fn onchain_settlement_without_liquidity(web3: Web3) {
             SecretKeyRef::from(&SecretKey::from_slice(&TRADER_A_PK).unwrap()),
         )
         .build()
-        .creation;
+        .into_order_creation();
     let placement = client
         .post(&format!("{}{}", API_HOST, ORDER_PLACEMENT_ENDPOINT))
         .body(json!(order).to_string())

--- a/crates/e2e/tests/e2e/smart_contract_orders.rs
+++ b/crates/e2e/tests/e2e/smart_contract_orders.rs
@@ -107,7 +107,7 @@ async fn smart_contract_orders(web3: Web3) {
         .with_valid_to(model::time::now_in_epoch_seconds() + 300)
         .with_presign(trader.address())
         .build()
-        .creation;
+        .into_order_creation();
     let placement = client
         .post(&format!("{}{}", API_HOST, ORDER_PLACEMENT_ENDPOINT))
         .json(&order)

--- a/crates/e2e/tests/e2e/vault_balances.rs
+++ b/crates/e2e/tests/e2e/vault_balances.rs
@@ -120,7 +120,7 @@ async fn vault_balances(web3: Web3) {
             SecretKeyRef::from(&SecretKey::from_slice(&TRADER).unwrap()),
         )
         .build()
-        .creation;
+        .into_order_creation();
     let placement = client
         .post(&format!("{}{}", API_HOST, ORDER_PLACEMENT_ENDPOINT))
         .body(json!(order).to_string())

--- a/crates/model/src/order.rs
+++ b/crates/model/src/order.rs
@@ -44,7 +44,7 @@ pub struct Order {
 impl Default for Order {
     fn default() -> Self {
         let domain = &DomainSeparator::default();
-        let creation = OrderCreationPayload::default();
+        let creation = OrderCreation::default();
         Self::from_order_creation(
             &creation,
             domain,
@@ -68,7 +68,7 @@ pub enum OrderStatus {
 
 impl Order {
     pub fn from_order_creation(
-        order: &OrderCreationPayload,
+        order: &OrderCreation,
         domain: &DomainSeparator,
         settlement_contract: H160,
         full_fee_amount: U256,
@@ -90,8 +90,8 @@ impl Order {
         })
     }
 
-    pub fn into_order_creation(self) -> OrderCreationPayload {
-        OrderCreationPayload {
+    pub fn into_order_creation(self) -> OrderCreation {
+        OrderCreation {
             data: self.data,
             signature: self.signature.into_creation_signature(),
             quote_id: None,
@@ -360,7 +360,7 @@ impl OrderData {
 // An order as provided to the orderbook by the frontend.
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 #[serde(rename_all = "camelCase")]
-pub struct OrderCreationPayload {
+pub struct OrderCreation {
     #[serde(flatten)]
     pub data: OrderData,
     #[serde(flatten)]
@@ -368,7 +368,7 @@ pub struct OrderCreationPayload {
     pub quote_id: Option<QuoteId>,
 }
 
-impl OrderCreationPayload {
+impl OrderCreation {
     /// Recovers the owner address for the specified domain.
     ///
     /// This can return an error for orders with ECDSA signatures if the
@@ -380,7 +380,7 @@ impl OrderCreationPayload {
     }
 }
 
-impl Default for OrderCreationPayload {
+impl Default for OrderCreation {
     // Custom implementation to make sure the default order creation is valid.
     fn default() -> Self {
         let order = OrderData {

--- a/crates/model/src/order.rs
+++ b/crates/model/src/order.rs
@@ -3,7 +3,7 @@
 use crate::{
     app_id::AppId,
     quote::QuoteId,
-    signature::{EcdsaSignature, EcdsaSigningScheme, Signature},
+    signature::{CreationSignature, EcdsaSignature, EcdsaSigningScheme, RecoveryError, Signature},
     u256_decimal::{self, DecimalU256},
     DomainSeparator, TokenPair,
 };
@@ -36,25 +36,23 @@ pub struct Order {
     #[serde(flatten)]
     pub metadata: OrderMetadata,
     #[serde(flatten)]
-    pub creation: OrderCreation,
+    pub data: OrderData,
+    #[serde(flatten)]
+    pub signature: Signature,
 }
 
 impl Default for Order {
     fn default() -> Self {
         let domain = &DomainSeparator::default();
-        let order = OrderCreation::default();
-        let owner = order
-            .signature
-            .validate(domain, &order.hash_struct())
-            .unwrap();
+        let creation = OrderCreationPayload::default();
         Self::from_order_creation(
-            &order,
+            &creation,
             domain,
             H160::default(),
             Default::default(),
-            owner,
             false,
         )
+        .unwrap()
     }
 }
 
@@ -70,30 +68,38 @@ pub enum OrderStatus {
 
 impl Order {
     pub fn from_order_creation(
-        order_creation: &OrderCreation,
+        order: &OrderCreationPayload,
         domain: &DomainSeparator,
         settlement_contract: H160,
         full_fee_amount: U256,
-        owner: H160,
         is_liquidity_order: bool,
-    ) -> Self {
-        Self {
+    ) -> Result<Self, RecoveryError> {
+        let owner = order.recover_owner(domain)?;
+        Ok(Self {
             metadata: OrderMetadata {
-                creation_date: chrono::offset::Utc::now(),
                 owner,
-                uid: order_creation.uid(domain, &owner),
+                creation_date: chrono::offset::Utc::now(),
+                uid: order.data.uid(domain, &owner),
                 settlement_contract,
                 full_fee_amount,
                 is_liquidity_order,
                 ..Default::default()
             },
-            creation: *order_creation,
+            signature: order.signature.to_protocol_signature(),
+            data: order.data,
+        })
+    }
+
+    pub fn into_order_creation(self) -> OrderCreationPayload {
+        OrderCreationPayload {
+            data: self.data,
+            signature: self.signature.into_creation_signature(),
+            quote_id: None,
         }
     }
 
     pub fn contains_token_from(&self, token_list: &HashSet<H160>) -> bool {
-        token_list.contains(&self.creation.buy_token)
-            || token_list.contains(&self.creation.sell_token)
+        token_list.contains(&self.data.buy_token) || token_list.contains(&self.data.sell_token)
     }
 
     /// Returns the remaining amounts for the order.
@@ -107,28 +113,28 @@ impl Order {
     ///
     /// Returns an error on overflows or malformed orders.
     pub fn remaining_amounts(&self) -> Result<RemainingOrderAmounts> {
-        if !self.creation.partially_fillable {
+        if !self.data.partially_fillable {
             // Note that we skip the "fill-ratio" computation for fill-or-kill
             // orders despite yielding the same results in most cases. This is
             // because this computation only happens for partially fillable
             // orders in the settlement contract, and therefore overflows that
             // may happen would incorrectly return `Err`.
             return Ok(RemainingOrderAmounts {
-                sell_amount: self.creation.sell_amount,
-                buy_amount: self.creation.buy_amount,
-                fee_amount: self.creation.fee_amount,
+                sell_amount: self.data.sell_amount,
+                buy_amount: self.data.buy_amount,
+                fee_amount: self.data.fee_amount,
                 full_fee_amount: self.metadata.full_fee_amount,
             });
         }
 
-        let (max_executable_amount, executed_amount) = match self.creation.kind {
+        let (max_executable_amount, executed_amount) = match self.data.kind {
             OrderKind::Buy => (
-                self.creation.buy_amount,
+                self.data.buy_amount,
                 biguint_to_u256(&self.metadata.executed_buy_amount)
                     .context("buy order executed amount overflows a u256")?,
             ),
             OrderKind::Sell => (
-                self.creation.sell_amount,
+                self.data.sell_amount,
                 self.metadata.executed_sell_amount_before_fees,
             ),
         };
@@ -144,9 +150,9 @@ impl Order {
         };
 
         Ok(RemainingOrderAmounts {
-            sell_amount: scale(self.creation.sell_amount)?,
-            buy_amount: scale(self.creation.buy_amount)?,
-            fee_amount: scale(self.creation.fee_amount)?,
+            sell_amount: scale(self.data.sell_amount)?,
+            buy_amount: scale(self.data.buy_amount)?,
+            fee_amount: scale(self.data.fee_amount)?,
             full_fee_amount: scale(self.metadata.full_fee_amount)?,
         })
     }
@@ -166,37 +172,37 @@ pub struct OrderBuilder(Order);
 
 impl OrderBuilder {
     pub fn with_sell_token(mut self, sell_token: H160) -> Self {
-        self.0.creation.sell_token = sell_token;
+        self.0.data.sell_token = sell_token;
         self
     }
 
     pub fn with_buy_token(mut self, buy_token: H160) -> Self {
-        self.0.creation.buy_token = buy_token;
+        self.0.data.buy_token = buy_token;
         self
     }
 
     pub fn with_sell_amount(mut self, sell_amount: U256) -> Self {
-        self.0.creation.sell_amount = sell_amount;
+        self.0.data.sell_amount = sell_amount;
         self
     }
 
     pub fn with_buy_amount(mut self, buy_amount: U256) -> Self {
-        self.0.creation.buy_amount = buy_amount;
+        self.0.data.buy_amount = buy_amount;
         self
     }
 
     pub fn with_valid_to(mut self, valid_to: u32) -> Self {
-        self.0.creation.valid_to = valid_to;
+        self.0.data.valid_to = valid_to;
         self
     }
 
     pub fn with_app_data(mut self, app_data: [u8; 32]) -> Self {
-        self.0.creation.app_data = AppId(app_data);
+        self.0.data.app_data = AppId(app_data);
         self
     }
 
     pub fn with_fee_amount(mut self, fee_amount: U256) -> Self {
-        self.0.creation.fee_amount = fee_amount;
+        self.0.data.fee_amount = fee_amount;
         self
     }
 
@@ -206,22 +212,22 @@ impl OrderBuilder {
     }
 
     pub fn with_kind(mut self, kind: OrderKind) -> Self {
-        self.0.creation.kind = kind;
+        self.0.data.kind = kind;
         self
     }
 
     pub fn with_partially_fillable(mut self, partially_fillable: bool) -> Self {
-        self.0.creation.partially_fillable = partially_fillable;
+        self.0.data.partially_fillable = partially_fillable;
         self
     }
 
     pub fn with_sell_token_balance(mut self, balance: SellTokenSource) -> Self {
-        self.0.creation.sell_token_balance = balance;
+        self.0.data.sell_token_balance = balance;
         self
     }
 
     pub fn with_buy_token_balance(mut self, balance: BuyTokenDestination) -> Self {
-        self.0.creation.buy_token_balance = balance;
+        self.0.data.buy_token_balance = balance;
         self
     }
 
@@ -238,16 +244,16 @@ impl OrderBuilder {
         key: SecretKeyRef,
     ) -> Self {
         self.0.metadata.owner = key.address();
-        self.0.metadata.uid = self.0.creation.uid(domain, &key.address());
-        self.0.creation.signature =
-            EcdsaSignature::sign(signing_scheme, domain, &self.0.creation.hash_struct(), key)
+        self.0.metadata.uid = self.0.data.uid(domain, &key.address());
+        self.0.signature =
+            EcdsaSignature::sign(signing_scheme, domain, &self.0.data.hash_struct(), key)
                 .to_signature(signing_scheme);
         self
     }
 
     pub fn with_presign(mut self, owner: H160) -> Self {
         self.0.metadata.owner = owner;
-        self.0.creation.signature = Signature::PreSign(owner);
+        self.0.signature = Signature::PreSign(owner);
         self
     }
 
@@ -256,11 +262,13 @@ impl OrderBuilder {
     }
 }
 
-/// An order as provided to the orderbook by the frontend.
-#[serde_as]
-#[derive(Eq, PartialEq, Copy, Clone, Deserialize, Debug, Serialize, Hash)]
+/// The complete order data.
+///
+/// These are the exact fields that get signed and verified by the settlement
+/// contract.
+#[derive(Clone, Copy, Debug, Default, Deserialize, Eq, Hash, PartialEq, Serialize)]
 #[serde(rename_all = "camelCase")]
-pub struct OrderCreation {
+pub struct OrderData {
     pub sell_token: H160,
     pub buy_token: H160,
     #[serde(default)]
@@ -275,72 +283,13 @@ pub struct OrderCreation {
     pub fee_amount: U256,
     pub kind: OrderKind,
     pub partially_fillable: bool,
-    #[serde(flatten)]
-    pub signature: Signature,
     #[serde(default)]
     pub sell_token_balance: SellTokenSource,
     #[serde(default)]
     pub buy_token_balance: BuyTokenDestination,
 }
 
-#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
-#[serde(rename_all = "camelCase")]
-pub struct OrderCreationPayload {
-    #[serde(flatten)]
-    pub order_creation: OrderCreation,
-    pub from: Option<H160>,
-    pub quote_id: Option<QuoteId>,
-}
-
-impl Default for OrderCreation {
-    // Custom implementation to make sure the default order is valid
-    fn default() -> Self {
-        let signing_scheme = EcdsaSigningScheme::Eip712;
-        let mut result = Self {
-            sell_token: Default::default(),
-            buy_token: Default::default(),
-            receiver: Default::default(),
-            sell_amount: Default::default(),
-            buy_amount: Default::default(),
-            valid_to: u32::MAX,
-            app_data: Default::default(),
-            fee_amount: Default::default(),
-            kind: Default::default(),
-            partially_fillable: Default::default(),
-            signature: Default::default(),
-            sell_token_balance: Default::default(),
-            buy_token_balance: Default::default(),
-        };
-        result.signature = EcdsaSignature::sign(
-            signing_scheme,
-            &DomainSeparator::default(),
-            &result.hash_struct(),
-            SecretKeyRef::new(&ONE_KEY),
-        )
-        .to_signature(signing_scheme);
-        result
-    }
-}
-
-impl OrderCreation {
-    pub fn token_pair(&self) -> Option<TokenPair> {
-        TokenPair::new(self.buy_token, self.sell_token)
-    }
-
-    pub fn uid(&self, domain: &DomainSeparator, owner: &H160) -> OrderUid {
-        let mut uid = OrderUid([0u8; 56]);
-        uid.0[0..32].copy_from_slice(&super::signature::hashed_eip712_message(
-            domain,
-            &self.hash_struct(),
-        ));
-        uid.0[32..52].copy_from_slice(owner.as_fixed_bytes());
-        uid.0[52..56].copy_from_slice(&self.valid_to.to_be_bytes());
-        uid
-    }
-}
-
-// EIP-712
-impl OrderCreation {
+impl OrderData {
     // See <https://github.com/cowprotocol/contracts/blob/v1.1.2/src/contracts/libraries/GPv2Order.sol#L47>
     pub const TYPE_HASH: [u8; 32] =
         hex!("d5a25ba2e97094ad7d83dc28a6572da797d6b3e7fc6663bd93efb789fc17e489");
@@ -390,6 +339,59 @@ impl OrderCreation {
             BuyTokenDestination::Internal => &Self::BALANCE_INTERNAL,
         });
         signing::keccak256(&hash_data)
+    }
+
+    pub fn token_pair(&self) -> Option<TokenPair> {
+        TokenPair::new(self.buy_token, self.sell_token)
+    }
+
+    pub fn uid(&self, domain: &DomainSeparator, owner: &H160) -> OrderUid {
+        let mut uid = OrderUid([0u8; 56]);
+        uid.0[0..32].copy_from_slice(&super::signature::hashed_eip712_message(
+            domain,
+            &self.hash_struct(),
+        ));
+        uid.0[32..52].copy_from_slice(owner.as_fixed_bytes());
+        uid.0[52..56].copy_from_slice(&self.valid_to.to_be_bytes());
+        uid
+    }
+}
+
+// An order as provided to the orderbook by the frontend.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct OrderCreationPayload {
+    #[serde(flatten)]
+    pub data: OrderData,
+    #[serde(flatten)]
+    pub signature: CreationSignature,
+    pub quote_id: Option<QuoteId>,
+}
+
+impl OrderCreationPayload {
+    /// Recovers the owner address for the specified domain.
+    ///
+    /// This can return an error for orders with ECDSA signatures if the
+    /// optinally specidied `from` address does not match the address
+    /// EC-recovered address from the signature.
+    pub fn recover_owner(&self, domain: &DomainSeparator) -> Result<H160, RecoveryError> {
+        self.signature
+            .recover_owner(domain, &self.data.hash_struct())
+    }
+}
+
+impl Default for OrderCreationPayload {
+    // Custom implementation to make sure the default order creation is valid.
+    fn default() -> Self {
+        let order = OrderData {
+            valid_to: u32::MAX,
+            ..Default::default()
+        };
+        Self {
+            data: order,
+            signature: Default::default(),
+            quote_id: None,
+        }
     }
 }
 
@@ -721,7 +723,7 @@ mod tests {
                 full_fee_amount: U256::MAX,
                 is_liquidity_order: false,
             },
-            creation: OrderCreation {
+            data: OrderData {
                 sell_token: H160::from_low_u64_be(10),
                 buy_token: H160::from_low_u64_be(9),
                 receiver: Some(H160::from_low_u64_be(11)),
@@ -734,21 +736,21 @@ mod tests {
                 fee_amount: U256::MAX,
                 kind: OrderKind::Buy,
                 partially_fillable: false,
-                signature: EcdsaSignature {
-                    v: 1,
-                    r: H256::from_str(
-                        "0200000000000000000000000000000000000000000000000000000000000003",
-                    )
-                    .unwrap(),
-                    s: H256::from_str(
-                        "0400000000000000000000000000000000000000000000000000000000000005",
-                    )
-                    .unwrap(),
-                }
-                .to_signature(signing_scheme),
                 sell_token_balance: SellTokenSource::External,
                 buy_token_balance: BuyTokenDestination::Internal,
             },
+            signature: EcdsaSignature {
+                v: 1,
+                r: H256::from_str(
+                    "0200000000000000000000000000000000000000000000000000000000000003",
+                )
+                .unwrap(),
+                s: H256::from_str(
+                    "0400000000000000000000000000000000000000000000000000000000000005",
+                )
+                .unwrap(),
+            }
+            .to_signature(signing_scheme),
         };
         let deserialized: Order = serde_json::from_value(value.clone()).unwrap();
         assert_eq!(deserialized, expected);
@@ -783,7 +785,7 @@ mod tests {
                 ),
             ),
         ] {
-            let order = OrderCreation {
+            let order = OrderData {
                 sell_token: hex!("0101010101010101010101010101010101010101").into(),
                 buy_token: hex!("0202020202020202020202020202020202020202").into(),
                 receiver: Some(hex!("0303030303030303030303030303030303030303").into()),
@@ -798,11 +800,10 @@ mod tests {
                 partially_fillable: false,
                 sell_token_balance: SellTokenSource::Erc20,
                 buy_token_balance: BuyTokenDestination::Erc20,
-                signature: Signature::from_bytes(*signing_scheme, signature).unwrap(),
             };
+            let signature = Signature::from_bytes(*signing_scheme, signature).unwrap();
 
-            let owner = order
-                .signature
+            let owner = signature
                 .validate(&domain_separator, &order.hash_struct())
                 .unwrap();
             assert_eq!(owner, expected_owner);
@@ -817,7 +818,7 @@ mod tests {
             "74e0b11bd18120612556bae4578cfd3a254d7e2495f543c569a92ff5794d9b09"
         ));
         let owner = hex!("70997970C51812dc3A010C7d01b50e0d17dc79C8").into();
-        let order = OrderCreation {
+        let order = OrderData {
             sell_token: hex!("0101010101010101010101010101010101010101").into(),
             buy_token: hex!("0202020202020202020202020202020202020202").into(),
             receiver: Some(hex!("0303030303030303030303030303030303030303").into()),
@@ -832,8 +833,6 @@ mod tests {
             partially_fillable: false,
             sell_token_balance: SellTokenSource::Erc20,
             buy_token_balance: BuyTokenDestination::Erc20,
-            // Other properties are not considered in the order UID.
-            ..Default::default()
         };
 
         assert_eq!(
@@ -889,12 +888,12 @@ mod tests {
     #[test]
     fn order_contains_token_from() {
         let order = Order::default();
-        assert!(order.contains_token_from(&hashset!(order.creation.sell_token)),);
-        assert!(order.contains_token_from(&hashset!(order.creation.buy_token)),);
+        assert!(order.contains_token_from(&hashset!(order.data.sell_token)),);
+        assert!(order.contains_token_from(&hashset!(order.data.buy_token)),);
         assert!(!order.contains_token_from(&HashSet::new()));
         let other_token = H160::from_low_u64_be(1);
-        assert_ne!(other_token, order.creation.sell_token);
-        assert_ne!(other_token, order.creation.buy_token);
+        assert_ne!(other_token, order.data.sell_token);
+        assert_ne!(other_token, order.data.buy_token);
         assert!(!order.contains_token_from(&hashset!(other_token)));
     }
 
@@ -934,9 +933,8 @@ mod tests {
             .build();
 
         let owner = order
-            .creation
             .signature
-            .validate(&DomainSeparator::default(), &order.creation.hash_struct())
+            .validate(&DomainSeparator::default(), &order.data.hash_struct())
             .unwrap();
 
         assert_eq!(owner, h160_from_public_key(public_key));
@@ -953,7 +951,7 @@ mod tests {
         // orders (where `{sell,fee}_amount * buy_amount` would overflow).
         assert_eq!(
             Order {
-                creation: OrderCreation {
+                data: OrderData {
                     sell_amount: 1000.into(),
                     buy_amount: U256::MAX,
                     fee_amount: 337.into(),
@@ -965,6 +963,7 @@ mod tests {
                     full_fee_amount: 42.into(),
                     ..Default::default()
                 },
+                ..Default::default()
             }
             .remaining_amounts()
             .unwrap(),
@@ -980,7 +979,7 @@ mod tests {
         // order amounts.
         assert_eq!(
             Order {
-                creation: OrderCreation {
+                data: OrderData {
                     sell_amount: 10.into(),
                     buy_amount: 11.into(),
                     fee_amount: 12.into(),
@@ -993,6 +992,7 @@ mod tests {
                     full_fee_amount: 13.into(),
                     ..Default::default()
                 },
+                ..Default::default()
             }
             .remaining_amounts()
             .unwrap(),
@@ -1008,7 +1008,7 @@ mod tests {
         // settlement contract.
         assert_eq!(
             Order {
-                creation: OrderCreation {
+                data: OrderData {
                     sell_amount: 100.into(),
                     buy_amount: 100.into(),
                     fee_amount: 101.into(),
@@ -1021,6 +1021,7 @@ mod tests {
                     full_fee_amount: 200.into(),
                     ..Default::default()
                 },
+                ..Default::default()
             }
             .remaining_amounts()
             .unwrap(),
@@ -1033,7 +1034,7 @@ mod tests {
         );
         assert_eq!(
             Order {
-                creation: OrderCreation {
+                data: OrderData {
                     sell_amount: 100.into(),
                     buy_amount: 10.into(),
                     fee_amount: 101.into(),
@@ -1046,6 +1047,7 @@ mod tests {
                     full_fee_amount: 200.into(),
                     ..Default::default()
                 },
+                ..Default::default()
             }
             .remaining_amounts()
             .unwrap(),
@@ -1062,7 +1064,7 @@ mod tests {
     fn remaining_amount_errors() {
         // Partially fillable order overflow when computing fill ratio.
         assert!(Order {
-            creation: OrderCreation {
+            data: OrderData {
                 sell_amount: 1000.into(),
                 fee_amount: 337.into(),
                 buy_amount: U256::MAX,
@@ -1077,7 +1079,7 @@ mod tests {
 
         // Partially filled order overflowing executed amount.
         assert!(Order {
-            creation: OrderCreation {
+            data: OrderData {
                 buy_amount: U256::MAX,
                 kind: OrderKind::Sell,
                 partially_fillable: true,
@@ -1087,13 +1089,14 @@ mod tests {
                 executed_buy_amount: BigUint::from(1_u8) << 256,
                 ..Default::default()
             },
+            ..Default::default()
         }
         .remaining_amounts()
         .is_err());
 
         // Partially filled order that has executed more than its maximum.
         assert!(Order {
-            creation: OrderCreation {
+            data: OrderData {
                 sell_amount: 1.into(),
                 kind: OrderKind::Sell,
                 partially_fillable: true,
@@ -1103,13 +1106,14 @@ mod tests {
                 executed_sell_amount_before_fees: 2.into(),
                 ..Default::default()
             },
+            ..Default::default()
         }
         .remaining_amounts()
         .is_err());
 
         // Partially fillable order with zero amount.
         assert!(Order {
-            creation: OrderCreation {
+            data: OrderData {
                 sell_amount: 0.into(),
                 kind: OrderKind::Sell,
                 partially_fillable: true,

--- a/crates/orderbook/src/account_balances.rs
+++ b/crates/orderbook/src/account_balances.rs
@@ -19,8 +19,8 @@ impl Query {
     pub fn from_order(o: &Order) -> Self {
         Self {
             owner: o.metadata.owner,
-            token: o.creation.sell_token,
-            source: o.creation.sell_token_balance,
+            token: o.data.sell_token,
+            source: o.data.sell_token_balance,
         }
     }
 }

--- a/crates/orderbook/src/api/create_order.rs
+++ b/crates/orderbook/src/api/create_order.rs
@@ -3,13 +3,13 @@ use crate::{
     orderbook::{AddOrderError, Orderbook},
 };
 use anyhow::Result;
-use model::order::{OrderCreationPayload, OrderUid};
+use model::order::{OrderCreation, OrderUid};
 use std::{convert::Infallible, sync::Arc};
 use warp::reply::with_status;
 use warp::{hyper::StatusCode, Filter, Rejection};
 
 pub fn create_order_request(
-) -> impl Filter<Extract = (OrderCreationPayload,), Error = Rejection> + Clone {
+) -> impl Filter<Extract = (OrderCreation,), Error = Rejection> + Clone {
     warp::path!("orders")
         .and(warp::post())
         .and(extract_payload())
@@ -41,7 +41,7 @@ pub fn create_order_response(result: Result<OrderUid, AddOrderError>) -> super::
 pub fn create_order(
     orderbook: Arc<Orderbook>,
 ) -> impl Filter<Extract = (super::ApiReply,), Error = Rejection> + Clone {
-    create_order_request().and_then(move |order_payload: OrderCreationPayload| {
+    create_order_request().and_then(move |order_payload: OrderCreation| {
         let orderbook = orderbook.clone();
         async move {
             let quote_id = order_payload.quote_id;
@@ -58,14 +58,14 @@ pub fn create_order(
 mod tests {
     use super::*;
     use crate::api::response_body;
-    use model::order::{OrderCreationPayload, OrderUid};
+    use model::order::{OrderCreation, OrderUid};
     use serde_json::json;
     use warp::{test::request, Reply};
 
     #[tokio::test]
     async fn create_order_request_ok() {
         let filter = create_order_request();
-        let order_payload = OrderCreationPayload::default();
+        let order_payload = OrderCreation::default();
         let request = request()
             .path("/orders")
             .method("POST")

--- a/crates/orderbook/src/api/order_validation.rs
+++ b/crates/orderbook/src/api/order_validation.rs
@@ -7,9 +7,10 @@ use contracts::WETH9;
 use ethcontract::{H160, U256};
 use model::{
     order::{
-        BuyTokenDestination, Order, OrderCreation, OrderKind, SellTokenSource, BUY_ETH_ADDRESS,
+        BuyTokenDestination, Order, OrderCreationPayload, OrderData, OrderKind, SellTokenSource,
+        BUY_ETH_ADDRESS,
     },
-    signature::SigningScheme,
+    signature::{RecoveryError, SigningScheme},
     DomainSeparator,
 };
 use shared::{
@@ -39,7 +40,7 @@ pub trait OrderValidating: Send + Sync {
     /// This is the full order validation performed at the time of order placement
     /// (i.e. once all the required fields on an Order are provided). Specifically, verifying that
     ///     - buy & sell amounts are non-zero,
-    ///     - order's owner matches the from field (if specified),
+    ///     - order's signature recovers correctly
     ///     - fee is sufficient,
     ///     - buy & sell tokens passed "bad token" detection,
     ///     - user has sufficient (transferable) funds to execute the order.
@@ -48,8 +49,7 @@ pub trait OrderValidating: Send + Sync {
     /// other aspects of the order are not malformed.
     async fn validate_and_construct_order(
         &self,
-        order_creation: OrderCreation,
-        sender: Option<H160>,
+        order: OrderCreationPayload,
         domain_separator: &DomainSeparator,
         settlement_contract: H160,
     ) -> Result<(Order, FeeParameters), ValidationError>;
@@ -152,6 +152,15 @@ pub enum ValidationError {
     Other(anyhow::Error),
 }
 
+impl From<RecoveryError> for ValidationError {
+    fn from(err: RecoveryError) -> Self {
+        match err {
+            RecoveryError::UnableToRecoverSigner => Self::InvalidSignature,
+            RecoveryError::UnexpectedSigner(signer) => Self::WrongOwner(signer),
+        }
+    }
+}
+
 impl IntoWarpReply for ValidationError {
     fn into_warp_reply(self) -> super::ApiReply {
         match self {
@@ -248,7 +257,7 @@ pub struct PreOrderData {
     pub is_liquidity_order: bool,
 }
 
-fn actual_receiver(owner: H160, order: &OrderCreation) -> H160 {
+fn actual_receiver(owner: H160, order: &OrderData) -> H160 {
     let receiver = order.receiver.unwrap_or_default();
     if receiver == H160::zero() {
         owner
@@ -260,7 +269,8 @@ fn actual_receiver(owner: H160, order: &OrderCreation) -> H160 {
 impl PreOrderData {
     pub fn from_order_creation(
         owner: H160,
-        order: &OrderCreation,
+        order: &OrderData,
+        signing_scheme: SigningScheme,
         is_liquidity_order: bool,
     ) -> Self {
         Self {
@@ -272,7 +282,7 @@ impl PreOrderData {
             partially_fillable: order.partially_fillable,
             buy_token_balance: order.buy_token_balance,
             sell_token_balance: order.sell_token_balance,
-            signing_scheme: order.signature.scheme(),
+            signing_scheme,
             is_liquidity_order,
         }
     }
@@ -372,23 +382,17 @@ impl OrderValidating for OrderValidator {
 
     async fn validate_and_construct_order(
         &self,
-        order_creation: OrderCreation,
-        sender: Option<H160>,
+        order: OrderCreationPayload,
         domain_separator: &DomainSeparator,
         settlement_contract: H160,
     ) -> Result<(Order, FeeParameters), ValidationError> {
-        let owner = order_creation
-            .signature
-            .validate(domain_separator, &order_creation.hash_struct())
-            .ok_or(ValidationError::InvalidSignature)?;
+        let owner = order.recover_owner(domain_separator)?;
+        let signing_scheme = order.signature.to_protocol_signature().scheme();
 
-        if order_creation.buy_amount.is_zero() || order_creation.sell_amount.is_zero() {
+        if order.data.buy_amount.is_zero() || order.data.sell_amount.is_zero() {
             return Err(ValidationError::ZeroAmount);
         }
-        if matches!(sender, Some(from) if from != owner) {
-            return Err(ValidationError::WrongOwner(owner));
-        }
-        for &token in &[order_creation.sell_token, order_creation.buy_token] {
+        for &token in &[order.data.sell_token, order.data.buy_token] {
             if !self
                 .bad_token_detector
                 .detect(token)
@@ -403,7 +407,8 @@ impl OrderValidating for OrderValidator {
         let is_liquidity_order = self.liquidity_order_owners.contains(&owner);
         self.partial_validate(PreOrderData::from_order_creation(
             owner,
-            &order_creation,
+            &order.data,
+            signing_scheme,
             is_liquidity_order,
         ))
         .await
@@ -413,16 +418,16 @@ impl OrderValidating for OrderValidator {
             .fee_validator
             .get_unsubsidized_min_fee(
                 FeeData {
-                    sell_token: order_creation.sell_token,
-                    buy_token: order_creation.buy_token,
-                    amount: match order_creation.kind {
-                        OrderKind::Buy => order_creation.buy_amount,
-                        OrderKind::Sell => order_creation.sell_amount,
+                    sell_token: order.data.sell_token,
+                    buy_token: order.data.buy_token,
+                    amount: match order.data.kind {
+                        OrderKind::Buy => order.data.buy_amount,
+                        OrderKind::Sell => order.data.sell_amount,
                     },
-                    kind: order_creation.kind,
+                    kind: order.data.kind,
                 },
-                order_creation.app_data,
-                order_creation.fee_amount,
+                order.data.app_data,
+                order.data.fee_amount,
                 owner,
             )
             .await
@@ -441,7 +446,7 @@ impl OrderValidating for OrderValidator {
                 }
             })?;
 
-        let min_balance = match minimum_balance(&order_creation) {
+        let min_balance = match minimum_balance(&order.data) {
             Some(amount) => amount,
             None => return Err(ValidationError::SellAmountOverflow),
         };
@@ -451,10 +456,10 @@ impl OrderValidating for OrderValidator {
         match self
             .balance_fetcher
             .can_transfer(
-                order_creation.sell_token,
+                order.data.sell_token,
                 owner,
                 min_balance,
-                order_creation.sell_token_balance,
+                order.data.sell_token_balance,
             )
             .await
         {
@@ -462,7 +467,7 @@ impl OrderValidating for OrderValidator {
             Err(
                 TransferSimulationError::InsufficientAllowance
                 | TransferSimulationError::InsufficientBalance,
-            ) if order_creation.signature.scheme() == SigningScheme::PreSign => {
+            ) if signing_scheme == SigningScheme::PreSign => {
                 // We have an exception for pre-sign orders where they do not
                 // require sufficient balance or allowance. The idea, is that
                 // this allows smart contracts to place orders bundled with
@@ -489,13 +494,12 @@ impl OrderValidating for OrderValidator {
         }
 
         let order = Order::from_order_creation(
-            &order_creation,
+            &order,
             domain_separator,
             settlement_contract,
             unsubsidized_fee.amount_in_sell_token(),
-            owner,
             is_liquidity_order,
-        );
+        )?;
         Ok((order, unsubsidized_fee))
     }
 }
@@ -511,7 +515,7 @@ fn has_same_buy_and_sell_token(order: &PreOrderData, native_token: &WETH9) -> bo
 /// Min balance user must have in sell token for order to be accepted.
 ///
 /// None when addition overflows.
-fn minimum_balance(order: &OrderCreation) -> Option<U256> {
+fn minimum_balance(order: &OrderData) -> Option<U256> {
     // TODO: Note that we are pessimistic here for partially fillable orders,
     // since they don't need the full balance in order for the order to be
     // tradable. However, since they are currently only used for PMMs for
@@ -530,7 +534,10 @@ mod tests {
     use anyhow::anyhow;
     use ethcontract::web3::signing::SecretKeyRef;
     use maplit::hashset;
-    use model::{order::OrderBuilder, signature::EcdsaSigningScheme};
+    use model::{
+        order::OrderBuilder,
+        signature::{CreationSignature, EcdsaSignature, EcdsaSigningScheme},
+    };
     use secp256k1::ONE_KEY;
     use shared::{
         bad_token::{MockBadTokenDetecting, TokenQuality},
@@ -540,13 +547,13 @@ mod tests {
 
     #[test]
     fn minimum_balance_() {
-        let order = OrderCreation {
+        let order = OrderData {
             sell_amount: U256::MAX,
             fee_amount: U256::from(1),
             ..Default::default()
         };
         assert_eq!(minimum_balance(&order), None);
-        let order = OrderCreation {
+        let order = OrderData {
             sell_amount: U256::from(1),
             fee_amount: U256::from(1),
             ..Default::default()
@@ -823,19 +830,22 @@ mod tests {
             Arc::new(bad_token_detector),
             Arc::new(balance_fetcher),
         );
-        let order = OrderCreation {
-            valid_to: model::time::now_in_epoch_seconds() + 2,
-            sell_token: H160::from_low_u64_be(1),
-            buy_token: H160::from_low_u64_be(2),
-            buy_amount: U256::from(1),
-            sell_amount: U256::from(1),
+        let order = OrderCreationPayload {
+            data: OrderData {
+                valid_to: model::time::now_in_epoch_seconds() + 2,
+                sell_token: H160::from_low_u64_be(1),
+                buy_token: H160::from_low_u64_be(2),
+                buy_amount: U256::from(1),
+                sell_amount: U256::from(1),
+                ..Default::default()
+            },
             ..Default::default()
         };
         let (order, _) = validator
-            .validate_and_construct_order(order, None, &Default::default(), Default::default())
+            .validate_and_construct_order(order, &Default::default(), Default::default())
             .await
             .unwrap();
-        assert_eq!(order.metadata.full_fee_amount, order.creation.fee_amount);
+        assert_eq!(order.metadata.full_fee_amount, order.data.fee_amount);
     }
 
     #[tokio::test]
@@ -864,16 +874,19 @@ mod tests {
             Arc::new(bad_token_detector),
             Arc::new(balance_fetcher),
         );
-        let order = OrderCreation {
-            valid_to: model::time::now_in_epoch_seconds() + 2,
-            sell_token: H160::from_low_u64_be(1),
-            buy_token: H160::from_low_u64_be(2),
-            buy_amount: U256::from(0),
-            sell_amount: U256::from(0),
+        let order = OrderCreationPayload {
+            data: OrderData {
+                valid_to: model::time::now_in_epoch_seconds() + 2,
+                sell_token: H160::from_low_u64_be(1),
+                buy_token: H160::from_low_u64_be(2),
+                buy_amount: U256::from(0),
+                sell_amount: U256::from(0),
+                ..Default::default()
+            },
             ..Default::default()
         };
         let result = validator
-            .validate_and_construct_order(order, None, &Default::default(), Default::default())
+            .validate_and_construct_order(order, &Default::default(), Default::default())
             .await;
         dbg!(&result);
         assert!(matches!(result, Err(ValidationError::ZeroAmount)));
@@ -905,21 +918,23 @@ mod tests {
             Arc::new(bad_token_detector),
             Arc::new(balance_fetcher),
         );
-        let order = OrderCreation {
-            valid_to: model::time::now_in_epoch_seconds() + 2,
-            sell_token: H160::from_low_u64_be(1),
-            buy_token: H160::from_low_u64_be(2),
-            buy_amount: U256::from(1),
-            sell_amount: U256::from(1),
+        let order = OrderCreationPayload {
+            data: OrderData {
+                valid_to: model::time::now_in_epoch_seconds() + 2,
+                sell_token: H160::from_low_u64_be(1),
+                buy_token: H160::from_low_u64_be(2),
+                buy_amount: U256::from(1),
+                sell_amount: U256::from(1),
+                ..Default::default()
+            },
+            signature: CreationSignature::Eip712 {
+                from: Some(Default::default()),
+                signature: EcdsaSignature::non_zero(),
+            },
             ..Default::default()
         };
         let result = validator
-            .validate_and_construct_order(
-                order,
-                Some(Default::default()),
-                &Default::default(),
-                Default::default(),
-            )
+            .validate_and_construct_order(order, &Default::default(), Default::default())
             .await;
         assert!(matches!(result, Err(ValidationError::WrongOwner(_))));
     }
@@ -950,16 +965,19 @@ mod tests {
             Arc::new(bad_token_detector),
             Arc::new(balance_fetcher),
         );
-        let order = OrderCreation {
-            valid_to: model::time::now_in_epoch_seconds() + 2,
-            sell_token: H160::from_low_u64_be(1),
-            buy_token: H160::from_low_u64_be(2),
-            buy_amount: U256::from(1),
-            sell_amount: U256::from(1),
+        let order = OrderCreationPayload {
+            data: OrderData {
+                valid_to: model::time::now_in_epoch_seconds() + 2,
+                sell_token: H160::from_low_u64_be(1),
+                buy_token: H160::from_low_u64_be(2),
+                buy_amount: U256::from(1),
+                sell_amount: U256::from(1),
+                ..Default::default()
+            },
             ..Default::default()
         };
         let result = validator
-            .validate_and_construct_order(order, None, &Default::default(), Default::default())
+            .validate_and_construct_order(order, &Default::default(), Default::default())
             .await;
         dbg!(&result);
         assert!(matches!(result, Err(ValidationError::InsufficientFee)));
@@ -993,16 +1011,19 @@ mod tests {
             Arc::new(bad_token_detector),
             Arc::new(balance_fetcher),
         );
-        let order = OrderCreation {
-            valid_to: model::time::now_in_epoch_seconds() + 2,
-            sell_token: H160::from_low_u64_be(1),
-            buy_token: H160::from_low_u64_be(2),
-            buy_amount: U256::from(1),
-            sell_amount: U256::from(1),
+        let order = OrderCreationPayload {
+            data: OrderData {
+                valid_to: model::time::now_in_epoch_seconds() + 2,
+                sell_token: H160::from_low_u64_be(1),
+                buy_token: H160::from_low_u64_be(2),
+                buy_amount: U256::from(1),
+                sell_amount: U256::from(1),
+                ..Default::default()
+            },
             ..Default::default()
         };
         let result = validator
-            .validate_and_construct_order(order, None, &Default::default(), Default::default())
+            .validate_and_construct_order(order, &Default::default(), Default::default())
             .await;
         dbg!(&result);
         assert!(matches!(result, Err(ValidationError::UnsupportedToken(_))));
@@ -1034,17 +1055,20 @@ mod tests {
             Arc::new(bad_token_detector),
             Arc::new(balance_fetcher),
         );
-        let order = OrderCreation {
-            valid_to: model::time::now_in_epoch_seconds() + 2,
-            sell_token: H160::from_low_u64_be(1),
-            buy_token: H160::from_low_u64_be(2),
-            buy_amount: U256::from(1),
-            sell_amount: U256::MAX,
-            fee_amount: U256::from(1),
+        let order = OrderCreationPayload {
+            data: OrderData {
+                valid_to: model::time::now_in_epoch_seconds() + 2,
+                sell_token: H160::from_low_u64_be(1),
+                buy_token: H160::from_low_u64_be(2),
+                buy_amount: U256::from(1),
+                sell_amount: U256::MAX,
+                fee_amount: U256::from(1),
+                ..Default::default()
+            },
             ..Default::default()
         };
         let result = validator
-            .validate_and_construct_order(order, None, &Default::default(), Default::default())
+            .validate_and_construct_order(order, &Default::default(), Default::default())
             .await;
         dbg!(&result);
         assert!(matches!(result, Err(ValidationError::SellAmountOverflow)));
@@ -1076,16 +1100,19 @@ mod tests {
             Arc::new(bad_token_detector),
             Arc::new(balance_fetcher),
         );
-        let order = OrderCreation {
-            valid_to: model::time::now_in_epoch_seconds() + 2,
-            sell_token: H160::from_low_u64_be(1),
-            buy_token: H160::from_low_u64_be(2),
-            buy_amount: U256::from(1),
-            sell_amount: U256::from(1),
+        let order = OrderCreationPayload {
+            data: OrderData {
+                valid_to: model::time::now_in_epoch_seconds() + 2,
+                sell_token: H160::from_low_u64_be(1),
+                buy_token: H160::from_low_u64_be(2),
+                buy_amount: U256::from(1),
+                sell_amount: U256::from(1),
+                ..Default::default()
+            },
             ..Default::default()
         };
         let result = validator
-            .validate_and_construct_order(order, None, &Default::default(), Default::default())
+            .validate_and_construct_order(order, &Default::default(), Default::default())
             .await;
         dbg!(&result);
         assert!(matches!(result, Err(ValidationError::InsufficientBalance)));
@@ -1139,8 +1166,7 @@ mod tests {
                                         SecretKeyRef::new(&ONE_KEY)
                                     )
                                     .build()
-                                    .creation,
-                                None,
+                                    .into_order_creation(),
                                 &Default::default(),
                                 Default::default()
                             )
@@ -1152,8 +1178,10 @@ mod tests {
                 assert!(matches!(
                     validator
                         .validate_and_construct_order(
-                            order.with_presign(Default::default()).build().creation,
-                            None,
+                            order
+                                .with_presign(Default::default())
+                                .build()
+                                .into_order_creation(),
                             &Default::default(),
                             Default::default()
                         )

--- a/crates/orderbook/src/api/order_validation.rs
+++ b/crates/orderbook/src/api/order_validation.rs
@@ -7,7 +7,7 @@ use contracts::WETH9;
 use ethcontract::{H160, U256};
 use model::{
     order::{
-        BuyTokenDestination, Order, OrderCreationPayload, OrderData, OrderKind, SellTokenSource,
+        BuyTokenDestination, Order, OrderCreation, OrderData, OrderKind, SellTokenSource,
         BUY_ETH_ADDRESS,
     },
     signature::{RecoveryError, SigningScheme},
@@ -49,7 +49,7 @@ pub trait OrderValidating: Send + Sync {
     /// other aspects of the order are not malformed.
     async fn validate_and_construct_order(
         &self,
-        order: OrderCreationPayload,
+        order: OrderCreation,
         domain_separator: &DomainSeparator,
         settlement_contract: H160,
     ) -> Result<(Order, FeeParameters), ValidationError>;
@@ -382,7 +382,7 @@ impl OrderValidating for OrderValidator {
 
     async fn validate_and_construct_order(
         &self,
-        order: OrderCreationPayload,
+        order: OrderCreation,
         domain_separator: &DomainSeparator,
         settlement_contract: H160,
     ) -> Result<(Order, FeeParameters), ValidationError> {
@@ -830,7 +830,7 @@ mod tests {
             Arc::new(bad_token_detector),
             Arc::new(balance_fetcher),
         );
-        let order = OrderCreationPayload {
+        let order = OrderCreation {
             data: OrderData {
                 valid_to: model::time::now_in_epoch_seconds() + 2,
                 sell_token: H160::from_low_u64_be(1),
@@ -874,7 +874,7 @@ mod tests {
             Arc::new(bad_token_detector),
             Arc::new(balance_fetcher),
         );
-        let order = OrderCreationPayload {
+        let order = OrderCreation {
             data: OrderData {
                 valid_to: model::time::now_in_epoch_seconds() + 2,
                 sell_token: H160::from_low_u64_be(1),
@@ -918,7 +918,7 @@ mod tests {
             Arc::new(bad_token_detector),
             Arc::new(balance_fetcher),
         );
-        let order = OrderCreationPayload {
+        let order = OrderCreation {
             data: OrderData {
                 valid_to: model::time::now_in_epoch_seconds() + 2,
                 sell_token: H160::from_low_u64_be(1),
@@ -965,7 +965,7 @@ mod tests {
             Arc::new(bad_token_detector),
             Arc::new(balance_fetcher),
         );
-        let order = OrderCreationPayload {
+        let order = OrderCreation {
             data: OrderData {
                 valid_to: model::time::now_in_epoch_seconds() + 2,
                 sell_token: H160::from_low_u64_be(1),
@@ -1011,7 +1011,7 @@ mod tests {
             Arc::new(bad_token_detector),
             Arc::new(balance_fetcher),
         );
-        let order = OrderCreationPayload {
+        let order = OrderCreation {
             data: OrderData {
                 valid_to: model::time::now_in_epoch_seconds() + 2,
                 sell_token: H160::from_low_u64_be(1),
@@ -1055,7 +1055,7 @@ mod tests {
             Arc::new(bad_token_detector),
             Arc::new(balance_fetcher),
         );
-        let order = OrderCreationPayload {
+        let order = OrderCreation {
             data: OrderData {
                 valid_to: model::time::now_in_epoch_seconds() + 2,
                 sell_token: H160::from_low_u64_be(1),
@@ -1100,7 +1100,7 @@ mod tests {
             Arc::new(bad_token_detector),
             Arc::new(balance_fetcher),
         );
-        let order = OrderCreationPayload {
+        let order = OrderCreation {
             data: OrderData {
                 valid_to: model::time::now_in_epoch_seconds() + 2,
                 sell_token: H160::from_low_u64_be(1),

--- a/crates/orderbook/src/api/replace_order.rs
+++ b/crates/orderbook/src/api/replace_order.rs
@@ -3,12 +3,12 @@ use crate::{
     orderbook::{Orderbook, ReplaceOrderError},
 };
 use anyhow::Result;
-use model::order::{OrderCreationPayload, OrderUid};
+use model::order::{OrderCreation, OrderUid};
 use reqwest::StatusCode;
 use std::{convert::Infallible, sync::Arc};
 use warp::{reply, Filter, Rejection};
 
-fn request() -> impl Filter<Extract = (OrderUid, OrderCreationPayload), Error = Rejection> + Clone {
+fn request() -> impl Filter<Extract = (OrderUid, OrderCreation), Error = Rejection> + Clone {
     warp::path!("orders" / OrderUid)
         .and(warp::patch())
         .and(extract_payload())
@@ -53,7 +53,7 @@ mod tests {
     #[tokio::test]
     async fn replace_order_request_filter() {
         let old_order = OrderUid::default();
-        let new_order = OrderCreationPayload::default();
+        let new_order = OrderCreation::default();
 
         let result = warp::test::request()
             .path(&format!("/orders/{old_order}"))

--- a/crates/orderbook/src/database/orders.rs
+++ b/crates/orderbook/src/database/orders.rs
@@ -149,6 +149,7 @@ impl DbBuyTokenDestination {
 #[sqlx(rename_all = "lowercase")]
 pub enum DbSigningScheme {
     Eip712,
+    Eip1271,
     EthSign,
     PreSign,
 }
@@ -157,6 +158,7 @@ impl DbSigningScheme {
     pub fn from(signing_scheme: SigningScheme) -> Self {
         match signing_scheme {
             SigningScheme::Eip712 => Self::Eip712,
+            SigningScheme::Eip1271 => Self::Eip1271,
             SigningScheme::EthSign => Self::EthSign,
             SigningScheme::PreSign => Self::PreSign,
         }
@@ -165,6 +167,7 @@ impl DbSigningScheme {
     fn into(self) -> SigningScheme {
         match self {
             Self::Eip712 => SigningScheme::Eip712,
+            Self::Eip1271 => SigningScheme::Eip1271,
             Self::EthSign => SigningScheme::EthSign,
             Self::PreSign => SigningScheme::PreSign,
         }

--- a/crates/orderbook/src/database/orders.rs
+++ b/crates/orderbook/src/database/orders.rs
@@ -8,7 +8,7 @@ use futures::{stream::TryStreamExt, FutureExt};
 use model::{
     app_id::AppId,
     order::{
-        BuyTokenDestination, Order, OrderCreation, OrderKind, OrderMetadata, OrderStatus, OrderUid,
+        BuyTokenDestination, Order, OrderData, OrderKind, OrderMetadata, OrderStatus, OrderUid,
         SellTokenSource,
     },
     signature::{Signature, SigningScheme},
@@ -238,30 +238,28 @@ async fn insert_order(
                 settlement_contract, sell_token_balance, buy_token_balance, full_fee_amount, is_liquidity_order) \
             VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20);";
     let receiver = order
-        .creation
+        .data
         .receiver
         .map(|address| address.as_bytes().to_vec());
     sqlx::query(QUERY)
         .bind(order.metadata.uid.0.as_ref())
         .bind(order.metadata.owner.as_bytes())
         .bind(order.metadata.creation_date)
-        .bind(order.creation.sell_token.as_bytes())
-        .bind(order.creation.buy_token.as_bytes())
+        .bind(order.data.sell_token.as_bytes())
+        .bind(order.data.buy_token.as_bytes())
         .bind(receiver)
-        .bind(u256_to_big_decimal(&order.creation.sell_amount))
-        .bind(u256_to_big_decimal(&order.creation.buy_amount))
-        .bind(order.creation.valid_to)
-        .bind(&order.creation.app_data.0[..])
-        .bind(u256_to_big_decimal(&order.creation.fee_amount))
-        .bind(DbOrderKind::from(order.creation.kind))
-        .bind(order.creation.partially_fillable)
-        .bind(&*order.creation.signature.to_bytes())
-        .bind(DbSigningScheme::from(order.creation.signature.scheme()))
+        .bind(u256_to_big_decimal(&order.data.sell_amount))
+        .bind(u256_to_big_decimal(&order.data.buy_amount))
+        .bind(order.data.valid_to)
+        .bind(&order.data.app_data.0[..])
+        .bind(u256_to_big_decimal(&order.data.fee_amount))
+        .bind(DbOrderKind::from(order.data.kind))
+        .bind(order.data.partially_fillable)
+        .bind(&*order.signature.to_bytes())
+        .bind(DbSigningScheme::from(order.signature.scheme()))
         .bind(order.metadata.settlement_contract.as_bytes())
-        .bind(DbSellTokenSource::from(order.creation.sell_token_balance))
-        .bind(DbBuyTokenDestination::from(
-            order.creation.buy_token_balance,
-        ))
+        .bind(DbSellTokenSource::from(order.data.sell_token_balance))
+        .bind(DbBuyTokenDestination::from(order.data.buy_token_balance))
         .bind(u256_to_big_decimal(&order.metadata.full_fee_amount))
         .bind(order.metadata.is_liquidity_order)
         .execute(transaction)
@@ -601,7 +599,7 @@ impl OrdersQueryRow {
 
     fn into_order(self) -> Result<Order> {
         let status = self.calculate_status();
-        let order_metadata = OrderMetadata {
+        let metadata = OrderMetadata {
             creation_date: self.creation_timestamp,
             owner: h160_from_vec(self.owner)?,
             uid: OrderUid(
@@ -629,7 +627,7 @@ impl OrdersQueryRow {
             is_liquidity_order: self.is_liquidity_order,
         };
         let signing_scheme = self.signing_scheme.into();
-        let order_creation = OrderCreation {
+        let data = OrderData {
             sell_token: h160_from_vec(self.sell_token)?,
             buy_token: h160_from_vec(self.buy_token)?,
             receiver: self.receiver.map(h160_from_vec).transpose()?,
@@ -647,13 +645,14 @@ impl OrdersQueryRow {
                 .ok_or_else(|| anyhow!("fee_amount is not U256"))?,
             kind: self.kind.into(),
             partially_fillable: self.partially_fillable,
-            signature: Signature::from_bytes(signing_scheme, &self.signature)?,
             sell_token_balance: self.sell_token_balance.into(),
             buy_token_balance: self.buy_token_balance.into(),
         };
+        let signature = Signature::from_bytes(signing_scheme, &self.signature)?;
         Ok(Order {
-            metadata: order_metadata,
-            creation: order_creation,
+            metadata,
+            data,
+            signature,
         })
     }
 }
@@ -908,7 +907,7 @@ mod tests {
         db.insert_order(&order, Default::default()).await.unwrap();
 
         // Note that order UIDs do not care about the signing scheme.
-        order.creation.signature = Signature::default_with(SigningScheme::PreSign);
+        order.signature = Signature::default_with(SigningScheme::PreSign);
         assert!(matches!(
             db.insert_order(&order, Default::default()).await,
             Err(InsertionError::DuplicatedRecord)
@@ -966,7 +965,7 @@ mod tests {
                     },
                     ..Default::default()
                 },
-                creation: OrderCreation {
+                data: OrderData {
                     sell_token: H160::from_low_u64_be(1),
                     buy_token: H160::from_low_u64_be(2),
                     receiver: Some(H160::from_low_u64_be(6)),
@@ -977,10 +976,10 @@ mod tests {
                     fee_amount: 5.into(),
                     kind: OrderKind::Sell,
                     partially_fillable: true,
-                    signature: Signature::default_with(*signing_scheme),
                     sell_token_balance: SellTokenSource::Erc20,
                     buy_token_balance: BuyTokenDestination::Internal,
                 },
+                signature: Signature::default_with(*signing_scheme),
             };
             db.insert_order(&order, Default::default()).await.unwrap();
             assert_eq!(db.orders(&filter).await.unwrap(), vec![order]);
@@ -1161,12 +1160,13 @@ mod tests {
                     status: OrderStatus::Expired,
                     ..Default::default()
                 },
-                creation: OrderCreation {
+                data: OrderData {
                     sell_token: H160::from_low_u64_be(1),
                     buy_token: H160::from_low_u64_be(2),
                     valid_to: 10,
                     ..Default::default()
                 },
+                ..Default::default()
             },
             Order {
                 metadata: OrderMetadata {
@@ -1175,12 +1175,13 @@ mod tests {
                     status: OrderStatus::Expired,
                     ..Default::default()
                 },
-                creation: OrderCreation {
+                data: OrderData {
                     sell_token: H160::from_low_u64_be(1),
                     buy_token: H160::from_low_u64_be(3),
                     valid_to: 11,
                     ..Default::default()
                 },
+                ..Default::default()
             },
             Order {
                 metadata: OrderMetadata {
@@ -1189,12 +1190,13 @@ mod tests {
                     status: OrderStatus::Expired,
                     ..Default::default()
                 },
-                creation: OrderCreation {
+                data: OrderData {
                     sell_token: H160::from_low_u64_be(1),
                     buy_token: H160::from_low_u64_be(3),
                     valid_to: 12,
                     ..Default::default()
                 },
+                ..Default::default()
             },
         ];
         for order in orders.iter() {
@@ -1283,13 +1285,13 @@ mod tests {
         db.clear().await.unwrap();
 
         let order = Order {
-            metadata: Default::default(),
-            creation: OrderCreation {
+            data: OrderData {
                 kind: OrderKind::Sell,
                 sell_amount: 10.into(),
                 buy_amount: 100.into(),
                 ..Default::default()
             },
+            ..Default::default()
         };
         db.insert_order(&order, Default::default()).await.unwrap();
 
@@ -1382,11 +1384,11 @@ mod tests {
         db.clear().await.unwrap();
 
         let order = Order {
-            metadata: Default::default(),
-            creation: OrderCreation {
+            data: OrderData {
                 kind: OrderKind::Sell,
                 ..Default::default()
             },
+            ..Default::default()
         };
         db.insert_order(&order, Default::default()).await.unwrap();
 
@@ -1508,13 +1510,13 @@ mod tests {
         db.clear().await.unwrap();
 
         let order = Order {
-            metadata: Default::default(),
-            creation: OrderCreation {
+            data: OrderData {
                 sell_amount: 1.into(),
                 buy_amount: 1.into(),
-                signature: Signature::default_with(SigningScheme::PreSign),
                 ..Default::default()
             },
+            signature: Signature::default_with(SigningScheme::PreSign),
+            ..Default::default()
         };
         db.insert_order(&order, Default::default()).await.unwrap();
 
@@ -1604,8 +1606,7 @@ mod tests {
         db.clear().await.unwrap();
 
         let order = Order {
-            metadata: Default::default(),
-            creation: OrderCreation {
+            data: OrderData {
                 kind: OrderKind::Sell,
                 sell_amount: 10.into(),
                 buy_amount: 100.into(),
@@ -1613,6 +1614,7 @@ mod tests {
                 partially_fillable: true,
                 ..Default::default()
             },
+            ..Default::default()
         };
         db.insert_order(&order, Default::default()).await.unwrap();
 
@@ -1720,14 +1722,14 @@ mod tests {
         db.clear().await.unwrap();
         let uid = OrderUid([0u8; 56]);
         let order = Order {
-            creation: OrderCreation {
-                signature: Signature::default_with(SigningScheme::PreSign),
+            data: OrderData {
                 ..Default::default()
             },
             metadata: OrderMetadata {
                 uid,
                 ..Default::default()
             },
+            signature: Signature::default_with(SigningScheme::PreSign),
         };
         db.insert_order(&order, Default::default()).await.unwrap();
 
@@ -1795,14 +1797,14 @@ mod tests {
         db.clear().await.unwrap();
         let order_uid = |uid: u8| OrderUid([uid; 56]);
         let order = |uid: u8, scheme: SigningScheme| Order {
-            creation: OrderCreation {
-                signature: Signature::default_with(scheme),
+            data: OrderData {
                 ..Default::default()
             },
             metadata: OrderMetadata {
                 uid: order_uid(uid),
                 ..Default::default()
             },
+            signature: Signature::default_with(scheme),
         };
 
         db.insert_order(&order(0, SigningScheme::Eip712), Default::default())
@@ -1968,7 +1970,7 @@ mod tests {
                     uid: OrderUid::from_integer(i),
                     ..Default::default()
                 },
-                creation: Default::default(),
+                ..Default::default()
             })
             .collect();
 

--- a/crates/orderbook/src/database/trades.rs
+++ b/crates/orderbook/src/database/trades.rs
@@ -122,7 +122,7 @@ mod tests {
     };
     use ethcontract::H256;
     use model::{
-        order::{Order, OrderCreation, OrderMetadata},
+        order::{Order, OrderData, OrderMetadata},
         trade::Trade,
     };
     use shared::event_handling::EventIndex;
@@ -178,9 +178,10 @@ mod tests {
                 uid: order_uid,
                 ..Default::default()
             },
-            creation: OrderCreation {
+            data: OrderData {
                 ..Default::default()
             },
+            ..Default::default()
         };
         db.insert_order(&order, Default::default()).await.unwrap();
         add_trade(db, owner, order_uid, event_index, tx_hash).await

--- a/crates/orderbook/src/lib.rs
+++ b/crates/orderbook/src/lib.rs
@@ -58,7 +58,7 @@ pub async fn verify_deployed_contract_constants(
         return Err(anyhow!("Bytecode did not contain domain separator"));
     }
 
-    if !bytecode.contains(&hex::encode(model::order::OrderCreation::TYPE_HASH)) {
+    if !bytecode.contains(&hex::encode(model::order::OrderData::TYPE_HASH)) {
         return Err(anyhow!("Bytecode did not contain order type hash"));
     }
     Ok(())

--- a/crates/orderbook/src/orderbook.rs
+++ b/crates/orderbook/src/orderbook.rs
@@ -8,7 +8,7 @@ use chrono::Utc;
 use ethcontract::H256;
 use model::{
     auction::Auction,
-    order::{Order, OrderCancellation, OrderCreationPayload, OrderStatus, OrderUid},
+    order::{Order, OrderCancellation, OrderCreation, OrderStatus, OrderUid},
     DomainSeparator,
 };
 use primitive_types::H160;
@@ -150,7 +150,7 @@ impl Orderbook {
 
     pub async fn add_order(
         &self,
-        payload: OrderCreationPayload,
+        payload: OrderCreation,
     ) -> Result<OrderUid, AddOrderError> {
         let (order, fee) = self
             .order_validator
@@ -223,7 +223,7 @@ impl Orderbook {
     pub async fn replace_order(
         &self,
         old_order: OrderUid,
-        new_order: OrderCreationPayload,
+        new_order: OrderCreation,
     ) -> Result<OrderUid, ReplaceOrderError> {
         // Replacement order signatures need to be validated meaning we cannot
         // accept `PreSign` orders, otherwise anyone can cancel a user order by
@@ -497,7 +497,7 @@ mod tests {
             orderbook
                 .replace_order(
                     old_order.metadata.uid,
-                    OrderCreationPayload {
+                    OrderCreation {
                         signature: CreationSignature::Eip712 {
                             from: Some(old_order.metadata.owner),
                             signature: Default::default(),
@@ -514,7 +514,7 @@ mod tests {
             orderbook
                 .replace_order(
                     old_order.metadata.uid,
-                    OrderCreationPayload {
+                    OrderCreation {
                         signature: CreationSignature::Eip712 {
                             from: Some(H160([2; 20])),
                             signature: Default::default(),
@@ -535,7 +535,7 @@ mod tests {
             orderbook
                 .replace_order(
                     old_order.metadata.uid,
-                    OrderCreationPayload {
+                    OrderCreation {
                         signature: CreationSignature::PreSign {
                             from: old_order.metadata.owner,
                         },
@@ -555,7 +555,7 @@ mod tests {
             orderbook
                 .replace_order(
                     old_order.metadata.uid,
-                    OrderCreationPayload {
+                    OrderCreation {
                         signature: CreationSignature::Eip712 {
                             from: Some(old_order.metadata.owner),
                             signature: Default::default(),

--- a/crates/orderbook/src/solvable_orders.rs
+++ b/crates/orderbook/src/solvable_orders.rs
@@ -353,7 +353,7 @@ async fn get_orders_with_native_prices(
 ) -> (Vec<Order>, BTreeMap<H160, U256>) {
     let traded_tokens = orders
         .iter()
-        .flat_map(|order| [order.creation.sell_token, order.creation.buy_token])
+        .flat_map(|order| [order.data.sell_token, order.data.buy_token])
         .collect::<HashSet<_>>()
         .into_iter()
         .collect::<Vec<_>>();
@@ -395,7 +395,7 @@ async fn get_orders_with_native_prices(
     // have orders.
     let mut used_prices = BTreeMap::new();
     orders.retain(|order| {
-        let (t0, t1) = (&order.creation.sell_token, &order.creation.buy_token);
+        let (t0, t1) = (&order.data.sell_token, &order.data.buy_token);
         match (prices.get(t0), prices.get(t1)) {
             (Some(p0), Some(p1)) => {
                 used_prices.insert(*t0, *p0);
@@ -440,7 +440,7 @@ mod tests {
     use chrono::{DateTime, NaiveDateTime, Utc};
     use futures::StreamExt;
     use maplit::{btreemap, hashmap, hashset};
-    use model::order::{OrderBuilder, OrderCreation, OrderKind, OrderMetadata, SellTokenSource};
+    use model::order::{OrderBuilder, OrderData, OrderKind, OrderMetadata, SellTokenSource};
     use primitive_types::H160;
     use shared::price_estimation::{native::MockNativePriceEstimating, PriceEstimationError};
 
@@ -448,7 +448,7 @@ mod tests {
     async fn filters_insufficient_balances() {
         let mut orders = vec![
             Order {
-                creation: OrderCreation {
+                data: OrderData {
                     sell_amount: 3.into(),
                     fee_amount: 3.into(),
                     ..Default::default()
@@ -457,9 +457,10 @@ mod tests {
                     creation_date: DateTime::from_utc(NaiveDateTime::from_timestamp(2, 0), Utc),
                     ..Default::default()
                 },
+                ..Default::default()
             },
             Order {
-                creation: OrderCreation {
+                data: OrderData {
                     sell_amount: 2.into(),
                     fee_amount: 2.into(),
                     ..Default::default()
@@ -468,6 +469,7 @@ mod tests {
                     creation_date: DateTime::from_utc(NaiveDateTime::from_timestamp(0, 0), Utc),
                     ..Default::default()
                 },
+                ..Default::default()
             },
         ];
 
@@ -495,7 +497,7 @@ mod tests {
 
         let orders = [
             Order {
-                creation: OrderCreation {
+                data: OrderData {
                     sell_token: sell_token_0,
                     sell_token_balance: SellTokenSource::Erc20,
                     sell_amount: 1.into(),
@@ -506,9 +508,10 @@ mod tests {
                     owner,
                     ..Default::default()
                 },
+                ..Default::default()
             },
             Order {
-                creation: OrderCreation {
+                data: OrderData {
                     sell_token: sell_token_1,
                     sell_token_balance: SellTokenSource::Erc20,
                     sell_amount: 1.into(),
@@ -519,6 +522,7 @@ mod tests {
                     owner,
                     ..Default::default()
                 },
+                ..Default::default()
             },
         ];
 
@@ -732,7 +736,7 @@ mod tests {
         // orders (where `{sell,fee}_amount * buy_amount` would overflow).
         assert_eq!(
             max_transfer_out_amount(&Order {
-                creation: OrderCreation {
+                data: OrderData {
                     sell_amount: 1000.into(),
                     fee_amount: 337.into(),
                     buy_amount: U256::MAX,
@@ -749,7 +753,7 @@ mod tests {
         // Partially filled order scales amount.
         assert_eq!(
             max_transfer_out_amount(&Order {
-                creation: OrderCreation {
+                data: OrderData {
                     sell_amount: 100.into(),
                     buy_amount: 10.into(),
                     fee_amount: 101.into(),
@@ -761,6 +765,7 @@ mod tests {
                     executed_buy_amount: 9_u32.into(),
                     ..Default::default()
                 },
+                ..Default::default()
             })
             .unwrap(),
             U256::from(20),
@@ -773,7 +778,7 @@ mod tests {
         // overflows a uint. This kind of order cannot be filled by the
         // settlement contract anyway.
         assert!(max_transfer_out_amount(&Order {
-            creation: OrderCreation {
+            data: OrderData {
                 sell_amount: U256::MAX,
                 fee_amount: 1.into(),
                 partially_fillable: false,
@@ -785,7 +790,7 @@ mod tests {
 
         // Handles overflow when computing fill ratio.
         assert!(max_transfer_out_amount(&Order {
-            creation: OrderCreation {
+            data: OrderData {
                 sell_amount: 1000.into(),
                 fee_amount: 337.into(),
                 buy_amount: U256::MAX,
@@ -842,8 +847,8 @@ mod tests {
         // for the tokens.
         assert!(orders_[0] == orders[0] || orders_[0] == orders[1]);
         assert_eq!(prices.len(), 2);
-        assert!(prices.contains_key(&orders_[0].creation.sell_token));
-        assert!(prices.contains_key(&orders_[0].creation.buy_token));
+        assert!(prices.contains_key(&orders_[0].data.sell_token));
+        assert!(prices.contains_key(&orders_[0].data.buy_token));
     }
 
     #[test]
@@ -864,11 +869,12 @@ mod tests {
                 owner,
                 ..Default::default()
             },
-            creation: OrderCreation {
+            data: OrderData {
                 buy_amount: 1.into(),
                 sell_amount: 1.into(),
                 ..Default::default()
             },
+            ..Default::default()
         })
         .collect();
 
@@ -888,7 +894,7 @@ mod tests {
         let orders = vec![
             // normal order with non zero amounts
             Order {
-                creation: OrderCreation {
+                data: OrderData {
                     buy_amount: 1u8.into(),
                     sell_amount: 1u8.into(),
                     ..Default::default()
@@ -897,7 +903,7 @@ mod tests {
             },
             // partially fillable order with remaining liquidity
             Order {
-                creation: OrderCreation {
+                data: OrderData {
                     partially_fillable: true,
                     buy_amount: 1u8.into(),
                     sell_amount: 1u8.into(),
@@ -914,12 +920,13 @@ mod tests {
                     executed_sell_amount: 1u8.into(),
                     ..Default::default()
                 },
-                creation: OrderCreation {
+                data: OrderData {
                     partially_fillable: true,
                     buy_amount: 1u8.into(),
                     sell_amount: 1u8.into(),
                     ..Default::default()
                 },
+                ..Default::default()
             },
         ];
 

--- a/crates/solver/src/analytics.rs
+++ b/crates/solver/src/analytics.rs
@@ -90,8 +90,8 @@ pub fn report_alternative_settlement_surplus(
         .order_trades()
         .iter()
         .map(|order_trade| {
-            let sell_token_price = &submitted_prices[&order_trade.trade.order.creation.sell_token];
-            let buy_token_price = &submitted_prices[&order_trade.trade.order.creation.buy_token];
+            let sell_token_price = &submitted_prices[&order_trade.trade.order.data.sell_token];
+            let buy_token_price = &submitted_prices[&order_trade.trade.order.data.buy_token];
             (
                 order_trade.trade.order.metadata.uid,
                 SurplusInfo {
@@ -132,8 +132,8 @@ fn best_surplus_by_order(
         let clearing_prices = get_prices(&solution.settlement);
         for order_trade in trades {
             let order_id = order_trade.trade.order.metadata.uid;
-            let sell_token_price = &clearing_prices[&order_trade.trade.order.creation.sell_token];
-            let buy_token_price = &clearing_prices[&order_trade.trade.order.creation.buy_token];
+            let sell_token_price = &clearing_prices[&order_trade.trade.order.data.sell_token];
+            let buy_token_price = &clearing_prices[&order_trade.trade.order.data.buy_token];
             let surplus = SurplusInfo {
                 solver_name: solver.name().to_string(),
                 ratio: order_trade

--- a/crates/solver/src/driver.rs
+++ b/crates/solver/src/driver.rs
@@ -178,7 +178,7 @@ impl Driver {
         {
             let mut group = group.into_iter().peekable();
             let order = &group.peek().unwrap().order;
-            let was_already_filled = match order.creation.kind {
+            let was_already_filled = match order.data.kind {
                 OrderKind::Buy => &order.metadata.executed_buy_amount,
                 OrderKind::Sell => &order.metadata.executed_sell_amount,
             } > &0u8.into();
@@ -809,7 +809,7 @@ impl Driver {
 fn is_only_selling_trusted_tokens(settlement: &Settlement, token_list: &TokenList) -> bool {
     !settlement
         .traded_orders()
-        .any(|order| token_list.get(&order.creation.sell_token).is_none())
+        .any(|order| token_list.get(&order.data.sell_token).is_none())
 }
 
 fn print_settlements(
@@ -860,7 +860,7 @@ mod tests {
         solver::dummy_arc_solver,
     };
     use maplit::hashmap;
-    use model::order::{Order, OrderCreation};
+    use model::order::{Order, OrderData};
     use shared::token_list::Token;
     use std::collections::HashMap;
 
@@ -888,7 +888,7 @@ mod tests {
         let trade = |token| OrderTrade {
             trade: Trade {
                 order: Order {
-                    creation: OrderCreation {
+                    data: OrderData {
                         sell_token: token,
                         ..Default::default()
                     },

--- a/crates/solver/src/driver/solver_settlements.rs
+++ b/crates/solver/src/driver/solver_settlements.rs
@@ -174,7 +174,7 @@ mod tests {
     use crate::solver::dummy_arc_solver;
     use chrono::{offset::Utc, DateTime, Duration, Local};
     use maplit::hashmap;
-    use model::order::{Order, OrderCreation, OrderKind, OrderMetadata, OrderUid};
+    use model::order::{Order, OrderData, OrderKind, OrderMetadata, OrderUid};
     use num::{BigRational, One as _};
     use primitive_types::{H160, U256};
     use std::collections::HashSet;
@@ -353,7 +353,7 @@ mod tests {
                         uid: uid(uid_),
                         ..Default::default()
                     },
-                    creation: OrderCreation {
+                    data: OrderData {
                         sell_token: token0,
                         buy_token: token1,
                         sell_amount: executed_amount,
@@ -361,6 +361,7 @@ mod tests {
                         kind: OrderKind::Buy,
                         ..Default::default()
                     },
+                    ..Default::default()
                 },
                 ..Default::default()
             },

--- a/crates/solver/src/solver/balancer_sor_solver.rs
+++ b/crates/solver/src/solver/balancer_sor_solver.rs
@@ -225,7 +225,7 @@ mod tests {
     use crate::interactions::allowances::{AllowanceManager, Approval, MockAllowanceManaging};
     use ethcontract::{H160, H256};
     use mockall::predicate::*;
-    use model::order::{Order, OrderCreation};
+    use model::order::{Order, OrderData};
     use reqwest::Client;
     use shared::{
         addr,
@@ -320,7 +320,7 @@ mod tests {
         let result = solver
             .try_settle_order(
                 Order {
-                    creation: OrderCreation {
+                    data: OrderData {
                         sell_token,
                         buy_token,
                         sell_amount,
@@ -442,7 +442,7 @@ mod tests {
         let result = solver
             .try_settle_order(
                 Order {
-                    creation: OrderCreation {
+                    data: OrderData {
                         sell_token,
                         buy_token,
                         sell_amount,
@@ -547,7 +547,7 @@ mod tests {
         let sell_settlement = solver
             .try_settle_order(
                 Order {
-                    creation: OrderCreation {
+                    data: OrderData {
                         sell_token: addr!("ba100000625a3754423978a60c9317c58a424e3d"),
                         buy_token: addr!("6b175474e89094c44da98b954eedeac495271d0f"),
                         sell_amount: 1_000_000_000_000_000_000_u128.into(),
@@ -571,7 +571,7 @@ mod tests {
         let buy_settlement = solver
             .try_settle_order(
                 Order {
-                    creation: OrderCreation {
+                    data: OrderData {
                         sell_token: addr!("ba100000625a3754423978a60c9317c58a424e3d"),
                         buy_token: addr!("6b175474e89094c44da98b954eedeac495271d0f"),
                         sell_amount: u128::MAX.into(),

--- a/crates/solver/src/solver/naive_solver.rs
+++ b/crates/solver/src/solver/naive_solver.rs
@@ -107,7 +107,7 @@ mod tests {
     use crate::liquidity::tests::CapturingSettlementHandler;
     use ethcontract::H160;
     use maplit::hashmap;
-    use model::order::{Order, OrderCreation, OrderKind};
+    use model::order::{Order, OrderData, OrderKind};
     use num::rational::Ratio;
     use shared::addr;
 
@@ -167,7 +167,7 @@ mod tests {
 
         let orders = vec![
             LimitOrder::from(Order {
-                creation: OrderCreation {
+                data: OrderData {
                     sell_token: addr!("d533a949740bb3306d119cc777fa900ba034cd52"),
                     buy_token: addr!("a0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"),
                     sell_amount: 995952859647034749952_u128.into(),
@@ -180,7 +180,7 @@ mod tests {
             LimitOrder {
                 is_liquidity_order: true,
                 ..LimitOrder::from(Order {
-                    creation: OrderCreation {
+                    data: OrderData {
                         sell_token: addr!("a0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"),
                         buy_token: addr!("d533a949740bb3306d119cc777fa900ba034cd52"),
                         sell_amount: 2469904889_u128.into(),

--- a/crates/solver/src/solver/naive_solver/multi_order_solver.rs
+++ b/crates/solver/src/solver/naive_solver/multi_order_solver.rs
@@ -280,7 +280,7 @@ fn compute_uniswap_in(
 ///
 fn is_valid_solution(solution: &Settlement) -> bool {
     for order in solution.traded_orders() {
-        let order = &order.creation;
+        let order = &order.data;
         let buy_token_price = solution
             .clearing_price(order.buy_token)
             .expect("Solution should contain clearing price for buy token");
@@ -305,7 +305,7 @@ mod tests {
     use liquidity::tests::CapturingSettlementHandler;
     use maplit::hashmap;
     use model::{
-        order::{Order, OrderCreation},
+        order::{Order, OrderData},
         TokenPair,
     };
     use num::rational::Ratio;
@@ -591,7 +591,7 @@ mod tests {
         let orders = vec![
             // Unreasonable order a -> b
             Order {
-                creation: OrderCreation {
+                data: OrderData {
                     sell_token: token_a,
                     buy_token: token_b,
                     sell_amount: to_wei(1),
@@ -605,7 +605,7 @@ mod tests {
             .into(),
             // Reasonable order a -> b
             Order {
-                creation: OrderCreation {
+                data: OrderData {
                     sell_token: token_a,
                     buy_token: token_b,
                     sell_amount: to_wei(1000),
@@ -619,7 +619,7 @@ mod tests {
             .into(),
             // Reasonable order b -> a
             Order {
-                creation: OrderCreation {
+                data: OrderData {
                     sell_token: token_b,
                     buy_token: token_a,
                     sell_amount: to_wei(1000),
@@ -633,7 +633,7 @@ mod tests {
             .into(),
             // Unreasonable order b -> a
             Order {
-                creation: OrderCreation {
+                data: OrderData {
                     sell_token: token_b,
                     buy_token: token_a,
                     sell_amount: to_wei(2),
@@ -666,7 +666,7 @@ mod tests {
         let token_b = Address::from_low_u64_be(1);
         let orders = vec![
             Order {
-                creation: OrderCreation {
+                data: OrderData {
                     sell_token: token_a,
                     buy_token: token_b,
                     sell_amount: to_wei(900),
@@ -679,7 +679,7 @@ mod tests {
             }
             .into(),
             Order {
-                creation: OrderCreation {
+                data: OrderData {
                     sell_token: token_b,
                     buy_token: token_a,
                     sell_amount: to_wei(900),
@@ -709,7 +709,7 @@ mod tests {
         let token_b = Address::from_low_u64_be(1);
         let orders = vec![
             Order {
-                creation: OrderCreation {
+                data: OrderData {
                     sell_token: token_a,
                     buy_token: token_b,
                     sell_amount: to_wei(10),
@@ -721,7 +721,7 @@ mod tests {
                 ..Default::default()
             },
             Order {
-                creation: OrderCreation {
+                data: OrderData {
                     sell_token: token_b,
                     buy_token: token_a,
                     sell_amount: to_wei(10),
@@ -792,7 +792,7 @@ mod tests {
         let token_b = Address::from_low_u64_be(1);
         let orders = vec![
             Order {
-                creation: OrderCreation {
+                data: OrderData {
                     sell_token: token_a,
                     buy_token: token_b,
                     sell_amount: U256::MAX,
@@ -805,7 +805,7 @@ mod tests {
             }
             .into(),
             Order {
-                creation: OrderCreation {
+                data: OrderData {
                     sell_token: token_b,
                     buy_token: token_a,
                     sell_amount: 1.into(),
@@ -836,7 +836,7 @@ mod tests {
         let token_b = Address::from_low_u64_be(1);
         let orders = vec![
             Order {
-                creation: OrderCreation {
+                data: OrderData {
                     sell_token: token_a,
                     buy_token: token_b,
                     sell_amount: 70145218378783248142575u128.into(),
@@ -849,7 +849,7 @@ mod tests {
             }
             .into(),
             Order {
-                creation: OrderCreation {
+                data: OrderData {
                     sell_token: token_a,
                     buy_token: token_b,
                     sell_amount: 900_000_000_000_000u128.into(),
@@ -884,7 +884,7 @@ mod tests {
         let token_b = Address::from_low_u64_be(1);
         let orders = vec![
             Order {
-                creation: OrderCreation {
+                data: OrderData {
                     sell_token: token_a,
                     buy_token: token_b,
                     sell_amount: 9_000_000.into(),
@@ -897,7 +897,7 @@ mod tests {
             }
             .into(),
             Order {
-                creation: OrderCreation {
+                data: OrderData {
                     buy_token: token_a,
                     sell_token: token_b,
                     buy_amount: 8_000_001.into(),

--- a/crates/solver/src/solver/oneinch_solver.rs
+++ b/crates/solver/src/solver/oneinch_solver.rs
@@ -188,7 +188,7 @@ mod tests {
     use contracts::{GPv2Settlement, WETH9};
     use ethcontract::{Web3, H160, U256};
     use mockall::{predicate::*, Sequence};
-    use model::order::{Order, OrderCreation, OrderKind};
+    use model::order::{Order, OrderData, OrderKind};
     use shared::oneinch_api::{MockOneInchClient, Protocols, Spender};
     use shared::{dummy_contract, transport::create_env_test_transport};
 
@@ -441,7 +441,7 @@ mod tests {
         let settlement = solver
             .settle_order_with_protocols(
                 Order {
-                    creation: OrderCreation {
+                    data: OrderData {
                         sell_token: weth.address(),
                         buy_token: gno,
                         sell_amount: 1_000_000_000_000_000_000u128.into(),

--- a/crates/solver/src/solver/paraswap_solver.rs
+++ b/crates/solver/src/solver/paraswap_solver.rs
@@ -210,7 +210,7 @@ mod tests {
     use contracts::WETH9;
     use ethcontract::U256;
     use mockall::{predicate::*, Sequence};
-    use model::order::{Order, OrderCreation, OrderKind};
+    use model::order::{Order, OrderData, OrderKind};
     use reqwest::Client;
     use shared::{
         dummy_contract,
@@ -548,7 +548,7 @@ mod tests {
         let settlement = solver
             .try_settle_order(
                 Order {
-                    creation: OrderCreation {
+                    data: OrderData {
                         sell_token: weth.address(),
                         buy_token: gno,
                         sell_amount: 1_000_000_000_000_000_000u128.into(),

--- a/crates/solver/src/solver/uni_v3_router_solver.rs
+++ b/crates/solver/src/solver/uni_v3_router_solver.rs
@@ -107,7 +107,7 @@ impl SingleOrderSolving for UniV3RouterSolver {
 mod tests {
     use super::*;
     use contracts::WETH9;
-    use model::order::{Order, OrderCreation};
+    use model::order::{Order, OrderData};
 
     #[tokio::test]
     #[ignore]
@@ -130,7 +130,7 @@ mod tests {
         let settlement = solver
             .try_settle_order(
                 Order {
-                    creation: OrderCreation {
+                    data: OrderData {
                         sell_token: weth.address(),
                         buy_token: testlib::tokens::DAI,
                         sell_amount: U256::from_f64_lossy(1e18),

--- a/crates/solver/src/solver/zeroex_solver.rs
+++ b/crates/solver/src/solver/zeroex_solver.rs
@@ -168,7 +168,7 @@ mod tests {
     use ethcontract::{Web3, H160, U256};
     use mockall::predicate::*;
     use mockall::Sequence;
-    use model::order::{Order, OrderCreation, OrderKind};
+    use model::order::{Order, OrderData, OrderKind};
     use shared::transport::{create_env_test_transport, create_test_transport};
     use shared::zeroex_api::{DefaultZeroExApi, MockZeroExApi, PriceResponse};
 
@@ -195,7 +195,7 @@ mod tests {
         let settlement = solver
             .try_settle_order(
                 Order {
-                    creation: OrderCreation {
+                    data: OrderData {
                         sell_token: weth.address(),
                         buy_token: gno,
                         sell_amount: 1_000_000_000_000_000_000u128.into(),
@@ -237,7 +237,7 @@ mod tests {
         let settlement = solver
             .try_settle_order(
                 Order {
-                    creation: OrderCreation {
+                    data: OrderData {
                         sell_token: weth.address(),
                         buy_token: gno,
                         sell_amount: 1_000_000_000_000_000_000u128.into(),


### PR DESCRIPTION
Following up on the changes in #250 with the addition of EIP-1271 signature.

We're trying to find a suitable way to alter the Signature & Order types to have an aligned way to validate & recover addresses off-chain and on-chain (for `EIP-1271`)