### PR TITLE
Move some U256 conversions into own crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1839,6 +1839,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "number_conversions"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "num",
+ "primitive-types",
+]
+
+[[package]]
 name = "object"
 version = "0.28.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1932,6 +1941,7 @@ dependencies = [
  "mockall",
  "model",
  "num",
+ "number_conversions",
  "primitive-types",
  "prometheus",
  "prometheus-metric-storage",
@@ -2681,6 +2691,7 @@ dependencies = [
  "mockall",
  "model",
  "num",
+ "number_conversions",
  "once_cell",
  "primitive-types",
  "prometheus",
@@ -2758,6 +2769,7 @@ dependencies = [
  "mockall",
  "model",
  "num",
+ "number_conversions",
  "primitive-types",
  "prometheus",
  "prometheus-metric-storage",

--- a/crates/number_conversions/Cargo.toml
+++ b/crates/number_conversions/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "number_conversions"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+anyhow = "1.0"
+num = "0.4"
+primitive-types = { version = "0.10" }

--- a/crates/number_conversions/src/lib.rs
+++ b/crates/number_conversions/src/lib.rs
@@ -1,0 +1,76 @@
+use anyhow::{ensure, Result};
+use num::{bigint::Sign, BigInt, BigRational, BigUint, Zero};
+use primitive_types::U256;
+
+pub fn u256_to_big_uint(input: &U256) -> BigUint {
+    let mut bytes = [0; 32];
+    input.to_big_endian(&mut bytes);
+    BigUint::from_bytes_be(&bytes)
+}
+
+pub fn u256_to_big_int(input: &U256) -> BigInt {
+    BigInt::from_biguint(Sign::Plus, u256_to_big_uint(input))
+}
+
+pub fn u256_to_big_rational(input: &U256) -> BigRational {
+    BigRational::new(u256_to_big_int(input), 1.into())
+}
+
+pub fn big_uint_to_u256(input: &BigUint) -> Result<U256> {
+    let bytes = input.to_bytes_be();
+    ensure!(bytes.len() <= 32, "too large");
+    Ok(U256::from_big_endian(&bytes))
+}
+
+pub fn big_int_to_u256(input: &BigInt) -> Result<U256> {
+    ensure!(input.sign() != Sign::Minus, "negative");
+    big_uint_to_u256(input.magnitude())
+}
+
+pub fn big_rational_to_u256(ratio: &BigRational) -> Result<U256> {
+    ensure!(!ratio.denom().is_zero(), "zero denominator");
+    big_int_to_u256(&(ratio.numer() / ratio.denom()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use num::One;
+    use std::str::FromStr;
+
+    #[test]
+    fn big_integer_to_u256() {
+        for val in &[0i32, 42, 1337] {
+            assert_eq!(
+                big_int_to_u256(&BigInt::from(*val)).unwrap(),
+                U256::from(*val),
+            );
+        }
+    }
+
+    #[test]
+    fn u256_to_big_uint_() {
+        assert_eq!(u256_to_big_uint(&U256::zero()), BigUint::zero());
+        assert_eq!(u256_to_big_uint(&U256::one()), BigUint::one());
+        assert_eq!(
+            u256_to_big_uint(&U256::MAX),
+            BigUint::from_str(
+                "115792089237316195423570985008687907853269984665640564039457584007913129639935"
+            )
+            .unwrap()
+        );
+    }
+
+    #[test]
+    fn bigint_to_u256_() {
+        assert_eq!(big_int_to_u256(&BigInt::zero()).unwrap(), U256::zero());
+        assert_eq!(big_int_to_u256(&BigInt::one()).unwrap(), U256::one());
+        let max_u256_as_bigint = BigInt::from_str(
+            "115792089237316195423570985008687907853269984665640564039457584007913129639935",
+        )
+        .unwrap();
+        assert_eq!(big_int_to_u256(&max_u256_as_bigint).unwrap(), U256::MAX);
+        assert!(big_int_to_u256(&(max_u256_as_bigint + BigInt::one())).is_err());
+        assert!(big_int_to_u256(&BigInt::from(-1)).is_err());
+    }
+}

--- a/crates/orderbook/Cargo.toml
+++ b/crates/orderbook/Cargo.toml
@@ -32,6 +32,7 @@ hex-literal = "0.3"
 maplit = "1.0"
 model = { path = "../model" }
 num = "0.4"
+number_conversions = { path = "../number_conversions" }
 primitive-types = { version = "0.10", features = ["fp-conversion"] }
 prometheus = "0.13"
 prometheus-metric-storage = { git = "https://github.com/cowprotocol/prometheus-metric-storage" , tag = "v0.4.0" }

--- a/crates/orderbook/src/database/orders.rs
+++ b/crates/orderbook/src/database/orders.rs
@@ -1,5 +1,10 @@
 use super::*;
-use crate::{conversions::*, order_quoting::Quote};
+use crate::{
+    conversions::{
+        big_decimal_to_big_uint, big_decimal_to_u256, h160_from_vec, u256_to_big_decimal,
+    },
+    order_quoting::Quote,
+};
 use anyhow::{anyhow, Context as _, Result};
 use chrono::{DateTime, Utc};
 use const_format::concatcp;
@@ -681,6 +686,7 @@ mod tests {
     use crate::{fee_subsidy::FeeParameters, order_quoting::QuoteData};
     use chrono::{Duration, NaiveDateTime};
     use num::BigUint;
+    use number_conversions::u256_to_big_uint;
     use primitive_types::U256;
     use shared::event_handling::EventIndex;
     use std::sync::atomic::{AtomicI64, Ordering};

--- a/crates/shared/Cargo.toml
+++ b/crates/shared/Cargo.toml
@@ -32,6 +32,7 @@ maplit = "1.0"
 mockall = "0.11"
 model = { path = "../model" }
 num = "0.4"
+number_conversions = { path = "../number_conversions" }
 once_cell = "1.9.0"
 primitive-types = "0.10"
 prometheus = "0.13"

--- a/crates/shared/src/conversions.rs
+++ b/crates/shared/src/conversions.rs
@@ -1,47 +1,6 @@
 use anyhow::{ensure, Result};
-use num::{
-    bigint::Sign, rational::Ratio, BigInt, BigRational, BigUint, ToPrimitive as _, Zero as _,
-};
+use num::{rational::Ratio, BigInt, BigRational};
 use primitive_types::U256;
-
-pub fn big_rational_to_float(ratio: &BigRational) -> Option<f64> {
-    Some(ratio.numer().to_f64()? / ratio.denom().to_f64()?)
-}
-
-pub fn big_rational_to_u256(ratio: &BigRational) -> Result<U256> {
-    ensure!(
-        !ratio.denom().is_zero(),
-        "Division by 0 in BigRational to U256 conversion"
-    );
-    big_int_to_u256(&(ratio.numer() / ratio.denom()))
-}
-
-pub fn u256_to_big_int(input: &U256) -> BigInt {
-    let mut bytes = [0; 32];
-    input.to_big_endian(&mut bytes);
-    BigInt::from_bytes_be(Sign::Plus, &bytes)
-}
-
-pub fn u256_to_big_uint(input: &U256) -> BigUint {
-    let mut bytes = [0; 32];
-    input.to_big_endian(&mut bytes);
-    BigUint::from_bytes_be(&bytes)
-}
-
-pub fn u256_to_big_rational(input: &U256) -> BigRational {
-    let as_bigint = u256_to_big_int(input);
-    BigRational::new(as_bigint, 1.into())
-}
-
-pub fn big_int_to_u256(input: &BigInt) -> Result<U256> {
-    if input.is_zero() {
-        return Ok(0.into());
-    }
-    let (sign, bytes) = input.to_bytes_be();
-    ensure!(sign == Sign::Plus, "Negative BigInt to U256 conversion");
-    ensure!(bytes.len() <= 32, "BigInt too big for U256 conversion");
-    Ok(U256::from_big_endian(&bytes))
-}
 
 // Convenience:
 
@@ -69,10 +28,10 @@ pub trait U256Ext: Sized {
 
 impl U256Ext for U256 {
     fn to_big_int(&self) -> BigInt {
-        u256_to_big_int(self)
+        number_conversions::u256_to_big_int(self)
     }
     fn to_big_rational(&self) -> BigRational {
-        u256_to_big_rational(self)
+        number_conversions::u256_to_big_rational(self)
     }
 
     fn checked_ceil_div(&self, other: &Self) -> Option<Self> {
@@ -82,20 +41,5 @@ impl U256Ext for U256 {
     fn ceil_div(&self, other: &Self) -> Self {
         self.checked_ceil_div(other)
             .expect("ceiling division arithmetic error")
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn big_integer_to_u256() {
-        for val in &[0i32, 42, 1337] {
-            assert_eq!(
-                big_int_to_u256(&BigInt::from(*val)).unwrap(),
-                U256::from(*val),
-            );
-        }
     }
 }

--- a/crates/shared/src/sources/balancer_v2/swap/fixed_point.rs
+++ b/crates/shared/src/sources/balancer_v2/swap/fixed_point.rs
@@ -4,11 +4,11 @@
 //! https://github.com/balancer-labs/balancer-v2-monorepo/blob/6c9e24e22d0c46cca6dd15861d3d33da61a60b98/pkg/solidity-utils/contracts/math/FixedPoint.sol
 
 use super::error::Error;
-use crate::conversions::{big_int_to_u256, u256_to_big_int};
 use anyhow::{anyhow, bail, ensure, Result};
 use ethcontract::U256;
 use lazy_static::lazy_static;
 use num::{BigInt, BigRational};
+use number_conversions::{big_int_to_u256, u256_to_big_int};
 use std::{
     convert::TryFrom,
     fmt::{self, Debug, Formatter},

--- a/crates/solver/Cargo.toml
+++ b/crates/solver/Cargo.toml
@@ -18,6 +18,7 @@ path = "src/main.rs"
 anyhow = "1.0"
 async-trait = "0.1"
 chrono = { version = "0.4", default-features = false, features = ["clock"] }
+clap = { version = "3.1", features = ["derive", "env"] }
 contracts = { path = "../contracts" }
 derivative = "2.2"
 derive_more = "0.99"
@@ -33,6 +34,7 @@ lazy_static = "1.4"
 maplit = "1.0"
 model = { path = "../model" }
 num = "0.4"
+number_conversions = { path = "../number_conversions" }
 primitive-types = { version = "0.10", features = ["fp-conversion"] }
 prometheus = "0.13"
 prometheus-metric-storage = { git = "https://github.com/cowprotocol/prometheus-metric-storage" , tag = "v0.4.0" }
@@ -42,7 +44,6 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 serde_with = { version = "1.11", default-features = false }
 shared = { path = "../shared" }
-clap = { version = "3.1", features = ["derive", "env"] }
 strum = { version = "0.24", features = ["derive"] }
 thiserror = "1.0"
 tokio = { version = "1.15", features = ["macros", "rt-multi-thread", "time", "test-util"] }

--- a/crates/solver/src/in_flight_orders.rs
+++ b/crates/solver/src/in_flight_orders.rs
@@ -4,7 +4,7 @@ use model::{
     auction::Auction,
     order::{Order, OrderUid},
 };
-use shared::conversions::u256_to_big_uint;
+use number_conversions::u256_to_big_uint;
 use std::collections::{BTreeMap, HashMap, HashSet};
 
 #[derive(Debug, Clone)]

--- a/crates/solver/src/settlement/settlement_encoder.rs
+++ b/crates/solver/src/settlement/settlement_encoder.rs
@@ -6,8 +6,9 @@ use crate::{
 use anyhow::{bail, ensure, Context as _, Result};
 use model::order::{Order, OrderKind};
 use num::{BigRational, One, Zero};
+use number_conversions::big_rational_to_u256;
 use primitive_types::{H160, U256};
-use shared::conversions::{big_rational_to_u256, U256Ext};
+use shared::conversions::U256Ext;
 use std::{
     collections::{hash_map::Entry, HashMap, HashSet},
     iter,

--- a/crates/solver/src/solver/naive_solver/multi_order_solver.rs
+++ b/crates/solver/src/solver/naive_solver/multi_order_solver.rs
@@ -3,10 +3,9 @@ use anyhow::Result;
 use liquidity::{AmmOrderExecution, ConstantProductOrder, LimitOrder};
 use model::order::OrderKind;
 use num::{rational::Ratio, BigInt, BigRational, CheckedDiv};
+use number_conversions::{big_int_to_u256, big_rational_to_u256, u256_to_big_int};
 use primitive_types::U256;
-use shared::conversions::{
-    big_int_to_u256, big_rational_to_u256, u256_to_big_int, RatioExt, U256Ext,
-};
+use shared::conversions::{RatioExt, U256Ext};
 use std::collections::HashMap;
 use web3::types::Address;
 


### PR DESCRIPTION
In order to disentangle some dependencies I'm moving this to it's own crate. The plan is to move the BigDecimal <-> U256 conversion into the database crate without making it depend on shared.

Some of the conversion implementations have been slightly changed.

### Test Plan

CI, existing tests
