### PR TITLE
Refactor token list module

### DIFF
--- a/crates/e2e/tests/e2e/settlement_without_onchain_liquidity.rs
+++ b/crates/e2e/tests/e2e/settlement_without_onchain_liquidity.rs
@@ -31,7 +31,7 @@ use {
         http_client::HttpClientFactory,
         maintenance::Maintaining,
         sources::uniswap_v2::pool_fetching::PoolFetcher,
-        token_list::{AutoUpdatingTokenList, Token},
+        token_list::AutoUpdatingTokenList,
     },
     solver::{
         liquidity::uniswap_v2::UniswapLikeLiquidity,
@@ -198,14 +198,8 @@ async fn onchain_settlement_without_liquidity(web3: Web3) {
         base_tokens,
     };
     let network_id = web3.net().version().await.unwrap();
-    let market_makable_token_list = AutoUpdatingTokenList::new(maplit::hashmap! {
-        token_a.address() => Token {
-            address: token_a.address(),
-            name: "Test Coin".into(),
-            symbol: "TC".into(),
-            decimals: 18,
-        }
-    });
+    let market_makable_token_list =
+        AutoUpdatingTokenList::new(std::iter::once(token_a.address()).collect());
     let post_processing_pipeline = Arc::new(PostProcessingPipeline::new(
         contracts.weth.address(),
         web3.clone(),

--- a/crates/solver/src/arguments.rs
+++ b/crates/solver/src/arguments.rs
@@ -117,10 +117,14 @@ pub struct Arguments {
     )]
     pub solver_time_limit: Duration,
 
-    /// The list of tokens our settlement contract is willing to buy when
-    /// settling trades without external liquidity
-    #[clap(long, env, default_value = "https://files.cow.fi/token_list.json")]
-    pub market_makable_token_list: String,
+    /// The URL of a list of tokens our settlement contract is willing to buy
+    /// when settling trades without external liquidity
+    #[clap(long, env)]
+    pub market_makable_token_list: Option<Url>,
+
+    /// Like `market_makable_token_list` but hardcoded list of tokens.
+    #[clap(long, env, use_value_delimiter = true)]
+    pub market_makable_tokens: Option<Vec<H160>>,
 
     /// Time interval after which market makable list needs to be updated
     #[clap(
@@ -339,10 +343,18 @@ impl std::fmt::Display for Arguments {
         writeln!(f, "metrics_port: {}", self.metrics_port)?;
         writeln!(f, "max_merged_settlements: {}", self.max_merged_settlements)?;
         writeln!(f, "solver_time_limit: {:?}", self.solver_time_limit)?;
-        writeln!(
+        display_option(
             f,
-            "market_makable_token_list: {}",
-            self.market_makable_token_list
+            "market_makable_token_list",
+            &self.market_makable_token_list,
+        )?;
+        display_option(
+            f,
+            "market_makable_tokens",
+            &self
+                .market_makable_tokens
+                .as_ref()
+                .map(|list| format!("{list:?}")),
         )?;
         writeln!(f, "gas_price_cap: {}", self.gas_price_cap)?;
         writeln!(f, "transaction_strategy: {:?}", self.transaction_strategy)?;

--- a/crates/solver/src/run.rs
+++ b/crates/solver/src/run.rs
@@ -266,6 +266,7 @@ pub async fn run(args: Arguments) {
         update_interval: args.market_makable_token_list_update_interval,
         chain_id,
         client: http_factory.create(),
+        hardcoded: args.market_makable_tokens.unwrap_or_default(),
     };
     // updated in background task
     let market_makable_token_list =

--- a/crates/solver/src/settlement_post_processing/optimize_buffer_usage.rs
+++ b/crates/solver/src/settlement_post_processing/optimize_buffer_usage.rs
@@ -34,7 +34,7 @@ fn is_only_selling_trusted_tokens(
     settlement: &Settlement,
     market_makable_token_list: &AutoUpdatingTokenList,
 ) -> bool {
-    let market_makable_token_list = market_makable_token_list.addresses();
+    let market_makable_token_list = market_makable_token_list.all();
     !settlement
         .traded_orders()
         .any(|order| !market_makable_token_list.contains(&order.data.sell_token))
@@ -45,10 +45,8 @@ mod tests {
     use {
         super::*,
         crate::settlement::Trade,
-        maplit::hashmap,
         model::order::{Order, OrderData},
         primitive_types::H160,
-        shared::token_list::Token,
     };
 
     #[test]
@@ -57,20 +55,8 @@ mod tests {
         let another_good_token = H160::from_low_u64_be(2);
         let bad_token = H160::from_low_u64_be(3);
 
-        let token_list = AutoUpdatingTokenList::new(hashmap! {
-            good_token => Token {
-                address: good_token,
-                symbol: "Foo".into(),
-                name: "FooCoin".into(),
-                decimals: 18,
-            },
-            another_good_token => Token {
-                address: another_good_token,
-                symbol: "Bar".into(),
-                name: "BarCoin".into(),
-                decimals: 18,
-            }
-        });
+        let token_list =
+            AutoUpdatingTokenList::new([good_token, another_good_token].into_iter().collect());
 
         let trade = |token| Trade {
             order: Order {

--- a/crates/solver/src/solver/http_solver.rs
+++ b/crates/solver/src/solver/http_solver.rs
@@ -119,7 +119,7 @@ impl Solver for HttpSolver {
         // settlement contract
         let non_bufferable_tokens = non_bufferable_tokens_used(
             &settled.interaction_data,
-            &self.market_makable_token_list.addresses(),
+            &self.market_makable_token_list.all(),
         );
         if !non_bufferable_tokens.is_empty() {
             tracing::warn!(

--- a/crates/solver/src/solver/http_solver/instance_creation.rs
+++ b/crates/solver/src/solver/http_solver/instance_creation.rs
@@ -65,7 +65,7 @@ impl InstanceCreator {
                 });
         orders.extend(limit_orders);
 
-        let market_makable_token_list = self.market_makable_token_list.addresses();
+        let market_makable_token_list = self.market_makable_token_list.all();
 
         let tokens = map_tokens_for_solver(&orders, &amms, &market_makable_token_list);
         let (token_infos, buffers_result) = futures::join!(


### PR DESCRIPTION
Factored out of https://github.com/cowprotocol/services/pull/1229 .

For an e2e test we need a token whose buffers are allowed to be traded. The existing test accomplishes this by manually creating the token list component. With the change to using only the main/run functions of the crates this is no longer possible.

In this PR we change the driver arguments to allow passing in a hardcoded token list and not using a remote URL. We also simplify the token list component by removing extra token information like the symbol, decimals etc that are not relevant for the rust code.

### Test Plan

CI

