### PR TITLE
Make sure to maintain UniV2 pool fetcher

### DIFF
--- a/crates/autopilot/src/lib.rs
+++ b/crates/autopilot/src/lib.rs
@@ -445,7 +445,7 @@ pub async fn main(args: arguments::Arguments) {
     ));
 
     let mut service_maintainer = shared::maintenance::ServiceMaintenance {
-        maintainers: vec![event_updater, Arc::new(db.clone())],
+        maintainers: vec![pool_fetcher, event_updater, Arc::new(db.clone())],
     };
     if let Some(balancer) = balancer_pool_fetcher {
         service_maintainer.maintainers.push(balancer);


### PR DESCRIPTION
Fixed #462 

This PR adds the UniswapV2-like liquidity `PoolCache` instance to the list of components that require block maintenance.

We noticed that prices included in the auctions were inaccurate for specific tokens. We identified that one potential issue was that the configuration between the `autopilot` and `orderbook` were different. However, it did not explain why the configuration with **less** liquidity had **better** prices.

It turns out that we weren't running block maintenance on our `PoolCache` instance. The check that verifies that the cached pool data is sufficiently up to date compares the fetched block with the last updated block:

https://github.com/cowprotocol/services/blob/6d56663e7b6296597599a5accce746278243606c/crates/shared/src/recent_block_cache.rs#L286-L293

Which only gets updated on maintenance:

https://github.com/cowprotocol/services/blob/6d56663e7b6296597599a5accce746278243606c/crates/shared/src/recent_block_cache.rs#L179

Fortunately the solution is simple: schedule the `PoolCache` to update when new blocks are observed.

### Test Plan

CI. You can also run locally and see that the `PoolCache` is getting updated periodically:
```
% cargo test -p autopilot
...
2022-08-23T12:36:03.897Z DEBUG maintenance{block=15396578}: shared::recent_block_cache: dropping blocks older than 15396569 from cache
2022-08-23T12:36:03.897Z DEBUG maintenance{block=15396578}: shared::recent_block_cache: the cache now contains entries for 0 block-key combinations
...
```