### PR TITLE
Better tracability with more info spans

### DIFF
--- a/crates/autopilot/src/lib.rs
+++ b/crates/autopilot/src/lib.rs
@@ -85,7 +85,10 @@ impl LivenessChecking for Liveness {
 /// Assumes tracing and metrics registry have already been set up.
 pub async fn main(args: arguments::Arguments) -> ! {
     let db = Postgres::new(args.db_url.as_str()).await.unwrap();
-    tokio::task::spawn(crate::database::database_metrics(db.clone()));
+    tokio::task::spawn(
+        crate::database::database_metrics(db.clone())
+            .instrument(tracing::info_span!("database_metrics")),
+    );
 
     let http_factory = HttpClientFactory::new(&args.http_client);
     let web3 = shared::ethrpc::web3(

--- a/crates/autopilot/src/lib.rs
+++ b/crates/autopilot/src/lib.rs
@@ -564,7 +564,7 @@ pub async fn main(args: arguments::Arguments) -> ! {
     tokio::task::spawn(
         auction_transaction_updater
             .run_forever()
-            .instrument(tracing::info_span!("AuctionTransactionUpdater")),
+            .instrument(tracing::info_span!("auction_transaction_updater")),
     );
 
     if args.enable_limit_orders {

--- a/crates/autopilot/src/limit_orders/metrics.rs
+++ b/crates/autopilot/src/limit_orders/metrics.rs
@@ -54,7 +54,7 @@ impl LimitOrderMetrics {
                     tokio::time::sleep(Duration::from_secs(10)).await;
                 }
             }
-            .instrument(tracing::info_span!("LimitOrderMetrics")),
+            .instrument(tracing::info_span!("limit_order_metrics")),
         );
     }
 }

--- a/crates/autopilot/src/limit_orders/metrics.rs
+++ b/crates/autopilot/src/limit_orders/metrics.rs
@@ -1,4 +1,5 @@
 use std::time::Duration;
+use tracing::Instrument;
 
 use prometheus::IntGauge;
 
@@ -14,43 +15,47 @@ pub struct LimitOrderMetrics {
 
 impl LimitOrderMetrics {
     pub fn spawn(self) {
-        tokio::spawn(async move {
-            let limit_orders_gauge = gauge("limit_orders", "Open limit orders.");
-            let quoted_limit_orders_gauge = gauge("quoted_limit_orders", "Quoted limit orders.");
-            let unquoted_limit_orders_gauge =
-                gauge("unquoted_limit_orders", "Limit orders awaiting a quote.");
-            let usable_limit_orders_gauge =
-                gauge("usable_limit_orders", "Limit orders usable in the auction.");
-            let unusable_limit_orders_gauge = gauge(
-                "unusable_limit_orders",
-                "Limit orders with surplus_fee too old for the auction.",
-            );
+        tokio::spawn(
+            async move {
+                let limit_orders_gauge = gauge("limit_orders", "Open limit orders.");
+                let quoted_limit_orders_gauge =
+                    gauge("quoted_limit_orders", "Quoted limit orders.");
+                let unquoted_limit_orders_gauge =
+                    gauge("unquoted_limit_orders", "Limit orders awaiting a quote.");
+                let usable_limit_orders_gauge =
+                    gauge("usable_limit_orders", "Limit orders usable in the auction.");
+                let unusable_limit_orders_gauge = gauge(
+                    "unusable_limit_orders",
+                    "Limit orders with surplus_fee too old for the auction.",
+                );
 
-            loop {
-                let limit_orders = self.database.count_limit_orders().await.unwrap();
-                let awaiting_quote = self
-                    .database
-                    .count_limit_orders_with_outdated_fees(self.quoting_age)
-                    .await
-                    .unwrap();
-                let unusable = self
-                    .database
-                    .count_limit_orders_with_outdated_fees(self.validity_age)
-                    .await
-                    .unwrap();
+                loop {
+                    let limit_orders = self.database.count_limit_orders().await.unwrap();
+                    let awaiting_quote = self
+                        .database
+                        .count_limit_orders_with_outdated_fees(self.quoting_age)
+                        .await
+                        .unwrap();
+                    let unusable = self
+                        .database
+                        .count_limit_orders_with_outdated_fees(self.validity_age)
+                        .await
+                        .unwrap();
 
-                let quoted_limit_orders = limit_orders - awaiting_quote;
-                let usable_limit_orders = limit_orders - unusable;
+                    let quoted_limit_orders = limit_orders - awaiting_quote;
+                    let usable_limit_orders = limit_orders - unusable;
 
-                limit_orders_gauge.set(limit_orders);
-                unquoted_limit_orders_gauge.set(awaiting_quote);
-                quoted_limit_orders_gauge.set(quoted_limit_orders);
-                usable_limit_orders_gauge.set(usable_limit_orders);
-                unusable_limit_orders_gauge.set(unusable);
+                    limit_orders_gauge.set(limit_orders);
+                    unquoted_limit_orders_gauge.set(awaiting_quote);
+                    quoted_limit_orders_gauge.set(quoted_limit_orders);
+                    usable_limit_orders_gauge.set(usable_limit_orders);
+                    unusable_limit_orders_gauge.set(unusable);
 
-                tokio::time::sleep(Duration::from_secs(10)).await;
+                    tokio::time::sleep(Duration::from_secs(10)).await;
+                }
             }
-        });
+            .instrument(tracing::info_span!("LimitOrderMetrics")),
+        );
     }
 }
 

--- a/crates/autopilot/src/limit_orders/quoter.rs
+++ b/crates/autopilot/src/limit_orders/quoter.rs
@@ -33,7 +33,11 @@ pub struct LimitOrderQuoter {
 
 impl LimitOrderQuoter {
     pub fn spawn(self) {
-        tokio::spawn(async move { self.background_task().await });
+        tokio::spawn(async move {
+            self.background_task()
+                .instrument(tracing::info_span!("LimitOrderQuoter"))
+                .await
+        });
     }
 
     async fn background_task(&self) -> ! {

--- a/crates/autopilot/src/limit_orders/quoter.rs
+++ b/crates/autopilot/src/limit_orders/quoter.rs
@@ -35,7 +35,7 @@ impl LimitOrderQuoter {
     pub fn spawn(self) {
         tokio::spawn(async move {
             self.background_task()
-                .instrument(tracing::info_span!("LimitOrderQuoter"))
+                .instrument(tracing::info_span!("limit_order_quoter"))
                 .await
         });
     }

--- a/crates/autopilot/src/solvable_orders.rs
+++ b/crates/autopilot/src/solvable_orders.rs
@@ -127,7 +127,7 @@ impl SolvableOrdersCache {
         });
         tokio::task::spawn(
             update_task(Arc::downgrade(&self_), update_interval, current_block)
-                .instrument(tracing::info_span!("SolvableOrdersCache")),
+                .instrument(tracing::info_span!("solvable_orders_cache")),
         );
         self_
     }

--- a/crates/autopilot/src/solvable_orders.rs
+++ b/crates/autopilot/src/solvable_orders.rs
@@ -27,6 +27,7 @@ use std::{
 };
 use strum::VariantNames;
 use tokio::time::Instant;
+use tracing::Instrument;
 
 #[derive(prometheus_metric_storage::MetricStorage)]
 pub struct Metrics {
@@ -124,11 +125,10 @@ impl SolvableOrdersCache {
             surplus_fee_age,
             limit_order_price_factor,
         });
-        tokio::task::spawn(update_task(
-            Arc::downgrade(&self_),
-            update_interval,
-            current_block,
-        ));
+        tokio::task::spawn(
+            update_task(Arc::downgrade(&self_), update_interval, current_block)
+                .instrument(tracing::info_span!("SolvableOrdersCache")),
+        );
         self_
     }
 

--- a/crates/shared/src/bad_token/token_owner_finder/solvers/solver_finder.rs
+++ b/crates/shared/src/bad_token/token_owner_finder/solvers/solver_finder.rs
@@ -12,6 +12,7 @@ use std::{
     sync::{Arc, RwLock},
     time::Duration,
 };
+use tracing::Instrument;
 
 type Token = H160;
 type Owner = H160;
@@ -74,7 +75,9 @@ impl AutoUpdatingSolverTokenOwnerFinder {
                     tokio::time::sleep(update_interval).await;
                 }
             };
-            tokio::task::spawn(updater);
+            tokio::task::spawn(
+                updater.instrument(tracing::info_span!("AutoUpdatingSolverTokenOwnerFinder")),
+            );
         }
 
         Self { inner }

--- a/crates/shared/src/bad_token/token_owner_finder/solvers/solver_finder.rs
+++ b/crates/shared/src/bad_token/token_owner_finder/solvers/solver_finder.rs
@@ -76,7 +76,7 @@ impl AutoUpdatingSolverTokenOwnerFinder {
                 }
             };
             tokio::task::spawn(
-                updater.instrument(tracing::info_span!("AutoUpdatingSolverTokenOwnerFinder")),
+                updater.instrument(tracing::info_span!("auto_updating_token_owner_finder")),
             );
         }
 

