### PR TITLE
Refactor token holder finding startup

### DIFF
--- a/crates/autopilot/src/arguments.rs
+++ b/crates/autopilot/src/arguments.rs
@@ -1,5 +1,8 @@
 use primitive_types::{H160, U256};
-use shared::{arguments::display_option, bad_token::token_owner_finder::FeeValues};
+use shared::{
+    arguments::display_option,
+    bad_token::token_owner_finder::{liquidity::FeeValues, TokenOwnerFindingStrategy},
+};
 use std::{net::SocketAddr, time::Duration};
 use url::Url;
 
@@ -31,11 +34,11 @@ pub struct Arguments {
     /// The fee value strategy to use for locating Uniswap V3 pools as token holders for bad token
     /// detection.
     #[clap(long, env, default_value = "static", arg_enum)]
-    pub token_detector_fee_values: FeeValues,
+    pub uniswapv3_token_owner_finder_fee_values: FeeValues,
 
-    /// Use Blockscout as a TokenOwnerFinding implementation.
-    #[clap(long, env)]
-    pub enable_blockscout: bool,
+    /// The token owner finding strategies to use.
+    #[clap(long, env, use_value_delimiter = true, arg_enum)]
+    pub token_owner_finders: Option<Vec<TokenOwnerFindingStrategy>>,
 
     /// The amount of time in seconds a classification of a token into good or bad is valid for.
     #[clap(
@@ -130,10 +133,10 @@ impl std::fmt::Display for Arguments {
         writeln!(f, "unsupported_tokens: {:?}", self.unsupported_tokens)?;
         writeln!(
             f,
-            "token_detector_fee_values: {:?}",
-            self.token_detector_fee_values
+            "uniswapv3_token_owner_finder_fee_values: {:?}",
+            self.uniswapv3_token_owner_finder_fee_values
         )?;
-        writeln!(f, "enable_blockscout: {}", self.enable_blockscout)?;
+        writeln!(f, "token_owner_finders: {:?}", self.token_owner_finders)?;
         writeln!(
             f,
             "token_quality_cache_expiry: {:?}",

--- a/crates/autopilot/src/lib.rs
+++ b/crates/autopilot/src/lib.rs
@@ -12,10 +12,7 @@ use shared::{
         cache::CachingDetector,
         instrumented::InstrumentedBadTokenDetectorExt,
         list_based::{ListBasedDetector, UnknownTokenStrategy},
-        token_owner_finder::{
-            blockscout::BlockscoutTokenOwnerFinder, BalancerVaultFinder, TokenOwnerFinding,
-            UniswapLikePairProviderFinder, UniswapV3Finder,
-        },
+        token_owner_finder,
         trace_call::TraceCallDetector,
     },
     balancer_sor_api::DefaultBalancerSorApi,
@@ -163,35 +160,20 @@ pub async fn main(args: arguments::Arguments) {
     allowed_tokens.push(model::order::BUY_ETH_ADDRESS);
     let unsupported_tokens = args.unsupported_tokens.clone();
 
-    let mut finders: Vec<Arc<dyn TokenOwnerFinding>> = pair_providers
-        .into_iter()
-        .map(|provider| -> Arc<dyn TokenOwnerFinding> {
-            Arc::new(UniswapLikePairProviderFinder {
-                inner: provider,
-                base_tokens: base_tokens.tokens().iter().copied().collect(),
-            })
-        })
-        .collect();
-    if let Some(contract) = &vault {
-        finders.push(Arc::new(BalancerVaultFinder(contract.clone())));
-    }
-    if let Some(contract) = uniswapv3_factory {
-        finders.push(Arc::new(
-            UniswapV3Finder::new(
-                contract,
-                base_tokens.tokens().iter().copied().collect(),
-                current_block,
-                args.token_detector_fee_values,
-            )
-            .await
-            .expect("create uniswapv3 finder"),
-        ));
-    }
-    if args.enable_blockscout {
-        if let Ok(finder) = BlockscoutTokenOwnerFinder::try_with_network(client.clone(), chain_id) {
-            finders.push(Arc::new(finder));
-        }
-    }
+    let finders = token_owner_finder::init(
+        args.token_owner_finders.as_deref(),
+        &pair_providers,
+        &base_tokens,
+        vault.as_ref(),
+        uniswapv3_factory.as_ref(),
+        current_block,
+        args.uniswapv3_token_owner_finder_fee_values,
+        &client,
+        chain_id,
+    )
+    .await
+    .expect("failed to initialize token owner finders");
+
     let trace_call_detector = TraceCallDetector {
         web3: web3.clone(),
         finders,

--- a/crates/shared/src/bad_token/token_owner_finder.rs
+++ b/crates/shared/src/bad_token/token_owner_finder.rs
@@ -88,7 +88,7 @@ pub async fn init(
         }
     }
 
-    if finders.contains(&TokenOwnerFindingStrategy::Liquidity) {
+    if finders.contains(&TokenOwnerFindingStrategy::Blockscout) {
         result.push(Arc::new(BlockscoutTokenOwnerFinder::try_with_network(
             client.clone(),
             chain_id,

--- a/crates/shared/src/bad_token/token_owner_finder.rs
+++ b/crates/shared/src/bad_token/token_owner_finder.rs
@@ -89,9 +89,10 @@ pub async fn init(
     }
 
     if finders.contains(&TokenOwnerFindingStrategy::Liquidity) {
-        if let Ok(finder) = BlockscoutTokenOwnerFinder::try_with_network(client.clone(), chain_id) {
-            result.push(Arc::new(finder));
-        }
+        result.push(Arc::new(BlockscoutTokenOwnerFinder::try_with_network(
+            client.clone(),
+            chain_id,
+        )?));
     }
 
     Ok(result)

--- a/crates/shared/src/bad_token/token_owner_finder.rs
+++ b/crates/shared/src/bad_token/token_owner_finder.rs
@@ -57,6 +57,7 @@ pub async fn init(
 ) -> Result<Vec<Arc<dyn TokenOwnerFinding>>> {
     let finders =
         finders.unwrap_or_else(|| TokenOwnerFindingStrategy::defaults_for_chain(chain_id));
+    tracing::debug!(?finders, "initializing token owner finders");
 
     let mut result = Vec::<Arc<dyn TokenOwnerFinding>>::new();
 

--- a/crates/shared/src/bad_token/token_owner_finder.rs
+++ b/crates/shared/src/bad_token/token_owner_finder.rs
@@ -1,14 +1,15 @@
-use crate::{
-    event_handling::MAX_REORG_BLOCK_COUNT,
-    sources::{uniswap_v2::pair_provider::PairProvider, uniswap_v3_pair_provider},
-};
-use anyhow::Result;
-use contracts::IUniswapV3Factory;
-use ethcontract::BlockNumber;
-use model::TokenPair;
-use primitive_types::H160;
-
 pub mod blockscout;
+pub mod liquidity;
+
+use self::{
+    blockscout::BlockscoutTokenOwnerFinder,
+    liquidity::{BalancerVaultFinder, FeeValues, UniswapLikePairProviderFinder, UniswapV3Finder},
+};
+use crate::{baseline_solver::BaseTokens, sources::uniswap_v2::pair_provider::PairProvider};
+use anyhow::Result;
+use contracts::{BalancerV2Vault, IUniswapV3Factory};
+use primitive_types::H160;
+use std::sync::Arc;
 
 /// To detect bad tokens we need to find some address on the network that owns the token so that we
 /// can use it in our simulations.
@@ -18,99 +19,79 @@ pub trait TokenOwnerFinding: Send + Sync {
     async fn find_candidate_owners(&self, token: H160) -> Result<Vec<H160>>;
 }
 
-pub struct UniswapLikePairProviderFinder {
-    pub inner: PairProvider,
-    pub base_tokens: Vec<H160>,
+/// Support token owner finding strategies.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, clap::ArgEnum)]
+pub enum TokenOwnerFindingStrategy {
+    /// Using baseline liquidity pools as token owners.
+    ///
+    /// The actual liquidity pools used depends on the configured baseline
+    /// liquidity.
+    Liquidity,
+
+    /// Use the Blockscout token holder API to find token holders.
+    Blockscout,
 }
 
-#[async_trait::async_trait]
-impl TokenOwnerFinding for UniswapLikePairProviderFinder {
-    async fn find_candidate_owners(&self, token: H160) -> Result<Vec<H160>> {
-        Ok(self
-            .base_tokens
-            .iter()
-            .filter_map(|&base_token| TokenPair::new(base_token, token))
-            .map(|pair| self.inner.pair_address(&pair))
-            .collect())
+impl TokenOwnerFindingStrategy {
+    /// Returns the default set of token owner finding strategies.
+    pub fn defaults_for_chain(chain_id: u64) -> &'static [Self] {
+        match chain_id {
+            1 | 100 => &[Self::Liquidity, Self::Blockscout],
+            _ => &[Self::Liquidity],
+        }
     }
 }
 
-/// The balancer vault contract contains all the balances of all pools.
-pub struct BalancerVaultFinder(pub contracts::BalancerV2Vault);
+/// Initializes a set of token owner finders.
+#[allow(clippy::too_many_arguments)]
+pub async fn init(
+    finders: Option<&[TokenOwnerFindingStrategy]>,
+    pair_providers: &[PairProvider],
+    base_tokens: &BaseTokens,
+    vault: Option<&BalancerV2Vault>,
+    uniswapv3_factory: Option<&IUniswapV3Factory>,
+    current_block: u64,
+    uniswapv3_fee_values: FeeValues,
+    client: &reqwest::Client,
+    chain_id: u64,
+) -> Result<Vec<Arc<dyn TokenOwnerFinding>>> {
+    let finders =
+        finders.unwrap_or_else(|| TokenOwnerFindingStrategy::defaults_for_chain(chain_id));
 
-#[async_trait::async_trait]
-impl TokenOwnerFinding for BalancerVaultFinder {
-    async fn find_candidate_owners(&self, _: H160) -> Result<Vec<H160>> {
-        Ok(vec![self.0.address()])
+    let mut result = Vec::<Arc<dyn TokenOwnerFinding>>::new();
+
+    if finders.contains(&TokenOwnerFindingStrategy::Liquidity) {
+        result.extend(
+            pair_providers
+                .iter()
+                .map(|provider| -> Arc<dyn TokenOwnerFinding> {
+                    Arc::new(UniswapLikePairProviderFinder {
+                        inner: provider.clone(),
+                        base_tokens: base_tokens.tokens().iter().copied().collect(),
+                    })
+                }),
+        );
+        if let Some(contract) = vault {
+            result.push(Arc::new(BalancerVaultFinder(contract.clone())));
+        }
+        if let Some(contract) = uniswapv3_factory {
+            result.push(Arc::new(
+                UniswapV3Finder::new(
+                    contract.clone(),
+                    base_tokens.tokens().iter().copied().collect(),
+                    current_block,
+                    uniswapv3_fee_values,
+                )
+                .await?,
+            ));
+        }
     }
-}
 
-pub struct UniswapV3Finder {
-    pub factory: IUniswapV3Factory,
-    pub base_tokens: Vec<H160>,
-    fee_values: Vec<u32>,
-}
-
-#[derive(Debug, Clone, Copy, clap::ArgEnum)]
-pub enum FeeValues {
-    /// Use hardcoded list
-    Static,
-    /// Fetch on creation based on events queried from node.
-    /// Some nodes struggle with the request and take a long time to respond leading to timeouts.
-    Dynamic,
-}
-
-impl UniswapV3Finder {
-    pub async fn new(
-        factory: IUniswapV3Factory,
-        base_tokens: Vec<H160>,
-        current_block: u64,
-        fee_values: FeeValues,
-    ) -> Result<Self> {
-        let fee_values = match fee_values {
-            FeeValues::Static => vec![500, 3000, 10000, 100],
-            // We fetch these once at start up because we don't expect them to change often.
-            // Alternatively could use a time based cache.
-            FeeValues::Dynamic => Self::fee_values(&factory, current_block).await?,
-        };
-        tracing::debug!(?fee_values);
-        Ok(Self {
-            factory,
-            base_tokens,
-            fee_values,
-        })
+    if finders.contains(&TokenOwnerFindingStrategy::Liquidity) {
+        if let Ok(finder) = BlockscoutTokenOwnerFinder::try_with_network(client.clone(), chain_id) {
+            result.push(Arc::new(finder));
+        }
     }
 
-    // Possible fee values as given by
-    // https://github.com/Uniswap/v3-core/blob/9161f9ae4aaa109f7efdff84f1df8d4bc8bfd042/contracts/UniswapV3Factory.sol#L26
-    async fn fee_values(factory: &IUniswapV3Factory, current_block: u64) -> Result<Vec<u32>> {
-        // We expect there to be few of these kind of events (currently there are 4) so fetching all
-        // of them is fine. Alternatively we could index these events in the database.
-        let events = factory
-            .events()
-            .fee_amount_enabled()
-            .from_block(BlockNumber::Earliest)
-            .to_block(BlockNumber::Number(
-                current_block.saturating_sub(MAX_REORG_BLOCK_COUNT).into(),
-            ))
-            .query()
-            .await?;
-        let fee_values = events.into_iter().map(|event| event.data.fee).collect();
-        Ok(fee_values)
-    }
-}
-
-#[async_trait::async_trait]
-impl TokenOwnerFinding for UniswapV3Finder {
-    async fn find_candidate_owners(&self, token: H160) -> Result<Vec<H160>> {
-        Ok(self
-            .base_tokens
-            .iter()
-            .filter_map(|base_token| TokenPair::new(*base_token, token))
-            .flat_map(|pair| self.fee_values.iter().map(move |fee| (pair, *fee)))
-            .map(|(pair, fee)| {
-                uniswap_v3_pair_provider::pair_address(&self.factory.address(), &pair, fee)
-            })
-            .collect())
-    }
+    Ok(result)
 }

--- a/crates/shared/src/bad_token/token_owner_finder/liquidity.rs
+++ b/crates/shared/src/bad_token/token_owner_finder/liquidity.rs
@@ -1,0 +1,108 @@
+//! Module containing liquidity-based token owner finding implementations.
+
+use super::TokenOwnerFinding;
+use crate::{
+    event_handling::MAX_REORG_BLOCK_COUNT,
+    sources::{uniswap_v2::pair_provider::PairProvider, uniswap_v3_pair_provider},
+};
+use anyhow::Result;
+use contracts::{BalancerV2Vault, IUniswapV3Factory};
+use ethcontract::{BlockNumber, H160};
+use model::TokenPair;
+
+pub struct UniswapLikePairProviderFinder {
+    pub inner: PairProvider,
+    pub base_tokens: Vec<H160>,
+}
+
+#[async_trait::async_trait]
+impl TokenOwnerFinding for UniswapLikePairProviderFinder {
+    async fn find_candidate_owners(&self, token: H160) -> Result<Vec<H160>> {
+        Ok(self
+            .base_tokens
+            .iter()
+            .filter_map(|&base_token| TokenPair::new(base_token, token))
+            .map(|pair| self.inner.pair_address(&pair))
+            .collect())
+    }
+}
+
+/// The balancer vault contract contains all the balances of all pools.
+pub struct BalancerVaultFinder(pub BalancerV2Vault);
+
+#[async_trait::async_trait]
+impl TokenOwnerFinding for BalancerVaultFinder {
+    async fn find_candidate_owners(&self, _: H160) -> Result<Vec<H160>> {
+        Ok(vec![self.0.address()])
+    }
+}
+
+pub struct UniswapV3Finder {
+    pub factory: IUniswapV3Factory,
+    pub base_tokens: Vec<H160>,
+    fee_values: Vec<u32>,
+}
+
+#[derive(Debug, Clone, Copy, clap::ArgEnum)]
+pub enum FeeValues {
+    /// Use hardcoded list
+    Static,
+    /// Fetch on creation based on events queried from node.
+    /// Some nodes struggle with the request and take a long time to respond leading to timeouts.
+    Dynamic,
+}
+
+impl UniswapV3Finder {
+    pub async fn new(
+        factory: IUniswapV3Factory,
+        base_tokens: Vec<H160>,
+        current_block: u64,
+        fee_values: FeeValues,
+    ) -> Result<Self> {
+        let fee_values = match fee_values {
+            FeeValues::Static => vec![500, 3000, 10000, 100],
+            // We fetch these once at start up because we don't expect them to change often.
+            // Alternatively could use a time based cache.
+            FeeValues::Dynamic => Self::fee_values(&factory, current_block).await?,
+        };
+        tracing::debug!(?fee_values);
+        Ok(Self {
+            factory,
+            base_tokens,
+            fee_values,
+        })
+    }
+
+    // Possible fee values as given by
+    // https://github.com/Uniswap/v3-core/blob/9161f9ae4aaa109f7efdff84f1df8d4bc8bfd042/contracts/UniswapV3Factory.sol#L26
+    async fn fee_values(factory: &IUniswapV3Factory, current_block: u64) -> Result<Vec<u32>> {
+        // We expect there to be few of these kind of events (currently there are 4) so fetching all
+        // of them is fine. Alternatively we could index these events in the database.
+        let events = factory
+            .events()
+            .fee_amount_enabled()
+            .from_block(BlockNumber::Earliest)
+            .to_block(BlockNumber::Number(
+                current_block.saturating_sub(MAX_REORG_BLOCK_COUNT).into(),
+            ))
+            .query()
+            .await?;
+        let fee_values = events.into_iter().map(|event| event.data.fee).collect();
+        Ok(fee_values)
+    }
+}
+
+#[async_trait::async_trait]
+impl TokenOwnerFinding for UniswapV3Finder {
+    async fn find_candidate_owners(&self, token: H160) -> Result<Vec<H160>> {
+        Ok(self
+            .base_tokens
+            .iter()
+            .filter_map(|base_token| TokenPair::new(*base_token, token))
+            .flat_map(|pair| self.fee_values.iter().map(move |fee| (pair, *fee)))
+            .map(|(pair, fee)| {
+                uniswap_v3_pair_provider::pair_address(&self.factory.address(), &pair, fee)
+            })
+            .collect())
+    }
+}

--- a/crates/shared/src/bad_token/trace_call.rs
+++ b/crates/shared/src/bad_token/trace_call.rs
@@ -308,7 +308,7 @@ fn ensure_transaction_ok_and_get_gas(trace: &BlockTrace) -> Result<Result<U256, 
 mod tests {
     use super::*;
     use crate::{
-        bad_token::token_owner_finder::{
+        bad_token::token_owner_finder::liquidity::{
             FeeValues, UniswapLikePairProviderFinder, UniswapV3Finder,
         },
         sources::{sushiswap, uniswap_v2},


### PR DESCRIPTION
This PR refactors how token owner finder initialization works.

Specifically, it:
1. Changes the command line arguments to expect a list of `TokenHolderFinderStrategies`. The idea here is that we plan on falling back to additional token holder APIs, and having separate `enable_...` flags for each is untenable.
2. Moves the liquidity-based token holder finder implementations to a separate module. The main motivation here is that the logic for finding a token holder with a minimum amount needs to move to a shared place. This is because various bad token detection implementations (Tenderly, storage override, etc.) will need a token holder address.
3. Shared initialization code - this ensures that the `autopilot` and `orderbook` are in-sync WRT token holder initialization logic.

### Test Plan

This PR is mostly a refactor. The only new logic is in the initialization, and how it chooses which token finders to initialize. Run the autopilot and make sure the defaults make sense:

```
% cargo run -p autopilot
...
2022-09-01T08:39:13.858Z DEBUG shared::bad_token::token_owner_finder: initializing token owner finders finders=[Liquidity, Blockscout]
...
```
