### PR TITLE
Enable s3 instance uploading

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -214,6 +214,245 @@ dependencies = [
 ]
 
 [[package]]
+name = "aws-endpoint"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "253d7cd480bfa59a5323390e9e91885a8f06a275e0517d81eeb1070b6aa7d271"
+dependencies = [
+ "aws-smithy-http",
+ "aws-smithy-types",
+ "aws-types",
+ "http",
+ "regex",
+ "tracing",
+]
+
+[[package]]
+name = "aws-http"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd1b83859383e46ea8fda633378f9f3f02e6e3a446fd89f0240b5c3662716c9"
+dependencies = [
+ "aws-smithy-http",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "http",
+ "http-body",
+ "lazy_static",
+ "percent-encoding",
+ "pin-project-lite",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-s3"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4d240ff751efc65099d18f6b0fb80360b31a298cec7b392c511692bec4a6e21"
+dependencies = [
+ "aws-endpoint",
+ "aws-http",
+ "aws-sig-auth",
+ "aws-sigv4",
+ "aws-smithy-async",
+ "aws-smithy-checksums",
+ "aws-smithy-client",
+ "aws-smithy-eventstream",
+ "aws-smithy-http",
+ "aws-smithy-http-tower",
+ "aws-smithy-types",
+ "aws-smithy-xml",
+ "aws-types",
+ "bytes",
+ "bytes-utils",
+ "fastrand",
+ "http",
+ "http-body",
+ "tokio-stream",
+ "tower",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sig-auth"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6126c4ff918e35fb9ae1bf2de71157fad36f0cc6a2b1d0f7197ee711713700fc"
+dependencies = [
+ "aws-sigv4",
+ "aws-smithy-eventstream",
+ "aws-smithy-http",
+ "aws-types",
+ "http",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sigv4"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84c7f88d7395f5411c6eef5889b6cd577ce6b677af461356cbfc20176c26c160"
+dependencies = [
+ "aws-smithy-eventstream",
+ "aws-smithy-http",
+ "bytes",
+ "form_urlencoded",
+ "hex",
+ "hmac",
+ "http",
+ "once_cell",
+ "percent-encoding",
+ "regex",
+ "sha2",
+ "time 0.3.14",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-async"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e6a895d68852dd1564328e63ef1583e5eb307dd2a5ebf35d862a5c402957d5e"
+dependencies = [
+ "futures-util",
+ "pin-project-lite",
+ "tokio",
+ "tokio-stream",
+]
+
+[[package]]
+name = "aws-smithy-checksums"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b847d960abc993319d77b52e82971e2bbdce94f6192df42142e14ed5c9c917"
+dependencies = [
+ "aws-smithy-http",
+ "aws-smithy-types",
+ "bytes",
+ "crc32c",
+ "crc32fast",
+ "hex",
+ "http",
+ "http-body",
+ "md-5",
+ "pin-project-lite",
+ "sha1",
+ "sha2",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-client"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f505bf793eb3e6d7c166ef1275c27b4b2cd5361173fe950ac8e2cfc08c29a7ef"
+dependencies = [
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-http-tower",
+ "aws-smithy-types",
+ "bytes",
+ "fastrand",
+ "http",
+ "http-body",
+ "hyper",
+ "hyper-tls",
+ "pin-project-lite",
+ "tokio",
+ "tower",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-eventstream"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d751c99da757aecc1408ab6b2d65e9493220a5e7a68bcafa4f07b6fd1bc473f1"
+dependencies = [
+ "aws-smithy-types",
+ "bytes",
+ "crc32fast",
+]
+
+[[package]]
+name = "aws-smithy-http"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37e4b4304b7ea4af1af3e08535100eb7b6459d5a6264b92078bf85176d04ab85"
+dependencies = [
+ "aws-smithy-eventstream",
+ "aws-smithy-types",
+ "bytes",
+ "bytes-utils",
+ "futures-core",
+ "http",
+ "http-body",
+ "hyper",
+ "once_cell",
+ "percent-encoding",
+ "pin-project-lite",
+ "pin-utils",
+ "tokio",
+ "tokio-util 0.7.4",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-http-tower"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e86072ecc4dc4faf3e2071144285cfd539263fe7102b701d54fb991eafb04af8"
+dependencies = [
+ "aws-smithy-http",
+ "aws-smithy-types",
+ "bytes",
+ "http",
+ "http-body",
+ "pin-project-lite",
+ "tower",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-types"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "987b1e37febb9bd409ca0846e82d35299e572ad8279bc404778caeb5fc05ad56"
+dependencies = [
+ "base64-simd",
+ "itoa",
+ "num-integer",
+ "ryu",
+ "time 0.3.14",
+]
+
+[[package]]
+name = "aws-smithy-xml"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37ce3791e14eec75ffac851a5a559f1ce6b31843297f42cc8bfba82714a6a5d8"
+dependencies = [
+ "xmlparser",
+]
+
+[[package]]
+name = "aws-types"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c05adca3e2bcf686dd2c47836f216ab52ed7845c177d180c84b08522c1166a3"
+dependencies = [
+ "aws-smithy-async",
+ "aws-smithy-client",
+ "aws-smithy-http",
+ "aws-smithy-types",
+ "http",
+ "rustc_version",
+ "tracing",
+ "zeroize",
+]
+
+[[package]]
 name = "axum"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -268,6 +507,15 @@ name = "base64"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
+
+[[package]]
+name = "base64-simd"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "781dd20c3aff0bd194fe7d2a977dd92f21c173891f3a03b677359e5fa457e5d5"
+dependencies = [
+ "simd-abstraction",
+]
 
 [[package]]
 name = "bigdecimal"
@@ -359,6 +607,16 @@ name = "bytes"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec8a7b6a70fde80372154c65702f00a0f56f3e1c36abbc6c440484be248856db"
+
+[[package]]
+name = "bytes-utils"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e47d3a8076e283f3acd27400535992edb3ba4b5bb72f8891ad8fbe7932a7d4b9"
+dependencies = [
+ "bytes",
+ "either",
+]
 
 [[package]]
 name = "cached"
@@ -584,6 +842,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d997bd5e24a5928dd43e46dc529867e207907fe0b239c3477d924f7f2ca320"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "crc32c"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3dfea2db42e9927a3845fb268a10a72faed6d416065f77873f05e411457c363e"
+dependencies = [
+ "rustc_version",
 ]
 
 [[package]]
@@ -2299,6 +2566,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ff7415e9ae3fff1225851df9e0d9e4e5479f947619774677a63572e55e80eff"
 
 [[package]]
+name = "outref"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f222829ae9293e33a9f5e9f440c6760a3d450a64affe1846486b140db81c1f4"
+
+[[package]]
 name = "parity-scale-codec"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3190,6 +3463,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "simd-abstraction"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cadb29c57caadc51ff8346233b5cec1d240b68ce55cf1afc764818791876987"
+dependencies = [
+ "outref",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3235,6 +3517,8 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
+ "aws-sdk-s3",
+ "aws-types",
  "chrono",
  "clap 4.0.8",
  "contracts",
@@ -4231,6 +4515,12 @@ checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
 dependencies = [
  "tap",
 ]
+
+[[package]]
+name = "xmlparser"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d25c75bf9ea12c4040a97f829154768bbbce366287e2dc044af160cd79a13fd"
 
 [[package]]
 name = "zeroize"

--- a/crates/solver/Cargo.toml
+++ b/crates/solver/Cargo.toml
@@ -17,6 +17,8 @@ path = "src/main.rs"
 [dependencies]
 anyhow = { workspace = true }
 async-trait = { workspace = true }
+aws-sdk-s3 = { version = "0.22", default-features = false, features = ["native-tls", "rt-tokio"] }
+aws-types = { version = "0.52", features = ["hardcoded-credentials"] }
 chrono = { workspace = true, features = ["clock"] }
 clap = { workspace = true }
 contracts = { path = "../contracts" }

--- a/crates/solver/src/arguments.rs
+++ b/crates/solver/src/arguments.rs
@@ -1,5 +1,6 @@
 use crate::{
     liquidity::slippage,
+    s3_instance_upload_arguments::S3UploadArguments,
     settlement_access_list::AccessListEstimatorType,
     solver::{single_order_solver, ExternalSolverArg, SolverAccountArg, SolverType},
 };
@@ -300,25 +301,8 @@ pub struct Arguments {
     #[clap(long, env, default_value = "0")]
     pub solution_comparison_decimal_cutoff: u16,
 
-    /// The s3_instance_upload_* arguments configure how quasimodo instances should be uploaded to
-    /// AWS S3. They must either all be set or all not set. If they are set then every instance sent to
-    /// Quasimodo as part of auction solving is also uploaded to S3.
-    #[clap(long, env)]
-    pub s3_instance_upload_region: Option<String>,
-
-    #[clap(long, env)]
-    pub s3_instance_upload_bucket: Option<String>,
-
-    /// Prepended to the auction id to form the final instance filename on S3. Something like
-    /// "staging/mainnet/quasimodo/". Should end with `/` if intended to be a folder.
-    #[clap(long, env)]
-    pub s3_instance_upload_filename_prefix: Option<String>,
-
-    #[clap(long, env)]
-    pub s3_instance_upload_access_key_id: Option<String>,
-
-    #[clap(long, env)]
-    pub s3_instance_upload_secret_access_key: Option<String>,
+    #[clap(flatten)]
+    pub s3_upload: S3UploadArguments,
 }
 
 impl std::fmt::Display for Arguments {
@@ -432,31 +416,6 @@ impl std::fmt::Display for Arguments {
             f,
             "token_list_restriction_for_price_checks: {:?}",
             self.token_list_restriction_for_price_checks
-        )?;
-        display_option(
-            f,
-            "s3_instance_upload_region",
-            &self.s3_instance_upload_region,
-        )?;
-        display_option(
-            f,
-            "s3_instance_upload_bucket",
-            &self.s3_instance_upload_bucket,
-        )?;
-        display_option(
-            f,
-            "s3_instance_upload_filename_prefix",
-            &self.s3_instance_upload_filename_prefix,
-        )?;
-        display_option(
-            f,
-            "s3_instance_upload_access_key_id",
-            &self.s3_instance_upload_access_key_id,
-        )?;
-        display_secret_option(
-            f,
-            "s3_instance_upload_secret_access_key",
-            &self.s3_instance_upload_secret_access_key,
         )?;
         Ok(())
     }

--- a/crates/solver/src/arguments.rs
+++ b/crates/solver/src/arguments.rs
@@ -299,6 +299,26 @@ pub struct Arguments {
     /// value 0.0012 ETH and 0.0016 ETH equivalent.
     #[clap(long, env, default_value = "0")]
     pub solution_comparison_decimal_cutoff: u16,
+
+    /// The s3_instance_upload_* arguments configure how quasimodo instances should be uploaded to
+    /// AWS S3. They must either all be set or all not set. If they are set then every instance sent to
+    /// Quasimodo as part of auction solving is also uploaded to S3.
+    #[clap(long, env)]
+    pub s3_instance_upload_region: Option<String>,
+
+    #[clap(long, env)]
+    pub s3_instance_upload_bucket: Option<String>,
+
+    /// Prepended to the auction id to form the final instance filename on S3. Something like
+    /// "staging/mainnet/quasimodo/". Should end with `/` if intended to be a folder.
+    #[clap(long, env)]
+    pub s3_instance_upload_filename_prefix: Option<String>,
+
+    #[clap(long, env)]
+    pub s3_instance_upload_access_key_id: Option<String>,
+
+    #[clap(long, env)]
+    pub s3_instance_upload_secret_access_key: Option<String>,
 }
 
 impl std::fmt::Display for Arguments {
@@ -412,6 +432,31 @@ impl std::fmt::Display for Arguments {
             f,
             "token_list_restriction_for_price_checks: {:?}",
             self.token_list_restriction_for_price_checks
+        )?;
+        display_option(
+            f,
+            "s3_instance_upload_region",
+            &self.s3_instance_upload_region,
+        )?;
+        display_option(
+            f,
+            "s3_instance_upload_bucket",
+            &self.s3_instance_upload_bucket,
+        )?;
+        display_option(
+            f,
+            "s3_instance_upload_filename_prefix",
+            &self.s3_instance_upload_filename_prefix,
+        )?;
+        display_option(
+            f,
+            "s3_instance_upload_access_key_id",
+            &self.s3_instance_upload_access_key_id,
+        )?;
+        display_secret_option(
+            f,
+            "s3_instance_upload_secret_access_key",
+            &self.s3_instance_upload_secret_access_key,
         )?;
         Ok(())
     }

--- a/crates/solver/src/lib.rs
+++ b/crates/solver/src/lib.rs
@@ -11,6 +11,7 @@ pub mod liquidity_collector;
 pub mod metrics;
 pub mod orderbook;
 pub mod s3_instance_upload;
+pub mod s3_instance_upload_arguments;
 pub mod settlement;
 pub mod settlement_access_list;
 pub mod settlement_post_processing;

--- a/crates/solver/src/lib.rs
+++ b/crates/solver/src/lib.rs
@@ -10,6 +10,7 @@ pub mod liquidity;
 pub mod liquidity_collector;
 pub mod metrics;
 pub mod orderbook;
+pub mod s3_instance_upload;
 pub mod settlement;
 pub mod settlement_access_list;
 pub mod settlement_post_processing;

--- a/crates/solver/src/main.rs
+++ b/crates/solver/src/main.rs
@@ -34,6 +34,7 @@ use solver::{
     liquidity_collector::{LiquidityCollecting, LiquidityCollector},
     metrics::Metrics,
     orderbook::OrderBookApi,
+    s3_instance_upload::S3InstanceUploader,
     settlement_post_processing::PostProcessingPipeline,
     settlement_submission::{
         gelato::GelatoSubmitter,
@@ -252,13 +253,15 @@ async fn main() -> ! {
         }
         if any_some {
             tracing::debug!("quasimodo s3 instance uploading is enabled");
-            Some(solver::s3_instance_upload::Config {
-                region: args.s3_instance_upload_region.unwrap(),
-                bucket: args.s3_instance_upload_bucket.unwrap(),
-                access_key_id: args.s3_instance_upload_access_key_id.unwrap(),
-                secret_access_key: args.s3_instance_upload_secret_access_key.unwrap(),
-                filename_prefix: args.s3_instance_upload_filename_prefix.unwrap(),
-            })
+            Some(S3InstanceUploader::new(
+                solver::s3_instance_upload::Config {
+                    region: args.s3_instance_upload_region.unwrap(),
+                    bucket: args.s3_instance_upload_bucket.unwrap(),
+                    access_key_id: args.s3_instance_upload_access_key_id.unwrap(),
+                    secret_access_key: args.s3_instance_upload_secret_access_key.unwrap(),
+                    filename_prefix: args.s3_instance_upload_filename_prefix.unwrap(),
+                },
+            ))
         } else {
             tracing::debug!("quasimodo s3 instance uploading is disabled");
             None

--- a/crates/solver/src/main.rs
+++ b/crates/solver/src/main.rs
@@ -236,6 +236,35 @@ async fn main() -> ! {
     ));
 
     let domain = DomainSeparator::new(chain_id, settlement_contract.address());
+
+    let s3_config = {
+        let s3_args = &[
+            &args.s3_instance_upload_region,
+            &args.s3_instance_upload_bucket,
+            &args.s3_instance_upload_filename_prefix,
+            &args.s3_instance_upload_access_key_id,
+            &args.s3_instance_upload_secret_access_key,
+        ];
+        let any_some = s3_args.iter().any(|arg| arg.is_some());
+        let any_none = s3_args.iter().any(|arg| arg.is_none());
+        if any_none && any_some {
+            panic!("Either set all s3_instance_upload args or none.");
+        }
+        if any_some {
+            tracing::debug!("quasimodo s3 instance uploading is enabled");
+            Some(solver::s3_instance_upload::Config {
+                region: args.s3_instance_upload_region.unwrap(),
+                bucket: args.s3_instance_upload_bucket.unwrap(),
+                access_key_id: args.s3_instance_upload_access_key_id.unwrap(),
+                secret_access_key: args.s3_instance_upload_secret_access_key.unwrap(),
+                filename_prefix: args.s3_instance_upload_filename_prefix.unwrap(),
+            })
+        } else {
+            tracing::debug!("quasimodo s3 instance uploading is disabled");
+            None
+        }
+    };
+
     let solver = solver::solver::create(
         web3.clone(),
         solvers,
@@ -270,6 +299,7 @@ async fn main() -> ! {
         &args.order_prioritization,
         post_processing_pipeline,
         &domain,
+        s3_config,
     )
     .expect("failure creating solvers");
 

--- a/crates/solver/src/s3_instance_upload.rs
+++ b/crates/solver/src/s3_instance_upload.rs
@@ -1,0 +1,112 @@
+use anyhow::Result;
+use aws_sdk_s3::{types::ByteStream, Client, Credentials, Region};
+use aws_types::credentials::SharedCredentialsProvider;
+use chrono::{DateTime, Utc};
+use model::auction::AuctionId;
+
+#[derive(Default)]
+pub struct Config {
+    pub region: String,
+    pub bucket: String,
+    pub access_key_id: String,
+    pub secret_access_key: String,
+    /// Prepended to the auction id to form the final filename. Something like
+    /// "staging/mainnet/quasimodo/". Should end with `/` if intended to be a folder.
+    pub filename_prefix: String,
+}
+
+pub struct S3InstanceUploader {
+    bucket: String,
+    filename_prefix: String,
+    client: Client,
+}
+
+impl S3InstanceUploader {
+    pub fn new(config: Config) -> Self {
+        let aws_config = aws_types::sdk_config::Builder::default()
+            .region(Region::new(config.region))
+            .credentials_provider(SharedCredentialsProvider::new(Credentials::from_keys(
+                config.access_key_id,
+                config.secret_access_key,
+                None,
+            )))
+            .build();
+        Self {
+            bucket: config.bucket,
+            filename_prefix: config.filename_prefix,
+            client: Client::new(&aws_config),
+        }
+    }
+
+    /// Upload the bytes (expected to represent a json encoded solver instance) to the configured S3
+    /// bucket.
+    ///
+    /// The final filename is the configured prefix followed by `{current_date}/{auction_id}`.
+    pub async fn upload_instance(&self, auction: AuctionId, value: Vec<u8>) -> Result<()> {
+        let key = self.filename(chrono::offset::Utc::now(), auction);
+        self.upload(key, value).await
+    }
+
+    fn filename(&self, now: DateTime<Utc>, auction: AuctionId) -> String {
+        let date = now.format("%Y-%m-%d");
+        format!("{}{date}/{auction}.json", self.filename_prefix)
+    }
+
+    async fn upload(&self, key: String, value: Vec<u8>) -> Result<()> {
+        self.client
+            .put_object()
+            .bucket(self.bucket.clone())
+            .key(key)
+            .body(ByteStream::new(value.into()))
+            .send()
+            .await?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    #[ignore]
+    fn print_filename() {
+        let uploader = S3InstanceUploader::new(Default::default());
+        let key = uploader.filename(chrono::offset::Utc::now(), 11);
+        println!("{key}");
+    }
+
+    #[tokio::test]
+    #[ignore]
+    async fn real_upload() {
+        let config = Config {
+            region: "eu-central-1".to_string(),
+            bucket: std::env::var("bucket").unwrap(),
+            access_key_id: std::env::var("access_key_id").unwrap(),
+            secret_access_key: std::env::var("secret_access_key").unwrap(),
+            filename_prefix: "".to_string(),
+        };
+
+        let key = "test.txt".to_string();
+        let value = format!("Hello {:?}", std::time::SystemTime::now());
+
+        let uploader = S3InstanceUploader::new(config);
+        uploader
+            .upload(key.clone(), value.as_bytes().to_vec())
+            .await
+            .unwrap();
+
+        let get_object = uploader
+            .client
+            .get_object()
+            .bucket(uploader.bucket)
+            .key(key)
+            .send()
+            .await
+            .unwrap();
+        let body = get_object.body.collect().await.unwrap().to_vec();
+        let body = std::str::from_utf8(&body).unwrap();
+
+        assert_eq!(value, body);
+    }
+}

--- a/crates/solver/src/s3_instance_upload_arguments.rs
+++ b/crates/solver/src/s3_instance_upload_arguments.rs
@@ -1,0 +1,86 @@
+use shared::arguments::{display_option, display_secret_option};
+
+use crate::s3_instance_upload::Config;
+
+#[derive(clap::Parser)]
+pub struct S3UploadArguments {
+    /// The s3_instance_upload_* arguments configure how quasimodo instances should be uploaded to
+    /// AWS S3. They must either all be set or all not set. If they are set then every instance sent to
+    /// Quasimodo as part of auction solving is also uploaded to S3.
+    #[clap(long, env)]
+    pub s3_instance_upload_region: Option<String>,
+
+    #[clap(long, env)]
+    pub s3_instance_upload_bucket: Option<String>,
+
+    /// Prepended to the auction id to form the final instance filename on S3. Something like
+    /// "staging/mainnet/quasimodo/". Should end with `/` if intended to be a folder.
+    #[clap(long, env)]
+    pub s3_instance_upload_filename_prefix: Option<String>,
+
+    #[clap(long, env)]
+    pub s3_instance_upload_access_key_id: Option<String>,
+
+    #[clap(long, env)]
+    pub s3_instance_upload_secret_access_key: Option<String>,
+}
+
+impl std::fmt::Display for S3UploadArguments {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        display_option(
+            f,
+            "s3_instance_upload_region",
+            &self.s3_instance_upload_region,
+        )?;
+        display_option(
+            f,
+            "s3_instance_upload_bucket",
+            &self.s3_instance_upload_bucket,
+        )?;
+        display_option(
+            f,
+            "s3_instance_upload_filename_prefix",
+            &self.s3_instance_upload_filename_prefix,
+        )?;
+        display_option(
+            f,
+            "s3_instance_upload_access_key_id",
+            &self.s3_instance_upload_access_key_id,
+        )?;
+        display_secret_option(
+            f,
+            "s3_instance_upload_secret_access_key",
+            &self.s3_instance_upload_secret_access_key,
+        )?;
+        Ok(())
+    }
+}
+
+impl S3UploadArguments {
+    pub fn into_config(self) -> anyhow::Result<Option<Config>> {
+        let s3_args = &[
+            &self.s3_instance_upload_region,
+            &self.s3_instance_upload_bucket,
+            &self.s3_instance_upload_filename_prefix,
+            &self.s3_instance_upload_access_key_id,
+            &self.s3_instance_upload_secret_access_key,
+        ];
+        let all_some = s3_args.iter().all(|arg| arg.is_some());
+        let all_none = s3_args.iter().all(|arg| arg.is_none());
+        anyhow::ensure!(
+            all_some || all_none,
+            "either set all s3_instance_upload arguments or none"
+        );
+        Ok(if all_some {
+            Some(Config {
+                region: self.s3_instance_upload_region.unwrap(),
+                bucket: self.s3_instance_upload_bucket.unwrap(),
+                access_key_id: self.s3_instance_upload_access_key_id.unwrap(),
+                secret_access_key: self.s3_instance_upload_secret_access_key.unwrap(),
+                filename_prefix: self.s3_instance_upload_filename_prefix.unwrap(),
+            })
+        } else {
+            None
+        })
+    }
+}

--- a/crates/solver/src/solver.rs
+++ b/crates/solver/src/solver.rs
@@ -283,7 +283,7 @@ pub fn create(
     order_prioritization_config: &single_order_solver::Arguments,
     post_processing_pipeline: Arc<dyn PostProcessing>,
     domain: &DomainSeparator,
-    mut instance_uploader_config_for_quasimodo: Option<S3InstanceUploader>,
+    mut s3_instance_uploader_for_quasimodo: Option<S3InstanceUploader>,
 ) -> Result<Solvers> {
     // Tiny helper function to help out with type inference. Otherwise, all
     // `Box::new(...)` expressions would have to be cast `as Box<dyn Solver>`.
@@ -401,7 +401,7 @@ pub fn create(
                     },
                     true,
                     slippage_calculator,
-                    instance_uploader_config_for_quasimodo.take(),
+                    s3_instance_uploader_for_quasimodo.take(),
                 )),
                 SolverType::OneInch => shared(single_order(Box::new(
                     OneInchSolver::with_disabled_protocols(

--- a/crates/solver/src/solver/http_solver.rs
+++ b/crates/solver/src/solver/http_solver.rs
@@ -8,6 +8,7 @@ use crate::{
         order_converter::OrderConverter, slippage::SlippageCalculator, Exchange, LimitOrder,
         Liquidity,
     },
+    s3_instance_upload::S3InstanceUploader,
     settlement::{external_prices::ExternalPrices, Settlement},
     solver::{http_solver::settlement::ConversionError, Auction, Solver},
 };
@@ -69,6 +70,7 @@ pub struct HttpSolver {
     slippage_calculator: SlippageCalculator,
     market_makable_token_list: AutoUpdatingTokenList,
     domain: DomainSeparator,
+    instance_uploader: Option<Arc<S3InstanceUploader>>,
 }
 
 impl HttpSolver {
@@ -86,6 +88,7 @@ impl HttpSolver {
         slippage_calculator: SlippageCalculator,
         market_makable_token_list: AutoUpdatingTokenList,
         domain: DomainSeparator,
+        instance_uploader: Option<Arc<S3InstanceUploader>>,
     ) -> Self {
         Self {
             solver,
@@ -100,6 +103,7 @@ impl HttpSolver {
             slippage_calculator,
             market_makable_token_list,
             domain,
+            instance_uploader,
         }
     }
 
@@ -516,6 +520,25 @@ impl Solver for HttpSolver {
             }
         };
 
+        // Upload the instance if configured. Happens in a task to not delay solving.
+        if let Some(uploader) = &self.instance_uploader {
+            let model = model.clone();
+            let uploader = uploader.clone();
+            let task = async move {
+                let auction = match serde_json::to_vec(&model) {
+                    Ok(auction) => auction,
+                    Err(err) => {
+                        tracing::error!(?err, "encode auction for instance upload");
+                        return;
+                    }
+                };
+                if let Err(err) = uploader.upload_instance(id, auction).await {
+                    tracing::error!(?err, "error uploading instance");
+                }
+            };
+            tokio::task::spawn(task);
+        }
+
         let timeout = deadline
             .checked_duration_since(Instant::now())
             .context("no time left to send request")?;
@@ -670,6 +693,7 @@ mod tests {
             SlippageCalculator::default(),
             Default::default(),
             Default::default(),
+            None,
         );
         let base = |x: u128| x * 10u128.pow(18);
         let limit_orders = vec![LimitOrder {
@@ -901,6 +925,7 @@ mod tests {
             SlippageCalculator::default(),
             Default::default(),
             Default::default(),
+            None,
         );
 
         let (model, context) = solver

--- a/crates/solver/src/solver/http_solver.rs
+++ b/crates/solver/src/solver/http_solver.rs
@@ -88,8 +88,9 @@ impl HttpSolver {
         slippage_calculator: SlippageCalculator,
         market_makable_token_list: AutoUpdatingTokenList,
         domain: DomainSeparator,
-        instance_uploader: Option<Arc<S3InstanceUploader>>,
+        instance_uploader: Option<S3InstanceUploader>,
     ) -> Self {
+        let instance_uploader = instance_uploader.map(Arc::new);
         Self {
             solver,
             account,


### PR DESCRIPTION
We want Quasimodo instances to be stored on AWS S3 for later debugging. See https://github.com/cowprotocol/services/issues/334 .

This currently happens through the obsolete MIP solver which in our cluster is configured to do nothing except upload the instance. However, this instance uploading is hard to maintain and brittle. Recently it started failing and filling up the disk space of the container. It is also unnecessary overhead to run the whole MIP image just to upload instances.

There were two main ideas for re-implementing the uploading in Rust:
1. Continue using a full solver pod to upload instances.
2. Integrate the uploading into the driver.

I went with 2. because the extra pod has too much organizational overhead. I do not want to maintain a whole binary, pod, staging configuration to upload instances. An even better solution might be to do the instance uploading in Quasimodo because it isn't really relevant to the driver. But that would be more work because it would be harder to use Rust there.

To interface with S3 I decided on the official AWS Rust libraries. They are technically in preview stage but this seems to be referring to breaking changes and not bugs. I intentionally use as little of the API. Breaking changes won't be difficult to handle.

I tried out manually  interfacing with S3's http rest api in order to reduce dependencies. This did not work well because AWS recently added signing requirements to requests which are too difficult to implement standalone. The AWS libraries we depend on now do not add many transitive dependencies anyway because a lot of the tokio and http libraries we already depend on.

Follow up tasks if this works on staging:
- Remove references to MIP solver in the Rust code.
- Remove references to MIP solver in the cluster.
- Clean up the old S3 bucket?

### Test Plan

manually ran the ignored s3 upload tests, can only test for real after merging and configuring staging
