### PR TITLE
Implement Gelato Settlement Submission Strategy

### DIFF
--- a/crates/driver/src/arguments.rs
+++ b/crates/driver/src/arguments.rs
@@ -99,6 +99,10 @@ pub struct Arguments {
     )]
     pub transaction_strategy: Vec<TransactionStrategyArg>,
 
+    /// The API key to use for the Gelato submission strategy.
+    #[clap(long, env)]
+    pub gelato_api_key: Option<String>,
+
     /// The API endpoint of the Eden network for transaction submission.
     #[clap(long, env, default_value = "https://api.edennetwork.io/v1/rpc")]
     pub eden_api_url: Url,
@@ -305,6 +309,7 @@ impl std::fmt::Display for Arguments {
         )?;
         writeln!(f, "min_order_age: {:?}", self.min_order_age,)?;
         writeln!(f, "transaction_strategy: {:?}", self.transaction_strategy)?;
+        display_secret_option(f, "gelato_api_key", &self.gelato_api_key)?;
         writeln!(f, "eden_api_url: {}", self.eden_api_url)?;
         writeln!(
             f,

--- a/crates/driver/src/arguments.rs
+++ b/crates/driver/src/arguments.rs
@@ -103,6 +103,16 @@ pub struct Arguments {
     #[clap(long, env)]
     pub gelato_api_key: Option<String>,
 
+    /// The poll interval for checking status of Gelato tasks when using it as a
+    /// transaction submission strategy.
+    #[clap(
+        long,
+        env,
+        default_value = "5",
+        value_parser = shared::arguments::duration_from_seconds,
+    )]
+    pub gelato_submission_poll_interval: Duration,
+
     /// The API endpoint of the Eden network for transaction submission.
     #[clap(long, env, default_value = "https://api.edennetwork.io/v1/rpc")]
     pub eden_api_url: Url,
@@ -310,6 +320,11 @@ impl std::fmt::Display for Arguments {
         writeln!(f, "min_order_age: {:?}", self.min_order_age,)?;
         writeln!(f, "transaction_strategy: {:?}", self.transaction_strategy)?;
         display_secret_option(f, "gelato_api_key", &self.gelato_api_key)?;
+        writeln!(
+            f,
+            "gelato_submission_poll_interval: {:?}",
+            &self.gelato_submission_poll_interval
+        )?;
         writeln!(f, "eden_api_url: {}", self.eden_api_url)?;
         writeln!(
             f,

--- a/crates/driver/src/main.rs
+++ b/crates/driver/src/main.rs
@@ -267,6 +267,7 @@ async fn build_submitter(common: &CommonComponents, args: &Arguments) -> Arc<Sol
                             &common.http_factory,
                             args.gelato_api_key.clone().unwrap(),
                         ),
+                        args.gelato_submission_poll_interval,
                     )
                     .await
                     .unwrap(),

--- a/crates/driver/src/main.rs
+++ b/crates/driver/src/main.rs
@@ -259,7 +259,7 @@ async fn build_submitter(common: &CommonComponents, args: &Arguments) -> Arc<Sol
                 }))
             }
             TransactionStrategyArg::Gelato => {
-                transaction_strategies.push(TransactionStrategy::Gelato(
+                transaction_strategies.push(TransactionStrategy::Gelato(Arc::new(
                     GelatoSubmitter::new(
                         web3.clone(),
                         common.settlement_contract.clone(),
@@ -270,7 +270,7 @@ async fn build_submitter(common: &CommonComponents, args: &Arguments) -> Arc<Sol
                     )
                     .await
                     .unwrap(),
-                ))
+                )))
             }
             TransactionStrategyArg::DryRun => {
                 transaction_strategies.push(TransactionStrategy::DryRun)

--- a/crates/shared/src/gelato_api.rs
+++ b/crates/shared/src/gelato_api.rs
@@ -36,7 +36,6 @@ impl GelatoClient {
         }
     }
 
