### PR TITLE
Implement autopilot transaction finding

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -187,6 +187,7 @@ dependencies = [
  "clap 4.0.8",
  "contracts",
  "database",
+ "derivative",
  "ethcontract",
  "futures",
  "gas-estimation",

--- a/crates/autopilot/Cargo.toml
+++ b/crates/autopilot/Cargo.toml
@@ -23,6 +23,7 @@ chrono = { workspace = true }
 clap = { workspace = true }
 contracts = { path = "../contracts" }
 database = { path = "../database" }
+derivative = { workspace = true }
 ethcontract = { workspace = true }
 futures = { workspace = true }
 gas-estimation = { workspace = true }

--- a/crates/autopilot/src/database.rs
+++ b/crates/autopilot/src/database.rs
@@ -5,6 +5,7 @@ mod events;
 pub mod onchain_order_events;
 pub mod orders;
 mod quotes;
+pub mod recent_settlements;
 
 use sqlx::{PgConnection, PgPool};
 use std::time::Duration;

--- a/crates/autopilot/src/database/recent_settlements.rs
+++ b/crates/autopilot/src/database/recent_settlements.rs
@@ -1,15 +1,24 @@
+use std::ops::Range;
+
 use anyhow::Context;
 use primitive_types::H256;
 
 impl super::Postgres {
-    pub async fn recent_settlement_tx_hashes(&self, start_block: i64) -> anyhow::Result<Vec<H256>> {
+    pub async fn recent_settlement_tx_hashes(
+        &self,
+        block_range: Range<u64>,
+    ) -> anyhow::Result<Vec<H256>> {
+        let start: i64 = block_range.start.try_into()?;
+        let end: i64 = block_range.end.try_into()?;
+        let block_range = start..end;
+
         let _timer = super::Metrics::get()
             .database_queries
             .with_label_values(&["recent_settlement_tx_hashes"])
             .start_timer();
 
         let mut ex = self.0.acquire().await.context("acquire")?;
-        let hashes = database::settlements::recent_settlement_tx_hashes(&mut ex, start_block)
+        let hashes = database::settlements::recent_settlement_tx_hashes(&mut ex, block_range)
             .await
             .context("recent_settlement_tx_hashes")?;
         Ok(hashes.into_iter().map(|hash| H256(hash.0)).collect())

--- a/crates/autopilot/src/database/recent_settlements.rs
+++ b/crates/autopilot/src/database/recent_settlements.rs
@@ -1,0 +1,17 @@
+use anyhow::Context;
+use primitive_types::H256;
+
+impl super::Postgres {
+    pub async fn recent_settlement_tx_hashes(&self, start_block: i64) -> anyhow::Result<Vec<H256>> {
+        let _timer = super::Metrics::get()
+            .database_queries
+            .with_label_values(&["recent_settlement_tx_hashes"])
+            .start_timer();
+
+        let mut ex = self.0.acquire().await.context("acquire")?;
+        let hashes = database::settlements::recent_settlement_tx_hashes(&mut ex, start_block)
+            .await
+            .context("recent_settlement_tx_hashes")?;
+        Ok(hashes.into_iter().map(|hash| H256(hash.0)).collect())
+    }
+}

--- a/crates/autopilot/src/driver_model.rs
+++ b/crates/autopilot/src/driver_model.rs
@@ -75,17 +75,20 @@ pub mod solve {
 }
 
 pub mod execute {
+    use derivative::Derivative;
     use model::{bytes_hex, order::OrderUid, u256_decimal};
     use primitive_types::{H160, U256};
     use serde::{Deserialize, Serialize};
     use serde_with::{serde_as, DisplayFromStr};
     use std::collections::BTreeMap;
 
-    #[derive(Clone, Debug, Default, Deserialize, Serialize)]
+    #[derive(Clone, Derivative, Default, Deserialize, Serialize)]
     #[serde(rename_all = "camelCase")]
+    #[derivative(Debug)]
     pub struct Request {
         pub auction_id: i64,
         #[serde(with = "bytes_hex")]
+        #[derivative(Debug(format_with = "shared::debug_bytes"))]
         pub transaction_identifier: Vec<u8>,
     }
 

--- a/crates/autopilot/src/driver_model.rs
+++ b/crates/autopilot/src/driver_model.rs
@@ -86,7 +86,7 @@ pub mod execute {
     pub struct Request {
         pub auction_id: i64,
         #[serde(with = "bytes_hex")]
-        pub tag: Vec<u8>,
+        pub transaction_identifier: Vec<u8>,
     }
 
     #[serde_as]

--- a/crates/autopilot/src/driver_model.rs
+++ b/crates/autopilot/src/driver_model.rs
@@ -85,6 +85,8 @@ pub mod execute {
     #[serde(rename_all = "camelCase")]
     pub struct Request {
         pub auction_id: i64,
+        #[serde(with = "bytes_hex")]
+        pub tag: Vec<u8>,
     }
 
     #[serde_as]

--- a/crates/autopilot/src/run_loop.rs
+++ b/crates/autopilot/src/run_loop.rs
@@ -164,7 +164,13 @@ impl RunLoop {
         // We do keep track of hashes we have already seen to reduce load from the node.
 
         let mut seen_transactions: HashSet<H256> = Default::default();
-        while self.current_block.borrow().number <= deadline {
+        loop {
+            // This could be a while loop. It isn't, because some care must be taken to not
+            // accidentally keep the borrow alive, which would block senders. Technically this is
+            // fine with while conditions but this is clearer.
+            if self.current_block.borrow().number <= deadline {
+                break;
+            }
             let mut hashes = self
                 .database
                 .recent_settlement_tx_hashes(start..deadline + 1)

--- a/crates/autopilot/src/run_loop.rs
+++ b/crates/autopilot/src/run_loop.rs
@@ -167,7 +167,7 @@ impl RunLoop {
         while self.current_block.borrow().number <= deadline {
             let mut hashes = self
                 .database
-                .recent_settlement_tx_hashes(start as i64)
+                .recent_settlement_tx_hashes(start..deadline + 1)
                 .await?;
             hashes.retain(|hash| !seen_transactions.contains(hash));
             for hash in hashes {

--- a/crates/autopilot/src/run_loop.rs
+++ b/crates/autopilot/src/run_loop.rs
@@ -3,7 +3,9 @@ use chrono::Utc;
 use model::auction::{Auction, AuctionId};
 use primitive_types::H256;
 use rand::seq::SliceRandom;
-use shared::{current_block::CurrentBlockStream, ethrpc::Web3};
+use shared::{
+    current_block::CurrentBlockStream, ethrpc::Web3, event_handling::MAX_REORG_BLOCK_COUNT,
+};
 use std::{collections::HashSet, time::Duration};
 use tracing::Instrument;
 use web3::types::Transaction;
@@ -146,7 +148,7 @@ impl RunLoop {
     pub async fn wait_for_settlement_transaction(&self, tag: &[u8]) -> Result<Option<Transaction>> {
         // Start earlier than current block because there might be a delay when receiving the
         // Solver's /execute response during which it already started broadcasting the tx.
-        let start_offset = 10;
+        let start_offset = MAX_REORG_BLOCK_COUNT;
         let max_wait_time = 20;
         let current = self.current_block.borrow().number;
         let start = current.saturating_sub(start_offset);

--- a/crates/autopilot/src/run_loop.rs
+++ b/crates/autopilot/src/run_loop.rs
@@ -126,11 +126,11 @@ impl RunLoop {
     ) -> Result<()> {
         let request = execute::Request {
             auction_id: id,
-            tag: id.to_be_bytes().into(),
+            transaction_identifier: id.to_be_bytes().into(),
         };
         let _response = driver.execute(&request).await.context("execute")?;
         // TODO: React to deadline expiring.
-        self.wait_for_settlement_transaction(&request.tag)
+        self.wait_for_settlement_transaction(&request.transaction_identifier)
             .await
             .context("wait for settlement transaction")?;
         Ok(())

--- a/crates/autopilot/src/run_loop.rs
+++ b/crates/autopilot/src/run_loop.rs
@@ -68,7 +68,7 @@ impl RunLoop {
                 .execute(auction, id, &self.drivers[index], &solution)
                 .await
             {
-                Ok(()) => tracing::info!("settled"),
+                Ok(()) => (),
                 Err(err) => {
                     tracing::error!(?err, "solver {index} failed to execute");
                 }
@@ -130,9 +130,13 @@ impl RunLoop {
         };
         let _response = driver.execute(&request).await.context("execute")?;
         // TODO: React to deadline expiring.
-        self.wait_for_settlement_transaction(&request.transaction_identifier)
+        let transaction = self
+            .wait_for_settlement_transaction(&request.transaction_identifier)
             .await
             .context("wait for settlement transaction")?;
+        if let Some(tx) = transaction {
+            tracing::debug!("settled in tx {:?}", tx.hash);
+        }
         Ok(())
     }
 

--- a/crates/database/src/lib.rs
+++ b/crates/database/src/lib.rs
@@ -11,6 +11,7 @@ pub mod onchain_invalidations;
 pub mod order_execution;
 pub mod orders;
 pub mod quotes;
+pub mod settlements;
 pub mod solver_competition;
 pub mod trades;
 

--- a/crates/database/src/settlements.rs
+++ b/crates/database/src/settlements.rs
@@ -1,0 +1,85 @@
+use sqlx::PgConnection;
+
+use crate::TransactionHash;
+
+pub async fn recent_settlement_tx_hashes(
+    ex: &mut PgConnection,
+    start_block: i64,
+) -> Result<Vec<TransactionHash>, sqlx::Error> {
+    const QUERY: &str = r#"
+SELECT tx_hash
+FROM settlements
+WHERE block_number >= $1
+    "#;
+    sqlx::query_scalar::<_, TransactionHash>(QUERY)
+        .bind(start_block)
+        .fetch_all(ex)
+        .await
+}
+
+#[cfg(test)]
+mod tests {
+    use sqlx::Connection;
+
+    use crate::{
+        byte_array::ByteArray,
+        events::{Event, EventIndex, Settlement},
+    };
+
+    use super::*;
+
+    #[tokio::test]
+    #[ignore]
+    async fn postgres_gets_event() {
+        let mut db = PgConnection::connect("postgresql://").await.unwrap();
+        let mut db = db.begin().await.unwrap();
+        crate::clear_DANGER_(&mut db).await.unwrap();
+
+        crate::events::append(
+            &mut db,
+            &[
+                (
+                    EventIndex {
+                        block_number: 0,
+                        log_index: 0,
+                    },
+                    Event::Settlement(Settlement {
+                        solver: Default::default(),
+                        transaction_hash: ByteArray([0u8; 32]),
+                    }),
+                ),
+                (
+                    EventIndex {
+                        block_number: 1,
+                        log_index: 0,
+                    },
+                    Event::Settlement(Settlement {
+                        solver: Default::default(),
+                        transaction_hash: ByteArray([1u8; 32]),
+                    }),
+                ),
+                (
+                    EventIndex {
+                        block_number: 2,
+                        log_index: 0,
+                    },
+                    Event::Settlement(Settlement {
+                        solver: Default::default(),
+                        transaction_hash: ByteArray([2u8; 32]),
+                    }),
+                ),
+            ],
+        )
+        .await
+        .unwrap();
+
+        let results = recent_settlement_tx_hashes(&mut db, 1).await.unwrap();
+        assert_eq!(results, &[ByteArray([1u8; 32]), ByteArray([2u8; 32])]);
+
+        let results = recent_settlement_tx_hashes(&mut db, 2).await.unwrap();
+        assert_eq!(results, &[ByteArray([2u8; 32])]);
+
+        let results = recent_settlement_tx_hashes(&mut db, 3).await.unwrap();
+        assert_eq!(results, &[]);
+    }
+}

--- a/crates/database/src/settlements.rs
+++ b/crates/database/src/settlements.rs
@@ -17,6 +17,7 @@ WHERE
     "#;
     sqlx::query_scalar::<_, TransactionHash>(QUERY)
         .bind(block_range.start)
+        .bind(block_range.end)
         .fetch_all(ex)
         .await
 }


### PR DESCRIPTION
I decided on the approach of using the existing event infrastructure to find recent settlement transactions. Otherwise it would be a lot more work to implement reorg robustness and event fetching.

For this PR I set the tag to the auction id. This can be considered a placeholder, although it works well in practice too as long as different environments on the same network do not use the same id at the same time. I'm going to make an issue for this because it isn't part of this PR.

### Test Plan

sql has a test, rest needs to wait for a proper end to end test
