### PR TITLE
Remove default eth-flow contract

### DIFF
--- a/crates/autopilot/src/arguments.rs
+++ b/crates/autopilot/src/arguments.rs
@@ -22,17 +22,9 @@ pub struct Arguments {
     #[clap(flatten)]
     pub price_estimation: price_estimation::Arguments,
 
-    /// Address of the ethflow contract
-    #[clap(
-        long,
-        env,
-        default_value = "0x76aAf674848311C7F21fc691B0b952f016dA49F3"
-    )]
-    pub ethflow_contract: H160,
-
-    // Feature flag for ethflow.
+    /// Address of the ethflow contract. If not specified, eth-flow orders are disabled.
     #[clap(long, env)]
-    pub enable_ethflow_orders: bool,
+    pub ethflow_contract: Option<H160>,
 
     /// A tracing Ethereum node URL to connect to, allowing a separate node URL
     /// to be used exclusively for tracing calls.
@@ -148,7 +140,6 @@ impl std::fmt::Display for Arguments {
         write!(f, "{}", self.price_estimation)?;
         display_option(f, "tracing_node_url", &self.tracing_node_url)?;
         writeln!(f, "ethflow contract: {:?}", self.ethflow_contract)?;
-        writeln!(f, "enable_ethflow_orders: {}", self.enable_ethflow_orders)?;
         writeln!(f, "metrics_address: {}", self.metrics_address)?;
         writeln!(f, "db_url: SECRET")?;
         writeln!(f, "skip_event_sync: {}", self.skip_event_sync)?;

--- a/crates/autopilot/src/lib.rs
+++ b/crates/autopilot/src/lib.rs
@@ -456,11 +456,11 @@ pub async fn main(args: arguments::Arguments) {
             .unwrap(),
     ));
 
