### PR TITLE
Log when orders are filtered because of missing allowance/balance

### DIFF
--- a/crates/autopilot/src/solvable_orders.rs
+++ b/crates/autopilot/src/solvable_orders.rs
@@ -312,6 +312,11 @@ fn solvable_orders(mut orders: Vec<Order>, balances: &Balances) -> Vec<Order> {
             if let Some(balance) = remaining_balance.checked_sub(needed_balance) {
                 remaining_balance = balance;
                 result.push(order);
+            } else {
+                tracing::debug!(
+                    "Filtering order {} because of insufficient allowance/balance",
+                    order.metadata.uid
+                );
             }
         }
     }


### PR DESCRIPTION
This should make it much simpler to debug issues teams are having with not getting their order matched.

### Test Plan

Run orderbook, autopilot and UI locally. Place order, afterwards move funds and observe:

> Filtering order 0xd4e66c93d079b48b4e947b2636063aeb121f8ae137e13b17d2200c1ae704f3002caef7f0ee82fb0abf1ab0dcd3a093803002e705630d6188 because of insufficient allowance/balance