### PR TITLE
Log fewer eden submission errors

### DIFF
--- a/crates/e2e/tests/e2e/eth_integration.rs
+++ b/crates/e2e/tests/e2e/eth_integration.rs
@@ -19,7 +19,8 @@ use solver::{
     metrics::NoopMetrics,
     settlement_access_list::{create_priority_estimator, AccessListEstimatorType},
     settlement_submission::{
-        submitter::custom_nodes_api::CustomNodesApi, GlobalTxPool, SolutionSubmitter, StrategyArgs,
+        submitter::{custom_nodes_api::CustomNodesApi, Strategy},
+        GlobalTxPool, SolutionSubmitter, StrategyArgs,
     },
 };
 use std::{sync::Arc, time::Duration};
@@ -229,7 +230,7 @@ async fn eth_integration(web3: Web3) {
                     submit_api: Box::new(CustomNodesApi::new(vec![web3.clone()])),
                     max_additional_tip: 0.,
                     additional_tip_percentage_of_max_fee: 0.,
-                    sub_tx_pool: submitted_transactions.add_sub_pool(),
+                    sub_tx_pool: submitted_transactions.add_sub_pool(Strategy::CustomNodes),
                 }),
             ],
             access_list_estimator: Arc::new(

--- a/crates/e2e/tests/e2e/onchain_settlement.rs
+++ b/crates/e2e/tests/e2e/onchain_settlement.rs
@@ -21,7 +21,8 @@ use solver::{
     metrics::NoopMetrics,
     settlement_access_list::{create_priority_estimator, AccessListEstimatorType},
     settlement_submission::{
-        submitter::custom_nodes_api::CustomNodesApi, GlobalTxPool, SolutionSubmitter, StrategyArgs,
+        submitter::{custom_nodes_api::CustomNodesApi, Strategy},
+        GlobalTxPool, SolutionSubmitter, StrategyArgs,
     },
 };
 use std::{sync::Arc, time::Duration};
@@ -234,7 +235,7 @@ async fn onchain_settlement(web3: Web3) {
                     submit_api: Box::new(CustomNodesApi::new(vec![web3.clone()])),
                     max_additional_tip: 0.,
                     additional_tip_percentage_of_max_fee: 0.,
-                    sub_tx_pool: submitted_transactions.add_sub_pool(),
+                    sub_tx_pool: submitted_transactions.add_sub_pool(Strategy::CustomNodes),
                 }),
             ],
             access_list_estimator: Arc::new(

--- a/crates/e2e/tests/e2e/settlement_without_onchain_liquidity.rs
+++ b/crates/e2e/tests/e2e/settlement_without_onchain_liquidity.rs
@@ -22,7 +22,8 @@ use solver::{
     metrics::NoopMetrics,
     settlement_access_list::{create_priority_estimator, AccessListEstimatorType},
     settlement_submission::{
-        submitter::custom_nodes_api::CustomNodesApi, GlobalTxPool, SolutionSubmitter, StrategyArgs,
+        submitter::{custom_nodes_api::CustomNodesApi, Strategy},
+        GlobalTxPool, SolutionSubmitter, StrategyArgs,
     },
 };
 use std::{sync::Arc, time::Duration};
@@ -223,7 +224,7 @@ async fn onchain_settlement_without_liquidity(web3: Web3) {
                     submit_api: Box::new(CustomNodesApi::new(vec![web3.clone()])),
                     max_additional_tip: 0.,
                     additional_tip_percentage_of_max_fee: 0.,
-                    sub_tx_pool: submitted_transactions.add_sub_pool(),
+                    sub_tx_pool: submitted_transactions.add_sub_pool(Strategy::CustomNodes),
                 }),
             ],
             access_list_estimator: Arc::new(

--- a/crates/e2e/tests/e2e/smart_contract_orders.rs
+++ b/crates/e2e/tests/e2e/smart_contract_orders.rs
@@ -12,7 +12,8 @@ use solver::{
     metrics::NoopMetrics,
     settlement_access_list::{create_priority_estimator, AccessListEstimatorType},
     settlement_submission::{
-        submitter::custom_nodes_api::CustomNodesApi, GlobalTxPool, SolutionSubmitter, StrategyArgs,
+        submitter::{custom_nodes_api::CustomNodesApi, Strategy},
+        GlobalTxPool, SolutionSubmitter, StrategyArgs,
     },
 };
 use std::{sync::Arc, time::Duration};
@@ -193,7 +194,7 @@ async fn smart_contract_orders(web3: Web3) {
                     submit_api: Box::new(CustomNodesApi::new(vec![web3.clone()])),
                     max_additional_tip: 0.,
                     additional_tip_percentage_of_max_fee: 0.,
-                    sub_tx_pool: submitted_transactions.add_sub_pool(),
+                    sub_tx_pool: submitted_transactions.add_sub_pool(Strategy::CustomNodes),
                 }),
             ],
             access_list_estimator: Arc::new(

--- a/crates/e2e/tests/e2e/vault_balances.rs
+++ b/crates/e2e/tests/e2e/vault_balances.rs
@@ -16,7 +16,8 @@ use solver::{
     metrics::NoopMetrics,
     settlement_access_list::{create_priority_estimator, AccessListEstimatorType},
     settlement_submission::{
-        submitter::custom_nodes_api::CustomNodesApi, GlobalTxPool, SolutionSubmitter, StrategyArgs,
+        submitter::{custom_nodes_api::CustomNodesApi, Strategy},
+        GlobalTxPool, SolutionSubmitter, StrategyArgs,
     },
 };
 use std::{sync::Arc, time::Duration};
@@ -173,7 +174,7 @@ async fn vault_balances(web3: Web3) {
                     submit_api: Box::new(CustomNodesApi::new(vec![web3.clone()])),
                     max_additional_tip: 0.,
                     additional_tip_percentage_of_max_fee: 0.,
-                    sub_tx_pool: submitted_transactions.add_sub_pool(),
+                    sub_tx_pool: submitted_transactions.add_sub_pool(Strategy::CustomNodes),
                 }),
             ],
             access_list_estimator: Arc::new(

--- a/crates/solver/src/main.rs
+++ b/crates/solver/src/main.rs
@@ -35,6 +35,7 @@ use solver::{
     settlement_submission::{
         submitter::{
             custom_nodes_api::CustomNodesApi, eden_api::EdenApi, flashbots_api::FlashbotsApi,
+            Strategy,
         },
         GlobalTxPool, SolutionSubmitter, StrategyArgs, TransactionStrategy,
     },
@@ -570,17 +571,22 @@ async fn main() {
                     submit_api: Box::new(CustomNodesApi::new(vec![web3.clone()])),
                     max_additional_tip: 0.,
                     additional_tip_percentage_of_max_fee: 0.,
-                    sub_tx_pool: submitted_transactions.add_sub_pool(),
+                    sub_tx_pool: submitted_transactions.add_sub_pool(Strategy::CustomNodes),
                 }))
             }
             TransactionStrategyArg::Eden => {
                 transaction_strategies.push(TransactionStrategy::Eden(StrategyArgs {
                     submit_api: Box::new(
-                        EdenApi::new(client.clone(), args.eden_api_url.clone()).unwrap(),
+                        EdenApi::new(
+                            client.clone(),
+                            args.eden_api_url.clone(),
+                            submitted_transactions.clone(),
+                        )
+                        .unwrap(),
                     ),
                     max_additional_tip: args.max_additional_eden_tip,
                     additional_tip_percentage_of_max_fee: args.additional_tip_percentage,
-                    sub_tx_pool: submitted_transactions.add_sub_pool(),
+                    sub_tx_pool: submitted_transactions.add_sub_pool(Strategy::Eden),
                 }))
             }
             TransactionStrategyArg::Flashbots => {
@@ -591,7 +597,7 @@ async fn main() {
                         ),
                         max_additional_tip: args.max_additional_flashbot_tip,
                         additional_tip_percentage_of_max_fee: args.additional_tip_percentage,
-                        sub_tx_pool: submitted_transactions.add_sub_pool(),
+                        sub_tx_pool: submitted_transactions.add_sub_pool(Strategy::Flashbots),
                     }))
                 }
             }
