### PR TITLE
Implement steps (2) and (3) for EventHandler

### DIFF
--- a/crates/autopilot/src/database/events.rs
+++ b/crates/autopilot/src/database/events.rs
@@ -78,7 +78,7 @@ impl EventStoring<ContractEvent> for Postgres {
     async fn replace_events(
         &mut self,
         events: Vec<EthContractEvent<ContractEvent>>,
-        range: std::ops::RangeInclusive<shared::event_handling::BlockNumber>,
+        range: std::ops::RangeInclusive<u64>,
     ) -> Result<()> {
         let _timer = super::Metrics::get()
             .database_queries
@@ -87,7 +87,7 @@ impl EventStoring<ContractEvent> for Postgres {
 
         let events = contract_to_db_events(events)?;
         let mut transaction = self.0.begin().await?;
-        database::events::delete(&mut transaction, range.start().to_u64() as i64)
+        database::events::delete(&mut transaction, *range.start() as i64)
             .await
             .context("delete_events failed")?;
         database::events::append(&mut transaction, events.as_slice())

--- a/crates/autopilot/src/database/events.rs
+++ b/crates/autopilot/src/database/events.rs
@@ -41,7 +41,7 @@ pub fn contract_to_db_events(
 
 #[async_trait::async_trait]
 impl EventStoring<ContractEvent> for Postgres {
-    async fn last_event_blocks(&self) -> Result<Vec<BlockNumberHash>> {
+    async fn last_event_block(&self) -> Result<BlockNumberHash> {
         let _timer = super::Metrics::get()
             .database_queries
             .with_label_values(&["last_event_block"])
@@ -52,12 +52,12 @@ impl EventStoring<ContractEvent> for Postgres {
             .await
             .context("block_number_of_most_recent_event failed")?;
 
-        Ok(vec![(
+        Ok((
             block_number
                 .try_into()
                 .context("block number is negative")?,
             Some(H256(block_hash.0)),
-        )]) //todo
+        ))
     }
 
     async fn append_events(&mut self, events: Vec<EthContractEvent<ContractEvent>>) -> Result<()> {

--- a/crates/autopilot/src/database/events.rs
+++ b/crates/autopilot/src/database/events.rs
@@ -41,7 +41,7 @@ pub fn contract_to_db_events(
 
 #[async_trait::async_trait]
 impl EventStoring<ContractEvent> for Postgres {
-    async fn last_event_block(&self) -> Result<BlockNumberHash> {
+    async fn last_event_blocks(&self) -> Result<Vec<BlockNumberHash>> {
         let _timer = super::Metrics::get()
             .database_queries
             .with_label_values(&["last_event_block"])
@@ -52,12 +52,12 @@ impl EventStoring<ContractEvent> for Postgres {
             .await
             .context("block_number_of_most_recent_event failed")?;
 
-        Ok((
+        Ok(vec![(
             block_number
                 .try_into()
                 .context("block number is negative")?,
             Some(H256(block_hash.0)),
-        ))
+        )]) //todo
     }
 
     async fn append_events(&mut self, events: Vec<EthContractEvent<ContractEvent>>) -> Result<()> {

--- a/crates/autopilot/src/database/events.rs
+++ b/crates/autopilot/src/database/events.rs
@@ -56,7 +56,7 @@ impl EventStoring<ContractEvent> for Postgres {
             block_number
                 .try_into()
                 .context("block number is negative")?,
-            Some(H256(block_hash.0)),
+            H256(block_hash.0),
         ))
     }
 

--- a/crates/autopilot/src/lib.rs
+++ b/crates/autopilot/src/lib.rs
@@ -439,7 +439,7 @@ pub async fn main(args: arguments::Arguments) {
             .map(|block| {
                 (
                     block.number.expect("number must exist").as_u64(),
-                    block.hash,
+                    block.hash.expect("hash must exist"),
                 )
             })
     } else {

--- a/crates/shared/src/current_block.rs
+++ b/crates/shared/src/current_block.rs
@@ -90,12 +90,8 @@ pub fn block_number(block: &Block) -> Result<u64> {
 pub trait BlockRetrieving {
     async fn current_block(&self) -> Result<Block>;
     async fn current_block_number(&self) -> Result<u64>;
-    /// gets nmb_of_blocks consecutive blocks starting from block_number acting as a `Latest` block
-    async fn block_history(
-        &self,
-        block_number: BlockId,
-        nmb_of_blocks: u64,
-    ) -> Result<Vec<BlockNumberHash>>;
+    /// gets latest `length` blocks
+    async fn current_blocks(&self, length: u64) -> Result<Vec<BlockNumberHash>>;
 }
 
 #[async_trait::async_trait]
@@ -121,13 +117,9 @@ where
             .as_u64())
     }
 
-    /// gets nmb_of_blocks consecutive blocks starting from block_number acting as a `Latest` block
-    async fn block_history(
-        &self,
-        _block_number: BlockId,
-        _nmb_of_blocks: u64,
-    ) -> Result<Vec<BlockNumberHash>> {
-        Ok(vec![]) //todo
+    /// gets latest `length` blocks
+    async fn current_blocks(&self, _length: u64) -> Result<Vec<BlockNumberHash>> {
+        Ok(vec![])
     }
 }
 

--- a/crates/shared/src/current_block.rs
+++ b/crates/shared/src/current_block.rs
@@ -1,4 +1,4 @@
-use crate::Web3;
+use crate::{event_handling::BlockNumberHash, Web3};
 use anyhow::{anyhow, Context as _, Result};
 use primitive_types::H256;
 use std::time::Duration;
@@ -89,6 +89,7 @@ pub fn block_number(block: &Block) -> Result<u64> {
 #[async_trait::async_trait]
 pub trait BlockRetrieving {
     async fn current_block(&self) -> Result<Block>;
+    async fn current_blocks(&self) -> Result<Vec<BlockNumberHash>>;
     async fn current_block_number(&self) -> Result<u64>;
 }
 
@@ -104,6 +105,10 @@ where
             .await
             .context("failed to get current block")?
             .ok_or_else(|| anyhow!("no current block"))
+    }
+
+    async fn current_blocks(&self) -> Result<Vec<BlockNumberHash>> {
+        Ok(vec![]) //todo
     }
 
     async fn current_block_number(&self) -> Result<u64> {

--- a/crates/shared/src/current_block.rs
+++ b/crates/shared/src/current_block.rs
@@ -147,7 +147,9 @@ impl BlockRetrieving for Web3 {
                 Ok(response) => serde_json::from_value::<web3::types::Block<H256>>(response)
                     .context("unexpected response format")
                     .and_then(|response| match response.number {
-                        Some(number) => Ok((number.as_u64(), response.hash)),
+                        Some(number) => {
+                            Ok((number.as_u64(), response.hash.context("missing hash")?))
+                        }
                         None => Err(anyhow!("missing block number")),
                     }),
                 Err(err) => Err(anyhow!("web3 error: {}", err)),

--- a/crates/shared/src/current_block.rs
+++ b/crates/shared/src/current_block.rs
@@ -89,8 +89,13 @@ pub fn block_number(block: &Block) -> Result<u64> {
 #[async_trait::async_trait]
 pub trait BlockRetrieving {
     async fn current_block(&self) -> Result<Block>;
-    async fn current_blocks(&self) -> Result<Vec<BlockNumberHash>>;
     async fn current_block_number(&self) -> Result<u64>;
+    /// gets nmb_of_blocks consecutive blocks starting from block_number acting as a `Latest` block
+    async fn block_history(
+        &self,
+        block_number: BlockId,
+        nmb_of_blocks: u64,
+    ) -> Result<Vec<BlockNumberHash>>;
 }
 
 #[async_trait::async_trait]
@@ -107,10 +112,6 @@ where
             .ok_or_else(|| anyhow!("no current block"))
     }
 
-    async fn current_blocks(&self) -> Result<Vec<BlockNumberHash>> {
-        Ok(vec![]) //todo
-    }
-
     async fn current_block_number(&self) -> Result<u64> {
         Ok(self
             .eth()
@@ -118,6 +119,15 @@ where
             .await
             .context("failed to get current block number")?
             .as_u64())
+    }
+
+    /// gets nmb_of_blocks consecutive blocks starting from block_number acting as a `Latest` block
+    async fn block_history(
+        &self,
+        _block_number: BlockId,
+        _nmb_of_blocks: u64,
+    ) -> Result<Vec<BlockNumberHash>> {
+        Ok(vec![]) //todo
     }
 }
 

--- a/crates/shared/src/current_block.rs
+++ b/crates/shared/src/current_block.rs
@@ -146,11 +146,11 @@ impl BlockRetrieving for Web3 {
             .map(|_req| match batch_response.next().unwrap() {
                 Ok(response) => serde_json::from_value::<web3::types::Block<H256>>(response)
                     .context("unexpected response format")
-                    .and_then(|response| match response.number {
-                        Some(number) => {
-                            Ok((number.as_u64(), response.hash.context("missing hash")?))
-                        }
-                        None => Err(anyhow!("missing block number")),
+                    .and_then(|response| {
+                        Ok((
+                            response.number.context("missing block number")?.as_u64(),
+                            response.hash.context("missing hash")?,
+                        ))
                     }),
                 Err(err) => Err(anyhow!("web3 error: {}", err)),
             })

--- a/crates/shared/src/event_handling.rs
+++ b/crates/shared/src/event_handling.rs
@@ -1,5 +1,5 @@
 use crate::{current_block::BlockRetrieving, maintenance::Maintaining};
-use anyhow::{ensure, Context, Error, Result};
+use anyhow::{Context, Error, Result};
 use ethcontract::contract::{AllEventsBuilder, ParseLog};
 use ethcontract::errors::ExecutionError;
 use ethcontract::H256;
@@ -225,11 +225,9 @@ where
 }
 
 fn detect_reorg_path(
-    handled_blocks: &Vec<BlockNumberHash>,
-    current_blocks: &Vec<BlockNumberHash>,
+    handled_blocks: &[BlockNumberHash],
+    current_blocks: &[BlockNumberHash],
 ) -> Result<RangeInclusive<u64>> {
-    ensure!(!handled_blocks.is_empty() && !current_blocks.is_empty());
-
     // in most cases, current_blocks = handled_blocks + 1 newest block
     // therefore, is it more efficient to put the handled_blocks in outer loop,
     // so everything finishes in only two iterations.
@@ -245,10 +243,10 @@ fn detect_reorg_path(
     //cant figure out the reorg, fallback to regular 25 blocks reorg
     let start_index = handled_blocks
         .last()
-        .unwrap()
+        .context("empty handled_blocks")?
         .0
         .saturating_sub(MAX_REORG_BLOCK_COUNT);
-    let end_index = current_blocks.last().unwrap().0;
+    let end_index = current_blocks.last().context("empty current_blocks")?.0;
     Ok(start_index..=end_index)
 }
 

--- a/crates/shared/src/event_handling.rs
+++ b/crates/shared/src/event_handling.rs
@@ -202,8 +202,7 @@ where
                 .last_handled_blocks
                 .len()
                 .saturating_sub(MAX_REORG_BLOCK_COUNT as usize);
-            self.last_handled_blocks =
-                self.last_handled_blocks[start_index..self.last_handled_blocks.len()].to_vec();
+            self.last_handled_blocks = self.last_handled_blocks[start_index..].to_vec();
         }
         Ok(())
     }

--- a/crates/shared/src/event_handling.rs
+++ b/crates/shared/src/event_handling.rs
@@ -117,7 +117,7 @@ where
 
         let current_blocks = self
             .block_retriever
-            .current_blocks(current_block_number, MAX_REORG_BLOCK_COUNT)
+            .preceding_blocks(current_block_number, MAX_REORG_BLOCK_COUNT)
             .await?;
 
         let block_range = detect_reorg_path(&current_blocks, &handled_blocks)?;

--- a/crates/shared/src/event_handling.rs
+++ b/crates/shared/src/event_handling.rs
@@ -207,12 +207,12 @@ where
             self.last_handled_blocks
                 .extend(replacement_blocks.into_iter());
             // cap number of blocks to MAX_REORG_BLOCK_COUNT
-            self.last_handled_blocks = self.last_handled_blocks[self
+            let start_index = self
                 .last_handled_blocks
                 .len()
-                .saturating_sub(MAX_REORG_BLOCK_COUNT as usize)
-                ..self.last_handled_blocks.len()]
-                .to_vec();
+                .saturating_sub(MAX_REORG_BLOCK_COUNT as usize);
+            self.last_handled_blocks =
+                self.last_handled_blocks[start_index..self.last_handled_blocks.len()].to_vec();
         }
         Ok(())
     }

--- a/crates/shared/src/sources/balancer_v2/graph_api.rs
+++ b/crates/shared/src/sources/balancer_v2/graph_api.rs
@@ -99,7 +99,7 @@ impl BalancerSubgraphClient {
         }
 
         Ok(RegisteredPools {
-            fetched_block_number: (block_number, Some(block_number_hash)),
+            fetched_block_number: (block_number, block_number_hash),
             pools,
         })
     }
@@ -433,7 +433,7 @@ mod tests {
                 pool(H160([1; 20]), 2),
                 pool(H160([2; 20]), 3),
             ],
-            fetched_block_number: (42, Some(H256::from_low_u64_be(42))),
+            fetched_block_number: (42, H256::from_low_u64_be(42)),
         };
 
         assert_eq!(
@@ -444,13 +444,13 @@ mod tests {
                         pool(H160([1; 20]), 1),
                         pool(H160([1; 20]), 2),
                     ],
-                    fetched_block_number: (42, Some(H256::from_low_u64_be(42))),
+                    fetched_block_number: (42, H256::from_low_u64_be(42)),
                 },
                 H160([2; 20]) => RegisteredPools {
                     pools: vec![
                         pool(H160([2; 20]), 3),
                     ],
-                    fetched_block_number: (42, Some(H256::from_low_u64_be(42))),
+                    fetched_block_number: (42, H256::from_low_u64_be(42)),
                 },
             }
         )

--- a/crates/shared/src/sources/balancer_v2/pool_fetching.rs
+++ b/crates/shared/src/sources/balancer_v2/pool_fetching.rs
@@ -482,7 +482,7 @@ mod tests {
         println!("Indexing events for chain {}", chain_id);
         crate::tracing::initialize_for_tests("warn,shared=debug");
 
-        let pool_initializer = EmptyPoolInitializer::for_chain(chain_id);
+        let pool_initializer = EmptyPoolInitializer::for_chain(chain_id, web3.clone());
         let token_infos = TokenInfoFetcher { web3: web3.clone() };
         let contracts =
             BalancerContracts::new(&web3, BalancerFactoryKind::value_variants().to_vec())

--- a/crates/shared/src/sources/balancer_v2/pool_fetching/pool_storage.rs
+++ b/crates/shared/src/sources/balancer_v2/pool_fetching/pool_storage.rs
@@ -165,14 +165,15 @@ where
         }
     }
 
-    pub fn last_event_block(&self) -> BlockNumberHash {
+    pub fn last_event_blocks(&self) -> Vec<BlockNumberHash> {
         // Technically we could keep this updated more effectively in a field on balancer pools,
         // but the maintenance seems like more overhead that needs to be tested.
-        self.pools
+        vec![self
+            .pools
             .values()
             .map(|pool| pool.common().block_created)
             .max()
-            .unwrap_or_default()
+            .unwrap_or_default()] //todo
     }
 }
 
@@ -211,8 +212,8 @@ where
         Ok(())
     }
 
-    async fn last_event_block(&self) -> Result<BlockNumberHash> {
-        Ok(self.last_event_block())
+    async fn last_event_blocks(&self) -> Result<Vec<BlockNumberHash>> {
+        Ok(self.last_event_blocks())
     }
 }
 

--- a/crates/shared/src/sources/balancer_v2/pool_fetching/pool_storage.rs
+++ b/crates/shared/src/sources/balancer_v2/pool_fetching/pool_storage.rs
@@ -17,7 +17,7 @@
 //!     on token pairs.
 
 use crate::{
-    event_handling::{BlockNumber, BlockNumberHash, EventStoring},
+    event_handling::{BlockNumberHash, EventStoring},
     sources::balancer_v2::pools::{common, FactoryIndexing, PoolIndexing},
 };
 use anyhow::{anyhow, Result};
@@ -184,11 +184,11 @@ where
     async fn replace_events(
         &mut self,
         events: Vec<Event<BasePoolFactoryEvent>>,
-        range: RangeInclusive<BlockNumber>,
+        range: RangeInclusive<u64>,
     ) -> Result<()> {
         tracing::debug!("replacing {} events for block {:?}", events.len(), range);
 
-        self.remove_pools_newer_than_block(range.start().to_u64());
+        self.remove_pools_newer_than_block(*range.start());
         self.append_events(events).await
     }
 

--- a/crates/shared/src/sources/balancer_v2/pool_fetching/pool_storage.rs
+++ b/crates/shared/src/sources/balancer_v2/pool_fetching/pool_storage.rs
@@ -203,7 +203,7 @@ where
 
             self.index_pool_creation(
                 pool_created,
-                (event_meta.block_number, Some(event_meta.block_hash)),
+                (event_meta.block_number, event_meta.block_hash),
             )
             .await?;
         }
@@ -231,7 +231,7 @@ mod tests {
         Vec<H160>,
         Vec<H160>,
         Vec<Bfp>,
-        Vec<(PoolCreated, (u64, Option<H256>))>,
+        Vec<(PoolCreated, (u64, H256))>,
     );
     fn pool_init_data(start: usize, end: usize) -> PoolInitData {
         let pool_ids: Vec<H256> = (start..=end)
@@ -244,13 +244,13 @@ mod tests {
             .map(|i| H160::from_low_u64_be(i as u64))
             .collect();
         let weights: Vec<Bfp> = (start..=end + 1).map(|i| Bfp::from_wei(i.into())).collect();
-        let creation_events: Vec<(PoolCreated, (u64, Option<H256>))> = (start..=end)
+        let creation_events: Vec<(PoolCreated, (u64, H256))> = (start..=end)
             .map(|i| {
                 (
                     PoolCreated {
                         pool: pool_addresses[i],
                     },
-                    (i as u64, Some(H256::from_low_u64_be(i as u64))),
+                    (i as u64, H256::from_low_u64_be(i as u64)),
                 )
             })
             .collect();
@@ -268,7 +268,7 @@ mod tests {
                         address: H160([1; 20]),
                         tokens: vec![H160([0x11; 20]), H160([0x22; 20])],
                         scaling_exponents: vec![0, 0],
-                        block_created: (0, Some(H256::from_low_u64_be(0))),
+                        block_created: (0, H256::from_low_u64_be(0)),
                     },
                     weights: vec![
                         Bfp::from_wei(500_000_000_000_000_000u128.into()),
@@ -281,7 +281,7 @@ mod tests {
                         address: H160([2; 20]),
                         tokens: vec![H160([0x11; 20]), H160([0x33; 20]), H160([0x77; 20])],
                         scaling_exponents: vec![0, 0],
-                        block_created: (0, Some(H256::from_low_u64_be(0))),
+                        block_created: (0, H256::from_low_u64_be(0)),
                     },
                     weights: vec![
                         Bfp::from_wei(500_000_000_000_000_000u128.into()),
@@ -295,7 +295,7 @@ mod tests {
                         address: H160([3; 20]),
                         tokens: vec![H160([0x11; 20]), H160([0x77; 20])],
                         scaling_exponents: vec![0, 0],
-                        block_created: (0, Some(H256::from_low_u64_be(0))),
+                        block_created: (0, H256::from_low_u64_be(0)),
                     },
                     weights: vec![
                         Bfp::from_wei(500_000_000_000_000_000u128.into()),
@@ -354,10 +354,7 @@ mod tests {
 
         // Note that it is never expected that blocks for events will differ,
         // but in this test block_created for the pool is the first block it receives.
-        assert_eq!(
-            pool_store.last_event_block(),
-            (2, Some(H256::from_low_u64_be(2)))
-        );
+        assert_eq!(pool_store.last_event_block(), (2, H256::from_low_u64_be(2)));
         assert_eq!(
             pool_store.pools_by_token.get(&tokens[0]).unwrap(),
             &hashset! { pool_ids[0] }
@@ -384,7 +381,7 @@ mod tests {
                         address: pool_addresses[i],
                         tokens: vec![tokens[i], tokens[i + 1]],
                         scaling_exponents: vec![0, 0],
-                        block_created: (i as _, Some(H256::from_low_u64_be(i as _))),
+                        block_created: (i as _, H256::from_low_u64_be(i as _)),
                     },
                     weights: vec![weights[i], weights[i + 1]],
                 },
@@ -428,7 +425,7 @@ mod tests {
                 address: H160::from_low_u64_be(42),
                 tokens: vec![H160::from_low_u64_be(808)],
                 scaling_exponents: vec![0],
-                block_created: (3, Some(H256::from_low_u64_be(3))),
+                block_created: (3, H256::from_low_u64_be(3)),
             },
             weights: vec![Bfp::from_wei(1337.into())],
         };
@@ -459,10 +456,7 @@ mod tests {
         // Make sure that we indexed all the initial events, and replace
         assert_eq!(
             pool_store.last_event_block(),
-            (
-                end_block as u64,
-                Some(H256::from_low_u64_be(end_block as u64))
-            )
+            (end_block as u64, H256::from_low_u64_be(end_block as u64))
         );
         pool_store.remove_pools_newer_than_block(3);
         pool_store
@@ -480,7 +474,7 @@ mod tests {
                         address: pool_addresses[i],
                         tokens: vec![tokens[i], tokens[i + 1]],
                         scaling_exponents: vec![0, 0],
-                        block_created: (i as u64, Some(H256::from_low_u64_be(i as u64))),
+                        block_created: (i as u64, H256::from_low_u64_be(i as u64)),
                     },
                     weights: vec![weights[i], weights[i + 1]],
                 },
@@ -550,7 +544,7 @@ mod tests {
                     id: pool_ids[i],
                     tokens: tokens[i..n].to_owned(),
                     scaling_exponents: vec![],
-                    block_created: (0, Some(H256::from_low_u64_be(0))),
+                    block_created: (0, H256::from_low_u64_be(0)),
                     address: pool_addresses[i],
                 },
                 weights: vec![],

--- a/crates/shared/src/sources/balancer_v2/pool_fetching/pool_storage.rs
+++ b/crates/shared/src/sources/balancer_v2/pool_fetching/pool_storage.rs
@@ -165,15 +165,14 @@ where
         }
     }
 
-    pub fn last_event_blocks(&self) -> Vec<BlockNumberHash> {
+    pub fn last_event_block(&self) -> BlockNumberHash {
         // Technically we could keep this updated more effectively in a field on balancer pools,
         // but the maintenance seems like more overhead that needs to be tested.
-        vec![self
-            .pools
+        self.pools
             .values()
             .map(|pool| pool.common().block_created)
             .max()
-            .unwrap_or_default()] //todo
+            .unwrap_or_default()
     }
 }
 
@@ -212,8 +211,8 @@ where
         Ok(())
     }
 
-    async fn last_event_blocks(&self) -> Result<Vec<BlockNumberHash>> {
-        Ok(self.last_event_blocks())
+    async fn last_event_block(&self) -> Result<BlockNumberHash> {
+        Ok(self.last_event_block())
     }
 }
 

--- a/crates/shared/src/sources/balancer_v2/pools/common.rs
+++ b/crates/shared/src/sources/balancer_v2/pools/common.rs
@@ -398,7 +398,7 @@ mod tests {
             token_infos: Arc::new(token_infos),
         };
         let pool_info = pool_info_fetcher
-            .fetch_common_pool_info(pool.address(), (1337, Some(H256::from_low_u64_be(1337))))
+            .fetch_common_pool_info(pool.address(), (1337, H256::from_low_u64_be(1337)))
             .await
             .unwrap();
 
@@ -409,7 +409,7 @@ mod tests {
                 address: pool.address(),
                 tokens: tokens.to_vec(),
                 scaling_exponents: vec![0, 0, 12],
-                block_created: (1337, Some(H256::from_low_u64_be(1337))),
+                block_created: (1337, H256::from_low_u64_be(1337)),
             }
         );
     }
@@ -452,7 +452,7 @@ mod tests {
             address: pool.address(),
             tokens: tokens.to_vec(),
             scaling_exponents: scaling_exponents.to_vec(),
-            block_created: (1337, Some(H256::from_low_u64_be(1337))),
+            block_created: (1337, H256::from_low_u64_be(1337)),
         };
 
         let pool_state = {
@@ -524,7 +524,7 @@ mod tests {
             address: pool.address(),
             tokens: tokens.to_vec(),
             scaling_exponents: vec![0, 0, 0],
-            block_created: (1337, Some(H256::from_low_u64_be(1337))),
+            block_created: (1337, H256::from_low_u64_be(1337)),
         };
 
         let pool_state = {
@@ -560,7 +560,7 @@ mod tests {
                 address: pool.address(),
                 tokens: vec![H160([1; 20]), H160([2; 20]), H160([3; 20])],
                 scaling_exponents: vec![0, 0, 12],
-                block_created: (1337, Some(H256::from_low_u64_be(1337))),
+                block_created: (1337, H256::from_low_u64_be(1337)),
             },
             weights: vec![bfp!("0.5"), bfp!("0.25"), bfp!("0.25")],
         };
@@ -821,13 +821,13 @@ mod tests {
         };
 
         assert_eq!(
-            PoolInfo::from_graph_data(&pool, (42, Some(H256::from_low_u64_be(42)))).unwrap(),
+            PoolInfo::from_graph_data(&pool, (42, H256::from_low_u64_be(42))).unwrap(),
             PoolInfo {
                 id: H256([4; 32]),
                 address: H160([3; 20]),
                 tokens: vec![H160([0x33; 20]), H160([0x44; 20])],
                 scaling_exponents: vec![15, 0],
-                block_created: (42, Some(H256::from_low_u64_be(42))),
+                block_created: (42, H256::from_low_u64_be(42)),
             }
         );
     }
@@ -846,7 +846,7 @@ mod tests {
                 weight: Some("1.337".parse().unwrap()),
             }],
         };
-        assert!(PoolInfo::from_graph_data(&pool, (42, Some(H256::from_low_u64_be(42)))).is_err());
+        assert!(PoolInfo::from_graph_data(&pool, (42, H256::from_low_u64_be(42))).is_err());
     }
 
     #[test]
@@ -870,7 +870,7 @@ mod tests {
                 },
             ],
         };
