### PR TITLE
Make driver run loop update interval smarter

### DIFF
--- a/crates/solver/src/arguments.rs
+++ b/crates/solver/src/arguments.rs
@@ -70,7 +70,7 @@ pub struct Arguments {
     #[clap(
         long,
         env,
-        default_value = "1",
+        default_value = "10",
         value_parser = shared::arguments::duration_from_seconds,
     )]
     pub settle_interval: Duration,

--- a/crates/solver/src/driver.rs
+++ b/crates/solver/src/driver.rs
@@ -142,12 +142,13 @@ impl Driver {
 
     pub async fn run_forever(&mut self) -> ! {
         loop {
+            let start = Instant::now();
             match self.single_run().await {
                 Ok(()) => tracing::debug!("single run finished ok"),
                 Err(err) => tracing::error!("single run errored: {:?}", err),
             }
             self.metrics.runloop_completed();
-            tokio::time::sleep(self.settle_interval).await;
+            tokio::time::sleep_until((start + self.settle_interval).into()).await;
         }
     }
 


### PR DESCRIPTION
Same change as https://github.com/cowprotocol/services/pull/1101 but for the driver. I forgot we'd need it there too.

As before, the reasoning for changing the default is that this won't have any effect on busy networks where solving already takes 10 seconds. Also need to adjust the value we set this too in the cluster, which I have a Gitlab branch for.

### Test Plan

observe after merging