### PR TITLE
Log DB byte arrays as hex string

### DIFF
--- a/crates/database/src/byte_array.rs
+++ b/crates/database/src/byte_array.rs
@@ -1,3 +1,4 @@
+use std::fmt::{self, Formatter, Debug};
 use sqlx::{
     encode::IsNull,
     error::BoxDynError,
@@ -6,8 +7,14 @@ use sqlx::{
 };
 
 /// Wrapper type for fixed size byte arrays compatible with sqlx's Postgres implementation.
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy)]
 pub struct ByteArray<const N: usize>(pub [u8; N]);
+
+impl<const N: usize> Debug for ByteArray<N> {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        write!(f, "0x{}", hex::encode(self.0))
+    }
+}
 
 impl<const N: usize> Default for ByteArray<N> {
     fn default() -> Self {

--- a/crates/database/src/byte_array.rs
+++ b/crates/database/src/byte_array.rs
@@ -1,10 +1,10 @@
-use std::fmt::{self, Formatter, Debug};
 use sqlx::{
     encode::IsNull,
     error::BoxDynError,
     postgres::{PgArgumentBuffer, PgHasArrayType, PgTypeInfo, PgValueFormat, PgValueRef},
     Decode, Encode, Postgres, Type,
 };
+use std::fmt::{self, Debug, Formatter};
 
 /// Wrapper type for fixed size byte arrays compatible with sqlx's Postgres implementation.
 #[derive(Clone, Copy)]


### PR DESCRIPTION
When I started updating identical `surplus_fee`s in bulk I introduced an unreadable tracing span into our log messages. This PR implements `Debug` for the DB `ByteArray` such that it prints a hex encoded string instead of an array of numbers.

### Test Plan
compare logs
old: `2023-01-11T11:03:59.059Z DEBUG surplus_fee{order_spec=OrderFeeSpecifier { sell_token: ByteArray([218, 193, 127, 149, 141, 46, 229, 35, 162, 32, 98, 6, 153, 69, 151, 193, 61, 131, 30, 199]), buy_token: ByteArray([67, 171, 118, 94, 224, 80, 117, 215, 138, 216, 170, 121, 220, 177, 151, 140, 163, 7, 146, 88]), sell_amount: BigDecimal("1000000000") }}: shared::rate_limiter: reset rate limit ...`
new: `2023-01-11T11:13:11.459Z DEBUG surplus_fee{order_spec=OrderFeeSpecifier { sell_token: 0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2, buy_token: 0xd4c435f5b09f855c3317c8524cb1f586e42795fa, sell_amount: BigDecimal("500000000000000000") }}: shared::order_quoting: computed quote quote=Quote ...`
