### PR TITLE
Fix Debug implementation of InteractionData

### DIFF
--- a/crates/shared/src/http_solver/model.rs
+++ b/crates/shared/src/http_solver/model.rs
@@ -127,11 +127,12 @@ pub struct ApprovalModel {
     pub amount: U256,
 }
 
-#[derive(Clone, Debug, Derivative, Deserialize, Eq, PartialEq, Serialize)]
+#[derive(Clone, Derivative, Deserialize, Eq, PartialEq, Serialize)]
+#[derivative(Debug)]
 pub struct InteractionData {
     pub target: H160,
     pub value: U256,
-    #[derivative(Debug(format_with = "debug_bytes"))]
+    #[derivative(Debug(format_with = "crate::debug_bytes"))]
     #[serde(deserialize_with = "bytes_hex_or_array::deserialize")]
     #[serde(serialize_with = "model::bytes_hex::serialize")]
     pub call_data: Vec<u8>,


### PR DESCRIPTION
The `Debug` implementation of `InteractionData` was not doing what it was supposed to. It was clearly intended to print the `call_data` as `0x123....` although [Kibana](https://logs.cow.fi/app/discover#/doc/63bc0b10-5f93-11e9-bf17-fbe383fc7c9c/logstash-2022.08.18?id=4fpcsIIBO2Iz_eQrKT_b) shows it currently being logged as `[1, 2, 3, ...]` instead.

To enable the `#[derivative(...)]` override macros on the members of the struct the struct also has to use the `#[derivative(TRAIT_TO_OVERRIDE)]` macro as a whole.

### Test Plan
CI
verified the fixed `Debug` output with a temporary local test:
```
InteractionData { target: 0xffffffffffffffffffffffffffffffffffffffff, value: 0, call_data: 0x01020304, inputs: [TokenAmount { amount: 9999, token: 0x0101010101010101010101010101010101010101 }], outputs: [TokenAmount { amount: 2000, token: 0x0202020202020202020202020202020202020202 }, TokenAmount { amount: 3000, token: 0x0303030303030303030303030303030303030303 }], exec_plan: Some(Internal) }
```
