### PR TITLE
Omit toml parsing error details for secrecy

### DIFF
--- a/crates/driver/src/infra/config/file/load.rs
+++ b/crates/driver/src/infra/config/file/load.rs
@@ -17,7 +17,7 @@ pub async fn load(path: &Path) -> infra::Config {
         .await
         .unwrap_or_else(|e| panic!("I/O error while reading {path:?}: {e:?}"));
     let config: file::Config = toml::de::from_str(&data)
-        .unwrap_or_else(|e| panic!("TOML syntax error while reading {path:?}: {e:?}"));
+        .unwrap_or_else(|_| panic!("TOML syntax error while reading {path:?}"));
     infra::Config {
         solvers: config
             .solvers

--- a/crates/solvers/src/infra/config/balancer/file.rs
+++ b/crates/solvers/src/infra/config/balancer/file.rs
@@ -52,7 +52,7 @@ pub async fn load(path: &Path) -> super::Config {
         .await
         .unwrap_or_else(|e| panic!("I/O error while reading {path:?}: {e:?}"));
     let config = toml::de::from_str::<Config>(&data)
-        .unwrap_or_else(|e| panic!("TOML syntax error while reading {path:?}: {e:?}"));
+        .unwrap_or_else(|_| panic!("TOML syntax error while reading {path:?}"));
 
     // Balancer SOR solver only supports mainnet.
     let contracts = contracts::Contracts::for_chain(eth::ChainId::Mainnet);

--- a/crates/solvers/src/infra/config/baseline/file.rs
+++ b/crates/solvers/src/infra/config/baseline/file.rs
@@ -41,7 +41,7 @@ pub async fn load(path: &Path) -> super::Config {
         .await
         .unwrap_or_else(|e| panic!("I/O error while reading {path:?}: {e:?}"));
     let config = toml::de::from_str::<Config>(&data)
-        .unwrap_or_else(|e| panic!("TOML syntax error while reading {path:?}: {e:?}"));
+        .unwrap_or_else(|_| panic!("TOML syntax error while reading {path:?}"));
     let weth = match (config.chain_id, config.weth) {
         (Some(chain_id), None) => contracts::Contracts::for_chain(chain_id).weth,
         (None, Some(weth)) => eth::WethAddress(weth),

--- a/crates/solvers/src/infra/config/legacy.rs
+++ b/crates/solvers/src/infra/config/legacy.rs
@@ -37,7 +37,7 @@ pub async fn load(path: &Path) -> legacy::Config {
         .await
         .unwrap_or_else(|e| panic!("I/O error while reading {path:?}: {e:?}"));
     let config = toml::de::from_str::<Config>(&data)
-        .unwrap_or_else(|e| panic!("TOML syntax error while reading {path:?}: {e:?}"));
+        .unwrap_or_else(|_| panic!("TOML syntax error while reading {path:?}"));
     let contracts = contracts::Contracts::for_chain(config.chain_id);
 
     legacy::Config {

--- a/crates/solvers/src/infra/config/zeroex/file.rs
+++ b/crates/solvers/src/infra/config/zeroex/file.rs
@@ -76,7 +76,7 @@ pub async fn load(path: &Path) -> super::Config {
         .await
         .unwrap_or_else(|e| panic!("I/O error while reading {path:?}: {e:?}"));
     let config = toml::de::from_str::<Config>(&data)
-        .unwrap_or_else(|e| panic!("TOML syntax error while reading {path:?}: {e:?}"));
+        .unwrap_or_else(|_| panic!("TOML syntax error while reading {path:?}"));
 
     super::Config {
         zeroex: zeroex::Config {


### PR DESCRIPTION
Fixes #1266 

Printing the exact TOML parsing error is helpful to quickly fix your syntax but unfortunately it can also reveal secrets like a private key or api keys.

Unfortunately there is also a way to expose secrets with the `Display` formatted version of the error. It's more difficult to expose secrets with that but we should probably not take the risk and drop the TOML parsing error altogether.

### Test Plan
Before (text includes private key):
```
thread 'main' panicked at 'TOML syntax error while reading "../driver.toml": Error { inner: Error { inner: TomlError { message: "expected `.`, `=`", original: Some("disable-access-list-simulation = true\nmiep\n\n[[solver]]\nname = \"cowdexag\"\nendpoint = \"http://0.0.0.0:7872\"\nabsolute-slippage = \"1000000000000000000\" # Denominated in wei, optional\nrelative-slippage = \"1\" # Percentage in the [0, 1] range\naddress = \"0x6d1247b8acf4dfd5ff8cfd6c47077ddc43d4500e\" # The ETH address of this solver\nprivate-key = \"0xaa1de59084f3b7e501f2d48cafb2ee04cd06a79ea126fd27ddf3d1b8903bb85a\" # The private key of the solver\n\n[liquidity]\nbase-tokens = [\n    \"0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2\",\n    \"0x6B175474E89094C44Da98b954EedeAC495271d0F\",\n    \"0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48\",\n    \"0xdAC17F958D2ee523a2206206994597C13D831ec7\",\n    \"0xc00e94Cb662C3520282E6f5717214004A7f26888\",\n    \"0x9f8F72aA9304c8B593d555F12eF6589cC3A579A2\",\n    \"0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599\",\n    \"0x6810e776880C02933D47DB1b9fc05908e5386b96\",\n]\n\n[[liquidity.uniswap-v3]] # Mainnet Uniswap V3 configuration\nrouter = \"0xE592427A0AEce92De3Edee1F18E0157C05861564\"\nmax-pools-to-initialize = 100\n\n# [[liquidity.uniswap-v2]] # Mainnet Uniswap V2 configuration\n# router = \"0x7a250d5630B4cF539739dF2C5dAcb4c659F2488D\"\n# pool-code = \"0x96e8ac4277198ff8b6f785478aa9a39f403cb768dd02cbee326c3e7da348845f\"\n"), keys: [], span: Some(42..43) } } }', /Users/martin/work/backend/main/crates/driver/src/infra/config/file/load.rs:20:29
```
After (no sensitive data exposed):
```
thread 'main' panicked at 'TOML syntax error while reading "../driver.toml"', /Users/martin/work/backend/main/crates/driver/src/infra/config/file/load.rs:20:29
```