### PR TITLE
Deny unknown fields in colocation APIs

### DIFF
--- a/crates/autopilot/src/driver_model.rs
+++ b/crates/autopilot/src/driver_model.rs
@@ -8,7 +8,7 @@ pub mod quote {
         serde::{Deserialize, Serialize},
     };
 
-    #[derive(Clone, Debug, Default, Deserialize, Serialize)]
+    #[derive(Clone, Debug, Default, Serialize)]
     #[serde(rename_all = "camelCase")]
     pub struct Request {
         pub sell_token: H160,
@@ -18,7 +18,7 @@ pub mod quote {
         pub amount: U256,
     }
 
-    #[derive(Clone, Debug, Default, Deserialize, Serialize)]
+    #[derive(Clone, Debug, Default, Serialize)]
     #[serde(rename_all = "lowercase")]
     pub enum Kind {
         #[default]
@@ -26,8 +26,8 @@ pub mod quote {
         Sell,
     }
 
-    #[derive(Clone, Debug, Deserialize, Serialize)]
-    #[serde(untagged, rename_all = "camelCase")]
+    #[derive(Clone, Debug, Deserialize)]
+    #[serde(untagged, rename_all = "camelCase", deny_unknown_fields)]
     pub enum Response {
         Successful {
             #[serde(with = "u256_decimal")]
@@ -51,14 +51,14 @@ pub mod solve {
         std::collections::BTreeMap,
     };
 
-    #[derive(Clone, Debug, Default, Deserialize, Serialize)]
+    #[derive(Clone, Debug, Default, Serialize)]
     pub struct Request {
         pub auction: Auction,
         pub deadline: DateTime<Utc>,
     }
 
     #[serde_as]
-    #[derive(Clone, Debug, Default, Deserialize, Serialize)]
+    #[derive(Clone, Debug, Default, Serialize)]
     pub struct Auction {
         pub id: i64,
         pub block: u64,
@@ -67,12 +67,13 @@ pub mod solve {
         pub prices: BTreeMap<H160, U256>,
     }
 
-    #[derive(Clone, Debug, Default, Deserialize, Serialize)]
+    #[derive(Clone, Debug, Default, Serialize)]
     pub struct Order {
         // TODO: what fields? Needs to be documented in openapi too.
     }
 
-    #[derive(Clone, Debug, Default, Deserialize, Serialize)]
+    #[derive(Clone, Debug, Default, Deserialize)]
+    #[serde(deny_unknown_fields)]
     pub struct Response {
         pub objective: f64,
         pub signature: String,
@@ -89,7 +90,7 @@ pub mod execute {
         std::collections::BTreeMap,
     };
 
-    #[derive(Clone, Derivative, Default, Deserialize, Serialize)]
+    #[derive(Clone, Derivative, Default, Serialize)]
     #[serde(rename_all = "camelCase")]
     #[derivative(Debug)]
     pub struct Request {
@@ -100,8 +101,8 @@ pub mod execute {
     }
 
     #[serde_as]
-    #[derive(Clone, Debug, Default, Deserialize, Serialize)]
-    #[serde(rename_all = "camelCase")]
+    #[derive(Clone, Debug, Default, Deserialize)]
+    #[serde(rename_all = "camelCase", deny_unknown_fields)]
     pub struct Response {
         pub account: H160,
         pub nonce: u64,
@@ -114,8 +115,8 @@ pub mod execute {
         pub signature: String,
     }
 
-    #[derive(Clone, Debug, Default, Deserialize, Serialize)]
-    #[serde(rename_all = "camelCase")]
+    #[derive(Clone, Debug, Default, Deserialize)]
+    #[serde(rename_all = "camelCase", deny_unknown_fields)]
     pub struct Trade {
         pub uid: OrderUid,
         #[serde(with = "u256_decimal")]
@@ -123,7 +124,8 @@ pub mod execute {
     }
 
     #[serde_as]
-    #[derive(Clone, Debug, Default, Deserialize, Serialize)]
+    #[derive(Clone, Debug, Default, Deserialize)]
+    #[serde(rename_all = "camelCase", deny_unknown_fields)]
     pub struct InternalizedInteraction {
         #[serde(with = "bytes_hex")]
         pub calldata: Vec<u8>,

--- a/crates/driver/src/infra/api/routes/quote/dto/order.rs
+++ b/crates/driver/src/infra/api/routes/quote/dto/order.rs
@@ -25,7 +25,7 @@ impl Order {
 
 #[serde_as]
 #[derive(Debug, Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct Order {
     sell_token: eth::H160,
     buy_token: eth::H160,
@@ -38,7 +38,7 @@ pub struct Order {
 }
 
 #[derive(Debug, Deserialize)]
-#[serde(rename_all = "lowercase")]
+#[serde(rename_all = "lowercase", deny_unknown_fields)]
 enum Kind {
     Sell,
     Buy,

--- a/crates/driver/src/infra/api/routes/solve/dto/auction.rs
+++ b/crates/driver/src/infra/api/routes/solve/dto/auction.rs
@@ -132,7 +132,7 @@ pub enum Error {
 
 #[serde_as]
 #[derive(Debug, Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct Auction {
     id: i64,
     prices: HashMap<eth::H160, eth::U256>,
@@ -142,7 +142,7 @@ pub struct Auction {
 
 #[serde_as]
 #[derive(Debug, Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
 struct Order {
     #[serde_as(as = "serialize::Hex")]
     uid: [u8; 56],
@@ -181,7 +181,7 @@ struct Order {
 }
 
 #[derive(Debug, Deserialize)]
-#[serde(rename_all = "lowercase")]
+#[serde(rename_all = "lowercase", deny_unknown_fields)]
 enum Kind {
     Sell,
     Buy,
@@ -189,7 +189,7 @@ enum Kind {
 
 #[serde_as]
 #[derive(Debug, Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
 struct Interaction {
     target: eth::H160,
     #[serde_as(as = "serialize::U256")]
@@ -199,7 +199,7 @@ struct Interaction {
 }
 
 #[derive(Debug, Default, Deserialize)]
-#[serde(rename_all = "lowercase")]
+#[serde(rename_all = "lowercase", deny_unknown_fields)]
 enum SellTokenBalance {
     #[default]
     Erc20,
@@ -208,7 +208,7 @@ enum SellTokenBalance {
 }
 
 #[derive(Debug, Default, Deserialize)]
-#[serde(rename_all = "lowercase")]
+#[serde(rename_all = "lowercase", deny_unknown_fields)]
 enum BuyTokenBalance {
     #[default]
     Erc20,
@@ -216,7 +216,7 @@ enum BuyTokenBalance {
 }
 
 #[derive(Debug, Deserialize)]
-#[serde(rename_all = "lowercase")]
+#[serde(rename_all = "lowercase", deny_unknown_fields)]
 enum SigningScheme {
     Eip712,
     EthSign,
@@ -225,7 +225,7 @@ enum SigningScheme {
 }
 
 #[derive(Debug, Deserialize)]
-#[serde(rename_all = "lowercase")]
+#[serde(rename_all = "lowercase", deny_unknown_fields)]
 enum Class {
     Market,
     Limit,

--- a/crates/driver/src/infra/solver/dto/solution.rs
+++ b/crates/driver/src/infra/solver/dto/solution.rs
@@ -182,6 +182,7 @@ impl Solution {
 
 #[serde_as]
 #[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct Solution {
     #[serde_as(as = "HashMap<_, serialize::U256>")]
     // TODO I also need to use this
@@ -192,7 +193,7 @@ pub struct Solution {
 }
 
 #[derive(Debug, Deserialize)]
-#[serde(tag = "kind", rename_all = "lowercase")]
+#[serde(tag = "kind", rename_all = "lowercase", deny_unknown_fields)]
 enum Trade {
     Fulfillment(Fulfillment),
     Jit(JitTrade),
@@ -200,7 +201,7 @@ enum Trade {
 
 #[serde_as]
 #[derive(Debug, Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
 struct Fulfillment {
     #[serde_as(as = "serialize::Hex")]
     order: [u8; 56],
@@ -210,6 +211,7 @@ struct Fulfillment {
 
 #[serde_as]
 #[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
 struct JitTrade {
     order: JitOrder,
     #[serde_as(as = "serialize::U256")]
@@ -218,6 +220,7 @@ struct JitTrade {
 
 #[serde_as]
 #[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
 struct JitOrder {
     sell_token: eth::H160,
     buy_token: eth::H160,
@@ -241,14 +244,14 @@ struct JitOrder {
 }
 
 #[derive(Debug, Deserialize)]
-#[serde(rename_all = "lowercase")]
+#[serde(rename_all = "lowercase", deny_unknown_fields)]
 enum Kind {
     Sell,
     Buy,
 }
 
 #[derive(Debug, Deserialize)]
-#[serde(tag = "kind", rename_all = "lowercase")]
+#[serde(tag = "kind", rename_all = "lowercase", deny_unknown_fields)]
 enum Interaction {
     Liquidity(LiquidityInteraction),
     Custom(CustomInteraction),
@@ -256,7 +259,7 @@ enum Interaction {
 
 #[serde_as]
 #[derive(Debug, Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
 struct LiquidityInteraction {
     internalize: bool,
     #[serde_as(as = "serde_with::DisplayFromStr")]
@@ -271,7 +274,7 @@ struct LiquidityInteraction {
 
 #[serde_as]
 #[derive(Debug, Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
 struct CustomInteraction {
     internalize: bool,
     target: eth::H160,
@@ -286,6 +289,7 @@ struct CustomInteraction {
 
 #[serde_as]
 #[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
 struct Asset {
     token: eth::H160,
     #[serde_as(as = "serialize::U256")]
@@ -294,6 +298,7 @@ struct Asset {
 
 #[serde_as]
 #[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
 struct Allowance {
     token: eth::H160,
     spender: eth::H160,
@@ -302,7 +307,7 @@ struct Allowance {
 }
 
 #[derive(Debug, Default, Deserialize)]
-#[serde(rename_all = "lowercase")]
+#[serde(rename_all = "lowercase", deny_unknown_fields)]
 enum SellTokenBalance {
     #[default]
     Erc20,
@@ -311,7 +316,7 @@ enum SellTokenBalance {
 }
 
 #[derive(Debug, Default, Deserialize)]
-#[serde(rename_all = "lowercase")]
+#[serde(rename_all = "lowercase", deny_unknown_fields)]
 enum BuyTokenBalance {
     #[default]
     Erc20,
@@ -319,7 +324,7 @@ enum BuyTokenBalance {
 }
 
 #[derive(Debug, Deserialize)]
-#[serde(rename_all = "lowercase")]
+#[serde(rename_all = "lowercase", deny_unknown_fields)]
 enum SigningScheme {
     Eip712,
     EthSign,

--- a/crates/solvers/src/api/dto/auction.rs
+++ b/crates/solvers/src/api/dto/auction.rs
@@ -59,7 +59,7 @@ impl Auction {
 
 #[serde_as]
 #[derive(Debug, Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct Auction {
     id: Option<String>,
     tokens: HashMap<H160, Token>,
@@ -72,7 +72,7 @@ pub struct Auction {
 
 #[serde_as]
 #[derive(Debug, Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
 struct Order {
     #[serde_as(as = "serialize::Hex")]
     uid: [u8; 56],
@@ -107,7 +107,7 @@ enum Class {
 
 #[serde_as]
 #[derive(Debug, Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
 struct Token {
     decimals: Option<u8>,
     symbol: Option<String>,
@@ -119,7 +119,7 @@ struct Token {
 }
 
 #[derive(Debug, Deserialize)]
-#[serde(tag = "kind", rename_all = "lowercase")]
+#[serde(tag = "kind", rename_all = "lowercase", deny_unknown_fields)]
 enum Liquidity {
     ConstantProduct(ConstantProductPool),
     WeightedProduct(WeightedProductPool),
@@ -130,7 +130,7 @@ enum Liquidity {
 
 #[serde_as]
 #[derive(Debug, Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
 struct ConstantProductPool {
     id: String,
     address: H160,
@@ -142,6 +142,7 @@ struct ConstantProductPool {
 
 #[serde_as]
 #[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
 struct ConstantProductReserve {
     #[serde_as(as = "serialize::U256")]
     balance: U256,
@@ -177,7 +178,7 @@ impl ConstantProductPool {
 
 #[serde_as]
 #[derive(Debug, Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
 struct WeightedProductPool {
     id: String,
     address: H160,
@@ -189,6 +190,7 @@ struct WeightedProductPool {
 
 #[serde_as]
 #[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
 struct WeightedProductReserve {
     #[serde_as(as = "serialize::U256")]
     balance: U256,
@@ -234,7 +236,7 @@ impl WeightedProductPool {
 
 #[serde_as]
 #[derive(Debug, Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
 struct StablePool {
     id: String,
     address: H160,
@@ -247,7 +249,7 @@ struct StablePool {
 
 #[serde_as]
 #[derive(Debug, Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
 struct StableReserve {
     #[serde_as(as = "serialize::U256")]
     balance: U256,
@@ -291,7 +293,7 @@ impl StablePool {
 
 #[serde_as]
 #[derive(Debug, Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
 struct ConcentratedLiquidityPool {
     id: String,
     address: H160,
@@ -350,7 +352,7 @@ impl ConcentratedLiquidityPool {
 
 #[serde_as]
 #[derive(Debug, Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
 struct ForeignLimitOrder {
     id: String,
     address: H160,

--- a/crates/solvers/src/api/dto/solution.rs
+++ b/crates/solvers/src/api/dto/solution.rs
@@ -55,6 +55,7 @@ impl Solution {
 
 #[serde_as]
 #[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct Solution {
     #[serde_as(as = "HashMap<_, serialize::U256>")]
     prices: HashMap<H160, U256>,
@@ -81,6 +82,7 @@ struct Fulfillment {
 
 #[serde_as]
 #[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
 struct JitTrade {
     order: JitOrder,
     #[serde_as(as = "serialize::U256")]
@@ -89,6 +91,7 @@ struct JitTrade {
 
 #[serde_as]
 #[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
 struct JitOrder {
     sell_token: H160,
     buy_token: H160,
@@ -156,6 +159,7 @@ struct CustomInteraction {
 
 #[serde_as]
 #[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
 struct Asset {
     token: H160,
     #[serde_as(as = "serialize::U256")]
@@ -164,6 +168,7 @@ struct Asset {
 
 #[serde_as]
 #[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
 struct Allowance {
     token: H160,
     spender: H160,


### PR DESCRIPTION
This helps catch cases where the types used in serialization don't line up.

Also added some `camelCase` annotations where they were missing and removed one of of the deserialize/serialize derives when the type is only used in one direction.

### Test Plan

CI, ran existing colocation tests