### PR TITLE
Searchers can provide preferred submission strategy

### DIFF
--- a/crates/driver/src/settlement_proposal.rs
+++ b/crates/driver/src/settlement_proposal.rs
@@ -186,6 +186,7 @@ impl SettlementProposal {
     pub async fn into_settlement(self) -> Result<Settlement> {
         Ok(Settlement {
             encoder: self.into_encoder().await?,
+            ..Default::default()
         })
     }
 

--- a/crates/shared/src/http_solver/model.rs
+++ b/crates/shared/src/http_solver/model.rs
@@ -185,6 +185,8 @@ pub struct SettledBatchAuctionModel {
     pub approvals: Vec<ApprovalModel>,
     #[serde(default)]
     pub interaction_data: Vec<InteractionData>,
+    #[serde(default)]
+    pub submitter: SubmissionPreference,
     pub metadata: Option<SettledBatchAuctionMetadataModel>,
 }
 
@@ -390,6 +392,14 @@ pub enum InternalizationStrategy {
     EncodeAllInteractions,
     #[serde(rename = "Enabled")]
     SkipInternalizableInteraction,
+}
+
+/// Searchers can override submission strategy of the protocol
+#[derive(Debug, Clone, Default, Deserialize, PartialEq, Eq, Serialize)]
+pub enum SubmissionPreference {
+    #[default]
+    ProtocolDefault,
+    Flashbots,
 }
 
 #[cfg(test)]
@@ -798,6 +808,25 @@ mod tests {
             }
         "#;
         assert!(serde_json::from_str::<SettledBatchAuctionModel>(x).is_ok());
+    }
+
+    #[test]
+    fn decode_submitter_flashbots() {
+        let solution = r#"
+            {
+                "tokens": {},
+                "orders": {},
+                "metadata": {
+                    "environment": null
+                },
+                "ref_token": null,
+                "prices": {},
+                "uniswaps": {},
+                "submitter": "Flashbots"
+            }
+        "#;
+        let deserialized = serde_json::from_str::<SettledBatchAuctionModel>(solution).unwrap();
+        assert_eq!(deserialized.submitter, SubmissionPreference::Flashbots);
     }
 
     #[test]

--- a/crates/shared/src/http_solver/model.rs
+++ b/crates/shared/src/http_solver/model.rs
@@ -400,6 +400,7 @@ pub enum SubmissionPreference {
     #[default]
     ProtocolDefault,
     Flashbots,
+    PublicMempool,
 }
 
 #[cfg(test)]

