### PR TITLE
Prioritize orders in `SingleOrderSolvers`

### DIFF
--- a/crates/solver/src/arguments.rs
+++ b/crates/solver/src/arguments.rs
@@ -1,7 +1,7 @@
 use crate::{
     liquidity::slippage,
     settlement_access_list::AccessListEstimatorType,
-    solver::{ExternalSolverArg, SolverAccountArg, SolverType},
+    solver::{single_order_solver, ExternalSolverArg, SolverAccountArg, SolverType},
 };
 use primitive_types::H160;
 use reqwest::Url;
@@ -21,6 +21,9 @@ pub struct Arguments {
 
     #[clap(flatten)]
     pub slippage: slippage::Arguments,
+
+    #[clap(flatten)]
+    pub order_prioritization: single_order_solver::Arguments,
 
     /// The API endpoint to fetch the orderbook
     #[clap(long, env, default_value = "http://localhost:8080")]
@@ -293,6 +296,7 @@ impl std::fmt::Display for Arguments {
         write!(f, "{}", self.shared)?;
         write!(f, "{}", self.http_client)?;
         write!(f, "{}", self.slippage)?;
+        write!(f, "{}", self.order_prioritization)?;
         writeln!(f, "orderbook_url: {}", self.orderbook_url)?;
         writeln!(f, "mip_solver_url: {}", self.mip_solver_url)?;
         writeln!(f, "quasimodo_solver_url: {}", self.quasimodo_solver_url)?;

--- a/crates/solver/src/main.rs
+++ b/crates/solver/src/main.rs
@@ -254,6 +254,7 @@ async fn main() {
         args.max_merged_settlements,
         &args.slippage,
         market_makable_token_list.clone(),
+        &args.order_prioritization,
     )
     .expect("failure creating solvers");
 

--- a/crates/solver/src/solver.rs
+++ b/crates/solver/src/solver.rs
@@ -52,7 +52,7 @@ pub mod http_solver;
 mod naive_solver;
 mod oneinch_solver;
 mod paraswap_solver;
-mod single_order_solver;
+pub mod single_order_solver;
 pub mod uni_v3_router_solver;
 mod zeroex_solver;
 
@@ -277,6 +277,7 @@ pub fn create(
     max_merged_settlements: usize,
     slippage_configuration: &slippage::Arguments,
     market_makable_token_list: AutoUpdatingTokenList,
+    order_prioritization_config: &single_order_solver::Arguments,
 ) -> Result<Solvers> {
     // Tiny helper function to help out with type inference. Otherwise, all
     // `Box::new(...)` expressions would have to be cast `as Box<dyn Solver>`.
@@ -343,6 +344,7 @@ pub fn create(
                     solver_metrics.clone(),
                     max_merged_settlements,
                     max_settlements_per_solver,
+                    order_prioritization_config.clone(),
                 )
             };
 

--- a/crates/solver/src/solver/single_order_solver.rs
+++ b/crates/solver/src/solver/single_order_solver.rs
@@ -2,11 +2,13 @@ use crate::{
     driver::solver_settlements::merge_settlements,
     liquidity::LimitOrder,
     metrics::SolverMetrics,
-    settlement::Settlement,
+    settlement::{external_prices::ExternalPrices, Settlement},
     solver::{Auction, Solver},
 };
 use anyhow::{Error, Result};
 use ethcontract::Account;
+use num::BigRational;
+use number_conversions::u256_to_big_rational;
 use primitive_types::U256;
 use rand::prelude::SliceRandom;
 use std::{collections::VecDeque, sync::Arc, time::Duration};
@@ -51,20 +53,42 @@ impl SingleOrderSolver {
             max_settlements_per_solver,
         }
     }
+
+    /// Returns the `native_sell_amount / native_buy_amount` of the given order under the current
+    /// market conditions. The higher the value the more likely it is that this order could get filled.
+    fn estimate_price_viability(order: &LimitOrder, prices: &ExternalPrices) -> BigRational {
+        let sell_amount = u256_to_big_rational(&order.sell_amount);
+        let buy_amount = u256_to_big_rational(&order.buy_amount);
+        let native_sell_amount = prices.get_native_amount(order.sell_token, sell_amount);
+        let native_buy_amount = prices.get_native_amount(order.buy_token, buy_amount);
+        native_sell_amount / native_buy_amount
+    }
+
+    /// In case there are too many orders to solve before the auction deadline we want to
+    /// prioritize orders which are more likely to be matchable. This is implemented by looking at
+    /// the current native price of the traded tokens and comparing that to the order's limit price.
+    /// Sorts the highest priority orders to the front of the list.
+    fn get_prioritized_orders(
+        orders: &[LimitOrder],
+        prices: &ExternalPrices,
+    ) -> VecDeque<LimitOrder> {
+        // Liquidity orders don't make sense on their own and a `SingleOrderSolver` can't
+        // settle them together with a user order.
+        let mut user_orders: Vec<_> = orders
+            .iter()
+            .filter(|o| !o.is_liquidity_order)
+            .cloned()
+            .collect();
+        user_orders.sort_by_cached_key(|o| Self::estimate_price_viability(o, prices));
+        user_orders.into()
+    }
 }
 
 #[async_trait::async_trait]
 impl Solver for SingleOrderSolver {
     async fn solve(&self, auction: Auction) -> Result<Vec<Settlement>> {
-        let mut orders = auction.orders.clone();
+        let mut orders = Self::get_prioritized_orders(&auction.orders, &auction.external_prices);
 
-        // Randomize which orders we start with to prevent us getting stuck on bad orders.
-        orders.shuffle(&mut rand::thread_rng());
-
-        let mut orders = orders
-            .into_iter()
-            .filter(|order| !order.is_liquidity_order)
-            .collect::<VecDeque<_>>();
         let mut settlements = Vec::new();
         let settle = async {
             while let Some(order) = orders.pop_front() {

--- a/crates/solver/src/solver/single_order_solver.rs
+++ b/crates/solver/src/solver/single_order_solver.rs
@@ -158,7 +158,7 @@ fn get_prioritized_orders(orders: &[LimitOrder], prices: &ExternalPrices) -> Vec
 
     let mut rng = rand::thread_rng();
 
-    // Chose `choices.len()` distinct items from `user_orders` weighted by the viability of the order.
+    // Chose `user_orders.len()` distinct items from `user_orders` weighted by the viability of the order.
     // This effectively sorts the orders by viability with a slight randomness to not get stuck on
     // bad orders.
     match user_orders.choose_multiple_weighted(&mut rng, user_orders.len(), |order| {

--- a/crates/solver/src/solver/single_order_solver.rs
+++ b/crates/solver/src/solver/single_order_solver.rs
@@ -320,7 +320,7 @@ mod tests {
     #[test]
     fn orders_get_prioritized() {
         let token = H160::from_low_u64_be;
-        let amount = |amount: u128| U256::from(amount);
+        let amount = U256::from;
         let order = |sell_amount: u128, is_liquidity_order: bool| LimitOrder {
             sell_token: token(1),
             sell_amount: amount(sell_amount),

--- a/crates/solver/src/solver/single_order_solver.rs
+++ b/crates/solver/src/solver/single_order_solver.rs
@@ -132,6 +132,8 @@ impl Solver for SingleOrderSolver {
             &self.order_prioritization_config,
         );
 
+        tracing::trace!(name = self.name(), ?orders, "prioritized orders");
+
         let mut settlements = Vec::new();
         let settle = async {
             while let Some(order) = orders.pop_front() {
@@ -242,8 +244,9 @@ fn get_prioritized_orders(
         order_prioritization_config.apply_weight_constraints(price_viability)
     }) {
         Ok(weighted_user_orders) => weighted_user_orders.into_iter().cloned().collect(),
-        Err(_) => {
+        Err(err) => {
             // if weighted sorting by viability fails we fall back to shuffling randomly
+            tracing::warn!(?err, "weighted order prioritization failed");
             user_orders.shuffle(&mut rng);
             user_orders.into()
         }

--- a/crates/solver/src/solver/single_order_solver.rs
+++ b/crates/solver/src/solver/single_order_solver.rs
@@ -6,12 +6,77 @@ use crate::{
     solver::{Auction, Solver},
 };
 use anyhow::{Error, Result};
+use clap::Parser;
 use ethcontract::Account;
 use num::ToPrimitive;
 use number_conversions::u256_to_big_rational;
 use primitive_types::U256;
 use rand::prelude::SliceRandom;
-use std::{collections::VecDeque, sync::Arc, time::Duration};
+use std::{
+    collections::VecDeque,
+    fmt::{self, Display, Formatter},
+    sync::Arc,
+    time::Duration,
+};
+
+/// CLI arguments to configure order prioritization of single order solvers based on an orders price.
+#[derive(Debug, Parser, Clone)]
+#[group(skip)]
+pub struct Arguments {
+    /// Exponent to turn an order's price ratio into a weight for a weighted prioritization.
+    #[clap(long, env, default_value = "10.0")]
+    pub price_priority_exponent: f64,
+
+    /// The lowest possible weight an order can have for the weighted order prioritization.
+    #[clap(long, env, default_value = "0.01")]
+    pub price_priority_min_weight: f64,
+
+    /// The highest possible weight an order can have for the weighted order prioritization.
+    #[clap(long, env, default_value = "10.0")]
+    pub price_priority_max_weight: f64,
+}
+
+impl Display for Arguments {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        writeln!(
+            f,
+            "price_priority_exponent: {}",
+            self.price_priority_exponent
+        )?;
+        writeln!(
+            f,
+            "price_priority_min_weight: {}",
+            self.price_priority_min_weight
+        )?;
+        writeln!(
+            f,
+            "price_priority_max_weight: {}",
+            self.price_priority_max_weight
+        )?;
+        Ok(())
+    }
+}
+
+impl Arguments {
+    fn apply_weight_constraints(&self, original_weight: f64) -> f64 {
+        original_weight
+            .powf(self.price_priority_exponent)
+            .max(self.price_priority_min_weight)
+            .min(self.price_priority_max_weight)
+    }
+}
+
+impl Default for Arguments {
+    fn default() -> Self {
+        // Arguments which seem to produce reasonable results for orders between 90% and
+        // 130% of the market price.
+        Self {
+            price_priority_exponent: 10.,
+            price_priority_min_weight: 0.01,
+            price_priority_max_weight: 10.,
+        }
+    }
+}
 
 #[cfg_attr(test, mockall::automock)]
 #[async_trait::async_trait]
@@ -37,6 +102,7 @@ pub struct SingleOrderSolver {
     metrics: Arc<dyn SolverMetrics>,
     max_merged_settlements: usize,
     max_settlements_per_solver: usize,
+    order_prioritization_config: Arguments,
 }
 
 impl SingleOrderSolver {
@@ -45,12 +111,14 @@ impl SingleOrderSolver {
         metrics: Arc<dyn SolverMetrics>,
         max_settlements_per_solver: usize,
         max_merged_settlements: usize,
+        order_prioritization_config: Arguments,
     ) -> Self {
         Self {
             inner,
             metrics,
             max_merged_settlements,
             max_settlements_per_solver,
+            order_prioritization_config,
         }
     }
 }
@@ -58,7 +126,11 @@ impl SingleOrderSolver {
 #[async_trait::async_trait]
 impl Solver for SingleOrderSolver {
     async fn solve(&self, auction: Auction) -> Result<Vec<Settlement>> {
-        let mut orders = get_prioritized_orders(&auction.orders, &auction.external_prices);
+        let mut orders = get_prioritized_orders(
+            &auction.orders,
+            &auction.external_prices,
+            &self.order_prioritization_config,
+        );
 
         let mut settlements = Vec::new();
         let settle = async {
@@ -144,7 +216,11 @@ fn estimate_price_viability(order: &LimitOrder, prices: &ExternalPrices) -> f64 
 /// prioritize orders which are more likely to be matchable. This is implemented by rating each
 /// order's viability by comparing the ask price with the current market price. The lower the ask
 /// price is compared to the market price the higher the chance the order will get prioritized.
-fn get_prioritized_orders(orders: &[LimitOrder], prices: &ExternalPrices) -> VecDeque<LimitOrder> {
+fn get_prioritized_orders(
+    orders: &[LimitOrder],
+    prices: &ExternalPrices,
+    order_prioritization_config: &Arguments,
+) -> VecDeque<LimitOrder> {
     // Liquidity orders don't make sense on their own and a `SingleOrderSolver` can't
     // settle them together with a user order.
     let mut user_orders: Vec<_> = orders
@@ -162,7 +238,8 @@ fn get_prioritized_orders(orders: &[LimitOrder], prices: &ExternalPrices) -> Vec
     // This effectively sorts the orders by viability with a slight randomness to not get stuck on
     // bad orders.
     match user_orders.choose_multiple_weighted(&mut rng, user_orders.len(), |order| {
-        estimate_price_viability(order, prices)
+        let price_viability = estimate_price_viability(order, prices);
+        order_prioritization_config.apply_weight_constraints(price_viability)
     }) {
         Ok(weighted_user_orders) => weighted_user_orders.into_iter().cloned().collect(),
         Err(_) => {
@@ -204,6 +281,7 @@ mod tests {
             metrics: Arc::new(NoopMetrics::default()),
             max_merged_settlements: 5,
             max_settlements_per_solver: 5,
+            order_prioritization_config: Default::default(),
         }
     }
 
@@ -338,7 +416,7 @@ mod tests {
 
     #[ignore] // ignore this test because it could fail due to randomness
     #[test]
-    fn orders_get_prioritized() {
+    fn spread_orders_get_prioritized() {
         let token = H160::from_low_u64_be;
         let amount = U256::from;
         let order = |sell_amount: u128, is_liquidity_order: bool| LimitOrder {
@@ -351,9 +429,9 @@ mod tests {
         };
         let orders = [
             order(500, true),
+            order(90, false),
             order(100, false),
-            order(2_000, false),
-            order(30_000, false),
+            order(130, false),
         ];
         let prices = ExternalPrices::new(
             token(0),
@@ -364,12 +442,51 @@ mod tests {
         )
         .unwrap();
 
+        let config = Arguments::default();
+
         const SAMPLES: usize = 1_000;
         let mut expected_results = 0;
         for _ in 0..SAMPLES {
-            let prioritized_orders = get_prioritized_orders(&orders, &prices);
-            let expected_output = &[order(30_000, false), order(2_000, false), order(100, false)];
+            let prioritized_orders = get_prioritized_orders(&orders, &prices, &config);
+            let expected_output = &[orders[3].clone(), orders[2].clone(), orders[1].clone()];
             expected_results += usize::from(prioritized_orders == expected_output);
+        }
+        // Using weighted selection should give us some suboptimal orderings even with skewed
+        // weights.
+        dbg!(expected_results);
+        assert!((expected_results as f64) < (SAMPLES as f64 * 0.9));
+    }
+
+    #[ignore] // ignore this test because it could fail due to randomness
+    #[test]
+    fn tight_orders_get_prioritized() {
+        let token = H160::from_low_u64_be;
+        let amount = U256::from;
+        let order = |sell_amount: u128, is_liquidity_order: bool| LimitOrder {
+            sell_token: token(1),
+            sell_amount: amount(sell_amount),
+            buy_token: token(2),
+            buy_amount: amount(100),
+            is_liquidity_order,
+            ..Default::default()
+        };
+        let orders = [order(105, false), order(103, false), order(101, false)];
+        let prices = ExternalPrices::new(
+            token(0),
+            hashmap! {
+                token(1) => BigRational::from_u8(100).unwrap(),
+                token(2) => BigRational::from_u8(100).unwrap(),
+            },
+        )
+        .unwrap();
+
+        let config = Arguments::default();
+
+        const SAMPLES: usize = 1_000;
+        let mut expected_results = 0;
+        for _ in 0..SAMPLES {
+            let prioritized_orders = get_prioritized_orders(&orders, &prices, &config);
+            expected_results += usize::from(prioritized_orders == orders);
         }
         // Using weighted selection should give us some suboptimal orderings even with skewed
         // weights.

--- a/crates/solver/src/solver/single_order_solver.rs
+++ b/crates/solver/src/solver/single_order_solver.rs
@@ -201,6 +201,8 @@ mod tests {
         let handler = Arc::new(CapturingSettlementHandler::default());
         let order = LimitOrder {
             settlement_handling: handler.clone(),
+            is_liquidity_order: false,
+            buy_amount: 1.into(),
             ..Default::default()
         };
         let orders = vec![


### PR DESCRIPTION
Fixes #753

With the release of the limit order feature we expect that we have to handle a lot more orders. The `SingleOrderSolver` (aptly named) can only solve a single order at a time and every order takes some amount of time. Because the `SingleOrderSolver`s can be quite slow solving an entire `Auction` is already time boxed.
To improve the chances to work on orders that can actually be settled and make the most of our the time we have we want to prioritize orders which are generously priced; meaning that they want to sell a lot and buy a little (denominated in ETH).

Since the auction already gives us prices for all the traded tokens in the order we can simply use those to compute each order's native `sell_amount` and `buy_amount` and prioritize the orders based on their ratio.
Note that we had issues in the past with deterministic order ordering because all `SingleOrderSolver`s would get stuck on "bad" orders. That's why we don't simply sort the orders by their price but assign a weight (based on its price) to each order and pick randomly from the weighted orders. That effectively gives us a semi-random ordering where orders which are generously priced have a higher chance to get solved early than orders with close to market pricing.

### Test Plan
Added unit test but it's ignored because it could fail randomly with a very low probability.
