### PR TITLE
Fix not filtering out already solved orders for limit order quoting

### DIFF
--- a/crates/database/src/orders.rs
+++ b/crates/database/src/orders.rs
@@ -551,13 +551,11 @@ pub fn user_orders<'a>(
         .fetch(ex)
 }
 
-pub fn solvable_orders(
-    ex: &mut PgConnection,
-    min_valid_to: i64,
-    min_surplus_fee_timestamp: DateTime<Utc>,
-) -> BoxStream<'_, Result<FullOrder, sqlx::Error>> {
-    #[rustfmt::skip]
-    const QUERY: &str = const_format::concatcp!(
+/// The base solvable orders query used in specialized queries. Parametrized by valid_to.
+///
+/// Does not take limit order surplus fee into account.
+#[rustfmt::skip]
+const OPEN_ORDERS: &str = const_format::concatcp!(
 "SELECT * FROM ( ",
     "SELECT ", ORDERS_SELECT,
     " FROM ", ORDERS_FROM,
@@ -571,9 +569,18 @@ WHERE
         WHEN 'buy' THEN sum_buy < buy_amount
     END AND
     (NOT invalidated) AND
-    (NOT presignature_pending) AND
-    (class <> 'limit' OR (surplus_fee IS NOT NULL AND surplus_fee_timestamp > $2));
+    (NOT presignature_pending)
 "#
+);
+
+pub fn solvable_orders(
+    ex: &mut PgConnection,
+    min_valid_to: i64,
+    min_surplus_fee_timestamp: DateTime<Utc>,
+) -> BoxStream<'_, Result<FullOrder, sqlx::Error>> {
+    const QUERY: &str = const_format::concatcp!(
+        OPEN_ORDERS,
+        " AND (class <> 'limit' OR (surplus_fee IS NOT NULL AND surplus_fee_timestamp > $2))"
     );
     sqlx::query_as(QUERY)
         .bind(min_valid_to)
@@ -589,6 +596,8 @@ FROM settlements
     sqlx::query_scalar(QUERY).fetch_one(ex).await
 }
 
+/// Return valid limit orders with outdated surplus fee.
+///
 /// The ordering by most outdated in combination with updating the timestamp when updating the fee
 /// fails is important. It ensures that we cannot get stuck on orders for which the update process
 /// keeps failing.
@@ -599,18 +608,11 @@ pub fn limit_orders_with_most_outdated_fees(
     limit: i64,
 ) -> BoxStream<'_, Result<FullOrder, sqlx::Error>> {
     const QUERY: &str = const_format::concatcp!(
-        "SELECT * FROM (",
-        "SELECT ",
-        ORDERS_SELECT,
-        " FROM ",
-        ORDERS_FROM,
-        " WHERE o.valid_to >= $1 ",
-        "AND o.class = 'limit' ",
-        "AND COALESCE(o.surplus_fee_timestamp, 'epoch') < $2 ",
-        "ORDER BY o.surplus_fee_timestamp ASC NULLS FIRST",
-        ") AS o ",
-        "WHERE NOT o.invalidated ",
-        "LIMIT $3 ",
+        OPEN_ORDERS,
+        " AND class = 'limit'",
+        " AND COALESCE(surplus_fee_timestamp, 'epoch') < $2",
+        " ORDER BY surplus_fee_timestamp ASC NULLS FIRST",
+        " LIMIT $3"
     );
     sqlx::query_as(QUERY)
         .bind(min_valid_to)
