### PR TITLE
Don't error on insert_orders conflicts for the onchain_placed_orders

### DIFF
--- a/crates/autopilot/src/database/onchain_order_events.rs
+++ b/crates/autopilot/src/database/onchain_order_events.rs
@@ -153,7 +153,7 @@ impl<T: Sync + Send + Clone, W: Sync + Send + Clone> EventStoring<ContractEvent>
         .await
         .context("append_onchain_orders failed")?;
 
-        database::orders::insert_orders(&mut transaction, orders.as_slice())
+        database::orders::insert_orders_and_ignore_conflicts(&mut transaction, orders.as_slice())
             .await
             .context("insert_orders failed")?;
         transaction.commit().await.context("commit")?;
@@ -182,7 +182,7 @@ impl<T: Sync + Send + Clone, W: Sync + Send + Clone> EventStoring<ContractEvent>
             .await
             .context("append_custom_onchain_orders failed")?;
 
-        database::orders::insert_orders(&mut transaction, orders.as_slice())
+        database::orders::insert_orders_and_ignore_conflicts(&mut transaction, orders.as_slice())
             .await
             .context("insert_orders failed")?;
 


### PR DESCRIPTION
For the old order placement process via API, we wanna populate the error "DuplicatedOrder" to the API and throw it as an error.
But for the orders that are indexed via the onchain_order parsing, we don't wanna receive an error, as it's expected that with each reorg, we would try to insert the orders again.


### Test Plan
