### PR TITLE
Bulk update surplus fees

### DIFF
--- a/crates/autopilot/src/database/orders.rs
+++ b/crates/autopilot/src/database/orders.rs
@@ -66,7 +66,7 @@ impl Postgres {
     }
 
     /// Updates the `surplus_fee` of all limit orders matching the [`SurplusFeeQuoteParameters`]
-    /// together with the quote used to compute that fee.
+    /// and stores a quote for each one.
     pub async fn update_limit_order_fees(
         &self,
         parameters: &SurplusFeeQuoteParameters,

--- a/crates/autopilot/src/database/orders.rs
+++ b/crates/autopilot/src/database/orders.rs
@@ -60,10 +60,7 @@ impl Postgres {
             now_in_epoch_seconds().into(),
             limit,
         )
-        .map(|result| match result {
-            Ok(order) => Ok(order),
-            Err(err) => Err(anyhow::Error::from(err)),
-        })
+        .map(|result| result.map_err(anyhow::Error::from))
         .try_collect()
         .await
     }

--- a/crates/autopilot/src/limit_orders/quoter.rs
+++ b/crates/autopilot/src/limit_orders/quoter.rs
@@ -80,8 +80,8 @@ impl LimitOrderQuoter {
                     value: big_decimal_to_u256(&parameters.sell_amount).unwrap(),
                 },
             },
-            // The remaining parameters are only relevant for subsidy computation which doesn't
-            // matter for the `surplus_fee` computation.
+            // The remaining parameters are only relevant for subsidy computation which is
+            // irrelevant for the `surplus_fee`.
             ..Default::default()
         };
         match self.quoter.calculate_quote(quote_parameters).await {

--- a/crates/autopilot/src/limit_orders/quoter.rs
+++ b/crates/autopilot/src/limit_orders/quoter.rs
@@ -64,10 +64,7 @@ impl LimitOrderQuoter {
                     let quote = self.get_quote(parameters).await;
                     self.update_fee(parameters, &quote).await;
                 }
-                .instrument(tracing::debug_span!(
-                    "surplus_fee",
-                    ?parameters
-                ))
+                .instrument(tracing::debug_span!("surplus_fee", ?parameters))
             })
             .await;
         Ok(parameters.len() < self.parallelism)
