### PR TITLE
Allow multiple `Interaction`s per `Trade`

### DIFF
--- a/crates/shared/src/price_estimation/trade_finder.rs
+++ b/crates/shared/src/price_estimation/trade_finder.rs
@@ -425,11 +425,11 @@ mod tests {
             out_amount: 2_000_000_u128.into(),
             gas_estimate: 133_700,
             approval: None,
-            interaction: Interaction {
+            interactions: vec![Interaction {
                 target: H160([0x7; 20]),
                 value: 0_u64.into(),
                 data: vec![1, 2, 3, 4],
-            },
+            }],
         };
         let sell_token_code = bytes!("05060708");
 
@@ -564,6 +564,7 @@ mod tests {
         };
         let trade = Trade {
             out_amount: 1_000_000_u128.into(),
+            interactions: vec![Default::default()],
             ..Default::default()
         };
 

--- a/crates/shared/src/price_estimation/trade_finder.rs
+++ b/crates/shared/src/price_estimation/trade_finder.rs
@@ -145,7 +145,7 @@ impl TradeVerifier {
             .settle(
                 vec![query.sell_token, query.buy_token],
                 vec![buy_amount, sell_amount],
-                trade.encode(),
+                trade.encode()?,
                 sell_amount,
             )
             .tx;

--- a/crates/shared/src/price_estimation/trade_finder.rs
+++ b/crates/shared/src/price_estimation/trade_finder.rs
@@ -714,6 +714,7 @@ mod tests {
         let trade = Trade {
             out_amount: 2_000_000_u128.into(),
             gas_estimate: 133_700,
+            interactions: vec![Default::default()],
             ..Default::default()
         };
 
@@ -763,6 +764,7 @@ mod tests {
         };
         let trade = Trade {
             out_amount: 203_u64.into(),
+            interactions: vec![Default::default()],
             ..Default::default()
         };
 

--- a/crates/shared/src/trade_finding.rs
+++ b/crates/shared/src/trade_finding.rs
@@ -34,7 +34,7 @@ pub struct Trade {
     pub out_amount: U256,
     pub gas_estimate: u64,
     pub approval: Option<(H160, H160)>,
-    pub interaction: Interaction,
+    pub interactions: Vec<Interaction>,
 }
 
 impl Trade {
@@ -53,7 +53,7 @@ impl Trade {
             }
             None => vec![],
         };
-        let intra_interactions = vec![self.interaction.encode()];
+        let intra_interactions = self.interactions.iter().map(|i| i.encode()).collect();
 
         [pre_interactions, intra_interactions, vec![]]
     }
@@ -133,11 +133,18 @@ mod tests {
             out_amount: Default::default(),
             gas_estimate: 0,
             approval: Some((H160([0xdd; 20]), H160([0xee; 20]))),
-            interaction: Interaction {
-                target: H160([0xaa; 20]),
-                value: 42.into(),
-                data: vec![1, 2, 3, 4],
-            },
+            interactions: vec![
+                Interaction {
+                    target: H160([0xaa; 20]),
+                    value: 42.into(),
+                    data: vec![1, 2, 3, 4],
+                },
+                Interaction {
+                    target: H160([0xbb; 20]),
+                    value: 43.into(),
+                    data: vec![5, 6, 7, 8],
+                },
+            ],
         };
 
         assert_eq!(
@@ -169,7 +176,10 @@ mod tests {
                         ),
                     )
                 ],
-                vec![(H160([0xaa; 20]), U256::from(42), Bytes(vec![1, 2, 3, 4]))],
+                vec![
+                    (H160([0xaa; 20]), U256::from(42), Bytes(vec![1, 2, 3, 4])),
+                    (H160([0xbb; 20]), U256::from(43), Bytes(vec![5, 6, 7, 8])),
+                ],
                 vec![],
             ]
         );

