### PR TITLE
Refactor Price Estimation Initialization

### DIFF
--- a/crates/autopilot/src/lib.rs
+++ b/crates/autopilot/src/lib.rs
@@ -25,28 +25,17 @@ use shared::{
         token_owner_finder,
         trace_call::TraceCallDetector,
     },
-    balancer_sor_api::DefaultBalancerSorApi,
     baseline_solver::BaseTokens,
     fee_subsidy::{
         config::FeeSubsidyConfiguration, cow_token::CowSubsidy, FeeSubsidies, FeeSubsidizing,
     },
     gas_price::InstrumentedGasEstimator,
     http_client::HttpClientFactory,
-    http_solver::{DefaultHttpSolverApi, SolverConfig},
     maintenance::Maintaining,
     metrics::LivenessChecking,
     oneinch_api::OneInchClientImpl,
     order_quoting::OrderQuoter,
-    paraswap_api::DefaultParaswapApi,
-    price_estimation::{
-        balancer_sor::BalancerSor, baseline::BaselinePriceEstimator,
-        competition::CompetitionPriceEstimator, http::HttpPriceEstimator,
-        instrumented::InstrumentedPriceEstimator, native::NativePriceEstimator,
-        native_price_cache::CachingNativePriceEstimator, oneinch::OneInchPriceEstimator,
-        paraswap::ParaswapPriceEstimator, sanitized::SanitizedPriceEstimator,
-        zeroex::ZeroExPriceEstimator, PriceEstimating, PriceEstimatorType,
-    },
-    rate_limiter::RateLimiter,
+    price_estimation::factory::{self, PriceEstimatorFactory},
     recent_block_cache::CacheConfig,
     signature_validator::Web3SignatureValidator,
     sources::{
@@ -58,7 +47,7 @@ use shared::{
     token_info::{CachedTokenInfoFetcher, TokenInfoFetcher},
     zeroex_api::DefaultZeroExApi,
 };
-use std::{collections::HashMap, sync::Arc, time::Duration};
+use std::{sync::Arc, time::Duration};
 
 struct Liveness {
     solvable_orders_cache: Arc<SolvableOrdersCache>,
@@ -145,7 +134,7 @@ pub async fn main(args: arguments::Arguments) {
         .expect("failed to create gas price estimator"),
     );
 
-    let baseline_sources = args.shared.baseline_sources.unwrap_or_else(|| {
+    let baseline_sources = args.shared.baseline_sources.clone().unwrap_or_else(|| {
         shared::sources::defaults_for_chain(chain_id)
             .expect("failed to get default baseline sources")
     });
@@ -225,6 +214,7 @@ pub async fn main(args: arguments::Arguments) {
         let factories = args
             .shared
             .balancer_factories
+            .clone()
             .unwrap_or_else(|| BalancerFactoryKind::for_chain(chain_id));
         let contracts = BalancerContracts::new(&web3, factories).await.unwrap();
         let balancer_pool_fetcher = Arc::new(
@@ -236,7 +226,7 @@ pub async fn main(args: arguments::Arguments) {
                 http_factory.create(),
                 web3.clone(),
                 &contracts,
-                args.shared.balancer_pool_deny_list,
+                args.shared.balancer_pool_deny_list.clone(),
             )
             .await
             .expect("failed to create Balancer pool fetcher"),
@@ -276,132 +266,35 @@ pub async fn main(args: arguments::Arguments) {
         chain_id,
     )
     .map(Arc::new);
-    let instrumented = |inner: Box<dyn PriceEstimating>, name: String| {
-        InstrumentedPriceEstimator::new(inner, name)
-    };
-    let balancer_sor_api = args.balancer_sor_url.map(|url| {
-        Arc::new(DefaultBalancerSorApi::new(http_factory.create(), url, chain_id).unwrap())
-    });
-    let native_token_price_estimation_amount = args
-        .amount_to_estimate_prices_with
-        .or_else(|| {
-            shared::price_estimation::native::default_amount_to_estimate_native_prices_with(
-                &network,
-            )
-        })
-        .expect("No amount to estimate prices with set.");
 
-    let create_base_estimator =
-        |estimator: PriceEstimatorType| -> (String, Arc<dyn PriceEstimating>) {
-            let rate_limiter = |name| {
-                Arc::new(RateLimiter::from_strategy(
-                    args.price_estimation_rate_limiter
-                        .clone()
-                        .unwrap_or_default(),
-                    format!("{}_estimator", &name),
-                ))
-            };
-            let create_http_estimator = |name, base| -> Box<dyn PriceEstimating> {
-                Box::new(HttpPriceEstimator::new(
-                    Arc::new(DefaultHttpSolverApi {
-                        name,
-                        network_name: network_name.to_string(),
-                        chain_id,
-                        base,
-                        client: http_factory.create(),
-                        config: SolverConfig {
-                            use_internal_buffers: Some(args.shared.quasimodo_uses_internal_buffers),
-                            objective: Some(shared::http_solver::Objective::SurplusFeesCosts),
-                            ..Default::default()
-                        },
-                    }),
-                    pool_fetcher.clone(),
-                    balancer_pool_fetcher.clone(),
-                    uniswap_v3_pool_fetcher.clone(),
-                    token_info_fetcher.clone(),
-                    gas_price_estimator.clone(),
-                    native_token.address(),
-                    base_tokens.clone(),
-                    network_name.to_string(),
-                    rate_limiter(estimator.name()),
-                ))
-            };
-            let instance: Box<dyn PriceEstimating> = match estimator {
-                PriceEstimatorType::Baseline => Box::new(BaselinePriceEstimator::new(
-                    pool_fetcher.clone(),
-                    gas_price_estimator.clone(),
-                    base_tokens.clone(),
-                    native_token.address(),
-                    native_token_price_estimation_amount,
-                    rate_limiter(estimator.name()),
-                )),
-                PriceEstimatorType::Paraswap => Box::new(ParaswapPriceEstimator::new(
-                    Arc::new(DefaultParaswapApi {
-                        client: http_factory.create(),
-                        partner: args.shared.paraswap_partner.clone().unwrap_or_default(),
-                        rate_limiter: args.shared.paraswap_rate_limiter.clone().map(|strategy| {
-                            RateLimiter::from_strategy(strategy, "paraswap_api".into())
-                        }),
-                    }),
-                    token_info_fetcher.clone(),
-                    args.shared.disabled_paraswap_dexs.clone(),
-                    rate_limiter(estimator.name()),
-                )),
-                PriceEstimatorType::ZeroEx => Box::new(ZeroExPriceEstimator::new(
-                    zeroex_api.clone(),
-                    args.shared.disabled_zeroex_sources.clone(),
-                    rate_limiter(estimator.name()),
-                )),
-                PriceEstimatorType::Quasimodo => create_http_estimator(
-                    "quasimodo-price-estimator".to_string(),
-                    args.quasimodo_solver_url.clone().expect(
-                        "quasimodo solver url is required when using quasimodo price estimation",
-                    ),
-                ),
-                PriceEstimatorType::OneInch => Box::new(OneInchPriceEstimator::new(
-                    one_inch_api.as_ref().unwrap().clone(),
-                    args.shared.disabled_one_inch_protocols.clone(),
-                    rate_limiter(estimator.name()),
-                    args.shared.one_inch_referrer_address
-                )),
-                PriceEstimatorType::Yearn => create_http_estimator(
-                    "yearn-price-estimator".to_string(),
-                    args.yearn_solver_url
-                        .clone()
-                        .expect("yearn solver url is required when using yearn price estimation"),
-                ),
-                PriceEstimatorType::BalancerSor => Box::new(BalancerSor::new(
-                    balancer_sor_api.clone().expect("trying to create BalancerSor price estimator but didn't get balancer sor url"),
-                    rate_limiter(estimator.name()),
-                    gas_price_estimator.clone(),
-                )),
-            };
+    let mut price_estimator_factory = PriceEstimatorFactory::new(
+        &args.price_estimation,
+        &args.shared,
+        factory::Network {
+            name: network_name.to_string(),
+            chain_id,
+            native_token: native_token.address(),
+            base_tokens: base_tokens.clone(),
+        },
+        factory::Components {
+            http_factory: http_factory.clone(),
+            bad_token_detector: bad_token_detector.clone(),
+            uniswap_v2_pools: pool_fetcher.clone(),
+            balancer_pools: balancer_pool_fetcher.clone().map(|a| a as _),
+            uniswap_v3_pools: uniswap_v3_pool_fetcher.clone().map(|a| a as _),
+            tokens: token_info_fetcher.clone(),
+            gas_price: gas_price_estimator.clone(),
+            zeroex: zeroex_api.clone(),
+            oneinch: one_inch_api.ok().map(|a| a as _),
+        },
+    );
 
-            (
-                estimator.name(),
-                Arc::new(instrumented(instance, estimator.name())),
-            )
-        };
-    let sanitized = |estimator| {
-        SanitizedPriceEstimator::new(
-            estimator,
-            native_token.address(),
-            bad_token_detector.clone(),
-        )
-    };
-    let native_price_estimator = Arc::new(CachingNativePriceEstimator::new(
-        Box::new(NativePriceEstimator::new(
-            Arc::new(sanitized(Box::new(CompetitionPriceEstimator::new(
-                args.native_price_estimators
-                    .iter()
-                    .map(|estimator| create_base_estimator(*estimator))
-                    .collect(),
-            )))),
-            native_token.address(),
-            native_token_price_estimation_amount,
-        )),
-        args.native_price_cache_max_age_secs,
-    ));
+    let price_estimator = price_estimator_factory
+        .price_estimator(&args.order_quoting.price_estimators)
+        .unwrap();
+    let native_price_estimator = price_estimator_factory
+        .native_price_estimator(&args.native_price_estimators)
+        .unwrap();
 
     let solvable_orders_cache = SolvableOrdersCache::new(
         args.min_order_validity_period,
@@ -503,20 +396,6 @@ pub async fn main(args: arguments::Arguments) {
             ])),
             None => fee_subsidy_config,
         };
-        let mut base_estimators_instances: HashMap<_, _> = Default::default();
-        let mut get_or_create_base_estimator = move |estimator| {
-            base_estimators_instances
-                .entry(estimator)
-                .or_insert_with(|| create_base_estimator(estimator))
-                .clone()
-        };
-        let price_estimator = Arc::new(sanitized(Box::new(CompetitionPriceEstimator::new(
-            args.order_quoting
-                .price_estimators
-                .iter()
-                .map(|estimator| get_or_create_base_estimator(*estimator))
-                .collect(),
-        ))));
         let database = Arc::new(db.clone());
         let quoter = OrderQuoter::new(
             price_estimator,

--- a/crates/orderbook/src/arguments.rs
+++ b/crates/orderbook/src/arguments.rs
@@ -1,8 +1,10 @@
-use primitive_types::{H160, U256};
+use primitive_types::H160;
 use reqwest::Url;
 use shared::{
-    arguments::display_option, bad_token::token_owner_finder, http_client,
-    price_estimation::PriceEstimatorType, rate_limiter::RateLimitingStrategy,
+    arguments::display_option,
+    bad_token::token_owner_finder,
+    http_client,
+    price_estimation::{self, PriceEstimatorType},
 };
 use std::{net::SocketAddr, num::NonZeroUsize, time::Duration};
 
@@ -19,6 +21,9 @@ pub struct Arguments {
 
     #[clap(flatten)]
     pub token_owner_finder: token_owner_finder::Arguments,
+
+    #[clap(flatten)]
+    pub price_estimation: price_estimation::Arguments,
 
     /// A tracing Ethereum node URL to connect to, allowing a separate node URL
     /// to be used exclusively for tracing calls.
@@ -68,6 +73,25 @@ pub struct Arguments {
     #[clap(long, env, use_value_delimiter = true)]
     pub banned_users: Vec<H160>,
 
+    /// Which estimators to use to estimate token prices in terms of the chain's native token.
+    #[clap(
+        long,
+        env,
+        default_value = "Baseline",
+        value_enum,
+        use_value_delimiter = true
+    )]
+    pub native_price_estimators: Vec<PriceEstimatorType>,
+
+    /// How many successful price estimates for each order will cause a fast price estimation to
+    /// return its result early.
+    /// The bigger the value the more the fast price estimation performs like the optimal price
+    /// estimation.
+    /// It's possible to pass values greater than the total number of enabled estimators but that
+    /// will not have any further effect.
+    #[clap(long, env, default_value = "2")]
+    pub fast_price_estimation_results_required: NonZeroUsize,
+
     /// List of token addresses that should be allowed regardless of whether the bad token detector
     /// thinks they are bad. Base tokens are automatically allowed.
     #[clap(long, env, use_value_delimiter = true)]
@@ -92,76 +116,19 @@ pub struct Arguments {
     #[clap(long, env)]
     pub enable_presign_orders: bool,
 
-    /// The API endpoint to call the mip v2 solver for price estimation
-    #[clap(long, env)]
-    pub quasimodo_solver_url: Option<Url>,
-
-    /// The API endpoint to call the yearn solver for price estimation
-    #[clap(long, env)]
-    pub yearn_solver_url: Option<Url>,
-
-    /// How long cached native prices stay valid.
-    #[clap(
-        long,
-        env,
-        default_value = "30",
-        value_parser = shared::arguments::duration_from_seconds,
-    )]
-    pub native_price_cache_max_age_secs: Duration,
-
-    /// How many cached native token prices can be updated at most in one maintenance cycle.
-    #[clap(long, env, default_value = "3")]
-    pub native_price_cache_max_update_size: usize,
-
-    /// Which estimators to use to estimate token prices in terms of the chain's native token.
-    #[clap(
-        long,
-        env,
-        default_value = "Baseline",
-        value_enum,
-        use_value_delimiter = true
-    )]
-    pub native_price_estimators: Vec<PriceEstimatorType>,
-
-    /// The amount in native tokens atoms to use for price estimation. Should be reasonably large so
-    /// that small pools do not influence the prices. If not set a reasonable default is used based
-    /// on network id.
-    #[clap(
-        long,
-        env,
-        value_parser = U256::from_dec_str
-    )]
-    pub amount_to_estimate_prices_with: Option<U256>,
-
-    /// How many successful price estimates for each order will cause a fast price estimation to
-    /// return its result early.
-    /// The bigger the value the more the fast price estimation performs like the optimal price
-    /// estimation.
-    /// It's possible to pass values greater than the total number of enabled estimators but that
-    /// will not have any further effect.
-    #[clap(long, env, default_value = "2")]
-    pub fast_price_estimation_results_required: NonZeroUsize,
-
-    /// Configures the back off strategy for price estimators when requests take too long.
-    /// Requests issued while back off is active get dropped entirely.
-    /// Needs to be passed as "<back_off_growth_factor>,<min_back_off>,<max_back_off>".
-    /// back_off_growth_factor: f64 >= 1.0
-    /// min_back_off: f64 in seconds
-    /// max_back_off: f64 in seconds
-    #[clap(long, env, verbatim_doc_comment)]
-    pub price_estimation_rate_limiter: Option<RateLimitingStrategy>,
-
-    /// The API endpoint for the Balancer SOR API for solving.
-    #[clap(long, env)]
-    pub balancer_sor_url: Option<Url>,
+    /// If solvable orders haven't been successfully updated in this many blocks attempting
+    /// to get them errors and our liveness check fails.
+    #[clap(long, default_value = "24")]
+    pub solvable_orders_max_update_age_blocks: u64,
 }
 
 impl std::fmt::Display for Arguments {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         write!(f, "{}", self.shared)?;
         write!(f, "{}", self.order_quoting)?;
         write!(f, "{}", self.http_client)?;
         write!(f, "{}", self.token_owner_finder)?;
+        write!(f, "{}", self.price_estimation)?;
         display_option(f, "tracing_node_url", &self.tracing_node_url)?;
         writeln!(f, "bind_address: {}", self.bind_address)?;
         writeln!(f, "db_url: SECRET")?;
@@ -191,39 +158,22 @@ impl std::fmt::Display for Arguments {
             self.eip1271_skip_creation_validation
         )?;
         writeln!(f, "enable_presign_orders: {}", self.enable_presign_orders)?;
-        display_option(f, "quasimodo_solver_url", &self.quasimodo_solver_url)?;
-        display_option(f, "yearn_solver_url", &self.yearn_solver_url)?;
         writeln!(
             f,
-            "native_price_cache_max_age_secs: {:?}",
-            self.native_price_cache_max_age_secs
-        )?;
-        writeln!(
-            f,
-            "native_price_cache_max_update_size: {}",
-            self.native_price_cache_max_update_size
+            "solvable_orders_max_update_age_blocks: {}",
+            self.solvable_orders_max_update_age_blocks,
         )?;
         writeln!(
             f,
             "native_price_estimators: {:?}",
             self.native_price_estimators
         )?;
-        display_option(
-            f,
-            "amount_to_estimate_prices_with",
-            &self.amount_to_estimate_prices_with,
-        )?;
         writeln!(
             f,
             "fast_price_estimation_results_required: {}",
             self.fast_price_estimation_results_required
         )?;
-        display_option(
-            f,
-            "price_estimation_rate_limites",
-            &self.price_estimation_rate_limiter,
-        )?;
-        display_option(f, "balancer_sor_url", &self.balancer_sor_url)?;
+
         Ok(())
     }
 }

