### PR TITLE
Reword log for filtered invalid EIP-1271 orders

### DIFF
--- a/crates/autopilot/src/solvable_orders.rs
+++ b/crates/autopilot/src/solvable_orders.rs
@@ -239,7 +239,7 @@ async fn filter_invalid_signature_orders(
                 if let Err(err) = validations.next().unwrap() {
                     tracing::warn!(
                         order_uid =% order.metadata.uid, ?err,
-                        "filtering EIP-1271 order as signature became invalid"
+                        "filtered order because of invalid EIP-1271 signature"
                     );
                     return false;
                 }


### PR DESCRIPTION
This just rewords the message that gets logged when EIP-1271 signatures for orders become invalid.

The main motivation here is to make all "order filtering" messages follow a similar pattern for better grep-ability in the logs.

### Test Plan

CI
