### PR TITLE
Add Possibility To Receive Both Coordinates and Internalization Flag

### DIFF
--- a/crates/shared/src/http_solver/model.rs
+++ b/crates/shared/src/http_solver/model.rs
@@ -344,12 +344,6 @@ pub struct ExecutionPlanCoordinatesModel {
     pub internal: bool,
 }
 
-#[derive(Clone, Debug, Default, Deserialize, PartialEq, Eq, Serialize)]
-pub struct CoordinatesWithInternal {
-    pub coordinates: ExecutionPlanCoordinatesModel,
-    pub internal: bool,
-}
-
 /// The result a given solver achieved in the auction
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]

--- a/crates/shared/src/http_solver/model.rs
+++ b/crates/shared/src/http_solver/model.rs
@@ -335,7 +335,6 @@ mod execution_plan_internal {
     }
 }
 
-#[serde_as]
 #[derive(Clone, Debug, Default, Deserialize, PartialEq, Eq, PartialOrd, Ord, Serialize)]
 pub struct ExecutionPlanCoordinatesModel {
     pub sequence: u32,

--- a/crates/solver/src/settlement_simulation.rs
+++ b/crates/solver/src/settlement_simulation.rs
@@ -517,8 +517,11 @@ mod tests {
                             "buy_token": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
                             "exec_buy_amount": "21135750171",
                             "exec_plan": {
-                                "position": 0,
-                                "sequence": 0
+                                "coordinates": {
+                                    "sequence": 0,
+                                    "position": 0
+                                },
+                                "internal": false
                             },
                             "exec_sell_amount": "21129728791",
                             "sell_token": "0xdac17f958d2ee523a2206206994597c13d831ec7"
@@ -543,8 +546,11 @@ mod tests {
                             "buy_token": "0xdac17f958d2ee523a2206206994597c13d831ec7",
                             "exec_buy_amount": "7922480269",
                             "exec_plan": {
-                                "position": 1,
-                                "sequence": 0
+                                "coordinates": {
+                                    "sequence": 0,
+                                    "position": 1
+                                },
+                                "internal": false
                             },
                             "exec_sell_amount": "2005171356556612050",
                             "sell_token": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"

--- a/crates/solver/src/solver/http_solver.rs
+++ b/crates/solver/src/solver/http_solver.rs
@@ -669,6 +669,7 @@ mod tests {
             ExecutionPlan::Coordinates(ExecutionPlanCoordinatesModel {
                 sequence: 0,
                 position: 0,
+                internal: false,
             }),
         ));
 
@@ -809,10 +810,8 @@ mod tests {
                       "exec_sell_amount": "56532986820633012234",
                       "exec_buy_amount": "590320000000000032",
                       "exec_plan": {
-                        "coordinates": {
-                            "sequence": 0,
-                            "position": 0
-                        },
+                        "sequence": 0,
+                        "position": 0,
                         "internal": false
                       }
                     }

--- a/crates/solver/src/solver/http_solver.rs
+++ b/crates/solver/src/solver/http_solver.rs
@@ -809,8 +809,11 @@ mod tests {
                       "exec_sell_amount": "56532986820633012234",
                       "exec_buy_amount": "590320000000000032",
                       "exec_plan": {
-                        "sequence": 0,
-                        "position": 0
+                        "coordinates": {
+                            "sequence": 0,
+                            "position": 0
+                        },
+                        "internal": false
                       }
                     }
                   ]

--- a/crates/solver/src/solver/http_solver/settlement.rs
+++ b/crates/solver/src/solver/http_solver/settlement.rs
@@ -62,9 +62,6 @@ impl Execution {
     fn coordinates(&self) -> Option<ExecutionPlanCoordinatesModel> {
         match self.execution_plan()? {
             ExecutionPlan::Coordinates(coords) => Some(coords.clone()),
-            ExecutionPlan::CoordinatesWithInternal(coords_with_internal) => {
-                Some(coords_with_internal.coordinates.clone())
-            }
             _ => None,
         }
     }
@@ -499,6 +496,7 @@ mod tests {
                 exec_plan: Some(ExecutionPlan::Coordinates(ExecutionPlanCoordinatesModel {
                     sequence: 0,
                     position: 0,
+                    internal: false,
                 })),
             }],
             cost: Default::default(),
@@ -509,7 +507,11 @@ mod tests {
                 buy_token: t0,
                 exec_sell_amount: U256::from(1),
                 exec_buy_amount: U256::from(1),
-                exec_plan: Some(ExecutionPlan::Internal),
+                exec_plan: Some(ExecutionPlan::Coordinates(ExecutionPlanCoordinatesModel {
+                    sequence: 1,
+                    position: 0,
+                    internal: true,
+                })),
             }],
             cost: Default::default(),
         };
