### PR TITLE
Add e2e test for eth flow orders

### DIFF
--- a/crates/autopilot/src/database/onchain_order_events/ethflow_events.rs
+++ b/crates/autopilot/src/database/onchain_order_events/ethflow_events.rs
@@ -20,7 +20,7 @@ use super::{OnchainOrderCustomData, OnchainOrderParsing};
 
 // 4c84c1c8 is the identifier of the following function:
 // https://github.com/cowprotocol/ethflowcontract/blob/main/src/CoWSwapEthFlow.sol#L57
-const WRAP_ALL_SELECTOR: [u8; 4] = hex!("4c84c1c8");
+pub const WRAP_ALL_SELECTOR: [u8; 4] = hex!("4c84c1c8");
 
 pub struct EthFlowOnchainOrderParser;
 

--- a/crates/e2e/tests/e2e/eth_flow.rs
+++ b/crates/e2e/tests/e2e/eth_flow.rs
@@ -1,17 +1,346 @@
-use crate::{deploy::Contracts, tx_value};
-use contracts::{CoWSwapEthFlow, WETH9};
-use ethcontract::{transaction::TransactionResult, Account, Bytes, H160, H256};
+use crate::{
+    deploy::Contracts,
+    local_node::AccountAssigner,
+    onchain_components::{
+        deploy_token_with_weth_uniswap_pool, to_wei, MintableToken, WethPoolConfig,
+    },
+    services::{
+        create_orderbook_api, setup_naive_solver_uniswapv2_driver, wait_for_solvable_orders,
+        OrderbookServices, API_HOST,
+    },
+};
+use anyhow::bail;
+use autopilot::database::onchain_order_events::ethflow_events::WRAP_ALL_SELECTOR;
+use contracts::{CoWSwapEthFlow, ERC20Mintable, WETH9};
+use ethcontract::{transaction::TransactionResult, Account, Bytes, H160, H256, U256};
 use hex_literal::hex;
 use model::{
-    order::{Order, OrderBuilder, OrderClass, OrderKind},
-    quote::OrderQuoteResponse,
-    signature::hashed_eip712_message,
+    app_id::AppId,
+    auction::AuctionWithId,
+    order::{
+        BuyTokenDestination, EthflowData, Order, OrderBuilder, OrderClass, OrderKind, OrderUid,
+        SellTokenSource,
+    },
+    quote::{
+        OrderQuoteRequest, OrderQuoteResponse, OrderQuoteSide, PriceQuality, QuoteSigningScheme,
+        Validity,
+    },
+    signature::{hashed_eip712_message, Signature},
+    trade::Trade,
     DomainSeparator,
 };
 use refunder::{
     ethflow_order::EthflowOrder,
     refund_service::{INVALIDATED_OWNER, NO_OWNER},
 };
