### PR TITLE
Allow Cancelling Multiple Orders At Once

### DIFF
--- a/crates/model/src/order.rs
+++ b/crates/model/src/order.rs
@@ -355,8 +355,53 @@ impl From<Order> for OrderCreation {
     }
 }
 
+/// Cancellation of multiple orders.
+#[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
+pub struct OrderCancellations {
+    pub order_uids: Vec<OrderUid>,
+}
+
+impl OrderCancellations {
+    /// The EIP-712 type hash for order cancellations. Computed with:
+    /// `keccak256("OrderCancellations(bytes[] orderUid)")`.
+    const TYPE_HASH: [u8; 32] =
+        hex!("4c89efb91ae246f78d2fe68b47db2fa1444a121a4f2dc3fda7a5a408c2e3588e");
+
+    pub fn hash_struct(&self) -> [u8; 32] {
+        let mut encoded_uids = Vec::with_capacity(32 * self.order_uids.len());
+        for order_uid in &self.order_uids {
+            encoded_uids.extend_from_slice(&signing::keccak256(&order_uid.0));
+        }
+
+        let array_hash = signing::keccak256(&encoded_uids);
+
+        let mut hash_data = [0u8; 64];
+        hash_data[0..32].copy_from_slice(&Self::TYPE_HASH);
+        hash_data[32..64].copy_from_slice(&array_hash);
+        signing::keccak256(&hash_data)
+    }
+}
+
+/// Signed order cancellations.
+#[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
+pub struct SignedOrderCancellations {
+    #[serde(flatten)]
+    pub data: OrderCancellations,
+    pub signature: EcdsaSignature,
+    pub signing_scheme: EcdsaSigningScheme,
+}
+
+impl SignedOrderCancellations {
+    pub fn validate(&self, domain_separator: &DomainSeparator) -> Result<H160> {
+        self.signature.recover(
+            self.signing_scheme,
+            domain_separator,
+            &self.data.hash_struct(),
+        )
+    }
+}
+
 /// An order cancellation as provided to the orderbook by the frontend.
