### PR TITLE
Prevent limit order fee updater from getting stuck

### DIFF
--- a/crates/autopilot/src/database/orders.rs
+++ b/crates/autopilot/src/database/orders.rs
@@ -93,6 +93,11 @@ impl Postgres {
                 }),
             ),
             FeeUpdate::Failure { timestamp } => (
+                // Note that the surplus fee must be removed so that the order does not count as
+                // solvable. In order to be solvable the timestamp must be recent and the fee must
+                // be set. We don't reset the timestamp because it indicates the last update time
+                // (regardless of error or success). This is needed so that we can query the least
+                // recently updated limit orders. See #965 .
                 database::orders::FeeUpdate {
                     surplus_fee: None,
                     surplus_fee_timestamp: *timestamp,

--- a/crates/autopilot/src/database/orders.rs
+++ b/crates/autopilot/src/database/orders.rs
@@ -1,6 +1,6 @@
 use super::Postgres;
-use anyhow::Result;
-use chrono::{Duration, Utc};
+use anyhow::{Context, Result};
+use chrono::{DateTime, Duration, Utc};
 use database::byte_array::ByteArray;
 use ethcontract::U256;
 use futures::{StreamExt, TryStreamExt};
@@ -12,14 +12,22 @@ use number_conversions::u256_to_big_decimal;
 use shared::{db_order_conversions::full_order_into_model_order, fee_subsidy::FeeParameters};
 
 /// New fee data to update a limit order with.
-pub struct FeeUpdate {
-    /// The actual fee amount to charge the order from its surplus.
-    pub surplus_fee: U256,
-
-    /// The full unsubsidized fee amount that settling the order is expected to
-    /// actually cost. This is used for objective value computation so that fee
-    /// subsidies do not change the objective value.
-    pub full_fee_amount: U256,
+///
+/// Both success and failure to calculate the new fee are recorded in the database.
+pub enum FeeUpdate {
+    Success {
+        timestamp: DateTime<Utc>,
+        /// The actual fee amount to charge the order from its surplus.
+        surplus_fee: U256,
+        /// The full unsubsidized fee amount that settling the order is expected to
+        /// actually cost. This is used for objective value computation so that fee
+        /// subsidies do not change the objective value.
+        full_fee_amount: U256,
+        quote: LimitOrderQuote,
+    },
+    Failure {
+        timestamp: DateTime<Utc>,
+    },
 }
 
 /// Data required to compute risk adjusted rewards for limit orders.
@@ -43,7 +51,7 @@ impl Postgres {
 
         let mut ex = self.0.acquire().await?;
         let timestamp = Utc::now() - age;
-        database::orders::limit_orders_with_outdated_fees(
+        database::orders::limit_orders_with_most_outdated_fees(
             &mut ex,
             timestamp,
             now_in_epoch_seconds().into(),
@@ -62,38 +70,52 @@ impl Postgres {
         &self,
         order_uid: &OrderUid,
         update: &FeeUpdate,
-        quote: &LimitOrderQuote,
     ) -> Result<()> {
+        let (update, quote) = match update {
+            FeeUpdate::Success {
+                timestamp,
+                surplus_fee,
+                full_fee_amount,
+                quote,
+            } => (
+                database::orders::FeeUpdate {
+                    surplus_fee: Some(u256_to_big_decimal(surplus_fee)),
+                    surplus_fee_timestamp: *timestamp,
+                    full_fee_amount: u256_to_big_decimal(full_fee_amount),
+                },
+                Some(database::orders::Quote {
+                    order_uid: ByteArray(order_uid.0),
+                    gas_amount: quote.fee_parameters.gas_amount,
+                    gas_price: quote.fee_parameters.gas_price,
+                    sell_token_price: quote.fee_parameters.sell_token_price,
+                    sell_amount: u256_to_big_decimal(&quote.sell_amount),
+                    buy_amount: u256_to_big_decimal(&quote.buy_amount),
+                }),
+            ),
+            FeeUpdate::Failure { timestamp } => (
+                database::orders::FeeUpdate {
+                    surplus_fee: None,
+                    surplus_fee_timestamp: *timestamp,
+                    full_fee_amount: 0.into(),
+                },
+                None,
+            ),
+        };
+
         let _timer = super::Metrics::get()
             .database_queries
             .with_label_values(&["update_limit_order_fees"])
             .start_timer();
-
         let mut ex = self.0.begin().await?;
-        database::orders::update_limit_order_fees(
-            &mut ex,
-            &database::byte_array::ByteArray(order_uid.0),
-            &database::orders::FeeUpdate {
-                surplus_fee: u256_to_big_decimal(&update.surplus_fee),
-                surplus_fee_timestamp: Utc::now(),
-                full_fee_amount: u256_to_big_decimal(&update.full_fee_amount),
-            },
-        )
-        .await?;
-
-        database::orders::insert_quote_and_update_on_conflict(
-            &mut ex,
-            &database::orders::Quote {
-                order_uid: ByteArray(order_uid.0),
-                gas_amount: quote.fee_parameters.gas_amount,
-                gas_price: quote.fee_parameters.gas_price,
-                sell_token_price: quote.fee_parameters.sell_token_price,
-                sell_amount: u256_to_big_decimal(&quote.sell_amount),
-                buy_amount: u256_to_big_decimal(&quote.buy_amount),
-            },
-        )
-        .await?;
-        ex.commit().await?;
+        database::orders::update_limit_order_fees(&mut ex, &ByteArray(order_uid.0), &update)
+            .await
+            .context("update_limit_order_fee")?;
+        if let Some(quote) = quote {
+            database::orders::insert_quote_and_update_on_conflict(&mut ex, &quote)
+                .await
+                .context("insert_quote_and_update_on_conflict")?;
+        }
+        ex.commit().await.context("commit")?;
         Ok(())
     }
 

--- a/crates/autopilot/src/limit_orders/quoter.rs
+++ b/crates/autopilot/src/limit_orders/quoter.rs
@@ -3,17 +3,18 @@ use crate::database::{
     Postgres,
 };
 use anyhow::Result;
-use chrono::Duration;
+use chrono::{Duration, Utc};
 use futures::future::join_all;
 use model::{
-    order::{Order, OrderKind},
+    order::{Order, OrderKind, OrderUid},
     quote::{OrderQuoteSide, QuoteSigningScheme, SellAmount},
     signature::{hashed_eip712_message, Signature},
     DomainSeparator,
 };
 use shared::{
-    order_quoting::{OrderQuoting, QuoteParameters},
-    signature_validator::{SignatureCheck, SignatureValidating},
+    order_quoting::{CalculateQuoteError, OrderQuoting, Quote, QuoteParameters},
+    price_estimation::PriceEstimationError,
+    signature_validator::{SignatureCheck, SignatureValidating, SignatureValidationError},
 };
 use std::sync::Arc;
 use tracing::Instrument as _;
@@ -43,7 +44,6 @@ impl LimitOrderQuoter {
     }
 
     async fn update(&self) -> Result<()> {
-        let mut failed_orders = 0;
         loop {
             let orders = self
                 .database
@@ -53,103 +53,145 @@ impl LimitOrderQuoter {
                 break;
             }
             for chunk in orders.chunks(10) {
-                failed_orders += join_all(chunk.iter().map(|order| async move {
-                    let update_result = self
-                        .update_surplus_fee(order)
-                        .instrument(tracing::debug_span!(
-                            "surplus_fee",
-                            order =% order.metadata.uid
-                        ))
-                        .await;
-                    if let Err(err) = &update_result {
-                        let order_uid = &order.metadata.uid;
-                        tracing::warn!(%order_uid, ?err, "skipped limit order due to error");
-                    };
-                    usize::from(update_result.is_err())
+                join_all(chunk.iter().map(|order| {
+                    async move {
+                        let quote = self.get_quote(order).await;
+                        self.update_fee(&order.metadata.uid, &quote).await;
+                    }
+                    .instrument(tracing::debug_span!(
+                        "surplus_fee",
+                        order =% order.metadata.uid
+                    ))
                 }))
-                .await
-                .into_iter()
-                .sum::<usize>();
+                .await;
             }
         }
-        Metrics::on_failed(failed_orders.try_into().unwrap());
         Ok(())
     }
 
-    async fn update_surplus_fee(&self, order: &Order) -> Result<()> {
-        let quote = self
-            .quoter
-            .calculate_quote(QuoteParameters {
-                sell_token: order.data.sell_token,
-                buy_token: order.data.buy_token,
-                side: match order.data.kind {
-                    OrderKind::Buy => OrderQuoteSide::Buy {
-                        buy_amount_after_fee: order.data.buy_amount,
-                    },
-                    OrderKind::Sell => OrderQuoteSide::Sell {
-                        sell_amount: SellAmount::BeforeFee {
-                            value: order.data.sell_amount + order.data.fee_amount,
-                        },
-                    },
-                },
-                from: order.metadata.owner,
-                app_data: order.data.app_data,
-                signing_scheme: match &order.signature {
-                    Signature::Eip712(_) => QuoteSigningScheme::Eip712,
-                    Signature::EthSign(_) => QuoteSigningScheme::EthSign,
-                    Signature::Eip1271(signature) => {
-                        let additional_gas = self
-                            .signature_validator
-                            .validate_signature_and_get_additional_gas(SignatureCheck {
-                                signer: order.metadata.owner,
-                                hash: hashed_eip712_message(
-                                    &self.domain_separator,
-                                    &order.data.hash_struct(),
-                                ),
-                                signature: signature.to_owned(),
-                            })
-                            .await?;
-                        QuoteSigningScheme::Eip1271 {
-                            onchain_order: false,
-                            verification_gas_limit: additional_gas,
-                        }
+    /// Handles errors internally.
+    async fn get_quote(&self, order: &Order) -> Option<Quote> {
+        let uid = &order.metadata.uid;
+        let signing_scheme = match &order.signature {
+            Signature::Eip712(_) => QuoteSigningScheme::Eip712,
+            Signature::EthSign(_) => QuoteSigningScheme::EthSign,
+            Signature::Eip1271(signature) => {
+                let additional_gas = match self
+                    .signature_validator
+                    .validate_signature_and_get_additional_gas(SignatureCheck {
+                        signer: order.metadata.owner,
+                        hash: hashed_eip712_message(
+                            &self.domain_separator,
+                            &order.data.hash_struct(),
+                        ),
+                        signature: signature.to_owned(),
+                    })
+                    .await
+                {
+                    Ok(gas) => gas,
+                    Err(SignatureValidationError::Invalid) => {
+                        tracing::debug!(%uid, "limit order has an invalid signature");
+                        Metrics::get()
+                            .update_result
+                            .with_label_values(&["unpreventable_failure"])
+                            .inc();
+                        return None;
                     }
-                    Signature::PreSign => QuoteSigningScheme::PreSign {
-                        onchain_order: false,
+                    Err(SignatureValidationError::Other(err)) => {
+                        tracing::warn!(%uid, ?err, "limit order signature validation error");
+                        Metrics::get()
+                            .update_result
+                            .with_label_values(&["preventable_failure"])
+                            .inc();
+                        return None;
+                    }
+                };
+                QuoteSigningScheme::Eip1271 {
+                    onchain_order: false,
+                    verification_gas_limit: additional_gas,
+                }
+            }
+            Signature::PreSign => QuoteSigningScheme::PreSign {
+                onchain_order: false,
+            },
+        };
+        let parameters = QuoteParameters {
+            sell_token: order.data.sell_token,
+            buy_token: order.data.buy_token,
+            side: match order.data.kind {
+                OrderKind::Buy => OrderQuoteSide::Buy {
+                    buy_amount_after_fee: order.data.buy_amount,
+                },
+                OrderKind::Sell => OrderQuoteSide::Sell {
+                    sell_amount: SellAmount::BeforeFee {
+                        value: order.data.sell_amount + order.data.fee_amount,
                     },
                 },
-            })
-            .await?;
-        self.database
-            .update_limit_order_fees(
-                &order.metadata.uid,
-                &FeeUpdate {
-                    surplus_fee: quote.fee_amount,
-                    full_fee_amount: quote.full_fee_amount,
-                },
-                &LimitOrderQuote {
+            },
+            from: order.metadata.owner,
+            app_data: order.data.app_data,
+            signing_scheme,
+        };
+        match self.quoter.calculate_quote(parameters).await {
+            Ok(quote) => Some(quote),
+            Err(
+                CalculateQuoteError::Other(err)
+                | CalculateQuoteError::Price(PriceEstimationError::Other(err)),
+            ) => {
+                tracing::warn!(%uid, ?err, "limit order quote error");
+                Metrics::get()
+                    .update_result
+                    .with_label_values(&["preventable_failure"])
+                    .inc();
+                None
+            }
+            Err(err) => {
+                tracing::debug!(%uid, ?err, "limit order unqoutable");
+                Metrics::get()
+                    .update_result
+                    .with_label_values(&["unpreventable_failure"])
+                    .inc();
+                None
+            }
+        }
+    }
+
+    /// Handles errors internally.
+    async fn update_fee(&self, uid: &OrderUid, quote: &Option<Quote>) {
+        let timestamp = Utc::now();
+        let update = match quote {
+            Some(quote) => FeeUpdate::Success {
+                timestamp,
+                surplus_fee: quote.fee_amount,
+                full_fee_amount: quote.full_fee_amount,
+                quote: LimitOrderQuote {
                     fee_parameters: quote.data.fee_parameters,
                     sell_amount: quote.sell_amount,
                     buy_amount: quote.buy_amount,
                 },
-            )
-            .await?;
-        Ok(())
+            },
+            None => FeeUpdate::Failure { timestamp },
+        };
+        if let Err(err) = self.database.update_limit_order_fees(uid, &update).await {
+            tracing::warn!(%uid, ?err, "limit order fee update db error");
+            Metrics::get()
+                .update_result
+                .with_label_values(&["preventable_failure"])
+                .inc();
+        }
     }
 }
 
 #[derive(prometheus_metric_storage::MetricStorage, Clone, Debug)]
 #[metric(subsystem = "limit_order_quoter")]
 struct Metrics {
-    /// Counter for failed limit orders.
-    failed: prometheus::IntCounter,
+    /// Categorizes order quote update results into success, preventable_failure, unpreventable_failure.
+    #[metric(labels("type"))]
+    update_result: prometheus::IntCounterVec,
 }
 
 impl Metrics {
-    fn on_failed(failed: u64) {
-        Self::instance(global_metrics::get_metric_storage_registry())
-            .unwrap()
-            .failed
-            .inc_by(failed);
+    fn get() -> &'static Self {
+        Self::instance(global_metrics::get_metric_storage_registry()).unwrap()
     }
 }

--- a/crates/database/src/orders.rs
+++ b/crates/database/src/orders.rs
@@ -126,8 +126,8 @@ INSERT INTO interactions (
 )
 VALUES ($1, $2, $3, $4, $5)
 ON CONFLICT (order_uid, index) DO UPDATE
-SET target = $3, 
-value = $4, data = $5    
+SET target = $3,
+value = $4, data = $5
     "#;
     sqlx::query(QUERY)
         .bind(&order_uid)
@@ -587,7 +587,10 @@ FROM settlements
     sqlx::query_scalar(QUERY).fetch_one(ex).await
 }
 
-pub fn limit_orders_with_outdated_fees(
+/// The ordering by most outdated in combination with updating the timestamp when updating the fee
+/// fails is important. It ensures that we cannot get stuck on orders for which the update process
+/// keeps failing.
+pub fn limit_orders_with_most_outdated_fees(
     ex: &mut PgConnection,
     max_fee_timestamp: DateTime<Utc>,
     min_valid_to: i64,
@@ -600,9 +603,11 @@ pub fn limit_orders_with_outdated_fees(
         ORDERS_FROM,
         " WHERE o.valid_to >= $1 ",
         "AND o.class = 'limit' ",
-        "AND o.surplus_fee_timestamp < $2 ",
+        "AND COALESCE(o.surplus_fee_timestamp, 'epoch') < $2 ",
+        "ORDER BY o.surplus_fee_timestamp ASC NULLS FIRST",
         ") AS o ",
-        "WHERE NOT o.invalidated LIMIT 100",
+        "WHERE NOT o.invalidated ",
+        "LIMIT 100 ",
     );
     sqlx::query_as(QUERY)
         .bind(min_valid_to)
@@ -636,7 +641,7 @@ pub async fn count_limit_orders_by_owner(
 }
 
 pub struct FeeUpdate {
-    pub surplus_fee: BigDecimal,
+    pub surplus_fee: Option<BigDecimal>,
     pub surplus_fee_timestamp: DateTime<Utc>,
     pub full_fee_amount: BigDecimal,
 }
@@ -698,7 +703,7 @@ pub async fn count_limit_orders_with_outdated_fees(
         ORDERS_FROM,
         " WHERE o.valid_to >= $1 ",
         "AND o.class = 'limit' ",
-        "AND o.surplus_fee_timestamp < $2 ",
+        "AND COALESCE(o.surplus_fee_timestamp, 'epoch') < $2 ",
         ") AS o ",
         "WHERE NOT o.invalidated",
     );
@@ -1588,7 +1593,7 @@ mod tests {
         .unwrap();
 
         let update = FeeUpdate {
-            surplus_fee: 42.into(),
+            surplus_fee: Some(42.into()),
             surplus_fee_timestamp: DateTime::from_utc(
                 NaiveDateTime::from_timestamp(1234567890, 0),
                 Utc,
@@ -1600,7 +1605,7 @@ mod tests {
             .unwrap();
 
         let order = read_order(&mut db, &order_uid).await.unwrap().unwrap();
-        assert_eq!(order.surplus_fee, Some(update.surplus_fee));
+        assert_eq!(order.surplus_fee, update.surplus_fee);
         assert_eq!(
             order.surplus_fee_timestamp,
             Some(update.surplus_fee_timestamp)
@@ -1616,16 +1621,15 @@ mod tests {
         crate::clear_DANGER_(&mut db).await.unwrap();
 
         let timestamp = DateTime::from_utc(NaiveDateTime::from_timestamp(1234567890, 0), Utc);
-        let order_uid = ByteArray([1; 56]);
         // Valid limit order with an outdated surplus fee.
         insert_order(
             &mut db,
             &Order {
-                uid: order_uid,
+                uid: ByteArray([1; 56]),
                 class: OrderClass::Limit,
                 valid_to: 3,
                 surplus_fee: Some(0.into()),
-                surplus_fee_timestamp: Some(Default::default()),
+                surplus_fee_timestamp: Some(timestamp - chrono::Duration::seconds(1)),
                 ..Default::default()
             },
         )
@@ -1674,11 +1678,39 @@ mod tests {
         )
         .await
         .unwrap();
-        // Not a limit order.
+        // Limit order that was never estimated.
         insert_order(
             &mut db,
             &Order {
                 uid: ByteArray([5; 56]),
+                class: OrderClass::Limit,
+                valid_to: 3,
+                surplus_fee: None,
+                surplus_fee_timestamp: None,
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+        // Limit order that was recently unsuccessfully estimated.
+        insert_order(
+            &mut db,
+            &Order {
+                uid: ByteArray([6; 56]),
+                class: OrderClass::Limit,
+                valid_to: 3,
+                surplus_fee: None,
+                surplus_fee_timestamp: Some(timestamp),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+        // Not a limit order.
+        insert_order(
+            &mut db,
+            &Order {
+                uid: ByteArray([7; 56]),
                 valid_to: 3,
                 ..Default::default()
             },
@@ -1686,13 +1718,14 @@ mod tests {
         .await
         .unwrap();
 
-        let orders: Vec<_> = limit_orders_with_outdated_fees(&mut db, timestamp, 2)
+        let orders: Vec<_> = limit_orders_with_most_outdated_fees(&mut db, timestamp, 2)
             .try_collect()
             .await
             .unwrap();
 
-        assert_eq!(orders.len(), 1);
-        assert_eq!(orders[0].uid, order_uid);
+        assert_eq!(orders.len(), 2);
+        assert_eq!(orders[0].uid.0, [5; 56]);
+        assert_eq!(orders[1].uid.0, [1; 56]);
     }
 
     #[tokio::test]


### PR DESCRIPTION
This is a theoretical issue I noticed while thinking about limit orders as part of oncall.

Currently, the limit order fee updater retrieves orders with outdated fees in an arbitrary ordering because the sql query does not include an ORDER BY clause. This is problematic because it is possible that the fee estimate for an order keeps failing forever, for example because the quote is out of price. If this happened for all of the 100 orders that the query returns, then the updater would never make progress.

This PR fixes this issue by slightly changing the semantics of the surplus_fee and surplus_fee_timestamp columns. When updating the fee fails, surplus_fee is set to null and surplus_fee_timestamp is updated to the current time. With this change we can return the limit orders with outdated fees ordered by surplus_fee_timestamp, giving us the most outdated orders first.

As part of this I am categorizing errors into preventable and unpreventable to improve logging and metrics.

---

The diff is hard to read because I had to move a lot of code around even though the logic hasn't changed that much. It is more understandable side-by-side instead of inline.

### Test Plan

adjusted the db unit tests, there is an e2e test for limit orders and will watch logs afterwards
