### PR TITLE
Driver: don't return solutions with no settled order

### DIFF
--- a/crates/autopilot/src/driver_model.rs
+++ b/crates/autopilot/src/driver_model.rs
@@ -116,7 +116,7 @@ pub mod solve {
     #[serde(deny_unknown_fields)]
     pub struct Response {
         pub id: String,
-        pub score: f64,
+        pub score: Option<f64>,
     }
 }
 

--- a/crates/driver/src/domain/competition/solution/mod.rs
+++ b/crates/driver/src/domain/competition/solution/mod.rs
@@ -1,8 +1,13 @@
 use {
+    self::trade::Fulfillment,
     crate::{
         boundary,
         domain::{
-            competition::{self, order},
+            competition::{
+                self,
+                order::{self, Kind},
+                Order,
+            },
             eth,
         },
         infra::{
@@ -162,6 +167,21 @@ impl Solution {
             inner: settlement,
             access_list,
             gas,
+        })
+    }
+
+    pub fn has_user_trade(&self) -> bool {
+        self.trades.iter().any(|trade| {
+            matches!(
+                trade,
+                Trade::Fulfillment(Fulfillment {
+                    order: Order {
+                        kind: Kind::Market | Kind::Limit { .. },
+                        ..
+                    },
+                    ..
+                })
+            )
         })
     }
 }

--- a/crates/driver/src/infra/api/routes/solve/dto/solution.rs
+++ b/crates/driver/src/infra/api/routes/solve/dto/solution.rs
@@ -5,10 +5,11 @@ use {
 };
 
 impl Solution {
-    pub fn from_domain(id: solution::Id, score: competition::Score) -> Self {
+    /// A None score indicates no solution was found.
+    pub fn from_domain(id: solution::Id, score: Option<competition::Score>) -> Self {
         Self {
             id: id.into(),
-            score: score.into(),
+            score: score.map(Into::into),
         }
     }
 }
@@ -18,5 +19,5 @@ impl Solution {
 pub struct Solution {
     #[serde_as(as = "DisplayFromStr")]
     id: u64,
-    score: f64,
+    score: Option<f64>,
 }


### PR DESCRIPTION
Currently Driver will happily forward empty solutions from Solvers which Autopilot then tells Driver to settle resulting in a wasted on chain transaction.

Note that the openapi document already allows for score to be null for this reason.

### Test Plan

e2e test still works, didn't add a test for specifically what is prevented by this PR
