### PR TITLE
Refactor ParaSwap Price Estimator

### DIFF
--- a/crates/shared/src/price_estimation/paraswap.rs
+++ b/crates/shared/src/price_estimation/paraswap.rs
@@ -1,29 +1,11 @@
+use super::{trade_finder::TradeEstimator, PriceEstimateResult, PriceEstimating, Query};
 use crate::{
-    paraswap_api::{ParaswapApi, ParaswapResponseError, PriceQuery, PriceResponse, Side},
-    price_estimation::{
-        gas, rate_limited, Estimate, PriceEstimateResult, PriceEstimating, PriceEstimationError,
-        Query,
-    },
-    rate_limiter::RateLimiter,
-    request_sharing::RequestSharing,
-    token_info::{TokenInfo, TokenInfoFetching},
+    paraswap_api::ParaswapApi, rate_limiter::RateLimiter, token_info::TokenInfoFetching,
+    trade_finding::paraswap::ParaswapTradeFinder,
 };
-use anyhow::{anyhow, Context, Result};
-use futures::{future::BoxFuture, FutureExt, StreamExt};
-use model::order::OrderKind;
-use primitive_types::H160;
-use std::{
-    collections::{HashMap, HashSet},
-    sync::Arc,
-};
+use std::sync::Arc;
 
-pub struct ParaswapPriceEstimator {
-    paraswap: Arc<dyn ParaswapApi>,
-    sharing: RequestSharing<Query, BoxFuture<'static, Result<PriceResponse, PriceEstimationError>>>,
-    token_info: Arc<dyn TokenInfoFetching>,
-    disabled_paraswap_dexs: Vec<String>,
-    rate_limiter: Arc<RateLimiter>,
-}
+pub struct ParaswapPriceEstimator(TradeEstimator);
 
 impl ParaswapPriceEstimator {
     pub fn new(
@@ -32,67 +14,15 @@ impl ParaswapPriceEstimator {
         disabled_paraswap_dexs: Vec<String>,
         rate_limiter: Arc<RateLimiter>,
     ) -> Self {
-        Self {
-            paraswap: api,
-            sharing: Default::default(),
-            token_info,
-            disabled_paraswap_dexs,
+        Self(TradeEstimator::new(
+            Arc::new(ParaswapTradeFinder::new(
+                api,
+                token_info,
+                disabled_paraswap_dexs,
+            )),
             rate_limiter,
-        }
+        ))
     }
-
-    async fn estimate_(
-        &self,
-        query: &Query,
-        sell_decimals: u8,
-        buy_decimals: u8,
-    ) -> PriceEstimateResult {
-        let price_query = PriceQuery {
-            src_token: query.sell_token,
-            dest_token: query.buy_token,
-            src_decimals: sell_decimals,
-            dest_decimals: buy_decimals,
-            amount: query.in_amount,
-            side: match query.kind {
-                OrderKind::Buy => Side::Buy,
-                OrderKind::Sell => Side::Sell,
-            },
-            exclude_dexs: Some(self.disabled_paraswap_dexs.clone()),
-        };
-        let paraswap = self.paraswap.clone();
-        let response_future = async move {
-            paraswap.price(price_query).await.map_err(|err| match err {
-                ParaswapResponseError::InsufficientLiquidity(_) => {
-                    PriceEstimationError::NoLiquidity
-                }
-                _ => PriceEstimationError::Other(err.into()),
-            })
-        };
-        let response_future = rate_limited(self.rate_limiter.clone(), response_future);
-
-        let response = self
-            .sharing
-            .shared(*query, response_future.boxed())
-            .await
-            .context("paraswap")?;
-        Ok(Estimate {
-            out_amount: match query.kind {
-                OrderKind::Buy => response.src_amount,
-                OrderKind::Sell => response.dest_amount,
-            },
-            gas: gas::SETTLEMENT_OVERHEAD + response.gas_cost,
-        })
-    }
-}
-
-fn decimals(
-    token: &H160,
-    token_infos: &HashMap<H160, TokenInfo>,
-) -> Result<u8, PriceEstimationError> {
-    token_infos
-        .get(token)
-        .and_then(|info| info.decimals)
-        .ok_or_else(|| PriceEstimationError::Other(anyhow!("failed to get decimals")))
 }
 
 impl PriceEstimating for ParaswapPriceEstimator {
@@ -100,36 +30,7 @@ impl PriceEstimating for ParaswapPriceEstimator {
         &'a self,
         queries: &'a [Query],
     ) -> futures::stream::BoxStream<'_, (usize, PriceEstimateResult)> {
-        debug_assert!(queries.iter().all(|query| {
-            query.buy_token != model::order::BUY_ETH_ADDRESS
-                && query.sell_token != model::order::BUY_ETH_ADDRESS
-                && query.sell_token != query.buy_token
-        }));
-
-        let tokens = queries
-            .iter()
-            .flat_map(|query| [query.sell_token, query.buy_token])
-            .collect::<HashSet<_>>()
-            .into_iter()
-            .collect::<Vec<_>>();
-        let token_infos = async move { self.token_info.get_token_infos(&tokens).await };
-        futures::stream::once(token_infos)
-            .flat_map(move |token_infos: HashMap<H160, TokenInfo>| {
-                // This looks weird because for lifetime reasons we need to get the decimals here instead of in the
-                // `then` closure below.
-                let queries = queries.iter().map(move |query| {
-                    (
-                        query,
-                        decimals(&query.sell_token, &token_infos),
-                        decimals(&query.buy_token, &token_infos),
-                    )
-                });
-                futures::stream::iter(queries).then(|(query, sell_decimals, buy_decimals)| async {
-                    self.estimate_(query, sell_decimals?, buy_decimals?).await
-                })
-            })
-            .enumerate()
-            .boxed()
+        self.0.estimates(queries)
     }
 }
 
