### PR TITLE
Pretty print paraswap rate limiting CLI argument

### DIFF
--- a/crates/shared/src/arguments.rs
+++ b/crates/shared/src/arguments.rs
@@ -227,7 +227,9 @@ impl Display for Arguments {
             "disabled_paraswap_dexs: {:?}",
             self.disabled_paraswap_dexs
         )?;
-        writeln!(f, "paraswap_rate_limiter: {:?}", self.paraswap_rate_limiter)?;
+        write!(f, "paraswap_rate_limiter: ")?;
+        display_option(&self.paraswap_rate_limiter, f)?;
+        writeln!(f)?;
         writeln!(
             f,
             "zeroex_url: {}",


### PR DESCRIPTION
Prints the CLI argument for the paraswap rate limiting strategy the same way we print the price estimator strategy:
Before:
```
...
disabled_paraswap_dexs: ["ParaSwapPool4"]
paraswap_rate_limiter: Some(RateLimitingStrategy { drop_requests_until: Instant { t: 324338013644 }, times_rate_limited: 0, back_off_growth_factor: 2.0, min_back_off: 1s, max_back_off: 5s })
zeroex_url: None
...
```
After:
```
...
disabled_paraswap_dexs: ["ParaSwapPool4"]
paraswap_rate_limiter: RateLimitingStrategy{ min_back_off: 1s, max_back_off: 5s, growth_factor: 2.0 }
zeroex_url: None
...
```
