### PR TITLE
Mark /v1/orders route as deprecated

### DIFF
--- a/crates/orderbook/openapi.yml
+++ b/crates/orderbook/openapi.yml
@@ -116,6 +116,7 @@ paths:
                 type: array
                 items:
                   $ref: "#/components/schemas/Order"
+      deprecated: true
   /api/v1/orders/{UID}:
     get:
       summary: Get existing order from UID.


### PR DESCRIPTION
We recently marked some other routes as deprecated which reminded me that our original orders route has also been deprecated since we moved to the paginated and solvable routes.

### Test Plan

CI
