### PR TITLE
Get gas price in driver

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1197,6 +1197,7 @@ name = "driver"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "approx",
  "async-trait",
  "axum",
  "bigdecimal",
@@ -1226,6 +1227,7 @@ dependencies = [
  "serde_with 2.0.1",
  "shared",
  "solver",
+ "tap",
  "thiserror",
  "tokio",
  "toml 0.7.0",

--- a/crates/driver/Cargo.toml
+++ b/crates/driver/Cargo.toml
@@ -58,8 +58,10 @@ shared = { path = "../shared" }
 solver = { path = "../solver" }
 tracing = { workspace = true }
 warp = { workspace = true }
+tap = "1.0.1"
 
 [dev-dependencies]
+approx = "0.5"
 maplit = { workspace = true }
 mockall = { workspace = true }
 tokio = { workspace = true, features = ["test-util"] }

--- a/crates/driver/src/infra/api/error.rs
+++ b/crates/driver/src/infra/api/error.rs
@@ -85,6 +85,7 @@ impl From<api::routes::AuctionError> for axum::Json<Error> {
         let error = match value {
             api::routes::AuctionError::InvalidAuctionId => Kind::InvalidAuctionId,
             api::routes::AuctionError::MissingSurplusFee => Kind::MissingSurplusFee,
+            api::routes::AuctionError::GasPrice(_) => Kind::Unknown,
         };
         error.into()
     }

--- a/crates/driver/src/infra/api/routes/solve/mod.rs
+++ b/crates/driver/src/infra/api/routes/solve/mod.rs
@@ -1,8 +1,10 @@
-use crate::infra::api::{Error, State};
-
 mod dto;
 
 pub use dto::AuctionError;
+use {
+    crate::infra::api::{Error, State},
+    tap::TapFallible,
+};
 
 pub(in crate::infra::api) fn solve(router: axum::Router<State>) -> axum::Router<State> {
     router.route("/solve", axum::routing::post(route))
@@ -12,8 +14,12 @@ async fn route(
     state: axum::extract::State<State>,
     auction: axum::Json<dto::Auction>,
 ) -> Result<axum::Json<dto::Solution>, axum::Json<Error>> {
-    let auction = auction.0.into_domain()?;
+    let auction = auction.0.into_domain(state.eth()).await.tap_err(|err| {
+        tracing::warn!(?err, "error creating auction");
+    })?;
     let competition = state.competition();
-    let (solution_id, score) = competition.solve(&auction).await?;
+    let (solution_id, score) = competition.solve(&auction).await.tap_err(|err| {
+        tracing::warn!(?err, "error solving auction");
+    })?;
     Ok(axum::Json(dto::Solution::from_domain(solution_id, score)))
 }

--- a/crates/driver/src/infra/blockchain/mod.rs
+++ b/crates/driver/src/infra/blockchain/mod.rs
@@ -124,6 +124,15 @@ impl Ethereum {
             .map_err(Into::into)
     }
 
+    pub async fn gas_price(&self) -> Result<eth::EffectiveGasPrice, Error> {
+        self.web3
+            .eth()
+            .gas_price()
+            .await
+            .map(Into::into)
+            .map_err(Into::into)
+    }
+
     fn into_request(tx: eth::Tx) -> web3::types::TransactionRequest {
         web3::types::TransactionRequest {
             from: tx.from.into(),


### PR DESCRIPTION
Fixes #1196 .

The driver was not fetching gas prices but they are required for the solvers.

- Add some logging to the `route` function. This is useful because it doesn't make sense to report on all errors in detail through the autopilot-driver API but we do want to log them for debugging.
- Change the score comparison in the test to be approximate. Required because the computed score is not deterministic (unrelated to my change). The test fails if the score deviates by more than 1% from the expected value.

### Test Plan

run the changed test
