### PR TITLE
Introduce Remaining Liquidity Domain Objects

### DIFF
--- a/crates/solvers/src/api/dto/auction.rs
+++ b/crates/solvers/src/api/dto/auction.rs
@@ -323,7 +323,7 @@ impl ConcentratedLiquidityPool {
             state: liquidity::State::Concentrated(liquidity::concentrated::Pool {
                 tokens,
                 sqrt_price: liquidity::concentrated::SqrtPrice(self.sqrt_price),
-                liquidity: liquidity::concentrated::LiquidityAmount(self.liquidity),
+                liquidity: liquidity::concentrated::Amount(self.liquidity),
                 tick: liquidity::concentrated::Tick(self.tick),
                 liquidity_net: self
                     .liquidity_net
@@ -331,7 +331,7 @@ impl ConcentratedLiquidityPool {
                     .map(|(tick, liquidity)| {
                         (
                             liquidity::concentrated::Tick(*tick),
-                            liquidity::concentrated::LiquidityAmount(*liquidity),
+                            liquidity::concentrated::Amount(*liquidity),
                         )
                     })
                     .collect(),

--- a/crates/solvers/src/api/dto/auction.rs
+++ b/crates/solvers/src/api/dto/auction.rs
@@ -43,12 +43,12 @@ impl Auction {
             liquidity: self
                 .liquidity
                 .iter()
-                .filter_map(|liquidity| match liquidity {
-                    Liquidity::ConstantProduct(liquidity) => Some(liquidity.to_domain()),
-                    Liquidity::WeightedProduct(liquidity) => Some(liquidity.to_domain()),
-                    Liquidity::Stable(_)
-                    | Liquidity::ConcentratedLiquidity(_)
-                    | Liquidity::LimitOrder(_) => None,
+                .map(|liquidity| match liquidity {
+                    Liquidity::ConstantProduct(liquidity) => liquidity.to_domain(),
+                    Liquidity::WeightedProduct(liquidity) => liquidity.to_domain(),
+                    Liquidity::Stable(liquidity) => liquidity.to_domain(),
+                    Liquidity::ConcentratedLiquidity(liquidity) => liquidity.to_domain(),
+                    Liquidity::LimitOrder(liquidity) => Ok(liquidity.to_domain()),
                 })
                 .try_collect()?,
         })
@@ -207,10 +207,8 @@ impl WeightedProductPool {
                         },
                         weight: conv::decimal_to_rational(&token.weight)
                             .ok_or("invalid token weight")?,
-                        scale: liquidity::weighted_product::ScalingFactor::new(
-                            token.scaling_factor,
-                        )
-                        .ok_or("invalid token scaling factor")?,
+                        scale: liquidity::ScalingFactor::new(token.scaling_factor)
+                            .ok_or("invalid token scaling factor")?,
                     })
                 })
                 .collect::<Result<Vec<_>, Error>>()?;
@@ -224,7 +222,7 @@ impl WeightedProductPool {
             gas: eth::Gas(self.gas_estimate.into()),
             state: liquidity::State::WeightedProduct(liquidity::weighted_product::Pool {
                 reserves,
-                fee: conv::decimal_to_rational(&self.fee).ok_or("invalid constant product fee")?,
+                fee: conv::decimal_to_rational(&self.fee).ok_or("invalid weighted product fee")?,
             }),
         })
     }
@@ -252,6 +250,40 @@ struct StableReserve {
     scaling_factor: U256,
 }
 
+impl StablePool {
+    fn to_domain(&self) -> Result<liquidity::Liquidity, Error> {
+        let reserves = {
+            let entries = self
+                .tokens
+                .iter()
+                .map(|(address, token)| {
+                    Ok(liquidity::stable::Reserve {
+                        asset: eth::Asset {
+                            token: eth::TokenAddress(*address),
+                            amount: token.balance,
+                        },
+                        scale: liquidity::ScalingFactor::new(token.scaling_factor)
+                            .ok_or("invalid token scaling factor")?,
+                    })
+                })
+                .collect::<Result<Vec<_>, Error>>()?;
+            liquidity::stable::Reserves::new(entries).ok_or("duplicate stable token addresss")?
+        };
+
+        Ok(liquidity::Liquidity {
+            id: liquidity::Id(self.id.clone()),
+            address: self.address,
+            gas: eth::Gas(self.gas_estimate.into()),
+            state: liquidity::State::Stable(liquidity::stable::Pool {
+                reserves,
+                amplification_parameter: conv::decimal_to_rational(&self.amplification_parameter)
+                    .ok_or("invalid amplification parameter")?,
+                fee: conv::decimal_to_rational(&self.fee).ok_or("invalid stable pool fee")?,
+            }),
+        })
+    }
+}
+
 #[serde_as]
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -268,6 +300,46 @@ struct ConcentratedLiquidityPool {
     #[serde_as(as = "HashMap<DisplayFromStr, serialize::U256>")]
     liquidity_net: HashMap<i32, U256>,
     fee: BigDecimal,
+}
+
+impl ConcentratedLiquidityPool {
+    fn to_domain(&self) -> Result<liquidity::Liquidity, Error> {
+        let tokens = {
+            let (a, b) = self
+                .tokens
+                .iter()
+                .copied()
+                .map(eth::TokenAddress)
+                .collect_tuple()
+                .ok_or("invalid number of concentrated liquidity pool tokens")?;
+            liquidity::TokenPair::new(a, b)
+                .ok_or("duplicate concentrated liquidity pool token address")?
+        };
+
+        Ok(liquidity::Liquidity {
+            id: liquidity::Id(self.id.clone()),
+            address: self.address,
+            gas: eth::Gas(self.gas_estimate.into()),
+            state: liquidity::State::Concentrated(liquidity::concentrated::Pool {
+                tokens,
+                sqrt_price: liquidity::concentrated::SqrtPrice(self.sqrt_price),
+                liquidity: liquidity::concentrated::LiquidityAmount(self.liquidity),
+                tick: liquidity::concentrated::Tick(self.tick),
+                liquidity_net: self
+                    .liquidity_net
+                    .iter()
+                    .map(|(tick, liquidity)| {
+                        (
+                            liquidity::concentrated::Tick(*tick),
+                            liquidity::concentrated::LiquidityAmount(*liquidity),
+                        )
+                    })
+                    .collect(),
+                fee: conv::decimal_to_rational(&self.fee)
+                    .ok_or("invalid concentrated liquidity pool fee")?,
+            }),
+        })
+    }
 }
 
 #[serde_as]
