### PR TITLE
Update MAX_REORG_BLOCK_COUNT to 64

### DIFF
--- a/crates/shared/src/current_block.rs
+++ b/crates/shared/src/current_block.rs
@@ -137,7 +137,6 @@ pub fn block_number(block: &Block) -> Result<u64> {
 #[async_trait::async_trait]
 pub trait BlockRetrieving {
     async fn current_block(&self) -> Result<Block>;
-    async fn current_block_number(&self) -> Result<u64>;
     async fn blocks(&self, range: RangeInclusive<u64>) -> Result<Vec<BlockNumberHash>>;
 }
 
@@ -149,15 +148,6 @@ impl BlockRetrieving for Web3 {
             .await
             .context("failed to get current block")?
             .ok_or_else(|| anyhow!("no current block"))
-    }
-
-    async fn current_block_number(&self) -> Result<u64> {
-        Ok(self
-            .eth()
-            .block_number()
-            .await
-            .context("failed to get current block number")?
-            .as_u64())
     }
 
     /// get blocks defined by the range (inclusive)

--- a/crates/shared/src/event_handling.rs
+++ b/crates/shared/src/event_handling.rs
@@ -646,7 +646,10 @@ mod tests {
         let range = RangeInclusive::try_new(0, MAX_BLOCKS_QUERIED + 1).unwrap();
         let (history_range, latest_range) = split_range(range);
         assert_eq!(history_range, Some(RangeInclusive::try_new(0, 1).unwrap()));
-        assert_eq!(latest_range, RangeInclusive::try_new(2, 51).unwrap());
+        assert_eq!(
+            latest_range,
+            RangeInclusive::try_new(2, MAX_BLOCKS_QUERIED + 1).unwrap()
+        );
     }
 
     #[tokio::test]

--- a/crates/shared/src/event_handling.rs
+++ b/crates/shared/src/event_handling.rs
@@ -10,7 +10,7 @@ use futures::{future, Stream, StreamExt, TryStreamExt};
 use tokio::sync::Mutex;
 
 // We expect that there is never a reorg that changes more than the last n blocks.
-pub const MAX_REORG_BLOCK_COUNT: u64 = 25;
+pub const MAX_REORG_BLOCK_COUNT: u64 = 64;
 // Saving events, we process at most this many at a time.
 const INSERT_EVENT_BATCH_SIZE: usize = 10_000;
 // MAX_BLOCKS_QUERIED is bigger than MAX_REORG_BLOCK_COUNT to increase the chances


### PR DESCRIPTION
Updates `MAX_REORG_BLOCK_COUNT` to `64` since in POS blocks are finalized after 2 epochs of 32 blocks.

While at it, removed function `async fn current_block_number(&self) -> Result<u64>;` since it's no longer used anywhere.
