### PR TITLE
Implement retries for communication with nodes

### DIFF
--- a/crates/shared/src/current_block.rs
+++ b/crates/shared/src/current_block.rs
@@ -137,7 +137,6 @@ pub fn block_number(block: &Block) -> Result<u64> {
 #[async_trait::async_trait]
 pub trait BlockRetrieving {
     async fn current_block(&self) -> Result<Block>;
-    async fn current_block_number(&self) -> Result<u64>;
     async fn blocks(&self, range: RangeInclusive<u64>) -> Result<Vec<BlockNumberHash>>;
 }
 
@@ -149,15 +148,6 @@ impl BlockRetrieving for Web3 {
             .await
             .context("failed to get current block")?
             .ok_or_else(|| anyhow!("no current block"))
-    }
-
-    async fn current_block_number(&self) -> Result<u64> {
-        Ok(self
-            .eth()
-            .block_number()
-            .await
-            .context("failed to get current block number")?
-            .as_u64())
     }
 
     /// get blocks defined by the range (inclusive)


### PR DESCRIPTION
Fixes https://github.com/cowprotocol/services/issues/587

Communication with nodes in `EventHandler` is done with:
1. `BlockRetriving` implemenation for `Web3`
2. Calling `eth_getLogs`

This PR wraps all these calls into a version with multiple retries.

Additionally, changes `MAX_REORG_BLOCK_COUNT` to `64` because POS merge is done.
Additionally, removes function `async fn current_block_number(&self) -> Result<u64>` from `BlockRetriving` since no longer is used.

### Test Plan

UT passes. Local testing.
