### PR TITLE
Do not treat http solver rate limit as generic error

### DIFF
--- a/crates/shared/src/rate_limiter.rs
+++ b/crates/shared/src/rate_limiter.rs
@@ -174,8 +174,9 @@ impl RateLimiter {
     }
 }
 
-#[derive(Error, Debug, Clone)]
+#[derive(Error, Debug, Clone, Default)]
 pub enum RateLimiterError {
+    #[default]
     #[error("rate limited")]
     RateLimited,
 }


### PR DESCRIPTION
Quasimodo has recently gotten the ability to signal when it can't keep up through the TOO_MANY_REQUESTS status code. Our code is not aware of this and treats it as a generic error. Generic errors sometimes end up logged as internal errors so that we can investigate them. This doesn't make sense for the rate limit.

This PR makes us aware of the rate limit and turns it into the already existing price estimation error of the same type.

Note that this PR does not make the Rust RateLimiter aware of this status code. We might want to integrate that this so that it counts towards our local rate limit too. This can be done in another PR.

### Test Plan

Didn't see a good way to unit test this. After merging the error logs about this status code should go away.
