### PR TITLE
Refactor modules

### DIFF
--- a/crates/e2e/tests/e2e/services.rs
+++ b/crates/e2e/tests/e2e/services.rs
@@ -3,13 +3,13 @@ use contracts::{ERC20Mintable, WETH9};
 use ethcontract::{prelude::U256, H160};
 use orderbook::{
     account_balances::Web3BalanceFetcher,
-    api::order_validation::OrderValidator,
-    api::post_quote::OrderQuoter,
     cow_subsidy::FixedCowSubsidy,
     database::Postgres,
     event_updater::EventUpdater,
     fee::{FeeSubsidyConfiguration, MinFeeCalculator},
     metrics::NoopMetrics,
+    order_quoting::OrderQuoter,
+    order_validation::OrderValidator,
     orderbook::Orderbook,
     solvable_orders::SolvableOrdersCache,
 };

--- a/crates/orderbook/src/api.rs
+++ b/crates/orderbook/src/api.rs
@@ -9,18 +9,15 @@ mod get_orders;
 mod get_orders_by_tx;
 mod get_solvable_orders;
 mod get_solvable_orders_v2;
-pub mod get_solver_competition;
+mod get_solver_competition;
 mod get_trades;
 mod get_user_orders;
-pub mod order_validation;
-pub mod post_quote;
-pub mod post_solver_competition;
+mod post_quote;
+mod post_solver_competition;
 mod replace_order;
 
 use crate::solver_competition::SolverCompetition;
-use crate::{
-    api::post_quote::OrderQuoter, database::trades::TradeRetrieving, orderbook::Orderbook,
-};
+use crate::{database::trades::TradeRetrieving, order_quoting::OrderQuoter, orderbook::Orderbook};
 use anyhow::{Error as anyhowError, Result};
 use serde::{de::DeserializeOwned, Serialize};
 use shared::{metrics::get_metric_storage_registry, price_estimation::PriceEstimationError};

--- a/crates/orderbook/src/api/create_order.rs
+++ b/crates/orderbook/src/api/create_order.rs
@@ -1,5 +1,6 @@
 use crate::{
     api::{extract_payload, IntoWarpReply},
+    order_validation::{PartialValidationError, ValidationError},
     orderbook::{AddOrderError, Orderbook},
 };
 use anyhow::Result;
@@ -13,6 +14,138 @@ pub fn create_order_request() -> impl Filter<Extract = (OrderCreation,), Error =
     warp::path!("orders")
         .and(warp::post())
         .and(extract_payload())
