### PR TITLE
Use Slippage Calculator for Internal Solvers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2945,6 +2945,7 @@ dependencies = [
  "model",
  "num",
  "number-conversions",
+ "once_cell",
  "primitive-types",
  "prometheus",
  "prometheus-metric-storage",

--- a/crates/solver/Cargo.toml
+++ b/crates/solver/Cargo.toml
@@ -36,6 +36,7 @@ mockall = { workspace = true }
 model = { path = "../model" }
 num = { workspace = true }
 number-conversions = { path = "../number-conversions" }
+once_cell = { workspace = true }
 primitive-types = { workspace = true }
 prometheus = { workspace = true }
 prometheus-metric-storage = { workspace = true }

--- a/crates/solver/src/liquidity.rs
+++ b/crates/solver/src/liquidity.rs
@@ -239,7 +239,7 @@ pub fn token_pairs<T>(reserves: &HashMap<H160, T>) -> Vec<TokenPair> {
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct AmmOrderExecution {
-    pub input: (H160, U256),
+    pub input_max: (H160, U256),
     pub output: (H160, U256),
 }
 

--- a/crates/solver/src/liquidity/slippage.rs
+++ b/crates/solver/src/liquidity/slippage.rs
@@ -1,9 +1,10 @@
 //! Module defining slippage computation for AMM liquidiy.
 
-use crate::settlement::external_prices::ExternalPrices;
+use crate::{settlement::external_prices::ExternalPrices, solver::Auction};
 use anyhow::{Context as _, Result};
 use ethcontract::{H160, U256};
 use num::{BigInt, BigRational, Integer as _, ToPrimitive as _};
+use once_cell::sync::OnceCell;
 use std::{borrow::Cow, cmp};
 
 /// Constant maximum slippage of 10 BPS (0.1%) to use for on-chain liquidity.
@@ -11,6 +12,56 @@ pub const DEFAULT_MAX_SLIPPAGE_BPS: u32 = 10;
 
 /// Basis points in 100%.
 const BPS_BASE: u32 = 10000;
+
+/// A per-auction context for computing slippage.
+pub struct SlippageContext<'a> {
+    prices: &'a ExternalPrices,
+    calculator: &'a SlippageCalculator,
+}
+
+impl<'a> SlippageContext<'a> {
+    /// Creates a new slippage context.
+    pub fn new(prices: &'a ExternalPrices, calculator: &'a SlippageCalculator) -> Self {
+        Self { prices, calculator }
+    }
+
+    /// Create a new solving context for the specified auction and slippage
+    /// calculator.
+    pub fn for_auction(auction: &'a Auction, calculator: &'a SlippageCalculator) -> Self {
+        Self::new(&auction.external_prices, calculator)
+    }
+
+    /// Computes the AMM execution maximum input amount.
+    pub fn execution_input_max(&self, input: (H160, U256)) -> Result<(H160, U256)> {
+        let (token, amount) = input;
+        let slippage = self.calculator.compute(self.prices, token, amount)?;
+        Ok((token, slippage.add_to_amount(amount)))
+    }
+
+    /// Applies slippage to an input amount.
+    pub fn apply_to_amount_in(&self, token: H160, amount: U256) -> Result<U256> {
+        Ok(self
+            .calculator
+            .compute(self.prices, token, amount)?
+            .add_to_amount(amount))
+    }
+
+    /// Applies slippage to an output amount.
+    pub fn apply_to_amount_out(&self, token: H160, amount: U256) -> Result<U256> {
+        Ok(self
+            .calculator
+            .compute(self.prices, token, amount)?
+            .sub_from_amount(amount))
+    }
+}
+
+impl Default for SlippageContext<'static> {
+    fn default() -> Self {
+        static CONTEXT: OnceCell<(ExternalPrices, SlippageCalculator)> = OnceCell::new();
+        let (prices, calculator) = CONTEXT.get_or_init(Default::default);
+        Self { prices, calculator }
+    }
+}
 
 /// Component used for computing negative slippage limits for internal solvers.
 #[derive(Clone, Debug)]
