### PR TITLE
[UniV2Like] Add Pancakce Swap to Baseline Liquidity

### DIFF
--- a/crates/contracts/artifacts/PancakeFactory.json
+++ b/crates/contracts/artifacts/PancakeFactory.json
@@ -1,0 +1,1 @@
+IUniswapLikeFactory.json

--- a/crates/contracts/artifacts/PancakeRouter.json
+++ b/crates/contracts/artifacts/PancakeRouter.json
@@ -1,0 +1,1 @@
+IUniswapLikeRouter.json

--- a/crates/contracts/build.rs
+++ b/crates/contracts/build.rs
@@ -220,6 +220,12 @@ fn main() {
     generate_contract("IUniswapLikePair");
     // EIP-1271 contract - SignatureValidator
     generate_contract("ERC1271SignatureValidator");
+    generate_contract_with_config("PancakeFactory", |builder| {
+        builder.add_network_str("1", "0x1097053Fd2ea711dad45caCcc45EfF7548fCB362")
+    });
+    generate_contract_with_config("PancakeRouter", |builder| {
+        builder.add_network_str("1", "0xeff92a263d31888d860bd50809a8d171709b7b1c")
+    });
     generate_contract_with_config("SushiSwapFactory", |builder| {
         builder
             .add_network_str(MAINNET, "0xC0AEe478e3658e2610c5F7A4A2E1777cE9e4f2Ac")

--- a/crates/contracts/src/lib.rs
+++ b/crates/contracts/src/lib.rs
@@ -48,6 +48,8 @@ include_contracts! {
     IUniswapLikeRouter;
     IUniswapV3Factory;
     IZeroEx;
+    PancakeFactory;
+    PancakeRouter;
     SolverTrampoline;
     SushiSwapFactory;
     SushiSwapRouter;

--- a/crates/shared/src/sources.rs
+++ b/crates/shared/src/sources.rs
@@ -26,6 +26,7 @@ pub enum BaselineSource {
     Swapr,
     ZeroEx,
     UniswapV3,
+    PancakeSwap,
 }
 
 pub fn defaults_for_chain(chain_id: u64) -> Result<Vec<BaselineSource>> {
@@ -37,6 +38,7 @@ pub fn defaults_for_chain(chain_id: u64) -> Result<Vec<BaselineSource>> {
             BaselineSource::BalancerV2,
             BaselineSource::ZeroEx,
             BaselineSource::UniswapV3,
+            BaselineSource::PancakeSwap,
         ],
         4 => vec![
             BaselineSource::UniswapV2,

--- a/crates/shared/src/sources/uniswap_v2.rs
+++ b/crates/shared/src/sources/uniswap_v2.rs
@@ -30,6 +30,8 @@ pub const BAOSWAP_INIT: [u8; 32] =
     hex!("0bae3ead48c325ce433426d2e8e6b07dac10835baec21e163760682ea3d3520d");
 pub const SWAPR_INIT: [u8; 32] =
     hex!("d306a548755b9295ee49cc729e13ca4a45e00199bbd890fa146da43a50571776");
+pub const PANCAKE_INIT: [u8; 32] =
+    hex!("57224589c67f3f30a6b0d7a1b54cf3153ab84563bc609ef41dfb34f8b2974d2d");
 
 #[derive(Debug, Clone, Copy)]
 pub struct UniV2BaselineSourceParameters {
@@ -79,6 +81,11 @@ impl UniV2BaselineSourceParameters {
                 contracts::SwaprRouter::raw_contract(),
                 SWAPR_INIT,
                 PoolReadingStyle::Swapr,
+            )),
+            BS::PancakeSwap => Some((
+                contracts::PancakeRouter::raw_contract(),
+                PANCAKE_INIT,
+                PoolReadingStyle::Default,
             )),
         }?;
         Some(Self {


### PR DESCRIPTION
Based on a [Request in slack](https://cowservices.slack.com/archives/C0375NV72SC/p1677154605070629) and also (hopefully) to serve as documentation for future liquidity integrations. 

This PR adds Pancake swap Router and Factory contracts.

Also, I am not sure if this documentation [here](https://github.com/cowprotocol/services/tree/main/crates/contracts) is relevant when creating sim links to existing contracts.

## Test Plan

Unfortunately it has been quite a long time since I have touched this and I am not sure how to test this anymore (ideally we see that a pancake pool is being included in an auction).

