### PR TITLE
Fix ParaSwap Trade Simulation Slippage

### DIFF
--- a/crates/shared/src/trade_finding/paraswap.rs
+++ b/crates/shared/src/trade_finding/paraswap.rs
@@ -101,7 +101,7 @@ impl Inner {
     }
 
     // Default to 1% slippage - same as the ParaSwap UI.
-    const DEFAULT_SLIPPAGE: u32 = 10_000;
+    const DEFAULT_SLIPPAGE: u32 = 100;
     // Use a default non-zero user address, otherwise the API will return an
     // error.
     const DEFAULT_USER: H160 = addr!("BEeFbeefbEefbeEFbeEfbEEfBEeFbeEfBeEfBeef");


### PR DESCRIPTION
This PR just fixes the ParaSwap slippage configuration for trade simulations. It was mistakenly set to 100% 🤦.

### Test Plan

CI
