### PR TITLE
Fetch missing native prices in background task

### DIFF
--- a/crates/autopilot/src/solvable_orders.rs
+++ b/crates/autopilot/src/solvable_orders.rs
@@ -788,10 +788,12 @@ mod tests {
         let mut native_price_estimator = MockNativePriceEstimating::new();
         native_price_estimator
             .expect_estimate_native_prices()
+            .times(1)
             .withf(move |tokens| *tokens == [token1])
             .returning(|_| futures::stream::iter([(0, Ok(2.))].into_iter()).boxed());
         native_price_estimator
             .expect_estimate_native_prices()
+            .times(1)
             .withf(move |tokens| *tokens == [token2])
             .returning(|_| {
                 futures::stream::iter([(0, Err(PriceEstimationError::NoLiquidity))].into_iter())
@@ -799,10 +801,12 @@ mod tests {
             });
         native_price_estimator
             .expect_estimate_native_prices()
+            .times(1)
             .withf(move |tokens| *tokens == [token3])
             .returning(|_| futures::stream::iter([(0, Ok(0.25))].into_iter()).boxed());
         native_price_estimator
             .expect_estimate_native_prices()
+            .times(1)
             .withf(move |tokens| *tokens == [token4])
             .returning(|_| futures::stream::iter([(0, Ok(0.))].into_iter()).boxed());
 

--- a/crates/autopilot/src/solvable_orders.rs
+++ b/crates/autopilot/src/solvable_orders.rs
@@ -20,7 +20,7 @@ use shared::{
     signature_validator::{SignatureCheck, SignatureValidating},
 };
 use std::{
-    collections::{BTreeMap, BTreeSet, HashMap, HashSet},
+    collections::{BTreeMap, HashMap, HashSet},
     iter::FromIterator,
     sync::{Arc, Mutex, Weak},
     time::Duration,
@@ -452,12 +452,10 @@ fn get_orders_with_native_prices(
     mut orders: Vec<Order>,
     native_price_estimator: &CachingNativePriceEstimator,
 ) -> (Vec<Order>, BTreeMap<H160, U256>) {
-    // Collect traded tokens while giving market orders a higher priority.
-    itertools::partition(&mut orders, |o| o.metadata.class == OrderClass::Market);
     let traded_tokens = orders
         .iter()
         .flat_map(|order| [order.data.sell_token, order.data.buy_token])
-        .collect::<BTreeSet<_>>()
+        .collect::<HashSet<_>>()
         .into_iter()
         .collect::<Vec<_>>();
 

--- a/crates/autopilot/src/solvable_orders.rs
+++ b/crates/autopilot/src/solvable_orders.rs
@@ -20,7 +20,7 @@ use shared::{
     signature_validator::{SignatureCheck, SignatureValidating},
 };
 use std::{
-    collections::{BTreeMap, HashMap, HashSet},
+    collections::{BTreeMap, BTreeSet, HashMap, HashSet},
     iter::FromIterator,
     sync::{Arc, Mutex, Weak},
     time::Duration,
@@ -452,10 +452,12 @@ fn get_orders_with_native_prices(
     mut orders: Vec<Order>,
     native_price_estimator: &CachingNativePriceEstimator,
 ) -> (Vec<Order>, BTreeMap<H160, U256>) {
+    // Collect traded tokens while giving market orders a higher priority.
+    itertools::partition(&mut orders, |o| o.metadata.class == OrderClass::Market);
     let traded_tokens = orders
         .iter()
         .flat_map(|order| [order.data.sell_token, order.data.buy_token])
-        .collect::<HashSet<_>>()
+        .collect::<BTreeSet<_>>()
         .into_iter()
         .collect::<Vec<_>>();
 

--- a/crates/autopilot/src/solvable_orders.rs
+++ b/crates/autopilot/src/solvable_orders.rs
@@ -814,7 +814,7 @@ mod tests {
             None,
         );
 
-        // We'll have no native prices in this call. But this call will spawns a background task
+        // We'll have no native prices in this call. But this call will spawn a background task
         // fetching native prices so we'll have them in the next call.
         let (filtered_orders, prices) =
             get_orders_with_native_prices(orders.clone(), &native_price_estimator).await;

--- a/crates/autopilot/src/solvable_orders.rs
+++ b/crates/autopilot/src/solvable_orders.rs
@@ -817,8 +817,8 @@ mod tests {
             None,
         );
 
-        // We'll have no native prices in this call. But this call will spawn a background task
-        // fetching native prices so we'll have them in the next call.
+        // We'll have no native prices in this call. But this call will cause a background task
+        // to fetch the missing prices so we'll have them in the next call.
         let (filtered_orders, prices) =
             get_orders_with_native_prices(orders.clone(), &native_price_estimator);
         assert!(filtered_orders.is_empty());

--- a/crates/autopilot/src/solvable_orders.rs
+++ b/crates/autopilot/src/solvable_orders.rs
@@ -44,9 +44,6 @@ pub struct Metrics {
     /// Auction filtered orders grouped by class.
     #[metric(labels("reason"))]
     auction_filtered_orders: IntGaugeVec,
-
-    /// Auction errored price estimates.
-    auction_errored_price_estimates: IntCounter,
 }
 
 /// Keeps track and updates the set of currently solvable orders.

--- a/crates/e2e/tests/e2e/services.rs
+++ b/crates/e2e/tests/e2e/services.rs
@@ -35,7 +35,7 @@ use shared::{
     order_validation::{OrderValidPeriodConfiguration, OrderValidator, SignatureConfiguration},
     price_estimation::{
         baseline::BaselinePriceEstimator, native::NativePriceEstimator,
-        sanitized::SanitizedPriceEstimator,
+        native_price_cache::CachingNativePriceEstimator, sanitized::SanitizedPriceEstimator,
     },
     rate_limiter::RateLimiter,
     recent_block_cache::CacheConfig,
@@ -136,10 +136,17 @@ impl OrderbookServices {
             contracts.weth.address(),
             bad_token_detector.clone(),
         ));
-        let native_price_estimator = Arc::new(NativePriceEstimator::new(
+        let native_price_estimator = Box::new(NativePriceEstimator::new(
             price_estimator.clone(),
             contracts.weth.address(),
             1_000_000_000_000_000_000_u128.into(),
+        ));
+        let native_price_estimator = Arc::new(CachingNativePriceEstimator::new(
+            native_price_estimator,
+            Duration::from_secs(10),
+            Duration::from_secs(10),
+            None,
+            None,
         ));
         let quoter = Arc::new(OrderQuoter::new(
             price_estimator.clone(),

--- a/crates/shared/src/price_estimation/factory.rs
+++ b/crates/shared/src/price_estimation/factory.rs
@@ -4,7 +4,7 @@ use super::{
     competition::{CompetitionPriceEstimator, RacingCompetitionPriceEstimator},
     http::HttpPriceEstimator,
     instrumented::InstrumentedPriceEstimator,
-    native::{self, NativePriceEstimating, NativePriceEstimator},
+    native::{self, NativePriceEstimator},
     native_price_cache::CachingNativePriceEstimator,
     oneinch::OneInchPriceEstimator,
     paraswap::ParaswapPriceEstimator,
@@ -321,7 +321,7 @@ impl<'a> PriceEstimatorFactory<'a> {
         &mut self,
         kinds: &[PriceEstimatorType],
         drivers: &[Driver],
-    ) -> Result<Arc<dyn NativePriceEstimating>> {
+    ) -> Result<Arc<CachingNativePriceEstimator>> {
         let mut estimators = self.get_estimators(kinds, |entry| &entry.native)?;
         estimators.append(&mut self.get_external_estimators(drivers, |entry| &entry.native)?);
         let native_estimator = Arc::new(CachingNativePriceEstimator::new(

--- a/crates/shared/src/price_estimation/native_price_cache.rs
+++ b/crates/shared/src/price_estimation/native_price_cache.rs
@@ -84,7 +84,7 @@ impl Inner {
     /// Checks cache for the given tokens one by one. If the price is already cached it gets
     /// returned. If it's not in the cache a new price estimation request gets issued.
     /// We check the cache before each request because they can take a long time and some other
-    /// task might have some requested price in the meantime.
+    /// task might have fetched some requested price in the meantime.
     fn estimate_prices_and_update_cache<'a>(
         &'a self,
         tokens: &'a [H160],

--- a/crates/shared/src/price_estimation/native_price_cache.rs
+++ b/crates/shared/src/price_estimation/native_price_cache.rs
@@ -41,11 +41,8 @@ impl Inner {
             Entry::Occupied(mut entry) => {
                 let entry = entry.get_mut();
                 entry.requested_at = now;
-                if now.saturating_duration_since(entry.updated_at) < *max_age {
-                    Some(entry.price)
-                } else {
-                    None
-                }
+                let is_recent = now.saturating_duration_since(entry.updated_at) < *max_age;
+                is_recent.then_some(entry.price)
             }
             Entry::Vacant(entry) => {
                 // Create an outdated cache entry so the background task keeping the cache warm


### PR DESCRIPTION
This PR tries to optimize how we fetch native prices for the solvable orders.

Currently the approach is to:
1. collect all traded tokens in the solvable orders
2. query their native prices
3. filter out all solvable orders for which we don't have the native prices of the tokens

Step `2` already uses the `CachingNativePriceEstimator` so all the cached prices get returned immediately and we only issue price estimation requests for the uncached prices. In order to not delay the auction creation for too long in case we have too many uncached prices step `2` gets aborted after some time (3.5 seconds). Since estimating a single price can already take 2 seconds and we currently don't do parallel price estimates we can usually only get 2 new prices in the 3.5 seconds. This means by delaying the entire auction by up to 3.5s we might add only a single solvable order in the worst case.
Also note that the price estimation requests get aborted after 3.5 seconds so we can't make additional progress there.

To decrease the auction creation time and keep making progress in the background this PR proposes following change:
1. collect all traded tokens in the solvable orders
2. return the currently cached relevant native prices immediately
3. mark entries of missing prices in the `CachingNativePriceEstimator` such that the existing background task will fetch them during the next maintenance cycles
4. filter out all solvable orders for which we don't have the cached prices of the traded tokens

### Test Plan
Updated existing unit tests.