### PR TITLE
Increase e2e test wait_for_condition timeouts

### DIFF
--- a/crates/e2e/tests/e2e/colocation_univ2.rs
+++ b/crates/e2e/tests/e2e/colocation_univ2.rs
@@ -8,7 +8,6 @@ use {
     reqwest::Url,
     secp256k1::SecretKey,
     shared::{ethrpc::Web3, sources::uniswap_v2::UNISWAP_INIT},
-    std::time::Duration,
     tokio::task::JoinHandle,
     web3::signing::SecretKeyRef,
 };
@@ -76,9 +75,7 @@ async fn test(web3: Web3) {
     tracing::info!("Waiting for trade.");
     let trade_happened =
         || async { token.balance_of(trader.address()).call().await.unwrap() != 0.into() };
-    wait_for_condition(Duration::from_secs(10), trade_happened)
-        .await
-        .unwrap();
+    wait_for_condition(TIMEOUT, trade_happened).await.unwrap();
 
     let balance = token.balance_of(trader.address()).call().await.unwrap();
     assert_eq!(balance, to_wei(1));

--- a/crates/e2e/tests/e2e/eth_flow.rs
+++ b/crates/e2e/tests/e2e/eth_flow.rs
@@ -41,7 +41,6 @@ use {
         ethrpc::Web3,
         signature_validator::check_erc1271_result,
     },
-    std::time::Duration,
 };
 
 const DAI_PER_ETH: u32 = 1_000;