+}
+
+impl IntoWarpReply for PartialValidationError {
+    fn into_warp_reply(self) -> super::ApiReply {
+        match self {
+            Self::UnsupportedBuyTokenDestination(dest) => with_status(
+                super::error("UnsupportedBuyTokenDestination", format!("Type {:?}", dest)),
+                StatusCode::BAD_REQUEST,
+            ),
+            Self::UnsupportedSellTokenSource(src) => with_status(
+                super::error("UnsupportedSellTokenSource", format!("Type {:?}", src)),
+                StatusCode::BAD_REQUEST,
+            ),
+            Self::UnsupportedOrderType => with_status(
+                super::error(
+                    "UnsupportedOrderType",
+                    "This order type is currently not supported",
+                ),
+                StatusCode::BAD_REQUEST,
+            ),
+            Self::Forbidden => with_status(
+                super::error("Forbidden", "Forbidden, your account is deny-listed"),
+                StatusCode::FORBIDDEN,
+            ),
+            Self::InsufficientValidTo => with_status(
+                super::error(
+                    "InsufficientValidTo",
+                    "validTo is not far enough in the future",
+                ),
+                StatusCode::BAD_REQUEST,
+            ),
+            Self::ExcessiveValidTo => with_status(
+                super::error("ExcessiveValidTo", "validTo is too far into the future"),
+                StatusCode::BAD_REQUEST,
+            ),
+            Self::TransferEthToContract => with_status(
+                super::error(
+                    "TransferEthToContract",
+                    "Sending Ether to smart contract wallets is currently not supported",
+                ),
+                StatusCode::BAD_REQUEST,
+            ),
+            Self::InvalidNativeSellToken => with_status(
+                super::error(
+                    "InvalidNativeSellToken",
+                    "The chain's native token (Ether/xDai) cannot be used as the sell token",
+                ),
+                StatusCode::BAD_REQUEST,
+            ),
+            Self::SameBuyAndSellToken => with_status(
+                super::error(
+                    "SameBuyAndSellToken",
+                    "Buy token is the same as the sell token.",
+                ),
+                StatusCode::BAD_REQUEST,
+            ),
+            Self::UnsupportedSignature => with_status(
+                super::error("UnsupportedSignature", "signing scheme is not supported"),
+                StatusCode::BAD_REQUEST,
+            ),
+            Self::Other(err) => with_status(
+                super::internal_error(err.context("partial_validation")),
+                StatusCode::INTERNAL_SERVER_ERROR,
+            ),
+        }
+    }
+}
+
+impl IntoWarpReply for ValidationError {
+    fn into_warp_reply(self) -> super::ApiReply {
+        match self {
+            Self::Partial(pre) => pre.into_warp_reply(),
+            Self::UnsupportedToken(token) => with_status(
+                super::error("UnsupportedToken", format!("Token address {}", token)),
+                StatusCode::BAD_REQUEST,
+            ),
+            Self::WrongOwner(owner) => with_status(
+                super::error(
+                    "WrongOwner",
+                    format!(
+                        "Address recovered from signature {} does not match from address",
+                        owner
+                    ),
+                ),
+                StatusCode::BAD_REQUEST,
+            ),
+            Self::InsufficientBalance => with_status(
+                super::error(
+                    "InsufficientBalance",
+                    "order owner must have funds worth at least x in his account",
+                ),
+                StatusCode::BAD_REQUEST,
+            ),
+            Self::InsufficientAllowance => with_status(
+                super::error(
+                    "InsufficientAllowance",
+                    "order owner must give allowance to VaultRelayer",
+                ),
+                StatusCode::BAD_REQUEST,
+            ),
+            Self::InvalidSignature => with_status(
+                super::error("InvalidSignature", "invalid signature"),
+                StatusCode::BAD_REQUEST,
+            ),
+            Self::InsufficientFee => with_status(
+                super::error("InsufficientFee", "Order does not include sufficient fee"),
+                StatusCode::BAD_REQUEST,
+            ),
+            Self::SellAmountOverflow => with_status(
+                super::error(
+                    "SellAmountOverflow",
+                    "Sell amount + fee amount must fit in U256",
+                ),
+                StatusCode::INTERNAL_SERVER_ERROR,
+            ),
+            Self::TransferSimulationFailed => with_status(
+                super::error(
+                    "TransferSimulationFailed",
+                    "sell token cannot be transferred",
+                ),
+                StatusCode::BAD_REQUEST,
+            ),
+            Self::ZeroAmount => with_status(
+                super::error("ZeroAmount", "Buy or sell amount is zero."),
+                StatusCode::BAD_REQUEST,
+            ),
+            Self::Other(err) => with_status(
+                super::internal_error(err.context("order_validation")),
+                StatusCode::INTERNAL_SERVER_ERROR,
+            ),
+        }
+    }
 }
 
 impl IntoWarpReply for AddOrderError {

--- a/crates/orderbook/src/api/get_fee_and_quote.rs
+++ b/crates/orderbook/src/api/get_fee_and_quote.rs
@@ -1,4 +1,4 @@
-use crate::api::{convert_json_response, post_quote::OrderQuoter};
+use crate::{api::convert_json_response, order_quoting::OrderQuoter};
 use anyhow::Result;
 use chrono::{DateTime, Utc};
 use ethcontract::{H160, U256};

--- a/crates/orderbook/src/api/get_fee_info.rs
+++ b/crates/orderbook/src/api/get_fee_info.rs
@@ -1,7 +1,8 @@
 use crate::{
-    api::{convert_json_response, order_validation::PartialValidationError, IntoWarpReply},
+    api::{convert_json_response, IntoWarpReply},
     fee::FeeData,
     fee::MinFeeCalculating,
+    order_validation::PartialValidationError,
 };
 use anyhow::Result;
 use chrono::{DateTime, Utc};

--- a/crates/orderbook/src/api/post_quote.rs
+++ b/crates/orderbook/src/api/post_quote.rs
@@ -1,322 +1,11 @@
 use crate::{
-    api::{
-        self, convert_json_response,
-        order_validation::{OrderValidating, PreOrderData, ValidationError},
-        IntoWarpReply,
-    },
-    fee::{FeeData, MinFeeCalculating},
+    api::{self, convert_json_response, IntoWarpReply},
+    order_quoting::{FeeError, OrderQuoteError, OrderQuoter},
 };
 use anyhow::Result;
-use chrono::{DateTime, Utc};
-use ethcontract::U256;
-use futures::try_join;
-use model::{
-    order::OrderKind,
-    quote::{
-        OrderQuote, OrderQuoteRequest, OrderQuoteResponse, OrderQuoteSide, PriceQuality, SellAmount,
-    },
-    u256_decimal,
-};
-use serde::Serialize;
-use shared::price_estimation::{self, single_estimate, PriceEstimating, PriceEstimationError};
-use std::{
-    convert::Infallible,
-    sync::{
-        atomic::{AtomicU64, Ordering},
-        Arc,
-    },
-};
+use model::quote::OrderQuoteRequest;
+use std::{convert::Infallible, sync::Arc};
 use warp::{hyper::StatusCode, Filter, Rejection};
-
-impl From<&OrderQuoteRequest> for PreOrderData {
-    fn from(quote_request: &OrderQuoteRequest) -> Self {
-        let owner = quote_request.from;
-        Self {
-            owner,
-            sell_token: quote_request.sell_token,
-            buy_token: quote_request.buy_token,
-            receiver: quote_request.receiver.unwrap_or(owner),
-            valid_to: quote_request.validity.actual_valid_to(),
-            partially_fillable: quote_request.partially_fillable,
-            buy_token_balance: quote_request.buy_token_balance,
-            sell_token_balance: quote_request.sell_token_balance,
-            signing_scheme: quote_request.signing_scheme,
-            is_liquidity_order: quote_request.partially_fillable,
-        }
-    }
-}
-
-#[derive(Debug)]
-pub enum FeeError {
-    SellAmountDoesNotCoverFee(FeeInfo),
-    PriceEstimate(PriceEstimationError),
-}
-
-#[derive(Debug, Serialize)]
-#[serde(rename_all = "camelCase")]
-pub struct FeeInfo {
-    #[serde(with = "u256_decimal")]
-    pub fee_amount: U256,
-    pub expiration: DateTime<Utc>,
-}
-
-impl IntoWarpReply for FeeError {
-    fn into_warp_reply(self) -> super::ApiReply {
-        match self {
-            FeeError::PriceEstimate(err) => err.into_warp_reply(),
-            FeeError::SellAmountDoesNotCoverFee(fee) => warp::reply::with_status(
-                super::rich_error(
-                    "SellAmountDoesNotCoverFee",
-                    "The sell amount for the sell order is lower than the fee.",
-                    fee,
-                ),
-                StatusCode::BAD_REQUEST,
-            ),
-        }
-    }
-}
-
-#[derive(Debug)]
-pub enum OrderQuoteError {
-    Fee(FeeError),
-    Order(ValidationError),
-}
-
-impl IntoWarpReply for OrderQuoteError {
-    fn into_warp_reply(self) -> super::ApiReply {
-        match self {
-            OrderQuoteError::Fee(err) => err.into_warp_reply(),
-            OrderQuoteError::Order(err) => err.into_warp_reply(),
-        }
-    }
-}
-
-#[derive(Debug, Serialize, PartialEq)]
-struct FeeParameters {
-    buy_amount: U256,
-    sell_amount: U256,
-    fee_amount: U256,
-    expiration: DateTime<Utc>,
-    kind: OrderKind,
-}
-
-#[derive(Clone)]
-pub struct OrderQuoter {
-    pub fee_calculator: Arc<dyn MinFeeCalculating>,
-    pub price_estimator: Arc<dyn PriceEstimating>,
-    pub order_validator: Arc<dyn OrderValidating>,
-    pub fast_fee_calculator: Arc<dyn MinFeeCalculating>,
-    pub fast_price_estimator: Arc<dyn PriceEstimating>,
-    pub current_id: Arc<AtomicU64>,
-}
-
-impl OrderQuoter {
-    pub fn new(
-        fee_calculator: Arc<dyn MinFeeCalculating>,
-        price_estimator: Arc<dyn PriceEstimating>,
-        order_validator: Arc<dyn OrderValidating>,
-    ) -> Self {
-        Self {
-            fast_fee_calculator: fee_calculator.clone(),
-            fast_price_estimator: price_estimator.clone(),
-            fee_calculator,
-            price_estimator,
-            order_validator,
-            current_id: Default::default(),
-        }
-    }
-
-    pub fn with_fast_quotes(
-        mut self,
-        fee_calculator: Arc<dyn MinFeeCalculating>,
-        price_estimator: Arc<dyn PriceEstimating>,
-    ) -> Self {
-        self.fast_fee_calculator = fee_calculator;
-        self.fast_price_estimator = price_estimator;
-        self
-    }
-
-    pub async fn calculate_quote(
-        &self,
-        quote_request: &OrderQuoteRequest,
-    ) -> Result<OrderQuoteResponse, OrderQuoteError> {
-        tracing::debug!("Received quote request {:?}", quote_request);
-        let pre_order = PreOrderData::from(quote_request);
-        let valid_to = pre_order.valid_to;
-        self.order_validator
-            .partial_validate(pre_order)
-            .await
-            .map_err(|err| OrderQuoteError::Order(ValidationError::Partial(err)))?;
-        let fee_parameters = self
-            .calculate_fee_parameters(quote_request)
-            .await
-            .map_err(OrderQuoteError::Fee)?;
-        Ok(OrderQuoteResponse {
-            quote: OrderQuote {
-                sell_token: quote_request.sell_token,
-                buy_token: quote_request.buy_token,
-                receiver: quote_request.receiver,
-                sell_amount: fee_parameters.sell_amount,
-                buy_amount: fee_parameters.buy_amount,
-                valid_to,
-                app_data: quote_request.app_data,
-                fee_amount: fee_parameters.fee_amount,
-                kind: fee_parameters.kind,
-                partially_fillable: quote_request.partially_fillable,
-                sell_token_balance: quote_request.sell_token_balance,
-                buy_token_balance: quote_request.buy_token_balance,
-            },
-            from: quote_request.from,
-            expiration: fee_parameters.expiration,
-            id: self.current_id.fetch_add(1, Ordering::SeqCst),
-        })
-    }
-
-    async fn calculate_fee_parameters(
-        &self,
-        quote_request: &OrderQuoteRequest,
-    ) -> Result<FeeParameters, FeeError> {
-        let (fee_calculator, price_estimator) = match quote_request.price_quality {
-            PriceQuality::Fast => (&self.fast_fee_calculator, &self.fast_price_estimator),
-            PriceQuality::Optimal => (&self.fee_calculator, &self.price_estimator),
-        };
-
-        Ok(match quote_request.side {
-            OrderQuoteSide::Sell {
-                sell_amount:
-                    SellAmount::BeforeFee {
-                        value: sell_amount_before_fee,
-                    },
-            } => {
-                if sell_amount_before_fee.is_zero() {
-                    return Err(FeeError::PriceEstimate(PriceEstimationError::ZeroAmount));
-                }
-                let query = price_estimation::Query {
-                    // It would be more correct to use sell_amount_after_fee here, however this makes the two long-running fee and price estimation queries dependent and causes very long roundtrip times
-                    // We therefore compute the exchange rate for the sell_amount_before_fee and assume that the price for selling a smaller amount (after fee) will be close to but at least as good
-                    sell_token: quote_request.sell_token,
-                    buy_token: quote_request.buy_token,
-                    in_amount: sell_amount_before_fee,
-                    kind: OrderKind::Sell,
-                };
-                let ((fee, expiration), estimate) = try_join!(
-                    fee_calculator.compute_subsidized_min_fee(
-                        FeeData {
-                            sell_token: quote_request.sell_token,
-                            buy_token: quote_request.buy_token,
-                            amount: sell_amount_before_fee,
-                            kind: OrderKind::Sell,
-                        },
-                        quote_request.app_data,
-                        quote_request.from,
-                    ),
-                    single_estimate(price_estimator.as_ref(), &query)
-                )
-                .map_err(FeeError::PriceEstimate)?;
-                let sell_amount_after_fee = sell_amount_before_fee
-                    .checked_sub(fee)
-                    .ok_or(FeeError::SellAmountDoesNotCoverFee(FeeInfo {
-                        fee_amount: fee,
-                        expiration,
-                    }))?
-                    .max(U256::one());
-                let buy_amount_after_fee =
-                    match estimate.out_amount.checked_mul(sell_amount_after_fee) {
-                        // sell_amount_before_fee is at least 1 (cf. above)
-                        Some(product) => product / sell_amount_before_fee,
-                        None => (estimate.out_amount / sell_amount_before_fee)
-                            .checked_mul(sell_amount_after_fee)
-                            .unwrap_or(U256::MAX),
-                    };
-                FeeParameters {
-                    buy_amount: buy_amount_after_fee,
-                    sell_amount: sell_amount_after_fee,
-                    fee_amount: fee,
-                    expiration,
-                    kind: OrderKind::Sell,
-                }
-            }
-            OrderQuoteSide::Sell {
-                sell_amount:
-                    SellAmount::AfterFee {
-                        value: sell_amount_after_fee,
-                    },
-            } => {
-                if sell_amount_after_fee.is_zero() {
-                    return Err(FeeError::PriceEstimate(PriceEstimationError::ZeroAmount));
-                }
-
-                let price_estimation_query = price_estimation::Query {
-                    sell_token: quote_request.sell_token,
-                    buy_token: quote_request.buy_token,
-                    in_amount: sell_amount_after_fee,
-                    kind: OrderKind::Sell,
-                };
-
-                // Since both futures are long running and independent, run concurrently
-                let ((fee, expiration), estimate) = try_join!(
-                    fee_calculator.compute_subsidized_min_fee(
-                        FeeData {
-                            sell_token: quote_request.sell_token,
-                            buy_token: quote_request.buy_token,
-                            amount: sell_amount_after_fee,
-                            kind: OrderKind::Sell,
-                        },
-                        quote_request.app_data,
-                        quote_request.from,
-                    ),
-                    single_estimate(price_estimator.as_ref(), &price_estimation_query)
-                )
-                .map_err(FeeError::PriceEstimate)?;
-                FeeParameters {
-                    buy_amount: estimate.out_amount,
-                    sell_amount: sell_amount_after_fee,
-                    fee_amount: fee,
-                    expiration,
-                    kind: OrderKind::Sell,
-                }
-            }
-            OrderQuoteSide::Buy {
-                buy_amount_after_fee,
-            } => {
-                if buy_amount_after_fee.is_zero() {
-                    return Err(FeeError::PriceEstimate(PriceEstimationError::ZeroAmount));
-                }
-
-                let price_estimation_query = price_estimation::Query {
-                    sell_token: quote_request.sell_token,
-                    buy_token: quote_request.buy_token,
-                    in_amount: buy_amount_after_fee,
-                    kind: OrderKind::Buy,
-                };
-
-                // Since both futures are long running and independent, run concurrently
-                let ((fee, expiration), estimate) = try_join!(
-                    fee_calculator.compute_subsidized_min_fee(
-                        FeeData {
-                            sell_token: quote_request.sell_token,
-                            buy_token: quote_request.buy_token,
-                            amount: buy_amount_after_fee,
-                            kind: OrderKind::Buy,
-                        },
-                        quote_request.app_data,
-                        quote_request.from,
-                    ),
-                    single_estimate(price_estimator.as_ref(), &price_estimation_query)
-                )
-                .map_err(FeeError::PriceEstimate)?;
-                let sell_amount_after_fee = estimate.out_amount;
-                FeeParameters {
-                    buy_amount: buy_amount_after_fee,
-                    sell_amount: sell_amount_after_fee,
-                    fee_amount: fee,
-                    expiration,
-                    kind: OrderKind::Buy,
-                }
-            }
-        })
-    }
-}
 
 fn post_quote_request() -> impl Filter<Extract = (OrderQuoteRequest,), Error = Rejection> + Clone {
     warp::path!("quote")
@@ -339,26 +28,47 @@ pub fn post_quote(
     })
 }
 
