### PR TITLE
Fix missing ticks

### DIFF
--- a/crates/shared/src/sources/uniswap_v3/graph_api.rs
+++ b/crates/shared/src/sources/uniswap_v3/graph_api.rs
@@ -100,9 +100,12 @@ impl UniV3SubgraphClient {
     /// Retrieves the list of registered pools from the subgraph.
     pub async fn get_registered_pools(&self) -> Result<RegisteredPools> {
         let block_number = self.get_safe_block().await?;
+        let variables = Some(json_map! {
+            "block" => block_number,
+        });
         let pools = self
             .0
-            .paginated_query(block_number, ALL_POOLS_QUERY)
+            .paginated_query(ALL_POOLS_QUERY, variables)
             .await?
             .into_iter()
             .filter(|pool: &PoolData| pool.total_value_locked_eth.is_normal())

--- a/crates/shared/src/subgraph.rs
+++ b/crates/shared/src/subgraph.rs
@@ -85,8 +85,10 @@ impl SubgraphClient {
         // suggested approach to paging best performance:
         // <https://thegraph.com/docs/en/developer/graphql-api/#pagination>
         let mut variables = variables.unwrap_or_default();
-        variables.insert("pageSize".to_string(), json!(QUERY_PAGE_SIZE));
-        variables.insert("lastId".to_string(), json!(String::default()));
+        variables.extend(json_map! {
+            "pageSize" => QUERY_PAGE_SIZE,
+            "lastId" => json!(String::default()),
+        });
         loop {
             let page = self
                 .query::<Data<T>>(query, Some(variables.clone()))


### PR DESCRIPTION
This PR makes `SubgraphClient::paginated_query()` function more general.  It makes sense to define variables at the same level where query is defined, because each query might require different variables. Now `paginated_query` takes in already defined variables and adds additional variables specifically related to paging: `pageSize` and `lastId`.

This PR is needed because I found a bug in fetching ticks so I need this change to add few more paginated queries. Will be explained in the following PRs.

### Test Plan

UT uniswap_v3_subgraph_query_get_pools() passes.
