### PR TITLE
Fix default baseline sources for Goerli

### DIFF
--- a/crates/shared/src/arguments.rs
+++ b/crates/shared/src/arguments.rs
@@ -20,7 +20,7 @@ pub struct Arguments {
     #[clap(
         long,
         env,
-        default_value = "warn,orderbook=debug,solver=debug,shared=debug,shared::transport::http=info"
+        default_value = "warn,autopilot=debug,driver=debug,orderbook=debug,solver=debug,shared=debug,shared::transport::http=info"
     )]
     pub log_filter: String,
 

--- a/crates/shared/src/sources.rs
+++ b/crates/shared/src/sources.rs
@@ -51,7 +51,7 @@ pub fn defaults_for_chain(chain_id: u64) -> Result<Vec<BaselineSource>> {
         5 => vec![
             BaselineSource::UniswapV2,
             BaselineSource::SushiSwap,
-            BaselineSource::UniswapV3,
+            BaselineSource::BalancerV2,
         ],
         100 => vec![
             BaselineSource::Honeyswap,


### PR DESCRIPTION
I noticed when configuring our `autopilot` pod that when using the default `--baseline-sources`, it would crash-loop.

The default baseline sources include Uniswap V3, however it fails to initialize for Görli because of a missing subgraph.

Additionally, Balancer V2 is supported on Görli but was missing from the default configuration.

### Test Plan

Run the autopilot with `UniswapV2,SushiSwap,BalancerV2` connected to Görli and see it not crash:
```
...
2022-08-09T17:40:47.437Z  INFO autopilot: using baseline sources baseline_sources=[UniswapV2, SushiSwap, BalancerV2]
...
```
