### PR TITLE
Add `driver` and `solvers` to Docker Image

### DIFF
--- a/docker/Dockerfile.binary
+++ b/docker/Dockerfile.binary
@@ -13,11 +13,13 @@ FROM docker.io/debian:bullseye-slim
 
 # Handle signal handlers properly
 RUN apt-get update && apt-get install -y ca-certificates tini && apt-get clean
-COPY --from=cargo-build /src/target/release/orderbook /usr/local/bin/orderbook
-COPY --from=cargo-build /src/target/release/solver /usr/local/bin/solver
 COPY --from=cargo-build /src/target/release/alerter /usr/local/bin/alerter
 COPY --from=cargo-build /src/target/release/autopilot /usr/local/bin/autopilot
+COPY --from=cargo-build /src/target/release/driver /usr/local/bin/driver
+COPY --from=cargo-build /src/target/release/orderbook /usr/local/bin/orderbook
 COPY --from=cargo-build /src/target/release/refunder /usr/local/bin/refunder
+COPY --from=cargo-build /src/target/release/solver /usr/local/bin/solver
+COPY --from=cargo-build /src/target/release/solvers /usr/local/bin/solvers
 
-CMD echo "Specify binary - either solver or orderbook"
-ENTRYPOINT ["/usr/bin/tini"]
+CMD echo "Specify binary..."
+ENTRYPOINT ["/usr/bin/tini", "--"]


### PR DESCRIPTION
This PR adds the `driver` and `solvers` binaries to the "binaries" Docker image we build. This will enable us to run them in our infrastructure.

### Test Plan

1. Build the docker image
   ```sh
   docker build . -f docker/Dockerfile.binary -t cowprotocol/services
   ```
2. Check that the binaries are there
   ```sh
   docker run -it --rm cowprotocol/services bash -c 'which driver; which solvers'
   ```
   ```
   /usr/local/bin/driver
   /usr/local/bin/solvers
   ```
