### PR TITLE
Do not add full http request body to error

### DIFF
--- a/crates/shared/src/http_solver.rs
+++ b/crates/shared/src/http_solver.rs
@@ -162,12 +162,7 @@ impl HttpSolverApi for DefaultHttpSolverApi {
                 .context("response body")?;
         let text = std::str::from_utf8(&response_body).context("failed to decode response body")?;
         tracing::trace!(body = %text, "response");
-        let context = || {
-            format!(
-                "request query {}, request body {}, response body {}",
-                query, body, text
-            )
-        };
+        let context = || format!("request query {}, response body {}", query, text);
         ensure!(
             status.is_success(),
             "solver response is not success: status {}, {}",


### PR DESCRIPTION
The body can be huge. It does not make sense to keep it in the error and log it later. There is still a trace log than can be enabled to see the body.

### Test Plan

not directly tested, should see we no longer log huge price estimation errors that don't look right in slack/kibana

