### PR TITLE
Give metrics for token owner updates more specific name

### DIFF
--- a/crates/shared/src/bad_token/token_owner_finder/solvers/solver_finder.rs
+++ b/crates/shared/src/bad_token/token_owner_finder/solvers/solver_finder.rs
@@ -25,7 +25,7 @@ pub struct AutoUpdatingSolverTokenOwnerFinder {
 struct Metrics {
     /// Tracks how often a token owner update succeeded or failed.
     #[metric(labels("identifier", "result"))]
-    updates: IntCounterVec,
+    token_owner_list_updates: IntCounterVec,
 }
 
 struct Inner {
@@ -38,8 +38,9 @@ struct Inner {
 impl Inner {
     pub fn get_update_counter(&self, success: bool) -> GenericCounter<AtomicU64> {
         let result = if success { "success" } else { "failure" };
-        let labels = [&self.identifier, result];
-        self.metrics.updates.with_label_values(&labels)
+        self.metrics
+            .token_owner_list_updates
+            .with_label_values(&[&self.identifier, result])
     }
 }
 


### PR DESCRIPTION
While creating a grafana panel for the new metrics I noticed that the metric name is horribly vague so I made it more specific.

### Test Plan
simple rename; no test
