### PR TITLE
Add the flag is_ethflow_order

### DIFF
--- a/crates/autopilot/src/database/auction.rs
+++ b/crates/autopilot/src/database/auction.rs
@@ -142,6 +142,7 @@ fn full_order_into_model_order(order: database::orders::FullOrder) -> Result<Ord
         full_fee_amount: big_decimal_to_u256(&order.full_fee_amount)
             .ok_or_else(|| anyhow!("full_fee_amount is not U256"))?,
         is_liquidity_order: order.is_liquidity_order,
+        is_ethflow_order: order.is_ethflow_order,
     };
     let data = OrderData {
         sell_token: H160(order.sell_token.0),

--- a/crates/database/src/ethflow_orders.rs
+++ b/crates/database/src/ethflow_orders.rs
@@ -17,7 +17,7 @@ pub async fn append(
     Ok(())
 }
 
-async fn insert_ethflow_order(
+pub async fn insert_ethflow_order(
     ex: &mut PgConnection,
     event: &EthOrderPlacement,
 ) -> Result<(), sqlx::Error> {

--- a/crates/database/src/orders.rs
+++ b/crates/database/src/orders.rs
@@ -174,8 +174,8 @@ pub async fn read_order(
     id: &OrderUid,
 ) -> Result<Option<Order>, sqlx::Error> {
     const QUERY: &str = r#"
-SELECT * FROM ORDERS
-WHERE uid = $1
+        SELECT * FROM ORDERS
+        WHERE uid = $1
     "#;
     sqlx::query_as(QUERY).bind(id).fetch_optional(ex).await
 }
@@ -285,6 +285,7 @@ pub struct FullOrder {
     pub buy_token_balance: BuyTokenDestination,
     pub presignature_pending: bool,
     pub is_liquidity_order: bool,
+    pub is_ethflow_order: bool,
 }
 
 // When querying orders we have several specialized use cases working with their own filtering,
@@ -311,7 +312,7 @@ const ORDERS_SELECT: &str = r#"
 o.uid, o.owner, o.creation_timestamp, o.sell_token, o.buy_token, o.sell_amount, o.buy_amount,
 o.valid_to, o.app_data, o.fee_amount, o.full_fee_amount, o.kind, o.partially_fillable, o.signature,
 o.receiver, o.signing_scheme, o.settlement_contract, o.sell_token_balance, o.buy_token_balance,
-o.is_liquidity_order,
+o.is_liquidity_order, (CASE WHEN eth_o.uid is NULL THEN false ELSE true END) as is_ethflow_order,
 (SELECT COALESCE(SUM(t.buy_amount), 0) FROM trades t WHERE t.order_uid = o.uid) AS sum_buy,
 (SELECT COALESCE(SUM(t.sell_amount), 0) FROM trades t WHERE t.order_uid = o.uid) AS sum_sell,
 (SELECT COALESCE(SUM(t.fee_amount), 0) FROM trades t WHERE t.order_uid = o.uid) AS sum_fee,
@@ -327,7 +328,7 @@ o.is_liquidity_order,
 ), true)) AS presignature_pending
 "#;
 
-const ORDERS_FROM: &str = "orders o";
+const ORDERS_FROM: &str = "orders o LEFT OUTER JOIN ethflow_orders eth_o on eth_o.uid = o.uid";
 
 pub async fn single_full_order(
     ex: &mut PgConnection,
@@ -444,6 +445,7 @@ mod tests {
     use super::*;
     use crate::{
         byte_array::ByteArray,
+        ethflow_orders::{insert_ethflow_order, EthOrderPlacement},
         events::{Event, EventIndex, Invalidation, PreSignature, Settlement, Trade},
         PgTransaction,
     };
@@ -597,6 +599,41 @@ mod tests {
         );
         assert_eq!(order.sum_buy.to_bigint().unwrap(), expected_buy_amount);
         assert_eq!(order.sum_fee.to_bigint().unwrap(), expected_fee_amount);
+    }
+
+    #[tokio::test]
+    #[ignore]
+    async fn postgres_solvable_ethflow_orders() {
+        let mut db = PgConnection::connect("postgresql://").await.unwrap();
+        let mut db = db.begin().await.unwrap();
+        crate::clear_DANGER_(&mut db).await.unwrap();
+
+        let order = Order {
+            sell_amount: 1.into(),
+            buy_amount: 1.into(),
+            signing_scheme: SigningScheme::Eip1271,
+            ..Default::default()
+        };
+        insert_order(&mut db, &order).await.unwrap();
+
+        let order = single_full_order(&mut db, &order.uid)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(order.is_ethflow_order, false);
+
+        let eth_order_placement = EthOrderPlacement {
+            uid: order.uid,
+            valid_to: 0i64,
+        };
+        insert_ethflow_order(&mut db, &eth_order_placement)
+            .await
+            .unwrap();
+        let order = single_full_order(&mut db, &order.uid)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(order.is_ethflow_order, true);
     }
 
     #[tokio::test]

--- a/crates/database/src/orders.rs
+++ b/crates/database/src/orders.rs
@@ -174,8 +174,8 @@ pub async fn read_order(
     id: &OrderUid,
 ) -> Result<Option<Order>, sqlx::Error> {
     const QUERY: &str = r#"
-        SELECT * FROM ORDERS
-        WHERE uid = $1
+SELECT * FROM ORDERS
+WHERE uid = $1
     "#;
     sqlx::query_as(QUERY).bind(id).fetch_optional(ex).await
 }
@@ -312,7 +312,8 @@ const ORDERS_SELECT: &str = r#"
 o.uid, o.owner, o.creation_timestamp, o.sell_token, o.buy_token, o.sell_amount, o.buy_amount,
 o.valid_to, o.app_data, o.fee_amount, o.full_fee_amount, o.kind, o.partially_fillable, o.signature,
 o.receiver, o.signing_scheme, o.settlement_contract, o.sell_token_balance, o.buy_token_balance,
-o.is_liquidity_order, (CASE WHEN eth_o.uid is NULL THEN false ELSE true END) as is_ethflow_order,
+o.is_liquidity_order,
+(SELECT EXISTS(SELECT 1 FROM ethflow_orders eo WHERE eo.uid = o.uid)) as is_ethflow_order,
 (SELECT COALESCE(SUM(t.buy_amount), 0) FROM trades t WHERE t.order_uid = o.uid) AS sum_buy,
 (SELECT COALESCE(SUM(t.sell_amount), 0) FROM trades t WHERE t.order_uid = o.uid) AS sum_sell,
 (SELECT COALESCE(SUM(t.fee_amount), 0) FROM trades t WHERE t.order_uid = o.uid) AS sum_fee,
@@ -328,7 +329,7 @@ o.is_liquidity_order, (CASE WHEN eth_o.uid is NULL THEN false ELSE true END) as 
 ), true)) AS presignature_pending
 "#;
 
