### PR TITLE
Revert "Add the flag is_ethflow_order"

### DIFF
--- a/crates/autopilot/src/database/auction.rs
+++ b/crates/autopilot/src/database/auction.rs
@@ -142,7 +142,6 @@ fn full_order_into_model_order(order: database::orders::FullOrder) -> Result<Ord
         full_fee_amount: big_decimal_to_u256(&order.full_fee_amount)
             .ok_or_else(|| anyhow!("full_fee_amount is not U256"))?,
         is_liquidity_order: order.is_liquidity_order,
-        is_ethflow_order: order.is_ethflow_order,
     };
     let data = OrderData {
         sell_token: H160(order.sell_token.0),

--- a/crates/database/src/ethflow_orders.rs
+++ b/crates/database/src/ethflow_orders.rs
@@ -17,7 +17,7 @@ pub async fn append(
     Ok(())
 }
 
-async fn insert_ethflow_order(
+pub async fn insert_ethflow_order(
     ex: &mut PgConnection,
     event: &EthOrderPlacement,
 ) -> Result<(), sqlx::Error> {

--- a/crates/database/src/ethflow_orders.rs
+++ b/crates/database/src/ethflow_orders.rs
@@ -17,7 +17,7 @@ pub async fn append(
     Ok(())
 }
 
-pub async fn insert_ethflow_order(
+async fn insert_ethflow_order(
     ex: &mut PgConnection,
     event: &EthOrderPlacement,
 ) -> Result<(), sqlx::Error> {

--- a/crates/database/src/orders.rs
+++ b/crates/database/src/orders.rs
@@ -454,6 +454,7 @@ mod tests {
     use super::*;
     use crate::{
         byte_array::ByteArray,
+        ethflow_orders::{insert_ethflow_order, EthOrderPlacement},
         events::{Event, EventIndex, Invalidation, PreSignature, Settlement, Trade},
         onchain_broadcasted_orders::{insert_onchain_order, OnchainOrderPlacement},
         PgTransaction,

--- a/crates/database/src/orders.rs
+++ b/crates/database/src/orders.rs
@@ -292,7 +292,6 @@ pub struct FullOrder {
     pub buy_token_balance: BuyTokenDestination,
     pub presignature_pending: bool,
     pub is_liquidity_order: bool,
-    pub is_ethflow_order: bool,
 }
 
 // When querying orders we have several specialized use cases working with their own filtering,
@@ -320,7 +319,6 @@ o.uid, o.owner, o.creation_timestamp, o.sell_token, o.buy_token, o.sell_amount, 
 o.valid_to, o.app_data, o.fee_amount, o.full_fee_amount, o.kind, o.partially_fillable, o.signature,
 o.receiver, o.signing_scheme, o.settlement_contract, o.sell_token_balance, o.buy_token_balance,
 o.is_liquidity_order,
-(SELECT EXISTS(SELECT 1 FROM ethflow_orders eo WHERE eo.uid = o.uid)) as is_ethflow_order,
 (SELECT COALESCE(SUM(t.buy_amount), 0) FROM trades t WHERE t.order_uid = o.uid) AS sum_buy,
 (SELECT COALESCE(SUM(t.sell_amount), 0) FROM trades t WHERE t.order_uid = o.uid) AS sum_sell,
 (SELECT COALESCE(SUM(t.fee_amount), 0) FROM trades t WHERE t.order_uid = o.uid) AS sum_fee,
@@ -456,7 +454,6 @@ mod tests {
     use super::*;
     use crate::{
         byte_array::ByteArray,
-        ethflow_orders::{insert_ethflow_order, EthOrderPlacement},
         events::{Event, EventIndex, Invalidation, PreSignature, Settlement, Trade},
         onchain_broadcasted_orders::{insert_onchain_order, OnchainOrderPlacement},
         PgTransaction,
@@ -627,41 +624,6 @@ mod tests {
         );
         assert_eq!(order.sum_buy.to_bigint().unwrap(), expected_buy_amount);
         assert_eq!(order.sum_fee.to_bigint().unwrap(), expected_fee_amount);
-    }
-
-    #[tokio::test]
-    #[ignore]
-    async fn postgres_reading_ethflow_orders() {
-        let mut db = PgConnection::connect("postgresql://").await.unwrap();
-        let mut db = db.begin().await.unwrap();
-        crate::clear_DANGER_(&mut db).await.unwrap();
-
-        let order = Order {
-            sell_amount: 1.into(),
-            buy_amount: 1.into(),
-            signing_scheme: SigningScheme::Eip1271,
-            ..Default::default()
-        };
-        insert_order(&mut db, &order).await.unwrap();
-
-        let order = single_full_order(&mut db, &order.uid)
-            .await
-            .unwrap()
-            .unwrap();
-        assert!(!order.is_ethflow_order);
-
-        let eth_order_placement = EthOrderPlacement {
-            uid: order.uid,
-            valid_to: 0i64,
-        };
-        insert_ethflow_order(&mut db, &eth_order_placement)
-            .await
-            .unwrap();
-        let order = single_full_order(&mut db, &order.uid)
-            .await
-            .unwrap()
-            .unwrap();
-        assert!(order.is_ethflow_order);
     }
 
     #[tokio::test]

--- a/crates/model/src/order.rs
+++ b/crates/model/src/order.rs
@@ -405,7 +405,6 @@ pub struct OrderMetadata {
     #[serde(default, with = "u256_decimal")]
     pub full_fee_amount: U256,
     pub is_liquidity_order: bool,
-    pub is_ethflow_order: bool,
 }
 
 impl Default for OrderMetadata {
@@ -424,7 +423,6 @@ impl Default for OrderMetadata {
             settlement_contract: H160::default(),
             full_fee_amount: U256::default(),
             is_liquidity_order: false,
-            is_ethflow_order: false,
         }
     }
 }
@@ -681,7 +679,6 @@ mod tests {
             "sellTokenBalance": "external",
             "buyTokenBalance": "internal",
             "isLiquidityOrder": false,
-            "isEthflowOrder": false,
         });
         let signing_scheme = EcdsaSigningScheme::Eip712;
         let expected = Order {
@@ -699,7 +696,6 @@ mod tests {
                 settlement_contract: H160::from_low_u64_be(2),
                 full_fee_amount: U256::MAX,
                 is_liquidity_order: false,
-                is_ethflow_order: false,
             },
             data: OrderData {
                 sell_token: H160::from_low_u64_be(10),

--- a/crates/orderbook/src/database/orders.rs
+++ b/crates/orderbook/src/database/orders.rs
@@ -299,7 +299,6 @@ fn full_order_into_model_order(order: FullOrder) -> Result<Order> {
         full_fee_amount: big_decimal_to_u256(&order.full_fee_amount)
             .ok_or_else(|| anyhow!("full_fee_amount is not U256"))?,
         is_liquidity_order: order.is_liquidity_order,
-        is_ethflow_order: order.is_ethflow_order,
     };
     let data = OrderData {
         sell_token: H160(order.sell_token.0),
@@ -388,7 +387,6 @@ mod tests {
             buy_token_balance: DbBuyTokenDestination::Internal,
             presignature_pending: false,
             is_liquidity_order: true,
-            is_ethflow_order: false,
         };
 
         // Open - sell (filled - 0%)


### PR DESCRIPTION
Reverts cowprotocol/services#580

We will try to remove the is_ethflow_flag and instead store a pre_interaction for ethflow orders that identifies them uniquely.
See discussions:  https://github.com/cowprotocol/services/pull/581#issuecomment-1261852674