### PR TITLE
Handle base tokens in `LiquidityCollector`

### DIFF
--- a/crates/e2e/tests/e2e/limit_orders.rs
+++ b/crates/e2e/tests/e2e/limit_orders.rs
@@ -197,13 +197,13 @@ async fn single_limit_order_test(web3: Web3) {
     let uniswap_liquidity = UniswapLikeLiquidity::new(
         IUniswapLikeRouter::at(&web3, contracts.uniswap_router.address()),
         contracts.gp_settlement.clone(),
-        base_tokens,
         web3.clone(),
         Arc::new(PoolFetcher::uniswap(uniswap_pair_provider, web3.clone())),
     );
     let solver = solver::solver::naive_solver(solver_account);
     let liquidity_collector = LiquidityCollector {
         liquidity_sources: vec![Box::new(uniswap_liquidity)],
+        base_tokens,
     };
     let network_id = web3.net().version().await.unwrap();
     let submitted_transactions = GlobalTxPool::default();
@@ -448,13 +448,13 @@ async fn two_limit_orders_test(web3: Web3) {
     let uniswap_liquidity = UniswapLikeLiquidity::new(
         IUniswapLikeRouter::at(&web3, contracts.uniswap_router.address()),
         contracts.gp_settlement.clone(),
-        base_tokens,
         web3.clone(),
         Arc::new(PoolFetcher::uniswap(uniswap_pair_provider, web3.clone())),
     );
     let solver = solver::solver::naive_solver(solver_account);
     let liquidity_collector = LiquidityCollector {
         liquidity_sources: vec![Box::new(uniswap_liquidity)],
+        base_tokens,
     };
     let network_id = web3.net().version().await.unwrap();
     let submitted_transactions = GlobalTxPool::default();
@@ -701,13 +701,13 @@ async fn mixed_limit_and_market_orders_test(web3: Web3) {
     let uniswap_liquidity = UniswapLikeLiquidity::new(
         IUniswapLikeRouter::at(&web3, contracts.uniswap_router.address()),
         contracts.gp_settlement.clone(),
-        base_tokens,
         web3.clone(),
         Arc::new(PoolFetcher::uniswap(uniswap_pair_provider, web3.clone())),
     );
     let solver = solver::solver::naive_solver(solver_account);
     let liquidity_collector = LiquidityCollector {
         liquidity_sources: vec![Box::new(uniswap_liquidity)],
+        base_tokens,
     };
     let network_id = web3.net().version().await.unwrap();
     let submitted_transactions = GlobalTxPool::default();

--- a/crates/e2e/tests/e2e/onchain_settlement.rs
+++ b/crates/e2e/tests/e2e/onchain_settlement.rs
@@ -183,13 +183,13 @@ async fn onchain_settlement(web3: Web3) {
     let uniswap_liquidity = UniswapLikeLiquidity::new(
         IUniswapLikeRouter::at(&web3, contracts.uniswap_router.address()),
         contracts.gp_settlement.clone(),
-        base_tokens,
         web3.clone(),
         Arc::new(PoolFetcher::uniswap(uniswap_pair_provider, web3.clone())),
     );
     let solver = solver::solver::naive_solver(solver_account);
     let liquidity_collector = LiquidityCollector {
         liquidity_sources: vec![Box::new(uniswap_liquidity)],
+        base_tokens,
     };
     let network_id = web3.net().version().await.unwrap();
     let submitted_transactions = GlobalTxPool::default();

--- a/crates/e2e/tests/e2e/services.rs
+++ b/crates/e2e/tests/e2e/services.rs
@@ -263,13 +263,13 @@ pub async fn setup_naive_solver_uniswapv2_driver(
     let uniswap_liquidity = UniswapLikeLiquidity::new(
         IUniswapLikeRouter::at(web3, contracts.uniswap_router.address()),
         contracts.gp_settlement.clone(),
-        base_tokens,
         web3.clone(),
         Arc::new(PoolFetcher::uniswap(uniswap_pair_provider, web3.clone())),
     );
     let solver = solver::solver::naive_solver(solver_account);
     let liquidity_collector = LiquidityCollector {
         liquidity_sources: vec![Box::new(uniswap_liquidity)],
+        base_tokens,
     };
     let network_id = web3.net().version().await.unwrap();
     let submitted_transactions = GlobalTxPool::default();

--- a/crates/e2e/tests/e2e/settlement_without_onchain_liquidity.rs
+++ b/crates/e2e/tests/e2e/settlement_without_onchain_liquidity.rs
@@ -167,13 +167,13 @@ async fn onchain_settlement_without_liquidity(web3: Web3) {
     let uniswap_liquidity = UniswapLikeLiquidity::new(
         IUniswapLikeRouter::at(&web3, contracts.uniswap_router.address()),
         contracts.gp_settlement.clone(),
-        base_tokens,
         web3.clone(),
         Arc::new(PoolFetcher::uniswap(uniswap_pair_provider, web3.clone())),
     );
 
     let liquidity_collector = LiquidityCollector {
         liquidity_sources: vec![Box::new(uniswap_liquidity)],
+        base_tokens,
     };
     let network_id = web3.net().version().await.unwrap();
     let market_makable_token_list = AutoUpdatingTokenList::new(maplit::hashmap! {

--- a/crates/e2e/tests/e2e/smart_contract_orders.rs
+++ b/crates/e2e/tests/e2e/smart_contract_orders.rs
@@ -203,13 +203,13 @@ async fn smart_contract_orders(web3: Web3) {
     let uniswap_liquidity = UniswapLikeLiquidity::new(
         IUniswapLikeRouter::at(&web3, contracts.uniswap_router.address()),
         contracts.gp_settlement.clone(),
-        base_tokens,
         web3.clone(),
         Arc::new(PoolFetcher::uniswap(uniswap_pair_provider, web3.clone())),
     );
     let solver = solver::solver::naive_solver(solver_account);
     let liquidity_collector = LiquidityCollector {
         liquidity_sources: vec![Box::new(uniswap_liquidity)],
+        base_tokens,
     };
     let network_id = web3.net().version().await.unwrap();
     let submitted_transactions = GlobalTxPool::default();

--- a/crates/e2e/tests/e2e/vault_balances.rs
+++ b/crates/e2e/tests/e2e/vault_balances.rs
@@ -116,13 +116,13 @@ async fn vault_balances(web3: Web3) {
     let uniswap_liquidity = UniswapLikeLiquidity::new(
         IUniswapLikeRouter::at(&web3, contracts.uniswap_router.address()),
         contracts.gp_settlement.clone(),
-        base_tokens,
         web3.clone(),
         Arc::new(PoolFetcher::uniswap(uniswap_pair_provider, web3.clone())),
     );
     let solver = solver::solver::naive_solver(solver_account);
     let liquidity_collector = LiquidityCollector {
         liquidity_sources: vec![Box::new(uniswap_liquidity)],
+        base_tokens,
     };
     let network_id = web3.net().version().await.unwrap();
     let submitted_transactions = GlobalTxPool::default();

--- a/crates/solver/src/driver.rs
+++ b/crates/solver/src/driver.rs
@@ -39,6 +39,7 @@ use shared::{
     tenderly_api::TenderlyApi,
 };
 use std::{
+    collections::HashSet,
     sync::Arc,
     time::{Duration, Instant},
 };
@@ -283,14 +284,14 @@ impl Driver {
             .bump(MAX_BASE_GAS_FEE_INCREASE);
         tracing::debug!("solving with gas price of {:?}", gas_price);
 
-        let pairs: Vec<_> = orders
+        let pairs: HashSet<_> = orders
             .iter()
             .filter(|o| !o.is_liquidity_order())
             .flat_map(|o| TokenPair::new(o.buy_token, o.sell_token))
             .collect();
         let liquidity = self
             .liquidity_collector
-            .get_liquidity(&pairs, Block::Number(current_block_during_liquidity_fetch))
+            .get_liquidity(pairs, Block::Number(current_block_during_liquidity_fetch))
             .await?;
         self.metrics.liquidity_fetched(&liquidity);
 

--- a/crates/solver/src/liquidity/balancer_v2.rs
+++ b/crates/solver/src/liquidity/balancer_v2.rs
@@ -16,10 +16,10 @@ use contracts::{BalancerV2Vault, GPv2Settlement};
 use ethcontract::H256;
 use model::TokenPair;
 use shared::{
-    baseline_solver::BaseTokens, ethrpc::Web3, recent_block_cache::Block,
+    ethrpc::Web3, recent_block_cache::Block,
     sources::balancer_v2::pool_fetching::BalancerPoolFetching,
 };
-use std::sync::Arc;
+use std::{collections::HashSet, sync::Arc};
 
 /// A liquidity provider for Balancer V2 weighted pools.
 pub struct BalancerV2Liquidity {
@@ -27,14 +27,12 @@ pub struct BalancerV2Liquidity {
     vault: BalancerV2Vault,
     pool_fetcher: Arc<dyn BalancerPoolFetching>,
     allowance_manager: Box<dyn AllowanceManaging>,
-    base_tokens: Arc<BaseTokens>,
 }
 
 impl BalancerV2Liquidity {
     pub fn new(
         web3: Web3,
         pool_fetcher: Arc<dyn BalancerPoolFetching>,
-        base_tokens: Arc<BaseTokens>,
         settlement: GPv2Settlement,
         vault: BalancerV2Vault,
     ) -> Self {
@@ -44,16 +42,14 @@ impl BalancerV2Liquidity {
             vault,
             pool_fetcher,
             allowance_manager: Box::new(allowance_manager),
-            base_tokens,
         }
     }
 
     async fn get_orders(
         &self,
-        pairs: &[TokenPair],
+        pairs: HashSet<TokenPair>,
         block: Block,
     ) -> Result<(Vec<StablePoolOrder>, Vec<WeightedProductOrder>)> {
-        let pairs = self.base_tokens.relevant_pairs(pairs.iter().cloned());
         let pools = self.pool_fetcher.fetch(pairs, block).await?;
 
         let tokens = pools.relevant_tokens();
@@ -103,7 +99,11 @@ impl BalancerV2Liquidity {
 impl LiquidityCollecting for BalancerV2Liquidity {
     /// Returns relevant Balancer V2 weighted pools given a list of off-chain
     /// orders.
-    async fn get_liquidity(&self, pairs: &[TokenPair], block: Block) -> Result<Vec<Liquidity>> {
+    async fn get_liquidity(
+        &self,
+        pairs: HashSet<TokenPair>,
+        block: Block,
+    ) -> Result<Vec<Liquidity>> {
         let (stable, weighted) = self.get_orders(pairs, block).await?;
         let liquidity = stable
             .into_iter()
@@ -193,6 +193,7 @@ mod tests {
     use num::BigRational;
     use primitive_types::H160;
     use shared::{
+        baseline_solver::BaseTokens,
         dummy_contract,
         http_solver::model::InternalizationStrategy,
         interaction::Interaction,
@@ -336,24 +337,23 @@ mod tests {
             )
             .returning(|_, _| Ok(Allowances::empty(H160([0xc1; 20]))));
 
-        let base_tokens = Arc::new(BaseTokens::new(H160([0xb0; 20]), &[]));
+        let base_tokens = BaseTokens::new(H160([0xb0; 20]), &[]);
+        let traded_pairs = [
+            TokenPair::new(H160([0x70; 20]), H160([0x71; 20])).unwrap(),
+            TokenPair::new(H160([0x70; 20]), H160([0x72; 20])).unwrap(),
+            TokenPair::new(H160([0xb0; 20]), H160([0x73; 20])).unwrap(),
+        ];
+        let pairs = base_tokens.relevant_pairs(traded_pairs.into_iter());
+
         let (settlement, vault) = dummy_contracts();
         let liquidity_provider = BalancerV2Liquidity {
             settlement,
             vault,
             pool_fetcher: Arc::new(pool_fetcher),
             allowance_manager: Box::new(allowance_manager),
-            base_tokens,
         };
         let (stable_orders, weighted_orders) = liquidity_provider
-            .get_orders(
-                &[
-                    TokenPair::new(H160([0x70; 20]), H160([0x71; 20])).unwrap(),
-                    TokenPair::new(H160([0x70; 20]), H160([0x72; 20])).unwrap(),
-                    TokenPair::new(H160([0xb0; 20]), H160([0x73; 20])).unwrap(),
-                ],
-                Block::Recent,
-            )
+            .get_orders(pairs, Block::Recent)
             .await
             .unwrap();
 

--- a/crates/solver/src/liquidity_collector.rs
+++ b/crates/solver/src/liquidity_collector.rs
@@ -1,25 +1,36 @@
 use crate::liquidity::Liquidity;
 use anyhow::Result;
 use model::TokenPair;
-use shared::recent_block_cache::Block;
+use shared::{baseline_solver::BaseTokens, recent_block_cache::Block};
+use std::{collections::HashSet, sync::Arc};
 
 #[mockall::automock]
 #[async_trait::async_trait]
 pub trait LiquidityCollecting: Send + Sync {
-    async fn get_liquidity(&self, pairs: &[TokenPair], at_block: Block) -> Result<Vec<Liquidity>>;
+    async fn get_liquidity(
+        &self,
+        pairs: HashSet<TokenPair>,
+        at_block: Block,
+    ) -> Result<Vec<Liquidity>>;
 }
 
 pub struct LiquidityCollector {
     pub liquidity_sources: Vec<Box<dyn LiquidityCollecting>>,
+    pub base_tokens: Arc<BaseTokens>,
 }
 
 #[async_trait::async_trait]
 impl LiquidityCollecting for LiquidityCollector {
-    async fn get_liquidity(&self, pairs: &[TokenPair], at_block: Block) -> Result<Vec<Liquidity>> {
+    async fn get_liquidity(
+        &self,
+        pairs: HashSet<TokenPair>,
+        at_block: Block,
+    ) -> Result<Vec<Liquidity>> {
+        let pairs = self.base_tokens.relevant_pairs(pairs.into_iter());
         let futures = self
             .liquidity_sources
             .iter()
-            .map(|source| source.get_liquidity(pairs, at_block));
+            .map(|source| source.get_liquidity(pairs.clone(), at_block));
         let amms: Vec<_> = futures::future::join_all(futures)
             .await
             .into_iter()


### PR DESCRIPTION
Fixes #900 

This is just a small refactor to remove a bit of duplicated logic.
Instead of collecting relevant token pairs based on the `BaseTokens` in each `LiquidityCollecting` implementation we can simply do it once in the `LiquidityCollector`.

### Test Plan
Existing unit tests still pass
