### PR TITLE
Make referrer address configurable for 1Inch

### DIFF
--- a/crates/autopilot/src/lib.rs
+++ b/crates/autopilot/src/lib.rs
@@ -371,6 +371,7 @@ pub async fn main(args: arguments::Arguments) {
                     one_inch_api.as_ref().unwrap().clone(),
                     args.shared.disabled_one_inch_protocols.clone(),
                     rate_limiter(estimator.name()),
+                    args.shared.one_inch_referrer_address
                 )),
                 PriceEstimatorType::Yearn => create_http_estimator(
                     "yearn-price-estimator".to_string(),

--- a/crates/orderbook/src/main.rs
+++ b/crates/orderbook/src/main.rs
@@ -393,6 +393,7 @@ async fn main() {
                     one_inch_api.as_ref().unwrap().clone(),
                     args.shared.disabled_one_inch_protocols.clone(),
                     rate_limiter(estimator.name()),
+                    args.shared.one_inch_referrer_address
                 )),
                 PriceEstimatorType::Yearn => create_http_estimator(
                     "yearn-price-estimator".to_string(),

--- a/crates/shared/src/arguments.rs
+++ b/crates/shared/src/arguments.rs
@@ -143,6 +143,10 @@ pub struct Arguments {
     #[structopt(long, env, default_value = "https://api.1inch.exchange/")]
     pub one_inch_url: Url,
 
+    /// Which address should receive the rewards for referring trades to 1Inch.
+    #[structopt(long, env)]
+    pub one_inch_referrer_address: Option<H160>,
+
     /// The list of disabled 0x sources.
     #[clap(long, env, use_value_delimiter = true)]
     pub disabled_zeroex_sources: Vec<String>,
@@ -270,6 +274,9 @@ impl Display for Arguments {
             self.disabled_one_inch_protocols
         )?;
         writeln!(f, "one_inch_url: {}", self.one_inch_url)?;
+        write!(f, "one_inch_referrer_address: ")?;
+        display_option(&self.one_inch_referrer_address.map(|a| format!("{a:?}")), f)?;
+        writeln!(f)?;
         writeln!(
             f,
             "disabled_zeroex_sources: {:?}",

--- a/crates/shared/src/price_estimation/oneinch.rs
+++ b/crates/shared/src/price_estimation/oneinch.rs
@@ -11,6 +11,7 @@ use crate::{
 };
 use futures::{future::BoxFuture, FutureExt, StreamExt};
 use model::order::OrderKind;
+use primitive_types::H160;
 use std::sync::Arc;
 
 pub struct OneInchPriceEstimator {
@@ -22,6 +23,7 @@ pub struct OneInchPriceEstimator {
     disabled_protocols: Vec<String>,
     protocol_cache: ProtocolCache,
     rate_limiter: Arc<RateLimiter>,
+    referrer_address: Option<H160>,
 }
 
 impl OneInchPriceEstimator {
@@ -41,6 +43,7 @@ impl OneInchPriceEstimator {
             query.buy_token,
             allowed_protocols,
             query.in_amount,
+            self.referrer_address,
         );
         let quote_future = async move {
             api.get_sell_order_quote(oneinch_query)
@@ -68,6 +71,7 @@ impl OneInchPriceEstimator {
         api: Arc<dyn OneInchClient>,
         disabled_protocols: Vec<String>,
         rate_limiter: Arc<RateLimiter>,
+        referrer_address: Option<H160>,
     ) -> Self {
         Self {
             api,
@@ -75,6 +79,7 @@ impl OneInchPriceEstimator {
             protocol_cache: ProtocolCache::default(),
             sharing: Default::default(),
             rate_limiter,
+            referrer_address,
         }
     }
 }
@@ -118,6 +123,7 @@ mod tests {
                 Default::default(),
                 "test".into(),
             )),
+            None,
         )
     }
 

--- a/crates/solver/src/main.rs
+++ b/crates/solver/src/main.rs
@@ -242,6 +242,7 @@ async fn main() {
         args.shared.quasimodo_uses_internal_buffers,
         args.shared.mip_uses_internal_buffers,
         args.shared.one_inch_url,
+        args.shared.one_inch_referrer_address,
         args.external_solvers.unwrap_or_default(),
         args.oneinch_max_slippage_in_eth
             .map(|float| U256::from_f64_lossy(float * 1e18)),

--- a/crates/solver/src/solver.rs
+++ b/crates/solver/src/solver.rs
@@ -248,6 +248,7 @@ pub fn create(
     quasimodo_uses_internal_buffers: bool,
     mip_uses_internal_buffers: bool,
     one_inch_url: Url,
+    one_inch_referrer_address: Option<H160>,
     external_solvers: Vec<ExternalSolverArg>,
     oneinch_max_slippage_in_wei: Option<U256>,
     order_converter: Arc<OrderConverter>,
@@ -342,6 +343,7 @@ pub fn create(
                         one_inch_url.clone(),
                         oneinch_slippage_bps,
                         oneinch_max_slippage_in_wei,
+                        one_inch_referrer_address,
                     )?,
                 )))),
                 SolverType::ZeroEx => {

--- a/crates/solver/src/solver/oneinch_solver.rs
+++ b/crates/solver/src/solver/oneinch_solver.rs
@@ -20,7 +20,7 @@ use ethcontract::{Account, Bytes};
 use maplit::hashmap;
 use model::order::OrderKind;
 use num::{BigRational, FromPrimitive, ToPrimitive};
-use primitive_types::U256;
+use primitive_types::{H160, U256};
 use reqwest::Client;
 use reqwest::Url;
 use shared::conversions::U256Ext;
@@ -46,6 +46,7 @@ pub struct OneInchSolver {
     oneinch_slippage_bps: u32,
     /// how much slippage in wei we allow per trade
     max_slippage_in_wei: Option<U256>,
+    referrer_address: Option<H160>,
 }
 
 impl From<RestError> for SettlementError {
@@ -70,6 +71,7 @@ impl OneInchSolver {
         one_inch_url: Url,
         oneinch_slippage_bps: u32,
         max_slippage_in_wei: Option<U256>,
+        referrer_address: Option<H160>,
     ) -> Result<Self> {
         let settlement_address = settlement_contract.address();
         Ok(Self {
@@ -81,6 +83,7 @@ impl OneInchSolver {
             protocol_cache: ProtocolCache::default(),
             oneinch_slippage_bps,
             max_slippage_in_wei,
+            referrer_address,
         })
     }
 }
@@ -158,6 +161,7 @@ impl OneInchSolver {
             self.settlement_contract.address(),
             protocols,
             slippage,
+            self.referrer_address,
         );
 
         tracing::debug!("querying 1Inch swap api with {:?}", query);
@@ -269,6 +273,7 @@ mod tests {
             protocol_cache: ProtocolCache::default(),
             oneinch_slippage_bps: 10u32,
             max_slippage_in_wei: Some(U256::MAX),
+            referrer_address: None,
         }
     }
 
@@ -575,6 +580,7 @@ mod tests {
             Client::new(),
             OneInchClientImpl::DEFAULT_URL.try_into().unwrap(),
             10u32,
+            None,
             None,
         )
         .unwrap();


### PR DESCRIPTION
The 1Inch solver is costing a lot of money to run because it keeps positive slippage. One way to reduce the cost a bit is to participate in 1Inch's referral program.
This program rewards referrers some amount of `1INCH` tokens for every trade referred to 1Inch. The rewards can be claimed "approximately once per week" [[0](https://help.1inch.io/en/articles/4585140-what-is-the-referral-program-and-how-does-it-work)]. The 1Inch DAO can vote how much of the fees get rewarded for the referral [[1](https://app.1inch.io/#/1/dao/vote/referralShare)].

new CLI argument:
```
        --one-inch-referrer-address <ONE_INCH_REFERRER_ADDRESS>
            Which address should receive the rewards for referring trades to 1Inch

            [env: ONE_INCH_REFERRER_ADDRESS=]
```

logs for CLI argument:
```
...
one_inch_url: https://api.1inch.exchange/
one_inch_referrer_address: 0x6c642cafcbd9d8383250bb25f67ae409147f78b2
disabled_zeroex_sources: []
...
```

### Test Plan
Updated and ran automated and relevant ignored unit tests
Local test with the orderbook and solver to verify that both the `OneInchEstimator` and `OneInchSolver` append the referrer address to their queries.

logs from solver:
```
...
2022-08-18T07:10:55.795Z DEBUG auction{id=21994 run=0}: shared::oneinch_api: Query 1inch API for url https://api.1inch.exchange/v4.1/1/swap?fromTokenAddress=0x3f382dbd960e3a9bbceae22651e88158d2791550&toTokenAddress=0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48&amount=321827029307309282465&fromAddress=0x9008d19f58aabd9ed0d60971565aa8510560ab41&slippage=0.1&protocols=UNISWAP_V1%2CUNISWAP_V2%2CSUSHI%2CMOONISWAP%2CBALANCER%2CCOMPOUND%2CCURVE%2CCURVE_V2_SPELL_2_ASSET%2CCURVE_V2_SGT_2_ASSET%2CCURVE_V2_THRESHOLDNETWORK_2_ASSET%2CCHAI%2COASIS%2CKYBER%2CAAVE%2CIEARN%2CBANCOR%2CCREAMSWAP%2CSWERVE%2CBLACKHOLESWAP%2CDODO%2CDODO_V2%2CVALUELIQUID%2CSHELL%2CDEFISWAP%2CSAKESWAP%2CLUASWAP%2CMINISWAP%2CMSTABLE%2CPMM2%2CSYNTHETIX%2CAAVE_V2%2CST_ETH%2CONE_INCH_LP%2CONE_INCH_LP_1_1%2CLINKSWAP%2CS_FINANCE%2CPSM%2CPOWERINDEX%2CXSIGMA%2CCREAM_LENDING%2CSMOOTHY_FINANCE%2CSADDLE%2CPMM4%2CKYBER_DMM%2CBALANCER_V2%2CUNISWAP_V3%2CSETH_WRAPPER%2CCURVE_V2%2CCURVE_V2_EURS_2_ASSET%2CCURVE_V2_EURT_2_ASSET%2CCURVE_V2_XAUT_2_ASSET%2CCURVE_V2_ETH_CRV%2CCURVE_V2_ETH_CVX%2CCONVERGENCE_X%2CONE_INCH_LIMIT_ORDER%2CONE_INCH_LIMIT_ORDER_V2%2CDFX_FINANCE%2CFIXED_FEE_SWAP%2CDXSWAP%2CCLIPPER%2CSHIBASWAP%2CUNIFI%2CPSM_PAX%2CWSTETH%2CDEFI_PLAZA%2CFIXED_FEE_SWAP_V3%2CSYNTHETIX_WRAPPER%2CSYNAPSE%2CCURVE_V2_YFI_2_ASSET%2CCURVE_V2_ETH_PAL%2CPOOLTOGETHER%2CETH_BANCOR_V3%2CELASTICSWAP%2CBALANCER_V2_WRAPPER%2CSYNTHETIX_ATOMIC%2CFRAXSWAP%2CRADIOSHACK%2CKYBERSWAP_ELASTIC%2CCURVE_V2_TWO_CRYPTO%2CSTABLE_PLAZA%2CZEROX_LIMIT_ORDER&disableEstimate=true&referrerAddress=0x6c642cafcbd9d8383250bb25f67ae409147f78b2&allowPartialFill=false
2022-08-18T07:10:55.955Z DEBUG auction{id=21994 run=0}: shared::oneinch_api: Response from 1inch API: Ok("{\"fromToken\":{\"symbol\":\"GHST\",\"name\":\"Aavegotchi GHST Token\",\"decimals\":18,\"address\":\"0x3f382dbd960e3a9bbceae22651e88158d2791550\",\"logoURI\":\"https://tokens.1inch.io/0x3f382dbd960e3a9bbceae22651e88158d2791550.png\",\"tags\":[\"tokens\"]},\"toToken\":{\"symbol\":\"USDC\",\"name\":\"USD Coin\",\"address\":\"0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48\",\"decimals\":6,\"logoURI\":\"https://tokens.1inch.io/0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48.png\",\"eip2612\":true,\"domainVersion\":\"2\",\"tags\":[\"tokens\"]},\"toTokenAmount\":\"407243367\",\"fromTokenAmount\":\"321827029307309282465\",\"protocols\":[[[{\"name\":\"UNISWAP_V3\",\"part\":100,\"fromTokenAddress\":\"0x3f382dbd960e3a9bbceae22651e88158d2791550\",\"toTokenAddress\":\"0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2\"}],[{\"name\":\"UNISWAP_V3\",\"part\":100,\"fromTokenAddress\":\"0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2\",\"toTokenAddress\":\"0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48\"}]]],\"tx\":{\"from\":\"0x9008d19f58aabd9ed0d60971565aa8510560ab41\",\"to\":\"0x1111111254fb6c44bac0bed2854e76f90643097d\",\"data\":\"0xe449022e000000000000000000000000000000000000000000000011723f4a0ad565d4a100000000000000000000000000000000000000000000000000000000183fd39b00000000000000000000000000000000000000000000000000000000000000600000000000000000000000000000000000000000000000000000000000000002000000000000000000000000fba31f01058db09573a383f26a088f23774d4e5d80000000000000000000000088e6a0c2ddd26feeb64f039a2c41296fcb3f5640cfee7c08\",\"value\":\"0\",\"gas\":0,\"maxFeePerGas\":\"11312815143\",\"maxPriorityFeePerGas\":\"5449322350\"}}")
```

logs from estimator:
```
...
2022-08-18T07:31:38.872Z DEBUG request{id=1}: shared::oneinch_api: Query 1inch API for url https://api.1inch.exchange/v4.1/1/quote?fromTokenAddress=0xdac17f958d2ee523a2206206994597c13d831ec7&toTokenAddress=0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48&amount=1000000000&protocols=UNISWAP_V1%2CUNISWAP_V2%2CSUSHI%2CMOONISWAP%2CBALANCER%2CCOMPOUND%2CCURVE%2CCURVE_V2_SPELL_2_ASSET%2CCURVE_V2_SGT_2_ASSET%2CCURVE_V2_THRESHOLDNETWORK_2_ASSET%2CCHAI%2COASIS%2CKYBER%2CAAVE%2CIEARN%2CBANCOR%2CCREAMSWAP%2CSWERVE%2CBLACKHOLESWAP%2CDODO%2CDODO_V2%2CVALUELIQUID%2CSHELL%2CDEFISWAP%2CSAKESWAP%2CLUASWAP%2CMINISWAP%2CMSTABLE%2CPMM2%2CSYNTHETIX%2CAAVE_V2%2CST_ETH%2CONE_INCH_LP%2CONE_INCH_LP_1_1%2CLINKSWAP%2CS_FINANCE%2CPSM%2CPOWERINDEX%2CXSIGMA%2CCREAM_LENDING%2CSMOOTHY_FINANCE%2CSADDLE%2CPMM4%2CKYBER_DMM%2CBALANCER_V2%2CUNISWAP_V3%2CSETH_WRAPPER%2CCURVE_V2%2CCURVE_V2_EURS_2_ASSET%2CCURVE_V2_EURT_2_ASSET%2CCURVE_V2_XAUT_2_ASSET%2CCURVE_V2_ETH_CRV%2CCURVE_V2_ETH_CVX%2CCONVERGENCE_X%2CONE_INCH_LIMIT_ORDER%2CONE_INCH_LIMIT_ORDER_V2%2CDFX_FINANCE%2CFIXED_FEE_SWAP%2CDXSWAP%2CCLIPPER%2CSHIBASWAP%2CUNIFI%2CPSM_PAX%2CWSTETH%2CDEFI_PLAZA%2CFIXED_FEE_SWAP_V3%2CSYNTHETIX_WRAPPER%2CSYNAPSE%2CCURVE_V2_YFI_2_ASSET%2CCURVE_V2_ETH_PAL%2CPOOLTOGETHER%2CETH_BANCOR_V3%2CELASTICSWAP%2CBALANCER_V2_WRAPPER%2CSYNTHETIX_ATOMIC%2CFRAXSWAP%2CRADIOSHACK%2CKYBERSWAP_ELASTIC%2CCURVE_V2_TWO_CRYPTO%2CSTABLE_PLAZA%2CZEROX_LIMIT_ORDER&referrerAddress=0x6c642cafcbd9d8383250bb25f67ae409147f78b2
2022-08-18T07:31:38.926Z DEBUG maintenance{block=15363722}: shared::event_handling: updating events in block range Specific(15363671)..=Latest(15363723)
2022-08-18T07:31:38.945Z DEBUG maintenance{block=15363722}: shared::event_handling: updating events in block range Specific(15363671)..=Latest(15363723)
2022-08-18T07:31:39.052Z DEBUG request{id=1}: shared::oneinch_api: Response from 1inch API: Ok("{\"fromToken\":{\"symbol\":\"USDT\",\"name\":\"Tether USD\",\"address\":\"0xdac17f958d2ee523a2206206994597c13d831ec7\",\"decimals\":6,\"logoURI\":\"https://tokens.1inch.io/0xdac17f958d2ee523a2206206994597c13d831ec7.png\",\"tags\":[\"tokens\"]},\"toToken\":{\"symbol\":\"USDC\",\"name\":\"USD Coin\",\"address\":\"0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48\",\"decimals\":6,\"logoURI\":\"https://tokens.1inch.io/0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48.png\",\"eip2612\":true,\"domainVersion\":\"2\",\"tags\":[\"tokens\"]},\"toTokenAmount\":\"1000034052\",\"fromTokenAmount\":\"1000000000\",\"protocols\":[[[{\"name\":\"UNISWAP_V3\",\"part\":100,\"fromTokenAddress\":\"0xdac17f958d2ee523a2206206994597c13d831ec7\",\"toTokenAddress\":\"0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48\"}]]],\"estimatedGas\":238614}")
```
