### PR TITLE
Add metric to count onchain orders

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1091,6 +1091,7 @@ dependencies = [
  "futures",
  "hex",
  "sqlx",
+ "strum",
  "tokio",
 ]
 
@@ -3467,6 +3468,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with 2.0.1",
+ "strum",
  "testlib",
  "thiserror",
  "time 0.3.14",

--- a/crates/autopilot/src/database/onchain_order_events/metrics.rs
+++ b/crates/autopilot/src/database/onchain_order_events/metrics.rs
@@ -1,0 +1,139 @@
+use super::OnchainOrderData;
+use database::{
+    events::EventIndex, onchain_broadcasted_orders::OnchainOrderPlacement, orders::OrderClass,
+};
+use itertools::Itertools;
+use model::order::OrderUid;
+use shared::{
+    current_block::RangeInclusive,
+    event_handling::MAX_REORG_BLOCK_COUNT,
+    orderbook_metrics::{db_order_class_label, operation_label, OrderOperation},
+};
+use std::collections::{HashMap, HashSet};
+use strum::IntoEnumIterator;
+
+#[derive(prometheus_metric_storage::MetricStorage, Clone, Debug)]
+#[metric(subsystem = "onchain_orders")]
+pub struct Metrics {
+    /// Keeps track of errors in picking up onchain orders.
+    /// Note that an order might be created even if an error is encountered.
+    #[metric(labels("error_type"))]
+    onchain_order_errors: prometheus::IntCounterVec,
+
+    /// Counts the number of onchain orders that were created or cancelled.
+    /// It accounts for reorg, which means that its value might decrease.
+    /// It might provide incorrect data if a reorg happens during a restart of
+    /// the services.
+    #[metric(labels("kind", "operation"))]
+    orders: prometheus::IntGaugeVec,
+}
+
+impl Metrics {
+    pub fn get() -> &'static Self {
+        Self::instance(global_metrics::get_metric_storage_registry())
+            .expect("unexpected error getting metrics instance")
+    }
+
+    pub fn init(&self) {
+        for (class, op) in OrderClass::iter().cartesian_product(OrderOperation::iter()) {
+            self.change_orders_by(0, &class, &op);
+        }
+
+        // Note: `onchain_order_errors` isn't initialized because keeping track
+        // of all possible error labels would require more maintenance than
+        // it's worth it.
+    }
+
+    pub fn inc_onchain_order_errors(&self, error_label: &str) {
+        self.onchain_order_errors
+            .with_label_values(&[error_label])
+            .inc();
+    }
+
+    pub fn change_orders_by(&self, amount: i64, class: &OrderClass, op: &OrderOperation) {
+        let class = db_order_class_label(class);
+        let op = operation_label(op);
+        self.orders.with_label_values(&[class, op]).add(amount);
+    }
+}
+
+type OrderDetailsForMetrics = (u64, OrderClass, OrderOperation);
+pub type OrderDetailsToOrderUids = HashMap<OrderDetailsForMetrics, HashSet<OrderUid>>;
+#[derive(Debug, Default)]
+pub struct OrdersByBlockNumber(OrderDetailsToOrderUids);
+
+impl OrdersByBlockNumber {
+    pub fn prepare_created_orders<W>(orders: &[OnchainOrderData<W>]) -> OrderDetailsToOrderUids {
+        let mut to_add = HashMap::<OrderDetailsForMetrics, HashSet<OrderUid>>::new();
+        for order in orders {
+            to_add
+                .entry((
+                    order
+                        .broadcasted_order_data
+                        .0
+                        .block_number
+                        .try_into()
+                        .expect("Block number should not be negative"),
+                    order.order.class,
+                    OrderOperation::Created,
+                ))
+                .or_default()
+                .insert(OrderUid(order.broadcasted_order_data.1.order_uid.0));
+        }
+
+        to_add
+    }
+
+    pub fn add_orders(&mut self, to_add: OrderDetailsToOrderUids, metrics: &'static Metrics) {
+        for (order_details, order_uids) in to_add {
+            let num_changes = order_uids
+                .into_iter()
+                .map(|uid| self.0.entry(order_details).or_default().insert(uid))
+                .filter(|&result| result)
+                .count();
+
+            metrics.change_orders_by(num_changes as i64, &order_details.1, &order_details.2);
+        }
+    }
+
+    pub fn remove_orders_in_range(
+        &mut self,
+        range: RangeInclusive<u64>,
+        metrics: &'static Metrics,
+    ) {
+        self.0.retain(|(block_nr, class, op), uids| {
+            let should_skip = range.contains(*block_nr);
+            if should_skip {
+                metrics.change_orders_by(-(uids.len() as i64), class, op);
+            }
+            !should_skip
+        });
+    }
+
+    pub fn purge_old_orders(&mut self, current_block: u64) {
+        self.0
+            .retain(|(block_nr, _, _), _| *block_nr < current_block + MAX_REORG_BLOCK_COUNT);
+    }
+}
+
+pub fn get_most_recent_block(
+    invalided_order_uids: &[(EventIndex, database::OrderUid)],
+    broadcasted_order_data: &[(database::events::EventIndex, OnchainOrderPlacement)],
+) -> Option<u64> {
+    [
+        invalided_order_uids
+            .iter()
+            .map(|event| event.0.block_number)
+            .max()
+            .into_iter(),
+        broadcasted_order_data
+            .iter()
+            .map(|event| event.0.block_number)
+            .max()
+            .into_iter(),
+    ]
+    .into_iter()
+    .flatten()
+    .max()
+    .map(|max| max.try_into().expect("Block number should be positive"))
+}

