### PR TITLE
Add Swapr Mainnet Liquidity

### DIFF
--- a/crates/contracts/build.rs
+++ b/crates/contracts/build.rs
@@ -230,10 +230,14 @@ fn main() {
             .add_network_str(GNOSIS, "0x1b02dA8Cb0d097eB8D57A175b88c7D8b47997506")
     });
     generate_contract_with_config("SwaprFactory", |builder| {
-        builder.add_network_str(GNOSIS, "0x5D48C95AdfFD4B40c1AAADc4e08fc44117E02179")
+        builder
+            .add_network_str(MAINNET, "0xd34971BaB6E5E356fd250715F5dE0492BB070452")
+            .add_network_str(GNOSIS, "0x5D48C95AdfFD4B40c1AAADc4e08fc44117E02179")
     });
     generate_contract_with_config("SwaprRouter", |builder| {
-        builder.add_network_str(GNOSIS, "0xE43e60736b1cb4a75ad25240E2f9a62Bff65c0C0")
+        builder
+            .add_network_str(MAINNET, "0xb9960d9bca016e9748be75dd52f02188b9d0829f")
+            .add_network_str(GNOSIS, "0xE43e60736b1cb4a75ad25240E2f9a62Bff65c0C0")
     });
     generate_contract("ISwaprPair");
     generate_contract_with_config("UniswapV2Factory", |builder| {

--- a/crates/shared/src/sources.rs
+++ b/crates/shared/src/sources.rs
@@ -39,6 +39,7 @@ pub fn defaults_for_chain(chain_id: u64) -> Result<Vec<BaselineSource>> {
         1 => vec![
             BaselineSource::UniswapV2,
             BaselineSource::SushiSwap,
+            BaselineSource::Swapr,
             BaselineSource::BalancerV2,
             BaselineSource::ZeroEx,
             BaselineSource::UniswapV3,

--- a/crates/shared/src/sources/swapr.rs
+++ b/crates/shared/src/sources/swapr.rs
@@ -17,6 +17,20 @@ mod tests {
     use model::TokenPair;
 
     #[tokio::test]
+    async fn test_create2_mainnet() {
+        let (mainnet_pair_provider, _) = get_liquidity_source(&Mock::new(1).web3()).await.unwrap();
+        let mainnet_pair = TokenPair::new(
+            addr!("a1d65E8fB6e87b60FECCBc582F7f97804B725521"),
+            addr!("C02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2"),
+        )
+        .unwrap();
+        assert_eq!(
+            mainnet_pair_provider.pair_address(&mainnet_pair),
+            addr!("b0Dc4B36e0B4d2e3566D2328F6806EA0B76b4F13")
+        );
+    }
+
+    #[tokio::test]
     async fn test_create2_xdai() {
         let (xdai_pair_provider, _) = get_liquidity_source(&Mock::new(100).web3()).await.unwrap();
         let xdai_pair = TokenPair::new(


### PR DESCRIPTION
This PR adds Swapr liquidity on Mainnet.

Swapr is UniV2 clone from the DXdao which we already supported on Gnosis Chain, so adding support on Mainnet was super easy.

### Test Plan

Added a unit test to check that the pool address matches an existing pool on Mainnet.

Also ran the solver locally with just Swapr liquidity and [generated a settlement simulation](https://dashboard.tenderly.co/gp-v2/staging/simulator/3338c8c5-a982-49c2-a02e-6f42466a43da). Note that the transferred amounts are exact to the atom, so it looks like the pool computation is working as expected (Swapr has different fees per pool).
