### PR TITLE
Route version endpoint at `/v1/version` again

### DIFF
--- a/crates/orderbook/src/api/version.rs
+++ b/crates/orderbook/src/api/version.rs
@@ -5,14 +5,16 @@ use std::convert::Infallible;
 use warp::{reply::with_status, Filter, Rejection};
 
 pub fn version() -> impl Filter<Extract = (ApiReply,), Error = Rejection> + Clone {
-    warp::path!("v1" / "version").and(warp::get()).and_then(|| async {
-        Result::<_, Infallible>::Ok(with_status(
-            warp::reply::json(&json!({
-                "version": env!("VERGEN_GIT_SEMVER_LIGHTWEIGHT"),
-                "commit": env!("VERGEN_GIT_SHA"),
-                "branch": env!("VERGEN_GIT_BRANCH"),
-            })),
-            StatusCode::OK,
-        ))
-    })
+    warp::path!("v1" / "version")
+        .and(warp::get())
+        .and_then(|| async {
+            Result::<_, Infallible>::Ok(with_status(
+                warp::reply::json(&json!({
+                    "version": env!("VERGEN_GIT_SEMVER_LIGHTWEIGHT"),
+                    "commit": env!("VERGEN_GIT_SHA"),
+                    "branch": env!("VERGEN_GIT_BRANCH"),
+                })),
+                StatusCode::OK,
+            ))
+        })
 }

--- a/crates/orderbook/src/api/version.rs
+++ b/crates/orderbook/src/api/version.rs
@@ -5,7 +5,7 @@ use std::convert::Infallible;
 use warp::{reply::with_status, Filter, Rejection};
 
 pub fn version() -> impl Filter<Extract = (ApiReply,), Error = Rejection> + Clone {
-    warp::path!("version").and(warp::get()).and_then(|| async {
+    warp::path!("v1" / "version").and(warp::get()).and_then(|| async {
         Result::<_, Infallible>::Ok(with_status(
             warp::reply::json(&json!({
                 "version": env!("VERGEN_GIT_SEMVER_LIGHTWEIGHT"),


### PR DESCRIPTION
In a recent refactoring the `/version` endpoint lost its `/v1` prefix. It's currently `/api/version` instead of `/api/v1/version` like the openapi specification says.
With this PR the openapi specification and the actual routes are back in order again.

Credit to @ennmichael and @poolpitako for noticing.

### Test Plan
```
curl --request GET --url http://localhost:8080/api/v1/version
{"branch":"fix-api-version-endpoint","commit":"6db54a76144ccba2e52a32f3510f930b66bba8d0","version":"v2.82.0-19-g6db54a7"}
```
