### PR TITLE
Price Estimates From Settlement Contract

### DIFF
--- a/crates/autopilot/src/lib.rs
+++ b/crates/autopilot/src/lib.rs
@@ -304,6 +304,7 @@ pub async fn main(args: arguments::Arguments) {
             name: network_name.to_string(),
             chain_id,
             native_token: native_token.address(),
+            settlement: settlement_contract.address(),
             authenticator: settlement_contract
                 .authenticator()
                 .call()

--- a/crates/autopilot/src/risk_adjusted_rewards.rs
+++ b/crates/autopilot/src/risk_adjusted_rewards.rs
@@ -309,6 +309,7 @@ mod tests {
                     )),
                     Default::default(),
                     shared::rate_limiter::RateLimiter::test(),
+                    testlib::protocol::SETTLEMENT,
                 )),
                 testlib::tokens::WETH,
                 primitive_types::U256::from_f64_lossy(1e18),

--- a/crates/orderbook/src/main.rs
+++ b/crates/orderbook/src/main.rs
@@ -291,6 +291,7 @@ async fn main() {
             name: network_name.to_string(),
             chain_id,
             native_token: native_token.address(),
+            settlement: settlement_contract.address(),
             authenticator: settlement_contract
                 .authenticator()
                 .call()

--- a/crates/shared/src/oneinch_api.rs
+++ b/crates/shared/src/oneinch_api.rs
@@ -527,6 +527,11 @@ impl OneInchClientImpl {
             chain_id,
         })
     }
+
+    #[cfg(test)]
+    pub fn test() -> Self {
+        OneInchClientImpl::new(OneInchClientImpl::DEFAULT_URL, Client::new(), 1).unwrap()
+    }
 }
 
 #[async_trait::async_trait]
