### PR TITLE
Allow specifying custom univ2 like liquidity in command line arguments

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3487,6 +3487,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with 2.0.1",
+ "strum",
  "testlib",
  "thiserror",
  "time 0.3.14",

--- a/crates/shared/Cargo.toml
+++ b/crates/shared/Cargo.toml
@@ -43,6 +43,7 @@ secp256k1 = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 serde_with = { workspace = true }
+strum = { workspace = true }
 thiserror = { workspace = true }
 time = { version = "0.3", features = ["macros"] }
 tokio = { workspace = true, features = ["macros", "time"] }

--- a/crates/shared/src/arguments.rs
+++ b/crates/shared/src/arguments.rs
@@ -9,7 +9,11 @@ use {
         gas_price_estimation::GasEstimatorType,
         price_estimation::PriceEstimatorType,
         rate_limiter::RateLimitingStrategy,
-        sources::{balancer_v2::BalancerFactoryKind, BaselineSource},
+        sources::{
+            balancer_v2::BalancerFactoryKind,
+            uniswap_v2::UniV2BaselineSourceParameters,
+            BaselineSource,
+        },
         tenderly_api,
     },
     anyhow::{anyhow, ensure, Context, Result},
@@ -200,6 +204,10 @@ pub struct Arguments {
     /// Which Liquidity sources to be used by Price Estimator.
     #[clap(long, env, value_enum, ignore_case = true, use_value_delimiter = true)]
     pub baseline_sources: Option<Vec<BaselineSource>>,
+
+    /// List of non hardcoded univ2-like contracts.
+    #[clap(long, env, value_enum, ignore_case = true, use_value_delimiter = true)]
+    pub custom_univ2_baseline_sources: Vec<UniV2BaselineSourceParameters>,
 
     /// The number of blocks kept in the pool cache.
     #[clap(long, env, default_value = "10")]
@@ -441,6 +449,11 @@ impl Display for Arguments {
             self.balancer_pool_deny_list
         )?;
         display_secret_option(f, "solver_competition_auth", &self.solver_competition_auth)?;
+        display_list(
+            f,
+            "custom_univ2_baseline_sources",
+            &self.custom_univ2_baseline_sources,
+        )?;
 
         Ok(())
     }

