### PR TITLE
Adding new error messages for existing tx from erigon node

### DIFF
--- a/crates/solver/src/settlement_submission/submitter/custom_nodes_api.rs
+++ b/crates/solver/src/settlement_submission/submitter/custom_nodes_api.rs
@@ -16,6 +16,8 @@ const ALREADY_KNOWN_TRANSACTION: &[&str] = &[
     "nonce too low",                             //infura
     "OldNonce",                                  //erigon
     "INTERNAL_ERROR: nonce too low",             //erigon
+    "INTERNAL_ERROR: existing tx with same hash", //erigon
+    "ALREADY_EXISTS: already known",             //erigon
 ];
 
 #[derive(Clone)]


### PR DESCRIPTION
We got some new error messages from Erigon node for already existing txs. See [here](https://logs.cow.fi/app/discover#/?_g=(filters:!(),refreshInterval:(pause:!t,value:0),time:(from:now-7d%2Fd,to:now))&_a=(columns:!(log),filters:!(),index:'63bc0b10-5f93-11e9-bf17-fbe383fc7c9c',interval:auto,query:(language:kuery,query:'%20log:%20%22custom_nodes_1%22%20and%20log:%20%22error%22'),sort:!(!('@timestamp',desc))))