### PR TITLE
Store settlement competition as JSON blobs in database

### DIFF
--- a/crates/database/src/lib.rs
+++ b/crates/database/src/lib.rs
@@ -34,18 +34,11 @@ pub const ALL_TABLES: &[&str] = &[
     "solver_competitions",
 ];
 
-/// The names of all the sequences in the db.
-pub const ALL_SEQUENCES: &[&str] = &["quotes_id_seq", "solver_competitions_id_seq"];
-
 /// Delete all data in the database. Only used by tests.
 #[allow(non_snake_case)]
 pub async fn clear_DANGER_(ex: &mut PgTransaction<'_>) -> sqlx::Result<()> {
     for table in ALL_TABLES {
-        ex.execute(&*format!("TRUNCATE {table};")).await?;
-    }
-    for sequence in ALL_SEQUENCES {
-        ex.execute(&*format!("SELECT setval('{sequence}', 1, false);"))
-            .await?;
+        ex.execute(format!("TRUNCATE {table};").as_str()).await?;
     }
     Ok(())
 }

--- a/crates/database/src/lib.rs
+++ b/crates/database/src/lib.rs
@@ -22,7 +22,7 @@ use sqlx::{Executor, PgPool};
 
 pub type PgTransaction<'a> = sqlx::Transaction<'a, sqlx::Postgres>;
 
