### PR TITLE
Drop oneinch solutions with insignificant improvement

### DIFF
--- a/crates/e2e/tests/e2e/eth_integration.rs
+++ b/crates/e2e/tests/e2e/eth_integration.rs
@@ -256,6 +256,7 @@ async fn eth_integration(web3: Web3) {
         None,
         None.into(),
         None,
+        None,
     );
     driver.single_run().await.unwrap();
 

--- a/crates/e2e/tests/e2e/onchain_settlement.rs
+++ b/crates/e2e/tests/e2e/onchain_settlement.rs
@@ -261,6 +261,7 @@ async fn onchain_settlement(web3: Web3) {
         None,
         None.into(),
         None,
+        None,
     );
     driver.single_run().await.unwrap();
 

--- a/crates/e2e/tests/e2e/settlement_without_onchain_liquidity.rs
+++ b/crates/e2e/tests/e2e/settlement_without_onchain_liquidity.rs
@@ -250,6 +250,7 @@ async fn onchain_settlement_without_liquidity(web3: Web3) {
         None,
         None.into(),
         None,
+        None,
     );
     driver.single_run().await.unwrap();
 

--- a/crates/e2e/tests/e2e/smart_contract_orders.rs
+++ b/crates/e2e/tests/e2e/smart_contract_orders.rs
@@ -287,6 +287,7 @@ async fn smart_contract_orders(web3: Web3) {
         None,
         None.into(),
         None,
+        None,
     );
     driver.single_run().await.unwrap();
 

--- a/crates/e2e/tests/e2e/vault_balances.rs
+++ b/crates/e2e/tests/e2e/vault_balances.rs
@@ -200,6 +200,7 @@ async fn vault_balances(web3: Web3) {
         None,
         None.into(),
         None,
+        None,
     );
     driver.single_run().await.unwrap();
 

