### PR TITLE
Add from field to price estimation queries

### DIFF
--- a/crates/shared/src/order_quoting.rs
+++ b/crates/shared/src/order_quoting.rs
@@ -132,6 +132,7 @@ impl QuoteParameters {
         };
 
         price_estimation::Query {
+            from: Some(self.from),
             sell_token: self.sell_token,
             buy_token: self.buy_token,
             in_amount,
@@ -725,6 +726,7 @@ mod tests {
             .expect_estimates()
             .withf(|q| {
                 q == [price_estimation::Query {
+                    from: Some(H160([3; 20])),
                     sell_token: H160([1; 20]),
                     buy_token: H160([2; 20]),
                     in_amount: 100.into(),
@@ -837,6 +839,7 @@ mod tests {
             .expect_estimates()
             .withf(|q| {
                 q == [price_estimation::Query {
+                    from: Some(H160([3; 20])),
                     sell_token: H160([1; 20]),
                     buy_token: H160([2; 20]),
                     in_amount: 100.into(),
@@ -952,6 +955,7 @@ mod tests {
             .expect_estimates()
             .withf(|q| {
                 q == [price_estimation::Query {
+                    from: Some(H160([3; 20])),
                     sell_token: H160([1; 20]),
                     buy_token: H160([2; 20]),
                     in_amount: 42.into(),

--- a/crates/shared/src/price_estimation.rs
+++ b/crates/shared/src/price_estimation.rs
@@ -86,6 +86,8 @@ impl Clone for PriceEstimationError {
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, Default)]
 pub struct Query {
+    /// Optional `from` address that would be executing the query.
+    pub from: Option<H160>,
     pub sell_token: H160,
     pub buy_token: H160,
     /// For OrderKind::Sell amount is in sell_token and for OrderKind::Buy in buy_token.

--- a/crates/shared/src/price_estimation/balancer_sor.rs
+++ b/crates/shared/src/price_estimation/balancer_sor.rs
@@ -109,6 +109,7 @@ mod tests {
         let gas = Arc::new(FixedGasPriceEstimator(1e7));
         let estimator = BalancerSor::new(api, rate_limiter, gas);
         let query = Query {
+            from: None,
             sell_token: testlib::tokens::WETH,
             buy_token: testlib::tokens::DAI,
             in_amount: U256::from_f64_lossy(1e18),

--- a/crates/shared/src/price_estimation/baseline.rs
+++ b/crates/shared/src/price_estimation/baseline.rs
@@ -375,6 +375,7 @@ mod tests {
         assert!(single_estimate(
             &estimator,
             &Query {
+                from: None,
                 sell_token: token_a,
                 buy_token: token_b,
                 in_amount: 1.into(),
@@ -408,6 +409,7 @@ mod tests {
         assert!(single_estimate(
             &estimator,
             &Query {
+                from: None,
                 sell_token: token_a,
                 buy_token: token_b,
                 in_amount: 1.into(),
@@ -448,6 +450,7 @@ mod tests {
         assert!(single_estimate(
             &estimator,
             &Query {
+                from: None,
                 sell_token: token_a,
                 buy_token: token_b,
                 in_amount: 100.into(),
@@ -459,6 +462,7 @@ mod tests {
         assert!(single_estimate(
             &estimator,
             &Query {
+                from: None,
                 sell_token: token_a,
                 buy_token: token_b,
                 in_amount: 100.into(),
@@ -513,6 +517,7 @@ mod tests {
         );
 
         let query = Query {
+            from: None,
             sell_token: token_a,
             buy_token: token_b,
             in_amount: 100.into(),
@@ -526,6 +531,7 @@ mod tests {
         );
 
         let query = Query {
+            from: None,
             sell_token: token_b,
             buy_token: token_a,
             in_amount: 100.into(),
@@ -570,6 +576,7 @@ mod tests {
             let intermediate = single_estimate(
                 &estimator,
                 &Query {
+                    from: None,
                     sell_token: token_a,
                     buy_token: token_b,
                     in_amount: 1.into(),
@@ -583,6 +590,7 @@ mod tests {
             let direct = single_estimate(
                 &estimator,
                 &Query {
+                    from: None,
                     sell_token: token_b,
                     buy_token: token_a,
                     in_amount: 10.into(),
@@ -645,6 +653,7 @@ mod tests {
                 single_estimate(
                     &estimator,
                     &Query {
+                        from: None,
                         sell_token: sell,
                         buy_token: buy,
                         in_amount: 10.into(),
@@ -671,6 +680,7 @@ mod tests {
                 single_estimate(
                     &estimator,
                     &Query {
+                        from: None,
                         sell_token: sell,
                         buy_token: buy,
                         in_amount: 10.into(),
@@ -720,6 +730,7 @@ mod tests {
 
         let gas_price = 1000000000000000.0;
         let query = Query {
+            from: None,
             sell_token: token_a,
             buy_token: token_c,
             in_amount: 10u128.pow(19).into(),

--- a/crates/shared/src/price_estimation/competition.rs
+++ b/crates/shared/src/price_estimation/competition.rs
@@ -202,30 +202,35 @@ mod tests {
     async fn works() {
         let queries = [
             Query {
+                from: None,
                 sell_token: H160::from_low_u64_le(0),
                 buy_token: H160::from_low_u64_le(1),
                 in_amount: 1.into(),
                 kind: OrderKind::Buy,
             },
             Query {
+                from: None,
                 sell_token: H160::from_low_u64_le(2),
                 buy_token: H160::from_low_u64_le(3),
                 in_amount: 1.into(),
                 kind: OrderKind::Sell,
             },
             Query {
+                from: None,
                 sell_token: H160::from_low_u64_le(2),
                 buy_token: H160::from_low_u64_le(3),
                 in_amount: 1.into(),
                 kind: OrderKind::Buy,
             },
             Query {
+                from: None,
                 sell_token: H160::from_low_u64_le(3),
                 buy_token: H160::from_low_u64_le(4),
                 in_amount: 1.into(),
                 kind: OrderKind::Buy,
             },
             Query {
+                from: None,
                 sell_token: H160::from_low_u64_le(5),
                 buy_token: H160::from_low_u64_le(6),
                 in_amount: 1.into(),
@@ -302,12 +307,14 @@ mod tests {
     async fn racing_estimator_returns_early() {
         let queries = [
             Query {
+                from: None,
                 sell_token: H160::from_low_u64_le(0),
                 buy_token: H160::from_low_u64_le(1),
                 in_amount: 1.into(),
                 kind: OrderKind::Buy,
             },
             Query {
+                from: None,
                 sell_token: H160::from_low_u64_le(2),
                 buy_token: H160::from_low_u64_le(3),
                 in_amount: 1.into(),

--- a/crates/shared/src/price_estimation/http.rs
+++ b/crates/shared/src/price_estimation/http.rs
@@ -512,6 +512,7 @@ mod tests {
 
         let result = estimator
             .estimate(&Query {
+                from: None,
                 sell_token: t1.1,
                 buy_token: t2.1,
                 in_amount: amount1,
@@ -532,6 +533,7 @@ mod tests {
 
         let result = estimator
             .estimate(&Query {
+                from: None,
                 sell_token: t1.1,
                 buy_token: t2.1,
                 in_amount: amount2,

--- a/crates/shared/src/price_estimation/instrumented.rs
+++ b/crates/shared/src/price_estimation/instrumented.rs
@@ -82,12 +82,14 @@ mod tests {
     async fn records_metrics_for_each_query() {
         let queries = [
             Query {
+                from: None,
                 sell_token: H160([1; 20]),
                 buy_token: H160([2; 20]),
                 in_amount: 3.into(),
                 kind: OrderKind::Sell,
             },
             Query {
+                from: None,
                 sell_token: H160([4; 20]),
                 buy_token: H160([5; 20]),
                 in_amount: 6.into(),

--- a/crates/shared/src/price_estimation/native.rs
+++ b/crates/shared/src/price_estimation/native.rs
@@ -52,6 +52,7 @@ impl NativePriceEstimator {
 
     fn query(&self, token: &H160) -> Query {
         Query {
+            from: None,
             sell_token: *token,
             buy_token: self.native_token,
             in_amount: self.price_estimation_amount,

--- a/crates/shared/src/price_estimation/oneinch.rs
+++ b/crates/shared/src/price_estimation/oneinch.rs
@@ -157,6 +157,7 @@ mod tests {
 
         let est = estimator
             .estimate(&Query {
+                from: None,
                 sell_token: testlib::tokens::WETH,
                 buy_token: testlib::tokens::GNO,
                 in_amount: 1_000_000_000_000_000_000u128.into(),
@@ -179,6 +180,7 @@ mod tests {
 
         let est = estimator
             .estimate(&Query {
+                from: None,
                 sell_token: testlib::tokens::WETH,
                 buy_token: testlib::tokens::GNO,
                 in_amount: 1_000_000_000_000_000_000u128.into(),
@@ -209,6 +211,7 @@ mod tests {
 
         let est = estimator
             .estimate(&Query {
+                from: None,
                 sell_token: testlib::tokens::WETH,
                 buy_token: testlib::tokens::GNO,
                 in_amount: 1_000_000_000_000_000_000u128.into(),
@@ -234,6 +237,7 @@ mod tests {
 
         let est = estimator
             .estimate(&Query {
+                from: None,
                 sell_token: testlib::tokens::WETH,
                 buy_token: testlib::tokens::GNO,
                 in_amount: 1_000_000_000_000_000_000u128.into(),
@@ -259,6 +263,7 @@ mod tests {
 
         let result = estimator
             .estimate(&Query {
+                from: None,
                 sell_token: weth,
                 buy_token: gno,
                 in_amount: 10u128.pow(18).into(),

--- a/crates/shared/src/price_estimation/paraswap.rs
+++ b/crates/shared/src/price_estimation/paraswap.rs
@@ -179,6 +179,7 @@ mod tests {
         let weth = testlib::tokens::WETH;
         let gno = testlib::tokens::GNO;
         let query = Query {
+            from: None,
             sell_token: weth,
             buy_token: gno,
             in_amount: 10u128.pow(18).into(),

--- a/crates/shared/src/price_estimation/sanitized.rs
+++ b/crates/shared/src/price_estimation/sanitized.rs
@@ -230,6 +230,7 @@ mod tests {
             // This is the common case (Tokens are supported, distinct and not ETH).
             // Will be estimated by the wrapped_estimator.
             Query {
+                from: None,
                 sell_token: H160::from_low_u64_le(1),
                 buy_token: H160::from_low_u64_le(2),
                 in_amount: 1.into(),
@@ -239,6 +240,7 @@ mod tests {
             // `wrapped_estimator`.
             // `sanitized_estimator` will add cost of unwrapping ETH to Estimate.
             Query {
+                from: None,
                 sell_token: H160::from_low_u64_le(1),
                 buy_token: BUY_ETH_ADDRESS,
                 in_amount: 1.into(),
@@ -246,6 +248,7 @@ mod tests {
             },
             // Will cause buffer overflow of gas price in `sanitized_estimator`.
             Query {
+                from: None,
                 sell_token: H160::from_low_u64_le(1),
                 buy_token: BUY_ETH_ADDRESS,
                 in_amount: U256::MAX,
@@ -255,6 +258,7 @@ mod tests {
             // `wrapped_estimator`.
             // `sanitized_estimator` will add cost of wrapping ETH to Estimate.
             Query {
+                from: None,
                 sell_token: BUY_ETH_ADDRESS,
                 buy_token: H160::from_low_u64_le(1),
                 in_amount: 1.into(),
@@ -262,6 +266,7 @@ mod tests {
             },
             // Can be estimated by `sanitized_estimator` because `buy_token` and `sell_token` are identical.
             Query {
+                from: None,
                 sell_token: H160::from_low_u64_le(1),
                 buy_token: H160::from_low_u64_le(1),
                 in_amount: 1.into(),
@@ -269,6 +274,7 @@ mod tests {
             },
             // Can be estimated by `sanitized_estimator` because both tokens are the native token.
             Query {
+                from: None,
                 sell_token: BUY_ETH_ADDRESS,
                 buy_token: BUY_ETH_ADDRESS,
                 in_amount: 1.into(),
@@ -276,6 +282,7 @@ mod tests {
             },
             // Can be estimated by `sanitized_estimator` because it is a native token unwrap.
             Query {
+                from: None,
                 sell_token: native_token,
                 buy_token: BUY_ETH_ADDRESS,
                 in_amount: 1.into(),
@@ -283,6 +290,7 @@ mod tests {
             },
             // Can be estimated by `sanitized_estimator` because it is a native token wrap.
             Query {
+                from: None,
                 sell_token: BUY_ETH_ADDRESS,
                 buy_token: native_token,
                 in_amount: 1.into(),
@@ -290,6 +298,7 @@ mod tests {
             },
             // Will throw `UnsupportedToken` error in `sanitized_estimator`.
             Query {
+                from: None,
                 sell_token: BAD_TOKEN,
                 buy_token: H160::from_low_u64_le(1),
                 in_amount: 1.into(),
@@ -297,6 +306,7 @@ mod tests {
             },
             // Will throw `UnsupportedToken` error in `sanitized_estimator`.
             Query {
+                from: None,
                 sell_token: H160::from_low_u64_le(1),
                 buy_token: BAD_TOKEN,
                 in_amount: 1.into(),
@@ -440,6 +450,7 @@ mod tests {
         let queries = [
             // difficult
             Query {
+                from: None,
                 sell_token: H160::from_low_u64_le(1),
                 buy_token: H160::from_low_u64_le(2),
                 in_amount: 1.into(),
@@ -447,6 +458,7 @@ mod tests {
             },
             //easy
             Query {
+                from: None,
                 sell_token: H160::from_low_u64_le(1),
                 buy_token: H160::from_low_u64_le(1),
                 in_amount: 1.into(),

--- a/crates/shared/src/price_estimation/zeroex.rs
+++ b/crates/shared/src/price_estimation/zeroex.rs
@@ -81,6 +81,7 @@ mod tests {
         let est = single_estimate(
             &estimator,
             &Query {
+                from: None,
                 sell_token: weth,
                 buy_token: gno,
                 in_amount: 100000000000000000u64.into(),
@@ -126,6 +127,7 @@ mod tests {
         let est = single_estimate(
             &estimator,
             &Query {
+                from: None,
                 sell_token: weth,
                 buy_token: gno,
                 in_amount: 100000000000000000u64.into(),
@@ -151,6 +153,7 @@ mod tests {
         let result = single_estimate(
             &estimator,
             &Query {
+                from: None,
                 sell_token: weth,
                 buy_token: gno,
                 in_amount: 10u128.pow(18).into(),

--- a/crates/shared/src/trade_finding/zeroex.rs
+++ b/crates/shared/src/trade_finding/zeroex.rs
@@ -116,6 +116,7 @@ mod tests {
 
         let trade = trader
             .get_trade(&Query {
+                from: None,
                 sell_token: weth,
                 buy_token: gno,
                 in_amount: 100000000000000000u64.into(),
@@ -172,6 +173,7 @@ mod tests {
 
         let trade = trader
             .get_trade(&Query {
+                from: None,
                 sell_token: weth,
                 buy_token: gno,
                 in_amount: 100000000000000000u64.into(),
@@ -196,6 +198,7 @@ mod tests {
 
         let trade = trader
             .get_trade(&Query {
+                from: None,
                 sell_token: weth,
                 buy_token: gno,
                 in_amount: 10u128.pow(18).into(),


### PR DESCRIPTION
This PR adds a new `from` optional field for price estimation queries. This can be used by the quote endpoint for specifying the user it is quoting for. This allows components like the `TradeVerifier` to use this user address as the actual trader when verifying the trading logic so that:
- We can check that the token can be traded by the actual user doing the trade
- We can use the user's real token balance: this makes the simulation more accurate (so actual token `tranfer` logic gets used, and the gas estimation more accurately reflects what will be used by the trade execution).

### Test Plan

Adjusted unit tests to ensure field is properly set.
