### PR TITLE
Implement Component for Simulating EVM Bytecode

### DIFF
--- a/crates/model/src/bytes_hex.rs
+++ b/crates/model/src/bytes_hex.rs
@@ -1,6 +1,7 @@
 //! Serialization of Vec<u8> to 0x prefixed hex string
 
 use serde::{de::Error, Deserialize, Deserializer, Serializer};
+use serde_with::{DeserializeAs, SerializeAs};
 use std::borrow::Cow;
 
 pub fn serialize<S, T>(bytes: T, serializer: S) -> Result<S::Ok, S::Error>
@@ -26,6 +27,29 @@ where
         .strip_prefix("0x")
         .ok_or_else(|| D::Error::custom("missing '0x' prefix"))?;
     hex::decode(hex_str).map_err(D::Error::custom)
+}
+
+pub struct BytesHex(());
+
+impl<T> SerializeAs<T> for BytesHex
+where
+    T: AsRef<[u8]>,
+{
+    fn serialize_as<S>(bytes: &T, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serialize(bytes, serializer)
+    }
+}
+
+impl<'de> DeserializeAs<'de, Vec<u8>> for BytesHex {
+    fn deserialize_as<D>(deserializer: D) -> Result<Vec<u8>, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        deserialize(deserializer)
+    }
 }
 
 #[cfg(test)]

