### PR TITLE
Cargo Dependency Update

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -44,7 +44,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "chrono",
- "clap 3.2.22",
+ "clap 4.0.4",
  "global-metrics",
  "model",
  "primitive-types",
@@ -167,7 +167,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "chrono",
- "clap 3.2.22",
+ "clap 4.0.4",
  "contracts",
  "database",
  "ethcontract",
@@ -289,11 +289,12 @@ checksum = "ec8a7b6a70fde80372154c65702f00a0f56f3e1c36abbc6c440484be248856db"
 
 [[package]]
 name = "cached"
-version = "0.34.1"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12f5cd208ba696f870238022d81ca1d80ed9d696fd62341c747f2d8f6ecdd9fe"
+checksum = "f3e27085975166ffaacbd04527132e1cf5906fa612991f9b4fea08e787da2961"
 dependencies = [
  "hashbrown",
+ "instant",
  "once_cell",
  "thiserror",
 ]
@@ -339,32 +340,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
 dependencies = [
  "bitflags",
- "textwrap 0.11.0",
+ "textwrap",
  "unicode-width",
 ]
 
 [[package]]
 name = "clap"
-version = "3.2.22"
+version = "4.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86447ad904c7fb335a790c9d7fe3d0d971dc523b8ccd1561a520de9a85302750"
+checksum = "7f78ad8e84aa8e8aa3e821857be40eb4b925ff232de430d4dd2ae6aa058cbd92"
 dependencies = [
  "atty",
  "bitflags",
  "clap_derive",
  "clap_lex",
- "indexmap",
  "once_cell",
  "strsim",
  "termcolor",
- "textwrap 0.15.1",
 ]
 
 [[package]]
 name = "clap_derive"
