### PR TITLE
Move auction creation into autopilot

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -172,6 +172,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
+ "chrono",
  "clap 3.2.5",
  "contracts",
  "database",
@@ -179,6 +180,8 @@ dependencies = [
  "futures",
  "gas-estimation",
  "global-metrics",
+ "maplit",
+ "mockall",
  "model",
  "number_conversions",
  "primitive-types",

--- a/crates/autopilot/Cargo.toml
+++ b/crates/autopilot/Cargo.toml
@@ -15,6 +15,7 @@ path = "src/main.rs"
 [dependencies]
 anyhow = "1.0"
 async-trait = "0.1"
+chrono = { version = "0.4", default-features = false, features = ["clock"] }
 clap = { version = "3.1", features = ["derive", "env"] }
 contracts = { path = "../contracts" }
 database = { path = "../database" }
@@ -22,6 +23,7 @@ ethcontract = { version = "0.17.0", default-features = false }
 futures = "0.3"
 gas-estimation = { git = "https://github.com/cowprotocol/gas-estimation", tag = "v0.7.0", features = ["web3_"] }
 global-metrics = { path = "../global-metrics" }
+maplit = "1.0"
 model = { path = "../model" }
 number_conversions = { path = "../number_conversions" }
 primitive-types = { version = "0.10" }
@@ -34,3 +36,7 @@ tokio = { version = "1.15", features = ["macros", "rt-multi-thread", "sync", "ti
 tracing = "0.1"
 url = "2.2"
 web3 = { version = "0.18", default-features = false }
+
+
+[dev-dependencies]
+mockall = "0.11"

--- a/crates/autopilot/src/arguments.rs
+++ b/crates/autopilot/src/arguments.rs
@@ -103,6 +103,19 @@ pub struct Arguments {
         parse(try_from_str = shared::arguments::duration_from_seconds),
     )]
     pub native_price_cache_max_age_secs: Duration,
+
+    /// The minimum amount of time in seconds an order has to be valid for.
+    #[clap(
+        long,
+        env,
+        default_value = "60",
+        parse(try_from_str = shared::arguments::duration_from_seconds),
+    )]
+    pub min_order_validity_period: Duration,
+
+    /// List of account addresses to be denied from order creation
+    #[clap(long, env, use_value_delimiter = true)]
+    pub banned_users: Vec<H160>,
 }
 
 impl std::fmt::Display for Arguments {
@@ -149,6 +162,12 @@ impl std::fmt::Display for Arguments {
             "native_price_cache_max_age_secs: {:?}",
             self.native_price_cache_max_age_secs
         )?;
+        writeln!(
+            f,
+            "min_order_validity_period: {:?}",
+            self.min_order_validity_period
+        )?;
+        writeln!(f, "banned_users: {:?}", self.banned_users)?;
         Ok(())
     }
 }

--- a/crates/autopilot/src/database.rs
+++ b/crates/autopilot/src/database.rs
@@ -1,4 +1,4 @@
-pub mod auction;
+mod auction;
 mod events;
 mod quotes;
 

--- a/crates/autopilot/src/solvable_orders.rs
+++ b/crates/autopilot/src/solvable_orders.rs
@@ -1,15 +1,13 @@
-use crate::{database::orders::OrderStoring, solver_competition::SolverCompetitionStoring};
+use crate::database::Postgres;
 use anyhow::{Context as _, Result};
-use ethcontract::H256;
 use futures::StreamExt;
 use model::{auction::Auction, order::Order, signature::Signature, time::now_in_epoch_seconds};
-use primitive_types::{H160, U256};
+use primitive_types::{H160, H256, U256};
 use prometheus::{IntCounter, IntGauge};
 use shared::{
     account_balances::{BalanceFetching, Query},
     bad_token::BadTokenDetecting,
     current_block::CurrentBlockStream,
-    maintenance::Maintaining,
     price_estimation::native::NativePriceEstimating,
     signature_validator::{SignatureCheck, SignatureValidating},
 };
@@ -19,7 +17,7 @@ use std::{
     sync::{Arc, Mutex, Weak},
     time::Duration,
 };
