### PR TITLE
toolchain-config: Using channel with a specified version

### DIFF
--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "stable"
+channel = "1.67.0"
 components = ["clippy", "rustfmt"]
 profile = "minimal"


### PR DESCRIPTION
I have installed already 1.67.1 locally. With the current configuration, toolchain-config would pick 1.67.1 as the latest stable version, instead of 1.67.0 - even after running `rustup default 1.67.0` as the toolchain config file would overwrite this rustup default.

How do you guys do it?

### Test Plan
