### PR TITLE
Refactor 1Inch Price Estimator

### DIFF
--- a/crates/shared/src/oneinch_api.rs
+++ b/crates/shared/src/oneinch_api.rs
@@ -449,7 +449,7 @@ pub struct Protocols {
 // Mockable version of API Client
 #[mockall::automock]
 #[async_trait::async_trait]
-pub trait OneInchClient: Send + Sync {
+pub trait OneInchClient: Send + Sync + 'static {
     /// Retrieves a swap for the specified parameters from the 1Inch API.
     async fn get_swap(&self, query: SwapQuery) -> Result<Swap, OneInchError>;
 

--- a/crates/shared/src/trade_finding/oneinch.rs
+++ b/crates/shared/src/trade_finding/oneinch.rs
@@ -18,6 +18,19 @@ pub struct OneInchTradeFinder {
 }
 
 impl OneInchTradeFinder {
+    pub fn new(
+        api: Arc<dyn OneInchClient>,
+        disabled_protocols: Vec<String>,
+        referrer_address: Option<H160>,
+    ) -> Self {
+        Self {
+            api,
+            disabled_protocols,
+            protocol_cache: ProtocolCache::default(),
+            referrer_address,
+        }
+    }
+
     async fn verify_query_and_get_protocols(
         &self,
         query: &Query,
@@ -87,19 +100,6 @@ impl OneInchTradeFinder {
                 data: swap.tx.data,
             },
         })
-    }
-
-    pub fn new(
-        api: Arc<dyn OneInchClient>,
-        disabled_protocols: Vec<String>,
-        referrer_address: Option<H160>,
-    ) -> Self {
-        Self {
-            api,
-            disabled_protocols,
-            protocol_cache: ProtocolCache::default(),
-            referrer_address,
-        }
     }
 }
 


### PR DESCRIPTION
Follow up from #552 (and very similar to #520) - this PR refactors the 1Inch price estimator to be implemented in function of the `OneInchTradeFinder` (i.e. its trade finding interface). This allows the price estimator to use the shared `TradeFinderPriceEstimator` implementation with rate limiting, request sharing and trade simulation.

### Test Plan

Existing unit tests continue to pass, as does manual test:
```
% cargo test -p shared -- --ignored --nocapture price_estimation::oneinch
    Finished test [unoptimized + debuginfo] target(s) in 13.46s
     Running unittests src/lib.rs (target/debug/deps/shared-dc5df787a41d4411)

running 1 test
[crates/shared/src/price_estimation/oneinch.rs:211] &result = Ok(
    Estimate {
        out_amount: 10512215403913030143,
        gas: 703807,
    },
)
1 WETH buys 10.51221540391303 GNO, costing 703807 gas
test price_estimation::oneinch::tests::real_estimate ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 340 filtered out; finished in 0.30s
```

Additionally, the price estimators are created **without** `TradeVerifier`, and we can check chat we are still making the same requests to the 1Inch API as before:
```
% cargo run -p orderbook -- --price-estimators OneInch | rg shared::oneinch_api
    Finished dev [unoptimized + debuginfo] target(s) in 0.31s
     Running `target/debug/orderbook --price-estimators OneInch`
2022-09-20T05:05:07.667Z DEBUG request{id=0}: shared::oneinch_api: Query 1inch API for url https://api.1inch.exchange/v4.1/1/liquidity-sources
2022-09-20T05:05:07.794Z DEBUG request{id=0}: shared::oneinch_api: Response from 1inch API: ...
2022-09-20T05:05:07.795Z DEBUG request{id=0}: shared::oneinch_api: Query 1inch API for url https://api.1inch.exchange/v4.1/1/quote?fromTokenAddress=0xdac17f958d2ee523a2206206994597c13d831ec7&toTokenAddress=0x6b175474e89094c44da98b954eedeac495271d0f&amount=10000000&protocols=...
2022-09-20T05:05:07.953Z DEBUG request{id=0}: shared::oneinch_api: Response from 1inch API:  ...
```
