### PR TITLE
Add BalancerSor price estimator

### DIFF
--- a/crates/orderbook/src/arguments.rs
+++ b/crates/orderbook/src/arguments.rs
@@ -224,6 +224,10 @@ pub struct Arguments {
     /// Use Blockscout as a TokenOwnerFinding implementation.
     #[clap(long, env, default_value = "true")]
     pub enable_blockscout: bool,
+
+    /// The API endpoint for the Balancer SOR API for solving.
+    #[clap(long, env)]
+    pub balancer_sor_url: Url,
 }
 
 impl std::fmt::Display for Arguments {
@@ -312,6 +316,7 @@ impl std::fmt::Display for Arguments {
             self.liquidity_order_owners
         )?;
         writeln!(f, "enable_blockscout: {}", self.enable_blockscout)?;
+        writeln!(f, "balancer_sor_url: {}", self.balancer_sor_url)?;
         Ok(())
     }
 }

--- a/crates/orderbook/src/arguments.rs
+++ b/crates/orderbook/src/arguments.rs
@@ -227,7 +227,7 @@ pub struct Arguments {
 
     /// The API endpoint for the Balancer SOR API for solving.
     #[clap(long, env)]
-    pub balancer_sor_url: Url,
+    pub balancer_sor_url: Option<Url>,
 }
 
 impl std::fmt::Display for Arguments {
@@ -316,7 +316,9 @@ impl std::fmt::Display for Arguments {
             self.liquidity_order_owners
         )?;
         writeln!(f, "enable_blockscout: {}", self.enable_blockscout)?;
-        writeln!(f, "balancer_sor_url: {}", self.balancer_sor_url)?;
+        write!(f, "balancer_sor_url: ")?;
+        display_option(&self.balancer_sor_url, f)?;
+        writeln!(f)?;
         Ok(())
     }
 }

--- a/crates/shared/src/price_estimation.rs
+++ b/crates/shared/src/price_estimation.rs
@@ -1,3 +1,4 @@
+pub mod balancer_sor;
 pub mod baseline;
 pub mod competition;
 pub mod gas;
@@ -38,6 +39,7 @@ pub enum PriceEstimatorType {
     Quasimodo,
     OneInch,
     Yearn,
+    BalancerSor,
 }
 
 impl PriceEstimatorType {

--- a/crates/shared/src/price_estimation/balancer_sor.rs
+++ b/crates/shared/src/price_estimation/balancer_sor.rs
@@ -1,0 +1,121 @@
+use super::{
+    gas::{GAS_PER_BALANCER_SWAP, SETTLEMENT_SINGLE_TRADE},
+    Estimate, PriceEstimateResult, PriceEstimating, PriceEstimationError, Query,
+};
+use crate::{
+    balancer_sor_api::{self, BalancerSorApi},
+    rate_limiter::RateLimiter,
+    request_sharing::RequestSharing,
+};
+use anyhow::Result;
+use futures::{future::BoxFuture, stream::BoxStream, FutureExt, StreamExt};
+use gas_estimation::GasPriceEstimating;
+use primitive_types::U256;
+use std::sync::Arc;
+
+pub struct BalancerSor {
+    api: Arc<dyn BalancerSorApi>,
+    sharing: RequestSharing<
+        Query,
+        BoxFuture<'static, Result<balancer_sor_api::Quote, PriceEstimationError>>,
+    >,
+    rate_limiter: Arc<RateLimiter>,
+    gas: Arc<dyn GasPriceEstimating>,
+}
+
+impl BalancerSor {
+    pub fn new(
+        api: Arc<dyn BalancerSorApi>,
+        rate_limiter: Arc<RateLimiter>,
+        gas: Arc<dyn GasPriceEstimating>,
+    ) -> Self {
+        Self {
+            api,
+            sharing: Default::default(),
+            rate_limiter,
+            gas,
+        }
+    }
+
+    async fn estimate(&self, query: &Query) -> PriceEstimateResult {
+        let gas_price = self.gas.estimate().await?;
+        let query_ = balancer_sor_api::Query {
+            sell_token: query.sell_token,
+            buy_token: query.buy_token,
+            order_kind: query.kind,
+            amount: query.in_amount,
+            gas_price: U256::from_f64_lossy(gas_price.effective_gas_price()),
+        };
+        let api = self.api.clone();
+        let future = async move {
+            match api.quote(query_).await {
+                Ok(Some(quote)) => Ok(quote),
+                Ok(None) => Err(PriceEstimationError::NoLiquidity),
+                Err(err) => Err(PriceEstimationError::from(err)),
+            }
+        };
+        let future = super::rate_limited(self.rate_limiter.clone(), future);
+        let future = self.sharing.shared(*query, future.boxed());
+        let quote = future.await?;
+        Ok(Estimate {
+            out_amount: quote.return_amount,
+            gas: SETTLEMENT_SINGLE_TRADE + (quote.swaps.len() as u64) * GAS_PER_BALANCER_SWAP,
+        })
+    }
+}
+
+impl PriceEstimating for BalancerSor {
+    fn estimates<'a>(
+        &'a self,
+        queries: &'a [Query],
+    ) -> BoxStream<'_, (usize, PriceEstimateResult)> {
+        futures::stream::iter(queries)
+            .then(|query| self.estimate(query))
+            .enumerate()
+            .boxed()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{balancer_sor_api::DefaultBalancerSorApi, price_estimation::single_estimate};
+    use gas_estimation::GasPrice1559;
+    use model::order::OrderKind;
+    use std::time::Duration;
+
+    struct FixedGasPriceEstimator(f64);
+
+    #[async_trait::async_trait]
+    impl GasPriceEstimating for FixedGasPriceEstimator {
+        async fn estimate_with_limits(&self, _: f64, _: Duration) -> Result<GasPrice1559> {
+            Ok(GasPrice1559 {
+                base_fee_per_gas: self.0,
+                max_fee_per_gas: self.0,
+                max_priority_fee_per_gas: 0.,
+            })
+        }
+    }
+
+    #[tokio::test]
+    #[ignore]
+    async fn mainnet() {
+        let url = std::env::var("BALANCER_SOR_URL").unwrap();
+        let api = Arc::new(DefaultBalancerSorApi::new(Default::default(), url, 1).unwrap());
+        let rate_limiter = Arc::new(RateLimiter::from_strategy(
+            Default::default(),
+            "test".into(),
+        ));
+        let gas = Arc::new(FixedGasPriceEstimator(1e7));
+        let estimator = BalancerSor::new(api, rate_limiter, gas);
+        let query = Query {
+            sell_token: testlib::tokens::WETH,
+            buy_token: testlib::tokens::DAI,
+            in_amount: U256::from_f64_lossy(1e18),
+            kind: OrderKind::Sell,
+        };
+        let result = single_estimate(&estimator, &query).await;
+        println!("{:?}", result);
+        result.unwrap();
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/cowprotocol/services/issues/342

After merging should change configuration to enable this as price estimator and native price estimator.

### Test Plan

new ignored test and manually ran orderbook and estimated price between the two problematic tokens from https://app.balancer.fi/#/pool/0x3dd0843a028c86e0b760b1a76929d1c5ef93a2dd000200000000000000000249 .