### PR TITLE
Missing pools update is not maintenance error

### DIFF
--- a/crates/shared/src/sources/uniswap_v3/pool_fetching.rs
+++ b/crates/shared/src/sources/uniswap_v3/pool_fetching.rs
@@ -452,7 +452,7 @@ impl Maintaining for UniswapV3PoolFetcher {
             self.checkpoint.update_missing_pools()
         );
         result1?;
-        // since failure in updating the missing pools is not critical for UniswapV3PoolFetcher maintenance 
+        // since failure in updating the missing pools is not critical for UniswapV3PoolFetcher maintenance
         // and future liquidity fetch calls, then there is no need to return error
         if let Err(err) = result2 {
             tracing::warn!(

--- a/crates/shared/src/sources/uniswap_v3/pool_fetching.rs
+++ b/crates/shared/src/sources/uniswap_v3/pool_fetching.rs
@@ -451,7 +451,15 @@ impl Maintaining for UniswapV3PoolFetcher {
             self.events.run_maintenance(),
             self.checkpoint.update_missing_pools()
         );
-        result1.and(result2)?;
+        result1?;
+        // since failure in updating the missing pools is not critical for UniswapV3PoolFetcher maintenance 
+        // and future liquidity fetch calls, then there is no need to return error
+        if let Err(err) = result2 {
+            tracing::warn!(
+                "UniswapV3PoolFetcher failed to update missing pools: {}",
+                err
+            );
+        }
         self.move_checkpoint_to_future().await
     }
 


### PR DESCRIPTION
Fixes https://github.com/cowprotocol/services/issues/1020

UniswapV3PoolFetcher does two things in a single maintenance run:
1. Update events for already cached pools.
2. Fetch pools state checkpoint for non-cached pools (this is where the problematic subgraph call is used).

This PR lowers severity of error for task (2). In case of error during missing pools update, we just log the error.
