### PR TITLE
Use tracing span for submission loop

### DIFF
--- a/crates/solver/src/settlement_submission.rs
+++ b/crates/solver/src/settlement_submission.rs
@@ -240,7 +240,7 @@ impl SolutionSubmitter {
             .submit(settlement, params)
             .instrument(tracing::info_span!(
                 "submission",
-                name = strategy_args.submit_api.name().as_str(),
+                name = %strategy_args.submit_api.name(),
                 i = index
             ))
             .await

--- a/crates/solver/src/settlement_submission.rs
+++ b/crates/solver/src/settlement_submission.rs
@@ -25,6 +25,7 @@ use submitter::{
     DisabledReason, Strategy, Submitter, SubmitterGasPriceEstimator, SubmitterParams,
     TransactionHandle, TransactionSubmitting,
 };
+use tracing::Instrument;
 use web3::types::TransactionReceipt;
 
 const ESTIMATE_GAS_LIMIT_FACTOR: f64 = 1.2;
@@ -201,7 +202,12 @@ impl SolutionSubmitter {
                             strategy_args.sub_tx_pool.clone(),
                             self.max_gas_price_bumps
                         )?;
-                        submitter.submit(settlement.clone(), params).await
+                        submitter.submit(settlement.clone(), params)
+                            .instrument(tracing::info_span!(
+                                "submission",
+                                name = strategy_args.submit_api.name().as_str()
+                            ))
+                            .await
                     }
                     .boxed()
                 })

--- a/crates/solver/src/settlement_submission.rs
+++ b/crates/solver/src/settlement_submission.rs
@@ -160,55 +160,16 @@ impl SolutionSubmitter {
             let mut futures = self
                 .transaction_strategies
                 .iter()
-                .map(|strategy| {
-                    async {
-                        // Needed so that the compiler understands that we don't
-                        // want to move `strategy` into the closure but use a
-                        // reference to it.
-                        #[allow(clippy::borrow_deref_ref)]
-                        match &*strategy {
-                            TransactionStrategy::Eden(_) | TransactionStrategy::Flashbots(_) => {
-                                if !matches!(account, Account::Offline(..)) {
-                                    return Err(SubmissionError::from(anyhow!(
-                                        "Submission to private network requires offline account for signing"
-                                    )));
-                                }
-                            }
-                            TransactionStrategy::CustomNodes(_) => {}
-                            TransactionStrategy::DryRun => unreachable!(),
-                        };
-
-                        let strategy_args = strategy.strategy_args().expect("unreachable code executed");
-                        let params = SubmitterParams {
-                            target_confirm_time: self.target_confirm_time,
-                            gas_estimate,
-                            deadline: Some(Instant::now() + self.max_confirm_time),
-                            retry_interval: self.retry_interval,
-                            network_id: network_id.clone(),
-                        };
-                        let gas_price_estimator = SubmitterGasPriceEstimator {
-                            inner: self.gas_price_estimator.as_ref(),
-                            gas_price_cap: self.gas_price_cap,
-                            additional_tip_percentage_of_max_fee: Some(strategy_args.additional_tip_percentage_of_max_fee),
-                            max_additional_tip: Some(strategy_args.max_additional_tip),
-                            pending_gas_price: None,
-                        };
-                        let submitter = Submitter::new(
-                            &self.contract,
-                            &account,
-                            strategy_args.submit_api.as_ref(),
-                            &gas_price_estimator,
-                            self.access_list_estimator.as_ref(),
-                            strategy_args.sub_tx_pool.clone(),
-                            self.max_gas_price_bumps
-                        )?;
-                        submitter.submit(settlement.clone(), params)
-                            .instrument(tracing::info_span!(
-                                "submission",
-                                name = strategy_args.submit_api.name().as_str()
-                            ))
-                            .await
-                    }
+                .enumerate()
+                .map(|(i, strategy)| {
+                    self.settle_with_strategy(
+                        strategy,
+                        &account,
+                        gas_estimate,
+                        network_id.clone(),
+                        settlement.clone(),
+                        i,
+                    )
                     .boxed()
                 })
                 .collect::<Vec<_>>();
@@ -226,6 +187,63 @@ impl SolutionSubmitter {
                 }
             }
         }
+    }
+
+    async fn settle_with_strategy(
+        &self,
+        strategy: &TransactionStrategy,
+        account: &Account,
+        gas_estimate: U256,
+        network_id: String,
+        settlement: Settlement,
+        index: usize,
+    ) -> Result<TransactionReceipt, SubmissionError> {
+        match strategy {
+            TransactionStrategy::Eden(_) | TransactionStrategy::Flashbots(_) => {
+                if !matches!(account, Account::Offline(..)) {
+                    return Err(SubmissionError::from(anyhow!(
+                        "Submission to private network requires offline account for signing"
+                    )));
+                }
+            }
+            TransactionStrategy::CustomNodes(_) => {}
+            TransactionStrategy::DryRun => unreachable!(),
+        };
+
+        let strategy_args = strategy.strategy_args().expect("unreachable code executed");
+        let params = SubmitterParams {
+            target_confirm_time: self.target_confirm_time,
+            gas_estimate,
+            deadline: Some(Instant::now() + self.max_confirm_time),
+            retry_interval: self.retry_interval,
+            network_id,
+        };
+        let gas_price_estimator = SubmitterGasPriceEstimator {
+            inner: self.gas_price_estimator.as_ref(),
+            gas_price_cap: self.gas_price_cap,
+            additional_tip_percentage_of_max_fee: Some(
+                strategy_args.additional_tip_percentage_of_max_fee,
+            ),
+            max_additional_tip: Some(strategy_args.max_additional_tip),
+            pending_gas_price: None,
+        };
+        let submitter = Submitter::new(
+            &self.contract,
+            account,
+            strategy_args.submit_api.as_ref(),
+            &gas_price_estimator,
+            self.access_list_estimator.as_ref(),
+            strategy_args.sub_tx_pool.clone(),
+            self.max_gas_price_bumps,
+        )?;
+        submitter
+            .submit(settlement, params)
+            .instrument(tracing::info_span!(
+                "submission",
+                name = strategy_args.submit_api.name().as_str(),
+                i = index
+            ))
+            .await
     }
 }
 

