### PR TITLE
Reuse submission logic from current driver in the new driver

### DIFF
--- a/crates/driver/src/arguments.rs
+++ b/crates/driver/src/arguments.rs
@@ -134,6 +134,12 @@ pub struct Arguments {
     #[clap(long, env)]
     pub tenderly_api_key: Option<String>,
 
+    /// Gas limit for simulations. This parameter is important to set correctly, such that
+    /// there are no simulation errors due to: err: insufficient funds for gas * price + value,
+    /// but at the same time we don't restrict solutions sizes too much
+    #[clap(long, env, default_value = "15000000")]
+    pub simulation_gas_limit: u128,
+
     /// The target confirmation time in seconds for settlement transactions used to estimate gas price.
     #[clap(
         long,
@@ -310,6 +316,7 @@ impl std::fmt::Display for Arguments {
                 .map(|_| "SECRET")
                 .unwrap_or("None")
         )?;
+        writeln!(f, "simulation_gas_limit: {}", self.simulation_gas_limit)?;
         writeln!(f, "target_confirm_time: {:?}", self.target_confirm_time)?;
         writeln!(
             f,

--- a/crates/driver/src/commit_reveal.rs
+++ b/crates/driver/src/commit_reveal.rs
@@ -161,8 +161,10 @@ impl CommitRevealSolving for CommitRevealSolver {
 }
 
 /// This is just a wrapper type to make a `dyn CommitRevealSolving` usable where `dyn Solver` is
-/// expected. This type is only supposed to give information about the name and account of the
-/// underlying solver and will panic if `solve()` gets called.
+/// expected for logging purposes. This type is only supposed to give information about the
+/// name and account of the underlying solver and will panic if `solve()` gets called.
+/// Eventually this wrapper should get removed when the logging code got refactored to expect
+/// something like a `NamedAccount` (name + account info) instead of an `Arc<dyn Solver>`.
 #[derive(Clone)]
 pub struct CommitRevealSolverAdapter {
     solver: Arc<dyn CommitRevealSolving>,

--- a/crates/driver/src/driver.rs
+++ b/crates/driver/src/driver.rs
@@ -54,7 +54,11 @@ impl Driver {
             .simulate_settlements(vec![(fake_solver, settlement)], gas_price)
             .await?
             .pop()
-            .unwrap();
+            .context("simulation returned no results")?;
+        anyhow::ensure!(
+            simulation_details.gas_estimate.is_ok(),
+            "settlement reverted during simulation"
+        );
         Ok(simulation_details)
     }
 
@@ -87,7 +91,7 @@ impl Driver {
             simulation_details.settlement,
             simulation_details
                 .gas_estimate
-                .context("settlement reverted during simulation")?,
+                .expect("checked simulation gas_estimate during validation"),
             12, // TODO propagate tracable settlement id
         )
         .await

--- a/crates/driver/src/driver.rs
+++ b/crates/driver/src/driver.rs
@@ -1,22 +1,33 @@
 use crate::{
     api::{execute::ExecuteError, solve::SolveError},
     auction_converter::AuctionConverting,
-    commit_reveal::{CommitRevealSolving, SettlementSummary},
+    commit_reveal::{CommitRevealSolverAdapter, CommitRevealSolving, SettlementSummary},
 };
-use anyhow::Result;
+use anyhow::{Context, Result};
+use gas_estimation::GasPriceEstimating;
 use model::auction::Auction;
 use shared::{
     current_block::{block_number, CurrentBlockStream},
     recent_block_cache::Block,
 };
-use solver::{settlement::Settlement, settlement_submission::SolutionSubmitter};
+use solver::{
+    driver::submit_settlement,
+    driver_logger::DriverLogger,
+    settlement::Settlement,
+    settlement_rater::{SettlementRating, SimulationDetails},
+    settlement_submission::{SolutionSubmitter, SubmissionError},
+};
 use std::sync::Arc;
+use web3::types::TransactionReceipt;
 
 pub struct Driver {
     pub solver: Arc<dyn CommitRevealSolving>,
     pub submitter: Arc<SolutionSubmitter>,
     pub auction_converter: Arc<dyn AuctionConverting>,
     pub block_stream: CurrentBlockStream,
+    pub settlement_rater: Arc<dyn SettlementRating>,
+    pub logger: Arc<DriverLogger>,
+    pub gas_price_estimator: Arc<dyn GasPriceEstimating>,
 }
 
 impl Driver {
@@ -35,28 +46,50 @@ impl Driver {
     }
 
     /// Validates that the `Settlement` satisfies expected fairness and correctness properties.
-    async fn validate_settlement(&self, _settlement: &Settlement) -> Result<()> {
-        // TODO simulation
-        // TODO token conservation
-        Ok(())
+    async fn validate_settlement(&self, settlement: Settlement) -> Result<SimulationDetails> {
+        let gas_price = self.gas_price_estimator.estimate().await?;
+        let fake_solver = Arc::new(CommitRevealSolverAdapter::from(self.solver.clone()));
+        let simulation_details = self
+            .settlement_rater
+            .simulate_settlements(vec![(fake_solver, settlement)], gas_price)
+            .await?
+            .pop()
+            .unwrap();
+        Ok(simulation_details)
     }
 
     /// When the solver won the competition it finalizes the `Settlement` and decides whether it
     /// still wants to execute and submit that `Settlement`.
-    pub async fn on_auction_won(&self, summary: SettlementSummary) -> Result<(), ExecuteError> {
+    pub async fn on_auction_won(
+        &self,
+        summary: SettlementSummary,
+    ) -> Result<TransactionReceipt, ExecuteError> {
         let settlement = match self.solver.reveal(summary).await? {
             None => return Err(ExecuteError::ExecutionRejected),
             Some(solution) => solution,
         };
-        self.validate_settlement(&settlement).await?;
-        self.submit_settlement(settlement).await?;
-        Ok(())
+        let simulation_details = self.validate_settlement(settlement).await?;
+        self.submit_settlement(simulation_details)
+            .await
+            // TODO correctly propagate specific errors to the end
+            .map_err(|e| ExecuteError::from(e.into_anyhow()))
     }
 
     /// Tries to submit the `Settlement` on chain. Returns a transaction hash if it was successful.
-    async fn submit_settlement(&self, _settlement: Settlement) -> Result<()> {
-        // TODO execute
-        // TODO notify about execution
-        Ok(())
+    async fn submit_settlement(
+        &self,
+        simulation_details: SimulationDetails,
+    ) -> Result<TransactionReceipt, SubmissionError> {
+        submit_settlement(
+            &self.submitter,
+            &self.logger,
+            simulation_details.solver,
+            simulation_details.settlement,
+            simulation_details
+                .gas_estimate
+                .context("settlement reverted during simulation")?,
+            12, // TODO propagate tracable settlement id
+        )
+        .await
     }
 }

--- a/crates/driver/src/driver.rs
+++ b/crates/driver/src/driver.rs
@@ -92,7 +92,7 @@ impl Driver {
             simulation_details
                 .gas_estimate
                 .expect("checked simulation gas_estimate during validation"),
-            12, // TODO propagate tracable settlement id
+            42, // TODO propagate tracable settlement id
         )
         .await
     }

--- a/crates/driver/src/main.rs
+++ b/crates/driver/src/main.rs
@@ -499,7 +499,7 @@ async fn build_logger(common: &CommonComponents, args: &Arguments) -> Arc<Driver
         metrics: Arc::new(Metrics::new().unwrap()),
         network_id: common.network_id.clone(),
         settlement_contract: common.settlement_contract.clone(),
-        simulation_gas_limit: u128::MAX, // TODO pass as CLI argument?
+        simulation_gas_limit: 15000000, // TODO pass as CLI argument?
         tenderly,
     })
 }

--- a/crates/driver/src/main.rs
+++ b/crates/driver/src/main.rs
@@ -27,14 +27,17 @@ use shared::{
 };
 use solver::{
     arguments::TransactionStrategyArg,
+    driver_logger::DriverLogger,
     interactions::allowances::AllowanceManager,
     liquidity::{
         balancer_v2::BalancerV2Liquidity, order_converter::OrderConverter,
         uniswap_v2::UniswapLikeLiquidity, uniswap_v3::UniswapV3Liquidity, zeroex::ZeroExLiquidity,
     },
     liquidity_collector::LiquidityCollector,
+    metrics::Metrics,
     settlement_access_list::AccessListEstimating,
     settlement_rater::SettlementRater,
+    settlement_simulation::TenderlyApi,
     settlement_submission::{
         submitter::{
             custom_nodes_api::CustomNodesApi, eden_api::EdenApi, flashbots_api::FlashbotsApi,
@@ -484,6 +487,23 @@ async fn build_amm_artifacts(
     res
 }
 
+async fn build_logger(common: &CommonComponents, args: &Arguments) -> Arc<DriverLogger> {
+    let tenderly = args
+        .tenderly_url
+        .clone()
+        .zip(args.tenderly_api_key.clone())
+        .and_then(|(url, api_key)| TenderlyApi::new(url, common.client.clone(), &api_key).ok());
+
+    Arc::new(DriverLogger {
+        web3: common.web3.clone(),
+        metrics: Arc::new(Metrics::new().unwrap()),
+        network_id: common.network_id.clone(),
+        settlement_contract: common.settlement_contract.clone(),
+        simulation_gas_limit: u128::MAX, // TODO pass as CLI argument?
+        tenderly,
+    })
+}
+
 #[tokio::main]
 async fn main() {
     let args = driver::arguments::Arguments::parse();
@@ -499,6 +519,7 @@ async fn main() {
         web3: common.web3.clone(),
     });
     let auction_converter = build_auction_converter(&common, &args).await.unwrap();
+    let logger = build_logger(&common, &args).await;
 
     let drivers = solvers
         .into_iter()
@@ -513,6 +534,9 @@ async fn main() {
                 submitter: submitter.clone(),
                 auction_converter: auction_converter.clone(),
                 block_stream: common.current_block_stream.clone(),
+                logger: logger.clone(),
+                settlement_rater: settlement_rater.clone(),
+                gas_price_estimator: common.gas_price_estimator.clone(),
             });
             (driver, name)
         })

--- a/crates/driver/src/main.rs
+++ b/crates/driver/src/main.rs
@@ -508,7 +508,7 @@ async fn build_drivers(common: &CommonComponents, args: &Arguments) -> Vec<(Arc<
         network_id: common.network_id.clone(),
         metrics,
         settlement_contract: common.settlement_contract.clone(),
-        simulation_gas_limit: 15000000, // TODO pass as CLI argument?
+        simulation_gas_limit: args.simulation_gas_limit,
         tenderly,
     });
 

--- a/crates/driver/src/main.rs
+++ b/crates/driver/src/main.rs
@@ -487,7 +487,7 @@ async fn build_amm_artifacts(
     res
 }
 
-async fn build_logger(common: &CommonComponents, args: &Arguments) -> Arc<DriverLogger> {
+fn build_logger(common: &CommonComponents, args: &Arguments) -> Arc<DriverLogger> {
     let tenderly = args
         .tenderly_url
         .clone()
@@ -519,7 +519,7 @@ async fn main() {
         web3: common.web3.clone(),
     });
     let auction_converter = build_auction_converter(&common, &args).await.unwrap();
-    let logger = build_logger(&common, &args).await;
+    let logger = build_logger(&common, &args);
 
     let drivers = solvers
         .into_iter()

--- a/crates/solver/src/settlement_rater.rs
+++ b/crates/solver/src/settlement_rater.rs
@@ -7,15 +7,24 @@ use crate::{
 };
 use anyhow::{Context, Result};
 use contracts::GPv2Settlement;
+use ethcontract::errors::ExecutionError;
 use gas_estimation::GasPrice1559;
 use itertools::{Either, Itertools};
 use num::BigRational;
+use primitive_types::U256;
 use shared::Web3;
 use std::sync::Arc;
 use web3::types::AccessList;
 
 type SolverSettlement = (Arc<dyn Solver>, Settlement);
 pub type RatedSolverSettlement = (Arc<dyn Solver>, RatedSettlement, Option<AccessList>);
+
+pub struct SimulationDetails {
+    pub settlement: Settlement,
+    pub solver: Arc<dyn Solver>,
+    pub access_list: Option<AccessList>,
+    pub gas_estimate: Result<U256, ExecutionError>,
+}
 
 #[mockall::automock]
 #[async_trait::async_trait]
@@ -27,6 +36,12 @@ pub trait SettlementRating: Send + Sync {
         prices: &ExternalPrices,
         gas_price: GasPrice1559,
     ) -> Result<(Vec<RatedSolverSettlement>, Vec<SettlementWithError>)>;
+
+    async fn simulate_settlements(
+        &self,
+        settlements: Vec<SolverSettlement>,
+        gas_price: GasPrice1559,
+    ) -> Result<Vec<SimulationDetails>>;
 }
 
 pub struct SettlementRater {
@@ -73,14 +88,12 @@ impl SettlementRater {
 
 #[async_trait::async_trait]
 impl SettlementRating for SettlementRater {
-    async fn rate_settlements(
+    async fn simulate_settlements(
         &self,
-        settlements: Vec<SolverSettlement>,
-        prices: &ExternalPrices,
+        settlements: Vec<(Arc<dyn Solver>, Settlement)>,
         gas_price: GasPrice1559,
-    ) -> Result<(Vec<RatedSolverSettlement>, Vec<SettlementWithError>)> {
+    ) -> Result<Vec<SimulationDetails>> {
         let settlements = self.append_access_lists(settlements, gas_price).await;
-
         let simulations = simulate_and_estimate_gas_at_current_block(
             settlements.iter().map(|settlement| {
                 (
@@ -95,6 +108,29 @@ impl SettlementRating for SettlementRater {
         )
         .await
         .context("failed to simulate settlements")?;
+
+        let details: Vec<_> = settlements
+            .into_iter()
+            .zip(simulations.into_iter())
+            .map(
+                |((solver, settlement, access_list), simulation_result)| SimulationDetails {
+                    settlement,
+                    solver,
+                    access_list,
+                    gas_estimate: simulation_result,
+                },
+            )
+            .collect();
+        Ok(details)
+    }
+
+    async fn rate_settlements(
+        &self,
+        settlements: Vec<SolverSettlement>,
+        prices: &ExternalPrices,
+        gas_price: GasPrice1559,
+    ) -> Result<(Vec<RatedSolverSettlement>, Vec<SettlementWithError>)> {
+        let simulations = self.simulate_settlements(settlements, gas_price).await?;
 
         let gas_price =
             BigRational::from_float(gas_price.effective_gas_price()).expect("Invalid gas price.");
@@ -115,16 +151,21 @@ impl SettlementRating for SettlementRater {
         };
 
         Ok(
-            (settlements.into_iter().zip(simulations).enumerate()).partition_map(
-                |(i, ((solver, settlement, access_list), result))| match result {
+            (simulations.into_iter().enumerate()).partition_map(|(i, details)| {
+                match details.gas_estimate {
                     Ok(gas_estimate) => Either::Left((
-                        solver.clone(),
-                        rate_settlement(i, settlement, gas_estimate),
-                        access_list,
+                        details.solver,
+                        rate_settlement(i, details.settlement, gas_estimate),
+                        details.access_list,
                     )),
-                    Err(err) => Either::Right((solver, settlement, access_list, err)),
-                },
-            ),
+                    Err(err) => Either::Right((
+                        details.solver,
+                        details.settlement,
+                        details.access_list,
+                        err,
+                    )),
+                }
+            }),
         )
     }
 }


### PR DESCRIPTION
Implements step 8 and partly step 7 of #337

Recently I refactored some of the current driver logic into separate components in order to reuse them in the new driver. This PR makes use of the free function responsible for submitting settlements as well as logging and metrics related to that.
In order to make the refactored code compatible with the new driver I had to do a few additional changes:
1. Don't submit a `RatedSettlement` but instead  require a `Settlement` and a few additional pieces of information.
2. Split `SettlementRater::rate_settlements()` into simulating (+estimating gas costs) and rating the settlement.
3. Add an wrapper around `dyn CommitRevealSolving` which implements `dyn Solver`. This is definitely not optimal but much of the existing logic passes around `Arc<dyn Solver>` (although it actually only needs a name and an account). This way only very little code has to be changed right now and I can focus on finishing the functionality.

With those changes in place instantiating and using the required components is trivial.

For simulating the settlements I had to copy another CLI argument from the current driver:
new init logs:
```
...
tenderly_api_key: SECRET
simulation_gas_limit: 15000000
target_confirm_time: 30s
...
```
new help:
```
        --simulation-gas-limit <SIMULATION_GAS_LIMIT>
            Gas limit for simulations. This parameter is important to set correctly, such that there
            are no simulation errors due to: err: insufficient funds for gas * price + value, but at
            the same time we don't restrict solutions sizes too much [env: SIMULATION_GAS_LIMIT=]
            [default: 15000000]
```

### Test Plan
CI
