### PR TITLE
Improve Handling of Slippage for AMMs

### DIFF
--- a/crates/solver/src/liquidity/slippage.rs
+++ b/crates/solver/src/liquidity/slippage.rs
@@ -186,21 +186,18 @@ impl<'a> SlippageContext<'a> {
             // the slippage using the buy token and its external price for
             // capping the relative slippage, and fall back to using the
             // relative slippage without capping.
-            let relative = match self.prices.price(&execution.output.0) {
-                Some(price) => {
-                    let (relative, _) = self.calculator.compute_inner(
-                        Some(price),
-                        number_conversions::u256_to_big_int(&execution.output.1),
-                    )?;
-                    relative
-                }
-                None => {
-                    tracing::warn!(
-                        sell_token = ?execution.input_max.0,
-                        "unable to compute capped slippage; falling back to relative slippage",
-                    );
-                    Cow::Borrowed(&self.calculator.relative)
-                }
+            let relative = if let Some(price) = self.prices.price(&execution.output.0) {
+                let (relative, _) = self.calculator.compute_inner(
+                    Some(price),
+                    number_conversions::u256_to_big_int(&execution.output.1),
+                )?;
+                relative
+            } else {
+                tracing::warn!(
+                    sell_token = ?execution.input_max.0,
+                    "unable to compute capped slippage; falling back to relative slippage",
+                );
+                Cow::Borrowed(&self.calculator.relative)
             };
 
             let absolute = absolute_slippage_amount(

--- a/crates/solver/src/liquidity/slippage.rs
+++ b/crates/solver/src/liquidity/slippage.rs
@@ -194,7 +194,13 @@ impl<'a> SlippageContext<'a> {
                     )?;
                     relative
                 }
-                None => Cow::Borrowed(&self.calculator.relative),
+                None => {
+                    tracing::warn!(
+                        sell_token = ?execution.input_max.0,
+                        "unable to compute capped slippage; falling back to relative slippage",
+                    );
+                    Cow::Borrowed(&self.calculator.relative)
+                }
             };
 
             let absolute = absolute_slippage_amount(

--- a/crates/solver/src/solver/baseline_solver.rs
+++ b/crates/solver/src/solver/baseline_solver.rs
@@ -277,11 +277,11 @@ impl Solution {
             let buy_amount = amm
                 .get_amount_out(buy_token, (sell_amount, sell_token))
                 .expect("Path was found, so amount must be calculable");
-            let execution = AmmOrderExecution {
-                input_max: slippage.execution_input_max((sell_token, sell_amount))?,
+            let execution = slippage.apply_to_amm_execution(AmmOrderExecution {
+                input_max: (sell_token, sell_amount),
                 output: (buy_token, buy_amount),
                 internalizable: false,
-            };
+            })?;
             match &amm.order {
                 AmmOrder::ConstantProduct(order) => settlement.with_liquidity(order, execution),
                 AmmOrder::WeightedProduct(order) => settlement.with_liquidity(order, execution),
@@ -422,23 +422,23 @@ mod tests {
         assert_eq!(amm_handler[0].clone().calls().len(), 0);
         assert_eq!(
             amm_handler[1].clone().calls()[0],
-            AmmOrderExecution {
-                input_max: slippage
-                    .execution_input_max((sell_token, 100_000.into()))
-                    .unwrap(),
-                output: (native_token, 98_715.into()),
-                internalizable: false
-            }
+            slippage
+                .apply_to_amm_execution(AmmOrderExecution {
+                    input_max: (sell_token, 100_000.into()),
+                    output: (native_token, 98_715.into()),
+                    internalizable: false
+                })
+                .unwrap(),
         );
         assert_eq!(
             amm_handler[2].clone().calls()[0],
-            AmmOrderExecution {
-                input_max: slippage
-                    .execution_input_max((native_token, 98_715.into()))
-                    .unwrap(),
-                output: (buy_token, 97_459.into()),
-                internalizable: false
-            }
+            slippage
+                .apply_to_amm_execution(AmmOrderExecution {
+                    input_max: (native_token, 98_715.into()),
+                    output: (buy_token, 97_459.into()),
+                    internalizable: false
+                })
+                .unwrap(),
         );
     }
 
@@ -535,23 +535,23 @@ mod tests {
         assert_eq!(amm_handler[0].clone().calls().len(), 0);
         assert_eq!(
             amm_handler[1].clone().calls()[0],
-            AmmOrderExecution {
-                input_max: slippage
-                    .execution_input_max((sell_token, 102_660.into()))
-                    .unwrap(),
-                output: (native_token, 101_315.into()),
-                internalizable: false
-            }
+            slippage
+                .apply_to_amm_execution(AmmOrderExecution {
+                    input_max: (sell_token, 102_660.into()),
+                    output: (native_token, 101_315.into()),
+                    internalizable: false
+                })
+                .unwrap(),
         );
         assert_eq!(
             amm_handler[2].clone().calls()[0],
-            AmmOrderExecution {
-                input_max: slippage
-                    .execution_input_max((native_token, 101_315.into()))
-                    .unwrap(),
-                output: (buy_token, 100_000.into()),
-                internalizable: false
-            }
+            slippage
+                .apply_to_amm_execution(AmmOrderExecution {
+                    input_max: (native_token, 101_315.into()),
+                    output: (buy_token, 100_000.into()),
+                    internalizable: false
+                })
+                .unwrap(),
         );
     }
 

--- a/crates/solver/src/solver/http_solver/settlement.rs
+++ b/crates/solver/src/solver/http_solver/settlement.rs
@@ -77,11 +77,11 @@ impl Execution {
         match self {
             LimitOrder(order) => settlement.with_liquidity(&order.order, order.executed_amount()),
             Amm(executed_amm) => {
-                let execution = AmmOrderExecution {
-                    input_max: slippage.execution_input_max(executed_amm.input)?,
+                let execution = slippage.apply_to_amm_execution(AmmOrderExecution {
+                    input_max: executed_amm.input,
                     output: executed_amm.output,
                     internalizable,
-                };
+                })?;
                 match &executed_amm.order {
                     Liquidity::ConstantProduct(liquidity) => {
                         settlement.with_liquidity(liquidity, execution)

--- a/crates/solver/src/solver/naive_solver/multi_order_solver.rs
+++ b/crates/solver/src/solver/naive_solver/multi_order_solver.rs
@@ -177,13 +177,13 @@ fn solve_with_uniswap(
     settlement
         .with_liquidity(
             pool,
-            AmmOrderExecution {
-                input_max: slippage
-                    .execution_input_max((uniswap_in_token, uniswap_in))
-                    .ok()?,
-                output: (uniswap_out_token, uniswap_out_with_rounding),
-                internalizable: false,
-            },
+            slippage
+                .apply_to_amm_execution(AmmOrderExecution {
+                    input_max: (uniswap_in_token, uniswap_in),
+                    output: (uniswap_out_token, uniswap_out_with_rounding),
+                    internalizable: false,
+                })
+                .ok()?,
         )
         .ok()?;
 
@@ -1033,14 +1033,16 @@ mod tests {
 
         assert_eq!(
             amm_handler.calls(),
-            vec![AmmOrderExecution {
-                input_max: slippage.execution_input_max((token_a, to_wei(40))).unwrap(),
-                output: (
-                    token_b,
-                    pool.get_amount_out(token_b, (to_wei(40), token_a)).unwrap()
-                ),
-                internalizable: false
-            }],
+            vec![slippage
+                .apply_to_amm_execution(AmmOrderExecution {
+                    input_max: (token_a, to_wei(40)),
+                    output: (
+                        token_b,
+                        pool.get_amount_out(token_b, (to_wei(40), token_a)).unwrap()
+                    ),
+                    internalizable: false
+                })
+                .unwrap()],
         );
     }
 }


### PR DESCRIPTION
In #589 et. al., we introduced a new mechanism for computing slippage values. Specifically, we now have a hybrid relative/absolute slippage approach, where we apply a relative slippage capped at a maximum absolute value denominated in the network's native token.

This works well for DEX aggregators since the slippage calculation relies on external prices, and DEX aggregators **always** apply slippage to a token amount for a traded token (which are guaranteed to have external prices).

However, this does not work well for solvers that use the "liquidity" abstraction. Specifically, we fetch liquidity for all traded tokens **AND** a set of base tokens. While the traded tokens all have external prices, base tokens are not guaranteed to have external prices. This means that it is possible to try and compute slippage for a token amount for which there is no price information.

This PR changes the capped slippage computation to:
- First, try and compute the `input_max` token amount with slippage added normally (that is, use the token amount and external token price to compute the actual slippage amount to use)
- Then, try and compute the relative slippage amount using the `output` token amount, and apply this relative slippage to the input token amount. This means that for cases where there is no external price for the input token, but there is an external price for the output token, we still get a correct capped slippage amount
- Finally, just use the configured relative slippage amount without a cap. Ideally, we would be able to use a combination of external prices, clearing prices, executed AMM amounts, in order to compute a capped slippage amount, but that is a **much** more complicated and should rarely happen.

### Test Plan

Added a unit test. Existing tests continue to pass.

### Release notes

We can re-enable absolute slippage caps for **all** solvers (right now, they are only enabled for DEX aggregator solvers).
