### PR TITLE
Make test deterministic

### DIFF
--- a/crates/shared/src/http_solver/model.rs
+++ b/crates/shared/src/http_solver/model.rs
@@ -11,7 +11,7 @@ use num::BigRational;
 use primitive_types::U256;
 use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
-use std::collections::{BTreeMap, HashMap, HashSet};
+use std::collections::{BTreeMap, BTreeSet, HashMap};
 use web3::types::AccessList;
 
 use crate::{
@@ -372,7 +372,7 @@ pub enum SolverRejectionReason {
 
     /// The solution contains custom interation/s using the token/s not contained in the allowed bufferable list
     /// Returns the list of not allowed tokens
-    NonBufferableTokensUsed(HashSet<H160>),
+    NonBufferableTokensUsed(BTreeSet<H160>),
 
     /// The solution didn't pass simulation. Includes all data needed to re-create simulation locally
     SimulationFailure(TransactionWithError),
@@ -1026,7 +1026,9 @@ mod tests {
     fn serialize_rejection_non_bufferable_tokens_used() {
         assert_eq!(
             serde_json::to_value(&SolverRejectionReason::NonBufferableTokensUsed(
-                HashSet::from([H160::from_low_u64_be(1), H160::from_low_u64_be(2),])
+                [H160::from_low_u64_be(1), H160::from_low_u64_be(2)]
+                    .into_iter()
+                    .collect()
             ))
             .unwrap(),
             json!({

--- a/crates/solver/src/solver/http_solver.rs
+++ b/crates/solver/src/solver/http_solver.rs
@@ -28,7 +28,7 @@ use shared::{
     token_list::AutoUpdatingTokenList,
 };
 use std::{
-    collections::{BTreeMap, HashMap, HashSet},
+    collections::{BTreeMap, BTreeSet, HashMap, HashSet},
     iter::FromIterator as _,
     sync::Arc,
     time::Instant,
@@ -448,7 +448,7 @@ fn compute_fee_connected_tokens(liquidity: &[Liquidity], native_token: H160) -> 
 fn non_bufferable_tokens_used(
     interactions: &[InteractionData],
     market_makable_token_list: &HashSet<H160>,
-) -> HashSet<H160> {
+) -> BTreeSet<H160> {
     interactions
         .iter()
         .filter(|interaction| {
@@ -979,7 +979,7 @@ mod tests {
         let market_makable_token_list = HashSet::<H160>::new();
         assert_eq!(
             non_bufferable_tokens_used(&interactions, &market_makable_token_list),
-            HashSet::new()
+            BTreeSet::new()
         );
     }
 
@@ -1002,7 +1002,7 @@ mod tests {
 
         assert_eq!(
             non_bufferable_tokens_used(&interactions, &market_makable_token_list),
-            HashSet::new()
+            BTreeSet::new()
         );
     }
 
@@ -1025,7 +1025,7 @@ mod tests {
 
         assert_eq!(
             non_bufferable_tokens_used(&interactions, &market_makable_token_list),
-            HashSet::from([non_bufferable_token])
+            BTreeSet::from([non_bufferable_token])
         );
     }
 
@@ -1050,7 +1050,7 @@ mod tests {
 
         assert_eq!(
             non_bufferable_tokens_used(&interactions, &market_makable_token_list),
-            HashSet::new()
+            BTreeSet::new()
         );
     }
 }


### PR DESCRIPTION
This test randomly fails because HashSet order is not guaranteed.

### Test Plan
CI

