### PR TITLE
Fix duplicate db metric name

### DIFF
--- a/crates/orderbook/src/database/orders.rs
+++ b/crates/orderbook/src/database/orders.rs
@@ -295,7 +295,7 @@ impl LimitOrderCounting for Postgres {
     async fn count(&self, owner: H160) -> Result<u64> {
         let _timer = super::Metrics::get()
             .database_queries
-            .with_label_values(&["count_limit_orders"])
+            .with_label_values(&["count_limit_orders_by_owner"])
             .start_timer();
 
         let mut ex = self.pool.acquire().await?;


### PR DESCRIPTION
Probably a copy paste error. The current name is already used to query the total number of limit orders in autopilot. They are different queries so shouldn't use the same name.

### Test Plan

CI, look at Grafana afterwards

