### PR TITLE
Introduce initial autopilot binary

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -153,6 +153,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
+name = "autopilot"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "clap 3.2.5",
+ "prometheus",
+ "prometheus-metric-storage",
+ "shared",
+ "tokio",
+ "tracing",
+ "url",
+]
+
+[[package]]
 name = "backtrace"
 version = "0.3.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/crates/autopilot/Cargo.toml
+++ b/crates/autopilot/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "autopilot"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+name = "autopilot"
+path = "src/lib.rs"
+doctest = false
+
+[[bin]]
+name = "autopilot"
+path = "src/main.rs"
+
+[dependencies]
+anyhow = "1.0"
+async-trait = "0.1"
+clap = { version = "3.1", features = ["derive", "env"] }
+prometheus = "0.13"
+prometheus-metric-storage = { git = "https://github.com/cowprotocol/prometheus-metric-storage" , tag = "v0.4.0" }
+shared= { path = "../shared" }
+tokio = { version = "1.15", features = ["macros", "rt-multi-thread", "sync", "time", "signal"] }
+tracing = "0.1"
+url = "2.2"

--- a/crates/autopilot/src/arguments.rs
+++ b/crates/autopilot/src/arguments.rs
@@ -1,0 +1,23 @@
+use std::net::SocketAddr;
+use tracing::level_filters::LevelFilter;
+
+#[derive(clap::Parser)]
+pub struct Arguments {
+    #[clap(long, env, default_value = "warn,autopilot=debug,shared=debug")]
+    pub log_filter: String,
+
+    #[clap(long, env, default_value = "error", parse(try_from_str))]
+    pub log_stderr_threshold: LevelFilter,
+
+    #[clap(long, env, default_value = "0.0.0.0:9589")]
+    pub metrics_address: SocketAddr,
+}
+
+impl std::fmt::Display for Arguments {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        writeln!(f, "log_filter: {}", self.log_filter)?;
+        writeln!(f, "log_stderr_threshold: {}", self.log_stderr_threshold)?;
+        writeln!(f, "metrics_address: {}", self.metrics_address)?;
+        Ok(())
+    }
+}

--- a/crates/autopilot/src/lib.rs
+++ b/crates/autopilot/src/lib.rs
@@ -1,0 +1,38 @@
+pub mod arguments;
+
+use shared::metrics::LivenessChecking;
+use std::{
+    sync::Arc,
+    time::{Duration, Instant},
+};
+
+#[derive(prometheus_metric_storage::MetricStorage)]
+struct Metrics {
+    /// Number of seconds program has been running for.
+    seconds_alive: prometheus::IntGauge,
+}
+
+struct Liveness;
+#[async_trait::async_trait]
+impl LivenessChecking for Liveness {
+    async fn is_alive(&self) -> bool {
+        true
+    }
+}
+
+/// Assumes tracing and metrics registry have already been set up.
+pub async fn main(args: arguments::Arguments) {
+    let update_metrics = async {
+        let start = Instant::now();
+        let metrics = Metrics::instance(shared::metrics::get_metric_storage_registry()).unwrap();
+        loop {
+            metrics.seconds_alive.set(start.elapsed().as_secs() as i64);
+            tokio::time::sleep(Duration::from_secs(1)).await;
+        }
+    };
+    let serve_metrics = shared::metrics::serve_metrics(Arc::new(Liveness), args.metrics_address);
+    tokio::select! {
+        result = serve_metrics => tracing::error!(?result, "serve_metrics exited"),
+        _ = update_metrics => (),
+    };
+}

--- a/crates/autopilot/src/main.rs
+++ b/crates/autopilot/src/main.rs
@@ -1,0 +1,10 @@
+use clap::Parser;
+
+#[tokio::main]
+async fn main() {
+    let args = autopilot::arguments::Arguments::parse();
+    shared::tracing::initialize(args.log_filter.as_str(), args.log_stderr_threshold);
+    tracing::info!("running autopilot with validated arguments:\n{}", args);
+    shared::metrics::setup_metrics_registry(Some("gp_v2_autopilot".into()), None);
+    autopilot::main(args).await;
+}

--- a/docker/Dockerfile.binary
+++ b/docker/Dockerfile.binary
@@ -16,6 +16,7 @@ RUN apt-get update && apt-get install -y ca-certificates tini && apt-get clean
 COPY --from=cargo-build /src/target/release/orderbook /usr/local/bin/orderbook
 COPY --from=cargo-build /src/target/release/solver /usr/local/bin/solver
 COPY --from=cargo-build /src/target/release/alerter /usr/local/bin/alerter
+COPY --from=cargo-build /src/target/release/autopilot /usr/local/bin/autopilot
 
 CMD echo "Specify binary - either solver or orderbook"
 ENTRYPOINT ["/usr/bin/tini"]


### PR DESCRIPTION
Has been discussed in https://github.com/cowprotocol/services/issues/175 and https://github.com/cowprotocol/services/issues/230 .

Currently does nothing except export a metric. Once it is integrated into kubernetes I will start moving functionality from Orderbook into it.

One design idea is that this can automatically be run by the orderbook (and the e2e tests) which is why it exports the main function in its library. I'm not yet sure what the best approach for that is with regards to its command line arguments. It seems like for anything that we want configurable (not default) we would need to duplicate them into the orderbook arguments. Or maybe there is some advanced Clap use that makes this easier (subcommands?). Anyway I don't want the details of this to delay other changes so will think about it more later.

Another thing to think about is that before the shared crate contained things needed for both orderbook and solver but now that we have 3 binaries using it this doesn't make much sense because we will also have things shared between all only two of the binaries. I think we should split up shared into more smaller crates which likely helps with compilation time too. Again I don't want this to delay the main change more so for now I will just move some stuff from orderbook into shared.

### Test Plan

CI and manually ran the autopilot binary to see that the metrics work
