### PR TITLE
Add authorization to competition info post

### DIFF
--- a/crates/e2e/tests/e2e/services.rs
+++ b/crates/e2e/tests/e2e/services.rs
@@ -65,7 +65,11 @@ pub fn to_wei(base: u32) -> U256 {
 
 #[allow(dead_code)]
 pub fn create_orderbook_api() -> OrderBookApi {
-    OrderBookApi::new(reqwest::Url::from_str(API_HOST).unwrap(), Client::new())
+    OrderBookApi::new(
+        reqwest::Url::from_str(API_HOST).unwrap(),
+        Client::new(),
+        None,
+    )
 }
 
 pub fn create_order_converter(web3: &Web3, weth_address: H160) -> OrderConverter {
@@ -206,6 +210,7 @@ impl OrderbookServices {
             API_HOST[7..].parse().expect("Couldn't parse API address"),
             pending(),
             Default::default(),
+            None,
         );
 
         Self {

--- a/crates/orderbook/src/api.rs
+++ b/crates/orderbook/src/api.rs
@@ -42,6 +42,7 @@ pub fn handle_all_routes(
     orderbook: Arc<Orderbook>,
     quoter: Arc<OrderQuoter>,
     solver_competition: Arc<SolverCompetition>,
+    solver_competition_auth: Option<String>,
 ) -> impl Filter<Extract = (impl Reply,), Error = Rejection> + Clone {
     // Routes for api v1.
 
@@ -97,9 +98,10 @@ pub fn handle_all_routes(
     let get_solver_competition = get_solver_competition::get(solver_competition.clone())
         .map(|result| (result, "v1/solver_competition"))
         .boxed();
-    let post_solver_competition = post_solver_competition::post(solver_competition)
-        .map(|result| (result, "v1/solver_competition"))
-        .boxed();
+    let post_solver_competition =
+        post_solver_competition::post(solver_competition, solver_competition_auth)
+            .map(|result| (result, "v1/solver_competition"))
+            .boxed();
 
     let routes_v1 = warp::path!("api" / "v1" / ..)
         .and(

--- a/crates/orderbook/src/lib.rs
+++ b/crates/orderbook/src/lib.rs
@@ -29,8 +29,16 @@ pub fn serve_api(
     address: SocketAddr,
     shutdown_receiver: impl Future<Output = ()> + Send + 'static,
     solver_competition: Arc<SolverCompetition>,
+    solver_competition_auth: Option<String>,
 ) -> JoinHandle<()> {
-    let filter = api::handle_all_routes(database, orderbook, quoter, solver_competition).boxed();
+    let filter = api::handle_all_routes(
+        database,
+        orderbook,
+        quoter,
+        solver_competition,
+        solver_competition_auth,
+    )
+    .boxed();
     tracing::info!(%address, "serving order book");
     let (_, server) = warp::serve(filter).bind_with_graceful_shutdown(address, shutdown_receiver);
     task::spawn(server)

--- a/crates/orderbook/src/main.rs
+++ b/crates/orderbook/src/main.rs
@@ -762,6 +762,7 @@ async fn main() {
             let _ = shutdown_receiver.await;
         },
         solver_competition,
+        args.shared.solver_competition_auth,
     );
     let maintenance_task =
         task::spawn(service_maintainer.run_maintenance_on_new_block(current_block_stream));

--- a/crates/shared/src/arguments.rs
+++ b/crates/shared/src/arguments.rs
@@ -148,6 +148,10 @@ pub struct Arguments {
     /// Deny list of balancer pool ids.
     #[clap(long, env, use_value_delimiter = true)]
     pub balancer_pool_deny_list: Vec<H256>,
+
+    /// Value of the authorization header for the solver competition post api.
+    #[clap(long, env)]
+    pub solver_competition_auth: Option<String>,
 }
 
 pub fn parse_unbounded_factor(s: &str) -> Result<f64> {

--- a/crates/solver/src/main.rs
+++ b/crates/solver/src/main.rs
@@ -635,7 +635,11 @@ async fn main() {
         transaction_strategies,
         access_list_estimator,
     };
-    let api = OrderBookApi::new(args.orderbook_url, client.clone());
+    let api = OrderBookApi::new(
+        args.orderbook_url,
+        client.clone(),
+        args.shared.solver_competition_auth,
+    );
     let order_converter = OrderConverter {
         native_token: native_token_contract.clone(),
         fee_objective_scaling_factor: args.fee_objective_scaling_factor,


### PR DESCRIPTION
In https://github.com/cowprotocol/services/pull/188 we originally had an authorization header for this route as we only want it to be POSTable from the driver pod. In the PR we decided it would be better to handle this on the nginx ingress level. This turned out to not work and while devops is investigating other solutions we should add our own authentication back.

### Test Plan

CI