### PR TITLE
Changing the quote-life-time depending on the order signature

### DIFF
--- a/crates/e2e/tests/e2e/services.rs
+++ b/crates/e2e/tests/e2e/services.rs
@@ -233,6 +233,8 @@ impl OrderbookServices {
                 ..Default::default()
             }),
             db.clone(),
+            60i64,
+            60i64,
         ));
         let balance_fetcher = Arc::new(Web3BalanceFetcher::new(
             web3.clone(),

--- a/crates/e2e/tests/e2e/services.rs
+++ b/crates/e2e/tests/e2e/services.rs
@@ -233,8 +233,8 @@ impl OrderbookServices {
                 ..Default::default()
             }),
             db.clone(),
-            60i64,
-            60i64,
+            Duration::from_secs(60u64),
+            Duration::from_secs(60u64),
         ));
         let balance_fetcher = Arc::new(Web3BalanceFetcher::new(
             web3.clone(),

--- a/crates/orderbook/src/arguments.rs
+++ b/crates/orderbook/src/arguments.rs
@@ -45,12 +45,22 @@ pub struct Arguments {
     pub max_order_validity_period: Duration,
 
     /// The time period an EIP1271-quote request is valid.
-    #[clap(long, env, default_value = "600")]
-    pub eip1271_quote_validity_seconds: i64,
+    #[clap(
+        long,
+        env,
+        default_value = "600",
+        parse(try_from_str = shared::arguments::duration_from_seconds),
+    )]
+    pub eip1271_quote_validity_seconds: Duration,
 
     /// The time period an PRESIGN-quote request is valid.
-    #[clap(long, env, default_value = "86400")]
-    pub presign_quote_validity_seconds: i64,
+    #[clap(
+        long,
+        env,
+        default_value = "86400",
+        parse(try_from_str = shared::arguments::duration_from_seconds),
+    )]
+    pub presign_quote_validity_seconds: Duration,
 
     /// Don't use the trace_callMany api that only some nodes support to check whether a token
     /// should be denied.

--- a/crates/orderbook/src/arguments.rs
+++ b/crates/orderbook/src/arguments.rs
@@ -44,6 +44,14 @@ pub struct Arguments {
     )]
     pub max_order_validity_period: Duration,
 
+    /// The time period an EIP1271-quote requests is valid.
+    #[clap(long, env, default_value = "600")]
+    pub eip1271_quote_validity_seconds: i64,
+
+    /// The time period an PRESIGN-quote requests is valid.
+    #[clap(long, env, default_value = "86400")]
+    pub presign_quote_validity_seconds: i64,
+
     /// Don't use the trace_callMany api that only some nodes support to check whether a token
     /// should be denied.
     /// Note that if a node does not support the api we still use the less accurate call api.
@@ -245,6 +253,16 @@ impl std::fmt::Display for Arguments {
             f,
             "max_order_validity_period: {:?}",
             self.max_order_validity_period
+        )?;
+        writeln!(
+            f,
+            "eip1271_quote_validity_second: {:?}",
+            self.eip1271_quote_validity_seconds
+        )?;
+        writeln!(
+            f,
+            "presign_quote_validity_second: {:?}",
+            self.presign_quote_validity_seconds
         )?;
         writeln!(f, "skip_trace_api: {}", self.skip_trace_api)?;
         writeln!(

--- a/crates/orderbook/src/arguments.rs
+++ b/crates/orderbook/src/arguments.rs
@@ -44,11 +44,11 @@ pub struct Arguments {
     )]
     pub max_order_validity_period: Duration,
 
-    /// The time period an EIP1271-quote requests is valid.
+    /// The time period an EIP1271-quote request is valid.
     #[clap(long, env, default_value = "600")]
     pub eip1271_quote_validity_seconds: i64,
 
-    /// The time period an PRESIGN-quote requests is valid.
+    /// The time period an PRESIGN-quote request is valid.
     #[clap(long, env, default_value = "86400")]
     pub presign_quote_validity_seconds: i64,
 

--- a/crates/orderbook/src/main.rs
+++ b/crates/orderbook/src/main.rs
@@ -507,6 +507,8 @@ async fn main() {
             gas_price_estimator.clone(),
             fee_subsidy.clone(),
             storage,
+            args.eip1271_quote_validity_seconds,
+            args.presign_quote_validity_seconds,
         ))
     };
     let optimal_quoter = create_quoter(price_estimator.clone(), database.clone());

