### PR TITLE
Make solver_competition route work with tx hash

### DIFF
--- a/crates/orderbook/openapi.yml
+++ b/crates/orderbook/openapi.yml
@@ -481,11 +481,7 @@ paths:
     get:
       summary: Information about solver competition
       description: |
-        Returns the settlements submitted by every solver for a specific auction
-        id. The auction id corresponds to the id external solvers are provided
-        with. Auction ids are not globally unique, they are reused from time to
-        time. The backend keeps the competition information for a limited amount
-        of time.
+        Returns the competition information by auction id.
       parameters:
         - name: auction_id
           in: path
@@ -501,6 +497,26 @@ paths:
                 $ref: "#/components/schemas/SolverCompetitionResponse"
         404:
           description: No competition information available for this auction id.
+  /api/v1/solver_competition/by_tx_hash/{tx_hash}:
+    get:
+      summary: Information about solver competition
+      description: |
+        Returns the competition information by transaction hash.
+      parameters:
+        - name: tx_hash
+          in: path
+          required: true
+          schema:
+            $ref: "#/components/schemas/TransactionHash"
+      responses:
+        200:
+          description: competition info
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SolverCompetitionResponse"
+        404:
+          description: No competition information available for this tx hash.
 components:
   schemas:
     TransactionHash:
@@ -1077,6 +1093,10 @@ components:
             order slippage.
           type: integer
     SolverCompetitionResponse:
+      description: |
+        The settlements submitted by every solver for a specific auction.
+        The auction id corresponds to the id external solvers are provided
+        with.
       type: object
       properties:
         transactionHash:

--- a/crates/orderbook/src/api/get_solver_competition.rs
+++ b/crates/orderbook/src/api/get_solver_competition.rs
@@ -1,31 +1,43 @@
-use crate::solver_competition::{LoadSolverCompetitionError, SolverCompetitionStoring};
+use crate::solver_competition::{Identifier, LoadSolverCompetitionError, SolverCompetitionStoring};
 use anyhow::Result;
 use model::solver_competition::SolverCompetitionId;
+use primitive_types::H256;
 use reqwest::StatusCode;
 use shared::api::{convert_json_response, IntoWarpReply};
 use std::{convert::Infallible, sync::Arc};
 use warp::{reply::with_status, Filter, Rejection};
 