--- a/crates/shared/src/trade_finding/oneinch.rs
+++ b/crates/shared/src/trade_finding/oneinch.rs
@@ -91,11 +91,11 @@ impl OneInchTradeFinder {
             out_amount: quote.out_amount,
             gas_estimate: quote.gas_estimate,
             approval: Some((query.sell_token, spender)),
-            interaction: Interaction {
+            interactions: vec![Interaction {
                 target: swap.tx.to,
                 value: swap.tx.value,
                 data: swap.tx.data,
-            },
+            }],
         })
     }
 }
@@ -354,12 +354,12 @@ mod tests {
         assert_eq!(trade.out_amount, 808_069_760_400_778_577u128.into());
         assert!(trade.gas_estimate > 189_386);
         assert_eq!(
-            trade.interaction,
-            Interaction {
+            trade.interactions,
+            vec![Interaction {
                 target: addr!("1111111254fb6c44bac0bed2854e76f90643097d"),
                 value: Default::default(),
                 data: vec![0xe4, 0x49, 0x02, 0x2e],
-            }
+            }]
         );
     }
 

--- a/crates/shared/src/trade_finding/paraswap.rs
+++ b/crates/shared/src/trade_finding/paraswap.rs
@@ -132,11 +132,11 @@ impl Inner {
             out_amount: quote.data.out_amount,
             gas_estimate: quote.data.gas_estimate,
             approval: Some((query.sell_token, quote.price.token_transfer_proxy)),
-            interaction: Interaction {
+            interactions: vec![Interaction {
                 target: tx.to,
                 value: tx.value,
                 data: tx.data,
-            },
+            }],
         })
     }
 }

--- a/crates/shared/src/trade_finding/zeroex.rs
+++ b/crates/shared/src/trade_finding/zeroex.rs
@@ -68,11 +68,11 @@ impl Inner {
             },
             gas_estimate: gas::SETTLEMENT_OVERHEAD + swap.price.estimated_gas,
             approval: Some((query.sell_token, swap.price.allowance_target)),
-            interaction: Interaction {
+            interactions: vec![Interaction {
                 target: swap.to,
                 value: swap.value,
                 data: swap.data,
-            },
+            }],
         })
     }
 }
@@ -161,12 +161,12 @@ mod tests {
             Some((weth, addr!("def1c0ded9bec7f1a1670819833240f027b25eff"))),
         );
         assert_eq!(
-            trade.interaction,
-            Interaction {
+            trade.interactions,
+            vec![Interaction {
                 target: addr!("def1c0ded9bec7f1a1670819833240f027b25eff"),
                 value: 42.into(),
                 data: vec![1, 2, 3, 4],
-            }
+            }]
         );
     }
 
@@ -216,7 +216,8 @@ mod tests {
 
         assert_eq!(trade.out_amount, 8986186353137488u64.into());
         assert!(trade.gas_estimate > 111000);
-        assert_eq!(trade.interaction.data, [5, 6, 7, 8]);
+        assert_eq!(trade.interactions.len(), 1);
+        assert_eq!(trade.interactions[0].data, [5, 6, 7, 8]);
     }
 
     #[tokio::test]
@@ -261,6 +262,8 @@ mod tests {
         let gno = trade.out_amount.to_f64_lossy() / 1e18;
         println!("1.0 ETH buys {gno} GNO");
         println!("gas:  {}", trade.gas_estimate);
-        println!("data: 0x{}", hex::encode(&trade.interaction.data));
+        for interaction in trade.interactions {
+            println!("data: 0x{}", hex::encode(interaction.data));
+        }
     }
 }


### PR DESCRIPTION
Fixes #866 

Now we allow a `Trade` to include more than 1 `Interaction`. This is useful for solvers which might need more than one `Interaction` to settle a trade optimally for a `/quote` request.

To avoid unachievable quotes that settle with internal buffers of the contract we require at least 1 "main" interaction. However, this could easily be circumvented. The correct solution would be to solve that within the trade simulation logic itself.

### Test Plan
Updated existing unit test to cover encoding of multiple interactions.
