### PR TITLE
Fix handling of limit orders without surplus_fee

### DIFF
--- a/crates/autopilot/src/solvable_orders.rs
+++ b/crates/autopilot/src/solvable_orders.rs
@@ -566,8 +566,9 @@ async fn filter_unsupported_tokens(
 }
 
 fn filter_limit_orders_with_insufficient_sell_amount(mut orders: Vec<Order>) -> Vec<Order> {
+    // Unwrap because solvable orders always have a surplus fee.
     orders.retain(|order| match &order.metadata.class {
-        OrderClass::Limit(limit) => order.data.sell_amount > limit.surplus_fee,
+        OrderClass::Limit(limit) => order.data.sell_amount > limit.surplus_fee.unwrap(),
         _ => true,
     });
     orders
@@ -585,7 +586,8 @@ fn filter_mispriced_limit_orders(
             _ => return true,
         };
 
-        let effective_sell_amount = order.data.sell_amount.saturating_sub(surplus_fee);
+        // Unwrap because solvable orders always have a surplus fee.
+        let effective_sell_amount = order.data.sell_amount.saturating_sub(surplus_fee.unwrap());
         if effective_sell_amount.is_zero() {
             return false;
         }
@@ -1210,7 +1212,7 @@ mod tests {
             },
             metadata: OrderMetadata {
                 class: OrderClass::Limit(LimitOrderClass {
-                    surplus_fee: surplus_fee.into(),
+                    surplus_fee: Some(surplus_fee.into()),
                     ..Default::default()
                 }),
                 ..Default::default()
@@ -1255,7 +1257,7 @@ mod tests {
             },
             metadata: OrderMetadata {
                 class: OrderClass::Limit(LimitOrderClass {
-                    surplus_fee: surplus_fee.into(),
+                    surplus_fee: Some(surplus_fee.into()),
                     ..Default::default()
                 }),
                 ..Default::default()

--- a/crates/model/src/order.rs
+++ b/crates/model/src/order.rs
@@ -220,7 +220,7 @@ impl OrderBuilder {
 
     pub fn with_surplus_fee(mut self, surplus_fee: U256) -> Self {
         if let OrderClass::Limit(limit) = &mut self.0.metadata.class {
-            limit.surplus_fee = surplus_fee;
+            limit.surplus_fee = Some(surplus_fee);
         } else {
             panic!("not a limit order");
         }
@@ -688,9 +688,9 @@ impl OrderClass {
 #[derive(Eq, PartialEq, Clone, Debug, Default, Hash, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct LimitOrderClass {
-    #[serde(with = "u256_decimal")]
-    pub surplus_fee: U256,
-    pub surplus_fee_timestamp: DateTime<Utc>,
+    #[serde_as(as = "Option<DecimalU256>")]
+    pub surplus_fee: Option<U256>,
+    pub surplus_fee_timestamp: Option<DateTime<Utc>>,
     #[serde_as(as = "Option<DecimalU256>")]
     pub executed_surplus_fee: Option<U256>,
 }
@@ -836,8 +836,8 @@ mod tests {
             metadata: OrderMetadata {
                 creation_date: DateTime::<Utc>::from_utc(NaiveDateTime::from_timestamp(3, 0), Utc),
                 class: OrderClass::Limit(LimitOrderClass {
-                    surplus_fee: U256::MAX,
-                    surplus_fee_timestamp: Default::default(),
+                    surplus_fee: Some(U256::MAX),
+                    surplus_fee_timestamp: Some(Default::default()),
                     executed_surplus_fee: Some(1.into()),
                 }),
                 owner: H160::from_low_u64_be(1),

--- a/crates/orderbook/src/database/orders.rs
+++ b/crates/orderbook/src/database/orders.rs
@@ -98,7 +98,7 @@ async fn insert_order(order: &Order, ex: &mut PgConnection) -> Result<(), Insert
         cancellation_timestamp: None,
         surplus_fee: match order.metadata.class {
             OrderClass::Limit(LimitOrderClass { surplus_fee, .. }) => {
-                Some(u256_to_big_decimal(&surplus_fee))
+                surplus_fee.as_ref().map(u256_to_big_decimal)
             }
             _ => None,
         },
@@ -106,7 +106,7 @@ async fn insert_order(order: &Order, ex: &mut PgConnection) -> Result<(), Insert
             OrderClass::Limit(LimitOrderClass {
                 surplus_fee_timestamp,
                 ..
-            }) => Some(surplus_fee_timestamp),
+            }) => surplus_fee_timestamp,
             _ => None,
         },
     };

--- a/crates/shared/src/db_order_conversions.rs
+++ b/crates/shared/src/db_order_conversions.rs
@@ -123,16 +123,11 @@ pub fn order_class_from(order: &FullOrderDb) -> OrderClass {
         DbOrderClass::Market => OrderClass::Market,
         DbOrderClass::Liquidity => OrderClass::Liquidity,
         DbOrderClass::Limit => OrderClass::Limit(LimitOrderClass {
-            surplus_fee: big_decimal_to_u256(
-                order
-                    .surplus_fee
-                    .as_ref()
-                    .expect("limit orders must have surplus fee set"),
-            )
-            .unwrap(),
-            surplus_fee_timestamp: order
-                .surplus_fee_timestamp
-                .expect("limit orders must have surplus fee timestamp set"),
+            surplus_fee: order
+                .surplus_fee
+                .as_ref()
+                .map(|fee| big_decimal_to_u256(fee).unwrap()),
+            surplus_fee_timestamp: order.surplus_fee_timestamp,
             executed_surplus_fee: order
                 .executed_surplus_fee
                 .as_ref()

--- a/crates/shared/src/order_validation.rs
+++ b/crates/shared/src/order_validation.rs
@@ -16,8 +16,8 @@ use database::quotes::QuoteKind;
 use ethcontract::{H160, U256};
 use model::{
     order::{
-        BuyTokenDestination, Order, OrderClass, OrderCreation, OrderData, OrderKind,
-        SellTokenSource, BUY_ETH_ADDRESS,
+        BuyTokenDestination, LimitOrderClass, Order, OrderClass, OrderCreation, OrderData,
+        OrderKind, SellTokenSource, BUY_ETH_ADDRESS,
     },
     quote::{OrderQuoteSide, QuoteSigningScheme, SellAmount},
     signature::{hashed_eip712_message, Signature, SigningScheme, VerificationError},
@@ -406,7 +406,12 @@ impl OrderValidating for OrderValidator {
         let class = if self.liquidity_order_owners.contains(&owner) {
             OrderClass::Liquidity
         } else if self.enable_limit_orders && order.data.fee_amount.is_zero() {
-            OrderClass::Limit(Default::default())
+            // intentionally not Default so that we notice if we change the type
+            OrderClass::Limit(LimitOrderClass {
+                surplus_fee: None,
+                surplus_fee_timestamp: None,
+                executed_surplus_fee: None,
+            })
         } else {
             OrderClass::Market
         };

--- a/crates/solver/src/driver.rs
+++ b/crates/solver/src/driver.rs
@@ -385,7 +385,7 @@ impl Driver {
                     let uid = &trade.order.metadata.uid;
                     let reward = rewards.get(uid).copied().unwrap_or(0.);
                     let surplus_fee = match trade.order.metadata.class {
-                        OrderClass::Limit(LimitOrderClass { surplus_fee, .. }) => Some(surplus_fee),
+                        OrderClass::Limit(LimitOrderClass { surplus_fee, .. }) => surplus_fee,
                         _ => None,
                     };
                     // Log in case something goes wrong with storing the rewards in the database.

--- a/crates/solver/src/driver/solver_settlements.rs
+++ b/crates/solver/src/driver/solver_settlements.rs
@@ -132,7 +132,7 @@ mod tests {
     use crate::{settlement::Trade, solver::dummy_arc_solver};
     use chrono::{offset::Utc, DateTime, Duration, Local};
 
-    use model::order::{Order, OrderClass, OrderData, OrderMetadata, OrderUid};
+    use model::order::{LimitOrderClass, Order, OrderClass, OrderData, OrderMetadata, OrderUid};
     use num::BigRational;
 
     use std::ops::Sub;
@@ -221,7 +221,15 @@ mod tests {
 
         let s1 = Settlement::with_default_prices(vec![
             trade(old, 1, OrderClass::Market),
-            trade(recent, 2, OrderClass::Limit(Default::default())),
+            trade(
+                recent,
+                2,
+                OrderClass::Limit(LimitOrderClass {
+                    surplus_fee: Some(Default::default()),
+                    surplus_fee_timestamp: Some(Default::default()),
+                    executed_surplus_fee: None,
+                }),
+            ),
         ]);
         let s2 = Settlement::with_default_prices(vec![
             trade(recent, 3, OrderClass::Market),
@@ -436,7 +444,11 @@ mod tests {
         assert!(!has_user_order(&settlement));
 
         let settlement =
-            Settlement::with_default_prices(vec![order(OrderClass::Limit(Default::default()))]);
+            Settlement::with_default_prices(vec![order(OrderClass::Limit(LimitOrderClass {
+                surplus_fee: Some(Default::default()),
+                surplus_fee_timestamp: Some(Default::default()),
+                executed_surplus_fee: None,
+            }))]);
         assert!(has_user_order(&settlement));
 
         let settlement = Settlement::with_default_prices(vec![order(OrderClass::Liquidity)]);
@@ -453,7 +465,11 @@ mod tests {
 
         let settlement = Settlement::with_default_prices(vec![
             order(OrderClass::Liquidity),
-            order(OrderClass::Limit(Default::default())),
+            order(OrderClass::Limit(LimitOrderClass {
+                surplus_fee: Some(Default::default()),
+                surplus_fee_timestamp: Some(Default::default()),
+                executed_surplus_fee: None,
+            })),
         ]);
         assert!(has_user_order(&settlement));
     }

--- a/crates/solver/src/liquidity/order_converter.rs
+++ b/crates/solver/src/liquidity/order_converter.rs
@@ -100,14 +100,18 @@ fn compute_synthetic_order_amounts_for_limit_order(
         order.metadata.class.is_limit(),
         "this function should only be called for limit orders"
     );
+    // Solvable limit orders always have a surplus fee. It would be nice if this was enforced in the API.
+    let surplus_fee = limit
+        .surplus_fee
+        .context("solvable order without surplus fee")?;
     let sell_amount = order
         .data
         .sell_amount
         .checked_add(order.data.fee_amount)
         .context("surplus_fee adjustment would overflow sell_amount")?
-        .checked_sub(limit.surplus_fee)
+        .checked_sub(surplus_fee)
         .context("surplus_fee adjustment would underflow sell_amount")?;
-    Ok((sell_amount, limit.surplus_fee))
+    Ok((sell_amount, surplus_fee))
 }
 
 impl SettlementHandling<LimitOrder> for OrderSettlementHandler {
@@ -278,7 +282,11 @@ pub mod tests {
     fn adds_unwrap_interaction_for_buy_order_with_eth_flag() {
         for class in [
             OrderClass::Market,
-            OrderClass::Limit(Default::default()),
+            OrderClass::Limit(LimitOrderClass {
+                surplus_fee: Some(Default::default()),
+                surplus_fee_timestamp: Some(Default::default()),
+                executed_surplus_fee: None,
+            }),
             OrderClass::Liquidity,
         ] {
             let native_token_address = H160([0x42; 20]);

--- a/crates/solver/src/settlement.rs
+++ b/crates/solver/src/settlement.rs
@@ -1394,7 +1394,7 @@ pub mod tests {
                         },
                         metadata: OrderMetadata {
                             class: OrderClass::Limit(LimitOrderClass {
-                                surplus_fee: 1_000_u128.into(),
+                                surplus_fee: Some(1_000_u128.into()),
                                 ..Default::default()
                             }),
                             ..Default::default()
@@ -1428,7 +1428,7 @@ pub mod tests {
                         },
                         metadata: OrderMetadata {
                             class: OrderClass::Limit(LimitOrderClass {
-                                surplus_fee: 1_000_u128.into(),
+                                surplus_fee: Some(1_000_u128.into()),
                                 ..Default::default()
                             }),
                             ..Default::default()
@@ -1469,7 +1469,7 @@ pub mod tests {
                     },
                     metadata: OrderMetadata {
                         class: OrderClass::Limit(LimitOrderClass {
-                            surplus_fee: 1_000_u128.into(),
+                            surplus_fee: Some(1_000_u128.into()),
                             ..Default::default()
                         }),
                         ..Default::default()

--- a/crates/solver/src/settlement/settlement_encoder.rs
+++ b/crates/solver/src/settlement/settlement_encoder.rs
@@ -315,6 +315,8 @@ impl SettlementEncoder {
             .get(&order.data.sell_token)
             .context("sell token price is missing")?;
 
+        // Solvable limit orders always have a surplus fee. It would be nice if this was enforced in the API.
+        let surplus_fee = limit.surplus_fee.unwrap();
         let (sell_amount, buy_amount) = match order.data.kind {
             // This means sell as much `sell_token` as needed to buy exactly the expected
             // `buy_amount`. Therefore we need to solve for `sell_amount`.
@@ -328,7 +330,7 @@ impl SettlementEncoder {
                     .context("sell_amount computation failed")?;
                 // We have to sell slightly more `sell_token` to capture the `surplus_fee`
                 let sell_amount_adjusted_for_fees = sell_amount
-                    .checked_add(limit.surplus_fee)
+                    .checked_add(surplus_fee)
                     .context("sell_amount computation failed")?;
                 (sell_amount_adjusted_for_fees, order.data.buy_amount)
             }
@@ -339,7 +341,7 @@ impl SettlementEncoder {
                 let sell_amount = order
                     .data
                     .sell_amount
-                    .checked_sub(limit.surplus_fee)
+                    .checked_sub(surplus_fee)
                     .context("buy_amount computation failed")?;
                 let buy_amount = sell_amount
                     .checked_mul(uniform_sell_price)


### PR DESCRIPTION
This fixes the panic that we saw in the last hour on staging.

The root cause is a mismatch on the expectations on the surplus_fee field for limit orders. In #775 we want back and forth on whether it should be nullable. In the end we decided against nullable becausae we would quote limit orders on order creation. That however was decided against in #784 . This left some parts of the code expecting the field to be non nullable and other parts expecting it to be nullable. 

In this PR make sure we can handle the fields being null.

Note that this issue wasn't introduced by #965 . That just made it more visible. We already had orders without surplus_fee in the database which would trigger a panic if anyone tried to fetch them from the /orders endpoint.

### Test Plan

CI, adjusted unit tests, manual test