### PR TITLE
Refactor `TenderlyApi` for reuse in bad token detection

### DIFF
--- a/crates/driver/src/arguments.rs
+++ b/crates/driver/src/arguments.rs
@@ -126,9 +126,13 @@ pub struct Arguments {
     #[clap(long, env, arg_enum, ignore_case = true, use_value_delimiter = true)]
     pub access_list_estimators: Vec<AccessListEstimatorType>,
 
-    /// The URL for tenderly transaction simulation.
+    /// The Tenderly user associated with the API key.
     #[clap(long, env)]
-    pub tenderly_url: Option<Url>,
+    pub tenderly_user: Option<String>,
+
+    /// The Tenderly project associated with the API key.
+    #[clap(long, env)]
+    pub tenderly_project: Option<String>,
 
     /// Tenderly requires api key to work. Optional since Tenderly could be skipped in access lists estimators.
     #[clap(long, env)]
@@ -310,7 +314,8 @@ impl std::fmt::Display for Arguments {
             "access_list_estimators: {:?}",
             self.access_list_estimators
         )?;
-        display_option(f, "tenderly_url", &self.tenderly_url)?;
+        display_option(f, "tenderly_user", &self.tenderly_project)?;
+        display_option(f, "tenderly_project", &self.tenderly_project)?;
         display_secret_option(f, "tenderly_api_key", &self.tenderly_api_key)?;
         writeln!(f, "simulation_gas_limit: {}", self.simulation_gas_limit)?;
         writeln!(f, "max_gas_price_bumps: {}", self.max_gas_price_bumps)?;

--- a/crates/driver/src/main.rs
+++ b/crates/driver/src/main.rs
@@ -20,6 +20,7 @@ use shared::{
         uniswap_v3::pool_fetching::UniswapV3PoolFetcher,
         BaselineSource,
     },
+    tenderly_api::{TenderlyApi, TenderlyHttpApi},
     token_info::{CachedTokenInfoFetcher, TokenInfoFetcher, TokenInfoFetching},
     zeroex_api::DefaultZeroExApi,
 };
