### PR TITLE
Introduce 1Inch Trade Finder

### DIFF
--- a/crates/shared/src/oneinch_api.rs
+++ b/crates/shared/src/oneinch_api.rs
@@ -1,4 +1,4 @@
-//! 1]]Inch HTTP API client implementation.
+//! 1Inch HTTP API client implementation.
 //!
 //! For more information on the HTTP API, consult:
 //! <https://docs.1inch.io/docs/aggregation-protocol/api/swagger>

--- a/crates/shared/src/oneinch_api.rs
+++ b/crates/shared/src/oneinch_api.rs
@@ -1,19 +1,22 @@
-//! 1Inch HTTP API client implementation.
+//! 1]]Inch HTTP API client implementation.
 //!
 //! For more information on the HTTP API, consult:
 //! <https://docs.1inch.io/docs/aggregation-protocol/api/swagger>
 //! Although there is no documentation about API v4.1, it exists and is identical to v4.0 except it
 //! uses EIP 1559 gas prices.
 use crate::solver_utils::Slippage;
-use anyhow::{ensure, Context, Result};
+use anyhow::{ensure, Result};
 use cached::{Cached, TimedCache};
 use ethcontract::{H160, U256};
 use model::u256_decimal;
 use reqwest::{Client, IntoUrl, Url};
-use serde::Deserialize;
-use std::fmt::{self, Display, Formatter};
-use std::sync::{Arc, Mutex};
-use std::time::Duration;
+use serde::{de::DeserializeOwned, Deserialize};
+use std::{
+    fmt::{self, Display, Formatter},
+    sync::{Arc, Mutex},
+    time::Duration,
+};
+use thiserror::Error;
 
 /// Parts to split a swap.
 ///
@@ -324,7 +327,34 @@ pub enum RestResponse<T> {
     Err(RestError),
 }
 