-fn request() -> impl Filter<Extract = (SolverCompetitionId,), Error = Rejection> + Clone {
-    warp::path!("solver_competition" / SolverCompetitionId).and(warp::get())
+fn request_id() -> impl Filter<Extract = (Identifier,), Error = Rejection> + Clone {
+    warp::path!("solver_competition" / SolverCompetitionId)
+        .and(warp::get())
+        .map(Identifier::Id)
+}
+
+fn request_hash() -> impl Filter<Extract = (Identifier,), Error = Rejection> + Clone {
+    warp::path!("solver_competition" / "by_tx_hash" / H256)
+        .and(warp::get())
+        .map(Identifier::Transaction)
 }
 
 pub fn get(
     handler: Arc<dyn SolverCompetitionStoring>,
 ) -> impl Filter<Extract = (super::ApiReply,), Error = Rejection> + Clone {
-    request().and_then(move |id| {
-        let handler = handler.clone();
-        async move {
-            let result = handler.load(id).await;
-            Result::<_, Infallible>::Ok(convert_json_response(result))
-        }
-    })
+    request_id()
+        .or(request_hash())
+        .unify()
+        .and_then(move |identifier: Identifier| {
+            let handler = handler.clone();
+            async move {
+                let result = handler.load(identifier).await;
+                Result::<_, Infallible>::Ok(convert_json_response(result))
+            }
+        })
 }
 
 impl IntoWarpReply for LoadSolverCompetitionError {
     fn into_warp_reply(self) -> shared::api::ApiReply {
         match self {
-            Self::NotFound(_) => with_status(super::error("NotFound", ""), StatusCode::NOT_FOUND),
+            Self::NotFound => with_status(super::error("NotFound", ""), StatusCode::NOT_FOUND),
             Self::Other(err) => err.into_warp_reply(),
         }
     }
@@ -34,18 +46,28 @@ impl IntoWarpReply for LoadSolverCompetitionError {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::solver_competition::InMemoryStorage;
+    use crate::solver_competition::MockSolverCompetitionStoring;
     use warp::{test::request, Reply};
 
     #[tokio::test]
     async fn test() {
-        let handler = InMemoryStorage::default();
-        let id = handler.save(Default::default()).await.unwrap();
-        let filter = get(Arc::new(handler));
+        let mut storage = MockSolverCompetitionStoring::new();
+        storage
+            .expect_load()
+            .times(2)
+            .returning(|_| Ok(Default::default()));
+        storage
+            .expect_load()
+            .times(1)
+            .return_once(|_| Err(LoadSolverCompetitionError::NotFound));
+        let filter = get(Arc::new(storage));
 
-        let request_ = request()
-            .path(&format!("/solver_competition/{id}"))
-            .method("GET");
+        let request_ = request().path("/solver_competition/0").method("GET");
+        let response = request_.filter(&filter).await.unwrap().into_response();
+        dbg!(&response);
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let request_ = request().path("/solver_competition/by_tx_hash/0xd51f28edffcaaa76be4a22f6375ad289272c037f3cc072345676e88d92ced8b5").method("GET");
         let response = request_.filter(&filter).await.unwrap().into_response();
         dbg!(&response);
         assert_eq!(response.status(), StatusCode::OK);

--- a/crates/orderbook/src/database/solver_competition.rs
+++ b/crates/orderbook/src/database/solver_competition.rs
@@ -1,5 +1,5 @@
 use super::Postgres;
-use crate::solver_competition::{LoadSolverCompetitionError, SolverCompetitionStoring};
+use crate::solver_competition::{Identifier, LoadSolverCompetitionError, SolverCompetitionStoring};
 use anyhow::{Context, Result};
 use database::byte_array::ByteArray;
 use model::solver_competition::{SolverCompetition, SolverCompetitionId};
@@ -24,21 +24,22 @@ impl SolverCompetitionStoring for Postgres {
         Ok(id)
     }
 
-    async fn load(
-        &self,
-        id: SolverCompetitionId,
-    ) -> Result<SolverCompetition, LoadSolverCompetitionError> {
+    async fn load(&self, id: Identifier) -> Result<SolverCompetition, LoadSolverCompetitionError> {
         let _timer = super::Metrics::get()
             .database_queries
             .with_label_values(&["load_solver_competition"])
             .start_timer();
 
         let mut ex = self.pool.acquire().await.map_err(anyhow::Error::from)?;
-        let value = database::solver_competition::load_by_id(&mut ex, id)
-            .await
-            .context("failed to get solver competition by ID")?;
+        let value = match id {
+            Identifier::Id(id) => database::solver_competition::load_by_id(&mut ex, id).await,
+            Identifier::Transaction(hash) => {
+                database::solver_competition::load_by_tx_hash(&mut ex, &ByteArray(hash.0)).await
+            }
+        }
+        .context("failed to get solver competition by ID")?;
         match value {
-            None => Err(LoadSolverCompetitionError::NotFound(id)),
+            None => Err(LoadSolverCompetitionError::NotFound),
             Some(value) => serde_json::from_value(value)
                 .map_err(anyhow::Error::from)
                 .map_err(Into::into),
@@ -89,7 +90,7 @@ mod tests {
             }],
         };
         let id = db.save(expected.clone()).await.unwrap();
-        let actual = db.load(id).await.unwrap();
+        let actual = db.load(Identifier::Id(id)).await.unwrap();
         assert_eq!(expected, actual);
     }
 
@@ -100,7 +101,7 @@ mod tests {
         database::clear_DANGER(&db.pool).await.unwrap();
 
         let id = db.next_solver_competition().await.unwrap();
-        let result = db.load(id + 1).await.unwrap_err();
-        assert!(matches!(result, LoadSolverCompetitionError::NotFound(_)));
+        let result = db.load(Identifier::Id(id + 1)).await.unwrap_err();
+        assert!(matches!(result, LoadSolverCompetitionError::NotFound));
     }
 }

--- a/crates/orderbook/src/solver_competition.rs
+++ b/crates/orderbook/src/solver_competition.rs
@@ -1,13 +1,14 @@
 //! Manage solver competition data received by the driver through a private spi.
 
 use anyhow::Result;
-use cached::{Cached, SizedCache};
 use model::solver_competition::{SolverCompetition, SolverCompetitionId};
-use std::sync::{
-    atomic::{AtomicI64, Ordering},
-    Mutex,
-};
+use primitive_types::H256;
 use thiserror::Error;
+
+pub enum Identifier {
+    Id(SolverCompetitionId),
+    Transaction(H256),
+}
 
 /// Component used for saving and loading past solver competitions.
 #[cfg_attr(test, mockall::automock)]
@@ -22,7 +23,7 @@ pub trait SolverCompetitionStoring: Send + Sync {
     /// be found.
     async fn load(
         &self,
-        id: SolverCompetitionId,
+        identifier: Identifier,
     ) -> Result<SolverCompetition, LoadSolverCompetitionError>;
 
     /// Retrieves the ID that will be assigned to the next solver competition
@@ -33,52 +34,8 @@ pub trait SolverCompetitionStoring: Send + Sync {
 /// Possible errors when loading a solver competition by ID.
 #[derive(Debug, Error)]
 pub enum LoadSolverCompetitionError {
-    #[error("solver competition {0} not found")]
-    NotFound(SolverCompetitionId),
+    #[error("solver competition not found")]
+    NotFound,
     #[error(transparent)]
     Other(#[from] anyhow::Error),
-}
-
-// The size controls
-// - how long we store competition info depending on how often the driver run loop completes
-// - how much memory the cache takes up depending on how big the average response is
-const CACHE_SIZE: usize = 500;
-
-pub struct InMemoryStorage {
-    last_id: AtomicI64,
-    cache: Mutex<SizedCache<SolverCompetitionId, SolverCompetition>>,
-}
-
-impl Default for InMemoryStorage {
-    fn default() -> Self {
-        Self {
-            last_id: Default::default(),
-            cache: Mutex::new(SizedCache::with_size(CACHE_SIZE)),
-        }
-    }
-}
-
-#[async_trait::async_trait]
-impl SolverCompetitionStoring for InMemoryStorage {
-    async fn save(&self, model: SolverCompetition) -> Result<SolverCompetitionId> {
-        let id = self.last_id.fetch_add(1, Ordering::SeqCst);
-        self.cache.lock().unwrap().cache_set(id, model);
-        Ok(id)
-    }
-
-    async fn load(
-        &self,
-        id: SolverCompetitionId,
-    ) -> Result<SolverCompetition, LoadSolverCompetitionError> {
-        self.cache
-            .lock()
-            .unwrap()
-            .cache_get(&id)
-            .cloned()
-            .ok_or(LoadSolverCompetitionError::NotFound(id))
-    }
-
-    async fn next_solver_competition(&self) -> Result<SolverCompetitionId> {
-        Ok(self.last_id.load(Ordering::SeqCst))
-    }
 }


### PR DESCRIPTION
- Removed InMemoryStorage because it wasn't needed anymore.
- Simplified NotFound error because there is no reason to return the id back.

I added a new route `by_tx_hash` instead of overloading a single route because I felt it was more clear and harder to accidentally misuse.

### Test Plan

CI, adapted test
