### PR TITLE
Different quote expiration for off-chain orders(via api-calls) and on-chain orders

### DIFF
--- a/crates/database/src/quotes.rs
+++ b/crates/database/src/quotes.rs
@@ -20,6 +20,7 @@ pub struct Quote {
     pub sell_token_price: f64,
     pub order_kind: OrderKind,
     pub expiration_timestamp: DateTime<Utc>,
+    pub expiration_for_api_call_timestamp: Option<DateTime<Utc>>,
 }
 
 /// Stores the quote and returns the id. The id of the quote parameter is not used.
@@ -34,9 +35,10 @@ INSERT INTO quotes (
     gas_price,
     sell_token_price,
     order_kind,
-    expiration_timestamp
+    expiration_timestamp,
+    expiration_for_api_call_timestamp
 )
-VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
 RETURNING id
     "#;
     let (id,) = sqlx::query_as(QUERY)
@@ -49,6 +51,7 @@ RETURNING id
         .bind(quote.sell_token_price)
         .bind(quote.order_kind)
         .bind(quote.expiration_timestamp)
+        .bind(quote.expiration_for_api_call_timestamp)
         .fetch_one(ex)
         .await?;
     Ok(id)
@@ -155,6 +158,7 @@ mod tests {
             sell_token_price: 7.,
             order_kind: OrderKind::Sell,
             expiration_timestamp: now,
+            expiration_for_api_call_timestamp: Some(now),
         };
         let id = save(&mut db, &quote).await.unwrap();
         quote.id = id;
@@ -181,11 +185,12 @@ mod tests {
             buy_token: ByteArray([3; 20]),
             sell_amount: 4.into(),
             buy_amount: 5.into(),
-            order_kind: OrderKind::Sell,
             gas_amount: 1.,
             gas_price: 1.,
             sell_token_price: 1.,
+            order_kind: OrderKind::Sell,
             expiration_timestamp: now,
+            expiration_for_api_call_timestamp: Some(now),
         };
 
         let token_b = ByteArray([2; 20]);
@@ -200,6 +205,7 @@ mod tests {
             gas_price: 1.,
             sell_token_price: 1.,
             expiration_timestamp: now,
+            expiration_for_api_call_timestamp: Some(now),
         };
 
         // Save two measurements for token_a

--- a/crates/orderbook/openapi.yml
+++ b/crates/orderbook/openapi.yml
@@ -548,11 +548,6 @@ components:
             the fee after this expiration date. Encoded as ISO 8601 UTC.
           type: string
           example: "2020-12-03T18:35:18.814523Z"
-        expirationForApiCall:
-          description: |
-            Expiration date of the offered fee for off-chain order placements.
-          type: string
-          example: "1985-03-10T18:35:18.814523Z"
         amount:
           description: Absolute amount of fee charged per order in specified sellToken
           $ref: "#/components/schemas/TokenAmount"

--- a/crates/orderbook/openapi.yml
+++ b/crates/orderbook/openapi.yml
@@ -542,17 +542,22 @@ components:
         Provides the information to calculate the fees.
       type: object
       properties:
-        expirationDate:
+        expiration:
           description: |
             Expiration date of the offered fee. Order service might not accept
             the fee after this expiration date. Encoded as ISO 8601 UTC.
           type: string
           example: "2020-12-03T18:35:18.814523Z"
+        expirationForApiCall:
+          description: |
+            Expiration date of the offered fee for off-chain order placements.
+          type: string
+          example: "1985-03-10T18:35:18.814523Z"
         amount:
           description: Absolute amount of fee charged per order in specified sellToken
           $ref: "#/components/schemas/TokenAmount"
       required:
-        - expirationDate
+        - expiration
         - amount
     OrderType:
       description: Is this a buy order or sell order?
@@ -1081,10 +1086,15 @@ components:
           $ref: "#/components/schemas/OrderParameters"
         from:
           $ref: "#/components/schemas/Address"
-        expirationDate:
+        expiration:
           description: |
             Expiration date of the offered fee. Order service might not accept
             the fee after this expiration date. Encoded as ISO 8601 UTC.
+          type: string
+          example: "1985-03-10T18:35:18.814523Z"
+        expirationForApiCall:
+          description: |
+            Expiration date of the offered fee for off-chain order placements.
           type: string
           example: "1985-03-10T18:35:18.814523Z"
         id:

--- a/crates/orderbook/src/database/quotes.rs
+++ b/crates/orderbook/src/database/quotes.rs
@@ -35,6 +35,7 @@ impl TryFrom<QuoteRow> for QuoteData {
             },
             kind: order_kind_from(row.order_kind),
             expiration: row.expiration_timestamp,
+            expiration_for_api_call: row.expiration_for_api_call_timestamp,
         })
     }
 }
@@ -59,6 +60,7 @@ impl QuoteStoring for Postgres {
             sell_token_price: data.fee_parameters.sell_token_price,
             order_kind: order_kind_into(data.kind),
             expiration_timestamp: data.expiration,
+            expiration_for_api_call_timestamp: data.expiration_for_api_call,
         };
         let id = database::quotes::save(&mut ex, &row).await?;
         Ok(Some(id))

--- a/database/sql/V026__quotes_add_field_expiration_for_api_call.sql
+++ b/database/sql/V026__quotes_add_field_expiration_for_api_call.sql
@@ -1,0 +1,4 @@
+  -- Adding new column on table quotes for the expiration_for_api_call_timestamp
+  ALTER TABLE quotes
+  ADD COLUMN expiration_for_api_call_timestamp timestamptz;
+


### PR DESCRIPTION
Successor PR for https://github.com/cowprotocol/services/pull/355.
In the upper PR, Felix mentioned that he would expect that the expiration of EIP1271 orders would not be prolonged for off-chain orders that are placed via the API and that the expiration time should be the normal expiration for standard eip712 orders.

I decided that it's the cleanest solution if we communicate for EIP1271 orders both expiration dates over the API: the one for on-chain orders that is relevant for the eth-flow - this one will still be called expiration - and the one that is relevant for off-chain order placements for use cases like "gnosis safe eip1271 order" - this one will be called 'expiration_for_api_calls'.

This PR introduces the changes necessary for dealing with the two expiration dates: normal expiration and expiration_for_api_calls. It also ensures that off-chain placed EIP1271 orders are only accepted until expiration_for_api_calls although their expiration date is longer

### Test Plan
Check that the flyway is still working:
```
docker run -d -e POSTGRES_HOST_AUTH_METHOD=trust -e POSTGRES_USER=`whoami` -p 5432:5432 docker.io/postgres

docker run -ti -e FLYWAY_URL="jdbc:postgresql://host.docker.internal/?user="$USER"&password=" -v $PWD/database/sql:/flyway/sql services-migration migrate
```


### Release notes

Introduces a new field: 'expiration_for_api_calls' to the quote api.