-use tokio::{sync::Notify, time::Instant};
+use tokio::time::Instant;
 
 // When creating the auction after solvable orders change we need to fetch native prices for a
 // potentially large amount of tokens. This is the maximum amount of time we allot for this
@@ -52,15 +50,13 @@ pub struct Metrics {
 /// book.
 pub struct SolvableOrdersCache {
     min_order_validity_period: Duration,
-    database: Arc<dyn OrderStoring>,
+    database: Postgres,
     banned_users: HashSet<H160>,
     balance_fetcher: Arc<dyn BalanceFetching>,
     bad_token_detector: Arc<dyn BadTokenDetecting>,
-    notify: Notify,
     cache: Mutex<Inner>,
     native_price_estimator: Arc<dyn NativePriceEstimating>,
     signature_validator: Arc<dyn SignatureValidating>,
-    solver_competition: Arc<dyn SolverCompetitionStoring>,
     metrics: &'static Metrics,
 }
 
@@ -69,7 +65,6 @@ type Balances = HashMap<Query, U256>;
 struct Inner {
     orders: SolvableOrders,
     balances: Balances,
-    auction: Auction,
 }
 
 #[derive(Clone, Debug)]
@@ -84,14 +79,14 @@ impl SolvableOrdersCache {
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         min_order_validity_period: Duration,
-        database: Arc<dyn OrderStoring>,
+        database: Postgres,
         banned_users: HashSet<H160>,
         balance_fetcher: Arc<dyn BalanceFetching>,
         bad_token_detector: Arc<dyn BadTokenDetecting>,
         current_block: CurrentBlockStream,
         native_price_estimator: Arc<dyn NativePriceEstimating>,
         signature_validator: Arc<dyn SignatureValidating>,
-        solver_competition: Arc<dyn SolverCompetitionStoring>,
+        update_interval: Duration,
     ) -> Arc<Self> {
         let self_ = Arc::new(Self {
             min_order_validity_period,
@@ -99,7 +94,6 @@ impl SolvableOrdersCache {
             banned_users,
             balance_fetcher,
             bad_token_detector,
-            notify: Default::default(),
             cache: Mutex::new(Inner {
                 orders: SolvableOrders {
                     orders: Default::default(),
@@ -108,43 +102,17 @@ impl SolvableOrdersCache {
                     block: 0,
                 },
                 balances: Default::default(),
-                auction: Auction::default(),
             }),
             native_price_estimator,
             signature_validator,
-            solver_competition,
             metrics: Metrics::instance(global_metrics::get_metric_storage_registry()).unwrap(),
         });
-        tokio::task::spawn(update_task(Arc::downgrade(&self_), current_block));
+        tokio::task::spawn(update_task(
+            Arc::downgrade(&self_),
+            update_interval,
+            current_block,
+        ));
         self_
-    }
-
-    pub fn cached_balance(&self, key: &Query) -> Option<U256> {
-        let inner = self.cache.lock().unwrap();
-        inner.balances.get(key).copied()
-    }
-
-    /// Orders and timestamp at which last update happened.
-    pub fn cached_solvable_orders(&self) -> SolvableOrders {
-        self.cache.lock().unwrap().orders.clone()
-    }
-
-    // Returns auction and update time.
-    pub fn cached_auction(&self) -> (Auction, Instant) {
-        let cache = self.cache.lock().unwrap();
-        (cache.auction.clone(), cache.orders.update_time)
-    }
-
-    /// The cache will update the solvable orders and missing balances as soon as possible.
-    pub fn request_update(&self) {
-        self.notify.notify_one();
-    }
-
-    /// Updates the id immediately without having to wait for next full cache update.
-    pub async fn update_next_solver_competition_id(&self) -> Result<()> {
-        let id = self.solver_competition.next_solver_competition().await?;
-        self.cache.lock().unwrap().auction.next_solver_competition = id;
-        Ok(())
     }
 
     /// Manually update solvable orders. Usually called by the background updating task.
@@ -202,15 +170,15 @@ impl SolvableOrdersCache {
             self.metrics,
         )
         .await;
-        let next_solver_competition = self.solver_competition.next_solver_competition().await?;
         let auction = Auction {
             block,
             latest_settlement_block: db_solvable_orders.latest_settlement_block,
-            next_solver_competition,
+            next_solver_competition: self.database.next_solver_competition().await?,
             orders: orders.clone(),
             prices,
         };
 
+        self.database.replace_current_auction(&auction).await?;
         *self.cache.lock().unwrap() = Inner {
             orders: SolvableOrders {
                 orders,
@@ -219,8 +187,12 @@ impl SolvableOrdersCache {
                 block,
             },
             balances: new_balances,
-            auction,
         };
+
+        tracing::debug!(
+            "updated auction with {} solvable orders",
+            auction.orders.len(),
+        );
 
         Ok(())
     }
@@ -363,8 +335,18 @@ fn max_transfer_out_amount(order: &Order) -> Result<U256> {
 
 /// Keep updating the cache every N seconds or when an update notification happens.
 /// Exits when this becomes the only reference to the cache.
-async fn update_task(cache: Weak<SolvableOrdersCache>, current_block: CurrentBlockStream) {
+async fn update_task(
+    cache: Weak<SolvableOrdersCache>,
+    update_interval: Duration,
+    current_block: CurrentBlockStream,
+) {
     loop {
+        // We are not updating on block changes because
+        // - the state of orders could change even when the block does not like when an order
+        //   gets cancelled off chain
+        // - the event updater takes some time to run and if we go first we would not update the
+        //   orders with the most recent events.
+        tokio::time::sleep(update_interval).await;
         let cache = match cache.upgrade() {
             Some(self_) => self_,
             None => {
@@ -372,19 +354,6 @@ async fn update_task(cache: Weak<SolvableOrdersCache>, current_block: CurrentBlo
                 break;
             }
         };
-        {
-            // We are not updating on block changes because
-            // - the state of orders could change even when the block does not like when an order
-            //   gets cancelled off chain
-            // - the event updater takes some time to run and if we go first we would not update the
-            //   orders with the most recent events.
-            const UPDATE_INTERVAL: Duration = Duration::from_secs(2);
-            let timeout = tokio::time::sleep(UPDATE_INTERVAL);
-            let notified = cache.notify.notified();
-            futures::pin_mut!(timeout);
-            futures::pin_mut!(notified);
-            futures::future::select(timeout, notified).await;
-        }
         let block = match current_block.borrow().number {
             Some(block) => block.as_u64(),
             None => {
@@ -404,14 +373,6 @@ async fn update_task(cache: Weak<SolvableOrdersCache>, current_block: CurrentBlo
                 start.elapsed().as_secs_f32()
             ),
         }
-    }
-}
-
-#[async_trait::async_trait]
-impl Maintaining for SolvableOrdersCache {
-    async fn run_maintenance(&self) -> Result<()> {
-        self.request_update();
-        Ok(())
     }
 }
 
@@ -530,20 +491,13 @@ async fn filter_unsupported_tokens(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{
-        database::orders::MockOrderStoring, database::orders::SolvableOrders as DbOrders,
-        solver_competition::MockSolverCompetitionStoring,
-    };
     use chrono::{DateTime, NaiveDateTime, Utc};
     use futures::{FutureExt, StreamExt};
     use maplit::{btreemap, hashmap, hashset};
     use mockall::predicate::eq;
-    use model::order::{
-        OrderBuilder, OrderData, OrderKind, OrderMetadata, OrderUid, SellTokenSource,
-    };
+    use model::order::{OrderBuilder, OrderData, OrderKind, OrderMetadata, OrderUid};
     use primitive_types::H160;
     use shared::{
-        account_balances::MockBalanceFetching,
         bad_token::list_based::ListBasedDetector,
         price_estimation::{native::MockNativePriceEstimating, PriceEstimationError},
         signature_validator::{MockSignatureValidating, SignatureValidationError},
@@ -586,153 +540,6 @@ mod tests {
             DateTime::from_utc(NaiveDateTime::from_timestamp(3, 0), Utc);
         let orders_ = solvable_orders(orders.clone(), &balances);
         assert_eq!(orders_, orders[1..]);
-    }
-
-    #[tokio::test]
-    async fn caches_orders_and_balances() {
-        let mut balance_fetcher = MockBalanceFetching::new();
-        let mut order_storing = MockOrderStoring::new();
-        let (_, receiver) = tokio::sync::watch::channel(Default::default());
-        let bad_token_detector =
-            shared::bad_token::list_based::ListBasedDetector::deny_list(Vec::new());
-
-        let owner = H160::from_low_u64_le(0);
-        let sell_token_0 = H160::from_low_u64_le(1);
-        let sell_token_1 = H160::from_low_u64_le(2);
-
-        let orders = [
-            Order {
-                data: OrderData {
-                    sell_token: sell_token_0,
-                    sell_token_balance: SellTokenSource::Erc20,
-                    sell_amount: 1.into(),
-                    buy_amount: 1.into(),
-                    ..Default::default()
-                },
-                metadata: OrderMetadata {
-                    owner,
-                    ..Default::default()
-                },
-                ..Default::default()
-            },
-            Order {
-                data: OrderData {
-                    sell_token: sell_token_1,
-                    sell_token_balance: SellTokenSource::Erc20,
-                    sell_amount: 1.into(),
-                    buy_amount: 1.into(),
-                    ..Default::default()
-                },
-                metadata: OrderMetadata {
-                    owner,
-                    ..Default::default()
-                },
-                ..Default::default()
-            },
-        ];
-
-        order_storing
-            .expect_solvable_orders()
-            .times(1)
-            .return_once({
-                let orders = orders.clone();
-                move |_| {
-                    Ok(DbOrders {
-                        orders: vec![orders[0].clone()],
-                        latest_settlement_block: 0,
-                    })
-                }
-            });
-        order_storing
-            .expect_solvable_orders()
-            .times(1)
-            .return_once({
-                let orders = orders.clone();
-                move |_| {
-                    Ok(DbOrders {
-                        orders: orders.into(),
-                        latest_settlement_block: 0,
-                    })
-                }
-            });
-        order_storing
-            .expect_solvable_orders()
-            .times(1)
-            .return_once(|_| {
-                Ok(DbOrders {
-                    orders: Vec::new(),
-                    latest_settlement_block: 0,
-                })
-            });
-
-        balance_fetcher
-            .expect_get_balances()
-            .times(1)
-            .return_once(|_| vec![Ok(1.into())]);
-        balance_fetcher
-            .expect_get_balances()
-            .times(1)
-            .return_once(|_| vec![Ok(2.into())]);
-        balance_fetcher
-            .expect_get_balances()
-            .times(1)
-            .return_once(|_| Vec::new());
-
-        let mut native = MockNativePriceEstimating::new();
-        native.expect_estimate_native_prices().returning(|a| {
-            futures::stream::iter(std::iter::repeat(Ok(1.0)).take(a.len()).enumerate()).boxed()
-        });
-
-        let mut solver_competition = MockSolverCompetitionStoring::new();
-        solver_competition
-            .expect_next_solver_competition()
-            .returning(|| Ok(1337));
-
-        let cache = SolvableOrdersCache::new(
-            Duration::from_secs(0),
-            Arc::new(order_storing),
-            Default::default(),
-            Arc::new(balance_fetcher),
-            Arc::new(bad_token_detector),
-            receiver,
-            Arc::new(native),
-            Arc::new(MockSignatureValidating::new()),
-            Arc::new(solver_competition),
-        );
-
-        cache.update(0).await.unwrap();
-        assert_eq!(
-            cache.cached_balance(&Query::from_order(&orders[0])),
-            Some(1.into())
-        );
-        assert_eq!(cache.cached_balance(&Query::from_order(&orders[1])), None);
-        let orders_ = cache.cached_solvable_orders().orders;
-        assert_eq!(orders_.len(), 1);
-        assert_eq!(orders_[0].metadata.available_balance, Some(1.into()));
-        let auction = cache.cached_auction().0;
-        assert_eq!(auction.orders.len(), 1);
-
-        cache.update(0).await.unwrap();
-        assert_eq!(
-            cache.cached_balance(&Query::from_order(&orders[0])),
-            Some(1.into())
-        );
-        assert_eq!(
-            cache.cached_balance(&Query::from_order(&orders[1])),
-            Some(2.into())
-        );
-        let orders_ = cache.cached_solvable_orders().orders;
-        assert_eq!(orders_.len(), 2);
-        let auction = cache.cached_auction().0;
-        assert_eq!(auction.orders.len(), 2);
-
-        cache.update(0).await.unwrap();
-        assert_eq!(cache.cached_balance(&Query::from_order(&orders[0])), None,);
-        assert_eq!(cache.cached_balance(&Query::from_order(&orders[1])), None,);
-        let orders_ = cache.cached_solvable_orders().orders;
-        assert_eq!(orders_.len(), 0);
-        let auction = cache.cached_auction().0;
-        assert_eq!(auction.orders.len(), 0);
     }
 
     #[test]

--- a/crates/e2e/tests/e2e/eth_integration.rs
+++ b/crates/e2e/tests/e2e/eth_integration.rs
@@ -39,7 +39,7 @@ async fn local_node_eth_integration() {
 }
 
 async fn eth_integration(web3: Web3) {
-    shared::tracing::initialize_for_tests("warn,orderbook=debug,solver=debug");
+    shared::tracing::initialize_for_tests("warn,orderbook=debug,solver=debug,autopilot=debug");
     let contracts = crate::deploy::deploy(&web3).await.expect("deploy");
 
     let accounts: Vec<Address> = web3.eth().accounts().await.expect("get accounts failed");
@@ -183,8 +183,7 @@ async fn eth_integration(web3: Web3) {
         .await;
     assert_eq!(placement.unwrap().status(), 201);
 
-    let api = create_orderbook_api();
-    wait_for_solvable_orders(&api, 2).await.unwrap();
+    wait_for_solvable_orders(&client, 2).await.unwrap();
 
     // Drive solution
     let uniswap_pair_provider = uniswap_pair_provider(&contracts);
@@ -247,7 +246,7 @@ async fn eth_integration(web3: Web3) {
                 .unwrap(),
             ),
         },
-        api,
+        create_orderbook_api(),
         create_order_converter(&web3, contracts.weth.address()),
         0.0,
         15000000u128,

--- a/crates/e2e/tests/e2e/onchain_settlement.rs
+++ b/crates/e2e/tests/e2e/onchain_settlement.rs
@@ -42,7 +42,7 @@ async fn local_node_onchain_settlement() {
 }
 
 async fn onchain_settlement(web3: Web3) {
-    shared::tracing::initialize_for_tests("warn,orderbook=debug,solver=debug");
+    shared::tracing::initialize_for_tests("warn,orderbook=debug,solver=debug,autopilot=debug");
     let contracts = crate::deploy::deploy(&web3).await.expect("deploy");
 
     let accounts: Vec<Address> = web3.eth().accounts().await.expect("get accounts failed");
@@ -188,8 +188,7 @@ async fn onchain_settlement(web3: Web3) {
         .send()
         .await;
     assert_eq!(placement.unwrap().status(), 201);
-    let api = create_orderbook_api();
-    wait_for_solvable_orders(&api, 2).await.unwrap();
+    wait_for_solvable_orders(&client, 2).await.unwrap();
 
     // Drive solution
     let uniswap_pair_provider = uniswap_pair_provider(&contracts);
@@ -252,7 +251,7 @@ async fn onchain_settlement(web3: Web3) {
                 .unwrap(),
             ),
         },
-        api,
+        create_orderbook_api(),
         create_order_converter(&web3, contracts.weth.address()),
         0.0,
         15000000u128,

--- a/crates/e2e/tests/e2e/settlement_without_onchain_liquidity.rs
+++ b/crates/e2e/tests/e2e/settlement_without_onchain_liquidity.rs
@@ -41,7 +41,7 @@ async fn local_node_onchain_settlement_without_liquidity() {
 }
 
 async fn onchain_settlement_without_liquidity(web3: Web3) {
-    shared::tracing::initialize_for_tests("warn,orderbook=debug,solver=debug");
+    shared::tracing::initialize_for_tests("warn,orderbook=debug,solver=debug,autopilot=debug");
     let contracts = crate::deploy::deploy(&web3).await.expect("deploy");
 
     let accounts: Vec<Address> = web3.eth().accounts().await.expect("get accounts failed");
@@ -169,8 +169,7 @@ async fn onchain_settlement_without_liquidity(web3: Web3) {
         .await;
     assert_eq!(placement.unwrap().status(), 201);
 
-    let api = create_orderbook_api();
-    wait_for_solvable_orders(&api, 1).await.unwrap();
+    wait_for_solvable_orders(&client, 1).await.unwrap();
 
     // Drive solution
     let uniswap_pair_provider = uniswap_pair_provider(&contracts);
@@ -241,7 +240,7 @@ async fn onchain_settlement_without_liquidity(web3: Web3) {
                 .unwrap(),
             ),
         },
-        api,
+        create_orderbook_api(),
         create_order_converter(&web3, contracts.weth.address()),
         0.0,
         15000000u128,

--- a/crates/e2e/tests/e2e/smart_contract_orders.rs
+++ b/crates/e2e/tests/e2e/smart_contract_orders.rs
@@ -37,7 +37,7 @@ async fn local_node_smart_contract_orders() {
 }
 
 async fn smart_contract_orders(web3: Web3) {
-    shared::tracing::initialize_for_tests("warn,orderbook=debug,solver=debug");
+    shared::tracing::initialize_for_tests("warn,orderbook=debug,solver=debug,autopilot=debug");
     let contracts = crate::deploy::deploy(&web3).await.expect("deploy");
 
     let accounts: Vec<Address> = web3.eth().accounts().await.expect("get accounts failed");
@@ -117,7 +117,7 @@ async fn smart_contract_orders(web3: Web3) {
     let OrderbookServices {
         block_stream,
         maintenance,
-        solvable_orders_cache: _,
+        solvable_orders_cache: _solvable_orders_cache,
         base_tokens,
         ..
     } = OrderbookServices::new(&web3, &contracts).await;
@@ -214,8 +214,7 @@ async fn smart_contract_orders(web3: Web3) {
         OrderStatus::Open
     );
 
-    let api = create_orderbook_api();
-    wait_for_solvable_orders(&api, 2).await.unwrap();
+    wait_for_solvable_orders(&client, 2).await.unwrap();
 
     // Drive solution
     let uniswap_pair_provider = uniswap_pair_provider(&contracts);
@@ -278,7 +277,7 @@ async fn smart_contract_orders(web3: Web3) {
                 .unwrap(),
             ),
         },
-        api,
+        create_orderbook_api(),
         create_order_converter(&web3, contracts.weth.address()),
         0.0,
         15000000u128,

--- a/crates/e2e/tests/e2e/vault_balances.rs
+++ b/crates/e2e/tests/e2e/vault_balances.rs
@@ -34,7 +34,7 @@ async fn local_node_vault_balances() {
 }
 
 async fn vault_balances(web3: Web3) {
-    shared::tracing::initialize_for_tests("warn,orderbook=debug,solver=debug");
+    shared::tracing::initialize_for_tests("warn,orderbook=debug,solver=debug,autopilot=debug");
     let contracts = crate::deploy::deploy(&web3).await.expect("deploy");
 
     let accounts: Vec<Address> = web3.eth().accounts().await.expect("get accounts failed");
@@ -96,7 +96,7 @@ async fn vault_balances(web3: Web3) {
 
     let OrderbookServices {
         block_stream,
-        solvable_orders_cache: _,
+        solvable_orders_cache: _solvable_orders_cache,
         base_tokens,
         ..
     } = OrderbookServices::new(&web3, &contracts).await;
@@ -127,8 +127,7 @@ async fn vault_balances(web3: Web3) {
         .await;
     assert_eq!(placement.unwrap().status(), 201);
 
-    let api = create_orderbook_api();
-    wait_for_solvable_orders(&api, 1).await.unwrap();
+    wait_for_solvable_orders(&client, 1).await.unwrap();
 
     // Drive solution
     let uniswap_pair_provider = uniswap_pair_provider(&contracts);
@@ -191,7 +190,7 @@ async fn vault_balances(web3: Web3) {
                 .unwrap(),
             ),
         },
-        api,
+        create_orderbook_api(),
         create_order_converter(&web3, contracts.weth.address()),
         0.0,
         15000000u128,

--- a/crates/model/src/lib.rs
+++ b/crates/model/src/lib.rs
@@ -136,7 +136,7 @@ impl DomainSeparator {
     }
 }
 
-#[derive(Clone, Debug, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, Default, serde::Deserialize, serde::Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct SolvableOrders {
     pub orders: Vec<order::Order>,

--- a/crates/orderbook/src/api.rs
+++ b/crates/orderbook/src/api.rs
@@ -15,7 +15,6 @@ mod post_quote;
 pub mod post_solver_competition;
 mod replace_order;
 
-use self::post_solver_competition::SolvableOrdersCache;
 use crate::solver_competition::SolverCompetitionStoring;
 use crate::{database::trades::TradeRetrieving, order_quoting::QuoteHandler, orderbook::Orderbook};
 use shared::api::{error, finalize_router, internal_error, ApiReply};
@@ -28,7 +27,6 @@ pub fn handle_all_routes(
     quotes: Arc<QuoteHandler>,
     solver_competition: Arc<dyn SolverCompetitionStoring>,
     solver_competition_auth: Option<String>,
-    solvable_orders: Arc<dyn SolvableOrdersCache>,
 ) -> impl Filter<Extract = (impl Reply,), Error = Rejection> + Clone {
     // Routes for api v1.
 
@@ -82,7 +80,7 @@ pub fn handle_all_routes(
         .map(|result| (result, "v1/solver_competition"))
         .boxed();
     let post_solver_competition =
-        post_solver_competition::post(solver_competition, solvable_orders, solver_competition_auth)
+        post_solver_competition::post(solver_competition, solver_competition_auth)
             .map(|result| (result, "v1/solver_competition"))
             .boxed();
 

--- a/crates/orderbook/src/api/get_auction.rs
+++ b/crates/orderbook/src/api/get_auction.rs
@@ -1,8 +1,9 @@
 use crate::orderbook::Orderbook;
 use anyhow::Result;
-use shared::api::{convert_json_response, ApiReply};
+use reqwest::StatusCode;
+use shared::api::{ApiReply, IntoWarpReply};
 use std::{convert::Infallible, sync::Arc};
-use warp::{Filter, Rejection};
+use warp::{reply::with_status, Filter, Rejection};
 
 fn get_auction_request() -> impl Filter<Extract = (), Error = Rejection> + Clone {
     warp::path!("auction").and(warp::get())
@@ -14,8 +15,19 @@ pub fn get_auction(
     get_auction_request().and_then(move || {
         let orderbook = orderbook.clone();
         async move {
-            let auction = orderbook.get_auction();
-            Result::<_, Infallible>::Ok(convert_json_response(auction))
+            let result = orderbook.get_auction().await;
+            let reply = match result {
+                Ok(Some(auction)) => with_status(warp::reply::json(&auction), StatusCode::OK),
+                Ok(None) => with_status(
+                    super::error("NotFound", "There is no active auction"),
+                    StatusCode::NOT_FOUND,
+                ),
+                Err(err) => {
+                    tracing::error!(?err, "/api/v1/get_auction");
+                    err.into_warp_reply()
+                }
+            };
+            Result::<_, Infallible>::Ok(reply)
         }
     })
 }

--- a/crates/orderbook/src/api/get_solvable_orders.rs
+++ b/crates/orderbook/src/api/get_solvable_orders.rs
@@ -14,9 +14,9 @@ pub fn get_solvable_orders(
     get_solvable_orders_request().and_then(move || {
         let orderbook = orderbook.clone();
         async move {
-            let result = orderbook.get_solvable_orders();
+            let result = orderbook.get_auction().await;
             Result::<_, Infallible>::Ok(convert_json_response(
-                result.map(|solvable_orders| solvable_orders.orders),
+                result.map(|auction| auction.map(|auction| auction.orders).unwrap_or_default()),
             ))
         }
     })

--- a/crates/orderbook/src/api/get_solvable_orders_v2.rs
+++ b/crates/orderbook/src/api/get_solvable_orders_v2.rs
@@ -14,12 +14,14 @@ pub fn get_solvable_orders(
     get_solvable_orders_request().and_then(move || {
         let orderbook = orderbook.clone();
         async move {
-            let result = orderbook.get_solvable_orders();
-            Result::<_, Infallible>::Ok(convert_json_response(result.map(|orders| {
-                model::SolvableOrders {
-                    orders: orders.orders,
-                    latest_settlement_block: orders.latest_settlement_block,
-                }
+            let result = orderbook.get_auction().await;
+            Result::<_, Infallible>::Ok(convert_json_response(result.map(|auction| {
+                auction
+                    .map(|auction| model::SolvableOrders {
+                        orders: auction.orders,
+                        latest_settlement_block: auction.latest_settlement_block,
+                    })
+                    .unwrap_or_default()
             })))
         }
     })

--- a/crates/orderbook/src/arguments.rs
+++ b/crates/orderbook/src/arguments.rs
@@ -101,14 +101,10 @@ pub struct Arguments {
     #[clap(long, env, parse(try_from_str), default_value = "false")]
     pub enable_presign_orders: bool,
 
-    /// If solvable orders haven't been successfully update in this time in seconds attempting
+    /// If solvable orders haven't been successfully updated in this many blocks attempting
     /// to get them errors and our liveness check fails.
-    #[clap(
-        long,
-        default_value = "300",
-        parse(try_from_str = shared::arguments::duration_from_seconds),
-    )]
-    pub solvable_orders_max_update_age: Duration,
+    #[clap(long, default_value = "24")]
+    pub solvable_orders_max_update_age_blocks: u64,
 
     /// A flat fee discount denominated in the network's native token (i.e. Ether for Mainnet).
     ///
@@ -283,8 +279,8 @@ impl std::fmt::Display for Arguments {
         writeln!(f, "enable_presign_orders: {}", self.enable_presign_orders)?;
         writeln!(
             f,
-            "solvable_orders_max_update_age: {:?}",
-            self.solvable_orders_max_update_age
+            "solvable_orders_max_update_age_blocks: {:?}",
+            self.solvable_orders_max_update_age_blocks,
         )?;
         writeln!(f, "fee_discount: {}", self.fee_discount)?;
         writeln!(f, "min_discounted_fee: {}", self.min_discounted_fee)?;

--- a/crates/orderbook/src/lib.rs
+++ b/crates/orderbook/src/lib.rs
@@ -5,13 +5,11 @@ pub mod fee_subsidy;
 pub mod order_quoting;
 pub mod order_validation;
 pub mod orderbook;
-pub mod solvable_orders;
 pub mod solver_competition;
 
 use crate::database::trades::TradeRetrieving;
 use crate::{order_quoting::QuoteHandler, orderbook::Orderbook};
 use anyhow::{anyhow, Context as _, Result};
-use api::post_solver_competition::SolvableOrdersCache;
 use contracts::GPv2Settlement;
 use futures::Future;
 use model::DomainSeparator;
@@ -29,7 +27,6 @@ pub fn serve_api(
     shutdown_receiver: impl Future<Output = ()> + Send + 'static,
     solver_competition: Arc<dyn SolverCompetitionStoring>,
     solver_competition_auth: Option<String>,
-    solvable_orders: Arc<dyn SolvableOrdersCache>,
 ) -> JoinHandle<()> {
     let filter = api::handle_all_routes(
         database,
@@ -37,7 +34,6 @@ pub fn serve_api(
         quotes,
         solver_competition,
         solver_competition_auth,
-        solvable_orders,
     )
     .boxed();
     tracing::info!(%address, "serving order book");

--- a/crates/orderbook/src/solver_competition.rs
+++ b/crates/orderbook/src/solver_competition.rs
@@ -25,10 +25,6 @@ pub trait SolverCompetitionStoring: Send + Sync {
         &self,
         identifier: Identifier,
     ) -> Result<SolverCompetition, LoadSolverCompetitionError>;
-
-    /// Retrieves the ID that will be assigned to the next solver competition
-    /// entry to get saved.
-    async fn next_solver_competition(&self) -> Result<SolverCompetitionId>;
 }
 
 /// Possible errors when loading a solver competition by ID.


### PR DESCRIPTION
Moves the solvable_orders module into autopilot, instantiates it, and makes it store the auctions in the database.
In the orderbook we read the auction from the database.

### Test Plan

CI