+impl IntoWarpReply for FeeError {
+    fn into_warp_reply(self) -> super::ApiReply {
+        match self {
+            FeeError::PriceEstimate(err) => err.into_warp_reply(),
+            FeeError::SellAmountDoesNotCoverFee(fee) => warp::reply::with_status(
+                super::rich_error(
+                    "SellAmountDoesNotCoverFee",
+                    "The sell amount for the sell order is lower than the fee.",
+                    fee,
+                ),
+                StatusCode::BAD_REQUEST,
+            ),
+        }
+    }
+}
+
+impl IntoWarpReply for OrderQuoteError {
+    fn into_warp_reply(self) -> super::ApiReply {
+        match self {
+            OrderQuoteError::Fee(err) => err.into_warp_reply(),
+            OrderQuoteError::Order(err) => err.into_warp_reply(),
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{
-        api::{order_validation::MockOrderValidating, response_body},
-        fee::MockMinFeeCalculating,
-    };
+    use crate::{api::response_body, order_validation::ValidationError};
     use anyhow::anyhow;
-    use chrono::{NaiveDateTime, Utc};
-    use ethcontract::H160;
-    use futures::FutureExt;
+    use chrono::{DateTime, NaiveDateTime, Utc};
+    use ethcontract::{H160, U256};
     use model::{
         app_id::AppId,
         order::{BuyTokenDestination, SellTokenSource},
-        quote::Validity,
+        quote::{
+            OrderQuote, OrderQuoteResponse, OrderQuoteSide, PriceQuality, SellAmount, Validity,
+        },
         signature::SigningScheme,
-        time,
     };
     use serde_json::json;
-    use shared::price_estimation::mocks::FakePriceEstimator;
     use warp::{test::request, Reply};
 
     #[test]
@@ -556,210 +266,5 @@ mod tests {
         let expected_error = json!({"errorType": "InternalServerError", "description": ""});
         assert_eq!(body, expected_error);
         // There are many other FeeAndQuoteErrors, but writing a test for each would follow the same pattern as this.
-    }
-
-    #[test]
-    fn calculate_fee_sell_before_fees_quote_request() {
-        let mut fee_calculator = MockMinFeeCalculating::new();
-
-        let expiration = Utc::now();
-        fee_calculator
-            .expect_compute_subsidized_min_fee()
-            .returning(move |_, _, _| Ok((3.into(), expiration)));
-
-        let fee_calculator = Arc::new(fee_calculator);
-        let price_estimator = FakePriceEstimator(price_estimation::Estimate {
-            out_amount: 14.into(),
-            gas: 1000,
-        });
-        let sell_query = OrderQuoteRequest::new(
-            H160::from_low_u64_ne(0),
-            H160::from_low_u64_ne(1),
-            OrderQuoteSide::Sell {
-                sell_amount: SellAmount::BeforeFee { value: 10.into() },
-            },
-        );
-        let quoter = Arc::new(OrderQuoter::new(
-            fee_calculator,
-            Arc::new(price_estimator),
-            Arc::new(MockOrderValidating::new()),
-        ));
-        let result = quoter
-            .calculate_fee_parameters(&sell_query)
-            .now_or_never()
-            .unwrap()
-            .unwrap();
-        // After the deducting the fee 10 - 3 = 7 units of sell token are being sold.
-        // Selling 10 units will buy us 14. Therefore, selling 7 should buy us 9.8 => 9 whole units
-        assert_eq!(
-            result,
-            FeeParameters {
-                buy_amount: 9.into(),
-                sell_amount: 7.into(),
-                fee_amount: 3.into(),
-                expiration,
-                kind: OrderKind::Sell
-            }
-        );
-    }
-
-    #[test]
-    fn calculate_fee_sell_after_fees_quote_request() {
-        let mut fee_calculator = MockMinFeeCalculating::new();
-        let expiration = Utc::now();
-        fee_calculator
-            .expect_compute_subsidized_min_fee()
-            .returning(move |_, _, _| Ok((3.into(), expiration)));
-
-        let fee_calculator = Arc::new(fee_calculator);
-        let price_estimator = FakePriceEstimator(price_estimation::Estimate {
-            out_amount: 14.into(),
-            gas: 1000,
-        });
-        let sell_query = OrderQuoteRequest::new(
-            H160::from_low_u64_ne(0),
-            H160::from_low_u64_ne(1),
-            OrderQuoteSide::Sell {
-                sell_amount: SellAmount::AfterFee { value: 7.into() },
-            },
-        );
-
-        let quoter = Arc::new(OrderQuoter::new(
-            fee_calculator,
-            Arc::new(price_estimator),
-            Arc::new(MockOrderValidating::new()),
-        ));
-        let result = quoter
-            .calculate_fee_parameters(&sell_query)
-            .now_or_never()
-            .unwrap()
-            .unwrap();
-        assert_eq!(
-            result,
-            FeeParameters {
-                buy_amount: 14.into(),
-                sell_amount: 7.into(),
-                fee_amount: 3.into(),
-                expiration,
-                kind: OrderKind::Sell
-            }
-        );
-    }
-
-    #[test]
-    fn calculate_fee_buy_quote_request() {
-        let mut fee_calculator = MockMinFeeCalculating::new();
-        let expiration = Utc::now();
-        fee_calculator
-            .expect_compute_subsidized_min_fee()
-            .returning(move |_, _, _| Ok((3.into(), expiration)));
-
-        let fee_calculator = Arc::new(fee_calculator);
-        let price_estimator = FakePriceEstimator(price_estimation::Estimate {
-            out_amount: 20.into(),
-            gas: 1000,
-        });
-        let buy_query = OrderQuoteRequest::new(
-            H160::from_low_u64_ne(0),
-            H160::from_low_u64_ne(1),
-            OrderQuoteSide::Buy {
-                buy_amount_after_fee: 10.into(),
-            },
-        );
-        let quoter = Arc::new(OrderQuoter::new(
-            fee_calculator,
-            Arc::new(price_estimator),
-            Arc::new(MockOrderValidating::new()),
-        ));
-        let result = quoter
-            .calculate_fee_parameters(&buy_query)
-            .now_or_never()
-            .unwrap()
-            .unwrap();
-        // To buy 10 units of buy_token the fee in sell_token must be at least 3 and at least 20
-        // units of sell_token must be sold.
-        assert_eq!(
-            result,
-            FeeParameters {
-                buy_amount: 10.into(),
-                sell_amount: 20.into(),
-                fee_amount: 3.into(),
-                expiration,
-                kind: OrderKind::Buy
-            }
-        );
-    }
-
-    #[test]
-    fn pre_order_data_from_quote_request() {
-        let quote_request = OrderQuoteRequest {
-            validity: Validity::To(0),
-            ..Default::default()
-        };
-        let result = PreOrderData::from(&quote_request);
-        let expected = PreOrderData::default();
-        assert_eq!(result, expected);
-    }
-
-    #[test]
-    fn pre_order_data_from_quote_request_with_valid_for() {
-        let quote_request = OrderQuoteRequest {
-            validity: Validity::For(100),
-            ..Default::default()
-        };
-        let result = PreOrderData::from(&quote_request);
-
-        let valid_duration = result.valid_to - time::now_in_epoch_seconds();
-
-        // use time-range to make sure test isn't flaky.
-        assert!((95..=105).contains(&valid_duration));
-    }
-
-    #[tokio::test]
-    async fn calculate_quote() {
-        let buy_request = OrderQuoteRequest {
-            sell_token: H160::from_low_u64_be(1),
-            buy_token: H160::from_low_u64_be(2),
-            side: OrderQuoteSide::Buy {
-                buy_amount_after_fee: 2.into(),
-            },
-            validity: Validity::To(0),
-            ..Default::default()
-        };
-
-        let mut fee_calculator = MockMinFeeCalculating::new();
-        fee_calculator
-            .expect_compute_subsidized_min_fee()
-            .returning(move |_, _, _| Ok((3.into(), Utc::now())));
-        let price_estimator = FakePriceEstimator(price_estimation::Estimate {
-            out_amount: 14.into(),
-            gas: 1000,
-        });
-        let mut order_validator = MockOrderValidating::new();
-        order_validator
-            .expect_partial_validate()
-            .returning(|_| Ok(()));
-        let quoter = Arc::new(OrderQuoter::new(
-            Arc::new(fee_calculator),
-            Arc::new(price_estimator),
-            Arc::new(order_validator),
-        ));
-        let result = quoter.calculate_quote(&buy_request).await.unwrap();
-
-        let expected = OrderQuote {
-            sell_token: H160::from_low_u64_be(1),
-            buy_token: H160::from_low_u64_be(2),
-            receiver: None,
-            sell_amount: 14.into(),
-            kind: OrderKind::Buy,
-            partially_fillable: false,
-            sell_token_balance: Default::default(),
-            buy_amount: 2.into(),
-            valid_to: 0,
-            app_data: Default::default(),
-            fee_amount: 3.into(),
-            buy_token_balance: Default::default(),
-        };
-        assert_eq!(result.quote, expected);
     }
 }

--- a/crates/orderbook/src/lib.rs
+++ b/crates/orderbook/src/lib.rs
@@ -7,12 +7,14 @@ pub mod event_updater;
 pub mod fee;
 pub mod gas_price;
 pub mod metrics;
+pub mod order_quoting;
+pub mod order_validation;
 pub mod orderbook;
 pub mod signature_validator;
 pub mod solvable_orders;
 pub mod solver_competition;
 
-use crate::{api::post_quote::OrderQuoter, orderbook::Orderbook};
+use crate::{order_quoting::OrderQuoter, orderbook::Orderbook};
 use anyhow::{anyhow, Context as _, Result};
 use contracts::GPv2Settlement;
 use database::trades::TradeRetrieving;

--- a/crates/orderbook/src/main.rs
+++ b/crates/orderbook/src/main.rs
@@ -12,13 +12,14 @@ use model::{
 };
 use orderbook::{
     account_balances::Web3BalanceFetcher,
-    api::{order_validation::OrderValidator, post_quote::OrderQuoter},
     cow_subsidy::{CowSubsidy, CowSubsidyImpl, FixedCowSubsidy, SubsidyTiers},
     database::{self, orders::OrderFilter, Postgres},
     event_updater::EventUpdater,
     fee::{FeeSubsidyConfiguration, MinFeeCalculator},
     gas_price::InstrumentedGasEstimator,
     metrics::Metrics,
+    order_quoting::OrderQuoter,
+    order_validation::OrderValidator,
     orderbook::Orderbook,
     serve_api,
     solvable_orders::SolvableOrdersCache,

--- a/crates/orderbook/src/order_quoting.rs
+++ b/crates/orderbook/src/order_quoting.rs
@@ -1,0 +1,502 @@
+use crate::{
+    fee::{FeeData, MinFeeCalculating},
+    order_validation::{OrderValidating, PreOrderData, ValidationError},
+};
+use anyhow::Result;
+use chrono::{DateTime, Utc};
+use ethcontract::U256;
+use futures::try_join;
+use model::{
+    order::OrderKind,
+    quote::{
+        OrderQuote, OrderQuoteRequest, OrderQuoteResponse, OrderQuoteSide, PriceQuality, SellAmount,
+    },
+    u256_decimal,
+};
+use serde::Serialize;
+use shared::price_estimation::{self, single_estimate, PriceEstimating, PriceEstimationError};
+use std::sync::{
+    atomic::{AtomicU64, Ordering},
+    Arc,
+};
+
+impl From<&OrderQuoteRequest> for PreOrderData {
+    fn from(quote_request: &OrderQuoteRequest) -> Self {
+        let owner = quote_request.from;
+        Self {
+            owner,
+            sell_token: quote_request.sell_token,
+            buy_token: quote_request.buy_token,
+            receiver: quote_request.receiver.unwrap_or(owner),
+            valid_to: quote_request.validity.actual_valid_to(),
+            partially_fillable: quote_request.partially_fillable,
+            buy_token_balance: quote_request.buy_token_balance,
+            sell_token_balance: quote_request.sell_token_balance,
+            signing_scheme: quote_request.signing_scheme,
+            is_liquidity_order: quote_request.partially_fillable,
+        }
+    }
+}
+
+#[derive(Debug)]
+pub enum FeeError {
+    SellAmountDoesNotCoverFee(FeeInfo),
+    PriceEstimate(PriceEstimationError),
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FeeInfo {
+    #[serde(with = "u256_decimal")]
+    pub fee_amount: U256,
+    pub expiration: DateTime<Utc>,
+}
+
+#[derive(Debug)]
+pub enum OrderQuoteError {
+    Fee(FeeError),
+    Order(ValidationError),
+}
+
+#[derive(Debug, Serialize, PartialEq)]
+struct FeeParameters {
+    buy_amount: U256,
+    sell_amount: U256,
+    fee_amount: U256,
+    expiration: DateTime<Utc>,
+    kind: OrderKind,
+}
+
+#[derive(Clone)]
+pub struct OrderQuoter {
+    pub fee_calculator: Arc<dyn MinFeeCalculating>,
+    pub price_estimator: Arc<dyn PriceEstimating>,
+    pub order_validator: Arc<dyn OrderValidating>,
+    pub fast_fee_calculator: Arc<dyn MinFeeCalculating>,
+    pub fast_price_estimator: Arc<dyn PriceEstimating>,
+    pub current_id: Arc<AtomicU64>,
+}
+
+impl OrderQuoter {
+    pub fn new(
+        fee_calculator: Arc<dyn MinFeeCalculating>,
+        price_estimator: Arc<dyn PriceEstimating>,
+        order_validator: Arc<dyn OrderValidating>,
+    ) -> Self {
+        Self {
+            fast_fee_calculator: fee_calculator.clone(),
+            fast_price_estimator: price_estimator.clone(),
+            fee_calculator,
+            price_estimator,
+            order_validator,
+            current_id: Default::default(),
+        }
+    }
+
+    pub fn with_fast_quotes(
+        mut self,
+        fee_calculator: Arc<dyn MinFeeCalculating>,
+        price_estimator: Arc<dyn PriceEstimating>,
+    ) -> Self {
+        self.fast_fee_calculator = fee_calculator;
+        self.fast_price_estimator = price_estimator;
+        self
+    }
+
+    pub async fn calculate_quote(
+        &self,
+        quote_request: &OrderQuoteRequest,
+    ) -> Result<OrderQuoteResponse, OrderQuoteError> {
+        tracing::debug!("Received quote request {:?}", quote_request);
+        let pre_order = PreOrderData::from(quote_request);
+        let valid_to = pre_order.valid_to;
+        self.order_validator
+            .partial_validate(pre_order)
+            .await
+            .map_err(|err| OrderQuoteError::Order(ValidationError::Partial(err)))?;
+        let fee_parameters = self
+            .calculate_fee_parameters(quote_request)
+            .await
+            .map_err(OrderQuoteError::Fee)?;
+        Ok(OrderQuoteResponse {
+            quote: OrderQuote {
+                sell_token: quote_request.sell_token,
+                buy_token: quote_request.buy_token,
+                receiver: quote_request.receiver,
+                sell_amount: fee_parameters.sell_amount,
+                buy_amount: fee_parameters.buy_amount,
+                valid_to,
+                app_data: quote_request.app_data,
+                fee_amount: fee_parameters.fee_amount,
+                kind: fee_parameters.kind,
+                partially_fillable: quote_request.partially_fillable,
+                sell_token_balance: quote_request.sell_token_balance,
+                buy_token_balance: quote_request.buy_token_balance,
+            },
+            from: quote_request.from,
+            expiration: fee_parameters.expiration,
+            id: self.current_id.fetch_add(1, Ordering::SeqCst),
+        })
+    }
+
+    async fn calculate_fee_parameters(
+        &self,
+        quote_request: &OrderQuoteRequest,
+    ) -> Result<FeeParameters, FeeError> {
+        let (fee_calculator, price_estimator) = match quote_request.price_quality {
+            PriceQuality::Fast => (&self.fast_fee_calculator, &self.fast_price_estimator),
+            PriceQuality::Optimal => (&self.fee_calculator, &self.price_estimator),
+        };
+
+        Ok(match quote_request.side {
+            OrderQuoteSide::Sell {
+                sell_amount:
+                    SellAmount::BeforeFee {
+                        value: sell_amount_before_fee,
+                    },
+            } => {
+                if sell_amount_before_fee.is_zero() {
+                    return Err(FeeError::PriceEstimate(PriceEstimationError::ZeroAmount));
+                }
+                let query = price_estimation::Query {
+                    // It would be more correct to use sell_amount_after_fee here, however this makes the two long-running fee and price estimation queries dependent and causes very long roundtrip times
+                    // We therefore compute the exchange rate for the sell_amount_before_fee and assume that the price for selling a smaller amount (after fee) will be close to but at least as good
+                    sell_token: quote_request.sell_token,
+                    buy_token: quote_request.buy_token,
+                    in_amount: sell_amount_before_fee,
+                    kind: OrderKind::Sell,
+                };
+                let ((fee, expiration), estimate) = try_join!(
+                    fee_calculator.compute_subsidized_min_fee(
+                        FeeData {
+                            sell_token: quote_request.sell_token,
+                            buy_token: quote_request.buy_token,
+                            amount: sell_amount_before_fee,
+                            kind: OrderKind::Sell,
+                        },
+                        quote_request.app_data,
+                        quote_request.from,
+                    ),
+                    single_estimate(price_estimator.as_ref(), &query)
+                )
+                .map_err(FeeError::PriceEstimate)?;
+                let sell_amount_after_fee = sell_amount_before_fee
+                    .checked_sub(fee)
+                    .ok_or(FeeError::SellAmountDoesNotCoverFee(FeeInfo {
+                        fee_amount: fee,
+                        expiration,
+                    }))?
+                    .max(U256::one());
+                let buy_amount_after_fee =
+                    match estimate.out_amount.checked_mul(sell_amount_after_fee) {
+                        // sell_amount_before_fee is at least 1 (cf. above)
+                        Some(product) => product / sell_amount_before_fee,
+                        None => (estimate.out_amount / sell_amount_before_fee)
+                            .checked_mul(sell_amount_after_fee)
+                            .unwrap_or(U256::MAX),
+                    };
+                FeeParameters {
+                    buy_amount: buy_amount_after_fee,
+                    sell_amount: sell_amount_after_fee,
+                    fee_amount: fee,
+                    expiration,
+                    kind: OrderKind::Sell,
+                }
+            }
+            OrderQuoteSide::Sell {
+                sell_amount:
+                    SellAmount::AfterFee {
+                        value: sell_amount_after_fee,
+                    },
+            } => {
+                if sell_amount_after_fee.is_zero() {
+                    return Err(FeeError::PriceEstimate(PriceEstimationError::ZeroAmount));
+                }
+
+                let price_estimation_query = price_estimation::Query {
+                    sell_token: quote_request.sell_token,
+                    buy_token: quote_request.buy_token,
+                    in_amount: sell_amount_after_fee,
+                    kind: OrderKind::Sell,
+                };
+
+                // Since both futures are long running and independent, run concurrently
+                let ((fee, expiration), estimate) = try_join!(
+                    fee_calculator.compute_subsidized_min_fee(
+                        FeeData {
+                            sell_token: quote_request.sell_token,
+                            buy_token: quote_request.buy_token,
+                            amount: sell_amount_after_fee,
+                            kind: OrderKind::Sell,
+                        },
+                        quote_request.app_data,
+                        quote_request.from,
+                    ),
+                    single_estimate(price_estimator.as_ref(), &price_estimation_query)
+                )
+                .map_err(FeeError::PriceEstimate)?;
+                FeeParameters {
+                    buy_amount: estimate.out_amount,
+                    sell_amount: sell_amount_after_fee,
+                    fee_amount: fee,
+                    expiration,
+                    kind: OrderKind::Sell,
+                }
+            }
+            OrderQuoteSide::Buy {
+                buy_amount_after_fee,
+            } => {
+                if buy_amount_after_fee.is_zero() {
+                    return Err(FeeError::PriceEstimate(PriceEstimationError::ZeroAmount));
+                }
+
+                let price_estimation_query = price_estimation::Query {
+                    sell_token: quote_request.sell_token,
+                    buy_token: quote_request.buy_token,
+                    in_amount: buy_amount_after_fee,
+                    kind: OrderKind::Buy,
+                };
+
+                // Since both futures are long running and independent, run concurrently
+                let ((fee, expiration), estimate) = try_join!(
+                    fee_calculator.compute_subsidized_min_fee(
+                        FeeData {
+                            sell_token: quote_request.sell_token,
+                            buy_token: quote_request.buy_token,
+                            amount: buy_amount_after_fee,
+                            kind: OrderKind::Buy,
+                        },
+                        quote_request.app_data,
+                        quote_request.from,
+                    ),
+                    single_estimate(price_estimator.as_ref(), &price_estimation_query)
+                )
+                .map_err(FeeError::PriceEstimate)?;
+                let sell_amount_after_fee = estimate.out_amount;
+                FeeParameters {
+                    buy_amount: buy_amount_after_fee,
+                    sell_amount: sell_amount_after_fee,
+                    fee_amount: fee,
+                    expiration,
+                    kind: OrderKind::Buy,
+                }
+            }
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{fee::MockMinFeeCalculating, order_validation::MockOrderValidating};
+    use chrono::Utc;
+    use ethcontract::H160;
+    use futures::FutureExt;
+    use model::{quote::Validity, time};
+    use shared::price_estimation::mocks::FakePriceEstimator;
+
+    #[test]
+    fn calculate_fee_sell_before_fees_quote_request() {
+        let mut fee_calculator = MockMinFeeCalculating::new();
+
+        let expiration = Utc::now();
+        fee_calculator
+            .expect_compute_subsidized_min_fee()
+            .returning(move |_, _, _| Ok((3.into(), expiration)));
+
+        let fee_calculator = Arc::new(fee_calculator);
+        let price_estimator = FakePriceEstimator(price_estimation::Estimate {
+            out_amount: 14.into(),
+            gas: 1000,
+        });
+        let sell_query = OrderQuoteRequest::new(
+            H160::from_low_u64_ne(0),
+            H160::from_low_u64_ne(1),
+            OrderQuoteSide::Sell {
+                sell_amount: SellAmount::BeforeFee { value: 10.into() },
+            },
+        );
+        let quoter = Arc::new(OrderQuoter::new(
+            fee_calculator,
+            Arc::new(price_estimator),
+            Arc::new(MockOrderValidating::new()),
+        ));
+        let result = quoter
+            .calculate_fee_parameters(&sell_query)
+            .now_or_never()
+            .unwrap()
+            .unwrap();
+        // After the deducting the fee 10 - 3 = 7 units of sell token are being sold.
+        // Selling 10 units will buy us 14. Therefore, selling 7 should buy us 9.8 => 9 whole units
+        assert_eq!(
+            result,
+            FeeParameters {
+                buy_amount: 9.into(),
+                sell_amount: 7.into(),
+                fee_amount: 3.into(),
+                expiration,
+                kind: OrderKind::Sell
+            }
+        );
+    }
+
+    #[test]
+    fn calculate_fee_sell_after_fees_quote_request() {
+        let mut fee_calculator = MockMinFeeCalculating::new();
+        let expiration = Utc::now();
+        fee_calculator
+            .expect_compute_subsidized_min_fee()
+            .returning(move |_, _, _| Ok((3.into(), expiration)));
+
+        let fee_calculator = Arc::new(fee_calculator);
+        let price_estimator = FakePriceEstimator(price_estimation::Estimate {
+            out_amount: 14.into(),
+            gas: 1000,
+        });
+        let sell_query = OrderQuoteRequest::new(
+            H160::from_low_u64_ne(0),
+            H160::from_low_u64_ne(1),
+            OrderQuoteSide::Sell {
+                sell_amount: SellAmount::AfterFee { value: 7.into() },
+            },
+        );
+
+        let quoter = Arc::new(OrderQuoter::new(
+            fee_calculator,
+            Arc::new(price_estimator),
+            Arc::new(MockOrderValidating::new()),
+        ));
+        let result = quoter
+            .calculate_fee_parameters(&sell_query)
+            .now_or_never()
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            result,
+            FeeParameters {
+                buy_amount: 14.into(),
+                sell_amount: 7.into(),
+                fee_amount: 3.into(),
+                expiration,
+                kind: OrderKind::Sell
+            }
+        );
+    }
+
+    #[test]
+    fn calculate_fee_buy_quote_request() {
+        let mut fee_calculator = MockMinFeeCalculating::new();
+        let expiration = Utc::now();
+        fee_calculator
+            .expect_compute_subsidized_min_fee()
+            .returning(move |_, _, _| Ok((3.into(), expiration)));
+
+        let fee_calculator = Arc::new(fee_calculator);
+        let price_estimator = FakePriceEstimator(price_estimation::Estimate {
+            out_amount: 20.into(),
+            gas: 1000,
+        });
+        let buy_query = OrderQuoteRequest::new(
+            H160::from_low_u64_ne(0),
+            H160::from_low_u64_ne(1),
+            OrderQuoteSide::Buy {
+                buy_amount_after_fee: 10.into(),
+            },
+        );
+        let quoter = Arc::new(OrderQuoter::new(
+            fee_calculator,
+            Arc::new(price_estimator),
+            Arc::new(MockOrderValidating::new()),
+        ));
+        let result = quoter
+            .calculate_fee_parameters(&buy_query)
+            .now_or_never()
+            .unwrap()
+            .unwrap();
+        // To buy 10 units of buy_token the fee in sell_token must be at least 3 and at least 20
+        // units of sell_token must be sold.
+        assert_eq!(
+            result,
+            FeeParameters {
+                buy_amount: 10.into(),
+                sell_amount: 20.into(),
+                fee_amount: 3.into(),
+                expiration,
+                kind: OrderKind::Buy
+            }
+        );
+    }
+
+    #[test]
+    fn pre_order_data_from_quote_request() {
+        let quote_request = OrderQuoteRequest {
+            validity: Validity::To(0),
+            ..Default::default()
+        };
+        let result = PreOrderData::from(&quote_request);
+        let expected = PreOrderData::default();
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn pre_order_data_from_quote_request_with_valid_for() {
+        let quote_request = OrderQuoteRequest {
+            validity: Validity::For(100),
+            ..Default::default()
+        };
+        let result = PreOrderData::from(&quote_request);
+
+        let valid_duration = result.valid_to - time::now_in_epoch_seconds();
+
+        // use time-range to make sure test isn't flaky.
+        assert!((95..=105).contains(&valid_duration));
+    }
+
+    #[tokio::test]
+    async fn calculate_quote() {
+        let buy_request = OrderQuoteRequest {
+            sell_token: H160::from_low_u64_be(1),
+            buy_token: H160::from_low_u64_be(2),
+            side: OrderQuoteSide::Buy {
+                buy_amount_after_fee: 2.into(),
+            },
+            validity: Validity::To(0),
+            ..Default::default()
+        };
+
+        let mut fee_calculator = MockMinFeeCalculating::new();
+        fee_calculator
+            .expect_compute_subsidized_min_fee()
+            .returning(move |_, _, _| Ok((3.into(), Utc::now())));
+        let price_estimator = FakePriceEstimator(price_estimation::Estimate {
+            out_amount: 14.into(),
+            gas: 1000,
+        });
+        let mut order_validator = MockOrderValidating::new();
+        order_validator
+            .expect_partial_validate()
+            .returning(|_| Ok(()));
+        let quoter = Arc::new(OrderQuoter::new(
+            Arc::new(fee_calculator),
+            Arc::new(price_estimator),
+            Arc::new(order_validator),
+        ));
+        let result = quoter.calculate_quote(&buy_request).await.unwrap();
+
+        let expected = OrderQuote {
+            sell_token: H160::from_low_u64_be(1),
+            buy_token: H160::from_low_u64_be(2),
+            receiver: None,
+            sell_amount: 14.into(),
+            kind: OrderKind::Buy,
+            partially_fillable: false,
+            sell_token_balance: Default::default(),
+            buy_amount: 2.into(),
+            valid_to: 0,
+            app_data: Default::default(),
+            fee_amount: 3.into(),
+            buy_token_balance: Default::default(),
+        };
+        assert_eq!(result.quote, expected);
+    }
+}

--- a/crates/orderbook/src/orderbook.rs
+++ b/crates/orderbook/src/orderbook.rs
@@ -1,6 +1,6 @@
 use crate::{
-    api::order_validation::{OrderValidating, ValidationError},
     database::orders::{InsertionError, OrderFilter, OrderStoring},
+    order_validation::{OrderValidating, ValidationError},
     solvable_orders::{SolvableOrders, SolvableOrdersCache},
 };
 use anyhow::{ensure, Context, Result};
@@ -373,8 +373,8 @@ fn set_available_balances(orders: &mut [Order], cache: &SolvableOrdersCache) {
 mod tests {
     use super::*;
     use crate::{
-        account_balances::MockBalanceFetching, api::order_validation::MockOrderValidating,
-        database::orders::MockOrderStoring, metrics::NoopMetrics,
+        account_balances::MockBalanceFetching, database::orders::MockOrderStoring,
+        metrics::NoopMetrics, order_validation::MockOrderValidating,
     };
     use ethcontract::H160;
     use futures::FutureExt;


### PR DESCRIPTION
This PR just trivially moves code around into new modules to accommodate upcoming changes to quotes (so that they get stored in the database alongside fees).

1. Refactor order quoting component outside of the `api::post_quote` module into its own thing. The motivation here is that we will move fee computation and quote storing into the `order_quoting` tree.
2. Move `order_validation` outside of `api::` - it was the only submodule that wasn't dedicated to API routes, and was a bit unintuitive for me to find.

### Test Plan

CI. Code just moved. 0 logic changes.
