### PR TITLE
Add argument for MAX_POOLS_TO_INITIALIZE

### DIFF
--- a/crates/autopilot/src/lib.rs
+++ b/crates/autopilot/src/lib.rs
@@ -238,9 +238,14 @@ pub async fn main(args: arguments::Arguments) {
     };
     let uniswap_v3_pool_fetcher = if baseline_sources.contains(&BaselineSource::UniswapV3) {
         let uniswap_v3_pool_fetcher = Arc::new(
-            UniswapV3PoolFetcher::new(chain_id, http_factory.create(), web3.clone())
-                .await
-                .expect("failed to create UniswapV3 pool fetcher in orderbook"),
+            UniswapV3PoolFetcher::new(
+                chain_id,
+                http_factory.create(),
+                web3.clone(),
+                args.shared.max_pools_to_initialize_cache,
+            )
+            .await
+            .expect("failed to create UniswapV3 pool fetcher in autopilot"),
         );
         Some(uniswap_v3_pool_fetcher)
     } else {

--- a/crates/driver/src/arguments.rs
+++ b/crates/driver/src/arguments.rs
@@ -265,6 +265,10 @@ pub struct Arguments {
     /// value 0.0012 ETH and 0.0016 ETH equivalent.
     #[clap(long, env, default_value = "0")]
     pub solution_comparison_decimal_cutoff: u16,
+
+    /// The number of pools to initially populate the UniswapV3 cache
+    #[clap(long, env, default_value = "100")]
+    pub max_pools_to_initialize_cache: u64,
 }
 
 impl std::fmt::Display for Arguments {

--- a/crates/driver/src/main.rs
+++ b/crates/driver/src/main.rs
@@ -382,6 +382,7 @@ async fn build_auction_converter(
                 common.chain_id,
                 common.http_factory.create(),
                 common.web3.clone(),
+                args.max_pools_to_initialize_cache,
             )
             .await
             .expect("failed to create UniswapV3 pool fetcher in solver"),

--- a/crates/orderbook/src/main.rs
+++ b/crates/orderbook/src/main.rs
@@ -236,9 +236,14 @@ async fn main() {
     };
     let uniswap_v3_pool_fetcher = if baseline_sources.contains(&BaselineSource::UniswapV3) {
         let uniswap_v3_pool_fetcher = Arc::new(
-            UniswapV3PoolFetcher::new(chain_id, http_factory.create(), web3.clone())
-                .await
-                .expect("failed to create UniswapV3 pool fetcher in orderbook"),
+            UniswapV3PoolFetcher::new(
+                chain_id,
+                http_factory.create(),
+                web3.clone(),
+                args.shared.max_pools_to_initialize_cache,
+            )
+            .await
+            .expect("failed to create UniswapV3 pool fetcher in orderbook"),
         );
         Some(uniswap_v3_pool_fetcher)
     } else {

--- a/crates/shared/src/arguments.rs
+++ b/crates/shared/src/arguments.rs
@@ -251,6 +251,10 @@ pub struct Arguments {
         value_parser = duration_from_seconds,
     )]
     pub liquidity_fetcher_max_age_update: Duration,
+
+    /// The number of pools to initially populate the UniswapV3 cache
+    #[clap(long, env, default_value = "100")]
+    pub max_pools_to_initialize_cache: u64,
 }
 
 pub fn display_secret_option<T>(

--- a/crates/shared/src/price_estimation/http.rs
+++ b/crates/shared/src/price_estimation/http.rs
@@ -708,7 +708,7 @@ mod tests {
             .expect("failed to create Balancer pool fetcher"),
         );
         let uniswap_v3_pool_fetcher = Arc::new(
-            UniswapV3PoolFetcher::new(chain_id, client.clone(), web3.clone())
+            UniswapV3PoolFetcher::new(chain_id, client.clone(), web3.clone(), 100)
                 .await
                 .expect("failed to create uniswap v3 pool fetcher"),
         );

--- a/crates/solver/src/main.rs
+++ b/crates/solver/src/main.rs
@@ -263,9 +263,14 @@ async fn main() {
     let (uniswap_v3_liquidity, uniswap_v3_maintainer) =
         if baseline_sources.contains(&BaselineSource::UniswapV3) {
             let uniswap_v3_pool_fetcher = Arc::new(
-                UniswapV3PoolFetcher::new(chain_id, http_factory.create(), web3.clone())
-                    .await
-                    .expect("failed to create UniswapV3 pool fetcher in solver"),
+                UniswapV3PoolFetcher::new(
+                    chain_id,
+                    http_factory.create(),
+                    web3.clone(),
+                    args.shared.max_pools_to_initialize_cache,
+                )
+                .await
+                .expect("failed to create UniswapV3 pool fetcher in solver"),
             );
 
             (


### PR DESCRIPTION
This PR makes UniswapV3 pool fetcher reads `MAX_POOLS_TO_INITIALIZE` from configuration.

We might need this to lower the number if performance is bad.