### PR TITLE
Basic mock up of new driver logic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -729,9 +729,14 @@ name = "driver"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "async-trait",
  "clap 3.2.5",
  "futures",
+ "mockall",
+ "model",
+ "primitive-types",
  "shared",
+ "solver",
  "thiserror",
  "tokio",
  "tracing",

--- a/crates/driver/Cargo.toml
+++ b/crates/driver/Cargo.toml
@@ -16,12 +16,17 @@ path = "src/main.rs"
 
 [dependencies]
 anyhow = "1.0"
+async-trait = "0.1"
 clap = { version = "3.1", features = ["derive", "env"] }
 futures = "0.3"
+model = { path = "../model" }
+primitive-types = { version = "0.10" }
 shared = { path = "../shared" }
+solver = { path = "../solver" }
 thiserror = "1.0"
 tokio = { version = "1.15", features = ["macros", "rt-multi-thread", "time", "test-util", "signal"] }
 tracing = "0.1"
 warp = { version = "0.3", default-features = false }
 
 [dev-dependencies]
+mockall = "0.11"

--- a/crates/driver/src/api.rs
+++ b/crates/driver/src/api.rs
@@ -1,5 +1,5 @@
-mod execute;
-mod solve;
+pub mod execute;
+pub mod solve;
 
 use futures::Future;
 use shared::api::finalize_router;

--- a/crates/driver/src/api/solve.rs
+++ b/crates/driver/src/api/solve.rs
@@ -20,9 +20,11 @@ pub fn post_solve() -> impl Filter<Extract = (ApiReply,), Error = Rejection> + C
 }
 
 #[derive(thiserror::Error, Debug)]
-enum SolveError {
+pub enum SolveError {
     #[error("not implemented")]
     NotImplemented,
+    #[error(transparent)]
+    Other(#[from] anyhow::Error),
 }
 
 impl IntoWarpReply for SolveError {
@@ -32,6 +34,7 @@ impl IntoWarpReply for SolveError {
                 error("Route not yet implemented", "try again later"),
                 StatusCode::INTERNAL_SERVER_ERROR,
             ),
+            Self::Other(err) => err.into_warp_reply(),
         }
     }
 }

--- a/crates/driver/src/commit_reveal.rs
+++ b/crates/driver/src/commit_reveal.rs
@@ -1,0 +1,36 @@
+use anyhow::Result;
+use solver::{settlement::Settlement, solver::Auction};
+
+/// A `SolutionSummary` holds all information solvers are willing to disclose during settlement
+/// competition. It does **not** have to include the call data, yet.
+pub struct SettlementSummary {}
+
+#[cfg_attr(test, mockall::automock)]
+#[async_trait::async_trait]
+pub trait CommitRevealSolving: Send + Sync {
+    /// Calculates a solution for a given `Auction` but does **not** disclose secret details.
+    async fn commit(&self, auction: Auction) -> Result<SettlementSummary>;
+
+    /// Finalizes solution for a previously calculated `SolutionSummary` which can be used to compute
+    /// executable call data. If the solver no longer wants to execute the solution it returns
+    /// `Ok(None)`.
+    async fn reveal(&self, summary: SettlementSummary) -> Result<Option<Settlement>>;
+}
+
+// Wraps an HttpSolver and makes it compatible with the commit reveal protocol. Because
+// RFQ support can not be solved generically the wrapped solver will not be able to opt into
+// RFQ orders, yet. A solver would have to support RFQ themselves.
+// For now this wrapper is only a compatibility layer to let us use the new driver with existing
+// solvers for faster development.
+pub struct CommitRevealSolver {}
+
+#[async_trait::async_trait]
+impl CommitRevealSolving for CommitRevealSolver {
+    async fn commit(&self, _auction: Auction) -> Result<SettlementSummary> {
+        todo!()
+    }
+
+    async fn reveal(&self, _summary: SettlementSummary) -> Result<Option<Settlement>> {
+        todo!()
+    }
+}

--- a/crates/driver/src/driver.rs
+++ b/crates/driver/src/driver.rs
@@ -1,0 +1,52 @@
+use crate::{
+    api::{execute::ExecuteError, solve::SolveError},
+    commit_reveal::{CommitRevealSolving, SettlementSummary},
+};
+use anyhow::Result;
+use model::auction::Auction;
+use solver::settlement::Settlement;
+use std::sync::Arc;
+
+pub struct Driver {
+    pub solver: Arc<dyn CommitRevealSolving>,
+}
+
+impl Driver {
+    /// Does some sanity checks on the auction, collects some liquidity and prepares the auction
+    /// for the solver.
+    pub async fn on_auction_started(
+        &self,
+        _auction: Auction,
+    ) -> Result<SettlementSummary, SolveError> {
+        // TODO sanity checks
+        // TODO liquidity collection
+        let auction = solver::solver::Auction::default();
+        self.solver.commit(auction).await.map_err(SolveError::from)
+    }
+
+    /// Validates that the `Settlement` satisfies expected fairness and correctness properties.
+    async fn validate_settlement(&self, _settlement: &Settlement) -> Result<()> {
+        // TODO simulation
+        // TODO token conservation
+        Ok(())
+    }
+
+    /// When the solver won the competition it finalizes the `Settlement` and decides whether it
+    /// still wants to execute and submit that `Settlement`.
+    pub async fn on_auction_won(&self, summary: SettlementSummary) -> Result<(), ExecuteError> {
+        let settlement = match self.solver.reveal(summary).await? {
+            None => return Err(ExecuteError::ExecutionRejected),
+            Some(solution) => solution,
+        };
+        self.validate_settlement(&settlement).await?;
+        self.submit_settlement(settlement).await?;
+        Ok(())
+    }
+
+    /// Tries to submit the `Settlement` on chain. Returns a transaction hash if it was successful.
+    async fn submit_settlement(&self, _settlement: Settlement) -> Result<()> {
+        // TODO execute
+        // TODO notify about execution
+        Ok(())
+    }
+}

--- a/crates/driver/src/lib.rs
+++ b/crates/driver/src/lib.rs
@@ -1,2 +1,4 @@
 pub mod api;
 pub mod arguments;
+pub mod commit_reveal;
+pub mod driver;


### PR DESCRIPTION
This PR implements step 1 of #337 and creates a very rough sketch of the internal architecture of the new `Driver`.
It introduces the new `CommitRevealSolving` trait and makes use of it.

### Test Plan
Nothing to test yet
