### PR TITLE
EIP-1271 signing scheme

### DIFF
--- a/crates/model/src/order.rs
+++ b/crates/model/src/order.rs
@@ -70,7 +70,7 @@ impl Order {
                 is_liquidity_order,
                 ..Default::default()
             },
-            signature: order.signature,
+            signature: order.signature.clone(),
             data: order.data,
         })
     }

--- a/crates/model/src/signature.rs
+++ b/crates/model/src/signature.rs
@@ -1,5 +1,5 @@
 use super::DomainSeparator;
-use anyhow::{Context as _, Result};
+use anyhow::{ensure, Context as _, Result};
 use primitive_types::{H160, H256};
 use serde::{de, Deserialize, Serialize};
 use std::{convert::TryInto as _, fmt};
@@ -106,9 +106,7 @@ impl Signature {
                 )
             }
             SigningScheme::Eip1271 => {
-                if bytes.len() < 20 {
-                    return Err(anyhow::anyhow!("The provided bytes are less than 20"));
-                }
+                ensure!(bytes.len() >= 20, "The provided bytes are less than 20");
 
                 let (from, signature) = bytes.split_at(20);
                 let from = H160::from_slice(from);

--- a/crates/orderbook/src/database/orders.rs
+++ b/crates/orderbook/src/database/orders.rs
@@ -150,6 +150,7 @@ impl DbBuyTokenDestination {
 pub enum DbSigningScheme {
     Eip712,
     EthSign,
+    Eip1271,
     PreSign,
 }
 
@@ -158,6 +159,7 @@ impl DbSigningScheme {
         match signing_scheme {
             SigningScheme::Eip712 => Self::Eip712,
             SigningScheme::EthSign => Self::EthSign,
+            SigningScheme::Eip1271 => Self::Eip1271,
             SigningScheme::PreSign => Self::PreSign,
         }
     }
@@ -166,6 +168,7 @@ impl DbSigningScheme {
         match self {
             Self::Eip712 => SigningScheme::Eip712,
             Self::EthSign => SigningScheme::EthSign,
+            Self::Eip1271 => SigningScheme::Eip1271,
             Self::PreSign => SigningScheme::PreSign,
         }
     }

--- a/crates/solver/src/encoding.rs
+++ b/crates/solver/src/encoding.rs
@@ -66,6 +66,7 @@ fn order_flags(order: &OrderData, signature: &Signature) -> U256 {
     result |= match signature.scheme() {
         SigningScheme::Eip712 => 0b00,
         SigningScheme::EthSign => 0b01,
+        SigningScheme::Eip1271 => 0b10,
         SigningScheme::PreSign => 0b11,
     } << 5;
     result.into()


### PR DESCRIPTION
Following up the changes made in #268 #250 this PR adds the EIP-1271 signing scheme to:

- model - Signature
- model - SigningScheme
- orderbook - DbSigningScheme
- solver - encode_trade

**NOTE:** EIP-1271 won't be available for Orders yet as there is currently a match  allowing only a certain signatures:
https://github.com/cowprotocol/services/blob/8f1ad7730b160a25dd66ad844b657089e0d05daa/crates/orderbook/src/api/order_validation.rs#L346-L351

cc @nlordell another small PR to add the EIP-1271 signature before tiding everything together