### PR TITLE
Log simulation error with readable settlement

### DIFF
--- a/crates/solver/src/driver_logger.rs
+++ b/crates/solver/src/driver_logger.rs
@@ -176,9 +176,10 @@ impl DriverLogger {
                     );
                     // split warning into separate logs so that the messages aren't too long.
                     tracing::warn!(
-                        "{} settlement failure for: \n{:#?}",
+                        "{} settlement failure for: \n{:#?}\n{}",
                         solver.name(),
                         settlement,
+                        error_at_earlier_block
                     );
 
                     metrics.settlement_simulation_failed(solver.name());


### PR DESCRIPTION
It happened to me a few times that I wanted to analyze the occurrence of a simulation error in relation to certain properties of the failed settlement. The most recent example is [here](https://cowservices.slack.com/archives/C0361CDD1FZ/p1661587836883249?thread_ts=1661543463.263019&cid=C0361CDD1FZ).

If you only look at a few specific simulation error it's possible to get the human readable settlement. But if you want to do gather some large scale data this approach is too cumbersome and manual.
A simple way to address this issue is to also log the simulation error with the readable and queryable settlement. Theoretically one could also only have 1 log statement for readable settlement, simulation link and simulation error but the code has a comment saying this option would lead to too long logs so I went with the former approach.

### Test Plan
CI
