### PR TITLE
[Refunder] creating basic crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2519,6 +2519,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "refunder"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "chrono",
+ "clap 4.0.8",
+ "database",
+ "prometheus",
+ "shared",
+ "sqlx",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+ "url",
+]
+
+[[package]]
 name = "regex"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/crates/refunder/Cargo.toml
+++ b/crates/refunder/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "refunder"
+version = "0.1.0"
+authors = ["Gnosis Developers <developers@gnosis.io>", "Cow Protocol Developers <dev@cow.fi>"]
+edition = "2021"
+license = "MIT OR Apache-2.0"
+
+[dependencies]
+anyhow = { workspace = true }
+chrono = { workspace = true }
+clap = { workspace = true }
+database = { path = "../database" }
+prometheus = { workspace = true }
+shared = { path = "../shared" }
+tokio = { workspace = true, features = ["macros", "time", "rt-multi-thread"] }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true }
+url = { workspace = true }
+sqlx = { workspace = true }

--- a/crates/refunder/LICENSE-APACHE
+++ b/crates/refunder/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../../LICENSE-APACHE

--- a/crates/refunder/LICENSE-MIT
+++ b/crates/refunder/LICENSE-MIT
@@ -1,0 +1,1 @@
+../../LICENSE-MIT

--- a/crates/refunder/src/arguments.rs
+++ b/crates/refunder/src/arguments.rs
@@ -29,7 +29,7 @@ pub struct Arguments {
 impl std::fmt::Display for Arguments {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         writeln!(f, "min_validity_duration: {:?}", self.min_validity_duration)?;
-        writeln!(f, "min_slippage: {}", self.min_slippage_bps)?;
+        writeln!(f, "min_slippage_bps: {}", self.min_slippage_bps)?;
         writeln!(f, "db_url: SECRET")?;
         Ok(())
     }

--- a/crates/refunder/src/arguments.rs
+++ b/crates/refunder/src/arguments.rs
@@ -4,7 +4,7 @@ use url::Url;
 
 #[derive(Parser)]
 pub struct Arguments {
-    /// Minimum time an order must have been valid for, in order
+    /// Minimum time in seconds an order must have been valid for
     /// to be eligble for refunding
     #[clap(
         long,

--- a/crates/refunder/src/arguments.rs
+++ b/crates/refunder/src/arguments.rs
@@ -16,14 +16,10 @@ pub struct Arguments {
 
     /// Minimum slippage an order must have, in order
     /// to be eligble for refunding
-    /// Front-end will place orders with a default slippage of 2% 
-    /// hence, we are requiring as a default 1.9%
-    #[clap(
-        long,
-        env,
-        default_value = "0.019",
-    )]
-    pub min_slippage: f64,
+    /// Front-end will place orders with a default slippage of 2%
+    /// hence, we are requiring as a default 190 bps or 1.9 %
+    #[clap(long, env, default_value = "190")]
+    pub min_slippage_bps: u64,
 
     /// Url of the Postgres database. By default connects to locally running postgres.
     #[clap(long, env, default_value = "postgresql://")]
@@ -33,7 +29,7 @@ pub struct Arguments {
 impl std::fmt::Display for Arguments {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         writeln!(f, "min_validity_duration: {:?}", self.min_validity_duration)?;
-        writeln!(f, "min_slippage: {}", self.min_slippage)?;
+        writeln!(f, "min_slippage: {}", self.min_slippage_bps)?;
         writeln!(f, "db_url: SECRET")?;
         Ok(())
     }

--- a/crates/refunder/src/arguments.rs
+++ b/crates/refunder/src/arguments.rs
@@ -1,0 +1,38 @@
+use clap::Parser;
+use std::time::Duration;
+use url::Url;
+
+#[derive(Parser)]
+pub struct Arguments {
+    /// Minimum time an order must have been valid for, in order
+    /// to be eligble for refunding
+    #[clap(
+        long,
+        env,
+        value_parser = shared::arguments::duration_from_seconds,
+    )]
+    pub min_validity_duration: Duration,
+
+    /// Minimum slippage an order must have, in order
+    /// to be eligble for refunding
+    #[clap(
+        long,
+        env,
+        default_value = "1800",
+        value_parser = shared::arguments::duration_from_seconds,
+    )]
+    pub min_slippage: f64,
+
+    /// Url of the Postgres database. By default connects to locally running postgres.
+    #[clap(long, env, default_value = "postgresql://")]
+    pub db_url: Url,
+}
+
+impl std::fmt::Display for Arguments {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        writeln!(f, "min_validity_duration: {:?}", self.min_validity_duration)?;
+        writeln!(f, "min_slippage: {}", self.min_slippage)?;
+        writeln!(f, "db_url: SECRET")?;
+        Ok(())
+    }
+}

--- a/crates/refunder/src/arguments.rs
+++ b/crates/refunder/src/arguments.rs
@@ -9,17 +9,19 @@ pub struct Arguments {
     #[clap(
         long,
         env,
+        default_value = "120",
         value_parser = shared::arguments::duration_from_seconds,
     )]
     pub min_validity_duration: Duration,
 
     /// Minimum slippage an order must have, in order
     /// to be eligble for refunding
+    /// Front-end will place orders with a default slippage of 2% 
+    /// hence, we are requiring as a default 1.9%
     #[clap(
         long,
         env,
-        default_value = "1800",
-        value_parser = shared::arguments::duration_from_seconds,
+        default_value = "0.019",
     )]
     pub min_slippage: f64,
 

