### PR TITLE
Add Request Sharing to 0x Trade Finder

### DIFF
--- a/crates/shared/src/price_estimation/zeroex.rs
+++ b/crates/shared/src/price_estimation/zeroex.rs
@@ -35,6 +35,7 @@ mod tests {
         price_estimation::single_estimate,
         zeroex_api::{DefaultZeroExApi, MockZeroExApi, PriceResponse, SwapResponse},
     };
+    use ethcontract::futures::FutureExt as _;
     use model::order::OrderKind;
     use reqwest::Client;
 
@@ -61,16 +62,19 @@ mod tests {
         //     slippagePercentage=0&\
         //     sellAmount=100000000000000000"
         zeroex_api.expect_get_swap().return_once(|_| {
-            Ok(SwapResponse {
-                price: PriceResponse {
-                    sell_amount: 100000000000000000u64.into(),
-                    buy_amount: 1110165823572443613u64.into(),
-                    allowance_target: addr!("def1c0ded9bec7f1a1670819833240f027b25eff"),
-                    price: 11.101_658_235_724_436,
-                    estimated_gas: 111000,
-                },
-                ..Default::default()
-            })
+            async move {
+                Ok(SwapResponse {
+                    price: PriceResponse {
+                        sell_amount: 100000000000000000u64.into(),
+                        buy_amount: 1110165823572443613u64.into(),
+                        allowance_target: addr!("def1c0ded9bec7f1a1670819833240f027b25eff"),
+                        price: 11.101_658_235_724_436,
+                        estimated_gas: 111000,
+                    },
+                    ..Default::default()
+                })
+            }
+            .boxed()
         });
 
         let weth = testlib::tokens::WETH;
@@ -107,16 +111,19 @@ mod tests {
         //     slippagePercentage=0&\
         //     buyAmount=100000000000000000"
         zeroex_api.expect_get_swap().return_once(|_| {
-            Ok(SwapResponse {
-                price: PriceResponse {
-                    sell_amount: 8986186353137488u64.into(),
-                    buy_amount: 100000000000000000u64.into(),
-                    allowance_target: addr!("def1c0ded9bec7f1a1670819833240f027b25eff"),
-                    price: 0.089_861_863_531_374_87,
-                    estimated_gas: 111000,
-                },
-                ..Default::default()
-            })
+            async move {
+                Ok(SwapResponse {
+                    price: PriceResponse {
+                        sell_amount: 8986186353137488u64.into(),
+                        buy_amount: 100000000000000000u64.into(),
+                        allowance_target: addr!("def1c0ded9bec7f1a1670819833240f027b25eff"),
+                        price: 0.089_861_863_531_374_87,
+                        estimated_gas: 111000,
+                    },
+                    ..Default::default()
+                })
+            }
+            .boxed()
         });
 
         let weth = testlib::tokens::WETH;

--- a/crates/shared/src/request_sharing.rs
+++ b/crates/shared/src/request_sharing.rs
@@ -1,5 +1,5 @@
 use futures::{
-    future::{Shared, WeakShared},
+    future::{BoxFuture, Shared, WeakShared},
     FutureExt,
 };
 use std::{future::Future, sync::Mutex};
@@ -17,6 +17,13 @@ use std::{future::Future, sync::Mutex};
 pub struct RequestSharing<Request, Fut: Future> {
     in_flight: Mutex<Vec<(Request, WeakShared<Fut>)>>,
 }
+
+/// Request sharing for boxed futures.
+pub type BoxRequestSharing<Request, Response> =
+    RequestSharing<Request, BoxFuture<'static, Response>>;
+
+/// A boxed shared future.
+pub type BoxShared<T> = Shared<BoxFuture<'static, T>>;
 
 impl<Request, Fut: Future> Default for RequestSharing<Request, Fut> {
     fn default() -> Self {
@@ -41,6 +48,18 @@ where
     /// Note that futures do nothing util polled so merely creating the response future is not
     /// expensive.
     pub fn shared(&self, request: Request, future: Fut) -> Shared<Fut> {
+        self.shared_or_else(request, move || future)
+    }
+
+    /// Returns an existing in flight future or creates and uses a new future from the specified
+    /// closure.
+    ///
+    /// This is similar to [`RequestSharing::shared`] but lazily creates the future. This can be
+    /// helpful when creating futures is non trivial (such as cloning a large vector).
+    pub fn shared_or_else<F>(&self, request: Request, future: F) -> Shared<Fut>
+    where
+        F: FnOnce() -> Fut,
+    {
         let mut in_flight = self.in_flight.lock().unwrap();
 
         // collect garbage and find copy of existing request
@@ -65,7 +84,7 @@ where
             return existing;
         }
 
-        let shared = future.shared();
+        let shared = future().shared();
         // unwrap because downgrade only returns None if the Shared has already completed which
         // cannot be the case because we haven't polled it yet.
         in_flight.push((request, shared.downgrade().unwrap()));

--- a/crates/shared/src/trade_finding.rs
+++ b/crates/shared/src/trade_finding.rs
@@ -97,7 +97,7 @@ pub fn convert_interaction_group(interactions: &[Interaction]) -> Vec<EncodedInt
     interactions.iter().map(Interaction::encode).collect()
 }
 
-#[derive(Error, Debug)]
+#[derive(Debug, Error)]
 pub enum TradeError {
     #[error("No liquidity")]
     NoLiquidity,
@@ -107,6 +107,16 @@ pub enum TradeError {
 
     #[error(transparent)]
     Other(#[from] anyhow::Error),
+}
+
+impl Clone for TradeError {
+    fn clone(&self) -> Self {
+        match self {
+            Self::NoLiquidity => Self::NoLiquidity,
+            Self::UnsupportedOrderType => Self::UnsupportedOrderType,
+            Self::Other(err) => Self::Other(crate::clone_anyhow_error(err)),
+        }
+    }
 }
 
 #[cfg(test)]

--- a/crates/shared/src/zeroex_api.rs
+++ b/crates/shared/src/zeroex_api.rs
@@ -286,8 +286,8 @@ pub struct SwapResponse {
 }
 
 /// Abstract 0x API. Provides a mockable implementation.
-#[mockall::automock]
 #[async_trait::async_trait]
+#[mockall::automock]
 pub trait ZeroExApi: Send + Sync {
     /// Retrieve a swap for the specified parameters from the 0x API.
     ///

--- a/crates/solver/src/solver/zeroex_solver.rs
+++ b/crates/solver/src/solver/zeroex_solver.rs
@@ -166,6 +166,7 @@ mod tests {
     use crate::liquidity::LimitOrder;
     use crate::test::account;
     use contracts::{GPv2Settlement, WETH9};
+    use ethcontract::futures::FutureExt as _;
     use ethcontract::{Web3, H160, U256};
     use mockall::predicate::*;
     use mockall::Sequence;
@@ -267,18 +268,21 @@ mod tests {
 
         let allowance_target = shared::addr!("def1c0ded9bec7f1a1670819833240f027b25eff");
         client.expect_get_swap().returning(move |_| {
-            Ok(SwapResponse {
-                price: PriceResponse {
-                    sell_amount: U256::from_dec_str("100").unwrap(),
-                    buy_amount: U256::from_dec_str("91").unwrap(),
-                    allowance_target,
-                    price: 0.91_f64,
-                    estimated_gas: Default::default(),
-                },
-                to: shared::addr!("0000000000000000000000000000000000000000"),
-                data: hex::decode("00").unwrap(),
-                value: U256::from_dec_str("0").unwrap(),
-            })
+            async move {
+                Ok(SwapResponse {
+                    price: PriceResponse {
+                        sell_amount: U256::from_dec_str("100").unwrap(),
+                        buy_amount: U256::from_dec_str("91").unwrap(),
+                        allowance_target,
+                        price: 0.91_f64,
+                        estimated_gas: Default::default(),
+                    },
+                    to: shared::addr!("0000000000000000000000000000000000000000"),
+                    data: hex::decode("00").unwrap(),
+                    value: U256::from_dec_str("0").unwrap(),
+                })
+            }
+            .boxed()
         });
 
         allowance_fetcher
@@ -407,18 +411,21 @@ mod tests {
 
         let allowance_target = shared::addr!("def1c0ded9bec7f1a1670819833240f027b25eff");
         client.expect_get_swap().returning(move |_| {
-            Ok(SwapResponse {
-                price: PriceResponse {
-                    sell_amount: U256::from_dec_str("100").unwrap(),
-                    buy_amount: U256::from_dec_str("91").unwrap(),
-                    allowance_target,
-                    price: 13.121_002_575_170_278_f64,
-                    estimated_gas: Default::default(),
-                },
-                to: shared::addr!("0000000000000000000000000000000000000000"),
-                data: hex::decode("").unwrap(),
-                value: U256::from_dec_str("0").unwrap(),
-            })
+            async move {
+                Ok(SwapResponse {
+                    price: PriceResponse {
+                        sell_amount: U256::from_dec_str("100").unwrap(),
+                        buy_amount: U256::from_dec_str("91").unwrap(),
+                        allowance_target,
+                        price: 13.121_002_575_170_278_f64,
+                        estimated_gas: Default::default(),
+                    },
+                    to: shared::addr!("0000000000000000000000000000000000000000"),
+                    data: hex::decode("").unwrap(),
+                    value: U256::from_dec_str("0").unwrap(),
+                })
+            }
+            .boxed()
         });
 
         // On first invocation no prior allowance, then max allowance set.
@@ -483,19 +490,22 @@ mod tests {
         let buy_token = H160::from_low_u64_be(2);
 
         let mut client = MockZeroExApi::new();
-        client.expect_get_swap().returning(move |_| {
-            Ok(SwapResponse {
-                price: PriceResponse {
-                    sell_amount: 1000.into(),
-                    buy_amount: 5000.into(),
-                    allowance_target: shared::addr!("0000000000000000000000000000000000000000"),
-                    price: 0.,
-                    estimated_gas: Default::default(),
-                },
-                to: shared::addr!("0000000000000000000000000000000000000000"),
-                data: vec![],
-                value: 0.into(),
-            })
+        client.expect_get_swap().returning(|_| {
+            async move {
+                Ok(SwapResponse {
+                    price: PriceResponse {
+                        sell_amount: 1000.into(),
+                        buy_amount: 5000.into(),
+                        allowance_target: shared::addr!("0000000000000000000000000000000000000000"),
+                        price: 0.,
+                        estimated_gas: Default::default(),
+                    },
+                    to: shared::addr!("0000000000000000000000000000000000000000"),
+                    data: vec![],
+                    value: 0.into(),
+                })
+            }
+            .boxed()
         });
 
         let mut allowance_fetcher = Box::new(MockAllowanceManaging::new());


### PR DESCRIPTION
This PR adds request sharing internally to the 0x `TradeFinding` implementation.

While enabling trade simulation and verification, I noticed it would be beneficial for the "fast" and "optimal" and native price estimators to share requests during quoting. For this to happen, we now have two layers of request sharing:
- First, we share requests internally to the `TradeFinding` implementations. This allows requests to be shared regardless of whether or not we will simulate the trade. For example, when the FE starts, it issues parallel "fast" and "optimal" requests. For `TradeFinding` implementations, they can share all (0x - `get_swap`) or some (1Inch - `get_quote` - and ParaSwap - `get_price`) of the API requests they are making for computing the quote and/or trades.
- Second, we share `PriceEstimation` requests, this is so parallel requests reuse the `CodeSimulating` simulation. The FE will make price estimation requests for the sell token to USDC for trade impact calculation, this allows us to reuse the native price estimate with trade simulation across those requests.

With this PR, we would setup the "fast", "optimal" and native price estimators to share their inner `TradeFinding` instances for maximum efficiency 💪.

A follow up PR to implement this for the 1Inch and ParaSwap `TradeFinding` implementations is on its way!

### Test Plan

Added unit test to verify requests are shared across `get_trade` and `get_quote` calls.