### PR TITLE
Adjust Market Order Logic When Limit Orders Are Disabled

### DIFF
--- a/crates/autopilot/src/database/onchain_order_events.rs
+++ b/crates/autopilot/src/database/onchain_order_events.rs
@@ -439,6 +439,10 @@ fn convert_onchain_order_placement(
         false
     };
 
+    // TODO(nlordell): It is currently possible to create limit orders from
+    // on-chain events even if they are disabled at the API level. This feels
+    // non-intentional, and we should revisit this before releasing EthFlow
+    // orders.
     let class = match (is_outside_market_price, liquidity_owner) {
         (true, true) => OrderClass::Liquidity,
         (true, false) => OrderClass::Limit,

--- a/crates/shared/src/order_validation.rs
+++ b/crates/shared/src/order_validation.rs
@@ -686,7 +686,7 @@ pub async fn get_quote_and_check_fee(
                 .await
                 .map_err(ValidationError::Other)?;
 
-            tracing::debug!("computed fresh quote for order creation");
+            tracing::debug!(quote_id =? quote.id, "computed fresh quote for order creation");
             quote
         }
         Err(err) => return Err(err.into()),

--- a/crates/shared/src/order_validation.rs
+++ b/crates/shared/src/order_validation.rs
@@ -379,15 +379,19 @@ impl OrderValidating for OrderValidator {
             return Err(ValidationError::ZeroAmount);
         }
 
-        let liquidity_owner = self.liquidity_order_owners.contains(&owner);
+        let is_liquidity_owner = self.liquidity_order_owners.contains(&owner);
+        let is_limit_order =
+            self.enable_limit_orders && !is_liquidity_owner && order.data.fee_amount.is_zero();
+
         self.partial_validate(PreOrderData::from_order_creation(
             owner,
             &order.data,
             signing_scheme,
-            liquidity_owner,
+            is_liquidity_owner,
         ))
         .await
         .map_err(ValidationError::Partial)?;
+
         let quote_parameters = QuoteSearchParameters {
             sell_token: order.data.sell_token,
             buy_token: order.data.buy_token,
@@ -398,7 +402,7 @@ impl OrderValidating for OrderValidator {
             from: owner,
             app_data: order.data.app_data,
         };
-        let quote = if !liquidity_owner && order.data.fee_amount > U256::zero() {
+        let quote = if !is_liquidity_owner && !is_limit_order {
             let quote = get_quote_and_check_fee(
                 &*self.quoter,
                 &quote_parameters,
@@ -411,11 +415,6 @@ impl OrderValidating for OrderValidator {
                 )?,
             )
             .await?;
-            let quote = self
-                .quoter
-                .store_quote(quote)
-                .await
-                .map_err(ValidationError::Other)?;
             Some(quote)
         } else {
             // We don't try to get quotes for liquidity and limit orders
@@ -437,10 +436,8 @@ impl OrderValidating for OrderValidator {
             })
             .unwrap_or_default();
 
-        let min_balance = match minimum_balance(&order.data) {
-            Some(amount) => amount,
-            None => return Err(ValidationError::SellAmountOverflow),
-        };
+        let min_balance =
+            minimum_balance(&order.data).ok_or(ValidationError::SellAmountOverflow)?;
 
         // Fast path to check if transfer is possible with a single node query.
         // If not, run extra queries for additional information.
@@ -500,12 +497,14 @@ impl OrderValidating for OrderValidator {
             None => true,
         };
 
-        let class = match (is_outside_market_price, liquidity_owner) {
-            (true, true) => OrderClass::Liquidity,
-            (true, false) if self.enable_limit_orders && order.data.fee_amount.is_zero() => {
-                OrderClass::Limit
-            }
-            _ => OrderClass::Market,
+        let class = if is_limit_order {
+            OrderClass::Limit
+        } else if is_liquidity_owner || is_outside_market_price {
+            // Note that we consider out-of-price orders as liquidity orders.
+            // See <https://github.com/cowprotocol/services/pull/301>
+            OrderClass::Liquidity
+        } else {
+            OrderClass::Market
         };
 
         if class == OrderClass::Limit {
@@ -683,7 +682,12 @@ pub async fn get_quote_and_check_fee(
                 app_data: quote_search_parameters.app_data,
                 signing_scheme,
             };
+
             let quote = quoter.calculate_quote(parameters).await?;
+            let quote = quoter
+                .store_quote(quote)
+                .await
+                .map_err(ValidationError::Other)?;
 
             tracing::debug!("computed fresh quote for order creation");
             quote
@@ -1336,9 +1340,12 @@ mod tests {
         let mut order_quoter = MockOrderQuoting::new();
         let mut bad_token_detector = MockBadTokenDetecting::new();
         let mut balance_fetcher = MockBalanceFetching::new();
-        order_quoter
-            .expect_find_quote()
-            .returning(|_, _, _| Ok(Default::default()));
+        order_quoter.expect_find_quote().returning(|_, _, _| {
+            Ok(Quote {
+                fee_amount: U256::from(1),
+                ..Default::default()
+            })
+        });
         bad_token_detector
             .expect_detect()
             .returning(|_| Ok(TokenQuality::Good));
@@ -1373,12 +1380,71 @@ mod tests {
             },
             ..Default::default()
         };
+        let result = validator
+            .validate_and_construct_order(order, &Default::default(), Default::default())
+            .await;
+        assert!(matches!(result, Err(ValidationError::InsufficientFee)));
+    }
+
+    #[tokio::test]
+    async fn post_out_of_market_orders_when_limit_orders_disabled() {
+        let expected_buy_amount = U256::from(100);
+
+        let mut order_quoter = MockOrderQuoting::new();
+        let mut bad_token_detector = MockBadTokenDetecting::new();
+        let mut balance_fetcher = MockBalanceFetching::new();
+        order_quoter.expect_find_quote().returning(move |_, _, _| {
+            Ok(Quote {
+                buy_amount: expected_buy_amount,
+                sell_amount: U256::from(1),
+                fee_amount: U256::from(1),
+                ..Default::default()
+            })
+        });
+        bad_token_detector
+            .expect_detect()
+            .returning(|_| Ok(TokenQuality::Good));
+        balance_fetcher
+            .expect_can_transfer()
+            .returning(|_, _, _, _| Ok(()));
+        let mut limit_order_counter = MockLimitOrderCounting::new();
+        limit_order_counter.expect_count().returning(|_| Ok(0u64));
+        let validator = OrderValidator::new(
+            Box::new(MockCodeFetching::new()),
+            dummy_contract!(WETH9, [0xef; 20]),
+            hashset!(),
+            hashset!(),
+            OrderValidPeriodConfiguration::any(),
+            SignatureConfiguration::all(),
+            Arc::new(bad_token_detector),
+            Arc::new(order_quoter),
+            Arc::new(balance_fetcher),
+            Arc::new(MockSignatureValidating::new()),
+            Arc::new(limit_order_counter),
+            0,
+        );
+        let order = OrderCreation {
+            data: OrderData {
+                valid_to: time::now_in_epoch_seconds() + 2,
+                sell_token: H160::from_low_u64_be(1),
+                buy_token: H160::from_low_u64_be(2),
+                buy_amount: expected_buy_amount + 1, // buy more than expected
+                sell_amount: U256::from(1),
+                fee_amount: U256::from(1),
+                kind: OrderKind::Sell,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
         let (order, quote) = validator
             .validate_and_construct_order(order, &Default::default(), Default::default())
             .await
             .unwrap();
-        assert_eq!(quote, None);
-        assert_eq!(order.metadata.class, OrderClass::Market);
+
+        // Out-of-price orders are intentionally marked as liquidity
+        // orders!
+        assert_eq!(order.metadata.class, OrderClass::Liquidity);
+        assert!(quote.is_some());
     }
 
     #[tokio::test]
@@ -1855,7 +1921,19 @@ mod tests {
                 app_data: quote_search_parameters.app_data,
                 signing_scheme: QuoteSigningScheme::Eip712,
             }))
-            .returning(move |_| Ok(quote_data.clone()));
+            .returning({
+                let quote_data = quote_data.clone();
+                move |_| Ok(quote_data.clone())
+            });
+        order_quoter
+            .expect_store_quote()
+            .with(eq(quote_data.clone()))
+            .returning(|quote| {
+                Ok(Quote {
+                    id: Some(42),
+                    ..quote
+                })
+            });
 
         let quote = get_quote_and_check_fee(
             &order_quoter,
@@ -1870,6 +1948,7 @@ mod tests {
         assert_eq!(
             quote,
             Quote {
+                id: Some(42),
                 fee_amount: 6.into(),
                 ..Default::default()
             }


### PR DESCRIPTION
This PR adjusts the order classification logic.

Specifically, when limit orders were disabled, it was possible to create market orders with a 0-fee (as the 0-fee would cause it to skip the `get_quote_and_check_fee` fee check but disabled limit orders make the order be considered a market order).

@fedgiac and I already applied a hotfix in production, this PR adds the fix to `main` as 
well. This is not urgent (as limit orders are enabled in staging, so it is not possible to create 0-fee market orders ATM).

Additionally, this PR also:
- restores the behaviour of out-of-market orders being flagged as liquidity orders
- only stores quotes at order creation if an existing quote wasn't found. This is to avoid orders that are created with a specific quote ID getting a different one.

### Test Plan

Changed the test that checks 0-fee market orders error validation when limit orders are disabled, and added a new test to prevent regressions of the liquidity classification for out-of market orders.