### PR TITLE
Log solver name for failed simulation

### DIFF
--- a/crates/solver/src/driver.rs
+++ b/crates/solver/src/driver.rs
@@ -350,7 +350,11 @@ impl Driver {
                         error_at_earlier_block,
                     );
                     // split warning into separate logs so that the messages aren't too long.
-                    tracing::warn!("settlement failure for: \n{:#?}", settlement);
+                    tracing::warn!(
+                        "{} settlement failure for: \n{:#?}",
+                        solver.name(),
+                        settlement,
+                    );
 
                     metrics.settlement_simulation_failed(solver.name());
                 }


### PR DESCRIPTION
I like to debug a sudden increase of failed settlement simulations with this [Kibana query](https://logs.cow.fi/goto/768c7fa0-f382-11ec-97dd-b383b91e99a0).

In case we only get an alert for a single solve I would like to be able to filter by that solver to ignore the occasional simulation error of other solvers to more quickly and confidently know which token the solver has problems with.

AFAIK determining which solver created a settlement would currently involve clicking "surrounding documents" on each failed settlement to see the previous log which contains the solver name. This is quite cumbersome.