@@ -626,16 +628,11 @@ pub async fn count_limit_orders_by_owner(
     owner: &Address,
 ) -> Result<i64, sqlx::Error> {
     const QUERY: &str = const_format::concatcp!(
-        "SELECT COUNT(*) FROM (",
-        "SELECT ",
-        ORDERS_SELECT,
-        " FROM ",
-        ORDERS_FROM,
-        " WHERE o.valid_to >= $1 ",
-        "AND o.class = 'limit' ",
-        "AND o.owner = $2 ",
-        ") AS o ",
-        "WHERE NOT o.invalidated",
+        "SELECT COUNT (*) FROM (",
+        OPEN_ORDERS,
+        " AND class = 'limit'",
+        " AND owner = $2",
+        " ) AS subquery"
     );
     sqlx::query_scalar(QUERY)
         .bind(min_valid_to)
@@ -673,20 +670,16 @@ pub async fn update_limit_order_fees(
     Ok(())
 }
 
+/// Count the number of valid limit orders.
 pub async fn count_limit_orders(
     ex: &mut PgConnection,
     min_valid_to: i64,
 ) -> Result<i64, sqlx::Error> {
     const QUERY: &str = const_format::concatcp!(
-        "SELECT COUNT(*) FROM (",
-        "SELECT ",
-        ORDERS_SELECT,
-        " FROM ",
-        ORDERS_FROM,
-        " WHERE o.valid_to >= $1 ",
-        "AND o.class = 'limit' ",
-        ") AS o ",
-        "WHERE NOT o.invalidated",
+        "SELECT COUNT (*) FROM (",
+        OPEN_ORDERS,
+        " AND class = 'limit'",
+        ") AS subquery"
     );
     sqlx::query_scalar(QUERY)
         .bind(min_valid_to)
@@ -694,22 +687,19 @@ pub async fn count_limit_orders(
         .await
 }
 
+/// Count the number of valid limit orders with outdated fee as would be returned by
+/// `limit_orders_with_most_outdated_fees`.
 pub async fn count_limit_orders_with_outdated_fees(
     ex: &mut PgConnection,
     max_fee_timestamp: DateTime<Utc>,
     min_valid_to: i64,
 ) -> Result<i64, sqlx::Error> {
     const QUERY: &str = const_format::concatcp!(
-        "SELECT COUNT(*) FROM (",
-        "SELECT ",
-        ORDERS_SELECT,
-        " FROM ",
-        ORDERS_FROM,
-        " WHERE o.valid_to >= $1 ",
-        "AND o.class = 'limit' ",
-        "AND COALESCE(o.surplus_fee_timestamp, 'epoch') < $2 ",
-        ") AS o ",
-        "WHERE NOT o.invalidated",
+        "SELECT COUNT (*) FROM (",
+        OPEN_ORDERS,
+        " AND class = 'limit'",
+        " AND COALESCE(surplus_fee_timestamp, 'epoch') < $2",
+        ") AS subquery"
     );
     sqlx::query_scalar(QUERY)
         .bind(min_valid_to)
@@ -1645,6 +1635,8 @@ mod tests {
                 valid_to: 3,
                 surplus_fee: Some(0.into()),
                 surplus_fee_timestamp: Some(timestamp - chrono::Duration::seconds(1)),
+                sell_amount: 1.into(),
+                buy_amount: 1.into(),
                 ..Default::default()
             },
         )
@@ -1659,6 +1651,8 @@ mod tests {
                 valid_to: 1,
                 surplus_fee: Some(0.into()),
                 surplus_fee_timestamp: Some(Default::default()),
+                sell_amount: 1.into(),
+                buy_amount: 1.into(),
                 ..Default::default()
             },
         )
@@ -1674,6 +1668,8 @@ mod tests {
                 cancellation_timestamp: Some(Utc::now()),
                 surplus_fee: Some(0.into()),
                 surplus_fee_timestamp: Some(Default::default()),
+                sell_amount: 1.into(),
+                buy_amount: 1.into(),
                 ..Default::default()
             },
         )
@@ -1688,6 +1684,8 @@ mod tests {
                 valid_to: 3,
                 surplus_fee: Some(0.into()),
                 surplus_fee_timestamp: Some(timestamp),
+                sell_amount: 1.into(),
+                buy_amount: 1.into(),
                 ..Default::default()
             },
         )
@@ -1702,6 +1700,8 @@ mod tests {
                 valid_to: 3,
                 surplus_fee: None,
                 surplus_fee_timestamp: None,
+                sell_amount: 1.into(),
+                buy_amount: 1.into(),
                 ..Default::default()
             },
         )
