### PR TITLE
Expand TradeFinding Interface for Quoting

### DIFF
--- a/crates/shared/src/price_estimation/trade_finder.rs
+++ b/crates/shared/src/price_estimation/trade_finder.rs
@@ -74,16 +74,21 @@ impl TradeEstimator {
 
 impl Inner {
     async fn estimate(self, query: Query) -> Result<Estimate, PriceEstimationError> {
-        let trade = self.finder.get_trade(&query).await?;
         match self.verifier {
-            Some(verifier) => verifier
-                .verify(query, trade)
-                .await
-                .map_err(PriceEstimationError::Other),
-            None => Ok(Estimate {
-                out_amount: trade.out_amount,
-                gas: trade.gas_estimate,
-            }),
+            Some(verifier) => {
+                let trade = self.finder.get_trade(&query).await?;
+                verifier
+                    .verify(query, trade)
+                    .await
+                    .map_err(PriceEstimationError::Other)
+            }
+            None => {
+                let quote = self.finder.get_quote(&query).await?;
+                Ok(Estimate {
+                    out_amount: quote.out_amount,
+                    gas: quote.gas_estimate,
+                })
+            }
         }
     }
 }
@@ -295,7 +300,7 @@ mod tests {
         code_simulation::{MockCodeSimulating, TenderlyCodeSimulator},
         price_estimation::single_estimate,
         tenderly_api::TenderlyHttpApi,
-        trade_finding::{zeroex::ZeroExTradeFinder, Interaction, MockTradeFinding},
+        trade_finding::{zeroex::ZeroExTradeFinder, Interaction, MockTradeFinding, Quote},
         transport::create_env_test_transport,
         web3_traits::MockCodeFetching,
         zeroex_api::DefaultZeroExApi,
@@ -593,6 +598,42 @@ mod tests {
             Estimate {
                 out_amount: 1_010_000_u128.into(),
                 gas: 0,
+            }
+        );
+    }
+
+    #[tokio::test]
+    async fn estimates_with_quote_without_verifier() {
+        let query = Query {
+            from: Some(H160([0x1; 20])),
+            sell_token: H160([0x2; 20]),
+            buy_token: H160([0x3; 20]),
+            in_amount: 1_000_000_u128.into(),
+            kind: OrderKind::Sell,
+        };
+        let quote = Quote {
+            out_amount: 2_000_000_u128.into(),
+            gas_estimate: 133_700,
+        };
+
+        let mut finder = MockTradeFinding::new();
+        finder
+            .expect_get_quote()
+            .with(predicate::eq(query))
+            .returning({
+                let quote = quote.clone();
+                move |_| Ok(quote.clone())
+            });
+
+        let estimator = TradeEstimator::new(Arc::new(finder), RateLimiter::test());
+
+        let estimate = single_estimate(&estimator, &query).await.unwrap();
+
+        assert_eq!(
+            estimate,
+            Estimate {
+                out_amount: 2_000_000_u128.into(),
+                gas: 133_700,
             }
         );
     }

--- a/crates/shared/src/trade_finding.rs
+++ b/crates/shared/src/trade_finding.rs
@@ -16,7 +16,15 @@ use thiserror::Error;
 #[mockall::automock]
 #[async_trait::async_trait]
 pub trait TradeFinding: Send + Sync + 'static {
+    async fn get_quote(&self, query: &Query) -> Result<Quote, TradeError>;
     async fn get_trade(&self, query: &Query) -> Result<Trade, TradeError>;
+}
+
+/// A quote.
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct Quote {
+    pub out_amount: U256,
+    pub gas_estimate: u64,
 }
 
 /// A trade.

--- a/crates/shared/src/trade_finding/oneinch.rs
+++ b/crates/shared/src/trade_finding/oneinch.rs
@@ -1,6 +1,6 @@
 //! A 1Inch-based trade finder.
 
