### PR TITLE
Don't log rate limit reset unnecessarily

### DIFF
--- a/crates/shared/src/rate_limiter.rs
+++ b/crates/shared/src/rate_limiter.rs
@@ -213,7 +213,9 @@ impl RateLimiter {
             }
         } else {
             self.strategy().response_ok(&self.name);
-            tracing::debug!(?self.name, "reset rate limit");
+            if times_rate_limited > 0 {
+                tracing::debug!(?self.name, "reset rate limit");
+            }
         }
 
         Ok(result)


### PR DESCRIPTION
We only need to log that we reset the rate limit when we were rate limited before.
