### PR TITLE
Return better error message if auction is 404

### DIFF
--- a/crates/solver/src/orderbook.rs
+++ b/crates/solver/src/orderbook.rs
@@ -20,7 +20,12 @@ impl OrderBookApi {
 
     pub async fn get_auction(&self) -> Result<AuctionWithId> {
         let url = self.base.join("api/v1/auction")?;
-        let auction = self.client.get(url).send().await?.json().await?;
+        let response = self.client.get(url).send().await?;
+        if let Err(err) = response.error_for_status_ref() {
+            let body = response.text().await;
+            return Err(anyhow::Error::new(err).context(format!("body: {:?}", body)));
+        }
+        let auction = response.json().await?;
         Ok(auction)
     }
 


### PR DESCRIPTION
The api can return a 404 if there is no current auction. In this case the body is empty so we get a generic "failed to decode json" error message. With this change we check the status code and return a better message.

### Test Plan

CI, didn't manually test how the error message looks exactly