### PR TITLE
Updating rustc before running CI

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -12,13 +12,12 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: Swatinem/rust-cache@v1
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@stable
         with:
           profile: minimal
           toolchain: nightly
           components: rustfmt
       - run: |
-          rustup update stable
           rustup --version
           rustup show
           cargo --version

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -18,6 +18,7 @@ jobs:
           toolchain: nightly
           components: rustfmt
       - run: |
+          rustup update stable
           rustup --version
           rustup show
           cargo --version


### PR DESCRIPTION
Tests Nick proposal to run a rustup update, as github actions are lagging behind with their updates of the rustc versions.
This allows us to use the newest rust features earlier.

See here: https://cowservices.slack.com/archives/C0375NV72SC/p1668067505093759?thread_ts=1668067198.188059&cid=C0375NV72SC

Updating rustc adds 11 secs to our CI. Is it worth it? 
Personally, I am undecided. Wdyt?