### PR TITLE
Let http solvers indicate they cannot keep up

### DIFF
--- a/crates/driver/openapi.yml
+++ b/crates/driver/openapi.yml
@@ -23,6 +23,8 @@ paths:
                 $ref: "#/components/schemas/QuoteResponse"
         400:
           $ref: "#/components/responses/BadRequest"
+        429:
+          description: The solver cannot keep up. It is too busy to handle more requests.
         500:
           $ref: "#/components/responses/InternalServerError"
   /solve:

--- a/crates/solvers/openapi.yml
+++ b/crates/solvers/openapi.yml
@@ -26,6 +26,8 @@ paths:
                 $ref: "#/components/schemas/Solution"
         400:
           description: There is something wrong with the request.
+        429:
+          description: The solver cannot keep up. It is too busy to handle more requests.
         500:
           description: Something went wrong when handling the request.
 


### PR DESCRIPTION
Motivated by recent Quasimodo changes.

Note that for the driver API I only added the status code to /quote and not the other routes. The other routes should always be available.

### Test Plan

n/a

