### PR TITLE
Upload Auction Instance JSON with Gzip Content Encoding

### DIFF
--- a/crates/solver/src/s3_instance_upload.rs
+++ b/crates/solver/src/s3_instance_upload.rs
@@ -43,32 +43,31 @@ impl S3InstanceUploader {
     /// bucket.
     ///
     /// The final filename is the configured prefix followed by `{auction_id}.json.gzip`.
-    pub async fn upload_instance(&self, auction: AuctionId, value: Vec<u8>) -> Result<()> {
-        let (key, bytes) = self.prepare_instance(auction, &value)?;
-        self.upload(key, bytes).await
+    pub async fn upload_instance(&self, auction: AuctionId, value: &[u8]) -> Result<()> {
+        self.upload(self.filename(auction), value).await
     }
 
-    /// Returns the S3 key and body after gzipping.
-    fn prepare_instance(&self, auction: AuctionId, json: &[u8]) -> Result<(String, Vec<u8>)> {
-        let key = self.filename(auction);
-        // This function isn't async because we already have the body in memory and compressing is
-        // fast.
-        let mut encoder = GzEncoder::new(json, Compression::best());
-        let mut encoded: Vec<u8> = Vec::with_capacity(json.len());
+    /// Compresses the input bytes using Gzip.
+    fn gzip(&self, bytes: &[u8]) -> Result<Vec<u8>> {
+        let mut encoder = GzEncoder::new(bytes, Compression::best());
+        let mut encoded: Vec<u8> = Vec::with_capacity(bytes.len());
         encoder.read_to_end(&mut encoded).context("gzip encoding")?;
-        Ok((key, encoded))
+        Ok(encoded)
     }
 
     fn filename(&self, auction: AuctionId) -> String {
-        format!("{}{auction}.json.gzip", self.filename_prefix)
+        format!("{}{auction}.json", self.filename_prefix)
     }
 
-    async fn upload(&self, key: String, value: Vec<u8>) -> Result<()> {
+    async fn upload(&self, key: String, bytes: &[u8]) -> Result<()> {
+        let encoded = self.gzip(bytes)?;
         self.client
             .put_object()
             .bucket(self.bucket.clone())
             .key(key)
-            .body(ByteStream::new(value.into()))
+            .body(ByteStream::new(encoded.into()))
+            .content_encoding("gzip")
+            .content_type("application/json")
             .send()
             .await?;
         Ok(())
@@ -78,6 +77,8 @@ impl S3InstanceUploader {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use flate2::read::GzDecoder;
+    use serde_json::json;
 
     #[test]
     #[ignore]
@@ -101,12 +102,18 @@ mod tests {
             filename_prefix: "".to_string(),
         };
 
-        let key = "test.txt".to_string();
-        let value = format!("Hello {:?}", std::time::SystemTime::now());
+        let key = "test.json".to_string();
+        // Upload a reasonable amount of data. This helps see the benefits of
+        // compression.
+        let value = serde_json::to_string(&json!({
+            "content": include_str!("../../../README.md"),
+            "timestamp": chrono::Utc::now(),
+        }))
+        .unwrap();
 
         let uploader = S3InstanceUploader::new(config);
         uploader
-            .upload(key.clone(), value.as_bytes().to_vec())
+            .upload(key.clone(), value.as_bytes())
             .await
             .unwrap();
 
@@ -119,8 +126,11 @@ mod tests {
             .await
             .unwrap();
         let body = get_object.body.collect().await.unwrap().to_vec();
-        let body = std::str::from_utf8(&body).unwrap();
 
-        assert_eq!(value, body);
+        let mut decoder = GzDecoder::new(body.as_slice());
+        let mut decoded = String::new();
+        decoder.read_to_string(&mut decoded).unwrap();
+
+        assert_eq!(value, decoded);
     }
 }

--- a/crates/solver/src/solver/http_solver/instance_cache.rs
+++ b/crates/solver/src/solver/http_solver/instance_cache.rs
@@ -73,7 +73,7 @@ impl SharedInstanceCreator {
                     }
                 };
                 std::mem::drop(instances);
-                if let Err(err) = uploader.upload_instance(id, auction).await {
+                if let Err(err) = uploader.upload_instance(id, &auction).await {
                     tracing::error!(%id, ?err, "error uploading instance");
                 }
             };


### PR DESCRIPTION
Implemented suggestion from https://github.com/cowprotocol/services/pull/1086#pullrequestreview-1253174388 (I wasn't able to explain my suggestion very well, so thought it was easier to just write it out).

This PR changes the S3 upload logic to explicitly specify that:
- the file is a JSON document
- the file is Gzip encoded

This does a couple of nice things for us:
- It is stored compressed on S3, so saves space 🎉 (same as before)
- AWS automatically sets the correct `Content-*` headers when retrieving the file, this means that HTTP clients will do the Gzip decoding for us, removing the manual step of `gunzip` and making using these uploaded files slightly more ergonomic (motivation for this change)

### Test Plan

Manually run the ignored test.

Notice how it is stored in compressed format on S3 (4.6 KB):

<img width="337" alt="Screenshot 2023-01-18 at 15 00 03" src="https://user-images.githubusercontent.com/4210206/213191000-38707c5e-5557-4dd8-9b4e-0f42d5023b5e.png">

Downloading the file, the correct `Content-*` headers are set, the total JSON size is 11.8 KB, while the HTTP body is only 4.6 KB, and the gunzipping happens as part of "regular HTTP things" and I end up with a JSON document without manual a `gunzip`:

<img width="506" alt="Screenshot 2023-01-18 at 15 04 25" src="https://user-images.githubusercontent.com/4210206/213191744-75f4451f-78fd-41e0-9c4b-dce1847efc05.png">


