### PR TITLE
Configure custom node submission handling of high risk transactions

### DIFF
--- a/crates/driver/src/arguments.rs
+++ b/crates/driver/src/arguments.rs
@@ -51,6 +51,12 @@ pub struct Arguments {
     #[clap(long, env, use_value_delimiter = true)]
     pub transaction_submission_nodes: Vec<Url>,
 
+    /// Don't submit high revert risk (i.e. transactions that interact with on-chain
+    /// AMMs) to the public mempool. This can be enabled to avoid MEV when private
+    /// transaction submission strategies are available.
+    #[clap(long, env)]
+    pub disable_high_risk_public_mempool_transactions: bool,
+
     /// Fee scaling factor for objective value. This controls the constant
     /// factor by which order fees are multiplied with. Setting this to a value
     /// greater than 1.0 makes settlements with negative objective values less
@@ -258,6 +264,11 @@ impl std::fmt::Display for Arguments {
         write!(f, "transaction_submission_nodes: ")?;
         display_list(self.transaction_submission_nodes.iter(), f)?;
         writeln!(f)?;
+        writeln!(
+            f,
+            "disable_high_risk_public_mempool_transactions: {}",
+            self.disable_high_risk_public_mempool_transactions,
+        )?;
         writeln!(
             f,
             "fee_objective_scaling_factor: {}",

--- a/crates/driver/src/main.rs
+++ b/crates/driver/src/main.rs
@@ -220,7 +220,7 @@ async fn build_submitter(common: &CommonComponents, args: &Arguments) -> Arc<Sol
         match strategy {
             TransactionStrategyArg::PublicMempool => {
                 transaction_strategies.push(TransactionStrategy::CustomNodes(StrategyArgs {
-                    submit_api: Box::new(CustomNodesApi::new(vec![web3.clone()])),
+                    submit_api: Box::new(CustomNodesApi::new(vec![web3.clone()], false)),
                     max_additional_tip: 0.,
                     additional_tip_percentage_of_max_fee: 0.,
                     sub_tx_pool: submitted_transactions.add_sub_pool(Strategy::CustomNodes),
@@ -259,7 +259,10 @@ async fn build_submitter(common: &CommonComponents, args: &Arguments) -> Arc<Sol
                     "missing transaction submission nodes"
                 );
                 transaction_strategies.push(TransactionStrategy::CustomNodes(StrategyArgs {
-                    submit_api: Box::new(CustomNodesApi::new(submission_nodes.clone())),
+                    submit_api: Box::new(CustomNodesApi::new(
+                        submission_nodes.clone(),
+                        args.disable_high_risk_public_mempool_transactions,
+                    )),
                     max_additional_tip: 0.,
                     additional_tip_percentage_of_max_fee: 0.,
                     sub_tx_pool: submitted_transactions.add_sub_pool(Strategy::CustomNodes),

--- a/crates/e2e/tests/e2e/eth_integration.rs
+++ b/crates/e2e/tests/e2e/eth_integration.rs
@@ -227,7 +227,7 @@ async fn eth_integration(web3: Web3) {
             retry_interval: Duration::from_secs(5),
             transaction_strategies: vec![
                 solver::settlement_submission::TransactionStrategy::CustomNodes(StrategyArgs {
-                    submit_api: Box::new(CustomNodesApi::new(vec![web3.clone()])),
+                    submit_api: Box::new(CustomNodesApi::new(vec![web3.clone()], false)),
                     max_additional_tip: 0.,
                     additional_tip_percentage_of_max_fee: 0.,
                     sub_tx_pool: submitted_transactions.add_sub_pool(Strategy::CustomNodes),

--- a/crates/e2e/tests/e2e/onchain_settlement.rs
+++ b/crates/e2e/tests/e2e/onchain_settlement.rs
@@ -232,7 +232,7 @@ async fn onchain_settlement(web3: Web3) {
             retry_interval: Duration::from_secs(5),
             transaction_strategies: vec![
                 solver::settlement_submission::TransactionStrategy::CustomNodes(StrategyArgs {
-                    submit_api: Box::new(CustomNodesApi::new(vec![web3.clone()])),
+                    submit_api: Box::new(CustomNodesApi::new(vec![web3.clone()], false)),
                     max_additional_tip: 0.,
                     additional_tip_percentage_of_max_fee: 0.,
                     sub_tx_pool: submitted_transactions.add_sub_pool(Strategy::CustomNodes),

--- a/crates/e2e/tests/e2e/settlement_without_onchain_liquidity.rs
+++ b/crates/e2e/tests/e2e/settlement_without_onchain_liquidity.rs
@@ -221,7 +221,7 @@ async fn onchain_settlement_without_liquidity(web3: Web3) {
             retry_interval: Duration::from_secs(5),
             transaction_strategies: vec![
                 solver::settlement_submission::TransactionStrategy::CustomNodes(StrategyArgs {
-                    submit_api: Box::new(CustomNodesApi::new(vec![web3.clone()])),
+                    submit_api: Box::new(CustomNodesApi::new(vec![web3.clone()], false)),
                     max_additional_tip: 0.,
                     additional_tip_percentage_of_max_fee: 0.,
                     sub_tx_pool: submitted_transactions.add_sub_pool(Strategy::CustomNodes),

--- a/crates/e2e/tests/e2e/smart_contract_orders.rs
+++ b/crates/e2e/tests/e2e/smart_contract_orders.rs
@@ -258,7 +258,7 @@ async fn smart_contract_orders(web3: Web3) {
             retry_interval: Duration::from_secs(5),
             transaction_strategies: vec![
                 solver::settlement_submission::TransactionStrategy::CustomNodes(StrategyArgs {
-                    submit_api: Box::new(CustomNodesApi::new(vec![web3.clone()])),
+                    submit_api: Box::new(CustomNodesApi::new(vec![web3.clone()], false)),
                     max_additional_tip: 0.,
                     additional_tip_percentage_of_max_fee: 0.,
                     sub_tx_pool: submitted_transactions.add_sub_pool(Strategy::CustomNodes),

--- a/crates/e2e/tests/e2e/vault_balances.rs
+++ b/crates/e2e/tests/e2e/vault_balances.rs
@@ -171,7 +171,7 @@ async fn vault_balances(web3: Web3) {
             retry_interval: Duration::from_secs(5),
             transaction_strategies: vec![
                 solver::settlement_submission::TransactionStrategy::CustomNodes(StrategyArgs {
-                    submit_api: Box::new(CustomNodesApi::new(vec![web3.clone()])),
+                    submit_api: Box::new(CustomNodesApi::new(vec![web3.clone()], false)),
                     max_additional_tip: 0.,
                     additional_tip_percentage_of_max_fee: 0.,
                     sub_tx_pool: submitted_transactions.add_sub_pool(Strategy::CustomNodes),

--- a/crates/solver/src/arguments.rs
+++ b/crates/solver/src/arguments.rs
@@ -240,6 +240,12 @@ pub struct Arguments {
     #[clap(long, env, use_value_delimiter = true)]
     pub transaction_submission_nodes: Vec<Url>,
 
+    /// Don't submit high revert risk (i.e. transactions that interact with on-chain
+    /// AMMs) to the public mempool. This can be enabled to avoid MEV when private
+    /// transaction submission strategies are available.
+    #[clap(long, env)]
+    pub disable_high_risk_public_mempool_transactions: bool,
+
     /// Fee scaling factor for objective value. This controls the constant
     /// factor by which order fees are multiplied with. Setting this to a value
     /// greater than 1.0 makes settlements with negative objective values less
@@ -352,9 +358,14 @@ impl std::fmt::Display for Arguments {
             "additional_tip_percentage: {}",
             self.additional_tip_percentage
         )?;
-        write!(f, "transaction_submission_nodes: ",)?;
+        write!(f, "transaction_submission_nodes: ")?;
         display_list(self.transaction_submission_nodes.iter(), f)?;
         writeln!(f)?;
+        writeln!(
+            f,
+            "disable_high_risk_public_mempool_transactions: {}",
+            self.disable_high_risk_public_mempool_transactions,
+        )?;
         writeln!(
             f,
             "fee_objective_scaling_factor: {}",

--- a/crates/solver/src/main.rs
+++ b/crates/solver/src/main.rs
@@ -339,7 +339,10 @@ async fn main() {
         match strategy {
             TransactionStrategyArg::PublicMempool => {
                 transaction_strategies.push(TransactionStrategy::CustomNodes(StrategyArgs {
-                    submit_api: Box::new(CustomNodesApi::new(vec![web3.clone()])),
+                    submit_api: Box::new(CustomNodesApi::new(
+                        vec![web3.clone()],
+                        args.disable_high_risk_public_mempool_transactions,
+                    )),
                     max_additional_tip: 0.,
                     additional_tip_percentage_of_max_fee: 0.,
                     sub_tx_pool: submitted_transactions.add_sub_pool(Strategy::CustomNodes),
@@ -378,7 +381,10 @@ async fn main() {
                     "missing transaction submission nodes"
                 );
                 transaction_strategies.push(TransactionStrategy::CustomNodes(StrategyArgs {
-                    submit_api: Box::new(CustomNodesApi::new(submission_nodes.clone())),
+                    submit_api: Box::new(CustomNodesApi::new(
+                        submission_nodes.clone(),
+                        args.disable_high_risk_public_mempool_transactions,
+                    )),
                     max_additional_tip: 0.,
                     additional_tip_percentage_of_max_fee: 0.,
                     sub_tx_pool: submitted_transactions.add_sub_pool(Strategy::CustomNodes),

--- a/crates/solver/src/settlement.rs
+++ b/crates/solver/src/settlement.rs
@@ -256,6 +256,7 @@ pub struct Settlement {
     pub encoder: SettlementEncoder,
 }
 
+#[derive(Debug, Eq, PartialEq)]
 pub enum Revertable {
     NoRisk,
     HighRisk,

--- a/crates/solver/src/settlement_submission/submitter.rs
+++ b/crates/solver/src/settlement_submission/submitter.rs
@@ -54,7 +54,7 @@ pub struct SubmitterParams {
     pub network_id: String,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Eq, PartialEq)]
 pub enum SubmissionLoopStatus {
     Enabled(AdditionalTip),
     Disabled(DisabledReason),
@@ -73,13 +73,13 @@ impl fmt::Display for Strategy {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Eq, PartialEq)]
 pub enum AdditionalTip {
     Off,
     On,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Eq, PartialEq)]
 pub enum DisabledReason {
     MevExtractable,
 }


### PR DESCRIPTION
This PR introduces a new flag `--disable-high-risk-public-mempool-transactions` which controls whether or not "high-risk" transactions (i.e. transactions that interact with AMMs and can revert due to price movement and have MEV extracted from it) should be disabled for public mempool submission strategy.

Previously, we had hard-coded this to be enabled for Mainnet and disabled for other networks. This PR makes it configurable allowing is to:
- If we need to disable all private submission strategies, then we can still continue to function with the public mempool.
- If we eventually enable some additional private network submission for other networks (GChain, Polygon), then we can disable high-risk transactions to the public mempool without additional code changes

This PR is done in anticipation of The Merge™, where it is unclear whether or not Eden and Flashbots will continue to function for the first few epochs - so we need to be able to only submit to the public mempool in case of emergency.

### Test Plan

Run without `--disable-high-risk-public-mempool-transactions`:
```
% cargo run -p solver
...
disable_high_risk_public_mempool_transactions: false
...
```

Run with `--disable-high-risk-public-mempool-transactions`:
```
% cargo run -p solver
...
disable_high_risk_public_mempool_transactions: false
...
```

Also, unit test that verifies filtering logic was added.

### Release notes

- [ ] We need to set `DISABLE_HIGH_RISK_PUBLIC_MEMPOOL_TRANSACTIONS=true` environment variable for Mainnet and 