### PR TITLE
Move Out GasPrice Bump to CallSites

### DIFF
--- a/crates/driver/src/commit_reveal.rs
+++ b/crates/driver/src/commit_reveal.rs
@@ -15,6 +15,7 @@ use {
         driver_logger::DriverLogger,
         settlement::Settlement,
         settlement_ranker::SettlementRanker,
+        settlement_simulation::MAX_BASE_GAS_FEE_INCREASE,
         solver::{Auction, Solver},
     },
     std::sync::{Arc, Mutex},
@@ -101,7 +102,11 @@ impl CommitRevealSolver {
             Err(_timeout) => Err(SolverRunError::Timeout),
         };
 
-        let gas_price = self.gas_estimator.estimate().await?;
+        let gas_price = self
+            .gas_estimator
+            .estimate()
+            .await?
+            .bump(MAX_BASE_GAS_FEE_INCREASE);
         let (mut rated_settlements, errors) = self
             .settlement_ranker
             .rank_legal_settlements(

--- a/crates/driver/src/driver.rs
+++ b/crates/driver/src/driver.rs
@@ -19,6 +19,7 @@ use {
         driver_logger::DriverLogger,
         settlement::Settlement,
         settlement_rater::{SettlementRating, SimulationWithResult},
+        settlement_simulation::MAX_BASE_GAS_FEE_INCREASE,
         settlement_submission::{SolutionSubmitter, SubmissionError},
     },
     std::{
@@ -114,7 +115,11 @@ impl Driver {
     /// Validates that the `Settlement` satisfies expected fairness and
     /// correctness properties.
     async fn validate_settlement(&self, settlement: Settlement) -> Result<SimulationWithResult> {
-        let gas_price = self.gas_price_estimator.estimate().await?;
+        let gas_price = self
+            .gas_price_estimator
+            .estimate()
+            .await?
+            .bump(MAX_BASE_GAS_FEE_INCREASE);
         let fake_solver = Arc::new(CommitRevealSolverAdapter::from(self.solver.clone()));
         let simulation_details = self
             .settlement_rater

--- a/crates/solver/src/driver.rs
+++ b/crates/solver/src/driver.rs
@@ -11,7 +11,7 @@ use crate::{
     settlement::{external_prices::ExternalPrices, PriceCheckTokens, Settlement},
     settlement_ranker::SettlementRanker,
     settlement_rater::SettlementRater,
-    settlement_simulation,
+    settlement_simulation::{self, MAX_BASE_GAS_FEE_INCREASE},
     settlement_submission::{SolutionSubmitter, SubmissionError},
     solver::{Auction, Solver, Solvers},
 };
@@ -279,7 +279,8 @@ impl Driver {
             .gas_price_estimator
             .estimate()
             .await
-            .context("failed to estimate gas price")?;
+            .context("failed to estimate gas price")?
+            .bump(MAX_BASE_GAS_FEE_INCREASE);
         tracing::debug!("solving with gas price of {:?}", gas_price);
 
         let pairs: Vec<_> = orders

--- a/crates/solver/src/settlement_simulation.rs
+++ b/crates/solver/src/settlement_simulation.rs
@@ -34,7 +34,12 @@ const SIMULATE_BATCH_SIZE: usize = 10;
 /// Example of this in action:
 /// [Block 12998225](https://etherscan.io/block/12998225) with base fee of `43.353224173` and ~100% over the gas target.
 /// Next [block 12998226](https://etherscan.io/block/12998226) has base fee of `48.771904644` which is an increase of ~12.5%.
-const MAX_BASE_GAS_FEE_INCREASE: f64 = 1.125;
+///
+/// Increase the gas price by the highest possible base gas fee increase. This
+/// is done because the between retrieving the gas price and executing the simulation,
+/// a block may have been mined that increases the base gas fee and causes the
+/// `eth_call` simulation to fail with `max fee per gas less than block base fee`.
+pub const MAX_BASE_GAS_FEE_INCREASE: f64 = 1.125;
 
 pub async fn simulate_and_estimate_gas_at_current_block(
     settlements: impl Iterator<Item = (Account, EncodedSettlement, Option<AccessList>)>,
@@ -168,11 +173,6 @@ pub fn settle_method(
     settlement: EncodedSettlement,
     account: Account,
 ) -> MethodBuilder<DynTransport, ()> {
-    // Increase the gas price by the highest possible base gas fee increase. This
-    // is done because the between retrieving the gas price and executing the simulation,
-    // a block may have been mined that increases the base gas fee and causes the
-    // `eth_call` simulation to fail with `max fee per gas less than block base fee`.
-    let gas_price = gas_price.bump(MAX_BASE_GAS_FEE_INCREASE);
     settle_method_builder(contract, settlement, account)
         .gas_price(crate::into_gas_price(&gas_price))
 }


### PR DESCRIPTION
Inspired by https://github.com/cowprotocol/services/pull/913#issuecomment-1339027508

In order to know the exact gas price we are simulating with (and also to be able to log/print/report exact gas price), I've moved out the bumping from `settle_method` to final call sites.