-version = "3.2.18"
+version = "4.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea0c8bce528c4be4da13ea6fead8965e95b6073585a2f05204bd8f4119f82a65"
+checksum = "ca689d7434ce44517a12a89456b2be4d1ea1cafcd8f581978c03d45f5a5c12a7"
 dependencies = [
  "heck",
  "proc-macro-error",
@@ -375,9 +374,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.2.4"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
+checksum = "0d4198f73e42b4936b35b5bb248d81d2b595ecb170da0bac7655c54eedfa8da8"
 dependencies = [
  "os_str_bytes",
 ]
@@ -646,8 +645,18 @@ version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a01d95850c592940db9b8194bc39f4bc0e89dee5c4265e4b1807c34a9aba453c"
 dependencies = [
- "darling_core",
- "darling_macro",
+ "darling_core 0.13.4",
+ "darling_macro 0.13.4",
+]
+
+[[package]]
+name = "darling"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4529658bdda7fd6769b8614be250cdcfc3aeb0ee72fe66f9e41e5e5eb73eac02"
+dependencies = [
+ "darling_core 0.14.1",
+ "darling_macro 0.14.1",
 ]
 
 [[package]]
@@ -665,12 +674,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling_core"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "649c91bc01e8b1eac09fb91e8dbc7d517684ca6be8ebc75bb9cafc894f9fdb6f"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+]
+
+[[package]]
 name = "darling_macro"
 version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c972679f83bdf9c42bd905396b6c3588a843a17f0f16dfcfa3e2c5d57441835"
 dependencies = [
- "darling_core",
+ "darling_core 0.13.4",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddfc69c5bfcbd2fc09a0f38451d2daf0e372e367986a83906d1b0dbc88134fb5"
+dependencies = [
+ "darling_core 0.14.1",
  "quote",
  "syn",
 ]
@@ -779,7 +813,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
- "clap 3.2.22",
+ "clap 4.0.4",
  "contracts",
  "ethcontract",
  "futures",
@@ -794,7 +828,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "serde_with",
+ "serde_with 2.0.1",
  "shared",
  "solver",
  "thiserror",
@@ -1198,7 +1232,7 @@ dependencies = [
  "primitive-types",
  "serde",
  "serde_json",
- "serde_with",
+ "serde_with 1.14.0",
  "tokio",
  "tracing",
  "url",
@@ -1533,6 +1567,7 @@ checksum = "10a35a97730320ffe8e2d410b5d3b69279b98d2c14bdb8b70ea89ecf7888d41e"
 dependencies = [
  "autocfg",
  "hashbrown",
+ "serde",
 ]
 
 [[package]]
@@ -1667,9 +1702,9 @@ dependencies = [
 
 [[package]]
 name = "lru"
-version = "0.7.8"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e999beba7b6e8345721bd280141ed958096a2e4abdf74f67ff4ce49b4b54e47a"
+checksum = "936d98d2ddd79c18641c6709e7bb09981449694e402d1a0f0f657ea8d61f4a51"
 dependencies = [
  "hashbrown",
 ]
@@ -1806,7 +1841,7 @@ dependencies = [
  "secp256k1",
  "serde",
  "serde_json",
- "serde_with",
+ "serde_with 2.0.1",
  "strum",
  "web3",
 ]
@@ -1877,7 +1912,6 @@ dependencies = [
  "autocfg",
  "num-integer",
  "num-traits",
- "serde",
 ]
 
 [[package]]
@@ -1887,7 +1921,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ae39348c8bc5fbd7f40c727a9925f03517afd2ab27d46702108b6a7e5414c19"
 dependencies = [
  "num-traits",
- "serde",
 ]
 
 [[package]]
@@ -1921,7 +1954,6 @@ dependencies = [
  "num-bigint",
  "num-integer",
  "num-traits",
- "serde",
 ]
 
 [[package]]
@@ -2034,7 +2066,7 @@ dependencies = [
  "bigdecimal",
  "cached",
  "chrono",
- "clap 3.2.22",
+ "clap 4.0.4",
  "contracts",
  "database",
  "ethcontract",
@@ -2055,7 +2087,7 @@ dependencies = [
  "secp256k1",
  "serde",
  "serde_json",
- "serde_with",
+ "serde_with 2.0.1",
  "shared",
  "sqlx",
  "testlib",
@@ -2723,7 +2755,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "678b5a069e50bf00ecd22d0cd8ddf7c236f68581b03db652061ed5eb13a312ff"
 dependencies = [
  "serde",
- "serde_with_macros",
+ "serde_with_macros 1.5.2",
+]
+
+[[package]]
+name = "serde_with"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "368f2d60d049ea019a84dcd6687b0d1e0030fe663ae105039bdf967ed5e6a9a7"
+dependencies = [
+ "base64",
+ "chrono",
+ "hex",
+ "indexmap",
+ "serde",
+ "serde_json",
+ "serde_with_macros 2.0.1",
+ "time",
 ]
 
 [[package]]
@@ -2732,7 +2780,19 @@ version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e182d6ec6f05393cc0e5ed1bf81ad6db3a8feedf8ee515ecdd369809bcce8082"
 dependencies = [
- "darling",
+ "darling 0.13.4",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_with_macros"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ccadfacf6cf10faad22bbadf55986bdd0856edfb5d9210aa1dcf1f516e84e93"
+dependencies = [
+ "darling 0.14.1",
  "proc-macro2",
  "quote",
  "syn",
@@ -2791,7 +2851,7 @@ dependencies = [
  "atty",
  "cached",
  "chrono",
- "clap 3.2.22",
+ "clap 4.0.4",
  "contracts",
  "database",
  "derivative",
@@ -2820,7 +2880,7 @@ dependencies = [
  "secp256k1",
  "serde",
  "serde_json",
- "serde_with",
+ "serde_with 2.0.1",
  "testlib",
  "thiserror",
  "time",
@@ -2874,7 +2934,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "chrono",
- "clap 3.2.22",
+ "clap 4.0.4",
  "contracts",
  "derivative",
  "ethcontract",
@@ -2899,7 +2959,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "serde_with",
+ "serde_with 2.0.1",
  "shared",
  "strum",
  "testlib",
@@ -3143,12 +3203,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "textwrap"
-version = "0.15.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "949517c0cf1bf4ee812e2e07e08ab448e3ae0d23472aee8a06c985f0c8815b16"
-
-[[package]]
 name = "thiserror"
 version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3186,6 +3240,7 @@ dependencies = [
  "itoa 1.0.3",
  "libc",
  "num_threads",
+ "serde",
  "time-macros",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -69,6 +69,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
 name = "ansi_term"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -252,18 +258,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d696c370c750c948ada61c69a0ee2cbbb9c50b1019ddb86d9317157a99c2cae"
 
 [[package]]
-name = "bstr"
-version = "0.2.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba3569f383e8f1598449f1a423e72e99569137b47740b1da11ef19af3d5c3223"
-dependencies = [
- "lazy_static",
- "memchr",
- "regex-automata",
- "serde",
-]
-
-[[package]]
 name = "bumpalo"
 version = "3.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -334,14 +328,42 @@ dependencies = [
 ]
 
 [[package]]
-name = "clap"
-version = "2.34.0"
+name = "ciborium"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
+checksum = "b0c137568cc60b904a7724001b35ce2630fd00d5d84805fbb608ab89509d788f"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "346de753af073cc87b52b2083a506b38ac176a44cfb05497b622e27be899b369"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "213030a2b5a4e0c0892b6652260cf6ccac84827b83a85a534e178e3906c4cf1b"
+dependencies = [
+ "ciborium-io",
+ "half",
+]
+
+[[package]]
+name = "clap"
+version = "3.2.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86447ad904c7fb335a790c9d7fe3d0d971dc523b8ccd1561a520de9a85302750"
 dependencies = [
  "bitflags",
+ "clap_lex 0.2.4",
+ "indexmap",
  "textwrap",
- "unicode-width",
 ]
 
 [[package]]
@@ -353,7 +375,7 @@ dependencies = [
  "atty",
  "bitflags",
  "clap_derive",
- "clap_lex",
+ "clap_lex 0.3.0",
  "once_cell",
  "strsim",
  "termcolor",
@@ -370,6 +392,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
+dependencies = [
+ "os_str_bytes",
 ]
 
 [[package]]
@@ -484,15 +515,16 @@ dependencies = [
 
 [[package]]
 name = "criterion"
-version = "0.3.6"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b01d6de93b2b6c65e17c634a26653a29d107b3c98c607c765bf38d041531cd8f"
+checksum = "e7c76e09c1aae2bc52b3d2f29e13c6572553b30c4aa1b8a49fd70de6412654cb"
 dependencies = [
+ "anes",
  "atty",
  "cast",
- "clap 2.34.0",
+ "ciborium",
+ "clap 3.2.22",
  "criterion-plot",
- "csv",
  "itertools",
  "lazy_static",
  "num-traits",
@@ -501,7 +533,6 @@ dependencies = [
  "rayon",
  "regex",
  "serde",
- "serde_cbor",
  "serde_derive",
  "serde_json",
  "tinytemplate",
@@ -510,9 +541,9 @@ dependencies = [
 
 [[package]]
 name = "criterion-plot"
-version = "0.4.5"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2673cc8207403546f45f5fd319a974b1e6983ad1a3ee7e6041650013be041876"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
 dependencies = [
  "cast",
  "itertools",
@@ -585,28 +616,6 @@ checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
  "typenum",
-]
-
-[[package]]
-name = "csv"
-version = "1.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22813a6dc45b335f9bade10bf7271dc477e81113e89eb251a0bc2a8a81c536e1"
-dependencies = [
- "bstr",
- "csv-core",
- "itoa 0.4.8",
- "ryu",
- "serde",
-]
-
-[[package]]
-name = "csv-core"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b2466559f260f48ad25fe6317b3c8dac77b5bdb5763ac7d9d6103530663bc90"
-dependencies = [
- "memchr",
 ]
 
 [[package]]
@@ -1418,7 +1427,7 @@ checksum = "75f43d41e26995c17e71ee126451dd3941010b0514a81a9d11f3b341debc2399"
 dependencies = [
  "bytes",
  "fnv",
- "itoa 1.0.3",
+ "itoa",
 ]
 
 [[package]]
@@ -1459,7 +1468,7 @@ dependencies = [
  "http-body",
  "httparse",
  "httpdate",
- "itoa 1.0.3",
+ "itoa",
  "pin-project-lite",
  "socket2",
  "tokio",
@@ -1593,12 +1602,6 @@ checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
 dependencies = [
  "either",
 ]
-
-[[package]]
-name = "itoa"
-version = "0.4.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4"
 
 [[package]]
 name = "itoa"
@@ -2705,16 +2708,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_cbor"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bef2ebfde456fb76bbcf9f59315333decc4fda0b2b44b420243c11e0f5ec1f5"
-dependencies = [
- "half",
- "serde",
-]
-
-[[package]]
 name = "serde_derive"
 version = "1.0.145"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2731,7 +2724,7 @@ version = "1.0.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e55a28e3aaef9d5ce0506d0a14dbba8054ddc7e499ef522dd8b26859ec9d4a44"
 dependencies = [
- "itoa 1.0.3",
+ "itoa",
  "ryu",
  "serde",
 ]
@@ -2743,7 +2736,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
 dependencies = [
  "form_urlencoded",
- "itoa 1.0.3",
+ "itoa",
  "ryu",
  "serde",
 ]
@@ -3019,7 +3012,7 @@ dependencies = [
  "hkdf",
  "hmac",
  "indexmap",
- "itoa 1.0.3",
+ "itoa",
  "libc",
  "log",
  "md-5",
@@ -3195,12 +3188,9 @@ dependencies = [
 
 [[package]]
 name = "textwrap"
-version = "0.11.0"
+version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
-dependencies = [
- "unicode-width",
-]
+checksum = "949517c0cf1bf4ee812e2e07e08ab448e3ae0d23472aee8a06c985f0c8815b16"
 
 [[package]]
 name = "thiserror"
@@ -3237,7 +3227,7 @@ version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c3f9a28b618c3a6b9251b6908e9c99e04b9e5c02e6581ccbb67d59c34ef7f9b"
 dependencies = [
- "itoa 1.0.3",
+ "itoa",
  "libc",
  "num_threads",
  "serde",
@@ -3502,12 +3492,6 @@ name = "unicode-segmentation"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fdbf052a0783de01e944a6ce7a8cb939e295b1e7be835a1112c3b9a7f047a5a"
-
-[[package]]
-name = "unicode-width"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
 
 [[package]]
 name = "unicode-xid"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,9 +6,9 @@ members = ["crates/*"]
 anyhow = "1"
 async-trait = "0.1"
 bigdecimal = "0.3"
-cached = { version = "0.34", default-features = false }
+cached = { version = "0.39", default-features = false }
 chrono = { version = "0.4", default-features = false }
-clap = { version = "3", features = ["derive", "env"] }
+clap = { version = "4", features = ["derive", "env"] }
 derivative = "2"
 ethcontract = { version = "0.21", default-features = false }
 ethcontract-generate = { version = "0.21", default-features = false }
@@ -32,7 +32,7 @@ reqwest = "0.11"
 secp256k1 = "0.21"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-serde_with = { version = "1", default-features = false, features = ["macros"] }
+serde_with = "2"
 sqlx = { version = "0.6", default-features = false, features = ["runtime-tokio-native-tls"] }
 strum = { version = "0.24", features = ["derive"] }
 thiserror = "1"

--- a/crates/alerter/src/main.rs
+++ b/crates/alerter/src/main.rs
@@ -278,7 +278,7 @@ struct Arguments {
         long,
         env,
         default_value = "600",
-        parse(try_from_str = shared::arguments::duration_from_seconds),
+        value_parser = shared::arguments::duration_from_seconds,
     )]
     time_without_trade: Duration,
 
@@ -287,7 +287,7 @@ struct Arguments {
         long,
         env,
         default_value = "180",
-        parse(try_from_str = shared::arguments::duration_from_seconds),
+        value_parser = shared::arguments::duration_from_seconds,
     )]
     min_order_age: Duration,
 
@@ -296,7 +296,7 @@ struct Arguments {
         long,
         env,
         default_value = "1800",
-        parse(try_from_str = shared::arguments::duration_from_seconds),
+        value_parser = shared::arguments::duration_from_seconds,
     )]
     min_alert_interval: Duration,
 

--- a/crates/autopilot/src/arguments.rs
+++ b/crates/autopilot/src/arguments.rs
@@ -1,6 +1,6 @@
 use primitive_types::{H160, U256};
 use shared::{arguments::display_option, bad_token::token_owner_finder, http_client};
-use std::{net::SocketAddr, time::Duration};
+use std::{net::SocketAddr, num::NonZeroUsize, time::Duration};
 use url::Url;
 
 #[derive(clap::Parser)]
@@ -44,13 +44,13 @@ pub struct Arguments {
         long,
         env,
         default_value = "600",
-        parse(try_from_str = shared::arguments::duration_from_seconds),
+        value_parser = shared::arguments::duration_from_seconds,
     )]
     pub token_quality_cache_expiry: Duration,
 
     /// The number of pairs that are automatically updated in the pool cache.
     #[clap(long, env, default_value = "200")]
-    pub pool_cache_lru_size: usize,
+    pub pool_cache_lru_size: NonZeroUsize,
 
     /// The API endpoint for the Balancer SOR API for solving.
     #[clap(long, env)]
@@ -71,7 +71,7 @@ pub struct Arguments {
     #[clap(
         long,
         env,
-        parse(try_from_str = U256::from_dec_str)
+        value_parser = U256::from_dec_str
     )]
     pub amount_to_estimate_prices_with: Option<U256>,
 
@@ -88,7 +88,7 @@ pub struct Arguments {
         long,
         env,
         default_value = "Baseline",
-        arg_enum,
+        value_enum,
         use_value_delimiter = true
     )]
     pub native_price_estimators: Vec<shared::price_estimation::PriceEstimatorType>,
@@ -98,7 +98,7 @@ pub struct Arguments {
         long,
         env,
         default_value = "30",
-        parse(try_from_str = shared::arguments::duration_from_seconds),
+        value_parser = shared::arguments::duration_from_seconds,
     )]
     pub native_price_cache_max_age_secs: Duration,
 
@@ -107,7 +107,7 @@ pub struct Arguments {
         long,
         env,
         default_value = "60",
-        parse(try_from_str = shared::arguments::duration_from_seconds),
+        value_parser = shared::arguments::duration_from_seconds,
     )]
     pub min_order_validity_period: Duration,
 
@@ -120,7 +120,7 @@ pub struct Arguments {
         long,
         env,
         default_value = "300",
-        parse(try_from_str = shared::arguments::duration_from_seconds),
+        value_parser = shared::arguments::duration_from_seconds,
     )]
     pub max_auction_age: Duration,
 }

--- a/crates/driver/src/arguments.rs
+++ b/crates/driver/src/arguments.rs
@@ -57,7 +57,7 @@ pub struct Arguments {
     /// factor by which order fees are multiplied with. Setting this to a value
     /// greater than 1.0 makes settlements with negative objective values less
     /// likely, promoting more aggressive merging of single order settlements.
-    #[clap(long, env, default_value = "1", parse(try_from_str = shared::arguments::parse_unbounded_factor))]
+    #[clap(long, env, default_value = "1", value_parser = shared::arguments::parse_unbounded_factor)]
     pub fee_objective_scaling_factor: f64,
 
     /// How to to submit settlement transactions.
@@ -68,7 +68,7 @@ pub struct Arguments {
         long,
         env,
         default_value = "PublicMempool",
-        arg_enum,
+        value_enum,
         ignore_case = true,
         use_value_delimiter = true
     )]
@@ -83,7 +83,7 @@ pub struct Arguments {
         long,
         env,
         default_value = "3",
-        parse(try_from_str = shared::arguments::wei_from_gwei)
+        value_parser = shared::arguments::wei_from_gwei
     )]
     pub max_additional_eden_tip: f64,
 
@@ -92,7 +92,7 @@ pub struct Arguments {
         long,
         env,
         default_value = "0.05",
-        parse(try_from_str = shared::arguments::parse_percentage_factor)
+        value_parser = shared::arguments::parse_percentage_factor
     )]
     pub additional_tip_percentage: f64,
 
@@ -111,7 +111,7 @@ pub struct Arguments {
         long,
         env,
         default_value = "3",
-        parse(try_from_str = shared::arguments::wei_from_gwei)
+        value_parser = shared::arguments::wei_from_gwei
     )]
     pub max_additional_flashbot_tip: f64,
 
@@ -119,7 +119,7 @@ pub struct Arguments {
     /// fails. Individual estimators might support different networks.
     /// `Tenderly`: supports every network.
     /// `Web3`: supports every network.
-    #[clap(long, env, arg_enum, ignore_case = true, use_value_delimiter = true)]
+    #[clap(long, env, value_enum, ignore_case = true, use_value_delimiter = true)]
     pub access_list_estimators: Vec<AccessListEstimatorType>,
 
     /// The Tenderly user associated with the API key.
@@ -145,7 +145,7 @@ pub struct Arguments {
         long,
         env,
         default_value = "30",
-        parse(try_from_str = shared::arguments::duration_from_seconds),
+        value_parser = shared::arguments::duration_from_seconds,
     )]
     pub target_confirm_time: Duration,
 
@@ -154,7 +154,7 @@ pub struct Arguments {
     #[clap(
         long,
         default_value = "120",
-        parse(try_from_str = shared::arguments::duration_from_seconds),
+        value_parser = shared::arguments::duration_from_seconds,
     )]
     pub max_submission_seconds: Duration,
 
@@ -162,7 +162,7 @@ pub struct Arguments {
     #[clap(
         long,
         default_value = "2",
-        parse(try_from_str = shared::arguments::duration_from_seconds),
+        value_parser = shared::arguments::duration_from_seconds,
     )]
     pub submission_retry_interval_seconds: Duration,
 
@@ -171,7 +171,7 @@ pub struct Arguments {
         long,
         env,
         default_value = "1500",
-        parse(try_from_str = shared::arguments::wei_from_gwei)
+        value_parser = shared::arguments::wei_from_gwei
     )]
     pub gas_price_cap: f64,
 
@@ -186,7 +186,7 @@ pub struct Arguments {
         long,
         env,
         default_value = "Web3",
-        arg_enum,
+        value_enum,
         ignore_case = true,
         use_value_delimiter = true
     )]
@@ -202,7 +202,7 @@ pub struct Arguments {
     pub base_tokens: Vec<H160>,
 
     /// Which Liquidity sources to be used by Price Estimator.
-    #[clap(long, env, arg_enum, ignore_case = true, use_value_delimiter = true)]
+    #[clap(long, env, value_enum, ignore_case = true, use_value_delimiter = true)]
     pub baseline_sources: Option<Vec<BaselineSource>>,
 
     /// The number of blocks kept in the pool cache.
@@ -218,7 +218,7 @@ pub struct Arguments {
     pub pool_cache_maximum_retries: u32,
 
     /// How long to sleep in seconds between retries in the pool cache.
-    #[clap(long, env, default_value = "1", parse(try_from_str = duration_from_seconds))]
+    #[clap(long, env, default_value = "1", value_parser = duration_from_seconds)]
     pub pool_cache_delay_between_retries_seconds: Duration,
 
     /// How often in seconds we poll the node to check if the current block has changed.
@@ -226,14 +226,14 @@ pub struct Arguments {
         long,
         env,
         default_value = "5",
-        parse(try_from_str = duration_from_seconds),
+        value_parser = duration_from_seconds,
     )]
     pub block_stream_poll_interval_seconds: Duration,
 
     /// The Balancer V2 factories to consider for indexing liquidity. Allows
     /// specific pool kinds to be disabled via configuration. Will use all
     /// supported Balancer V2 factory kinds if not specified.
-    #[clap(long, env, arg_enum, ignore_case = true, use_value_delimiter = true)]
+    #[clap(long, env, value_enum, ignore_case = true, use_value_delimiter = true)]
     pub balancer_factories: Option<Vec<BalancerFactoryKind>>,
 
     /// Deny list of balancer pool ids.
@@ -245,7 +245,7 @@ pub struct Arguments {
     #[clap(
         long,
         default_value = "30",
-        parse(try_from_str = duration_from_seconds),
+        value_parser = duration_from_seconds,
     )]
     pub liquidity_fetcher_max_age_update: Duration,
 

--- a/crates/driver/src/main.rs
+++ b/crates/driver/src/main.rs
@@ -282,12 +282,10 @@ async fn build_auction_converter(
     ));
     let cache_config = CacheConfig {
         number_of_blocks_to_cache: args.pool_cache_blocks,
-        // 0 because we don't make use of the auto update functionality as we always fetch
-        // for specific blocks
-        number_of_entries_to_auto_update: 0,
         maximum_recent_block_age: args.pool_cache_maximum_recent_block_age,
         max_retries: args.pool_cache_maximum_retries,
         delay_between_retries: args.pool_cache_delay_between_retries_seconds,
+        ..Default::default()
     };
     let baseline_sources = args.baseline_sources.clone().unwrap_or_else(|| {
         sources::defaults_for_chain(common.chain_id)

--- a/crates/e2e/Cargo.toml
+++ b/crates/e2e/Cargo.toml
@@ -14,7 +14,7 @@ anyhow = { workspace = true }
 autopilot = { path = "../autopilot" }
 chrono = { workspace = true }
 contracts = { path = "../contracts" }
-criterion = "0.3"
+criterion = "0.4"
 database = { path = "../database" }
 ethcontract = { workspace = true }
 hex-literal = { workspace = true }

--- a/crates/e2e/tests/e2e/services.rs
+++ b/crates/e2e/tests/e2e/services.rs
@@ -188,6 +188,7 @@ impl OrderbookServices {
         let pool_fetcher = PoolCache::new(
             CacheConfig {
                 number_of_blocks_to_cache: NonZeroU64::new(10).unwrap(),
+                number_of_entries_to_auto_update: NonZeroUsize::new(20).unwrap(),
                 maximum_recent_block_age: 4,
                 ..Default::default()
             },

--- a/crates/e2e/tests/e2e/services.rs
+++ b/crates/e2e/tests/e2e/services.rs
@@ -27,7 +27,12 @@ use shared::{
 };
 use solver::{liquidity::order_converter::OrderConverter, orderbook::OrderBookApi};
 use std::{
-    collections::HashSet, future::pending, num::NonZeroU64, str::FromStr, sync::Arc, time::Duration,
+    collections::HashSet,
+    future::pending,
+    num::{NonZeroU64, NonZeroUsize},
+    str::FromStr,
+    sync::Arc,
+    time::Duration,
 };
 use web3::signing::{Key as _, SecretKeyRef};
 

--- a/crates/e2e/tests/e2e/services.rs
+++ b/crates/e2e/tests/e2e/services.rs
@@ -188,7 +188,6 @@ impl OrderbookServices {
         let pool_fetcher = PoolCache::new(
             CacheConfig {
                 number_of_blocks_to_cache: NonZeroU64::new(10).unwrap(),
-                number_of_entries_to_auto_update: 20,
                 maximum_recent_block_age: 4,
                 ..Default::default()
             },

--- a/crates/model/src/order.rs
+++ b/crates/model/src/order.rs
@@ -15,7 +15,7 @@ use num::BigUint;
 use primitive_types::{H160, H256, U256};
 use secp256k1::ONE_KEY;
 use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
-use serde_with::serde_as;
+use serde_with::{serde_as, DisplayFromStr};
 use std::{
     collections::HashSet,
     fmt::{self, Debug, Display},
@@ -391,10 +391,10 @@ pub struct OrderMetadata {
     #[serde_as(as = "Option<DecimalU256>")]
     pub available_balance: Option<U256>,
     #[derivative(Debug(format_with = "debug_biguint_to_string"))]
-    #[serde(with = "serde_with::rust::display_fromstr")]
+    #[serde_as(as = "DisplayFromStr")]
     pub executed_buy_amount: BigUint,
     #[derivative(Debug(format_with = "debug_biguint_to_string"))]
-    #[serde(with = "serde_with::rust::display_fromstr")]
+    #[serde_as(as = "DisplayFromStr")]
     pub executed_sell_amount: BigUint,
     #[serde(default, with = "u256_decimal")]
     pub executed_sell_amount_before_fees: U256,

--- a/crates/model/src/trade.rs
+++ b/crates/model/src/trade.rs
@@ -4,18 +4,20 @@ use crate::order::OrderUid;
 use num::BigUint;
 use primitive_types::{H160, H256};
 use serde::{Deserialize, Serialize};
+use serde_with::{serde_as, DisplayFromStr};
 
+#[serde_as]
 #[derive(Eq, PartialEq, Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Trade {
     pub block_number: u64,
     pub log_index: u64,
     pub order_uid: OrderUid,
-    #[serde(with = "serde_with::rust::display_fromstr")]
+    #[serde_as(as = "DisplayFromStr")]
     pub buy_amount: BigUint,
-    #[serde(with = "serde_with::rust::display_fromstr")]
+    #[serde_as(as = "DisplayFromStr")]
     pub sell_amount: BigUint,
-    #[serde(with = "serde_with::rust::display_fromstr")]
+    #[serde_as(as = "DisplayFromStr")]
     pub sell_amount_before_fees: BigUint,
     // ORDER DATA
     pub owner: H160,

--- a/crates/orderbook/src/arguments.rs
+++ b/crates/orderbook/src/arguments.rs
@@ -37,7 +37,7 @@ pub struct Arguments {
         long,
         env,
         default_value = "60",
-        parse(try_from_str = shared::arguments::duration_from_seconds),
+        value_parser = shared::arguments::duration_from_seconds,
     )]
     pub min_order_validity_period: Duration,
 
@@ -47,7 +47,7 @@ pub struct Arguments {
         long,
         env,
         default_value = "10800",
-        parse(try_from_str = shared::arguments::duration_from_seconds),
+        value_parser = shared::arguments::duration_from_seconds,
     )]
     pub max_order_validity_period: Duration,
 
@@ -56,7 +56,7 @@ pub struct Arguments {
         long,
         env,
         default_value = "600",
-        parse(try_from_str = shared::arguments::duration_from_seconds),
+        value_parser = shared::arguments::duration_from_seconds,
     )]
     pub token_quality_cache_expiry: Duration,
 
@@ -75,7 +75,7 @@ pub struct Arguments {
 
     /// The number of pairs that are automatically updated in the pool cache.
     #[clap(long, env, default_value = "200")]
-    pub pool_cache_lru_size: usize,
+    pub pool_cache_lru_size: NonZeroUsize,
 
     /// Enable EIP-1271 orders.
     #[clap(long, env)]
@@ -105,7 +105,7 @@ pub struct Arguments {
         long,
         env,
         default_value = "30",
-        parse(try_from_str = shared::arguments::duration_from_seconds),
+        value_parser = shared::arguments::duration_from_seconds,
     )]
     pub native_price_cache_max_age_secs: Duration,
 
@@ -118,7 +118,7 @@ pub struct Arguments {
         long,
         env,
         default_value = "Baseline",
-        arg_enum,
+        value_enum,
         use_value_delimiter = true
     )]
     pub native_price_estimators: Vec<PriceEstimatorType>,
@@ -129,7 +129,7 @@ pub struct Arguments {
     #[clap(
         long,
         env,
-        parse(try_from_str = U256::from_dec_str)
+        value_parser = U256::from_dec_str
     )]
     pub amount_to_estimate_prices_with: Option<U256>,
 

--- a/crates/shared/Cargo.toml
+++ b/crates/shared/Cargo.toml
@@ -28,11 +28,11 @@ hex = { workspace = true }
 hex-literal = { workspace = true }
 itertools = { workspace = true }
 lazy_static = { workspace = true }
-lru = "0.7"
+lru = "0.8"
 maplit = { workspace = true }
 mockall = { workspace = true }
 model = { path = "../model" }
-num = { workspace = true, features = ["serde"] }
+num = { workspace = true }
 number-conversions = { path = "../number-conversions" }
 primitive-types = { workspace = true }
 prometheus = { workspace = true }

--- a/crates/shared/src/arguments.rs
+++ b/crates/shared/src/arguments.rs
@@ -28,7 +28,7 @@ pub struct OrderQuotingArguments {
         long,
         env,
         default_value = "Baseline",
-        arg_enum,
+        value_enum,
         use_value_delimiter = true
     )]
     pub price_estimators: Vec<PriceEstimatorType>,
@@ -47,7 +47,7 @@ pub struct OrderQuotingArguments {
         long,
         env,
         default_value = "600",
-        parse(try_from_str = duration_from_seconds),
+        value_parser = duration_from_seconds,
     )]
     pub eip1271_onchain_quote_validity_seconds: Duration,
 
@@ -56,7 +56,7 @@ pub struct OrderQuotingArguments {
         long,
         env,
         default_value = "600",
-        parse(try_from_str = duration_from_seconds),
+        value_parser = duration_from_seconds,
     )]
     pub presign_onchain_quote_validity_seconds: Duration,
 
@@ -77,7 +77,7 @@ pub struct OrderQuotingArguments {
 
     /// Gas Fee Factor: 1.0 means cost is forwarded to users alteration, 0.9 means there is a 10%
     /// subsidy, 1.1 means users pay 10% in fees than what we estimate we pay for gas.
-    #[clap(long, env, default_value = "1", parse(try_from_str = parse_unbounded_factor))]
+    #[clap(long, env, default_value = "1", value_parser = parse_unbounded_factor)]
     pub fee_factor: f64,
 
     /// Used to specify additional fee subsidy factor based on app_ids contained in orders.
@@ -92,7 +92,7 @@ pub struct OrderQuotingArguments {
         long,
         env,
         default_value = "",
-        parse(try_from_str = parse_partner_fee_factor),
+        value_parser = parse_partner_fee_factor,
     )]
     pub partner_additional_fee_factors: HashMap<AppId, f64>,
 
@@ -114,7 +114,7 @@ pub struct Arguments {
     )]
     pub log_filter: String,
 