-#[serde_as]
 #[derive(Eq, PartialEq, Clone, Copy, Debug)]
 pub struct OrderCancellation {
     pub order_uid: OrderUid,
@@ -1022,5 +1067,23 @@ mod tests {
     #[test]
     fn debug_order_data() {
         dbg!(Order::default());
+    }
+
+    #[test]
+    fn order_cancellations_struct_hash() {
+        // Generated with Ethers.js as a reference EIP-712 hashing impl.
+        for (order_uids, struct_hash) in [
+            (
+                vec![],
+                hex!("56acdb3034898c6c23971cb3f92c32a4739e89a13c85282547025583a93911bd"),
+            ),
+            (
+                vec![OrderUid([0x11; 56]), OrderUid([0x22; 56])],
+                hex!("405f6cb53d87901a5385a824a99c94b43146547f5ea3623f8d2f50b925e97a8b"),
+            ),
+        ] {
+            let cancellations = OrderCancellations { order_uids };
+            assert_eq!(cancellations.hash_struct(), struct_hash);
+        }
     }
 }

--- a/crates/orderbook/openapi.yml
+++ b/crates/orderbook/openapi.yml
@@ -51,32 +51,6 @@ paths:
           application/json:
             schema:
               $ref: "#/components/schemas/OrderCreation"
-    delete:
-      summary: Cancels multiple orders by marking it invalid with a timestamp.
-      description: |
-        The successful deletion might not prevent solvers from settling the orders
-        Authentication must be provided by providing an EIP-712 signature of an
-        "OrderCacellations(bytes[] orderUids)" message.
-      requestBody:
-        description: "Signed OrderCancellations"
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/OrderCancellations"
-      responses:
-        200:
-          description: Orders deleted
-        400:
-          description: Malformed signature
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/OrderCancellationError"
-        401:
-          description: Invalid signature
-        404:
-          description: One or more orders were not found and no orders were cancelled.
   /api/v1/orders/{UID}:
     get:
       summary: Get existing order from UID.
@@ -99,8 +73,7 @@ paths:
       summary: Cancels order by marking it invalid with a timestamp.
       description: |
         The successful deletion might not prevent solvers from settling the order
-        Authentication must be provided by providing an EIP-712 signature of an
-        "OrderCacellation(bytes orderUids)" message.
+        Authentication must be provided by signing the following message:
       parameters:
         - in: path
           name: UID
@@ -854,27 +827,9 @@ components:
             addresses to a price denominated in native token (i.e. 1e18 represents a token that
             trades one to one with the native token). These prices are used for solution competition
             for computing surplus and converting fees to native token.
-    OrderCancellations:
-      description: |
-        EIP-712 signature of struct OrderCancellations { orderUid: bytes[] } from the order's owner
-      type: object
-      properties:
-        orderUids:
-          type: array
-          description: "UIDs of orders to cancel"
-          items:
-            $ref: "#/components/schemas/UID"
-        signature:
-          description: "OrderCancellation signed by owner"
-          $ref: "#/components/schemas/EcdsaSignature"
-        signingScheme:
-          $ref: "#/components/schemas/EcdsaSigningScheme"
-      required:
-        - signature
-        - signingScheme
     OrderCancellation:
       description: |
-        EIP-712 signature of struct OrderCancellation { orderUid: bytes } from the order's owner
+        EIP712 signature of struct OrderCancellation { orderUid: bytes } from the order's owner
       type: object
       properties:
         signature:

--- a/crates/orderbook/openapi.yml
+++ b/crates/orderbook/openapi.yml
@@ -51,6 +51,32 @@ paths:
           application/json:
             schema:
               $ref: "#/components/schemas/OrderCreation"
+    delete:
+      summary: Cancels multiple orders by marking it invalid with a timestamp.
+      description: |
+        The successful deletion might not prevent solvers from settling the orders
+        Authentication must be provided by providing an EIP-712 signature of an
+        "OrderCacellations(bytes[] orderUids)" message.
+      requestBody:
+        description: "Signed OrderCancellations"
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/OrderCancellations"
+      responses:
+        200:
+          description: Orders deleted
+        400:
+          description: Malformed signature
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OrderCancellationError"
+        401:
+          description: Invalid signature
+        404:
+          description: One or more orders were not found and no orders were cancelled.
   /api/v1/orders/{UID}:
     get:
       summary: Get existing order from UID.
@@ -73,7 +99,8 @@ paths:
       summary: Cancels order by marking it invalid with a timestamp.
       description: |
         The successful deletion might not prevent solvers from settling the order
-        Authentication must be provided by signing the following message:
+        Authentication must be provided by providing an EIP-712 signature of an
+        "OrderCacellation(bytes orderUids)" message.
       parameters:
         - in: path
           name: UID
@@ -827,9 +854,27 @@ components:
             addresses to a price denominated in native token (i.e. 1e18 represents a token that
             trades one to one with the native token). These prices are used for solution competition
             for computing surplus and converting fees to native token.
+    OrderCancellations:
+      description: |
+        EIP-712 signature of struct OrderCancellations { orderUid: bytes[] } from the order's owner
+      type: object
+      properties:
+        orderUids:
+          type: array
+          description: "UIDs of orders to cancel"
+          items:
+            $ref: "#/components/schemas/UID"
+        signature:
+          description: "OrderCancellation signed by owner"
+          $ref: "#/components/schemas/EcdsaSignature"
+        signingScheme:
+          $ref: "#/components/schemas/EcdsaSigningScheme"
+      required:
+        - signature
+        - signingScheme
     OrderCancellation:
       description: |
-        EIP712 signature of struct OrderCancellation { orderUid: bytes } from the order's owner
+        EIP-712 signature of struct OrderCancellation { orderUid: bytes } from the order's owner
       type: object
       properties:
         signature:


### PR DESCRIPTION
This PR adds multiple order cancellation to the orderbook.

The context for this change is that the CoW Swap limit order front end wants to add support for cancelling multiple orders at once.

With the current API (`DELETE /api/v1/orders/${orderUid}`), this has to be done where, for each order, a wallet signature is requested. This means that if you were to cancel 10 orders, you would need to sign 10 MetaMask popups at once. In order to work around this, we introduce a new `OrderCancellations` message that can be signed to indicate intent to cancel multiple orders at once. In the same example as above, the user would only need to sign a single MetaMask popup (including the order UIDs of all 10 orders).

The actual API documentation and end point will be added in a follow up PR, this just contains the implementation in the inner `Orderbook` component.

### Test Plan

CI, added a couple unit tests to smoke test the logic. Want to include an E2E test when the API endpoint gets introduced in the follow-up PR.