--- a/crates/solver/src/arguments.rs
+++ b/crates/solver/src/arguments.rs
@@ -149,6 +149,11 @@ pub struct Arguments {
     #[clap(long, env)]
     pub oneinch_max_slippage_in_eth: Option<f64>,
 
+    /// The minimum improvement in terms of objective solutions by 1Inch have to improve
+    /// over the next best solution to be considered viable. Denominated in ETH.
+    #[clap(long, env)]
+    pub minimum_oneinch_objective_improvement_in_eth: Option<f64>,
+
     /// How to to submit settlement transactions.
     /// Expected to contain either:
     /// 1. One value equal to TransactionStrategyArg::DryRun or
@@ -306,6 +311,9 @@ impl std::fmt::Display for Arguments {
         writeln!(f, "paraswap_slippage_bps: {}", self.paraswap_slippage_bps)?;
         writeln!(f, "zeroex_slippage_bps: {}", self.zeroex_slippage_bps)?;
         writeln!(f, "oneinch_slippage_bps: {}", self.oneinch_slippage_bps)?;
+        write!(f, "minimum_oneinch_objective_improvement_in_eth: ")?;
+        display_option(&self.minimum_oneinch_objective_improvement_in_eth, f)?;
+        writeln!(f)?;
         writeln!(f, "transaction_strategy: {:?}", self.transaction_strategy)?;
         writeln!(
             f,

--- a/crates/solver/src/driver.rs
+++ b/crates/solver/src/driver.rs
@@ -1016,48 +1016,20 @@ mod tests {
     }
 
     #[test]
-    fn none_oneinch_solutions_stay() {
-        let dummy = dummy_arc_solver_with_name("Dummy");
-
-        let solutions = vec![settlement(&dummy, 1, 1.), settlement(&dummy, 2, 1.)];
-        let filtered_solutions = drop_bad_oneinch_solutions(solutions, &r(1.));
-        // non-1Inch solutions don't get dropped although they don't impove upon each other
-        assert_solutions(&filtered_solutions, &[1, 2]);
-    }
-
-    #[test]
-    fn leading_oneinch_solutions_stay() {
+    fn drops_oneinch_solutions_with_insignificant_improvements() {
         let oneinch = dummy_arc_solver_with_name("1Inch");
         let dummy = dummy_arc_solver_with_name("Dummy");
 
         let solutions = vec![
-            settlement(&oneinch, 1, 1.), // no baseline exists -> stays
-            settlement(&oneinch, 2, 1.), // no baseline exists -> stays
-            settlement(&dummy, 3, 1.),   // non-1Inch solutions required to create a baseline
-            settlement(&oneinch, 4, 1.), // 1Inch solution as good as the baseline -> filtered out
-            settlement(&oneinch, 5, 2.), // 1Inch solution improving upon baseline enough -> stays
-            settlement(&dummy, 6, 2.),   // new baseline
-            settlement(&oneinch, 7, 2.), // 1Inch solution as good as the baseline -> filtered out
-            settlement(&oneinch, 8, 4.), // 1Inch solution improving upon baseline enough -> stays
+            settlement(&oneinch, 1, -4.),  // no baseline exists -> stays
+            settlement(&oneinch, 2, -3.),  // no baseline exists -> stays
+            settlement(&dummy, 3, -0.5),   // non-1Inch solutions required to create a baseline
+            settlement(&oneinch, 4, -0.5), // 1Inch solution as good as the baseline -> filtered out
+            settlement(&oneinch, 5, 0.5),  // 1Inch solution improving upon baseline enough -> stays
+            settlement(&dummy, 6, 3.0),    // new baseline
+            settlement(&oneinch, 7, 3.0),  // 1Inch solution as good as the baseline -> filtered out
+            settlement(&oneinch, 8, 4.0),  // 1Inch solution improving upon baseline enough -> stays
         ];
-        let filtered_solutions = drop_bad_oneinch_solutions(solutions.clone(), &r(1.));
-        assert_solutions(&filtered_solutions, &[1, 2, 3, 5, 6, 8]);
-    }
-
-    #[test]
-    fn oneinch_solutions_filtering_negative_objectives() {
-        let oneinch = dummy_arc_solver_with_name("1Inch");
-        let dummy = dummy_arc_solver_with_name("Dummy");
-
-        let solutions = vec![
-            settlement(&dummy, 1, -8.),
-            settlement(&oneinch, 2, -4.),
-            settlement(&dummy, 3, -1.),
-            settlement(&oneinch, 4, -0.),
-            settlement(&oneinch, 5, 0.),
-            settlement(&oneinch, 6, 1.),
-        ];
-
         let filtered_solutions = drop_bad_oneinch_solutions(solutions.clone(), &r(1.));
         assert_solutions(&filtered_solutions, &[1, 2, 3, 5, 6, 8]);
     }

--- a/crates/solver/src/main.rs
+++ b/crates/solver/src/main.rs
@@ -421,7 +421,7 @@ async fn main() {
         args.token_list_restriction_for_price_checks.into(),
         tenderly,
         args.minimum_oneinch_objective_improvement_in_eth
-            .and_then(|v| num::BigRational::from_float(v * 1e18)),
+            .and_then(|v| Some(U256::from_f64_lossy(v * 1e18))),
     );
 
     let maintainer = ServiceMaintenance {

--- a/crates/solver/src/main.rs
+++ b/crates/solver/src/main.rs
@@ -421,7 +421,7 @@ async fn main() {
         args.token_list_restriction_for_price_checks.into(),
         tenderly,
         args.minimum_oneinch_objective_improvement_in_eth
-            .and_then(|v| Some(U256::from_f64_lossy(v * 1e18))),
+            .map(|v| U256::from_f64_lossy(v * 1e18)),
     );
 
     let maintainer = ServiceMaintenance {

--- a/crates/solver/src/main.rs
+++ b/crates/solver/src/main.rs
@@ -420,6 +420,8 @@ async fn main() {
             .map(|max_price_deviation| Ratio::from_float(max_price_deviation).unwrap()),
         args.token_list_restriction_for_price_checks.into(),
         tenderly,
+        args.minimum_oneinch_objective_improvement_in_eth
+            .and_then(|v| num::BigRational::from_float(v * 1e18)),
     );
 
     let maintainer = ServiceMaintenance {

--- a/crates/solver/src/solver.rs
+++ b/crates/solver/src/solver.rs
@@ -464,7 +464,9 @@ impl Solver for SellVolumeFilteringSolver {
 }
 
 #[cfg(test)]
-struct DummySolver;
+struct DummySolver {
+    name: &'static str,
+}
 #[cfg(test)]
 #[async_trait::async_trait]
 impl Solver for DummySolver {
@@ -475,12 +477,18 @@ impl Solver for DummySolver {
         todo!()
     }
     fn name(&self) -> &'static str {
-        "DummySolver"
+        self.name
     }
 }
 #[cfg(test)]
 pub fn dummy_arc_solver() -> Arc<dyn Solver> {
-    Arc::new(DummySolver)
+    Arc::new(DummySolver {
+        name: "DummySolver",
+    })
+}
+#[cfg(test)]
+pub fn dummy_arc_solver_with_name(name: &'static str) -> Arc<dyn Solver> {
+    Arc::new(DummySolver { name })
 }
 
 #[cfg(test)]


### PR DESCRIPTION
The `1Inch` solver is costing us a lot of money because `1Inch` is keeping positive slippage. However, the prices generated by 1Inch are too good to drop it entirely so we have to be smart about which solutions we want to allow.

There are a few solvers which use `1Inch` under the hood and sometimes generate solutions very close to the `1Inch` solver (almost identical objective value). I think it would be a reasonable trade-off to use those slightly worse prices to manage the negative slippage we have to incur.
Intuitively I wanted to let the user specify that `1Inch` has to improve the currently best solution by X% in order to be considered but computing relative improvements becomes tricky when we can have negative objective values.
After consulting @harisang about it I ended up using an absolute improvement to decide whether an `1Inch` solution is good enough to consider.

Finding that threshold is a bit tricky because the objective value is based on a few variables.
I used following query to find the relevant data:
```sql
SELECT 
    ABS(((json->'solutions'->-2->'objective'->>'total')::float - (json->'solutions'->-1->'objective'->>'total')::float)) / 10e18 as objective_difference,
    ((json->'solutions'->-1->'objective'->>'total')::float / (json->'solutions'->-2->'objective'->>'total')::float) as objective_relative,
    json->'solutions'->-1->>'solver' as winner,
    json->'solutions'->-2->>'solver' as runner_up,
	*
FROM public.solver_competitions
WHERE json->'solutions'->-1->>'solver' = '1Inch'
    AND json->'solutions'->-2->>'solver' != '1Inch'
ORDER BY objective_difference ASC LIMIT 1000
```
With that data I propose a threshold of `5 * 10^-6`. This threshold would discard ~10% of the winning 1Inch solutions and replace a vast majority of them with a mostly equivalent solution by `Atlas`. If negative slippage is proportional to the number of settled auctions we should cut the costs of running the `1Inch` solver by ~10% as well. This is obviously not good enough but I think it's a good step in the right direction.

### Test Plan
unit test and monitoring of the negative slippage of `1Inch` after deployment.
