### PR TITLE
Fix handling of multiple settlements in same block

### DIFF
--- a/database/sql/V028__index_settlements_tx_hash.sql
+++ b/database/sql/V028__index_settlements_tx_hash.sql
@@ -1,0 +1,2 @@
+-- When getting orders by tx hash we index the settlements table by tx_hash.
+CREATE INDEX settlements_tx_hash ON settlements USING HASH (tx_hash);


### PR DESCRIPTION
Fixes https://github.com/cowprotocol/services/issues/89 .

- This is somewhat different from sketch in the comment because that approach wasn't valid sql and not entirely correct.
- The previous test wrongly inserted the settlement event before the trade event.
- We forgot to add an index on the settlements table by tx hash which I have fixed too. This doesn't influence the correctness of the code change.

### Test Plan

CI, adapted test
