### PR TITLE
Don't filter our partially fillable sell orders that have reached minBuyAmount

### DIFF
--- a/crates/solver/src/driver.rs
+++ b/crates/solver/src/driver.rs
@@ -36,9 +36,9 @@ use shared::{
     token_list::TokenList,
     Web3,
 };
-use std::collections::HashSet;
-use std::iter::FromIterator;
 use std::{
+    collections::HashSet,
+    iter::FromIterator,
     sync::Arc,
     time::{Duration, Instant},
 };

--- a/crates/solver/src/driver.rs
+++ b/crates/solver/src/driver.rs
@@ -37,8 +37,6 @@ use shared::{
     Web3,
 };
 use std::{
-    collections::HashSet,
-    iter::FromIterator,
     sync::Arc,
     time::{Duration, Instant},
 };
@@ -386,19 +384,16 @@ impl Driver {
         let current_block_during_liquidity_fetch =
             current_block::block_number(&self.block_stream.borrow())?;
 
-        let before = auction.orders.clone();
-        self.in_flight_orders.update_and_filter(&mut auction);
-        if before.len() != auction.orders.len() {
+        let before_count = auction.orders.len();
+        let inflight_order_uids = self.in_flight_orders.update_and_filter(&mut auction);
+        if before_count != auction.orders.len() {
             tracing::debug!(
-                "reduced {} orders to {} because in flight at last seen block {}, difference: {:?}",
-                before.len(),
+                "reduced {} orders to {} because in flight at last seen block {}, order in flight: {:?}",
+                before_count,
                 auction.orders.len(),
                 auction.block,
-                HashSet::<Order>::from_iter(before)
-                    .difference(&HashSet::from_iter(auction.orders.iter().cloned()))
-                    .into_iter()
-                    .map(|o| o.metadata.uid)
-                    .collect::<Vec<_>>()
+                inflight_order_uids.len()
+
             );
         }
 

--- a/crates/solver/src/driver.rs
+++ b/crates/solver/src/driver.rs
@@ -388,7 +388,7 @@ impl Driver {
         let inflight_order_uids = self.in_flight_orders.update_and_filter(&mut auction);
         if before_count != auction.orders.len() {
             tracing::debug!(
-                "reduced {} orders to {} because in flight at last seen block {}, order in flight: {:?}",
+                "reduced {} orders to {} because in flight at last seen block {}, orders in flight: {:?}",
                 before_count,
                 auction.orders.len(),
                 auction.block,

--- a/crates/solver/src/in_flight_orders.rs
+++ b/crates/solver/src/in_flight_orders.rs
@@ -75,7 +75,7 @@ impl InFlightOrders {
         });
         auction.orders.retain(|order| match order.data.kind {
             OrderKind::Sell => {
-                u256_to_big_uint(&order.data.sell_amount) > order.metadata.executed_sell_amount
+                u256_to_big_uint(&order.data.sell_amount) > order.metadata.executed_sell_amount_before_fees
             }
             OrderKind::Buy => {
                 u256_to_big_uint(&order.data.buy_amount) > order.metadata.executed_buy_amount

--- a/crates/solver/src/in_flight_orders.rs
+++ b/crates/solver/src/in_flight_orders.rs
@@ -42,7 +42,8 @@ impl InFlightOrders {
     /// Takes note of the new set of solvable orders and returns the ones that aren't in flight and
     /// scales down partially fillable orders if there are currently orders in-flight tapping into
     /// their executable amounts.
-    pub fn update_and_filter(&mut self, auction: &mut Auction) {
+    /// Returns the set of order uids that's considered in flight
+    pub fn update_and_filter(&mut self, auction: &mut Auction) -> HashSet<OrderUid> {
         // If api has seen block X then trades starting at X + 1 are still in flight.
         self.in_flight = self
             .in_flight
@@ -75,6 +76,7 @@ impl InFlightOrders {
             u256_to_big_uint(&order.data.buy_amount) > order.metadata.executed_buy_amount
                 && u256_to_big_uint(&order.data.sell_amount) > order.metadata.executed_sell_amount
         });
+        in_flight
     }
 
     /// Tracks all in_flight orders and how much of the executable amount of partially fillable

--- a/crates/solver/src/in_flight_orders.rs
+++ b/crates/solver/src/in_flight_orders.rs
@@ -75,7 +75,8 @@ impl InFlightOrders {
         });
         auction.orders.retain(|order| match order.data.kind {
             OrderKind::Sell => {
-                u256_to_big_uint(&order.data.sell_amount) > order.metadata.executed_sell_amount_before_fees
+                u256_to_big_uint(&order.data.sell_amount)
+                    > u256_to_big_uint(&order.metadata.executed_sell_amount_before_fees)
             }
             OrderKind::Buy => {
                 u256_to_big_uint(&order.data.buy_amount) > order.metadata.executed_buy_amount


### PR DESCRIPTION
I'm not sure if this logic change is the correct fix, but the problem I'm seeing is that we currently filter out [this order](https://explorer.cow.fi/orders/0xdcb5921ee9cb5e3124e84c1c7ce0f24ec097ca86179704cfbebbc2c6eff00aa8fc78f8e1af80a3bf5a1783bb59ed2d1b10f78ca962f50b60) as being "in-flight" even though it is not. 

The reason is that in the current logic an order is filtered if either its buy or sell Amount are reached. This means a partially fillable order (e.g. sell 100 DAI for at least 50USDC) would be filtered if it was filled at a 50% at a price of 1:1 (50 DAI sold for 50 USDC). In this case we would have reached the sell amount and therefore no longer retain this order.

In this fix I changed the filled condition to be based on the order kind. A sell order is filled if its sell amount is reached, a buy order is filled when the buy amount is reached. Please review carefully as this is changing logic I'm not very familiar with (@vkgnosis I think you wrote the logic initially).

### Test Plan

Added two unit tests and remaining unit tests still pass.
