### PR TITLE
Make amount check more strict

### DIFF
--- a/crates/alerter/src/main.rs
+++ b/crates/alerter/src/main.rs
@@ -122,10 +122,7 @@ impl ZeroExApi {
 
         tracing::debug!(url = url.as_str(), ?response, "0x");
 
-        Ok(match order.kind {
-            OrderKind::Buy => order.sell_amount >= response.sell_amount,
-            OrderKind::Sell => order.buy_amount <= response.buy_amount,
-        })
+        Ok(response.sell_amount <= order.sell_amount && response.buy_amount >= order.buy_amount)
     }
 }
 


### PR DESCRIPTION
Part of https://github.com/cowprotocol/services/issues/254

As commented here https://github.com/cowprotocol/services/blob/29cee54830831726bec5e4120867292fd2dff4b2/crates/solver/src/solver/single_order_solver.rs#L120 we previously discovered that sometimes these apis do not respect the input amount. This updates the alerter with the same check.

I found this when going through alerts that the alerter emitted and manually checking the solver logs for this order which lead to a false positive alert before.

### Test Plan

CI