--- a/crates/shared/src/current_block.rs
+++ b/crates/shared/src/current_block.rs
@@ -8,6 +8,7 @@ use primitive_types::H256;
 use std::{sync::Arc, time::Duration};
 use tokio::sync::watch;
 use tokio_stream::wrappers::WatchStream;
+use tracing::Instrument;
 use web3::{
     helpers,
     types::{BlockId, BlockNumber, U64},
@@ -91,7 +92,7 @@ pub async fn current_block_stream(
         }
     };
 
-    tokio::task::spawn(update_future);
+    tokio::task::spawn(update_future.instrument(tracing::info_span!("CurrentBlockStream")));
     Ok(receiver)
 }
 

--- a/crates/shared/src/current_block.rs
+++ b/crates/shared/src/current_block.rs
@@ -92,7 +92,7 @@ pub async fn current_block_stream(
         }
     };
 
-    tokio::task::spawn(update_future.instrument(tracing::info_span!("CurrentBlockStream")));
+    tokio::task::spawn(update_future.instrument(tracing::info_span!("current_block_stream")));
     Ok(receiver)
 }
 

--- a/crates/shared/src/http_solver.rs
+++ b/crates/shared/src/http_solver.rs
@@ -7,6 +7,7 @@ use reqwest::{
 };
 use serde_json::json;
 use std::time::Duration;
