### PR TITLE
Refactor solver competition storing

### DIFF
--- a/crates/e2e/tests/e2e/services.rs
+++ b/crates/e2e/tests/e2e/services.rs
@@ -12,6 +12,7 @@ use orderbook::{
     orderbook::Orderbook,
     signature_validator::Web3SignatureValidator,
     solvable_orders::SolvableOrdersCache,
+    solver_competition,
 };
 use reqwest::Client;
 use shared::{
@@ -282,7 +283,7 @@ impl OrderbookServices {
             quotes,
             API_HOST[7..].parse().expect("Couldn't parse API address"),
             pending(),
-            Default::default(),
+            Arc::new(solver_competition::InMemoryStorage::default()),
             None,
         );
 

--- a/crates/model/src/solver_competition.rs
+++ b/crates/model/src/solver_competition.rs
@@ -7,9 +7,11 @@ use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
 use std::collections::BTreeMap;
 
+pub type SolverCompetitionId = u64;
+
 #[derive(Clone, Debug, Default, Deserialize, Serialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
-pub struct SolverCompetitionResponse {
+pub struct SolverCompetition {
     pub gas_price: f64,
     pub auction_start_block: u64,
     pub liquidity_collected_block: u64,
@@ -116,7 +118,7 @@ mod tests {
             ],
         });
 
-        let orig = SolverCompetitionResponse {
+        let orig = SolverCompetition {
             gas_price: 1.,
             auction_start_block: 13,
             liquidity_collected_block: 14,
@@ -156,7 +158,7 @@ mod tests {
 
         let serialized = serde_json::to_value(&orig).unwrap();
         assert_eq!(correct, serialized);
-        let deserialized: SolverCompetitionResponse = serde_json::from_value(correct).unwrap();
+        let deserialized: SolverCompetition = serde_json::from_value(correct).unwrap();
         assert_eq!(orig, deserialized);
     }
 }

--- a/crates/orderbook/src/api.rs
+++ b/crates/orderbook/src/api.rs
@@ -15,7 +15,7 @@ mod post_quote;
 mod post_solver_competition;
 mod replace_order;
 
-use crate::solver_competition::SolverCompetition;
+use crate::solver_competition::SolverCompetitionStoring;
 use crate::{database::trades::TradeRetrieving, order_quoting::QuoteHandler, orderbook::Orderbook};
 use shared::api::{error, finalize_router, internal_error, ApiReply};
 use std::sync::Arc;
@@ -25,7 +25,7 @@ pub fn handle_all_routes(
     database: Arc<dyn TradeRetrieving>,
     orderbook: Arc<Orderbook>,
     quotes: Arc<QuoteHandler>,
-    solver_competition: Arc<SolverCompetition>,
+    solver_competition: Arc<dyn SolverCompetitionStoring>,
     solver_competition_auth: Option<String>,
 ) -> impl Filter<Extract = (impl Reply,), Error = Rejection> + Clone {
     // Routes for api v1.

--- a/crates/orderbook/src/api/get_solver_competition.rs
+++ b/crates/orderbook/src/api/get_solver_competition.rs
@@ -1,46 +1,55 @@
-use crate::solver_competition::SolverCompetition;
+use crate::solver_competition::{LoadSolverCompetitionError, SolverCompetitionStoring};
 use anyhow::Result;
 use reqwest::StatusCode;
+use shared::api::{convert_json_response, IntoWarpReply};
 use std::{convert::Infallible, sync::Arc};
-use warp::{Filter, Rejection};
+use warp::{reply::with_status, Filter, Rejection};
 
 fn request() -> impl Filter<Extract = (u64,), Error = Rejection> + Clone {
     warp::path!("solver_competition" / u64).and(warp::get())
 }
 
 pub fn get(
-    handler: Arc<SolverCompetition>,
+    handler: Arc<dyn SolverCompetitionStoring>,
 ) -> impl Filter<Extract = (super::ApiReply,), Error = Rejection> + Clone {
-    request().and_then(move |auction_id| {
+    request().and_then(move |id| {
         let handler = handler.clone();
         async move {
-            let (json, status) = match handler.get(auction_id) {
-                Some(response) => (warp::reply::json(&response), StatusCode::OK),
-                None => (super::error("NotFound", ""), StatusCode::NOT_FOUND),
-            };
-            let reply = warp::reply::with_status(json, status);
-            Result::<_, Infallible>::Ok(reply)
+            let result = handler.load(id).await;
+            Result::<_, Infallible>::Ok(convert_json_response(result))
         }
     })
+}
+
+impl IntoWarpReply for LoadSolverCompetitionError {
+    fn into_warp_reply(self) -> shared::api::ApiReply {
+        match self {
+            Self::NotFound(_) => with_status(super::error("NotFound", ""), StatusCode::NOT_FOUND),
+            Self::Other(err) => err.into_warp_reply(),
+        }
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::solver_competition::InMemoryStorage;
     use warp::{test::request, Reply};
 
     #[tokio::test]
     async fn test() {
-        let handler = SolverCompetition::default();
-        handler.set(0, Default::default());
+        let handler = InMemoryStorage::default();
+        let id = handler.save(Default::default()).await.unwrap();
         let filter = get(Arc::new(handler));
 
-        let request_ = request().path("/solver_competition/0").method("GET");
+        let request_ = request()
+            .path(&format!("/solver_competition/{id}"))
+            .method("GET");
         let response = request_.filter(&filter).await.unwrap().into_response();
         dbg!(&response);
         assert_eq!(response.status(), StatusCode::OK);
 
-        let request_ = request().path("/solver_competition/1").method("GET");
+        let request_ = request().path("/solver_competition/1337").method("GET");
         let response = request_.filter(&filter).await.unwrap().into_response();
         dbg!(&response);
         assert_eq!(response.status(), StatusCode::NOT_FOUND);

--- a/crates/orderbook/src/api/post_solver_competition.rs
+++ b/crates/orderbook/src/api/post_solver_competition.rs
@@ -1,17 +1,16 @@
 //! This is a private, undocumented api which will get replaced when we move the solution
 //! competition into the api.
 
-use crate::solver_competition::SolverCompetition;
-use anyhow::Result;
-use model::solver_competition::SolverCompetitionResponse;
+use crate::solver_competition::SolverCompetitionStoring;
+use model::solver_competition::SolverCompetition;
 use reqwest::StatusCode;
+use shared::api::convert_json_response_with_status;
 use std::{convert::Infallible, sync::Arc};
-use warp::{Filter, Rejection};
+use warp::{reply::with_status, Filter, Rejection};
 
-fn request(
-) -> impl Filter<Extract = (u64, Option<String>, SolverCompetitionResponse), Error = Rejection> + Clone
+fn request() -> impl Filter<Extract = (Option<String>, SolverCompetition), Error = Rejection> + Clone
 {
-    warp::path!("solver_competition" / u64)
+    warp::path!("solver_competition")
         .and(warp::post())
         .and(warp::header::optional::<String>("Authorization"))
         // While this is an authenticated endpoint we still want to protect against very large
@@ -21,73 +20,74 @@ fn request(
 }
 
 pub fn post(
-    handler: Arc<SolverCompetition>,
+    handler: Arc<dyn SolverCompetitionStoring>,
     expected_auth: Option<String>,
 ) -> impl Filter<Extract = (super::ApiReply,), Error = Rejection> + Clone {
-    request().and_then(
-        move |auction_id: u64, auth, model: SolverCompetitionResponse| {
-            let handler = handler.clone();
-            let expected_auth = expected_auth.clone();
-            async move {
-                let (json, status) = if expected_auth.is_none() || expected_auth == auth {
-                    handler.set(auction_id, model);
-                    (warp::reply::json(&()), StatusCode::CREATED)
-                } else {
-                    (super::error("Unauthorized", ""), StatusCode::UNAUTHORIZED)
-                };
-                let reply = warp::reply::with_status(json, status);
-                Result::<_, Infallible>::Ok(reply)
+    request().and_then(move |auth, model: SolverCompetition| {
+        let handler = handler.clone();
+        let expected_auth = expected_auth.clone();
+        async move {
+            if expected_auth.is_some() && expected_auth != auth {
+                return Result::<_, Infallible>::Ok(with_status(
+                    super::error("Unauthorized", ""),
+                    StatusCode::UNAUTHORIZED,
+                ));
             }
-        },
-    )
+
+            let result = handler.save(model).await;
+            Ok(convert_json_response_with_status(
+                result,
+                StatusCode::CREATED,
+            ))
+        }
+    })
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::solver_competition::MockSolverCompetitionStoring;
     use warp::{test::request, Reply};
 
     #[tokio::test]
     async fn test_no_auth() {
-        let handler = SolverCompetition::default();
-        let handler = Arc::new(handler);
-        let filter = post(handler.clone(), None);
-        let body = serde_json::to_vec(&SolverCompetitionResponse::default()).unwrap();
+        let mut handler = MockSolverCompetitionStoring::new();
+        handler.expect_save().returning(|_| Ok(1));
 
-        let request_ = request()
-            .path("/solver_competition/1")
+        let filter = post(Arc::new(handler), None);
+        let body = serde_json::to_vec(&SolverCompetition::default()).unwrap();
+
+        let request = request()
+            .path("/solver_competition")
             .method("POST")
             .header("authorization", "password")
             .body(body.clone());
-        let response = request_.filter(&filter).await.unwrap().into_response();
-        dbg!(&response);
+        let response = request.filter(&filter).await.unwrap().into_response();
         assert_eq!(response.status(), StatusCode::CREATED);
-        assert!(handler.get(1).is_some());
     }
 
     #[tokio::test]
     async fn test_auth() {
-        let handler = SolverCompetition::default();
-        let handler = Arc::new(handler);
-        let filter = post(handler.clone(), Some("auth".to_string()));
-        let body = serde_json::to_vec(&SolverCompetitionResponse::default()).unwrap();
+        let mut handler = MockSolverCompetitionStoring::new();
+        handler.expect_save().times(1).returning(|_| Ok(1));
+
+        let filter = post(Arc::new(handler), Some("auth".to_string()));
+        let body = serde_json::to_vec(&SolverCompetition::default()).unwrap();
 
         let request_ = request()
-            .path("/solver_competition/1")
+            .path("/solver_competition")
             .method("POST")
             .header("authorization", "wrong")
             .body(body.clone());
         let response = request_.filter(&filter).await.unwrap().into_response();
         assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
-        assert!(handler.get(1).is_none());
 
         let request_ = request()
-            .path("/solver_competition/1")
+            .path("/solver_competition")
             .method("POST")
             .header("authorization", "auth")
             .body(body);
         let response = request_.filter(&filter).await.unwrap().into_response();
         assert_eq!(response.status(), StatusCode::CREATED);
-        assert!(handler.get(1).is_some());
     }
 }

--- a/crates/orderbook/src/api/post_solver_competition.rs
+++ b/crates/orderbook/src/api/post_solver_competition.rs
@@ -62,8 +62,10 @@ mod tests {
             .method("POST")
             .header("authorization", "password")
             .body(body.clone());
-        let response = request.filter(&filter).await.unwrap().into_response();
+        let response = request.reply(&filter).await;
         assert_eq!(response.status(), StatusCode::CREATED);
+        let response: u64 = serde_json::from_slice(response.body()).unwrap();
+        assert_eq!(response, 1);
     }
 
     #[tokio::test]
@@ -87,7 +89,9 @@ mod tests {
             .method("POST")
             .header("authorization", "auth")
             .body(body);
-        let response = request_.filter(&filter).await.unwrap().into_response();
+        let response = request_.reply(&filter).await;
         assert_eq!(response.status(), StatusCode::CREATED);
+        let response: u64 = serde_json::from_slice(response.body()).unwrap();
+        assert_eq!(response, 1);
     }
 }

--- a/crates/orderbook/src/lib.rs
+++ b/crates/orderbook/src/lib.rs
@@ -20,7 +20,7 @@ use anyhow::{anyhow, Context as _, Result};
 use contracts::GPv2Settlement;
 use futures::Future;
 use model::DomainSeparator;
-use solver_competition::SolverCompetition;
+use solver_competition::SolverCompetitionStoring;
 use std::{net::SocketAddr, sync::Arc};
 use tokio::{task, task::JoinHandle};
 use warp::Filter;
@@ -31,7 +31,7 @@ pub fn serve_api(
     quotes: Arc<QuoteHandler>,
     address: SocketAddr,
     shutdown_receiver: impl Future<Output = ()> + Send + 'static,
-    solver_competition: Arc<SolverCompetition>,
+    solver_competition: Arc<dyn SolverCompetitionStoring>,
     solver_competition_auth: Option<String>,
 ) -> JoinHandle<()> {
     let filter = api::handle_all_routes(

--- a/crates/orderbook/src/main.rs
+++ b/crates/orderbook/src/main.rs
@@ -20,8 +20,7 @@ use orderbook::{
     serve_api,
     signature_validator::Web3SignatureValidator,
     solvable_orders::SolvableOrdersCache,
-    solver_competition::SolverCompetition,
-    verify_deployed_contract_constants,
+    solver_competition, verify_deployed_contract_constants,
 };
 use primitive_types::U256;
 use shared::{
@@ -577,7 +576,7 @@ async fn main() {
     let quotes =
         Arc::new(QuoteHandler::new(order_validator, optimal_quoter).with_fast_quoter(fast_quoter));
     let (shutdown_sender, shutdown_receiver) = tokio::sync::oneshot::channel();
-    let solver_competition = Arc::new(SolverCompetition::default());
+    let solver_competition = Arc::new(solver_competition::InMemoryStorage::default());
     let serve_api = serve_api(
         database.clone(),
         orderbook.clone(),

--- a/crates/shared/src/api.rs
+++ b/crates/shared/src/api.rs
@@ -96,8 +96,19 @@ where
     T: Serialize,
     E: IntoWarpReply + Debug,
 {
+    convert_json_response_with_status(result, StatusCode::OK)
+}
+
+pub fn convert_json_response_with_status<T, E>(
+    result: Result<T, E>,
+    status: StatusCode,
+) -> WithStatus<Json>
+where
+    T: Serialize,
+    E: IntoWarpReply + Debug,
+{
     match result {
-        Ok(response) => with_status(warp::reply::json(&response), StatusCode::OK),
+        Ok(response) => with_status(warp::reply::json(&response), status),
         Err(err) => err.into_warp_reply(),
     }
 }


### PR DESCRIPTION
This PR refactors solver competition storage into a `SolverCompetitionStoring` component. The existing in-memory storage was changed to conform to this new interface.

There are, however, some notable changes to how solver competition storage works. Storage competition will eventually need to be stored in the database. This means that the "ID" for storing it needs to come from there. This is a bit unfortunate because the auction ID is computed in the `solver`, but storage is happening in the `orderbook`. Previously, we had just allowed drivers to arbitrarily replace `SolverCompetition` values for arbitrary IDs. Moving forward with this change, drivers will just be able to `POST` a new solver competition (and will be returned the ID of the newly pushed storage competition). This has some notable effects:
- The auction ID and solver competition ID no longer match. In fact, you one or more driver runs per solver competition entry. While this is unfortunate, I plan on adding a `last_solver_competition` field to the data returned by the `api/v1/auction` endpoint for better logging in the driver. I will do this in a followup PR.
- The solver competition is no longer updated with a transaction hash. Instead we set the transaction hash only if we successfully mine a settlement and upload the solver competition unconditionally (rather, unconditionally **if** there is a winning settlement). This has the downside that solver competition information that is available before the transaction is mined is not immediately available. I am not too worried about this delay which I expect to go away in once the autopilot is in place.

This also raises an important point for discussion - should empty auctions or auctions without any solutions increment the solver competition ID? Intuitively, I don't think so. I imagine that going forward we will want to seprate:
- A "driver run ID" for grouping logs for a specific run loop. This for debugging purposes and should not be persisted, but should be included as metadata in solver instances.
- An "auction/solver competition ID" for identifying meaningful auctions (i.e. ones that produce settlements). This is what the current `SolverCompetitionId` aims to be.

Additionally, I plan on following up this change by implementing `SolverCompetitionStoring` on our Postgres database component in order to persist solver competition data.

### Test Plan

Refactor. Issues should be caught in CI.
