### PR TITLE
Add metrics for refunder

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2745,6 +2745,7 @@ name = "refunder"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "async-trait",
  "chrono",
  "clap 4.0.8",
  "contracts",
@@ -2752,11 +2753,13 @@ dependencies = [
  "ethcontract",
  "futures",
  "gas-estimation",
+ "global-metrics",
  "lazy_static",
  "model",
  "number-conversions",
  "primitive-types 0.10.1",
  "prometheus",
+ "prometheus-metric-storage",
  "shared",
  "sqlx",
  "tokio",

--- a/crates/refunder/Cargo.toml
+++ b/crates/refunder/Cargo.toml
@@ -7,21 +7,24 @@ license = "MIT OR Apache-2.0"
 
 [dependencies]
 anyhow = { workspace = true }
+async-trait = { workspace = true }
 chrono = { workspace = true }
 clap = { workspace = true }
 contracts  = { path = "../contracts" }
 database = { path = "../database" }
 ethcontract = { workspace = true }
-gas-estimation = { workspace = true }
 futures = {workspace = true}
-number-conversions = { path = "../number-conversions" }
+gas-estimation = { workspace = true }
+global-metrics = { path = "../global-metrics" }
 lazy_static = { workspace = true }
 model = { path = "../model" }
+number-conversions = { path = "../number-conversions" }
 primitive-types = { workspace = true }
 prometheus = { workspace = true }
+prometheus-metric-storage = { workspace = true }
 shared = { path = "../shared" }
+sqlx = { workspace = true }
 tokio = { workspace = true, features = ["macros", "time", "rt-multi-thread"] }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 url = { workspace = true }
-sqlx = { workspace = true }

--- a/crates/refunder/src/arguments.rs
+++ b/crates/refunder/src/arguments.rs
@@ -49,6 +49,10 @@ pub struct Arguments {
 
     #[clap(long, env, hide_env_values = true)]
     pub refunder_pk: String,
+
+    /// The port at which we serve our metrics
+    #[clap(long, env, default_value = "9590")]
+    pub metrics_port: u16,
 }
 
 impl std::fmt::Display for Arguments {
@@ -61,6 +65,7 @@ impl std::fmt::Display for Arguments {
         writeln!(f, "node_url: {}", self.node_url)?;
         writeln!(f, "ethflow_contract: {:?}", self.ethflow_contract)?;
         writeln!(f, "refunder_pk: SECRET")?;
+        writeln!(f, "metrics_port: {}", self.metrics_port)?;
         Ok(())
     }
 }

--- a/crates/refunder/src/lib.rs
+++ b/crates/refunder/src/lib.rs
@@ -13,8 +13,8 @@ use std::{
     time::{Duration, Instant},
 };
 
-const SLEEP_TIME_BETWEEN_LOOPS: u64 = 1;
-const SECONDS_FROM_LAST_LOOP_BEFORE_UNHEALTHY: u64 = 4 * SLEEP_TIME_BETWEEN_LOOPS;
+const SLEEP_TIME_BETWEEN_LOOPS: Duration = Duration::from_secs(30);
+const SECONDS_FROM_LAST_LOOP_BEFORE_UNHEALTHY: Duration = Duration::from_secs(120);
 
 pub async fn main(args: arguments::Arguments) {
     let pg_pool = PgPool::connect_lazy(args.db_url.as_str()).expect("failed to create database");
@@ -51,7 +51,7 @@ pub async fn main(args: arguments::Arguments) {
                 tracing::warn!("Error while refunding ethflow orders: {:?}", err)
             }
         }
-        tokio::time::sleep(Duration::from_secs(SLEEP_TIME_BETWEEN_LOOPS)).await;
+        tokio::time::sleep(SLEEP_TIME_BETWEEN_LOOPS).await;
     }
 }
 
