### PR TITLE
Hopefully fix noisy submission error alert on eden

### DIFF
--- a/crates/driver/src/arguments.rs
+++ b/crates/driver/src/arguments.rs
@@ -9,7 +9,11 @@ use solver::{
     arguments::TransactionStrategyArg, settlement_access_list::AccessListEstimatorType,
     solver::ExternalSolverArg,
 };
-use std::{net::SocketAddr, num::NonZeroU64, time::Duration};
+use std::{
+    net::SocketAddr,
+    num::{NonZeroU64, NonZeroU8},
+    time::Duration,
+};
 use tracing::level_filters::LevelFilter;
 
 #[derive(clap::Parser)]
@@ -143,7 +147,7 @@ pub struct Arguments {
     /// Configures how often the gas price of a transaction may be increased by the minimum amount
     /// compared to the previously failing transaction to eventually bring it on chain.
     #[clap(long, env, default_value = "1")]
-    pub max_gas_price_bumps: u8,
+    pub max_gas_price_bumps: NonZeroU8,
 
     /// The target confirmation time in seconds for settlement transactions used to estimate gas price.
     #[clap(

--- a/crates/driver/src/arguments.rs
+++ b/crates/driver/src/arguments.rs
@@ -140,11 +140,10 @@ pub struct Arguments {
     #[clap(long, env, default_value = "15000000")]
     pub simulation_gas_limit: u128,
 
-    /// It looks like sometimes transaction submission throw errors but the transaction actually
-    /// ends up in the mempool which can cause errors for subsequent submissions. If
-    /// `compensate_for_lost_transactions` is enabled the submission logic tries its best to work around that issue.
-    #[clap(long, env)]
-    pub compensate_for_lost_transactions: bool,
+    /// Configures how often the gas price of a transaction may be increased by the minimum amount
+    /// compared to the previsouly failing transaction to eventually bring it on chain.
+    #[clap(long, env, default_value = "1")]
+    pub max_gas_price_bumps: u8,
 
     /// The target confirmation time in seconds for settlement transactions used to estimate gas price.
     #[clap(
@@ -323,11 +322,7 @@ impl std::fmt::Display for Arguments {
                 .unwrap_or("None")
         )?;
         writeln!(f, "simulation_gas_limit: {}", self.simulation_gas_limit)?;
-        writeln!(
-            f,
-            "compensate_for_lost_transactions: {}",
-            self.compensate_for_lost_transactions
-        )?;
+        writeln!(f, "max_gas_price_bumps: {}", self.max_gas_price_bumps)?;
         writeln!(f, "target_confirm_time: {:?}", self.target_confirm_time)?;
         writeln!(
             f,

--- a/crates/driver/src/arguments.rs
+++ b/crates/driver/src/arguments.rs
@@ -141,7 +141,7 @@ pub struct Arguments {
     pub simulation_gas_limit: u128,
 
     /// Configures how often the gas price of a transaction may be increased by the minimum amount
-    /// compared to the previsouly failing transaction to eventually bring it on chain.
+    /// compared to the previously failing transaction to eventually bring it on chain.
     #[clap(long, env, default_value = "1")]
     pub max_gas_price_bumps: u8,
 

--- a/crates/driver/src/arguments.rs
+++ b/crates/driver/src/arguments.rs
@@ -140,6 +140,12 @@ pub struct Arguments {
     #[clap(long, env, default_value = "15000000")]
     pub simulation_gas_limit: u128,
 
+    /// It looks like sometimes transaction submission throw errors but the transaction actually
+    /// ends up in the mempool which can cause errors for subsequent submissions. If
+    /// `compensate_for_lost_transactions` is enabled the submission logic tries its best to work around that issue.
+    #[clap(long, env)]
+    pub compensate_for_lost_transactions: bool,
+
     /// The target confirmation time in seconds for settlement transactions used to estimate gas price.
     #[clap(
         long,
@@ -317,6 +323,11 @@ impl std::fmt::Display for Arguments {
                 .unwrap_or("None")
         )?;
         writeln!(f, "simulation_gas_limit: {}", self.simulation_gas_limit)?;
+        writeln!(
+            f,
+            "compensate_for_lost_transactions: {}",
+            self.compensate_for_lost_transactions
+        )?;
         writeln!(f, "target_confirm_time: {:?}", self.target_confirm_time)?;
         writeln!(
             f,

--- a/crates/driver/src/main.rs
+++ b/crates/driver/src/main.rs
@@ -291,6 +291,7 @@ async fn build_submitter(common: &CommonComponents, args: &Arguments) -> Arc<Sol
         gas_price_cap: args.gas_price_cap,
         transaction_strategies,
         access_list_estimator: common.access_list_estimator.clone(),
+        compensate_for_lost_transactions: args.compensate_for_lost_transactions,
     })
 }
 

--- a/crates/driver/src/main.rs
+++ b/crates/driver/src/main.rs
@@ -291,7 +291,7 @@ async fn build_submitter(common: &CommonComponents, args: &Arguments) -> Arc<Sol
         gas_price_cap: args.gas_price_cap,
         transaction_strategies,
         access_list_estimator: common.access_list_estimator.clone(),
-        compensate_for_lost_transactions: args.compensate_for_lost_transactions,
+        max_gas_price_bumps: args.max_gas_price_bumps,
     })
 }
 

