### PR TITLE
Remove Approval::AllowanceSufficient in AllowanceManager refactor

### DIFF
--- a/crates/solver/src/interactions/allowances.rs
+++ b/crates/solver/src/interactions/allowances.rs
@@ -25,17 +25,13 @@ pub trait AllowanceManaging: Send + Sync {
     async fn get_allowances(&self, tokens: HashSet<H160>, spender: H160) -> Result<Allowances>;
 
     /// Returns the approval interaction for the specified token and spender for
-    /// at least the specified amount.
-    async fn get_approval(&self, request: &ApprovalRequest) -> Result<Approval> {
-        Ok(self
-            .get_approvals(slice::from_ref(request))
-            .await?
-            .pop()
-            .expect("missing single approval result"))
+    /// at least the specified amount, if an approval is required.
+    async fn get_approval(&self, request: &ApprovalRequest) -> Result<Option<Approval>> {
+        Ok(self.get_approvals(slice::from_ref(request)).await?.pop())
     }
 
-    /// Returns the approval interaction for the specified token and spender for
-    /// at least the specified amount.
+    /// Returns the requried approval interaction for the requests.
+    /// Does not return approvals when they aren't required.
     async fn get_approvals(&self, requests: &[ApprovalRequest]) -> Result<Vec<Approval>>;
 }
 
@@ -65,7 +61,7 @@ impl Allowances {
     }
 
     /// Gets the approval interaction for the specified token and amount.
-    pub fn approve_token(&self, token: H160, amount: U256) -> Result<Approval> {
+    pub fn approve_token(&self, token: H160, amount: U256) -> Result<Option<Approval>> {
         let allowance = self
             .allowances
             .get(&token)
@@ -73,23 +69,22 @@ impl Allowances {
             .ok_or_else(|| anyhow!("missing allowance for token {:?}", token))?;
 
         Ok(if allowance < amount {
-            Approval::Approve {
+            Some(Approval {
                 token,
                 spender: self.spender,
-            }
+            })
         } else {
-            Approval::AllowanceSufficient
+            None
         })
     }
 
     /// Gets the token approval, unconditionally approving in case the token
     /// allowance is missing.
-    pub fn approve_token_or_default(&self, token: H160, amount: U256) -> Approval {
-        self.approve_token(token, amount)
-            .unwrap_or(Approval::Approve {
-                token,
-                spender: self.spender,
-            })
+    pub fn approve_token_or_default(&self, token: H160, amount: U256) -> Option<Approval> {
+        self.approve_token(token, amount).unwrap_or(Some(Approval {
+            token,
+            spender: self.spender,
+        }))
     }
 
     /// Extends the allowance cache with another.
@@ -106,35 +101,25 @@ impl Allowances {
 
 /// An ERC20 approval interaction.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub enum Approval {
-    /// The existing allowance is sufficient, so no additional `approve` is required.
-    AllowanceSufficient,
-
-    /// An ERC20 approve is needed. This interaction always approves U256::MAX
-    /// in order to save gas by allowing approvals to be used over multiple
-    /// settlements.
-    Approve { token: H160, spender: H160 },
+pub struct Approval {
+    pub token: H160,
+    pub spender: H160,
 }
 
 impl Interaction for Approval {
     fn encode(&self) -> Vec<EncodedInteraction> {
-        match self {
-            Approval::AllowanceSufficient => vec![],
-            Approval::Approve { token, spender } => {
-                // Use a "dummy" contract - unfortunately `ethcontract` doesn't
-                // allow you use the generated contract intances to encode
-                // transaction data without a `Web3` instance. Hopefully, this
-                // limitation will be lifted soon to clean up stuff like this.
-                let token = dummy_contract!(ERC20, *token);
-                let approve = Erc20ApproveInteraction {
-                    token,
-                    spender: *spender,
-                    amount: U256::max_value(),
-                };
+        // Use a "dummy" contract - unfortunately `ethcontract` doesn't
+        // allow you use the generated contract intances to encode
+        // transaction data without a `Web3` instance. Hopefully, this
+        // limitation will be lifted soon to clean up stuff like this.
+        let token = dummy_contract!(ERC20, self.token);
+        let approve = Erc20ApproveInteraction {
+            token,
+            spender: self.spender,
+            amount: U256::max_value(),
+        };
 
-                approve.encode()
-            }
-        }
+        approve.encode()
     }
 }
 
@@ -174,17 +159,15 @@ impl AllowanceManaging for AllowanceManager {
         }
 
         let allowances = fetch_allowances(self.web3.clone(), self.owner, spender_tokens).await?;
-        requests
-            .iter()
-            .map(|request| {
-                allowances
-                    .get(&request.spender)
-                    .with_context(|| {
-                        format!("no allowances found for spender {}", request.spender)
-                    })?
-                    .approve_token(request.token, request.amount)
-            })
-            .collect()
+        let mut result = Vec::new();
+        for request in requests {
+            let allowance = allowances
+                .get(&request.spender)
+                .with_context(|| format!("no allowances found for spender {}", request.spender))?
+                .approve_token(request.token, request.amount)?;
+            result.extend(allowance);
+        }
+        Ok(result)
     }
 }
 
@@ -269,14 +252,8 @@ mod tests {
             },
         );
 
-        assert_eq!(
-            allowances.approve_token(token, 42.into()).unwrap(),
-            Approval::AllowanceSufficient
-        );
-        assert_eq!(
-            allowances.approve_token(token, 100.into()).unwrap(),
-            Approval::AllowanceSufficient
-        );
+        assert_eq!(allowances.approve_token(token, 42.into()).unwrap(), None);
+        assert_eq!(allowances.approve_token(token, 100.into()).unwrap(), None);
     }
 
     #[test]
@@ -292,7 +269,7 @@ mod tests {
 
         assert_eq!(
             allowances.approve_token(token, 1337.into()).unwrap(),
-            Approval::Approve { token, spender }
+            Some(Approval { token, spender })
         );
     }
 
@@ -318,7 +295,7 @@ mod tests {
 
         assert_eq!(
             allowances.approve_token_or_default(token, 1337.into()),
-            Approval::Approve { token, spender }
+            Some(Approval { token, spender })
         );
     }
 
@@ -361,12 +338,10 @@ mod tests {
 
     #[test]
     fn approval_encode_interaction() {
-        assert_eq!(Approval::AllowanceSufficient.encode(), vec![]);
-
         let token = H160([0x01; 20]);
         let spender = H160([0x02; 20]);
         assert_eq!(
-            Approval::Approve { token, spender }.encode(),
+            Approval { token, spender }.encode(),
             vec![(
                 token,
                 0.into(),

--- a/crates/solver/src/liquidity/balancer_v2.rs
+++ b/crates/solver/src/liquidity/balancer_v2.rs
@@ -159,10 +159,9 @@ impl SettlementHandler {
         let (asset_in, amount_in_max) = execution.input_max;
         let (asset_out, amount_out) = execution.output;
 
-        encoder.append_to_execution_plan_internalizable(
-            self.allowances.approve_token(asset_in, amount_in_max)?,
-            execution.internalizable,
-        );
+        if let Some(approval) = self.allowances.approve_token(asset_in, amount_in_max)? {
+            encoder.append_to_execution_plan_internalizable(approval, execution.internalizable);
+        }
         encoder.append_to_execution_plan_internalizable(
             BalancerSwapGivenOutInteraction {
                 settlement: self.settlement.clone(),
@@ -422,7 +421,7 @@ mod tests {
         assert_eq!(
             interactions,
             [
-                Approval::Approve {
+                Approval {
                     token: H160([0x70; 20]),
                     spender: vault.address(),
                 }
@@ -438,7 +437,6 @@ mod tests {
                     user_data: Default::default(),
                 }
                 .encode(),
-                Approval::AllowanceSufficient.encode(),
                 BalancerSwapGivenOutInteraction {
                     settlement,
                     vault,

--- a/crates/solver/src/solver/balancer_sor_solver.rs
+++ b/crates/solver/src/solver/balancer_sor_solver.rs
@@ -129,7 +129,9 @@ impl SingleOrderSolving for BalancerSorSolver {
 
         let mut settlement = Settlement::new(prices);
         settlement.with_liquidity(&order, order.full_execution_amount())?;
-        settlement.encoder.append_to_execution_plan(approval);
+        if let Some(approval) = approval {
+            settlement.encoder.append_to_execution_plan(approval);
+        }
         settlement.encoder.append_to_execution_plan(batch_swap);
 
         Ok(Some(settlement))
@@ -227,7 +229,7 @@ impl Interaction for BatchSwap {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::interactions::allowances::{AllowanceManager, Approval, MockAllowanceManaging};
+    use crate::interactions::allowances::{AllowanceManager, MockAllowanceManaging};
     use ethcontract::{H160, H256};
     use mockall::predicate::*;
     use model::order::{Order, OrderData};
@@ -312,7 +314,7 @@ mod tests {
                 spender: vault.address(),
                 amount: sell_amount,
             }))
-            .returning(|_| Ok(Approval::AllowanceSufficient));
+            .returning(|_| Ok(None));
 
         let solver = BalancerSorSolver::new(
             Account::Local(H160([0x42; 20]), None),
@@ -435,7 +437,7 @@ mod tests {
                 spender: vault.address(),
                 amount: sell_amount * 1001 / 1000,
             }))
-            .returning(|_| Ok(Approval::AllowanceSufficient));
+            .returning(|_| Ok(None));
 
         let solver = BalancerSorSolver::new(
             Account::Local(H160([0x42; 20]), None),

--- a/crates/solver/src/solver/http_solver/settlement.rs
+++ b/crates/solver/src/solver/http_solver/settlement.rs
@@ -1034,12 +1034,7 @@ mod tests {
                             (H160([2; 20]), H160([0xf2; 20])) => U256::from(5),
                         }
             })
-            .returning(|requests| {
-                Ok(requests
-                    .iter()
-                    .map(|_| Approval::AllowanceSufficient)
-                    .collect())
-            });
+            .returning(|_| Ok(Vec::new()));
 
         assert_eq!(
             compute_approvals(
@@ -1074,7 +1069,7 @@ mod tests {
             )
             .await
             .unwrap(),
-            vec![Approval::AllowanceSufficient; 4],
+            Vec::new(),
         );
     }
 


### PR DESCRIPTION
While working with other code I found it wrong that "no allowance needed" is a separate enum case that also implements Interaction but is encoded as nothing so it disappears later. This feels weird because we still drag it around until the settlement is encoded.

### Test Plan

Ci with existing tests
