### PR TITLE
Encode Uniswap V2 Interactions

### DIFF
--- a/crates/driver/src/boundary/liquidity/mod.rs
+++ b/crates/driver/src/boundary/liquidity/mod.rs
@@ -28,7 +28,7 @@ use {
     },
 };
 
-mod uniswap;
+pub mod uniswap;
 
 /// The default poll interval for the block stream updating task.
 const BLOCK_POLL_INTERVAL: Duration = Duration::from_secs(1);

--- a/crates/driver/src/boundary/liquidity/mod.rs
+++ b/crates/driver/src/boundary/liquidity/mod.rs
@@ -50,7 +50,7 @@ pub struct Fetcher {
 }
 
 impl Fetcher {
-    /// Creates a new fether for the specified configuration.
+    /// Creates a new fetcher for the specified configuration.
     pub async fn new(eth: &Ethereum, config: &liquidity::fetcher::Config) -> Result<Self> {
         let blocks = current_block::Arguments {
             block_stream_poll_interval_seconds: BLOCK_POLL_INTERVAL,

--- a/crates/driver/src/boundary/liquidity/uniswap/mod.rs
+++ b/crates/driver/src/boundary/liquidity/uniswap/mod.rs
@@ -1,1 +1,1 @@
-pub(super) mod v2;
+pub mod v2;

--- a/crates/driver/src/boundary/mempool.rs
+++ b/crates/driver/src/boundary/mempool.rs
@@ -1,6 +1,6 @@
 use {
     crate::{
-        boundary::Result,
+        boundary::{self, Result},
         domain::{competition::solution::settlement, eth},
         infra::blockchain::Ethereum,
     },
@@ -73,7 +73,7 @@ impl Mempool {
     ) -> Result<Self> {
         Ok(Self {
             submit_api: Arc::new(PublicMempoolApi::new(
-                vec![config.eth.web3()],
+                vec![boundary::web3(&config.eth)],
                 matches!(high_risk, HighRisk::Disabled),
             )),
             submitted_transactions: config.pool.add_sub_pool(Strategy::PublicMempool),
@@ -99,7 +99,7 @@ impl Mempool {
     }
 
     pub async fn send(&self, settlement: settlement::Simulated) -> Result<()> {
-        let web3 = self.config.eth.web3();
+        let web3 = boundary::web3(&self.config.eth);
         let nonce = web3
             .eth()
             .transaction_count(self.config.account.address(), None)
@@ -145,7 +145,7 @@ pub async fn gas_price_estimator(config: &Config) -> Result<Arc<dyn GasPriceEsti
             &HttpClientFactory::new(&shared::http_client::Arguments {
                 http_timeout: std::time::Duration::from_secs(10),
             }),
-            &config.eth.web3(),
+            &boundary::web3(&config.eth),
             &[shared::gas_price_estimation::GasEstimatorType::Native],
             None,
         )

--- a/crates/driver/src/boundary/mod.rs
+++ b/crates/driver/src/boundary/mod.rs
@@ -39,7 +39,7 @@ use crate::infra::blockchain::Ethereum;
 
 /// Returns a Web3 instance with a trait object transport needed by various
 /// boundary components.
-pub fn web3(eth: &Ethereum) -> Web3 {
+fn web3(eth: &Ethereum) -> Web3 {
     // Ugly way to get access to one of these... However, this way we don't
     // leak this into our domain logic.
     eth.contracts().settlement().raw_instance().web3()

--- a/crates/driver/src/domain/liquidity/mod.rs
+++ b/crates/driver/src/domain/liquidity/mod.rs
@@ -40,6 +40,14 @@ impl PartialEq<usize> for Id {
     }
 }
 
+/// A limit input amount.
+#[derive(Clone, Copy, Debug)]
+pub struct MaxInput(pub eth::Asset);
+
+/// An exact output amount.
+#[derive(Clone, Copy, Debug)]
+pub struct ExactOutput(pub eth::Asset);
+
 /// Data tied to a particular liquidity instance, specific to the kind of
 /// liquidity.
 ///

--- a/crates/driver/src/domain/liquidity/uniswap/v2.rs
+++ b/crates/driver/src/domain/liquidity/uniswap/v2.rs
@@ -41,8 +41,8 @@ impl Pool {
     }
 }
 
-/// A Uniswap V2 pool reserves. These reserves are orders by token address and
-/// are guaranteed to be for distict tokens.
+/// The reserves of a Uniswap V2 pool. These reserves are ordered by token
+/// address and are guaranteed to be for distinct tokens.
 #[derive(Clone, Copy, Debug)]
 pub struct Reserves(eth::Asset, eth::Asset);
 

--- a/crates/driver/src/infra/blockchain/mod.rs
+++ b/crates/driver/src/infra/blockchain/mod.rs
@@ -124,12 +124,6 @@ impl Ethereum {
             .map_err(Into::into)
     }
 
-    /// Necessary for the boundary integration. This breaks the encapsulation of
-    /// this type and should never be used from the [`crate::domain`] code.
-    pub fn web3(&self) -> DynWeb3 {
-        self.web3.clone()
-    }
-
     fn into_request(tx: eth::Tx) -> web3::types::TransactionRequest {
         web3::types::TransactionRequest {
             from: tx.from.into(),

--- a/crates/solver/src/interactions/allowances.rs
+++ b/crates/solver/src/interactions/allowances.rs
@@ -234,26 +234,6 @@ fn is_batch_error(err: &ExecutionError) -> bool {
     }
 }
 
-/// An allowance manager that always reports no allowances.
-pub struct NoAllowanceManaging;
-
-#[async_trait::async_trait]
-impl AllowanceManaging for NoAllowanceManaging {
-    async fn get_allowances(&self, _: HashSet<H160>, spender: H160) -> Result<Allowances> {
-        Ok(Allowances::empty(spender))
-    }
-
-    async fn get_approvals(&self, requests: &[ApprovalRequest]) -> Result<Vec<Approval>> {
-        Ok(requests
-            .iter()
-            .map(|request| Approval {
-                spender: request.spender,
-                token: request.token,
-            })
-            .collect())
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/solver/src/interactions/allowances.rs
+++ b/crates/solver/src/interactions/allowances.rs
@@ -234,6 +234,26 @@ fn is_batch_error(err: &ExecutionError) -> bool {
     }
 }
 
+/// An allowance manager that always reports no allowances.
+pub struct NoAllowanceManaging;
+
+#[async_trait::async_trait]
+impl AllowanceManaging for NoAllowanceManaging {
+    async fn get_allowances(&self, _: HashSet<H160>, spender: H160) -> Result<Allowances> {
+        Ok(Allowances::empty(spender))
+    }
+
+    async fn get_approvals(&self, requests: &[ApprovalRequest]) -> Result<Vec<Approval>> {
+        Ok(requests
+            .iter()
+            .map(|request| Approval {
+                spender: request.spender,
+                token: request.token,
+            })
+            .collect())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/solver/src/interactions/uniswap_v2.rs
+++ b/crates/solver/src/interactions/uniswap_v2.rs
@@ -20,7 +20,7 @@ impl Interaction for UniswapInteraction {
 }
 
 impl UniswapInteraction {
-    fn encode_swap(&self) -> EncodedInteraction {
+    pub fn encode_swap(&self) -> EncodedInteraction {
         let method = self.router.swap_tokens_for_exact_tokens(
             self.amount_out,
             self.amount_in_max,

--- a/crates/solver/src/liquidity.rs
+++ b/crates/solver/src/liquidity.rs
@@ -80,7 +80,7 @@ pub trait SettlementHandling<L>: Send + Sync
 where
     L: Settleable,
 {
-    /// What is his craziness?!
+    /// What is this craziness?!
     ///
     /// While developing the `driver`, we want to access information that is
     /// part of a liquidity's settlement handler. Unfortunately, with how the

--- a/crates/solver/src/liquidity/uniswap_v2.rs
+++ b/crates/solver/src/liquidity/uniswap_v2.rs
@@ -33,21 +33,6 @@ pub struct Inner {
     allowances: Mutex<Allowances>,
 }
 
-#[cfg(test)]
-impl Inner {
-    pub fn new(
-        router: IUniswapLikeRouter,
-        gpv2_settlement: GPv2Settlement,
-        allowances: Mutex<Allowances>,
-    ) -> Self {
-        Inner {
-            router,
-            gpv2_settlement,
-            allowances,
-        }
-    }
-}
-
 impl UniswapLikeLiquidity {
     pub fn new(
         router: IUniswapLikeRouter,
@@ -55,9 +40,18 @@ impl UniswapLikeLiquidity {
         web3: Web3,
         pool_fetcher: Arc<dyn PoolFetching>,
     ) -> Self {
-        let router_address = router.address();
         let settlement_allowances =
             Box::new(AllowanceManager::new(web3, gpv2_settlement.address()));
+        Self::with_allowances(router, gpv2_settlement, settlement_allowances, pool_fetcher)
+    }
+
+    pub fn with_allowances(
+        router: IUniswapLikeRouter,
+        gpv2_settlement: GPv2Settlement,
+        settlement_allowances: Box<dyn AllowanceManaging>,
+        pool_fetcher: Arc<dyn PoolFetching>,
+    ) -> Self {
+        let router_address = router.address();
         Self {
             inner: Arc::new(Inner {
                 router,
@@ -114,7 +108,19 @@ impl LiquidityCollecting for UniswapLikeLiquidity {
 }
 
 impl Inner {
-    fn settle(
+    pub fn new(
+        router: IUniswapLikeRouter,
+        gpv2_settlement: GPv2Settlement,
+        allowances: Mutex<Allowances>,
+    ) -> Self {
+        Inner {
+            router,
+            gpv2_settlement,
+            allowances,
+        }
+    }
+
+    pub fn settle(
         &self,
         (token_in, amount_in_max): (H160, U256),
         (token_out, amount_out): (H160, U256),


### PR DESCRIPTION
This PR introduces Uniswap v2 swap encoding in the `driver`. It is implemented by wrapping existing `solver` crate logic.

One interesting detail is that the `UniswapInteraction` types expects `msg.sender == receiver` which is not always true. The new `driver` code no longer has this assumption, but it is worth pointing out.

Additionally, we introduce a `NoAllowanceManaging` type, which is just a dummy `AllowanceManaging` implementation that pretends like no allowances are set. The reason for this is that the current driver already has allowance setting logic in `eth::allowance` module that I intend to reuse. This saves the back-and-forth request to fetch approvals for all liquidity (instead of just fetching approvals for the tokens that are encoded in a settlement).

### Test Plan

Rust compiler, logic is already tested as part of the `shared` and `solver` crates. 
