### PR TITLE
Refactor how to add liquidity trades to SettlementEncoder

### DIFF
--- a/crates/driver/src/settlement_proposal.rs
+++ b/crates/driver/src/settlement_proposal.rs
@@ -155,16 +155,7 @@ impl SettlementProposal {
         for trade in self.trades {
             let remaining = shared::remaining_amounts::Remaining::from_order(&trade.order)?;
             let remaining_fee = remaining.remaining(trade.order.data.fee_amount)?;
-
-            if trade.order.metadata.class == OrderClass::Liquidity {
-                encoder.add_liquidity_order_trade(
-                    trade.order,
-                    trade.executed_amount,
-                    remaining_fee,
-                )?;
-            } else {
-                encoder.add_trade(trade.order, trade.executed_amount, remaining_fee)?;
-            }
+            encoder.add_trade(trade.order, trade.executed_amount, remaining_fee)?;
         }
 
         let futures = self

--- a/crates/model/src/order.rs
+++ b/crates/model/src/order.rs
@@ -200,6 +200,11 @@ impl OrderBuilder {
         self
     }
 
+    pub fn with_class(mut self, class: OrderClass) -> Self {
+        self.0.metadata.class = class;
+        self
+    }
+
     pub fn build(self) -> Order {
         self.0
     }

--- a/crates/solver/src/driver/solver_settlements.rs
+++ b/crates/solver/src/driver/solver_settlements.rs
@@ -179,7 +179,7 @@ pub fn retain_mature_settlements(
 mod tests {
     use super::*;
     use crate::{
-        settlement::{external_prices::externalprices, LiquidityOrderTrade, OrderTrade, Trade},
+        settlement::{external_prices::externalprices, CustomPriceTrade, OrderTrade, Trade},
         solver::dummy_arc_solver,
     };
     use chrono::{offset::Utc, DateTime, Duration, Local};
@@ -206,8 +206,8 @@ mod tests {
         }
     }
 
-    fn liquidity_trade(created_at: DateTime<Utc>, uid: u8) -> LiquidityOrderTrade {
-        LiquidityOrderTrade {
+    fn liquidity_trade(created_at: DateTime<Utc>, uid: u8) -> CustomPriceTrade {
+        CustomPriceTrade {
             trade: Trade {
                 order: Order {
                     metadata: OrderMetadata {
@@ -528,7 +528,7 @@ mod tests {
         let settlement = Settlement::with_trades(
             Default::default(),
             vec![],
-            vec![LiquidityOrderTrade::default()],
+            vec![CustomPriceTrade::default()],
         );
         assert!(!has_user_order(&settlement));
 
@@ -541,7 +541,7 @@ mod tests {
             vec![OrderTrade {
                 ..Default::default()
             }],
-            vec![LiquidityOrderTrade::default()],
+            vec![CustomPriceTrade::default()],
         );
         assert!(has_user_order(&settlement));
     }

--- a/crates/solver/src/in_flight_orders.rs
+++ b/crates/solver/src/in_flight_orders.rs
@@ -112,7 +112,7 @@ impl InFlightOrders {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::settlement::{LiquidityOrderTrade, OrderTrade, SettlementEncoder, Trade};
+    use crate::settlement::{CustomPriceTrade, OrderTrade, SettlementEncoder, Trade};
     use maplit::hashmap;
     use model::order::{Order, OrderData, OrderKind, OrderMetadata};
     use primitive_types::H160;
@@ -162,7 +162,7 @@ mod tests {
 
         let liquidity_trades = vec![
             // This order uses some of the remaining executable amount of partially_fillable_1
-            LiquidityOrderTrade {
+            CustomPriceTrade {
                 trade: Trade {
                     order: partially_fillable_2.clone(),
                     executed_amount: 20u8.into(),
@@ -172,7 +172,7 @@ mod tests {
                 ..Default::default()
             },
             // Following orders use remaining executable amount of partially_fillable_2
-            LiquidityOrderTrade {
+            CustomPriceTrade {
                 trade: Trade {
                     order: partially_fillable_1.clone(),
                     executed_amount: 50u8.into(),
@@ -181,7 +181,7 @@ mod tests {
                 buy_token_price: 1u8.into(),
                 ..Default::default()
             },
-            LiquidityOrderTrade {
+            CustomPriceTrade {
                 trade: Trade {
                     order: partially_fillable_1.clone(),
                     executed_amount: 20u8.into(),

--- a/crates/solver/src/settlement.rs
+++ b/crates/solver/src/settlement.rs
@@ -324,12 +324,12 @@ impl Settlement {
             .order_trades()
             .iter()
             .map(|trade| &trade.trade.order);
-        let liquidity_orders = self
+        let custom_trades = self
             .encoder
-            .liquidity_order_trades()
+            .custom_price_trades()
             .iter()
             .map(|trade| &trade.trade.order);
-        user_orders.chain(liquidity_orders)
+        user_orders.chain(custom_trades)
     }
 
     /// Returns an iterator of all executed trades.
@@ -344,23 +344,23 @@ impl Settlement {
                 )
                 .map(|execution| (&order_trade.trade, execution))
         });
-        let liquidity_order_trades =
+        let custom_price_trades =
             self.encoder
-                .liquidity_order_trades()
+                .custom_price_trades()
                 .iter()
-                .map(move |liquidity_order_trade| {
-                    let order = &liquidity_order_trade.trade.order.data;
-                    liquidity_order_trade
+                .map(move |custom_price_trade| {
+                    let order = &custom_price_trade.trade.order.data;
+                    custom_price_trade
                         .trade
                         .executed_amounts(
                             self.clearing_price(order.sell_token)?,
-                            liquidity_order_trade.buy_token_price,
+                            custom_price_trade.buy_token_price,
                         )
-                        .map(|execution| (&liquidity_order_trade.trade, execution))
+                        .map(|execution| (&custom_price_trade.trade, execution))
                 });
 
         order_trades
-            .chain(liquidity_order_trades)
+            .chain(custom_price_trades)
             .map(|execution| execution.expect("invalid trade was added to encoder"))
     }
 

--- a/crates/solver/src/settlement/settlement_encoder.rs
+++ b/crates/solver/src/settlement/settlement_encoder.rs
@@ -96,11 +96,11 @@ impl SettlementEncoder {
     pub fn with_trades(
         clearing_prices: HashMap<H160, U256>,
         trades: Vec<OrderTrade>,
-        liquidity_order_trades: Vec<CustomPriceTrade>,
+        custom_price_trades: Vec<CustomPriceTrade>,
     ) -> Self {
         let mut result = Self::new(clearing_prices);
         result.order_trades = trades;
-        result.custom_price_trades = liquidity_order_trades;
+        result.custom_price_trades = custom_price_trades;
         result
     }
 
@@ -125,7 +125,7 @@ impl SettlementEncoder {
         &self.order_trades
     }
 
-    pub fn liquidity_order_trades(&self) -> &[CustomPriceTrade] {
+    pub fn custom_price_trades(&self) -> &[CustomPriceTrade] {
         &self.custom_price_trades
     }
 

--- a/crates/solver/src/settlement/settlement_encoder.rs
+++ b/crates/solver/src/settlement/settlement_encoder.rs
@@ -225,7 +225,7 @@ impl SettlementEncoder {
         // <=> order.sellAmount.mul(sellPrice)  >= order.buyAmount.mul(sell_price * order.sellAmount / order.buyAmount)
         // <=> order.sellAmount.mul(sellPrice)  >= order.buyAmount.mul(buyPrice)
         // <=> equation from smart contract
-        //
+
         self.clearing_prices
             .get(&order.data.sell_token)
             .unwrap_or(&order.data.buy_amount)

--- a/crates/solver/src/settlement/settlement_encoder.rs
+++ b/crates/solver/src/settlement/settlement_encoder.rs
@@ -242,7 +242,6 @@ impl SettlementEncoder {
         scaled_unsubsidized_fee: U256,
         buy_price: U256,
     ) -> Result<TradeExecution> {
-        verify_executed_amount(&order, executed_amount)?;
         // For the encoding strategy of liquidity and limit orders, the sell prices are taken from
         // the uniform clearing price vector. Therefore, either there needs to be an existing price
         // for the sell token in the uniform clearing prices or we have to create a new price entry beforehand,

--- a/crates/solver/src/settlement/settlement_encoder.rs
+++ b/crates/solver/src/settlement/settlement_encoder.rs
@@ -355,8 +355,8 @@ impl SettlementEncoder {
         }
     }
     fn modify_token_index_for_liquidity_orders_after_change(&mut self, offset: usize) {
-        for i in 0..self.custom_price_trades.len() {
-            self.custom_price_trades[i].buy_token_offset_index += offset;
+        for custom_price_trade in &mut self.custom_price_trades {
+            custom_price_trade.buy_token_offset_index += offset;
         }
     }
 

--- a/crates/solver/src/settlement/settlement_encoder.rs
+++ b/crates/solver/src/settlement/settlement_encoder.rs
@@ -137,7 +137,7 @@ impl SettlementEncoder {
 
     /// Adds an order trade using the uniform clearing prices for sell and buy token.
     /// Fails if any used token doesn't have a price or if executed amount is impossible.
-    fn add_ucp_trade(
+    fn add_market_trade(
         &mut self,
         order: Order,
         executed_amount: U256,
@@ -189,7 +189,7 @@ impl SettlementEncoder {
         let interactions = order.interactions.clone();
         let execution = match order.metadata.class {
             OrderClass::Ordinary => {
-                self.add_ucp_trade(order, executed_amount, scaled_unsubsidized_fee)?
+                self.add_market_trade(order, executed_amount, scaled_unsubsidized_fee)?
             }
             OrderClass::Liquidity => {
                 let buy_price = self.compute_limit_buy_price(&order)?;

--- a/crates/solver/src/settlement/settlement_encoder.rs
+++ b/crates/solver/src/settlement/settlement_encoder.rs
@@ -201,7 +201,7 @@ impl SettlementEncoder {
                 )?
             }
             OrderClass::Limit => {
-                todo!()
+                anyhow::bail!("limit orders are not supported by the SettlementEncoder");
             }
         };
         self.pre_interactions.extend(interactions.pre.into_iter());

--- a/crates/solver/src/settlement/settlement_encoder.rs
+++ b/crates/solver/src/settlement/settlement_encoder.rs
@@ -247,7 +247,7 @@ impl SettlementEncoder {
         // the uniform clearing price vector. Therefore, either there needs to be an existing price
         // for the sell token in the uniform clearing prices or we have to create a new price entry beforehand,
         // if the sell token price is not yet available
-        if self.token_index(order.data.sell_token) == None {
+        if self.token_index(order.data.sell_token).is_none() {
             let sell_token = order.data.sell_token;
             let sell_price = order.data.buy_amount;
             self.tokens.push(sell_token);

--- a/crates/solver/src/settlement/settlement_encoder.rs
+++ b/crates/solver/src/settlement/settlement_encoder.rs
@@ -186,14 +186,15 @@ impl SettlementEncoder {
         scaled_unsubsidized_fee: U256,
     ) -> Result<TradeExecution> {
         verify_executed_amount(&order, executed_amount)?;
+        let interactions = order.interactions.clone();
         let execution = match order.metadata.class {
             OrderClass::Ordinary => {
-                self.add_ucp_trade(order.clone(), executed_amount, scaled_unsubsidized_fee)?
+                self.add_ucp_trade(order, executed_amount, scaled_unsubsidized_fee)?
             }
             OrderClass::Liquidity => {
                 let buy_price = self.compute_limit_buy_price(&order)?;
                 self.add_custom_price_trade(
-                    order.clone(),
+                    order,
                     executed_amount,
                     scaled_unsubsidized_fee,
                     buy_price,
@@ -203,8 +204,7 @@ impl SettlementEncoder {
                 todo!()
             }
         };
-        self.pre_interactions
-            .extend(order.interactions.pre.into_iter());
+        self.pre_interactions.extend(interactions.pre.into_iter());
         Ok(execution)
     }
 

--- a/crates/solver/src/solver/http_solver/settlement.rs
+++ b/crates/solver/src/solver/http_solver/settlement.rs
@@ -558,7 +558,7 @@ mod tests {
         );
 
         assert_eq!(
-            settlement.encoder.liquidity_order_trades(),
+            settlement.encoder.custom_price_trades(),
             [CustomPriceTrade {
                 trade: Trade {
                     order: Order {

--- a/crates/solver/src/solver/http_solver/settlement.rs
+++ b/crates/solver/src/solver/http_solver/settlement.rs
@@ -365,7 +365,7 @@ mod tests {
             tests::CapturingSettlementHandler, ConstantProductOrder, StablePoolOrder,
             WeightedProductOrder,
         },
-        settlement::{LiquidityOrderTrade, Trade},
+        settlement::{CustomPriceTrade, Trade},
     };
     use hex_literal::hex;
     use maplit::hashmap;
@@ -559,7 +559,7 @@ mod tests {
 
         assert_eq!(
             settlement.encoder.liquidity_order_trades(),
-            [LiquidityOrderTrade {
+            [CustomPriceTrade {
                 trade: Trade {
                     order: Order {
                         metadata: OrderMetadata {


### PR DESCRIPTION
Supporting limit orders ([#705](https://github.com/cowprotocol/services/issues/705)) requires a way to add trades to the `SettlementEncoder` in way that bypasses the uniform clearing price requirements. This is needed to account for the `surplus_fee`.
A similar thing was already needed for liquidity trades which had to be traded at exactly the limit price to not get any surplus. Instead of adding yet another field to the `SettlementEncoder` for limit orders I would like to rename `liquiditiy_order_trades` to `custom_price_trades` and reuse it for limit order trades because the underlying requirement is the same (bypass UCP in favor of a custom price).

Additionally I also refactored how you add orders to the `SettlementEncoder`. Instead of exposing multiple different functions (`add_ordinary_trade()`, `add_liquidity_trade()`, `add_limit_trade()`) this PR only exposes `add_trade()` and let's the `SettlementEncoder` match on the `order.metadata.class` to execute the appropriate implementation.

This change required a few changes in the unit tests which were made trivial by also adding `OrderBuilder::with_class()`.

In a follow up PR I would like to update `SettlementEncoder::add_trade()` to correctly encode limit orders with minimal changes for refactoring.

### Test Plan
Existing unit tests are still passing
