### PR TITLE
SolverRewards 6: Populate external prices from driver

### DIFF
--- a/crates/autopilot/src/database/auction_prices.rs
+++ b/crates/autopilot/src/database/auction_prices.rs
@@ -1,47 +1,12 @@
 use {
     anyhow::Context,
-    database::{auction::AuctionId, auction_prices::AuctionPrice, byte_array::ByteArray},
-    number_conversions::{big_decimal_to_u256, u256_to_big_decimal},
+    database::auction::AuctionId,
+    number_conversions::big_decimal_to_u256,
     primitive_types::{H160, U256},
     std::collections::BTreeMap,
 };
 
 impl super::Postgres {
-    /// Insert external prices for an auction, provided by the autopilot.
-    pub async fn insert_auction_prices(
-        &self,
-        auction_id: AuctionId,
-        prices: &BTreeMap<H160, U256>,
-    ) -> anyhow::Result<()> {
-        let _timer = super::Metrics::get()
-            .database_queries
-            .with_label_values(&["insert_auction_prices"])
-            .start_timer();
-
-        let mut ex = self.0.begin().await?;
-
-        database::auction_prices::delete(&mut ex, auction_id)
-            .await
-            .context("delete_auction_prices")?;
-        database::auction_prices::insert(
-            &mut ex,
-            prices
-                .iter()
-                .map(|(token, price)| AuctionPrice {
-                    auction_id,
-                    token: ByteArray(token.0),
-                    price: u256_to_big_decimal(price),
-                })
-                .collect::<Vec<_>>()
-                .as_slice(),
-        )
-        .await
-        .context("insert_auction_prices")?;
-
-        ex.commit().await?;
-        Ok(())
-    }
-
     pub async fn get_auction_prices(
         &self,
         auction_id: AuctionId,
@@ -54,8 +19,7 @@ impl super::Postgres {
         let mut ex = self.0.acquire().await.context("acquire")?;
         let prices = database::auction_prices::fetch(&mut ex, auction_id)
             .await
-            .context("get_auction_prices")?;
-        let prices = prices
+            .with_context(|| format!("get_auction_prices for auction {auction_id}"))?
             .into_iter()
             .map(|p| (H160(p.token.0), big_decimal_to_u256(&p.price).unwrap()))
             .collect();

--- a/crates/autopilot/src/decoded_settlement.rs
+++ b/crates/autopilot/src/decoded_settlement.rs
@@ -34,7 +34,6 @@ type DecodedSettlementTokenized = (
 );
 
 #[derive(Debug)]
-#[allow(dead_code)]
 pub struct DecodedSettlement {
     // TODO check if `EncodedSettlement` can be reused
     pub tokens: Vec<Address>,

--- a/crates/autopilot/src/on_settlement_event_updater.rs
+++ b/crates/autopilot/src/on_settlement_event_updater.rs
@@ -168,7 +168,7 @@ impl OnSettlementEventUpdater {
             fee,
         };
 
-        tracing::debug!("updating settlement details for tx {hash:?}: {update:?}");
+        tracing::debug!(?hash, ?update, "updating settlement details for tx");
 
         self.db
             .update_settlement_details(update.clone())

--- a/crates/autopilot/src/on_settlement_event_updater.rs
+++ b/crates/autopilot/src/on_settlement_event_updater.rs
@@ -26,12 +26,9 @@
 // a) the mined transaction call data
 // b) the auction external prices fetched from orderbook
 // c) the orders fetched from orderbook
-// Auction external prices for all tokens for all solvable orders are stored in
-// the database (auction_prices table) in autopilot before competition.
 // After a transaction is mined we calculate the surplus and fees for each
 // transaction and insert them into the database (settlement_observations
-// table). Now we know which tokens were used in the transaction so we
-// update the auction_prices table with the actual prices that were used.
+// table).
 
 use {
     crate::{
@@ -48,7 +45,7 @@ use {
         event_handling::MAX_REORG_BLOCK_COUNT,
         external_prices::ExternalPrices,
     },
-    std::{collections::HashSet, time::Duration},
+    std::time::Duration,
     web3::types::TransactionId,
 };
 
@@ -159,52 +156,6 @@ impl OnSettlementEventUpdater {
         let surplus = settlement.total_surplus(&external_prices);
         let fee = settlement.total_fees(&external_prices, &orders, &configuration);
 
-        // reduce external prices in `auction_prices` table to only include used tokens
-        // this is done to reduce the amount of data we store in the database
-        let order_tokens = orders
-            .into_iter()
-            .flat_map(|order| vec![order.buy_token, order.sell_token])
-            .collect::<HashSet<_>>();
-        let prices = settlement
-            .trades
-            .iter()
-            .flat_map(|trade| {
-                let buy_token = settlement
-                    .tokens
-                    .get(trade.buy_token_index.as_u64() as usize)?;
-                let sell_token = settlement
-                    .tokens
-                    .get(trade.sell_token_index.as_u64() as usize)?;
-                let buy_token_price = auction_external_prices.get(buy_token);
-                let sell_token_price = auction_external_prices.get(sell_token);
-                match (buy_token_price, sell_token_price) {
-                    (Some(buy_token_price), Some(sell_token_price)) => Some(vec![
-                        (*buy_token, *buy_token_price),
-                        (*sell_token, *sell_token_price),
-                    ]),
-                    _ => {
-                        // for db orders there should be external price for tokens
-                        if order_tokens.contains(buy_token) {
-                            tracing::error!(
-                                "missing buy_token {} auction {}",
-                                auction_id,
-                                sell_token
-                            );
-                        }
-                        if order_tokens.contains(sell_token) {
-                            tracing::error!(
-                                "missing sell_token {} auction {}",
-                                auction_id,
-                                sell_token
-                            );
-                        }
-                        None
-                    }
-                }
-            })
-            .flatten()
-            .collect::<std::collections::BTreeMap<_, _>>();
-
         let update = SettlementUpdate {
             block_number: event.block_number,
             log_index: event.log_index,
@@ -215,8 +166,9 @@ impl OnSettlementEventUpdater {
             effective_gas_price,
             surplus,
             fee,
-            prices,
         };
+
+        tracing::debug!("updating settlement details for tx {hash:?}: {update:?}");
 
         self.db
             .update_settlement_details(update.clone())

--- a/crates/autopilot/src/solvable_orders.rs
+++ b/crates/autopilot/src/solvable_orders.rs
@@ -269,16 +269,7 @@ impl SolvableOrdersCache {
         counter.record(&auction.orders);
 
         if self.store_in_db {
-            let auction_id = self.database.replace_current_auction(&auction).await?;
-            self.database
-                .insert_auction_prices(auction_id, &auction.prices)
-                .await
-                .with_context(|| {
-                    format!(
-                        "update external prices for auction {} with prices {:?}",
-                        auction_id, &auction.prices
-                    )
-                })?;
+            let _ = self.database.replace_current_auction(&auction).await?;
         }
 
         *self.cache.lock().unwrap() = Inner {

--- a/crates/database/src/auction_prices.rs
+++ b/crates/database/src/auction_prices.rs
@@ -29,12 +29,6 @@ pub async fn insert(
     Ok(())
 }
 
-pub async fn delete(ex: &mut PgTransaction<'_>, auction_id: AuctionId) -> Result<(), sqlx::Error> {
-    const QUERY: &str = "DELETE FROM auction_prices WHERE auction_id = $1";
-    sqlx::query(QUERY).bind(auction_id).execute(ex).await?;
-    Ok(())
-}
-
 pub async fn fetch(
     ex: &mut PgConnection,
     auction_id: AuctionId,
@@ -70,10 +64,6 @@ mod tests {
         insert(&mut db, &input).await.unwrap();
         let output = fetch(&mut db, 1).await.unwrap();
         assert_eq!(input, output);
-
-        delete(&mut db, 1).await.unwrap();
-        let output = fetch(&mut db, 1).await.unwrap();
-        assert!(output.is_empty());
 
         // non-existent auction
         let output = fetch(&mut db, 2).await.unwrap();

--- a/crates/model/src/solver_competition.rs
+++ b/crates/model/src/solver_competition.rs
@@ -24,7 +24,8 @@ pub struct Request {
     pub competition: SolverCompetitionDB,
     pub executions: Vec<(OrderUid, Execution)>,
     pub scores: Scores,
-    pub participants: Vec<H160>, // solver addresses
+    pub participants: Vec<H160>,      // solver addresses
+    pub prices: BTreeMap<H160, U256>, // external prices for auction
 }
 
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]

--- a/crates/model/src/solver_competition.rs
+++ b/crates/model/src/solver_competition.rs
@@ -8,7 +8,7 @@ use {
     primitive_types::{H160, H256, U256},
     serde::{Deserialize, Serialize},
     serde_with::serde_as,
-    std::collections::BTreeMap,
+    std::collections::{BTreeMap, HashSet},
 };
 
 /// As a temporary measure the driver informs the api about per competition data
@@ -24,7 +24,7 @@ pub struct Request {
     pub competition: SolverCompetitionDB,
     pub executions: Vec<(OrderUid, Execution)>,
     pub scores: Scores,
-    pub participants: Vec<H160>,      // solver addresses
+    pub participants: HashSet<H160>,  // solver addresses
     pub prices: BTreeMap<H160, U256>, // external prices for auction
 }
 

--- a/crates/orderbook/src/database/solver_competition.rs
+++ b/crates/orderbook/src/database/solver_competition.rs
@@ -191,7 +191,7 @@ mod tests {
                 reference_score: 99.into(),
                 block_deadline: 10,
             },
-            participants: vec![H160([1; 20])],
+            participants: [H160([1; 20])].into(),
             prices: BTreeMap::from([(H160([1; 20]), 1.into())]),
         };
         db.handle_request(request.clone()).await.unwrap();

--- a/crates/shared/src/http_solver/model.rs
+++ b/crates/shared/src/http_solver/model.rs
@@ -193,7 +193,7 @@ pub enum Score {
     /// To have more flexibility, the protocol score can be tweaked by the
     /// solver by providing a multiplication factor. Expected value: [0,
     /// inf], 0 being 100% discount, 1 being the same as protocol score
-    MulFactor(f64),
+    ScoreFactor(f64),
 }
 
 #[serde_as]
@@ -854,14 +854,14 @@ mod tests {
             {
                 "tokens": {},
                 "orders": {},
-                "mulFactor": 13.37,
+                "scoreFactor": 13.37,
                 "metadata": {},
                 "ref_token": "0xc778417e063141139fce010982780140aa0cd5ab",
                 "prices": {}
             }
         "#;
         let deserialized = serde_json::from_str::<SettledBatchAuctionModel>(solution).unwrap();
-        assert_eq!(deserialized.score, Some(Score::MulFactor(13.37)));
+        assert_eq!(deserialized.score, Some(Score::ScoreFactor(13.37)));
     }
 
     #[test]

--- a/crates/shared/src/http_solver/model.rs
+++ b/crates/shared/src/http_solver/model.rs
@@ -191,9 +191,10 @@ pub enum Score {
     /// This option is used to indicate that the solver did not provide a score.
     /// Instead, the score should be computed by the protocol.
     /// To have more flexibility, the protocol score can be tweaked by the
-    /// solver by providing a multiplication factor. Expected value: [0,
-    /// inf], 0 being 100% discount, 1 being the same as protocol score
-    ScoreFactor(f64),
+    /// solver by providing a discount.
+    #[serde(with = "u256_decimal")]
+    #[serde(rename = "scoreDiscount")]
+    Discount(U256),
 }
 
 #[serde_as]
@@ -854,14 +855,14 @@ mod tests {
             {
                 "tokens": {},
                 "orders": {},
-                "scoreFactor": 13.37,
+                "scoreDiscount": "1337",
                 "metadata": {},
                 "ref_token": "0xc778417e063141139fce010982780140aa0cd5ab",
                 "prices": {}
             }
         "#;
         let deserialized = serde_json::from_str::<SettledBatchAuctionModel>(solution).unwrap();
-        assert_eq!(deserialized.score, Some(Score::ScoreFactor(13.37)));
+        assert_eq!(deserialized.score, Some(Score::Discount(1337.into())));
     }
 
     #[test]

--- a/crates/solver/src/driver.rs
+++ b/crates/solver/src/driver.rs
@@ -472,7 +472,7 @@ impl Driver {
                 .flat_map(|trade| {
                     let sell_token = trade.order.data.sell_token;
                     let buy_token = trade.order.data.buy_token;
-                    vec![
+                    [
                         (
                             sell_token,
                             auction_prices.get(&sell_token).cloned().unwrap_or_default(),

--- a/crates/solver/src/driver.rs
+++ b/crates/solver/src/driver.rs
@@ -464,22 +464,25 @@ impl Driver {
                 .solutions
                 .iter()
                 .map(|solution| solution.solver_address)
-                .collect::<HashSet<_>>() // to avoid duplicates
-                .into_iter()
-                .collect();
-            // external prices for all tokens contained in the trades of a settlement
+                .collect::<HashSet<_>>(); // to avoid duplicates
+                                          // external prices for all tokens contained in the trades of a settlement
             let prices = winning_settlement
                 .settlement
                 .trades()
-                .filter_map(|trade| {
+                .flat_map(|trade| {
                     let sell_token = trade.order.data.sell_token;
                     let buy_token = trade.order.data.buy_token;
-                    Some(vec![
-                        (sell_token, auction_prices.get(&sell_token).cloned()?),
-                        (buy_token, auction_prices.get(&buy_token).cloned()?),
-                    ])
+                    vec![
+                        (
+                            sell_token,
+                            auction_prices.get(&sell_token).cloned().unwrap_or_default(),
+                        ),
+                        (
+                            buy_token,
+                            auction_prices.get(&buy_token).cloned().unwrap_or_default(),
+                        ),
+                    ]
                 })
-                .flatten()
                 .collect();
             tracing::debug!(?transaction, "winning solution transaction");
 

--- a/crates/solver/src/settlement_rater.rs
+++ b/crates/solver/src/settlement_rater.rs
@@ -209,7 +209,7 @@ impl SettlementRating for SettlementRater {
             let score = match &settlement.score {
                 Some(score) => match score {
                     shared::http_solver::model::Score::Score(score) => Score::Solver(*score),
-                    shared::http_solver::model::Score::MulFactor(factor) => Score::Discounted(
+                    shared::http_solver::model::Score::ScoreFactor(factor) => Score::Discounted(
                         discounted_score(&objective_value, factor).unwrap_or_default(),
                     ),
                 },


### PR DESCRIPTION
Fixes https://github.com/cowprotocol/services/pull/1279#discussion_r1118812860

Decision was made to simplify the insertion of the auction external prices. Now we do it from the driver instead of autopilot. 
Additionally, changes score multiplication factor to be an absolute value - score discount.
