### PR TITLE
Read All CLI Flags From Environment

### DIFF
--- a/crates/autopilot/src/arguments.rs
+++ b/crates/autopilot/src/arguments.rs
@@ -43,7 +43,7 @@ pub struct Arguments {
     pub db_url: Url,
 
     /// Skip syncing past events (useful for local deployments)
-    #[clap(long)]
+    #[clap(long, env)]
     pub skip_event_sync: bool,
 
     /// List of token addresses that should be allowed regardless of whether the bad token detector

--- a/crates/driver/src/arguments.rs
+++ b/crates/driver/src/arguments.rs
@@ -152,6 +152,7 @@ pub struct Arguments {
     /// network before going to back to solving.
     #[clap(
         long,
+        env,
         default_value = "120",
         value_parser = shared::arguments::duration_from_seconds,
     )]
@@ -160,6 +161,7 @@ pub struct Arguments {
     /// Amount of time to wait before retrying to submit the tx to the ethereum network
     #[clap(
         long,
+        env,
         default_value = "2",
         value_parser = shared::arguments::duration_from_seconds,
     )]
@@ -243,6 +245,7 @@ pub struct Arguments {
     /// to be before updating
     #[clap(
         long,
+        env,
         default_value = "30",
         value_parser = duration_from_seconds,
     )]

--- a/crates/orderbook/src/arguments.rs
+++ b/crates/orderbook/src/arguments.rs
@@ -118,7 +118,7 @@ pub struct Arguments {
 
     /// If solvable orders haven't been successfully updated in this many blocks attempting
     /// to get them errors and our liveness check fails.
-    #[clap(long, default_value = "24")]
+    #[clap(long, env, default_value = "24")]
     pub solvable_orders_max_update_age_blocks: u64,
 
     /// Enable limit orders. Once the full limit order flow is implemented, this can be removed.

--- a/crates/shared/src/arguments.rs
+++ b/crates/shared/src/arguments.rs
@@ -255,6 +255,7 @@ pub struct Arguments {
     /// to be before updating
     #[clap(
         long,
+        env,
         default_value = "30",
         value_parser = duration_from_seconds,
     )]

--- a/crates/shared/src/bad_token/token_owner_finder.rs
+++ b/crates/shared/src/bad_token/token_owner_finder.rs
@@ -62,7 +62,7 @@ pub struct Arguments {
     pub token_owner_finder_uniswap_v3_fee_values: FeeValues,
 
     /// Override the Blockscout token owner finder-specific timeout configuration.
-    #[clap(long, value_parser = duration_from_seconds, default_value = "45")]
+    #[clap(long, env, value_parser = duration_from_seconds, default_value = "45")]
     pub blockscout_http_timeout: Duration,
 
     /// The Ethplorer token holder API key.

--- a/crates/shared/src/ethrpc.rs
+++ b/crates/shared/src/ethrpc.rs
@@ -25,17 +25,17 @@ pub type Web3CallBatch = CallBatch<Web3Transport>;
 #[group(skip)]
 pub struct Arguments {
     /// Maximum batch size for Ethereum RPC requests. Use '0' to disable batching.
-    #[clap(long, default_value = "100")]
+    #[clap(long, env, default_value = "100")]
     pub ethrpc_max_batch_size: usize,
 
     /// Maximum number of concurrent requests to send to the node. Use '0' for
     /// no limit on concurrency.
-    #[clap(long, default_value = "10")]
+    #[clap(long, env, default_value = "10")]
     pub ethrpc_max_concurrent_requests: usize,
 
     /// Buffering "nagle" delay to wait for additional requests before sending out
     /// an incomplete batch.
-    #[clap(long, value_parser = duration_from_seconds, default_value = "0")]
+    #[clap(long, env, value_parser = duration_from_seconds, default_value = "0")]
     pub ethrpc_batch_delay: Duration,
 }
 

--- a/crates/shared/src/http_client.rs
+++ b/crates/shared/src/http_client.rs
@@ -59,6 +59,7 @@ pub struct Arguments {
     /// Default timeout in seconds for http requests.
     #[clap(
         long,
+        env,
         default_value = "10",
         value_parser = duration_from_seconds,
     )]

--- a/crates/solver/src/arguments.rs
+++ b/crates/solver/src/arguments.rs
@@ -137,6 +137,7 @@ pub struct Arguments {
     /// Time interval after which market makable list needs to be updated
     #[clap(
         long,
+        env,
         default_value = "3600",
         value_parser = shared::arguments::duration_from_seconds,
     )]
@@ -199,6 +200,7 @@ pub struct Arguments {
     /// network before going to back to solving.
     #[clap(
         long,
+        env,
         default_value = "120",
         value_parser = shared::arguments::duration_from_seconds,
     )]
@@ -216,6 +218,7 @@ pub struct Arguments {
     /// Amount of time to wait before retrying to submit the tx to the ethereum network
     #[clap(
         long,
+        env,
         default_value = "2",
         value_parser = shared::arguments::duration_from_seconds,
     )]


### PR DESCRIPTION
This PR just adds missing `env` attributes on CLI flags.

### Test Plan

Just the compiler - no new logic, just new attributes on CLI flags.
