### PR TITLE
Disable codecov PR comments

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,2 +1,1 @@
-comment:
-  layout: diff
+comment: false


### PR DESCRIPTION
Because I don't find them useful enough to justify the slightly annoying ping from the message. I got three thumbs up on Slack when suggesting this so I think enough people agree?

### Test Plan

This or next PR the comment stop happening