@@ -1716,6 +1716,8 @@ mod tests {
                 valid_to: 3,
                 surplus_fee: None,
                 surplus_fee_timestamp: Some(timestamp),
+                sell_amount: 1.into(),
+                buy_amount: 1.into(),
                 ..Default::default()
             },
         )
@@ -1727,6 +1729,8 @@ mod tests {
             &Order {
                 uid: ByteArray([7; 56]),
                 valid_to: 3,
+                sell_amount: 1.into(),
+                buy_amount: 1.into(),
                 ..Default::default()
             },
         )
@@ -1741,6 +1745,25 @@ mod tests {
         assert_eq!(orders.len(), 2);
         assert_eq!(orders[0].uid.0, [5; 56]);
         assert_eq!(orders[1].uid.0, [1; 56]);
+
+        // Invalidate one of the orders through a trade.
+        crate::events::insert_trade(
+            &mut db,
+            &EventIndex::default(),
+            &Trade {
+                order_uid: orders[0].uid,
+                sell_amount_including_fee: 1.into(),
+                buy_amount: 1.into(),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+        let orders: Vec<_> = limit_orders_with_most_outdated_fees(&mut db, timestamp, 2, 100)
+            .try_collect()
+            .await
+            .unwrap();
+        assert_eq!(orders.len(), 1);
     }
 
     #[tokio::test]
@@ -1798,6 +1821,8 @@ mod tests {
                 valid_to: 3,
                 surplus_fee: Some(0.into()),
                 surplus_fee_timestamp: Some(Default::default()),
+                sell_amount: 1.into(),
+                buy_amount: 1.into(),
                 ..Default::default()
             },
         )
@@ -1812,6 +1837,8 @@ mod tests {
                 valid_to: 1,
                 surplus_fee: Some(0.into()),
                 surplus_fee_timestamp: Some(Default::default()),
+                sell_amount: 1.into(),
+                buy_amount: 1.into(),
                 ..Default::default()
             },
         )
@@ -1827,6 +1854,8 @@ mod tests {
                 cancellation_timestamp: Some(Utc::now()),
                 surplus_fee: Some(0.into()),
                 surplus_fee_timestamp: Some(Default::default()),
+                sell_amount: 1.into(),
+                buy_amount: 1.into(),
                 ..Default::default()
             },
         )
@@ -1841,6 +1870,9 @@ mod tests {
                 valid_to: 3,
                 surplus_fee: Some(0.into()),
                 surplus_fee_timestamp: Some(timestamp),
+                owner: ByteArray([7u8; 20]),
+                sell_amount: 1.into(),
+                buy_amount: 1.into(),
                 ..Default::default()
             },
         )
@@ -1852,6 +1884,8 @@ mod tests {
             &Order {
                 uid: ByteArray([5; 56]),
                 valid_to: 3,
+                sell_amount: 1.into(),
+                buy_amount: 1.into(),
                 ..Default::default()
             },
         )
@@ -1861,6 +1895,12 @@ mod tests {
         assert_eq!(count_limit_orders(&mut db, 2).await.unwrap(), 2);
         assert_eq!(
             count_limit_orders_with_outdated_fees(&mut db, timestamp, 2)
+                .await
+                .unwrap(),
+            1
+        );
+        assert_eq!(
+            count_limit_orders_by_owner(&mut db, 2, &ByteArray([7u8; 20]))
                 .await
                 .unwrap(),
             1


### PR DESCRIPTION
The queries dealing with limit orders are not taking into account all the conditions that can cause an order to be unsolvable. Most importantly the "already settled" condition was missing.

In this PR I factor out the solvable orders query so that it can be reused by the solvable_orders function and the limit order related queries. This ensures that both work on the same conditions. Reusing this query is becoming hairy. If these queries diverge more I would stop reusing and copy paste instead.

After merging we should look at the speed of the changed queries to see if there is problematic performance.

### Test Plan

CI, existing and adjusted unit tests