### PR TITLE
Remove Unnecessary `#[metrics()]` Attibutes

### DIFF
--- a/crates/autopilot/src/solvable_orders.rs
+++ b/crates/autopilot/src/solvable_orders.rs
@@ -47,7 +47,6 @@ pub struct Metrics {
     auction_filtered_orders: IntGaugeVec,
 
     /// Auction filtered market orders due to missing native token price.
-    #[metric()]
     auction_market_order_missing_price: IntGauge,
 }
 

--- a/crates/shared/src/maintenance.rs
+++ b/crates/shared/src/maintenance.rs
@@ -133,11 +133,9 @@ impl ServiceMaintenance {
 #[metric(subsystem = "maintenance")]
 struct Metrics {
     /// Service maintenance last seen block.
-    #[metric()]
     last_seen_block: prometheus::IntGauge,
 
     /// Service maintenance last successfully updated block.
-    #[metric()]
     last_updated_block: prometheus::IntGauge,
 
     /// Service maintenance error counter


### PR DESCRIPTION
@MartinquaXD rightfully pointed out that the `#[metrics()]` attributes were unnecessary for metrics that don't have labels (or other configuration options).

This PR fixes that (and fixes it in other places as well).

### Test Plan

One of the changed metrics are still there:
```
% curl -s 'http://localhost:9587/metrics' | rg last_updated_block
# HELP gp_v2_solver_maintenance_last_updated_block Service maintenance last successfully updated block.
# TYPE gp_v2_solver_maintenance_last_updated_block gauge
gp_v2_solver_maintenance_last_updated_block 8409425
```