+use reqwest::Client;
+use shared::{
+    ethrpc::Web3, http_client::HttpClientFactory, maintenance::Maintaining,
+    signature_validator::check_erc1271_result,
+};
+const ACCOUNT_ENDPOINT: &str = "/api/v1/account";
+const AUCTION_ENDPOINT: &str = "/api/v1/auction";
+const ORDERS_ENDPOINT: &str = "/api/v1/orders";
+const QUOTE_ENDPOINT: &str = "/api/v1/quote";
+const TRADES_ENDPOINT: &str = "/api/v1/trades";
+
+const DAI_PER_ETH: u32 = 1000;
+
+#[tokio::test]
+#[ignore]
+async fn local_node_eth_flow() {
+    crate::local_node::test(refunder_tx).await;
+}
+
+async fn refunder_tx(web3: Web3) {
+    shared::tracing::initialize_for_tests(
+        "warn,orderbook=debug,orderbook=debug,solver=debug,autopilot=debug",
+    );
+    shared::exit_process_on_panic::set_panic_hook();
+    let contracts = crate::deploy::deploy(&web3).await.expect("deploy");
+
+    let mut accounts = AccountAssigner::new(&web3).await;
+    let trader = accounts.assign_free_account();
+    let solver = accounts.default_deployer; // is a solver by default
+
+    // Create token with Uniswap pool for price estimation
+    let MintableToken { contract: dai, .. } = deploy_token_with_weth_uniswap_pool(
+        &web3,
+        &contracts,
+        WethPoolConfig {
+            // 1 ETH ≈ 1k DAI
+            token_amount: to_wei(DAI_PER_ETH * 1_000),
+            weth_amount: to_wei(1_000),
+        },
+    )
+    .await;
+
+    let OrderbookServices {
+        maintenance,
+        block_stream,
+        solvable_orders_cache,
+        base_tokens,
+        ..
+    } = OrderbookServices::new(&web3, &contracts, false).await;
+    let http_factory = HttpClientFactory::default();
+    let client = http_factory.create();
+
+    // Get a quote from the services
+    let buy_token = dai.address();
+    let receiver = H160([0x42; 20]);
+    let sell_amount = to_wei(1);
+    let intent = EthFlowTradeIntent {
+        sell_amount,
+        buy_token,
+        receiver,
+    };
+
+    let quote: OrderQuoteResponse = submit_quote(
+        &intent.to_quote_request(&contracts.ethflow, &contracts.weth),
+        &client,
+    )
+    .await;
+
+    let valid_to = chrono::offset::Utc::now().timestamp() as u32 + 3600;
+    let ethflow_order =
+        ExtendedEthFlowOrder::from_quote(&quote, valid_to).include_slippage_bps(300);
+
+    sumbit_order(&ethflow_order, &trader, &contracts).await;
+
+    // Automatically pick up onchain order without any API request
+    maintenance.run_maintenance().await.unwrap();
+
+    test_order_availability_in_api(&client, &ethflow_order, &trader.address(), &contracts).await;
+
+    let mut driver =
+        setup_naive_solver_uniswapv2_driver(&web3, &contracts, base_tokens, block_stream, solver)
+            .await;
+    driver.single_run().await.unwrap();
+
+    // Update orderbook status
+    maintenance.run_maintenance().await.unwrap();
+    solvable_orders_cache.update(0).await.unwrap();
+
+    test_order_was_settled(&ethflow_order, &web3).await;
+
+    test_trade_availability_in_api(&client, &ethflow_order, &trader.address(), &contracts).await;
+}
+
+async fn submit_quote(quote: &OrderQuoteRequest, client: &reqwest::Client) -> OrderQuoteResponse {
+    let quoting = client
+        .post(&format!("{API_HOST}{QUOTE_ENDPOINT}"))
+        .json(&quote)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(quoting.status(), 200);
+    let response = quoting.json::<OrderQuoteResponse>().await.unwrap();
+
+    assert!(response.id.is_some());
+    // Ideally the fee would be nonzero, but this is not the case in the test environment
+    //assert_ne!(response.quote.fee_amount, 0.into());
+    // Amount is reasonable (±10% from real price)
+    let approx_output: U256 = response.quote.sell_amount * DAI_PER_ETH;
+    assert!(response.quote.buy_amount.gt(&(approx_output * 9u64 / 10)));
+    assert!(response.quote.buy_amount.lt(&(approx_output * 11u64 / 10)));
+
+    if let OrderQuoteSide::Sell {
+        sell_amount:
+            model::quote::SellAmount::AfterFee {
+                value: sell_amount_after_fees,
+            },
+    } = quote.side
+    {
+        assert_eq!(response.quote.sell_amount, sell_amount_after_fees);
+    } else {
+        panic!("Untested")
+    };
+
+    response
+}
+
+async fn sumbit_order(ethflow_order: &ExtendedEthFlowOrder, user: &Account, contracts: &Contracts) {
+    assert_eq!(
+        ethflow_order.status(contracts).await,
+        EthFlowOrderOnchainStatus::Free
+    );
+
+    let result = ethflow_order
+        .mine_order_creation(user, &contracts.ethflow)
+        .await;
+    assert_eq!(result.as_receipt().unwrap().status, Some(1.into()));
+    assert_eq!(
+        ethflow_order.status(contracts).await,
+        EthFlowOrderOnchainStatus::Created(user.address(), ethflow_order.0.valid_to)
+    );
+}
+
+async fn test_order_availability_in_api(
+    client: &Client,
+    order: &ExtendedEthFlowOrder,
+    owner: &H160,
+    contracts: &Contracts,
+) {
+    test_orders_query(client, order, owner, contracts).await;
+
+    // Api returns eth flow orders for both eth-flow contract address and actual owner
+    for address in [owner, &contracts.ethflow.address()] {
+        test_account_query(address, client, order, owner, contracts).await;
+    }
+
+    wait_for_solvable_orders(client, 1).await.unwrap();
+
+    test_auction_query(client, order, owner, contracts).await;
+}
+
+async fn test_trade_availability_in_api(
+    client: &Client,
+    order: &ExtendedEthFlowOrder,
+    owner: &H160,
+    contracts: &Contracts,
+) {
+    test_trade_query(
+        &TradeQuery::ByUid(order.uid(contracts).await),
+        client,
+        contracts,
+    )
+    .await;
+
+    // Api returns eth flow orders for both eth-flow contract address and actual owner
+    for address in [owner, &contracts.ethflow.address()] {
+        test_trade_query(&TradeQuery::ByOwner(*address), client, contracts).await;
+    }
+}
+
+async fn test_order_was_settled(ethflow_order: &ExtendedEthFlowOrder, web3: &Web3) {
+    let auction = create_orderbook_api().get_auction().await.unwrap();
+    assert!(auction.auction.orders.is_empty());
+
+    let buy_token = ERC20Mintable::at(web3, ethflow_order.0.buy_token);
+    let receiver_buy_token_balance = buy_token
+        .balance_of(ethflow_order.0.receiver)
+        .call()
+        .await
+        .expect("Unable to get token balance");
+    assert!(receiver_buy_token_balance >= ethflow_order.0.buy_amount);
+}
+
+async fn test_orders_query(
+    client: &Client,
+    order: &ExtendedEthFlowOrder,
+    owner: &H160,
+    contracts: &Contracts,
+) {
+    let query = client
+        .get(&format!(
+            "{API_HOST}{ORDERS_ENDPOINT}/{}",
+            order.uid(contracts).await
+        ))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(query.status(), 200);
+    let response = query.json::<Order>().await.unwrap();
+    test_order_parameters(&response, order, owner, contracts).await;
+}
+
+async fn test_account_query(
+    queried_account: &H160,
+    client: &Client,
+    order: &ExtendedEthFlowOrder,
+    owner: &H160,
+    contracts: &Contracts,
+) {
+    let query = client
+        .get(&format!(
+            "{API_HOST}{ACCOUNT_ENDPOINT}/{queried_account:?}/orders",
+        ))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(query.status(), 200);
+    let response = query.json::<Vec<Order>>().await.unwrap();
+    assert_eq!(response.len(), 1);
+    test_order_parameters(&response[0], order, owner, contracts).await;
+}
+
+async fn test_auction_query(
+    client: &Client,
+    order: &ExtendedEthFlowOrder,
+    owner: &H160,
+    contracts: &Contracts,
+) {
+    let query = client
+        .get(&format!("{API_HOST}{AUCTION_ENDPOINT}"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(query.status(), 200);
+    let response = query.json::<AuctionWithId>().await.unwrap();
+    assert_eq!(response.auction.orders.len(), 1);
+    test_order_parameters(&response.auction.orders[0], order, owner, contracts).await;
+}
+
+enum TradeQuery {
+    ByUid(OrderUid),
+    ByOwner(H160),
+}
+
+async fn test_trade_query(query_type: &TradeQuery, client: &Client, contracts: &Contracts) {
+    let query = client
+        .get(&format!("{API_HOST}{TRADES_ENDPOINT}",))
+        .query(&[match query_type {
+            TradeQuery::ByUid(uid) => ("orderUid", format!("{uid:?}")),
+            TradeQuery::ByOwner(owner) => ("owner", format!("{owner:?}")),
+        }])
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(query.status(), 200);
+    let response = query.json::<Vec<Trade>>().await.unwrap();
+    assert_eq!(response.len(), 1);
+
+    // Expected values from actual EIP1271 order instead of eth-flow order
+    assert_eq!(response[0].owner, contracts.ethflow.address());
+    assert_eq!(response[0].sell_token, contracts.weth.address());
+}
+
+async fn test_order_parameters(
+    response: &Order,
+    order: &ExtendedEthFlowOrder,
+    owner: &H160,
+    contracts: &Contracts,
+) {
+    // Expected values from actual EIP1271 order instead of eth-flow order
+    assert_eq!(response.data.valid_to, u32::MAX);
+    assert_eq!(response.metadata.owner, contracts.ethflow.address());
+    assert_eq!(response.data.sell_token, contracts.weth.address());
+
+    // Specific parameters return the missing values
+    assert_eq!(
+        response.metadata.ethflow_data,
+        Some(EthflowData {
+            user_valid_to: order.0.valid_to as i64,
+            is_refunded: false
+        })
+    );
+    assert_eq!(response.metadata.onchain_user, Some(*owner));
+
+    assert_eq!(response.metadata.class, OrderClass::Market);
+
+    assert!(order
+        .is_valid_cowswap_signature(&response.signature, contracts)
+        .await
+        .is_ok());
+
+    // Requires wrapping first
+    assert_eq!(response.interactions.pre.len(), 1);
+    assert_eq!(
+        response.interactions.pre[0].target,
+        contracts.ethflow.address()
+    );
+    assert_eq!(response.interactions.pre[0].call_data, WRAP_ALL_SELECTOR);
+}
 
 pub struct ExtendedEthFlowOrder(pub EthflowOrder);
 
@@ -70,6 +399,34 @@ impl ExtendedEthFlowOrder {
             .into()
     }
 
+    pub async fn is_valid_cowswap_signature(
+        &self,
+        cowswap_signature: &Signature,
+        contracts: &Contracts,
+    ) -> anyhow::Result<()> {
+        let bytes = match cowswap_signature {
+            Signature::Eip1271(bytes) => bytes,
+            _ => bail!(
+                "Invalid signature type, expected EIP1271, found {:?}",
+                cowswap_signature
+            ),
+        }
+        .clone();
+
+        let result = contracts
+            .ethflow
+            .is_valid_signature(
+                Bytes(self.hash(contracts).await.to_fixed_bytes()),
+                Bytes(bytes),
+            )
+            .call()
+            .await
+            .expect("Couldn't fetch signature validity");
+
+        check_erc1271_result(result)
+            .map_err(|err| anyhow::anyhow!("failed signature verification: {:?}", err))
+    }
+
     pub async fn mine_order_creation(
         &self,
         owner: &Account,
@@ -100,6 +457,21 @@ impl ExtendedEthFlowOrder {
                 .hash_struct(),
         ))
     }
+
+    async fn uid(&self, contracts: &Contracts) -> OrderUid {
+        let domain_separator = DomainSeparator(
+            contracts
+                .gp_settlement
+                .domain_separator()
+                .call()
+                .await
+                .expect("Couldn't query domain separator")
+                .0,
+        );
+        self.to_cow_swap_order(&contracts.ethflow, &contracts.weth)
+            .data
+            .uid(&domain_separator, &contracts.ethflow.address())
+    }
 }
 
 #[derive(Debug, PartialEq, Eq)]
