### PR TITLE
Consider that access list makes tx possible in the first place

### DIFF
--- a/crates/solver/src/settlement_submission/submitter.rs
+++ b/crates/solver/src/settlement_submission/submitter.rs
@@ -526,27 +526,41 @@ impl<'a> Submitter<'a> {
             tx,
         )
         .await?;
-        let (gas_before_access_list, gas_after_access_list) = futures::try_join!(
+        let (without_access_list, with_access_list) = futures::join!(
+            // This call will fail for orders paying ETH to SC wallets
             tx.clone().estimate_gas(),
             tx.clone().access_list(access_list.clone()).estimate_gas()
-        )?;
+        );
 
-        ensure!(
-            gas_before_access_list > gas_after_access_list,
-            "access list exist but does not lower the gas usage"
-        );
-        let gas_percent_saved = (gas_before_access_list.to_f64_lossy()
-            - gas_after_access_list.to_f64_lossy())
-            / gas_before_access_list.to_f64_lossy()
-            * 100.;
-        tracing::debug!(
-            "gas before/after access list: {}/{}, access_list: {:?}, gas percent saved: {}",
-            gas_before_access_list,
-            gas_after_access_list,
-            access_list,
-            gas_percent_saved
-        );
-        Ok(access_list)
+        match (without_access_list, with_access_list) {
+            (Err(_), Ok(_)) => {
+                tracing::debug!("using an access list made the transaction executable");
+                Ok(access_list)
+            }
+            (Ok(_), Err(_)) => {
+                anyhow::bail!("access list caused the transaction to fail");
+            }
+            (Ok(gas_without), Ok(gas_with)) => {
+                ensure!(
+                    gas_without > gas_with,
+                    "access list exists but does not lower the gas usage"
+                );
+                let gas_percent_saved = (gas_without.to_f64_lossy() - gas_with.to_f64_lossy())
+                    / gas_without.to_f64_lossy()
+                    * 100.;
+                tracing::debug!(
+                    "gas before/after access list: {}/{}, access_list: {:?}, gas percent saved: {}",
+                    gas_without,
+                    gas_with,
+                    access_list,
+                    gas_percent_saved
+                );
+                Ok(access_list)
+            }
+            (Err(_), Err(_)) => {
+                anyhow::bail!("transaction would revert with and without access list");
+            }
+        }
     }
 
     /// Prepare noop transaction. This transaction does transfer of 0 value to self and always spends 21000 gas.


### PR DESCRIPTION
Fixes #925 

The problem was that the code in the `Submitter` didn't expect that a failing transaction could be made executable by adding an access list. Instead of `try_join` we now always simulate both transactions (with and without access list) and return the access list correctly based on which one was successful.

### Test Plan
Ran `orderbook`, `autopilot` and `solver` locally and settled an order that sells `COW` for `ETH` and sends it to my `goerli` test safe ([tx](https://goerli.etherscan.io/tx/0x5371bdc380eb27281f4f9fb92338b7308e26c067a1fe3762cf942aa93a88e7aa)).
