### PR TITLE
Don't quote orders with insufficient funds

### DIFF
--- a/crates/autopilot/src/arguments.rs
+++ b/crates/autopilot/src/arguments.rs
@@ -132,7 +132,7 @@ pub struct Arguments {
     #[clap(long, env, default_value = "0")]
     pub limit_order_price_factor: f64,
 
-    // Enable background quoting for limit orders.
+    /// Enable background quoting for limit orders.
     #[clap(long, env)]
     pub enable_limit_orders: bool,
 
@@ -143,6 +143,11 @@ pub struct Arguments {
     /// The time between auction updates.
     #[clap(long, env, default_value = "10", value_parser = shared::arguments::duration_from_seconds)]
     pub auction_update_interval: Duration,
+
+    /// Skip updating the `surplus_fee` for orders where the owner currently doesn't have enough
+    /// balance.
+    #[clap(long, env)]
+    pub skip_quoting_unfunded_orders: bool,
 }
 
 impl std::fmt::Display for Arguments {
@@ -199,6 +204,11 @@ impl std::fmt::Display for Arguments {
             f,
             "limit_order_quoter_parallelism: {:?}",
             self.limit_order_quoter_parallelism
+        )?;
+        writeln!(
+            f,
+            "skip_quoting_unfunded_orders: {:?}",
+            self.skip_quoting_unfunded_orders
         )?;
         Ok(())
     }

--- a/crates/autopilot/src/database/orders.rs
+++ b/crates/autopilot/src/database/orders.rs
@@ -201,7 +201,11 @@ impl Postgres {
         Ok(database::orders::count_limit_orders(&mut ex, now_in_epoch_seconds().into()).await?)
     }
 
-    pub async fn count_limit_orders_with_outdated_fees(&self, age: Duration, quote_unfunded_orders: bool) -> Result<i64> {
+    pub async fn count_limit_orders_with_outdated_fees(
+        &self,
+        age: Duration,
+        quote_unfunded_orders: bool,
+    ) -> Result<i64> {
         let _timer = super::Metrics::get()
             .database_queries
             .with_label_values(&["count_limit_orders_with_outdated_fees"])

--- a/crates/autopilot/src/database/orders.rs
+++ b/crates/autopilot/src/database/orders.rs
@@ -201,7 +201,7 @@ impl Postgres {
         Ok(database::orders::count_limit_orders(&mut ex, now_in_epoch_seconds().into()).await?)
     }
 
-    pub async fn count_limit_orders_with_outdated_fees(&self, age: Duration) -> Result<i64> {
+    pub async fn count_limit_orders_with_outdated_fees(&self, age: Duration, quote_unfunded_orders: bool) -> Result<i64> {
         let _timer = super::Metrics::get()
             .database_queries
             .with_label_values(&["count_limit_orders_with_outdated_fees"])
@@ -212,6 +212,7 @@ impl Postgres {
             &mut ex,
             timestamp,
             now_in_epoch_seconds().into(),
+            quote_unfunded_orders,
         )
         .await?)
     }

--- a/crates/autopilot/src/lib.rs
+++ b/crates/autopilot/src/lib.rs
@@ -583,13 +583,14 @@ pub async fn main(args: arguments::Arguments) -> ! {
             signature_validator,
             domain_separator,
             parallelism: args.limit_order_quoter_parallelism,
-            skip_quoting_unfunded_orders: args.skip_quoting_unfunded_orders,
+            quote_unfunded_orders: !args.skip_quoting_unfunded_orders,
         }
         .spawn();
         LimitOrderMetrics {
             quoting_age: limit_order_age,
             validity_age: limit_order_age * SURPLUS_FEE_EXPIRATION_FACTOR.into(),
             database: db,
+            quote_unfunded_orders: !args.skip_quoting_unfunded_orders
         }
         .spawn();
     }

--- a/crates/autopilot/src/lib.rs
+++ b/crates/autopilot/src/lib.rs
@@ -590,7 +590,7 @@ pub async fn main(args: arguments::Arguments) -> ! {
             quoting_age: limit_order_age,
             validity_age: limit_order_age * SURPLUS_FEE_EXPIRATION_FACTOR.into(),
             database: db,
-            quote_unfunded_orders: !args.skip_quoting_unfunded_orders
+            quote_unfunded_orders: !args.skip_quoting_unfunded_orders,
         }
         .spawn();
     }

--- a/crates/autopilot/src/limit_orders/balance_tracker.rs
+++ b/crates/autopilot/src/limit_orders/balance_tracker.rs
@@ -1,0 +1,135 @@
+use crate::database::Postgres;
+use anyhow::Result;
+use futures::StreamExt;
+use primitive_types::U256;
+use prometheus::IntGaugeVec;
+use shared::{
+    account_balances::{BalanceFetching, Query},
+    current_block::{into_stream, CurrentBlockStream},
+};
+use std::{
+    collections::{HashMap, HashSet},
+    sync::Arc,
+};
+use tracing::Instrument;
+
+#[derive(prometheus_metric_storage::MetricStorage)]
+pub struct Metrics {
+    /// Results of last run loop of the BalanceTracker
+    #[metric(labels("result"))]
+    limit_orders_balances: IntGaugeVec,
+}
+
+/// Updates `has_sufficient_balance` column of open orders.
+pub struct BalanceTracker {
+    balance_fetcher: Arc<dyn BalanceFetching>,
+    database: Postgres,
+    metrics: &'static Metrics,
+}
+
+fn get_initialized_merics() -> &'static Metrics {
+    let metrics = Metrics::instance(global_metrics::get_metric_storage_registry()).unwrap();
+
+    let gauges = &metrics.limit_orders_balances;
+    gauges.with_label_values(&["error"]).set(0);
+    gauges.with_label_values(&["sufficient"]).set(0);
+    gauges.with_label_values(&["insufficient"]).set(0);
+
+    metrics
+}
+
+impl BalanceTracker {
+    pub fn new(balance_fetcher: Arc<dyn BalanceFetching>, database: Postgres) -> Self {
+        Self {
+            balance_fetcher,
+            database,
+            metrics: get_initialized_merics(),
+        }
+    }
+
+    // Updates the `has_sufficient_balance` flag of open limit orders in the background on every
+    // new block.
+    pub fn spawn(self, block_stream: CurrentBlockStream) {
+        tracing::debug!("spawning background task of BalanceTracker");
+        tokio::spawn(
+            self.background_task(block_stream)
+                .instrument(tracing::info_span!("balance_tracker")),
+        );
+    }
+
+    async fn background_task(self, block_stream: CurrentBlockStream) {
+        let mut block_stream = into_stream(block_stream);
+        while block_stream.next().await.is_some() {
+            if let Err(err) = self.update_payable_orders().await {
+                tracing::error!(?err, "error updating has_sufficient_balance flag, consider disabling --skip-quoting-unfunded-orders");
+            }
+        }
+        tracing::error!("current block stream terminated unexpectedly");
+    }
+
+    async fn update_payable_orders(&self) -> Result<()> {
+        let orders = self
+            .database
+            .open_limit_orders_without_pre_interactions()
+            .await?;
+
+        // Collect orders in a HashSet first to avoid duplicated requests.
+        let queries: HashSet<_> = orders.iter().map(Query::from_order).collect();
+        let queries: Vec<_> = queries.into_iter().collect();
+
+        let start = std::time::Instant::now();
+        let balances = self.balance_fetcher.get_balances(&queries).await;
+        let balances: HashMap<_, _> = queries
+            .iter()
+            .zip(balances.into_iter())
+            .map(|(query, result)| (query, result.unwrap_or_default()))
+            .collect();
+
+        let mut errors = 0;
+        let mut sufficient = 0;
+        let mut insufficient = 0;
+
+        let updates: Vec<_> = orders
+            .iter()
+            .map(|order| {
+                let balance = balances.get(&Query::from_order(order));
+
+                let has_sufficient_balance = if let Some(balance) = balance {
+                    let has_sufficient_balance = match order.data.partially_fillable {
+                        true => balance >= &U256::one(), // any amount would be enough
+                        false => balance >= &order.data.sell_amount,
+                    };
+                    sufficient += i64::from(has_sufficient_balance);
+                    insufficient += i64::from(!has_sufficient_balance);
+                    has_sufficient_balance
+                } else {
+                    errors += 1;
+                    // In case the balance couldn't be fetched err on the safe side and assume
+                    // the order can be filled to not discard limit orders unjustly.
+                    true
+                };
+
+                (order.metadata.uid, has_sufficient_balance)
+            })
+            .collect();
+
+        tracing::debug!(
+            orders = orders.len(),
+            balances = queries.len(),
+            errors,
+            time =? start.elapsed(),
+            "fetched balances"
+        );
+
+        let gauges = &self.metrics.limit_orders_balances;
+        gauges.with_label_values(&["error"]).set(errors);
+        gauges.with_label_values(&["sufficient"]).set(sufficient);
+        gauges
+            .with_label_values(&["insufficient"])
+            .set(insufficient);
+
+        self.database
+            .update_has_sufficient_balance_flags(&updates)
+            .await
+    }
+}

