### PR TITLE
Move `surplus_fee` and `surplus_fee_timestamp` into the `OrderClass::Limit` variant

### DIFF
--- a/crates/autopilot/src/solvable_orders.rs
+++ b/crates/autopilot/src/solvable_orders.rs
@@ -139,7 +139,7 @@ impl SolvableOrdersCache {
     /// Manually update solvable orders. Usually called by the background updating task.
     ///
     /// Usually this method is called from update_task. If it isn't, which is the case in unit tests,
-    /// then concurrent calls might overwrite eachother's results.
+    /// then concurrent calls might overwrite each other's results.
     pub async fn update(&self, block: u64) -> Result<()> {
         let min_valid_to = now_in_epoch_seconds() + self.min_order_validity_period.as_secs() as u32;
         let db_solvable_orders = self
@@ -257,22 +257,22 @@ impl SolvableOrdersCache {
         prices: &BTreeMap<H160, U256>,
     ) -> Vec<Order> {
         orders.retain(|order| {
-            if order.metadata.class != OrderClass::Limit {
-                return true;
-            }
-
-            // Convert the sell and buy price to the native token (ETH) and make sure that sell
-            // with the surplus fee is higher than buy with the configurable price factor.
-            let sell_native = (order.data.sell_amount + order.metadata.surplus_fee.unwrap())
-                * prices.get(&order.data.sell_token).unwrap();
-            let buy_native = order.data.buy_amount * prices.get(&order.data.buy_token).unwrap();
-            let sell_native = u256_to_big_decimal(&sell_native);
-            let buy_native = u256_to_big_decimal(&buy_native);
-            if sell_native >= buy_native * self.limit_order_price_factor.clone() {
-                true
+            if let OrderClass::Limit(limit) = &order.metadata.class {
+                // Convert the sell and buy price to the native token (ETH) and make sure that sell
+                // with the surplus fee is higher than buy with the configurable price factor.
+                let sell_native = (order.data.sell_amount + limit.surplus_fee)
+                    * prices.get(&order.data.sell_token).unwrap();
+                let buy_native = order.data.buy_amount * prices.get(&order.data.buy_token).unwrap();
+                let sell_native = u256_to_big_decimal(&sell_native);
+                let buy_native = u256_to_big_decimal(&buy_native);
+                if sell_native >= buy_native * self.limit_order_price_factor.clone() {
+                    true
+                } else {
+                    tracing::debug!(order_uid = %order.metadata.uid, "limit order is outside market price, skipping");
+                    false
+                }
             } else {
-                tracing::debug!(order_uid = %order.metadata.uid, "limit order is outside market price, skipping");
-                false
+                true
             }
         });
         orders

--- a/crates/driver/src/settlement_proposal.rs
+++ b/crates/driver/src/settlement_proposal.rs
@@ -49,7 +49,7 @@ impl TradedOrder {
     fn buy_token_price(&self, clearing_prices: &HashMap<H160, U256>) -> Option<U256> {
         match self.order.metadata.class {
             OrderClass::Market => clearing_prices.get(&self.order.data.buy_token).cloned(),
-            OrderClass::Liquidity | OrderClass::Limit => clearing_prices
+            OrderClass::Liquidity | OrderClass::Limit(_) => clearing_prices
                 .get(&self.order.data.sell_token)?
                 .checked_mul(self.order.data.sell_amount)?
                 .checked_div(self.order.data.buy_amount),

--- a/crates/e2e/tests/e2e/limit_orders.rs
+++ b/crates/e2e/tests/e2e/limit_orders.rs
@@ -201,7 +201,10 @@ async fn single_limit_order_test(web3: Web3) {
         .json()
         .await
         .unwrap();
-    assert_eq!(limit_order.metadata.class, OrderClass::Limit);
+    assert_eq!(
+        limit_order.metadata.class,
+        OrderClass::Limit(Default::default())
+    );
 
     wait_for_solvable_orders(&client, 1).await.unwrap();
 
@@ -441,7 +444,7 @@ async fn two_limit_orders_test(web3: Web3) {
         .json()
         .await
         .unwrap();
-    assert_eq!(limit_order.metadata.class, OrderClass::Limit);
+    assert!(limit_order.metadata.class.is_limit());
 
     let order_b = OrderBuilder::default()
         .with_sell_token(token_b.address())
@@ -475,7 +478,7 @@ async fn two_limit_orders_test(web3: Web3) {
         .json()
         .await
         .unwrap();
-    assert_eq!(limit_order.metadata.class, OrderClass::Limit);
+    assert!(limit_order.metadata.class.is_limit());
 
     wait_for_solvable_orders(&client, 2).await.unwrap();
 
@@ -714,7 +717,7 @@ async fn mixed_limit_and_market_orders_test(web3: Web3) {
         .json()
         .await
         .unwrap();
-    assert_eq!(limit_order.metadata.class, OrderClass::Limit);
+    assert!(limit_order.metadata.class.is_limit());
 
     let order_b = OrderBuilder::default()
         .with_sell_token(token_b.address())

--- a/crates/orderbook/src/database/orders.rs
+++ b/crates/orderbook/src/database/orders.rs
@@ -11,8 +11,8 @@ use futures::{stream::TryStreamExt, FutureExt, StreamExt};
 use model::{
     app_id::AppId,
     order::{
-        EthflowData, Interactions, Order, OrderClass, OrderData, OrderMetadata, OrderStatus,
-        OrderUid,
+        EthflowData, Interactions, LimitOrderClass, Order, OrderClass, OrderData, OrderMetadata,
+        OrderStatus, OrderUid,
     },
     signature::Signature,
     time::now_in_epoch_seconds,
@@ -87,7 +87,7 @@ async fn insert_order(order: &Order, ex: &mut PgConnection) -> Result<(), Insert
         app_data: ByteArray(order.data.app_data.0),
         fee_amount: u256_to_big_decimal(&order.data.fee_amount),
         kind: order_kind_into(order.data.kind),
-        class: order_class_into(order.metadata.class),
+        class: order_class_into(&order.metadata.class),
         partially_fillable: order.data.partially_fillable,
         signature: order.signature.to_bytes(),
         signing_scheme: signing_scheme_into(order.signature.scheme()),
@@ -96,8 +96,19 @@ async fn insert_order(order: &Order, ex: &mut PgConnection) -> Result<(), Insert
         buy_token_balance: buy_token_destination_into(order.data.buy_token_balance),
         full_fee_amount: u256_to_big_decimal(&order.metadata.full_fee_amount),
         cancellation_timestamp: None,
-        surplus_fee: order.metadata.surplus_fee.as_ref().map(u256_to_big_decimal),
-        surplus_fee_timestamp: order.metadata.surplus_fee_timestamp,
+        surplus_fee: match order.metadata.class {
+            OrderClass::Limit(LimitOrderClass { surplus_fee, .. }) => {
+                Some(u256_to_big_decimal(&surplus_fee))
+            }
+            _ => None,
+        },
+        surplus_fee_timestamp: match order.metadata.class {
+            OrderClass::Limit(LimitOrderClass {
+                surplus_fee_timestamp,
+                ..
+            }) => Some(surplus_fee_timestamp),
+            _ => None,
+        },
     };
     database::orders::insert_order(ex, &order)
         .await
@@ -336,7 +347,7 @@ fn full_order_into_model_order(order: FullOrder) -> Result<Order> {
         None
     };
     let onchain_user = order.onchain_user.map(|onchain_user| H160(onchain_user.0));
-    let class = order_class_from(order.class);
+    let class = order_class_from(&order);
     let metadata = OrderMetadata {
         creation_date: order.creation_timestamp,
         owner: H160(order.owner.0),
@@ -357,18 +368,13 @@ fn full_order_into_model_order(order: FullOrder) -> Result<Order> {
             .context("executed fee amount is not a valid u256")?,
         invalidated: order.invalidated,
         status,
+        is_liquidity_order: class == OrderClass::Liquidity,
         class,
         settlement_contract: H160(order.settlement_contract.0),
         full_fee_amount: big_decimal_to_u256(&order.full_fee_amount)
             .context("full_fee_amount is not U256")?,
         ethflow_data,
         onchain_user,
-        is_liquidity_order: class == OrderClass::Liquidity,
-        surplus_fee: match order.surplus_fee {
-            Some(fee) => Some(big_decimal_to_u256(&fee).context("surplus_fee is not U256")?),
-            None => None,
-        },
-        surplus_fee_timestamp: order.surplus_fee_timestamp,
     };
     let data = OrderData {
         sell_token: H160(order.sell_token.0),

--- a/crates/orderbook/src/orderbook.rs
+++ b/crates/orderbook/src/orderbook.rs
@@ -38,7 +38,7 @@ impl Metrics {
         let kind = match order.metadata.class {
             OrderClass::Market => "user",
             OrderClass::Liquidity => "liquidity",
-            OrderClass::Limit => "limit",
+            OrderClass::Limit(_) => "limit",
         };
         let op = match operation {
             OrderOperation::Created => "created",

--- a/crates/shared/src/db_order_conversions.rs
+++ b/crates/shared/src/db_order_conversions.rs
@@ -9,8 +9,8 @@ use model::{
     app_id::AppId,
     interaction::InteractionData,
     order::{
-        BuyTokenDestination, EthflowData, Interactions, Order, OrderClass, OrderData, OrderKind,
-        OrderMetadata, OrderStatus, OrderUid, SellTokenSource,
+        BuyTokenDestination, EthflowData, Interactions, LimitOrderClass, Order, OrderClass,
+        OrderData, OrderKind, OrderMetadata, OrderStatus, OrderUid, SellTokenSource,
     },
     signature::{Signature, SigningScheme},
 };
@@ -28,7 +28,7 @@ pub fn full_order_into_model_order(order: database::orders::FullOrder) -> Result
         None
     };
     let onchain_user = order.onchain_user.map(|onchain_user| H160(onchain_user.0));
-    let class = order_class_from(order.class);
+    let class = order_class_from(&order);
     let metadata = OrderMetadata {
         creation_date: order.creation_timestamp,
         owner: H160(order.owner.0),
@@ -49,18 +49,13 @@ pub fn full_order_into_model_order(order: database::orders::FullOrder) -> Result
             .context("executed fee amount is not a valid u256")?,
         invalidated: order.invalidated,
         status,
+        is_liquidity_order: class == OrderClass::Liquidity,
         class,
         settlement_contract: H160(order.settlement_contract.0),
         full_fee_amount: big_decimal_to_u256(&order.full_fee_amount)
             .context("full_fee_amount is not U256")?,
         ethflow_data,
         onchain_user,
-        is_liquidity_order: class == OrderClass::Liquidity,
-        surplus_fee: match order.surplus_fee {
-            Some(fee) => Some(big_decimal_to_u256(&fee).context("surplus_fee is not U256")?),
-            None => None,
-        },
-        surplus_fee_timestamp: order.surplus_fee_timestamp,
     };
     let data = OrderData {
         sell_token: H160(order.sell_token.0),
@@ -115,19 +110,30 @@ pub fn order_kind_from(kind: DbOrderKind) -> OrderKind {
     }
 }
 
-pub fn order_class_into(class: OrderClass) -> DbOrderClass {
+pub fn order_class_into(class: &OrderClass) -> DbOrderClass {
     match class {
         OrderClass::Market => DbOrderClass::Market,
         OrderClass::Liquidity => DbOrderClass::Liquidity,
-        OrderClass::Limit => DbOrderClass::Limit,
+        OrderClass::Limit(_) => DbOrderClass::Limit,
     }
 }
 
-pub fn order_class_from(class: DbOrderClass) -> OrderClass {
-    match class {
+pub fn order_class_from(order: &FullOrderDb) -> OrderClass {
+    match order.class {
         DbOrderClass::Market => OrderClass::Market,
         DbOrderClass::Liquidity => OrderClass::Liquidity,
-        DbOrderClass::Limit => OrderClass::Limit,
+        DbOrderClass::Limit => OrderClass::Limit(LimitOrderClass {
+            surplus_fee: big_decimal_to_u256(
+                order
+                    .surplus_fee
+                    .as_ref()
+                    .expect("limit orders must have surplus fee set"),
+            )
+            .unwrap(),
+            surplus_fee_timestamp: order
+                .surplus_fee_timestamp
+                .expect("limit orders must have surplus fee timestamp set"),
+        }),
     }
 }
 

--- a/crates/solver/src/driver/solver_settlements.rs
+++ b/crates/solver/src/driver/solver_settlements.rs
@@ -200,7 +200,6 @@ mod tests {
                     creation_date: created_at,
                     uid: OrderUid([uid; 56]),
                     class,
-                    surplus_fee: Some(0.into()),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -273,7 +272,7 @@ mod tests {
 
         let s1 = Settlement::with_default_prices(vec![
             trade(old, 1, OrderClass::Market),
-            trade(recent, 2, OrderClass::Limit),
+            trade(recent, 2, OrderClass::Limit(Default::default())),
         ]);
         let s2 = Settlement::with_default_prices(vec![
             trade(recent, 3, OrderClass::Market),
@@ -534,7 +533,8 @@ mod tests {
         let settlement = Settlement::with_default_prices(vec![]);
         assert!(!has_user_order(&settlement));
 
-        let settlement = Settlement::with_default_prices(vec![order(OrderClass::Limit)]);
+        let settlement =
+            Settlement::with_default_prices(vec![order(OrderClass::Limit(Default::default()))]);
         assert!(has_user_order(&settlement));
 
         let settlement = Settlement::with_default_prices(vec![order(OrderClass::Liquidity)]);
@@ -551,7 +551,7 @@ mod tests {
 
         let settlement = Settlement::with_default_prices(vec![
             order(OrderClass::Liquidity),
-            order(OrderClass::Limit),
+            order(OrderClass::Limit(Default::default())),
         ]);
         assert!(has_user_order(&settlement));
     }

--- a/crates/solver/src/metrics.rs
+++ b/crates/solver/src/metrics.rs
@@ -327,7 +327,7 @@ impl SolverMetrics for Metrics {
         let order_type = match order.metadata.class {
             OrderClass::Market => "user_order",
             OrderClass::Liquidity => "liquidity_order",
-            OrderClass::Limit => "limit_order",
+            OrderClass::Limit(_) => "limit_order",
         };
         self.trade_counter
             .with_label_values(&[solver, order_type])

--- a/crates/solver/src/settlement.rs
+++ b/crates/solver/src/settlement.rs
@@ -514,7 +514,7 @@ pub mod tests {
     use super::*;
     use crate::{liquidity::SettlementHandling, settlement::external_prices::externalprices};
     use maplit::hashmap;
-    use model::order::{OrderClass, OrderData, OrderKind, OrderMetadata};
+    use model::order::{LimitOrderClass, OrderClass, OrderData, OrderKind, OrderMetadata};
     use num::FromPrimitive;
     use shared::addr;
 
@@ -1380,8 +1380,10 @@ pub mod tests {
                             ..Default::default()
                         },
                         metadata: OrderMetadata {
-                            class: OrderClass::Limit,
-                            surplus_fee: Some(1_000_u128.into()),
+                            class: OrderClass::Limit(LimitOrderClass {
+                                surplus_fee: 1_000_u128.into(),
+                                surplus_fee_timestamp: Default::default(),
+                            }),
                             ..Default::default()
                         },
                         ..Default::default()
@@ -1412,8 +1414,10 @@ pub mod tests {
                             ..Default::default()
                         },
                         metadata: OrderMetadata {
-                            class: OrderClass::Limit,
-                            surplus_fee: Some(1_000_u128.into()),
+                            class: OrderClass::Limit(LimitOrderClass {
+                                surplus_fee: 1_000_u128.into(),
+                                surplus_fee_timestamp: Default::default(),
+                            }),
                             ..Default::default()
                         },
                         ..Default::default()
@@ -1451,8 +1455,10 @@ pub mod tests {
                         ..Default::default()
                     },
                     metadata: OrderMetadata {
-                        class: OrderClass::Limit,
-                        surplus_fee: Some(1_000_u128.into()),
+                        class: OrderClass::Limit(LimitOrderClass {
+                            surplus_fee: 1_000_u128.into(),
+                            surplus_fee_timestamp: Default::default(),
+                        }),
                         ..Default::default()
                     },
                     ..Default::default()

--- a/crates/solver/src/settlement/settlement_encoder.rs
+++ b/crates/solver/src/settlement/settlement_encoder.rs
@@ -4,7 +4,7 @@ use anyhow::{bail, ensure, Context as _, Result};
 use itertools::{Either, Itertools};
 use model::{
     interaction::InteractionData,
-    order::{Order, OrderClass, OrderKind},
+    order::{LimitOrderClass, Order, OrderClass, OrderKind},
 };
 use num::{BigRational, One};
 use number_conversions::big_rational_to_u256;
@@ -249,7 +249,7 @@ impl SettlementEncoder {
         scaled_unsubsidized_fee: U256,
     ) -> Result<TradeExecution> {
         let interactions = order.interactions.clone();
-        let execution = match order.metadata.class {
+        let execution = match &order.metadata.class {
             OrderClass::Market => {
                 self.add_market_trade(order, executed_amount, scaled_unsubsidized_fee)?
             }
@@ -262,14 +262,14 @@ impl SettlementEncoder {
                     buy_price,
                 )?
             }
-            OrderClass::Limit => {
+            OrderClass::Limit(limit) => {
                 // Solvers calculate with slightly adjusted amounts compared to this order but because
                 // limit orders are fill-or-kill we can simply use the total original `sell_amount`.
                 let executed_amount = match order.data.kind {
                     OrderKind::Sell => order.data.sell_amount,
                     OrderKind::Buy => order.data.buy_amount,
                 };
-                let buy_price = self.custom_price_for_limit_order(&order)?;
+                let buy_price = self.custom_price_for_limit_order(&order, limit)?;
 
                 self.add_custom_price_trade(
                     order,
@@ -288,7 +288,11 @@ impl SettlementEncoder {
     /// `compute_synthetic_order_amounts_if_limit_order()`).
     /// Returns an error if the UCP doesn't contain the traded tokens or if under- or overflows
     /// happen during the computation.
-    fn custom_price_for_limit_order(&self, order: &Order) -> Result<U256> {
+    fn custom_price_for_limit_order(&self, order: &Order, limit: &LimitOrderClass) -> Result<U256> {
+        anyhow::ensure!(
+            order.metadata.class.is_limit(),
+            "this function should only be called for limit orders"
+        );
         // The order passed into this function is the original order signed by the user.
         // But the solver actually computed a solution for an order with `sell_amount -= surplus_fee`.
         // To account for the `surplus_fee` we first have to compute the expected `sell_amount` and
@@ -304,10 +308,6 @@ impl SettlementEncoder {
             .get(&order.data.sell_token)
             .context("sell token price is missing")?;
 
-        let surplus_fee = order
-            .metadata
-            .surplus_fee
-            .context("limit order does not have surplus fee set")?;
         let (sell_amount, buy_amount) = match order.data.kind {
             // This means sell as much `sell_token` as needed to buy exactly the expected
             // `buy_amount`. Therefore we need to solve for `sell_amount`.
@@ -321,7 +321,7 @@ impl SettlementEncoder {
                     .context("sell_amount computation failed")?;
                 // We have to sell slightly more `sell_token` to capture the `surplus_fee`
                 let sell_amount_adjusted_for_fees = sell_amount
-                    .checked_add(surplus_fee)
+                    .checked_add(limit.surplus_fee)
                     .context("sell_amount computation failed")?;
                 (sell_amount_adjusted_for_fees, order.data.buy_amount)
             }
@@ -332,7 +332,7 @@ impl SettlementEncoder {
                 let sell_amount = order
                     .data
                     .sell_amount
-                    .checked_sub(surplus_fee)
+                    .checked_sub(limit.surplus_fee)
                     .context("buy_amount computation failed")?;
                 let buy_amount = sell_amount
                     .checked_mul(uniform_sell_price)
@@ -1334,7 +1334,7 @@ pub mod tests {
         let mut encoder = SettlementEncoder::new(prices);
         // sell 1.01 WETH for 1_000 USDC with a fee of 0.01 WETH (or 10 USDC)
         let order = OrderBuilder::default()
-            .with_class(OrderClass::Limit)
+            .with_class(OrderClass::Limit(Default::default()))
             .with_sell_token(weth)
             .with_sell_amount(1_010_000_000_000_000_000u128.into()) // 1.01 WETH
             .with_buy_token(usdc)
@@ -1388,7 +1388,7 @@ pub mod tests {
         let mut encoder = SettlementEncoder::new(prices);
         // buy 1 WETH for 1_010 USDC with a fee of 10 USDC
         let order = OrderBuilder::default()
-            .with_class(OrderClass::Limit)
+            .with_class(OrderClass::Limit(Default::default()))
             .with_buy_token(weth)
             .with_buy_amount(U256::exp10(18)) // 1 WETH
             .with_sell_token(usdc)


### PR DESCRIPTION
Final follow-up to https://github.com/cowprotocol/services/pull/784.

Move the `surplus_fee` and `surplus_fee_timestamp` fields into `OrderClass::Limit`.

### Test Plan

Automated tests.
