### PR TITLE
No liquidity or filtering of non-fee-connected-tokens for external solvers

### DIFF
--- a/crates/driver/src/main.rs
+++ b/crates/driver/src/main.rs
@@ -171,6 +171,7 @@ async fn build_solvers(common: &CommonComponents, args: &Arguments) -> Vec<Arc<d
                 allowance_mananger.clone(),
                 common.order_converter.clone(),
                 http_solver_cache.clone(),
+                false,
             )) as Arc<dyn Solver>
         })
         .collect()

--- a/crates/solver/src/solver.rs
+++ b/crates/solver/src/solver.rs
@@ -270,19 +270,18 @@ pub fn create(
     ));
 
     // We use two separate solver caches: one for our internal optimization
-    // solvers (which **does** include AMM liquidity and filter out orders with
-    // non-fee-connected-tokens), and one for external solvers (which **does
-    // not** include AMM liquidity or filter out orders with
+    // solvers (which **does** filter out orders with non-fee-connected-tokens),
+    // and one for external solvers (which **does not** filter out orders with
     // non-fee-connected-tokens)
-    let http_solver_cache_with_liquidity = http_solver::InstanceCache::default();
-    let http_solver_cache_without_liquidity = http_solver::InstanceCache::default();
+    let http_instance_with_filtered_orders = http_solver::InstanceCache::default();
+    let http_instance_with_all_orders = http_solver::InstanceCache::default();
 
     // Helper function to create http solver instances.
     let create_http_solver = |account: Account,
                               url: Url,
                               name: String,
                               config: SolverConfig,
