### PR TITLE
Add support for 0 slippage ETH flow refunds

### DIFF
--- a/crates/database/src/ethflow_orders.rs
+++ b/crates/database/src/ethflow_orders.rs
@@ -129,7 +129,7 @@ AND o.partially_fillable = false
 AND t.order_uid is null
 AND eo.valid_to < $1
 AND o.sell_amount = oq.sell_amount
-AND (1.0 - o.buy_amount / oq.buy_amount) > $3
+AND (1.0 - o.buy_amount / oq.buy_amount) >= $3
 AND eo.valid_to - extract(epoch from creation_timestamp)::int > $2
     "#;
     sqlx::query_as(QUERY)


### PR DESCRIPTION
Some integrators might send us orders with 0 slippage (e.g. [DefiLlama](https://cowservices.slack.com/archives/C0361CDD1FZ/p1674246929312629)). These orders can currently not be automatically refunded because the DB query currently requires the order's slippage to be strictly greater than the configured `--min-slippage-bps`. And we can also not configure negative `--min-slippage-bps`.

Note that we wouldn't really want to refund such orders but in case those orders make it into our system because the integrator was not aware it would be nice if we could just configure the `refunder` accordingly instead of having to manually refund those orders.

This PR patches the DB query such that the `order_slippage >= min_slippage_bps` is enough.

### Test Plan
Unit tests are still passing.
