### PR TITLE
Make config file content accessible without file on disk

### DIFF
--- a/crates/driver/src/infra/cli.rs
+++ b/crates/driver/src/infra/cli.rs
@@ -24,6 +24,11 @@ pub struct Args {
     /// Path to the driver configuration file. This file should be in TOML
     /// format. For an example see
     /// https://github.com/cowprotocol/services/blob/main/crates/driver/example.toml.
-    #[clap(long, env)]
-    pub config: PathBuf,
+    #[clap(long, env, conflicts_with = "config_string")]
+    pub config_path: Option<PathBuf>,
+
+    /// Like `config` but reads the configuration directly from the argument
+    /// instead of a file.
+    #[clap(long, env, conflicts_with = "config_path")]
+    pub config_string: Option<String>,
 }

--- a/crates/driver/src/infra/config/file/load.rs
+++ b/crates/driver/src/infra/config/file/load.rs
@@ -12,12 +12,21 @@ use {
 /// # Panics
 ///
 /// This method panics if the config is invalid or on I/O errors.
-pub async fn load(path: &Path) -> infra::Config {
+pub async fn load_path(path: &Path) -> infra::Config {
     let data = fs::read_to_string(path)
         .await
         .unwrap_or_else(|e| panic!("I/O error while reading {path:?}: {e:?}"));
-    let config: file::Config = toml::de::from_str(&data)
-        .unwrap_or_else(|e| panic!("TOML syntax error while reading {path:?}: {e:?}"));
+    load_string(&data)
+}
+
+/// Load the driver configuration from a string
+///
+/// # Panics
+///
+/// This method panics if the config is invalid.
+pub fn load_string(string: &str) -> infra::Config {
+    let config: file::Config =
+        toml::de::from_str(string).unwrap_or_else(|e| panic!("TOML syntax error: {e:?}"));
     infra::Config {
         solvers: config
             .solvers

--- a/crates/driver/src/infra/config/file/mod.rs
+++ b/crates/driver/src/infra/config/file/mod.rs
@@ -7,7 +7,7 @@ use {
 
 mod load;
 
-pub use load::load;
+pub use load::{load_path, load_string};
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "kebab-case", deny_unknown_fields)]

--- a/crates/driver/src/tests/setup/driver.rs
+++ b/crates/driver/src/tests/setup/driver.rs
@@ -132,7 +132,7 @@ pub async fn setup(config: Config<'_>) -> Client {
         "0.0.0.0:0".to_owned(),
         "--ethrpc".to_owned(),
         config.geth.url(),
-        "--config".to_owned(),
+        "--config-path".to_owned(),
         config_file.0.clone(),
         "--log".to_owned(),
         "error,web3=warn,hyper=warn,driver::infra::solver=error".to_owned(),

--- a/crates/solvers/src/infra/cli.rs
+++ b/crates/solvers/src/infra/cli.rs
@@ -19,8 +19,13 @@ pub struct Args {
 
     /// Path to the driver configuration file. This file should be in TOML
     /// format.
-    #[clap(long, env)]
-    pub config: PathBuf,
+    #[clap(long, env, conflicts_with = "config_string")]
+    pub config_path: Option<PathBuf>,
+
+    /// Like `config` but reads the configuration directly from the argument
+    /// instead of a file.
+    #[clap(long, env, conflicts_with = "config_path")]
+    pub config_string: Option<String>,
 
     #[command(subcommand)]
     pub command: Command,

--- a/crates/solvers/src/infra/config/baseline/file.rs
+++ b/crates/solvers/src/infra/config/baseline/file.rs
@@ -32,12 +32,21 @@ struct Config {
 /// # Panics
 ///
 /// This method panics if the config is invalid or on I/O errors.
-pub async fn load(path: &Path) -> super::BaselineConfig {
+pub async fn load_path(path: &Path) -> super::BaselineConfig {
     let data = fs::read_to_string(path)
         .await
         .unwrap_or_else(|e| panic!("I/O error while reading {path:?}: {e:?}"));
-    let config: Config = toml::de::from_str(&data)
-        .unwrap_or_else(|e| panic!("TOML syntax error while reading {path:?}: {e:?}"));
+    load_string(&data)
+}
+
+/// Load the driver configuration from a TOML string.
+///
+/// # Panics
+///
+/// This method panics if the config is invalid.
+pub fn load_string(string: &str) -> super::BaselineConfig {
+    let config: Config =
+        toml::de::from_str(string).unwrap_or_else(|e| panic!("TOML syntax error in config: {e:?}"));
     super::BaselineConfig {
         chain_id: config.chain_id,
         weth: config.weth.map(eth::WethAddress),

--- a/crates/solvers/src/run.rs
+++ b/crates/solvers/src/run.rs
@@ -18,7 +18,12 @@ pub async fn run(args: impl Iterator<Item = String>, bind: Option<oneshot::Sende
     // TODO In the future, should use different load methods based on the command
     // being executed
     let cli::Command::Baseline = args.command;
-    let baseline = config::baseline::file::load(&args.config).await;
+    let baseline = match (&args.config_string, &args.config_path) {
+        (Some(string), None) => config::baseline::file::load_string(string),
+        (None, Some(path)) => config::baseline::file::load_path(path).await,
+        (None, None) => panic!("specify --config-string or --config-path"),
+        (Some(_), Some(_)) => unreachable!(),
+    };
     let contracts = contracts::Contracts::new(
         baseline.chain_id,
         contracts::Addresses {

--- a/crates/solvers/src/tests/mod.rs
+++ b/crates/solvers/src/tests/mod.rs
@@ -28,7 +28,7 @@ impl SolverEngine {
                 "/test/solvers/path".to_owned(),
                 "--addr".to_owned(),
                 "0.0.0.0:0".to_owned(),
-                "--config".to_owned(),
+                "--config-path".to_owned(),
                 config,
                 command,
             ]


### PR DESCRIPTION
Currently the configuration file must be passed as a path to the driver and solvers binary. This is annoying in e2e tests because you need to create the file on disk to pass it in. With this change the config file content can be passed directly inside of an argument. This might also be useful for our kubernetes setup.

### Test Plan

colocation e2e test
