### PR TITLE
Refactor liquidity collection

### DIFF
--- a/crates/driver/src/main.rs
+++ b/crates/driver/src/main.rs
@@ -326,15 +326,13 @@ async fn build_auction_converter(
             .expect("failed to load baseline source uniswap liquidity")
             .into_iter()
             .map(|(source, (_, pool_fetcher))| {
-                let pool_cache = Arc::new(
-                    PoolCache::new(
-                        cache_config,
-                        pool_fetcher,
-                        common.current_block_stream.clone(),
-                    )
-                    .expect("failed to create pool cache"),
-                );
-                (source, pool_cache)
+                let pool_cache = PoolCache::new(
+                    cache_config,
+                    pool_fetcher,
+                    common.current_block_stream.clone(),
+                )
+                .expect("failed to create pool cache");
+                (source, Arc::new(pool_cache))
             })
             .collect();
     maintainers.extend(pool_caches.values().cloned().map(|p| p as Arc<_>));

--- a/crates/driver/src/main.rs
+++ b/crates/driver/src/main.rs
@@ -35,7 +35,7 @@ use solver::{
         balancer_v2::BalancerV2Liquidity, order_converter::OrderConverter,
         uniswap_v2::UniswapLikeLiquidity, uniswap_v3::UniswapV3Liquidity, zeroex::ZeroExLiquidity,
     },
-    liquidity_collector::LiquidityCollector,
+    liquidity_collector::{LiquidityCollecting, LiquidityCollector},
     metrics::Metrics,
     settlement_access_list::AccessListEstimating,
     settlement_ranker::SettlementRanker,
@@ -301,6 +301,9 @@ async fn build_auction_converter(
     common: &CommonComponents,
     args: &Arguments,
 ) -> Result<Arc<AuctionConverter>> {
+    let mut liquidity_sources: Vec<Box<dyn LiquidityCollecting>> = vec![];
+    let mut maintainers: Vec<Arc<dyn Maintaining>> = vec![];
+
     let base_tokens = Arc::new(BaseTokens::new(
         common.native_token_contract.address(),
         &args.base_tokens,
@@ -323,52 +326,51 @@ async fn build_auction_converter(
             .expect("failed to load baseline source uniswap liquidity")
             .into_iter()
             .map(|(source, (_, pool_fetcher))| {
-                let pool_cache = PoolCache::new(
-                    cache_config,
-                    pool_fetcher,
-                    common.current_block_stream.clone(),
-                )
-                .expect("failed to create pool cache");
-                (source, Arc::new(pool_cache))
+                let pool_cache = Arc::new(
+                    PoolCache::new(
+                        cache_config,
+                        pool_fetcher,
+                        common.current_block_stream.clone(),
+                    )
+                    .expect("failed to create pool cache"),
+                );
+                (source, pool_cache)
             })
             .collect();
-    let (balancer_pool_maintainer, balancer_v2_liquidity) =
-        if baseline_sources.contains(&BaselineSource::BalancerV2) {
-            let factories = args
-                .balancer_factories
-                .clone()
-                .unwrap_or_else(|| BalancerFactoryKind::for_chain(common.chain_id));
-            let contracts = BalancerContracts::new(&common.web3, factories)
-                .await
-                .unwrap();
-            let balancer_pool_fetcher = Arc::new(
-                BalancerPoolFetcher::new(
-                    common.chain_id,
-                    common.block_retriever.clone(),
-                    common.token_info_fetcher.clone(),
-                    cache_config,
-                    common.current_block_stream.clone(),
-                    common.http_factory.create(),
-                    common.web3.clone(),
-                    &contracts,
-                    args.balancer_pool_deny_list.clone(),
-                )
-                .await
-                .expect("failed to create Balancer pool fetcher"),
-            );
-            (
-                Some(balancer_pool_fetcher.clone() as Arc<dyn Maintaining>),
-                Some(BalancerV2Liquidity::new(
-                    common.web3.clone(),
-                    balancer_pool_fetcher,
-                    base_tokens.clone(),
-                    common.settlement_contract.clone(),
-                    contracts.vault,
-                )),
+    maintainers.extend(pool_caches.values().cloned().map(|p| p as Arc<_>));
+
+    if baseline_sources.contains(&BaselineSource::BalancerV2) {
+        let factories = args
+            .balancer_factories
+            .clone()
+            .unwrap_or_else(|| BalancerFactoryKind::for_chain(common.chain_id));
+        let contracts = BalancerContracts::new(&common.web3, factories)
+            .await
+            .unwrap();
+        let balancer_pool_fetcher = Arc::new(
+            BalancerPoolFetcher::new(
+                common.chain_id,
+                common.block_retriever.clone(),
+                common.token_info_fetcher.clone(),
+                cache_config,
+                common.current_block_stream.clone(),
+                common.http_factory.create(),
+                common.web3.clone(),
+                &contracts,
+                args.balancer_pool_deny_list.clone(),
             )
-        } else {
-            (None, None)
-        };
+            .await
+            .expect("failed to create Balancer pool fetcher"),
+        );
+        maintainers.push(balancer_pool_fetcher.clone());
+        liquidity_sources.push(Box::new(BalancerV2Liquidity::new(
+            common.web3.clone(),
+            balancer_pool_fetcher,
+            base_tokens.clone(),
+            common.settlement_contract.clone(),
+            contracts.vault,
+        )));
+    }
 
     let uniswap_like_liquidity = build_amm_artifacts(
         &pool_caches,
@@ -377,8 +379,9 @@ async fn build_auction_converter(
         common.web3.clone(),
     )
     .await;
+    liquidity_sources.extend(uniswap_like_liquidity.into_iter());
 
-    let zeroex_liquidity = if baseline_sources.contains(&BaselineSource::ZeroEx) {
+    if baseline_sources.contains(&BaselineSource::ZeroEx) {
         let zeroex_api = Arc::new(
             DefaultZeroExApi::new(
                 &common.http_factory,
@@ -390,68 +393,48 @@ async fn build_auction_converter(
             .unwrap(),
         );
 
-        Some(ZeroExLiquidity::new(
+        liquidity_sources.push(Box::new(ZeroExLiquidity::new(
             common.web3.clone(),
             zeroex_api,
             contracts::IZeroEx::deployed(&common.web3).await.unwrap(),
             base_tokens.clone(),
             common.settlement_contract.clone(),
-        ))
-    } else {
-        None
-    };
+        )));
+    }
 
-    let (uniswap_v3_maintainer, uniswap_v3_liquidity) =
-        if baseline_sources.contains(&BaselineSource::UniswapV3) {
-            match UniswapV3PoolFetcher::new(
-                common.chain_id,
-                common.web3.clone(),
-                common.http_factory.create(),
-                common.block_retriever.clone(),
-                args.max_pools_to_initialize_cache,
-            )
-            .await
-            {
-                Ok(uniswap_v3_pool_fetcher) => {
-                    let uniswap_v3_pool_fetcher = Arc::new(uniswap_v3_pool_fetcher);
-                    (
-                        Some(uniswap_v3_pool_fetcher.clone() as Arc<dyn Maintaining>),
-                        Some(UniswapV3Liquidity::new(
-                            UniswapV3SwapRouter::deployed(&common.web3).await.unwrap(),
-                            common.settlement_contract.clone(),
-                            base_tokens.clone(),
-                            common.web3.clone(),
-                            uniswap_v3_pool_fetcher,
-                        )),
-                    )
-                }
-                Err(err) => {
-                    tracing::error!("failed to create UniswapV3 pool fetcher in driver: {}", err);
-                    (None, None)
-                }
+    if baseline_sources.contains(&BaselineSource::UniswapV3) {
+        match UniswapV3PoolFetcher::new(
+            common.chain_id,
+            common.web3.clone(),
+            common.http_factory.create(),
+            common.block_retriever.clone(),
+            args.max_pools_to_initialize_cache,
+        )
+        .await
+        {
+            Ok(uniswap_v3_pool_fetcher) => {
+                let uniswap_v3_pool_fetcher = Arc::new(uniswap_v3_pool_fetcher);
+                maintainers.push(uniswap_v3_pool_fetcher.clone());
+                liquidity_sources.push(Box::new(UniswapV3Liquidity::new(
+                    UniswapV3SwapRouter::deployed(&common.web3).await.unwrap(),
+                    common.settlement_contract.clone(),
+                    base_tokens.clone(),
+                    common.web3.clone(),
+                    uniswap_v3_pool_fetcher,
+                )));
             }
-        } else {
-            (None, None)
-        };
+            Err(err) => {
+                tracing::error!("failed to create UniswapV3 pool fetcher in driver: {}", err);
+            }
+        }
+    }
 
-    let maintainer = ServiceMaintenance::new(
-        pool_caches
-            .into_iter()
-            .map(|(_, cache)| cache as Arc<dyn Maintaining>)
-            .chain(balancer_pool_maintainer)
-            .chain(uniswap_v3_maintainer)
-            .collect(),
-    );
+    let maintainer = ServiceMaintenance::new(maintainers);
     tokio::task::spawn(
         maintainer.run_maintenance_on_new_block(common.current_block_stream.clone()),
     );
 
-    let liquidity_collector = Box::new(LiquidityCollector {
-        uniswap_like_liquidity,
-        balancer_v2_liquidity,
-        zeroex_liquidity,
-        uniswap_v3_liquidity,
-    });
+    let liquidity_collector = Box::new(LiquidityCollector { liquidity_sources });
     Ok(Arc::new(AuctionConverter::new(
         common.gas_price_estimator.clone(),
         liquidity_collector,
@@ -464,8 +447,8 @@ async fn build_amm_artifacts(
     settlement_contract: contracts::GPv2Settlement,
     base_tokens: Arc<BaseTokens>,
     web3: Web3,
-) -> Vec<UniswapLikeLiquidity> {
-    let mut res = vec![];
+) -> Vec<Box<dyn LiquidityCollecting>> {
+    let mut res: Vec<Box<dyn LiquidityCollecting>> = vec![];
     for (source, pool_cache) in sources {
         let router_address = match source {
             BaselineSource::UniswapV2 => contracts::UniswapV2Router02::deployed(&web3)
@@ -492,13 +475,13 @@ async fn build_amm_artifacts(
             BaselineSource::ZeroEx => continue,
             BaselineSource::UniswapV3 => continue,
         };
-        res.push(UniswapLikeLiquidity::new(
+        res.push(Box::new(UniswapLikeLiquidity::new(
             IUniswapLikeRouter::at(&web3, router_address),
             settlement_contract.clone(),
             base_tokens.clone(),
             web3.clone(),
             pool_cache.clone(),
-        ));
+        )));
     }
     res
 }

--- a/crates/e2e/tests/e2e/limit_orders.rs
+++ b/crates/e2e/tests/e2e/limit_orders.rs
@@ -203,10 +203,7 @@ async fn single_limit_order_test(web3: Web3) {
     );
     let solver = solver::solver::naive_solver(solver_account);
     let liquidity_collector = LiquidityCollector {
-        uniswap_like_liquidity: vec![uniswap_liquidity],
-        balancer_v2_liquidity: None,
-        zeroex_liquidity: None,
-        uniswap_v3_liquidity: None,
+        liquidity_sources: vec![Box::new(uniswap_liquidity)],
     };
     let network_id = web3.net().version().await.unwrap();
     let submitted_transactions = GlobalTxPool::default();
@@ -457,10 +454,7 @@ async fn two_limit_orders_test(web3: Web3) {
     );
     let solver = solver::solver::naive_solver(solver_account);
     let liquidity_collector = LiquidityCollector {
-        uniswap_like_liquidity: vec![uniswap_liquidity],
-        balancer_v2_liquidity: None,
-        zeroex_liquidity: None,
-        uniswap_v3_liquidity: None,
+        liquidity_sources: vec![Box::new(uniswap_liquidity)],
     };
     let network_id = web3.net().version().await.unwrap();
     let submitted_transactions = GlobalTxPool::default();
@@ -713,10 +707,7 @@ async fn mixed_limit_and_market_orders_test(web3: Web3) {
     );
     let solver = solver::solver::naive_solver(solver_account);
     let liquidity_collector = LiquidityCollector {
-        uniswap_like_liquidity: vec![uniswap_liquidity],
-        balancer_v2_liquidity: None,
-        zeroex_liquidity: None,
-        uniswap_v3_liquidity: None,
+        liquidity_sources: vec![Box::new(uniswap_liquidity)],
     };
     let network_id = web3.net().version().await.unwrap();
     let submitted_transactions = GlobalTxPool::default();

--- a/crates/e2e/tests/e2e/onchain_settlement.rs
+++ b/crates/e2e/tests/e2e/onchain_settlement.rs
@@ -189,10 +189,7 @@ async fn onchain_settlement(web3: Web3) {
     );
     let solver = solver::solver::naive_solver(solver_account);
     let liquidity_collector = LiquidityCollector {
-        uniswap_like_liquidity: vec![uniswap_liquidity],
-        balancer_v2_liquidity: None,
-        zeroex_liquidity: None,
-        uniswap_v3_liquidity: None,
+        liquidity_sources: vec![Box::new(uniswap_liquidity)],
     };
     let network_id = web3.net().version().await.unwrap();
     let submitted_transactions = GlobalTxPool::default();

--- a/crates/e2e/tests/e2e/services.rs
+++ b/crates/e2e/tests/e2e/services.rs
@@ -270,10 +270,7 @@ pub async fn setup_naive_solver_uniswapv2_driver(
     );
     let solver = solver::solver::naive_solver(solver_account);
     let liquidity_collector = LiquidityCollector {
-        uniswap_like_liquidity: vec![uniswap_liquidity],
-        balancer_v2_liquidity: None,
-        zeroex_liquidity: None,
-        uniswap_v3_liquidity: None,
+        liquidity_sources: vec![Box::new(uniswap_liquidity)],
     };
     let network_id = web3.net().version().await.unwrap();
     let submitted_transactions = GlobalTxPool::default();

--- a/crates/e2e/tests/e2e/settlement_without_onchain_liquidity.rs
+++ b/crates/e2e/tests/e2e/settlement_without_onchain_liquidity.rs
@@ -173,10 +173,7 @@ async fn onchain_settlement_without_liquidity(web3: Web3) {
     );
 
     let liquidity_collector = LiquidityCollector {
-        uniswap_like_liquidity: vec![uniswap_liquidity],
-        balancer_v2_liquidity: None,
-        zeroex_liquidity: None,
-        uniswap_v3_liquidity: None,
+        liquidity_sources: vec![Box::new(uniswap_liquidity)],
     };
     let network_id = web3.net().version().await.unwrap();
     let market_makable_token_list = AutoUpdatingTokenList::new(maplit::hashmap! {

--- a/crates/e2e/tests/e2e/smart_contract_orders.rs
+++ b/crates/e2e/tests/e2e/smart_contract_orders.rs
@@ -209,10 +209,7 @@ async fn smart_contract_orders(web3: Web3) {
     );
     let solver = solver::solver::naive_solver(solver_account);
     let liquidity_collector = LiquidityCollector {
-        uniswap_like_liquidity: vec![uniswap_liquidity],
-        balancer_v2_liquidity: None,
-        zeroex_liquidity: None,
-        uniswap_v3_liquidity: None,
+        liquidity_sources: vec![Box::new(uniswap_liquidity)],
     };
     let network_id = web3.net().version().await.unwrap();
     let submitted_transactions = GlobalTxPool::default();

--- a/crates/e2e/tests/e2e/vault_balances.rs
+++ b/crates/e2e/tests/e2e/vault_balances.rs
@@ -122,10 +122,7 @@ async fn vault_balances(web3: Web3) {
     );
     let solver = solver::solver::naive_solver(solver_account);
     let liquidity_collector = LiquidityCollector {
-        uniswap_like_liquidity: vec![uniswap_liquidity],
-        balancer_v2_liquidity: None,
-        zeroex_liquidity: None,
-        uniswap_v3_liquidity: None,
+        liquidity_sources: vec![Box::new(uniswap_liquidity)],
     };
     let network_id = web3.net().version().await.unwrap();
     let submitted_transactions = GlobalTxPool::default();

--- a/crates/solver/src/driver.rs
+++ b/crates/solver/src/driver.rs
@@ -26,6 +26,7 @@ use model::{
     solver_competition::{
         self, CompetitionAuction, Execution, Objective, SolverCompetitionDB, SolverSettlement,
     },
+    TokenPair,
 };
 use num::{rational::Ratio, BigInt, BigRational, ToPrimitive};
 use primitive_types::{H160, U256};
@@ -277,9 +278,14 @@ impl Driver {
             .context("failed to estimate gas price")?;
         tracing::debug!("solving with gas price of {:?}", gas_price);
 
+        let pairs: Vec<_> = orders
+            .iter()
+            .filter(|o| !o.is_liquidity_order)
+            .flat_map(|o| TokenPair::new(o.buy_token, o.sell_token))
+            .collect();
         let liquidity = self
             .liquidity_collector
-            .get_liquidity_for_orders(&orders, Block::Number(current_block_during_liquidity_fetch))
+            .get_liquidity(&pairs, Block::Number(current_block_during_liquidity_fetch))
             .await?;
         self.metrics.liquidity_fetched(&liquidity);
 

--- a/crates/solver/src/liquidity/balancer_v2.rs
+++ b/crates/solver/src/liquidity/balancer_v2.rs
@@ -353,7 +353,7 @@ mod tests {
                 &[
                     TokenPair::new(H160([0x70; 20]), H160([0x71; 20])).unwrap(),
                     TokenPair::new(H160([0x70; 20]), H160([0x72; 20])).unwrap(),
-                    TokenPair::new(H160([0x0b; 20]), H160([0x73; 20])).unwrap(),
+                    TokenPair::new(H160([0xb0; 20]), H160([0x73; 20])).unwrap(),
                 ],
                 Block::Recent,
             )

--- a/crates/solver/src/liquidity/balancer_v2.rs
+++ b/crates/solver/src/liquidity/balancer_v2.rs
@@ -6,8 +6,9 @@ use crate::{
         BalancerSwapGivenOutInteraction,
     },
     liquidity::{
-        AmmOrderExecution, LimitOrder, SettlementHandling, StablePoolOrder, WeightedProductOrder,
+        AmmOrderExecution, Liquidity, SettlementHandling, StablePoolOrder, WeightedProductOrder,
     },
+    liquidity_collector::LiquidityCollecting,
     settlement::SettlementEncoder,
 };
 use anyhow::Result;
@@ -47,18 +48,12 @@ impl BalancerV2Liquidity {
         }
     }
 
-    /// Returns relevant Balancer V2 weighted pools given a list of off-chain
-    /// orders.
-    pub async fn get_liquidity(
+    async fn get_orders(
         &self,
-        orders: &[LimitOrder],
+        pairs: &[TokenPair],
         block: Block,
     ) -> Result<(Vec<StablePoolOrder>, Vec<WeightedProductOrder>)> {
-        let pairs = self.base_tokens.relevant_pairs(
-            &mut orders
-                .iter()
-                .flat_map(|order| TokenPair::new(order.buy_token, order.sell_token)),
-        );
+        let pairs = self.base_tokens.relevant_pairs(pairs.iter().cloned());
         let pools = self.pool_fetcher.fetch(pairs, block).await?;
 
         let tokens = pools.relevant_tokens();
@@ -101,6 +96,21 @@ impl BalancerV2Liquidity {
             .collect();
 
         Ok((stable_pool_orders, weighted_product_orders))
+    }
+}
+
+#[async_trait::async_trait]
+impl LiquidityCollecting for BalancerV2Liquidity {
+    /// Returns relevant Balancer V2 weighted pools given a list of off-chain
+    /// orders.
+    async fn get_liquidity(&self, pairs: &[TokenPair], block: Block) -> Result<Vec<Liquidity>> {
+        let (stable, weighted) = self.get_orders(pairs, block).await?;
+        let liquidity = stable
+            .into_iter()
+            .map(Liquidity::BalancerStable)
+            .chain(weighted.into_iter().map(Liquidity::BalancerWeighted))
+            .collect();
+        Ok(liquidity)
     }
 }
 
@@ -339,23 +349,11 @@ mod tests {
             base_tokens,
         };
         let (stable_orders, weighted_orders) = liquidity_provider
-            .get_liquidity(
+            .get_orders(
                 &[
-                    LimitOrder {
-                        sell_token: H160([0x70; 20]),
-                        buy_token: H160([0x71; 20]),
-                        ..Default::default()
-                    },
-                    LimitOrder {
-                        sell_token: H160([0x70; 20]),
-                        buy_token: H160([0x72; 20]),
-                        ..Default::default()
-                    },
-                    LimitOrder {
-                        sell_token: H160([0xb0; 20]),
-                        buy_token: H160([0x73; 20]),
-                        ..Default::default()
-                    },
+                    TokenPair::new(H160([0x70; 20]), H160([0x71; 20])).unwrap(),
+                    TokenPair::new(H160([0x70; 20]), H160([0x72; 20])).unwrap(),
+                    TokenPair::new(H160([0x0b; 20]), H160([0x73; 20])).unwrap(),
                 ],
                 Block::Recent,
             )

--- a/crates/solver/src/liquidity/zeroex.rs
+++ b/crates/solver/src/liquidity/zeroex.rs
@@ -5,6 +5,7 @@ use crate::{
         ZeroExInteraction,
     },
     liquidity::{Exchange, LimitOrder, Liquidity},
+    liquidity_collector::LiquidityCollecting,
     settlement::SettlementEncoder,
 };
 use anyhow::Result;
@@ -14,6 +15,7 @@ use primitive_types::{H160, U256};
 use shared::{
     baseline_solver::BaseTokens,
     ethrpc::Web3,
+    recent_block_cache::Block,
     zeroex_api::{Order, OrderRecord, OrdersQuery, ZeroExApi},
 };
 use std::{
@@ -49,55 +51,6 @@ impl ZeroExLiquidity {
         }
     }
 
-    pub async fn get_liquidity(&self, user_orders: &[LimitOrder]) -> Result<Vec<Liquidity>> {
-        let queries = &[
-            // orders fillable by anyone
-            OrdersQuery::default(),
-            // orders fillable only by our settlement contract
-            OrdersQuery {
-                sender: Some(self.gpv2.address()),
-                ..Default::default()
-            },
-        ];
-
-        let zeroex_orders_results =
-            futures::future::join_all(queries.iter().map(|query| self.api.get_orders(query))).await;
-        let zeroex_orders = zeroex_orders_results
-            .into_iter()
-            .flat_map(|result| match result {
-                Ok(order_record_vec) => order_record_vec,
-                Err(err) => {
-                    tracing::warn!("ZeroExResponse error during liqudity fetching: {}", err);
-                    vec![]
-                }
-            });
-
-        let user_order_pairs = user_orders
-            .iter()
-            .filter_map(|order| TokenPair::new(order.buy_token, order.sell_token));
-        let relevant_pairs = self.base_tokens.relevant_pairs(user_order_pairs);
-
-        let order_buckets = generate_order_buckets(zeroex_orders, relevant_pairs);
-        let filtered_zeroex_orders = get_useful_orders(order_buckets, 5);
-        let tokens: HashSet<_> = filtered_zeroex_orders
-            .iter()
-            .map(|o| o.order.taker_token)
-            .collect();
-
-        let allowances = Arc::new(
-            self.allowance_manager
-                .get_allowances(tokens, self.zeroex.address())
-                .await?,
-        );
-
-        let zeroex_liquidity_orders: Vec<_> = filtered_zeroex_orders
-            .into_iter()
-            .flat_map(|order| self.record_into_liquidity(order, allowances.clone()))
-            .collect();
-
-        Ok(zeroex_liquidity_orders)
-    }
-
     /// Turns 0x OrderRecord into liquidity which solvers can use.
     fn record_into_liquidity(
         &self,
@@ -131,6 +84,55 @@ impl ZeroExLiquidity {
             is_mature: false, // irrelevant for liquidity orders
         };
         Some(Liquidity::LimitOrder(limit_order))
+    }
+}
+
+#[async_trait::async_trait]
+impl LiquidityCollecting for ZeroExLiquidity {
+    async fn get_liquidity(&self, pairs: &[TokenPair], _block: Block) -> Result<Vec<Liquidity>> {
+        let queries = &[
+            // orders fillable by anyone
+            OrdersQuery::default(),
+            // orders fillable only by our settlement contract
+            OrdersQuery {
+                sender: Some(self.gpv2.address()),
+                ..Default::default()
+            },
+        ];
+
+        let zeroex_orders_results =
+            futures::future::join_all(queries.iter().map(|query| self.api.get_orders(query))).await;
+        let zeroex_orders = zeroex_orders_results
+            .into_iter()
+            .flat_map(|result| match result {
+                Ok(order_record_vec) => order_record_vec,
+                Err(err) => {
+                    tracing::warn!("ZeroExResponse error during liqudity fetching: {}", err);
+                    vec![]
+                }
+            });
+
+        let relevant_pairs = self.base_tokens.relevant_pairs(pairs.iter().cloned());
+
+        let order_buckets = generate_order_buckets(zeroex_orders, relevant_pairs);
+        let filtered_zeroex_orders = get_useful_orders(order_buckets, 5);
+        let tokens: HashSet<_> = filtered_zeroex_orders
+            .iter()
+            .map(|o| o.order.taker_token)
+            .collect();
+
+        let allowances = Arc::new(
+            self.allowance_manager
+                .get_allowances(tokens, self.zeroex.address())
+                .await?,
+        );
+
+        let zeroex_liquidity_orders: Vec<_> = filtered_zeroex_orders
+            .into_iter()
+            .flat_map(|order| self.record_into_liquidity(order, allowances.clone()))
+            .collect();
+
+        Ok(zeroex_liquidity_orders)
     }
 }
 

--- a/crates/solver/src/liquidity_collector.rs
+++ b/crates/solver/src/liquidity_collector.rs
@@ -1,86 +1,32 @@
-use crate::liquidity::{
-    balancer_v2::BalancerV2Liquidity, uniswap_v2::UniswapLikeLiquidity,
-    uniswap_v3::UniswapV3Liquidity, zeroex::ZeroExLiquidity, LimitOrder, Liquidity,
-};
-use anyhow::{Context, Result};
+use crate::liquidity::Liquidity;
+use anyhow::Result;
+use model::TokenPair;
 use shared::recent_block_cache::Block;
 
 #[mockall::automock]
 #[async_trait::async_trait]
 pub trait LiquidityCollecting: Send + Sync {
-    async fn get_liquidity_for_orders(
-        &self,
-        limit_orders: &[LimitOrder],
-        at_block: Block,
-    ) -> Result<Vec<Liquidity>>;
+    async fn get_liquidity(&self, pairs: &[TokenPair], at_block: Block) -> Result<Vec<Liquidity>>;
 }
 
 pub struct LiquidityCollector {
-    pub uniswap_like_liquidity: Vec<UniswapLikeLiquidity>,
-    pub balancer_v2_liquidity: Option<BalancerV2Liquidity>,
-    pub zeroex_liquidity: Option<ZeroExLiquidity>,
-    pub uniswap_v3_liquidity: Option<UniswapV3Liquidity>,
-}
-
-impl LiquidityCollector {
-    /// Creates a `LiquidityCollector` which does not collect any liquidity.
-    pub fn default() -> Self {
-        Self {
-            uniswap_like_liquidity: vec![],
-            balancer_v2_liquidity: None,
-            zeroex_liquidity: None,
-            uniswap_v3_liquidity: None,
-        }
-    }
+    pub liquidity_sources: Vec<Box<dyn LiquidityCollecting>>,
 }
 
 #[async_trait::async_trait]
 impl LiquidityCollecting for LiquidityCollector {
-    async fn get_liquidity_for_orders(
-        &self,
-        limit_orders: &[LimitOrder],
-        at_block: Block,
-    ) -> Result<Vec<Liquidity>> {
-        let mut amms = vec![];
-        let user_orders = limit_orders
+    async fn get_liquidity(&self, pairs: &[TokenPair], at_block: Block) -> Result<Vec<Liquidity>> {
+        let futures = self
+            .liquidity_sources
             .iter()
-            .filter(|order| !order.is_liquidity_order)
-            .cloned()
-            .collect::<Vec<_>>();
-        for liquidity in &self.uniswap_like_liquidity {
-            amms.extend(
-                liquidity
-                    .get_liquidity(&user_orders, at_block)
-                    .await
-                    .context("failed to get UniswapLike liquidity")?
-                    .into_iter()
-                    .map(Liquidity::ConstantProduct),
-            );
-        }
-        if let Some(balancer_v2_liquidity) = self.balancer_v2_liquidity.as_ref() {
-            let (stable_orders, weighted_orders) = balancer_v2_liquidity
-                .get_liquidity(&user_orders, at_block)
-                .await
-                .context("failed to get Balancer liquidity")?;
-
-            amms.extend(weighted_orders.into_iter().map(Liquidity::BalancerWeighted));
-            amms.extend(stable_orders.into_iter().map(Liquidity::BalancerStable));
-        }
-        if let Some(zeroex_liquidity) = self.zeroex_liquidity.as_ref() {
-            amms.append(&mut zeroex_liquidity.get_liquidity(limit_orders).await?)
-        }
-        if let Some(uniswap_v3_liquidity) = self.uniswap_v3_liquidity.as_ref() {
-            amms.extend(
-                uniswap_v3_liquidity
-                    .get_liquidity(&user_orders, at_block)
-                    .await
-                    .context("failed to get UniswapV3 liquidity")?
-                    .into_iter()
-                    .map(Liquidity::Concentrated),
-            )
-        }
+            .map(|source| source.get_liquidity(pairs, at_block));
+        let amms: Vec<_> = futures::future::join_all(futures)
+            .await
+            .into_iter()
+            .flatten()
+            .flatten()
+            .collect();
         tracing::debug!("got {} AMMs", amms.len());
-
         Ok(amms)
     }
 }

--- a/crates/solver/src/main.rs
+++ b/crates/solver/src/main.rs
@@ -30,7 +30,7 @@ use solver::{
         balancer_v2::BalancerV2Liquidity, order_converter::OrderConverter,
         uniswap_v2::UniswapLikeLiquidity, uniswap_v3::UniswapV3Liquidity, zeroex::ZeroExLiquidity,
     },
-    liquidity_collector::LiquidityCollector,
+    liquidity_collector::{LiquidityCollecting, LiquidityCollector},
     metrics::Metrics,
     orderbook::OrderBookApi,
     settlement_post_processing::PostProcessingPipeline,
@@ -122,6 +122,10 @@ async fn main() -> ! {
     let baseline_sources = args.shared.baseline_sources.unwrap_or_else(|| {
         sources::defaults_for_chain(chain_id).expect("failed to get default baseline sources")
     });
+
+    let mut liquidity_sources: Vec<Box<dyn LiquidityCollecting>> = vec![];
+    let mut maintainers: Vec<Arc<dyn Maintaining>> = vec![];
+
     tracing::info!(?baseline_sources, "using baseline sources");
     let pool_caches: HashMap<BaselineSource, Arc<PoolCache>> =
         sources::uniswap_like_liquidity_sources(&web3, &baseline_sources)
@@ -129,48 +133,45 @@ async fn main() -> ! {
             .expect("failed to load baseline source uniswap liquidity")
             .into_iter()
             .map(|(source, (_, pool_fetcher))| {
-                let pool_cache =
+                let pool_cache = Arc::new(
                     PoolCache::new(cache_config, pool_fetcher, current_block_stream.clone())
-                        .expect("failed to create pool cache");
-                (source, Arc::new(pool_cache))
+                        .expect("failed to create pool cache"),
+                );
+                (source, pool_cache)
             })
             .collect();
+    maintainers.extend(pool_caches.values().cloned().map(|p| p as Arc<_>));
 
-    let (balancer_pool_maintainer, balancer_v2_liquidity) =
-        if baseline_sources.contains(&BaselineSource::BalancerV2) {
-            let factories = args
-                .shared
-                .balancer_factories
-                .unwrap_or_else(|| BalancerFactoryKind::for_chain(chain_id));
-            let contracts = BalancerContracts::new(&web3, factories).await.unwrap();
-            let balancer_pool_fetcher = Arc::new(
-                BalancerPoolFetcher::new(
-                    chain_id,
-                    block_retriever.clone(),
-                    token_info_fetcher.clone(),
-                    cache_config,
-                    current_block_stream.clone(),
-                    http_factory.create(),
-                    web3.clone(),
-                    &contracts,
-                    args.shared.balancer_pool_deny_list,
-                )
-                .await
-                .expect("failed to create Balancer pool fetcher"),
-            );
-            (
-                Some(balancer_pool_fetcher.clone() as Arc<dyn Maintaining>),
-                Some(BalancerV2Liquidity::new(
-                    web3.clone(),
-                    balancer_pool_fetcher,
-                    base_tokens.clone(),
-                    settlement_contract.clone(),
-                    contracts.vault,
-                )),
+    if baseline_sources.contains(&BaselineSource::BalancerV2) {
+        let factories = args
+            .shared
+            .balancer_factories
+            .unwrap_or_else(|| BalancerFactoryKind::for_chain(chain_id));
+        let contracts = BalancerContracts::new(&web3, factories).await.unwrap();
+        let balancer_pool_fetcher = Arc::new(
+            BalancerPoolFetcher::new(
+                chain_id,
+                block_retriever.clone(),
+                token_info_fetcher.clone(),
+                cache_config,
+                current_block_stream.clone(),
+                http_factory.create(),
+                web3.clone(),
+                &contracts,
+                args.shared.balancer_pool_deny_list,
             )
-        } else {
-            (None, None)
-        };
+            .await
+            .expect("failed to create Balancer pool fetcher"),
+        );
+        maintainers.push(balancer_pool_fetcher.clone());
+        liquidity_sources.push(Box::new(BalancerV2Liquidity::new(
+            web3.clone(),
+            balancer_pool_fetcher,
+            base_tokens.clone(),
+            settlement_contract.clone(),
+            contracts.vault,
+        )));
+    }
 
     let uniswap_like_liquidity = build_amm_artifacts(
         &pool_caches,
@@ -179,6 +180,7 @@ async fn main() -> ! {
         web3.clone(),
     )
     .await;
+    liquidity_sources.extend(uniswap_like_liquidity);
 
     let solvers = {
         if let Some(solver_accounts) = args.solver_accounts {
@@ -282,57 +284,44 @@ async fn main() -> ! {
             .collect::<Vec<_>>(),
     );
 
-    let zeroex_liquidity = if baseline_sources.contains(&BaselineSource::ZeroEx) {
-        Some(ZeroExLiquidity::new(
+    if baseline_sources.contains(&BaselineSource::ZeroEx) {
+        liquidity_sources.push(Box::new(ZeroExLiquidity::new(
             web3.clone(),
             zeroex_api,
             contracts::IZeroEx::deployed(&web3).await.unwrap(),
             base_tokens.clone(),
             settlement_contract.clone(),
-        ))
-    } else {
-        None
-    };
+        )));
+    }
 
-    let (uniswap_v3_maintainer, uniswap_v3_liquidity) =
-        if baseline_sources.contains(&BaselineSource::UniswapV3) {
-            match UniswapV3PoolFetcher::new(
-                chain_id,
-                web3.clone(),
-                http_factory.create(),
-                block_retriever,
-                args.shared.max_pools_to_initialize_cache,
-            )
-            .await
-            {
-                Ok(uniswap_v3_pool_fetcher) => {
-                    let uniswap_v3_pool_fetcher = Arc::new(uniswap_v3_pool_fetcher);
-                    (
-                        Some(uniswap_v3_pool_fetcher.clone() as Arc<dyn Maintaining>),
-                        Some(UniswapV3Liquidity::new(
-                            UniswapV3SwapRouter::deployed(&web3).await.unwrap(),
-                            settlement_contract.clone(),
-                            base_tokens.clone(),
-                            web3.clone(),
-                            uniswap_v3_pool_fetcher,
-                        )),
-                    )
-                }
-                Err(err) => {
-                    tracing::error!("failed to create UniswapV3 pool fetcher in solver: {}", err);
-                    (None, None)
-                }
+    if baseline_sources.contains(&BaselineSource::UniswapV3) {
+        match UniswapV3PoolFetcher::new(
+            chain_id,
+            web3.clone(),
+            http_factory.create(),
+            block_retriever,
+            args.shared.max_pools_to_initialize_cache,
+        )
+        .await
+        {
+            Ok(uniswap_v3_pool_fetcher) => {
+                let uniswap_v3_pool_fetcher = Arc::new(uniswap_v3_pool_fetcher);
+                maintainers.push(uniswap_v3_pool_fetcher.clone());
+                liquidity_sources.push(Box::new(UniswapV3Liquidity::new(
+                    UniswapV3SwapRouter::deployed(&web3).await.unwrap(),
+                    settlement_contract.clone(),
+                    base_tokens.clone(),
+                    web3.clone(),
+                    uniswap_v3_pool_fetcher,
+                )));
             }
-        } else {
-            (None, None)
-        };
+            Err(err) => {
+                tracing::error!("failed to create UniswapV3 pool fetcher in solver: {}", err);
+            }
+        }
+    }
 
-    let liquidity_collector = LiquidityCollector {
-        uniswap_like_liquidity,
-        balancer_v2_liquidity,
-        zeroex_liquidity,
-        uniswap_v3_liquidity,
-    };
+    let liquidity_collector = LiquidityCollector { liquidity_sources };
     let submission_nodes_with_url = args
         .transaction_submission_nodes
         .into_iter()
@@ -481,14 +470,7 @@ async fn main() -> ! {
         code_fetcher,
     );
 
-    let maintainer = ServiceMaintenance::new(
-        pool_caches
-            .into_iter()
-            .map(|(_, cache)| cache as Arc<dyn Maintaining>)
-            .chain(balancer_pool_maintainer)
-            .chain(uniswap_v3_maintainer)
-            .collect(),
-    );
+    let maintainer = ServiceMaintenance::new(maintainers);
     tokio::task::spawn(maintainer.run_maintenance_on_new_block(current_block_stream));
 
     serve_metrics(metrics, ([0, 0, 0, 0], args.metrics_port).into());
@@ -500,8 +482,8 @@ async fn build_amm_artifacts(
     settlement_contract: contracts::GPv2Settlement,
     base_tokens: Arc<BaseTokens>,
     web3: Web3,
-) -> Vec<UniswapLikeLiquidity> {
-    let mut res = vec![];
+) -> Vec<Box<dyn LiquidityCollecting>> {
+    let mut res: Vec<Box<dyn LiquidityCollecting>> = vec![];
     for (source, pool_cache) in sources {
         let router_address = match source {
             BaselineSource::UniswapV2 => contracts::UniswapV2Router02::deployed(&web3)
@@ -528,13 +510,13 @@ async fn build_amm_artifacts(
             BaselineSource::ZeroEx => continue,
             BaselineSource::UniswapV3 => continue,
         };
-        res.push(UniswapLikeLiquidity::new(
+        res.push(Box::new(UniswapLikeLiquidity::new(
             IUniswapLikeRouter::at(&web3, router_address),
             settlement_contract.clone(),
             base_tokens.clone(),
             web3.clone(),
             pool_cache.clone(),
-        ));
+        )));
     }
     res
 }

--- a/crates/solver/src/main.rs
+++ b/crates/solver/src/main.rs
@@ -133,11 +133,10 @@ async fn main() -> ! {
             .expect("failed to load baseline source uniswap liquidity")
             .into_iter()
             .map(|(source, (_, pool_fetcher))| {
-                let pool_cache = Arc::new(
+                let pool_cache =
                     PoolCache::new(cache_config, pool_fetcher, current_block_stream.clone())
-                        .expect("failed to create pool cache"),
-                );
-                (source, pool_cache)
+                        .expect("failed to create pool cache");
+                (source, Arc::new(pool_cache))
             })
             .collect();
     maintainers.extend(pool_caches.values().cloned().map(|p| p as Arc<_>));


### PR DESCRIPTION
Fixes #869 

In order to reuse the `LiquidityCollector` for solving an auction as well as estimating a quote `Query` it should not rely on the `LimitOrder` type to collect liquidity for. Instead it internally only uses `TokenPair` so this is what I refactored it to use in the high level API.
Also I made the existing liquidity sources implement the `LiquidityCollecting` trait and the `LiquidityCollector` know takes a list of those to collect liquidity on them in parallel.

As a side note I also changed how the liquidity sources get initialized in the driver and solver main because it looked quite messy.

### Test Plan
Only a refactor so existing tests should detect an error
Updated 1 unit test to work with the new interface