@@ -35,12 +86,10 @@ impl SlippageCalculator {
         token: H160,
         amount: U256,
     ) -> Result<SlippageAmount> {
-        let price = external_prices
-            .price(&token)
-            .context("missing token price")?;
-
-        let (relative, absolute) =
-            self.compute_inner(price, number_conversions::u256_to_big_int(&amount));
+        let (relative, absolute) = self.compute_inner(
+            external_prices.price(&token),
+            number_conversions::u256_to_big_int(&amount),
+        )?;
         let slippage = SlippageAmount::from_num(&relative, &absolute)?;
 
         if *relative < self.relative {
@@ -58,18 +107,19 @@ impl SlippageCalculator {
 
     pub fn compute_with_price(&self, price: &BigRational, amount: U256) -> Result<SlippageAmount> {
         let (relative, absolute) =
-            self.compute_inner(price, number_conversions::u256_to_big_int(&amount));
+            self.compute_inner(Some(price), number_conversions::u256_to_big_int(&amount))?;
         SlippageAmount::from_num(&relative, &absolute)
     }
 
     fn compute_inner(
         &self,
-        token_price: &BigRational,
+        price: Option<&BigRational>,
         amount: BigInt,
-    ) -> (Cow<BigRational>, BigInt) {
+    ) -> Result<(Cow<BigRational>, BigInt)> {
         let relative = if let Some(max_absolute_native_token) = self.absolute.clone() {
+            let price = price.context("missing token price")?;
             let max_absolute_slippage =
-                BigRational::new(max_absolute_native_token, 1.into()) / token_price;
+                BigRational::new(max_absolute_native_token, 1.into()) / price;
 
             let max_relative_slippage_respecting_absolute_limit = max_absolute_slippage / &amount;
 
@@ -86,7 +136,7 @@ impl SlippageCalculator {
             ratio.numer().div_ceil(ratio.denom())
         };
 
-        (relative, absolute)
+        Ok((relative, absolute))
     }
 }
 
@@ -143,30 +193,6 @@ impl SlippageAmount {
     }
 }
 
-/// Multiply an integer amount by a rational, with additional handling in case
-/// of overflows.
-fn slippage_for_amount(amount: U256) -> SlippageAmount {
-    let calculator = SlippageCalculator::default();
-    let (relative, absolute) =
-        calculator.compute_inner(&num::one(), number_conversions::u256_to_big_int(&amount));
-
-    // The computed slippage amount for the default calculator will always
-    // succeed because:
-    // - The relative amount will be 0.1%, which is a known good value
-    // - 0.1% of any U256 fits into a U256, so it will also be a good value
-    SlippageAmount::from_num(&relative, &absolute).unwrap()
-}
-
-/// Reduce the specified amount by the constant slippage.
-pub fn amount_minus_max_slippage(amount: U256) -> U256 {
-    slippage_for_amount(amount).sub_from_amount(amount)
-}
-
-/// Increase the specified amount by the constant slippage.
-pub fn amount_plus_max_slippage(amount: U256) -> U256 {
-    slippage_for_amount(amount).add_to_amount(amount)
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -207,7 +233,7 @@ mod tests {
 
     #[test]
     fn errors_on_missing_token_price() {
-        let calculator = SlippageCalculator::default();
+        let calculator = SlippageCalculator::from_bps(10, Some(1_000.into()));
         assert!(calculator
             .compute(
                 &externalprices! { native_token: WETH, },
@@ -219,27 +245,42 @@ mod tests {
 
     #[test]
     fn test_out_amount_with_slippage() {
-        assert_eq!(amount_minus_max_slippage(0.into()), 0.into());
-        assert_eq!(amount_minus_max_slippage(100.into()), 99.into());
-        assert_eq!(amount_minus_max_slippage(1000.into()), 999.into());
-        assert_eq!(amount_minus_max_slippage(10000.into()), 9990.into());
-        assert_eq!(amount_minus_max_slippage(10001.into()), 9990.into());
-        assert_eq!(
-            amount_minus_max_slippage(U256::MAX),
-            U256::from_dec_str(
-                "115676297148078879228147414023679219945416714680974923475418126423905216510295"
-            )
-            .unwrap()
-        );
+        let calculator = SlippageCalculator::default();
+        let price = num::one();
+        for (amount, expected) in [
+            (0.into(), 0.into()),
+            (100.into(), 99.into()),
+            (1000.into(), 999.into()),
+            (10000.into(), 9990.into()),
+            (10001.into(), 9990.into()),
+            (
+                U256::MAX,
+                U256::from_dec_str(
+                    "115676297148078879228147414023679219945\
+                     416714680974923475418126423905216510295",
+                )
+                .unwrap(),
+            ),
+        ] {
+            let slippage = calculator.compute_with_price(&price, amount).unwrap();
+            assert_eq!(slippage.sub_from_amount(amount), expected);
+        }
     }
 
     #[test]
     fn test_in_amount_with_slippage() {
-        assert_eq!(amount_plus_max_slippage(0.into()), 0.into());
-        assert_eq!(amount_plus_max_slippage(100.into()), 101.into());
-        assert_eq!(amount_plus_max_slippage(1000.into()), 1001.into());
-        assert_eq!(amount_plus_max_slippage(10000.into()), 10010.into());
-        assert_eq!(amount_plus_max_slippage(10001.into()), 10012.into());
-        assert_eq!(amount_plus_max_slippage(U256::MAX), U256::MAX);
+        let calculator = SlippageCalculator::default();
+        let price = num::one();
+        for (amount, expected) in [
+            (0.into(), 0.into()),
+            (100.into(), 101.into()),
+            (1000.into(), 1001.into()),
+            (10000.into(), 10010.into()),
+            (10001.into(), 10012.into()),
+            (U256::MAX, U256::MAX),
+        ] {
+            let slippage = calculator.compute_with_price(&price, amount).unwrap();
+            assert_eq!(slippage.add_to_amount(amount), expected);
+        }
     }
 }

--- a/crates/solver/src/liquidity/uniswap_v3.rs
+++ b/crates/solver/src/liquidity/uniswap_v3.rs
@@ -1,4 +1,4 @@
-use super::{slippage, AmmOrderExecution, ConcentratedLiquidity, LimitOrder, SettlementHandling};
+use super::{AmmOrderExecution, ConcentratedLiquidity, LimitOrder, SettlementHandling};
 use crate::{
     interactions::{
         allowances::{AllowanceManager, AllowanceManaging, Allowances, Approval},
@@ -132,17 +132,16 @@ impl UniswapV3Liquidity {
 impl UniswapV3SettlementHandler {
     fn settle(
         &self,
-        (token_in, amount_in): (H160, U256),
+        (token_in, amount_in_max): (H160, U256),
         (token_out, amount_out): (H160, U256),
         fee: u32,
     ) -> (Approval, UniswapV3Interaction) {
-        let amount_in_with_slippage = slippage::amount_plus_max_slippage(amount_in);
         let approval = self
             .inner
             .allowances
             .lock()
             .expect("Thread holding mutex panicked")
-            .approve_token_or_default(token_in, amount_in_with_slippage);
+            .approve_token_or_default(token_in, amount_in_max);
 
         (
             approval,
@@ -162,7 +161,7 @@ impl UniswapV3SettlementHandler {
                             .into()
                     },
                     amount_out,
-                    amount_in_max: amount_in_with_slippage,
+                    amount_in_max,
                     sqrt_price_limit_x96: U256::zero(),
                 },
             },
@@ -171,10 +170,11 @@ impl UniswapV3SettlementHandler {
 }
 
 impl SettlementHandling<ConcentratedLiquidity> for UniswapV3SettlementHandler {
-    // Creates the required interaction to convert the given input into output. Applies 0.1% slippage tolerance to the output.
+    // Creates the required interaction to convert the given input into output. Assumes slippage is
+    // already applied to the `input_max` field.
     fn encode(&self, execution: AmmOrderExecution, encoder: &mut SettlementEncoder) -> Result<()> {
         let (approval, swap) = self.settle(
-            execution.input,
+            execution.input_max,
             execution.output,
             self.fee.context("missing fee")?,
         );
@@ -224,15 +224,6 @@ mod tests {
             settlement_handler.settle((token_a, 99.into()), (token_b, 100.into()), 10);
         assert_eq!(approval, Approval::AllowanceSufficient);
 
-        // Allowance needed because of slippage
-        let (approval, _) =
-            settlement_handler.settle((token_a, 100.into()), (token_b, 100.into()), 10);
-        assert_ne!(approval, Approval::AllowanceSufficient);
-
-        let (approval, _) =
-            settlement_handler.settle((token_a, 150.into()), (token_b, 100.into()), 10);
-        assert_ne!(approval, Approval::AllowanceSufficient);
-
         // Token B below, equal, above
         let (approval, _) =
             settlement_handler.settle((token_b, 150.into()), (token_a, 100.into()), 10);
@@ -241,15 +232,6 @@ mod tests {
         let (approval, _) =
             settlement_handler.settle((token_b, 199.into()), (token_a, 100.into()), 10);
         assert_eq!(approval, Approval::AllowanceSufficient);
-
-        // Allowance needed because of slippage
-        let (approval, _) =
-            settlement_handler.settle((token_b, 200.into()), (token_a, 100.into()), 10);
-        assert_ne!(approval, Approval::AllowanceSufficient);
-
-        let (approval, _) =
-            settlement_handler.settle((token_b, 250.into()), (token_a, 100.into()), 10);
-        assert_ne!(approval, Approval::AllowanceSufficient);
 
         // Untracked token
         let (approval, _) = settlement_handler.settle(
@@ -264,7 +246,7 @@ mod tests {
     fn test_encode() {
         let settlement_handler = UniswapV3SettlementHandler::new_dummy(Default::default());
         let execution = AmmOrderExecution {
-            input: (H160::default(), U256::zero()),
+            input_max: (H160::default(), U256::zero()),
             output: (H160::default(), U256::zero()),
         };
         let mut encoder = SettlementEncoder::new(Default::default());

--- a/crates/solver/src/settlement_simulation.rs
+++ b/crates/solver/src/settlement_simulation.rs
@@ -245,6 +245,7 @@ pub fn tenderly_link(
 mod tests {
     use super::*;
     use crate::interactions::allowances::{Allowances, MockAllowanceManaging};
+    use crate::liquidity::slippage::SlippageContext;
     use crate::liquidity::{
         balancer_v2::SettlementHandler, order_converter::OrderConverter, uniswap_v2::Inner,
         ConstantProductOrder, Liquidity, StablePoolOrder,
@@ -654,6 +655,7 @@ mod tests {
             settlement_context,
             Arc::new(MockAllowanceManaging::new()),
             Arc::new(OrderConverter::test(H160([0x42; 20]))),
+            SlippageContext::default(),
         )
         .await
         .map(|settlement| vec![settlement])

--- a/crates/solver/src/solver/naive_solver.rs
+++ b/crates/solver/src/solver/naive_solver.rs
@@ -1,22 +1,29 @@
 mod multi_order_solver;
 
 use crate::{
-    liquidity::{ConstantProductOrder, LimitOrder, Liquidity},
+    liquidity::{
+        slippage::{SlippageCalculator, SlippageContext},
+        ConstantProductOrder, LimitOrder, Liquidity,
+    },
     settlement::Settlement,
     solver::{Auction, Solver},
 };
 use anyhow::Result;
 use ethcontract::Account;
 use model::TokenPair;
-use std::collections::HashMap;
+use std::{collections::HashMap, sync::Arc};
 
 pub struct NaiveSolver {
     account: Account,
+    slippage_calculator: Arc<SlippageCalculator>,
 }
 
 impl NaiveSolver {
     pub fn new(account: Account) -> Self {
-        Self { account }
+        Self {
+            account,
+            slippage_calculator: Default::default(),
+        }
     }
 }
 
@@ -25,11 +32,15 @@ impl Solver for NaiveSolver {
     async fn solve(
         &self,
         Auction {
-            orders, liquidity, ..
+            orders,
+            liquidity,
+            external_prices,
+            ..
         }: Auction,
     ) -> Result<Vec<Settlement>> {
+        let slippage = SlippageContext::new(&external_prices, &self.slippage_calculator);
         let uniswaps = extract_deepest_amm_liquidity(&liquidity);
-        Ok(settle(orders, uniswaps))
+        Ok(settle(slippage, orders, uniswaps))
     }
 
     fn account(&self) -> &Account {
@@ -42,6 +53,7 @@ impl Solver for NaiveSolver {
 }
 
 fn settle(
+    slippage: SlippageContext,
     orders: Vec<LimitOrder>,
     uniswaps: HashMap<TokenPair, ConstantProductOrder>,
 ) -> Vec<Settlement> {
@@ -49,11 +61,12 @@ fn settle(
     // Settlements between different token pairs are thus independent.
     organize_orders_by_token_pair(orders)
         .into_iter()
-        .filter_map(|(pair, orders)| settle_pair(pair, orders, &uniswaps))
+        .filter_map(|(pair, orders)| settle_pair(&slippage, pair, orders, &uniswaps))
         .collect()
 }
 
 fn settle_pair(
+    slippage: &SlippageContext,
     pair: TokenPair,
     orders: Vec<LimitOrder>,
     uniswaps: &HashMap<TokenPair, ConstantProductOrder>,
@@ -69,7 +82,7 @@ fn settle_pair(
             return None;
         }
     };
-    multi_order_solver::solve(orders.into_iter(), uniswap)
+    multi_order_solver::solve(slippage, orders.into_iter(), uniswap)
 }
 
 fn organize_orders_by_token_pair(orders: Vec<LimitOrder>) -> HashMap<TokenPair, Vec<LimitOrder>> {
@@ -211,7 +224,7 @@ mod tests {
             },
         };
 
-        assert!(settle(orders, liquidity).is_empty());
+        assert!(settle(SlippageContext::default(), orders, liquidity).is_empty());
     }
 
     #[test]
@@ -259,7 +272,7 @@ mod tests {
             },
         };
 
-        assert!(settle(orders, liquidity).is_empty());
+        assert!(settle(SlippageContext::default(), orders, liquidity).is_empty());
     }
 
     #[test]
@@ -310,6 +323,9 @@ mod tests {
             },
         };
 
-        assert_eq!(settle(orders, liquidity).len(), 1);
+        assert_eq!(
+            settle(SlippageContext::default(), orders, liquidity).len(),
+            1
+        );
     }
 }

--- a/crates/solver/src/solver/naive_solver/multi_order_solver.rs
+++ b/crates/solver/src/solver/naive_solver/multi_order_solver.rs
@@ -1,4 +1,7 @@
-use crate::{liquidity, settlement::Settlement};
+use crate::{
+    liquidity::{self, slippage::SlippageContext},
+    settlement::Settlement,
+};
 use anyhow::Result;
 use liquidity::{AmmOrderExecution, ConstantProductOrder, LimitOrder};
 use model::{
@@ -39,13 +42,14 @@ impl TokenContext {
 }
 
 pub fn solve(
+    slippage: &SlippageContext,
     orders: impl IntoIterator<Item = LimitOrder>,
     pool: &ConstantProductOrder,
 ) -> Option<Settlement> {
     let mut orders: Vec<LimitOrder> = orders.into_iter().collect();
     while !orders.is_empty() {
         let (context_a, context_b) = split_into_contexts(&orders, pool);
-        if let Some(valid_solution) = solve_orders(&orders, pool, &context_a, &context_b)
+        if let Some(valid_solution) = solve_orders(slippage, &orders, pool, &context_a, &context_b)
             .filter(|settlement| is_valid_solution(settlement, pool.tokens))
         {
             return Some(valid_solution);
@@ -80,15 +84,16 @@ pub fn solve(
 /// for that pair is not available.
 ///
 fn solve_orders(
+    slippage: &SlippageContext,
     orders: &[LimitOrder],
     pool: &ConstantProductOrder,
     context_a: &TokenContext,
     context_b: &TokenContext,
 ) -> Option<Settlement> {
     if context_a.is_excess_after_fees(context_b, pool.fee) {
-        solve_with_uniswap(orders, pool, context_b, context_a)
+        solve_with_uniswap(slippage, orders, pool, context_b, context_a)
     } else if context_b.is_excess_after_fees(context_a, pool.fee) {
-        solve_with_uniswap(orders, pool, context_a, context_b)
+        solve_with_uniswap(slippage, orders, pool, context_a, context_b)
     } else {
         solve_without_uniswap(orders, context_a, context_b).ok()
     }
@@ -118,6 +123,7 @@ fn solve_without_uniswap(
 /// The clearing price is the effective exchange rate used by the AMM interaction.
 ///
 fn solve_with_uniswap(
+    slippage: &SlippageContext,
     orders: &[LimitOrder],
     pool: &ConstantProductOrder,
     shortage: &TokenContext,
@@ -172,7 +178,9 @@ fn solve_with_uniswap(
         .with_liquidity(
             pool,
             AmmOrderExecution {
-                input: (uniswap_in_token, uniswap_in),
+                input_max: slippage
+                    .execution_input_max((uniswap_in_token, uniswap_in))
+                    .ok()?,
                 output: (uniswap_out_token, uniswap_out_with_rounding),
             },
         )
@@ -319,6 +327,10 @@ fn is_valid_solution(solution: &Settlement, pair: TokenPair) -> bool {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+    use crate::{
+        liquidity::slippage::SlippageCalculator, settlement::external_prices::ExternalPrices,
+    };
     use liquidity::tests::CapturingSettlementHandler;
     use maplit::hashmap;
     use model::{
@@ -326,12 +338,18 @@ mod tests {
         TokenPair,
     };
     use num::rational::Ratio;
+    use once_cell::sync::OnceCell;
     use shared::{baseline_solver::BaselineSolvable, sources::uniswap_v2::pool_fetching::Pool};
-
-    use super::*;
 
     fn to_wei(base: u128) -> U256 {
         U256::from(base) * U256::from(10).pow(18.into())
+    }
+
+    fn without_slippage() -> SlippageContext<'static> {
+        static CONTEXT: OnceCell<(ExternalPrices, SlippageCalculator)> = OnceCell::new();
+        let (prices, calculator) =
+            CONTEXT.get_or_init(|| (Default::default(), SlippageCalculator::from_bps(0, None)));
+        SlippageContext::new(prices, calculator)
     }
 
     #[test]
@@ -366,16 +384,16 @@ mod tests {
             fee: Ratio::new(3, 1000),
             settlement_handling: amm_handler.clone(),
         };
-        let result = solve(orders.clone(), &pool).unwrap();
+        let result = solve(&without_slippage(), orders.clone(), &pool).unwrap();
 
         // Make sure the uniswap interaction is using the correct direction
         let interaction = amm_handler.calls()[0].clone();
-        assert_eq!(interaction.input.0, token_b);
+        assert_eq!(interaction.input_max.0, token_b);
         assert_eq!(interaction.output.0, token_a);
 
         // Make sure the sell amounts +/- uniswap interaction satisfy min_buy amounts
         assert!(orders[0].sell_amount + interaction.output.1 >= orders[1].buy_amount);
-        assert!(orders[1].sell_amount - interaction.input.1 > orders[0].buy_amount);
+        assert!(orders[1].sell_amount - interaction.input_max.1 > orders[0].buy_amount);
 
         // Make sure the sell amounts +/- uniswap interaction satisfy expected buy amounts given clearing price
         let price_a = result.clearing_price(token_a).unwrap();
@@ -384,10 +402,10 @@ mod tests {
         // Multiplying sellAmount with priceA, gives us sell value in "$", divided by priceB gives us value in buy token
         // We should have at least as much to give (sell amount +/- uniswap) as is expected by the buyer
         let expected_buy = (orders[0].sell_amount * price_a).ceil_div(&price_b);
-        assert!(orders[1].sell_amount - interaction.input.1 >= expected_buy);
+        assert!(orders[1].sell_amount - interaction.input_max.1 >= expected_buy);
 
         let expected_buy = (orders[1].sell_amount * price_b).ceil_div(&price_a);
-        assert!(orders[0].sell_amount + interaction.input.1 >= expected_buy);
+        assert!(orders[0].sell_amount + interaction.input_max.1 >= expected_buy);
     }
 
     #[test]
@@ -422,15 +440,15 @@ mod tests {
             fee: Ratio::new(3, 1000),
             settlement_handling: amm_handler.clone(),
         };
-        let result = solve(orders.clone(), &pool).unwrap();
+        let result = solve(&without_slippage(), orders.clone(), &pool).unwrap();
 
         // Make sure the uniswap interaction is using the correct direction
         let interaction = amm_handler.calls()[0].clone();
-        assert_eq!(interaction.input.0, token_a);
+        assert_eq!(interaction.input_max.0, token_a);
         assert_eq!(interaction.output.0, token_b);
 
         // Make sure the sell amounts cover the uniswap in, and min buy amounts are covered by uniswap out
-        assert!(orders[0].sell_amount + orders[1].sell_amount >= interaction.input.1);
+        assert!(orders[0].sell_amount + orders[1].sell_amount >= interaction.input_max.1);
         assert!(interaction.output.1 >= orders[0].buy_amount + orders[1].buy_amount);
 
         // Make sure expected buy amounts (given prices) are also covered by uniswap out amounts
@@ -474,16 +492,16 @@ mod tests {
             fee: Ratio::new(3, 1000),
             settlement_handling: amm_handler.clone(),
         };
-        let result = solve(orders.clone(), &pool).unwrap();
+        let result = solve(&SlippageContext::default(), orders.clone(), &pool).unwrap();
 
         // Make sure the uniswap interaction is using the correct direction
         let interaction = amm_handler.calls()[0].clone();
-        assert_eq!(interaction.input.0, token_b);
+        assert_eq!(interaction.input_max.0, token_b);
         assert_eq!(interaction.output.0, token_a);
 
         // Make sure the buy amounts +/- uniswap interaction satisfy max_sell amounts
         assert!(orders[0].sell_amount >= orders[1].buy_amount - interaction.output.1);
-        assert!(orders[1].sell_amount >= orders[0].buy_amount + interaction.input.1);
+        assert!(orders[1].sell_amount >= orders[0].buy_amount + interaction.input_max.1);
 
         // Make sure buy sell amounts +/- uniswap interaction satisfy expected sell amounts given clearing price
         let price_a = result.clearing_price(token_a).unwrap();
@@ -492,7 +510,7 @@ mod tests {
         // Multiplying buyAmount with priceB, gives us sell value in "$", divided by priceA gives us value in sell token
         // The seller should expect to sell at least as much as we require for the buyer + uniswap.
         let expected_sell = orders[0].buy_amount * price_b / price_a;
-        assert!(orders[1].buy_amount - interaction.input.1 <= expected_sell);
+        assert!(orders[1].buy_amount - interaction.input_max.1 <= expected_sell);
 
         let expected_sell = orders[1].buy_amount * price_a / price_b;
         assert!(orders[0].buy_amount + interaction.output.1 <= expected_sell);
@@ -530,18 +548,18 @@ mod tests {
             fee: Ratio::new(3, 1000),
             settlement_handling: amm_handler.clone(),
         };
-        let result = solve(orders.clone(), &pool).unwrap();
+        let result = solve(&SlippageContext::default(), orders.clone(), &pool).unwrap();
 
         // Make sure the uniswap interaction is using the correct direction
         let interaction = amm_handler.calls()[0].clone();
-        assert_eq!(interaction.input.0, token_b);
+        assert_eq!(interaction.input_max.0, token_b);
         assert_eq!(interaction.output.0, token_a);
 
         // Make sure the buy order's sell amount - uniswap interaction satisfies sell order's limit
         assert!(orders[0].sell_amount >= orders[1].buy_amount - interaction.output.1);
 
         // Make sure the sell order's buy amount + uniswap interaction satisfies buy order's limit
-        assert!(orders[1].buy_amount + interaction.input.1 >= orders[0].sell_amount);
+        assert!(orders[1].buy_amount + interaction.input_max.1 >= orders[0].sell_amount);
 
         // Make sure buy sell amounts +/- uniswap interaction satisfy expected sell amounts given clearing price
         let price_a = result.clearing_price(token_a).unwrap();
@@ -550,7 +568,7 @@ mod tests {
         // Multiplying buy_amount with priceB, gives us sell value in "$", divided by priceA gives us value in sell token
         // The seller should expect to sell at least as much as we require for the buyer + uniswap.
         let expected_sell = orders[0].buy_amount * price_b / price_a;
-        assert!(orders[1].buy_amount - interaction.input.1 <= expected_sell);
+        assert!(orders[1].buy_amount - interaction.input_max.1 <= expected_sell);
 
         // Multiplying sell_amount with priceA, gives us sell value in "$", divided by priceB gives us value in buy token
         // We should have at least as much to give (sell amount + uniswap out) as is expected by the buyer
@@ -590,7 +608,7 @@ mod tests {
             fee: Ratio::new(3, 1000),
             settlement_handling: amm_handler.clone(),
         };
-        let result = solve(orders, &pool).unwrap();
+        let result = solve(&SlippageContext::default(), orders, &pool).unwrap();
         assert!(amm_handler.calls().is_empty());
         assert_eq!(
             result.clearing_prices(),
@@ -671,7 +689,7 @@ mod tests {
             fee: Ratio::new(3, 1000),
             settlement_handling: amm_handler,
         };
-        let result = solve(orders, &pool).unwrap();
+        let result = solve(&SlippageContext::default(), orders, &pool).unwrap();
 
         assert_eq!(result.traded_orders().count(), 2);
         assert!(is_valid_solution(&result, pool.tokens));
@@ -717,7 +735,7 @@ mod tests {
             fee: Ratio::new(3, 1000),
             settlement_handling: amm_handler,
         };
-        assert!(solve(orders, &pool).is_none());
+        assert!(solve(&SlippageContext::default(), orders, &pool).is_none());
     }
 
     #[test]
@@ -850,7 +868,7 @@ mod tests {
             settlement_handling: amm_handler,
         };
         // This line should not panic.
-        solve(orders, &pool);
+        solve(&SlippageContext::default(), orders, &pool);
     }
 
     #[test]
@@ -894,10 +912,10 @@ mod tests {
         };
 
         // The first order by itself should not be matchable.
-        assert!(solve(orders[0..1].to_vec(), &pool).is_none());
+        assert!(solve(&SlippageContext::default(), orders[0..1].to_vec(), &pool).is_none());
 
         // Only the second order should match
-        let result = solve(orders, &pool).unwrap();
+        let result = solve(&SlippageContext::default(), orders, &pool).unwrap();
         assert_eq!(result.traded_orders().count(), 1);
     }
 
@@ -954,7 +972,7 @@ mod tests {
             token_b => excess_amount_a,
         };
 
-        let settlement = solve(orders, &pool.into()).unwrap();
+        let settlement = solve(&SlippageContext::default(), orders, &pool.into()).unwrap();
         let trades = settlement
             .executed_trades()
             .map(|(_, trade)| trade)
@@ -973,6 +991,42 @@ mod tests {
         assert_eq!(
             trades[1].sell_amount,
             U256::from(8_000_001) * expected_prices[&token_a] / expected_prices[&token_b],
+        );
+    }
+
+    #[test]
+    fn applies_slippage_to_amm_execution() {
+        let token_a = Address::from_low_u64_be(0);
+        let token_b = Address::from_low_u64_be(1);
+        let orders = vec![LimitOrder {
+            sell_token: token_a,
+            buy_token: token_b,
+            sell_amount: to_wei(40),
+            buy_amount: to_wei(30),
+            kind: OrderKind::Sell,
+            id: "0".to_string(),
+            ..Default::default()
+        }];
+
+        let amm_handler = CapturingSettlementHandler::arc();
+        let pool = ConstantProductOrder {
+            tokens: TokenPair::new(token_a, token_b).unwrap(),
+            reserves: (to_wei(1000).as_u128(), to_wei(1000).as_u128()),
+            fee: Ratio::new(3, 1000),
+            settlement_handling: amm_handler.clone(),
+        };
+        let slippage = SlippageContext::default();
+        solve(&slippage, orders, &pool).unwrap();
+
+        assert_eq!(
+            amm_handler.calls(),
+            vec![AmmOrderExecution {
+                input_max: slippage.execution_input_max((token_a, to_wei(40))).unwrap(),
+                output: (
+                    token_b,
+                    pool.get_amount_out(token_b, (to_wei(40), token_a)).unwrap()
+                ),
+            }],
         );
     }
 }


### PR DESCRIPTION
In preparation for #578, this PR changes all of our `liquidity`-based solvers (Baseline, Naive, Quasimodo) to use the new slippage calculation component for computing slippage.

This change:
- Makes applying slippage no longer part of the `Interaction` implementation. This allows different solvers to be configured with different slippage parameters.
- Introduces `SlippageContext` - a per-auction context for computing slippage amounts (since they are dependent on token prices, i.e. the auctions `ExternalPrices` value.

In a follow up PR I will:
- Add the slippage calculator to the remaining DEX aggregator solvers
- Add configuration command line options to control the maximum relative and absolute slippage for the solvers.

### Test Plan

Adjusted unit tests to account for the fact that the `AmmOrderExecution` is expected to have slippage built-in to the `input_max` field, and added, where needed, a new test verifying slippage computation amounts.