### PR TITLE
Log rewards of winning solution

### DIFF
--- a/crates/solver/src/driver.rs
+++ b/crates/solver/src/driver.rs
@@ -376,6 +376,8 @@ impl Driver {
             for trade in winning_settlement.settlement.encoder.order_trades() {
                 let uid = &trade.trade.order.metadata.uid;
                 let reward = rewards.get(uid).copied().unwrap_or(0.);
+                // Log in case something goes wrong with storing the rewards in the database.
+                tracing::debug!(%uid, %reward, "winning solution reward");
                 solver_competition.rewards.push((*uid, reward));
             }
 


### PR DESCRIPTION
in case something goes wrong with storing them in the database.

Note that the line below this `self.store_solver_competition` can fail. In that case we wouldn't store the rewards in the database. We could completely abort the settlement process but then we lose a perfectly good settlement. With these logs we have an alternative way of retrieving them. The downside is that we have to notice this either through the error log that is emitted when the storing fails or when the reward script runs and can't find the competition info for this settlement.

### Test Plan

CI
