### PR TITLE
Added new Ethplorer based token holder API

### DIFF
--- a/crates/shared/src/bad_token/token_owner_finder.rs
+++ b/crates/shared/src/bad_token/token_owner_finder.rs
@@ -86,7 +86,8 @@ impl TokenOwnerFindingStrategy {
     /// Returns the default set of token owner finding strategies.
     pub fn defaults_for_chain(chain_id: u64) -> &'static [Self] {
         match chain_id {
-            1 | 100 => &[Self::Liquidity, Self::Blockscout],
+            1 => &[Self::Liquidity, Self::Blockscout, Self::Ethplorer],
+            100 => &[Self::Liquidity, Self::Blockscout],
             _ => &[Self::Liquidity],
         }
     }

--- a/crates/shared/src/bad_token/token_owner_finder.rs
+++ b/crates/shared/src/bad_token/token_owner_finder.rs
@@ -1,4 +1,5 @@
 pub mod blockscout;
+pub mod ethplorer;
 pub mod liquidity;
 
 use self::{
@@ -6,8 +7,10 @@ use self::{
     liquidity::{BalancerVaultFinder, FeeValues, UniswapLikePairProviderFinder, UniswapV3Finder},
 };
 use crate::{
-    arguments::duration_from_seconds, baseline_solver::BaseTokens,
-    ethcontract_error::EthcontractErrorType, sources::uniswap_v2::pair_provider::PairProvider,
+    arguments::duration_from_seconds,
+    bad_token::token_owner_finder::ethplorer::EthplorerTokenOwnerFinder,
+    baseline_solver::BaseTokens, ethcontract_error::EthcontractErrorType,
+    rate_limiter::RateLimitingStrategy, sources::uniswap_v2::pair_provider::PairProvider,
     transport::MAX_BATCH_SIZE, Web3, Web3CallBatch,
 };
 use anyhow::Result;
@@ -53,6 +56,14 @@ pub struct Arguments {
     /// Override the Blockscout token owner finder-specific timeout configuration.
     #[clap(long, parse(try_from_str = duration_from_seconds), default_value = "45")]
     pub blockscout_http_timeout: Duration,
+
+    /// The Ethplorer token holder API key.
+    pub ethplorer_api_key: Option<String>,
+
+    /// Token owner finding rate limiting strategy. See --price-estimation-rate-limiter
+    /// documentation for format details.
+    #[clap(long, env)]
+    pub token_owner_finder_rate_limiter: Option<RateLimitingStrategy>,
 }
 
 /// Support token owner finding strategies.
@@ -66,6 +77,9 @@ pub enum TokenOwnerFindingStrategy {
 
     /// Use the Blockscout token holder API to find token holders.
     Blockscout,
+
+    /// Use the Ethplorer token holder API.
+    Ethplorer,
 }
 
 impl TokenOwnerFindingStrategy {
@@ -150,6 +164,18 @@ pub async fn init(
                 args.blockscout_http_timeout,
             )?,
         ));
+    }
+
+    if finders.contains(&TokenOwnerFindingStrategy::Ethplorer) {
+        let mut ethplorer = EthplorerTokenOwnerFinder::try_with_network(
+            client.clone(),
+            args.ethplorer_api_key.clone(),
+            chain_id,
+        )?;
+        if let Some(strategy) = args.token_owner_finder_rate_limiter.clone() {
+            ethplorer.with_rate_limiter(strategy);
+        }
+        proposers.push(Arc::new(ethplorer));
     }
 
     Ok(Arc::new(TokenOwnerFinder { web3, proposers }))

