### PR TITLE
Init rate limiting metrics

### DIFF
--- a/crates/shared/src/rate_limiter.rs
+++ b/crates/shared/src/rate_limiter.rs
@@ -150,6 +150,16 @@ impl RateLimiter {
     }
 
     pub fn from_strategy(strategy: RateLimitingStrategy, name: String) -> Self {
+        let metrics = metrics();
+        metrics.requests_dropped.with_label_values(&[&name]).reset();
+        metrics
+            .rate_limited_requests
+            .with_label_values(&[&name])
+            .reset();
+        metrics
+            .successful_requests
+            .with_label_values(&[&name])
+            .reset();
         Self {
             strategy: Mutex::new(strategy),
             name,


### PR DESCRIPTION
While checking up on the grafana panel for the rate limiters I saw that they didn't display data for all the configured rate limiters.
In order to display the percent of "bad" requests (dropped or too slow) I would have to create a query like this:
`(rate_limited + dropped) / (rate_limited + dropped + success)` (basically requests_bad / requests_total)
The problem is that grafana won't draw the graph if one of the metrics in the query doesn't have a value because it hasn't been initialized yet.
To get around this fact I decided to `reset()` the metric counters to populate each counter with 0.
Now the legend and graphs can be drawn even if no request has been made through the `RateLimiter`.

Note that the `Baseline_estimator` has a graph although it doesn't even use a `RateLimiter`, yet. I plan to tackle this in a separate PR.

### Test Plan
Manual test with local grafana instance:
<img width="1496" alt="Screenshot 2022-06-23 at 14 05 55" src="https://user-images.githubusercontent.com/19190235/175294858-0afd1a17-80ce-4e08-8322-d879bd7f7fb6.png">


Metrics:
```
# HELP gp_v2_api_rate_limiter_rate_limited_requests Number of responses indicating a rate limiting error.
# TYPE gp_v2_api_rate_limiter_rate_limited_requests counter
gp_v2_api_rate_limiter_rate_limited_requests{endpoint="Baseline_estimator"} 0
gp_v2_api_rate_limiter_rate_limited_requests{endpoint="OneInch_estimator"} 0
gp_v2_api_rate_limiter_rate_limited_requests{endpoint="Paraswap_estimator"} 27
gp_v2_api_rate_limiter_rate_limited_requests{endpoint="Quasimodo_estimator"} 0
gp_v2_api_rate_limiter_rate_limited_requests{endpoint="ZeroEx_estimator"} 52
# HELP gp_v2_api_rate_limiter_requests_dropped Number of requests dropped while being rate limited.
# TYPE gp_v2_api_rate_limiter_requests_dropped counter
gp_v2_api_rate_limiter_requests_dropped{endpoint="Baseline_estimator"} 0
gp_v2_api_rate_limiter_requests_dropped{endpoint="OneInch_estimator"} 0
gp_v2_api_rate_limiter_requests_dropped{endpoint="Paraswap_estimator"} 7
gp_v2_api_rate_limiter_requests_dropped{endpoint="Quasimodo_estimator"} 0
gp_v2_api_rate_limiter_requests_dropped{endpoint="ZeroEx_estimator"} 11
# HELP gp_v2_api_rate_limiter_successful_requests Number of successful requests.
# TYPE gp_v2_api_rate_limiter_successful_requests counter
gp_v2_api_rate_limiter_successful_requests{endpoint="Baseline_estimator"} 0
gp_v2_api_rate_limiter_successful_requests{endpoint="OneInch_estimator"} 26
gp_v2_api_rate_limiter_successful_requests{endpoint="Paraswap_estimator"} 81
gp_v2_api_rate_limiter_successful_requests{endpoint="Quasimodo_estimator"} 115
gp_v2_api_rate_limiter_successful_requests{endpoint="ZeroEx_estimator"} 52
```
