### PR TITLE
Add auction to settlement competition information

### DIFF
--- a/crates/model/src/solver_competition.rs
+++ b/crates/model/src/solver_competition.rs
@@ -5,16 +5,27 @@ use crate::{
 use primitive_types::{H160, H256, U256};
 use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 
 #[derive(Clone, Debug, Default, Deserialize, Serialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct SolverCompetitionResponse {
     pub gas_price: f64,
+    pub auction_start_block: u64,
     pub liquidity_collected_block: u64,
     pub competition_simulation_block: u64,
     pub transaction_hash: Option<H256>,
+    pub auction: CompetitionAuction,
     pub solutions: Vec<SolverSettlement>,
+}
+
+#[serde_as]
+#[derive(Clone, Debug, Default, Deserialize, Serialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct CompetitionAuction {
+    pub orders: Vec<OrderUid>,
+    #[serde_as(as = "BTreeMap<_, DecimalU256>")]
+    pub prices: BTreeMap<H160, U256>,
 }
 
 #[serde_as]
@@ -23,8 +34,8 @@ pub struct SolverCompetitionResponse {
 pub struct SolverSettlement {
     pub solver: String,
     pub objective: Objective,
-    #[serde_as(as = "HashMap<_, DecimalU256>")]
-    pub prices: HashMap<H160, U256>,
+    #[serde_as(as = "BTreeMap<_, DecimalU256>")]
+    pub clearing_prices: BTreeMap<H160, U256>,
     pub orders: Vec<Order>,
     #[serde(with = "crate::bytes_hex")]
     pub call_data: Vec<u8>,
@@ -51,47 +62,78 @@ pub struct Order {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use hex_literal::hex;
+    use maplit::btreemap;
 
     #[test]
     fn serialize() {
         let correct = serde_json::json!({
-            "transactionHash": "0x1111111111111111111111111111111111111111111111111111111111111111",
             "gasPrice": 1.0f64,
+            "auctionStartBlock": 13u64,
             "liquidityCollectedBlock": 14u64,
             "competitionSimulationBlock": 15u64,
+            "transactionHash": "0x1111111111111111111111111111111111111111111111111111111111111111",
+            "auction": {
+                "orders": [
+                    "0x1111111111111111111111111111111111111111111111111111111111111111\
+                       1111111111111111111111111111111111111111\
+                       11111111",
+                    "0x2222222222222222222222222222222222222222222222222222222222222222\
+                       2222222222222222222222222222222222222222\
+                       22222222",
+                    "0x3333333333333333333333333333333333333333333333333333333333333333\
+                       3333333333333333333333333333333333333333\
+                       33333333",
+                ],
+                "prices": {
+                    "0x1111111111111111111111111111111111111111": "1000",
+                    "0x2222222222222222222222222222222222222222": "2000",
+                    "0x3333333333333333333333333333333333333333": "3000",
+                },
+            },
             "solutions": [
                 {
-                "solver": "2",
-                "objective": {
-                    "total": 3.0f64,
-                    "surplus": 4.0f64,
-                    "fees": 5.0f64,
-                    "cost": 6.0f64,
-                    "gas": 7u64,
+                    "solver": "2",
+                    "objective": {
+                        "total": 3.0f64,
+                        "surplus": 4.0f64,
+                        "fees": 5.0f64,
+                        "cost": 6.0f64,
+                        "gas": 7u64,
+                    },
+                    "clearingPrices": {
+                        "0x2222222222222222222222222222222222222222": "8",
+                    },
+                    "orders": [
+                        {
+                            "id": "0x3333333333333333333333333333333333333333333333333333333333333333\
+                                     3333333333333333333333333333333333333333\
+                                     33333333",
+                            "executedAmount": "12",
+                        }
+                    ],
+                    "callData": "0x13",
                 },
-                "prices": {
-                    "0x2222222222222222222222222222222222222222": "8",
-                },
-                "orders": [
-                    {
-                    "id": "0x1111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
-                    "executedAmount": "12"
-                    }
-                ],
-                "callData": "0x13"
-                }
-            ]
+            ],
         });
-        let transaction_hash = H256(hex!(
-            "1111111111111111111111111111111111111111111111111111111111111111"
-        ));
-        let order_id =OrderUid(hex!("1111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111"));
+
         let orig = SolverCompetitionResponse {
             gas_price: 1.,
+            auction_start_block: 13,
             liquidity_collected_block: 14,
             competition_simulation_block: 15,
-            transaction_hash: Some(transaction_hash),
+            transaction_hash: Some(H256([0x11; 32])),
+            auction: CompetitionAuction {
+                orders: vec![
+                    OrderUid([0x11; 56]),
+                    OrderUid([0x22; 56]),
+                    OrderUid([0x33; 56]),
+                ],
+                prices: btreemap! {
+                    H160([0x11; 20]) => 1000.into(),
+                    H160([0x22; 20]) => 2000.into(),
+                    H160([0x33; 20]) => 3000.into(),
+                },
+            },
             solutions: vec![SolverSettlement {
                 solver: "2".to_string(),
                 objective: Objective {
@@ -101,19 +143,17 @@ mod tests {
                     cost: 6.,
                     gas: 7,
                 },
-                prices: [(
-                    H160(hex!("2222222222222222222222222222222222222222")),
-                    8.into(),
-                )]
-                .into_iter()
-                .collect(),
+                clearing_prices: btreemap! {
+                    H160([0x22; 20]) => 8.into(),
+                },
                 orders: vec![Order {
-                    id: order_id,
+                    id: OrderUid([0x33; 56]),
                     executed_amount: 12.into(),
                 }],
                 call_data: vec![0x13],
             }],
         };
+
         let serialized = serde_json::to_value(&orig).unwrap();
         assert_eq!(correct, serialized);
         let deserialized: SolverCompetitionResponse = serde_json::from_value(correct).unwrap();


### PR DESCRIPTION
This PR extends the settlement competition JSON to additionally include `auction` field that contains information about the orders that were considered in the auction and, more critically, the external price vector that was used for ranking the settlements.

The main motivations for adding additional information are:
- External prices are required for verifying the computed objective value amounts
- We intend on using the external price vector from the auction to compute total solver surplus that will be used in the solver payout computation.
- Orders allow us to compute disregarded utility for an auction (and verify things like envy-freeness - not necessarily something we want to enforce at the moment, but a general target that we have AFAIU).

Note that this still does not store the settlement competition information in the database, but just contains additional information that we will want to store eventually.

### Test Plan

Adjusted the test used for checking serialization format for the settlement competition information.