-use super::{Interaction, Query, Trade, TradeError, TradeFinding};
+use super::{Interaction, Query, Quote, Trade, TradeError, TradeFinding};
 use crate::{
     oneinch_api::{OneInchClient, OneInchError, ProtocolCache, SellOrderQuoteQuery, SwapQuery},
     price_estimation::gas,
@@ -18,7 +18,10 @@ pub struct OneInchTradeFinder {
 }
 
 impl OneInchTradeFinder {
-    async fn quote_and_swap(&self, query: &Query) -> Result<Trade, TradeError> {
+    async fn verify_query_and_get_protocols(
+        &self,
+        query: &Query,
+    ) -> Result<Option<Vec<String>>, TradeError> {
         if query.kind == OrderKind::Buy {
             return Err(TradeError::UnsupportedOrderType);
         }
@@ -28,15 +31,40 @@ impl OneInchTradeFinder {
             .get_allowed_protocols(&self.disabled_protocols, self.api.as_ref())
             .await?;
 
+        Ok(allowed_protocols)
+    }
+
+    async fn quote(&self, query: &Query) -> Result<Quote, TradeError> {
+        let allowed_protocols = self.verify_query_and_get_protocols(query).await?;
+        Ok(self.perform_quote(query, allowed_protocols).await?)
+    }
+
+    async fn perform_quote(
+        &self,
+        query: &Query,
+        allowed_protocols: Option<Vec<String>>,
+    ) -> Result<Quote, OneInchError> {
+        let quote = self
+            .api
+            .get_sell_order_quote(SellOrderQuoteQuery::with_default_options(
+                query.sell_token,
+                query.buy_token,
+                allowed_protocols,
+                query.in_amount,
+                self.referrer_address,
+            ))
+            .await?;
+
+        Ok(Quote {
+            out_amount: quote.to_token_amount,
+            gas_estimate: gas::SETTLEMENT_OVERHEAD + quote.estimated_gas,
+        })
+    }
+
+    async fn quote_and_swap(&self, query: &Query) -> Result<Trade, TradeError> {
+        let allowed_protocols = self.verify_query_and_get_protocols(query).await?;
         let (quote, spender, swap) = futures::try_join!(
-            self.api
-                .get_sell_order_quote(SellOrderQuoteQuery::with_default_options(
-                    query.sell_token,
-                    query.buy_token,
-                    allowed_protocols.clone(),
-                    query.in_amount,
-                    self.referrer_address,
-                )),
+            self.perform_quote(query, allowed_protocols.clone()),
             self.api.get_spender(),
             self.api.get_swap(SwapQuery::with_default_options(
                 query.sell_token,
@@ -50,8 +78,8 @@ impl OneInchTradeFinder {
         )?;
 
         Ok(Trade {
-            out_amount: quote.to_token_amount,
-            gas_estimate: gas::SETTLEMENT_OVERHEAD + quote.estimated_gas,
+            out_amount: quote.out_amount,
+            gas_estimate: quote.gas_estimate,
             approval: Some((query.sell_token, spender.address)),
             interaction: Interaction {
                 target: swap.tx.to,
@@ -86,6 +114,10 @@ impl From<OneInchError> for TradeError {
 
 #[async_trait::async_trait]
 impl TradeFinding for OneInchTradeFinder {
+    async fn get_quote(&self, query: &Query) -> Result<Quote, TradeError> {
+        self.quote(query).await
+    }
+
     async fn get_trade(&self, query: &Query) -> Result<Trade, TradeError> {
         self.quote_and_swap(query).await
     }
@@ -102,6 +134,49 @@ mod tests {
 
     fn create_trade_finder<T: OneInchClient + 'static>(api: T) -> OneInchTradeFinder {
         OneInchTradeFinder::new(Arc::new(api), Vec::default(), None)
+    }
+
+    #[tokio::test]
+    async fn quote_sell_order_succeeds() {
+        // How much GNO can you buy for 1 WETH
+        let mut one_inch = MockOneInchClient::new();
+
+        // Response was generated with:
+        //
+        // curl 'https://api.1inch.io/v4.0/1/quote?\
+        //     fromTokenAddress=0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2&\
+        //     toTokenAddress=0x6810e776880c02933d47db1b9fc05908e5386b96&\
+        //     amount=100000000000000000'
+        one_inch.expect_get_sell_order_quote().return_once(|_| {
+            Ok(SellOrderQuote {
+                from_token: Token {
+                    address: testlib::tokens::WETH,
+                },
+                to_token: Token {
+                    address: testlib::tokens::GNO,
+                },
+                to_token_amount: 808_069_760_400_778_577u128.into(),
+                from_token_amount: 100_000_000_000_000_000u128.into(),
+                protocols: Vec::default(),
+                estimated_gas: 189_386,
+            })
+        });
+
+        let estimator = create_trade_finder(one_inch);
+
+        let quote = estimator
+            .get_quote(&Query {
+                from: None,
+                sell_token: testlib::tokens::WETH,
+                buy_token: testlib::tokens::GNO,
+                in_amount: 1_000_000_000_000_000_000u128.into(),
+                kind: OrderKind::Sell,
+            })
+            .await
+            .unwrap();
+
+        assert_eq!(quote.out_amount, 808_069_760_400_778_577u128.into());
+        assert!(quote.gas_estimate > 189_386);
     }
 
     #[tokio::test]

--- a/crates/shared/src/trade_finding/zeroex.rs
+++ b/crates/shared/src/trade_finding/zeroex.rs
@@ -1,6 +1,6 @@
 //! A 0x-based trade finder.
 
-use super::{Interaction, Trade, TradeError, TradeFinding};
+use super::{Interaction, Quote, Trade, TradeError, TradeFinding};
 use crate::{
     price_estimation::{gas, Query},
     zeroex_api::{SwapQuery, ZeroExApi, ZeroExResponseError},
@@ -58,6 +58,14 @@ impl ZeroExTradeFinder {
 
 #[async_trait::async_trait]
 impl TradeFinding for ZeroExTradeFinder {
+    async fn get_quote(&self, query: &Query) -> Result<Quote, TradeError> {
+        let trade = self.quote(query).await?;
+        Ok(Quote {
+            out_amount: trade.out_amount,
+            gas_estimate: trade.gas_estimate,
+        })
+    }
+
     async fn get_trade(&self, query: &Query) -> Result<Trade, TradeError> {
         self.quote(query).await
     }


### PR DESCRIPTION
When porting 1Inch and ParaSwap price estimators to the new `TradeFinding` abstraction (so that we can simulate trades).

For both 1Inch and ParaSwap, we only need the calldata **IF** we are simulating trades (i.e. `trade_verifier.is_some()`). The "vision" is to have only trade verification for `price_quality: Optimal`, so for our `Fast` estimates, we don't want the additional parallel API requests (for 1Inch) or additional roundtrip API requests (for ParaSwap).

With this change, expand the `TradeFinding` abstraction to also provide logic for getting quotes without calldata, and use that when no verification is needed. This has the effect that our 1Inch and ParaSwap `Fast` price estimates will work exactly as they do today, and the `Optional` one will simluate trades.

### Test Plan

Added unit test to verify new logic.
