### PR TITLE
Forward Order Maturity to Solvers

### DIFF
--- a/crates/driver/src/arguments.rs
+++ b/crates/driver/src/arguments.rs
@@ -308,6 +308,7 @@ impl std::fmt::Display for Arguments {
             "fee_objective_scaling_factor: {}",
             self.fee_objective_scaling_factor,
         )?;
+        writeln!(f, "min_order_age: {:?}", self.min_order_age,)?;
         writeln!(f, "transaction_strategy: {:?}", self.transaction_strategy)?;
         writeln!(f, "eden_api_url: {}", self.eden_api_url)?;
         writeln!(

--- a/crates/driver/src/arguments.rs
+++ b/crates/driver/src/arguments.rs
@@ -71,6 +71,17 @@ pub struct Arguments {
     #[clap(long, env, default_value = "1", value_parser = shared::arguments::parse_unbounded_factor)]
     pub fee_objective_scaling_factor: f64,
 
+    /// A settlement must contain at least one order older than this duration in seconds for it
+    /// to be applied.  Larger values delay individual settlements more but have a higher
+    /// coincidence of wants chance.
+    #[clap(
+        long,
+        env,
+        default_value = "30",
+        value_parser = shared::arguments::duration_from_seconds,
+    )]
+    pub min_order_age: Duration,
+
     /// How to to submit settlement transactions.
     /// Expected to contain either:
     /// 1. One value equal to TransactionStrategyArg::DryRun or

