### PR TITLE
Change token owner finding error log to warning

### DIFF
--- a/crates/shared/src/bad_token/trace_call.rs
+++ b/crates/shared/src/bad_token/trace_call.rs
@@ -77,7 +77,7 @@ impl TraceCallDetector {
             candidates.extend(match result {
                 Ok(candidates) => candidates,
                 Err(err) => {
-                    tracing::error!("token owner finding failed: {:?}", err);
+                    tracing::warn!("token owner finding failed: {:?}", err);
                     continue;
                 }
             });


### PR DESCRIPTION
This error is not serious enough to warrant an error log.

The context is that in today's prod release we saw that we were getting this error log a lot from the Blockscout TokenOwnerFinding implementation.

### Test Plan

CI
