### PR TITLE
Make auction update interval smarter

### DIFF
--- a/crates/autopilot/src/arguments.rs
+++ b/crates/autopilot/src/arguments.rs
@@ -139,6 +139,10 @@ pub struct Arguments {
     /// How many quotes the limit order quoter updates in parallel.
     #[clap(long, env, default_value = "5")]
     pub limit_order_quoter_parallelism: usize,
+
+    /// The time between auction updates.
+    #[clap(long, env, default_value = "10", value_parser = shared::arguments::duration_from_seconds)]
+    pub auction_update_interval: Duration,
 }
 
 impl std::fmt::Display for Arguments {

--- a/crates/autopilot/src/lib.rs
+++ b/crates/autopilot/src/lib.rs
@@ -538,7 +538,7 @@ pub async fn main(args: arguments::Arguments) -> ! {
         current_block_stream.clone(),
         native_price_estimator.clone(),
         signature_validator.clone(),
-        Duration::from_secs(2),
+        args.auction_update_interval,
         risk_adjusted_rewards,
         args.ethflow_contract,
         args.max_surplus_fee_age * SURPLUS_FEE_EXPIRATION_FACTOR.into(),

--- a/crates/autopilot/src/solvable_orders.rs
+++ b/crates/autopilot/src/solvable_orders.rs
@@ -422,7 +422,7 @@ async fn update_task(
         //   gets cancelled off chain
         // - the event updater takes some time to run and if we go first we would not update the
         //   orders with the most recent events.
-        tokio::time::sleep(update_interval).await;
+        let start = Instant::now();
         let cache = match cache.upgrade() {
             Some(self_) => self_,
             None => {
@@ -431,7 +431,6 @@ async fn update_task(
             }
         };
         let block = current_block.borrow().number;
-        let start = Instant::now();
         match cache.update(block).await {
             Ok(()) => tracing::debug!(
                 %block,
@@ -445,6 +444,7 @@ async fn update_task(
                 start.elapsed().as_secs_f32()
             ),
         }
+        tokio::time::sleep_until(start + update_interval).await;
     }
 }
 


### PR DESCRIPTION
Currently we wait a fixed interval of 2 seconds after every auction update loop. This commit change the behavior to wait as long is needed to reach the configured target effective update interval.

If creating the auction is slow then we sleep less or not at all. If creating the auction is fast then we sleep the for longer.

This an improvement because we get more auctions on slow environments and less on fast environments. For example, at the moment creating the auction on staging Goerli is very fast which means there is a new auction every 2 seconds. This creates unnecessary churn for the solvers and for the data that we keep track of per auction like instance uploading.

This PR makes the target interval configurable and sets the default to 10 seconds from the previous 2 seconds. This won't make auction creation slower on prod mainnet because creating the auction already takes this long.

### Test Plan
observe after merging
