### PR TITLE
Refactor HTTP client initialization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -447,6 +447,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
 
 [[package]]
+name = "cookie"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94d4706de1b0fa5b132270cddffa8585166037822e260a944fe161acd137ca05"
+dependencies = [
+ "percent-encoding",
+ "time 0.3.14",
+ "version_check",
+]
+
+[[package]]
+name = "cookie_store"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e4b6aa369f41f5faa04bb80c9b1f4216ea81646ed6124d76ba5c49a7aafd9cd"
+dependencies = [
+ "cookie",
+ "idna",
+ "log",
+ "publicsuffix",
+ "serde",
+ "serde_json",
+ "time 0.3.14",
+ "url",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2378,6 +2405,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro-hack"
+version = "0.5.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2426,6 +2459,22 @@ name = "protobuf"
 version = "2.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf7e6d18738ecd0902d30d1ad232c9125985a3422929b16c65517b38adc14f96"
+
+[[package]]
+name = "psl-types"
+version = "2.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33cb294fe86a74cbcf50d4445b37da762029549ebeea341421c7c70370f86cac"
+
+[[package]]
+name = "publicsuffix"
+version = "2.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aeeedb0b429dc462f30ad27ef3de97058b060016f47790c066757be38ef792b4"
+dependencies = [
+ "idna",
+ "psl-types",
+]
 
 [[package]]
 name = "quote"
@@ -2560,6 +2609,8 @@ dependencies = [
  "async-compression",
  "base64",
  "bytes",
+ "cookie",
+ "cookie_store",
  "encoding_rs",
  "futures-core",
  "futures-util",
@@ -2576,6 +2627,7 @@ dependencies = [
  "native-tls",
  "percent-encoding",
  "pin-project-lite",
+ "proc-macro-hack",
  "serde",
  "serde_json",
  "serde_urlencoded",
@@ -2960,6 +3012,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "shared",
+ "sqlx",
  "strum",
  "testlib",
  "thiserror",

--- a/crates/autopilot/src/arguments.rs
+++ b/crates/autopilot/src/arguments.rs
@@ -1,5 +1,5 @@
 use primitive_types::{H160, U256};
-use shared::{arguments::display_option, bad_token::token_owner_finder};
+use shared::{arguments::display_option, bad_token::token_owner_finder, http_client};
 use std::{net::SocketAddr, time::Duration};
 use url::Url;
 
@@ -7,6 +7,9 @@ use url::Url;
 pub struct Arguments {
     #[clap(flatten)]
     pub shared: shared::arguments::Arguments,
+
+    #[clap(flatten)]
+    pub http_client: http_client::Arguments,
 
     #[clap(flatten)]
     pub token_owner_finder: token_owner_finder::Arguments,
@@ -116,6 +119,7 @@ pub struct Arguments {
 impl std::fmt::Display for Arguments {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.shared)?;
+        write!(f, "{}", self.http_client)?;
         write!(f, "{}", self.token_owner_finder)?;
         display_option(f, "tracing_node_url", &self.tracing_node_url)?;
         writeln!(f, "metrics_address: {}", self.metrics_address)?;

--- a/crates/driver/src/arguments.rs
+++ b/crates/driver/src/arguments.rs
@@ -3,6 +3,7 @@ use reqwest::Url;
 use shared::{
     arguments::{display_list, display_option, display_secret_option, duration_from_seconds},
     gas_price_estimation::GasEstimatorType,
+    http_client,
     sources::{balancer_v2::BalancerFactoryKind, BaselineSource},
 };
 use solver::{
@@ -18,6 +19,9 @@ use tracing::level_filters::LevelFilter;
 
 #[derive(clap::Parser)]
 pub struct Arguments {
+    #[clap(flatten)]
+    pub http_client: http_client::Arguments,
+
     #[clap(long, env, default_value = "0.0.0.0:8080")]
     pub bind_address: SocketAddr,
 
@@ -38,14 +42,6 @@ pub struct Arguments {
     /// The Ethereum node URL to connect to.
     #[clap(long, env, default_value = "http://localhost:8545")]
     pub node_url: Url,
-
-    /// Timeout in seconds for all http requests.
-    #[clap(
-        long,
-        default_value = "10",
-        parse(try_from_str = duration_from_seconds),
-    )]
-    pub http_timeout: Duration,
 
     /// If solvers should use internal buffers to improve solution quality.
     #[clap(long, env)]
@@ -269,12 +265,12 @@ pub struct Arguments {
 
 impl std::fmt::Display for Arguments {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.http_client)?;
         writeln!(f, "bind_address: {}", self.bind_address)?;
         writeln!(f, "log_filter: {}", self.log_filter)?;
         writeln!(f, "log_stderr_threshold: {}", self.log_stderr_threshold)?;
         writeln!(f, "solvers: {:?}", self.solvers)?;
         writeln!(f, "node_url: {}", self.node_url)?;
-        writeln!(f, "http_timeout: {:?}", self.http_timeout)?;
         writeln!(f, "use_internal_buffers: {}", self.use_internal_buffers)?;
         display_list(
             f,

--- a/crates/driver/src/main.rs
+++ b/crates/driver/src/main.rs
@@ -6,10 +6,10 @@ use driver::{
     commit_reveal::CommitRevealSolver, driver::Driver,
 };
 use gas_estimation::GasPriceEstimating;
-use reqwest::Client;
 use shared::{
     baseline_solver::BaseTokens,
     current_block::{current_block_stream, CurrentBlockStream},
+    http_client::HttpClientFactory,
     http_solver::{DefaultHttpSolverApi, SolverConfig},
     maintenance::{Maintaining, ServiceMaintenance},
     recent_block_cache::CacheConfig,
@@ -52,7 +52,7 @@ use solver::{
 use std::{collections::HashMap, sync::Arc, time::Duration};
 
 struct CommonComponents {
-    client: Client,
+    http_factory: HttpClientFactory,
     web3: shared::Web3,
     network_id: String,
     chain_id: u64,
@@ -66,8 +66,8 @@ struct CommonComponents {
 }
 
 async fn init_common_components(args: &Arguments) -> CommonComponents {
-    let client = shared::http_client(args.http_timeout);
-    let web3 = shared::web3(&client, &args.node_url, "base");
+    let http_factory = HttpClientFactory::new(&args.http_client);
+    let web3 = shared::web3(&http_factory, &args.node_url, "base");
     let network_id = web3
         .net()
         .version()
@@ -87,19 +87,18 @@ async fn init_common_components(args: &Arguments) -> CommonComponents {
         .expect("couldn't load deployed native token");
     let access_list_estimator = Arc::new(
         solver::settlement_access_list::create_priority_estimator(
-            &client,
+            &http_factory,
             &web3,
             args.access_list_estimators.as_slice(),
             args.tenderly_url.clone(),
             args.tenderly_api_key.clone(),
             network_id.clone(),
         )
-        .await
         .expect("failed to create access list estimator"),
     );
     let gas_price_estimator = Arc::new(
         shared::gas_price_estimation::create_priority_estimator(
-            client.clone(),
+            &http_factory,
             &web3,
             args.gas_estimators.as_slice(),
             args.blocknative_api_key.clone(),
@@ -121,7 +120,7 @@ async fn init_common_components(args: &Arguments) -> CommonComponents {
     });
 
     CommonComponents {
-        client,
+        http_factory,
         web3,
         network_id,
         chain_id,
@@ -155,7 +154,7 @@ async fn build_solvers(common: &CommonComponents, args: &Arguments) -> Vec<Arc<d
                     network_name: common.network_id.clone(),
                     chain_id: common.chain_id,
                     base: arg.url.clone(),
-                    client: common.client.clone(),
+                    client: common.http_factory.create(),
                     config: SolverConfig {
                         use_internal_buffers: Some(args.use_internal_buffers),
                         ..Default::default()
@@ -175,14 +174,14 @@ async fn build_solvers(common: &CommonComponents, args: &Arguments) -> Vec<Arc<d
 }
 
 async fn build_submitter(common: &CommonComponents, args: &Arguments) -> Arc<SolutionSubmitter> {
-    let client = &common.client;
+    let client = || common.http_factory.create();
     let web3 = &common.web3;
 
     let submission_nodes_with_url = args
         .transaction_submission_nodes
         .iter()
         .enumerate()
-        .map(|(index, url)| (shared::web3(client, url, index), url))
+        .map(|(index, url)| (shared::web3(&common.http_factory, url, index), url))
         .collect::<Vec<_>>();
     for (node, url) in &submission_nodes_with_url {
         let node_network_id = node
@@ -223,7 +222,7 @@ async fn build_submitter(common: &CommonComponents, args: &Arguments) -> Arc<Sol
                 transaction_strategies.push(TransactionStrategy::Eden(StrategyArgs {
                     submit_api: Box::new(
                         EdenApi::new(
-                            client.clone(),
+                            client(),
                             args.eden_api_url.clone(),
                             submitted_transactions.clone(),
                         )
@@ -237,9 +236,7 @@ async fn build_submitter(common: &CommonComponents, args: &Arguments) -> Arc<Sol
             TransactionStrategyArg::Flashbots => {
                 for flashbots_url in args.flashbots_api_url.clone() {
                     transaction_strategies.push(TransactionStrategy::Flashbots(StrategyArgs {
-                        submit_api: Box::new(
-                            FlashbotsApi::new(client.clone(), flashbots_url).unwrap(),
-                        ),
+                        submit_api: Box::new(FlashbotsApi::new(client(), flashbots_url).unwrap()),
                         max_additional_tip: args.max_additional_flashbot_tip,
                         additional_tip_percentage_of_max_fee: args.additional_tip_percentage,
                         sub_tx_pool: submitted_transactions.add_sub_pool(Strategy::Flashbots),
@@ -333,7 +330,7 @@ async fn build_auction_converter(
                     common.token_info_fetcher.clone(),
                     cache_config,
                     common.current_block_stream.clone(),
-                    common.client.clone(),
+                    common.http_factory.create(),
                     &contracts,
                     args.balancer_pool_deny_list.clone(),
                 )
@@ -365,11 +362,11 @@ async fn build_auction_converter(
     let zeroex_liquidity = if baseline_sources.contains(&BaselineSource::ZeroEx) {
         let zeroex_api = Arc::new(
             DefaultZeroExApi::new(
+                &common.http_factory,
                 args.zeroex_url
                     .as_deref()
                     .unwrap_or(DefaultZeroExApi::DEFAULT_URL),
                 args.zeroex_api_key.clone(),
-                common.client.clone(),
             )
             .unwrap(),
         );
@@ -390,7 +387,7 @@ async fn build_auction_converter(
             UniswapV3PoolFetcher::new(
                 common.chain_id,
                 args.liquidity_fetcher_max_age_update,
-                common.client.clone(),
+                common.http_factory.create(),
             )
             .await
             .expect("failed to create UniswapV3 pool fetcher in solver"),
@@ -488,7 +485,7 @@ async fn build_drivers(common: &CommonComponents, args: &Arguments) -> Vec<(Arc<
         .tenderly_url
         .clone()
         .zip(args.tenderly_api_key.clone())
-        .and_then(|(url, api_key)| TenderlyApi::new(url, common.client.clone(), &api_key).ok());
+        .and_then(|(url, api_key)| TenderlyApi::new(&common.http_factory, url, &api_key).ok());
     let metrics = Arc::new(Metrics::new().unwrap());
 
     let settlement_ranker = Arc::new(SettlementRanker {

--- a/crates/e2e/tests/e2e/eth_integration.rs
+++ b/crates/e2e/tests/e2e/eth_integration.rs
@@ -12,7 +12,10 @@ use model::{
     signature::EcdsaSigningScheme,
 };
 use secp256k1::SecretKey;
-use shared::{maintenance::Maintaining, sources::uniswap_v2::pool_fetching::PoolFetcher, Web3};
+use shared::{
+    http_client::HttpClientFactory, maintenance::Maintaining,
+    sources::uniswap_v2::pool_fetching::PoolFetcher, Web3,
+};
 use solver::{
     liquidity::uniswap_v2::UniswapLikeLiquidity,
     liquidity_collector::LiquidityCollector,
@@ -114,7 +117,8 @@ async fn eth_integration(web3: Web3) {
         ..
     } = OrderbookServices::new(&web3, &contracts).await;
 
-    let client = reqwest::Client::new();
+    let http_factory = HttpClientFactory::default();
+    let client = http_factory.create();
 
     // Test fee endpoint
     let client_ref = &client;
@@ -235,14 +239,13 @@ async fn eth_integration(web3: Web3) {
             ],
             access_list_estimator: Arc::new(
                 create_priority_estimator(
-                    client_ref,
+                    &http_factory,
                     &web3,
                     &[AccessListEstimatorType::Web3],
                     None,
                     None,
                     network_id,
                 )
-                .await
                 .unwrap(),
             ),
             max_gas_price_bumps: NonZeroU8::new(1).unwrap(),

--- a/crates/e2e/tests/e2e/onchain_settlement.rs
+++ b/crates/e2e/tests/e2e/onchain_settlement.rs
@@ -13,7 +13,7 @@ use model::{
     signature::EcdsaSigningScheme,
 };
 use secp256k1::SecretKey;
-use shared::maintenance::Maintaining;
+use shared::{http_client::HttpClientFactory, maintenance::Maintaining};
 use shared::{sources::uniswap_v2::pool_fetching::PoolFetcher, Web3};
 use solver::{
     liquidity::uniswap_v2::UniswapLikeLiquidity,
@@ -143,7 +143,8 @@ async fn onchain_settlement(web3: Web3) {
         ..
     } = OrderbookServices::new(&web3, &contracts).await;
 
-    let client = reqwest::Client::new();
+    let http_factory = HttpClientFactory::default();
+    let client = http_factory.create();
 
     let order_a = OrderBuilder::default()
         .with_sell_token(token_a.address())
@@ -240,14 +241,13 @@ async fn onchain_settlement(web3: Web3) {
             ],
             access_list_estimator: Arc::new(
                 create_priority_estimator(
-                    &client,
+                    &http_factory,
                     &web3,
                     &[AccessListEstimatorType::Web3],
                     None,
                     None,
                     network_id,
                 )
-                .await
                 .unwrap(),
             ),
             max_gas_price_bumps: NonZeroU8::new(1).unwrap(),

--- a/crates/e2e/tests/e2e/settlement_without_onchain_liquidity.rs
+++ b/crates/e2e/tests/e2e/settlement_without_onchain_liquidity.rs
@@ -10,7 +10,7 @@ use model::{
     signature::EcdsaSigningScheme,
 };
 use secp256k1::SecretKey;
-use shared::maintenance::Maintaining;
+use shared::{http_client::HttpClientFactory, maintenance::Maintaining};
 use shared::{
     sources::uniswap_v2::pool_fetching::PoolFetcher,
     token_list::{Token, TokenList},
@@ -146,7 +146,8 @@ async fn onchain_settlement_without_liquidity(web3: Web3) {
         ..
     } = OrderbookServices::new(&web3, &contracts).await;
 
-    let client = reqwest::Client::new();
+    let http_factory = HttpClientFactory::default();
+    let client = http_factory.create();
 
     let order = OrderBuilder::default()
         .with_sell_token(token_a.address())
@@ -229,14 +230,13 @@ async fn onchain_settlement_without_liquidity(web3: Web3) {
             ],
             access_list_estimator: Arc::new(
                 create_priority_estimator(
-                    &client,
+                    &http_factory,
                     &web3,
                     &[AccessListEstimatorType::Web3],
                     None,
                     None,
                     network_id,
                 )
-                .await
                 .unwrap(),
             ),
             max_gas_price_bumps: NonZeroU8::new(1).unwrap(),

--- a/crates/e2e/tests/e2e/smart_contract_orders.rs
+++ b/crates/e2e/tests/e2e/smart_contract_orders.rs
@@ -12,7 +12,10 @@ use model::{
     signature::hashed_eip712_message,
 };
 use secp256k1::SecretKey;
-use shared::{maintenance::Maintaining, sources::uniswap_v2::pool_fetching::PoolFetcher, Web3};
+use shared::{
+    http_client::HttpClientFactory, maintenance::Maintaining,
+    sources::uniswap_v2::pool_fetching::PoolFetcher, Web3,
+};
 use solver::{
     liquidity::uniswap_v2::UniswapLikeLiquidity,
     liquidity_collector::LiquidityCollector,
@@ -122,7 +125,8 @@ async fn smart_contract_orders(web3: Web3) {
         ..
     } = OrderbookServices::new(&web3, &contracts).await;
 
-    let client = reqwest::Client::new();
+    let http_factory = HttpClientFactory::default();
+    let client = http_factory.create();
 
     // Place Orders
     let order_template = || {
@@ -266,14 +270,13 @@ async fn smart_contract_orders(web3: Web3) {
             ],
             access_list_estimator: Arc::new(
                 create_priority_estimator(
-                    &client,
+                    &http_factory,
                     &web3,
                     &[AccessListEstimatorType::Web3],
                     None,
                     None,
                     network_id,
                 )
-                .await
                 .unwrap(),
             ),
             max_gas_price_bumps: NonZeroU8::new(1).unwrap(),

--- a/crates/e2e/tests/e2e/vault_balances.rs
+++ b/crates/e2e/tests/e2e/vault_balances.rs
@@ -9,7 +9,9 @@ use model::{
     signature::EcdsaSigningScheme,
 };
 use secp256k1::SecretKey;
-use shared::{sources::uniswap_v2::pool_fetching::PoolFetcher, Web3};
+use shared::{
+    http_client::HttpClientFactory, sources::uniswap_v2::pool_fetching::PoolFetcher, Web3,
+};
 use solver::{
     liquidity::uniswap_v2::UniswapLikeLiquidity,
     liquidity_collector::LiquidityCollector,
@@ -101,7 +103,8 @@ async fn vault_balances(web3: Web3) {
         ..
     } = OrderbookServices::new(&web3, &contracts).await;
 
-    let client = reqwest::Client::new();
+    let http_factory = HttpClientFactory::default();
+    let client = http_factory.create();
 
     // Place Orders
     let order = OrderBuilder::default()
@@ -179,14 +182,13 @@ async fn vault_balances(web3: Web3) {
             ],
             access_list_estimator: Arc::new(
                 create_priority_estimator(
-                    &client,
+                    &http_factory,
                     &web3,
                     &[AccessListEstimatorType::Web3],
                     None,
                     None,
                     network_id,
                 )
-                .await
                 .unwrap(),
             ),
             max_gas_price_bumps: NonZeroU8::new(1).unwrap(),

--- a/crates/orderbook/src/arguments.rs
+++ b/crates/orderbook/src/arguments.rs
@@ -2,10 +2,9 @@ use anyhow::{anyhow, Context, Result};
 use model::app_id::AppId;
 use primitive_types::{H160, U256};
 use reqwest::Url;
-use shared::fee_subsidy::cow_token::SubsidyTiers;
 use shared::{
-    arguments::display_option, bad_token::token_owner_finder, price_estimation::PriceEstimatorType,
-    rate_limiter::RateLimitingStrategy,
+    arguments::display_option, bad_token::token_owner_finder, fee_subsidy::cow_token::SubsidyTiers,
+    http_client, price_estimation::PriceEstimatorType, rate_limiter::RateLimitingStrategy,
 };
 use std::{collections::HashMap, net::SocketAddr, num::NonZeroUsize, time::Duration};
 
@@ -13,6 +12,9 @@ use std::{collections::HashMap, net::SocketAddr, num::NonZeroUsize, time::Durati
 pub struct Arguments {
     #[clap(flatten)]
     pub shared: shared::arguments::Arguments,
+
+    #[clap(flatten)]
+    pub http_client: http_client::Arguments,
 
     #[clap(flatten)]
     pub token_owner_finder: token_owner_finder::Arguments,
@@ -238,6 +240,7 @@ pub struct Arguments {
 impl std::fmt::Display for Arguments {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.shared)?;
+        write!(f, "{}", self.http_client)?;
         write!(f, "{}", self.token_owner_finder)?;
         display_option(f, "tracing_node_url", &self.tracing_node_url)?;
         writeln!(f, "bind_address: {}", self.bind_address)?;

--- a/crates/shared/Cargo.toml
+++ b/crates/shared/Cargo.toml
@@ -39,7 +39,7 @@ number-conversions = { path = "../number-conversions" }
 primitive-types = "0.10"
 prometheus = "0.13"
 prometheus-metric-storage = { git = "https://github.com/cowprotocol/prometheus-metric-storage" , tag = "v0.4.0" }
-reqwest = { version = "0.11", features = ["gzip", "json"] }
+reqwest = { version = "0.11", features = ["cookies", "gzip", "json"] }
 scopeguard = "1.1.0"
 serde = "1.0"
 serde_json = "1.0"

--- a/crates/shared/src/arguments.rs
+++ b/crates/shared/src/arguments.rs
@@ -31,14 +31,6 @@ pub struct Arguments {
     #[clap(long, env, default_value = "http://localhost:8545")]
     pub node_url: Url,
 
-    /// Timeout in seconds for all http requests.
-    #[clap(
-        long,
-        default_value = "10",
-        parse(try_from_str = duration_from_seconds),
-    )]
-    pub http_timeout: Duration,
-
     /// Which gas estimators to use. Multiple estimators are used in sequence if a previous one
     /// fails. Individual estimators support different networks.
     /// `EthGasStation`: supports mainnet.
@@ -215,7 +207,6 @@ impl Display for Arguments {
         writeln!(f, "log_filter: {}", self.log_filter)?;
         writeln!(f, "log_stderr_threshold: {}", self.log_stderr_threshold)?;
         writeln!(f, "node_url: {}", self.node_url)?;
-        writeln!(f, "http_timeout: {:?}", self.http_timeout)?;
         writeln!(f, "gas_estimators: {:?}", self.gas_estimators)?;
         display_secret_option(f, "blocknative_api_key", &self.blocknative_api_key)?;
         writeln!(f, "base_tokens: {:?}", self.base_tokens)?;

--- a/crates/shared/src/bad_token/token_owner_finder/blockscout.rs
+++ b/crates/shared/src/bad_token/token_owner_finder/blockscout.rs
@@ -5,31 +5,16 @@ use prometheus::IntCounterVec;
 use prometheus_metric_storage::MetricStorage;
 use reqwest::{Client, Url};
 use serde::Deserialize;
-use std::time::Duration;
 
 const BASE: &str = "https://blockscout.com/";
-
-// Blockscout uses a custom timeout because their api is often slow. We would like those requests
-// to finish even if slow as bad token detection results are cached for a while and faster
-// TokenOwnerFinding implementations are not slowed down by slower ones.
-const DEFAULT_TIMEOUT: Duration = Duration::from_secs(45);
 
 pub struct BlockscoutTokenOwnerFinder {
     client: Client,
     base: Url,
-    timeout: Duration,
 }
 
 impl BlockscoutTokenOwnerFinder {
     pub fn try_with_network(client: Client, network_id: u64) -> Result<Self> {
-        Self::try_with_network_and_timeout(client, network_id, DEFAULT_TIMEOUT)
-    }
-
-    pub fn try_with_network_and_timeout(
-        client: Client,
-        network_id: u64,
-        timeout: Duration,
-    ) -> Result<Self> {
         let network = match network_id {
             1 => "eth/",
             100 => "xdai/",
@@ -44,7 +29,6 @@ impl BlockscoutTokenOwnerFinder {
                 .expect("Invalid Blockscout URL Segement")
                 .join("mainnet/api")
                 .expect("Invalid Blockscout URL Segement"),
-            timeout,
         })
     }
 
@@ -57,7 +41,7 @@ impl BlockscoutTokenOwnerFinder {
 
         tracing::debug!(%url, "Querying Blockscout API");
 
-        let response = self.client.get(url).timeout(self.timeout).send().await?;
+        let response = self.client.get(url).send().await?;
         let status = response.status();
         let status_result = response.error_for_status_ref().map(|_| ());
         let body = response.text().await?;

--- a/crates/shared/src/http_client.rs
+++ b/crates/shared/src/http_client.rs
@@ -1,5 +1,74 @@
+use crate::arguments::duration_from_seconds;
 use anyhow::{anyhow, Result};
-use reqwest::Response;
+use reqwest::{Client, ClientBuilder, Response};
+use std::{
+    fmt::{self, Display, Formatter},
+    time::Duration,
+};
+
+const USER_AGENT: &str = "cowprotocol-services/2.0.0";
+
+/// An HTTP client factory.
+///
+/// This ensures a common configuration for all our HTTP clients used in various
+/// places, while allowing for separate configurations, connection pools, and
+/// cookie stores (for things like sessions and default headers) across
+/// different APIs.
+#[derive(Debug)]
+pub struct HttpClientFactory {
+    timeout: Duration,
+}
+
+impl HttpClientFactory {
+    pub fn new(args: &Arguments) -> Self {
+        Self {
+            timeout: args.http_timeout,
+        }
+    }
+
+    /// Creates a new HTTP client with the default settings.
+    pub fn create(&self) -> Client {
+        self.builder().build().unwrap()
+    }
+
+    /// Creates a new HTTP client, allowing for additional configuration.
+    pub fn configure(&self, config: impl FnOnce(ClientBuilder) -> ClientBuilder) -> Client {
+        config(self.builder()).build().unwrap()
+    }
+
+    /// Returns a `ClientBuilder` with the default settings.
+    pub fn builder(&self) -> ClientBuilder {
+        ClientBuilder::new()
+            .timeout(self.timeout)
+            .user_agent(USER_AGENT)
+    }
+}
+
+impl Default for HttpClientFactory {
+    fn default() -> Self {
+        Self {
+            timeout: Duration::from_secs(10),
+        }
+    }
+}
+
+/// Command line arguments for the common HTTP factory.
+#[derive(clap::Parser)]
+pub struct Arguments {
+    /// Default timeout in seconds for http requests.
+    #[clap(
+        long,
+        default_value = "10",
+        parse(try_from_str = duration_from_seconds),
+    )]
+    pub http_timeout: Duration,
+}
+
+impl Display for Arguments {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        writeln!(f, "http_timeout: {:?}", self.http_timeout)
+    }
+}
 
 /// Extracts the bytes of the response up to some size limit.
 ///

--- a/crates/shared/src/lib.rs
+++ b/crates/shared/src/lib.rs
@@ -42,12 +42,12 @@ pub mod univ3_router_api;
 pub mod web3_traits;
 pub mod zeroex_api;
 
-use self::transport::http::HttpTransport;
+use self::{http_client::HttpClientFactory, transport::http::HttpTransport};
 use ethcontract::{
     batch::CallBatch,
     dyns::{DynTransport, DynWeb3},
 };
-use reqwest::{Client, Url};
+use reqwest::Url;
 use std::{
     future::Future,
     time::{Duration, Instant},
@@ -57,19 +57,10 @@ pub type Web3Transport = DynTransport;
 pub type Web3 = DynWeb3;
 pub type Web3CallBatch = CallBatch<Web3Transport>;
 
-/// The standard http client we use in the api and driver.
-pub fn http_client(timeout: Duration) -> reqwest::Client {
-    reqwest::ClientBuilder::new()
-        .timeout(timeout)
-        .user_agent("cowprotocol-services/2.0.0")
-        .build()
-        .unwrap()
-}
-
 /// Create a Web3 instance.
-pub fn web3(client: &Client, url: &Url, name: impl ToString) -> Web3 {
+pub fn web3(http_factory: &HttpClientFactory, url: &Url, name: impl ToString) -> Web3 {
     let transport = Web3Transport::new(HttpTransport::new(
-        client.clone(),
+        http_factory.configure(|builder| builder.cookie_store(true)),
         url.clone(),
         name.to_string(),
     ));

--- a/crates/solver/Cargo.toml
+++ b/crates/solver/Cargo.toml
@@ -53,5 +53,6 @@ web3 = { version = "0.18", default-features = false }
 mockall = "0.11"
 
 [dev-dependencies]
+sqlx = { version = "0.6", default-features = false, features = ["runtime-tokio-native-tls"] }
 tracing-subscriber = "0.3"
 testlib = { path = "../testlib" }

--- a/crates/solver/src/arguments.rs
+++ b/crates/solver/src/arguments.rs
@@ -4,13 +4,19 @@ use crate::{
 };
 use primitive_types::H160;
 use reqwest::Url;
-use shared::arguments::{display_list, display_option, display_secret_option};
+use shared::{
+    arguments::{display_list, display_option, display_secret_option},
+    http_client,
+};
 use std::{num::NonZeroU8, time::Duration};
 
 #[derive(clap::Parser)]
 pub struct Arguments {
     #[clap(flatten)]
     pub shared: shared::arguments::Arguments,
+
+    #[clap(flatten)]
+    pub http_client: http_client::Arguments,
 
     /// The API endpoint to fetch the orderbook
     #[clap(long, env, default_value = "http://localhost:8080")]
@@ -293,6 +299,7 @@ pub struct Arguments {
 impl std::fmt::Display for Arguments {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.shared)?;
+        write!(f, "{}", self.http_client)?;
         writeln!(f, "orderbook_url: {}", self.orderbook_url)?;
         writeln!(f, "mip_solver_url: {}", self.mip_solver_url)?;
         writeln!(f, "quasimodo_solver_url: {}", self.quasimodo_solver_url)?;

--- a/crates/solver/src/main.rs
+++ b/crates/solver/src/main.rs
@@ -6,6 +6,7 @@ use primitive_types::U256;
 use shared::{
     baseline_solver::BaseTokens,
     current_block::current_block_stream,
+    http_client::HttpClientFactory,
     maintenance::{Maintaining, ServiceMaintenance},
     metrics::serve_metrics,
     network::network_name,
@@ -54,9 +55,9 @@ async fn main() {
     global_metrics::setup_metrics_registry(Some("gp_v2_solver".into()), None);
     let metrics = Arc::new(Metrics::new().expect("Couldn't register metrics"));
 
-    let client = shared::http_client(args.shared.http_timeout);
+    let http_factory = HttpClientFactory::new(&args.http_client);
 
-    let web3 = shared::web3(&client, &args.shared.node_url, "base");
+    let web3 = shared::web3(&http_factory, &args.shared.node_url, "base");
     let chain_id = web3
         .eth()
         .chain_id()
@@ -86,7 +87,7 @@ async fn main() {
     })));
     let gas_price_estimator = Arc::new(
         shared::gas_price_estimation::create_priority_estimator(
-            client.clone(),
+            &http_factory,
             &web3,
             args.shared.gas_estimators.as_slice(),
             args.shared.blocknative_api_key,
@@ -139,7 +140,7 @@ async fn main() {
                     token_info_fetcher.clone(),
                     cache_config,
                     current_block_stream.clone(),
-                    client.clone(),
+                    http_factory.create(),
                     &contracts,
                     args.shared.balancer_pool_deny_list,
                 )
@@ -193,12 +194,12 @@ async fn main() {
 
     let zeroex_api = Arc::new(
         DefaultZeroExApi::new(
+            &http_factory,
             args.shared
                 .zeroex_url
                 .as_deref()
                 .unwrap_or(DefaultZeroExApi::DEFAULT_URL),
             args.shared.zeroex_api_key,
-            client.clone(),
         )
         .unwrap(),
     );
@@ -226,7 +227,7 @@ async fn main() {
         args.paraswap_slippage_bps,
         args.shared.disabled_paraswap_dexs,
         args.shared.paraswap_partner,
-        client.clone(),
+        &http_factory,
         metrics.clone(),
         zeroex_api.clone(),
         args.zeroex_slippage_bps,
@@ -263,7 +264,7 @@ async fn main() {
                 UniswapV3PoolFetcher::new(
                     chain_id,
                     args.shared.liquidity_fetcher_max_age_update,
-                    client.clone(),
+                    http_factory.create(),
                 )
                 .await
                 .expect("failed to create UniswapV3 pool fetcher in solver"),
@@ -289,16 +290,19 @@ async fn main() {
         zeroex_liquidity,
         uniswap_v3_liquidity,
     };
-    let market_makable_token_list =
-        TokenList::from_url(&args.market_makable_token_list, chain_id, client.clone())
-            .await
-            .map_err(|err| tracing::error!("Couldn't fetch market makable token list: {}", err))
-            .ok();
+    let market_makable_token_list = TokenList::from_url(
+        &args.market_makable_token_list,
+        chain_id,
+        http_factory.create(),
+    )
+    .await
+    .map_err(|err| tracing::error!("Couldn't fetch market makable token list: {}", err))
+    .ok();
     let submission_nodes_with_url = args
         .transaction_submission_nodes
         .into_iter()
         .enumerate()
-        .map(|(index, url)| (shared::web3(&client, &url, index), url))
+        .map(|(index, url)| (shared::web3(&http_factory, &url, index), url))
         .collect::<Vec<_>>();
     for (node, url) in &submission_nodes_with_url {
         let node_network_id = node
@@ -339,7 +343,7 @@ async fn main() {
                 transaction_strategies.push(TransactionStrategy::Eden(StrategyArgs {
                     submit_api: Box::new(
                         EdenApi::new(
-                            client.clone(),
+                            http_factory.create(),
                             args.eden_api_url.clone(),
                             submitted_transactions.clone(),
                         )
@@ -354,7 +358,7 @@ async fn main() {
                 for flashbots_url in args.flashbots_api_url.clone() {
                     transaction_strategies.push(TransactionStrategy::Flashbots(StrategyArgs {
                         submit_api: Box::new(
-                            FlashbotsApi::new(client.clone(), flashbots_url).unwrap(),
+                            FlashbotsApi::new(http_factory.create(), flashbots_url).unwrap(),
                         ),
                         max_additional_tip: args.max_additional_flashbot_tip,
                         additional_tip_percentage_of_max_fee: args.additional_tip_percentage,
@@ -384,14 +388,13 @@ async fn main() {
     }
     let access_list_estimator = Arc::new(
         solver::settlement_access_list::create_priority_estimator(
-            &client,
+            &http_factory,
             &web3,
             args.access_list_estimators.as_slice(),
             args.tenderly_url.clone(),
             args.tenderly_api_key.clone(),
             network_id.clone(),
         )
-        .await
         .expect("failed to create access list estimator"),
     );
     let solution_submitter = SolutionSubmitter {
@@ -408,13 +411,13 @@ async fn main() {
     };
     let api = OrderBookApi::new(
         args.orderbook_url,
-        client.clone(),
+        http_factory.create(),
         args.shared.solver_competition_auth,
     );
     let tenderly = args
         .tenderly_url
         .zip(args.tenderly_api_key)
-        .and_then(|(url, api_key)| TenderlyApi::new(url, client.clone(), &api_key).ok());
+        .and_then(|(url, api_key)| TenderlyApi::new(&http_factory, url, &api_key).ok());
 
     let mut driver = Driver::new(
         settlement_contract,

--- a/crates/solver/src/settlement_submission/submitter.rs
+++ b/crates/solver/src/settlement_submission/submitter.rs
@@ -666,6 +666,7 @@ mod tests {
     use gas_estimation::blocknative::BlockNative;
     use reqwest::Client;
     use shared::gas_price_estimation::FakeGasPriceEstimator;
+    use shared::http_client::HttpClientFactory;
     use shared::transport::create_env_test_transport;
     use tracing::level_filters::LevelFilter;
 
@@ -705,14 +706,13 @@ mod tests {
         };
         let access_list_estimator = Arc::new(
             create_priority_estimator(
-                &Client::new(),
+                &HttpClientFactory::default(),
                 &web3,
                 &[AccessListEstimatorType::Web3],
                 None,
                 None,
                 "1".to_string(),
             )
-            .await
             .unwrap(),
         );
 

--- a/crates/solver/src/solver.rs
+++ b/crates/solver/src/solver.rs
@@ -18,8 +18,9 @@ use naive_solver::NaiveSolver;
 use num::BigRational;
 use oneinch_solver::OneInchSolver;
 use paraswap_solver::ParaswapSolver;
-use reqwest::{Client, Url};
+use reqwest::Url;
 use shared::balancer_sor_api::DefaultBalancerSorApi;
+use shared::http_client::HttpClientFactory;
 use shared::http_solver::{DefaultHttpSolverApi, SolverConfig};
 use shared::zeroex_api::ZeroExApi;
 use shared::{
@@ -251,7 +252,7 @@ pub fn create(
     paraswap_slippage_bps: u32,
     disabled_paraswap_dexs: Vec<String>,
     paraswap_partner: Option<String>,
-    client: Client,
+    http_factory: &HttpClientFactory,
     solver_metrics: Arc<dyn SolverMetrics>,
     zeroex_api: Arc<dyn ZeroExApi>,
     zeroex_slippage_bps: u32,
@@ -302,7 +303,7 @@ pub fn create(
                 network_name: network_id.clone(),
                 chain_id,
                 base: url,
-                client: client.clone(),
+                client: http_factory.create(),
                 config,
             },
             account,
@@ -370,7 +371,7 @@ pub fn create(
                         settlement_contract.clone(),
                         chain_id,
                         disabled_one_inch_protocols.clone(),
-                        client.clone(),
+                        http_factory.create(),
                         one_inch_url.clone(),
                         oneinch_slippage_bps,
                         oneinch_max_slippage_in_wei,
@@ -397,7 +398,7 @@ pub fn create(
                     token_info_fetcher.clone(),
                     paraswap_slippage_bps,
                     disabled_paraswap_dexs.clone(),
-                    client.clone(),
+                    http_factory.create(),
                     paraswap_partner.clone(),
                     None,
                 ))))),
@@ -411,7 +412,7 @@ pub fn create(
                             .clone(),
                         settlement_contract.clone(),
                         Arc::new(DefaultBalancerSorApi::new(
-                            client.clone(),
+                            http_factory.create(),
                             balancer_sor_url.clone(),
                             chain_id,
                         )?),


### PR DESCRIPTION
This PR refactors how we create and pass around HTTP clients.

Previously, we used to use one shared `reqwest::Client` instance globally in our application. This was good because it ensured that our HTTP configuration was common everywhere. However this has some limitations:
- We share connection pools across APIs, which doesn't make sense since they connect to different hosts.
- We cannot configure API HTTP clients differently, this was an issue with Blockscout, but also things like the `ZeroExApi` and `TenderlyApi` where we needed to specify headers per request instead of specifying default headers per client.
- We need cookies for sticky connections with our load balancer. This meant we would have a globally shared cookie jar, instead of a cookie jar just for our Ethereum node connection.

This PR adds a new `HttpClientFactory` component for creating HTTP `reqwest::Client`s and:
- Changes some APIs to use default headers instead of headers per request
- Makes sure to enable cookies support for our Ethereum node connections
- Change the Blockscout API to configure a timeout on its client

### Test Plan

CI - the compiler is my fried. Also, we can make sure API keys still work:
```
% cargo test -p solver -- --ignored --nocapture tenderly_estimate_access_lists
    Finished test [unoptimized + debuginfo] target(s) in 0.14s
     Running unittests src/lib.rs (target/debug/deps/solver-7c9d9b10c84d3f82)

running 1 test
[crates/solver/src/settlement_access_list.rs:342] access_lists = [
    Ok(
        [
            AccessListItem {
                address: 0x2c4c28ddbdac9c5e7055b4c863b72ea0149d8afe,
                storage_keys: [
                    0x3e0a6b9ca93e33d18d2a2214f9ba022e0362fbadbdf27cd46f31629229baa68b,
                    0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc,
                ],
            },
            AccessListItem {
                address: 0x9e7ae8bdba9aa346739792d219a808884996db67,
                storage_keys: [],
            },
        ],
    ),
]
[crates/solver/src/settlement_access_list.rs:344] access_lists = []
test settlement_access_list::tests::tenderly_estimate_access_lists ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 179 filtered out; finished in 0.72s

     Running unittests src/main.rs (target/debug/deps/solver-14a04ada997c99bf)

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
```

☝️ Tenderly API key is being used correctly!