### PR TITLE
Gracefully handle liquidity errors in `driver`

### DIFF
--- a/crates/driver/src/domain/competition/mod.rs
+++ b/crates/driver/src/domain/competition/mod.rs
@@ -45,10 +45,7 @@ pub struct Competition {
 impl Competition {
     /// Solve an auction as part of this competition.
     pub async fn solve(&self, auction: &Auction) -> Result<(solution::Id, solution::Score), Error> {
-        let liquidity = self
-            .liquidity
-            .fetch(&Self::liquidity_pairs(auction))
-            .await?;
+        let liquidity = self.liquidity.fetch(&Self::liquidity_pairs(auction)).await;
         let solution = self
             .solver
             .solve(auction, &liquidity, auction.deadline.timeout(self.now)?)
@@ -114,6 +111,4 @@ pub enum Error {
     DeadlineExceeded(#[from] auction::DeadlineExceeded),
     #[error("solver error: {0:?}")]
     Solver(#[from] solver::Error),
-    #[error("liquidity fetcher error: {0:?}")]
-    Liquidity(#[from] infra::liquidity::fetcher::Error),
 }

--- a/crates/driver/src/domain/quote.rs
+++ b/crates/driver/src/domain/quote.rs
@@ -81,7 +81,7 @@ impl Order {
         liquidity: &infra::liquidity::Fetcher,
         now: time::Now,
     ) -> Result<Quote, Error> {
-        let liquidity = liquidity.fetch(&self.liquidity_pairs()).await?;
+        let liquidity = liquidity.fetch(&self.liquidity_pairs()).await;
         let timeout = self.deadline.timeout(now)?;
         let solution = solver
             .solve(&self.fake_auction(), &liquidity, timeout)
@@ -221,8 +221,6 @@ pub enum Error {
     DeadlineExceeded(#[from] DeadlineExceeded),
     #[error("solver error: {0:?}")]
     Solver(#[from] solver::Error),
-    #[error("liquidity fetcher error: {0:?}")]
-    Liquidity(#[from] infra::liquidity::fetcher::Error),
     #[error("boundary error: {0:?}")]
     Boundary(#[from] boundary::Error),
 }

--- a/crates/driver/src/infra/api/error.rs
+++ b/crates/driver/src/infra/api/error.rs
@@ -21,7 +21,6 @@ enum Kind {
     TransactionPublishingFailed,
     InvalidAuctionId,
     MissingSurplusFee,
-    LiquidityError,
     QuoteSameTokens,
 }
 
@@ -44,7 +43,6 @@ impl From<Kind> for axum::Json<Error> {
             Kind::TransactionPublishingFailed => "Failed to publish the settlement transaction",
             Kind::InvalidAuctionId => "Invalid ID specified in the auction",
             Kind::MissingSurplusFee => "Auction contains a limit order with no surplus fee",
-            Kind::LiquidityError => "Failed to fetch onchain liquidity",
             Kind::QuoteSameTokens => "Invalid quote with same buy and sell tokens",
         };
         axum::Json(Error {
@@ -60,7 +58,6 @@ impl From<quote::Error> for axum::Json<Error> {
             quote::Error::QuotingFailed => Kind::QuotingFailed,
             quote::Error::DeadlineExceeded(_) => Kind::DeadlineExceeded,
             quote::Error::Solver(_) => Kind::SolverFailed,
-            quote::Error::Liquidity(_) => Kind::LiquidityError,
             quote::Error::Boundary(_) => Kind::Unknown,
         };
         error.into()
@@ -78,7 +75,6 @@ impl From<competition::Error> for axum::Json<Error> {
             competition::Error::Boundary(_) => Kind::Unknown,
             competition::Error::DeadlineExceeded(_) => Kind::DeadlineExceeded,
             competition::Error::Solver(_) => Kind::SolverFailed,
-            competition::Error::Liquidity(_) => Kind::LiquidityError,
         };
         error.into()
     }

--- a/crates/driver/src/infra/liquidity/fetcher.rs
+++ b/crates/driver/src/infra/liquidity/fetcher.rs
@@ -23,13 +23,16 @@ impl Fetcher {
         })
     }
 
-    /// Fetches all relevant liquidity for the specified token pairs.
-    pub async fn fetch(
-        &self,
-        pairs: &HashSet<liquidity::TokenPair>,
-    ) -> Result<Vec<liquidity::Liquidity>, Error> {
-        let liquidity = self.inner.fetch(pairs).await?;
-        Ok(liquidity)
+    /// Fetches all relevant liquidity for the specified token pairs. Handles
+    /// failures by logging and returning an empty vector.
+    pub async fn fetch(&self, pairs: &HashSet<liquidity::TokenPair>) -> Vec<liquidity::Liquidity> {
+        match self.inner.fetch(pairs).await {
+            Ok(liquidity) => liquidity,
+            Err(e) => {
+                tracing::warn!(?e, "failed to fetch liquidity");
+                Default::default()
+            }
+        }
     }
 }
 


### PR DESCRIPTION
Fixes https://github.com/cowprotocol/services/issues/1130.

Log an error when liquidity fetching fails instead of returning an HTTP error.
