### PR TITLE
Introduce Driver Liquidity Domain Objects

### DIFF
--- a/crates/driver/src/domain/liquidity/balancer/mod.rs
+++ b/crates/driver/src/domain/liquidity/balancer/mod.rs
@@ -1,0 +1,2 @@
+pub mod stable;
+pub mod weighted;

--- a/crates/driver/src/domain/liquidity/balancer/stable.rs
+++ b/crates/driver/src/domain/liquidity/balancer/stable.rs
@@ -1,0 +1,9 @@
+/// Liquidity data tied to a Balancer V2 stable pool.
+///
+/// These pools are an implementation of Curve.fi StableSwap pools [^1] on the
+/// Balancer V2 Vault contract [^2].
+///
+/// [^1]: <https://classic.curve.fi/whitepaper>
+/// [^2]: <https://docs.balancer.fi/products/balancer-pools/composable-stable-pools>
+#[derive(Clone, Debug)]
+pub struct Pool {}

--- a/crates/driver/src/domain/liquidity/balancer/weighted.rs
+++ b/crates/driver/src/domain/liquidity/balancer/weighted.rs
@@ -1,0 +1,14 @@
+/// Liquidity data tied to a Balancer V2 pool based on "Weighted Math" [^1].
+///
+/// Balancer V2 supports two kind pools that fall in this category:
+/// - Weighted Pools [^2]
+/// - Liquidity Bootstrapping Pools [^3]
+///
+/// Both of these pools have an identical representation, and are therefore
+/// modelled by the same type.
+///
+/// [^1]: <https://docs.balancer.fi/concepts/math/weighted-math>
+/// [^2]: <https://docs.balancer.fi/products/balancer-pools/weighted-pools>
+/// [^3]: <https://docs.balancer.fi/products/balancer-pools/liquidity-bootstrapping-pools-lbps>
+#[derive(Clone, Debug)]
+pub struct Pool {}

--- a/crates/driver/src/domain/liquidity/balancer/weighted.rs
+++ b/crates/driver/src/domain/liquidity/balancer/weighted.rs
@@ -1,6 +1,6 @@
 /// Liquidity data tied to a Balancer V2 pool based on "Weighted Math" [^1].
 ///
-/// Balancer V2 supports two kind pools that fall in this category:
+/// Balancer V2 supports two kinds of pools that fall in this category:
 /// - Weighted Pools [^2]
 /// - Liquidity Bootstrapping Pools [^3]
 ///

--- a/crates/driver/src/domain/liquidity/fetcher.rs
+++ b/crates/driver/src/domain/liquidity/fetcher.rs
@@ -1,0 +1,17 @@
+use crate::domain::{competition::auction, liquidity};
+
+/// Fetch liquidity for auctions to be sent to solver engines.
+#[derive(Debug)]
+pub struct Fetcher {}
+
+impl Fetcher {
+    /// Fetches all relevant liquidity for the specified auction.
+    pub async fn fetch(
+        &self,
+        _auction: &auction::Auction,
+    ) -> Result<Vec<liquidity::Liquidity>, Error> {
+        todo!()
+    }
+}
+
+pub struct Error;

--- a/crates/driver/src/domain/liquidity/mod.rs
+++ b/crates/driver/src/domain/liquidity/mod.rs
@@ -4,6 +4,7 @@ use crate::domain::eth;
 pub mod balancer;
 pub mod fetcher;
 pub mod uniswap;
+pub mod swapr;
 pub mod zeroex;
 
 /// A source of liquidity which can be used by the solver.
@@ -50,5 +51,6 @@ pub enum Data {
     UnswapV3(uniswap::v3::Pool),
     BalancerV2Stable(balancer::stable::Pool),
     BalancerV2Weighted(balancer::weighted::Pool),
+    Swapr(swapr::Pool),
     ZeroEx(zeroex::LimitOrder),
 }

--- a/crates/driver/src/domain/liquidity/mod.rs
+++ b/crates/driver/src/domain/liquidity/mod.rs
@@ -3,8 +3,8 @@ use crate::domain::eth;
 
 pub mod balancer;
 pub mod fetcher;
-pub mod uniswap;
 pub mod swapr;
+pub mod uniswap;
 pub mod zeroex;
 
 /// A source of liquidity which can be used by the solver.

--- a/crates/driver/src/domain/liquidity/mod.rs
+++ b/crates/driver/src/domain/liquidity/mod.rs
@@ -1,7 +1,13 @@
+pub use self::fetcher::Fetcher;
 use crate::domain::eth;
 