@@ -115,6 +487,40 @@ impl From<(H160, u32)> for EthFlowOrderOnchainStatus {
             owner if owner == NO_OWNER => Self::Free,
             owner if owner == INVALIDATED_OWNER => Self::Invalidated,
             _ => Self::Created(owner, valid_to),
+        }
+    }
+}
+
+struct EthFlowTradeIntent {
+    sell_amount: U256,
+    buy_token: H160,
+    receiver: H160,
+}
+
+impl EthFlowTradeIntent {
+    // How a user trade intent is converted into a quote request by the frontend
+    fn to_quote_request(&self, ethflow: &CoWSwapEthFlow, weth: &WETH9) -> OrderQuoteRequest {
+        OrderQuoteRequest {
+            from: ethflow.address(),
+            // Even if the user sells ETH, we request a quote for WETH
+            sell_token: weth.address(),
+            buy_token: self.buy_token,
+            receiver: Some(self.receiver),
+            validity: Validity::For(u32::MAX),
+            app_data: AppId([0x42; 32]),
+            signing_scheme: QuoteSigningScheme::Eip1271 {
+                onchain_order: true,
+                verification_gas_limit: 0,
+            },
+            side: OrderQuoteSide::Sell {
+                sell_amount: model::quote::SellAmount::AfterFee {
+                    value: self.sell_amount,
+                },
+            },
+            buy_token_balance: BuyTokenDestination::Erc20,
+            sell_token_balance: SellTokenSource::Erc20,
+            partially_fillable: false,
+            price_quality: PriceQuality::Optimal,
         }
     }
 }

