### PR TITLE
Change driver default log filter

### DIFF
--- a/crates/driver/src/infra/cli.rs
+++ b/crates/driver/src/infra/cli.rs
@@ -13,7 +13,7 @@ pub struct Args {
     #[clap(
         long,
         env,
-        default_value = "debug,hyper=warn,driver::infra::solver=trace"
+        default_value = "warn,driver=debug,driver::infra::solver=trace,shared=debug,solver=debug"
     )]
     pub log: String,
 


### PR DESCRIPTION
We don't need debug logs for all crates like arbitrary dependencies.

### Test Plan

n/a
