### PR TITLE
New tracing logs for debugging Paraswap

### DIFF
--- a/crates/shared/src/paraswap_api.rs
+++ b/crates/shared/src/paraswap_api.rs
@@ -70,7 +70,9 @@ impl ParaswapApi for DefaultParaswapApi {
             Some(limiter) => limiter.execute(request, back_off::on_http_429).await??,
             _ => request.await?,
         };
+        let status = response.status();
         let response_text = response.text().await?;
+        tracing::trace!(%status, %response_text, "Response from Paraswap transaction API");
         parse_paraswap_response_text(&response_text)
     }
 }


### PR DESCRIPTION
We are getting a lot of errors from paraswap that contain the error message: `Err(Other("EOF while parsing a value at line 1))`.https://production-6de61f.kb.eu-central-1.aws.cloud.es.io/app/r/s/kXG8f

In order to understand this error better, I want to see the raw response and introduce the same tracing log as we have it for the price API request.