-        assert!(PoolInfo::from_graph_data(&pool, (42, Some(H256::from_low_u64_be(42)))).is_err());
+        assert!(PoolInfo::from_graph_data(&pool, (42, H256::from_low_u64_be(42))).is_err());
     }
 
     #[test]

--- a/crates/shared/src/sources/balancer_v2/pools/liquidity_bootstrapping.rs
+++ b/crates/shared/src/sources/balancer_v2/pools/liquidity_bootstrapping.rs
@@ -165,7 +165,7 @@ mod tests {
                     .values()
                     .map(|token| token.common.scaling_exponent)
                     .collect(),
-                block_created: (1337, Some(H256::from_low_u64_be(1337))),
+                block_created: (1337, H256::from_low_u64_be(1337)),
             },
         };
         let common_pool_state = common::PoolState {
@@ -219,7 +219,7 @@ mod tests {
                 address: pool.address(),
                 tokens: vec![H160([1; 20]), H160([1; 20])],
                 scaling_exponents: vec![0, 0],
-                block_created: (1337, Some(H256::from_low_u64_be(1337))),
+                block_created: (1337, H256::from_low_u64_be(1337)),
             },
         };
         let common_pool_state = common::PoolState {
@@ -277,6 +277,6 @@ mod tests {
             ],
         };
 
