### PR TITLE
Introduce Order and order::NonLiquidity Domain Objects

### DIFF
--- a/crates/solvers/src/domain/mod.rs
+++ b/crates/solvers/src/domain/mod.rs
@@ -2,3 +2,4 @@
 
 pub mod eth;
 pub mod liquidity;
+pub mod order;

--- a/crates/solvers/src/domain/order.rs
+++ b/crates/solvers/src/domain/order.rs
@@ -33,11 +33,11 @@ pub enum Class {
     Liquidity,
 }
 
-/// A user order marker type.
+/// An order that is guaranteed to not be a liquidity order.
 #[derive(Debug)]
-pub struct UserOrder<'a>(&'a Order);
+pub struct NonLiquidityOrder<'a>(&'a Order);
 
-impl<'a> UserOrder<'a> {
+impl<'a> NonLiquidityOrder<'a> {
     /// Wraps an order as a user order, returns `None` if the specified order is
     /// not a user order.
     pub fn new(order: &'a Order) -> Option<Self> {

--- a/crates/solvers/src/domain/order.rs
+++ b/crates/solvers/src/domain/order.rs
@@ -35,9 +35,9 @@ pub enum Class {
 
 /// An order that is guaranteed to not be a liquidity order.
 #[derive(Debug)]
-pub struct NonLiquidityOrder<'a>(&'a Order);
+pub struct NonLiquidity<'a>(&'a Order);
 
-impl<'a> NonLiquidityOrder<'a> {
+impl<'a> NonLiquidity<'a> {
     /// Wraps an order as a user order, returns `None` if the specified order is
     /// not a user order.
     pub fn new(order: &'a Order) -> Option<Self> {

--- a/crates/solvers/src/domain/order.rs
+++ b/crates/solvers/src/domain/order.rs
@@ -1,0 +1,54 @@
+//! The domain object representing a CoW Protocol order.
+
+use crate::domain::eth;
+
+/// A CoW Protocol order in the auction.
+#[derive(Debug, Clone)]
+pub struct Order {
+    pub uid: Uid,
+    pub sell: eth::Asset,
+    pub buy: eth::Asset,
+    pub side: Side,
+    pub class: Class,
+}
+
+/// UID of an order.
+#[derive(Debug, Clone, Copy)]
+pub struct Uid(pub [u8; 56]);
+
+/// The trading side of an order.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Side {
+    /// An order with a fixed buy amount and maximum sell amount.
+    Buy,
+    /// An order with a fixed sell amount and a minimum buy amount.
+    Sell,
+}
+
+/// The order classification.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Class {
+    Market,
+    Limit,
+    Liquidity,
+}
+
+/// A user order marker type.
+#[derive(Debug)]
+pub struct UserOrder<'a>(&'a Order);
+
+impl<'a> UserOrder<'a> {
+    /// Wraps an order as a user order, returns `None` if the specified order is
+    /// not a user order.
+    pub fn new(order: &'a Order) -> Option<Self> {
+        match order.class {
+            Class::Market | Class::Limit => Some(Self(order)),
+            Class::Liquidity => None,
+        }
+    }
+
+    /// Returns a reference to the underlying CoW Protocol order.
+    pub fn get(&self) -> &'a Order {
+        self.0
+    }
+}


### PR DESCRIPTION
This PR adds the `Order` domain model. Additionally, it introduces a `NonLiquidity` marker type that wraps an order to indicate that it is a user and non-liquidity order. This allows the Baseline solver to operate on `NonLiquidity` orders only so it never accidentally solver for a liquidity order.

### Test Plan

Rust compiler. An E2E test will be added for testing baseline solving.