### PR TITLE
Make auction order format change backward compatible

### DIFF
--- a/crates/autopilot/src/database.rs
+++ b/crates/autopilot/src/database.rs
@@ -1,4 +1,4 @@
-mod auction;
+pub mod auction;
 mod events;
 pub mod onchain_order_events;
 mod quotes;

--- a/crates/autopilot/src/risk_adjusted_rewards.rs
+++ b/crates/autopilot/src/risk_adjusted_rewards.rs
@@ -315,7 +315,14 @@ mod tests {
             )),
         };
         let min_valid_to = model::time::now_in_epoch_seconds();
-        let orders = db.solvable_orders(min_valid_to).await.unwrap().orders;
+        let orders = db
+            .solvable_orders(min_valid_to)
+            .await
+            .unwrap()
+            .orders
+            .into_iter()
+            .map(|order| order.1)
+            .collect::<Vec<_>>();
         let results = calc.calculate_many(&orders).await.unwrap();
         assert!(orders.len() == results.len());
         for (order, result) in orders.iter().zip(results) {

--- a/crates/database/src/orders.rs
+++ b/crates/database/src/orders.rs
@@ -265,7 +265,7 @@ AND cancellation_timestamp IS NULL
 }
 
 /// Order with extra information from other tables. Has all the information needed to construct a model::Order.
-#[derive(sqlx::FromRow)]
+#[derive(Clone, sqlx::FromRow)]
 pub struct FullOrder {
     pub uid: OrderUid,
     pub owner: Address,

--- a/crates/driver/src/auction_converter.rs
+++ b/crates/driver/src/auction_converter.rs
@@ -209,6 +209,7 @@ mod tests {
             auction: model::auction::Auction {
                 block: 1,
                 latest_settlement_block: 2,
+                orders_v1: Default::default(),
                 orders: vec![order(1, 2, false), order(2, 3, false), order(1, 3, true)],
                 prices: btreemap! { token(2) => U256::exp10(18), token(3) => U256::exp10(18) },
             },

--- a/crates/model/src/auction.rs
+++ b/crates/model/src/auction.rs
@@ -88,6 +88,16 @@ pub struct Auction {
     pub latest_settlement_block: u64,
 
     /// The solvable orders included in the auction.
+    ///
+    /// v1 is included temporarily for backward compatibility.
+    #[serde(default, rename = "orders")]
+    pub orders_v1: Vec<crate::order::Order>,
+
+    /// The solvable orders included in the auction.
+    ///
+    /// These are the same orders as v1 but the type definition has changed. Some fields have been
+    /// removed and some added.
+    #[serde(default, rename = "orders_v2")]
     pub orders: Vec<Order>,
 
     /// The reference prices for all traded tokens in the auction.
@@ -122,6 +132,7 @@ mod tests {
         let auction = Auction {
             block: 42,
             latest_settlement_block: 40,
+            orders_v1: vec![],
             orders: vec![order(1), order(2)],
             prices: btreemap! {
                 H160([2; 20]) => U256::from(2),
@@ -136,7 +147,8 @@ mod tests {
                 "id": 0,
                 "block": 42,
                 "latestSettlementBlock": 40,
-                "orders": [
+                "orders": [],
+                "orders_v2": [
                     order(1),
                     order(2),
                 ],
@@ -177,6 +189,7 @@ mod tests {
             "sellTokenBalance": "external",
             "buyTokenBalance": "internal",
             "isLiquidityOrder": false,
+            "reward": 2.,
         });
         let signing_scheme = EcdsaSigningScheme::Eip712;
         let expected = Order {

--- a/crates/orderbook/openapi.yml
+++ b/crates/orderbook/openapi.yml
@@ -680,7 +680,7 @@ components:
         but not provided by users when creating orders.
       type: object
       properties:
-        creationTime:
+        creationDate:
           description: Creation time of the order. Encoded as ISO 8601 UTC.
           type: string
           example: "2020-12-03T18:35:18.814523Z"
@@ -732,10 +732,46 @@ components:
         - executedBuyAmount
         - executedFeeAmount
         - invalidated
+    AuctionOrderMetaData:
+      description: |
+        Extra order data included for orders in the auction endpoint.
+      type: object
+      properties:
+        creationDate:
+          description: "see OrderMetaData::creationDate"
+          type: string
+        owner:
+          $ref: "#/components/schemas/Address"
+        UID:
+          $ref: "#/components/schemas/UID"
+        executedAmount:
+          description: "see OrderMetaData::executedAmount"
+          $ref: "#/components/schemas/BigUint"
+        fullFeeAmount:
+          description: "see OrderMetaData::fullFeeAmount"
+          $ref: "#/components/schemas/TokenAmount"
+        isLiquidityOrder:
+          description: "see OrderMetaData::isLiquidityOrder"
+          type: boolean
+        reward:
+          description: "The CIP-14 risk adjusted reward in COW base units."
+          type: number
+      required:
+        - creationDate
+        - owner
+        - UID
+        - executedAmount
+        - fullFeeAmount
+        - isLiquidityOrder
+        - reward
     Order:
       allOf:
         - $ref: "#/components/schemas/OrderCreation"
         - $ref: "#/components/schemas/OrderMetaData"
+    AuctionOrder:
+      allOf:
+        - $ref: "#/components/schemas/OrderCreation"
+        - $ref: "#/components/schemas/AuctionOrderMetaData"
     Auction:
       description: |
         A batch auction for solving.
@@ -761,6 +797,14 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/Order"
+          description: |
+            DEPRECATED
+
+            The solvable orders included in the auction.
+        orders_v2:
+          type: array
+          items:
+            $ref: "#/components/schemas/AuctionOrder"
           description: |
             The solvable orders included in the auction.
         prices:


### PR DESCRIPTION
This is an attempt to make https://github.com/cowprotocol/services/pull/529 backward compatible. We keep the old `orders` field and add a new one `orders_v2` that uses the new order format. This results in some awkward code in the autopilot where we have to pass both order structs along for the time being.

I did this instead of going with completely new routes to make the required code changes smaller. Otherwise we would to duplicate the whole Auction struct and the Auction route and it would be awkward to make a similar change in the autopilot code that stores the current auction in the database to be read by the orderbook because that would have to be backward compatible too. Changing the field felt like a reasonable compromise.

A follow up change that is still needed is to make sure the shadow solver will continue to work because it is using staging code pointing at the prod endpoint.

### Test Plan

CI
