### PR TITLE
Improve bool argument handling

### DIFF
--- a/crates/autopilot/src/arguments.rs
+++ b/crates/autopilot/src/arguments.rs
@@ -58,7 +58,7 @@ pub struct Arguments {
     pub db_url: Url,
 
     /// Skip syncing past events (useful for local deployments)
-    #[clap(long, env)]
+    #[clap(long, env, action = clap::ArgAction::Set, default_value = "false")]
     pub skip_event_sync: bool,
 
     /// List of token addresses that should be allowed regardless of whether the
@@ -198,7 +198,7 @@ pub struct Arguments {
     pub trusted_tokens_update_interval: Duration,
 
     /// Enable the colocation run loop.
-    #[clap(long, env)]
+    #[clap(long, env, action = clap::ArgAction::Set, default_value = "false")]
     pub enable_colocation: bool,
 
     /// Driver base URLs.

--- a/crates/e2e/tests/e2e/colocation_univ2.rs
+++ b/crates/e2e/tests/e2e/colocation_univ2.rs
@@ -47,7 +47,7 @@ async fn test(web3: Web3) {
 
     let services = Services::new(onchain.contracts()).await;
     services.start_autopilot(vec![
-        "--enable-colocation".to_string(),
+        "--enable-colocation=true".to_string(),
         "--drivers=http://localhost:11088/test_solver".to_string(),
     ]);
     services.start_api(vec![]).await;

--- a/crates/e2e/tests/e2e/setup/services.rs
+++ b/crates/e2e/tests/e2e/setup/services.rs
@@ -79,7 +79,7 @@ impl<'a> Services<'a> {
             "autopilot".to_string(),
             "--auction-update-interval=1".to_string(),
             format!("--ethflow-contract={:?}", self.contracts.ethflow.address()),
-            "--skip-event-sync".to_string(),
+            "--skip-event-sync=true".to_string(),
         ]
         .into_iter()
         .chain(self.api_autopilot_solver_arguments())
@@ -95,8 +95,8 @@ impl<'a> Services<'a> {
     pub async fn start_api(&self, extra_args: Vec<String>) {
         let args = [
             "orderbook",
-            "--enable-presign-orders",
-            "--enable-eip1271-orders",
+            "--enable-presign-orders=true",
+            "--enable-eip1271-orders=true",
         ]
         .into_iter()
         .map(ToString::to_string)

--- a/crates/orderbook/src/arguments.rs
+++ b/crates/orderbook/src/arguments.rs
@@ -124,11 +124,11 @@ pub struct Arguments {
     pub pool_cache_lru_size: NonZeroUsize,
 
     /// Enable EIP-1271 orders.
-    #[clap(long, env)]
+    #[clap(long, env, action = clap::ArgAction::Set, default_value = "false")]
     pub enable_eip1271_orders: bool,
 
     /// Skip EIP-1271 order signature validation on creation.
-    #[clap(long, env)]
+    #[clap(long, env, action = clap::ArgAction::Set, default_value = "false")]
     pub eip1271_skip_creation_validation: bool,
 
     /// Enable pre-sign orders. Pre-sign orders are accepted into the database
@@ -136,7 +136,7 @@ pub struct Arguments {
     /// turned off if malicious users are abusing the database by inserting
     /// a bunch of order rows that won't ever be valid. This flag can be
     /// removed once DDoS protection is implemented.
-    #[clap(long, env)]
+    #[clap(long, env, action = clap::ArgAction::Set, default_value = "false")]
     pub enable_presign_orders: bool,
 
     /// If solvable orders haven't been successfully updated in this many blocks
@@ -155,7 +155,7 @@ pub struct Arguments {
     pub max_limit_orders_per_user: u64,
 
     /// Enable buy ETH orders paying to smart contract wallets.
-    #[clap(long, env, default_value = "false")]
+    #[clap(long, env, action = clap::ArgAction::Set, default_value = "false")]
     pub enable_eth_smart_contract_payments: bool,
 }
 

--- a/crates/shared/src/arguments.rs
+++ b/crates/shared/src/arguments.rs
@@ -266,7 +266,7 @@ pub struct Arguments {
     pub zeroex_api_key: Option<String>,
 
     /// If solvers should use internal buffers to improve solution quality.
-    #[clap(long, env)]
+    #[clap(long, env, action = clap::ArgAction::Set, default_value = "false")]
     pub use_internal_buffers: bool,
 
     /// The Balancer V2 factories to consider for indexing liquidity. Allows


### PR DESCRIPTION
By default a clap bool argument is disabled and enabled when the flag is specified like `--foo`. This makes it impossible to define a flag that is default enabled while also being able to be manually turned off with something like `--foo=false`. In this  PR I change all bool arguments to require passing in a value. This is  more consistent with how other arguments are parsed and more flexibly because it allows default enabled. This changes that that a plain `--foo` without value is not longer accepted, which is fine.

### Test Plan

CI

I have checked that the cluster is fine because it uses environment variables, which always needed a manual `=true`.
