### PR TITLE
Initialize solver metrics

### DIFF
--- a/crates/driver/src/main.rs
+++ b/crates/driver/src/main.rs
@@ -477,6 +477,12 @@ async fn build_drivers(common: &CommonComponents, args: &Arguments) -> Vec<(Arc<
     });
     let auction_converter = build_auction_converter(common, args).await.unwrap();
     let metrics = Arc::new(Metrics::new().unwrap());
+    metrics.initialize_solver_metrics(
+        &solvers
+            .iter()
+            .map(|solver| solver.name())
+            .collect::<Vec<_>>(),
+    );
 
     let settlement_ranker = Arc::new(SettlementRanker {
         metrics: metrics.clone(),

--- a/crates/solver/src/driver_logger.rs
+++ b/crates/solver/src/driver_logger.rs
@@ -1,7 +1,7 @@
 use crate::{
     analytics,
     driver::solver_settlements::RatedSettlement,
-    metrics::SolverMetrics,
+    metrics::{SolverMetrics, SolverSimulationOutcome},
     settlement::Settlement,
     settlement_simulation::{
         simulate_and_error_with_tenderly_link, simulate_before_after_access_list,
@@ -164,7 +164,8 @@ impl DriverLogger {
             .await;
 
             for ((solver, settlement, _, _), result) in errors.iter().zip(simulations) {
-                metrics.settlement_simulation_failed_on_latest(solver.name());
+                metrics
+                    .settlement_simulation(solver.name(), SolverSimulationOutcome::FailureOnLatest);
                 if let Err(error_at_earlier_block) = result {
                     tracing::warn!(
                         "{} settlement simulation failed at submission and block {}:\n{:?}",
@@ -179,7 +180,7 @@ impl DriverLogger {
                         settlement,
                     );
 
-                    metrics.settlement_simulation_failed(solver.name());
+                    metrics.settlement_simulation(solver.name(), SolverSimulationOutcome::Failure);
                 }
             }
         };

--- a/crates/solver/src/main.rs
+++ b/crates/solver/src/main.rs
@@ -248,6 +248,13 @@ async fn main() {
     )
     .expect("failure creating solvers");
 
+    metrics.initialize_solver_metrics(
+        &solver
+            .iter()
+            .map(|solver| solver.name())
+            .collect::<Vec<_>>(),
+    );
+
     let zeroex_liquidity = if baseline_sources.contains(&BaselineSource::ZeroEx) {
         Some(ZeroExLiquidity::new(
             web3.clone(),

--- a/crates/solver/src/settlement_ranker.rs
+++ b/crates/solver/src/settlement_ranker.rs
@@ -1,6 +1,6 @@
 use crate::{
     driver::solver_settlements::{self, retain_mature_settlements},
-    metrics::{SolverMetrics, SolverRunOutcome},
+    metrics::{SolverMetrics, SolverRunOutcome, SolverSimulationOutcome},
     settlement::{external_prices::ExternalPrices, PriceCheckTokens, Settlement},
     settlement_rater::{RatedSolverSettlement, SettlementRating},
     solver::{SettlementWithError, Solver, SolverRunError},
@@ -144,7 +144,8 @@ impl SettlementRanker {
             errors.len(),
         );
         for (solver, _, _) in &rated_settlements {
-            self.metrics.settlement_simulation_succeeded(solver.name());
+            self.metrics
+                .settlement_simulation(solver.name(), SolverSimulationOutcome::Success);
         }
 
         Ok((rated_settlements, errors))


### PR DESCRIPTION
Our solver metrics usually have labels for the solver name and the outcome of the thing being measured (like simulation failure/success). By default these metrics do not exist until they receive their first value because the prometheus library cannot know the label values in advance.
This is problematic for our alerting setup where we want to write rules that mention these labels. These alerts would enter the "no data" state until the metric really exists. Semantically "no data" is equivalent to a 0 value in these cases but we don't want to assume this in the alert itself because then we might later accidentally rename a metric or label causing the alert to stop working even though the alert would report itself as "ok". By doing the 0 initialization we will get warned on rename.

There are more metrics we could do this for but this PR focuses only on ones we currently have this kind of alert for and that are related to solvers.

### Test Plan

CI, see current "no data" alerts change to "ok"
