### PR TITLE
Align fee with objective value computation in solution competition reporting

### DIFF
--- a/crates/solver/src/driver.rs
+++ b/crates/solver/src/driver.rs
@@ -322,7 +322,7 @@ impl Driver {
                             .unwrap_or(f64::NAN),
                         surplus: rated_settlement.surplus.to_f64().unwrap_or(f64::NAN),
                         fees: rated_settlement
-                            .unscaled_subsidized_fee
+                            .scaled_unsubsidized_fee
                             .to_f64()
                             .unwrap_or(f64::NAN),
                         cost: rated_settlement.gas_estimate.to_f64_lossy()


### PR DESCRIPTION
Currently the values we report in the solution competition endpoint doesn't end up. E.g.: 0xf51ff72d36a8207a73c7f0b44885ad28e54e2f202c784bdeed0a909a7428ee46

```
"objective": {
        "total": 7150641875698944,
        "surplus": 8271014084027250,
        "fees": 12404678571674150,
        "cost": 15526027201486478,
        "gas": 828962
      }
```

`surplus + fees - cost != total`

This is because we record `unscaled_subsidized_fee` but use `scaled_unsubsidized_fee` when evaluating the objective ([code](https://github.com/cowprotocol/services/blob/2cbeac93ea82cf5b4bdba0459e8a37b0c099f1cf/crates/solver/src/driver/solver_settlements.rs#L44)).

I'm not sure if this was originally intended, but if not I'm changing it to make the values match (it has caused confusion for solvers checking the values).