### PR TITLE
Separate e2e helper function: services and onchain components

### DIFF
--- a/crates/e2e/tests/e2e/eth_integration.rs
+++ b/crates/e2e/tests/e2e/eth_integration.rs
@@ -1,7 +1,9 @@
 use crate::{
+    onchain_components::{
+        deploy_token_with_weth_uniswap_pool, to_wei, uniswap_pair_provider, WethPoolConfig,
+    },
     services::{
-        create_order_converter, create_orderbook_api, deploy_token_with_weth_uniswap_pool, to_wei,
-        uniswap_pair_provider, wait_for_solvable_orders, OrderbookServices, WethPoolConfig,
+        create_order_converter, create_orderbook_api, wait_for_solvable_orders, OrderbookServices,
         API_HOST,
     },
     tx,

--- a/crates/e2e/tests/e2e/limit_orders.rs
+++ b/crates/e2e/tests/e2e/limit_orders.rs
@@ -1,9 +1,14 @@
 use std::sync::Arc;
 
-use crate::services::{
-    create_order_converter, create_orderbook_api, deploy_mintable_token,
-    deploy_token_with_weth_uniswap_pool, to_wei, uniswap_pair_provider, wait_for_solvable_orders,
-    OrderbookServices, WethPoolConfig, API_HOST,
+use crate::{
+    onchain_components::{
+        deploy_mintable_token, deploy_token_with_weth_uniswap_pool, to_wei, uniswap_pair_provider,
+        WethPoolConfig,
+    },
+    services::{
+        create_order_converter, create_orderbook_api, wait_for_solvable_orders, OrderbookServices,
+        API_HOST,
+    },
 };
 use contracts::IUniswapLikeRouter;
 use ethcontract::prelude::{Account, Address, PrivateKey, U256};

--- a/crates/e2e/tests/e2e/main.rs
+++ b/crates/e2e/tests/e2e/main.rs
@@ -3,10 +3,11 @@
 // here and in this test we include all the tests we want to run.
 
 #[macro_use]
-mod services;
+mod onchain_components;
 mod deploy;
 mod eth_flow;
 mod local_node;
+mod services;
 
 // Each of the following modules contains tests.
 mod eth_integration;

--- a/crates/e2e/tests/e2e/onchain_components.rs
+++ b/crates/e2e/tests/e2e/onchain_components.rs
@@ -1,0 +1,190 @@
+use crate::deploy::Contracts;
+use contracts::{ERC20Mintable, GnosisSafe, GnosisSafeCompatibilityFallbackHandler};
+use ethcontract::{Account, Bytes, H160, H256, U256};
+use shared::{
+    ethrpc::Web3,
+    sources::uniswap_v2::{self, pair_provider::PairProvider},
+};
+use web3::signing::{Key as _, SecretKeyRef};
+
+#[macro_export]
+macro_rules! tx_value {
+    ($acc:expr, $value:expr, $call:expr) => {{
+        const NAME: &str = stringify!($call);
+        $call
+            .from($acc.clone())
+            .value($value)
+            .gas_price(0.0.into())
+            .send()
+            .await
+            .expect(&format!("{} failed", NAME))
+    }};
+}
+
+#[macro_export]
+macro_rules! tx {
+    ($acc:expr, $call:expr) => {
+        $crate::tx_value!($acc, U256::zero(), $call)
+    };
+}
+
+#[macro_export]
+macro_rules! tx_safe {
+    ($acc:ident, $safe:ident, $call:expr) => {{
+        let call = $call;
+        $crate::tx!(
+            $acc,
+            $safe.exec_transaction(
+                call.tx.to.unwrap(),
+                call.tx.value.unwrap_or_default(),
+                ::ethcontract::Bytes(call.tx.data.unwrap_or_default().0),
+                Default::default(),
+                Default::default(),
+                Default::default(),
+                Default::default(),
+                Default::default(),
+                Default::default(),
+                $crate::onchain_components::gnosis_safe_prevalidated_signature($acc.address()),
+            )
+        );
+    }};
+}
+
+pub fn to_wei(base: u32) -> U256 {
+    U256::from(base) * U256::from(10).pow(18.into())
+}
+
+/// Generate a Safe "pre-validated" signature.
+///
+/// This is a special "marker" signature that can be used if the account that
+/// is executing the transaction is an owner. For single owner safes, this is
+/// the easiest way to execute a transaction as it does not involve any ECDSA
+/// signing.
+///
+/// See:
+/// - Documentation: <https://docs.gnosis-safe.io/contracts/signatures#pre-validated-signatures>
+/// - Code: <https://github.com/safe-global/safe-contracts/blob/c36bcab46578a442862d043e12a83fec41143dec/contracts/GnosisSafe.sol#L287-L291>
+pub fn gnosis_safe_prevalidated_signature(owner: H160) -> Bytes<Vec<u8>> {
+    let mut signature = vec![0; 65];
+    signature[12..32].copy_from_slice(owner.as_bytes());
+    signature[64] = 1;
+    Bytes(signature)
+}
+
+/// Generate an owner signature for EIP-1271.
+///
+/// The Gnosis Safe uses off-chain ECDSA signatures from its owners as the
+/// signature bytes when validating EIP-1271 signatures. Specifically, it
+/// expects a signed EIP-712 `SafeMessage(bytes message)` (where `message` is
+/// the 32-byte hash of the data being verified).
+///
+/// See:
+/// - Code: <https://github.com/safe-global/safe-contracts/blob/c36bcab46578a442862d043e12a83fec41143dec/contracts/handler/CompatibilityFallbackHandler.sol#L66-L70>
+pub async fn gnosis_safe_eip1271_signature(
+    key: SecretKeyRef<'_>,
+    safe: &GnosisSafe,
+    message_hash: H256,
+) -> Vec<u8> {
+    let handler =
+        GnosisSafeCompatibilityFallbackHandler::at(&safe.raw_instance().web3(), safe.address());
+
+    let signing_hash = handler
+        .get_message_hash(Bytes(message_hash.as_bytes().to_vec()))
+        .call()
+        .await
+        .unwrap();
+
+    let signature = key.sign(&signing_hash.0, None).unwrap();
+
+    let mut bytes = vec![0u8; 65];
+    bytes[0..32].copy_from_slice(signature.r.as_bytes());
+    bytes[32..64].copy_from_slice(signature.s.as_bytes());
+    bytes[64] = signature.v as _;
+
+    bytes
+}
+
+pub async fn deploy_mintable_token(web3: &Web3) -> ERC20Mintable {
+    ERC20Mintable::builder(web3)
+        .deploy()
+        .await
+        .expect("MintableERC20 deployment failed")
+}
+
+pub struct WethPoolConfig {
+    pub token_amount: U256,
+    pub weth_amount: U256,
+}
+
+pub struct MintableToken {
+    pub contract: ERC20Mintable,
+    minter: Account,
+}
+
+impl MintableToken {
+    pub async fn mint(&self, to: H160, amount: U256) {
+        tx!(self.minter, self.contract.mint(to, amount));
+    }
+}
+
+pub async fn deploy_token_with_weth_uniswap_pool(
+    web3: &Web3,
+    deployed_contracts: &Contracts,
+    pool_config: WethPoolConfig,
+) -> MintableToken {
+    let token = deploy_mintable_token(web3).await;
+    let minter = Account::Local(
+        web3.eth().accounts().await.expect("get accounts failed")[0],
+        None,
+    );
+
+    let WethPoolConfig {
+        weth_amount,
+        token_amount,
+    } = pool_config;
+
+    tx!(minter, token.mint(minter.address(), token_amount));
+    tx_value!(minter, weth_amount, deployed_contracts.weth.deposit());
+
+    tx!(
+        minter,
+        deployed_contracts
+            .uniswap_factory
+            .create_pair(token.address(), deployed_contracts.weth.address())
+    );
+    tx!(
+        minter,
+        token.approve(deployed_contracts.uniswap_router.address(), token_amount)
+    );
+    tx!(
+        minter,
+        deployed_contracts
+            .weth
+            .approve(deployed_contracts.uniswap_router.address(), weth_amount)
+    );
+    tx!(
+        minter,
+        deployed_contracts.uniswap_router.add_liquidity(
+            token.address(),
+            deployed_contracts.weth.address(),
+            token_amount,
+            weth_amount,
+            0_u64.into(),
+            0_u64.into(),
+            minter.address(),
+            U256::max_value(),
+        )
+    );
+
+    MintableToken {
+        contract: token,
+        minter,
+    }
+}
+
+pub fn uniswap_pair_provider(contracts: &Contracts) -> PairProvider {
+    PairProvider {
+        factory: contracts.uniswap_factory.address(),
+        init_code_digest: uniswap_v2::INIT_CODE_DIGEST,
+    }
+}

--- a/crates/e2e/tests/e2e/onchain_settlement.rs
+++ b/crates/e2e/tests/e2e/onchain_settlement.rs
@@ -1,7 +1,9 @@
 use crate::{
+    onchain_components::{
+        deploy_token_with_weth_uniswap_pool, to_wei, uniswap_pair_provider, WethPoolConfig,
+    },
     services::{
-        create_order_converter, create_orderbook_api, deploy_token_with_weth_uniswap_pool, to_wei,
-        uniswap_pair_provider, wait_for_solvable_orders, OrderbookServices, WethPoolConfig,
+        create_order_converter, create_orderbook_api, wait_for_solvable_orders, OrderbookServices,
         API_HOST,
     },
     tx,

--- a/crates/e2e/tests/e2e/order_cancellation.rs
+++ b/crates/e2e/tests/e2e/order_cancellation.rs
@@ -1,8 +1,6 @@
 use crate::{
-    services::{
-        create_orderbook_api, deploy_token_with_weth_uniswap_pool, to_wei, OrderbookServices,
-        WethPoolConfig, API_HOST,
-    },
+    onchain_components::{deploy_token_with_weth_uniswap_pool, to_wei, WethPoolConfig},
+    services::{create_orderbook_api, OrderbookServices, API_HOST},
     tx, tx_value,
 };
 use ethcontract::prelude::{Account, Address, PrivateKey, U256};

--- a/crates/e2e/tests/e2e/refunder.rs
+++ b/crates/e2e/tests/e2e/refunder.rs
@@ -1,10 +1,10 @@
 use crate::{
     eth_flow::{EthFlowOrderOnchainStatus, ExtendedEthFlowOrder},
     local_node::AccountAssigner,
-    services::{
-        deploy_token_with_weth_uniswap_pool, to_wei, MintableToken, OrderbookServices,
-        WethPoolConfig, API_HOST,
+    onchain_components::{
+        deploy_token_with_weth_uniswap_pool, to_wei, MintableToken, WethPoolConfig,
     },
+    services::{OrderbookServices, API_HOST},
 };
 use ethcontract::{H160, U256};
 use model::quote::{

--- a/crates/e2e/tests/e2e/services.rs
+++ b/crates/e2e/tests/e2e/services.rs
@@ -49,7 +49,6 @@ use std::{
 
 pub const API_HOST: &str = "http://127.0.0.1:8080";
 
-#[allow(dead_code)]
 pub fn create_orderbook_api() -> OrderBookApi {
     OrderBookApi::new(
         reqwest::Url::from_str(API_HOST).unwrap(),

--- a/crates/e2e/tests/e2e/services.rs
+++ b/crates/e2e/tests/e2e/services.rs
@@ -1,4 +1,4 @@
-use crate::deploy::Contracts;
+use crate::{deploy::Contracts, onchain_components::uniswap_pair_provider};
 use anyhow::{anyhow, Result};
 use async_trait::async_trait;
 use autopilot::{
@@ -9,11 +9,9 @@ use autopilot::{
     limit_order_quoter::LimitOrderQuoter,
     solvable_orders::SolvableOrdersCache,
 };
-use contracts::{
-    CoWSwapOnchainOrders, ERC20Mintable, GnosisSafe, GnosisSafeCompatibilityFallbackHandler, WETH9,
-};
+use contracts::{CoWSwapOnchainOrders, WETH9};
 use database::quotes::QuoteId;
-use ethcontract::{Account, Bytes, H160, H256, U256};
+use ethcontract::{H160, U256};
 use model::{quote::QuoteSigningScheme, DomainSeparator};
 use orderbook::{database::Postgres, orderbook::Orderbook};
 use reqwest::{Client, StatusCode};
@@ -37,9 +35,7 @@ use shared::{
     rate_limiter::RateLimiter,
     recent_block_cache::CacheConfig,
     signature_validator::Web3SignatureValidator,
-    sources::uniswap_v2::{
-        self, pair_provider::PairProvider, pool_cache::PoolCache, pool_fetching::PoolFetcher,
-    },
+    sources::uniswap_v2::{pool_cache::PoolCache, pool_fetching::PoolFetcher},
 };
 use solver::{liquidity::order_converter::OrderConverter, orderbook::OrderBookApi};
 use std::{
@@ -50,106 +46,8 @@ use std::{
     sync::Arc,
     time::Duration,
 };
-use web3::signing::{Key as _, SecretKeyRef};
 
 pub const API_HOST: &str = "http://127.0.0.1:8080";
-
-#[macro_export]
-macro_rules! tx_value {
-    ($acc:expr, $value:expr, $call:expr) => {{
-        const NAME: &str = stringify!($call);
-        $call
-            .from($acc.clone())
-            .value($value)
-            .gas_price(0.0.into())
-            .send()
-            .await
-            .expect(&format!("{} failed", NAME))
-    }};
-}
-
-#[macro_export]
-macro_rules! tx {
-    ($acc:expr, $call:expr) => {
-        $crate::tx_value!($acc, U256::zero(), $call)
-    };
-}
-
-#[macro_export]
-macro_rules! tx_safe {
-    ($acc:ident, $safe:ident, $call:expr) => {{
-        let call = $call;
-        $crate::tx!(
-            $acc,
-            $safe.exec_transaction(
-                call.tx.to.unwrap(),
-                call.tx.value.unwrap_or_default(),
-                ::ethcontract::Bytes(call.tx.data.unwrap_or_default().0),
-                Default::default(),
-                Default::default(),
-                Default::default(),
-                Default::default(),
-                Default::default(),
-                Default::default(),
-                $crate::services::gnosis_safe_prevalidated_signature($acc.address()),
-            )
-        );
-    }};
-}
-
-pub fn to_wei(base: u32) -> U256 {
-    U256::from(base) * U256::from(10).pow(18.into())
-}
-
-/// Generate a Safe "pre-validated" signature.
-///
-/// This is a special "marker" signature that can be used if the account that
-/// is executing the transaction is an owner. For single owner safes, this is
-/// the easiest way to execute a transaction as it does not involve any ECDSA
-/// signing.
-///
-/// See:
-/// - Documentation: <https://docs.gnosis-safe.io/contracts/signatures#pre-validated-signatures>
-/// - Code: <https://github.com/safe-global/safe-contracts/blob/c36bcab46578a442862d043e12a83fec41143dec/contracts/GnosisSafe.sol#L287-L291>
-pub fn gnosis_safe_prevalidated_signature(owner: H160) -> Bytes<Vec<u8>> {
-    let mut signature = vec![0; 65];
-    signature[12..32].copy_from_slice(owner.as_bytes());
-    signature[64] = 1;
-    Bytes(signature)
-}
-
-/// Generate an owner signature for EIP-1271.
-///
-/// The Gnosis Safe uses off-chain ECDSA signatures from its owners as the
-/// signature bytes when validating EIP-1271 signatures. Specifically, it
-/// expects a signed EIP-712 `SafeMessage(bytes message)` (where `message` is
-/// the 32-byte hash of the data being verified).
-///
-/// See:
-/// - Code: <https://github.com/safe-global/safe-contracts/blob/c36bcab46578a442862d043e12a83fec41143dec/contracts/handler/CompatibilityFallbackHandler.sol#L66-L70>
-pub async fn gnosis_safe_eip1271_signature(
-    key: SecretKeyRef<'_>,
-    safe: &GnosisSafe,
-    message_hash: H256,
-) -> Vec<u8> {
-    let handler =
-        GnosisSafeCompatibilityFallbackHandler::at(&safe.raw_instance().web3(), safe.address());
-
-    let signing_hash = handler
-        .get_message_hash(Bytes(message_hash.as_bytes().to_vec()))
-        .call()
-        .await
-        .unwrap();
-
-    let signature = key.sign(&signing_hash.0, None).unwrap();
-
-    let mut bytes = vec![0u8; 65];
-    bytes[0..32].copy_from_slice(signature.r.as_bytes());
-    bytes[32..64].copy_from_slice(signature.s.as_bytes());
-    bytes[64] = signature.v as _;
-
-    bytes
-}
 
 #[allow(dead_code)]
 pub fn create_orderbook_api() -> OrderBookApi {
@@ -166,91 +64,6 @@ pub fn create_order_converter(web3: &Web3, weth_address: H160) -> Arc<OrderConve
         fee_objective_scaling_factor: 1.,
         min_order_age: Duration::from_secs(0),
     })
-}
-
-pub async fn deploy_mintable_token(web3: &Web3) -> ERC20Mintable {
-    ERC20Mintable::builder(web3)
-        .deploy()
-        .await
-        .expect("MintableERC20 deployment failed")
-}
-
-pub struct WethPoolConfig {
-    pub token_amount: U256,
-    pub weth_amount: U256,
-}
-
-pub struct MintableToken {
-    pub contract: ERC20Mintable,
-    minter: Account,
-}
-
-impl MintableToken {
-    pub async fn mint(&self, to: H160, amount: U256) {
-        tx!(self.minter, self.contract.mint(to, amount));
-    }
-}
-
-pub async fn deploy_token_with_weth_uniswap_pool(
-    web3: &Web3,
-    deployed_contracts: &Contracts,
-    pool_config: WethPoolConfig,
-) -> MintableToken {
-    let token = deploy_mintable_token(web3).await;
-    let minter = Account::Local(
-        web3.eth().accounts().await.expect("get accounts failed")[0],
-        None,
-    );
-
-    let WethPoolConfig {
-        weth_amount,
-        token_amount,
-    } = pool_config;
-
-    tx!(minter, token.mint(minter.address(), token_amount));
-    tx_value!(minter, weth_amount, deployed_contracts.weth.deposit());
-
-    tx!(
-        minter,
-        deployed_contracts
-            .uniswap_factory
-            .create_pair(token.address(), deployed_contracts.weth.address())
-    );
-    tx!(
-        minter,
-        token.approve(deployed_contracts.uniswap_router.address(), token_amount)
-    );
-    tx!(
-        minter,
-        deployed_contracts
-            .weth
-            .approve(deployed_contracts.uniswap_router.address(), weth_amount)
-    );
-    tx!(
-        minter,
-        deployed_contracts.uniswap_router.add_liquidity(
-            token.address(),
-            deployed_contracts.weth.address(),
-            token_amount,
-            weth_amount,
-            0_u64.into(),
-            0_u64.into(),
-            minter.address(),
-            U256::max_value(),
-        )
-    );
-
-    MintableToken {
-        contract: token,
-        minter,
-    }
-}
-
-pub fn uniswap_pair_provider(contracts: &Contracts) -> PairProvider {
-    PairProvider {
-        factory: contracts.uniswap_factory.address(),
-        init_code_digest: uniswap_v2::INIT_CODE_DIGEST,
-    }
 }
 
 pub struct OrderbookServices {

--- a/crates/e2e/tests/e2e/settlement_without_onchain_liquidity.rs
+++ b/crates/e2e/tests/e2e/settlement_without_onchain_liquidity.rs
@@ -1,6 +1,11 @@
-use crate::services::{
-    create_order_converter, create_orderbook_api, deploy_token_with_weth_uniswap_pool, to_wei,
-    uniswap_pair_provider, wait_for_solvable_orders, OrderbookServices, WethPoolConfig, API_HOST,
+use crate::{
+    onchain_components::{
+        deploy_token_with_weth_uniswap_pool, to_wei, uniswap_pair_provider, WethPoolConfig,
+    },
+    services::{
+        create_order_converter, create_orderbook_api, wait_for_solvable_orders, OrderbookServices,
+        API_HOST,
+    },
 };
 use contracts::IUniswapLikeRouter;
 use ethcontract::prelude::{Account, Address, PrivateKey, U256};

--- a/crates/e2e/tests/e2e/smart_contract_orders.rs
+++ b/crates/e2e/tests/e2e/smart_contract_orders.rs
@@ -1,7 +1,12 @@
-use crate::services::{
-    create_order_converter, create_orderbook_api, deploy_token_with_weth_uniswap_pool,
-    gnosis_safe_eip1271_signature, to_wei, uniswap_pair_provider, wait_for_solvable_orders,
-    OrderbookServices, WethPoolConfig, API_HOST,
+use crate::{
+    onchain_components::{
+        deploy_token_with_weth_uniswap_pool, gnosis_safe_eip1271_signature, to_wei,
+        uniswap_pair_provider, WethPoolConfig,
+    },
+    services::{
+        create_order_converter, create_orderbook_api, wait_for_solvable_orders, OrderbookServices,
+        API_HOST,
+    },
 };
 use contracts::{
     GnosisSafe, GnosisSafeCompatibilityFallbackHandler, GnosisSafeProxy, IUniswapLikeRouter,

--- a/crates/e2e/tests/e2e/vault_balances.rs
+++ b/crates/e2e/tests/e2e/vault_balances.rs
@@ -1,6 +1,11 @@
-use crate::services::{
-    create_order_converter, create_orderbook_api, deploy_token_with_weth_uniswap_pool, to_wei,
-    uniswap_pair_provider, wait_for_solvable_orders, OrderbookServices, WethPoolConfig, API_HOST,
+use crate::{
+    onchain_components::{
+        deploy_token_with_weth_uniswap_pool, to_wei, uniswap_pair_provider, WethPoolConfig,
+    },
+    services::{
+        create_order_converter, create_orderbook_api, wait_for_solvable_orders, OrderbookServices,
+        API_HOST,
+    },
 };
 use contracts::IUniswapLikeRouter;
 use ethcontract::prelude::{Account, Address, PrivateKey, U256};


### PR DESCRIPTION
Implements Nick's suggestion from [here](https://github.com/cowprotocol/services/pull/808#discussion_r1026141436).

With these changes `e2e::services` only contains functions related to setting up the services, all other functions are related to some form of onchain execution and are moved to `e2e::onchain_components` . No logic changes are included.

### Test Plan

E2e tests still work. Number of new lines is larger than number of deleted lines (no functions missing, import statements are bigger now).