### PR TITLE
Add command line arguments to control limit orders

### DIFF
--- a/crates/autopilot/src/arguments.rs
+++ b/crates/autopilot/src/arguments.rs
@@ -148,9 +148,11 @@ pub struct Arguments {
     #[clap(long, env, default_value = "0")]
     pub limit_order_price_factor: f64,
 
-    /// Enable background quoting for limit orders.
-    #[clap(long, env)]
-    pub enable_limit_orders: bool,
+    #[clap(long, env, default_value = "true")]
+    pub process_fill_or_kill_limit_orders: bool,
+
+    #[clap(long, env, default_value = "false")]
+    pub process_partially_fillable_limit_orders: bool,
 
     /// How many quotes the limit order quoter updates in parallel.
     #[clap(long, env, default_value = "5")]
@@ -254,7 +256,16 @@ impl std::fmt::Display for Arguments {
             "limit_order_price_factor: {:?}",
             self.limit_order_price_factor
         )?;
-        writeln!(f, "enable_limit_orders: {:?}", self.enable_limit_orders)?;
+        writeln!(
+            f,
+            "process_fill_or_kill_limit_orders: {:?}",
+            self.process_fill_or_kill_limit_orders
+        )?;
+        writeln!(
+            f,
+            "process_partially_fillable_limit_orders: {:?}",
+            self.process_partially_fillable_limit_orders
+        )?;
         writeln!(
             f,
             "limit_order_quoter_parallelism: {:?}",

--- a/crates/autopilot/src/arguments.rs
+++ b/crates/autopilot/src/arguments.rs
@@ -148,10 +148,10 @@ pub struct Arguments {
     #[clap(long, env, default_value = "0")]
     pub limit_order_price_factor: f64,
 
-    #[clap(long, env, default_value = "true")]
+    #[clap(long, env, action = clap::ArgAction::Set, default_value = "true")]
     pub process_fill_or_kill_limit_orders: bool,
 
-    #[clap(long, env, default_value = "false")]
+    #[clap(long, env, action = clap::ArgAction::Set, default_value = "false")]
     pub process_partially_fillable_limit_orders: bool,
 
     /// How many quotes the limit order quoter updates in parallel.

--- a/crates/autopilot/src/lib.rs
+++ b/crates/autopilot/src/lib.rs
@@ -637,7 +637,7 @@ pub async fn main(args: arguments::Arguments) {
             .instrument(tracing::info_span!("on_settlement_event_updater")),
     );
 
-    if args.enable_limit_orders {
+    if args.process_fill_or_kill_limit_orders {
         let limit_order_age = chrono::Duration::from_std(args.max_surplus_fee_age).unwrap();
         LimitOrderQuoter {
             limit_order_age,

--- a/crates/e2e/tests/e2e/setup/services.rs
+++ b/crates/e2e/tests/e2e/setup/services.rs
@@ -80,7 +80,6 @@ impl<'a> Services<'a> {
             "--auction-update-interval=1".to_string(),
             format!("--ethflow-contract={:?}", self.contracts.ethflow.address()),
             "--skip-event-sync".to_string(),
-            "--enable-limit-orders".to_string(),
         ]
         .into_iter()
         .chain(self.api_autopilot_solver_arguments())
@@ -98,7 +97,6 @@ impl<'a> Services<'a> {
             "orderbook",
             "--enable-presign-orders",
             "--enable-eip1271-orders",
-            "--enable-limit-orders",
         ]
         .into_iter()
         .map(ToString::to_string)

--- a/crates/orderbook/src/arguments.rs
+++ b/crates/orderbook/src/arguments.rs
@@ -144,10 +144,10 @@ pub struct Arguments {
     #[clap(long, env, default_value = "24")]
     pub solvable_orders_max_update_age_blocks: u64,
 
-    #[clap(long, env, default_value = "true")]
+    #[clap(long, env, action = clap::ArgAction::Set, default_value = "true")]
     pub allow_placing_fill_or_kill_limit_orders: bool,
 
-    #[clap(long, env, default_value = "false")]
+    #[clap(long, env, action = clap::ArgAction::Set, default_value = "false")]
     pub allow_placing_partially_fillable_limit_orders: bool,
 
     /// Max number of limit orders per user.

--- a/crates/orderbook/src/arguments.rs
+++ b/crates/orderbook/src/arguments.rs
@@ -144,10 +144,11 @@ pub struct Arguments {
     #[clap(long, env, default_value = "24")]
     pub solvable_orders_max_update_age_blocks: u64,
 
-    /// Enable limit orders. Once the full limit order flow is implemented, this
-    /// can be removed.
+    #[clap(long, env, default_value = "true")]
+    pub allow_placing_fill_or_kill_limit_orders: bool,
+
     #[clap(long, env, default_value = "false")]
-    pub enable_limit_orders: bool,
+    pub allow_placing_partially_fillable_limit_orders: bool,
 
     /// Max number of limit orders per user.
     #[clap(long, env, default_value = "10")]
@@ -215,7 +216,16 @@ impl std::fmt::Display for Arguments {
             "fast_price_estimation_results_required: {}",
             self.fast_price_estimation_results_required
         )?;
-        writeln!(f, "enable_limit_orders: {}", self.enable_limit_orders)?;
+        writeln!(
+            f,
+            "allow_placing_fill_or_kill_limit_orders: {}",
+            self.allow_placing_fill_or_kill_limit_orders
+        )?;
+        writeln!(
+            f,
+            "allow_placing_partially_fillable_limit_orders: {}",
+            self.allow_placing_partially_fillable_limit_orders
+        )?;
         writeln!(
             f,
             "max_limit_orders_per_user: {}",

--- a/crates/orderbook/src/run.rs
+++ b/crates/orderbook/src/run.rs
@@ -467,7 +467,7 @@ pub async fn run(args: Arguments) {
             args.max_limit_orders_per_user,
             Arc::new(CachedCodeFetcher::new(Arc::new(web3.clone()))),
         )
-        .with_limit_orders(args.enable_limit_orders)
+        .with_limit_orders(args.allow_placing_fill_or_kill_limit_orders)
         .with_eth_smart_contract_payments(args.enable_eth_smart_contract_payments),
     );
     let orderbook = Arc::new(Orderbook::new(


### PR DESCRIPTION
Fixes https://github.com/cowprotocol/services/issues/1288 

This PR adds/changes flags for controlling limit orders. We can independently control fill or kill and partially fillable. fill or kill is enabled by default.

### Test Plan

CI
