### PR TITLE
Remove Clap ArgGroup Workaround

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -44,7 +44,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "chrono",
- "clap 4.0.4",
+ "clap 4.0.8",
  "global-metrics",
  "model",
  "primitive-types",
@@ -173,7 +173,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "chrono",
- "clap 4.0.4",
+ "clap 4.0.8",
  "contracts",
  "database",
  "ethcontract",
@@ -368,9 +368,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.0.4"
+version = "4.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f78ad8e84aa8e8aa3e821857be40eb4b925ff232de430d4dd2ae6aa058cbd92"
+checksum = "5840cd9093aabeabf7fd932754c435b7674520fc3ddc935c397837050f0f1e4b"
 dependencies = [
  "atty",
  "bitflags",
@@ -383,9 +383,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.0.1"
+version = "4.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca689d7434ce44517a12a89456b2be4d1ea1cafcd8f581978c03d45f5a5c12a7"
+checksum = "92289ffc6fb4a85d85c246ddb874c05a87a2e540fb6ad52f7ca07c8c1e1840b1"
 dependencies = [
  "heck",
  "proc-macro-error",
@@ -822,7 +822,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
- "clap 4.0.4",
+ "clap 4.0.8",
  "contracts",
  "ethcontract",
  "futures",
@@ -1705,9 +1705,9 @@ dependencies = [
 
 [[package]]
 name = "lru"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "936d98d2ddd79c18641c6709e7bb09981449694e402d1a0f0f657ea8d61f4a51"
+checksum = "b6e8aaa3f231bb4bd57b84b2d5dc3ae7f350265df8aa96492e0bc394a1571909"
 dependencies = [
  "hashbrown",
 ]
@@ -2069,7 +2069,7 @@ dependencies = [
  "bigdecimal",
  "cached",
  "chrono",
- "clap 4.0.4",
+ "clap 4.0.8",
  "contracts",
  "database",
  "ethcontract",
@@ -2844,7 +2844,7 @@ dependencies = [
  "atty",
  "cached",
  "chrono",
- "clap 4.0.4",
+ "clap 4.0.8",
  "contracts",
  "database",
  "derivative",
@@ -2906,9 +2906,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fd0db749597d91ff862fd1d55ea87f7855a744a8425a64695b6fca237d1dad1"
+checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
 
 [[package]]
 name = "socket2"
@@ -2927,7 +2927,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "chrono",
- "clap 4.0.4",
+ "clap 4.0.8",
  "contracts",
  "derivative",
  "ethcontract",

--- a/crates/shared/src/arguments.rs
+++ b/crates/shared/src/arguments.rs
@@ -106,11 +106,9 @@ pub struct OrderQuotingArguments {
     pub cow_fee_factors: Option<SubsidyTiers>,
 }
 
-// Temporary workaround for <https://github.com/clap-rs/clap/issues/4279>
-pub type Arguments = SharedArguments;
-
 #[derive(clap::Parser)]
-pub struct SharedArguments {
+#[group(skip)]
+pub struct Arguments {
     #[clap(
         long,
         env,

--- a/crates/shared/src/bad_token/token_owner_finder.rs
+++ b/crates/shared/src/bad_token/token_owner_finder.rs
@@ -42,12 +42,10 @@ pub trait TokenOwnerFinding: Send + Sync {
     async fn find_owner(&self, token: H160, min_balance: U256) -> Result<Option<(H160, U256)>>;
 }
 
-// Temporary workaround for <https://github.com/clap-rs/clap/issues/4279>
-pub type Arguments = TokenOwnerFinderArguments;
-
 /// Arguments related to the token owner finder.
 #[derive(clap::Parser)]
-pub struct TokenOwnerFinderArguments {
+#[group(skip)]
+pub struct Arguments {
     /// The token owner finding strategies to use.
     #[clap(long, env, use_value_delimiter = true, value_enum)]
     pub token_owner_finders: Option<Vec<TokenOwnerFindingStrategy>>,

--- a/crates/shared/src/http_client.rs
+++ b/crates/shared/src/http_client.rs
@@ -52,12 +52,10 @@ impl Default for HttpClientFactory {
     }
 }
 
-// Temporary workaround for <https://github.com/clap-rs/clap/issues/4279>
-pub type Arguments = HttpClientArguments;
-
 /// Command line arguments for the common HTTP factory.
 #[derive(clap::Parser)]
-pub struct HttpClientArguments {
+#[group(skip)]
+pub struct Arguments {
     /// Default timeout in seconds for http requests.
     #[clap(
         long,

--- a/crates/solver/src/liquidity/slippage.rs
+++ b/crates/solver/src/liquidity/slippage.rs
@@ -19,12 +19,10 @@ use std::{
     str::FromStr,
 };
 
-// Temporary workaround for <https://github.com/clap-rs/clap/issues/4279>
-pub type Arguments = SlippageArguments;
-
 /// Slippage configuration command line arguments.
 #[derive(Debug, Parser)]
-pub struct SlippageArguments {
+#[group(skip)]
+pub struct Arguments {
     /// The relative slippage tolerance to apply to on-chain swaps. This flag
     /// expects a comma-separated list of relative slippage values in basis
     /// points per solver. If a solver is not included, it will use the default


### PR DESCRIPTION
When upgrading to `clap` version 4, the new auto-`ArgGroup` feature caused some issues with how we do command line arguments.

Specifically, `clap`'s `derive(Parser)` was creating `ArgGroups` automatically for every `Arguments` type. The name of the group was the struct name, meaning that when we flattened multiple `Arguments` together, the group names would collide. The work-around we used was to rename the structs (I also added a type alias to keep the work-around local to the individual argument types).

Now, `clap` added a `group(skip)` that we can use for our "flattened" `Arguments` making the work-around no longer needed.

### Test Plan

Make sure the executables run:
```
% cargo run -p alerter -- --help
...
% cargo run -p autopilot -- --help
...
% cargo run -p driver -- --help
...
% cargo run -p orderbook -- --help
...
% cargo run -p solver -- --help
...
```
