### PR TITLE
Improve Metrics fo Auction Building

### DIFF
--- a/crates/autopilot/src/solvable_orders.rs
+++ b/crates/autopilot/src/solvable_orders.rs
@@ -495,9 +495,7 @@ fn get_orders_with_native_prices(
                 true
             }
             _ => {
-                if order.metadata.class == OrderClass::Market {
-                    filtered_market_orders += 1;
-                }
+                filtered_market_orders += i64::from(order.metadata.class == OrderClass::Market);
                 false
             }
         }


### PR DESCRIPTION
This PR adds a new gauge for the number of **market** orders that are filtered out because of missing prices. This is because filtering out market orders for this reason is more serious than limit orders. This new metric will allow us to monitor this separately and potentially create alerts to deal with missing market order native token prices.

I also changed the `checkpoint` to log the order's class to make debugging filtered orders in the log easier.

### Test Plan

Rust compiler
