### PR TITLE
Handle ERC-1271 Signature Verification Reverts

### DIFF
--- a/crates/shared/src/order_validation.rs
+++ b/crates/shared/src/order_validation.rs
@@ -158,8 +158,7 @@ impl From<SignatureValidationError> for ValidationError {
     fn from(err: SignatureValidationError) -> Self {
         match err {
             SignatureValidationError::Invalid => Self::InvalidSignature,
-            SignatureValidationError::Method(err) => Self::Other(err.into()),
-            SignatureValidationError::Execution(err) => Self::Other(err.into()),
+            SignatureValidationError::Other(err) => Self::Other(err),
         }
     }
 }

--- a/crates/shared/src/signature_validator.rs
+++ b/crates/shared/src/signature_validator.rs
@@ -115,7 +115,7 @@ impl SignatureValidating for Web3SignatureValidator {
         check_erc1271_result(result?)?;
 
         // Adjust the estimate we receive by the fixed transaction gas cost.
-        // This is because this cost is not payed by an internal call, but by
+        // This is because this cost is not paid by an internal call, but by
         // the root transaction only.
         Ok(gas_estimate?.as_u64() - TRANSACTION_INITIALIZATION_GAS_AMOUNT)
     }


### PR DESCRIPTION
I observed alerts:
```
request{id="..."}: shared::api: internal server error error=order_validation
Caused by:
   contract call reverted with message: Some("!match")
```

This was caused because the `validate_signature_and_get_additional_gas` check would call `is_valid_signature` which would revert. We weren't classifying these contract reverts and they were bubbling up as "other" errors and turning into 500 errors (when really they should be 400 bad request errors).

### Test Plan

Just the compiler. Logic didn't really change, we should add an E2E test that trades an ERC-1271 order.
