### PR TITLE
Prioritize updates of market order native token prices

### DIFF
--- a/crates/autopilot/src/solvable_orders.rs
+++ b/crates/autopilot/src/solvable_orders.rs
@@ -482,6 +482,16 @@ fn get_orders_with_native_prices(
         .flat_map(|(token, price)| to_normalized_price(price).map(|price| (token, price)))
         .collect();
 
+    let high_priority_tokens = orders
+        .iter()
+        .filter_map(|order| match order.metadata.class {
+            OrderClass::Market => Some([order.data.sell_token, order.data.buy_token]),
+            OrderClass::Liquidity => None,
+            OrderClass::Limit(_) => None,
+        })
+        .flatten();
+    native_price_estimator.replace_high_priority(high_priority_tokens.collect());
+
     // Filter both orders and prices so that we only return orders that have prices and prices that
     // have orders.
     let mut filtered_market_orders = 0_i64;

--- a/crates/contracts/src/bin/vendor.rs
+++ b/crates/contracts/src/bin/vendor.rs
@@ -248,7 +248,7 @@ impl VendorContext<'_> {
     fn github(&self, name: &str, path: &str) -> Result<&Self> {
         self.vendor_source(
             name,
-            Source::http(&format!("https://raw.githubusercontent.com/{}", path))?,
+            Source::http(&format!("https://raw.githubusercontent.com/{path}"))?,
         )
     }
 


### PR DESCRIPTION
The native price cache cannot keep up with the amount of tokens it has to process in production. This can lead to market orders not settling because the orders are not considered solvable because of missing native prices.

This PR prioritizes the updates of market order tokens over other tokens. This functionality is only used by the autopilot's solvable order module.

### Test Plan

new unit test for the harder to understand part of the change