--- a/crates/solver/src/settlement_submission/submitter.rs
+++ b/crates/solver/src/settlement_submission/submitter.rs
@@ -68,6 +68,16 @@ pub enum Strategy {
     CustomNodes,
 }
 
+impl Strategy {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Strategy::Eden => "eden",
+            Strategy::Flashbots => "flashbots",
+            Strategy::CustomNodes => "custom_nodes",
+        }
+    }
+}
+
 impl fmt::Display for Strategy {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{:?}", self)
@@ -230,11 +240,7 @@ impl<'a> Submitter<'a> {
         let nonce = self.nonce().await?;
         let name = self.submit_api.name();
 
-        tracing::debug!(
-            "starting solution submission at nonce {} with submitter {}",
-            nonce,
-            name
-        );
+        tracing::debug!("starting solution submission at nonce {}", nonce);
 
         self.submitted_transactions.remove_older_than(nonce);
 
@@ -266,15 +272,15 @@ impl<'a> Submitter<'a> {
 
         let fallback_result = tokio::select! {
             method_error = submit_future.fuse() => {
-                tracing::debug!("stopping submission for {} because simulation failed: {:?}", name, method_error);
+                tracing::debug!("stopping submission because simulation failed: {:?}", method_error);
                 Err(method_error)
             },
             new_nonce = nonce_future.fuse() => {
-                tracing::debug!("stopping submission for {} because account nonce changed to {}", name, new_nonce);
+                tracing::debug!("stopping submission because account nonce changed to {}", new_nonce);
                 Ok(None)
             },
             _ = deadline_future.fuse() => {
-                tracing::debug!("stopping submission for {} because deadline has been reached. cancelling last submitted transaction...", name);
+                tracing::debug!("stopping submission because deadline has been reached. cancelling last submitted transaction...");
 
                 if let Some((_, gas_price)) = transactions.last() {
                     let gas_price = gas_price.bump(GAS_PRICE_BUMP).ceil();
@@ -313,9 +319,8 @@ impl<'a> Submitter<'a> {
             let tx_to_propagate_deadline = Instant::now() + MINED_TX_PROPAGATE_TIME;
 
             tracing::debug!(
-                "waiting up to {} seconds for {} to see if a transaction was mined",
+                "waiting up to {} seconds to see if a transaction was mined",
                 MINED_TX_PROPAGATE_TIME.as_secs(),
-                name
             );
 
             let transactions = transactions
@@ -328,7 +333,7 @@ impl<'a> Submitter<'a> {
                     find_mined_transaction(&self.contract.raw_instance().web3(), &transactions)
                         .await
                 {
-                    tracing::debug!("{} found mined transaction {:?}", name, receipt);
+                    tracing::debug!("found mined transaction {:?}", receipt);
                     track_mined_transactions(&format!("{name}"));
                     return status(receipt);
                 }
@@ -339,7 +344,7 @@ impl<'a> Submitter<'a> {
             }
         }
 
-        tracing::debug!("{} did not find any mined transaction", name);
+        tracing::debug!("did not find any mined transaction");
         fallback_result
             .transpose()
             .unwrap_or(Err(SubmissionError::Timeout))
@@ -382,14 +387,12 @@ impl<'a> Submitter<'a> {
         params: &SubmitterParams,
         transactions: &mut Vec<(TransactionHandle, GasPrice1559)>,
     ) -> SubmissionError {
-        let submitter_name = self.submit_api.name();
         let target_confirm_time = Instant::now() + params.target_confirm_time;
 
         let mut allowed_gas_price_bumps = 1i32;
 
         tracing::debug!(
-            "submit_with_increasing_gas_prices_until_simulation_fails entered with submitter: {}",
-            submitter_name
+            "submit_with_increasing_gas_prices_until_simulation_fails entered with submitter",
         );
 
         // Try to find submitted transaction from previous submission loop (with the same address and nonce)
@@ -398,18 +401,14 @@ impl<'a> Submitter<'a> {
         let mut access_list: Option<AccessList> = None;
 
         loop {
-            tracing::debug!("entered loop with submitter: {}", submitter_name);
+            tracing::debug!("entered loop with submitter");
 
             let submission_status = self
                 .submit_api
                 .submission_status(&settlement, &params.network_id);
             let estimator = match submission_status {
                 SubmissionLoopStatus::Disabled(reason) => {
-                    tracing::debug!(
-                        "strategy {} temporarily disabled, reason: {:?}",
-                        submitter_name,
-                        reason
-                    );
+                    tracing::debug!("strategy temporarily disabled, reason: {:?}", reason);
                     return SubmissionError::from(anyhow!("strategy temporarily disabled"));
                 }
                 SubmissionLoopStatus::Enabled(AdditionalTip::Off) => self
@@ -496,30 +495,23 @@ impl<'a> Submitter<'a> {
             }
 
             tracing::debug!(
-                "creating transaction with gas price (base_fee={}, max_fee={}, tip={}), gas estimate {}, submitter name: {}",
+                "creating transaction with gas price (base_fee={}, max_fee={}, tip={}), gas estimate {}",
                 gas_price.base_fee_per_gas,
                 gas_price.max_fee_per_gas,
                 gas_price.max_priority_fee_per_gas,
                 params.gas_estimate,
-                submitter_name,
             );
 
             // execute transaction
 
             match self.submit_api.submit_transaction(method.tx).await {
                 Ok(handle) => {
-                    tracing::debug!(
-                        submitter = %submitter_name, ?handle,
-                        "submitted transaction",
-                    );
+                    tracing::debug!(?handle, "submitted transaction",);
                     transactions.push((handle, gas_price));
                     allowed_gas_price_bumps = 1;
                 }
                 Err(err) => {
-                    tracing::warn!(
-                        submitter = %submitter_name, ?err,
-                        "submission failed",
-                    );
+                    tracing::warn!(?err, "submission failed",);
                     let err = err.to_string();
                     if err.contains("underpriced") || err.contains("already known") {
                         allowed_gas_price_bumps = std::cmp::min(

--- a/crates/solver/src/settlement_submission/submitter.rs
+++ b/crates/solver/src/settlement_submission/submitter.rs
@@ -68,16 +68,6 @@ pub enum Strategy {
     CustomNodes,
 }
 
-impl Strategy {
-    pub fn as_str(&self) -> &'static str {
-        match self {
-            Strategy::Eden => "eden",
-            Strategy::Flashbots => "flashbots",
-            Strategy::CustomNodes => "custom_nodes",
-        }
-    }
-}
-
 impl fmt::Display for Strategy {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{:?}", self)


### PR DESCRIPTION
Right now it's quite tricky to follow what each submission strategy is doing (eden, flashbots, custom nodes) because they are all running concurrently. Many log statements have the submission name in them but not all and it's easy to forget to add the name when adding a new log.

To address both issues I added a tracing info span to the call site of `Submitter::submit()` method.
The tracing span obviously has to contain the submission API name, but since some submission APIs can be instantiated multiples times (custom nodes, flashbots) I also added the index of the submission strategy to the tracing span.

Because the borrow checker was not happy with me trying to copy the index into the async block I ended up moving the logic into a helper function which made it easier to specify which values have to be owned and which values can be borrowed in the async block.

### Test Plan
Ran local solver on rinkeby with `PublicMempool` submission strategy. It resulted in errors but all that matters is that the tracing span showed up:
```
2022-09-07T08:09:25.826Z DEBUG auction{id=1098728 run=3}:submission{name=CustomNodes i=0}: solver::settlement_submission::submitter: starting solution submission at nonce 368
2022-09-07T08:09:25.826Z DEBUG auction{id=1098728 run=3}:submission{name=CustomNodes i=0}: solver::settlement_submission::submitter: submit_with_increasing_gas_prices_until_simulation_fails entered with submitter
2022-09-07T08:09:25.826Z DEBUG auction{id=1098728 run=3}:submission{name=CustomNodes i=0}: solver::settlement_submission::submitter: entered loop with submitter
2022-09-07T08:09:25.828Z DEBUG auction{id=1098728 run=3}:submission{name=CustomNodes i=0}: solver::settlement_submission::submitter: access list not created, reason: no access list. no estimators defined or all estimators failed
2022-09-07T08:09:25.955Z DEBUG auction{id=1098728 run=3}:submission{name=CustomNodes i=0}: solver::settlement_submission::submitter: creating transaction with gas price (base_fee=10, max_fee=2060003118.791417, tip=1030001550.0806017), gas estimate 196049
2022-09-07T08:09:25.956Z DEBUG auction{id=1098728 run=3}:submission{name=CustomNodes i=0}: solver::settlement_submission::submitter::custom_nodes_api: Custom nodes submit transaction entered
2022-09-07T08:09:25.956Z DEBUG auction{id=1098728 run=3}:submission{name=CustomNodes i=0}: solver::settlement_submission::submitter::custom_nodes_api: sending transaction... label=custom_nodes_0
2022-09-07T08:09:26.077Z  WARN auction{id=1098728 run=3}:submission{name=CustomNodes i=0}: solver::settlement_submission::submitter::custom_nodes_api: single custom node tx failed err=Rpc(Error { code: MethodNotFound, message: "The method eth_sendTransaction does not exist/is not available", data: None }) label=custom_nodes_0
2022-09-07T08:09:26.079Z  WARN auction{id=1098728 run=3}:submission{name=CustomNodes i=0}: solver::settlement_submission::submitter: submission failed err=all custom nodes tx failed

Caused by:
    0: RPC error: Error { code: MethodNotFound, message: "The method eth_sendTransaction does not exist/is not available", data: None }
    1: Method not found: The method eth_sendTransaction does not exist/is not available
```