### PR TITLE
Refactor e2e tests to use crate run functions

### DIFF
--- a/crates/autopilot/src/lib.rs
+++ b/crates/autopilot/src/lib.rs
@@ -153,13 +153,18 @@ pub async fn main(args: arguments::Arguments) {
             .await
             .expect("load native token contract"),
     };
-    let vault = match BalancerV2Vault::deployed(&web3).await {
-        Ok(contract) => Some(contract),
-        Err(DeployError::NotFound(_)) => {
-            tracing::warn!("balancer contracts are not deployed on this network");
-            None
-        }
-        Err(err) => panic!("failed to get balancer vault contract: {err}"),
+    let vault = match args.shared.balancer_v2_vault_address {
+        Some(address) => Some(contracts::BalancerV2Vault::with_deployment_info(
+            &web3, address, None,
+        )),
+        None => match BalancerV2Vault::deployed(&web3).await {
+            Ok(contract) => Some(contract),
+            Err(DeployError::NotFound(_)) => {
+                tracing::warn!("balancer contracts are not deployed on this network");
+                None
+            }
+            Err(err) => panic!("failed to get balancer vault contract: {err}"),
+        },
     };
     let uniswapv3_factory = match IUniswapV3Factory::deployed(&web3).await {
         Err(DeployError::NotFound(_)) => None,

--- a/crates/autopilot/src/limit_orders/quoter.rs
+++ b/crates/autopilot/src/limit_orders/quoter.rs
@@ -47,7 +47,7 @@ impl LimitOrderQuoter {
         loop {
             let sleep = match self.update().await {
                 // Prevent busy looping on the database if there is no work to be done.
-                Ok(true) => Duration::from_secs_f32(10.),
+                Ok(true) => Duration::from_secs_f32(1.),
                 Ok(false) => Duration::from_secs_f32(0.),
                 Err(err) => {
                     tracing::error!(?err, "limit order quoter update error");

--- a/crates/autopilot/src/solvable_orders.rs
+++ b/crates/autopilot/src/solvable_orders.rs
@@ -201,8 +201,8 @@ impl SolvableOrdersCache {
                 Ok(balance) => balance,
                 Err(err) => {
                     tracing::warn!(
-                        owner = %query.owner,
-                        token = %query.token,
+                        owner = ?query.owner,
+                        token = ?query.token,
                         source = ?query.source,
                         error = ?err,
                         "failed to get balance"

--- a/crates/e2e/tests/e2e/eth_integration.rs
+++ b/crates/e2e/tests/e2e/eth_integration.rs
@@ -1,13 +1,7 @@
 use {
     crate::{
         onchain_components::{deploy_token_with_weth_uniswap_pool, to_wei, WethPoolConfig},
-        services::{
-            create_orderbook_api,
-            setup_naive_solver_uniswapv2_driver,
-            wait_for_solvable_orders,
-            OrderbookServices,
-            API_HOST,
-        },
+        services::{solvable_orders, wait_for_condition, API_HOST},
         tx,
     },
     ethcontract::{
@@ -20,12 +14,14 @@ use {
     },
     secp256k1::SecretKey,
     serde_json::json,
-    shared::{ethrpc::Web3, http_client::HttpClientFactory, maintenance::Maintaining},
+    shared::ethrpc::Web3,
+    std::time::Duration,
     web3::signing::SecretKeyRef,
 };
 
-const TRADER_BUY_ETH_A_PK: [u8; 32] = [1; 32];
-const TRADER_BUY_ETH_B_PK: [u8; 32] = [2; 32];
+const TRADER_A_PK: [u8; 32] = [1; 32];
+const TRADER_B_PK: [u8; 32] = [2; 32];
+const SOLVER_PK: [u8; 32] = [3; 32];
 
 const ORDER_PLACEMENT_ENDPOINT: &str = "/api/v1/orders/";
 
@@ -36,25 +32,33 @@ async fn local_node_eth_integration() {
 }
 
 async fn eth_integration(web3: Web3) {
-    shared::tracing::initialize_reentrant("warn,orderbook=debug,solver=debug,autopilot=debug");
+    shared::tracing::initialize_reentrant(
+        "e2e=debug,orderbook=debug,solver=debug,autopilot=debug,\
+         orderbook::api::request_summary=off",
+    );
     shared::exit_process_on_panic::set_panic_hook();
+
+    crate::services::clear_database().await;
     let contracts = crate::deploy::deploy(&web3).await.expect("deploy");
 
-    let accounts: Vec<Address> = web3.eth().accounts().await.expect("get accounts failed");
-    let solver_account = Account::Local(accounts[0], None);
-    let trader_buy_eth_a =
-        Account::Offline(PrivateKey::from_raw(TRADER_BUY_ETH_A_PK).unwrap(), None);
-    let trader_buy_eth_b =
-        Account::Offline(PrivateKey::from_raw(TRADER_BUY_ETH_B_PK).unwrap(), None);
-
-    for trader in [&trader_buy_eth_a, &trader_buy_eth_b] {
+    let solver = Account::Offline(PrivateKey::from_raw(SOLVER_PK).unwrap(), None);
+    let trader_a = Account::Offline(PrivateKey::from_raw(TRADER_A_PK).unwrap(), None);
+    let trader_b = Account::Offline(PrivateKey::from_raw(TRADER_B_PK).unwrap(), None);
+    for account in [&trader_a, &trader_b, &solver] {
         TransactionBuilder::new(web3.clone())
             .value(to_wei(1))
-            .to(trader.address())
+            .to(account.address())
             .send()
             .await
             .unwrap();
     }
+
+    contracts
+        .gp_authenticator
+        .add_solver(solver.address())
+        .send()
+        .await
+        .unwrap();
 
     // Create & mint tokens to trade, pools for fee connections
     let token = deploy_token_with_weth_uniswap_pool(
@@ -67,41 +71,22 @@ async fn eth_integration(web3: Web3) {
     )
     .await;
 
-    token.mint(trader_buy_eth_a.address(), to_wei(51)).await;
-    token.mint(trader_buy_eth_b.address(), to_wei(51)).await;
+    token.mint(trader_a.address(), to_wei(51)).await;
+    token.mint(trader_b.address(), to_wei(51)).await;
     let token = token.contract;
 
     // Approve GPv2 for trading
-    tx!(
-        trader_buy_eth_a,
-        token.approve(contracts.allowance, to_wei(51))
-    );
-    tx!(
-        trader_buy_eth_b,
-        token.approve(contracts.allowance, to_wei(51))
-    );
+    tx!(trader_a, token.approve(contracts.allowance, to_wei(51)));
+    tx!(trader_b, token.approve(contracts.allowance, to_wei(51)));
 
-    let trader_a_eth_balance_before = web3
-        .eth()
-        .balance(trader_buy_eth_a.address(), None)
-        .await
-        .unwrap();
-    let trader_b_eth_balance_before = web3
-        .eth()
-        .balance(trader_buy_eth_b.address(), None)
-        .await
-        .unwrap();
+    let trader_a_eth_balance_before = web3.eth().balance(trader_a.address(), None).await.unwrap();
+    let trader_b_eth_balance_before = web3.eth().balance(trader_b.address(), None).await.unwrap();
 
-    let OrderbookServices {
-        maintenance,
-        block_stream,
-        solvable_orders_cache,
-        base_tokens,
-        ..
-    } = OrderbookServices::new(&web3, &contracts, false).await;
+    crate::services::start_autopilot(&contracts, &[]);
+    crate::services::start_api(&contracts, &[]);
+    crate::services::wait_for_api_to_come_up().await;
 
-    let http_factory = HttpClientFactory::default();
-    let client = http_factory.create();
+    let client = reqwest::Client::default();
 
     // Test quote
     let client_ref = &client;
@@ -145,7 +130,7 @@ async fn eth_integration(web3: Web3) {
         .sign_with(
             EcdsaSigningScheme::Eip712,
             &contracts.domain_separator,
-            SecretKeyRef::from(&SecretKey::from_slice(&TRADER_BUY_ETH_A_PK).unwrap()),
+            SecretKeyRef::from(&SecretKey::from_slice(&TRADER_A_PK).unwrap()),
         )
         .build()
         .into_order_creation();
@@ -166,7 +151,7 @@ async fn eth_integration(web3: Web3) {
         .sign_with(
             EcdsaSigningScheme::Eip712,
             &contracts.domain_separator,
-            SecretKeyRef::from(&SecretKey::from_slice(&TRADER_BUY_ETH_B_PK).unwrap()),
+            SecretKeyRef::from(&SecretKey::from_slice(&TRADER_B_PK).unwrap()),
         )
         .build()
         .into_order_creation();
@@ -177,30 +162,25 @@ async fn eth_integration(web3: Web3) {
         .await;
     assert_eq!(placement.unwrap().status(), 201);
 
-    wait_for_solvable_orders(&client, 2).await.unwrap();
-
-    // Drive solution
-    let mut driver = setup_naive_solver_uniswapv2_driver(
-        &web3,
-        &contracts,
-        base_tokens,
-        block_stream,
-        solver_account,
-    )
-    .await;
-    driver.single_run().await.unwrap();
+    tracing::info!("Waiting for trade.");
+    wait_for_condition(Duration::from_secs(10), || async {
+        solvable_orders().await.unwrap() == 2
+    })
+    .await
+    .unwrap();
+    crate::services::start_old_driver(&contracts, &SOLVER_PK, &[]);
+    let trade_happened = || async {
+        let balance_a = web3.eth().balance(trader_a.address(), None).await.unwrap();
+        let balance_b = web3.eth().balance(trader_b.address(), None).await.unwrap();
+        balance_a != trader_a_eth_balance_before && balance_b != trader_b_eth_balance_before
+    };
+    wait_for_condition(Duration::from_secs(10), trade_happened)
+        .await
+        .unwrap();
 
     // Check matching
-    let trader_a_eth_balance_after = web3
-        .eth()
-        .balance(trader_buy_eth_a.address(), None)
-        .await
-        .unwrap();
-    let trader_b_eth_balance_after = web3
-        .eth()
-        .balance(trader_buy_eth_b.address(), None)
-        .await
-        .unwrap();
+    let trader_a_eth_balance_after = web3.eth().balance(trader_a.address(), None).await.unwrap();
+    let trader_b_eth_balance_after = web3.eth().balance(trader_b.address(), None).await.unwrap();
     assert_eq!(
         trader_a_eth_balance_after - trader_a_eth_balance_before,
         to_wei(49)
@@ -209,11 +189,4 @@ async fn eth_integration(web3: Web3) {
         trader_b_eth_balance_after - trader_b_eth_balance_before,
         49_800_747_827_208_136_744_u128.into()
     );
-
-    // Drive orderbook in order to check that all orders were settled
-    maintenance.run_maintenance().await.unwrap();
-    solvable_orders_cache.update(0).await.unwrap();
-
-    let auction = create_orderbook_api().get_auction().await.unwrap();
-    assert!(auction.auction.orders.is_empty());
 }

--- a/crates/e2e/tests/e2e/local_node.rs
+++ b/crates/e2e/tests/e2e/local_node.rs
@@ -1,6 +1,6 @@
 use {
     chrono::{DateTime, Utc},
-    ethcontract::{futures::FutureExt, Account, Address, U256},
+    ethcontract::{futures::FutureExt, U256},
     lazy_static::lazy_static,
     shared::ethrpc::{create_test_transport, Web3},
     std::{
@@ -120,28 +120,5 @@ impl<T: Transport> TestNodeApi<T> {
 
     pub fn mine_pending_block(&self) -> CallFuture<String, T::Out> {
         CallFuture::new(self.transport.execute("evm_mine", vec![]))
-    }
-}
-
-pub struct AccountAssigner {
-    pub default_deployer: Account,
-    free_accounts: Vec<Account>,
-}
-
-impl AccountAssigner {
-    pub async fn new(web3: &Web3) -> Self {
-        let addresses: Vec<Address> = web3.eth().accounts().await.expect("get accounts failed");
-        let mut accounts = addresses.into_iter().map(|addr| Account::Local(addr, None));
-        AccountAssigner {
-            default_deployer: accounts.next().expect("No accounts available"),
-            free_accounts: accounts.collect(),
-        }
-    }
-
-    pub fn assign_free_account(&mut self) -> Account {
-        self.free_accounts.pop().expect(
-            "No testing accounts available, consider increasing the number of testing account in \
-             the test node",
-        )
     }
 }

--- a/crates/e2e/tests/e2e/onchain_components.rs
+++ b/crates/e2e/tests/e2e/onchain_components.rs
@@ -2,10 +2,7 @@ use {
     crate::deploy::Contracts,
     contracts::{ERC20Mintable, GnosisSafe, GnosisSafeCompatibilityFallbackHandler},
     ethcontract::{Account, Bytes, H160, H256, U256},
-    shared::{
-        ethrpc::Web3,
-        sources::uniswap_v2::{pair_provider::PairProvider, UNISWAP_INIT},
-    },
+    shared::ethrpc::Web3,
     web3::signing::{Key as _, SecretKeyRef},
 };
 
@@ -180,12 +177,5 @@ pub async fn deploy_token_with_weth_uniswap_pool(
     MintableToken {
         contract: token,
         minter,
-    }
-}
-
-pub fn uniswap_pair_provider(contracts: &Contracts) -> PairProvider {
-    PairProvider {
-        factory: contracts.uniswap_factory.address(),
-        init_code_digest: UNISWAP_INIT,
     }
 }

--- a/crates/e2e/tests/e2e/onchain_settlement.rs
+++ b/crates/e2e/tests/e2e/onchain_settlement.rs
@@ -1,23 +1,11 @@
 use {
     crate::{
-        onchain_components::{
-            deploy_token_with_weth_uniswap_pool,
-            to_wei,
-            uniswap_pair_provider,
-            WethPoolConfig,
-        },
-        services::{
-            create_order_converter,
-            create_orderbook_api,
-            wait_for_solvable_orders,
-            OrderbookServices,
-            API_HOST,
-        },
+        onchain_components::{deploy_token_with_weth_uniswap_pool, to_wei, WethPoolConfig},
+        services::{get_auction, API_HOST},
         tx,
     },
-    contracts::IUniswapLikeRouter,
     ethcontract::{
-        prelude::{Account, Address, PrivateKey, U256},
+        prelude::{Account, PrivateKey, U256},
         transaction::TransactionBuilder,
     },
     hex_literal::hex,
@@ -26,29 +14,8 @@ use {
         signature::EcdsaSigningScheme,
     },
     secp256k1::SecretKey,
-    shared::{
-        code_fetching::MockCodeFetching,
-        ethrpc::Web3,
-        http_client::HttpClientFactory,
-        maintenance::Maintaining,
-        sources::uniswap_v2::pool_fetching::PoolFetcher,
-    },
-    solver::{
-        liquidity::uniswap_v2::UniswapLikeLiquidity,
-        liquidity_collector::LiquidityCollector,
-        metrics::NoopMetrics,
-        settlement_access_list::{create_priority_estimator, AccessListEstimatorType},
-        settlement_submission::{
-            submitter::{
-                public_mempool_api::{PublicMempoolApi, SubmissionNode, SubmissionNodeKind},
-                Strategy,
-            },
-            GlobalTxPool,
-            SolutionSubmitter,
-            StrategyArgs,
-        },
-    },
-    std::{sync::Arc, time::Duration},
+    shared::ethrpc::Web3,
+    std::time::Duration,
     web3::signing::SecretKeyRef,
 };
 
@@ -56,6 +23,8 @@ const TRADER_A_PK: [u8; 32] =
     hex!("0000000000000000000000000000000000000000000000000000000000000001");
 const TRADER_B_PK: [u8; 32] =
     hex!("0000000000000000000000000000000000000000000000000000000000000002");
+const SOLVER_PK: [u8; 32] =
+    hex!("0000000000000000000000000000000000000000000000000000000000000003");
 
 const ORDER_PLACEMENT_ENDPOINT: &str = "/api/v1/orders/";
 
@@ -66,30 +35,41 @@ async fn local_node_onchain_settlement() {
 }
 
 async fn onchain_settlement(web3: Web3) {
-    shared::tracing::initialize_reentrant("warn,orderbook=debug,solver=debug,autopilot=debug");
+    shared::tracing::initialize_reentrant(
+        "e2e=debug,orderbook=debug,solver=debug,autopilot=debug,\
+         orderbook::api::request_summary=off",
+    );
     shared::exit_process_on_panic::set_panic_hook();
+
+    crate::services::clear_database().await;
     let contracts = crate::deploy::deploy(&web3).await.expect("deploy");
 
-    let accounts: Vec<Address> = web3.eth().accounts().await.expect("get accounts failed");
-    let solver_account = Account::Local(accounts[0], None);
+    let solver = Account::Offline(PrivateKey::from_raw(SOLVER_PK).unwrap(), None);
     let trader_a = Account::Offline(PrivateKey::from_raw(TRADER_A_PK).unwrap(), None);
     let trader_b = Account::Offline(PrivateKey::from_raw(TRADER_B_PK).unwrap(), None);
-    for trader in [&trader_a, &trader_b] {
+    for account in [&trader_a, &trader_b, &solver] {
         TransactionBuilder::new(web3.clone())
             .value(to_wei(1))
-            .to(trader.address())
+            .to(account.address())
             .send()
             .await
             .unwrap();
     }
+
+    contracts
+        .gp_authenticator
+        .add_solver(solver.address())
+        .send()
+        .await
+        .unwrap();
 
     // Create & mint tokens to trade, pools for fee connections
     let token_a = deploy_token_with_weth_uniswap_pool(
         &web3,
         &contracts,
         WethPoolConfig {
-            token_amount: to_wei(100_000),
-            weth_amount: to_wei(100_000),
+            token_amount: to_wei(1000),
+            weth_amount: to_wei(1000),
         },
     )
     .await;
@@ -97,8 +77,8 @@ async fn onchain_settlement(web3: Web3) {
         &web3,
         &contracts,
         WethPoolConfig {
-            token_amount: to_wei(100_000),
-            weth_amount: to_wei(100_000),
+            token_amount: to_wei(1000),
+            weth_amount: to_wei(1000),
         },
     )
     .await;
@@ -108,38 +88,34 @@ async fn onchain_settlement(web3: Web3) {
     token_b.mint(trader_b.address(), to_wei(51)).await;
 
     // Create and fund Uniswap pool
-    token_a
-        .mint(solver_account.address(), to_wei(100_000))
-        .await;
-    token_b
-        .mint(solver_account.address(), to_wei(100_000))
-        .await;
+    token_a.mint(solver.address(), to_wei(1000)).await;
+    token_b.mint(solver.address(), to_wei(1000)).await;
     let token_a = token_a.contract;
     let token_b = token_b.contract;
     tx!(
-        solver_account,
+        solver,
         contracts
             .uniswap_factory
             .create_pair(token_a.address(), token_b.address())
     );
     tx!(
-        solver_account,
-        token_a.approve(contracts.uniswap_router.address(), to_wei(100_000))
+        solver,
+        token_a.approve(contracts.uniswap_router.address(), to_wei(1000))
     );
     tx!(
-        solver_account,
-        token_b.approve(contracts.uniswap_router.address(), to_wei(100_000))
+        solver,
+        token_b.approve(contracts.uniswap_router.address(), to_wei(1000))
     );
     tx!(
-        solver_account,
+        solver,
         contracts.uniswap_router.add_liquidity(
             token_a.address(),
             token_b.address(),
-            to_wei(100_000),
-            to_wei(100_000),
+            to_wei(1000),
+            to_wei(1000),
             0_u64.into(),
             0_u64.into(),
-            solver_account.address(),
+            solver.address(),
             U256::max_value(),
         )
     );
@@ -148,17 +124,11 @@ async fn onchain_settlement(web3: Web3) {
     tx!(trader_a, token_a.approve(contracts.allowance, to_wei(101)));
     tx!(trader_b, token_b.approve(contracts.allowance, to_wei(51)));
 
-    // Place Orders
-    let OrderbookServices {
-        maintenance,
-        block_stream,
-        solvable_orders_cache,
-        base_tokens,
-        ..
-    } = OrderbookServices::new(&web3, &contracts, false).await;
+    crate::services::start_autopilot(&contracts, &[]);
+    crate::services::start_api(&contracts, &[]);
+    crate::services::wait_for_api_to_come_up().await;
 
-    let http_factory = HttpClientFactory::default();
-    let client = http_factory.create();
+    let client = reqwest::Client::default();
 
     let order_a = OrderBuilder::default()
         .with_sell_token(token_a.address())
@@ -203,101 +173,29 @@ async fn onchain_settlement(web3: Web3) {
         .send()
         .await;
     assert_eq!(placement.unwrap().status(), 201);
-    wait_for_solvable_orders(&client, 2).await.unwrap();
 
-    // Drive solution
-    let uniswap_pair_provider = uniswap_pair_provider(&contracts);
-    let uniswap_liquidity = UniswapLikeLiquidity::new(
-        IUniswapLikeRouter::at(&web3, contracts.uniswap_router.address()),
-        contracts.gp_settlement.clone(),
-        web3.clone(),
-        Arc::new(PoolFetcher::uniswap(uniswap_pair_provider, web3.clone())),
-    );
-    let solver = solver::solver::naive_solver(solver_account);
-    let liquidity_collector = LiquidityCollector {
-        liquidity_sources: vec![Box::new(uniswap_liquidity)],
-        base_tokens,
-    };
-    let network_id = web3.net().version().await.unwrap();
-    let submitted_transactions = GlobalTxPool::default();
-    let mut driver = solver::driver::Driver::new(
-        contracts.gp_settlement.clone(),
-        liquidity_collector,
-        vec![solver],
-        Arc::new(web3.clone()),
-        Duration::from_secs(30),
-        contracts.weth.address(),
-        Arc::new(NoopMetrics::default()),
-        web3.clone(),
-        network_id.clone(),
-        Duration::from_secs(30),
-        block_stream,
-        SolutionSubmitter {
-            web3: web3.clone(),
-            contract: contracts.gp_settlement.clone(),
-            gas_price_estimator: Arc::new(web3.clone()),
-            target_confirm_time: Duration::from_secs(1),
-            gas_price_cap: f64::MAX,
-            max_confirm_time: Duration::from_secs(120),
-            retry_interval: Duration::from_secs(5),
-            transaction_strategies: vec![
-                solver::settlement_submission::TransactionStrategy::PublicMempool(StrategyArgs {
-                    submit_api: Box::new(PublicMempoolApi::new(
-                        vec![SubmissionNode::new(
-                            SubmissionNodeKind::Broadcast,
-                            web3.clone(),
-                        )],
-                        false,
-                    )),
-                    max_additional_tip: 0.,
-                    additional_tip_percentage_of_max_fee: 0.,
-                    sub_tx_pool: submitted_transactions.add_sub_pool(Strategy::PublicMempool),
-                }),
-            ],
-            access_list_estimator: Arc::new(
-                create_priority_estimator(
-                    &web3,
-                    &[AccessListEstimatorType::Web3],
-                    None,
-                    network_id,
-                )
-                .unwrap(),
-            ),
-            code_fetcher: Arc::new(MockCodeFetching::new()),
-        },
-        create_orderbook_api(),
-        create_order_converter(&web3, contracts.weth.address()),
-        15000000u128,
-        None,
-        None.into(),
-        None,
-        0,
-        Arc::new(MockCodeFetching::new()),
-    );
-    driver.single_run().await.unwrap();
+    let balance = token_b.balance_of(trader_a.address()).call().await.unwrap();
+    assert_eq!(balance, 0.into());
+    let balance = token_a.balance_of(trader_b.address()).call().await.unwrap();
+    assert_eq!(balance, 0.into());
+
+    tracing::info!("Waiting for trade.");
+    crate::services::start_old_driver(&contracts, &SOLVER_PK, &[]);
+    let trade_happened =
+        || async { token_b.balance_of(trader_a.address()).call().await.unwrap() != 0.into() };
+    crate::services::wait_for_condition(Duration::from_secs(10), trade_happened)
+        .await
+        .unwrap();
 
     // Check matching
-    let balance = token_b
-        .balance_of(trader_a.address())
-        .call()
+    let balance = token_b.balance_of(trader_a.address()).call().await.unwrap();
+    assert!(balance >= order_a.data.buy_amount);
+    let balance = token_a.balance_of(trader_b.address()).call().await.unwrap();
+    assert!(balance >= order_b.data.buy_amount);
+
+    tracing::info!("Waiting for auction to be cleared.");
+    let auction_is_empty = || async { get_auction().await.unwrap().auction.orders.is_empty() };
+    crate::services::wait_for_condition(Duration::from_secs(10), auction_is_empty)
         .await
-        .expect("Couldn't fetch TokenB's balance");
-    assert_eq!(balance, U256::from(99_650_498_453_042_316_811_u128));
-
-    let balance = token_a
-        .balance_of(trader_b.address())
-        .call()
-        .await
-        .expect("Couldn't fetch TokenA's balance");
-    assert_eq!(balance, U256::from(50_175_363_672_226_073_523_u128));
-
-    // Drive orderbook in order to check the removal of settled order_b
-    maintenance.run_maintenance().await.unwrap();
-    solvable_orders_cache.update(0).await.unwrap();
-
-    let auction = create_orderbook_api().get_auction().await.unwrap();
-    assert!(auction.auction.orders.is_empty());
-
-    // Drive again to ensure we can continue solution finding
-    driver.single_run().await.unwrap();
+        .unwrap();
 }

--- a/crates/e2e/tests/e2e/settlement_without_onchain_liquidity.rs
+++ b/crates/e2e/tests/e2e/settlement_without_onchain_liquidity.rs
@@ -1,22 +1,10 @@
 use {
     crate::{
-        onchain_components::{
-            deploy_token_with_weth_uniswap_pool,
-            to_wei,
-            uniswap_pair_provider,
-            WethPoolConfig,
-        },
-        services::{
-            create_order_converter,
-            create_orderbook_api,
-            wait_for_solvable_orders,
-            OrderbookServices,
-            API_HOST,
-        },
+        onchain_components::{deploy_token_with_weth_uniswap_pool, to_wei, WethPoolConfig},
+        services::{solvable_orders, wait_for_condition, API_HOST},
     },
-    contracts::IUniswapLikeRouter,
     ethcontract::{
-        prelude::{Account, Address, PrivateKey, U256},
+        prelude::{Account, PrivateKey, U256},
         transaction::TransactionBuilder,
     },
     hex_literal::hex,
@@ -25,37 +13,15 @@ use {
         signature::EcdsaSigningScheme,
     },
     secp256k1::SecretKey,
-    shared::{
-        code_fetching::MockCodeFetching,
-        ethrpc::Web3,
-        http_client::HttpClientFactory,
-        maintenance::Maintaining,
-        sources::uniswap_v2::pool_fetching::PoolFetcher,
-        token_list::AutoUpdatingTokenList,
-    },
-    solver::{
-        liquidity::uniswap_v2::UniswapLikeLiquidity,
-        liquidity_collector::LiquidityCollector,
-        metrics::NoopMetrics,
-        settlement_access_list::{create_priority_estimator, AccessListEstimatorType},
-        settlement_post_processing::PostProcessingPipeline,
-        settlement_submission::{
-            submitter::{
-                public_mempool_api::{PublicMempoolApi, SubmissionNode, SubmissionNodeKind},
-                Strategy,
-            },
-            GlobalTxPool,
-            SolutionSubmitter,
-            StrategyArgs,
-        },
-        solver::optimizing_solver::OptimizingSolver,
-    },
-    std::{sync::Arc, time::Duration},
+    shared::ethrpc::Web3,
+    std::time::Duration,
     web3::signing::SecretKeyRef,
 };
 
-const TRADER_A_PK: [u8; 32] =
+const TRADER_PK: [u8; 32] =
     hex!("0000000000000000000000000000000000000000000000000000000000000001");
+const SOLVER_PK: [u8; 32] =
+    hex!("0000000000000000000000000000000000000000000000000000000000000003");
 
 const ORDER_PLACEMENT_ENDPOINT: &str = "/api/v1/orders/";
 
@@ -66,16 +32,29 @@ async fn local_node_onchain_settlement_without_liquidity() {
 }
 
 async fn onchain_settlement_without_liquidity(web3: Web3) {
-    shared::tracing::initialize_reentrant("warn,orderbook=debug,solver=debug,autopilot=debug");
+    shared::tracing::initialize_reentrant(
+        "e2e=debug,orderbook=debug,solver=debug,autopilot=debug,\
+         orderbook::api::request_summary=off",
+    );
     shared::exit_process_on_panic::set_panic_hook();
+
+    crate::services::clear_database().await;
     let contracts = crate::deploy::deploy(&web3).await.expect("deploy");
 
-    let accounts: Vec<Address> = web3.eth().accounts().await.expect("get accounts failed");
-    let solver_account = Account::Local(accounts[0], None);
-    let trader_account = Account::Offline(PrivateKey::from_raw(TRADER_A_PK).unwrap(), None);
-    TransactionBuilder::new(web3.clone())
-        .value(to_wei(1))
-        .to(trader_account.address())
+    let solver = Account::Offline(PrivateKey::from_raw(SOLVER_PK).unwrap(), None);
+    let trader = Account::Offline(PrivateKey::from_raw(TRADER_PK).unwrap(), None);
+    for account in [&trader, &solver] {
+        TransactionBuilder::new(web3.clone())
+            .value(to_wei(1))
+            .to(account.address())
+            .send()
+            .await
+            .unwrap();
+    }
+
+    contracts
+        .gp_authenticator
+        .add_solver(solver.address())
         .send()
         .await
         .unwrap();
@@ -85,8 +64,8 @@ async fn onchain_settlement_without_liquidity(web3: Web3) {
         &web3,
         &contracts,
         WethPoolConfig {
-            token_amount: to_wei(100_000),
-            weth_amount: to_wei(100_000),
+            token_amount: to_wei(1000),
+            weth_amount: to_wei(1000),
         },
     )
     .await;
@@ -94,84 +73,78 @@ async fn onchain_settlement_without_liquidity(web3: Web3) {
         &web3,
         &contracts,
         WethPoolConfig {
-            token_amount: to_wei(100_000),
-            weth_amount: to_wei(100_000),
+            token_amount: to_wei(1000),
+            weth_amount: to_wei(1000),
         },
     )
     .await;
 
     // Fund trader, settlement accounts, and pool creation
-    token_a.mint(trader_account.address(), to_wei(100)).await;
+    token_a.mint(trader.address(), to_wei(10)).await;
     token_b
         .mint(contracts.gp_settlement.address(), to_wei(100))
         .await;
-    token_a
-        .mint(solver_account.address(), to_wei(100_000))
-        .await;
-    token_b
-        .mint(solver_account.address(), to_wei(100_000))
-        .await;
+    token_a.mint(solver.address(), to_wei(1000)).await;
+    token_b.mint(solver.address(), to_wei(1000)).await;
     let token_a = token_a.contract;
     let token_b = token_b.contract;
+    let settlement_contract_balance_before = token_b
+        .balance_of(contracts.gp_settlement.address())
+        .call()
+        .await
+        .unwrap();
 
     // Create and fund Uniswap pool
     tx!(
-        solver_account,
+        solver,
         contracts
             .uniswap_factory
             .create_pair(token_a.address(), token_b.address())
     );
     tx!(
-        solver_account,
-        token_a.approve(contracts.uniswap_router.address(), to_wei(100_000))
+        solver,
+        token_a.approve(contracts.uniswap_router.address(), to_wei(1000))
     );
     tx!(
-        solver_account,
-        token_b.approve(contracts.uniswap_router.address(), to_wei(100_000))
+        solver,
+        token_b.approve(contracts.uniswap_router.address(), to_wei(1000))
     );
     tx!(
-        solver_account,
+        solver,
         contracts.uniswap_router.add_liquidity(
             token_a.address(),
             token_b.address(),
-            to_wei(100_000),
-            to_wei(100_000),
+            to_wei(1000),
+            to_wei(1000),
             0_u64.into(),
             0_u64.into(),
-            solver_account.address(),
+            solver.address(),
             U256::max_value(),
         )
     );
 
     // Approve GPv2 for trading
-    tx!(
-        trader_account,
-        token_a.approve(contracts.allowance, to_wei(100))
-    );
+    tx!(trader, token_a.approve(contracts.allowance, to_wei(10)));
 
     // Place Orders
-    let OrderbookServices {
-        maintenance,
-        block_stream,
-        solvable_orders_cache,
-        base_tokens,
-        ..
-    } = OrderbookServices::new(&web3, &contracts, false).await;
+    crate::services::start_autopilot(&contracts, &[]);
+    crate::services::start_api(&contracts, &[]);
+    crate::services::wait_for_api_to_come_up().await;
 
-    let http_factory = HttpClientFactory::default();
-    let client = http_factory.create();
+    let client = reqwest::Client::default();
 
     let order = OrderBuilder::default()
         .with_sell_token(token_a.address())
-        .with_sell_amount(to_wei(100))
+        .with_sell_amount(to_wei(9))
+        .with_fee_amount(to_wei(1))
         .with_buy_token(token_b.address())
-        .with_buy_amount(to_wei(90))
+        .with_buy_amount(to_wei(5))
         .with_valid_to(model::time::now_in_epoch_seconds() + 300)
         .with_kind(OrderKind::Sell)
         .sign_with(
             EcdsaSigningScheme::Eip712,
             &contracts.domain_separator,
-            SecretKeyRef::from(&SecretKey::from_slice(&TRADER_A_PK).unwrap()),
+            SecretKeyRef::from(&SecretKey::from_slice(&TRADER_PK).unwrap()),
         )
         .build()
         .into_order_creation();
@@ -182,123 +155,49 @@ async fn onchain_settlement_without_liquidity(web3: Web3) {
         .await;
     assert_eq!(placement.unwrap().status(), 201);
 
-    wait_for_solvable_orders(&client, 1).await.unwrap();
-
     // Drive solution
-    let uniswap_pair_provider = uniswap_pair_provider(&contracts);
-    let uniswap_liquidity = UniswapLikeLiquidity::new(
-        IUniswapLikeRouter::at(&web3, contracts.uniswap_router.address()),
-        contracts.gp_settlement.clone(),
-        web3.clone(),
-        Arc::new(PoolFetcher::uniswap(uniswap_pair_provider, web3.clone())),
+    tracing::info!("Waiting for trade.");
+    wait_for_condition(Duration::from_secs(10), || async {
+        solvable_orders().await.unwrap() == 1
+    })
+    .await
+    .unwrap();
+    crate::services::start_old_driver(
+        &contracts,
+        &SOLVER_PK,
+        &[format!(
+            "--market-makable-tokens={:?},{:?}",
+            token_a.address(),
+            token_b.address()
+        )],
     );
-
-    let liquidity_collector = LiquidityCollector {
-        liquidity_sources: vec![Box::new(uniswap_liquidity)],
-        base_tokens,
-    };
-    let network_id = web3.net().version().await.unwrap();
-    let market_makable_token_list =
-        AutoUpdatingTokenList::new(std::iter::once(token_a.address()).collect());
-    let post_processing_pipeline = Arc::new(PostProcessingPipeline::new(
-        contracts.weth.address(),
-        web3.clone(),
-        1.,
-        contracts.gp_settlement.clone(),
-        market_makable_token_list,
-    ));
-    let solver = Arc::new(OptimizingSolver {
-        inner: solver::solver::naive_solver(solver_account),
-        post_processing_pipeline,
-    });
-
-    let submitted_transactions = GlobalTxPool::default();
-    let mut driver = solver::driver::Driver::new(
-        contracts.gp_settlement.clone(),
-        liquidity_collector,
-        vec![solver],
-        Arc::new(web3.clone()),
-        Duration::from_secs(30),
-        contracts.weth.address(),
-        Arc::new(NoopMetrics::default()),
-        web3.clone(),
-        network_id.clone(),
-        Duration::from_secs(10),
-        block_stream,
-        SolutionSubmitter {
-            web3: web3.clone(),
-            contract: contracts.gp_settlement.clone(),
-            gas_price_estimator: Arc::new(web3.clone()),
-            target_confirm_time: Duration::from_secs(1),
-            gas_price_cap: f64::MAX,
-            max_confirm_time: Duration::from_secs(120),
-            retry_interval: Duration::from_secs(5),
-            transaction_strategies: vec![
-                solver::settlement_submission::TransactionStrategy::PublicMempool(StrategyArgs {
-                    submit_api: Box::new(PublicMempoolApi::new(
-                        vec![SubmissionNode::new(
-                            SubmissionNodeKind::Broadcast,
-                            web3.clone(),
-                        )],
-                        false,
-                    )),
-                    max_additional_tip: 0.,
-                    additional_tip_percentage_of_max_fee: 0.,
-                    sub_tx_pool: submitted_transactions.add_sub_pool(Strategy::PublicMempool),
-                }),
-            ],
-            access_list_estimator: Arc::new(
-                create_priority_estimator(
-                    &web3,
-                    &[AccessListEstimatorType::Web3],
-                    None,
-                    network_id,
-                )
-                .unwrap(),
-            ),
-            code_fetcher: Arc::new(MockCodeFetching::new()),
-        },
-        create_orderbook_api(),
-        create_order_converter(&web3, contracts.weth.address()),
-        15000000u128,
-        None,
-        None.into(),
-        None,
-        0,
-        Arc::new(MockCodeFetching::new()),
-    );
-    driver.single_run().await.unwrap();
+    wait_for_condition(Duration::from_secs(10), || async {
+        solvable_orders().await.unwrap() == 0
+    })
+    .await
+    .unwrap();
 
     // Check that trader traded.
     let balance = token_a
-        .balance_of(trader_account.address())
+        .balance_of(trader.address())
         .call()
         .await
         .expect("Couldn't fetch trader TokenA's balance");
     assert_eq!(balance, U256::from(0_u128));
 
     let balance = token_b
-        .balance_of(trader_account.address())
+        .balance_of(trader.address())
         .call()
         .await
         .expect("Couldn't fetch trader TokenB's balance");
     assert!(balance > U256::zero());
 
     // Check that settlement buffers were traded.
-    let balance = token_a
+    let settlement_contract_balance_after = token_b
         .balance_of(contracts.gp_settlement.address())
         .call()
         .await
-        .expect("Couldn't fetch settlements TokenA's balance");
-    assert_eq!(balance, to_wei(100));
-
-    // Drive orderbook in order to check the removal of settled order_b
-    maintenance.run_maintenance().await.unwrap();
-    solvable_orders_cache.update(0).await.unwrap();
-
-    let auction = create_orderbook_api().get_auction().await.unwrap();
-    assert!(auction.auction.orders.is_empty());
-
-    // Drive again to ensure we can continue solution finding
-    driver.single_run().await.unwrap();
+        .unwrap();
+    // Would fail if the settlement didn't internalize the uniswap interaction.
+    assert!(settlement_contract_balance_before > settlement_contract_balance_after);
 }

--- a/crates/e2e/tests/e2e/vault_balances.rs
+++ b/crates/e2e/tests/e2e/vault_balances.rs
@@ -1,22 +1,10 @@
 use {
     crate::{
-        onchain_components::{
-            deploy_token_with_weth_uniswap_pool,
-            to_wei,
-            uniswap_pair_provider,
-            WethPoolConfig,
-        },
-        services::{
-            create_order_converter,
-            create_orderbook_api,
-            wait_for_solvable_orders,
-            OrderbookServices,
-            API_HOST,
-        },
+        onchain_components::{deploy_token_with_weth_uniswap_pool, to_wei, WethPoolConfig},
+        services::{solvable_orders, wait_for_condition, API_HOST},
     },
-    contracts::IUniswapLikeRouter,
     ethcontract::{
-        prelude::{Account, Address, PrivateKey, U256},
+        prelude::{Account, PrivateKey, U256},
         transaction::TransactionBuilder,
     },
     model::{
@@ -24,32 +12,13 @@ use {
         signature::EcdsaSigningScheme,
     },
     secp256k1::SecretKey,
-    shared::{
-        code_fetching::MockCodeFetching,
-        ethrpc::Web3,
-        http_client::HttpClientFactory,
-        sources::uniswap_v2::pool_fetching::PoolFetcher,
-    },
-    solver::{
-        liquidity::uniswap_v2::UniswapLikeLiquidity,
-        liquidity_collector::LiquidityCollector,
-        metrics::NoopMetrics,
-        settlement_access_list::{create_priority_estimator, AccessListEstimatorType},
-        settlement_submission::{
-            submitter::{
-                public_mempool_api::{PublicMempoolApi, SubmissionNode, SubmissionNodeKind},
-                Strategy,
-            },
-            GlobalTxPool,
-            SolutionSubmitter,
-            StrategyArgs,
-        },
-    },
-    std::{sync::Arc, time::Duration},
+    shared::ethrpc::Web3,
+    std::time::Duration,
     web3::signing::SecretKeyRef,
 };
 
 const TRADER: [u8; 32] = [1; 32];
+const SOLVER: [u8; 32] = [2; 32];
 
 const ORDER_PLACEMENT_ENDPOINT: &str = "/api/v1/orders/";
 
@@ -60,16 +29,29 @@ async fn local_node_vault_balances() {
 }
 
 async fn vault_balances(web3: Web3) {
-    shared::tracing::initialize_reentrant("warn,orderbook=debug,solver=debug,autopilot=debug");
+    shared::tracing::initialize_reentrant(
+        "e2e=debug,orderbook=debug,solver=debug,autopilot=debug,\
+         orderbook::api::request_summary=off",
+    );
     shared::exit_process_on_panic::set_panic_hook();
+
+    crate::services::clear_database().await;
     let contracts = crate::deploy::deploy(&web3).await.expect("deploy");
 
-    let accounts: Vec<Address> = web3.eth().accounts().await.expect("get accounts failed");
-    let solver_account = Account::Local(accounts[0], None);
+    let solver = Account::Offline(PrivateKey::from_raw(SOLVER).unwrap(), None);
     let trader = Account::Offline(PrivateKey::from_raw(TRADER).unwrap(), None);
-    TransactionBuilder::new(web3.clone())
-        .value(to_wei(1))
-        .to(trader.address())
+    for account in [&trader, &solver] {
+        TransactionBuilder::new(web3.clone())
+            .value(to_wei(1))
+            .to(account.address())
+            .send()
+            .await
+            .unwrap();
+    }
+
+    contracts
+        .gp_authenticator
+        .add_solver(solver.address())
         .send()
         .await
         .unwrap();
@@ -79,8 +61,8 @@ async fn vault_balances(web3: Web3) {
         &web3,
         &contracts,
         WethPoolConfig {
-            token_amount: to_wei(100_000),
-            weth_amount: to_wei(100_000),
+            token_amount: to_wei(1000),
+            weth_amount: to_wei(1000),
         },
     )
     .await;
@@ -99,15 +81,11 @@ async fn vault_balances(web3: Web3) {
             .set_relayer_approval(trader.address(), contracts.allowance, true)
     );
 
-    let OrderbookServices {
-        block_stream,
-        solvable_orders_cache: _solvable_orders_cache,
-        base_tokens,
-        ..
-    } = OrderbookServices::new(&web3, &contracts, false).await;
+    crate::services::start_autopilot(&contracts, &[]);
+    crate::services::start_api(&contracts, &[]);
+    crate::services::wait_for_api_to_come_up().await;
 
-    let http_factory = HttpClientFactory::default();
-    let client = http_factory.create();
+    let client = reqwest::Client::default();
 
     // Place Orders
     let order = OrderBuilder::default()
@@ -132,79 +110,26 @@ async fn vault_balances(web3: Web3) {
         .send()
         .await;
     assert_eq!(placement.unwrap().status(), 201);
-
-    wait_for_solvable_orders(&client, 1).await.unwrap();
+    let balance_before = contracts
+        .weth
+        .balance_of(trader.address())
+        .call()
+        .await
+        .unwrap();
 
     // Drive solution
-    let uniswap_pair_provider = uniswap_pair_provider(&contracts);
-    let uniswap_liquidity = UniswapLikeLiquidity::new(
-        IUniswapLikeRouter::at(&web3, contracts.uniswap_router.address()),
-        contracts.gp_settlement.clone(),
-        web3.clone(),
-        Arc::new(PoolFetcher::uniswap(uniswap_pair_provider, web3.clone())),
-    );
-    let solver = solver::solver::naive_solver(solver_account);
-    let liquidity_collector = LiquidityCollector {
-        liquidity_sources: vec![Box::new(uniswap_liquidity)],
-        base_tokens,
-    };
-    let network_id = web3.net().version().await.unwrap();
-    let submitted_transactions = GlobalTxPool::default();
-    let mut driver = solver::driver::Driver::new(
-        contracts.gp_settlement.clone(),
-        liquidity_collector,
-        vec![solver],
-        Arc::new(web3.clone()),
-        Duration::from_secs(30),
-        contracts.weth.address(),
-        Arc::new(NoopMetrics::default()),
-        web3.clone(),
-        network_id.clone(),
-        Duration::from_secs(30),
-        block_stream,
-        SolutionSubmitter {
-            web3: web3.clone(),
-            contract: contracts.gp_settlement.clone(),
-            gas_price_estimator: Arc::new(web3.clone()),
-            target_confirm_time: Duration::from_secs(1),
-            gas_price_cap: f64::MAX,
-            max_confirm_time: Duration::from_secs(120),
-            retry_interval: Duration::from_secs(5),
-            transaction_strategies: vec![
-                solver::settlement_submission::TransactionStrategy::PublicMempool(StrategyArgs {
-                    submit_api: Box::new(PublicMempoolApi::new(
-                        vec![SubmissionNode::new(
-                            SubmissionNodeKind::Broadcast,
-                            web3.clone(),
-                        )],
-                        false,
-                    )),
-                    max_additional_tip: 0.,
-                    additional_tip_percentage_of_max_fee: 0.,
-                    sub_tx_pool: submitted_transactions.add_sub_pool(Strategy::PublicMempool),
-                }),
-            ],
-            access_list_estimator: Arc::new(
-                create_priority_estimator(
-                    &web3,
-                    &[AccessListEstimatorType::Web3],
-                    None,
-                    network_id,
-                )
-                .unwrap(),
-            ),
-            code_fetcher: Arc::new(MockCodeFetching::new()),
-        },
-        create_orderbook_api(),
-        create_order_converter(&web3, contracts.weth.address()),
-        15000000u128,
-        None,
-        None.into(),
-        None,
-        0,
-        Arc::new(MockCodeFetching::new()),
-    );
-    driver.single_run().await.unwrap();
+    tracing::info!("Waiting for trade.");
+    wait_for_condition(Duration::from_secs(10), || async {
+        solvable_orders().await.unwrap() == 1
+    })
+    .await
+    .unwrap();
+    crate::services::start_old_driver(&contracts, &SOLVER, &[]);
+    crate::services::wait_for_condition(Duration::from_secs(10), || async {
+        solvable_orders().await.unwrap() == 0
+    })
+    .await
+    .unwrap();
 
     // Check matching
     let balance = token
@@ -214,11 +139,11 @@ async fn vault_balances(web3: Web3) {
         .expect("Couldn't fetch token balance");
     assert_eq!(balance, U256::zero());
 
-    let balance = contracts
+    let balance_after = contracts
         .weth
         .balance_of(trader.address())
         .call()
         .await
-        .expect("Couldn't fetch native token balance");
-    assert_eq!(balance, U256::from(8_972_194_924_949_384_291_u128));
+        .unwrap();
+    assert!(balance_after.checked_sub(balance_before).unwrap() >= to_wei(8));
 }

--- a/crates/shared/src/arguments.rs
+++ b/crates/shared/src/arguments.rs
@@ -315,6 +315,10 @@ pub struct Arguments {
     /// Override address of the settlement contract.
     #[clap(long, env)]
     pub native_token_address: Option<H160>,
+
+    /// Override address of the balancer vault contract.
+    #[clap(long, env)]
+    pub balancer_v2_vault_address: Option<H160>,
 }
 
 pub fn display_secret_option<T>(
@@ -460,6 +464,11 @@ impl Display for Arguments {
             f,
             "native_token_address",
             &self.native_token_address.map(|a| format!("{a:?}")),
+        )?;
+        display_option(
+            f,
+            "balancer_v2_vault_address",
+            &self.balancer_v2_vault_address.map(|a| format!("{a:?}")),
         )?;
         display_list(
             f,

--- a/crates/shared/src/current_block.rs
+++ b/crates/shared/src/current_block.rs
@@ -173,14 +173,16 @@ impl BlockRetrieving for Web3 {
             .await?
             .into_iter()
             .map(|response| match response {
-                Ok(response) => serde_json::from_value::<web3::types::Block<H256>>(response)
-                    .context("unexpected response format")
-                    .and_then(|response| {
-                        Ok((
-                            response.number.context("missing block number")?.as_u64(),
-                            response.hash.context("missing hash")?,
-                        ))
-                    }),
+                Ok(response) => {
+                    serde_json::from_value::<web3::types::Block<H256>>(response.clone())
+                        .with_context(|| format!("unexpected response format: {response:?}"))
+                        .and_then(|response| {
+                            Ok((
+                                response.number.context("missing block number")?.as_u64(),
+                                response.hash.context("missing hash")?,
+                            ))
+                        })
+                }
                 Err(err) => Err(anyhow!("web3 error: {}", err)),
             })
             .collect()

--- a/crates/solver/src/arguments.rs
+++ b/crates/solver/src/arguments.rs
@@ -248,7 +248,12 @@ pub struct Arguments {
 
     /// The RPC endpoints to use for submitting transaction to a custom set of
     /// nodes.
-    #[clap(long, env, use_value_delimiter = true)]
+    #[clap(
+        long,
+        env,
+        use_value_delimiter = true,
+        default_value = "http://localhost:8545"
+    )]
     pub transaction_submission_nodes: Vec<Url>,
 
     /// Additional RPC endpoints that we notify when we submit a transaction to

--- a/crates/solver/src/settlement_access_list.rs
+++ b/crates/solver/src/settlement_access_list.rs
@@ -101,7 +101,7 @@ pub async fn estimate_settlement_access_list(
     }))
     .await?;
 
-    tracing::debug!(
+    tracing::trace!(
         ?settlement,
         ?partial_access_lists,
         "generated partial access lists"
@@ -131,7 +131,7 @@ pub async fn estimate_settlement_access_list(
         tx.clone(),
         Some(partial_access_list.clone()),
     );
-    tracing::debug!(?settlement, %simulation_link, "generating access list for settlement");
+    tracing::trace!(?settlement, %simulation_link, "generating access list for settlement");
 
     // Generate the final access list
     estimator

--- a/crates/solver/src/settlement_ranker.rs
+++ b/crates/solver/src/settlement_ranker.rs
@@ -60,7 +60,7 @@ impl SettlementRanker {
 
                     // Do not continue with settlements that are empty or only liquidity orders.
                     if !solver_settlements::has_user_order(&settlement) {
-                        tracing::debug!(
+                        tracing::trace!(
                             solver_name = %name,
                             "settlement(s) filtered containing only liquidity orders",
                         );

--- a/crates/solver/src/settlement_submission/submitter.rs
+++ b/crates/solver/src/settlement_submission/submitter.rs
@@ -330,7 +330,7 @@ impl<'a> Submitter<'a> {
                     find_mined_transaction(&self.contract.raw_instance().web3(), &transactions)
                         .await
                 {
-                    tracing::debug!("found mined transaction {:?}", receipt);
+                    tracing::debug!("found mined transaction {:?}", receipt.transaction_hash);
                     track_mined_transactions(&format!("{name}"));
                     return status(receipt);
                 }


### PR DESCRIPTION
This PR makes all e2e tests use the library run functions instead of manually creating components. This separates the test from the code more which will help future refactoring and makes the tests more extensive because the components are run just like they are as standalone binaries.

As a side effect many tests become simpler. There is potential for a lot more e2e improvements after this but I didn't want to put more than necessary in this PR.

E2e tests become slower because we can no longer drive individual components at the exact moment it is needed. Instead some checks have to be converted to polling with the `wait_for_condition` function. Running all tests on CI goes from 90s to 120s. This is not a big deal. There are low hanging fruits to speed tests up and eventually the plan is to run e2e tests in parallel.

Most of the changed lines are in the individual e2e tests. It's not worth it to review this super closely because the e2e tests still pass and I spent a lot of time debugging them so I'm pretty sure they didn't become less correct than before (most became more correct).

Other changes in this PR that I did not factor out:
- Improve logging. I was looking at a lot of logs while debugging the tests and in the process moved some to trace when they were large and printing duplicate information. We can always change some of these back later if they turn out to have been useful. Other logs were missing information.
- Make balancer contract address configurable. Needed for e2e test.

### Test Plan

CI