### PR TITLE
SolverRewards 10: Fix score sorting

### DIFF
--- a/crates/solver/src/driver.rs
+++ b/crates/solver/src/driver.rs
@@ -399,7 +399,7 @@ impl Driver {
             .map(|(solver, rated_settlement, _)| {
                 (solver.account().address(), rated_settlement.score.score())
             })
-            .sorted_unstable_by_key(|(_, score)| std::cmp::Reverse(*score)); // descending
+            .sorted_by_key(|(_, score)| std::cmp::Reverse(*score)); // descending
         if let Some((winning_solver, winning_settlement, _)) = rated_settlements.pop() {
             tracing::info!(
                 "winning settlement id {} by solver {}: {:?}",
@@ -486,6 +486,8 @@ impl Driver {
                 participants,
                 prices,
             };
+            tracing::debug!(?solver_competition, "submitting competition info");
+            
             // This has to succeed in order to continue settling. Otherwise we can't be sure
             // the competition info has been stored.
             self.send_solver_competition(&solver_competition).await?;

--- a/crates/solver/src/driver.rs
+++ b/crates/solver/src/driver.rs
@@ -487,7 +487,7 @@ impl Driver {
                 prices,
             };
             tracing::debug!(?solver_competition, "submitting competition info");
-            
+
             // This has to succeed in order to continue settling. Otherwise we can't be sure
             // the competition info has been stored.
             self.send_solver_competition(&solver_competition).await?;


### PR DESCRIPTION
If we have 2 best solutions with identical scores, I don't want to mess them up sorting with `unstable`.

Also adding solver competition log (temporarily since we have issues with the database in staging right now).
