### PR TITLE
Introduce ParaSwap Trade Finder

### DIFF
--- a/crates/shared/src/paraswap_api.rs
+++ b/crates/shared/src/paraswap_api.rs
@@ -150,9 +150,9 @@ pub struct PriceQuery {
     /// destination token address
     pub dest_token: H160,
     /// decimals of from token (according to API needed  to trade any token)
-    pub src_decimals: usize,
+    pub src_decimals: u8,
     /// decimals of to token (according to API needed to trade any token)
-    pub dest_decimals: usize,
+    pub dest_decimals: u8,
     /// amount of source token (in the smallest denomination, e.g. for ETH - 10**18)
     pub amount: U256,
     /// Type of order
@@ -261,9 +261,9 @@ pub struct TransactionBuilderQuery {
     /// The maximum slippage in BPS.
     pub slippage: u32,
     /// The decimals of the source token
-    pub src_decimals: usize,
+    pub src_decimals: u8,
     /// The decimals of the destination token
-    pub dest_decimals: usize,
+    pub dest_decimals: u8,
     /// priceRoute part from /prices endpoint response (without any change)
     pub price_route: Value,
     /// The address of the signer

--- a/crates/shared/src/price_estimation/paraswap.rs
+++ b/crates/shared/src/price_estimation/paraswap.rs
@@ -50,8 +50,8 @@ impl ParaswapPriceEstimator {
         let price_query = PriceQuery {
             src_token: query.sell_token,
             dest_token: query.buy_token,
-            src_decimals: sell_decimals as usize,
-            dest_decimals: buy_decimals as usize,
+            src_decimals: sell_decimals,
+            dest_decimals: buy_decimals,
             amount: query.in_amount,
             side: match query.kind {
                 OrderKind::Buy => Side::Buy,

--- a/crates/shared/src/token_info.rs
+++ b/crates/shared/src/token_info.rs
@@ -6,8 +6,6 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use tokio::sync::Mutex;
 
-use mockall::*;
-
 const MAX_BATCH_SIZE: usize = 100;
 
 #[cfg_attr(test, derive(Eq, PartialEq))]
@@ -21,7 +19,7 @@ pub struct TokenInfoFetcher {
     pub web3: Web3,
 }
 
-#[automock]
+#[mockall::automock]
 #[async_trait]
 pub trait TokenInfoFetching: Send + Sync {
     /// Retrieves all token information.

--- a/crates/shared/src/trade_finding.rs
+++ b/crates/shared/src/trade_finding.rs
@@ -2,6 +2,7 @@
 //! for a specified token pair and amount.
 
 pub mod oneinch;
+pub mod paraswap;
 pub mod zeroex;
 
 use crate::price_estimation::Query;

--- a/crates/shared/src/trade_finding/paraswap.rs
+++ b/crates/shared/src/trade_finding/paraswap.rs
@@ -1,0 +1,175 @@
+use super::{Query, Quote, TradeError, TradeFinding};
+use crate::{
+    paraswap_api::{
+        ParaswapApi, ParaswapResponseError, PriceQuery, PriceResponse, Side, TradeAmount,
+        TransactionBuilderQuery,
+    },
+    price_estimation::gas,
+    token_info::{TokenInfo, TokenInfoFetching},
+    trade_finding::{Interaction, Trade},
+};
+use anyhow::{Context, Result};
+use model::order::OrderKind;
+use primitive_types::H160;
+use std::{collections::HashMap, sync::Arc};
+
+pub struct ParaswapTradeFinder {
+    paraswap: Arc<dyn ParaswapApi>,
+    tokens: Arc<dyn TokenInfoFetching>,
+    disabled_paraswap_dexs: Vec<String>,
+}
+
+type Tokens = HashMap<H160, TokenInfo>;
+
+impl ParaswapTradeFinder {
+    pub fn new(
+        api: Arc<dyn ParaswapApi>,
+        tokens: Arc<dyn TokenInfoFetching>,
+        disabled_paraswap_dexs: Vec<String>,
+    ) -> Self {
+        Self {
+            paraswap: api,
+            tokens,
+            disabled_paraswap_dexs,
+        }
+    }
+
+    async fn quote(&self, query: &Query) -> Result<(Quote, Tokens, PriceResponse), TradeError> {
+        let tokens = self
+            .tokens
+            .get_token_infos(&[query.sell_token, query.buy_token])
+            .await;
+
+        let price_query = PriceQuery {
+            src_token: query.sell_token,
+            dest_token: query.buy_token,
+            src_decimals: decimals(&tokens, &query.sell_token)?,
+            dest_decimals: decimals(&tokens, &query.buy_token)?,
+            amount: query.in_amount,
+            side: match query.kind {
+                OrderKind::Buy => Side::Buy,
+                OrderKind::Sell => Side::Sell,
+            },
+            exclude_dexs: Some(self.disabled_paraswap_dexs.clone()),
+        };
+
+        let price = self.paraswap.price(price_query).await?;
+        let quote = Quote {
+            out_amount: match query.kind {
+                OrderKind::Buy => price.src_amount,
+                OrderKind::Sell => price.dest_amount,
+            },
+            gas_estimate: gas::SETTLEMENT_OVERHEAD + price.gas_cost,
+        };
+
+        Ok((quote, tokens, price))
+    }
+
+    // Default to 1% slippage - same as the ParaSwap UI.
+    const DEFAULT_SLIPPAGE: u32 = 10_000;
+    // Use a default non-zero user address, otherwise the API will return an
+    // error.
+    const DEFAULT_USER: H160 = addr!("BEeFbeefbEefbeEFbeEfbEEfBEeFbeEfBeEfBeef");
+
+    async fn trade(&self, query: &Query) -> Result<Trade, TradeError> {
+        let (quote, tokens, mut price) = self.quote(query).await?;
+        let tx_query = TransactionBuilderQuery {
+            src_token: query.sell_token,
+            dest_token: query.buy_token,
+            trade_amount: match query.kind {
+                OrderKind::Buy => TradeAmount::Buy {
+                    dest_amount: query.in_amount,
+                },
+                OrderKind::Sell => TradeAmount::Sell {
+                    src_amount: query.in_amount,
+                },
+            },
+            slippage: Self::DEFAULT_SLIPPAGE,
+            src_decimals: decimals(&tokens, &query.sell_token)?,
+            dest_decimals: decimals(&tokens, &query.buy_token)?,
+            price_route: price.price_route_raw.take(),
+            user_address: query.from.unwrap_or(Self::DEFAULT_USER),
+        };
+
+        let tx = self.paraswap.transaction(tx_query).await?;
+
+        Ok(Trade {
+            out_amount: quote.out_amount,
+            gas_estimate: quote.gas_estimate,
+            approval: Some((query.sell_token, price.token_transfer_proxy)),
+            interaction: Interaction {
+                target: tx.to,
+                value: tx.value,
+                data: tx.data,
+            },
+        })
+    }
+}
+
+#[async_trait::async_trait]
+impl TradeFinding for ParaswapTradeFinder {
+    async fn get_quote(&self, query: &Query) -> Result<Quote, TradeError> {
+        let (quote, ..) = self.quote(query).await?;
+        Ok(quote)
+    }
+
+    async fn get_trade(&self, query: &Query) -> Result<Trade, TradeError> {
+        self.trade(query).await
+    }
+}
+
+impl From<ParaswapResponseError> for TradeError {
+    fn from(err: ParaswapResponseError) -> Self {
+        match err {
+            ParaswapResponseError::InsufficientLiquidity(_) => Self::NoLiquidity,
+            _ => Self::Other(err.into()),
+        }
+    }
+}
+
+fn decimals(tokens: &Tokens, token: &H160) -> Result<u8, TradeError> {
+    Ok(tokens
+        .get(token)
+        .and_then(|info| info.decimals)
+        .context("failed to get decimals")?)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        paraswap_api::DefaultParaswapApi, token_info::TokenInfoFetcher,
+        transport::create_env_test_transport, Web3,
+    };
+    use reqwest::Client;
+
+    #[tokio::test]
+    #[ignore]
+    async fn real_trade() {
+        let web3 = Web3::new(create_env_test_transport());
+        let tokens = TokenInfoFetcher { web3 };
+        let paraswap = DefaultParaswapApi {
+            client: Client::new(),
+            partner: "Test".to_string(),
+            rate_limiter: None,
+        };
+        let finder = ParaswapTradeFinder {
+            paraswap: Arc::new(paraswap),
+            tokens: Arc::new(tokens),
+            disabled_paraswap_dexs: Vec::new(),
+        };
+
+        let trade = finder
+            .get_trade(&Query {
+                from: None,
+                sell_token: testlib::tokens::WETH,
+                buy_token: testlib::tokens::COW,
+                in_amount: 10u128.pow(18).into(),
+                kind: OrderKind::Sell,
+            })
+            .await
+            .unwrap();
+
+        println!("1 ETH buys {} COW", trade.out_amount.to_f64_lossy() / 1e18);
+    }
+}

--- a/crates/solver/src/solver/paraswap_solver.rs
+++ b/crates/solver/src/solver/paraswap_solver.rs
@@ -187,10 +187,10 @@ impl ParaswapSolver {
     }
 }
 
-fn decimals(token_info: &HashMap<H160, TokenInfo>, token: &H160) -> Result<usize> {
+fn decimals(token_info: &HashMap<H160, TokenInfo>, token: &H160) -> Result<u8> {
     token_info
         .get(token)
-        .and_then(|info| info.decimals.map(usize::from))
+        .and_then(|info| info.decimals)
         .ok_or_else(|| anyhow!("decimals for token {:?} not found", token))
 }
 


### PR DESCRIPTION
This PR is a follow up to https://github.com/cowprotocol/services/pull/519 and https://github.com/cowprotocol/services/pull/520, where we introduced a `TradeFinding` interface and price estimator (with trade simulations).

Specifically, this PR implements a ParaSwap price finder that conforms to the new interface. This way, we will be able to make ParaSwap price estimates as before, but with one important caveat: We used to pre-fetch all token information for the "streamed" estimates. This was a nice optimization that allowed us to use a single round-trip to fetch all token infos for all traded tokens when batching price estimation queries.

For now, I just removed this feature because:
- It doesn't really improve price estimate performance since that is for a single trading pair anyway (so the `api/v1/quote` should perform the same as before).
- Token infos are already very aggressively cached, so over a long enough period, the gains should be minimal.

This would mostly negatively affect the auction building in the `autopilot`, but because of the aggressive caching, I imagine that this wouldn't make a very big difference. There are other strategies to address this (such as, specifically for the `autopilot` auction building, pre-fetch token infos before doing native price estimates).

### Test Plan

Run manual ParaSwap test:
```
% cargo test -p shared -- --ignored --nocapture trade_finding::paraswap
    Finished test [unoptimized + debuginfo] target(s) in 10.11s
     Running unittests src/lib.rs (target/debug/deps/shared-dc5df787a41d4411)

running 1 test
1 ETH buys 14577.219242427527 COW
test trade_finding::paraswap::tests::real_trade ... ok
```
