### PR TITLE
Implemented quote storage for Postgres

### DIFF
--- a/crates/model/src/quote.rs
+++ b/crates/model/src/quote.rs
@@ -170,7 +170,7 @@ pub struct OrderQuote {
     pub buy_token_balance: BuyTokenDestination,
 }
 
-pub type QuoteId = u64;
+pub type QuoteId = i64;
 
 #[derive(Clone, Debug, PartialEq, Serialize)]
 #[serde(rename_all = "camelCase")]

--- a/crates/orderbook/src/database.rs
+++ b/crates/orderbook/src/database.rs
@@ -2,6 +2,7 @@ pub mod events;
 pub mod fees;
 pub mod instrumented;
 pub mod orders;
+pub mod quotes;
 pub mod trades;
 
 use anyhow::Result;

--- a/crates/orderbook/src/database/fees.rs
+++ b/crates/orderbook/src/database/fees.rs
@@ -3,143 +3,11 @@ use crate::{
     conversions::*,
     fee::{FeeData, MinFeeStoring},
     fee_subsidy::FeeParameters,
-    order_quoting::{QuoteData, QuoteSearchParameters, QuoteStoring},
+    order_quoting::{QuoteData, QuoteSearchParameters, QuoteStoring as _},
 };
 use anyhow::{Context, Result};
-use bigdecimal::BigDecimal;
 use chrono::{DateTime, Utc};
-use model::{order::OrderKind, quote::QuoteId};
-use shared::maintenance::Maintaining;
-
-#[derive(sqlx::FromRow)]
-struct QuoteRow {
-    id: QuoteId,
-    sell_token: Vec<u8>,
-    buy_token: Vec<u8>,
-    sell_amount: BigDecimal,
-    buy_amount: BigDecimal,
-    gas_amount: f64,
-    gas_price: f64,
-    sell_token_price: f64,
-    order_kind: DbOrderKind,
-    expiration_timestamp: DateTime<Utc>,
-}
-
-impl TryFrom<QuoteRow> for QuoteData {
-    type Error = anyhow::Error;
-
-    fn try_from(row: QuoteRow) -> Result<QuoteData> {
-        Ok(QuoteData {
-            sell_token: h160_from_vec(row.sell_token)?,
-            buy_token: h160_from_vec(row.buy_token)?,
-            quoted_sell_amount: big_decimal_to_u256(&row.sell_amount)
-                .context("quoted sell amount is not a valid U256")?,
-            quoted_buy_amount: big_decimal_to_u256(&row.buy_amount)
-                .context("quoted buy amount is not a valid U256")?,
-            fee_parameters: FeeParameters {
-                gas_amount: row.gas_amount,
-                gas_price: row.gas_price,
-                sell_token_price: row.sell_token_price,
-            },
-            kind: row.order_kind.into(),
-            expiration: row.expiration_timestamp,
-        })
-    }
-}
-
-#[async_trait::async_trait]
-impl QuoteStoring for Postgres {
-    async fn save(&self, data: QuoteData) -> Result<Option<QuoteId>> {
-        const QUERY: &str = r#"
-            INSERT INTO quotes (
-                sell_token,
-                buy_token,
-                sell_amount,
-                buy_amount,
-                gas_amount,
-                gas_price,
-                sell_token_price,
-                order_kind,
-                expiration_timestamp
-            )
-            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
-            RETURNING id
-        ;"#;
-
-        let (id,) = sqlx::query_as(QUERY)
-            .bind(data.sell_token.as_bytes())
-            .bind(data.buy_token.as_bytes())
-            .bind(u256_to_big_decimal(&data.quoted_sell_amount))
-            .bind(u256_to_big_decimal(&data.quoted_buy_amount))
-            .bind(&data.fee_parameters.gas_amount)
-            .bind(&data.fee_parameters.gas_price)
-            .bind(&data.fee_parameters.sell_token_price)
-            .bind(DbOrderKind::from(data.kind))
-            .bind(data.expiration)
-            .fetch_one(&self.pool)
-            .await
-            .context("failed to insert quote")?;
-
-        Ok(Some(id))
-    }
-
-    async fn get(&self, id: QuoteId, _: DateTime<Utc>) -> Result<Option<QuoteData>> {
-        const QUERY: &str = r#"
-            SELECT *
-            FROM quotes
-            WHERE id = $1
-        ;"#;
-
-        let quote: Option<QuoteRow> = sqlx::query_as(QUERY)
-            .bind(id)
-            .fetch_optional(&self.pool)
-            .await
-            .context("failed to get quote by ID")?;
-
-        quote.map(TryFrom::try_from).transpose()
-    }
-
-    async fn find(
-        &self,
-        parameters: QuoteSearchParameters,
-        expiration: DateTime<Utc>,
-    ) -> Result<Option<(QuoteId, QuoteData)>> {
-        const QUERY: &str = r#"
-            SELECT *
-            FROM quotes
-            WHERE
-                sell_token = $1 AND
-                buy_token = $2 AND
-                (
-                    order_kind = 'sell' AND sell_amount = $3 OR
-                    order_kind = 'sell' AND sell_amount = $4 OR
-                    order_kind = 'buy' AND buy_amount = $5
-                ) AND
-                order_kind = $6 AND
-                expiration_timestamp >= $7
-            ORDER BY gas_amount * gas_price * sell_token_price ASC
-            LIMIT 1
-        ;"#;
-
-        let quote: Option<QuoteRow> = sqlx::query_as(QUERY)
-            .bind(parameters.sell_token.as_bytes())
-            .bind(parameters.buy_token.as_bytes())
-            .bind(u256_to_big_decimal(&parameters.sell_amount))
-            .bind(u256_to_big_decimal(
-                &(parameters.sell_amount + parameters.fee_amount),
-            ))
-            .bind(u256_to_big_decimal(&parameters.buy_amount))
-            .bind(DbOrderKind::from(parameters.kind))
-            .bind(expiration)
-            .fetch_optional(&self.pool)
-            .await
-            .context("failed finding quote by parameters")?;
-
-        quote
-            .map(|quote| Ok((quote.id, quote.try_into()?)))
-            .transpose()
-    }
-}
+use model::order::OrderKind;
 
 #[derive(sqlx::FromRow)]
 struct FeeRow {
@@ -243,207 +111,74 @@ impl MinFeeStoring for Postgres {
     }
 }
 
