### PR TITLE
Limit order metrics

### DIFF
--- a/crates/autopilot/src/database/orders.rs
+++ b/crates/autopilot/src/database/orders.rs
@@ -66,4 +66,28 @@ impl Postgres {
         .await?;
         Ok(())
     }
+
+    pub async fn count_limit_orders(&self) -> Result<i64> {
+        let _timer = super::Metrics::get()
+            .database_queries
+            .with_label_values(&["count_limit_orders"])
+            .start_timer();
+        let mut ex = self.0.acquire().await?;
+        Ok(database::orders::count_limit_orders(&mut ex, now_in_epoch_seconds().into()).await?)
+    }
+
+    pub async fn count_limit_orders_with_outdated_fees(&self, age: Duration) -> Result<i64> {
+        let _timer = super::Metrics::get()
+            .database_queries
+            .with_label_values(&["count_limit_orders_with_outdated_fees"])
+            .start_timer();
+        let mut ex = self.0.acquire().await?;
+        let timestamp = Utc::now() - age;
+        Ok(database::orders::count_limit_orders_with_outdated_fees(
+            &mut ex,
+            timestamp,
+            now_in_epoch_seconds().into(),
+        )
+        .await?)
+    }
 }

--- a/crates/autopilot/src/limit_orders/metrics.rs
+++ b/crates/autopilot/src/limit_orders/metrics.rs
@@ -1,0 +1,43 @@
+use chrono::Duration;
+use prometheus::IntGauge;
+
+use crate::database::Postgres;
+
+pub struct LimitOrderMetrics {
+    pub limit_order_age: Duration,
+    pub loop_delay: std::time::Duration,
+    pub database: Postgres,
+}
+
+impl LimitOrderMetrics {
+    pub fn spawn(self) {
+        tokio::spawn(async move {
+            let limit_orders_gauge = gauge("limit_orders", "Valid limit orders.");
+            let quoted_limit_orders_gauge = gauge("quoted_limit_orders", "Quoted limit orders.");
+            let unquoted_limit_orders_gauge = gauge(
+                "unquoted_limit_orders",
+                "Unquoted or outdated limit orders.",
+            );
+            loop {
+                let limit_orders = self.database.count_limit_orders().await.unwrap();
+                let unquoted_limit_orders = self
+                    .database
+                    .count_limit_orders_with_outdated_fees(self.limit_order_age)
+                    .await
+                    .unwrap();
+                let quoted_limit_orders = limit_orders - unquoted_limit_orders;
+                limit_orders_gauge.set(limit_orders);
+                unquoted_limit_orders_gauge.set(unquoted_limit_orders);
+                quoted_limit_orders_gauge.set(quoted_limit_orders);
+                tokio::time::sleep(self.loop_delay).await;
+            }
+        });
+    }
+}
+
+fn gauge(name: &str, help: &str) -> IntGauge {
+    let registry = global_metrics::get_metrics_registry();
+    let gauge = IntGauge::new(name, help).unwrap();
+    registry.register(Box::new(gauge.clone())).unwrap();
+    gauge
+}

--- a/crates/autopilot/src/limit_orders/mod.rs
+++ b/crates/autopilot/src/limit_orders/mod.rs
@@ -1,0 +1,5 @@
+mod metrics;
+mod quoter;
+
+pub use metrics::LimitOrderMetrics;
+pub use quoter::LimitOrderQuoter;

--- a/crates/autopilot/src/limit_orders/quoter.rs
+++ b/crates/autopilot/src/limit_orders/quoter.rs
@@ -14,22 +14,6 @@ use shared::{
 };
 use std::sync::Arc;
 
-#[derive(prometheus_metric_storage::MetricStorage, Clone, Debug)]
-#[metric(subsystem = "limit_order_quoter")]
-struct Metrics {
-    /// Counter for failed limit orders.
-    failed: prometheus::IntCounter,
-}
-
-impl Metrics {
-    fn on_failed(failed: u64) {
-        Self::instance(global_metrics::get_metric_storage_registry())
-            .unwrap()
-            .failed
-            .inc_by(failed);
-    }
-}
-
 /// Background task which quotes all limit orders and sets the surplus_fee for each one
 /// to the fee returned by the quoting process. If quoting fails, the corresponding
 /// order is skipped.
@@ -135,5 +119,21 @@ impl LimitOrderQuoter {
                 },
             )
             .await
+    }
+}
+
+#[derive(prometheus_metric_storage::MetricStorage, Clone, Debug)]
+#[metric(subsystem = "limit_order_quoter")]
+struct Metrics {
+    /// Counter for failed limit orders.
+    failed: prometheus::IntCounter,
+}
+
+impl Metrics {
+    fn on_failed(failed: u64) {
+        Self::instance(global_metrics::get_metric_storage_registry())
+            .unwrap()
+            .failed
+            .inc_by(failed);
     }
 }

--- a/crates/autopilot/src/solvable_orders.rs
+++ b/crates/autopilot/src/solvable_orders.rs
@@ -34,19 +34,19 @@ const MAX_AUCTION_CREATION_TIME: Duration = Duration::from_secs(10);
 
 #[derive(prometheus_metric_storage::MetricStorage)]
 pub struct Metrics {
-    /// auction creations
+    /// Auction creations.
     auction_creations: IntCounter,
 
-    /// auction solvable orders
+    /// Auction solvable orders.
     auction_solvable_orders: IntGauge,
 
-    /// auction filtered orders
+    /// Auction filtered orders.
     auction_filtered_orders: IntGauge,
 
-    /// auction errored price estimates
+    /// Auction errored price estimates.
     auction_errored_price_estimates: IntCounter,
 
-    /// auction price estimate timeouts
+    /// Auction price estimate timeouts.
     auction_price_estimate_timeouts: IntCounter,
 }
 

--- a/crates/e2e/tests/e2e/services.rs
+++ b/crates/e2e/tests/e2e/services.rs
@@ -6,7 +6,7 @@ use autopilot::{
         ethflow_events::EthFlowOnchainOrderParser, OnchainOrderParser,
     },
     event_updater::{CoWSwapOnchainOrdersContract, GPv2SettlementContract},
-    limit_order_quoter::LimitOrderQuoter,
+    limit_orders::LimitOrderQuoter,
     solvable_orders::SolvableOrdersCache,
 };
 use contracts::{CoWSwapOnchainOrders, WETH9};

--- a/crates/orderbook/src/database/orders.rs
+++ b/crates/orderbook/src/database/orders.rs
@@ -299,7 +299,7 @@ impl LimitOrderCounting for Postgres {
             .start_timer();
 
         let mut ex = self.pool.acquire().await?;
-        Ok(database::orders::count_limit_orders(
+        Ok(database::orders::count_limit_orders_by_owner(
             &mut ex,
             now_in_epoch_seconds().try_into().unwrap(),
             &ByteArray(owner.0),


### PR DESCRIPTION
Fixes https://github.com/cowprotocol/services/issues/767.

Creates a new background task to collect some limit order metrics.

These metrics did not fit into the auction cutting process IMO since we always use `LIMIT` when fetching rows.

### Test Plan

Automated tests for the DB queries. Not sure if we test the metrics themselves, I don't think so?
