### PR TITLE
Improve tracability of logs for simulation failures on the latest block

### DIFF
--- a/crates/shared/src/http_solver.rs
+++ b/crates/shared/src/http_solver.rs
@@ -184,7 +184,7 @@ impl HttpSolverApi for DefaultHttpSolverApi {
 
         let client = self.client.clone();
         let config_api_key = self.config.api_key.clone();
-        let name = self.name.clone();
+        tracing::debug!(solver_name = self.name, ?result, "notify auction result");
         let future = async move {
             url.query_pairs_mut()
                 .append_pair("auction_id", auction_id.to_string().as_str());
@@ -200,7 +200,6 @@ impl HttpSolverApi for DefaultHttpSolverApi {
                 request = request.header("X-API-KEY", header);
             }
 
-            tracing::debug!(auction_id, name, ?result, "notify auction result");
             let _result = request.json(&json!(result)).send().await;
         };
         tokio::task::spawn(future);

--- a/crates/shared/src/http_solver.rs
+++ b/crates/shared/src/http_solver.rs
@@ -200,7 +200,7 @@ impl HttpSolverApi for DefaultHttpSolverApi {
                 request = request.header("X-API-KEY", header);
             }
 
-            tracing::debug!(name, auction_id, ?result, "notify auction result");
+            tracing::debug!(auction_id, name, ?result, "notify auction result");
             let _result = request.json(&json!(result)).send().await;
         };
         tokio::task::spawn(future);

--- a/crates/shared/src/http_solver.rs
+++ b/crates/shared/src/http_solver.rs
@@ -184,6 +184,7 @@ impl HttpSolverApi for DefaultHttpSolverApi {
 
         let client = self.client.clone();
         let config_api_key = self.config.api_key.clone();
+        let name = self.name.clone();
         let future = async move {
             url.query_pairs_mut()
                 .append_pair("auction_id", auction_id.to_string().as_str());
@@ -199,7 +200,7 @@ impl HttpSolverApi for DefaultHttpSolverApi {
                 request = request.header("X-API-KEY", header);
             }
 
-            tracing::debug!(?result, "notify auction result");
+            tracing::debug!(name, auction_id, ?result, "notify auction result");
             let _result = request.json(&json!(result)).send().await;
         };
         tokio::task::spawn(future);

--- a/crates/solver/src/driver_logger.rs
+++ b/crates/solver/src/driver_logger.rs
@@ -190,6 +190,12 @@ impl DriverLogger {
                     );
 
                     metrics.settlement_simulation(solver.name(), SolverSimulationOutcome::Failure);
+                } else {
+                    tracing::debug!(
+                        name = solver.name(),
+                        ?settlement,
+                        "simulation only failed on the latest block but not on the block the auction started",
+                    );
                 }
             }
         };

--- a/crates/solver/src/driver_logger.rs
+++ b/crates/solver/src/driver_logger.rs
@@ -168,7 +168,7 @@ impl DriverLogger {
                         Simulation {
                             solver, settlement, ..
                         },
-                    ..
+                    error: error_at_latest_block,
                 },
                 result,
             ) in errors.iter().zip(simulations)
@@ -193,7 +193,7 @@ impl DriverLogger {
                 } else {
                     tracing::debug!(
                         name = solver.name(),
-                        ?settlement,
+                        ?error_at_latest_block,
                         "simulation only failed on the latest block but not on the block the auction started",
                     );
                 }


### PR DESCRIPTION
If a solution fails to simulate on the latest block but not on the block the auction started at we don't report an error in the usual [place](https://github.com/cowprotocol/services/blob/main/crates/solver/src/driver_logger.rs#L178-L193) because most of the time this was caused by the racy nature of the blockchain. This makes debugging errors that happen only on the latest block much harder.
However, since Dusan introduced the `/notify` endpoint there exists a [log](https://production-6de61f.kb.eu-central-1.aws.cloud.es.io/app/discover#/doc/6eecf430-220f-11ed-bbdc-2f476b18353d/logstash-prod-2022.11.22?id=TkccoYQBdK0bxeq9cejm) which reports the simulation failure on the latest block. It's just very hard to find because the log gets printed in a new task which doesn't have the tracing span with the solver name and auction_id associated with it.
A simple fix is to add the auction id and solver name manually to the log.