-impl Postgres {
-    pub async fn remove_expired_quotes(&self, max_expiry: DateTime<Utc>) -> Result<()> {
-        const QUERY: &str = "DELETE FROM quotes WHERE expiration_timestamp < $1;";
-        sqlx::query(QUERY)
-            .bind(max_expiry)
-            .execute(&self.pool)
-            .await
-            .context("remove_expired_quotes failed")
-            .map(|_| ())
-    }
-}
-
-#[async_trait::async_trait]
-impl Maintaining for Postgres {
-    async fn run_maintenance(&self) -> Result<()> {
-        self.remove_expired_quotes(Utc::now())
-            .await
-            .context("fee measurement maintenance error")
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
     use chrono::Duration;
-    use ethcontract::U256;
     use model::order::OrderKind;
     use primitive_types::H160;
 
     #[tokio::test]
     #[ignore]
-    async fn postgres_save_and_get_quote_by_id() {
-        let db = Postgres::new("postgresql://").unwrap();
-        db.clear().await.unwrap();
-
-        let now = Utc::now();
-        let quote = QuoteData {
-            sell_token: H160([1; 20]),
-            buy_token: H160([2; 20]),
-            quoted_sell_amount: 3.into(),
-            quoted_buy_amount: 4.into(),
-            fee_parameters: 5_u32.into(),
-            kind: OrderKind::Sell,
-            expiration: now,
-        };
-        let id = db.save(quote.clone()).await.unwrap().unwrap();
-
-        assert_eq!(db.get(id, now).await.unwrap().unwrap(), quote);
-        assert_eq!(
-            db.get(id, now + Duration::seconds(30))
-                .await
-                .unwrap()
-                .unwrap(),
-            quote
-        );
-
-        db.remove_expired_quotes(now + Duration::seconds(30))
-            .await
-            .unwrap();
-        assert_eq!(db.get(id, now).await.unwrap(), None);
-    }
-
-    #[tokio::test]
-    #[ignore]
-    async fn postgres_save_and_find_quote() {
+    async fn postgres_save_and_load_fee_measurements() {
         let db = Postgres::new("postgresql://").unwrap();
         db.clear().await.unwrap();
 
         let now = Utc::now();
         let token_a = H160::from_low_u64_be(1);
-        let quote_a = QuoteData {
+        let fee_data_a = FeeData {
             sell_token: token_a,
             buy_token: H160::from_low_u64_be(3),
-            quoted_sell_amount: 4.into(),
-            quoted_buy_amount: 5.into(),
+            amount: 4.into(),
             kind: OrderKind::Sell,
-            ..Default::default()
         };
-
         let token_b = H160::from_low_u64_be(2);
-        let quote_b = QuoteData {
+        let fee_data_b = FeeData {
             sell_token: token_b,
             buy_token: token_a,
-            quoted_sell_amount: 200.into(),
-            quoted_buy_amount: 100.into(),
-            fee_parameters: 20_000_u32.into(),
+            amount: 100.into(),
             kind: OrderKind::Buy,
-            expiration: now,
         };
 
         // Save two measurements for token_a
-        let quotes_a = [
-            {
-                let quote = QuoteData {
-                    expiration: now,
-                    fee_parameters: 100_u32.into(),
-                    ..quote_a.clone()
-                };
-                let id = db.save(quote.clone()).await.unwrap().unwrap();
-
-                (id, quote)
-            },
-            {
-                let quote = QuoteData {
-                    expiration: now + Duration::seconds(60),
-                    fee_parameters: 200_u32.into(),
-                    ..quote_a.clone()
-                };
-                let id = db.save(quote.clone()).await.unwrap().unwrap();
-
-                (id, quote)
-            },
-        ];
+        db.save_fee_measurement(fee_data_a, now, 100u32.into())
+            .await
+            .unwrap();
+        db.save_fee_measurement(fee_data_a, now + Duration::seconds(60), 200u32.into())
+            .await
+            .unwrap();
 
         // Save one measurement for token_b
-        let quotes_b = [{
-            let quote = QuoteData {
-                expiration: now,
-                fee_parameters: 10_u32.into(),
-                ..quote_b.clone()
-            };
-            let id = db.save(quote.clone()).await.unwrap().unwrap();
-
-            (id, quote)
-        }];
+        db.save_fee_measurement(fee_data_b, now, 10u32.into())
+            .await
+            .unwrap();
 
         // Token A has readings valid until now and in 30s
-        let search_a = QuoteSearchParameters {
-            sell_token: quote_a.sell_token,
-            buy_token: quote_a.buy_token,
-            sell_amount: quote_a.quoted_sell_amount,
-            buy_amount: 1.into(),
-            fee_amount: 0.into(),
-            kind: quote_a.kind,
-            ..Default::default()
-        };
         assert_eq!(
-            db.find(search_a.clone(), now).await.unwrap().unwrap(),
-            quotes_a[0],
-        );
-        assert_eq!(
-            db.find(search_a.clone(), now + Duration::seconds(30))
+            db.find_measurement_exact(fee_data_a, now)
                 .await
                 .unwrap()
                 .unwrap(),
-            quotes_a[1],
-        );
-
-        // Token A has readings for sell + fee amount equal to quoted amount.
-        assert_eq!(
-            db.find(
-                QuoteSearchParameters {
-                    sell_amount: quote_a.quoted_sell_amount - U256::from(1),
-                    fee_amount: 1.into(),
-                    ..search_a.clone()
-                },
-                now
-            )
-            .await
-            .unwrap()
-            .unwrap(),
-            quotes_a[0],
+            100_u32.into()
         );
         assert_eq!(
-            db.find(search_a.clone(), now + Duration::seconds(30))
+            db.find_measurement_exact(fee_data_a, now + Duration::seconds(30))
                 .await
                 .unwrap()
                 .unwrap(),
-            quotes_a[1],
-        );
-
-        // Token A has no reading for wrong filter
-        assert_eq!(
-            db.find(
-                QuoteSearchParameters {
-                    sell_amount: quote_a.quoted_sell_amount - U256::from(1),
-                    ..search_a.clone()
-                },
-                now
-            )
-            .await
-            .unwrap(),
-            None
+            200u32.into()
         );
 
         // Token B only has readings valid until now
-        let search_b = QuoteSearchParameters {
-            sell_token: quote_b.sell_token,
-            buy_token: quote_b.buy_token,
-            sell_amount: 999.into(),
-            buy_amount: quote_b.quoted_buy_amount,
-            fee_amount: 0.into(),
-            kind: quote_b.kind,
-            ..Default::default()
-        };
         assert_eq!(
-            db.find(search_b.clone(), now).await.unwrap().unwrap(),
-            quotes_b[0],
+            db.find_measurement_exact(fee_data_b, now)
+                .await
+                .unwrap()
+                .unwrap(),
+            10u32.into()
         );
         assert_eq!(
-            db.find(search_b.clone(), now + Duration::seconds(30))
+            db.find_measurement_exact(fee_data_b, now + Duration::seconds(30))
                 .await
                 .unwrap(),
             None
@@ -451,10 +186,10 @@ mod tests {
 
         // Token B has no reading for wrong filter
         assert_eq!(
-            db.find(
-                QuoteSearchParameters {
-                    buy_amount: 99.into(),
-                    ..search_b.clone()
+            db.find_measurement_exact(
+                FeeData {
+                    amount: 99.into(),
+                    ..fee_data_b
                 },
                 now
             )
@@ -467,8 +202,10 @@ mod tests {
         db.remove_expired_quotes(now + Duration::seconds(120))
             .await
             .unwrap();
-        assert_eq!(db.find(search_a, now).await.unwrap(), None);
-        assert_eq!(db.find(search_b, now).await.unwrap(), None);
+        assert_eq!(
+            db.find_measurement_exact(fee_data_b, now).await.unwrap(),
+            None
+        );
     }
 
     #[tokio::test]

--- a/crates/orderbook/src/database/fees.rs
+++ b/crates/orderbook/src/database/fees.rs
@@ -3,11 +3,143 @@ use crate::{
     conversions::*,
     fee::{FeeData, MinFeeStoring},
     fee_subsidy::FeeParameters,
+    order_quoting::{QuoteData, QuoteSearchParameters, QuoteStoring},
 };
 use anyhow::{Context, Result};
+use bigdecimal::BigDecimal;
 use chrono::{DateTime, Utc};
-use model::order::OrderKind;
+use model::{order::OrderKind, quote::QuoteId};
 use shared::maintenance::Maintaining;
+
+#[derive(sqlx::FromRow)]
+struct QuoteRow {
+    id: QuoteId,
+    sell_token: Vec<u8>,
+    buy_token: Vec<u8>,
+    sell_amount: BigDecimal,
+    buy_amount: BigDecimal,
+    gas_amount: f64,
+    gas_price: f64,
+    sell_token_price: f64,
+    order_kind: DbOrderKind,
+    expiration_timestamp: DateTime<Utc>,
+}
+
+impl TryFrom<QuoteRow> for QuoteData {
+    type Error = anyhow::Error;
+
+    fn try_from(row: QuoteRow) -> Result<QuoteData> {
+        Ok(QuoteData {
+            sell_token: h160_from_vec(row.sell_token)?,
+            buy_token: h160_from_vec(row.buy_token)?,
+            quoted_sell_amount: big_decimal_to_u256(&row.sell_amount)
+                .context("quoted sell amount is not a valid U256")?,
+            quoted_buy_amount: big_decimal_to_u256(&row.buy_amount)
+                .context("quoted buy amount is not a valid U256")?,
+            fee_parameters: FeeParameters {
+                gas_amount: row.gas_amount,
+                gas_price: row.gas_price,
+                sell_token_price: row.sell_token_price,
+            },
+            kind: row.order_kind.into(),
+            expiration: row.expiration_timestamp,
+        })
+    }
+}
+
+#[async_trait::async_trait]
+impl QuoteStoring for Postgres {
+    async fn save(&self, data: QuoteData) -> Result<Option<QuoteId>> {
+        const QUERY: &str = r#"
+            INSERT INTO quotes (
+                sell_token,
+                buy_token,
+                sell_amount,
+                buy_amount,
+                gas_amount,
+                gas_price,
+                sell_token_price,
+                order_kind,
+                expiration_timestamp
+            )
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+            RETURNING id
+        ;"#;
+
+        let (id,) = sqlx::query_as(QUERY)
+            .bind(data.sell_token.as_bytes())
+            .bind(data.buy_token.as_bytes())
+            .bind(u256_to_big_decimal(&data.quoted_sell_amount))
+            .bind(u256_to_big_decimal(&data.quoted_buy_amount))
+            .bind(&data.fee_parameters.gas_amount)
+            .bind(&data.fee_parameters.gas_price)
+            .bind(&data.fee_parameters.sell_token_price)
+            .bind(DbOrderKind::from(data.kind))
+            .bind(data.expiration)
+            .fetch_one(&self.pool)
+            .await
+            .context("failed to insert quote")?;
+
+        Ok(Some(id))
+    }
+
+    async fn get(&self, id: QuoteId, _: DateTime<Utc>) -> Result<Option<QuoteData>> {
+        const QUERY: &str = r#"
+            SELECT *
+            FROM quotes
+            WHERE id = $1
+        ;"#;
+
+        let quote: Option<QuoteRow> = sqlx::query_as(QUERY)
+            .bind(id)
+            .fetch_optional(&self.pool)
+            .await
+            .context("failed to get quote by ID")?;
+
+        quote.map(TryFrom::try_from).transpose()
+    }
+
+    async fn find(
+        &self,
+        parameters: QuoteSearchParameters,
+        expiration: DateTime<Utc>,
+    ) -> Result<Option<(QuoteId, QuoteData)>> {
+        const QUERY: &str = r#"
+            SELECT *
+            FROM quotes
+            WHERE
+                sell_token = $1 AND
+                buy_token = $2 AND
+                (
+                    order_kind = 'sell' AND sell_amount = $3 OR
+                    order_kind = 'sell' AND sell_amount = $4 OR
+                    order_kind = 'buy' AND buy_amount = $5
+                ) AND
+                order_kind = $6 AND
+                expiration_timestamp >= $7
+            ORDER BY gas_amount * gas_price * sell_token_price ASC
+            LIMIT 1
+        ;"#;
+
+        let quote: Option<QuoteRow> = sqlx::query_as(QUERY)
+            .bind(parameters.sell_token.as_bytes())
+            .bind(parameters.buy_token.as_bytes())
+            .bind(u256_to_big_decimal(&parameters.sell_amount))
+            .bind(u256_to_big_decimal(
+                &(parameters.sell_amount + parameters.fee_amount),
+            ))
+            .bind(u256_to_big_decimal(&parameters.buy_amount))
+            .bind(DbOrderKind::from(parameters.kind))
+            .bind(expiration)
+            .fetch_optional(&self.pool)
+            .await
+            .context("failed finding quote by parameters")?;
+
+        quote
+            .map(|quote| Ok((quote.id, quote.try_into()?)))
+            .transpose()
+    }
+}
 
 #[derive(sqlx::FromRow)]
 struct FeeRow {
@@ -34,26 +166,22 @@ impl MinFeeStoring for Postgres {
         expiry: DateTime<Utc>,
         estimate: FeeParameters,
     ) -> Result<()> {
-        const QUERY: &str =
-            "INSERT INTO quotes (sell_token, buy_token, sell_amount, buy_amount, order_kind, expiration_timestamp, gas_amount, gas_price, sell_token_price) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9);";
         let (sell_amount, buy_amount) = match fee_data.kind {
             OrderKind::Buy => (0.into(), fee_data.amount),
             OrderKind::Sell => (fee_data.amount, 0.into()),
         };
-        sqlx::query(QUERY)
-            .bind(fee_data.sell_token.as_bytes())
-            .bind(fee_data.buy_token.as_bytes())
-            .bind(u256_to_big_decimal(&sell_amount))
-            .bind(u256_to_big_decimal(&buy_amount))
-            .bind(DbOrderKind::from(fee_data.kind))
-            .bind(expiry)
-            .bind(&estimate.gas_amount)
-            .bind(&estimate.gas_price)
-            .bind(&estimate.sell_token_price)
-            .execute(&self.pool)
-            .await
-            .context("insert MinFeeMeasurement failed")
-            .map(|_| ())
+        let quote = QuoteData {
+            sell_token: fee_data.sell_token,
+            buy_token: fee_data.buy_token,
+            quoted_sell_amount: sell_amount,
+            quoted_buy_amount: buy_amount,
+            fee_parameters: estimate,
+            kind: fee_data.kind,
+            expiration: expiry,
+        };
+
+        self.save(quote).await?;
+        Ok(())
     }
 
     async fn find_measurement_exact(
@@ -61,35 +189,21 @@ impl MinFeeStoring for Postgres {
         fee_data: FeeData,
         min_expiry: DateTime<Utc>,
     ) -> Result<Option<FeeParameters>> {
-        // Fetches the lowest fee estimate we may have for the user
-        const QUERY: &str = "\
-            SELECT gas_amount, gas_price, sell_token_price FROM quotes \
-            WHERE
-                sell_token = $1 AND \
-                buy_token = $2 AND \
-                sell_amount = $3 AND \
-                buy_amount = $4 AND \
-                order_kind = $5 AND \
-                expiration_timestamp >= $6 \
-            ORDER BY gas_amount * gas_price * sell_token_price ASC \
-            LIMIT 1 \
-            ;";
-
         let (sell_amount, buy_amount) = match fee_data.kind {
             OrderKind::Buy => (0.into(), fee_data.amount),
             OrderKind::Sell => (fee_data.amount, 0.into()),
         };
-        let result: Option<FeeRow> = sqlx::query_as(QUERY)
-            .bind(fee_data.sell_token.as_bytes())
-            .bind(fee_data.buy_token.as_bytes())
-            .bind(u256_to_big_decimal(&sell_amount))
-            .bind(u256_to_big_decimal(&buy_amount))
-            .bind(DbOrderKind::from(fee_data.kind))
-            .bind(min_expiry)
-            .fetch_optional(&self.pool)
-            .await
-            .context("find_measurement_exact")?;
-        Ok(result.map(FeeRow::into_fee))
+        let search = QuoteSearchParameters {
+            sell_token: fee_data.sell_token,
+            buy_token: fee_data.buy_token,
+            sell_amount,
+            buy_amount,
+            kind: fee_data.kind,
+            ..Default::default()
+        };
+
+        let quote = self.find(search, min_expiry).await?;
+        Ok(quote.map(|(_, quote)| quote.fee_parameters))
     }
 
     async fn find_measurement_including_larger_amount(
@@ -136,7 +250,7 @@ impl Postgres {
             .bind(max_expiry)
             .execute(&self.pool)
             .await
-            .context("remove_expired_fee_measurements failed")
+            .context("remove_expired_quotes failed")
             .map(|_| ())
     }
 }
@@ -154,70 +268,182 @@ impl Maintaining for Postgres {
 mod tests {
     use super::*;
     use chrono::Duration;
+    use ethcontract::U256;
     use model::order::OrderKind;
     use primitive_types::H160;
 
     #[tokio::test]
     #[ignore]
-    async fn postgres_save_and_load_fee_measurements() {
+    async fn postgres_save_and_get_quote_by_id() {
+        let db = Postgres::new("postgresql://").unwrap();
+        db.clear().await.unwrap();
+
+        let now = Utc::now();
+        let quote = QuoteData {
+            sell_token: H160([1; 20]),
+            buy_token: H160([2; 20]),
+            quoted_sell_amount: 3.into(),
+            quoted_buy_amount: 4.into(),
+            fee_parameters: 5_u32.into(),
+            kind: OrderKind::Sell,
+            expiration: now,
+        };
+        let id = db.save(quote.clone()).await.unwrap().unwrap();
+
+        assert_eq!(db.get(id, now).await.unwrap().unwrap(), quote);
+        assert_eq!(
+            db.get(id, now + Duration::seconds(30))
+                .await
+                .unwrap()
+                .unwrap(),
+            quote
+        );
+
+        db.remove_expired_quotes(now + Duration::seconds(30))
+            .await
+            .unwrap();
+        assert_eq!(db.get(id, now).await.unwrap(), None);
+    }
+
+    #[tokio::test]
+    #[ignore]
+    async fn postgres_save_and_find_quote() {
         let db = Postgres::new("postgresql://").unwrap();
         db.clear().await.unwrap();
 
         let now = Utc::now();
         let token_a = H160::from_low_u64_be(1);
-        let fee_data_a = FeeData {
+        let quote_a = QuoteData {
             sell_token: token_a,
             buy_token: H160::from_low_u64_be(3),
-            amount: 4.into(),
+            quoted_sell_amount: 4.into(),
+            quoted_buy_amount: 5.into(),
             kind: OrderKind::Sell,
+            ..Default::default()
         };
+
         let token_b = H160::from_low_u64_be(2);
-        let fee_data_b = FeeData {
+        let quote_b = QuoteData {
             sell_token: token_b,
             buy_token: token_a,
-            amount: 100.into(),
+            quoted_sell_amount: 200.into(),
+            quoted_buy_amount: 100.into(),
+            fee_parameters: 20_000_u32.into(),
             kind: OrderKind::Buy,
+            expiration: now,
         };
 
         // Save two measurements for token_a
-        db.save_fee_measurement(fee_data_a, now, 100u32.into())
-            .await
-            .unwrap();
-        db.save_fee_measurement(fee_data_a, now + Duration::seconds(60), 200u32.into())
-            .await
-            .unwrap();
+        let quotes_a = [
+            {
+                let quote = QuoteData {
+                    expiration: now,
+                    fee_parameters: 100_u32.into(),
+                    ..quote_a.clone()
+                };
+                let id = db.save(quote.clone()).await.unwrap().unwrap();
+
+                (id, quote)
+            },
+            {
+                let quote = QuoteData {
+                    expiration: now + Duration::seconds(60),
+                    fee_parameters: 200_u32.into(),
+                    ..quote_a.clone()
+                };
+                let id = db.save(quote.clone()).await.unwrap().unwrap();
+
+                (id, quote)
+            },
+        ];
 
         // Save one measurement for token_b
-        db.save_fee_measurement(fee_data_b, now, 10u32.into())
-            .await
-            .unwrap();
+        let quotes_b = [{
+            let quote = QuoteData {
+                expiration: now,
+                fee_parameters: 10_u32.into(),
+                ..quote_b.clone()
+            };
+            let id = db.save(quote.clone()).await.unwrap().unwrap();
+
+            (id, quote)
+        }];
 
         // Token A has readings valid until now and in 30s
+        let search_a = QuoteSearchParameters {
+            sell_token: quote_a.sell_token,
+            buy_token: quote_a.buy_token,
+            sell_amount: quote_a.quoted_sell_amount,
+            buy_amount: 1.into(),
+            fee_amount: 0.into(),
+            kind: quote_a.kind,
+            ..Default::default()
+        };
         assert_eq!(
-            db.find_measurement_exact(fee_data_a, now)
-                .await
-                .unwrap()
-                .unwrap(),
-            100_u32.into()
+            db.find(search_a.clone(), now).await.unwrap().unwrap(),
+            quotes_a[0],
         );
         assert_eq!(
-            db.find_measurement_exact(fee_data_a, now + Duration::seconds(30))
+            db.find(search_a.clone(), now + Duration::seconds(30))
                 .await
                 .unwrap()
                 .unwrap(),
-            200u32.into()
+            quotes_a[1],
+        );
+
+        // Token A has readings for sell + fee amount equal to quoted amount.
+        assert_eq!(
+            db.find(
+                QuoteSearchParameters {
+                    sell_amount: quote_a.quoted_sell_amount - U256::from(1),
+                    fee_amount: 1.into(),
+                    ..search_a.clone()
+                },
+                now
+            )
+            .await
+            .unwrap()
+            .unwrap(),
+            quotes_a[0],
+        );
+        assert_eq!(
+            db.find(search_a.clone(), now + Duration::seconds(30))
+                .await
+                .unwrap()
+                .unwrap(),
+            quotes_a[1],
+        );
+
+        // Token A has no reading for wrong filter
+        assert_eq!(
+            db.find(
+                QuoteSearchParameters {
+                    sell_amount: quote_a.quoted_sell_amount - U256::from(1),
+                    ..search_a.clone()
+                },
+                now
+            )
+            .await
+            .unwrap(),
+            None
         );
 
         // Token B only has readings valid until now
+        let search_b = QuoteSearchParameters {
+            sell_token: quote_b.sell_token,
+            buy_token: quote_b.buy_token,
+            sell_amount: 999.into(),
+            buy_amount: quote_b.quoted_buy_amount,
+            fee_amount: 0.into(),
+            kind: quote_b.kind,
+            ..Default::default()
+        };
         assert_eq!(
-            db.find_measurement_exact(fee_data_b, now)
-                .await
-                .unwrap()
-                .unwrap(),
-            10u32.into()
+            db.find(search_b.clone(), now).await.unwrap().unwrap(),
+            quotes_b[0],
         );
         assert_eq!(
-            db.find_measurement_exact(fee_data_b, now + Duration::seconds(30))
+            db.find(search_b.clone(), now + Duration::seconds(30))
                 .await
                 .unwrap(),
             None
@@ -225,10 +451,10 @@ mod tests {
 
         // Token B has no reading for wrong filter
         assert_eq!(
-            db.find_measurement_exact(
-                FeeData {
-                    amount: 99.into(),
-                    ..fee_data_b
+            db.find(
+                QuoteSearchParameters {
+                    buy_amount: 99.into(),
+                    ..search_b.clone()
                 },
                 now
             )
@@ -241,10 +467,8 @@ mod tests {
         db.remove_expired_quotes(now + Duration::seconds(120))
             .await
             .unwrap();
-        assert_eq!(
-            db.find_measurement_exact(fee_data_b, now).await.unwrap(),
-            None
-        );
+        assert_eq!(db.find(search_a, now).await.unwrap(), None);
+        assert_eq!(db.find(search_b, now).await.unwrap(), None);
     }
 
     #[tokio::test]

--- a/crates/orderbook/src/database/orders.rs
+++ b/crates/orderbook/src/database/orders.rs
@@ -72,18 +72,20 @@ pub enum DbOrderKind {
     Sell,
 }
 
-impl DbOrderKind {
-    pub fn from(order_kind: OrderKind) -> Self {
-        match order_kind {
+impl From<OrderKind> for DbOrderKind {
+    fn from(kind: OrderKind) -> Self {
+        match kind {
             OrderKind::Buy => Self::Buy,
             OrderKind::Sell => Self::Sell,
         }
     }
+}
 
-    fn into(self) -> OrderKind {
-        match self {
-            Self::Buy => OrderKind::Buy,
-            Self::Sell => OrderKind::Sell,
+impl From<DbOrderKind> for OrderKind {
+    fn from(kind: DbOrderKind) -> Self {
+        match kind {
+            DbOrderKind::Buy => Self::Buy,
+            DbOrderKind::Sell => Self::Sell,
         }
     }
 }

--- a/crates/orderbook/src/database/quotes.rs
+++ b/crates/orderbook/src/database/quotes.rs
@@ -110,9 +110,9 @@ impl QuoteStoring for Postgres {
                 sell_token = $1 AND
                 buy_token = $2 AND
                 (
-                    order_kind = 'sell' AND sell_amount = $3 OR
-                    order_kind = 'sell' AND sell_amount = $4 OR
-                    order_kind = 'buy' AND buy_amount = $5
+                    (order_kind = 'sell' AND sell_amount = $3) OR
+                    (order_kind = 'sell' AND sell_amount = $4) OR
+                    (order_kind = 'buy' AND buy_amount = $5)
                 ) AND
                 order_kind = $6 AND
                 expiration_timestamp >= $7

--- a/crates/orderbook/src/database/quotes.rs
+++ b/crates/orderbook/src/database/quotes.rs
@@ -82,7 +82,7 @@ impl QuoteStoring for Postgres {
         Ok(Some(id))
     }
 
-    async fn get(&self, id: QuoteId, _: DateTime<Utc>) -> Result<Option<QuoteData>> {
+    async fn get(&self, id: QuoteId) -> Result<Option<QuoteData>> {
         const QUERY: &str = r#"
             SELECT *
             FROM quotes
@@ -187,19 +187,13 @@ mod tests {
         };
         let id = db.save(quote.clone()).await.unwrap().unwrap();
 
-        assert_eq!(db.get(id, now).await.unwrap().unwrap(), quote);
-        assert_eq!(
-            db.get(id, now + Duration::seconds(30))
-                .await
-                .unwrap()
-                .unwrap(),
-            quote
-        );
+        assert_eq!(db.get(id).await.unwrap().unwrap(), quote);
 
         db.remove_expired_quotes(now + Duration::seconds(30))
             .await
             .unwrap();
-        assert_eq!(db.get(id, now).await.unwrap(), None);
+
+        assert_eq!(db.get(id).await.unwrap(), None);
     }
 
     #[tokio::test]

--- a/crates/orderbook/src/database/quotes.rs
+++ b/crates/orderbook/src/database/quotes.rs
@@ -164,10 +164,17 @@ impl Maintaining for Postgres {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use chrono::Duration;
+    use chrono::{Duration, TimeZone as _};
     use ethcontract::U256;
     use model::order::OrderKind;
     use primitive_types::H160;
+
+    /// The postgres database in our CI has different datetime precision than
+    /// the `DateTime` uses. This leads to issues comparing round-tripped data.
+    /// Work around the issue by created `DateTime`s with lower precision.
+    fn low_precision_now() -> DateTime<Utc> {
+        Utc.timestamp(Utc::now().timestamp(), 0)
+    }
 
     #[tokio::test]
     #[ignore]
@@ -175,7 +182,7 @@ mod tests {
         let db = Postgres::new("postgresql://").unwrap();
         db.clear().await.unwrap();
 
-        let now = Utc::now();
+        let now = low_precision_now();
         let quote = QuoteData {
             sell_token: H160([1; 20]),
             buy_token: H160([2; 20]),
@@ -202,7 +209,7 @@ mod tests {
         let db = Postgres::new("postgresql://").unwrap();
         db.clear().await.unwrap();
 
-        let now = Utc::now();
+        let now = low_precision_now();
         let token_a = H160::from_low_u64_be(1);
         let quote_a = QuoteData {
             sell_token: token_a,

--- a/crates/orderbook/src/database/quotes.rs
+++ b/crates/orderbook/src/database/quotes.rs
@@ -1,0 +1,370 @@
+use super::{orders::DbOrderKind, Postgres};
+use crate::{
+    conversions::*,
+    fee_subsidy::FeeParameters,
+    order_quoting::{QuoteData, QuoteSearchParameters, QuoteStoring},
+};
+use anyhow::{Context, Result};
+use bigdecimal::BigDecimal;
+use chrono::{DateTime, Utc};
+use model::quote::QuoteId;
+use shared::maintenance::Maintaining;
+
+#[derive(sqlx::FromRow)]
+struct QuoteRow {
+    id: QuoteId,
+    sell_token: Vec<u8>,
+    buy_token: Vec<u8>,
+    sell_amount: BigDecimal,
+    buy_amount: BigDecimal,
+    gas_amount: f64,
+    gas_price: f64,
+    sell_token_price: f64,
+    order_kind: DbOrderKind,
+    expiration_timestamp: DateTime<Utc>,
+}
+
+impl TryFrom<QuoteRow> for QuoteData {
+    type Error = anyhow::Error;
+
+    fn try_from(row: QuoteRow) -> Result<QuoteData> {
+        Ok(QuoteData {
+            sell_token: h160_from_vec(row.sell_token)?,
+            buy_token: h160_from_vec(row.buy_token)?,
+            quoted_sell_amount: big_decimal_to_u256(&row.sell_amount)
+                .context("quoted sell amount is not a valid U256")?,
+            quoted_buy_amount: big_decimal_to_u256(&row.buy_amount)
+                .context("quoted buy amount is not a valid U256")?,
+            fee_parameters: FeeParameters {
+                gas_amount: row.gas_amount,
+                gas_price: row.gas_price,
+                sell_token_price: row.sell_token_price,
+            },
+            kind: row.order_kind.into(),
+            expiration: row.expiration_timestamp,
+        })
+    }
+}
+
+#[async_trait::async_trait]
+impl QuoteStoring for Postgres {
+    async fn save(&self, data: QuoteData) -> Result<Option<QuoteId>> {
+        const QUERY: &str = r#"
+            INSERT INTO quotes (
+                sell_token,
+                buy_token,
+                sell_amount,
+                buy_amount,
+                gas_amount,
+                gas_price,
+                sell_token_price,
+                order_kind,
+                expiration_timestamp
+            )
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+            RETURNING id
+        ;"#;
+
+        let (id,) = sqlx::query_as(QUERY)
+            .bind(data.sell_token.as_bytes())
+            .bind(data.buy_token.as_bytes())
+            .bind(u256_to_big_decimal(&data.quoted_sell_amount))
+            .bind(u256_to_big_decimal(&data.quoted_buy_amount))
+            .bind(&data.fee_parameters.gas_amount)
+            .bind(&data.fee_parameters.gas_price)
+            .bind(&data.fee_parameters.sell_token_price)
+            .bind(DbOrderKind::from(data.kind))
+            .bind(data.expiration)
+            .fetch_one(&self.pool)
+            .await
+            .context("failed to insert quote")?;
+
+        Ok(Some(id))
+    }
+
+    async fn get(&self, id: QuoteId, _: DateTime<Utc>) -> Result<Option<QuoteData>> {
+        const QUERY: &str = r#"
+            SELECT *
+            FROM quotes
+            WHERE id = $1
+        ;"#;
+
+        let quote: Option<QuoteRow> = sqlx::query_as(QUERY)
+            .bind(id)
+            .fetch_optional(&self.pool)
+            .await
+            .context("failed to get quote by ID")?;
+
+        quote.map(TryFrom::try_from).transpose()
+    }
+
+    async fn find(
+        &self,
+        parameters: QuoteSearchParameters,
+        expiration: DateTime<Utc>,
+    ) -> Result<Option<(QuoteId, QuoteData)>> {
+        const QUERY: &str = r#"
+            SELECT *
+            FROM quotes
+            WHERE
+                sell_token = $1 AND
+                buy_token = $2 AND
+                (
+                    order_kind = 'sell' AND sell_amount = $3 OR
+                    order_kind = 'sell' AND sell_amount = $4 OR
+                    order_kind = 'buy' AND buy_amount = $5
+                ) AND
+                order_kind = $6 AND
+                expiration_timestamp >= $7
+            ORDER BY gas_amount * gas_price * sell_token_price ASC
+            LIMIT 1
+        ;"#;
+
+        let quote: Option<QuoteRow> = sqlx::query_as(QUERY)
+            .bind(parameters.sell_token.as_bytes())
+            .bind(parameters.buy_token.as_bytes())
+            .bind(u256_to_big_decimal(&parameters.sell_amount))
+            .bind(u256_to_big_decimal(
+                &(parameters.sell_amount + parameters.fee_amount),
+            ))
+            .bind(u256_to_big_decimal(&parameters.buy_amount))
+            .bind(DbOrderKind::from(parameters.kind))
+            .bind(expiration)
+            .fetch_optional(&self.pool)
+            .await
+            .context("failed finding quote by parameters")?;
+
+        quote
+            .map(|quote| Ok((quote.id, quote.try_into()?)))
+            .transpose()
+    }
+}
+
+impl Postgres {
+    pub async fn remove_expired_quotes(&self, max_expiry: DateTime<Utc>) -> Result<()> {
+        const QUERY: &str = "DELETE FROM quotes WHERE expiration_timestamp < $1;";
+        sqlx::query(QUERY)
+            .bind(max_expiry)
+            .execute(&self.pool)
+            .await
+            .context("remove_expired_quotes failed")
+            .map(|_| ())
+    }
+}
+
+#[async_trait::async_trait]
+impl Maintaining for Postgres {
+    async fn run_maintenance(&self) -> Result<()> {
+        self.remove_expired_quotes(Utc::now())
+            .await
+            .context("fee measurement maintenance error")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::Duration;
+    use ethcontract::U256;
+    use model::order::OrderKind;
+    use primitive_types::H160;
+
+    #[tokio::test]
+    #[ignore]
+    async fn postgres_save_and_get_quote_by_id() {
+        let db = Postgres::new("postgresql://").unwrap();
+        db.clear().await.unwrap();
+
+        let now = Utc::now();
+        let quote = QuoteData {
+            sell_token: H160([1; 20]),
+            buy_token: H160([2; 20]),
+            quoted_sell_amount: 3.into(),
+            quoted_buy_amount: 4.into(),
+            fee_parameters: 5_u32.into(),
+            kind: OrderKind::Sell,
+            expiration: now,
+        };
+        let id = db.save(quote.clone()).await.unwrap().unwrap();
+
+        assert_eq!(db.get(id, now).await.unwrap().unwrap(), quote);
+        assert_eq!(
+            db.get(id, now + Duration::seconds(30))
+                .await
+                .unwrap()
+                .unwrap(),
+            quote
+        );
+
+        db.remove_expired_quotes(now + Duration::seconds(30))
+            .await
+            .unwrap();
+        assert_eq!(db.get(id, now).await.unwrap(), None);
+    }
+
+    #[tokio::test]
+    #[ignore]
+    async fn postgres_save_and_find_quote() {
+        let db = Postgres::new("postgresql://").unwrap();
+        db.clear().await.unwrap();
+
+        let now = Utc::now();
+        let token_a = H160::from_low_u64_be(1);
+        let quote_a = QuoteData {
+            sell_token: token_a,
+            buy_token: H160::from_low_u64_be(3),
+            quoted_sell_amount: 4.into(),
+            quoted_buy_amount: 5.into(),
+            kind: OrderKind::Sell,
+            ..Default::default()
+        };
+
+        let token_b = H160::from_low_u64_be(2);
+        let quote_b = QuoteData {
+            sell_token: token_b,
+            buy_token: token_a,
+            quoted_sell_amount: 200.into(),
+            quoted_buy_amount: 100.into(),
+            fee_parameters: 20_000_u32.into(),
+            kind: OrderKind::Buy,
+            expiration: now,
+        };
+
+        // Save two measurements for token_a
+        let quotes_a = [
+            {
+                let quote = QuoteData {
+                    expiration: now,
+                    fee_parameters: 100_u32.into(),
+                    ..quote_a.clone()
+                };
+                let id = db.save(quote.clone()).await.unwrap().unwrap();
+
+                (id, quote)
+            },
+            {
+                let quote = QuoteData {
+                    expiration: now + Duration::seconds(60),
+                    fee_parameters: 200_u32.into(),
+                    ..quote_a.clone()
+                };
+                let id = db.save(quote.clone()).await.unwrap().unwrap();
+
+                (id, quote)
+            },
+        ];
+
+        // Save one measurement for token_b
+        let quotes_b = [{
+            let quote = QuoteData {
+                expiration: now,
+                fee_parameters: 10_u32.into(),
+                ..quote_b.clone()
+            };
+            let id = db.save(quote.clone()).await.unwrap().unwrap();
+
+            (id, quote)
+        }];
+
+        // Token A has readings valid until now and in 30s
+        let search_a = QuoteSearchParameters {
+            sell_token: quote_a.sell_token,
+            buy_token: quote_a.buy_token,
+            sell_amount: quote_a.quoted_sell_amount,
+            buy_amount: 1.into(),
+            fee_amount: 0.into(),
+            kind: quote_a.kind,
+            ..Default::default()
+        };
+        assert_eq!(
+            db.find(search_a.clone(), now).await.unwrap().unwrap(),
+            quotes_a[0],
+        );
+        assert_eq!(
+            db.find(search_a.clone(), now + Duration::seconds(30))
+                .await
+                .unwrap()
+                .unwrap(),
+            quotes_a[1],
+        );
+
+        // Token A has readings for sell + fee amount equal to quoted amount.
+        assert_eq!(
+            db.find(
+                QuoteSearchParameters {
+                    sell_amount: quote_a.quoted_sell_amount - U256::from(1),
+                    fee_amount: 1.into(),
+                    ..search_a.clone()
+                },
+                now
+            )
+            .await
+            .unwrap()
+            .unwrap(),
+            quotes_a[0],
+        );
+        assert_eq!(
+            db.find(search_a.clone(), now + Duration::seconds(30))
+                .await
+                .unwrap()
+                .unwrap(),
+            quotes_a[1],
+        );
+
+        // Token A has no reading for wrong filter
+        assert_eq!(
+            db.find(
+                QuoteSearchParameters {
+                    sell_amount: quote_a.quoted_sell_amount - U256::from(1),
+                    ..search_a.clone()
+                },
+                now
+            )
+            .await
+            .unwrap(),
+            None
+        );
+
+        // Token B only has readings valid until now
+        let search_b = QuoteSearchParameters {
+            sell_token: quote_b.sell_token,
+            buy_token: quote_b.buy_token,
+            sell_amount: 999.into(),
+            buy_amount: quote_b.quoted_buy_amount,
+            fee_amount: 0.into(),
+            kind: quote_b.kind,
+            ..Default::default()
+        };
+        assert_eq!(
+            db.find(search_b.clone(), now).await.unwrap().unwrap(),
+            quotes_b[0],
+        );
+        assert_eq!(
+            db.find(search_b.clone(), now + Duration::seconds(30))
+                .await
+                .unwrap(),
+            None
+        );
+
+        // Token B has no reading for wrong filter
+        assert_eq!(
+            db.find(
+                QuoteSearchParameters {
+                    buy_amount: 99.into(),
+                    ..search_b.clone()
+                },
+                now
+            )
+            .await
+            .unwrap(),
+            None
+        );
+
+        // Query that previously succeeded after cleaning up expired measurements.
+        db.remove_expired_quotes(now + Duration::seconds(120))
+            .await
+            .unwrap();
+        assert_eq!(db.find(search_a, now).await.unwrap(), None);
+        assert_eq!(db.find(search_b, now).await.unwrap(), None);
+    }
+}

--- a/crates/orderbook/src/order_quoting.rs
+++ b/crates/orderbook/src/order_quoting.rs
@@ -467,6 +467,9 @@ pub enum FindQuoteError {
     #[error("quote does not match parameters")]
     ParameterMismatch(QuoteData),
 
+    #[error("quote expired")]
+    Expired(DateTime<Utc>),
+
     #[error(transparent)]
     Other(#[from] anyhow::Error),
 }
@@ -512,7 +515,7 @@ pub trait QuoteStoring: Send + Sync {
     async fn save(&self, data: QuoteData) -> Result<Option<QuoteId>>;
 
     /// Retrieves an existing quote by ID.
-    async fn get(&self, id: QuoteId, expiration: DateTime<Utc>) -> Result<Option<QuoteData>>;
+    async fn get(&self, id: QuoteId) -> Result<Option<QuoteData>>;
 
     /// Retrieves an existing quote by ID.
     async fn find(
@@ -534,7 +537,7 @@ impl QuoteStoring for Forget {
         Ok(None)
     }
 
-    async fn get(&self, _: QuoteId, _: DateTime<Utc>) -> Result<Option<QuoteData>> {
+    async fn get(&self, _: QuoteId) -> Result<Option<QuoteData>> {
         Ok(None)
     }
 
@@ -699,12 +702,15 @@ impl OrderQuoting for OrderQuoter2 {
                 Some(id) => {
                     let data = self
                         .storage
-                        .get(id, now)
+                        .get(id)
                         .await?
                         .ok_or(FindQuoteError::NotFound(Some(id)))?;
 
                     if !parameters.matches(&data) {
                         return Err(FindQuoteError::ParameterMismatch(data));
+                    }
+                    if data.expiration < now {
+                        return Err(FindQuoteError::Expired(data.expiration));
                     }
 
                     (id, data)
@@ -746,7 +752,7 @@ mod tests {
     use ethcontract::H160;
     use futures::{FutureExt as _, StreamExt as _};
     use gas_estimation::GasPrice1559;
-    use mockall::predicate::eq;
+    use mockall::{predicate::eq, Sequence};
     use model::{quote::Validity, time};
     use shared::{
         gas_price_estimation::FakeGasPriceEstimator,
@@ -1370,24 +1376,21 @@ mod tests {
         };
 
         let mut storage = MockQuoteStoring::new();
-        storage
-            .expect_get()
-            .with(eq(42), eq(now))
-            .returning(move |_, _| {
-                Ok(Some(QuoteData {
-                    sell_token: H160([1; 20]),
-                    buy_token: H160([2; 20]),
-                    quoted_sell_amount: 100.into(),
-                    quoted_buy_amount: 42.into(),
-                    fee_parameters: FeeParameters {
-                        gas_amount: 3.,
-                        gas_price: 2.,
-                        sell_token_price: 0.2,
-                    },
-                    kind: OrderKind::Sell,
-                    expiration: now + chrono::Duration::seconds(10),
-                }))
-            });
+        storage.expect_get().with(eq(42)).returning(move |_| {
+            Ok(Some(QuoteData {
+                sell_token: H160([1; 20]),
+                buy_token: H160([2; 20]),
+                quoted_sell_amount: 100.into(),
+                quoted_buy_amount: 42.into(),
+                fee_parameters: FeeParameters {
+                    gas_amount: 3.,
+                    gas_price: 2.,
+                    sell_token_price: 0.2,
+                },
+                kind: OrderKind::Sell,
+                expiration: now + chrono::Duration::seconds(10),
+            }))
+        });
 
         let quoter = OrderQuoter2 {
             price_estimator: Arc::new(MockPriceEstimating::new()),
@@ -1448,24 +1451,21 @@ mod tests {
         };
 
         let mut storage = MockQuoteStoring::new();
-        storage
-            .expect_get()
-            .with(eq(42), eq(now))
-            .returning(move |_, _| {
-                Ok(Some(QuoteData {
-                    sell_token: H160([1; 20]),
-                    buy_token: H160([2; 20]),
-                    quoted_sell_amount: 100.into(),
-                    quoted_buy_amount: 42.into(),
-                    fee_parameters: FeeParameters {
-                        gas_amount: 3.,
-                        gas_price: 2.,
-                        sell_token_price: 0.2,
-                    },
-                    kind: OrderKind::Sell,
-                    expiration: now + chrono::Duration::seconds(10),
-                }))
-            });
+        storage.expect_get().with(eq(42)).returning(move |_| {
+            Ok(Some(QuoteData {
+                sell_token: H160([1; 20]),
+                buy_token: H160([2; 20]),
+                quoted_sell_amount: 100.into(),
+                quoted_buy_amount: 42.into(),
+                fee_parameters: FeeParameters {
+                    gas_amount: 3.,
+                    gas_price: 2.,
+                    sell_token_price: 0.2,
+                },
+                kind: OrderKind::Sell,
+                expiration: now + chrono::Duration::seconds(10),
+            }))
+        });
 
         let quoter = OrderQuoter2 {
             price_estimator: Arc::new(MockPriceEstimating::new()),
@@ -1571,19 +1571,37 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn find_quote_error_on_mismatch() {
+    async fn find_invalid_quote_error() {
+        let now = Utc::now();
         let parameters = QuoteSearchParameters {
             sell_token: H160([1; 20]),
             ..Default::default()
         };
 
         let mut storage = MockQuoteStoring::new();
-        storage.expect_get().returning(move |_, _| {
-            Ok(Some(QuoteData {
-                sell_token: H160([2; 20]),
-                ..Default::default()
-            }))
-        });
+        let mut sequence = Sequence::new();
+        storage
+            .expect_get()
+            .times(1)
+            .in_sequence(&mut sequence)
+            .returning(move |_| {
+                Ok(Some(QuoteData {
+                    sell_token: H160([2; 20]),
+                    expiration: now,
+                    ..Default::default()
+                }))
+            });
+        storage
+            .expect_get()
+            .times(1)
+            .in_sequence(&mut sequence)
+            .returning(move |_| {
+                Ok(Some(QuoteData {
+                    sell_token: H160([1; 20]),
+                    expiration: now - chrono::Duration::seconds(1),
+                    ..Default::default()
+                }))
+            });
 
         let quoter = OrderQuoter2 {
             price_estimator: Arc::new(MockPriceEstimating::new()),
@@ -1591,19 +1609,26 @@ mod tests {
             gas_estimator: Arc::new(FakeGasPriceEstimator::default()),
             fee_subsidy: Arc::new(Subsidy::default()),
             storage: Arc::new(storage),
-            now: Arc::new(Utc::now),
+            now: Arc::new(now),
         };
 
         assert!(matches!(
-            quoter.find_quote(Some(0), parameters).await.unwrap_err(),
+            quoter
+                .find_quote(Some(0), parameters.clone())
+                .await
+                .unwrap_err(),
             FindQuoteError::ParameterMismatch(_),
+        ));
+        assert!(matches!(
+            quoter.find_quote(Some(0), parameters).await.unwrap_err(),
+            FindQuoteError::Expired(_),
         ));
     }
 
     #[tokio::test]
     async fn find_quote_error_when_not_found() {
         let mut storage = MockQuoteStoring::new();
-        storage.expect_get().returning(move |_, _| Ok(None));
+        storage.expect_get().returning(move |_| Ok(None));
         storage.expect_find().returning(move |_, _| Ok(None));
 
         let quoter = OrderQuoter2 {

--- a/crates/orderbook/src/order_quoting.rs
+++ b/crates/orderbook/src/order_quoting.rs
@@ -24,7 +24,7 @@ use shared::price_estimation::{
     single_estimate, PriceEstimating, PriceEstimationError,
 };
 use std::sync::{
-    atomic::{AtomicU64, Ordering},
+    atomic::{AtomicI64, Ordering},
     Arc,
 };
 use thiserror::Error;
@@ -83,7 +83,7 @@ pub struct OrderQuoter {
     pub order_validator: Arc<dyn OrderValidating>,
     pub fast_fee_calculator: Arc<dyn MinFeeCalculating>,
     pub fast_price_estimator: Arc<dyn PriceEstimating>,
-    pub current_id: Arc<AtomicU64>,
+    pub current_id: Arc<AtomicI64>,
 }
 
 impl OrderQuoter {


### PR DESCRIPTION
This PR implements `QuoteStoring` for Postgres. Additionally, it modifies `MinFeeStoring` implementation to be implemented in function of the new `QuoteStoring`.

### Test Plan

Added new test cases. Tests for `MinFeeStoring` implemented in function of `QuoteStoring` continue to pass.
