### PR TITLE
Estimate cost of interaction when quoting price estimates

### DIFF
--- a/crates/shared/src/http_solver/model.rs
+++ b/crates/shared/src/http_solver/model.rs
@@ -148,6 +148,7 @@ pub struct InteractionData {
     /// `AMM -> GPv2Settlement`
     pub outputs: Vec<TokenAmount>,
     pub exec_plan: Option<ExecutionPlan>,
+    pub cost: Option<TokenAmount>,
 }
 
 #[serde_as]
@@ -762,7 +763,11 @@ mod tests {
                                 "amount": "3000"
                             }
                         ],
-                        "exec_plan": "internal"
+                        "exec_plan": "internal",
+                        "cost": {
+                            "amount": "1",
+                            "token": "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
+                        }
                     }
                 "#,
             )
@@ -786,6 +791,10 @@ mod tests {
                     }
                 ],
                 exec_plan: Some(ExecutionPlan::Internal),
+                cost: Some(TokenAmount {
+                    amount: 1.into(),
+                    token: addr!("eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee")
+                })
             },
         );
     }

--- a/crates/shared/src/price_estimation/http.rs
+++ b/crates/shared/src/price_estimation/http.rs
@@ -203,6 +203,9 @@ impl HttpPriceEstimator {
         for amm in settlement.amms.values() {
             cost += self.extract_cost(&amm.cost)? * amm.execution.len();
         }
+        for interaction in settlement.interaction_data {
+            cost += self.extract_cost(&interaction.cost)?;
+        }
         let gas = (cost / gas_price).as_u64()
             + INITIALIZATION_COST // Call into contract
             + SETTLEMENT // overhead for entering the `settle()` function

--- a/crates/solver/src/solver/http_solver/settlement.rs
+++ b/crates/solver/src/solver/http_solver/settlement.rs
@@ -926,6 +926,7 @@ mod tests {
                 sequence: 1u32,
                 position: 1u32,
             })),
+            cost: None,
         }];
         let orders = vec![ExecutedLimitOrder {
             order: Default::default(),


### PR DESCRIPTION
Adds cost to the interaction_data struct so that the price estimator can account for complicated settlements with private liquidity (ie. Yearn's solver) accordingly.

### Test Plan

I was surprised this code isn't unit tested. Will look into what it would take to add a test suite, but wanted to get the logic change out for review first.

### Release notes

Non breaking change to the solver interface. @harisang would you be able to update the docs?
