### PR TITLE
Configure network's time between block

### DIFF
--- a/crates/autopilot/src/arguments.rs
+++ b/crates/autopilot/src/arguments.rs
@@ -143,6 +143,10 @@ pub struct Arguments {
     /// The time between auction updates.
     #[clap(long, env, default_value = "10", value_parser = shared::arguments::duration_from_seconds)]
     pub auction_update_interval: Duration,
+
+    /// The time in seconds between new blocks on the network.
+    #[clap(long, env, value_parser = shared::arguments::duration_from_seconds)]
+    pub network_block_interval: Option<Duration>,
 }
 
 impl std::fmt::Display for Arguments {
@@ -199,6 +203,13 @@ impl std::fmt::Display for Arguments {
             f,
             "limit_order_quoter_parallelism: {:?}",
             self.limit_order_quoter_parallelism
+        )?;
+        display_option(
+            f,
+            "network_block_interval",
+            &self
+                .network_block_interval
+                .map(|duration| duration.as_secs_f32()),
         )?;
         Ok(())
     }

--- a/crates/autopilot/src/lib.rs
+++ b/crates/autopilot/src/lib.rs
@@ -143,6 +143,10 @@ pub async fn main(args: arguments::Arguments) -> ! {
         .await
         .expect("Failed to retrieve network version ID");
     let network_name = shared::network::network_name(&network, chain_id);
+    let _network_time_between_blocks = args
+        .network_block_interval
+        .or_else(|| shared::network::block_interval(&network, chain_id))
+        .expect("unknown network block interval");
 
     let signature_validator = Arc::new(Web3SignatureValidator::new(web3.clone()));
 

--- a/crates/shared/src/network.rs
+++ b/crates/shared/src/network.rs
@@ -1,7 +1,8 @@
-// Maps (NetworkId, ChainId) to the network name.
-// Contents of the "match" block obtained via:
-// wget -O - -o /dev/null https://chainid.network/chains.json | jq -r '.[] | [.networkId, .chainId, .name] | @tsv' | gawk '{print("(\""$1"\", "$2") => \""$3"\",")}'
+use std::time::Duration;
 
+/// Maps (NetworkId, ChainId) to the network name.
+/// Contents of the "match" block obtained via:
+/// wget -O - -o /dev/null https://chainid.network/chains.json | jq -r '.[] | [.networkId, .chainId, .name] | @tsv' | gawk '{print("(\""$1"\", "$2") => \""$3"\",")}'
 pub fn network_name(network_id: &str, chain_id: u64) -> &'static str {
     match (network_id, chain_id) {
         ("1", 1) => "Ethereum / Mainnet",
@@ -157,4 +158,14 @@ pub fn network_name(network_id: &str, chain_id: u64) -> &'static str {
         ("999", 999) => "Wanchain",
         _ => "<unknown>",
     }
+}
+
+/// The expected time between blocks on the network.
+pub fn block_interval(network_id: &str, chain_id: u64) -> Option<Duration> {
+    Some(Duration::from_secs(match (network_id, chain_id) {
+        ("1", 1) => 12,
+        ("5", 5) => 12,
+        ("100", 100) => 5,
+        _ => return None,
+    }))
 }


### PR DESCRIPTION
In the colocated autopilot we need to know the time between blocks on the network. Instead of making several individual block timeouts configurable I feel it makes more sense to derive them automatically from the block interval.

### Test Plan

CI, double check that staging pods still start