-                              include_liquidity_in_instance: bool|
+                              filter_non_fee_connected_orders: bool|
      -> HttpSolver {
         HttpSolver::new(
             DefaultHttpSolverApi {
@@ -299,13 +298,12 @@ pub fn create(
             buffer_retriever.clone(),
             allowance_mananger.clone(),
             order_converter.clone(),
-            if include_liquidity_in_instance {
-                http_solver_cache_with_liquidity.clone()
+            if filter_non_fee_connected_orders {
+                http_instance_with_filtered_orders.clone()
             } else {
-                http_solver_cache_without_liquidity.clone()
+                http_instance_with_all_orders.clone()
             },
-            // include AMM liquidity for our internal optimiation solvers
-            include_liquidity_in_instance,
+            filter_non_fee_connected_orders,
         )
     };
 

--- a/crates/solver/src/solver.rs
+++ b/crates/solver/src/solver.rs
@@ -268,28 +268,46 @@ pub fn create(
         web3.clone(),
         settlement_contract.address(),
     ));
-    let http_solver_cache = http_solver::InstanceCache::default();
+
+    // We use two separate solver caches: one for our internal optimization
+    // solvers (which **does** include AMM liquidity and filter out orders with
+    // non-fee-connected-tokens), and one for external solvers (which **does
+    // not** include AMM liquidity or filter out orders with
+    // non-fee-connected-tokens)
+    let http_solver_cache_with_liquidity = http_solver::InstanceCache::default();
+    let http_solver_cache_without_liquidity = http_solver::InstanceCache::default();
+
     // Helper function to create http solver instances.
-    let create_http_solver =
-        |account: Account, url: Url, name: String, config: SolverConfig| -> HttpSolver {
-            HttpSolver::new(
-                DefaultHttpSolverApi {
-                    name,
-                    network_name: network_id.clone(),
-                    chain_id,
-                    base: url,
-                    client: client.clone(),
-                    config,
-                },
-                account,
-                native_token,
-                token_info_fetcher.clone(),
-                buffer_retriever.clone(),
-                allowance_mananger.clone(),
-                order_converter.clone(),
-                http_solver_cache.clone(),
-            )
-        };
+    let create_http_solver = |account: Account,
+                              url: Url,
+                              name: String,
+                              config: SolverConfig,
+                              include_liquidity_in_instance: bool|
+     -> HttpSolver {
+        HttpSolver::new(
+            DefaultHttpSolverApi {
+                name,
+                network_name: network_id.clone(),
+                chain_id,
+                base: url,
+                client: client.clone(),
+                config,
+            },
+            account,
+            native_token,
+            token_info_fetcher.clone(),
+            buffer_retriever.clone(),
+            allowance_mananger.clone(),
+            order_converter.clone(),
+            if include_liquidity_in_instance {
+                http_solver_cache_with_liquidity.clone()
+            } else {
+                http_solver_cache_without_liquidity.clone()
+            },
+            // include AMM liquidity for our internal optimiation solvers
+            include_liquidity_in_instance,
+        )
+    };
 
     let mut solvers: Vec<Arc<dyn Solver>> = solvers
         .into_iter()
@@ -315,12 +333,14 @@ pub fn create(
                         use_internal_buffers: Some(mip_uses_internal_buffers),
                         ..Default::default()
                     },
+                    true,
                 ))),
                 SolverType::CowDexAg => Ok(shared(create_http_solver(
                     account,
                     cow_dex_ag_solver_url.clone(),
                     "CowDexAg".to_string(),
                     SolverConfig::default(),
+                    false,
                 ))),
                 SolverType::Quasimodo => Ok(shared(create_http_solver(
                     account,
@@ -330,6 +350,7 @@ pub fn create(
                         use_internal_buffers: Some(quasimodo_uses_internal_buffers),
                         ..Default::default()
                     },
+                    true,
                 ))),
                 SolverType::OneInch => Ok(shared(single_order(Box::new(
                     OneInchSolver::with_disabled_protocols(
@@ -407,6 +428,7 @@ pub fn create(
                 use_internal_buffers: Some(mip_uses_internal_buffers),
                 ..Default::default()
             },
+            false,
         ))
     });
     solvers.extend(external_solvers);


### PR DESCRIPTION
Patches #454.

One of the external solvers integrating with our protocol noticed that orders that they were explicitly trying to solve for were being filtered out and not sent as part of the instance they were solving for.

Specifically, the external solver integration aimed at handling orders trading specific tokens by entering and exiting on-chain positions instead of the standard swapping with on-chain liquidity. This meant that orders for these tokens were not being passed to the solvers and were being filtered out (since there was no baseline liquidity between those tokens and the fee token) despite the order being allowed (because of existing price estimate). This meant that these orders could never be solved! They can't be handled by our single order solvers and were getting filtered out in the instance that is sent to all external HTTP solvers. This also implies that for orders without Baseline/Quasimodo price estimates that they were never going to external solvers and were only being handled by our single order solvers.

This PR adds a flat that controls whether or not to filter orders with non-fee-connected-tokens for solvers based on baseline liquidity. This allows our optimization solvers (MIP and Quasimodo) to continue to function, as they rely on the fact that no orders on "islands" not connected to the fee token exist, while passing all orders to external solvers (as they should be).

Ideally, we should **stop** filtering out orders in the instance file. Since this requirement is specific to our optimization solvers (MIP and Quasimodo), they should do the filtering themselves internally. However, since this fix is important we shouldn't wait for the required changes to MIP and Quasimodo to just disable the non-fee-connected-tokens order filtering altogether.

### Test Plan

Some manual testing. Start the `orderbook` and `autopilot` and create an order trading a token **without UniswapV2 liquidity**. I just found a random pair and used `0x33d63ba1e57e54779f7ddaeaa7109349344cf5f1` to `0x89d71dfbdd6ebecd0dfe27d55189f903169d2991` (found them by looking through newly deployed UniV3 pairs and checking `getPair` on the UniV2 factory contract).

Start the `solver` with **only UniswapV2** baseline liquidity with an optimization solver and an external HTTP solver, and see that it sends an instance including the order created ☝️ but without any AMMs (this used to be filtered out because it was "not connected to fee token"):
```
cargo run -p solver -- \
  --baseline-sources UniswapV2 \
  --solvers Quasimodo \
  --external-solvers 'Test|http://localhost:9999|0x4242424242424242424242424242424242424242' \
  --solver-account 0x4242424242424242424242424242424242424242 \
  --transaction-strategy DryRun
```

<details><summary>Notice that we send an empty instance to Quasimodo:</summary>

```
{
  "tokens": {
    "0x33d63ba1e57e54779f7ddaeaa7109349344cf5f1": {
      "decimals": 18,
      "alias": "DATA",
      "external_price": 0.012628828654630182,
      "normalize_priority": 0,
      "internal_buffer": "240849371584716781"
    },
    "0x89d71dfbdd6ebecd0dfe27d55189f903169d2991": {
      "decimals": 0,
      "alias": "THDX",
      "external_price": 1785714285714285.8,
      "normalize_priority": 0,
      "internal_buffer": "0"
    }
  },
  "orders": {},
  "amms": {},
  "metadata": {
    "environment": "Ethereum / Mainnet",
    "auction_id": 1,
    "run_id": 1,
    "gas_price": 15268515361.0,
    "native_token": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"
  }
}
```

</details>

<details><summary>But that we include the order for the external HTTP solver:</summary>

```
{
  "tokens": {
    "0x33d63ba1e57e54779f7ddaeaa7109349344cf5f1": {
      "decimals": 18,
      "alias": "DATA",
      "external_price": 0.012628828654630182,
      "normalize_priority": 0,
      "internal_buffer": "240849371584716781"
    },
    "0x89d71dfbdd6ebecd0dfe27d55189f903169d2991": {
      "decimals": 0,
      "alias": "THDX",
      "external_price": 1785714285714285.8,
      "normalize_priority": 0,
      "internal_buffer": "0"
    }
  },
  "orders": {
    "0": {
      "sell_token": "0x33d63ba1e57e54779f7ddaeaa7109349344cf5f1",
      "buy_token": "0x89d71dfbdd6ebecd0dfe27d55189f903169d2991",
      "sell_amount": "999351486382391283712",
      "buy_amount": "5238",
      "allow_partial_fill": false,
      "is_sell_order": true,
      "fee": {
        "amount": "648513617608716288",
        "token": "0x33d63ba1e57e54779f7ddaeaa7109349344cf5f1"
      },
      "cost": {
        "amount": "1012531596164715",
        "token": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"
      },
      "is_liquidity_order": false,
      "mandatory": false,
      "has_atomic_execution": false
    }
  },
  "amms": {},
  "metadata": {
    "environment": "Ethereum / Mainnet",
    "auction_id": 1,
    "run_id": 1,
    "gas_price": 15268515361.0,
    "native_token": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"
  }
}
```

</details>