### PR TITLE
Fix driver e2e test

### DIFF
--- a/crates/driver/src/infra/api/routes/solve/dto/auction.rs
+++ b/crates/driver/src/infra/api/routes/solve/dto/auction.rs
@@ -135,6 +135,7 @@ pub enum Error {
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct Auction {
     id: i64,
+    #[serde_as(as = "HashMap<_, serialize::U256>")]
     prices: HashMap<eth::H160, eth::U256>,
     orders: Vec<Order>,
     deadline: chrono::DateTime<chrono::Utc>,

--- a/crates/driver/src/tests/cases/quote.rs
+++ b/crates/driver/src/tests/cases/quote.rs
@@ -13,6 +13,7 @@ use {
 #[ignore]
 #[tokio::test]
 async fn test() {
+    crate::boundary::initialize_tracing("driver=trace");
     // Set up the uniswap swap.
     let setup::blockchain::Uniswap {
         web3,


### PR DESCRIPTION
Some of my recent changes broke the e2e test:
- Didn't update some field names detected by `deny_unknown_fields` .
- Solution score changes because driver no longer sets gas price. See https://github.com/cowprotocol/services/issues/1196 . Getting the current gas price has to be implemented in the driver.

### Test Plan

manually ran driver e2e tests