--- a/crates/orderbook/src/order_quoting.rs
+++ b/crates/orderbook/src/order_quoting.rs
@@ -106,7 +106,7 @@ impl From<PartialValidationError> for OrderQuoteError {
 }
 
 /// Order parameters for quoting.
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, Default, PartialEq)]
 pub struct QuoteParameters {
     pub sell_token: H160,
     pub buy_token: H160,
@@ -114,19 +114,6 @@ pub struct QuoteParameters {
     pub from: H160,
     pub app_data: AppId,
     pub signing_scheme: SigningScheme,
-}
-
-impl Default for QuoteParameters {
-    fn default() -> Self {
-        QuoteParameters {
-            sell_token: Default::default(),
-            buy_token: Default::default(),
-            side: Default::default(),
-            from: Default::default(),
-            app_data: Default::default(),
-            signing_scheme: SigningScheme::Eip712,
-        }
-    }
 }
 
 impl QuoteParameters {

--- a/crates/orderbook/src/order_quoting.rs
+++ b/crates/orderbook/src/order_quoting.rs
@@ -14,6 +14,7 @@ use model::{
         OrderQuote, OrderQuoteRequest, OrderQuoteResponse, OrderQuoteSide, PriceQuality, QuoteId,
         SellAmount,
     },
+    signature::SigningScheme,
 };
 use shared::price_estimation::{
     self,
@@ -104,13 +105,27 @@ impl From<PartialValidationError> for OrderQuoteError {
 }
 
 /// Order parameters for quoting.
-#[derive(Clone, Debug, Default, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct QuoteParameters {
     pub sell_token: H160,
     pub buy_token: H160,
     pub side: OrderQuoteSide,
     pub from: H160,
     pub app_data: AppId,
+    pub signing_scheme: SigningScheme,
+}
+
+impl Default for QuoteParameters {
+    fn default() -> Self {
+        QuoteParameters {
+            sell_token: Default::default(),
+            buy_token: Default::default(),
+            side: Default::default(),
+            from: Default::default(),
+            app_data: Default::default(),
+            signing_scheme: SigningScheme::Eip712,
+        }
+    }
 }
 
 impl QuoteParameters {
@@ -379,8 +394,8 @@ impl Now for DateTime<Utc> {
     }
 }
 
-/// How long a quote remains valid for.
-const QUOTE_VALIDITY_SECONDS: i64 = 60;
+/// Standard validity for a quote: Quotes are stored only as long as their validity is.
+const STANDARD_QUOTE_VALIDITY_SECONDS: i64 = 60;
 
 /// An order quoter implementation that relies
 pub struct OrderQuoter {
@@ -390,6 +405,8 @@ pub struct OrderQuoter {
     fee_subsidy: Arc<dyn FeeSubsidizing>,
     storage: Arc<dyn QuoteStoring>,
     now: Arc<dyn Now>,
+    eip1271_quote_validity_seconds: i64,
+    presign_quote_validity_seconds: i64,
 }
 
 impl OrderQuoter {
@@ -399,6 +416,8 @@ impl OrderQuoter {
         gas_estimator: Arc<dyn GasPriceEstimating>,
         fee_subsidy: Arc<dyn FeeSubsidizing>,
         storage: Arc<dyn QuoteStoring>,
+        eip1271_quote_validity_seconds: i64,
+        presign_quote_validity_seconds: i64,
     ) -> Self {
         Self {
             price_estimator,
@@ -407,6 +426,8 @@ impl OrderQuoter {
             fee_subsidy,
             storage,
             now: Arc::new(Utc::now),
+            eip1271_quote_validity_seconds,
+            presign_quote_validity_seconds,
         }
     }
 
@@ -414,7 +435,15 @@ impl OrderQuoter {
         &self,
         parameters: &QuoteParameters,
     ) -> Result<QuoteData, CalculateQuoteError> {
-        let expiration = self.now.now() + chrono::Duration::seconds(QUOTE_VALIDITY_SECONDS);
+        let expiration = match parameters.signing_scheme {
+            SigningScheme::Eip1271 => {
+                self.now.now() + chrono::Duration::seconds(self.eip1271_quote_validity_seconds)
+            }
+            SigningScheme::PreSign => {
+                self.now.now() + chrono::Duration::seconds(self.presign_quote_validity_seconds)
+            }
+            _ => self.now.now() + chrono::Duration::seconds(STANDARD_QUOTE_VALIDITY_SECONDS),
+        };
 
         let trade_query = parameters.to_price_query();
         let (gas_estimate, trade_estimate, sell_token_price, _) = futures::try_join!(
@@ -598,6 +627,7 @@ impl From<&OrderQuoteRequest> for QuoteParameters {
             side: request.side,
             from: request.from,
             app_data: request.app_data,
+            signing_scheme: request.signing_scheme,
         }
     }
 }
@@ -654,6 +684,7 @@ mod tests {
             },
             from: H160([3; 20]),
             app_data: AppId([4; 32]),
+            signing_scheme: SigningScheme::Eip712,
         };
         let gas_price = GasPrice1559 {
             base_fee_per_gas: 1.5,
@@ -713,7 +744,7 @@ mod tests {
                     sell_token_price: 0.2,
                 },
                 kind: OrderKind::Sell,
-                expiration: now + chrono::Duration::seconds(QUOTE_VALIDITY_SECONDS),
+                expiration: now + chrono::Duration::seconds(STANDARD_QUOTE_VALIDITY_SECONDS),
             }))
             .returning(|_| Ok(Some(1337)));
 
@@ -724,6 +755,8 @@ mod tests {
             fee_subsidy: Arc::new(Subsidy::default()),
             storage: Arc::new(storage),
             now: Arc::new(now),
+            eip1271_quote_validity_seconds: 60i64,
+            presign_quote_validity_seconds: 60i64,
         };
 
         assert_eq!(
@@ -741,7 +774,7 @@ mod tests {
                         sell_token_price: 0.2,
                     },
                     kind: OrderKind::Sell,
-                    expiration: now + chrono::Duration::seconds(QUOTE_VALIDITY_SECONDS),
+                    expiration: now + chrono::Duration::seconds(STANDARD_QUOTE_VALIDITY_SECONDS),
                 },
                 sell_amount: 70.into(),
                 buy_amount: 29.into(),
@@ -761,6 +794,7 @@ mod tests {
             },
             from: H160([3; 20]),
             app_data: AppId([4; 32]),
+            signing_scheme: SigningScheme::Eip712,
         };
         let gas_price = GasPrice1559 {
             base_fee_per_gas: 1.5,
@@ -820,7 +854,7 @@ mod tests {
                     sell_token_price: 0.2,
                 },
                 kind: OrderKind::Sell,
-                expiration: now + chrono::Duration::seconds(QUOTE_VALIDITY_SECONDS),
+                expiration: now + chrono::Duration::seconds(STANDARD_QUOTE_VALIDITY_SECONDS),
             }))
             .returning(|_| Ok(Some(1337)));
 
