### PR TITLE
Use eth_sendSlotTxs in eden submission

### DIFF
--- a/crates/solver/src/settlement_submission/submitter/eden_api.rs
+++ b/crates/solver/src/settlement_submission/submitter/eden_api.rs
@@ -17,6 +17,7 @@ use ethcontract::{
     H160, H256, U256,
 };
 use futures::{FutureExt, TryFutureExt};
+use jsonrpc_core::types::Value;
 use reqwest::{Client, IntoUrl, Url};
 use serde::Deserialize;
 use shared::{transport::http::HttpTransport, Web3, Web3Transport};
@@ -82,7 +83,8 @@ impl EdenApi {
         };
         let params =
             serde_json::to_value(Bytes(raw_signed_transaction)).context("failed to serialize")?;
-        let request = helpers::build_request(1, "eth_sendSlotTx", vec![params]);
+        let request =
+            helpers::build_request(1, "eth_sendSlotTxs", vec![Value::Array(vec![params])]);
         tracing::debug!(?request, "sending Eden API request");
 
         let response = self


### PR DESCRIPTION
The eden submitter tries 2 ways of submitting a transaction. In case we currently hold a prioritized slot in the block due to staking eden we start with `eth_sendSlotTx` and if that fails because we currently don't hold the slot we try the normal `eth_sendRawTransaction`.

The problem is that `eth_sendSlotTx` has apparently been removed which leads to [these](https://production-6de61f.kb.eu-central-1.aws.cloud.es.io/app/discover#/doc/6eecf430-220f-11ed-bbdc-2f476b18353d/logstash-prod-2022.08.30?id=eZhQ7YIBNGla5u5d5v43) errors. However, the error suggests that the method `eth_sendSlotTxs` exists so let's just use that one instead.

### Test Plan
CI + deploy and check errors
