### PR TITLE
Add temporary logs for Quasimodo encoding issue

### DIFF
--- a/crates/solver/src/liquidity/uniswap_v3.rs
+++ b/crates/solver/src/liquidity/uniswap_v3.rs
@@ -173,10 +173,15 @@ impl SettlementHandling<ConcentratedLiquidity> for UniswapV3SettlementHandler {
     // Creates the required interaction to convert the given input into output. Assumes slippage is
     // already applied to the `input_max` field.
     fn encode(&self, execution: AmmOrderExecution, encoder: &mut SettlementEncoder) -> Result<()> {
+        tracing::debug!("entered encoding UniswapV3SettlementHandler");
         let (approval, swap) = self.settle(
             execution.input_max,
             execution.output,
             self.fee.context("missing fee")?,
+        );
+        tracing::debug!(
+            "adding interactions, internalizable: {}",
+            execution.internalizable
         );
         encoder.append_to_execution_plan_internalizable(approval, execution.internalizable);
         encoder.append_to_execution_plan_internalizable(swap, execution.internalizable);

--- a/crates/solver/src/settlement/settlement_encoder.rs
+++ b/crates/solver/src/settlement/settlement_encoder.rs
@@ -441,6 +441,7 @@ impl SettlementEncoder {
             .map(|trade| trade.encode(uniform_clearing_price_vec_length))
             .collect();
         trades.append(&mut liquidity_order_trades);
+        tracing::debug!("execution plan: {:?}", self.execution_plan);
         EncodedSettlement {
             tokens,
             clearing_prices,
@@ -457,13 +458,18 @@ impl SettlementEncoder {
                     .chain(
                         self.execution_plan
                             .iter()
-                            .filter_map(|(interaction, internalizable)| {
+                            .enumerate()
+                            .filter_map(|(index, (interaction, internalizable))| {
                                 if *internalizable
                                     && matches!(
                                         internalization_strategy,
                                         InternalizationStrategy::SkipInternalizableInteraction
                                     )
                                 {
+                                    tracing::debug!(
+                                        "skipped internalizable interaction with index {}",
+                                        index
+                                    );
                                     None
                                 } else {
                                     Some(interaction)

--- a/crates/solver/src/settlement_ranker.rs
+++ b/crates/solver/src/settlement_ranker.rs
@@ -141,10 +141,20 @@ impl SettlementRanker {
         // statement allows us to figure out which settlements were filtered out and which ones are
         // going to be simulated and considered for competition.
         for (solver, settlement) in &solver_settlements {
+            let encoded_settlement = settlement
+                .encoder
+                .clone()
+                .finish(InternalizationStrategy::EncodeAllInteractions);
             tracing::debug!(
-                solver_name = %solver.name(), ?settlement, uninternalized_calldata = hex::encode(call_data(settlement.encoder.clone().finish(InternalizationStrategy::EncodeAllInteractions))),
+                solver_name = %solver.name(), ?settlement, uninternalized_calldata = hex::encode(call_data(encoded_settlement.clone())),
                 "considering solution for solver competition",
             );
+            if encoded_settlement.interactions[1].is_empty() {
+                tracing::warn!(
+                    "no interactions for valid settlement: {:?}",
+                    encoded_settlement
+                );
+            }
         }
 
         let (mut rated_settlements, errors) = self

--- a/crates/solver/src/solver/http_solver.rs
+++ b/crates/solver/src/solver/http_solver.rs
@@ -497,6 +497,7 @@ impl Solver for HttpSolver {
             self.solver.name,
             serde_json::to_string_pretty(&settled).unwrap()
         );
+        tracing::debug!("Solver context {}, context {:?}", self.solver.name, context);
 
         if settled.orders.is_empty() {
             return Ok(vec![]);


### PR DESCRIPTION
Add temporary logs to better inspect encoding flow for Quasimodo solutions.

More context [here](https://cowservices.slack.com/archives/C0375NV72SC/p1667386363586569)

### Release notes

This PR should not be part of the next week release, meaning revert PR is expected to be merged until the end of week.
