### PR TITLE
Configure Relative and Absolute Slippage for all Solvers

### DIFF
--- a/crates/driver/src/arguments.rs
+++ b/crates/driver/src/arguments.rs
@@ -7,8 +7,8 @@ use shared::{
     sources::{balancer_v2::BalancerFactoryKind, BaselineSource},
 };
 use solver::{
-    arguments::TransactionStrategyArg, settlement_access_list::AccessListEstimatorType,
-    solver::ExternalSolverArg,
+    arguments::TransactionStrategyArg, liquidity::slippage,
+    settlement_access_list::AccessListEstimatorType, solver::ExternalSolverArg,
 };
 use std::{net::SocketAddr, num::NonZeroU64, time::Duration};
 use tracing::level_filters::LevelFilter;
@@ -17,6 +17,9 @@ use tracing::level_filters::LevelFilter;
 pub struct Arguments {
     #[clap(flatten)]
     pub http_client: http_client::Arguments,
+
+    #[clap(flatten)]
+    pub slippage: slippage::Arguments,
 
     #[clap(long, env, default_value = "0.0.0.0:8080")]
     pub bind_address: SocketAddr,
@@ -261,6 +264,7 @@ pub struct Arguments {
 impl std::fmt::Display for Arguments {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.http_client)?;
+        write!(f, "{}", self.slippage)?;
         writeln!(f, "bind_address: {}", self.bind_address)?;
         writeln!(f, "log_filter: {}", self.log_filter)?;
         writeln!(f, "log_stderr_threshold: {}", self.log_stderr_threshold)?;

--- a/crates/driver/src/main.rs
+++ b/crates/driver/src/main.rs
@@ -179,6 +179,7 @@ async fn build_solvers(common: &CommonComponents, args: &Arguments) -> Vec<Arc<d
                 common.order_converter.clone(),
                 http_solver_cache.clone(),
                 false,
+                args.slippage.get_global_calculator(),
             )) as Arc<dyn Solver>
         })
         .collect()

--- a/crates/shared/src/arguments.rs
+++ b/crates/shared/src/arguments.rs
@@ -105,8 +105,12 @@ pub struct OrderQuotingArguments {
     #[clap(long, env)]
     pub cow_fee_factors: Option<SubsidyTiers>,
 }
+
+// Temporary workaround for <https://github.com/clap-rs/clap/issues/4279>
+pub type Arguments = SharedArguments;
+
 #[derive(clap::Parser)]