@@ -66,9 +66,7 @@ impl LivenessChecking for Liveness {
             .read()
             .ok()
             .map(|last_successful_loop| {
-                Instant::now()
-                    .duration_since(*last_successful_loop)
-                    .as_secs()
+                Instant::now().duration_since(*last_successful_loop)
                     < SECONDS_FROM_LAST_LOOP_BEFORE_UNHEALTHY
             })
             .unwrap_or(false)

--- a/crates/refunder/src/lib.rs
+++ b/crates/refunder/src/lib.rs
@@ -6,14 +6,25 @@ pub mod submitter;
 use contracts::CoWSwapEthFlow;
 use ethcontract::{Account, PrivateKey};
 use refund_service::RefundService;
-use shared::http_client::HttpClientFactory;
+use shared::{http_client::HttpClientFactory, metrics::LivenessChecking};
 use sqlx::PgPool;
-use std::time::Duration;
+use std::{
+    sync::{Arc, RwLock},
+    time::{Duration, Instant},
+};
 
-const SLEEP_TIME_BETWEEN_LOOPS: u64 = 30;
+const SLEEP_TIME_BETWEEN_LOOPS: u64 = 1;
+const SECONDS_FROM_LAST_LOOP_BEFORE_UNHEALTHY: u64 = 4 * SLEEP_TIME_BETWEEN_LOOPS;
 
 pub async fn main(args: arguments::Arguments) {
     let pg_pool = PgPool::connect_lazy(args.db_url.as_str()).expect("failed to create database");
+
+    let liveness = Arc::new(Liveness {
+        // Program will be healthy at the start even if no loop was ran yet.
+        last_successful_loop: RwLock::new(Instant::now()),
+    });
+    shared::metrics::serve_metrics(liveness.clone(), ([0, 0, 0, 0], args.metrics_port).into());
+
     let http_factory = HttpClientFactory::new(&args.http_client);
     let web3 = shared::ethrpc::web3(&args.ethrpc, &http_factory, &args.node_url, "base");
     let ethflow_contract = CoWSwapEthFlow::at(&web3, args.ethflow_contract);
@@ -29,9 +40,53 @@ pub async fn main(args: arguments::Arguments) {
     loop {
         tracing::info!("Staring a new refunding loop");
         match refunder.try_to_refund_all_eligble_orders().await {
-            Ok(_) => (),
-            Err(err) => tracing::error!("Error while refunding ethflow orders: {:?}", err),
+            Ok(_) => {
+                track_refunding_loop_result("success");
+                *liveness.last_successful_loop.write().expect(
+                    "Lock is only written to at this point and the program should just crash on a panic",
+                ) = Instant::now()
+            }
+            Err(err) => {
+                track_refunding_loop_result("error");
+                tracing::warn!("Error while refunding ethflow orders: {:?}", err)
+            }
         }
         tokio::time::sleep(Duration::from_secs(SLEEP_TIME_BETWEEN_LOOPS)).await;
     }
+}
+
+struct Liveness {
+    last_successful_loop: RwLock<Instant>,
+}
+
+#[async_trait::async_trait]
+impl LivenessChecking for Liveness {
+    async fn is_alive(&self) -> bool {
+        self.last_successful_loop
+            .read()
+            .ok()
+            .map(|last_successful_loop| {
+                Instant::now()
+                    .duration_since(*last_successful_loop)
+                    .as_secs()
+                    < SECONDS_FROM_LAST_LOOP_BEFORE_UNHEALTHY
+            })
+            .unwrap_or(false)
+    }
+}
+
+#[derive(prometheus_metric_storage::MetricStorage, Debug)]
+#[metric(subsystem = "main")]
+struct Metrics {
+    /// Tracks the result of every refunding loops.
+    #[metric(labels("result"))]
+    refunding_loops: prometheus::IntCounterVec,
+}
+
+fn track_refunding_loop_result(result: &str) {
+    Metrics::instance(global_metrics::get_metric_storage_registry())
+        .expect("unexpected error getting metrics instance")
+        .refunding_loops
+        .with_label_values(&[result])
+        .inc();
 }

--- a/crates/refunder/src/main.rs
+++ b/crates/refunder/src/main.rs
@@ -9,5 +9,6 @@ async fn main() {
     );
     shared::exit_process_on_panic::set_panic_hook();
     tracing::info!("running refunder with validated arguments:\n{}", args);
+    global_metrics::setup_metrics_registry(Some("refunder".into()), None);
     refunder::main(args).await;
 }


### PR DESCRIPTION
Closes #977.

Adds metrics and liveness checks to the refunder.
Refund loop errors have been demoted from `error!`s to `warn!`s.

### Test Plan

I ran the refunder locally with `cargo run --bin refunder -- --ethflow-contract 0xD02De8Da0B71E1B59489794F423FaBBa2AdC4d93 --refunder-pk 0x1111111111111111111111111111111111111111111111111111111111111111`.

For checking that everything worked I used:
```
curl --write-out '%{http_code}' localhost:9590/liveness
curl localhost:9590/metrics | grep refunder_main
```

I triggered refunder failures by disconnecting my computer from the internet.

<details><summary>Example output</summary>

```
# HELP refunder_main_refunding_loops Tracks the result of every refunding loops.
# TYPE refunder_main_refunding_loops counter
refunder_main_refunding_loops{result="error"} 20
refunder_main_refunding_loops{result="success"} 9
```
</details>