@@ -138,43 +39,30 @@ mod tests {
     use super::*;
     use crate::{
         paraswap_api::DefaultParaswapApi, price_estimation::single_estimate,
-        token_info::MockTokenInfoFetching,
+        token_info::TokenInfoFetcher, transport::create_env_test_transport, Web3,
     };
+    use model::order::OrderKind;
     use reqwest::Client;
 
     #[tokio::test]
     #[ignore]
     async fn real_estimate() {
-        let mut token_info = MockTokenInfoFetching::new();
-        token_info.expect_get_token_infos().returning(|tokens| {
-            tokens
-                .iter()
-                .map(|token| {
-                    (
-                        *token,
-                        TokenInfo {
-                            decimals: Some(18),
-                            symbol: Some("SYM".to_string()),
-                        },
-                    )
-                })
-                .collect()
-        });
+        let web3 = Web3::new(create_env_test_transport());
+        let tokens = TokenInfoFetcher { web3 };
         let paraswap = DefaultParaswapApi {
             client: Client::new(),
-            partner: "".to_string(),
+            partner: "Test".to_string(),
             rate_limiter: None,
         };
-        let estimator = ParaswapPriceEstimator {
-            paraswap: Arc::new(paraswap),
-            sharing: Default::default(),
-            token_info: Arc::new(token_info),
-            disabled_paraswap_dexs: Vec::new(),
-            rate_limiter: Arc::new(RateLimiter::from_strategy(
+        let estimator = ParaswapPriceEstimator::new(
+            Arc::new(paraswap),
+            Arc::new(tokens),
+            Vec::default(),
+            Arc::new(RateLimiter::from_strategy(
                 Default::default(),
                 "test".into(),
             )),
-        };
+        );
 
         let weth = testlib::tokens::WETH;
         let gno = testlib::tokens::GNO;
@@ -193,7 +81,5 @@ mod tests {
             "1 eth buys {} gno",
             estimate.out_amount.to_f64_lossy() / 1e18
         );
-        // You can compare this to
-        // <api url>/api/v1/markets/c02aaa39b223fe8d0a0e5c4f27ead9083c756cc2-6810e776880c02933d47db1b9fc05908e5386b96/sell/1000000000000000000
     }
 }


### PR DESCRIPTION
This PR is similar to #561. It refactors the ParaSwap price estimator to be implemented in function of the `ParaswapTradeFinder` (i.e. its trade finding interface). This allows the price estimator to use the shared `TradeFinderPriceEstimator` implementation with rate limiting, request sharing and trade simulation.

### Test Plan

Manual ParaSwap test passes:
```
% cargo test -p shared -- --ignored --nocapture price_estimation::paraswap
    Blocking waiting for file lock on build directory
   Compiling shared v0.1.0 (/Users/nlordell/Developer/cowprotocol/services/crates/shared)
    Finished test [unoptimized + debuginfo] target(s) in 19.33s
     Running unittests src/lib.rs (target/debug/deps/shared-dc5df787a41d4411)

running 1 test
[crates/shared/src/price_estimation/paraswap.rs:78] &result = Ok(
    Estimate {
        out_amount: 10479615245004819204,
        gas: 415691,
    },
)
1 eth buys 10.479615245004819 gno
test price_estimation::paraswap::tests::real_estimate ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 340 filtered out; finished in 1.64s
```
