### PR TITLE
Fix not using full error description for solver run errors

### DIFF
--- a/crates/shared/src/http_solver/model.rs
+++ b/crates/shared/src/http_solver/model.rs
@@ -343,12 +343,6 @@ pub enum SolverRunError {
     Solving(String),
 }
 
-impl From<anyhow::Error> for SolverRunError {
-    fn from(err: anyhow::Error) -> Self {
-        Self::Solving(err.to_string())
-    }
-}
-
 /// Contains all information about a failing settlement simulation
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]

--- a/crates/solver/src/driver.rs
+++ b/crates/solver/src/driver.rs
@@ -165,7 +165,9 @@ impl Driver {
                     match tokio::time::timeout_at(auction.deadline.into(), solver.solve(auction))
                         .await
                     {
-                        Ok(inner) => inner.map_err(Into::into),
+                        Ok(inner) => {
+                            inner.map_err(|err| SolverRunError::Solving(format!("{:?}", err)))
+                        }
                         Err(_timeout) => Err(SolverRunError::Timeout),
                     };
                 let response = match &result {


### PR DESCRIPTION
anyhow errors must be converted to string using the debug representation in order to get the full stack of error information.

I also removed the From implementation because it was used in one place and I felt inlining it was easier to understand.

### Test Plan

look at logs afterwards