### PR TITLE
SolverRewards 9: Update settlement details if exist

### DIFF
--- a/crates/autopilot/src/database/on_settlement_event_updater.rs
+++ b/crates/autopilot/src/database/on_settlement_event_updater.rs
@@ -6,16 +6,20 @@ use {
 };
 
 #[derive(Debug, Default, Clone)]
-pub struct SettlementUpdate {
-    pub block_number: i64,
-    pub log_index: i64,
-    pub auction_id: Option<i64>,
-    pub tx_from: H160,
-    pub tx_nonce: i64,
+pub struct AuctionData {
     pub gas_used: U256,
     pub effective_gas_price: U256,
     pub surplus: U256,
     pub fee: U256,
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct SettlementUpdate {
+    pub block_number: i64,
+    pub log_index: i64,
+    pub tx_from: H160,
+    pub tx_nonce: i64,
+    pub auction_data: Option<AuctionData>,
 }
 
 impl super::Postgres {
@@ -42,18 +46,16 @@ impl super::Postgres {
         .context("insert_settlement_tx_info")?;
 
         // update settlement_observations if exist
-        if settlement_update.auction_id.is_some() {
+        if let Some(auction_data) = settlement_update.auction_data {
             database::settlement_observations::insert(
                 &mut ex,
                 Observation {
                     block_number: settlement_update.block_number,
                     log_index: settlement_update.log_index,
-                    gas_used: u256_to_big_decimal(&settlement_update.gas_used),
-                    effective_gas_price: u256_to_big_decimal(
-                        &settlement_update.effective_gas_price,
-                    ),
-                    surplus: u256_to_big_decimal(&settlement_update.surplus),
-                    fee: u256_to_big_decimal(&settlement_update.fee),
+                    gas_used: u256_to_big_decimal(&auction_data.gas_used),
+                    effective_gas_price: u256_to_big_decimal(&auction_data.effective_gas_price),
+                    surplus: u256_to_big_decimal(&auction_data.surplus),
+                    fee: u256_to_big_decimal(&auction_data.fee),
                 },
             )
             .await

--- a/crates/autopilot/src/on_settlement_event_updater.rs
+++ b/crates/autopilot/src/on_settlement_event_updater.rs
@@ -121,7 +121,7 @@ impl OnSettlementEventUpdater {
             log_index: event.log_index,
             tx_from,
             tx_nonce,
-            ..Default::default()
+            auction_data: None,
         };
 
         // It is possible that auction_id does not exist for a transaction.

--- a/crates/autopilot/src/on_settlement_event_updater.rs
+++ b/crates/autopilot/src/on_settlement_event_updater.rs
@@ -32,7 +32,10 @@
 
 use {
     crate::{
-        database::{on_settlement_event_updater::SettlementUpdate, Postgres},
+        database::{
+            on_settlement_event_updater::{AuctionData, SettlementUpdate},
+            Postgres,
+        },
         decoded_settlement::{DecodedSettlement, FeeConfiguration},
     },
     anyhow::{anyhow, Context, Result},
@@ -116,7 +119,6 @@ impl OnSettlementEventUpdater {
         let mut update = SettlementUpdate {
             block_number: event.block_number,
             log_index: event.log_index,
-            auction_id,
             tx_from,
             tx_nonce,
             ..Default::default()
@@ -174,10 +176,12 @@ impl OnSettlementEventUpdater {
             let surplus = settlement.total_surplus(&external_prices);
             let fee = settlement.total_fees(&external_prices, &orders, &configuration);
 
-            update.surplus = surplus;
-            update.fee = fee;
-            update.gas_used = gas_used;
-            update.effective_gas_price = effective_gas_price;
+            update.auction_data = Some(AuctionData {
+                surplus,
+                fee,
+                gas_used,
+                effective_gas_price,
+            });
         }
 
         tracing::debug!(?hash, ?update, "updating settlement details for tx");


### PR DESCRIPTION
All settlement events are indexed by both staging and production databases.
However, auctions only exist in one of the environments.

This PR inserts settlement observations only if the auction exist.
Thanks @MartinquaXD for figuring out the issue. I did have the same issue when ran CIP20 changes locally, but thought it is because of running the local db. :/