+use tracing::Instrument;
 
 pub mod gas_model;
 pub mod model;
@@ -216,7 +217,7 @@ impl HttpSolverApi for DefaultHttpSolverApi {
 
             let _result = request.json(&json!(result)).send().await;
         };
-        tokio::task::spawn(future);
+        tokio::task::spawn(future.instrument(tracing::Span::current()));
     }
 }
 

--- a/crates/shared/src/maintenance.rs
+++ b/crates/shared/src/maintenance.rs
@@ -123,6 +123,7 @@ impl ServiceMaintenance {
 
     pub async fn run_maintenance_on_new_block(self, current_block_stream: CurrentBlockStream) -> ! {
         self.run_maintenance_for_blocks(current_block::into_stream(current_block_stream))
+            .instrument(tracing::info_span!("ServiceMaintenance"))
             .await;
         panic!("block stream unexpectedly dropped");
     }

--- a/crates/shared/src/maintenance.rs
+++ b/crates/shared/src/maintenance.rs
@@ -123,7 +123,7 @@ impl ServiceMaintenance {
 
     pub async fn run_maintenance_on_new_block(self, current_block_stream: CurrentBlockStream) -> ! {
         self.run_maintenance_for_blocks(current_block::into_stream(current_block_stream))
-            .instrument(tracing::info_span!("ServiceMaintenance"))
+            .instrument(tracing::info_span!("service_maintenance"))
             .await;
         panic!("block stream unexpectedly dropped");
     }

--- a/crates/shared/src/price_estimation/native_price_cache.rs
+++ b/crates/shared/src/price_estimation/native_price_cache.rs
@@ -8,6 +8,7 @@ use std::{
     sync::{Arc, Mutex, MutexGuard, Weak},
     time::{Duration, Instant},
 };
+use tracing::Instrument;
 
 #[derive(prometheus_metric_storage::MetricStorage)]
 struct Metrics {
@@ -165,13 +166,16 @@ impl CachingNativePriceEstimator {
             estimator,
             cache: Default::default(),
         });
-        tokio::spawn(update_recently_used_outdated_prices(
-            Arc::downgrade(&inner),
-            update_interval,
-            update_size,
-            max_age.saturating_sub(prefetch_time.unwrap_or(PREFETCH_TIME)),
-            concurrent_requests,
-        ));
+        tokio::spawn(
+            update_recently_used_outdated_prices(
+                Arc::downgrade(&inner),
+                update_interval,
+                update_size,
+                max_age.saturating_sub(prefetch_time.unwrap_or(PREFETCH_TIME)),
+                concurrent_requests,
+            )
+            .instrument(tracing::info_span!("CachingNativePriceEstimator")),
+        );
         let metrics = Metrics::instance(global_metrics::get_metric_storage_registry()).unwrap();
         Self {
             inner,

--- a/crates/shared/src/price_estimation/native_price_cache.rs
+++ b/crates/shared/src/price_estimation/native_price_cache.rs
@@ -174,7 +174,7 @@ impl CachingNativePriceEstimator {
                 max_age.saturating_sub(prefetch_time.unwrap_or(PREFETCH_TIME)),
                 concurrent_requests,
             )
-            .instrument(tracing::info_span!("CachingNativePriceEstimator")),
+            .instrument(tracing::info_span!("caching_native_price_estimator")),
         );
         let metrics = Metrics::instance(global_metrics::get_metric_storage_registry()).unwrap();
         Self {

--- a/crates/shared/src/token_list.rs
+++ b/crates/shared/src/token_list.rs
@@ -77,7 +77,7 @@ impl AutoUpdatingTokenList {
                     }
                 }
             };
-            tokio::task::spawn(updater.instrument(tracing::info_span!("AutoUpdatingTokenList")));
+            tokio::task::spawn(updater.instrument(tracing::info_span!("auto_updating_token_list")));
         }
 
         Self { tokens }

