### PR TITLE
Mark interaction as internalizable instead of dropping it

### DIFF
--- a/crates/solver/src/settlement/settlement_encoder.rs
+++ b/crates/solver/src/settlement/settlement_encoder.rs
@@ -139,7 +139,13 @@ impl SettlementEncoder {
             tokens: self.tokens.clone(),
             clearing_prices: self.clearing_prices.clone(),
             trades: self.trades.clone(),
-            execution_plan: Vec::new(),
+            execution_plan: self
+                .execution_plan
+                .iter()
+                // Instead of simply dropping the executions we mark all the interactions as
+                // internalizable.
+                .map(|(execution, _)| (execution.clone(), true))
+                .collect(),
             pre_interactions: self.pre_interactions.clone(),
             unwraps: self.unwraps.clone(),
         }


### PR DESCRIPTION
The optimization pipeline which should improve the objective value of a settlement by applying a few gas optimizations can cause solutions that are not viable to pass the simulation by internalizing AMM interactions that are overly optimistic.

Check out this [trade](https://explorer.cow.fi/orders/0x79d6e25eb8dfe279df8e6248c01fd9b337b14a2842af1719deb556e09483ca031a0af84ef9f0a5e60967c319b03dca9a9221bde563920171) selling `USDC` for `AMPL`. `Paraswap` currently gives too optimistic prices for `AMPL`. That means the settlement provided by `paraswap` would likely have reverted. Because the order was selling `USDC` (a trusted token) the optimization pipeline was allowed to internalize the erroneous AMM interaction which resulted in a working settlement with an unbeatable price (because we pay with our buffers).

I saw 2 ways to tackle this issue:
1. Don't apply optimizations if the original settlement would already revert
2. Instead of right out dropping the interaction we keep the original interaction but mark it as internalizable

I decided to go with `2` because together with #843 it should prevent the same problems while offering better debuggability than `1`.

### Test Plan
?