### PR TITLE
Add logging options to refunder

### DIFF
--- a/crates/autopilot/src/main.rs
+++ b/crates/autopilot/src/main.rs
@@ -4,8 +4,8 @@ use clap::Parser;
 async fn main() {
     let args = autopilot::arguments::Arguments::parse();
     shared::tracing::initialize(
-        args.shared.log_filter.as_str(),
-        args.shared.log_stderr_threshold,
+        args.shared.logging.log_filter.as_str(),
+        args.shared.logging.log_stderr_threshold,
     );
     shared::exit_process_on_panic::set_panic_hook();
     tracing::info!("running autopilot with validated arguments:\n{}", args);

--- a/crates/driver/src/arguments.rs
+++ b/crates/driver/src/arguments.rs
@@ -7,6 +7,7 @@ use {
         ethrpc,
         gas_price_estimation::GasEstimatorType,
         http_client,
+        logging_args_with_default_filter,
         sources::{balancer_v2::BalancerFactoryKind, BaselineSource},
         tenderly_api,
     },
@@ -19,6 +20,11 @@ use {
     std::{net::SocketAddr, num::NonZeroU64, time::Duration},
     tracing::level_filters::LevelFilter,
 };
+
+logging_args_with_default_filter!(
+    LoggingArguments,
+    "warn,driver=debug,solver=debug,shared=debug"
+);
 
 #[derive(clap::Parser)]
 pub struct Arguments {
@@ -37,18 +43,11 @@ pub struct Arguments {
     #[clap(flatten)]
     pub tenderly: tenderly_api::Arguments,
 
+    #[clap(flatten)]
+    pub logging: LoggingArguments,
+
     #[clap(long, env, default_value = "0.0.0.0:8080")]
     pub bind_address: SocketAddr,
-
-    #[clap(
-        long,
-        env,
-        default_value = "warn,driver=debug,solver=debug,shared=debug"
-    )]
-    pub log_filter: String,
-
-    #[clap(long, env, default_value = "error")]
-    pub log_stderr_threshold: LevelFilter,
 
     /// List of solvers in the form of `name|url|account`.
     #[clap(long, env, use_value_delimiter = true)]
@@ -314,8 +313,12 @@ impl std::fmt::Display for Arguments {
         write!(f, "{}", self.slippage)?;
         write!(f, "{}", self.tenderly)?;
         writeln!(f, "bind_address: {}", self.bind_address)?;
-        writeln!(f, "log_filter: {}", self.log_filter)?;
-        writeln!(f, "log_stderr_threshold: {}", self.log_stderr_threshold)?;
+        writeln!(f, "log_filter: {}", self.logging.log_filter)?;
+        writeln!(
+            f,
+            "log_stderr_threshold: {}",
+            self.logging.log_stderr_threshold
+        )?;
         writeln!(f, "solvers: {:?}", self.solvers)?;
         writeln!(f, "node_url: {}", self.node_url)?;
         writeln!(f, "use_internal_buffers: {}", self.use_internal_buffers)?;

--- a/crates/driver/src/main.rs
+++ b/crates/driver/src/main.rs
@@ -566,7 +566,10 @@ async fn build_drivers(common: &CommonComponents, args: &Arguments) -> Vec<(Arc<
 #[tokio::main]
 async fn main() {
     let args = driver::arguments::Arguments::parse();
-    shared::tracing::initialize(args.log_filter.as_str(), args.log_stderr_threshold);
+    shared::tracing::initialize(
+        args.logging.log_filter.as_str(),
+        args.logging.log_stderr_threshold,
+    );
     shared::exit_process_on_panic::set_panic_hook();
     tracing::info!("running driver with validated arguments:\n{}", args);
     global_metrics::setup_metrics_registry(Some("gp_v2_driver".into()), None);

--- a/crates/orderbook/src/main.rs
+++ b/crates/orderbook/src/main.rs
@@ -53,8 +53,8 @@ use tokio::task;
 async fn main() -> ! {
     let args = orderbook::arguments::Arguments::parse();
     shared::tracing::initialize(
-        args.shared.log_filter.as_str(),
-        args.shared.log_stderr_threshold,
+        args.shared.logging.log_filter.as_str(),
+        args.shared.logging.log_stderr_threshold,
     );
     shared::exit_process_on_panic::set_panic_hook();
     tracing::info!("running order book with validated arguments:\n{}", args);

--- a/crates/refunder/src/arguments.rs
+++ b/crates/refunder/src/arguments.rs
@@ -1,8 +1,11 @@
 use clap::Parser;
 use ethcontract::H160;
-use shared::{ethrpc, http_client};
+use shared::{ethrpc, http_client, logging_args_with_default_filter};
 use std::time::Duration;
+use tracing::level_filters::LevelFilter;
 use url::Url;
+
+logging_args_with_default_filter!(LoggingArguments, "warn,refunder=debug,shared=debug");
 
 #[derive(Parser)]
 pub struct Arguments {
@@ -11,6 +14,9 @@ pub struct Arguments {
 
     #[clap(flatten)]
     pub ethrpc: ethrpc::Arguments,
+
+    #[clap(flatten)]
+    pub logging: LoggingArguments,
 
     /// Minimum time in seconds an order must have been valid for
     /// to be eligible for refunding

--- a/crates/refunder/src/main.rs
+++ b/crates/refunder/src/main.rs
@@ -4,8 +4,8 @@ use clap::Parser;
 async fn main() {
     let args = refunder::arguments::Arguments::parse();
     shared::tracing::initialize(
-        "warn,refunder=debug,shared=debug",
-        tracing::Level::ERROR.into(),
+        args.logging.log_filter.as_str(),
+        args.logging.log_stderr_threshold,
     );
     shared::exit_process_on_panic::set_panic_hook();
     tracing::info!("running refunder with validated arguments:\n{}", args);

--- a/crates/solver/src/main.rs
+++ b/crates/solver/src/main.rs
@@ -50,8 +50,8 @@ use std::{collections::HashMap, sync::Arc};
 async fn main() -> ! {
     let args = solver::arguments::Arguments::parse();
     shared::tracing::initialize(
-        args.shared.log_filter.as_str(),
-        args.shared.log_stderr_threshold,
+        args.shared.logging.log_filter.as_str(),
+        args.shared.logging.log_stderr_threshold,
     );
     shared::exit_process_on_panic::set_panic_hook();
     tracing::info!("running solver with validated arguments:\n{}", args);


### PR DESCRIPTION
Parameter to customize the refunder at a logger level.
They were taken from the other services and isolated to a macro.

### Test Plan

```
$ cargo run --bin refunder -- --ethflow-contract 0x0000000000000000000000000000000000000000 --refunder-pk 0x0  2>/dev/null
2022-12-06T14:08:49.918Z  INFO refunder: running refunder with validated arguments:
[...]
$ cargo run --bin refunder -- --ethflow-contract 0x0000000000000000000000000000000000000000 --refunder-pk 0x0 --log-stderr-threshold 'trace' 2>/dev/null
[no output]
```
