### PR TITLE
Allow limit order placement

### DIFF
--- a/crates/e2e/tests/e2e/services.rs
+++ b/crates/e2e/tests/e2e/services.rs
@@ -269,7 +269,6 @@ impl OrderbookServices {
             quoter.clone(),
             balance_fetcher,
             signature_validator,
-            false,
         ));
         let orderbook = Arc::new(Orderbook::new(
             contracts.domain_separator,

--- a/crates/e2e/tests/e2e/services.rs
+++ b/crates/e2e/tests/e2e/services.rs
@@ -269,6 +269,7 @@ impl OrderbookServices {
             quoter.clone(),
             balance_fetcher,
             signature_validator,
+            false,
         ));
         let orderbook = Arc::new(Orderbook::new(
             contracts.domain_separator,

--- a/crates/orderbook/src/api.rs
+++ b/crates/orderbook/src/api.rs
@@ -1,5 +1,4 @@
 mod cancel_order;
-mod create_order;
 mod get_auction;
 mod get_fee_and_quote;
 mod get_fee_info;
@@ -12,6 +11,7 @@ mod get_solvable_orders_v2;
 mod get_solver_competition;
 mod get_trades;
 mod get_user_orders;
+mod post_order;
 mod post_quote;
 pub mod post_solver_competition;
 mod replace_order;
@@ -43,7 +43,7 @@ pub fn handle_all_routes(
     // This string will be used later to report metrics.
     // It is not used to form the actual server response.
 
-    let create_order = create_order::create_order(orderbook.clone())
+    let post_order = post_order::post_order(orderbook.clone())
         .map(|result| (result, "v1/create_order"))
         .boxed();
     let fee_info = get_fee_info::get_fee_info(quotes.clone())
@@ -101,7 +101,7 @@ pub fn handle_all_routes(
 
     let routes_v1 = warp::path!("api" / "v1" / ..)
         .and(
-            create_order
+            post_order
                 .or(fee_info)
                 .unify()
                 .or(get_order)

--- a/crates/orderbook/src/api/post_order.rs
+++ b/crates/orderbook/src/api/post_order.rs
@@ -198,7 +198,7 @@ pub fn create_order_response(result: Result<OrderUid, AddOrderError>) -> ApiRepl
     }
 }
 
-pub fn create_order(
+pub fn post_order(
     orderbook: Arc<Orderbook>,
 ) -> impl Filter<Extract = (ApiReply,), Error = Rejection> + Clone {
     create_order_request().and_then(move |order_payload: OrderCreation| {

--- a/crates/orderbook/src/api/post_quote.rs
+++ b/crates/orderbook/src/api/post_quote.rs
@@ -1,4 +1,4 @@
-use super::create_order::PartialValidationErrorWrapper;
+use super::post_order::PartialValidationErrorWrapper;
 use anyhow::Result;
 use model::quote::OrderQuoteRequest;
 use reqwest::StatusCode;

--- a/crates/orderbook/src/arguments.rs
+++ b/crates/orderbook/src/arguments.rs
@@ -120,6 +120,10 @@ pub struct Arguments {
     /// to get them errors and our liveness check fails.
     #[clap(long, default_value = "24")]
     pub solvable_orders_max_update_age_blocks: u64,
+
+    /// Enable limit orders. Once the full limit order flow is implemented, this can be removed.
+    #[clap(long, env, default_value = "false")]
+    pub enable_limit_orders: bool,
 }
 
 impl std::fmt::Display for Arguments {
@@ -173,6 +177,7 @@ impl std::fmt::Display for Arguments {
             "fast_price_estimation_results_required: {}",
             self.fast_price_estimation_results_required
         )?;
+        writeln!(f, "enable_limit_orders: {}", self.enable_limit_orders)?;
 
         Ok(())
     }

--- a/crates/orderbook/src/main.rs
+++ b/crates/orderbook/src/main.rs
@@ -390,6 +390,7 @@ async fn main() {
         optimal_quoter.clone(),
         balance_fetcher,
         signature_validator,
+        args.enable_limit_orders,
     ));
     let orderbook = Arc::new(Orderbook::new(
         domain_separator,

--- a/crates/orderbook/src/main.rs
+++ b/crates/orderbook/src/main.rs
@@ -374,24 +374,26 @@ async fn main() {
     let optimal_quoter = create_quoter(price_estimator.clone(), database.clone());
     let fast_quoter = create_quoter(fast_price_estimator.clone(), Arc::new(Forget));
 
-    let order_validator = Arc::new(OrderValidator::new(
-        Box::new(web3.clone()),
-        native_token.clone(),
-        args.banned_users.iter().copied().collect(),
-        args.order_quoting
-            .liquidity_order_owners
-            .iter()
-            .copied()
-            .collect(),
-        args.min_order_validity_period,
-        args.max_order_validity_period,
-        signature_configuration,
-        bad_token_detector.clone(),
-        optimal_quoter.clone(),
-        balance_fetcher,
-        signature_validator,
-        args.enable_limit_orders,
-    ));
+    let order_validator = Arc::new(
+        OrderValidator::new(
+            Box::new(web3.clone()),
+            native_token.clone(),
+            args.banned_users.iter().copied().collect(),
+            args.order_quoting
+                .liquidity_order_owners
+                .iter()
+                .copied()
+                .collect(),
+            args.min_order_validity_period,
+            args.max_order_validity_period,
+            signature_configuration,
+            bad_token_detector.clone(),
+            optimal_quoter.clone(),
+            balance_fetcher,
+            signature_validator,
+        )
+        .with_limit_orders(args.enable_limit_orders),
+    );
     let orderbook = Arc::new(Orderbook::new(
         domain_separator,
         settlement_contract.address(),

--- a/crates/shared/src/order_quoting.rs
+++ b/crates/shared/src/order_quoting.rs
@@ -121,10 +121,9 @@ impl QuoteParameters {
     fn to_price_query(&self) -> price_estimation::Query {
         let (kind, in_amount) = match self.side {
             OrderQuoteSide::Sell {
-                sell_amount: SellAmount::BeforeFee { value: sell_amount },
-            }
-            | OrderQuoteSide::Sell {
-                sell_amount: SellAmount::AfterFee { value: sell_amount },
+                sell_amount:
+                    SellAmount::BeforeFee { value: sell_amount }
+                    | SellAmount::AfterFee { value: sell_amount },
             } => (OrderKind::Sell, sell_amount),
             OrderQuoteSide::Buy {
                 buy_amount_after_fee,

--- a/crates/shared/src/order_validation.rs
+++ b/crates/shared/src/order_validation.rs
@@ -380,7 +380,7 @@ impl OrderValidating for OrderValidator {
             from: owner,
             app_data: order.data.app_data,
         };
-        let quote = if !liquidity_owner {
+        let quote = if !liquidity_owner && order.data.fee_amount > U256::zero() {
             Some(
                 get_quote_and_check_fee(
                     &*self.quoter,
@@ -1185,6 +1185,7 @@ mod tests {
                 buy_token: H160::from_low_u64_be(2),
                 buy_amount: U256::from(1),
                 sell_amount: U256::from(1),
+                fee_amount: U256::from(1),
                 ..Default::default()
             },
             ..Default::default()

--- a/crates/shared/src/order_validation.rs
+++ b/crates/shared/src/order_validation.rs
@@ -1074,8 +1074,8 @@ mod tests {
             },
             ..creation
         };
-        let limit_order_enabled_validator = validator.with_limit_orders(true);
-        let result = limit_order_enabled_validator
+        let validator = validator.with_limit_orders(true);
+        let result = validator
             .validate_and_construct_order(creation.clone(), &domain_separator, Default::default())
             .await;
         assert!(result.is_ok());

--- a/crates/shared/src/order_validation.rs
+++ b/crates/shared/src/order_validation.rs
@@ -172,6 +172,7 @@ pub struct OrderValidator {
     quoter: Arc<dyn OrderQuoting>,
     balance_fetcher: Arc<dyn BalanceFetching>,
     signature_validator: Arc<dyn SignatureValidating>,
+    enable_limit_orders: bool,
 }
 
 #[derive(Debug, Eq, PartialEq, Default)]
@@ -233,6 +234,7 @@ impl OrderValidator {
         quoter: Arc<dyn OrderQuoting>,
         balance_fetcher: Arc<dyn BalanceFetching>,
         signature_validator: Arc<dyn SignatureValidating>,
+        enable_limit_orders: bool,
     ) -> Self {
         Self {
             code_fetcher,
@@ -246,6 +248,7 @@ impl OrderValidator {
             quoter,
             balance_fetcher,
             signature_validator,
+            enable_limit_orders,
         }
     }
 }
@@ -480,7 +483,7 @@ impl OrderValidating for OrderValidator {
 
         let class = match (is_outside_market_price, liquidity_owner) {
             (true, true) => OrderClass::Liquidity,
-            (true, false) => OrderClass::Limit,
+            (true, false) if self.enable_limit_orders => OrderClass::Limit,
             _ => OrderClass::Ordinary,
         };
 
@@ -756,6 +759,7 @@ mod tests {
             Arc::new(MockOrderQuoting::new()),
             Arc::new(MockBalanceFetching::new()),
             Arc::new(MockSignatureValidating::new()),
+            false,
         );
         assert!(matches!(
             validator
@@ -884,6 +888,7 @@ mod tests {
             Arc::new(MockOrderQuoting::new()),
             Arc::new(MockBalanceFetching::new()),
             Arc::new(MockSignatureValidating::new()),
+            false,
         );
 
         assert!(matches!(
@@ -926,6 +931,7 @@ mod tests {
             Arc::new(MockOrderQuoting::new()),
             Arc::new(MockBalanceFetching::new()),
             Arc::new(MockSignatureValidating::new()),
+            false,
         );
         let order = || PreOrderData {
             valid_to: model::time::now_in_epoch_seconds()
@@ -989,6 +995,7 @@ mod tests {
             Arc::new(order_quoter),
             Arc::new(balance_fetcher),
             Arc::new(signature_validating),
+            false,
         );
 
         let creation = OrderCreation {
@@ -1087,6 +1094,7 @@ mod tests {
             Arc::new(order_quoter),
             Arc::new(balance_fetcher),
             Arc::new(MockSignatureValidating::new()),
+            false,
         );
         let order = OrderCreation {
             data: OrderData {
@@ -1132,6 +1140,7 @@ mod tests {
             Arc::new(order_quoter),
             Arc::new(balance_fetcher),
             Arc::new(MockSignatureValidating::new()),
+            false,
         );
         let order = OrderCreation {
             data: OrderData {
@@ -1177,6 +1186,7 @@ mod tests {
             Arc::new(order_quoter),
             Arc::new(balance_fetcher),
             Arc::new(MockSignatureValidating::new()),
+            false,
         );
         let order = OrderCreation {
             data: OrderData {
@@ -1225,6 +1235,7 @@ mod tests {
             Arc::new(order_quoter),
             Arc::new(balance_fetcher),
             Arc::new(MockSignatureValidating::new()),
+            false,
         );
         let order = OrderCreation {
             data: OrderData {
@@ -1275,6 +1286,7 @@ mod tests {
             Arc::new(order_quoter),
             Arc::new(balance_fetcher),
             Arc::new(MockSignatureValidating::new()),
+            false,
         );
         let order = OrderCreation {
             data: OrderData {
@@ -1321,6 +1333,7 @@ mod tests {
             Arc::new(order_quoter),
             Arc::new(balance_fetcher),
             Arc::new(MockSignatureValidating::new()),
+            false,
         );
         let order = OrderCreation {
             data: OrderData {
@@ -1371,6 +1384,7 @@ mod tests {
             Arc::new(order_quoter),
             Arc::new(balance_fetcher),
             Arc::new(signature_validator),
+            false,
         );
 
         let creation = OrderCreation {
@@ -1424,6 +1438,7 @@ mod tests {
                     Arc::new(order_quoter),
                     Arc::new(balance_fetcher),
                     Arc::new(MockSignatureValidating::new()),
+                    false,
                 );
 
                 let order = OrderBuilder::default()

--- a/crates/solver/src/driver.rs
+++ b/crates/solver/src/driver.rs
@@ -250,7 +250,7 @@ impl Driver {
 
         let external_prices =
             ExternalPrices::try_from_auction_prices(self.native_token, auction.prices)
-                .context("malformed acution prices")?;
+                .context("malformed auction prices")?;
         tracing::debug!(?external_prices, "estimated prices");
 
         let liquidity = self


### PR DESCRIPTION
Progress on #643.

Added the ability to create limit orders for the API so that the frontend can start implementing their UI against it. I considered a few different alternatives, such as checking the price estimate before actually generating the quote, but ultimately the best way is to simply check that the fees are zero. Added some tests for that.

Also, there is now a new CLI argument for optionally enabling limit orders to be created. I propose to keep this flag disabled in prod but enable it on staging.

### Test Plan

Automated tests.

### Release notes

Limit orders can be placed now. These are the same as liquidity orders (zero fees), but the owner doesn't have to be whitelisted.