@@ -36,7 +37,6 @@ use solver::{
     settlement_access_list::AccessListEstimating,
     settlement_ranker::SettlementRanker,
     settlement_rater::SettlementRater,
-    settlement_simulation::TenderlyApi,
     settlement_submission::{
         submitter::{
             custom_nodes_api::CustomNodesApi, eden_api::EdenApi, flashbots_api::FlashbotsApi,
@@ -58,6 +58,7 @@ struct CommonComponents {
     chain_id: u64,
     settlement_contract: contracts::GPv2Settlement,
     native_token_contract: WETH9,
+    tenderly_api: Option<Arc<dyn TenderlyApi>>,
     access_list_estimator: Arc<dyn AccessListEstimating>,
     gas_price_estimator: Arc<dyn GasPriceEstimating>,
     order_converter: Arc<OrderConverter>,
@@ -85,13 +86,22 @@ async fn init_common_components(args: &Arguments) -> CommonComponents {
     let native_token_contract = WETH9::deployed(&web3)
         .await
         .expect("couldn't load deployed native token");
+    let tenderly_api = Some(()).and_then(|_| {
+        Some(Arc::new(
+            TenderlyHttpApi::new(
+                &http_factory,
+                args.tenderly_user.as_deref()?,
+                args.tenderly_project.as_deref()?,
+                args.tenderly_api_key.as_deref()?,
+            )
+            .expect("failed to create Tenderly API"),
+        ) as Arc<dyn TenderlyApi>)
+    });
     let access_list_estimator = Arc::new(
         solver::settlement_access_list::create_priority_estimator(
-            &http_factory,
             &web3,
             args.access_list_estimators.as_slice(),
-            args.tenderly_url.clone(),
-            args.tenderly_api_key.clone(),
+            tenderly_api.clone(),
             network_id.clone(),
         )
         .expect("failed to create access list estimator"),
@@ -126,6 +136,7 @@ async fn init_common_components(args: &Arguments) -> CommonComponents {
         chain_id,
         settlement_contract,
         native_token_contract,
+        tenderly_api,
         access_list_estimator,
         gas_price_estimator,
         order_converter,
@@ -481,11 +492,6 @@ async fn build_drivers(common: &CommonComponents, args: &Arguments) -> Vec<(Arc<
         web3: common.web3.clone(),
     });
     let auction_converter = build_auction_converter(common, args).await.unwrap();
-    let tenderly = args
-        .tenderly_url
-        .clone()
-        .zip(args.tenderly_api_key.clone())
-        .and_then(|(url, api_key)| TenderlyApi::new(&common.http_factory, url, &api_key).ok());
     let metrics = Arc::new(Metrics::new().unwrap());
 
     let settlement_ranker = Arc::new(SettlementRanker {
@@ -501,7 +507,7 @@ async fn build_drivers(common: &CommonComponents, args: &Arguments) -> Vec<(Arc<
         metrics,
         settlement_contract: common.settlement_contract.clone(),
         simulation_gas_limit: args.simulation_gas_limit,
-        tenderly,
+        tenderly: common.tenderly_api.clone(),
     });
 
     solvers

--- a/crates/e2e/tests/e2e/eth_integration.rs
+++ b/crates/e2e/tests/e2e/eth_integration.rs
@@ -240,10 +240,8 @@ async fn eth_integration(web3: Web3) {
             ],
             access_list_estimator: Arc::new(
                 create_priority_estimator(
-                    &http_factory,
                     &web3,
                     &[AccessListEstimatorType::Web3],
-                    None,
                     None,
                     network_id,
                 )

--- a/crates/e2e/tests/e2e/onchain_settlement.rs
+++ b/crates/e2e/tests/e2e/onchain_settlement.rs
@@ -242,10 +242,8 @@ async fn onchain_settlement(web3: Web3) {
             ],
             access_list_estimator: Arc::new(
                 create_priority_estimator(
-                    &http_factory,
                     &web3,
                     &[AccessListEstimatorType::Web3],
-                    None,
                     None,
                     network_id,
                 )

--- a/crates/e2e/tests/e2e/settlement_without_onchain_liquidity.rs
+++ b/crates/e2e/tests/e2e/settlement_without_onchain_liquidity.rs
@@ -231,10 +231,8 @@ async fn onchain_settlement_without_liquidity(web3: Web3) {
             ],
             access_list_estimator: Arc::new(
                 create_priority_estimator(
-                    &http_factory,
                     &web3,
                     &[AccessListEstimatorType::Web3],
-                    None,
                     None,
                     network_id,
                 )

--- a/crates/e2e/tests/e2e/smart_contract_orders.rs
+++ b/crates/e2e/tests/e2e/smart_contract_orders.rs
@@ -271,10 +271,8 @@ async fn smart_contract_orders(web3: Web3) {
             ],
             access_list_estimator: Arc::new(
                 create_priority_estimator(
-                    &http_factory,
                     &web3,
                     &[AccessListEstimatorType::Web3],
-                    None,
                     None,
                     network_id,
                 )

--- a/crates/e2e/tests/e2e/vault_balances.rs
+++ b/crates/e2e/tests/e2e/vault_balances.rs
@@ -183,10 +183,8 @@ async fn vault_balances(web3: Web3) {
             ],
             access_list_estimator: Arc::new(
                 create_priority_estimator(
-                    &http_factory,
                     &web3,
                     &[AccessListEstimatorType::Web3],
-                    None,
                     None,
                     network_id,
                 )

--- a/crates/shared/src/lib.rs
+++ b/crates/shared/src/lib.rs
@@ -34,6 +34,7 @@ pub mod signature_validator;
 pub mod solver_utils;
 pub mod sources;
 pub mod subgraph;
+pub mod tenderly_api;
 pub mod token_info;
 pub mod token_list;
 pub mod trace_many;

--- a/crates/shared/src/tenderly_api.rs
+++ b/crates/shared/src/tenderly_api.rs
@@ -1,0 +1,222 @@
+//! Module containing Tenderly API implementation.
+
+use crate::{http_client::HttpClientFactory, transport::extensions::StateOverrides};
+use anyhow::Result;
+use reqwest::{
+    header::{HeaderMap, HeaderValue},
+    Url,
+};
+use serde::{Deserialize, Serialize};
+use std::sync::Arc;
+use web3::types::{H160, H256, U256};
+
+/// Trait for abstracting Tenderly API.
+#[async_trait::async_trait]
+pub trait TenderlyApi: Send + Sync + 'static {
+    async fn block_number(&self, network_id: &str) -> Result<u64>;
+    async fn simulate(&self, simulation: SimulationRequest) -> Result<SimulationResponse>;
+}
+
+const BASE_URL: &str = "https://api.tenderly.co/api";
+
+/// Tenderly HTTP API.
+pub struct TenderlyHttpApi {
+    url: Url,
+    client: reqwest::Client,
+}
+
+impl TenderlyHttpApi {
+    /// Creates a new Tenderly API
+    pub fn new(
+        http_factory: &HttpClientFactory,
+        user: &str,
+        project: &str,
+        api_key: &str,
+    ) -> Result<Self> {
+        let mut api_key = HeaderValue::from_str(api_key)?;
+        api_key.set_sensitive(true);
+
+        let mut headers = HeaderMap::new();
+        headers.insert("x-access-key", api_key);
+
+        Ok(Self {
+            url: Url::parse(&format!("{BASE_URL}/v1/account/{user}/project/{project}/"))?,
+            client: http_factory.configure(|builder| builder.default_headers(headers)),
+        })
+    }
+
+    /// Creates a Tenderly API from the environment for testing.
+    pub fn test_from_env() -> Arc<dyn TenderlyApi> {
+        Arc::new(
+            Self::new(
+                &HttpClientFactory::default(),
+                &std::env::var("TENDERLY_USER").unwrap(),
+                &std::env::var("TENDERLY_PROJECT").unwrap(),
+                &std::env::var("TENDERLY_API_KEY").unwrap(),
+            )
+            .unwrap(),
+        )
+    }
+}
+
+#[async_trait::async_trait]
+impl TenderlyApi for TenderlyHttpApi {
+    async fn block_number(&self, network_id: &str) -> Result<u64> {
+        Ok(self
+            .client
+            .get(format!("{BASE_URL}/v1/network/{network_id}/block-number"))
+            .send()
+            .await?
+            .error_for_status()?
+            .json::<BlockNumber>()
+            .await?
+            .block_number)
+    }
+
+    async fn simulate(&self, simulation: SimulationRequest) -> Result<SimulationResponse> {
+        Ok(self
+            .client
+            .post(self.url.join("simulate")?)
+            .json(&simulation)
+            .send()
+            .await?
+            .error_for_status()?
+            .json()
+            .await?)
+    }
+}
+
+#[derive(Deserialize)]
+pub struct BlockNumber {
+    pub block_number: u64,
+}
+
+#[derive(Clone, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
+pub struct SimulationRequest {
+    pub network_id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub block_number: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub transaction_index: Option<u64>,
+    pub from: H160,
+    pub to: H160,
+    #[serde(with = "model::bytes_hex")]
+    pub input: Vec<u8>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub gas: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub gas_price: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub value: Option<U256>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub simulation_kind: Option<SimulationKind>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub save: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub save_if_fails: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub generate_access_list: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub state_objects: Option<StateOverrides>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum SimulationKind {
+    Full,
+    Quick,
+}
+
+#[derive(Clone, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
+pub struct SimulationResponse {
+    pub transaction: Transaction,
+    pub generated_access_list: Option<Vec<AccessListItem>>,
+}
+
+#[derive(Clone, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
+pub struct Transaction {
+    pub status: bool,
+    pub gas_used: u64,
+}
+
+// Had to introduce copy of the web3 AccessList because tenderly responds with snake_case fields
+// and tenderly storage_keys field does not exist if empty (it should be empty Vec instead)
+#[derive(Clone, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
+pub struct AccessListItem {
+    /// Accessed address
+    pub address: H160,
+    /// Accessed storage keys
+    #[serde(default)]
+    pub storage_keys: Vec<H256>,
+}
+
+impl From<AccessListItem> for web3::types::AccessListItem {
+    fn from(item: AccessListItem) -> Self {
+        Self {
+            address: item.address,
+            storage_keys: item.storage_keys,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use hex_literal::hex;
+    use serde_json::json;
+
+    #[test]
+    fn serialize_deserialize_simulation_request() {
+        let request = SimulationRequest {
+            network_id: "1".to_string(),
+            block_number: Some(14122310),
+            from: addr!("e92f359e6f05564849afa933ce8f62b8007a1d5d"),
+            input: hex!("13d79a0b00000000000000000000000000000000000000000000").into(),
+            to: addr!("9008d19f58aabd9ed0d60971565aa8510560ab41"),
+            generate_access_list: Some(true),
+            transaction_index: None,
+            gas: None,
+            ..Default::default()
+        };
+
+        let json = json!({
+            "network_id": "1",
+            "block_number": 14122310,
+            "from": "0xe92f359e6f05564849afa933ce8f62b8007a1d5d",
+            "input": "0x13d79a0b00000000000000000000000000000000000000000000",
+            "to": "0x9008d19f58aabd9ed0d60971565aa8510560ab41",
+            "generate_access_list": true
+        });
+
+        assert_eq!(serde_json::to_value(&request).unwrap(), json);
+        assert_eq!(
+            serde_json::from_value::<SimulationRequest>(json).unwrap(),
+            request
+        );
+    }
+
+    #[tokio::test]
+    #[ignore]
+    async fn get_block_number() {
+        let tenderly = TenderlyHttpApi::test_from_env();
+        let block_number = tenderly.block_number("1").await.unwrap();
+        assert!(block_number > 0);
+    }
+
+    #[tokio::test]
+    #[ignore]
+    async fn simulate_transaction() {
+        let tenderly = TenderlyHttpApi::test_from_env();
+        let result = tenderly
+            .simulate(SimulationRequest {
+                network_id: "1".to_string(),
+                to: addr!("9008d19f58aabd9ed0d60971565aa8510560ab41"),
+                simulation_kind: Some(SimulationKind::Quick),
+                ..Default::default()
+            })
+            .await
+            .unwrap();
+
+        assert!(result.transaction.status);
+    }
+}

--- a/crates/solver/src/arguments.rs
+++ b/crates/solver/src/arguments.rs
@@ -176,9 +176,13 @@ pub struct Arguments {
     #[clap(long, env, arg_enum, ignore_case = true, use_value_delimiter = true)]
     pub access_list_estimators: Vec<AccessListEstimatorType>,
 
-    /// The URL for tenderly transaction simulation.
+    /// The Tenderly user associated with the API key.
     #[clap(long, env)]
-    pub tenderly_url: Option<Url>,
+    pub tenderly_user: Option<String>,
+
+    /// The Tenderly project associated with the API key.
+    #[clap(long, env)]
+    pub tenderly_project: Option<String>,
 
     /// Tenderly requires api key to work. Optional since Tenderly could be skipped in access lists estimators.
     #[clap(long, env)]
@@ -344,7 +348,8 @@ impl std::fmt::Display for Arguments {
             "access_list_estimators: {:?}",
             &self.access_list_estimators
         )?;
-        display_option(f, "tenderly_url", &self.tenderly_url)?;
+        display_option(f, "tenderly_user", &self.tenderly_user)?;
+        display_option(f, "tenderly_project", &self.tenderly_project)?;
         display_secret_option(f, "tenderly_api_key", &self.tenderly_api_key)?;
         writeln!(f, "eden_api_url: {}", self.eden_api_url)?;
         display_list(f, "flashbots_api_url", &self.flashbots_api_url)?;

--- a/crates/solver/src/driver.rs
+++ b/crates/solver/src/driver.rs
@@ -12,7 +12,7 @@ use crate::{
     settlement_post_processing::PostProcessingPipeline,
     settlement_ranker::SettlementRanker,
     settlement_rater::SettlementRater,
-    settlement_simulation::{self, TenderlyApi},
+    settlement_simulation,
     settlement_submission::{SolutionSubmitter, SubmissionError},
     solver::{Auction, Solver, SolverRunError, Solvers},
 };
@@ -31,6 +31,7 @@ use primitive_types::{H160, U256};
 use shared::{
     current_block::{self, CurrentBlockStream},
     recent_block_cache::Block,
+    tenderly_api::TenderlyApi,
     token_list::TokenList,
     Web3,
 };
@@ -84,7 +85,7 @@ impl Driver {
         fee_objective_scaling_factor: f64,
         max_settlement_price_deviation: Option<Ratio<BigInt>>,
         token_list_restriction_for_price_checks: PriceCheckTokens,
-        tenderly: Option<TenderlyApi>,
+        tenderly: Option<Arc<dyn TenderlyApi>>,
     ) -> Self {
         let post_processing_pipeline = PostProcessingPipeline::new(
             native_token,

--- a/crates/solver/src/driver_logger.rs
+++ b/crates/solver/src/driver_logger.rs
@@ -4,7 +4,7 @@ use crate::{
     metrics::SolverMetrics,
     settlement::Settlement,
     settlement_simulation::{
-        simulate_and_error_with_tenderly_link, simulate_before_after_access_list, TenderlyApi,
+        simulate_and_error_with_tenderly_link, simulate_before_after_access_list,
     },
     settlement_submission::SubmissionError,
     solver::{SettlementWithError, Solver},
@@ -16,7 +16,7 @@ use itertools::Itertools;
 use model::order::{Order, OrderKind};
 use num::{BigRational, ToPrimitive};
 use primitive_types::H256;
-use shared::Web3;
+use shared::{tenderly_api::TenderlyApi, Web3};
 use std::sync::Arc;
 use tracing::{Instrument as _, Span};
 use web3::types::{AccessList, TransactionReceipt};
@@ -24,7 +24,7 @@ use web3::types::{AccessList, TransactionReceipt};
 pub struct DriverLogger {
     pub metrics: Arc<dyn SolverMetrics>,
     pub web3: Web3,
-    pub tenderly: Option<TenderlyApi>,
+    pub tenderly: Option<Arc<dyn TenderlyApi>>,
     pub network_id: String,
     pub settlement_contract: GPv2Settlement,
     pub simulation_gas_limit: u128,
@@ -34,7 +34,7 @@ impl DriverLogger {
     pub async fn metric_access_list_gas_saved(&self, transaction_hash: H256) -> Result<()> {
         let gas_saved = simulate_before_after_access_list(
             &self.web3,
-            self.tenderly.as_ref().context("tenderly disabled")?,
+            self.tenderly.as_deref().context("tenderly disabled")?,
             self.network_id.clone(),
             transaction_hash,
         )

--- a/crates/solver/src/settlement_simulation.rs
+++ b/crates/solver/src/settlement_simulation.rs
@@ -7,17 +7,15 @@ use ethcontract::{
     dyns::{DynMethodBuilder, DynTransport},
     errors::ExecutionError,
     transaction::TransactionBuilder,
-    Account, Address,
+    Account,
 };
 use futures::FutureExt;
 use gas_estimation::GasPrice1559;
 use primitive_types::{H160, H256, U256};
-use reqwest::{
-    header::{HeaderMap, HeaderValue},
-    Client, IntoUrl, Url,
+use shared::{
+    tenderly_api::{SimulationRequest, TenderlyApi},
+    Web3,
 };
-use serde::{de::DeserializeOwned, Deserialize, Serialize};
-use shared::{http_client::HttpClientFactory, Web3};
 use web3::types::{AccessList, BlockId};
 
 const SIMULATE_BATCH_SIZE: usize = 10;
@@ -124,19 +122,9 @@ pub async fn simulate_and_error_with_tenderly_link(
         .collect()
 }
 
-#[derive(Debug, Clone, Deserialize)]
-struct TenderlyResponse {
-    transaction: TenderlyTransaction,
-}
-
-#[derive(Debug, Clone, Deserialize)]
-struct TenderlyTransaction {
-    gas_used: u64,
-}
-
 pub async fn simulate_before_after_access_list(
     web3: &Web3,
-    tenderly: &TenderlyApi,
+    tenderly: &dyn TenderlyApi,
     network_id: String,
     transaction_hash: H256,
 ) -> Result<f64> {
@@ -165,22 +153,18 @@ pub async fn simulate_before_after_access_list(
             .as_u64(),
     );
 
-    let request = TenderlyRequest {
+    let request = SimulationRequest {
         network_id,
-        block_number,
+        block_number: Some(block_number),
+        transaction_index: Some(transaction_index),
         from,
         input: transaction.input.0,
         to,
         gas: Some(transaction.gas.as_u64()),
-        generate_access_list: false,
-        transaction_index: Some(transaction_index),
+        ..Default::default()
     };
 
-    let gas_used_without_access_list = tenderly
-        .send::<TenderlyResponse>(request)
-        .await?
-        .transaction
-        .gas_used;
+    let gas_used_without_access_list = tenderly.simulate(request).await?.transaction.gas_used;
     let gas_used_with_access_list = web3
         .eth()
         .transaction_receipt(transaction_hash)
@@ -257,74 +241,6 @@ pub fn tenderly_link(
     )
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
-pub struct TenderlyRequest {
-    pub network_id: String,
-    pub block_number: u64,
-    pub from: Address,
-    #[serde(with = "model::bytes_hex")]
-    pub input: Vec<u8>,
-    pub to: Address,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub gas: Option<u64>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub transaction_index: Option<u64>,
-    pub generate_access_list: bool,
-}
-
-#[derive(Debug, Clone, Deserialize)]
-pub struct BlockNumber {
-    pub block_number: u64,
-}
-
-#[derive(Debug)]
-pub struct TenderlyApi {
-    url: Url,
-    client: Client,
-}
-
-impl TenderlyApi {
-    pub fn new(http_factory: &HttpClientFactory, url: impl IntoUrl, api_key: &str) -> Result<Self> {
-        let mut api_key = HeaderValue::from_str(api_key)?;
-        api_key.set_sensitive(true);
-
-        let mut headers = HeaderMap::new();
-        headers.insert("x-access-key", api_key);
-
-        Ok(Self {
-            client: http_factory.configure(|builder| builder.default_headers(headers)),
-            url: url.into_url()?,
-        })
-    }
-
-    pub async fn send<T>(&self, body: TenderlyRequest) -> reqwest::Result<T>
-    where
-        T: DeserializeOwned,
-    {
-        self.client
-            .post(self.url.clone())
-            .json(&body)
-            .send()
-            .await?
-            .error_for_status()?
-            .json()
-            .await
-    }
-
-    pub async fn block_number(&self, network_id: &str) -> reqwest::Result<BlockNumber> {
-        self.client
-            .get(format!(
-                "https://api.tenderly.co/api/v1/network/{}/block-number",
-                network_id
-            ))
-            .send()
-            .await?
-            .error_for_status()?
-            .json()
-            .await
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -342,6 +258,7 @@ mod tests {
     use serde_json::json;
     use shared::http_solver::model::SettledBatchAuctionModel;
     use shared::sources::balancer_v2::pools::{common::TokenState, stable::AmplificationParameter};
+    use shared::tenderly_api::TenderlyHttpApi;
     use shared::transport::create_env_test_transport;
     use std::str::FromStr;
     use std::sync::{Arc, Mutex};
@@ -785,16 +702,10 @@ mod tests {
         let transaction_hash =
             H256::from_str("e337fcd52afd6b98847baab279cda6c3980fcb185da9e959fd489ffd210eac60")
                 .unwrap();
-        let tenderly_api = TenderlyApi::new(
-            &HttpClientFactory::default(),
-            // http://api.tenderly.co/api/v1/account/<USER_NAME>/project/<PROJECT_NAME>/simulate
-            Url::parse(&std::env::var("TENDERLY_URL").unwrap()).unwrap(),
-            &std::env::var("TENDERLY_API_KEY").unwrap(),
-        )
-        .unwrap();
+        let tenderly_api = TenderlyHttpApi::test_from_env();
         let gas_saved = simulate_before_after_access_list(
             &web3,
-            &tenderly_api,
+            &*tenderly_api,
             "1".to_string(),
             transaction_hash,
         )

--- a/crates/solver/src/settlement_submission/submitter.rs
+++ b/crates/solver/src/settlement_submission/submitter.rs
@@ -655,19 +655,16 @@ fn track_mined_transactions(submitter: &str) {
 
 #[cfg(test)]
 mod tests {
-
-    use std::sync::Arc;
-
-    use crate::settlement_access_list::{create_priority_estimator, AccessListEstimatorType};
-
     use super::super::submitter::flashbots_api::FlashbotsApi;
     use super::*;
+    use crate::settlement_access_list::{create_priority_estimator, AccessListEstimatorType};
     use ethcontract::PrivateKey;
     use gas_estimation::blocknative::BlockNative;
     use reqwest::Client;
-    use shared::gas_price_estimation::FakeGasPriceEstimator;
-    use shared::http_client::HttpClientFactory;
-    use shared::transport::create_env_test_transport;
+    use shared::{
+        gas_price_estimation::FakeGasPriceEstimator, transport::create_env_test_transport,
+    };
+    use std::sync::Arc;
     use tracing::level_filters::LevelFilter;
 
     #[tokio::test]
@@ -706,10 +703,8 @@ mod tests {
         };
         let access_list_estimator = Arc::new(
             create_priority_estimator(
-                &HttpClientFactory::default(),
                 &web3,
                 &[AccessListEstimatorType::Web3],
-                None,
                 None,
                 "1".to_string(),
             )


### PR DESCRIPTION
This PR refactors the `TenderlyApi` type to more closely follow our other API implementations. Namely:
- Define a `TenderlyApi` trait
- Define a `TenderlyHttpApi` implementation for it

We need to split out the `TenderlyApi` into something that can also be re-used for trade simulation and bad token detection. Specifically, not all nodes support `eth_call` with state overrides, but Tenderly does - so it can be used as an alternative for `eth_call` with state override and `trace_callMany` bad token detection.

### Test Plan

CI. Existing tests continue to pass.

Additionally, existing integration test continues to pass.

### Release notes

The `--tenderly-url` flag was replaced by `--tenderly-user` and `--tenderly-project`.
- [ ] Adjust the deployment configuration to account for the new options.