### PR TITLE
Add Balancer SOR Solver E2E Tests

### DIFF
--- a/crates/solvers/src/tests/balancer/market_order.rs
+++ b/crates/solvers/src/tests/balancer/market_order.rs
@@ -1,0 +1,311 @@
+//! This test ensures that the Balancer solver properly handles cases where no
+//! swap was found for the specified quoted order.
+
+use {
+    crate::tests::{self, balancer},
+    serde_json::json,
+};
+
+#[tokio::test]
+async fn sell() {
+    let api = tests::dex::setup(vec![tests::dex::Expectation::Post {
+        path: "".to_owned(),
+        req: json!({
+            "sellToken": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+            "buyToken": "0xba100000625a3754423978a60c9317c58a424e3d",
+            "orderKind": "sell",
+            "amount": "1000000000000000000",
+            "gasPrice": "15000000000",
+        }),
+        res: json!({
+            "tokenAddresses": [
+                "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+                "0xba100000625a3754423978a60c9317c58a424e3d"
+            ],
+            "swaps": [
+                {
+                    "poolId": "0x5c6ee304399dbdb9c8ef030ab642b10820db8f56000200000000000000000014",
+                    "assetInIndex": 0,
+                    "assetOutIndex": 1,
+                    "amount": "1000000000000000000",
+                    "userData": "0x",
+                    "returnAmount": "227598784442065388110"
+                }
+            ],
+            "swapAmount": "1000000000000000000",
+            "swapAmountForSwaps": "1000000000000000000",
+            "returnAmount": "227598784442065388110",
+            "returnAmountFromSwaps": "227598784442065388110",
+            "returnAmountConsideringFees": "227307710853355710706",
+            "tokenIn": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+            "tokenOut": "0xba100000625a3754423978a60c9317c58a424e3d",
+            "marketSp": "0.004393607339632106",
+        }),
+    }])
+    .await;
+
+    let engine = tests::SolverEngine::new("balancer", balancer::config(&api)).await;
+
+    let solution = engine
+        .solve(json!({
+            "id": null,
+            "tokens": {
+                "0xba100000625a3754423978a60c9317c58a424e3D": {
+                    "decimals": 18,
+                    "symbol": "BAL",
+                    "referencePrice": "4327903683155778",
+                    "availableBalance": "1583034704488033979459",
+                    "trusted": true
+                },
+                "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2": {
+                    "decimals": 18,
+                    "symbol": "WETH",
+                    "referencePrice": "1000000000000000000",
+                    "availableBalance": "482725140468789680",
+                    "trusted": true
+                },
+            },
+            "orders": [
+                {
+                    "uid": "0x2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a\
+                              2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a\
+                              2a2a2a2a",
+                    "sellToken": "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
+                    "buyToken": "0xba100000625a3754423978a60c9317c58a424e3D",
+                    "sellAmount": "1000000000000000000",
+                    "buyAmount": "200000000000000000000",
+                    "feeAmount": "1000000000000000",
+                    "kind": "sell",
+                    "partiallyFillable": false,
+                    "class": "market",
+                    "reward": 0.
+                }
+            ],
+            "liquidity": [],
+            "effectiveGasPrice": "15000000000",
+            "deadline": "2106-01-01T00:00:00.000Z"
+        }))
+        .await;
+
+    assert_eq!(
+        solution,
+        json!({
+            "prices": {
+                "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2": "227598784442065388110",
+                "0xba100000625a3754423978a60c9317c58a424e3d": "1000000000000000000"
+            },
+            "trades": [
+                {
+                    "kind": "fulfillment",
+                    "order": "0x2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a\
+                                2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a\
+                                2a2a2a2a",
+                    "executedAmount": "1000000000000000000"
+                }
+            ],
+            "interactions": [
+                {
+                    "kind": "custom",
+                    "internalize": false,
+                    "target": "0xba12222222228d8ba445958a75a0704d566bf2c8",
+                    "value": "0",
+                    "calldata": "0x945bcec9\
+                                   0000000000000000000000000000000000000000000000000000000000000000\
+                                   0000000000000000000000000000000000000000000000000000000000000120\
+                                   0000000000000000000000000000000000000000000000000000000000000220\
+                                   0000000000000000000000009008d19f58aabd9ed0d60971565aa8510560ab41\
+                                   0000000000000000000000000000000000000000000000000000000000000000\
+                                   0000000000000000000000009008d19f58aabd9ed0d60971565aa8510560ab41\
+                                   0000000000000000000000000000000000000000000000000000000000000000\
+                                   0000000000000000000000000000000000000000000000000000000000000280\
+                                   8000000000000000000000000000000000000000000000000000000000000000\
+                                   0000000000000000000000000000000000000000000000000000000000000001\
+                                   0000000000000000000000000000000000000000000000000000000000000020\
+                                   5c6ee304399dbdb9c8ef030ab642b10820db8f56000200000000000000000014\
+                                   0000000000000000000000000000000000000000000000000000000000000000\
+                                   0000000000000000000000000000000000000000000000000000000000000001\
+                                   0000000000000000000000000000000000000000000000000de0b6b3a7640000\
+                                   00000000000000000000000000000000000000000000000000000000000000a0\
+                                   0000000000000000000000000000000000000000000000000000000000000000\
+                                   0000000000000000000000000000000000000000000000000000000000000002\
+                                   000000000000000000000000c02aaa39b223fe8d0a0e5c4f27ead9083c756cc2\
+                                   000000000000000000000000ba100000625a3754423978a60c9317c58a424e3d\
+                                   0000000000000000000000000000000000000000000000000000000000000002\
+                                   0000000000000000000000000000000000000000000000000de0b6b3a7640000\
+                                   fffffffffffffffffffffffffffffffffffffffffffffff3c9049e4e47ca50ec",
+                    "allowances": [
+                        {
+                            "token": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+                            "spender": "0xba12222222228d8ba445958a75a0704d566bf2c8",
+                            "amount": "1000000000000000000",
+                        },
+                    ],
+                    "inputs": [
+                        {
+                            "token": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+                            "amount": "1000000000000000000"
+                        },
+                    ],
+                    "outputs": [
+                        {
+                            "token": "0xba100000625a3754423978a60c9317c58a424e3d",
+                            "amount": "227598784442065388110"
+                        },
+                    ],
+                }
+            ]
+        }),
+    );
+}
+
+#[tokio::test]
+async fn buy() {
+    let api = tests::dex::setup(vec![tests::dex::Expectation::Post {
+        path: "".to_owned(),
+        req: json!({
+            "sellToken": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+            "buyToken": "0xba100000625a3754423978a60c9317c58a424e3d",
+            "orderKind": "buy",
+            "amount": "100000000000000000000",
+            "gasPrice": "15000000000",
+        }),
+        res: json!({
+            "tokenAddresses": [
+                "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+                "0xba100000625a3754423978a60c9317c58a424e3d"
+            ],
+            "swaps": [
+                {
+                    "poolId": "0x5c6ee304399dbdb9c8ef030ab642b10820db8f56000200000000000000000014",
+                    "assetInIndex": 0,
+                    "assetOutIndex": 1,
+                    "amount": "100000000000000000000",
+                    "userData": "0x",
+                    "returnAmount": "439470293178110675"
+                }
+            ],
+            "swapAmount": "100000000000000000000",
+            "swapAmountForSwaps": "100000000000000000000",
+            "returnAmount": "439470293178110675",
+            "returnAmountFromSwaps": "439470293178110675",
+            "returnAmountConsideringFees": "440745919677086983",
+            "tokenIn": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+            "tokenOut": "0xba100000625a3754423978a60c9317c58a424e3d",
+            "marketSp": "0.004394663712203829"
+        }),
+    }])
+    .await;
+
+    let engine = tests::SolverEngine::new("balancer", balancer::config(&api)).await;
+
+    let solution = engine
+        .solve(json!({
+            "id": null,
+            "tokens": {
+                "0xba100000625a3754423978a60c9317c58a424e3D": {
+                    "decimals": 18,
+                    "symbol": "BAL",
+                    "referencePrice": "4327903683155778",
+                    "availableBalance": "1583034704488033979459",
+                    "trusted": true
+                },
+                "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2": {
+                    "decimals": 18,
+                    "symbol": "WETH",
+                    "referencePrice": "1000000000000000000",
+                    "availableBalance": "482725140468789680",
+                    "trusted": true
+                },
+            },
+            "orders": [
+                {
+                    "uid": "0x2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a\
+                              2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a\
+                              2a2a2a2a",
+                    "sellToken": "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
+                    "buyToken": "0xba100000625a3754423978a60c9317c58a424e3D",
+                    "sellAmount": "1000000000000000000",
+                    "buyAmount": "100000000000000000000",
+                    "feeAmount": "1000000000000000",
+                    "kind": "buy",
+                    "partiallyFillable": false,
+                    "class": "market",
+                    "reward": 0.
+                }
+            ],
+            "liquidity": [],
+            "effectiveGasPrice": "15000000000",
+            "deadline": "2106-01-01T00:00:00.000Z"
+        }))
+        .await;
+
+    assert_eq!(
+        solution,
+        json!({
+            "prices": {
+                "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2": "100000000000000000000",
+                "0xba100000625a3754423978a60c9317c58a424e3d": "439470293178110675"
+            },
+            "trades": [
+                {
+                    "kind": "fulfillment",
+                    "order": "0x2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a\
+                                2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a\
+                                2a2a2a2a",
+                    "executedAmount": "100000000000000000000"
+                }
+            ],
+            "interactions": [
+                {
+                    "kind": "custom",
+                    "internalize": false,
+                    "target": "0xba12222222228d8ba445958a75a0704d566bf2c8",
+                    "value": "0",
+                    "calldata": "0x945bcec9\
+                                   0000000000000000000000000000000000000000000000000000000000000001\
+                                   0000000000000000000000000000000000000000000000000000000000000120\
+                                   0000000000000000000000000000000000000000000000000000000000000220\
+                                   0000000000000000000000009008d19f58aabd9ed0d60971565aa8510560ab41\
+                                   0000000000000000000000000000000000000000000000000000000000000000\
+                                   0000000000000000000000009008d19f58aabd9ed0d60971565aa8510560ab41\
+                                   0000000000000000000000000000000000000000000000000000000000000000\
+                                   0000000000000000000000000000000000000000000000000000000000000280\
+                                   8000000000000000000000000000000000000000000000000000000000000000\
+                                   0000000000000000000000000000000000000000000000000000000000000001\
+                                   0000000000000000000000000000000000000000000000000000000000000020\
+                                   5c6ee304399dbdb9c8ef030ab642b10820db8f56000200000000000000000014\
+                                   0000000000000000000000000000000000000000000000000000000000000000\
+                                   0000000000000000000000000000000000000000000000000000000000000001\
+                                   0000000000000000000000000000000000000000000000056bc75e2d63100000\
+                                   00000000000000000000000000000000000000000000000000000000000000a0\
+                                   0000000000000000000000000000000000000000000000000000000000000000\
+                                   0000000000000000000000000000000000000000000000000000000000000002\
+                                   000000000000000000000000c02aaa39b223fe8d0a0e5c4f27ead9083c756cc2\
+                                   000000000000000000000000ba100000625a3754423978a60c9317c58a424e3d\
+                                   0000000000000000000000000000000000000000000000000000000000000002\
+                                   0000000000000000000000000000000000000000000000000628ecdcbd5c38c6\
+                                   fffffffffffffffffffffffffffffffffffffffffffffffa9438a1d29cf00000",
+                    "allowances": [
+                        {
+                            "token": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+                            "spender": "0xba12222222228d8ba445958a75a0704d566bf2c8",
+                            "amount": "443864996109891782",
+                        },
+                    ],
+                    "inputs": [
+                        {
+                            "token": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+                            "amount": "439470293178110675"
+                        },
+                    ],
+                    "outputs": [
+                        {
+                            "token": "0xba100000625a3754423978a60c9317c58a424e3d",
+                            "amount": "100000000000000000000"
+                        },
+                    ],
+                }
+            ]
+        }),
+    );
+}

