### PR TITLE
Record Metrics for S3 Uploads

### DIFF
--- a/crates/solver/src/solver/http_solver/instance_cache.rs
+++ b/crates/solver/src/solver/http_solver/instance_cache.rs
@@ -79,7 +79,7 @@ impl SharedInstanceCreator {
                 let label = match uploader.upload_instance(id, &auction).await {
                     Ok(()) => "success",
                     Err(err) => {
-                        tracing::error!(%id, ?err, "error uploading instance");
+                        tracing::warn!(%id, ?err, "error uploading instance");
                         "failure"
                     }
                 };

--- a/crates/solver/src/solver/http_solver/instance_cache.rs
+++ b/crates/solver/src/solver/http_solver/instance_cache.rs
@@ -1,6 +1,8 @@
 use super::instance_creation::{InstanceCreator, Instances};
 use crate::{s3_instance_upload::S3InstanceUploader, solver::Auction};
 use model::auction::AuctionId;
+use once_cell::sync::OnceCell;
+use prometheus::IntCounterVec;
 use std::sync::Arc;
 use tokio::sync::Mutex;
 use tracing::{Instrument, Span};
@@ -73,12 +75,44 @@ impl SharedInstanceCreator {
                     }
                 };
                 std::mem::drop(instances);
-                if let Err(err) = uploader.upload_instance(id, &auction).await {
-                    tracing::error!(%id, ?err, "error uploading instance");
-                }
+
+                let label = match uploader.upload_instance(id, &auction).await {
+                    Ok(()) => "success",
+                    Err(err) => {
+                        tracing::error!(%id, ?err, "error uploading instance");
+                        "failure"
+                    }
+                };
+                Metrics::get()
+                    .instance_cache_uploads
+                    .with_label_values(&[label])
+                    .inc();
             };
             tokio::task::spawn(task.instrument(Span::current()));
         }
+    }
+}
+
+#[derive(prometheus_metric_storage::MetricStorage)]
+pub struct Metrics {
+    /// Auction filtered orders grouped by class.
+    #[metric(labels("result"))]
+    instance_cache_uploads: IntCounterVec,
+}
+
+impl Metrics {
+    fn get() -> &'static Self {
+        static INIT: OnceCell<&'static Metrics> = OnceCell::new();
+        INIT.get_or_init(|| {
+            let metrics = Metrics::instance(global_metrics::get_metric_storage_registry()).unwrap();
+            for result in ["success", "failure"] {
+                metrics
+                    .instance_cache_uploads
+                    .with_label_values(&[result])
+                    .reset();
+            }
+            metrics
+        })
     }
 }
 


### PR DESCRIPTION
This PR changes the instance cache to record metrics instead of issuing error alerts when uploading to S3 fails. This is because uploading can intermittently fail, and these instance are used for debugging anyway, so temporary failures to upload is not a big issue. With metrics, we can setup an alert if it starts failing for, say, 10 minutes straight which means that there is probably something more seriously wrong that requires some attention.

### Test Plan

CI
