### PR TITLE
Encode simulation failure call data has hex string

### DIFF
--- a/crates/shared/src/http_solver/model.rs
+++ b/crates/shared/src/http_solver/model.rs
@@ -403,7 +403,8 @@ pub struct TransactionWithError {
 }
 
 /// Transaction data used for simulation of the settlement
-#[derive(Clone, Debug, Serialize)]
+#[derive(Clone, Serialize, Derivative)]
+#[derivative(Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct SimulatedTransaction {
     /// The simulation was done on top of all transactions from the given block number
@@ -416,6 +417,7 @@ pub struct SimulatedTransaction {
     /// GPv2 settlement contract address
     pub to: H160,
     /// Transaction input data
+    #[derivative(Debug(format_with = "crate::debug_bytes"))]
     #[serde(with = "model::bytes_hex")]
     pub data: Vec<u8>,
 }


### PR DESCRIPTION
While investigating a few cases where we notified solvers about failed simulations I noticed that we [log](https://production-6de61f.kb.eu-central-1.aws.cloud.es.io/app/discover#/doc/6eecf430-220f-11ed-bbdc-2f476b18353d/logstash-prod-2022.11.23?id=jQpjo4QBiG37jPBs3VQS) the `call_data` as an array of numbers instead of a hex string. This less condensed and overall less useful so we should log the hex string instead.

### Test Plan
Used a temporary `dbg!()` statement to see that the formatting works as intended
