### PR TITLE
Demote 0x, Paraswap and 1Inch api logs to `trace!`

### DIFF
--- a/crates/shared/src/oneinch_api.rs
+++ b/crates/shared/src/oneinch_api.rs
@@ -552,9 +552,9 @@ async fn logged_query<D>(client: &Client, url: Url) -> Result<D, OneInchError>
 where
     D: DeserializeOwned,
 {
-    tracing::debug!("Query 1inch API for url {}", url);
+    tracing::trace!("Query 1inch API for url {}", url);
     let response = client.get(url).send().await?.text().await;
-    tracing::debug!("Response from 1inch API: {:?}", response);
+    tracing::trace!("Response from 1inch API: {:?}", response);
     match serde_json::from_str::<RestResponse<D>>(&response?)? {
         RestResponse::Ok(result) => Ok(result),
         RestResponse::Err(err) => Err(err.into()),

--- a/crates/shared/src/paraswap_api.rs
+++ b/crates/shared/src/paraswap_api.rs
@@ -40,7 +40,7 @@ pub struct DefaultParaswapApi {
 impl ParaswapApi for DefaultParaswapApi {
     async fn price(&self, query: PriceQuery) -> Result<PriceResponse, ParaswapResponseError> {
         let url = query.into_url(&self.partner);
-        tracing::debug!("Querying Paraswap price API: {}", url);
+        tracing::trace!("Querying Paraswap price API: {}", url);
         let request = self.client.get(url).send();
 
         let response = match &self.rate_limiter {
@@ -49,7 +49,7 @@ impl ParaswapApi for DefaultParaswapApi {
         };
         let status = response.status();
         let text = response.text().await?;
-        tracing::debug!(%status, %text, "Response from Paraswap price API");
+        tracing::trace!(%status, %text, "Response from Paraswap price API");
         parse_paraswap_response_text(&text)
     }
 
@@ -331,7 +331,7 @@ impl TransactionBuilderQueryWithPartner<'_> {
             .expect("unexpectedly invalid URL segment");
         url.query_pairs_mut().append_pair("ignoreChecks", "true");
 
-        tracing::debug!("Paraswap API (transaction) query url: {}", url);
+        tracing::trace!("Paraswap API (transaction) query url: {}", url);
         client.post(url).json(&self)
     }
 }

--- a/crates/shared/src/rate_limiter.rs
+++ b/crates/shared/src/rate_limiter.rs
@@ -213,7 +213,9 @@ impl RateLimiter {
             }
         } else {
             self.strategy().response_ok(&self.name);
-            tracing::debug!(?self.name, "reset rate limit");
+            if times_rate_limited > 0 {
+                tracing::debug!(?self.name, "reset rate limit");
+            }
         }
 
         Ok(result)

--- a/crates/shared/src/zeroex_api.rs
+++ b/crates/shared/src/zeroex_api.rs
@@ -506,7 +506,7 @@ impl DefaultZeroExApi {
         &self,
         url: Url,
     ) -> Result<T, ZeroExResponseError> {
-        tracing::debug!("Querying 0x API: {}", url);
+        tracing::trace!("Querying 0x API: {}", url);
 
         let request = self.client.get(url.clone());
         let response_text = request
@@ -516,7 +516,7 @@ impl DefaultZeroExApi {
             .text()
             .await
             .map_err(ZeroExResponseError::TextFetch)?;
-        tracing::debug!("Response from 0x API: {}", response_text);
+        tracing::trace!("Response from 0x API: {}", response_text);
 
         match serde_json::from_str::<RawResponse<T>>(&response_text) {
             Ok(RawResponse::ResponseOk(response)) => Ok(response),


### PR DESCRIPTION
The `0x`, `Paraswap` and `1Inch` api implementation can issue a lot of logs which essentially all get duplicated in the `CompetitionPriceEstimator`.
Also `1Inch` and `0x` can issue logs which are crazy long (`1Inch` liquidity sources and `0x` limit orders as liquidity).

All of this seems to be just noise when you are debugging something locally. I think one could even argue how useful those logs are in the actual deployment but I left them just to be safe.
