### PR TITLE
Store quote data with order

### DIFF
--- a/crates/orderbook/src/database/instrumented.rs
+++ b/crates/orderbook/src/database/instrumented.rs
@@ -1,5 +1,5 @@
 use super::{orders::OrderStoring, trades::TradeRetrieving, Postgres};
-use crate::{fee_subsidy::FeeParameters, order_quoting::QuoteStoring};
+use crate::order_quoting::QuoteStoring;
 use ethcontract::H256;
 use model::order::Order;
 use prometheus::Histogram;
@@ -99,13 +99,13 @@ impl OrderStoring for Instrumented {
     async fn insert_order(
         &self,
         order: &model::order::Order,
-        fee: FeeParameters,
+        quote: Option<crate::order_quoting::Quote>,
     ) -> anyhow::Result<(), super::orders::InsertionError> {
         let _timer = self
             .metrics
             .database_query_histogram("insert_order")
             .start_timer();
-        self.inner.insert_order(order, fee).await
+        self.inner.insert_order(order, quote).await
     }
 
     async fn cancel_order(
@@ -124,14 +124,14 @@ impl OrderStoring for Instrumented {
         &self,
         old_order: &model::order::OrderUid,
         new_order: &model::order::Order,
-        new_fee: FeeParameters,
+        new_quote: Option<crate::order_quoting::Quote>,
     ) -> anyhow::Result<(), super::orders::InsertionError> {
         let _timer = self
             .metrics
             .database_query_histogram("replace_order")
             .start_timer();
         self.inner
-            .replace_order(old_order, new_order, new_fee)
+            .replace_order(old_order, new_order, new_quote)
             .await
     }
 

--- a/crates/orderbook/src/database/orders.rs
+++ b/crates/orderbook/src/database/orders.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::{conversions::*, fee_subsidy::FeeParameters};
+use crate::{conversions::*, order_quoting::Quote};
 use anyhow::{anyhow, Context as _, Result};
 use chrono::{DateTime, Utc};
 use const_format::concatcp;
@@ -21,13 +21,14 @@ use std::{borrow::Cow, convert::TryInto};
 #[cfg_attr(test, mockall::automock)]
 #[async_trait::async_trait]
 pub trait OrderStoring: Send + Sync {
-    async fn insert_order(&self, order: &Order, fee: FeeParameters) -> Result<(), InsertionError>;
+    async fn insert_order(&self, order: &Order, quote: Option<Quote>)
+        -> Result<(), InsertionError>;
     async fn cancel_order(&self, order_uid: &OrderUid, now: DateTime<Utc>) -> Result<()>;
     async fn replace_order(
         &self,
         old_order: &OrderUid,
         new_order: &Order,
-        new_fee: FeeParameters,
+        new_quote: Option<Quote>,
     ) -> Result<(), InsertionError>;
     // Legacy generic orders route that we are phasing out.
     async fn orders(&self, filter: &OrderFilter) -> Result<Vec<Order>>;
@@ -280,25 +281,35 @@ async fn insert_order(
         })
 }
 
-async fn insert_fee(
+async fn insert_quote(
     uid: &OrderUid,
-    fee: &FeeParameters,
+    quote: &Quote,
     transaction: &mut sqlx::Transaction<'_, sqlx::Postgres>,
 ) -> Result<(), InsertionError> {
-    const QUERY: &str = "\
-                INSERT INTO order_quotes (\
-                    order_uid, gas_amount, gas_price, sell_token_price, sell_amount, buy_amount) \
-                VALUES($1, $2, $3, $4, 0, 0)\
-            ;";
+    const QUERY: &str = r#"
+        INSERT INTO order_quotes (
+            order_uid,
+            gas_amount,
+            gas_price,
+            sell_token_price,
+            sell_amount,
+            buy_amount
+        )
+        VALUES ($1, $2, $3, $4, $5, $6)
+    ;"#;
+
     sqlx::query(QUERY)
         .bind(uid.0.as_ref())
-        .bind(fee.gas_amount)
-        .bind(fee.gas_price)
-        .bind(fee.sell_token_price)
+        .bind(quote.data.fee_parameters.gas_amount)
+        .bind(quote.data.fee_parameters.gas_price)
+        .bind(quote.data.fee_parameters.sell_token_price)
+        .bind(u256_to_big_decimal(&quote.sell_amount))
+        .bind(u256_to_big_decimal(&quote.buy_amount))
         .execute(transaction)
         .await
-        .map(|_| ())
-        .map_err(InsertionError::DbError)
+        .map_err(InsertionError::DbError)?;
+
+    Ok(())
 }
 
 async fn cancel_order(
@@ -324,14 +335,20 @@ async fn cancel_order(
 
 #[async_trait::async_trait]
 impl OrderStoring for Postgres {
-    async fn insert_order(&self, order: &Order, fee: FeeParameters) -> Result<(), InsertionError> {
+    async fn insert_order(
+        &self,
+        order: &Order,
+        quote: Option<Quote>,
+    ) -> Result<(), InsertionError> {
         let order = order.clone();
         let mut connection = self.pool.acquire().await?;
         connection
             .transaction(move |transaction| {
                 async move {
                     insert_order(&order, transaction).await?;
-                    insert_fee(&order.metadata.uid, &fee, transaction).await?;
+                    if let Some(quote) = quote {
+                        insert_quote(&order.metadata.uid, &quote, transaction).await?;
+                    }
                     Ok(())
                 }
                 .boxed()
@@ -354,7 +371,7 @@ impl OrderStoring for Postgres {
         &self,
         old_order: &model::order::OrderUid,
         new_order: &model::order::Order,
-        new_fee: FeeParameters,
+        new_quote: Option<Quote>,
     ) -> anyhow::Result<(), super::orders::InsertionError> {
         let old_order = *old_order;
         let new_order = new_order.clone();
@@ -364,7 +381,9 @@ impl OrderStoring for Postgres {
                 async move {
                     cancel_order(&old_order, new_order.metadata.creation_date, transaction).await?;
                     insert_order(&new_order, transaction).await?;
-                    insert_fee(&new_order.metadata.uid, &new_fee, transaction).await?;
+                    if let Some(quote) = new_quote {
+                        insert_quote(&new_order.metadata.uid, &quote, transaction).await?;
+                    }
                     Ok(())
                 }
                 .boxed()
@@ -680,8 +699,8 @@ fn is_buy_order_filled(amount: &BigDecimal, executed_amount: &BigDecimal) -> boo
 
 #[cfg(test)]
 mod tests {
-    use super::events::*;
-    use super::*;
+    use super::{events::*, *};
+    use crate::{fee_subsidy::FeeParameters, order_quoting::QuoteData};
     use chrono::{Duration, NaiveDateTime};
     use num::BigUint;
     use primitive_types::U256;
@@ -909,12 +928,12 @@ mod tests {
         db.clear().await.unwrap();
 
         let mut order = Order::default();
-        db.insert_order(&order, Default::default()).await.unwrap();
+        db.insert_order(&order, None).await.unwrap();
 
         // Note that order UIDs do not care about the signing scheme.
         order.signature = Signature::default_with(SigningScheme::PreSign);
         assert!(matches!(
-            db.insert_order(&order, Default::default()).await,
+            db.insert_order(&order, None).await,
             Err(InsertionError::DuplicatedRecord)
         ));
     }
@@ -922,17 +941,45 @@ mod tests {
     #[tokio::test]
     #[ignore]
     #[allow(clippy::float_cmp)]
-    async fn postgres_insert_fee() {
+    async fn postgres_insert_order_without_quote() {
         let db = Postgres::new("postgresql://").unwrap();
         db.clear().await.unwrap();
 
         let order = Order::default();
-        let fee = FeeParameters {
-            gas_amount: 1.,
-            gas_price: 2.,
-            sell_token_price: 3.,
+        db.insert_order(&order, None).await.unwrap();
+
+        let query = "SELECT COUNT(*) FROM order_quotes;";
+        let (count,): (i64,) = sqlx::query_as(query)
+            .bind(order.metadata.uid.0.as_ref())
+            .fetch_one(&db.pool)
+            .await
+            .unwrap();
+
+        assert_eq!(count, 0);
+    }
+
+    #[tokio::test]
+    #[ignore]
+    #[allow(clippy::float_cmp)]
+    async fn postgres_insert_order_with_quote() {
+        let db = Postgres::new("postgresql://").unwrap();
+        db.clear().await.unwrap();
+
+        let order = Order::default();
+        let quote = Quote {
+            data: QuoteData {
+                fee_parameters: FeeParameters {
+                    gas_amount: 1.,
+                    gas_price: 2.,
+                    sell_token_price: 3.,
+                },
+                ..Default::default()
+            },
+            sell_amount: 4.into(),
+            buy_amount: 5.into(),
+            ..Default::default()
         };
-        db.insert_order(&order, fee).await.unwrap();
+        db.insert_order(&order, Some(quote)).await.unwrap();
         let query = "SELECT * FROM order_quotes;";
         let (uid, gas_amount, gas_price, sell_token_price, sell_amount, buy_amount): (
             Vec<u8>,
@@ -950,8 +997,8 @@ mod tests {
         assert_eq!(gas_amount, 1.);
         assert_eq!(gas_price, 2.);
         assert_eq!(sell_token_price, 3.);
-        assert!(sell_amount.is_zero());
-        assert!(buy_amount.is_zero());
+        assert_eq!(sell_amount, 4.into());
+        assert_eq!(buy_amount, 5.into());
     }
 
     #[tokio::test]
@@ -994,7 +1041,7 @@ mod tests {
                 },
                 signature: Signature::default_with(*signing_scheme),
             };
-            db.insert_order(&order, Default::default()).await.unwrap();
+            db.insert_order(&order, None).await.unwrap();
             assert_eq!(db.orders(&filter).await.unwrap(), vec![order]);
         }
     }
@@ -1013,7 +1060,7 @@ mod tests {
         assert!(db.orders(&filter).await.unwrap().is_empty());
 
         let order = Order::default();
-        db.insert_order(&order, Default::default()).await.unwrap();
+        db.insert_order(&order, None).await.unwrap();
         let db_orders = db.orders(&filter).await.unwrap();
         assert!(!db_orders[0].metadata.invalidated);
 
@@ -1069,9 +1116,7 @@ mod tests {
             },
             ..Default::default()
         };
-        db.insert_order(&old_order, Default::default())
-            .await
-            .unwrap();
+        db.insert_order(&old_order, None).await.unwrap();
 
         let new_order = Order {
             data: OrderData {
@@ -1086,7 +1131,7 @@ mod tests {
             },
             ..Default::default()
         };
-        db.replace_order(&old_order.metadata.uid, &new_order, Default::default())
+        db.replace_order(&old_order.metadata.uid, &new_order, None)
             .await
             .unwrap();
 
@@ -1133,9 +1178,7 @@ mod tests {
             },
             ..Default::default()
         };
-        db.insert_order(&old_order, Default::default())
-            .await
-            .unwrap();
+        db.insert_order(&old_order, None).await.unwrap();
 
         let new_order = Order {
             metadata: OrderMetadata {
@@ -1146,13 +1189,11 @@ mod tests {
             },
             ..Default::default()
         };
-        db.insert_order(&new_order, Default::default())
-            .await
-            .unwrap();
+        db.insert_order(&new_order, None).await.unwrap();
 
         // Attempt to replace an old order with one that already exists should fail.
         let err = db
-            .replace_order(&old_order.metadata.uid, &new_order, Default::default())
+            .replace_order(&old_order.metadata.uid, &new_order, None)
             .await
             .unwrap_err();
         assert!(matches!(err, InsertionError::DuplicatedRecord));
@@ -1221,7 +1262,7 @@ mod tests {
             },
         ];
         for order in orders.iter() {
-            db.insert_order(order, Default::default()).await.unwrap();
+            db.insert_order(order, None).await.unwrap();
         }
 
         async fn assert_orders(db: &Postgres, filter: &OrderFilter, expected: &[Order]) {
@@ -1314,7 +1355,7 @@ mod tests {
             },
             ..Default::default()
         };
-        db.insert_order(&order, Default::default()).await.unwrap();
+        db.insert_order(&order, None).await.unwrap();
 
         let get_order = |exclude_fully_executed| {
             let db = db.clone();
@@ -1411,7 +1452,7 @@ mod tests {
             },
             ..Default::default()
         };
-        db.insert_order(&order, Default::default()).await.unwrap();
+        db.insert_order(&order, None).await.unwrap();
 
         let sell_amount_before_fees = U256::MAX / 16;
         let fee_amount = U256::MAX / 16;
@@ -1473,7 +1514,7 @@ mod tests {
             },
             ..Default::default()
         };
-        db.insert_order(&order, Default::default()).await.unwrap();
+        db.insert_order(&order, None).await.unwrap();
 
         let is_order_valid = || async {
             !db.orders(&OrderFilter {
@@ -1539,7 +1580,7 @@ mod tests {
             signature: Signature::default_with(SigningScheme::PreSign),
             ..Default::default()
         };
-        db.insert_order(&order, Default::default()).await.unwrap();
+        db.insert_order(&order, None).await.unwrap();
 
         let get_order = || {
             let db = db.clone();
@@ -1637,7 +1678,7 @@ mod tests {
             },
             ..Default::default()
         };
-        db.insert_order(&order, Default::default()).await.unwrap();
+        db.insert_order(&order, None).await.unwrap();
 
         let get_order = |min_valid_to| {
             let db = db.clone();
@@ -1723,8 +1764,8 @@ mod tests {
             ..Default::default()
         };
         assert!(order0.metadata.uid != order1.metadata.uid);
-        db.insert_order(&order0, Default::default()).await.unwrap();
-        db.insert_order(&order1, Default::default()).await.unwrap();
+        db.insert_order(&order0, None).await.unwrap();
+        db.insert_order(&order1, None).await.unwrap();
 
         let get_order = |uid| {
             let db = db.clone();
@@ -1753,7 +1794,7 @@ mod tests {
             },
             signature: Signature::default_with(SigningScheme::PreSign),
         };
-        db.insert_order(&order, Default::default()).await.unwrap();
+        db.insert_order(&order, None).await.unwrap();
 
         let order_status = || async {
             db.orders(&OrderFilter {
@@ -1829,11 +1870,11 @@ mod tests {
             signature: Signature::default_with(scheme),
         };
 
-        db.insert_order(&order(0, SigningScheme::Eip712), Default::default())
+        db.insert_order(&order(0, SigningScheme::Eip712), None)
             .await
             .unwrap();
         for i in 1..=4 {
-            db.insert_order(&order(i, SigningScheme::PreSign), Default::default())
+            db.insert_order(&order(i, SigningScheme::PreSign), None)
                 .await
                 .unwrap();
         }
@@ -1969,7 +2010,7 @@ mod tests {
         ];
 
         for order in &orders {
-            db.insert_order(order, Default::default()).await.unwrap();
+            db.insert_order(order, None).await.unwrap();
         }
 
         let result = db.user_orders(&owners[0], 0, None).await.unwrap();
@@ -2010,7 +2051,7 @@ mod tests {
 
         // Each order was traded in the consecutive blocks.
         for (i, order) in orders.clone().iter().enumerate() {
-            db.insert_order(order, Default::default()).await.unwrap();
+            db.insert_order(order, None).await.unwrap();
             db.append_events_(vec![
                 // Add settlement
                 (

--- a/crates/orderbook/src/order_validation.rs
+++ b/crates/orderbook/src/order_validation.rs
@@ -448,7 +448,10 @@ async fn get_quote_and_check_fee(
     };
 
     let quote = match quoter.find_quote(order.quote_id, parameters).await {
-        Ok(quote) => quote,
+        Ok(quote) => {
+            tracing::debug!(quote_id =? order.quote_id, "found quote for order creation");
+            quote
+        }
         // We couldn't find a quote, and no ID was specified. Try computing a
         // fresh quote to use instead.
         Err(FindQuoteError::NotFound(_)) if order.quote_id.is_none() => {
@@ -468,7 +471,10 @@ async fn get_quote_and_check_fee(
                 from: owner,
                 app_data: order.data.app_data,
             };
-            quoter.calculate_quote(parameters).await?
+            let quote = quoter.calculate_quote(parameters).await?;
+
+            tracing::debug!("computed fresh quote for order creation");
+            quote
         }
         Err(err) => return Err(err.into()),
     };

--- a/crates/orderbook/src/order_validation.rs
+++ b/crates/orderbook/src/order_validation.rs
@@ -1,6 +1,5 @@
 use crate::{
     account_balances::{BalanceFetching, TransferSimulationError},
-    fee_subsidy::FeeParameters,
     order_quoting::{
         CalculateQuoteError, FindQuoteError, OrderQuoting, Quote, QuoteParameters,
         QuoteSearchParameters,
@@ -56,7 +55,7 @@ pub trait OrderValidating: Send + Sync {
         order: OrderCreation,
         domain_separator: &DomainSeparator,
         settlement_contract: H160,
-    ) -> Result<(Order, FeeParameters), ValidationError>;
+    ) -> Result<(Order, Option<Quote>), ValidationError>;
 }
 
 #[derive(Debug)]
@@ -313,7 +312,7 @@ impl OrderValidating for OrderValidator {
         order: OrderCreation,
         domain_separator: &DomainSeparator,
         settlement_contract: H160,
-    ) -> Result<(Order, FeeParameters), ValidationError> {
+    ) -> Result<(Order, Option<Quote>), ValidationError> {
         let owner = order.verify_owner(domain_separator)?;
         let signing_scheme = order.signature.scheme();
 
@@ -343,8 +342,9 @@ impl OrderValidating for OrderValidator {
             None
         };
 
-        let fee_parameters = quote
-            .map(|quote| quote.data.fee_parameters)
+        let full_fee_amount = quote
+            .as_ref()
+            .map(|quote| quote.data.fee_parameters.unsubsidized())
             .unwrap_or_default();
 
         let min_balance = match minimum_balance(&order.data) {
@@ -398,10 +398,10 @@ impl OrderValidating for OrderValidator {
             &order,
             domain_separator,
             settlement_contract,
-            fee_parameters.unsubsidized(),
+            full_fee_amount,
             is_liquidity_order,
         )?;
-        Ok((order, fee_parameters))
+        Ok((order, quote))
     }
 }
 


### PR DESCRIPTION
This PR changes the `OrderStoring` implementation to actually store the quote data instead of just the fee parameters.

While the database schema was changed in #295 to allow for order quotes to get stored alongside orders, the `OrderStoring` implementation did not, at the time, make use of this and stored dummy `0` values (there was additional "wiring" that was needed in order to make the quote data available).

### Test Plan

Added new unit tests to make sure data is stored.

### Manual Testing

I also did some manual testing to verify that order creation is working as expected.

1. Run the orderbook on Rinkeby:
   ```
   % cargo run -p orderbook -- --skip-trace-api true --skip-event-sync --node-url $RINKEBY
   ```
2. Run the attached script:
   ```
   % ./quoteids.sh
   ```
3. Restart the orderbook with the account as a liquidity owner:
   ```
   % cargo run -p orderbook -- --skip-trace-api true --skip-event-sync --node-url $RINKEBY --liquidity-order-owners $(hdwallet address)
   ```
4. Run the script again:
   ```
   % ./quoteids.sh
   ```
5. Inspect the database. Note that the quotes are being stored with the orders as expected and that there is no associated quotes for liquidity orders:
   ```
   => SELECT o.uid,o.is_liquidity_order,o.sell_amount,o.buy_amount,o.cancellation_timestamp,q.sell_amount,q.buy_amount FROM orders AS o LEFT JOIN order_quotes AS q ON o.uid = q.order_uid ORDER BY o.creation_timestamp;
                                                           uid                                                         | is_liquidity_order |     sell_amount     |       buy_amount       |    cancellation_timestamp     |    sell_amount     |       buy_amount       
   --------------------------------------------------------------------------------------------------------------------+--------------------+---------------------+------------------------+-------------------------------+--------------------+------------------------
    \x7b893286cc105822d4a0891642a6b0e36350ee618b2022d7866e8f6fe2d32f6bdbc682d0ec19bd276fd6c2af4e0189b584bb31e162b34aea | f                  |                1000 | 1000000000000000000000 | 2022-06-22 16:31:31.543119+00 | 896447231714365852 | 1000000000000000000000
    \x23f06b275e2d665551fb9286d32b364c79b733964a60ef16d9a18bcab5db29ccdbc682d0ec19bd276fd6c2af4e0189b584bb31e162b34aeb | f                  | 1000000000000000000 | 1000000000000000000000 |                               | 896447231714365852 | 1000000000000000000000
    \x44ccf59621ab3c40778e0137abd15bcb13c2b7057a8e2d2b606e05d3126ca700dbc682d0ec19bd276fd6c2af4e0189b584bb31e162b34b16 | t                  |                1000 | 1000000000000000000000 | 2022-06-22 16:32:15.310289+00 |                    |                       
    \x7d5f3302f8572594b81a6d0526196913b4aefda9556f9844ef4b6e2973beffe7dbc682d0ec19bd276fd6c2af4e0189b584bb31e162b34b17 | t                  | 1000000000000000000 | 1000000000000000000000 |                               |                    |                       
   (4 rows)
   ```
   
Script for manual testing: [quoteids.sh](https://github.com/cowprotocol/services/files/8959922/quoteids.txt) (note that it was uploaded as a text file because of Github limitations and you will need to `mv quoteids.txt quoteids.sh && chmod +x quoteids.sh` in order to run it).

