### PR TITLE
Ethflow orders in get_user_order()

### DIFF
--- a/crates/database/src/onchain_broadcasted_orders.rs
+++ b/crates/database/src/onchain_broadcasted_orders.rs
@@ -45,7 +45,7 @@ pub async fn append(
     Ok(())
 }
 
-async fn insert_onchain_order(
+pub async fn insert_onchain_order(
     ex: &mut PgConnection,
     index: &EventIndex,
     event: &OnchainOrderPlacement,

--- a/crates/database/src/orders.rs
+++ b/crates/database/src/orders.rs
@@ -833,11 +833,11 @@ mod tests {
             }
         }
 
-        let now = Utc::now();
+        let now = std::time::Instant::now();
         let _result = user_orders(&mut db, &ByteArray([2u8; 20]), 10, Some(10)).await;
-        let time_diff = Utc::now() - now;
-        println!("{:?}", time_diff);
-        assert!(time_diff < chrono::Duration::seconds(1));
+        let time_diff = now.elapsed();
+        println!("{:?}", elapsed);
+        assert!(elapsed < std::time::Duration::from_secs(1));
     }
 
     #[tokio::test]

--- a/crates/database/src/orders.rs
+++ b/crates/database/src/orders.rs
@@ -788,10 +788,11 @@ mod tests {
         assert!(get_order(&mut db, 2).await.is_some());
     }
 
