### PR TITLE
Add params for solver callback

### DIFF
--- a/crates/solver/src/driver_logger.rs
+++ b/crates/solver/src/driver_logger.rs
@@ -147,24 +147,14 @@ impl DriverLogger {
         let simulation_gas_limit = self.simulation_gas_limit;
         let task = async move {
             let simulations = simulate_and_error_with_tenderly_link(
-                errors.iter().map(
-                    |SimulationWithError {
-                         simulation:
-                             Simulation {
-                                 solver,
-                                 settlement,
-                                 transaction,
-                                 ..
-                             },
-                         ..
-                     }| {
-                        (
-                            solver.account().clone(),
-                            settlement.clone(),
-                            transaction.access_list.clone(),
-                        )
-                    },
-                ),
+                errors.iter().map(|simulation_with_error| {
+                    let simulation = &simulation_with_error.simulation;
+                    (
+                        simulation.solver.account().clone(),
+                        simulation.settlement.clone(),
+                        simulation.transaction.access_list.clone(),
+                    )
+                }),
                 &contract,
                 &web3,
                 gas_price,

--- a/crates/solver/src/driver_logger.rs
+++ b/crates/solver/src/driver_logger.rs
@@ -147,15 +147,20 @@ impl DriverLogger {
         let simulation_gas_limit = self.simulation_gas_limit;
         let task = async move {
             let simulations = simulate_and_error_with_tenderly_link(
-                errors
-                    .iter()
-                    .map(|(solver, settlement, access_list, _, _)| {
+                errors.iter().map(
+                    |SettlementWithError {
+                         solver,
+                         settlement,
+                         access_list,
+                         ..
+                     }| {
                         (
                             solver.account().clone(),
                             settlement.clone(),
                             access_list.clone(),
                         )
-                    }),
+                    },
+                ),
                 &contract,
                 &web3,
                 gas_price,
@@ -165,7 +170,13 @@ impl DriverLogger {
             )
             .await;
 
-            for ((solver, settlement, _, _, _), result) in errors.iter().zip(simulations) {
+            for (
+                SettlementWithError {
+                    solver, settlement, ..
+                },
+                result,
+            ) in errors.iter().zip(simulations)
+            {
                 metrics
                     .settlement_simulation(solver.name(), SolverSimulationOutcome::FailureOnLatest);
                 if let Err(error_at_earlier_block) = result {

--- a/crates/solver/src/driver_logger.rs
+++ b/crates/solver/src/driver_logger.rs
@@ -147,13 +147,15 @@ impl DriverLogger {
         let simulation_gas_limit = self.simulation_gas_limit;
         let task = async move {
             let simulations = simulate_and_error_with_tenderly_link(
-                errors.iter().map(|(solver, settlement, access_list, _)| {
-                    (
-                        solver.account().clone(),
-                        settlement.clone(),
-                        access_list.clone(),
-                    )
-                }),
+                errors
+                    .iter()
+                    .map(|(solver, settlement, access_list, _, _)| {
+                        (
+                            solver.account().clone(),
+                            settlement.clone(),
+                            access_list.clone(),
+                        )
+                    }),
                 &contract,
                 &web3,
                 gas_price,
@@ -163,7 +165,7 @@ impl DriverLogger {
             )
             .await;
 
-            for ((solver, settlement, _, _), result) in errors.iter().zip(simulations) {
+            for ((solver, settlement, _, _, _), result) in errors.iter().zip(simulations) {
                 metrics
                     .settlement_simulation(solver.name(), SolverSimulationOutcome::FailureOnLatest);
                 if let Err(error_at_earlier_block) = result {

--- a/crates/solver/src/driver_logger.rs
+++ b/crates/solver/src/driver_logger.rs
@@ -151,13 +151,13 @@ impl DriverLogger {
                     |SettlementWithError {
                          solver,
                          settlement,
-                         access_list,
+                         simulation,
                          ..
                      }| {
                         (
                             solver.account().clone(),
                             settlement.clone(),
-                            access_list.clone(),
+                            simulation.access_list.clone(),
                         )
                     },
                 ),

--- a/crates/solver/src/settlement_ranker.rs
+++ b/crates/solver/src/settlement_ranker.rs
@@ -162,14 +162,23 @@ impl SettlementRanker {
             rated_settlements.len(),
             errors.len(),
         );
-        for (solver, settlement, _, block_number, error) in &errors {
+        for SettlementWithError {
+            solver,
+            settlement,
+            error,
+            simulation,
+            ..
+        } in &errors
+        {
             solver.notify_auction_result(
                 auction_id,
                 AuctionResult::Rejected(SolverRejectionReason::SimulationFailure(
                     SimulationFailureParams {
                         message: error.to_string(),
-                        block_number: *block_number,
                         data: call_data(settlement.clone().into()),
+                        from: solver.account().address(),
+                        to: simulation.to,
+                        block_number: simulation.block_number,
                     },
                 )),
             );

--- a/crates/solver/src/settlement_ranker.rs
+++ b/crates/solver/src/settlement_ranker.rs
@@ -178,9 +178,7 @@ impl SettlementRanker {
                     SimulationFailureParams {
                         message: error.to_string(),
                         data: call_data(settlement.clone().into()),
-                        from: solver.account().address(),
-                        to: transaction.to,
-                        block_number: transaction.block_number,
+                        transaction: transaction.clone(),
                     },
                 )),
             );

--- a/crates/solver/src/settlement_ranker.rs
+++ b/crates/solver/src/settlement_ranker.rs
@@ -8,7 +8,7 @@ use crate::{
     settlement_simulation::call_data,
     solver::{
         AuctionResult, SimulationWithError, Solver, SolverRejectionReason, SolverRunError,
-        TransactionWithMessage,
+        TransactionWithError,
     },
 };
 use anyhow::Result;
@@ -166,9 +166,9 @@ impl SettlementRanker {
             error.simulation.solver.notify_auction_result(
                 auction_id,
                 AuctionResult::Rejected(SolverRejectionReason::SimulationFailure(
-                    TransactionWithMessage {
+                    TransactionWithError {
                         transaction: error.simulation.transaction.clone(),
-                        message: error.error.to_string(),
+                        error: error.error.to_string(),
                     },
                 )),
             );

--- a/crates/solver/src/settlement_ranker.rs
+++ b/crates/solver/src/settlement_ranker.rs
@@ -6,7 +6,10 @@ use crate::{
     },
     settlement_rater::{RatedSolverSettlement, SettlementRating},
     settlement_simulation::call_data,
-    solver::{AuctionResult, SettlementWithError, Solver, SolverRejectionReason, SolverRunError},
+    solver::{
+        AuctionResult, SettlementWithError, SimulationFailureParams, Solver, SolverRejectionReason,
+        SolverRunError,
+    },
 };
 use anyhow::Result;
 use gas_estimation::GasPrice1559;
@@ -159,12 +162,15 @@ impl SettlementRanker {
             rated_settlements.len(),
             errors.len(),
         );
-        for (solver, settlement, _, error) in &errors {
+        for (solver, settlement, _, block_number, error) in &errors {
             solver.notify_auction_result(
                 auction_id,
                 AuctionResult::Rejected(SolverRejectionReason::SimulationFailure(
-                    error.to_string(),
-                    call_data(settlement.clone().into()),
+                    SimulationFailureParams {
+                        message: error.to_string(),
+                        block_number: *block_number,
+                        data: call_data(settlement.clone().into()),
+                    },
                 )),
             );
         }

--- a/crates/solver/src/settlement_ranker.rs
+++ b/crates/solver/src/settlement_ranker.rs
@@ -7,8 +7,8 @@ use crate::{
     settlement_rater::{RatedSolverSettlement, SettlementRating},
     settlement_simulation::call_data,
     solver::{
-        AuctionResult, Simulation, SimulationFailureParams, SimulationWithError, Solver,
-        SolverRejectionReason, SolverRunError,
+        AuctionResult, SimulationWithError, Solver, SolverRejectionReason, SolverRunError,
+        TransactionWithMessage,
     },
 };
 use anyhow::Result;
@@ -162,23 +162,13 @@ impl SettlementRanker {
             rated_settlements.len(),
             errors.len(),
         );
-        for SimulationWithError {
-            simulation:
-                Simulation {
-                    solver,
-                    settlement,
-                    transaction,
-                },
-            error,
-        } in &errors
-        {
-            solver.notify_auction_result(
+        for error in &errors {
+            error.simulation.solver.notify_auction_result(
                 auction_id,
                 AuctionResult::Rejected(SolverRejectionReason::SimulationFailure(
-                    SimulationFailureParams {
-                        message: error.to_string(),
-                        data: call_data(settlement.clone().into()),
-                        transaction: transaction.clone(),
+                    TransactionWithMessage {
+                        transaction: error.simulation.transaction.clone(),
+                        message: error.error.to_string(),
                     },
                 )),
             );

--- a/crates/solver/src/settlement_rater.rs
+++ b/crates/solver/src/settlement_rater.rs
@@ -116,13 +116,14 @@ impl SettlementRating for SettlementRater {
             .map(
                 |((solver, settlement, access_list), simulation_result)| SimulationWithResult {
                     simulation: Simulation {
-                        settlement,
-                        solver,
                         transaction: SimulatedTransaction {
                             access_list,
                             block_number,
                             to: self.settlement_contract.address(),
+                            from: solver.account().address(),
                         },
+                        settlement,
+                        solver,
                     },
                     gas_estimate: simulation_result,
                 },

--- a/crates/solver/src/settlement_rater.rs
+++ b/crates/solver/src/settlement_rater.rs
@@ -159,20 +159,26 @@ impl SettlementRating for SettlementRater {
             }
         };
 
-        Ok(
-            (simulations.into_iter().enumerate()).partition_map(|(i, details)| {
-                match details.gas_estimate {
+        Ok((simulations.into_iter().enumerate()).partition_map(
+            |(
+                i,
+                SimulationWithResult {
+                    simulation,
+                    gas_estimate,
+                },
+            )| {
+                match gas_estimate {
                     Ok(gas_estimate) => Either::Left((
-                        details.simulation.solver,
-                        rate_settlement(i, details.simulation.settlement, gas_estimate),
-                        details.simulation.transaction.access_list,
+                        simulation.solver,
+                        rate_settlement(i, simulation.settlement, gas_estimate),
+                        simulation.transaction.access_list,
                     )),
                     Err(err) => Either::Right(SimulationWithError {
-                        simulation: details.simulation,
+                        simulation,
                         error: err,
                     }),
                 }
-            }),
-        )
+            },
+        ))
     }
 }

--- a/crates/solver/src/settlement_rater.rs
+++ b/crates/solver/src/settlement_rater.rs
@@ -21,6 +21,8 @@ pub type RatedSolverSettlement = (Arc<dyn Solver>, RatedSettlement, Option<Acces
 
 pub struct SimulationWithResult {
     pub simulation: Simulation,
+    /// The outcome of the simulation. Contains either how much gas the settlement used or the
+    /// reason why the transaction reverted during the simulation.
     pub gas_estimate: Result<U256, ExecutionError>,
 }
 

--- a/crates/solver/src/settlement_rater.rs
+++ b/crates/solver/src/settlement_rater.rs
@@ -174,11 +174,11 @@ impl SettlementRating for SettlementRater {
                     Err(err) => Either::Right(SettlementWithError {
                         solver: details.solver,
                         settlement: details.settlement,
-                        access_list: details.access_list,
                         error: err,
                         simulation: SimulatedTransaction {
                             block_number: details.block_number,
                             to: details.to,
+                            access_list: details.access_list,
                         },
                     }),
                 }

--- a/crates/solver/src/settlement_rater.rs
+++ b/crates/solver/src/settlement_rater.rs
@@ -2,7 +2,7 @@ use crate::{
     driver::solver_settlements::RatedSettlement,
     settlement::{external_prices::ExternalPrices, Settlement},
     settlement_access_list::AccessListEstimating,
-    settlement_simulation::{settle_method, simulate_and_estimate_gas_at_current_block},
+    settlement_simulation::{call_data, settle_method, simulate_and_estimate_gas_at_current_block},
     solver::{SettlementWithSolver, SimulatedTransaction, Simulation, SimulationWithError, Solver},
 };
 use anyhow::{Context, Result};
@@ -121,6 +121,7 @@ impl SettlementRating for SettlementRater {
                             block_number,
                             to: self.settlement_contract.address(),
                             from: solver.account().address(),
+                            data: call_data(settlement.clone().into()),
                         },
                         settlement,
                         solver,

--- a/crates/solver/src/solver.rs
+++ b/crates/solver/src/solver.rs
@@ -98,8 +98,12 @@ pub enum AuctionResult {
 }
 
 pub struct SimulationFailureParams {
+    /// Error message from the simulator
     pub message: String,
+    /// The simulation was done on top of all transactions from the given block number
+    /// If block_number is to be used for tenderly simulation, it should be increased by 1
     pub block_number: BlockNumber,
+    /// Transaction input data
     pub data: Vec<u8>,
 }
 

--- a/crates/solver/src/solver.rs
+++ b/crates/solver/src/solver.rs
@@ -102,13 +102,8 @@ pub struct SimulationFailureParams {
     pub message: String,
     /// Transaction input data
     pub data: Vec<u8>,
-    /// The simulation was done on top of all transactions from the given block number
-    /// If block_number is to be used for tenderly simulation, it should be increased by 1
-    pub block_number: BlockNumber,
-    /// Solver address
-    pub from: H160,
-    /// GPv2 settlement contract address
-    pub to: H160,
+    /// Data needed to reconstruct the simulation
+    pub transaction: SimulatedTransaction,
 }
 
 /// Reason for why a solution may have been invalid
@@ -200,12 +195,15 @@ pub type Solvers = Vec<Arc<dyn Solver>>;
 /// A single settlement and a solver that produced it.
 pub type SettlementWithSolver = (Arc<dyn Solver>, Settlement, Option<AccessList>);
 
+#[derive(Clone)]
 pub struct SimulatedTransaction {
     /// Which storage the settlement tries to access. Contains `None` if some error happened while
     /// estimating the access list.
     pub access_list: Option<AccessList>,
     /// The simulation was done on top of all transactions from the given block number
     pub block_number: BlockNumber,
+    /// Solver address
+    pub from: H160,
     /// GPv2 settlement contract address
     pub to: H160,
 }

--- a/crates/solver/src/solver.rs
+++ b/crates/solver/src/solver.rs
@@ -20,7 +20,7 @@ use crate::{
 };
 use anyhow::{anyhow, Context, Result};
 use contracts::{BalancerV2Vault, GPv2Settlement};
-use ethcontract::{errors::ExecutionError, Account, PrivateKey, H160, U256};
+use ethcontract::{errors::ExecutionError, Account, BlockNumber, PrivateKey, H160, U256};
 use model::auction::AuctionId;
 use num::BigRational;
 use reqwest::Url;
@@ -97,6 +97,12 @@ pub enum AuctionResult {
     Rejected(SolverRejectionReason),
 }
 
+pub struct SimulationFailureParams {
+    pub message: String,
+    pub block_number: BlockNumber,
+    pub data: Vec<u8>,
+}
+
 /// Reason for why a solution may have been invalid
 pub enum SolverRejectionReason {
     /// The solver didn't return a successful response
@@ -113,7 +119,7 @@ pub enum SolverRejectionReason {
 
     /// The solution didn't pass simulation. Includes revert reason as well as the calldata
     /// to re-create simulation locally
-    SimulationFailure(String, Vec<u8>),
+    SimulationFailure(SimulationFailureParams),
 }
 
 /// A batch auction for a solver to produce a settlement for.
@@ -190,6 +196,7 @@ pub type SettlementWithError = (
     Arc<dyn Solver>,
     Settlement,
     Option<AccessList>,
+    BlockNumber,
     ExecutionError,
 );
 

--- a/crates/solver/src/solver.rs
+++ b/crates/solver/src/solver.rs
@@ -201,6 +201,7 @@ pub type Solvers = Vec<Arc<dyn Solver>>;
 pub type SettlementWithSolver = (Arc<dyn Solver>, Settlement, Option<AccessList>);
 
 pub struct SimulatedTransaction {
+    pub access_list: Option<AccessList>,
     pub block_number: BlockNumber,
     pub to: H160,
 }
@@ -208,7 +209,6 @@ pub struct SimulatedTransaction {
 pub struct SettlementWithError {
     pub solver: Arc<dyn Solver>,
     pub settlement: Settlement,
-    pub access_list: Option<AccessList>,
     pub error: ExecutionError,
     pub simulation: SimulatedTransaction,
 }

--- a/crates/solver/src/solver.rs
+++ b/crates/solver/src/solver.rs
@@ -100,11 +100,15 @@ pub enum AuctionResult {
 pub struct SimulationFailureParams {
     /// Error message from the simulator
     pub message: String,
+    /// Transaction input data
+    pub data: Vec<u8>,
     /// The simulation was done on top of all transactions from the given block number
     /// If block_number is to be used for tenderly simulation, it should be increased by 1
     pub block_number: BlockNumber,
-    /// Transaction input data
-    pub data: Vec<u8>,
+    /// Solver address
+    pub from: H160,
+    /// GPv2 settlement contract address
+    pub to: H160,
 }
 
 /// Reason for why a solution may have been invalid
@@ -196,14 +200,18 @@ pub type Solvers = Vec<Arc<dyn Solver>>;
 /// A single settlement and a solver that produced it.
 pub type SettlementWithSolver = (Arc<dyn Solver>, Settlement, Option<AccessList>);
 
-pub type SettlementWithError = (
-    Arc<dyn Solver>,
-    Settlement,
-    Option<AccessList>,
-    BlockNumber,
-    ExecutionError,
-);
+pub struct SimulatedTransaction {
+    pub block_number: BlockNumber,
+    pub to: H160,
+}
 
+pub struct SettlementWithError {
+    pub solver: Arc<dyn Solver>,
+    pub settlement: Settlement,
+    pub access_list: Option<AccessList>,
+    pub error: ExecutionError,
+    pub simulation: SimulatedTransaction,
+}
 #[derive(Copy, Clone, Debug, Eq, Hash, PartialEq, clap::ValueEnum)]
 #[clap(rename_all = "verbatim")]
 pub enum SolverType {

--- a/crates/solver/src/solver.rs
+++ b/crates/solver/src/solver.rs
@@ -201,16 +201,23 @@ pub type Solvers = Vec<Arc<dyn Solver>>;
 pub type SettlementWithSolver = (Arc<dyn Solver>, Settlement, Option<AccessList>);
 
 pub struct SimulatedTransaction {
+    /// Which storage the settlement tries to access. Contains `None` if some error happened while
+    /// estimating the access list.
     pub access_list: Option<AccessList>,
+    /// The simulation was done on top of all transactions from the given block number
     pub block_number: BlockNumber,
+    /// GPv2 settlement contract address
     pub to: H160,
 }
-
-pub struct SettlementWithError {
-    pub solver: Arc<dyn Solver>,
+pub struct Simulation {
     pub settlement: Settlement,
+    pub solver: Arc<dyn Solver>,
+    pub transaction: SimulatedTransaction,
+}
+
+pub struct SimulationWithError {
+    pub simulation: Simulation,
     pub error: ExecutionError,
-    pub simulation: SimulatedTransaction,
 }
 #[derive(Copy, Clone, Debug, Eq, Hash, PartialEq, clap::ValueEnum)]
 #[clap(rename_all = "verbatim")]

--- a/crates/solver/src/solver.rs
+++ b/crates/solver/src/solver.rs
@@ -97,11 +97,12 @@ pub enum AuctionResult {
     Rejected(SolverRejectionReason),
 }
 
-pub struct TransactionWithMessage {
-    /// Data needed to reconstruct the simulation
+/// Contains all information about a failing settlement simulation
+pub struct TransactionWithError {
+    /// Transaction data used for simulation of the settlement
     pub transaction: SimulatedTransaction,
     /// Error message from the simulator
-    pub message: String,
+    pub error: String,
 }
 
 /// Reason for why a solution may have been invalid
@@ -119,7 +120,7 @@ pub enum SolverRejectionReason {
     PriceViolation,
 
     /// The solution didn't pass simulation. Includes all data needed to re-create simulation locally
-    SimulationFailure(TransactionWithMessage),
+    SimulationFailure(TransactionWithError),
 }
 
 /// A batch auction for a solver to produce a settlement for.
@@ -192,6 +193,7 @@ pub type Solvers = Vec<Arc<dyn Solver>>;
 /// A single settlement and a solver that produced it.
 pub type SettlementWithSolver = (Arc<dyn Solver>, Settlement, Option<AccessList>);
 
+/// Transaction data used for simulation of the settlement
 #[derive(Clone)]
 pub struct SimulatedTransaction {
     /// The simulation was done on top of all transactions from the given block number
@@ -206,15 +208,18 @@ pub struct SimulatedTransaction {
     /// Transaction input data
     pub data: Vec<u8>,
 }
+
 pub struct Simulation {
     pub settlement: Settlement,
     pub solver: Arc<dyn Solver>,
     pub transaction: SimulatedTransaction,
 }
+
 pub struct SimulationWithError {
     pub simulation: Simulation,
     pub error: ExecutionError,
 }
+
 #[derive(Copy, Clone, Debug, Eq, Hash, PartialEq, clap::ValueEnum)]
 #[clap(rename_all = "verbatim")]
 pub enum SolverType {

--- a/crates/solver/src/solver.rs
+++ b/crates/solver/src/solver.rs
@@ -97,13 +97,11 @@ pub enum AuctionResult {
     Rejected(SolverRejectionReason),
 }
 
-pub struct SimulationFailureParams {
-    /// Error message from the simulator
-    pub message: String,
-    /// Transaction input data
-    pub data: Vec<u8>,
+pub struct TransactionWithMessage {
     /// Data needed to reconstruct the simulation
     pub transaction: SimulatedTransaction,
+    /// Error message from the simulator
+    pub message: String,
 }
 
 /// Reason for why a solution may have been invalid
@@ -120,9 +118,8 @@ pub enum SolverRejectionReason {
     /// The solution violated a price constraint (ie. max deviation to external price vector)
     PriceViolation,
 
-    /// The solution didn't pass simulation. Includes revert reason as well as the calldata
-    /// to re-create simulation locally
-    SimulationFailure(SimulationFailureParams),
+    /// The solution didn't pass simulation. Includes all data needed to re-create simulation locally
+    SimulationFailure(TransactionWithMessage),
 }
 
 /// A batch auction for a solver to produce a settlement for.
@@ -197,22 +194,23 @@ pub type SettlementWithSolver = (Arc<dyn Solver>, Settlement, Option<AccessList>
 
 #[derive(Clone)]
 pub struct SimulatedTransaction {
+    /// The simulation was done on top of all transactions from the given block number
+    pub block_number: BlockNumber,
     /// Which storage the settlement tries to access. Contains `None` if some error happened while
     /// estimating the access list.
     pub access_list: Option<AccessList>,
-    /// The simulation was done on top of all transactions from the given block number
-    pub block_number: BlockNumber,
     /// Solver address
     pub from: H160,
     /// GPv2 settlement contract address
     pub to: H160,
+    /// Transaction input data
+    pub data: Vec<u8>,
 }
 pub struct Simulation {
     pub settlement: Settlement,
     pub solver: Arc<dyn Solver>,
     pub transaction: SimulatedTransaction,
 }
-
 pub struct SimulationWithError {
     pub simulation: Simulation,
     pub error: ExecutionError,


### PR DESCRIPTION
Follow up PR for https://github.com/cowprotocol/services/pull/661

Defines struct `TransactionWithMessage` with data to be sent to solvers in case of simulation failure. 

Transaction input data + block number represents the bare minimum needed for simulation reconstruction.
~All other data is more or less static or irrelevant (`from`, `to`, `gas`, `gas_price`) therefore being skipped.~
Edit: added `from` and `to`.