### PR TITLE
Pre_interactions: db operations  

### DIFF
--- a/crates/autopilot/src/database/auction.rs
+++ b/crates/autopilot/src/database/auction.rs
@@ -27,7 +27,7 @@ pub struct SolvableOrders {
 use chrono::{DateTime, Utc};
 use model::quote::QuoteId;
 use shared::{
-    db_order_conversions::order_kind_from,
+    db_order_conversions::{extract_pre_interactions, order_kind_from},
     event_storing_helpers::{create_db_search_parameters, create_quote_row},
     order_quoting::{QuoteData, QuoteSearchParameters, QuoteStoring},
 };
@@ -118,6 +118,7 @@ impl Postgres {
 
 fn full_order_into_model_order(order: database::orders::FullOrder) -> Result<Order> {
     let status = OrderStatus::Open;
+    let pre_interactions = extract_pre_interactions(&order)?;
     let metadata = OrderMetadata {
         creation_date: order.creation_timestamp,
         owner: H160(order.owner.0),
@@ -166,6 +167,7 @@ fn full_order_into_model_order(order: database::orders::FullOrder) -> Result<Ord
         metadata,
         data,
         signature,
+        pre_interactions,
     })
 }
 

--- a/crates/model/src/interaction.rs
+++ b/crates/model/src/interaction.rs
@@ -1,0 +1,10 @@
+use primitive_types::{H160, U256};
+use serde::{Deserialize, Serialize};
+
+#[derive(Eq, PartialEq, Clone, Debug, Hash, Default, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct InteractionData {
+    pub to: H160,
+    pub value: U256,
+    pub call_data: Vec<u8>,
+}

--- a/crates/model/src/lib.rs
+++ b/crates/model/src/lib.rs
@@ -3,6 +3,7 @@
 pub mod app_id;
 pub mod auction;
 pub mod bytes_hex;
+pub mod interaction;
 pub mod order;
 pub mod quote;
 pub mod ratio_as_decimal;

--- a/crates/model/src/order.rs
+++ b/crates/model/src/order.rs
@@ -2,6 +2,7 @@
 
 use crate::{
     app_id::AppId,
+    interaction::InteractionData,
     quote::QuoteId,
     signature::{EcdsaSignature, EcdsaSigningScheme, Signature, VerificationError},
     u256_decimal::{self, DecimalU256},
@@ -40,6 +41,7 @@ pub struct Order {
     pub data: OrderData,
     #[serde(flatten)]
     pub signature: Signature,
+    pub pre_interactions: Vec<InteractionData>,
 }
 
 #[derive(Eq, PartialEq, Clone, Copy, Debug, Deserialize, Serialize, Hash)]
@@ -73,6 +75,9 @@ impl Order {
             },
             signature: order.signature.clone(),
             data: order.data,
+            // Currenlty, we only support pre_interactions created
+            // via the on-chain order parsing
+            pre_interactions: Vec::new(),
         })
     }
 
@@ -674,6 +679,7 @@ mod tests {
             "sellTokenBalance": "external",
             "buyTokenBalance": "internal",
             "isLiquidityOrder": false,
+            "preInteractions": [],
         });
         let signing_scheme = EcdsaSigningScheme::Eip712;
         let expected = Order {
@@ -720,6 +726,7 @@ mod tests {
                 .unwrap(),
             }
             .to_signature(signing_scheme),
+            pre_interactions: Vec::new(),
         };
         let deserialized: Order = serde_json::from_value(value.clone()).unwrap();
         assert_eq!(deserialized, expected);

--- a/crates/orderbook/src/database/orders.rs
+++ b/crates/orderbook/src/database/orders.rs
@@ -17,8 +17,9 @@ use number_conversions::{big_decimal_to_big_uint, big_decimal_to_u256, u256_to_b
 use primitive_types::H160;
 use shared::{
     db_order_conversions::{
-        buy_token_destination_from, buy_token_destination_into, order_kind_from, order_kind_into,
-        sell_token_source_from, sell_token_source_into, signing_scheme_from, signing_scheme_into,
+        buy_token_destination_from, buy_token_destination_into, extract_pre_interactions,
+        order_kind_from, order_kind_into, sell_token_source_from, sell_token_source_into,
+        signing_scheme_from, signing_scheme_into,
     },
     order_quoting::Quote,
 };
@@ -275,6 +276,7 @@ fn calculate_status(order: &FullOrder) -> OrderStatus {
 
 fn full_order_into_model_order(order: FullOrder) -> Result<Order> {
     let status = calculate_status(&order);
+    let pre_interactions = extract_pre_interactions(&order)?;
     let metadata = OrderMetadata {
         creation_date: order.creation_timestamp,
         owner: H160(order.owner.0),
@@ -323,6 +325,7 @@ fn full_order_into_model_order(order: FullOrder) -> Result<Order> {
         metadata,
         data,
         signature,
+        pre_interactions,
     })
 }
 
@@ -389,6 +392,9 @@ mod tests {
             buy_token_balance: DbBuyTokenDestination::Internal,
             presignature_pending: false,
             is_liquidity_order: true,
+            pre_interactions_tos: Vec::new(),
+            pre_interactions_values: Vec::new(),
+            pre_interactions_data: Vec::new(),
         };
 
         // Open - sell (filled - 0%)
@@ -683,6 +689,7 @@ mod tests {
                 ..Default::default()
             },
             signature: Signature::default_with(SigningScheme::PreSign),
+            ..Default::default()
         };
         db.insert_order(&order, None).await.unwrap();
 

--- a/crates/orderbook/src/orderbook.rs
+++ b/crates/orderbook/src/orderbook.rs
@@ -345,6 +345,7 @@ mod tests {
                         },
                         data: creation.data,
                         signature: creation.signature,
+                        ..Default::default()
                     },
                     Default::default(),
                 ))

--- a/crates/solver/src/solver/http_solver/settlement.rs
+++ b/crates/solver/src/solver/http_solver/settlement.rs
@@ -258,6 +258,7 @@ fn convert_foreign_liquidity_orders(
                 },
                 data: liquidity.order.data,
                 signature: liquidity.order.signature,
+                pre_interactions: Vec::new(),
             })?;
             Ok(ExecutedLimitOrder {
                 order: converted,
@@ -588,6 +589,7 @@ mod tests {
                             ..Default::default()
                         },
                         signature: Signature::PreSign,
+                        ..Default::default()
                     },
                     sell_token_index: 1,
                     executed_amount: 101.into(),


### PR DESCRIPTION
This PR provides the dp operations for the pre-interactions: inserting and reading of the interactions + reading the interactions for all orders.

Please note that reading the array of pre_interactions in xsql in a type-save way is not easy. I tried to find a better method for quite some time, but I was not successful. If you know a better method, let me know.

### Test Plan

