### PR TITLE
Use Slippage Calculator for DEX Ag Solvers

### DIFF
--- a/crates/solver/src/solver/balancer_sor_solver.rs
+++ b/crates/solver/src/solver/balancer_sor_solver.rs
@@ -6,13 +6,12 @@ use super::{
 };
 use crate::{
     encoding::EncodedInteraction,
-    interactions::{allowances::ApprovalRequest, balancer_v2::SwapKind},
+    interactions::{
+        allowances::{AllowanceManaging, ApprovalRequest},
+        balancer_v2::{self, SwapKind},
+    },
     liquidity::{slippage::SlippageCalculator, LimitOrder},
     settlement::{Interaction, Settlement},
-};
-use crate::{
-    interactions::{allowances::AllowanceManaging, balancer_v2},
-    liquidity::slippage::SlippageContext,
 };
 use anyhow::Result;
 use contracts::{BalancerV2Vault, GPv2Settlement};
@@ -93,7 +92,7 @@ impl SingleOrderSolving for BalancerSorSolver {
             return Ok(None);
         }
 
-        let slippage = SlippageContext::for_auction(auction, &self.slippage_calculator);
+        let slippage = self.slippage_calculator.auction_context(auction);
         let (quoted_sell_amount_with_slippage, quoted_buy_amount_with_slippage) = match order.kind {
             OrderKind::Sell => (
                 quoted_sell_amount,

--- a/crates/solver/src/solver/baseline_solver.rs
+++ b/crates/solver/src/solver/baseline_solver.rs
@@ -34,7 +34,7 @@ impl Solver for BaselineSolver {
             ..
         }: Auction,
     ) -> Result<Vec<Settlement>> {
-        let slippage = SlippageContext::new(&external_prices, &self.slippage_calculator);
+        let slippage = self.slippage_calculator.context(&external_prices);
         Ok(self.solve_(orders, liquidity, slippage))
     }
 

--- a/crates/solver/src/solver/http_solver.rs
+++ b/crates/solver/src/solver/http_solver.rs
@@ -5,9 +5,8 @@ use self::settlement::SettlementContext;
 use crate::{
     interactions::allowances::AllowanceManaging,
     liquidity::{
-        order_converter::OrderConverter,
-        slippage::{SlippageCalculator, SlippageContext},
-        Exchange, LimitOrder, Liquidity,
+        order_converter::OrderConverter, slippage::SlippageCalculator, Exchange, LimitOrder,
+        Liquidity,
     },
     settlement::{external_prices::ExternalPrices, Settlement},
     solver::{Auction, Solver},
@@ -20,9 +19,8 @@ use maplit::{btreemap, hashset};
 use model::{auction::AuctionId, order::OrderKind};
 use num::{BigInt, BigRational};
 use primitive_types::H160;
-use shared::http_solver::{DefaultHttpSolverApi, HttpSolverApi};
 use shared::{
-    http_solver::{gas_model::GasModel, model::*},
+    http_solver::{gas_model::GasModel, model::*, DefaultHttpSolverApi, HttpSolverApi},
     sources::balancer_v2::pools::common::compute_scaling_rate,
 };
 use shared::{
@@ -477,7 +475,7 @@ impl Solver for HttpSolver {
             serde_json::to_string_pretty(&settled).unwrap()
         );
 
-        let slippage = SlippageContext::new(&external_prices, &self.slippage_calculator);
+        let slippage = self.slippage_calculator.context(&external_prices);
         match settlement::convert_settlement(
             settled.clone(),
             context,

--- a/crates/solver/src/solver/naive_solver.rs
+++ b/crates/solver/src/solver/naive_solver.rs
@@ -38,7 +38,7 @@ impl Solver for NaiveSolver {
             ..
         }: Auction,
     ) -> Result<Vec<Settlement>> {
-        let slippage = SlippageContext::new(&external_prices, &self.slippage_calculator);
+        let slippage = self.slippage_calculator.context(&external_prices);
         let uniswaps = extract_deepest_amm_liquidity(&liquidity);
         Ok(settle(slippage, orders, uniswaps))
     }

--- a/crates/solver/src/solver/naive_solver/multi_order_solver.rs
+++ b/crates/solver/src/solver/naive_solver/multi_order_solver.rs
@@ -349,7 +349,7 @@ mod tests {
         static CONTEXT: OnceCell<(ExternalPrices, SlippageCalculator)> = OnceCell::new();
         let (prices, calculator) =
             CONTEXT.get_or_init(|| (Default::default(), SlippageCalculator::from_bps(0, None)));
-        SlippageContext::new(prices, calculator)
+        calculator.context(prices)
     }
 
     #[test]

--- a/crates/solver/src/solver/oneinch_solver.rs
+++ b/crates/solver/src/solver/oneinch_solver.rs
@@ -165,7 +165,8 @@ impl SingleOrderSolving for OneInchSolver {
             .await?;
         let slippage = Slippage::percentage(
             self.slippage_calculator
-                .compute(&auction.external_prices, order.buy_token, order.buy_amount)?
+                .auction_context(auction)
+                .relative_for_order(&order)?
                 .as_percentage(),
         )?;
         self.settle_order_with_protocols_and_slippage(order, protocols, slippage)

--- a/crates/solver/src/solver/paraswap_solver.rs
+++ b/crates/solver/src/solver/paraswap_solver.rs
@@ -5,7 +5,7 @@ use super::{
 use crate::{
     encoding::EncodedInteraction,
     interactions::allowances::{AllowanceManager, AllowanceManaging, ApprovalRequest},
-    liquidity::LimitOrder,
+    liquidity::{slippage::SlippageCalculator, LimitOrder},
     settlement::{Interaction, Settlement},
 };
 use anyhow::{anyhow, Result};
@@ -39,8 +39,8 @@ pub struct ParaswapSolver {
     allowance_fetcher: Box<dyn AllowanceManaging>,
     #[derivative(Debug = "ignore")]
     client: Box<dyn ParaswapApi + Send + Sync>,
-    slippage_bps: u32,
     disabled_paraswap_dexs: Vec<String>,
+    slippage_calculator: SlippageCalculator,
 }
 
 impl ParaswapSolver {
@@ -68,8 +68,8 @@ impl ParaswapSolver {
                 partner: partner.unwrap_or_else(|| REFERRER.into()),
                 rate_limiter,
             }),
-            slippage_bps,
             disabled_paraswap_dexs,
+            slippage_calculator: SlippageCalculator::from_bps(slippage_bps, None),
         }
     }
 }
@@ -89,7 +89,7 @@ impl SingleOrderSolving for ParaswapSolver {
     async fn try_settle_order(
         &self,
         order: LimitOrder,
-        _: &Auction,
+        auction: &Auction,
     ) -> Result<Option<Settlement>, SettlementError> {
         let token_info = self
             .token_info
@@ -105,7 +105,7 @@ impl SingleOrderSolving for ParaswapSolver {
             return Ok(None);
         }
         let transaction_query =
-            self.transaction_query_from(&order, &price_response, &token_info)?;
+            self.transaction_query_from(auction, &order, &price_response, &token_info)?;
         let transaction = self.client.transaction(transaction_query).await?;
         let mut settlement = Settlement::new(hashmap! {
             order.sell_token => price_response.dest_amount,
@@ -161,6 +161,7 @@ impl ParaswapSolver {
 
     fn transaction_query_from(
         &self,
+        auction: &Auction,
         order: &LimitOrder,
         price_response: &PriceResponse,
         token_info: &HashMap<H160, TokenInfo>,
@@ -177,7 +178,11 @@ impl ParaswapSolver {
             src_token: order.sell_token,
             dest_token: order.buy_token,
             trade_amount,
-            slippage: self.slippage_bps,
+            slippage: self
+                .slippage_calculator
+                .auction_context(auction)
+                .relative_for_order(order)?
+                .as_bps(),
             src_decimals: decimals(token_info, &order.sell_token)?,
             dest_decimals: decimals(token_info, &order.buy_token)?,
             price_route: price_response.clone().price_route_raw,
@@ -237,8 +242,8 @@ mod tests {
             token_info: Arc::new(token_info),
             allowance_fetcher,
             settlement_contract: dummy_contract!(GPv2Settlement, H160::zero()),
-            slippage_bps: 10,
             disabled_paraswap_dexs: vec![],
+            slippage_calculator: Default::default(),
         };
 
         let order = LimitOrder::default();
@@ -290,8 +295,8 @@ mod tests {
             token_info: Arc::new(token_info),
             allowance_fetcher,
             settlement_contract: dummy_contract!(GPv2Settlement, H160::zero()),
-            slippage_bps: 10,
             disabled_paraswap_dexs: vec![],
+            slippage_calculator: Default::default(),
         };
 
         let order_passing_limit = LimitOrder {
@@ -398,8 +403,8 @@ mod tests {
             token_info: Arc::new(token_info),
             allowance_fetcher,
             settlement_contract: dummy_contract!(GPv2Settlement, H160::zero()),
-            slippage_bps: 10,
             disabled_paraswap_dexs: vec![],
+            slippage_calculator: Default::default(),
         };
 
         let order = LimitOrder {
@@ -497,8 +502,8 @@ mod tests {
             token_info: Arc::new(token_info),
             allowance_fetcher,
             settlement_contract: dummy_contract!(GPv2Settlement, H160::zero()),
-            slippage_bps: 1000, // 10%
             disabled_paraswap_dexs: vec![],
+            slippage_calculator: SlippageCalculator::from_bps(1000, None),
         };
 
         let sell_order = LimitOrder {


### PR DESCRIPTION
This PR adds the `SlippageCalculator` component to each DEX aggregator solver. This is in preparation for #578 to allow configuring absolute slippage limits for all solvers.

Additionally, I refactored `SlippageContext` (i.e. the per-`Auction` context for computing slippage with absolute slippage limits) creation to make its use a bit more ergonomic.

### Test Plan

Existing tests continue to pass.