### PR TITLE
Forward order id to solvers

### DIFF
--- a/crates/shared/src/http_solver/model.rs
+++ b/crates/shared/src/http_solver/model.rs
@@ -2,7 +2,7 @@ use derivative::Derivative;
 use ethcontract::{Bytes, H160};
 use model::{
     auction::AuctionId,
-    order::OrderData,
+    order::{OrderData, OrderUid},
     ratio_as_decimal,
     signature::Signature,
     u256_decimal::{self, DecimalU256},
@@ -22,7 +22,7 @@ use crate::{
 #[derive(Clone, Debug, Default, Serialize)]
 pub struct BatchAuctionModel {
     pub tokens: BTreeMap<H160, TokenInfoModel>,
-    pub orders: BTreeMap<usize, OrderModel>,
+    pub orders: BTreeMap<OrderUid, OrderModel>,
     pub amms: BTreeMap<usize, AmmModel>,
     pub metadata: Option<MetadataModel>,
 }
@@ -602,7 +602,7 @@ mod tests {
                     accepted_for_internalization: true,
                 }
             },
-            orders: btreemap! { 0 => order_model },
+            orders: btreemap! { Default::default() => order_model },
             amms: btreemap! {
                 0 => constant_product_pool_model,
                 1 => weighted_product_pool_model,
@@ -637,7 +637,7 @@ mod tests {
             },
           },
           "orders": {
-            "0": {
+            "0x0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000": {
               "sell_token": "0x000000000000000000000000000000000000a866",
               "buy_token": "0x0000000000000000000000000000000000000539",
               "sell_amount": "1",

--- a/crates/shared/src/http_solver/model.rs
+++ b/crates/shared/src/http_solver/model.rs
@@ -22,6 +22,9 @@ use crate::{
 #[derive(Clone, Debug, Default, Serialize)]
 pub struct BatchAuctionModel {
     pub tokens: BTreeMap<H160, TokenInfoModel>,
+    /// Note that orders can contain 0x limit orders that are not sent to solvers as liquidity (`amms` field)
+    /// but as an order. Since 0x sets OrderUid externally (in their own format), these orders (Uid wise)
+    /// are not expected to be matched to orders from orderbook
     pub orders: BTreeMap<OrderUid, OrderModel>,
     pub amms: BTreeMap<usize, AmmModel>,
     pub metadata: Option<MetadataModel>,

--- a/crates/shared/src/http_solver/model.rs
+++ b/crates/shared/src/http_solver/model.rs
@@ -169,7 +169,7 @@ impl Interaction for InteractionData {
 #[serde_as]
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct SettledBatchAuctionModel {
-    pub orders: HashMap<usize, ExecutedOrderModel>,
+    pub orders: HashMap<OrderUid, ExecutedOrderModel>,
     #[serde(default)]
     pub foreign_liquidity_orders: Vec<ExecutedLiquidityOrderModel>,
     #[serde(default)]

--- a/crates/shared/src/price_estimation/http.rs
+++ b/crates/shared/src/price_estimation/http.rs
@@ -92,7 +92,7 @@ impl HttpPriceEstimator {
         };
 
         let orders = maplit::btreemap! {
-            0 => OrderModel {
+            Default::default() => OrderModel {
                 sell_token: query.sell_token,
                 buy_token: query.buy_token,
                 sell_amount,

--- a/crates/solver/src/settlement_simulation.rs
+++ b/crates/solver/src/settlement_simulation.rs
@@ -574,7 +574,7 @@ mod tests {
                 "total_runtime": 0.247607875
             },
             "orders": {
-                "0": {
+                "0x721f9c5c4bbadeff130c4b0279951a2703c91ccc440cd64acb6b11caba0c64e9295a0bc540f3d9a9bd67a777ca9da9fb5619d3a961be1c03": {
                     "allow_partial_fill": false,
                     "buy_amount": "2377438739352985079",
                     "buy_token": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -594,7 +594,7 @@ mod tests {
                     "sell_amount": "9413614019",
                     "sell_token": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"
                 },
-                "1": {
+                "0x4da985bb7639bdac928553d0c39a3840388e27f825c572bb8addb47ef2de1f03e63a13eedd01b624958acfe32145298788a7a7ba61be1542": {
                     "allow_partial_fill": false,
                     "buy_amount": "11727881818",
                     "buy_token": "0xdac17f958d2ee523a2206206994597c13d831ec7",
@@ -614,7 +614,7 @@ mod tests {
                     "sell_amount": "11722136152",
                     "sell_token": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"
                 },
-                "2": {
+                "0x9a6986670e989c0bd4049d983ad574c2a8e8bdd6dd91473e197c2539caf8e025f105e7d4dc8b1592e806a36c3b351a8b63b5c07c61be1776": {
                     "allow_partial_fill": false,
                     "buy_amount": "1475587283",
                     "buy_token": "0xdac17f958d2ee523a2206206994597c13d831ec7",

--- a/crates/solver/src/solver/http_solver.rs
+++ b/crates/solver/src/solver/http_solver.rs
@@ -287,8 +287,16 @@ fn order_models(
                 Exchange::ZeroEx => gas_model.zeroex_order_cost(),
             };
 
+            let uid = match OrderUid::from_str(&order.id) {
+                Ok(uid) => uid,
+                Err(err) => {
+                    tracing::error!(?err, "failed to convert back to order uid");
+                    return None;
+                }
+            };
+
             Some((
-                OrderUid::from_str(&order.id).expect("failed conversion back to OrderUid"),
+                uid,
                 OrderModel {
                     sell_token: order.sell_token,
                     buy_token: order.buy_token,
@@ -733,7 +741,7 @@ mod tests {
             {
               "extra_crap": ["Hello"],
               "orders": {
-                "0": {
+                "0x0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000": {
                   "sell_token": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
                   "buy_token": "0xba100000625a3754423978a60c9317c58a424e3d",
                   "sell_amount": "195160000000000000",
@@ -751,7 +759,7 @@ mod tests {
                   "exec_buy_amount": "18689825362370811941",
                   "exec_sell_amount": "195160000000000000"
                 },
-                "1": {
+                "0x0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001": {
                   "sell_token": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
                   "buy_token": "0xba100000625a3754423978a60c9317c58a424e3d",
                   "sell_amount": "395160000000000000",


### PR DESCRIPTION
Fixes #346 
Essentially, order list is changed to be hashed by `OrderUid` instead of `usize` in structs `BatchAuctionModel` and `SettledBatchAuctionModel`. All other changes in this PR are changes on the dependent code.

### Test Plan

Unit tests updated and passing.

### Release notes

Notify solvers to update their schemas. Orders are now indexed by UID when data is sent to solvers, but also we expect the response containing order list to be also indexed by UID.
