### PR TITLE
Make native price cache prefetch time configurable

### DIFF
--- a/crates/autopilot/src/solvable_orders.rs
+++ b/crates/autopilot/src/solvable_orders.rs
@@ -823,7 +823,7 @@ mod tests {
             Duration::from_secs(10),
             Duration::MAX,
             None,
-            None,
+            Default::default(),
             1,
         );
 

--- a/crates/e2e/tests/e2e/services.rs
+++ b/crates/e2e/tests/e2e/services.rs
@@ -146,7 +146,7 @@ impl OrderbookServices {
             Duration::from_secs(10),
             Duration::from_secs(10),
             None,
-            None,
+            Default::default(),
             1,
         ));
         let quoter = Arc::new(OrderQuoter::new(

--- a/crates/e2e/tests/e2e/services.rs
+++ b/crates/e2e/tests/e2e/services.rs
@@ -146,7 +146,7 @@ impl OrderbookServices {
             Duration::from_secs(10),
             Duration::from_secs(10),
             None,
-            Default::default(),
+            Duration::from_secs(2),
             1,
         ));
         let quoter = Arc::new(OrderQuoter::new(

--- a/crates/shared/src/price_estimation.rs
+++ b/crates/shared/src/price_estimation.rs
@@ -94,6 +94,17 @@ pub struct Arguments {
     )]
     pub native_price_cache_max_age_secs: Duration,
 
+    /// How long before expiry the native price cache should try to update the price in the
+    /// background. This is useful to make sure that prices are usable at all times.
+    /// This value has to be smaller than `--native-price-cache-max-age-secs`.
+    #[clap(
+        long,
+        env,
+        default_value = "2",
+        value_parser = crate::arguments::duration_from_seconds,
+    )]
+    pub native_price_prefetch_time_secs: Duration,
+
     /// How many cached native token prices can be updated at most in one maintenance cycle.
     #[clap(long, env, default_value = "3")]
     pub native_price_cache_max_update_size: usize,
@@ -149,6 +160,11 @@ impl Display for Arguments {
             f,
             "native_price_cache_max_age_secs: {:?}",
             self.native_price_cache_max_age_secs
+        )?;
+        writeln!(
+            f,
+            "native_price_prefetch_time_secs: {:?}",
+            self.native_price_prefetch_time_secs
         )?;
         writeln!(
             f,

--- a/crates/shared/src/price_estimation/factory.rs
+++ b/crates/shared/src/price_estimation/factory.rs
@@ -322,8 +322,9 @@ impl<'a> PriceEstimatorFactory<'a> {
         kinds: &[PriceEstimatorType],
         drivers: &[Driver],
     ) -> Result<Arc<CachingNativePriceEstimator>> {
-        assert!(
-            self.args.native_price_cache_max_age_secs > self.args.native_price_prefetch_time_secs
+        anyhow::ensure!(
+            self.args.native_price_cache_max_age_secs > self.args.native_price_prefetch_time_secs,
+            "price cache prefetch time needs to be less than price cache max age"
         );
         let mut estimators = self.get_estimators(kinds, |entry| &entry.native)?;
         estimators.append(&mut self.get_external_estimators(drivers, |entry| &entry.native)?);

--- a/crates/shared/src/price_estimation/factory.rs
+++ b/crates/shared/src/price_estimation/factory.rs
@@ -322,6 +322,9 @@ impl<'a> PriceEstimatorFactory<'a> {
         kinds: &[PriceEstimatorType],
         drivers: &[Driver],
     ) -> Result<Arc<CachingNativePriceEstimator>> {
+        assert!(
+            self.args.native_price_cache_max_age_secs > self.args.native_price_prefetch_time_secs
+        );
         let mut estimators = self.get_estimators(kinds, |entry| &entry.native)?;
         estimators.append(&mut self.get_external_estimators(drivers, |entry| &entry.native)?);
         let native_estimator = Arc::new(CachingNativePriceEstimator::new(
@@ -333,7 +336,7 @@ impl<'a> PriceEstimatorFactory<'a> {
             self.args.native_price_cache_max_age_secs,
             self.args.native_price_cache_refresh_secs,
             Some(self.args.native_price_cache_max_update_size),
-            None,
+            self.args.native_price_prefetch_time_secs,
             self.args.native_price_cache_concurrent_requests,
         ));
         Ok(native_estimator)

--- a/crates/shared/src/price_estimation/native_price_cache.rs
+++ b/crates/shared/src/price_estimation/native_price_cache.rs
@@ -159,7 +159,7 @@ impl CachingNativePriceEstimator {
         max_age: Duration,
         update_interval: Duration,
         update_size: Option<usize>,
-        prefetch_time: Option<Duration>,
+        prefetch_time: Duration,
         concurrent_requests: usize,
     ) -> Self {
         let inner = Arc::new(Inner {
@@ -171,7 +171,7 @@ impl CachingNativePriceEstimator {
                 Arc::downgrade(&inner),
                 update_interval,
                 update_size,
-                max_age.saturating_sub(prefetch_time.unwrap_or(PREFETCH_TIME)),
+                max_age.saturating_sub(prefetch_time),
                 concurrent_requests,
             )
             .instrument(tracing::info_span!("caching_native_price_estimator")),
@@ -232,9 +232,6 @@ impl NativePriceEstimating for CachingNativePriceEstimator {
         stream.boxed()
     }
 }
-
-// Update prices early by this amount to increase the number of cache hits.
-const PREFETCH_TIME: Duration = Duration::from_millis(2_000);
 
 async fn update_recently_used_outdated_prices(
     inner: Weak<Inner>,
@@ -303,7 +300,7 @@ mod tests {
             Duration::from_millis(30),
             Default::default(),
             None,
-            None,
+            Default::default(),
             1,
         );
 
@@ -333,7 +330,7 @@ mod tests {
             Duration::from_millis(30),
             Default::default(),
             None,
-            None,
+            Default::default(),
             1,
         );
 
@@ -393,7 +390,7 @@ mod tests {
             Duration::from_millis(30),
             Duration::from_millis(50),
             Some(1),
-            Some(Duration::default()),
+            Duration::default(),
             1,
         );
 
@@ -451,7 +448,7 @@ mod tests {
             Duration::from_millis(30),
             Duration::from_millis(50),
             None,
-            Some(Duration::default()),
+            Duration::default(),
             1,
         );
 
@@ -507,7 +504,7 @@ mod tests {
             Duration::from_millis(30),
             Duration::from_millis(50),
             None,
-            Some(Duration::default()),
+            Duration::default(),
             BATCH_SIZE,
         );
 


### PR DESCRIPTION
Ideally the `autopilot`'s native price cache has the prices warm in the cache at all times. For that to work the `CachingNativePriceEstimator` supports updating prices in the background before they actually expire.
The component already supported customizing that prefetch time but so far we didn't have a CLI argument for that.
This PR adds that argument: `--native-price-cache-prefetch-time-secs`. Configuring this should help us reduce the number of orders that don't make it into the current auction due to missing native prices.

### Test Plan
Ran `autopilot` locally:
Prints CLI arguments:
```
...
native_price_cache_max_age_secs: 60s
native_price_prefetch_time_secs: 2s
native_price_cache_max_update_size: 100
...
```
Prints a help text:
```
      --native-price-prefetch-time-secs <NATIVE_PRICE_PREFETCH_TIME_SECS>
          How long before expiry the native price cache should try to update the price in the background. This is useful to make sure that prices are usable at all times. This value has to be smaller than `--native-price-cache-max-age-secs`

          [env: NATIVE_PRICE_PREFETCH_TIME_SECS=]
          [default: 2]
```
