### PR TITLE
Configuring refunder builds and auto-redeployments

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -55,7 +55,7 @@ jobs:
       - uses: cowprotocol/autodeploy-action@v1
         if: ${{ github.ref == 'refs/heads/main' }}
         with:
-          pods: dfusion-v2-autopilot-goerli,dfusion-v2-api-goerli,dfusion-v2-solver-goerli,dfusion-v2-autopilot-mainnet,dfusion-v2-api-mainnet,dfusion-v2-solver-mainnet,dfusion-v2-autopilot-xdai,dfusion-v2-api-xdai,dfusion-v2-solver-xdai,dfusion-v2-solver-shadow,dfusion-v2-alerter-mainnet,dfusion-v2-alerter-mainnet
+          pods: dfusion-v2-autopilot-goerli,dfusion-v2-api-goerli,dfusion-v2-solver-goerli,dfusion-v2-autopilot-mainnet,dfusion-v2-api-mainnet,dfusion-v2-solver-mainnet,dfusion-v2-autopilot-xdai,dfusion-v2-api-xdai,dfusion-v2-solver-xdai,dfusion-v2-solver-shadow,dfusion-v2-alerter-mainnet,dfusion-v2-refunder-mainnet
           tag: ${{ secrets.AUTODEPLOY_TAG }}
           url: ${{ secrets.AUTODEPLOY_URL }}
           token: ${{ secrets.AUTODEPLOY_TOKEN }}

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -55,7 +55,7 @@ jobs:
       - uses: cowprotocol/autodeploy-action@v1
         if: ${{ github.ref == 'refs/heads/main' }}
         with:
-          pods: dfusion-v2-autopilot-goerli,dfusion-v2-api-goerli,dfusion-v2-solver-goerli,dfusion-v2-autopilot-mainnet,dfusion-v2-api-mainnet,dfusion-v2-solver-mainnet,dfusion-v2-autopilot-xdai,dfusion-v2-api-xdai,dfusion-v2-solver-xdai,dfusion-v2-solver-shadow,dfusion-v2-alerter-mainnet
+          pods: dfusion-v2-autopilot-goerli,dfusion-v2-api-goerli,dfusion-v2-solver-goerli,dfusion-v2-autopilot-mainnet,dfusion-v2-api-mainnet,dfusion-v2-solver-mainnet,dfusion-v2-autopilot-xdai,dfusion-v2-api-xdai,dfusion-v2-solver-xdai,dfusion-v2-solver-shadow,dfusion-v2-alerter-mainnet,dfusion-v2-alerter-mainnet
           tag: ${{ secrets.AUTODEPLOY_TAG }}
           url: ${{ secrets.AUTODEPLOY_URL }}
           token: ${{ secrets.AUTODEPLOY_TOKEN }}

--- a/docker/Dockerfile.binary
+++ b/docker/Dockerfile.binary
@@ -17,6 +17,7 @@ COPY --from=cargo-build /src/target/release/orderbook /usr/local/bin/orderbook
 COPY --from=cargo-build /src/target/release/solver /usr/local/bin/solver
 COPY --from=cargo-build /src/target/release/alerter /usr/local/bin/alerter
 COPY --from=cargo-build /src/target/release/autopilot /usr/local/bin/autopilot
+COPY --from=cargo-build /src/target/release/refunder /usr/local/bin/refunder
 
 CMD echo "Specify binary - either solver or orderbook"
 ENTRYPOINT ["/usr/bin/tini"]


### PR DESCRIPTION
Refunder builds need to also be copied into the docker image. 
Also, we want to have automatic re-deployments of the refunder