### PR TITLE
Remove old temporary logs

### DIFF
--- a/crates/solver/src/settlement_submission/submitter.rs
+++ b/crates/solver/src/settlement_submission/submitter.rs
@@ -368,18 +368,12 @@ impl<'a> Submitter<'a> {
     ) -> SubmissionError {
         let target_confirm_time = Instant::now() + params.target_confirm_time;
 
-        tracing::debug!(
-            "submit_with_increasing_gas_prices_until_simulation_fails entered with submitter",
-        );
-
         let mut access_list: Option<AccessList> = None;
 
         // Try to find submitted transaction from previous submission attempt (with the same address and nonce)
         let mut pending_gas_price = transactions.last().cloned().map(|(_, gas_price)| gas_price);
 
         loop {
-            tracing::debug!("entered loop with submitter");
-
             let submission_status = self
                 .submit_api
                 .submission_status(&settlement, &params.network_id);


### PR DESCRIPTION
This PR removes noisy temporary logs that are no longer needed, especially after @MartinquaXD implemented the submitter prefix for each log printed in `settlement_submission`.

