### PR TITLE
More readable order hash in error message

### DIFF
--- a/crates/refunder/src/refund_service.rs
+++ b/crates/refunder/src/refund_service.rs
@@ -8,7 +8,7 @@ use {
         orders::read_order as read_db_order,
         OrderUid,
     },
-    ethcontract::{Account, H160},
+    ethcontract::{Account, H160, H256},
     futures::{stream, StreamExt},
     shared::{
         current_block::timestamp_of_current_block_in_seconds,
@@ -115,7 +115,7 @@ impl RefundService {
                             tracing::error!(
                                 "Error while getting the currentonchain status of orderhash {:?}, \
                                  {:?}",
-                                order_hash,
+                                H256(order_hash),
                                 err
                             );
                             return None;


### PR DESCRIPTION
Makes error message more readable, as suggested by Martin when [we saw it in the alerts](https://cowservices.slack.com/archives/C037PB929ME/p1677142527169469).

### Test Plan

I just confirmed that debug printing H256 looks good:
 
```
let order_hash = [
    223, 233, 185, 202, 128, 197, 77, 101, 90, 198, 129, 33, 192, 78, 11, 250, 201, 191, 1,
    211, 166, 49, 250, 113, 169, 224, 81, 185, 214, 166, 7, 25,
];
tracing::error!("{:?}", H256(order_hash));
```

prints

```
2023-02-23T10:58:25.131Z ERROR refunder: 0xdfe9b9ca80c54d655ac68121c04e0bfac9bf01d3a631fa71a9e051b9d6a60719
```