-    // This test is only for the PR. Can be removed before merging...
     #[tokio::test]
     #[ignore]
     async fn postgres_user_orders_performance() {
+        //The following test can be used as performanc etest, if the values for
+        // i and j are increased ->i=240 and j=1000 are reasonable values
         let mut db = PgConnection::connect("postgresql://").await.unwrap();
         let mut db = db.begin().await.unwrap();
         crate::clear_DANGER_(&mut db).await.unwrap();
@@ -812,12 +813,11 @@ mod tests {
                 .await
         }
 
-        // fill the database
-        for i in 0..240u32 {
+        for i in 0..2u32 {
             let mut owner_bytes = i.to_ne_bytes().to_vec();
             owner_bytes.append(&mut vec![0; 20 - owner_bytes.len()]);
             let owner = ByteArray(owner_bytes.try_into().unwrap());
-            for j in 0..1000u32 {
+            for j in 0..1u32 {
                 let mut i_as_bytes = i.to_ne_bytes().to_vec();
                 let mut j_as_bytes = j.to_ne_bytes().to_vec();
                 let mut order_uid_info = vec![0; 56 - i_as_bytes.len() - j_as_bytes.len()];
@@ -834,8 +834,7 @@ mod tests {
         }
 
         let now = std::time::Instant::now();
-        let _result = user_orders(&mut db, &ByteArray([2u8; 20]), 10, Some(10)).await;
-        let time_diff = now.elapsed();
+        let elapsed = now.elapsed();
         println!("{:?}", elapsed);
         assert!(elapsed < std::time::Duration::from_secs(1));
     }

--- a/crates/database/src/orders.rs
+++ b/crates/database/src/orders.rs
@@ -461,6 +461,7 @@ mod tests {
         byte_array::ByteArray,
         ethflow_orders::{insert_ethflow_order, EthOrderPlacement},
         events::{Event, EventIndex, Invalidation, PreSignature, Settlement, Trade},
+        onchain_broadcasted_orders::{insert_onchain_order, OnchainOrderPlacement},
         PgTransaction,
     };
     use bigdecimal::num_bigint::{BigInt, ToBigInt};

--- a/database/sql/V032__create_index_order_owner.sql
+++ b/database/sql/V032__create_index_order_owner.sql
@@ -1,0 +1,3 @@
+-- replace index for effective order searching
+DROP INDEX IF EXISTS public.user_order_creation_timestamp
+CREATE INDEX order_owner ON orders USING HASH (owner);

--- a/database/sql/V032__create_index_order_owner.sql
+++ b/database/sql/V032__create_index_order_owner.sql
@@ -1,3 +1,0 @@
--- replace index for effective order searching
-DROP INDEX IF EXISTS public.user_order_creation_timestamp
-CREATE INDEX order_owner ON orders USING HASH (owner);

--- a/database/sql/V034__create_index_order_owner.sql
+++ b/database/sql/V034__create_index_order_owner.sql
@@ -1,4 +1,4 @@
 -- replace index for effective order searching
-DROP INDEX public.user_order_creation_timestamp;
+DROP INDEX user_order_creation_timestamp;
 
-CREATE INDEX order_owner ON public.orders USING HASH (owner);
+CREATE INDEX order_owner ON orders USING HASH (owner);

--- a/database/sql/V034__create_index_order_owner.sql
+++ b/database/sql/V034__create_index_order_owner.sql
@@ -1,0 +1,4 @@
+-- replace index for effective order searching
+DROP INDEX public.user_order_creation_timestamp;
+
+CREATE INDEX order_owner ON public.orders USING HASH (owner);


### PR DESCRIPTION
Since my previous [PR](https://github.com/cowprotocol/services/pull/583/files), the query get_user_order is no longer performant. Since the index `user_order_creation_timestamp` is a combination of user and creation_timestamp, my left outer join + additional where condition lowered the performance of the query significantly.

I see two ways to fix it:
- serve ethflow-orders and normal orders via different API requests and combine them in the front-end
- have non-optimized queries in the backend, hoping that they are still fast enough
(kudos to @vkgnosis who foresaw the challenge already 3 months ago during a design discussion. Unfortunately, I forgot about it)


This PR implements the second alternative:

I think if we have an index on the 'owner' instead the index on the combination of owner and creation_timestamp, then I guess our queries are still sufficiently fast, as the number of orders per users are not so huge and can be sorted by the creation_timestamp in reasonable time. Espeically for most non-bot users. We can combine this approach with limiting the amount of orders per user.
I don't know, but I really hope that its still fast enough. I used the test in the code and got the following results:
```
I created 1 users with  each 1000 orders and the test query within the code took `Duration { secs: 0, nanos: 6100000 }`
I created 64 users with  each 1000 orders and the test query within the code took  'Duration { secs: 0, nanos: 5461000 }'
I created 128 users with each 1000 orders and the test query within the code took `Duration { secs: 0, nanos: 4977000 }`
I created 240 users with  each 1000 orders and the test query within the code took `Duration { secs: 0, nanos: 5079000 }`
```
=>We can see that the performance is not really impacted by more users. Assuming, we will never have more than 1000 orders per user, the query should be still performant enough.


For reference, the indexing over owner+timstamp was introduced here: 
https://github.com/gnosis/gp-v2-services/pull/1020

For a complete overview, here is the combined log of the orders table:
```
-- Table: public.orders

-- DROP TABLE IF EXISTS public.orders;

CREATE TABLE IF NOT EXISTS public.orders
(
    uid bytea NOT NULL,
    owner bytea NOT NULL,
    creation_timestamp timestamp with time zone NOT NULL,
    sell_token bytea NOT NULL,
    buy_token bytea NOT NULL,
    sell_amount numeric(78,0) NOT NULL,
    buy_amount numeric(78,0) NOT NULL,
    valid_to bigint NOT NULL,
    fee_amount numeric(78,0) NOT NULL,
    kind orderkind NOT NULL,
    partially_fillable boolean NOT NULL,
    signature bytea NOT NULL,
    cancellation_timestamp timestamp with time zone,
    receiver bytea,
    app_data bytea NOT NULL,
    signing_scheme signingscheme NOT NULL,
    settlement_contract bytea NOT NULL,
    sell_token_balance selltokensource NOT NULL,
    buy_token_balance buytokendestination NOT NULL,
    full_fee_amount numeric(78,0) NOT NULL,
    is_liquidity_order boolean NOT NULL,
    CONSTRAINT orders_pkey PRIMARY KEY (uid)
)

TABLESPACE pg_default;

ALTER TABLE IF EXISTS public.orders
    OWNER to mainnet_admin;

REVOKE ALL ON TABLE public.orders FROM readonly;

GRANT SELECT ON TABLE public.orders TO gp_readonly;

GRANT ALL ON TABLE public.orders TO mainnet_admin;

GRANT SELECT ON TABLE public.orders TO readonly;
-- Index: order_creation_timestamp

-- DROP INDEX IF EXISTS public.order_creation_timestamp;

CREATE INDEX IF NOT EXISTS order_creation_timestamp
    ON public.orders USING btree
    (creation_timestamp ASC NULLS LAST)
    TABLESPACE pg_default;
-- Index: order_valid_to

-- DROP INDEX IF EXISTS public.order_valid_to;

CREATE INDEX IF NOT EXISTS order_valid_to
    ON public.orders USING btree
    (valid_to ASC NULLS LAST)
    TABLESPACE pg_default;
-- Index: user_order_creation_timestamp

-- DROP INDEX IF EXISTS public.user_order_creation_timestamp;

CREATE INDEX IF NOT EXISTS user_order_creation_timestamp
    ON public.orders USING btree
    (owner ASC NULLS LAST, creation_timestamp DESC NULLS FIRST)
    TABLESPACE pg_default;
-- Index: user_valid_to

-- DROP INDEX IF EXISTS public.user_valid_to;

CREATE INDEX IF NOT EXISTS user_valid_to
    ON public.orders USING btree
    (valid_to ASC NULLS LAST)
    TABLESPACE pg_default;
-- Index: version_idx

-- DROP INDEX IF EXISTS public.version_idx;

CREATE INDEX IF NOT EXISTS version_idx
    ON public.orders USING btree
    (settlement_contract ASC NULLS LAST)
    TABLESPACE pg_default;
```

### Test Plan