### PR TITLE
Make `execution_plan` Mandatory for Custom Interactions Again

### DIFF
--- a/crates/shared/src/http_solver/model.rs
+++ b/crates/shared/src/http_solver/model.rs
@@ -159,8 +159,7 @@ pub struct InteractionData {
     ///
     /// `AMM -> GPv2Settlement`
     pub outputs: Vec<TokenAmount>,
-    // TODO remove Option once all external solvers conform to sending exec plans instead of null.
-    pub exec_plan: Option<ExecutionPlan>,
+    pub exec_plan: ExecutionPlan,
     pub cost: Option<TokenAmount>,
 }
 
@@ -188,26 +187,6 @@ pub struct SettledBatchAuctionModel {
     #[serde(default)]
     pub submitter: SubmissionPreference,
     pub metadata: Option<SettledBatchAuctionMetadataModel>,
-}
-
-impl SettledBatchAuctionModel {
-    // TODO remove this function once all solvers conform to sending the
-    // execution plan for their custom interactions!
-    pub fn add_missing_execution_plans(&mut self) {
-        for (index, interaction) in self.interaction_data.iter_mut().enumerate() {
-            if interaction.exec_plan.is_none() {
-                // if no exec plan is provided, convert to the default exec plan by setting the
-                // position coordinate to the position of the exec plan in the interactions vector
-                interaction.exec_plan = Some(ExecutionPlan {
-                    coordinates: ExecutionPlanCoordinatesModel {
-                        sequence: u32::MAX,
-                        position: index as u32,
-                    },
-                    internal: false,
-                })
-            }
-        }
-    }
 }
 
 #[derive(Clone, Debug, Serialize, Default)]
@@ -912,13 +891,13 @@ mod tests {
                         amount: 3000.into(),
                     }
                 ],
