### PR TITLE
Use AllowanceManager in ZeroExInteraction

### DIFF
--- a/crates/driver/src/main.rs
+++ b/crates/driver/src/main.rs
@@ -383,12 +383,13 @@ async fn build_auction_converter(
             .unwrap(),
         );
 
-        Some(ZeroExLiquidity {
-            api: zeroex_api,
-            zeroex: contracts::IZeroEx::deployed(&common.web3).await.unwrap(),
-            base_tokens: base_tokens.clone(),
-            gpv2: common.settlement_contract.clone(),
-        })
+        Some(ZeroExLiquidity::new(
+            common.web3.clone(),
+            zeroex_api,
+            contracts::IZeroEx::deployed(&common.web3).await.unwrap(),
+            base_tokens.clone(),
+            common.settlement_contract.clone(),
+        ))
     } else {
         None
     };

--- a/crates/solver/src/liquidity/zeroex.rs
+++ b/crates/solver/src/liquidity/zeroex.rs
@@ -76,7 +76,7 @@ impl ZeroExLiquidity {
         let filtered_zeroex_orders = get_useful_orders(order_buckets, 5);
         let tokens: HashSet<_> = filtered_zeroex_orders
             .iter()
-            .flat_map(|o| [o.order.maker_token, o.order.taker_token])
+            .map(|o| o.order.taker_token)
             .collect();
 
         let allowances = Arc::new(

--- a/crates/solver/src/main.rs
+++ b/crates/solver/src/main.rs
@@ -253,12 +253,13 @@ async fn main() {
     .expect("failure creating solvers");
 
     let zeroex_liquidity = if baseline_sources.contains(&BaselineSource::ZeroEx) {
-        Some(ZeroExLiquidity {
-            api: zeroex_api,
-            zeroex: contracts::IZeroEx::deployed(&web3).await.unwrap(),
-            base_tokens: base_tokens.clone(),
-            gpv2: settlement_contract.clone(),
-        })
+        Some(ZeroExLiquidity::new(
+            web3.clone(),
+            zeroex_api,
+            contracts::IZeroEx::deployed(&web3).await.unwrap(),
+            base_tokens.clone(),
+            settlement_contract.clone(),
+        ))
     } else {
         None
     };


### PR DESCRIPTION
There were quite a few [simulation failures](https://cowservices.slack.com/archives/C0361CDD1FZ/p1661543463263019) for settlements including `ZeroExInteraction`s. This was caused by the `ZeroExInteraction` not automatically appending the appropriate `Approval` interaction when the `ZeroExInteraction` was used and encoded in a settlement.

To fix that I followed how the balancer liquidity and interaction handles this and implemented it accordingly for ZeroEx.

### Test Plan
added unit test verifying the encoded `Approval` and `ZeroExInteraction`
