### PR TITLE
Fix unused `:` in format strings

### DIFF
--- a/crates/autopilot/src/database/onchain_order_events.rs
+++ b/crates/autopilot/src/database/onchain_order_events.rs
@@ -487,9 +487,8 @@ async fn parse_general_onchain_order_placement_data<'a>(
                 Err(err) => {
                     let err_label = err.to_metrics_label();
                     tracing::debug!(
-                        "Could not retrieve a quote for order {:?}: {}",
+                        "Could not retrieve a quote for order {:?}: {err_label}",
                         order_data.1.uid,
-                        err_label
                     );
                     metrics.inc_onchain_order_errors(err_label);
                     None
@@ -509,7 +508,7 @@ async fn parse_general_onchain_order_placement_data<'a>(
         .into_iter()
         .filter_map(|data| match data {
             Err(err) => {
-                tracing::debug!("Error while parsing onchain orders: {:}", err);
+                tracing::debug!("Error while parsing onchain orders: {err:?}");
                 None
             }
             Ok(data) => Some(data),

--- a/crates/orderbook/src/api/cancel_order.rs
+++ b/crates/orderbook/src/api/cancel_order.rs
@@ -116,7 +116,7 @@ mod tests {
         let cancellation = OrderCancellation::default();
 
         let request = request()
-            .path(&format!("/v1/orders/{:}", cancellation.order_uid))
+            .path(&format!("/v1/orders/{}", cancellation.order_uid))
             .method("DELETE")
             .header("content-type", "application/json")
             .json(&CancellationPayload {

--- a/crates/orderbook/src/api/get_order_by_uid.rs
+++ b/crates/orderbook/src/api/get_order_by_uid.rs
@@ -46,7 +46,7 @@ mod tests {
     #[tokio::test]
     async fn get_order_by_uid_request_ok() {
         let uid = OrderUid::default();
-        let request = request().path(&format!("/v1/orders/{uid:}")).method("GET");
+        let request = request().path(&format!("/v1/orders/{uid}")).method("GET");
         let filter = get_order_by_uid_request();
         let result = request.filter(&filter).await.unwrap();
         assert_eq!(result, uid);

--- a/crates/orderbook/src/api/get_orders_by_tx.rs
+++ b/crates/orderbook/src/api/get_orders_by_tx.rs
@@ -37,7 +37,7 @@ mod tests {
     async fn request_ok() {
         let hash_str = "0x0191dbb560e936bd3320d5a505c9c05580a0ebb7e12fe117551ac26e484f295e";
         let result = warp::test::request()
-            .path(&format!("/v1/transactions/{hash_str:}/orders"))
+            .path(&format!("/v1/transactions/{hash_str}/orders"))
             .method("GET")
             .filter(&get_orders_by_tx_request())
             .await

--- a/crates/orderbook/src/api/get_trades.rs
+++ b/crates/orderbook/src/api/get_trades.rs
@@ -95,7 +95,7 @@ mod tests {
         assert_eq!(result.order_uid, None);
 
         let uid = OrderUid([1u8; 56]);
-        let order_uid_path = format!("/v1/trades?orderUid={uid:}");
+        let order_uid_path = format!("/v1/trades?orderUid={uid}");
         let result = trade_filter(request().path(order_uid_path.as_str()))
             .await
             .unwrap()
@@ -113,7 +113,7 @@ mod tests {
 
         let owner = H160::from_slice(&hex!("0000000000000000000000000000000000000001"));
         let uid = OrderUid([1u8; 56]);
-        let path = format!("/v1/trades?owner=0x{owner:x}&orderUid={uid:}");
+        let path = format!("/v1/trades?owner=0x{owner:x}&orderUid={uid}");
 
         let result = trade_filter(request().path(path.as_str())).await.unwrap();
         assert!(result.is_err());

--- a/crates/refunder/src/submitter.rs
+++ b/crates/refunder/src/submitter.rs
@@ -55,7 +55,7 @@ impl Submitter {
             .eth()
             .transaction_count(self.account.address(), None)
             .await
-            .map_err(|err| anyhow!("Could not get latest nonce due to err: {:}", err))
+            .map_err(|err| anyhow!("Could not get latest nonce due to err: {err}"))
     }
 
     pub async fn submit(

--- a/crates/solver/src/solver/http_solver.rs
+++ b/crates/solver/src/solver/http_solver.rs
@@ -188,7 +188,7 @@ impl HttpSolver {
         settled.add_missing_execution_plans();
 
         tracing::debug!(
-            "Solution received from http solver {} (json):\n{:}",
+            "Solution received from http solver {} (json):\n{}",
             self.solver.name,
             serde_json::to_string_pretty(&settled).unwrap()
         );


### PR DESCRIPTION
Martin noticed in https://github.com/cowprotocol/services/pull/1144 that we sometimes include `:` in format strings even though this doesn't have any effect.

I also inlined some more cases that clippy doesn't catch because they appear in macros that aren't std's `format!`.

### Test Plan

CI
