### PR TITLE
Port 0x Api

### DIFF
--- a/crates/solvers/src/domain/dex/mod.rs
+++ b/crates/solvers/src/domain/dex/mod.rs
@@ -165,4 +165,8 @@ impl Amount {
     pub fn new(value: U256) -> Self {
         Self(value)
     }
+
+    pub fn get(&self) -> U256 {
+        self.0
+    }
 }

--- a/crates/solvers/src/domain/dex/slippage.rs
+++ b/crates/solvers/src/domain/dex/slippage.rs
@@ -54,6 +54,10 @@ impl Limits {
 pub struct Slippage(BigDecimal);
 
 impl Slippage {
+    pub fn one_percent() -> Self {
+        Self("0.01".parse().unwrap())
+    }
+
     /// Adds slippage to the specified token amount. This can be used to account
     /// for negative slippage in a sell amount.
     pub fn add(&self, amount: U256) -> U256 {
@@ -76,6 +80,11 @@ impl Slippage {
 
         let abs = numer.div_ceil(&denom);
         conv::biguint_to_u256(&abs).unwrap_or_else(U256::max_value)
+    }
+
+    /// Returns the relative slippage as a `BigDecimal` factor.
+    pub fn as_factor(&self) -> &BigDecimal {
+        &self.0
     }
 }
 

--- a/crates/solvers/src/infra/dex/mod.rs
+++ b/crates/solvers/src/infra/dex/mod.rs
@@ -1,1 +1,2 @@
 pub mod balancer;
+pub mod zeroex;

--- a/crates/solvers/src/infra/dex/zeroex/dto.rs
+++ b/crates/solvers/src/infra/dex/zeroex/dto.rs
@@ -95,19 +95,19 @@ pub struct Quote {
     /// The address of the contract to call in order to execute the swap.
     pub to: H160,
 
-    #[serde_as(as = "serialize::Hex")]
     /// The swap calldata.
+    #[serde_as(as = "serialize::Hex")]
     pub data: Vec<u8>,
 
     /// The Ether value to use in order to execute the swap.
     #[serde_as(as = "serialize::U256")]
     pub value: U256,
 
-    // The amount of sell token (in atoms) that would be sold in this swap.
+    /// The amount of sell token (in atoms) that would be sold in this swap.
     #[serde_as(as = "serialize::U256")]
     pub sell_amount: U256,
 
-    // The amount of buy token (in atoms) that would be bought in this swap.
+    /// The amount of buy token (in atoms) that would be bought in this swap.
     #[serde_as(as = "serialize::U256")]
     pub buy_amount: U256,
 

--- a/crates/solvers/src/infra/dex/zeroex/dto.rs
+++ b/crates/solvers/src/infra/dex/zeroex/dto.rs
@@ -1,0 +1,160 @@
+//! DTOs for the 0x swap API. Full documentation for the API can be found
+//! [here](https://docs.0x.org/0x-api-swap/api-references/get-swap-v1-quote).
+
+use {
+    crate::{
+        domain::{auction, dex, order},
+        util::serialize,
+    },
+    bigdecimal::BigDecimal,
+    ethereum_types::{H160, U256},
+    serde::{Deserialize, Serialize},
+    serde_with::serde_as,
+};
+
+/// A 0x API quote query parameters.
+///
+/// See [API](https://docs.0x.org/0x-api-swap/api-references/get-swap-v1-quote)
+/// documentation for more detailed information on each parameter.
+#[serde_as]
+#[derive(Clone, Default, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Query {
+    /// Contract address of a token to sell.
+    pub sell_token: H160,
+
+    /// Contract address of a token to buy.
+    pub buy_token: H160,
+
+    /// Amount of a token to sell, set in atoms.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde_as(as = "Option<serialize::U256>")]
+    pub sell_amount: Option<U256>,
+
+    /// Amount of a token to sell, set in atoms.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde_as(as = "Option<serialize::U256>")]
+    pub buy_amount: Option<U256>,
+
+    /// Limit of price slippage you are willing to accept.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub slippage_percentage: Option<Slippage>,
+
+    /// The target gas price for the swap transaction.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde_as(as = "Option<serialize::U256>")]
+    pub gas_price: Option<U256>,
+
+    /// List of sources to exclude.
+    #[serde(skip_serializing_if = "Vec::is_empty", with = "comma_separated")]
+    pub excluded_sources: Vec<String>,
+
+    /// The affiliate address to use for tracking and analytics purposes.
+    pub affiliate_address: H160,
+
+    /// Requests trade routes which aim to protect against high slippage and MEV
+    /// attacks.
+    pub enable_slippage_protection: bool,
+}
+
+/// A 0x slippage amount.
+#[derive(Clone, Debug, Serialize)]
+pub struct Slippage(BigDecimal);
+
+impl Query {
+    pub fn with_domain(
+        self,
+        order: &dex::Order,
+        slippage: &dex::Slippage,
+        gas_price: auction::GasPrice,
+    ) -> Self {
+        let (sell_amount, buy_amount) = match order.side {
+            order::Side::Buy => (None, Some(order.amount.get())),
+            order::Side::Sell => (Some(order.amount.get()), None),
+        };
+
+        Self {
+            sell_token: order.sell.0,
+            buy_token: order.buy.0,
+            sell_amount,
+            buy_amount,
+            // Note that the API calls this "slippagePercentage", but it is **not** a
+            // percentage but a factor.
+            slippage_percentage: Some(Slippage(slippage.as_factor().clone())),
+            gas_price: Some(gas_price.0 .0),
+            ..self
+        }
+    }
+}
+
+/// A Ox API quote response.
+#[serde_as]
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Quote {
+    /// The address of the contract to call in order to execute the swap.
+    pub to: H160,
+
+    #[serde_as(as = "serialize::Hex")]
+    /// The swap calldata.
+    pub data: Vec<u8>,
+
+    /// The Ether value to use in order to execute the swap.
+    #[serde_as(as = "serialize::U256")]
+    pub value: U256,
+
+    // The amount of sell token (in atoms) that would be sold in this swap.
+    #[serde_as(as = "serialize::U256")]
+    pub sell_amount: U256,
+
+    // The amount of buy token (in atoms) that would be bought in this swap.
+    #[serde_as(as = "serialize::U256")]
+    pub buy_amount: U256,
+
+    /// The target contract address for which the user needs to have an
+    /// allowance in order to be able to complete the swap.
+    #[serde(with = "address_none_when_zero")]
+    pub allowance_target: Option<H160>,
+}
+
+/// The 0x API uses the 0-address to indicate that no approvals are needed for a
+/// swap. Use a custom deserializer to turn that into `None`.
+mod address_none_when_zero {
+    use {
+        ethereum_types::H160,
+        serde::{Deserialize, Deserializer},
+    };
+
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<Option<H160>, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let value = H160::deserialize(deserializer)?;
+        Ok((!value.is_zero()).then_some(value))
+    }
+}
+
+/// 0x API expects comma separated lists for `excludedSources` query parameter.
+mod comma_separated {
+    use serde::Serializer;
+
+    pub fn serialize<S>(list: &[String], serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(&list.join(","))
+    }
+}
+
+#[derive(Deserialize)]
+#[serde(untagged)]
+pub enum Response {
+    Ok(Quote),
+    Err(Error),
+}
+
+#[derive(Deserialize)]
+pub struct Error {
+    pub code: i64,
+    pub reason: String,
+}

--- a/crates/solvers/src/infra/dex/zeroex/mod.rs
+++ b/crates/solvers/src/infra/dex/zeroex/mod.rs
@@ -1,0 +1,192 @@
+use {
+    crate::domain::{auction, dex, eth, order},
+    ethereum_types::H160,
+    std::sync::atomic::{self, AtomicU64},
+    tracing::Instrument,
+};
+
+mod dto;
+
+/// Bindings to the 0x swap API.
+pub struct ZeroEx {
+    client: reqwest::Client,
+    endpoint: reqwest::Url,
+    settlement: eth::ContractAddress,
+    defaults: dto::Query,
+}
+
+pub struct Config {
+    /// The base URL for the 0x swap API.
+    pub endpoint: Option<reqwest::Url>,
+
+    /// Optional API key.
+    ///
+    /// 0x provides a gated API for partners that requires authentication
+    /// by specifying this as header in the HTTP request.
+    pub api_key: Option<String>,
+
+    /// The address of the Settlement contract.
+    pub settlement: eth::ContractAddress,
+
+    /// The list of excluded liquidity sources. These will not be considered
+    /// when quoting.
+    pub excluded_sources: Vec<String>,
+
+    /// The affiliate address to use.
+    ///
+    /// This is used by 0x for tracking and analytic purposes.
+    pub affiliate_address: Option<H160>,
+
+    /// Whether or not to enable slippage protection.
+    pub enable_slippage_protection: bool,
+}
+
+const DEFAULT_URL: &str = "https://api.0x.org/";
+
+impl ZeroEx {
+    pub fn new(config: Config) -> Result<Self, CreationError> {
+        let client = match config.api_key {
+            Some(key) => {
+                let mut key = reqwest::header::HeaderValue::from_str(&key)?;
+                key.set_sensitive(true);
+
+                let mut headers = reqwest::header::HeaderMap::new();
+                headers.insert("0x-api-key", key);
+
+                reqwest::Client::builder()
+                    .default_headers(headers)
+                    .build()?
+            }
+            None => reqwest::Client::new(),
+        };
+        let defaults = dto::Query {
+            excluded_sources: config.excluded_sources,
+            affiliate_address: config.affiliate_address.unwrap_or(config.settlement.0),
+            enable_slippage_protection: config.enable_slippage_protection,
+            ..Default::default()
+        };
+
+        Ok(Self {
+            client,
+            endpoint: config
+                .endpoint
+                .unwrap_or_else(|| DEFAULT_URL.parse().unwrap()),
+            settlement: config.settlement,
+            defaults,
+        })
+    }
+
+    async fn quote(&self, query: &dto::Query) -> Result<dto::Quote, Error> {
+        let request = self
+            .client
+            .get(self.endpoint.join("swap/v1/quote").unwrap())
+            .query(query)
+            .build()?;
+        tracing::trace!(request = %request.url(), "quoting");
+        let response = self
+            .client
+            .execute(request)
+            .await?
+            .error_for_status()?
+            .text()
+            .await?;
+        tracing::trace!(%response, "quoted");
+        let quote = serde_json::from_str(&response)?;
+
+        Ok(quote)
+    }
+
+    pub async fn swap(
+        &self,
+        order: &dex::Order,
+        slippage: &dex::Slippage,
+        gas_price: auction::GasPrice,
+    ) -> Result<dex::Swap, Error> {
+        let query = self
+            .defaults
+            .clone()
+            .with_domain(order, slippage, gas_price);
+        let quote = {
+            // Set up a tracing span to make debugging of API requests easier.
+            // Historically, debugging API requests to external DEXs was a bit
+            // of a headache.
+            static ID: AtomicU64 = AtomicU64::new(0);
+            let id = ID.fetch_add(1, atomic::Ordering::Relaxed);
+            self.quote(&query)
+                .instrument(tracing::trace_span!("quote", id = %id))
+                .await?
+        };
+
+        // Since we only trade ERC20 tokens, we expect that the swap should
+        // never require a value.
+        if !quote.value.is_zero() {
+            return Err(Error::NonZeroValue);
+        }
+
+        let max_sell_amount = match order.side {
+            order::Side::Buy => slippage.add(quote.sell_amount),
+            order::Side::Sell => quote.sell_amount,
+        };
+
+        Ok(dex::Swap {
+            call: dex::Call {
+                to: eth::ContractAddress(quote.to),
+                calldata: quote.data,
+            },
+            input: eth::Asset {
+                token: order.sell,
+                amount: quote.sell_amount,
+            },
+            output: eth::Asset {
+                token: order.buy,
+                amount: quote.buy_amount,
+            },
+            allowance: dex::Allowance {
+                spender: quote
+                    .allowance_target
+                    .ok_or(Error::MissingSpender)
+                    .map(eth::ContractAddress)?,
+                amount: dex::Amount::new(max_sell_amount),
+            },
+        })
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum CreationError {
+    #[error(transparent)]
+    Header(#[from] reqwest::header::InvalidHeaderValue),
+    #[error(transparent)]
+    Client(#[from] reqwest::Error),
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    #[error("unable to find a quote")]
+    NotFound,
+    #[error("quote has a non-zero transaction value")]
+    NonZeroValue,
+    #[error("quote does not specify an approval spender")]
+    MissingSpender,
+    #[error("api error code {code}: {reason}")]
+    Api { code: i64, reason: String },
+    #[error(transparent)]
+    Json(#[from] serde_json::Error),
+    #[error(transparent)]
+    Http(#[from] reqwest::Error),
+}
+
+impl From<dto::Error> for Error {
+    fn from(err: dto::Error) -> Self {
+        // Unfortunately, AFAIK these codes aren't documented anywhere. These
+        // based on empirical observations of what the API has returned in the
+        // past.
+        match err.code {
+            100 => Self::NotFound,
+            _ => Self::Api {
+                code: err.code,
+                reason: err.reason,
+            },
+        }
+    }
+}


### PR DESCRIPTION
Similar to #1234, this PR ports the 0x API to the `solvers` crate.

Nothing too special, although we make use of the `reqwest::RequestBuilder::query(q: impl serde::Serialize)` to avoid manual serialization code 🎉.

Additionally, I added some (hopefully) more complete documentation to the DTOs with links to the online documentation. I also removed fields that we don't need/use to keep the DTOs as slim as possible.

### Test Plan

No E2E test quite yet. However, a manual test can be run:

<details><summary><code>manual-test.patch</code></summary>

```diff
diff --git a/crates/solvers/src/infra/dex/zeroex/mod.rs b/crates/solvers/src/infra/dex/zeroex/mod.rs
index 287385da..d2ff7ce3 100644
--- a/crates/solvers/src/infra/dex/zeroex/mod.rs
+++ b/crates/solvers/src/infra/dex/zeroex/mod.rs
@@ -190,3 +190,55 @@ impl From<dto::Error> for Error {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn manual() {
+        shared::tracing::initialize_reentrant("solvers=trace");
+
+        let dex = ZeroEx {
+            client: reqwest::Client::new(),
+            endpoint: DEFAULT_URL.parse().unwrap(),
+            settlement: eth::ContractAddress(
+                "0x9008D19f58AAbD9eD0D60971565AA8510560ab41"
+                    .parse()
+                    .unwrap(),
+            ),
+            defaults: dto::Query {
+                excluded_sources: vec![
+                    "Uniswap".to_owned(),
+                    "SushiSwap".to_owned(),
+                    "Curve".to_string(),
+                ],
+                ..Default::default()
+            },
+        };
+
+        let swap = dex
+            .swap(
+                &dex::Order {
+                    sell: eth::TokenAddress(
+                        "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2"
+                            .parse()
+                            .unwrap(),
+                    ),
+                    buy: eth::TokenAddress(
+                        "0xE41d2489571d322189246DaFA5ebDe1F4699F498"
+                            .parse()
+                            .unwrap(),
+                    ),
+                    side: order::Side::Sell,
+                    amount: dex::Amount::new(1_000_000_000_000_000_000_u128.into()),
+                },
+                &dex::Slippage::one_percent(),
+                auction::GasPrice(eth::Ether(15_000_000_000_u128.into())),
+            )
+            .await
+            .unwrap();
+
+        panic!("{swap:#?}");
+    }
+}

```

</details>
