### PR TITLE
[Refunder] Ignore uids with zero owner for refunding

### DIFF
--- a/crates/refunder/src/refund_service.rs
+++ b/crates/refunder/src/refund_service.rs
@@ -175,9 +175,6 @@ impl RefundService {
                 invalid_uids
             );
         }
-        // Invalid uids will also be marked as refunded, as otherwise, the service will revisit
-        // these invalid uids every loop.
-        refunded_uids.append(&mut invalid_uids);
         let result = SplittedOrderUids {
             refunded: refunded_uids,
             to_be_refunded: to_be_refunded_uids,

--- a/crates/refunder/src/refund_service.rs
+++ b/crates/refunder/src/refund_service.rs
@@ -29,6 +29,13 @@ pub struct RefundService {
     pub submitter: Submitter,
 }
 
+#[derive(Debug, Eq, PartialEq)]
+enum RefundStatus {
+    Refunded,
+    NotYetRefunded,
+    Invalid,
+}
+
 struct SplittedOrderUids {
     refunded: Vec<OrderUid>,
     to_be_refunded: Vec<OrderUid>,
@@ -63,7 +70,7 @@ impl RefundService {
         let refundable_order_uids = self.get_refundable_ethflow_orders_from_db().await?;
 
         let order_uids_per_status = self
-            .identify_already_refunded_order_uids_via_web3_calls(refundable_order_uids)
+            .identify_uids_refunding_status_via_web3_calls(refundable_order_uids)
             .await?;
 
         self.update_already_refunded_orders_in_db(order_uids_per_status.refunded)
@@ -108,7 +115,7 @@ impl RefundService {
         })
     }
 
-    async fn identify_already_refunded_order_uids_via_web3_calls(
+    async fn identify_uids_refunding_status_via_web3_calls(
         &self,
         refundable_order_uids: Vec<EthOrderPlacement>,
     ) -> Result<SplittedOrderUids> {
@@ -136,25 +143,42 @@ impl RefundService {
                             return None;
                         }
                     };
-                    let is_refunded: bool = order_owner == Some(INVALIDATED_OWNER);
-                    Some((eth_order_placement.uid, is_refunded))
+                    let refund_status = match order_owner {
+                        Some(bytes) if bytes == INVALIDATED_OWNER => RefundStatus::Refunded,
+                        Some(bytes) if bytes == H160::zero() => RefundStatus::Invalid,
+                        // any other owner
+                        _ => RefundStatus::NotYetRefunded,
+                    };
+                    Some((eth_order_placement.uid, refund_status))
                 }
             })
             .collect::<Vec<_>>();
 
         batch.execute_all(MAX_BATCH_SIZE).await;
         let uid_with_latest_refundablility = futures::future::join_all(futures).await;
-        type TupleWithRefundStatus = (Vec<(OrderUid, bool)>, Vec<(OrderUid, bool)>);
-        let (refunded_uids, to_be_refunded_uids): TupleWithRefundStatus =
+        type TupleWithRefundStatus = (Vec<(OrderUid, RefundStatus)>, Vec<(OrderUid, RefundStatus)>);
+        let (refunded_uids, uid_with_latest_refundablility): TupleWithRefundStatus =
             uid_with_latest_refundablility
                 .into_iter()
                 .flatten()
-                .partition(|(_, is_refunded)| *is_refunded);
+                .partition(|(_, refund_status)| *refund_status == RefundStatus::Refunded);
+        let (to_be_refunded_uids, invalid_uids): TupleWithRefundStatus =
+            uid_with_latest_refundablility
+                .into_iter()
+                .partition(|(_, refund_status)| *refund_status == RefundStatus::NotYetRefunded);
         let refunded_uids: Vec<OrderUid> = refunded_uids.into_iter().map(|(uid, _)| uid).collect();
         let to_be_refunded_uids: Vec<OrderUid> = to_be_refunded_uids
             .into_iter()
             .map(|(uid, _)| uid)
             .collect();
+        if !invalid_uids.is_empty() {
+            // In exceptional cases, e.g. if the refunder tries to refund orders from a previous contract,
+            // the order_owners could be zero
+            tracing::warn!(
+                "following Uids have a invalid owner (=0x0..0) stored onchain: {:?}",
+                invalid_uids
+            );
+        }
         let result = SplittedOrderUids {
             refunded: refunded_uids,
             to_be_refunded: to_be_refunded_uids,

--- a/crates/refunder/src/refund_service.rs
+++ b/crates/refunder/src/refund_service.rs
@@ -175,7 +175,7 @@ impl RefundService {
             // In exceptional cases, e.g. if the refunder tries to refund orders from a previous contract,
             // the order_owners could be zero
             tracing::warn!(
-                "following Uids have a invalid owner (=0x0..0) stored onchain: {:?}",
+                "Following ethflow uids have a invalid owner (=0x0..0) stored onchain: {:?}",
                 invalid_uids
             );
         }


### PR DESCRIPTION
The refunder checks the owner of a Uid in the earthflow contract. Normally, this owner is a non-zero value, as the 0 address can not place orders, and invalided orders have a non-zero uid.

But since we migrated the contracts, and the refunder tried to refund non-existing orders, this owner field has become zero for some orders. Hence, I decided to filter these cases out and throw a warning. 

(But this still is no perfect solution for contract migrations)

### Test Plan
