### PR TITLE
Allow configuration of separate tracing nodes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,7 +183,6 @@ Run an `autopilot` with:
 ```sh
 cargo run --bin autopilot -- \
   --skip-event-sync \
-  --skip-trace-api \
   --node-url <YOUR_NODE_URL>
 ```
 
@@ -197,11 +196,11 @@ Run an `orderbook` on `localhost:8080` with:
 
 ```sh
 cargo run --bin orderbook -- \
-  --skip-trace-api \
   --node-url <YOUR_NODE_URL>
 ```
 
-`--skip-trace-api` will make the orderbook compatible with more ethereum nodes. If your node supports `trace_callMany` you can drop this argument.
+If your node supports `trace_callMany`, or you have an additional node with tracing support, consider also specifying `--tracing-node-url <YOUR_NODE_URL>`.
+This will enable the tracing-based bad token detection.
 
 Note: Current version of the code does not compile under Windows OS. Context and workaround are [here](https://github.com/cowprotocol/services/issues/226).
 

--- a/crates/autopilot/src/arguments.rs
+++ b/crates/autopilot/src/arguments.rs
@@ -45,12 +45,6 @@ pub struct Arguments {
     )]
     pub token_quality_cache_expiry: Duration,
 
-    /// Don't use the trace_callMany api that only some nodes support to check whether a token
-    /// should be denied.
-    /// Note that if a node does not support the api we still use the less accurate call api.
-    #[clap(long, env)]
-    pub skip_trace_api: bool,
-
     /// The number of pairs that are automatically updated in the pool cache.
     #[clap(long, env, default_value = "200")]
     pub pool_cache_lru_size: usize,
@@ -134,7 +128,6 @@ impl std::fmt::Display for Arguments {
             "token_quality_cache_expiry: {:?}",
             self.token_quality_cache_expiry
         )?;