--- a/crates/solvers/src/tests/balancer/mod.rs
+++ b/crates/solvers/src/tests/balancer/mod.rs
@@ -1,0 +1,14 @@
+use {crate::tests, std::net::SocketAddr};
+
+mod market_order;
+mod not_found;
+mod out_of_price;
+
+/// Creates a temporary file containing the config of the given solver.
+pub fn config(solver_addr: &SocketAddr) -> tests::Config {
+    tests::Config::String(format!(
+        r"
+endpoint = 'http://{solver_addr}/'
+        ",
+    ))
+}

--- a/crates/solvers/src/tests/balancer/not_found.rs
+++ b/crates/solvers/src/tests/balancer/not_found.rs
@@ -1,0 +1,72 @@
+//! This test ensures that the Balancer solver properly handles cases where no
+//! swap was found for the specified quoted order.
+
+use {
+    crate::tests::{self, balancer},
+    serde_json::json,
+};
+
+/// Tests that orders get marked as "mandatory" in `/quote` requests.
+#[tokio::test]
+async fn test() {
+    let api = tests::dex::setup(vec![tests::dex::Expectation::Post {
+        path: "".to_owned(),
+        req: json!({
+            "sellToken": "0x1111111111111111111111111111111111111111",
+            "buyToken": "0x2222222222222222222222222222222222222222",
+            "orderKind": "sell",
+            "amount": "1000000000000000000",
+            "gasPrice": "15000000000",
+        }),
+        res: json!({
+            "tokenAddresses": [],
+            "swaps": [],
+            "swapAmount": "0",
+            "swapAmountForSwaps": "0",
+            "returnAmount": "0",
+            "returnAmountFromSwaps": "0",
+            "returnAmountConsideringFees": "0",
+            "tokenIn": "",
+            "tokenOut": "",
+            "marketSp": "0",
+        }),
+    }])
+    .await;
+
+    let engine = tests::SolverEngine::new("balancer", balancer::config(&api)).await;
+
+    let solution = engine
+        .solve(json!({
+            "id": null,
+            "tokens": {},
+            "orders": [
+                {
+                    "uid": "0x2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a\
+                              2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a\
+                              2a2a2a2a",
+                    "sellToken": "0x1111111111111111111111111111111111111111",
+                    "buyToken": "0x2222222222222222222222222222222222222222",
+                    "sellAmount": "1000000000000000000",
+                    "buyAmount": "1000000000000000000",
+                    "feeAmount": "1000000000000000",
+                    "kind": "sell",
+                    "partiallyFillable": false,
+                    "class": "market",
+                    "reward": 0.,
+                },
+            ],
+            "liquidity": [],
+            "effectiveGasPrice": "15000000000",
+            "deadline": "2106-01-01T00:00:00.000Z",
+        }))
+        .await;
+
+    assert_eq!(
+        solution,
+        json!({
+            "prices": {},
+            "trades": [],
+            "interactions": [],
+        }),
+    );
+}

