### PR TITLE
Move much of the logging out of the driver

### DIFF
--- a/crates/solver/src/driver.rs
+++ b/crates/solver/src/driver.rs
@@ -473,14 +473,6 @@ impl Driver {
             .number
             .unwrap_or_default()
             .as_u64();
-        tracing::info!(
-            "{} settlements passed simulation and {} failed",
-            rated_settlements.len(),
-            errors.len(),
-        );
-        for (solver, _, _) in &rated_settlements {
-            self.metrics.settlement_simulation_succeeded(solver.name());
-        }
 
         print_settlements(&rated_settlements, &self.fee_objective_scaling_factor);
 

--- a/crates/solver/src/driver.rs
+++ b/crates/solver/src/driver.rs
@@ -239,6 +239,14 @@ impl Driver {
                 {
                     tracing::debug!(?err, "access list metric not saved");
                 }
+                match receipt.effective_gas_price {
+                    Some(price) => {
+                        self.metrics.transaction_gas_price(price);
+                    }
+                    None => {
+                        tracing::error!("node did not return effective gas price in tx receipt");
+                    }
+                }
                 Ok(receipt)
             }
             Err(err) => {
@@ -549,17 +557,6 @@ impl Driver {
             {
                 Ok(receipt) => {
                     self.update_in_flight_orders(&receipt, &winning_settlement.settlement);
-                    match receipt.effective_gas_price {
-                        Some(price) => {
-                            self.metrics.transaction_gas_price(price);
-                        }
-                        None => {
-                            tracing::error!(
-                                "node did not return effective gas price in tx receipt"
-                            );
-                        }
-                    }
-
                     solver_competition.transaction_hash = Some(receipt.transaction_hash);
                 }
                 Err(SubmissionError::Revert(hash)) => {

--- a/crates/solver/src/driver.rs
+++ b/crates/solver/src/driver.rs
@@ -204,6 +204,7 @@ impl Driver {
         solver: Arc<dyn Solver>,
         rated_settlement: RatedSettlement,
     ) -> Result<TransactionReceipt, SubmissionError> {
+        let start = Instant::now();
         let result = self
             .solution_submitter
             .settle(
@@ -212,6 +213,7 @@ impl Driver {
                 solver.account().clone(),
             )
             .await;
+        self.metrics.transaction_submission(start.elapsed());
         self.log_submission_info(&result, &rated_settlement, &solver)
             .await;
         result
@@ -555,7 +557,6 @@ impl Driver {
 
             self.metrics
                 .complete_runloop_until_transaction(start.elapsed());
-            let start = Instant::now();
             match self
                 .submit_settlement(winning_solver.clone(), winning_settlement.clone())
                 .await
@@ -570,7 +571,6 @@ impl Driver {
                 _ => (),
             }
 
-            self.metrics.transaction_submission(start.elapsed());
             self.report_on_batch(
                 &(winning_solver, winning_settlement),
                 rated_settlements

--- a/crates/solver/src/driver_logger.rs
+++ b/crates/solver/src/driver_logger.rs
@@ -1,7 +1,10 @@
 use crate::{
+    driver::solver_settlements::RatedSettlement,
     metrics::SolverMetrics,
     settlement::Settlement,
     settlement_simulation::{simulate_before_after_access_list, TenderlyApi},
+    settlement_submission::SubmissionError,
+    solver::Solver,
 };
 use anyhow::{Context, Result};
 use itertools::Itertools;
@@ -9,6 +12,7 @@ use model::order::{Order, OrderKind};
 use primitive_types::H256;
 use shared::Web3;
 use std::sync::Arc;
+use web3::types::TransactionReceipt;
 
 pub struct DriverLogger {
     pub metrics: Arc<dyn SolverMetrics>,
@@ -41,7 +45,7 @@ impl DriverLogger {
     /// Collects all orders which got traded in the settlement. Tapping into partially fillable
     /// orders multiple times will not result in duplicates. Partially fillable orders get
     /// considered as traded only the first time we tap into their liquidity.
-    pub fn get_traded_orders(settlement: &Settlement) -> Vec<Order> {
+    fn get_traded_orders(settlement: &Settlement) -> Vec<Order> {
         let mut traded_orders = Vec::new();
         for (_, group) in &settlement
             .executed_trades()
@@ -60,5 +64,61 @@ impl DriverLogger {
             }
         }
         traded_orders
+    }
+
+    pub async fn log_submission_info(
+        &self,
+        submission: &Result<TransactionReceipt, SubmissionError>,
+        rated_settlement: &RatedSettlement,
+        solver: &Arc<dyn Solver>,
+    ) {
+        self.metrics
+            .settlement_revertable_status(rated_settlement.settlement.revertable(), solver.name());
+        match submission {
+            Ok(receipt) => {
+                let name = solver.name();
+                tracing::info!(
+                    settlement_id =% rated_settlement.id,
+                    transaction_hash =? receipt.transaction_hash,
+                    "Successfully submitted settlement",
+                );
+                Self::get_traded_orders(&rated_settlement.settlement)
+                    .iter()
+                    .for_each(|order| self.metrics.order_settled(order, name));
+                self.metrics.settlement_submitted(
+                    crate::metrics::SettlementSubmissionOutcome::Success,
+                    name,
+                );
+                if let Err(err) = self
+                    .metric_access_list_gas_saved(receipt.transaction_hash)
+                    .await
+                {
+                    tracing::debug!(?err, "access list metric not saved");
+                }
+                match receipt.effective_gas_price {
+                    Some(price) => {
+                        self.metrics.transaction_gas_price(price);
+                    }
+                    None => {
+                        tracing::error!("node did not return effective gas price in tx receipt");
+                    }
+                }
+            }
+            Err(err) => {
+                // Since we simulate and only submit solutions when they used to pass before, there is no
+                // point in logging transaction failures in the form of race conditions as hard errors.
+                tracing::warn!(
+                    settlement_id =% rated_settlement.id, ?err,
+                    "Failed to submit settlement",
+                );
+                self.metrics
+                    .settlement_submitted(err.as_outcome(), solver.name());
+                if let Some(transaction_hash) = err.transaction_hash() {
+                    if let Err(err) = self.metric_access_list_gas_saved(transaction_hash).await {
+                        tracing::debug!(?err, "access list metric not saved");
+                    }
+                }
+            }
+        }
     }
 }

--- a/crates/solver/src/driver_logger.rs
+++ b/crates/solver/src/driver_logger.rs
@@ -1,0 +1,37 @@
+use crate::{
+    metrics::SolverMetrics,
+    settlement_simulation::{simulate_before_after_access_list, TenderlyApi},
+};
+use anyhow::{Context, Result};
+use primitive_types::H256;
+use shared::Web3;
+use std::sync::Arc;
+
+pub struct DriverLogger {
+    pub metrics: Arc<dyn SolverMetrics>,
+    pub web3: Web3,
+    pub tenderly: Option<TenderlyApi>,
+    pub network_id: String,
+}
+
+impl DriverLogger {
+    pub async fn metric_access_list_gas_saved(&self, transaction_hash: H256) -> Result<()> {
+        let gas_saved = simulate_before_after_access_list(
+            &self.web3,
+            self.tenderly.as_ref().context("tenderly disabled")?,
+            self.network_id.clone(),
+            transaction_hash,
+        )
+        .await?;
+        tracing::debug!(?gas_saved, "access list gas saved");
+        if gas_saved.is_sign_positive() {
+            self.metrics
+                .settlement_access_list_saved_gas(gas_saved, "positive");
+        } else {
+            self.metrics
+                .settlement_access_list_saved_gas(-gas_saved, "negative");
+        }
+
+        Ok(())
+    }
+}

--- a/crates/solver/src/lib.rs
+++ b/crates/solver/src/lib.rs
@@ -2,6 +2,7 @@ mod analytics;
 pub mod arguments;
 mod auction_preprocessing;
 pub mod driver;
+pub mod driver_logger;
 pub mod encoding;
 pub mod in_flight_orders;
 pub mod interactions;

--- a/crates/solver/src/settlement_ranker.rs
+++ b/crates/solver/src/settlement_ranker.rs
@@ -137,6 +137,16 @@ impl SettlementRanker {
         rated_settlements.shuffle(&mut rand::thread_rng());
 
         rated_settlements.sort_by(|a, b| a.1.objective_value().cmp(&b.1.objective_value()));
+
+        tracing::info!(
+            "{} settlements passed simulation and {} failed",
+            rated_settlements.len(),
+            errors.len(),
+        );
+        for (solver, _, _) in &rated_settlements {
+            self.metrics.settlement_simulation_succeeded(solver.name());
+        }
+
         Ok((rated_settlements, errors))
     }
 }


### PR DESCRIPTION
Useful refactoring for step 8 of #337 

Settlement submission has a lot of subtleties and currently involves a huge amount of logging and metrics. Ideally the new driver would do that exactly as the current one and to not introduce bugs by poorly copying bits and pieces I refactored the current logging logic into the `DriverLogger`. I also made `submit_settlement()` a free function which only needs a `SolutionSubmitter` and a `DriverLogger` to handle the submission, logging and metrics.
That allows me to simply re-use that component in the new driver resulting in the identical behavior.

The refactor moves a bunch of code so to help with the review I made small commits which all compiled without any clippy warnings. So I would suggest reviewing those commits individually and in order.

To be perfectly honest this refactor feels a bit shoehorned but I think it's a reasonable step to untangle the current driver and hopefully move to greener pastures in the new driver.

### Test Plan
CI
