### PR TITLE
Don't require `interactions` field

### DIFF
--- a/crates/model/src/order.rs
+++ b/crates/model/src/order.rs
@@ -47,6 +47,7 @@ pub struct Order {
     pub data: OrderData,
     #[serde(flatten)]
     pub signature: Signature,
+    #[serde(default)]
     pub interactions: Interactions,
 }
 


### PR DESCRIPTION
This fixes the shadow solver not working because prod endpoint doesn't have the field yet.

### Test Plan
CI
