### PR TITLE
Balancer response status code

### DIFF
--- a/crates/shared/src/balancer_sor_api.rs
+++ b/crates/shared/src/balancer_sor_api.rs
@@ -46,10 +46,12 @@ impl BalancerSorApi for DefaultBalancerSorApi {
             .post(self.url.clone())
             .json(&query)
             .send()
-            .await?
+            .await?;
+        let status = response.status();
+        let response = response
             .text()
             .await?;
-        tracing::debug!(%response, "received Balancer SOR quote");
+        tracing::debug!(%response, %status, "received Balancer SOR quote");
 
         let quote = serde_json::from_str::<Quote>(&response)?;
         if quote.is_empty() {

--- a/crates/shared/src/balancer_sor_api.rs
+++ b/crates/shared/src/balancer_sor_api.rs
@@ -8,7 +8,7 @@ use {
     ethcontract::{H160, H256, U256},
     model::{order::OrderKind, u256_decimal},
     num::BigInt,
-    reqwest::{Client, IntoUrl, Url},
+    reqwest::{Client, IntoUrl, StatusCode, Url},
     serde::{Deserialize, Serialize},
     serde_with::{serde_as, DisplayFromStr},
 };
@@ -48,10 +48,9 @@ impl BalancerSorApi for DefaultBalancerSorApi {
             .send()
             .await?;
         let status = response.status();
-        let response = response
-            .text()
-            .await?;
+        let response = response.text().await?;
         tracing::debug!(%response, %status, "received Balancer SOR quote");
+        anyhow::ensure!(status != StatusCode::TOO_MANY_REQUESTS, "rate limited");
 
         let quote = serde_json::from_str::<Quote>(&response)?;
         if quote.is_empty() {


### PR DESCRIPTION
Balancer sometime sends empty responses leading to these logs:
```
2023-02-27T07:44:20.562Z  WARN auction{id=5699489 run=7891}: solver::solver::single_order_solver: Solver BalancerSOR error: EOF while parsing a value at line 1 column 0
```

In the past this usually meant that we got a 429 (rate limiting) error. This PR starts logging the status code and preemptively adds a nicer error message for that case.

### Test Plan
CI
