### PR TITLE
Proof of concept EIP-1271 orders

### DIFF
--- a/crates/model/src/order.rs
+++ b/crates/model/src/order.rs
@@ -494,6 +494,15 @@ impl OrderUid {
         uid.0[0..4].copy_from_slice(&i.to_le_bytes());
         uid
     }
+
+    /// Splits an order UID into its parts.
+    pub fn parts(&self) -> (H256, H160, u32) {
+        (
+            H256::from_slice(&self.0[0..32]),
+            H160::from_slice(&self.0[32..52]),
+            u32::from_le_bytes(self.0[52..].try_into().unwrap()),
+        )
+    }
 }
 
 impl FromStr for OrderUid {

--- a/crates/model/src/signature.rs
+++ b/crates/model/src/signature.rs
@@ -2,7 +2,10 @@ use crate::{bytes_hex, DomainSeparator};
 use anyhow::{ensure, Context as _, Result};
 use primitive_types::{H160, H256};
 use serde::{de, Deserialize, Serialize};
-use std::{convert::TryInto as _, fmt};
+use std::{
+    convert::TryInto as _,
+    fmt::{self, Debug, Formatter},
+};
 use web3::{
     signing::{self, Key, SecretKeyRef},
     types::Recovery,
@@ -23,7 +26,7 @@ impl Default for SigningScheme {
     }
 }
 
-#[derive(Eq, PartialEq, Clone, Debug, Deserialize, Serialize, Hash)]
+#[derive(Eq, PartialEq, Clone, Deserialize, Serialize, Hash)]
 #[serde(into = "JsonSignature", try_from = "JsonSignature")]
 pub enum Signature {
     Eip712(EcdsaSignature),
@@ -35,6 +38,18 @@ pub enum Signature {
 impl Default for Signature {
     fn default() -> Self {
         Self::default_with(SigningScheme::default())
+    }
+}
+
+impl Debug for Signature {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        if let Signature::PreSign = self {
+            return f.write_str("PreSign");
+        }
+
+        let scheme = format!("{:?}", self.scheme());
+        let bytes = format!("0x{}", hex::encode(self.to_bytes()));
+        f.debug_tuple(&scheme).field(&bytes).finish()
     }
 }
 

--- a/crates/orderbook/src/arguments.rs
+++ b/crates/orderbook/src/arguments.rs
@@ -76,6 +76,10 @@ pub struct Arguments {
     #[clap(long, env, default_value = "200")]
     pub pool_cache_lru_size: usize,
 
+    /// Enable EIP-1271 orders.
+    #[clap(long, env, parse(try_from_str), default_value = "false")]
+    pub enable_eip1271_orders: bool,
+
     /// Enable pre-sign orders. Pre-sign orders are accepted into the database without a valid
     /// signature, so this flag allows this feature to be turned off if malicious users are
     /// abusing the database by inserting a bunch of order rows that won't ever be valid.

--- a/crates/orderbook/src/arguments.rs
+++ b/crates/orderbook/src/arguments.rs
@@ -252,6 +252,7 @@ impl std::fmt::Display for Arguments {
         writeln!(f, "banned_users: {:?}", self.banned_users)?;
         writeln!(f, "allowed_tokens: {:?}", self.allowed_tokens)?;
         writeln!(f, "pool_cache_lru_size: {}", self.pool_cache_lru_size)?;
+        writeln!(f, "enable_eip1271_orders: {}", self.enable_eip1271_orders)?;
         writeln!(f, "enable_presign_orders: {}", self.enable_presign_orders)?;
         writeln!(
             f,

--- a/crates/orderbook/src/order_validation.rs
+++ b/crates/orderbook/src/order_validation.rs
@@ -4,6 +4,7 @@ use crate::{
         CalculateQuoteError, FindQuoteError, OrderQuoting, Quote, QuoteParameters,
         QuoteSearchParameters,
     },
+    signature_validator::{SignatureCheck, SignatureValidating, SignatureValidationError},
 };
 use anyhow::anyhow;
 use contracts::WETH9;
@@ -14,7 +15,7 @@ use model::{
         BUY_ETH_ADDRESS,
     },
     quote::{OrderQuoteSide, SellAmount},
-    signature::{SigningScheme, VerificationError},
+    signature::{hashed_eip712_message, Signature, SigningScheme, VerificationError},
     DomainSeparator,
 };
 use shared::{
@@ -145,6 +146,15 @@ impl From<CalculateQuoteError> for ValidationError {
     }
 }
 
+impl From<SignatureValidationError> for ValidationError {
+    fn from(err: SignatureValidationError) -> Self {
+        match err {
+            SignatureValidationError::Invalid => Self::InvalidSignature,
+            SignatureValidationError::Other(err) => Self::Other(err.into()),
+        }
+    }
+}
+
 pub struct OrderValidator {
     /// For Pre/Partial-Validation: performed during fee & quote phase
     /// when only part of the order data is available
@@ -154,11 +164,12 @@ pub struct OrderValidator {
     liquidity_order_owners: HashSet<H160>,
     min_order_validity_period: Duration,
     max_order_validity_period: Duration,
-    enable_presign_orders: bool,
+    signature_configuration: SignatureConfiguration,
     bad_token_detector: Arc<dyn BadTokenDetecting>,
     /// For Full-Validation: performed time of order placement
     quoter: Arc<dyn OrderQuoting>,
     balance_fetcher: Arc<dyn BalanceFetching>,
+    signature_validator: Arc<dyn SignatureValidating>,
 }
 
 #[derive(Debug, PartialEq, Default)]
@@ -215,10 +226,11 @@ impl OrderValidator {
         liquidity_order_owners: HashSet<H160>,
         min_order_validity_period: Duration,
         max_order_validity_period: Duration,
-        enable_presign_orders: bool,
+        signature_configuration: SignatureConfiguration,
         bad_token_detector: Arc<dyn BadTokenDetecting>,
         quoter: Arc<dyn OrderQuoting>,
         balance_fetcher: Arc<dyn BalanceFetching>,
+        signature_validator: Arc<dyn SignatureValidating>,
     ) -> Self {
         Self {
             code_fetcher,
@@ -227,10 +239,11 @@ impl OrderValidator {
             liquidity_order_owners,
             min_order_validity_period,
             max_order_validity_period,
-            enable_presign_orders,
+            signature_configuration,
             bad_token_detector,
             quoter,
             balance_fetcher,
+            signature_validator,
         }
     }
 }
@@ -261,10 +274,10 @@ impl OrderValidating for OrderValidator {
         }
 
         // Eventually we will support all Signature types and can remove this.
-        if !matches!(
-            (order.signing_scheme, self.enable_presign_orders),
-            (SigningScheme::Eip712 | SigningScheme::EthSign, _) | (SigningScheme::PreSign, true)
-        ) {
+        if !self
+            .signature_configuration
+            .is_signing_scheme_supported(order.signing_scheme)
+        {
             return Err(PartialValidationError::UnsupportedSignature);
         }
 
@@ -319,6 +332,16 @@ impl OrderValidating for OrderValidator {
     ) -> Result<(Order, Option<Quote>), ValidationError> {
         let owner = order.verify_owner(domain_separator)?;
         let signing_scheme = order.signature.scheme();
+
+        if let Signature::Eip1271(signature) = &order.signature {
+            self.signature_validator
+                .validate_signature(SignatureCheck {
+                    signer: owner,
+                    hash: hashed_eip712_message(domain_separator, &order.data.hash_struct()),
+                    signature: signature.to_owned(),
+                })
+                .await?;
+        }
 
         if order.data.buy_amount.is_zero() || order.data.sell_amount.is_zero() {
             return Err(ValidationError::ZeroAmount);
@@ -424,6 +447,41 @@ impl OrderValidating for OrderValidator {
     }
 }
 
+/// Signature configuration that is accepted by the orderbook.
+#[derive(Debug, PartialEq, Default)]
+pub struct SignatureConfiguration {
+    pub eip1271: bool,
+    pub presign: bool,
+}
+
+impl SignatureConfiguration {
+    /// Returns a configuration where only off-chain signing schemes are
+    /// supported.
+    pub fn off_chain() -> Self {
+        Self {
+            eip1271: false,
+            presign: false,
+        }
+    }
+
+    /// Returns a configuration where all signing schemes are enabled.
+    pub fn all() -> Self {
+        Self {
+            eip1271: true,
+            presign: true,
+        }
+    }
+
+    /// returns whether the supplied signature scheme is supported.
+    pub fn is_signing_scheme_supported(&self, signing_scheme: SigningScheme) -> bool {
+        match signing_scheme {
+            SigningScheme::Eip712 | SigningScheme::EthSign => true,
+            SigningScheme::Eip1271 => self.eip1271,
+            SigningScheme::PreSign => self.presign,
+        }
+    }
+}
+
 /// Returns true if the orders have same buy and sell tokens.
 ///
 /// This also checks for orders selling wrapped native token for native token.
@@ -517,7 +575,10 @@ fn is_order_outside_market_price(order: &OrderData, quote: &Quote) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{account_balances::MockBalanceFetching, order_quoting::MockOrderQuoting};
+    use crate::{
+        account_balances::MockBalanceFetching, order_quoting::MockOrderQuoting,
+        signature_validator::MockSignatureValidating,
+    };
     use anyhow::anyhow;
     use chrono::Utc;
     use ethcontract::web3::signing::SecretKeyRef;
@@ -608,10 +669,11 @@ mod tests {
             hashset!(),
             min_order_validity_period,
             max_order_validity_period,
-            false,
+            SignatureConfiguration::off_chain(),
             Arc::new(MockBadTokenDetecting::new()),
             Arc::new(MockOrderQuoting::new()),
             Arc::new(MockBalanceFetching::new()),
+            Arc::new(MockSignatureValidating::new()),
         );
         assert!(matches!(
             validator
@@ -726,10 +788,11 @@ mod tests {
             hashset!(),
             Duration::from_secs(1),
             Duration::from_secs(100),
-            false,
+            SignatureConfiguration::off_chain(),
             Arc::new(MockBadTokenDetecting::new()),
             Arc::new(MockOrderQuoting::new()),
             Arc::new(MockBalanceFetching::new()),
+            Arc::new(MockSignatureValidating::new()),
         );
 
         assert!(matches!(
@@ -767,10 +830,11 @@ mod tests {
             hashset!(liquidity_order_owner),
             min_order_validity_period,
             max_order_validity_period,
-            true,
+            SignatureConfiguration::all(),
             Arc::new(bad_token_detector),
             Arc::new(MockOrderQuoting::new()),
             Arc::new(MockBalanceFetching::new()),
+            Arc::new(MockSignatureValidating::new()),
         );
         let order = || PreOrderData {
             valid_to: model::time::now_in_epoch_seconds()
@@ -823,10 +887,11 @@ mod tests {
             hashset!(),
             Duration::from_secs(1),
             Duration::from_secs(100),
-            true,
+            SignatureConfiguration::all(),
             Arc::new(bad_token_detector),
             Arc::new(order_quoter),
             Arc::new(balance_fetcher),
+            Arc::new(MockSignatureValidating::new()),
         );
         let order = OrderCreation {
             data: OrderData {
@@ -867,10 +932,11 @@ mod tests {
             hashset!(),
             Duration::from_secs(1),
             Duration::from_secs(100),
-            true,
+            SignatureConfiguration::all(),
             Arc::new(bad_token_detector),
             Arc::new(order_quoter),
             Arc::new(balance_fetcher),
+            Arc::new(MockSignatureValidating::new()),
         );
         let order = OrderCreation {
             data: OrderData {
@@ -911,10 +977,11 @@ mod tests {
             hashset!(),
             Duration::from_secs(1),
             Duration::from_secs(100),
-            true,
+            SignatureConfiguration::all(),
             Arc::new(bad_token_detector),
             Arc::new(order_quoter),
             Arc::new(balance_fetcher),
+            Arc::new(MockSignatureValidating::new()),
         );
         let order = OrderCreation {
             data: OrderData {
@@ -955,10 +1022,11 @@ mod tests {
             hashset!(),
             Duration::from_secs(1),
             Duration::from_secs(100),
-            true,
+            SignatureConfiguration::all(),
             Arc::new(bad_token_detector),
             Arc::new(order_quoter),
             Arc::new(balance_fetcher),
+            Arc::new(MockSignatureValidating::new()),
         );
         let order = OrderCreation {
             data: OrderData {
@@ -1001,10 +1069,11 @@ mod tests {
             hashset!(),
             Duration::from_secs(1),
             Duration::from_secs(100),
-            true,
+            SignatureConfiguration::all(),
             Arc::new(bad_token_detector),
             Arc::new(order_quoter),
             Arc::new(balance_fetcher),
+            Arc::new(MockSignatureValidating::new()),
         );
         let order = OrderCreation {
             data: OrderData {
@@ -1050,10 +1119,11 @@ mod tests {
             hashset!(),
             Duration::from_secs(1),
             Duration::from_secs(100),
-            true,
+            SignatureConfiguration::all(),
             Arc::new(bad_token_detector),
             Arc::new(order_quoter),
             Arc::new(balance_fetcher),
+            Arc::new(MockSignatureValidating::new()),
         );
         let order = OrderCreation {
             data: OrderData {
@@ -1095,10 +1165,11 @@ mod tests {
             hashset!(),
             Duration::from_secs(1),
             Duration::from_secs(100),
-            true,
+            SignatureConfiguration::all(),
             Arc::new(bad_token_detector),
             Arc::new(order_quoter),
             Arc::new(balance_fetcher),
+            Arc::new(MockSignatureValidating::new()),
         );
         let order = OrderCreation {
             data: OrderData {
@@ -1141,10 +1212,11 @@ mod tests {
                     hashset!(),
                     Duration::from_secs(1),
                     Duration::MAX,
-                    true,
+                    SignatureConfiguration::all(),
                     Arc::new(bad_token_detector),
                     Arc::new(order_quoter),
                     Arc::new(balance_fetcher),
+                    Arc::new(MockSignatureValidating::new()),
                 );
 
                 let order = OrderBuilder::default()

--- a/crates/orderbook/src/orderbook.rs
+++ b/crates/orderbook/src/orderbook.rs
@@ -375,6 +375,7 @@ mod tests {
     use crate::{
         account_balances::MockBalanceFetching, database::orders::MockOrderStoring,
         metrics::NoopMetrics, order_validation::MockOrderValidating,
+        signature_validator::MockSignatureValidating,
     };
     use ethcontract::H160;
     use futures::FutureExt;
@@ -405,6 +406,7 @@ mod tests {
                 current_block::mock_single_block(Default::default()),
                 Arc::new(MockNativePriceEstimating::new()),
                 Arc::new(NoopMetrics),
+                Arc::new(MockSignatureValidating::new()),
             ),
             solvable_orders_max_update_age: Default::default(),
             order_validator: Arc::new(MockOrderValidating::new()),

--- a/crates/orderbook/src/signature_validator.rs
+++ b/crates/orderbook/src/signature_validator.rs
@@ -3,7 +3,7 @@ use ethcontract::{batch::CallBatch, errors::MethodError, Bytes};
 use futures::future;
 use hex_literal::hex;
 use primitive_types::H160;
-use shared::{ethcontract_error::EthcontractErrorType, Web3};
+use shared::{ethcontract_error::EthcontractErrorType, transport::MAX_BATCH_SIZE, Web3};
 use thiserror::Error;
 
 /// Structure used to represent a signature.
@@ -83,6 +83,7 @@ impl SignatureValidating for Web3SignatureValidator {
             })
             .collect::<Vec<_>>();
 
+        batch.execute_all(MAX_BATCH_SIZE).await;
         future::join_all(calls).await
     }
 }

--- a/crates/orderbook/src/signature_validator.rs
+++ b/crates/orderbook/src/signature_validator.rs
@@ -1,5 +1,5 @@
 use contracts::ERC1271SignatureValidator;
-use ethcontract::{errors::MethodError, Bytes};
+use ethcontract::{batch::CallBatch, errors::MethodError, Bytes};
 use futures::future;
 use hex_literal::hex;
 use primitive_types::H160;
@@ -7,6 +7,7 @@ use shared::{ethcontract_error::EthcontractErrorType, Web3};
 use thiserror::Error;
 
 /// Structure used to represent a signature.
+#[derive(Clone, Debug, PartialEq)]
 pub struct SignatureCheck {
     pub signer: H160,
     pub hash: [u8; 32],
@@ -45,9 +46,6 @@ pub struct Web3SignatureValidator {
 }
 
 impl Web3SignatureValidator {
-    /// The Magical value as defined by EIP-1271
-    pub const MAGICAL_VALUE: [u8; 4] = hex!("1626ba7e");
-
     pub fn new(web3: Web3) -> Self {
         Self { web3 }
     }
@@ -60,33 +58,50 @@ impl SignatureValidating for Web3SignatureValidator {
         check: SignatureCheck,
     ) -> Result<(), SignatureValidationError> {
         let instance = ERC1271SignatureValidator::at(&self.web3, check.signer);
-        match instance
+        let result = instance
             .is_valid_signature(Bytes(check.hash), Bytes(check.signature))
             .call()
-            .await
-        {
-            Ok(Bytes(value)) if value == Self::MAGICAL_VALUE => Ok(()),
-            Ok(_) => Err(SignatureValidationError::Invalid),
-            // Classify "contract" errors as invalid signatures instead of node
-            // errors (which may be temporary). This can happen if there is ABI
-            // compability issues or calling an EOA instead of a SC.
-            Err(err) if EthcontractErrorType::classify(&err) == EthcontractErrorType::Contract => {
-                Err(SignatureValidationError::Invalid)
-            }
-            Err(err) => Err(SignatureValidationError::Other(err)),
-        }
+            .await;
+
+        parse_is_valid_signature_result(result)
     }
 
     async fn validate_signatures(
         &self,
         checks: Vec<SignatureCheck>,
     ) -> Vec<Result<(), SignatureValidationError>> {
-        // TODO(nlordell): Use batch calls!
-        future::join_all(
-            checks
-                .into_iter()
-                .map(|check| self.validate_signature(check)),
-        )
-        .await
+        let mut batch = CallBatch::new(self.web3.transport().clone());
+        let calls = checks
+            .into_iter()
+            .map(|check| {
+                let instance = ERC1271SignatureValidator::at(&self.web3, check.signer);
+                let call = instance
+                    .is_valid_signature(Bytes(check.hash), Bytes(check.signature))
+                    .batch_call(&mut batch);
+
+                async move { parse_is_valid_signature_result(call.await) }
+            })
+            .collect::<Vec<_>>();
+
+        future::join_all(calls).await
+    }
+}
+
+/// The Magical value as defined by EIP-1271
+const MAGICAL_VALUE: [u8; 4] = hex!("1626ba7e");
+
+fn parse_is_valid_signature_result(
+    result: Result<Bytes<[u8; 4]>, MethodError>,
+) -> Result<(), SignatureValidationError> {
+    match result {
+        Ok(Bytes(value)) if value == MAGICAL_VALUE => Ok(()),
+        Ok(_) => Err(SignatureValidationError::Invalid),
+        // Classify "contract" errors as invalid signatures instead of node
+        // errors (which may be temporary). This can happen if there is ABI
+        // compability issues or calling an EOA instead of a SC.
+        Err(err) if EthcontractErrorType::classify(&err) == EthcontractErrorType::Contract => {
+            Err(SignatureValidationError::Invalid)
+        }
+        Err(err) => Err(SignatureValidationError::Other(err)),
     }
 }

--- a/database/sql/V023__add_eip1271_signature.sql
+++ b/database/sql/V023__add_eip1271_signature.sql
@@ -1,0 +1,1 @@
+ALTER TYPE SigningScheme ADD VALUE 'eip1271';


### PR DESCRIPTION
This PR adds initial proof-of-concept support for EIP-1271 orders with help from the initial work done by @elpiel.

This PR does a few things:
1. Changes the `SignatureValidating` component to support batched validation. This is important for computing solvable orders as we don't want increase the delay too significantly by doing one node round-trip per order.
2. Add a check when the order is added on whether or not the EIP-1271 signature is valid in the `OrderValidator`.
3. When building batches in the `SolvableOrdersCache`, check on each auction whether or not the EIP-1271 signature is **still** valid (and filter out the order if it is not). This is because EIP-1271 is implementation dependent and may have mechanisms to cancel a signature on-chain for example.

### Future Work

There are still a few important outstanding items for EIP-1271 support:
1. Consider additional signature validation gas costs in fee computation
2. Support EIP-1271 in order cancellation and order replacement (i.e. atomic cancel + place)

I would even think that implementing 1 needs to be done before the feature is widely enabled.

### Test Plan

Added unit tests for the additional checks in the `OrderValidator` and `SolvableOrdersCache` components

### Manual Testing

I did a manual E2E test that resulted in a **GASLESS* Smart Contract order [getting traded](https://rinkeby.etherscan.io/tx/0x82aa767b1cb220bf75dc574668b50d149ec2f07347070e044ecf2f63c409b539) on Rinkeby :tada:.

1. Run the orderbook with EIP-1271 orders enabled:
   ```
   % cargo run -p orderbook -- --skip-trace-api true --skip-event-sync --enable-eip1271-orders true
   ```
2. Create and place a smart contract order. I had a test Gnosis Safe that I used for this with [this script](https://github.com/cowprotocol/services/files/8974964/scsig.txt)).
3. Run the solver as normal.

### Release Notes

This feature is gated behind a `--enable-eip1271-orders` flag which is disabled by default, so it should be fine 