### PR TITLE
Add flag for skipping EIP-1271 order signature validation on creation

### DIFF
--- a/crates/orderbook/src/arguments.rs
+++ b/crates/orderbook/src/arguments.rs
@@ -98,6 +98,10 @@ pub struct Arguments {
     #[clap(long, env)]
     pub enable_eip1271_orders: bool,
 
+    /// Skip EIP-1271 order signature validation on creation.
+    #[clap(long, env)]
+    pub eip1271_skip_creation_validation: bool,
+
     /// Enable pre-sign orders. Pre-sign orders are accepted into the database without a valid
     /// signature, so this flag allows this feature to be turned off if malicious users are
     /// abusing the database by inserting a bunch of order rows that won't ever be valid.
@@ -275,6 +279,11 @@ impl std::fmt::Display for Arguments {
         writeln!(f, "allowed_tokens: {:?}", self.allowed_tokens)?;
         writeln!(f, "pool_cache_lru_size: {}", self.pool_cache_lru_size)?;
         writeln!(f, "enable_eip1271_orders: {}", self.enable_eip1271_orders)?;
+        writeln!(
+            f,
+            "eip1271_skip_creation_validation: {}",
+            self.eip1271_skip_creation_validation
+        )?;
         writeln!(f, "enable_presign_orders: {}", self.enable_presign_orders)?;
         writeln!(
             f,

--- a/crates/orderbook/src/main.rs
+++ b/crates/orderbook/src/main.rs
@@ -492,6 +492,7 @@ async fn main() {
         args.max_order_validity_period,
         SignatureConfiguration {
             eip1271: args.enable_eip1271_orders,
+            eip1271_skip_creation_validation: args.eip1271_skip_creation_validation,
             presign: args.enable_presign_orders,
         },
         bad_token_detector.clone(),

--- a/crates/shared/src/order_validation.rs
+++ b/crates/shared/src/order_validation.rs
@@ -336,13 +336,20 @@ impl OrderValidating for OrderValidator {
         let signing_scheme = order.signature.scheme();
 
         if let Signature::Eip1271(signature) = &order.signature {
-            self.signature_validator
-                .validate_signature(SignatureCheck {
-                    signer: owner,
-                    hash: hashed_eip712_message(domain_separator, &order.data.hash_struct()),
-                    signature: signature.to_owned(),
-                })
-                .await?;
+            if self
+                .signature_configuration
+                .eip1271_skip_creation_validation
+            {
+                tracing::debug!(?signature, "skipping EIP-1271 signature validation");
+            } else {
+                self.signature_validator
+                    .validate_signature(SignatureCheck {
+                        signer: owner,
+                        hash: hashed_eip712_message(domain_separator, &order.data.hash_struct()),
+                        signature: signature.to_owned(),
+                    })
+                    .await?;
+            }
         }
 
         if order.data.buy_amount.is_zero() || order.data.sell_amount.is_zero() {
@@ -479,9 +486,10 @@ impl OrderValidating for OrderValidator {
 }
 
 /// Signature configuration that is accepted by the orderbook.
-#[derive(Debug, Eq, PartialEq, Default)]
+#[derive(Debug, Eq, PartialEq)]
 pub struct SignatureConfiguration {
     pub eip1271: bool,
+    pub eip1271_skip_creation_validation: bool,
     pub presign: bool,
 }
 
@@ -491,6 +499,7 @@ impl SignatureConfiguration {
     pub fn off_chain() -> Self {
         Self {
             eip1271: false,
+            eip1271_skip_creation_validation: false,
             presign: false,
         }
     }
@@ -499,6 +508,7 @@ impl SignatureConfiguration {
     pub fn all() -> Self {
         Self {
             eip1271: true,
+            eip1271_skip_creation_validation: false,
             presign: true,
         }
     }
@@ -993,7 +1003,31 @@ mod tests {
         };
 
         assert!(validator
-            .validate_and_construct_order(creation, &domain_separator, Default::default())
+            .validate_and_construct_order(creation.clone(), &domain_separator, Default::default())
+            .await
+            .is_ok());
+
+        let mut signature_validator = MockSignatureValidating::new();
+        signature_validator
+            .expect_validate_signature()
+            .with(eq(SignatureCheck {
+                signer: creation.from.unwrap(),
+                hash: order_hash,
+                signature: vec![1, 2, 3],
+            }))
+            .returning(|_| Err(SignatureValidationError::Invalid));
+
+        let validator = OrderValidator {
+            signature_validator: Arc::new(signature_validator),
+            signature_configuration: SignatureConfiguration {
+                eip1271_skip_creation_validation: true,
+                ..SignatureConfiguration::all()
+            },
+            ..validator
+        };
+
+        assert!(validator
+            .validate_and_construct_order(creation.clone(), &domain_separator, Default::default())
             .await
             .is_ok());
     }

--- a/crates/solver/Cargo.toml
+++ b/crates/solver/Cargo.toml
@@ -45,6 +45,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 serde_with = { version = "1.11", default-features = false }
 shared = { path = "../shared" }
+sqlx = { version = "0.6", default-features = false, features = ["runtime-tokio-native-tls"] }
 strum = { version = "0.24", features = ["derive"] }
 thiserror = "1.0"
 tokio = { version = "1.15", features = ["macros", "rt-multi-thread", "time", "test-util"] }
@@ -53,6 +54,5 @@ web3 = { version = "0.18", default-features = false }
 mockall = "0.11"
 
 [dev-dependencies]
-sqlx = { version = "0.6", default-features = false, features = ["runtime-tokio-native-tls"] }
 tracing-subscriber = "0.3"
 testlib = { path = "../testlib" }


### PR DESCRIPTION
This PR adds a new `--eip1271-skip-creation-validation` flag to the `orderbook` API. This flag controls whether or not ERC-1271 orders need to have `isValidSignature` on creation. Note that order signatures are still verified by the `autopilot` when preparing auctions (i.e. it still filters invalid signatures from batches). This means that this change will not change the orders that make it to the solver, but just allow invalid orders to be placed.

The main motivation for this change is to enable "smart" orders that start off invalid and become valid at some later point in time.
Examples of this are:
- "Good after time" (GAT) orders
- Stop-loss orders

There are some potential concerns about order spamming (i.e. creating orders with invalid signatures that won't ever become valid). However, I don't think change makes the situation worse (as this can already be achieved by placing ERC-1271 orders where the `isValidSignature` detects simulation), as well as with pre-sign orders.

In the future, once we stablize on-chain order event signaling (which we are close to doing for Eth-flow orders) this change can be reversed. Using on-chain events for these kinds of order would get us spam protection (by nature of Ethereum transactions already having spam protection).

### Test Plan

CI - added new unit test to verify logic.
