### PR TITLE
Colocation: Do not execute empty solutions

### DIFF
--- a/crates/autopilot/src/run_loop.rs
+++ b/crates/autopilot/src/run_loop.rs
@@ -78,6 +78,10 @@ impl RunLoop {
 
         // TODO: Keep going with other solutions until some deadline.
         if let Some((index, solution)) = solutions.pop() {
+            // The winner has score 0 so all solutions are empty.
+            if solution.score == 0. {
+                return;
+            }
             tracing::info!("executing with solver {}", index);
             match self
                 .execute(auction, id, &self.drivers[index], &solution)
@@ -188,7 +192,13 @@ impl RunLoop {
         results
             .into_iter()
             .filter_map(|(index, result)| match result {
-                Ok(result) => Some((index, result)),
+                Ok(result) if result.score.is_finite() && result.score >= 0. => {
+                    Some((index, result))
+                }
+                Ok(result) => {
+                    tracing::warn!("bad score {:?}", result.score);
+                    None
+                }
                 Err(err) => {
                     tracing::warn!(?err, "driver solve error");
                     None

--- a/crates/driver/openapi.yml
+++ b/crates/driver/openapi.yml
@@ -273,16 +273,16 @@ components:
           type: string
           example: "2020-12-03T18:35:18.814523Z"
     SolveResponse:
-      description: Response of the solve endpoint.
+      description: |
+        Response of the solve endpoint.
+
+        A score of 0 indicates the empty solution, which is never executed.
       type: object
       properties:
-        objective:
+        score:
           description: |
             The objective value of the solution.
-
-            `null` indicates that solving was successful but no solution was found.
           type: number
-          nullable: true
         signature:
           description: |
             Signature confirming that the Solver promised to have this solution for this auction.


### PR DESCRIPTION
Closes https://github.com/cowprotocol/services/pull/1268 . Nick suggested that an empty solution can be indicated by using a 0 score. This makes sense to me. This means Driver doesn't need to change. Although I'm not sure if Driver assigns nonzero score to solutions that only settle liquidity orders, in which case a change should still be done.


### Test Plan

colocation e2e test still works