--- a/crates/shared/src/arguments.rs
+++ b/crates/shared/src/arguments.rs
@@ -388,6 +388,7 @@ impl Display for Arguments {
             self.balancer_pool_deny_list
         )?;
         display_secret_option(f, "solver_competition_auth", &self.solver_competition_auth)?;
+
         Ok(())
     }
 }

--- a/crates/shared/src/http_client.rs
+++ b/crates/shared/src/http_client.rs
@@ -14,7 +14,7 @@ const USER_AGENT: &str = "cowprotocol-services/2.0.0";
 /// places, while allowing for separate configurations, connection pools, and
 /// cookie stores (for things like sessions and default headers) across
 /// different APIs.
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct HttpClientFactory {
     timeout: Duration,
 }

--- a/crates/shared/src/price_estimation/factory.rs
+++ b/crates/shared/src/price_estimation/factory.rs
@@ -1,0 +1,292 @@
+use super::{
+    balancer_sor::BalancerSor,
+    baseline::BaselinePriceEstimator,
+    competition::{CompetitionPriceEstimator, RacingCompetitionPriceEstimator},
+    http::HttpPriceEstimator,
+    instrumented::InstrumentedPriceEstimator,
+    native::{self, NativePriceEstimating, NativePriceEstimator},
+    native_price_cache::CachingNativePriceEstimator,
+    oneinch::OneInchPriceEstimator,
+    paraswap::ParaswapPriceEstimator,
+    sanitized::SanitizedPriceEstimator,
+    zeroex::ZeroExPriceEstimator,
+    Arguments, PriceEstimating, PriceEstimatorType,
+};
+use crate::{
+    arguments,
+    bad_token::BadTokenDetecting,
+    balancer_sor_api::DefaultBalancerSorApi,
+    baseline_solver::BaseTokens,
+    http_client::HttpClientFactory,
+    http_solver::{DefaultHttpSolverApi, Objective, SolverConfig},
+    oneinch_api::OneInchClient,
+    paraswap_api::DefaultParaswapApi,
+    rate_limiter::RateLimiter,
+    sources::{
+        balancer_v2::BalancerPoolFetching,
+        uniswap_v2::pool_fetching::PoolFetching as UniswapV2PoolFetching,
+        uniswap_v3::pool_fetching::PoolFetching as UniswapV3PoolFetching,
+    },
+    token_info::TokenInfoFetching,
+    zeroex_api::ZeroExApi,
+};
+use anyhow::{Context as _, Result};
+use ethcontract::{H160, U256};
+use gas_estimation::GasPriceEstimating;
+use reqwest::Url;
+use std::{collections::HashMap, num::NonZeroUsize, sync::Arc};
+
+/// A factory for initializing shared price estimators.
+pub struct PriceEstimatorFactory<'a> {
+    args: &'a Arguments,
+    shared_args: &'a arguments::Arguments,
+    network: Network,
+    components: Components,
+    estimators: HashMap<PriceEstimatorType, Arc<dyn PriceEstimating>>,
+}
+
+/// Network options needed for creating price estimators.
+pub struct Network {
+    pub name: String,
+    pub chain_id: u64,
+    pub native_token: H160,
+    pub base_tokens: Arc<BaseTokens>,
+}
+
+/// The shared components needed for creating price estimators.
+pub struct Components {
+    pub http_factory: HttpClientFactory,
+    pub bad_token_detector: Arc<dyn BadTokenDetecting>,
+    pub uniswap_v2_pools: Arc<dyn UniswapV2PoolFetching>,
+    pub balancer_pools: Option<Arc<dyn BalancerPoolFetching>>,
+    pub uniswap_v3_pools: Option<Arc<dyn UniswapV3PoolFetching>>,
+    pub tokens: Arc<dyn TokenInfoFetching>,
+    pub gas_price: Arc<dyn GasPriceEstimating>,
+    pub zeroex: Arc<dyn ZeroExApi>,
+    pub oneinch: Option<Arc<dyn OneInchClient>>,
+}
+
+impl<'a> PriceEstimatorFactory<'a> {
+    pub fn new(
+        args: &'a Arguments,
+        shared_args: &'a arguments::Arguments,
+        network: Network,
+        components: Components,
+    ) -> Self {
+        Self {
+            args,
+            shared_args,
+            network,
+            components,
+            estimators: HashMap::new(),
+        }
+    }
+
+    fn native_token_price_estimation_amount(&self) -> Result<U256> {
+        self.args
+            .amount_to_estimate_prices_with
+            .or_else(|| {
+                native::default_amount_to_estimate_native_prices_with(self.network.chain_id)
+            })
+            .context("No amount to estimate prices with set.")
+    }
+
+    fn rate_limiter(&self, kind: PriceEstimatorType) -> Arc<RateLimiter> {
+        Arc::new(RateLimiter::from_strategy(
+            self.args
+                .price_estimation_rate_limiter
+                .clone()
+                .unwrap_or_default(),
+            format!("{kind:?}_estimator"),
+        ))
+    }
+
+    fn create_http_estimator(
+        &self,
+        kind: PriceEstimatorType,
+        base: Url,
+    ) -> Box<dyn PriceEstimating> {
+        Box::new(HttpPriceEstimator::new(
+            Arc::new(DefaultHttpSolverApi {
+                name: kind.name(),
+                network_name: self.network.name.clone(),
+                chain_id: self.network.chain_id,
+                base,
+                client: self.components.http_factory.create(),
+                config: SolverConfig {
+                    use_internal_buffers: Some(self.shared_args.quasimodo_uses_internal_buffers),
+                    objective: Some(Objective::SurplusFeesCosts),
+                    ..Default::default()
+                },
+            }),
+            self.components.uniswap_v2_pools.clone(),
+            self.components.balancer_pools.clone(),
+            self.components.uniswap_v3_pools.clone(),
+            self.components.tokens.clone(),
+            self.components.gas_price.clone(),
+            self.network.native_token,
+            self.network.base_tokens.clone(),
+            self.network.name.clone(),
+            self.rate_limiter(kind),
+        ))
+    }
+
+    fn create_estimator(&self, kind: PriceEstimatorType) -> Result<InstrumentedPriceEstimator> {
+        let estimator: Box<dyn PriceEstimating> =
+            match kind {
+                PriceEstimatorType::Baseline => Box::new(BaselinePriceEstimator::new(
+                    self.components.uniswap_v2_pools.clone(),
+                    self.components.gas_price.clone(),
+                    self.network.base_tokens.clone(),
+                    self.network.native_token,
+                    self.native_token_price_estimation_amount()?,
+                    self.rate_limiter(kind),
+                )),
+                PriceEstimatorType::Paraswap => Box::new(ParaswapPriceEstimator::new(
+                    Arc::new(DefaultParaswapApi {
+                        client: self.components.http_factory.create(),
+                        partner: self
+                            .shared_args
+                            .paraswap_partner
+                            .clone()
+                            .unwrap_or_default(),
+                        rate_limiter: self.shared_args.paraswap_rate_limiter.clone().map(
+                            |strategy| RateLimiter::from_strategy(strategy, "paraswap_api".into()),
+                        ),
+                    }),
+                    self.components.tokens.clone(),
+                    self.shared_args.disabled_paraswap_dexs.clone(),
+                    self.rate_limiter(kind),
+                )),
+                PriceEstimatorType::ZeroEx => Box::new(ZeroExPriceEstimator::new(
+                    self.components.zeroex.clone(),
+                    self.shared_args.disabled_zeroex_sources.clone(),
+                    self.rate_limiter(kind),
+                )),
+                PriceEstimatorType::Quasimodo => self.create_http_estimator(
+                    kind,
+                    self.args
+                        .quasimodo_solver_url
+                        .clone()
+                        .context("quasimodo solver url not specified")?,
+                ),
+                PriceEstimatorType::OneInch => Box::new(OneInchPriceEstimator::new(
+                    self.components
+                        .oneinch
+                        .clone()
+                        .context("1Inch API not supported for network")?,
+                    self.shared_args.disabled_one_inch_protocols.clone(),
+                    self.rate_limiter(kind),
+                    self.shared_args.one_inch_referrer_address,
+                )),
+                PriceEstimatorType::Yearn => self.create_http_estimator(
+                    kind,
+                    self.args
+                        .yearn_solver_url
+                        .clone()
+                        .context("yearn solver url not specified")?,
+                ),
+                PriceEstimatorType::BalancerSor => Box::new(BalancerSor::new(
+                    Arc::new(DefaultBalancerSorApi::new(
+                        self.components.http_factory.create(),
+                        self.args
+                            .balancer_sor_url
+                            .clone()
+                            .context("balancer SOR url not specified")?,
+                        self.network.chain_id,
+                    )?),
+                    self.rate_limiter(kind),
+                    self.components.gas_price.clone(),
+                )),
+            };
+
+        Ok(InstrumentedPriceEstimator::new(estimator, kind.name()))
+    }
+
+    fn get_estimator(&mut self, kind: PriceEstimatorType) -> Result<Arc<dyn PriceEstimating>> {
+        if let Some(existing) = self.estimators.get(&kind) {
+            return Ok(existing.clone());
+        }
+
+        let estimator = Arc::new(self.create_estimator(kind)?);
+        self.estimators.insert(kind, estimator.clone());
+        Ok(estimator)
+    }
+
+    fn get_estimators(
+        &mut self,
+        kinds: &[PriceEstimatorType],
+    ) -> Result<Vec<(String, Arc<dyn PriceEstimating>)>> {
+        kinds
+            .iter()
+            .copied()
+            .map(|kind| Ok((kind.name(), self.get_estimator(kind)?)))
+            .collect()
+    }
+
+    fn sanitized(&self, estimator: Box<dyn PriceEstimating>) -> SanitizedPriceEstimator {
+        SanitizedPriceEstimator::new(
+            estimator,
+            self.network.native_token,
+            self.components.bad_token_detector.clone(),
+        )
+    }
+
+    pub fn price_estimator(
+        &mut self,
+        kinds: &[PriceEstimatorType],
+    ) -> Result<Arc<dyn PriceEstimating>> {
+        let estimators = self.get_estimators(kinds)?;
+        Ok(Arc::new(self.sanitized(Box::new(
+            CompetitionPriceEstimator::new(estimators),
+        ))))
+    }
+
+    pub fn fast_price_estimator(
+        &mut self,
+        kinds: &[PriceEstimatorType],
+        fast_price_estimation_results_required: NonZeroUsize,
+    ) -> Result<Arc<dyn PriceEstimating>> {
+        let estimators = self.get_estimators(kinds)?;
+        Ok(Arc::new(self.sanitized(Box::new(
+            RacingCompetitionPriceEstimator::new(
+                estimators,
+                fast_price_estimation_results_required,
+            ),
+        ))))
+    }
+
+    pub fn native_price_estimator(
+        &mut self,
+        kinds: &[PriceEstimatorType],
+    ) -> Result<Arc<dyn NativePriceEstimating>> {
+        let estimator = Arc::new(CachingNativePriceEstimator::new(
+            Box::new(NativePriceEstimator::new(
+                Arc::new(
+                    self.sanitized(Box::new(CompetitionPriceEstimator::new(
+                        kinds
+                            .iter()
+                            .copied()
+                            .map(|kind| {
+                                Ok((
+                                    kind.name(),
+                                    Arc::new(self.create_estimator(kind)?)
+                                        as Arc<dyn PriceEstimating>,
+                                ))
+                            })
+                            .collect::<Result<_>>()?,
+                    ))),
+                ),
+                self.network.native_token,
+                self.native_token_price_estimation_amount()?,
+            )),
+            self.args.native_price_cache_max_age_secs,
+        ));
+
+        estimator.spawn_maintenance_task(
+            self.args.native_price_cache_refresh_secs,
+            Some(self.args.native_price_cache_max_update_size),
+        );
+        Ok(estimator)
+    }
+}

