### PR TITLE
Store solver_competition tx_hash in column

### DIFF
--- a/crates/orderbook/src/database/solver_competition.rs
+++ b/crates/orderbook/src/database/solver_competition.rs
@@ -1,6 +1,7 @@
 use super::Postgres;
 use crate::solver_competition::{LoadSolverCompetitionError, SolverCompetitionStoring};
 use anyhow::{Context, Result};
+use database::byte_array::ByteArray;
 use model::solver_competition::{SolverCompetition, SolverCompetitionId};
 
 #[async_trait::async_trait]
@@ -11,10 +12,15 @@ impl SolverCompetitionStoring for Postgres {
             .with_label_values(&["save_solver_competition"])
             .start_timer();
 
+        let tx_hash = data.transaction_hash.map(|h256| ByteArray(h256.0));
         let mut ex = self.pool.acquire().await?;
-        let id = database::solver_competition::save(&mut ex, &serde_json::to_value(data)?)
-            .await
-            .context("failed to insert solver competition")?;
+        let id = database::solver_competition::save(
+            &mut ex,
+            &serde_json::to_value(data)?,
+            tx_hash.as_ref(),
+        )
+        .await
+        .context("failed to insert solver competition")?;
         Ok(id)
     }
 
@@ -28,7 +34,7 @@ impl SolverCompetitionStoring for Postgres {
             .start_timer();
 
         let mut ex = self.pool.acquire().await.map_err(anyhow::Error::from)?;
-        let value = database::solver_competition::load(&mut ex, id)
+        let value = database::solver_competition::load_by_id(&mut ex, id)
             .await
             .context("failed to get solver competition by ID")?;
         match value {
@@ -55,8 +61,10 @@ impl SolverCompetitionStoring for Postgres {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use database::TransactionHash;
     use model::solver_competition::{CompetitionAuction, SolverSettlement};
     use primitive_types::H256;
+    use sqlx::Executor;
 
     #[tokio::test]
     #[ignore]
@@ -96,5 +104,79 @@ mod tests {
         let id = db.next_solver_competition().await.unwrap();
         let result = db.load(id + 1).await.unwrap_err();
         assert!(matches!(result, LoadSolverCompetitionError::NotFound(_)));
+    }
+
+    #[tokio::test]
+    #[ignore]
+    async fn temp_test_migration() {
+        let db = Postgres::new("postgresql://").unwrap();
+        database::clear_DANGER(&db.pool).await.unwrap();
+
+        db.save(SolverCompetition {
+            gas_price: 1.,
+            transaction_hash: Some(H256([5; 32])),
+            ..Default::default()
+        })
+        .await
+        .unwrap();
+
+        db.save(SolverCompetition {
+            gas_price: 2.,
+            transaction_hash: None,
+            ..Default::default()
+        })
+        .await
+        .unwrap();
+
+        #[derive(Debug, sqlx::FromRow)]
+        struct Row {
+            id: i64,
+            json: sqlx::types::JsonValue,
+        }
+
+        let rows: Vec<Row> = sqlx::query_as("SELECT * FROM solver_competitions")
+            .fetch_all(&db.pool)
+            .await
+            .unwrap();
+
+        for row in rows {
+            println!("{:#?}", row);
+        }
+
+        // ---
+
+        let mut transaction = db.pool.begin().await.unwrap();
+        transaction
+            .execute(
+                r#"
+ALTER TABLE solver_competitions
+    ADD COLUMN tx_hash bytea UNIQUE;
+
+UPDATE solver_competitions
+    SET tx_hash = decode(substr(json ->> 'transactionHash', 3), 'hex');
+            "#,
+            )
+            .await
+            .unwrap();
+
+        #[derive(Debug, sqlx::FromRow)]
+        struct Row_ {
+            id: i64,
+            json: sqlx::types::JsonValue,
+            tx_hash: Option<TransactionHash>,
+        }
+
+        let rows: Vec<Row_> = sqlx::query_as("SELECT * FROM solver_competitions")
+            .fetch_all(&mut transaction)
+            .await
+            .unwrap();
+
+        for row in &rows {
+            println!("{:#?}", row);
+        }
+
+        assert_eq!(rows.len(), 2);
+        assert_eq!(rows[0].tx_hash.unwrap().0, [5; 32]);
+        assert_eq!(rows[1].tx_hash, None);
     }
 }

--- a/database/sql/V025__settlement_competition_tx_hash.sql
+++ b/database/sql/V025__settlement_competition_tx_hash.sql
@@ -1,0 +1,9 @@
+-- Add transaction hash a column to allow indexed retrieval.
+-- Unique columns automatically gain a corresponding index.
+
+ALTER TABLE solver_competitions
+ADD COLUMN tx_hash bytea UNIQUE;
+
+-- The `substr` call removes the `0x` prefix.
+UPDATE solver_competitions
+SET tx_hash = decode(substr(json ->> 'transactionHash', 3), 'hex');


### PR DESCRIPTION
Allows us to query solver competition info by tx hash.

Next step is to change the api route to also allow a hash.

### Test Plan

New unit test and temporary unit test that shows the migration works.
The temporary test should be removed before merging.