### PR TITLE
Fix matching amms

### DIFF
--- a/crates/shared/src/http_solver/model.rs
+++ b/crates/shared/src/http_solver/model.rs
@@ -23,7 +23,7 @@ use crate::{
 pub struct BatchAuctionModel {
     pub tokens: BTreeMap<H160, TokenInfoModel>,
     pub orders: BTreeMap<usize, OrderModel>,
-    pub amms: BTreeMap<usize, AmmModel>,
+    pub amms: BTreeMap<H160, AmmModel>,
     pub metadata: Option<MetadataModel>,
 }
 
@@ -175,7 +175,7 @@ pub struct SettledBatchAuctionModel {
     #[serde(default)]
     pub foreign_liquidity_orders: Vec<ExecutedLiquidityOrderModel>,
     #[serde(default)]
-    pub amms: HashMap<usize, UpdatedAmmModel>,
+    pub amms: HashMap<H160, UpdatedAmmModel>,
     pub ref_token: Option<H160>,
     #[serde_as(as = "HashMap<_, DecimalU256>")]
     pub prices: HashMap<H160, U256>,
@@ -607,10 +607,10 @@ mod tests {
             },
             orders: btreemap! { 0 => order_model },
             amms: btreemap! {
-                0 => constant_product_pool_model,
-                1 => weighted_product_pool_model,
-                2 => stable_pool_model,
-                3 => concentrated_pool_model,
+                H160::from_low_u64_be(0) => constant_product_pool_model,
+                H160::from_low_u64_be(1) => weighted_product_pool_model,
+                H160::from_low_u64_be(2) => stable_pool_model,
+                H160::from_low_u64_be(3) => concentrated_pool_model,
             },
             metadata: Some(MetadataModel {
                 environment: Some(String::from("Such Meta")),
@@ -663,7 +663,7 @@ mod tests {
             },
           },
           "amms": {
-            "0": {
+            "0x0000000000000000000000000000000000000000": {
               "kind": "ConstantProduct",
               "reserves": {
                 "0x000000000000000000000000000000000000a866": "200",
@@ -677,7 +677,7 @@ mod tests {
               "mandatory": false,
               "address": "0x0000000000000000000000000000000000000001",
             },
-            "1": {
+            "0x0000000000000000000000000000000000000001": {
               "kind": "WeightedProduct",
               "reserves": {
                 "0x000000000000000000000000000000000000a866": {
@@ -697,7 +697,7 @@ mod tests {
               "mandatory": true,
               "address": "0x0000000000000000000000000000000000000002",
             },
-            "2": {
+            "0x0000000000000000000000000000000000000002": {
               "kind": "Stable",
               "reserves": {
                 "0x000000000000000000000000000000000000a866": "1000",
@@ -716,7 +716,7 @@ mod tests {
               "mandatory": true,
               "address": "0x0000000000000000000000000000000000000003",
             },
-            "3": {
+            "0x0000000000000000000000000000000000000003": {
               "kind": "Concentrated",
               "pool": {
                  "tokens": [

--- a/crates/shared/src/price_estimation/http.rs
+++ b/crates/shared/src/price_estimation/http.rs
@@ -128,11 +128,11 @@ impl HttpPriceEstimator {
             self.balancer_pools(pairs.clone(), &gas_model),
             self.uniswap_v3_pools(pairs.clone(), &gas_model)
         )?;
-        let amms: BTreeMap<usize, AmmModel> = uniswap_pools
+        let amms: BTreeMap<H160, AmmModel> = uniswap_pools
             .into_iter()
             .chain(balancer_pools)
             .chain(uniswap_v3_pools)
-            .enumerate()
+            .map(|amm| (amm.address, amm))
             .collect();
 
         let mut tokens: HashSet<H160> = Default::default();
@@ -579,7 +579,7 @@ mod tests {
                     }
                 },
                 amms: hashmap! {
-                    0 => UpdatedAmmModel {
+                    H160::from_low_u64_be(0) => UpdatedAmmModel {
                         execution: vec![ExecutedAmmModel {
                             sell_token: H160::from_low_u64_be(0),
                             buy_token: H160::from_low_u64_be(1),

--- a/crates/solver/src/liquidity.rs
+++ b/crates/solver/src/liquidity.rs
@@ -53,6 +53,16 @@ impl Liquidity {
             Liquidity::Concentrated(amm) => vec![amm.tokens],
         }
     }
+
+    pub fn address(&self) -> Option<H160> {
+        match self {
+            Liquidity::ConstantProduct(amm) => Some(amm.address),
+            Liquidity::BalancerWeighted(amm) => Some(amm.address),
+            Liquidity::BalancerStable(amm) => Some(amm.address),
+            Liquidity::LimitOrder(_) => None,
+            Liquidity::Concentrated(amm) => Some(amm.pool.address),
+        }
+    }
 }
 
 /// A trait associating some liquidity model to how it is executed and encoded

--- a/crates/solver/src/solver/http_solver.rs
+++ b/crates/solver/src/solver/http_solver.rs
@@ -302,7 +302,7 @@ fn order_models(
         .collect()
 }
 
-fn amm_models(liquidity: &[Liquidity], gas_model: &GasModel) -> BTreeMap<usize, AmmModel> {
+fn amm_models(liquidity: &[Liquidity], gas_model: &GasModel) -> BTreeMap<H160, AmmModel> {
     liquidity
         .iter()
         .filter(|liquidity| !matches!(liquidity, Liquidity::LimitOrder(_)))
@@ -383,9 +383,8 @@ fn amm_models(liquidity: &[Liquidity], gas_model: &GasModel) -> BTreeMap<usize, 
                 },
             })
         })
-        .enumerate()
-        .filter_map(|(index, result)| match result {
-            Ok(value) => Some((index, value)),
+        .filter_map(|result| match result {
+            Ok(value) => Some((value.address, value)),
             Err(err) => {
                 tracing::error!(?err, "error converting liquidity to solver model");
                 None

--- a/crates/solver/src/solver/http_solver/settlement.rs
+++ b/crates/solver/src/solver/http_solver/settlement.rs
@@ -663,6 +663,19 @@ mod tests {
             settlement_handling: CapturingSettlementHandler::arc(),
         };
 
+        let lo_1 = LimitOrder {
+            id: crate::liquidity::LimitOrderUid::ZeroEx("1".to_string()),
+            sell_token: token_a,
+            buy_token: token_a,
+            sell_amount: U256::from(996570293625199060u128),
+            buy_amount: U256::from(289046068204476404625u128),
+            kind: OrderKind::Buy,
+            partially_fillable: false,
+            settlement_handling: CapturingSettlementHandler::arc(),
+            exchange: crate::liquidity::Exchange::ZeroEx,
+            ..Default::default()
+        };
+
         let wpo = WeightedProductOrder {
             address: H160::from_low_u64_be(2),
             reserves: hashmap! {
@@ -705,6 +718,7 @@ mod tests {
         let liquidity = vec![
             Liquidity::ConstantProduct(cpo_0.clone()),
             Liquidity::ConstantProduct(cpo_1.clone()),
+            Liquidity::LimitOrder(lo_1.clone()),
             Liquidity::BalancerWeighted(wpo.clone()),
             Liquidity::BalancerStable(spo.clone()),
         ];

--- a/crates/solver/src/solver/http_solver/settlement.rs
+++ b/crates/solver/src/solver/http_solver/settlement.rs
@@ -261,22 +261,28 @@ fn convert_foreign_liquidity_orders(
 
 fn match_prepared_and_settled_amms(
     prepared_amms: Vec<Liquidity>,
-    settled_amms: HashMap<usize, UpdatedAmmModel>,
+    settled_amms: HashMap<H160, UpdatedAmmModel>,
 ) -> Result<Vec<ExecutedAmm>> {
     settled_amms
         .into_iter()
-        .filter(|(index, settled)| {
+        .filter(|(address, settled)| {
             if !settled.is_non_trivial() {
-                tracing::debug!("filtered trivial amm with index {}", index);
+                tracing::debug!("filtered trivial amm with address {}", address);
             }
             settled.is_non_trivial()
         })
-        .flat_map(|(index, settled)| settled.execution.into_iter().map(move |exec| (index, exec)))
-        .map(|(index, settled)| {
+        .flat_map(|(address, settled)| {
+            settled
+                .execution
+                .into_iter()
+                .map(move |exec| (address, exec))
+        })
+        .map(|(address, settled)| {
             Ok(ExecutedAmm {
                 order: prepared_amms
-                    .get(index)
-                    .ok_or_else(|| anyhow!("Invalid AMM {}", index))?
+                    .iter()
+                    .find(|amm| amm.address().unwrap_or_default() == address)
+                    .ok_or_else(|| anyhow!("Invalid AMM {}", address))?
                     .clone(),
                 input: (settled.buy_token, settled.exec_buy_amount),
                 output: (settled.sell_token, settled.exec_sell_amount),
@@ -409,21 +415,21 @@ mod tests {
         let sp_amm_handler = CapturingSettlementHandler::arc();
         let liquidity = vec![
             Liquidity::ConstantProduct(ConstantProductOrder {
-                address: H160::from_low_u64_be(1),
+                address: H160::from_low_u64_be(0),
                 tokens: TokenPair::new(t0, t1).unwrap(),
                 reserves: (3, 4),
                 fee: 5.into(),
                 settlement_handling: cp_amm_handler.clone(),
             }),
             Liquidity::ConstantProduct(ConstantProductOrder {
-                address: H160::from_low_u64_be(2),
+                address: H160::from_low_u64_be(1),
                 tokens: TokenPair::new(t0, t1).unwrap(),
                 reserves: (6, 7),
                 fee: 8.into(),
                 settlement_handling: internal_amm_handler.clone(),
             }),
             Liquidity::BalancerWeighted(WeightedProductOrder {
-                address: H160::from_low_u64_be(3),
+                address: H160::from_low_u64_be(2),
                 reserves: hashmap! {
                     t0 => WeightedTokenState {
                         common: TokenState {
@@ -444,7 +450,7 @@ mod tests {
                 settlement_handling: wp_amm_handler.clone(),
             }),
             Liquidity::BalancerStable(StablePoolOrder {
-                address: H160::from_low_u64_be(4),
+                address: H160::from_low_u64_be(3),
                 reserves: hashmap! {
                     t0 => TokenState {
                         balance: U256::from(300),
@@ -539,10 +545,10 @@ mod tests {
             orders: hashmap! { 0 => executed_order },
             foreign_liquidity_orders: vec![foreign_liquidity_order],
             amms: hashmap! {
-                0 => updated_uniswap,
-                1 => internal_uniswap,
-                2 => updated_balancer_weighted,
-                3 => updated_balancer_stable,
+                H160::from_low_u64_be(0) => updated_uniswap,
+                H160::from_low_u64_be(1) => internal_uniswap,
+                H160::from_low_u64_be(2) => updated_balancer_weighted,
+                H160::from_low_u64_be(3) => updated_balancer_stable,
             },
             ref_token: Some(t0),
             prices: hashmap! { t0 => 10.into(), t1 => 11.into() },
@@ -640,14 +646,14 @@ mod tests {
         let token_c = H160::from_slice(&hex!("e4b9895e638f54c3bee2a3a78d6a297cc03e0353"));
 
         let cpo_0 = ConstantProductOrder {
-            address: H160::from_low_u64_be(1),
+            address: H160::from_low_u64_be(0),
             tokens: TokenPair::new(token_a, token_b).unwrap(),
             reserves: (597249810824827988770940, 225724246562756585230),
             fee: Ratio::new(3, 1000),
             settlement_handling: CapturingSettlementHandler::arc(),
         };
         let cpo_1 = ConstantProductOrder {
-            address: H160::from_low_u64_be(2),
+            address: H160::from_low_u64_be(1),
             tokens: TokenPair::new(token_b, token_c).unwrap(),
             reserves: (8488677530563931705, 75408146511005299032),
             fee: Ratio::new(3, 1000),
@@ -655,7 +661,7 @@ mod tests {
         };
 
         let wpo = WeightedProductOrder {
-            address: H160::from_low_u64_be(3),
+            address: H160::from_low_u64_be(2),
             reserves: hashmap! {
                 token_c => WeightedTokenState {
                     common: TokenState {
@@ -677,7 +683,7 @@ mod tests {
         };
 
         let spo = StablePoolOrder {
-            address: H160::from_low_u64_be(4),
+            address: H160::from_low_u64_be(3),
             reserves: hashmap! {
                 token_c => TokenState {
                     balance: U256::from(1234u128),
@@ -745,7 +751,7 @@ mod tests {
                 }
             },
             "amms": {
-                "0": {
+                "0x0000000000000000000000000000000000000000": {
                     "kind": "ConstantProduct",
                     "reserves": {
                         "0xa7d1c04faf998f9161fc9f800a99a809b84cfc9d": "597249810824827988770940",
@@ -769,7 +775,7 @@ mod tests {
                         }
                     ]
                 },
-                "1": {
+                "0x0000000000000000000000000000000000000001": {
                     "execution": [
                         {
                             "sell_token": "0xc778417e063141139fce010982780140aa0cd5ab",
@@ -783,7 +789,7 @@ mod tests {
                         }
                     ]
                 },
-                "2": {
+                "0x0000000000000000000000000000000000000002": {
                     "kind": "WeightedProduct",
                     "reserves": {
                         "0xe4b9895e638f54c3bee2a3a78d6a297cc03e0353": {
@@ -813,7 +819,7 @@ mod tests {
                         }
                     ]
                 },
-                "3": {
+                "0x0000000000000000000000000000000000000003": {
                     "kind": "Stable",
                     "reserves": {
                         "0xe4b9895e638f54c3bee2a3a78d6a297cc03e0353": "1234",

--- a/crates/solver/src/solver/http_solver/settlement.rs
+++ b/crates/solver/src/solver/http_solver/settlement.rs
@@ -263,6 +263,10 @@ fn match_prepared_and_settled_amms(
     prepared_amms: Vec<Liquidity>,
     settled_amms: HashMap<H160, UpdatedAmmModel>,
 ) -> Result<Vec<ExecutedAmm>> {
+    let prepared_amms: HashMap<H160, Liquidity> = prepared_amms
+        .into_iter()
+        .filter_map(|amm| amm.address().map(|address| (address, amm)))
+        .collect();
     settled_amms
         .into_iter()
         .filter(|(address, settled)| {
@@ -280,8 +284,7 @@ fn match_prepared_and_settled_amms(
         .map(|(address, settled)| {
             Ok(ExecutedAmm {
                 order: prepared_amms
-                    .iter()
-                    .find(|amm| amm.address().unwrap_or_default() == address)
+                    .get(&address)
                     .ok_or_else(|| anyhow!("Invalid AMM {}", address))?
                     .clone(),
                 input: (settled.buy_token, settled.exec_buy_amount),


### PR DESCRIPTION
This PR does two things:

1. Implements https://github.com/cowprotocol/services/issues/346#issuecomment-1205347501
2. At the same time fixes the bug with wrong amms matching. The matching is done here:
https://github.com/cowprotocol/services/blob/main/crates/solver/src/solver/http_solver/settlement.rs#L277-L280
assuming the `prepared_amms` has same index values as `settled_amms`, but `prepared_amms` is actually filtered here:
https://github.com/cowprotocol/services/blob/570b9124e6ade3211cf6f085065c9f008890d9ae/crates/solver/src/solver/http_solver.rs#L308
which messes up the indexing.

### Test plan

Updated unite test should cover all the changes.

### Release notes

1. I believe this PR is worth making the release hotfix.
2. Solvers need to be notified about this change.