-pub struct Arguments {
+pub struct SharedArguments {
     #[clap(
         long,
         env,

--- a/crates/shared/src/bad_token/token_owner_finder.rs
+++ b/crates/shared/src/bad_token/token_owner_finder.rs
@@ -42,9 +42,12 @@ pub trait TokenOwnerFinding: Send + Sync {
     async fn find_owner(&self, token: H160, min_balance: U256) -> Result<Option<(H160, U256)>>;
 }
 
+// Temporary workaround for <https://github.com/clap-rs/clap/issues/4279>
+pub type Arguments = TokenOwnerFinderArguments;
+
 /// Arguments related to the token owner finder.
 #[derive(clap::Parser)]
-pub struct Arguments {
+pub struct TokenOwnerFinderArguments {
     /// The token owner finding strategies to use.
     #[clap(long, env, use_value_delimiter = true, value_enum)]
     pub token_owner_finders: Option<Vec<TokenOwnerFindingStrategy>>,

--- a/crates/shared/src/http_client.rs
+++ b/crates/shared/src/http_client.rs
@@ -52,9 +52,12 @@ impl Default for HttpClientFactory {
     }
 }
 
+// Temporary workaround for <https://github.com/clap-rs/clap/issues/4279>
+pub type Arguments = HttpClientArguments;
+
 /// Command line arguments for the common HTTP factory.
 #[derive(clap::Parser)]
-pub struct Arguments {
+pub struct HttpClientArguments {
     /// Default timeout in seconds for http requests.
     #[clap(
         long,

--- a/crates/solver/src/arguments.rs
+++ b/crates/solver/src/arguments.rs
@@ -1,4 +1,5 @@
 use crate::{
+    liquidity::slippage,
     settlement_access_list::AccessListEstimatorType,
     solver::{ExternalSolverArg, SolverAccountArg, SolverType},
 };
@@ -17,6 +18,9 @@ pub struct Arguments {
 
     #[clap(flatten)]
     pub http_client: http_client::Arguments,
+
+    #[clap(flatten)]
+    pub slippage: slippage::Arguments,
 
     /// The API endpoint to fetch the orderbook
     #[clap(long, env, default_value = "http://localhost:8080")]
@@ -138,22 +142,6 @@ pub struct Arguments {
         value_parser = shared::arguments::wei_from_gwei
     )]
     pub gas_price_cap: f64,
-
-    /// The slippage tolerance we apply to the price quoted by Paraswap
-    #[clap(long, env, default_value = "10")]
-    pub paraswap_slippage_bps: u32,
-
-    /// The slippage tolerance we apply to the price quoted by zeroEx
-    #[clap(long, env, default_value = "10")]
-    pub zeroex_slippage_bps: u32,
-
-    /// The default slippage tolerance we apply to the price quoted by OneInchSolver
-    #[clap(long, env, default_value = "10")]
-    pub oneinch_slippage_bps: u32,
-
-    /// The maximum slippage in ETH we are willing to incur per trade on 1Inch
-    #[clap(long, env)]
-    pub oneinch_max_slippage_in_eth: Option<f64>,
 
     /// How to to submit settlement transactions.
     /// Expected to contain either:
@@ -299,6 +287,7 @@ impl std::fmt::Display for Arguments {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.shared)?;
         write!(f, "{}", self.http_client)?;
+        write!(f, "{}", self.slippage)?;
         writeln!(f, "orderbook_url: {}", self.orderbook_url)?;
         writeln!(f, "mip_solver_url: {}", self.mip_solver_url)?;
         writeln!(f, "quasimodo_solver_url: {}", self.quasimodo_solver_url)?;
@@ -334,9 +323,6 @@ impl std::fmt::Display for Arguments {
             self.market_makable_token_list
         )?;
         writeln!(f, "gas_price_cap: {}", self.gas_price_cap)?;
-        writeln!(f, "paraswap_slippage_bps: {}", self.paraswap_slippage_bps)?;
-        writeln!(f, "zeroex_slippage_bps: {}", self.zeroex_slippage_bps)?;
-        writeln!(f, "oneinch_slippage_bps: {}", self.oneinch_slippage_bps)?;
         writeln!(f, "transaction_strategy: {:?}", self.transaction_strategy)?;
         writeln!(
             f,

--- a/crates/solver/src/liquidity/slippage.rs
+++ b/crates/solver/src/liquidity/slippage.rs
@@ -19,9 +19,12 @@ use std::{
     str::FromStr,
 };
 
+// Temporary workaround for <https://github.com/clap-rs/clap/issues/4279>
+pub type Arguments = SlippageArguments;
+
 /// Slippage configuration command line arguments.
 #[derive(Debug, Parser)]
-pub struct Arguments {
+pub struct SlippageArguments {
     /// The relative slippage tolerance to apply to on-chain swaps. This flag
     /// expects a comma-separated list of relative slippage values in basis
     /// points per solver. If a solver is not included, it will use the default

--- a/crates/solver/src/liquidity/slippage.rs
+++ b/crates/solver/src/liquidity/slippage.rs
@@ -6,7 +6,7 @@ use crate::{
     solver::{Auction, SolverType},
 };
 use anyhow::{anyhow, Context as _, Result};
-use clap::{ArgEnum, Parser};
+use clap::{Parser, ValueEnum as _};
 use ethcontract::{H160, U256};
 use model::order::OrderKind;
 use num::{BigInt, BigRational, Integer as _, ToPrimitive as _};
@@ -91,7 +91,7 @@ impl Display for Arguments {
 }
 
 /// A comma separated slippage value per solver.
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct SlippageArgumentValues<T>(Option<T>, HashMap<SolverType, T>);
 
 impl<T> SlippageArgumentValues<T> {

--- a/crates/solver/src/liquidity/slippage.rs
+++ b/crates/solver/src/liquidity/slippage.rs
@@ -1,13 +1,160 @@
 //! Module defining slippage computation for AMM liquidiy.
 
 use super::LimitOrder;
-use crate::{settlement::external_prices::ExternalPrices, solver::Auction};
-use anyhow::{Context as _, Result};
+use crate::{
+    settlement::external_prices::ExternalPrices,
+    solver::{Auction, SolverType},
+};
+use anyhow::{anyhow, Context as _, Result};
+use clap::{ArgEnum, Parser};
 use ethcontract::{H160, U256};
 use model::order::OrderKind;
 use num::{BigInt, BigRational, Integer as _, ToPrimitive as _};
 use once_cell::sync::OnceCell;
-use std::{borrow::Cow, cmp};
+use std::{
+    borrow::Cow,
+    cmp,
+    collections::HashMap,
+    fmt::{self, Display, Formatter},
+    str::FromStr,
+};
+
+/// Slippage configuration command line arguments.
+#[derive(Debug, Parser)]
+pub struct Arguments {
+    /// The relative slippage tolerance to apply to on-chain swaps. This flag
+    /// expects a comma-separated list of relative slippage values in basis
+    /// points per solver. If a solver is not included, it will use the default
+    /// global value. For example, "10,oneinch=20,zeroex=5" will configure all
+    /// solvers to have 10 BPS of relative slippage tolerance, with 1Inch and
+    /// 0x solvers configured for 20 and 5 BPS respectively. The global value
+    /// can be specified as `~` to keep it its default. For example,
+    /// "~,paraswap=42" will configure all solvers to use the default
+    /// configuration, while overriding the ParaSwap solver to use 42 BPS.
+    #[clap(long, env, default_value = "10")]
+    pub relative_slippage_bps: SlippageArgumentValues<u32>,
+
+    /// The absolute slippage tolerance in native token units to cap relative
+    /// slippage at. This makes it so very large trades use a potentially
+    /// tighter slippage tolerance to reduce absolute losses. This parameter
+    /// uses the same format as `--relative-slippage-bps`. For example,
+    /// "~,oneinch=0.001,zeroex=0.042" will disable absolute slippage tolerance
+    /// globally for all solvers, while overriding 1Inch and 0x solvers to cap
+    /// absolute slippage at 0.001Ξ and 0.042Ξ respectively.
+    #[clap(long, env, default_value = "~")]
+    pub absolute_slippage_in_native_token: SlippageArgumentValues<f64>,
+}
+
+impl Arguments {
+    /// Returns the slippage calculator for the specified solver.
+    pub fn get_calculator(&self, solver: SolverType) -> SlippageCalculator {
+        let bps = self
+            .relative_slippage_bps
+            .get(solver)
+            .copied()
+            .unwrap_or(DEFAULT_MAX_SLIPPAGE_BPS);
+        let absolute = self
+            .absolute_slippage_in_native_token
+            .get(solver)
+            .map(|value| U256::from_f64_lossy(value * 1e18));
+
+        SlippageCalculator::from_bps(bps, absolute)
+    }
+
+    /// Returns the slippage calculator for the specified solver.
+    pub fn get_global_calculator(&self) -> SlippageCalculator {
+        let bps = self
+            .relative_slippage_bps
+            .get_global()
+            .copied()
+            .unwrap_or(DEFAULT_MAX_SLIPPAGE_BPS);
+        let absolute = self
+            .absolute_slippage_in_native_token
+            .get_global()
+            .map(|value| U256::from_f64_lossy(value * 1e18));
+
+        SlippageCalculator::from_bps(bps, absolute)
+    }
+}
+
+impl Display for Arguments {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        writeln!(f, "relative_slippage_bps: {}", self.relative_slippage_bps)?;
+        writeln!(
+            f,
+            "absolute_slippage_in_native_token: {}",
+            self.absolute_slippage_in_native_token,
+        )?;
+
+        Ok(())
+    }
+}
+
+/// A comma separated slippage value per solver.
+#[derive(Debug)]
+pub struct SlippageArgumentValues<T>(Option<T>, HashMap<SolverType, T>);
+
+impl<T> SlippageArgumentValues<T> {
+    /// Gets the slippage configuration value for the specified solver.
+    pub fn get(&self, solver: SolverType) -> Option<&T> {
+        self.1.get(&solver).or(self.0.as_ref())
+    }
+
+    /// Gets the global slippage configuration value.
+    pub fn get_global(&self) -> Option<&T> {
+        self.0.as_ref()
+    }
+}
+
+impl<T> Display for SlippageArgumentValues<T>
+where
+    T: Display,
+{
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        match &self.0 {
+            Some(global) => write!(f, "{global}")?,
+            None => f.write_str("~")?,
+        }
+        for (solver, value) in &self.1 {
+            write!(f, ",{solver:?}={value}")?;
+        }
+        Ok(())
+    }
+}
+
+impl<T> FromStr for SlippageArgumentValues<T>
+where
+    T: FromStr,
+    anyhow::Error: From<T::Err>,
+{
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let mut values = s.split(',');
+
+        let global_value = values
+            .next()
+            .map(|value| match value {
+                "~" => Ok(None),
+                _ => Ok(Some(value.parse()?)),
+            })
+            .transpose()?
+            .flatten();
+        let solver_values = values
+            .map(|part| {
+                let (solver, value) = part
+                    .split_once('=')
+                    .context("malformed solver slippage value")?;
+                Ok((
+                    SolverType::from_str(solver, true).map_err(|message| anyhow!(message))?,
+                    value.parse()?,
+                ))
+            })
+            .collect::<Result<HashMap<_, _>>>()?;
+
+        Ok(Self(global_value, solver_values))
+    }
+}
 
 /// Constant maximum slippage of 10 BPS (0.1%) to use for on-chain liquidity.
 pub const DEFAULT_MAX_SLIPPAGE_BPS: u32 = 10;

--- a/crates/solver/src/main.rs
+++ b/crates/solver/src/main.rs
@@ -2,7 +2,6 @@ use anyhow::Context;
 use clap::Parser;
 use contracts::{BalancerV2Vault, IUniswapLikeRouter, UniswapV3SwapRouter, WETH9};
 use num::rational::Ratio;
-use primitive_types::U256;
 use shared::{
     baseline_solver::BaseTokens,
     current_block::current_block_stream,
@@ -224,25 +223,21 @@ async fn main() {
         network_name.to_string(),
         chain_id,
         args.shared.disabled_one_inch_protocols,
-        args.paraswap_slippage_bps,
         args.shared.disabled_paraswap_dexs,
         args.shared.paraswap_partner,
         &http_factory,
         metrics.clone(),
         zeroex_api.clone(),
-        args.zeroex_slippage_bps,
         args.shared.disabled_zeroex_sources,
-        args.oneinch_slippage_bps,
         args.shared.quasimodo_uses_internal_buffers,
         args.shared.mip_uses_internal_buffers,
         args.shared.one_inch_url,
         args.shared.one_inch_referrer_address,
         args.external_solvers.unwrap_or_default(),
-        args.oneinch_max_slippage_in_eth
-            .map(|float| U256::from_f64_lossy(float * 1e18)),
         order_converter.clone(),
         args.max_settlements_per_solver,
         args.max_merged_settlements,
+        &args.slippage,
     )
     .expect("failure creating solvers");
 

--- a/crates/solver/src/solver.rs
+++ b/crates/solver/src/solver.rs
@@ -1,32 +1,36 @@
-use crate::interactions::allowances::AllowanceManager;
-use crate::liquidity::order_converter::OrderConverter;
-use crate::metrics::SolverMetrics;
-use crate::settlement::external_prices::ExternalPrices;
-use crate::solver::balancer_sor_solver::BalancerSorSolver;
+use self::{
+    baseline_solver::BaselineSolver,
+    http_solver::{buffers::BufferRetriever, HttpSolver},
+    naive_solver::NaiveSolver,
+    oneinch_solver::OneInchSolver,
+    paraswap_solver::ParaswapSolver,
+    single_order_solver::{SingleOrderSolver, SingleOrderSolving},
+    zeroex_solver::ZeroExSolver,
+};
 use crate::{
-    liquidity::{LimitOrder, Liquidity},
-    settlement::Settlement,
+    interactions::allowances::AllowanceManager,
+    liquidity::{
+        order_converter::OrderConverter,
+        slippage::{self, SlippageCalculator},
+        LimitOrder, Liquidity,
+    },
+    metrics::SolverMetrics,
+    settlement::{external_prices::ExternalPrices, Settlement},
+    solver::balancer_sor_solver::BalancerSorSolver,
 };
 use anyhow::{anyhow, Context, Result};
-use baseline_solver::BaselineSolver;
 use contracts::{BalancerV2Vault, GPv2Settlement};
-use ethcontract::errors::ExecutionError;
-use ethcontract::{Account, PrivateKey, H160, U256};
-use http_solver::{buffers::BufferRetriever, HttpSolver};
+use ethcontract::{errors::ExecutionError, Account, PrivateKey, H160, U256};
 use model::auction::AuctionId;
-use naive_solver::NaiveSolver;
 use num::BigRational;
-use oneinch_solver::OneInchSolver;
-use paraswap_solver::ParaswapSolver;
 use reqwest::Url;
-use shared::balancer_sor_api::DefaultBalancerSorApi;
-use shared::http_client::HttpClientFactory;
-use shared::http_solver::{DefaultHttpSolverApi, SolverConfig};
-use shared::zeroex_api::ZeroExApi;
 use shared::{
-    baseline_solver::BaseTokens, conversions::U256Ext, token_info::TokenInfoFetching, Web3,
+    balancer_sor_api::DefaultBalancerSorApi,
+    http_client::HttpClientFactory,
+    http_solver::{DefaultHttpSolverApi, SolverConfig},
+    zeroex_api::ZeroExApi,
+    {baseline_solver::BaseTokens, conversions::U256Ext, token_info::TokenInfoFetching, Web3},
 };
-use single_order_solver::{SingleOrderSolver, SingleOrderSolving};
 use std::{
     fmt::{self, Debug, Formatter},
     str::FromStr,
@@ -34,7 +38,6 @@ use std::{
     time::{Duration, Instant},
 };
 use web3::types::AccessList;
-use zeroex_solver::ZeroExSolver;
 
 pub mod balancer_sor_solver;
 mod baseline_solver;
@@ -154,7 +157,7 @@ pub type SettlementWithError = (
     ExecutionError,
 );
 
-#[derive(Copy, Clone, Debug, clap::ValueEnum)]
+#[derive(Copy, Clone, Debug, Eq, Hash, PartialEq, clap::ValueEnum)]
 #[clap(rename_all = "verbatim")]
 pub enum SolverType {
     Naive,
@@ -249,24 +252,21 @@ pub fn create(
     network_id: String,
     chain_id: u64,
     disabled_one_inch_protocols: Vec<String>,
-    paraswap_slippage_bps: u32,
     disabled_paraswap_dexs: Vec<String>,
     paraswap_partner: Option<String>,
     http_factory: &HttpClientFactory,
     solver_metrics: Arc<dyn SolverMetrics>,
     zeroex_api: Arc<dyn ZeroExApi>,
-    zeroex_slippage_bps: u32,
     disabled_zeroex_sources: Vec<String>,
-    oneinch_slippage_bps: u32,
     quasimodo_uses_internal_buffers: bool,
     mip_uses_internal_buffers: bool,
     one_inch_url: Url,
     one_inch_referrer_address: Option<H160>,
     external_solvers: Vec<ExternalSolverArg>,
-    oneinch_max_slippage_in_wei: Option<U256>,
     order_converter: Arc<OrderConverter>,
     max_settlements_per_solver: usize,
     max_merged_settlements: usize,
+    slippage_configuration: &slippage::Arguments,
 ) -> Result<Solvers> {
     // Tiny helper function to help out with type inference. Otherwise, all
     // `Box::new(...)` expressions would have to be cast `as Box<dyn Solver>`.
@@ -295,7 +295,8 @@ pub fn create(
                               url: Url,
                               name: String,
                               config: SolverConfig,
-                              filter_non_fee_connected_orders: bool|
+                              filter_non_fee_connected_orders: bool,
+                              slippage_calculator: SlippageCalculator|
      -> HttpSolver {
         HttpSolver::new(
             DefaultHttpSolverApi {
@@ -318,6 +319,7 @@ pub fn create(
                 http_instance_with_all_orders.clone()
             },
             filter_non_fee_connected_orders,
+            slippage_calculator,
         )
     };
 
@@ -332,11 +334,14 @@ pub fn create(
                     max_settlements_per_solver,
                 )
             };
+            let slippage_calculator = slippage_configuration.get_calculator(solver_type);
             let solver = match solver_type {
-                SolverType::Naive => Ok(shared(NaiveSolver::new(account))),
-                SolverType::Baseline => {
-                    Ok(shared(BaselineSolver::new(account, base_tokens.clone())))
-                }
+                SolverType::Naive => Ok(shared(NaiveSolver::new(account, slippage_calculator))),
+                SolverType::Baseline => Ok(shared(BaselineSolver::new(
+                    account,
+                    base_tokens.clone(),
+                    slippage_calculator,
+                ))),
                 SolverType::Mip => Ok(shared(create_http_solver(
                     account,
                     mip_solver_url.clone(),
@@ -346,6 +351,7 @@ pub fn create(
                         ..Default::default()
                     },
                     true,
+                    slippage_calculator,
                 ))),
                 SolverType::CowDexAg => Ok(shared(create_http_solver(
                     account,
@@ -353,6 +359,7 @@ pub fn create(
                     "CowDexAg".to_string(),
                     SolverConfig::default(),
                     false,
+                    slippage_calculator,
                 ))),
                 SolverType::Quasimodo => Ok(shared(create_http_solver(
                     account,
@@ -363,6 +370,7 @@ pub fn create(
                         ..Default::default()
                     },
                     true,
+                    slippage_calculator,
                 ))),
                 SolverType::OneInch => Ok(shared(single_order(Box::new(
                     OneInchSolver::with_disabled_protocols(
@@ -373,8 +381,7 @@ pub fn create(
                         disabled_one_inch_protocols.clone(),
                         http_factory.create(),
                         one_inch_url.clone(),
-                        oneinch_slippage_bps,
-                        oneinch_max_slippage_in_wei,
+                        slippage_calculator,
                         one_inch_referrer_address,
                     )?,
                 )))),
@@ -385,8 +392,8 @@ pub fn create(
                         settlement_contract.clone(),
                         chain_id,
                         zeroex_api.clone(),
-                        zeroex_slippage_bps,
                         disabled_zeroex_sources.clone(),
+                        slippage_calculator,
                     )
                     .unwrap();
                     Ok(shared(single_order(Box::new(zeroex_solver))))
@@ -396,11 +403,11 @@ pub fn create(
                     web3.clone(),
                     settlement_contract.clone(),
                     token_info_fetcher.clone(),
-                    paraswap_slippage_bps,
                     disabled_paraswap_dexs.clone(),
                     http_factory.create(),
                     paraswap_partner.clone(),
                     None,
+                    slippage_calculator,
                 ))))),
                 SolverType::BalancerSor => {
                     Ok(shared(single_order(Box::new(BalancerSorSolver::new(
@@ -417,6 +424,7 @@ pub fn create(
                             chain_id,
                         )?),
                         allowance_mananger.clone(),
+                        slippage_calculator,
                     )))))
                 }
             };
@@ -442,6 +450,7 @@ pub fn create(
                 ..Default::default()
             },
             false,
+            slippage_configuration.get_global_calculator(),
         ))
     });
     solvers.extend(external_solvers);
@@ -451,7 +460,7 @@ pub fn create(
 
 /// Returns a naive solver to be used e.g. in e2e tests.
 pub fn naive_solver(account: Account) -> Arc<dyn Solver> {
-    Arc::new(NaiveSolver::new(account))
+    Arc::new(NaiveSolver::new(account, SlippageCalculator::default()))
 }
 
 /// A solver that remove limit order below a certain threshold and

--- a/crates/solver/src/solver.rs
+++ b/crates/solver/src/solver.rs
@@ -334,7 +334,13 @@ pub fn create(
                     max_settlements_per_solver,
                 )
             };
+
             let slippage_calculator = slippage_configuration.get_calculator(solver_type);
+            tracing::debug!(
+                solver = ?solver_type, slippage = ?slippage_calculator,
+                "configured slippage",
+            );
+
             let solver = match solver_type {
                 SolverType::Naive => Ok(shared(NaiveSolver::new(account, slippage_calculator))),
                 SolverType::Baseline => Ok(shared(BaselineSolver::new(
@@ -428,14 +434,6 @@ pub fn create(
                     )))))
                 }
             };
-
-            if let Ok(solver) = &solver {
-                tracing::info!(
-                    "initialized solver {} at address {:#x}",
-                    solver.name(),
-                    solver.account().address()
-                )
-            }
             solver
         })
         .collect::<Result<_>>()?;
