### PR TITLE
Improve Order Creation Logging

### DIFF
--- a/crates/orderbook/src/api/post_order.rs
+++ b/crates/orderbook/src/api/post_order.rs
@@ -202,7 +202,7 @@ pub fn create_order_response(
     result: Result<(OrderUid, Option<QuoteId>), AddOrderError>,
 ) -> ApiReply {
     match result {
-        Ok(uid) => with_status(warp::reply::json(&uid), StatusCode::CREATED),
+        Ok((uid, _)) => with_status(warp::reply::json(&uid), StatusCode::CREATED),
         Err(err) => err.into_warp_reply(),
     }
 }


### PR DESCRIPTION
This PR makes some small improvements to logging of order creation. Specifically, today, I was trying to debug a failed order creation for @avsavsavs, but wasn't able to find the exact cause (or even match a quote to the equivalent order creation request).

We add two things here:
- We add the actual quote ID that the order gets created with (and not just the optional quote ID that the order was made with - this allows us to find what quote ID actually gets chosen for an order in line with the UID - right now we have a multi-step process to try and find the "found quote" log in the same request)
- We log the order creation parameters on failure, making it easier to see exactly what the order was created with and better understand the error.

### Test Plan

The compiler - no real logic changes just piping some data around.
