### PR TITLE
Do not block onchain order parsing on unknown events

### DIFF
--- a/crates/autopilot/src/database/onchain_order_events.rs
+++ b/crates/autopilot/src/database/onchain_order_events.rs
@@ -1,4 +1,5 @@
 pub mod ethflow_events;
+pub mod event_retriever;
 
 use super::{
     events::{bytes_to_order_uid, meta_to_event_index},

--- a/crates/autopilot/src/database/onchain_order_events/event_retriever.rs
+++ b/crates/autopilot/src/database/onchain_order_events/event_retriever.rs
@@ -1,0 +1,45 @@
+use contracts::cowswap_onchain_orders;
+use ethcontract::{contract::AllEventsBuilder, transport::DynTransport, H160, H256};
+use hex_literal::hex;
+use shared::{ethrpc::Web3, event_handling::EventRetrieving};
+
+const ORDER_PLACEMENT_TOPIC: H256 = H256(hex!(
+    "cf5f9de2984132265203b5c335b25727702ca77262ff622e136baa7362bf1da9"
+));
+const ORDER_INVALIDATION_TOPIC: H256 = H256(hex!(
+    "b8bad102ac8bbacfef31ff1c906ec6d951c230b4dce750bb0376b812ad35852a"
+));
+static ALL_VALID_ONCHAIN_ORDER_TOPICS: [H256; 2] =
+    [ORDER_PLACEMENT_TOPIC, ORDER_INVALIDATION_TOPIC];
+
+// Note: we use a custom implementation of `EventRetrieving` rather than using the one that is
+// automatically derivable from the onchain-order contract. This is because the Rust implementation
+// of the onchain-order contract assumes that only events that appear in the ABI can be emitted.
+// In this custom implementation, we ignore all events except for those specified by the above
+// hardcoded topics (which should correspond to the topics of all avents in the onchain-order
+// contract ABI).
+pub struct CoWSwapOnchainOrdersContract {
+    web3: Web3,
+    address: H160,
+}
+
+impl CoWSwapOnchainOrdersContract {
+    pub fn new(web3: Web3, address: H160) -> Self {
+        Self { web3, address }
+    }
+}
+
+impl EventRetrieving for CoWSwapOnchainOrdersContract {
+    type Event = cowswap_onchain_orders::Event;
+
+    fn get_events(&self) -> AllEventsBuilder<DynTransport, Self::Event> {
+        let mut events = AllEventsBuilder::new(self.web3.clone(), self.address, None);
+        // Filter out events that don't belong to the ABI of `OnchainOrdersContract`. This is done
+        // because there could be other unrelated events fired by the contract which should be
+        // ignored. Also, it makes the request more efficient, since it needs to return less events.
+        events.filter = events
+            .filter
+            .topic0(ALL_VALID_ONCHAIN_ORDER_TOPICS.to_vec().into());
+        events
+    }
+}

--- a/crates/autopilot/src/event_updater.rs
+++ b/crates/autopilot/src/event_updater.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use contracts::{cowswap_onchain_orders, gpv2_settlement};
+use contracts::gpv2_settlement;
 use shared::{
     current_block::{BlockNumberHash, BlockRetrieving},
     event_handling::{EventHandler, EventRetrieving, EventStoring},
@@ -16,10 +16,6 @@ pub struct EventUpdater<
 
 impl_event_retrieving! {
     pub GPv2SettlementContract for gpv2_settlement
-}
-
-impl_event_retrieving! {
-    pub CoWSwapOnchainOrdersContract for cowswap_onchain_orders
 }
 
 impl<Database, W> EventUpdater<Database, W>

--- a/crates/e2e/tests/e2e/local_node.rs
+++ b/crates/e2e/tests/e2e/local_node.rs
@@ -1,5 +1,5 @@
 use chrono::{DateTime, Utc};
-use ethcontract::{futures::FutureExt, Account, Address, U256};
+use ethcontract::{futures::FutureExt, Account, Address, BlockNumber, U256};
 use lazy_static::lazy_static;
 use shared::ethrpc::{create_test_transport, Web3};
 use std::{
@@ -173,4 +173,14 @@ impl AccountAssigner {
     pub fn assign_free_account(&mut self) -> Account {
         self.free_accounts.pop().expect("No testing accounts available, consider increasing the number of testing account in the test node")
     }
+}
+
+pub async fn blockchain_time(web3: &Web3) -> u32 {
+    web3.eth()
+        .block(BlockNumber::Latest.into())
+        .await
+        .expect("Unable to query block from node")
+        .expect("Block should exist")
+        .timestamp
+        .as_u32()
 }

--- a/crates/e2e/tests/e2e/refunder.rs
+++ b/crates/e2e/tests/e2e/refunder.rs
@@ -1,13 +1,13 @@
 use crate::{
     eth_flow::{EthFlowOrderOnchainStatus, ExtendedEthFlowOrder},
-    local_node::{AccountAssigner, TestNodeApi},
+    local_node::{blockchain_time, AccountAssigner, TestNodeApi},
     onchain_components::{
         deploy_token_with_weth_uniswap_pool, to_wei, MintableToken, WethPoolConfig,
     },
     services::{OrderbookServices, API_HOST},
 };
 use chrono::{DateTime, NaiveDateTime, Utc};
-use ethcontract::{BlockNumber, H160, U256};
+use ethcontract::{H160, U256};
 use model::quote::{
     OrderQuoteRequest, OrderQuoteResponse, OrderQuoteSide, QuoteSigningScheme, Validity,
 };
@@ -129,14 +129,4 @@ async fn refunder_tx(web3: Web3) {
         ethflow_order.status(&contracts).await,
         EthFlowOrderOnchainStatus::Invalidated
     );
-}
-
-async fn blockchain_time(web3: &Web3) -> u32 {
-    web3.eth()
-        .block(BlockNumber::Latest.into())
-        .await
-        .expect("Unable to query block from node")
-        .expect("Block should exist")
-        .timestamp
-        .as_u32()
 }

--- a/crates/e2e/tests/e2e/services.rs
+++ b/crates/e2e/tests/e2e/services.rs
@@ -3,13 +3,14 @@ use anyhow::{anyhow, Result};
 use async_trait::async_trait;
 use autopilot::{
     database::onchain_order_events::{
-        ethflow_events::EthFlowOnchainOrderParser, OnchainOrderParser,
+        ethflow_events::EthFlowOnchainOrderParser, event_retriever::CoWSwapOnchainOrdersContract,
+        OnchainOrderParser,
     },
-    event_updater::{CoWSwapOnchainOrdersContract, GPv2SettlementContract},
+    event_updater::GPv2SettlementContract,
     limit_orders::LimitOrderQuoter,
     solvable_orders::SolvableOrdersCache,
 };
-use contracts::{CoWSwapOnchainOrders, IUniswapLikeRouter, WETH9};
+use contracts::{IUniswapLikeRouter, WETH9};
 use database::quotes::QuoteId;
 use ethcontract::{Account, H160, U256};
 use model::{quote::QuoteSigningScheme, DomainSeparator};
@@ -212,10 +213,8 @@ impl OrderbookServices {
             contracts.gp_settlement.address(),
             HashSet::new(),
         );
-        let cow_onchain_order_contract =
-            CoWSwapOnchainOrders::at(web3, contracts.ethflow.address());
         let ethflow_event_updater = Arc::new(autopilot::event_updater::EventUpdater::new(
-            CoWSwapOnchainOrdersContract::new(cow_onchain_order_contract),
+            CoWSwapOnchainOrdersContract::new(web3.clone(), contracts.ethflow.address()),
             onchain_order_event_parser,
             block_retriever,
             None,


### PR DESCRIPTION
(A rehashing of #934, if you are familiar with it just read the section **This PR** and keep in mind that the e2e test is copied from there.)

### Context

We pick up orders from the eth-flow contract by interpreting it as an instance of a generic wrapper contract `CoWSwapOnchainOrders`. This generic contracts defines events that should be interpreted as the creation of valid orders, directly from the blockchain.
However, the eth-flow contract can also emit other events that are not part of the `CoWSwapOnchainOrders` interface (namely order refunds). In the current implementation, our `CoWSwapOnchainOrders` contract instance (representing the contract at the eth-flow address) tries to interpret these events as an event that belongs to `CoWSwapOnchainOrders` itself and, when failing, returns an error that stalls the process of picking up events from the blockchain.

### This PR

Instead of deriving an event reader directly from the contract, we build a custom implementation that filters out events that aren't part of the contract ABI. This makes for a more localized and efficient implementation of #934.

(It looks different but it's somewhat the same as what suggested by Nick [here](https://github.com/cowprotocol/services/pull/934#issuecomment-1344306685).)

### Test Plan

A new e2e test is introduced to simulate the bad behavior.
