### PR TITLE
Fixing conflict in reorg handling by autopilot for ethflow

### DIFF
--- a/crates/database/src/orders.rs
+++ b/crates/database/src/orders.rs
@@ -849,15 +849,16 @@ mod tests {
 
     #[tokio::test]
     #[ignore]
-    async fn postgres_insert_same_order_twice_fails() {
+    async fn postgres_insert_same_order_twice_results_in_only_one_order() {
         let mut db = PgConnection::connect("postgresql://").await.unwrap();
         let mut db = db.begin().await.unwrap();
         crate::clear_DANGER_(&mut db).await.unwrap();
 
         let order = Order::default();
         insert_order(&mut db, &order).await.unwrap();
-        let err = insert_order(&mut db, &order).await.unwrap_err();
-        assert!(is_duplicate_record_error(&err));
+        insert_order(&mut db, &order).await.unwrap();
+        let order_ = read_order(&mut db, &order.uid).await.unwrap().unwrap();
+        assert_eq!(order, order_);
     }
 
     #[tokio::test]

--- a/crates/database/src/orders.rs
+++ b/crates/database/src/orders.rs
@@ -157,15 +157,12 @@ pub async fn insert_orders_and_ignore_conflicts(
     orders: &[Order],
 ) -> Result<(), sqlx::Error> {
     for order in orders {
-        insert_order(ex, order).await?;
+        insert_order_and_ignore_conflicts(ex, order).await?;
     }
     Ok(())
 }
 
-pub async fn insert_order(ex: &mut PgConnection, order: &Order) -> Result<(), sqlx::Error> {
-    // Since each order has a unique UID even after a reorg onchain placed orders have the same
-    // data. Hence, we can disregard any conflicts.
-    const QUERY: &str = r#"
+const INSERT_ORDER_QUERY: &str = r#"
 INSERT INTO orders (
     uid,
     owner,
@@ -192,9 +189,26 @@ INSERT INTO orders (
     surplus_fee_timestamp
 )
 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23)
-ON CONFLICT (uid) DO NOTHING
     "#;
-    sqlx::query(QUERY)
+
+pub async fn insert_order_and_ignore_conflicts(
+    ex: &mut PgConnection,
+    order: &Order,
+) -> Result<(), sqlx::Error> {
+    // To be used only for the ethflow contract order placement, where reorgs force us to update
+    // orders
+    // Since each order has a unique UID even after a reorg onchain placed orders have the same
+    // data. Hence, we can disregard any conflicts.
+    const QUERY: &str = const_format::concatcp!(INSERT_ORDER_QUERY, "ON CONFLICT (uid) DO NOTHING");
+    insert_order_execute_sqlx(QUERY, ex, order).await
+}
+
+async fn insert_order_execute_sqlx(
+    query_str: &str,
+    ex: &mut PgConnection,
+    order: &Order,
+) -> Result<(), sqlx::Error> {
+    sqlx::query(query_str)
         .bind(&order.uid)
         .bind(&order.owner)
         .bind(order.creation_timestamp)
@@ -221,6 +235,10 @@ ON CONFLICT (uid) DO NOTHING
         .execute(ex)
         .await?;
     Ok(())
+}
+
+pub async fn insert_order(ex: &mut PgConnection, order: &Order) -> Result<(), sqlx::Error> {
+    insert_order_execute_sqlx(INSERT_ORDER_QUERY, ex, order).await
 }
 
 pub async fn read_order(
@@ -722,6 +740,21 @@ mod tests {
 
     #[tokio::test]
     #[ignore]
+    async fn postgres_order_roundtrip_with_function_irgnoring_duplications() {
+        let mut db = PgConnection::connect("postgresql://").await.unwrap();
+        let mut db = db.begin().await.unwrap();
+        crate::clear_DANGER_(&mut db).await.unwrap();
+
+        let order = Order::default();
+        insert_order_and_ignore_conflicts(&mut db, &order)
+            .await
+            .unwrap();
+        let order_ = read_order(&mut db, &order.uid).await.unwrap().unwrap();
+        assert_eq!(order, order_);
+    }
+
+    #[tokio::test]
+    #[ignore]
     async fn postgres_onchain_user_order_roundtrip() {
         let mut db = PgConnection::connect("postgresql://").await.unwrap();
         let mut db = db.begin().await.unwrap();
@@ -849,6 +882,19 @@ mod tests {
 
     #[tokio::test]
     #[ignore]
+    async fn postgres_insert_same_order_twice_fails() {
+        let mut db = PgConnection::connect("postgresql://").await.unwrap();
+        let mut db = db.begin().await.unwrap();
+        crate::clear_DANGER_(&mut db).await.unwrap();
+
+        let order = Order::default();
+        insert_order(&mut db, &order).await.unwrap();
+        let err = insert_order(&mut db, &order).await.unwrap_err();
+        assert!(is_duplicate_record_error(&err));
+    }
+
+    #[tokio::test]
+    #[ignore]
     async fn postgres_insert_same_order_twice_results_in_only_one_order() {
         let mut db = PgConnection::connect("postgresql://").await.unwrap();
         let mut db = db.begin().await.unwrap();
@@ -856,7 +902,9 @@ mod tests {
 
         let order = Order::default();
         insert_order(&mut db, &order).await.unwrap();
-        insert_order(&mut db, &order).await.unwrap();
+        insert_order_and_ignore_conflicts(&mut db, &order)
+            .await
+            .unwrap();
         let order_ = read_order(&mut db, &order.uid).await.unwrap().unwrap();
         assert_eq!(order, order_);
     }


### PR DESCRIPTION
Currently, we see on staging the following error:
```
WARN maintenance{block=16189813}: shared::maintenance: Service Maintenance Error: insert_orders failedCaused by:
    0: error returned from database: current transaction is aborted, commands ignored until end of transaction block
    1: current transaction is aborted, commands ignored until end of transaction block
 ```
 
 I think this is due to the fact that a first insert_order returns an error - duplication of uid - which we ignore. Then we try to proceed with another query. But since it's a db-transaction, and not a single query, it keeps on telling that the last command produced already an error. 
 This PR makes sure that the first insertion does not even fail.
 (see here for more context: https://stackoverflow.com/questions/10399727/psqlexception-current-transaction-is-aborted-commands-ignored-until-end-of-tra)

### Test Plan
test only