--- a/crates/refunder/src/lib.rs
+++ b/crates/refunder/src/lib.rs
@@ -6,8 +6,7 @@ use sqlx::PgPool;
 use std::time::Duration;
 
 pub async fn main(args: arguments::Arguments) {
-    let pg_pool = PgPool::connect(args.db_url.as_str())
-        .await
+    let pg_pool = PgPool::connect_lazy(args.db_url.as_str())
         .expect("failed to create database");
     let refunder = RefundService::new(
         pg_pool,
@@ -15,6 +14,7 @@ pub async fn main(args: arguments::Arguments) {
         args.min_slippage,
     );
     loop {
+        tracing::info!("Staring a new refunding loop");
         match refunder.try_to_refund_all_eligble_orders().await {
             Ok(_) => (),
             Err(err) => tracing::error!("Error while refunding ethflow orders: {:?}", err),

--- a/crates/refunder/src/lib.rs
+++ b/crates/refunder/src/lib.rs
@@ -8,12 +8,11 @@ use std::time::Duration;
 const SLEEP_TIME_BETWEEN_LOOPS: u64 = 30;
 
 pub async fn main(args: arguments::Arguments) {
-    let pg_pool = PgPool::connect_lazy(args.db_url.as_str())
-        .expect("failed to create database");
+    let pg_pool = PgPool::connect_lazy(args.db_url.as_str()).expect("failed to create database");
     let refunder = RefundService::new(
         pg_pool,
         args.min_validity_duration.as_secs() as i64,
-        args.min_slippage,
+        args.min_slippage_bps,
     );
     loop {
         tracing::info!("Staring a new refunding loop");

--- a/crates/refunder/src/lib.rs
+++ b/crates/refunder/src/lib.rs
@@ -5,6 +5,8 @@ use refund_service::RefundService;
 use sqlx::PgPool;
 use std::time::Duration;
 
+const SLEEP_TIME_BETWEEN_LOOPS: u64 = 30;
+
 pub async fn main(args: arguments::Arguments) {
     let pg_pool = PgPool::connect_lazy(args.db_url.as_str())
         .expect("failed to create database");
@@ -19,6 +21,6 @@ pub async fn main(args: arguments::Arguments) {
             Ok(_) => (),
             Err(err) => tracing::error!("Error while refunding ethflow orders: {:?}", err),
         }
-        tokio::time::sleep(Duration::from_secs(30)).await;
+        tokio::time::sleep(Duration::from_secs(SLEEP_TIME_BETWEEN_LOOPS)).await;
     }
 }

--- a/crates/refunder/src/main.rs
+++ b/crates/refunder/src/main.rs
@@ -1,0 +1,13 @@
+use clap::Parser;
+
+#[tokio::main]
+async fn main() {
+    let args = refunder::arguments::Arguments::parse();
+    shared::tracing::initialize(
+        "warn,refunder=debug,shared=debug,shared::transport::http=info",
+        tracing::Level::ERROR.into(),
+    );
+    shared::exit_process_on_panic::set_panic_hook();
+    tracing::info!("running refunder with validiated arguments:\n{}", args);
+    refunder::main(args).await;
+}

--- a/crates/refunder/src/main.rs
+++ b/crates/refunder/src/main.rs
@@ -8,6 +8,6 @@ async fn main() {
         tracing::Level::ERROR.into(),
     );
     shared::exit_process_on_panic::set_panic_hook();
-    tracing::info!("running refunder with validiated arguments:\n{}", args);
+    tracing::info!("running refunder with validated arguments:\n{}", args);
     refunder::main(args).await;
 }

--- a/crates/refunder/src/refund_service.rs
+++ b/crates/refunder/src/refund_service.rs
@@ -1,0 +1,47 @@
+use anyhow::Result;
+use database::ethflow_orders::refundable_orders;
+use sqlx::PgPool;
+use std::time::SystemTime;
+
+pub struct RefundService {
+    pub db: PgPool,
+    pub min_validity_duration: i64,
+    pub min_slippage: f64,
+}
+
+impl RefundService {
+    pub fn new(db: PgPool, min_validity_duration: i64, min_slippage: f64) -> Self {
+        RefundService {
+            db,
+            min_validity_duration,
+            min_slippage,
+        }
+    }
+
+    pub async fn try_to_refund_all_eligble_orders(&self) -> Result<()> {
+        // Step 1:
+        // Look for all refundable orders by calling the database
+        let unix_timestamp = SystemTime::now()
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .unwrap()
+            .as_secs() as i64;
+        let mut ex = self.db.acquire().await?;
+        let _refundable_order_uids = refundable_orders(
+            &mut ex,
+            unix_timestamp,
+            self.min_validity_duration,
+            self.min_slippage,
+        )
+        .await?;
+
+        // Step 2:
+        // take out orderUids that are already refunded
+        // by making a batched web3 call. Update refunded ones.
+
+        // Step 3:
+        // Send out tx to deleteOrders, and wait for 5 block for the tx
+        // to be mined
+
+        Ok(())
+    }
+}

--- a/crates/refunder/src/refund_service.rs
+++ b/crates/refunder/src/refund_service.rs
@@ -10,11 +10,11 @@ pub struct RefundService {
 }
 
 impl RefundService {
-    pub fn new(db: PgPool, min_validity_duration: i64, min_slippage: f64) -> Self {
+    pub fn new(db: PgPool, min_validity_duration: i64, min_slippage_in_bps: u64) -> Self {
         RefundService {
             db,
             min_validity_duration,
-            min_slippage,
+            min_slippage: min_slippage_in_bps as f64 / 10000f64,
         }
     }
 


### PR DESCRIPTION
Part of: https://github.com/cowprotocol/services/issues/626

After longer thoughts, we decided to go for a separate crate, see discussion in issue. This was also Nick's suggestion.

This PR provides an empty crate with a start of a basic refunder activity:
- Getting the refundable orderUids. 

In the following PRs, I will try to create the tx that refunds these orderUids.

### Test Plan
None