### PR TITLE
[Trivial] Allow Ethplorer API Key to be passed via env variable

### DIFF
--- a/crates/shared/src/bad_token/token_owner_finder.rs
+++ b/crates/shared/src/bad_token/token_owner_finder.rs
@@ -60,6 +60,7 @@ pub struct Arguments {
     pub blockscout_http_timeout: Duration,
 
     /// The Ethplorer token holder API key.
+    #[clap(long, env)]
     pub ethplorer_api_key: Option<String>,
 
     /// Token owner finding rate limiting strategy. See --price-estimation-rate-limiter


### PR DESCRIPTION
Since we configure everything using env vars in practice, we also need to allow for the Ethplorer API Key to be parsed via env var.

### Test Plan

export ETHPLORER_API_KEY=
And then observe that the key is set when launching both the orderbook as well as the autopilot.
