### PR TITLE
Print full token address in prioce violation log

### DIFF
--- a/crates/solver/src/settlement.rs
+++ b/crates/solver/src/settlement.rs
@@ -440,7 +440,7 @@ impl Settlement {
                     .mul(&external_price_buy_token.mul(&clearing_price_sell_token)));
                 if !price_check_result {
                     tracing::debug!(
-                        token_pair =% format!("{}-{}", sell_token, buy_token),
+                        token_pair =% format!("{:?}-{:?}", sell_token, buy_token),
                         %solver_name, settlement =? self,
                         "price violation",
                     );


### PR DESCRIPTION
Need to debug log them to see the full address.

### Test Plan

CI still compiles