### PR TITLE
Store risk adjusted reward in DB even if it is 0

### DIFF
--- a/crates/solver/src/driver.rs
+++ b/crates/solver/src/driver.rs
@@ -375,9 +375,8 @@ impl Driver {
             // Note that order_trades doesn't include liquidity orders.
             for trade in winning_settlement.settlement.encoder.order_trades() {
                 let uid = &trade.trade.order.metadata.uid;
-                if let Some(reward) = rewards.get(uid) {
-                    solver_competition.rewards.push((*uid, *reward));
-                }
+                let reward = rewards.get(uid).copied().unwrap_or(0.);
+                solver_competition.rewards.push((*uid, reward));
             }
 
             // At this point we know that we are going to attempt to settle on chain. We store the


### PR DESCRIPTION
Previously we did not store 0 and assumed that orders without a row had 0 reward. Now we make the 0 explicit to distinguish it from some other reason that no reward was stored.

### Test Plan

CI, simple enough to not warrant specific test
