### PR TITLE
Add more result context

### DIFF
--- a/crates/autopilot/src/lib.rs
+++ b/crates/autopilot/src/lib.rs
@@ -399,8 +399,11 @@ pub async fn main(args: arguments::Arguments) -> ! {
         block_retriever.clone(),
         skip_event_sync_start,
     ));
-    let mut maintainers: Vec<Arc<dyn Maintaining>> =
-        vec![pool_fetcher.clone(), event_updater, Arc::new(db.clone())];
+    let mut maintainers: Vec<(Arc<dyn Maintaining>, &'static str)> = vec![
+        (pool_fetcher.clone(), "pool_fetcher"),
+        (event_updater, "event_updater"),
+        (Arc::new(db.clone()), "db"),
+    ];
 
     let gas_price_estimator = Arc::new(InstrumentedGasEstimator::new(
         shared::gas_price_estimation::create_priority_estimator(
@@ -486,13 +489,13 @@ pub async fn main(args: arguments::Arguments) -> ! {
             .await
             .expect("Should be able to initialize event updater. Database read issues?"),
         );
-        maintainers.push(broadcaster_event_updater);
+        maintainers.push((broadcaster_event_updater, "broadcaster_event_updater"));
     }
     if let Some(balancer) = balancer_pool_fetcher {
-        maintainers.push(balancer);
+        maintainers.push((balancer, "balancer_pool_fetcher"));
     }
     if let Some(uniswap_v3) = uniswap_v3_pool_fetcher {
-        maintainers.push(uniswap_v3);
+        maintainers.push((uniswap_v3, "uniswap_v3_pool_fetcher"));
     }
 
     let service_maintainer = ServiceMaintenance::new(maintainers);

--- a/crates/e2e/tests/e2e/services.rs
+++ b/crates/e2e/tests/e2e/services.rs
@@ -226,9 +226,9 @@ impl OrderbookServices {
             order_validator.clone(),
         ));
         let maintenance = ServiceMaintenance::new(vec![
-            Arc::new(autopilot_db.clone()),
-            ethflow_event_updater,
-            gpv2_event_updater,
+            (Arc::new(autopilot_db.clone()), "autopilot_db"),
+            (ethflow_event_updater, "ethflow_event_update"),
+            (gpv2_event_updater, "gpv2_event_updater"),
         ]);
         let quotes = Arc::new(QuoteHandler::new(order_validator, quoter.clone()));
         orderbook::serve_api(

--- a/crates/orderbook/src/main.rs
+++ b/crates/orderbook/src/main.rs
@@ -437,12 +437,12 @@ async fn main() -> ! {
         order_validator.clone(),
     ));
 
-    let mut maintainers = vec![pool_fetcher as Arc<dyn Maintaining>];
+    let mut maintainers = vec![(pool_fetcher as Arc<dyn Maintaining>, "pool_fetcher")];
     if let Some(balancer) = balancer_pool_fetcher {
-        maintainers.push(balancer);
+        maintainers.push((balancer, "balancer_pool_fetcher"));
     }
     if let Some(uniswap_v3) = uniswap_v3_pool_fetcher {
-        maintainers.push(uniswap_v3);
+        maintainers.push((uniswap_v3, "univ3_pool_fetcher"));
     }
 
     check_database_connection(orderbook.as_ref()).await;

--- a/crates/shared/src/sources/balancer_v2/pool_fetching/pool_storage.rs
+++ b/crates/shared/src/sources/balancer_v2/pool_fetching/pool_storage.rs
@@ -130,7 +130,8 @@ where
         let pool = self
             .pool_info_fetcher
             .fetch_pool_info(pool_creation.pool, block_created)
-            .await?;
+            .await
+            .context("fetch_pool_info")?;
         self.insert_pool(pool);
 
         Ok(())
@@ -200,7 +201,8 @@ where
             let BasePoolFactoryEvent::PoolCreated(pool_created) = event.data;
 
             self.index_pool_creation(pool_created, block_created)
-                .await?;
+                .await
+                .context("index_pool_creation")?;
         }
 
         Ok(())

--- a/crates/shared/src/sources/balancer_v2/pools/common.rs
+++ b/crates/shared/src/sources/balancer_v2/pools/common.rs
@@ -171,8 +171,12 @@ where
     ) -> Result<Factory::PoolInfo> {
         let common_pool_info = self
             .fetch_common_pool_info(pool_address, block_created)
-            .await?;
-        self.factory.specialize_pool_info(common_pool_info).await
+            .await
+            .context("fetch_common_pool_info")?;
+        self.factory
+            .specialize_pool_info(common_pool_info)
+            .await
+            .context("specialize_pool_info")
     }
 
     fn fetch_pool(
@@ -189,11 +193,11 @@ where
                 .fetch_pool_state(pool_info, common_pool_state_ok.boxed(), batch, block);
 
         async move {
-            let common_pool_state = common_pool_state.await?;
+            let common_pool_state = common_pool_state.await.context("common_pool_state")?;
             if common_pool_state.paused {
                 return Ok(PoolStatus::Paused);
             }
-            let pool_state = match pool_state.await? {
+            let pool_state = match pool_state.await.context("pool_state")? {
                 Some(state) => state,
                 None => return Ok(PoolStatus::Disabled),
             };

--- a/crates/shared/src/subgraph.rs
+++ b/crates/shared/src/subgraph.rs
@@ -1,6 +1,6 @@
 //! A module implementing a client for querying subgraphs.
 
-use anyhow::{bail, Result};
+use anyhow::{bail, Context, Result};
 use lazy_static::lazy_static;
 use reqwest::{Client, IntoUrl, Url};
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
@@ -106,7 +106,8 @@ impl SubgraphClient {
         loop {
             let page = self
                 .query::<Data<T>>(query, Some(variables.clone()))
-                .await?
+                .await
+                .context("query")?
                 .inner;
             let no_more_pages = page.len() != QUERY_PAGE_SIZE;
             if let Some(last_elem) = page.last() {


### PR DESCRIPTION
While oncall we had maintenance fail with an unhelpful error message like "Bad Gateway". These contexts are supposed to help with that. Some of the messages could be better but I didn't want to invest the time to understand the surrounding code more and this is already enough to make it easier to trace the execution from the error message.

I moved the maintainer impl names into the ServiceMaintenance struct instead of the Maintenance trait because it we really only need the names in ServiceMaintenance and I didn't want to force it on all the implementations. Not completely clear what is better.

### Test Plan

next time these errors happen should have better message
