### PR TITLE
Fix transaction-submission-nodes driver argument

### DIFF
--- a/crates/e2e/tests/e2e/services.rs
+++ b/crates/e2e/tests/e2e/services.rs
@@ -73,6 +73,7 @@ pub fn start_old_driver(
         "solver".to_string(),
         format!("--solver-account={}", hex::encode(private_key)),
         "--settle-interval=1".to_string(),
+        "--transaction-submission-nodes=http://localhost:8545".to_string(),
     ]
     .into_iter()
     .chain(api_autopilot_solver_arguments(contracts).chain(extra_args.iter().cloned()));

--- a/crates/solver/src/arguments.rs
+++ b/crates/solver/src/arguments.rs
@@ -248,12 +248,7 @@ pub struct Arguments {
 
     /// The RPC endpoints to use for submitting transaction to a custom set of
     /// nodes.
-    #[clap(
-        long,
-        env,
-        use_value_delimiter = true,
-        default_value = "http://localhost:8545"
-    )]
+    #[clap(long, env, use_value_delimiter = true)]
     pub transaction_submission_nodes: Vec<Url>,
 
     /// Additional RPC endpoints that we notify when we submit a transaction to


### PR DESCRIPTION
My e2e refactor added a default to the argument. This is problematic because in shadow mode we don't want any such node and it is hard to set the argument to no value with clap.

### Test Plan

see that CI succeeds