@@ -287,4 +359,25 @@ struct ForeignLimitOrder {
     taker_amount: U256,
     #[serde_as(as = "serialize::U256")]
     taker_token_fee_amount: U256,
+}
+
+impl ForeignLimitOrder {
+    fn to_domain(&self) -> liquidity::Liquidity {
+        liquidity::Liquidity {
+            id: liquidity::Id(self.id.clone()),
+            address: self.address,
+            gas: eth::Gas(self.gas_estimate.into()),
+            state: liquidity::State::LimitOrder(liquidity::limit_order::LimitOrder {
+                maker: eth::Asset {
+                    token: eth::TokenAddress(self.maker_token),
+                    amount: self.maker_amount,
+                },
+                taker: eth::Asset {
+                    token: eth::TokenAddress(self.taker_token),
+                    amount: self.taker_amount,
+                },
+                fee: liquidity::limit_order::TakerAmount(self.taker_token_fee_amount),
+            }),
+        }
+    }
 }

--- a/crates/solvers/src/boundary/baseline.rs
+++ b/crates/solvers/src/boundary/baseline.rs
@@ -133,7 +133,7 @@ fn to_boundary_amms(liquidity: &[liquidity::Liquidity]) -> HashMap<TokenPair, Ve
                             pool,
                         )
                     {
-                        for pair in pool.token_pairs() {
+                        for pair in pool.reserves.token_pairs() {
                             let token_pair = to_boundary_token_pair(&pair);
                             amms.entry(token_pair).or_default().push(Amm {
                                 id: liquidity.id.clone(),
@@ -143,6 +143,8 @@ fn to_boundary_amms(liquidity: &[liquidity::Liquidity]) -> HashMap<TokenPair, Ve
                         }
                     }
                 }
+                // The baseline solver does not currently support other AMMs.
+                _ => {}
             };
             amms
         })

--- a/crates/solvers/src/domain/liquidity/concentrated.rs
+++ b/crates/solvers/src/domain/liquidity/concentrated.rs
@@ -7,9 +7,9 @@ use std::collections::BTreeMap;
 pub struct Pool {
     pub tokens: liquidity::TokenPair,
     pub sqrt_price: SqrtPrice,
-    pub liquidity: LiquidityAmount,
+    pub liquidity: Amount,
     pub tick: Tick,
-    pub liquidity_net: BTreeMap<Tick, LiquidityAmount>,
+    pub liquidity_net: BTreeMap<Tick, Amount>,
     pub fee: eth::Rational,
 }
 
@@ -26,8 +26,12 @@ pub struct SqrtPrice(pub U256);
 /// The exact amount in tokens that this liquidity represents is dependant on
 /// the current state of the pool.
 #[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
-pub struct LiquidityAmount(pub U256);
+pub struct Amount(pub U256);
 
-/// A liquidity tick.
+/// An index to a tick within a concentrated liquidity pool.
+///
+/// A tick represents a +/- 0.01% partition of the price space where liquidity
+/// positions may exist. For more information, consult the
+/// [Uniswap V3 documentation](https://docs.uniswap.org/concepts/protocol/concentrated-liquidity#ticks).
 #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct Tick(pub i32);

