### PR TITLE
Require inputs and outputs for interactions in settlement

### DIFF
--- a/crates/shared/src/http_solver/model.rs
+++ b/crates/shared/src/http_solver/model.rs
@@ -141,14 +141,12 @@ pub struct InteractionData {
     /// for this calldata.
     ///
     /// `GPv2Settlement -> AMM`
-    #[serde(default)]
     pub inputs: Vec<TokenAmount>,
     /// The output amounts from the AMM interaction - i.e. the amount of tokens
     /// that are expected to be sent from the AMM into the settlement contract
     /// for this calldata.
     ///
     /// `AMM -> GPv2Settlement`
-    #[serde(default)]
     pub outputs: Vec<TokenAmount>,
     pub exec_plan: Option<ExecutionPlan>,
 }
@@ -830,7 +828,9 @@ mod tests {
                     {
                         "target": "0xffffffffffffffffffffffffffffffffffffffff",
                         "value": "0",
-                        "call_data": [1, 2, 3, 4]
+                        "call_data": [1, 2, 3, 4],
+                        "inputs": [],
+                        "outputs": []
                     }
                 "#,
             )
@@ -838,6 +838,7 @@ mod tests {
             InteractionData {
                 target: H160([0xff; 20]),
                 value: 0.into(),
+                // the only backwards compatible thing remaining
                 call_data: vec![1, 2, 3, 4],
                 inputs: Vec::new(),
                 outputs: Vec::new(),


### PR DESCRIPTION
Partly fixes #453

AFAIK the new interaction format changed 2 things in backwards compatible ways:
1. add `inputs` and `outputs` for interactions and assume empty lists if they were not in the serialized response
2. allow serializing call data as an array of numbers (old way) and as a hex string

I see that solvers already adopted the `input` and `outputs` but not the new serialization scheme so this PR will only make `inputs` and `outputs` required but still allows the old `call_data` format.

### Test Plan
Manual test verifying that solutions don't cause deserialization errors.
Updated existing unit test for backwards compatibility (it now only verifies desierialization of the old `call_data` format).
