### PR TITLE
Do not group s3 uploads by date

### DIFF
--- a/crates/solver/src/s3_instance_upload.rs
+++ b/crates/solver/src/s3_instance_upload.rs
@@ -1,7 +1,6 @@
 use anyhow::Result;
 use aws_sdk_s3::{types::ByteStream, Client, Credentials, Region};
 use aws_types::credentials::SharedCredentialsProvider;
-use chrono::{DateTime, Utc};
 use model::auction::AuctionId;
 
 #[derive(Default)]
@@ -43,13 +42,12 @@ impl S3InstanceUploader {
     ///
     /// The final filename is the configured prefix followed by `{current_date}/{auction_id}`.
     pub async fn upload_instance(&self, auction: AuctionId, value: Vec<u8>) -> Result<()> {
-        let key = self.filename(chrono::offset::Utc::now(), auction);
+        let key = self.filename(auction);
         self.upload(key, value).await
     }
 
-    fn filename(&self, now: DateTime<Utc>, auction: AuctionId) -> String {
-        let date = now.format("%Y-%m-%d");
-        format!("{}{date}/{auction}.json", self.filename_prefix)
+    fn filename(&self, auction: AuctionId) -> String {
+        format!("{}{auction}.json", self.filename_prefix)
     }
 
     async fn upload(&self, key: String, value: Vec<u8>) -> Result<()> {
@@ -71,8 +69,11 @@ mod tests {
     #[test]
     #[ignore]
     fn print_filename() {
-        let uploader = S3InstanceUploader::new(Default::default());
-        let key = uploader.filename(chrono::offset::Utc::now(), 11);
+        let uploader = S3InstanceUploader::new(Config {
+            filename_prefix: "test/".to_string(),
+            ..Default::default()
+        });
+        let key = uploader.filename(11);
         println!("{key}");
     }
 


### PR DESCRIPTION
I've been thinking about allowing external access to the s3 instances and came to the conclusion that it doesn't make sense to group them by date. The Gnosis s3 script does something like this, probably so that they can display the bucket like a folder structure without having too many files in the same folder. However, to S3 there are no folders. These are just files that happen to have slashes in their name. By introducing some arbitrary partitioning scheme like the date, we make it harder to know the path of an instance. By using only the id the path is perfectly predictable.

### Test Plan

manual test