--- a/crates/e2e/tests/e2e/eth_integration.rs
+++ b/crates/e2e/tests/e2e/eth_integration.rs
@@ -245,6 +245,7 @@ async fn eth_integration(web3: Web3) {
                 .await
                 .unwrap(),
             ),
+            compensate_for_lost_transactions: false,
         },
         create_orderbook_api(),
         create_order_converter(&web3, contracts.weth.address()),

--- a/crates/e2e/tests/e2e/eth_integration.rs
+++ b/crates/e2e/tests/e2e/eth_integration.rs
@@ -245,7 +245,7 @@ async fn eth_integration(web3: Web3) {
                 .await
                 .unwrap(),
             ),
-            compensate_for_lost_transactions: false,
+            max_gas_price_bumps: 1,
         },
         create_orderbook_api(),
         create_order_converter(&web3, contracts.weth.address()),

--- a/crates/e2e/tests/e2e/eth_integration.rs
+++ b/crates/e2e/tests/e2e/eth_integration.rs
@@ -23,7 +23,7 @@ use solver::{
         GlobalTxPool, SolutionSubmitter, StrategyArgs,
     },
 };
-use std::{sync::Arc, time::Duration};
+use std::{num::NonZeroU8, sync::Arc, time::Duration};
 use web3::signing::SecretKeyRef;
 
 const TRADER_BUY_ETH_A_PK: [u8; 32] = [1; 32];
@@ -245,7 +245,7 @@ async fn eth_integration(web3: Web3) {
                 .await
                 .unwrap(),
             ),
-            max_gas_price_bumps: 1,
+            max_gas_price_bumps: NonZeroU8::new(1).unwrap(),
         },
         create_orderbook_api(),
         create_order_converter(&web3, contracts.weth.address()),

--- a/crates/e2e/tests/e2e/onchain_settlement.rs
+++ b/crates/e2e/tests/e2e/onchain_settlement.rs
@@ -250,7 +250,7 @@ async fn onchain_settlement(web3: Web3) {
                 .await
                 .unwrap(),
             ),
-            compensate_for_lost_transactions: false,
+            max_gas_price_bumps: 1,
         },
         create_orderbook_api(),
         create_order_converter(&web3, contracts.weth.address()),

--- a/crates/e2e/tests/e2e/onchain_settlement.rs
+++ b/crates/e2e/tests/e2e/onchain_settlement.rs
@@ -25,7 +25,7 @@ use solver::{
         GlobalTxPool, SolutionSubmitter, StrategyArgs,
     },
 };
-use std::{sync::Arc, time::Duration};
+use std::{num::NonZeroU8, sync::Arc, time::Duration};
 use web3::signing::SecretKeyRef;
 
 const TRADER_A_PK: [u8; 32] =
