### PR TITLE
Fix race condition in transaction submission

### DIFF
--- a/crates/driver/src/boundary/mempool.rs
+++ b/crates/driver/src/boundary/mempool.rs
@@ -128,7 +128,10 @@ impl Mempool {
             },
         };
         let estimator = AccessListEstimator(settlement.access_list.clone());
-        let account = ethcontract::Account::Offline(solver.private_key(), None);
+        let account = ethcontract::Account::Offline(
+            solver.private_key(),
+            Some(self.eth.chain_id().0.low_u64()),
+        );
         let submitter = Submitter::new(
             self.eth.contracts().settlement(),
             &account,

--- a/crates/solver/src/settlement_submission/submitter/flashbots_api.rs
+++ b/crates/solver/src/settlement_submission/submitter/flashbots_api.rs
@@ -1,14 +1,14 @@
 use {
     super::{
-        super::submitter::{TransactionHandle, TransactionSubmitting},
+        super::submitter::TransactionSubmitting,
         common::PrivateNetwork,
         AdditionalTip,
+        RawTransaction,
         Strategy,
         SubmissionLoopStatus,
     },
     crate::settlement::{Revertable, Settlement},
     anyhow::{Context, Result},
-    ethcontract::transaction::TransactionBuilder,
     reqwest::{Client, IntoUrl},
     shared::ethrpc::{http::HttpTransport, Web3, Web3Transport},
 };
@@ -33,10 +33,7 @@ impl FlashbotsApi {
 
 #[async_trait::async_trait]
 impl TransactionSubmitting for FlashbotsApi {
-    async fn submit_transaction(
-        &self,
-        tx: TransactionBuilder<Web3Transport>,
-    ) -> Result<TransactionHandle> {
+    async fn submit_transaction(&self, tx: RawTransaction) -> Result<()> {
         self.rpc
             .api::<PrivateNetwork>()
             .submit_raw_transaction(tx)
@@ -44,10 +41,7 @@ impl TransactionSubmitting for FlashbotsApi {
     }
 
     // https://docs.flashbots.net/flashbots-protect/rpc/cancellations
-    async fn cancel_transaction(
-        &self,
-        tx: TransactionBuilder<Web3Transport>,
-    ) -> Result<TransactionHandle> {
+    async fn cancel_transaction(&self, tx: RawTransaction) -> Result<()> {
         self.rpc
             .api::<PrivateNetwork>()
             .submit_raw_transaction(tx)


### PR DESCRIPTION
fixes #671 

See the description of the linked issue. We have  a race condition where a successfully submitted transaction counts as failed. In order to fix this, this PR refactors the `settlement_submission` module to get rid of `TransactionHandle` in favor of passing complete raw transaction bytes around. This allows us to know the tx hash in advance before submitting, which is required to solve the race condition. The handle struct seems to serve no purpose (anymore?) because the handle is never used.

The shadow solver still works because it uses the dry run strategy which does not require an offline account.

Alternatively instead of requiring knowing the tx hash in advance, we could wait for the nonce to increase and inspect the calldata of the new transaction to see if it matches the calldata of the transaction we wanted to settle. That would be a bigger change and is related to how we identify transactions in colocation.

### Test Plan

CI e2e test,
