### PR TITLE
Add Gelato API Module

### DIFF
--- a/crates/shared/src/gelato_api.rs
+++ b/crates/shared/src/gelato_api.rs
@@ -1,0 +1,210 @@
+//! Gelato HTTP API client and data types.
+//!
+//! <https://docs.gelato.network/developer-services/relay/quick-start/api>
+
+use crate::http_client::HttpClientFactory;
+use anyhow::{ensure, Result};
+use chrono::{DateTime, Utc};
+use ethcontract::{H160, H256, U256};
+use model::u256_decimal::DecimalU256;
+use reqwest::Url;
+use serde::{Deserialize, Serialize};
+use serde_with::{serde_as, skip_serializing_none};
+use std::{
+    env,
+    fmt::{self, Display, Formatter},
+};
+
+pub struct GelatoClient {
+    client: reqwest::Client,
+    base: Url,
+    api_key: String,
+}
+
+impl GelatoClient {
+    pub fn new(factory: &HttpClientFactory, api_key: String) -> Self {
+        Self::with_url(
+            factory,
+            Url::parse("https://relay.gelato.digital/").unwrap(),
+            api_key,
+        )
+    }
+
+    pub fn with_url(factory: &HttpClientFactory, base: Url, api_key: String) -> Self {
+        Self {
+            client: factory.create(),
+            base,
+            api_key,
+        }
+    }
+
+    pub fn from_env() -> Result<Self> {
+        Ok(Self::new(
+            &HttpClientFactory::default(),
+            env::var("GELATO_API_KEY")?,
+        ))
+    }
+
+    pub async fn sponsored_call(&self, call: &Call) -> Result<TaskId> {
+        let response = self
+            .client
+            .post(self.base.join("relays/v2/sponsored-call")?)
+            .json(&CallWithKey {
+                call,
+                sponsor_api_key: &self.api_key,
+            })
+            .send()
+            .await?;
+
+        let status = response.status();
+        let text = response.text().await?;
+        ensure!(status.is_success(), "HTTP {status} error: {text}");
+
+        let receipt = serde_json::from_str::<CallReceipt>(&text)?;
+        Ok(receipt.task_id)
+    }
+
+    pub async fn task_status(&self, id: &TaskId) -> Result<Task> {
+        let response = self
+            .client
+            .get(self.base.join("tasks/status/")?.join(&id.0)?)
+            .send()
+            .await?;
+
+        let status = response.status();
+        let text = response.text().await?;
+        ensure!(status.is_success(), "HTTP {status} error: {text}");
+
+        let data = serde_json::from_str::<TaskResponse>(&text)?;
+        Ok(data.task)
+    }
+}
+
+/// A call to send to the Gelato relay network and to be executed onchain.
+#[serde_as]
+#[skip_serializing_none]
+#[derive(Clone, Debug, Default, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Call {
+    pub chain_id: u64,
+    pub target: H160,
+    #[serde(with = "model::bytes_hex")]
+    pub data: Vec<u8>,
+    #[serde_as(as = "Option<DecimalU256>")]
+    pub gas_limit: Option<U256>,
+    pub retries: Option<usize>,
+}
+
+/// A task ID associated with a call that is queued for execution.
+///
+/// It looks like, from observing API responses that this is a 32-byte hash of
+/// some sort. However, since this isn't documented behaviour - treat it like
+/// an opaque string identifier.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(transparent)]
+pub struct TaskId(String);
+
+impl Display for TaskId {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+/// A task status.
+#[derive(Clone, Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Task {
+    pub chain_id: u64,
+    pub task_id: TaskId,
+    pub task_state: TaskState,
+    pub creation_date: DateTime<Utc>,
+    pub last_check_date: Option<DateTime<Utc>>,
+    pub last_check_message: Option<String>,
+    pub transaction_hash: Option<H256>,
+    pub execution_date: Option<DateTime<Utc>>,
+    pub block_number: Option<u64>,
+}
+
+/// The state of a executing Gelato relay task.
+///
+/// <https://github.com/gelatodigital/relay-sdk/blob/c327debf611b606832dee9876c3f915d0262359b/src/lib/status/types/index.ts#L13-L22>
+#[derive(Clone, Debug, Deserialize)]
+pub enum TaskState {
+    CheckPending,
+    ExecPending,
+    ExecSuccess,
+    ExecReverted,
+    WaitingForConfirmation,
+    Blacklisted,
+    Cancelled,
+    NotFound,
+}
+
+/// Internal helper type for serializing a call with an API key.
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct CallWithKey<'a> {
+    #[serde(flatten)]
+    call: &'a Call,
+    sponsor_api_key: &'a str,
+}
+
+/// Internal helper for deserializing call receipts.
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct CallReceipt {
+    task_id: TaskId,
+}
+
+/// Internal helper for deserializing task responses.
+#[derive(Deserialize)]
+struct TaskResponse {
+    task: Task,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ethrpc::{create_env_test_transport, Web3};
+    use contracts::WETH9;
+    use std::time::Duration;
+
+    #[ignore]
+    #[tokio::test]
+    async fn execute_transaction() {
+        let web3 = Web3::new(create_env_test_transport());
+        let chain_id = web3.eth().chain_id().await.unwrap();
+
+        let weth = WETH9::deployed(&web3).await.unwrap();
+
+        let gelato = GelatoClient::from_env().unwrap();
+        let call = Call {
+            chain_id: chain_id.as_u64(),
+            target: weth.address(),
+            data: weth.deposit().tx.data.unwrap().0,
+            ..Default::default()
+        };
+
+        let id = gelato.sponsored_call(&call).await.unwrap();
+        println!("executing task {id}");
+
+        loop {
+            let task = gelato.task_status(&id).await.unwrap();
+
+            match task.task_state {
+                TaskState::ExecSuccess => {
+                    println!("task executed {:?}", task.transaction_hash.unwrap());
+                    break;
+                }
+                TaskState::ExecReverted
+                | TaskState::Blacklisted
+                | TaskState::Cancelled
+                | TaskState::NotFound => panic!("error executing {task:#?}"),
+                state => {
+                    println!("task is {state:?}...");
+                    tokio::time::sleep(Duration::from_secs(1)).await;
+                }
+            }
+        }
+    }
+}

