### PR TITLE
[Refunder] DB operations for refundable orders considering min validity duration, min slippage

### DIFF
--- a/crates/database/src/ethflow_orders.rs
+++ b/crates/database/src/ethflow_orders.rs
@@ -47,16 +47,28 @@ pub async fn read_order(
 
 pub async fn refundable_orders(
     ex: &mut PgConnection,
-    id: i64,
+    min_valid_to: i64,
+    min_validity_duration: i64,
+    min_slippage: f64,
 ) -> Result<Vec<EthOrderPlacement>, sqlx::Error> {
     const QUERY: &str = r#"
-        SELECT * FROM ethflow_orders eo
-        LEFT JOIN trades t on eo.uid = t.order_uid
-        WHERE eo.valid_to < $1
-        AND eo.is_refunded = false
-        AND t.order_uid is null
+SELECT eo.uid, eo.valid_to, eo.is_refunded from orders o 
+INNER JOIN ethflow_orders eo on eo.uid = o.uid 
+INNER JOIN order_quotes oq on o.uid = oq.order_uid
+LEFT JOIN trades t on o.uid = t.order_uid
+WHERE 
+eo.is_refunded = false
+AND t.order_uid is null
+AND eo.valid_to < $1
+AND (1.0 - o.buy_amount * 1.0 / oq.buy_amount) > $3
+AND eo.valid_to - extract(epoch from creation_timestamp)::int > $2
     "#;
-    sqlx::query_as(QUERY).bind(id).fetch_all(ex).await
+    sqlx::query_as(QUERY)
+        .bind(min_valid_to)
+        .bind(min_validity_duration)
+        .bind(min_slippage)
+        .fetch_all(ex)
+        .await
 }
 
 #[cfg(test)]
@@ -64,9 +76,12 @@ mod tests {
     use crate::{
         byte_array::ByteArray,
         events::{insert_trade, EventIndex, Trade},
+        orders::{insert_order, insert_quote, Order, Quote},
     };
 
     use super::*;
+    use bigdecimal::BigDecimal;
+    use chrono::{TimeZone, Utc};
     use sqlx::Connection;
 
     #[tokio::test]
@@ -109,40 +124,128 @@ mod tests {
         let mut db = db.begin().await.unwrap();
         crate::clear_DANGER_(&mut db).await.unwrap();
 
-        let order_1 = EthOrderPlacement {
-            uid: ByteArray([1u8; 56]),
-            valid_to: 1,
+        let order_uid_1 = ByteArray([1u8; 56]);
+        let eth_order_1 = EthOrderPlacement {
+            uid: order_uid_1,
+            valid_to: 4,
             is_refunded: false,
         };
-        let order_2 = EthOrderPlacement {
-            uid: ByteArray([2u8; 56]),
-            valid_to: 2,
-            is_refunded: false,
+        insert_ethflow_order(&mut db, &eth_order_1).await.unwrap();
+        let order_1 = Order {
+            uid: order_uid_1,
+            buy_amount: BigDecimal::from(1),
+            creation_timestamp: Utc.timestamp(1, 0),
+            ..Default::default()
         };
-        let order_3 = EthOrderPlacement {
-            uid: ByteArray([3u8; 56]),
-            valid_to: 3,
-            is_refunded: true,
+        insert_order(&mut db, &order_1).await.unwrap();
+        let quote_1 = Quote {
+            order_uid: order_uid_1,
+            buy_amount: BigDecimal::from(2),
+            ..Default::default()
         };
+        insert_quote(&mut db, &quote_1).await.unwrap();
 
-        append(
-            &mut db,
-            vec![order_1.clone(), order_2.clone(), order_3].as_slice(),
-        )
-        .await
-        .unwrap();
-        let orders = refundable_orders(&mut db, 3).await.unwrap();
-        assert_eq!(orders, vec![order_1.clone(), order_2]);
-        let orders = refundable_orders(&mut db, 2).await.unwrap();
-        assert_eq!(orders, vec![order_1.clone()]);
+        // all criteria are fulfilled
+        let orders = refundable_orders(&mut db, 5, 1, 0.01).await.unwrap();
+        assert_eq!(orders, vec![eth_order_1.clone()]);
+        // slippage is not fulfilled
+        let orders = refundable_orders(&mut db, 5, 1, 0.53).await.unwrap();
+        assert_eq!(orders, Vec::new());
+        // min_validity is not fulfilled
+        let orders = refundable_orders(&mut db, 1, 1, 0.01).await.unwrap();
+        assert_eq!(orders, Vec::new());
+        // min_duration is not fulfilled
+        let orders = refundable_orders(&mut db, 5, 3, 0.01).await.unwrap();
+        assert_eq!(orders, Vec::new());
+        // order already settled
         let trade = Trade {
-            order_uid: ByteArray([2u8; 56]),
+            order_uid: order_uid_1,
             ..Default::default()
         };
         insert_trade(&mut db, &EventIndex::default(), &trade)
             .await
             .unwrap();
-        let orders = refundable_orders(&mut db, 3).await.unwrap();
-        assert_eq!(orders, vec![order_1]);
+        let orders = refundable_orders(&mut db, 5, 1, 0.01).await.unwrap();
+        assert_eq!(orders, Vec::new());
+        let order_uid_2 = ByteArray([2u8; 56]);
+        let eth_order_2 = EthOrderPlacement {
+            uid: order_uid_2,
+            valid_to: 4,
+            is_refunded: true, // <-- sole change in setup
+        };
+        insert_ethflow_order(&mut db, &eth_order_2).await.unwrap();
+        let order_2 = Order {
+            uid: order_uid_2,
+            buy_amount: BigDecimal::from(1),
+            creation_timestamp: Utc.timestamp(1, 0),
+            ..Default::default()
+        };
+        insert_order(&mut db, &order_2).await.unwrap();
+        let quote_2 = Quote {
+            order_uid: order_uid_2,
+            buy_amount: BigDecimal::from(2),
+            ..Default::default()
+        };
+        insert_quote(&mut db, &quote_2).await.unwrap();
+        // is_refunded is not fulfilled
+        let orders = refundable_orders(&mut db, 5, 1, 0.01).await.unwrap();
+        assert_eq!(orders, Vec::new());
+    }
+
+    #[tokio::test]
+    #[ignore]
+    async fn postgres_refundable_orders_performance() {
+        // The following test can be used as performanc test,
+        // if the limit is set to->100000u32, the query should still finish
+        // below 13 ms
+        let mut db = PgConnection::connect("postgresql://").await.unwrap();
+        let mut db = db.begin().await.unwrap();
+        crate::clear_DANGER_(&mut db).await.unwrap();
+
+        let limit = 10u32;
+        for i in 0..limit {
+            let mut owner_bytes = i.to_ne_bytes().to_vec();
+            owner_bytes.append(&mut vec![0; 20 - owner_bytes.len()]);
+            let owner = ByteArray(owner_bytes.try_into().unwrap());
+            let mut i_as_bytes = i.to_ne_bytes().to_vec();
+            let mut order_uid_info = vec![0; 56 - i_as_bytes.len()];
+            i_as_bytes.append(&mut order_uid_info);
+            let order_uid = ByteArray(i_as_bytes.try_into().unwrap());
+            let trade = Trade {
+                order_uid,
+                ..Default::default()
+            };
+            // for 3/4 of the orders, we assume that they are actually settling
+            if i > limit / 4 * 3 {
+                let event_index = EventIndex::default();
+                insert_trade(&mut db, &event_index, &trade).await.unwrap();
+            }
+            let ethflow_order = EthOrderPlacement {
+                uid: order_uid,
+                valid_to: i as i64,
+                is_refunded: (i % 10u32 == 0),
+            };
+            insert_ethflow_order(&mut db, &ethflow_order).await.unwrap();
+            let order = Order {
+                uid: order_uid,
+                owner,
+                creation_timestamp: Utc::now(),
+                buy_amount: BigDecimal::from(100u32),
+                ..Default::default()
+            };
+            insert_order(&mut db, &order).await.unwrap();
+            let quote = Quote {
+                order_uid,
+                buy_amount: BigDecimal::from(100u32 - i % 3),
+                ..Default::default()
+            };
+            insert_quote(&mut db, &quote).await.unwrap();
+        }
+
+        let now = std::time::Instant::now();
+        refundable_orders(&mut db, 1, 1, 1.0).await.unwrap();
+        let elapsed = now.elapsed();
+        println!("{:?}", elapsed);
+        assert!(elapsed < std::time::Duration::from_secs(1));
     }
 }


### PR DESCRIPTION
Related to: https://github.com/cowprotocol/services/issues/626

EThflow orders should only be refunded if they were placed reasonably. This PR allows querying for the reasonably placed ethflow orders by querying for all ethflow orders with a certain min_validity_duration, and min_slippage.

### Test Plan
unit tests only.

I provided a performance test, as the query has several joins and calculations in the query. But the performance is reasonable. 

Thanks @e00E for suggesting this direct approach. I had doubts about the query performance, but I think it's good enough and hence this is the right way to go.