@@ -250,7 +250,7 @@ async fn onchain_settlement(web3: Web3) {
                 .await
                 .unwrap(),
             ),
-            max_gas_price_bumps: 1,
+            max_gas_price_bumps: NonZeroU8::new(1).unwrap(),
         },
         create_orderbook_api(),
         create_order_converter(&web3, contracts.weth.address()),

--- a/crates/e2e/tests/e2e/onchain_settlement.rs
+++ b/crates/e2e/tests/e2e/onchain_settlement.rs
@@ -250,6 +250,7 @@ async fn onchain_settlement(web3: Web3) {
                 .await
                 .unwrap(),
             ),
+            compensate_for_lost_transactions: false,
         },
         create_orderbook_api(),
         create_order_converter(&web3, contracts.weth.address()),

--- a/crates/e2e/tests/e2e/settlement_without_onchain_liquidity.rs
+++ b/crates/e2e/tests/e2e/settlement_without_onchain_liquidity.rs
@@ -239,6 +239,7 @@ async fn onchain_settlement_without_liquidity(web3: Web3) {
                 .await
                 .unwrap(),
             ),
+            compensate_for_lost_transactions: false,
         },
         create_orderbook_api(),
         create_order_converter(&web3, contracts.weth.address()),

--- a/crates/e2e/tests/e2e/settlement_without_onchain_liquidity.rs
+++ b/crates/e2e/tests/e2e/settlement_without_onchain_liquidity.rs
@@ -239,7 +239,7 @@ async fn onchain_settlement_without_liquidity(web3: Web3) {
                 .await
                 .unwrap(),
             ),
-            compensate_for_lost_transactions: false,
+            max_gas_price_bumps: 1,
         },
         create_orderbook_api(),
         create_order_converter(&web3, contracts.weth.address()),

--- a/crates/e2e/tests/e2e/settlement_without_onchain_liquidity.rs
+++ b/crates/e2e/tests/e2e/settlement_without_onchain_liquidity.rs
@@ -26,7 +26,7 @@ use solver::{
         GlobalTxPool, SolutionSubmitter, StrategyArgs,
     },
 };
-use std::{sync::Arc, time::Duration};
+use std::{num::NonZeroU8, sync::Arc, time::Duration};
 use web3::signing::SecretKeyRef;
 
 const TRADER_A_PK: [u8; 32] =
@@ -239,7 +239,7 @@ async fn onchain_settlement_without_liquidity(web3: Web3) {
                 .await
                 .unwrap(),
             ),
-            max_gas_price_bumps: 1,
+            max_gas_price_bumps: NonZeroU8::new(1).unwrap(),
         },
         create_orderbook_api(),
         create_order_converter(&web3, contracts.weth.address()),

--- a/crates/e2e/tests/e2e/smart_contract_orders.rs
+++ b/crates/e2e/tests/e2e/smart_contract_orders.rs
@@ -276,7 +276,7 @@ async fn smart_contract_orders(web3: Web3) {
                 .await
                 .unwrap(),
             ),
-            compensate_for_lost_transactions: false,
+            max_gas_price_bumps: 1,
         },
         create_orderbook_api(),
         create_order_converter(&web3, contracts.weth.address()),

--- a/crates/e2e/tests/e2e/smart_contract_orders.rs
+++ b/crates/e2e/tests/e2e/smart_contract_orders.rs
@@ -23,7 +23,7 @@ use solver::{
         GlobalTxPool, SolutionSubmitter, StrategyArgs,
     },
 };
-use std::{sync::Arc, time::Duration};
+use std::{num::NonZeroU8, sync::Arc, time::Duration};
 use web3::signing::SecretKeyRef;
 
 const TRADER: [u8; 32] = [1; 32];
@@ -276,7 +276,7 @@ async fn smart_contract_orders(web3: Web3) {
                 .await
                 .unwrap(),
             ),
-            max_gas_price_bumps: 1,
+            max_gas_price_bumps: NonZeroU8::new(1).unwrap(),
         },
         create_orderbook_api(),
         create_order_converter(&web3, contracts.weth.address()),

