### PR TITLE
Ethflow: No balance check for ethflow orders

### DIFF
--- a/crates/autopilot/src/lib.rs
+++ b/crates/autopilot/src/lib.rs
@@ -349,6 +349,7 @@ pub async fn main(args: arguments::Arguments) {
         signature_validator.clone(),
         Duration::from_secs(2),
         risk_adjusted_rewards,
+        args.ethflow_contract,
     );
     let block = current_block_stream.borrow().number.unwrap().as_u64();
     solvable_orders_cache

--- a/crates/autopilot/src/solvable_orders.rs
+++ b/crates/autopilot/src/solvable_orders.rs
@@ -60,6 +60,7 @@ pub struct SolvableOrdersCache {
     metrics: &'static Metrics,
     // Optional because reward calculation only makes sense on mainnet. Other networks have 0 rewards.
     reward_calculator: Option<risk_adjusted_rewards::Calculator>,
+    ethflow_contract_address: H160,
 }
 
 type Balances = HashMap<Query, U256>;
@@ -90,6 +91,7 @@ impl SolvableOrdersCache {
         signature_validator: Arc<dyn SignatureValidating>,
         update_interval: Duration,
         reward_calculator: Option<risk_adjusted_rewards::Calculator>,
+        ethflow_contract_address: H160,
     ) -> Arc<Self> {
         let self_ = Arc::new(Self {
             min_order_validity_period,
@@ -110,6 +112,7 @@ impl SolvableOrdersCache {
             signature_validator,
             metrics: Metrics::instance(global_metrics::get_metric_storage_registry()).unwrap(),
             reward_calculator,
+            ethflow_contract_address,
         });
         tokio::task::spawn(update_task(
             Arc::downgrade(&self_),
@@ -160,7 +163,7 @@ impl SolvableOrdersCache {
             new_balances.insert(query, balance);
         }
 
-        let mut orders = solvable_orders(orders, &new_balances);
+        let mut orders = solvable_orders(orders, &new_balances, self.ethflow_contract_address);
         for order in &mut orders {
             let query = Query::from_order(order);
             order.metadata.available_balance = new_balances.get(&query).copied();
@@ -299,7 +302,11 @@ fn new_balances(old_balances: &Balances, orders: &[Order]) -> (HashMap<Query, U2
 // The order book has to make a choice for which orders to include when a user has multiple orders
 // selling the same token but not enough balance for all of them.
 // Assumes balance fetcher is already tracking all balances.
-fn solvable_orders(mut orders: Vec<Order>, balances: &Balances) -> Vec<Order> {
+fn solvable_orders(
+    mut orders: Vec<Order>,
+    balances: &Balances,
+    ethflow_contract: H160,
+) -> Vec<Order> {
     let mut orders_map = HashMap::<Query, Vec<Order>>::new();
     orders.sort_by_key(|order| std::cmp::Reverse(order.metadata.creation_date));
     for order in orders {
@@ -314,6 +321,13 @@ fn solvable_orders(mut orders: Vec<Order>, balances: &Balances) -> Vec<Order> {
             None => continue,
         };
         for order in orders {
+            // For ethflow orders, there is no need to check the balance. The contract
+            // ensures that there will always be sufficient balance, after the wrapAll
+            // pre_interaction has been called.
+            if order.metadata.owner == ethflow_contract {
+                result.push(order);
+                continue;
+            }
             // TODO: This is overly pessimistic for partially filled orders where the needed balance
             // is lower. For partially fillable orders that cannot be fully filled because of the
             // balance we could also give them as much balance as possible instead of skipping. For
@@ -566,12 +580,12 @@ mod tests {
         ];
 
         let balances = hashmap! {Query::from_order(&orders[0]) => U256::from(9)};
-        let orders_ = solvable_orders(orders.clone(), &balances);
+        let orders_ = solvable_orders(orders.clone(), &balances, H160::zero());
         // Second order has lower timestamp so it isn't picked.
         assert_eq!(orders_, orders[..1]);
         orders[1].metadata.creation_date =
             DateTime::from_utc(NaiveDateTime::from_timestamp(3, 0), Utc);
-        let orders_ = solvable_orders(orders.clone(), &balances);
+        let orders_ = solvable_orders(orders.clone(), &balances, H160::zero());
         assert_eq!(orders_, orders[1..]);
     }
 
@@ -883,7 +897,7 @@ mod tests {
 
         let balances = hashmap! {Query::from_order(&orders[0]) => U256::MAX};
         let expected_result = vec![orders[0].clone(), orders[1].clone()];
-        let mut filtered_orders = solvable_orders(orders, &balances);
+        let mut filtered_orders = solvable_orders(orders, &balances, H160::zero());
         // Deal with `solvable_orders()` sorting the orders.
         filtered_orders.sort_by_key(|order| order.metadata.creation_date);
         assert_eq!(expected_result, filtered_orders);

--- a/crates/e2e/tests/e2e/services.rs
+++ b/crates/e2e/tests/e2e/services.rs
@@ -255,6 +255,7 @@ impl OrderbookServices {
             signature_validator.clone(),
             Duration::from_secs(1),
             None,
+            H160::zero(),
         );
         let order_validator = Arc::new(OrderValidator::new(
             Box::new(web3.clone()),


### PR DESCRIPTION
The ethflow contract always enforces that every ethflow order has sufficient balance. Hence, we don't need to check it with the autopilot. 
Note that it's necessary to bypass the check, as otherwise, it might happen that the WETH balance is not sufficient. This is due to the fact, that sometimes first the eth needs to be wrapped as WETH.

Alternative implementation:
We could have also checked that there is sufficient balance, after executing the pre_interactions of an order. This would have been nice since it is more generic. But this would cost us even more time during auction cutting and would put more load on our nodes. Hence, I decided against this implementation.
