### PR TITLE
Fetch liquidity after order check

### DIFF
--- a/crates/solver/src/driver.rs
+++ b/crates/solver/src/driver.rs
@@ -240,19 +240,12 @@ impl Driver {
             })
             .collect::<Vec<_>>();
         tracing::info!(?orders, "got {} orders", orders.len());
+        self.metrics.orders_fetched(&orders);
 
         let external_prices =
             ExternalPrices::try_from_auction_prices(self.native_token, auction.prices)
                 .context("malformed auction prices")?;
         tracing::debug!(?external_prices, "estimated prices");
-
-        let liquidity = self
-            .liquidity_collector
-            .get_liquidity_for_orders(&orders, Block::Number(current_block_during_liquidity_fetch))
-            .await?;
-
-        self.metrics.orders_fetched(&orders);
-        self.metrics.liquidity_fetched(&liquidity);
 
         if !auction_preprocessing::has_at_least_one_user_order(&orders)
             || !auction_preprocessing::has_at_least_one_mature_order(&orders)
@@ -266,6 +259,12 @@ impl Driver {
             .await
             .context("failed to estimate gas price")?;
         tracing::debug!("solving with gas price of {:?}", gas_price);
+
+        let liquidity = self
+            .liquidity_collector
+            .get_liquidity_for_orders(&orders, Block::Number(current_block_during_liquidity_fetch))
+            .await?;
+        self.metrics.liquidity_fetched(&liquidity);
 
         let rewards = auction.rewards;
         let auction = Auction {


### PR DESCRIPTION
We exit the run loop early if there is no mature user order check. In this case we don't make use of liquidity so we can avoid some work by fetching liquidity afterwards.

Fixes #issue.

Describe context of what this change does, why it is needed and how it is accomplished

### Test Plan

CI, not directly tested
