### PR TITLE
Improve flanky refunder test

### DIFF
--- a/crates/e2e/tests/e2e/refunder.rs
+++ b/crates/e2e/tests/e2e/refunder.rs
@@ -81,7 +81,7 @@ async fn refunder_tx(web3: Web3) {
     assert_eq!(quoting.status(), 200);
     let quote_response = quoting.json::<OrderQuoteResponse>().await.unwrap();
 
-    let validity_duration = 60;
+    let validity_duration = 600;
     let valid_to = timestamp_of_current_block_in_seconds(&web3).await.unwrap() + validity_duration;
     // Accounting for slippage is necesary for the order to be picked up by the refunder
     let ethflow_order =
@@ -114,7 +114,7 @@ async fn refunder_tx(web3: Web3) {
         pg_pool,
         web3,
         contracts.ethflow.clone(),
-        validity_duration as i64 - 10,
+        validity_duration as i64 / 2,
         10u64,
         refunder_account,
     );


### PR DESCRIPTION
The refunder test is flanky. E.g. [here](https://github.com/cowprotocol/services/actions/runs/3695869171/jobs/6258798439) it failed on main branch.

The reason is probably that the time of the blockchain proceeds too much between these commands: 
```
let valid_to = timestamp_of_current_block_in_seconds(&web3).await.unwrap() + validity_duration;
    // Accounting for slippage is necesary for the order to be picked up by the refunder
    let ethflow_order =
        ExtendedEthFlowOrder::from_quote(&quote_response, valid_to).include_slippage_bps(9999);
    ethflow_order
        .mine_order_creation(&user, &contracts.ethflow)
        .await;
```
such that the validity_duration - 10 - this is the time between mining and valid_to -  was too strict:
```
RefundService::new(..., validity_duration -10, ...)
 ```
 
I fixed it by being less strict about it.

### Test Plan
None