### PR TITLE
Rate limit BaselinePriceEstimator

### DIFF
--- a/crates/e2e/tests/e2e/services.rs
+++ b/crates/e2e/tests/e2e/services.rs
@@ -21,6 +21,7 @@ use shared::{
     price_estimation::baseline::BaselinePriceEstimator,
     price_estimation::native::NativePriceEstimator,
     price_estimation::sanitized::SanitizedPriceEstimator,
+    rate_limiter::RateLimiter,
     recent_block_cache::CacheConfig,
     sources::uniswap_v2::{
         self,
@@ -135,6 +136,10 @@ impl OrderbookServices {
                 base_tokens.clone(),
                 contracts.weth.address(),
                 1_000_000_000_000_000_000_u128.into(),
+                Arc::new(RateLimiter::from_strategy(
+                    Default::default(),
+                    "baseline_estimator".into(),
+                )),
             )),
             contracts.weth.address(),
             bad_token_detector.clone(),

--- a/crates/orderbook/src/main.rs
+++ b/crates/orderbook/src/main.rs
@@ -377,6 +377,7 @@ async fn main() {
                     base_tokens.clone(),
                     native_token.address(),
                     native_token_price_estimation_amount,
+                    rate_limiter,
                 )),
                 PriceEstimatorType::Paraswap => Box::new(ParaswapPriceEstimator::new(
                     Arc::new(DefaultParaswapApi {


### PR DESCRIPTION
Implements rate limiting logic for the `BaselinePriceEstimator`.
I think it's a little unclear how rate limiting an estimator which does a single request for multiple queries should work.

I ended up only rate limiting the 2 parallelized requests which query all the data needed to calculate the price estimates.
I think this is most likely what we want given the fact that those requests are probably what take most of the time and their execution times are what's not under our control when processing price estimates.

### Test Plan
CI