--- a/crates/driver/src/auction_converter.rs
+++ b/crates/driver/src/auction_converter.rs
@@ -202,6 +202,7 @@ mod tests {
         let order_converter = Arc::new(OrderConverter {
             native_token: native_token.clone(),
             fee_objective_scaling_factor: 2.,
+            min_order_age: Duration::from_secs(30),
         });
         let converter = AuctionConverter::new(
             gas_estimator,

--- a/crates/driver/src/main.rs
+++ b/crates/driver/src/main.rs
@@ -121,6 +121,7 @@ async fn init_common_components(args: &Arguments) -> CommonComponents {
     let order_converter = Arc::new(OrderConverter {
         native_token: native_token_contract.clone(),
         fee_objective_scaling_factor: args.fee_objective_scaling_factor,
+        min_order_age: args.min_order_age,
     });
 
     CommonComponents {

--- a/crates/e2e/tests/e2e/services.rs
+++ b/crates/e2e/tests/e2e/services.rs
@@ -149,7 +149,7 @@ pub fn create_order_converter(web3: &Web3, weth_address: H160) -> Arc<OrderConve
     Arc::new(OrderConverter {
         native_token: WETH9::at(web3, weth_address),
         fee_objective_scaling_factor: 1.,
-        min_order_age: Duration::from_secs(30),
+        min_order_age: Duration::from_secs(0),
     })
 }
 

--- a/crates/e2e/tests/e2e/services.rs
+++ b/crates/e2e/tests/e2e/services.rs
@@ -149,6 +149,7 @@ pub fn create_order_converter(web3: &Web3, weth_address: H160) -> Arc<OrderConve
     Arc::new(OrderConverter {
         native_token: WETH9::at(web3, weth_address),
         fee_objective_scaling_factor: 1.,
+        min_order_age: Duration::from_secs(30),
     })
 }
 

--- a/crates/shared/src/http_solver/model.rs
+++ b/crates/shared/src/http_solver/model.rs
@@ -1,3 +1,4 @@
+use chrono::{DateTime, Utc};
 use derivative::Derivative;
 use ethcontract::{Bytes, H160};
 use model::{
@@ -31,6 +32,7 @@ pub struct BatchAuctionModel {
 pub struct OrderModel {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub id: Option<OrderUid>,
+    pub created_at: DateTime<Utc>,
     pub sell_token: H160,
     pub buy_token: H160,
     #[serde(with = "u256_decimal")]
@@ -418,6 +420,7 @@ mod tests {
     };
     use serde_json::json;
     use web3::types::AccessListItem;
+    use chrono::NaiveDateTime;
 
     #[test]
     fn updated_amm_model_is_non_trivial() {
@@ -486,6 +489,7 @@ mod tests {
         let sell_token = H160::from_low_u64_be(43110);
         let order_model = OrderModel {
             id: Some(OrderUid::default()),
+            created_at: DateTime::from_utc(NaiveDateTime::from_timestamp(2, 0), Utc),
             sell_token,
             buy_token,
             sell_amount: U256::from(1),
@@ -642,6 +646,7 @@ mod tests {
           "orders": {
             "0": {
               "id": "0x0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+              "created_at": "1970-01-01T00:00:02Z",
               "sell_token": "0x000000000000000000000000000000000000a866",
               "buy_token": "0x0000000000000000000000000000000000000539",
               "sell_amount": "1",

--- a/crates/shared/src/http_solver/model.rs
+++ b/crates/shared/src/http_solver/model.rs
@@ -412,6 +412,7 @@ mod tests {
     use crate::sources::uniswap_v3::graph_api::Token;
 
     use super::*;
+    use chrono::NaiveDateTime;
     use ethcontract::H256;
     use maplit::btreemap;
     use model::{
@@ -420,7 +421,6 @@ mod tests {
     };
     use serde_json::json;
     use web3::types::AccessListItem;
-    use chrono::NaiveDateTime;
 
     #[test]
     fn updated_amm_model_is_non_trivial() {

--- a/crates/shared/src/http_solver/model.rs
+++ b/crates/shared/src/http_solver/model.rs
@@ -1,4 +1,3 @@
-use chrono::{DateTime, Utc};
 use derivative::Derivative;
 use ethcontract::{Bytes, H160};
 use model::{
@@ -32,7 +31,6 @@ pub struct BatchAuctionModel {
 pub struct OrderModel {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub id: Option<OrderUid>,
-    pub created_at: DateTime<Utc>,
     pub sell_token: H160,
     pub buy_token: H160,
     #[serde(with = "u256_decimal")]
@@ -44,6 +42,7 @@ pub struct OrderModel {
     pub fee: TokenAmount,
     pub cost: TokenAmount,
     pub is_liquidity_order: bool,
+    pub is_mature: bool,
     #[serde(default)]
     pub mandatory: bool,
     /// Signals if the order will be executed as an atomic unit. In that case the order's
@@ -412,7 +411,6 @@ mod tests {
     use crate::sources::uniswap_v3::graph_api::Token;
 
     use super::*;
-    use chrono::NaiveDateTime;
     use ethcontract::H256;
     use maplit::btreemap;
     use model::{
@@ -489,7 +487,6 @@ mod tests {
         let sell_token = H160::from_low_u64_be(43110);
         let order_model = OrderModel {
             id: Some(OrderUid::default()),
-            created_at: DateTime::from_utc(NaiveDateTime::from_timestamp(2, 0), Utc),
             sell_token,
             buy_token,
             sell_amount: U256::from(1),
@@ -508,6 +505,7 @@ mod tests {
             mandatory: false,
             has_atomic_execution: false,
             reward: 3.,
+            is_mature: false,
         };
         let constant_product_pool_model = AmmModel {
             parameters: AmmParameters::ConstantProduct(ConstantProductPoolParameters {
@@ -646,7 +644,6 @@ mod tests {
           "orders": {
             "0": {
               "id": "0x0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
-              "created_at": "1970-01-01T00:00:02Z",
               "sell_token": "0x000000000000000000000000000000000000a866",
               "buy_token": "0x0000000000000000000000000000000000000539",
               "sell_amount": "1",
@@ -664,7 +661,8 @@ mod tests {
               },
               "mandatory": false,
               "has_atomic_execution": false,
-              "reward": 3.0
+              "reward": 3.0,
+              "is_mature": false,
             },
           },
           "amms": {

--- a/crates/shared/src/price_estimation/http.rs
+++ b/crates/shared/src/price_estimation/http.rs
@@ -94,7 +94,6 @@ impl HttpPriceEstimator {
         let orders = maplit::btreemap! {
             0 => OrderModel {
                 id: Default::default(),
-                created_at: Default::default(),
                 sell_token: query.sell_token,
                 buy_token: query.buy_token,
                 sell_amount,
@@ -114,6 +113,7 @@ impl HttpPriceEstimator {
                 has_atomic_execution: false,
                 // TODO: is it possible to set a more accurate reward?
                 reward: 35.,
+                is_mature: true, // irrelevant for price estimation
             },
         };
 

--- a/crates/shared/src/price_estimation/http.rs
+++ b/crates/shared/src/price_estimation/http.rs
@@ -94,6 +94,7 @@ impl HttpPriceEstimator {
         let orders = maplit::btreemap! {
             0 => OrderModel {
                 id: Default::default(),
+                created_at: Default::default(),
                 sell_token: query.sell_token,
                 buy_token: query.buy_token,
                 sell_amount,

--- a/crates/solver/src/auction_preprocessing.rs
+++ b/crates/solver/src/auction_preprocessing.rs
@@ -2,8 +2,10 @@
 
 use crate::liquidity::LimitOrder;
 
-// vk: I would like to extend this to also check that the order has minimum age but for this we need
-// access to the creation date which is a more involved change.
 pub fn has_at_least_one_user_order(orders: &[LimitOrder]) -> bool {
     orders.iter().any(|order| !order.is_liquidity_order)
+}
+
+pub fn has_at_least_one_mature_order(orders: &[LimitOrder]) -> bool {
+    orders.iter().any(|order| order.is_mature)
 }

--- a/crates/solver/src/driver.rs
+++ b/crates/solver/src/driver.rs
@@ -272,7 +272,9 @@ impl Driver {
         self.metrics.orders_fetched(&orders);
         self.metrics.liquidity_fetched(&liquidity);
 
-        if !auction_preprocessing::has_at_least_one_user_order(&orders) {
+        if !auction_preprocessing::has_at_least_one_user_order(&orders)
+            || !auction_preprocessing::has_at_least_one_mature_order(&orders)
+        {
             return Ok(());
         }
 

--- a/crates/solver/src/liquidity.rs
+++ b/crates/solver/src/liquidity.rs
@@ -7,7 +7,6 @@ pub mod zeroex;
 
 use crate::settlement::SettlementEncoder;
 use anyhow::Result;
-use chrono::{DateTime, Utc};
 #[cfg(test)]
 use derivative::Derivative;
 #[cfg(test)]
@@ -134,7 +133,6 @@ impl From<u32> for LimitOrderUid {
 pub struct LimitOrder {
     // Opaque Identifier for debugging purposes
     pub id: LimitOrderUid,
-    pub created_at: DateTime<Utc>,
     pub sell_token: H160,
     pub buy_token: H160,
     pub sell_amount: U256,
@@ -150,6 +148,7 @@ pub struct LimitOrder {
     /// perspective.
     pub scaled_unsubsidized_fee: U256,
     pub is_liquidity_order: bool,
+    /// Indicator if the order is mature at the creation of the Auction. Relevant to user orders.
     pub is_mature: bool,
     #[cfg_attr(test, derivative(PartialEq = "ignore"))]
     pub settlement_handling: Arc<dyn SettlementHandling<Self>>,
@@ -208,7 +207,6 @@ impl Default for LimitOrder {
             is_liquidity_order: false,
             is_mature: false,
             id: Default::default(),
-            created_at: Default::default(),
             exchange: Exchange::GnosisProtocol,
             reward: Default::default(),
         }

--- a/crates/solver/src/liquidity.rs
+++ b/crates/solver/src/liquidity.rs
@@ -150,6 +150,7 @@ pub struct LimitOrder {
     /// perspective.
     pub scaled_unsubsidized_fee: U256,
     pub is_liquidity_order: bool,
+    pub is_mature: bool,
     #[cfg_attr(test, derivative(PartialEq = "ignore"))]
     pub settlement_handling: Arc<dyn SettlementHandling<Self>>,
     pub exchange: Exchange,
@@ -205,6 +206,7 @@ impl Default for LimitOrder {
             scaled_unsubsidized_fee: Default::default(),
             settlement_handling: tests::CapturingSettlementHandler::arc(),
             is_liquidity_order: false,
+            is_mature: false,
             id: Default::default(),
             created_at: Default::default(),
             exchange: Exchange::GnosisProtocol,

--- a/crates/solver/src/liquidity.rs
+++ b/crates/solver/src/liquidity.rs
@@ -7,6 +7,7 @@ pub mod zeroex;
 
 use crate::settlement::SettlementEncoder;
 use anyhow::Result;
+use chrono::{DateTime, Utc};
 #[cfg(test)]
 use derivative::Derivative;
 #[cfg(test)]
@@ -28,7 +29,6 @@ use shared::sources::{
 };
 use std::{collections::HashMap, sync::Arc};
 use strum::{EnumVariantNames, IntoStaticStr};
-use chrono::{DateTime, Utc};
 
 /// Defines the different types of liquidity our solvers support
 #[derive(Clone, IntoStaticStr, EnumVariantNames, Debug)]

--- a/crates/solver/src/liquidity.rs
+++ b/crates/solver/src/liquidity.rs
@@ -28,6 +28,7 @@ use shared::sources::{
 };
 use std::{collections::HashMap, sync::Arc};
 use strum::{EnumVariantNames, IntoStaticStr};
+use chrono::{DateTime, Utc};
 
 /// Defines the different types of liquidity our solvers support
 #[derive(Clone, IntoStaticStr, EnumVariantNames, Debug)]
@@ -133,6 +134,7 @@ impl From<u32> for LimitOrderUid {
 pub struct LimitOrder {
     // Opaque Identifier for debugging purposes
     pub id: LimitOrderUid,
+    pub created_at: DateTime<Utc>,
     pub sell_token: H160,
     pub buy_token: H160,
     pub sell_amount: U256,
@@ -204,6 +206,7 @@ impl Default for LimitOrder {
             settlement_handling: tests::CapturingSettlementHandler::arc(),
             is_liquidity_order: false,
             id: Default::default(),
+            created_at: Default::default(),
             exchange: Exchange::GnosisProtocol,
             reward: Default::default(),
         }

--- a/crates/solver/src/liquidity/order_converter.rs
+++ b/crates/solver/src/liquidity/order_converter.rs
@@ -4,11 +4,12 @@ use anyhow::{Context, Result};
 use contracts::WETH9;
 use ethcontract::U256;
 use model::order::{Order, OrderClass, BUY_ETH_ADDRESS};
-use std::sync::Arc;
+use std::{sync::Arc, time::Duration};
 
 pub struct OrderConverter {
     pub native_token: WETH9,
     pub fee_objective_scaling_factor: f64,
+    pub min_order_age: Duration,
 }
 
 impl OrderConverter {
@@ -19,6 +20,7 @@ impl OrderConverter {
         Self {
             native_token: shared::dummy_contract!(WETH9, native_token),
             fee_objective_scaling_factor: 1.,
+            min_order_age: Duration::from_secs(30),
         }
     }
 
@@ -42,6 +44,9 @@ impl OrderConverter {
                 * self.fee_objective_scaling_factor,
         );
         let is_liquidity_order = order.metadata.class == OrderClass::Liquidity;
+        let is_mature = order.metadata.creation_date
+            + chrono::Duration::from_std(self.min_order_age).unwrap()
+            <= chrono::offset::Utc::now();
 
         let (sell_amount, fee_amount) = match order.metadata.class {
             OrderClass::Limit => compute_synthetic_order_amounts_for_limit_order(&order)?,
@@ -68,6 +73,7 @@ impl OrderConverter {
             exchange: Exchange::GnosisProtocol,
             // TODO: It would be nicer to set this here too but we need #529 first.
             reward: 0.,
+            is_mature,
         })
     }
 }

--- a/crates/solver/src/liquidity/order_converter.rs
+++ b/crates/solver/src/liquidity/order_converter.rs
@@ -50,6 +50,7 @@ impl OrderConverter {
 
         Ok(LimitOrder {
             id: order.metadata.uid.into(),
+            created_at: order.metadata.creation_date,
             sell_token: order.data.sell_token,
             buy_token,
             sell_amount: remaining.remaining(sell_amount)?,

--- a/crates/solver/src/liquidity/order_converter.rs
+++ b/crates/solver/src/liquidity/order_converter.rs
@@ -55,7 +55,6 @@ impl OrderConverter {
 
         Ok(LimitOrder {
             id: order.metadata.uid.into(),
-            created_at: order.metadata.creation_date,
             sell_token: order.data.sell_token,
             buy_token,
             sell_amount: remaining.remaining(sell_amount)?,

--- a/crates/solver/src/liquidity/zeroex.rs
+++ b/crates/solver/src/liquidity/zeroex.rs
@@ -112,6 +112,7 @@ impl ZeroExLiquidity {
 
         let limit_order = LimitOrder {
             id: LimitOrderUid::ZeroEx(hex::encode(&record.metadata.order_hash)),
+            created_at: record.metadata.created_at,
             sell_token: record.order.maker_token,
             buy_token: record.order.taker_token,
             sell_amount,

--- a/crates/solver/src/liquidity/zeroex.rs
+++ b/crates/solver/src/liquidity/zeroex.rs
@@ -112,7 +112,6 @@ impl ZeroExLiquidity {
 
         let limit_order = LimitOrder {
             id: LimitOrderUid::ZeroEx(hex::encode(&record.metadata.order_hash)),
-            created_at: record.metadata.created_at,
             sell_token: record.order.maker_token,
             buy_token: record.order.taker_token,
             sell_amount,

--- a/crates/solver/src/liquidity/zeroex.rs
+++ b/crates/solver/src/liquidity/zeroex.rs
@@ -129,6 +129,7 @@ impl ZeroExLiquidity {
             }),
             exchange: Exchange::ZeroEx,
             reward: 0.,
+            is_mature: false, // irrelevant for liquidity orders
         };
         Some(Liquidity::LimitOrder(limit_order))
     }

--- a/crates/solver/src/main.rs
+++ b/crates/solver/src/main.rs
@@ -211,6 +211,7 @@ async fn main() {
     let order_converter = Arc::new(OrderConverter {
         native_token: native_token_contract.clone(),
         fee_objective_scaling_factor: args.fee_objective_scaling_factor,
+        min_order_age: args.min_order_age,
     });
 
     let market_makable_token_list_configuration = TokenListConfiguration {

--- a/crates/solver/src/settlement_simulation.rs
+++ b/crates/solver/src/settlement_simulation.rs
@@ -340,6 +340,7 @@ mod tests {
         let order_converter = OrderConverter {
             native_token: native_token_contract.clone(),
             fee_objective_scaling_factor: 0.91_f64,
+            min_order_age: std::time::Duration::from_secs(30),
         };
         let value = json!(
         {

--- a/crates/solver/src/solver/http_solver.rs
+++ b/crates/solver/src/solver/http_solver.rs
@@ -304,6 +304,7 @@ fn order_models(
                 index,
                 OrderModel {
                     id: order.id.order_uid(),
+                    created_at: order.created_at,
                     sell_token: order.sell_token,
                     buy_token: order.buy_token,
                     sell_amount: order.sell_amount,

--- a/crates/solver/src/solver/http_solver.rs
+++ b/crates/solver/src/solver/http_solver.rs
@@ -304,7 +304,6 @@ fn order_models(
                 index,
                 OrderModel {
                     id: order.id.order_uid(),
-                    created_at: order.created_at,
                     sell_token: order.sell_token,
                     buy_token: order.buy_token,
                     sell_amount: order.sell_amount,
@@ -317,6 +316,7 @@ fn order_models(
                     mandatory: false,
                     has_atomic_execution: !matches!(order.exchange, Exchange::GnosisProtocol),
                     reward: order.reward,
+                    is_mature: order.is_mature,
                 },
             ))
         })


### PR DESCRIPTION
This PR defines each order maturity at the beginning of each `Auction`. Then forwards this information to all solvers.
This will allow solvers to be smarter about our order maturity logic and avoid creating settlement that will fail the maturity check in the driver.

Makes sense to add this since I expect all solvers to use this to optimize their algorithms.

### Test Plan

Updated unit tests.

### Release notes

Changed data format for `solve` endpoint. Solvers should be notified about new `is_mature` field.
