### PR TITLE
Filter Order With Insufficient Sell Amount

### DIFF
--- a/crates/autopilot/src/solvable_orders.rs
+++ b/crates/autopilot/src/solvable_orders.rs
@@ -199,7 +199,7 @@ impl SolvableOrdersCache {
         )
         .await;
 
-        let orders = self.filter_mispriced_limit_orders(orders, &prices);
+        let orders = filter_mispriced_limit_orders(orders, &prices, &self.limit_order_price_factor);
 
         let rewards = if let Some(calculator) = &self.reward_calculator {
             let rewards = calculator
@@ -249,56 +249,6 @@ impl SolvableOrdersCache {
 
     pub fn last_update_time(&self) -> Instant {
         self.cache.lock().unwrap().orders.update_time
-    }
-
-    /// Filter out limit orders which are far enough outside the estimated native token price.
-    fn filter_mispriced_limit_orders(
-        &self,
-        mut orders: Vec<Order>,
-        prices: &BTreeMap<H160, U256>,
-    ) -> Vec<Order> {
-        orders.retain(|order| {
-            let surplus_fee = match &order.metadata.class {
-                OrderClass::Limit(limit) => limit.surplus_fee,
-                _ => return true,
-            };
-
-            let sell_price = *prices.get(&order.data.sell_token).unwrap();
-            let buy_price = *prices.get(&order.data.buy_token).unwrap();
-
-            // Convert the sell and buy price to the native token (ETH) and make sure that sell
-            // discounting the surplus fee is higher than buy with the configurable price factor.
-            let (sell_native, buy_native) = match (
-                order
-                    .data
-                    .sell_amount
-                    .checked_sub(surplus_fee)
-                    .and_then(|sell| sell.checked_mul(sell_price)),
-                order.data.buy_amount.checked_mul(buy_price),
-            ) {
-                (Some(sell), Some(buy)) => (sell, buy),
-                _ => {
-                    tracing::debug!(
-                        order_uid = %order.metadata.uid,
-                        "limit order overflow computing native amounts; skipping",
-                    );
-                    return false;
-                }
-            };
-
-            let sell_native = u256_to_big_decimal(&sell_native);
-            let buy_native = u256_to_big_decimal(&buy_native);
-            if sell_native >= buy_native * &self.limit_order_price_factor {
-                true
-            } else {
-                tracing::debug!(
-                    order_uid = %order.metadata.uid,
-                    "limit order is outside market price, skipping",
-                );
-                false
-            }
-        });
-        orders
     }
 }
 
@@ -607,6 +557,57 @@ fn filter_limit_orders_with_insufficient_sell_amount(mut orders: Vec<Order>) -> 
     orders.retain(|order| match &order.metadata.class {
         OrderClass::Limit(limit) => order.data.sell_amount > limit.surplus_fee,
         _ => true,
+    });
+    orders
+}
+
+/// Filter out limit orders which are far enough outside the estimated native token price.
+fn filter_mispriced_limit_orders(
+    mut orders: Vec<Order>,
+    prices: &BTreeMap<H160, U256>,
+    price_factor: &BigDecimal,
+) -> Vec<Order> {
+    orders.retain(|order| {
+        let surplus_fee = match &order.metadata.class {
+            OrderClass::Limit(limit) => limit.surplus_fee,
+            _ => return true,
+        };
+
+        let effective_sell_amount = order.data.sell_amount.saturating_sub(surplus_fee);
+        if effective_sell_amount.is_zero() {
+            return false;
+        }
+
+        let sell_price = *prices.get(&order.data.sell_token).unwrap();
+        let buy_price = *prices.get(&order.data.buy_token).unwrap();
+
+        // Convert the sell and buy price to the native token (ETH) and make sure that sell
+        // discounting the surplus fee is higher than buy with the configurable price factor.
+        let (sell_native, buy_native) = match (
+            effective_sell_amount.checked_mul(sell_price),
+            order.data.buy_amount.checked_mul(buy_price),
+        ) {
+            (Some(sell), Some(buy)) => (sell, buy),
+            _ => {
+                tracing::debug!(
+                    order_uid = %order.metadata.uid,
+                    "limit order overflow computing native amounts; skipping",
+                );
+                return false;
+            }
+        };
+
+        let sell_native = u256_to_big_decimal(&sell_native);
+        let buy_native = u256_to_big_decimal(&buy_native);
+        if sell_native >= buy_native * price_factor {
+            true
+        } else {
+            tracing::debug!(
+                order_uid = %order.metadata.uid,
+                "limit order is outside market price, skipping",
+            );
+            false
+        }
     });
     orders
 }
