### PR TITLE
Get liquidity for latest state (not specific block)

### DIFF
--- a/crates/driver/src/auction_converter.rs
+++ b/crates/driver/src/auction_converter.rs
@@ -88,7 +88,7 @@ impl AuctionConverting for AuctionConverter {
 
         let liquidity = self
             .liquidity_collector
-            .get_liquidity_for_orders(&orders, Block::Number(block))
+            .get_liquidity_for_orders(&orders, Block::Recent)
             .await?;
 
         let external_prices =


### PR DESCRIPTION
This PR should fix the error when liquidity fetchers use `eth_call` for a block number that still does not exist in their blockchain state.

This happens because of the block propagation delay. More context: https://cowservices.slack.com/archives/C0361CDD1FZ/p1663258604879449

The consequence of this fix is that solvers will think the state of liquidity they received (field `liquidity_fetch_block`) is for some specific block, while sometimes some part of liquidity could be older than that specific block.
This is better than failing to get liquidity as it is now.


### Test Plan
Will test locally if team members agree this change makes sense.

