### PR TITLE
Refactor Slippage Computation

### DIFF
--- a/crates/shared/src/oneinch_api.rs
+++ b/crates/shared/src/oneinch_api.rs
@@ -224,13 +224,17 @@ impl Slippage {
             (0. ..=50.).contains(&amount),
             "slippage outside of [0%, 50%] range"
         );
+
         Ok(Slippage(amount))
     }
 }
 
 impl Display for Slippage {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
-        write!(f, "{}", self.0)
+        // Note that we use a rounded slippage percentage. This is because the
+        // 1Inch API will repsond with server errors if the slippage paramter
+        // has too much precision.
+        write!(f, "{:.2}", self.0)
     }
 }
 
@@ -621,6 +625,11 @@ mod tests {
     use crate::addr;
 
     #[test]
+    fn slippage_rounds_percentage() {
+        assert_eq!(Slippage(1.2345678).to_string(), "1.23");
+    }
+
+    #[test]
     fn slippage_out_of_range() {
         assert!(Slippage::percentage(-1.).is_err());
         assert!(Slippage::percentage(1337.).is_err());
@@ -669,7 +678,7 @@ mod tests {
                 &toTokenAddress=0x111111111117dc0aa78b770fa6a738034120c302\
                 &amount=1000000000000000000\
                 &fromAddress=0x00000000219ab540356cbb839cbe05303d7705fa\
-                &slippage=0.5",
+                &slippage=0.50",
         );
     }
 
@@ -711,7 +720,7 @@ mod tests {
                 &toTokenAddress=0x111111111117dc0aa78b770fa6a738034120c302\
                 &amount=1000000000000000000\
                 &fromAddress=0x00000000219ab540356cbb839cbe05303d7705fa\
-                &slippage=0.5\
+                &slippage=0.50\
                 &protocols=WETH%2CUNISWAP_V3\
                 &disableEstimate=true\
                 &complexityLevel=2\

--- a/crates/shared/src/oneinch_api.rs
+++ b/crates/shared/src/oneinch_api.rs
@@ -226,12 +226,6 @@ impl Slippage {
         );
         Ok(Slippage(amount))
     }
-
-    /// Creates a slippage amount from the specified basis points.
-    pub fn from_basis_points(basis_points: u32) -> Result<Self> {
-        let percent = (basis_points as f64) / 100.;
-        Slippage::percentage(percent)
-    }
 }
 
 impl Display for Slippage {
@@ -627,14 +621,6 @@ mod tests {
     use crate::addr;
 
     #[test]
-    fn slippage_from_basis_points() {
-        assert_eq!(
-            Slippage::from_basis_points(50).unwrap(),
-            Slippage::percentage(0.5).unwrap(),
-        )
-    }
-
-    #[test]
     fn slippage_out_of_range() {
         assert!(Slippage::percentage(-1.).is_err());
         assert!(Slippage::percentage(1337.).is_err());
@@ -653,7 +639,7 @@ mod tests {
         let base_url = Url::parse("https://api.1inch.exchange/").unwrap();
         let url = SwapQuery {
             from_address: addr!("00000000219ab540356cBB839Cbe05303d7705Fa"),
-            slippage: Slippage::from_basis_points(50).unwrap(),
+            slippage: Slippage::percentage(0.5).unwrap(),
             disable_estimate: None,
             quote: SellOrderQuoteQuery {
                 from_token_address: addr!("EeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE"),
@@ -692,7 +678,7 @@ mod tests {
         let base_url = Url::parse("https://api.1inch.exchange/").unwrap();
         let url = SwapQuery {
             from_address: addr!("00000000219ab540356cBB839Cbe05303d7705Fa"),
-            slippage: Slippage::from_basis_points(50).unwrap(),
+            slippage: Slippage::percentage(0.5).unwrap(),
             disable_estimate: Some(true),
             quote: SellOrderQuoteQuery {
                 from_token_address: addr!("EeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE"),
@@ -884,7 +870,7 @@ mod tests {
             .unwrap()
             .get_swap(SwapQuery {
                 from_address: addr!("00000000219ab540356cBB839Cbe05303d7705Fa"),
-                slippage: Slippage::from_basis_points(50).unwrap(),
+                slippage: Slippage::percentage(0.5).unwrap(),
                 disable_estimate: None,
                 quote: SellOrderQuoteQuery::with_default_options(
                     addr!("EeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE"),
@@ -909,7 +895,7 @@ mod tests {
             .unwrap()
             .get_swap(SwapQuery {
                 from_address: addr!("4e608b7da83f8e9213f554bdaa77c72e125529d0"),
-                slippage: Slippage::from_basis_points(50).unwrap(),
+                slippage: Slippage::percentage(0.5).unwrap(),
                 disable_estimate: Some(true),
                 quote: SellOrderQuoteQuery {
                     from_token_address: addr!("EeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE"),

--- a/crates/solver/src/liquidity/slippage.rs
+++ b/crates/solver/src/liquidity/slippage.rs
@@ -1,45 +1,219 @@
-//! Module defining static slippage parameters for AMM liquidiy.
+//! Module defining slippage computation for AMM liquidiy.
 
-use ethcontract::U256;
+use crate::settlement::external_prices::ExternalPrices;
+use anyhow::{Context as _, Result};
+use ethcontract::{H160, U256};
+use num::{BigInt, BigRational, Integer as _, ToPrimitive as _};
+use std::{borrow::Cow, cmp};
 
 /// Constant maximum slippage of 10 BPS (0.1%) to use for on-chain liquidity.
-pub const MAX_SLIPPAGE_BPS: u16 = 10;
+pub const DEFAULT_MAX_SLIPPAGE_BPS: u32 = 10;
 
 /// Basis points in 100%.
-const BPS_BASE: u16 = 10000;
+const BPS_BASE: u32 = 10000;
+
+/// Component used for computing negative slippage limits for internal solvers.
+#[derive(Clone, Debug)]
+pub struct SlippageCalculator {
+    /// The maximum relative slippage factor.
+    relative: BigRational,
+    /// The maximum absolute slippage in native tokens.
+    absolute: Option<BigInt>,
+}
+
+impl SlippageCalculator {
+    pub fn from_bps(relative_bps: u32, absolute: Option<U256>) -> Self {
+        Self {
+            relative: BigRational::new(relative_bps.into(), BPS_BASE.into()),
+            absolute: absolute.map(|value| number_conversions::u256_to_big_int(&value)),
+        }
+    }
+
+    pub fn compute(
+        &self,
+        external_prices: &ExternalPrices,
+        token: H160,
+        amount: U256,
+    ) -> Result<SlippageAmount> {
+        let price = external_prices
+            .price(&token)
+            .context("missing token price")?;
+
+        let (relative, absolute) =
+            self.compute_inner(price, number_conversions::u256_to_big_int(&amount));
+        let slippage = SlippageAmount::from_num(&relative, &absolute)?;
+
+        if *relative < self.relative {
+            tracing::debug!(
+                ?token,
+                %amount,
+                relative = ?slippage.relative,
+                absolute = %slippage.absolute,
+                "reducing relative to respect maximum absolute slippage",
+            );
+        }
+
+        Ok(slippage)
+    }
+
+    pub fn compute_with_price(&self, price: &BigRational, amount: U256) -> Result<SlippageAmount> {
+        let (relative, absolute) =
+            self.compute_inner(price, number_conversions::u256_to_big_int(&amount));
+        SlippageAmount::from_num(&relative, &absolute)
+    }
+
+    fn compute_inner(
+        &self,
+        token_price: &BigRational,
+        amount: BigInt,
+    ) -> (Cow<BigRational>, BigInt) {
+        let relative = if let Some(max_absolute_native_token) = self.absolute.clone() {
+            let max_absolute_slippage =
+                BigRational::new(max_absolute_native_token, 1.into()) / token_price;
+
+            let max_relative_slippage_respecting_absolute_limit = max_absolute_slippage / &amount;
+
+            cmp::min(
+                Cow::Owned(max_relative_slippage_respecting_absolute_limit),
+                Cow::Borrowed(&self.relative),
+            )
+        } else {
+            Cow::Borrowed(&self.relative)
+        };
+        let absolute = {
+            let ratio = &*relative * amount;
+            ratio.numer().div_ceil(ratio.denom())
+        };
+
+        (relative, absolute)
+    }
+}
+
+impl Default for SlippageCalculator {
+    fn default() -> Self {
+        Self::from_bps(DEFAULT_MAX_SLIPPAGE_BPS, None)
+    }
+}
+
+/// A result of a slippage computation containing both relative and absolute
+/// slippage amounts.
+#[derive(Clone, Copy, Debug, Default)]
+pub struct SlippageAmount {
+    /// The relative slippage amount factor.
+    relative: f64,
+    /// The absolute slippage amount in the token it was computed for.
+    absolute: U256,
+}
+
+impl SlippageAmount {
+    /// Computes a slippage amount from arbitrary precision `num` values.
+    fn from_num(relative: &BigRational, absolute: &BigInt) -> Result<Self> {
+        let relative = relative
+            .to_f64()
+            .context("relative slippage ratio is not a number")?;
+        let absolute = number_conversions::big_int_to_u256(absolute)?;
+
+        Ok(Self { relative, absolute })
+    }
+
+    /// Reduce the specified amount by the constant slippage.
+    pub fn amount_minus(&self, amount: U256) -> U256 {
+        amount.saturating_sub(self.absolute)
+    }
+
+    /// Increase the specified amount by the constant slippage.
+    pub fn amount_plus(&self, amount: U256) -> U256 {
+        amount.saturating_add(self.absolute)
+    }
+
+    /// Returns the relative slippage as basis points rounded down.
+    pub fn as_bps(&self) -> u32 {
+        (self.relative * 10000.) as _
+    }
+
+    /// As a percentage rounderd to the closest 0.01.
+    ///
+    /// This is useful for protocols that don't accept high precision slippage
+    /// values.
+    pub fn as_rounded_percentage(&self) -> f64 {
+        (self.as_bps() as f64) / 100.
+    }
+
+    /// Returns the relative slippage as a factor.
+    pub fn as_factor(&self) -> f64 {
+        self.relative
+    }
+}
 
 /// Multiply an integer amount by a rational, with additional handling in case
 /// of overflows.
-fn slippage_for_amount(amount: U256) -> U256 {
-    let p = U256::from(MAX_SLIPPAGE_BPS);
-    let q = U256::from(BPS_BASE);
+fn slippage_for_amount(amount: U256) -> SlippageAmount {
+    let calculator = SlippageCalculator::default();
+    let (relative, absolute) =
+        calculator.compute_inner(&num::one(), number_conversions::u256_to_big_int(&amount));
 
-    // In order to prevent overflow on the multiplication when dealing with
-    // very large numbers. In that case we divide first and add the computed
-    // rounding error.
-    let product = (amount / q) * p;
-    let rounding_error = {
-        let numerator = (amount % q) * p;
-        // Perform a ceil division so that we round up with slippage amount
-        (numerator + q - 1) / q
-    };
-
-    product + rounding_error
+    // The computed slippage amount for the default calculator will always
+    // succeed because:
+    // - The relative amount will be 0.1%, which is a known good value
+    // - 0.1% of any U256 fits into a U256, so it will also be a good value
+    SlippageAmount::from_num(&relative, &absolute).unwrap()
 }
 
 /// Reduce the specified amount by the constant slippage.
 pub fn amount_minus_max_slippage(amount: U256) -> U256 {
-    amount.saturating_sub(slippage_for_amount(amount))
+    slippage_for_amount(amount).amount_minus(amount)
 }
 
 /// Increase the specified amount by the constant slippage.
 pub fn amount_plus_max_slippage(amount: U256) -> U256 {
-    amount.saturating_add(slippage_for_amount(amount))
+    slippage_for_amount(amount).amount_plus(amount)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::settlement::external_prices::externalprices;
+    use assert_approx_eq::assert_approx_eq;
+    use shared::conversions::U256Ext as _;
+    use testlib::tokens::{USDC, WETH};
+
+    #[test]
+    fn limits_max_slippage() {
+        let calculator = SlippageCalculator::from_bps(10, Some(U256::exp10(17)));
+
+        for (price, amount, expected_slippage) in [
+            (U256::exp10(9).to_big_rational(), U256::exp10(12), 0.01),
+            (
+                BigRational::new(2.into(), 1000.into()),
+                U256::exp10(23),
+                0.05,
+            ),
+            (U256::exp10(9).to_big_rational(), U256::exp10(8), 0.1),
+            (U256::exp10(9).to_big_rational(), U256::exp10(17), 0.),
+        ] {
+            let slippage = calculator
+                .compute(
+                    &externalprices! { native_token: WETH, USDC => price },
+                    USDC,
+                    amount,
+                )
+                .unwrap();
+
+            assert_approx_eq!(slippage.as_rounded_percentage(), expected_slippage);
+        }
+    }
+
+    #[test]
+    fn errors_on_missing_token_price() {
+        let calculator = SlippageCalculator::default();
+        assert!(calculator
+            .compute(
+                &externalprices! { native_token: WETH, },
+                USDC,
+                1_000_000.into(),
+            )
+            .is_err());
+    }
 
     #[test]
     fn test_out_amount_with_slippage() {

--- a/crates/solver/src/liquidity/slippage.rs
+++ b/crates/solver/src/liquidity/slippage.rs
@@ -82,6 +82,7 @@ impl SlippageCalculator {
         };
         let absolute = {
             let ratio = &*relative * amount;
+            // Perform a ceil division so that we round up with slippage amount
             ratio.numer().div_ceil(ratio.denom())
         };
 
@@ -117,12 +118,12 @@ impl SlippageAmount {
     }
 
     /// Reduce the specified amount by the constant slippage.
-    pub fn amount_minus(&self, amount: U256) -> U256 {
+    pub fn sub_from_amount(&self, amount: U256) -> U256 {
         amount.saturating_sub(self.absolute)
     }
 
     /// Increase the specified amount by the constant slippage.
-    pub fn amount_plus(&self, amount: U256) -> U256 {
+    pub fn add_to_amount(&self, amount: U256) -> U256 {
         amount.saturating_add(self.absolute)
     }
 
@@ -158,12 +159,12 @@ fn slippage_for_amount(amount: U256) -> SlippageAmount {
 
 /// Reduce the specified amount by the constant slippage.
 pub fn amount_minus_max_slippage(amount: U256) -> U256 {
-    slippage_for_amount(amount).amount_minus(amount)
+    slippage_for_amount(amount).sub_from_amount(amount)
 }
 
 /// Increase the specified amount by the constant slippage.
 pub fn amount_plus_max_slippage(amount: U256) -> U256 {
-    slippage_for_amount(amount).amount_plus(amount)
+    slippage_for_amount(amount).add_to_amount(amount)
 }
 
 #[cfg(test)]

--- a/crates/solver/src/solver/oneinch_solver.rs
+++ b/crates/solver/src/solver/oneinch_solver.rs
@@ -163,16 +163,11 @@ impl SingleOrderSolving for OneInchSolver {
             .protocol_cache
             .get_allowed_protocols(&self.disabled_protocols, self.client.as_ref())
             .await?;
-
-        // Note that we use a rounded slippage percentage. This is because the
-        // 1Inch API will repsond with server errors if the slippage paramter
-        // has too much precision.
         let slippage = Slippage::percentage(
             self.slippage_calculator
                 .compute(&auction.external_prices, order.buy_token, order.buy_amount)?
-                .as_rounded_percentage(),
+                .as_percentage(),
         )?;
-
         self.settle_order_with_protocols_and_slippage(order, protocols, slippage)
             .await
     }

--- a/crates/solver/src/solver/oneinch_solver.rs
+++ b/crates/solver/src/solver/oneinch_solver.rs
@@ -490,7 +490,6 @@ mod tests {
             None,
         )
         .unwrap();
-        let slippage = Slippage::percentage(1.).unwrap();
         let settlement = solver
             .settle_order_with_protocols_and_slippage(
                 Order {
@@ -506,7 +505,7 @@ mod tests {
                 }
                 .into(),
                 None,
-                slippage,
+                Slippage::ONE_PERCENT,
             )
             .await
             .unwrap()

--- a/crates/solver/src/solver/oneinch_solver.rs
+++ b/crates/solver/src/solver/oneinch_solver.rs
@@ -10,7 +10,7 @@ use super::{
 use crate::{
     encoding::EncodedInteraction,
     interactions::allowances::{AllowanceManager, AllowanceManaging, ApprovalRequest},
-    liquidity::LimitOrder,
+    liquidity::{slippage::SlippageCalculator, LimitOrder},
     settlement::{Interaction, Settlement},
 };
 use anyhow::Result;
@@ -19,11 +19,9 @@ use derivative::Derivative;
 use ethcontract::{Account, Bytes};
 use maplit::hashmap;
 use model::order::OrderKind;
-use num::{BigRational, FromPrimitive, ToPrimitive};
 use primitive_types::{H160, U256};
 use reqwest::{Client, Url};
 use shared::{
-    conversions::U256Ext,
     oneinch_api::{
         OneInchClient, OneInchClientImpl, OneInchError, ProtocolCache, Slippage, Swap, SwapQuery,
     },
@@ -43,9 +41,7 @@ pub struct OneInchSolver {
     #[derivative(Debug = "ignore")]
     allowance_fetcher: Box<dyn AllowanceManaging>,
     protocol_cache: ProtocolCache,
-    oneinch_slippage_bps: u32,
-    /// how much slippage in wei we allow per trade
-    max_slippage_in_wei: Option<U256>,
+    slippage_calculator: SlippageCalculator,
     referrer_address: Option<H160>,
 }
 
@@ -72,54 +68,16 @@ impl OneInchSolver {
             client: Box::new(OneInchClientImpl::new(one_inch_url, client, chain_id)?),
             allowance_fetcher: Box::new(AllowanceManager::new(web3, settlement_address)),
             protocol_cache: ProtocolCache::default(),
-            oneinch_slippage_bps,
-            max_slippage_in_wei,
+            slippage_calculator: SlippageCalculator::from_bps(
+                oneinch_slippage_bps,
+                max_slippage_in_wei,
+            ),
             referrer_address,
         })
     }
 }
 
 impl OneInchSolver {
-    /// Computes the max slippage we are willing to use for a given trade to limit the absolute
-    /// slippage to a configured upper limit in terms of wei. Because 1Inch keeps positive
-    /// slippage, always applying a default slippage would otherwise become very costly for huge
-    /// orders.
-    fn compute_max_slippage(
-        external_buy_token_price_in_wei: &BigRational,
-        buy_amount: &U256,
-        default_slippage_bps: u32,
-        max_slippage_in_wei: &U256,
-    ) -> Result<Slippage> {
-        let max_absolute_slippage_in_buy_token =
-            max_slippage_in_wei.to_big_rational() / external_buy_token_price_in_wei;
-
-        let max_relative_slippage_respecting_wei_limit =
-            max_absolute_slippage_in_buy_token / buy_amount.to_big_rational();
-
-        let max_slippage_bps_respecting_wei_limit =
-            max_relative_slippage_respecting_wei_limit * BigRational::from_u128(10_000).unwrap();
-
-        let final_slippage_bps = std::cmp::min(
-            max_slippage_bps_respecting_wei_limit
-                .to_u32()
-                // if the wei based slippage is too big for u32 the default slippage will be smaller
-                // so we can safely use it as a fallback
-                .unwrap_or(default_slippage_bps),
-            default_slippage_bps,
-        );
-
-        if final_slippage_bps < default_slippage_bps {
-            tracing::debug!(
-                default_slippage_bps,
-                final_slippage_bps,
-                ?max_slippage_in_wei,
-                "reducing default slippage bps to respect max absolute slippage configuration",
-            );
-        }
-
-        Slippage::from_basis_points(final_slippage_bps)
-    }
-
     /// Settles a single sell order against a 1Inch swap using the specified protocols and
     /// slippage.
     async fn settle_order_with_protocols_and_slippage(
@@ -205,18 +163,16 @@ impl SingleOrderSolving for OneInchSolver {
             .protocol_cache
             .get_allowed_protocols(&self.disabled_protocols, self.client.as_ref())
             .await?;
-        let slippage = match self.max_slippage_in_wei {
-            Some(wei) => Self::compute_max_slippage(
-                auction.external_prices.price(&order.buy_token).expect(
-                    "auction should only contain orders where prices \
-                    for buy_token and sell_token are known",
-                ),
-                &order.buy_amount,
-                self.oneinch_slippage_bps,
-                &wei,
-            )?,
-            None => Slippage::from_basis_points(self.oneinch_slippage_bps).unwrap(),
-        };
+
+        // Note that we use a rounded slippage percentage. This is because the
+        // 1Inch API will repsond with server errors if the slippage paramter
+        // has too much precision.
+        let slippage = Slippage::percentage(
+            self.slippage_calculator
+                .compute(&auction.external_prices, order.buy_token, order.buy_amount)?
+                .as_rounded_percentage(),
+        )?;
+
         self.settle_order_with_protocols_and_slippage(order, protocols, slippage)
             .await
     }
@@ -249,16 +205,22 @@ impl From<OneInchError> for SettlementError {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::interactions::allowances::{Approval, MockAllowanceManaging};
-    use crate::liquidity::LimitOrder;
-    use crate::solver::ExternalPrices;
-    use crate::test::account;
+    use crate::{
+        interactions::allowances::{Approval, MockAllowanceManaging},
+        liquidity::LimitOrder,
+        solver::ExternalPrices,
+        test::account,
+    };
     use contracts::{GPv2Settlement, WETH9};
     use ethcontract::{Web3, H160, U256};
     use mockall::{predicate::*, Sequence};
     use model::order::{Order, OrderData, OrderKind};
-    use shared::oneinch_api::{MockOneInchClient, Protocols, Spender};
-    use shared::{dummy_contract, transport::create_env_test_transport};
+    use shared::{
+        conversions::U256Ext as _,
+        dummy_contract,
+        oneinch_api::{MockOneInchClient, Protocols, Spender},
+        transport::create_env_test_transport,
+    };
 
     fn dummy_solver(
         client: MockOneInchClient,
@@ -272,8 +234,7 @@ mod tests {
             client: Box::new(client),
             allowance_fetcher: Box::new(allowance_fetcher),
             protocol_cache: ProtocolCache::default(),
-            oneinch_slippage_bps: 10u32,
-            max_slippage_in_wei: Some(U256::MAX),
+            slippage_calculator: SlippageCalculator::default(),
             referrer_address: None,
         }
     }
@@ -293,54 +254,6 @@ mod tests {
                 .unwrap()
                 .is_none()
         );
-    }
-
-    #[test]
-    fn limits_max_slippage() {
-        let slippage = OneInchSolver::compute_max_slippage(
-            &U256::exp10(9).to_big_rational(), // USDC price in wei
-            &U256::exp10(12),                  // USDC buy amount
-            10,                                // default slippage in bps
-            &U256::exp10(17),                  // max slippage in wei
-        )
-        .unwrap();
-        assert_eq!(slippage, Slippage::from_basis_points(1).unwrap());
-    }
-
-    #[test]
-    fn limits_max_slippage_second() {
-        let slippage = OneInchSolver::compute_max_slippage(
-            &BigRational::new(2.into(), 1000.into()), // price in wei
-            &U256::exp10(23),                         // buy amount
-            10,                                       // default slippage in bps
-            &U256::exp10(17),                         // max slippage in wei
-        )
-        .unwrap();
-        assert_eq!(slippage, Slippage::from_basis_points(5).unwrap());
-    }
-
-    #[test]
-    fn limits_max_slippage_third() {
-        let slippage = OneInchSolver::compute_max_slippage(
-            &U256::exp10(9).to_big_rational(), // USDC price in wei
-            &U256::exp10(8),                   // USDC buy amount
-            10,                                // default slippage in bps
-            &U256::exp10(17),                  // max slippage in wei
-        )
-        .unwrap();
-        assert_eq!(slippage, Slippage::from_basis_points(10).unwrap());
-    }
-
-    #[test]
-    fn limits_max_slippage_fourth() {
-        let slippage = OneInchSolver::compute_max_slippage(
-            &U256::exp10(9).to_big_rational(), // USDC price in wei
-            &U256::exp10(17),                  // USDC buy amount
-            10,                                // default slippage in bps
-            &U256::exp10(17),                  // max slippage in wei
-        )
-        .unwrap();
-        assert_eq!(slippage, Slippage::from_basis_points(0).unwrap());
     }
 
     #[tokio::test]
@@ -582,7 +495,7 @@ mod tests {
             None,
         )
         .unwrap();
-        let slippage = Slippage::from_basis_points(solver.oneinch_slippage_bps).unwrap();
+        let slippage = Slippage::percentage(1.).unwrap();
         let settlement = solver
             .settle_order_with_protocols_and_slippage(
                 Order {


### PR DESCRIPTION
This change is motivated by #578, where we want absolute caps for other internal solvers.

Specifically, this PR introduces a `SlippageCalculator` component that is responsible for computing slippage amounts for input tokens. It contains shared logic for computing an approximate slippage percentage that capped by a native token value.

Additionally, this PR re-writes existing slippage computations in function of this new component, making sure that the previous slippage related tests continue to function as before.

Note that we also start rounding the percentages for the 1Inch API. This is because the API only accepts up to a certain precision. Experimentally, it appears that it accepts up to 4 digits after the `.`. However, in this PR truncate it to the nearest basis point (so it continues to work as it did before - since the 1Inch max slippage computation used to convert to BPS before converting to a slippage percentage):

```
% curl -s "https://api.1inch.exchange/v4.0/1/swap?slippage=1.2345678&fromTokenAddress=0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE&toTokenAddress=0x111111111117dc0aa78b770fa6a738034120c302&amount=10000000000000000&fromAddress=0x9008D19f58AAbD9eD0D60971565AA8510560ab41&disableEstimate=true" | jq
{
  "statusCode": 500,
  "error": "Internal Server Error",
  "description": "Internal Server Error",
  "meta": [],
  "requestId": "48f4ab64-ea2d-43f5-a2c6-168416c9c7b3"
}
% curl -s "https://api.1inch.exchange/v4.0/1/swap?slippage=1.23&fromTokenAddress=0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE&toTokenAddress=0x111111111117dc0aa78b770fa6a738034120c302&amount=10000000000000000&fromAddress=0x9008D19f58AAbD9eD0D60971565AA8510560ab41&disableEstimate=true" | jq 
{
  ... # A swap response...
}
```

### Test Plan

CI - existing slippage computation tests continue to pass exactly as before. Also make sure that the slippage formatting change continues to work:

```
% cargo test -- --ignored oneinch
    Finished test [unoptimized + debuginfo] target(s) in 1.72s
     Running unittests src/lib.rs (target/debug/deps/shared-18ccb9e2646671b5)

running 8 tests
test oneinch_api::tests::oneinch_spender_address ... ok
test oneinch_api::tests::oneinch_liquidity_sources ... ok
test oneinch_api::tests::oneinch_swap_fully_parameterized ... ok
test price_estimation::oneinch::tests::real_estimate ... ok
test oneinch_api::tests::oneinch_sell_order_quote_fully_parameterized ... ok
test oneinch_api::tests::oneinch_sell_order_quote ... ok
test trade_finding::oneinch::tests::real_estimate ... ok
test oneinch_api::tests::oneinch_swap ... ok

test result: ok. 8 passed; 0 failed; 0 ignored; 0 measured; 354 filtered out; finished in 0.49s

     Running unittests src/lib.rs (target/debug/deps/solver-b8f42427b1d8b09c)

running 1 test
test solver::oneinch_solver::tests::solve_order_on_oneinch ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 175 filtered out; finished in 1.54s
```