@@ -1141,6 +1142,67 @@ mod tests {
         assert_eq!(
             filter_limit_orders_with_insufficient_sell_amount(orders),
             [order(100, 10)]
+        );
+    }
+
+    #[test]
+    fn filters_mispriced_orders() {
+        let sell_token = H160([1; 20]);
+        let buy_token = H160([2; 20]);
+
+        // Prices are set such that 1 sell token is equivalent to 2 buy tokens.
+        // Additionally, they are scaled to large values to allow for overflows.
+        let prices = btreemap! {
+            sell_token => U256::MAX / 100,
+            buy_token => U256::MAX / 200,
+        };
+        let price_factor = "0.95".parse().unwrap();
+
+        let order = |sell_amount: u8, buy_amount: u8, surplus_fee: u8| Order {
+            data: OrderData {
+                sell_token,
+                sell_amount: sell_amount.into(),
+                buy_token,
+                buy_amount: buy_amount.into(),
+                ..Default::default()
+            },
+            metadata: OrderMetadata {
+                class: OrderClass::Limit(LimitOrderClass {
+                    surplus_fee: surplus_fee.into(),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        let valid_orders = vec![
+            // Reasonably priced order, doesn't get filtered.
+            order(101, 200, 1),
+            // Slightly out of price order, doesn't get filtered.
+            order(10, 21, 0),
+        ];
+
+        let invalid_orders = vec![
+            // Out of price order gets filtered out.
+            order(10, 100, 0),
+            // Reasonably priced order becomes out of price after fees and gets
+            // filtered out
+            order(10, 18, 5),
+            // Zero sell amount after fees gets filtered.
+            order(1, 1, 1),
+            // Overflow sell amount after fees gets filtered.
+            order(1, 1, 100),
+            // Overflow sell value gets filtered.
+            order(255, 1, 1),
+            // Overflow buy value gets filtered.
+            order(100, 255, 1),
+        ];
+
+        let orders = [valid_orders.clone(), invalid_orders].concat();
+        assert_eq!(
+            filter_mispriced_limit_orders(orders, &prices, &price_factor),
+            valid_orders,
         );
     }
 }

--- a/crates/autopilot/src/solvable_orders.rs
+++ b/crates/autopilot/src/solvable_orders.rs
@@ -600,18 +600,9 @@ async fn filter_unsupported_tokens(
 }
 
 fn filter_limit_orders_with_insufficient_sell_amount(mut orders: Vec<Order>) -> Vec<Order> {
-    orders.retain(|order| {
-        let surplus_fee = match &order.metadata.class {
-            OrderClass::Limit(limit) => limit.surplus_fee,
-            _ => return true,
-        };
-
-        match order.data.sell_amount.checked_sub(surplus_fee) {
-            Some(value) if value > U256::zero() => true,
-            // There is not enough sell amount to account for the surplus fee, so exclude
-            // the order unconditionally.
-            _ => false,
-        }
+    orders.retain(|order| match &order.metadata.class {
+        OrderClass::Limit(limit) => order.data.sell_amount > limit.surplus_fee,
+        _ => true,
     });
     orders
 }

--- a/crates/autopilot/src/solvable_orders.rs
+++ b/crates/autopilot/src/solvable_orders.rs
@@ -269,7 +269,11 @@ impl SolvableOrdersCache {
             // Convert the sell and buy price to the native token (ETH) and make sure that sell
             // discounting the surplus fee is higher than buy with the configurable price factor.
             let (sell_native, buy_native) = match (
-                (order.data.sell_amount - surplus_fee).checked_mul(sell_price),
+                order
+                    .data
+                    .sell_amount
+                    .checked_sub(surplus_fee)
+                    .and_then(|sell| sell.checked_mul(sell_price)),
                 order.data.buy_amount.checked_mul(buy_price),
             ) {
                 (Some(sell), Some(buy)) => (sell, buy),


### PR DESCRIPTION
We started getting a few alerts related to:
```
2022-11-17T15:02:08.583Z ERROR auction{id=4083531 run=3196}: solver::driver: error normalizing limit order err=surplus_fee adjustment would underflow sell_amount
```

This PR fixes that alert by removing invalid limit orders from the auction where their computed surplus fee is greater than what they are actually selling (so no amount of surplus can pay the order fee).

Additionally, I changed the `filter_mispriced_limit_orders` computation (I originally was surprised it didn't catch this) to use the discounted sell amount for the market price check. Specifically, we should use the discounted sell amount (as that represents what is actually being traded for the buy token) and added some overflow checking.

### Test Plan

Added unit test!

