### PR TITLE
Use Obviously Wrong Private Keys in Example Config

### DIFF
--- a/crates/driver/example.toml
+++ b/crates/driver/example.toml
@@ -3,14 +3,14 @@ name = "mysolver" # Arbitrary name given to this solver, must be unique
 endpoint = "http://0.0.0.0:33219/solve"
 absolute-slippage = "12" # Denominated in wei, optional
 relative-slippage = "0.1" # Percentage in the [0, 1] range
-address = "0x2cf0a2Fef084b6DB3fb3161c8f2b6B61bcE2F73c" # The ETH address of this solver
-private-key = "0xaa1de59084f3b7e501f2d48cafb2ee04cd06a79ea126fd27ddf3d1b8903bb85a" # The private key of the solver
+address = "0x7E5F4552091A69125d5DfCb7b8C2659029395Bdf" # The ETH address of this solver
+private-key = "0x0000000000000000000000000000000000000000000000000000000000000001" # The private key of the solver
 
 [[solver]] # And so on, specify as many solvers as needed
 name = "othersolver"
 endpoint = "http://localhost:1235"
 relative-slippage = "0.1"
-private-key = "0xfe1cbe78dbf9511c37be9716b9b347bcefaaaf8ee5e86dd40cfc3d763ac9a7b6"
+private-key = "0x0000000000000000000000000000000000000000000000000000000000000002"
 
 [contracts] # Optionally override the contract addresses, necessary on less popular blockchains
 gp-v2-settlement = "0x9008D19f58AAbD9eD0D60971565AA8510560ab41"


### PR DESCRIPTION
Use obviously fake PKs in example configuration to avoid confusion.
