### PR TITLE
Get_user_order performance next trial

### DIFF
--- a/crates/database/src/orders.rs
+++ b/crates/database/src/orders.rs
@@ -500,7 +500,7 @@ pub fn user_orders<'a>(
 " WHERE o.owner = $1",
 " ORDER BY creation_timestamp DESC LIMIT $2 * ($3 + 1) ) ",
 " UNION ",
-" (SElECT ", ORDERS_SELECT,
+" (SELECT ", ORDERS_SELECT,
 " FROM ", ORDERS_FROM,
 " LEFT OUTER JOIN onchain_placed_orders onchain_o on onchain_o.uid = o.uid",
 " WHERE onchain_o.sender = $1 ",

--- a/crates/database/src/orders.rs
+++ b/crates/database/src/orders.rs
@@ -494,10 +494,16 @@ pub fn user_orders<'a>(
     // queries are taking too long in practice.
     #[rustfmt::skip]
     const QUERY: &str = const_format::concatcp!(
-" SELECT ", ORDERS_SELECT,
+"(SELECT ", ORDERS_SELECT,
 " FROM ", ORDERS_FROM,
 " LEFT OUTER JOIN onchain_placed_orders onchain_o on onchain_o.uid = o.uid",
-" WHERE o.owner = $1 OR onchain_o.sender = $1 ",
+" WHERE o.owner = $1",
+" ORDER BY creation_timestamp DESC LIMIT $2 * ($3 + 1) ) ",
+" UNION ",
+" (SElECT ", ORDERS_SELECT,
+" FROM ", ORDERS_FROM,
+" LEFT OUTER JOIN onchain_placed_orders onchain_o on onchain_o.uid = o.uid",
+" WHERE onchain_o.sender = $1) ",
 " ORDER BY creation_timestamp DESC ",
 " LIMIT $2 ",
 " OFFSET $3 ",

--- a/crates/database/src/orders.rs
+++ b/crates/database/src/orders.rs
@@ -1167,11 +1167,11 @@ mod tests {
         let mut db = db.begin().await.unwrap();
         crate::clear_DANGER_(&mut db).await.unwrap();
 
-        for i in 0..1000u32 {
+        for i in 0..1u32 {
             let mut owner_bytes = i.to_ne_bytes().to_vec();
             owner_bytes.append(&mut vec![0; 20 - owner_bytes.len()]);
             let owner = ByteArray(owner_bytes.try_into().unwrap());
-            for j in 0..300u32 {
+            for j in 0..10u32 {
                 let mut i_as_bytes = i.to_ne_bytes().to_vec();
                 let mut j_as_bytes = j.to_ne_bytes().to_vec();
                 let mut order_uid_info = vec![0; 56 - i_as_bytes.len() - j_as_bytes.len()];

--- a/crates/database/src/orders.rs
+++ b/crates/database/src/orders.rs
@@ -503,7 +503,8 @@ pub fn user_orders<'a>(
 " (SElECT ", ORDERS_SELECT,
 " FROM ", ORDERS_FROM,
 " LEFT OUTER JOIN onchain_placed_orders onchain_o on onchain_o.uid = o.uid",
-" WHERE onchain_o.sender = $1) ",
+" WHERE onchain_o.sender = $1 ",
+" ORDER BY creation_timestamp DESC LIMIT $2 * ($3 + 1) ) ",
 " ORDER BY creation_timestamp DESC ",
 " LIMIT $2 ",
 " OFFSET $3 ",
@@ -1166,11 +1167,11 @@ mod tests {
         let mut db = db.begin().await.unwrap();
         crate::clear_DANGER_(&mut db).await.unwrap();
 
-        for i in 0..1u32 {
+        for i in 0..1000u32 {
             let mut owner_bytes = i.to_ne_bytes().to_vec();
             owner_bytes.append(&mut vec![0; 20 - owner_bytes.len()]);
             let owner = ByteArray(owner_bytes.try_into().unwrap());
-            for j in 0..10u32 {
+            for j in 0..300u32 {
                 let mut i_as_bytes = i.to_ne_bytes().to_vec();
                 let mut j_as_bytes = j.to_ne_bytes().to_vec();
                 let mut order_uid_info = vec![0; 56 - i_as_bytes.len() - j_as_bytes.len()];

--- a/database/sql/V041__create_index_on_orders_with_owner_and_timestamp.sql
+++ b/database/sql/V041__create_index_on_orders_with_owner_and_timestamp.sql
@@ -1,0 +1,3 @@
+-- The index can be traversed in both directions anyway but we usually fetch user orders with this
+-- ordering so using it here too.
+CREATE INDEX user_order_creation_timestamp ON orders USING BTREE (owner, creation_timestamp DESC);

--- a/database/sql/V041__create_index_on_orders_with_owner_and_timestamp.sql
+++ b/database/sql/V041__create_index_on_orders_with_owner_and_timestamp.sql
@@ -1,3 +1,4 @@
--- The index can be traversed in both directions anyway but we usually fetch user orders with this
--- ordering so using it here too.
+-- To optimize the performance of the user_orders query, we introduce a new index that allows
+-- us to quickly get the latest orders from a owner
 CREATE INDEX user_order_creation_timestamp ON orders USING BTREE (owner, creation_timestamp DESC);
+


### PR DESCRIPTION
When we deployed this PR: https://github.com/cowprotocol/services/pull/701 to production, it caused severe performance decreases. This PR reverts the PR + improves the performance with another trick.

 It re-creates the old index that was deleted [here](https://github.com/cowprotocol/services/pull/610/files#diff-2794b4d292d74cb53a35285b59b1c05669ee45a9298edfe40098c720eb8f8433R2) and thereby optimizes the first search query of the union all. This helps especially, by limiting the requested rows in the first query by (OFFSET * OVER_ALL_LIMIT). Especially for small offsets, the query gets its old performance back.

 But let's also discuss in this PR other methods to make the query faster, or whether we should delete old orders. I think with limit orders approaching, the db performance will become more problematic over time.

---

**Testing the previous issue:**
Query that caused problems before can be tested with this query (problematic address mentioned [here](https://cowservices.slack.com/archives/C0361CDD1FZ/p1667035528153689) is already in it). Query needs to be run against xdai readonly db:
https://gist.github.com/josojo/fb73fdfdec6734472fa48d9344d9ad0c
My execution time without the index created in this PR is: 
=>01.081 secs

---

**Why the issue was not caught in the previous PR:** 
I was testing with a too small database. With the size I could already see the difference clearly between the UNION and OR statements, but I could not see the performance degradation of OR. THis shows only later with more orders in the database.

New performance results of `postgres_user_orders_performance_many_users_with_some_orders`

On main branch with `I in 0..1000u32` and `J in 0..300u32`
=> Time per execution 404.366335ms
On this branch with `I in 0..1000u32` and `J in 0..300u32`
=> Time per execution 1.51164ms
On branch: v2.80.2(hotfix in prod) with `I in 0..1000u32` and `J in 0..300u32`
=> Time per execution 2.073314ms

New performance results of `postgres_user_orders_performance_user_with_many_orders`

On branch v2.80.2(hotfix in prod) with `j in 0..100_000u32` 
=>Time per execution 929.626571ms
On this branch:
=> Time per execution 4.141594ms 


But for sure, the performance will degrate with higher Offsets again. :( I think there is nothing I can do about it. Hope you guys have other ideas.