### PR TITLE
Include next solver competition ID in auction and logs

### DIFF
--- a/crates/e2e/tests/e2e/services.rs
+++ b/crates/e2e/tests/e2e/services.rs
@@ -241,6 +241,7 @@ impl OrderbookServices {
             contracts.gp_settlement.address(),
         ));
         let signature_validator = Arc::new(Web3SignatureValidator::new(web3.clone()));
+        let solver_competition = Arc::new(solver_competition::InMemoryStorage::default());
         let solvable_orders_cache = SolvableOrdersCache::new(
             Duration::from_secs(120),
             db.clone(),
@@ -251,6 +252,7 @@ impl OrderbookServices {
             native_price_estimator,
             Arc::new(NoopMetrics),
             signature_validator.clone(),
+            solver_competition.clone(),
         );
         let order_validator = Arc::new(OrderValidator::new(
             Box::new(web3.clone()),
@@ -283,7 +285,7 @@ impl OrderbookServices {
             quotes,
             API_HOST[7..].parse().expect("Couldn't parse API address"),
             pending(),
-            Arc::new(solver_competition::InMemoryStorage::default()),
+            solver_competition,
             None,
         );
 

--- a/crates/model/src/auction.rs
+++ b/crates/model/src/auction.rs
@@ -1,6 +1,6 @@
 //! Module defining a batch auction.
 
-use crate::{order::Order, u256_decimal::DecimalU256};
+use crate::{order::Order, solver_competition::SolverCompetitionId, u256_decimal::DecimalU256};
 use primitive_types::{H160, U256};
 use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
@@ -21,6 +21,13 @@ pub struct Auction {
     /// Note that under certain conditions it is possible for a settlement to
     /// have been mined as part of [`block`] but not have yet been processed.
     pub latest_settlement_block: u64,
+
+    /// The ID of the next solver competition to be recorded.
+    ///
+    /// This gives an indication as to what the ID will be if solver competition
+    /// were to happen and be recorded in the database.
+    #[serde(default)]
+    pub next_solver_competition: SolverCompetitionId,
 
     /// The solvable orders included in the auction.
     pub orders: Vec<Order>,
@@ -49,6 +56,7 @@ mod tests {
         let auction = Auction {
             block: 42,
             latest_settlement_block: 40,
+            next_solver_competition: 1337,
             orders: vec![order(1), order(2)],
             prices: btreemap! {
                 H160([2; 20]) => U256::from(2),
@@ -61,6 +69,7 @@ mod tests {
             json!({
                 "block": 42,
                 "latestSettlementBlock": 40,
+                "nextSolverCompetition": 1337,
                 "orders": [
                     order(1),
                     order(2),

--- a/crates/orderbook/src/main.rs
+++ b/crates/orderbook/src/main.rs
@@ -521,6 +521,7 @@ async fn main() {
     let optimal_quoter = create_quoter(price_estimator.clone(), database.clone());
     let fast_quoter = create_quoter(fast_price_estimator.clone(), Arc::new(Forget));
 
+    let solver_competition = Arc::new(solver_competition::InMemoryStorage::default());
     let solvable_orders_cache = SolvableOrdersCache::new(
         args.min_order_validity_period,
         database.clone(),
@@ -531,6 +532,7 @@ async fn main() {
         native_price_estimator.clone(),
         metrics.clone(),
         signature_validator.clone(),
+        solver_competition.clone(),
     );
     let block = current_block_stream.borrow().number.unwrap().as_u64();
     solvable_orders_cache
@@ -576,7 +578,6 @@ async fn main() {
     let quotes =
         Arc::new(QuoteHandler::new(order_validator, optimal_quoter).with_fast_quoter(fast_quoter));
     let (shutdown_sender, shutdown_receiver) = tokio::sync::oneshot::channel();
-    let solver_competition = Arc::new(solver_competition::InMemoryStorage::default());
     let serve_api = serve_api(
         database.clone(),
         orderbook.clone(),

--- a/crates/orderbook/src/orderbook.rs
+++ b/crates/orderbook/src/orderbook.rs
@@ -332,6 +332,7 @@ mod tests {
         account_balances::MockBalanceFetching, database::orders::MockOrderStoring,
         metrics::NoopMetrics, order_validation::MockOrderValidating,
         signature_validator::MockSignatureValidating,
+        solver_competition::MockSolverCompetitionStoring,
     };
     use ethcontract::H160;
     use mockall::predicate::eq;
@@ -360,6 +361,7 @@ mod tests {
                 Arc::new(MockNativePriceEstimating::new()),
                 Arc::new(NoopMetrics),
                 Arc::new(MockSignatureValidating::new()),
+                Arc::new(MockSolverCompetitionStoring::new()),
             ),
             solvable_orders_max_update_age: Default::default(),
             order_validator: Arc::new(MockOrderValidating::new()),

--- a/crates/shared/src/http_solver/model.rs
+++ b/crates/shared/src/http_solver/model.rs
@@ -206,6 +206,7 @@ impl SettledBatchAuctionModel {
 pub struct MetadataModel {
     pub environment: Option<String>,
     pub auction_id: Option<u64>,
+    pub run_id: Option<u64>,
     pub gas_price: Option<f64>,
     pub native_token: Option<H160>,
 }
@@ -478,9 +479,7 @@ mod tests {
             },
             metadata: Some(MetadataModel {
                 environment: Some(String::from("Such Meta")),
-                auction_id: None,
-                gas_price: None,
-                native_token: None,
+                ..Default::default()
             }),
         };
 
@@ -579,6 +578,7 @@ mod tests {
           "metadata": {
             "environment": "Such Meta",
             "auction_id": null,
+            "run_id": null,
             "gas_price": null,
             "native_token": null,
           },

--- a/crates/shared/src/price_estimation/http.rs
+++ b/crates/shared/src/price_estimation/http.rs
@@ -161,9 +161,9 @@ impl HttpPriceEstimator {
             amms,
             metadata: Some(MetadataModel {
                 environment: Some(self.network_name.clone()),
-                auction_id: None,
                 gas_price: Some(gas_price.to_f64_lossy()),
                 native_token: Some(self.native_token),
+                ..Default::default()
             }),
         };
 

--- a/crates/solver/src/settlement.rs
+++ b/crates/solver/src/settlement.rs
@@ -330,7 +330,6 @@ impl Settlement {
     // Checks whether the settlement prices do not deviate more than max_settlement_price_deviation from the auction prices on certain pairs.
     pub fn satisfies_price_checks(
         &self,
-        auction_id: u64,
         solver_name: &str,
         external_prices: &ExternalPrices,
         max_settlement_price_deviation: &Ratio<BigInt>,
@@ -387,11 +386,9 @@ impl Settlement {
                     .mul(&external_price_buy_token.mul(&clearing_price_sell_token)));
                 if !price_check_result {
                     tracing::debug!(
-                        "For auction id {:?} there is a price violation on the token-pair {:?} from solver {:?} for the settlement: {:?}",
-                        auction_id,
-                        format!("{}-{}", sell_token, buy_token),
-                        solver_name,
-                        self
+                        token_pair =% format!("{}-{}", sell_token, buy_token),
+                        %solver_name, settlement =? self,
+                        "price violation",
                     );
                 }
                 price_check_result
@@ -586,7 +583,6 @@ pub mod tests {
         ).unwrap();
         // Tolerance exceed on token2
         assert!(!settlement.satisfies_price_checks(
-            0u64,
             "test_solver",
             &external_prices,
             &max_price_deviation,
@@ -594,7 +590,6 @@ pub mod tests {
         ));
         // No tolerance exceeded on token0 and token1
         assert!(settlement.satisfies_price_checks(
-            0u64,
             "test_solver",
             &external_prices,
             &max_price_deviation,
@@ -602,7 +597,6 @@ pub mod tests {
         ));
         // Tolerance exceeded on token2
         assert!(!settlement.satisfies_price_checks(
-            0u64,
             "test_solver",
             &external_prices,
             &max_price_deviation,
@@ -615,7 +609,6 @@ pub mod tests {
         ).unwrap();
         // No tolerance exceeded
         assert!(settlement.satisfies_price_checks(
-            0u64,
             "test_solver",
             &external_prices,
             &max_price_deviation,
@@ -629,7 +622,6 @@ pub mod tests {
         .unwrap();
         // If only 1 token should be checked: trivially satisfies equation
         assert!(settlement.satisfies_price_checks(
-            0u64,
             "test_solver",
             &external_prices,
             &max_price_deviation,
@@ -643,7 +635,6 @@ pub mod tests {
         .unwrap();
         // Can deal with missing token1, tolerance exceeded on token1
         assert!(!settlement.satisfies_price_checks(
-            0u64,
             "test_solver",
             &external_prices,
             &max_price_deviation,
@@ -657,7 +648,6 @@ pub mod tests {
         .unwrap();
         // Can deal with missing token1, tolerance not exceeded
         assert!(settlement.satisfies_price_checks(
-            0u64,
             "test_solver",
             &external_prices,
             &max_price_deviation,
@@ -671,7 +661,6 @@ pub mod tests {
         .unwrap();
         // Token3 from external price is not in settlement, hence, it should accept any price
         assert!(settlement.satisfies_price_checks(
-            0u64,
             "test_solver",
             &external_prices,
             &max_price_deviation,
@@ -679,7 +668,6 @@ pub mod tests {
         ));
         // If no tokens are in the check_list settlements always satisfy the check
         assert!(settlement.satisfies_price_checks(
-            0u64,
             "test_solver",
             &external_prices,
             &max_price_deviation,

--- a/crates/solver/src/solver.rs
+++ b/crates/solver/src/solver.rs
@@ -69,7 +69,7 @@ pub trait Solver: Send + Sync + 'static {
 /// A batch auction for a solver to produce a settlement for.
 #[derive(Clone, Debug)]
 pub struct Auction {
-    /// An ID that identifies the unique solver competition that is exectuting.
+    /// An ID that identifies the unique solver competition that is executing.
     ///
     /// Note that multiple consecutive driver runs may use the same ID if the
     /// previous run was unable to find a settlement.

--- a/crates/solver/src/solver.rs
+++ b/crates/solver/src/solver.rs
@@ -69,12 +69,18 @@ pub trait Solver: Send + Sync + 'static {
 /// A batch auction for a solver to produce a settlement for.
 #[derive(Clone, Debug)]
 pub struct Auction {
-    /// An ID that identifies a batch within a `Driver` instance.
+    /// An ID that identifies the unique solver competition that is exectuting.
+    ///
+    /// Note that multiple consecutive driver runs may use the same ID if the
+    /// previous run was unable to find a settlement.
+    pub id: u64,
+
+    /// An ID that identifies a driver run.
     ///
     /// Note that this ID is not unique across multiple instances of drivers,
     /// in particular it cannot be used to uniquely identify batches across
     /// service restarts.
-    pub id: u64,
+    pub run: u64,
 
     /// The GPv2 orders to match.
     pub orders: Vec<LimitOrder>,
@@ -112,6 +118,7 @@ impl Default for Auction {
         let never = Instant::now() + Duration::from_secs(SECONDS_IN_A_YEAR);
         Self {
             id: Default::default(),
+            run: Default::default(),
             orders: Default::default(),
             liquidity: Default::default(),
             gas_price: Default::default(),


### PR DESCRIPTION
This PR is a follow up to #352

Specifically, this PR changes the `Auction` model to also include the next solver competition ID that will be used. This gives the driver information as to which solver competition it is "fighting" for.

Additionally, the previous `auction_id` used in the driver was renamed to `run_id` and identifies the driver run and **not** the settlement competition. Note that these two things increment separately since a run can end up with no settlements, and the next run will be different (hence, have a different `run_id`) but still be "fighting" for the same solver competition (hence, have the same `auction_id`).

This information is used in a few places:
- Each driver run now includes both the auction ID and run ID in the span
- The HTTP solvers send the auction ID, making it easier for them to match up specific auctions with solver competition results
- The run ID is still used in the instance cache. It is important to not use the acution ID here since subsequent solver runs can have different orders/liquidity but the same auction ID if no settlements were found in the previous runs.

### Test Plan

Run `solver` locally and see that runs and next solver competition being solved for are included in logs and increment independently:
```
2022-07-08T15:19:18.399Z  INFO auction{id=0 run=1}: solver::driver: Successfully submitted settlement settlement_id=1 transaction_hash=0x0000000000000000000000000000000000000000000000000000000000000000
...
2022-07-08T15:19:22.093Z  INFO auction{id=0 run=2}: solver::driver: Successfully submitted settlement settlement_id=0 transaction_hash=0x0000000000000000000000000000000000000000000000000000000000000000
```
