### PR TITLE
Include Full Fee Amount For Limit Orders

### DIFF
--- a/crates/autopilot/src/database.rs
+++ b/crates/autopilot/src/database.rs
@@ -2,7 +2,7 @@ mod auction;
 pub mod auction_transaction;
 mod events;
 pub mod onchain_order_events;
-mod orders;
+pub mod orders;
 mod quotes;
 
 use sqlx::{PgConnection, PgPool};

--- a/crates/autopilot/src/database/onchain_order_events.rs
+++ b/crates/autopilot/src/database/onchain_order_events.rs
@@ -1206,6 +1206,7 @@ mod test {
             sell_amount,
             buy_amount,
             fee_amount,
+            full_fee_amount: 24.into(),
         };
         let cloned_quote = quote.clone();
         order_quoter

--- a/crates/autopilot/src/database/orders.rs
+++ b/crates/autopilot/src/database/orders.rs
@@ -10,7 +10,7 @@ use model::{
 use number_conversions::u256_to_big_decimal;
 use shared::db_order_conversions::full_order_into_model_order;
 
-/// New fee data to update the order with.
+/// New fee data to update a limit order with.
 pub struct FeeUpdate {
     /// The actual fee amount to charge the order from its surplus.
     pub surplus_fee: U256,

--- a/crates/autopilot/src/database/orders.rs
+++ b/crates/autopilot/src/database/orders.rs
@@ -10,6 +10,17 @@ use model::{
 use number_conversions::u256_to_big_decimal;
 use shared::db_order_conversions::full_order_into_model_order;
 
+/// New fee data to update the order with.
+pub struct FeeUpdate {
+    /// The actual fee amount to charge the order from its surplus.
+    pub surplus_fee: U256,
+
+    /// The full unsubsidized fee amount that settling the order is expected to
+    /// actually cost. This is used for objective value computation so that fee
+    /// subsidies do not change the objective value.
+    pub full_fee_amount: U256,
+}
+
 impl Postgres {
     pub async fn limit_orders_with_outdated_fees(&self, age: Duration) -> Result<Vec<Order>> {
         let _timer = super::Metrics::get()
@@ -32,18 +43,25 @@ impl Postgres {
         .await
     }
 
-    pub async fn update_surplus_fee(&self, order_uid: &OrderUid, surplus_fee: U256) -> Result<()> {
+    pub async fn update_limit_order_fees(
+        &self,
+        order_uid: &OrderUid,
+        update: &FeeUpdate,
+    ) -> Result<()> {
         let _timer = super::Metrics::get()
             .database_queries
-            .with_label_values(&["update_surplus_fee"])
+            .with_label_values(&["update_limit_order_fees"])
             .start_timer();
 
         let mut ex = self.0.acquire().await?;
-        database::orders::update_surplus_fee(
+        database::orders::update_limit_order_fees(
             &mut ex,
             &database::byte_array::ByteArray(order_uid.0),
-            &u256_to_big_decimal(&surplus_fee),
-            Utc::now(),
+            &database::orders::FeeUpdate {
+                surplus_fee: u256_to_big_decimal(&update.surplus_fee),
+                surplus_fee_timestamp: Utc::now(),
+                full_fee_amount: u256_to_big_decimal(&update.full_fee_amount),
+            },
         )
         .await?;
         Ok(())

--- a/crates/autopilot/src/limit_order_quoter.rs
+++ b/crates/autopilot/src/limit_order_quoter.rs
@@ -1,4 +1,4 @@
-use crate::database::{Postgres, orders::FeeUpdate};
+use crate::database::{orders::FeeUpdate, Postgres};
 use anyhow::Result;
 use chrono::Duration;
 use futures::future::join_all;

--- a/crates/autopilot/src/limit_order_quoter.rs
+++ b/crates/autopilot/src/limit_order_quoter.rs
@@ -1,4 +1,4 @@
-use crate::database::Postgres;
+use crate::database::{Postgres, orders::FeeUpdate};
 use anyhow::Result;
 use chrono::Duration;
 use futures::future::join_all;
@@ -94,7 +94,13 @@ impl LimitOrderQuoter {
                         Ok(quote) => {
                             if let Err(err) = self
                                 .database
-                                .update_surplus_fee(&order.metadata.uid, quote.fee_amount)
+                                .update_limit_order_fees(
+                                    &order.metadata.uid,
+                                    &FeeUpdate {
+                                        surplus_fee: quote.fee_amount,
+                                        full_fee_amount: quote.full_fee_amount,
+                                    },
+                                )
                                 .await
                             {
                                 tracing::error!(

--- a/crates/model/src/quote.rs
+++ b/crates/model/src/quote.rs
@@ -44,6 +44,17 @@ pub enum QuoteSigningScheme {
 }
 
 impl QuoteSigningScheme {
+    /// Returns the additional gas amount associated with a signing scheme.
+    pub fn additional_gas_amount(&self) -> u64 {
+        match self {
+            QuoteSigningScheme::Eip1271 {
+                verification_gas_limit,
+                ..
+            } => *verification_gas_limit,
+            _ => 0u64,
+        }
+    }
+
     pub fn new_eip1271_with_default_gas(onchain_order: bool) -> Self {
         QuoteSigningScheme::Eip1271 {
             onchain_order,

--- a/crates/shared/src/order_quoting.rs
+++ b/crates/shared/src/order_quoting.rs
@@ -181,7 +181,7 @@ pub struct Quote {
     /// The final minimum subsidized fee amount for any order created for this
     /// quote. The fee is denoted in the sell token.
     pub fee_amount: U256,
-    /// The actual fee amount that is esimated to be require in order to settle
+    /// The actual fee amount that is esimated to be required in order to settle
     /// the order on chain. This is the fee in full without any subsidies. The
     /// fee is denoted in the sell token.
     pub full_fee_amount: U256,

--- a/crates/shared/src/order_validation.rs
+++ b/crates/shared/src/order_validation.rs
@@ -432,12 +432,7 @@ impl OrderValidating for OrderValidator {
 
         let full_fee_amount = quote
             .as_ref()
-            .map(|quote| {
-                quote
-                    .data
-                    .fee_parameters
-                    .unsubsidized_with_additional_cost(additional_gas)
-            })
+            .map(|quote| quote.full_fee_amount)
             .unwrap_or_default();
 
         let min_balance =


### PR DESCRIPTION
Fixes #770 

This PR makes sure limit orders also set their `full_fee_amount`. Specifically, CoW Protocol orders have 2 different fee fields:
- `fee_amount`: This is the actual fee amount that we charge the user. In order to make trading more attractive on CoW Swap, we have a few "knobs" for configuring subsidies on orders used to compute this amount. For limit orders, this is the analogous to `surplus_fee` which is the actual fee we change the user (but instead of it being a pro-rated fee, it is taken from the order's surplus).
- `full_fee_amount`: This is the actual expected "cost" of executing the order. We store this for a couple of reasons:
  1. Primary reason is that we want to use this value in the objective function and **not** the actual fee amount. The reason for this is we want competition to be done without taking subsidies into account.
  2. Secondary reason (and much less important) is to help in debugging and make sure our fee estimation is working as expected and somewhat accurate (we should compare these values with the actual on-chain gas costs of settlement executions).
  
These fields should be accurate for limit orders now 🎉.

### Test Plan

Unit test to check that this field is being set. It gets read in the same way that it gets read for regular orders during auction building.
