### PR TITLE
Implement Inner Request Sharing for ParaSwap Trade Finder

### DIFF
--- a/crates/shared/src/paraswap_api.rs
+++ b/crates/shared/src/paraswap_api.rs
@@ -17,9 +17,9 @@ use thiserror::Error;
 const BASE_URL: &str = "https://apiv5.paraswap.io";
 
 /// Mockable implementation of the API for unit test
-#[mockall::automock]
 #[async_trait::async_trait]
-pub trait ParaswapApi: Send + Sync {
+#[mockall::automock]
+pub trait ParaswapApi: Send + Sync + 'static {
     async fn price(&self, query: PriceQuery) -> Result<PriceResponse, ParaswapResponseError>;
     async fn transaction(
         &self,

--- a/crates/shared/src/trade_finding/paraswap.rs
+++ b/crates/shared/src/trade_finding/paraswap.rs
@@ -5,21 +5,34 @@ use crate::{
         TransactionBuilderQuery,
     },
     price_estimation::gas,
+    request_sharing::{BoxRequestSharing, BoxShared},
     token_info::{TokenInfo, TokenInfoFetching},
     trade_finding::{Interaction, Trade},
 };
 use anyhow::{Context, Result};
+use futures::FutureExt as _;
 use model::order::OrderKind;
 use primitive_types::H160;
 use std::{collections::HashMap, sync::Arc};
 
 pub struct ParaswapTradeFinder {
+    inner: Inner,
+    sharing: BoxRequestSharing<Query, Result<InternalQuote, TradeError>>,
+}
+
+#[derive(Clone)]
+struct Inner {
     paraswap: Arc<dyn ParaswapApi>,
     tokens: Arc<dyn TokenInfoFetching>,
     disabled_paraswap_dexs: Vec<String>,
 }
 
-type Tokens = HashMap<H160, TokenInfo>;
+#[derive(Clone)]
+struct InternalQuote {
+    data: Quote,
+    tokens: HashMap<H160, TokenInfo>,
+    price: PriceResponse,
+}
 
 impl ParaswapTradeFinder {
     pub fn new(
@@ -28,13 +41,31 @@ impl ParaswapTradeFinder {
         disabled_paraswap_dexs: Vec<String>,
     ) -> Self {
         Self {
-            paraswap: api,
-            tokens,
-            disabled_paraswap_dexs,
+            inner: Inner {
+                paraswap: api,
+                tokens,
+                disabled_paraswap_dexs,
+            },
+            sharing: Default::default(),
         }
     }
 
-    async fn quote(&self, query: &Query) -> Result<(Quote, Tokens, PriceResponse), TradeError> {
+    fn shared_quote(&self, query: &Query) -> BoxShared<Result<InternalQuote, TradeError>> {
+        self.sharing.shared_or_else(*query, || {
+            let inner = self.inner.clone();
+            let query = *query;
+            async move { inner.quote(&query).await }.boxed()
+        })
+    }
+
+    async fn trade(&self, query: &Query) -> Result<Trade, TradeError> {
+        let quote = self.shared_quote(query).await?;
+        self.inner.trade(query, quote).await
+    }
+}
+
+impl Inner {
+    async fn quote(&self, query: &Query) -> Result<InternalQuote, TradeError> {
         let tokens = self
             .tokens
             .get_token_infos(&[query.sell_token, query.buy_token])
@@ -62,7 +93,11 @@ impl ParaswapTradeFinder {
             gas_estimate: gas::SETTLEMENT_OVERHEAD + price.gas_cost,
         };
 
-        Ok((quote, tokens, price))
+        Ok(InternalQuote {
+            data: quote,
+            tokens,
+            price,
+        })
     }
 
     // Default to 1% slippage - same as the ParaSwap UI.
@@ -71,8 +106,7 @@ impl ParaswapTradeFinder {
     // error.
     const DEFAULT_USER: H160 = addr!("BEeFbeefbEefbeEFbeEfbEEfBEeFbeEfBeEfBeef");
 
-    async fn trade(&self, query: &Query) -> Result<Trade, TradeError> {
-        let (quote, tokens, mut price) = self.quote(query).await?;
+    async fn trade(&self, query: &Query, mut quote: InternalQuote) -> Result<Trade, TradeError> {
         let tx_query = TransactionBuilderQuery {
             src_token: query.sell_token,
             dest_token: query.buy_token,
@@ -85,18 +119,18 @@ impl ParaswapTradeFinder {
                 },
             },
             slippage: Self::DEFAULT_SLIPPAGE,
-            src_decimals: decimals(&tokens, &query.sell_token)?,
-            dest_decimals: decimals(&tokens, &query.buy_token)?,
-            price_route: price.price_route_raw.take(),
+            src_decimals: decimals(&quote.tokens, &query.sell_token)?,
+            dest_decimals: decimals(&quote.tokens, &query.buy_token)?,
+            price_route: quote.price.price_route_raw.take(),
             user_address: query.from.unwrap_or(Self::DEFAULT_USER),
         };
 
         let tx = self.paraswap.transaction(tx_query).await?;
 
         Ok(Trade {
-            out_amount: quote.out_amount,
-            gas_estimate: quote.gas_estimate,
-            approval: Some((query.sell_token, price.token_transfer_proxy)),
+            out_amount: quote.data.out_amount,
+            gas_estimate: quote.data.gas_estimate,
+            approval: Some((query.sell_token, quote.price.token_transfer_proxy)),
             interaction: Interaction {
                 target: tx.to,
                 value: tx.value,
@@ -109,8 +143,8 @@ impl ParaswapTradeFinder {
 #[async_trait::async_trait]
 impl TradeFinding for ParaswapTradeFinder {
     async fn get_quote(&self, query: &Query) -> Result<Quote, TradeError> {
-        let (quote, ..) = self.quote(query).await?;
-        Ok(quote)
+        let quote = self.shared_quote(query).await?;
+        Ok(quote.data)
     }
 
     async fn get_trade(&self, query: &Query) -> Result<Trade, TradeError> {
@@ -127,7 +161,7 @@ impl From<ParaswapResponseError> for TradeError {
     }
 }
 
-fn decimals(tokens: &Tokens, token: &H160) -> Result<u8, TradeError> {
+fn decimals(tokens: &HashMap<H160, TokenInfo>, token: &H160) -> Result<u8, TradeError> {
     Ok(tokens
         .get(token)
         .and_then(|info| info.decimals)
@@ -138,10 +172,46 @@ fn decimals(tokens: &Tokens, token: &H160) -> Result<u8, TradeError> {
 mod tests {
     use super::*;
     use crate::{
-        paraswap_api::DefaultParaswapApi, token_info::TokenInfoFetcher,
-        transport::create_env_test_transport, Web3,
+        paraswap_api::{DefaultParaswapApi, MockParaswapApi},
+        token_info::{MockTokenInfoFetching, TokenInfoFetcher},
+        transport::create_env_test_transport,
+        Web3,
     };
+    use maplit::hashmap;
     use reqwest::Client;
+    use std::time::Duration;
+
+    #[tokio::test]
+    async fn shares_prices_api_request() {
+        let mut paraswap = MockParaswapApi::new();
+        paraswap.expect_price().return_once(|_| {
+            async move {
+                tokio::time::sleep(Duration::from_millis(1)).await;
+                Ok(Default::default())
+            }
+            .boxed()
+        });
+        paraswap
+            .expect_transaction()
+            .return_once(|_| async { Ok(Default::default()) }.boxed());
+
+        let mut tokens = MockTokenInfoFetching::new();
+        tokens.expect_get_token_infos().returning(|_| {
+            hashmap! {
+                H160::default() => TokenInfo {
+                    decimals: Some(18),
+                    ..Default::default()
+                },
+            }
+        });
+
+        let trader = ParaswapTradeFinder::new(Arc::new(paraswap), Arc::new(tokens), Vec::new());
+
+        let query = Query::default();
+        let result = futures::try_join!(trader.get_quote(&query), trader.get_trade(&query));
+
+        assert!(result.is_ok());
+    }
 
     #[tokio::test]
     #[ignore]
@@ -153,11 +223,7 @@ mod tests {
             partner: "Test".to_string(),
             rate_limiter: None,
         };
-        let finder = ParaswapTradeFinder {
-            paraswap: Arc::new(paraswap),
-            tokens: Arc::new(tokens),
-            disabled_paraswap_dexs: Vec::new(),
-        };
+        let finder = ParaswapTradeFinder::new(Arc::new(paraswap), Arc::new(tokens), Vec::new());
 
         let trade = finder
             .get_trade(&Query {

--- a/crates/shared/src/trade_finding/zeroex.rs
+++ b/crates/shared/src/trade_finding/zeroex.rs
@@ -221,7 +221,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn shares_quotes() {
+    async fn shares_quote_api_request() {
         let mut zeroex_api = MockZeroExApi::new();
         zeroex_api.expect_get_swap().return_once(|_| {
             async move {


### PR DESCRIPTION
This PR implements inner request sharing for the ParaSwap trade finder.

Specifically, computing a trade with the ParaSwap API is a two step process:
- First query the `price` API endpoint to get a priceroute
- Commit to the price route by building transaction data with the `transaction` API endpoint

For price estimation, a "fast" estimate would just optimistically use the quoted result from the `price` API call, while the "optimal" one would additionally build a transaction and simulate it to make sure its valid.

Since the FE typically makes simultaneous "fast" and "optimal" requests for a given price quote, it makes to share the `price` API request between the two estimators. For this, we add a `RequestSharing` to the ParaSwap `TradeFinding` implementation so that it can share its inner `price` API request across `get_quote` and `get_trade` calls.

### Test Plan

Added a unit test that asserts that the inner `price` API gets called only once (i.e. shared) when doing simultaneous `get_quote` and `get_trade` calls.
