### PR TITLE
Create http solver filtered and unfiltered instance together

### DIFF
--- a/crates/solver/src/solver/http_solver.rs
+++ b/crates/solver/src/solver/http_solver.rs
@@ -5,17 +5,14 @@ pub mod settlement;
 
 use self::{
     instance_cache::{InstanceType, SharedInstanceCreator},
-    settlement::SettlementContext,
+    instance_creation::Instance,
+    settlement::{ConversionError, SettlementContext},
 };
-use super::AuctionResult;
+use super::{Auction, AuctionResult, Solver};
 use crate::{
     interactions::allowances::AllowanceManaging,
     liquidity::{order_converter::OrderConverter, slippage::SlippageCalculator},
     settlement::Settlement,
-    solver::{
-        http_solver::{instance_cache::Instance, settlement::ConversionError},
-        Auction, Solver,
-    },
 };
 use anyhow::{Context, Result};
 use ethcontract::Account;


### PR DESCRIPTION
Currently (since https://github.com/cowprotocol/services/pull/461) we do some duplicate work in `prepare_model` because the function either returns a filtered or an unfiltered version. Both versions use the same data from the node so it is wasteful to fetch it twice. With this PR we fetch the data only once.

### Test Plan

adjusted test still works

### Release notes

Optionally add notes, suggestions and warnings for the releaser. They will be included in the release changelog.
