### PR TITLE
Fix endless recursion when cloning PriceEstimationError

### DIFF
--- a/crates/shared/src/price_estimation.rs
+++ b/crates/shared/src/price_estimation.rs
@@ -77,7 +77,7 @@ impl Clone for PriceEstimationError {
             Self::NoLiquidity => Self::NoLiquidity,
             Self::ZeroAmount => Self::ZeroAmount,
             Self::UnsupportedOrderType => Self::UnsupportedOrderType,
-            err @ Self::RateLimited(_) => err.clone(),
+            Self::RateLimited(err) => Self::RateLimited(err.clone()),
             Self::Other(err) => Self::Other(crate::clone_anyhow_error(err)),
         }
     }


### PR DESCRIPTION
The old implementation of `PriceEstimationError::clone()` would recurse endlessly when it contained the `RateLimited` error type.
This problem was only triggered in the Baseline estimator. That's the only estimator which is able to estimate multiple prices queries with a single request. That's why it's the only one which needed to clone the single original error into the result of multiple price estimation requests.
This [code example](https://play.rust-lang.org/?version=nightly&mode=release&edition=2021&gist=97080f772cdcd3305ef391fb39b07004) shows the problem nicely.

The issue results in different errors for debug and release builds. In debug builds you will get a stack overflow and on release builds the code gets optimized to a busy loop. This busy loop caused the baseline estimator to never yield its thread and pegged the CPU at 100%.

Now instead of `PriceEstimationError::clone()` calling `PriceEstimationError::clone()` endlessly for the `RateLimited` case it calls `RateLimiterError::clone()` on the contained error. Using the wrong `clone()` method was definitely not my proudest moment. 🙈 

### Test Plan
manual test
