### PR TITLE
Refactor Trade encoding

### DIFF
--- a/crates/shared/src/macros.rs
+++ b/crates/shared/src/macros.rs
@@ -39,3 +39,13 @@ macro_rules! dummy_contract {
         $contract::at(&$crate::transport::dummy::web3(), $addr.into())
     };
 }
+
+#[macro_export]
+macro_rules! deployed_bytecode {
+    ($contract:ty) => {
+        <$contract>::raw_contract()
+            .deployed_bytecode
+            .to_bytes()
+            .unwrap()
+    };
+}

--- a/crates/shared/src/trade_finding/zeroex.rs
+++ b/crates/shared/src/trade_finding/zeroex.rs
@@ -46,7 +46,7 @@ impl ZeroExTradeFinder {
                 OrderKind::Sell => swap.price.buy_amount,
             },
             gas_estimate: gas::SETTLEMENT_OVERHEAD + swap.price.estimated_gas,
-            approval_spender: Some(swap.price.allowance_target),
+            approval: Some((query.sell_token, swap.price.allowance_target)),
             interaction: Interaction {
                 target: swap.to,
                 value: swap.value,
@@ -127,8 +127,8 @@ mod tests {
         assert_eq!(trade.out_amount, 1110165823572443613u64.into());
         assert!(trade.gas_estimate > 111000);
         assert_eq!(
-            trade.approval_spender,
-            Some(addr!("def1c0ded9bec7f1a1670819833240f027b25eff")),
+            trade.approval,
+            Some((weth, addr!("def1c0ded9bec7f1a1670819833240f027b25eff"))),
         );
         assert_eq!(
             trade.interaction,


### PR DESCRIPTION
This PR moves some helper methods for encoding `TradeFinding` results so that they can be used with the `Trader` contract for both bad token detection and trade simulation.

Specifically for trade simulation, DEX aggregators are expected to produce "trade" results (similar to price estimates but with calldata). These trade results get used with the new `Trader` contract for simulations. The new `encode` functions facilitate this encoding for generating calldata for trade simulations.

### Test Plan

CI. Existing tests continue to pass. Added new unit test for ensuring trade encoding works as expected.