--- a/crates/database/Cargo.toml
+++ b/crates/database/Cargo.toml
@@ -12,6 +12,7 @@ const_format = "0.2"
 futures = { workspace = true }
 hex = { workspace = true }
 sqlx = { workspace = true, features = ["bigdecimal", "chrono", "macros", "postgres"] }
+strum = { workspace = true }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["macros"] }

--- a/crates/database/src/orders.rs
+++ b/crates/database/src/orders.rs
@@ -20,7 +20,7 @@ pub enum OrderKind {
     Sell,
 }
 
-#[derive(Clone, Copy, Debug, Default, Eq, PartialEq, sqlx::Type)]
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Hash, sqlx::Type, strum::EnumIter)]
 #[sqlx(type_name = "OrderClass")]
 #[sqlx(rename_all = "lowercase")]
 pub enum OrderClass {

--- a/crates/orderbook/src/orderbook.rs
+++ b/crates/orderbook/src/orderbook.rs
@@ -15,6 +15,7 @@ use primitive_types::H160;
 use shared::{
     metrics::LivenessChecking,
     order_validation::{OrderValidating, ValidationError},
+    orderbook_metrics::{operation_label, order_class_label, OrderOperation},
 };
 use std::sync::Arc;
 use thiserror::Error;
@@ -25,26 +26,6 @@ struct Metrics {
     /// Counter for measuring order statistics.
     #[metric(labels("kind", "operation"))]
     orders: prometheus::IntCounterVec,
-}
-
-enum OrderOperation {
-    Created,
-    Cancelled,
-}
-
-fn operation_label(op: &OrderOperation) -> &'static str {
-    match op {
-        OrderOperation::Created => "created",
-        OrderOperation::Cancelled => "cancelled",
-    }
-}
-
-fn order_class_label(class: &OrderClass) -> &'static str {
-    match class {
-        OrderClass::Market => "user",
-        OrderClass::Liquidity => "liquidity",
-        OrderClass::Limit(_) => "limit",
-    }
 }
 
 impl Metrics {

--- a/crates/shared/Cargo.toml
+++ b/crates/shared/Cargo.toml
@@ -43,6 +43,7 @@ secp256k1 = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 serde_with = { workspace = true }
+strum = { workspace = true }
 thiserror = { workspace = true }
 time = { version = "0.3", features = ["macros"] }
 tokio = { workspace = true, features = ["macros", "time"] }

--- a/crates/shared/src/current_block.rs
+++ b/crates/shared/src/current_block.rs
@@ -37,6 +37,10 @@ impl<T: Ord> RangeInclusive<T> {
     pub fn into_inner(self) -> (T, T) {
         (self.start, self.end)
     }
+
+    pub fn contains(&self, elt: T) -> bool {
+        elt >= self.start && elt <= self.end
+    }
 }
 
 /// Block information.
@@ -297,5 +301,16 @@ mod tests {
         assert_eq!(blocks.len(), 6);
         assert_eq!(blocks.last().unwrap().0, 5);
         assert_eq!(blocks.first().unwrap().0, 0);
+    }
+
+    #[test]
+    fn range_contains() {
+        let range = RangeInclusive::try_new(42, 1337).unwrap();
+        assert!(!range.contains(41));
+        assert!(range.contains(42));
+        assert!(range.contains(43));
+        assert!(range.contains(1336));
+        assert!(range.contains(1337));
+        assert!(!range.contains(1338));
     }
 }

--- a/crates/shared/src/lib.rs
+++ b/crates/shared/src/lib.rs
@@ -31,6 +31,7 @@ pub mod network;
 pub mod oneinch_api;
 pub mod order_quoting;
 pub mod order_validation;
+pub mod orderbook_metrics;
 pub mod paraswap_api;
 pub mod price_estimation;
 pub mod rate_limiter;

--- a/crates/shared/src/orderbook_metrics.rs
+++ b/crates/shared/src/orderbook_metrics.rs
@@ -1,0 +1,34 @@
+#[derive(Debug, PartialEq, Eq, Hash, Clone, Copy, strum::EnumIter)]
+pub enum OrderOperation {
+    Created,
+    Cancelled,
+}
+
+pub fn operation_label(op: &OrderOperation) -> &'static str {
+    match op {
+        OrderOperation::Created => "created",
+        OrderOperation::Cancelled => "cancelled",
+    }
+}
+
+pub fn order_class_label(class: &model::order::OrderClass) -> &'static str {
+    match class {
+        model::order::OrderClass::Market => {
+            db_order_class_label(&database::orders::OrderClass::Market)
+        }
+        model::order::OrderClass::Liquidity => {
+            db_order_class_label(&database::orders::OrderClass::Liquidity)
+        }
+        model::order::OrderClass::Limit(_) => {
+            db_order_class_label(&database::orders::OrderClass::Limit)
+        }
+    }
+}
+
+pub fn db_order_class_label(class: &database::orders::OrderClass) -> &'static str {
+    match class {
+        database::orders::OrderClass::Market => "user",
+        database::orders::OrderClass::Liquidity => "liquidity",
+        database::orders::OrderClass::Limit => "limit",
+    }
+}


### PR DESCRIPTION
In partial fulfillment of https://github.com/cowprotocol/services/issues/1033.

Adds a metric that counts orders created from onchain transactions that is robust to reorgs if excluding pod restarts.
The metric labels mirror the ones that are already available in the orderbook for new orders.

Note that no metric currently tracks invalidated order (despite it being already initialized to zero).

### Test Plan

I don't know how to properly test this code as I'd need to trigger a reorg. I tested it by running the autopilot, creating some orders, and seeing the metrics increase from zero with the expected labels.