### PR TITLE
Verbose error message on node startup failure

### DIFF
--- a/crates/solver/src/main.rs
+++ b/crates/solver/src/main.rs
@@ -556,10 +556,10 @@ async fn main() {
         })
         .collect::<Vec<_>>();
     for (node, url) in &submission_nodes_with_url {
-        let node_network_id = node.net().version().await.unwrap_or_else(|_| {
+        let node_network_id = node.net().version().await.unwrap_or_else(|err| {
             panic!(
-                "Unable to retrieve network id on startup using the submission node at {}",
-                url
+                "Unable to retrieve network id on startup using the submission node at {}. Error: {}",
+                url, err
             )
         });
         assert_eq!(

--- a/crates/solver/src/main.rs
+++ b/crates/solver/src/main.rs
@@ -561,9 +561,11 @@ async fn main() {
             .net()
             .version()
             .await
-            .context(format!(
-                "Unable to retrieve network id on startup using the submission node at {url}"
-            ))
+            .with_context(|| {
+                format!(
+                    "Unable to retrieve network id on startup using the submission node at {url}"
+                )
+            })
             .unwrap();
         assert_eq!(
             node_network_id, network_id,

--- a/crates/solver/src/main.rs
+++ b/crates/solver/src/main.rs
@@ -543,25 +543,34 @@ async fn main() {
             .await
             .map_err(|err| tracing::error!("Couldn't fetch market makable token list: {}", err))
             .ok();
-    let submission_nodes = args
+    let submission_nodes_with_url = args
         .transaction_submission_nodes
         .into_iter()
         .enumerate()
         .map(|(index, url)| {
             let transport = create_instrumented_transport(
-                HttpTransport::new(client.clone(), url, index.to_string()),
+                HttpTransport::new(client.clone(), url.clone(), index.to_string()),
                 metrics.clone(),
             );
-            web3::Web3::new(transport)
+            (web3::Web3::new(transport), url)
         })
         .collect::<Vec<_>>();
-    for node in &submission_nodes {
-        let node_network_id = node.net().version().await.unwrap();
+    for (node, url) in &submission_nodes_with_url {
+        let node_network_id = node.net().version().await.unwrap_or_else(|_| {
+            panic!(
+                "Unable to retrieve network id on startup using the submission node at {}",
+                url
+            )
+        });
         assert_eq!(
             node_network_id, network_id,
             "network id of custom node doesn't match main node"
         );
     }
+    let submission_nodes = submission_nodes_with_url
+        .into_iter()
+        .map(|(node, _)| node)
+        .collect::<Vec<_>>();
     let submitted_transactions = GlobalTxPool::default();
     let mut transaction_strategies = vec![];
     for strategy in args.transaction_strategy {

--- a/crates/solver/src/main.rs
+++ b/crates/solver/src/main.rs
@@ -1,3 +1,4 @@
+use anyhow::Context;
 use clap::{ArgEnum, Parser};
 use contracts::{BalancerV2Vault, IUniswapLikeRouter, WETH9};
 use ethcontract::H160;
@@ -556,12 +557,14 @@ async fn main() {
         })
         .collect::<Vec<_>>();
     for (node, url) in &submission_nodes_with_url {
-        let node_network_id = node.net().version().await.unwrap_or_else(|err| {
-            panic!(
-                "Unable to retrieve network id on startup using the submission node at {}. Error: {}",
-                url, err
-            )
-        });
+        let node_network_id = node
+            .net()
+            .version()
+            .await
+            .context(format!(
+                "Unable to retrieve network id on startup using the submission node at {url}"
+            ))
+            .unwrap();
         assert_eq!(
             node_network_id, network_id,
             "network id of custom node doesn't match main node"


### PR DESCRIPTION
This change makes it easier to understand which transaction node is failing on startup.
Without this change, it could be unclear which submission node is failing for some error types ([example](https://cowservices.slack.com/archives/C0371SB243E/p1655301131999599)).

### Test Plan

See the new panic:

```
cargo run -p solver -- --orderbook-url "https://barn.api.cow.fi/mainnet/api" --node-url ""https://mainnet.infura.io/v3/$INFURA_KEY"" --transaction-submission-nodes http://bad.node/bad/path --solver-account 0x0000000000000000000000000000000000000000
[...]
2022-06-16T10:49:27.815Z ERROR shared::tracing: thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: Unable to retrieve network id on startup using the submission node at http://bad.node/bad/path

Caused by:
    failed to send request: error sending request for url (http://bad.node/bad/path): error trying to connect: dns error: failed to lookup address information: Name or service not known', crates/solver/src/main.rs:567:14:
thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: Unable to retrieve network id on startup using the submission node at http://bad.node/bad/path

Caused by:
    failed to send request: error sending request for url (http://bad.node/bad/path): error trying to connect: dns error: failed to lookup address information: Name or service not known', crates/solver/src/main.rs:567:14
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```
