### PR TITLE
Fetch Uniswap V2 Liquidity

### DIFF
--- a/crates/driver/src/boundary/liquidity/uniswap/v2.rs
+++ b/crates/driver/src/boundary/liquidity/uniswap/v2.rs
@@ -42,7 +42,7 @@ pub fn to_domain(id: liquidity::Id, pool: ConstantProductOrder) -> liquidity::Li
         id,
         address: pool.address.into(),
         gas: price_estimation::gas::GAS_PER_UNISWAP.into(),
-        data: liquidity::Data::UniswapV2(liquidity::uniswap::v2::Pool {
+        kind: liquidity::Kind::UniswapV2(liquidity::uniswap::v2::Pool {
             router: handler.router().address().into(),
             reserves: liquidity::uniswap::v2::Reserves::new(
                 eth::Asset {

--- a/crates/driver/src/boundary/liquidity/uniswap/v2.rs
+++ b/crates/driver/src/boundary/liquidity/uniswap/v2.rs
@@ -11,6 +11,7 @@ use {
     shared::{
         current_block::{self, CurrentBlockStream},
         maintenance::Maintaining,
+        price_estimation,
         sources::uniswap_v2::{
             pair_provider::PairProvider,
             pool_cache::PoolCache,
@@ -18,12 +19,45 @@ use {
         },
     },
     solver::{
-        liquidity::uniswap_v2::UniswapLikeLiquidity,
+        liquidity::{uniswap_v2, uniswap_v2::UniswapLikeLiquidity, ConstantProductOrder},
         liquidity_collector::LiquidityCollecting,
     },
     std::{sync, sync::Arc},
     tracing::Instrument,
 };
+
+pub fn to_domain(id: liquidity::Id, pool: ConstantProductOrder) -> liquidity::Liquidity {
+    assert!(
+        *pool.fee.numer() == 3 && *pool.fee.denom() == 1000,
+        "uniswap pools have constant fees",
+    );
+
+    let handler = pool
+        .settlement_handling
+        .as_any()
+        .downcast_ref::<uniswap_v2::Inner>()
+        .expect("downcast uniswap settlment handler");
+
+    liquidity::Liquidity {
+        id,
+        address: pool.address.into(),
+        gas: price_estimation::gas::GAS_PER_UNISWAP.into(),
+        data: liquidity::Data::UniswapV2(liquidity::uniswap::v2::Pool {
+            router: handler.router().address().into(),
+            reserves: liquidity::uniswap::v2::Reserves::new(
+                eth::Asset {
+                    token: pool.tokens.get().0.into(),
+                    amount: pool.reserves.0.into(),
+                },
+                eth::Asset {
+                    token: pool.tokens.get().1.into(),
+                    amount: pool.reserves.1.into(),
+                },
+            )
+            .expect("invalid uniswap token pair"),
+        }),
+    }
+}
 
 pub async fn collector(
     eth: &Ethereum,

--- a/crates/driver/src/domain/liquidity/mod.rs
+++ b/crates/driver/src/domain/liquidity/mod.rs
@@ -11,6 +11,9 @@ pub mod zeroex;
 #[derive(Debug, Clone)]
 pub struct Liquidity {
     pub id: Id,
+    /// Depending on the liquidity provider, this can mean different things.
+    /// Usually it's the address of the liquidity pool.
+    pub address: eth::Address,
     /// Estimation of gas needed to use this liquidity on-chain.
     pub gas: eth::Gas,
     pub kind: Kind,

--- a/crates/driver/src/domain/liquidity/mod.rs
+++ b/crates/driver/src/domain/liquidity/mod.rs
@@ -11,9 +11,6 @@ pub mod zeroex;
 #[derive(Debug, Clone)]
 pub struct Liquidity {
     pub id: Id,
-    /// Depending on the liquidity provider, this can mean different things.
-    /// Usually it's the address of the liquidity pool.
-    pub address: eth::Address,
     /// Estimation of gas needed to use this liquidity on-chain.
     pub gas: eth::Gas,
     pub kind: Kind,
@@ -47,8 +44,8 @@ impl PartialEq<usize> for Id {
 /// liquidity, as well as state required by the solver engine.
 #[derive(Debug, Clone)]
 pub enum Kind {
-    UnswapV2(uniswap::v2::Pool),
-    UnswapV3(uniswap::v3::Pool),
+    UniswapV2(uniswap::v2::Pool),
+    UniswapV3(uniswap::v3::Pool),
     BalancerV2Stable(balancer::stable::Pool),
     BalancerV2Weighted(balancer::weighted::Pool),
     Swapr(swapr::Pool),

--- a/crates/driver/src/domain/liquidity/uniswap/v2.rs
+++ b/crates/driver/src/domain/liquidity/uniswap/v2.rs
@@ -11,7 +11,6 @@ use {crate::domain::eth, std::cmp::Ordering};
 /// [^1]: <https://uniswap.org/whitepaper.pdf>
 #[derive(Clone, Debug)]
 pub struct Pool {
-    pub address: eth::Address,
     pub router: eth::ContractAddress,
     pub reserves: Reserves,
 }

--- a/crates/driver/src/domain/liquidity/uniswap/v2.rs
+++ b/crates/driver/src/domain/liquidity/uniswap/v2.rs
@@ -1,12 +1,34 @@
+use {crate::domain::eth, std::cmp::Ordering};
+
 /// The famous Uniswap V2 constant product pool, modelled by `x · y = k` [^1].
 ///
 /// Note that there are many Uniswap V2 clones with identical behaviour from a
 /// liquidity point of view, that are therefore modelled by the same type:
 /// - SushiSwap (Mainnet and Gnosis Chain)
-/// - Swapr (Mainnet and Gnosis Chain)
 /// - Honeyswap (Gnosis Chain)
 /// - Baoswap (Gnosis Chain)
 ///
 /// [^1]: <https://uniswap.org/whitepaper.pdf>
 #[derive(Clone, Debug)]
-pub struct Pool {}
+pub struct Pool {
+    pub address: eth::Address,
+    pub router: eth::ContractAddress,
+    pub reserves: Reserves,
+}
+
+/// A Uniswap V2 pool reserves. These reserves are orders by token address and
+/// are guaranteed to be for distict tokens.
+#[derive(Clone, Copy, Debug)]
+pub struct Reserves(eth::Asset, eth::Asset);
+
+impl Reserves {
+    /// Creates new Uniswap V2 token reserves, returns `None` if the specified
+    /// token addresses are equal.
+    pub fn new(a: eth::Asset, b: eth::Asset) -> Option<Self> {
+        match a.token.cmp(&b.token) {
+            Ordering::Less => Some(Self(a, b)),
+            Ordering::Equal => None,
+            Ordering::Greater => Some(Self(b, a)),
+        }
+    }
+}

--- a/crates/solver/src/liquidity/balancer_v2.rs
+++ b/crates/solver/src/liquidity/balancer_v2.rs
@@ -139,12 +139,20 @@ impl SettlementHandler {
 }
 
 impl SettlementHandling<WeightedProductOrder> for SettlementHandler {
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+
     fn encode(&self, execution: AmmOrderExecution, encoder: &mut SettlementEncoder) -> Result<()> {
         self.inner_encode(execution, encoder)
     }
 }
 
 impl SettlementHandling<StablePoolOrder> for SettlementHandler {
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+
     fn encode(&self, execution: AmmOrderExecution, encoder: &mut SettlementEncoder) -> Result<()> {
         self.inner_encode(execution, encoder)
     }

--- a/crates/solver/src/liquidity/order_converter.rs
+++ b/crates/solver/src/liquidity/order_converter.rs
@@ -115,6 +115,10 @@ fn compute_synthetic_order_amounts_for_limit_order(
 }
 
 impl SettlementHandling<LimitOrder> for OrderSettlementHandler {
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+
     fn encode(&self, executed_amount: U256, encoder: &mut SettlementEncoder) -> Result<()> {
         let is_native_token_buy_order = self.order.data.buy_token == BUY_ETH_ADDRESS;
         if is_native_token_buy_order {

--- a/crates/solver/src/liquidity/uniswap_v2.rs
+++ b/crates/solver/src/liquidity/uniswap_v2.rs
@@ -137,9 +137,17 @@ impl Inner {
             },
         )
     }
+
+    pub fn router(&self) -> &IUniswapLikeRouter {
+        &self.router
+    }
 }
 
 impl SettlementHandling<ConstantProductOrder> for Inner {
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+
     // Creates the required interaction to convert the given input into output. Assumes slippage is
     // already applied to `input_max`.
     fn encode(&self, execution: AmmOrderExecution, encoder: &mut SettlementEncoder) -> Result<()> {

--- a/crates/solver/src/liquidity/uniswap_v3.rs
+++ b/crates/solver/src/liquidity/uniswap_v3.rs
@@ -165,6 +165,10 @@ impl UniswapV3SettlementHandler {
 }
 
 impl SettlementHandling<ConcentratedLiquidity> for UniswapV3SettlementHandler {
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+
     // Creates the required interaction to convert the given input into output. Assumes slippage is
     // already applied to the `input_max` field.
     fn encode(&self, execution: AmmOrderExecution, encoder: &mut SettlementEncoder) -> Result<()> {

--- a/crates/solver/src/liquidity/zeroex.rs
+++ b/crates/solver/src/liquidity/zeroex.rs
@@ -182,6 +182,10 @@ struct OrderSettlementHandler {
 }
 
 impl SettlementHandling<LimitOrder> for OrderSettlementHandler {
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+
     fn encode(&self, executed_amount: U256, encoder: &mut SettlementEncoder) -> Result<()> {
         if executed_amount > u128::MAX.into() {
             anyhow::bail!("0x only supports executed amounts of size u128");


### PR DESCRIPTION
This PR introduces boundary logic for fetching Uniswap V2 liquidity, and mapping it to domain liquidity models.

This is mostly just mapping `solver` types to `driver` types.

One notable change is the introduction of a `SettlementHandling::as_any` method, in order to downcast `dyn SettlementHandling` trait objects into concrete types. This is needed to extract pool information that is relevant to the domain liquidity object. I think that this is a bit of a hack, but mostly harmless and should be removed (i.e. purged with 🔥) once we complete the boundary liquidity mappings and finally move code from `solver` to `driver` crate. The plan for removing the use of `Any` is to change `settlement_handler` to use concrete types for each pool type. This is quite hard to do ATM because `settlement_handler` being a trait object is needed in multiple places in the code - but once the `solver` binary can be decommissioned, then this should no longer be an issue to change (as the code that relies on `settlement_handler` being a trait object can be removed).

### Test Plan

Rust compiler, E2E test that verifies liquidity fetching is coming once we integrate liquidity fetching into the driver's solving code.
