### PR TITLE
[Trivial] add metadata to Quasimodo request when estimating price

### DIFF
--- a/crates/orderbook/src/main.rs
+++ b/crates/orderbook/src/main.rs
@@ -571,6 +571,7 @@ async fn main() {
                 gas_price_estimator.clone(),
                 native_token.address(),
                 base_tokens.clone(),
+                network_name.to_string(),
             )),
             PriceEstimatorType::OneInch => Box::new(OneInchPriceEstimator::new(
                 one_inch_api.as_ref().unwrap().clone(),

--- a/crates/shared/src/price_estimation/quasimodo.rs
+++ b/crates/shared/src/price_estimation/quasimodo.rs
@@ -3,9 +3,9 @@ use crate::{
     http_solver::{
         gas_model::GasModel,
         model::{
-            AmmModel, AmmParameters, BatchAuctionModel, ConstantProductPoolParameters, OrderModel,
-            SettledBatchAuctionModel, StablePoolParameters, TokenAmount, TokenInfoModel,
-            WeightedPoolTokenData, WeightedProductPoolParameters, MetadataModel
+            AmmModel, AmmParameters, BatchAuctionModel, ConstantProductPoolParameters,
+            MetadataModel, OrderModel, SettledBatchAuctionModel, StablePoolParameters, TokenAmount,
+            TokenInfoModel, WeightedPoolTokenData, WeightedProductPoolParameters,
         },
         HttpSolverApi,
     },
@@ -457,7 +457,7 @@ mod tests {
                 testlib::tokens::WETH,
                 &[testlib::tokens::WETH, t1.1, t2.1],
             )),
-            network_name: "Ethereum / Mainnet".to_string()
+            network_name: "Ethereum / Mainnet".to_string(),
         };
 
         let result = estimator

--- a/crates/shared/src/price_estimation/quasimodo.rs
+++ b/crates/shared/src/price_estimation/quasimodo.rs
@@ -5,7 +5,7 @@ use crate::{
         model::{
             AmmModel, AmmParameters, BatchAuctionModel, ConstantProductPoolParameters, OrderModel,
             SettledBatchAuctionModel, StablePoolParameters, TokenAmount, TokenInfoModel,
-            WeightedPoolTokenData, WeightedProductPoolParameters,
+            WeightedPoolTokenData, WeightedProductPoolParameters, MetadataModel
         },
         HttpSolverApi,
     },
@@ -47,9 +47,11 @@ pub struct QuasimodoPriceEstimator {
     gas_info: Arc<dyn GasPriceEstimating>,
     native_token: H160,
     base_tokens: Arc<BaseTokens>,
+    network_name: String,
 }
 
 impl QuasimodoPriceEstimator {
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         api: Arc<dyn HttpSolverApi>,
         pools: Arc<PoolCache>,
@@ -58,6 +60,7 @@ impl QuasimodoPriceEstimator {
         gas_info: Arc<dyn GasPriceEstimating>,
         native_token: H160,
         base_tokens: Arc<BaseTokens>,
+        network_name: String,
     ) -> Self {
         Self {
             api,
@@ -68,6 +71,7 @@ impl QuasimodoPriceEstimator {
             gas_info,
             native_token,
             base_tokens,
+            network_name,
         }
     }
 
@@ -151,7 +155,12 @@ impl QuasimodoPriceEstimator {
             tokens,
             orders,
             amms,
-            metadata: None,
+            metadata: Some(MetadataModel {
+                environment: Some(self.network_name.clone()),
+                auction_id: None,
+                gas_price: Some(gas_price.to_f64_lossy()),
+                native_token: Some(self.native_token),
+            }),
         };
 
         let api = self.api.clone();
@@ -448,6 +457,7 @@ mod tests {
                 testlib::tokens::WETH,
                 &[testlib::tokens::WETH, t1.1, t2.1],
             )),
+            network_name: "Ethereum / Mainnet".to_string()
         };
 
         let result = estimator


### PR DESCRIPTION
When using Quasimodo in PriceEstimator mode we weren't passing metadata (like gas price, network, etc). While not strictly required, it feels more correct to pass it. Also as we are potentially onboarding external solvers as price estimators (like the yearn solver to deal give prices for "exotic" tokens that are otherwise not supported) we need to comply with a more unified interface.

### Test Plan

Checking that both with https://xdai.barn.seasolver.dev as well as with the Quasimodo staging address we can still get price estimates.
