### PR TITLE
Flag out of market price orders as liquidity

### DIFF
--- a/crates/orderbook/src/order_validation.rs
+++ b/crates/orderbook/src/order_validation.rs
@@ -1458,7 +1458,7 @@ mod tests {
             &OrderData {
                 sell_amount: 100.into(),
                 buy_amount: 100.into(),
-                kind: OrderKind::Sell,
+                kind: OrderKind::Buy,
                 ..Default::default()
             },
             &quote,
@@ -1468,7 +1468,7 @@ mod tests {
             &OrderData {
                 sell_amount: 101.into(), // 1% slippage
                 buy_amount: 100.into(),
-                kind: OrderKind::Sell,
+                kind: OrderKind::Buy,
                 ..Default::default()
             },
             &quote,
@@ -1478,7 +1478,7 @@ mod tests {
             &OrderData {
                 sell_amount: 1.into(),
                 buy_amount: 100.into(),
-                kind: OrderKind::Sell,
+                kind: OrderKind::Buy,
                 ..Default::default()
             },
             &quote

--- a/crates/orderbook/src/order_validation.rs
+++ b/crates/orderbook/src/order_validation.rs
@@ -496,12 +496,11 @@ async fn get_quote_and_check_fee(
     Ok(quote)
 }
 
-/// Checks whether or not an order is a market order.
+/// Checks whether or not an order's limit price is within the market price
+/// specified by the quote.
 ///
-/// A market order is defined as an order whose price is equal or worse to the
-/// best on-chain price that can be found at the time. This allows the protocol
-/// to detect orders that place orders that aren't intended to be traded right
-/// away and flag them as liquidity orders.
+/// Note that this check only looks at the order's limit price and the market
+/// price and is independent of amounts or trade direction.
 fn is_market_priced_order(order: &OrderData, quote: &Quote) -> bool {
     order.sell_amount.full_mul(quote.buy_amount) >= quote.sell_amount.full_mul(order.buy_amount)
 }


### PR DESCRIPTION
This PR uses order quotes to determine when orders are outside of the current market price and flag them as liquidity orders.

The rationale behind this change is that these orders are not intended to be traded immediately (i.e. they are long standing orders) and so should be treated differently. Concretely, we treat them as liquidity orders so that they don't trade against AMMs but other users once the market price moves in their favour. Longer term, we will start charging fees from order limit prices and will no longer need this distinction.

Note that this should not affect CowSwap UI traders at all since they will always create orders based on an API quote and will be "in the market price".

### Test Plan

Added test cases verifying pricing logic.

### Release notes

This PR flags additional orders as liquidity orders. We should monitor our metrics and make sure that they aren't getting mis-flagged on release.
