### PR TITLE
Configurable Maximum Limit Order Validity

### DIFF
--- a/crates/e2e/tests/e2e/services.rs
+++ b/crates/e2e/tests/e2e/services.rs
@@ -14,7 +14,7 @@ use shared::{
     fee_subsidy::Subsidy,
     maintenance::ServiceMaintenance,
     order_quoting::{OrderQuoter, QuoteHandler},
-    order_validation::{OrderValidator, OrderValidityConfiguration, SignatureConfiguration},
+    order_validation::{OrderValidPeriodConfiguration, OrderValidator, SignatureConfiguration},
     price_estimation::{
         baseline::BaselinePriceEstimator, native::NativePriceEstimator,
         sanitized::SanitizedPriceEstimator,

--- a/crates/e2e/tests/e2e/services.rs
+++ b/crates/e2e/tests/e2e/services.rs
@@ -264,7 +264,7 @@ impl OrderbookServices {
                 contracts.weth.clone(),
                 HashSet::default(),
                 HashSet::default(),
-                OrderValidityConfiguration::any(),
+                OrderValidPeriodConfiguration::any(),
                 SignatureConfiguration::all(),
                 bad_token_detector,
                 quoter.clone(),

--- a/crates/e2e/tests/e2e/services.rs
+++ b/crates/e2e/tests/e2e/services.rs
@@ -14,7 +14,7 @@ use shared::{
     fee_subsidy::Subsidy,
     maintenance::ServiceMaintenance,
     order_quoting::{OrderQuoter, QuoteHandler},
-    order_validation::{OrderValidator, SignatureConfiguration},
+    order_validation::{OrderValidator, OrderValidityConfiguration, SignatureConfiguration},
     price_estimation::{
         baseline::BaselinePriceEstimator, native::NativePriceEstimator,
         sanitized::SanitizedPriceEstimator,
@@ -264,8 +264,7 @@ impl OrderbookServices {
                 contracts.weth.clone(),
                 HashSet::default(),
                 HashSet::default(),
-                Duration::from_secs(120),
-                Duration::MAX,
+                OrderValidityConfiguration::any(),
                 SignatureConfiguration::all(),
                 bad_token_detector,
                 quoter.clone(),

--- a/crates/model/src/time.rs
+++ b/crates/model/src/time.rs
@@ -1,4 +1,7 @@
-use std::{convert::TryInto, time::SystemTime};
+use std::{
+    convert::TryInto,
+    time::{Duration, SystemTime},
+};
 
 /// The current time in the same unit as `valid_to` for orders in the smart contract.
 pub fn now_in_epoch_seconds() -> u32 {
@@ -8,4 +11,10 @@ pub fn now_in_epoch_seconds() -> u32 {
         .as_secs()
         .try_into()
         .expect("epoch seconds larger than max u32")
+}
+
+/// Adds a `std::time::Duration` to a `u32` timestamp. This function uses
+/// saturating semantics and can't panic.
+pub fn timestamp_after_duration(timestamp: u32, duration: Duration) -> u32 {
+    timestamp.saturating_add(duration.as_secs().try_into().unwrap_or(u32::MAX))
 }

--- a/crates/orderbook/src/api/post_order.rs
+++ b/crates/orderbook/src/api/post_order.rs
@@ -3,7 +3,7 @@ use anyhow::Result;
 use model::order::{OrderCreation, OrderUid};
 use shared::{
     api::{error, extract_payload, internal_error, ApiReply, IntoWarpReply},
-    order_validation::{OrderValidityError, PartialValidationError, ValidationError},
+    order_validation::{OrderValidToError, PartialValidationError, ValidationError},
 };
 use std::{convert::Infallible, sync::Arc};
 use warp::{hyper::StatusCode, reply::with_status, Filter, Rejection};
@@ -38,16 +38,14 @@ impl IntoWarpReply for PartialValidationErrorWrapper {
                 error("Forbidden", "Forbidden, your account is deny-listed"),
                 StatusCode::FORBIDDEN,
             ),
-            PartialValidationError::Validity(OrderValidityError::InsufficientValidTo) => {
-                with_status(
-                    error(
-                        "InsufficientValidTo",
-                        "validTo is not far enough in the future",
-                    ),
-                    StatusCode::BAD_REQUEST,
-                )
-            }
-            PartialValidationError::Validity(OrderValidityError::ExcessiveValidTo) => with_status(
+            PartialValidationError::ValidTo(OrderValidToError::Insufficient) => with_status(
+                error(
+                    "InsufficientValidTo",
+                    "validTo is not far enough in the future",
+                ),
+                StatusCode::BAD_REQUEST,
+            ),
+            PartialValidationError::ValidTo(OrderValidToError::Excessive) => with_status(
                 error("ExcessiveValidTo", "validTo is too far into the future"),
                 StatusCode::BAD_REQUEST,
             ),

--- a/crates/orderbook/src/api/post_order.rs
+++ b/crates/orderbook/src/api/post_order.rs
@@ -3,7 +3,7 @@ use anyhow::Result;
 use model::order::{OrderCreation, OrderUid};
 use shared::{
     api::{error, extract_payload, internal_error, ApiReply, IntoWarpReply},
-    order_validation::{PartialValidationError, ValidationError},
+    order_validation::{OrderValidityError, PartialValidationError, ValidationError},
 };
 use std::{convert::Infallible, sync::Arc};
 use warp::{hyper::StatusCode, reply::with_status, Filter, Rejection};
@@ -38,14 +38,16 @@ impl IntoWarpReply for PartialValidationErrorWrapper {
                 error("Forbidden", "Forbidden, your account is deny-listed"),
                 StatusCode::FORBIDDEN,
             ),
-            PartialValidationError::InsufficientValidTo => with_status(
-                error(
-                    "InsufficientValidTo",
-                    "validTo is not far enough in the future",
-                ),
-                StatusCode::BAD_REQUEST,
-            ),
-            PartialValidationError::ExcessiveValidTo => with_status(
+            PartialValidationError::Validity(OrderValidityError::InsufficientValidTo) => {
+                with_status(
+                    error(
+                        "InsufficientValidTo",
+                        "validTo is not far enough in the future",
+                    ),
+                    StatusCode::BAD_REQUEST,
+                )
+            }
+            PartialValidationError::Validity(OrderValidityError::ExcessiveValidTo) => with_status(
                 error("ExcessiveValidTo", "validTo is too far into the future"),
                 StatusCode::BAD_REQUEST,
             ),

--- a/crates/orderbook/src/arguments.rs
+++ b/crates/orderbook/src/arguments.rs
@@ -56,6 +56,15 @@ pub struct Arguments {
     )]
     pub max_order_validity_period: Duration,
 
+    /// The maximum amount of time in seconds a limit order can be valid for. Defaults to 1 year.
+    #[clap(
+        long,
+        env,
+        default_value = "31536000",
+        value_parser = shared::arguments::duration_from_seconds,
+    )]
+    pub max_limit_order_validity_period: Duration,
+
     /// The amount of time in seconds a classification of a token into good or bad is valid for.
     #[clap(
         long,
@@ -149,6 +158,11 @@ impl std::fmt::Display for Arguments {
             f,
             "max_order_validity_period: {:?}",
             self.max_order_validity_period
+        )?;
+        writeln!(
+            f,
+            "max_limit_order_validity_period: {:?}",
+            self.max_limit_order_validity_period
         )?;
         writeln!(
             f,

--- a/crates/orderbook/src/main.rs
+++ b/crates/orderbook/src/main.rs
@@ -29,7 +29,7 @@ use shared::{
     network::network_name,
     oneinch_api::OneInchClientImpl,
     order_quoting::{OrderQuoter, QuoteHandler},
-    order_validation::{OrderValidator, OrderValidityConfiguration, SignatureConfiguration},
+    order_validation::{OrderValidPeriodConfiguration, OrderValidator, SignatureConfiguration},
     price_estimation::{
         factory::{self, PriceEstimatorFactory},
         PriceEstimating,
@@ -369,7 +369,7 @@ async fn main() {
         None => fee_subsidy_config,
     };
 
-    let validity_configuration = OrderValidityConfiguration {
+    let validity_configuration = OrderValidPeriodConfiguration {
         min: args.min_order_validity_period,
         max_market: args.max_order_validity_period,
         max_limit: args.max_limit_order_validity_period,

--- a/crates/orderbook/src/main.rs
+++ b/crates/orderbook/src/main.rs
@@ -29,7 +29,7 @@ use shared::{
     network::network_name,
     oneinch_api::OneInchClientImpl,
     order_quoting::{OrderQuoter, QuoteHandler},
-    order_validation::{OrderValidator, SignatureConfiguration},
+    order_validation::{OrderValidator, OrderValidityConfiguration, SignatureConfiguration},
     price_estimation::{
         factory::{self, PriceEstimatorFactory},
         PriceEstimating,
@@ -369,6 +369,11 @@ async fn main() {
         None => fee_subsidy_config,
     };
 
+    let validity_configuration = OrderValidityConfiguration {
+        min: args.min_order_validity_period,
+        max_market: args.max_order_validity_period,
+        max_limit: args.max_limit_order_validity_period,
+    };
     let signature_configuration = SignatureConfiguration {
         eip1271: args.enable_eip1271_orders,
         eip1271_skip_creation_validation: args.eip1271_skip_creation_validation,
@@ -401,8 +406,7 @@ async fn main() {
                 .iter()
                 .copied()
                 .collect(),
-            args.min_order_validity_period,
-            args.max_order_validity_period,
+            validity_configuration,
             signature_configuration,
             bad_token_detector.clone(),
             optimal_quoter.clone(),

--- a/crates/shared/src/order_quoting.rs
+++ b/crates/shared/src/order_quoting.rs
@@ -638,7 +638,7 @@ impl From<&OrderQuoteRequest> for PreOrderData {
             buy_token_balance: quote_request.buy_token_balance,
             sell_token_balance: quote_request.sell_token_balance,
             signing_scheme: quote_request.signing_scheme.into(),
-            class: OrderClass::Ordinary,
+            class: OrderClass::Market,
         }
     }
 }

--- a/crates/shared/src/order_quoting.rs
+++ b/crates/shared/src/order_quoting.rs
@@ -16,7 +16,7 @@ use futures::TryFutureExt as _;
 use gas_estimation::GasPriceEstimating;
 use model::{
     app_id::AppId,
-    order::OrderKind,
+    order::{OrderClass, OrderKind},
     quote::{
         OrderQuote, OrderQuoteRequest, OrderQuoteResponse, OrderQuoteSide, PriceQuality, QuoteId,
         QuoteSigningScheme, SellAmount,
@@ -638,7 +638,7 @@ impl From<&OrderQuoteRequest> for PreOrderData {
             buy_token_balance: quote_request.buy_token_balance,
             sell_token_balance: quote_request.sell_token_balance,
             signing_scheme: quote_request.signing_scheme.into(),
-            is_liquidity_order: quote_request.partially_fillable,
+            class: OrderClass::Ordinary,
         }
     }
 }

--- a/crates/shared/src/order_validation.rs
+++ b/crates/shared/src/order_validation.rs
@@ -21,7 +21,7 @@ use model::{
     },
     quote::{OrderQuoteSide, QuoteSigningScheme, SellAmount},
     signature::{hashed_eip712_message, Signature, SigningScheme, VerificationError},
-    DomainSeparator,
+    time, DomainSeparator,
 };
 use std::{collections::HashSet, sync::Arc, time::Duration};
 
@@ -541,12 +541,12 @@ pub struct OrderValidityConfiguration {
 impl OrderValidityConfiguration {
     /// Validates an order's timestamp based on additional data.
     fn validate_period(&self, order: &PreOrderData) -> Result<(), OrderValidityError> {
-        let now = model::time::now_in_epoch_seconds();
-        if order.valid_to < timestamp_after_duration(now, self.min) {
+        let now = time::now_in_epoch_seconds();
+        if order.valid_to < time::timestamp_after_duration(now, self.min) {
             return Err(OrderValidityError::InsufficientValidTo);
         }
         if let Some(max) = self.max(order) {
-            if order.valid_to > timestamp_after_duration(now, max) {
+            if order.valid_to > time::timestamp_after_duration(now, max) {
                 return Err(OrderValidityError::ExcessiveValidTo);
             }
         }
@@ -569,12 +569,6 @@ impl OrderValidityConfiguration {
             OrderClass::Liquidity => None,
         }
     }
-}
-
-/// Adds a `std::time::Duration` to a `u32` timestamp. This function uses
-/// saturating semantics and can't panic.
-fn timestamp_after_duration(timestamp: u32, duration: Duration) -> u32 {
-    timestamp.saturating_add(duration.as_secs().try_into().unwrap_or(u32::MAX))
 }
 
 #[derive(Debug)]
@@ -830,7 +824,7 @@ mod tests {
         };
         let banned_users = hashset![H160::from_low_u64_be(1)];
         let legit_valid_to =
-            model::time::now_in_epoch_seconds() + validity_configuration.min.as_secs() as u32 + 2;
+            time::now_in_epoch_seconds() + validity_configuration.min.as_secs() as u32 + 2;
         code_fetcher
             .expect_code_size()
             .times(1)
@@ -1055,7 +1049,7 @@ mod tests {
             0,
         );
         let order = || PreOrderData {
-            valid_to: model::time::now_in_epoch_seconds()
+            valid_to: time::now_in_epoch_seconds()
                 + validity_configuration.min.as_secs() as u32
                 + 2,
             sell_token: H160::from_low_u64_be(1),
@@ -1076,7 +1070,7 @@ mod tests {
             .partial_validate(PreOrderData {
                 class: OrderClass::Limit,
                 owner: liquidity_order_owner,
-                valid_to: model::time::now_in_epoch_seconds()
+                valid_to: time::now_in_epoch_seconds()
                     + validity_configuration.max_market.as_secs() as u32
                     + 2,
                 ..order()
@@ -1140,7 +1134,7 @@ mod tests {
 
         let creation = OrderCreation {
             data: OrderData {
-                valid_to: model::time::now_in_epoch_seconds() + 2,
+                valid_to: time::now_in_epoch_seconds() + 2,
                 sell_token: H160::from_low_u64_be(1),
                 buy_token: H160::from_low_u64_be(2),
                 buy_amount: U256::from(1),
@@ -1320,7 +1314,7 @@ mod tests {
         );
         let order = OrderCreation {
             data: OrderData {
-                valid_to: model::time::now_in_epoch_seconds() + 2,
+                valid_to: time::now_in_epoch_seconds() + 2,
                 sell_token: H160::from_low_u64_be(1),
                 buy_token: H160::from_low_u64_be(2),
                 buy_amount: U256::from(0),
@@ -1371,7 +1365,7 @@ mod tests {
         );
         let order = OrderCreation {
             data: OrderData {
-                valid_to: model::time::now_in_epoch_seconds() + 2,
+                valid_to: time::now_in_epoch_seconds() + 2,
                 sell_token: H160::from_low_u64_be(1),
                 buy_token: H160::from_low_u64_be(2),
                 buy_amount: U256::from(1),
@@ -1425,7 +1419,7 @@ mod tests {
         );
         let order = OrderCreation {
             data: OrderData {
-                valid_to: model::time::now_in_epoch_seconds() + 2,
+                valid_to: time::now_in_epoch_seconds() + 2,
                 sell_token: H160::from_low_u64_be(1),
                 buy_token: H160::from_low_u64_be(2),
                 buy_amount: U256::from(1),
@@ -1477,7 +1471,7 @@ mod tests {
         );
         let order = OrderCreation {
             data: OrderData {
-                valid_to: model::time::now_in_epoch_seconds() + 2,
+                valid_to: time::now_in_epoch_seconds() + 2,
                 sell_token: H160::from_low_u64_be(1),
                 buy_token: H160::from_low_u64_be(2),
                 buy_amount: U256::from(1),
@@ -1532,7 +1526,7 @@ mod tests {
         );
         let order = OrderCreation {
             data: OrderData {
-                valid_to: model::time::now_in_epoch_seconds() + 2,
+                valid_to: time::now_in_epoch_seconds() + 2,
                 sell_token: H160::from_low_u64_be(1),
                 buy_token: H160::from_low_u64_be(2),
                 buy_amount: U256::from(1),
@@ -1590,7 +1584,7 @@ mod tests {
         );
         let order = OrderCreation {
             data: OrderData {
-                valid_to: model::time::now_in_epoch_seconds() + 2,
+                valid_to: time::now_in_epoch_seconds() + 2,
                 sell_token: H160::from_low_u64_be(1),
                 buy_token: H160::from_low_u64_be(2),
                 buy_amount: U256::from(1),
@@ -1643,7 +1637,7 @@ mod tests {
         );
         let order = OrderCreation {
             data: OrderData {
-                valid_to: model::time::now_in_epoch_seconds() + 2,
+                valid_to: time::now_in_epoch_seconds() + 2,
                 sell_token: H160::from_low_u64_be(1),
                 buy_token: H160::from_low_u64_be(2),
                 buy_amount: U256::from(1),
@@ -1701,7 +1695,7 @@ mod tests {
 
         let creation = OrderCreation {
             data: OrderData {
-                valid_to: model::time::now_in_epoch_seconds() + 2,
+                valid_to: time::now_in_epoch_seconds() + 2,
                 sell_token: H160::from_low_u64_be(1),
                 buy_token: H160::from_low_u64_be(2),
                 buy_amount: U256::from(1),

--- a/crates/shared/src/order_validation.rs
+++ b/crates/shared/src/order_validation.rs
@@ -230,7 +230,7 @@ impl PreOrderData {
             sell_token_balance: order.sell_token_balance,
             signing_scheme,
             class: match (liquidity_owner, order.fee_amount.is_zero()) {
-                (false, false) => OrderClass::Ordinary,
+                (false, false) => OrderClass::Market,
                 (false, true) => OrderClass::Limit,
                 (true, _) => OrderClass::Liquidity,
             },
@@ -539,6 +539,15 @@ pub struct OrderValidPeriodConfiguration {
 }
 
 impl OrderValidPeriodConfiguration {
+    /// Creates an configuration where any `validTo` is accepted.
+    pub fn any() -> Self {
+        Self {
+            min: Duration::ZERO,
+            max_market: Duration::MAX,
+            max_limit: Duration::MAX,
+        }
+    }
+
     /// Validates an order's timestamp based on additional data.
     fn validate_period(&self, order: &PreOrderData) -> Result<(), OrderValidToError> {
         let now = time::now_in_epoch_seconds();
@@ -562,7 +571,7 @@ impl OrderValidPeriodConfiguration {
         }
 
         match order.class {
-            OrderClass::Ordinary => self.max_market,
+            OrderClass::Market => self.max_market,
             OrderClass::Limit => self.max_limit,
             OrderClass::Liquidity => Duration::MAX,
         }
@@ -1247,8 +1256,7 @@ mod tests {
             dummy_contract!(WETH9, [0xef; 20]),
             hashset!(),
             hashset!(),
-            Duration::from_secs(1),
-            Duration::from_secs(100),
+            OrderValidPeriodConfiguration::any(),
             SignatureConfiguration::all(),
             Arc::new(bad_token_detector),
             Arc::new(order_quoter),
@@ -1297,11 +1305,7 @@ mod tests {
             dummy_contract!(WETH9, [0xef; 20]),
             hashset!(),
             hashset!(),
-            OrderValidPeriodConfiguration {
-                min: Duration::from_secs(1),
-                max_market: Duration::from_secs(100),
-                max_limit: Duration::from_secs(200),
-            },
+            OrderValidPeriodConfiguration::any(),
             SignatureConfiguration::all(),
             Arc::new(bad_token_detector),
             Arc::new(order_quoter),
@@ -1348,11 +1352,7 @@ mod tests {
             dummy_contract!(WETH9, [0xef; 20]),
             hashset!(),
             hashset!(),
-            OrderValidPeriodConfiguration {
-                min: Duration::from_secs(1),
-                max_market: Duration::from_secs(100),
-                max_limit: Duration::from_secs(200),
-            },
+            OrderValidPeriodConfiguration::any(),
             SignatureConfiguration::all(),
             Arc::new(bad_token_detector),
             Arc::new(order_quoter),
@@ -1402,11 +1402,7 @@ mod tests {
             dummy_contract!(WETH9, [0xef; 20]),
             hashset!(),
             hashset!(),
-            OrderValidPeriodConfiguration {
-                min: Duration::from_secs(1),
-                max_market: Duration::from_secs(100),
-                max_limit: Duration::from_secs(200),
-            },
+            OrderValidPeriodConfiguration::any(),
             SignatureConfiguration::all(),
             Arc::new(bad_token_detector),
             Arc::new(order_quoter),
@@ -1454,11 +1450,7 @@ mod tests {
             dummy_contract!(WETH9, [0xef; 20]),
             hashset!(),
             hashset!(),
-            OrderValidPeriodConfiguration {
-                min: Duration::from_secs(1),
-                max_market: Duration::from_secs(100),
-                max_limit: Duration::from_secs(200),
-            },
+            OrderValidPeriodConfiguration::any(),
             SignatureConfiguration::all(),
             Arc::new(bad_token_detector),
             Arc::new(order_quoter),
@@ -1509,11 +1501,7 @@ mod tests {
             dummy_contract!(WETH9, [0xef; 20]),
             hashset!(),
             hashset!(),
-            OrderValidPeriodConfiguration {
-                min: Duration::from_secs(1),
-                max_market: Duration::from_secs(100),
-                max_limit: Duration::from_secs(200),
-            },
+            OrderValidPeriodConfiguration::any(),
             SignatureConfiguration::all(),
             Arc::new(bad_token_detector),
             Arc::new(order_quoter),
@@ -1567,11 +1555,7 @@ mod tests {
             dummy_contract!(WETH9, [0xef; 20]),
             hashset!(),
             hashset!(),
-            OrderValidPeriodConfiguration {
-                min: Duration::from_secs(1),
-                max_market: Duration::from_secs(100),
-                max_limit: Duration::from_secs(200),
-            },
+            OrderValidPeriodConfiguration::any(),
             SignatureConfiguration::all(),
             Arc::new(bad_token_detector),
             Arc::new(order_quoter),
@@ -1620,11 +1604,7 @@ mod tests {
             dummy_contract!(WETH9, [0xef; 20]),
             hashset!(),
             hashset!(),
-            OrderValidPeriodConfiguration {
-                min: Duration::from_secs(1),
-                max_market: Duration::from_secs(100),
-                max_limit: Duration::from_secs(200),
-            },
+            OrderValidPeriodConfiguration::any(),
             SignatureConfiguration::all(),
             Arc::new(bad_token_detector),
             Arc::new(order_quoter),
@@ -1677,11 +1657,7 @@ mod tests {
             dummy_contract!(WETH9, [0xef; 20]),
             hashset!(),
             hashset!(),
-            OrderValidPeriodConfiguration {
-                min: Duration::from_secs(1),
-                max_market: Duration::from_secs(100),
-                max_limit: Duration::from_secs(200),
-            },
+            OrderValidPeriodConfiguration::any(),
             SignatureConfiguration::all(),
             Arc::new(bad_token_detector),
             Arc::new(order_quoter),
@@ -1737,11 +1713,7 @@ mod tests {
                     dummy_contract!(WETH9, [0xef; 20]),
                     hashset!(),
                     hashset!(),
-                    OrderValidPeriodConfiguration {
-                        min: Duration::from_secs(1),
-                        max_market: Duration::MAX,
-                        max_limit: Duration::MAX,
-                    },
+                    OrderValidPeriodConfiguration::any(),
                     SignatureConfiguration::all(),
                     Arc::new(bad_token_detector),
                     Arc::new(order_quoter),


### PR DESCRIPTION
Fixes #728 

This PR adds a new configuration option for specifying the maximum order validity for limit orders. This allows separate values to be set for market and limit orders.

Additionally, it was done in a way that opens the door to add other validity limits (for example, we should probably add one for `pre-sign` orders as well).

### Test Plan

Existing order validation tests continue to pass. Also extended the existing unit test to cover the new code paths.

### Release notes

We can now specify `MAX_LIMIT_ORDER_VALIDITY_PERIOD`. The default of 1 year is what was suggested on Slack.
