### PR TITLE
Add metrics for `AutoUpdatingSolverTokenOwnerFinder`

### DIFF
--- a/crates/shared/src/bad_token/token_owner_finder.rs
+++ b/crates/shared/src/bad_token/token_owner_finder.rs
@@ -240,11 +240,13 @@ pub async fn init(
             .into_iter()
             .zip(args.solver_token_owners_cache_update_intervals.clone())
         {
+            let identifier = url.to_string();
             let solver = Box::new(SolverConfiguration {
                 url,
                 client: http_factory.create(),
             });
-            let solver = AutoUpdatingSolverTokenOwnerFinder::new(solver, update_interval);
+            let solver =
+                AutoUpdatingSolverTokenOwnerFinder::new(solver, update_interval, identifier);
             proposers.push(Arc::new(solver));
         }
     }

--- a/crates/shared/src/bad_token/trace_call.rs
+++ b/crates/shared/src/bad_token/trace_call.rs
@@ -747,6 +747,7 @@ mod tests {
                 client: reqwest::Client::new(),
             }),
             Duration::MAX,
+            "test".to_owned(),
         ));
 
         // Force the cache to update at least once.


### PR DESCRIPTION
Sometimes the new token owner finder implementation is quite noisy because it always logs an error when something fails. However, those errors tend to be temporary, not critical and not really actionable (because we are relying on external servers).
To not let the alert channels become too noisy we can simply add a few metrics and alert based on those.

In order to have meaningful metrics we need to have some identifier associated with them (in case we have to query more urls in the future). To not introduce unnecessary complexity I decided to simply use the urls as the identifier.

### Test Plan
Manual test running the order book locally and grepping for the new metrics:
```
# HELP gp_v2_api_updates Tracks how often a token owner update succeeded or failed.
# TYPE gp_v2_api_updates counter
gp_v2_api_updates{identifier="https://seasolver.dev/token_holders",result="failure"} 0
gp_v2_api_updates{identifier="https://seasolver.dev/token_holders",result="success"} 25
```
