### PR TITLE
Force Hardhat to Bind to 127.0.0.1

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -75,7 +75,7 @@ jobs:
         working-directory: ${{ env.HARDHAT_PATH_ }}
         run: |
           cp ${{ github.workspace }}/docker/hardhat/hardhat.config.js hardhat.config.js
-          node_modules/.bin/hardhat node &
+          node_modules/.bin/hardhat node --hostname 127.0.0.1 &
       - name: Setup Database
         run: |
           sudo systemctl start postgresql.service


### PR DESCRIPTION
Some networking changes in GitHub CI is causing Hardhat to bind to **only** `::1`, and is no longer binding to `127.0.0.1`. This causes local node tests to fail, as they are unable to connect to the Hardhat instance.

This PR just forces Hardhat to bind to `127.0.0.1` instead of `localhost`, thus avoiding the issue.

### Test Plan

Tests should start running again.
