### PR TITLE
Log and store optimized winning settlement correctly

### DIFF
--- a/crates/model/src/solver_competition.rs
+++ b/crates/model/src/solver_competition.rs
@@ -35,6 +35,7 @@ pub struct SolverCompetition {
     pub transaction_hash: Option<H256>,
     pub auction: CompetitionAuction,
     pub solutions: Vec<SolverSettlement>,
+    pub optimized_winning_solution: Option<SolverSettlement>,
 }
 
 #[serde_as]
@@ -133,7 +134,48 @@ mod tests {
                     "callData": "0x13",
                 },
             ],
+            "optimizedWinningSolution": {
+                "solver": "2",
+                "objective": {
+                    "total": 3.0f64,
+                    "surplus": 4.0f64,
+                    "fees": 5.0f64,
+                    "cost": 6.0f64,
+                    "gas": 7u64,
+                },
+                "clearingPrices": {
+                    "0x2222222222222222222222222222222222222222": "8",
+                },
+                "orders": [
+                    {
+                        "id": "0x3333333333333333333333333333333333333333333333333333333333333333\
+                                 3333333333333333333333333333333333333333\
+                                 33333333",
+                        "executedAmount": "12",
+                    }
+                ],
+                "callData": "0x13",
+            },
         });
+
+        let winning_solution = SolverSettlement {
+            solver: "2".to_string(),
+            objective: Objective {
+                total: 3.,
+                surplus: 4.,
+                fees: 5.,
+                cost: 6.,
+                gas: 7,
+            },
+            clearing_prices: btreemap! {
+                H160([0x22; 20]) => 8.into(),
+            },
+            orders: vec![Order {
+                id: OrderUid([0x33; 56]),
+                executed_amount: 12.into(),
+            }],
+            call_data: vec![0x13],
+        };
 
         let orig = SolverCompetition {
             auction_id: 0,
@@ -154,24 +196,8 @@ mod tests {
                     H160([0x33; 20]) => 3000.into(),
                 },
             },
-            solutions: vec![SolverSettlement {
-                solver: "2".to_string(),
-                objective: Objective {
-                    total: 3.,
-                    surplus: 4.,
-                    fees: 5.,
-                    cost: 6.,
-                    gas: 7,
-                },
-                clearing_prices: btreemap! {
-                    H160([0x22; 20]) => 8.into(),
-                },
-                orders: vec![Order {
-                    id: OrderUid([0x33; 56]),
-                    executed_amount: 12.into(),
-                }],
-                call_data: vec![0x13],
-            }],
+            solutions: vec![winning_solution.clone()],
+            optimized_winning_solution: Some(winning_solution),
         };
 
         let serialized = serde_json::to_value(&orig).unwrap();

