### PR TITLE
Deny unknown config file fields

### DIFF
--- a/crates/driver/src/infra/config/file/mod.rs
+++ b/crates/driver/src/infra/config/file/mod.rs
@@ -10,7 +10,7 @@ mod load;
 pub use load::load;
 
 #[derive(Debug, Deserialize)]
-#[serde(rename_all = "kebab-case")]
+#[serde(rename_all = "kebab-case", deny_unknown_fields)]
 struct Config {
     /// Disable access list simulation, useful for environments that don't
     /// support this, such as less popular blockchains.
@@ -36,7 +36,7 @@ struct Config {
 }
 
 #[derive(Debug, Default, Deserialize)]
-#[serde(rename_all = "kebab-case")]
+#[serde(rename_all = "kebab-case", deny_unknown_fields)]
 struct SubmissionConfig {
     /// Additional tip in percentage of max_fee_per_gas we are willing to give
     /// to miners above regular gas price estimation. Expects a floating point
@@ -142,7 +142,7 @@ struct SolverConfig {
 }
 
 #[derive(Debug, Default, Deserialize)]
-#[serde(rename_all = "kebab-case")]
+#[serde(rename_all = "kebab-case", deny_unknown_fields)]
 pub struct ContractsConfig {
     /// Override the default address of the GPv2Settlement contract.
     pub gp_v2_settlement: Option<eth::H160>,
@@ -152,7 +152,7 @@ pub struct ContractsConfig {
 }
 
 #[derive(Debug, Deserialize)]
-#[serde(rename_all = "kebab-case")]
+#[serde(rename_all = "kebab-case", deny_unknown_fields)]
 struct TenderlyConfig {
     /// Optionally override the Tenderly API URL.
     url: Option<Url>,
@@ -175,7 +175,7 @@ struct TenderlyConfig {
 }
 
 #[derive(Debug, Default, Deserialize)]
-#[serde(rename_all = "kebab-case")]
+#[serde(rename_all = "kebab-case", deny_unknown_fields)]
 struct LiquidityConfig {
     /// Additional tokens for which liquidity is always fetched, regardless of
     /// whether or not the token appears in the auction.
@@ -196,7 +196,7 @@ struct LiquidityConfig {
 // preset = "sushiswap"
 // ```
 #[derive(Debug, Deserialize)]
-#[serde(rename_all = "kebab-case")]
+#[serde(rename_all = "kebab-case", deny_unknown_fields)]
 struct UniswapV2Config {
     /// The address of the Uniswap V2 compatible router contract.
     router: eth::H160,

--- a/crates/driver/src/tests/setup/driver.rs
+++ b/crates/driver/src/tests/setup/driver.rs
@@ -128,7 +128,7 @@ pub async fn setup(config: Config<'_>) -> Client {
     };
     let args = vec![
         "/test/driver/path".to_owned(),
-        "--bind-addr".to_owned(),
+        "--addr".to_owned(),
         "0.0.0.0:0".to_owned(),
         "--ethrpc".to_owned(),
         config.geth.url(),

--- a/crates/solvers/src/config/baseline/file.rs
+++ b/crates/solvers/src/config/baseline/file.rs
@@ -1,7 +1,7 @@
 use {crate::domain::eth, serde::Deserialize, std::path::Path, tokio::fs};
 
 #[derive(Deserialize)]
-#[serde(rename_all = "kebab-case")]
+#[serde(rename_all = "kebab-case", deny_unknown_fields)]
 struct Config {
     /// The address of the WETH contract.
     pub weth: eth::H160,


### PR DESCRIPTION
This helps detect accidentally specifying configuration that has no effect. I was unable to find something similar for clap argument parsing.

### Test Plan

ran the driver and solvers test