### PR TITLE
Smooth out limit order fee updates

### DIFF
--- a/crates/autopilot/src/arguments.rs
+++ b/crates/autopilot/src/arguments.rs
@@ -113,15 +113,6 @@ pub struct Arguments {
     )]
     pub max_surplus_fee_age: Duration,
 
-    /// The interval between successive limit order surplus fee updating loops in seconds.
-    #[clap(
-        long,
-        env,
-        default_value = "60",
-        value_parser = shared::arguments::duration_from_seconds,
-    )]
-    pub surplus_fee_update_interval: Duration,
-
     #[clap(long, env)]
     pub cip_14_beta: Option<f64>,
     #[clap(long, env)]
@@ -184,11 +175,6 @@ impl std::fmt::Display for Arguments {
         writeln!(f, "banned_users: {:?}", self.banned_users)?;
         writeln!(f, "max_auction_age: {:?}", self.max_auction_age)?;
         writeln!(f, "max_surplus_fee_age: {:?}", self.max_surplus_fee_age)?;
-        writeln!(
-            f,
-            "surplus_fee_update_interval: {:?}",
-            self.surplus_fee_update_interval
-        )?;
         display_option(f, "cip_14_beta", &self.cip_14_beta)?;
         display_option(f, "cip_14_alpha1", &self.cip_14_alpha1)?;
         display_option(f, "cip_14_alpha2", &self.cip_14_alpha2)?;

--- a/crates/autopilot/src/database/orders.rs
+++ b/crates/autopilot/src/database/orders.rs
@@ -43,7 +43,13 @@ pub struct LimitOrderQuote {
 }
 
 impl Postgres {
-    pub async fn limit_orders_with_outdated_fees(&self, age: Duration) -> Result<Vec<Order>> {
+    pub async fn limit_orders_with_outdated_fees(
+        &self,
+        age: Duration,
+        limit: usize,
+    ) -> Result<Vec<Order>> {
+        let limit: i64 = limit.try_into().context("convert limit")?;
+
         let _timer = super::Metrics::get()
             .database_queries
             .with_label_values(&["limit_orders_with_outdated_fees"])
@@ -55,6 +61,7 @@ impl Postgres {
             &mut ex,
             timestamp,
             now_in_epoch_seconds().into(),
+            limit,
         )
         .map(|result| match result {
             Ok(order) => full_order_into_model_order(order),

--- a/crates/autopilot/src/lib.rs
+++ b/crates/autopilot/src/lib.rs
@@ -545,7 +545,6 @@ pub async fn main(args: arguments::Arguments) -> ! {
         let limit_order_age = chrono::Duration::from_std(args.max_surplus_fee_age).unwrap();
         LimitOrderQuoter {
             limit_order_age,
-            loop_delay: args.surplus_fee_update_interval,
             quoter,
             database: db.clone(),
             signature_validator,
@@ -554,7 +553,6 @@ pub async fn main(args: arguments::Arguments) -> ! {
         .spawn();
         LimitOrderMetrics {
             limit_order_age,
-            loop_delay: Duration::from_secs(5),
             database: db,
         }
         .spawn();

--- a/crates/autopilot/src/limit_orders/metrics.rs
+++ b/crates/autopilot/src/limit_orders/metrics.rs
@@ -1,11 +1,11 @@
-use chrono::Duration;
+use std::time::Duration;
+
 use prometheus::IntGauge;
 
 use crate::database::Postgres;
 
 pub struct LimitOrderMetrics {
-    pub limit_order_age: Duration,
-    pub loop_delay: std::time::Duration,
+    pub limit_order_age: chrono::Duration,
     pub database: Postgres,
 }
 
@@ -29,7 +29,7 @@ impl LimitOrderMetrics {
                 limit_orders_gauge.set(limit_orders);
                 unquoted_limit_orders_gauge.set(unquoted_limit_orders);
                 quoted_limit_orders_gauge.set(quoted_limit_orders);
-                tokio::time::sleep(self.loop_delay).await;
+                tokio::time::sleep(Duration::from_secs(10)).await;
             }
         });
     }

--- a/crates/e2e/tests/e2e/services.rs
+++ b/crates/e2e/tests/e2e/services.rs
@@ -174,7 +174,6 @@ impl OrderbookServices {
         );
         LimitOrderQuoter {
             limit_order_age: chrono::Duration::seconds(15),
-            loop_delay: Duration::from_secs(1),
             quoter: Arc::new(FixedFeeQuoter {
                 quoter: quoter.clone(),
                 fee: 1_000.into(),
@@ -344,7 +343,7 @@ pub async fn wait_for_solvable_orders(client: &Client, minimum: usize) -> Result
             tokio::time::sleep(Duration::from_millis(100)).await;
         }
     };
-    match tokio::time::timeout(Duration::from_secs(5), task).await {
+    match tokio::time::timeout(Duration::from_secs(30), task).await {
         Ok(inner) => inner,
         Err(_) => Err(anyhow!("timeout")),
     }


### PR DESCRIPTION
The current update mechanism works in the following way:

1.  Get all outdated fee limit orders.
2. Update the fee for every order. Do this for N orders in parallel.
3. Sleep 60 seconds.
4. Repeat.

The new update mechanism works in the following way:
1. Get the N most outdated fee limit orders.
2. Update the fee these N orders in parallel.
3. If there were no outdated orders sleep 10 seconds. If there were outdated do not sleep.
4. Repeat

The new update mechanism has the following advantages:
- When there are too many limit orders to keep up with, it has more throughput because there is no sleep between updates.
- When we can keep up with all limit orders, the average time an order is outdated for is lower.
- A single update is shorter which prevents wasting work on orders that become invalid during the update loop.

Other changes:
- Because the new update mechanism is more efficient I've lowered the parallelism factor from 10 to 5. We might want to make this configurable in a later PR.
- Removed the configuration option for the wait between loops. I see no reason to change this with the new mechanism.
- Change the limit order metrics update interval to 10 seconds.

### Test Plan

tested by e2e test and I will observe metrics after merging