@@ -834,6 +868,8 @@ mod tests {
             }),
             storage: Arc::new(storage),
             now: Arc::new(now),
+            eip1271_quote_validity_seconds: 60i64,
+            presign_quote_validity_seconds: 60i64,
         };
 
         assert_eq!(
@@ -851,7 +887,7 @@ mod tests {
                         sell_token_price: 0.2,
                     },
                     kind: OrderKind::Sell,
-                    expiration: now + chrono::Duration::seconds(QUOTE_VALIDITY_SECONDS),
+                    expiration: now + chrono::Duration::seconds(STANDARD_QUOTE_VALIDITY_SECONDS),
                 },
                 sell_amount: 100.into(),
                 buy_amount: 42.into(),
@@ -871,6 +907,7 @@ mod tests {
             },
             from: H160([3; 20]),
             app_data: AppId([4; 32]),
+            signing_scheme: SigningScheme::Eip712,
         };
         let gas_price = GasPrice1559 {
             base_fee_per_gas: 1.5,
@@ -930,7 +967,7 @@ mod tests {
                     sell_token_price: 0.2,
                 },
                 kind: OrderKind::Buy,
-                expiration: now + chrono::Duration::seconds(QUOTE_VALIDITY_SECONDS),
+                expiration: now + chrono::Duration::seconds(STANDARD_QUOTE_VALIDITY_SECONDS),
             }))
             .returning(|_| Ok(Some(1337)));
 
@@ -945,6 +982,8 @@ mod tests {
             }),
             storage: Arc::new(storage),
             now: Arc::new(now),