--- a/crates/shared/src/bad_token/roundtrip.rs
+++ b/crates/shared/src/bad_token/roundtrip.rs
@@ -105,12 +105,6 @@ mod tests {
     use ethcontract::{dyns::DynMethodBuilder, tokens::Tokenize};
     use maplit::hashmap;
 
-    macro_rules! bytes {
-        ($x:literal) => {
-            ::web3::types::Bytes(::hex_literal::hex!($x).to_vec())
-        };
-    }
-
     fn interaction<R>(method: DynMethodBuilder<R>) -> Interaction
     where
         R: Tokenize,

--- a/crates/shared/src/code_simulation.rs
+++ b/crates/shared/src/code_simulation.rs
@@ -1,0 +1,177 @@
+//! Abstraction for simulating calls with overrides.
+
+use crate::{
+    tenderly_api::{SimulationKind, SimulationRequest, TenderlyApi},
+    transport::extensions::{EthExt as _, StateOverrides},
+    Web3,
+};
+use anyhow::{bail, Context as _, Result};
+use std::sync::Arc;
+use web3::types::{BlockNumber, CallRequest};
+
+/// Simulate a call with state overrides.
+#[async_trait::async_trait]
+pub trait CodeSimulating {
+    async fn simulate(&self, call: CallRequest, overrides: StateOverrides) -> Result<Vec<u8>>;
+}
+
+#[async_trait::async_trait]
+impl CodeSimulating for Web3 {
+    async fn simulate(&self, call: CallRequest, overrides: StateOverrides) -> Result<Vec<u8>> {
+        Ok(self
+            .eth()
+            .call_with_state_overrides(call, BlockNumber::Latest.into(), overrides)
+            .await?
+            .0)
+    }
+}
+
+pub struct TenderlyCodeSimlator {
+    tenderly: Arc<dyn TenderlyApi>,
+    network_id: String,
+}
+
+impl TenderlyCodeSimlator {
+    pub fn new(tenderly: Arc<dyn TenderlyApi>, network_id: String) -> Self {
+        Self {
+            tenderly,
+            network_id,
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl CodeSimulating for TenderlyCodeSimlator {
+    async fn simulate(&self, call: CallRequest, overrides: StateOverrides) -> Result<Vec<u8>> {
+        let result = self
+            .tenderly
+            .simulate(SimulationRequest {
+                network_id: self.network_id.clone(),
+                from: call.to.unwrap_or_default(),
+                to: call.to.unwrap_or_default(),
+                input: call.data.unwrap_or_default().0,
+                gas: call.gas.map(|g| g.as_u64()),
+                gas_price: call.gas_price.map(|p| p.as_u64()),
+                value: call.value,
+                simulation_kind: Some(SimulationKind::Quick),
+                state_objects: Some(overrides),
+                ..Default::default()
+            })
+            .await?;
+
+        let trace = result
+            .transaction
+            .call_trace
+            .into_iter()
+            .next()
+            .context("Tenderly simulation missing call trace")?;
+
+        if let Some(err) = trace.error {
+            bail!("Tenderly simulation error: {err}");
+        }
+
+        trace
+            .output
+            .context("Tenderly simulation missing transaction output")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        tenderly_api::TenderlyHttpApi,
+        transport::{create_env_test_transport, extensions::StateOverride},
+    };
+    use maplit::hashmap;
+
+    #[ignore]
+    #[tokio::test]
+    async fn can_simulate_contract_code() {
+        let web3 = Web3::new(create_env_test_transport());
+        let network_id = web3.net().version().await.unwrap();
+
+        for simulator in [
+            Arc::new(web3) as Arc<dyn CodeSimulating>,
+            Arc::new(TenderlyCodeSimlator::new(
+                TenderlyHttpApi::test_from_env(),
+                network_id,
+            )),
+        ] {
+            let address = addr!("EeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE");
+            let output = simulator
+                .simulate(
+                    CallRequest {
+                        to: Some(address),
+                        ..Default::default()
+                    },
+                    hashmap! {
+                        address => StateOverride {
+                            // EVM program to just returns the Answer to Life,
+                            // the Universe, and Everything.
+                            code: Some(bytes!(
+                                "60 2a
+                                 60 00
+                                 53
+                                 60 01
+                                 60 00
+                                 f3"
+                            )),
+                            ..Default::default()
+                        },
+                    },
+                )
+                .await
+                .unwrap();
+
+            assert_eq!(output, [42]);
+        }
+    }
+
+    #[ignore]
+    #[tokio::test]
+    async fn errors_on_reverts() {
+        let web3 = Web3::new(create_env_test_transport());
+        let network_id = web3.net().version().await.unwrap();
+
+        for simulator in [
+            Arc::new(web3) as Arc<dyn CodeSimulating>,
+            Arc::new(TenderlyCodeSimlator::new(
+                TenderlyHttpApi::test_from_env(),
+                network_id,
+            )),
+        ] {
+            let address = addr!("EeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE");
+            let result = simulator
+                .simulate(
+                    CallRequest {
+                        to: Some(address),
+                        ..Default::default()
+                    },
+                    hashmap! {
+                        address => StateOverride {
+                            // EVM program revert with a message.
+                            code: Some(bytes!(
+                                "60 64
+                                 80
+                                 60 0b
+                                 60 00
+                                 39
+                                 60 00
+                                 fd
+
+                                 08c379a0
+                                 0000000000000000000000000000000000000000000000000000000000000020
+                                 0000000000000000000000000000000000000000000000000000000000000004
+                                 706f6f7000000000000000000000000000000000000000000000000000000000"
+                            )),
+                            ..Default::default()
+                        },
+                    },
+                )
+                .await;
+
+            assert!(result.is_err());
+        }
+    }
+}

--- a/crates/shared/src/lib.rs
+++ b/crates/shared/src/lib.rs
@@ -7,6 +7,7 @@ pub mod arguments;
 pub mod bad_token;
 pub mod balancer_sor_api;
 pub mod baseline_solver;
+pub mod code_simulation;
 pub mod conversions;
 pub mod current_block;
 pub mod db_order_conversions;

--- a/crates/shared/src/macros.rs
+++ b/crates/shared/src/macros.rs
@@ -15,6 +15,13 @@ macro_rules! bfp {
 }
 
 #[macro_export]
+macro_rules! bytes {
+    ($x:literal) => {
+        ::ethcontract::web3::types::Bytes(::hex_literal::hex!($x).to_vec())
+    };
+}
+
+#[macro_export]
 macro_rules! json_map {
     ($($key:expr => $value:expr),* $(,)?) => {{
         #[allow(unused_mut)]

--- a/crates/shared/src/tenderly_api.rs
+++ b/crates/shared/src/tenderly_api.rs
@@ -144,6 +144,7 @@ pub struct Transaction {
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
 pub struct CallTrace {
+    #[serde(default)]
     #[serde_as(as = "Option<BytesHex>")]
     pub output: Option<Vec<u8>>,
     pub error: Option<String>,

--- a/crates/shared/src/tenderly_api.rs
+++ b/crates/shared/src/tenderly_api.rs
@@ -2,6 +2,7 @@
 
 use crate::{http_client::HttpClientFactory, transport::extensions::StateOverrides};
 use anyhow::Result;
+use model::bytes_hex::BytesHex;
 use reqwest::{
     header::{HeaderMap, HeaderValue},
     Url,
@@ -137,6 +138,15 @@ pub struct SimulationResponse {
 pub struct Transaction {
     pub status: bool,
     pub gas_used: u64,
+    pub call_trace: Vec<CallTrace>,
+}
+
+#[serde_with::serde_as]
+#[derive(Clone, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
+pub struct CallTrace {
+    #[serde_as(as = "Option<BytesHex>")]
+    pub output: Option<Vec<u8>>,
+    pub error: Option<String>,
 }
 
 // Had to introduce copy of the web3 AccessList because tenderly responds with snake_case fields

--- a/crates/shared/src/transport/extensions.rs
+++ b/crates/shared/src/transport/extensions.rs
@@ -78,7 +78,6 @@ pub struct StateOverride {
 mod tests {
     use super::*;
     use crate::{transport::create_env_test_transport, Web3};
-    use hex_literal::hex;
     use maplit::hashmap;
     use web3::types::BlockNumber;
 
@@ -100,17 +99,14 @@ mod tests {
                 hashmap! {
                     address => StateOverride {
                         // EVM program to just return 32 bytes from 0 to 31
-                        code: Some(Bytes(
-                            hex!(
-                                "7f 000102030405060708090a0b0c0d0e0f
-                                    101112131415161718191a1b1c1d1e1f
-                                 60 00
-                                 52
-                                 60 20
-                                 60 00
-                                 f3"
-                            )
-                            .to_vec(),
+                        code: Some(bytes!(
+                            "7f 000102030405060708090a0b0c0d0e0f
+                                101112131415161718191a1b1c1d1e1f
+                             60 00
+                             52
+                             60 20
+                             60 00
+                             f3"
                         )),
                         ..Default::default()
                     },


### PR DESCRIPTION
This PR implements a new `CodeSimulating` abstraction for simulating a contract call with state overrides.

This is **different** than the `eth_call` with state overrides introduced in #507, in that it abstracts away how the simulation is done. Specifically, not all nodes implement `eth_call` with state overrides (Nethermind for example), but Tenderly works for all of our supported networks. This means we can use Tenderly for these simulations even on networks where we connect to Nethermind nodes (Gnosis Chain for instance).

### Test Plan

Added some integration tests:
```
% cargo test -p shared -- --ignored code_simulation
    Finished test [unoptimized + debuginfo] target(s) in 0.24s
     Running unittests src/lib.rs (target/debug/deps/shared-e14dee386a6fa988)

running 2 tests
test code_simulation::tests::errors_on_reverts ... ok
test code_simulation::tests::can_simulate_contract_code ... ok

test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 321 filtered out; finished in 1.04s
```