--- a/crates/autopilot/src/limit_orders/metrics.rs
+++ b/crates/autopilot/src/limit_orders/metrics.rs
@@ -34,12 +34,12 @@ impl LimitOrderMetrics {
                     let limit_orders = self.database.count_limit_orders().await.unwrap();
                     let awaiting_quote = self
                         .database
-                        .count_limit_orders_with_outdated_fees(self.quoting_age)
+                        .count_limit_orders_with_outdated_fees(self.quoting_age, self.quote_unfunded_orders)
                         .await
                         .unwrap();
                     let unusable = self
                         .database
-                        .count_limit_orders_with_outdated_fees(self.validity_age)
+                        .count_limit_orders_with_outdated_fees(self.validity_age, self.quote_unfunded_orders)
                         .await
                         .unwrap();
 

--- a/crates/autopilot/src/limit_orders/metrics.rs
+++ b/crates/autopilot/src/limit_orders/metrics.rs
@@ -11,6 +11,7 @@ pub struct LimitOrderMetrics {
     /// At that age the [`SolvableOrdersCache`] would consider a `surplus_fee` too old.
     pub validity_age: chrono::Duration,
     pub database: Postgres,
+    pub quote_unfunded_orders: bool,
 }
 
 impl LimitOrderMetrics {

--- a/crates/autopilot/src/limit_orders/metrics.rs
+++ b/crates/autopilot/src/limit_orders/metrics.rs
@@ -34,12 +34,18 @@ impl LimitOrderMetrics {
                     let limit_orders = self.database.count_limit_orders().await.unwrap();
                     let awaiting_quote = self
                         .database
-                        .count_limit_orders_with_outdated_fees(self.quoting_age, self.quote_unfunded_orders)
+                        .count_limit_orders_with_outdated_fees(
+                            self.quoting_age,
+                            self.quote_unfunded_orders,
+                        )
                         .await
                         .unwrap();
                     let unusable = self
                         .database
-                        .count_limit_orders_with_outdated_fees(self.validity_age, self.quote_unfunded_orders)
+                        .count_limit_orders_with_outdated_fees(
+                            self.validity_age,
+                            self.quote_unfunded_orders,
+                        )
                         .await
                         .unwrap();
 

--- a/crates/autopilot/src/limit_orders/mod.rs
+++ b/crates/autopilot/src/limit_orders/mod.rs
@@ -1,5 +1,7 @@
+mod balance_tracker;
 mod metrics;
 mod quoter;
 
+pub use balance_tracker::BalanceTracker;
 pub use metrics::LimitOrderMetrics;
 pub use quoter::LimitOrderQuoter;

--- a/crates/autopilot/src/limit_orders/quoter.rs
+++ b/crates/autopilot/src/limit_orders/quoter.rs
@@ -29,7 +29,7 @@ pub struct LimitOrderQuoter {
     pub signature_validator: Arc<dyn SignatureValidating>,
     pub domain_separator: DomainSeparator,
     pub parallelism: usize,
-    pub skip_quoting_unfunded_orders: bool,
+    pub quote_unfunded_orders: bool,
 }
 
 impl LimitOrderQuoter {
@@ -64,7 +64,7 @@ impl LimitOrderQuoter {
             .order_specs_with_outdated_fees(
                 self.limit_order_age,
                 self.parallelism,
-                !self.skip_quoting_unfunded_orders,
+                self.quote_unfunded_orders,
             )
             .await?;
         futures::stream::iter(&order_specs)

--- a/crates/database/src/orders.rs
+++ b/crates/database/src/orders.rs
@@ -2093,7 +2093,9 @@ mod tests {
         );
 
         // Metrics discard unfunded orders if we configure them so.
-        update_has_sufficient_balance_flag(&mut db, &order_uid, false).await.unwrap();
+        update_has_sufficient_balance_flag(&mut db, &order_uid, false)
+            .await
+            .unwrap();
         assert_eq!(
             count_limit_orders_with_outdated_fees(&mut db, timestamp, 2, false)
                 .await

--- a/crates/e2e/tests/e2e/services.rs
+++ b/crates/e2e/tests/e2e/services.rs
@@ -10,7 +10,7 @@ use autopilot::{
         },
     },
     event_updater::GPv2SettlementContract,
-    limit_orders::LimitOrderQuoter,
+    limit_orders::{BalanceTracker, LimitOrderQuoter},
     solvable_orders::SolvableOrdersCache,
 };
 use contracts::{IUniswapLikeRouter, WETH9};
@@ -194,8 +194,11 @@ impl OrderbookServices {
             signature_validator: signature_validator.clone(),
             domain_separator: contracts.domain_separator,
             parallelism: 2,
+            skip_quoting_unfunded_orders: true,
         }
         .spawn();
+        BalanceTracker::new(balance_fetcher.clone(), autopilot_db.clone())
+            .spawn(current_block_stream.clone());
         let mut code_fetcher = MockCodeFetching::new();
         code_fetcher.expect_code_size().returning(|_| Ok(0));
         let order_validator = Arc::new(

--- a/crates/e2e/tests/e2e/services.rs
+++ b/crates/e2e/tests/e2e/services.rs
@@ -194,7 +194,7 @@ impl OrderbookServices {
             signature_validator: signature_validator.clone(),
             domain_separator: contracts.domain_separator,
             parallelism: 2,
-            skip_quoting_unfunded_orders: true,
+            quote_unfunded_orders: false,
         }
         .spawn();
         BalanceTracker::new(balance_fetcher.clone(), autopilot_db.clone())

--- a/database/sql/V048__add_has_required_balance.sql
+++ b/database/sql/V048__add_has_required_balance.sql
@@ -1,0 +1,3 @@
+-- Add a flag to avoid quoting orders where the owner doesn't have the required balance.
+-- To err on the safe side we initialize the flag to true per default.
+ALTER TABLE orders ADD COLUMN has_sufficient_balance boolean NOT NULL DEFAULT true;


### PR DESCRIPTION
Fixes: #1030

A lot of our limit orders don't make it into the auction because the owner doesn't have the required `sell_token` balance.
Because determining whether the order's owner has enough balances is a lot cheaper than getting a `surplus_fee` update this PR  adds the flag `has_sufficient_balance` to the `orders` table and only quotes orders where this is true.
A new background task keeps this flag up-to-date on every new block.
I added a DB migration step which sets that flag to true for all existing orders and initializes it to true for new orders. Also in case of an error I tried to err on the safe side to avoid discarding orders unjustly.
This behavior is feature gated by `--skip-quoting-unfunded-orders` so we can quickly disable that in case some problem occurs.
I also updated the existing metrics and added a few new ones to measure this optimization's performance.

We know that around half of the quoted orders (600) are missing the required funds but it's unclear how many of them will still have to be discarded in the `SolvableOrdersCache` due to #1037. However I'm still confident that this is still a useful optimization.

### Test Plan
Updated/extended existing unit tests and added a new one.
Manual tests are looking good.
Prints the CLI argument:
```
...
limit_order_quoter_parallelism: 5
skip_quoting_unfunded_orders: true
```
Prints a help text:
```
      --skip-quoting-unfunded-orders
          Skip updating the `surplus_fee` for orders where the owner currently doesn't have enough balance

          [env: SKIP_QUOTING_UNFUNDED_ORDERS=]
```
