### PR TITLE
Specify default whitelisted owners

### DIFF
--- a/crates/shared/src/bad_token/token_owner_finder.rs
+++ b/crates/shared/src/bad_token/token_owner_finder.rs
@@ -81,6 +81,7 @@ pub struct Arguments {
         long,
         env,
         value_parser = parse_owners,
+        default_value = "",
     )]
     pub whitelisted_owners: HashMap<H160, Vec<H160>>,
 }


### PR DESCRIPTION
This PR just makes the newly introduced `--whitelisted-owners` default to the empty list so that it isn't required for running the `orderbook` binaries.

### Test Plan

The following starts:

```
cargo run -p orderbook
```
