### PR TITLE
Disable 0x slippage protection

### DIFF
--- a/crates/shared/src/price_estimation/zeroex.rs
+++ b/crates/shared/src/price_estimation/zeroex.rs
@@ -45,6 +45,7 @@ impl ZeroExPriceEstimator {
             buy_amount,
             slippage_percentage: Default::default(),
             excluded_sources: self.excluded_sources.clone(),
+            enable_slippage_protection: false,
         };
         let api = self.api.clone();
         let swap_future = async move {

--- a/crates/shared/src/zeroex_api.rs
+++ b/crates/shared/src/zeroex_api.rs
@@ -62,7 +62,11 @@ impl SwapQuery {
         url.query_pairs_mut()
             .append_pair("sellToken", &addr2str(self.sell_token))
             .append_pair("buyToken", &addr2str(self.buy_token))
-            .append_pair("slippagePercentage", &self.slippage_percentage.to_string());
+            .append_pair("slippagePercentage", &self.slippage_percentage.to_string())
+            .append_pair(
+                "enableSlippageProtection",
+                &self.enable_slippage_protection.to_string(),
+            );
         if let Some(amount) = self.sell_amount {
             url.query_pairs_mut()
                 .append_pair("sellAmount", &amount.to_string());

--- a/crates/shared/src/zeroex_api.rs
+++ b/crates/shared/src/zeroex_api.rs
@@ -47,6 +47,8 @@ pub struct SwapQuery {
     pub slippage_percentage: Slippage,
     /// List of sources to exclude.
     pub excluded_sources: Vec<String>,
+    /// Requests trade routes which aim to protect against high slippage and MEV attacks.
+    pub enable_slippage_protection: bool,
 }
 
 impl SwapQuery {
@@ -479,6 +481,7 @@ mod tests {
             buy_amount: None,
             slippage_percentage: Slippage(0.1_f64),
             excluded_sources: Vec::new(),
+            enable_slippage_protection: false,
         };
 
         let price_response = zeroex_client.get_swap(swap_query).await;
@@ -499,6 +502,7 @@ mod tests {
             buy_amount: None,
             slippage_percentage: Slippage(0.1_f64),
             excluded_sources: Vec::new(),
+            enable_slippage_protection: false,
         };
 
         let price_response = zeroex_client.get_price(swap_query.clone()).await;
@@ -520,6 +524,7 @@ mod tests {
             buy_amount: None,
             slippage_percentage: Slippage(0.1_f64),
             excluded_sources: Vec::new(),
+            enable_slippage_protection: false,
         };
 
         let swap = zeroex.get_swap(query.clone()).await;

--- a/crates/solver/src/solver/zeroex_solver.rs
+++ b/crates/solver/src/solver/zeroex_solver.rs
@@ -98,6 +98,7 @@ impl SingleOrderSolving for ZeroExSolver {
             slippage_percentage: Slippage::number_from_basis_points(self.zeroex_slippage_bps)
                 .unwrap(),
             excluded_sources: self.excluded_sources.clone(),
+            enable_slippage_protection: false,
         };
         let swap = self.api.get_swap(query).await?;
 


### PR DESCRIPTION
Starting on 2022-06-30 0x will by default compute trade routes which aim to protect against high slippage and MEV attacks.
Those routes can have worse prices than unprotected routes so because we already protect against those things we don't need to use the worse prices unnecessarily.

[Slack thread](https://cowservices.slack.com/archives/C0360881AHZ/p1655502415558449) of the 0x team reaching out to use and suggesting this change.

### Test Plan
Ran ignored test making a swap request to the 0x API which still produces results suggesting that the API either already supports the flag or doesn't throw an error when it encounters an unsupported flag.

<details>
<summary>Output of ignored test</summary>

```
test zeroex_api::tests::test_api_e2e ... ok
Price Response: {
  "bestRoute": [
    {
      "percent": 100,
      "swaps": [
        {
          "destDecimals": 18,
          "destToken": "0x6810e776880C02933D47DB1b9fc05908e5386b96",
          "srcDecimals": 18,
          "srcToken": "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
          "swapExchanges": [
            {
              "data": {
                "fee": 3000,
                "gasUSD": "6.889680"
              },
              "destAmount": "1303662151285561701707",
              "exchange": "UniswapV3",
              "percent": 100,
              "poolAddresses": [
                "0xf56D08221B5942C428Acc5De8f78489A97fC5599"
              ],
              "srcAmount": "135000000000000000000"
            }
          ]
        }
      ]
    }
  ],
  "blockNumber": 15033709,
  "contractAddress": "0xDEF171Fe48CF0115B1d80b88dc8eAB59176FEe57",
  "contractMethod": "simpleSwap",
  "destAmount": "1303662151285561701707",
  "destDecimals": 18,
  "destToken": "0x6810e776880C02933D47DB1b9fc05908e5386b96",
  "destUSD": "164065.8817392879",
  "gasCost": "289300",
  "gasCostUSD": "9.965922",
  "hmac": "e89a23697594c5d4e8ce841504f5c854aaed2e9f",
  "maxImpactReached": false,
  "network": 1,
  "partner": "Test",
  "partnerFee": 0,
  "side": "SELL",
  "srcAmount": "135000000000000000000",
  "srcDecimals": 18,
  "srcToken": "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
  "srcUSD": "166090.5000000000",
  "tokenTransferProxy": "0x216b4b4ba9f3e719726886d34a177484278bfcae"
}
Transaction Query: {
  "srcToken": "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
  "destToken": "0x6810e776880c02933d47db1b9fc05908e5386b96",
  "srcAmount": "135000000000000000000",
  "slippage": 1000,
  "srcDecimals": 18,
  "destDecimals": 18,
  "priceRoute": {
    "bestRoute": [
      {
        "percent": 100,
        "swaps": [
          {
            "destDecimals": 18,
            "destToken": "0x6810e776880C02933D47DB1b9fc05908e5386b96",
            "srcDecimals": 18,
            "srcToken": "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
            "swapExchanges": [
              {
                "data": {
                  "fee": 3000,
                  "gasUSD": "6.889680"
                },
                "destAmount": "1303662151285561701707",
                "exchange": "UniswapV3",
                "percent": 100,
                "poolAddresses": [
                  "0xf56D08221B5942C428Acc5De8f78489A97fC5599"
                ],
                "srcAmount": "135000000000000000000"
              }
            ]
          }
        ]
      }
    ],
    "blockNumber": 15033709,
    "contractAddress": "0xDEF171Fe48CF0115B1d80b88dc8eAB59176FEe57",
    "contractMethod": "simpleSwap",
    "destAmount": "1303662151285561701707",
    "destDecimals": 18,
    "destToken": "0x6810e776880C02933D47DB1b9fc05908e5386b96",
    "destUSD": "164065.8817392879",
    "gasCost": "289300",
    "gasCostUSD": "9.965922",
    "hmac": "e89a23697594c5d4e8ce841504f5c854aaed2e9f",
    "maxImpactReached": false,
    "network": 1,
    "partner": "Test",
    "partnerFee": 0,
    "side": "SELL",
    "srcAmount": "135000000000000000000",
    "srcDecimals": 18,
    "srcToken": "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
    "srcUSD": "166090.5000000000",
    "tokenTransferProxy": "0x216b4b4ba9f3e719726886d34a177484278bfcae"
  },
  "userAddress": "0xe0b3700e0aadcb18ed8d4bff648bc99896a18ad1",
  "partner": "Test"
}
Transaction Response: {"from":"0xe0b3700e0aadcb18ed8d4bff648bc99896a18ad1","to":"0xDEF171Fe48CF0115B1d80b88dc8eAB59176FEe57","value":"205344050020952719246","data":"0x2298207a0000000000000000000000000000000000000000000000000000000000000020000000000000000000000000eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee0000000000000000000000006810e776880c02933d47db1b9fc05908e5386b9600000000000000000000000000000000000000000000000b21b89d88deee3f8e00000000000000000000000000000000000000000000006194049f30f720000000000000000000000000000000000000000000000000000a1ea7d508107b7f9900000000000000000000000000000000000000000000000000000000000001e0000000000000000000000000000000000000000000000000000000000000026000000000000000000000000000000000000000000000000000000000000003c0000000000000000000000000000000000000000000000000000000000000046000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000054657374010000000000000000000000000000000000000000000000000000000000c00000000000000000000000000000000000000000000000000000000000000004e00000000000000000000000000000000000000000000000000000000062b9cf186d273ca91d5641088f08251f794d13d9000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000003000000000000000000000000c02aaa39b223fe8d0a0e5c4f27ead9083c756cc2000000000000000000000000e592427a0aece92de3edee1f18e0157c05861564000000000000000000000000def171fe48cf0115b1d80b88dc8eab59176fee57000000000000000000000000000000000000000000000000000000000000012cd0e30db0db3e2198000000000000000000000000c02aaa39b223fe8d0a0e5c4f27ead9083c756cc20000000000000000000000006810e776880c02933d47db1b9fc05908e5386b960000000000000000000000000000000000000000000000000000000000000bb8000000000000000000000000def171fe48cf0115b1d80b88dc8eab59176fee570000000000000000000000000000000000000000000000000000000062b988c700000000000000000000000000000000000000000000006194049f30f720000000000000000000000000000000000000000000000000000b21b89d88deee3f8e0000000000000000000000000000000000000000000000000000000000000000e1829cfe000000000000000000000000c02aaa39b223fe8d0a0e5c4f27ead9083c756cc200000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000004000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000040000000000000000000000000000000000000000000000000000000000000108000000000000000000000000000000000000000000000000000000000000012c000000000000000000000000000000000000000000000000000000000000000300000000000000000000000000000000000000000000000b21b89d88deee3f8e000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000","gasPrice":"28000000000","chainId":1}
```
</details>

<details>
<summary>requested URL during test</summary>

`https://api.0x.org/swap/v1/quote?sellToken=0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2&buyToken=0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48&slippagePercentage=0.1&enableSlippageProtection=false&sellAmount=1000000000000000000&affiliateAddress=0x9008D19f58AAbD9eD0D60971565AA8510560ab41&skipValidation=true&intentOnFilling=false`
</details>