### PR TITLE
[refunder] refundable order calculation should depend on blocktime

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -79,7 +79,6 @@ jobs:
             networks: {
               hardhat: {
                 initialBaseFeePerGas: 0,
-                initialDate: "2000-01-01T00:00:00.000+00:00",
                 accounts: {
                   accountsBalance: "1000000000000000000000000"
                 },

--- a/README.md
+++ b/README.md
@@ -153,7 +153,6 @@ Due to the RPC calls the services issue `Ganache` is incompatible, so we will us
        networks: {
            hardhat: {
                initialBaseFeePerGas: 0,
-               initialDate: "2000-01-01T00:00:00.000+00:00",
                accounts: {
                    accountsBalance: "1000000000000000000000000"
                }

--- a/crates/e2e/tests/e2e/eth_flow.rs
+++ b/crates/e2e/tests/e2e/eth_flow.rs
@@ -1,6 +1,6 @@
 use crate::{
     deploy::Contracts,
-    local_node::{blockchain_time, AccountAssigner, TestNodeApi},
+    local_node::{AccountAssigner, TestNodeApi},
     onchain_components::{
         deploy_token_with_weth_uniswap_pool, to_wei, MintableToken, WethPoolConfig,
     },
@@ -36,8 +36,8 @@ use refunder::{
 };
 use reqwest::Client;
 use shared::{
-    ethrpc::Web3, http_client::HttpClientFactory, maintenance::Maintaining,
-    signature_validator::check_erc1271_result,
+    current_block::blockchain_time, ethrpc::Web3, http_client::HttpClientFactory,
+    maintenance::Maintaining, signature_validator::check_erc1271_result,
 };
 const ACCOUNT_ENDPOINT: &str = "/api/v1/account";
 const AUCTION_ENDPOINT: &str = "/api/v1/auction";
@@ -170,7 +170,7 @@ async fn eth_flow_indexing_after_refund(web3: Web3) {
 
     // Create an order that only exists to be refunded, which triggers an event in the eth-flow contract that is not
     // included in the ABI of `CoWSwapOnchainOrders`.
-    let valid_to = blockchain_time(&web3).await + 60;
+    let valid_to = blockchain_time(&web3).await.unwrap() + 60;
     let dummy_order = ExtendedEthFlowOrder::from_quote(
         &submit_quote(
             &(EthFlowTradeIntent {
@@ -201,7 +201,7 @@ async fn eth_flow_indexing_after_refund(web3: Web3) {
     let buy_token = dai.address();
     let receiver = H160([0x42; 20]);
     let sell_amount = to_wei(1);
-    let valid_to = blockchain_time(&web3).await + 60;
+    let valid_to = blockchain_time(&web3).await.unwrap() + 60;
     let ethflow_order = ExtendedEthFlowOrder::from_quote(
         &submit_quote(
             &(EthFlowTradeIntent {

--- a/crates/e2e/tests/e2e/eth_flow.rs
+++ b/crates/e2e/tests/e2e/eth_flow.rs
@@ -36,8 +36,9 @@ use refunder::{
 };
 use reqwest::Client;
 use shared::{
-    current_block::blockchain_time, ethrpc::Web3, http_client::HttpClientFactory,
-    maintenance::Maintaining, signature_validator::check_erc1271_result,
+    current_block::timestamp_of_current_block_in_seconds, ethrpc::Web3,
+    http_client::HttpClientFactory, maintenance::Maintaining,
+    signature_validator::check_erc1271_result,
 };
 const ACCOUNT_ENDPOINT: &str = "/api/v1/account";
 const AUCTION_ENDPOINT: &str = "/api/v1/auction";
@@ -170,7 +171,7 @@ async fn eth_flow_indexing_after_refund(web3: Web3) {
 
     // Create an order that only exists to be refunded, which triggers an event in the eth-flow contract that is not
     // included in the ABI of `CoWSwapOnchainOrders`.
-    let valid_to = blockchain_time(&web3).await.unwrap() + 60;
+    let valid_to = timestamp_of_current_block_in_seconds(&web3).await.unwrap() + 60;
     let dummy_order = ExtendedEthFlowOrder::from_quote(
         &submit_quote(
             &(EthFlowTradeIntent {
@@ -201,7 +202,7 @@ async fn eth_flow_indexing_after_refund(web3: Web3) {
     let buy_token = dai.address();
     let receiver = H160([0x42; 20]);
     let sell_amount = to_wei(1);
-    let valid_to = blockchain_time(&web3).await.unwrap() + 60;
+    let valid_to = timestamp_of_current_block_in_seconds(&web3).await.unwrap() + 60;
     let ethflow_order = ExtendedEthFlowOrder::from_quote(
         &submit_quote(
             &(EthFlowTradeIntent {

--- a/crates/e2e/tests/e2e/local_node.rs
+++ b/crates/e2e/tests/e2e/local_node.rs
@@ -16,46 +16,12 @@ lazy_static! {
 
 const NODE_HOST: &str = "http://127.0.0.1:8545";
 
-pub async fn test<F, Fut>(test_function: F)
-where
-    F: FnOnce(Web3) -> Fut,
-    Fut: Future<Output = ()>,
-{
-    revert_node_state_after(|web3| async move {
-        // We want all tests run with the node starting to mine at the current time.
-        web3.api::<TestNodeApi<_>>()
-            .set_next_block_timestamp(&chrono::offset::Utc::now())
-            .await
-            .expect("Could not set block timestamp");
-
-        // Mine an empty block. This writes the current time to the blockchain, also it can be retrieved from the latest
-        // block.
-        web3.api::<TestNodeApi<_>>()
-            .mine_pending_block()
-            .await
-            .expect("Could not mine empty block");
-
-        // Run the actual test function.
-        test_function(web3.clone()).await;
-    })
-    .await;
-}
-
-pub async fn test_node_in_the_past<F, Fut>(test_function: F)
-where
-    F: FnOnce(Web3) -> Fut,
-    Fut: Future<Output = ()>,
-{
-    // Use the node timestamp provided by default
-    revert_node_state_after(test_function).await;
-}
-
 /// *Testing* function that takes a closure and runs it on a local testing node.
 /// Before each test, it creates a snapshot of the current state of the chain.
 /// The saved state is restored at the end of the test.
 ///
 /// Note that tests calling with this function will not be run simultaneously.
-pub async fn revert_node_state_after<F, Fut>(f: F)
+pub async fn test<F, Fut>(f: F)
 where
     F: FnOnce(Web3) -> Fut,
     Fut: Future<Output = ()>,

--- a/crates/e2e/tests/e2e/local_node.rs
+++ b/crates/e2e/tests/e2e/local_node.rs
@@ -1,5 +1,5 @@
 use chrono::{DateTime, Utc};
-use ethcontract::{futures::FutureExt, Account, Address, BlockNumber, U256};
+use ethcontract::{futures::FutureExt, Account, Address, U256};
 use lazy_static::lazy_static;
 use shared::ethrpc::{create_test_transport, Web3};
 use std::{
@@ -173,14 +173,4 @@ impl AccountAssigner {
     pub fn assign_free_account(&mut self) -> Account {
         self.free_accounts.pop().expect("No testing accounts available, consider increasing the number of testing account in the test node")
     }
-}
-
-pub async fn blockchain_time(web3: &Web3) -> u32 {
-    web3.eth()
-        .block(BlockNumber::Latest.into())
-        .await
-        .expect("Unable to query block from node")
-        .expect("Block should exist")
-        .timestamp
-        .as_u32()
 }

--- a/crates/e2e/tests/e2e/refunder.rs
+++ b/crates/e2e/tests/e2e/refunder.rs
@@ -101,6 +101,11 @@ async fn refunder_tx(web3: Web3) {
         ))
         .await
         .expect("Must be able to set block timestamp");
+    // mine next block to push time forward
+    web3.api::<TestNodeApi<_>>()
+        .mine_pending_block()
+        .await
+        .expect("Unable to mine next block");
 
     // Create the refund service and execute the refund tx
     let pg_pool = PgPool::connect_lazy("postgresql://").expect("failed to create database");

--- a/crates/e2e/tests/e2e/refunder.rs
+++ b/crates/e2e/tests/e2e/refunder.rs
@@ -13,8 +13,8 @@ use model::quote::{
 };
 use refunder::refund_service::RefundService;
 use shared::{
-    current_block::blockchain_time, ethrpc::Web3, http_client::HttpClientFactory,
-    maintenance::Maintaining,
+    current_block::timestamp_of_current_block_in_seconds, ethrpc::Web3,
+    http_client::HttpClientFactory, maintenance::Maintaining,
 };
 use sqlx::PgPool;
 
@@ -82,7 +82,7 @@ async fn refunder_tx(web3: Web3) {
     let quote_response = quoting.json::<OrderQuoteResponse>().await.unwrap();
 
     let validity_duration = 60;
-    let valid_to = blockchain_time(&web3).await.unwrap() + validity_duration;
+    let valid_to = timestamp_of_current_block_in_seconds(&web3).await.unwrap() + validity_duration;
     // Accounting for slippage is necesary for the order to be picked up by the refunder
     let ethflow_order =
         ExtendedEthFlowOrder::from_quote(&quote_response, valid_to).include_slippage_bps(9999);

--- a/crates/e2e/tests/e2e/refunder.rs
+++ b/crates/e2e/tests/e2e/refunder.rs
@@ -1,6 +1,6 @@
 use crate::{
     eth_flow::{EthFlowOrderOnchainStatus, ExtendedEthFlowOrder},
-    local_node::{blockchain_time, AccountAssigner, TestNodeApi},
+    local_node::{AccountAssigner, TestNodeApi},
     onchain_components::{
         deploy_token_with_weth_uniswap_pool, to_wei, MintableToken, WethPoolConfig,
     },
@@ -12,7 +12,10 @@ use model::quote::{
     OrderQuoteRequest, OrderQuoteResponse, OrderQuoteSide, QuoteSigningScheme, Validity,
 };
 use refunder::refund_service::RefundService;
-use shared::{ethrpc::Web3, http_client::HttpClientFactory, maintenance::Maintaining};
+use shared::{
+    current_block::blockchain_time, ethrpc::Web3, http_client::HttpClientFactory,
+    maintenance::Maintaining,
+};
 use sqlx::PgPool;
 
 const QUOTING_ENDPOINT: &str = "/api/v1/quote/";
@@ -78,7 +81,7 @@ async fn refunder_tx(web3: Web3) {
     assert_eq!(quoting.status(), 200);
     let quote_response = quoting.json::<OrderQuoteResponse>().await.unwrap();
 
-    let valid_to = blockchain_time(&web3).await + 60;
+    let valid_to = blockchain_time(&web3).await.unwrap() + 60;
     // Accounting for slippage is necesary for the order to be picked up by the refunder
     let ethflow_order =
         ExtendedEthFlowOrder::from_quote(&quote_response, valid_to).include_slippage_bps(9999);

--- a/crates/e2e/tests/e2e/refunder.rs
+++ b/crates/e2e/tests/e2e/refunder.rs
@@ -93,15 +93,7 @@ async fn refunder_tx(web3: Web3) {
     // Run autopilot indexing loop
     services.maintenance.run_maintenance().await.unwrap();
 
-    // The blockchain is in the past for this test. We validate this assumption here, if this assertion fails then the
-    // original test conditions should be restored.
-    let now = chrono::offset::Utc::now().timestamp();
-    assert!(
-        (valid_to as i64) < now,
-        "Order should be expired from the point of view of the refunder."
-    );
-    let time_after_expiration = now + 60;
-
+    let time_after_expiration = valid_to as i64 + 60;
     web3.api::<TestNodeApi<_>>()
         .set_next_block_timestamp(&DateTime::from_utc(
             NaiveDateTime::from_timestamp(time_after_expiration, 0),

--- a/crates/e2e/tests/e2e/refunder.rs
+++ b/crates/e2e/tests/e2e/refunder.rs
@@ -114,7 +114,7 @@ async fn refunder_tx(web3: Web3) {
         pg_pool,
         web3,
         contracts.ethflow.clone(),
-        validity_duration as i64 - 1,
+        validity_duration as i64 - 10,
         10u64,
         refunder_account,
     );

--- a/crates/refunder/src/refund_service.rs
+++ b/crates/refunder/src/refund_service.rs
@@ -10,7 +10,10 @@ use database::{
 };
 use ethcontract::{Account, H160};
 use futures::{stream, StreamExt};
-use shared::ethrpc::{Web3, Web3CallBatch, MAX_BATCH_SIZE};
+use shared::{
+    current_block::blockchain_time,
+    ethrpc::{Web3, Web3CallBatch, MAX_BATCH_SIZE},
+};
 use sqlx::PgPool;
 
 use super::ethflow_order::{EncodedEthflowOrder, EthflowOrder};
@@ -99,10 +102,12 @@ impl RefundService {
     }
 
     pub async fn get_refundable_ethflow_orders_from_db(&self) -> Result<Vec<EthOrderPlacement>> {
+        let block_time = blockchain_time(&self.web3).await? as i64;
+
         let mut ex = self.db.acquire().await?;
         refundable_orders(
             &mut ex,
-            model::time::now_in_epoch_seconds().into(),
+            block_time,
             self.min_validity_duration,
             self.min_slippage,
         )

--- a/crates/refunder/src/refund_service.rs
+++ b/crates/refunder/src/refund_service.rs
@@ -11,7 +11,7 @@ use database::{
 use ethcontract::{Account, H160};
 use futures::{stream, StreamExt};
 use shared::{
-    current_block::blockchain_time,
+    current_block::timestamp_of_current_block_in_seconds,
     ethrpc::{Web3, Web3CallBatch, MAX_BATCH_SIZE},
 };
 use sqlx::PgPool;
@@ -102,7 +102,7 @@ impl RefundService {
     }
 
     pub async fn get_refundable_ethflow_orders_from_db(&self) -> Result<Vec<EthOrderPlacement>> {
-        let block_time = blockchain_time(&self.web3).await? as i64;
+        let block_time = timestamp_of_current_block_in_seconds(&self.web3).await? as i64;
 
         let mut ex = self.db.acquire().await?;
         refundable_orders(

--- a/crates/shared/src/current_block.rs
+++ b/crates/shared/src/current_block.rs
@@ -179,6 +179,17 @@ async fn get_block_info_at_id(web3: &Web3, id: BlockId) -> Result<BlockInfo> {
     })
 }
 
+pub async fn blockchain_time(web3: &Web3) -> Result<u32> {
+    Ok(web3
+        .eth()
+        .block(BlockNumber::Latest.into())
+        .await
+        .context("failed to get latest block")?
+        .context("block should exists")?
+        .timestamp
+        .as_u32())
+}
+
 pub async fn block_number_to_block_number_hash(
     web3: &Web3,
     block_number: BlockNumber,

--- a/crates/shared/src/current_block.rs
+++ b/crates/shared/src/current_block.rs
@@ -179,7 +179,7 @@ async fn get_block_info_at_id(web3: &Web3, id: BlockId) -> Result<BlockInfo> {
     })
 }
 
-pub async fn blockchain_time(web3: &Web3) -> Result<u32> {
+pub async fn timestamp_of_current_block_in_seconds(web3: &Web3) -> Result<u32> {
     Ok(web3
         .eth()
         .block(BlockNumber::Latest.into())


### PR DESCRIPTION
The refunder showed some tricky patterns:
It was using the CPU time to check which orders are refundable. Then it simulated the refund tx on the last block, but in the last block, the orders were not yet refundable, and hence, the simulation resulted in a very low gas limit estimation. 
If then the tx would hit on chain, the tx would use a lot more gas - as it would actually do the refunding. See [here](https://goerli.etherscan.io/address/0x2c53223ec0d536defd79a422b6dedf324b398bbd) for the failed tx.

This PR fixes this, as the refunder will only use the block-time and not the CPU time for the calculation of the refundable orders.

One nice side effect of this change is that we no longer need to do the complicated "node starting point from the past" introduce here: https://github.com/cowprotocol/services/pull/851

Testplan:
e2e tests