### PR TITLE
Refactoring cow subsidy

### DIFF
--- a/crates/autopilot/src/lib.rs
+++ b/crates/autopilot/src/lib.rs
@@ -473,6 +473,7 @@ pub async fn main(args: arguments::Arguments) -> ! {
             token,
             vtoken,
             args.order_quoting.cow_fee_factors.unwrap_or_default(),
+            balance_fetcher.clone(),
         )
     });
     let liquidity_order_owners: HashSet<_> = args

--- a/crates/database/src/onchain_broadcasted_orders.rs
+++ b/crates/database/src/onchain_broadcasted_orders.rs
@@ -14,6 +14,7 @@ pub enum OnchainOrderPlacementError {
     ValidToTooFarInFuture,
     InvalidOrderData,
     InsufficientFee,
+    UnavailableSubsidy,
     Other,
 }
 
@@ -27,6 +28,7 @@ impl OnchainOrderPlacementError {
             Self::ValidToTooFarInFuture => "expired",
             Self::InvalidOrderData => "invalid_data",
             Self::InsufficientFee => "low_fee",
+            Self::UnavailableSubsidy => "unavailable_subsidy",
             Self::Other => "unspecified",
         }
     }

--- a/crates/model/src/order.rs
+++ b/crates/model/src/order.rs
@@ -555,6 +555,7 @@ pub enum OnchainOrderPlacementError {
     // together
     InvalidQuote,
     InsufficientFee,
+    UnavailableSubsidy,
     // In case order data is invalid - e.g. signature type EIP-712 for
     // onchain orders - this error is returned
     InvalidOrderData,

--- a/crates/orderbook/src/api/post_order.rs
+++ b/crates/orderbook/src/api/post_order.rs
@@ -176,6 +176,10 @@ impl IntoWarpReply for ValidationErrorWrapper {
                 error("TooManyLimitOrders", "Too many limit orders"),
                 StatusCode::BAD_REQUEST,
             ),
+            ValidationError::UnavailableSubsidy(err) => {
+                tracing::error!(?err, "Subsidy could not be calculated");
+                shared::api::internal_error_reply()
+            }
             ValidationError::Other(err) => {
                 tracing::error!(?err, "ValidationErrorWrapper");
                 shared::api::internal_error_reply()

--- a/crates/orderbook/src/run.rs
+++ b/crates/orderbook/src/run.rs
@@ -26,6 +26,7 @@ use {
             trace_call::TraceCallDetector,
         },
         baseline_solver::BaseTokens,
+        caching_balance_fetcher::CachingBalanceFetcher,
         code_fetching::CachedCodeFetcher,
         fee_subsidy::{
             config::FeeSubsidyConfiguration,
@@ -129,6 +130,7 @@ pub async fn run(args: Arguments) {
         vault_relayer,
         settlement_contract.address(),
     ));
+    let caching_balance_fetcher = Arc::new(CachingBalanceFetcher::new(balance_fetcher.clone()));
 
     let gas_price_estimator = Arc::new(InstrumentedGasEstimator::new(
         shared::gas_price_estimation::create_priority_estimator(
@@ -378,6 +380,7 @@ pub async fn run(args: Arguments) {
             token,
             vtoken,
             args.order_quoting.cow_fee_factors.unwrap_or_default(),
+            caching_balance_fetcher,
         )
     });
 

--- a/crates/shared/src/db_order_conversions.rs
+++ b/crates/shared/src/db_order_conversions.rs
@@ -182,6 +182,9 @@ pub fn onchain_order_placement_error_from(
         Some(DbOnchainOrderPlacementError::InsufficientFee) => {
             Some(OnchainOrderPlacementError::InsufficientFee)
         }
+        Some(DbOnchainOrderPlacementError::UnavailableSubsidy) => {
+            Some(OnchainOrderPlacementError::UnavailableSubsidy)
+        }
         Some(DbOnchainOrderPlacementError::Other) => Some(OnchainOrderPlacementError::Other),
         None => None,
     }

--- a/crates/shared/src/order_quoting.rs
+++ b/crates/shared/src/order_quoting.rs
@@ -355,6 +355,9 @@ pub enum FindQuoteError {
     #[error("quote expired")]
     Expired(DateTime<Utc>),
 
+    #[error("subsidy calcuation failed")]
+    UnavailableSubsidy(anyhow::Error),
+
     #[error(transparent)]
     Other(#[from] anyhow::Error),
 }
@@ -631,7 +634,7 @@ impl OrderQuoting for OrderQuoter {
             quote,
             self.fee_subsidy
                 .subsidy(subsidy)
-                .map_err(FindQuoteError::from)
+                .map_err(FindQuoteError::UnavailableSubsidy)
         )?;
 
         let quote = quote.with_subsidy_and_signing_scheme(&subsidy, signing_scheme);

--- a/crates/shared/src/order_validation.rs
+++ b/crates/shared/src/order_validation.rs
@@ -121,6 +121,7 @@ pub enum ValidationError {
     ZeroAmount,
     IncompatibleSigningScheme,
     TooManyLimitOrders,
+    UnavailableSubsidy(anyhow::Error),
     Other(anyhow::Error),
 }
 
@@ -130,6 +131,7 @@ pub fn onchain_order_placement_error_from(error: ValidationError) -> OnchainOrde
         ValidationError::Partial(_) => OnchainOrderPlacementError::PreValidationError,
         ValidationError::InvalidQuote => OnchainOrderPlacementError::InvalidQuote,
         ValidationError::InsufficientFee => OnchainOrderPlacementError::InsufficientFee,
+        ValidationError::UnavailableSubsidy(_) => OnchainOrderPlacementError::UnavailableSubsidy,
         _ => OnchainOrderPlacementError::Other,
     }
 }
@@ -149,6 +151,7 @@ impl From<FindQuoteError> for ValidationError {
         match err {
             FindQuoteError::NotFound(_) => Self::QuoteNotFound,
             FindQuoteError::ParameterMismatch(_) | FindQuoteError::Expired(_) => Self::InvalidQuote,
+            FindQuoteError::UnavailableSubsidy(err) => Self::UnavailableSubsidy(err),
             FindQuoteError::Other(err) => Self::Other(err),
         }
     }


### PR DESCRIPTION
Fixes #1176 as discussed in the issue.

Since the cached balance fetcher is more error-prone, I am escalating a new error: UnavailableSubsidy through the onchain order parsing logic. This is likely then a temporary issue with the nodes and I just stop indexing by escalating the error to the highest level and the indexer is then no longer updating the most recent block. If then later the node connection is healthy again, then the indexing will be restarted successfully in a new indexing loop.

### Test Plan
