### PR TITLE
Custom 'solve' URL Path for HTTP Solvers

### DIFF
--- a/crates/shared/src/http_solver.rs
+++ b/crates/shared/src/http_solver.rs
@@ -62,6 +62,9 @@ pub struct DefaultHttpSolverApi {
     /// Base solver url.
     pub base: Url,
 
+    /// The custom URL path used for the solve request.
+    pub custom_solve_path: Option<String>,
+
     /// An async HTTP client instance that will be used to interact with the
     /// solver.
     pub client: Client,
@@ -117,7 +120,8 @@ impl HttpSolverApi for DefaultHttpSolverApi {
             .checked_sub(Duration::from_secs(1))
             .context("no time left to send request")?;
 
-        let mut url = self.base.join("solve").context("join base")?;
+        let path = self.custom_solve_path.as_deref().unwrap_or("solve");
+        let mut url = self.base.join(path).context("join base")?;
 
         let maybe_auction_id = model.metadata.as_ref().and_then(|data| data.auction_id);
         let instance_name = self.generate_instance_name(maybe_auction_id.unwrap_or(0));
@@ -275,6 +279,7 @@ HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Encoding: gzip\r\n\
             network_name: Default::default(),
             chain_id: Default::default(),
             base: "http://localhost:1234".parse().unwrap(),
+            custom_solve_path: None,
             client: Default::default(),
             config: Default::default(),
         };

--- a/crates/shared/src/http_solver.rs
+++ b/crates/shared/src/http_solver.rs
@@ -63,7 +63,7 @@ pub struct DefaultHttpSolverApi {
     pub base: Url,
 
     /// The custom URL path used for the solve request.
-    pub custom_solve_path: Option<String>,
+    pub solve_path: String,
 
     /// An async HTTP client instance that will be used to interact with the
     /// solver.
@@ -120,8 +120,7 @@ impl HttpSolverApi for DefaultHttpSolverApi {
             .checked_sub(Duration::from_secs(1))
             .context("no time left to send request")?;
 
-        let path = self.custom_solve_path.as_deref().unwrap_or("solve");
-        let mut url = self.base.join(path).context("join base")?;
+        let mut url = self.base.join(&self.solve_path).context("join base")?;
 
         let maybe_auction_id = model.metadata.as_ref().and_then(|data| data.auction_id);
         let instance_name = self.generate_instance_name(maybe_auction_id.unwrap_or(0));
@@ -279,7 +278,7 @@ HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Encoding: gzip\r\n\
             network_name: Default::default(),
             chain_id: Default::default(),
             base: "http://localhost:1234".parse().unwrap(),
-            custom_solve_path: None,
+            solve_path: "solve".to_owned(),
             client: Default::default(),
             config: Default::default(),
         };

--- a/crates/shared/src/price_estimation.rs
+++ b/crates/shared/src/price_estimation.rs
@@ -133,6 +133,10 @@ pub struct Arguments {
     #[clap(long, env)]
     pub yearn_solver_url: Option<Url>,
 
+    /// The API path to use for solving.
+    #[clap(long, env, default_value = "solve")]
+    pub yearn_solver_path: String,
+
     /// The API endpoint for the Balancer SOR API for solving.
     #[clap(long, env)]
     pub balancer_sor_url: Option<Url>,
@@ -190,6 +194,7 @@ impl Display for Arguments {
         )?;
         display_option(f, "quasimodo_solver_url", &self.quasimodo_solver_url)?;
         display_option(f, "yearn_solver_url", &self.yearn_solver_url)?;
+        writeln!(f, "yearn_solver_path: {}", self.yearn_solver_path)?;
         display_option(f, "balancer_sor_url", &self.balancer_sor_url)?;
         display_option(
             f,

--- a/crates/shared/src/price_estimation/factory.rs
+++ b/crates/shared/src/price_estimation/factory.rs
@@ -221,7 +221,7 @@ impl<'a> PriceEstimatorFactory<'a> {
                         .yearn_solver_url
                         .clone()
                         .context("yearn solver url not specified")?,
-                    "quote".to_owned(),
+                    self.args.yearn_solver_path.clone(),
                 ),
             ),
             PriceEstimatorType::BalancerSor => self.create_estimator_entry::<BalancerSor>(kind, ()),

--- a/crates/shared/src/price_estimation/factory.rs
+++ b/crates/shared/src/price_estimation/factory.rs
@@ -203,20 +203,26 @@ impl<'a> PriceEstimatorFactory<'a> {
             }
             PriceEstimatorType::Quasimodo => self.create_estimator_entry::<HttpPriceEstimator>(
                 kind,
-                self.args
-                    .quasimodo_solver_url
-                    .clone()
-                    .context("quasimodo solver url not specified")?,
+                (
+                    self.args
+                        .quasimodo_solver_url
+                        .clone()
+                        .context("quasimodo solver url not specified")?,
+                    None,
+                ),
             ),
             PriceEstimatorType::OneInch => {
                 self.create_estimator_entry::<OneInchPriceEstimator>(kind, ())
             }
             PriceEstimatorType::Yearn => self.create_estimator_entry::<HttpPriceEstimator>(
                 kind,
-                self.args
-                    .yearn_solver_url
-                    .clone()
-                    .context("yearn solver url not specified")?,
+                (
+                    self.args
+                        .yearn_solver_url
+                        .clone()
+                        .context("yearn solver url not specified")?,
+                    Some("quote".to_owned()),
+                ),
             ),
             PriceEstimatorType::BalancerSor => self.create_estimator_entry::<BalancerSor>(kind, ()),
         }
@@ -489,12 +495,12 @@ impl PriceEstimatorCreating for BalancerSor {
 }
 
 impl PriceEstimatorCreating for HttpPriceEstimator {
-    type Params = Url;
+    type Params = (Url, Option<String>);
 
     fn init(
         factory: &PriceEstimatorFactory,
         kind: PriceEstimatorType,
-        base: Self::Params,
+        (base, custom_solve_path): Self::Params,
     ) -> Result<Self> {
         Ok(HttpPriceEstimator::new(
             Arc::new(DefaultHttpSolverApi {
@@ -502,6 +508,7 @@ impl PriceEstimatorCreating for HttpPriceEstimator {
                 network_name: factory.network.name.clone(),
                 chain_id: factory.network.chain_id,
                 base,
+                custom_solve_path,
                 client: factory.components.http_factory.create(),
                 config: SolverConfig {
                     use_internal_buffers: Some(factory.shared_args.use_internal_buffers),

--- a/crates/shared/src/price_estimation/factory.rs
+++ b/crates/shared/src/price_estimation/factory.rs
@@ -208,7 +208,7 @@ impl<'a> PriceEstimatorFactory<'a> {
                         .quasimodo_solver_url
                         .clone()
                         .context("quasimodo solver url not specified")?,
-                    None,
+                    "solve".to_owned(),
                 ),
             ),
             PriceEstimatorType::OneInch => {
@@ -221,7 +221,7 @@ impl<'a> PriceEstimatorFactory<'a> {
                         .yearn_solver_url
                         .clone()
                         .context("yearn solver url not specified")?,
-                    Some("quote".to_owned()),
+                    "quote".to_owned(),
                 ),
             ),
             PriceEstimatorType::BalancerSor => self.create_estimator_entry::<BalancerSor>(kind, ()),
@@ -495,12 +495,12 @@ impl PriceEstimatorCreating for BalancerSor {
 }
 
 impl PriceEstimatorCreating for HttpPriceEstimator {
-    type Params = (Url, Option<String>);
+    type Params = (Url, String);
 
     fn init(
         factory: &PriceEstimatorFactory,
         kind: PriceEstimatorType,
-        (base, custom_solve_path): Self::Params,
+        (base, solve_path): Self::Params,
     ) -> Result<Self> {
         Ok(HttpPriceEstimator::new(
             Arc::new(DefaultHttpSolverApi {
@@ -508,7 +508,7 @@ impl PriceEstimatorCreating for HttpPriceEstimator {
                 network_name: factory.network.name.clone(),
                 chain_id: factory.network.chain_id,
                 base,
-                custom_solve_path,
+                solve_path,
                 client: factory.components.http_factory.create(),
                 config: SolverConfig {
                     use_internal_buffers: Some(factory.shared_args.use_internal_buffers),

--- a/crates/shared/src/price_estimation/http.rs
+++ b/crates/shared/src/price_estimation/http.rs
@@ -776,7 +776,7 @@ mod tests {
                 network_name: "1".to_string(),
                 chain_id: 1,
                 base: Url::parse(&quasimodo_url).expect("failed to parse quasimodo url"),
-                custom_solve_path: None,
+                solve_path: "solve".to_owned(),
                 client,
                 config: SolverConfig {
                     use_internal_buffers: Some(true),

--- a/crates/shared/src/price_estimation/http.rs
+++ b/crates/shared/src/price_estimation/http.rs
@@ -776,6 +776,7 @@ mod tests {
                 network_name: "1".to_string(),
                 chain_id: 1,
                 base: Url::parse(&quasimodo_url).expect("failed to parse quasimodo url"),
+                custom_solve_path: None,
                 client,
                 config: SolverConfig {
                     use_internal_buffers: Some(true),

--- a/crates/solver/src/solver.rs
+++ b/crates/solver/src/solver.rs
@@ -342,6 +342,7 @@ pub fn create(
                 network_name: network_id.clone(),
                 chain_id,
                 base: url,
+                custom_solve_path: None,
                 client: http_factory.create(),
                 config,
             },

--- a/crates/solver/src/solver.rs
+++ b/crates/solver/src/solver.rs
@@ -342,7 +342,7 @@ pub fn create(
                 network_name: network_id.clone(),
                 chain_id,
                 base: url,
-                custom_solve_path: None,
+                solve_path: "solve".to_owned(),
                 client: http_factory.create(),
                 config,
             },

--- a/crates/solver/src/solver/http_solver.rs
+++ b/crates/solver/src/solver/http_solver.rs
@@ -279,6 +279,7 @@ mod tests {
                 network_name: "mock_network_id".to_string(),
                 chain_id: 0,
                 base: url.parse().unwrap(),
+                custom_solve_path: None,
                 client: Client::new(),
                 config: SolverConfig::default(),
             },

--- a/crates/solver/src/solver/http_solver.rs
+++ b/crates/solver/src/solver/http_solver.rs
@@ -279,7 +279,7 @@ mod tests {
                 network_name: "mock_network_id".to_string(),
                 chain_id: 0,
                 base: url.parse().unwrap(),
-                custom_solve_path: None,
+                solve_path: "solve".to_owned(),
                 client: Client::new(),
                 config: SolverConfig::default(),
             },


### PR DESCRIPTION
I did something bad...

This **incredibly hacky** PR changes the Yearn solver price estimator to use a custom path for the solve request. This is because the HTTP solver expects requests to `/quote` instead of `/solve` for price estimation.

Why is it done in such a hacky way? Well the new `driver` binary already supports arbitrary paths for solvers (so in this case we would be able to configure the URL to be `https://the.yearn.solver.eth/path/to/quote`). This means that this technical debt will be removed for free in the very near future without any additional work.

The alternative would be to stop appending `/solve` in the `http_solver.rs` implementation and to add `/solve` to the URL for each external solver in our deployment configuration. I chose against this for a couple of reasons:
1. It is a configuration hassle with a non-0 risk.
2. External solvers have a `/notify` URL that gets added to the base for solver competition. This has some pretty ambiguous semantics when paired with changing the `DefaultHttpSolverApi` to be configured with a "solve" URL instead of a base URL: is `/notify` appended to the solve URL, does it `s/solve/notify/`? etc.

As mentioned ☝️, since this is already solved in the new driver, in a correct and non-hacky way, I decided to use this hacky patch for now.

### Test Plan

Run the orderbook API and see it make requests with different paths:
```
% cargo run -p orderbook -- --price-estimators Yearn,Quasimodo --native-price-estimators Yearn,Quasimodo --yearn-solver-url http://localhost:10001 --yearn-solver-path quote --quasimodo-solver-url http://localhost:10002
...
2023-02-16T16:08:14.652Z DEBUG request{id=0}: shared::price_estimation::competition: new price estimate query=Query { from: None, sell_token: 0xdac17f958d2ee523a2206206994597c13d831ec7, buy_token: 0x6b175474e89094c44da98b954eedeac495271d0f, in_amount: 1000000000, kind: Sell } result=Err(Other(failed to send request

Caused by:
    0: error sending request for url (http://localhost:10001/quote?instance_name=2023-02-16_16%3A08%3A14.644312_UTC_Ethereum___Mainnet_1_0&time_limit=2&max_nr_exec_orders=100&use_internal_buffers=false&objective=surplusfeescosts): error trying to connect: tcp connect error: Connection refused (os error 61)
    1: error trying to connect: tcp connect error: Connection refused (os error 61)
    2: tcp connect error: Connection refused (os error 61)
    3: Connection refused (os error 61))) estimator="Yearn"
2023-02-16T16:08:14.652Z DEBUG request{id=0}: shared::price_estimation::competition: new price estimate query=Query { from: None, sell_token: 0xdac17f958d2ee523a2206206994597c13d831ec7, buy_token: 0x6b175474e89094c44da98b954eedeac495271d0f, in_amount: 1000000000, kind: Sell } result=Err(Other(failed to send request

Caused by:
    0: error sending request for url (http://localhost:10002/solve?instance_name=2023-02-16_16%3A08%3A14.646544_UTC_Ethereum___Mainnet_1_0&time_limit=2&max_nr_exec_orders=100&use_internal_buffers=false&objective=surplusfeescosts): error trying to connect: tcp connect error: Connection refused (os error 61)
    1: error trying to connect: tcp connect error: Connection refused (os error 61)
    2: tcp connect error: Connection refused (os error 61)
    3: Connection refused (os error 61))) estimator="Quasimodo"
...
```

**Note**: The errors are expected because I don't have anything actually bound to those ports, but the paths are different for both price estimators as expected.

### Release Notes

We should set `YEARN_SOLVER_PATH` to `quote` once it they switch their routing.