### PR TITLE
Fix Order Cancellation Serialization

### DIFF
--- a/crates/model/src/order.rs
+++ b/crates/model/src/order.rs
@@ -376,6 +376,7 @@ impl From<Order> for OrderCreation {
 
 /// Cancellation of multiple orders.
 #[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct OrderCancellations {
     pub order_uids: Vec<OrderUid>,
 }
@@ -403,6 +404,7 @@ impl OrderCancellations {
 
 /// Signed order cancellations.
 #[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct SignedOrderCancellations {
     #[serde(flatten)]
     pub data: OrderCancellations,


### PR DESCRIPTION
This PR trivially adds a `serde` rename directive to the `*OrderCancellations` types so that they match their OpenAPI specification (and are more consistent with other JSON schemas we use).

### Test Plan

<details><summary><code></code></summary>

```
{"orderUids":["0x1d0e87d99d20405c2bf39c074d8d72a9f946b15875473bacc2421fa8c62f23faa309cce4e2dfd48204da682b65e4af0c7203e41063948eb8"],"from":"0xA309Cce4E2Dfd48204Da682B65e4AF0C7203E410","signingScheme":"eip712","signature":"0x49ccee176bd1da9fdb732684ba8b504ea302c3e96379f94b5b4ecdf4900755986d2a2213fbf6d4d3c47d7e23d5a79cc852236cec5fe0afb888048a1f4fac18f21b"}
```

</details>

Before:
```
% cat cancellation.json | curl http://localhost:8080/api/v1/orders -X DELETE -H 'content-type: application/json' --data "@-"
Request body deserialize error: missing field `signing_scheme` at line 1 column 374
```

After:
```
% cat cancellation.json | curl http://localhost:8080/api/v1/orders -X DELETE -H 'content-type: application/json' --data "@-"
{"errorType":"OrderNotFound","description":"Order not located in database"}
```

Note that the error makes sense as this order doesn't exist in my local deployment.