-const ORDERS_FROM: &str = "orders o LEFT OUTER JOIN ethflow_orders eth_o on eth_o.uid = o.uid";
+const ORDERS_FROM: &str = "orders o";
 
 pub async fn single_full_order(
     ex: &mut PgConnection,

--- a/crates/database/src/orders.rs
+++ b/crates/database/src/orders.rs
@@ -603,7 +603,7 @@ mod tests {
 
     #[tokio::test]
     #[ignore]
-    async fn postgres_solvable_ethflow_orders() {
+    async fn postgres_reading_ethflow_orders() {
         let mut db = PgConnection::connect("postgresql://").await.unwrap();
         let mut db = db.begin().await.unwrap();
         crate::clear_DANGER_(&mut db).await.unwrap();

--- a/crates/database/src/orders.rs
+++ b/crates/database/src/orders.rs
@@ -620,7 +620,7 @@ mod tests {
             .await
             .unwrap()
             .unwrap();
-        assert_eq!(order.is_ethflow_order, false);
+        assert!(!order.is_ethflow_order);
 
         let eth_order_placement = EthOrderPlacement {
             uid: order.uid,
@@ -633,7 +633,7 @@ mod tests {
             .await
             .unwrap()
             .unwrap();
-        assert_eq!(order.is_ethflow_order, true);
+        assert!(order.is_ethflow_order);
     }
 
     #[tokio::test]

--- a/crates/model/src/order.rs
+++ b/crates/model/src/order.rs
@@ -405,6 +405,7 @@ pub struct OrderMetadata {
     #[serde(default, with = "u256_decimal")]
     pub full_fee_amount: U256,
     pub is_liquidity_order: bool,
+    pub is_ethflow_order: bool,
 }
 
 impl Default for OrderMetadata {
@@ -423,6 +424,7 @@ impl Default for OrderMetadata {
             settlement_contract: H160::default(),
             full_fee_amount: U256::default(),
             is_liquidity_order: false,
+            is_ethflow_order: false,
         }
     }
 }
@@ -696,6 +698,7 @@ mod tests {
                 settlement_contract: H160::from_low_u64_be(2),
                 full_fee_amount: U256::MAX,
                 is_liquidity_order: false,
+                is_ethflow_order: false,
             },
             data: OrderData {
                 sell_token: H160::from_low_u64_be(10),

--- a/crates/model/src/order.rs
+++ b/crates/model/src/order.rs
@@ -681,6 +681,7 @@ mod tests {
             "sellTokenBalance": "external",
             "buyTokenBalance": "internal",
             "isLiquidityOrder": false,
+            "isEthflowOrder": false,
         });
         let signing_scheme = EcdsaSigningScheme::Eip712;
         let expected = Order {

--- a/crates/orderbook/src/database/orders.rs
+++ b/crates/orderbook/src/database/orders.rs
@@ -299,6 +299,7 @@ fn full_order_into_model_order(order: FullOrder) -> Result<Order> {
         full_fee_amount: big_decimal_to_u256(&order.full_fee_amount)
             .ok_or_else(|| anyhow!("full_fee_amount is not U256"))?,
         is_liquidity_order: order.is_liquidity_order,
+        is_ethflow_order: order.is_ethflow_order,
     };
     let data = OrderData {
         sell_token: H160(order.sell_token.0),
@@ -387,6 +388,7 @@ mod tests {
             buy_token_balance: DbBuyTokenDestination::Internal,
             presignature_pending: false,
             is_liquidity_order: true,
+            is_ethflow_order: false,
         };
 
         // Open - sell (filled - 0%)


### PR DESCRIPTION
Adds a new flag `is_ethflow_order`. This flag is required, as we need to do some special operations for ethflow orders, e.g. add a special pre_interaction to wrap eth.

Please review together with the follow-up: [PR](https://github.com/cowprotocol/services/pull/581)

Note: There is an alternative way to implement it:
- storing the ethflow_address in the settlement_encoder and then identifying ethflow orders as orders that use this ethflow_address as owner. However, I found this more cumbersome for 1 main reason: This would mean we need to propagate the eth_flow address to all places where we need to check whether an order is an ethflow order. Just alone for the settlement encoder, this requires storing the ethflow_address in the SettlementEncoder + Settlement structs. Since they are currently created by the solvers, this would affect all solver implementation, unless it's nicely abstracted away by a new abstraction layer.


### Test Plan
unit test