-    if args.enable_ethflow_orders {
+    if let Some(ethflow_contract) = args.ethflow_contract {
         // The events from the ethflow contract are read with the more generic contract
         // interface called CoWSwapOnchainOrders.
         let cowswap_onchain_order_contract_for_eth_flow =
-            contracts::CoWSwapOnchainOrders::at(&web3, args.ethflow_contract);
+            contracts::CoWSwapOnchainOrders::at(&web3, ethflow_contract);
         let custom_ethflow_order_parser = EthFlowOnchainOrderParser {};
         let onchain_order_event_parser = OnchainOrderParser::new(
             db.clone(),

--- a/crates/autopilot/src/solvable_orders.rs
+++ b/crates/autopilot/src/solvable_orders.rs
@@ -68,7 +68,7 @@ pub struct SolvableOrdersCache {
     metrics: &'static Metrics,
     // Optional because reward calculation only makes sense on mainnet. Other networks have 0 rewards.
     reward_calculator: Option<risk_adjusted_rewards::Calculator>,
-    ethflow_contract_address: H160,
+    ethflow_contract_address: Option<H160>,
     surplus_fee_age: Duration,
     limit_order_price_factor: BigDecimal,
 }
@@ -101,7 +101,7 @@ impl SolvableOrdersCache {
         signature_validator: Arc<dyn SignatureValidating>,
         update_interval: Duration,
         reward_calculator: Option<risk_adjusted_rewards::Calculator>,
-        ethflow_contract_address: H160,
+        ethflow_contract_address: Option<H160>,
         surplus_fee_age: Duration,
         limit_order_price_factor: BigDecimal,
     ) -> Arc<Self> {
@@ -329,7 +329,7 @@ fn new_balances(old_balances: &Balances, orders: &[Order]) -> (HashMap<Query, U2
 fn solvable_orders(
     mut orders: Vec<Order>,
     balances: &Balances,
-    ethflow_contract: H160,
+    ethflow_contract: Option<H160>,
 ) -> Vec<Order> {
     let mut orders_map = HashMap::<Query, Vec<Order>>::new();
     orders.sort_by_key(|order| std::cmp::Reverse(order.metadata.creation_date));
@@ -348,7 +348,7 @@ fn solvable_orders(
             // For ethflow orders, there is no need to check the balance. The contract
             // ensures that there will always be sufficient balance, after the wrapAll
             // pre_interaction has been called.
-            if order.metadata.owner == ethflow_contract {
+            if Some(order.metadata.owner) == ethflow_contract {
                 result.push(order);
                 continue;
             }
@@ -659,12 +659,12 @@ mod tests {
         ];
 
         let balances = hashmap! {Query::from_order(&orders[0]) => U256::from(9)};
-        let orders_ = solvable_orders(orders.clone(), &balances, H160([1u8; 20]));
+        let orders_ = solvable_orders(orders.clone(), &balances, None);
         // Second order has lower timestamp so it isn't picked.
         assert_eq!(orders_, orders[..1]);
         orders[1].metadata.creation_date =
             DateTime::from_utc(NaiveDateTime::from_timestamp(3, 0), Utc);
-        let orders_ = solvable_orders(orders.clone(), &balances, H160([1u8; 20]));
+        let orders_ = solvable_orders(orders.clone(), &balances, None);
         assert_eq!(orders_, orders[1..]);
     }
 
@@ -686,7 +686,7 @@ mod tests {
         }];
 
         let balances = hashmap! {Query::from_order(&orders[0]) => U256::from(0)};
-        let orders_ = solvable_orders(orders.clone(), &balances, ethflow_address);
+        let orders_ = solvable_orders(orders.clone(), &balances, Some(ethflow_address));
         assert_eq!(orders_, orders);
     }
 
@@ -998,7 +998,7 @@ mod tests {
 
         let balances = hashmap! {Query::from_order(&orders[0]) => U256::MAX};
         let expected_result = vec![orders[0].clone(), orders[1].clone()];
-        let mut filtered_orders = solvable_orders(orders, &balances, H160([1u8; 20]));
+        let mut filtered_orders = solvable_orders(orders, &balances, None);
         // Deal with `solvable_orders()` sorting the orders.
         filtered_orders.sort_by_key(|order| order.metadata.creation_date);
         assert_eq!(expected_result, filtered_orders);

--- a/crates/e2e/tests/e2e/services.rs
+++ b/crates/e2e/tests/e2e/services.rs
@@ -166,7 +166,7 @@ impl OrderbookServices {
             signature_validator.clone(),
             Duration::from_secs(1),
             None,
-            contracts.ethflow.address(),
+            Some(contracts.ethflow.address()),
             Duration::from_secs(5),
             Default::default(),
         );

--- a/crates/refunder/src/arguments.rs
+++ b/crates/refunder/src/arguments.rs
@@ -38,11 +38,7 @@ pub struct Arguments {
     pub node_url: Url,
 
     /// Address of the ethflow contract
-    #[clap(
-        long,
-        env,
-        default_value = "0x76aAf674848311C7F21fc691B0b952f016dA49F3"
-    )]
+    #[clap(long, env)]
     pub ethflow_contract: H160,
 
     #[clap(long, env, hide_env_values = true)]


### PR DESCRIPTION
The eth-flow contract is deployed independently for each supported network and should not have a default value. The current default is the testing contract on Görli.

The changes here are as follows:
1. `ethflow_contract` and `enable_ethflow_orders` arguments are merged together. If no contract is specified, the eth flow is disabled. Otherwise it's enabled.
2. `ethflow_contract` is now a required argument to the refunder.

It also fixes a small bug where even if the eth flow is disabled the eth-flow orders were given preferential treatment in `solvable_orders`.

Note that [this MR](https://gitlab.gnosisdev.com/devops/aws/aws-infra-staging/k8s-team-namespaces/gnosis-staging-k8s-gp/-/merge_requests/584) should be applied before merging this one (please also review that if you approve this). There should be no impact for the prod release as the eth flow is disabled everywhere.

### Test Plan

Existing tests. Try to run the autopilot and see that the default is `None`. Try to run the refunder and see:
```
error: The following required arguments were not provided:
  --ethflow-contract <ETHFLOW_CONTRACT>
```