### PR TITLE
Use configured contract addresses

### DIFF
--- a/crates/solver/src/lib.rs
+++ b/crates/solver/src/lib.rs
@@ -24,9 +24,3 @@ pub mod settlement_submission;
 pub mod solver;
 #[cfg(test)]
 mod test;
-
-use {anyhow::Result, shared::ethrpc::Web3};
-
-pub async fn get_settlement_contract(web3: &Web3) -> Result<contracts::GPv2Settlement> {
-    Ok(contracts::GPv2Settlement::deployed(web3).await?)
-}

--- a/crates/solver/src/settlement_submission/submitter.rs
+++ b/crates/solver/src/settlement_submission/submitter.rs
@@ -722,7 +722,7 @@ mod tests {
             .transaction_count(account.address(), None)
             .await
             .unwrap();
-        let contract = crate::get_settlement_contract(&web3).await.unwrap();
+        let contract = GPv2Settlement::deployed(&web3).await.unwrap();
         let flashbots_api = FlashbotsApi::new(Client::new(), "https://rpc.flashbots.net").unwrap();
         let mut header = reqwest::header::HeaderMap::new();
         header.insert(


### PR DESCRIPTION
Like with other crates this allows use to use the solver main function in e2e tests.

### Test Plan

still compiles, no logic change if argument isn't specified