### PR TITLE
Fix initial indexing of pools for UniswapV3

### DIFF
--- a/crates/shared/src/sources/uniswap_v3/graph_api.rs
+++ b/crates/shared/src/sources/uniswap_v3/graph_api.rs
@@ -22,6 +22,7 @@ const ALL_POOLS_QUERY: &str = r#"
             where: {
                 id_gt: $lastId
                 tick_not: null
+                ticks_: { liquidityNet_not: "0" }
             }
         ) {
             id


### PR DESCRIPTION
UniswapV3 uses two subgraph queries to index pools:
1. `ALL_POOLS_QUERY` to get all existing pools and their ids
2. `POOLS_WITH_TICKS_BY_IDS_QUERY` to get the subset of pools INCLUDING TICKS

These two queries need to be aligned by strictness, in order to avoid having zero liquidity pools indexed by (1) and then skipped by (2), and, as a consequence, being stuck in `missing_pools` cache and never get cached:
https://logs-cow.gnosisdev.com/goto/47322330-4f8b-11ed-8b60-8535f869b417

Since these pools are useless anyway, I am making `ALL_POOLS_QUERY` more strict to avoid indexing these pools at the first place.