--- a/crates/shared/src/lib.rs
+++ b/crates/shared/src/lib.rs
@@ -20,6 +20,7 @@ pub mod exit_process_on_panic;
 pub mod fee_subsidy;
 pub mod gas_price;
 pub mod gas_price_estimation;
+pub mod gelato_api;
 pub mod http_client;
 pub mod http_solver;
 pub mod interaction;


### PR DESCRIPTION
Follow up to #599 

I previously experimented with a Gelato relay service submitter in #599. The idea is to allow a separate relay service to execute settlement transactions on behalf of solvers so that they don't have to worry about execution details.

This PR is the first in a stack of 3 for enabling Gelato submission support. I am basically just breaking down the existing #599 into smaller pieces to make them easier to review and "self-contained".

In the following PRs I will:
1. Introduce the Solver trampoline contract and settlement signing.
2. Implement a Gelato submitter using the API introduced in this PR executed over the solver trampoline.

### Test Plan

Added a manual test for executing a transaction over the Gelato relay. Requires a 1Balance account with an API key.

```
% cargo test -p shared -- --ignored --nocapture gelato_api
   Compiling shared v0.1.0 (/Users/nlordell/Developer/cowprotocol/services/crates/shared)
    Finished test [unoptimized + debuginfo] target(s) in 14.19s
     Running unittests src/lib.rs (target/debug/deps/shared-b80690e295f197ca)

running 1 test
executing task 0xf75fd1215ac82c0b77b58bf0f51537184f621bba41db847cc7ba2a7920e4cca1
task is CheckPending...
task is CheckPending...
task is CheckPending...
task is WaitingForConfirmation...
task is WaitingForConfirmation...
task is WaitingForConfirmation...
task is WaitingForConfirmation...
task is WaitingForConfirmation...
task is WaitingForConfirmation...
task is WaitingForConfirmation...
task is WaitingForConfirmation...
task is WaitingForConfirmation...
task is WaitingForConfirmation...
task is WaitingForConfirmation...
task is WaitingForConfirmation...
task is WaitingForConfirmation...
task is WaitingForConfirmation...
task is WaitingForConfirmation...
task is WaitingForConfirmation...
task executed 0x00f1e1ebeff7df0cf7bd1b27b478085d842b7e0af99478a939b2a68ed6ba9c23
test gelato_api::tests::execute_transaction ... ok
```

Check the executed transaction on Görli: <https://goerli.etherscan.io/tx/0x00f1e1ebeff7df0cf7bd1b27b478085d842b7e0af99478a939b2a68ed6ba9c23>.