### PR TITLE
Activate UniswapV3 pool fetching periodic maintenance

### DIFF
--- a/crates/orderbook/src/main.rs
+++ b/crates/orderbook/src/main.rs
@@ -62,7 +62,7 @@ use shared::{
         self,
         balancer_v2::{pool_fetching::BalancerContracts, BalancerPoolFetcher},
         uniswap_v2::pool_cache::PoolCache,
-        uniswap_v3::pool_fetching::AutoUpdatingUniswapV3PoolFetcher,
+        uniswap_v3::pool_fetching::UniswapV3PoolFetcher,
         BaselineSource, PoolAggregator,
     },
     token_info::{CachedTokenInfoFetcher, TokenInfoFetcher},
@@ -289,7 +289,7 @@ async fn main() {
     };
     let uniswap_v3_pool_fetcher = if baseline_sources.contains(&BaselineSource::UniswapV3) {
         let uniswap_v3_pool_fetcher = Arc::new(
-            AutoUpdatingUniswapV3PoolFetcher::new(
+            UniswapV3PoolFetcher::new(
                 chain_id,
                 args.shared.liquidity_fetcher_max_age_update,
                 client.clone(),
@@ -553,6 +553,9 @@ async fn main() {
     };
     if let Some(balancer) = balancer_pool_fetcher {
         service_maintainer.maintainers.push(balancer);
+    }
+    if let Some(uniswap_v3) = uniswap_v3_pool_fetcher {
+        service_maintainer.maintainers.push(uniswap_v3);
     }
     check_database_connection(orderbook.as_ref()).await;
     let quotes =

--- a/crates/shared/src/price_estimation/http.rs
+++ b/crates/shared/src/price_estimation/http.rs
@@ -22,9 +22,7 @@ use crate::{
             pools::common::compute_scaling_rate, BalancerPoolFetcher, BalancerPoolFetching,
         },
         uniswap_v2::{pool_cache::PoolCache, pool_fetching::PoolFetching},
-        uniswap_v3::pool_fetching::{
-            AutoUpdatingUniswapV3PoolFetcher, PoolFetching as UniswapV3PoolFetching,
-        },
+        uniswap_v3::pool_fetching::{PoolFetching as UniswapV3PoolFetching, UniswapV3PoolFetcher},
     },
     token_info::TokenInfoFetching,
 };
@@ -48,7 +46,7 @@ pub struct HttpPriceEstimator {
     >,
     pools: Arc<PoolCache>,
     balancer_pools: Option<Arc<BalancerPoolFetcher>>,
-    uniswap_v3_pools: Option<Arc<AutoUpdatingUniswapV3PoolFetcher>>,
+    uniswap_v3_pools: Option<Arc<UniswapV3PoolFetcher>>,
     token_info: Arc<dyn TokenInfoFetching>,
     gas_info: Arc<dyn GasPriceEstimating>,
     native_token: H160,
@@ -63,7 +61,7 @@ impl HttpPriceEstimator {
         api: Arc<dyn HttpSolverApi>,
         pools: Arc<PoolCache>,
         balancer_pools: Option<Arc<BalancerPoolFetcher>>,
-        uniswap_v3_pools: Option<Arc<AutoUpdatingUniswapV3PoolFetcher>>,
+        uniswap_v3_pools: Option<Arc<UniswapV3PoolFetcher>>,
         token_info: Arc<dyn TokenInfoFetching>,
         gas_info: Arc<dyn GasPriceEstimating>,
         native_token: H160,
@@ -476,13 +474,9 @@ mod tests {
             .expect("failed to create Balancer pool fetcher"),
         );
         let uniswap_v3_pool_fetcher = Arc::new(
-            AutoUpdatingUniswapV3PoolFetcher::new(
-                chain_id,
-                Duration::from_secs(30),
-                client.clone(),
-            )
-            .await
-            .expect("failed to create uniswap v3 pool fetcher"),
+            UniswapV3PoolFetcher::new(chain_id, Duration::from_secs(30), client.clone())
+                .await
+                .expect("failed to create uniswap v3 pool fetcher"),
         );
         let gas_info = Arc::new(web3);
 

--- a/crates/shared/src/sources/uniswap_v3/pool_fetching.rs
+++ b/crates/shared/src/sources/uniswap_v3/pool_fetching.rs
@@ -1,3 +1,5 @@
+use crate::maintenance::Maintaining;
+
 use super::graph_api::{PoolData, Token, UniV3SubgraphClient};
 use anyhow::{Context, Result};
 use ethcontract::{H160, U256};
@@ -10,7 +12,7 @@ use serde::{Deserialize, Serialize};
 use serde_with::{serde_as, DisplayFromStr};
 use std::{
     collections::{BTreeMap, HashMap, HashSet},
-    sync::{Arc, Mutex, Weak},
+    sync::Mutex,
     time::{Duration, Instant},
 };
 
@@ -208,52 +210,18 @@ impl PoolFetching for UniswapV3PoolFetcher {
     }
 }
 
-pub struct AutoUpdatingUniswapV3PoolFetcher(Arc<UniswapV3PoolFetcher>);
-
-impl AutoUpdatingUniswapV3PoolFetcher {
-    /// Creates new CachingUniswapV3PoolFetcher with the purpose of spawning an additional
-    /// background task for periodic update of cache
-    pub async fn new(chain_id: u64, max_age: Duration, client: Client) -> Result<Self> {
-        Ok(Self(Arc::new(
-            UniswapV3PoolFetcher::new(chain_id, max_age, client).await?,
-        )))
-    }
-
-    /// Spawns a background task maintaining the cache once per `update_interval`.
-    /// Only soon to be outdated pools get updated and recently used pools have a higher priority.
-    /// If `update_size` is `Some(n)` at most `n` pools get updated per interval.
-    /// If `update_size` is `None` no limit gets applied.
-    pub fn spawn_maintenance_task(&self, update_interval: Duration, update_size: Option<usize>) {
-        tokio::spawn(update_recently_used_outdated_pools(
-            Arc::downgrade(&self.0),
-            update_interval,
-            update_size,
-        ));
-    }
-}
-
 #[async_trait::async_trait]
-impl PoolFetching for AutoUpdatingUniswapV3PoolFetcher {
-    async fn fetch(&self, token_pairs: &HashSet<TokenPair>) -> Result<Vec<PoolInfo>> {
-        self.0.fetch(token_pairs).await
-    }
-}
-
-async fn update_recently_used_outdated_pools(
-    inner: Weak<UniswapV3PoolFetcher>,
-    update_interval: Duration,
-    update_size: Option<usize>,
-) {
-    while let Some(inner) = inner.upgrade() {
-        tracing::debug!("periodical update started");
+impl Maintaining for UniswapV3PoolFetcher {
+    async fn run_maintenance(&self) -> Result<()> {
+        tracing::debug!("periodic update started");
         let now = Instant::now();
 
-        let mut outdated_entries = inner
+        let mut outdated_entries = self
             .cache
             .lock()
             .unwrap()
             .iter()
-            .filter(|(_, cached)| now.saturating_duration_since(cached.updated_at) > inner.max_age)
+            .filter(|(_, cached)| now.saturating_duration_since(cached.updated_at) > self.max_age)
             .map(|(pool_id, cached)| (*pool_id, cached.requested_at))
             .collect::<Vec<_>>();
         outdated_entries.sort_by_key(|entry| std::cmp::Reverse(entry.1));
@@ -261,13 +229,12 @@ async fn update_recently_used_outdated_pools(
 
         let pools_to_update = outdated_entries
             .iter()
-            .take(update_size.unwrap_or(outdated_entries.len()))
             .map(|(pool_id, _)| *pool_id)
             .collect::<Vec<_>>();
         tracing::debug!("pools to update {:?}", pools_to_update);
 
         if !pools_to_update.is_empty() {
-            if let Err(err) = inner.get_pools_and_update_cache(&pools_to_update).await {
+            if let Err(err) = self.get_pools_and_update_cache(&pools_to_update).await {
                 tracing::warn!(
                     error = %err,
                     "failed to update pools",
@@ -275,8 +242,8 @@ async fn update_recently_used_outdated_pools(
             }
         }
 
-        tracing::debug!("periodical update ended");
-        tokio::time::sleep(update_interval.saturating_sub(now.elapsed())).await;
+        tracing::debug!("periodic update ended");
+        Ok(())
     }
 }
 
@@ -379,26 +346,10 @@ mod tests {
 
     #[tokio::test]
     #[ignore]
-    async fn caching_uniswap_v3_pool_fetcher_test() {
-        let fetcher =
-            AutoUpdatingUniswapV3PoolFetcher::new(1, Duration::from_secs(10), Client::new())
-                .await
-                .unwrap();
-
-        fetcher.spawn_maintenance_task(Duration::from_secs(1), Some(50));
-
-        loop {
-            tokio::time::sleep(Duration::from_secs(1)).await;
-        }
-    }
-
-    #[tokio::test]
-    #[ignore]
     async fn fetch_test() {
-        let fetcher =
-            AutoUpdatingUniswapV3PoolFetcher::new(1, Duration::from_secs(10), Client::new())
-                .await
-                .unwrap();
+        let fetcher = UniswapV3PoolFetcher::new(1, Duration::from_secs(10), Client::new())
+            .await
+            .unwrap();
         let token_pairs = HashSet::from([TokenPair::new(
             H160::from_str("0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2").unwrap(),
             H160::from_str("0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48").unwrap(),


### PR DESCRIPTION
This PR activates periodic background maintenance task to update the pools liquidity on UniswapV3 pools (I forgot to add this in https://github.com/cowprotocol/services/pull/388).

Initially, this was intended to be done with:
`uniswap_v3_pool_fetcher.spawn_maintenance_task(...)`
but it makes more sense to me to add this function to the `ServiceMaintenance` which is triggered on each new block. Although currently UniswapV3 is using subgraph under the hood, this change makes even more sense since we are moving towards an event based pool liquidity update.
