### PR TITLE
Don't implement `Hash` for `Order`.

### DIFF
--- a/crates/model/src/order.rs
+++ b/crates/model/src/order.rs
@@ -253,7 +253,7 @@ impl OrderBuilder {
 ///
 /// These are the exact fields that get signed and verified by the settlement
 /// contract.
-#[derive(Clone, Copy, Debug, Default, Deserialize, Eq, PartialEq, Serialize, Hash)]
+#[derive(Clone, Copy, Debug, Default, Deserialize, Eq, Hash, PartialEq, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct OrderData {
     pub sell_token: H160,

--- a/crates/model/src/order.rs
+++ b/crates/model/src/order.rs
@@ -30,7 +30,7 @@ pub const BUY_ETH_ADDRESS: H160 = H160([0xee; 20]);
 /// An order that is returned when querying the orderbook.
 ///
 /// Contains extra fields that are populated by the orderbook.
-#[derive(Eq, PartialEq, Clone, Debug, Default, Deserialize, Serialize, Hash)]
+#[derive(Eq, PartialEq, Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Order {
     #[serde(flatten)]
@@ -253,7 +253,7 @@ impl OrderBuilder {
 ///
 /// These are the exact fields that get signed and verified by the settlement
 /// contract.
-#[derive(Clone, Copy, Debug, Default, Deserialize, Eq, Hash, PartialEq, Serialize)]
+#[derive(Clone, Copy, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct OrderData {
     pub sell_token: H160,
@@ -397,7 +397,7 @@ impl From<Order> for OrderCreation {
 
 /// An order cancellation as provided to the orderbook by the frontend.
 #[serde_as]
-#[derive(Eq, PartialEq, Clone, Copy, Debug, Hash)]
+#[derive(Eq, PartialEq, Clone, Copy, Debug)]
 pub struct OrderCancellation {
     pub order_uid: OrderUid,
     pub signature: EcdsaSignature,
@@ -442,7 +442,7 @@ impl OrderCancellation {
 
 /// An order as provided to the orderbook by the frontend.
 #[serde_as]
-#[derive(Eq, PartialEq, Clone, Derivative, Deserialize, Serialize, Hash)]
+#[derive(Eq, PartialEq, Clone, Derivative, Deserialize, Serialize)]
 #[derivative(Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct OrderMetadata {

--- a/crates/model/src/order.rs
+++ b/crates/model/src/order.rs
@@ -253,7 +253,7 @@ impl OrderBuilder {
 ///
 /// These are the exact fields that get signed and verified by the settlement
 /// contract.
-#[derive(Clone, Copy, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+#[derive(Clone, Copy, Debug, Default, Deserialize, Eq, PartialEq, Serialize, Hash)]
 #[serde(rename_all = "camelCase")]
 pub struct OrderData {
     pub sell_token: H160,

--- a/crates/solver/src/driver.rs
+++ b/crates/solver/src/driver.rs
@@ -391,7 +391,7 @@ impl Driver {
                 "reduced {} orders to {} because in flight at last seen block {}",
                 before_count,
                 auction.orders.len(),
-                auction.block
+                auction.latest_settlement_block,
             );
         }
 

--- a/crates/solver/src/driver.rs
+++ b/crates/solver/src/driver.rs
@@ -391,7 +391,7 @@ impl Driver {
                 "reduced {} orders to {} because in flight at last seen block {}",
                 before_count,
                 auction.orders.len(),
-                auction.latest_settlement_block,
+                auction.block
             );
         }
 

--- a/crates/solver/src/in_flight_orders.rs
+++ b/crates/solver/src/in_flight_orders.rs
@@ -86,12 +86,11 @@ impl InFlightOrders {
         settlement
             .executed_trades()
             .filter(|(trade, _)| trade.order.data.partially_fillable)
-            .into_group_map_by(|(trade, _)| &trade.order)
+            .into_group_map_by(|(trade, _)| trade.order.metadata.uid)
             .into_iter()
-            .for_each(|(order, trades)| {
-                let uid = order.metadata.uid;
+            .for_each(|(uid, trades)| {
                 let most_recent_data = PartiallyFilledOrder {
-                    order: order.clone(),
+                    order: trades[0].0.order.clone(),
                     in_flight_trades: trades.into_iter().map(|(_, trade)| trade).collect(),
                 };
                 // always overwrite existing data with the most recent data


### PR DESCRIPTION
This PR removes the `Hash` implementation from the `Order` type because it is ambiguous.

For example, consider the following order:
```rust
let order0 = Order {
    metadata: OrderMetadata {
       uid: x,
       executed_amount: 0,
       // ...
    },
    data: OrderData {
       partially_fillable: true,
       // ...
    },
    // ...
}
```

And
```rust
let order1 = {
    let mut order = order0.clone();
    order.metadata.executed_amount += 1; // so it got a little executed
    order
};
```

Then, you might expect:
```rust
let mut set = HashSet::new();
set.insert(order0);
set.insert(order1);
assert!(set.len(), 1);
```

HOWEVER, this is not the case, as it would be actually (and for good reason):
```rust
assert!(set.len(), 2);
```

This change required a small refactor to the in-flight order code (although should not change the behaviour).

Note that we keep `OrderData: Hash` because order data is unique at a protocol order (i.e. two orders are the same IIF they have the exact same data parameters <=> having the same `GPv2Order.Data` struct hash value).

### Test Plan

CI and existing unit tests.
