### PR TITLE
Balancer Stable Math: calculate_invariant_v2

### DIFF
--- a/crates/shared/src/sources/balancer_v2/swap/math.rs
+++ b/crates/shared/src/sources/balancer_v2/swap/math.rs
@@ -41,39 +41,9 @@ impl BalU256 for U256 {
     }
 }
 
-pub fn rounded_div(numerator: U256, denominator: U256, round_up: bool) -> Result<U256, Error> {
-    if round_up {
-        numerator.bdiv_up(denominator)
-    } else {
-        numerator.bdiv_down(denominator)
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn rounded_div_ok() {
-        assert_eq!(rounded_div(1.into(), 2.into(), true).unwrap(), 1.into());
-        assert_eq!(rounded_div(1.into(), 2.into(), false).unwrap(), 0.into());
-    }
-
-    #[test]
-    fn rounded_div_err() {
-        assert_eq!(
-            rounded_div(1.into(), 0.into(), true)
-                .unwrap_err()
-                .to_string(),
-            "BAL#004: ZeroDivision"
-        );
-        assert_eq!(
-            rounded_div(1.into(), 0.into(), false)
-                .unwrap_err()
-                .to_string(),
-            "BAL#004: ZeroDivision"
-        );
-    }
 
     #[test]
     fn bmul_tests() {

--- a/crates/shared/src/sources/balancer_v2/swap/stable_math.rs
+++ b/crates/shared/src/sources/balancer_v2/swap/stable_math.rs
@@ -5,7 +5,6 @@
 //! https://github.com/balancer-labs/balancer-v2-monorepo/blob/stable-deployment/pkg/pool-stable/contracts/StableMath.sol
 
 use super::error::Error;
-use crate::sources::balancer_v2::swap::math::rounded_div;
 use crate::sources::balancer_v2::swap::{fixed_point::Bfp, math::BalU256};
 use ethcontract::U256;
 use lazy_static::lazy_static;
@@ -14,12 +13,8 @@ lazy_static! {
     static ref AMP_PRECISION: U256 = U256::from(1000);
 }
 
-/// https://github.com/balancer-labs/balancer-v2-monorepo/blob/9eb7e44a4e9ebbadfe3c6242a086118298cadc9f/pkg/pool-stable-phantom/contracts/StableMath.sol#L57-L85
-fn calculate_invariant(
-    amplification_parameter: U256,
-    balances: &[Bfp],
-    round_up: bool,
-) -> Result<U256, Error> {
+/// https://github.com/balancer-labs/balancer-v2-monorepo/blob/9eb7e44a4e9ebbadfe3c6242a086118298cadc9f/pkg/pool-stable-phantom/contracts/StableMath.sol#L57-L119
+fn calculate_invariant(amplification_parameter: U256, balances: &[Bfp]) -> Result<U256, Error> {
     let mut sum = U256::zero();
     let num_tokens_usize = balances.len();
     for balance_i in balances.iter() {
@@ -29,80 +24,9 @@ fn calculate_invariant(
         return Ok(sum);
     }
 
-    let invariant = sum;
+    let mut invariant = sum;
     let num_tokens = U256::from(num_tokens_usize);
     let amp_times_total = amplification_parameter.bmul(num_tokens)?;
-    if round_up {
-        convergence_loop_v1(invariant, amp_times_total, balances, num_tokens, sum)
-    } else {
-        convergence_loop_v2(invariant, amp_times_total, balances, num_tokens, sum)
-    }
-}
-
-/// https://github.com/balancer-labs/balancer-v2-monorepo/blob/ad1442113b26ec22081c2047e2ec95355a7f12ba/pkg/pool-stable/contracts/StableMath.sol#L78-L104
-fn convergence_loop_v1(
-    mut invariant: U256,
-    amp_times_total: U256,
-    balances: &[Bfp],
-    num_tokens: U256,
-    sum: U256,
-) -> Result<U256, Error> {
-    for _ in 0..255 {
-        // If balances were empty, we would have returned on sum.is_zero()
-        let mut p_d = balances[0].as_uint256().bmul(num_tokens)?;
-        for balance in &balances[1..] {
-            // P_D = Math.div(Math.mul(Math.mul(P_D, balances[j]), numTokens), invariant, roundUp);
-            p_d = rounded_div(
-                p_d.bmul(balance.as_uint256())?.bmul(num_tokens)?,
-                invariant,
-                true,
-            )?
-        }
-        let prev_invariant = invariant;
-
-        invariant = rounded_div(
-            // invariant = Math.div(
-            //     Math.mul(Math.mul(numTokens, invariant), invariant).add(
-            //         Math.div(Math.mul(Math.mul(ampTimesTotal, sum), P_D), _AMP_PRECISION, roundUp)
-            //     ),
-            num_tokens
-                .bmul(invariant)?
-                .bmul(invariant)?
-                .badd(rounded_div(
-                    amp_times_total.bmul(sum)?.bmul(p_d)?,
-                    *AMP_PRECISION,
-                    true,
-                )?)?,
-            // Math.mul(numTokens + 1, invariant).add(
-            //     // No need to use checked arithmetic for the amp precision, the amp is guaranteed to be at least 1
-            //     Math.div(Math.mul(ampTimesTotal - _AMP_PRECISION, P_D), _AMP_PRECISION, !roundUp)
-            // ),
-            (num_tokens.badd(1.into())?)
-                .bmul(invariant)?
-                .badd(rounded_div(
-                    (amp_times_total.bsub(*AMP_PRECISION)?).bmul(p_d)?,
-                    *AMP_PRECISION,
-                    false,
-                )?)?,
-            true,
-        )?;
-
-        match convergence_criteria(invariant, prev_invariant) {
-            None => continue,
-            Some(invariant) => return Ok(invariant),
-        }
-    }
-    Err(Error::StableInvariantDidntConverge)
-}
-
-/// https://github.com/balancer-labs/balancer-v2-monorepo/blob/9eb7e44a4e9ebbadfe3c6242a086118298cadc9f/pkg/pool-stable-phantom/contracts/StableMath.sol#L86-L119
-fn convergence_loop_v2(
-    mut invariant: U256,
-    amp_times_total: U256,
-    balances: &[Bfp],
-    num_tokens: U256,
-    sum: U256,
-) -> Result<U256, Error> {
     for _ in 0..255 {
         // If balances were empty, we would have returned on sum.is_zero()
         let mut d_p = invariant;
@@ -147,7 +71,7 @@ pub fn calc_out_given_in(
     if token_index_out >= balances.len() || token_index_in >= balances.len() {
         return Err(Error::InvalidToken);
     }
-    let invariant = calculate_invariant(amplification_parameter, balances, true)?;
+    let invariant = calculate_invariant(amplification_parameter, balances)?;
     balances[token_index_in] = balances[token_index_in].add(token_amount_in)?;
 
     let final_balance_out = get_token_balance_given_invariant_and_all_other_balances(
@@ -179,7 +103,7 @@ pub fn calc_in_given_out(
     if token_index_out >= balances.len() || token_index_in >= balances.len() {
         return Err(Error::InvalidToken);
     }
-    let invariant = calculate_invariant(amplification_parameter, balances, true)?;
+    let invariant = calculate_invariant(amplification_parameter, balances)?;
     balances[token_index_out] = balances[token_index_out].sub(token_amount_out)?;
 
     let final_balance_in = get_token_balance_given_invariant_and_all_other_balances(
@@ -414,29 +338,10 @@ mod tests {
             balances[1].to_f64_lossy(),
             amp,
         );
-        for round_up in &[true, false] {
-            let result =
-                calculate_invariant(amplification_parameter, &balances, *round_up).unwrap();
-            assert!((result.to_f64_lossy() / 1e18 - expected)
-                .abs()
-                .le(&max_relative_error));
-        }
-    }
-
-    #[test]
-    fn invariant_two_tokens_err() {
-        let amp = 5000.;
-        let balances: Vec<Bfp> = vec!["0.00001", "1200000", "300"]
-            .iter()
-            .map(|x| Bfp::from_str(x).unwrap())
-            .collect();
-        let amplification_parameter = U256::from_f64_lossy(amp * AMP_PRECISION.to_f64_lossy());
-        assert_eq!(
-            calculate_invariant(amplification_parameter, balances.as_slice(), true)
-                .unwrap_err()
-                .to_string(),
-            "BAL#321: StableInvariantDidntConverge"
-        );
+        let result = calculate_invariant(amplification_parameter, &balances).unwrap();
+        assert!((result.to_f64_lossy() / 1e18 - expected)
+            .abs()
+            .le(&max_relative_error));
     }
 
     #[test]
@@ -447,8 +352,7 @@ mod tests {
             .map(|x| Bfp::from_str(x).unwrap())
             .collect();
         let amplification_parameter = U256::from_f64_lossy(amp * AMP_PRECISION.to_f64_lossy());
-        let result =
-            calculate_invariant(amplification_parameter, balances.as_slice(), false).unwrap();
+        let result = calculate_invariant(amplification_parameter, balances.as_slice()).unwrap();
         let float_balances = balances.iter().map(|x| x.to_f64_lossy()).collect();
         let expected = calculate_invariant_approx(float_balances, amp);
         let max_relative_error = 0.001;
@@ -465,13 +369,10 @@ mod tests {
         let float_balances = balances.iter().map(|x| x.to_f64_lossy()).collect();
         let expected = calculate_invariant_approx(float_balances, amp);
         let max_relative_error = 0.001;
-        for round_up in &[true, false] {
-            let result =
-                calculate_invariant(amplification_parameter, &balances, *round_up).unwrap();
-            assert!((result.to_f64_lossy() / 1e18 - expected)
-                .abs()
-                .le(&max_relative_error));
-        }
+        let result = calculate_invariant(amplification_parameter, &balances).unwrap();
+        assert!((result.to_f64_lossy() / 1e18 - expected)
+            .abs()
+            .le(&max_relative_error));
     }
 
     #[test]


### PR DESCRIPTION
First part of #343: refactoring the calculate_invariant method so that we can support both versions of `StablePool`.

There has been a change to the `calculateInvariant` method in Balancer's stable math. Previously they had a boolean indicator for rounding up or down on division and now they only support rounding up. 

The Balancer team have assured us that this computation will always return the same results as the previous implementation of the contract (also confirmed by out unit tests still agreeing), and that the only difference is better convergence. This means we can simply adjust the implementation and use it for all stable pools going forward.

### Test Plan

Only one unit test needed to be updated (since this new implementation has a wider convergence ratio).

### Release notes
 
Not yet determined. These changes may also need to be propagated to the quasi-modo solver (where stable math is also implemented) and we will also need to start indexing pools coming from their newly deployed factory.
