### PR TITLE
Refactor `liquidity` Field out of `Auction` Domain Object

### DIFF
--- a/crates/driver/src/domain/competition/auction.rs
+++ b/crates/driver/src/domain/competition/auction.rs
@@ -3,7 +3,6 @@ use {
         domain::{
             competition::{self, solution},
             eth,
-            liquidity,
         },
         infra::time,
     },
@@ -22,7 +21,6 @@ pub struct Auction {
     pub id: Option<Id>,
     pub tokens: Vec<Token>,
     pub orders: Vec<competition::Order>,
-    pub liquidity: Vec<liquidity::Liquidity>,
     pub gas_price: eth::EffectiveGasPrice,
     pub deadline: Deadline,
 }

--- a/crates/driver/src/domain/quote.rs
+++ b/crates/driver/src/domain/quote.rs
@@ -97,7 +97,7 @@ impl Order {
     /// returns.
     pub async fn quote(&self, solver: &Solver, now: time::Now) -> Result<Quote, Error> {
         let timeout = self.deadline.timeout(now)?;
-        let solution = solver.solve(&self.fake_auction(), timeout).await?;
+        let solution = solver.solve(&self.fake_auction(), &[], timeout).await?;
         Quote::new(self, solution)
     }
 
@@ -126,7 +126,6 @@ impl Order {
                 },
                 reward: FAKE_AUCTION_REWARD,
             }],
-            liquidity: Default::default(),
             gas_price: self.gas_price,
             deadline: Default::default(),
         }

--- a/crates/driver/src/infra/api/error.rs
+++ b/crates/driver/src/infra/api/error.rs
@@ -74,6 +74,7 @@ impl From<competition::Error> for axum::Json<Error> {
             competition::Error::Boundary(_) => Kind::Unknown,
             competition::Error::DeadlineExceeded(_) => Kind::DeadlineExceeded,
             competition::Error::Solver(_) => Kind::SolverFailed,
+            competition::Error::Liquidity(_) => Kind::LiquidityError,
         };
         error.into()
     }
@@ -84,7 +85,6 @@ impl From<api::routes::AuctionError> for axum::Json<Error> {
         let error = match value {
             api::routes::AuctionError::InvalidAuctionId => Kind::InvalidAuctionId,
             api::routes::AuctionError::MissingSurplusFee => Kind::MissingSurplusFee,
-            api::routes::AuctionError::Liquidity(_) => Kind::LiquidityError,
         };
         error.into()
     }

