### PR TITLE
Support fixed size byte arrays in database natively

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -638,6 +638,7 @@ dependencies = [
 name = "database"
 version = "0.1.0"
 dependencies = [
+ "hex",
  "sqlx",
  "tokio",
 ]

--- a/crates/database/Cargo.toml
+++ b/crates/database/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+hex = "0.4"
 sqlx = { version = "0.6", default-features = false, features = ["postgres"] }
 
 [dev-dependencies]

--- a/crates/database/src/byte_array.rs
+++ b/crates/database/src/byte_array.rs
@@ -1,0 +1,84 @@
+use sqlx::{
+    encode::IsNull,
+    error::BoxDynError,
+    postgres::{PgArgumentBuffer, PgHasArrayType, PgTypeInfo, PgValueFormat, PgValueRef},
+    Decode, Encode, Postgres, Type,
+};
+
+/// Wrapper type for fixed size byte arrays compatible with sqlx's Postgres implementation.
+pub struct ByteArray<const N: usize>(pub [u8; N]);
+
+impl<const N: usize> Type<Postgres> for ByteArray<N> {
+    fn type_info() -> PgTypeInfo {
+        <[u8] as Type<Postgres>>::type_info()
+    }
+}
+
+impl<const N: usize> PgHasArrayType for ByteArray<N> {
+    fn array_type_info() -> PgTypeInfo {
+        <[&[u8]] as Type<Postgres>>::type_info()
+    }
+}
+
+impl<const N: usize> Decode<'_, Postgres> for ByteArray<N> {
+    fn decode(value: PgValueRef<'_>) -> Result<Self, BoxDynError> {
+        let mut bytes = [0u8; N];
+        match value.format() {
+            // prepared query
+            PgValueFormat::Binary => {
+                bytes = value.as_bytes()?.try_into().unwrap();
+            }
+            // unpreprared raw query
+            PgValueFormat::Text => {
+                let text = value
+                    .as_bytes()?
+                    .strip_prefix(b"\\x")
+                    .ok_or("text does not start with \\x")?;
+                hex::decode_to_slice(text, &mut bytes)?
+            }
+        };
+        Ok(Self(bytes))
+    }
+}
+
+impl<const N: usize> Encode<'_, Postgres> for ByteArray<N> {
+    fn encode_by_ref(&self, buf: &mut PgArgumentBuffer) -> IsNull {
+        <&[u8] as Encode<Postgres>>::encode(&self.0, buf)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use sqlx::{Executor, PgPool, Row};
+
+    #[tokio::test]
+    #[ignore]
+    async fn postgres_fixed_bytes() {
+        const TABLE: &str = "fixed_bytes_test";
+        let db = PgPool::connect("postgresql://").await.unwrap();
+        db.execute(format!("CREATE TABLE IF NOT EXISTS {} (bytes bytea);", TABLE).as_str())
+            .await
+            .unwrap();
+        db.execute(format!("TRUNCATE {};", TABLE).as_str())
+            .await
+            .unwrap();
+
+        let data: ByteArray<3> = ByteArray([1, 2, 3]);
+        sqlx::query(&format!("INSERT INTO {} (bytes) VALUES ($1);", TABLE))
+            .bind(&data)
+            .execute(&db)
+            .await
+            .unwrap();
+        let query = format!("SELECT * FROM {} LIMIT 1;", TABLE);
+
+        // unprepared raw query
+        let row = db.fetch_one(query.as_str()).await.unwrap();
+        let data_: ByteArray<3> = row.try_get(0).unwrap();
+        assert_eq!(data.0, data_.0);
+
+        // prepared query
+        let data_: ByteArray<3> = sqlx::query_scalar(&query).fetch_one(&db).await.unwrap();
+        assert_eq!(data.0, data_.0);
+    }
+}

--- a/crates/database/src/lib.rs
+++ b/crates/database/src/lib.rs
@@ -1,3 +1,6 @@
+pub mod byte_array;
+
+use byte_array::ByteArray;
 use sqlx::PgExecutor;
 
 // The names of all tables we use in the db.
@@ -19,6 +22,11 @@ pub async fn clear_DANGER(ex: impl PgExecutor<'_> + Copy) -> sqlx::Result<()> {
     }
     Ok(())
 }
