### PR TITLE
Move database quote maintenance into autopilot

### DIFF
--- a/crates/autopilot/src/database.rs
+++ b/crates/autopilot/src/database.rs
@@ -1,4 +1,5 @@
 mod events;
+mod quotes;
 
 use sqlx::{PgConnection, PgPool};
 use std::time::Duration;

--- a/crates/autopilot/src/database/quotes.rs
+++ b/crates/autopilot/src/database/quotes.rs
@@ -1,0 +1,26 @@
+use super::Postgres;
+use anyhow::{Context, Result};
+use shared::maintenance::Maintaining;
+use sqlx::types::chrono::{DateTime, Utc};
+
+impl Postgres {
+    pub async fn remove_expired_quotes(&self, max_expiry: DateTime<Utc>) -> Result<()> {
+        let _timer = super::Metrics::get()
+            .database_queries
+            .with_label_values(&["remove_expired_quotes"])
+            .start_timer();
+
+        let mut ex = self.0.acquire().await?;
+        database::quotes::remove_expired_quotes(&mut ex, max_expiry).await?;
+        Ok(())
+    }
+}
+
+#[async_trait::async_trait]
+impl Maintaining for Postgres {
+    async fn run_maintenance(&self) -> Result<()> {
+        self.remove_expired_quotes(Utc::now())
+            .await
+            .context("fee measurement maintenance error")
+    }
+}

--- a/crates/autopilot/src/lib.rs
+++ b/crates/autopilot/src/lib.rs
@@ -54,7 +54,7 @@ pub async fn main(args: arguments::Arguments) {
     ));
 
     let service_maintainer = shared::maintenance::ServiceMaintenance {
-        maintainers: vec![event_updater],
+        maintainers: vec![event_updater, Arc::new(db.clone())],
     };
     let maintenance_task =
         tokio::task::spawn(service_maintainer.run_maintenance_on_new_block(current_block_stream));

--- a/crates/orderbook/src/database/quotes.rs
+++ b/crates/orderbook/src/database/quotes.rs
@@ -15,7 +15,6 @@ use database::{
 use model::quote::QuoteId;
 use number_conversions::{big_decimal_to_u256, u256_to_big_decimal};
 use primitive_types::H160;
-use shared::maintenance::Maintaining;
 
 impl TryFrom<QuoteRow> for QuoteData {
     type Error = anyhow::Error;
@@ -101,27 +100,5 @@ impl QuoteStoring for Postgres {
         quote
             .map(|quote| Ok((quote.id, quote.try_into()?)))
             .transpose()
-    }
-}
-
-impl Postgres {
-    pub async fn remove_expired_quotes(&self, max_expiry: DateTime<Utc>) -> Result<()> {
-        let _timer = super::Metrics::get()
-            .database_queries
-            .with_label_values(&["remove_expired_quotes"])
-            .start_timer();
-
-        let mut ex = self.pool.acquire().await?;
-        database::quotes::remove_expired_quotes(&mut ex, max_expiry).await?;
-        Ok(())
-    }
-}
-
-#[async_trait::async_trait]
-impl Maintaining for Postgres {
-    async fn run_maintenance(&self) -> Result<()> {
-        self.remove_expired_quotes(Utc::now())
-            .await
-            .context("fee measurement maintenance error")
     }
 }

--- a/crates/orderbook/src/main.rs
+++ b/crates/orderbook/src/main.rs
@@ -540,11 +540,7 @@ async fn main() {
         order_validator.clone(),
     ));
     let mut service_maintainer = ServiceMaintenance {
-        maintainers: vec![
-            database.clone(),
-            pool_fetcher,
-            solvable_orders_cache.clone(),
-        ],
+        maintainers: vec![pool_fetcher, solvable_orders_cache.clone()],
     };
     if let Some(balancer) = balancer_pool_fetcher {
         service_maintainer.maintainers.push(balancer);


### PR DESCRIPTION
No logic change.
Cleaning old quotes makes more sense in the autopilot because it doesn't make sense to scale this process up with the api pods. It only needs to happen in one place.

### Test Plan

CI
