### PR TITLE
Fix rust 1.67.0 warnings

### DIFF
--- a/crates/alerter/src/main.rs
+++ b/crates/alerter/src/main.rs
@@ -92,7 +92,7 @@ impl OrderBookApi {
     }
 
     pub async fn order(&self, uid: &OrderUid) -> reqwest::Result<Order> {
-        let url = self.base.join(&format!("api/v1/orders/{}", uid)).unwrap();
+        let url = self.base.join(&format!("api/v1/orders/{uid}")).unwrap();
         self.client
             .get(url)
             .send()
@@ -142,7 +142,7 @@ impl ZeroExApi {
         let buy_token = convert_eth_to_weth(order.buy_token);
         url.query_pairs_mut()
             .append_pair("sellToken", &format!("{:#x}", order.sell_token))
-            .append_pair("buyToken", &format!("{:#x}", buy_token))
+            .append_pair("buyToken", &format!("{buy_token:#x}"))
             .append_pair(amount_name, &amount.to_string());
 
         #[derive(Debug, serde::Deserialize)]

--- a/crates/autopilot/src/database.rs
+++ b/crates/autopilot/src/database.rs
@@ -30,7 +30,7 @@ impl Postgres {
 }
 
 async fn count_rows_in_table(ex: &mut PgConnection, table: &str) -> sqlx::Result<i64> {
-    let query = format!("SELECT COUNT(*) FROM {};", table);
+    let query = format!("SELECT COUNT(*) FROM {table};");
     sqlx::query_scalar(&query).fetch_one(ex).await
 }
 

--- a/crates/autopilot/src/lib.rs
+++ b/crates/autopilot/src/lib.rs
@@ -124,7 +124,7 @@ pub async fn main(args: arguments::Arguments) -> ! {
             tracing::warn!("balancer contracts are not deployed on this network");
             None
         }
-        Err(err) => panic!("failed to get balancer vault contract: {}", err),
+        Err(err) => panic!("failed to get balancer vault contract: {err}"),
     };
     let uniswapv3_factory = match IUniswapV3Factory::deployed(&web3).await {
         Err(DeployError::NotFound(_)) => None,
@@ -591,5 +591,5 @@ pub async fn main(args: arguments::Arguments) -> ! {
     }
 
     let result = serve_metrics.await;
-    panic!("serve_metrics exited {:?}", result);
+    panic!("serve_metrics exited {result:?}");
 }

--- a/crates/contracts/build.rs
+++ b/crates/contracts/build.rs
@@ -339,7 +339,7 @@ fn generate_contract_with_config(
     config(ContractBuilder::new().visibility_modifier("pub"))
         .generate(&contract)
         .unwrap()
-        .write_to_file(Path::new(&dest).join(format!("{}.rs", name)))
+        .write_to_file(Path::new(&dest).join(format!("{name}.rs")))
         .unwrap();
 }
 

--- a/crates/database/src/byte_array.rs
+++ b/crates/database/src/byte_array.rs
@@ -79,20 +79,20 @@ mod tests {
     async fn postgres_fixed_bytes() {
         const TABLE: &str = "fixed_bytes_test";
         let db = PgPool::connect("postgresql://").await.unwrap();
-        db.execute(format!("CREATE TABLE IF NOT EXISTS {} (bytes bytea);", TABLE).as_str())
+        db.execute(format!("CREATE TABLE IF NOT EXISTS {TABLE} (bytes bytea);").as_str())
             .await
             .unwrap();
-        db.execute(format!("TRUNCATE {};", TABLE).as_str())
+        db.execute(format!("TRUNCATE {TABLE};").as_str())
             .await
             .unwrap();
 
         let data: ByteArray<3> = ByteArray([1, 2, 3]);
-        sqlx::query(&format!("INSERT INTO {} (bytes) VALUES ($1);", TABLE))
+        sqlx::query(&format!("INSERT INTO {TABLE} (bytes) VALUES ($1);"))
             .bind(&data)
             .execute(&db)
             .await
             .unwrap();
-        let query = format!("SELECT * FROM {} LIMIT 1;", TABLE);
+        let query = format!("SELECT * FROM {TABLE} LIMIT 1;");
 
         // unprepared raw query
         let row = db.fetch_one(query.as_str()).await.unwrap();

--- a/crates/database/src/ethflow_orders.rs
+++ b/crates/database/src/ethflow_orders.rs
@@ -449,7 +449,7 @@ mod tests {
         let now = std::time::Instant::now();
         refundable_orders(&mut db, 1, 1, 1.0).await.unwrap();
         let elapsed = now.elapsed();
-        println!("{:?}", elapsed);
+        println!("{elapsed:?}");
         assert!(elapsed < std::time::Duration::from_secs(1));
     }
 }

--- a/crates/database/src/trades.rs
+++ b/crates/database/src/trades.rs
@@ -212,7 +212,7 @@ mod tests {
             .await
             .unwrap();
         let elapsed = now.elapsed();
-        println!("{:?}", elapsed);
+        println!("{elapsed:?}");
         assert!(elapsed < std::time::Duration::from_secs(1));
     }
 

--- a/crates/dev-geth/src/main.rs
+++ b/crates/dev-geth/src/main.rs
@@ -94,7 +94,7 @@ struct Processes {
 impl Processes {
     async fn start(&self) -> Port {
         let port = self.next_port();
-        let datadir = format!("/{}", port);
+        let datadir = format!("/{port}");
         let status = tokio::process::Command::new("cp")
             .arg("-r")
             .arg(BASE_DATADIR)

--- a/crates/driver/src/tests/setup/blockchain/mod.rs
+++ b/crates/driver/src/tests/setup/blockchain/mod.rs
@@ -39,7 +39,7 @@ impl Drop for Geth {
         tokio::spawn(async move {
             let client = reqwest::Client::new();
             client
-                .delete(&format!("http://localhost:{DEV_GETH_PORT}/{}", port))
+                .delete(&format!("http://localhost:{DEV_GETH_PORT}/{port}"))
                 .send()
                 .await
                 .unwrap();

--- a/crates/e2e/tests/e2e/eth_integration.rs
+++ b/crates/e2e/tests/e2e/eth_integration.rs
@@ -122,7 +122,7 @@ async fn eth_integration(web3: Web3) {
         .build()
         .into_order_creation();
     let placement = client
-        .post(&format!("{}{}", API_HOST, ORDER_PLACEMENT_ENDPOINT))
+        .post(&format!("{API_HOST}{ORDER_PLACEMENT_ENDPOINT}"))
         .json(&order_buy_eth_a)
         .send()
         .await;
@@ -143,7 +143,7 @@ async fn eth_integration(web3: Web3) {
         .build()
         .into_order_creation();
     let placement = client
-        .post(&format!("{}{}", API_HOST, ORDER_PLACEMENT_ENDPOINT))
+        .post(&format!("{API_HOST}{ORDER_PLACEMENT_ENDPOINT}"))
         .json(&order_buy_eth_b)
         .send()
         .await;

--- a/crates/e2e/tests/e2e/onchain_settlement.rs
+++ b/crates/e2e/tests/e2e/onchain_settlement.rs
@@ -149,7 +149,7 @@ async fn onchain_settlement(web3: Web3) {
         .build()
         .into_order_creation();
     let placement = client
-        .post(&format!("{}{}", API_HOST, ORDER_PLACEMENT_ENDPOINT))
+        .post(&format!("{API_HOST}{ORDER_PLACEMENT_ENDPOINT}"))
         .json(&order_a)
         .send()
         .await;
@@ -171,7 +171,7 @@ async fn onchain_settlement(web3: Web3) {
         .build()
         .into_order_creation();
     let placement = client
-        .post(&format!("{}{}", API_HOST, ORDER_PLACEMENT_ENDPOINT))
+        .post(&format!("{API_HOST}{ORDER_PLACEMENT_ENDPOINT}"))
         .json(&order_b)
         .send()
         .await;

--- a/crates/e2e/tests/e2e/order_cancellation.rs
+++ b/crates/e2e/tests/e2e/order_cancellation.rs
@@ -80,7 +80,7 @@ async fn order_cancellation(web3: Web3) {
         };
         async move {
             let quote = client
-                .post(&format!("{}{}", API_HOST, QUOTE_ENDPOINT))
+                .post(&format!("{API_HOST}{QUOTE_ENDPOINT}"))
                 .json(&request)
                 .send()
                 .await
@@ -108,7 +108,7 @@ async fn order_cancellation(web3: Web3) {
                 .into_order_creation();
 
             let placement = client
-                .post(&format!("{}{}", API_HOST, ORDER_PLACEMENT_ENDPOINT))
+                .post(&format!("{API_HOST}{ORDER_PLACEMENT_ENDPOINT}"))
                 .json(&order)
                 .send()
                 .await
@@ -130,10 +130,7 @@ async fn order_cancellation(web3: Web3) {
 
         async move {
             let cancellation = client
-                .delete(&format!(
-                    "{}{}{}",
-                    API_HOST, ORDER_PLACEMENT_ENDPOINT, order_uid
-                ))
+                .delete(&format!("{API_HOST}{ORDER_PLACEMENT_ENDPOINT}{order_uid}"))
                 .json(&CancellationPayload {
                     signature: cancellation.signature,
                     signing_scheme: cancellation.signing_scheme,
@@ -165,7 +162,7 @@ async fn order_cancellation(web3: Web3) {
 
         async move {
             let cancellation = client
-                .delete(&format!("{}{}", API_HOST, ORDER_PLACEMENT_ENDPOINT))
+                .delete(&format!("{API_HOST}{ORDER_PLACEMENT_ENDPOINT}"))
                 .json(&signed_cancellations)
                 .send()
                 .await
@@ -185,10 +182,7 @@ async fn order_cancellation(web3: Web3) {
         let client = &client;
         async move {
             client
-                .get(&format!(
-                    "{}{}{}",
-                    API_HOST, ORDER_PLACEMENT_ENDPOINT, order_uid
-                ))
+                .get(&format!("{API_HOST}{ORDER_PLACEMENT_ENDPOINT}{order_uid}"))
                 .send()
                 .await
                 .unwrap()

--- a/crates/e2e/tests/e2e/services.rs
+++ b/crates/e2e/tests/e2e/services.rs
@@ -348,7 +348,7 @@ pub async fn setup_naive_solver_uniswapv2_driver(
 pub async fn wait_for_solvable_orders(client: &Client, minimum: usize) -> Result<()> {
     let condition = || async {
         let response = client
-            .get(format!("{}/api/v1/auction", API_HOST))
+            .get(format!("{API_HOST}/api/v1/auction"))
             .send()
             .await
             .unwrap();
@@ -358,7 +358,7 @@ pub async fn wait_for_solvable_orders(client: &Client, minimum: usize) -> Result
                 auction.auction.orders.len() >= minimum
             }
             StatusCode::NOT_FOUND => false,
-            other => panic!("unexpected status code {}", other),
+            other => panic!("unexpected status code {other}"),
         }
     };
     wait_for_condition(Duration::from_secs(30), condition).await

--- a/crates/e2e/tests/e2e/settlement_without_onchain_liquidity.rs
+++ b/crates/e2e/tests/e2e/settlement_without_onchain_liquidity.rs
@@ -154,7 +154,7 @@ async fn onchain_settlement_without_liquidity(web3: Web3) {
         .build()
         .into_order_creation();
     let placement = client
-        .post(&format!("{}{}", API_HOST, ORDER_PLACEMENT_ENDPOINT))
+        .post(&format!("{API_HOST}{ORDER_PLACEMENT_ENDPOINT}"))
         .json(&order)
         .send()
         .await;

--- a/crates/e2e/tests/e2e/smart_contract_orders.rs
+++ b/crates/e2e/tests/e2e/smart_contract_orders.rs
@@ -141,7 +141,7 @@ async fn smart_contract_orders(web3: Web3) {
     for order in &mut orders {
         let creation = order.clone().into_order_creation();
         let placement = client
-            .post(&format!("{}{}", API_HOST, ORDER_PLACEMENT_ENDPOINT))
+            .post(&format!("{API_HOST}{ORDER_PLACEMENT_ENDPOINT}"))
             .json(&creation)
             .send()
             .await

--- a/crates/e2e/tests/e2e/vault_balances.rs
+++ b/crates/e2e/tests/e2e/vault_balances.rs
@@ -103,7 +103,7 @@ async fn vault_balances(web3: Web3) {
         .build()
         .into_order_creation();
     let placement = client
-        .post(&format!("{}{}", API_HOST, ORDER_PLACEMENT_ENDPOINT))
+        .post(&format!("{API_HOST}{ORDER_PLACEMENT_ENDPOINT}"))
         .json(&order)
         .send()
         .await;

--- a/crates/model/src/app_id.rs
+++ b/crates/model/src/app_id.rs
@@ -50,8 +50,7 @@ impl<'de> Deserialize<'de> for AppId {
         let s = Cow::<str>::deserialize(deserializer)?;
         let value = s.parse().map_err(|err| {
             de::Error::custom(format!(
-                "failed to decode {:?} as hex appdata 32 bytes: {}",
-                s, err
+                "failed to decode {s:?} as hex appdata 32 bytes: {err}"
             ))
         })?;
         Ok(value)

--- a/crates/model/src/order.rs
+++ b/crates/model/src/order.rs
@@ -645,7 +645,7 @@ impl Display for OrderUid {
 
 impl fmt::Debug for OrderUid {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self)
+        write!(f, "{self}")
     }
 }
 
@@ -683,13 +683,12 @@ impl<'de> Deserialize<'de> for OrderUid {
             {
                 let s = s.strip_prefix("0x").ok_or_else(|| {
                     de::Error::custom(format!(
-                        "{:?} can't be decoded as hex uid because it does not start with '0x'",
-                        s
+                        "{s:?} can't be decoded as hex uid because it does not start with '0x'"
                     ))
                 })?;
                 let mut value = [0u8; 56];
                 hex::decode_to_slice(s, value.as_mut()).map_err(|err| {
-                    de::Error::custom(format!("failed to decode {:?} as hex uid: {}", s, err))
+                    de::Error::custom(format!("failed to decode {s:?} as hex uid: {err}"))
                 })?;
                 Ok(OrderUid(value))
             }
@@ -839,7 +838,7 @@ pub fn debug_biguint_to_string(
     value: &BigUint,
     formatter: &mut std::fmt::Formatter,
 ) -> Result<(), std::fmt::Error> {
-    formatter.write_fmt(format_args!("{}", value))
+    formatter.write_fmt(format_args!("{value}"))
 }
 
 #[cfg(test)]
@@ -1141,7 +1140,7 @@ mod tests {
         uid.0[55] = 0xff;
         let expected = "0x01000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ff";
         assert_eq!(uid.to_string(), expected);
-        assert_eq!(format!("{}", uid), expected);
+        assert_eq!(format!("{uid}"), expected);
     }
 
     #[test]

--- a/crates/model/src/ratio_as_decimal.rs
+++ b/crates/model/src/ratio_as_decimal.rs
@@ -41,10 +41,8 @@ pub fn deserialize<'de, D>(deserializer: D) -> Result<BigRational, D::Error>
 where
     D: Deserializer<'de>,
 {
-    let big_decimal =
-        BigDecimal::from_str(&Cow::<str>::deserialize(deserializer)?).map_err(|err| {
-            de::Error::custom(format!("failed to decode decimal BigDecimal: {}", err))
-        })?;
+    let big_decimal = BigDecimal::from_str(&Cow::<str>::deserialize(deserializer)?)
+        .map_err(|err| de::Error::custom(format!("failed to decode decimal BigDecimal: {err}")))?;
     let (x, exp) = big_decimal.into_bigint_and_exponent();
     let numerator_bytes = x.to_bytes_le();
     let base = num::bigint::BigInt::from_bytes_le(numerator_bytes.0, &numerator_bytes.1);
@@ -53,7 +51,7 @@ where
     Ok(numerator
         / ten.pow(
             exp.try_into()
-                .map_err(|err| de::Error::custom(format!("decimal exponent overflow: {}", err)))?,
+                .map_err(|err| de::Error::custom(format!("decimal exponent overflow: {err}")))?,
         ))
 }
 

--- a/crates/model/src/signature.rs
+++ b/crates/model/src/signature.rs
@@ -394,15 +394,13 @@ impl<'de> Deserialize<'de> for EcdsaSignature {
             {
                 let s = s.strip_prefix("0x").ok_or_else(|| {
                     de::Error::custom(format!(
-                        "{:?} can't be decoded as hex ecdsa signature because it does not start with '0x'",
-                        s
+                        "{s:?} can't be decoded as hex ecdsa signature because it does not start with '0x'"
                     ))
                 })?;
                 let mut bytes = [0u8; 65];
                 hex::decode_to_slice(s, &mut bytes).map_err(|err| {
                     de::Error::custom(format!(
-                        "failed to decode {:?} as hex ecdsa signature: {}",
-                        s, err
+                        "failed to decode {s:?} as hex ecdsa signature: {err}"
                     ))
                 })?;
                 Ok(EcdsaSignature::from_bytes(&bytes))

--- a/crates/model/src/u256_decimal.rs
+++ b/crates/model/src/u256_decimal.rs
@@ -47,7 +47,7 @@ where
             E: de::Error,
         {
             U256::from_dec_str(s).map_err(|err| {
-                de::Error::custom(format!("failed to decode {:?} as decimal u256: {}", s, err))
+                de::Error::custom(format!("failed to decode {s:?} as decimal u256: {err}"))
             })
         }
     }
@@ -71,7 +71,7 @@ pub fn format_units(amount: U256, decimals: usize) -> String {
     if decimals == 0 {
         str_amount
     } else if str_amount.len() <= decimals {
-        format!("0.{:0>pad_left$}", str_amount, pad_left = decimals)
+        format!("0.{str_amount:0>decimals$}")
     } else {
         format!(
             "{}.{}",

--- a/crates/orderbook/src/api/get_order_by_uid.rs
+++ b/crates/orderbook/src/api/get_order_by_uid.rs
@@ -46,9 +46,7 @@ mod tests {
     #[tokio::test]
     async fn get_order_by_uid_request_ok() {
         let uid = OrderUid::default();
-        let request = request()
-            .path(&format!("/v1/orders/{:}", uid))
-            .method("GET");
+        let request = request().path(&format!("/v1/orders/{uid:}")).method("GET");
         let filter = get_order_by_uid_request();
         let result = request.filter(&filter).await.unwrap();
         assert_eq!(result, uid);

--- a/crates/orderbook/src/api/get_orders_by_tx.rs
+++ b/crates/orderbook/src/api/get_orders_by_tx.rs
@@ -37,7 +37,7 @@ mod tests {
     async fn request_ok() {
         let hash_str = "0x0191dbb560e936bd3320d5a505c9c05580a0ebb7e12fe117551ac26e484f295e";
         let result = warp::test::request()
-            .path(&format!("/v1/transactions/{:}/orders", hash_str))
+            .path(&format!("/v1/transactions/{hash_str:}/orders"))
             .method("GET")
             .filter(&get_orders_by_tx_request())
             .await

--- a/crates/orderbook/src/api/get_trades.rs
+++ b/crates/orderbook/src/api/get_trades.rs
@@ -86,7 +86,7 @@ mod tests {
         };
 
         let owner = H160::from_slice(&hex!("0000000000000000000000000000000000000001"));
-        let owner_path = format!("/v1/trades?owner=0x{:x}", owner);
+        let owner_path = format!("/v1/trades?owner=0x{owner:x}");
         let result = trade_filter(request().path(owner_path.as_str()))
             .await
             .unwrap()
@@ -95,7 +95,7 @@ mod tests {
         assert_eq!(result.order_uid, None);
 
         let uid = OrderUid([1u8; 56]);
-        let order_uid_path = format!("/v1/trades?orderUid={:}", uid);
+        let order_uid_path = format!("/v1/trades?orderUid={uid:}");
         let result = trade_filter(request().path(order_uid_path.as_str()))
             .await
             .unwrap()
@@ -113,7 +113,7 @@ mod tests {
 
         let owner = H160::from_slice(&hex!("0000000000000000000000000000000000000001"));
         let uid = OrderUid([1u8; 56]);
-        let path = format!("/v1/trades?owner=0x{:x}&orderUid={:}", owner, uid);
+        let path = format!("/v1/trades?owner=0x{owner:x}&orderUid={uid:}");
 
         let result = trade_filter(request().path(path.as_str())).await.unwrap();
         assert!(result.is_err());

--- a/crates/orderbook/src/api/get_user_orders.rs
+++ b/crates/orderbook/src/api/get_user_orders.rs
@@ -34,7 +34,7 @@ pub fn get_user_orders(
                 return Ok(with_status(
                     super::error(
                         "LIMIT_OUT_OF_BOUNDS",
-                        format!("The pagination limit is [{},{}].", MIN_LIMIT, MAX_LIMIT),
+                        format!("The pagination limit is [{MIN_LIMIT},{MAX_LIMIT}]."),
                     ),
                     StatusCode::BAD_REQUEST,
                 ));

--- a/crates/orderbook/src/main.rs
+++ b/crates/orderbook/src/main.rs
@@ -101,7 +101,7 @@ async fn main() -> ! {
             tracing::warn!("balancer contracts are not deployed on this network");
             None
         }
-        Err(err) => panic!("failed to get balancer vault contract: {}", err),
+        Err(err) => panic!("failed to get balancer vault contract: {err}"),
     };
 
     verify_deployed_contract_constants(&settlement_contract, chain_id)
@@ -472,8 +472,8 @@ async fn main() -> ! {
 
     futures::pin_mut!(serve_api);
     tokio::select! {
-        result = &mut serve_api => panic!("API task exited {:?}", result),
-        result = metrics_task => panic!("metrics task exited {:?}", result),
+        result = &mut serve_api => panic!("API task exited {result:?}"),
+        result = metrics_task => panic!("metrics task exited {result:?}"),
         _ = shutdown_signal() => {
             tracing::info!("Gracefully shutting down API");
             shutdown_sender.send(()).expect("failed to send shutdown signal");

--- a/crates/shared/src/account_balances.rs
+++ b/crates/shared/src/account_balances.rs
@@ -343,7 +343,7 @@ mod tests {
             .next()
             .unwrap()
             .unwrap();
-        println!("{}", result);
+        println!("{result}");
         assert!(result >= U256::from(811));
 
         let call_result = fetcher.can_transfer_call(token, owner, 811.into()).await;

--- a/crates/shared/src/api.rs
+++ b/crates/shared/src/api.rs
@@ -242,7 +242,7 @@ impl IntoWarpReply for PriceEstimationError {
     fn into_warp_reply(self) -> WithStatus<Json> {
         match self {
             Self::UnsupportedToken(token) => with_status(
-                error("UnsupportedToken", format!("Token address {:?}", token)),
+                error("UnsupportedToken", format!("Token address {token:?}")),
                 StatusCode::BAD_REQUEST,
             ),
             Self::NoLiquidity => with_status(

--- a/crates/shared/src/arguments.rs
+++ b/crates/shared/src/arguments.rs
@@ -298,7 +298,7 @@ pub fn display_option(
 ) -> std::fmt::Result {
     write!(f, "{name}: ")?;
     match option {
-        Some(display) => writeln!(f, "{}", display),
+        Some(display) => writeln!(f, "{display}"),
         None => writeln!(f, "None"),
     }
 }
@@ -536,17 +536,17 @@ mod test {
         let y = "0x0101010101010101010101010101010101010101010101010101010101010101";
         // without spaces
         assert_eq!(
-            parse_partner_fee_factor(&format!("{}:0.5,{}:0.7", x, y)).unwrap(),
+            parse_partner_fee_factor(&format!("{x}:0.5,{y}:0.7")).unwrap(),
             hashmap! { AppId([0u8; 32]) => 0.5, AppId([1u8; 32]) => 0.7 }
         );
         // with spaces
         assert_eq!(
-            parse_partner_fee_factor(&format!("{}: 0.5, {}: 0.7", x, y)).unwrap(),
+            parse_partner_fee_factor(&format!("{x}: 0.5, {y}: 0.7")).unwrap(),
             hashmap! { AppId([0u8; 32]) => 0.5, AppId([1u8; 32]) => 0.7 }
         );
         // whole numbers
         assert_eq!(
-            parse_partner_fee_factor(&format!("{}: 1, {}: 2", x, y)).unwrap(),
+            parse_partner_fee_factor(&format!("{x}: 1, {y}: 2")).unwrap(),
             hashmap! { AppId([0u8; 32]) => 1., AppId([1u8; 32]) => 2. }
         );
     }

--- a/crates/shared/src/bad_token/token_owner_finder/solvers/solver_api.rs
+++ b/crates/shared/src/bad_token/token_owner_finder/solvers/solver_api.rs
@@ -23,6 +23,6 @@ impl TokenOwnerSolverApi for SolverConfiguration {
             .await?
             .text()
             .await?;
-        serde_json::from_str(&response).context(format!("bad query response: {:?}", response))
+        serde_json::from_str(&response).context(format!("bad query response: {response:?}"))
     }
 }

--- a/crates/shared/src/bad_token/trace_call.rs
+++ b/crates/shared/src/bad_token/trace_call.rs
@@ -191,8 +191,7 @@ impl TraceCallDetector {
 
         if let Err(err) = ensure_transaction_ok_and_get_gas(&traces[7])? {
             return Ok(TokenQuality::bad(format!(
-                "can't approve max amount: {}",
-                err
+                "can't approve max amount: {err}"
             )));
         }
 
@@ -609,13 +608,13 @@ mod tests {
         println!("testing good tokens");
         for &token in base_tokens {
             let result = token_cache.detect(token).await;
-            println!("token {:?} is {:?}", token, result);
+            println!("token {token:?} is {result:?}");
         }
 
         println!("testing bad tokens");
         for &token in bad_tokens {
             let result = token_cache.detect(token).await;
-            println!("token {:?} is {:?}", token, result);
+            println!("token {token:?} is {result:?}");
         }
     }
 
@@ -770,7 +769,7 @@ mod tests {
 
         for token in tokens {
             let result = token_cache.detect(token).await;
-            println!("token {:?} is {:?}", token, result);
+            println!("token {token:?} is {result:?}");
         }
     }
 }

--- a/crates/shared/src/balancer_sor_api.rs
+++ b/crates/shared/src/balancer_sor_api.rs
@@ -326,7 +326,7 @@ mod tests {
 
         fn base(atoms: U256) -> String {
             let base = atoms.to_f64_lossy() / 1e18;
-            format!("{:.6}", base)
+            format!("{base:.6}")
         }
 
         let sell_quote = api

--- a/crates/shared/src/ethrpc/http.rs
+++ b/crates/shared/src/ethrpc/http.rs
@@ -193,7 +193,7 @@ fn handle_batch_response(
     ids.iter()
         .map(|id| {
             outputs.remove(id).ok_or_else(|| {
-                Web3Error::InvalidResponse(format!("batch response is missing id {}", id))
+                Web3Error::InvalidResponse(format!("batch response is missing id {id}"))
             })
         })
         .collect()

--- a/crates/shared/src/ethrpc/mock.rs
+++ b/crates/shared/src/ethrpc/mock.rs
@@ -101,7 +101,7 @@ fn extract_call(call: Call) -> (String, Vec<Value>) {
             params: Params::Array(params),
             ..
         }) => (method, params),
-        _ => panic!("unexpected call {:?}", call),
+        _ => panic!("unexpected call {call:?}"),
     }
 }
 

--- a/crates/shared/src/fee_subsidy/cow_token.rs
+++ b/crates/shared/src/fee_subsidy/cow_token.rs
@@ -21,18 +21,18 @@ impl std::str::FromStr for SubsidyTiers {
         for tier in serialized.split(',') {
             let (threshold, fee_factor) = tier
                 .split_once(':')
-                .with_context(|| format!("too few arguments for subsidy tier in \"{}\"", tier))?;
+                .with_context(|| format!("too few arguments for subsidy tier in \"{tier}\""))?;
 
             let threshold: u64 = threshold
                 .parse()
-                .with_context(|| format!("can not parse threshold \"{}\" as u64", threshold))?;
+                .with_context(|| format!("can not parse threshold \"{threshold}\" as u64"))?;
             let threshold = U256::from(threshold)
                 .checked_mul(U256::exp10(18))
                 .with_context(|| format!("threshold {threshold} would overflow U256"))?;
 
             let fee_factor: f64 = fee_factor
                 .parse()
-                .with_context(|| format!("can not parse fee factor \"{}\" as f64", fee_factor))?;
+                .with_context(|| format!("can not parse fee factor \"{fee_factor}\" as f64"))?;
 
             anyhow::ensure!(
                 (0.0..=1.0).contains(&fee_factor),
@@ -138,7 +138,7 @@ mod tests {
         ] {
             let user = H160(user);
             let result = subsidy.cow_subsidy_factor(user).await;
-            println!("{:?} {:?}", user, result);
+            println!("{user:?} {result:?}");
         }
     }
 }

--- a/crates/shared/src/http_solver.rs
+++ b/crates/shared/src/http_solver.rs
@@ -171,7 +171,7 @@ impl HttpSolverApi for DefaultHttpSolverApi {
                 .context("response body")?;
         let text = std::str::from_utf8(&response_body).context("failed to decode response body")?;
         tracing::trace!(body = %text, "response");
-        let context = || format!("request query {}, response body {}", query, text);
+        let context = || format!("request query {query}, response body {text}");
         if status == StatusCode::TOO_MANY_REQUESTS {
             return Err(Error::RateLimited);
         }

--- a/crates/shared/src/oneinch_api.rs
+++ b/crates/shared/src/oneinch_api.rs
@@ -85,12 +85,12 @@ pub struct SellOrderQuoteQuery {
 // the full address and instead uses ellipsis (e.g. "0xeeee…eeee"). This
 // helper just works around that.
 fn addr2str(addr: H160) -> String {
-    format!("{:?}", addr)
+    format!("{addr:?}")
 }
 
 impl SellOrderQuoteQuery {
     fn into_url(self, base_url: &Url, chain_id: u64) -> Url {
-        let endpoint = format!("v5.0/{}/quote", chain_id);
+        let endpoint = format!("v5.0/{chain_id}/quote");
         let mut url = base_url
             .join(&endpoint)
             .expect("unexpectedly invalid URL segment");
@@ -241,7 +241,7 @@ impl Display for Slippage {
 impl SwapQuery {
     /// Encodes the swap query as
     fn into_url(self, base_url: &Url, chain_id: u64) -> Url {
-        let endpoint = format!("v5.0/{}/swap", chain_id);
+        let endpoint = format!("v5.0/{chain_id}/swap");
         let mut url = base_url
             .join(&endpoint)
             .expect("unexpectedly invalid URL segment");
@@ -883,7 +883,7 @@ mod tests {
             })
             .await
             .unwrap();
-        println!("{:#?}", swap);
+        println!("{swap:#?}");
     }
 
     #[tokio::test]
@@ -917,7 +917,7 @@ mod tests {
             })
             .await
             .unwrap();
-        println!("{:#?}", swap);
+        println!("{swap:#?}");
     }
 
     #[tokio::test]
@@ -927,7 +927,7 @@ mod tests {
             .get_liquidity_sources()
             .await
             .unwrap();
-        println!("{:#?}", protocols);
+        println!("{protocols:#?}");
     }
 
     #[tokio::test]
@@ -938,7 +938,7 @@ mod tests {
             .get_spender()
             .await
             .unwrap();
-        println!("{:#?}", spender);
+        println!("{spender:#?}");
     }
 
     #[test]
@@ -1136,7 +1136,7 @@ mod tests {
             ))
             .await
             .unwrap();
-        println!("{:#?}", swap);
+        println!("{swap:#?}");
     }
 
     #[tokio::test]
@@ -1163,7 +1163,7 @@ mod tests {
             })
             .await
             .unwrap();
-        println!("{:#?}", swap);
+        println!("{swap:#?}");
     }
 
     #[tokio::test]

--- a/crates/shared/src/paraswap_api.rs
+++ b/crates/shared/src/paraswap_api.rs
@@ -724,7 +724,7 @@ mod tests {
             "Too much slippage on quote, please try again",
         ] {
             assert!(matches!(
-                parse(&format!("{{\"error\": \"{}\"}}", liquidity_error)),
+                parse(&format!("{{\"error\": \"{liquidity_error}\"}}")),
                 Err(ParaswapResponseError::InsufficientLiquidity(message)) if &message == liquidity_error,
             ));
         }
@@ -737,7 +737,7 @@ mod tests {
             "It seems like the rate has changed, please re-query the latest Price",
         ] {
             assert!(matches!(
-                parse(&format!("{{\"error\": \"{}\"}}", retryable_error)),
+                parse(&format!("{{\"error\": \"{retryable_error}\"}}")),
                 Err(ParaswapResponseError::Retryable(message)) if &message == retryable_error,
             ));
         }

--- a/crates/shared/src/price_estimation.rs
+++ b/crates/shared/src/price_estimation.rs
@@ -52,7 +52,7 @@ pub enum PriceEstimatorType {
 impl PriceEstimatorType {
     /// Returns the name of this price estimator type.
     pub fn name(&self) -> String {
-        format!("{:?}", self)
+        format!("{self:?}")
     }
 }
 

--- a/crates/shared/src/price_estimation/balancer_sor.rs
+++ b/crates/shared/src/price_estimation/balancer_sor.rs
@@ -116,7 +116,7 @@ mod tests {
             kind: OrderKind::Sell,
         };
         let result = single_estimate(&estimator, &query).await;
-        println!("{:?}", result);
+        println!("{result:?}");
         result.unwrap();
     }
 }

--- a/crates/shared/src/price_estimation/native_price_cache.rs
+++ b/crates/shared/src/price_estimation/native_price_cache.rs
@@ -51,7 +51,7 @@ impl Inner {
                     // will fetch the price during the next maintenance cycle.
                     // This should happen only for prices missing while building the auction.
                     // Otherwise malicious actors could easily cause the cache size to blow up.
-                    let outdated_timestamp = now - *max_age;
+                    let outdated_timestamp = now.checked_sub(*max_age).unwrap();
                     entry.insert(CachedPrice {
                         price: 0.,
                         updated_at: outdated_timestamp,

--- a/crates/shared/src/sources/balancer_v2/graph_api.rs
+++ b/crates/shared/src/sources/balancer_v2/graph_api.rs
@@ -442,7 +442,7 @@ mod tests {
     #[ignore]
     async fn balancer_subgraph_query() {
         for (network_name, chain_id) in [("Mainnet", 1), ("Goerli", 5)] {
-            println!("### {}", network_name);
+            println!("### {network_name}");
 
             let client = BalancerSubgraphClient::for_chain(chain_id, Client::new()).unwrap();
             let result = client.get_registered_pools().await.unwrap();

--- a/crates/shared/src/sources/balancer_v2/pool_fetching.rs
+++ b/crates/shared/src/sources/balancer_v2/pool_fetching.rs
@@ -507,7 +507,7 @@ mod tests {
         let web3 = Web3::new(transport);
         let chain_id = web3.eth().chain_id().await.unwrap().as_u64();
 
-        println!("Indexing events for chain {}", chain_id);
+        println!("Indexing events for chain {chain_id}");
         crate::tracing::initialize_for_tests("warn,shared=debug");
 
         let pool_initializer = EmptyPoolInitializer::for_chain(chain_id);

--- a/crates/shared/src/sources/balancer_v2/swap/fixed_point.rs
+++ b/crates/shared/src/sources/balancer_v2/swap/fixed_point.rs
@@ -71,7 +71,7 @@ impl FromStr for Bfp {
         if units.is_empty() || decimals.is_empty() || decimals.len() > 18 {
             bail!("Invalid decimal representation");
         }
-        Ok(Bfp(U256::from_dec_str(&format!("{:0<18}", decimals))?
+        Ok(Bfp(U256::from_dec_str(&format!("{decimals:0<18}"))?
             .checked_add(
                 U256::from_dec_str(units)?
                     .checked_mul(*ONE_18)

--- a/crates/shared/src/sources/swapr/reader.rs
+++ b/crates/shared/src/sources/swapr/reader.rs
@@ -130,6 +130,6 @@ mod tests {
             .next()
             .unwrap();
 
-        println!("WETH <> wxDAI pool: {:#?}", pool);
+        println!("WETH <> wxDAI pool: {pool:#?}");
     }
 }

--- a/crates/shared/src/trade_finding/oneinch.rs
+++ b/crates/shared/src/trade_finding/oneinch.rs
@@ -107,7 +107,7 @@ impl Inner {
         referrer_address: Option<H160>,
         spender_max_age: Duration,
     ) -> Self {
-        let outdated_timestamp = Instant::now() - spender_max_age;
+        let outdated_timestamp = Instant::now().checked_sub(spender_max_age).unwrap();
         let outdated_cache_entry = (H160::default(), outdated_timestamp);
 
         Self {

--- a/crates/shared/src/univ3_router_api.rs
+++ b/crates/shared/src/univ3_router_api.rs
@@ -113,6 +113,6 @@ mod tests {
             recipient: addr!("0000000000000000000000000000000000000000"),
         };
         let response = api.request(&request).await.unwrap();
-        println!("{:?}", response);
+        println!("{response:?}");
     }
 }

--- a/crates/shared/src/zeroex_api.rs
+++ b/crates/shared/src/zeroex_api.rs
@@ -36,7 +36,7 @@ const AFFILIATE_ADDRESS: &str = "0x9008D19f58AAbD9eD0D60971565AA8510560ab41";
 // the full address ad instead uses ellipsis (e.g. "0xeeee…eeee"). This
 // helper just works around that.
 fn addr2str(addr: H160) -> String {
-    format!("{:#x}", addr)
+    format!("{addr:#x}")
 }
 
 /// A 0x API quote query parameters.
@@ -523,7 +523,7 @@ impl DefaultZeroExApi {
             Ok(RawResponse::ResponseErr { reason, code }) => match code {
                 // Validation Error
                 100 => Err(ZeroExResponseError::InsufficientLiquidity),
-                500..=599 => Err(ZeroExResponseError::ServerError(format!("{:?}", url))),
+                500..=599 => Err(ZeroExResponseError::ServerError(format!("{url:?}"))),
                 _ => Err(ZeroExResponseError::UnknownZeroExError(reason)),
             },
             Err(err) => Err(ZeroExResponseError::DeserializeError(

--- a/crates/solver/src/driver.rs
+++ b/crates/solver/src/driver.rs
@@ -167,7 +167,7 @@ impl Driver {
                         .await
                     {
                         Ok(inner) => {
-                            inner.map_err(|err| SolverRunError::Solving(format!("{:?}", err)))
+                            inner.map_err(|err| SolverRunError::Solving(format!("{err:?}")))
                         }
                         Err(_timeout) => Err(SolverRunError::Timeout),
                     };

--- a/crates/solver/src/interactions/allowances.rs
+++ b/crates/solver/src/interactions/allowances.rs
@@ -396,7 +396,7 @@ mod tests {
                             addr!("2222222222222222222222222222222222222222") => {
                                 Err(web3::Error::Decoder("test error".to_string()))
                             }
-                            token => panic!("call to unexpected token {:?}", token),
+                            token => panic!("call to unexpected token {token:?}"),
                         }
                     })
                     .collect())

--- a/crates/solver/src/orderbook.rs
+++ b/crates/solver/src/orderbook.rs
@@ -23,7 +23,7 @@ impl OrderBookApi {
         let response = self.client.get(url).send().await?;
         if let Err(err) = response.error_for_status_ref() {
             let body = response.text().await;
-            return Err(anyhow::Error::new(err).context(format!("body: {:?}", body)));
+            return Err(anyhow::Error::new(err).context(format!("body: {body:?}")));
         }
         let auction = response.json().await?;
         Ok(auction)
@@ -46,7 +46,7 @@ impl OrderBookApi {
         let response = request.json(&body).send().await.context("send")?;
         if let Err(err) = response.error_for_status_ref() {
             let body = response.text().await;
-            return Err(anyhow::Error::new(err).context(format!("body: {:?}", body)));
+            return Err(anyhow::Error::new(err).context(format!("body: {body:?}")));
         }
         Ok(())
     }
@@ -66,7 +66,7 @@ pub mod test_util {
             None,
         );
         let auction = api.get_auction().await.unwrap();
-        println!("{:#?}", auction);
+        println!("{auction:#?}");
     }
 
     // cargo test real_orderbook -- --ignored --nocapture
@@ -79,6 +79,6 @@ pub mod test_util {
             None,
         );
         let auction = api.get_auction().await.unwrap();
-        println!("{:#?}", auction);
+        println!("{auction:#?}");
     }
 }

--- a/crates/solver/src/settlement.rs
+++ b/crates/solver/src/settlement.rs
@@ -398,7 +398,7 @@ impl Settlement {
                     .mul(&external_price_buy_token.mul(&clearing_price_sell_token)));
                 if !price_check_result {
                     tracing::debug!(
-                        token_pair =% format!("{:?}-{:?}", sell_token, buy_token),
+                        token_pair =% format!("{sell_token:?}-{buy_token:?}"),
                         %solver_name, settlement =? self,
                         "price violation",
                     );

--- a/crates/solver/src/settlement_simulation.rs
+++ b/crates/solver/src/settlement_simulation.rs
@@ -235,7 +235,7 @@ pub fn tenderly_link(
                     format!("0x{:x}", item.address),
                     item.storage_keys
                         .into_iter()
-                        .map(|key| format!("0x{:x}", key))
+                        .map(|key| format!("0x{key:x}"))
                         .collect_vec(),
                 )
             })
@@ -695,7 +695,7 @@ mod tests {
         let settlement_encoded = settlement
             .clone()
             .encode(InternalizationStrategy::SkipInternalizableInteraction);
-        println!("Settlement_encoded: {:?}", settlement_encoded);
+        println!("Settlement_encoded: {settlement_encoded:?}");
         let settlement = settle_method_builder(&contract, settlement_encoded, account).tx;
         println!(
             "Tenderly simulation for generated tx: {:?}",

--- a/crates/solver/src/settlement_submission/submitter.rs
+++ b/crates/solver/src/settlement_submission/submitter.rs
@@ -79,7 +79,7 @@ pub enum Strategy {
 
 impl fmt::Display for Strategy {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{:?}", self)
+        write!(f, "{self:?}")
     }
 }
 

--- a/crates/solver/src/solver/balancer_sor_solver.rs
+++ b/crates/solver/src/solver/balancer_sor_solver.rs
@@ -572,7 +572,7 @@ mod tests {
             .await
             .unwrap()
             .unwrap();
-        println!("Found settlement for sell order: {:#?}", sell_settlement);
+        println!("Found settlement for sell order: {sell_settlement:#?}");
 
         let buy_settlement = solver
             .try_settle_order(
@@ -596,6 +596,6 @@ mod tests {
             .await
             .unwrap()
             .unwrap();
-        println!("Found settlement for buy order: {:#?}", buy_settlement);
+        println!("Found settlement for buy order: {buy_settlement:#?}");
     }
 }

--- a/crates/solver/src/solver/http_solver/buffers.rs
+++ b/crates/solver/src/solver/http_solver/buffers.rs
@@ -113,7 +113,7 @@ mod test {
         let buffers = buffer_retriever
             .get_buffers(&[weth, dai, BUY_ETH_ADDRESS, not_a_token])
             .await;
-        println!("Buffers: {:#?}", buffers);
+        println!("Buffers: {buffers:#?}");
         assert!(buffers.get(&weth).unwrap().is_ok());
         assert!(buffers.get(&dai).unwrap().is_ok());
         assert!(buffers.get(&BUY_ETH_ADDRESS).unwrap().is_ok());

--- a/crates/solver/src/solver/http_solver/instance_creation.rs
+++ b/crates/solver/src/solver/http_solver/instance_creation.rs
@@ -324,7 +324,7 @@ fn amm_models(liquidity: &[Liquidity], gas_model: &GasModel) -> BTreeMap<H160, A
                             })
                             .collect::<Result<_>>()
                             .with_context(|| {
-                                format!("error converting stable pool to solver model: {:?}", amm)
+                                format!("error converting stable pool to solver model: {amm:?}")
                             })?,
                         amplification_parameter: amm.amplification_parameter.as_big_rational(),
                     }),

--- a/crates/solver/src/solver/oneinch_solver.rs
+++ b/crates/solver/src/solver/oneinch_solver.rs
@@ -516,6 +516,6 @@ mod tests {
             .unwrap()
             .unwrap();
 
-        println!("{:#?}", settlement);
+        println!("{settlement:#?}");
     }
 }

--- a/crates/solver/src/solver/paraswap_solver.rs
+++ b/crates/solver/src/solver/paraswap_solver.rs
@@ -571,6 +571,6 @@ mod tests {
             .unwrap()
             .unwrap();
 
-        println!("{:#?}", settlement);
+        println!("{settlement:#?}");
     }
 }

--- a/crates/solver/src/solver/single_order_solver.rs
+++ b/crates/solver/src/solver/single_order_solver.rs
@@ -171,8 +171,15 @@ impl Solver for SingleOrderSolver {
         };
 
         // Subtract a small amount of time to ensure that the driver doesn't reach the deadline first.
-        let _ = tokio::time::timeout_at((auction.deadline - Duration::from_secs(1)).into(), settle)
-            .await;
+        let _ = tokio::time::timeout_at(
+            auction
+                .deadline
+                .checked_sub(Duration::from_secs(1))
+                .unwrap()
+                .into(),
+            settle,
+        )
+        .await;
 
         // Keep at most this many settlements. This is important in case where a solver produces
         // a large number of settlements which would hold up the driver logic when simulating

--- a/crates/solver/src/solver/zeroex_solver.rs
+++ b/crates/solver/src/solver/zeroex_solver.rs
@@ -254,7 +254,7 @@ mod tests {
             .await
             .unwrap();
 
-        println!("{:#?}", settlement);
+        println!("{settlement:#?}");
     }
 
     #[tokio::test]
@@ -296,7 +296,7 @@ mod tests {
             .await
             .unwrap();
 
-        println!("{:#?}", settlement);
+        println!("{settlement:#?}");
     }
 
     #[tokio::test]

--- a/crates/solvers/src/tests/mod.rs
+++ b/crates/solvers/src/tests/mod.rs
@@ -28,7 +28,7 @@ impl SolverEngine {
         let handle = tokio::spawn(async move { crate::run(arguments, command, Some(bind)).await });
 
         let addr = bind_receiver.await.unwrap();
-        let url = format!("http://{}/", addr).parse().unwrap();
+        let url = format!("http://{addr}/").parse().unwrap();
 
         Self { url, handle }
     }


### PR DESCRIPTION
This release introduced a new clippy warnings. The most common one is about not inlining variables into format strings.

### Test Plan

CI