### PR TITLE
Move signature validator module into shared

### DIFF
--- a/crates/e2e/tests/e2e/services.rs
+++ b/crates/e2e/tests/e2e/services.rs
@@ -9,7 +9,6 @@ use orderbook::{
     order_quoting::{OrderQuoter, QuoteHandler},
     order_validation::{OrderValidator, SignatureConfiguration},
     orderbook::Orderbook,
-    signature_validator::Web3SignatureValidator,
     solvable_orders::SolvableOrdersCache,
 };
 use reqwest::Client;
@@ -24,6 +23,7 @@ use shared::{
     price_estimation::sanitized::SanitizedPriceEstimator,
     rate_limiter::RateLimiter,
     recent_block_cache::CacheConfig,
+    signature_validator::Web3SignatureValidator,
     sources::uniswap_v2::{
         self,
         pair_provider::PairProvider,

--- a/crates/orderbook/src/lib.rs
+++ b/crates/orderbook/src/lib.rs
@@ -7,7 +7,6 @@ pub mod metrics;
 pub mod order_quoting;
 pub mod order_validation;
 pub mod orderbook;
-pub mod signature_validator;
 pub mod solvable_orders;
 pub mod solver_competition;
 

--- a/crates/orderbook/src/main.rs
+++ b/crates/orderbook/src/main.rs
@@ -16,7 +16,6 @@ use orderbook::{
     order_validation::{OrderValidator, SignatureConfiguration},
     orderbook::Orderbook,
     serve_api,
-    signature_validator::Web3SignatureValidator,
     solvable_orders::SolvableOrdersCache,
     verify_deployed_contract_constants,
 };
@@ -58,6 +57,7 @@ use shared::{
     },
     rate_limiter::RateLimiter,
     recent_block_cache::CacheConfig,
+    signature_validator::Web3SignatureValidator,
     sources::balancer_v2::BalancerFactoryKind,
     sources::{
         self,

--- a/crates/orderbook/src/order_validation.rs
+++ b/crates/orderbook/src/order_validation.rs
@@ -1,9 +1,6 @@
-use crate::{
-    order_quoting::{
-        CalculateQuoteError, FindQuoteError, OrderQuoting, Quote, QuoteParameters,
-        QuoteSearchParameters,
-    },
-    signature_validator::{SignatureCheck, SignatureValidating, SignatureValidationError},
+use crate::order_quoting::{
+    CalculateQuoteError, FindQuoteError, OrderQuoting, Quote, QuoteParameters,
+    QuoteSearchParameters,
 };
 use anyhow::anyhow;
 use contracts::WETH9;
@@ -21,6 +18,7 @@ use shared::{
     account_balances::{BalanceFetching, TransferSimulationError},
     bad_token::BadTokenDetecting,
     price_estimation::PriceEstimationError,
+    signature_validator::{SignatureCheck, SignatureValidating, SignatureValidationError},
     web3_traits::CodeFetching,
 };
 use std::{collections::HashSet, sync::Arc, time::Duration};
@@ -577,7 +575,7 @@ fn is_order_outside_market_price(order: &OrderData, quote: &Quote) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{order_quoting::MockOrderQuoting, signature_validator::MockSignatureValidating};
+    use crate::order_quoting::MockOrderQuoting;
     use anyhow::anyhow;
     use chrono::Utc;
     use ethcontract::web3::signing::SecretKeyRef;
@@ -590,6 +588,7 @@ mod tests {
         bad_token::{MockBadTokenDetecting, TokenQuality},
         dummy_contract,
         rate_limiter::RateLimiterError,
+        signature_validator::MockSignatureValidating,
         web3_traits::MockCodeFetching,
     };
 

--- a/crates/orderbook/src/orderbook.rs
+++ b/crates/orderbook/src/orderbook.rs
@@ -330,8 +330,7 @@ mod tests {
     use super::*;
     use crate::{
         database::orders::MockOrderStoring, metrics::NoopMetrics,
-        order_validation::MockOrderValidating, signature_validator::MockSignatureValidating,
-        solver_competition::MockSolverCompetitionStoring,
+        order_validation::MockOrderValidating, solver_competition::MockSolverCompetitionStoring,
     };
     use ethcontract::H160;
     use mockall::predicate::eq;
@@ -343,6 +342,7 @@ mod tests {
     use shared::{
         account_balances::MockBalanceFetching, bad_token::MockBadTokenDetecting, current_block,
         price_estimation::native::MockNativePriceEstimating,
+        signature_validator::MockSignatureValidating,
     };
 
     fn mock_orderbook() -> Orderbook {

--- a/crates/orderbook/src/solvable_orders.rs
+++ b/crates/orderbook/src/solvable_orders.rs
@@ -1,8 +1,4 @@
-use crate::{
-    database::orders::OrderStoring,
-    signature_validator::{SignatureCheck, SignatureValidating},
-    solver_competition::SolverCompetitionStoring,
-};
+use crate::{database::orders::OrderStoring, solver_competition::SolverCompetitionStoring};
 use anyhow::{Context as _, Result};
 use ethcontract::H256;
 use futures::StreamExt;
@@ -14,6 +10,7 @@ use shared::{
     current_block::CurrentBlockStream,
     maintenance::Maintaining,
     price_estimation::native::NativePriceEstimating,
+    signature_validator::{SignatureCheck, SignatureValidating},
 };
 use std::{
     collections::{BTreeMap, HashMap, HashSet},
@@ -518,11 +515,8 @@ async fn filter_unsupported_tokens(
 mod tests {
     use super::*;
     use crate::{
-        database::orders::MockOrderStoring,
-        database::orders::SolvableOrders as DbOrders,
-        metrics::NoopMetrics,
-        signature_validator::{MockSignatureValidating, SignatureValidationError},
-        solver_competition::MockSolverCompetitionStoring,
+        database::orders::MockOrderStoring, database::orders::SolvableOrders as DbOrders,
+        metrics::NoopMetrics, solver_competition::MockSolverCompetitionStoring,
     };
     use chrono::{DateTime, NaiveDateTime, Utc};
     use futures::{FutureExt, StreamExt};
@@ -536,6 +530,7 @@ mod tests {
         account_balances::MockBalanceFetching,
         bad_token::list_based::ListBasedDetector,
         price_estimation::{native::MockNativePriceEstimating, PriceEstimationError},
+        signature_validator::{MockSignatureValidating, SignatureValidationError},
     };
 
     #[tokio::test]

--- a/crates/shared/src/lib.rs
+++ b/crates/shared/src/lib.rs
@@ -23,6 +23,7 @@ pub mod price_estimation;
 pub mod rate_limiter;
 pub mod recent_block_cache;
 pub mod request_sharing;
+pub mod signature_validator;
 pub mod solver_utils;
 pub mod sources;
 pub mod subgraph;

--- a/crates/shared/src/signature_validator.rs
+++ b/crates/shared/src/signature_validator.rs
@@ -1,9 +1,9 @@
+use crate::{ethcontract_error::EthcontractErrorType, transport::MAX_BATCH_SIZE, Web3};
 use contracts::ERC1271SignatureValidator;
 use ethcontract::{batch::CallBatch, errors::MethodError, Bytes};
 use futures::future;
 use hex_literal::hex;
 use primitive_types::H160;
-use shared::{ethcontract_error::EthcontractErrorType, transport::MAX_BATCH_SIZE, Web3};
 use thiserror::Error;
 
 /// Structure used to represent a signature.
@@ -26,7 +26,7 @@ pub enum SignatureValidationError {
     Other(#[from] MethodError),
 }
 
-#[cfg_attr(test, mockall::automock)]
+#[mockall::automock]
 #[async_trait::async_trait]
 /// <https://eips.ethereum.org/EIPS/eip-1271>
 pub trait SignatureValidating: Send + Sync {


### PR DESCRIPTION
This module is needed in orderbook and autopilot. Later I might do a fine grained refactor move some things out of shared again.

No logic change.

### Test Plan

CI
