### PR TITLE
Whitelist owners

### DIFF
--- a/crates/shared/src/bad_token/token_owner_finder/seasolver.rs
+++ b/crates/shared/src/bad_token/token_owner_finder/seasolver.rs
@@ -1,0 +1,45 @@
+use super::TokenOwnerProposing;
+use anyhow::Result;
+use ethcontract::H160;
+
+pub struct SeasolverTokenOwnerFinder {
+    owners: Vec<H160>,
+}
+
+impl SeasolverTokenOwnerFinder {
+    pub fn new(owners: Vec<H160>) -> Self {
+        Self { owners }
+    }
+}
+
+#[async_trait::async_trait]
+impl TokenOwnerProposing for SeasolverTokenOwnerFinder {
+    async fn find_candidate_owners(&self, _: H160) -> Result<Vec<H160>> {
+        Ok(self.owners.clone())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn seasolver_finder_constructor_empty() {
+        let finder = SeasolverTokenOwnerFinder::new(vec![]);
+        let candidate_owners = finder
+            .find_candidate_owners(H160::from_low_u64_be(10))
+            .await;
+        assert!(candidate_owners.unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn seasolver_finder_constructor() {
+        let owners = vec![H160::from_low_u64_be(1), H160::from_low_u64_be(2)];
+        let finder = SeasolverTokenOwnerFinder::new(owners.clone());
+        let candidate_owners = finder
+            .find_candidate_owners(H160::from_low_u64_be(10))
+            .await
+            .unwrap();
+        assert_eq!(owners, candidate_owners);
+    }
+}

--- a/crates/shared/src/bad_token/trace_call.rs
+++ b/crates/shared/src/bad_token/trace_call.rs
@@ -592,6 +592,7 @@ mod tests {
                         .unwrap(),
                 ),
             ],
+            whitelisted_owners: Default::default(),
         });
         let token_cache = TraceCallDetector {
             web3,
@@ -629,6 +630,7 @@ mod tests {
         let finder = Arc::new(TokenOwnerFinder {
             web3: web3.clone(),
             proposers: vec![univ3],
+            whitelisted_owners: Default::default(),
         });
         let token_cache = super::TraceCallDetector {
             web3,

--- a/crates/shared/src/bad_token/trace_call.rs
+++ b/crates/shared/src/bad_token/trace_call.rs
@@ -592,7 +592,6 @@ mod tests {
                         .unwrap(),
                 ),
             ],
-            whitelisted_owners: Default::default(),
         });
         let token_cache = TraceCallDetector {
             web3,
@@ -630,7 +629,6 @@ mod tests {
         let finder = Arc::new(TokenOwnerFinder {
             web3: web3.clone(),
             proposers: vec![univ3],
-            whitelisted_owners: Default::default(),
         });
         let token_cache = super::TraceCallDetector {
             web3,


### PR DESCRIPTION
This PR adds possibility to define a hardcoded list of candidate token owner addresses to be considered in the `BadTokenDetector`.

For now only Seasolver asked for this, since they were using some tokens that we were not able to find token owners for, therefore marking them as bad.

Implemented as `TokenOwnerProposing` instance since I expect this list to eventually be provided by seasolver at some endpoint so we don't have to manually update every time the list is changed.
