### PR TITLE
Add Support for Limit Order Buying Eth

### DIFF
--- a/crates/model/src/order.rs
+++ b/crates/model/src/order.rs
@@ -94,6 +94,13 @@ impl Order {
     pub fn contains_token_from(&self, token_list: &HashSet<H160>) -> bool {
         token_list.contains(&self.data.buy_token) || token_list.contains(&self.data.sell_token)
     }
+
+    pub fn is_user_order(&self) -> bool {
+        match self.metadata.class {
+            OrderClass::Market | OrderClass::Limit => true,
+            OrderClass::Liquidity => false,
+        }
+    }
 }
 
 /// Remaining order buy, sell and fee amounts.

--- a/crates/solver/src/settlement/settlement_encoder.rs
+++ b/crates/solver/src/settlement/settlement_encoder.rs
@@ -160,7 +160,7 @@ impl SettlementEncoder {
     pub fn user_trades(&self) -> impl Iterator<Item = PricedTrade> + '_ {
         self.trades
             .iter()
-            .filter(|trade| is_user_order(&trade.data.order))
+            .filter(|trade| trade.data.order.is_user_order())
             .map(move |trade| self.compute_trade_token_prices(trade))
     }
 
@@ -760,13 +760,6 @@ pub fn verify_executed_amount(order: &Order, executed: U256) -> Result<()> {
     };
     ensure!(valid_executed_amount, "invalid executed amount");
     Ok(())
-}
-
-fn is_user_order(order: &Order) -> bool {
-    match order.metadata.class {
-        OrderClass::Market | OrderClass::Limit => true,
-        OrderClass::Liquidity => false,
-    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
This PR fixes an issue with encoding limit orders with the special `BUY_ETH_ADDRESS`.

Specifically, we don't add a token equivalency for these kinds of orders (because their buy price) which causes a "missing buy token error" when adding the limit order to the settlement encoder.

I changed the PR to unconditionally add token equivalency for all orders. I did this so that the order converter doesn't need to know implementation details about the `SettlementEncoder`, and even if we add an additional price here that isn't needed, it gets cleaned up in the `drop_unnecessary_tokens_and_prices` call so we don't have to pay more gas for it.

### Test Plan

Added case in unit test.
