### PR TITLE
Insert wrapAll pre-interacton for ethflow orders

### DIFF
--- a/crates/database/src/orders.rs
+++ b/crates/database/src/orders.rs
@@ -181,8 +181,8 @@ pub async fn read_order(
     id: &OrderUid,
 ) -> Result<Option<Order>, sqlx::Error> {
     const QUERY: &str = r#"
-SELECT * FROM ORDERS
-WHERE uid = $1
+        SELECT * FROM ORDERS
+        WHERE uid = $1
     "#;
     sqlx::query_as(QUERY).bind(id).fetch_optional(ex).await
 }
@@ -336,7 +336,7 @@ o.is_liquidity_order,
 ), true)) AS presignature_pending
 "#;
 
-const ORDERS_FROM: &str = "orders o";
+const ORDERS_FROM: &str = "orders o LEFT OUTER JOIN ethflow_orders eth_o on eth_o.uid = o.uid";
 
 pub async fn single_full_order(
     ex: &mut PgConnection,

--- a/crates/database/src/orders.rs
+++ b/crates/database/src/orders.rs
@@ -181,8 +181,8 @@ pub async fn read_order(
     id: &OrderUid,
 ) -> Result<Option<Order>, sqlx::Error> {
     const QUERY: &str = r#"
-        SELECT * FROM ORDERS
-        WHERE uid = $1
+SELECT * FROM ORDERS
+WHERE uid = $1
     "#;
     sqlx::query_as(QUERY).bind(id).fetch_optional(ex).await
 }
@@ -336,7 +336,7 @@ o.is_liquidity_order,
 ), true)) AS presignature_pending
 "#;
 
-const ORDERS_FROM: &str = "orders o LEFT OUTER JOIN ethflow_orders eth_o on eth_o.uid = o.uid";
+const ORDERS_FROM: &str = "orders o";
 
 pub async fn single_full_order(
     ex: &mut PgConnection,

--- a/crates/solver/src/settlement/settlement_encoder.rs
+++ b/crates/solver/src/settlement/settlement_encoder.rs
@@ -1,7 +1,6 @@
 use super::{ExternalPrices, Interaction, LiquidityOrderTrade, OrderTrade, Trade, TradeExecution};
 use crate::{
-    encoding::EncodedInteraction,
-    encoding::{EncodedSettlement, EncodedTrade},
+    encoding::{EncodedInteraction, EncodedSettlement, EncodedTrade},
     interactions::UnwrapWethInteraction,
     settlement::trade_surplus_in_native_token,
 };


### PR DESCRIPTION
This PR builds the pre-interaction needed to wrap eth for the ethflow orders.

### Test Plan
This can only be properly tested with e2e tests. Hence, I hope it's okay if I don't add a test. Curious about your opinion.

I tested it like this, but its probably not needed for the review:
```
-- merge the PR that activates indexing:
git merge indexing16

— database setup
docker run -d -e POSTGRES_HOST_AUTH_METHOD=trust -e POSTGRES_USER=`whoami` -p 5432:5432 docker.io/postgres
docker build --tag services-migration -f docker/Dockerfile.migration .
docker run -ti -e FLYWAY_URL="jdbc:postgresql://host.docker.internal/?user="$USER"&password=" -v $PWD/database/sql:/flyway/sql services-migration migrate

— running the order book:
export INFURA_KEY=<Your KEY>  && 
cargo run --bin orderbook -- --node-url "https://goerli.infura.io/v3/$INFURA_KEY" --enable-eip1271-orders

— running autopilot
export INFURA_KEY=<Your KEY>   &&
cargo run --bin autopilot -- --node-url "https://goerli.infura.io/v3/$INFURA_KEY" --skip-event-sync

— running solver
export INFURA_KEY=<Your KEY>  &&
Export SOLVER_PK=<Your PK> &&
cargo run -p solver --  --orderbook-url http://localhost:8080/ \
   --node-url "https://goerli.infura.io/v3/$INFURA_KEY" \
  --solver-account $SOLVER_PK\
  --solvers Naive,Baseline \
  --transaction-strategy PublicMempool \
--transaction-submission-nodes "https://goerli.infura.io/v3/$INFURA_KEY"
```

and then I was placing orders with David's interface from here: 
https://github.com/cowprotocol/cowswap/tree/eth-flow/contract-hooks
and set `REACT_APP_API_URL_STAGING_GOERLI=http://localhost:8080/api` in .env file

