### PR TITLE
Fix Rust 1.63 Cargo Clippy Warnings

### DIFF
--- a/crates/database/src/quotes.rs
+++ b/crates/database/src/quotes.rs
@@ -7,7 +7,7 @@ use sqlx::{
 
 pub type QuoteId = i64;
 
-#[derive(Clone, Debug, Default, PartialEq, sqlx::Type)]
+#[derive(Clone, Debug, Default, Eq, PartialEq, sqlx::Type)]
 #[sqlx(type_name = "QuoteKind")]
 #[sqlx(rename_all = "lowercase")]
 pub enum QuoteKind {

--- a/crates/database/src/trades.rs
+++ b/crates/database/src/trades.rs
@@ -3,7 +3,7 @@ use bigdecimal::BigDecimal;
 use futures::stream::BoxStream;
 use sqlx::PgConnection;
 
-#[derive(Clone, Debug, Default, PartialEq, sqlx::FromRow)]
+#[derive(Clone, Debug, Default, Eq, PartialEq, sqlx::FromRow)]
 pub struct TradesQueryRow {
     pub block_number: i64,
     pub log_index: i64,

--- a/crates/model/src/auction.rs
+++ b/crates/model/src/auction.rs
@@ -8,7 +8,7 @@ use std::collections::BTreeMap;
 
 /// A batch auction.
 #[serde_as]
-#[derive(Clone, Debug, Default, Deserialize, PartialEq, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Auction {
     /// The block that this auction is valid for.

--- a/crates/model/src/quote.rs
+++ b/crates/model/src/quote.rs
@@ -9,7 +9,7 @@ use chrono::{DateTime, Utc};
 use primitive_types::{H160, U256};
 use serde::{de, ser::SerializeStruct as _, Deserialize, Deserializer, Serialize, Serializer};
 
-#[derive(Clone, Copy, Debug, Default, Deserialize, Serialize, PartialEq)]
+#[derive(Clone, Copy, Debug, Default, Deserialize, Serialize, Eq, PartialEq)]
 #[serde(rename_all = "snake_case")]
 pub enum PriceQuality {
     Fast,
@@ -63,7 +63,7 @@ impl TryFrom<QuoteSigningDeserializationData> for QuoteSigningScheme {
 }
 
 /// The order parameters to quote a price and fee for.
-#[derive(Clone, Copy, Debug, Default, Deserialize, Serialize, PartialEq)]
+#[derive(Clone, Copy, Debug, Default, Deserialize, Serialize, Eq, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct OrderQuoteRequest {
     pub from: H160,
@@ -89,7 +89,7 @@ pub struct OrderQuoteRequest {
     pub price_quality: PriceQuality,
 }
 
-#[derive(Clone, Copy, Debug, Deserialize, Serialize, PartialEq)]
+#[derive(Clone, Copy, Debug, Deserialize, Serialize, Eq, PartialEq)]
 #[serde(tag = "kind", rename_all = "lowercase")]
 pub enum OrderQuoteSide {
     #[serde(rename_all = "camelCase")]
@@ -112,7 +112,7 @@ impl Default for OrderQuoteSide {
     }
 }
 
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum Validity {
     To(u32),
     For(u32),
@@ -177,7 +177,7 @@ impl Serialize for Validity {
     }
 }
 
-#[derive(Clone, Copy, Debug, Deserialize, Serialize, PartialEq)]
+#[derive(Clone, Copy, Debug, Deserialize, Serialize, Eq, PartialEq)]
 #[serde(untagged)]
 pub enum SellAmount {
     BeforeFee {
@@ -191,7 +191,7 @@ pub enum SellAmount {
 }
 
 /// The quoted order by the service.
-#[derive(Clone, Debug, PartialEq, Serialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct OrderQuote {
     pub sell_token: H160,
@@ -213,7 +213,7 @@ pub struct OrderQuote {
 
 pub type QuoteId = i64;
 
-#[derive(Clone, Debug, PartialEq, Serialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct OrderQuoteResponse {
     pub quote: OrderQuote,

--- a/crates/model/src/solver_competition.rs
+++ b/crates/model/src/solver_competition.rs
@@ -22,7 +22,7 @@ pub struct SolverCompetition {
 }
 
 #[serde_as]
-#[derive(Clone, Debug, Default, Deserialize, Serialize, PartialEq)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize, Eq, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct CompetitionAuction {
     pub orders: Vec<OrderUid>,
@@ -53,7 +53,7 @@ pub struct Objective {
     pub gas: u64,
 }
 
-#[derive(Clone, Debug, Default, Deserialize, Serialize, PartialEq)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize, Eq, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct Order {
     pub id: OrderUid,

--- a/crates/orderbook/src/database/trades.rs
+++ b/crates/orderbook/src/database/trades.rs
@@ -14,7 +14,7 @@ pub trait TradeRetrieving: Send + Sync {
 }
 
 /// Any default value means that this field is unfiltered.
-#[derive(Debug, Default, PartialEq)]
+#[derive(Debug, Default, Eq, PartialEq)]
 pub struct TradeFilter {
     pub owner: Option<H160>,
     pub order_uid: Option<OrderUid>,

--- a/crates/orderbook/src/order_quoting.rs
+++ b/crates/orderbook/src/order_quoting.rs
@@ -105,7 +105,7 @@ impl From<PartialValidationError> for OrderQuoteError {
 }
 
 /// Order parameters for quoting.
-#[derive(Clone, Debug, Default, PartialEq)]
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
 pub struct QuoteParameters {
     pub sell_token: H160,
     pub buy_token: H160,
@@ -290,7 +290,7 @@ pub enum FindQuoteError {
 }
 
 /// Fields for searching stored quotes.
-#[derive(Clone, Debug, Default, PartialEq)]
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
 pub struct QuoteSearchParameters {
     pub sell_token: H160,
     pub buy_token: H160,

--- a/crates/orderbook/src/order_validation.rs
+++ b/crates/orderbook/src/order_validation.rs
@@ -174,7 +174,7 @@ pub struct OrderValidator {
     signature_validator: Arc<dyn SignatureValidating>,
 }
 
-#[derive(Debug, PartialEq, Default)]
+#[derive(Debug, Eq, PartialEq, Default)]
 pub struct PreOrderData {
     pub owner: H160,
     pub sell_token: H160,
@@ -450,7 +450,7 @@ impl OrderValidating for OrderValidator {
 }
 
 /// Signature configuration that is accepted by the orderbook.
-#[derive(Debug, PartialEq, Default)]
+#[derive(Debug, Eq, PartialEq, Default)]
 pub struct SignatureConfiguration {
     pub eip1271: bool,
     pub presign: bool,

--- a/crates/shared/src/arguments.rs
+++ b/crates/shared/src/arguments.rs
@@ -300,7 +300,7 @@ pub fn parse_unbounded_factor(s: &str) -> Result<f64> {
 
 pub fn parse_percentage_factor(s: &str) -> Result<f64> {
     let percentage_factor = f64::from_str(s)?;
-    ensure!(percentage_factor.is_finite() && percentage_factor >= 0. && percentage_factor <= 1.0);
+    ensure!(percentage_factor.is_finite() && (0. ..=1.0).contains(&percentage_factor));
     Ok(percentage_factor)
 }
 

--- a/crates/shared/src/balancer_sor_api.rs
+++ b/crates/shared/src/balancer_sor_api.rs
@@ -62,7 +62,7 @@ impl BalancerSorApi for DefaultBalancerSorApi {
 }
 
 /// An SOR query.
-#[derive(Clone, Debug, Default, PartialEq, Serialize)]
+#[derive(Clone, Debug, Default, Eq, PartialEq, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Query {
     /// The sell token to quote.
@@ -135,7 +135,7 @@ pub struct Quote {
 }
 
 /// A swap included in a larger batched swap.
-#[derive(Clone, Debug, Default, PartialEq, Deserialize)]
+#[derive(Clone, Debug, Default, Eq, PartialEq, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Swap {
     /// The ID of the pool swapping in this step.

--- a/crates/shared/src/http_solver/model.rs
+++ b/crates/shared/src/http_solver/model.rs
@@ -112,14 +112,14 @@ pub struct TokenInfoModel {
     pub internal_buffer: Option<U256>,
 }
 
-#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
 pub struct TokenAmount {
     #[serde(with = "u256_decimal")]
     pub amount: U256,
     pub token: H160,
 }
 
-#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct ApprovalModel {
     pub token: H160,
     pub spender: H160,
@@ -127,7 +127,7 @@ pub struct ApprovalModel {
     pub amount: U256,
 }
 
-#[derive(Clone, Debug, Derivative, Deserialize, PartialEq, Serialize)]
+#[derive(Clone, Debug, Derivative, Deserialize, Eq, PartialEq, Serialize)]
 pub struct InteractionData {
     pub target: H160,
     pub value: U256,
@@ -243,7 +243,7 @@ pub struct ExecutedOrderModel {
     pub exec_plan: Option<ExecutionPlan>,
 }
 
-#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
 pub struct ExecutedLiquidityOrderModel {
     pub order: NativeLiquidityOrder,
     #[serde(with = "u256_decimal")]
@@ -252,7 +252,7 @@ pub struct ExecutedLiquidityOrderModel {
     pub exec_buy_amount: U256,
 }
 
-#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
 pub struct NativeLiquidityOrder {
     pub from: H160,
     #[serde(flatten)]

--- a/crates/shared/src/oneinch_api.rs
+++ b/crates/shared/src/oneinch_api.rs
@@ -18,7 +18,7 @@ use std::time::Duration;
 /// Parts to split a swap.
 ///
 /// This type is generic on the maximum number of splits allowed.
-#[derive(Clone, Copy, Debug, PartialEq, PartialOrd)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, PartialOrd)]
 pub struct Amount<const MIN: usize, const MAX: usize>(usize);
 
 impl<const MIN: usize, const MAX: usize> Amount<MIN, MAX> {
@@ -306,14 +306,14 @@ impl SwapQuery {
 }
 
 /// A 1Inch API response.
-#[derive(Clone, Debug, Deserialize, PartialEq)]
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq)]
 #[serde(untagged)]
 pub enum RestResponse<T> {
     Ok(T),
     Err(RestError),
 }
 
-#[derive(Clone, Debug, Deserialize, PartialEq, Default)]
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct RestError {
     pub status_code: u32,

--- a/crates/shared/src/paraswap_api.rs
+++ b/crates/shared/src/paraswap_api.rs
@@ -198,7 +198,7 @@ impl PriceQuery {
 }
 
 /// A Paraswap API price response.
-#[derive(Clone, Debug, PartialEq, Default)]
+#[derive(Clone, Debug, Eq, PartialEq, Default)]
 pub struct PriceResponse {
     /// Opaque type, which the API expects to get echoed back in the exact form when requesting settlement transaction data
     pub price_route_raw: Value,

--- a/crates/shared/src/price_estimation.rs
+++ b/crates/shared/src/price_estimation.rs
@@ -92,7 +92,7 @@ pub struct Query {
     pub kind: OrderKind,
 }
 
-#[derive(Copy, Clone, Debug, Default, PartialEq)]
+#[derive(Copy, Clone, Debug, Default, Eq, PartialEq)]
 pub struct Estimate {
     pub out_amount: U256,
     /// full gas cost when settling this order alone on gp

--- a/crates/shared/src/signature_validator.rs
+++ b/crates/shared/src/signature_validator.rs
@@ -7,7 +7,7 @@ use primitive_types::H160;
 use thiserror::Error;
 
 /// Structure used to represent a signature.
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct SignatureCheck {
     pub signer: H160,
     pub hash: [u8; 32],

--- a/crates/shared/src/sources/balancer_v2/graph_api.rs
+++ b/crates/shared/src/sources/balancer_v2/graph_api.rs
@@ -108,7 +108,7 @@ impl BalancerSubgraphClient {
 }
 
 /// Result of the registered stable pool query.
-#[derive(Debug, Default, PartialEq)]
+#[derive(Debug, Default, Eq, PartialEq)]
 pub struct RegisteredPools {
     /// The block number that the data was fetched, and for which the registered
     /// weighted pools can be considered up to date.
@@ -147,7 +147,7 @@ impl RegisteredPools {
 }
 
 /// Pool data from the Balancer V2 subgraph.
-#[derive(Debug, Deserialize, PartialEq)]
+#[derive(Debug, Deserialize, Eq, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct PoolData {
     pub pool_type: PoolType,
@@ -168,7 +168,7 @@ pub enum PoolType {
 
 /// Token data for pools.
 #[serde_as]
-#[derive(Debug, Deserialize, PartialEq)]
+#[derive(Debug, Deserialize, Eq, PartialEq)]
 pub struct Token {
     pub address: H160,
     pub decimals: u8,
@@ -209,7 +209,7 @@ mod pools_query {
         }
     "#;
 
-    #[derive(Debug, Deserialize, PartialEq)]
+    #[derive(Debug, Deserialize, Eq, PartialEq)]
     pub struct Data {
         pub pools: Vec<PoolData>,
     }
@@ -224,18 +224,18 @@ mod block_number_query {
         }
     }"#;
 
-    #[derive(Debug, Deserialize, PartialEq)]
+    #[derive(Debug, Deserialize, Eq, PartialEq)]
     pub struct Data {
         #[serde(rename = "_meta")]
         pub meta: Meta,
     }
 
-    #[derive(Debug, Deserialize, PartialEq)]
+    #[derive(Debug, Deserialize, Eq, PartialEq)]
     pub struct Meta {
         pub block: Block,
     }
 
-    #[derive(Debug, Deserialize, PartialEq)]
+    #[derive(Debug, Deserialize, Eq, PartialEq)]
     pub struct Block {
         pub number: u64,
     }

--- a/crates/shared/src/sources/balancer_v2/pools.rs
+++ b/crates/shared/src/sources/balancer_v2/pools.rs
@@ -49,7 +49,7 @@ macro_rules! impl_from_state {
 impl_from_state!(weighted::PoolState, Weighted);
 impl_from_state!(stable::PoolState, Stable);
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 /// Balancer pool status.
 pub enum PoolStatus {
     Active(Pool),

--- a/crates/shared/src/sources/uniswap_v3/graph_api.rs
+++ b/crates/shared/src/sources/uniswap_v3/graph_api.rs
@@ -165,7 +165,7 @@ impl UniV3SubgraphClient {
 }
 
 /// Result of the registered stable pool query.
-#[derive(Debug, Default, PartialEq)]
+#[derive(Debug, Default, Eq, PartialEq)]
 pub struct RegisteredPools {
     /// The block number that the data was fetched
     pub fetched_block_number: u64,
@@ -174,7 +174,7 @@ pub struct RegisteredPools {
 }
 
 /// Pool data from the Uniswap V3 subgraph.
-#[derive(Debug, Clone, Deserialize, Default, PartialEq)]
+#[derive(Debug, Clone, Deserialize, Default, Eq, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct PoolData {
     pub id: H160,
@@ -195,7 +195,7 @@ impl ContainsId for PoolData {
 }
 
 /// Tick data from the Uniswap V3 subgraph.
-#[derive(Debug, Clone, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Deserialize, Eq, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct TickData {
     pub id: String,
@@ -212,7 +212,7 @@ impl ContainsId for TickData {
     }
 }
 
-#[derive(Debug, Clone, Default, Deserialize, PartialEq, Serialize)]
+#[derive(Debug, Clone, Default, Deserialize, Eq, PartialEq, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Token {
     pub id: H160,
@@ -230,18 +230,18 @@ mod block_number_query {
         }
     }"#;
 
-    #[derive(Debug, Deserialize, PartialEq)]
+    #[derive(Debug, Deserialize, Eq, PartialEq)]
     pub struct Data {
         #[serde(rename = "_meta")]
         pub meta: Meta,
     }
 
-    #[derive(Debug, Deserialize, PartialEq)]
+    #[derive(Debug, Deserialize, Eq, PartialEq)]
     pub struct Meta {
         pub block: Block,
     }
 
-    #[derive(Debug, Deserialize, PartialEq)]
+    #[derive(Debug, Deserialize, Eq, PartialEq)]
     pub struct Block {
         pub number: u64,
     }

--- a/crates/shared/src/sources/uniswap_v3/pool_fetching.rs
+++ b/crates/shared/src/sources/uniswap_v3/pool_fetching.rs
@@ -22,7 +22,7 @@ pub trait PoolFetching: Send + Sync {
 }
 
 /// Pool data in a format prepared for solvers.
-#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
 pub struct PoolInfo {
     pub address: H160,
     pub tokens: Vec<Token>,
@@ -32,7 +32,7 @@ pub struct PoolInfo {
 
 /// Pool state in a format prepared for solvers.
 #[serde_as]
-#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
 pub struct PoolState {
     #[serde(with = "u256_decimal")]
     pub sqrt_price: U256,
@@ -48,7 +48,7 @@ pub struct PoolState {
 }
 
 /// Pool stats in a format prepared for solvers
-#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
 pub struct PoolStats {
     #[serde(with = "u256_decimal")]
     #[serde(rename = "mean")]

--- a/crates/shared/src/subgraph.rs
+++ b/crates/shared/src/subgraph.rs
@@ -25,7 +25,7 @@ pub trait ContainsId {
     fn get_id(&self) -> String;
 }
 
-#[derive(Debug, Deserialize, PartialEq)]
+#[derive(Debug, Deserialize, Eq, PartialEq)]
 pub struct Data<T> {
     #[serde(alias = "pools", alias = "ticks")]
     pub inner: Vec<T>,

--- a/crates/shared/src/token_list.rs
+++ b/crates/shared/src/token_list.rs
@@ -8,7 +8,7 @@ use serde::Deserialize;
 pub struct TokenList {
     tokens: HashMap<H160, Token>,
 }
-#[derive(Clone, Debug, Deserialize, PartialEq)]
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct Token {
     pub address: H160,
@@ -47,14 +47,14 @@ impl TokenList {
 }
 
 /// Relevant parts of TokenList schema as defined in https://uniswap.org/tokenlist.schema.json
-#[derive(Clone, Debug, Deserialize, PartialEq)]
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq)]
 #[serde(rename_all = "camelCase")]
 struct TokenListModel {
     name: String,
     tokens: Vec<TokenModel>,
 }
 
-#[derive(Clone, Debug, Deserialize, PartialEq)]
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq)]
 #[serde(rename_all = "camelCase")]
 struct TokenModel {
     chain_id: u64,

--- a/crates/shared/src/zeroex_api.rs
+++ b/crates/shared/src/zeroex_api.rs
@@ -142,7 +142,7 @@ impl Default for OrdersQuery {
     }
 }
 
-#[derive(Debug, Derivative, Clone, Deserialize, PartialEq)]
+#[derive(Debug, Derivative, Clone, Deserialize, Eq, PartialEq)]
 #[derivative(Default)]
 #[serde(rename_all = "camelCase")]
 pub struct OrderMetadata {
@@ -154,7 +154,7 @@ pub struct OrderMetadata {
     pub remaining_fillable_taker_amount: u128,
 }
 
-#[derive(Debug, Clone, Deserialize, PartialEq, Default)]
+#[derive(Debug, Clone, Deserialize, Eq, PartialEq, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct ZeroExSignature {
     pub r: H256,
@@ -163,7 +163,7 @@ pub struct ZeroExSignature {
     pub signature_type: u8,
 }
 
-#[derive(Debug, Derivative, Clone, Deserialize, PartialEq)]
+#[derive(Debug, Derivative, Clone, Deserialize, Eq, PartialEq)]
 #[derivative(Default)]
 #[serde(rename_all = "camelCase")]
 pub struct Order {
@@ -213,7 +213,7 @@ pub struct Order {
     pub verifying_contract: H160,
 }
 
-#[derive(Debug, Default, Clone, Deserialize, PartialEq)]
+#[derive(Debug, Default, Clone, Deserialize, Eq, PartialEq)]
 pub struct OrderRecord {
     #[serde(rename = "metaData")]
     pub metadata: OrderMetadata,
@@ -239,7 +239,7 @@ impl OrderRecord {
 }
 
 /// A Ox API `orders` response.
-#[derive(Debug, Default, Clone, Deserialize, PartialEq)]
+#[derive(Debug, Default, Clone, Deserialize, Eq, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct OrdersResponse {
     pub total: u64,

--- a/crates/solver/src/interactions/allowances.rs
+++ b/crates/solver/src/interactions/allowances.rs
@@ -41,14 +41,14 @@ pub trait AllowanceManaging: Send + Sync {
     async fn get_approvals(&self, requests: &[ApprovalRequest]) -> Result<Vec<Approval>>;
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Eq, PartialEq)]
 pub struct ApprovalRequest {
     pub token: H160,
     pub spender: H160,
     pub amount: U256,
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Eq, PartialEq)]
 pub struct Allowances {
     spender: H160,
     allowances: HashMap<H160, U256>,

--- a/crates/solver/src/settlement_simulation.rs
+++ b/crates/solver/src/settlement_simulation.rs
@@ -257,7 +257,7 @@ pub fn tenderly_link(
     )
 }
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
 pub struct TenderlyRequest {
     pub network_id: String,
     pub block_number: u64,

--- a/crates/solver/src/settlement_submission.rs
+++ b/crates/solver/src/settlement_submission.rs
@@ -159,6 +159,10 @@ impl SolutionSubmitter {
                 .iter()
                 .map(|strategy| {
                     async {
+                        // Needed so that the compiler understands that we don't
+                        // want to move `strategy` into the closure but use a
+                        // reference to it.
+                        #[allow(clippy::borrow_deref_ref)]
                         match &*strategy {
                             TransactionStrategy::Eden(_) | TransactionStrategy::Flashbots(_) => {
                                 if !matches!(account, Account::Offline(..)) {


### PR DESCRIPTION
CI has updated to use Rust 1.63. This introduced some new clippy lints which caused our CI to fail (mostly "you should implement `Eq` as well" lints).

This PR just fixes the lints so we can move on with our lives.
