### PR TITLE
Check Solver Balance Before Submission V2

### DIFF
--- a/crates/solver/src/settlement_ranker.rs
+++ b/crates/solver/src/settlement_ranker.rs
@@ -20,6 +20,12 @@ use std::{cmp::Ordering, sync::Arc, time::Duration};
 
 type SolverResult = (Arc<dyn Solver>, Result<Vec<Settlement>, SolverRunError>);
 
+// We require from solvers to have a bit more ETH balance then needed
+// at the moment of simulating the transaction, to cover the potential increase
+// of the cost of sending transaction onchain, because of the sudden gas price increase.
+// To simulate this sudden increase of gas price during simulation, we artificially multiply
+// the gas price with this factor.
+const SOLVER_BALANCE_MULTIPLIER: f64 = 3.;
 pub struct SettlementRanker {
     pub metrics: Arc<dyn SolverMetrics>,
     pub settlement_rater: Arc<dyn SettlementRating>,
@@ -133,6 +139,8 @@ impl SettlementRanker {
         gas_price: GasPrice1559,
         auction_id: AuctionId,
     ) -> Result<(Vec<RatedSolverSettlement>, Vec<SimulationWithError>)> {
+        let gas_price = gas_price.bump(SOLVER_BALANCE_MULTIPLIER);
+
         let solver_settlements =
             self.get_legal_settlements(settlements, external_prices, auction_id);
 


### PR DESCRIPTION
Another version of https://github.com/cowprotocol/services/pull/913 as proposed [here](https://github.com/cowprotocol/services/pull/913#issuecomment-1339027508)

This PR bumps the gas price inside `SettlementRanker` only, because we don't want to have the bumped value stored in solver competition (right?).

Obviously much simpler and does not require additional node calls to check the balance of solver accounts.

On the other side, if simulation fails because of low solver balance, we don't send the specialized message to notify solvers (as in https://github.com/cowprotocol/services/pull/913), but we send a regular `simulation failure` where the reason of failing is hidden (luckily, we also send the used gas price to solvers so they can reproduce the transaction and figure out the reason of failure in tenderly).

https://github.com/cowprotocol/services/pull/913 seems like a proper way of doing this check. This PR, however, is much simpler change but feels like misusing the gas price. Also, https://github.com/cowprotocol/services/pull/913 seems like more future proof, because we might want to remove this gas price multiplier one day (for whatever reason I can't think of right now).

That said, I don't know which one to merge. I'll let the team decide.