--- a/crates/solvers/src/tests/balancer/out_of_price.rs
+++ b/crates/solvers/src/tests/balancer/out_of_price.rs
@@ -1,0 +1,194 @@
+//! This test verifies that the Balancer SOR solver does not generate solutions
+//! when the swap returned from the API does not satisfy an orders limit price.
+//!
+//! The actual test case is a modified version of the [`super::market_order`]
+//! test cases with exuberant limit prices.
+
+use {
+    crate::tests::{self, balancer},
+    serde_json::json,
+};
+
+#[tokio::test]
+async fn sell() {
+    let api = tests::dex::setup(vec![tests::dex::Expectation::Post {
+        path: "".to_owned(),
+        req: json!({
+            "sellToken": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+            "buyToken": "0xba100000625a3754423978a60c9317c58a424e3d",
+            "orderKind": "sell",
+            "amount": "1000000000000000000",
+            "gasPrice": "15000000000",
+        }),
+        res: json!({
+            "tokenAddresses": [
+                "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+                "0xba100000625a3754423978a60c9317c58a424e3d"
+            ],
+            "swaps": [
+                {
+                    "poolId": "0x5c6ee304399dbdb9c8ef030ab642b10820db8f56000200000000000000000014",
+                    "assetInIndex": 0,
+                    "assetOutIndex": 1,
+                    "amount": "1000000000000000000",
+                    "userData": "0x",
+                    "returnAmount": "227598784442065388110"
+                }
+            ],
+            "swapAmount": "1000000000000000000",
+            "swapAmountForSwaps": "1000000000000000000",
+            "returnAmount": "227598784442065388110",
+            "returnAmountFromSwaps": "227598784442065388110",
+            "returnAmountConsideringFees": "227307710853355710706",
+            "tokenIn": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+            "tokenOut": "0xba100000625a3754423978a60c9317c58a424e3d",
+            "marketSp": "0.004393607339632106",
+        }),
+    }])
+    .await;
+
+    let engine = tests::SolverEngine::new("balancer", balancer::config(&api)).await;
+
+    let solution = engine
+        .solve(json!({
+            "id": null,
+            "tokens": {
+                "0xba100000625a3754423978a60c9317c58a424e3D": {
+                    "decimals": 18,
+                    "symbol": "BAL",
+                    "referencePrice": "4327903683155778",
+                    "availableBalance": "1583034704488033979459",
+                    "trusted": true
+                },
+                "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2": {
+                    "decimals": 18,
+                    "symbol": "WETH",
+                    "referencePrice": "1000000000000000000",
+                    "availableBalance": "482725140468789680",
+                    "trusted": true
+                },
+            },
+            "orders": [
+                {
+                    "uid": "0x2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a\
+                              2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a\
+                              2a2a2a2a",
+                    "sellToken": "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
+                    "buyToken": "0xba100000625a3754423978a60c9317c58a424e3D",
+                    "sellAmount": "1000000000000000000",
+                    // Way too much...
+                    "buyAmount": "1000000000000000000000000000000000000",
+                    "feeAmount": "1000000000000000",
+                    "kind": "sell",
+                    "partiallyFillable": false,
+                    "class": "market",
+                    "reward": 0.
+                }
+            ],
+            "liquidity": [],
+            "effectiveGasPrice": "15000000000",
+            "deadline": "2106-01-01T00:00:00.000Z"
+        }))
+        .await;
+
+    assert_eq!(
+        solution,
+        json!({
+            "prices": {},
+            "trades": [],
+            "interactions": [],
+        }),
+    );
+}
+
+#[tokio::test]
+async fn buy() {
+    let api = tests::dex::setup(vec![tests::dex::Expectation::Post {
+        path: "".to_owned(),
+        req: json!({
+            "sellToken": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+            "buyToken": "0xba100000625a3754423978a60c9317c58a424e3d",
+            "orderKind": "buy",
+            "amount": "100000000000000000000",
+            "gasPrice": "15000000000",
+        }),
+        res: json!({
+            "tokenAddresses": [
+                "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+                "0xba100000625a3754423978a60c9317c58a424e3d"
+            ],
+            "swaps": [
+                {
+                    "poolId": "0x5c6ee304399dbdb9c8ef030ab642b10820db8f56000200000000000000000014",
+                    "assetInIndex": 0,
+                    "assetOutIndex": 1,
+                    "amount": "100000000000000000000",
+                    "userData": "0x",
+                    "returnAmount": "439470293178110675"
+                }
+            ],
+            "swapAmount": "100000000000000000000",
+            "swapAmountForSwaps": "100000000000000000000",
+            "returnAmount": "439470293178110675",
+            "returnAmountFromSwaps": "439470293178110675",
+            "returnAmountConsideringFees": "440745919677086983",
+            "tokenIn": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+            "tokenOut": "0xba100000625a3754423978a60c9317c58a424e3d",
+            "marketSp": "0.004394663712203829"
+        }),
+    }])
+    .await;
+
+    let engine = tests::SolverEngine::new("balancer", balancer::config(&api)).await;
+
+    let solution = engine
+        .solve(json!({
+            "id": null,
+            "tokens": {
+                "0xba100000625a3754423978a60c9317c58a424e3D": {
+                    "decimals": 18,
+                    "symbol": "BAL",
+                    "referencePrice": "4327903683155778",
+                    "availableBalance": "1583034704488033979459",
+                    "trusted": true
+                },
+                "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2": {
+                    "decimals": 18,
+                    "symbol": "WETH",
+                    "referencePrice": "1000000000000000000",
+                    "availableBalance": "482725140468789680",
+                    "trusted": true
+                },
+            },
+            "orders": [
+                {
+                    "uid": "0x2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a\
+                              2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a\
+                              2a2a2a2a",
+                    "sellToken": "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
+                    "buyToken": "0xba100000625a3754423978a60c9317c58a424e3D",
+                    // Way too little...
+                    "sellAmount": "1",
+                    "buyAmount": "100000000000000000000",
+                    "feeAmount": "1000000000000000",
+                    "kind": "buy",
+                    "partiallyFillable": false,
+                    "class": "market",
+                    "reward": 0.
+                }
+            ],
+            "liquidity": [],
+            "effectiveGasPrice": "15000000000",
+            "deadline": "2106-01-01T00:00:00.000Z"
+        }))
+        .await;
+
+    assert_eq!(
+        solution,
+        json!({
+            "prices": {},
+            "trades": [],
+            "interactions": [],
+        }),
+    );
+}

