### PR TITLE
Fix e2e test solvable orders logic

### DIFF
--- a/crates/e2e/tests/e2e/eth_integration.rs
+++ b/crates/e2e/tests/e2e/eth_integration.rs
@@ -1,7 +1,7 @@
 use crate::{
     services::{
         create_order_converter, create_orderbook_api, deploy_mintable_token, to_wei,
-        uniswap_pair_provider, OrderbookServices, API_HOST,
+        uniswap_pair_provider, wait_for_solvable_orders, OrderbookServices, API_HOST,
     },
     tx, tx_value,
 };
@@ -183,7 +183,8 @@ async fn eth_integration(web3: Web3) {
         .await;
     assert_eq!(placement.unwrap().status(), 201);
 
-    solvable_orders_cache.update(0).await.unwrap();
+    let api = create_orderbook_api();
+    wait_for_solvable_orders(&api, 2).await.unwrap();
 
     // Drive solution
     let uniswap_pair_provider = uniswap_pair_provider(&contracts);
@@ -247,7 +248,7 @@ async fn eth_integration(web3: Web3) {
             ),
         },
         10,
-        create_orderbook_api(),
+        api,
         create_order_converter(&web3, contracts.weth.address()),
         0.0,
         15000000u128,

--- a/crates/e2e/tests/e2e/onchain_settlement.rs
+++ b/crates/e2e/tests/e2e/onchain_settlement.rs
@@ -1,7 +1,7 @@
 use crate::{
     services::{
         create_order_converter, create_orderbook_api, deploy_mintable_token, to_wei,
-        uniswap_pair_provider, OrderbookServices, API_HOST,
+        uniswap_pair_provider, wait_for_solvable_orders, OrderbookServices, API_HOST,
     },
     tx, tx_value,
 };
@@ -188,7 +188,8 @@ async fn onchain_settlement(web3: Web3) {
         .send()
         .await;
     assert_eq!(placement.unwrap().status(), 201);
-    solvable_orders_cache.update(0).await.unwrap();
+    let api = create_orderbook_api();
+    wait_for_solvable_orders(&api, 2).await.unwrap();
 
     // Drive solution
     let uniswap_pair_provider = uniswap_pair_provider(&contracts);
@@ -252,7 +253,7 @@ async fn onchain_settlement(web3: Web3) {
             ),
         },
         10,
-        create_orderbook_api(),
+        api,
         create_order_converter(&web3, contracts.weth.address()),
         0.0,
         15000000u128,

--- a/crates/e2e/tests/e2e/settlement_without_onchain_liquidity.rs
+++ b/crates/e2e/tests/e2e/settlement_without_onchain_liquidity.rs
@@ -1,6 +1,6 @@
 use crate::services::{
     create_order_converter, create_orderbook_api, deploy_mintable_token, to_wei,
-    uniswap_pair_provider, OrderbookServices, API_HOST,
+    uniswap_pair_provider, wait_for_solvable_orders, OrderbookServices, API_HOST,
 };
 use contracts::IUniswapLikeRouter;
 use ethcontract::prelude::{Account, Address, PrivateKey, U256};
@@ -169,7 +169,8 @@ async fn onchain_settlement_without_liquidity(web3: Web3) {
         .await;
     assert_eq!(placement.unwrap().status(), 201);
 
-    solvable_orders_cache.update(0).await.unwrap();
+    let api = create_orderbook_api();
+    wait_for_solvable_orders(&api, 1).await.unwrap();
 
     // Drive solution
     let uniswap_pair_provider = uniswap_pair_provider(&contracts);
@@ -241,7 +242,7 @@ async fn onchain_settlement_without_liquidity(web3: Web3) {
             ),
         },
         10,
-        create_orderbook_api(),
+        api,
         create_order_converter(&web3, contracts.weth.address()),
         0.0,
         15000000u128,

--- a/crates/e2e/tests/e2e/vault_balances.rs
+++ b/crates/e2e/tests/e2e/vault_balances.rs
@@ -1,6 +1,6 @@
 use crate::services::{
     create_order_converter, create_orderbook_api, deploy_mintable_token, to_wei,
-    uniswap_pair_provider, OrderbookServices, API_HOST,
+    uniswap_pair_provider, wait_for_solvable_orders, OrderbookServices, API_HOST,
 };
 use contracts::IUniswapLikeRouter;
 use ethcontract::prelude::{Account, Address, PrivateKey, U256};
@@ -96,7 +96,7 @@ async fn vault_balances(web3: Web3) {
 
     let OrderbookServices {
         block_stream,
-        solvable_orders_cache,
+        solvable_orders_cache: _,
         base_tokens,
         ..
     } = OrderbookServices::new(&web3, &contracts).await;
@@ -127,7 +127,8 @@ async fn vault_balances(web3: Web3) {
         .await;
     assert_eq!(placement.unwrap().status(), 201);
 
-    solvable_orders_cache.update(0).await.unwrap();
+    let api = create_orderbook_api();
+    wait_for_solvable_orders(&api, 1).await.unwrap();
 
     // Drive solution
     let uniswap_pair_provider = uniswap_pair_provider(&contracts);
@@ -191,7 +192,7 @@ async fn vault_balances(web3: Web3) {
             ),
         },
         10,
-        create_orderbook_api(),
+        api,
         create_order_converter(&web3, contracts.weth.address()),
         0.0,
         15000000u128,

--- a/crates/orderbook/src/solvable_orders.rs
+++ b/crates/orderbook/src/solvable_orders.rs
@@ -134,6 +134,9 @@ impl SolvableOrdersCache {
     }
 
     /// Manually update solvable orders. Usually called by the background updating task.
+    ///
+    /// Usually this method is called from update_task. If it isn't, which is the case in unit tests,
+    /// then concurrent calls might overwrite eachother's results.
     pub async fn update(&self, block: u64) -> Result<()> {
         let min_valid_to = now_in_epoch_seconds() + self.min_order_validity_period.as_secs() as u32;
         let db_solvable_orders = self.database.solvable_orders(min_valid_to).await?;


### PR DESCRIPTION
When e2e tests manually update the solvable orders cache it is possible
that the result is overwritten by the automatic update which in turn
could have been initiated at an earlier point in time leading to a
recently created order being missing.

Fixes https://github.com/cowprotocol/services/issues/362
