### PR TITLE
Fix serialize for SimulatedTransaction

### DIFF
--- a/crates/solver/src/settlement_rater.rs
+++ b/crates/solver/src/settlement_rater.rs
@@ -96,7 +96,7 @@ impl SettlementRating for SettlementRater {
         gas_price: GasPrice1559,
     ) -> Result<Vec<SimulationWithResult>> {
         let settlements = self.append_access_lists(settlements, gas_price).await;
-        let block_number = self.web3.eth().block_number().await?.into();
+        let block_number = self.web3.eth().block_number().await?.as_u64();
         let simulations = simulate_and_estimate_gas_at_current_block(
             settlements.iter().map(|(solver, settlement, access_list)| {
                 (


### PR DESCRIPTION
This PR changes the format of serialized data for `SimulatedTransaction` struct which is used to store all transaction data previously used to simulate solver solutions.

1. Block number is now serialized as decimal number.
2. Transaction input is now a hex string.
