### PR TITLE
Separate Configuration For Limit Order Update Interval

### DIFF
--- a/crates/autopilot/src/arguments.rs
+++ b/crates/autopilot/src/arguments.rs
@@ -107,6 +107,15 @@ pub struct Arguments {
     )]
     pub max_surplus_fee_age: Duration,
 
+    /// The interval between successive limit order surplus fee updating loops in seconds.
+    #[clap(
+        long,
+        env,
+        default_value = "60",
+        value_parser = shared::arguments::duration_from_seconds,
+    )]
+    pub surplus_fee_update_interval: Duration,
+
     #[clap(long, env)]
     pub cip_14_beta: Option<f64>,
     #[clap(long, env)]
@@ -163,12 +172,23 @@ impl std::fmt::Display for Arguments {
         )?;
         writeln!(f, "banned_users: {:?}", self.banned_users)?;
         writeln!(f, "max_auction_age: {:?}", self.max_auction_age)?;
+        writeln!(f, "max_surplus_fee_age: {:?}", self.max_surplus_fee_age)?;
+        writeln!(
+            f,
+            "surplus_fee_update_interval: {:?}",
+            self.surplus_fee_update_interval
+        )?;
         display_option(f, "cip_14_beta", &self.cip_14_beta)?;
         display_option(f, "cip_14_alpha1", &self.cip_14_alpha1)?;
         display_option(f, "cip_14_alpha2", &self.cip_14_alpha2)?;
         display_option(f, "cip_14_profit", &self.cip_14_profit)?;
         display_option(f, "cip_14_gas_cap", &self.cip_14_gas_cap)?;
         display_option(f, "cip_14_reward_cap", &self.cip_14_reward_cap)?;
+        writeln!(
+            f,
+            "limit_order_price_factor: {:?}",
+            self.limit_order_price_factor
+        )?;
         writeln!(f, "enable_limit_orders: {:?}", self.enable_limit_orders)?;
         Ok(())
     }

--- a/crates/autopilot/src/lib.rs
+++ b/crates/autopilot/src/lib.rs
@@ -537,7 +537,7 @@ pub async fn main(args: arguments::Arguments) -> ! {
         let limit_order_age = chrono::Duration::from_std(args.max_surplus_fee_age).unwrap();
         LimitOrderQuoter {
             limit_order_age,
-            loop_delay: args.max_surplus_fee_age / 2,
+            loop_delay: args.surplus_fee_update_interval,
             quoter,
             database: db.clone(),
             signature_validator,


### PR DESCRIPTION
This PR adds a new `--surplus-fee-update-interval` flag.

Currently the surplus fee update interval is determined by the surplus fee expiry configuration, but it makes sense to have this be configured by a separate knob. Specifically, we may want to update more often in order to have limit orders get included in the auction sooner, without needing to make the limit order surplus fee expiry shorter.

The default value is set to 60s, so 30s shorter than the current default configuration.

### Test Plan

Run the autopilot and see that the the configuration option is set:
```
% cargo run -p autopilot
...
surplus_fee_update_interval: 60s
...
```