-        assert!(PoolInfo::from_graph_data(&pool, (42, Some(H256::from_low_u64_be(42)))).is_err());
+        assert!(PoolInfo::from_graph_data(&pool, (42, H256::from_low_u64_be(42))).is_err());
     }
 }

--- a/crates/shared/src/sources/balancer_v2/pools/stable.rs
+++ b/crates/shared/src/sources/balancer_v2/pools/stable.rs
@@ -183,7 +183,7 @@ mod tests {
                     .values()
                     .map(|token| token.scaling_exponent)
                     .collect(),
-                block_created: (1337, Some(H256::from_low_u64_be(1337))),
+                block_created: (1337, H256::from_low_u64_be(1337)),
             },
         };
         let common_pool_state = common::PoolState {
@@ -239,7 +239,7 @@ mod tests {
             ],
         };
 
-        assert!(PoolInfo::from_graph_data(&pool, (42, Some(H256::from_low_u64_be(42)))).is_err());
+        assert!(PoolInfo::from_graph_data(&pool, (42, H256::from_low_u64_be(42))).is_err());
     }
 
     #[test]

--- a/crates/shared/src/sources/balancer_v2/pools/weighted.rs
+++ b/crates/shared/src/sources/balancer_v2/pools/weighted.rs
@@ -132,14 +132,14 @@ mod tests {
         };
 
         assert_eq!(
-            PoolInfo::from_graph_data(&pool, (42, Some(H256::from_low_u64_be(42)))).unwrap(),
+            PoolInfo::from_graph_data(&pool, (42, H256::from_low_u64_be(42))).unwrap(),
             PoolInfo {
                 common: common::PoolInfo {
                     id: H256([2; 32]),
                     address: H160([1; 20]),
                     tokens: vec![H160([0x11; 20]), H160([0x22; 20])],
                     scaling_exponents: vec![17, 16],
-                    block_created: (42, Some(H256::from_low_u64_be(42))),
+                    block_created: (42, H256::from_low_u64_be(42)),
                 },
                 weights: vec![
                     Bfp::from_wei(1_337_000_000_000_000_000u128.into()),
@@ -171,7 +171,7 @@ mod tests {
             ],
         };
 
-        assert!(PoolInfo::from_graph_data(&pool, (42, Some(H256::from_low_u64_be(42)))).is_err());
+        assert!(PoolInfo::from_graph_data(&pool, (42, H256::from_low_u64_be(42))).is_err());
     }
 
     #[tokio::test]
@@ -192,7 +192,7 @@ mod tests {
                 tokens: vec![H160([1; 20]), H160([2; 20]), H160([3; 20])],
                 address: pool.address(),
                 scaling_exponents: vec![0, 0, 0],
-                block_created: (42, Some(H256::from_low_u64_be(42))),
+                block_created: (42, H256::from_low_u64_be(42)),
             })
             .await
             .unwrap();
@@ -228,7 +228,7 @@ mod tests {
                     .values()
                     .map(|token| token.scaling_exponent)
                     .collect(),
-                block_created: (1337, Some(H256::from_low_u64_be(1337))),
+                block_created: (1337, H256::from_low_u64_be(1337)),
             },
             weights: weights.to_vec(),
         };


### PR DESCRIPTION
This PR starts implementing steps (2) and (3) from https://github.com/cowprotocol/services/issues/478 (but slightly different than explained in here)

Step (1) is implemented in https://github.com/cowprotocol/services/pull/485

Changes in this PR:
1. Implemented batch RPC call to get the block number and block hash from last N blocks.
2. `last_handled_block` in `EventHandler` is no longer a single value, but vector. It remembers last N blocks number and hash.
3. Function `EventHandler::event_block_range` is smarter. Now it detects the most common situation (where only one block is added compared to last function call), but also, if this is not the case, does a reorg search and returns the minimum block range needed to update the events (instead of always returning the full N length block range).
4. Added metric for reorg depth.
