### PR TITLE
Set more realistic value for mean gas used for UniswapV3 swap

### DIFF
--- a/crates/shared/src/sources/uniswap_v3/pool_fetching.rs
+++ b/crates/shared/src/sources/uniswap_v3/pool_fetching.rs
@@ -93,7 +93,7 @@ impl TryFrom<PoolData> for PoolInfo {
                 fee: Ratio::new(pool.fee_tier.as_u32(), 1_000_000u32),
             },
             gas_stats: PoolStats {
-                mean_gas: U256::from(300_000), // todo: hardcoded for testing purposes
+                mean_gas: U256::from(108_163), // as estimated by https://dune.com/queries/1044812
             },
         })
     }


### PR DESCRIPTION
This PR sets more realistic value for average gas used for UniswapV3 swap. Initially it was set to 300k since we had no idea what to put there.

We considered calculating this programmatically but concluded that value received is not worth the implementation effort.
