### PR TITLE
Fetch Liquidity when `/quote`-ing

### DIFF
--- a/crates/driver/src/boundary/liquidity/mod.rs
+++ b/crates/driver/src/boundary/liquidity/mod.rs
@@ -18,6 +18,7 @@ use {
         liquidity_collector::{LiquidityCollecting, LiquidityCollector},
     },
     std::{
+        collections::HashSet,
         num::{NonZeroU64, NonZeroUsize},
         sync::Arc,
         time::Duration,
@@ -86,7 +87,7 @@ impl Fetcher {
     /// Fetches liquidity for the specified auction.
     pub async fn fetch(
         &self,
-        pairs: &[infra::liquidity::TokenPair],
+        pairs: &HashSet<liquidity::TokenPair>,
     ) -> Result<Vec<liquidity::Liquidity>> {
         let pairs = pairs
             .iter()

--- a/crates/driver/src/boundary/liquidity/mod.rs
+++ b/crates/driver/src/boundary/liquidity/mod.rs
@@ -1,7 +1,7 @@
 use {
     crate::{
         boundary,
-        domain::{competition::order, eth, liquidity},
+        domain::{eth, liquidity},
         infra::{self, blockchain::Ethereum},
     },
     anyhow::Result,
@@ -84,14 +84,15 @@ impl Fetcher {
     }
 
     /// Fetches liquidity for the specified auction.
-    pub async fn fetch(&self, orders: &[order::Order]) -> Result<Vec<liquidity::Liquidity>> {
-        let pairs = orders
+    pub async fn fetch(
+        &self,
+        pairs: &[infra::liquidity::TokenPair],
+    ) -> Result<Vec<liquidity::Liquidity>> {
+        let pairs = pairs
             .iter()
-            .filter_map(|order| match order.kind {
-                order::Kind::Market | order::Kind::Limit { .. } => {
-                    TokenPair::new(order.sell.token.into(), order.buy.token.into())
-                }
-                order::Kind::Liquidity => None,
+            .map(|pair| {
+                let (a, b) = pair.get();
+                TokenPair::new(a.into(), b.into()).expect("a != b")
             })
             .collect();
         let block_number = self.blocks.borrow().number;

--- a/crates/driver/src/domain/competition/mod.rs
+++ b/crates/driver/src/domain/competition/mod.rs
@@ -44,7 +44,7 @@ pub struct Competition {
 impl Competition {
     /// Solve an auction as part of this competition.
     pub async fn solve(&self, auction: &Auction) -> Result<(solution::Id, solution::Score), Error> {
-        let liquidity = self.liquidity.fetch(&auction.orders).await?;
+        let liquidity = self.liquidity.for_auction(auction).await?;
         let solution = self
             .solver
             .solve(auction, &liquidity, auction.deadline.timeout(self.now)?)

--- a/crates/driver/src/domain/liquidity/mod.rs
+++ b/crates/driver/src/domain/liquidity/mod.rs
@@ -1,4 +1,4 @@
-use crate::domain::eth;
+use {crate::domain::eth, std::cmp::Ordering};
 
 pub mod balancer;
 pub mod swapr;
@@ -56,4 +56,25 @@ pub enum Kind {
     BalancerV2Weighted(balancer::weighted::Pool),
     Swapr(swapr::Pool),
     ZeroEx(zeroex::LimitOrder),
+}
+
+/// An ordered token pair.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub struct TokenPair(eth::TokenAddress, eth::TokenAddress);
+
+impl TokenPair {
+    /// Returns a token pair for the given tokens, or `None` if `a` and `b` are
+    /// equal.
+    pub fn new(a: eth::TokenAddress, b: eth::TokenAddress) -> Option<Self> {
+        match a.cmp(&b) {
+            Ordering::Less => Some(Self(a, b)),
+            Ordering::Equal => None,
+            Ordering::Greater => Some(Self(b, a)),
+        }
+    }
+
+    /// Returns the wrapped token pair as a tuple.
+    pub fn get(&self) -> (eth::TokenAddress, eth::TokenAddress) {
+        (self.0, self.1)
+    }
 }

--- a/crates/driver/src/infra/api/error.rs
+++ b/crates/driver/src/infra/api/error.rs
@@ -4,7 +4,7 @@ use {
             competition::{self, solution},
             quote,
         },
-        infra::{self, api},
+        infra::api,
     },
     serde::Serialize,
 };
@@ -60,6 +60,7 @@ impl From<quote::Error> for axum::Json<Error> {
             quote::Error::QuotingFailed => Kind::QuotingFailed,
             quote::Error::DeadlineExceeded(_) => Kind::DeadlineExceeded,
             quote::Error::Solver(_) => Kind::SolverFailed,
+            quote::Error::Liquidity(_) => Kind::LiquidityError,
         };
         error.into()
     }
@@ -98,11 +99,5 @@ impl From<api::routes::OrderError> for axum::Json<Error> {
             api::routes::OrderError::SameTokens => Kind::QuoteSameTokens,
         };
         error.into()
-    }
-}
-
-impl From<infra::liquidity::fetcher::Error> for axum::Json<Error> {
-    fn from(_: infra::liquidity::fetcher::Error) -> Self {
-        Kind::LiquidityError.into()
     }
 }

--- a/crates/driver/src/infra/api/mod.rs
+++ b/crates/driver/src/infra/api/mod.rs
@@ -61,6 +61,7 @@ impl Api {
                     mempools: self.mempools.clone(),
                     settlement: Default::default(),
                 },
+                liquidity: self.liquidity.clone(),
                 now: self.now,
             })));
             app = app.nest(&format!("/{name}"), router);
@@ -87,6 +88,10 @@ impl State {
         &self.0.competition
     }
 
+    fn liquidity(&self) -> &liquidity::Fetcher {
+        &self.0.liquidity
+    }
+
     fn now(&self) -> time::Now {
         self.0.now
     }
@@ -96,5 +101,6 @@ impl State {
 struct Inner {
     solver: Solver,
     competition: domain::Competition,
+    liquidity: liquidity::Fetcher,
     now: time::Now,
 }

--- a/crates/driver/src/infra/api/routes/mod.rs
+++ b/crates/driver/src/infra/api/routes/mod.rs
@@ -5,7 +5,7 @@ mod solve;
 
 pub(super) use {
     info::info,
-    quote::quote,
+    quote::{quote, OrderError},
     settle::settle,
     solve::{solve, AuctionError},
 };

--- a/crates/driver/src/infra/api/routes/quote/dto/mod.rs
+++ b/crates/driver/src/infra/api/routes/quote/dto/mod.rs
@@ -1,4 +1,7 @@
 mod order;
 mod quote;
 
-pub use {order::Order, quote::Quote};
+pub use {
+    order::{Error as OrderError, Order},
+    quote::Quote,
+};

--- a/crates/driver/src/infra/api/routes/quote/mod.rs
+++ b/crates/driver/src/infra/api/routes/quote/mod.rs
@@ -2,6 +2,8 @@ use crate::infra::api::{Error, State};
 
 mod dto;
 
+pub use dto::OrderError;
+
 pub(in crate::infra::api) fn quote(router: axum::Router<State>) -> axum::Router<State> {
     router.route("/quote", axum::routing::post(route))
 }
@@ -10,7 +12,8 @@ async fn route(
     state: axum::extract::State<State>,
     order: axum::Json<dto::Order>,
 ) -> Result<axum::Json<dto::Quote>, axum::Json<Error>> {
-    let order = order.0.into_domain();
-    let quote = order.quote(state.solver(), state.now()).await?;
+    let order = order.0.into_domain()?;
+    let liquidity = state.liquidity().for_quote(&order).await?;
+    let quote = order.quote(state.solver(), &liquidity, state.now()).await?;
     Ok(axum::response::Json(dto::Quote::from_domain(&quote)))
 }

--- a/crates/driver/src/infra/api/routes/quote/mod.rs
+++ b/crates/driver/src/infra/api/routes/quote/mod.rs
@@ -13,7 +13,8 @@ async fn route(
     order: axum::Json<dto::Order>,
 ) -> Result<axum::Json<dto::Quote>, axum::Json<Error>> {
     let order = order.0.into_domain()?;
-    let liquidity = state.liquidity().for_quote(&order).await?;
-    let quote = order.quote(state.solver(), &liquidity, state.now()).await?;
+    let quote = order
+        .quote(state.solver(), state.liquidity(), state.now())
+        .await?;
     Ok(axum::response::Json(dto::Quote::from_domain(&quote)))
 }

--- a/crates/driver/src/infra/liquidity/mod.rs
+++ b/crates/driver/src/infra/liquidity/mod.rs
@@ -10,30 +10,7 @@
 //!    service, at which point being it will truly fit in the [`crate::infra`]
 //!    module.
 
-use {crate::domain::eth, std::cmp::Ordering};
-
 pub mod config;
 pub mod fetcher;
 
 pub use self::{config::Config, fetcher::Fetcher};
-
-/// An ordered token pair.
-#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
-pub struct TokenPair(eth::TokenAddress, eth::TokenAddress);
-
-impl TokenPair {
-    /// Returns a token pair for the given tokens, or `None` if `a` and `b` are
-    /// equal.
-    pub fn new(a: eth::TokenAddress, b: eth::TokenAddress) -> Option<Self> {
-        match a.cmp(&b) {
-            Ordering::Less => Some(Self(a, b)),
-            Ordering::Equal => None,
-            Ordering::Greater => Some(Self(b, a)),
-        }
-    }
-
-    /// Returns the wrapped token pair as a tuple.
-    pub fn get(&self) -> (eth::TokenAddress, eth::TokenAddress) {
-        (self.0, self.1)
-    }
-}

--- a/crates/driver/src/infra/liquidity/mod.rs
+++ b/crates/driver/src/infra/liquidity/mod.rs
@@ -10,7 +10,30 @@
 //!    service, at which point being it will truly fit in the [`crate::infra`]
 //!    module.
 
+use {crate::domain::eth, std::cmp::Ordering};
+
 pub mod config;
 pub mod fetcher;
 
 pub use self::{config::Config, fetcher::Fetcher};
+
+/// An ordered token pair.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub struct TokenPair(eth::TokenAddress, eth::TokenAddress);
+
+impl TokenPair {
+    /// Returns a token pair for the given tokens, or `None` if `a` and `b` are
+    /// equal.
+    pub fn new(a: eth::TokenAddress, b: eth::TokenAddress) -> Option<Self> {
+        match a.cmp(&b) {
+            Ordering::Less => Some(Self(a, b)),
+            Ordering::Equal => None,
+            Ordering::Greater => Some(Self(b, a)),
+        }
+    }
+
+    /// Returns the wrapped token pair as a tuple.
+    pub fn get(&self) -> (eth::TokenAddress, eth::TokenAddress) {
+        (self.0, self.1)
+    }
+}


### PR DESCRIPTION
This PR changes `/quote` endpoint to first fetch and pass in liquidity to the solver engine.

Additionally, it introduces a new `quote::Tokens` struct to maintain the invariant that `sellToken != buyToken` for quotes (which doesn't make sense).

### Test Plan

Driver tests continue to pass.

Also, manually request a quote with a driver + baseline solver pair and see the baseline solver find a price!
```
2023-01-20T12:48:10.736Z TRACE driver::infra::solver: got response from solver self.config.endpoint=http://localhost:7872/ res=Ok("{\"prices\":{\"0x6b175474e89094c44da98b954eedeac495271d0f\":\"1000000000000000000\",\"0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2\":\"1547346991108415943371\"},\"trades\":[{\"kind\":\"fulfillment\",\"order\":\"0x0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000\",\"executedAmount\":\"1000000000000000000\"}],\"interactions\":[{\"kind\":\"liquidity\",\"internalize\":false,\"id\":\"0\",\"inputToken\":\"0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2\",\"outputToken\":\"0x6b175474e89094c44da98b954eedeac495271d0f\",\"inputAmount\":\"1000000000000000000\",\"outputAmount\":\"1547346991108415943371\"}]}")
```

We can't quite E2E this yet, since interaction encoding for quotes is not done yet.
