### PR TITLE
Do not block onchain order parsing on unknown events

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1046,8 +1046,7 @@ dependencies = [
 [[package]]
 name = "ethcontract"
 version = "0.23.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7236691dcb4b9b3672808fa072a413c67d025fd113681f1550e3379c299dd810"
+source = "git+https://github.com/fedgiac/ethcontract-rs?branch=keep-errors-in-event-query#17c9c8e61b840701c3ce0e90aefe4e33f726dceb"
 dependencies = [
  "arrayvec",
  "ethcontract-common",
@@ -1070,8 +1069,7 @@ dependencies = [
 [[package]]
 name = "ethcontract-common"
 version = "0.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8312590754c75b14aa2e7f0f759f3dc68817398ab5bb1115552fea2751b623fc"
+source = "git+https://github.com/fedgiac/ethcontract-rs?branch=keep-errors-in-event-query#17c9c8e61b840701c3ce0e90aefe4e33f726dceb"
 dependencies = [
  "ethabi",
  "hex",
@@ -1086,8 +1084,7 @@ dependencies = [
 [[package]]
 name = "ethcontract-derive"
 version = "0.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "942653d82ad2ade8fcf25dc065516653d1c965cf6c1982de5cc079fdd6dba93c"
+source = "git+https://github.com/fedgiac/ethcontract-rs?branch=keep-errors-in-event-query#17c9c8e61b840701c3ce0e90aefe4e33f726dceb"
 dependencies = [
  "anyhow",
  "ethcontract-common",
@@ -1100,8 +1097,7 @@ dependencies = [
 [[package]]
 name = "ethcontract-generate"
 version = "0.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdaf86f28ebe51e92aaab1d477458f8bd991880bf557881b4daae69529c76e42"
+source = "git+https://github.com/fedgiac/ethcontract-rs?branch=keep-errors-in-event-query#17c9c8e61b840701c3ce0e90aefe4e33f726dceb"
 dependencies = [
  "Inflector",
  "anyhow",
@@ -1116,8 +1112,7 @@ dependencies = [
 [[package]]
 name = "ethcontract-mock"
 version = "0.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c248f7d5b465507f3d45df5fa91dd0fc743f2b9580cab2117b861e4242fee589"
+source = "git+https://github.com/fedgiac/ethcontract-rs?branch=keep-errors-in-event-query#17c9c8e61b840701c3ce0e90aefe4e33f726dceb"
 dependencies = [
  "ethcontract",
  "hex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,9 +10,9 @@ cached = { version = "0.39", default-features = false }
 chrono = { version = "0.4", default-features = false }
 clap = { version = "4", features = ["derive", "env"] }
 derivative = "2"
-ethcontract = { version = "0.23.1", default-features = false }
-ethcontract-generate = { version = "0.23", default-features = false }
-ethcontract-mock = { version = "0.23", default-features = false }
+ethcontract = { git = "https://github.com/fedgiac/ethcontract-rs", branch = "keep-errors-in-event-query" , default-features = false }
+ethcontract-generate = { git = "https://github.com/fedgiac/ethcontract-rs", branch = "keep-errors-in-event-query" , default-features = false }
+ethcontract-mock = { git = "https://github.com/fedgiac/ethcontract-rs", branch = "keep-errors-in-event-query" , default-features = false }
 futures = "0.3"
 gas-estimation = { git = "https://github.com/cowprotocol/gas-estimation", tag = "v0.7.1", features = ["web3_", "tokio_"] }
 hex = { version = "0.4", default-features = false }

--- a/crates/autopilot/src/event_updater.rs
+++ b/crates/autopilot/src/event_updater.rs
@@ -2,7 +2,7 @@ use anyhow::Result;
 use contracts::{cowswap_onchain_orders, gpv2_settlement};
 use shared::{
     current_block::{BlockNumberHash, BlockRetrieving},
-    event_handling::{EventHandler, EventRetrieving, EventStoring},
+    event_handling::{EventHandler, EventRetrieving, EventStoring, OnEventDecodingError},
     impl_event_retrieving,
     maintenance::Maintaining,
 };
@@ -32,12 +32,14 @@ where
         db: Database,
         block_retriever: Arc<dyn BlockRetrieving>,
         start_sync_at_block: Option<BlockNumberHash>,
+        on_event_decoding_error: OnEventDecodingError,
     ) -> Self {
         Self(Mutex::new(EventHandler::new(
             block_retriever,
             contract,
             db,
             start_sync_at_block,
+            on_event_decoding_error,
         )))
     }
 }

--- a/crates/autopilot/src/lib.rs
+++ b/crates/autopilot/src/lib.rs
@@ -34,6 +34,7 @@ use shared::{
     baseline_solver::BaseTokens,
     contracts::settlement_deployment_block_number_hash,
     current_block::block_number_to_block_number_hash,
+    event_handling::OnEventDecodingError,
     fee_subsidy::{
         config::FeeSubsidyConfiguration, cow_token::CowSubsidy, FeeSubsidies, FeeSubsidizing,
     },
@@ -389,6 +390,7 @@ pub async fn main(args: arguments::Arguments) -> ! {
         db.clone(),
         block_retriever.clone(),
         skip_event_sync_start,
+        OnEventDecodingError::Error,
     ));
     let mut maintainers: Vec<Arc<dyn Maintaining>> =
         vec![pool_fetcher.clone(), event_updater, Arc::new(db.clone())];
@@ -478,6 +480,7 @@ pub async fn main(args: arguments::Arguments) -> ! {
                         }),
                 ),
             ),
+            OnEventDecodingError::Ignore,
         ));
         maintainers.push(broadcaster_event_updater);
     }

--- a/crates/e2e/tests/e2e/local_node.rs
+++ b/crates/e2e/tests/e2e/local_node.rs
@@ -1,5 +1,5 @@
 use chrono::{DateTime, Utc};
-use ethcontract::{futures::FutureExt, Account, Address, U256};
+use ethcontract::{futures::FutureExt, Account, Address, BlockNumber, U256};
 use lazy_static::lazy_static;
 use shared::ethrpc::{create_test_transport, Web3};
 use std::{
@@ -173,4 +173,14 @@ impl AccountAssigner {
     pub fn assign_free_account(&mut self) -> Account {
         self.free_accounts.pop().expect("No testing accounts available, consider increasing the number of testing account in the test node")
     }
+}
+
+pub async fn blockchain_time(web3: &Web3) -> u32 {
+    web3.eth()
+        .block(BlockNumber::Latest.into())
+        .await
+        .expect("Unable to query block from node")
+        .expect("Block should exist")
+        .timestamp
+        .as_u32()
 }

--- a/crates/e2e/tests/e2e/refunder.rs
+++ b/crates/e2e/tests/e2e/refunder.rs
@@ -1,13 +1,13 @@
 use crate::{
     eth_flow::{EthFlowOrderOnchainStatus, ExtendedEthFlowOrder},
-    local_node::{AccountAssigner, TestNodeApi},
+    local_node::{blockchain_time, AccountAssigner, TestNodeApi},
     onchain_components::{
         deploy_token_with_weth_uniswap_pool, to_wei, MintableToken, WethPoolConfig,
     },
     services::{OrderbookServices, API_HOST},
 };
 use chrono::{DateTime, NaiveDateTime, Utc};
-use ethcontract::{BlockNumber, H160, U256};
+use ethcontract::{H160, U256};
 use model::quote::{
     OrderQuoteRequest, OrderQuoteResponse, OrderQuoteSide, QuoteSigningScheme, Validity,
 };
@@ -129,14 +129,4 @@ async fn refunder_tx(web3: Web3) {
         ethflow_order.status(&contracts).await,
         EthFlowOrderOnchainStatus::Invalidated
     );
-}
-
-async fn blockchain_time(web3: &Web3) -> u32 {
-    web3.eth()
-        .block(BlockNumber::Latest.into())
-        .await
-        .expect("Unable to query block from node")
-        .expect("Block should exist")
-        .timestamp
-        .as_u32()
 }

--- a/crates/e2e/tests/e2e/services.rs
+++ b/crates/e2e/tests/e2e/services.rs
@@ -22,6 +22,7 @@ use shared::{
     code_fetching::{CachedCodeFetcher, MockCodeFetching},
     current_block::{current_block_stream, CurrentBlockStream},
     ethrpc::Web3,
+    event_handling::OnEventDecodingError,
     fee_subsidy::Subsidy,
     maintenance::ServiceMaintenance,
     order_quoting::{
@@ -97,6 +98,7 @@ impl OrderbookServices {
             autopilot_db.clone(),
             block_retriever.clone(),
             None,
+            OnEventDecodingError::Error,
         ));
         let pair_provider = uniswap_pair_provider(contracts);
         let current_block_stream =
@@ -219,6 +221,7 @@ impl OrderbookServices {
             onchain_order_event_parser,
             block_retriever,
             None,
+            OnEventDecodingError::Ignore,
         ));
         let orderbook = Arc::new(Orderbook::new(
             contracts.domain_separator,

--- a/crates/shared/src/event_handling.rs
+++ b/crates/shared/src/event_handling.rs
@@ -435,8 +435,8 @@ where
 /// Filter function that always returns true unless set to ignore event decoding
 /// errors. In this latter case, all errors are preserved except those that come
 /// from decoding an invalid event for the contract.
-fn filter_decoding_errors<E>(
-    event: &Result<E, ExecutionError>,
+fn filter_decoding_errors<Event>(
+    event: &Result<Event, ExecutionError>,
     on_event_decoding_error: OnEventDecodingError,
 ) -> bool {
     on_event_decoding_error != OnEventDecodingError::Ignore || {

--- a/crates/shared/src/event_handling.rs
+++ b/crates/shared/src/event_handling.rs
@@ -4,12 +4,13 @@ use crate::{
 };
 use anyhow::{Context, Error, Result};
 use ethcontract::{
+    common::abi,
     contract::{AllEventsBuilder, ParseLog},
     dyns::DynTransport,
     errors::ExecutionError,
     Event as EthcontractEvent, EventMetadata,
 };
-use futures::{future, Stream, StreamExt, TryStreamExt};
+use futures::{future, Stream, StreamExt, TryFutureExt, TryStreamExt};
 use std::sync::Arc;
 use tokio::sync::Mutex;
 
@@ -33,7 +34,11 @@ const MAX_PARALLEL_RPC_CALLS: usize = 128;
 /// 3. If this range is too big, split it into two subranges, one to update the deep history blocks, second one
 /// to update the latest blocks (last X canonical blocks)
 /// 4. Do the history update, and if successful, update `last_handled_blocks` to make sure the data is consistent.
-/// 5. If history update is successful, procceed with latest update, and if successful update `last_handled_blocks`.  
+/// 5. If history update is successful, procceed with latest update, and if successful update `last_handled_blocks`.
+///
+/// The parameter `on_event_decoding_error` determines what the event handler does in case it encounters an error when
+/// decoding an event from contract. Ignoring error may be necessary if, for example, the address that we read events
+/// from does not exclusively implement the ABI specified by the contract type `C` but also emit unrelated events.
 pub struct EventHandler<C, S>
 where
     C: EventRetrieving,
@@ -43,6 +48,13 @@ where
     contract: C,
     store: S,
     last_handled_blocks: Vec<BlockNumberHash>,
+    on_event_decoding_error: OnEventDecodingError,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OnEventDecodingError {
+    Ignore,
+    Error,
 }
 
 /// `EventStoring` is used by `EventHandler` for the purpose of giving the user freedom
@@ -97,6 +109,7 @@ where
         contract: C,
         store: S,
         start_sync_at_block: Option<BlockNumberHash>,
+        on_event_decoding_error: OnEventDecodingError,
     ) -> Self {
         Self {
             block_retriever,
@@ -108,6 +121,7 @@ where
                     None => vec![],
                 }
             },
+            on_event_decoding_error,
         }
     }
 
@@ -335,13 +349,25 @@ where
     ) -> (Vec<BlockNumberHash>, Vec<EthcontractEvent<C::Event>>) {
         let (mut blocks_filtered, mut events) = (vec![], vec![]);
         for chunk in blocks.chunks(MAX_PARALLEL_RPC_CALLS) {
-            for (i, result) in future::join_all(
-                chunk
-                    .iter()
-                    .map(|block| self.contract.get_events().block_hash(block.1).query()),
-            )
+            for (i, result) in future::join_all(chunk.iter().map(|block| {
+                let bubble_up_errors = |events: Vec<Result<EthcontractEvent<_>, _>>| {
+                    events
+                        .into_iter()
+                        .filter(|event| filter_decoding_errors(event, self.on_event_decoding_error))
+                        .collect::<Result<Vec<_>, _>>()
+                };
+                self.contract
+                    .get_events()
+                    .block_hash(block.1)
+                    .query_return_errors()
+                    .map_ok(bubble_up_errors)
+            }))
             .await
             .into_iter()
+            .map(|result| match result {
+                Err(err) => Err(err),
+                Ok(ok) => ok,
+            })
             .enumerate()
             {
                 match result {
@@ -361,6 +387,7 @@ where
         &self,
         block_range: &RangeInclusive<u64>,
     ) -> Result<impl Stream<Item = Result<EthcontractEvent<C::Event>>>, ExecutionError> {
+        let on_event_decoding_error = self.on_event_decoding_error;
         Ok(self
             .contract
             .get_events()
@@ -369,6 +396,9 @@ where
             .block_page_size(500)
             .query_paginated()
             .await?
+            .filter(move |event: &Result<EthcontractEvent<_>, ExecutionError>| {
+                future::ready(filter_decoding_errors(event, on_event_decoding_error))
+            })
             .map_err(Error::from))
     }
 
@@ -399,6 +429,21 @@ where
             self.last_handled_blocks.first(),
             self.last_handled_blocks.last(),
         );
+    }
+}
+
+/// Filter function that always returns true unless set to ignore event decoding
+/// errors. In this latter case, all errors are preserved except those that come
+/// from decoding an invalid event for the contract.
+fn filter_decoding_errors<E>(
+    event: &Result<E, ExecutionError>,
+    on_event_decoding_error: OnEventDecodingError,
+) -> bool {
+    on_event_decoding_error != OnEventDecodingError::Ignore || {
+        !matches!(
+            event,
+            Err(ExecutionError::AbiDecode(abi::Error::InvalidData))
+        )
     }
 }
 
@@ -712,6 +757,7 @@ mod tests {
             GPv2SettlementContract(contract),
             storage,
             None,
+            OnEventDecodingError::Error,
         );
         let (replacement_blocks, _) = event_handler.past_events_by_block_hashes(&blocks).await;
         assert_eq!(replacement_blocks, blocks[..2]);
@@ -743,6 +789,7 @@ mod tests {
             GPv2SettlementContract(contract),
             storage,
             Some(block),
+            OnEventDecodingError::Error,
         );
         let _result = event_handler.update_events().await;
         // add logs to event handler and observe

--- a/crates/shared/src/sources/balancer_v2/pool_fetching.rs
+++ b/crates/shared/src/sources/balancer_v2/pool_fetching.rs
@@ -24,6 +24,7 @@ use super::{
 use crate::{
     current_block::{BlockRetrieving, CurrentBlockStream},
     ethrpc::{Web3, Web3Transport},
+    event_handling::OnEventDecodingError,
     maintenance::Maintaining,
     recent_block_cache::{Block, CacheConfig},
     token_info::TokenInfoFetching,
@@ -404,6 +405,7 @@ where
         factory_instance,
         initial_pools,
         start_sync_at_block,
+        OnEventDecodingError::Error,
     )))
 }
 

--- a/crates/shared/src/sources/balancer_v2/pool_fetching/registry.rs
+++ b/crates/shared/src/sources/balancer_v2/pool_fetching/registry.rs
@@ -6,7 +6,7 @@ use crate::{
     current_block::{BlockNumberHash, BlockRetrieving},
     ethcontract_error::EthcontractErrorType,
     ethrpc::{Web3, Web3CallBatch, Web3Transport, MAX_BATCH_SIZE},
-    event_handling::EventHandler,
+    event_handling::{EventHandler, OnEventDecodingError},
     impl_event_retrieving,
     maintenance::Maintaining,
     recent_block_cache::Block,
@@ -52,6 +52,7 @@ where
         factory_instance: &Instance<Web3Transport>,
         initial_pools: Vec<Factory::PoolInfo>,
         start_sync_at_block: Option<BlockNumberHash>,
+        on_event_decoding_error: OnEventDecodingError,
     ) -> Self {
         let web3 = factory_instance.web3();
         let updater = Mutex::new(EventHandler::new(
@@ -59,6 +60,7 @@ where
             BasePoolFactoryContract(base_pool_factory(factory_instance)),
             PoolStorage::new(initial_pools, fetcher.clone()),
             start_sync_at_block,
+            on_event_decoding_error,
         ));
         Self {
             web3,

--- a/crates/shared/src/sources/uniswap_v3/pool_fetching.rs
+++ b/crates/shared/src/sources/uniswap_v3/pool_fetching.rs
@@ -5,7 +5,7 @@ use super::{
 use crate::{
     current_block::{BlockRetrieving, RangeInclusive},
     ethrpc::Web3,
-    event_handling::{EventHandler, EventStoring, MAX_REORG_BLOCK_COUNT},
+    event_handling::{EventHandler, EventStoring, OnEventDecodingError, MAX_REORG_BLOCK_COUNT},
     maintenance::Maintaining,
     recent_block_cache::Block,
 };
@@ -265,6 +265,7 @@ impl UniswapV3PoolFetcher {
             UniswapV3PoolEventFetcher(web3),
             RecentEventsCache::default(),
             Some(init_block),
+            OnEventDecodingError::Error,
         ));
 
         Ok(Self { checkpoint, events })


### PR DESCRIPTION
### Context

We pick up orders from the eth-flow contract by interpreting it as an instance of a generic wrapper contract `CoWSwapOnchainOrders`. This generic contracts defines events that should be interpreted as the creation of valid orders, directly from the blockchain.
However, the eth-flow contract can also emit other events that are not part of the `CoWSwapOnchainOrders` interface (namely order refunds). In the current implementation, our `CoWSwapOnchainOrders` contract instance (representing the contract at the eth-flow address) tries to interpret these events as an event that belongs to `CoWSwapOnchainOrders` itself and, when failing, returns an error that stalls the process of picking up events from the blockchain.

### This PR

We try to solve this issue by ignoring related errors on demand. This behavior must be opted in explicitly by the event handler instance and only applies to errors that are triggered by a failed ABI decoding of the error.  

### Requirements before merging

This PR requires changes to ethcontracts as otherwise we would copy over a lot of code from there. The reason for this is that one of the needed functions that decodes contract events squashes all errors together and returns `Result<Vec<Event>,_>` rather than the needed `Result<Vec<Event,_>>`.

I don't have access to the ethcontracts repo so I can't push a PR, but if given access I'll open one and release a new version once accepted. The changes would look like [this](https://github.com/fedgiac/ethcontract-rs/commit/17c9c8e61b840701c3ce0e90aefe4e33f726dceb) (but I expect to make small changes).

### Test Plan

A new e2e test is introduced to simulate the bad behavior.
