### PR TITLE
Change Default Market Makable Token List

### DIFF
--- a/crates/solver/src/arguments.rs
+++ b/crates/solver/src/arguments.rs
@@ -130,11 +130,7 @@ pub struct Arguments {
 
     /// The list of tokens our settlement contract is willing to buy when settling trades
     /// without external liquidity
-    #[clap(
-        long,
-        env,
-        default_value = "https://tokens.coingecko.com/uniswap/all.json"
-    )]
+    #[clap(long, env, default_value = "https://files.cow.fi/token_list.json")]
     pub market_makable_token_list: String,
 
     /// Time interval after which market makable list needs to be updated


### PR DESCRIPTION
Related to #820

We recently changed the batch auction model preparation to fetch balances for all market makable tokens. This isn't an issue for our deployments because the list is quite small, however, the list that the driver uses by default has 4900(!) tokens.

This PR is just a really easy change to help the situation by:
- using a much smaller list with 50 tokens
- using the actual list that is being used for market makable tokens

### Test Plan

Run locally and see that the new default list is accepted by the driver.
