### PR TITLE
Include Limit Order Buy Token Uniform Clearing Price

### DIFF
--- a/crates/solver/src/settlement.rs
+++ b/crates/solver/src/settlement.rs
@@ -1429,4 +1429,50 @@ pub mod tests {
             );
         }
     }
+
+    #[test]
+    fn includes_limit_order_ucp() {
+        let sell_token = H160([1; 20]);
+        let buy_token = H160([2; 20]);
+
+        let settlement = EncodedSettlement::from(test_settlement(
+            hashmap! {
+                sell_token => 100_000_u128.into(),
+                buy_token => 100_000_u128.into(),
+            },
+            vec![Trade {
+                order: Order {
+                    data: OrderData {
+                        sell_token,
+                        buy_token,
+                        sell_amount: 100_000_u128.into(),
+                        buy_amount: 99_000_u128.into(),
+                        kind: OrderKind::Sell,
+                        ..Default::default()
+                    },
+                    metadata: OrderMetadata {
+                        class: OrderClass::Limit,
+                        surplus_fee: Some(1_000_u128.into()),
+                        ..Default::default()
+                    },
+                    ..Default::default()
+                },
+                executed_amount: 100_000_u128.into(),
+                scaled_unsubsidized_fee: 1_000_u128.into(),
+            }],
+        ));
+
+        // Note that for limit order **both** the uniform clearing price of the
+        // buy token as well as the executed clearing price accounting for fees
+        // are included.
+        assert_eq!(settlement.tokens, [sell_token, buy_token, buy_token]);
+        assert_eq!(
+            settlement.clearing_prices,
+            [
+                100_000_u128.into(),
+                100_000_u128.into(),
+                101_010_u128.into()
+            ],
+        );
+    }
 }

--- a/crates/solver/src/settlement/settlement_encoder.rs
+++ b/crates/solver/src/settlement/settlement_encoder.rs
@@ -520,15 +520,19 @@ impl SettlementEncoder {
         let traded_tokens: HashSet<_> = self
             .trades
             .iter()
-            .flat_map(|trade| match trade.tokens {
-                TokenReference::Indexed { .. } => Either::Left(
-                    [
-                        trade.data.order.data.sell_token,
-                        trade.data.order.data.buy_token,
-                    ]
-                    .into_iter(),
-                ),
-                TokenReference::CustomPrice { .. } => {
+            .flat_map(|trade| {
+                // For user order trades, always keep uniform clearing prices
+                // for all tokens (even if we could technically drop the buy
+                // token for limit orders).
+                if trade.data.order.is_user_order() {
+                    Either::Left(
+                        [
+                            trade.data.order.data.sell_token,
+                            trade.data.order.data.buy_token,
+                        ]
+                        .into_iter(),
+                    )
+                } else {
                     Either::Right(iter::once(trade.data.order.data.sell_token))
                 }
             })


### PR DESCRIPTION
This PR changes the logic of `drop_unnecessary_tokens_and_prices` to not filter out uniform clearing prices for any user orders.

This is because, as part of our design, we wanted to include the uniform clearing price in the settlement clearing price vector (even if it doesn't get used) to on-chain uniform clearing price "documentation".

### Test Plan

Added unit test that verifies this.
