### PR TITLE
Update the auction's next solver competition id immediately

### DIFF
--- a/crates/e2e/tests/e2e/services.rs
+++ b/crates/e2e/tests/e2e/services.rs
@@ -286,6 +286,7 @@ impl OrderbookServices {
             pending(),
             db.clone(),
             None,
+            solvable_orders_cache.clone(),
         );
 
         Self {

--- a/crates/orderbook/src/api.rs
+++ b/crates/orderbook/src/api.rs
@@ -12,9 +12,10 @@ mod get_solver_competition;
 mod get_trades;
 mod get_user_orders;
 mod post_quote;
-mod post_solver_competition;
+pub mod post_solver_competition;
 mod replace_order;
 
+use self::post_solver_competition::SolvableOrdersCache;
 use crate::solver_competition::SolverCompetitionStoring;
 use crate::{database::trades::TradeRetrieving, order_quoting::QuoteHandler, orderbook::Orderbook};
 use shared::api::{error, finalize_router, internal_error, ApiReply};
@@ -27,6 +28,7 @@ pub fn handle_all_routes(
     quotes: Arc<QuoteHandler>,
     solver_competition: Arc<dyn SolverCompetitionStoring>,
     solver_competition_auth: Option<String>,
+    solvable_orders: Arc<dyn SolvableOrdersCache>,
 ) -> impl Filter<Extract = (impl Reply,), Error = Rejection> + Clone {
     // Routes for api v1.
 
@@ -80,7 +82,7 @@ pub fn handle_all_routes(
         .map(|result| (result, "v1/solver_competition"))
         .boxed();
     let post_solver_competition =
-        post_solver_competition::post(solver_competition, solver_competition_auth)
+        post_solver_competition::post(solver_competition, solvable_orders, solver_competition_auth)
             .map(|result| (result, "v1/solver_competition"))
             .boxed();
 

--- a/crates/orderbook/src/api/post_solver_competition.rs
+++ b/crates/orderbook/src/api/post_solver_competition.rs
@@ -8,6 +8,18 @@ use shared::api::convert_json_response_with_status;
 use std::{convert::Infallible, sync::Arc};
 use warp::{reply::with_status, Filter, Rejection};
 
+#[async_trait::async_trait]
+pub trait SolvableOrdersCache: Send + Sync {
+    async fn update_next_solver_competition_id(&self) -> anyhow::Result<()>;
+}
+
+#[async_trait::async_trait]
+impl SolvableOrdersCache for crate::solvable_orders::SolvableOrdersCache {
+    async fn update_next_solver_competition_id(&self) -> anyhow::Result<()> {
+        crate::solvable_orders::SolvableOrdersCache::update_next_solver_competition_id(self).await
+    }
+}
+
 fn request() -> impl Filter<Extract = (Option<String>, SolverCompetition), Error = Rejection> + Clone
 {
     warp::path!("solver_competition")
@@ -21,10 +33,12 @@ fn request() -> impl Filter<Extract = (Option<String>, SolverCompetition), Error
 
 pub fn post(
     handler: Arc<dyn SolverCompetitionStoring>,
+    solvable_orders: Arc<dyn SolvableOrdersCache>,
     expected_auth: Option<String>,
 ) -> impl Filter<Extract = (super::ApiReply,), Error = Rejection> + Clone {
     request().and_then(move |auth, model: SolverCompetition| {
         let handler = handler.clone();
+        let solvable_orders = solvable_orders.clone();
         let expected_auth = expected_auth.clone();
         async move {
             if expected_auth.is_some() && expected_auth != auth {
@@ -35,6 +49,10 @@ pub fn post(
             }
 
             let result = handler.save(model).await;
+            // Update the id immediately so that the next driver run cannot observe the id repeating.
+            if let Err(err) = solvable_orders.update_next_solver_competition_id().await {
+                tracing::warn!(?err, "failed to update next solver competition id");
+            }
             Ok(convert_json_response_with_status(
                 result,
                 StatusCode::CREATED,
@@ -49,12 +67,21 @@ mod tests {
     use crate::solver_competition::MockSolverCompetitionStoring;
     use warp::{test::request, Reply};
 
+    struct NoopSolvableOrdersCache;
+    #[async_trait::async_trait]
+    impl SolvableOrdersCache for NoopSolvableOrdersCache {
+        async fn update_next_solver_competition_id(&self) -> anyhow::Result<()> {
+            Ok(())
+        }
+    }
+
     #[tokio::test]
     async fn test_no_auth() {
         let mut handler = MockSolverCompetitionStoring::new();
         handler.expect_save().returning(|_| Ok(1));
+        let cache = Arc::new(NoopSolvableOrdersCache);
 
-        let filter = post(Arc::new(handler), None);
+        let filter = post(Arc::new(handler), cache, None);
         let body = serde_json::to_vec(&SolverCompetition::default()).unwrap();
 
         let request = request()
@@ -72,8 +99,9 @@ mod tests {
     async fn test_auth() {
         let mut handler = MockSolverCompetitionStoring::new();
         handler.expect_save().times(1).returning(|_| Ok(1));
+        let cache = Arc::new(NoopSolvableOrdersCache);
 
-        let filter = post(Arc::new(handler), Some("auth".to_string()));
+        let filter = post(Arc::new(handler), cache, Some("auth".to_string()));
         let body = serde_json::to_vec(&SolverCompetition::default()).unwrap();
 
         let request_ = request()

--- a/crates/orderbook/src/lib.rs
+++ b/crates/orderbook/src/lib.rs
@@ -17,6 +17,7 @@ pub mod solver_competition;
 use crate::database::trades::TradeRetrieving;
 use crate::{order_quoting::QuoteHandler, orderbook::Orderbook};
 use anyhow::{anyhow, Context as _, Result};
+use api::post_solver_competition::SolvableOrdersCache;
 use contracts::GPv2Settlement;
 use futures::Future;
 use model::DomainSeparator;
@@ -25,6 +26,7 @@ use std::{net::SocketAddr, sync::Arc};
 use tokio::{task, task::JoinHandle};
 use warp::Filter;
 
+#[allow(clippy::too_many_arguments)]
 pub fn serve_api(
     database: Arc<dyn TradeRetrieving>,
     orderbook: Arc<Orderbook>,
@@ -33,6 +35,7 @@ pub fn serve_api(
     shutdown_receiver: impl Future<Output = ()> + Send + 'static,
     solver_competition: Arc<dyn SolverCompetitionStoring>,
     solver_competition_auth: Option<String>,
+    solvable_orders: Arc<dyn SolvableOrdersCache>,
 ) -> JoinHandle<()> {
     let filter = api::handle_all_routes(
         database,
@@ -40,6 +43,7 @@ pub fn serve_api(
         quotes,
         solver_competition,
         solver_competition_auth,
+        solvable_orders,
     )
     .boxed();
     tracing::info!(%address, "serving order book");

--- a/crates/orderbook/src/main.rs
+++ b/crates/orderbook/src/main.rs
@@ -558,7 +558,7 @@ async fn main() {
             database.clone(),
             event_updater,
             pool_fetcher,
-            solvable_orders_cache,
+            solvable_orders_cache.clone(),
         ],
     };
     if let Some(balancer) = balancer_pool_fetcher {
@@ -578,6 +578,7 @@ async fn main() {
         },
         database.clone(),
         args.shared.solver_competition_auth,
+        solvable_orders_cache.clone(),
     );
     let maintenance_task =
         task::spawn(service_maintainer.run_maintenance_on_new_block(current_block_stream));

--- a/crates/orderbook/src/solvable_orders.rs
+++ b/crates/orderbook/src/solvable_orders.rs
@@ -133,6 +133,13 @@ impl SolvableOrdersCache {
         self.notify.notify_one();
     }
 
+    /// Updates the id immediately without having to wait for next full cache update.
+    pub async fn update_next_solver_competition_id(&self) -> Result<()> {
+        let id = self.solver_competition.next_solver_competition().await?;
+        self.cache.lock().unwrap().auction.next_solver_competition = id;
+        Ok(())
+    }
+
     /// Manually update solvable orders. Usually called by the background updating task.
     ///
     /// Usually this method is called from update_task. If it isn't, which is the case in unit tests,


### PR DESCRIPTION
Without this change it is possible for one driver run loop to store the
solver competition info for the current id and then start the next run
loop before the api updates the solvable orders cache which results in
the id being reused by the driver.

### Test Plan

CI. There isn't a great way to observe this in a unit or e2e test. Afterwards can check that we don't get the log message "stored solver competition with unexpected ID".