### PR TITLE
Increase Slippage Precision

### DIFF
--- a/crates/shared/src/oneinch_api.rs
+++ b/crates/shared/src/oneinch_api.rs
@@ -234,7 +234,7 @@ impl Display for Slippage {
         // Note that we use a rounded slippage percentage. This is because the
         // 1Inch API will repsond with server errors if the slippage paramter
         // has too much precision.
-        write!(f, "{:.2}", self.0)
+        write!(f, "{:.4}", self.0)
     }
 }
 
@@ -627,7 +627,7 @@ mod tests {
 
     #[test]
     fn slippage_rounds_percentage() {
-        assert_eq!(Slippage(1.2345678).to_string(), "1.23");
+        assert_eq!(Slippage(1.2345678).to_string(), "1.2346");
     }
 
     #[test]
@@ -679,7 +679,7 @@ mod tests {
                 &toTokenAddress=0x111111111117dc0aa78b770fa6a738034120c302\
                 &amount=1000000000000000000\
                 &fromAddress=0x00000000219ab540356cbb839cbe05303d7705fa\
-                &slippage=0.50",
+                &slippage=0.5000",
         );
     }
 
@@ -721,7 +721,7 @@ mod tests {
                 &toTokenAddress=0x111111111117dc0aa78b770fa6a738034120c302\
                 &amount=1000000000000000000\
                 &fromAddress=0x00000000219ab540356cbb839cbe05303d7705fa\
-                &slippage=0.50\
+                &slippage=0.5000\
                 &protocols=WETH%2CUNISWAP_V3\
                 &disableEstimate=true\
                 &complexityLevel=2\
@@ -880,7 +880,7 @@ mod tests {
             .unwrap()
             .get_swap(SwapQuery {
                 from_address: addr!("00000000219ab540356cBB839Cbe05303d7705Fa"),
-                slippage: Slippage::percentage(0.5).unwrap(),
+                slippage: Slippage::ONE_PERCENT,
                 disable_estimate: None,
                 quote: SellOrderQuoteQuery::with_default_options(
                     addr!("EeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE"),
@@ -905,7 +905,7 @@ mod tests {
             .unwrap()
             .get_swap(SwapQuery {
                 from_address: addr!("4e608b7da83f8e9213f554bdaa77c72e125529d0"),
-                slippage: Slippage::percentage(0.5).unwrap(),
+                slippage: Slippage::percentage(1.2345678).unwrap(),
                 disable_estimate: Some(true),
                 quote: SellOrderQuoteQuery {
                     from_token_address: addr!("EeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE"),

--- a/crates/shared/src/zeroex_api.rs
+++ b/crates/shared/src/zeroex_api.rs
@@ -106,9 +106,8 @@ pub struct Slippage(f64);
 impl Slippage {
     pub const ONE_PERCENT: Self = Self(0.01);
 
-    /// Creates a slippage amount from the specified basis points.
-    pub fn from_basis_points(basis_points: u32) -> Self {
-        let factor = (basis_points as f64) / 10000.;
+    /// Creates a slippage amount from the specified slippage factor.
+    pub fn new(factor: f64) -> Self {
         Slippage(factor)
     }
 }
@@ -528,14 +527,14 @@ mod tests {
 
     #[tokio::test]
     #[ignore]
-    async fn test_api_e2e() {
+    async fn zeroex_swap() {
         let zeroex_client = DefaultZeroExApi::default();
         let swap_query = SwapQuery {
             sell_token: testlib::tokens::WETH,
             buy_token: testlib::tokens::USDC,
             sell_amount: Some(U256::from_f64_lossy(1e18)),
             buy_amount: None,
-            slippage_percentage: Some(Slippage::ONE_PERCENT),
+            slippage_percentage: Some(Slippage::new(0.012345678)),
             excluded_sources: Vec::new(),
             enable_slippage_protection: false,
         };

--- a/crates/solver/src/solver/zeroex_solver.rs
+++ b/crates/solver/src/solver/zeroex_solver.rs
@@ -97,11 +97,11 @@ impl SingleOrderSolving for ZeroExSolver {
             buy_token: order.buy_token,
             sell_amount,
             buy_amount,
-            slippage_percentage: Some(Slippage::from_basis_points(
+            slippage_percentage: Some(Slippage::new(
                 self.slippage_calculator
                     .auction_context(auction)
                     .relative_for_order(&order)?
-                    .as_bps(),
+                    .as_factor(),
             )),
             excluded_sources: self.excluded_sources.clone(),
             enable_slippage_protection: false,


### PR DESCRIPTION
In investigating the new absolute slippage logic, I found that there are cases (for *very* large orders) where we were submitting settlements with 0 slippage tolerance.

This is because, in a couple of places, we use a **truncating** conversion from slippage to basis points. This means that if the relative adjusted slippage (capped by the absolute slippage value) is less than a basis point, we were 

This PR does two things:
- Changes the 1Inch `Slippage` to encode more precision (I determined experimentally that 4 decimal digits of precision is the maximum that accepted by 1Inch - see #589 for original discussion of how the 1Inch API does not accept arbitrary precision in its slippage tolerance configuration)
- Changes the 0x solver to use the full precision slippage factor, instead of first truncating to basis points.

Note that this does not fix this issue for the ParaSwap solver. Unfortunately, the API only accepts slippage in basis points, so this fix won't work for it. While we round to the nearest basis point, I don't think this is a good idea. Specifically for the order that I investigated [`2e2e42a`](https://explorer.cow/fi/orders/0x2e2e42a16bb16495b8fd75604a05625fd31710961cd3fffe99b0a81e8992ada20945260089850bc72432072501c6f545f6b64cec6337087f), the adjusted relative slippage was ~0.55 basis points, meaning that rounding would have made the absolute slippage tolerance be almost double of what the configured absolute slippage cap was. The proper fix for ParaSwap would be to instead to provide src and dest amounts directly instead of a slippage configuration (the API supports either `slippage + {src,dest}Amount` or `srcAmount + destAmount` for building the transaction), this is a larger change so will be introduced in a separate PR).

### Test Plan

Double check that the APIs accept slippage parameters with increased slippage precision:
```
% cargo test -p shared -- --ignored zeroex_swap oneinch_swap_fully_parameterized
    Finished test [unoptimized + debuginfo] target(s) in 0.17s
     Running unittests src/lib.rs (target/debug/deps/shared-0be2a3e8da8411a3)

running 2 tests
test oneinch_api::tests::oneinch_swap_fully_parameterized ... ok
test zeroex_api::tests::zeroex_swap ... ok

test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 361 filtered out; finished in 1.76s
```