@@ -883,8 +888,7 @@ mod tests {
     #[tokio::test]
     #[ignore]
     async fn oneinch_swap() {
-        let swap = OneInchClientImpl::new(OneInchClientImpl::DEFAULT_URL, Client::new(), 1)
-            .unwrap()
+        let swap = OneInchClientImpl::test()
             .get_swap(SwapQuery {
                 from_address: addr!("00000000219ab540356cBB839Cbe05303d7705Fa"),
                 slippage: Slippage::ONE_PERCENT,
@@ -908,8 +912,7 @@ mod tests {
     #[tokio::test]
     #[ignore]
     async fn oneinch_swap_fully_parameterized() {
-        let swap = OneInchClientImpl::new(OneInchClientImpl::DEFAULT_URL, Client::new(), 1)
-            .unwrap()
+        let swap = OneInchClientImpl::test()
             .get_swap(SwapQuery {
                 from_address: addr!("4e608b7da83f8e9213f554bdaa77c72e125529d0"),
                 slippage: Slippage::percentage(1.2345678).unwrap(),
@@ -945,8 +948,7 @@ mod tests {
     #[tokio::test]
     #[ignore]
     async fn oneinch_liquidity_sources() {
-        let protocols = OneInchClientImpl::new(OneInchClientImpl::DEFAULT_URL, Client::new(), 1)
-            .unwrap()
+        let protocols = OneInchClientImpl::test()
             .get_liquidity_sources()
             .await
             .unwrap();

--- a/crates/shared/src/price_estimation/factory.rs
+++ b/crates/shared/src/price_estimation/factory.rs
@@ -63,6 +63,7 @@ pub struct Network {
     pub name: String,
     pub chain_id: u64,
     pub native_token: H160,
+    pub settlement: H160,
     pub authenticator: H160,
     pub base_tokens: Arc<BaseTokens>,
 }
@@ -347,6 +348,7 @@ impl PriceEstimatorCreating for ParaswapPriceEstimator {
             factory.components.tokens.clone(),
             factory.shared_args.disabled_paraswap_dexs.clone(),
             factory.rate_limiter(kind),
+            factory.network.settlement,
         ))
     }
 
@@ -366,6 +368,7 @@ impl PriceEstimatorCreating for ZeroExPriceEstimator {
             factory.components.zeroex.clone(),
             factory.shared_args.disabled_zeroex_sources.clone(),
             factory.rate_limiter(kind),
+            factory.network.settlement,
         ))
     }
 
@@ -390,6 +393,7 @@ impl PriceEstimatorCreating for OneInchPriceEstimator {
                 .context("1Inch API not supported for network")?,
             factory.shared_args.disabled_one_inch_protocols.clone(),
             factory.rate_limiter(kind),
+            factory.network.settlement,
             factory.shared_args.one_inch_referrer_address,
         ))
     }

--- a/crates/shared/src/price_estimation/oneinch.rs
+++ b/crates/shared/src/price_estimation/oneinch.rs
@@ -16,9 +16,11 @@ impl OneInchPriceEstimator {
         api: Arc<dyn OneInchClient>,
         disabled_protocols: Vec<String>,
         rate_limiter: Arc<RateLimiter>,
+        settlement: H160,
         referrer_address: Option<H160>,
     ) -> Self {
         Self(TradeEstimator::new(
+            settlement,
             Arc::new(OneInchTradeFinder::new(
                 api,
                 disabled_protocols,
@@ -62,6 +64,7 @@ mod tests {
                     Default::default(),
                     "test".into(),
                 )),
+                testlib::protocol::SETTLEMENT,
                 None,
             )
         }

--- a/crates/shared/src/price_estimation/paraswap.rs
+++ b/crates/shared/src/price_estimation/paraswap.rs
@@ -6,6 +6,7 @@ use crate::{
     paraswap_api::ParaswapApi, rate_limiter::RateLimiter, token_info::TokenInfoFetching,
     trade_finding::paraswap::ParaswapTradeFinder,
 };
+use ethcontract::H160;
 use std::sync::Arc;
 
 pub struct ParaswapPriceEstimator(TradeEstimator);
@@ -16,8 +17,10 @@ impl ParaswapPriceEstimator {
         token_info: Arc<dyn TokenInfoFetching>,
         disabled_paraswap_dexs: Vec<String>,
         rate_limiter: Arc<RateLimiter>,
+        settlement: H160,
     ) -> Self {
         Self(TradeEstimator::new(
+            settlement,
             Arc::new(ParaswapTradeFinder::new(
                 api,
                 token_info,
@@ -71,6 +74,7 @@ mod tests {
                 Default::default(),
                 "test".into(),
             )),
+            testlib::protocol::SETTLEMENT,
         );
 
         let weth = testlib::tokens::WETH;

--- a/crates/shared/src/price_estimation/trade_finder.rs
+++ b/crates/shared/src/price_estimation/trade_finder.rs
@@ -27,13 +27,14 @@ use web3::{ethabi::Token, types::CallRequest};
 /// A `TradeFinding`-based price estimator with request sharing and rate
 /// limiting.
 pub struct TradeEstimator {
-    inner: Inner,
+    inner: Arc<Inner>,
     sharing: RequestSharing<Query, BoxFuture<'static, Result<Estimate, PriceEstimationError>>>,
     rate_limiter: Arc<RateLimiter>,
 }
 
 #[derive(Clone)]
 struct Inner {
+    settlement: H160,
     finder: Arc<dyn TradeFinding>,
     verifier: Option<TradeVerifier>,
 }
@@ -47,19 +48,27 @@ pub struct TradeVerifier {
 }
 
 impl TradeEstimator {
-    pub fn new(finder: Arc<dyn TradeFinding>, rate_limiter: Arc<RateLimiter>) -> Self {
+    pub fn new(
+        settlement: H160,
+        finder: Arc<dyn TradeFinding>,
+        rate_limiter: Arc<RateLimiter>,
+    ) -> Self {
         Self {
-            inner: Inner {
+            inner: Arc::new(Inner {
+                settlement,
                 finder,
                 verifier: None,
-            },
+            }),
             sharing: Default::default(),
             rate_limiter,
         }
     }
 
     pub fn with_verifier(mut self, verifier: TradeVerifier) -> Self {
-        self.inner.verifier = Some(verifier);
+        self.inner = Arc::new(Inner {
+            verifier: Some(verifier),
+            ..arc_unwrap_or_clone(self.inner)
+        });
         self
     }
 
@@ -73,17 +82,27 @@ impl TradeEstimator {
 }
 
 impl Inner {
-    async fn estimate(self, query: Query) -> Result<Estimate, PriceEstimationError> {
-        match self.verifier {
+    async fn estimate(self: Arc<Self>, query: Query) -> Result<Estimate, PriceEstimationError> {
+        // Trades are simulated from the settlement contract, so when finding
+        // trades and quotes make sure to use the settlement contract as the
+        // `from` address. This is important as some trade finders (1Inch for
+        // example) encode the `from` address as the recipient of the swap and
+        // don't use `msg.sender`.
+        let finder_query = Query {
+            from: Some(self.settlement),
+            ..query
+        };
+
+        match &self.verifier {
             Some(verifier) => {
-                let trade = self.finder.get_trade(&query).await?;
+                let trade = self.finder.get_trade(&finder_query).await?;
                 verifier
                     .verify(query, trade)
                     .await
                     .map_err(PriceEstimationError::Other)
             }
             None => {
-                let quote = self.finder.get_quote(&query).await?;
+                let quote = self.finder.get_quote(&finder_query).await?;
                 Ok(Estimate {
                     out_amount: quote.out_amount,
                     gas: quote.gas_estimate,
@@ -317,6 +336,13 @@ mod slippage {
     }
 }
 
+fn arc_unwrap_or_clone<T>(arc: Arc<T>) -> T
+where
+    T: Clone,
+{
+    Arc::try_unwrap(arc).unwrap_or_else(|arc| (*arc).clone())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -324,9 +350,13 @@ mod tests {
         code_fetching::MockCodeFetching,
         code_simulation::{MockCodeSimulating, TenderlyCodeSimulator},
         ethrpc::{create_env_test_transport, Web3},
+        oneinch_api::OneInchClientImpl,
         price_estimation::single_estimate,
         tenderly_api::TenderlyHttpApi,
-        trade_finding::{zeroex::ZeroExTradeFinder, Interaction, MockTradeFinding, Quote},
+        trade_finding::{
+            oneinch::OneInchTradeFinder, zeroex::ZeroExTradeFinder, Interaction, MockTradeFinding,
+            Quote,
+        },
         zeroex_api::DefaultZeroExApi,
     };
     use anyhow::anyhow;
@@ -382,7 +412,8 @@ mod tests {
 
     #[tokio::test]
     async fn simulates_trades() {
-        let authenticator = H160([0xa; 20]);
+        let settlement = H160([0xa; 20]);
+        let authenticator = H160([0xb; 20]);
         let query = Query {
             from: Some(H160([0x1; 20])),
             sell_token: H160([0x2; 20]),
@@ -482,7 +513,10 @@ mod tests {
         let mut finder = MockTradeFinding::new();
         finder
             .expect_get_trade()
-            .with(predicate::eq(query))
+            .with(predicate::eq(Query {
+                from: Some(settlement),
+                ..query
+            }))
             .returning({
                 let trade = trade.clone();
                 move |_| Ok(trade.clone())
@@ -503,9 +537,10 @@ mod tests {
                 move |_| Ok(code.clone())
             });
 
-        let estimator = TradeEstimator::new(Arc::new(finder), RateLimiter::test()).with_verifier(
-            TradeVerifier::new(Arc::new(simulator), Arc::new(code_fetcher), authenticator),
-        );
+        let estimator =
+            TradeEstimator::new(settlement, Arc::new(finder), RateLimiter::test()).with_verifier(
+                TradeVerifier::new(Arc::new(simulator), Arc::new(code_fetcher), authenticator),
+            );
 
         let estimate = single_estimate(&estimator, &query).await.unwrap();
 
@@ -607,13 +642,13 @@ mod tests {
             .expect_code()
             .returning(|_| Ok(Default::default()));
 
-        let estimator = TradeEstimator::new(Arc::new(finder), RateLimiter::test()).with_verifier(
-            TradeVerifier::new(
-                Arc::new(simulator),
-                Arc::new(code_fetcher),
-                Default::default(),
-            ),
-        );
+        let estimator =
+            TradeEstimator::new(Default::default(), Arc::new(finder), RateLimiter::test())
+                .with_verifier(TradeVerifier::new(
+                    Arc::new(simulator),
+                    Arc::new(code_fetcher),
+                    Default::default(),
+                ));
 
         let estimate = single_estimate(&estimator, &query).await.unwrap();
 
@@ -628,6 +663,7 @@ mod tests {
 
     #[tokio::test]
     async fn estimates_with_quote_without_verifier() {
+        let settlement = H160([0xa; 20]);
         let query = Query {
             from: Some(H160([0x1; 20])),
             sell_token: H160([0x2; 20]),
@@ -643,13 +679,16 @@ mod tests {
         let mut finder = MockTradeFinding::new();
         finder
             .expect_get_quote()
-            .with(predicate::eq(query))
+            .with(predicate::eq(Query {
+                from: Some(settlement),
+                ..query
+            }))
             .returning({
                 let quote = quote.clone();
                 move |_| Ok(quote.clone())
             });
 
-        let estimator = TradeEstimator::new(Arc::new(finder), RateLimiter::test());
+        let estimator = TradeEstimator::new(settlement, Arc::new(finder), RateLimiter::test());
 
         let estimate = single_estimate(&estimator, &query).await.unwrap();
 
@@ -693,13 +732,13 @@ mod tests {
             .expect_code()
             .returning(|_| Ok(Default::default()));
 
-        let estimator = TradeEstimator::new(Arc::new(finder), RateLimiter::test()).with_verifier(
-            TradeVerifier::new(
-                Arc::new(simulator),
-                Arc::new(code_fetcher),
-                Default::default(),
-            ),
-        );
+        let estimator =
+            TradeEstimator::new(Default::default(), Arc::new(finder), RateLimiter::test())
+                .with_verifier(TradeVerifier::new(
+                    Arc::new(simulator),
+                    Arc::new(code_fetcher),
+                    Default::default(),
+                ));
 
         let estimate = single_estimate(&estimator, &query).await.unwrap();
 
@@ -742,13 +781,13 @@ mod tests {
         let mut code_fetcher = MockCodeFetching::new();
         code_fetcher.expect_code().returning(|_| Ok(bytes!("")));
 
-        let estimator = TradeEstimator::new(Arc::new(finder), RateLimiter::test()).with_verifier(
-            TradeVerifier::new(
-                Arc::new(simulator),
-                Arc::new(code_fetcher),
-                Default::default(),
-            ),
-        );
+        let estimator =
+            TradeEstimator::new(Default::default(), Arc::new(finder), RateLimiter::test())
+                .with_verifier(TradeVerifier::new(
+                    Arc::new(simulator),
+                    Arc::new(code_fetcher),
+                    Default::default(),
+                ));
 
         macro_rules! assert_output {
             ($check:ident: $x:literal) => {
@@ -911,14 +950,18 @@ mod tests {
         let verifier = TradeVerifier::new(
             Arc::new(simulator),
             Arc::new(web3),
-            addr!("2c4c28DDBdAc9C5E7055b4C863b72eA0149D8aFE"),
+            testlib::protocol::AUTHENTICATOR,
         );
 
         let zeroex_api = DefaultZeroExApi::test();
         let finder = ZeroExTradeFinder::new(Arc::new(zeroex_api), vec![]);
 
-        let estimator =
-            TradeEstimator::new(Arc::new(finder), RateLimiter::test()).with_verifier(verifier);
+        let estimator = TradeEstimator::new(
+            testlib::protocol::SETTLEMENT,
+            Arc::new(finder),
+            RateLimiter::test(),
+        )
+        .with_verifier(verifier);
 
         let estimate = single_estimate(
             &estimator,
@@ -935,6 +978,53 @@ mod tests {
 
         println!(
             "1.0 WETH buys {} COW, costing {} gas",
+            estimate.out_amount.to_f64_lossy() / 1e18,
+            estimate.gas,
+        );
+    }
+
+    #[tokio::test]
+    #[ignore]
+    async fn verified_oneinch_trade() {
+        let web3 = Web3::new(create_env_test_transport());
+
+        let tenderly_api = TenderlyHttpApi::test_from_env();
+        let simulator = TenderlyCodeSimulator::new(tenderly_api, 1).save(true, true);
+        let verifier = TradeVerifier::new(
+            Arc::new(simulator),
+            Arc::new(web3),
+            testlib::protocol::AUTHENTICATOR,
+        );
+
+        let oneinch_api = OneInchClientImpl::test();
+        let finder = OneInchTradeFinder::new(
+            Arc::new(oneinch_api),
+            vec![],
+            Some(testlib::protocol::SETTLEMENT),
+        );
+
+        let estimator = TradeEstimator::new(
+            testlib::protocol::SETTLEMENT,
+            Arc::new(finder),
+            RateLimiter::test(),
+        )
+        .with_verifier(verifier);
+
+        let estimate = single_estimate(
+            &estimator,
+            &Query {
+                from: Some(addr!("A03be496e67Ec29bC62F01a428683D7F9c204930")),
+                sell_token: testlib::tokens::WETH,
+                buy_token: testlib::tokens::DAI,
+                in_amount: 10u128.pow(2 + 18).into(),
+                kind: OrderKind::Sell,
+            },
+        )
+        .await
+        .unwrap();
+
+        println!(
+            "100.0 WETH buys {} DAI, costing {} gas",
             estimate.out_amount.to_f64_lossy() / 1e18,
             estimate.gas,
         );

--- a/crates/shared/src/price_estimation/zeroex.rs
+++ b/crates/shared/src/price_estimation/zeroex.rs
@@ -5,6 +5,7 @@ use super::{
 use crate::{
     rate_limiter::RateLimiter, trade_finding::zeroex::ZeroExTradeFinder, zeroex_api::ZeroExApi,
 };
+use ethcontract::H160;
 use std::sync::Arc;
 
 pub struct ZeroExPriceEstimator(TradeEstimator);
@@ -14,8 +15,10 @@ impl ZeroExPriceEstimator {
         api: Arc<dyn ZeroExApi>,
         excluded_sources: Vec<String>,
         rate_limiter: Arc<RateLimiter>,
+        settlement: H160,
     ) -> Self {
         Self(TradeEstimator::new(
+            settlement,
             Arc::new(ZeroExTradeFinder::new(api, excluded_sources)),
             rate_limiter,
         ))
@@ -54,6 +57,7 @@ mod tests {
                 Default::default(),
                 "test".into(),
             )),
+            testlib::protocol::SETTLEMENT,
         )
     }
 

--- a/crates/testlib/src/lib.rs
+++ b/crates/testlib/src/lib.rs
@@ -2,4 +2,5 @@
 
 pub use ethcontract_mock::utils::*;
 
+pub mod protocol;
 pub mod tokens;

--- a/crates/testlib/src/protocol.rs
+++ b/crates/testlib/src/protocol.rs
@@ -1,0 +1,18 @@
+//! Mainnet addresses of protocol contracts.
+
+use ethcontract::H160;
+
+/// Address for the settlement contract.
+pub const SETTLEMENT: H160 = H160(hex_literal::hex!(
+    "9008D19f58AAbD9eD0D60971565AA8510560ab41"
+));
+
+/// Address for the vault relayer contract.
+pub const RELAYER: H160 = H160(hex_literal::hex!(
+    "C92E8bdf79f0507f65a392b0ab4667716BFE0110"
+));
+
+/// Address for the settlement contract.
+pub const AUTHENTICATOR: H160 = H160(hex_literal::hex!(
+    "2c4c28DDBdAc9C5E7055b4C863b72eA0149D8aFE"
+));


### PR DESCRIPTION
In debugging failed trade simulations, I came [across an example](https://dashboard.tenderly.co/gp-v2/staging/simulator/d23e02b3-bd0e-44cd-9d53-e7ff43d20e3b/debugger?trace=0.9.10.0.0) of a failed simulation caused by having the proceeds of a trade interaction go to the trader instead of the settlement contract (which is what is expected for the usual settlement flow).

This is because some trade calldata encodes the receiver of the proceeds directly instead of assuming `msg.sender` (i.e. the address of the caller of the transaction).

This PR changes the `TradeFinder` price estimator to always query `TradeFinding` interfaces with the `from` address set to the settlement contract. Conceptually, this makes sense as we want to estimate the price of a trade as if it were being executed as part of a CoW Protocol settlement, and not as if the trader was executing it directly. This causes price estimates to more closely match what the equivalent DEX aggregator solvers are querying and should produce more accurate results.

### Test Plan

CI, adjusted unit tests to verify that the trade finder is getting the query with an adjusted `from` address.

Also, added a manual test that verifies that trade simulations work for large 1Inch trades using their `swap` interface which always encode the receiver and doesn't assume `msg.sender`:

```
% cargo test -p shared -- --ignored --nocapture trade_finder
    Finished test [unoptimized + debuginfo] target(s) in 0.19s
     Running unittests src/lib.rs (target/debug/deps/shared-04565d164529f1fa)

running 2 tests
100.0 WETH buys 163978.296523 DAI, costing 553646 gas
test price_estimation::trade_finder::tests::verified_oneinch_trade ... ok
1.0 WETH buys 18708.522999634923 COW, costing 351884 gas
test price_estimation::trade_finder::tests::verified_zeroex_trade ... ok

test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 382 filtered out; finished in 2.46s
```