-    #[cfg(test)]
     pub fn test_from_env() -> Result<Self> {
         Ok(Self::new(
             &HttpClientFactory::default(),

--- a/crates/solver/src/arguments.rs
+++ b/crates/solver/src/arguments.rs
@@ -6,7 +6,7 @@ use crate::{
 use primitive_types::H160;
 use reqwest::Url;
 use shared::{
-    arguments::{display_list, display_option},
+    arguments::{display_list, display_option, display_secret_option},
     http_client,
 };
 use std::time::Duration;
@@ -164,6 +164,10 @@ pub struct Arguments {
         use_value_delimiter = true
     )]
     pub transaction_strategy: Vec<TransactionStrategyArg>,
+
+    /// The API key to use for the Gelato submission strategy.
+    #[clap(long, env)]
+    pub gelato_api_key: Option<String>,
 
     /// Which access list estimators to use. Multiple estimators are used in sequence if a previous one
     /// fails. Individual estimators might support different networks.
@@ -329,6 +333,7 @@ impl std::fmt::Display for Arguments {
         )?;
         writeln!(f, "gas_price_cap: {}", self.gas_price_cap)?;
         writeln!(f, "transaction_strategy: {:?}", self.transaction_strategy)?;
+        display_secret_option(f, "gelato_api_key", &self.gelato_api_key)?;
         writeln!(
             f,
             "access_list_estimators: {:?}",
@@ -403,5 +408,6 @@ pub enum TransactionStrategyArg {
     PublicMempool,
     Eden,
     Flashbots,
+    Gelato,
     DryRun,
 }

--- a/crates/solver/src/arguments.rs
+++ b/crates/solver/src/arguments.rs
@@ -169,6 +169,16 @@ pub struct Arguments {
     #[clap(long, env)]
     pub gelato_api_key: Option<String>,
 
+    /// The poll interval for checking status of Gelato tasks when using it as a
+    /// transaction submission strategy.
+    #[clap(
+        long,
+        env,
+        default_value = "5",
+        value_parser = shared::arguments::duration_from_seconds,
+    )]
+    pub gelato_submission_poll_interval: Duration,
+
     /// Which access list estimators to use. Multiple estimators are used in sequence if a previous one
     /// fails. Individual estimators might support different networks.
     /// `Tenderly`: supports every network.
@@ -334,6 +344,11 @@ impl std::fmt::Display for Arguments {
         writeln!(f, "gas_price_cap: {}", self.gas_price_cap)?;
         writeln!(f, "transaction_strategy: {:?}", self.transaction_strategy)?;
         display_secret_option(f, "gelato_api_key", &self.gelato_api_key)?;
+        writeln!(
+            f,
+            "gelato_submission_poll_interval: {:?}",
+            &self.gelato_submission_poll_interval
+        )?;
         writeln!(
             f,
             "access_list_estimators: {:?}",

--- a/crates/solver/src/main.rs
+++ b/crates/solver/src/main.rs
@@ -410,6 +410,7 @@ async fn main() -> ! {
                         web3.clone(),
                         settlement_contract.clone(),
                         GelatoClient::new(&http_factory, args.gelato_api_key.clone().unwrap()),
+                        args.gelato_submission_poll_interval,
                     )
                     .await
                     .unwrap(),

--- a/crates/solver/src/main.rs
+++ b/crates/solver/src/main.rs
@@ -405,7 +405,7 @@ async fn main() -> ! {
                 }))
             }
             TransactionStrategyArg::Gelato => {
-                transaction_strategies.push(TransactionStrategy::Gelato(
+                transaction_strategies.push(TransactionStrategy::Gelato(Arc::new(
                     GelatoSubmitter::new(
                         web3.clone(),
                         settlement_contract.clone(),
@@ -413,7 +413,7 @@ async fn main() -> ! {
                     )
                     .await
                     .unwrap(),
-                ))
+                )))
             }
             TransactionStrategyArg::DryRun => {
                 transaction_strategies.push(TransactionStrategy::DryRun)

--- a/crates/solver/src/settlement_submission.rs
+++ b/crates/solver/src/settlement_submission.rs
@@ -123,7 +123,7 @@ pub enum TransactionStrategy {
     Eden(StrategyArgs),
     Flashbots(StrategyArgs),
     PublicMempool(StrategyArgs),
-    Gelato(GelatoSubmitter),
+    Gelato(Arc<GelatoSubmitter>),
     DryRun,
 }
 

--- a/crates/solver/src/settlement_submission.rs
+++ b/crates/solver/src/settlement_submission.rs
@@ -133,7 +133,7 @@ impl TransactionStrategy {
             TransactionStrategy::Eden(args) => Some(args),
             TransactionStrategy::Flashbots(args) => Some(args),
             TransactionStrategy::PublicMempool(args) => Some(args),
-            _ => None,
+            TransactionStrategy::Gelato(_) | TransactionStrategy::DryRun => None,
         }
     }
 }
@@ -155,7 +155,7 @@ impl SolutionSubmitter {
         // account signing a raw transaction for a nonce, and waiting until that
         // nonce increases to detect that it actually mined. However, the
         // strategies below are **not** compatible with this. So if one of them
-        // is specified, use it exclusively for submitting and exist the loop.
+        // is specified, use it exclusively for submitting and exit the loop.
         // TODO(nlordell): We can refactor the `SolutionSubmitter` interface to
         // better reflect configuration incompatibilities like this.
         for strategy in &self.transaction_strategies {

--- a/crates/solver/src/settlement_submission.rs
+++ b/crates/solver/src/settlement_submission.rs
@@ -151,6 +151,13 @@ impl SolutionSubmitter {
         account: Account,
         nonce: U256,
     ) -> Result<TransactionReceipt, SubmissionError> {
+        // Other transaction strategies than the ones below, depend on an
+        // account signing a raw transaction for a nonce, and waiting until that
+        // nonce increases to detect that it actually mined. However, the
+        // strategies below are **not** compatible with this. So if one of them
+        // is specified, use it exclusively for submitting and exist the loop.
+        // TODO(nlordell): We can refactor the `SolutionSubmitter` interface to
+        // better reflect configuration incompatibilities like this.
         for strategy in &self.transaction_strategies {
             match strategy {
                 TransactionStrategy::DryRun => {

--- a/crates/solver/src/settlement_submission/gelato.rs
+++ b/crates/solver/src/settlement_submission/gelato.rs
@@ -102,14 +102,14 @@ mod tests {
     async fn execute_relayed_settlement() {
         let web3 = Web3::new(create_env_test_transport());
         let settlement = GPv2Settlement::deployed(&web3).await.unwrap();
-        let client = GelatoClient::from_env().unwrap();
+        let client = GelatoClient::test_from_env().unwrap();
 
         let gelato = GelatoSubmitter::new(web3, settlement, client, Duration::from_secs(5))
             .await
             .unwrap();
 
         let solver = Account::Offline(env::var("SOLVER_ACCOUNT").unwrap().parse().unwrap(), None);
-        let settlement = Settlement::empty();
+        let settlement = Settlement::default();
 
         let transaction = gelato.relay_settlement(solver, settlement).await.unwrap();
         println!("executed transaction {:?}", transaction.transaction_hash);

--- a/crates/solver/src/settlement_submission/gelato.rs
+++ b/crates/solver/src/settlement_submission/gelato.rs
@@ -24,13 +24,18 @@ pub struct GelatoSubmitter {
 }
 
 impl GelatoSubmitter {
-    pub async fn new(web3: Web3, settlement: GPv2Settlement, client: GelatoClient) -> Result<Self> {
+    pub async fn new(
+        web3: Web3,
+        settlement: GPv2Settlement,
+        client: GelatoClient,
+        poll_interval: Duration,
+    ) -> Result<Self> {
         let trampoline = Trampoline::initialize(settlement).await?;
         Ok(Self {
             web3,
             client,
             trampoline,
-            poll_interval: Duration::from_secs(5),
+            poll_interval,
         })
     }
 
@@ -99,7 +104,7 @@ mod tests {
         let settlement = GPv2Settlement::deployed(&web3).await.unwrap();
         let client = GelatoClient::from_env().unwrap();
 
-        let gelato = GelatoSubmitter::new(web3, settlement, client)
+        let gelato = GelatoSubmitter::new(web3, settlement, client, Duration::from_secs(5))
             .await
             .unwrap();
 

--- a/crates/solver/src/settlement_submission/gelato.rs
+++ b/crates/solver/src/settlement_submission/gelato.rs
@@ -1,2 +1,114 @@
-#[allow(dead_code)]
+//! Gelato settlement submission strategy.
+
 mod trampoline;
+
+use self::trampoline::Trampoline;
+use super::SubmissionError;
+use crate::settlement::Settlement;
+use anyhow::{anyhow, Context as _, Result};
+use contracts::GPv2Settlement;
+use ethcontract::{Account, H256};
+use shared::{
+    ethrpc::Web3,
+    gelato_api::{GelatoClient, TaskId, TaskState},
+};
+use std::time::Duration;
+use web3::types::TransactionReceipt;
+
+/// A Gelato submitter.
+pub struct GelatoSubmitter {
+    web3: Web3,
+    client: GelatoClient,
+    trampoline: Trampoline,
+    poll_interval: Duration,
+}
+
+impl GelatoSubmitter {
+    pub async fn new(web3: Web3, settlement: GPv2Settlement, client: GelatoClient) -> Result<Self> {
+        let trampoline = Trampoline::initialize(settlement).await?;
+        Ok(Self {
+            web3,
+            client,
+            trampoline,
+            poll_interval: Duration::from_secs(5),
+        })
+    }
+
+    pub async fn relay_settlement(
+        &self,
+        account: Account,
+        settlement: Settlement,
+    ) -> Result<TransactionReceipt, SubmissionError> {
+        let call = self.trampoline.prepare_call(&account, &settlement).await?;
+        let task_id = self.client.sponsored_call(&call).await?;
+        let transaction_hash = self.wait_for_task(task_id).await?;
+        self.wait_for_transaction(transaction_hash).await
+    }
+
+    async fn wait_for_task(&self, task_id: TaskId) -> Result<H256, SubmissionError> {
+        loop {
+            let task = self.client.task_status(&task_id).await?;
+            match task.task_state {
+                TaskState::CheckPending
+                | TaskState::ExecPending
+                | TaskState::WaitingForConfirmation => {
+                    tracing::trace!(?task, "task pending...");
+                    tokio::time::sleep(self.poll_interval).await;
+                }
+                TaskState::ExecSuccess | TaskState::ExecReverted => {
+                    let transaction_hash = task
+                        .transaction_hash
+                        .context("missing transaction hash for confirmed Gelato task")?;
+                    return Ok(transaction_hash);
+                }
+                TaskState::Blacklisted | TaskState::Cancelled | TaskState::NotFound => {
+                    tracing::error!(?task, "unexpected Gelato task state");
+                    return Err(anyhow!("error executing Gelato task {task_id}").into());
+                }
+            }
+        }
+    }
+
+    async fn wait_for_transaction(
+        &self,
+        hash: H256,
+    ) -> Result<TransactionReceipt, SubmissionError> {
+        loop {
+            let receipt = self.web3.eth().transaction_receipt(hash).await?;
+            match receipt {
+                Some(receipt) => return Ok(receipt),
+                None => {
+                    tracing::trace!(?hash, "waiting for transaction...");
+                    tokio::time::sleep(self.poll_interval).await;
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use shared::ethrpc::{create_env_test_transport, Web3};
+    use std::env;
+
+    #[ignore]
+    #[tokio::test]
+    async fn execute_relayed_settlement() {
+        let web3 = Web3::new(create_env_test_transport());
+        let settlement = GPv2Settlement::deployed(&web3).await.unwrap();
+        let client = GelatoClient::from_env().unwrap();
+
+        let gelato = GelatoSubmitter::new(web3, settlement, client)
+            .await
+            .unwrap();
+
+        let solver = Account::Offline(env::var("SOLVER_ACCOUNT").unwrap().parse().unwrap(), None);
+        let settlement = Settlement::empty();
+
+        let transaction = gelato.relay_settlement(solver, settlement).await.unwrap();
+        println!("executed transaction {:?}", transaction.transaction_hash);
+
+        assert_eq!(transaction.status, Some(1.into()));
+    }
+}


### PR DESCRIPTION
Succeeds #599 

This PR adds the Gelato settlement submission strategy and is based on #839 and #840. 

With this new strategy, transaction are submitted over the Gelato relay network, so no transaction execution/submission needs to be handled by the driver 🎉.

Note that there is a bit of a code-smell in the `SettlementSubmitter` component. I didn't want to address that in this PR, but I left a clarifying comment to try and explain the issue. Perhaps this is something we can refactor in the near future.

### Test Plan

Added a new manual test for submitting a [settlement](https://goerli.etherscan.io/tx/0x9b3d0a61d2862f98651cf7b8e8d7edccc3f7aaa3621dd9a8e26576c9a6cc4e5e):
```
% cargo test -p solver -- gelato::tests::execute_relayed_settlement --ignored --nocapture
   Compiling solver v0.1.0 (/Users/nlordell/Developer/cowprotocol/services/crates/solver)
    Finished test [unoptimized + debuginfo] target(s) in 5.97s
     Running unittests src/lib.rs (target/debug/deps/solver-4e294b2061fada4d)

running 1 test
executed transaction 0x9b3d0a61d2862f98651cf7b8e8d7edccc3f7aaa3621dd9a8e26576c9a6cc4e5e
test settlement_submission::gelato::tests::execute_relayed_settlement ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 196 filtered out; finished in 27.26s
```
