### PR TITLE
Give solver competition endpoint larger size limit

### DIFF
--- a/crates/orderbook/src/api/post_solver_competition.rs
+++ b/crates/orderbook/src/api/post_solver_competition.rs
@@ -14,7 +14,10 @@ fn request(
     warp::path!("solver_competition" / u64)
         .and(warp::post())
         .and(warp::header::optional::<String>("Authorization"))
-        .and(crate::api::extract_payload())
+        // While this is an authenticated endpoint we still want to protect against very large
+        // that might originate from bugs.
+        .and(warp::body::content_length_limit(1e6 as u64))
+        .and(warp::body::json())
 }
 
 pub fn post(

--- a/crates/orderbook/src/solver_competition.rs
+++ b/crates/orderbook/src/solver_competition.rs
@@ -6,7 +6,10 @@ use std::sync::Mutex;
 
 type AuctionId = u64;
 
-const CACHE_SIZE: usize = 1000;
+// The size controls
+// - how long we store competition info depending on how often the driver run loop completes
+// - how much memory the cache takes up depending on how big the average response is
+const CACHE_SIZE: usize = 500;
 
 pub struct SolverCompetition {
     cache: Mutex<SizedCache<AuctionId, SolverCompetitionResponse>>,

--- a/crates/solver/src/driver.rs
+++ b/crates/solver/src/driver.rs
@@ -712,9 +712,13 @@ impl Driver {
                 })
                 .collect(),
         };
-        // This will happen again after transaction submission with the tx hash.
-        self.send_solver_competition(auction_id, &solver_competition_response)
-            .await;
+        // Don't bother sending if there were no solutions so we don't take up space in the
+        // competition info cache in the orderbook.
+        if !solver_competition_response.solutions.is_empty() {
+            // This will happen again after transaction submission with the tx hash.
+            self.send_solver_competition(auction_id, &solver_competition_response)
+                .await;
+        }
 
         if let Some((winning_solver, mut winning_settlement, access_list)) = rated_settlements.pop()
         {


### PR DESCRIPTION
We have a default of 16 KiB limit which is likely exceeded when there
are several solutions with calldata causing the solver competition
endpoint to not accept the data from the driver.

### Test Plan

CI and manual test after merging. Would be easier to diagnose if https://github.com/cowprotocol/services/pull/279 got merged first.