--- a/crates/solvers/src/tests/baseline/direct_swap.rs
+++ b/crates/solvers/src/tests/baseline/direct_swap.rs
@@ -5,7 +5,11 @@ use {crate::tests, serde_json::json};
 
 #[tokio::test]
 async fn test() {
-    let engine = tests::SolverEngine::new("baseline", Some("example.baseline.toml")).await;
+    let engine = tests::SolverEngine::new(
+        "baseline",
+        tests::Config::File("example.baseline.toml".into()),
+    )
+    .await;
 
     let solution = engine
         .solve(json!({

--- a/crates/solvers/src/tests/dex.rs
+++ b/crates/solvers/src/tests/dex.rs
@@ -1,0 +1,113 @@
+use std::{
+    net::SocketAddr,
+    sync::{Arc, Mutex},
+};
+
+#[derive(Debug, Clone)]
+pub enum Expectation {
+    Get {
+        path: String,
+        res: serde_json::Value,
+    },
+    Post {
+        path: String,
+        req: serde_json::Value,
+        res: serde_json::Value,
+    },
+}
+
+/// Set up an mock external DEX or DEX aggregator API.
+pub async fn setup(expectations: Vec<Expectation>) -> SocketAddr {
+    let state = Arc::new(Mutex::new(expectations));
+    let app = axum::Router::new()
+        .route(
+            "/*path",
+            axum::routing::get(
+                |axum::extract::State(state),
+                 axum::extract::Path(path),
+                 axum::extract::RawQuery(query)| async move {
+                    axum::response::Json(get(state, Some(path), query))
+                },
+            )
+            .post(
+                |axum::extract::State(state),
+                 axum::extract::Path(path),
+                 axum::extract::RawQuery(query),
+                 axum::extract::Json(req)| async move {
+                    axum::response::Json(post(state, Some(path), query, req))
+                },
+            ),
+        )
+        // Annoying, but `axum` doesn't seem to match `/` with the above route,
+        // so explicitely mount `/`.
+        .route(
+            "/",
+            axum::routing::get(
+                |axum::extract::State(state), axum::extract::RawQuery(query)| async move {
+                    axum::response::Json(get(state, None, query))
+                },
+            )
+            .post(
+                |axum::extract::State(state),
+                 axum::extract::RawQuery(query),
+                 axum::extract::Json(req)| async move {
+                    axum::response::Json(post(state, None, query, req))
+                },
+            ),
+        )
+        .with_state(State(state));
+    let server = axum::Server::bind(&"0.0.0.0:0".parse().unwrap()).serve(app.into_make_service());
+    let addr = server.local_addr();
+    tokio::spawn(async move { server.await.unwrap() });
+    tokio::time::sleep(tokio::time::Duration::from_millis(1_000)).await;
+    addr
+}
+
+#[derive(Debug, Clone)]
+struct State(Arc<Mutex<Vec<Expectation>>>);
+
+fn get(state: State, path: Option<String>, query: Option<String>) -> serde_json::Value {
+    let mut state = state.0.lock().unwrap();
+    assert!(
+        !state.is_empty(),
+        "got another GET request, but didn't expect any more"
+    );
+
+    let full_path = full_path(path, query);
+    let (expected_path, res) = match state.pop().unwrap() {
+        Expectation::Get { path, res } => (path, res),
+        other => panic!("expected GET request but got {other:?}"),
+    };
+
+    assert_eq!(full_path, expected_path, "GET request has unexpected path");
+    res
+}
+
+fn post(
+    state: State,
+    path: Option<String>,
+    query: Option<String>,
+    req: serde_json::Value,
+) -> serde_json::Value {
+    let mut state = state.0.lock().unwrap();
+    assert!(
+        !state.is_empty(),
+        "got another POST request, but didn't expect any more"
+    );
+
+    let full_path = full_path(path, query);
+    let (expected_path, expected_req, res) = match state.pop().unwrap() {
+        Expectation::Post { path, req, res } => (path, req, res),
+        other => panic!("expected POST request but got {other:?}"),
+    };
+
+    assert_eq!(full_path, expected_path, "POST request has unexpected path");
+    assert_eq!(req, expected_req, "POST request has unexpected body");
+    res
+}
+
+fn full_path(path: Option<String>, query: Option<String>) -> String {
+    let path = path.unwrap_or_default();
+    let query = query.unwrap_or_default();
+    format!("{path}{query}")
+}

--- a/crates/solvers/src/tests/dex.rs
+++ b/crates/solvers/src/tests/dex.rs
@@ -59,7 +59,6 @@ pub async fn setup(expectations: Vec<Expectation>) -> SocketAddr {
     let server = axum::Server::bind(&"0.0.0.0:0".parse().unwrap()).serve(app.into_make_service());
     let addr = server.local_addr();
     tokio::spawn(async move { server.await.unwrap() });
-    tokio::time::sleep(tokio::time::Duration::from_millis(1_000)).await;
     addr
 }
 
@@ -67,18 +66,14 @@ pub async fn setup(expectations: Vec<Expectation>) -> SocketAddr {
 struct State(Arc<Mutex<Vec<Expectation>>>);
 
 fn get(state: State, path: Option<String>, query: Option<String>) -> serde_json::Value {
-    let mut state = state.0.lock().unwrap();
-    assert!(
-        !state.is_empty(),
-        "got another GET request, but didn't expect any more"
-    );
-
-    let full_path = full_path(path, query);
-    let (expected_path, res) = match state.pop().unwrap() {
-        Expectation::Get { path, res } => (path, res),
-        other => panic!("expected GET request but got {other:?}"),
+    let expectation = state.0.lock().unwrap().pop();
+    let (expected_path, res) = match expectation {
+        Some(Expectation::Get { path, res }) => (path, res),
+        Some(other) => panic!("expected GET request but got {other:?}"),
+        None => panic!("got another GET request, but didn't expect any more"),
     };
 
+    let full_path = full_path(path, query);
     assert_eq!(full_path, expected_path, "GET request has unexpected path");
     res
 }
@@ -89,18 +84,14 @@ fn post(
     query: Option<String>,
     req: serde_json::Value,
 ) -> serde_json::Value {
-    let mut state = state.0.lock().unwrap();
-    assert!(
-        !state.is_empty(),
-        "got another POST request, but didn't expect any more"
-    );
-
-    let full_path = full_path(path, query);
-    let (expected_path, expected_req, res) = match state.pop().unwrap() {
-        Expectation::Post { path, req, res } => (path, req, res),
-        other => panic!("expected POST request but got {other:?}"),
+    let expectation = state.0.lock().unwrap().pop();
+    let (expected_path, expected_req, res) = match expectation {
+        Some(Expectation::Post { path, req, res }) => (path, req, res),
+        Some(other) => panic!("expected POST request but got {other:?}"),
+        None => panic!("got another POST request, but didn't expect any more"),
     };
 
+    let full_path = full_path(path, query);
     assert_eq!(full_path, expected_path, "POST request has unexpected path");
     assert_eq!(req, expected_req, "POST request has unexpected body");
     res

--- a/crates/solvers/src/tests/legacy/attaching_approvals.rs
+++ b/crates/solvers/src/tests/legacy/attaching_approvals.rs
@@ -82,9 +82,8 @@ async fn test() {
         }),
     }])
     .await;
-    let config = legacy::create_temp_config_file(&legacy_solver);
 
-    let engine = tests::SolverEngine::new("legacy", Some(config.to_str().unwrap())).await;
+    let engine = tests::SolverEngine::new("legacy", legacy::config(&legacy_solver)).await;
 
     let solution = engine
         .solve(json!({

--- a/crates/solvers/src/tests/legacy/jit_order.rs
+++ b/crates/solvers/src/tests/legacy/jit_order.rs
@@ -63,9 +63,8 @@ async fn test() {
         }),
     }])
     .await;
-    let config = legacy::create_temp_config_file(&legacy_solver);
 
-    let engine = tests::SolverEngine::new("legacy", Some(config.to_str().unwrap())).await;
+    let engine = tests::SolverEngine::new("legacy", legacy::config(&legacy_solver)).await;
 
     let solution = engine
         .solve(json!({

--- a/crates/solvers/src/tests/legacy/market_order.rs
+++ b/crates/solvers/src/tests/legacy/market_order.rs
@@ -106,9 +106,8 @@ async fn test_quoting() {
             }
         }),
     }]).await;
-    let config = legacy::create_temp_config_file(&legacy_solver);
 
-    let engine = tests::SolverEngine::new("legacy", Some(config.to_str().unwrap())).await;
+    let engine = tests::SolverEngine::new("legacy", legacy::config(&legacy_solver)).await;
 
     let solution = engine
         .solve(json!({
@@ -296,9 +295,8 @@ async fn test_solving() {
             }
         }),
     }]).await;
