### PR TITLE
Bump Ethcontract To Improve Nethermind Revert Detection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1370,9 +1370,9 @@ dependencies = [
 
 [[package]]
 name = "ethcontract"
-version = "0.23.1"
+version = "0.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7236691dcb4b9b3672808fa072a413c67d025fd113681f1550e3379c299dd810"
+checksum = "c8556dce50fbb89c2f3a8e5e7c5199ada9d8390c1177b30960bce6b6350586f7"
 dependencies = [
  "arrayvec",
  "ethcontract-common",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ cached = { version = "0.39", default-features = false }
 chrono = { version = "0.4", default-features = false }
 clap = { version = "4", features = ["derive", "env"] }
 derivative = "2"
-ethcontract = { version = "0.23.1", default-features = false }
+ethcontract = { version = "0.23.2", default-features = false }
 ethcontract-generate = { version = "0.23", default-features = false }
 ethcontract-mock = { version = "0.23", default-features = false }
 futures = "0.3"


### PR DESCRIPTION
This PR improves the revert detection from Nethermind nodes and should help us detect the following errors (instead of causing alerts):

```
ERROR (pod: dfusion-v2-api-xdai-86774456bb-9lhdt):
2023-02-16T07:11:37.743Z ERROR request{id="b4b48a376396a0c741bc6bb499199ecd"}: orderbook::api::post_order: ValidationErrorWrapper err=web3 error: RPC error: Error { code: ServerError(-32015), message: "Reverted 0x656e636f646564206f7264657220213d207472616461626c65206f72646572", data: None }
```

### Test Plan

Tests were added in `ethcontract`
