### PR TITLE
Fix panic for liquidity orders buying Eth

### DIFF
--- a/crates/solver/src/solver/naive_solver/multi_order_solver.rs
+++ b/crates/solver/src/solver/naive_solver/multi_order_solver.rs
@@ -1,7 +1,10 @@
 use crate::{liquidity, settlement::Settlement};
 use anyhow::Result;
 use liquidity::{AmmOrderExecution, ConstantProductOrder, LimitOrder};
-use model::order::OrderKind;
+use model::{
+    order::{OrderData, OrderKind},
+    TokenPair,
+};
 use num::{rational::Ratio, BigInt, BigRational, CheckedDiv};
 use primitive_types::U256;
 use shared::conversions::{
@@ -43,8 +46,8 @@ pub fn solve(
     let mut orders: Vec<LimitOrder> = orders.into_iter().collect();
     while !orders.is_empty() {
         let (context_a, context_b) = split_into_contexts(&orders, pool);
-        if let Some(valid_solution) =
-            solve_orders(&orders, pool, &context_a, &context_b).filter(is_valid_solution)
+        if let Some(valid_solution) = solve_orders(&orders, pool, &context_a, &context_b)
+            .filter(|settlement| is_valid_solution(settlement, pool.tokens))
         {
             return Some(valid_solution);
         } else {
@@ -278,12 +281,27 @@ fn compute_uniswap_in(
 /// Returns true if for each trade the executed price is not smaller than the limit price
 /// Thus we ensure that `buy_token_price / sell_token_price >= limit_buy_amount / limit_sell_amount`
 ///
-fn is_valid_solution(solution: &Settlement) -> bool {
+fn is_valid_solution(solution: &Settlement, pair: TokenPair) -> bool {
+    // We can't rely on the buy token having a price for liquidity orders that
+    // buy Eth. This is because no "token equivalency" clearing price gets added
+    // for these orders, and their clearing buy price only gets added at when
+    // actually building the settlement calldata. Instead, we use the token pair
+    // to find and return the address of the token that is not the order's sell
+    // token.
+    let mapped_buy_token = |order: &OrderData| {
+        let (token0, token1) = pair.get();
+        if order.sell_token == token0 {
+            token1
+        } else {
+            token0
+        }
+    };
+
     for order in solution.traded_orders() {
         let order = &order.data;
         let buy_token_price = solution
-            .clearing_price(order.buy_token)
-            .expect("Solution should contain clearing price for buy token");
+            .clearing_price(mapped_buy_token(order))
+            .expect("Solution should contain clearing price for mapped buy token");
         let sell_token_price = solution
             .clearing_price(order.sell_token)
             .expect("Solution should contain clearing price for sell token");
@@ -657,7 +675,7 @@ mod tests {
         let result = solve(orders, &pool).unwrap();
 
         assert_eq!(result.traded_orders().count(), 2);
-        assert!(is_valid_solution(&result));
+        assert!(is_valid_solution(&result, pool.tokens));
     }
 
     #[test]
@@ -707,6 +725,7 @@ mod tests {
     fn test_is_valid_solution() {
         let token_a = Address::from_low_u64_be(0);
         let token_b = Address::from_low_u64_be(1);
+        let tokens = TokenPair::new(token_a, token_b).unwrap();
         let orders = vec![
             Order {
                 data: OrderData {
@@ -746,44 +765,49 @@ mod tests {
         };
 
         // Price in the middle is ok
-        assert!(is_valid_solution(&settlement_with_prices(
-            maplit::hashmap! {
+        assert!(is_valid_solution(
+            &settlement_with_prices(maplit::hashmap! {
                 token_a => to_wei(1),
                 token_b => to_wei(1)
-            }
-        )));
+            }),
+            tokens
+        ));
 
         // Price at the limit of first order is ok
-        assert!(is_valid_solution(&settlement_with_prices(
-            maplit::hashmap! {
+        assert!(is_valid_solution(
+            &settlement_with_prices(maplit::hashmap! {
                 token_a => to_wei(8),
                 token_b => to_wei(10)
-            }
-        )));
+            }),
+            tokens
+        ));
 
         // Price at the limit of second order is ok
-        assert!(is_valid_solution(&settlement_with_prices(
-            maplit::hashmap! {
+        assert!(is_valid_solution(
+            &settlement_with_prices(maplit::hashmap! {
                 token_a => to_wei(10),
                 token_b => to_wei(9)
-            }
-        )));
+            }),
+            tokens
+        ));
 
         // Price violating first order is not ok
-        assert!(!is_valid_solution(&settlement_with_prices(
-            maplit::hashmap! {
+        assert!(!is_valid_solution(
+            &settlement_with_prices(maplit::hashmap! {
                 token_a => to_wei(7),
                 token_b => to_wei(10)
-            }
-        )));
+            }),
+            tokens
+        ));
 
         // Price violating second order is not ok
-        assert!(!is_valid_solution(&settlement_with_prices(
-            maplit::hashmap! {
+        assert!(!is_valid_solution(
+            &settlement_with_prices(maplit::hashmap! {
                 token_a => to_wei(10),
                 token_b => to_wei(8)
-            }
-        )));
+            }),
+            tokens
+        ));
     }
 
     #[test]


### PR DESCRIPTION
Fixes observed naive solver panics.

We have special encoding semantics for:
- Liquidity orders
- Ether buy orders (i.e. buy orders that use the special `0xe...` marker address.

Specifically, for liquidity orders, we add additional clearing price entries for their `buy_token` to ensure that they always get exactly their limit price when trading.

For Ether buy orders, we change their `buy_token` to the wrapped native token (WETH on mainnet for example) before sending `LiquidityOrder` instances to individual solvers. When these orders get added to the settlement, we add an extra clearing price for `0xe...` that matches exactly the price of the wrapped native token (e.g. WETH). In the code we call this a "token equivalency".

However, when adding liquidity Ether buy orders, **we do not add a "token equivalency" between `0xe...` and the native wrapped token**. This leads to a missing `buy_token` price for liquidity Ether buy orders when we are checking the settlement is valid in the Naive solver. Note that when encoding the liquidity Ether buy order we already add a `0xe...` token price matching its buy amount, so the settlement should actually be valid.

The solution is simple: since we already know that the orders in the settlement trade over the same token pair and this token pair already converts `0xe...` to native wrapped token, we can just use the token that isn't the order's sell token as the buy token (instead of the order's actual buy token).

### Test Plan

Added a unit test. You can also verify that the added test was indeed causing the panic by:
```
% git checkout main -- crates/solver/src/solver/naive_solver/multi_order_solver.rs 
% cargo test -p solver -- works_with_eth_liquidity_orders
   Compiling solver v0.1.0 (/Users/nlordell/Developer/cowprotocol/services/crates/solver)
    Finished test [unoptimized + debuginfo] target(s) in 6.90s
     Running unittests src/lib.rs (target/debug/deps/solver-8a3820337d63a133)

running 1 test
test solver::naive_solver::tests::works_with_eth_liquidity_orders ... FAILED

failures:

---- solver::naive_solver::tests::works_with_eth_liquidity_orders stdout ----
thread 'solver::naive_solver::tests::works_with_eth_liquidity_orders' panicked at 'Solution should contain clearing price for buy token', crates/solver/src/solver/naive_solver/multi_order_solver.rs:286:14
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace


failures:
    solver::naive_solver::tests::works_with_eth_liquidity_orders

test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 165 filtered out; finished in 0.01s

error: test failed, to rerun pass '-p solver --lib'
```
