### PR TITLE
Update hardhat config for docker testing container

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -74,19 +74,7 @@ jobs:
       - name: Setup Hardhat
         working-directory: ${{ env.HARDHAT_PATH_ }}
         run: |
-          cat > hardhat.config.js <<EOF
-          module.exports = {
-            networks: {
-              hardhat: {
-                initialBaseFeePerGas: 0,
-                initialDate: "2000-01-01T00:00:00.000+00:00",
-                accounts: {
-                  accountsBalance: "1000000000000000000000000"
-                },
-              },
-            },
-          };
-          EOF
+          cp ${{ github.workspace }}/docker/hardhat/hardhat.config.js hardhat.config.js
           node_modules/.bin/hardhat node &
       - name: Setup Database
         run: |

--- a/docker/hardhat/hardhat.config.js
+++ b/docker/hardhat/hardhat.config.js
@@ -2,6 +2,7 @@ module.exports = {
     networks: {
         hardhat: {
             initialBaseFeePerGas: 0,
+            initialDate: "2000-01-01T00:00:00.000+00:00",
             accounts: {
                 accountsBalance: "1000000000000000000000000"
             }


### PR DESCRIPTION
While working on a patch I wanted to run e2e tests locally but they failed. After some investigation I saw that the hardhat config file we initialize the docker testing container with differs slightly from the hardhat config we use for our CI tests.
The difference was that only the CI config sets the `initialDate` to enable time travel shenanigans required for eth flow e2e tests.

Edit: Instead of keeping the github workflow file and the `hardhat.config.js` file in sync I made the github workflow file import the other file. That means all the hardhat changes required for our e2e test should be added to [hardhat.config.js](https://github.com/cowprotocol/services/blob/main/docker/hardhat/hardhat.config.js) from now on.

### Test Plan
Ran e2e test locally using the updated docker container.
e2e tests in CI still work.