@@ -106,11 +105,9 @@ async fn eth_flow_tx(web3: Web3) {
     .await;
 
     tracing::info!("waiting for trade");
-    wait_for_condition(Duration::from_secs(10), || async {
-        services.solvable_orders().await == 1
-    })
-    .await
-    .unwrap();
+    wait_for_condition(TIMEOUT, || async { services.solvable_orders().await == 1 })
+        .await
+        .unwrap();
 
     services.start_old_driver(solver.private_key(), vec![]);
     test_order_was_settled(&services, &ethflow_order, &web3).await;
@@ -191,11 +188,9 @@ async fn eth_flow_indexing_after_refund(web3: Web3) {
     sumbit_order(&ethflow_order, trader.account(), onchain.contracts()).await;
 
     tracing::info!("waiting for trade");
-    wait_for_condition(Duration::from_secs(10), || async {
-        services.solvable_orders().await == 1
-    })
-    .await
-    .unwrap();
+    wait_for_condition(TIMEOUT, || async { services.solvable_orders().await == 1 })
+        .await
+        .unwrap();
 
     services.start_old_driver(solver.private_key(), vec![]);
     test_order_was_settled(&services, &ethflow_order, &web3).await;
@@ -254,9 +249,7 @@ async fn test_order_availability_in_api(
     tracing::info!("Waiting for order to show up in API.");
     let uid = order.uid(contracts).await;
     let is_available = || async { services.get_order(&uid).await.is_ok() };
-    wait_for_condition(Duration::from_secs(10), is_available)
-        .await
-        .unwrap();
+    wait_for_condition(TIMEOUT, is_available).await.unwrap();
 
     test_orders_query(services, order, owner, contracts).await;
 
@@ -266,11 +259,9 @@ async fn test_order_availability_in_api(
         test_account_query(address, services.client(), order, owner, contracts).await;
     }
 
-    wait_for_condition(Duration::from_secs(10), || async {
-        services.solvable_orders().await == 1
-    })
-    .await
-    .unwrap();
+    wait_for_condition(TIMEOUT, || async { services.solvable_orders().await == 1 })
+        .await
+        .unwrap();
 
     test_auction_query(services, order, owner, contracts).await;
 }
@@ -301,9 +292,7 @@ async fn test_order_was_settled(
     web3: &Web3,
 ) {
     let auction_is_empty = || async { services.solvable_orders().await == 0 };
-    wait_for_condition(Duration::from_secs(10), auction_is_empty)
-        .await
-        .unwrap();
+    wait_for_condition(TIMEOUT, auction_is_empty).await.unwrap();
 
     let buy_token = ERC20Mintable::at(web3, ethflow_order.0.buy_token);
     let receiver_buy_token_balance = buy_token

--- a/crates/e2e/tests/e2e/eth_integration.rs
+++ b/crates/e2e/tests/e2e/eth_integration.rs
@@ -8,7 +8,6 @@ use {
     },
     secp256k1::SecretKey,
     shared::ethrpc::Web3,
-    std::time::Duration,
     web3::signing::SecretKeyRef,
 };
 
@@ -104,11 +103,9 @@ async fn eth_integration(web3: Web3) {
     services.create_order(&order_buy_eth_b).await.unwrap();
 
     tracing::info!("Waiting for trade.");
-    wait_for_condition(Duration::from_secs(10), || async {
-        services.solvable_orders().await == 2
-    })
-    .await
-    .unwrap();
+    wait_for_condition(TIMEOUT, || async { services.solvable_orders().await == 2 })
+        .await
+        .unwrap();
 
     services.start_old_driver(solver.private_key(), vec![]);
 
@@ -117,9 +114,7 @@ async fn eth_integration(web3: Web3) {
         let balance_b = web3.eth().balance(trader_b.address(), None).await.unwrap();
         balance_a != trader_a_eth_balance_before && balance_b != trader_b_eth_balance_before
     };
-    wait_for_condition(Duration::from_secs(10), trade_happened)
-        .await
-        .unwrap();
+    wait_for_condition(TIMEOUT, trade_happened).await.unwrap();
 
     // Check matching
     let trader_a_eth_balance_after = web3.eth().balance(trader_a.address(), None).await.unwrap();

--- a/crates/e2e/tests/e2e/limit_orders.rs
+++ b/crates/e2e/tests/e2e/limit_orders.rs
@@ -7,7 +7,6 @@ use {
     },
     secp256k1::SecretKey,
     shared::ethrpc::Web3,
-    std::time::Duration,
     web3::signing::SecretKeyRef,
 };
 
@@ -120,18 +119,14 @@ async fn single_limit_order_test(web3: Web3) {
     // Drive solution
     tracing::info!("Waiting for trade.");
     let balance_before = token_b.balance_of(trader_a.address()).call().await.unwrap();
-    wait_for_condition(Duration::from_secs(10), || async {
-        services.solvable_orders().await == 1
-    })
-    .await
-    .unwrap();
+    wait_for_condition(TIMEOUT, || async { services.solvable_orders().await == 1 })
+        .await
+        .unwrap();
 
     services.start_old_driver(solver.private_key(), vec![]);
-    wait_for_condition(Duration::from_secs(10), || async {
-        services.solvable_orders().await == 0
-    })
-    .await
-    .unwrap();
+    wait_for_condition(TIMEOUT, || async { services.solvable_orders().await == 0 })
+        .await
+        .unwrap();
 
     let balance_after = token_b.balance_of(trader_a.address()).call().await.unwrap();
     assert!(balance_after.checked_sub(balance_before).unwrap() >= to_wei(5));
@@ -241,29 +236,23 @@ async fn two_limit_orders_test(web3: Web3) {
     let limit_order = services.get_order(&order_id).await.unwrap();
     assert!(limit_order.metadata.class.is_limit());
 
-    wait_for_condition(Duration::from_secs(10), || async {
-        services.solvable_orders().await == 2
-    })
-    .await
-    .unwrap();
+    wait_for_condition(TIMEOUT, || async { services.solvable_orders().await == 2 })
+        .await
+        .unwrap();
 
     // Drive solution
     tracing::info!("Waiting for trade.");
     let balance_before_a = token_b.balance_of(trader_a.address()).call().await.unwrap();
     let balance_before_b = token_a.balance_of(trader_b.address()).call().await.unwrap();
-    wait_for_condition(Duration::from_secs(10), || async {
-        services.solvable_orders().await == 2
-    })
-    .await
-    .unwrap();
+    wait_for_condition(TIMEOUT, || async { services.solvable_orders().await == 2 })
+        .await
+        .unwrap();
 
     services.start_old_driver(solver.private_key(), vec![]);
 
-    wait_for_condition(Duration::from_secs(10), || async {
-        services.solvable_orders().await == 0
-    })
-    .await
-    .unwrap();
+    wait_for_condition(TIMEOUT, || async { services.solvable_orders().await == 0 })
+        .await
+        .unwrap();
 
     let balance_after_a = token_b.balance_of(trader_a.address()).call().await.unwrap();
     let balance_after_b = token_a.balance_of(trader_b.address()).call().await.unwrap();
@@ -376,29 +365,23 @@ async fn mixed_limit_and_market_orders_test(web3: Web3) {
     let limit_order = services.get_order(&order_id).await.unwrap();
     assert_eq!(limit_order.metadata.class, OrderClass::Market);
 
-    wait_for_condition(Duration::from_secs(10), || async {
-        services.solvable_orders().await == 2
-    })
-    .await
-    .unwrap();
+    wait_for_condition(TIMEOUT, || async { services.solvable_orders().await == 2 })
+        .await
+        .unwrap();
 
     // Drive solution
     tracing::info!("Waiting for trade.");
     let balance_before_a = token_b.balance_of(trader_a.address()).call().await.unwrap();
     let balance_before_b = token_a.balance_of(trader_b.address()).call().await.unwrap();
-    wait_for_condition(Duration::from_secs(10), || async {
-        services.solvable_orders().await == 2
-    })
-    .await
-    .unwrap();
+    wait_for_condition(TIMEOUT, || async { services.solvable_orders().await == 2 })
+        .await
+        .unwrap();
 
     services.start_old_driver(solver.private_key(), vec![]);
 
-    wait_for_condition(Duration::from_secs(10), || async {
-        services.solvable_orders().await == 0
-    })
-    .await
-    .unwrap();
+    wait_for_condition(TIMEOUT, || async { services.solvable_orders().await == 0 })
+        .await
+        .unwrap();
 
     let balance_after_a = token_b.balance_of(trader_a.address()).call().await.unwrap();
     let balance_after_b = token_a.balance_of(trader_b.address()).call().await.unwrap();

--- a/crates/e2e/tests/e2e/onchain_settlement.rs
+++ b/crates/e2e/tests/e2e/onchain_settlement.rs
@@ -7,7 +7,6 @@ use {
     },
     secp256k1::SecretKey,
     shared::ethrpc::Web3,
-    std::time::Duration,
     web3::signing::SecretKeyRef,
 };
 
@@ -125,9 +124,7 @@ async fn onchain_settlement(web3: Web3) {
     services.start_old_driver(solver.private_key(), vec![]);
     let trade_happened =
         || async { token_b.balance_of(trader_a.address()).call().await.unwrap() != 0.into() };
-    wait_for_condition(Duration::from_secs(10), trade_happened)
-        .await
-        .unwrap();
+    wait_for_condition(TIMEOUT, trade_happened).await.unwrap();
 
     // Check matching
     let balance = token_b.balance_of(trader_a.address()).call().await.unwrap();
@@ -137,7 +134,5 @@ async fn onchain_settlement(web3: Web3) {
 
     tracing::info!("Waiting for auction to be cleared.");
     let auction_is_empty = || async { services.get_auction().await.auction.orders.is_empty() };
-    wait_for_condition(Duration::from_secs(10), auction_is_empty)
-        .await
-        .unwrap();
+    wait_for_condition(TIMEOUT, auction_is_empty).await.unwrap();
 }

--- a/crates/e2e/tests/e2e/order_cancellation.rs
+++ b/crates/e2e/tests/e2e/order_cancellation.rs
@@ -17,7 +17,6 @@ use {
     },
     secp256k1::SecretKey,
     shared::ethrpc::Web3,
-    std::time::Duration,
     web3::signing::SecretKeyRef,
 };
 
@@ -144,7 +143,7 @@ async fn order_cancellation(web3: Web3) {
         place_order(1).await,
         place_order(2).await,
     ];
-    wait_for_condition(Duration::from_secs(10), || async {
+    wait_for_condition(TIMEOUT, || async {
         services.get_auction().await.auction.orders.len() == 3
     })
     .await
@@ -158,7 +157,7 @@ async fn order_cancellation(web3: Web3) {
 
     // Cancel one of them.
     cancel_order(order_uids[0]).await;
-    wait_for_condition(Duration::from_secs(10), || async {
+    wait_for_condition(TIMEOUT, || async {
         services.get_auction().await.auction.orders.len() == 2
     })
     .await
@@ -175,7 +174,7 @@ async fn order_cancellation(web3: Web3) {
 
     // Cancel the other two.
     cancel_orders(vec![order_uids[1], order_uids[2]]).await;
-    wait_for_condition(Duration::from_secs(10), || async {
+    wait_for_condition(TIMEOUT, || async {
         services.get_auction().await.auction.orders.is_empty()
     })
     .await

--- a/crates/e2e/tests/e2e/refunder.rs
+++ b/crates/e2e/tests/e2e/refunder.rs
@@ -10,7 +10,6 @@ use {
     refunder::refund_service::RefundService,
     shared::{current_block::timestamp_of_current_block_in_seconds, ethrpc::Web3},
     sqlx::PgPool,
-    std::time::Duration,
 };
 
 #[tokio::test]
@@ -66,7 +65,7 @@ async fn refunder_tx(web3: Web3) {
     let order_id = ethflow_order.uid(onchain.contracts()).await;
 
     tracing::info!("Waiting for order to be indexed.");
-    wait_for_condition(Duration::from_secs(10), || async {
+    wait_for_condition(TIMEOUT, || async {
         services.get_order(&order_id).await.is_ok()
     })
     .await
@@ -121,7 +120,5 @@ async fn refunder_tx(web3: Web3) {
             .refund_tx_hash
             .is_some()
     };
-    wait_for_condition(Duration::from_secs(10), has_tx_hash)
-        .await
-        .unwrap();
+    wait_for_condition(TIMEOUT, has_tx_hash).await.unwrap();
 }

--- a/crates/e2e/tests/e2e/settlement_without_onchain_liquidity.rs
+++ b/crates/e2e/tests/e2e/settlement_without_onchain_liquidity.rs
@@ -7,7 +7,6 @@ use {
     },
     secp256k1::SecretKey,
     shared::ethrpc::Web3,
-    std::time::Duration,
     web3::signing::SecretKeyRef,
 };
 
@@ -106,7 +105,7 @@ async fn onchain_settlement_without_liquidity(web3: Web3) {
 
     // Drive solution
     tracing::info!("Waiting for trade.");
-    wait_for_condition(Duration::from_secs(10), || async {
+    wait_for_condition(TIMEOUT, || async {
         services.get_auction().await.auction.orders.len() == 1
     })
     .await
@@ -120,7 +119,7 @@ async fn onchain_settlement_without_liquidity(web3: Web3) {
             token_b.address()
         )],
     );
-    wait_for_condition(Duration::from_secs(10), || async {
+    wait_for_condition(TIMEOUT, || async {
         services.get_auction().await.auction.orders.is_empty()
     })
     .await

--- a/crates/e2e/tests/e2e/setup/mod.rs
+++ b/crates/e2e/tests/e2e/setup/mod.rs
@@ -26,6 +26,14 @@ pub fn config_tmp_file<C: AsRef<[u8]>>(content: C) -> TempPath {
     file.into_temp_path()
 }
 
+/// Reasonable default timeout for `wait_for_condition`.
+///
+/// The correct timeout depends on the condition and where the test is run. For
+/// example, it can take a couple of seconds for a newly placed order to show up
+/// in the auction. When running on Github CI, anything can take an unexpectedly
+/// long time.
+pub const TIMEOUT: Duration = Duration::from_secs(30);
+
 /// Repeatedly evaluate condition until it returns true or the timeout is
 /// reached. If condition evaluates to true, Ok(()) is returned. If the timeout
 /// is reached Err is returned.
@@ -38,7 +46,7 @@ where
 {
     let start = std::time::Instant::now();
     while !condition().await {
-        tokio::time::sleep(Duration::from_millis(100)).await;
+        tokio::time::sleep(Duration::from_millis(200)).await;
         if start.elapsed() > timeout {
             return Err(anyhow!("timeout"));
         }

--- a/crates/e2e/tests/e2e/setup/services.rs
+++ b/crates/e2e/tests/e2e/setup/services.rs
@@ -1,7 +1,7 @@
 use {
     crate::{
         local_node::NODE_HOST,
-        setup::{wait_for_condition, Contracts},
+        setup::{wait_for_condition, Contracts, TIMEOUT},
     },
     clap::Parser,
     ethcontract::H256,
@@ -136,7 +136,7 @@ impl<'a> Services<'a> {
         };
 
         tracing::info!("Waiting for API to come up.");
-        wait_for_condition(Duration::from_secs(10), is_up)
+        wait_for_condition(TIMEOUT, is_up)
             .await
             .expect("waiting for API timed out");
     }

--- a/crates/e2e/tests/e2e/smart_contract_orders.rs
+++ b/crates/e2e/tests/e2e/smart_contract_orders.rs
@@ -8,7 +8,6 @@ use {
     },
     secp256k1::SecretKey,
     shared::ethrpc::Web3,
-    std::time::Duration,
     web3::signing::SecretKeyRef,
 };
 
@@ -139,7 +138,7 @@ async fn smart_contract_orders(web3: Web3) {
     );
 
     // Check that the presignature event was received.
-    wait_for_condition(Duration::from_secs(10), || async {
+    wait_for_condition(TIMEOUT, || async {
         services.get_auction().await.auction.orders.len() == 2
     })
     .await
@@ -152,7 +151,7 @@ async fn smart_contract_orders(web3: Web3) {
     // Drive solution
     tracing::info!("Waiting for trade.");
     services.start_old_driver(solver.private_key(), vec![]);
-    wait_for_condition(Duration::from_secs(10), || async {
+    wait_for_condition(TIMEOUT, || async {
         services.get_auction().await.auction.orders.is_empty()
     })
     .await

--- a/crates/e2e/tests/e2e/vault_balances.rs
+++ b/crates/e2e/tests/e2e/vault_balances.rs
@@ -7,7 +7,6 @@ use {
     },
     secp256k1::SecretKey,
     shared::ethrpc::Web3,
-    std::time::Duration,
     web3::signing::SecretKeyRef,
 };
 
@@ -74,13 +73,13 @@ async fn vault_balances(web3: Web3) {
 
     // Drive solution
     tracing::info!("Waiting for trade.");
-    wait_for_condition(Duration::from_secs(10), || async {
+    wait_for_condition(TIMEOUT, || async {
         services.get_auction().await.auction.orders.len() == 1
     })
     .await
     .unwrap();
     services.start_old_driver(solver.private_key(), vec![]);
-    wait_for_condition(Duration::from_secs(10), || async {
+    wait_for_condition(TIMEOUT, || async {
         services.get_auction().await.auction.orders.is_empty()
     })
     .await


### PR DESCRIPTION
Fixes https://github.com/cowprotocol/services/issues/1223 .

The last two failures were cases where simulating the transactions in solver::driver took surprisingly long. Without more detail I'm guessing this is hardhat being slow on Github CI and not a bug in our code. To fix it I change the timeout of all wait_for_condition from 10 s to 30 s.

### Test Plan

CI e2e tests