--- a/crates/e2e/tests/e2e/smart_contract_orders.rs
+++ b/crates/e2e/tests/e2e/smart_contract_orders.rs
@@ -276,6 +276,7 @@ async fn smart_contract_orders(web3: Web3) {
                 .await
                 .unwrap(),
             ),
+            compensate_for_lost_transactions: false,
         },
         create_orderbook_api(),
         create_order_converter(&web3, contracts.weth.address()),

--- a/crates/e2e/tests/e2e/vault_balances.rs
+++ b/crates/e2e/tests/e2e/vault_balances.rs
@@ -189,7 +189,7 @@ async fn vault_balances(web3: Web3) {
                 .await
                 .unwrap(),
             ),
-            compensate_for_lost_transactions: false,
+            max_gas_price_bumps: 1,
         },
         create_orderbook_api(),
         create_order_converter(&web3, contracts.weth.address()),

--- a/crates/e2e/tests/e2e/vault_balances.rs
+++ b/crates/e2e/tests/e2e/vault_balances.rs
@@ -20,7 +20,7 @@ use solver::{
         GlobalTxPool, SolutionSubmitter, StrategyArgs,
     },
 };
-use std::{sync::Arc, time::Duration};
+use std::{num::NonZeroU8, sync::Arc, time::Duration};
 use web3::signing::SecretKeyRef;
 
 const TRADER: [u8; 32] = [1; 32];
@@ -189,7 +189,7 @@ async fn vault_balances(web3: Web3) {
                 .await
                 .unwrap(),
             ),
-            max_gas_price_bumps: 1,
+            max_gas_price_bumps: NonZeroU8::new(1).unwrap(),
         },
         create_orderbook_api(),
         create_order_converter(&web3, contracts.weth.address()),

--- a/crates/e2e/tests/e2e/vault_balances.rs
+++ b/crates/e2e/tests/e2e/vault_balances.rs
@@ -189,6 +189,7 @@ async fn vault_balances(web3: Web3) {
                 .await
                 .unwrap(),
             ),
+            compensate_for_lost_transactions: false,
         },
         create_orderbook_api(),
         create_order_converter(&web3, contracts.weth.address()),

--- a/crates/shared/src/arguments.rs
+++ b/crates/shared/src/arguments.rs
@@ -20,7 +20,7 @@ pub struct Arguments {
     #[clap(
         long,
         env,
-        default_value = "warn,autopilot=debug,driver=debug,orderbook=debug,solver=debug,shared=debug,shared::transport::http=info,gas_estimation=debug"
+        default_value = "warn,autopilot=debug,driver=debug,orderbook=debug,solver=debug,shared=debug,shared::transport::http=info"
     )]
     pub log_filter: String,
 

--- a/crates/shared/src/arguments.rs
+++ b/crates/shared/src/arguments.rs
@@ -20,7 +20,7 @@ pub struct Arguments {
     #[clap(
         long,
         env,
-        default_value = "warn,autopilot=debug,driver=debug,orderbook=debug,solver=debug,shared=debug,shared::transport::http=info"
+        default_value = "warn,autopilot=debug,driver=debug,orderbook=debug,solver=debug,shared=debug,shared::transport::http=info,gas_estimation=debug"
     )]
     pub log_filter: String,
 

