### PR TITLE
Drop deprecated call_data format

### DIFF
--- a/crates/shared/src/http_solver/model.rs
+++ b/crates/shared/src/http_solver/model.rs
@@ -133,8 +133,7 @@ pub struct InteractionData {
     pub target: H160,
     pub value: U256,
     #[derivative(Debug(format_with = "crate::debug_bytes"))]
-    #[serde(deserialize_with = "bytes_hex_or_array::deserialize")]
-    #[serde(serialize_with = "model::bytes_hex::serialize")]
+    #[serde(with = "model::bytes_hex")]
     pub call_data: Vec<u8>,
     /// The input amounts into the AMM interaction - i.e. the amount of tokens
     /// that are expected to be sent from the settlement contract into the AMM
@@ -149,35 +148,6 @@ pub struct InteractionData {
     /// `AMM -> GPv2Settlement`
     pub outputs: Vec<TokenAmount>,
     pub exec_plan: Option<ExecutionPlan>,
-}
-
-/// Module to allow for backwards compatibility with the HTTP solver API.
-///
-/// Specifically, the HTTP solver API used to expect calldata as a JSON array of
-/// integers that fit in a `u8`. This changed to allow `0x-` prefixed hex
-/// strings to be more consistent with how bytes are typically represented in
-/// Ethereum-related APIs. This module implements JSON deserialization that
-/// accepts either format.
-mod bytes_hex_or_array {
-    use serde::{Deserialize, Deserializer};
-
-    #[derive(Deserialize)]
-    #[serde(untagged)]
-    enum HexOrArray {
-        Hex(#[serde(with = "model::bytes_hex")] Vec<u8>),
-        Array(Vec<u8>),
-    }
-
-    pub fn deserialize<'de, D>(deserializer: D) -> Result<Vec<u8>, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        let bytes = match HexOrArray::deserialize(deserializer)? {
-            HexOrArray::Hex(bytes) => bytes,
-            HexOrArray::Array(bytes) => bytes,
-        };
-        Ok(bytes)
-    }
 }
 
 #[serde_as]
@@ -816,33 +786,6 @@ mod tests {
                     }
                 ],
                 exec_plan: Some(ExecutionPlan::Internal),
-            },
-        );
-    }
-
-    #[test]
-    fn decode_interaction_data_backwards_compatibility() {
-        assert_eq!(
-            serde_json::from_str::<InteractionData>(
-                r#"
-                    {
-                        "target": "0xffffffffffffffffffffffffffffffffffffffff",
-                        "value": "0",
-                        "call_data": [1, 2, 3, 4],
-                        "inputs": [],
-                        "outputs": []
-                    }
-                "#,
-            )
-            .unwrap(),
-            InteractionData {
-                target: H160([0xff; 20]),
-                value: 0.into(),
-                // the only backwards compatible thing remaining
-                call_data: vec![1, 2, 3, 4],
-                inputs: Vec::new(),
-                outputs: Vec::new(),
-                exec_plan: None,
             },
         );
     }


### PR DESCRIPTION
Fixes #453

Drops deprecated way to serialize `call_data` (as integer array instead of hex string). This was done in a separate PR to make reverting it easier if this causes issues (because some solvers might still use it) as discussed [here](https://github.com/cowprotocol/services/pull/455#issuecomment-1224146798).

### Test Plan
CI