### PR TITLE
Use new quoting component for order creation

### DIFF
--- a/crates/orderbook/src/api/create_order.rs
+++ b/crates/orderbook/src/api/create_order.rs
@@ -104,20 +104,7 @@ impl IntoWarpReply for ValidationError {
                 ),
                 StatusCode::BAD_REQUEST,
             ),
-            Self::NoLiquidityForQuote => with_status(
-                super::error(
-                    "NoLiquidityForQuote",
-                    "unable to compute a minimum fee amount because of insufficient liquidity",
-                ),
-                StatusCode::BAD_REQUEST,
-            ),
-            Self::UnsupportedOrderTypeForQuote => with_status(
-                super::error(
-                    "UnsupportedOrderTypeForQuote",
-                    "unable to compute a minimum fee amount for this order kind",
-                ),
-                StatusCode::BAD_REQUEST,
-            ),
+            Self::PriceForQuote(err) => err.into_warp_reply(),
             Self::WrongOwner(owner) => with_status(
                 super::error(
                     "WrongOwner",

--- a/crates/orderbook/src/api/create_order.rs
+++ b/crates/orderbook/src/api/create_order.rs
@@ -90,6 +90,34 @@ impl IntoWarpReply for ValidationError {
     fn into_warp_reply(self) -> super::ApiReply {
         match self {
             Self::Partial(pre) => pre.into_warp_reply(),
+            Self::QuoteNotFound => with_status(
+                super::error(
+                    "QuoteNotFound",
+                    "could not find quote with the specified ID",
+                ),
+                StatusCode::BAD_REQUEST,
+            ),
+            Self::InvalidQuote => with_status(
+                super::error(
+                    "InvalidQuote",
+                    "the quote with the specified ID does not match the order",
+                ),
+                StatusCode::BAD_REQUEST,
+            ),
+            Self::NoLiquidityForQuote => with_status(
+                super::error(
+                    "NoLiquidityForQuote",
+                    "unable to compute a minimum fee amount because of insufficient liquidity",
+                ),
+                StatusCode::BAD_REQUEST,
+            ),
+            Self::UnsupportedOrderTypeForQuote => with_status(
+                super::error(
+                    "UnsupportedOrderTypeForQuote",
+                    "unable to compute a minimum fee amount for this order kind",
+                ),
+                StatusCode::BAD_REQUEST,
+            ),
             Self::WrongOwner(owner) => with_status(
                 super::error(
                     "WrongOwner",

--- a/crates/orderbook/src/main.rs
+++ b/crates/orderbook/src/main.rs
@@ -12,7 +12,6 @@ use orderbook::{
     account_balances::Web3BalanceFetcher,
     database::{self, orders::OrderFilter, Postgres},
     event_updater::EventUpdater,
-    fee::MinFeeCalculator,
     fee_subsidy::{
         config::FeeSubsidyConfiguration, cow_token::CowSubsidy, FeeSubsidies, FeeSubsidizing,
     },
@@ -544,16 +543,7 @@ async fn main() {
         args.max_order_validity_period,
         args.enable_presign_orders,
         bad_token_detector.clone(),
-        Arc::new(MinFeeCalculator::new(
-            price_estimator.clone(),
-            gas_price_estimator.clone(),
-            database.clone(),
-            bad_token_detector.clone(),
-            fee_subsidy.clone(),
-            native_price_estimator,
-            args.liquidity_order_owners.iter().copied().collect(),
-            true,
-        )),
+        optimal_quoter.clone(),
         balance_fetcher,
     ));
     let orderbook = Arc::new(Orderbook::new(

--- a/crates/orderbook/src/order_quoting.rs
+++ b/crates/orderbook/src/order_quoting.rs
@@ -386,7 +386,7 @@ impl From<PartialValidationError> for OrderQuoteError {
 }
 
 /// Order parameters for quoting.
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq)]
 pub struct QuoteParameters {
     pub sell_token: H160,
     pub buy_token: H160,

--- a/crates/orderbook/src/order_validation.rs
+++ b/crates/orderbook/src/order_validation.rs
@@ -443,7 +443,7 @@ fn minimum_balance(order: &OrderData) -> Option<U256> {
 }
 
 /// Retrieves the quote for an order that is being created and verify that its
-/// fee is
+/// fee is sufficient.
 ///
 /// This works by first trying to find an existing quote, and then falling back
 /// to calculating a brand new one if none can be found and a quote ID was not


### PR DESCRIPTION
This PR builds on #297 and implements order creation in function of the new `OrderQuoting` component.

At this point, the legacy `OrderQuoterLegacy` and `MinFeeCalculator` should no longer be used and can be removed (follow up PR to not make this harder to review).

### Test Plan

Added new unit test cases to verify the new `get_quote_and_check_fee` logic (that replaced `MinFeeStoring::get_unsubsidized_min_fee`). Existing unit tests continue to work.