--- a/crates/driver/src/infra/api/mod.rs
+++ b/crates/driver/src/infra/api/mod.rs
@@ -52,10 +52,10 @@ impl Api {
             let router = routes::settle(router);
             let router = router.with_state(State(Arc::new(Inner {
                 solver: solver.clone(),
-                liquidity: self.liquidity.clone(),
                 competition: domain::Competition {
                     solver,
                     eth: self.eth.clone(),
+                    liquidity: self.liquidity.clone(),
                     simulator: self.simulator.clone(),
                     now: self.now,
                     mempools: self.mempools.clone(),
@@ -83,10 +83,6 @@ impl State {
         &self.0.solver
     }
 
-    fn liquidity(&self) -> &liquidity::Fetcher {
-        &self.0.liquidity
-    }
-
     fn competition(&self) -> &domain::Competition {
         &self.0.competition
     }
@@ -99,7 +95,6 @@ impl State {
 #[derive(Debug)]
 struct Inner {
     solver: Solver,
-    liquidity: liquidity::Fetcher,
     competition: domain::Competition,
     now: time::Now,
 }

--- a/crates/driver/src/infra/api/routes/solve/dto/auction.rs
+++ b/crates/driver/src/infra/api/routes/solve/dto/auction.rs
@@ -1,102 +1,16 @@
 use {
     crate::{
         domain::{competition, eth},
-        infra::liquidity,
         util::serialize,
     },
+    itertools::Itertools,
     serde::Deserialize,
     serde_with::serde_as,
     std::{collections::HashMap, str::FromStr},
 };
 
 impl Auction {
-    pub async fn into_domain(
-        self,
-        liquidity: &liquidity::Fetcher,
-    ) -> Result<competition::Auction, Error> {
-        let orders = self
-            .orders
-            .into_iter()
-            .map(|order| {
-                Ok(competition::Order {
-                    uid: order.uid.into(),
-                    receiver: order.receiver.map(Into::into),
-                    valid_to: order.valid_to.into(),
-                    sell: eth::Asset {
-                        amount: order.sell_amount,
-                        token: order.sell_token.into(),
-                    },
-                    buy: eth::Asset {
-                        amount: order.buy_amount,
-                        token: order.buy_token.into(),
-                    },
-                    side: match order.kind {
-                        Kind::Sell => competition::order::Side::Sell,
-                        Kind::Buy => competition::order::Side::Buy,
-                    },
-                    fee: competition::order::Fee {
-                        user: order.user_fee.into(),
-                        solver: order.solver_fee.into(),
-                    },
-                    kind: match order.class {
-                        Class::Market => competition::order::Kind::Market,
-                        Class::Limit => competition::order::Kind::Limit {
-                            surplus_fee: order.surplus_fee.ok_or(Error::MissingSurplusFee)?.into(),
-                        },
-                        Class::Liquidity => competition::order::Kind::Liquidity,
-                    },
-                    app_data: order.app_data.into(),
-                    partial: if order.partially_fillable {
-                        competition::order::Partial::Yes {
-                            executed: order.executed.into(),
-                        }
-                    } else {
-                        competition::order::Partial::No
-                    },
-                    interactions: order
-                        .interactions
-                        .into_iter()
-                        .map(|interaction| eth::Interaction {
-                            target: interaction.target.into(),
-                            value: interaction.value.into(),
-                            call_data: interaction.call_data,
-                        })
-                        .collect(),
-                    sell_token_balance: match order.sell_token_balance {
-                        SellTokenBalance::Erc20 => competition::order::SellTokenBalance::Erc20,
-                        SellTokenBalance::Internal => {
-                            competition::order::SellTokenBalance::Internal
-                        }
-                        SellTokenBalance::External => {
-                            competition::order::SellTokenBalance::External
-                        }
-                    },
-                    buy_token_balance: match order.buy_token_balance {
-                        BuyTokenBalance::Erc20 => competition::order::BuyTokenBalance::Erc20,
-                        BuyTokenBalance::Internal => competition::order::BuyTokenBalance::Internal,
-                    },
-                    signature: competition::order::Signature {
-                        scheme: match order.signing_scheme {
-                            SigningScheme::Eip712 => competition::order::signature::Scheme::Eip712,
-                            SigningScheme::EthSign => {
-                                competition::order::signature::Scheme::EthSign
-                            }
-                            SigningScheme::PreSign => {
-                                competition::order::signature::Scheme::PreSign
-                            }
-                            SigningScheme::Eip1271 => {
-                                competition::order::signature::Scheme::Eip1271
-                            }
-                        },
-                        data: order.signature,
-                        signer: order.owner.into(),
-                    },
-                    reward: order.reward,
-                })
-            })
-            .collect::<Result<Vec<_>, Error>>()?;
-        let liquidity = liquidity.fetch(&orders).await?;
-
+    pub fn into_domain(self) -> Result<competition::Auction, Error> {
         Ok(competition::Auction {
             id: Some(FromStr::from_str(&self.id).map_err(|_| Error::InvalidAuctionId)?),
             tokens: self
@@ -111,8 +25,94 @@ impl Auction {
                     trusted: token.trusted,
                 })
                 .collect(),
-            orders,
-            liquidity,
+            orders: self
+                .orders
+                .into_iter()
+                .map(|order| {
+                    Ok(competition::Order {
+                        uid: order.uid.into(),
+                        receiver: order.receiver.map(Into::into),
+                        valid_to: order.valid_to.into(),
+                        sell: eth::Asset {
+                            amount: order.sell_amount,
+                            token: order.sell_token.into(),
+                        },
+                        buy: eth::Asset {
+                            amount: order.buy_amount,
+                            token: order.buy_token.into(),
+                        },
+                        side: match order.kind {
+                            Kind::Sell => competition::order::Side::Sell,
+                            Kind::Buy => competition::order::Side::Buy,
+                        },
+                        fee: competition::order::Fee {
+                            user: order.user_fee.into(),
+                            solver: order.solver_fee.into(),
+                        },
+                        kind: match order.class {
+                            Class::Market => competition::order::Kind::Market,
+                            Class::Limit => competition::order::Kind::Limit {
+                                surplus_fee: order
+                                    .surplus_fee
+                                    .ok_or(Error::MissingSurplusFee)?
+                                    .into(),
+                            },
+                            Class::Liquidity => competition::order::Kind::Liquidity,
+                        },
+                        app_data: order.app_data.into(),
+                        partial: if order.partially_fillable {
+                            competition::order::Partial::Yes {
+                                executed: order.executed.into(),
+                            }
+                        } else {
+                            competition::order::Partial::No
+                        },
+                        interactions: order
+                            .interactions
+                            .into_iter()
+                            .map(|interaction| eth::Interaction {
+                                target: interaction.target.into(),
+                                value: interaction.value.into(),
+                                call_data: interaction.call_data,
+                            })
+                            .collect(),
+                        sell_token_balance: match order.sell_token_balance {
+                            SellTokenBalance::Erc20 => competition::order::SellTokenBalance::Erc20,
+                            SellTokenBalance::Internal => {
+                                competition::order::SellTokenBalance::Internal
+                            }
+                            SellTokenBalance::External => {
+                                competition::order::SellTokenBalance::External
+                            }
+                        },
+                        buy_token_balance: match order.buy_token_balance {
+                            BuyTokenBalance::Erc20 => competition::order::BuyTokenBalance::Erc20,
+                            BuyTokenBalance::Internal => {
+                                competition::order::BuyTokenBalance::Internal
+                            }
+                        },
+                        signature: competition::order::Signature {
+                            scheme: match order.signing_scheme {
+                                SigningScheme::Eip712 => {
+                                    competition::order::signature::Scheme::Eip712
+                                }
+                                SigningScheme::EthSign => {
+                                    competition::order::signature::Scheme::EthSign
+                                }
+                                SigningScheme::PreSign => {
+                                    competition::order::signature::Scheme::PreSign
+                                }
+                                SigningScheme::Eip1271 => {
+                                    competition::order::signature::Scheme::Eip1271
+                                }
+                            },
+                            data: order.signature,
+                            signer: order.owner.into(),
+                        },
+                        reward: order.reward,
+                    })
+                })
+                .try_collect()?,
             gas_price: self.effective_gas_price.into(),
             deadline: self.deadline.into(),
         })
@@ -125,8 +125,6 @@ pub enum Error {
     InvalidAuctionId,
     #[error("surplus fee is missing for limit order")]
     MissingSurplusFee,
-    #[error("error fetching liquidity for auction: {0}")]
-    Liquidity(#[from] liquidity::fetcher::Error),
 }
 
 #[serde_as]

--- a/crates/driver/src/infra/api/routes/solve/mod.rs
+++ b/crates/driver/src/infra/api/routes/solve/mod.rs
@@ -12,7 +12,7 @@ async fn route(
     state: axum::extract::State<State>,
     auction: axum::Json<dto::Auction>,
 ) -> Result<axum::Json<dto::Solution>, axum::Json<Error>> {
-    let auction = auction.0.into_domain(state.liquidity()).await?;
+    let auction = auction.0.into_domain()?;
     let competition = state.competition();
     let (solution_id, score) = competition.solve(&auction).await?;
     Ok(axum::Json(dto::Solution::from_domain(solution_id, score)))

--- a/crates/driver/src/infra/solver/dto/auction.rs
+++ b/crates/driver/src/infra/solver/dto/auction.rs
@@ -12,6 +12,7 @@ use {
 impl Auction {
     pub fn from_domain(
         auction: &competition::Auction,
+        liquidity: &[liquidity::Liquidity],
         timeout: competition::SolverTimeout,
         now: infra::time::Now,
     ) -> Self {
@@ -56,8 +57,7 @@ impl Auction {
                     reward: order.reward,
                 })
                 .collect(),
-            liquidity: auction
-                .liquidity
+            liquidity: liquidity
                 .iter()
                 .map(|liquidity| match &liquidity.kind {
                     liquidity::Kind::UniswapV2(pool) => {

--- a/crates/driver/src/infra/solver/dto/solution.rs
+++ b/crates/driver/src/infra/solver/dto/solution.rs
@@ -1,6 +1,6 @@
 use {
     crate::{
-        domain::{competition, eth},
+        domain::{competition, eth, liquidity},
         util::serialize,
         Solver,
     },
@@ -14,6 +14,7 @@ impl Solution {
     pub fn into_domain(
         self,
         auction: &competition::Auction,
+        liquidity: &[liquidity::Liquidity],
         solver: Solver,
     ) -> Result<competition::Solution, super::Error> {
         Ok(competition::Solution {
@@ -150,8 +151,7 @@ impl Solution {
                         ))
                     }
                     Interaction::Liquidity(interaction) => {
-                        let liquidity = auction
-                            .liquidity
+                        let liquidity = liquidity
                             .iter()
                             .find(|liquidity| liquidity.id == interaction.id)
                             .ok_or(super::Error(


### PR DESCRIPTION
This PR refactors the `liquidity` field out of the `Auction` domain type.

The rationale behind this change is that `Auction`s can exist with or without liquidity, and that `liquidity` is just an "augmentation" provided by the driver, but orthogonal to the actual auction.

Furthermore, having liquidity part of the `Auction` already made its creation (in `dto::Auction::from_domain`) a bit awkward:
1. We need to first have the orders and then get the liquidity, so we need a partial auction to create the full one
2. Makes it awkward to look at other auction parameters (like `tokens` or `deadline` for example)
3. Makes it `async`.

Additionally, `liquidity` is a shared concept between `Auction` and `quote::Order`, so having as sidecar data seemed more natural.

### Test Plan

Driver tests still pass.
```
test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 2.73s
```
