### PR TITLE
Include Solution Liquidity in Settlement

### DIFF
--- a/crates/driver/src/boundary/liquidity/uniswap/v2.rs
+++ b/crates/driver/src/boundary/liquidity/uniswap/v2.rs
@@ -45,9 +45,9 @@ pub fn to_domain(id: liquidity::Id, pool: ConstantProductOrder) -> liquidity::Li
 
     liquidity::Liquidity {
         id,
-        address: pool.address.into(),
         gas: price_estimation::gas::GAS_PER_UNISWAP.into(),
         kind: liquidity::Kind::UniswapV2(liquidity::uniswap::v2::Pool {
+            address: pool.address.into(),
             router: handler.router().address().into(),
             reserves: liquidity::uniswap::v2::Reserves::new(
                 eth::Asset {

--- a/crates/driver/src/boundary/settlement.rs
+++ b/crates/driver/src/boundary/settlement.rs
@@ -104,7 +104,7 @@ impl Settlement {
             settlement
                 .encoder
                 .append_to_execution_plan(Erc20ApproveInteraction {
-                    token: eth.contract_at::<contracts::ERC20>(approval.0.spender.token.into()),
+                    token: eth.contract_at(approval.0.spender.token.into()),
                     spender: approval.0.spender.address.into(),
                     amount: approval.0.amount,
                 });
@@ -299,8 +299,6 @@ fn to_boundary_jit_order(domain: &DomainSeparator, order: &order::Jit) -> Order 
         uid: data.uid(domain, &order.signature.signer.into()),
         // These fields do not seem to be used at all for order
         // encoding, so we just use the default values.
-        settlement_contract: Default::default(),
-        // For other metdata fields, the default value is correct.
         ..Default::default()
     };
     let signature = to_boundary_signature(&order.signature);

--- a/crates/driver/src/boundary/settlement.rs
+++ b/crates/driver/src/boundary/settlement.rs
@@ -249,9 +249,6 @@ fn to_boundary_order(order: &competition::Order) -> Order {
             onchain_order_data: Default::default(),
             is_liquidity_order: order.is_liquidity(),
         },
-        // TODO Different signing schemes imply different sizes of signature data, which indicates
-        // that I'm missing an invariant in my types and I need to fix that
-        // PreSign, for example, carries no data. Everything should be reflected in the types!
         signature: to_boundary_signature(&order.signature),
         interactions: Interactions {
             pre: order

--- a/crates/driver/src/domain/competition/solution/interaction.rs
+++ b/crates/driver/src/domain/competition/solution/interaction.rs
@@ -8,6 +8,16 @@ pub enum Interaction {
     Liquidity(Liquidity),
 }
 
+impl Interaction {
+    /// Returns whether or not the interaction should be internalized.
+    pub fn internalize(&self) -> bool {
+        match self {
+            Interaction::Custom(custom) => custom.internalize,
+            Interaction::Liquidity(liquidity) => liquidity.internalize,
+        }
+    }
+}
+
 /// An arbitrary interaction with any smart contract.
 #[derive(Debug)]
 pub struct Custom {

--- a/crates/driver/src/domain/competition/solution/mod.rs
+++ b/crates/driver/src/domain/competition/solution/mod.rs
@@ -88,6 +88,9 @@ impl Solution {
     /// deterministically.
     fn allowances(&self) -> impl Iterator<Item = eth::allowance::Required> {
         let mut normalized = HashMap::new();
+        // TODO: we need to carry the "internalize" flag with the allowances,
+        // since we don't want to include approvals for interactions that are
+        // meant to be internalized anyway.
         let allowances = self
             .interactions
             .iter()
@@ -95,9 +98,7 @@ impl Solution {
                 Interaction::Custom(interaction) => interaction.allowances.clone().into_iter(),
                 Interaction::Liquidity(interaction) => vec![eth::Allowance {
                     spender: eth::allowance::Spender {
-                        // TODO This is a mistake, right? I think this should be the settlement
-                        // contract address?
-                        address: interaction.liquidity.address,
+                        address: interaction.liquidity.spender(),
                         token: interaction.output.token,
                     },
                     amount: interaction.output.amount,

--- a/crates/driver/src/domain/competition/solution/mod.rs
+++ b/crates/driver/src/domain/competition/solution/mod.rs
@@ -5,6 +5,7 @@ use {
         domain::{
             competition::{self, order},
             eth,
+            liquidity,
         },
         infra::{self, blockchain, time},
         simulator,
@@ -95,16 +96,25 @@ impl Solution {
             .interactions
             .iter()
             .flat_map(|interaction| match interaction {
-                Interaction::Custom(interaction) => interaction.allowances.clone().into_iter(),
-                Interaction::Liquidity(interaction) => vec![eth::Allowance {
-                    spender: eth::allowance::Spender {
-                        address: interaction.liquidity.spender(),
-                        token: interaction.output.token,
-                    },
-                    amount: interaction.output.amount,
+                Interaction::Custom(interaction) => interaction.allowances.clone(),
+                Interaction::Liquidity(interaction) => {
+                    let address = match &interaction.liquidity.kind {
+                        liquidity::Kind::UniswapV2(pool) => pool.router.into(),
+                        liquidity::Kind::UniswapV3(_) => todo!(),
+                        liquidity::Kind::BalancerV2Stable(_) => todo!(),
+                        liquidity::Kind::BalancerV2Weighted(_) => todo!(),
+                        liquidity::Kind::Swapr(_) => todo!(),
+                        liquidity::Kind::ZeroEx(_) => todo!(),
+                    };
+                    vec![eth::Allowance {
+                        spender: eth::allowance::Spender {
+                            address,
+                            token: interaction.output.token,
+                        },
+                        amount: interaction.output.amount,
+                    }
+                    .into()]
                 }
-                .into()]
-                .into_iter(),
             });
         for allowance in allowances {
             let amount = normalized

--- a/crates/driver/src/domain/eth/mod.rs
+++ b/crates/driver/src/domain/eth/mod.rs
@@ -218,6 +218,12 @@ impl From<TokenAddress> for H160 {
     }
 }
 
+impl From<TokenAddress> for ContractAddress {
+    fn from(token: TokenAddress) -> Self {
+        token.0
+    }
+}
+
 /// An asset on the Ethereum blockchain. Represents a particular amount of a
 /// particular token.
 #[derive(Debug, Clone, Copy)]

--- a/crates/driver/src/domain/liquidity/mod.rs
+++ b/crates/driver/src/domain/liquidity/mod.rs
@@ -19,6 +19,21 @@ pub struct Liquidity {
     pub kind: Kind,
 }
 
+impl Liquidity {
+    /// Returns the spender for an ERC20 allowance that is required for using
+    /// the liquidity.
+    pub fn spender(&self) -> eth::Address {
+        match &self.kind {
+            Kind::UniswapV2(pool) => pool.router.into(),
+            Kind::UniswapV3(_) => todo!(),
+            Kind::BalancerV2Stable(_) => todo!(),
+            Kind::BalancerV2Weighted(_) => todo!(),
+            Kind::Swapr(_) => todo!(),
+            Kind::ZeroEx(_) => todo!(),
+        }
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Id(pub usize);
 

--- a/crates/driver/src/domain/liquidity/mod.rs
+++ b/crates/driver/src/domain/liquidity/mod.rs
@@ -11,27 +11,9 @@ pub mod zeroex;
 #[derive(Debug, Clone)]
 pub struct Liquidity {
     pub id: Id,
-    /// Depending on the liquidity provider, this can mean different things.
-    /// Usually it's the address of the liquidity pool.
-    pub address: eth::Address,
     /// Estimation of gas needed to use this liquidity on-chain.
     pub gas: eth::Gas,
     pub kind: Kind,
-}
-
-impl Liquidity {
-    /// Returns the spender for an ERC20 allowance that is required for using
-    /// the liquidity.
-    pub fn spender(&self) -> eth::Address {
-        match &self.kind {
-            Kind::UniswapV2(pool) => pool.router.into(),
-            Kind::UniswapV3(_) => todo!(),
-            Kind::BalancerV2Stable(_) => todo!(),
-            Kind::BalancerV2Weighted(_) => todo!(),
-            Kind::Swapr(_) => todo!(),
-            Kind::ZeroEx(_) => todo!(),
-        }
-    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/crates/driver/src/domain/liquidity/uniswap/v2.rs
+++ b/crates/driver/src/domain/liquidity/uniswap/v2.rs
@@ -17,6 +17,7 @@ use {
 /// [^1]: <https://uniswap.org/whitepaper.pdf>
 #[derive(Clone, Debug)]
 pub struct Pool {
+    pub address: eth::Address,
     pub router: eth::ContractAddress,
     pub reserves: Reserves,
 }


### PR DESCRIPTION
This PR changes the `boundary::settlement` module to create a settlement in function of the `solver::settlement::Settlement` and `solver::settlement::SettlementEncoder` interfaces.

This simplifies the work we need to do for encoding `LiquidityInteraction`s within a settlement (no need to setup a "liquidity map" like we would have to with the `SettledBatchAuctionModel` interface).

### Test Plan

Existing driver settlement E2E test continues to work!
```
% cargo test -p driver -- --nocapture --ignored --test-threads 1
...
test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.76s
```

Note that we aren't testing Uniswap V2 interactions quite yet (the existing E2E tests use `Interaction::Custom` interactions ATM), but that is the next PR.
