### PR TITLE
Use default arguments for 1inch solution complexity

### DIFF
--- a/crates/shared/src/oneinch_api.rs
+++ b/crates/shared/src/oneinch_api.rs
@@ -146,11 +146,9 @@ impl SellOrderQuoteQuery {
             to_token_address: buy_token,
             amount,
             protocols,
-            // Use max value instead of default
-            complexity_level: Some(Amount::new(3).unwrap()),
+            complexity_level: None,
             gas_limit: None,
-            // use max value instead of default
-            main_route_parts: Some(Amount::new(50).unwrap()),
+            main_route_parts: None,
             parts: None,
             fee: None,
             gas_price: None,


### PR DESCRIPTION
In order to match or slightly beat the prices 1inch offers in their frontend we tolerated more complex solution than they did. Complex solutions have a higher risk of reverting and of negative slippage costing us a lot of money.
To stay competitive but hopefully reduce the overall costs slightly we instead now use the default complexity arguments again (which are identical to what 1Inch uses for their frontend).


### Test Plan

manual test running the order book locally
```
2022-08-01T09:55:08.006Z DEBUG request{id=1}: shared::oneinch_api: Query 1inch API for url https://api.1inch.exchange/v4.1/1/quote?fromTokenAddress=0xdef1ca1fb7fbcdc777520aa7f396b4e015f497ab&toTokenAddress=0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48&amount=1000000000000000000000000&protocols=UNISWAP_V1%2CUNISWAP_V2%2CSUSHI%2CMOONISWAP%2CBALANCER%2CCOMPOUND%2CCURVE%2CCURVE_V2_SPELL_2_ASSET%2CCURVE_V2_SGT_2_ASSET%2CCURVE_V2_THRESHOLDNETWORK_2_ASSET%2CCHAI%2COASIS%2CKYBER%2CAAVE%2CIEARN%2CBANCOR%2CCREAMSWAP%2CSWERVE%2CBLACKHOLESWAP%2CDODO%2CDODO_V2%2CVALUELIQUID%2CSHELL%2CDEFISWAP%2CSAKESWAP%2CLUASWAP%2CMINISWAP%2CMSTABLE%2CPMM2%2CSYNTHETIX%2CAAVE_V2%2CST_ETH%2CONE_INCH_LP%2CONE_INCH_LP_1_1%2CLINKSWAP%2CS_FINANCE%2CPSM%2CPOWERINDEX%2CPMM3%2CXSIGMA%2CCREAM_LENDING%2CSMOOTHY_FINANCE%2CSADDLE%2CPMM4%2CKYBER_DMM%2CBALANCER_V2%2CUNISWAP_V3%2CSETH_WRAPPER%2CCURVE_V2%2CCURVE_V2_EURS_2_ASSET%2CCURVE_V2_EURT_2_ASSET%2CCURVE_V2_XAUT_2_ASSET%2CCURVE_V2_ETH_CRV%2CCURVE_V2_ETH_CVX%2CCONVERGENCE_X%2CONE_INCH_LIMIT_ORDER%2CONE_INCH_LIMIT_ORDER_V2%2CDFX_FINANCE%2CFIXED_FEE_SWAP%2CDXSWAP%2CCLIPPER%2CSHIBASWAP%2CUNIFI%2CPSM_PAX%2CWSTETH%2CDEFI_PLAZA%2CFIXED_FEE_SWAP_V3%2CSYNTHETIX_WRAPPER%2CSYNAPSE%2CCURVE_V2_YFI_2_ASSET%2CCURVE_V2_ETH_PAL%2CPOOLTOGETHER%2CETH_BANCOR_V3%2CELASTICSWAP%2CBALANCER_V2_WRAPPER%2CSYNTHETIX_ATOMIC%2CFRAXSWAP%2CRADIOSHACK%2CKYBERSWAP_ELASTIC%2CCURVE_V2_TWO_CRYPTO%2CSTABLE_PLAZA
...
2022-08-01T09:55:08.190Z DEBUG request{id=1}: shared::oneinch_api: Response from 1inch API: Ok("{\"fromToken\":{\"symbol\":\"COW\",\"name\":\"CoW Protocol Token\",\"decimals\":18,\"address\":\"0xdef1ca1fb7fbcdc777520aa7f396b4e015f497ab\",\"logoURI\":\"https://tokens.1inch.io/0xdef1ca1fb7fbcdc777520aa7f396b4e015f497ab.png\",\"eip2612\":true,\"tags\":[\"tokens\"]},\"toToken\":{\"symbol\":\"USDC\",\"name\":\"USD Coin\",\"address\":\"0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48\",\"decimals\":6,\"logoURI\":\"https://tokens.1inch.io/0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48.png\",\"eip2612\":true,\"domainVersion\":\"2\",\"tags\":[\"tokens\"]},\"toTokenAmount\":\"132541584217\",\"fromTokenAmount\":\"1000000000000000000000000\",\"protocols\":[[[{\"name\":\"BALANCER_V2\",\"part\":100,\"fromTokenAddress\":\"0xdef1ca1fb7fbcdc777520aa7f396b4e015f497ab\",\"toTokenAddress\":\"0x6810e776880c02933d47db1b9fc05908e5386b96\"}],[{\"name\":\"UNISWAP_V3\",\"part\":100,\"fromTokenAddress\":\"0x6810e776880c02933d47db1b9fc05908e5386b96\",\"toTokenAddress\":\"0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee\"}],[{\"name\":\"UNISWAP_V3\",\"part\":100,\"fromTokenAddress\":\"0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee\",\"toTokenAddress\":\"0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48\"}]],[[{\"name\":\"BALANCER_V2\",\"part\":96,\"fromTokenAddress\":\"0xdef1ca1fb7fbcdc777520aa7f396b4e015f497ab\",\"toTokenAddress\":\"0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee\"},{\"name\":\"UNISWAP_V3\",\"part\":4,\"fromTokenAddress\":\"0xdef1ca1fb7fbcdc777520aa7f396b4e015f497ab\",\"toTokenAddress\":\"0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee\"}],[{\"name\":\"CURVE_V2\",\"part\":100,\"fromTokenAddress\":\"0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee\",\"toTokenAddress\":\"0xdac17f958d2ee523a2206206994597c13d831ec7\"}],[{\"name\":\"DODO\",\"part\":100,\"fromTokenAddress\":\"0xdac17f958d2ee523a2206206994597c13d831ec7\",\"toTokenAddress\":\"0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48\"}]]],\"estimatedGas\":1607539}")
```
