### PR TITLE
refactor arguments display

### DIFF
--- a/crates/autopilot/src/arguments.rs
+++ b/crates/autopilot/src/arguments.rs
@@ -28,6 +28,8 @@ pub struct Arguments {
     #[clap(long, env, use_value_delimiter = true)]
     pub unsupported_tokens: Vec<H160>,
 
+    /// The fee value strategy to use for locating Uniswap V3 pools as token holders for bad token
+    /// detection.
     #[clap(long, env, default_value = "static", arg_enum)]
     pub token_detector_fee_values: FeeValues,
 
@@ -134,24 +136,24 @@ impl std::fmt::Display for Arguments {
         writeln!(f, "enable_blockscout: {}", self.enable_blockscout)?;
         writeln!(
             f,
-            "token_quality_cache_expiry: {:?}",
-            self.token_quality_cache_expiry
+            "token_quality_cache_expiry: {}s",
+            self.token_quality_cache_expiry.as_secs_f64()
         )?;
         writeln!(f, "skip_trace_api: {}", self.skip_trace_api)?;
         writeln!(f, "pool_cache_lru_size: {}", self.pool_cache_lru_size)?;
-        write!(f, "balancer_sor_url: ")?;
-        write!(f, "price_estimation_rate_limiter: ")?;
-        display_option(&self.price_estimation_rate_limiter, f)?;
-        writeln!(f)?;
-        write!(f, "amount_to_estimate_prices_with: ")?;
-        display_option(&self.amount_to_estimate_prices_with, f)?;
-        writeln!(f)?;
-        write!(f, "quasimodo_solver_url: ")?;
-        display_option(&self.quasimodo_solver_url, f)?;
-        writeln!(f)?;
-        write!(f, "yearn_solver_url: ")?;
-        display_option(&self.yearn_solver_url, f)?;
-        writeln!(f)?;
+        display_option(f, "balancer_sor_url", &self.balancer_sor_url)?;
+        display_option(
+            f,
+            "price_estimation_rate_limiter",
+            &self.price_estimation_rate_limiter,
+        )?;
+        display_option(
+            f,
+            "amount_to_estimate_prices_with",
+            &self.amount_to_estimate_prices_with,
+        )?;
+        display_option(f, "quasimodo_solver_url", &self.quasimodo_solver_url)?;
+        display_option(f, "yearn_solver_url", &self.yearn_solver_url)?;
         writeln!(
             f,
             "native_price_estimators: {:?}",
@@ -159,13 +161,13 @@ impl std::fmt::Display for Arguments {
         )?;
         writeln!(
             f,
-            "native_price_cache_max_age_secs: {:?}",
-            self.native_price_cache_max_age_secs
+            "native_price_cache_max_age_secs: {}s",
+            self.native_price_cache_max_age_secs.as_secs_f64()
         )?;
         writeln!(
             f,
-            "min_order_validity_period: {:?}",
-            self.min_order_validity_period
+            "min_order_validity_period: {}s",
+            self.min_order_validity_period.as_secs_f64()
         )?;
         writeln!(f, "banned_users: {:?}", self.banned_users)?;
         Ok(())

--- a/crates/autopilot/src/arguments.rs
+++ b/crates/autopilot/src/arguments.rs
@@ -136,8 +136,8 @@ impl std::fmt::Display for Arguments {
         writeln!(f, "enable_blockscout: {}", self.enable_blockscout)?;
         writeln!(
             f,
-            "token_quality_cache_expiry: {}s",
-            self.token_quality_cache_expiry.as_secs_f64()
+            "token_quality_cache_expiry: {:?}",
+            self.token_quality_cache_expiry
         )?;
         writeln!(f, "skip_trace_api: {}", self.skip_trace_api)?;
         writeln!(f, "pool_cache_lru_size: {}", self.pool_cache_lru_size)?;
@@ -161,13 +161,13 @@ impl std::fmt::Display for Arguments {
         )?;
         writeln!(
             f,
-            "native_price_cache_max_age_secs: {}s",
-            self.native_price_cache_max_age_secs.as_secs_f64()
+            "native_price_cache_max_age_secs: {:?}",
+            self.native_price_cache_max_age_secs
         )?;
         writeln!(
             f,
-            "min_order_validity_period: {}s",
-            self.min_order_validity_period.as_secs_f64()
+            "min_order_validity_period: {:?}",
+            self.min_order_validity_period
         )?;
         writeln!(f, "banned_users: {:?}", self.banned_users)?;
         Ok(())

--- a/crates/driver/src/arguments.rs
+++ b/crates/driver/src/arguments.rs
@@ -1,7 +1,7 @@
 use primitive_types::{H160, H256};
 use reqwest::Url;
 use shared::{
-    arguments::{display_list, display_option, duration_from_seconds},
+    arguments::{display_list, display_option, display_secret_option, duration_from_seconds},
     gas_price_estimation::GasEstimatorType,
     sources::{balancer_v2::BalancerFactoryKind, BaselineSource},
 };
@@ -265,11 +265,13 @@ impl std::fmt::Display for Arguments {
         writeln!(f, "log_stderr_threshold: {}", self.log_stderr_threshold)?;
         writeln!(f, "solvers: {:?}", self.solvers)?;
         writeln!(f, "node_url: {}", self.node_url)?;
-        writeln!(f, "http_timeout: {:?}", self.http_timeout)?;
+        writeln!(f, "http_timeout: {}s", self.http_timeout.as_secs_f64())?;
         writeln!(f, "use_internal_buffers: {}", self.use_internal_buffers)?;
-        write!(f, "transaction_submission_nodes: ")?;
-        display_list(self.transaction_submission_nodes.iter(), f)?;
-        writeln!(f)?;
+        display_list(
+            f,
+            "transaction_submission_nodes",
+            &self.transaction_submission_nodes,
+        )?;
         writeln!(
             f,
             "disable_high_risk_public_mempool_transactions: {}",
@@ -292,9 +294,7 @@ impl std::fmt::Display for Arguments {
             "additional_tip_percentage: {}",
             self.additional_tip_percentage
         )?;
-        write!(f, "flashbots_api_url: ")?;
-        display_list(self.flashbots_api_url.iter(), f)?;
-        writeln!(f)?;
+        display_list(f, "flashbots_api_url", &self.flashbots_api_url)?;
         writeln!(
             f,
             "max_additional_flashbots_tip: {}",
@@ -305,39 +305,27 @@ impl std::fmt::Display for Arguments {
             "access_list_estimators: {:?}",
             self.access_list_estimators
         )?;
-        write!(f, "tenderly_url: ")?;
-        display_option(&self.tenderly_url, f)?;
-        writeln!(f)?;
-        writeln!(
-            f,
-            "tenderly_api_key: {}",
-            self.tenderly_api_key
-                .as_deref()
-                .map(|_| "SECRET")
-                .unwrap_or("None")
-        )?;
+        display_option(f, "tenderly_url", &self.tenderly_url)?;
+        display_secret_option(f, "tenderly_api_key", &self.tenderly_api_key)?;
         writeln!(f, "simulation_gas_limit: {}", self.simulation_gas_limit)?;
-        writeln!(f, "target_confirm_time: {:?}", self.target_confirm_time)?;
         writeln!(
             f,
-            "max_submission_seconds: {:?}",
-            self.max_submission_seconds
+            "target_confirm_time: {}s",
+            self.target_confirm_time.as_secs_f64()
         )?;
         writeln!(
             f,
-            "submission_retry_interval_seconds: {:?}",
-            self.submission_retry_interval_seconds
+            "max_submission_seconds: {}s",
+            self.max_submission_seconds.as_secs_f64()
+        )?;
+        writeln!(
+            f,
+            "submission_retry_interval_seconds: {}",
+            self.submission_retry_interval_seconds.as_secs_f64()
         )?;
         writeln!(f, "gas_price_cap: {}", self.gas_price_cap)?;
         writeln!(f, "gas_estimators: {:?}", self.gas_estimators)?;
-        writeln!(
-            f,
-            "blocknative_api_key: {}",
-            self.blocknative_api_key
-                .as_ref()
-                .map(|_| "SECRET")
-                .unwrap_or("None")
-        )?;
+        display_secret_option(f, "blocknative_api_key: {}", &self.blocknative_api_key)?;
         writeln!(f, "base_tokens: {:?}", self.base_tokens)?;
         writeln!(f, "baseline_sources: {:?}", self.baseline_sources)?;
         writeln!(f, "pool_cache_blocks: {}", self.pool_cache_blocks)?;
@@ -353,13 +341,13 @@ impl std::fmt::Display for Arguments {
         )?;
         writeln!(
             f,
-            "pool_cache_delay_between_retries_seconds: {:?}",
-            self.pool_cache_delay_between_retries_seconds
+            "pool_cache_delay_between_retries_seconds: {}",
+            self.pool_cache_delay_between_retries_seconds.as_secs_f64()
         )?;
         writeln!(
             f,
-            "block_stream_poll_interval_seconds: {:?}",
-            self.block_stream_poll_interval_seconds
+            "block_stream_poll_interval_seconds: {}",
+            self.block_stream_poll_interval_seconds.as_secs_f64()
         )?;
         writeln!(f, "balancer_factories: {:?}", self.balancer_factories)?;
         writeln!(
@@ -369,22 +357,11 @@ impl std::fmt::Display for Arguments {
         )?;
         writeln!(
             f,
-            "liquidity_fetcher_max_age_update: {:?}",
-            self.liquidity_fetcher_max_age_update
+            "liquidity_fetcher_max_age_update: {}",
+            self.liquidity_fetcher_max_age_update.as_secs_f64()
         )?;
-        writeln!(
-            f,
-            "zeroex_url: {}",
-            self.zeroex_url.as_deref().unwrap_or("None")
-        )?;
-        writeln!(
-            f,
-            "zeroex_api_key: {}",
-            self.zeroex_api_key
-                .as_ref()
-                .map(|_| "SECRET")
-                .unwrap_or("None")
-        )?;
+        display_option(f, "zeroex_url", &self.zeroex_url)?;
+        display_secret_option(f, "zeroex_api_key: {}", &self.zeroex_api_key)?;
         Ok(())
     }
 }

--- a/crates/driver/src/arguments.rs
+++ b/crates/driver/src/arguments.rs
@@ -265,7 +265,7 @@ impl std::fmt::Display for Arguments {
         writeln!(f, "log_stderr_threshold: {}", self.log_stderr_threshold)?;
         writeln!(f, "solvers: {:?}", self.solvers)?;
         writeln!(f, "node_url: {}", self.node_url)?;
-        writeln!(f, "http_timeout: {}s", self.http_timeout.as_secs_f64())?;
+        writeln!(f, "http_timeout: {:?}", self.http_timeout)?;
         writeln!(f, "use_internal_buffers: {}", self.use_internal_buffers)?;
         display_list(
             f,
@@ -308,24 +308,20 @@ impl std::fmt::Display for Arguments {
         display_option(f, "tenderly_url", &self.tenderly_url)?;
         display_secret_option(f, "tenderly_api_key", &self.tenderly_api_key)?;
         writeln!(f, "simulation_gas_limit: {}", self.simulation_gas_limit)?;
+        writeln!(f, "target_confirm_time: {:?}", self.target_confirm_time)?;
         writeln!(
             f,
-            "target_confirm_time: {}s",
-            self.target_confirm_time.as_secs_f64()
+            "max_submission_seconds: {:?}",
+            self.max_submission_seconds
         )?;
         writeln!(
             f,
-            "max_submission_seconds: {}s",
-            self.max_submission_seconds.as_secs_f64()
-        )?;
-        writeln!(
-            f,
-            "submission_retry_interval_seconds: {}",
-            self.submission_retry_interval_seconds.as_secs_f64()
+            "submission_retry_interval_seconds: {:?}",
+            self.submission_retry_interval_seconds
         )?;
         writeln!(f, "gas_price_cap: {}", self.gas_price_cap)?;
         writeln!(f, "gas_estimators: {:?}", self.gas_estimators)?;
-        display_secret_option(f, "blocknative_api_key: {}", &self.blocknative_api_key)?;
+        display_secret_option(f, "blocknative_api_key", &self.blocknative_api_key)?;
         writeln!(f, "base_tokens: {:?}", self.base_tokens)?;
         writeln!(f, "baseline_sources: {:?}", self.baseline_sources)?;
         writeln!(f, "pool_cache_blocks: {}", self.pool_cache_blocks)?;
@@ -341,13 +337,13 @@ impl std::fmt::Display for Arguments {
         )?;
         writeln!(
             f,
-            "pool_cache_delay_between_retries_seconds: {}",
-            self.pool_cache_delay_between_retries_seconds.as_secs_f64()
+            "pool_cache_delay_between_retries_seconds: {:?}",
+            self.pool_cache_delay_between_retries_seconds
         )?;
         writeln!(
             f,
-            "block_stream_poll_interval_seconds: {}",
-            self.block_stream_poll_interval_seconds.as_secs_f64()
+            "block_stream_poll_interval_seconds: {:?}",
+            self.block_stream_poll_interval_seconds
         )?;
         writeln!(f, "balancer_factories: {:?}", self.balancer_factories)?;
         writeln!(
@@ -357,11 +353,11 @@ impl std::fmt::Display for Arguments {
         )?;
         writeln!(
             f,
-            "liquidity_fetcher_max_age_update: {}",
-            self.liquidity_fetcher_max_age_update.as_secs_f64()
+            "liquidity_fetcher_max_age_update: {:?}",
+            self.liquidity_fetcher_max_age_update
         )?;
         display_option(f, "zeroex_url", &self.zeroex_url)?;
-        display_secret_option(f, "zeroex_api_key: {}", &self.zeroex_api_key)?;
+        display_secret_option(f, "zeroex_api_key", &self.zeroex_api_key)?;
         Ok(())
     }
 }

--- a/crates/orderbook/src/arguments.rs
+++ b/crates/orderbook/src/arguments.rs
@@ -4,8 +4,10 @@ use model::app_id::AppId;
 use primitive_types::{H160, U256};
 use reqwest::Url;
 use shared::{
-    arguments::display_option, bad_token::token_owner_finder::FeeValues,
-    price_estimation::PriceEstimatorType, rate_limiter::RateLimitingStrategy,
+    arguments::{display_list, display_option},
+    bad_token::token_owner_finder::FeeValues,
+    price_estimation::PriceEstimatorType,
+    rate_limiter::RateLimitingStrategy,
 };
 use std::{collections::HashMap, net::SocketAddr, num::NonZeroUsize, time::Duration};
 
@@ -247,29 +249,29 @@ impl std::fmt::Display for Arguments {
         writeln!(f, "db_url: SECRET")?;
         writeln!(
             f,
-            "min_order_validity_period: {:?}",
-            self.min_order_validity_period
+            "min_order_validity_period: {}s",
+            self.min_order_validity_period.as_secs_f64()
         )?;
         writeln!(
             f,
-            "max_order_validity_period: {:?}",
-            self.max_order_validity_period
+            "max_order_validity_period: {}s",
+            self.max_order_validity_period.as_secs_f64()
         )?;
         writeln!(
             f,
-            "eip1271_onchain_quote_validity_second: {:?}",
-            self.eip1271_onchain_quote_validity_seconds
+            "eip1271_onchain_quote_validity_second: {}s",
+            self.eip1271_onchain_quote_validity_seconds.as_secs_f64()
         )?;
         writeln!(
             f,
-            "presign_onchain_quote_validity_second: {:?}",
-            self.presign_onchain_quote_validity_seconds
+            "presign_onchain_quote_validity_second: {}s",
+            self.presign_onchain_quote_validity_seconds.as_secs_f64()
         )?;
         writeln!(f, "skip_trace_api: {}", self.skip_trace_api)?;
         writeln!(
             f,
-            "token_quality_cache_expiry: {:?}",
-            self.token_quality_cache_expiry
+            "token_quality_cache_expiry: {}s",
+            self.token_quality_cache_expiry.as_secs_f64()
         )?;
         writeln!(f, "unsupported_tokens: {:?}", self.unsupported_tokens)?;
         writeln!(f, "banned_users: {:?}", self.banned_users)?;
@@ -279,28 +281,26 @@ impl std::fmt::Display for Arguments {
         writeln!(f, "enable_presign_orders: {}", self.enable_presign_orders)?;
         writeln!(
             f,
-            "solvable_orders_max_update_age_blocks: {:?}",
+            "solvable_orders_max_update_age_blocks: {}",
             self.solvable_orders_max_update_age_blocks,
         )?;
         writeln!(f, "fee_discount: {}", self.fee_discount)?;
         writeln!(f, "min_discounted_fee: {}", self.min_discounted_fee)?;
         writeln!(f, "fee_factor: {}", self.fee_factor)?;
-        writeln!(
+        display_list(
             f,
-            "partner_additional_fee_factors: {:?}",
+            "partner_additional_fee_factors",
             self.partner_additional_fee_factors
+                .iter()
+                .map(|(k, v)| format!("{k:?}: {v}")),
         )?;
         writeln!(f, "cow_fee_factors: {:?}", self.cow_fee_factors)?;
-        write!(f, "quasimodo_solver_url: ")?;
-        display_option(&self.quasimodo_solver_url, f)?;
-        writeln!(f)?;
-        write!(f, "yearn_solver_url: ")?;
-        display_option(&self.yearn_solver_url, f)?;
-        writeln!(f)?;
+        display_option(f, "quasimodo_solver_url", &self.quasimodo_solver_url)?;
+        display_option(f, "yearn_solver_url", &self.yearn_solver_url)?;
         writeln!(
             f,
-            "native_price_cache_max_age_secs: {:?}",
-            self.native_price_cache_max_age_secs
+            "native_price_cache_max_age_secs: {}s",
+            self.native_price_cache_max_age_secs.as_secs_f64()
         )?;
         writeln!(
             f,
@@ -312,18 +312,22 @@ impl std::fmt::Display for Arguments {
             "native_price_estimators: {:?}",
             self.native_price_estimators
         )?;
-        write!(f, "amount_to_estimate_prices_with: ")?;
-        display_option(&self.amount_to_estimate_prices_with, f)?;
-        writeln!(f)?;
+        display_option(
+            f,
+            "amount_to_estimate_prices_with",
+            &self.amount_to_estimate_prices_with,
+        )?;
         writeln!(f, "price_estimators: {:?}", self.price_estimators)?;
         writeln!(
             f,
             "fast_price_estimation_results_required: {}",
             self.fast_price_estimation_results_required
         )?;
-        write!(f, "price_estimation_rate_limiter: ")?;
-        display_option(&self.price_estimation_rate_limiter, f)?;
-        writeln!(f)?;
+        display_option(
+            f,
+            "price_estimation_rate_limites",
+            &self.price_estimation_rate_limiter,
+        )?;
         writeln!(
             f,
             "token_detector_fee_values: {:?}",
@@ -335,9 +339,7 @@ impl std::fmt::Display for Arguments {
             self.liquidity_order_owners
         )?;
         writeln!(f, "enable_blockscout: {}", self.enable_blockscout)?;
-        write!(f, "balancer_sor_url: ")?;
-        display_option(&self.balancer_sor_url, f)?;
-        writeln!(f)?;
+        display_option(f, "balancer_sor_url", &self.balancer_sor_url)?;
         Ok(())
     }
 }

--- a/crates/orderbook/src/arguments.rs
+++ b/crates/orderbook/src/arguments.rs
@@ -4,10 +4,8 @@ use model::app_id::AppId;
 use primitive_types::{H160, U256};
 use reqwest::Url;
 use shared::{
-    arguments::{display_list, display_option},
-    bad_token::token_owner_finder::FeeValues,
-    price_estimation::PriceEstimatorType,
-    rate_limiter::RateLimitingStrategy,
+    arguments::display_option, bad_token::token_owner_finder::FeeValues,
+    price_estimation::PriceEstimatorType, rate_limiter::RateLimitingStrategy,
 };
 use std::{collections::HashMap, net::SocketAddr, num::NonZeroUsize, time::Duration};
 
@@ -249,29 +247,29 @@ impl std::fmt::Display for Arguments {
         writeln!(f, "db_url: SECRET")?;
         writeln!(
             f,
-            "min_order_validity_period: {}s",
-            self.min_order_validity_period.as_secs_f64()
+            "min_order_validity_period: {:?}",
+            self.min_order_validity_period
         )?;
         writeln!(
             f,
-            "max_order_validity_period: {}s",
-            self.max_order_validity_period.as_secs_f64()
+            "max_order_validity_period: {:?}",
+            self.max_order_validity_period
         )?;
         writeln!(
             f,
-            "eip1271_onchain_quote_validity_second: {}s",
-            self.eip1271_onchain_quote_validity_seconds.as_secs_f64()
+            "eip1271_onchain_quote_validity_second: {:?}",
+            self.eip1271_onchain_quote_validity_seconds
         )?;
         writeln!(
             f,
-            "presign_onchain_quote_validity_second: {}s",
-            self.presign_onchain_quote_validity_seconds.as_secs_f64()
+            "presign_onchain_quote_validity_second: {:?}",
+            self.presign_onchain_quote_validity_seconds
         )?;
         writeln!(f, "skip_trace_api: {}", self.skip_trace_api)?;
         writeln!(
             f,
-            "token_quality_cache_expiry: {}s",
-            self.token_quality_cache_expiry.as_secs_f64()
+            "token_quality_cache_expiry: {:?}",
+            self.token_quality_cache_expiry
         )?;
         writeln!(f, "unsupported_tokens: {:?}", self.unsupported_tokens)?;
         writeln!(f, "banned_users: {:?}", self.banned_users)?;
@@ -287,20 +285,18 @@ impl std::fmt::Display for Arguments {
         writeln!(f, "fee_discount: {}", self.fee_discount)?;
         writeln!(f, "min_discounted_fee: {}", self.min_discounted_fee)?;
         writeln!(f, "fee_factor: {}", self.fee_factor)?;
-        display_list(
+        writeln!(
             f,
-            "partner_additional_fee_factors",
+            "partner_additional_fee_factors: {:?}",
             self.partner_additional_fee_factors
-                .iter()
-                .map(|(k, v)| format!("{k:?}: {v}")),
         )?;
         writeln!(f, "cow_fee_factors: {:?}", self.cow_fee_factors)?;
         display_option(f, "quasimodo_solver_url", &self.quasimodo_solver_url)?;
         display_option(f, "yearn_solver_url", &self.yearn_solver_url)?;
         writeln!(
             f,
-            "native_price_cache_max_age_secs: {}s",
-            self.native_price_cache_max_age_secs.as_secs_f64()
+            "native_price_cache_max_age_secs: {:?}",
+            self.native_price_cache_max_age_secs
         )?;
         writeln!(
             f,

--- a/crates/shared/src/arguments.rs
+++ b/crates/shared/src/arguments.rs
@@ -198,8 +198,11 @@ where
     T: Display,
 {
     write!(f, "{name}: [")?;
-    for t in iter {
-        write!(f, "{t}, ")?;
+    for (i, t) in iter.into_iter().enumerate() {
+        if i != 0 {
+            f.write_str(", ")?;
+        }
+        write!(f, "{t}")?;
     }
     writeln!(f, "]")?;
     Ok(())
@@ -212,7 +215,7 @@ impl Display for Arguments {
         writeln!(f, "log_filter: {}", self.log_filter)?;
         writeln!(f, "log_stderr_threshold: {}", self.log_stderr_threshold)?;
         writeln!(f, "node_url: {}", self.node_url)?;
-        writeln!(f, "http_timeout: {}s", self.http_timeout.as_secs_f64())?;
+        writeln!(f, "http_timeout: {:?}", self.http_timeout)?;
         writeln!(f, "gas_estimators: {:?}", self.gas_estimators)?;
         display_secret_option(f, "blocknative_api_key", &self.blocknative_api_key)?;
         writeln!(f, "base_tokens: {:?}", self.base_tokens)?;
@@ -230,15 +233,15 @@ impl Display for Arguments {
         )?;
         writeln!(
             f,
-            "pool_cache_delay_between_retries_seconds: {}s",
-            self.pool_cache_delay_between_retries_seconds.as_secs_f64()
+            "pool_cache_delay_between_retries_seconds: {:?}",
+            self.pool_cache_delay_between_retries_seconds
         )?;
         writeln!(
             f,
-            "block_stream_poll_interval_seconds: {}s",
-            self.block_stream_poll_interval_seconds.as_secs_f64(),
+            "block_stream_poll_interval_seconds: {:?}",
+            self.block_stream_poll_interval_seconds,
         )?;
-        display_secret_option(f, "paraswap_partner: {}", &self.paraswap_partner)?;
+        display_secret_option(f, "paraswap_partner", &self.paraswap_partner)?;
         display_list(f, "disabled_paraswap_dexs", &self.disabled_paraswap_dexs)?;
         display_option(f, "paraswap_rate_limiter", &self.paraswap_rate_limiter)?;
         display_option(f, "zeroex_url", &self.zeroex_url)?;

--- a/crates/shared/src/arguments.rs
+++ b/crates/shared/src/arguments.rs
@@ -169,22 +169,39 @@ pub struct Arguments {
     pub liquidity_fetcher_max_age_update: Duration,
 }
 
-pub fn display_option(option: &Option<impl Display>, f: &mut Formatter<'_>) -> std::fmt::Result {
+pub fn display_secret_option<T>(
+    f: &mut Formatter<'_>,
+    name: &str,
+    option: &Option<T>,
+) -> std::fmt::Result {
+    display_option(f, name, &option.as_ref().map(|_| "SECRET"))
+}
+
+pub fn display_option(
+    f: &mut Formatter<'_>,
+    name: &str,
+    option: &Option<impl Display>,
+) -> std::fmt::Result {
+    write!(f, "{name}: ")?;
     match option {
-        Some(display) => write!(f, "{}", display),
-        None => write!(f, "None"),
+        Some(display) => writeln!(f, "{}", display),
+        None => writeln!(f, "None"),
     }
 }
 
-pub fn display_list<T>(iter: impl Iterator<Item = T>, f: &mut Formatter<'_>) -> std::fmt::Result
+pub fn display_list<T>(
+    f: &mut Formatter<'_>,
+    name: &str,
+    iter: impl IntoIterator<Item = T>,
+) -> std::fmt::Result
 where
     T: Display,
 {
-    write!(f, "[")?;
+    write!(f, "{name}: [")?;
     for t in iter {
-        write!(f, "{}, ", t)?;
+        write!(f, "{t}, ")?;
     }
-    write!(f, "]")?;
+    writeln!(f, "]")?;
     Ok(())
 }
 
@@ -195,16 +212,9 @@ impl Display for Arguments {
         writeln!(f, "log_filter: {}", self.log_filter)?;
         writeln!(f, "log_stderr_threshold: {}", self.log_stderr_threshold)?;
         writeln!(f, "node_url: {}", self.node_url)?;
-        writeln!(f, "http_timeout: {:?}", self.http_timeout)?;
+        writeln!(f, "http_timeout: {}s", self.http_timeout.as_secs_f64())?;
         writeln!(f, "gas_estimators: {:?}", self.gas_estimators)?;
-        writeln!(
-            f,
-            "blocknative_api_key: {}",
-            self.blocknative_api_key
-                .as_ref()
-                .map(|_| "SECRET")
-                .unwrap_or("None")
-        )?;
+        display_secret_option(f, "blocknative_api_key", &self.blocknative_api_key)?;
         writeln!(f, "base_tokens: {:?}", self.base_tokens)?;
         writeln!(f, "baseline_sources: {:?}", self.baseline_sources)?;
         writeln!(f, "pool_cache_blocks: {}", self.pool_cache_blocks)?;
@@ -220,43 +230,19 @@ impl Display for Arguments {
         )?;
         writeln!(
             f,
-            "pool_cache_delay_between_retries_seconds: {:?}",
-            self.pool_cache_delay_between_retries_seconds
+            "pool_cache_delay_between_retries_seconds: {}s",
+            self.pool_cache_delay_between_retries_seconds.as_secs_f64()
         )?;
         writeln!(
             f,
-            "block_stream_poll_interval_seconds: {:?}",
-            self.block_stream_poll_interval_seconds
+            "block_stream_poll_interval_seconds: {}s",
+            self.block_stream_poll_interval_seconds.as_secs_f64(),
         )?;
-        writeln!(
-            f,
-            "paraswap_partner: {}",
-            self.paraswap_partner
-                .as_ref()
-                .map(|_| "SECRET")
-                .unwrap_or("None")
-        )?;
-        writeln!(
-            f,
-            "disabled_paraswap_dexs: {:?}",
-            self.disabled_paraswap_dexs
-        )?;
-        write!(f, "paraswap_rate_limiter: ")?;
-        display_option(&self.paraswap_rate_limiter, f)?;
-        writeln!(f)?;
-        writeln!(
-            f,
-            "zeroex_url: {}",
-            self.zeroex_url.as_deref().unwrap_or("None")
-        )?;
-        writeln!(
-            f,
-            "zeroex_api_key: {}",
-            self.zeroex_api_key
-                .as_ref()
-                .map(|_| "SECRET")
-                .unwrap_or("None")
-        )?;
+        display_secret_option(f, "paraswap_partner: {}", &self.paraswap_partner)?;
+        display_list(f, "disabled_paraswap_dexs", &self.disabled_paraswap_dexs)?;
+        display_option(f, "paraswap_rate_limiter", &self.paraswap_rate_limiter)?;
+        display_option(f, "zeroex_url", &self.zeroex_url)?;
+        display_secret_option(f, "zeroex_api_key", &self.zeroex_api_key)?;
         writeln!(
             f,
             "quasimodo_uses_internal_buffers: {}",
@@ -268,33 +254,24 @@ impl Display for Arguments {
             self.mip_uses_internal_buffers
         )?;
         writeln!(f, "balancer_factories: {:?}", self.balancer_factories)?;
-        writeln!(
+        display_list(
             f,
-            "disabled_one_inch_protocols: {:?}",
-            self.disabled_one_inch_protocols
+            "disabled_one_inch_protocols",
+            &self.disabled_one_inch_protocols,
         )?;
         writeln!(f, "one_inch_url: {}", self.one_inch_url)?;
-        write!(f, "one_inch_referrer_address: ")?;
-        display_option(&self.one_inch_referrer_address.map(|a| format!("{a:?}")), f)?;
-        writeln!(f)?;
-        writeln!(
+        display_option(
             f,
-            "disabled_zeroex_sources: {:?}",
-            self.disabled_zeroex_sources
+            "one_inch_referrer_address",
+            &self.one_inch_referrer_address.map(|a| format!("{a:?}")),
         )?;
+        display_list(f, "disabled_zeroex_sources", &self.disabled_zeroex_sources)?;
         writeln!(
             f,
             "balancer_pool_deny_list: {:?}",
             self.balancer_pool_deny_list
         )?;
-        writeln!(
-            f,
-            "solver_competition_auth: {}",
-            self.solver_competition_auth
-                .as_ref()
-                .map(|_| "SECRET")
-                .unwrap_or("None")
-        )?;
+        display_secret_option(f, "solver_competition_auth", &self.solver_competition_auth)?;
         Ok(())
     }
 }

--- a/crates/solver/src/arguments.rs
+++ b/crates/solver/src/arguments.rs
@@ -293,17 +293,16 @@ impl std::fmt::Display for Arguments {
         writeln!(f, "quasimodo_solver_url: {}", self.quasimodo_solver_url)?;
         writeln!(f, "cow_dex_ag_solver_url: {}", self.cow_dex_ag_solver_url)?;
         writeln!(f, "balancer_sor_url: {}", self.balancer_sor_url)?;
-        writeln!(f, "solver_account: {:?}", self.solver_account)?;
-        writeln!(
+        display_option(
             f,
-            "target_confirm_time: {}s",
-            self.target_confirm_time.as_secs_f64()
+            "solver_account",
+            &self
+                .solver_account
+                .as_ref()
+                .map(|account| format!("{account:?}")),
         )?;
-        writeln!(
-            f,
-            "settle_interval: {}s",
-            self.settle_interval.as_secs_f64()
-        )?;
+        writeln!(f, "target_confirm_time: {:?}", self.target_confirm_time)?;
+        writeln!(f, "settle_interval: {:?}", self.settle_interval)?;
         writeln!(f, "solvers: {:?}", self.solvers)?;
         writeln!(f, "solver_accounts: {:?}", self.solver_accounts)?;
         display_list(
@@ -314,14 +313,10 @@ impl std::fmt::Display for Arguments {
                 .flatten()
                 .map(|solver| format!("{}|{}|{:?}", solver.name, solver.url, solver.account)),
         )?;
-        writeln!(f, "min_order_age: {}s", self.min_order_age.as_secs_f64())?;
+        writeln!(f, "min_order_age: {:?}", self.min_order_age)?;
         writeln!(f, "metrics_port: {}", self.metrics_port)?;
         writeln!(f, "max_merged_settlements: {}", self.max_merged_settlements)?;
-        writeln!(
-            f,
-            "solver_time_limit: {}",
-            self.solver_time_limit.as_secs_f64()
-        )?;
+        writeln!(f, "solver_time_limit: {:?}", self.solver_time_limit)?;
         writeln!(
             f,
             "market_makable_token_list: {}",
@@ -348,8 +343,8 @@ impl std::fmt::Display for Arguments {
         )?;
         writeln!(
             f,
-            "max_submission_seconds: {}s",
-            self.max_submission_seconds.as_secs_f64()
+            "max_submission_seconds: {:?}",
+            self.max_submission_seconds
         )?;
         writeln!(
             f,
@@ -358,8 +353,8 @@ impl std::fmt::Display for Arguments {
         )?;
         writeln!(
             f,
-            "submission_retry_interval_seconds: {}s",
-            self.submission_retry_interval_seconds.as_secs_f64()
+            "submission_retry_interval_seconds: {:?}",
+            self.submission_retry_interval_seconds
         )?;
         writeln!(
             f,

--- a/crates/solver/src/arguments.rs
+++ b/crates/solver/src/arguments.rs
@@ -4,7 +4,7 @@ use crate::{
 };
 use primitive_types::H160;
 use reqwest::Url;
-use shared::arguments::{display_list, display_option};
+use shared::arguments::{display_list, display_option, display_secret_option};
 use std::time::Duration;
 
 #[derive(clap::Parser)]
@@ -294,15 +294,34 @@ impl std::fmt::Display for Arguments {
         writeln!(f, "cow_dex_ag_solver_url: {}", self.cow_dex_ag_solver_url)?;
         writeln!(f, "balancer_sor_url: {}", self.balancer_sor_url)?;
         writeln!(f, "solver_account: {:?}", self.solver_account)?;
-        writeln!(f, "target_confirm_time: {:?}", self.target_confirm_time)?;
-        writeln!(f, "settle_interval: {:?}", self.settle_interval)?;
+        writeln!(
+            f,
+            "target_confirm_time: {}s",
+            self.target_confirm_time.as_secs_f64()
+        )?;
+        writeln!(
+            f,
+            "settle_interval: {}s",
+            self.settle_interval.as_secs_f64()
+        )?;
         writeln!(f, "solvers: {:?}", self.solvers)?;
         writeln!(f, "solver_accounts: {:?}", self.solver_accounts)?;
-        writeln!(f, "external_solvers: {:?}", self.external_solvers)?;
-        writeln!(f, "min_order_age: {:?}", self.min_order_age)?;
+        display_list(
+            f,
+            "external_solvers",
+            self.external_solvers
+                .iter()
+                .flatten()
+                .map(|solver| format!("{}|{}|{:?}", solver.name, solver.url, solver.account)),
+        )?;
+        writeln!(f, "min_order_age: {}s", self.min_order_age.as_secs_f64())?;
         writeln!(f, "metrics_port: {}", self.metrics_port)?;
         writeln!(f, "max_merged_settlements: {}", self.max_merged_settlements)?;
-        writeln!(f, "solver_time_limit: {:?}", self.solver_time_limit)?;
+        writeln!(
+            f,
+            "solver_time_limit: {}",
+            self.solver_time_limit.as_secs_f64()
+        )?;
         writeln!(
             f,
             "market_makable_token_list: {}",
@@ -316,23 +335,12 @@ impl std::fmt::Display for Arguments {
         writeln!(
             f,
             "access_list_estimators: {:?}",
-            self.access_list_estimators
+            &self.access_list_estimators
         )?;
-        write!(f, "tenderly_url: ")?;
-        display_option(&self.tenderly_url, f)?;
-        writeln!(f)?;
-        writeln!(
-            f,
-            "tenderly_api_key: {}",
-            self.tenderly_api_key
-                .as_deref()
-                .map(|_| "SECRET")
-                .unwrap_or("None")
-        )?;
+        display_option(f, "tenderly_url", &self.tenderly_url)?;
+        display_secret_option(f, "tenderly_api_key", &self.tenderly_api_key)?;
         writeln!(f, "eden_api_url: {}", self.eden_api_url)?;
-        write!(f, "flashbots_api_url: ")?;
-        display_list(self.flashbots_api_url.iter(), f)?;
-        writeln!(f)?;
+        display_list(f, "flashbots_api_url", &self.flashbots_api_url)?;
         writeln!(
             f,
             "max_additional_eden_tip: {}",
@@ -340,8 +348,8 @@ impl std::fmt::Display for Arguments {
         )?;
         writeln!(
             f,
-            "max_submission_seconds: {:?}",
-            self.max_submission_seconds
+            "max_submission_seconds: {}s",
+            self.max_submission_seconds.as_secs_f64()
         )?;
         writeln!(
             f,
@@ -350,17 +358,19 @@ impl std::fmt::Display for Arguments {
         )?;
         writeln!(
             f,
-            "submission_retry_interval_seconds: {:?}",
-            self.submission_retry_interval_seconds
+            "submission_retry_interval_seconds: {}s",
+            self.submission_retry_interval_seconds.as_secs_f64()
         )?;
         writeln!(
             f,
-            "additional_tip_percentage: {}",
+            "additional_tip_percentage: {}%",
             self.additional_tip_percentage
         )?;
-        write!(f, "transaction_submission_nodes: ")?;
-        display_list(self.transaction_submission_nodes.iter(), f)?;
-        writeln!(f)?;
+        display_list(
+            f,
+            "transaction_submission_nodes",
+            &self.transaction_submission_nodes,
+        )?;
         writeln!(
             f,
             "disable_high_risk_public_mempool_transactions: {}",
@@ -378,9 +388,11 @@ impl std::fmt::Display for Arguments {
         )?;
         writeln!(f, "weth_unwrap_factor: {}", self.weth_unwrap_factor)?;
         writeln!(f, "simulation_gas_limit: {}", self.simulation_gas_limit)?;
-        write!(f, "max_settlement_price_deviation: ")?;
-        display_option(&self.max_settlement_price_deviation, f)?;
-        writeln!(f)?;
+        display_option(
+            f,
+            "max_settlement_price_deviation",
+            &self.max_settlement_price_deviation,
+        )?;
         writeln!(
             f,
             "token_list_restriction_for_price_checks: {:?}",

--- a/crates/solver/src/solver.rs
+++ b/crates/solver/src/solver.rs
@@ -26,8 +26,9 @@ use shared::{
     baseline_solver::BaseTokens, conversions::U256Ext, token_info::TokenInfoFetching, Web3,
 };
 use single_order_solver::{SingleOrderSolver, SingleOrderSolving};
-use std::str::FromStr;
 use std::{
+    fmt::{self, Debug, Formatter},
+    str::FromStr,
     sync::Arc,
     time::{Duration, Instant},
 };
@@ -168,10 +169,19 @@ pub enum SolverType {
     BalancerSor,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub enum SolverAccountArg {
     PrivateKey(PrivateKey),
     Address(H160),
+}
+
+impl Debug for SolverAccountArg {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        match self {
+            SolverAccountArg::PrivateKey(k) => write!(f, "PrivateKey({:?})", k.public_address()),
+            SolverAccountArg::Address(a) => write!(f, "Address({a:?})"),
+        }
+    }
 }
 
 impl SolverAccountArg {


### PR DESCRIPTION
This PR refactors `arguments::display_*` to do a little more than just display the arguments. When implementing additional arguments flags for other PRs, I found the pattern required to use those helper methods quite tedious and error-prone (I would forget the `writeln` at the end, use `writeln` instead of `write` for the name, place another field between the `display_*` and `writeln!(f)` to name a few):
```rust
write!(f, "some_flag: ")?;
display_X(&f.some_flag, f)?;
writeln!(f)?;
```

Since the `arguments::display_*` methods are only ever used for fields, I thought it made sense to specialize them so its a bit more ergonomic to use:
```rust
display_X(f, "some_flag", &f.some_flag)?;
```

### Test Plan

Run the crates and see the formatted arguments still work (not included here as it would make the PR description too long).

#### Some highlights:

**Before:**
```
...
balancer_sor_url: price_estimation_rate_limiter: None
...
disabled_one_inch_protocols: ["PMM1"]
...
flashbots_api_url: [https://rpc.flashbots.net/, ]
...
additional_tip_percentage: 0.05
...
solver_account: Some(PrivateKey(PrivateKey(0x1111111111111111111111111111111111111111)))
...
external_solvers: Some([ExternalSolverArg { name: "example", url: Url { scheme: "https", cannot_be_a_base: false, username: "", password: None, host: Some(Domain("example.com")), port: None, path: "/", query: None, fragment: None }, account: Address(0x1111111111111111111111111111111111111111) }
...
```

**After:**
```
...

balancer_sor_url: None
price_estimation_rate_limiter: None
...
disabled_one_inch_protocols: [PMM1]
...
flashbots_api_url: [https://rpc.flashbots.net/]
...
additional_tip_percentage: 0.05%
...
solver_account: PrivateKey(0x1111111111111111111111111111111111111111)
...
external_solvers: [example|https://example.com/|Address(0x1111111111111111111111111111111111111111)]
...
```