@@ -520,8 +522,9 @@ mod tests {
                 exec_sell_amount: U256::from(2),
                 exec_buy_amount: U256::from(1),
                 exec_plan: Some(ExecutionPlan::Coordinates(ExecutionPlanCoordinatesModel {
-                    sequence: 1,
+                    sequence: 2,
                     position: 0,
+                    internal: false,
                 })),
             }],
             cost: Default::default(),
@@ -533,8 +536,9 @@ mod tests {
                 exec_sell_amount: U256::from(6),
                 exec_buy_amount: U256::from(4),
                 exec_plan: Some(ExecutionPlan::Coordinates(ExecutionPlanCoordinatesModel {
-                    sequence: 2,
+                    sequence: 3,
                     position: 0,
+                    internal: false,
                 })),
             }],
             cost: Default::default(),
@@ -780,10 +784,8 @@ mod tests {
                             "exec_sell_amount": "932415220613609833982",
                             "exec_buy_amount": "354009510372389956",
                             "exec_plan": {
-                                "coordinates": {
-                                    "sequence": 0,
-                                    "position": 1
-                                },
+                                "sequence": 0,
+                                "position": 1,
                                 "internal": false
                             }
                         }
@@ -797,10 +799,8 @@ mod tests {
                             "exec_sell_amount": "1",
                             "exec_buy_amount": "2",
                             "exec_plan": {
-                                "coordinates": {
-                                    "sequence": 0,
-                                    "position": 2
-                                },
+                                "sequence": 0,
+                                "position": 2,
                                 "internal": false
                             }
                         }
@@ -830,10 +830,8 @@ mod tests {
                             "exec_sell_amount": "354009510372384890",
                             "exec_buy_amount": "996570293625184642",
                             "exec_plan": {
-                                "coordinates": {
-                                    "sequence": 0,
-                                    "position": 0
-                                },
+                                "sequence": 0,
+                                "position": 0,
                                 "internal": false
                             }
                         }
@@ -857,10 +855,8 @@ mod tests {
                             "exec_sell_amount": "3",
                             "exec_buy_amount": "4",
                             "exec_plan": {
-                                "coordinates": {
-                                    "sequence": 0,
-                                    "position": 3
-                                },
+                                "sequence": 0,
+                                "position": 3,
                                 "internal": false
                             }
                         }
@@ -901,57 +897,41 @@ mod tests {
                     order: Liquidity::BalancerWeighted(wpo),
                     input: (token_c, U256::from(996570293625184642u128)),
                     output: (token_b, U256::from(354009510372384890u128)),
-                    exec_plan: Some(ExecutionPlan::CoordinatesWithInternal(
-                        CoordinatesWithInternal {
-                            coordinates: ExecutionPlanCoordinatesModel {
-                                sequence: 0u32,
-                                position: 0u32,
-                            },
-                            internal: false,
-                        }
-                    )),
+                    exec_plan: Some(ExecutionPlan::Coordinates(ExecutionPlanCoordinatesModel {
+                        sequence: 0u32,
+                        position: 0u32,
+                        internal: false,
+                    })),
                 })),
                 Execution::Amm(Box::new(ExecutedAmm {
                     order: Liquidity::ConstantProduct(cpo_0),
                     input: (token_b, U256::from(354009510372389956u128)),
                     output: (token_a, U256::from(932415220613609833982u128)),
-                    exec_plan: Some(ExecutionPlan::CoordinatesWithInternal(
-                        CoordinatesWithInternal {
-                            coordinates: ExecutionPlanCoordinatesModel {
-                                sequence: 0u32,
-                                position: 1u32,
-                            },
-                            internal: false,
-                        }
-                    )),
+                    exec_plan: Some(ExecutionPlan::Coordinates(ExecutionPlanCoordinatesModel {
+                        sequence: 0u32,
+                        position: 1u32,
+                        internal: false,
+                    })),
                 })),
                 Execution::Amm(Box::new(ExecutedAmm {
                     order: Liquidity::ConstantProduct(cpo_1),
                     input: (token_c, U256::from(2)),
                     output: (token_b, U256::from(1)),
-                    exec_plan: Some(ExecutionPlan::CoordinatesWithInternal(
-                        CoordinatesWithInternal {
-                            coordinates: ExecutionPlanCoordinatesModel {
-                                sequence: 0u32,
-                                position: 2u32,
-                            },
-                            internal: false,
-                        }
-                    )),
+                    exec_plan: Some(ExecutionPlan::Coordinates(ExecutionPlanCoordinatesModel {
+                        sequence: 0u32,
+                        position: 2u32,
+                        internal: false,
+                    })),
                 })),
                 Execution::Amm(Box::new(ExecutedAmm {
                     order: Liquidity::BalancerStable(spo),
                     input: (token_c, U256::from(4)),
                     output: (token_b, U256::from(3)),
-                    exec_plan: Some(ExecutionPlan::CoordinatesWithInternal(
-                        CoordinatesWithInternal {
-                            coordinates: ExecutionPlanCoordinatesModel {
-                                sequence: 0u32,
-                                position: 3u32,
-                            },
-                            internal: false,
-                        }
-                    )),
+                    exec_plan: Some(ExecutionPlan::Coordinates(ExecutionPlanCoordinatesModel {
+                        sequence: 0u32,
+                        position: 3u32,
+                        internal: false,
+                    })),
                 })),
             ],
         );
