### PR TITLE
Boundary Naive Solver Implementation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3422,6 +3422,7 @@ dependencies = [
  "serde_json",
  "serde_with 2.0.1",
  "shared",
+ "solver",
  "tempfile",
  "thiserror",
  "tokio",

--- a/crates/e2e/tests/e2e/colocation_univ2.rs
+++ b/crates/e2e/tests/e2e/colocation_univ2.rs
@@ -157,8 +157,8 @@ max-hops = 0
     let file = file.into_temp_path();
     let args = vec![
         "solvers".to_string(),
-        format!("--config={}", file.to_str().unwrap()),
         "baseline".to_string(),
+        format!("--config={}", file.to_str().unwrap()),
     ];
     let (bind, bind_receiver) = tokio::sync::oneshot::channel();
     let task = async move {

--- a/crates/solver/src/solver.rs
+++ b/crates/solver/src/solver.rs
@@ -65,7 +65,7 @@ use {
 pub mod balancer_sor_solver;
 mod baseline_solver;
 pub mod http_solver;
-mod naive_solver;
+pub mod naive_solver;
 mod oneinch_solver;
 pub mod optimizing_solver;
 mod paraswap_solver;

--- a/crates/solver/src/solver/naive_solver.rs
+++ b/crates/solver/src/solver/naive_solver.rs
@@ -1,4 +1,4 @@
-mod multi_order_solver;
+pub mod multi_order_solver;
 
 use {
     crate::{

--- a/crates/solvers/Cargo.toml
+++ b/crates/solvers/Cargo.toml
@@ -39,6 +39,7 @@ anyhow = { workspace = true }
 contracts = { path = "../contracts" }
 model = { path = "../model" }
 shared = { path = "../shared" }
+solver = { path = "../solver" }
 tracing = { workspace = true }
 
 [dev-dependencies]

--- a/crates/solvers/src/boundary/mod.rs
+++ b/crates/solvers/src/boundary/mod.rs
@@ -4,6 +4,7 @@
 pub mod baseline;
 pub mod legacy;
 pub mod liquidity;
+pub mod naive;
 
 pub use shared::{exit_process_on_panic, tracing::initialize_reentrant as initialize_tracing};
 

--- a/crates/solvers/src/boundary/naive.rs
+++ b/crates/solvers/src/boundary/naive.rs
@@ -43,11 +43,12 @@ pub fn solve(
 
     // Note that the `order::Order` -> `boundary::LimitOrder` mapping here is
     // not exact. Among other things, the signature and various signed order
-    // fields are missing from the `order::Order` data that have access to in
-    // the solver engines. This means that the naive solver in the `solver`
-    // crate will encode "incorrect" settlements. This is fine, since we give
-    // it just enough data to compute the swapped orders and the swap amounts.
-    // The `driver` is then responsible for encoding the solution into a valid
+    // fields are missing from the `order::Order` data that the solver engines
+    // have access to. This means that the naive solver in the `solver` crate
+    // will encode "incorrect" settlements. This is fine, since we give it just
+    // enough data to compute the correct swapped orders and the swap amounts
+    // which is what the naive solver in the `solvers` crate cares about. The
+    // `driver` is then responsible for encoding the solution into a valid
     // settlement transaction anyway.
     let boundary_orders = orders
         .iter()
@@ -155,14 +156,14 @@ pub fn solve(
 //
 // Joking aside, the existing naive solver implementation is tightly coupled
 // with the `Settlement` and `SettlementEncoder` types in the `solver` crate.
-// This meeans that there is no convinient way to say: "please compute a
-// solution given this list of orders and constant product pool" without it
-// creating a full settlement for encoding. In order to adapt that API into
-// something that is useful in this boundary module, we create a fake slippage
-// context that applies 0 slippage (so that we can recover the exact executed
-// amounts from the constant product pool) and we create capturing settlement
-// handler implementations that record the swap that gets added to each
-// settlement so that it can be recovered later to build a solution.
+// This means that there is no convenient way to say: "please compute a solution
+// given this list of orders and constant product pool" without it creating a
+// full settlement for encoding. In order to adapt that API into something that
+// is useful in this boundary module, we create a fake slippage context that
+// applies 0 slippage (so that we can recover the exact executed amounts from
+// the constant product pool) and we create capturing settlement handler
+// implementations that record the swap that gets added to each settlement so
+// that it can be recovered later to build a solution.
 
 struct Slippage {
     calculator: SlippageCalculator,

--- a/crates/solvers/src/boundary/naive.rs
+++ b/crates/solvers/src/boundary/naive.rs
@@ -1,0 +1,239 @@
+use {
+    crate::{
+        boundary::liquidity::constant_product::to_boundary_pool,
+        domain::{eth, liquidity, order, solution},
+    },
+    ethereum_types::{H160, U256},
+    itertools::Itertools,
+    model::order::{
+        LimitOrderClass,
+        Order,
+        OrderClass,
+        OrderData,
+        OrderKind,
+        OrderMetadata,
+        OrderUid,
+    },
+    num::{BigRational, One},
+    solver::{
+        liquidity::{
+            slippage::{SlippageCalculator, SlippageContext},
+            AmmOrderExecution,
+            ConstantProductOrder,
+            Exchange,
+            LimitOrder,
+            LimitOrderId,
+            LiquidityOrderId,
+            SettlementHandling,
+        },
+        settlement::{external_prices::ExternalPrices, SettlementEncoder},
+        solver::naive_solver::multi_order_solver,
+    },
+    std::sync::{Arc, Mutex},
+};
+
+pub fn solve(
+    orders: &[&order::Order],
+    liquidity: &liquidity::Liquidity,
+) -> Option<solution::Solution> {
+    let pool = match &liquidity.state {
+        liquidity::State::ConstantProduct(pool) => pool,
+        _ => return None,
+    };
+
+    let boundary_orders = orders
+        .iter()
+        .map(|order| LimitOrder {
+            id: match order.class {
+                order::Class::Market => LimitOrderId::Market(OrderUid(order.uid.0)),
+                order::Class::Limit => LimitOrderId::Limit(OrderUid(order.uid.0)),
+                order::Class::Liquidity => {
+                    LimitOrderId::Liquidity(LiquidityOrderId::Protocol(OrderUid(order.uid.0)))
+                }
+            },
+            sell_token: order.sell.token.0,
+            buy_token: order.buy.token.0,
+            sell_amount: order.sell.amount,
+            buy_amount: order.buy.amount,
+            kind: match order.side {
+                order::Side::Buy => OrderKind::Buy,
+                order::Side::Sell => OrderKind::Sell,
+            },
+            partially_fillable: order.partially_fillable,
+            solver_fee: order.fee().amount,
+            settlement_handling: Arc::new(OrderHandler {
+                order: Order {
+                    metadata: OrderMetadata {
+                        uid: OrderUid(order.uid.0),
+                        class: match order.class {
+                            order::Class::Market => OrderClass::Market,
+                            order::Class::Limit => OrderClass::Limit(LimitOrderClass {
+                                surplus_fee: Some(order.fee().amount),
+                                ..Default::default()
+                            }),
+                            order::Class::Liquidity => OrderClass::Liquidity,
+                        },
+                        solver_fee: order.fee().amount,
+                        ..Default::default()
+                    },
+                    data: OrderData {
+                        sell_token: order.sell.token.0,
+                        buy_token: order.buy.token.0,
+                        sell_amount: order.sell.amount,
+                        buy_amount: order.buy.amount,
+                        fee_amount: order.fee().amount,
+                        kind: match order.side {
+                            order::Side::Buy => OrderKind::Buy,
+                            order::Side::Sell => OrderKind::Sell,
+                        },
+                        partially_fillable: order.partially_fillable,
+                        ..Default::default()
+                    },
+                    ..Default::default()
+                },
+            }),
+            exchange: Exchange::GnosisProtocol,
+            reward: 0.,
+        })
+        .collect_vec();
+
+    let slippage = Slippage::new(pool.tokens());
+    let pool_handler = Arc::new(PoolHandler::default());
+    let boundary_pool = ConstantProductOrder::for_pool(
+        to_boundary_pool(liquidity.address, pool)?,
+        pool_handler.clone(),
+    );
+
+    let boundary_solution =
+        multi_order_solver::solve(&slippage.context(), boundary_orders, &boundary_pool)?;
+
+    let mut swap = pool_handler.swap.lock().unwrap();
+    Some(solution::Solution {
+        prices: solution::ClearingPrices::new(
+            boundary_solution
+                .clearing_prices()
+                .iter()
+                .map(|(token, price)| (eth::TokenAddress(*token), *price)),
+        ),
+        trades: boundary_solution
+            .traded_orders()
+            .map(|order| {
+                solution::Trade::Fulfillment(solution::Fulfillment::fill(
+                    orders
+                        .iter()
+                        .copied()
+                        .find(|o| o.uid.0 == order.metadata.uid.0)
+                        .unwrap()
+                        .clone(),
+                ))
+            })
+            .collect(),
+        interactions: swap
+            .take()
+            .into_iter()
+            .map(|(input, output)| {
+                solution::Interaction::Liquidity(solution::LiquidityInteraction {
+                    liquidity: liquidity.clone(),
+                    input,
+                    output,
+                    internalize: false,
+                })
+            })
+            .collect(),
+    })
+}
+
+// Beyond this point is... well... nameless and boundless chaos. The
+// unfathomable horrors that follow are not for the faint of heart!
+//
+// Joking asside, the existing naive solver implementation is tightly coupled
+// with the `Settlement` and `SettlementEncoder` types in the `solver` crate.
+// This meeans that there is no convinient way to say: "please compute a
+// solution given this list of orders and constant product pool" without it
+// creating a full settlement for encoding. In order to adapt that API into
+// something that is useful in this boundary module, we create a fake slippage
+// context that applies 0 slippage (so that we can recover the exact executed
+// amounts from the constant product pool) and we create capturing settlement
+// handler implementations that record the swap that gets added to each
+// settlement so that it can be recovered later to build a solution.
+
+struct Slippage {
+    calculator: SlippageCalculator,
+    prices: ExternalPrices,
+}
+
+impl Slippage {
+    fn new(tokens: liquidity::TokenPair) -> Self {
+        // We don't actually want to include slippage yet. This is because the
+        // Naive solver encodes liquidity interactions and the driver is
+        // responsible for applying slippage to those. Create a dummy slippage
+        // context for use with the legacy Naive solver.
+        let (token0, token1) = tokens.get();
+        Self {
+            calculator: SlippageCalculator::from_bps(0, None),
+            prices: ExternalPrices::new(
+                H160::default(),
+                [
+                    (token0.0, BigRational::one()),
+                    (token1.0, BigRational::one()),
+                ]
+                .into_iter()
+                .collect(),
+            )
+            .unwrap(),
+        }
+    }
+
+    fn context(&self) -> SlippageContext {
+        self.calculator.context(&self.prices)
+    }
+}
+
+struct OrderHandler {
+    order: Order,
+}
+
+impl SettlementHandling<LimitOrder> for OrderHandler {
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+
+    fn encode(&self, execution: U256, encoder: &mut SettlementEncoder) -> anyhow::Result<()> {
+        encoder.add_trade(
+            self.order.clone(),
+            execution,
+            self.order.metadata.solver_fee,
+        )?;
+        Ok(())
+    }
+}
+
+#[derive(Default)]
+struct PoolHandler {
+    swap: Mutex<Option<(eth::Asset, eth::Asset)>>,
+}
+
+impl SettlementHandling<ConstantProductOrder> for PoolHandler {
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+
+    fn encode(
+        &self,
+        execution: AmmOrderExecution,
+        _: &mut SettlementEncoder,
+    ) -> anyhow::Result<()> {
+        let mut swap = self.swap.lock().unwrap();
+        *swap = Some((
+            eth::Asset {
+                token: eth::TokenAddress(execution.input_max.token),
+                amount: execution.input_max.amount,
+            },
+            eth::Asset {
+                token: eth::TokenAddress(execution.output.token),
+                amount: execution.output.amount,
+            },
+        ));
+        Ok(())
+    }
+}

--- a/crates/solvers/src/boundary/naive.rs
+++ b/crates/solvers/src/boundary/naive.rs
@@ -153,7 +153,7 @@ pub fn solve(
 // Beyond this point is... well... nameless and boundless chaos. The
 // unfathomable horrors that follow are not for the faint of heart!
 //
-// Joking asside, the existing naive solver implementation is tightly coupled
+// Joking aside, the existing naive solver implementation is tightly coupled
 // with the `Settlement` and `SettlementEncoder` types in the `solver` crate.
 // This meeans that there is no convinient way to say: "please compute a
 // solution given this list of orders and constant product pool" without it

--- a/crates/solvers/src/domain/liquidity/constant_product.rs
+++ b/crates/solvers/src/domain/liquidity/constant_product.rs
@@ -1,6 +1,10 @@
 //! Constant product pool.
 
-use {crate::domain::eth, std::cmp::Ordering};
+use {
+    crate::domain::{eth, liquidity},
+    ethereum_types::U256,
+    std::cmp::Ordering,
+};
 
 /// Uniswap-v2 like pool state.
 #[derive(Clone, Debug)]
@@ -9,14 +13,40 @@ pub struct Pool {
     pub fee: eth::Rational,
 }
 
+impl Pool {
+    /// Returns the pool's token pair.
+    pub fn tokens(&self) -> liquidity::TokenPair {
+        liquidity::TokenPair::new(self.reserves.0.token, self.reserves.1.token)
+            .expect("pool reserve assets have different tokens")
+    }
+
+    /// Returns the constant product pool's `k` value. This is the product of
+    /// the pool's token balances.
+    pub fn k(&self) -> U256 {
+        self.reserves
+            .0
+            .amount
+            .checked_mul(self.reserves.1.amount)
+            .expect("product of two u96 cannot overflow a u256")
+    }
+}
+
 /// Constant product pool reserves.
 #[derive(Clone, Debug)]
 pub struct Reserves(eth::Asset, eth::Asset);
 
 impl Reserves {
     /// Creates a new constant product pool reserves with the specified assets.
-    /// Returns `None` if the assets are denominated in the same tokens.
+    /// Returns `None` if the assets are denominated in the same token or if the
+    /// balances are larger than the maximum allowed values.
     pub fn new(a: eth::Asset, b: eth::Asset) -> Option<Self> {
+        // UniswapV2-Like constant product pools are limited to uint96 values
+        // for token reserves - so verify this invariant.
+        let max = (U256::one() << 96) - 1;
+        if a.amount > max || b.amount > max {
+            return None;
+        }
+
         match a.token.cmp(&b.token) {
             Ordering::Less => Some(Self(a, b)),
             Ordering::Equal => None,

--- a/crates/solvers/src/domain/mod.rs
+++ b/crates/solvers/src/domain/mod.rs
@@ -5,11 +5,13 @@ pub mod baseline;
 pub mod eth;
 pub mod legacy;
 pub mod liquidity;
+pub mod naive;
 pub mod order;
 pub mod solution;
 
 pub enum Solver {
     Baseline(baseline::Baseline),
+    Naive(naive::Naive),
     Legacy(legacy::Legacy),
 }
 
@@ -20,6 +22,7 @@ impl Solver {
     pub async fn solve(&self, auction: auction::Auction) -> Vec<solution::Solution> {
         match self {
             Solver::Baseline(solver) => solver.solve(auction),
+            Solver::Naive(solver) => solver.solve(auction),
             Solver::Legacy(solver) => solver.solve(auction).await,
         }
     }

--- a/crates/solvers/src/domain/naive.rs
+++ b/crates/solvers/src/domain/naive.rs
@@ -1,0 +1,82 @@
+//! "Naive" solver implementation.
+//!
+//! The naive solver is a solver that collects all orders over a single token
+//! pair, and matches the excess over a Uniswap V2 pool.
+
+use {
+    crate::{
+        boundary,
+        domain::{auction, liquidity, order, solution},
+    },
+    std::collections::HashMap,
+};
+
+pub struct Naive;
+
+impl Naive {
+    /// Solves the specified auction, returning a vector of all possible
+    /// solutions.
+    pub fn solve(&self, auction: auction::Auction) -> Vec<solution::Solution> {
+        let groups = group_by_token_pair(&auction);
+        groups
+            .values()
+            .filter_map(|group| boundary::naive::solve(&group.orders, group.liquidity))
+            .collect()
+    }
+}
+
+#[derive(Debug)]
+struct Group<'a> {
+    orders: Vec<&'a order::Order>,
+    liquidity: &'a liquidity::Liquidity,
+    pool: &'a liquidity::constant_product::Pool,
+}
+
+type Groups<'a> = HashMap<liquidity::TokenPair, Group<'a>>;
+
+/// Groups an auction by token pairs, where each group contains all orders over
+/// the token pair as well as the **deepest** constant product pool.
+fn group_by_token_pair(auction: &auction::Auction) -> Groups {
+    let mut groups = Groups::new();
+
+    for liquidity in &auction.liquidity {
+        let pool = match &liquidity.state {
+            liquidity::State::ConstantProduct(pool) => pool,
+            _ => continue,
+        };
+
+        groups
+            .entry(pool.tokens())
+            .and_modify(|group| {
+                if group.pool.k() < pool.k() {
+                    group.liquidity = liquidity;
+                    group.pool = pool;
+                }
+            })
+            .or_insert_with(|| Group {
+                orders: Vec::new(),
+                liquidity,
+                pool,
+            });
+    }
+
+    for order in &auction.orders {
+        // the naive solver algorithm is sensitive to 0-amount orders (i.e. they
+        // cause panics). Make sure we don't consider them.
+        if order.sell.amount.is_zero() || order.buy.amount.is_zero() {
+            continue;
+        }
+
+        let tokens = match liquidity::TokenPair::new(order.sell.token, order.buy.token) {
+            Some(value) => value,
+            None => continue,
+        };
+
+        groups
+            .entry(tokens)
+            .and_modify(|group| group.orders.push(order));
+    }
+
+    groups.retain(|_, group| !group.orders.is_empty());
+    groups
+}

--- a/crates/solvers/src/domain/naive.rs
+++ b/crates/solvers/src/domain/naive.rs
@@ -1,7 +1,9 @@
 //! "Naive" solver implementation.
 //!
 //! The naive solver is a solver that collects all orders over a single token
-//! pair, and matches the excess over a Uniswap V2 pool.
+//! pair, computing how many leftover tokens can't be matched peer-to-peer, and
+//! matching that excess over a Uniswap V2 pool. This allows for naive
+//! coincidence of wants over a single Uniswap V2 pools.
 
 use {
     crate::{
@@ -35,7 +37,9 @@ struct Group<'a> {
 type Groups<'a> = HashMap<liquidity::TokenPair, Group<'a>>;
 
 /// Groups an auction by token pairs, where each group contains all orders over
-/// the token pair as well as the **deepest** constant product pool.
+/// the token pair as well as the **deepest** constant product pool (i.e. most
+/// liquidity, which translates to a higher `K` value for Uniswap V2 style
+/// constant product pools).
 fn group_by_token_pair(auction: &auction::Auction) -> Groups {
     let mut groups = Groups::new();
 

--- a/crates/solvers/src/domain/naive.rs
+++ b/crates/solvers/src/domain/naive.rs
@@ -61,7 +61,7 @@ fn group_by_token_pair(auction: &auction::Auction) -> Groups {
     }
 
     for order in &auction.orders {
-        // the naive solver algorithm is sensitive to 0-amount orders (i.e. they
+        // The naive solver algorithm is sensitive to 0-amount orders (i.e. they
         // cause panics). Make sure we don't consider them.
         if order.sell.amount.is_zero() || order.buy.amount.is_zero() {
             continue;

--- a/crates/solvers/src/domain/order.rs
+++ b/crates/solvers/src/domain/order.rs
@@ -29,7 +29,7 @@ impl Order {
 }
 
 /// UID of an order.
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub struct Uid(pub [u8; 56]);
 
 /// An order fee amount, denominated in its sell token.

--- a/crates/solvers/src/infra/cli.rs
+++ b/crates/solvers/src/infra/cli.rs
@@ -17,11 +17,6 @@ pub struct Args {
     #[arg(long, env, default_value = "127.0.0.1:7872")]
     pub addr: SocketAddr,
 
-    /// Path to the driver configuration file. This file should be in TOML
-    /// format.
-    #[clap(long, env)]
-    pub config: PathBuf,
-
     #[command(subcommand)]
     pub command: Command,
 }
@@ -30,7 +25,19 @@ pub struct Args {
 #[derive(Subcommand, Debug)]
 pub enum Command {
     /// Baseline solver.
-    Baseline,
+    Baseline {
+        /// Path to the solver configuration file. This file should be in TOML
+        /// format.
+        #[clap(long, env)]
+        config: PathBuf,
+    },
+    /// Naive solver.
+    Naive,
     /// Wrapper for solvers implementing the legacy HTTP interface.
-    Legacy,
+    Legacy {
+        /// Path to the solver configuration file. This file should be in TOML
+        /// format.
+        #[clap(long, env)]
+        config: PathBuf,
+    },
 }

--- a/crates/solvers/src/tests/baseline/direct_swap.rs
+++ b/crates/solvers/src/tests/baseline/direct_swap.rs
@@ -5,8 +5,7 @@ use {crate::tests, serde_json::json};
 
 #[tokio::test]
 async fn test() {
-    let engine =
-        tests::SolverEngine::new("baseline".to_owned(), "example.baseline.toml".to_owned()).await;
+    let engine = tests::SolverEngine::new("baseline", Some("example.baseline.toml")).await;
 
     let solution = engine
         .solve(json!({

--- a/crates/solvers/src/tests/legacy/attaching_approvals.rs
+++ b/crates/solvers/src/tests/legacy/attaching_approvals.rs
@@ -84,8 +84,7 @@ async fn test() {
     .await;
     let config = legacy::create_temp_config_file(&legacy_solver);
 
-    let engine =
-        tests::SolverEngine::new("legacy".to_owned(), config.to_str().unwrap().to_owned()).await;
+    let engine = tests::SolverEngine::new("legacy", Some(config.to_str().unwrap())).await;
 
     let solution = engine
         .solve(json!({

--- a/crates/solvers/src/tests/legacy/jit_order.rs
+++ b/crates/solvers/src/tests/legacy/jit_order.rs
@@ -1,4 +1,4 @@
-//! Tests that orders that provide just-in-time liquidity get correctly
+//! Tests that solutions that use just-in-time liquidity orders get correctly
 //! serialized.
 
 use {

--- a/crates/solvers/src/tests/legacy/jit_order.rs
+++ b/crates/solvers/src/tests/legacy/jit_order.rs
@@ -65,8 +65,7 @@ async fn test() {
     .await;
     let config = legacy::create_temp_config_file(&legacy_solver);
 
-    let engine =
-        tests::SolverEngine::new("legacy".to_owned(), config.to_str().unwrap().to_owned()).await;
+    let engine = tests::SolverEngine::new("legacy", Some(config.to_str().unwrap())).await;
 
     let solution = engine
         .solve(json!({

--- a/crates/solvers/src/tests/legacy/market_order.rs
+++ b/crates/solvers/src/tests/legacy/market_order.rs
@@ -108,8 +108,7 @@ async fn test_quoting() {
     }]).await;
     let config = legacy::create_temp_config_file(&legacy_solver);
 
-    let engine =
-        tests::SolverEngine::new("legacy".to_owned(), config.to_str().unwrap().to_owned()).await;
+    let engine = tests::SolverEngine::new("legacy", Some(config.to_str().unwrap())).await;
 
     let solution = engine
         .solve(json!({
@@ -299,8 +298,7 @@ async fn test_solving() {
     }]).await;
     let config = legacy::create_temp_config_file(&legacy_solver);
 
-    let engine =
-        tests::SolverEngine::new("legacy".to_owned(), config.to_str().unwrap().to_owned()).await;
+    let engine = tests::SolverEngine::new("legacy", Some(config.to_str().unwrap())).await;
 
     let solution = engine
         .solve(json!({

--- a/crates/solvers/src/tests/mod.rs
+++ b/crates/solvers/src/tests/mod.rs
@@ -21,21 +21,20 @@ pub struct SolverEngine {
 impl SolverEngine {
     /// Creates a new solver engine handle for the specified command
     /// configuration.
-    pub async fn new(command: String, config: String) -> Self {
+    pub async fn new(command: impl Into<String>, config: Option<impl Into<String>>) -> Self {
         let (bind, bind_receiver) = oneshot::channel();
 
-        let handle = tokio::spawn(crate::run::run(
-            vec![
-                "/test/solvers/path".to_owned(),
-                "--addr".to_owned(),
-                "0.0.0.0:0".to_owned(),
-                "--config".to_owned(),
-                config,
-                command,
-            ]
-            .into_iter(),
-            Some(bind),
-        ));
+        let mut args = vec![
+            "/test/solvers/path".to_owned(),
+            "--addr".to_owned(),
+            "0.0.0.0:0".to_owned(),
+            command.into(),
+        ];
+        if let Some(config) = config {
+            args.extend(["--config".to_owned(), config.into()]);
+        }
+
+        let handle = tokio::spawn(crate::run::run(args, Some(bind)));
 
         let addr = bind_receiver.await.unwrap();
         let url = format!("http://{addr}/").parse().unwrap();


### PR DESCRIPTION
This PR adds the naive solver to the `solvers` crate. It turned out to be harder than anticipated because the naive solver implementation is tightly coupled with the `Settlement` type.

Since the code is fairly simple, I hope to move the logic into the `domain` as soon as possible (hence the test coverage from #1233), especially considering since most of the bugs stem from the fact that we are mixing `LimitOrder` "synthetic" orders with `Order` "signed" orders (and all the weird cases related to custom prices, and synthetic order amounts).

### Test Plan

Tests are included in #1233.