### PR TITLE
Use non zero gas price in e2e tests

### DIFF
--- a/crates/e2e/tests/e2e/eth_integration.rs
+++ b/crates/e2e/tests/e2e/eth_integration.rs
@@ -10,7 +10,10 @@ use {
         },
         tx,
     },
-    ethcontract::prelude::{Account, Address, PrivateKey, U256},
+    ethcontract::{
+        prelude::{Account, Address, PrivateKey, U256},
+        transaction::TransactionBuilder,
+    },
     model::{
         order::{OrderBuilder, OrderKind, BUY_ETH_ADDRESS},
         signature::EcdsaSigningScheme,
@@ -44,6 +47,15 @@ async fn eth_integration(web3: Web3) {
     let trader_buy_eth_b =
         Account::Offline(PrivateKey::from_raw(TRADER_BUY_ETH_B_PK).unwrap(), None);
 
+    for trader in [&trader_buy_eth_a, &trader_buy_eth_b] {
+        TransactionBuilder::new(web3.clone())
+            .value(to_wei(1))
+            .to(trader.address())
+            .send()
+            .await
+            .unwrap();
+    }
+
     // Create & mint tokens to trade, pools for fee connections
     let token = deploy_token_with_weth_uniswap_pool(
         &web3,
@@ -68,6 +80,17 @@ async fn eth_integration(web3: Web3) {
         trader_buy_eth_b,
         token.approve(contracts.allowance, to_wei(51))
     );
+
+    let trader_a_eth_balance_before = web3
+        .eth()
+        .balance(trader_buy_eth_a.address(), None)
+        .await
+        .unwrap();
+    let trader_b_eth_balance_before = web3
+        .eth()
+        .balance(trader_buy_eth_b.address(), None)
+        .await
+        .unwrap();
 
     let OrderbookServices {
         maintenance,
@@ -168,18 +191,23 @@ async fn eth_integration(web3: Web3) {
     driver.single_run().await.unwrap();
 
     // Check matching
-    let web3_ref = &web3;
-    let eth_balance = |trader: Account| async move {
-        web3_ref
-            .eth()
-            .balance(trader.address(), None)
-            .await
-            .expect("Couldn't fetch ETH balance")
-    };
-    assert_eq!(eth_balance(trader_buy_eth_a).await, to_wei(49));
+    let trader_a_eth_balance_after = web3
+        .eth()
+        .balance(trader_buy_eth_a.address(), None)
+        .await
+        .unwrap();
+    let trader_b_eth_balance_after = web3
+        .eth()
+        .balance(trader_buy_eth_b.address(), None)
+        .await
+        .unwrap();
     assert_eq!(
-        eth_balance(trader_buy_eth_b).await,
-        U256::from(49_800_747_827_208_136_744_u128)
+        trader_a_eth_balance_after - trader_a_eth_balance_before,
+        to_wei(49)
+    );
+    assert_eq!(
+        trader_b_eth_balance_after - trader_b_eth_balance_before,
+        49_800_747_827_208_136_744_u128.into()
     );
 
     // Drive orderbook in order to check that all orders were settled

--- a/crates/e2e/tests/e2e/limit_orders.rs
+++ b/crates/e2e/tests/e2e/limit_orders.rs
@@ -17,7 +17,10 @@ use {
         },
     },
     contracts::IUniswapLikeRouter,
-    ethcontract::prelude::{Account, Address, PrivateKey, U256},
+    ethcontract::{
+        prelude::{Account, Address, PrivateKey, U256},
+        transaction::TransactionBuilder,
+    },
     hex_literal::hex,
     model::{
         order::{Order, OrderBuilder, OrderClass, OrderKind},
@@ -90,6 +93,14 @@ async fn single_limit_order_test(web3: Web3) {
     let solver_account = Account::Local(accounts[0], None);
     let trader_a = Account::Offline(PrivateKey::from_raw(TRADER_A_PK).unwrap(), None);
     let trader_b = Account::Offline(PrivateKey::from_raw(TRADER_B_PK).unwrap(), None);
+    for trader in [&trader_a, &trader_b] {
+        TransactionBuilder::new(web3.clone())
+            .value(to_wei(1))
+            .to(trader.address())
+            .send()
+            .await
+            .unwrap();
+    }
 
     // Create & mint tokens to trade, pools for fee connections
     let token_a = deploy_token_with_weth_uniswap_pool(
@@ -316,6 +327,14 @@ async fn two_limit_orders_test(web3: Web3) {
     let solver_account = Account::Local(accounts[0], None);
     let trader_a = Account::Offline(PrivateKey::from_raw(TRADER_A_PK).unwrap(), None);
     let trader_b = Account::Offline(PrivateKey::from_raw(TRADER_B_PK).unwrap(), None);
+    for trader in [&trader_a, &trader_b] {
+        TransactionBuilder::new(web3.clone())
+            .value(to_wei(1))
+            .to(trader.address())
+            .send()
+            .await
+            .unwrap();
+    }
 
     // Create & mint tokens to trade, pools for fee connections
     let token_a = deploy_token_with_weth_uniswap_pool(
@@ -567,6 +586,14 @@ async fn mixed_limit_and_market_orders_test(web3: Web3) {
     let solver_account = Account::Local(accounts[0], None);
     let trader_a = Account::Offline(PrivateKey::from_raw(TRADER_A_PK).unwrap(), None);
     let trader_b = Account::Offline(PrivateKey::from_raw(TRADER_B_PK).unwrap(), None);
+    for trader in [&trader_a, &trader_b] {
+        TransactionBuilder::new(web3.clone())
+            .value(to_wei(1))
+            .to(trader.address())
+            .send()
+            .await
+            .unwrap();
+    }
 
     // Create & mint tokens to trade, pools for fee connections
     let token_a = deploy_token_with_weth_uniswap_pool(
@@ -825,6 +852,12 @@ async fn too_many_limit_orders_test(web3: Web3) {
     let accounts: Vec<Address> = web3.eth().accounts().await.expect("get accounts failed");
     let solver_account = Account::Local(accounts[0], None);
     let trader_account = Account::Offline(PrivateKey::from_raw(TRADER_A_PK).unwrap(), None);
+    TransactionBuilder::new(web3.clone())
+        .value(to_wei(1))
+        .to(trader_account.address())
+        .send()
+        .await
+        .unwrap();
 
     // Create & Mint tokens to trade
     let token_a = deploy_mintable_token(&web3).await;

--- a/crates/e2e/tests/e2e/onchain_components.rs
+++ b/crates/e2e/tests/e2e/onchain_components.rs
@@ -16,7 +16,6 @@ macro_rules! tx_value {
         $call
             .from($acc.clone())
             .value($value)
-            .gas_price(0.0.into())
             .send()
             .await
             .expect(&format!("{} failed", NAME))

--- a/crates/e2e/tests/e2e/onchain_settlement.rs
+++ b/crates/e2e/tests/e2e/onchain_settlement.rs
@@ -16,7 +16,10 @@ use {
         tx,
     },
     contracts::IUniswapLikeRouter,
-    ethcontract::prelude::{Account, Address, PrivateKey, U256},
+    ethcontract::{
+        prelude::{Account, Address, PrivateKey, U256},
+        transaction::TransactionBuilder,
+    },
     hex_literal::hex,
     model::{
         order::{OrderBuilder, OrderKind},
@@ -71,6 +74,14 @@ async fn onchain_settlement(web3: Web3) {
     let solver_account = Account::Local(accounts[0], None);
     let trader_a = Account::Offline(PrivateKey::from_raw(TRADER_A_PK).unwrap(), None);
     let trader_b = Account::Offline(PrivateKey::from_raw(TRADER_B_PK).unwrap(), None);
+    for trader in [&trader_a, &trader_b] {
+        TransactionBuilder::new(web3.clone())
+            .value(to_wei(1))
+            .to(trader.address())
+            .send()
+            .await
+            .unwrap();
+    }
 
     // Create & mint tokens to trade, pools for fee connections
     let token_a = deploy_token_with_weth_uniswap_pool(

--- a/crates/e2e/tests/e2e/order_cancellation.rs
+++ b/crates/e2e/tests/e2e/order_cancellation.rs
@@ -5,7 +5,10 @@ use {
         tx,
         tx_value,
     },
-    ethcontract::prelude::{Account, Address, PrivateKey, U256},
+    ethcontract::{
+        prelude::{Account, Address, PrivateKey, U256},
+        transaction::TransactionBuilder,
+    },
     model::{
         app_id::AppId,
         order::{
@@ -46,6 +49,12 @@ async fn order_cancellation(web3: Web3) {
     let accounts: Vec<Address> = web3.eth().accounts().await.expect("get accounts failed");
     let solver_account = Account::Local(accounts[0], None);
     let trader = Account::Offline(PrivateKey::from_raw(TRADER_PK).unwrap(), None);
+    TransactionBuilder::new(web3.clone())
+        .value(to_wei(1))
+        .to(trader.address())
+        .send()
+        .await
+        .unwrap();
 
     // Create & mint tokens to trade, pools for fee connections
     let token = deploy_token_with_weth_uniswap_pool(

--- a/crates/e2e/tests/e2e/settlement_without_onchain_liquidity.rs
+++ b/crates/e2e/tests/e2e/settlement_without_onchain_liquidity.rs
@@ -15,7 +15,10 @@ use {
         },
     },
     contracts::IUniswapLikeRouter,
-    ethcontract::prelude::{Account, Address, PrivateKey, U256},
+    ethcontract::{
+        prelude::{Account, Address, PrivateKey, U256},
+        transaction::TransactionBuilder,
+    },
     hex_literal::hex,
     model::{
         order::{OrderBuilder, OrderKind},
@@ -70,6 +73,12 @@ async fn onchain_settlement_without_liquidity(web3: Web3) {
     let accounts: Vec<Address> = web3.eth().accounts().await.expect("get accounts failed");
     let solver_account = Account::Local(accounts[0], None);
     let trader_account = Account::Offline(PrivateKey::from_raw(TRADER_A_PK).unwrap(), None);
+    TransactionBuilder::new(web3.clone())
+        .value(to_wei(1))
+        .to(trader_account.address())
+        .send()
+        .await
+        .unwrap();
 
     // Create & mint tokens to trade, pools for fee connections
     let token_a = deploy_token_with_weth_uniswap_pool(

--- a/crates/e2e/tests/e2e/smart_contract_orders.rs
+++ b/crates/e2e/tests/e2e/smart_contract_orders.rs
@@ -21,7 +21,16 @@ use {
         GnosisSafeProxy,
         IUniswapLikeRouter,
     },
-    ethcontract::{Account, Address, Bytes, PrivateKey, H160, H256, U256},
+    ethcontract::{
+        transaction::TransactionBuilder,
+        Account,
+        Address,
+        Bytes,
+        PrivateKey,
+        H160,
+        H256,
+        U256,
+    },
     model::{
         order::{Order, OrderBuilder, OrderKind, OrderStatus, OrderUid},
         signature::hashed_eip712_message,
@@ -72,6 +81,12 @@ async fn smart_contract_orders(web3: Web3) {
     let solver_account = Account::Local(accounts[0], None);
 
     let user = Account::Offline(PrivateKey::from_raw(TRADER).unwrap(), None);
+    TransactionBuilder::new(web3.clone())
+        .value(to_wei(1))
+        .to(user.address())
+        .send()
+        .await
+        .unwrap();
 
     // Deploy and setup a Gnosis Safe.
     let safe_singleton = GnosisSafe::builder(&web3).deploy().await.unwrap();

--- a/crates/e2e/tests/e2e/vault_balances.rs
+++ b/crates/e2e/tests/e2e/vault_balances.rs
@@ -15,7 +15,10 @@ use {
         },
     },
     contracts::IUniswapLikeRouter,
-    ethcontract::prelude::{Account, Address, PrivateKey, U256},
+    ethcontract::{
+        prelude::{Account, Address, PrivateKey, U256},
+        transaction::TransactionBuilder,
+    },
     model::{
         order::{OrderBuilder, OrderKind, SellTokenSource},
         signature::EcdsaSigningScheme,
@@ -64,6 +67,12 @@ async fn vault_balances(web3: Web3) {
     let accounts: Vec<Address> = web3.eth().accounts().await.expect("get accounts failed");
     let solver_account = Account::Local(accounts[0], None);
     let trader = Account::Offline(PrivateKey::from_raw(TRADER).unwrap(), None);
+    TransactionBuilder::new(web3.clone())
+        .value(to_wei(1))
+        .to(trader.address())
+        .send()
+        .await
+        .unwrap();
 
     // Create & mint tokens to trade, pools for fee connections
     let token = deploy_token_with_weth_uniswap_pool(

--- a/docker/hardhat/hardhat.config.js
+++ b/docker/hardhat/hardhat.config.js
@@ -5,7 +5,9 @@ module.exports = {
             initialDate: "2000-01-01T00:00:00.000+00:00",
             accounts: {
                 accountsBalance: "1000000000000000000000000"
-            }
+            },
+            gas: 1e7,
+            gasPrice: 1
         }
     }
 };


### PR DESCRIPTION
Our older hardhat e2e tests assume they can send transactions with 0 gas price. This doesn't work with the new geth e2e tests. To bring the systems in line I change the existing tests to no longer use 0 gas price. In some tests this requires changes to fund trader accounts that need to send an approval transaction.

### Test Plan

CI e2e tests