### PR TITLE
Revert "Fix handling of limit orders without surplus_fee"

### DIFF
--- a/crates/autopilot/src/solvable_orders.rs
+++ b/crates/autopilot/src/solvable_orders.rs
@@ -566,9 +566,8 @@ async fn filter_unsupported_tokens(
 }
 
 fn filter_limit_orders_with_insufficient_sell_amount(mut orders: Vec<Order>) -> Vec<Order> {
-    // Unwrap because solvable orders always have a surplus fee.
     orders.retain(|order| match &order.metadata.class {
-        OrderClass::Limit(limit) => order.data.sell_amount > limit.surplus_fee.unwrap(),
+        OrderClass::Limit(limit) => order.data.sell_amount > limit.surplus_fee,
         _ => true,
     });
     orders
@@ -586,8 +585,7 @@ fn filter_mispriced_limit_orders(
             _ => return true,
         };
 
-        // Unwrap because solvable orders always have a surplus fee.
-        let effective_sell_amount = order.data.sell_amount.saturating_sub(surplus_fee.unwrap());
+        let effective_sell_amount = order.data.sell_amount.saturating_sub(surplus_fee);
         if effective_sell_amount.is_zero() {
             return false;
         }
@@ -1212,7 +1210,7 @@ mod tests {
             },
             metadata: OrderMetadata {
                 class: OrderClass::Limit(LimitOrderClass {
-                    surplus_fee: Some(surplus_fee.into()),
+                    surplus_fee: surplus_fee.into(),
                     ..Default::default()
                 }),
                 ..Default::default()
@@ -1257,7 +1255,7 @@ mod tests {
             },
             metadata: OrderMetadata {
                 class: OrderClass::Limit(LimitOrderClass {
-                    surplus_fee: Some(surplus_fee.into()),
+                    surplus_fee: surplus_fee.into(),
                     ..Default::default()
                 }),
                 ..Default::default()

--- a/crates/model/src/order.rs
+++ b/crates/model/src/order.rs
@@ -220,7 +220,7 @@ impl OrderBuilder {
 
     pub fn with_surplus_fee(mut self, surplus_fee: U256) -> Self {
         if let OrderClass::Limit(limit) = &mut self.0.metadata.class {
-            limit.surplus_fee = Some(surplus_fee);
+            limit.surplus_fee = surplus_fee;
         } else {
             panic!("not a limit order");
         }
@@ -688,9 +688,9 @@ impl OrderClass {
 #[derive(Eq, PartialEq, Clone, Debug, Default, Hash, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct LimitOrderClass {
-    #[serde_as(as = "Option<DecimalU256>")]
-    pub surplus_fee: Option<U256>,
-    pub surplus_fee_timestamp: Option<DateTime<Utc>>,
+    #[serde(with = "u256_decimal")]
+    pub surplus_fee: U256,
+    pub surplus_fee_timestamp: DateTime<Utc>,
     #[serde_as(as = "Option<DecimalU256>")]
     pub executed_surplus_fee: Option<U256>,
 }
@@ -836,8 +836,8 @@ mod tests {
             metadata: OrderMetadata {
                 creation_date: DateTime::<Utc>::from_utc(NaiveDateTime::from_timestamp(3, 0), Utc),
                 class: OrderClass::Limit(LimitOrderClass {
-                    surplus_fee: Some(U256::MAX),
-                    surplus_fee_timestamp: Some(Default::default()),
+                    surplus_fee: U256::MAX,
+                    surplus_fee_timestamp: Default::default(),
                     executed_surplus_fee: Some(1.into()),
                 }),
                 owner: H160::from_low_u64_be(1),

--- a/crates/orderbook/src/database/orders.rs
+++ b/crates/orderbook/src/database/orders.rs
@@ -98,7 +98,7 @@ async fn insert_order(order: &Order, ex: &mut PgConnection) -> Result<(), Insert
         cancellation_timestamp: None,
         surplus_fee: match order.metadata.class {
             OrderClass::Limit(LimitOrderClass { surplus_fee, .. }) => {
-                surplus_fee.as_ref().map(u256_to_big_decimal)
+                Some(u256_to_big_decimal(&surplus_fee))
             }
             _ => None,
         },
@@ -106,7 +106,7 @@ async fn insert_order(order: &Order, ex: &mut PgConnection) -> Result<(), Insert
             OrderClass::Limit(LimitOrderClass {
                 surplus_fee_timestamp,
                 ..
-            }) => surplus_fee_timestamp,
+            }) => Some(surplus_fee_timestamp),
             _ => None,
         },
     };

--- a/crates/shared/src/db_order_conversions.rs
+++ b/crates/shared/src/db_order_conversions.rs
@@ -123,11 +123,16 @@ pub fn order_class_from(order: &FullOrderDb) -> OrderClass {
         DbOrderClass::Market => OrderClass::Market,
         DbOrderClass::Liquidity => OrderClass::Liquidity,
         DbOrderClass::Limit => OrderClass::Limit(LimitOrderClass {
-            surplus_fee: order
-                .surplus_fee
-                .as_ref()
-                .map(|fee| big_decimal_to_u256(fee).unwrap()),
-            surplus_fee_timestamp: order.surplus_fee_timestamp,
+            surplus_fee: big_decimal_to_u256(
+                order
+                    .surplus_fee
+                    .as_ref()
+                    .expect("limit orders must have surplus fee set"),
+            )
+            .unwrap(),
+            surplus_fee_timestamp: order
+                .surplus_fee_timestamp
+                .expect("limit orders must have surplus fee timestamp set"),
             executed_surplus_fee: order
                 .executed_surplus_fee
                 .as_ref()

--- a/crates/shared/src/order_validation.rs
+++ b/crates/shared/src/order_validation.rs
@@ -16,8 +16,8 @@ use database::quotes::QuoteKind;
 use ethcontract::{H160, U256};
 use model::{
     order::{
-        BuyTokenDestination, LimitOrderClass, Order, OrderClass, OrderCreation, OrderData,
-        OrderKind, SellTokenSource, BUY_ETH_ADDRESS,
+        BuyTokenDestination, Order, OrderClass, OrderCreation, OrderData, OrderKind,
+        SellTokenSource, BUY_ETH_ADDRESS,
     },
     quote::{OrderQuoteSide, QuoteSigningScheme, SellAmount},
     signature::{hashed_eip712_message, Signature, SigningScheme, VerificationError},
@@ -406,12 +406,7 @@ impl OrderValidating for OrderValidator {
         let class = if self.liquidity_order_owners.contains(&owner) {
             OrderClass::Liquidity
         } else if self.enable_limit_orders && order.data.fee_amount.is_zero() {
-            // intentionally not Default so that we notice if we change the type
-            OrderClass::Limit(LimitOrderClass {
-                surplus_fee: None,
-                surplus_fee_timestamp: None,
-                executed_surplus_fee: None,
-            })
+            OrderClass::Limit(Default::default())
         } else {
             OrderClass::Market
         };

--- a/crates/solver/src/driver.rs
+++ b/crates/solver/src/driver.rs
@@ -385,7 +385,7 @@ impl Driver {
                     let uid = &trade.order.metadata.uid;
                     let reward = rewards.get(uid).copied().unwrap_or(0.);
                     let surplus_fee = match trade.order.metadata.class {
-                        OrderClass::Limit(LimitOrderClass { surplus_fee, .. }) => surplus_fee,
+                        OrderClass::Limit(LimitOrderClass { surplus_fee, .. }) => Some(surplus_fee),
                         _ => None,
                     };
                     // Log in case something goes wrong with storing the rewards in the database.

--- a/crates/solver/src/driver/solver_settlements.rs
+++ b/crates/solver/src/driver/solver_settlements.rs
@@ -132,7 +132,7 @@ mod tests {
     use crate::{settlement::Trade, solver::dummy_arc_solver};
     use chrono::{offset::Utc, DateTime, Duration, Local};
 
-    use model::order::{LimitOrderClass, Order, OrderClass, OrderData, OrderMetadata, OrderUid};
+    use model::order::{Order, OrderClass, OrderData, OrderMetadata, OrderUid};
     use num::BigRational;
 
     use std::ops::Sub;
@@ -221,15 +221,7 @@ mod tests {
 
         let s1 = Settlement::with_default_prices(vec![
             trade(old, 1, OrderClass::Market),
-            trade(
-                recent,
-                2,
-                OrderClass::Limit(LimitOrderClass {
-                    surplus_fee: Some(Default::default()),
-                    surplus_fee_timestamp: Some(Default::default()),
-                    executed_surplus_fee: None,
-                }),
-            ),
+            trade(recent, 2, OrderClass::Limit(Default::default())),
         ]);
         let s2 = Settlement::with_default_prices(vec![
             trade(recent, 3, OrderClass::Market),
@@ -444,11 +436,7 @@ mod tests {
         assert!(!has_user_order(&settlement));
 
         let settlement =
-            Settlement::with_default_prices(vec![order(OrderClass::Limit(LimitOrderClass {
-                surplus_fee: Some(Default::default()),
-                surplus_fee_timestamp: Some(Default::default()),
-                executed_surplus_fee: None,
-            }))]);
+            Settlement::with_default_prices(vec![order(OrderClass::Limit(Default::default()))]);
         assert!(has_user_order(&settlement));
 
         let settlement = Settlement::with_default_prices(vec![order(OrderClass::Liquidity)]);
@@ -465,11 +453,7 @@ mod tests {
 
         let settlement = Settlement::with_default_prices(vec![
             order(OrderClass::Liquidity),
-            order(OrderClass::Limit(LimitOrderClass {
-                surplus_fee: Some(Default::default()),
-                surplus_fee_timestamp: Some(Default::default()),
-                executed_surplus_fee: None,
-            })),
+            order(OrderClass::Limit(Default::default())),
         ]);
         assert!(has_user_order(&settlement));
     }

--- a/crates/solver/src/settlement.rs
+++ b/crates/solver/src/settlement.rs
@@ -1394,7 +1394,7 @@ pub mod tests {
                         },
                         metadata: OrderMetadata {
                             class: OrderClass::Limit(LimitOrderClass {
-                                surplus_fee: Some(1_000_u128.into()),
+                                surplus_fee: 1_000_u128.into(),
                                 ..Default::default()
                             }),
                             ..Default::default()
@@ -1428,7 +1428,7 @@ pub mod tests {
                         },
                         metadata: OrderMetadata {
                             class: OrderClass::Limit(LimitOrderClass {
-                                surplus_fee: Some(1_000_u128.into()),
+                                surplus_fee: 1_000_u128.into(),
                                 ..Default::default()
                             }),
                             ..Default::default()
@@ -1469,7 +1469,7 @@ pub mod tests {
                     },
                     metadata: OrderMetadata {
                         class: OrderClass::Limit(LimitOrderClass {
-                            surplus_fee: Some(1_000_u128.into()),
+                            surplus_fee: 1_000_u128.into(),
                             ..Default::default()
                         }),
                         ..Default::default()


### PR DESCRIPTION
Reverts cowprotocol/services#981

Reverting #981 as the condition that determines whether or not to include an order in the list of pending surplus fee updates requires a non-null surplus fee timestamp, and that PR adds orders with NULL `surplus_fee_timestamp` which cause limit orders to never get updated. This was also not caught by our metrics because they have similar conditions on `surplus_fee_timestamp`.

Reverting for now to unblock barn limit orders.

### Release Notes

The reason this PR is blocked in "Draft" mode is that we get panics from orders with NULL `surplus_fee` that were already added to the orderbook. A correct fix also requires a DB migration to fix the orders that were added with unexpected values since #965 and #981:

```sql
UPDATE orders
SET surplus_fee = 0
WHERE surplus_fee IS NULL
AND class='limit';

UPDATE orders
SET surplus_fee_timestamp = '1970-01-01 00:00:00'::timestamp
WHERE surplus_fee_timestamp IS NULL
AND class='limit';
```