--- a/crates/solvers/src/domain/liquidity/concentrated.rs
+++ b/crates/solvers/src/domain/liquidity/concentrated.rs
@@ -1,0 +1,33 @@
+use crate::domain::{eth, liquidity};
+use ethereum_types::U256;
+use std::collections::BTreeMap;
+
+/// State for a UniswapV3-like concentrated liquidity pool.
+#[derive(Clone, Debug)]
+pub struct Pool {
+    pub tokens: liquidity::TokenPair,
+    pub sqrt_price: SqrtPrice,
+    pub liquidity: LiquidityAmount,
+    pub tick: Tick,
+    pub liquidity_net: BTreeMap<Tick, LiquidityAmount>,
+    pub fee: eth::Rational,
+}
+
+/// A compressed representation of the current exchange rate between the tokens
+/// belonging to a pool.
+///
+/// Specifically, this is the representation used in the Uniswap V3 contracts
+/// that are needed for amount input and output computation.
+#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
+pub struct SqrtPrice(pub U256);
+
+/// An amount of concetrated liquidity within a pool.
+///
+/// The exact amount in tokens that this liquidity represents is dependant on
+/// the current state of the pool.
+#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
+pub struct LiquidityAmount(pub U256);
+
+/// A liquidity tick.
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub struct Tick(pub i32);

--- a/crates/solvers/src/domain/liquidity/limit_order.rs
+++ b/crates/solvers/src/domain/liquidity/limit_order.rs
@@ -1,0 +1,24 @@
+use crate::domain::eth;
+use ethereum_types::U256;
+
+/// A 0x-like foreign limit order.
+#[derive(Clone, Debug)]
+pub struct LimitOrder {
+    pub maker: eth::Asset,
+    pub taker: eth::Asset,
+    pub fee: TakerAmount,
+}
+
+impl LimitOrder {
+    /// Returns the fee amount as an asset.
+    pub fn fee(&self) -> eth::Asset {
+        eth::Asset {
+            token: self.taker.token,
+            amount: self.fee.0,
+        }
+    }
+}
+
+/// An amount denominated in the taker token of a [`LimitOrder`].
+#[derive(Debug, Clone, Copy)]
+pub struct TakerAmount(pub U256);

--- a/crates/solvers/src/domain/liquidity/mod.rs
+++ b/crates/solvers/src/domain/liquidity/mod.rs
@@ -1,10 +1,13 @@
 //! Modelling on-chain liquidity.
 
+pub mod concentrated;
 pub mod constant_product;
+pub mod limit_order;
+pub mod stable;
 pub mod weighted_product;
 
 use crate::domain::eth;
-use ethereum_types::H160;
+use ethereum_types::{H160, U256};
 use std::cmp::Ordering;
 
 /// A source of liquidity which can be used by the solver.
@@ -25,6 +28,9 @@ pub struct Id(pub String);
 pub enum State {
     ConstantProduct(constant_product::Pool),
     WeightedProduct(weighted_product::Pool),
+    Stable(stable::Pool),
+    Concentrated(concentrated::Pool),
+    LimitOrder(limit_order::LimitOrder),
 }
 
 /// An ordered token pair.
@@ -45,5 +51,82 @@ impl TokenPair {
     /// Returns the wrapped token pair as a tuple.
     pub fn get(&self) -> (eth::TokenAddress, eth::TokenAddress) {
         (self.0, self.1)
+    }
+}
+
+/// A scaling factor used for normalizing token amounts.
+#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
+pub struct ScalingFactor(U256);
+
+impl ScalingFactor {
+    /// Creates a new scaling factor. Returns `None` if the value is not a power
+    /// of 10.
+    pub fn new(value: U256) -> Option<Self> {
+        if !Self::is_power_of_10(value) {
+            return None;
+        }
+        Some(Self(value))
+    }
+
+    /// Returns the underlying scaling factor value.
+    pub fn get(&self) -> U256 {
+        self.0
+    }
+
+    /// Returns the exponent of a scaling factor.
+    pub fn exponent(&self) -> u8 {
+        let mut factor = self.0;
+        let mut exponent = 0_u8;
+        while factor > U256::one() {
+            factor /= 10;
+            exponent += 1;
+        }
+        exponent
+    }
+
+    fn is_power_of_10(mut value: U256) -> bool {
+        while value > U256::one() {
+            let (quotient, remainder) = value.div_mod(10.into());
+            if !remainder.is_zero() {
+                return false;
+            }
+            value = quotient;
+        }
+        value == U256::one()
+    }
+}
+
+impl Default for ScalingFactor {
+    fn default() -> Self {
+        Self(U256::one())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn scaling_factor_requires_power_of_10() {
+        for result in [
+            ScalingFactor::new(0.into()),
+            ScalingFactor::new(9.into()),
+            ScalingFactor::new(11.into()),
+            ScalingFactor::new(90.into()),
+            ScalingFactor::new(99.into()),
+            ScalingFactor::new(101.into()),
+            ScalingFactor::new(110.into()),
+            ScalingFactor::new(100010000.into()),
+        ] {
+            assert!(result.is_none());
+        }
+    }
+
+    #[test]
+    fn scaling_factor_computes_exponent() {
+        for i in 0..18 {
+            let factor = ScalingFactor::new(U256::from(10).pow(i.into())).unwrap();
+            assert_eq!(factor.exponent(), i);
+        }
     }
 }


### PR DESCRIPTION
In order to integrate the remaining Gnosis solvers, we need to map the remaining liquidity from the Auction DTO into domain objects.

This PR introduces new liquidity types as well as mapping boilerplate between the DTOs and the domain objects.

### Test Plan

Rust compiler, just simple data-mapping.
