### PR TITLE
Move common API types and functions into shared

### DIFF
--- a/crates/orderbook/src/api.rs
+++ b/crates/orderbook/src/api.rs
@@ -18,21 +18,13 @@ mod replace_order;
 
 use crate::solver_competition::SolverCompetition;
 use crate::{database::trades::TradeRetrieving, order_quoting::QuoteHandler, orderbook::Orderbook};
-use anyhow::{Error as anyhowError, Result};
-use serde::{de::DeserializeOwned, Serialize};
-use shared::{metrics::get_metric_storage_registry, price_estimation::PriceEstimationError};
+use shared::api::{error, handle_rejection, internal_error, ApiMetrics, ApiReply};
 use std::{
-    convert::Infallible,
-    fmt::Debug,
     sync::atomic::{AtomicUsize, Ordering},
     sync::Arc,
     time::Instant,
 };
-use warp::{
-    hyper::StatusCode,
-    reply::{json, with_status, Json, WithStatus},
-    Filter, Rejection, Reply,
-};
+use warp::{Filter, Rejection, Reply};
 
 pub fn handle_all_routes(
     database: Arc<dyn TradeRetrieving>,
@@ -155,7 +147,7 @@ pub fn handle_all_routes(
 
     // Metrics
 
-    let metrics = ApiMetrics::instance(get_metric_storage_registry()).unwrap();
+    let metrics = ApiMetrics::pub_instance();
     let routes_with_metrics = warp::any()
         .map(Instant::now) // Start a timer at the beginning of response processing
         .and(routes) // Parse requests
@@ -203,216 +195,4 @@ pub fn handle_all_routes(
         .with(cors)
         .with(warp::log::log("orderbook::api::request_summary"))
         .with(tracing_span)
-}
-
-pub type ApiReply = warp::reply::WithStatus<warp::reply::Json>;
-
-// We turn Rejection into Reply to workaround warp not setting CORS headers on rejections.
-async fn handle_rejection(err: Rejection) -> Result<impl Reply, Infallible> {
-    let response = err.default_response();
-
-    let metrics = ApiMetrics::instance(get_metric_storage_registry()).unwrap();
-    metrics
-        .requests_rejected
-        .with_label_values(&[response.status().as_str()])
-        .inc();
-
-    Ok(response)
-}
-
-#[derive(prometheus_metric_storage::MetricStorage, Clone, Debug)]
-#[metric(subsystem = "api")]
-struct ApiMetrics {
-    /// Number of completed API requests.
-    #[metric(labels("method", "status_code"))]
-    requests_complete: prometheus::IntCounterVec,
-
-    /// Number of rejected API requests.
-    #[metric(labels("status_code"))]
-    requests_rejected: prometheus::IntCounterVec,
-
-    /// Execution time for each API request.
-    #[metric(labels("method"))]
-    requests_duration_seconds: prometheus::HistogramVec,
-}
-
-#[derive(Serialize)]
-#[serde(rename_all = "camelCase")]
-struct Error<'a> {
-    error_type: &'a str,
-    description: &'a str,
-    /// Additional arbitrary data that can be attached to an API error.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    data: Option<serde_json::Value>,
-}
-
-fn error(error_type: &str, description: impl AsRef<str>) -> Json {
-    json(&Error {
-        error_type,
-        description: description.as_ref(),
-        data: None,
-    })
-}
-
-fn rich_error(error_type: &str, description: impl AsRef<str>, data: impl Serialize) -> Json {
-    let data = match serde_json::to_value(&data) {
-        Ok(value) => Some(value),
-        Err(err) => {
-            tracing::warn!(?err, "failed to serialize error data");
-            None
-        }
-    };
-
-    json(&Error {
-        error_type,
-        description: description.as_ref(),
-        data,
-    })
-}
-
-fn internal_error(error: anyhowError) -> Json {
-    tracing::error!(?error, "internal server error");
-    json(&Error {
-        error_type: "InternalServerError",
-        description: "",
-        data: None,
-    })
-}
-
-pub fn convert_json_response<T, E>(result: Result<T, E>) -> WithStatus<Json>
-where
-    T: Serialize,
-    E: IntoWarpReply + Debug,
-{
-    match result {
-        Ok(response) => with_status(warp::reply::json(&response), StatusCode::OK),
-        Err(err) => err.into_warp_reply(),
-    }
-}
-
-pub trait IntoWarpReply {
-    fn into_warp_reply(self) -> ApiReply;
-}
-
-impl IntoWarpReply for anyhowError {
-    fn into_warp_reply(self) -> ApiReply {
-        with_status(internal_error(self), StatusCode::INTERNAL_SERVER_ERROR)
-    }
-}
-
-impl IntoWarpReply for PriceEstimationError {
-    fn into_warp_reply(self) -> WithStatus<Json> {
-        match self {
-            Self::UnsupportedToken(token) => with_status(
-                error("UnsupportedToken", format!("Token address {:?}", token)),
-                StatusCode::BAD_REQUEST,
-            ),
-            Self::NoLiquidity => with_status(
-                error("NoLiquidity", "not enough liquidity"),
-                StatusCode::NOT_FOUND,
-            ),
-            Self::ZeroAmount => with_status(
-                error("ZeroAmount", "Please use non-zero amount field"),
-                StatusCode::BAD_REQUEST,
-            ),
-            Self::UnsupportedOrderType => with_status(
-                internal_error(anyhow::anyhow!("UnsupportedOrderType").context("price_estimation")),
-                StatusCode::INTERNAL_SERVER_ERROR,
-            ),
-            Self::RateLimited(_) => with_status(
-                internal_error(
-                    anyhow::anyhow!("price estimators temporarily inactive")
-                        .context("price_estimation"),
-                ),
-                StatusCode::INTERNAL_SERVER_ERROR,
-            ),
-            Self::Other(err) => with_status(
-                internal_error(err.context("price_estimation")),
-                StatusCode::INTERNAL_SERVER_ERROR,
-            ),
-        }
-    }
-}
-
-#[cfg(test)]
-async fn response_body(response: warp::hyper::Response<warp::hyper::Body>) -> Vec<u8> {
-    let mut body = response.into_body();
-    let mut result = Vec::new();
-    while let Some(bytes) = futures::StreamExt::next(&mut body).await {
-        result.extend_from_slice(bytes.unwrap().as_ref());
-    }
-    result
-}
-
-const MAX_JSON_BODY_PAYLOAD: u64 = 1024 * 16;
-
-fn extract_payload<T: DeserializeOwned + Send>(
-) -> impl Filter<Extract = (T,), Error = Rejection> + Clone {
-    // (rejecting huge payloads)...
-    warp::body::content_length_limit(MAX_JSON_BODY_PAYLOAD).and(warp::body::json())
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use serde::ser;
-    use serde_json::json;
-
-    #[test]
-    fn rich_errors_skip_unset_data_field() {
-        assert_eq!(
-            serde_json::to_value(&Error {
-                error_type: "foo",
-                description: "bar",
-                data: None,
-            })
-            .unwrap(),
-            json!({
-                "errorType": "foo",
-                "description": "bar",
-            }),
-        );
-        assert_eq!(
-            serde_json::to_value(&Error {
-                error_type: "foo",
-                description: "bar",
-                data: Some(json!(42)),
-            })
-            .unwrap(),
-            json!({
-                "errorType": "foo",
-                "description": "bar",
-                "data": 42,
-            }),
-        );
-    }
-
-    #[tokio::test]
-    async fn rich_errors_handle_serialization_errors() {
-        struct AlwaysErrors;
-        impl Serialize for AlwaysErrors {
-            fn serialize<S>(&self, _: S) -> Result<S::Ok, S::Error>
-            where
-                S: serde::Serializer,
-            {
-                Err(ser::Error::custom("error"))
-            }
-        }
-
-        let body = warp::hyper::body::to_bytes(
-            rich_error("foo", "bar", AlwaysErrors)
-                .into_response()
-                .into_body(),
-        )
-        .await
-        .unwrap();
-
-        assert_eq!(
-            serde_json::from_slice::<serde_json::Value>(&*body).unwrap(),
-            json!({
-                "errorType": "foo",
-                "description": "bar",
-            })
-        );
-    }
 }

--- a/crates/orderbook/src/api/cancel_order.rs
+++ b/crates/orderbook/src/api/cancel_order.rs
@@ -1,13 +1,11 @@
-use crate::{
-    api::{convert_json_response, extract_payload, IntoWarpReply},
-    orderbook::{OrderCancellationError, Orderbook},
-};
+use crate::orderbook::{OrderCancellationError, Orderbook};
 use anyhow::Result;
 use model::{
     order::{OrderCancellation, OrderUid},
     signature::{EcdsaSignature, EcdsaSigningScheme},
 };
 use serde::{Deserialize, Serialize};
+use shared::api::{convert_json_response, extract_payload, IntoWarpReply};
 use std::{convert::Infallible, sync::Arc};
 use warp::{hyper::StatusCode, reply::with_status, Filter, Rejection};
 

--- a/crates/orderbook/src/api/get_auction.rs
+++ b/crates/orderbook/src/api/get_auction.rs
@@ -1,5 +1,6 @@
-use crate::{api::convert_json_response, orderbook::Orderbook};
+use crate::orderbook::Orderbook;
 use anyhow::Result;
+use shared::api::{convert_json_response, ApiReply};
 use std::{convert::Infallible, sync::Arc};
 use warp::{Filter, Rejection};
 
@@ -9,7 +10,7 @@ fn get_auction_request() -> impl Filter<Extract = (), Error = Rejection> + Clone
 
 pub fn get_auction(
     orderbook: Arc<Orderbook>,
-) -> impl Filter<Extract = (super::ApiReply,), Error = Rejection> + Clone {
+) -> impl Filter<Extract = (ApiReply,), Error = Rejection> + Clone {
     get_auction_request().and_then(move || {
         let orderbook = orderbook.clone();
         async move {

--- a/crates/orderbook/src/api/get_fee_and_quote.rs
+++ b/crates/orderbook/src/api/get_fee_and_quote.rs
@@ -1,4 +1,4 @@
-use crate::{api::convert_json_response, order_quoting::QuoteHandler};
+use crate::order_quoting::QuoteHandler;
 use anyhow::Result;
 use chrono::{DateTime, Utc};
 use ethcontract::{H160, U256};
@@ -7,6 +7,7 @@ use model::{
     u256_decimal,
 };
 use serde::{Deserialize, Serialize};
+use shared::api::{convert_json_response, ApiReply};
 use std::{convert::Infallible, sync::Arc};
 use warp::{Filter, Rejection};
 
@@ -117,7 +118,7 @@ fn buy_request() -> impl Filter<Extract = (BuyQuery,), Error = Rejection> + Clon
 
 pub fn get_fee_and_quote_sell(
     quotes: Arc<QuoteHandler>,
-) -> impl Filter<Extract = (super::ApiReply,), Error = Rejection> + Clone {
+) -> impl Filter<Extract = (ApiReply,), Error = Rejection> + Clone {
     sell_request().and_then(move |query: SellQuery| {
         let quotes = quotes.clone();
         async move {
@@ -133,7 +134,7 @@ pub fn get_fee_and_quote_sell(
 
 pub fn get_fee_and_quote_buy(
     quotes: Arc<QuoteHandler>,
-) -> impl Filter<Extract = (super::ApiReply,), Error = Rejection> + Clone {
+) -> impl Filter<Extract = (ApiReply,), Error = Rejection> + Clone {
     buy_request().and_then(move |query: BuyQuery| {
         let quotes = quotes.clone();
         async move {

--- a/crates/orderbook/src/api/get_fee_info.rs
+++ b/crates/orderbook/src/api/get_fee_info.rs
@@ -1,4 +1,4 @@
-use crate::{api::convert_json_response, order_quoting::QuoteHandler};
+use crate::order_quoting::QuoteHandler;
 use anyhow::Result;
 use chrono::{DateTime, Utc};
 use model::{
@@ -8,6 +8,7 @@ use model::{
 };
 use primitive_types::{H160, U256};
 use serde::{Deserialize, Serialize};
+use shared::api::{convert_json_response, ApiReply};
 use std::{convert::Infallible, sync::Arc};
 use warp::{Filter, Rejection};
 
@@ -37,7 +38,7 @@ fn get_fee_info_request() -> impl Filter<Extract = (Query,), Error = Rejection> 
 
 pub fn get_fee_info(
     quotes: Arc<QuoteHandler>,
-) -> impl Filter<Extract = (super::ApiReply,), Error = Rejection> + Clone {
+) -> impl Filter<Extract = (ApiReply,), Error = Rejection> + Clone {
     get_fee_info_request().and_then(move |query: Query| {
         let quotes = quotes.clone();
         async move {
@@ -69,8 +70,8 @@ pub fn get_fee_info(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::api::response_body;
     use chrono::FixedOffset;
+    use shared::api::response_body;
     use shared::price_estimation::PriceEstimationError;
     use warp::hyper::StatusCode;
     use warp::{test::request, Reply};

--- a/crates/orderbook/src/api/get_markets.rs
+++ b/crates/orderbook/src/api/get_markets.rs
@@ -1,4 +1,4 @@
-use crate::{api::convert_json_response, order_quoting::QuoteHandler};
+use crate::order_quoting::QuoteHandler;
 use anyhow::{anyhow, Result};
 use ethcontract::{H160, U256};
 use model::{
@@ -6,6 +6,7 @@ use model::{
     quote::{OrderQuoteRequest, OrderQuoteSide, SellAmount},
 };
 use serde::{Deserialize, Serialize};
+use shared::api::{convert_json_response, ApiReply};
 use std::{convert::Infallible, str::FromStr, sync::Arc};
 use warp::{Filter, Rejection};
 
@@ -69,7 +70,7 @@ fn get_amount_estimate_request(
 
 pub fn get_amount_estimate(
     quotes: Arc<QuoteHandler>,
-) -> impl Filter<Extract = (super::ApiReply,), Error = Rejection> + Clone {
+) -> impl Filter<Extract = (ApiReply,), Error = Rejection> + Clone {
     get_amount_estimate_request().and_then(move |query: AmountEstimateQuery| {
         let quotes = quotes.clone();
         async move {
@@ -118,7 +119,7 @@ pub fn get_amount_estimate(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::api::response_body;
+    use shared::api::response_body;
     use shared::price_estimation::PriceEstimationError;
     use warp::hyper::StatusCode;
     use warp::{test::request, Reply};

--- a/crates/orderbook/src/api/get_order_by_uid.rs
+++ b/crates/orderbook/src/api/get_order_by_uid.rs
@@ -1,6 +1,7 @@
-use crate::{api::IntoWarpReply, orderbook::Orderbook};
+use crate::orderbook::Orderbook;
 use anyhow::Result;
 use model::order::{Order, OrderUid};
+use shared::api::IntoWarpReply;
 use std::{convert::Infallible, sync::Arc};
 use warp::{hyper::StatusCode, reply, Filter, Rejection};
 
@@ -39,7 +40,7 @@ pub fn get_order_by_uid(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::api::response_body;
+    use shared::api::response_body;
     use warp::{test::request, Reply};
 
     #[tokio::test]

--- a/crates/orderbook/src/api/get_orders.rs
+++ b/crates/orderbook/src/api/get_orders.rs
@@ -1,11 +1,9 @@
-use crate::{
-    api::convert_json_response,
-    {database::orders::OrderFilter, orderbook::Orderbook},
-};
+use crate::{database::orders::OrderFilter, orderbook::Orderbook};
 use anyhow::{Context, Result};
 use model::time::now_in_epoch_seconds;
 use primitive_types::H160;
 use serde::Deserialize;
+use shared::api::{convert_json_response, error, ApiReply};
 use std::{convert::Infallible, sync::Arc};
 use warp::{hyper::StatusCode, Filter, Rejection};
 
@@ -60,14 +58,14 @@ pub fn get_orders_request(
 
 pub fn get_orders(
     orderbook: Arc<Orderbook>,
-) -> impl Filter<Extract = (super::ApiReply,), Error = Rejection> + Clone {
+) -> impl Filter<Extract = (ApiReply,), Error = Rejection> + Clone {
     get_orders_request().and_then(move |order_filter| {
         let orderbook = orderbook.clone();
         async move {
             let order_filter = match order_filter {
                 Ok(order_filter) => order_filter,
                 Err(err) => {
-                    let err = super::error("InvalidOrderFilter", err);
+                    let err = error("InvalidOrderFilter", err);
                     return Ok(warp::reply::with_status(err, StatusCode::BAD_REQUEST));
                 }
             };

--- a/crates/orderbook/src/api/get_orders_by_tx.rs
+++ b/crates/orderbook/src/api/get_orders_by_tx.rs
@@ -1,6 +1,7 @@
-use crate::{api::convert_json_response, orderbook::Orderbook};
+use crate::orderbook::Orderbook;
 use anyhow::Result;
 use ethcontract::H256;
+use shared::api::{convert_json_response, ApiReply};
 use std::{convert::Infallible, sync::Arc};
 use warp::{Filter, Rejection};
 
@@ -10,7 +11,7 @@ pub fn get_orders_by_tx_request() -> impl Filter<Extract = (H256,), Error = Reje
 
 pub fn get_orders_by_tx(
     orderbook: Arc<Orderbook>,
-) -> impl Filter<Extract = (super::ApiReply,), Error = Rejection> + Clone {
+) -> impl Filter<Extract = (ApiReply,), Error = Rejection> + Clone {
     get_orders_by_tx_request().and_then(move |hash: H256| {
         let orderbook = orderbook.clone();
         async move {

--- a/crates/orderbook/src/api/get_solvable_orders.rs
+++ b/crates/orderbook/src/api/get_solvable_orders.rs
@@ -1,5 +1,6 @@
-use crate::{api::convert_json_response, orderbook::Orderbook};
+use crate::orderbook::Orderbook;
 use anyhow::Result;
+use shared::api::{convert_json_response, ApiReply};
 use std::{convert::Infallible, sync::Arc};
 use warp::{Filter, Rejection};
 
@@ -9,7 +10,7 @@ fn get_solvable_orders_request() -> impl Filter<Extract = (), Error = Rejection>
 
 pub fn get_solvable_orders(
     orderbook: Arc<Orderbook>,
-) -> impl Filter<Extract = (super::ApiReply,), Error = Rejection> + Clone {
+) -> impl Filter<Extract = (ApiReply,), Error = Rejection> + Clone {
     get_solvable_orders_request().and_then(move || {
         let orderbook = orderbook.clone();
         async move {

--- a/crates/orderbook/src/api/get_solvable_orders_v2.rs
+++ b/crates/orderbook/src/api/get_solvable_orders_v2.rs
@@ -1,5 +1,6 @@
-use crate::{api::convert_json_response, orderbook::Orderbook};
+use crate::orderbook::Orderbook;
 use anyhow::Result;
+use shared::api::{convert_json_response, ApiReply};
 use std::{convert::Infallible, sync::Arc};
 use warp::{Filter, Rejection};
 
@@ -9,7 +10,7 @@ fn get_solvable_orders_request() -> impl Filter<Extract = (), Error = Rejection>
 
 pub fn get_solvable_orders(
     orderbook: Arc<Orderbook>,
-) -> impl Filter<Extract = (super::ApiReply,), Error = Rejection> + Clone {
+) -> impl Filter<Extract = (ApiReply,), Error = Rejection> + Clone {
     get_solvable_orders_request().and_then(move || {
         let orderbook = orderbook.clone();
         async move {
@@ -27,8 +28,8 @@ pub fn get_solvable_orders(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::api::response_body;
     use model::SolvableOrders;
+    use shared::api::response_body;
     use warp::{hyper::StatusCode, Reply};
 
     #[tokio::test]

--- a/crates/orderbook/src/api/get_trades.rs
+++ b/crates/orderbook/src/api/get_trades.rs
@@ -1,11 +1,9 @@
-use crate::{
-    api::convert_json_response,
-    database::trades::{TradeFilter, TradeRetrieving},
-};
+use crate::database::trades::{TradeFilter, TradeRetrieving};
 use anyhow::{Context, Result};
 use model::order::OrderUid;
 use primitive_types::H160;
 use serde::Deserialize;
+use shared::api::{convert_json_response, error, ApiReply};
 use std::{convert::Infallible, sync::Arc};
 use warp::{hyper::StatusCode, Filter, Rejection};
 
@@ -49,7 +47,7 @@ fn get_trades_request(
 
 pub fn get_trades(
     db: Arc<dyn TradeRetrieving>,
-) -> impl Filter<Extract = (super::ApiReply,), Error = Rejection> + Clone {
+) -> impl Filter<Extract = (ApiReply,), Error = Rejection> + Clone {
     get_trades_request().and_then(move |request_result| {
         let database = db.clone();
         async move {
@@ -59,7 +57,7 @@ pub fn get_trades(
                     Result::<_, Infallible>::Ok(convert_json_response(result))
                 }
                 Err(TradeFilterError::InvalidFilter(msg)) => {
-                    let err = super::error("InvalidTradeFilter", msg);
+                    let err = error("InvalidTradeFilter", msg);
                     Ok(warp::reply::with_status(err, StatusCode::BAD_REQUEST))
                 }
             }

--- a/crates/orderbook/src/api/get_user_orders.rs
+++ b/crates/orderbook/src/api/get_user_orders.rs
@@ -1,7 +1,8 @@
-use crate::{api::convert_json_response, orderbook::Orderbook};
+use crate::orderbook::Orderbook;
 use anyhow::Result;
 use primitive_types::H160;
 use serde::Deserialize;
+use shared::api::{convert_json_response, ApiReply};
 use std::{convert::Infallible, sync::Arc};
 use warp::{hyper::StatusCode, reply::with_status, Filter, Rejection};
 
@@ -19,7 +20,7 @@ fn request() -> impl Filter<Extract = (H160, Query), Error = Rejection> + Clone 
 
 pub fn get_user_orders(
     orderbook: Arc<Orderbook>,
-) -> impl Filter<Extract = (super::ApiReply,), Error = Rejection> + Clone {
+) -> impl Filter<Extract = (ApiReply,), Error = Rejection> + Clone {
     request().and_then(move |owner: H160, query: Query| {
         let orderbook = orderbook.clone();
         async move {

--- a/crates/orderbook/src/api/post_quote.rs
+++ b/crates/orderbook/src/api/post_quote.rs
@@ -1,10 +1,8 @@
-use crate::{
-    api::{self, convert_json_response, IntoWarpReply},
-    order_quoting::{CalculateQuoteError, OrderQuoteError, QuoteHandler},
-};
+use crate::order_quoting::{CalculateQuoteError, OrderQuoteError, QuoteHandler};
 use anyhow::Result;
 use model::quote::OrderQuoteRequest;
 use serde_json::json;
+use shared::api::{self, convert_json_response, rich_error, IntoWarpReply};
 use std::{convert::Infallible, sync::Arc};
 use warp::{hyper::StatusCode, Filter, Rejection};
 
@@ -34,7 +32,7 @@ impl IntoWarpReply for CalculateQuoteError {
         match self {
             Self::Price(err) => err.into_warp_reply(),
             Self::SellAmountDoesNotCoverFee { fee_amount } => warp::reply::with_status(
-                super::rich_error(
+                rich_error(
                     "SellAmountDoesNotCoverFee",
                     "The sell amount for the sell order is lower than the fee.",
                     json!({ "fee_amount": fee_amount }),
@@ -58,7 +56,6 @@ impl IntoWarpReply for OrderQuoteError {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::api::response_body;
     use anyhow::anyhow;
     use chrono::{DateTime, NaiveDateTime, Utc};
     use ethcontract::{H160, U256};
@@ -71,6 +68,7 @@ mod tests {
         signature::SigningScheme,
     };
     use serde_json::json;
+    use shared::api::response_body;
     use warp::{test::request, Reply};
 
     #[test]

--- a/crates/orderbook/src/api/replace_order.rs
+++ b/crates/orderbook/src/api/replace_order.rs
@@ -1,10 +1,8 @@
-use crate::{
-    api::{extract_payload, IntoWarpReply},
-    orderbook::{Orderbook, ReplaceOrderError},
-};
+use crate::orderbook::{Orderbook, ReplaceOrderError};
 use anyhow::Result;
 use model::order::{OrderCreation, OrderUid};
 use reqwest::StatusCode;
+use shared::api::{extract_payload, IntoWarpReply};
 use std::{convert::Infallible, sync::Arc};
 use warp::{reply, Filter, Rejection};
 

--- a/crates/shared/src/api.rs
+++ b/crates/shared/src/api.rs
@@ -1,0 +1,227 @@
+use crate::metrics::get_metric_storage_registry;
+use crate::price_estimation::PriceEstimationError;
+use anyhow::{Error as anyhowError, Result};
+use serde::{de::DeserializeOwned, Serialize};
+use std::{convert::Infallible, fmt::Debug};
+use warp::{
+    hyper::StatusCode,
+    reply::{json, with_status, Json, WithStatus},
+    Filter, Rejection, Reply,
+};
+
+pub type ApiReply = WithStatus<Json>;
+
+// We turn Rejection into Reply to workaround warp not setting CORS headers on rejections.
+pub async fn handle_rejection(err: Rejection) -> Result<impl Reply, Infallible> {
+    let response = err.default_response();
+
+    ApiMetrics::pub_instance()
+        .requests_rejected
+        .with_label_values(&[response.status().as_str()])
+        .inc();
+
+    Ok(response)
+}
+
+#[derive(prometheus_metric_storage::MetricStorage, Clone, Debug)]
+#[metric(subsystem = "api")]
+pub struct ApiMetrics {
+    /// Number of completed API requests.
+    #[metric(labels("method", "status_code"))]
+    pub requests_complete: prometheus::IntCounterVec,
+
+    /// Number of rejected API requests.
+    #[metric(labels("status_code"))]
+    pub requests_rejected: prometheus::IntCounterVec,
+
+    /// Execution time for each API request.
+    #[metric(labels("method"))]
+    pub requests_duration_seconds: prometheus::HistogramVec,
+}
+
+impl ApiMetrics {
+    /// We need this helper function to make `ApiMetrics` usable in crates using `shared`.
+    pub fn pub_instance() -> &'static ApiMetrics {
+        ApiMetrics::instance(get_metric_storage_registry()).unwrap()
+    }
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct Error<'a> {
+    error_type: &'a str,
+    description: &'a str,
+    /// Additional arbitrary data that can be attached to an API error.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    data: Option<serde_json::Value>,
+}
+
+pub fn error(error_type: &str, description: impl AsRef<str>) -> Json {
+    json(&Error {
+        error_type,
+        description: description.as_ref(),
+        data: None,
+    })
+}
+
+pub fn rich_error(error_type: &str, description: impl AsRef<str>, data: impl Serialize) -> Json {
+    let data = match serde_json::to_value(&data) {
+        Ok(value) => Some(value),
+        Err(err) => {
+            tracing::warn!(?err, "failed to serialize error data");
+            None
+        }
+    };
+
+    json(&Error {
+        error_type,
+        description: description.as_ref(),
+        data,
+    })
+}
+
+pub fn internal_error(error: anyhowError) -> Json {
+    tracing::error!(?error, "internal server error");
+    json(&Error {
+        error_type: "InternalServerError",
+        description: "",
+        data: None,
+    })
+}
+
+pub fn convert_json_response<T, E>(result: Result<T, E>) -> WithStatus<Json>
+where
+    T: Serialize,
+    E: IntoWarpReply + Debug,
+{
+    match result {
+        Ok(response) => with_status(warp::reply::json(&response), StatusCode::OK),
+        Err(err) => err.into_warp_reply(),
+    }
+}
+
+pub trait IntoWarpReply {
+    fn into_warp_reply(self) -> ApiReply;
+}
+
+impl IntoWarpReply for anyhowError {
+    fn into_warp_reply(self) -> ApiReply {
+        with_status(internal_error(self), StatusCode::INTERNAL_SERVER_ERROR)
+    }
+}
+
+pub async fn response_body(response: warp::hyper::Response<warp::hyper::Body>) -> Vec<u8> {
+    let mut body = response.into_body();
+    let mut result = Vec::new();
+    while let Some(bytes) = futures::StreamExt::next(&mut body).await {
+        result.extend_from_slice(bytes.unwrap().as_ref());
+    }
+    result
+}
+
+const MAX_JSON_BODY_PAYLOAD: u64 = 1024 * 16;
+
+pub fn extract_payload<T: DeserializeOwned + Send>(
+) -> impl Filter<Extract = (T,), Error = Rejection> + Clone {
+    // (rejecting huge payloads)...
+    warp::body::content_length_limit(MAX_JSON_BODY_PAYLOAD).and(warp::body::json())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde::ser;
+    use serde_json::json;
+
+    #[test]
+    fn rich_errors_skip_unset_data_field() {
+        assert_eq!(
+            serde_json::to_value(&Error {
+                error_type: "foo",
+                description: "bar",
+                data: None,
+            })
+            .unwrap(),
+            json!({
+                "errorType": "foo",
+                "description": "bar",
+            }),
+        );
+        assert_eq!(
+            serde_json::to_value(&Error {
+                error_type: "foo",
+                description: "bar",
+                data: Some(json!(42)),
+            })
+            .unwrap(),
+            json!({
+                "errorType": "foo",
+                "description": "bar",
+                "data": 42,
+            }),
+        );
+    }
+
+    #[tokio::test]
+    async fn rich_errors_handle_serialization_errors() {
+        struct AlwaysErrors;
+        impl Serialize for AlwaysErrors {
+            fn serialize<S>(&self, _: S) -> Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                Err(ser::Error::custom("error"))
+            }
+        }
+
+        let body = warp::hyper::body::to_bytes(
+            rich_error("foo", "bar", AlwaysErrors)
+                .into_response()
+                .into_body(),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(
+            serde_json::from_slice::<serde_json::Value>(&*body).unwrap(),
+            json!({
+                "errorType": "foo",
+                "description": "bar",
+            })
+        );
+    }
+}
+
+impl IntoWarpReply for PriceEstimationError {
+    fn into_warp_reply(self) -> WithStatus<Json> {
+        match self {
+            Self::UnsupportedToken(token) => with_status(
+                error("UnsupportedToken", format!("Token address {:?}", token)),
+                StatusCode::BAD_REQUEST,
+            ),
+            Self::NoLiquidity => with_status(
+                error("NoLiquidity", "not enough liquidity"),
+                StatusCode::NOT_FOUND,
+            ),
+            Self::ZeroAmount => with_status(
+                error("ZeroAmount", "Please use non-zero amount field"),
+                StatusCode::BAD_REQUEST,
+            ),
+            Self::UnsupportedOrderType => with_status(
+                internal_error(anyhow::anyhow!("UnsupportedOrderType").context("price_estimation")),
+                StatusCode::INTERNAL_SERVER_ERROR,
+            ),
+            Self::RateLimited(_) => with_status(
+                internal_error(
+                    anyhow::anyhow!("price estimators temporarily inactive")
+                        .context("price_estimation"),
+                ),
+                StatusCode::INTERNAL_SERVER_ERROR,
+            ),
+            Self::Other(err) => with_status(
+                internal_error(err.context("price_estimation")),
+                StatusCode::INTERNAL_SERVER_ERROR,
+            ),
+        }
+    }
+}

--- a/crates/shared/src/lib.rs
+++ b/crates/shared/src/lib.rs
@@ -1,6 +1,7 @@
 #[macro_use]
 pub mod macros;
 
+pub mod api;
 pub mod arguments;
 pub mod bad_token;
 pub mod balancer_sor_api;


### PR DESCRIPTION
The new driver is supposed to expose a few HTTP endpoints.
To not copy a bunch of code around I wanted to move common API types and functions into the `shared` crate.

### Test Plan
No changes to logic => type checking in CI
