### PR TITLE
[Easy] rename part of the ethflow data api

### DIFF
--- a/crates/e2e/tests/e2e/eth_flow.rs
+++ b/crates/e2e/tests/e2e/eth_flow.rs
@@ -441,7 +441,7 @@ async fn test_order_parameters(
     assert_eq!(
         response.metadata.onchain_order_data,
         Some(OnchainOrderData {
-            user: *owner,
+            sender: *owner,
             placement_error: None,
         })
     );

--- a/crates/model/src/order.rs
+++ b/crates/model/src/order.rs
@@ -549,7 +549,7 @@ pub enum OnchainOrderPlacementError {
 #[derivative(Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct OnchainOrderData {
-    pub user: H160,
+    pub sender: H160,
     pub placement_error: Option<OnchainOrderPlacementError>,
 }
 

--- a/crates/orderbook/openapi.yml
+++ b/crates/orderbook/openapi.yml
@@ -641,7 +641,6 @@ components:
           type: integer
       required:
         - refundTxHash
-        - isRefunded
         - userValidTo
     FeeInformation:
       description: |

--- a/crates/orderbook/src/database/orders.rs
+++ b/crates/orderbook/src/database/orders.rs
@@ -351,7 +351,7 @@ fn full_order_into_model_order(order: FullOrder) -> Result<Order> {
     let class = order_class_from(&order);
     let onchain_placement_error = onchain_order_placement_error_from(&order);
     let onchain_order_data = onchain_user.map(|onchain_user| OnchainOrderData {
-        user: onchain_user,
+        sender: onchain_user,
         placement_error: onchain_placement_error,
     });
     let metadata = OrderMetadata {

--- a/crates/shared/src/db_order_conversions.rs
+++ b/crates/shared/src/db_order_conversions.rs
@@ -35,7 +35,7 @@ pub fn full_order_into_model_order(order: database::orders::FullOrder) -> Result
     let class = order_class_from(&order);
     let onchain_placement_error = onchain_order_placement_error_from(&order);
     let onchain_order_data = onchain_user.map(|onchain_user| OnchainOrderData {
-        user: onchain_user,
+        sender: onchain_user,
         placement_error: onchain_placement_error,
     });
     let metadata = OrderMetadata {


### PR DESCRIPTION
There was a tiny inconsitency between the openapi spec and the sent data. We wanted to send the user field sender instead of user.