+
+pub type Address = ByteArray<20>;
+pub type AppId = ByteArray<32>;
+pub type TransactionHash = ByteArray<32>;
+pub type OrderUid = ByteArray<56>;
 
 #[cfg(test)]
 mod tests {

--- a/crates/orderbook/src/conversions.rs
+++ b/crates/orderbook/src/conversions.rs
@@ -1,7 +1,6 @@
-use anyhow::{anyhow, Result};
 use bigdecimal::num_bigint::ToBigInt;
 use num::bigint::{BigInt, BigUint};
-use primitive_types::{H160, H256, U256};
+use primitive_types::U256;
 use sqlx::types::BigDecimal;
 use std::convert::TryInto;
 
@@ -23,20 +22,6 @@ pub fn big_decimal_to_u256(big_decimal: &BigDecimal) -> Option<U256> {
     }
     let big_int = big_decimal.to_bigint()?;
     number_conversions::big_int_to_u256(&big_int).ok()
-}
-
-pub fn h160_from_vec(vec: Vec<u8>) -> Result<H160> {
-    let array: [u8; 20] = vec
-        .try_into()
-        .map_err(|_| anyhow!("h160 has wrong length"))?;
-    Ok(H160::from(array))
-}
-
-pub fn h256_from_vec(vec: Vec<u8>) -> Result<H256> {
-    let array: [u8; 32] = vec
-        .try_into()
-        .map_err(|_| anyhow!("h256 has wrong length"))?;
-    Ok(H256::from(array))
 }
 
 #[cfg(test)]
@@ -95,35 +80,5 @@ mod tests {
             Some(U256::MAX)
         );
         assert!(big_decimal_to_u256(&(max_u256_as_big_decimal + BigDecimal::one())).is_none());
-    }
-
-    #[test]
-    fn h160_from_vec_() {
-        let valid_input = [1u8; 20].to_vec();
-        assert_eq!(
-            h160_from_vec(valid_input).unwrap(),
-            H160::from_slice(&[1u8; 20])
-        );
-
-        let wrong_length = vec![0u8];
-        assert_eq!(
-            h160_from_vec(wrong_length).unwrap_err().to_string(),
-            "h160 has wrong length"
-        );
-    }
-
-    #[test]
-    fn h256_from_vec_() {
-        let valid_input = [1u8; 32].to_vec();
-        assert_eq!(
-            h256_from_vec(valid_input).unwrap(),
-            H256::from_slice(&[1u8; 32])
-        );
-
-        let wrong_length = vec![0u8];
-        assert_eq!(
-            h256_from_vec(wrong_length).unwrap_err().to_string(),
-            "h256 has wrong length"
-        );
     }
 }

--- a/crates/orderbook/src/database/quotes.rs
+++ b/crates/orderbook/src/database/quotes.rs
@@ -8,13 +8,14 @@ use anyhow::{Context, Result};
 use bigdecimal::BigDecimal;
 use chrono::{DateTime, Utc};
 use model::quote::QuoteId;
+use primitive_types::H160;
 use shared::maintenance::Maintaining;
 
 #[derive(sqlx::FromRow)]
 struct QuoteRow {
     id: QuoteId,
-    sell_token: Vec<u8>,
-    buy_token: Vec<u8>,
+    sell_token: database::Address,
+    buy_token: database::Address,
     sell_amount: BigDecimal,
     buy_amount: BigDecimal,
     gas_amount: f64,
@@ -29,8 +30,8 @@ impl TryFrom<QuoteRow> for QuoteData {
 
     fn try_from(row: QuoteRow) -> Result<QuoteData> {
         Ok(QuoteData {
-            sell_token: h160_from_vec(row.sell_token)?,
-            buy_token: h160_from_vec(row.buy_token)?,
+            sell_token: H160(row.sell_token.0),
+            buy_token: H160(row.buy_token.0),
             quoted_sell_amount: big_decimal_to_u256(&row.sell_amount)
                 .context("quoted sell amount is not a valid U256")?,
             quoted_buy_amount: big_decimal_to_u256(&row.buy_amount)


### PR DESCRIPTION
without going through Vec<u8>

This is more efficient, more type safe, easier to use.

### Test Plan

new and old unit tests