+            eip1271_quote_validity_seconds: 60i64,
+            presign_quote_validity_seconds: 60i64,
         };
 
         assert_eq!(
@@ -962,7 +1001,7 @@ mod tests {
                         sell_token_price: 0.2,
                     },
                     kind: OrderKind::Buy,
-                    expiration: now + chrono::Duration::seconds(QUOTE_VALIDITY_SECONDS),
+                    expiration: now + chrono::Duration::seconds(STANDARD_QUOTE_VALIDITY_SECONDS),
                 },
                 sell_amount: 100.into(),
                 buy_amount: 42.into(),
@@ -981,6 +1020,7 @@ mod tests {
             },
             from: H160([3; 20]),
             app_data: AppId([4; 32]),
+            signing_scheme: SigningScheme::Eip712,
         };
         let gas_price = GasPrice1559 {
             base_fee_per_gas: 1.,
@@ -1023,6 +1063,8 @@ mod tests {
             fee_subsidy: Arc::new(Subsidy::default()),
             storage: Arc::new(MockQuoteStoring::new()),
             now: Arc::new(Utc::now),
+            eip1271_quote_validity_seconds: 60i64,
+            presign_quote_validity_seconds: 60i64,
         };
 
         assert!(matches!(
@@ -1124,6 +1166,8 @@ mod tests {
             fee_subsidy: Arc::new(Subsidy::default()),
             storage: Arc::new(Forget),
             now: Arc::new(now),
+            eip1271_quote_validity_seconds: 60i64,
+            presign_quote_validity_seconds: 60i64,
         };
 
         let quote = quoter.calculate_quote(Default::default()).await.unwrap();
@@ -1172,6 +1216,8 @@ mod tests {
             }),
             storage: Arc::new(storage),
             now: Arc::new(now),
+            eip1271_quote_validity_seconds: 60i64,
+            presign_quote_validity_seconds: 60i64,
         };
 
         assert_eq!(
@@ -1244,6 +1290,8 @@ mod tests {
             fee_subsidy: Arc::new(Subsidy::default()),
             storage: Arc::new(storage),
             now: Arc::new(now),
+            eip1271_quote_validity_seconds: 60i64,
+            presign_quote_validity_seconds: 60i64,
         };
 
         assert_eq!(
@@ -1314,6 +1362,8 @@ mod tests {
             fee_subsidy: Arc::new(Subsidy::default()),
             storage: Arc::new(storage),
             now: Arc::new(now),
+            eip1271_quote_validity_seconds: 60i64,
+            presign_quote_validity_seconds: 60i64,
         };
 
         assert_eq!(
@@ -1380,6 +1430,8 @@ mod tests {
             fee_subsidy: Arc::new(Subsidy::default()),
             storage: Arc::new(storage),
             now: Arc::new(now),
+            eip1271_quote_validity_seconds: 60i64,
+            presign_quote_validity_seconds: 60i64,
         };
 
         assert!(matches!(
@@ -1408,6 +1460,8 @@ mod tests {
             fee_subsidy: Arc::new(Subsidy::default()),
             storage: Arc::new(storage),
             now: Arc::new(Utc::now),
+            eip1271_quote_validity_seconds: 60i64,
+            presign_quote_validity_seconds: 60i64,
         };
 
         assert!(matches!(

--- a/crates/orderbook/src/order_validation.rs
+++ b/crates/orderbook/src/order_validation.rs
@@ -547,6 +547,7 @@ async fn get_quote_and_check_fee(
                 },
                 from: owner,
                 app_data: order.data.app_data,
+                signing_scheme: order.signature.scheme(),
             };
             let quote = quoter.calculate_quote(parameters).await?;
 
@@ -1437,6 +1438,7 @@ mod tests {
                 },
                 from,
                 app_data: AppId([5; 32]),
+                signing_scheme: SigningScheme::Eip712,
             }))
             .returning(|_| {
                 Ok(Quote {


### PR DESCRIPTION
Nick and I discussed, that we want to store the order quotes longer for EIP1271 orders and presign orders (cf. [here](https://cowservices.slack.com/archives/C036BL4AANP/p1657298413114719?thread_ts=1657018904.390399&cid=C036BL4AANP)) in order to allow order placing from just ETH-events issues by a contract.

For EIP1271 orders, the orders might get placed via the API or via the mining a real transaction emitting events that we will parse and thereby place the order in the database. If the orders are mined, the time between quote request and mining is much longer than the usual 1 minute timespan and in order to make the link at event-parsing time, we need to store the orders longer in the database.
Also, the pre_sign orders might be multi-sig transactions and hence have even bigger time delays. Hence, we allow even longer waiting time periods. 

### Test Plan

Unit tests
