### PR TITLE
Do not pass solver address in driver config

### DIFF
--- a/crates/driver/example.toml
+++ b/crates/driver/example.toml
@@ -10,7 +10,6 @@ private-key = "0xaa1de59084f3b7e501f2d48cafb2ee04cd06a79ea126fd27ddf3d1b8903bb85
 name = "othersolver"
 endpoint = "http://localhost:1235"
 relative-slippage = "0.1"
-address = "0x1bDf4b007819cB9C26b980e34A2a226ad980441a"
 private-key = "0xfe1cbe78dbf9511c37be9716b9b347bcefaaaf8ee5e86dd40cfc3d763ac9a7b6"
 
 [contracts] # Optionally override the contract addresses, necessary on less popular blockchains

--- a/crates/driver/src/infra/config/file/load.rs
+++ b/crates/driver/src/infra/config/file/load.rs
@@ -29,7 +29,6 @@ pub async fn load(path: &Path) -> infra::Config {
                     relative: config.relative_slippage,
                     absolute: config.absolute_slippage.map(Into::into),
                 },
-                address: config.address.into(),
                 private_key: eth::PrivateKey::from_raw(config.private_key.0).unwrap(),
             })
             .collect(),

--- a/crates/driver/src/infra/config/file/mod.rs
+++ b/crates/driver/src/infra/config/file/mod.rs
@@ -136,9 +136,6 @@ struct SolverConfig {
     #[serde_as(as = "Option<serialize::U256>")]
     absolute_slippage: Option<eth::U256>,
 
-    /// The address of this solver. Expects a 20-byte hex encoded string.
-    address: eth::H160,
-
     /// The private key used to sign transactions. Expects a 32-byte hex encoded
     /// string.
     private_key: eth::H256,

--- a/crates/driver/src/infra/solver/mod.rs
+++ b/crates/driver/src/infra/solver/mod.rs
@@ -58,8 +58,6 @@ pub struct Config {
     pub name: Name,
     /// The acceptable slippage for this solver.
     pub slippage: Slippage,
-    /// The address of this solver.
-    pub address: eth::Address,
     /// The private key of this solver.
     pub private_key: eth::PrivateKey,
 }
@@ -94,7 +92,7 @@ impl Solver {
 
     /// The blockchain address of this solver.
     pub fn address(&self) -> eth::Address {
-        self.config.address
+        self.config.private_key.public_address().into()
     }
 
     /// The private key of this solver.


### PR DESCRIPTION
The address can be calculated from the private key so there is no reason to pass it separately. That only leaves space for mismatching the parameters.

### Test Plan

still compiles