+pub mod balancer;
+pub mod fetcher;
+pub mod uniswap;
+pub mod zeroex;
+
 /// A source of liquidity which can be used by the solver.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone)]
 pub struct Liquidity {
     pub id: Id,
     /// Depending on the liquidity provider, this can mean different things.
@@ -9,7 +15,7 @@ pub struct Liquidity {
     pub address: eth::Address,
     /// Estimation of gas needed to use this liquidity on-chain.
     pub gas: eth::Gas,
-    // TODO There will be plenty more data here in the future.
+    pub data: Data,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -31,4 +37,18 @@ impl PartialEq<usize> for Id {
     fn eq(&self, other: &usize) -> bool {
         self.0 == *other
     }
+}
+
+/// Data tied to a particular liquidity instance, specific to the type of
+/// liquidity.
+///
+/// This contains relevant data for encoding interactions for the given
+/// liquidity, as well as state required by the solver engine.
+#[derive(Debug, Clone)]
+pub enum Data {
+    UnswapV2(uniswap::v2::Pool),
+    UnswapV3(uniswap::v3::Pool),
+    BalancerV2Stable(balancer::stable::Pool),
+    BalancerV2Weighted(balancer::weighted::Pool),
+    ZeroEx(zeroex::LimitOrder),
 }

--- a/crates/driver/src/domain/liquidity/mod.rs
+++ b/crates/driver/src/domain/liquidity/mod.rs
@@ -16,7 +16,7 @@ pub struct Liquidity {
     pub address: eth::Address,
     /// Estimation of gas needed to use this liquidity on-chain.
     pub gas: eth::Gas,
-    pub data: Data,
+    pub kind: Kind,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -40,13 +40,13 @@ impl PartialEq<usize> for Id {
     }
 }
 
-/// Data tied to a particular liquidity instance, specific to the type of
+/// Data tied to a particular liquidity instance, specific to the kind of
 /// liquidity.
 ///
 /// This contains relevant data for encoding interactions for the given
 /// liquidity, as well as state required by the solver engine.
 #[derive(Debug, Clone)]
-pub enum Data {
+pub enum Kind {
     UnswapV2(uniswap::v2::Pool),
     UnswapV3(uniswap::v3::Pool),
     BalancerV2Stable(balancer::stable::Pool),

--- a/crates/driver/src/domain/liquidity/swapr.rs
+++ b/crates/driver/src/domain/liquidity/swapr.rs
@@ -1,0 +1,4 @@
+/// A Unswap V2 like constant product pool, with the notable difference that the
+/// pool fees are dynamic and can be changed by the protocol administrator.
+#[derive(Clone, Debug)]
+pub struct Pool {}

--- a/crates/driver/src/domain/liquidity/uniswap/mod.rs
+++ b/crates/driver/src/domain/liquidity/uniswap/mod.rs
@@ -1,0 +1,2 @@
+pub mod v2;
+pub mod v3;

--- a/crates/driver/src/domain/liquidity/uniswap/v2.rs
+++ b/crates/driver/src/domain/liquidity/uniswap/v2.rs
@@ -1,0 +1,12 @@
+/// The famous Uniswap V2 constant product pool, modelled by `x · y = k` [^1].
+///
+/// Note that there are many Uniswap V2 clones with identical behaviour from a
+/// liquidity point of view, that are therefore modelled by the same type:
+/// - SushiSwap (Mainnet and Gnosis Chain)
+/// - Swapr (Mainnet and Gnosis Chain)
+/// - Honeyswap (Gnosis Chain)
+/// - Baoswap (Gnosis Chain)
+///
+/// [^1]: <https://uniswap.org/whitepaper.pdf>
+#[derive(Clone, Debug)]
+pub struct Pool {}

--- a/crates/driver/src/domain/liquidity/uniswap/v3.rs
+++ b/crates/driver/src/domain/liquidity/uniswap/v3.rs
@@ -1,0 +1,5 @@
+/// A Uniswap V3 concentrated liquidity pool.
+///
+/// [^1]: <https://uniswap.org/whitepaper-v3.pdf>
+#[derive(Clone, Debug)]
+pub struct Pool {}

--- a/crates/driver/src/domain/liquidity/zeroex.rs
+++ b/crates/driver/src/domain/liquidity/zeroex.rs
@@ -1,0 +1,5 @@
+/// A signed 0x Protocol Limit Order [^1].
+///
+/// [^1]: <https://docs.0x.org/limit-orders-advanced-traders/docs/introduction>
+#[derive(Clone, Debug)]
+pub struct LimitOrder {}


### PR DESCRIPTION
This PR introduces "skeleton" types for the `driver` liquidity.

The idea is to wrap the existing `LiquidityCollector` in a boundary module, and "baseline source" by "baseline source" introduce wrapping logic into the `driver`. As such, each of the liquidity data types are intentionally left empty and will be populated once the wrapping/conversion logic gets introduced.

For now, I wanted to have this PR to:
- Come to consensus on the type names and module layout for liquidity and liquidity fetching
- Introduce documentation for each of the supported pool types

In following PRs, I will slowly build these abstractions and fill in code and types as needed.

I also proposed a module organization following the suggestion [here](https://github.com/cowprotocol/services/pull/1066#pullrequestreview-1251281875) - namely, using the names of the actual DEX sources they correspond to (i.e. `uniswap::v2::Pool` instead of `constant_product::Pool`). I'm not 100% convinced about this:
- I like how it looks and it fits better into my mental model of what these domain objects represent
- HOWEVER, it feels a bit weird to have 4 different DEXs that use `uniswap::v2::Pool`:
    - Uniswap V2
    - SushiSwap
    - Honeyswap
    - Baoswap

### Test Plan

Just types and documentation - so the Rust compiler 🙌.
