### PR TITLE
Print s3 arguments

### DIFF
--- a/crates/solver/src/arguments.rs
+++ b/crates/solver/src/arguments.rs
@@ -417,6 +417,7 @@ impl std::fmt::Display for Arguments {
             "token_list_restriction_for_price_checks: {:?}",
             self.token_list_restriction_for_price_checks
         )?;
+        writeln!(f, "{}", self.s3_upload)?;
         Ok(())
     }
 }


### PR DESCRIPTION
After refactoring into a second argument struct I forgot to add the print here.

### Test Plan

not needed