-    #[clap(long, env, default_value = "error", parse(try_from_str))]
+    #[clap(long, env, default_value = "error")]
     pub log_stderr_threshold: LevelFilter,
 
     /// The Ethereum node URL to connect to.
@@ -132,7 +132,7 @@ pub struct Arguments {
         long,
         env,
         default_value = "Web3",
-        arg_enum,
+        value_enum,
         ignore_case = true,
         use_value_delimiter = true
     )]
@@ -148,7 +148,7 @@ pub struct Arguments {
     pub base_tokens: Vec<H160>,
 
     /// Which Liquidity sources to be used by Price Estimator.
-    #[clap(long, env, arg_enum, ignore_case = true, use_value_delimiter = true)]
+    #[clap(long, env, value_enum, ignore_case = true, use_value_delimiter = true)]
     pub baseline_sources: Option<Vec<BaselineSource>>,
 
     /// The number of blocks kept in the pool cache.
@@ -164,7 +164,7 @@ pub struct Arguments {
     pub pool_cache_maximum_retries: u32,
 
     /// How long to sleep in seconds between retries in the pool cache.
-    #[clap(long, env, default_value = "1", parse(try_from_str = duration_from_seconds))]
+    #[clap(long, env, default_value = "1", value_parser = duration_from_seconds)]
     pub pool_cache_delay_between_retries_seconds: Duration,
 
     /// How often in seconds we poll the node to check if the current block has changed.
@@ -172,7 +172,7 @@ pub struct Arguments {
         long,
         env,
         default_value = "5",
-        parse(try_from_str = duration_from_seconds),
+        value_parser = duration_from_seconds,
     )]
     pub block_stream_poll_interval_seconds: Duration,
 
@@ -212,7 +212,7 @@ pub struct Arguments {
     /// The Balancer V2 factories to consider for indexing liquidity. Allows
     /// specific pool kinds to be disabled via configuration. Will use all
     /// supported Balancer V2 factory kinds if not specified.
-    #[clap(long, env, arg_enum, ignore_case = true, use_value_delimiter = true)]
+    #[clap(long, env, value_enum, ignore_case = true, use_value_delimiter = true)]
     pub balancer_factories: Option<Vec<BalancerFactoryKind>>,
 
     /// The list of disabled 1Inch protocols. By default, the `PMM1` protocol
@@ -246,7 +246,7 @@ pub struct Arguments {
     #[clap(
         long,
         default_value = "30",
-        parse(try_from_str = duration_from_seconds),
+        value_parser = duration_from_seconds,
     )]
     pub liquidity_fetcher_max_age_update: Duration,
 }