@@ -604,7 +610,7 @@ async fn main() {
                     submit_api: Box::new(CustomNodesApi::new(submission_nodes.clone())),
                     max_additional_tip: 0.,
                     additional_tip_percentage_of_max_fee: 0.,
-                    sub_tx_pool: submitted_transactions.add_sub_pool(),
+                    sub_tx_pool: submitted_transactions.add_sub_pool(Strategy::CustomNodes),
                 }))
             }
             TransactionStrategyArg::DryRun => {

--- a/crates/solver/src/settlement_submission/submitter/eden_api.rs
+++ b/crates/solver/src/settlement_submission/submitter/eden_api.rs
@@ -1,16 +1,20 @@
 //! https://docs.edennetwork.io/for-traders/getting-started
 
-use crate::settlement::{Revertable, Settlement};
-
-use super::{
-    super::submitter::{TransactionHandle, TransactionSubmitting},
-    common::PrivateNetwork,
-    AdditionalTip, Strategy, SubmissionLoopStatus,
+use crate::{
+    settlement::{Revertable, Settlement},
+    settlement_submission::{
+        submitter::{
+            common::PrivateNetwork, AdditionalTip, Strategy, SubmissionLoopStatus,
+            TransactionHandle, TransactionSubmitting,
+        },
+        GlobalTxPool,
+    },
 };
+
 use anyhow::{bail, Context, Result};
 use ethcontract::{
     transaction::{Transaction, TransactionBuilder},
-    H256,
+    H160, H256, U256,
 };
 use futures::{FutureExt, TryFutureExt};
 use reqwest::{Client, IntoUrl, Url};
@@ -29,6 +33,7 @@ pub struct EdenApi {
     client: Client,
     url: Url,
     rpc: Web3,
+    global_tx_pool: GlobalTxPool,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -36,8 +41,26 @@ struct EdenSuccess {
     result: H256,
 }
 
+fn biggest_public_nonce(global_tx_pool: &GlobalTxPool, address: H160) -> Option<U256> {
+    let mut biggest_nonce = None;
+
+    for sub_pool in global_tx_pool.pools.lock().unwrap().iter() {
+        if !matches!(sub_pool.strategy, Strategy::CustomNodes) {
+            // we are only interested in transactions from the public mempool
+            continue;
+        }
+
+        for (sender, nonce) in sub_pool.pools.keys() {
+            if sender == &address && nonce > &biggest_nonce.unwrap_or_default() {
+                biggest_nonce = Some(*nonce);
+            }
+        }
+    }
+    biggest_nonce
+}
+
 impl EdenApi {
-    pub fn new(client: Client, url: impl IntoUrl) -> Result<Self> {
+    pub fn new(client: Client, url: impl IntoUrl, global_tx_pool: GlobalTxPool) -> Result<Self> {
         let url = url.into_url().context("bad eden url")?;
         let transport = Web3Transport::new(HttpTransport::new(
             client.clone(),
@@ -46,7 +69,12 @@ impl EdenApi {
         ));
         let rpc = Web3::new(transport);
 
-        Ok(Self { client, url, rpc })
+        Ok(Self {
+            client,
+            url,
+            rpc,
+            global_tx_pool,
+        })
     }
 
     // When using `eth_sendSlotTx` method, we must use native Client because the response for this method
@@ -83,6 +111,37 @@ impl EdenApi {
             handle: response.result,
         })
     }
+
+    fn track_submission_success(
+        &self,
+        result: &Result<TransactionHandle>,
+        sender: H160,
+        nonce: U256,
+        tx_hash: H256,
+    ) {
+        match result {
+            Ok(_) => {
+                super::track_submission_success("eden", true);
+            }
+            Err(e) => {
+                let error = e.to_string();
+
+                let supposedly_already_known = ALREADY_KNOWN_TRANSACTION
+                    .iter()
+                    .any(|message| error.contains(message));
+
+                let publicly_submitted_bigger_nonce =
+                    biggest_public_nonce(&self.global_tx_pool, sender).unwrap_or_default() >= nonce;
+
+                if supposedly_already_known && publicly_submitted_bigger_nonce {
+                    tracing::debug!(?tx_hash, "transaction already known");
+                } else {
+                    tracing::warn!(?error, "transaction submission error");
+                    super::track_submission_success("eden", false);
+                }
+            }
+        }
+    }
 }
 
 #[async_trait::async_trait]
@@ -91,6 +150,9 @@ impl TransactionSubmitting for EdenApi {
         &self,
         tx: TransactionBuilder<Web3Transport>,
     ) -> Result<TransactionHandle> {
+        let sender = tx.from.as_ref().expect("sender has to be set").address();
+        let nonce = *tx.nonce.as_ref().expect("nonce has to be set");
+
         let tx_hash = match tx.clone().build().now_or_never() {
             Some(Ok(Transaction::Raw { hash, .. })) => hash,
             _ => bail!("Eden submission requires fully built raw transactions"),
@@ -108,23 +170,9 @@ impl TransactionSubmitting for EdenApi {
                     .submit_raw_transaction(tx)
                     .await
             })
-            .await;
+            .await as Result<TransactionHandle>;
 
-        match &result {
-            Ok(_) => super::track_submission_success("eden", true),
-            Err(err) => {
-                let error = err.to_string();
-                if ALREADY_KNOWN_TRANSACTION
-                    .iter()
-                    .any(|message| error.contains(message))
-                {
-                    tracing::debug!(?tx_hash, "transaction already known");
-                } else {
-                    tracing::warn!(?error, "transaction submission error");
-                    super::track_submission_success("eden", false);
-                }
-            }
-        };
+        self.track_submission_success(&result, sender, nonce, tx_hash);
 
         result
     }
@@ -172,5 +220,26 @@ mod tests {
             H256::from_str("41df922fd0d4766fcc02e161f8295ec28522f329ae487f14d811e4b64c8d6e31")
                 .unwrap()
         );
+    }
+
+    #[test]
+    fn finds_biggest_publicly_submitted_nonce_for_sender() {
+        let sender = H160([1; 20]);
+        let global = GlobalTxPool::default();
+        let pub_pool = global.add_sub_pool(Strategy::CustomNodes);
+        let flashbots_pool = global.add_sub_pool(Strategy::Flashbots);
+        let eden_pool = global.add_sub_pool(Strategy::Eden);
+
+        pub_pool.update(sender, 1.into(), vec![]);
+        pub_pool.update(sender, 2.into(), vec![]);
+
+        // is public but has the wrong sender
+        pub_pool.update(H160([2; 20]), 1_000.into(), vec![]);
+
+        // right sender but not in public mempool
+        flashbots_pool.update(sender, 1_000.into(), vec![]);
+        eden_pool.update(sender, 1_000.into(), vec![]);
+
+        assert_eq!(Some(2.into()), biggest_public_nonce(&global, sender));
     }
 }

--- a/crates/solver/src/settlement_submission/submitter/eden_api.rs
+++ b/crates/solver/src/settlement_submission/submitter/eden_api.rs
@@ -119,6 +119,9 @@ impl EdenApi {
             Err(e) => {
                 let error = e.to_string();
 
+                // The eden mempool also contains tx from the public mempool. If our in-memory
+                // tx pool already knows that we successfully submitted this or a more recent tx
+                // to the public mempool we discard those "already known" errors as false positives.
                 let supposedly_already_known = ALREADY_KNOWN_TRANSACTION
                     .iter()
                     .any(|message| error.contains(message));


### PR DESCRIPTION
At the moment our the alert for transaction submission errors is quite noisy because we log many errors coming from eden which seem to be false positives.

For the custom nodes submitting transactions to the public mempool we ignore a number of [error messages](https://github.com/cowprotocol/services/blob/79cba9c4817497ab0a1256f595021dd017062833/crates/solver/src/settlement_submission/submitter/custom_nodes_api.rs#L15-L22) which can be caused by another custom node submitting the transaction to the mempool faster.

Since we learned at some point that the eden mempool also contains messages from the public mempool it seems reasonable to ignore the corresponding eden error messages as well.

To see how big of an impact this change would make I analyzed the logged errors over a period from 2022-05-24 to 2022-06-10 (a total of 985 errors).
transaction underpriced: 775
nonce too low: 198
unable to decode txs: 7
internal server error: 3
invalid nonce: 2

So if we consider the first 2 categories false positives as we do for custom node submissions we would reduce the number of false positives by 98,8%.

### Test Plan

Monitor metrics after deploying
