### PR TITLE
[Logging] Log filtered orders that are assumed to be inflight

### DIFF
--- a/crates/solver/src/driver.rs
+++ b/crates/solver/src/driver.rs
@@ -36,9 +36,9 @@ use shared::{
     token_list::TokenList,
     Web3,
 };
-use std::collections::HashSet;
-use std::iter::FromIterator;
 use std::{
+    collections::HashSet,
+    iter::FromIterator,
     sync::Arc,
     time::{Duration, Instant},
 };

--- a/crates/solver/src/driver.rs
+++ b/crates/solver/src/driver.rs
@@ -37,8 +37,6 @@ use shared::{
     Web3,
 };
 use std::{
-    collections::HashSet,
-    iter::FromIterator,
     sync::Arc,
     time::{Duration, Instant},
 };
@@ -386,19 +384,16 @@ impl Driver {
         let current_block_during_liquidity_fetch =
             current_block::block_number(&self.block_stream.borrow())?;
 
-        let before = auction.orders.clone();
-        self.in_flight_orders.update_and_filter(&mut auction);
-        if before.len() != auction.orders.len() {
+        let before_count = auction.orders.len();
+        let inflight_order_uids = self.in_flight_orders.update_and_filter(&mut auction);
+        if before_count != auction.orders.len() {
             tracing::debug!(
-                "reduced {} orders to {} because in flight at last seen block {}, difference: {:?}",
-                before.len(),
+                "reduced {} orders to {} because in flight at last seen block {}, order in flight: {:?}",
+                before_count,
                 auction.orders.len(),
                 auction.block,
-                HashSet::<Order>::from_iter(before)
-                    .difference(&HashSet::from_iter(auction.orders.iter().cloned()))
-                    .into_iter()
-                    .map(|o| o.metadata.uid)
-                    .collect::<Vec<_>>()
+                inflight_order_uids.len()
+
             );
         }
 

--- a/crates/solver/src/driver.rs
+++ b/crates/solver/src/driver.rs
@@ -388,7 +388,7 @@ impl Driver {
         let inflight_order_uids = self.in_flight_orders.update_and_filter(&mut auction);
         if before_count != auction.orders.len() {
             tracing::debug!(
-                "reduced {} orders to {} because in flight at last seen block {}, order in flight: {:?}",
+                "reduced {} orders to {} because in flight at last seen block {}, orders in flight: {:?}",
                 before_count,
                 auction.orders.len(),
                 auction.block,

--- a/crates/solver/src/driver.rs
+++ b/crates/solver/src/driver.rs
@@ -393,7 +393,6 @@ impl Driver {
                 auction.orders.len(),
                 auction.latest_settlement_block,
                 inflight_order_uids
-
             );
         }
 

--- a/crates/solver/src/driver.rs
+++ b/crates/solver/src/driver.rs
@@ -391,8 +391,8 @@ impl Driver {
                 "reduced {} orders to {} because in flight at last seen block {}, orders in flight: {:?}",
                 before_count,
                 auction.orders.len(),
-                auction.block,
-                inflight_order_uids.len()
+                auction.latest_settlement_block,
+                inflight_order_uids
 
             );
         }

--- a/crates/solver/src/in_flight_orders.rs
+++ b/crates/solver/src/in_flight_orders.rs
@@ -42,7 +42,7 @@ impl InFlightOrders {
     /// Takes note of the new set of solvable orders and returns the ones that aren't in flight and
     /// scales down partially fillable orders if there are currently orders in-flight tapping into
     /// their executable amounts.
-    /// Returns the set of order uids that's considered in flight
+    /// Returns the set of order uids that are considered in flight.
     pub fn update_and_filter(&mut self, auction: &mut Auction) -> HashSet<OrderUid> {
         // If api has seen block X then trades starting at X + 1 are still in flight.
         self.in_flight = self

--- a/crates/solver/src/in_flight_orders.rs
+++ b/crates/solver/src/in_flight_orders.rs
@@ -42,7 +42,8 @@ impl InFlightOrders {
     /// Takes note of the new set of solvable orders and returns the ones that aren't in flight and
     /// scales down partially fillable orders if there are currently orders in-flight tapping into
     /// their executable amounts.
-    pub fn update_and_filter(&mut self, auction: &mut Auction) {
+    /// Returns the set of order uids that's considered in flight
+    pub fn update_and_filter(&mut self, auction: &mut Auction) -> HashSet<OrderUid> {
         // If api has seen block X then trades starting at X + 1 are still in flight.
         self.in_flight = self
             .in_flight
@@ -75,6 +76,7 @@ impl InFlightOrders {
             u256_to_big_uint(&order.data.buy_amount) > order.metadata.executed_buy_amount
                 && u256_to_big_uint(&order.data.sell_amount) > order.metadata.executed_sell_amount
         });
+        in_flight
     }
 
     /// Tracks all in_flight orders and how much of the executable amount of partially fillable


### PR DESCRIPTION
I really hope this PR doesn't again break something 🤞 , it's just adding some more logging (I promise to not do any logic changes).

When debugging why a specific order took long to get matched, I noticed that it wasn't included in all auctions even though it had never been part of an in-flight settlement. Currently we log the number of orders that get filtered in this step but not their order IDs. This PR add logging for the filtered IDs

### Test Plan

Run driver against mainnet prod in DryRun mode and see the following log statement:

> 2022-08-10T14:17:11.786Z DEBUG auction{id=15977 run=0}: solver::driver: reduced 12 orders to 11 because in flight at last seen block 15314828, difference: [0xdcb5921ee9cb5e3124e84c1c7ce0f24ec097ca86179704cfbebbc2c6eff00aa8fc78f8e1af80a3bf5a1783bb59ed2d1b10f78ca962f50b60]
