### PR TITLE
Remove Rinkeby From OpenAPI Spec

### DIFF
--- a/crates/orderbook/openapi.yml
+++ b/crates/orderbook/openapi.yml
@@ -7,10 +7,6 @@ servers:
     url: https://api.cow.fi/mainnet
   - description: Mainnet (Staging)
     url: https://barn.api.cow.fi/mainnet
-  - description: Rinkeby (Prod)
-    url: https://api.cow.fi/rinkeby
-  - description: Rinkeby (Staging)
-    url: https://barn.api.cow.fi/rinkeby
   - description: Görli (Prod)
     url: https://api.cow.fi/goerli
   - description: Görli (Staging)


### PR DESCRIPTION
Just remove Rinkeby from the OpenAPI spec - it isn't a thing anymore.

### Test Plan

CI - we validate the OpenAPI spec 🎉.
