### PR TITLE
Always log 1Inch parsing errors

### DIFF
--- a/crates/shared/src/oneinch_api.rs
+++ b/crates/shared/src/oneinch_api.rs
@@ -554,11 +554,16 @@ where
     D: DeserializeOwned,
 {
     tracing::trace!("Query 1inch API for url {}", url);
-    let response = client.get(url).send().await?.text().await;
-    tracing::trace!("Response from 1inch API: {:?}", response);
-    match serde_json::from_str::<RestResponse<D>>(&response?)? {
-        RestResponse::Ok(result) => Ok(result),
-        RestResponse::Err(err) => Err(err.into()),
+    let response = client.get(url).send().await?.text().await?;
+    match serde_json::from_str::<RestResponse<D>>(&response)? {
+        RestResponse::Ok(result) => {
+            tracing::trace!("Response from 1inch API: {:?}", response);
+            Ok(result)
+        }
+        RestResponse::Err(err) => {
+            tracing::warn!("Failed to parse response from 1inch API: {:?}", response);
+            Err(err.into())
+        }
     }
 }
 


### PR DESCRIPTION
Right now 1Inch responses only get logged if tracing is enabled. Since this is currently not enabled we don't get to see what caused these [parsing errors](https://production-6de61f.kb.eu-central-1.aws.cloud.es.io/app/discover#/?_g=(filters:!(),refreshInterval:(pause:!t,value:0),time:(from:'2023-02-28T21:31:14.884Z',to:'2023-03-01T09:00:00.000Z'))&_a=(columns:!(log),filters:!(),grid:(columns:('@timestamp':(width:164))),index:'6eecf430-220f-11ed-bbdc-2f476b18353d',interval:auto,query:(language:kuery,query:'log:%20%22solver::solver::single_order_solver:%20Solver%201Inch%22%20or%20log:%20%22response%20from%201inch%20api%22'),sort:!(!('@timestamp',desc)))).
We could simply enable trace logs again but that would be quite noisy and AFAIK we currently have to avoid putting to much pressure on the elastic search instance to not crash the logging system.
Instead I decided to always log the response if it can not be parsed.

### Test Plan
only the compiler