### PR TITLE
Hook up Baseline Solver to API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3566,6 +3566,7 @@ dependencies = [
  "axum",
  "bigdecimal",
  "chrono",
+ "clap 4.0.8",
  "ethereum-types 0.12.1",
  "hex",
  "hyper",
@@ -3578,6 +3579,7 @@ dependencies = [
  "tokio",
  "tower",
  "tower-http",
+ "tracing",
 ]
 
 [[package]]

--- a/crates/solvers/Cargo.toml
+++ b/crates/solvers/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 axum = "0.6"
 bigdecimal = { version = "0.3", features = ["serde"] }
 chrono = { version = "0.4", features = ["serde"] }
+clap = { version = "4", features = ["derive", "env"] }
 ethereum-types = "0.12"
 hex = "0.4"
 hyper = "0.14"
@@ -22,3 +23,4 @@ tower-http = { version = "0.3", features = ["trace"] }
 # remove/re-evaluate these dependencies.
 model = { path = "../model" }
 shared = { path = "../shared" }
+tracing = { workspace = true }

--- a/crates/solvers/src/api/dto/mod.rs
+++ b/crates/solvers/src/api/dto/mod.rs
@@ -6,6 +6,13 @@ use serde::Serialize;
 pub use self::{auction::Auction, solution::Solution};
 
 #[derive(Debug, Serialize)]
+#[serde(untagged)]
+pub enum Response<T> {
+    Ok(T),
+    Err(Error),
+}
+
+#[derive(Debug, Serialize)]
 pub struct Error {
     pub message: &'static str,
 }

--- a/crates/solvers/src/api/mod.rs
+++ b/crates/solvers/src/api/mod.rs
@@ -1,11 +1,13 @@
 //! Serve a solver engine API.
 
-use std::{future::Future, net::SocketAddr};
+use crate::domain::baseline;
+use std::{future::Future, net::SocketAddr, sync::Arc};
 
 pub mod dto;
 
 pub struct Api {
     pub addr: SocketAddr,
+    pub solver: baseline::Baseline,
 }
 
 impl Api {
@@ -15,10 +17,11 @@ impl Api {
     ) -> Result<(), hyper::Error> {
         // Add middleware.
         let app = axum::Router::new()
+            .route("/", axum::routing::post(solve))
             .layer(
                 tower::ServiceBuilder::new().layer(tower_http::trace::TraceLayer::new_for_http()),
             )
-            .route("/", axum::routing::post(solve));
+            .with_state(Arc::new(self.solver));
 
         // Start the server.
         axum::Server::bind(&self.addr)
@@ -28,6 +31,31 @@ impl Api {
     }
 }
 
-async fn solve(_auction: axum::extract::Json<dto::Auction>) -> axum::response::Json<dto::Solution> {
-    axum::response::Json(dto::Solution::trivial())
+async fn solve(
+    state: axum::extract::State<Arc<baseline::Baseline>>,
+    auction: axum::extract::Json<dto::Auction>,
+) -> (
+    axum::http::StatusCode,
+    axum::response::Json<dto::Response<dto::Solution>>,
+) {
+    let auction = match auction.to_domain() {
+        Ok(value) => value,
+        Err(err) => {
+            return (
+                axum::http::StatusCode::BAD_REQUEST,
+                axum::response::Json(dto::Response::Err(err)),
+            )
+        }
+    };
+    let solution = state
+        .solve(&auction)
+        .into_iter()
+        .next()
+        .map(|solution| dto::Solution::from_domain(&solution))
+        .unwrap_or_else(dto::Solution::trivial);
+
+    (
+        axum::http::StatusCode::OK,
+        axum::response::Json(dto::Response::Ok(solution)),
+    )
 }

--- a/crates/solvers/src/api/mod.rs
+++ b/crates/solvers/src/api/mod.rs
@@ -41,17 +41,18 @@ async fn solve(
     let auction = match auction.to_domain() {
         Ok(value) => value,
         Err(err) => {
+            tracing::warn!(?err, "invalid auction");
             return (
                 axum::http::StatusCode::BAD_REQUEST,
                 axum::response::Json(dto::Response::Err(err)),
-            )
+            );
         }
     };
+
     let solution = state
         .solve(&auction)
-        .into_iter()
-        .next()
-        .map(|solution| dto::Solution::from_domain(&solution))
+        .first()
+        .map(dto::Solution::from_domain)
         .unwrap_or_else(dto::Solution::trivial);
 
     (

--- a/crates/solvers/src/cli/baseline.rs
+++ b/crates/solvers/src/cli/baseline.rs
@@ -1,0 +1,21 @@
+use crate::domain::eth;
+use clap::Args;
+
+/// Baseline solver command line arguments.
+#[derive(Args, Debug)]
+pub struct Arguments {
+    /// The address of the WETH contract.
+    #[arg(long, env)]
+    pub weth: eth::WethAddress,
+
+    /// List of base tokens to use when path finding. This defines the tokens
+    /// that can appear as intermediate "hops" within a trading route. Note that
+    /// the address specified with `--weth` is always considered a base token.
+    #[arg(long, env, value_delimiter = ',')]
+    pub base_tokens: Vec<eth::TokenAddress>,
+
+    /// The maximum number of hops to consider when finding the optimal trading
+    /// path.
+    #[arg(long, env, default_value = "2")]
+    pub max_hops: usize,
+}

--- a/crates/solvers/src/cli/mod.rs
+++ b/crates/solvers/src/cli/mod.rs
@@ -1,0 +1,36 @@
+//! CLI arguments for the `solvers` binary.
+
+mod baseline;
+
+use clap::{Args, Parser, Subcommand};
+use std::net::SocketAddr;
+
+/// Run a solver engine
+#[derive(Parser, Debug)]
+#[command(version)]
+pub struct Cli {
+    /// The log filter to use.
+    #[arg(long, env, default_value = "debug")]
+    pub log_filter: String,
+
+    #[command(flatten)]
+    pub arguments: Arguments,
+
+    #[command(subcommand)]
+    pub command: Command,
+}
+
+/// Shared solver engine arguments.
+#[derive(Args, Debug)]
+pub struct Arguments {
+    /// The socket address to bind to.
+    #[arg(long, env, default_value = "127.0.0.1:7872")]
+    pub addr: SocketAddr,
+}
+
+/// The solver engine command to run.
+#[derive(Subcommand, Debug)]
+pub enum Command {
+    /// Baseline solver.
+    Baseline(baseline::Arguments),
+}

--- a/crates/solvers/src/domain/eth/mod.rs
+++ b/crates/solvers/src/domain/eth/mod.rs
@@ -1,4 +1,8 @@
 use ethereum_types::{H160, U256};
+use std::{
+    fmt::{self, Display, Formatter},
+    str::FromStr,
+};
 
 /// An ERC20 token address.
 ///
@@ -6,9 +10,41 @@ use ethereum_types::{H160, U256};
 #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct TokenAddress(pub H160);
 
+impl Display for TokenAddress {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        f.write_str("0x")?;
+        for b in self.0.as_bytes() {
+            write!(f, "{b:02x}")?;
+        }
+        Ok(())
+    }
+}
+
+impl FromStr for TokenAddress {
+    type Err = <H160 as FromStr>::Err;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        s.parse().map(Self)
+    }
+}
+
 /// The WETH token (or equivalent) for the EVM compatible network.
 #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct WethAddress(pub H160);
+
+impl Display for WethAddress {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        write!(f, "{}", TokenAddress(self.0))
+    }
+}
+
+impl FromStr for WethAddress {
+    type Err = <H160 as FromStr>::Err;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        s.parse().map(Self)
+    }
+}
 
 /// An asset on the Ethereum blockchain. Represents a particular amount of a
 /// particular token.

