### PR TITLE
Metrics for ignored orders

### DIFF
--- a/crates/autopilot/src/limit_order_quoter.rs
+++ b/crates/autopilot/src/limit_order_quoter.rs
@@ -12,7 +12,7 @@ use std::sync::Arc;
 #[derive(prometheus_metric_storage::MetricStorage, Clone, Debug)]
 #[metric(subsystem = "limit_order_quoter")]
 struct Metrics {
-    /// Histogram for counting failed limit orders.
+    /// Counter for failed limit orders.
     failed: prometheus::IntCounter,
 }
 


### PR DESCRIPTION
Fixes https://github.com/cowprotocol/services/issues/729.

Adds a histogram metric for ignored limit orders.

### Test Plan

Not sure, how do we usually test metrics?