-                exec_plan: Some(ExecutionPlan {
+                exec_plan: ExecutionPlan {
                     coordinates: ExecutionPlanCoordinatesModel {
                         sequence: 0,
                         position: 0,
                     },
                     internal: true,
-                }),
+                },
                 cost: Some(TokenAmount {
                     amount: 1.into(),
                     token: addr!("eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee")

--- a/crates/solver/src/solver/http_solver.rs
+++ b/crates/solver/src/solver/http_solver.rs
@@ -454,13 +454,7 @@ fn non_bufferable_tokens_used(
 ) -> BTreeSet<H160> {
     interactions
         .iter()
-        .filter(|interaction| {
-            interaction
-                .exec_plan
-                .as_ref()
-                .map(|plan| plan.internal)
-                .unwrap_or_default()
-        })
+        .filter(|interaction| interaction.exec_plan.internal)
         .flat_map(|interaction| &interaction.inputs)
         .filter(|input| !market_makable_token_list.contains(&input.token))
         .map(|input| input.token)
@@ -519,8 +513,7 @@ impl Solver for HttpSolver {
         let timeout = deadline
             .checked_duration_since(Instant::now())
             .context("no time left to send request")?;
-        let mut settled = self.solver.solve(&model, timeout).await?;
-        settled.add_missing_execution_plans();
+        let settled = self.solver.solve(&model, timeout).await?;
 
         tracing::debug!(
             "Solution received from http solver {} (json):\n{:}",
@@ -993,10 +986,10 @@ mod tests {
 
         let interactions = vec![InteractionData {
             inputs: vec![token_amount],
-            exec_plan: Some(ExecutionPlan {
+            exec_plan: ExecutionPlan {
                 internal: true,
                 ..Default::default()
-            }),
+            },
             ..Default::default()
         }];
 
@@ -1019,10 +1012,10 @@ mod tests {
 
         let interactions = vec![InteractionData {
             inputs: vec![token_amount],
-            exec_plan: Some(ExecutionPlan {
+            exec_plan: ExecutionPlan {
                 internal: true,
                 ..Default::default()
-            }),
+            },
             ..Default::default()
         }];
 
@@ -1045,10 +1038,10 @@ mod tests {
 
         let interactions = vec![InteractionData {
             inputs: vec![token_amount],
-            exec_plan: Some(ExecutionPlan {
+            exec_plan: ExecutionPlan {
                 internal: false,
                 ..Default::default()
-            }),
+            },
             ..Default::default()
         }];
 

--- a/crates/solver/src/solver/http_solver/settlement.rs
+++ b/crates/solver/src/solver/http_solver/settlement.rs
@@ -59,7 +59,7 @@ impl Execution {
     fn execution_plan(&self) -> Option<&ExecutionPlan> {
         match self {
             Execution::Amm(executed_amm) => Some(&executed_amm.exec_plan),
-            Execution::CustomInteraction(interaction) => interaction.exec_plan.as_ref(),
+            Execution::CustomInteraction(interaction) => Some(&interaction.exec_plan),
             Execution::LimitOrder(order) => order.exec_plan.as_ref(),
         }
     }
@@ -146,7 +146,7 @@ impl From<ConversionError> for anyhow::Error {
 }
 
 #[derive(Clone, Debug)]
-#[cfg_attr(test, derive(PartialEq))]
+#[cfg_attr(test, derive(PartialEq, Default))]
 struct ExecutedLimitOrder {
     order: LimitOrder,
     executed_buy_amount: U256,
@@ -1056,13 +1056,13 @@ mod tests {
             call_data: Vec::new(),
             inputs: vec![],
             outputs: vec![],
-            exec_plan: Some(ExecutionPlan {
+            exec_plan: ExecutionPlan {
                 coordinates: ExecutionPlanCoordinatesModel {
                     sequence: 1u32,
                     position: 1u32,
                 },
                 internal: false,
-            }),
+            },
             cost: None,
         }];
         let orders = vec![ExecutedLimitOrder {
@@ -1170,10 +1170,20 @@ mod tests {
         .is_err());
     }
 
-    fn interaction_with_coordinate(
+    fn interaction_with_coordinate(coordinates: ExecutionPlanCoordinatesModel) -> Execution {
+        Execution::CustomInteraction(Box::new(InteractionData {
+            exec_plan: ExecutionPlan {
+                coordinates,
+                ..Default::default()
+            },
+            ..Default::default()
+        }))
+    }
+
+    fn limit_order_with_coordinate(
         coordinates: Option<ExecutionPlanCoordinatesModel>,
     ) -> Execution {
-        Execution::CustomInteraction(Box::new(InteractionData {
+        Execution::LimitOrder(Box::new(ExecutedLimitOrder {
             exec_plan: coordinates.map(|coordinates| ExecutionPlan {
                 coordinates,
                 ..Default::default()
@@ -1185,15 +1195,20 @@ mod tests {
     #[test]
     pub fn duplicate_coordinates_false() {
         let executions = vec![
-            interaction_with_coordinate(None),
-            interaction_with_coordinate(Some(ExecutionPlanCoordinatesModel {
+            limit_order_with_coordinate(None),
+            interaction_with_coordinate(ExecutionPlanCoordinatesModel {
                 sequence: 0,
                 position: 0,
+            }),
+            limit_order_with_coordinate(None),
+            limit_order_with_coordinate(Some(ExecutionPlanCoordinatesModel {
+                sequence: 0,
+                position: 2,
             })),
-            interaction_with_coordinate(Some(ExecutionPlanCoordinatesModel {
+            interaction_with_coordinate(ExecutionPlanCoordinatesModel {
                 sequence: 0,
                 position: 1,
-            })),
+            }),
         ];
         assert!(!duplicate_coordinates(&executions));
     }
@@ -1201,15 +1216,20 @@ mod tests {
     #[test]
     pub fn duplicate_coordinates_true() {
         let executions = vec![
-            interaction_with_coordinate(None),
-            interaction_with_coordinate(Some(ExecutionPlanCoordinatesModel {
+            limit_order_with_coordinate(None),
+            interaction_with_coordinate(ExecutionPlanCoordinatesModel {
                 sequence: 0,
                 position: 0,
+            }),
+            limit_order_with_coordinate(None),
+            limit_order_with_coordinate(Some(ExecutionPlanCoordinatesModel {
+                sequence: 0,
+                position: 1,
             })),
-            interaction_with_coordinate(Some(ExecutionPlanCoordinatesModel {
+            interaction_with_coordinate(ExecutionPlanCoordinatesModel {
                 sequence: 0,
                 position: 0,
-            })),
+            }),
         ];
         assert!(duplicate_coordinates(&executions));
     }


### PR DESCRIPTION
This PR re-applies https://github.com/cowprotocol/services/pull/928.

We needed to **temporarily** disable it because it would break price estimation. This should be merged once the HTTP solver price estimation is changed to include execution plans.