--- a/crates/e2e/tests/e2e/main.rs
+++ b/crates/e2e/tests/e2e/main.rs
@@ -5,11 +5,11 @@
 #[macro_use]
 mod onchain_components;
 mod deploy;
-mod eth_flow;
 mod local_node;
 mod services;
 
 // Each of the following modules contains tests.
+mod eth_flow;
 mod eth_integration;
 mod limit_orders;
 mod onchain_settlement;

--- a/crates/e2e/tests/e2e/services.rs
+++ b/crates/e2e/tests/e2e/services.rs
@@ -9,9 +9,9 @@ use autopilot::{
     limit_order_quoter::LimitOrderQuoter,
     solvable_orders::SolvableOrdersCache,
 };
-use contracts::{CoWSwapOnchainOrders, WETH9};
+use contracts::{CoWSwapOnchainOrders, IUniswapLikeRouter, WETH9};
 use database::quotes::QuoteId;
-use ethcontract::{H160, U256};
+use ethcontract::{Account, H160, U256};
 use model::{quote::QuoteSigningScheme, DomainSeparator};
 use orderbook::{database::Postgres, orderbook::Orderbook};
 use reqwest::{Client, StatusCode};
@@ -37,7 +37,17 @@ use shared::{
     signature_validator::Web3SignatureValidator,
     sources::uniswap_v2::{pool_cache::PoolCache, pool_fetching::PoolFetcher},
 };
