### PR TITLE
Increase Slippage Precision for ParaSwap Solver

### DIFF
--- a/crates/shared/src/paraswap_api.rs
+++ b/crates/shared/src/paraswap_api.rs
@@ -260,8 +260,6 @@ pub struct TransactionBuilderQuery {
     /// The trade amount amount
     #[serde(flatten)]
     pub trade_amount: TradeAmount,
-    /// The maximum slippage in BPS.
-    pub slippage: u32,
     /// The decimals of the source token
     pub src_decimals: u8,
     /// The decimals of the destination token
@@ -276,15 +274,33 @@ pub struct TransactionBuilderQuery {
 #[derive(Clone, Debug, Eq, PartialEq, Serialize)]
 #[serde(untagged)]
 pub enum TradeAmount {
+    /// For a sell order, specify the sell amount and slippage used for
+    /// determining the minimum buy amount.
     #[serde(rename_all = "camelCase")]
     Sell {
         /// The source amount
         #[serde(with = "u256_decimal")]
         src_amount: U256,
+        /// The maximum slippage in BPS.
+        slippage: u32,
     },
+    /// For a buy order, specify the buy amount and slippage used for
+    /// determining the maximum sell amount.
     #[serde(rename_all = "camelCase")]
     Buy {
         /// The destination amount
+        #[serde(with = "u256_decimal")]
+        dest_amount: U256,
+        /// The maximum slippage in BPS.
+        slippage: u32,
+    },
+    /// For a any order (buy or sell), specify the limit amounts for building
+    /// the transaction. The order "side" (i.e. buy or sell) is determined based
+    /// on the initial `/price` query and the included `price_route`.
+    #[serde(rename_all = "camelCase")]
+    Exact {
+        #[serde(with = "u256_decimal")]
+        src_amount: U256,
         #[serde(with = "u256_decimal")]
         dest_amount: U256,
     },
@@ -380,8 +396,8 @@ mod tests {
                 dest_token,
                 trade_amount: TradeAmount::Sell {
                     src_amount: price_response.src_amount,
+                    slippage: 1000,
                 },
-                slippage: 1000,
                 src_decimals: 18,
                 dest_decimals: 18,
                 price_route: price_response.price_route_raw,
@@ -443,8 +459,8 @@ mod tests {
                 dest_token,
                 trade_amount: TradeAmount::Buy {
                     dest_amount: price_response.dest_amount,
+                    slippage: 1000,
                 },
-                slippage: 1000,
                 src_decimals: 18,
                 dest_decimals: 18,
                 price_route: price_response.price_route_raw,
@@ -750,8 +766,8 @@ mod tests {
             dest_token,
             trade_amount: TradeAmount::Sell {
                 src_amount: price_response.src_amount,
+                slippage: 1000, // 10%
             },
-            slippage: 1000, // 10%
             src_decimals: 18,
             dest_decimals: 18,
             price_route: price_response.price_route_raw,
@@ -769,8 +785,8 @@ mod tests {
                 dest_token: H160([2; 20]),
                 trade_amount: TradeAmount::Sell {
                     src_amount: 1337.into(),
+                    slippage: 250,
                 },
-                slippage: 250,
                 src_decimals: 18,
                 dest_decimals: 18,
                 price_route: Value::Null,

--- a/crates/shared/src/trade_finding/paraswap.rs
+++ b/crates/shared/src/trade_finding/paraswap.rs
@@ -113,12 +113,13 @@ impl Inner {
             trade_amount: match query.kind {
                 OrderKind::Buy => TradeAmount::Buy {
                     dest_amount: query.in_amount,
+                    slippage: Self::DEFAULT_SLIPPAGE,
                 },
                 OrderKind::Sell => TradeAmount::Sell {
                     src_amount: query.in_amount,
+                    slippage: Self::DEFAULT_SLIPPAGE,
                 },
             },
-            slippage: Self::DEFAULT_SLIPPAGE,
             src_decimals: decimals(&quote.tokens, &query.sell_token)?,
             dest_decimals: decimals(&quote.tokens, &query.buy_token)?,
             price_route: quote.price.price_route_raw.take(),


### PR DESCRIPTION
Follow up to #600 

The ParaSwap API only accepts integer BPS slippage values. While this is typically precise enough, now that we started capping slippage tolerance to some absolute value, it can be that the adjusted relative slippage ends up less than a basis point for very large orders (see description in #600).

This PR changes the ParaSwap solver to no longer specify slippage when building transactions with the API, but instead specify exact amounts. This allows us to apply more precise and sub-BPS relative slippage amounts to trades.

### Test Plan

Adjusted test to verify slippage is applied in correct direction in the ParaSwap solver. You can also run the existing manual ParaSwap API tests to verify things are working:
```
% cargo test -- --ignored solve_order_on_paraswap paraswap_api::tests::test_api_e2e_sell paraswap::tests::real_trade paraswap::tests::real_estimate
    Finished test [unoptimized + debuginfo] target(s) in 0.21s
...
     Running unittests src/lib.rs (target/debug/deps/shared-7b91e13f0dbd22f7)

running 3 tests
test price_estimation::paraswap::tests::real_estimate ... ok
test paraswap_api::tests::test_api_e2e_sell ... ok
test trade_finding::paraswap::tests::real_trade ... ok

test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 360 filtered out; finished in 2.33s

     Running unittests src/lib.rs (target/debug/deps/solver-897adbf29f9ea4e6)

running 1 test
test solver::paraswap_solver::tests::solve_order_on_paraswap ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 176 filtered out; finished in 2.04s
...
```
