### PR TITLE
Configure Balancer V2 subgraph for Goerli

### DIFF
--- a/crates/shared/src/sources/balancer_v2/graph_api.rs
+++ b/crates/shared/src/sources/balancer_v2/graph_api.rs
@@ -36,6 +36,7 @@ impl BalancerSubgraphClient {
         let subgraph_name = match chain_id {
             1 => "balancer-v2",
             4 => "balancer-rinkeby-v2",
+            5 => "balancer-goerli-v2",
             _ => bail!("unsupported chain {}", chain_id),
         };
         Ok(Self(SubgraphClient::new(


### PR DESCRIPTION
This PR configures our Subgraph initialization to know about the Görli subgraph.

This is the last piece required for Balancer V2 to work on Görli.

### Test Plan

Make sure we can query Balancer V2 liquidity on Görli:

```
% cargo run -p solver -- \
  --baseline-sources BalancerV2 \
  --solver-account 0xA70B6e99FCF41bF78d626a95B8C095b87D4A4285 \ 
  --transaction-strategy DryRun \
  --orderbook-url https://barn.api.cow.fi/goerli/                            
...
2022-07-27T13:53:32.736Z  INFO shared::gas_price_estimation: estimator Web3, networkid 5
2022-07-27T13:53:32.856Z  INFO solver: using baseline sources baseline_sources=[BalancerV2]
2022-07-27T13:53:34.019Z DEBUG shared::sources::balancer_v2::pool_init: initialized registered pools block=7299817 pools=100
...
2022-07-27T13:53:37.348Z DEBUG solver::driver: single run finished ok
...
```
