### PR TITLE
Track maintenance blocks

### DIFF
--- a/crates/shared/src/maintenance.rs
+++ b/crates/shared/src/maintenance.rs
@@ -47,10 +47,11 @@ impl ServiceMaintenance {
             let block = block.number.unwrap_or_default().as_u64();
             metrics.last_seen_block.set(block as _);
 
-            if let Ok(_) = self
+            if self
                 .run_maintenance()
                 .instrument(tracing::debug_span!("maintenance", block))
                 .await
+                .is_ok()
             {
                 metrics.last_updated_block.set(block as _);
             }


### PR DESCRIPTION
Fixes #444.

This PR replaces maintenance error alerts (i.e. `tracing::error!` log messages that cause alert notifications) with metrics tracking the last seen block, as well as the last successfully updated block.

This allows us to have more complex alerts (such as >3 successive maintenance failures, or no new block in past minute) and reduce noise.

### Test Plan

Check the metrics are there:

```
% cargo run -p orderbook &
% cargo run -p solver &
% cargo run -p autopilot &

% curl -s http://localhost:9586/metrics | rg maintenance
# HELP gp_v2_api_maintenance_last_seen_block Service maintenance last seen block.
# TYPE gp_v2_api_maintenance_last_seen_block gauge
gp_v2_api_maintenance_last_seen_block 15322558
# HELP gp_v2_api_maintenance_last_updated_block Service maintenance last seen block.
# TYPE gp_v2_api_maintenance_last_updated_block gauge
gp_v2_api_maintenance_last_updated_block 15322558

% curl -s http://localhost:9587/metrics | rg maintenance
# HELP gp_v2_solver_maintenance_last_seen_block Service maintenance last seen block.
# TYPE gp_v2_solver_maintenance_last_seen_block gauge
gp_v2_solver_maintenance_last_seen_block 15322560
# HELP gp_v2_solver_maintenance_last_updated_block Service maintenance last seen block.
# TYPE gp_v2_solver_maintenance_last_updated_block gauge
gp_v2_solver_maintenance_last_updated_block 15322560

% curl -s http://localhost:9589/metrics | rg maintenance
# HELP gp_v2_autopilot_maintenance_last_seen_block Service maintenance last seen block.
# TYPE gp_v2_autopilot_maintenance_last_seen_block gauge
gp_v2_autopilot_maintenance_last_seen_block 15322560
# HELP gp_v2_autopilot_maintenance_last_updated_block Service maintenance last seen block.
# TYPE gp_v2_autopilot_maintenance_last_updated_block gauge
gp_v2_autopilot_maintenance_last_updated_block 15322560
```
