### PR TITLE
Revert temporary logs

### DIFF
--- a/crates/solver/src/liquidity/uniswap_v3.rs
+++ b/crates/solver/src/liquidity/uniswap_v3.rs
@@ -173,15 +173,10 @@ impl SettlementHandling<ConcentratedLiquidity> for UniswapV3SettlementHandler {
     // Creates the required interaction to convert the given input into output. Assumes slippage is
     // already applied to the `input_max` field.
     fn encode(&self, execution: AmmOrderExecution, encoder: &mut SettlementEncoder) -> Result<()> {
-        tracing::debug!("entered encoding UniswapV3SettlementHandler");
         let (approval, swap) = self.settle(
             execution.input_max,
             execution.output,
             self.fee.context("missing fee")?,
-        );
-        tracing::debug!(
-            "adding interactions, internalizable: {}",
-            execution.internalizable
         );
         encoder.append_to_execution_plan_internalizable(approval, execution.internalizable);
         encoder.append_to_execution_plan_internalizable(swap, execution.internalizable);

--- a/crates/solver/src/settlement/settlement_encoder.rs
+++ b/crates/solver/src/settlement/settlement_encoder.rs
@@ -518,7 +518,6 @@ impl SettlementEncoder {
             .map(|trade| trade.encode(uniform_clearing_price_vec_length))
             .collect();
         trades.append(&mut liquidity_order_trades);
-        tracing::debug!("execution plan: {:?}", self.execution_plan);
         EncodedSettlement {
             tokens,
             clearing_prices,
@@ -535,18 +534,13 @@ impl SettlementEncoder {
                     .chain(
                         self.execution_plan
                             .iter()
-                            .enumerate()
-                            .filter_map(|(index, (interaction, internalizable))| {
+                            .filter_map(|(interaction, internalizable)| {
                                 if *internalizable
                                     && matches!(
                                         internalization_strategy,
                                         InternalizationStrategy::SkipInternalizableInteraction
                                     )
                                 {
-                                    tracing::debug!(
-                                        "skipped internalizable interaction with index {}",
-                                        index
-                                    );
                                     None
                                 } else {
                                     Some(interaction)

--- a/crates/solver/src/settlement_ranker.rs
+++ b/crates/solver/src/settlement_ranker.rs
@@ -141,20 +141,10 @@ impl SettlementRanker {
         // statement allows us to figure out which settlements were filtered out and which ones are
         // going to be simulated and considered for competition.
         for (solver, settlement) in &solver_settlements {
-            let encoded_settlement = settlement
-                .encoder
-                .clone()
-                .finish(InternalizationStrategy::EncodeAllInteractions);
             tracing::debug!(
-                solver_name = %solver.name(), ?settlement, uninternalized_calldata = hex::encode(call_data(encoded_settlement.clone())),
+                solver_name = %solver.name(), ?settlement, uninternalized_calldata = hex::encode(call_data(settlement.encoder.clone().finish(InternalizationStrategy::EncodeAllInteractions))),
                 "considering solution for solver competition",
             );
-            if encoded_settlement.interactions[1].is_empty() {
-                tracing::warn!(
-                    "no interactions for valid settlement: {:?}",
-                    encoded_settlement
-                );
-            }
         }
 
         let (mut rated_settlements, errors) = self

--- a/crates/solver/src/solver/http_solver.rs
+++ b/crates/solver/src/solver/http_solver.rs
@@ -511,7 +511,6 @@ impl Solver for HttpSolver {
             self.solver.name,
             serde_json::to_string_pretty(&settled).unwrap()
         );
-        tracing::debug!("Solver context {}, context {:?}", self.solver.name, context);
 
         if settled.orders.is_empty() {
             return Ok(vec![]);

--- a/crates/solver/src/solver/http_solver.rs
+++ b/crates/solver/src/solver/http_solver.rs
@@ -529,7 +529,7 @@ impl Solver for HttpSolver {
             Ok(settlement) => Ok(vec![settlement]),
             Err(err) => {
                 tracing::debug!(
-                    name = %self.name(), ?settled,
+                    name = %self.name(), ?settled, ?err,
                     "failed to process HTTP solver result",
                 );
                 Err(err)

--- a/crates/solver/src/solver/http_solver/settlement.rs
+++ b/crates/solver/src/solver/http_solver/settlement.rs
@@ -74,7 +74,6 @@ impl Execution {
     ) -> Result<()> {
         use Execution::*;
 
-        tracing::debug!("internalizable: {}", internalizable);
         match self {
             LimitOrder(order) => settlement.with_liquidity(&order.order, order.executed_amount()),
             Amm(executed_amm) => {
@@ -162,7 +161,6 @@ impl<'a> IntermediateSettlement<'a> {
         let prices = match_settled_prices(executed_limit_orders.as_slice(), settled.prices)?;
         let approvals = compute_approvals(allowance_manager, settled.approvals).await?;
         let executions_amm = match_prepared_and_settled_amms(context.liquidity, settled.amms)?;
-        tracing::debug!("executions_amm: {:?}", executions_amm);
 
         let executions = merge_and_order_executions(
             executions_amm,
@@ -170,7 +168,6 @@ impl<'a> IntermediateSettlement<'a> {
             [executed_limit_orders, foreign_liquidity_orders].concat(),
         );
 
-        tracing::debug!("executions: {:?}", executions);
         Ok(Self {
             executions,
             prices,
@@ -269,12 +266,7 @@ fn match_prepared_and_settled_amms(
         .collect();
     settled_amms
         .into_iter()
-        .filter(|(address, settled)| {
-            if !settled.is_non_trivial() {
-                tracing::debug!("filtered trivial amm with address {}", address);
-            }
-            settled.is_non_trivial()
-        })
+        .filter(|(_, settled)| settled.is_non_trivial())
         .flat_map(|(address, settled)| {
             settled
                 .execution


### PR DESCRIPTION
Reverts https://github.com/cowprotocol/services/pull/743 since the encoding issue is fixed with https://github.com/cowprotocol/services/pull/751 (we had quite a few Quasimodo settlements using UniV3 liquidity on staging and none of them failed).

While at it, I've also added printing of the error in case of `failed to process HTTP solver result` error we have experienced lately.
