### PR TITLE
Set solver rewards in auction and http solver model

### DIFF
--- a/crates/model/src/auction.rs
+++ b/crates/model/src/auction.rs
@@ -1,6 +1,9 @@
 //! Module defining a batch auction.
 
-use crate::{order::Order, u256_decimal::DecimalU256};
+use crate::{
+    order::{Order, OrderUid},
+    u256_decimal::DecimalU256,
+};
 use primitive_types::{H160, U256};
 use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
@@ -43,12 +46,17 @@ pub struct Auction {
     /// The reference prices for all traded tokens in the auction.
     #[serde_as(as = "BTreeMap<_, DecimalU256>")]
     pub prices: BTreeMap<H160, U256>,
+
+    /// CIP-14 risk adjusted solver rewards
+    ///
+    /// Some orders like liquidity orders do not have associated rewards.
+    pub rewards: BTreeMap<OrderUid, f64>,
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::order::{OrderMetadata, OrderUid};
+    use crate::order::OrderMetadata;
     use maplit::btreemap;
     use serde_json::json;
 
@@ -69,6 +77,10 @@ mod tests {
                 H160([2; 20]) => U256::from(2),
                 H160([1; 20]) => U256::from(1),
             },
+            rewards: btreemap! {
+                OrderUid([1; 56]) => 1.,
+                OrderUid([2; 56]) => 2.,
+            },
         };
         let auction = AuctionWithId { id: 0, auction };
 
@@ -85,6 +97,10 @@ mod tests {
                 "prices": {
                     "0x0101010101010101010101010101010101010101": "1",
                     "0x0202020202020202020202020202020202020202": "2",
+                },
+                "rewards": {
+                    "0x0101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101": 1.0,
+                    "0x0202020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202": 2.0,
                 },
             }),
         );

--- a/crates/model/src/order.rs
+++ b/crates/model/src/order.rs
@@ -429,7 +429,7 @@ impl Default for OrderMetadata {
 }
 
 // uid as 56 bytes: 32 for orderDigest, 20 for ownerAddress and 4 for validTo
-#[derive(Clone, Copy, Eq, Hash, PartialEq)]
+#[derive(Clone, Copy, Eq, Hash, PartialEq, PartialOrd, Ord)]
 pub struct OrderUid(pub [u8; 56]);
 
 impl OrderUid {

--- a/crates/shared/src/http_solver/model.rs
+++ b/crates/shared/src/http_solver/model.rs
@@ -43,6 +43,8 @@ pub struct OrderModel {
     /// usual user provided orders because those can be batched together and it's only relevant if
     /// the pre- and post conditions are met after the complete batch got executed.
     pub has_atomic_execution: bool,
+    /// CIP-14 risk adjusted solver reward
+    pub reward: f64,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -408,6 +410,7 @@ mod tests {
             is_liquidity_order: false,
             mandatory: false,
             has_atomic_execution: false,
+            reward: 3.,
         };
         let constant_product_pool_model = AmmModel {
             parameters: AmmParameters::ConstantProduct(ConstantProductPoolParameters {
@@ -555,7 +558,8 @@ mod tests {
                 "token": "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
               },
               "mandatory": false,
-              "has_atomic_execution": false
+              "has_atomic_execution": false,
+              "reward": 3.0
             },
           },
           "amms": {

--- a/crates/shared/src/price_estimation/http.rs
+++ b/crates/shared/src/price_estimation/http.rs
@@ -111,6 +111,8 @@ impl HttpPriceEstimator {
                 is_liquidity_order: false,
                 mandatory: true,
                 has_atomic_execution: false,
+                // TODO: is it possible to set a more accurate reward?
+                reward: 35.,
             },
         };
 

--- a/crates/solver/src/liquidity.rs
+++ b/crates/solver/src/liquidity.rs
@@ -100,6 +100,9 @@ pub struct LimitOrder {
     #[cfg_attr(test, derivative(PartialEq = "ignore"))]
     pub settlement_handling: Arc<dyn SettlementHandling<Self>>,
     pub exchange: Exchange,
+    // TODO: decide how reward works for partially fillable orders
+    /// CIP-14 risk adjusted solver reward
+    pub reward: f64,
 }
 
 impl std::fmt::Debug for LimitOrder {
@@ -151,6 +154,7 @@ impl Default for LimitOrder {
             is_liquidity_order: false,
             id: Default::default(),
             exchange: Exchange::GnosisProtocol,
+            reward: Default::default(),
         }
     }
 }

--- a/crates/solver/src/liquidity/order_converter.rs
+++ b/crates/solver/src/liquidity/order_converter.rs
@@ -60,6 +60,8 @@ impl OrderConverter {
                 is_liquidity_order,
             }),
             exchange: Exchange::GnosisProtocol,
+            // TODO: It would be nicer to set this here too but we need #529 first.
+            reward: 0.,
         })
     }
 }

--- a/crates/solver/src/liquidity/zeroex.rs
+++ b/crates/solver/src/liquidity/zeroex.rs
@@ -127,6 +127,7 @@ impl ZeroExLiquidity {
                 allowances,
             }),
             exchange: Exchange::ZeroEx,
+            reward: 0.,
         };
         Some(Liquidity::LimitOrder(limit_order))
     }

--- a/crates/solver/src/solver/http_solver.rs
+++ b/crates/solver/src/solver/http_solver.rs
@@ -277,6 +277,7 @@ fn order_models(
                     is_liquidity_order: order.is_liquidity_order,
                     mandatory: false,
                     has_atomic_execution: !matches!(order.exchange, Exchange::GnosisProtocol),
+                    reward: order.reward,
                 },
             ))
         })


### PR DESCRIPTION
part of https://github.com/cowprotocol/services/issues/606

This would have been nicer with https://github.com/cowprotocol/services/pull/529 but I decided to do it this way first so we get this out quicker. I plan on doing 529 later at which point the rewards in the auction can be passed directly in the order vector instead of being an separate map.

### Test Plan

CI
