### PR TITLE
Check Chain ID on Startup

### DIFF
--- a/crates/autopilot/src/lib.rs
+++ b/crates/autopilot/src/lib.rs
@@ -159,6 +159,13 @@ pub async fn main(args: arguments::Arguments) {
         .await
         .expect("Could not get chainId")
         .as_u64();
+    if let Some(expected_chain_id) = args.shared.chain_id {
+        assert_eq!(
+            chain_id, expected_chain_id,
+            "connected to node with incorrect chain ID",
+        );
+    }
+
     let network = web3
         .net()
         .version()

--- a/crates/autopilot/src/lib.rs
+++ b/crates/autopilot/src/lib.rs
@@ -116,6 +116,19 @@ pub async fn main(args: arguments::Arguments) {
         "base",
     );
 
+    let chain_id = web3
+        .eth()
+        .chain_id()
+        .await
+        .expect("Could not get chainId")
+        .as_u64();
+    if let Some(expected_chain_id) = args.shared.chain_id {
+        assert_eq!(
+            chain_id, expected_chain_id,
+            "connected to node with incorrect chain ID",
+        );
+    }
+
     let current_block_stream = args
         .shared
         .current_block
@@ -152,19 +165,6 @@ pub async fn main(args: arguments::Arguments) {
         Err(DeployError::NotFound(_)) => None,
         other => Some(other.unwrap()),
     };
-
-    let chain_id = web3
-        .eth()
-        .chain_id()
-        .await
-        .expect("Could not get chainId")
-        .as_u64();
-    if let Some(expected_chain_id) = args.shared.chain_id {
-        assert_eq!(
-            chain_id, expected_chain_id,
-            "connected to node with incorrect chain ID",
-        );
-    }
 
     let network = web3
         .net()

--- a/crates/orderbook/src/run.rs
+++ b/crates/orderbook/src/run.rs
@@ -92,12 +92,20 @@ pub async fn run(args: Arguments) {
             .await
             .expect("load native token contract"),
     };
+
     let chain_id = web3
         .eth()
         .chain_id()
         .await
         .expect("Could not get chainId")
         .as_u64();
+    if let Some(expected_chain_id) = args.shared.chain_id {
+        assert_eq!(
+            chain_id, expected_chain_id,
+            "connected to node with incorrect chain ID",
+        );
+    }
+
     let network = web3
         .net()
         .version()

--- a/crates/orderbook/src/run.rs
+++ b/crates/orderbook/src/run.rs
@@ -75,6 +75,20 @@ pub async fn run(args: Arguments) {
         &args.shared.node_url,
         "base",
     );
+
+    let chain_id = web3
+        .eth()
+        .chain_id()
+        .await
+        .expect("Could not get chainId")
+        .as_u64();
+    if let Some(expected_chain_id) = args.shared.chain_id {
+        assert_eq!(
+            chain_id, expected_chain_id,
+            "connected to node with incorrect chain ID",
+        );
+    }
+
     let settlement_contract = match args.shared.settlement_contract_address {
         Some(address) => contracts::GPv2Settlement::with_deployment_info(&web3, address, None),
         None => contracts::GPv2Settlement::deployed(&web3)
@@ -92,19 +106,6 @@ pub async fn run(args: Arguments) {
             .await
             .expect("load native token contract"),
     };
-
-    let chain_id = web3
-        .eth()
-        .chain_id()
-        .await
-        .expect("Could not get chainId")
-        .as_u64();
-    if let Some(expected_chain_id) = args.shared.chain_id {
-        assert_eq!(
-            chain_id, expected_chain_id,
-            "connected to node with incorrect chain ID",
-        );
-    }
 
     let network = web3
         .net()

--- a/crates/refunder/src/arguments.rs
+++ b/crates/refunder/src/arguments.rs
@@ -1,7 +1,7 @@
 use {
     clap::Parser,
     ethcontract::H160,
-    shared::{ethrpc, http_client, logging_args_with_default_filter},
+    shared::{arguments::display_option, ethrpc, http_client, logging_args_with_default_filter},
     std::time::Duration,
     tracing::level_filters::LevelFilter,
     url::Url,
@@ -46,6 +46,12 @@ pub struct Arguments {
     #[clap(long, env, default_value = "http://localhost:8545")]
     pub node_url: Url,
 
+    /// The expected chain ID that the services are expected to run against.
+    /// This can be optionally specified in order to check at startup whether
+    /// the connected nodes match to detect misconfigurations.
+    #[clap(long, env)]
+    pub chain_id: Option<u64>,
+
     /// Address of the ethflow contract
     #[clap(long, env)]
     pub ethflow_contract: H160,
@@ -66,6 +72,7 @@ impl std::fmt::Display for Arguments {
         writeln!(f, "min_slippage_bps: {}", self.min_slippage_bps)?;
         writeln!(f, "db_url: SECRET")?;
         writeln!(f, "node_url: {}", self.node_url)?;
+        display_option(f, "chain_id", &self.chain_id)?;
         writeln!(f, "ethflow_contract: {:?}", self.ethflow_contract)?;
         writeln!(f, "refunder_pk: SECRET")?;
         writeln!(f, "metrics_port: {}", self.metrics_port)?;

--- a/crates/refunder/src/lib.rs
+++ b/crates/refunder/src/lib.rs
@@ -19,6 +19,21 @@ const LOOP_INTERVAL: Duration = Duration::from_secs(30);
 const DELAY_FROM_LAST_LOOP_BEFORE_UNHEALTHY: Duration = LOOP_INTERVAL.saturating_mul(4);
 
 pub async fn main(args: arguments::Arguments) {
+    let http_factory = HttpClientFactory::new(&args.http_client);
+    let web3 = shared::ethrpc::web3(&args.ethrpc, &http_factory, &args.node_url, "base");
+    if let Some(expected_chain_id) = args.chain_id {
+        let chain_id = web3
+            .eth()
+            .chain_id()
+            .await
+            .expect("Could not get chainId")
+            .as_u64();
+        assert_eq!(
+            chain_id, expected_chain_id,
+            "connected to node with incorrect chain ID",
+        );
+    }
+
     let pg_pool = PgPool::connect_lazy(args.db_url.as_str()).expect("failed to create database");
 
     let liveness = Arc::new(Liveness {
@@ -27,8 +42,6 @@ pub async fn main(args: arguments::Arguments) {
     });
     shared::metrics::serve_metrics(liveness.clone(), ([0, 0, 0, 0], args.metrics_port).into());
 
-    let http_factory = HttpClientFactory::new(&args.http_client);
-    let web3 = shared::ethrpc::web3(&args.ethrpc, &http_factory, &args.node_url, "base");
     let ethflow_contract = CoWSwapEthFlow::at(&web3, args.ethflow_contract);
     let refunder_account = Account::Offline(args.refunder_pk.parse::<PrivateKey>().unwrap(), None);
     let mut refunder = RefundService::new(

--- a/crates/shared/src/arguments.rs
+++ b/crates/shared/src/arguments.rs
@@ -174,6 +174,12 @@ pub struct Arguments {
     #[clap(long, env, default_value = "http://localhost:8545")]
     pub node_url: Url,
 
+    /// The expected chain ID that the services are expected to run against.
+    /// This can be optionally specified in order to check at startup whether
+    /// the connected nodes match to detect misconfigurations.
+    #[clap(long, env)]
+    pub chain_id: Option<u64>,
+
     /// Which gas estimators to use. Multiple estimators are used in sequence if
     /// a previous one fails. Individual estimators support different
     /// networks. `EthGasStation`: supports mainnet.
@@ -399,6 +405,7 @@ impl Display for Arguments {
             self.logging.log_stderr_threshold
         )?;
         writeln!(f, "node_url: {}", self.node_url)?;
+        display_option(f, "chain_id", &self.chain_id)?;
         writeln!(f, "gas_estimators: {:?}", self.gas_estimators)?;
         display_secret_option(f, "blocknative_api_key", &self.blocknative_api_key)?;
         writeln!(f, "base_tokens: {:?}", self.base_tokens)?;

--- a/crates/solver/src/driver.rs
+++ b/crates/solver/src/driver.rs
@@ -346,10 +346,7 @@ impl Driver {
                             .to_f64()
                             .unwrap_or(f64::NAN),
                         surplus: rated_settlement.surplus.to_f64().unwrap_or(f64::NAN),
-                        fees: rated_settlement
-                            .solver_fees
-                            .to_f64()
-                            .unwrap_or(f64::NAN),
+                        fees: rated_settlement.solver_fees.to_f64().unwrap_or(f64::NAN),
                         cost: rated_settlement.gas_estimate.to_f64_lossy()
                             * rated_settlement.gas_price.to_f64().unwrap_or(f64::NAN),
                         gas: rated_settlement.gas_estimate.low_u64(),

--- a/crates/solver/src/run.rs
+++ b/crates/solver/src/run.rs
@@ -40,7 +40,7 @@ use {
     shared::{
         baseline_solver::BaseTokens,
         code_fetching::CachedCodeFetcher,
-        ethrpc::{self},
+        ethrpc,
         gelato_api::GelatoClient,
         http_client::HttpClientFactory,
         maintenance::{Maintaining, ServiceMaintenance},
@@ -76,12 +76,20 @@ pub async fn run(args: Arguments) {
         &args.shared.node_url,
         "base",
     );
+
     let chain_id = web3
         .eth()
         .chain_id()
         .await
         .expect("Could not get chainId")
         .as_u64();
+    if let Some(expected_chain_id) = args.shared.chain_id {
+        assert_eq!(
+            chain_id, expected_chain_id,
+            "connected to node with incorrect chain ID",
+        );
+    }
+
     let network_id = web3
         .net()
         .version()


### PR DESCRIPTION
A couple of times, we have accidentally connected services meant for Goerli to Mainnet. This leads to a bunch of events getting indexed in the wrong database and is very painful to cleanup.

This PR adds a chain ID sanity check on start up to prevent this from happening.

### Test Plan

```
% cargo run -p autopilot -- --node-url https://goerli.infura.io/v3/$INFURA_PROJECT_ID --chain-id 6
...
2023-02-15T15:40:45.363Z ERROR shared::tracing: thread 'main' panicked at 'assertion failed: `(left == right)`
  left: `5`,
 right: `6`: connected to node with incorrect chain ID'
```

### Release Notes

We should configure the `CHAIN_ID` environment variable on all our pods.