@@ -81,7 +78,9 @@ impl LimitOrderQuoter {
             // We prefer to use `sell` here because this allows us to use more price estimators but
             // ultimately the only important thing is that the amounts are correct.
             side: OrderQuoteSide::Sell {
-                sell_amount: SellAmount::AfterFee { value: big_decimal_to_u256(&parameters.sell_amount).unwrap() }
+                sell_amount: SellAmount::AfterFee {
+                    value: big_decimal_to_u256(&parameters.sell_amount).unwrap(),
+                },
             },
             // The remaining parameters are only relevant for subsidy computation which doesn't
             // matter for the `surplus_fee` computation.

--- a/crates/autopilot/src/limit_orders/quoter.rs
+++ b/crates/autopilot/src/limit_orders/quoter.rs
@@ -75,8 +75,6 @@ impl LimitOrderQuoter {
         let quote_parameters = QuoteParameters {
             sell_token: H160(parameters.sell_token.0),
             buy_token: H160(parameters.buy_token.0),
-            // We prefer to use `sell` here because this allows us to use more price estimators but
-            // ultimately the only important thing is that the amounts are correct.
             side: OrderQuoteSide::Sell {
                 sell_amount: SellAmount::AfterFee {
                     value: big_decimal_to_u256(&parameters.sell_amount).unwrap(),

--- a/crates/database/src/orders.rs
+++ b/crates/database/src/orders.rs
@@ -609,7 +609,10 @@ pub struct SurplusFeeQuoteParameters {
     pub sell_amount: BigDecimal,
 }
 
-/// Return valid limit orders with outdated surplus fee.
+/// Groups valid orders with outdated `surplus_fee` together and returns the parameters required to
+/// update the `surplus_fee` of each group. This is because we update the `surplus_fee` of
+/// identical orders in bulk so in order to not do unnecessary price estimation requests during
+/// `surplus_fee` computations we only do it once per group.
 ///
 /// The ordering by most outdated in combination with updating the timestamp when updating the fee
 /// fails is important. It ensures that we cannot get stuck on orders for which the update process

--- a/crates/database/src/orders.rs
+++ b/crates/database/src/orders.rs
@@ -636,7 +636,6 @@ pub fn order_parameters_with_most_outdated_fees(
         " ORDER BY surplus_fee_timestamp ASC NULLS FIRST",
         " LIMIT $3"
     );
-    dbg!(QUERY);
 
     sqlx::query_as(QUERY)
         .bind(min_valid_to)

--- a/crates/database/src/orders.rs
+++ b/crates/database/src/orders.rs
@@ -694,7 +694,6 @@ pub async fn update_limit_order_fees(
         RETURNING
             uid
     ";
-    // TODO there has to be a way to make this nicer
     #[derive(FromRow)]
     struct OrderUidRow {
         uid: OrderUid,

--- a/crates/database/src/orders.rs
+++ b/crates/database/src/orders.rs
@@ -694,11 +694,7 @@ pub async fn update_limit_order_fees(
         RETURNING
             uid
     ";
-    #[derive(FromRow)]
-    struct OrderUidRow {
-        uid: OrderUid,
-    }
-    let rows: Vec<OrderUidRow> = sqlx::query_as(QUERY)
+    sqlx::query_scalar(QUERY)
         .bind(&update.surplus_fee)
         .bind(update.surplus_fee_timestamp)
         .bind(&update.full_fee_amount)
@@ -706,9 +702,7 @@ pub async fn update_limit_order_fees(
         .bind(&update.buy_token)
         .bind(&update.sell_amount)
         .fetch_all(ex)
-        .await?;
-    let uids = rows.into_iter().map(|row| row.uid).collect();
-    Ok(uids)
+        .await
 }
 
 /// Count the number of valid limit orders.

--- a/crates/database/src/orders.rs
+++ b/crates/database/src/orders.rs
@@ -624,10 +624,11 @@ pub fn order_parameters_with_most_outdated_fees(
         " WITH outdated_groups as (",
         "   SELECT sell_token, buy_token, sell_amount,",
         "          NULLIF(MIN(COALESCE(surplus_fee_timestamp, '-infinity'::timestamp)), '-infinity'::timestamp) as surplus_fee_timestamp",
-        "   FROM",
+        "   FROM (",
         OPEN_ORDERS,
-        "     AND class = 'limit'",
-        "     AND COALESCE(surplus_fee_timestamp, 'epoch') < $2",
+        "       AND class = 'limit'",
+        "       AND COALESCE(surplus_fee_timestamp, 'epoch') < $2",
+        "   ) as subquery",
         "   GROUP BY sell_token, buy_token, sell_amount",
         " )",
         " SELECT sell_token, buy_token, sell_amount",
@@ -635,6 +636,7 @@ pub fn order_parameters_with_most_outdated_fees(
         " ORDER BY surplus_fee_timestamp ASC NULLS FIRST",
         " LIMIT $3"
     );
+    dbg!(QUERY);
 
     sqlx::query_as(QUERY)
         .bind(min_valid_to)

--- a/database/sql/V047__index_orders_by_quote_parameters.sql
+++ b/database/sql/V047__index_orders_by_quote_parameters.sql
@@ -2,4 +2,4 @@
 -- updated based on the same underlying quote.
 -- To update an order's `surplus_fee` more quickly based on those parameters we need an index across
 -- all those columns.
-CREATE INDEX order_quoting_parameters ON orders USING BTREE (sell_token, buy_token, sell_amount);
+CREATE INDEX order_quoting_parameters ON orders USING HASH (sell_token, buy_token, sell_amount);

--- a/database/sql/V047__index_orders_by_quote_parameters.sql
+++ b/database/sql/V047__index_orders_by_quote_parameters.sql
@@ -1,0 +1,5 @@
+-- Orders that have the same `sell_token`, `buy_token` and `sell_amount` can have their `surplus_fee`
+-- updated based on the same underlying quote.
+-- To update an order's `surplus_fee` more quickly based on those parameters we need an index across
+-- all those columns.
+CREATE INDEX order_quoting_parameters ON orders USING BTREE (sell_token, buy_token, sell_amount);

--- a/database/sql/V047__index_orders_by_quote_parameters.sql
+++ b/database/sql/V047__index_orders_by_quote_parameters.sql
@@ -2,4 +2,4 @@
 -- updated based on the same underlying quote.
 -- To update an order's `surplus_fee` more quickly based on those parameters we need an index across
 -- all those columns.
-CREATE INDEX order_quoting_parameters ON orders USING HASH (sell_token, buy_token, sell_amount);
+CREATE INDEX order_quoting_parameters ON orders USING BTREE (sell_token, buy_token, sell_amount);


### PR DESCRIPTION
Fixes #1029

After computing a quote for the `surplus_fee` of an order we'll use the same quote for all identical orders (`sell_token`, `buy_token`, `sell_amount`).
This will make sure that users with identical orders will get treated fairly (same `surplus_fee`) and that we issue ~40% fewer price estimation requests for limit order quoting.

### Test Plan
Updated existing unit tests
[Manual test](https://github.com/cowprotocol/services/pull/1037#issuecomment-1376037932) to verify that orders get picked up as quoted and that the performance is alright.