-use solver::{liquidity::order_converter::OrderConverter, orderbook::OrderBookApi};
+use solver::{
+    liquidity::{order_converter::OrderConverter, uniswap_v2::UniswapLikeLiquidity},
+    liquidity_collector::LiquidityCollector,
+    metrics::NoopMetrics,
+    orderbook::OrderBookApi,
+    settlement_access_list::{create_priority_estimator, AccessListEstimatorType},
+    settlement_submission::{
+        submitter::{public_mempool_api::PublicMempoolApi, Strategy},
+        GlobalTxPool, SolutionSubmitter, StrategyArgs,
+    },
+};
 use std::{
     collections::HashSet,
     future::pending,
@@ -156,7 +166,7 @@ impl OrderbookServices {
             signature_validator.clone(),
             Duration::from_secs(1),
             None,
-            H160::zero(),
+            contracts.ethflow.address(),
             Duration::from_secs(5),
             Default::default(),
         );
@@ -238,6 +248,76 @@ impl OrderbookServices {
             base_tokens,
         }
     }
+}
+
+pub async fn setup_naive_solver_uniswapv2_driver(
+    web3: &Web3,
+    contracts: &Contracts,
+    base_tokens: Arc<BaseTokens>,
+    block_stream: CurrentBlockStream,
+    solver_account: Account,
+) -> solver::driver::Driver {
+    let uniswap_pair_provider = uniswap_pair_provider(contracts);
+    let uniswap_liquidity = UniswapLikeLiquidity::new(
+        IUniswapLikeRouter::at(web3, contracts.uniswap_router.address()),
+        contracts.gp_settlement.clone(),
+        base_tokens,
+        web3.clone(),
+        Arc::new(PoolFetcher::uniswap(uniswap_pair_provider, web3.clone())),
+    );
+    let solver = solver::solver::naive_solver(solver_account);
+    let liquidity_collector = LiquidityCollector {
+        uniswap_like_liquidity: vec![uniswap_liquidity],
+        balancer_v2_liquidity: None,
+        zeroex_liquidity: None,
+        uniswap_v3_liquidity: None,
+    };
+    let network_id = web3.net().version().await.unwrap();
+    let submitted_transactions = GlobalTxPool::default();
+
+    solver::driver::Driver::new(
+        contracts.gp_settlement.clone(),
+        liquidity_collector,
+        vec![solver],
+        Arc::new(web3.clone()),
+        Duration::from_secs(30),
+        contracts.weth.address(),
+        Duration::from_secs(0),
+        Arc::new(NoopMetrics::default()),
+        web3.clone(),
+        network_id.clone(),
+        Duration::from_secs(30),
+        block_stream,
+        SolutionSubmitter {
+            web3: web3.clone(),
+            contract: contracts.gp_settlement.clone(),
+            gas_price_estimator: Arc::new(web3.clone()),
+            target_confirm_time: Duration::from_secs(1),
+            gas_price_cap: f64::MAX,
+            max_confirm_time: Duration::from_secs(120),
+            retry_interval: Duration::from_secs(5),
+            transaction_strategies: vec![
+                solver::settlement_submission::TransactionStrategy::PublicMempool(StrategyArgs {
+                    submit_api: Box::new(PublicMempoolApi::new(vec![web3.clone()], false)),
+                    max_additional_tip: 0.,
+                    additional_tip_percentage_of_max_fee: 0.,
+                    sub_tx_pool: submitted_transactions.add_sub_pool(Strategy::PublicMempool),
+                }),
+            ],
+            access_list_estimator: Arc::new(
+                create_priority_estimator(web3, &[AccessListEstimatorType::Web3], None, network_id)
+                    .unwrap(),
+            ),
+        },
+        create_orderbook_api(),
+        create_order_converter(web3, contracts.weth.address()),
+        15000000u128,
+        1.0,
+        None,
+        None.into(),
+        None,
+        0,
+    )
 }
 
 /// Returns error if communicating with the api fails or if a timeout is reached.

--- a/crates/shared/src/signature_validator.rs
+++ b/crates/shared/src/signature_validator.rs
@@ -124,7 +124,7 @@ impl SignatureValidating for Web3SignatureValidator {
 /// The Magical value as defined by EIP-1271
 const MAGICAL_VALUE: [u8; 4] = hex!("1626ba7e");
 
-fn check_erc1271_result(result: Bytes<[u8; 4]>) -> Result<(), SignatureValidationError> {
+pub fn check_erc1271_result(result: Bytes<[u8; 4]>) -> Result<(), SignatureValidationError> {
     if result.0 == MAGICAL_VALUE {
         Ok(())
     } else {


### PR DESCRIPTION
Adds an e2e test for eth-flow orders and corresponding API expectations.

I also extracted what was needed to initialize the driver from another test into its own function. I don't think it contains any specific logic for that test, but it's worth double checking this when reviewing.

### Test Plan

New code is a test.