### PR TITLE
Include Uninternalized Settlement In Solver Competition Data

### DIFF
--- a/crates/model/src/solver_competition.rs
+++ b/crates/model/src/solver_competition.rs
@@ -1,5 +1,6 @@
 use crate::{
     auction::AuctionId,
+    bytes_hex::BytesHex,
     order::OrderUid,
     u256_decimal::{self, DecimalU256},
 };
@@ -78,6 +79,9 @@ pub struct SolverSettlement {
     pub orders: Vec<Order>,
     #[serde(with = "crate::bytes_hex")]
     pub call_data: Vec<u8>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde_as(as = "Option<BytesHex>")]
+    pub uninternalized_call_data: Option<Vec<u8>>,
 }
 
 #[derive(Clone, Debug, Default, Deserialize, Serialize, PartialEq)]
@@ -152,6 +156,7 @@ mod tests {
                         }
                     ],
                     "callData": "0x13",
+                    "uninternalizedCallData": "0x1314",
                 },
             ],
         });
@@ -193,6 +198,7 @@ mod tests {
                         executed_amount: 12.into(),
                     }],
                     call_data: vec![0x13],
+                    uninternalized_call_data: Some(vec![0x13, 0x14]),
                 }],
             },
         };

--- a/crates/orderbook/src/database/solver_competition.rs
+++ b/crates/orderbook/src/database/solver_competition.rs
@@ -120,6 +120,7 @@ mod tests {
                     clearing_prices: [Default::default()].into_iter().collect(),
                     orders: vec![Default::default()],
                     call_data: vec![1, 2],
+                    uninternalized_call_data: Some(vec![1, 2, 3, 4]),
                 }],
             },
             executions: Default::default(),

--- a/crates/solver/src/driver.rs
+++ b/crates/solver/src/driver.rs
@@ -365,6 +365,11 @@ impl Driver {
                             .clone()
                             .encode(InternalizationStrategy::SkipInternalizableInteraction), // rating is done with internalizations
                     ),
+                    uninternalized_call_data: rated_settlement
+                        .settlement
+                        .clone()
+                        .encode_uninternalized_if_different()
+                        .map(settlement_simulation::call_data),
                 })
                 .collect(),
         };

--- a/crates/solver/src/settlement.rs
+++ b/crates/solver/src/settlement.rs
@@ -453,6 +453,17 @@ impl Settlement {
     pub fn encode(self, internalization_strategy: InternalizationStrategy) -> EncodedSettlement {
         self.encoder.finish(internalization_strategy)
     }
+
+    pub fn encode_uninternalized_if_different(self) -> Option<EncodedSettlement> {
+        if self.encoder.contains_internalized_interactions() {
+            Some(
+                self.encoder
+                    .finish(InternalizationStrategy::EncodeAllInteractions),
+            )
+        } else {
+            None
+        }
+    }
 }
 
 // The difference between what you were willing to sell (executed_amount * limit_price)

--- a/crates/solver/src/settlement/settlement_encoder.rs
+++ b/crates/solver/src/settlement/settlement_encoder.rs
@@ -499,6 +499,12 @@ impl SettlementEncoder {
         self.sort_tokens_and_update_indices();
     }
 
+    pub fn contains_internalized_interactions(&self) -> bool {
+        self.execution_plan
+            .iter()
+            .any(|(_, internalizable)| *internalizable)
+    }
+
     pub fn finish(
         mut self,
         internalization_strategy: InternalizationStrategy,


### PR DESCRIPTION
Fixes https://github.com/cowprotocol/services/issues/604

This PR adds a new `uniniternalized_call_data` field to the settlement competition debug JSON blob that gets uploaded to the database.

The motivation behind this change is that, currently, the only way for external solvers to inspect internalized data from their competition is to ask us to look it up in the logs. This is not ideal.

For this change, I made the `uniniternalized_call_data` **only get added if it different from `call_data`**. The reason for this is database size considerations.

### Test Plan

Rust compiler. Serialization test.