--- a/crates/orderbook/src/database/solver_competition.rs
+++ b/crates/orderbook/src/database/solver_competition.rs
@@ -89,6 +89,13 @@ mod tests {
         let db = Postgres::new("postgresql://").unwrap();
         database::clear_DANGER(&db.pool).await.unwrap();
 
+        let winning_solution = SolverSettlement {
+            solver: "asdf".to_string(),
+            objective: Default::default(),
+            clearing_prices: [Default::default()].into_iter().collect(),
+            orders: vec![Default::default()],
+            call_data: vec![1, 2],
+        };
         let expected = SolverCompetition {
             auction_id: 0,
             gas_price: 1.,
@@ -100,13 +107,8 @@ mod tests {
                 orders: vec![Default::default()],
                 prices: [Default::default()].into_iter().collect(),
             },
-            solutions: vec![SolverSettlement {
-                solver: "asdf".to_string(),
-                objective: Default::default(),
-                clearing_prices: [Default::default()].into_iter().collect(),
-                orders: vec![Default::default()],
-                call_data: vec![1, 2],
-            }],
+            solutions: vec![winning_solution.clone()],
+            optimized_winning_solution: Some(winning_solution),
         };
         db.save_competition(expected.clone()).await.unwrap();
         let actual = db.load_competition(Identifier::Id(0)).await.unwrap();

--- a/crates/orderbook/src/database/solver_competition.rs
+++ b/crates/orderbook/src/database/solver_competition.rs
@@ -89,13 +89,6 @@ mod tests {
         let db = Postgres::new("postgresql://").unwrap();
         database::clear_DANGER(&db.pool).await.unwrap();
 
-        let winning_solution = SolverSettlement {
-            solver: "asdf".to_string(),
-            objective: Default::default(),
-            clearing_prices: [Default::default()].into_iter().collect(),
-            orders: vec![Default::default()],
-            call_data: vec![1, 2],
-        };
         let expected = SolverCompetition {
             auction_id: 0,
             gas_price: 1.,
@@ -107,8 +100,14 @@ mod tests {
                 orders: vec![Default::default()],
                 prices: [Default::default()].into_iter().collect(),
             },
-            solutions: vec![winning_solution.clone()],
-            optimized_winning_solution: Some(winning_solution),
+            solutions: vec![SolverSettlement {
+                solver: "asdf".to_string(),
+                objective: Default::default(),
+                clearing_prices: [Default::default()].into_iter().collect(),
+                orders: vec![Default::default()],
+                call_data: vec![1, 2],
+            }],
+            optimized_call_data: Some(vec![1]),
         };
         db.save_competition(expected.clone()).await.unwrap();
         let actual = db.load_competition(Identifier::Id(0)).await.unwrap();

--- a/crates/solver/src/driver.rs
+++ b/crates/solver/src/driver.rs
@@ -330,7 +330,9 @@ impl Driver {
                 .cloned()
                 .map(into_solver_settlement)
                 .collect(),
-            optimized_winning_solution: optimized_solution.clone().map(into_solver_settlement),
+            optimized_call_data: optimized_solution
+                .as_ref()
+                .map(|s| settlement_simulation::call_data(s.1.settlement.clone().into())),
         };
         rated_settlements.extend(optimized_solution);
 

--- a/crates/solver/src/driver.rs
+++ b/crates/solver/src/driver.rs
@@ -321,7 +321,7 @@ impl Driver {
                 let original_solution = rated_settlements.last();
                 tracing::debug!(
                     original_solution = ?original_solution.map(|s| &s.1),
-                    "failed to compute optimized solution, copying last solution"
+                    "failed to compute the optimized solution, copying original winning solution"
                 );
                 rated_settlements.extend(original_solution.cloned());
             }

--- a/crates/solver/src/driver.rs
+++ b/crates/solver/src/driver.rs
@@ -12,7 +12,7 @@ use crate::{
     settlement::{external_prices::ExternalPrices, PriceCheckTokens, Settlement},
     settlement_post_processing::PostProcessingPipeline,
     settlement_ranker::SettlementRanker,
-    settlement_rater::{SettlementRater, SettlementRating},
+    settlement_rater::{RatedSolverSettlement, SettlementRater, SettlementRating},
     settlement_simulation,
     settlement_submission::{SolutionSubmitter, SubmissionError},
     solver::{Auction, Solver, Solvers},
@@ -312,20 +312,9 @@ impl Driver {
             .as_u64();
 
         DriverLogger::print_settlements(&rated_settlements, &self.fee_objective_scaling_factor);
-        match self
+        let optimized_solution = self
             .optimize_winning_solution(&rated_settlements, gas_price, &external_prices)
-            .await
-        {
-            Some(optimized_solution) => rated_settlements.push(optimized_solution),
-            None => {
-                let original_solution = rated_settlements.last();
-                tracing::debug!(
-                    original_solution = ?original_solution.map(|s| &s.1),
-                    "failed to compute the optimized solution, copying original winning solution"
-                );
-                rated_settlements.extend(original_solution.cloned());
-            }
-        }
+            .await;
 
         // Report solver competition data to the api.
         let solver_competition = SolverCompetition {
@@ -338,42 +327,13 @@ impl Driver {
             auction: competition_auction,
             solutions: rated_settlements
                 .iter()
-                .map(|(solver, rated_settlement, _)| SolverSettlement {
-                    solver: solver.name().to_string(),
-                    objective: Objective {
-                        total: rated_settlement
-                            .objective_value()
-                            .to_f64()
-                            .unwrap_or(f64::NAN),
-                        surplus: rated_settlement.surplus.to_f64().unwrap_or(f64::NAN),
-                        fees: rated_settlement
-                            .scaled_unsubsidized_fee
-                            .to_f64()
-                            .unwrap_or(f64::NAN),
-                        cost: rated_settlement.gas_estimate.to_f64_lossy()
-                            * rated_settlement.gas_price.to_f64().unwrap_or(f64::NAN),
-                        gas: rated_settlement.gas_estimate.low_u64(),
-                    },
-                    clearing_prices: rated_settlement
-                        .settlement
-                        .clearing_prices()
-                        .iter()
-                        .map(|(address, price)| (*address, *price))
-                        .collect(),
-                    orders: rated_settlement
-                        .settlement
-                        .executed_trades()
-                        .map(|(trade, _)| solver_competition::Order {
-                            id: trade.order.metadata.uid,
-                            executed_amount: trade.executed_amount,
-                        })
-                        .collect(),
-                    call_data: settlement_simulation::call_data(
-                        rated_settlement.settlement.clone().into(),
-                    ),
-                })
+                .cloned()
+                .map(into_solver_settlement)
                 .collect(),
+            optimized_winning_solution: optimized_solution.clone().map(into_solver_settlement),
         };
+        rated_settlements.extend(optimized_solution);
+
         let mut solver_competition = model::solver_competition::Request {
             auction: auction_id,
             competition: solver_competition,
@@ -537,4 +497,36 @@ pub async fn submit_settlement(
         .log_submission_info(&result, &settlement, settlement_id, &solver)
         .await;
     result
+}
+
+fn into_solver_settlement((solver, settlement, _): RatedSolverSettlement) -> SolverSettlement {
+    SolverSettlement {
+        solver: solver.name().to_string(),
+        objective: Objective {
+            total: settlement.objective_value().to_f64().unwrap_or(f64::NAN),
+            surplus: settlement.surplus.to_f64().unwrap_or(f64::NAN),
+            fees: settlement
+                .unscaled_subsidized_fee
+                .to_f64()
+                .unwrap_or(f64::NAN),
+            cost: settlement.gas_estimate.to_f64_lossy()
+                * settlement.gas_price.to_f64().unwrap_or(f64::NAN),
+            gas: settlement.gas_estimate.low_u64(),
+        },
+        clearing_prices: settlement
+            .settlement
+            .clearing_prices()
+            .iter()
+            .map(|(address, price)| (*address, *price))
+            .collect(),
+        orders: settlement
+            .settlement
+            .executed_trades()
+            .map(|(trade, _)| solver_competition::Order {
+                id: trade.order.metadata.uid,
+                executed_amount: trade.executed_amount,
+            })
+            .collect(),
+        call_data: settlement_simulation::call_data(settlement.settlement.into()),
+    }
 }

--- a/crates/solver/src/driver.rs
+++ b/crates/solver/src/driver.rs
@@ -334,7 +334,6 @@ impl Driver {
                 .as_ref()
                 .map(|s| settlement_simulation::call_data(s.1.settlement.clone().into())),
         };
-        rated_settlements.extend(optimized_solution);
 
         let mut solver_competition = model::solver_competition::Request {
             auction: auction_id,


### PR DESCRIPTION
Fixes #438 

So far the `/solver_competition` endpoint was completely unaware that we optimized the winning solution. Now we do the optimization before submitting the rated settlements to `/solver_competition`.

I decided to clone the winning solution in case the optimization fails. This was done to have a consistent behavior where the second to last settlement is always the original winning solution and the last one is always the optimized winning solution (even if they are identical).

### Test Plan
TODO (will probably end up doing a manual test)
