### PR TITLE
Remove redundant metrics names

### DIFF
--- a/crates/autopilot/src/database.rs
+++ b/crates/autopilot/src/database.rs
@@ -36,7 +36,7 @@ struct Metrics {
     table_rows: prometheus::IntGaugeVec,
 
     /// Timing of db queries.
-    #[metric(name = "autopilot_database_queries", labels("type"))]
+    #[metric(labels("type"))]
     database_queries: prometheus::HistogramVec,
 }
 

--- a/crates/orderbook/src/database.rs
+++ b/crates/orderbook/src/database.rs
@@ -30,7 +30,7 @@ impl Postgres {
 #[derive(prometheus_metric_storage::MetricStorage)]
 struct Metrics {
     /// Timing of db queries.
-    #[metric(name = "orderbook_database_queries", labels("type"))]
+    #[metric(labels("type"))]
     database_queries: prometheus::HistogramVec,
 }
 


### PR DESCRIPTION
I noticed when looking at metrics that we collect that we were "double-prefixing" some metrics with where they were running. Specifically, we had `gp_v2_autopilot_autopilot_database_queries` and `gp_v2_api_orderbook_database_queries_bucket`.

This PR removes the extra `autopilot_` and `orderbook_` manually installed prefixes.

### Test Plan

Run the `orderbook` and `autopilot` and make sure the metrics have different names:

```
% cargo run -p orderbook &
% cargo run -p autopilot &

% curl -s http://localhost:9586/metrics | rg database_queries
# HELP gp_v2_api_database_queries Timing of db queries.
# TYPE gp_v2_api_database_queries histogram
...

% curl -s http://localhost:9589/metrics | rg database_queries
# HELP gp_v2_autopilot_database_queries Timing of db queries.
# TYPE gp_v2_autopilot_database_queries histogram
...
```