@@ -976,6 +956,7 @@ mod tests {
             exec_plan: Some(ExecutionPlan::Coordinates(ExecutionPlanCoordinatesModel {
                 sequence: 1u32,
                 position: 2u32,
+                internal: false,
             })),
         }];
         let interactions = vec![InteractionData {
@@ -987,6 +968,7 @@ mod tests {
             exec_plan: Some(ExecutionPlan::Coordinates(ExecutionPlanCoordinatesModel {
                 sequence: 1u32,
                 position: 1u32,
+                internal: false,
             })),
             cost: None,
         }];

--- a/crates/solver/src/solver/http_solver/settlement.rs
+++ b/crates/solver/src/solver/http_solver/settlement.rs
@@ -901,49 +901,57 @@ mod tests {
                     order: Liquidity::BalancerWeighted(wpo),
                     input: (token_c, U256::from(996570293625184642u128)),
                     output: (token_b, U256::from(354009510372384890u128)),
-                    exec_plan: Some(ExecutionPlan::CoordinatesWithInternal(CoordinatesWithInternal {
-                        coordinates: ExecutionPlanCoordinatesModel {
-                            sequence: 0u32,
-                            position: 0u32,
-                        },
-                        internal: false,
-                    })),
+                    exec_plan: Some(ExecutionPlan::CoordinatesWithInternal(
+                        CoordinatesWithInternal {
+                            coordinates: ExecutionPlanCoordinatesModel {
+                                sequence: 0u32,
+                                position: 0u32,
+                            },
+                            internal: false,
+                        }
+                    )),
                 })),
                 Execution::Amm(Box::new(ExecutedAmm {
                     order: Liquidity::ConstantProduct(cpo_0),
                     input: (token_b, U256::from(354009510372389956u128)),
                     output: (token_a, U256::from(932415220613609833982u128)),
-                    exec_plan: Some(ExecutionPlan::CoordinatesWithInternal(CoordinatesWithInternal {
-                        coordinates: ExecutionPlanCoordinatesModel {
-                            sequence: 0u32,
-                            position: 1u32,
-                        },
-                        internal: false,
-                    })),
+                    exec_plan: Some(ExecutionPlan::CoordinatesWithInternal(
+                        CoordinatesWithInternal {
+                            coordinates: ExecutionPlanCoordinatesModel {
+                                sequence: 0u32,
+                                position: 1u32,
+                            },
+                            internal: false,
+                        }
+                    )),
                 })),
                 Execution::Amm(Box::new(ExecutedAmm {
                     order: Liquidity::ConstantProduct(cpo_1),
                     input: (token_c, U256::from(2)),
                     output: (token_b, U256::from(1)),
-                    exec_plan: Some(ExecutionPlan::CoordinatesWithInternal(CoordinatesWithInternal {
-                        coordinates: ExecutionPlanCoordinatesModel {
-                            sequence: 0u32,
-                            position: 2u32,
-                        },
-                        internal: false,
-                    })),
+                    exec_plan: Some(ExecutionPlan::CoordinatesWithInternal(
+                        CoordinatesWithInternal {
+                            coordinates: ExecutionPlanCoordinatesModel {
+                                sequence: 0u32,
+                                position: 2u32,
+                            },
+                            internal: false,
+                        }
+                    )),
                 })),
                 Execution::Amm(Box::new(ExecutedAmm {
                     order: Liquidity::BalancerStable(spo),
                     input: (token_c, U256::from(4)),
                     output: (token_b, U256::from(3)),
-                    exec_plan: Some(ExecutionPlan::CoordinatesWithInternal(CoordinatesWithInternal {
-                        coordinates: ExecutionPlanCoordinatesModel {
-                            sequence: 0u32,
-                            position: 3u32,
-                        },
-                        internal: false,
-                    })),
+                    exec_plan: Some(ExecutionPlan::CoordinatesWithInternal(
+                        CoordinatesWithInternal {
+                            coordinates: ExecutionPlanCoordinatesModel {
+                                sequence: 0u32,
+                                position: 3u32,
+                            },
+                            internal: false,
+                        }
+                    )),
                 })),
             ],
         );


### PR DESCRIPTION
Preparation PR for https://github.com/cowprotocol/services/pull/791

The purpose of this PR is to make the https://github.com/cowprotocol/services/pull/791 breaking change less _breaking_, meaning we would give solvers time to change their format for `ExecutionPlan`, and once we make sure all solvers are using the new format, we can merge https://github.com/cowprotocol/services/pull/791.

### Test Plan

Updated unit tests.
