### PR TITLE
Configure Ethereum RPC Request Buffering

### DIFF
--- a/crates/autopilot/src/lib.rs
+++ b/crates/autopilot/src/lib.rs
@@ -71,7 +71,12 @@ pub async fn main(args: arguments::Arguments) {
     let db_metrics = tokio::task::spawn(crate::database::database_metrics(db.clone()));
 
     let http_factory = HttpClientFactory::new(&args.http_client);
-    let web3 = shared::ethrpc::web3(&http_factory, &args.shared.node_url, "base");
+    let web3 = shared::ethrpc::web3(
+        &args.shared.ethrpc,
+        &http_factory,
+        &args.shared.node_url,
+        "base",
+    );
 
     let current_block_stream = shared::current_block::current_block_stream(
         web3.clone(),
@@ -175,7 +180,12 @@ pub async fn main(args: arguments::Arguments) {
     let trace_call_detector = args.tracing_node_url.as_ref().map(|tracing_node_url| {
         Box::new(CachingDetector::new(
             Box::new(TraceCallDetector {
-                web3: shared::ethrpc::web3(&http_factory, tracing_node_url, "trace"),
+                web3: shared::ethrpc::web3(
+                    &args.shared.ethrpc,
+                    &http_factory,
+                    tracing_node_url,
+                    "trace",
+                ),
                 finder,
                 settlement_contract: settlement_contract.address(),
             }),

--- a/crates/driver/src/arguments.rs
+++ b/crates/driver/src/arguments.rs
@@ -2,6 +2,7 @@ use primitive_types::{H160, H256};
 use reqwest::Url;
 use shared::{
     arguments::{display_list, display_option, display_secret_option, duration_from_seconds},
+    ethrpc,
     gas_price_estimation::GasEstimatorType,
     http_client,
     sources::{balancer_v2::BalancerFactoryKind, BaselineSource},
@@ -18,6 +19,9 @@ use tracing::level_filters::LevelFilter;
 pub struct Arguments {
     #[clap(flatten)]
     pub http_client: http_client::Arguments,
+
+    #[clap(flatten)]
+    pub ethrpc: ethrpc::Arguments,
 
     #[clap(flatten)]
     pub slippage: slippage::Arguments,
@@ -266,6 +270,7 @@ pub struct Arguments {
 impl std::fmt::Display for Arguments {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.http_client)?;
+        write!(f, "{}", self.ethrpc)?;
         write!(f, "{}", self.slippage)?;
         write!(f, "{}", self.tenderly)?;
         writeln!(f, "bind_address: {}", self.bind_address)?;

--- a/crates/orderbook/src/main.rs
+++ b/crates/orderbook/src/main.rs
@@ -63,7 +63,12 @@ async fn main() {
 
     let http_factory = HttpClientFactory::new(&args.http_client);
 
-    let web3 = shared::ethrpc::web3(&http_factory, &args.shared.node_url, "base");
+    let web3 = shared::ethrpc::web3(
+        &args.shared.ethrpc,
+        &http_factory,
+        &args.shared.node_url,
+        "base",
+    );
     let settlement_contract = GPv2Settlement::deployed(&web3)
         .await
         .expect("Couldn't load deployed settlement");
@@ -166,7 +171,12 @@ async fn main() {
     let trace_call_detector = args.tracing_node_url.as_ref().map(|tracing_node_url| {
         Box::new(CachingDetector::new(
             Box::new(TraceCallDetector {
-                web3: shared::ethrpc::web3(&http_factory, tracing_node_url, "trace"),
+                web3: shared::ethrpc::web3(
+                    &args.shared.ethrpc,
+                    &http_factory,
+                    tracing_node_url,
+                    "trace",
+                ),
                 finder,
                 settlement_contract: settlement_contract.address(),
             }),

--- a/crates/refunder/src/arguments.rs
+++ b/crates/refunder/src/arguments.rs
@@ -1,5 +1,5 @@
 use clap::Parser;
-use shared::http_client;
+use shared::{ethrpc, http_client};
 use std::time::Duration;
 use url::Url;
 
@@ -7,6 +7,9 @@ use url::Url;
 pub struct Arguments {
     #[clap(flatten)]
     pub http_client: http_client::Arguments,
+
+    #[clap(flatten)]
+    pub ethrpc: ethrpc::Arguments,
 
     /// Minimum time in seconds an order must have been valid for
     /// to be eligible for refunding
@@ -36,9 +39,12 @@ pub struct Arguments {
 
 impl std::fmt::Display for Arguments {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.http_client)?;
+        write!(f, "{}", self.ethrpc)?;
         writeln!(f, "min_validity_duration: {:?}", self.min_validity_duration)?;
         writeln!(f, "min_slippage_bps: {}", self.min_slippage_bps)?;
         writeln!(f, "db_url: SECRET")?;
+        writeln!(f, "node_url: {}", self.node_url)?;
         Ok(())
     }
 }

--- a/crates/refunder/src/lib.rs
+++ b/crates/refunder/src/lib.rs
@@ -12,7 +12,7 @@ const SLEEP_TIME_BETWEEN_LOOPS: u64 = 30;
 pub async fn main(args: arguments::Arguments) {
     let pg_pool = PgPool::connect_lazy(args.db_url.as_str()).expect("failed to create database");
     let http_factory = HttpClientFactory::new(&args.http_client);
-    let web3 = shared::ethrpc::web3(&http_factory, &args.node_url, "base");
+    let web3 = shared::ethrpc::web3(&args.ethrpc, &http_factory, &args.node_url, "base");
     let ethflow_contract = CoWSwapEthFlow::deployed(&web3)
         .await
         .expect("Could not find the CoWSwapEthFlow contract");

--- a/crates/shared/src/arguments.rs
+++ b/crates/shared/src/arguments.rs
@@ -1,5 +1,6 @@
 //! Contains command line arguments and related helpers that are shared between the binaries.
 use crate::{
+    ethrpc,
     fee_subsidy::cow_token::SubsidyTiers,
     gas_price_estimation::GasEstimatorType,
     price_estimation::PriceEstimatorType,
@@ -12,7 +13,7 @@ use ethcontract::{H160, H256, U256};
 use model::app_id::AppId;
 use std::{
     collections::HashMap,
-    fmt::{Display, Formatter},
+    fmt::{self, Display, Formatter},
     num::{NonZeroU64, ParseFloatError},
     str::FromStr,
     time::Duration,
@@ -110,6 +111,9 @@ pub struct OrderQuotingArguments {
 #[derive(clap::Parser)]
 #[group(skip)]
 pub struct Arguments {
+    #[clap(flatten)]
+    pub ethrpc: ethrpc::Arguments,
+
     #[clap(flatten)]
     pub tenderly: tenderly_api::Arguments,
 
@@ -333,7 +337,8 @@ impl Display for OrderQuotingArguments {
 // We have a custom Display implementation so that we can log the arguments on start up without
 // leaking any potentially secret values.
 impl Display for Arguments {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        write!(f, "{}", self.ethrpc)?;
         write!(f, "{}", self.tenderly)?;
         writeln!(f, "log_filter: {}", self.log_filter)?;
         writeln!(f, "log_stderr_threshold: {}", self.log_stderr_threshold)?;

--- a/crates/shared/src/arguments.rs
+++ b/crates/shared/src/arguments.rs
@@ -420,7 +420,7 @@ pub fn parse_percentage_factor(s: &str) -> Result<f64> {
 }
 
 pub fn duration_from_seconds(s: &str) -> Result<Duration, ParseFloatError> {
-    Ok(Duration::from_secs_f32(s.parse()?))
+    Ok(Duration::from_secs_f64(s.parse()?))
 }
 
 pub fn wei_from_base_unit(s: &str) -> anyhow::Result<U256> {

--- a/crates/shared/src/ethrpc.rs
+++ b/crates/shared/src/ethrpc.rs
@@ -30,7 +30,7 @@ pub struct Arguments {
 
     /// Maximum number of concurrent requests to send to the node. Use '0' for
     /// no limit on concurrency.
-    #[clap(long, default_value = "1")]
+    #[clap(long, default_value = "10")]
     pub ethrpc_max_concurrent_requests: usize,
 
     /// Buffering "nagle" delay to wait for additional requests before sending out

--- a/crates/shared/src/ethrpc.rs
+++ b/crates/shared/src/ethrpc.rs
@@ -8,7 +8,10 @@ use self::{buffered::BufferedTransport, http::HttpTransport};
 use crate::http_client::HttpClientFactory;
 use ethcontract::{batch::CallBatch, dyns::DynWeb3, transport::DynTransport};
 use reqwest::{Client, Url};
-use std::convert::TryInto as _;
+use std::{
+    fmt::{self, Display, Formatter},
+    num::NonZeroUsize,
+};
 
 pub const MAX_BATCH_SIZE: usize = 100;
 
@@ -16,13 +19,68 @@ pub type Web3 = DynWeb3;
 pub type Web3Transport = DynTransport;
 pub type Web3CallBatch = CallBatch<Web3Transport>;
 
+/// Command line arguments for the common Ethereum RPC connections.
+#[derive(clap::Parser)]
+#[group(skip)]
+pub struct Arguments {
+    /// Maximum batch size for Ethereum RPC requests. Use '0' to disable batching.
+    #[clap(long, default_value = "100")]
+    pub ethrpc_max_batch_size: usize,
+
+    /// Maximum number of concurrent requests to send to the node. Use '0' for
+    /// no limit on concurrency.
+    #[clap(long, default_value = "1")]
+    pub ethrpc_max_concurrent_requests: usize,
+}
+
+impl Arguments {
+    /// Returns the buffered transport configuration or `None` if batching is
+    /// disabled.
+    fn buffered_configuration(&self) -> Option<buffered::Configuration> {
+        match (
+            self.ethrpc_max_batch_size,
+            self.ethrpc_max_concurrent_requests,
+        ) {
+            (0 | 1, 0) => None,
+            _ => Some(buffered::Configuration {
+                max_concurrent_requests: NonZeroUsize::new(self.ethrpc_max_concurrent_requests),
+                max_batch_len: self.ethrpc_max_batch_size.max(1),
+                ..Default::default()
+            }),
+        }
+    }
+}
+
+impl Display for Arguments {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        writeln!(f, "ethrpc_max_batch_size: {}", self.ethrpc_max_batch_size)?;
+        writeln!(
+            f,
+            "ethrpc_max_concurrent_requests: {}",
+            self.ethrpc_max_concurrent_requests
+        )?;
+
+        Ok(())
+    }
+}
+
 /// Create a Web3 instance.
-pub fn web3(http_factory: &HttpClientFactory, url: &Url, name: impl ToString) -> Web3 {
-    let transport = Web3Transport::new(BufferedTransport::new(HttpTransport::new(
+pub fn web3(
+    args: &Arguments,
+    http_factory: &HttpClientFactory,
+    url: &Url,
+    name: impl ToString,
+) -> Web3 {
+    let http = HttpTransport::new(
         http_factory.configure(|builder| builder.cookie_store(true)),
         url.clone(),
         name.to_string(),
-    )));
+    );
+    let transport = match args.buffered_configuration() {
+        Some(config) => Web3Transport::new(BufferedTransport::with_config(http, config)),
+        None => Web3Transport::new(http),
+    };
+
     Web3::new(transport)
 }
 

--- a/crates/solver/src/main.rs
+++ b/crates/solver/src/main.rs
@@ -5,7 +5,7 @@ use num::rational::Ratio;
 use shared::{
     baseline_solver::BaseTokens,
     current_block::current_block_stream,
-    ethrpc::Web3,
+    ethrpc::{self, Web3},
     http_client::HttpClientFactory,
     maintenance::{Maintaining, ServiceMaintenance},
     metrics::serve_metrics,
@@ -57,7 +57,12 @@ async fn main() {
 
     let http_factory = HttpClientFactory::new(&args.http_client);
 
-    let web3 = shared::ethrpc::web3(&http_factory, &args.shared.node_url, "base");
+    let web3 = ethrpc::web3(
+        &args.shared.ethrpc,
+        &http_factory,
+        &args.shared.node_url,
+        "base",
+    );
     let chain_id = web3
         .eth()
         .chain_id()
@@ -313,7 +318,12 @@ async fn main() {
         .transaction_submission_nodes
         .into_iter()
         .enumerate()
-        .map(|(index, url)| (shared::ethrpc::web3(&http_factory, &url, index), url))
+        .map(|(index, url)| {
+            (
+                ethrpc::web3(&args.shared.ethrpc, &http_factory, &url, index),
+                url,
+            )
+        })
         .collect::<Vec<_>>();
     for (node, url) in &submission_nodes_with_url {
         let node_network_id = node


### PR DESCRIPTION
Fixes #688.

This PR adds CLI configuration options for controlling request buffering. Specifically, you can now control:
- The maximum batch size. This is used to 
- The maximum concurrency for Ethereum RPC requests.

For example:
- `--ethrpc-max-batch-size 10`: Sets the maximum batch size to 10 RPC requests. Uses the default `--ethrpc-max-concurrent-requests` value of `1`, meaning only ever 1 batch RPC request is sent to the node at any given time
- `--ethrpc-max-batch-size 10 --ethrpc-max-concurrent-requests 0`: Like above but disable concurrent request limiting (that is, if you make 93 simultaneous requests, the buffered transport will send 10 simultaneous batches to the node)
- `--ethrpc-max-batch-size 0 --ethrpc-max-concurrent-requests 5`: Disable batching, but only send up to 5 simultaneous requests to the node, buffering other requests to be sent after previous RPC calls resolve
- `--ethrpc-max-batch-size 0 --ethrpc-max-concurrent-requests 0`: Free-for-all! Immediately send all RPC requests to the node, as-is. This configuration actually matches what we have now (since we make use of manual batching in the services code). I will make a follow-up PR to remove the manual batching, in which case we will send a bunch of simultaneous HTTP requests to the node. This should be fine on Mainnet as our Dshackle setup is made to handle these situations.

### Test Plan

Run the services with various Ethereum RPC configuration options and see how it works.

### Release notes

New Ethereum RPC configuration options. We should tweak the configuration in staging before the next week's release.