--- a/crates/shared/src/price_estimation/http.rs
+++ b/crates/shared/src/price_estimation/http.rs
@@ -18,11 +18,9 @@ use crate::{
     recent_block_cache::Block,
     request_sharing::RequestSharing,
     sources::{
-        balancer_v2::{
-            pools::common::compute_scaling_rate, BalancerPoolFetcher, BalancerPoolFetching,
-        },
-        uniswap_v2::pool_fetching::PoolFetching,
-        uniswap_v3::pool_fetching::{PoolFetching as UniswapV3PoolFetching, UniswapV3PoolFetcher},
+        balancer_v2::{pools::common::compute_scaling_rate, BalancerPoolFetching},
+        uniswap_v2::pool_fetching::PoolFetching as UniswapV2PoolFetching,
+        uniswap_v3::pool_fetching::PoolFetching as UniswapV3PoolFetching,
     },
     token_info::TokenInfoFetching,
 };
@@ -44,9 +42,9 @@ pub struct HttpPriceEstimator {
         Query,
         BoxFuture<'static, Result<SettledBatchAuctionModel, PriceEstimationError>>,
     >,
-    pools: Arc<dyn PoolFetching>,
-    balancer_pools: Option<Arc<BalancerPoolFetcher>>,
-    uniswap_v3_pools: Option<Arc<UniswapV3PoolFetcher>>,
+    pools: Arc<dyn UniswapV2PoolFetching>,
+    balancer_pools: Option<Arc<dyn BalancerPoolFetching>>,
+    uniswap_v3_pools: Option<Arc<dyn UniswapV3PoolFetching>>,
     token_info: Arc<dyn TokenInfoFetching>,
     gas_info: Arc<dyn GasPriceEstimating>,
     native_token: H160,
@@ -59,9 +57,9 @@ impl HttpPriceEstimator {
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         api: Arc<dyn HttpSolverApi>,
-        pools: Arc<dyn PoolFetching>,
-        balancer_pools: Option<Arc<BalancerPoolFetcher>>,
-        uniswap_v3_pools: Option<Arc<UniswapV3PoolFetcher>>,
+        pools: Arc<dyn UniswapV2PoolFetching>,
+        balancer_pools: Option<Arc<dyn BalancerPoolFetching>>,
+        uniswap_v3_pools: Option<Arc<dyn UniswapV3PoolFetching>>,
         token_info: Arc<dyn TokenInfoFetching>,
         gas_info: Arc<dyn GasPriceEstimating>,
         native_token: H160,
@@ -377,8 +375,6 @@ impl PriceEstimating for HttpPriceEstimator {
 
 #[cfg(test)]
 mod tests {
-    use std::collections::HashMap;
-
     use super::*;
     use crate::{
         current_block::current_block_stream,
@@ -390,9 +386,12 @@ mod tests {
         price_estimation::Query,
         recent_block_cache::CacheConfig,
         sources::{
-            balancer_v2::{pool_fetching::BalancerContracts, BalancerFactoryKind},
+            balancer_v2::{
+                pool_fetching::BalancerContracts, BalancerFactoryKind, BalancerPoolFetcher,
+            },
             uniswap_v2,
             uniswap_v2::{pool_cache::PoolCache, pool_fetching::test_util::FakePoolFetcher},
+            uniswap_v3::pool_fetching::UniswapV3PoolFetcher,
         },
         token_info::{MockTokenInfoFetching, TokenInfoFetcher},
         transport::http::HttpTransport,
@@ -405,6 +404,7 @@ mod tests {
     use maplit::hashmap;
     use model::order::OrderKind;
     use reqwest::Client;
+    use std::collections::HashMap;
     use url::Url;
 
     #[tokio::test]

--- a/crates/shared/src/price_estimation/native.rs
+++ b/crates/shared/src/price_estimation/native.rs
@@ -6,12 +6,12 @@ use std::sync::Arc;
 
 pub type NativePriceEstimateResult = Result<f64, PriceEstimationError>;
 
-pub fn default_amount_to_estimate_native_prices_with(network_id: &str) -> Option<U256> {
-    match network_id {
+pub fn default_amount_to_estimate_native_prices_with(chain_id: u64) -> Option<U256> {
+    match chain_id {
         // Mainnet, Rinkeby, Göŕli
-        "1" | "4" | "5" => Some(10u128.pow(18).into()),
+        1 | 4 | 5 => Some(10u128.pow(18).into()),
         // Xdai
-        "100" => Some(10u128.pow(21).into()),
+        100 => Some(10u128.pow(21).into()),
         _ => None,
     }
 }


### PR DESCRIPTION
This PR moves the price estimator creation logic into a new `factory` module, and moves shared price estimation arguments into `price_estimation::Arguments` structure.

This is mostly a refactor, the logic should have remained the same (modulo moving from closures to a struct, and passing `PriceEstimatorType` around instead of strings).

### Test Plan

Rust compiler. Also run the autopilot and orderbook with all the supported price estimators and see that the startup works.
