### PR TITLE
Alter Database Schema for quote storage

### DIFF
--- a/crates/orderbook/src/database.rs
+++ b/crates/orderbook/src/database.rs
@@ -17,10 +17,10 @@ const ALL_TABLES: [&str; 7] = [
     "orders",
     "trades",
     "invalidations",
-    "min_fee_measurements",
+    "quotes",
     "settlements",
     "presignature_events",
-    "order_fee_parameters",
+    "order_quotes",
 ];
 
 // The pool uses an Arc internally.

--- a/database/sql/V021__store_full_quotes.sql
+++ b/database/sql/V021__store_full_quotes.sql
@@ -1,0 +1,27 @@
+-- This migration step will change how we store min-fee measurements to store
+-- full quote data that can later be attached to an order.
+--
+-- This involves adding new columns for buy and sell amounts in the quotes as
+-- well as renaming the tables so its more apparent what they are for.
+-- Additionally, for the quotes table, we add a `bigserial` ID column for
+-- generating unique quote IDs for each order.
+
+ALTER TABLE min_fee_measurements RENAME TO quotes;
+ALTER INDEX min_fee_measurements_token_expiration RENAME TO quotes_token_expiration;
+DELETE FROM quotes;
+ALTER TABLE quotes
+    DROP COLUMN amount,
+    ALTER COLUMN buy_token SET NOT NULL,
+    ALTER COLUMN order_kind SET NOT NULL,
+    ADD COLUMN id bigserial PRIMARY KEY,
+    ADD COLUMN sell_amount numeric(78,0) NOT NULL,
+    ADD COLUMN buy_amount numeric(78,0) NOT NULL;
+
+ALTER TABLE order_fee_parameters RENAME TO order_quotes;
+ALTER INDEX order_fee_parameters_pkey RENAME TO order_quotes_pkey;
+ALTER TABLE order_quotes
+    ADD COLUMN sell_amount numeric(78,0) NOT NULL DEFAULT 0,
+    ADD COLUMN buy_amount numeric(78,0) NOT NULL DEFAULT 0;
+ALTER TABLE order_quotes
+    ALTER COLUMN sell_amount DROP DEFAULT,
+    ALTER COLUMN buy_amount DROP DEFAULT;

--- a/database/sql/V021__store_full_quotes.sql
+++ b/database/sql/V021__store_full_quotes.sql
@@ -7,7 +7,7 @@
 -- generating unique quote IDs for each order.
 
 ALTER TABLE min_fee_measurements RENAME TO quotes;
-ALTER INDEX min_fee_measurements_token_expiration RENAME TO quotes_token_expiration;
+DROP INDEX min_fee_measurements_token_expiration;
 DELETE FROM quotes;
 ALTER TABLE quotes
     DROP COLUMN amount,
@@ -16,6 +16,8 @@ ALTER TABLE quotes
     ADD COLUMN id bigserial PRIMARY KEY,
     ADD COLUMN sell_amount numeric(78,0) NOT NULL,
     ADD COLUMN buy_amount numeric(78,0) NOT NULL;
+CREATE INDEX quotes_token_expiration ON quotes USING BTREE
+    (sell_token, buy_token, expiration_timestamp DESC);
 
 ALTER TABLE order_fee_parameters RENAME TO order_quotes;
 ALTER INDEX order_fee_parameters_pkey RENAME TO order_quotes_pkey;


### PR DESCRIPTION
This PR applies a new migration to our Postgres database in order to get it ready for storing full quotes.

Additionally, it modifies the components used for storing min fee measurements and retrieving order fee parameters to use "dummy" values in the meantime, so that they can continue to work with the new database schema (and keep the PRs as short as possible). I also felt that there are enough important details that I didn't want to get lost in larger changes (see 👇).

There are a couple of notable changes that merit some additional discussion:
- We populate `{buy,sell}_amount` values with `0` for existing order quotes. This means that we should be able to distinguish between orders with stored fee parameters "pre-quote-storage" and "post-quote-storage". Some alternatives:
    * Allow `NULL` values. The reason I chose against this is that we [disallow orders with zero amounts](https://github.com/cowprotocol/services/blob/f5fcd0d542913e8cb78efde2927baff47d5f4c18/crates/orderbook/src/order_validation.rs#L83) meaning that 0 _should_ be a reasonable marker value for "not there". Additionally, it would make us have hard database errors if we ever try to create order quotes with missing amounts. This is, however, a good alternative IMO.
    * Use the order's `{buy,sell}_amount`. I chose against this as there is some loss of information (i.e. we lose the information about which order was created "pre-quote-storage" and "post-quote-storage"). Furthermore, this can be "emulated" at a query level if it would be useful.
- The `find_measurement_including_larger_amount` logic is slightly different (i.e. it does NOT allow larger buy amounts). This is slightly more correct as only sell amounts (because of `sellAmountBeforeFee` quotes) can be lower than the stored fee measurement.

### Test Plan

CI. Nothing very notable added except we modified the current database component implementation to support the new schema (with 

### Release notes

This PR applies a new migration to our Postgres database. Be prepared to be able to roll back the database in case of any issues.