-#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Default)]
+#[derive(Debug, Error)]
+pub enum OneInchError {
+    #[error("1Inch API error: {0}")]
+    Api(#[from] RestError),
+    #[error(transparent)]
+    Other(#[from] anyhow::Error),
+}
+
+impl OneInchError {
+    pub fn is_insuffucient_liquidity(&self) -> bool {
+        matches!(self, Self::Api(err) if err.description == "insufficient liquidity")
+    }
+}
+
+impl From<reqwest::Error> for OneInchError {
+    fn from(err: reqwest::Error) -> Self {
+        Self::Other(err.into())
+    }
+}
+
+impl From<serde_json::Error> for OneInchError {
+    fn from(err: serde_json::Error) -> Self {
+        Self::Other(err.into())
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Default, Error)]
+#[error("1Inch API error ({status_code}): {description}")]
 #[serde(rename_all = "camelCase")]
 pub struct RestError {
     pub status_code: u32,
@@ -421,19 +451,19 @@ pub struct Protocols {
 #[async_trait::async_trait]
 pub trait OneInchClient: Send + Sync {
     /// Retrieves a swap for the specified parameters from the 1Inch API.
-    async fn get_swap(&self, query: SwapQuery) -> Result<RestResponse<Swap>>;
+    async fn get_swap(&self, query: SwapQuery) -> Result<Swap, OneInchError>;
 
     /// Quotes a sell order with the 1Inch API.
     async fn get_sell_order_quote(
         &self,
         query: SellOrderQuoteQuery,
-    ) -> Result<RestResponse<SellOrderQuote>>;
+    ) -> Result<SellOrderQuote, OneInchError>;
 
     /// Retrieves the address of the spender to use for token approvals.
-    async fn get_spender(&self) -> Result<Spender>;
+    async fn get_spender(&self) -> Result<Spender, OneInchError>;
 
     /// Retrieves a list of the on-chain protocols supported by 1Inch.
-    async fn get_liquidity_sources(&self) -> Result<Protocols>;
+    async fn get_liquidity_sources(&self) -> Result<Protocols, OneInchError>;
 }
 
 /// 1Inch API Client implementation.
@@ -467,18 +497,18 @@ impl OneInchClientImpl {
 
 #[async_trait::async_trait]
 impl OneInchClient for OneInchClientImpl {
-    async fn get_swap(&self, query: SwapQuery) -> Result<RestResponse<Swap>> {
+    async fn get_swap(&self, query: SwapQuery) -> Result<Swap, OneInchError> {
         logged_query(&self.client, query.into_url(&self.base_url, self.chain_id)).await
     }
 
     async fn get_sell_order_quote(
         &self,
         query: SellOrderQuoteQuery,
-    ) -> Result<RestResponse<SellOrderQuote>> {
+    ) -> Result<SellOrderQuote, OneInchError> {
         logged_query(&self.client, query.into_url(&self.base_url, self.chain_id)).await
     }
 
-    async fn get_spender(&self) -> Result<Spender> {
+    async fn get_spender(&self) -> Result<Spender, OneInchError> {
         let endpoint = format!("v4.1/{}/approve/spender", self.chain_id);
         let url = self
             .base_url
@@ -487,7 +517,7 @@ impl OneInchClient for OneInchClientImpl {
         logged_query(&self.client, url).await
     }
 
-    async fn get_liquidity_sources(&self) -> Result<Protocols> {
+    async fn get_liquidity_sources(&self) -> Result<Protocols, OneInchError> {
         let endpoint = format!("v4.1/{}/liquidity-sources", self.chain_id);
         let url = self
             .base_url
@@ -497,14 +527,17 @@ impl OneInchClient for OneInchClientImpl {
     }
 }
 
-async fn logged_query<D>(client: &Client, url: Url) -> Result<D>
+async fn logged_query<D>(client: &Client, url: Url) -> Result<D, OneInchError>
 where
-    D: for<'de> Deserialize<'de>,
+    D: DeserializeOwned,
 {
     tracing::debug!("Query 1inch API for url {}", url);
     let response = client.get(url).send().await?.text().await;
     tracing::debug!("Response from 1inch API: {:?}", response);
-    serde_json::from_str(&response?).context("1inch result parsing failed")
+    match serde_json::from_str::<RestResponse<D>>(&response?)? {
+        RestResponse::Ok(result) => Ok(result),
+        RestResponse::Err(err) => Err(err.into()),
+    }
 }
 
 #[derive(Debug, Clone)]

--- a/crates/shared/src/solver_utils.rs
+++ b/crates/shared/src/solver_utils.rs
@@ -13,6 +13,8 @@ use std::{
 pub struct Slippage(pub f64);
 
 impl Slippage {
+    pub const ONE_PERCENT: Self = Self(1.);
+
     /// Creates a slippage amount from the specified percentage.
     pub fn percentage(amount: f64) -> Result<Self> {
         // 1Inch API only accepts a slippage from 0 to 50.

--- a/crates/shared/src/trade_finding.rs
+++ b/crates/shared/src/trade_finding.rs
@@ -1,6 +1,7 @@
 //! A module for abstracting a component that can produce a quote with calldata
 //! for a specified token pair and amount.
 
+pub mod oneinch;
 pub mod zeroex;
 
 use crate::price_estimation::Query;

--- a/crates/shared/src/trade_finding/oneinch.rs
+++ b/crates/shared/src/trade_finding/oneinch.rs
@@ -1,0 +1,298 @@
+//! A 1Inch-based trade finder.
+
+use super::{Interaction, Query, Trade, TradeError, TradeFinding};
+use crate::{
+    oneinch_api::{OneInchClient, OneInchError, ProtocolCache, SellOrderQuoteQuery, SwapQuery},
+    price_estimation::gas,
+    solver_utils::Slippage,
+};
+use model::order::OrderKind;
+use primitive_types::H160;
+use std::sync::Arc;
+
+pub struct OneInchTradeFinder {
+    api: Arc<dyn OneInchClient>,
+    disabled_protocols: Vec<String>,
+    protocol_cache: ProtocolCache,
+    referrer_address: Option<H160>,
+}
+
+impl OneInchTradeFinder {
+    async fn quote_and_swap(&self, query: &Query) -> Result<Trade, TradeError> {
+        if query.kind == OrderKind::Buy {
+            return Err(TradeError::UnsupportedOrderType);
+        }
+
+        let allowed_protocols = self
+            .protocol_cache
+            .get_allowed_protocols(&self.disabled_protocols, self.api.as_ref())
+            .await?;
+
+        let (quote, spender, swap) = futures::try_join!(
+            self.api
+                .get_sell_order_quote(SellOrderQuoteQuery::with_default_options(
+                    query.sell_token,
+                    query.buy_token,
+                    allowed_protocols.clone(),
+                    query.in_amount,
+                    self.referrer_address,
+                )),
+            self.api.get_spender(),
+            self.api.get_swap(SwapQuery::with_default_options(
+                query.sell_token,
+                query.buy_token,
+                query.in_amount,
+                query.from.unwrap_or_default(),
+                allowed_protocols,
+                Slippage::ONE_PERCENT,
+                self.referrer_address,
+            )),
+        )?;
+
+        Ok(Trade {
+            out_amount: quote.to_token_amount,
+            gas_estimate: gas::SETTLEMENT_OVERHEAD + quote.estimated_gas,
+            approval: Some((query.sell_token, spender.address)),
+            interaction: Interaction {
+                target: swap.tx.to,
+                value: swap.tx.value,
+                data: swap.tx.data,
+            },
+        })
+    }
+
+    pub fn new(
+        api: Arc<dyn OneInchClient>,
+        disabled_protocols: Vec<String>,
+        referrer_address: Option<H160>,
+    ) -> Self {
+        Self {
+            api,
+            disabled_protocols,
+            protocol_cache: ProtocolCache::default(),
+            referrer_address,
+        }
+    }
+}
+
+impl From<OneInchError> for TradeError {
+    fn from(err: OneInchError) -> Self {
+        match err {
+            err if err.is_insuffucient_liquidity() => Self::NoLiquidity,
+            err => Self::Other(err.into()),
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl TradeFinding for OneInchTradeFinder {
+    async fn get_trade(&self, query: &Query) -> Result<Trade, TradeError> {
+        self.quote_and_swap(query).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::oneinch_api::{
+        MockOneInchClient, OneInchClientImpl, RestError, SellOrderQuote, Spender, Swap, Token,
+        Transaction,
+    };
+    use reqwest::Client;
+
+    fn create_trade_finder<T: OneInchClient + 'static>(api: T) -> OneInchTradeFinder {
+        OneInchTradeFinder::new(Arc::new(api), Vec::default(), None)
+    }
+
+    #[tokio::test]
+    async fn estimate_sell_order_succeeds() {
+        // How much GNO can you buy for 1 WETH
+        let mut one_inch = MockOneInchClient::new();
+
+        // Response was generated with:
+        //
+        // curl 'https://api.1inch.io/v4.0/1/quote?\
+        //     fromTokenAddress=0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2&\
+        //     toTokenAddress=0x6810e776880c02933d47db1b9fc05908e5386b96&\
+        //     amount=100000000000000000'
+        //
+        // curl 'https://api.1inch.io/v4.0/1/swap?\
+        //     fromTokenAddress=0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2&\
+        //     toTokenAddress=0x6810e776880c02933d47db1b9fc05908e5386b96&\
+        //     amount=100000000000000000&\
+        //     fromAddress=0x0000000000000000000000000000000000000000&\
+        //     slippage=1&\
+        //     disableEstimate=true'
+        one_inch.expect_get_sell_order_quote().return_once(|_| {
+            Ok(SellOrderQuote {
+                from_token: Token {
+                    address: testlib::tokens::WETH,
+                },
+                to_token: Token {
+                    address: testlib::tokens::GNO,
+                },
+                to_token_amount: 808_069_760_400_778_577u128.into(),
+                from_token_amount: 100_000_000_000_000_000u128.into(),
+                protocols: Vec::default(),
+                estimated_gas: 189_386,
+            })
+        });
+        one_inch.expect_get_spender().return_once(|| {
+            Ok(Spender {
+                address: addr!("11111112542d85b3ef69ae05771c2dccff4faa26"),
+            })
+        });
+        one_inch.expect_get_swap().return_once(|_| {
+            Ok(Swap {
+                from_token: Token {
+                    address: testlib::tokens::WETH,
+                },
+                to_token: Token {
+                    address: testlib::tokens::GNO,
+                },
+                to_token_amount: 808_069_760_400_778_577u128.into(),
+                from_token_amount: 100_000_000_000_000_000u128.into(),
+                protocols: Default::default(),
+                tx: Transaction {
+                    from: Default::default(),
+                    to: addr!("1111111254fb6c44bac0bed2854e76f90643097d"),
+                    data: vec![0xe4, 0x49, 0x02, 0x2e],
+                    value: Default::default(),
+                    max_fee_per_gas: Default::default(),
+                    max_priority_fee_per_gas: Default::default(),
+                    gas: Default::default(),
+                },
+            })
+        });
+
+        let estimator = create_trade_finder(one_inch);
+
+        let trade = estimator
+            .get_trade(&Query {
+                from: None,
+                sell_token: testlib::tokens::WETH,
+                buy_token: testlib::tokens::GNO,
+                in_amount: 1_000_000_000_000_000_000u128.into(),
+                kind: OrderKind::Sell,
+            })
+            .await
+            .unwrap();
+
+        assert_eq!(trade.out_amount, 808_069_760_400_778_577u128.into());
+        assert!(trade.gas_estimate > 189_386);
+        assert_eq!(
+            trade.interaction,
+            Interaction {
+                target: addr!("1111111254fb6c44bac0bed2854e76f90643097d"),
+                value: Default::default(),
+                data: vec![0xe4, 0x49, 0x02, 0x2e],
+            }
+        );
+    }
+
+    #[tokio::test]
+    async fn estimating_buy_order_fails() {
+        let mut one_inch = MockOneInchClient::new();
+
+        one_inch.expect_get_sell_order_quote().times(0);
+
+        let estimator = create_trade_finder(one_inch);
+
+        let est = estimator
+            .get_trade(&Query {
+                from: None,
+                sell_token: testlib::tokens::WETH,
+                buy_token: testlib::tokens::GNO,
+                in_amount: 1_000_000_000_000_000_000u128.into(),
+                kind: OrderKind::Buy,
+            })
+            .await;
+
+        assert!(matches!(est, Err(TradeError::UnsupportedOrderType)));
+    }
+
+    #[tokio::test]
+    async fn rest_api_errors_get_propagated() {
+        let mut one_inch = MockOneInchClient::new();
+        one_inch
+            .expect_get_sell_order_quote()
+            .times(1)
+            .return_once(|_| {
+                Err(OneInchError::Api(RestError {
+                    status_code: 500,
+                    description: "Internal Server Error".to_string(),
+                }))
+            });
+
+        let estimator = create_trade_finder(one_inch);
+
+        let est = estimator
+            .get_trade(&Query {
+                from: None,
+                sell_token: testlib::tokens::WETH,
+                buy_token: testlib::tokens::GNO,
+                in_amount: 1_000_000_000_000_000_000u128.into(),
+                kind: OrderKind::Sell,
+            })
+            .await;
+
+        assert!(matches!(
+            est,
+            Err(TradeError::Other(e)) if e.to_string().contains("Internal Server Error")
+        ));
+    }
+
+    #[tokio::test]
+    async fn request_errors_get_propagated() {
+        let mut one_inch = MockOneInchClient::new();
+        one_inch
+            .expect_get_sell_order_quote()
+            .times(1)
+            .return_once(|_| Err(OneInchError::Other(anyhow::anyhow!("malformed JSON"))));
+
+        let estimator = create_trade_finder(one_inch);
+
+        let est = estimator
+            .get_trade(&Query {
+                from: None,
+                sell_token: testlib::tokens::WETH,
+                buy_token: testlib::tokens::GNO,
+                in_amount: 1_000_000_000_000_000_000u128.into(),
+                kind: OrderKind::Sell,
+            })
+            .await;
+
+        assert!(matches!(
+            est,
+            Err(TradeError::Other(e)) if e.to_string() == "malformed JSON"
+        ));
+    }
+
+    #[tokio::test]
+    #[ignore]
+    async fn real_estimate() {
+        let weth = testlib::tokens::WETH;
+        let gno = testlib::tokens::GNO;
+
+        let one_inch =
+            OneInchClientImpl::new(OneInchClientImpl::DEFAULT_URL, Client::new(), 1).unwrap();
+        let estimator = create_trade_finder(one_inch);
+
+        let result = estimator
+            .get_trade(&Query {
+                from: None,
+                sell_token: weth,
+                buy_token: gno,
+                in_amount: 10u128.pow(18).into(),
+                kind: OrderKind::Sell,
+            })
+            .await;
+
+        let trade = result.unwrap();
+        println!(
+            "1 WETH buys {} GNO, costing {} gas",
+            trade.out_amount.to_f64_lossy() / 1e18,
+            trade.gas_estimate,
+        );
+    }
+}


### PR DESCRIPTION
This PR introduces a 1Inch `TradeFinding` implementations.

In #519 and #520, we introduced a `TradeFinding` price estimator that can additionally simulate trade calldata to make sure trades are valid.

This PR adds a `TradeFinding` implementation for 1Inch so that it can be used with this price estimation abstraction in the future. Note that we don't quite make use of it yet, for reasons 👇.

One of the functionality changes in the PR is that now, for price estimation, we don't just compute a 1Inch `quote` but `quote` and `swap`. This is because:
- `quote` has `gas_estimate` values - while they aren't needed if we simulate, they are needed by the `TradeFinding` interface and will be used if:
  - A `TradeFinding`-based price estimator is configured without a `TradeVerifier` for trade simulation
  - If the `TradeVerifier` returns an intermittent HTTP error (like a node returning HTTP 503 or something)
- `swap` has calldata

Before making a 1Inch `TradeFinding`-based price estimator, I will refactor the interface a bit so that it can deal with the fact that getting a quote and getting a trade aren't necessarily done in a single call (for ParaSwap as well for example).

### Test Plan

Added unit tests, and ran manual tests with `cargo run -- --ignored oneinch`.