--- a/crates/shared/src/bad_token/token_owner_finder.rs
+++ b/crates/shared/src/bad_token/token_owner_finder.rs
@@ -46,16 +46,16 @@ pub trait TokenOwnerFinding: Send + Sync {
 #[derive(clap::Parser)]
 pub struct Arguments {
     /// The token owner finding strategies to use.
-    #[clap(long, env, use_value_delimiter = true, arg_enum)]
+    #[clap(long, env, use_value_delimiter = true, value_enum)]
     pub token_owner_finders: Option<Vec<TokenOwnerFindingStrategy>>,
 
     /// The fee value strategy to use for locating Uniswap V3 pools as token holders for bad token
     /// detection.
-    #[clap(long, env, default_value = "static", arg_enum)]
+    #[clap(long, env, default_value = "static", value_enum)]
     pub token_owner_finder_uniswap_v3_fee_values: FeeValues,
 
     /// Override the Blockscout token owner finder-specific timeout configuration.
-    #[clap(long, parse(try_from_str = duration_from_seconds), default_value = "45")]
+    #[clap(long, value_parser = duration_from_seconds, default_value = "45")]
     pub blockscout_http_timeout: Duration,
 
     /// The Ethplorer token holder API key.
@@ -68,7 +68,7 @@ pub struct Arguments {
 }
 
 /// Support token owner finding strategies.
-#[derive(Clone, Copy, Debug, Eq, PartialEq, clap::ArgEnum)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, clap::ValueEnum)]
 pub enum TokenOwnerFindingStrategy {
     /// Using baseline liquidity pools as token owners.
     ///

--- a/crates/shared/src/bad_token/token_owner_finder/liquidity.rs
+++ b/crates/shared/src/bad_token/token_owner_finder/liquidity.rs
@@ -40,7 +40,7 @@ pub struct UniswapV3Finder {
     fee_values: Vec<u32>,
 }
 
-#[derive(Debug, Clone, Copy, clap::ArgEnum)]
+#[derive(Debug, Clone, Copy, clap::ValueEnum)]
 pub enum FeeValues {
     /// Use hardcoded list
     Static,

--- a/crates/shared/src/balancer_sor_api.rs
+++ b/crates/shared/src/balancer_sor_api.rs
@@ -10,6 +10,7 @@ use model::u256_decimal;
 use num::BigInt;
 use reqwest::{Client, IntoUrl, Url};
 use serde::{Deserialize, Serialize};
+use serde_with::{serde_as, DisplayFromStr};
 
 /// Trait for mockable Balancer SOR API.
 #[mockall::automock]
@@ -84,6 +85,7 @@ pub struct Query {
 }
 
 /// The swap route found by the Balancer SOR service.
+#[serde_as]
 #[derive(Clone, Debug, Default, PartialEq, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Quote {
@@ -121,7 +123,7 @@ pub struct Quote {
     /// This can be negative when quoting small sell amounts at high gas costs
     /// or greater than `U256::MAX` when quoting large buy amounts at high
     /// gas costs.
-    #[serde(with = "serde_with::rust::display_fromstr")]
+    #[serde_as(as = "DisplayFromStr")]
     pub return_amount_considering_fees: BigInt,
     /// The input (sell) token.
     #[serde(with = "address_default_when_empty")]
@@ -130,7 +132,7 @@ pub struct Quote {
     #[serde(with = "address_default_when_empty")]
     pub token_out: H160,
     /// The price impact (i.e. market slippage).
-    #[serde(with = "serde_with::rust::display_fromstr")]
+    #[serde_as(as = "DisplayFromStr")]
     pub market_sp: f64,
 }
 

--- a/crates/shared/src/gas_price_estimation.rs
+++ b/crates/shared/src/gas_price_estimation.rs
@@ -9,7 +9,7 @@ use reqwest::header::{self, HeaderMap, HeaderValue};
 use serde::de::DeserializeOwned;
 use std::sync::{Arc, Mutex};
 
-#[derive(Copy, Clone, Debug, clap::ArgEnum)]
+#[derive(Copy, Clone, Debug, clap::ValueEnum)]
 #[clap(rename_all = "verbatim")]
 pub enum GasEstimatorType {
     EthGasStation,

--- a/crates/shared/src/http_client.rs
+++ b/crates/shared/src/http_client.rs
@@ -59,7 +59,7 @@ pub struct Arguments {
     #[clap(
         long,
         default_value = "10",
-        parse(try_from_str = duration_from_seconds),
+        value_parser = duration_from_seconds,
     )]
     pub http_timeout: Duration,
 }

--- a/crates/shared/src/paraswap_api.rs
+++ b/crates/shared/src/paraswap_api.rs
@@ -12,6 +12,7 @@ use serde::{
     Deserialize, Deserializer, Serialize,
 };
 use serde_json::Value;
+use serde_with::{serde_as, DisplayFromStr};
 use thiserror::Error;
 
 const BASE_URL: &str = "https://apiv5.paraswap.io";
@@ -217,6 +218,7 @@ impl<'de> Deserialize<'de> for PriceResponse {
             price_route: Value,
         }
 
+        #[serde_as]
         #[derive(Deserialize)]
         #[serde(rename_all = "camelCase")]
         struct PriceRoute {
@@ -225,7 +227,7 @@ impl<'de> Deserialize<'de> for PriceResponse {
             #[serde(with = "u256_decimal")]
             dest_amount: U256,
             token_transfer_proxy: H160,
-            #[serde(with = "serde_with::rust::display_fromstr")]
+            #[serde_as(as = "DisplayFromStr")]
             gas_cost: u64,
         }
 

--- a/crates/shared/src/price_estimation.rs
+++ b/crates/shared/src/price_estimation.rs
@@ -31,7 +31,7 @@ use std::{
 };
 use thiserror::Error;
 
-#[derive(Copy, Clone, Debug, clap::ArgEnum, Hash, Eq, PartialEq)]
+#[derive(Copy, Clone, Debug, Hash, Eq, PartialEq, clap::ValueEnum)]
 #[clap(rename_all = "verbatim")]
 pub enum PriceEstimatorType {
     Baseline,

--- a/crates/shared/src/price_estimation/http.rs
+++ b/crates/shared/src/price_estimation/http.rs
@@ -384,7 +384,7 @@ mod tests {
     use crate::token_info::TokenInfoFetcher;
     use crate::transport::http::HttpTransport;
     use crate::Web3;
-    use clap::ArgEnum;
+    use clap::ValueEnum;
     use ethcontract::dyns::DynTransport;
     use model::order::OrderKind;
     use reqwest::Client;

--- a/crates/shared/src/sources.rs
+++ b/crates/shared/src/sources.rs
@@ -21,7 +21,7 @@ use std::{
     sync::Arc,
 };
 
-#[derive(Debug, Clone, Copy, Eq, Hash, PartialEq, clap::ArgEnum)]
+#[derive(Debug, Clone, Copy, Eq, Hash, PartialEq, clap::ValueEnum)]
 #[clap(rename_all = "verbatim")]
 pub enum BaselineSource {
     UniswapV2,

--- a/crates/shared/src/sources/balancer_v2/pool_fetching.rs
+++ b/crates/shared/src/sources/balancer_v2/pool_fetching.rs
@@ -29,7 +29,7 @@ use crate::{
     Web3, Web3Transport,
 };
 use anyhow::{Context, Result};
-use clap::ArgEnum;
+use clap::ValueEnum;
 use contracts::{
     BalancerV2LiquidityBootstrappingPoolFactory,
     BalancerV2NoProtocolFeeLiquidityBootstrappingPoolFactory, BalancerV2StablePoolFactory,
@@ -144,7 +144,7 @@ pub struct BalancerPoolFetcher {
 }
 
 /// An enum containing all supported Balancer factory types.
-#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, ArgEnum)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, ValueEnum)]
 #[clap(rename_all = "verbatim")]
 pub enum BalancerFactoryKind {
     Weighted,

--- a/crates/shared/src/sources/uniswap_v3/graph_api.rs
+++ b/crates/shared/src/sources/uniswap_v3/graph_api.rs
@@ -11,6 +11,7 @@ use num::BigInt;
 use reqwest::Client;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
+use serde_with::{serde_as, DisplayFromStr};
 
 const ALL_POOLS_QUERY: &str = r#"
     query Pools($block: Int, $pageSize: Int, $lastId: ID) {
@@ -174,6 +175,7 @@ pub struct RegisteredPools {
 }
 
 /// Pool data from the Uniswap V3 subgraph.
+#[serde_as]
 #[derive(Debug, Clone, Deserialize, Default, Eq, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct PoolData {
@@ -183,7 +185,7 @@ pub struct PoolData {
     pub fee_tier: U256,
     pub liquidity: U256,
     pub sqrt_price: U256,
-    #[serde(with = "serde_with::rust::display_fromstr")]
+    #[serde_as(as = "DisplayFromStr")]
     pub tick: BigInt,
     pub ticks: Option<Vec<TickData>>,
 }
@@ -195,13 +197,14 @@ impl ContainsId for PoolData {
 }
 
 /// Tick data from the Uniswap V3 subgraph.
+#[serde_as]
 #[derive(Debug, Clone, Deserialize, Eq, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct TickData {
     pub id: String,
-    #[serde(with = "serde_with::rust::display_fromstr")]
+    #[serde_as(as = "DisplayFromStr")]
     pub tick_idx: BigInt,
-    #[serde(with = "serde_with::rust::display_fromstr")]
+    #[serde_as(as = "DisplayFromStr")]
     pub liquidity_net: BigInt,
     pub pool_address: H160,
 }
@@ -212,12 +215,13 @@ impl ContainsId for TickData {
     }
 }
 
+#[serde_as]
 #[derive(Debug, Clone, Default, Deserialize, Eq, PartialEq, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Token {
     pub id: H160,
     pub symbol: String,
-    #[serde(with = "serde_with::rust::display_fromstr")]
+    #[serde_as(as = "DisplayFromStr")]
     pub decimals: u8,
 }
 

--- a/crates/shared/src/sources/uniswap_v3/pool_fetching.rs
+++ b/crates/shared/src/sources/uniswap_v3/pool_fetching.rs
@@ -38,12 +38,12 @@ pub struct PoolState {
     pub sqrt_price: U256,
     #[serde(with = "u256_decimal")]
     pub liquidity: U256,
-    #[serde(with = "serde_with::rust::display_fromstr")]
+    #[serde_as(as = "DisplayFromStr")]
     pub tick: BigInt,
     // (tick_idx, liquidity_net)
     #[serde_as(as = "BTreeMap<DisplayFromStr, DisplayFromStr>")]
     pub liquidity_net: Vec<(BigInt, BigInt)>,
-    #[serde(with = "serde_with::rust::display_fromstr")]
+    #[serde_as(as = "DisplayFromStr")]
     pub fee: Ratio<u32>,
 }
 

--- a/crates/shared/src/univ3_router_api.rs
+++ b/crates/shared/src/univ3_router_api.rs
@@ -5,6 +5,7 @@ use model::u256_decimal;
 use primitive_types::{H160, U256};
 use reqwest::{Client, Url};
 use serde::{Deserialize, Serialize};
+use serde_with::{serde_as, DisplayFromStr};
 
 #[derive(Debug, Copy, Clone, Serialize)]
 pub enum Type {
@@ -25,11 +26,12 @@ pub struct Request {
     pub recipient: H160,
 }
 
+#[serde_as]
 #[derive(Debug, Clone, Deserialize)]
 pub struct Response {
     #[serde(with = "u256_decimal")]
     pub quote: U256,
-    #[serde(with = "serde_with::rust::display_fromstr")]
+    #[serde_as(as = "DisplayFromStr")]
     pub gas: u64,
     #[serde(with = "model::bytes_hex")]
     pub call_data: Vec<u8>,

--- a/crates/shared/src/zeroex_api.rs
+++ b/crates/shared/src/zeroex_api.rs
@@ -15,6 +15,7 @@ use reqwest::{
     Client, IntoUrl, Url,
 };
 use serde::Deserialize;
+use serde_with::{serde_as, DisplayFromStr};
 use std::{
     collections::HashSet,
     fmt::{self, Display, Formatter},
@@ -170,6 +171,7 @@ impl Default for OrdersQuery {
     }
 }
 
+#[serde_as]
 #[derive(Debug, Derivative, Clone, Deserialize, Eq, PartialEq)]
 #[derivative(Default)]
 #[serde(rename_all = "camelCase")]
@@ -178,7 +180,7 @@ pub struct OrderMetadata {
     pub created_at: DateTime<Utc>,
     #[serde(with = "model::bytes_hex")]
     pub order_hash: Vec<u8>,
-    #[serde(with = "serde_with::rust::display_fromstr")]
+    #[serde_as(as = "DisplayFromStr")]
     pub remaining_fillable_taker_amount: u128,
 }
 
@@ -191,6 +193,7 @@ pub struct ZeroExSignature {
     pub signature_type: u8,
 }
 
+#[serde_as]
 #[derive(Debug, Derivative, Clone, Deserialize, Eq, PartialEq)]
 #[derivative(Default)]
 #[serde(rename_all = "camelCase")]
@@ -199,7 +202,7 @@ pub struct Order {
     pub chain_id: u64,
     /// Timestamp in seconds of when the order expires. Expired orders cannot be filled.
     #[derivative(Default(value = "NaiveDateTime::MAX.timestamp() as u64"))]
-    #[serde(with = "serde_with::rust::display_fromstr")]
+    #[serde_as(as = "DisplayFromStr")]
     pub expiry: u64,
     /// The address of the entity that will receive any fees stipulated by the order.
     /// This is typically used to incentivize off-chain order relay.
@@ -208,7 +211,7 @@ pub struct Order {
     /// two parties that will be involved in the trade if the order gets filled.
     pub maker: H160,
     /// The amount of `maker_token` being sold by the maker.
-    #[serde(with = "serde_with::rust::display_fromstr")]
+    #[serde_as(as = "DisplayFromStr")]
     pub maker_amount: u128,
     /// The address of the ERC20 token the maker is selling to the taker.
     pub maker_token: H160,
@@ -229,12 +232,12 @@ pub struct Order {
     /// anyone can fill the order.
     pub taker: H160,
     /// The amount of `taker_token` being sold by the taker.
-    #[serde(with = "serde_with::rust::display_fromstr")]
+    #[serde_as(as = "DisplayFromStr")]
     pub taker_amount: u128,
     /// The address of the ERC20 token the taker is selling to the maker.
     pub taker_token: H160,
     /// Amount of takerToken paid by the taker to the feeRecipient.
-    #[serde(with = "serde_with::rust::display_fromstr")]
+    #[serde_as(as = "DisplayFromStr")]
     pub taker_token_fee_amount: u128,
     /// Address of the contract where the transaction should be sent, usually this is
     /// the 0x exchange proxy contract.
@@ -277,6 +280,7 @@ pub struct OrdersResponse {
 }
 
 /// A Ox API `price` response.
+#[serde_as]
 #[derive(Clone, Default, Derivative, Deserialize, PartialEq)]
 #[derivative(Debug)]
 #[serde(rename_all = "camelCase")]
@@ -286,9 +290,9 @@ pub struct PriceResponse {
     #[serde(with = "u256_decimal")]
     pub buy_amount: U256,
     pub allowance_target: H160,
-    #[serde(with = "serde_with::rust::display_fromstr")]
+    #[serde_as(as = "DisplayFromStr")]
     pub price: f64,
-    #[serde(with = "serde_with::rust::display_fromstr")]
+    #[serde_as(as = "DisplayFromStr")]
     pub estimated_gas: u64,
 }
 

--- a/crates/solver/src/arguments.rs
+++ b/crates/solver/src/arguments.rs
@@ -49,7 +49,7 @@ pub struct Arguments {
         long,
         env,
         default_value = "30",
-        parse(try_from_str = shared::arguments::duration_from_seconds),
+        value_parser = shared::arguments::duration_from_seconds,
     )]
     pub target_confirm_time: Duration,
 
@@ -63,7 +63,7 @@ pub struct Arguments {
         long,
         env,
         default_value = "1",
-        parse(try_from_str = shared::arguments::duration_from_seconds),
+        value_parser = shared::arguments::duration_from_seconds,
     )]
     pub settle_interval: Duration,
 
@@ -72,7 +72,7 @@ pub struct Arguments {
         long,
         env,
         default_values = &["Naive", "Baseline"],
-        arg_enum,
+        value_enum,
         ignore_case = true,
         use_value_delimiter = true
     )]
@@ -100,7 +100,7 @@ pub struct Arguments {
         long,
         env,
         default_value = "30",
-        parse(try_from_str = shared::arguments::duration_from_seconds),
+        value_parser = shared::arguments::duration_from_seconds,
     )]
     pub min_order_age: Duration,
 
@@ -117,7 +117,7 @@ pub struct Arguments {
         long,
         env,
         default_value = "30",
-        parse(try_from_str = shared::arguments::duration_from_seconds),
+        value_parser = shared::arguments::duration_from_seconds,
     )]
     pub solver_time_limit: Duration,
 
@@ -135,7 +135,7 @@ pub struct Arguments {
         long,
         env,
         default_value = "1500",
-        parse(try_from_str = shared::arguments::wei_from_gwei)
+        value_parser = shared::arguments::wei_from_gwei
     )]
     pub gas_price_cap: f64,
 
@@ -163,7 +163,7 @@ pub struct Arguments {
         long,
         env,
         default_value = "PublicMempool",
-        arg_enum,
+        value_enum,
         ignore_case = true,
         use_value_delimiter = true
     )]
@@ -173,7 +173,7 @@ pub struct Arguments {
     /// fails. Individual estimators might support different networks.
     /// `Tenderly`: supports every network.
     /// `Web3`: supports every network.
-    #[clap(long, env, arg_enum, ignore_case = true, use_value_delimiter = true)]
+    #[clap(long, env, value_enum, ignore_case = true, use_value_delimiter = true)]
     pub access_list_estimators: Vec<AccessListEstimatorType>,
 
     /// The Tenderly user associated with the API key.
@@ -207,7 +207,7 @@ pub struct Arguments {
         long,
         env,
         default_value = "3",
-        parse(try_from_str = shared::arguments::wei_from_gwei)
+        value_parser = shared::arguments::wei_from_gwei
     )]
     pub max_additional_eden_tip: f64,
 
@@ -216,7 +216,7 @@ pub struct Arguments {
     #[clap(
         long,
         default_value = "120",
-        parse(try_from_str = shared::arguments::duration_from_seconds),
+        value_parser = shared::arguments::duration_from_seconds,
     )]
     pub max_submission_seconds: Duration,
 
@@ -225,7 +225,7 @@ pub struct Arguments {
         long,
         env,
         default_value = "3",
-        parse(try_from_str = shared::arguments::wei_from_gwei)
+        value_parser = shared::arguments::wei_from_gwei
     )]
     pub max_additional_flashbot_tip: f64,
 
@@ -233,7 +233,7 @@ pub struct Arguments {
     #[clap(
         long,
         default_value = "2",
-        parse(try_from_str = shared::arguments::duration_from_seconds),
+        value_parser = shared::arguments::duration_from_seconds,
     )]
     pub submission_retry_interval_seconds: Duration,
 
@@ -242,7 +242,7 @@ pub struct Arguments {
         long,
         env,
         default_value = "0.05",
-        parse(try_from_str = shared::arguments::parse_percentage_factor)
+        value_parser = shared::arguments::parse_percentage_factor
     )]
     pub additional_tip_percentage: f64,
 
@@ -260,7 +260,7 @@ pub struct Arguments {
     /// factor by which order fees are multiplied with. Setting this to a value
     /// greater than 1.0 makes settlements with negative objective values less
     /// likely, promoting more aggressive merging of single order settlements.
-    #[clap(long, env, default_value = "1", parse(try_from_str = shared::arguments::parse_unbounded_factor))]
+    #[clap(long, env, default_value = "1", value_parser = shared::arguments::parse_unbounded_factor)]
     pub fee_objective_scaling_factor: f64,
 
     /// The maximum number of settlements the driver considers per solver.
@@ -272,7 +272,7 @@ pub struct Arguments {
     /// Unwrapping a bigger amount will cause fewer unwraps to happen and thereby reduce the cost
     /// of unwraps per settled batch.
     /// Only values in the range [0.0, 1.0] make sense.
-    #[clap(long, env, default_value = "0.6", parse(try_from_str = shared::arguments::parse_percentage_factor))]
+    #[clap(long, env, default_value = "0.6", value_parser = shared::arguments::parse_percentage_factor)]
     pub weth_unwrap_factor: f64,
 
     /// Gas limit for simulations. This parameter is important to set correctly, such that
@@ -409,7 +409,7 @@ impl std::fmt::Display for Arguments {
     }
 }
 
-#[derive(Copy, Clone, Debug, clap::ArgEnum)]
+#[derive(Copy, Clone, Debug, clap::ValueEnum)]
 #[clap(rename_all = "verbatim")]
 pub enum TransactionStrategyArg {
     PublicMempool,

--- a/crates/solver/src/main.rs
+++ b/crates/solver/src/main.rs
@@ -104,12 +104,10 @@ async fn main() {
 
     let cache_config = CacheConfig {
         number_of_blocks_to_cache: args.shared.pool_cache_blocks,
-        // 0 because we don't make use of the auto update functionality as we always fetch
-        // for specific blocks
-        number_of_entries_to_auto_update: 0,
         maximum_recent_block_age: args.shared.pool_cache_maximum_recent_block_age,
         max_retries: args.shared.pool_cache_maximum_retries,
         delay_between_retries: args.shared.pool_cache_delay_between_retries_seconds,
+        ..Default::default()
     };
     let baseline_sources = args.shared.baseline_sources.unwrap_or_else(|| {
         sources::defaults_for_chain(chain_id).expect("failed to get default baseline sources")

--- a/crates/solver/src/settlement_access_list.rs
+++ b/crates/solver/src/settlement_access_list.rs
@@ -225,7 +225,7 @@ impl AccessListEstimating for PriorityAccessListEstimating {
     }
 }
 
-#[derive(Copy, Clone, Debug, clap::ArgEnum)]
+#[derive(Copy, Clone, Debug, clap::ValueEnum)]
 #[clap(rename_all = "verbatim")]
 pub enum AccessListEstimatorType {
     Web3,

--- a/crates/solver/src/solver.rs
+++ b/crates/solver/src/solver.rs
@@ -154,7 +154,7 @@ pub type SettlementWithError = (
     ExecutionError,
 );
 
-#[derive(Copy, Clone, Debug, clap::ArgEnum)]
+#[derive(Copy, Clone, Debug, clap::ValueEnum)]
 #[clap(rename_all = "verbatim")]
 pub enum SolverType {
     Naive,
@@ -210,7 +210,7 @@ impl FromStr for SolverAccountArg {
     }
 }
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct ExternalSolverArg {
     pub name: String,
     pub url: Url,


### PR DESCRIPTION
This PR just updates Cargo dependencies in our repo. Nothing special. Some minor breaking changes that needed to deal with:
- `clap`
  - `ArgEnum` was renamed to `ValueEnum`
  - `parse(try_from_str = ...)` is now `value_parser = ...`
- `serde_with`
  - Deprecated `serde(with = ...)` modules available, so moved to `serde_as`
- `lru`
  - Cache needs a non-zero size. This just required adjusting some types and unit test asserts

Much easier to do with Cargo workspace dependencies!

### Test Plan

CI and the compiler
