### PR TITLE
Prevent very old blocks from entering the current_block_stream

### DIFF
--- a/crates/shared/src/current_block.rs
+++ b/crates/shared/src/current_block.rs
@@ -157,7 +157,7 @@ fn block_number_increased(current_block: &AtomicU64, new_block: u64) -> bool {
 
     let delta = (i128::from(new_block) - i128::from(current_block)) as f64;
     if delta <= 0. {
-        tracing::warn!(delta, new_block, "ignored new block number");
+        tracing::debug!(delta, new_block, "ignored new block number");
         metric.with_label_values(&["negative"]).observe(delta.abs());
     } else {
         tracing::debug!(delta, new_block, "increased current block number");

--- a/crates/shared/src/current_block.rs
+++ b/crates/shared/src/current_block.rs
@@ -20,9 +20,9 @@ pub type Block = web3::types::Block<H256>;
 /// Creates a cloneable stream that yields the current block whenever it changes.
 ///
 /// The stream is not guaranteed to yield *every* block individually without gaps but it does yield
-/// the newest block whenever it changes. In practice this means that if the node changes the
-/// current block in quick succession we might only observe the last block, skipping some blocks in
-/// between.
+/// the newest block whenever it detects a block number increase. In practice this means that if
+/// the node changes the current block in quick succession we might only observe the last block,
+/// skipping some blocks in between.
 ///
 /// The stream is cloneable so that we only have to poll the node once while being able to share the
 /// result with several consumers. Calling this function again would create a new poller so it is

--- a/crates/shared/src/current_block.rs
+++ b/crates/shared/src/current_block.rs
@@ -157,7 +157,7 @@ fn block_number_increased(current_block: &AtomicU64, new_block: u64) -> bool {
 
     let delta = i128::from(new_block) - i128::from(current_block);
     let delta_abs = (delta as f64).abs();
-    if delta < 0 {
+    if delta <= 0 {
         metrics.with_label_values(&["negative"]).observe(delta_abs);
     } else {
         metrics.with_label_values(&["positive"]).observe(delta_abs);

--- a/crates/shared/src/current_block.rs
+++ b/crates/shared/src/current_block.rs
@@ -68,7 +68,7 @@ pub async fn current_block_stream(
             };
 
             if !updated_current_block_with_new_block(current_block_number.as_ref(), number) {
-                tracing::error!("new block number is too old");
+                tracing::error!(new_block = number, "new block number is too old");
                 continue;
             }
 


### PR DESCRIPTION
Sometimes we have the problem that our load balancer starts sending requests to nodes which are stuck in the past. When that happens we receive vastly outdated blocks which can cause problems in our system.
Dshackle is supposed to handle old nodes but it looks like it forwards one outdated response before avoiding that node for a while.
Since this issue is quite problematic for the data consistency of the system but happens rarely I decided to log it as an error so we get automatic alerts when it happens.

<img width="1549" alt="Screenshot 2022-09-21 at 10 45 13" src="https://user-images.githubusercontent.com/19190235/191459164-f1c2a7cf-5262-4614-810e-e56f603d4a9c.png">

I added histogram metrics so we can configure alerts for suspicious update deltas without having to change the code later on.
<details>
<summary>metrics</summary>

```
# HELP gp_v2_api_block_stream_update_delta How much a new block number differs from the current block number.
# TYPE gp_v2_api_block_stream_update_delta histogram
gp_v2_api_block_stream_update_delta_bucket{sign="positive",le="0"} 0
gp_v2_api_block_stream_update_delta_bucket{sign="positive",le="1"} 14
gp_v2_api_block_stream_update_delta_bucket{sign="positive",le="2"} 14
gp_v2_api_block_stream_update_delta_bucket{sign="positive",le="4"} 14
gp_v2_api_block_stream_update_delta_bucket{sign="positive",le="8"} 14
gp_v2_api_block_stream_update_delta_bucket{sign="positive",le="25"} 14
gp_v2_api_block_stream_update_delta_bucket{sign="positive",le="+Inf"} 14
gp_v2_api_block_stream_update_delta_sum{sign="positive"} 14
gp_v2_api_block_stream_update_delta_count{sign="positive"} 14
gp_v2_api_block_stream_update_delta_bucket{sign="negative",le="0"} 0
gp_v2_api_block_stream_update_delta_bucket{sign="negative",le="1"} 1
gp_v2_api_block_stream_update_delta_bucket{sign="negative",le="2"} 1
gp_v2_api_block_stream_update_delta_bucket{sign="negative",le="4"} 1
gp_v2_api_block_stream_update_delta_bucket{sign="negative",le="8"} 1
gp_v2_api_block_stream_update_delta_bucket{sign="negative",le="25"} 1
gp_v2_api_block_stream_update_delta_bucket{sign="negative",le="+Inf"} 1
gp_v2_api_block_stream_update_delta_sum{sign="negative"} 1
gp_v2_api_block_stream_update_delta_count{sign="negative"} 1
```
</details>

### Test Plan
Added a few unit tests


