### PR TITLE
Native price cache concurrent requests

### DIFF
--- a/crates/autopilot/src/solvable_orders.rs
+++ b/crates/autopilot/src/solvable_orders.rs
@@ -815,6 +815,7 @@ mod tests {
             Duration::MAX,
             None,
             None,
+            1,
         );
 
         // We'll have no native prices in this call. But this call will cause a background task

--- a/crates/e2e/tests/e2e/services.rs
+++ b/crates/e2e/tests/e2e/services.rs
@@ -147,6 +147,7 @@ impl OrderbookServices {
             Duration::from_secs(10),
             None,
             None,
+            1,
         ));
         let quoter = Arc::new(OrderQuoter::new(
             price_estimator.clone(),

--- a/crates/shared/src/price_estimation.rs
+++ b/crates/shared/src/price_estimation.rs
@@ -99,7 +99,7 @@ pub struct Arguments {
     pub native_price_cache_max_update_size: usize,
 
     /// How many price estimation requests can be executed concurrently in the maintenance task.
-    #[clap(long, env, default_value = "3")]
+    #[clap(long, env, default_value = "1")]
     pub native_price_cache_concurrent_requests: usize,
 
     /// The amount in native tokens atoms to use for price estimation. Should be reasonably large so
@@ -154,6 +154,11 @@ impl Display for Arguments {
             f,
             "native_price_cache_max_update_size: {}",
             self.native_price_cache_max_update_size
+        )?;
+        writeln!(
+            f,
+            "native_price_cache_concurrent_requests: {}",
+            self.native_price_cache_concurrent_requests
         )?;
         display_option(
             f,

--- a/crates/shared/src/price_estimation.rs
+++ b/crates/shared/src/price_estimation.rs
@@ -98,6 +98,10 @@ pub struct Arguments {
     #[clap(long, env, default_value = "3")]
     pub native_price_cache_max_update_size: usize,
 
+    /// How many price estimation requests can be executed concurrently in the maintenance task.
+    #[clap(long, env, default_value = "3")]
+    pub native_price_cache_concurrent_requests: usize,
+
     /// The amount in native tokens atoms to use for price estimation. Should be reasonably large so
     /// that small pools do not influence the prices. If not set a reasonable default is used based
     /// on network id.

--- a/crates/shared/src/price_estimation/factory.rs
+++ b/crates/shared/src/price_estimation/factory.rs
@@ -334,6 +334,7 @@ impl<'a> PriceEstimatorFactory<'a> {
             self.args.native_price_cache_refresh_secs,
             Some(self.args.native_price_cache_max_update_size),
             None,
+            self.args.native_price_cache_concurrent_requests,
         ));
         Ok(native_estimator)
     }

--- a/crates/shared/src/price_estimation/native.rs
+++ b/crates/shared/src/price_estimation/native.rs
@@ -17,7 +17,6 @@ pub fn default_amount_to_estimate_native_prices_with(chain_id: u64) -> Option<U2
 }
 
 #[mockall::automock]
-#[async_trait::async_trait]
 pub trait NativePriceEstimating: Send + Sync {
     /// Like `PriceEstimating::estimates`.
     ///

--- a/crates/shared/src/price_estimation/native_price_cache.rs
+++ b/crates/shared/src/price_estimation/native_price_cache.rs
@@ -240,7 +240,6 @@ async fn update_recently_used_outdated_prices(
     concurrent_requests: usize,
 ) {
     while let Some(inner) = inner.upgrade() {
-        tracing::error!("run background task");
         let now = Instant::now();
 
         let mut outdated_entries: Vec<_> = inner


### PR DESCRIPTION
If we want to be able to keep all limit orders quoted at the same time we have to keep the native price cache up-to-date at all times. Unfortunately the number of unique tokens across all limit orders is too big (~200) for the native price cache background worker to keep up-to-date when we are updating prices purely sequentially.

This PR introduces a CLI argument (`--native-price-cache-concurrent-requests`) which allows the background worker to update prices concurrently.
This PR in conjunction with #1053 should allow us to perfectly tweak the parameters required to keep the native price cache entirely up-to-date on average.


### Test Plan
Updated existing unit tests
Added new unit test
Manual test to verify argument printing:
```
2023-01-12T10:22:46.540Z  INFO autopilot: running autopilot with validated arguments:
...
native_price_cache_max_update_size: 100
native_price_cache_concurrent_requests: 1
amount_to_estimate_prices_with: None
...
```
Manual test to verify help text:
```
      --native-price-cache-concurrent-requests <NATIVE_PRICE_CACHE_CONCURRENT_REQUESTS>
          How many price estimation requests can be executed concurrently in the maintenance task

          [env: NATIVE_PRICE_CACHE_CONCURRENT_REQUESTS=]
          [default: 1]
```
