### PR TITLE
Limit order fees

### DIFF
--- a/crates/autopilot/src/database/auction.rs
+++ b/crates/autopilot/src/database/auction.rs
@@ -158,6 +158,9 @@ fn full_order_into_model_order(order: database::orders::FullOrder) -> Result<Ord
         ethflow_data,
         onchain_user,
         is_liquidity_order: class == OrderClass::Liquidity,
+        // TODO #643 when we add surplus fee caching, this will be properly stored
+        // in the db
+        surplus_fee: Default::default(),
     };
     let data = OrderData {
         sell_token: H160(order.sell_token.0),

--- a/crates/autopilot/src/database/auction.rs
+++ b/crates/autopilot/src/database/auction.rs
@@ -35,7 +35,7 @@ use shared::{
 
 #[async_trait::async_trait]
 impl QuoteStoring for Postgres {
-    async fn save(&self, data: QuoteData) -> Result<Option<QuoteId>> {
+    async fn save(&self, data: QuoteData) -> Result<QuoteId> {
         let _timer = super::Metrics::get()
             .database_queries
             .with_label_values(&["save_quote"])
@@ -44,7 +44,7 @@ impl QuoteStoring for Postgres {
         let mut ex = self.0.acquire().await?;
         let row = create_quote_row(data);
         let id = database::quotes::save(&mut ex, &row).await?;
-        Ok(Some(id))
+        Ok(id)
     }
 
     async fn get(&self, id: QuoteId) -> Result<Option<QuoteData>> {

--- a/crates/autopilot/src/database/onchain_order_events.rs
+++ b/crates/autopilot/src/database/onchain_order_events.rs
@@ -364,9 +364,7 @@ async fn get_quote(
         from: order_placement.sender,
         app_data: order_data.app_data,
     };
-    // TODO No need to save the quote here, as it's being looked up by ID, but double-check this
-    // TODO Yes
-    let quote = get_quote_and_check_fee(
+    get_quote_and_check_fee(
         quoter,
         &parameters.clone(),
         Some(*quote_id as i64),
@@ -380,8 +378,7 @@ async fn get_quote(
             parameters,
             err
         )
-    })?;
-    Ok(quote)
+    })
 }
 
 fn convert_onchain_order_placement(

--- a/crates/autopilot/src/solvable_orders.rs
+++ b/crates/autopilot/src/solvable_orders.rs
@@ -239,6 +239,8 @@ impl SolvableOrdersCache {
         self.cache.lock().unwrap().orders.update_time
     }
 
+    /// Quotes all limit orders and sets the fee_amount for each one to the fee returned by the
+    /// quoting process. If quoting fails, the corresponding order is filtered out.
     async fn set_limit_order_fees(&self, orders: Vec<Order>) -> Vec<Order> {
         stream::iter(orders.into_iter())
             .filter_map(|mut order| async {

--- a/crates/autopilot/src/solvable_orders.rs
+++ b/crates/autopilot/src/solvable_orders.rs
@@ -1,13 +1,20 @@
 use crate::{database::Postgres, risk_adjusted_rewards};
 use anyhow::{Context as _, Result};
-use futures::StreamExt;
-use model::{auction::Auction, order::Order, signature::Signature, time::now_in_epoch_seconds};
+use futures::{stream, StreamExt};
+use model::{
+    auction::Auction,
+    order::{Order, OrderClass, OrderKind},
+    quote::{default_verification_gas_limit, OrderQuoteSide, QuoteSigningScheme, SellAmount},
+    signature::Signature,
+    time::now_in_epoch_seconds,
+};
 use primitive_types::{H160, H256, U256};
 use prometheus::{IntCounter, IntGauge};
 use shared::{
     account_balances::{BalanceFetching, Query},
     bad_token::BadTokenDetecting,
     current_block::CurrentBlockStream,
+    order_quoting::{OrderQuoting, QuoteParameters},
     price_estimation::native::NativePriceEstimating,
     signature_validator::{SignatureCheck, SignatureValidating},
 };
@@ -61,6 +68,7 @@ pub struct SolvableOrdersCache {
     // Optional because reward calculation only makes sense on mainnet. Other networks have 0 rewards.
     reward_calculator: Option<risk_adjusted_rewards::Calculator>,
     ethflow_contract_address: H160,
+    quoter: Arc<dyn OrderQuoting>,
 }
 
 type Balances = HashMap<Query, U256>;
@@ -92,6 +100,7 @@ impl SolvableOrdersCache {
         update_interval: Duration,
         reward_calculator: Option<risk_adjusted_rewards::Calculator>,
         ethflow_contract_address: H160,
+        quoter: Arc<dyn OrderQuoting>,
     ) -> Arc<Self> {
         let self_ = Arc::new(Self {
             min_order_validity_period,
@@ -113,6 +122,7 @@ impl SolvableOrdersCache {
             metrics: Metrics::instance(global_metrics::get_metric_storage_registry()).unwrap(),
             reward_calculator,
             ethflow_contract_address,
+            quoter,
         });
         tokio::task::spawn(update_task(
             Arc::downgrade(&self_),
@@ -168,6 +178,8 @@ impl SolvableOrdersCache {
             let query = Query::from_order(order);
             order.metadata.available_balance = new_balances.get(&query).copied();
         }
+
+        let orders = self.set_limit_order_fees(orders).await;
 
         // create auction
         let (orders, prices) = get_orders_with_native_prices(
@@ -225,6 +237,61 @@ impl SolvableOrdersCache {
 
     pub fn last_update_time(&self) -> Instant {
         self.cache.lock().unwrap().orders.update_time
+    }
+
+    async fn set_limit_order_fees(&self, orders: Vec<Order>) -> Vec<Order> {
+        stream::iter(orders.into_iter())
+            .filter_map(|mut order| async {
+                if order.metadata.class != OrderClass::Limit {
+                    return Some(order);
+                }
+
+                match self
+                    .quoter
+                    .calculate_quote(QuoteParameters {
+                        sell_token: order.data.sell_token,
+                        buy_token: order.data.buy_token,
+                        side: match order.data.kind {
+                            OrderKind::Buy => OrderQuoteSide::Buy {
+                                buy_amount_after_fee: order.data.buy_amount,
+                            },
+                            OrderKind::Sell => OrderQuoteSide::Sell {
+                                sell_amount: SellAmount::AfterFee {
+                                    value: order.data.sell_amount,
+                                },
+                            },
+                        },
+                        from: order.metadata.owner,
+                        app_data: order.data.app_data,
+                        signing_scheme: match order.signature {
+                            Signature::Eip712(_) => QuoteSigningScheme::Eip712,
+                            Signature::EthSign(_) => QuoteSigningScheme::EthSign,
+                            Signature::Eip1271(_) => QuoteSigningScheme::Eip1271 {
+                                onchain_order: false,
+                                verification_gas_limit: default_verification_gas_limit(),
+                            },
+                            Signature::PreSign => QuoteSigningScheme::PreSign {
+                                onchain_order: false,
+                            },
+                        },
+                    })
+                    .await
+                {
+                    Ok(quote) => {
+                        order.data.fee_amount = quote.fee_amount;
+                        Some(order)
+                    }
+                    Err(err) => {
+                        tracing::error!(
+                            order_uid =% order.metadata.uid, ?err,
+                            "filtered limit order due to quoting error"
+                        );
+                        None
+                    }
+                }
+            })
+            .collect()
+            .await
     }
 }
 

--- a/crates/autopilot/src/solvable_orders.rs
+++ b/crates/autopilot/src/solvable_orders.rs
@@ -284,7 +284,7 @@ impl SolvableOrdersCache {
                         Some(order)
                     }
                     Err(err) => {
-                        tracing::error!(
+                        tracing::warn!(
                             order_uid =% order.metadata.uid, ?err,
                             "filtered limit order due to quoting error"
                         );

--- a/crates/autopilot/src/solvable_orders.rs
+++ b/crates/autopilot/src/solvable_orders.rs
@@ -280,7 +280,7 @@ impl SolvableOrdersCache {
                     .await
                 {
                     Ok(quote) => {
-                        order.data.fee_amount = quote.fee_amount;
+                        order.metadata.surplus_fee = quote.fee_amount;
                         Some(order)
                     }
                     Err(err) => {

--- a/crates/e2e/tests/e2e/services.rs
+++ b/crates/e2e/tests/e2e/services.rs
@@ -256,6 +256,7 @@ impl OrderbookServices {
             Duration::from_secs(1),
             None,
             H160::zero(),
+            quoter.clone(),
         );
         let order_validator = Arc::new(OrderValidator::new(
             Box::new(web3.clone()),

--- a/crates/model/src/order.rs
+++ b/crates/model/src/order.rs
@@ -427,6 +427,8 @@ pub struct OrderMetadata {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub onchain_user: Option<H160>,
     pub is_liquidity_order: bool,
+    #[serde(default, with = "u256_decimal")]
+    pub surplus_fee: U256,
 }
 
 impl Default for OrderMetadata {
@@ -448,6 +450,7 @@ impl Default for OrderMetadata {
             ethflow_data: None,
             onchain_user: None,
             is_liquidity_order: false,
+            surplus_fee: Default::default(),
         }
     }
 }
@@ -708,6 +711,7 @@ mod tests {
             "validTo": 4294967295u32,
             "appData": "0x6000000000000000000000000000000000000000000000000000000000000007",
             "feeAmount": "115792089237316195423570985008687907853269984665640564039457584007913129639935",
+            "surplusFee": "115792089237316195423570985008687907853269984665640564039457584007913129639935",
             "fullFeeAmount": "115792089237316195423570985008687907853269984665640564039457584007913129639935",
             "kind": "buy",
             "class": "ordinary",
@@ -738,6 +742,7 @@ mod tests {
                 status: OrderStatus::Open,
                 settlement_contract: H160::from_low_u64_be(2),
                 full_fee_amount: U256::MAX,
+                surplus_fee: U256::MAX,
                 ..Default::default()
             },
             data: OrderData {

--- a/crates/orderbook/src/api/get_auction.rs
+++ b/crates/orderbook/src/api/get_auction.rs
@@ -12,9 +12,6 @@ fn get_auction_request() -> impl Filter<Extract = (), Error = Rejection> + Clone
 pub fn get_auction(
     orderbook: Arc<Orderbook>,
 ) -> impl Filter<Extract = (ApiReply,), Error = Rejection> + Clone {
-    // TODO This is the code that fetches an auction, I just have to figure out where the code is
-    // that creates the auction
-    // I believe the DB call is replace_auction
     get_auction_request().and_then(move || {
         let orderbook = orderbook.clone();
         async move {

--- a/crates/orderbook/src/api/get_auction.rs
+++ b/crates/orderbook/src/api/get_auction.rs
@@ -12,6 +12,9 @@ fn get_auction_request() -> impl Filter<Extract = (), Error = Rejection> + Clone
 pub fn get_auction(
     orderbook: Arc<Orderbook>,
 ) -> impl Filter<Extract = (ApiReply,), Error = Rejection> + Clone {
+    // TODO This is the code that fetches an auction, I just have to figure out where the code is
+    // that creates the auction
+    // I believe the DB call is replace_auction
     get_auction_request().and_then(move || {
         let orderbook = orderbook.clone();
         async move {

--- a/crates/orderbook/src/database/orders.rs
+++ b/crates/orderbook/src/database/orders.rs
@@ -317,6 +317,9 @@ fn full_order_into_model_order(order: FullOrder) -> Result<Order> {
         ethflow_data,
         onchain_user,
         is_liquidity_order: class == OrderClass::Liquidity,
+        // TODO #643 when we add surplus fee caching, this will be properly stored
+        // in the db
+        surplus_fee: Default::default(),
     };
     let data = OrderData {
         sell_token: H160(order.sell_token.0),

--- a/crates/orderbook/src/database/quotes.rs
+++ b/crates/orderbook/src/database/quotes.rs
@@ -10,7 +10,7 @@ use shared::{
 
 #[async_trait::async_trait]
 impl QuoteStoring for Postgres {
-    async fn save(&self, data: QuoteData) -> Result<Option<QuoteId>> {
+    async fn save(&self, data: QuoteData) -> Result<QuoteId> {
         let _timer = super::Metrics::get()
             .database_queries
             .with_label_values(&["save_quote"])
@@ -19,7 +19,7 @@ impl QuoteStoring for Postgres {
         let mut ex = self.pool.acquire().await?;
         let row = create_quote_row(data);
         let id = database::quotes::save(&mut ex, &row).await?;
-        Ok(Some(id))
+        Ok(id)
     }
 
     async fn get(&self, id: QuoteId) -> Result<Option<QuoteData>> {

--- a/crates/orderbook/src/main.rs
+++ b/crates/orderbook/src/main.rs
@@ -28,7 +28,7 @@ use shared::{
     metrics::{serve_metrics, DEFAULT_METRICS_PORT},
     network::network_name,
     oneinch_api::OneInchClientImpl,
-    order_quoting::{Forget, OrderQuoter, QuoteHandler, QuoteStoring},
+    order_quoting::{OrderQuoter, QuoteHandler, QuoteStoring},
     order_validation::{OrderValidator, SignatureConfiguration},
     price_estimation::{
         factory::{self, PriceEstimatorFactory},
@@ -364,22 +364,21 @@ async fn main() {
         presign: args.enable_presign_orders,
     };
 
-    let create_quoter = |price_estimator: Arc<dyn PriceEstimating>,
-                         storage: Arc<dyn QuoteStoring>| {
+    let create_quoter = |price_estimator: Arc<dyn PriceEstimating>| {
         Arc::new(OrderQuoter::new(
             price_estimator,
             native_price_estimator.clone(),
             gas_price_estimator.clone(),
             fee_subsidy.clone(),
-            storage,
+            database.clone(),
             chrono::Duration::from_std(args.order_quoting.eip1271_onchain_quote_validity_seconds)
                 .unwrap(),
             chrono::Duration::from_std(args.order_quoting.presign_onchain_quote_validity_seconds)
                 .unwrap(),
         ))
     };
-    let optimal_quoter = create_quoter(price_estimator.clone(), database.clone());
-    let fast_quoter = create_quoter(fast_price_estimator.clone(), Arc::new(Forget));
+    let optimal_quoter = create_quoter(price_estimator.clone());
+    let fast_quoter = create_quoter(fast_price_estimator.clone());
 
     let order_validator = Arc::new(
         OrderValidator::new(

--- a/crates/orderbook/src/main.rs
+++ b/crates/orderbook/src/main.rs
@@ -28,7 +28,7 @@ use shared::{
     metrics::{serve_metrics, DEFAULT_METRICS_PORT},
     network::network_name,
     oneinch_api::OneInchClientImpl,
-    order_quoting::{OrderQuoter, QuoteHandler, QuoteStoring},
+    order_quoting::{OrderQuoter, QuoteHandler},
     order_validation::{OrderValidator, SignatureConfiguration},
     price_estimation::{
         factory::{self, PriceEstimatorFactory},

--- a/crates/shared/src/order_quoting.rs
+++ b/crates/shared/src/order_quoting.rs
@@ -301,14 +301,14 @@ impl TryFrom<QuoteRow> for QuoteData {
 #[mockall::automock]
 #[async_trait::async_trait]
 pub trait OrderQuoting: Send + Sync {
-    /// Computes a quote for the specified order paramters. Doesn't store the quote.
+    /// Computes a quote for the specified order parameters. Doesn't store the quote.
     async fn calculate_quote(
         &self,
         parameters: QuoteParameters,
     ) -> Result<Quote, CalculateQuoteError>;
 
     /// Stores a quote.
-    async fn store_quote(&self, quote: Quote) -> anyhow::Result<Quote>;
+    async fn store_quote(&self, quote: Quote) -> Result<Quote>;
 
     /// Finds an existing quote.
     async fn find_quote(
@@ -559,7 +559,7 @@ impl OrderQuoting for OrderQuoter {
         Ok(quote)
     }
 
-    async fn store_quote(&self, quote: Quote) -> anyhow::Result<Quote> {
+    async fn store_quote(&self, quote: Quote) -> Result<Quote> {
         let id = self.storage.save(quote.data.clone()).await?;
         Ok(Quote {
             id: Some(id),

--- a/crates/shared/src/order_quoting.rs
+++ b/crates/shared/src/order_quoting.rs
@@ -59,11 +59,22 @@ impl QuoteHandler {
         let valid_to = order.valid_to;
         self.order_validator.partial_validate(order).await?;
 
-        let quoter = match request.price_quality {
-            PriceQuality::Optimal => &self.optimal_quoter,
-            PriceQuality::Fast => &self.fast_quoter,
+        let quote = match request.price_quality {
+            PriceQuality::Optimal => {
+                let quote = self.optimal_quoter.calculate_quote(request.into()).await?;
+                self.optimal_quoter
+                    .store_quote(quote)
+                    .await
+                    .map_err(CalculateQuoteError::Other)?
+            }
+            PriceQuality::Fast => {
+                let mut quote = self.fast_quoter.calculate_quote(request.into()).await?;
+                // We maintain an API guarantee that fast quotes always have an expiry of zero, because
+                // they're not very accurate and can be considered to expire immediately.
+                quote.data.expiration = Utc.timestamp(0, 0);
+                quote
+            }
         };
-        let quote = quoter.calculate_quote(request.into()).await?;
 
         let response = OrderQuoteResponse {
             quote: OrderQuote {
@@ -290,11 +301,14 @@ impl TryFrom<QuoteRow> for QuoteData {
 #[mockall::automock]
 #[async_trait::async_trait]
 pub trait OrderQuoting: Send + Sync {
-    /// Computes a quote for the specified order paramters.
+    /// Computes a quote for the specified order paramters. Doesn't store the quote.
     async fn calculate_quote(
         &self,
         parameters: QuoteParameters,
     ) -> Result<Quote, CalculateQuoteError>;
+
+    /// Stores a quote.
+    async fn store_quote(&self, quote: Quote) -> anyhow::Result<Quote>;
 
     /// Finds an existing quote.
     async fn find_quote(
@@ -382,32 +396,6 @@ pub trait QuoteStoring: Send + Sync {
         expiration: DateTime<Utc>,
         quote_kind: QuoteKind,
     ) -> Result<Option<(QuoteId, QuoteData)>>;
-}
-
-/// A quote storing strategy that always forgets quotes.
-///
-/// This is used for the "fast" quoter, since those quotes cannot be used for
-/// determining minimum fee amounts.
-pub struct Forget;
-
-#[async_trait::async_trait]
-impl QuoteStoring for Forget {
-    async fn save(&self, _: QuoteData) -> Result<Option<QuoteId>> {
-        Ok(None)
-    }
-
-    async fn get(&self, _: QuoteId) -> Result<Option<QuoteData>> {
-        Ok(None)
-    }
-
-    async fn find(
-        &self,
-        _: QuoteSearchParameters,
-        _: DateTime<Utc>,
-        _: QuoteKind,
-    ) -> Result<Option<(QuoteId, QuoteData)>> {
-        Ok(None)
-    }
 }
 
 #[cfg_attr(test, mockall::automock)]
@@ -567,17 +555,14 @@ impl OrderQuoting for OrderQuoter {
             quote = quote.with_scaled_sell_amount(sell_amount);
         }
 
-        // Only save after we know the quote is valid.
-        quote.id = self.storage.save(quote.data.clone()).await?;
-        if quote.id.is_none() {
-            // Quote was not stored! Clear the expiration to signal to the
-            // caller that the quote is purely indicative and isn't valid for
-            // any period of time.
-            quote.data.expiration = Utc.timestamp(0, 0);
-        }
-
         tracing::debug!(?quote, ?subsidy, "computed quote");
         Ok(quote)
+    }
+
+    async fn store_quote(&self, quote: Quote) -> anyhow::Result<Quote> {
+        // TODO Does save need to be optional anymore?? Probably not, right?
+        let id = self.storage.save(quote.data.clone()).await?;
+        Ok(Quote { id, ..quote })
     }
 
     async fn find_quote(
@@ -817,8 +802,11 @@ mod tests {
             presign_onchain_quote_validity_seconds: Duration::seconds(60i64),
         };
 
+        let quote = quoter.calculate_quote(parameters).await.unwrap();
+        let quote = quoter.store_quote(quote).await.unwrap();
+
         assert_eq!(
-            quoter.calculate_quote(parameters).await.unwrap(),
+            quote,
             Quote {
                 id: Some(1337),
                 data: QuoteData {
@@ -933,8 +921,11 @@ mod tests {
             presign_onchain_quote_validity_seconds: Duration::seconds(60i64),
         };
 
+        let quote = quoter.calculate_quote(parameters).await.unwrap();
+        let quote = quoter.store_quote(quote).await.unwrap();
+
         assert_eq!(
-            quoter.calculate_quote(parameters).await.unwrap(),
+            quote,
             Quote {
                 id: Some(1337),
                 data: QuoteData {
@@ -1050,8 +1041,11 @@ mod tests {
             presign_onchain_quote_validity_seconds: Duration::seconds(60i64),
         };
 
+        let quote = quoter.calculate_quote(parameters).await.unwrap();
+        let quote = quoter.store_quote(quote).await.unwrap();
+
         assert_eq!(
-            quoter.calculate_quote(parameters).await.unwrap(),
+            quote,
             Quote {
                 id: Some(1337),
                 data: QuoteData {
@@ -1205,41 +1199,6 @@ mod tests {
             quoter.calculate_quote(parameters).await.unwrap_err(),
             CalculateQuoteError::Price(PriceEstimationError::NoLiquidity),
         ));
-    }
-
-    #[tokio::test]
-    async fn forgotten_quotes_are_expired() {
-        let now = Utc::now();
-        let mut price_estimator = MockPriceEstimating::new();
-        price_estimator.expect_estimates().returning(|_| {
-            futures::stream::iter([Ok(price_estimation::Estimate {
-                out_amount: 1.into(),
-                gas: 1,
-            })])
-            .enumerate()
-            .boxed()
-        });
-
-        let mut native_price_estimator = MockNativePriceEstimating::new();
-        native_price_estimator
-            .expect_estimate_native_prices()
-            .returning(|_| futures::stream::iter([Ok(1.)]).enumerate().boxed());
-
-        let quoter = OrderQuoter {
-            price_estimator: Arc::new(price_estimator),
-            native_price_estimator: Arc::new(native_price_estimator),
-            gas_estimator: Arc::new(FakeGasPriceEstimator(Arc::new(Mutex::new(
-                Default::default(),
-            )))),
-            fee_subsidy: Arc::new(Subsidy::default()),
-            storage: Arc::new(Forget),
-            now: Arc::new(now),
-            eip1271_onchain_quote_validity_seconds: Duration::seconds(60i64),
-            presign_onchain_quote_validity_seconds: Duration::seconds(60i64),
-        };
-
-        let quote = quoter.calculate_quote(Default::default()).await.unwrap();
-        assert_eq!((quote.id, quote.data.expiration.timestamp()), (None, 0));
     }
 
     #[tokio::test]

--- a/crates/shared/src/order_quoting.rs
+++ b/crates/shared/src/order_quoting.rs
@@ -384,7 +384,7 @@ pub trait QuoteStoring: Send + Sync {
     ///
     /// This storage implementation should return `None` to indicate that it
     /// will not store the quote.
-    async fn save(&self, data: QuoteData) -> Result<Option<QuoteId>>;
+    async fn save(&self, data: QuoteData) -> Result<QuoteId>;
 
     /// Retrieves an existing quote by ID.
     async fn get(&self, id: QuoteId) -> Result<Option<QuoteData>>;
@@ -560,9 +560,11 @@ impl OrderQuoting for OrderQuoter {
     }
 
     async fn store_quote(&self, quote: Quote) -> anyhow::Result<Quote> {
-        // TODO Does save need to be optional anymore?? Probably not, right?
         let id = self.storage.save(quote.data.clone()).await?;
-        Ok(Quote { id, ..quote })
+        Ok(Quote {
+            id: Some(id),
+            ..quote
+        })
     }
 
     async fn find_quote(
@@ -789,7 +791,7 @@ mod tests {
                 expiration: now + Duration::seconds(STANDARD_QUOTE_VALIDITY_SECONDS),
                 quote_kind: QuoteKind::Standard,
             }))
-            .returning(|_| Ok(Some(1337)));
+            .returning(|_| Ok(1337));
 
         let quoter = OrderQuoter {
             price_estimator: Arc::new(price_estimator),
@@ -905,7 +907,7 @@ mod tests {
                 expiration: now + chrono::Duration::seconds(STANDARD_QUOTE_VALIDITY_SECONDS),
                 quote_kind: QuoteKind::Standard,
             }))
-            .returning(|_| Ok(Some(1337)));
+            .returning(|_| Ok(1337));
 
         let quoter = OrderQuoter {
             price_estimator: Arc::new(price_estimator),
@@ -1024,7 +1026,7 @@ mod tests {
                 expiration: now + chrono::Duration::seconds(STANDARD_QUOTE_VALIDITY_SECONDS),
                 quote_kind: QuoteKind::Standard,
             }))
-            .returning(|_| Ok(Some(1337)));
+            .returning(|_| Ok(1337));
 
         let quoter = OrderQuoter {
             price_estimator: Arc::new(price_estimator),

--- a/crates/shared/src/order_validation.rs
+++ b/crates/shared/src/order_validation.rs
@@ -388,20 +388,24 @@ impl OrderValidating for OrderValidator {
             app_data: order.data.app_data,
         };
         let quote = if !liquidity_owner && order.data.fee_amount > U256::zero() {
-            Some(
-                get_quote_and_check_fee(
-                    &*self.quoter,
-                    &quote_parameters,
-                    order.quote_id,
-                    order.data.fee_amount,
-                    convert_signing_scheme_into_quote_signing_scheme(
-                        order.signature.scheme(),
-                        true,
-                        additional_gas,
-                    )?,
-                )
-                .await?,
+            let quote = get_quote_and_check_fee(
+                &*self.quoter,
+                &quote_parameters,
+                order.quote_id,
+                order.data.fee_amount,
+                convert_signing_scheme_into_quote_signing_scheme(
+                    order.signature.scheme(),
+                    true,
+                    additional_gas,
+                )?,
             )
+            .await?;
+            let quote = self
+                .quoter
+                .store_quote(quote)
+                .await
+                .map_err(ValidationError::Other)?;
+            Some(quote)
         } else {
             // We don't try to get quotes for liquidity and limit orders
             // for two reasons:
@@ -921,6 +925,16 @@ mod tests {
             .with(eq(H160::from_low_u64_be(2)))
             .returning(|_| Ok(TokenQuality::Good));
 
+        let mut order_quoter = MockOrderQuoting::new();
+        /*
+        order_quoter.expect_store_quote().returning(|q| {
+            Ok(Quote {
+                id: Some(1337),
+                ..q
+            })
+        });
+        */
+
         let validator = OrderValidator::new(
             Box::new(MockCodeFetching::new()),
             dummy_contract!(WETH9, [0xef; 20]),
@@ -930,7 +944,7 @@ mod tests {
             max_order_validity_period,
             SignatureConfiguration::all(),
             Arc::new(bad_token_detector),
-            Arc::new(MockOrderQuoting::new()),
+            Arc::new(order_quoter),
             Arc::new(MockBalanceFetching::new()),
             Arc::new(MockSignatureValidating::new()),
         );
@@ -1325,6 +1339,7 @@ mod tests {
         order_quoter
             .expect_find_quote()
             .returning(|_, _, _| Ok(Default::default()));
+        order_quoter.expect_store_quote().returning(|q| Ok(q));
         bad_token_detector
             .expect_detect()
             .returning(|_| Ok(TokenQuality::Good));

--- a/crates/shared/src/order_validation.rs
+++ b/crates/shared/src/order_validation.rs
@@ -925,16 +925,6 @@ mod tests {
             .with(eq(H160::from_low_u64_be(2)))
             .returning(|_| Ok(TokenQuality::Good));
 
-        let mut order_quoter = MockOrderQuoting::new();
-        /*
-        order_quoter.expect_store_quote().returning(|q| {
-            Ok(Quote {
-                id: Some(1337),
-                ..q
-            })
-        });
-        */
-
         let validator = OrderValidator::new(
             Box::new(MockCodeFetching::new()),
             dummy_contract!(WETH9, [0xef; 20]),
@@ -944,7 +934,7 @@ mod tests {
             max_order_validity_period,
             SignatureConfiguration::all(),
             Arc::new(bad_token_detector),
-            Arc::new(order_quoter),
+            Arc::new(MockOrderQuoting::new()),
             Arc::new(MockBalanceFetching::new()),
             Arc::new(MockSignatureValidating::new()),
         );
@@ -1339,7 +1329,7 @@ mod tests {
         order_quoter
             .expect_find_quote()
             .returning(|_, _, _| Ok(Default::default()));
-        order_quoter.expect_store_quote().returning(|q| Ok(q));
+        order_quoter.expect_store_quote().returning(Ok);
         bad_token_detector
             .expect_detect()
             .returning(|_| Ok(TokenQuality::Good));


### PR DESCRIPTION
Progress on #643.

Quotes limit orders whenever an auction is cut. The next PR will start caching the calculated fees to reduce the frequency of quoting, since quoting isn't cheap.

Note that the fee does not get stored anywhere in out database yet.

Refactored some interfaces to make things more explicit and to try to illustrate business logic a tiny bit more clearly.

### Test Plan

Currently the change is not covered by tests. I will add an E2E test once it makes sense.

### Release notes

Adds a new field to the `Order` type. This is a backwards-compatible change.