### PR TITLE
Improved Handling of Quotes From 0-Address

### DIFF
--- a/crates/shared/src/order_quoting.rs
+++ b/crates/shared/src/order_quoting.rs
@@ -131,6 +131,12 @@ pub struct QuoteParameters {
 
 impl QuoteParameters {
     fn to_price_query(&self) -> price_estimation::Query {
+        let from = if self.from != H160::default() {
+            Some(self.from)
+        } else {
+            None
+        };
+
         let (kind, in_amount) = match self.side {
             OrderQuoteSide::Sell {
                 sell_amount:
@@ -143,7 +149,7 @@ impl QuoteParameters {
         };
 
         price_estimation::Query {
-            from: Some(self.from),
+            from,
             sell_token: self.sell_token,
             buy_token: self.buy_token,
             in_amount,

--- a/crates/shared/src/order_quoting.rs
+++ b/crates/shared/src/order_quoting.rs
@@ -131,7 +131,10 @@ pub struct QuoteParameters {
 
 impl QuoteParameters {
     fn to_price_query(&self) -> price_estimation::Query {
-        let from = if self.from != H160::default() {
+        // Treat quotes with `from: 0` as if they didn't specify a `from` address
+        // for price quotes. This is because the 0 address typically has special
+        // semantics and causes issues with trade simulations.
+        let from = if self.from != H160::zero() {
             Some(self.from)
         } else {
             None


### PR DESCRIPTION
This PR makes a small change in the computed `price_estimation::Query` for a given `api/v1/quote` request.

In experimenting with trade simulations, I noticed that there are clients that are making price `quote` requests with `from: 0`. This is not a problem in and of itself, but does cause a lot of issues WRT trade simulation. Specifically, many tokens actually disallow transferring to and/or from the 0 address (as its treated as a special address), and it is conceivable that the 0-address has special semantics in existing exchanges (as it does for our exchange's `order.receiver`).

With that in mind, it makes sense for us to have special handling of the 0-address for price quoting. There were 3 different ways I thought of approaching this issue:
1. Have an additional condition in the `TradeVerifier` implementation to turn the 0-address into `TradeVerifier::DEFAULT_TRADER` address. The reason I didn't like this is that we already pass in a `Query` with a `from: Option<Address>` field, so having `None` for using the default trader makes sense, and having a "magic" `Some(0)` value felt icky.
2. Deny quotes with `from: 0`. This seems a bit heavy handed, as there are API users that are making price quotes with this address. Also, there is nothing intrinsically wrong with it (they could just use a `Address(1)` instead for example), and the 0-address seems like a reasonable value for a "I don't care about the `from` address in the quote". I do much prefer this to 1 though and almost went with this approach.
3. What I did here, basically, fudge the `Query::from` value when a quote is made with `from: 0`. This makes it so we don't break existing API usage while avoiding issues with simulations and price estimates in general.

### Test Plan

CI