--- a/crates/solver/src/arguments.rs
+++ b/crates/solver/src/arguments.rs
@@ -271,11 +271,10 @@ pub struct Arguments {
     #[clap(long, env, default_value = "15000000")]
     pub simulation_gas_limit: u128,
 
-    /// It looks like sometimes transaction submission throw errors but the transaction actually
-    /// ends up in the mempool which can cause errors for subsequent submissions. If
-    /// `compensate_for_lost_transactions` is enabled the submission logic tries its best to work around that issue.
-    #[clap(long, env)]
-    pub compensate_for_lost_transactions: bool,
+    /// Configures how often the gas price of a transaction may be increased by the minimum amount
+    /// compared to the previsouly failing transaction to eventually bring it on chain.
+    #[clap(long, env, default_value = "1")]
+    pub max_gas_price_bumps: u8,
 
     /// In order to protect against malicious solvers, the driver will check that settlements prices do not
     /// exceed a max price deviation compared to the external prices of the driver, if this optional value is set.
@@ -384,11 +383,7 @@ impl std::fmt::Display for Arguments {
         )?;
         writeln!(f, "weth_unwrap_factor: {}", self.weth_unwrap_factor)?;
         writeln!(f, "simulation_gas_limit: {}", self.simulation_gas_limit)?;
-        writeln!(
-            f,
-            "compensate_for_lost_transactions: {}",
-            self.compensate_for_lost_transactions
-        )?;
+        writeln!(f, "max_gas_price_bumps: {}", self.max_gas_price_bumps)?;
         write!(f, "max_settlement_price_deviation: ")?;
         display_option(&self.max_settlement_price_deviation, f)?;
         writeln!(f)?;

--- a/crates/solver/src/arguments.rs
+++ b/crates/solver/src/arguments.rs
@@ -271,6 +271,12 @@ pub struct Arguments {
     #[clap(long, env, default_value = "15000000")]
     pub simulation_gas_limit: u128,
 
+    /// It looks like sometimes transaction submission throw errors but the transaction actually
+    /// ends up in the mempool which can cause errors for subsequent submissions. If
+    /// `compensate_for_lost_transactions` is enabled the submission logic tries its best to work around that issue.
+    #[clap(long, env)]
+    pub compensate_for_lost_transactions: bool,
+
     /// In order to protect against malicious solvers, the driver will check that settlements prices do not
     /// exceed a max price deviation compared to the external prices of the driver, if this optional value is set.
     /// The max deviation value should be provided as a float percentage value. E.g. for a max price deviation
@@ -378,6 +384,11 @@ impl std::fmt::Display for Arguments {
         )?;
         writeln!(f, "weth_unwrap_factor: {}", self.weth_unwrap_factor)?;
         writeln!(f, "simulation_gas_limit: {}", self.simulation_gas_limit)?;
+        writeln!(
+            f,
+            "compensate_for_lost_transactions: {}",
+            self.compensate_for_lost_transactions
+        )?;
         write!(f, "max_settlement_price_deviation: ")?;
         display_option(&self.max_settlement_price_deviation, f)?;
         writeln!(f)?;

--- a/crates/solver/src/arguments.rs
+++ b/crates/solver/src/arguments.rs
@@ -272,7 +272,7 @@ pub struct Arguments {
     pub simulation_gas_limit: u128,
 
     /// Configures how often the gas price of a transaction may be increased by the minimum amount
-    /// compared to the previsouly failing transaction to eventually bring it on chain.
+    /// compared to the previously failing transaction to eventually bring it on chain.
     #[clap(long, env, default_value = "1")]
     pub max_gas_price_bumps: u8,
 

--- a/crates/solver/src/arguments.rs
+++ b/crates/solver/src/arguments.rs
@@ -5,7 +5,7 @@ use crate::{
 use primitive_types::H160;
 use reqwest::Url;
 use shared::arguments::{display_list, display_option, display_secret_option};
-use std::time::Duration;
+use std::{num::NonZeroU8, time::Duration};
 
 #[derive(clap::Parser)]
 pub struct Arguments {
@@ -274,7 +274,7 @@ pub struct Arguments {
     /// Configures how often the gas price of a transaction may be increased by the minimum amount
     /// compared to the previously failing transaction to eventually bring it on chain.
     #[clap(long, env, default_value = "1")]
-    pub max_gas_price_bumps: u8,
+    pub max_gas_price_bumps: NonZeroU8,
 
     /// In order to protect against malicious solvers, the driver will check that settlements prices do not
     /// exceed a max price deviation compared to the external prices of the driver, if this optional value is set.

--- a/crates/solver/src/main.rs
+++ b/crates/solver/src/main.rs
@@ -418,6 +418,7 @@ async fn main() {
         gas_price_cap: args.gas_price_cap,
         transaction_strategies,
         access_list_estimator,
+        compensate_for_lost_transactions: args.compensate_for_lost_transactions,
     };
     let api = OrderBookApi::new(
         args.orderbook_url,

--- a/crates/solver/src/main.rs
+++ b/crates/solver/src/main.rs
@@ -418,7 +418,7 @@ async fn main() {
         gas_price_cap: args.gas_price_cap,
         transaction_strategies,
         access_list_estimator,
-        compensate_for_lost_transactions: args.compensate_for_lost_transactions,
+        max_gas_price_bumps: args.max_gas_price_bumps,
     };
     let api = OrderBookApi::new(
         args.orderbook_url,

--- a/crates/solver/src/settlement_submission.rs
+++ b/crates/solver/src/settlement_submission.rs
@@ -17,6 +17,7 @@ use primitive_types::{H256, U256};
 use shared::Web3;
 use std::{
     collections::HashMap,
+    num::NonZeroU8,
     sync::{Arc, Mutex},
     time::{Duration, Instant},
 };
@@ -106,7 +107,7 @@ pub struct SolutionSubmitter {
     pub retry_interval: Duration,
     pub gas_price_cap: f64,
     pub transaction_strategies: Vec<TransactionStrategy>,
-    pub max_gas_price_bumps: u8,
+    pub max_gas_price_bumps: NonZeroU8,
 }
 
 pub struct StrategyArgs {

--- a/crates/solver/src/settlement_submission.rs
+++ b/crates/solver/src/settlement_submission.rs
@@ -106,6 +106,7 @@ pub struct SolutionSubmitter {
     pub retry_interval: Duration,
     pub gas_price_cap: f64,
     pub transaction_strategies: Vec<TransactionStrategy>,
+    pub compensate_for_lost_transactions: bool,
 }
 
 pub struct StrategyArgs {
@@ -197,6 +198,7 @@ impl SolutionSubmitter {
                             &gas_price_estimator,
                             self.access_list_estimator.as_ref(),
                             strategy_args.sub_tx_pool.clone(),
+                            self.compensate_for_lost_transactions
                         )?;
                         submitter.submit(settlement.clone(), params).await
                     }

--- a/crates/solver/src/settlement_submission.rs
+++ b/crates/solver/src/settlement_submission.rs
@@ -106,7 +106,7 @@ pub struct SolutionSubmitter {
     pub retry_interval: Duration,
     pub gas_price_cap: f64,
     pub transaction_strategies: Vec<TransactionStrategy>,
-    pub compensate_for_lost_transactions: bool,
+    pub max_gas_price_bumps: u8,
 }
 
 pub struct StrategyArgs {
@@ -198,7 +198,7 @@ impl SolutionSubmitter {
                             &gas_price_estimator,
                             self.access_list_estimator.as_ref(),
                             strategy_args.sub_tx_pool.clone(),
-                            self.compensate_for_lost_transactions
+                            self.max_gas_price_bumps
                         )?;
                         submitter.submit(settlement.clone(), params).await
                     }

--- a/crates/solver/src/settlement_submission/submitter.rs
+++ b/crates/solver/src/settlement_submission/submitter.rs
@@ -478,7 +478,7 @@ impl<'a> Submitter<'a> {
                 // Sometimes a tx gets successfully submitted but the API returns an error. When that
                 // happens the gas price computation will return a gas price which is not big enough to
                 // replace the supposedly not submitted tx. To get out of that issue the new gas price
-                // has to be bumped by `GAS_PRICE_BUMP * 2` in order to replace the stuck tx.
+                // has to be bumped by at least `GAS_PRICE_BUMP ^ 2` in order to replace the stuck tx.
                 let previous_gas_price = previous_gas_price
                     .bump(GAS_PRICE_BUMP.powi(allowed_gas_price_bumps))
                     .ceil();

--- a/crates/solver/src/settlement_submission/submitter.rs
+++ b/crates/solver/src/settlement_submission/submitter.rs
@@ -32,6 +32,7 @@ use primitive_types::{H256, U256};
 use shared::{Web3, Web3Transport};
 use std::{
     fmt,
+    num::NonZeroU8,
     time::{Duration, Instant},
 };
 use web3::types::{AccessList, TransactionReceipt, U64};
@@ -192,7 +193,7 @@ pub struct Submitter<'a> {
     gas_price_estimator: &'a SubmitterGasPriceEstimator<'a>,
     access_list_estimator: &'a dyn AccessListEstimating,
     submitted_transactions: SubTxPoolRef,
-    max_gas_price_bumps: u8,
+    max_gas_price_bumps: NonZeroU8,
 }
 
 impl<'a> Submitter<'a> {
@@ -203,7 +204,7 @@ impl<'a> Submitter<'a> {
         gas_price_estimator: &'a SubmitterGasPriceEstimator<'a>,
         access_list_estimator: &'a dyn AccessListEstimating,
         submitted_transactions: SubTxPoolRef,
-        max_gas_price_bumps: u8,
+        max_gas_price_bumps: NonZeroU8,
     ) -> Result<Self> {
         Ok(Self {
             contract,
@@ -523,7 +524,7 @@ impl<'a> Submitter<'a> {
                     if err.contains("underpriced") || err.contains("already known") {
                         allowed_gas_price_bumps = std::cmp::min(
                             allowed_gas_price_bumps + 1,
-                            self.max_gas_price_bumps as i32,
+                            self.max_gas_price_bumps.get() as i32,
                         );
                         tracing::debug!(allowed_gas_price_bumps, "bump gas price exponent");
                     } else {
@@ -757,7 +758,7 @@ mod tests {
             &gas_price_estimator,
             access_list_estimator.as_ref(),
             submitted_transactions,
-            1,
+            NonZeroU8::new(1).unwrap(),
         )
         .unwrap();
 

--- a/crates/solver/src/settlement_submission/submitter.rs
+++ b/crates/solver/src/settlement_submission/submitter.rs
@@ -521,7 +521,7 @@ impl<'a> Submitter<'a> {
                     );
                     let err = err.to_string();
                     if err.contains("underpriced") || err.contains("already known") {
-                        allowed_gas_price_bumps = std::cmp::max(
+                        allowed_gas_price_bumps = std::cmp::min(
                             allowed_gas_price_bumps + 1,
                             self.max_gas_price_bumps as i32,
                         );

--- a/crates/solver/src/settlement_submission/submitter.rs
+++ b/crates/solver/src/settlement_submission/submitter.rs
@@ -478,6 +478,11 @@ impl<'a> Submitter<'a> {
                 let previous_gas_price = previous_gas_price
                     .bump(GAS_PRICE_BUMP.powi(tx_consecutively_underpriced))
                     .ceil();
+                tracing::debug!(
+                    ?previous_gas_price,
+                    tx_consecutively_underpriced,
+                    "minimum gas price"
+                );
                 if gas_price.max_priority_fee_per_gas < previous_gas_price.max_priority_fee_per_gas
                     || gas_price.max_fee_per_gas < previous_gas_price.max_fee_per_gas
                 {
@@ -511,8 +516,10 @@ impl<'a> Submitter<'a> {
                         submitter = %submitter_name, ?err,
                         "submission failed",
                     );
-                    if err.to_string().contains("underpriced") {
+                    let err = err.to_string();
+                    if err.contains("underpriced") || err.contains("already known") {
                         tx_consecutively_underpriced += 1;
+                        tracing::debug!(tx_consecutively_underpriced, "bump gas price exponent");
                     } else {
                         tx_consecutively_underpriced = 1;
                     }

--- a/crates/solver/src/settlement_submission/submitter.rs
+++ b/crates/solver/src/settlement_submission/submitter.rs
@@ -381,7 +381,7 @@ impl<'a> Submitter<'a> {
         let submitter_name = self.submit_api.name();
         let target_confirm_time = Instant::now() + params.target_confirm_time;
 
-        let mut tx_underpriced = false;
+        let mut tx_consecutively_underpriced = 1.;
 
         tracing::debug!(
             "submit_with_increasing_gas_prices_until_simulation_fails entered with submitter: {}",
@@ -455,7 +455,9 @@ impl<'a> Submitter<'a> {
 
             if let Err(err) = method.clone().view().call().await {
                 if let Some((_, previous_gas_price)) = transactions.last() {
-                    let gas_price = previous_gas_price.bump(GAS_PRICE_BUMP).ceil();
+                    let gas_price = previous_gas_price
+                        .bump(GAS_PRICE_BUMP * tx_consecutively_underpriced)
+                        .ceil();
                     match self.cancel_transaction(&gas_price, nonce).await {
                         Ok(handle) => transactions.push((handle, gas_price)),
                         Err(err) => tracing::warn!("cancellation failed: {:?}", err),
@@ -473,9 +475,9 @@ impl<'a> Submitter<'a> {
                 // happens the gas price computation will return a gas price which is not big enough to
                 // replace the supposedly not submitted tx. To get out of that issue the new gas price
                 // has to be bumped by `GAS_PRICE_BUMP * 2` in order to replace the stuck tx.
-                let bump_factor = if tx_underpriced { 2. } else { 1. };
-                let previous_gas_price =
-                    previous_gas_price.bump(GAS_PRICE_BUMP * bump_factor).ceil();
+                let previous_gas_price = previous_gas_price
+                    .bump(GAS_PRICE_BUMP * tx_consecutively_underpriced)
+                    .ceil();
                 if gas_price.max_priority_fee_per_gas < previous_gas_price.max_priority_fee_per_gas
                     || gas_price.max_fee_per_gas < previous_gas_price.max_fee_per_gas
                 {
@@ -502,13 +504,18 @@ impl<'a> Submitter<'a> {
                         "submitted transaction",
                     );
                     transactions.push((handle, gas_price));
+                    tx_consecutively_underpriced = 1.;
                 }
                 Err(err) => {
                     tracing::warn!(
                         submitter = %submitter_name, ?err,
                         "submission failed",
                     );
-                    tx_underpriced = err.to_string().contains("underpriced");
+                    if err.to_string().contains("underpriced") {
+                        tx_consecutively_underpriced += 1.;
+                    } else {
+                        tx_consecutively_underpriced = 1.;
+                    }
                 }
             }
             tokio::time::sleep(params.retry_interval).await;


### PR DESCRIPTION
Currently eden's submission error alert is one of our noisiest. Also it's not really actionable so let's try to fix it.

My current working hypothesis is that eden sometimes submits a transaction into the mempool but reports an error anyway. This would lead our submission logic to think the gas price which would require a replacement tx would be the price of `tx_1 * 1.25 (MIN_GAS_BUMP)`. But since the mempool already knows about `tx_2` which must have at least a gas price of `tx_1 * 1.25` the actual replacement tx would have to have a gas price of at least `tx_2 * (1.25^2)`.

This hypothesis came from logs like [this](https://production-6de61f.kb.eu-central-1.aws.cloud.es.io/app/discover#/?_g=(filters:!(),refreshInterval:(pause:!t,value:0),time:(from:'2022-08-29T13:54:25.446Z',to:'2022-08-29T14:02:40.431Z'))&_a=(columns:!(log),filters:!(),grid:(columns:('@timestamp':(width:164))),index:'6eecf430-220f-11ed-bbdc-2f476b18353d',interval:auto,query:(language:kuery,query:'log:%20%22eden%22%20and%20(log:%20%22replacement%20transaction%20underpriced%22%20or%20log:%20%22creating%20transaction%20with%20gas%20price%22%20or%20log:%20%22nonce%20too%20low%22%20or%20log:%20%22status%20code%20is%20not%20success%22)'),sort:!(!('@timestamp',desc)))) where at some point eden returned some generic `internal server error` and afterwards reports many `replacement transaction underpriced` errors in a row.

As a side note this change could also lead to faster submission times when a solver run loop encounters that issue.

I don't really know how to test this idea without deploying it so please let me know if it seems reasonable to you.
We could also enable the gas price factor bumping with a CLI switch to test the fix temporarily without redeploying the solver.

### Test Plan
CI