### PR TITLE
[Easy] Inserting missing tables into ALL_TABLES constants

### DIFF
--- a/crates/database/src/lib.rs
+++ b/crates/database/src/lib.rs
@@ -41,6 +41,10 @@ pub const ALL_TABLES: &[&str] = &[
     "order_quotes",
     "solver_competitions",
     "auctions",
+    "onchain_placed_orders",
+    "ethflow_orders",
+    "order_rewards",
+    "interactions",
 ];
 
 /// Delete all data in the database. Only used by tests.


### PR DESCRIPTION
During the last weeks, we forgot to update this constant. It's being used for tests and metrics.