### PR TITLE
Added docker-compose file

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,44 @@
+version: '3.1'
+
+services:
+  db:
+    image: postgres
+    restart: always
+    environment:
+      POSTGRES_HOST_AUTH_METHOD: trust
+      POSTGRES_USER: $USER
+      POSTGRES_PASSWORD: 123
+    command: -d postgres
+    volumes:
+      - postgres:/var/lib/postgresql/data
+    ports:
+      - 5432:5432
+
+  adminer:
+    image: adminer
+    restart: always
+    ports:
+      - 7402:8080
+
+  migrations:
+    build:
+      context: .
+      dockerfile: docker/Dockerfile.migration
+    restart: on-failure
+    command: migrate
+    environment:
+      FLYWAY_URL: jdbc:postgresql://db/?user=$USER&password=
+    volumes:
+      - type: bind
+        source: database/sql/
+        target: /flyway/sql
+
+  hardhat:
+    build: docker/hardhat
+    restart: always
+    command: npx hardhat node
+    ports:
+      - 8545:8545
+
+volumes:
+  postgres:

--- a/docker/hardhat/Dockerfile
+++ b/docker/hardhat/Dockerfile
@@ -1,0 +1,7 @@
+FROM node:16-alpine3.15
+
+RUN mkdir hardhat
+WORKDIR hardhat
+RUN npm init -y
+RUN npm i hardhat
+COPY hardhat.config.js .

--- a/docker/hardhat/hardhat.config.js
+++ b/docker/hardhat/hardhat.config.js
@@ -1,0 +1,10 @@
+module.exports = {
+    networks: {
+        hardhat: {
+            initialBaseFeePerGas: 0,
+            accounts: {
+                accountsBalance: "1000000000000000000000000"
+            }
+        }
+    }
+};


### PR DESCRIPTION
Added a `docker-compose.yaml` file for easily setting up a local environment to run manual or e2e tests. This should simplify the setup for new and existing users. I'd like to see the team use this to learn if it works for everyone and if others find it convenient as well. This allows you to run the following:

```sh
docker-compose up
# Or alternatively, to run the services in the background:
docker-compose up -d
```

This creates a postgres database listening on `localhost:5432`, runs the migrations on the database, starts a local [adminer](https://www.adminer.org/) instance at `localhost:7402` which allows you to browse the database (password: 123), and starts a local hardhat node at `localhost:8545`.

If everyone agrees, we can update our `README.md` file to instruct users to simply run `docker-compose` instead of doing laborious manual configuration.

### Test Plan

With `docker-compose` running, execute e2e tests against the database and the hardhat node:

```sh
cargo test postgres -- --ignored --test-threads 1
cargo test local_node -- --ignored --test-threads 1
```