### PR TITLE
Encoded settlement with all interactions

### DIFF
--- a/crates/solver/src/liquidity/balancer_v2.rs
+++ b/crates/solver/src/liquidity/balancer_v2.rs
@@ -415,7 +415,7 @@ mod tests {
         )
         .unwrap();
 
-        let [_, interactions, _] = encoder.finish().interactions;
+        let [_, interactions, _] = encoder.finish(true).interactions;
         assert_eq!(
             interactions,
             [

--- a/crates/solver/src/liquidity/zeroex.rs
+++ b/crates/solver/src/liquidity/zeroex.rs
@@ -352,7 +352,7 @@ pub mod tests {
         };
         let mut encoder = SettlementEncoder::default();
         handler.encode(100.into(), &mut encoder).unwrap();
-        let [_, interactions, _] = encoder.finish().interactions;
+        let [_, interactions, _] = encoder.finish(true).interactions;
         assert_eq!(
             interactions,
             [
@@ -389,7 +389,7 @@ pub mod tests {
         };
         let mut encoder = SettlementEncoder::default();
         handler.encode(100.into(), &mut encoder).unwrap();
-        let [_, interactions, _] = encoder.finish().interactions;
+        let [_, interactions, _] = encoder.finish(true).interactions;
         assert_eq!(
             interactions,
             [

--- a/crates/solver/src/settlement.rs
+++ b/crates/solver/src/settlement.rs
@@ -488,7 +488,7 @@ impl Settlement {
 
 impl From<Settlement> for EncodedSettlement {
     fn from(settlement: Settlement) -> Self {
-        settlement.encoder.finish()
+        settlement.encoder.finish(true)
     }
 }
 
@@ -579,12 +579,12 @@ pub mod tests {
         let actual_settlement = {
             let mut encoder = SettlementEncoder::new(prices.clone());
             handler.encode(execution, &mut encoder).unwrap();
-            encoder.finish()
+            encoder.finish(true)
         };
         let expected_settlement = {
             let mut encoder = SettlementEncoder::new(prices);
             exec(&mut encoder);
-            encoder.finish()
+            encoder.finish(true)
         };
 
         assert_eq!(actual_settlement, expected_settlement);

--- a/crates/solver/src/settlement_ranker.rs
+++ b/crates/solver/src/settlement_ranker.rs
@@ -3,6 +3,7 @@ use crate::{
     metrics::{SolverMetrics, SolverRunOutcome, SolverSimulationOutcome},
     settlement::{external_prices::ExternalPrices, PriceCheckTokens, Settlement},
     settlement_rater::{RatedSolverSettlement, SettlementRating},
+    settlement_simulation::call_data,
     solver::{SettlementWithError, Solver, SolverRunError},
 };
 use anyhow::Result;
@@ -123,7 +124,7 @@ impl SettlementRanker {
         // going to be simulated and considered for competition.
         for (solver, settlement) in &solver_settlements {
             tracing::debug!(
-                solver_name = %solver.name(), ?settlement,
+                solver_name = %solver.name(), ?settlement, uninternalized_calldata = hex::encode(call_data(settlement.encoder.clone().finish(false))),
                 "considering solution for solver competition",
             );
         }

--- a/crates/solver/src/settlement_simulation.rs
+++ b/crates/solver/src/settlement_simulation.rs
@@ -667,7 +667,7 @@ mod tests {
         .map(|settlement| vec![settlement])
         .unwrap();
         let settlement = settlements.get(0).unwrap();
-        let settlement_encoded = settlement.encoder.clone().finish();
+        let settlement_encoded = settlement.encoder.clone().finish(true);
         println!("Settlement_encoded: {:?}", settlement_encoded);
         let settlement = settle_method_builder(&contract, settlement_encoded, account).tx;
         println!(

--- a/crates/solver/src/solver/balancer_sor_solver.rs
+++ b/crates/solver/src/solver/balancer_sor_solver.rs
@@ -346,7 +346,7 @@ mod tests {
             .unwrap()
             .unwrap()
             .encoder
-            .finish();
+            .finish(true);
 
         assert_eq!(result.tokens, [buy_token, sell_token]);
         assert_eq!(result.clearing_prices, [sell_amount, buy_amount]);
@@ -469,7 +469,7 @@ mod tests {
             .unwrap()
             .unwrap()
             .encoder
-            .finish();
+            .finish(true);
 
         assert_eq!(result.tokens, [buy_token, sell_token]);
         assert_eq!(result.clearing_prices, [sell_amount, buy_amount]);

--- a/crates/solver/src/solver/oneinch_solver.rs
+++ b/crates/solver/src/solver/oneinch_solver.rs
@@ -465,7 +465,7 @@ mod tests {
             .await
             .unwrap()
             .unwrap();
-        assert_eq!(result.encoder.finish().interactions[1].len(), 2);
+        assert_eq!(result.encoder.finish(true).interactions[1].len(), 2);
 
         // On second run we have only have one main interactions (swap)
         let result = solver
@@ -473,7 +473,7 @@ mod tests {
             .await
             .unwrap()
             .unwrap();
-        assert_eq!(result.encoder.finish().interactions[1].len(), 1)
+        assert_eq!(result.encoder.finish(true).interactions[1].len(), 1)
     }
 
     #[tokio::test]

--- a/crates/solver/src/solver/paraswap_solver.rs
+++ b/crates/solver/src/solver/paraswap_solver.rs
@@ -415,7 +415,7 @@ mod tests {
             .await
             .unwrap()
             .unwrap();
-        assert_eq!(result.encoder.finish().interactions[1].len(), 2);
+        assert_eq!(result.encoder.finish(true).interactions[1].len(), 2);
 
         // On second run we have only have one main interactions (swap)
         let result = solver
@@ -423,7 +423,7 @@ mod tests {
             .await
             .unwrap()
             .unwrap();
-        assert_eq!(result.encoder.finish().interactions[1].len(), 1)
+        assert_eq!(result.encoder.finish(true).interactions[1].len(), 1)
     }
 
     #[tokio::test]

--- a/crates/solver/src/solver/zeroex_solver.rs
+++ b/crates/solver/src/solver/zeroex_solver.rs
@@ -470,7 +470,7 @@ mod tests {
             .await
             .unwrap()
             .unwrap();
-        assert_eq!(result.encoder.finish().interactions[1].len(), 2);
+        assert_eq!(result.encoder.finish(true).interactions[1].len(), 2);
 
         // On second run we have only have one main interactions (swap)
         let result = solver
@@ -478,7 +478,7 @@ mod tests {
             .await
             .unwrap()
             .unwrap();
-        assert_eq!(result.encoder.finish().interactions[1].len(), 1)
+        assert_eq!(result.encoder.finish(true).interactions[1].len(), 1)
     }
 
     #[tokio::test]


### PR DESCRIPTION
Now that we have a concept of internalizable interactions in the settlement encode, we can print the create calldata with (default) and without internalizing interactions. This allows us to then report how the full settlement (including all interactions) would look like for simulation.

For now, I just added it to the print statement we are issuing for every considered solution (cc @harisang ). We may. consider also adding it to the solver competition data (this would allow external solvers to "debug" potential issues with the competition) - not sure if it's not a bit too verbose (should this only be submitted for the winner, or for all candidates?)

### Test Plan

Added a unit test to the Settlement Encoder
