### PR TITLE
Optional Chain ID in Baseline Solver Configuration

### DIFF
--- a/crates/solvers/example.baseline.toml
+++ b/crates/solvers/example.baseline.toml
@@ -1,4 +1,5 @@
 chain-id = "1"
-weth = "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2"
+# Alternatively, you can manually specify a WETH contract address:
+#weth = "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2"
 base-tokens = []
 max-hops = 0

--- a/crates/solvers/src/infra/config/baseline/file.rs
+++ b/crates/solvers/src/infra/config/baseline/file.rs
@@ -7,28 +7,28 @@ use {
     tokio::fs,
 };
 
+#[serde_as]
 #[derive(Deserialize)]
 #[serde(rename_all = "kebab-case", deny_unknown_fields)]
 struct Config {
-    #[serde(flatten)]
-    pub contracts: ContractsConfig,
+    /// Optional chain ID. This is used to automatically determine the address
+    /// of the WETH contract.
+    #[serde_as(as = "Option<serialize::ChainId>")]
+    chain_id: Option<eth::ChainId>,
+
+    /// Optional WETH contract address. This can be used to specify a manual
+    /// value **instead** of using the canonical WETH contract for the
+    /// configured chain.
+    weth: Option<H160>,
 
     /// List of base tokens to use when path finding. This defines the tokens
     /// that can appear as intermediate "hops" within a trading route. Note that
     /// WETH is always considered as a base token.
-    pub base_tokens: Vec<eth::H160>,
+    base_tokens: Vec<eth::H160>,
 
     /// The maximum number of hops to consider when finding the optimal trading
     /// path.
-    pub max_hops: usize,
-}
-
-#[serde_as]
-#[derive(Deserialize)]
-#[serde(rename_all = "kebab-case")]
-enum ContractsConfig {
-    ChainId(#[serde_as(as = "serialize::ChainId")] eth::ChainId),
-    Weth(H160),
+    max_hops: usize,
 }
 
 /// Load the driver configuration from a TOML file.
@@ -42,11 +42,18 @@ pub async fn load(path: &Path) -> super::BaselineConfig {
         .unwrap_or_else(|e| panic!("I/O error while reading {path:?}: {e:?}"));
     let config = toml::de::from_str::<Config>(&data)
         .unwrap_or_else(|e| panic!("TOML syntax error while reading {path:?}: {e:?}"));
-    let contracts = match config.contracts {
-        ContractsConfig::ChainId(chain_id) => contracts::Contracts::for_chain(chain_id),
-        ContractsConfig::Weth(weth) => contracts::Contracts {
+    let contracts = match (config.chain_id, config.weth) {
+        (Some(chain_id), None) => contracts::Contracts::for_chain(chain_id),
+        (None, Some(weth)) => contracts::Contracts {
             weth: eth::WethAddress(weth),
         },
+        (Some(_), Some(_)) => panic!(
+            "invalid configuration: cannot specify both `chain-id` and `weth` configuration \
+             options",
+        ),
+        (None, None) => panic!(
+            "invalid configuration: must specify either `chain-id` or `weth` configuration options",
+        ),
     };
 
     super::BaselineConfig {

--- a/crates/solvers/src/infra/config/baseline/mod.rs
+++ b/crates/solvers/src/infra/config/baseline/mod.rs
@@ -3,8 +3,7 @@ use crate::domain::eth;
 pub mod file;
 
 pub struct BaselineConfig {
-    pub chain_id: eth::ChainId,
-    pub weth: Option<eth::WethAddress>,
+    pub weth: eth::WethAddress,
     pub base_tokens: Vec<eth::TokenAddress>,
     pub max_hops: usize,
 }

--- a/crates/solvers/src/infra/contracts.rs
+++ b/crates/solvers/src/infra/contracts.rs
@@ -2,30 +2,19 @@ use crate::domain::eth;
 
 #[derive(Clone, Debug)]
 pub struct Contracts {
-    weth: eth::WethAddress,
-}
-
-#[derive(Clone, Copy, Debug, Default)]
-pub struct Addresses {
-    pub weth: Option<eth::WethAddress>,
+    pub weth: eth::WethAddress,
 }
 
 impl Contracts {
-    pub fn new(chain: eth::ChainId, addresses: Addresses) -> Self {
+    pub fn for_chain(chain: eth::ChainId) -> Self {
         Self {
-            weth: addresses.weth.unwrap_or_else(|| {
-                eth::WethAddress(
-                    contracts::WETH9::raw_contract()
-                        .networks
-                        .get(chain.network_id())
-                        .expect("contract address for all supported chains")
-                        .address,
-                )
-            }),
+            weth: eth::WethAddress(
+                contracts::WETH9::raw_contract()
+                    .networks
+                    .get(chain.network_id())
+                    .expect("contract address for all supported chains")
+                    .address,
+            ),
         }
-    }
-
-    pub fn weth(&self) -> &eth::WethAddress {
-        &self.weth
     }
 }

--- a/crates/solvers/src/run.rs
+++ b/crates/solvers/src/run.rs
@@ -3,7 +3,7 @@ use tokio::signal::unix::{self, SignalKind};
 use {
     crate::{
         domain::baseline,
-        infra::{cli, config, contracts},
+        infra::{cli, config},
     },
     clap::Parser,
     std::net::SocketAddr,
@@ -19,16 +19,10 @@ pub async fn run(args: impl Iterator<Item = String>, bind: Option<oneshot::Sende
     // being executed
     let cli::Command::Baseline = args.command;
     let baseline = config::baseline::file::load(&args.config).await;
-    let contracts = contracts::Contracts::new(
-        baseline.chain_id,
-        contracts::Addresses {
-            weth: baseline.weth,
-        },
-    );
     crate::api::Api {
         addr: args.addr,
         solver: baseline::Baseline {
-            weth: *contracts.weth(),
+            weth: baseline.weth,
             base_tokens: baseline.base_tokens.into_iter().collect(),
             max_hops: baseline.max_hops,
         },


### PR DESCRIPTION
@vkgnosis pointed out in #1202 that the chain ID parameter being mandatory is not practical for local deployments or when testing out on new chains.

In fact, the baseline solver only needs to know the WETH address, so this PR changes the configuration semantics to require either:
- specifying a `chain-id` to use the canonical WETH contract for that chain.
- specify a custom `weth` address to use that instead, at which point the `ChainId` is no longer needed

### Test Plan

Adjusted test loading the example TOML configuration.