@@ -454,6 +452,14 @@ pub fn create(
         ))
     });
     solvers.extend(external_solvers);
+
+    for solver in &solvers {
+        tracing::info!(
+            "initialized solver {} at address {:#x}",
+            solver.name(),
+            solver.account().address()
+        )
+    }
 
     Ok(solvers)
 }

--- a/crates/solver/src/solver/balancer_sor_solver.rs
+++ b/crates/solver/src/solver/balancer_sor_solver.rs
@@ -28,7 +28,7 @@ pub struct BalancerSorSolver {
     settlement: GPv2Settlement,
     api: Arc<dyn BalancerSorApi>,
     allowance_fetcher: Arc<dyn AllowanceManaging>,
-    slippage_calculator: Arc<SlippageCalculator>,
+    slippage_calculator: SlippageCalculator,
 }
 
 impl BalancerSorSolver {
@@ -38,6 +38,7 @@ impl BalancerSorSolver {
         settlement: GPv2Settlement,
         api: Arc<dyn BalancerSorApi>,
         allowance_fetcher: Arc<dyn AllowanceManaging>,
+        slippage_calculator: SlippageCalculator,
     ) -> Self {
         Self {
             account,
@@ -45,13 +46,8 @@ impl BalancerSorSolver {
             settlement,
             api,
             allowance_fetcher,
-            slippage_calculator: Arc::new(SlippageCalculator::default()),
+            slippage_calculator,
         }
-    }
-
-    pub fn with_slippage(mut self, calculator: Arc<SlippageCalculator>) -> Self {
-        self.slippage_calculator = calculator;
-        self
     }
 }
 
@@ -322,6 +318,7 @@ mod tests {
             settlement.clone(),
             Arc::new(api),
             Arc::new(allowance_fetcher),
+            SlippageCalculator::default(),
         );
 
         let result = solver
@@ -444,6 +441,7 @@ mod tests {
             settlement.clone(),
             Arc::new(api),
             Arc::new(allowance_fetcher),
+            SlippageCalculator::default(),
         );
 
         let result = solver
@@ -519,6 +517,7 @@ mod tests {
             settlement,
             Arc::new(api),
             Arc::new(allowance_fetcher),
+            SlippageCalculator::default(),
         );
 
         assert!(matches!(
@@ -549,6 +548,7 @@ mod tests {
             settlement,
             Arc::new(api),
             Arc::new(allowance_fetcher),
+            SlippageCalculator::default(),
         );
 
         let sell_settlement = solver

--- a/crates/solver/src/solver/baseline_solver.rs
+++ b/crates/solver/src/solver/baseline_solver.rs
@@ -20,7 +20,7 @@ use std::{collections::HashMap, sync::Arc};
 pub struct BaselineSolver {
     account: Account,
     base_tokens: Arc<BaseTokens>,
-    slippage_calculator: Arc<SlippageCalculator>,
+    slippage_calculator: SlippageCalculator,
 }
 
 #[async_trait::async_trait]
@@ -113,11 +113,15 @@ impl BaselineSolvable for Amm {
 }
 
 impl BaselineSolver {
-    pub fn new(account: Account, base_tokens: Arc<BaseTokens>) -> Self {
+    pub fn new(
+        account: Account,
+        base_tokens: Arc<BaseTokens>,
+        slippage_calculator: SlippageCalculator,
+    ) -> Self {
         Self {
             account,
             base_tokens,
-            slippage_calculator: Default::default(),
+            slippage_calculator,
         }
     }
 
@@ -389,7 +393,7 @@ mod tests {
         let liquidity = amms.into_iter().map(Liquidity::ConstantProduct).collect();
 
         let base_tokens = Arc::new(BaseTokens::new(native_token, &[]));
-        let solver = BaselineSolver::new(account(), base_tokens);
+        let solver = BaselineSolver::new(account(), base_tokens, SlippageCalculator::default());
         let result = solver.must_solve(orders, liquidity);
         assert_eq!(
             result.clearing_prices(),
@@ -496,7 +500,7 @@ mod tests {
         let liquidity = amms.into_iter().map(Liquidity::ConstantProduct).collect();
 
         let base_tokens = Arc::new(BaseTokens::new(native_token, &[]));
-        let solver = BaselineSolver::new(account(), base_tokens);
+        let solver = BaselineSolver::new(account(), base_tokens, SlippageCalculator::default());
         let result = solver.must_solve(orders, liquidity);
         assert_eq!(
             result.clearing_prices(),
@@ -567,7 +571,7 @@ mod tests {
         let liquidity = amms.into_iter().map(Liquidity::ConstantProduct).collect();
 
         let base_tokens = Arc::new(BaseTokens::new(H160::zero(), &[]));
-        let solver = BaselineSolver::new(account(), base_tokens);
+        let solver = BaselineSolver::new(account(), base_tokens, SlippageCalculator::default());
         assert_eq!(
             solver
                 .solve_(orders, liquidity, SlippageContext::default())
@@ -625,7 +629,7 @@ mod tests {
             addr!("c778417e063141139fce010982780140aa0cd5ab"),
             &[],
         ));
-        let solver = BaselineSolver::new(account(), base_tokens);
+        let solver = BaselineSolver::new(account(), base_tokens, SlippageCalculator::default());
         assert_eq!(
             solver
                 .solve_(vec![order], liquidity, SlippageContext::default())
@@ -706,7 +710,7 @@ mod tests {
             Liquidity::BalancerWeighted(pool_1),
         ];
         let base_tokens = Arc::new(BaseTokens::new(tokens[0], &tokens));
-        let solver = BaselineSolver::new(account(), base_tokens);
+        let solver = BaselineSolver::new(account(), base_tokens, SlippageCalculator::default());
         let settlements = solver.solve_(vec![order], liquidity, Default::default());
         assert!(settlements.is_empty());
     }

--- a/crates/solver/src/solver/http_solver.rs
+++ b/crates/solver/src/solver/http_solver.rs
@@ -64,7 +64,7 @@ pub struct HttpSolver {
     order_converter: Arc<OrderConverter>,
     instance_cache: InstanceCache,
     filter_non_fee_connected_orders: bool,
-    slippage_calculator: Arc<SlippageCalculator>,
+    slippage_calculator: SlippageCalculator,
 }
 
 impl HttpSolver {
@@ -79,6 +79,7 @@ impl HttpSolver {
         order_converter: Arc<OrderConverter>,
         instance_cache: InstanceCache,
         filter_non_fee_connected_orders: bool,
+        slippage_calculator: SlippageCalculator,
     ) -> Self {
         Self {
             solver,
@@ -90,7 +91,7 @@ impl HttpSolver {
             order_converter,
             instance_cache,
             filter_non_fee_connected_orders,
-            slippage_calculator: Default::default(),
+            slippage_calculator,
         }
     }
 
@@ -575,6 +576,7 @@ mod tests {
             Arc::new(OrderConverter::test(H160([0x42; 20]))),
             Default::default(),
             true,
+            SlippageCalculator::default(),
         );
         let base = |x: u128| x * 10u128.pow(18);
         let limit_orders = vec![LimitOrder {

--- a/crates/solver/src/solver/naive_solver.rs
+++ b/crates/solver/src/solver/naive_solver.rs
@@ -11,18 +11,18 @@ use crate::{
 use anyhow::Result;
 use ethcontract::Account;
 use model::TokenPair;
-use std::{collections::HashMap, sync::Arc};
+use std::collections::HashMap;
 
 pub struct NaiveSolver {
     account: Account,
-    slippage_calculator: Arc<SlippageCalculator>,
+    slippage_calculator: SlippageCalculator,
 }
 
 impl NaiveSolver {
-    pub fn new(account: Account) -> Self {
+    pub fn new(account: Account, slippage_calculator: SlippageCalculator) -> Self {
         Self {
             account,
-            slippage_calculator: Default::default(),
+            slippage_calculator,
         }
     }
 }

--- a/crates/solver/src/solver/oneinch_solver.rs
+++ b/crates/solver/src/solver/oneinch_solver.rs
@@ -19,7 +19,7 @@ use derivative::Derivative;
 use ethcontract::{Account, Bytes};
 use maplit::hashmap;
 use model::order::OrderKind;
-use primitive_types::{H160, U256};
+use primitive_types::H160;
 use reqwest::{Client, Url};
 use shared::{
     oneinch_api::{
@@ -56,8 +56,7 @@ impl OneInchSolver {
         disabled_protocols: impl IntoIterator<Item = String>,
         client: Client,
         one_inch_url: Url,
-        oneinch_slippage_bps: u32,
-        max_slippage_in_wei: Option<U256>,
+        slippage_calculator: SlippageCalculator,
         referrer_address: Option<H160>,
     ) -> Result<Self> {
         let settlement_address = settlement_contract.address();
@@ -68,10 +67,7 @@ impl OneInchSolver {
             client: Box::new(OneInchClientImpl::new(one_inch_url, client, chain_id)?),
             allowance_fetcher: Box::new(AllowanceManager::new(web3, settlement_address)),
             protocol_cache: ProtocolCache::default(),
-            slippage_calculator: SlippageCalculator::from_bps(
-                oneinch_slippage_bps,
-                max_slippage_in_wei,
-            ),
+            slippage_calculator,
             referrer_address,
         })
     }
@@ -505,8 +501,7 @@ mod tests {
             vec!["PMM1".to_string()],
             Client::new(),
             OneInchClientImpl::DEFAULT_URL.try_into().unwrap(),
-            10u32,
-            None,
+            SlippageCalculator::default(),
             None,
         )
         .unwrap();

--- a/crates/solver/src/solver/paraswap_solver.rs
+++ b/crates/solver/src/solver/paraswap_solver.rs
@@ -50,11 +50,11 @@ impl ParaswapSolver {
         web3: Web3,
         settlement_contract: GPv2Settlement,
         token_info: Arc<dyn TokenInfoFetching>,
-        slippage_bps: u32,
         disabled_paraswap_dexs: Vec<String>,
         client: Client,
         partner: Option<String>,
         rate_limiter: Option<RateLimiter>,
+        slippage_calculator: SlippageCalculator,
     ) -> Self {
         let allowance_fetcher = AllowanceManager::new(web3, settlement_contract.address());
 
@@ -69,7 +69,7 @@ impl ParaswapSolver {
                 rate_limiter,
             }),
             disabled_paraswap_dexs,
-            slippage_calculator: SlippageCalculator::from_bps(slippage_bps, None),
+            slippage_calculator,
         }
     }
 }
@@ -553,11 +553,11 @@ mod tests {
             web3,
             settlement,
             token_info_fetcher,
-            1,
             vec![],
             Client::new(),
             None,
             None,
+            SlippageCalculator::default(),
         );
 
         let settlement = solver

--- a/crates/solver/src/solver/zeroex_solver.rs
+++ b/crates/solver/src/solver/zeroex_solver.rs
@@ -63,8 +63,8 @@ impl ZeroExSolver {
         settlement_contract: GPv2Settlement,
         chain_id: u64,
         api: Arc<dyn ZeroExApi>,
-        zeroex_slippage_bps: u32,
         excluded_sources: Vec<String>,
+        slippage_calculator: SlippageCalculator,
     ) -> Result<Self> {
         ensure!(
             chain_id == MAINNET_CHAIN_ID,
@@ -76,7 +76,7 @@ impl ZeroExSolver {
             allowance_fetcher: Box::new(allowance_fetcher),
             api,
             excluded_sources,
-            slippage_calculator: SlippageCalculator::from_bps(zeroex_slippage_bps, None),
+            slippage_calculator,
         })
     }
 }
@@ -196,8 +196,8 @@ mod tests {
             settlement,
             chain_id,
             Arc::new(DefaultZeroExApi::default()),
-            10u32,
             Default::default(),
+            SlippageCalculator::default(),
         )
         .unwrap();
         let settlement = solver
@@ -238,8 +238,8 @@ mod tests {
             settlement,
             chain_id,
             Arc::new(DefaultZeroExApi::default()),
-            10u32,
             Default::default(),
+            SlippageCalculator::default(),
         )
         .unwrap();
         let settlement = solver
@@ -401,8 +401,8 @@ mod tests {
             settlement,
             chain_id,
             Arc::new(DefaultZeroExApi::default()),
-            10u32,
             Default::default(),
+            SlippageCalculator::default(),
         )
         .is_err())
     }


### PR DESCRIPTION
Fixes #578 

This PR adds command line configuration options for configuring relative and absolute slippage for all solvers. With this change, we can have an absolute cap on the negative slippage for all internal solvers can incur in a settlement, limiting potential solver losses.

Note that, in order to make slippage configuration more succinct, I modified how slippage configuration works. There are now only two flags `--relative-slippage-bps` and `--absolute-slippage-in-native-token`. These flags can specify values as:
```
${global_value}(,${solver_kind}=${solver_value})*
```

This allows us to specify a global value that applies to all solvers (with `~` to represent "default" - so 10 BPS and no absolute cap) as well as specific solver override values. This means that our current slippage configuration can be represented as:
```
--relative-slippage-bps "10,zeroex=30,oneinch=30,paraswap=30"
--absolute-slippage-in-native-token "~,oneinch=0.001"
```

Additionally, with the recent crate updates, the CLI arguments started generating a panic with:
```
% cargo run -p solver
    Finished dev [unoptimized + debuginfo] target(s) in 8.30s
     Running `target/debug/solver`
thread 'main' panicked at 'Command solver: Argument group name must be unique

	'Arguments' is already in use', /home/me/.cargo/registry/src/github.com-1ecc6299db9ec823/clap-4.0.4/src/builder/debug_asserts.rs:284:9
```

Note that this **does not** affect release, which is one of the reasons why it snuck by. The workaround is very easy, so I included it here.

### Test Plan

The compiler makes sure I didn't forget to initialize the `SlippageCalculator` anywhere. Check that solvers are initialized with expected values:

```
% cargo run -p solver -- --relative-slippage-bps 30,paraswap=40 --absolute-slippage-in-native-token ~,zeroex=0.01,oneinch=0.0042 --solvers OneInch,ZeroEx,ParaSwap,Baseline
    Finished dev [unoptimized + debuginfo] target(s) in 0.16s
     Running `target/debug/solver --relative-slippage-bps 30,paraswap=40 --absolute-slippage-in-native-token '~,zeroex=0.01,oneinch=0.0042' --solvers OneInch,ZeroEx,ParaSwap,Baseline`
...
relative_slippage_bps: 30,Paraswap=40
absolute_slippage_in_native_token: ~,OneInch=0.0042,ZeroEx=0.01
...
2022-09-29T16:25:17.263Z DEBUG solver::solver: configured slippage solver=OneInch slippage=SlippageCalculator { relative: Ratio { numer: 3, denom: 1000 }, absolute: Some(4199999999999999) }
2022-09-29T16:25:17.263Z DEBUG solver::solver: configured slippage solver=ZeroEx slippage=SlippageCalculator { relative: Ratio { numer: 3, denom: 1000 }, absolute: Some(10000000000000000) }
2022-09-29T16:25:17.264Z DEBUG solver::solver: configured slippage solver=Paraswap slippage=SlippageCalculator { relative: Ratio { numer: 1, denom: 250 }, absolute: None }
2022-09-29T16:25:17.264Z DEBUG solver::solver: configured slippage solver=Baseline slippage=SlippageCalculator { relative: Ratio { numer: 3, denom: 1000 }, absolute: None }
...
```

### Release Notes

This changes how we configure slippage:
- [x] Refactor slippage configuration for our deployments