### PR TITLE
SolverRewards: Add temporary logs

### DIFF
--- a/crates/autopilot/src/decoded_settlement.rs
+++ b/crates/autopilot/src/decoded_settlement.rs
@@ -252,9 +252,9 @@ fn fee(
     configuration: &FeeConfiguration,
 ) -> Option<U256> {
     let full_fee_amount = u256_to_big_rational(&order.full_fee_amount);
-    tracing::debug!(?full_fee_amount, ?order.full_fee_amount, "temp_fee_log");
+    tracing::trace!(?full_fee_amount, ?order.full_fee_amount, "full_fee_amount");
     let scaled_fee_amount = full_fee_amount * configuration.fee_objective_scaling_factor.clone();
-    tracing::debug!(?scaled_fee_amount, ?configuration.fee_objective_scaling_factor, "temp_fee_log");
+    tracing::trace!(?scaled_fee_amount, ?configuration.fee_objective_scaling_factor, "scaled_fee_amount");
 
     let fee = match order.kind {
         model::order::OrderKind::Buy => {
@@ -266,9 +266,9 @@ fn fee(
                 / u256_to_big_rational(&order.sell_amount)
         }
     };
-    tracing::debug!(?fee, "temp_fee_log");
+    tracing::trace!(?fee, "fee before conversion to native token");
     let fee = external_prices.try_get_native_amount(order.sell_token, fee)?;
-    tracing::debug!(?fee, "temp_fee_log");
+    tracing::trace!(?fee, "fee after conversion to native token");
     big_rational_to_u256(&fee).ok()
 }
 

--- a/crates/autopilot/src/decoded_settlement.rs
+++ b/crates/autopilot/src/decoded_settlement.rs
@@ -104,6 +104,7 @@ pub struct FeeConfiguration {
     pub fee_objective_scaling_factor: BigRational,
 }
 
+#[derive(Debug)]
 pub struct Order {
     pub full_fee_amount: U256,
     pub kind: OrderKind,
@@ -251,7 +252,9 @@ fn fee(
     configuration: &FeeConfiguration,
 ) -> Option<U256> {
     let full_fee_amount = u256_to_big_rational(&order.full_fee_amount);
+    tracing::debug!(?full_fee_amount, ?order.full_fee_amount, "temp_fee_log");
     let scaled_fee_amount = full_fee_amount * configuration.fee_objective_scaling_factor.clone();
+    tracing::debug!(?scaled_fee_amount, ?configuration.fee_objective_scaling_factor, "temp_fee_log");
 
     let fee = match order.kind {
         model::order::OrderKind::Buy => {
@@ -263,8 +266,9 @@ fn fee(
                 / u256_to_big_rational(&order.sell_amount)
         }
     };
-
+    tracing::debug!(?fee, "temp_fee_log");
     let fee = external_prices.try_get_native_amount(order.sell_token, fee)?;
+    tracing::debug!(?fee, "temp_fee_log");
     big_rational_to_u256(&fee).ok()
 }
 

--- a/crates/autopilot/src/on_settlement_event_updater.rs
+++ b/crates/autopilot/src/on_settlement_event_updater.rs
@@ -165,8 +165,9 @@ impl OnSettlementEventUpdater {
                 .collect::<Result<Vec<_>>>()?;
             let external_prices = ExternalPrices::try_from_auction_prices(
                 self.native_token,
-                auction_external_prices,
+                auction_external_prices.clone(),
             )?;
+            tracing::debug!(?auction_id, ?auction_external_prices, ?orders, ?external_prices, "temp_fee_log");
 
             // surplus and fees calculation
             let configuration = FeeConfiguration {

--- a/crates/autopilot/src/on_settlement_event_updater.rs
+++ b/crates/autopilot/src/on_settlement_event_updater.rs
@@ -167,7 +167,6 @@ impl OnSettlementEventUpdater {
                 self.native_token,
                 auction_external_prices.clone(),
             )?;
-            tracing::debug!(?auction_id, ?auction_external_prices, ?orders, ?external_prices, "temp_fee_log");
 
             // surplus and fees calculation
             let configuration = FeeConfiguration {
@@ -183,6 +182,14 @@ impl OnSettlementEventUpdater {
                 gas_used,
                 effective_gas_price,
             });
+
+            tracing::trace!(
+                ?auction_id,
+                ?auction_external_prices,
+                ?orders,
+                ?external_prices,
+                "observations input"
+            );
         }
 
         tracing::debug!(?hash, ?update, "updating settlement details for tx");


### PR DESCRIPTION
Adding temporary logs for fee calculation.

For tx hash 0xa0adf944224c3cda52dfb98e072dd98cb70f3eecb1fc2c8447644c2d70055ecf we get different fees when we compare:
1. what Solver competition endpoint returns
2. what OnSettlementEventUpdater calculated
3. what manual calculation returns using bare db values

I noticed that `full_fee_amount` is different for order when used `https://barn.api.cow.fi/docs/#/default/get_api_v1_orders__UID_` vs manually querying the staging db (super weird).