-        writeln!(f, "skip_trace_api: {}", self.skip_trace_api)?;
         writeln!(f, "pool_cache_lru_size: {}", self.pool_cache_lru_size)?;
         display_option(f, "balancer_sor_url", &self.balancer_sor_url)?;
         display_option(

--- a/crates/autopilot/src/arguments.rs
+++ b/crates/autopilot/src/arguments.rs
@@ -11,6 +11,11 @@ pub struct Arguments {
     #[clap(flatten)]
     pub token_owner_finder: token_owner_finder::Arguments,
 
+    /// A tracing Ethereum node URL to connect to, allowing a separate node URL
+    /// to be used exclusively for tracing calls.
+    #[clap(long, env)]
+    pub tracing_node_url: Option<Url>,
+
     #[clap(long, env, default_value = "0.0.0.0:9589")]
     pub metrics_address: SocketAddr,
 
@@ -118,6 +123,7 @@ impl std::fmt::Display for Arguments {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.shared)?;
         write!(f, "{}", self.token_owner_finder)?;
+        display_option(f, "tracing_node_url", &self.tracing_node_url)?;
         writeln!(f, "metrics_address: {}", self.metrics_address)?;
         writeln!(f, "db_url: SECRET")?;
         writeln!(f, "skip_event_sync: {}", self.skip_event_sync)?;

--- a/crates/autopilot/src/lib.rs
+++ b/crates/autopilot/src/lib.rs
@@ -160,28 +160,23 @@ pub async fn main(args: arguments::Arguments) {
     .await
     .expect("failed to initialize token owner finders");
 
-    let tracing_web3 = match &args.tracing_node_url {
-        Some(tracing_node_url) => shared::web3(&client, tracing_node_url, "trace"),
-        None => web3.clone(),
-    };
-    let trace_call_detector = TraceCallDetector {
-        web3: tracing_web3,
-        finder,
-        settlement_contract: settlement_contract.address(),
-    };
-    let caching_detector = CachingDetector::new(
-        Box::new(trace_call_detector),
-        args.token_quality_cache_expiry,
-    );
+    let trace_call_detector = args.tracing_node_url.as_ref().map(|tracing_node_url| {
+        Box::new(CachingDetector::new(
+            Box::new(TraceCallDetector {
+                web3: shared::web3(&client, tracing_node_url, "trace"),
+                finder,
+                settlement_contract: settlement_contract.address(),
+            }),
+            args.token_quality_cache_expiry,
+        ))
+    });
     let bad_token_detector = Arc::new(
         ListBasedDetector::new(
             allowed_tokens,
             unsupported_tokens,
-            if args.skip_trace_api {
-                UnknownTokenStrategy::Allow
-            } else {
-                UnknownTokenStrategy::Forward(Box::new(caching_detector))
-            },
+            trace_call_detector
+                .map(|detector| UnknownTokenStrategy::Forward(detector))
+                .unwrap_or(UnknownTokenStrategy::Allow),
         )
         .instrumented(),
     );

--- a/crates/orderbook/src/arguments.rs
+++ b/crates/orderbook/src/arguments.rs
@@ -66,12 +66,6 @@ pub struct Arguments {
     )]
     pub presign_onchain_quote_validity_seconds: Duration,
 
-    /// Don't use the trace_callMany api that only some nodes support to check whether a token
-    /// should be denied.
-    /// Note that if a node does not support the api we still use the less accurate call api.
-    #[clap(long, env)]
-    pub skip_trace_api: bool,
-
     /// The amount of time in seconds a classification of a token into good or bad is valid for.
     #[clap(
         long,
@@ -268,7 +262,6 @@ impl std::fmt::Display for Arguments {
             "presign_onchain_quote_validity_second: {:?}",
             self.presign_onchain_quote_validity_seconds
         )?;
-        writeln!(f, "skip_trace_api: {}", self.skip_trace_api)?;
         writeln!(
             f,
             "token_quality_cache_expiry: {:?}",

--- a/crates/orderbook/src/arguments.rs
+++ b/crates/orderbook/src/arguments.rs
@@ -17,6 +17,11 @@ pub struct Arguments {
     #[clap(flatten)]
     pub token_owner_finder: token_owner_finder::Arguments,
 
+    /// A tracing Ethereum node URL to connect to, allowing a separate node URL
+    /// to be used exclusively for tracing calls.
+    #[clap(long, env)]
+    pub tracing_node_url: Option<Url>,
+
     #[clap(long, env, default_value = "0.0.0.0:8080")]
     pub bind_address: SocketAddr,
 
@@ -240,6 +245,7 @@ impl std::fmt::Display for Arguments {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.shared)?;
         write!(f, "{}", self.token_owner_finder)?;
+        display_option(f, "tracing_node_url", &self.tracing_node_url)?;
         writeln!(f, "bind_address: {}", self.bind_address)?;
         writeln!(f, "db_url: SECRET")?;
         writeln!(

--- a/crates/shared/src/lib.rs
+++ b/crates/shared/src/lib.rs
@@ -37,10 +37,12 @@ pub mod univ3_router_api;
 pub mod web3_traits;
 pub mod zeroex_api;
 
+use self::transport::http::HttpTransport;
 use ethcontract::{
     batch::CallBatch,
     dyns::{DynTransport, DynWeb3},
 };
+use reqwest::{Client, Url};
 use std::{
     future::Future,
     time::{Duration, Instant},
@@ -57,6 +59,16 @@ pub fn http_client(timeout: Duration) -> reqwest::Client {
         .user_agent("cowprotocol-services/2.0.0")
         .build()
         .unwrap()
+}
+
+/// Create a Web3 instance.
+pub fn web3(client: &Client, url: &Url, name: impl ToString) -> Web3 {
+    let transport = Web3Transport::new(HttpTransport::new(
+        client.clone(),
+        url.clone(),
+        name.to_string(),
+    ));
+    Web3::new(transport)
 }
 
 /// Run a future and callback with the time the future took. The call back can for example log the

--- a/crates/solver/src/main.rs
+++ b/crates/solver/src/main.rs
@@ -19,9 +19,7 @@ use shared::{
     },
     token_info::{CachedTokenInfoFetcher, TokenInfoFetcher},
     token_list::TokenList,
-    transport::http::HttpTransport,
     zeroex_api::DefaultZeroExApi,
-    Web3Transport,
 };
 use solver::{
     arguments::TransactionStrategyArg,
@@ -58,12 +56,7 @@ async fn main() {
 
     let client = shared::http_client(args.shared.http_timeout);
 
-    let transport = Web3Transport::new(HttpTransport::new(
-        client.clone(),
-        args.shared.node_url,
-        "base".to_string(),
-    ));
-    let web3 = web3::Web3::new(transport);
+    let web3 = shared::web3(&client, &args.shared.node_url, "base");
     let chain_id = web3
         .eth()
         .chain_id()
@@ -305,14 +298,7 @@ async fn main() {
         .transaction_submission_nodes
         .into_iter()
         .enumerate()
-        .map(|(index, url)| {
-            let transport = Web3Transport::new(HttpTransport::new(
-                client.clone(),
-                url.clone(),
-                index.to_string(),
-            ));
-            (web3::Web3::new(transport), url)
-        })
+        .map(|(index, url)| (shared::web3(&client, &url, index), url))
         .collect::<Vec<_>>();
     for (node, url) in &submission_nodes_with_url {
         let node_network_id = node


### PR DESCRIPTION
This PR adds a separate `--tracing-node-url` parameter for allowing a separate node URL to for the `trace_callMany` calls.

It is possible that tracing nodes are harder to run and/or more expensive with external node providers. With this change, we have more flexibility with how we split our RPC calls (for example, we can have separate plans for our regular Ethereum RPC calls, and a special plan - with much less traffic - for our `trace_callMany` calls).

Additionally, we deprecate the no-longer-needed `--skip-trace-api` parameter, using the presence of the `--tracing-node-url` as an indicator of whether or not tracing API is supported.

### Test Plan

CI. Check that we are instantiating separate nodes:
```
% cargo run -p orderbook -- --node-url $NODE_URL --tracing-node-url $NODE_URL
2022-09-03T14:24:15.269Z DEBUG request{id=1}: shared::transport::http: [trace][id:17] sending request: "{\"jsonrpc\":\"2.0\",\"method\":\"trace_callMany\",...}"
```

### Release Notes

- [x] Configure deployments to specify `--trace-node-url` parameter to enable tracing