### PR TITLE
Restart refunder on deploy

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -55,7 +55,20 @@ jobs:
       - uses: cowprotocol/autodeploy-action@v1
         if: ${{ github.ref == 'refs/heads/main' }}
         with:
-          pods: dfusion-v2-autopilot-goerli,dfusion-v2-api-goerli,dfusion-v2-solver-goerli,dfusion-v2-autopilot-mainnet,dfusion-v2-api-mainnet,dfusion-v2-solver-mainnet,dfusion-v2-autopilot-xdai,dfusion-v2-api-xdai,dfusion-v2-solver-xdai,dfusion-v2-solver-shadow,dfusion-v2-alerter-mainnet,dfusion-v2-refunder-goerli
+          pods: "dfusion-v2-autopilot-goerli,\
+                 dfusion-v2-api-goerli,\
+                 dfusion-v2-solver-goerli,\
+                 dfusion-v2-refunder-goerli,\
+                 dfusion-v2-autopilot-mainnet,\
+                 dfusion-v2-api-mainnet,\
+                 dfusion-v2-solver-mainnet,\
+                 dfusion-v2-refunder-mainnet,\
+                 dfusion-v2-autopilot-xdai,\
+                 dfusion-v2-api-xdai,\
+                 dfusion-v2-solver-xdai,\
+                 dfusion-v2-refunder-xdai,\
+                 dfusion-v2-solver-shadow,\
+                 dfusion-v2-alerter-mainnet"
           tag: ${{ secrets.AUTODEPLOY_TAG }}
           url: ${{ secrets.AUTODEPLOY_URL }}
           token: ${{ secrets.AUTODEPLOY_TOKEN }}


### PR DESCRIPTION
The refunder is running in all networks in staging and needs to be restarted on deploy.

### Test Plan

Compare to same string in master.

Diffing the outputs of ` yq '.jobs.deploy.steps[6].with.pods' <.github/workflows/deploy.yaml` yields:

![image](https://user-images.githubusercontent.com/58218759/207831529-2fb45c19-b46c-46b0-ab3d-5311be0995f2.png)

