### PR TITLE
Consider Limit Orders as User Orders

### DIFF
--- a/crates/solver/src/driver/solver_settlements.rs
+++ b/crates/solver/src/driver/solver_settlements.rs
@@ -134,7 +134,7 @@ pub fn retain_mature_settlements(
                     || valid_trades.contains(&trade.order.metadata.uid)
                 });
 
-                if contains_valid_order_trade {
+                if contains_valid_user_trade {
                     for trade in settlement.user_trades() {
                         // make all user orders within this settlement mature by association
                         new_order_added |= valid_trades.insert(&trade.order.metadata.uid);

--- a/crates/solver/src/driver/solver_settlements.rs
+++ b/crates/solver/src/driver/solver_settlements.rs
@@ -127,7 +127,7 @@ pub fn retain_mature_settlements(
                     break;
                 }
 
-                let contains_valid_order_trade = settlement.user_trades().any(|trade| {
+                let contains_valid_user_trade = settlement.user_trades().any(|trade| {
                     // mature by age
                     trade.order.metadata.creation_date <= settle_orders_older_than
                     // mature by association

--- a/crates/solver/src/driver/solver_settlements.rs
+++ b/crates/solver/src/driver/solver_settlements.rs
@@ -12,7 +12,7 @@ use shared::{
 use std::{collections::HashSet, sync::Arc, time::Duration};
 
 pub fn has_user_order(settlement: &Settlement) -> bool {
-    !settlement.encoder.order_trades().is_empty()
+    settlement.user_trades().next().is_some()
 }
 
 // Each individual settlement has an objective value.
@@ -127,18 +127,17 @@ pub fn retain_mature_settlements(
                     break;
                 }
 
-                let contains_valid_order_trade =
-                    settlement.encoder.order_trades().iter().any(|order| {
-                        // mature by age
-                        order.trade.order.metadata.creation_date <= settle_orders_older_than
+                let contains_valid_order_trade = settlement.user_trades().any(|trade| {
+                    // mature by age
+                    trade.order.metadata.creation_date <= settle_orders_older_than
                     // mature by association
-                    || valid_trades.contains(&order.trade.order.metadata.uid)
-                    });
+                    || valid_trades.contains(&trade.order.metadata.uid)
+                });
 
                 if contains_valid_order_trade {
-                    for order in settlement.encoder.order_trades().iter() {
+                    for trade in settlement.user_trades() {
                         // make all user orders within this settlement mature by association
-                        new_order_added |= valid_trades.insert(&order.trade.order.metadata.uid);
+                        new_order_added |= valid_trades.insert(&trade.order.metadata.uid);
                     }
                     valid_settlement_indices.insert(index);
                 }
@@ -184,7 +183,7 @@ mod tests {
     };
     use chrono::{offset::Utc, DateTime, Duration, Local};
     use maplit::hashmap;
-    use model::order::{Order, OrderData, OrderKind, OrderMetadata, OrderUid};
+    use model::order::{Order, OrderClass, OrderData, OrderKind, OrderMetadata, OrderUid};
     use num::{BigRational, One as _};
     use primitive_types::{H160, U256};
     use std::{collections::HashSet, ops::Sub};
@@ -206,6 +205,24 @@ mod tests {
         }
     }
 
+    fn limit_trade(created_at: DateTime<Utc>, uid: u8) -> CustomPriceTrade {
+        CustomPriceTrade {
+            trade: Trade {
+                order: Order {
+                    metadata: OrderMetadata {
+                        creation_date: created_at,
+                        uid: OrderUid([uid; 56]),
+                        class: OrderClass::Limit,
+                        ..Default::default()
+                    },
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+            ..Default::default()
+        }
+    }
+
     fn liquidity_trade(created_at: DateTime<Utc>, uid: u8) -> CustomPriceTrade {
         CustomPriceTrade {
             trade: Trade {
@@ -213,6 +230,7 @@ mod tests {
                     metadata: OrderMetadata {
                         creation_date: created_at,
                         uid: OrderUid([uid; 56]),
+                        class: OrderClass::Liquidity,
                         ..Default::default()
                     },
                     ..Default::default()
@@ -244,8 +262,8 @@ mod tests {
     fn assert_same_settlements(expected: &[Settlement], actual: &[Settlement]) {
         assert!(expected
             .iter()
-            .map(|s| s.encoder.order_trades())
-            .eq(actual.iter().map(|s| s.encoder.order_trades())));
+            .map(|s| s.trades().collect::<Vec<_>>())
+            .eq(actual.iter().map(|s| s.trades().collect::<Vec<_>>())));
     }
 
     #[test]
@@ -279,7 +297,7 @@ mod tests {
         let settlement = |trades, liquidity_order_trades| {
             Settlement::with_trades(hashmap!(), trades, liquidity_order_trades)
         };
-        let s1 = settlement(vec![trade(old, 1), trade(recent, 2)], vec![]);
+        let s1 = settlement(vec![trade(old, 1)], vec![limit_trade(recent, 2)]);
         let s2 = settlement(vec![trade(recent, 3), trade(recent, 4)], vec![]);
         let s3 = settlement(vec![trade(recent, 5)], vec![liquidity_trade(old, 6)]);
         let settlements = vec![s1.clone(), s2, s3];
@@ -522,13 +540,34 @@ mod tests {
 
     #[test]
     fn has_user_order_() {
+        let custom_price_order = |class| CustomPriceTrade {
+            trade: Trade {
+                order: Order {
+                    metadata: OrderMetadata {
+                        class,
+                        ..Default::default()
+                    },
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
         let settlement = Settlement::with_trades(Default::default(), vec![], vec![]);
         assert!(!has_user_order(&settlement));
 
         let settlement = Settlement::with_trades(
             Default::default(),
             vec![],
-            vec![CustomPriceTrade::default()],
+            vec![custom_price_order(OrderClass::Limit)],
+        );
+        assert!(has_user_order(&settlement));
+
+        let settlement = Settlement::with_trades(
+            Default::default(),
+            vec![],
+            vec![custom_price_order(OrderClass::Liquidity)],
         );
         assert!(!has_user_order(&settlement));
 
@@ -541,7 +580,17 @@ mod tests {
             vec![OrderTrade {
                 ..Default::default()
             }],
-            vec![CustomPriceTrade::default()],
+            vec![custom_price_order(OrderClass::Liquidity)],
+        );
+        assert!(has_user_order(&settlement));
+
+        let settlement = Settlement::with_trades(
+            Default::default(),
+            vec![],
+            vec![
+                custom_price_order(OrderClass::Liquidity),
+                custom_price_order(OrderClass::Limit),
+            ],
         );
         assert!(has_user_order(&settlement));
     }

--- a/crates/solver/src/driver_logger.rs
+++ b/crates/solver/src/driver_logger.rs
@@ -57,8 +57,7 @@ impl DriverLogger {
     fn get_traded_orders(settlement: &Settlement) -> Vec<Order> {
         let mut traded_orders = Vec::new();
         for (_, group) in &settlement
-            .executed_trades()
-            .map(|(trade, _)| trade)
+            .trades()
             .group_by(|trade| trade.order.metadata.uid)
         {
             let mut group = group.into_iter().peekable();

--- a/crates/solver/src/settlement.rs
+++ b/crates/solver/src/settlement.rs
@@ -348,7 +348,7 @@ impl Settlement {
             .map(|execution| execution.expect("invalid trade was added to encoder"))
     }
 
-    /// Returns an iterator over all user trades.
+    /// Returns an iterator over all trades.
     pub fn trades(&self) -> impl Iterator<Item = &'_ Trade> + '_ {
         self.encoder.trades().map(move |trade| match trade {
             EncoderTrade::Order(order_trade) => &order_trade.trade,

--- a/crates/solver/src/settlement.rs
+++ b/crates/solver/src/settlement.rs
@@ -3,7 +3,7 @@ mod settlement_encoder;
 
 use self::external_prices::ExternalPrices;
 pub use self::settlement_encoder::{
-    verify_executed_amount, InternalizationStrategy, SettlementEncoder,
+    verify_executed_amount, EncoderTrade, InternalizationStrategy, SettlementEncoder,
 };
 use crate::{
     encoding::{self, EncodedSettlement, EncodedTrade},
@@ -11,7 +11,7 @@ use crate::{
 };
 use anyhow::Result;
 use itertools::Itertools;
-use model::order::{Order, OrderKind};
+use model::order::{Order, OrderClass, OrderKind};
 use num::{rational::Ratio, BigInt, BigRational, One, Signed, Zero};
 use primitive_types::{H160, U256};
 use shared::conversions::U256Ext as _;
@@ -319,49 +319,51 @@ impl Settlement {
 
     /// Returns all orders included in the settlement.
     pub fn traded_orders(&self) -> impl Iterator<Item = &Order> + '_ {
-        let user_orders = self
-            .encoder
-            .order_trades()
-            .iter()
-            .map(|trade| &trade.trade.order);
-        let custom_trades = self
-            .encoder
-            .custom_price_trades()
-            .iter()
-            .map(|trade| &trade.trade.order);
-        user_orders.chain(custom_trades)
+        self.encoder.trades().map(move |trade| match trade {
+            EncoderTrade::Order(order_trade) => &order_trade.trade.order,
+            EncoderTrade::CustomPrice(custom_price_trade) => &custom_price_trade.trade.order,
+        })
     }
 
     /// Returns an iterator of all executed trades.
-    pub fn executed_trades(&self) -> impl Iterator<Item = (&'_ Trade, TradeExecution)> + '_ {
-        let order_trades = self.encoder.order_trades().iter().map(move |order_trade| {
-            let order = &order_trade.trade.order.data;
-            order_trade
-                .trade
-                .executed_amounts(
-                    self.clearing_price(order.sell_token)?,
-                    self.clearing_price(order.buy_token)?,
-                )
-                .map(|execution| (&order_trade.trade, execution))
-        });
-        let custom_price_trades =
-            self.encoder
-                .custom_price_trades()
-                .iter()
-                .map(move |custom_price_trade| {
+    pub fn trade_executions(&self) -> impl Iterator<Item = TradeExecution> + '_ {
+        self.encoder
+            .trades()
+            .map(move |trade| match trade {
+                EncoderTrade::Order(order_trade) => {
+                    let order = &order_trade.trade.order.data;
+                    order_trade.trade.executed_amounts(
+                        self.clearing_price(order.sell_token)?,
+                        self.clearing_price(order.buy_token)?,
+                    )
+                }
+                EncoderTrade::CustomPrice(custom_price_trade) => {
                     let order = &custom_price_trade.trade.order.data;
-                    custom_price_trade
-                        .trade
-                        .executed_amounts(
-                            self.clearing_price(order.sell_token)?,
-                            custom_price_trade.buy_token_price,
-                        )
-                        .map(|execution| (&custom_price_trade.trade, execution))
-                });
-
-        order_trades
-            .chain(custom_price_trades)
+                    custom_price_trade.trade.executed_amounts(
+                        self.clearing_price(order.sell_token)?,
+                        custom_price_trade.buy_token_price,
+                    )
+                }
+            })
             .map(|execution| execution.expect("invalid trade was added to encoder"))
+    }
+
+    /// Returns an iterator over all user trades.
+    pub fn trades(&self) -> impl Iterator<Item = &'_ Trade> + '_ {
+        self.encoder.trades().map(move |trade| match trade {
+            EncoderTrade::Order(order_trade) => &order_trade.trade,
+            EncoderTrade::CustomPrice(custom_price_trade) => &custom_price_trade.trade,
+        })
+    }
+
+    /// Returns an iterator over all user trades.
+    pub fn user_trades(&self) -> impl Iterator<Item = &'_ Trade> + '_ {
+        self.trades()
+            // full match so we get compilation error when new variant is added
+            .filter(|trade| match trade.order.metadata.class {
+                OrderClass::Market | OrderClass::Limit => true,
+                OrderClass::Liquidity => false,
+            })
     }
 
     // Computes the total surplus of all protocol trades (in wei ETH).
@@ -445,16 +447,11 @@ impl Settlement {
 
     // Computes the total scaled unsubsidized fee of all protocol trades (in wei ETH).
     pub fn total_scaled_unsubsidized_fees(&self, external_prices: &ExternalPrices) -> BigRational {
-        self.encoder
-            .order_trades()
-            .iter()
-            .filter_map(|order_trade| {
+        self.user_trades()
+            .filter_map(|trade| {
                 external_prices.try_get_native_amount(
-                    order_trade.trade.order.data.sell_token,
-                    order_trade
-                        .trade
-                        .executed_scaled_unsubsidized_fee()?
-                        .to_big_rational(),
+                    trade.order.data.sell_token,
+                    trade.executed_scaled_unsubsidized_fee()?.to_big_rational(),
                 )
             })
             .sum()
@@ -462,16 +459,11 @@ impl Settlement {
 
     // Computes the total scaled unsubsidized fee of all protocol trades (in wei ETH).
     pub fn total_unscaled_subsidized_fees(&self, external_prices: &ExternalPrices) -> BigRational {
-        self.encoder
-            .order_trades()
-            .iter()
-            .filter_map(|order_trade| {
+        self.user_trades()
+            .filter_map(|trade| {
                 external_prices.try_get_native_amount(
-                    order_trade.trade.order.data.sell_token,
-                    order_trade
-                        .trade
-                        .executed_unscaled_subsidized_fee()?
-                        .to_big_rational(),
+                    trade.order.data.sell_token,
+                    trade.executed_unscaled_subsidized_fee()?.to_big_rational(),
                 )
             })
             .sum()
@@ -572,7 +564,7 @@ pub mod tests {
     use super::*;
     use crate::{liquidity::SettlementHandling, settlement::external_prices::externalprices};
     use maplit::hashmap;
-    use model::order::{OrderData, OrderKind};
+    use model::order::{OrderData, OrderKind, OrderMetadata};
     use num::FromPrimitive;
     use shared::addr;
 
@@ -1420,6 +1412,10 @@ pub mod tests {
                             buy_amount: 99760667014_u128.into(),
                             fee_amount: 10650127_u128.into(),
                             kind: OrderKind::Buy,
+                            ..Default::default()
+                        },
+                        metadata: OrderMetadata {
+                            class: OrderClass::Liquidity,
                             ..Default::default()
                         },
                         ..Default::default()

--- a/crates/solver/src/settlement/settlement_encoder.rs
+++ b/crates/solver/src/settlement/settlement_encoder.rs
@@ -52,7 +52,7 @@ pub struct SettlementEncoder {
     unwraps: Vec<UnwrapWethInteraction>,
 }
 
-/// An encoded trade.
+/// An trade that was added to the settlement encoder.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum EncoderTrade<'a> {
     Order(&'a OrderTrade),

--- a/crates/solver/src/settlement/settlement_encoder.rs
+++ b/crates/solver/src/settlement/settlement_encoder.rs
@@ -131,15 +131,6 @@ impl SettlementEncoder {
 
         order_trades.chain(custom_price_trades)
     }
-    /*
-    pub fn order_trades(&self) -> &[OrderTrade] {
-        &self.order_trades
-    }
-
-    pub fn custom_price_trades(&self) -> &[CustomPriceTrade] {
-        &self.custom_price_trades
-    }
-    */
 
     pub fn has_interactions(&self) -> bool {
         self.execution_plan

--- a/crates/solver/src/settlement/settlement_encoder.rs
+++ b/crates/solver/src/settlement/settlement_encoder.rs
@@ -52,6 +52,13 @@ pub struct SettlementEncoder {
     unwraps: Vec<UnwrapWethInteraction>,
 }
 
+/// An encoded trade.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum EncoderTrade<'a> {
+    Order(&'a OrderTrade),
+    CustomPrice(&'a CustomPriceTrade),
+}
+
 /// Whether or not internalizable interactions should be encoded as calldata
 pub enum InternalizationStrategy {
     EncodeAllInteractions,
@@ -115,6 +122,16 @@ impl SettlementEncoder {
         &self.clearing_prices
     }
 
+    pub fn trades(&self) -> impl Iterator<Item = EncoderTrade> + '_ {
+        let order_trades = self.order_trades.iter().map(EncoderTrade::Order);
+        let custom_price_trades = self
+            .custom_price_trades
+            .iter()
+            .map(EncoderTrade::CustomPrice);
+
+        order_trades.chain(custom_price_trades)
+    }
+    /*
     pub fn order_trades(&self) -> &[OrderTrade] {
         &self.order_trades
     }
@@ -122,6 +139,7 @@ impl SettlementEncoder {
     pub fn custom_price_trades(&self) -> &[CustomPriceTrade] {
         &self.custom_price_trades
     }
+    */
 
     pub fn has_interactions(&self) -> bool {
         self.execution_plan

--- a/crates/solver/src/settlement_ranker.rs
+++ b/crates/solver/src/settlement_ranker.rs
@@ -141,8 +141,18 @@ impl SettlementRanker {
         // statement allows us to figure out which settlements were filtered out and which ones are
         // going to be simulated and considered for competition.
         for (solver, settlement) in &solver_settlements {
+            let uninternalized_calldata = format!(
+                "0x{}",
+                hex::encode(call_data(
+                    settlement
+                        .encoder
+                        .clone()
+                        .finish(InternalizationStrategy::EncodeAllInteractions)
+                )),
+            );
+
             tracing::debug!(
-                solver_name = %solver.name(), ?settlement, uninternalized_calldata = hex::encode(call_data(settlement.encoder.clone().finish(InternalizationStrategy::EncodeAllInteractions))),
+                solver_name = %solver.name(), ?settlement, %uninternalized_calldata,
                 "considering solution for solver competition",
             );
         }

--- a/crates/solver/src/solver/http_solver/settlement.rs
+++ b/crates/solver/src/solver/http_solver/settlement.rs
@@ -374,7 +374,7 @@ mod tests {
             tests::CapturingSettlementHandler, ConstantProductOrder, StablePoolOrder,
             WeightedProductOrder,
         },
-        settlement::{CustomPriceTrade, Trade},
+        settlement::{CustomPriceTrade, EncoderTrade, Trade},
     };
     use hex_literal::hex;
     use maplit::hashmap;
@@ -567,8 +567,8 @@ mod tests {
         );
 
         assert_eq!(
-            settlement.encoder.custom_price_trades(),
-            [CustomPriceTrade {
+            settlement.encoder.trades().collect::<Vec<_>>(),
+            [EncoderTrade::CustomPrice(&CustomPriceTrade {
                 trade: Trade {
                     order: Order {
                         metadata: OrderMetadata {
@@ -596,7 +596,7 @@ mod tests {
                 },
                 buy_token_offset_index: 0,
                 buy_token_price: (10 * 102 / 101).into(),
-            }]
+            })]
         );
 
         assert_eq!(limit_handler.calls(), vec![7.into()]);

--- a/crates/solver/src/solver/naive_solver/multi_order_solver.rs
+++ b/crates/solver/src/solver/naive_solver/multi_order_solver.rs
@@ -152,13 +152,13 @@ fn solve_with_uniswap(
     // be that we actually require a bit more from the Uniswap pool in order to
     // pay out all proceeds. We move the rounding error to the sell token so that
     // it either comes out of the fees or existing buffers. Compute that amount:
-    let uniswap_out_with_rounding = big_int_to_u256(&settlement.executed_trades().fold(
+    let uniswap_out_with_rounding = big_int_to_u256(&settlement.trade_executions().fold(
         BigInt::default(),
-        |mut total, (_, trade)| {
-            if trade.sell_token == uniswap_out_token {
-                total -= trade.sell_amount.to_big_int();
+        |mut total, execution| {
+            if execution.sell_token == uniswap_out_token {
+                total -= execution.sell_amount.to_big_int();
             } else {
-                total += trade.buy_amount.to_big_int();
+                total += execution.buy_amount.to_big_int();
             };
             total
         },
@@ -985,10 +985,7 @@ mod tests {
         };
 
         let settlement = solve(&SlippageContext::default(), orders, &pool.into()).unwrap();
-        let trades = settlement
-            .executed_trades()
-            .map(|(_, trade)| trade)
-            .collect::<Vec<_>>();
+        let trades = settlement.trade_executions().collect::<Vec<_>>();
 
         // Check the prices are set according to the expected pool swap:
         assert_eq!(settlement.clearing_prices(), &expected_prices);


### PR DESCRIPTION
Throughout the code, we assume `order_trades == user_trades` (in order words, all custom price trades are non-user orders). This is because previously, we only had market and liquidity orders, so the distinction was true.

This PR adds removes `order_trades` and `custom_price_trades` methods in favour of new `trades` (for all trades) and `user_trades` (for user trades) methods, which IMO helps clarify intent as to which trades we care about at the various call-sites.

With this, we fix the issue where limit orders aren't considered as user orders in some places.

One thing I noticed and am not very fond of is the current `Settlement` vs `SettlementEncoder` abstraction. Specifically, I think the way that the current separation is designed contributed to this being an issue in the first place. I plan on submitting a follow-up PR that will refactor this into something that will be (IMO) nicer to use and less error prone.

### Test Plan

Existing tests continue to pass. Adjusted some tests to create limit orders to be considered as user orders.
