### PR TITLE
Removed unused parameter when calling quasimodo.

### DIFF
--- a/crates/shared/src/http_solver.rs
+++ b/crates/shared/src/http_solver.rs
@@ -58,9 +58,6 @@ pub struct SolverConfig {
     /// Controls value of the `max_nr_exec_orders` parameter.
     pub max_nr_exec_orders: u32,
 
-    /// Controls if we should fill the `ucp_policy` parameter.
-    pub has_ucp_policy_parameter: bool,
-
     /// Controls if/how to set `use_internal_buffers`.
     pub use_internal_buffers: Option<bool>,
 
@@ -73,7 +70,6 @@ impl Default for SolverConfig {
         Self {
             api_key: None,
             max_nr_exec_orders: 100,
-            has_ucp_policy_parameter: false,
             use_internal_buffers: None,
             objective: None,
         }
@@ -116,10 +112,6 @@ impl HttpSolverApi for DefaultHttpSolverApi {
                 "max_nr_exec_orders",
                 self.config.max_nr_exec_orders.to_string().as_str(),
             );
-        if self.config.has_ucp_policy_parameter {
-            url.query_pairs_mut()
-                .append_pair("ucp_policy", "EnforceForOrders");
-        }
         if let Some(use_internal_buffers) = self.config.use_internal_buffers {
             url.query_pairs_mut().append_pair(
                 "use_internal_buffers",


### PR DESCRIPTION
Passing "--ucp_policy EnforceForOrders" as a query parameter when calling quasimodo is no longer necessary.