### PR TITLE
Track solvable orders metrics grouped by order class

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -205,6 +205,7 @@ dependencies = [
  "serde_with 2.0.1",
  "shared",
  "sqlx",
+ "strum",
  "testlib",
  "tokio",
  "tracing",

--- a/crates/autopilot/Cargo.toml
+++ b/crates/autopilot/Cargo.toml
@@ -40,6 +40,7 @@ serde_json = { workspace = true }
 serde_with = { workspace = true }
 shared = { path = "../shared" }
 sqlx = { workspace = true }
+strum = { workspace = true }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread", "signal", "sync", "time"] }
 tracing = { workspace = true }
 url = { workspace = true }

--- a/crates/model/src/order.rs
+++ b/crates/model/src/order.rs
@@ -22,7 +22,7 @@ use std::{
     fmt::{self, Debug, Display},
     str::FromStr,
 };
-use strum::EnumString;
+use strum::{AsRefStr, EnumString, EnumVariantNames};
 use web3::signing::{self, Key, SecretKeyRef};
 
 /// The flag denoting that an order is buying ETH (or the chain's native token).
@@ -644,7 +644,19 @@ pub enum OrderKind {
     Sell,
 }
 
-#[derive(Eq, PartialEq, Clone, Debug, Default, Deserialize, Serialize, Hash, EnumString)]
+#[derive(
+    Eq,
+    PartialEq,
+    Clone,
+    Debug,
+    Default,
+    Deserialize,
+    Serialize,
+    Hash,
+    EnumString,
+    AsRefStr,
+    EnumVariantNames,
+)]
 #[strum(ascii_case_insensitive)]
 #[serde(tag = "class", rename_all = "lowercase")]
 pub enum OrderClass {


### PR DESCRIPTION
Instead of just knowing how many orders are in the current auction or got filtered out it would be nice to know how many orders of each class there are.

This could help us see how popular the new limit order feature is and if we are filtering out lots and lots of limit orders because they are out of the market price range.

[related slack thread](https://cowservices.slack.com/archives/C049P351GKF/p1669924566478809?thread_ts=1669912430.193089&cid=C049P351GKF)