### PR TITLE
Prevent storing fast fee estimates

### DIFF
--- a/crates/e2e/tests/e2e/services.rs
+++ b/crates/e2e/tests/e2e/services.rs
@@ -157,6 +157,7 @@ impl OrderbookServices {
             native_price_estimator.clone(),
             Arc::new(FixedCowSubsidy(1.0)),
             Default::default(),
+            true,
         ));
         let balance_fetcher = Arc::new(Web3BalanceFetcher::new(
             web3.clone(),

--- a/crates/orderbook/openapi.yml
+++ b/crates/orderbook/openapi.yml
@@ -616,7 +616,9 @@ components:
       type: string
       enum: [erc20, internal]
     PriceQuality:
-      description: How good should the price estimate be?
+      description: |
+        How good should the price estimate be?
+        Note that orders are supposed to be created from "optimal" price estimates.
       type: string
       enum: [fast, optimal]
     OrderStatus:

--- a/crates/orderbook/src/fee.rs
+++ b/crates/orderbook/src/fee.rs
@@ -350,10 +350,6 @@ impl MinFeeCalculating for MinFeeCalculator {
                         tracing::warn!(?err, "error saving fee measurement");
                     }
                 } else {
-                    // Set an expired timeout to signal that this fee estimate is only indicative
-                    // and not supposed to be used to create actual orders with it.
-                    official_valid_until =
-                        DateTime::from_utc(NaiveDateTime::from_timestamp(0, 0), Utc);
                     tracing::debug!("skip saving fee measurement");
                 }
 
@@ -371,6 +367,12 @@ impl MinFeeCalculating for MinFeeCalculator {
             "computed subsidized fee of {:?}",
             (subsidized_min_fee, fee_data.sell_token),
         );
+
+        if !self.store_computed_fees {
+            // Set an expired timeout to signal that this fee estimate is only indicative
+            // and not supposed to be used to create actual orders with it.
+            official_valid_until = DateTime::from_utc(NaiveDateTime::from_timestamp(0, 0), Utc);
+        }
 
         Ok((subsidized_min_fee, official_valid_until))
     }

--- a/crates/orderbook/src/fee.rs
+++ b/crates/orderbook/src/fee.rs
@@ -371,6 +371,10 @@ impl MinFeeCalculating for MinFeeCalculator {
         if !self.store_computed_fees {
             // Set an expired timeout to signal that this fee estimate is only indicative
             // and not supposed to be used to create actual orders with it.
+            //
+            // Technically we could only set this sentinel when we had to compute a fee
+            // estimate from scratch but to make it more consistent for the user we'll always
+            // return this value when the fee estimate will not end up in the database.
             official_valid_until = DateTime::from_utc(NaiveDateTime::from_timestamp(0, 0), Utc);
         }
 

--- a/crates/orderbook/src/main.rs
+++ b/crates/orderbook/src/main.rs
@@ -680,7 +680,8 @@ async fn main() {
         }
     };
 
-    let create_fee_calculator = |price_estimator: Arc<dyn PriceEstimating>| {
+    let create_fee_calculator = |price_estimator: Arc<dyn PriceEstimating>,
+                                 store_computed_fees: bool| {
         Arc::new(MinFeeCalculator::new(
             price_estimator.clone(),
             gas_price_estimator.clone(),
@@ -695,10 +696,11 @@ async fn main() {
             native_price_estimator.clone(),
             cow_subsidy.clone(),
             args.liquidity_order_owners.iter().copied().collect(),
+            store_computed_fees,
         ))
     };
-    let fee_calculator = create_fee_calculator(price_estimator.clone());
-    let fast_fee_calculator = create_fee_calculator(fast_price_estimator.clone());
+    let fee_calculator = create_fee_calculator(price_estimator.clone(), true);
+    let fast_fee_calculator = create_fee_calculator(fast_price_estimator.clone(), false);
 
     let solvable_orders_cache = SolvableOrdersCache::new(
         args.min_order_validity_period,


### PR DESCRIPTION
This [slack thread](https://cowservices.slack.com/archives/C036JAGRQ04/p1655373828067479?thread_ts=1655371868.842249&cid=C036JAGRQ04) showed that it's problematic to allow users to create orders using fee estimates coming from the `fast` price estimator.
Instead users should have to use quotes coming from an `optimal` estimate.

A very simply fix should be to simply not store `FeeData` coming from the `MinFeeCalculator` using the `fast` price estimator.
If a user would then try to create an order using a quote from the `fast` endpoint the orderbook would not find the `FeeData` in the DB, compute it from scratch with the `optimal` price estimator and reject the order if the fee measurements conflict.

### Test Plan
Unit test verifying that `MinFeeCalculator` can be configured such that it doesn't store the calculated `FeeData` in the database and returns sentinel `valid_to` value in such cases.
