### PR TITLE
Make u256 parsing more lenient

### DIFF
--- a/crates/shared/src/bad_token/trace_call.rs
+++ b/crates/shared/src/bad_token/trace_call.rs
@@ -216,8 +216,10 @@ fn call_request(
 
 fn decode_u256(trace: &BlockTrace) -> Result<U256> {
     let bytes = trace.output.0.as_slice();
-    ensure!(bytes.len() == 32, "invalid length");
-    Ok(U256::from_big_endian(bytes))
+    // >= because we have observed that some contracts return more bytes than expected.
+    // For example 0x19D3364A399d251E894aC732651be8B0E4e85001 .
+    ensure!(bytes.len() >= 32, "invalid length");
+    Ok(U256::from_big_endian(&bytes[0..32]))
 }
 
 // The outer result signals communication failure with the node.


### PR DESCRIPTION
Related to https://github.com/cowprotocol/services/issues/773 .

When investigating why `0x19D3364A399d251E894aC732651be8B0E4e85001` was classified as a bad token I found that `balanceOf` for this contract returns 4096 bytes instead of the expected 32 bytes for a u256. The balance is correctly encoded in the first 32 bytes but there are extra all 0 bytes at the end.

When doing a normal `balanceOf` view call through a node the extra data is ignored but in when parsing the u256 from the `trace_call` response we check for strict equality of the bytes length which fails. This commit makes this check more lenient in order to not fail for these kind of addresses.

I do not yet know where the extra data comes from. This is not a quirk of `trace_call`. From the transport logs I can see that for the the view call the data is there too, it is just ignored. I guess in some ethereum standard it says that extra unexpected data should be ignored? I suspect it is some quirk of the compiler they used for this contract. The abi is clear that it should be a u256.

### Test Plan

Tested manually
