### PR TITLE
Use `TokenAmount` in `AmmOrderExecution`

### DIFF
--- a/crates/driver/src/boundary/liquidity/uniswap/v2.rs
+++ b/crates/driver/src/boundary/liquidity/uniswap/v2.rs
@@ -10,6 +10,7 @@ use {
     futures::StreamExt,
     shared::{
         current_block::{self, CurrentBlockStream},
+        http_solver::model::TokenAmount,
         maintenance::Maintaining,
         price_estimation,
         sources::uniswap_v2::{
@@ -76,8 +77,8 @@ pub fn to_interaction(
     );
 
     let (_, interaction) = handler.settle(
-        (input.0.token.into(), input.0.amount),
-        (output.0.token.into(), output.0.amount),
+        TokenAmount::new(input.0.token.into(), input.0.amount),
+        TokenAmount::new(output.0.token.into(), output.0.amount),
     );
 
     let (target, value, call_data) = interaction.encode_swap();

--- a/crates/driver/src/boundary/settlement.rs
+++ b/crates/driver/src/boundary/settlement.rs
@@ -27,7 +27,7 @@ use {
         DomainSeparator,
     },
     number_conversions::u256_to_big_rational,
-    shared::http_solver::model::InternalizationStrategy,
+    shared::http_solver::model::{InternalizationStrategy, TokenAmount},
     solver::{
         interactions::Erc20ApproveInteraction,
         liquidity::{
@@ -342,18 +342,24 @@ pub fn to_boundary_interaction(
         competition::solution::Interaction::Liquidity(liquidity) => {
             let boundary_execution =
                 slippage_context.apply_to_amm_execution(AmmOrderExecution {
-                    input_max: (liquidity.input.token.into(), liquidity.input.amount),
-                    output: (liquidity.output.token.into(), liquidity.output.amount),
+                    input_max: TokenAmount::new(
+                        liquidity.input.token.into(),
+                        liquidity.input.amount,
+                    ),
+                    output: TokenAmount::new(
+                        liquidity.output.token.into(),
+                        liquidity.output.amount,
+                    ),
                     internalizable: interaction.internalize(),
                 })?;
 
             let input = liquidity::MaxInput(eth::Asset {
-                token: boundary_execution.input_max.0.into(),
-                amount: boundary_execution.input_max.1,
+                token: boundary_execution.input_max.token.into(),
+                amount: boundary_execution.input_max.amount,
             });
             let output = liquidity::ExactOutput(eth::Asset {
-                token: boundary_execution.output.0.into(),
-                amount: boundary_execution.output.1,
+                token: boundary_execution.output.token.into(),
+                amount: boundary_execution.output.amount,
             });
 
             let interaction = match &liquidity.liquidity.kind {

--- a/crates/shared/src/http_solver/model.rs
+++ b/crates/shared/src/http_solver/model.rs
@@ -134,6 +134,15 @@ pub struct TokenAmount {
     pub token: H160,
 }
 
+impl TokenAmount {
+    pub fn new<T: Into<U256>>(token: H160, amount: T) -> Self {
+        Self {
+            amount: amount.into(),
+            token,
+        }
+    }
+}
+
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct ApprovalModel {
     pub token: H160,

--- a/crates/solver/src/interactions/allowances.rs
+++ b/crates/solver/src/interactions/allowances.rs
@@ -11,6 +11,7 @@ use {
     shared::{
         dummy_contract,
         ethrpc::Web3,
+        http_solver::model::TokenAmount,
         interaction::{EncodedInteraction, Interaction},
     },
     std::{
@@ -67,16 +68,16 @@ impl Allowances {
     }
 
     /// Gets the approval interaction for the specified token and amount.
-    pub fn approve_token(&self, token: H160, amount: U256) -> Result<Option<Approval>> {
+    pub fn approve_token(&self, token_amount: TokenAmount) -> Result<Option<Approval>> {
         let allowance = self
             .allowances
-            .get(&token)
+            .get(&token_amount.token)
             .copied()
-            .ok_or_else(|| anyhow!("missing allowance for token {:?}", token))?;
+            .ok_or_else(|| anyhow!("missing allowance for token {:?}", token_amount.token))?;
 
-        Ok(if allowance < amount {
+        Ok(if allowance < token_amount.amount {
             Some(Approval {
-                token,
+                token: token_amount.token,
                 spender: self.spender,
             })
         } else {
@@ -86,8 +87,10 @@ impl Allowances {
 
     /// Gets the token approval, unconditionally approving in case the token
     /// allowance is missing.
-    pub fn approve_token_or_default(&self, token: H160, amount: U256) -> Option<Approval> {
-        self.approve_token(token, amount).unwrap_or(Some(Approval {
+    pub fn approve_token_or_default(&self, token_amount: TokenAmount) -> Option<Approval> {
+        let token = token_amount.token;
+
+        self.approve_token(token_amount).unwrap_or(Some(Approval {
             token,
             spender: self.spender,
         }))
@@ -170,7 +173,7 @@ impl AllowanceManaging for AllowanceManager {
             let allowance = allowances
                 .get(&request.spender)
                 .with_context(|| format!("no allowances found for spender {}", request.spender))?
-                .approve_token(request.token, request.amount)?;
+                .approve_token(TokenAmount::new(request.token, request.amount))?;
             result.extend(allowance);
         }
         Ok(result)
@@ -260,8 +263,18 @@ mod tests {
             },
         );
 
-        assert_eq!(allowances.approve_token(token, 42.into()).unwrap(), None);
-        assert_eq!(allowances.approve_token(token, 100.into()).unwrap(), None);
+        assert_eq!(
+            allowances
+                .approve_token(TokenAmount::new(token, 42))
+                .unwrap(),
+            None
+        );
+        assert_eq!(
+            allowances
+                .approve_token(TokenAmount::new(token, 100))
+                .unwrap(),
+            None
+        );
     }
 
     #[test]
@@ -276,7 +289,9 @@ mod tests {
         );
 
         assert_eq!(
-            allowances.approve_token(token, 1337.into()).unwrap(),
+            allowances
+                .approve_token(TokenAmount::new(token, 1337))
+                .unwrap(),
             Some(Approval { token, spender })
         );
     }
@@ -291,7 +306,7 @@ mod tests {
         );
 
         assert!(allowances
-            .approve_token(H160([0x03; 20]), 0.into())
+            .approve_token(TokenAmount::new(H160([0x03; 20]), 0))
             .is_err());
     }
 
@@ -302,7 +317,7 @@ mod tests {
         let allowances = Allowances::new(spender, hashmap! {});
 
         assert_eq!(
-            allowances.approve_token_or_default(token, 1337.into()),
+            allowances.approve_token_or_default(TokenAmount::new(token, 1337)),
             Some(Approval { token, spender })
         );
     }

--- a/crates/solver/src/liquidity.rs
+++ b/crates/solver/src/liquidity.rs
@@ -20,12 +20,15 @@ use {
     },
     num::{rational::Ratio, BigRational},
     primitive_types::{H160, U256},
-    shared::sources::{
-        balancer_v2::{
-            pool_fetching::{AmplificationParameter, TokenState, WeightedTokenState},
-            swap::fixed_point::Bfp,
+    shared::{
+        http_solver::model::TokenAmount,
+        sources::{
+            balancer_v2::{
+                pool_fetching::{AmplificationParameter, TokenState, WeightedTokenState},
+                swap::fixed_point::Bfp,
+            },
+            uniswap_v3::pool_fetching::PoolInfo,
         },
-        uniswap_v3::pool_fetching::PoolInfo,
     },
     std::{collections::HashMap, sync::Arc},
     strum::{EnumVariantNames, IntoStaticStr},
@@ -344,8 +347,8 @@ pub fn token_pairs<T>(reserves: &HashMap<H160, T>) -> Vec<TokenPair> {
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct AmmOrderExecution {
-    pub input_max: (H160, U256),
-    pub output: (H160, U256),
+    pub input_max: TokenAmount,
+    pub output: TokenAmount,
     pub internalizable: bool,
 }
 

--- a/crates/solver/src/liquidity/balancer_v2.rs
+++ b/crates/solver/src/liquidity/balancer_v2.rs
@@ -416,7 +416,7 @@ mod tests {
             &handler,
             AmmOrderExecution {
                 input_max: TokenAmount::new(H160([0x70; 20]), 10),
-                output: TokenAmount::new(H160([0x71; 20]), 1),
+                output: TokenAmount::new(H160([0x71; 20]), 11),
                 internalizable: false,
             },
             &mut encoder,

--- a/crates/solver/src/liquidity/balancer_v2.rs
+++ b/crates/solver/src/liquidity/balancer_v2.rs
@@ -171,10 +171,7 @@ impl SettlementHandler {
         execution: AmmOrderExecution,
         encoder: &mut SettlementEncoder,
     ) -> Result<()> {
-        let (asset_in, amount_in_max) = execution.input_max;
-        let (asset_out, amount_out) = execution.output;
-
-        if let Some(approval) = self.allowances.approve_token(asset_in, amount_in_max)? {
+        if let Some(approval) = self.allowances.approve_token(execution.input_max.clone())? {
             encoder.append_to_execution_plan_internalizable(approval, execution.internalizable);
         }
         encoder.append_to_execution_plan_internalizable(
@@ -182,10 +179,8 @@ impl SettlementHandler {
                 settlement: self.settlement.clone(),
                 vault: self.vault.clone(),
                 pool_id: self.pool_id,
-                asset_in,
-                asset_out,
-                amount_out,
-                amount_in_max,
+                asset_in_max: execution.input_max,
+                asset_out: execution.output,
                 // Balancer pools allow passing additional user data in order to
                 // control pool behaviour for swaps. That being said, weighted pools
                 // do not seem to make use of this at the moment so leave it empty.
@@ -211,7 +206,7 @@ mod tests {
         shared::{
             baseline_solver::BaseTokens,
             dummy_contract,
-            http_solver::model::InternalizationStrategy,
+            http_solver::model::{InternalizationStrategy, TokenAmount},
             interaction::Interaction,
             sources::balancer_v2::pool_fetching::{
                 AmplificationParameter,
@@ -420,8 +415,8 @@ mod tests {
         SettlementHandling::<WeightedProductOrder>::encode(
             &handler,
             AmmOrderExecution {
-                input_max: (H160([0x70; 20]), 10.into()),
-                output: (H160([0x71; 20]), 11.into()),
+                input_max: TokenAmount::new(H160([0x70; 20]), 10),
+                output: TokenAmount::new(H160([0x71; 20]), 1),
                 internalizable: false,
             },
             &mut encoder,
@@ -430,8 +425,8 @@ mod tests {
         SettlementHandling::<WeightedProductOrder>::encode(
             &handler,
             AmmOrderExecution {
-                input_max: (H160([0x71; 20]), 12.into()),
-                output: (H160([0x72; 20]), 13.into()),
+                input_max: TokenAmount::new(H160([0x71; 20]), 12),
+                output: TokenAmount::new(H160([0x72; 20]), 13),
                 internalizable: false,
             },
             &mut encoder,
@@ -453,10 +448,8 @@ mod tests {
                     settlement: settlement.clone(),
                     vault: vault.clone(),
                     pool_id: H256([0x90; 32]),
-                    asset_in: H160([0x70; 20]),
-                    asset_out: H160([0x71; 20]),
-                    amount_out: 11.into(),
-                    amount_in_max: 10.into(),
+                    asset_in_max: TokenAmount::new(H160([0x70; 20]), 10),
+                    asset_out: TokenAmount::new(H160([0x71; 20]), 11),
                     user_data: Default::default(),
                 }
                 .encode(),
@@ -464,10 +457,8 @@ mod tests {
                     settlement,
                     vault,
                     pool_id: H256([0x90; 32]),
-                    asset_in: H160([0x71; 20]),
-                    asset_out: H160([0x72; 20]),
-                    amount_out: 13.into(),
-                    amount_in_max: 12.into(),
+                    asset_in_max: TokenAmount::new(H160([0x71; 20]), 12),
+                    asset_out: TokenAmount::new(H160([0x72; 20]), 13),
                     user_data: Default::default(),
                 }
                 .encode(),

--- a/crates/solver/src/liquidity/zeroex.rs
+++ b/crates/solver/src/liquidity/zeroex.rs
@@ -15,6 +15,7 @@ use {
     primitive_types::{H160, U256},
     shared::{
         ethrpc::Web3,
+        http_solver::model::TokenAmount,
         recent_block_cache::Block,
         zeroex_api::{Order, OrderRecord, OrdersQuery, ZeroExApi},
     },
@@ -195,7 +196,7 @@ impl SettlementHandling<LimitOrder> for OrderSettlementHandler {
         }
         if let Some(approval) = self
             .allowances
-            .approve_token(self.order.taker_token, executed_amount)?
+            .approve_token(TokenAmount::new(self.order.taker_token, executed_amount))?
         {
             encoder.append_to_execution_plan(approval);
         }

--- a/crates/solver/src/solver/baseline_solver.rs
+++ b/crates/solver/src/solver/baseline_solver.rs
@@ -23,6 +23,7 @@ use {
             BaseTokens,
             BaselineSolvable,
         },
+        http_solver::model::TokenAmount,
         sources::{balancer_v2::swap::WeightedPoolRef, uniswap_v2::pool_fetching::Pool},
     },
     std::{collections::HashMap, sync::Arc},
@@ -290,8 +291,8 @@ impl Solution {
                 .get_amount_out(buy_token, (sell_amount, sell_token))
                 .expect("Path was found, so amount must be calculable");
             let execution = slippage.apply_to_amm_execution(AmmOrderExecution {
-                input_max: (sell_token, sell_amount),
-                output: (buy_token, buy_amount),
+                input_max: TokenAmount::new(sell_token, sell_amount),
+                output: TokenAmount::new(buy_token, buy_amount),
                 internalizable: false,
             })?;
             match &amm.order {
@@ -441,8 +442,8 @@ mod tests {
             amm_handler[1].clone().calls()[0],
             slippage
                 .apply_to_amm_execution(AmmOrderExecution {
-                    input_max: (sell_token, 100_000.into()),
-                    output: (native_token, 98_715.into()),
+                    input_max: TokenAmount::new(sell_token, 100_000),
+                    output: TokenAmount::new(native_token, 98_715),
                     internalizable: false
                 })
                 .unwrap(),
@@ -451,8 +452,8 @@ mod tests {
             amm_handler[2].clone().calls()[0],
             slippage
                 .apply_to_amm_execution(AmmOrderExecution {
-                    input_max: (native_token, 98_715.into()),
-                    output: (buy_token, 97_459.into()),
+                    input_max: TokenAmount::new(native_token, 98_715),
+                    output: TokenAmount::new(buy_token, 97_459),
                     internalizable: false
                 })
                 .unwrap(),
@@ -554,8 +555,8 @@ mod tests {
             amm_handler[1].clone().calls()[0],
             slippage
                 .apply_to_amm_execution(AmmOrderExecution {
-                    input_max: (sell_token, 102_660.into()),
-                    output: (native_token, 101_315.into()),
+                    input_max: TokenAmount::new(sell_token, 102_660),
+                    output: TokenAmount::new(native_token, 101_315),
                     internalizable: false
                 })
                 .unwrap(),
@@ -564,8 +565,8 @@ mod tests {
             amm_handler[2].clone().calls()[0],
             slippage
                 .apply_to_amm_execution(AmmOrderExecution {
-                    input_max: (native_token, 101_315.into()),
-                    output: (buy_token, 100_000.into()),
+                    input_max: TokenAmount::new(native_token, 101_315),
+                    output: TokenAmount::new(buy_token, 100_000),
                     internalizable: false
                 })
                 .unwrap(),

--- a/crates/solver/src/solver/http_solver/settlement.rs
+++ b/crates/solver/src/solver/http_solver/settlement.rs
@@ -88,8 +88,8 @@ impl Execution {
             LimitOrder(order) => settlement.with_liquidity(&order.order, order.executed_amount()),
             Amm(executed_amm) => {
                 let execution = slippage.apply_to_amm_execution(AmmOrderExecution {
-                    input_max: executed_amm.input,
-                    output: executed_amm.output,
+                    input_max: executed_amm.input.clone(),
+                    output: executed_amm.output.clone(),
                     internalizable,
                 })?;
                 match &executed_amm.order {
@@ -175,8 +175,8 @@ impl ExecutedLimitOrder {
 #[derive(Clone, Debug)]
 #[cfg_attr(test, derive(PartialEq))]
 struct ExecutedAmm {
-    input: (H160, U256),
-    output: (H160, U256),
+    input: TokenAmount,
+    output: TokenAmount,
     order: Liquidity,
     exec_plan: ExecutionPlan,
 }
@@ -338,8 +338,14 @@ fn match_prepared_and_settled_amms(
                     .copied()
                     .ok_or_else(|| anyhow!("Invalid AMM {}", address))?
                     .clone(),
-                input: (settled.buy_token, settled.exec_buy_amount),
-                output: (settled.sell_token, settled.exec_sell_amount),
+                input: TokenAmount {
+                    token: settled.buy_token,
+                    amount: settled.exec_buy_amount,
+                },
+                output: TokenAmount {
+                    token: settled.sell_token,
+                    amount: settled.exec_sell_amount,
+                },
                 exec_plan: settled.exec_plan,
             })
         })
@@ -704,32 +710,44 @@ mod tests {
         assert_eq!(
             cp_amm_handler.calls(),
             vec![AmmOrderExecution {
-                input_max: (t0, 9.into()),
-                output: (t1, 9.into()),
+                input_max: TokenAmount {
+                    token: t0,
+                    amount: 9.into()
+                },
+                output: TokenAmount {
+                    token: t1,
+                    amount: 9.into()
+                },
                 internalizable: false
             }]
         );
         assert_eq!(
             internal_amm_handler.calls(),
             vec![AmmOrderExecution {
-                input_max: (t0, 2.into()),
-                output: (t1, 1.into()),
+                input_max: TokenAmount {
+                    token: t0,
+                    amount: 2.into()
+                },
+                output: TokenAmount {
+                    token: t1,
+                    amount: 1.into()
+                },
                 internalizable: true
             }]
         );
         assert_eq!(
             wp_amm_handler.calls(),
             vec![AmmOrderExecution {
-                input_max: (t0, 2.into()),
-                output: (t1, 2.into()),
+                input_max: TokenAmount::new(t0, 2),
+                output: TokenAmount::new(t1, 2),
                 internalizable: false
             }]
         );
         assert_eq!(
             sp_amm_handler.calls(),
             vec![AmmOrderExecution {
-                input_max: (t0, 5.into()),
-                output: (t1, 6.into()),
+                input_max: TokenAmount::new(t0, 5),
+                output: TokenAmount::new(t1, 6),
                 internalizable: false
             }]
         );
@@ -992,8 +1010,8 @@ mod tests {
             vec![
                 Execution::Amm(Box::new(ExecutedAmm {
                     order: Liquidity::BalancerWeighted(wpo),
-                    input: (token_c, U256::from(996570293625184642u128)),
-                    output: (token_b, U256::from(354009510372384890u128)),
+                    input: TokenAmount::new(token_c, 996570293625184642u128),
+                    output: TokenAmount::new(token_b, 354009510372384890u128),
                     exec_plan: ExecutionPlan {
                         coordinates: ExecutionPlanCoordinatesModel {
                             sequence: 0,
@@ -1004,8 +1022,8 @@ mod tests {
                 })),
                 Execution::Amm(Box::new(ExecutedAmm {
                     order: Liquidity::ConstantProduct(cpo_0),
-                    input: (token_b, U256::from(354009510372389956u128)),
-                    output: (token_a, U256::from(932415220613609833982u128)),
+                    input: TokenAmount::new(token_b, 354009510372389956u128),
+                    output: TokenAmount::new(token_a, 932415220613609833982u128),
                     exec_plan: ExecutionPlan {
                         coordinates: ExecutionPlanCoordinatesModel {
                             sequence: 0,
@@ -1016,8 +1034,8 @@ mod tests {
                 })),
                 Execution::Amm(Box::new(ExecutedAmm {
                     order: Liquidity::ConstantProduct(cpo_1),
-                    input: (token_c, U256::from(2)),
-                    output: (token_b, U256::from(1)),
+                    input: TokenAmount::new(token_c, 2),
+                    output: TokenAmount::new(token_b, 1),
                     exec_plan: ExecutionPlan {
                         coordinates: ExecutionPlanCoordinatesModel {
                             sequence: 0,
@@ -1028,8 +1046,8 @@ mod tests {
                 })),
                 Execution::Amm(Box::new(ExecutedAmm {
                     order: Liquidity::BalancerStable(spo),
-                    input: (token_c, U256::from(4)),
-                    output: (token_b, U256::from(3)),
+                    input: TokenAmount::new(token_c, 4),
+                    output: TokenAmount::new(token_b, 3),
                     exec_plan: ExecutionPlan {
                         coordinates: ExecutionPlanCoordinatesModel {
                             sequence: 0,
@@ -1056,8 +1074,8 @@ mod tests {
         };
         let executions_amms = vec![ExecutedAmm {
             order: Liquidity::ConstantProduct(cpo_1),
-            input: (token_a, U256::from(2_u8)),
-            output: (token_b, U256::from(1_u8)),
+            input: TokenAmount::new(token_a, 2),
+            output: TokenAmount::new(token_b, 1),
             exec_plan: ExecutionPlan {
                 coordinates: ExecutionPlanCoordinatesModel {
                     sequence: 1u32,

--- a/crates/solver/src/solver/naive_solver.rs
+++ b/crates/solver/src/solver/naive_solver.rs
@@ -146,7 +146,7 @@ mod tests {
             BUY_ETH_ADDRESS,
         },
         num::rational::Ratio,
-        shared::addr,
+        shared::{addr, http_solver::model::TokenAmount},
     };
 
     #[test]
@@ -451,7 +451,10 @@ mod tests {
         };
 
         settle(SlippageContext::default(), orders, liquidity);
-        let (out_token, out_amount) = amm_handler.calls.lock().unwrap()[0].output;
+        let TokenAmount {
+            token: out_token,
+            amount: out_amount,
+        } = amm_handler.calls.lock().unwrap()[0].output;
         assert_eq!(out_token, usdc);
         assert!(out_amount < U256::from(32275540_u128));
     }

--- a/crates/solver/src/solver/naive_solver/multi_order_solver.rs
+++ b/crates/solver/src/solver/naive_solver/multi_order_solver.rs
@@ -9,7 +9,10 @@ use {
     num::{rational::Ratio, BigInt, BigRational, CheckedDiv},
     number_conversions::{big_int_to_u256, big_rational_to_u256, u256_to_big_int},
     primitive_types::U256,
-    shared::conversions::{RatioExt, U256Ext},
+    shared::{
+        conversions::{RatioExt, U256Ext},
+        http_solver::model::TokenAmount,
+    },
     std::collections::HashMap,
     web3::types::Address,
 };
@@ -196,8 +199,8 @@ fn solve_with_uniswap(
             pool,
             slippage
                 .apply_to_amm_execution(AmmOrderExecution {
-                    input_max: (uniswap_in_token, uniswap_in),
-                    output: (uniswap_out_token, uniswap_out_with_rounding),
+                    input_max: TokenAmount::new(uniswap_in_token, uniswap_in),
+                    output: TokenAmount::new(uniswap_out_token, uniswap_out_with_rounding),
                     internalizable: false,
                 })
                 .ok()?,
@@ -396,12 +399,12 @@ mod tests {
 
         // Make sure the uniswap interaction is using the correct direction
         let interaction = amm_handler.calls()[0].clone();
-        assert_eq!(interaction.input_max.0, token_b);
-        assert_eq!(interaction.output.0, token_a);
+        assert_eq!(interaction.input_max.token, token_b);
+        assert_eq!(interaction.output.token, token_a);
 
         // Make sure the sell amounts +/- uniswap interaction satisfy min_buy amounts
-        assert!(orders[0].sell_amount + interaction.output.1 >= orders[1].buy_amount);
-        assert!(orders[1].sell_amount - interaction.input_max.1 > orders[0].buy_amount);
+        assert!(orders[0].sell_amount + interaction.output.amount >= orders[1].buy_amount);
+        assert!(orders[1].sell_amount - interaction.input_max.amount > orders[0].buy_amount);
 
         // Make sure the sell amounts +/- uniswap interaction satisfy expected buy
         // amounts given clearing price
@@ -412,10 +415,10 @@ mod tests {
         // priceB gives us value in buy token We should have at least as much to
         // give (sell amount +/- uniswap) as is expected by the buyer
         let expected_buy = (orders[0].sell_amount * price_a).ceil_div(&price_b);
-        assert!(orders[1].sell_amount - interaction.input_max.1 >= expected_buy);
+        assert!(orders[1].sell_amount - interaction.input_max.amount >= expected_buy);
 
         let expected_buy = (orders[1].sell_amount * price_b).ceil_div(&price_a);
-        assert!(orders[0].sell_amount + interaction.input_max.1 >= expected_buy);
+        assert!(orders[0].sell_amount + interaction.input_max.amount >= expected_buy);
     }
 
     #[test]
@@ -455,13 +458,13 @@ mod tests {
 
         // Make sure the uniswap interaction is using the correct direction
         let interaction = amm_handler.calls()[0].clone();
-        assert_eq!(interaction.input_max.0, token_a);
-        assert_eq!(interaction.output.0, token_b);
+        assert_eq!(interaction.input_max.token, token_a);
+        assert_eq!(interaction.output.token, token_b);
 
         // Make sure the sell amounts cover the uniswap in, and min buy amounts are
         // covered by uniswap out
-        assert!(orders[0].sell_amount + orders[1].sell_amount >= interaction.input_max.1);
-        assert!(interaction.output.1 >= orders[0].buy_amount + orders[1].buy_amount);
+        assert!(orders[0].sell_amount + orders[1].sell_amount >= interaction.input_max.amount);
+        assert!(interaction.output.amount >= orders[0].buy_amount + orders[1].buy_amount);
 
         // Make sure expected buy amounts (given prices) are also covered by uniswap out
         // amounts
@@ -470,7 +473,7 @@ mod tests {
 
         let first_expected_buy = orders[0].sell_amount * price_a / price_b;
         let second_expected_buy = orders[1].sell_amount * price_a / price_b;
-        assert!(interaction.output.1 >= first_expected_buy + second_expected_buy);
+        assert!(interaction.output.amount >= first_expected_buy + second_expected_buy);
     }
 
     #[test]
@@ -510,12 +513,12 @@ mod tests {
 
         // Make sure the uniswap interaction is using the correct direction
         let interaction = amm_handler.calls()[0].clone();
-        assert_eq!(interaction.input_max.0, token_b);
-        assert_eq!(interaction.output.0, token_a);
+        assert_eq!(interaction.input_max.token, token_b);
+        assert_eq!(interaction.output.token, token_a);
 
         // Make sure the buy amounts +/- uniswap interaction satisfy max_sell amounts
-        assert!(orders[0].sell_amount >= orders[1].buy_amount - interaction.output.1);
-        assert!(orders[1].sell_amount >= orders[0].buy_amount + interaction.input_max.1);
+        assert!(orders[0].sell_amount >= orders[1].buy_amount - interaction.output.amount);
+        assert!(orders[1].sell_amount >= orders[0].buy_amount + interaction.input_max.amount);
 
         // Make sure buy sell amounts +/- uniswap interaction satisfy expected sell
         // amounts given clearing price
@@ -526,10 +529,10 @@ mod tests {
         // priceA gives us value in sell token The seller should expect to sell
         // at least as much as we require for the buyer + uniswap.
         let expected_sell = orders[0].buy_amount * price_b / price_a;
-        assert!(orders[1].buy_amount - interaction.input_max.1 <= expected_sell);
+        assert!(orders[1].buy_amount - interaction.input_max.amount <= expected_sell);
 
         let expected_sell = orders[1].buy_amount * price_a / price_b;
-        assert!(orders[0].buy_amount + interaction.output.1 <= expected_sell);
+        assert!(orders[0].buy_amount + interaction.output.amount <= expected_sell);
     }
 
     #[test]
@@ -569,16 +572,16 @@ mod tests {
 
         // Make sure the uniswap interaction is using the correct direction
         let interaction = amm_handler.calls()[0].clone();
-        assert_eq!(interaction.input_max.0, token_b);
-        assert_eq!(interaction.output.0, token_a);
+        assert_eq!(interaction.input_max.token, token_b);
+        assert_eq!(interaction.output.token, token_a);
 
         // Make sure the buy order's sell amount - uniswap interaction satisfies sell
         // order's limit
-        assert!(orders[0].sell_amount >= orders[1].buy_amount - interaction.output.1);
+        assert!(orders[0].sell_amount >= orders[1].buy_amount - interaction.output.amount);
 
         // Make sure the sell order's buy amount + uniswap interaction satisfies buy
         // order's limit
-        assert!(orders[1].buy_amount + interaction.input_max.1 >= orders[0].sell_amount);
+        assert!(orders[1].buy_amount + interaction.input_max.amount >= orders[0].sell_amount);
 
         // Make sure buy sell amounts +/- uniswap interaction satisfy expected sell
         // amounts given clearing price
@@ -589,13 +592,13 @@ mod tests {
         // priceA gives us value in sell token The seller should expect to sell
         // at least as much as we require for the buyer + uniswap.
         let expected_sell = orders[0].buy_amount * price_b / price_a;
-        assert!(orders[1].buy_amount - interaction.input_max.1 <= expected_sell);
+        assert!(orders[1].buy_amount - interaction.input_max.amount <= expected_sell);
 
         // Multiplying sell_amount with priceA, gives us sell value in "$", divided by
         // priceB gives us value in buy token We should have at least as much to
         // give (sell amount + uniswap out) as is expected by the buyer
         let expected_buy = orders[1].sell_amount * price_b / price_a;
-        assert!(orders[0].sell_amount + interaction.output.1 >= expected_buy);
+        assert!(orders[0].sell_amount + interaction.output.amount >= expected_buy);
     }
 
     #[test]
@@ -1042,8 +1045,8 @@ mod tests {
             amm_handler.calls(),
             vec![slippage
                 .apply_to_amm_execution(AmmOrderExecution {
-                    input_max: (token_a, to_wei(40)),
-                    output: (
+                    input_max: TokenAmount::new(token_a, to_wei(40)),
+                    output: TokenAmount::new(
                         token_b,
                         pool.get_amount_out(token_b, (to_wei(40), token_a)).unwrap()
                     ),


### PR DESCRIPTION
Replaced the `(H160, U256)` tuple in `AmmOrderExecution` with `TokenAmount` struct. Also replaced separate `token`, `amount` fields or params with `TokenAmount` in related code.

Fixes #692

# Test Plan

GitHub workflows