-// The names of all tables we use in the db.
+/// The names of all tables we use in the db.
 pub const ALL_TABLES: &[&str] = &[
     "orders",
     "trades",
@@ -31,13 +31,21 @@ pub const ALL_TABLES: &[&str] = &[
     "settlements",
     "presignature_events",
     "order_quotes",
+    "solver_competitions",
 ];
+
+/// The names of all the sequences in the db.
+pub const ALL_SEQUENCES: &[&str] = &["quotes_id_seq", "solver_competitions_id_seq"];
 
 /// Delete all data in the database. Only used by tests.
 #[allow(non_snake_case)]
 pub async fn clear_DANGER_(ex: &mut PgTransaction<'_>) -> sqlx::Result<()> {
     for table in ALL_TABLES {
-        ex.execute(format!("TRUNCATE {};", table).as_str()).await?;
+        ex.execute(&*format!("TRUNCATE {table};")).await?;
+    }
+    for sequence in ALL_SEQUENCES {
+        ex.execute(&*format!("SELECT setval('{sequence}', 1, false);"))
+            .await?;
     }
     Ok(())
 }

--- a/crates/e2e/tests/e2e/services.rs
+++ b/crates/e2e/tests/e2e/services.rs
@@ -12,7 +12,6 @@ use orderbook::{
     orderbook::Orderbook,
     signature_validator::Web3SignatureValidator,
     solvable_orders::SolvableOrdersCache,
-    solver_competition,
 };
 use reqwest::Client;
 use shared::{
@@ -241,7 +240,6 @@ impl OrderbookServices {
             contracts.gp_settlement.address(),
         ));
         let signature_validator = Arc::new(Web3SignatureValidator::new(web3.clone()));
-        let solver_competition = Arc::new(solver_competition::InMemoryStorage::default());
         let solvable_orders_cache = SolvableOrdersCache::new(
             Duration::from_secs(120),
             db.clone(),
@@ -252,7 +250,7 @@ impl OrderbookServices {
             native_price_estimator,
             Arc::new(NoopMetrics),
             signature_validator.clone(),
-            solver_competition.clone(),
+            db.clone(),
         );
         let order_validator = Arc::new(OrderValidator::new(
             Box::new(web3.clone()),
@@ -285,7 +283,7 @@ impl OrderbookServices {
             quotes,
             API_HOST[7..].parse().expect("Couldn't parse API address"),
             pending(),
-            solver_competition,
+            db.clone(),
             None,
         );
 

--- a/crates/model/src/solver_competition.rs
+++ b/crates/model/src/solver_competition.rs
@@ -7,7 +7,7 @@ use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
 use std::collections::BTreeMap;
 
-pub type SolverCompetitionId = u64;
+pub type SolverCompetitionId = i64;
 
 #[derive(Clone, Debug, Default, Deserialize, Serialize, PartialEq)]
 #[serde(rename_all = "camelCase")]

--- a/crates/orderbook/src/api/get_solver_competition.rs
+++ b/crates/orderbook/src/api/get_solver_competition.rs
@@ -1,12 +1,13 @@
 use crate::solver_competition::{LoadSolverCompetitionError, SolverCompetitionStoring};
 use anyhow::Result;
+use model::solver_competition::SolverCompetitionId;
 use reqwest::StatusCode;
 use shared::api::{convert_json_response, IntoWarpReply};
 use std::{convert::Infallible, sync::Arc};
 use warp::{reply::with_status, Filter, Rejection};
 
-fn request() -> impl Filter<Extract = (u64,), Error = Rejection> + Clone {
-    warp::path!("solver_competition" / u64).and(warp::get())
+fn request() -> impl Filter<Extract = (SolverCompetitionId,), Error = Rejection> + Clone {
+    warp::path!("solver_competition" / SolverCompetitionId).and(warp::get())
 }
 
 pub fn get(

--- a/crates/orderbook/src/database.rs
+++ b/crates/orderbook/src/database.rs
@@ -1,6 +1,7 @@
 pub mod events;
 pub mod orders;
 pub mod quotes;
+pub mod solver_competition;
 pub mod trades;
 
 use anyhow::Result;

--- a/crates/orderbook/src/database/solver_competition.rs
+++ b/crates/orderbook/src/database/solver_competition.rs
@@ -1,0 +1,127 @@
+use super::Postgres;
+use crate::solver_competition::{LoadSolverCompetitionError, SolverCompetitionStoring};
+use anyhow::{Context, Result};
+use model::solver_competition::{SolverCompetition, SolverCompetitionId};
+use sqlx::types::Json;
+
+#[async_trait::async_trait]
+impl SolverCompetitionStoring for Postgres {
+    async fn save(&self, data: SolverCompetition) -> Result<SolverCompetitionId> {
+        let _timer = super::Metrics::get()
+            .database_queries
+            .with_label_values(&["save_solver_competition"])
+            .start_timer();
+
+        const QUERY: &str = r#"
+            INSERT INTO solver_competitions (json)
+            VALUES ($1)
+            RETURNING id
+        ;"#;
+
+        let (id,) = sqlx::query_as(QUERY)
+            .bind(Json(data))
+            .fetch_one(&self.pool)
+            .await
+            .context("failed to insert solver competition")?;
+
+        Ok(id)
+    }
+
+    async fn load(
+        &self,
+        id: SolverCompetitionId,
+    ) -> Result<SolverCompetition, LoadSolverCompetitionError> {
+        let _timer = super::Metrics::get()
+            .database_queries
+            .with_label_values(&["load_solver_competition"])
+            .start_timer();
+
+        const QUERY: &str = r#"
+            SELECT json
+            FROM solver_competitions
+            WHERE id = $1
+        ;"#;
+
+        let (solver_competition,): (Json<SolverCompetition>,) = sqlx::query_as(QUERY)
+            .bind(id)
+            .fetch_optional(&self.pool)
+            .await
+            .context("failed to get solver competition by ID")?
+            .ok_or(LoadSolverCompetitionError::NotFound(id))?;
+
+        Ok(solver_competition.0)
+    }
+
+    async fn next_solver_competition(&self) -> Result<SolverCompetitionId> {
+        let _timer = super::Metrics::get()
+            .database_queries
+            .with_label_values(&["next_solver_competition"])
+            .start_timer();
+
+        // The sequence we created for the serial `id` column can be queried for
+        // the next value it will produce [0]. Note that the exact semenatics of
+        // the sequence's next value depend on its `is_called` flag [1].
+        //
+        // [0]: <https://www.postgresql.org/docs/current/sql-createsequence.html>
+        // [1]: <https://www.postgresql.org/docs/14/functions-sequence.html>
+        const QUERY: &str = r#"
+            SELECT
+                CASE
+                    WHEN is_called THEN last_value + 1
+                    ELSE last_value
+                END AS next
+            FROM solver_competitions_id_seq
+        ;"#;
+
+        let (id,): (SolverCompetitionId,) = sqlx::query_as(QUERY)
+            .fetch_one(&self.pool)
+            .await
+            .context("failed to get next solver competition ID")?;
+
+        Ok(id)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ethcontract::H256;
+
+    #[tokio::test]
+    #[ignore]
+    async fn postgres_save_and_load_solver_competition_by_id() {
+        let db = Postgres::new("postgresql://").unwrap();
+        database::clear_DANGER(&db.pool).await.unwrap();
+
+        let model = SolverCompetition {
+            gas_price: 1.,
+            auction_start_block: 2,
+            liquidity_collected_block: 3,
+            competition_simulation_block: 4,
+            transaction_hash: Some(H256([5; 32])),
+            auction: Default::default(),
+            solutions: Default::default(),
+        };
+
+        let id = db.save(model.clone()).await.unwrap();
+        let loaded = db.load(id).await.unwrap();
+
+        assert_eq!(model, loaded);
+    }
+
+    #[tokio::test]
+    #[ignore]
+    async fn postgres_solver_competition_id_sequence() {
+        let db = Postgres::new("postgresql://").unwrap();
+        database::clear_DANGER(&db.pool).await.unwrap();
+
+        let next_id = db.next_solver_competition().await.unwrap();
+        assert_eq!(next_id, 1);
+
+        let id = db.save(Default::default()).await.unwrap();
+        assert_eq!(id, 1);
+
+        let next_id = db.next_solver_competition().await.unwrap();
+        assert_eq!(next_id, 2);
+    }
+}

--- a/crates/orderbook/src/database/solver_competition.rs
+++ b/crates/orderbook/src/database/solver_competition.rs
@@ -116,12 +116,13 @@ mod tests {
         database::clear_DANGER(&db.pool).await.unwrap();
 
         let next_id = db.next_solver_competition().await.unwrap();
-        assert_eq!(next_id, 1);
+        // still the same
+        assert_eq!(db.next_solver_competition().await.unwrap(), next_id);
 
         let id = db.save(Default::default()).await.unwrap();
-        assert_eq!(id, 1);
+        assert_eq!(id, next_id);
 
-        let next_id = db.next_solver_competition().await.unwrap();
-        assert_eq!(next_id, 2);
+        let next_id_ = db.next_solver_competition().await.unwrap();
+        assert_eq!(next_id_, next_id + 1);
     }
 }

--- a/crates/orderbook/src/main.rs
+++ b/crates/orderbook/src/main.rs
@@ -20,7 +20,7 @@ use orderbook::{
     serve_api,
     signature_validator::Web3SignatureValidator,
     solvable_orders::SolvableOrdersCache,
-    solver_competition, verify_deployed_contract_constants,
+    verify_deployed_contract_constants,
 };
 use primitive_types::U256;
 use shared::{
@@ -521,7 +521,6 @@ async fn main() {
     let optimal_quoter = create_quoter(price_estimator.clone(), database.clone());
     let fast_quoter = create_quoter(fast_price_estimator.clone(), Arc::new(Forget));
 
-    let solver_competition = Arc::new(solver_competition::InMemoryStorage::default());
     let solvable_orders_cache = SolvableOrdersCache::new(
         args.min_order_validity_period,
         database.clone(),
@@ -532,7 +531,7 @@ async fn main() {
         native_price_estimator.clone(),
         metrics.clone(),
         signature_validator.clone(),
-        solver_competition.clone(),
+        database.clone(),
     );
     let block = current_block_stream.borrow().number.unwrap().as_u64();
     solvable_orders_cache
@@ -586,7 +585,7 @@ async fn main() {
         async {
             let _ = shutdown_receiver.await;
         },
-        solver_competition,
+        database.clone(),
         args.shared.solver_competition_auth,
     );
     let maintenance_task =

--- a/crates/orderbook/src/solver_competition.rs
+++ b/crates/orderbook/src/solver_competition.rs
@@ -4,7 +4,7 @@ use anyhow::Result;
 use cached::{Cached, SizedCache};
 use model::solver_competition::{SolverCompetition, SolverCompetitionId};
 use std::sync::{
-    atomic::{AtomicU64, Ordering},
+    atomic::{AtomicI64, Ordering},
     Mutex,
 };
 use thiserror::Error;
@@ -45,7 +45,7 @@ pub enum LoadSolverCompetitionError {
 const CACHE_SIZE: usize = 500;
 
 pub struct InMemoryStorage {
-    last_id: AtomicU64,
+    last_id: AtomicI64,
     cache: Mutex<SizedCache<SolverCompetitionId, SolverCompetition>>,
 }
 

--- a/crates/shared/src/http_solver.rs
+++ b/crates/shared/src/http_solver.rs
@@ -1,9 +1,10 @@
+use crate::http_client::response_body_with_size_limit;
+use ::model::solver_competition::SolverCompetitionId;
 use anyhow::{anyhow, ensure, Context, Result};
 use reqwest::header::{self, HeaderValue};
 use reqwest::{Client, Url};
 use std::time::Duration;
 
-use crate::http_client::response_body_with_size_limit;
 pub mod gas_model;
 pub mod model;
 
@@ -102,7 +103,7 @@ impl HttpSolverApi for DefaultHttpSolverApi {
         let mut url = self.base.join("solve")?;
 
         let maybe_auction_id = model.metadata.as_ref().and_then(|data| data.auction_id);
-        let instance_name = self.generate_instance_name(maybe_auction_id.unwrap_or(0u64));
+        let instance_name = self.generate_instance_name(maybe_auction_id.unwrap_or(0));
         tracing::debug!("http solver instance name is {}", instance_name);
 
         url.query_pairs_mut()
@@ -181,7 +182,7 @@ impl HttpSolverApi for DefaultHttpSolverApi {
 }
 
 impl DefaultHttpSolverApi {
-    fn generate_instance_name(&self, auction_id: u64) -> String {
+    fn generate_instance_name(&self, auction_id: SolverCompetitionId) -> String {
         let now = chrono::Utc::now();
         format!(
             "{}_{}_{}_{}",

--- a/crates/shared/src/http_solver/model.rs
+++ b/crates/shared/src/http_solver/model.rs
@@ -2,6 +2,7 @@ use derivative::Derivative;
 use ethcontract::H160;
 use model::{
     ratio_as_decimal,
+    solver_competition::SolverCompetitionId,
     u256_decimal::{self, DecimalU256},
 };
 use num::BigRational;
@@ -205,7 +206,7 @@ impl SettledBatchAuctionModel {
 #[derive(Clone, Debug, Serialize, Default)]
 pub struct MetadataModel {
     pub environment: Option<String>,
-    pub auction_id: Option<u64>,
+    pub auction_id: Option<SolverCompetitionId>,
     pub run_id: Option<u64>,
     pub gas_price: Option<f64>,
     pub native_token: Option<H160>,

--- a/crates/solver/src/solver.rs
+++ b/crates/solver/src/solver.rs
@@ -12,6 +12,7 @@ use contracts::{BalancerV2Vault, GPv2Settlement};
 use ethcontract::errors::ExecutionError;
 use ethcontract::{Account, PrivateKey, H160, U256};
 use http_solver::{buffers::BufferRetriever, HttpSolver};
+use model::solver_competition::SolverCompetitionId;
 use naive_solver::NaiveSolver;
 use num::BigRational;
 use oneinch_solver::OneInchSolver;
@@ -73,7 +74,7 @@ pub struct Auction {
     ///
     /// Note that multiple consecutive driver runs may use the same ID if the
     /// previous run was unable to find a settlement.
-    pub id: u64,
+    pub id: SolverCompetitionId,
 
     /// An ID that identifies a driver run.
     ///

--- a/crates/solver/src/solver/http_solver.rs
+++ b/crates/solver/src/solver/http_solver.rs
@@ -13,7 +13,7 @@ use buffers::{BufferRetrievalError, BufferRetrieving};
 use ethcontract::{errors::ExecutionError, Account, U256};
 use futures::{join, lock::Mutex};
 use maplit::{btreemap, hashset};
-use model::order::OrderKind;
+use model::{order::OrderKind, solver_competition::SolverCompetitionId};
 use num::{BigInt, BigRational};
 use primitive_types::H160;
 use shared::http_solver::{DefaultHttpSolverApi, HttpSolverApi};
@@ -86,7 +86,7 @@ impl HttpSolver {
 
     async fn prepare_model(
         &self,
-        auction_id: u64,
+        auction_id: SolverCompetitionId,
         run_id: u64,
         orders: Vec<LimitOrder>,
         liquidity: Vec<Liquidity>,
@@ -548,14 +548,7 @@ mod tests {
             settlement_handling: CapturingSettlementHandler::arc(),
         })];
         let (model, _context) = solver
-            .prepare_model(
-                0u64,
-                1u64,
-                limit_orders,
-                liquidity,
-                gas_price,
-                Default::default(),
-            )
+            .prepare_model(0, 1, limit_orders, liquidity, gas_price, Default::default())
             .await
             .unwrap();
         let settled = solver

--- a/database/sql/V024__store_settlement_competition_blobs.sql
+++ b/database/sql/V024__store_settlement_competition_blobs.sql
@@ -1,0 +1,7 @@
+-- Create a new table for persisting solver competition blobs.
+
+CREATE TABLE solver_competitions
+(
+    id bigserial PRIMARY KEY,
+    json jsonb
+);


### PR DESCRIPTION
This PR stores solver competitions as JSON data-blobs in the database.

This is a temporary measure to start permanently storing competition information in the database. In the long run the `autopilot` will be responsible for storing solver competition information (including things such as the solver proposals and execution attestations for each `driver`+solver combo). For now, because the format for storing solver competition information is very unclear, just store it as a JSON blob.

### Test Plan

CI uses database for end to end tests to exercise new code.

Also, running end to end tests locally:
```
% cargo test -p e2e -- --ignored
...
2022-07-08T17:37:27.616Z DEBUG auction{id=1 run=0}: solver::driver: starting single run
...
2022-07-08T17:37:29.140Z DEBUG auction{id=2 run=1}: solver::driver: starting single run
...
```

We notice that the ID is incrementing when a settlement gets executed. Additionally, the solver competition is being stored in Postgres:

```
# SELECT json->'transactionHash' AS transaction_hash FROM solver_competitions;
                           transaction_hash                           
----------------------------------------------------------------------
 "0xd6aa163a6875cabebcb27b5e5fb9c73d574c326a3300b7f18ad5ce5b6ed9b3fa"
(1 row)
```
