### PR TITLE
Trade Simulation Configuration

### DIFF
--- a/crates/autopilot/src/lib.rs
+++ b/crates/autopilot/src/lib.rs
@@ -288,9 +288,15 @@ pub async fn main(args: arguments::Arguments) {
         &args.price_estimation,
         &args.shared,
         factory::Network {
+            web3: web3.clone(),
             name: network_name.to_string(),
             chain_id,
             native_token: native_token.address(),
+            authenticator: settlement_contract
+                .authenticator()
+                .call()
+                .await
+                .expect("failed to query solver authenticator address"),
             base_tokens: base_tokens.clone(),
         },
         factory::Components {
@@ -304,7 +310,8 @@ pub async fn main(args: arguments::Arguments) {
             zeroex: zeroex_api.clone(),
             oneinch: one_inch_api.ok().map(|a| a as _),
         },
-    );
+    )
+    .expect("failed to initialize price estimator factory");
 
     let price_estimator = price_estimator_factory
         .price_estimator(&args.order_quoting.price_estimators)

--- a/crates/driver/src/arguments.rs
+++ b/crates/driver/src/arguments.rs
@@ -5,6 +5,7 @@ use shared::{
     gas_price_estimation::GasEstimatorType,
     http_client,
     sources::{balancer_v2::BalancerFactoryKind, BaselineSource},
+    tenderly_api,
 };
 use solver::{
     arguments::TransactionStrategyArg, liquidity::slippage,
@@ -20,6 +21,9 @@ pub struct Arguments {
 
     #[clap(flatten)]
     pub slippage: slippage::Arguments,
+
+    #[clap(flatten)]
+    pub tenderly: tenderly_api::Arguments,
 
     #[clap(long, env, default_value = "0.0.0.0:8080")]
     pub bind_address: SocketAddr,
@@ -124,18 +128,6 @@ pub struct Arguments {
     /// `Web3`: supports every network.
     #[clap(long, env, value_enum, ignore_case = true, use_value_delimiter = true)]
     pub access_list_estimators: Vec<AccessListEstimatorType>,
-
-    /// The Tenderly user associated with the API key.
-    #[clap(long, env)]
-    pub tenderly_user: Option<String>,
-
-    /// The Tenderly project associated with the API key.
-    #[clap(long, env)]
-    pub tenderly_project: Option<String>,
-
-    /// Tenderly requires api key to work. Optional since Tenderly could be skipped in access lists estimators.
-    #[clap(long, env)]
-    pub tenderly_api_key: Option<String>,
 
     /// Gas limit for simulations. This parameter is important to set correctly, such that
     /// there are no simulation errors due to: err: insufficient funds for gas * price + value,
@@ -275,6 +267,7 @@ impl std::fmt::Display for Arguments {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.http_client)?;
         write!(f, "{}", self.slippage)?;
+        write!(f, "{}", self.tenderly)?;
         writeln!(f, "bind_address: {}", self.bind_address)?;
         writeln!(f, "log_filter: {}", self.log_filter)?;
         writeln!(f, "log_stderr_threshold: {}", self.log_stderr_threshold)?;
@@ -319,9 +312,6 @@ impl std::fmt::Display for Arguments {
             "access_list_estimators: {:?}",
             self.access_list_estimators
         )?;
-        display_option(f, "tenderly_user", &self.tenderly_project)?;
-        display_option(f, "tenderly_project", &self.tenderly_project)?;
-        display_secret_option(f, "tenderly_api_key", &self.tenderly_api_key)?;
         writeln!(f, "simulation_gas_limit: {}", self.simulation_gas_limit)?;
         writeln!(f, "target_confirm_time: {:?}", self.target_confirm_time)?;
         writeln!(

--- a/crates/driver/src/main.rs
+++ b/crates/driver/src/main.rs
@@ -20,7 +20,7 @@ use shared::{
         uniswap_v3::pool_fetching::UniswapV3PoolFetcher,
         BaselineSource,
     },
-    tenderly_api::{TenderlyApi, TenderlyHttpApi},
+    tenderly_api::TenderlyApi,
     token_info::{CachedTokenInfoFetcher, TokenInfoFetcher, TokenInfoFetching},
     zeroex_api::DefaultZeroExApi,
 };
@@ -86,17 +86,10 @@ async fn init_common_components(args: &Arguments) -> CommonComponents {
     let native_token_contract = WETH9::deployed(&web3)
         .await
         .expect("couldn't load deployed native token");
-    let tenderly_api = Some(()).and_then(|_| {
-        Some(Arc::new(
-            TenderlyHttpApi::new(
-                &http_factory,
-                args.tenderly_user.as_deref()?,
-                args.tenderly_project.as_deref()?,
-                args.tenderly_api_key.as_deref()?,
-            )
-            .expect("failed to create Tenderly API"),
-        ) as Arc<dyn TenderlyApi>)
-    });
+    let tenderly_api = args
+        .tenderly
+        .get_api_instance(&http_factory)
+        .expect("failed to create Tenderly API");
     let access_list_estimator = Arc::new(
         solver::settlement_access_list::create_priority_estimator(
             &web3,

--- a/crates/orderbook/src/main.rs
+++ b/crates/orderbook/src/main.rs
@@ -277,9 +277,15 @@ async fn main() {
         &args.price_estimation,
         &args.shared,
         factory::Network {
+            web3: web3.clone(),
             name: network_name.to_string(),
             chain_id,
             native_token: native_token.address(),
+            authenticator: settlement_contract
+                .authenticator()
+                .call()
+                .await
+                .expect("failed to query solver authenticator address"),
             base_tokens: base_tokens.clone(),
         },
         factory::Components {
@@ -293,7 +299,8 @@ async fn main() {
             zeroex: zeroex_api.clone(),
             oneinch: one_inch_api.ok().map(|a| a as _),
         },
-    );
+    )
+    .expect("failed to initialize price estimator factory");
 
     let price_estimator = price_estimator_factory
         .price_estimator(&args.order_quoting.price_estimators)

--- a/crates/shared/src/arguments.rs
+++ b/crates/shared/src/arguments.rs
@@ -5,6 +5,7 @@ use crate::{
     price_estimation::PriceEstimatorType,
     rate_limiter::RateLimitingStrategy,
     sources::{balancer_v2::BalancerFactoryKind, BaselineSource},
+    tenderly_api,
 };
 use anyhow::{anyhow, ensure, Context, Result};
 use ethcontract::{H160, H256, U256};
@@ -109,6 +110,9 @@ pub struct OrderQuotingArguments {
 #[derive(clap::Parser)]
 #[group(skip)]
 pub struct Arguments {
+    #[clap(flatten)]
+    pub tenderly: tenderly_api::Arguments,
+
     #[clap(
         long,
         env,
@@ -330,6 +334,7 @@ impl Display for OrderQuotingArguments {
 // leaking any potentially secret values.
 impl Display for Arguments {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.tenderly)?;
         writeln!(f, "log_filter: {}", self.log_filter)?;
         writeln!(f, "log_stderr_threshold: {}", self.log_stderr_threshold)?;
         writeln!(f, "node_url: {}", self.node_url)?;

--- a/crates/shared/src/price_estimation.rs
+++ b/crates/shared/src/price_estimation.rs
@@ -166,6 +166,11 @@ impl Display for Arguments {
                 .as_ref()
                 .map(|value| format!("{value:?}")),
         )?;
+        writeln!(
+            f,
+            "tenderly_save_failed_trade_simulations: {}",
+            self.tenderly_save_failed_trade_simulations
+        )?;
 
         Ok(())
     }

--- a/crates/shared/src/price_estimation.rs
+++ b/crates/shared/src/price_estimation.rs
@@ -20,6 +20,7 @@ use crate::{
     rate_limiter::{RateLimiter, RateLimiterError, RateLimitingStrategy},
 };
 use anyhow::Result;
+use clap::ValueEnum;
 use ethcontract::{H160, U256};
 use futures::{stream::BoxStream, StreamExt};
 use model::order::OrderKind;
@@ -35,7 +36,7 @@ use std::{
 };
 use thiserror::Error;
 
-#[derive(Copy, Clone, Debug, Hash, Eq, PartialEq, clap::ValueEnum)]
+#[derive(Copy, Clone, Debug, Hash, Eq, PartialEq, ValueEnum)]
 #[clap(rename_all = "verbatim")]
 pub enum PriceEstimatorType {
     Baseline,
@@ -52,6 +53,13 @@ impl PriceEstimatorType {
     pub fn name(&self) -> String {
         format!("{:?}", self)
     }
+}
+
+#[derive(Copy, Clone, Debug, Hash, Eq, PartialEq, ValueEnum)]
+#[clap(rename_all = "verbatim")]
+pub enum TradeValidatorKind {
+    Web3,
+    Tenderly,
 }
 
 /// Shared price estimation configuration arguments.
@@ -106,6 +114,18 @@ pub struct Arguments {
     /// The API endpoint for the Balancer SOR API for solving.
     #[clap(long, env)]
     pub balancer_sor_url: Option<Url>,
+
+    /// The trade simulation strategy to use for supported price estimators. This ensures that
+    /// the proposed trade calldata gets simulated, thus avoiding invalid calldata mistakenly
+    /// advertising unachievable prices when quoting, as well as more robustly identifying
+    /// unsupported tokens.
+    #[clap(long, env)]
+    pub trade_simulator: Option<TradeValidatorKind>,
+
+    /// Flag to enable saving Tenderly simulations in the dashboard for failed trade simulations.
+    /// This helps debugging reverted quote simulations.
+    #[clap(long, env)]
+    pub tenderly_save_failed_trade_simulations: bool,
 }
 
 impl Display for Arguments {
@@ -138,6 +158,14 @@ impl Display for Arguments {
         display_option(f, "quasimodo_solver_url", &self.quasimodo_solver_url)?;
         display_option(f, "yearn_solver_url", &self.yearn_solver_url)?;
         display_option(f, "balancer_sor_url", &self.balancer_sor_url)?;
+        display_option(
+            f,
+            "trade_simulator",
+            &self
+                .trade_simulator
+                .as_ref()
+                .map(|value| format!("{value:?}")),
+        )?;
 
         Ok(())
     }

--- a/crates/shared/src/trade_finding.rs
+++ b/crates/shared/src/trade_finding.rs
@@ -43,10 +43,13 @@ impl Trade {
         let pre_interactions = match self.approval {
             Some((token, spender)) => {
                 let token = dummy_contract!(ERC20, token);
-                vec![
-                    Interaction::from_call(token.methods().approve(spender, U256::max_value()))
-                        .encode(),
-                ]
+                let approve = |amount| {
+                    Interaction::from_call(token.methods().approve(spender, amount)).encode()
+                };
+
+                // For approvals, reset the approval completely. Some tokens
+                // require this such as Tether USD.
+                vec![approve(U256::zero()), approve(U256::max_value())]
             }
             None => vec![],
         };

--- a/crates/shared/src/trade_finding.rs
+++ b/crates/shared/src/trade_finding.rs
@@ -143,18 +143,32 @@ mod tests {
         assert_eq!(
             trade.encode(),
             [
-                vec![(
-                    H160([0xdd; 20]),
-                    U256::zero(),
-                    Bytes(
-                        hex!(
-                            "095ea7b3
+                vec![
+                    (
+                        H160([0xdd; 20]),
+                        U256::zero(),
+                        Bytes(
+                            hex!(
+                                "095ea7b3
+                             000000000000000000000000eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee
+                             0000000000000000000000000000000000000000000000000000000000000000"
+                            )
+                            .to_vec()
+                        ),
+                    ),
+                    (
+                        H160([0xdd; 20]),
+                        U256::zero(),
+                        Bytes(
+                            hex!(
+                                "095ea7b3
                              000000000000000000000000eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee
                              ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
-                        )
-                        .to_vec()
-                    ),
-                )],
+                            )
+                            .to_vec()
+                        ),
+                    )
+                ],
                 vec![(H160([0xaa; 20]), U256::from(42), Bytes(vec![1, 2, 3, 4]))],
                 vec![],
             ]

--- a/crates/solver/src/arguments.rs
+++ b/crates/solver/src/arguments.rs
@@ -6,7 +6,7 @@ use crate::{
 use primitive_types::H160;
 use reqwest::Url;
 use shared::{
-    arguments::{display_list, display_option, display_secret_option},
+    arguments::{display_list, display_option},
     http_client,
 };
 use std::time::Duration;
@@ -172,18 +172,6 @@ pub struct Arguments {
     #[clap(long, env, value_enum, ignore_case = true, use_value_delimiter = true)]
     pub access_list_estimators: Vec<AccessListEstimatorType>,
 
-    /// The Tenderly user associated with the API key.
-    #[clap(long, env)]
-    pub tenderly_user: Option<String>,
-
-    /// The Tenderly project associated with the API key.
-    #[clap(long, env)]
-    pub tenderly_project: Option<String>,
-
-    /// Tenderly requires api key to work. Optional since Tenderly could be skipped in access lists estimators.
-    #[clap(long, env)]
-    pub tenderly_api_key: Option<String>,
-
     /// The API endpoint of the Eden network for transaction submission.
     #[clap(long, env, default_value = "https://api.edennetwork.io/v1/rpc")]
     pub eden_api_url: Url,
@@ -343,9 +331,6 @@ impl std::fmt::Display for Arguments {
             "access_list_estimators: {:?}",
             &self.access_list_estimators
         )?;
-        display_option(f, "tenderly_user", &self.tenderly_user)?;
-        display_option(f, "tenderly_project", &self.tenderly_project)?;
-        display_secret_option(f, "tenderly_api_key", &self.tenderly_api_key)?;
         writeln!(f, "eden_api_url: {}", self.eden_api_url)?;
         display_list(f, "flashbots_api_url", &self.flashbots_api_url)?;
         writeln!(

--- a/crates/solver/src/main.rs
+++ b/crates/solver/src/main.rs
@@ -17,7 +17,6 @@ use shared::{
         uniswap_v3::pool_fetching::UniswapV3PoolFetcher,
         BaselineSource,
     },
-    tenderly_api::{TenderlyApi, TenderlyHttpApi},
     token_info::{CachedTokenInfoFetcher, TokenInfoFetcher},
     token_list::{AutoUpdatingTokenList, TokenListConfiguration},
     zeroex_api::DefaultZeroExApi,
@@ -381,17 +380,11 @@ async fn main() {
             }
         }
     }
-    let tenderly_api = Some(()).and_then(|_| {
-        Some(Arc::new(
-            TenderlyHttpApi::new(
-                &http_factory,
-                args.tenderly_user.as_deref()?,
-                args.tenderly_project.as_deref()?,
-                args.tenderly_api_key.as_deref()?,
-            )
-            .expect("failed to create Tenderly API"),
-        ) as Arc<dyn TenderlyApi>)
-    });
+    let tenderly_api = args
+        .shared
+        .tenderly
+        .get_api_instance(&http_factory)
+        .expect("failed to create Tenderly API");
     let access_list_estimator = Arc::new(
         solver::settlement_access_list::create_priority_estimator(
             &web3,


### PR DESCRIPTION
Follow up to #657 

This PR adds the new command line options required for creating a `TradeVerifier` instance. The trade verifier gets used with the supported price estimators (introduced in #657).

With this change, it is now possible to configure DEX aggregator price estimators to simulate the estimates that they receive from their respective APIs, in order to have:
- A more accurate gas estimate for the trade
- An exact input and output amount for the trade (thus, helping catch issues where the advertised exchange rate does not match what actually gets executed on-chain - either because of a DEX aggregator bug, or weird on-chain interactions with the tokens and AMMs being used for the particular trade).

Additionally, while testing, I found some small improvements to the simulation setup that make it more robust for commonly traded tokens.

### Test Plan

Just command line configuration logic, so try it out by running the orderbook.

Note that request sharing appears to be working as expected. When doing simultaneous fast and optimal price queries (see test plan from #657), the `api.1inch.exchange/v4.1/1/quote` 1Inch API request gets reused across both estimates.
```
2022-10-22T12:36:43.006Z DEBUG shared::oneinch_api: Query 1inch API for url https://api.1inch.exchange/v4.1/1/quote?...
2022-10-22T12:36:43.006Z DEBUG shared::oneinch_api: Query 1inch API for url https://api.1inch.exchange/v4.1/1/approve/spender
2022-10-22T12:36:43.007Z DEBUG shared::oneinch_api: Query 1inch API for url https://api.1inch.exchange/v4.1/1/swap?...
```

Additionally, if the orderbook is run with `--tenderly-save-failed-trade-simulations`, simulation failures show up in the [Tenderly dashboard](https://dashboard.tenderly.co/nlordell/scratch/simulator/682b9cd8-55a0-468e-9dd1-44027f6a3d6d) for debugging. This allowed me to debug some issues with commonly traded tokens while testing.

### Release notes

Enable trade simulations by setting `TRADE_SIMULATOR={Web3,Tenderly}`.
