### PR TITLE
Do not emit negative objective value settlements in zeroex solver

### DIFF
--- a/crates/solver/src/solver/single_order_solver.rs
+++ b/crates/solver/src/solver/single_order_solver.rs
@@ -208,7 +208,7 @@ pub struct SingleOrderSettlement {
 }
 
 impl SingleOrderSettlement {
-    fn into_settlement(self, order: &LimitOrder) -> Result<Settlement> {
+    pub fn into_settlement(self, order: &LimitOrder) -> Result<Settlement> {
         let prices = [
             (order.sell_token, self.sell_token_price),
             (order.buy_token, self.buy_token_price),


### PR DESCRIPTION
Fixes https://github.com/cowprotocol/services/issues/1021
Closes https://github.com/cowprotocol/services/pull/1025 

See #1021 for motivation for this change.

I have intentionally not implemented Nic's [suggestion](https://github.com/cowprotocol/services/pull/1025#discussion_r1060501210) of only checking for negative objective value *after* merging all single solutions. This is because it makes more sense to filter out bad solutions individually. If we have some good orders and some bad orders (like stable to stable trade) then filtering out after merging could make the whole settlement become bad. By filtering before merging this doesn't happen and we can still merge all the good orders. There is some space for a more optimal algorithm but I felt the complexity wasn't worth it. I expect that almost always filtering before merging is what we want.

Follow ups:
- Maybe add some gas overhead to the 0x gas estimate because we go through our settlement contract.
- Maybe simulate the 0x solution to get our own gas estimate.
- Check that we aren't filtering out too many orders that are not stable-to-stable traders.
- Re-enable the zeroex solver in our cluster.

### Test Plan

added unit test
