### PR TITLE
Make flag command line arguments consistent

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,11 +179,11 @@ Run an `orderbook` on `localhost:8080` with:
 
 ```sh
 cargo run --bin orderbook -- \
-  --skip-trace-api true \
+  --skip-trace-api \
   --node-url <YOUR_NODE_URL>
 ```
 
-`--skip-trace-api true` will make the orderbook compatible with more ethereum nodes. If your node supports `trace_callMany` you can drop this argument.
+`--skip-trace-api` will make the orderbook compatible with more ethereum nodes. If your node supports `trace_callMany` you can drop this argument.
 
 Note: Current version of the code does not compile under Windows OS. Context and workaround are [here](https://github.com/cowprotocol/services/issues/226).
 

--- a/crates/autopilot/src/arguments.rs
+++ b/crates/autopilot/src/arguments.rs
@@ -32,7 +32,7 @@ pub struct Arguments {
     pub token_detector_fee_values: FeeValues,
 
     /// Use Blockscout as a TokenOwnerFinding implementation.
-    #[clap(long, env, default_value = "true")]
+    #[clap(long, env)]
     pub enable_blockscout: bool,
 
     /// The amount of time in seconds a classification of a token into good or bad is valid for.
@@ -47,7 +47,7 @@ pub struct Arguments {
     /// Don't use the trace_callMany api that only some nodes support to check whether a token
     /// should be denied.
     /// Note that if a node does not support the api we still use the less accurate call api.
-    #[clap(long, env, parse(try_from_str), default_value = "false")]
+    #[clap(long, env)]
     pub skip_trace_api: bool,
 
     /// The number of pairs that are automatically updated in the pool cache.

--- a/crates/orderbook/src/arguments.rs
+++ b/crates/orderbook/src/arguments.rs
@@ -61,7 +61,7 @@ pub struct Arguments {
     /// Don't use the trace_callMany api that only some nodes support to check whether a token
     /// should be denied.
     /// Note that if a node does not support the api we still use the less accurate call api.
-    #[clap(long, env, parse(try_from_str), default_value = "false")]
+    #[clap(long, env)]
     pub skip_trace_api: bool,
 
     /// The amount of time in seconds a classification of a token into good or bad is valid for.
@@ -91,14 +91,14 @@ pub struct Arguments {
     pub pool_cache_lru_size: usize,
 
     /// Enable EIP-1271 orders.
-    #[clap(long, env, parse(try_from_str), default_value = "false")]
+    #[clap(long, env)]
     pub enable_eip1271_orders: bool,
 
     /// Enable pre-sign orders. Pre-sign orders are accepted into the database without a valid
     /// signature, so this flag allows this feature to be turned off if malicious users are
     /// abusing the database by inserting a bunch of order rows that won't ever be valid.
     /// This flag can be removed once DDoS protection is implemented.
-    #[clap(long, env, parse(try_from_str), default_value = "false")]
+    #[clap(long, env)]
     pub enable_presign_orders: bool,
 
     /// If solvable orders haven't been successfully updated in this many blocks attempting
@@ -232,7 +232,7 @@ pub struct Arguments {
     pub liquidity_order_owners: Vec<H160>,
 
     /// Use Blockscout as a TokenOwnerFinding implementation.
-    #[clap(long, env, default_value = "true")]
+    #[clap(long, env)]
     pub enable_blockscout: bool,
 
     /// The API endpoint for the Balancer SOR API for solving.

--- a/crates/shared/src/arguments.rs
+++ b/crates/shared/src/arguments.rs
@@ -33,10 +33,10 @@ pub struct Arguments {
 
     /// Timeout in seconds for all http requests.
     #[clap(
-            long,
-            default_value = "10",
-            parse(try_from_str = duration_from_seconds),
-        )]
+        long,
+        default_value = "10",
+        parse(try_from_str = duration_from_seconds),
+    )]
     pub http_timeout: Duration,
 
     /// Which gas estimators to use. Multiple estimators are used in sequence if a previous one


### PR DESCRIPTION
As a follow up to #473, this PR makes all our "flag" command line arguments consistent. That is, you now enable flags with `--my-flag` instead of `--my-flag true`.

Previously, we had used `parse(try_from_str), default_value = "false"` to work around Kubernetes configuration templating limitations. However, those limitations are no longer present (well, they never were... we just figured out how to include conditionals in the template). This PR changes all flags to be more "Unix-y" (and IMO natural), where `--some-flag` is used to enable it instead of `--some-flag true`.

Additionally, I removed the `default_value = "true"` attribute from the `--enable-blockscout` flag. This is for two reasons:
- Since this is a flag that doesn't parse an argument value, this effectively means that it cannot be disabled (since neither `--enable-blockscout false`, `--enable-blockscout=false`, nor `ENABLE_BLOCKSCOUT=false` work).
- Second, this notation doesn't play nicely with `clap`. Specifically, it becomes a "half-flag" where the parser requires a value, but ignores it and bases the flag's value solely on whether or not the flag is present. See example 👇.

<details><summary>Example <code>clap</code> application with a flag and `default_value="true"`</summary>

```rust
use clap::Parser;

#[derive(Debug, Parser)]
struct A {
    /// Flag.
    #[clap(long, env, default_value = "true")]
    flag: bool,
}

fn main() {
    println!("{}", A::parse().flag);
}

```

```
% cargo run -- --flag
    Finished dev [unoptimized + debuginfo] target(s) in 0.03s
     Running `target/debug/clap-test --flag`
error: The argument '--flag <flag>' requires a value but none was supplied

For more information try --help

% cargo run -- --flag false
    Finished dev [unoptimized + debuginfo] target(s) in 0.03s
     Running `target/debug/clap-test --flag=false`
true

% cargo run -- --flag=false
    Finished dev [unoptimized + debuginfo] target(s) in 0.03s
     Running `target/debug/clap-test --flag=false`
true

% FLAG=false cargo run
    Finished dev [unoptimized + debuginfo] target(s) in 0.03s
     Running `target/debug/clap-test`
true
```

</details>

### Test Plan

CI - no logic changes, just slightly different CLI parameter semantics.

### Release notes

Refactor our deployment configuration to for the following flags:
- [x] `ENABLE_BLOCKSCOUT`
- [x] `SKIP_TRACE_API`
- [x] `ENABLE_EIP1271_ORDERS` (no changes needed - configuration already supported flags)
- [x] `ENABLE_PRESIGN_ORDERS` (no changes needed - configuration already supported flags)
