### PR TITLE
Add contract pool address to AMMs

### DIFF
--- a/crates/driver/src/auction_converter.rs
+++ b/crates/driver/src/auction_converter.rs
@@ -192,6 +192,7 @@ mod tests {
             })
             .returning(move |_, _| {
                 Ok(vec![ConstantProduct(ConstantProductOrder {
+                    address: H160::from_low_u64_be(1),
                     tokens: TokenPair::new(token(1), token(2)).unwrap(),
                     reserves: (1u128, 1u128),
                     fee: Ratio::<u32>::new(1, 1),

--- a/crates/shared/src/baseline_solver.rs
+++ b/crates/shared/src/baseline_solver.rs
@@ -315,6 +315,7 @@ mod tests {
 
         let path = vec![sell_token, intermediate, buy_token];
         let pools = [Pool::uniswap(
+            H160::from_low_u64_be(1),
             TokenPair::new(path[0], path[1]).unwrap(),
             (100, 100),
         )];
@@ -334,8 +335,8 @@ mod tests {
 
         let path = vec![sell_token, intermediate, buy_token];
         let pools = [
-            Pool::uniswap(TokenPair::new(path[0], path[1]).unwrap(), (100, 100)),
-            Pool::uniswap(TokenPair::new(path[1], path[2]).unwrap(), (200, 50)),
+            Pool::uniswap(H160::from_low_u64_be(1), TokenPair::new(path[0], path[1]).unwrap(), (100, 100)),
+            Pool::uniswap(H160::from_low_u64_be(2), TokenPair::new(path[1], path[2]).unwrap(), (200, 50)),
         ];
         let pools = hashmap! {
             pools[0].tokens => vec![pools[0]],
@@ -363,8 +364,8 @@ mod tests {
 
         let path = vec![sell_token, intermediate, buy_token];
         let pools = [
-            Pool::uniswap(TokenPair::new(path[0], path[1]).unwrap(), (100, 100)),
-            Pool::uniswap(TokenPair::new(path[1], path[2]).unwrap(), (200, 50)),
+            Pool::uniswap(H160::from_low_u64_be(1), TokenPair::new(path[0], path[1]).unwrap(), (100, 100)),
+            Pool::uniswap(H160::from_low_u64_be(2), TokenPair::new(path[1], path[2]).unwrap(), (200, 50)),
         ];
         let pools = hashmap! {
             pools[0].tokens => vec![pools[0]],
@@ -384,10 +385,10 @@ mod tests {
         let first_pair = TokenPair::new(path[0], path[1]).unwrap();
         let second_pair = TokenPair::new(path[1], path[2]).unwrap();
 
-        let first_hop_high_price = Pool::uniswap(first_pair, (101_000, 100_000));
-        let first_hop_low_price = Pool::uniswap(first_pair, (100_000, 101_000));
-        let second_hop_high_slippage = Pool::uniswap(second_pair, (200_000, 50_000));
-        let second_hop_low_slippage = Pool::uniswap(second_pair, (200_000_000, 50_000_000));
+        let first_hop_high_price = Pool::uniswap(H160::from_low_u64_be(1), first_pair, (101_000, 100_000));
+        let first_hop_low_price = Pool::uniswap(H160::from_low_u64_be(1), first_pair, (100_000, 101_000));
+        let second_hop_high_slippage = Pool::uniswap(H160::from_low_u64_be(2), second_pair, (200_000, 50_000));
+        let second_hop_low_slippage = Pool::uniswap(H160::from_low_u64_be(2), second_pair, (200_000_000, 50_000_000));
         let pools = hashmap! {
             first_pair => vec![first_hop_high_price, first_hop_low_price],
             second_pair => vec![second_hop_high_slippage, second_hop_low_slippage],
@@ -427,8 +428,8 @@ mod tests {
         let pair = TokenPair::new(sell_token, buy_token).unwrap();
 
         let path = vec![sell_token, buy_token];
-        let valid_pool = Pool::uniswap(pair, (100_000, 100_000));
-        let invalid_pool = Pool::uniswap(pair, (0, 0));
+        let valid_pool = Pool::uniswap(H160::from_low_u64_be(1), pair, (100_000, 100_000));
+        let invalid_pool = Pool::uniswap(H160::default(), pair, (0, 0));
         let pools = hashmap! {
             pair => vec![valid_pool, invalid_pool],
         };

--- a/crates/shared/src/baseline_solver.rs
+++ b/crates/shared/src/baseline_solver.rs
@@ -335,8 +335,16 @@ mod tests {
 
         let path = vec![sell_token, intermediate, buy_token];
         let pools = [
-            Pool::uniswap(H160::from_low_u64_be(1), TokenPair::new(path[0], path[1]).unwrap(), (100, 100)),
-            Pool::uniswap(H160::from_low_u64_be(2), TokenPair::new(path[1], path[2]).unwrap(), (200, 50)),
+            Pool::uniswap(
+                H160::from_low_u64_be(1),
+                TokenPair::new(path[0], path[1]).unwrap(),
+                (100, 100),
+            ),
+            Pool::uniswap(
+                H160::from_low_u64_be(2),
+                TokenPair::new(path[1], path[2]).unwrap(),
+                (200, 50),
+            ),
         ];
         let pools = hashmap! {
             pools[0].tokens => vec![pools[0]],
@@ -364,8 +372,16 @@ mod tests {
 
         let path = vec![sell_token, intermediate, buy_token];
         let pools = [
-            Pool::uniswap(H160::from_low_u64_be(1), TokenPair::new(path[0], path[1]).unwrap(), (100, 100)),
-            Pool::uniswap(H160::from_low_u64_be(2), TokenPair::new(path[1], path[2]).unwrap(), (200, 50)),
+            Pool::uniswap(
+                H160::from_low_u64_be(1),
+                TokenPair::new(path[0], path[1]).unwrap(),
+                (100, 100),
+            ),
+            Pool::uniswap(
+                H160::from_low_u64_be(2),
+                TokenPair::new(path[1], path[2]).unwrap(),
+                (200, 50),
+            ),
         ];
         let pools = hashmap! {
             pools[0].tokens => vec![pools[0]],
@@ -385,10 +401,17 @@ mod tests {
         let first_pair = TokenPair::new(path[0], path[1]).unwrap();
         let second_pair = TokenPair::new(path[1], path[2]).unwrap();
 
-        let first_hop_high_price = Pool::uniswap(H160::from_low_u64_be(1), first_pair, (101_000, 100_000));
-        let first_hop_low_price = Pool::uniswap(H160::from_low_u64_be(1), first_pair, (100_000, 101_000));
-        let second_hop_high_slippage = Pool::uniswap(H160::from_low_u64_be(2), second_pair, (200_000, 50_000));
-        let second_hop_low_slippage = Pool::uniswap(H160::from_low_u64_be(2), second_pair, (200_000_000, 50_000_000));
+        let first_hop_high_price =
+            Pool::uniswap(H160::from_low_u64_be(1), first_pair, (101_000, 100_000));
+        let first_hop_low_price =
+            Pool::uniswap(H160::from_low_u64_be(1), first_pair, (100_000, 101_000));
+        let second_hop_high_slippage =
+            Pool::uniswap(H160::from_low_u64_be(2), second_pair, (200_000, 50_000));
+        let second_hop_low_slippage = Pool::uniswap(
+            H160::from_low_u64_be(2),
+            second_pair,
+            (200_000_000, 50_000_000),
+        );
         let pools = hashmap! {
             first_pair => vec![first_hop_high_price, first_hop_low_price],
             second_pair => vec![second_hop_high_slippage, second_hop_low_slippage],

--- a/crates/shared/src/http_solver/model.rs
+++ b/crates/shared/src/http_solver/model.rs
@@ -58,6 +58,7 @@ pub struct AmmModel {
     pub fee: BigRational,
     pub cost: TokenAmount,
     pub mandatory: bool,
+    pub address: H160,
 }
 
 #[derive(Clone, Debug, Serialize)]

--- a/crates/shared/src/http_solver/model.rs
+++ b/crates/shared/src/http_solver/model.rs
@@ -435,6 +435,7 @@ mod tests {
                 token: native_token,
             },
             mandatory: false,
+            address: H160::from_low_u64_be(1),
         };
         let weighted_product_pool_model = AmmModel {
             parameters: AmmParameters::WeightedProduct(WeightedProductPoolParameters {
@@ -455,6 +456,7 @@ mod tests {
                 token: native_token,
             },
             mandatory: true,
+            address: H160::from_low_u64_be(2),
         };
         let stable_pool_model = AmmModel {
             parameters: AmmParameters::Stable(StablePoolParameters {
@@ -474,6 +476,7 @@ mod tests {
                 token: native_token,
             },
             mandatory: true,
+            address: H160::from_low_u64_be(3),
         };
         let concentrated_pool_model = AmmModel {
             parameters: AmmParameters::Concentrated(ConcentratedPoolParameters {
@@ -498,6 +501,7 @@ mod tests {
                 token: native_token,
             },
             mandatory: false,
+            address: H160::from_low_u64_be(4),
         };
         let model = BatchAuctionModel {
             tokens: btreemap! {
@@ -583,6 +587,7 @@ mod tests {
                 "token": "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
               },
               "mandatory": false,
+              "address": "0x0000000000000000000000000000000000000001",
             },
             "1": {
               "kind": "WeightedProduct",
@@ -602,6 +607,7 @@ mod tests {
                 "token": "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
               },
               "mandatory": true,
+              "address": "0x0000000000000000000000000000000000000002",
             },
             "2": {
               "kind": "Stable",
@@ -620,11 +626,11 @@ mod tests {
                 "token": "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
               },
               "mandatory": true,
+              "address": "0x0000000000000000000000000000000000000003",
             },
             "3": {
               "kind": "Concentrated",
               "pool": {
-                "address": "0x0000000000000000000000000000000000000001",
                  "tokens": [
                 {
                   "id": "0x0000000000000000000000000000000000000539",
@@ -651,6 +657,7 @@ mod tests {
                 "token": "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
               },
               "mandatory": false,
+              "address": "0x0000000000000000000000000000000000000004",
             },
           },
           "metadata": {

--- a/crates/shared/src/price_estimation/baseline.rs
+++ b/crates/shared/src/price_estimation/baseline.rs
@@ -376,7 +376,12 @@ mod tests {
     async fn return_error_if_invalid_reserves() {
         let token_a = H160::from_low_u64_be(1);
         let token_b = H160::from_low_u64_be(2);
-        let pool = Pool::uniswap(TokenPair::new(token_a, token_b).unwrap(), (0, 10));
+        let pool_address = H160::from_low_u64_be(1);
+        let pool = Pool::uniswap(
+            pool_address,
+            TokenPair::new(token_a, token_b).unwrap(),
+            (0, 10),
+        );
 
         let pool_fetcher = Arc::new(FakePoolFetcher(vec![pool]));
         let gas_estimator = Arc::new(FakeGasPriceEstimator(Arc::new(Mutex::new(
@@ -410,11 +415,13 @@ mod tests {
     async fn price_estimate_containing_valid_and_invalid_paths() {
         let token_a = H160::from_low_u64_be(1);
         let token_b = H160::from_low_u64_be(2);
+        let address = H160::from_low_u64_be(1);
 
         // The path via the base token does not exist (making it an invalid path)
         let base_token = H160::from_low_u64_be(3);
 
         let pool = Pool::uniswap(
+            address,
             TokenPair::new(token_a, token_b).unwrap(),
             (10u128.pow(28), 10u128.pow(27)),
         );
@@ -482,10 +489,15 @@ mod tests {
 
         let pools = vec![
             Pool::uniswap(
+                H160::from_low_u64_be(1),
                 TokenPair::new(token_a, token_b).unwrap(),
                 (100_000, 100_000),
             ),
-            Pool::uniswap(TokenPair::new(token_a, token_b).unwrap(), (100_000, 90_000)),
+            Pool::uniswap(
+                H160::from_low_u64_be(2),
+                TokenPair::new(token_a, token_b).unwrap(),
+                (100_000, 90_000),
+            ),
         ];
 
         let pool_fetcher = Arc::new(FakePoolFetcher(pools.clone()));
@@ -539,9 +551,21 @@ mod tests {
 
         // Direct trade is better when selling token_b
         let pools = vec![
-            Pool::uniswap(TokenPair::new(token_a, token_b).unwrap(), (1000, 1000)),
-            Pool::uniswap(TokenPair::new(token_a, intermediate).unwrap(), (900, 1000)),
-            Pool::uniswap(TokenPair::new(intermediate, token_b).unwrap(), (900, 1000)),
+            Pool::uniswap(
+                H160::from_low_u64_be(1),
+                TokenPair::new(token_a, token_b).unwrap(),
+                (1000, 1000),
+            ),
+            Pool::uniswap(
+                H160::from_low_u64_be(2),
+                TokenPair::new(token_a, intermediate).unwrap(),
+                (900, 1000),
+            ),
+            Pool::uniswap(
+                H160::from_low_u64_be(3),
+                TokenPair::new(intermediate, token_b).unwrap(),
+                (900, 1000),
+            ),
         ];
 
         let pool_fetcher = Arc::new(FakePoolFetcher(pools));
@@ -603,18 +627,32 @@ mod tests {
             // worse than the pools between 1, 2, 3 so that it is not used for the trade, just for
             // gas price.
             Pool::uniswap(
+                H160::from_low_u64_be(1),
                 TokenPair::new(native, sell).unwrap(),
                 (100_000_000_000, 2_000),
             ),
             Pool::uniswap(
+                H160::from_low_u64_be(2),
                 TokenPair::new(native, buy).unwrap(),
                 (100_000_000_000, 1_000),
             ),
             // Direct connection 1 to 3.
-            Pool::uniswap(TokenPair::new(sell, buy).unwrap(), (1000, 800)),
+            Pool::uniswap(
+                H160::from_low_u64_be(3),
+                TokenPair::new(sell, buy).unwrap(),
+                (1000, 800),
+            ),
             // Intermediate from 1 to 2 to 2, cheaper than direct.
-            Pool::uniswap(TokenPair::new(sell, intermediate).unwrap(), (1000, 1000)),
-            Pool::uniswap(TokenPair::new(intermediate, buy).unwrap(), (1000, 1000)),
+            Pool::uniswap(
+                H160::from_low_u64_be(4),
+                TokenPair::new(sell, intermediate).unwrap(),
+                (1000, 1000),
+            ),
+            Pool::uniswap(
+                H160::from_low_u64_be(5),
+                TokenPair::new(intermediate, buy).unwrap(),
+                (1000, 1000),
+            ),
         ];
 
         let pool_fetcher = Arc::new(FakePoolFetcher(pools.clone()));
@@ -691,14 +729,17 @@ mod tests {
         // A->C prices buy token to 1.007 but costs G.
 
         let pool_ab = Pool::uniswap(
+            H160::from_low_u64_be(1),
             TokenPair::new(token_a, token_b).unwrap(),
             (10u128.pow(28), 10u128.pow(28)),
         );
         let pool_bc = Pool::uniswap(
+            H160::from_low_u64_be(2),
             TokenPair::new(token_b, token_c).unwrap(),
             (10u128.pow(28), 10u128.pow(28)),
         );
         let pool_ac = Pool::uniswap(
+            H160::from_low_u64_be(3),
             TokenPair::new(token_a, token_c).unwrap(),
             (1004 * 10u128.pow(25), 10u128.pow(28)),
         );

--- a/crates/shared/src/price_estimation/http.rs
+++ b/crates/shared/src/price_estimation/http.rs
@@ -246,6 +246,7 @@ impl HttpPriceEstimator {
                 )),
                 cost: gas_model.uniswap_cost(),
                 mandatory: false,
+                address: pool.address,
             })
             .collect())
     }
@@ -270,6 +271,7 @@ impl HttpPriceEstimator {
                     BigInt::from(*pool.state.fee.denom()),
                 )),
                 cost: gas_model.cost_for_gas(pool.gas_stats.mean_gas),
+                address: pool.address,
                 parameters: AmmParameters::Concentrated(ConcentratedPoolParameters { pool }),
                 mandatory: false,
             })
@@ -310,6 +312,7 @@ impl HttpPriceEstimator {
             fee: pool.common.swap_fee.into(),
             cost: gas_model.balancer_cost(),
             mandatory: false,
+            address: pool.common.address,
         });
         let stable = pools
             .stable_pools
@@ -335,6 +338,7 @@ impl HttpPriceEstimator {
                     fee: pool.common.swap_fee.into(),
                     cost: gas_model.balancer_cost(),
                     mandatory: false,
+                    address: pool.common.address,
                 })
             });
         let mut models = Vec::from_iter(weighted);

--- a/crates/shared/src/sources/swapr/reader.rs
+++ b/crates/shared/src/sources/swapr/reader.rs
@@ -70,9 +70,11 @@ mod tests {
     #[test]
     fn sets_fee() {
         let tokens = TokenPair::new(H160([1; 20]), H160([2; 20])).unwrap();
+        let address = H160::from_low_u64_be(1);
         assert_eq!(
             handle_results(
                 Ok(Some(Pool {
+                    address,
                     tokens,
                     reserves: (13, 37),
                     fee: Ratio::new(3, 1000),
@@ -82,6 +84,7 @@ mod tests {
             .unwrap()
             .unwrap(),
             Pool {
+                address,
                 tokens,
                 reserves: (13, 37),
                 fee: Ratio::new(42, 10000),
@@ -92,8 +95,9 @@ mod tests {
     #[test]
     fn ignores_contract_errors_when_reading_fee() {
         let tokens = TokenPair::new(H160([1; 20]), H160([2; 20])).unwrap();
+        let address = H160::from_low_u64_be(1);
         assert!(handle_results(
-            Ok(Some(Pool::uniswap(tokens, (0, 0)))),
+            Ok(Some(Pool::uniswap(address, tokens, (0, 0)))),
             Err(ethcontract_error::testing_contract_error()),
         )
         .unwrap()

--- a/crates/shared/src/sources/uniswap_v2/pool_fetching.rs
+++ b/crates/shared/src/sources/uniswap_v2/pool_fetching.rs
@@ -360,7 +360,11 @@ mod tests {
         let buy_token = H160::from_low_u64_be(2);
 
         // Even Pool
-        let pool = Pool::uniswap(TokenPair::new(sell_token, buy_token).unwrap(), (100, 100));
+        let pool = Pool::uniswap(
+            H160::from_low_u64_be(1),
+            TokenPair::new(sell_token, buy_token).unwrap(),
+            (100, 100),
+        );
         assert_eq!(
             pool.get_amount_out(sell_token, 10.into()),
             Some((9.into(), buy_token))
@@ -375,7 +379,11 @@ mod tests {
         );
 
         //Uneven Pool
-        let pool = Pool::uniswap(TokenPair::new(sell_token, buy_token).unwrap(), (200, 50));
+        let pool = Pool::uniswap(
+            H160::from_low_u64_be(2),
+            TokenPair::new(sell_token, buy_token).unwrap(),
+            (200, 50),
+        );
         assert_eq!(
             pool.get_amount_out(sell_token, 10.into()),
             Some((2.into(), buy_token))
@@ -391,6 +399,7 @@ mod tests {
 
         // Large Numbers
         let pool = Pool::uniswap(
+            H160::from_low_u64_be(3),
             TokenPair::new(sell_token, buy_token).unwrap(),
             (1u128 << 90, 1u128 << 90),
         );
@@ -409,7 +418,11 @@ mod tests {
         let buy_token = H160::from_low_u64_be(2);
 
         // Even Pool
-        let pool = Pool::uniswap(TokenPair::new(sell_token, buy_token).unwrap(), (100, 100));
+        let pool = Pool::uniswap(
+            H160::from_low_u64_be(1),
+            TokenPair::new(sell_token, buy_token).unwrap(),
+            (100, 100),
+        );
         assert_eq!(
             pool.get_amount_in(buy_token, 10.into()),
             Some((12.into(), sell_token))
@@ -424,7 +437,11 @@ mod tests {
         assert_eq!(pool.get_amount_in(buy_token, 1000.into()), None);
 
         //Uneven Pool
-        let pool = Pool::uniswap(TokenPair::new(sell_token, buy_token).unwrap(), (200, 50));
+        let pool = Pool::uniswap(
+            H160::from_low_u64_be(2),
+            TokenPair::new(sell_token, buy_token).unwrap(),
+            (200, 50),
+        );
         assert_eq!(
             pool.get_amount_in(buy_token, 10.into()),
             Some((51.into(), sell_token))
@@ -436,6 +453,7 @@ mod tests {
 
         // Large Numbers
         let pool = Pool::uniswap(
+            H160::from_low_u64_be(3),
             TokenPair::new(sell_token, buy_token).unwrap(),
             (1u128 << 90, 1u128 << 90),
         );
@@ -472,7 +490,8 @@ mod tests {
             token0_balance: Ok(1.into()),
             token1_balance: Ok(1.into()),
         };
-        assert!(handle_results(fetched_pool).is_err());
+        let pool_address = Default::default();
+        assert!(handle_results(fetched_pool, pool_address).is_err());
     }
 
     #[test]
@@ -483,6 +502,9 @@ mod tests {
             token0_balance: Ok(1.into()),
             token1_balance: Ok(1.into()),
         };
-        assert!(handle_results(fetched_pool).unwrap().is_none())
+        let pool_address = Default::default();
+        assert!(handle_results(fetched_pool, pool_address)
+            .unwrap()
+            .is_none())
     }
 }

--- a/crates/shared/src/sources/uniswap_v3/pool_fetching.rs
+++ b/crates/shared/src/sources/uniswap_v3/pool_fetching.rs
@@ -479,7 +479,6 @@ mod tests {
     #[test]
     fn encode_decode_pool_info() {
         let json = json!({
-            "address": "0x0001fcbba8eb491c3ccfeddc5a5caba1a98c4c28",
             "tokens": [
                 {
                     "id": "0xbef81556ef066ec840a540595c8d12f516b6378f",

--- a/crates/shared/src/sources/uniswap_v3/pool_fetching.rs
+++ b/crates/shared/src/sources/uniswap_v3/pool_fetching.rs
@@ -36,6 +36,7 @@ pub trait PoolFetching: Send + Sync {
 /// Pool data in a format prepared for solvers.
 #[derive(Clone, Debug, Default, Eq, PartialEq, Serialize)]
 pub struct PoolInfo {
+    #[serde(skip_serializing)]
     pub address: H160,
     pub tokens: Vec<Token>,
     pub state: PoolState,

--- a/crates/shared/src/sources/uniswap_v3/pool_fetching.rs
+++ b/crates/shared/src/sources/uniswap_v3/pool_fetching.rs
@@ -36,6 +36,7 @@ pub trait PoolFetching: Send + Sync {
 /// Pool data in a format prepared for solvers.
 #[derive(Clone, Debug, Default, Eq, PartialEq, Serialize)]
 pub struct PoolInfo {
+    /// Skip serializing address since it's redundant (already serialized outside of this struct)
     #[serde(skip_serializing)]
     pub address: H160,
     pub tokens: Vec<Token>,

--- a/crates/solver/src/liquidity.rs
+++ b/crates/solver/src/liquidity.rs
@@ -164,6 +164,7 @@ impl Default for LimitOrder {
 #[cfg_attr(test, derive(Derivative))]
 #[cfg_attr(test, derivative(PartialEq))]
 pub struct ConstantProductOrder {
+    pub address: H160,
     pub tokens: TokenPair,
     pub reserves: (u128, u128),
     pub fee: Ratio<u32>,
@@ -181,6 +182,7 @@ impl std::fmt::Debug for ConstantProductOrder {
 impl From<Pool> for ConstantProductOrder {
     fn from(pool: Pool) -> Self {
         Self {
+            address: pool.address,
             tokens: pool.tokens,
             reserves: pool.reserves,
             fee: pool.fee,
@@ -194,6 +196,7 @@ impl From<Pool> for ConstantProductOrder {
 #[cfg_attr(test, derive(Derivative))]
 #[cfg_attr(test, derivative(PartialEq))]
 pub struct WeightedProductOrder {
+    pub address: H160,
     pub reserves: HashMap<H160, WeightedTokenState>,
     pub fee: Bfp,
     #[cfg_attr(test, derivative(PartialEq = "ignore"))]
@@ -210,6 +213,7 @@ impl std::fmt::Debug for WeightedProductOrder {
 #[cfg_attr(test, derive(Derivative))]
 #[cfg_attr(test, derivative(PartialEq))]
 pub struct StablePoolOrder {
+    pub address: H160,
     pub reserves: HashMap<H160, TokenState>,
     pub fee: BigRational,
     pub amplification_parameter: AmplificationParameter,
@@ -306,6 +310,7 @@ impl Settleable for ConcentratedLiquidity {
 impl Default for ConstantProductOrder {
     fn default() -> Self {
         ConstantProductOrder {
+            address: Default::default(),
             tokens: Default::default(),
             reserves: Default::default(),
             fee: num::Zero::zero(),
@@ -318,6 +323,7 @@ impl Default for ConstantProductOrder {
 impl Default for WeightedProductOrder {
     fn default() -> Self {
         WeightedProductOrder {
+            address: Default::default(),
             reserves: Default::default(),
             fee: Bfp::zero(),
             settlement_handling: tests::CapturingSettlementHandler::arc(),
@@ -329,6 +335,7 @@ impl Default for WeightedProductOrder {
 impl Default for StablePoolOrder {
     fn default() -> Self {
         StablePoolOrder {
+            address: Default::default(),
             reserves: Default::default(),
             fee: num::Zero::zero(),
             amplification_parameter: AmplificationParameter::new(1.into(), 1.into()).unwrap(),

--- a/crates/solver/src/liquidity/balancer_v2.rs
+++ b/crates/solver/src/liquidity/balancer_v2.rs
@@ -72,6 +72,7 @@ impl BalancerV2Liquidity {
             .weighted_pools
             .into_iter()
             .map(|pool| WeightedProductOrder {
+                address: pool.common.address,
                 reserves: pool.reserves,
                 fee: pool.common.swap_fee,
                 settlement_handling: Arc::new(SettlementHandler {
@@ -86,6 +87,7 @@ impl BalancerV2Liquidity {
             .stable_pools
             .into_iter()
             .map(|pool| StablePoolOrder {
+                address: pool.common.address,
                 reserves: pool.reserves,
                 fee: pool.common.swap_fee.into(),
                 amplification_parameter: pool.amplification_parameter,

--- a/crates/solver/src/liquidity/uniswap_v2.rs
+++ b/crates/solver/src/liquidity/uniswap_v2.rs
@@ -90,6 +90,7 @@ impl UniswapLikeLiquidity {
             tokens.insert(pool.tokens.get().1);
 
             result.push(ConstantProductOrder {
+                address: pool.address,
                 tokens: pool.tokens,
                 reserves: pool.reserves,
                 fee: pool.fee,

--- a/crates/solver/src/settlement_simulation.rs
+++ b/crates/solver/src/settlement_simulation.rs
@@ -454,6 +454,7 @@ mod tests {
             .collect::<Vec<_>>();
 
         let cpo_0 = ConstantProductOrder {
+            address: H160::from_low_u64_be(1),
             tokens: TokenPair::new(
                 "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"
                     .parse()
@@ -476,6 +477,7 @@ mod tests {
         };
 
         let spo = StablePoolOrder {
+            address: H160::from_low_u64_be(1),
             reserves: hashmap! {
                 "0x6b175474e89094c44da98b954eedeac495271d0f".parse().unwrap() => TokenState {
                     balance: U256::from(46543572661097157184873466u128),

--- a/crates/solver/src/solver/baseline_solver.rs
+++ b/crates/solver/src/solver/baseline_solver.rs
@@ -296,6 +296,7 @@ impl Solution {
 
 fn amm_to_pool(amm: &ConstantProductOrder) -> Pool {
     Pool {
+        address: amm.address,
         tokens: amm.tokens,
         reserves: amm.reserves,
         fee: amm.fee,

--- a/crates/solver/src/solver/baseline_solver.rs
+++ b/crates/solver/src/solver/baseline_solver.rs
@@ -370,6 +370,7 @@ mod tests {
         ];
         let amms = vec![
             ConstantProductOrder {
+                address: H160::from_low_u64_be(1),
                 tokens: TokenPair::new(buy_token, sell_token).unwrap(),
                 reserves: (1_000_000, 1_000_000),
                 fee: Ratio::new(3, 1000),
@@ -377,6 +378,7 @@ mod tests {
             },
             // Path via native token has more liquidity
             ConstantProductOrder {
+                address: H160::from_low_u64_be(2),
                 tokens: TokenPair::new(sell_token, native_token).unwrap(),
                 reserves: (10_000_000, 10_000_000),
                 fee: Ratio::new(3, 1000),
@@ -384,12 +386,14 @@ mod tests {
             },
             // Second native token pool has a worse price despite larger k
             ConstantProductOrder {
+                address: H160::from_low_u64_be(3),
                 tokens: TokenPair::new(sell_token, native_token).unwrap(),
                 reserves: (11_000_000, 10_000_000),
                 fee: Ratio::new(3, 1000),
                 settlement_handling: amm_handler[1].clone(),
             },
             ConstantProductOrder {
+                address: H160::from_low_u64_be(4),
                 tokens: TokenPair::new(native_token, buy_token).unwrap(),
                 reserves: (10_000_000, 10_000_000),
                 fee: Ratio::new(3, 1000),
@@ -479,6 +483,7 @@ mod tests {
         ];
         let amms = vec![
             ConstantProductOrder {
+                address: H160::from_low_u64_be(1),
                 tokens: TokenPair::new(buy_token, sell_token).unwrap(),
                 reserves: (1_000_000, 1_000_000),
                 fee: Ratio::new(3, 1000),
@@ -486,6 +491,7 @@ mod tests {
             },
             // Path via native token has more liquidity
             ConstantProductOrder {
+                address: H160::from_low_u64_be(2),
                 tokens: TokenPair::new(sell_token, native_token).unwrap(),
                 reserves: (10_000_000, 10_000_000),
                 fee: Ratio::new(3, 1000),
@@ -493,12 +499,14 @@ mod tests {
             },
             // Second native token pool has a worse price despite larger k
             ConstantProductOrder {
+                address: H160::from_low_u64_be(3),
                 tokens: TokenPair::new(sell_token, native_token).unwrap(),
                 reserves: (11_000_000, 10_000_000),
                 fee: Ratio::new(3, 1000),
                 settlement_handling: amm_handler[1].clone(),
             },
             ConstantProductOrder {
+                address: H160::from_low_u64_be(4),
                 tokens: TokenPair::new(native_token, buy_token).unwrap(),
                 reserves: (10_000_000, 10_000_000),
                 fee: Ratio::new(3, 1000),
@@ -565,6 +573,7 @@ mod tests {
 
         let amms = vec![
             ConstantProductOrder {
+                address: H160::from_low_u64_be(1),
                 tokens: TokenPair::new(buy_token, sell_token).unwrap(),
                 reserves: (10_000_000, 10_000_000),
                 fee: Ratio::new(3, 1000),
@@ -572,6 +581,7 @@ mod tests {
             },
             // Other direct pool has not enough liquidity to compute a valid estimate
             ConstantProductOrder {
+                address: H160::from_low_u64_be(2),
                 tokens: TokenPair::new(buy_token, sell_token).unwrap(),
                 reserves: (0, 0),
                 fee: Ratio::new(3, 1000),
@@ -604,6 +614,7 @@ mod tests {
         };
         let liquidity = vec![
             Liquidity::ConstantProduct(ConstantProductOrder {
+                address: H160::from_low_u64_be(1),
                 tokens: TokenPair::new(
                     addr!("a7d1c04faf998f9161fc9f800a99a809b84cfc9d"),
                     addr!("c778417e063141139fce010982780140aa0cd5ab"),
@@ -614,6 +625,7 @@ mod tests {
                 settlement_handling: CapturingSettlementHandler::arc(),
             }),
             Liquidity::BalancerWeighted(WeightedProductOrder {
+                address: H160::from_low_u64_be(2),
                 reserves: hashmap! {
                     addr!("c778417e063141139fce010982780140aa0cd5ab") => WeightedTokenState {
                         common: TokenState {
@@ -661,12 +673,14 @@ mod tests {
             ..Default::default()
         };
         let pool_0 = ConstantProductOrder {
+            address: H160::from_low_u64_be(1),
             tokens: TokenPair::new(tokens[1], tokens[2]).unwrap(),
             reserves: (10, 12),
             fee: Ratio::new(0, 1),
             settlement_handling: CapturingSettlementHandler::arc(),
         };
         let pool_1 = WeightedProductOrder {
+            address: H160::from_low_u64_be(2),
             reserves: [
                 (
                     tokens[0],

--- a/crates/solver/src/solver/http_solver.rs
+++ b/crates/solver/src/solver/http_solver.rs
@@ -594,6 +594,7 @@ mod tests {
             ..Default::default()
         }];
         let liquidity = vec![Liquidity::ConstantProduct(ConstantProductOrder {
+            address: H160::from_low_u64_be(1),
             tokens: TokenPair::new(buy_token, sell_token).unwrap(),
             reserves: (base(100), base(100)),
             fee: Ratio::new(0, 1),
@@ -652,6 +653,7 @@ mod tests {
             .iter()
             .map(|tokens| {
                 Liquidity::ConstantProduct(ConstantProductOrder {
+                    address: H160::from_low_u64_be(1),
                     tokens: TokenPair::new(tokens.0, tokens.1).unwrap(),
                     reserves: (0, 0),
                     fee: 0.into(),

--- a/crates/solver/src/solver/http_solver.rs
+++ b/crates/solver/src/solver/http_solver.rs
@@ -303,6 +303,7 @@ fn amm_models(liquidity: &[Liquidity], gas_model: &GasModel) -> BTreeMap<usize, 
                     ),
                     cost: gas_model.uniswap_cost(),
                     mandatory: false,
+                    address: amm.address,
                 },
                 Liquidity::BalancerWeighted(amm) => AmmModel {
                     parameters: AmmParameters::WeightedProduct(WeightedProductPoolParameters {
@@ -323,6 +324,7 @@ fn amm_models(liquidity: &[Liquidity], gas_model: &GasModel) -> BTreeMap<usize, 
                     fee: amm.fee.into(),
                     cost: gas_model.balancer_cost(),
                     mandatory: false,
+                    address: amm.address,
                 },
                 Liquidity::BalancerStable(amm) => AmmModel {
                     parameters: AmmParameters::Stable(StablePoolParameters {
@@ -346,6 +348,7 @@ fn amm_models(liquidity: &[Liquidity], gas_model: &GasModel) -> BTreeMap<usize, 
                     fee: amm.fee.clone(),
                     cost: gas_model.balancer_cost(),
                     mandatory: false,
+                    address: amm.address,
                 },
                 Liquidity::LimitOrder(_) => unreachable!("filtered out before"),
                 Liquidity::Concentrated(amm) => AmmModel {
@@ -358,6 +361,7 @@ fn amm_models(liquidity: &[Liquidity], gas_model: &GasModel) -> BTreeMap<usize, 
                     ),
                     cost: gas_model.cost_for_gas(amm.pool.gas_stats.mean_gas),
                     mandatory: false,
+                    address: amm.pool.address,
                 },
             })
         })

--- a/crates/solver/src/solver/http_solver/settlement.rs
+++ b/crates/solver/src/solver/http_solver/settlement.rs
@@ -401,18 +401,21 @@ mod tests {
         let sp_amm_handler = CapturingSettlementHandler::arc();
         let liquidity = vec![
             Liquidity::ConstantProduct(ConstantProductOrder {
+                address: H160::from_low_u64_be(1),
                 tokens: TokenPair::new(t0, t1).unwrap(),
                 reserves: (3, 4),
                 fee: 5.into(),
                 settlement_handling: cp_amm_handler.clone(),
             }),
             Liquidity::ConstantProduct(ConstantProductOrder {
+                address: H160::from_low_u64_be(2),
                 tokens: TokenPair::new(t0, t1).unwrap(),
                 reserves: (6, 7),
                 fee: 8.into(),
                 settlement_handling: internal_amm_handler.clone(),
             }),
             Liquidity::BalancerWeighted(WeightedProductOrder {
+                address: H160::from_low_u64_be(3),
                 reserves: hashmap! {
                     t0 => WeightedTokenState {
                         common: TokenState {
@@ -433,6 +436,7 @@ mod tests {
                 settlement_handling: wp_amm_handler.clone(),
             }),
             Liquidity::BalancerStable(StablePoolOrder {
+                address: H160::from_low_u64_be(4),
                 reserves: hashmap! {
                     t0 => TokenState {
                         balance: U256::from(300),
@@ -628,12 +632,14 @@ mod tests {
         let token_c = H160::from_slice(&hex!("e4b9895e638f54c3bee2a3a78d6a297cc03e0353"));
 
         let cpo_0 = ConstantProductOrder {
+            address: H160::from_low_u64_be(1),
             tokens: TokenPair::new(token_a, token_b).unwrap(),
             reserves: (597249810824827988770940, 225724246562756585230),
             fee: Ratio::new(3, 1000),
             settlement_handling: CapturingSettlementHandler::arc(),
         };
         let cpo_1 = ConstantProductOrder {
+            address: H160::from_low_u64_be(2),
             tokens: TokenPair::new(token_b, token_c).unwrap(),
             reserves: (8488677530563931705, 75408146511005299032),
             fee: Ratio::new(3, 1000),
@@ -641,6 +647,7 @@ mod tests {
         };
 
         let wpo = WeightedProductOrder {
+            address: H160::from_low_u64_be(3),
             reserves: hashmap! {
                 token_c => WeightedTokenState {
                     common: TokenState {
@@ -662,6 +669,7 @@ mod tests {
         };
 
         let spo = StablePoolOrder {
+            address: H160::from_low_u64_be(4),
             reserves: hashmap! {
                 token_c => TokenState {
                     balance: U256::from(1234u128),
@@ -898,6 +906,7 @@ mod tests {
         let token_b = H160::from_slice(&hex!("c778417e063141139fce010982780140aa0cd5ab"));
 
         let cpo_1 = ConstantProductOrder {
+            address: H160::from_low_u64_be(1),
             tokens: TokenPair::new(token_a, token_b).unwrap(),
             reserves: (8488677530563931705, 75408146511005299032),
             fee: Ratio::new(3, 1000),

--- a/crates/solver/src/solver/naive_solver.rs
+++ b/crates/solver/src/solver/naive_solver.rs
@@ -138,6 +138,7 @@ mod tests {
         let liquidity = vec![
             // Deep pool
             ConstantProductOrder {
+                address: H160::from_low_u64_be(1),
                 tokens: token_pair,
                 reserves: (10_000_000, 10_000_000),
                 fee: Ratio::new(3, 1000),
@@ -145,6 +146,7 @@ mod tests {
             },
             // Shallow pool
             ConstantProductOrder {
+                address: H160::from_low_u64_be(2),
                 tokens: token_pair,
                 reserves: (100, 100),
                 fee: Ratio::new(3, 1000),
@@ -152,6 +154,7 @@ mod tests {
             },
             // unrelated pool
             ConstantProductOrder {
+                address: H160::from_low_u64_be(3),
                 tokens: unrelated_token_pair,
                 reserves: (10_000_000, 10_000_000),
                 fee: Ratio::new(3, 1000),
@@ -217,6 +220,7 @@ mod tests {
         .unwrap();
         let liquidity = hashmap! {
             tokens => ConstantProductOrder {
+                address: H160::from_low_u64_be(1),
                 tokens,
                 reserves: (58360914, 17856367410307570970),
                 fee: Ratio::new(3, 1000),
@@ -265,6 +269,7 @@ mod tests {
         let tokens = TokenPair::new(H160([1; 20]), H160([2; 20])).unwrap();
         let liquidity = hashmap! {
             tokens => ConstantProductOrder {
+                address: H160::from_low_u64_be(1),
                 tokens,
                 reserves: (1_000_000_000_000_000_000, 1_000_000_000_000_000_000),
                 fee: Ratio::new(3, 1000),
@@ -316,6 +321,7 @@ mod tests {
         let tokens = TokenPair::new(native_token, H160([2; 20])).unwrap();
         let liquidity = hashmap! {
             tokens => ConstantProductOrder {
+                address: H160::from_low_u64_be(1),
                 tokens,
                 reserves: (1_000_000_000_000_000_000, 1_000_000_000_000_000_000),
                 fee: Ratio::new(3, 1000),

--- a/crates/solver/src/solver/naive_solver/multi_order_solver.rs
+++ b/crates/solver/src/solver/naive_solver/multi_order_solver.rs
@@ -332,6 +332,7 @@ mod tests {
     use crate::{
         liquidity::slippage::SlippageCalculator, settlement::external_prices::ExternalPrices,
     };
+    use ethcontract::H160;
     use liquidity::tests::CapturingSettlementHandler;
     use maplit::hashmap;
     use model::{
@@ -380,6 +381,7 @@ mod tests {
 
         let amm_handler = CapturingSettlementHandler::arc();
         let pool = ConstantProductOrder {
+            address: H160::from_low_u64_be(1),
             tokens: TokenPair::new(token_a, token_b).unwrap(),
             reserves: (to_wei(1000).as_u128(), to_wei(1000).as_u128()),
             fee: Ratio::new(3, 1000),
@@ -436,6 +438,7 @@ mod tests {
 
         let amm_handler = CapturingSettlementHandler::arc();
         let pool = ConstantProductOrder {
+            address: H160::from_low_u64_be(1),
             tokens: TokenPair::new(token_a, token_b).unwrap(),
             reserves: (to_wei(1_000_000).as_u128(), to_wei(1_000_000).as_u128()),
             fee: Ratio::new(3, 1000),
@@ -488,6 +491,7 @@ mod tests {
 
         let amm_handler = CapturingSettlementHandler::arc();
         let pool = ConstantProductOrder {
+            address: H160::from_low_u64_be(1),
             tokens: TokenPair::new(token_a, token_b).unwrap(),
             reserves: (to_wei(1000).as_u128(), to_wei(1000).as_u128()),
             fee: Ratio::new(3, 1000),
@@ -544,6 +548,7 @@ mod tests {
 
         let amm_handler = CapturingSettlementHandler::arc();
         let pool = ConstantProductOrder {
+            address: H160::from_low_u64_be(1),
             tokens: TokenPair::new(token_a, token_b).unwrap(),
             reserves: (to_wei(1000).as_u128(), to_wei(1000).as_u128()),
             fee: Ratio::new(3, 1000),
@@ -604,6 +609,7 @@ mod tests {
 
         let amm_handler = CapturingSettlementHandler::arc();
         let pool = ConstantProductOrder {
+            address: H160::from_low_u64_be(1),
             tokens: TokenPair::new(token_a, token_b).unwrap(),
             reserves: (to_wei(1_000_001).as_u128(), to_wei(1_000_000).as_u128()),
             fee: Ratio::new(3, 1000),
@@ -685,6 +691,7 @@ mod tests {
 
         let amm_handler = CapturingSettlementHandler::arc();
         let pool = ConstantProductOrder {
+            address: H160::from_low_u64_be(1),
             tokens: TokenPair::new(token_a, token_b).unwrap(),
             reserves: (to_wei(1_000_000).as_u128(), to_wei(1_000_000).as_u128()),
             fee: Ratio::new(3, 1000),
@@ -731,6 +738,7 @@ mod tests {
 
         let amm_handler = CapturingSettlementHandler::arc();
         let pool = ConstantProductOrder {
+            address: H160::from_low_u64_be(1),
             tokens: TokenPair::new(token_a, token_b).unwrap(),
             reserves: (to_wei(1_000_001).as_u128(), to_wei(1_000_000).as_u128()),
             fee: Ratio::new(3, 1000),
@@ -863,6 +871,7 @@ mod tests {
 
         let amm_handler = CapturingSettlementHandler::arc();
         let pool = ConstantProductOrder {
+            address: H160::from_low_u64_be(1),
             tokens: TokenPair::new(token_a, token_b).unwrap(),
             reserves: (u128::MAX, u128::MAX),
             fee: Ratio::new(3, 1000),
@@ -906,6 +915,7 @@ mod tests {
         ];
         // Reserves are much smaller than buy amount
         let pool = ConstantProductOrder {
+            address: H160::from_low_u64_be(1),
             tokens: TokenPair::new(token_a, token_b).unwrap(),
             reserves: (25000075, 2500007500),
             fee: Ratio::new(3, 1000),
@@ -954,6 +964,7 @@ mod tests {
         ];
 
         let pool = Pool::uniswap(
+            H160::from_low_u64_be(1),
             TokenPair::new(token_a, token_b).unwrap(),
             (1_000_000_000_000_000_000, 1_000_000_000_000_000_000),
         );
@@ -1011,6 +1022,7 @@ mod tests {
 
         let amm_handler = CapturingSettlementHandler::arc();
         let pool = ConstantProductOrder {
+            address: H160::from_low_u64_be(1),
             tokens: TokenPair::new(token_a, token_b).unwrap(),
             reserves: (to_wei(1000).as_u128(), to_wei(1000).as_u128()),
             fee: Ratio::new(3, 1000),


### PR DESCRIPTION
Fixes #494  partially.

Added pool address to each amm sent to solver.
Liquidity fetch block number, although it exists, is not guaranteed to be correct at the moment, and is a bit trickier to fix, so will leave it as a separate PR and work on that later.

Note that most of the code changes are fixes of dependent unit tests.

### Test Plan

Unit tests passing.
