### PR TITLE
Track number of limit orders with valid `surplus_fee`

### DIFF
--- a/crates/autopilot/src/lib.rs
+++ b/crates/autopilot/src/lib.rs
@@ -62,9 +62,9 @@ use shared::{
 use std::{collections::HashSet, sync::Arc, time::Duration};
 use tracing::Instrument;
 
-/// To no never get to the state where a limit order can not be considered usable because the
+/// To never get to the state where a limit order can not be considered usable because the
 /// `surplus_fee` is too old the `surplus_fee` is valid for longer than its update interval.
-/// This factor controls how much longer its considered valid.
+/// This factor controls how much longer it's considered valid.
 /// If the `surplus_fee` gets updated every 5 minutes and the factor is 2 we consider limit orders
 /// valid where the `surplus_fee` was computed up to 10 minutes ago.
 const SURPLUS_FEE_EXPIRATION_FACTOR: u8 = 2;

--- a/crates/autopilot/src/lib.rs
+++ b/crates/autopilot/src/lib.rs
@@ -577,7 +577,8 @@ pub async fn main(args: arguments::Arguments) -> ! {
         }
         .spawn();
         LimitOrderMetrics {
-            limit_order_age: limit_order_age * SURPLUS_FEE_EXPIRATION_FACTOR.into(),
+            quoting_age: limit_order_age,
+            validity_age: limit_order_age * SURPLUS_FEE_EXPIRATION_FACTOR.into(),
             database: db,
         }
         .spawn();

--- a/crates/autopilot/src/lib.rs
+++ b/crates/autopilot/src/lib.rs
@@ -67,7 +67,7 @@ use tracing::Instrument;
 /// This factor controls how much longer its considered valid.
 /// If the `surplus_fee` gets updated every 5 minutes and the factor is 2 we consider limit orders
 /// valid where the `surplus_fee` was computed up to 10 minutes ago.
-const SURPLUS_FEE_EXPIRATION_FACTOR: u32 = 2;
+const SURPLUS_FEE_EXPIRATION_FACTOR: u8 = 2;
 
 struct Liveness {
     solvable_orders_cache: Arc<SolvableOrdersCache>,
@@ -538,7 +538,7 @@ pub async fn main(args: arguments::Arguments) -> ! {
         Duration::from_secs(2),
         risk_adjusted_rewards,
         args.ethflow_contract,
-        args.max_surplus_fee_age * SURPLUS_FEE_EXPIRATION_FACTOR,
+        args.max_surplus_fee_age * SURPLUS_FEE_EXPIRATION_FACTOR.into(),
         args.limit_order_price_factor
             .try_into()
             .expect("limit order price factor can't be converted to BigDecimal"),
@@ -577,7 +577,7 @@ pub async fn main(args: arguments::Arguments) -> ! {
         }
         .spawn();
         LimitOrderMetrics {
-            limit_order_age: limit_order_age * SURPLUS_FEE_EXPIRATION_FACTOR as i32,
+            limit_order_age: limit_order_age * SURPLUS_FEE_EXPIRATION_FACTOR.into(),
             database: db,
         }
         .spawn();

--- a/crates/autopilot/src/limit_orders/metrics.rs
+++ b/crates/autopilot/src/limit_orders/metrics.rs
@@ -5,30 +5,49 @@ use prometheus::IntGauge;
 use crate::database::Postgres;
 
 pub struct LimitOrderMetrics {
-    pub limit_order_age: chrono::Duration,
+    /// At that age the [`LimitOrderQuoter`] would update the `surplus_fee`.
+    pub quoting_age: chrono::Duration,
+    /// At that age the [`SolvableOrdersCache`] would consider a `surplus_fee` too old.
+    pub validity_age: chrono::Duration,
     pub database: Postgres,
 }
 
 impl LimitOrderMetrics {
     pub fn spawn(self) {
         tokio::spawn(async move {
-            let limit_orders_gauge = gauge("limit_orders", "Valid limit orders.");
+            let limit_orders_gauge = gauge("limit_orders", "Open limit orders.");
             let quoted_limit_orders_gauge = gauge("quoted_limit_orders", "Quoted limit orders.");
-            let unquoted_limit_orders_gauge = gauge(
-                "unquoted_limit_orders",
-                "Unquoted or outdated limit orders.",
+            let unquoted_limit_orders_gauge =
+                gauge("unquoted_limit_orders", "Limit orders awaiting a quote.");
+            let usable_limit_orders_gauge =
+                gauge("usable_limit_orders", "Limit orders usable in the auction.");
+            let unusable_limit_orders_gauge = gauge(
+                "unusable_limit_orders",
+                "Limit orders with surplus_fee too old for the auction.",
             );
+
             loop {
                 let limit_orders = self.database.count_limit_orders().await.unwrap();
-                let unquoted_limit_orders = self
+                let awaiting_quote = self
                     .database
-                    .count_limit_orders_with_outdated_fees(self.limit_order_age)
+                    .count_limit_orders_with_outdated_fees(self.quoting_age)
                     .await
                     .unwrap();
-                let quoted_limit_orders = limit_orders - unquoted_limit_orders;
+                let unusable = self
+                    .database
+                    .count_limit_orders_with_outdated_fees(self.validity_age)
+                    .await
+                    .unwrap();
+
+                let quoted_limit_orders = limit_orders - awaiting_quote;
+                let usable_limit_orders = limit_orders - unusable;
+
                 limit_orders_gauge.set(limit_orders);
-                unquoted_limit_orders_gauge.set(unquoted_limit_orders);
+                unquoted_limit_orders_gauge.set(awaiting_quote);
                 quoted_limit_orders_gauge.set(quoted_limit_orders);
+                usable_limit_orders_gauge.set(usable_limit_orders);
+                unusable_limit_orders_gauge.set(unusable);
+
                 tokio::time::sleep(Duration::from_secs(10)).await;
             }
         });


### PR DESCRIPTION
While looking into ways to optimize `surplus_fee` quoting I found 1 metric somewhat confusing.

Limit order quoting was implemented in a way that updates the `surplus_fee` before the `autopilot` would consider it too old to be used in an auction.

However, the current metrics look a bit misleading:

![Screenshot 2023-01-05 at 11 00 59](https://user-images.githubusercontent.com/19190235/210753462-ffbb27f6-9900-4494-a2cd-3087c2ccf51c.png)

The upper graph shows spikes of unquoted orders whereas the other graphs combined suggest a constant number of orders with usable `surplus_fee`. After some investigation I realized the lower graph shows the number of orders the `LimitOrderQuoter` intends to quote; not the number of orders where the `surplus_fee` is too old to be considered.

To monitor the overall health/efficiency of the system I think it's more insightful to track the unusable limit orders instead.

In case you consider the original metric also helpful I can obviously update the PR to track both of them.