### PR TITLE
Fix cancelling of transactions

### DIFF
--- a/crates/solver/src/settlement_submission/submitter/custom_nodes_api.rs
+++ b/crates/solver/src/settlement_submission/submitter/custom_nodes_api.rs
@@ -5,12 +5,9 @@ use super::{
     AdditionalTip, DisabledReason, Strategy, SubmissionLoopStatus,
 };
 use anyhow::Result;
-use ethcontract::{
-    dyns::DynTransport,
-    transaction::{Transaction, TransactionBuilder},
-};
+use ethcontract::transaction::{Transaction, TransactionBuilder};
 use futures::FutureExt;
-use shared::Web3;
+use shared::{Web3, Web3Transport};
 
 const ALREADY_KNOWN_TRANSACTION: &[&str] = &[
     "Transaction gas price supplied is too low", //openethereum
@@ -36,7 +33,7 @@ impl CustomNodesApi {
 impl TransactionSubmitting for CustomNodesApi {
     async fn submit_transaction(
         &self,
-        tx: TransactionBuilder<DynTransport>,
+        tx: TransactionBuilder<Web3Transport>,
     ) -> Result<TransactionHandle> {
         tracing::debug!("Custom nodes submit transaction entered");
         let transaction_request = tx.build().now_or_never().unwrap().unwrap();
@@ -102,7 +99,7 @@ impl TransactionSubmitting for CustomNodesApi {
 
     async fn cancel_transaction(
         &self,
-        tx: TransactionBuilder<DynTransport>,
+        tx: TransactionBuilder<Web3Transport>,
     ) -> Result<TransactionHandle> {
         self.submit_transaction(tx).await
     }

--- a/crates/solver/src/settlement_submission/submitter/custom_nodes_api.rs
+++ b/crates/solver/src/settlement_submission/submitter/custom_nodes_api.rs
@@ -2,7 +2,7 @@ use crate::settlement::{Revertable, Settlement};
 
 use super::{
     super::submitter::{TransactionHandle, TransactionSubmitting},
-    AdditionalTip, CancelHandle, DisabledReason, Strategy, SubmissionLoopStatus,
+    AdditionalTip, DisabledReason, Strategy, SubmissionLoopStatus,
 };
 use anyhow::Result;
 use ethcontract::{
@@ -100,8 +100,11 @@ impl TransactionSubmitting for CustomNodesApi {
         }
     }
 
-    async fn cancel_transaction(&self, id: &CancelHandle) -> Result<TransactionHandle> {
-        self.submit_transaction(id.noop_transaction.clone()).await
+    async fn cancel_transaction(
+        &self,
+        tx: TransactionBuilder<DynTransport>,
+    ) -> Result<TransactionHandle> {
+        self.submit_transaction(tx).await
     }
 
     fn submission_status(&self, settlement: &Settlement, network_id: &str) -> SubmissionLoopStatus {

--- a/crates/solver/src/settlement_submission/submitter/flashbots_api.rs
+++ b/crates/solver/src/settlement_submission/submitter/flashbots_api.rs
@@ -6,9 +6,9 @@ use super::{
     AdditionalTip, Strategy, SubmissionLoopStatus,
 };
 use anyhow::{Context, Result};
-use ethcontract::{dyns::DynTransport, transaction::TransactionBuilder};
+use ethcontract::transaction::TransactionBuilder;
 use reqwest::{Client, IntoUrl};
-use shared::{transport::http::HttpTransport, Web3};
+use shared::{transport::http::HttpTransport, Web3, Web3Transport};
 
 #[derive(Clone)]
 pub struct FlashbotsApi {
@@ -17,7 +17,7 @@ pub struct FlashbotsApi {
 
 impl FlashbotsApi {
     pub fn new(client: Client, url: impl IntoUrl) -> Result<Self> {
-        let transport = DynTransport::new(HttpTransport::new(
+        let transport = Web3Transport::new(HttpTransport::new(
             client,
             url.into_url().context("bad flashbots url")?,
             "flashbots".to_owned(),
@@ -32,7 +32,7 @@ impl FlashbotsApi {
 impl TransactionSubmitting for FlashbotsApi {
     async fn submit_transaction(
         &self,
-        tx: TransactionBuilder<DynTransport>,
+        tx: TransactionBuilder<Web3Transport>,
     ) -> Result<TransactionHandle> {
         let result = self
             .rpc
@@ -48,7 +48,7 @@ impl TransactionSubmitting for FlashbotsApi {
     // https://docs.flashbots.net/flashbots-protect/rpc/cancellations
     async fn cancel_transaction(
         &self,
-        tx: TransactionBuilder<DynTransport>,
+        tx: TransactionBuilder<Web3Transport>,
     ) -> Result<TransactionHandle> {
         self.rpc
             .api::<PrivateNetwork>()


### PR DESCRIPTION
This PR fixes gas price for cancelling transactions. 

This has become extremely relevant now we have https://github.com/cowprotocol/services/pull/235 merged.

Also, some cleanup of `CancelHandle` since not needed anymore (all strategies are canceled using the noop transaction - no previous submitted transaction handle is needed).