-    let config = legacy::create_temp_config_file(&legacy_solver);
 
-    let engine = tests::SolverEngine::new("legacy", Some(config.to_str().unwrap())).await;
+    let engine = tests::SolverEngine::new("legacy", legacy::config(&legacy_solver)).await;
 
     let solution = engine
         .solve(json!({

--- a/crates/solvers/src/tests/legacy/mod.rs
+++ b/crates/solvers/src/tests/legacy/mod.rs
@@ -1,12 +1,14 @@
+use {
+    crate::tests,
+    std::{
+        net::SocketAddr,
+        sync::{Arc, Mutex},
+    },
+};
+
 mod attaching_approvals;
 mod jit_order;
 mod market_order;
-
-use std::{
-    io::Write,
-    net::SocketAddr,
-    sync::{Arc, Mutex},
-};
 
 #[derive(Debug, Clone)]
 pub struct Expectation {
@@ -47,18 +49,13 @@ pub async fn setup(expectations: Vec<Expectation>) -> SocketAddr {
 #[derive(Debug, Clone)]
 struct State(Arc<Mutex<Vec<Expectation>>>);
 
-/// Creates a temporary file containing the config of the given solver.
-pub fn create_temp_config_file(solver_addr: &SocketAddr) -> tempfile::TempPath {
-    let base_url = format!("http://{solver_addr}/solve");
-    let config = format!(
+/// Creates a legacy solver configuration for the specified host.
+pub fn config(solver_addr: &SocketAddr) -> tests::Config {
+    tests::Config::String(format!(
         r"
 solver-name = 'legacy_solver'
-endpoint = '{}'
+endpoint = 'http://{solver_addr}/solve'
 chain-id = '1'
-",
-        base_url
-    );
-    let mut file = tempfile::NamedTempFile::new().unwrap();
-    file.write_all(config.as_bytes()).unwrap();
-    file.into_temp_path()
+        ",
+    ))
 }

--- a/crates/solvers/src/tests/naive/extract_deepest_pool.rs
+++ b/crates/solvers/src/tests/naive/extract_deepest_pool.rs
@@ -13,7 +13,7 @@ use {crate::tests, serde_json::json};
 
 #[tokio::test]
 async fn test() {
-    let engine = tests::SolverEngine::new("naive", None).await;
+    let engine = tests::SolverEngine::new("naive", tests::Config::None).await;
 
     let solution = engine
         .solve(json!({

--- a/crates/solvers/src/tests/naive/filters_out_of_price_orders.rs
+++ b/crates/solvers/src/tests/naive/filters_out_of_price_orders.rs
@@ -5,7 +5,7 @@ use {crate::tests, serde_json::json};
 
 #[tokio::test]
 async fn sell_orders_on_both_sides() {
-    let engine = tests::SolverEngine::new("naive", None).await;
+    let engine = tests::SolverEngine::new("naive", tests::Config::None).await;
 
     let solution = engine
         .solve(json!({

--- a/crates/solvers/src/tests/naive/limit_order_price.rs
+++ b/crates/solvers/src/tests/naive/limit_order_price.rs
@@ -5,7 +5,7 @@ use {crate::tests, serde_json::json};
 
 #[tokio::test]
 async fn test() {
-    let engine = tests::SolverEngine::new("naive", None).await;
+    let engine = tests::SolverEngine::new("naive", tests::Config::None).await;
 
     let solution = engine
         .solve(json!({

--- a/crates/solvers/src/tests/naive/matches_orders.rs
+++ b/crates/solvers/src/tests/naive/matches_orders.rs
@@ -5,7 +5,7 @@ use {crate::tests, serde_json::json};
 
 #[tokio::test]
 async fn sell_orders_on_both_sides() {
-    let engine = tests::SolverEngine::new("naive", None).await;
+    let engine = tests::SolverEngine::new("naive", tests::Config::None).await;
 
     let solution = engine
         .solve(json!({
@@ -103,7 +103,7 @@ async fn sell_orders_on_both_sides() {
 
 #[tokio::test]
 async fn sell_orders_on_one_side() {
-    let engine = tests::SolverEngine::new("naive", None).await;
+    let engine = tests::SolverEngine::new("naive", tests::Config::None).await;
 
     let solution = engine
         .solve(json!({
@@ -201,7 +201,7 @@ async fn sell_orders_on_one_side() {
 
 #[tokio::test]
 async fn buy_orders_on_both_sides() {
-    let engine = tests::SolverEngine::new("naive", None).await;
+    let engine = tests::SolverEngine::new("naive", tests::Config::None).await;
 
     let solution = engine
         .solve(json!({
@@ -299,7 +299,7 @@ async fn buy_orders_on_both_sides() {
 
 #[tokio::test]
 async fn buy_and_sell_orders() {
-    let engine = tests::SolverEngine::new("naive", None).await;
+    let engine = tests::SolverEngine::new("naive", tests::Config::None).await;
 
     let solution = engine
         .solve(json!({

--- a/crates/solvers/src/tests/naive/reserves_too_small.rs
+++ b/crates/solvers/src/tests/naive/reserves_too_small.rs
@@ -5,7 +5,7 @@ use {crate::tests, serde_json::json};
 
 #[tokio::test]
 async fn test() {
-    let engine = tests::SolverEngine::new("naive", None).await;
+    let engine = tests::SolverEngine::new("naive", tests::Config::None).await;
 
     let solution = engine
         .solve(json!({

--- a/crates/solvers/src/tests/naive/rounds_prices_in_favour_of_traders.rs
+++ b/crates/solvers/src/tests/naive/rounds_prices_in_favour_of_traders.rs
@@ -12,7 +12,7 @@ use {crate::tests, serde_json::json};
 
 #[tokio::test]
 async fn test() {
-    let engine = tests::SolverEngine::new("naive", None).await;
+    let engine = tests::SolverEngine::new("naive", tests::Config::None).await;
 
     let solution = engine
         .solve(json!({

--- a/crates/solvers/src/tests/naive/swap_less_than_reserves.rs
+++ b/crates/solvers/src/tests/naive/swap_less_than_reserves.rs
@@ -10,7 +10,7 @@ use {crate::tests, serde_json::json};
 
 #[tokio::test]
 async fn test() {
-    let engine = tests::SolverEngine::new("naive", None).await;
+    let engine = tests::SolverEngine::new("naive", tests::Config::None).await;
 
     let solution = engine
         .solve(json!({

--- a/crates/solvers/src/tests/naive/without_pool.rs
+++ b/crates/solvers/src/tests/naive/without_pool.rs
@@ -5,7 +5,7 @@ use {crate::tests, serde_json::json};
 
 #[tokio::test]
 async fn test() {
-    let engine = tests::SolverEngine::new("naive", None).await;
+    let engine = tests::SolverEngine::new("naive", tests::Config::None).await;
 
     let solution = engine
         .solve(json!({


### PR DESCRIPTION
This PR adds E2E tests to the ported Balancer SOR solver.

Nothing too crazy happening here. I also moved the `tempfile` logic out of `create_temp_config_file` into the `tests::SolverEngine` creation in order to make it easier to reuse for future solvers.

Added a `dex::setup` API mock for mocking external DEX HTTP APIs. I made it accept bothe `GET` and `POST` methods right off the bat as they will be needed for other DEX aggregator API solvers.

### Test Plan

🥄 
