### PR TITLE
Make Solver Competition Deserialization Backwards Compatible

### DIFF
--- a/crates/model/src/solver_competition.rs
+++ b/crates/model/src/solver_competition.rs
@@ -76,6 +76,7 @@ pub struct CompetitionAuction {
 #[serde(rename_all = "camelCase")]
 pub struct SolverSettlement {
     pub solver: String,
+    #[serde(default)]
     pub solver_address: H160,
     pub objective: Objective,
     #[serde_as(as = "BTreeMap<_, DecimalU256>")]


### PR DESCRIPTION
This PR makes the solver competition endpoint backwards compatible, otherwise we are unable to request historic data.

### Test Plan

The One Compiler To Rule Them All (i.e. `rustc`).