--- a/crates/solver/src/in_flight_orders.rs
+++ b/crates/solver/src/in_flight_orders.rs
@@ -181,6 +181,7 @@ mod tests {
         let prices = hashmap! {token0 => 1u8.into(), token1 => 1u8.into()};
         let settlement = Settlement {
             encoder: SettlementEncoder::with_trades(prices, trades),
+            ..Default::default()
         };
 
         let mut inflight = InFlightOrders::default();

--- a/crates/solver/src/settlement.rs
+++ b/crates/solver/src/settlement.rs
@@ -12,7 +12,10 @@ use itertools::Itertools;
 use model::order::{Order, OrderKind};
 use num::{rational::Ratio, BigInt, BigRational, One, Signed, Zero};
 use primitive_types::{H160, U256};
-use shared::{conversions::U256Ext as _, http_solver::model::InternalizationStrategy};
+use shared::{
+    conversions::U256Ext as _,
+    http_solver::model::{InternalizationStrategy, SubmissionPreference},
+};
 use std::{
     collections::{HashMap, HashSet},
     ops::{Mul, Sub},
@@ -215,6 +218,7 @@ impl Interaction for NoopInteraction {
 #[derive(Debug, Clone, Default)]
 pub struct Settlement {
     pub encoder: SettlementEncoder,
+    pub submitter: SubmissionPreference,
 }
 
 #[derive(Debug, Eq, PartialEq)]
@@ -243,6 +247,7 @@ impl Settlement {
     pub fn new(clearing_prices: HashMap<H160, U256>) -> Self {
         Self {
             encoder: SettlementEncoder::new(clearing_prices),
+            ..Default::default()
         }
     }
 
@@ -258,13 +263,19 @@ impl Settlement {
 
     pub fn without_onchain_liquidity(&self) -> Self {
         let encoder = self.encoder.without_onchain_liquidity();
-        Self { encoder }
+        Self {
+            encoder,
+            submitter: self.submitter.clone(),
+        }
     }
 
     #[cfg(test)]
     pub fn with_trades(clearing_prices: HashMap<H160, U256>, trades: Vec<Trade>) -> Self {
         let encoder = SettlementEncoder::with_trades(clearing_prices, trades);
-        Self { encoder }
+        Self {
+            encoder,
+            ..Default::default()
+        }
     }
 
     #[cfg(test)]
@@ -275,7 +286,10 @@ impl Settlement {
             .map(|token| (token, U256::from(1_000_000_000_000_000_000_u128)))
             .collect();
         let encoder = SettlementEncoder::with_trades(clearing_prices, trades);
-        Self { encoder }
+        Self {
+            encoder,
+            ..Default::default()
+        }
     }
 
     /// Returns the clearing prices map.
@@ -420,7 +434,10 @@ impl Settlement {
     /// See SettlementEncoder::merge
     pub fn merge(self, other: Self) -> Result<Self> {
         let merged = self.encoder.merge(other.encoder)?;
-        Ok(Self { encoder: merged })
+        Ok(Self {
+            encoder: merged,
+            submitter: self.submitter,
+        })
     }
 
     // Calculates the risk level for settlement to be reverted
@@ -545,6 +562,7 @@ pub mod tests {
     fn test_settlement(prices: HashMap<H160, U256>, trades: Vec<Trade>) -> Settlement {
         Settlement {
             encoder: SettlementEncoder::with_trades(prices, trades),
+            ..Default::default()
         }
     }
 

--- a/crates/solver/src/settlement.rs
+++ b/crates/solver/src/settlement.rs
@@ -7,7 +7,7 @@ use crate::{
     encoding::{self, EncodedSettlement, EncodedTrade},
     liquidity::Settleable,
 };
-use anyhow::Result;
+use anyhow::{ensure, Result};
 use itertools::Itertools;
 use model::order::{Order, OrderKind};
 use num::{rational::Ratio, BigInt, BigRational, One, Signed, Zero};
@@ -433,6 +433,7 @@ impl Settlement {
 
     /// See SettlementEncoder::merge
     pub fn merge(self, other: Self) -> Result<Self> {
+        ensure!(self.submitter == other.submitter, "different submitters");
         let merged = self.encoder.merge(other.encoder)?;
         Ok(Self {
             encoder: merged,

--- a/crates/solver/src/settlement_submission.rs
+++ b/crates/solver/src/settlement_submission.rs
@@ -186,7 +186,18 @@ impl SolutionSubmitter {
                     .position(|strategy| matches!(strategy, TransactionStrategy::Flashbots(_)));
                 match position {
                     Some(index) => &self.transaction_strategies[index..index + 1],
-                    // if flasbots are disabled by protocol, default to protocol strategies
+                    // if flashbots are disabled by protocol, default to protocol strategies
+                    None => self.transaction_strategies.as_slice(),
+                }
+            }
+            SubmissionPreference::PublicMempool => {
+                let position = self
+                    .transaction_strategies
+                    .iter()
+                    .position(|strategy| matches!(strategy, TransactionStrategy::PublicMempool(_)));
+                match position {
+                    Some(index) => &self.transaction_strategies[index..index + 1],
+                    // if public mempool is disabled by protocol, default to protocol strategies
                     None => self.transaction_strategies.as_slice(),
                 }
             }

--- a/crates/solver/src/settlement_submission.rs
+++ b/crates/solver/src/settlement_submission.rs
@@ -15,7 +15,7 @@ use ethcontract::{
 use futures::FutureExt;
 use gas_estimation::{GasPrice1559, GasPriceEstimating};
 use primitive_types::{H256, U256};
-use shared::{code_fetching::CodeFetching, ethrpc::Web3};
+use shared::{code_fetching::CodeFetching, ethrpc::Web3, http_solver::model::SubmissionPreference};
 use std::{
     collections::HashMap,
     sync::{Arc, Mutex},
@@ -176,9 +176,24 @@ impl SolutionSubmitter {
             }
         }
 
+        // combine protocol enabled strategies with settlement prefered strategies
+        let strategies = match settlement.submitter {
+            SubmissionPreference::ProtocolDefault => self.transaction_strategies.as_slice(),
+            SubmissionPreference::Flashbots => {
+                let position = self
+                    .transaction_strategies
+                    .iter()
+                    .position(|strategy| matches!(strategy, TransactionStrategy::Flashbots(_)));
+                match position {
+                    Some(index) => &self.transaction_strategies[index..index + 1],
+                    // if flasbots are disabled by protocol, default to protocol strategies
+                    None => self.transaction_strategies.as_slice(),
+                }
+            }
+        };
+
         let network_id = self.web3.net().version().await?;
-        let mut futures = self
-            .transaction_strategies
+        let mut futures = strategies
             .iter()
             .enumerate()
             .map(|(i, strategy)| {

--- a/crates/solver/src/solver/http_solver/settlement.rs
+++ b/crates/solver/src/solver/http_solver/settlement.rs
@@ -119,6 +119,7 @@ struct IntermediateSettlement<'a> {
     executions: Vec<Execution>, // executions are sorted by execution coordinate.
     prices: HashMap<H160, U256>,
     slippage: SlippageContext<'a>,
+    submitter: SubmissionPreference,
 }
 
 #[derive(Clone, Debug)]
@@ -173,17 +174,20 @@ impl<'a> IntermediateSettlement<'a> {
             settled.interaction_data,
             [executed_limit_orders, foreign_liquidity_orders].concat(),
         );
+        let submitter = settled.submitter;
 
         Ok(Self {
             executions,
             prices,
             approvals,
             slippage,
+            submitter,
         })
     }
 
     fn into_settlement(self) -> Result<Settlement> {
         let mut settlement = Settlement::new(self.prices);
+        settlement.submitter = self.submitter;
 
         // Make sure to always add approval interactions **before** any
         // interactions from the execution plan - the execution plan typically


### PR DESCRIPTION
Fixes https://github.com/cowprotocol/services/issues/812
The simplest possible solution.

Additionally, we can improve this by:
1. Sending protocol strategies to http searchers and matching them with strategies received back from searchers .
2. Give option to searchers to define Vec<Strategy> instead of single strategy.

The case where searchers send solution and want to submit with flashbots or nothing would be best solved with (1) IMO.