--- a/crates/shared/src/token_list.rs
+++ b/crates/shared/src/token_list.rs
@@ -8,6 +8,7 @@ use anyhow::Result;
 use ethcontract::H160;
 use reqwest::Client;
 use serde::Deserialize;
+use tracing::Instrument;
 
 #[derive(Clone, Debug, Default)]
 pub struct TokenListConfiguration {
@@ -76,7 +77,7 @@ impl AutoUpdatingTokenList {
                     }
                 }
             };
-            tokio::task::spawn(updater);
+            tokio::task::spawn(updater.instrument(tracing::info_span!("AutoUpdatingTokenList")));
         }
 
         Self { tokens }

--- a/crates/solver/src/solver/http_solver/instance_cache.rs
+++ b/crates/solver/src/solver/http_solver/instance_cache.rs
@@ -3,6 +3,7 @@ use crate::{s3_instance_upload::S3InstanceUploader, solver::Auction};
 use model::auction::AuctionId;
 use std::sync::Arc;
 use tokio::sync::Mutex;
+use tracing::{Instrument, Span};
 
 /// To `Driver` every http solver is presented as an individual `Solver` implementor. Internally
 /// http solvers share the same data that is needed to create the instance for the same auction. In
@@ -76,7 +77,7 @@ impl SharedInstanceCreator {
                     tracing::error!(%id, ?err, "error uploading instance");
                 }
             };
-            tokio::task::spawn(task);
+            tokio::task::spawn(task.instrument(Span::current()));
         }
     }
 }


### PR DESCRIPTION
Ideally we would like to know what caused each log to appear. This means for any sort of request that we are using info spans containing the `request_id`.
But we have a bunch of background tasks which can produce a lot of logs which fly under the radar.
This PR adds an info span for every task we spawn (minus tests, request batching and the main tasks like the `orderbook`).

Note that logs originating from the initialization sequence didn't get any new tracing spans but I think this is fine.


### Test Plan
Ran autopilot locally to check logs (I just picked a bunch of updated logs in no particular order):
```
2023-01-16T12:02:36.063Z DEBUG ServiceMaintenance:maintenance{block=16419218}: shared::event_handling: latest blocks: Some((16419091, 0xbbbf69cb04d06485409046a10bdd55da81582849a7cbae8798ca34159ed06375)) - Some((16419218, 0xe0061b782368497a6aca7d309cadacfa868b3a5bf6ee625e4d0d46e7585c8d13))
2023-01-16T12:02:34.712Z DEBUG LimitOrderQuoter:surplus_fee{order_spec=OrderFeeSpecifier { sell_token: 0x95ad61b0a150d79219dcf64e1e6cc01f0b64c4ce, buy_token: 0xb4a81261b16b92af0b9f7c4a83f1e885132d81e4, sell_amount: BigDecimal("3875000000000000000000000000") }}: shared::price_estimation::competition: winning price estimate query=Query { from: None, sell_token: 0x95ad61b0a150d79219dcf64e1e6cc01f0b64c4ce, buy_token: 0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2, in_amount: 1000000000000000000, kind: Buy } result=Ok(Estimate { out_amount: 148056793816200000000000000, gas: 356391 }) estimator="ZeroEx"
2023-01-16T12:02:36.803Z DEBUG SolvableOrdersCache: autopilot::solvable_orders: filtered order order=0x112cca73d7670158cb3947889ac7d84e5c47774a8c727106fb7654c49fbc64b0e63a13eedd01b624958acfe32145298788a7a7ba800186a0 reason=insufficient_balance
2023-01-16T12:02:37.311Z DEBUG CurrentBlockStream: shared::current_block: increased current block number delta=1.0 new_block=16419219
2023-01-16T12:02:31.504Z  WARN AutoUpdatingSolverTokenOwnerFinder: shared::bad_token::token_owner_finder::solvers::solver_finder: failed to update token list err=error decoding response body: invalid length 19, expected a (both 0x-prefixed or not) hex string with length of 40 at line 2 column 25...
```
