### PR TITLE
Convert some insteances of CounterVec to IntCounterVec

### DIFF
--- a/crates/orderbook/src/api.rs
+++ b/crates/orderbook/src/api.rs
@@ -225,11 +225,11 @@ async fn handle_rejection(err: Rejection) -> Result<impl Reply, Infallible> {
 struct ApiMetrics {
     /// Number of completed API requests.
     #[metric(labels("method", "status_code"))]
-    requests_complete: prometheus::CounterVec,
+    requests_complete: prometheus::IntCounterVec,
 
     /// Number of rejected API requests.
     #[metric(labels("status_code"))]
-    requests_rejected: prometheus::CounterVec,
+    requests_rejected: prometheus::IntCounterVec,
 
     /// Execution time for each API request.
     #[metric(labels("method"))]

--- a/crates/orderbook/src/orderbook.rs
+++ b/crates/orderbook/src/orderbook.rs
@@ -21,7 +21,7 @@ use thiserror::Error;
 struct Metrics {
     /// Counter for measuring order statistics.
     #[metric(labels("kind", "operation"))]
-    orders: prometheus::CounterVec,
+    orders: prometheus::IntCounterVec,
 }
 
 enum OrderOperation {

--- a/crates/shared/src/bad_token/instrumented.rs
+++ b/crates/shared/src/bad_token/instrumented.rs
@@ -1,7 +1,7 @@
 use super::{BadTokenDetecting, TokenQuality};
 use crate::metrics::get_metric_storage_registry;
 use anyhow::Result;
-use prometheus::CounterVec;
+use prometheus::IntCounterVec;
 use prometheus_metric_storage::MetricStorage;
 
 pub trait InstrumentedBadTokenDetectorExt {
@@ -21,7 +21,7 @@ impl<T: BadTokenDetecting + 'static> InstrumentedBadTokenDetectorExt for T {
 struct Metrics {
     /// Tracks how many token detections result in good or bad token quality or an error.
     #[metric(labels("quality"))]
-    results: CounterVec,
+    results: IntCounterVec,
 }
 
 pub struct InstrumentedBadTokenDetector {

--- a/crates/shared/src/price_estimation/competition.rs
+++ b/crates/shared/src/price_estimation/competition.rs
@@ -182,7 +182,7 @@ struct Metrics {
     /// total metrics. Additionally, this allows us to see how different
     /// estimators behave for buy vs sell orders.
     #[metric(labels("estimator_type", "order_kind"))]
-    queries_won: prometheus::CounterVec,
+    queries_won: prometheus::IntCounterVec,
 }
 
 fn metrics() -> &'static Metrics {

--- a/crates/shared/src/rate_limiter.rs
+++ b/crates/shared/src/rate_limiter.rs
@@ -13,13 +13,13 @@ use thiserror::Error;
 struct Metrics {
     /// Number of requests dropped while being rate limited.
     #[metric(labels("endpoint"))]
-    requests_dropped: prometheus::CounterVec,
+    requests_dropped: prometheus::IntCounterVec,
     /// Number of responses indicating a rate limiting error.
     #[metric(labels("endpoint"))]
-    rate_limited_requests: prometheus::CounterVec,
+    rate_limited_requests: prometheus::IntCounterVec,
     /// Number of successful requests.
     #[metric(labels("endpoint"))]
-    successful_requests: prometheus::CounterVec,
+    successful_requests: prometheus::IntCounterVec,
 }
 
 fn metrics() -> &'static Metrics {

--- a/crates/shared/src/transport/http.rs
+++ b/crates/shared/src/transport/http.rs
@@ -230,7 +230,7 @@ struct TransportMetrics {
 
     /// Number of completed RPC requests for ethereum node.
     #[metric(labels("method"))]
-    requests_complete: prometheus::CounterVec,
+    requests_complete: prometheus::IntCounterVec,
 
     /// Execution time for each RPC request (batches are counted as one request).
     #[metric(labels("method"))]

--- a/crates/solver/src/settlement_submission/submitter.rs
+++ b/crates/solver/src/settlement_submission/submitter.rs
@@ -618,10 +618,10 @@ async fn find_mined_transaction(web3: &Web3, hashes: &[H256]) -> Option<Transact
 struct Metrics {
     /// Tracks how many transactions get successfully submitted with the different submission strategies.
     #[metric(labels("submitter", "result"))]
-    submissions: prometheus::CounterVec,
+    submissions: prometheus::IntCounterVec,
     /// Tracks how many transactions get successfully mined by the different submission strategies.
     #[metric(labels("submitter"))]
-    mined_transactions: prometheus::CounterVec,
+    mined_transactions: prometheus::IntCounterVec,
 }
 
 pub(crate) fn track_submission_success(submitter: &str, was_successful: bool) {


### PR DESCRIPTION
The prometheus documentation states that the Int version is more
performant and can be used when all values are natural numbers.
Internally this is based on u64 instead of f64.

We were already using the Int version in some places so this just makes it more consistent.

### Test Plan

CI