### PR TITLE
Do not update native prices in background in Orderbook

### DIFF
--- a/crates/autopilot/src/lib.rs
+++ b/crates/autopilot/src/lib.rs
@@ -365,6 +365,7 @@ pub async fn main(args: arguments::Arguments) -> ! {
         .native_price_estimator(
             &args.native_price_estimators,
             &args.order_quoting.price_estimation_drivers,
+            true,
         )
         .unwrap();
 

--- a/crates/autopilot/src/solvable_orders.rs
+++ b/crates/autopilot/src/solvable_orders.rs
@@ -821,11 +821,8 @@ mod tests {
         let native_price_estimator = CachingNativePriceEstimator::new(
             Box::new(native_price_estimator),
             Duration::from_secs(10),
-            Duration::MAX,
-            None,
-            Default::default(),
-            1,
         );
+        native_price_estimator.spawn_update_task(Duration::MAX, None, Default::default(), 1);
 
         // We'll have no native prices in this call. But this call will cause a background task
         // to fetch the missing prices so we'll have them in the next call.

--- a/crates/e2e/tests/e2e/services.rs
+++ b/crates/e2e/tests/e2e/services.rs
@@ -144,11 +144,8 @@ impl OrderbookServices {
         let native_price_estimator = Arc::new(CachingNativePriceEstimator::new(
             native_price_estimator,
             Duration::from_secs(10),
-            Duration::from_secs(10),
-            None,
-            Duration::from_secs(2),
-            1,
         ));
+
         let quoter = Arc::new(OrderQuoter::new(
             price_estimator.clone(),
             native_price_estimator.clone(),

--- a/crates/orderbook/src/main.rs
+++ b/crates/orderbook/src/main.rs
@@ -335,6 +335,7 @@ async fn main() -> ! {
         .native_price_estimator(
             &args.native_price_estimators,
             &args.order_quoting.price_estimation_drivers,
+            false,
         )
         .unwrap();
 

--- a/crates/shared/src/price_estimation/factory.rs
+++ b/crates/shared/src/price_estimation/factory.rs
@@ -321,6 +321,7 @@ impl<'a> PriceEstimatorFactory<'a> {
         &mut self,
         kinds: &[PriceEstimatorType],
         drivers: &[Driver],
+        spawn_update_task: bool,
     ) -> Result<Arc<CachingNativePriceEstimator>> {
         anyhow::ensure!(
             self.args.native_price_cache_max_age_secs > self.args.native_price_prefetch_time_secs,
@@ -335,11 +336,15 @@ impl<'a> PriceEstimatorFactory<'a> {
                 self.native_token_price_estimation_amount()?,
             )),
             self.args.native_price_cache_max_age_secs,
-            self.args.native_price_cache_refresh_secs,
-            Some(self.args.native_price_cache_max_update_size),
-            self.args.native_price_prefetch_time_secs,
-            self.args.native_price_cache_concurrent_requests,
         ));
+        if spawn_update_task {
+            native_estimator.spawn_update_task(
+                self.args.native_price_cache_refresh_secs,
+                Some(self.args.native_price_cache_max_update_size),
+                self.args.native_price_prefetch_time_secs,
+                self.args.native_price_cache_concurrent_requests,
+            );
+        }
         Ok(native_estimator)
     }
 }


### PR DESCRIPTION
The auto updating behavior makes sense for Autopilot, but not in Orderbook. This removes some load from our price estimators, especially because this cache never expires its entries (TODO future PR).

### Test Plan

CI
