### PR TITLE
Add EIP-1271 E2E Test

### DIFF
--- a/crates/e2e/tests/e2e/smart_contract_orders.rs
+++ b/crates/e2e/tests/e2e/smart_contract_orders.rs
@@ -9,7 +9,12 @@ use ethcontract::{
     prelude::{Account, Address, Bytes, PrivateKey, U256},
     H160,
 };
-use model::order::{Order, OrderBuilder, OrderKind, OrderStatus, OrderUid};
+use model::{
+    order::{Order, OrderBuilder, OrderKind, OrderStatus, OrderUid},
+    signature::hashed_eip712_message,
+    DomainSeparator,
+};
+use secp256k1::SecretKey;
 use shared::{maintenance::Maintaining, sources::uniswap_v2::pool_fetching::PoolFetcher, Web3};
 use solver::{
     liquidity::uniswap_v2::UniswapLikeLiquidity,
@@ -22,6 +27,7 @@ use solver::{
     },
 };
 use std::{sync::Arc, time::Duration};
+use web3::signing::{Key as _, SecretKeyRef};
 
 const TRADER: [u8; 32] = [1; 32];
 
@@ -122,58 +128,95 @@ async fn smart_contract_orders(web3: Web3) {
     let client = reqwest::Client::new();
 
     // Place Orders
-    let order = OrderBuilder::default()
-        .with_kind(OrderKind::Sell)
-        .with_sell_token(token.address())
-        .with_sell_amount(to_wei(9))
-        .with_fee_amount(to_wei(1))
-        .with_buy_token(contracts.weth.address())
-        .with_buy_amount(to_wei(8))
-        .with_valid_to(model::time::now_in_epoch_seconds() + 300)
-        .with_presign(safe.address())
-        .build()
-        .into_order_creation();
-    let placement = client
-        .post(&format!("{}{}", API_HOST, ORDER_PLACEMENT_ENDPOINT))
-        .json(&order)
-        .send()
-        .await
-        .unwrap();
-    assert_eq!(placement.status(), 201);
+    let order_template = || {
+        OrderBuilder::default()
+            .with_kind(OrderKind::Sell)
+            .with_sell_token(token.address())
+            .with_sell_amount(to_wei(4))
+            .with_fee_amount(to_wei(1))
+            .with_buy_token(contracts.weth.address())
+            .with_buy_amount(to_wei(3))
+            .with_valid_to(model::time::now_in_epoch_seconds() + 300)
+    };
+    let mut orders = [
+        order_template()
+            .with_eip1271(
+                safe.address(),
+                gnosis_safe_eip1271_signature(
+                    SecretKeyRef::from(&SecretKey::from_slice(&TRADER).unwrap()),
+                    &safe,
+                    &contracts.domain_separator,
+                    order_template(),
+                )
+                .await,
+            )
+            .build(),
+        order_template()
+            .with_app_data([1; 32])
+            .with_presign(safe.address())
+            .build(),
+    ];
+
+    for order in &mut orders {
+        let creation = order.clone().into_order_creation();
+        let placement = client
+            .post(&format!("{}{}", API_HOST, ORDER_PLACEMENT_ENDPOINT))
+            .json(&creation)
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(placement.status(), 201);
+        order.metadata.uid = placement.json::<OrderUid>().await.unwrap();
+    }
+    let orders = orders; // prevent further changes to `orders`.
 
     solvable_orders_cache.update(0).await.unwrap();
 
-    let order_uid = placement.json::<OrderUid>().await.unwrap();
-    let order_status = || async {
-        client
-            .get(&format!(
-                "{}{}{}",
-                API_HOST, ORDER_PLACEMENT_ENDPOINT, &order_uid
-            ))
-            .send()
-            .await
-            .unwrap()
-            .json::<Order>()
-            .await
-            .unwrap()
-            .metadata
-            .status
+    let order_status = |order_uid: OrderUid| {
+        let client = client.clone();
+        async move {
+            client
+                .get(&format!(
+                    "{}{}{}",
+                    API_HOST, ORDER_PLACEMENT_ENDPOINT, &order_uid
+                ))
+                .send()
+                .await
+                .unwrap()
+                .json::<Order>()
+                .await
+                .unwrap()
+                .metadata
+                .status
+        }
     };
 
+    // Check that the EIP-1271 order was received.
+    assert_eq!(
+        order_status(orders[0].metadata.uid).await,
+        OrderStatus::Open
+    );
+
     // Execute pre-sign transaction.
-    assert_eq!(order_status().await, OrderStatus::PresignaturePending);
+    assert_eq!(
+        order_status(orders[1].metadata.uid).await,
+        OrderStatus::PresignaturePending
+    );
     tx_safe!(
         user,
         safe,
         contracts
             .gp_settlement
-            .set_pre_signature(Bytes(order_uid.0.to_vec()), true)
+            .set_pre_signature(Bytes(orders[1].metadata.uid.0.to_vec()), true)
     );
 
     // Drive orderbook in order to check that the presignature event was received.
     maintenance.run_maintenance().await.unwrap();
     solvable_orders_cache.update(0).await.unwrap();
-    assert_eq!(order_status().await, OrderStatus::Open);
+    assert_eq!(
+        order_status(orders[1].metadata.uid).await,
+        OrderStatus::Open
+    );
 
     // Drive solution
     let uniswap_pair_provider = uniswap_pair_provider(&contracts);
@@ -262,5 +305,31 @@ async fn smart_contract_orders(web3: Web3) {
         .call()
         .await
         .expect("Couldn't fetch native token balance");
-    assert_eq!(balance, U256::from(8_972_194_924_949_384_291_u128));
+    assert_eq!(balance, U256::from(7_975_363_884_976_534_272_u128));
+}
+
+async fn gnosis_safe_eip1271_signature(
+    key: SecretKeyRef<'_>,
+    safe: &GnosisSafe,
+    domain: &DomainSeparator,
+    order: OrderBuilder,
+) -> Vec<u8> {
+    let handler =
+        GnosisSafeCompatibilityFallbackHandler::at(&safe.raw_instance().web3(), safe.address());
+
+    let order_hash = hashed_eip712_message(domain, &order.build().data.hash_struct());
+    let message_hash = handler
+        .get_message_hash(Bytes(order_hash.to_vec()))
+        .call()
+        .await
+        .unwrap();
+
+    let signature = key.sign(&message_hash.0, None).unwrap();
+
+    let mut bytes = vec![0u8; 65];
+    bytes[0..32].copy_from_slice(signature.r.as_bytes());
+    bytes[32..64].copy_from_slice(signature.s.as_bytes());
+    bytes[64] = signature.v as _;
+
+    bytes
 }

--- a/crates/model/src/order.rs
+++ b/crates/model/src/order.rs
@@ -232,6 +232,12 @@ impl OrderBuilder {
         self
     }
 
+    pub fn with_eip1271(mut self, owner: H160, signature: Vec<u8>) -> Self {
+        self.0.metadata.owner = owner;
+        self.0.signature = Signature::Eip1271(signature);
+        self
+    }
+
     pub fn with_presign(mut self, owner: H160) -> Self {
         self.0.metadata.owner = owner;
         self.0.signature = Signature::PreSign;


### PR DESCRIPTION
Preliminary support for EIP-1271 orders was introduced in #311. This PR adds a new E2E test to verify trading with Smart Contract EIP-1271 orders works.

Specifically, the `smart_contract_orders` E2E test was modified to include both an EIP-1271 (which is incidentally signed off-chain) and PreSign order from Gnosis Safe.

### Test Plan

This is the test plan 🥄.
