### PR TITLE
Make Auction Orders Log More Grep-able

### DIFF
--- a/crates/solver/src/driver.rs
+++ b/crates/solver/src/driver.rs
@@ -262,7 +262,8 @@ impl Driver {
                 }
             })
             .collect::<Vec<_>>();
-        tracing::info!(?orders, "got {} orders", orders.len());
+
+        tracing::info!(count =% orders.len(), ?orders, "got orders");
         self.metrics.orders_fetched(&orders);
 
         let external_prices =


### PR DESCRIPTION
When building log filters for getting the list of order UIDs considered in the auction, the fact that the number (which is dynamic) appears in the middle of the log (`got N orders`) makes it less grep-able.

```
2022-12-22T13:25:38.247Z  INFO auction{id=5558592 run=7146}: solver::driver: got 2 orders orders=[Limit Order Limit(0x6d8554bb8cec07dcfb840a54cd5f6f70e0e130b69ce19c2dbcda7a3aecb796074e8fcaf981631e23673bf85f423cf320888f7c4f63a4e826), Limit Order Limit(0x1411ecf77dc6dacd730d8c9034972e29def1dbd51c72e5edfc5f3306e4bd618f5b0abe214ab7875562adee331deff0fe1912fe4263a9d72e)]
```

### Test Plan

It builds, no logic changes just a minor log change.

Run the solver and see the new message in all its glory:
```
2022-12-22T13:53:32.865Z  INFO auction{id=5559413 run=0}: solver::driver: got orders count=2 orders=[Limit Order Limit(0x6d8554bb8cec07dcfb840a54cd5f6f70e0e130b69ce19c2dbcda7a3aecb796074e8fcaf981631e23673bf85f423cf320888f7c4f63a4e826), Limit Order Limit(0x1411ecf77dc6dacd730d8c9034972e29def1dbd51c72e5edfc5f3306e4bd618f5b0abe214ab7875562adee331deff0fe1912fe4263a9d72e)]
```