--- a/crates/shared/src/bad_token/token_owner_finder/ethplorer.rs
+++ b/crates/shared/src/bad_token/token_owner_finder/ethplorer.rs
@@ -145,7 +145,7 @@ mod tests {
 
     #[tokio::test]
     #[ignore]
-    async fn test_blockscout_token_finding_mainnet() {
+    async fn token_finding_mainnet() {
         let finder =
             EthplorerTokenOwnerFinder::try_with_network(Client::default(), None, 1).unwrap();
         let owners = finder
@@ -156,7 +156,7 @@ mod tests {
 
     #[tokio::test]
     #[ignore]
-    async fn test_blockscout_token_finding_no_owners() {
+    async fn returns_no_owners_on_invalid_token() {
         let finder =
             EthplorerTokenOwnerFinder::try_with_network(Client::default(), None, 1).unwrap();
         let owners = finder

--- a/crates/shared/src/bad_token/token_owner_finder/ethplorer.rs
+++ b/crates/shared/src/bad_token/token_owner_finder/ethplorer.rs
@@ -113,7 +113,7 @@ impl Error {
 #[derive(MetricStorage, Clone, Debug)]
 #[metric(subsystem = "ethplorer_token_owner_finding")]
 struct Metrics {
-    /// Tracks number of "ok" or "err" responses from blockscout.
+    /// Tracks number of "ok" or "err" responses from ethplorer.
     #[metric(labels("result"))]
     results: IntCounterVec,
 }

--- a/crates/shared/src/bad_token/token_owner_finder/ethplorer.rs
+++ b/crates/shared/src/bad_token/token_owner_finder/ethplorer.rs
@@ -1,0 +1,167 @@
+use super::TokenOwnerProposing;
+use crate::rate_limiter::{back_off, RateLimiter, RateLimitingStrategy};
+use anyhow::{ensure, Result};
+use ethcontract::H160;
+use prometheus::IntCounterVec;
+use prometheus_metric_storage::MetricStorage;
+use reqwest::{Client, StatusCode, Url};
+use serde::Deserialize;
+
+const BASE: &str = "https://api.ethplorer.io/getTopTokenHolders/";
+const FREE_API_KEY: &str = "freekey";
+
+pub struct EthplorerTokenOwnerFinder {
+    client: Client,
+    base: Url,
+    api_key: String,
+
+    /// The low tiers for Ethplorer have very aggressive rate limiting, so be sure to setup a rate
+    /// limiter for Ethplorer requests.
+    rate_limiter: Option<RateLimiter>,
+}
+
+impl EthplorerTokenOwnerFinder {
+    pub fn try_with_network(
+        client: Client,
+        api_key: Option<String>,
+        chain_id: u64,
+    ) -> Result<Self> {
+        ensure!(chain_id == 1, "Ethplorer API unsupported network");
+        Ok(Self {
+            client,
+            base: Url::try_from(BASE).unwrap(),
+            api_key: api_key.unwrap_or_else(|| FREE_API_KEY.to_owned()),
+            rate_limiter: None,
+        })
+    }
+
+    pub fn with_rate_limiter(&mut self, strategy: RateLimitingStrategy) -> &mut Self {
+        self.rate_limiter = Some(RateLimiter::from_strategy(strategy, "ethplorer".to_owned()));
+        self
+    }
+
+    async fn query_owners(&self, token: H160) -> Result<Vec<H160>> {
+        let mut url = self.base.join(&format!("{token:?}"))?;
+        // We technically only need one candidate, returning the top 2 in case there
+        // is a race condition and tokens have just been transferred out.
+        url.query_pairs_mut().append_pair("limit", "2");
+
+        tracing::debug!(%url, "querying Ethplorer");
+        // Don't log the API key!
+        url.query_pairs_mut().append_pair("apiKey", &self.api_key);
+
+        let request = self.client.get(url).send();
+        let response = match &self.rate_limiter {
+            Some(limiter) => limiter.execute(request, back_off::on_http_429).await??,
+            _ => request.await?,
+        };
+
+        let status = response.status();
+        let status_result = response.error_for_status_ref().map(|_| ());
+        let body = response.text().await?;
+
+        tracing::debug!(%status, %body, "response from Ethplorer API");
+
+        // We need some special handling for "not a token contract" errors. In
+        // this case, we just want to return an empty token holder list to conform
+        // to the expectations of the `TokenHolderProposing` trait.
+        if status == StatusCode::BAD_REQUEST {
+            let err = serde_json::from_str::<Error>(&body)?;
+            if err.not_token_contract() {
+                return Ok(Default::default());
+            }
+        }
+        status_result?;
+
+        let parsed = serde_json::from_str::<Response>(&body)?;
+
+        Ok(parsed
+            .holders
+            .into_iter()
+            .map(|holder| holder.address)
+            .collect())
+    }
+}
+
+#[derive(Deserialize)]
+struct Response {
+    holders: Vec<Holder>,
+}
+
+#[derive(Deserialize)]
+struct Holder {
+    address: H160,
+}
+
+#[derive(Deserialize)]
+struct Error {
+    error: ErrorData,
+}
+
+#[derive(Deserialize)]
+struct ErrorData {
+    code: i64,
+}
+
+impl Error {
+    fn not_token_contract(&self) -> bool {
+        // https://github.com/EverexIO/Ethplorer/wiki/Ethplorer-API#error-codes
+        self.error.code == 150
+    }
+}
+
+#[derive(MetricStorage, Clone, Debug)]
+#[metric(subsystem = "ethplorer_token_owner_finding")]
+struct Metrics {
+    /// Tracks number of "ok" or "err" responses from blockscout.
+    #[metric(labels("result"))]
+    results: IntCounterVec,
+}
+
+#[async_trait::async_trait]
+impl TokenOwnerProposing for EthplorerTokenOwnerFinder {
+    async fn find_candidate_owners(&self, token: H160) -> Result<Vec<H160>> {
+        let metric = &Metrics::instance(global_metrics::get_metric_storage_registry())
+            .unwrap()
+            .results;
+
+        let result = self.query_owners(token).await;
+        match &result {
+            Ok(_) => metric.with_label_values(&["ok"]).inc(),
+            Err(err) => {
+                tracing::warn!(?err, "error finding token owners with Ethplorer");
+                metric.with_label_values(&["err"]).inc();
+            }
+        }
+
+        result
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use hex_literal::hex;
+
+    #[tokio::test]
+    #[ignore]
+    async fn test_blockscout_token_finding_mainnet() {
+        let finder =
+            EthplorerTokenOwnerFinder::try_with_network(Client::default(), None, 1).unwrap();
+        let owners = finder
+            .find_candidate_owners(H160(hex!("1337BedC9D22ecbe766dF105c9623922A27963EC")))
+            .await;
+        assert!(!owners.unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    #[ignore]
+    async fn test_blockscout_token_finding_no_owners() {
+        let finder =
+            EthplorerTokenOwnerFinder::try_with_network(Client::default(), None, 1).unwrap();
+        let owners = finder
+            .find_candidate_owners(H160(hex!("000000000000000000000000000000000000def1")))
+            .await;
+        assert!(owners.unwrap().is_empty());
+    }
+}

--- a/crates/shared/src/rate_limiter.rs
+++ b/crates/shared/src/rate_limiter.rs
@@ -211,6 +211,16 @@ impl RateLimiter {
     }
 }
 
+/// Shared module with common back-off checks.
+pub mod back_off {
+    use reqwest::Response;
+
+    /// Determines if the HTTP response indicates that the API should back off for a while.
+    pub fn on_http_429(response: &Result<Response, reqwest::Error>) -> bool {
+        matches!(response, Ok(response) if response.status() == 429)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
Fixes #206.

This PR adds an additional external token holder API as a `TokenHolderFinding` implementation. This API seems much snappier than Blockscout, but it does aggressive rate-limiting in the free tier (which is why I already included a `RateLimiter` instance with it).

Not too long ago Blockscout API went down for maintenance. With this change, we have another "backup" external token holder API to fall-back to in those cases.

### Test Plan

Some additional integration tests that can be run:

```
% cargo test -p shared -- ethplorer --ignored                
    Finished test [unoptimized + debuginfo] target(s) in 0.30s
     Running unittests src/lib.rs (target/debug/deps/shared-7e49af595ac95baf)

running 2 tests
test bad_token::token_owner_finder::ethplorer::tests::test_blockscout_token_finding_no_owners ... ok
test bad_token::token_owner_finder::ethplorer::tests::test_blockscout_token_finding_mainnet ... ok

test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 275 filtered out; finished in 0.29s
```
