### PR TITLE
Add additional logging to access list simulation

### DIFF
--- a/crates/solver/src/settlement_submission/dry_run.rs
+++ b/crates/solver/src/settlement_submission/dry_run.rs
@@ -20,7 +20,7 @@ pub async fn log_settlement(
     let network = web3.net().version().await?;
     let settlement = settlement.encode(InternalizationStrategy::SkipInternalizableInteraction);
     let settlement = settle_method_builder(contract, settlement, account).tx;
-    let simulation_link = tenderly_link(current_block.as_u64(), &network, settlement);
+    let simulation_link = tenderly_link(current_block.as_u64(), &network, settlement, None);
 
     tracing::info!("not submitting transaction in dry-run mode");
     tracing::debug!("transaction simulation: {}", simulation_link);


### PR DESCRIPTION
Trying to figure out what's going on in https://github.com/cowprotocol/services/issues/925.

So `submit_with_increasing_gas_prices_until_simulation_fails` _does_ call the appropriate `estimate_settlement_access_list` function, which should do the partial access list estimation. However this `estimate_settlement_access_list` ends up with a tx reverted error. I added some logs to try to pinpoint what is failing (the partial access list estimation, or the final access list estimation). Would be good to merge this quickly and do another test on staging.