### PR TITLE
Store solver competition info in more cases

### DIFF
--- a/crates/database/src/solver_competition.rs
+++ b/crates/database/src/solver_competition.rs
@@ -11,7 +11,7 @@ pub async fn save(
 INSERT INTO solver_competitions (id, json, tx_hash)
 VALUES ($1, $2, $3)
 ON CONFLICT (id) DO UPDATE
-SET json = EXCLUDED.json, tx_hash = EXCLUDEd.tx_hash
+SET json = EXCLUDED.json, tx_hash = EXCLUDED.tx_hash
     ;"#;
     sqlx::query(QUERY)
         .bind(id)

--- a/crates/database/src/solver_competition.rs
+++ b/crates/database/src/solver_competition.rs
@@ -10,6 +10,8 @@ pub async fn save(
     const QUERY: &str = r#"
 INSERT INTO solver_competitions (id, json, tx_hash)
 VALUES ($1, $2, $3)
+ON CONFLICT (id) DO UPDATE
+SET json = EXCLUDED.json, tx_hash = EXCLUDEd.tx_hash
     ;"#;
     sqlx::query(QUERY)
         .bind(id)
@@ -90,5 +92,24 @@ mod tests {
             .await
             .unwrap();
         assert!(not_found.is_none());
+    }
+
+    #[tokio::test]
+    #[ignore]
+    async fn postgres_can_overwrite() {
+        let mut db = PgConnection::connect("postgresql://").await.unwrap();
+        let mut db = db.begin().await.unwrap();
+        crate::clear_DANGER_(&mut db).await.unwrap();
+
+        let value = JsonValue::Bool(true);
+        save(&mut db, 0, &value, None).await.unwrap();
+        let value_ = load_by_id(&mut db, 0).await.unwrap().unwrap();
+        assert_eq!(value, value_);
+
+        // overwrite id
+        let value = JsonValue::Bool(false);
+        save(&mut db, 0, &value, None).await.unwrap();
+        let value_ = load_by_id(&mut db, 0).await.unwrap().unwrap();
+        assert_eq!(value, value_);
     }
 }

--- a/crates/e2e/tests/e2e/services.rs
+++ b/crates/e2e/tests/e2e/services.rs
@@ -140,7 +140,7 @@ pub fn create_orderbook_api() -> OrderBookApi {
     OrderBookApi::new(
         reqwest::Url::from_str(API_HOST).unwrap(),
         Client::new(),
-        None,
+        Some("".to_string()),
     )
 }
 

--- a/crates/solver/src/driver.rs
+++ b/crates/solver/src/driver.rs
@@ -426,7 +426,7 @@ impl Driver {
     async fn send_solver_competition(&self, body: &SolverCompetition) {
         match self.api.send_solver_competition(body).await {
             Ok(()) => tracing::debug!("stored solver competition"),
-            Err(err) => tracing::warn!(?err, "failed to send solver competition"),
+            Err(err) => tracing::error!(?err, "failed to send solver competition"),
         }
     }
 }

--- a/crates/solver/src/driver.rs
+++ b/crates/solver/src/driver.rs
@@ -424,6 +424,10 @@ impl Driver {
     }
 
     async fn send_solver_competition(&self, body: &SolverCompetition) {
+        // For example shadow solver shouldn't store competition info.
+        if !self.api.is_authenticated() {
+            return;
+        }
         match self.api.send_solver_competition(body).await {
             Ok(()) => tracing::debug!("stored solver competition"),
             Err(err) => tracing::error!(?err, "failed to send solver competition"),

--- a/crates/solver/src/driver.rs
+++ b/crates/solver/src/driver.rs
@@ -360,6 +360,11 @@ impl Driver {
                 winning_settlement
             );
 
+            // At this point we know that we are going to attempt to settle on chain. We store the
+            // competition info immediately in case we don't find the mined transaction hash later
+            // for example because the driver got restarted. If we get a hash then we store the
+            // competition info again this time including the hash.
+            self.send_solver_competition(&solver_competition).await;
             self.metrics
                 .complete_runloop_until_transaction(start.elapsed());
             match submit_settlement(
@@ -381,6 +386,7 @@ impl Driver {
                 }
                 _ => (),
             }
+            self.send_solver_competition(&solver_competition).await;
 
             self.logger.report_on_batch(
                 &(winning_solver, winning_settlement),
@@ -389,7 +395,6 @@ impl Driver {
                     .map(|(solver, settlement, _)| (solver, settlement))
                     .collect(),
             );
-            self.send_solver_competition(solver_competition).await;
         }
         // Happens after settlement submission so that we do not delay it.
         self.logger.report_simulation_errors(
@@ -418,8 +423,8 @@ impl Driver {
         id
     }
 
-    async fn send_solver_competition(&self, body: SolverCompetition) {
-        match self.api.send_solver_competition(&body).await {
+    async fn send_solver_competition(&self, body: &SolverCompetition) {
+        match self.api.send_solver_competition(body).await {
             Ok(()) => tracing::debug!("stored solver competition"),
             Err(err) => tracing::warn!(?err, "failed to send solver competition"),
         }

--- a/crates/solver/src/main.rs
+++ b/crates/solver/src/main.rs
@@ -406,7 +406,7 @@ async fn main() {
     let api = OrderBookApi::new(
         args.orderbook_url,
         http_factory.create(),
-        args.shared.solver_competition_auth,
+        args.shared.solver_competition_auth.clone(),
     );
 
     let mut driver = Driver::new(

--- a/crates/solver/src/orderbook.rs
+++ b/crates/solver/src/orderbook.rs
@@ -29,6 +29,11 @@ impl OrderBookApi {
         Ok(auction)
     }
 
+    /// If this is false then sending solver competition most likely fails.
+    pub fn is_authenticated(&self) -> bool {
+        self.competition_auth.is_some()
+    }
+
     pub async fn send_solver_competition(&self, body: &SolverCompetition) -> Result<()> {
         let url = self.base.join("api/v1/solver_competition")?;
         let mut request = self.client.post(url);


### PR DESCRIPTION
The advantage of this is that we still have the competition info in cases where we don't observe a transaction hash (for example because driver is restarted or node doesn't see tx in time).

We originally did it this way but stopped when we had the auto incrementing competition id. Now that we have a proper auction id there is no reason to not go back to it.

### Test Plan

CI