--- a/crates/solvers/src/main.rs
+++ b/crates/solvers/src/main.rs
@@ -1,22 +1,40 @@
 // TODO remove this once the crate stabilizes a bit.
 #![allow(dead_code)]
 
-#[cfg(unix)]
-use tokio::signal::unix::{self, SignalKind};
-
 mod api;
 mod boundary;
+mod cli;
 mod domain;
 mod util;
 
+use crate::domain::baseline;
+use clap::Parser;
+#[cfg(unix)]
+use tokio::signal::unix::{self, SignalKind};
+use tracing::level_filters::LevelFilter;
+
 #[tokio::main]
 async fn main() {
-    run().await;
+    let cli = cli::Cli::parse();
+
+    shared::tracing::initialize(&cli.log_filter, LevelFilter::ERROR);
+    shared::exit_process_on_panic::set_panic_hook();
+
+    // TODO implement Display for the arguments
+    tracing::info!("running solver engine with {cli:#?}");
+    run(cli.arguments, cli.command).await;
 }
 
-async fn run() {
+async fn run(arguments: cli::Arguments, command: cli::Command) {
+    let cli::Command::Baseline(baseline) = command;
+
     api::Api {
-        addr: "127.0.0.1:7872".parse().unwrap(),
+        addr: arguments.addr,
+        solver: baseline::Baseline {
+            weth: baseline.weth,
+            base_tokens: baseline.base_tokens.into_iter().collect(),
+            max_hops: baseline.max_hops,
+        },
     }
     .serve(shutdown_signal())
     .await


### PR DESCRIPTION
Supersedes #1039 

As the title suggests, this PR hooks up the Baseline solver to the API endpoint in the `solvers` crate. Note that it is done in a very straight forward way - i.e. with the current implementation, multiple solver types are not implemented ATM. Once I add the second solver type, I will refactor the `api` module to make this possible.

Additionally, in order to configure the Baseline solver, I added some simple command line argument parsing. Note that the network-specific configuration options are included as command line arguments! Concretely, this means we will need a Baseline solver engine instance for each network. I _think_ this is a good thing as:
- It keeps per-network configuration to separate pods
- A spike in Görli and Gnosis Chain traffic will not affect Mainnet performance
- Allows custom scaling configurations per network (we can auto-scale Mainnet solvers to 10 GigaChad pods, but for Görli only use 1 pod with limited resources).

### Test Plan

It works!

```
% cargo run -p solvers -- baseline --weth 0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2
...
2023-01-12T21:25:36.334Z DEBUG request{method=POST uri=/ version=HTTP/1.1}: tower_http::trace::on_request: started processing request
2023-01-12T21:25:36.335Z DEBUG request{method=POST uri=/ version=HTTP/1.1}: tower_http::trace::on_response: finished processing request latency=1 ms status=200
...
```

<details><summary><code>auction.json</code></summary>

```json
{
  "id": null,
  "tokens": {
    "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2": {
      "decimals": 18,
      "symbol": "WETH",
      "referencePrice": "1000000000000000000",
      "availableBalance": "1412206645170290748",
      "trusted": true
    },
    "0xDEf1CA1fb7FBcDC777520aa7f396b4E015F497aB": {
      "decimals": 18,
      "symbol": "COW",
      "referencePrice": "53125132573502",
      "availableBalance": "740264138483556450389",
      "trusted": true
    }
  },
  "orders": [
    {
      "uid": "0x2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a",
      "sellToken": "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
      "buyToken": "0xDEf1CA1fb7FBcDC777520aa7f396b4E015F497aB",
      "sellAmount": "133700000000000000",
      "buyAmount": "6000000000000000000000",
      "feeAmount": "4200000000000000",
      "kind": "sell",
      "partiallyFillable": false,
      "class": "market",
      "reward": 42.42
    }
  ],
  "liquidity": [
    {
      "kind": "constantproduct",
      "tokens": {
        "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2": {
          "balance": "3828187314911751990"
        },
        "0xDEf1CA1fb7FBcDC777520aa7f396b4E015F497aB": {
          "balance": "179617892578796375604692"
        }
      },
      "fee": "0.003",
      "id": "0",
      "address": "0x97b744df0b59d93A866304f97431D8EfAd29a08d",
      "gasEstimate": 110000
    }
  ],
  "effectiveGasPrice": "15000000000",
  "deadline": "2024-01-01T00:00:00.000Z"
}
```

</details>

This produces a valid solution:
```
% curl -s localhost:7872 -H 'Content-Type: application/json' --data '@auction.json' | jq
{
  "prices": {
    "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2": "6043910341261930467761",
    "0xdef1ca1fb7fbcdc777520aa7f396b4e015f497ab": "133700000000000000"
  },
  "trades": [
    {
      "kind": "fulfillment",
      "order": "0x2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a",
      "executedAmount": "133700000000000000"
    }
  ],
  "interactions": [
    {
      "kind": "Liquidity",
      "internalize": false,
      "id": "0",
      "inputToken": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
      "outputToken": "0xdef1ca1fb7fbcdc777520aa7f396b4e015f497ab",
      "inputAmount": "133700000000000000",
      "outputAmount": "6043910341261930467761"
    }
  ]
}
```

Noting that [using the math from UniswapV2 library](https://github.com/Uniswap/v2-periphery/blob/0335e8f7e1bd1e8d8329fd300aea2ef2f36dd19f/contracts/libraries/UniswapV2Library.sol#L43-L50) we get the exact same output amount:
```
>>> (133700000000000000 * 997 * 179617892578796375604692) // (3828187314911751990 * 1000 + 133700000000000000 * 997)
6043910341261930467761
```