--- a/crates/shared/src/bad_token/trace_call.rs
+++ b/crates/shared/src/bad_token/trace_call.rs
@@ -413,6 +413,7 @@ mod tests {
         // shared::transport=debug", tracing::level_filters::LevelFilter::OFF);
         let http = create_env_test_transport();
         let web3 = Web3::new(http);
+        let version = web3.net().version().await.unwrap();
 
         let base_tokens = &[
             testlib::tokens::WETH,
@@ -590,25 +591,27 @@ mod tests {
             web3: web3.clone(),
             proposers: vec![
                 Arc::new(UniswapLikePairProviderFinder {
-                    inner: uniswap_v2::uniswap_like_liquidity_source(
+                    inner: uniswap_v2::UniV2BaselineSourceParameters::from_baseline_source(
                         BaselineSource::UniswapV2,
-                        &web3,
+                        &version,
                     )
+                    .unwrap()
+                    .into_source(&web3)
                     .await
                     .unwrap()
-                    .unwrap()
-                    .0,
+                    .pair_provider,
                     base_tokens: base_tokens.to_vec(),
                 }),
                 Arc::new(UniswapLikePairProviderFinder {
-                    inner: uniswap_v2::uniswap_like_liquidity_source(
+                    inner: uniswap_v2::UniV2BaselineSourceParameters::from_baseline_source(
                         BaselineSource::SushiSwap,
-                        &web3,
+                        &version,
                     )
+                    .unwrap()
+                    .into_source(&web3)
                     .await
                     .unwrap()
-                    .unwrap()
-                    .0,
+                    .pair_provider,
                     base_tokens: base_tokens.to_vec(),
                 }),
                 Arc::new(BalancerVaultFinder(

--- a/crates/shared/src/price_estimation/http.rs
+++ b/crates/shared/src/price_estimation/http.rs
@@ -712,15 +712,20 @@ mod tests {
         );
         let web3 = Web3::new(DynTransport::new(transport));
         let chain_id = web3.eth().chain_id().await.unwrap().as_u64();
+        let version = web3.net().version().await.unwrap();
 
         let pools = Arc::new(
             PoolCache::new(
                 CacheConfig::default(),
-                uniswap_v2::uniswap_like_liquidity_source(BaselineSource::UniswapV2, &web3)
-                    .await
-                    .unwrap()
-                    .unwrap()
-                    .1,
+                uniswap_v2::UniV2BaselineSourceParameters::from_baseline_source(
+                    BaselineSource::UniswapV2,
+                    &version,
+                )
+                .unwrap()
+                .into_source(&web3)
+                .await
+                .unwrap()
+                .pool_fetching,
                 current_block_stream(Arc::new(web3.clone()), Duration::from_secs(1))
                     .await
                     .unwrap(),

--- a/crates/shared/src/sources.rs
+++ b/crates/shared/src/sources.rs
@@ -7,22 +7,17 @@ pub mod uniswap_v3;
 pub mod uniswap_v3_pair_provider;
 
 use {
-    self::uniswap_v2::{
-        pair_provider::PairProvider,
-        pool_fetching::{Pool, PoolFetching},
-    },
-    crate::{ethrpc::Web3, recent_block_cache::Block},
+    self::uniswap_v2::pool_fetching::{Pool, PoolFetching},
+    crate::recent_block_cache::Block,
     anyhow::{bail, Result},
     model::TokenPair,
-    std::{
-        collections::{HashMap, HashSet},
-        sync::Arc,
-    },
+    std::{collections::HashSet, sync::Arc},
 };
 
 #[derive(Debug, Clone, Copy, Eq, Hash, PartialEq, clap::ValueEnum)]
 #[clap(rename_all = "verbatim")]
 pub enum BaselineSource {
+    None,
     UniswapV2,
     Honeyswap,
     SushiSwap,
@@ -61,21 +56,6 @@ pub fn defaults_for_chain(chain_id: u64) -> Result<Vec<BaselineSource>> {
         ],
         _ => bail!("unsupported chain {:#x}", chain_id),
     })
-}
-
-/// Returns a mapping of UniswapV2-like baseline sources to their respective
-/// pair providers and pool fetchers.
-pub async fn uniswap_like_liquidity_sources(
-    web3: &Web3,
-    sources: &[BaselineSource],
-) -> Result<HashMap<BaselineSource, (PairProvider, Arc<dyn PoolFetching>)>> {
-    let mut liquidity_sources = HashMap::new();
-    for source in sources {
-        if let Some(inner) = uniswap_v2::uniswap_like_liquidity_source(*source, web3).await? {
-            liquidity_sources.insert(*source, inner);
-        }
-    }
-    Ok(liquidity_sources)
 }
 
 pub struct PoolAggregator {

--- a/crates/shared/src/sources/swapr/reader.rs
+++ b/crates/shared/src/sources/swapr/reader.rs
@@ -108,12 +108,16 @@ mod tests {
     async fn fetch_swapr_pool() {
         let transport = create_env_test_transport();
         let web3 = Web3::new(transport);
-
-        let (_, pool_fetcher) =
-            uniswap_v2::uniswap_like_liquidity_source(BaselineSource::Swapr, &web3)
-                .await
-                .unwrap()
-                .unwrap();
+        let version = web3.net().version().await.unwrap();
+        let pool_fetcher = uniswap_v2::UniV2BaselineSourceParameters::from_baseline_source(
+            BaselineSource::Swapr,
+            &version,
+        )
+        .unwrap()
+        .into_source(&web3)
+        .await
+        .unwrap()
+        .pool_fetching;
         let pool = pool_fetcher
             .fetch(
                 hashset! {

--- a/crates/shared/src/sources/uniswap_v2.rs
+++ b/crates/shared/src/sources/uniswap_v2.rs
@@ -1,4 +1,5 @@
 //! Uniswap V2 baseline liquidity source implementation.
+
 pub mod pair_provider;
 pub mod pool_cache;
 pub mod pool_fetching;
@@ -13,9 +14,10 @@ use {
         sources::{swapr::reader::SwaprPoolReader, BaselineSource},
     },
     anyhow::{Context, Result},
+    contracts::IUniswapLikeRouter,
     ethcontract::{H160, H256},
     hex_literal::hex,
-    std::sync::Arc,
+    std::{fmt::Display, str::FromStr, sync::Arc},
 };
 
 pub const UNISWAP_INIT: [u8; 32] =
@@ -29,74 +31,152 @@ pub const BAOSWAP_INIT: [u8; 32] =
 pub const SWAPR_INIT: [u8; 32] =
     hex!("d306a548755b9295ee49cc729e13ca4a45e00199bbd890fa146da43a50571776");
 
-/// If the baseline source is uniswapv2-like, returns the address of the router
-/// contract and the init code digest needed for calculating pair addresses.
-pub fn from_baseline_source(source: BaselineSource, net_version: &str) -> Option<(H160, H256)> {
-    let (contract, init_code_digest) = match source {
-        BaselineSource::BalancerV2 => None,
-        BaselineSource::ZeroEx => None,
-        BaselineSource::UniswapV3 => None,
-        BaselineSource::UniswapV2 => {
-            Some((contracts::UniswapV2Router02::raw_contract(), UNISWAP_INIT))
-        }
-        BaselineSource::Honeyswap => {
-            Some((contracts::HoneyswapRouter::raw_contract(), HONEYSWAP_INIT))
-        }
-        BaselineSource::SushiSwap => {
-            Some((contracts::SushiSwapRouter::raw_contract(), SUSHISWAP_INIT))
-        }
-        BaselineSource::Baoswap => Some((contracts::BaoswapRouter::raw_contract(), BAOSWAP_INIT)),
-        BaselineSource::Swapr => Some((contracts::SwaprRouter::raw_contract(), SWAPR_INIT)),
-    }?;
-    let address = contract.networks.get(net_version)?.address;
-    Some((address, H256(init_code_digest)))
+#[derive(Debug, Clone, Copy)]
+pub struct UniV2BaselineSourceParameters {
+    router: H160,
+    init_code_digest: H256,
+    pool_reading: PoolReadingStyle,
 }
 
-/// If the baseline source is uniswapv2-like, returns the corresponding
-/// PoolReading implementation.
-pub fn pool_reader(
-    source: BaselineSource,
-    pair_provider: PairProvider,
-    web3: &Web3,
-) -> Option<Box<dyn PoolReading>> {
-    let default_reader = DefaultPoolReader {
-        pair_provider,
-        web3: web3.clone(),
-    };
-    match source {
-        BaselineSource::BalancerV2 => None,
-        BaselineSource::ZeroEx => None,
-        BaselineSource::UniswapV3 => None,
-        BaselineSource::UniswapV2 => Some(Box::new(default_reader)),
-        BaselineSource::Honeyswap => Some(Box::new(default_reader)),
-        BaselineSource::SushiSwap => Some(Box::new(default_reader)),
-        BaselineSource::Baoswap => Some(Box::new(default_reader)),
-        BaselineSource::Swapr => Some(Box::new(SwaprPoolReader(default_reader))),
+#[derive(Clone, Copy, Debug, strum::EnumString, strum::Display)]
+enum PoolReadingStyle {
+    Default,
+    Swapr,
+}
+
+pub struct UniV2BaselineSource {
+    pub router: IUniswapLikeRouter,
+    pub pair_provider: PairProvider,
+    pub pool_fetching: Arc<dyn PoolFetching>,
+}
+
+impl UniV2BaselineSourceParameters {
+    pub fn from_baseline_source(source: BaselineSource, net_version: &str) -> Option<Self> {
+        use BaselineSource as BS;
+        let (contract, init_code_digest, pool_reading) = match source {
+            BS::None | BS::BalancerV2 | BS::ZeroEx | BS::UniswapV3 => None,
+            BS::UniswapV2 => Some((
+                contracts::UniswapV2Router02::raw_contract(),
+                UNISWAP_INIT,
+                PoolReadingStyle::Default,
+            )),
+            BS::Honeyswap => Some((
+                contracts::HoneyswapRouter::raw_contract(),
+                HONEYSWAP_INIT,
+                PoolReadingStyle::Default,
+            )),
+            BS::SushiSwap => Some((
+                contracts::SushiSwapRouter::raw_contract(),
+                SUSHISWAP_INIT,
+                PoolReadingStyle::Default,
+            )),
+            BS::Baoswap => Some((
+                contracts::BaoswapRouter::raw_contract(),
+                BAOSWAP_INIT,
+                PoolReadingStyle::Default,
+            )),
+            BS::Swapr => Some((
+                contracts::SwaprRouter::raw_contract(),
+                SWAPR_INIT,
+                PoolReadingStyle::Swapr,
+            )),
+        }?;
+        Some(Self {
+            router: contract.networks.get(net_version)?.address,
+            init_code_digest: H256(init_code_digest),
+            pool_reading,
+        })
+    }
+
+    pub async fn into_source(&self, web3: &Web3) -> Result<UniV2BaselineSource> {
+        let router = contracts::IUniswapLikeRouter::at(web3, self.router);
+        let factory = router.factory().call().await.context("factory")?;
+        let pair_provider = pair_provider::PairProvider {
+            factory,
+            init_code_digest: self.init_code_digest.0,
+        };
+        let pool_reader = DefaultPoolReader {
+            pair_provider,
+            web3: web3.clone(),
+        };
+        let pool_reader: Box<dyn PoolReading> = match self.pool_reading {
+            PoolReadingStyle::Default => Box::new(pool_reader),
+            PoolReadingStyle::Swapr => Box::new(SwaprPoolReader(pool_reader)),
+        };
+        let fetcher = pool_fetching::PoolFetcher {
+            pool_reader,
+            web3: web3.clone(),
+        };
+        Ok(UniV2BaselineSource {
+            router,
+            pair_provider,
+            pool_fetching: Arc::new(fetcher),
+        })
     }
 }
 
-pub async fn uniswap_like_liquidity_source(
-    source: BaselineSource,
-    web3: &Web3,
-) -> Result<Option<(PairProvider, Arc<dyn PoolFetching>)>> {
-    let net_version = web3.net().version().await.context("net_version")?;
-    let (router, init_code_digest) = match from_baseline_source(source, &net_version) {
-        Some(inner) => inner,
-        None => return Ok(None),
-    };
-    let router = contracts::IUniswapLikeRouter::at(web3, router);
-    let factory = router.factory().call().await.context("factory")?;
-    let provider = pair_provider::PairProvider {
-        factory,
-        init_code_digest: init_code_digest.0,
-    };
-    let pool_reader = match pool_reader(source, provider, web3) {
-        Some(inner) => inner,
-        None => return Ok(None),
-    };
-    let fetcher = pool_fetching::PoolFetcher {
-        pool_reader,
-        web3: web3.clone(),
-    };
-    Ok(Some((provider, Arc::new(fetcher))))
+impl Display for UniV2BaselineSourceParameters {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{:?}|{:?}|{}",
+            self.router.0, self.init_code_digest, self.pool_reading
+        )
+    }
+}
+
+impl FromStr for UniV2BaselineSourceParameters {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let mut parts = s.split('|');
+        let router: H160 = parts
+            .next()
+            .context("no factory address")?
+            .parse()
+            .context("parse factory address")?;
+        let init_code_digest: H256 = parts
+            .next()
+            .context("no init code digest")?
+            .parse()
+            .context("parse init code digest")?;
+        let pool_reading = parts
+            .next()
+            .map(|part| part.parse().context("parse pool reading"))
+            .transpose()?
+            .unwrap_or(PoolReadingStyle::Default);
+        Ok(Self {
+            router,
+            init_code_digest,
+            pool_reading,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_address_init() {
+        let arg = "0x0000000000000000000000000000000000000001|0x0000000000000000000000000000000000000000000000000000000000000002";
+        let parsed = UniV2BaselineSourceParameters::from_str(arg).unwrap();
+        assert_eq!(parsed.router, H160::from_low_u64_be(1));
+        assert_eq!(parsed.init_code_digest, H256::from_low_u64_be(2));
+    }
+
+    #[test]
+    fn parse_pool_reading() {
+        let arg = "0x0000000000000000000000000000000000000000|0x0000000000000000000000000000000000000000000000000000000000000000";
+        let parsed = UniV2BaselineSourceParameters::from_str(arg).unwrap();
+        assert!(matches!(parsed.pool_reading, PoolReadingStyle::Default));
+
+        let arg = "0x0000000000000000000000000000000000000000|0x0000000000000000000000000000000000000000000000000000000000000000|Default";
+        let parsed = UniV2BaselineSourceParameters::from_str(arg).unwrap();
+        assert!(matches!(parsed.pool_reading, PoolReadingStyle::Default));
+
+        let arg = "0x0000000000000000000000000000000000000000|0x0000000000000000000000000000000000000000000000000000000000000000|Swapr";
+        let parsed = UniV2BaselineSourceParameters::from_str(arg).unwrap();
+        assert!(matches!(parsed.pool_reading, PoolReadingStyle::Swapr));
+    }
 }


### PR DESCRIPTION
Allows us to configure custom univ2 instances. This is useful in e2e tests. A custom univ2 instance is the address of a router contract along with the init_hash for calculating pool addresses.

As a follow up it could allow us to get rid of all of the univ2 fork hardcodes that we currently have in the code. We would remove them as baseline sources and move them into the new argument in our cluster configuration.

### Test Plan

manually test and observe after merging
