### PR TITLE
Initialize SolutionSubmitter in new driver

### DIFF
--- a/crates/driver/src/arguments.rs
+++ b/crates/driver/src/arguments.rs
@@ -1,6 +1,12 @@
 use reqwest::Url;
-use shared::arguments::duration_from_seconds;
-use solver::solver::ExternalSolverArg;
+use shared::{
+    arguments::{display_list, display_option, duration_from_seconds},
+    gas_price_estimation::GasEstimatorType,
+};
+use solver::{
+    arguments::TransactionStrategyArg, settlement_access_list::AccessListEstimatorType,
+    solver::ExternalSolverArg,
+};
 use std::{net::SocketAddr, time::Duration};
 use tracing::level_filters::LevelFilter;
 
@@ -38,6 +44,136 @@ pub struct Arguments {
     /// If solvers should use internal buffers to improve solution quality.
     #[clap(long, env)]
     pub use_internal_buffers: bool,
+
+    /// The RPC endpoints to use for submitting transaction to a custom set of nodes.
+    #[clap(long, env, use_value_delimiter = true)]
+    pub transaction_submission_nodes: Vec<Url>,
+
+    /// How to to submit settlement transactions.
+    /// Expected to contain either:
+    /// 1. One value equal to TransactionStrategyArg::DryRun or
+    /// 2. One or more values equal to any combination of enum variants except TransactionStrategyArg::DryRun
+    #[clap(
+        long,
+        env,
+        default_value = "PublicMempool",
+        arg_enum,
+        ignore_case = true,
+        use_value_delimiter = true
+    )]
+    pub transaction_strategy: Vec<TransactionStrategyArg>,
+
+    /// The API endpoint of the Eden network for transaction submission.
+    #[clap(long, env, default_value = "https://api.edennetwork.io/v1/rpc")]
+    pub eden_api_url: Url,
+
+    /// Maximum additional tip in gwei that we are willing to give to eden above regular gas price estimation
+    #[clap(
+        long,
+        env,
+        default_value = "3",
+        parse(try_from_str = shared::arguments::wei_from_gwei)
+    )]
+    pub max_additional_eden_tip: f64,
+
+    /// Additional tip in percentage of max_fee_per_gas we are willing to give to miners above regular gas price estimation
+    #[clap(
+        long,
+        env,
+        default_value = "0.05",
+        parse(try_from_str = shared::arguments::parse_percentage_factor)
+    )]
+    pub additional_tip_percentage: f64,
+
+    /// The API endpoint of the Flashbots network for transaction submission.
+    /// Multiple values could be defined for different Flashbots endpoints (Flashbots Protect and Flashbots fast).
+    #[clap(
+        long,
+        env,
+        use_value_delimiter = true,
+        default_value = "https://rpc.flashbots.net"
+    )]
+    pub flashbots_api_url: Vec<Url>,
+
+    /// Maximum additional tip in gwei that we are willing to give to flashbots above regular gas price estimation
+    #[clap(
+        long,
+        env,
+        default_value = "3",
+        parse(try_from_str = shared::arguments::wei_from_gwei)
+    )]
+    pub max_additional_flashbot_tip: f64,
+
+    /// Which access list estimators to use. Multiple estimators are used in sequence if a previous one
+    /// fails. Individual estimators might support different networks.
+    /// `Tenderly`: supports every network.
+    /// `Web3`: supports every network.
+    #[clap(long, env, arg_enum, ignore_case = true, use_value_delimiter = true)]
+    pub access_list_estimators: Vec<AccessListEstimatorType>,
+
+    /// The URL for tenderly transaction simulation.
+    #[clap(long, env)]
+    pub tenderly_url: Option<Url>,
+
+    /// Tenderly requires api key to work. Optional since Tenderly could be skipped in access lists estimators.
+    #[clap(long, env)]
+    pub tenderly_api_key: Option<String>,
+
+    /// The target confirmation time in seconds for settlement transactions used to estimate gas price.
+    #[clap(
+        long,
+        env,
+        default_value = "30",
+        parse(try_from_str = shared::arguments::duration_from_seconds),
+    )]
+    pub target_confirm_time: Duration,
+
+    /// The maximum time in seconds we spend trying to settle a transaction through the ethereum
+    /// network before going to back to solving.
+    #[clap(
+        long,
+        default_value = "120",
+        parse(try_from_str = shared::arguments::duration_from_seconds),
+    )]
+    pub max_submission_seconds: Duration,
+
+    /// Amount of time to wait before retrying to submit the tx to the ethereum network
+    #[clap(
+        long,
+        default_value = "2",
+        parse(try_from_str = shared::arguments::duration_from_seconds),
+    )]
+    pub submission_retry_interval_seconds: Duration,
+
+    /// The maximum gas price in Gwei the solver is willing to pay in a settlement.
+    #[clap(
+        long,
+        env,
+        default_value = "1500",
+        parse(try_from_str = shared::arguments::wei_from_gwei)
+    )]
+    pub gas_price_cap: f64,
+
+    /// Which gas estimators to use. Multiple estimators are used in sequence if a previous one
+    /// fails. Individual estimators support different networks.
+    /// `EthGasStation`: supports mainnet.
+    /// `GasNow`: supports mainnet.
+    /// `GnosisSafe`: supports mainnet, rinkeby and goerli.
+    /// `Web3`: supports every network.
+    /// `Native`: supports every network.
+    #[clap(
+        long,
+        env,
+        default_value = "Web3",
+        arg_enum,
+        ignore_case = true,
+        use_value_delimiter = true
+    )]
+    pub gas_estimators: Vec<GasEstimatorType>,
+
+    /// BlockNative requires api key to work. Optional since BlockNative could be skipped in gas estimators.
+    #[clap(long, env)]
+    pub blocknative_api_key: Option<String>,
 }
 
 impl std::fmt::Display for Arguments {
@@ -48,7 +184,67 @@ impl std::fmt::Display for Arguments {
         writeln!(f, "solvers: {:?}", self.solvers)?;
         writeln!(f, "node_url: {}", self.node_url)?;
         writeln!(f, "http_timeout: {:?}", self.http_timeout)?;
-        write!(f, "use_internal_buffers: {}", self.use_internal_buffers)?;
+        writeln!(f, "use_internal_buffers: {}", self.use_internal_buffers)?;
+        write!(f, "transaction_submission_nodes: ",)?;
+        display_list(self.transaction_submission_nodes.iter(), f)?;
+        writeln!(f)?;
+        writeln!(f, "transaction_strategy: {:?}", self.transaction_strategy)?;
+        writeln!(f, "eden_api_url: {}", self.eden_api_url)?;
+        writeln!(
+            f,
+            "max_additional_eden_tip: {}",
+            self.max_additional_eden_tip
+        )?;
+        writeln!(
+            f,
+            "additional_tip_percentage: {}",
+            self.additional_tip_percentage
+        )?;
+        write!(f, "flashbots_api_url: ")?;
+        display_list(self.flashbots_api_url.iter(), f)?;
+        writeln!(f)?;
+        writeln!(
+            f,
+            "max_additional_flashbots_tip: {}",
+            self.max_additional_flashbot_tip
+        )?;
+        writeln!(
+            f,
+            "access_list_estimators: {:?}",
+            self.access_list_estimators
+        )?;
+        write!(f, "tenderly_url: ")?;
+        display_option(&self.tenderly_url, f)?;
+        writeln!(f)?;
+        writeln!(
+            f,
+            "tenderly_api_key: {}",
+            self.tenderly_api_key
+                .as_deref()
+                .map(|_| "SECRET")
+                .unwrap_or("None")
+        )?;
+        writeln!(f, "target_confirm_time: {:?}", self.target_confirm_time)?;
+        writeln!(
+            f,
+            "max_submission_seconds: {:?}",
+            self.max_submission_seconds
+        )?;
+        writeln!(
+            f,
+            "submission_retry_interval_seconds: {:?}",
+            self.submission_retry_interval_seconds
+        )?;
+        writeln!(f, "gas_price_cap: {}", self.gas_price_cap)?;
+        writeln!(f, "gas_estimators: {:?}", self.gas_estimators)?;
+        writeln!(
+            f,
+            "blocknative_api_key: {}",
+            self.blocknative_api_key
+                .as_ref()
+                .map(|_| "SECRET")
+                .unwrap_or("None")
+        )?;
         Ok(())
     }
 }

--- a/crates/driver/src/driver.rs
+++ b/crates/driver/src/driver.rs
@@ -4,11 +4,12 @@ use crate::{
 };
 use anyhow::Result;
 use model::auction::Auction;
-use solver::settlement::Settlement;
+use solver::{settlement::Settlement, settlement_submission::SolutionSubmitter};
 use std::sync::Arc;
 
 pub struct Driver {
     pub solver: Arc<dyn CommitRevealSolving>,
+    pub submitter: Arc<SolutionSubmitter>,
 }
 
 impl Driver {


### PR DESCRIPTION
Implements step 4 of #337

This PR just instantiates the `SolutionSubmitter` and stores it in each `Driver` instance. The instantiation logic and CLI argument code has been lifted from the `solver` binary.

I used the same initialization approach explained in #340 to make it clearer what subcomponents actually belong to the submission logic.