### PR TITLE
Fix duration overflow bug

### DIFF
--- a/crates/shared/src/rate_limiter.rs
+++ b/crates/shared/src/rate_limiter.rs
@@ -97,16 +97,10 @@ impl RateLimitingStrategy {
             .back_off_growth_factor
             .powf(self.times_rate_limited as f64);
         let back_off_secs = self.min_back_off.as_secs_f64() * factor;
-        if !back_off_secs.is_normal()
-            || back_off_secs < 0.
-            || back_off_secs > self.max_back_off.as_secs_f64()
-        {
-            // This would cause a panic in `Duration::from_secs_f64()`
-            // TODO refactor this when `Duration::try_from_secs_f64()` gets stabilized:
-            // https://doc.rust-lang.org/stable/std/time/struct.Duration.html#method.try_from_secs_f64
-            return self.max_back_off;
-        }
-        Duration::from_secs_f64(back_off_secs)
+        std::cmp::min(
+            Duration::try_from_secs_f64(back_off_secs).unwrap_or(self.max_back_off),
+            self.max_back_off,
+        )
     }
 
     /// Returns updated back off if no other thread increased it in the mean

--- a/crates/shared/src/rate_limiter.rs
+++ b/crates/shared/src/rate_limiter.rs
@@ -97,14 +97,16 @@ impl RateLimitingStrategy {
             .back_off_growth_factor
             .powf(self.times_rate_limited as f64);
         let back_off_secs = self.min_back_off.as_secs_f64() * factor;
-        if !back_off_secs.is_normal() || back_off_secs < 0. || back_off_secs > u64::MAX as f64 {
+        if !back_off_secs.is_normal()
+            || back_off_secs < 0.
+            || back_off_secs > self.max_back_off.as_secs_f64()
+        {
             // This would cause a panic in `Duration::from_secs_f64()`
             // TODO refactor this when `Duration::try_from_secs_f64()` gets stabilized:
             // https://doc.rust-lang.org/stable/std/time/struct.Duration.html#method.try_from_secs_f64
             return self.max_back_off;
         }
-        let current_back_off = Duration::from_secs_f64(back_off_secs);
-        std::cmp::min(self.max_back_off, current_back_off)
+        Duration::from_secs_f64(back_off_secs)
     }
 
     /// Returns updated back off if no other thread increased it in the mean


### PR DESCRIPTION
https://play.rust-lang.org/?version=stable&mode=debug&edition=2021&gist=f36f362ce1571bcb34ed0debab7afc6c

The `u64::MAX` limit is not the right value to use here, and can cause panics. This showed up in staging.

### Test Plan

Tests still pass. After applying to staging we'll see if it goes away.
