### PR TITLE
Move auction age liveness check to autopilot

### DIFF
--- a/crates/autopilot/src/arguments.rs
+++ b/crates/autopilot/src/arguments.rs
@@ -114,6 +114,15 @@ pub struct Arguments {
     /// List of account addresses to be denied from order creation
     #[clap(long, env, use_value_delimiter = true)]
     pub banned_users: Vec<H160>,
+
+    /// If the auction hasn't been updated in this amount of time the pod fails the liveness check.
+    #[clap(
+        long,
+        env,
+        default_value = "300",
+        parse(try_from_str = shared::arguments::duration_from_seconds),
+    )]
+    pub max_auction_age: Duration,
 }
 
 impl std::fmt::Display for Arguments {
@@ -162,6 +171,7 @@ impl std::fmt::Display for Arguments {
             self.min_order_validity_period
         )?;
         writeln!(f, "banned_users: {:?}", self.banned_users)?;
+        writeln!(f, "max_auction_age: {:?}", self.max_auction_age)?;
         Ok(())
     }
 }

--- a/crates/autopilot/src/lib.rs
+++ b/crates/autopilot/src/lib.rs
@@ -46,18 +46,21 @@ use shared::{
 };
 use std::{sync::Arc, time::Duration};
 
-struct Liveness;
+struct Liveness {
+    solvable_orders_cache: Arc<SolvableOrdersCache>,
+    max_auction_age: Duration,
+}
+
 #[async_trait::async_trait]
 impl LivenessChecking for Liveness {
     async fn is_alive(&self) -> bool {
-        true
+        let age = self.solvable_orders_cache.last_update_time().elapsed();
+        age <= self.max_auction_age
     }
 }
 
 /// Assumes tracing and metrics registry have already been set up.
 pub async fn main(args: arguments::Arguments) {
-    let serve_metrics = shared::metrics::serve_metrics(Arc::new(Liveness), args.metrics_address);
-
     let db = Postgres::new(args.db_url.as_str()).await.unwrap();
     let db_metrics = crate::database::database_metrics(db.clone());
 
@@ -429,6 +432,12 @@ pub async fn main(args: arguments::Arguments) {
     }
     let maintenance_task =
         tokio::task::spawn(service_maintainer.run_maintenance_on_new_block(current_block_stream));
+
+    let liveness = Liveness {
+        max_auction_age: args.max_auction_age,
+        solvable_orders_cache,
+    };
+    let serve_metrics = shared::metrics::serve_metrics(Arc::new(liveness), args.metrics_address);
 
     tokio::select! {
         result = serve_metrics => tracing::error!(?result, "serve_metrics exited"),

--- a/crates/autopilot/src/solvable_orders.rs
+++ b/crates/autopilot/src/solvable_orders.rs
@@ -194,6 +194,10 @@ impl SolvableOrdersCache {
 
         Ok(())
     }
+
+    pub fn last_update_time(&self) -> Instant {
+        self.cache.lock().unwrap().orders.update_time
+    }
 }
 
 /// Filters all orders whose owners are in the set of "banned" users.

--- a/crates/e2e/tests/e2e/services.rs
+++ b/crates/e2e/tests/e2e/services.rs
@@ -267,8 +267,6 @@ impl OrderbookServices {
             contracts.gp_settlement.address(),
             api_db.as_ref().clone(),
             order_validator.clone(),
-            100,
-            current_block_stream.clone(),
         ));
         let maintenance = ServiceMaintenance {
             maintainers: vec![Arc::new(autopilot_db.clone()), event_updater],

--- a/crates/orderbook/src/arguments.rs
+++ b/crates/orderbook/src/arguments.rs
@@ -92,11 +92,6 @@ pub struct Arguments {
     #[clap(long, env)]
     pub enable_presign_orders: bool,
 
-    /// If solvable orders haven't been successfully updated in this many blocks attempting
-    /// to get them errors and our liveness check fails.
-    #[clap(long, default_value = "24")]
-    pub solvable_orders_max_update_age_blocks: u64,
-
     /// The API endpoint to call the mip v2 solver for price estimation
     #[clap(long, env)]
     pub quasimodo_solver_url: Option<Url>,
@@ -196,11 +191,6 @@ impl std::fmt::Display for Arguments {
             self.eip1271_skip_creation_validation
         )?;
         writeln!(f, "enable_presign_orders: {}", self.enable_presign_orders)?;
-        writeln!(
-            f,
-            "solvable_orders_max_update_age_blocks: {}",
-            self.solvable_orders_max_update_age_blocks,
-        )?;
         display_option(f, "quasimodo_solver_url", &self.quasimodo_solver_url)?;
         display_option(f, "yearn_solver_url", &self.yearn_solver_url)?;
         writeln!(

--- a/crates/orderbook/src/main.rs
+++ b/crates/orderbook/src/main.rs
@@ -522,8 +522,6 @@ async fn main() {
         settlement_contract.address(),
         database.as_ref().clone(),
         order_validator.clone(),
-        args.solvable_orders_max_update_age_blocks,
-        current_block_stream.clone(),
     ));
     let mut service_maintainer = ServiceMaintenance {
         maintainers: vec![pool_fetcher],


### PR DESCRIPTION
We currently have a liveness check in Orderbook that fails if the current auction is older than some threshold. This made sense when Orderbook was responsible for creating auctions but hasn't anymore since we made Autopilot create auctions.

This PR moves the check into Autopilot and changes the ordebook liveness check to instead query a default order uid which effectively checks whether the process can still communicate with the database. Note that the order uid doesn't have to exist, it just has to not error.

### Test Plan

CI, look at staging pods after merge