### PR TITLE
Persist limit order surplus fee

### DIFF
--- a/crates/database/src/lib.rs
+++ b/crates/database/src/lib.rs
@@ -48,7 +48,7 @@ pub const ALL_TABLES: &[&str] = &[
     "auctions",
     "onchain_placed_orders",
     "ethflow_orders",
-    "order_rewards",
+    "order_execution",
     "interactions",
     "auction_transaction",
 ];

--- a/crates/database/src/lib.rs
+++ b/crates/database/src/lib.rs
@@ -8,7 +8,7 @@ pub mod ethflow_orders;
 pub mod events;
 pub mod onchain_broadcasted_orders;
 pub mod onchain_invalidations;
-pub mod order_rewards;
+pub mod order_execution;
 pub mod orders;
 pub mod quotes;
 pub mod solver_competition;

--- a/crates/database/src/order_execution.rs
+++ b/crates/database/src/order_execution.rs
@@ -1,20 +1,23 @@
 use crate::{auction::AuctionId, OrderUid};
+use bigdecimal::BigDecimal;
 use sqlx::PgConnection;
 
 pub async fn save(
     ex: &mut PgConnection,
-    order: OrderUid,
+    order: &OrderUid,
     auction: AuctionId,
     reward: f64,
+    surplus_fee: Option<&BigDecimal>,
 ) -> Result<(), sqlx::Error> {
     const QUERY: &str = r#"
-INSERT INTO order_execution (order_uid, auction_id, reward)
-VALUES ($1, $2, $3)
+INSERT INTO order_execution (order_uid, auction_id, reward, surplus_fee)
+VALUES ($1, $2, $3, $4)
     ;"#;
     sqlx::query(QUERY)
         .bind(order)
         .bind(auction)
         .bind(reward)
+        .bind(surplus_fee)
         .execute(ex)
         .await?;
     Ok(())
@@ -32,11 +35,16 @@ mod tests {
         let mut db = db.begin().await.unwrap();
         crate::clear_DANGER_(&mut db).await.unwrap();
 
+        save(&mut db, &Default::default(), 0, 0., None)
+            .await
+            .unwrap();
+
         save(
             &mut db,
-            Default::default(),
-            Default::default(),
-            Default::default(),
+            &Default::default(),
+            1,
+            0.,
+            Some(&Default::default()),
         )
         .await
         .unwrap();

--- a/crates/database/src/order_rewards.rs
+++ b/crates/database/src/order_rewards.rs
@@ -8,7 +8,7 @@ pub async fn save(
     reward: f64,
 ) -> Result<(), sqlx::Error> {
     const QUERY: &str = r#"
-INSERT INTO order_rewards (order_uid, auction_id, reward)
+INSERT INTO order_execution (order_uid, auction_id, reward)
 VALUES ($1, $2, $3)
     ;"#;
     sqlx::query(QUERY)

--- a/crates/database/src/orders.rs
+++ b/crates/database/src/orders.rs
@@ -1,4 +1,4 @@
-use crate::{Address, AppId, OrderUid, TransactionHash};
+use crate::{auction::AuctionId, Address, AppId, OrderUid, TransactionHash};
 use futures::stream::BoxStream;
 use sqlx::{
     types::{
@@ -376,6 +376,7 @@ pub struct FullOrder {
     pub onchain_user: Option<Address>,
     pub surplus_fee: Option<BigDecimal>,
     pub surplus_fee_timestamp: Option<DateTime<Utc>>,
+    pub executed_surplus_fee: Option<BigDecimal>,
 }
 
 impl FullOrder {
@@ -435,7 +436,8 @@ o.class, o.surplus_fee, o.surplus_fee_timestamp,
 ), true)) AS presignature_pending,
 array(Select (p.target, p.value, p.data) from interactions p where p.order_uid = o.uid order by p.index) as pre_interactions,
 (SELECT (eth_o.is_refunded, eth_o.valid_to)  from ethflow_orders eth_o where eth_o.uid = o.uid limit 1) as ethflow_data,
-(SELECT onchain_o.sender from onchain_placed_orders onchain_o where onchain_o.uid = o.uid limit 1) as onchain_user
+(SELECT onchain_o.sender from onchain_placed_orders onchain_o where onchain_o.uid = o.uid limit 1) as onchain_user,
+(SELECT surplus_fee FROM order_execution oe WHERE oe.order_uid = o.uid ORDER BY oe.auction_id DESC LIMIT 1) as executed_surplus_fee
 "#;
 
 const ORDERS_FROM: &str = "orders o";
@@ -637,6 +639,25 @@ pub async fn update_limit_order_fees(
         .bind(update.surplus_fee_timestamp)
         .bind(&update.full_fee_amount)
         .bind(order_uid)
+        .execute(ex)
+        .await?;
+    Ok(())
+}
+
+pub async fn save_executed_surplus_fee(
+    ex: &mut PgConnection,
+    order: &OrderUid,
+    auction: AuctionId,
+    surplus_fee: &BigDecimal,
+) -> Result<(), sqlx::Error> {
+    const QUERY: &str = r#"
+INSERT INTO order_execution (order_uid, auction_id, surplus_fee)
+VALUES ($1, $2, $3)
+    ;"#;
+    sqlx::query(QUERY)
+        .bind(order)
+        .bind(auction)
+        .bind(surplus_fee)
         .execute(ex)
         .await?;
     Ok(())
@@ -1572,5 +1593,42 @@ mod tests {
 
         assert_eq!(orders.len(), 1);
         assert_eq!(orders[0].uid, order_uid);
+    }
+
+    #[tokio::test]
+    #[ignore]
+    async fn postgres_limit_order_executed() {
+        let mut db = PgConnection::connect("postgresql://").await.unwrap();
+        let mut db = db.begin().await.unwrap();
+        crate::clear_DANGER_(&mut db).await.unwrap();
+
+        let order_uid = ByteArray([1; 56]);
+        insert_order(
+            &mut db,
+            &Order {
+                uid: order_uid,
+                class: OrderClass::Limit,
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+
+        let order = single_full_order(&mut db, &order_uid)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(order.executed_surplus_fee, None);
+
+        let fee: BigDecimal = 1.into();
+        save_executed_surplus_fee(&mut db, &order_uid, 0, &fee)
+            .await
+            .unwrap();
+
+        let order = single_full_order(&mut db, &order_uid)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(order.executed_surplus_fee, Some(fee));
     }
 }

--- a/crates/model/src/order.rs
+++ b/crates/model/src/order.rs
@@ -667,12 +667,15 @@ impl OrderClass {
     }
 }
 
+#[serde_as]
 #[derive(Eq, PartialEq, Clone, Debug, Default, Hash, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct LimitOrderClass {
     #[serde(with = "u256_decimal")]
     pub surplus_fee: U256,
     pub surplus_fee_timestamp: DateTime<Utc>,
+    #[serde_as(as = "Option<DecimalU256>")]
+    pub executed_surplus_fee: Option<U256>,
 }
 
 impl OrderKind {
@@ -795,6 +798,7 @@ mod tests {
             "feeAmount": "115792089237316195423570985008687907853269984665640564039457584007913129639935",
             "surplusFee": "115792089237316195423570985008687907853269984665640564039457584007913129639935",
             "surplusFeeTimestamp": "1970-01-01T00:00:00Z",
+            "executedSurplusFee": "1",
             "fullFeeAmount": "115792089237316195423570985008687907853269984665640564039457584007913129639935",
             "kind": "buy",
             "class": "limit",
@@ -817,6 +821,7 @@ mod tests {
                 class: OrderClass::Limit(LimitOrderClass {
                     surplus_fee: U256::MAX,
                     surplus_fee_timestamp: Default::default(),
+                    executed_surplus_fee: Some(1.into()),
                 }),
                 owner: H160::from_low_u64_be(1),
                 uid: OrderUid([17u8; 56]),

--- a/crates/model/src/solver_competition.rs
+++ b/crates/model/src/solver_competition.rs
@@ -12,12 +12,15 @@ use std::collections::BTreeMap;
 /// stored in the database. This goes to the api through an unlisted and authenticated http endpoint
 /// because we do not want the driver to have a database connection.
 /// Once autopilot is handling the competition this will no longer be needed.
+#[serde_as]
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct Request {
     pub auction: AuctionId,
     pub transaction: Transaction,
     pub competition: SolverCompetitionDB,
     pub rewards: Vec<(OrderUid, f64)>,
+    #[serde_as(as = "Vec<(_, DecimalU256)>")]
+    pub executed_surplus_fees: Vec<(OrderUid, U256)>,
 }
 
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]

--- a/crates/model/src/solver_competition.rs
+++ b/crates/model/src/solver_competition.rs
@@ -18,15 +18,21 @@ pub struct Request {
     pub auction: AuctionId,
     pub transaction: Transaction,
     pub competition: SolverCompetitionDB,
-    pub rewards: Vec<(OrderUid, f64)>,
-    #[serde_as(as = "Vec<(_, DecimalU256)>")]
-    pub executed_surplus_fees: Vec<(OrderUid, U256)>,
+    pub executions: Vec<(OrderUid, Execution)>,
 }
 
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct Transaction {
     pub account: H160,
     pub nonce: u64,
+}
+
+#[serde_as]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+pub struct Execution {
+    pub reward: f64,
+    #[serde_as(as = "Option<DecimalU256>")]
+    pub surplus_fee: Option<U256>,
 }
 
 /// Stored directly in the database and turned into SolverCompetitionAPI for the

--- a/crates/orderbook/openapi.yml
+++ b/crates/orderbook/openapi.yml
@@ -610,7 +610,7 @@ components:
       properties:
         isRefunded:
           description: |
-            Provides a flag that shows whether the refunding service has 
+            Provides a flag that shows whether the refunding service has
             refunded the order, in case it was not settled onchain
           type: boolean
         userValidTo:
@@ -803,10 +803,14 @@ components:
           $ref: "#/components/schemas/EthflowData"
         onchainUser:
           description: |
-            If orders are placed as onchain orders, the owner of the order might 
-            specific smart contracts, but not the user placing the order. The 
+            If orders are placed as onchain orders, the owner of the order might
+            specific smart contracts, but not the user placing the order. The
             actual user will be provided in this field
           $ref: "#/components/schemas/Address"
+        executedSurplusFee:
+          description: "Surplus fee that the limit order was executed with."
+          $ref: "#/components/schemas/BigUint"
+          nullable: true
       required:
         - creationTime
         - owner

--- a/crates/orderbook/src/database/orders.rs
+++ b/crates/orderbook/src/database/orders.rs
@@ -471,6 +471,7 @@ mod tests {
             onchain_user: None,
             surplus_fee: Default::default(),
             surplus_fee_timestamp: Default::default(),
+            executed_surplus_fee: Default::default(),
         };
 
         // Open - sell (filled - 0%)

--- a/crates/shared/src/db_order_conversions.rs
+++ b/crates/shared/src/db_order_conversions.rs
@@ -133,6 +133,10 @@ pub fn order_class_from(order: &FullOrderDb) -> OrderClass {
             surplus_fee_timestamp: order
                 .surplus_fee_timestamp
                 .expect("limit orders must have surplus fee timestamp set"),
+            executed_surplus_fee: order
+                .executed_surplus_fee
+                .as_ref()
+                .and_then(big_decimal_to_u256),
         }),
     }
 }

--- a/crates/solver/src/settlement.rs
+++ b/crates/solver/src/settlement.rs
@@ -1382,7 +1382,7 @@ pub mod tests {
                         metadata: OrderMetadata {
                             class: OrderClass::Limit(LimitOrderClass {
                                 surplus_fee: 1_000_u128.into(),
-                                surplus_fee_timestamp: Default::default(),
+                                ..Default::default()
                             }),
                             ..Default::default()
                         },
@@ -1416,7 +1416,7 @@ pub mod tests {
                         metadata: OrderMetadata {
                             class: OrderClass::Limit(LimitOrderClass {
                                 surplus_fee: 1_000_u128.into(),
-                                surplus_fee_timestamp: Default::default(),
+                                ..Default::default()
                             }),
                             ..Default::default()
                         },
@@ -1457,7 +1457,7 @@ pub mod tests {
                     metadata: OrderMetadata {
                         class: OrderClass::Limit(LimitOrderClass {
                             surplus_fee: 1_000_u128.into(),
-                            surplus_fee_timestamp: Default::default(),
+                            ..Default::default()
                         }),
                         ..Default::default()
                     },

--- a/database/sql/V044__limit_order_execution.sql
+++ b/database/sql/V044__limit_order_execution.sql
@@ -6,6 +6,5 @@ RENAME TO order_execution
 ;
 
 ALTER TABLE order_execution
-ALTER COLUMN reward DROP NOT NULL,
 ADD COLUMN surplus_fee numeric(78, 0)
 ;

--- a/database/sql/V044__limit_order_execution.sql
+++ b/database/sql/V044__limit_order_execution.sql
@@ -1,0 +1,11 @@
+-- Like orders.surplus_fee but is the value used to execute a limit order in a specific auction.
+-- Frontend requested to have access to this.
+
+ALTER TABLE order_rewards
+RENAME TO order_execution
+;
+
+ALTER TABLE order_execution
+ALTER COLUMN reward DROP NOT NULL,
+ADD COLUMN surplus_fee numeric(78, 0)
+;


### PR DESCRIPTION
Fixes https://github.com/cowprotocol/services/issues/771 .

We store the surplus fee amount as it was used in the auction in the database in the same way we store the order cow reward. We rename the table to indicate that it stores generic per-auction-per-order information.

TODO before merging: Make sure solver rewards script can handle the new table name.

### Test Plan

CI, new unit test