### PR TITLE
Refactor `dev-geth` Dockerfile

### DIFF
--- a/docker/Dockerfile.dev-geth
+++ b/docker/Dockerfile.dev-geth
@@ -1,19 +1,24 @@
-FROM docker.io/rust:1-slim-bullseye
+FROM docker.io/rust:1-slim-bullseye as cargo-build
+
+RUN apt-get update &&\
+    apt-get install -y curl git libssl-dev pkg-config tar
 
 # Copy and build code
 WORKDIR /src
-RUN apt-get update && apt-get install -y git libssl-dev pkg-config curl tar tini
 COPY . .
-WORKDIR /src/crates/dev-geth
-RUN CARGO_PROFILE_RELEASE_DEBUG=1 cargo build --release
+RUN CARGO_PROFILE_RELEASE_DEBUG=1 cargo build -p dev-geth --release
 
-# Install geth via curl
-WORKDIR /geth
-RUN curl https://gethstore.blob.core.windows.net/builds/geth-linux-amd64-1.10.26-e5eb32ac.tar.gz -o geth.tar.gz
-RUN tar -xf geth.tar.gz
+# Download and extract Geth
+WORKDIR /opt/geth
+RUN curl https://gethstore.blob.core.windows.net/builds/geth-linux-$(dpkg --print-architecture)-1.10.26-e5eb32ac.tar.gz -o geth.tar.gz
+RUN tar --strip-components=1 -xf geth.tar.gz
 
-RUN cp /src/target/release/dev-geth /usr/local/bin/
-RUN cp /geth/geth-linux-amd64-1.10.26-e5eb32ac/geth /usr/local/bin/
+FROM docker.io/debian:bullseye-slim
+
+RUN apt-get update &&\
+    apt-get install -y ca-certificates tini
+COPY --from=cargo-build /src/target/release/dev-geth /usr/local/bin/dev-geth
+COPY --from=cargo-build /opt/geth/geth /usr/local/bin/geth
 
 ENTRYPOINT ["tini", "--"]
 CMD ["dev-geth"]

--- a/docker/Dockerfile.dev-geth
+++ b/docker/Dockerfile.dev-geth
@@ -2,7 +2,7 @@ FROM docker.io/rust:1-slim-bullseye
 
 # Copy and build code
 WORKDIR /src
-RUN apt-get update && apt-get install -y git libssl-dev pkg-config curl tar
+RUN apt-get update && apt-get install -y git libssl-dev pkg-config curl tar tini
 COPY . .
 WORKDIR /src/crates/dev-geth
 RUN CARGO_PROFILE_RELEASE_DEBUG=1 cargo build --release
@@ -12,7 +12,8 @@ WORKDIR /geth
 RUN curl https://gethstore.blob.core.windows.net/builds/geth-linux-amd64-1.10.26-e5eb32ac.tar.gz -o geth.tar.gz
 RUN tar -xf geth.tar.gz
 
-COPY /src/target/release/dev-geth /usr/local/bin/
-COPY /geth/geth-linux-amd64-1.10.26-e5eb32ac/geth /usr/local/bin/
+RUN cp /src/target/release/dev-geth /usr/local/bin/
+RUN cp /geth/geth-linux-amd64-1.10.26-e5eb32ac/geth /usr/local/bin/
 
-ENTRYPOINT ["dev-geth"]
+ENTRYPOINT ["tini", "--"]
+CMD ["dev-geth"]


### PR DESCRIPTION
This PR refactors the `dev-geth` Dockerfile to accomplish a few things:

1. Make it compatible with Apple Silicon (because, that is what I use!)
2. Wrap the execution in `tini` to handle things like `Ctrl-C` and not timeout on `docker compose down`
3. Reduce the image size

### Test Plan

Build and run the new image:
```
docker build -t dev-geth -f docker/Dockerfile.dev-geth .
docker run -it --rm dev-geth
```

Image size decreased 💪:
```
% docker images
REPOSITORY            TAG       IMAGE ID       CREATED              SIZE
dev-geth              latest    f7240baa55b6   About a minute ago   188MB
dev-geth-old          latest    7e2c9067809d   About an hour ago    3.17GB
```

I also double-checked that this would work on x86_64 Linux systems with:
```
docker build -t dev-geth-amd64 -f docker/Dockerfile.dev-geth . --platform linux/amd64
docker run -it --rm dev-geth-amd64
```