### PR TITLE
Handle partially fillable limit orders in order validation

### DIFF
--- a/crates/orderbook/src/arguments.rs
+++ b/crates/orderbook/src/arguments.rs
@@ -144,9 +144,11 @@ pub struct Arguments {
     #[clap(long, env, default_value = "24")]
     pub solvable_orders_max_update_age_blocks: u64,
 
+    /// Note that fill or kill liquidity limit orders are always allowed.
     #[clap(long, env, action = clap::ArgAction::Set, default_value = "true")]
     pub allow_placing_fill_or_kill_limit_orders: bool,
 
+    /// Note that partially fillable liquidity limit orders are always allowed.
     #[clap(long, env, action = clap::ArgAction::Set, default_value = "false")]
     pub allow_placing_partially_fillable_limit_orders: bool,
 

--- a/crates/orderbook/src/run.rs
+++ b/crates/orderbook/src/run.rs
@@ -467,7 +467,8 @@ pub async fn run(args: Arguments) {
             args.max_limit_orders_per_user,
             Arc::new(CachedCodeFetcher::new(Arc::new(web3.clone()))),
         )
-        .with_limit_orders(args.allow_placing_fill_or_kill_limit_orders)
+        .with_fill_or_kill_limit_orders(args.allow_placing_fill_or_kill_limit_orders)
+        .with_partially_fillable_limit_orders(args.allow_placing_partially_fillable_limit_orders)
         .with_eth_smart_contract_payments(args.enable_eth_smart_contract_payments),
     );
     let orderbook = Arc::new(Orderbook::new(


### PR DESCRIPTION
Part of https://github.com/cowprotocol/services/issues/1289 .

- Use config option for allowing partially fillable limit orders.
- Slightly refactor code.
- Logic change: Previously, when limit orders were disabled and an order with 0 fee was placed, it was automatically converted into a market order and validated as such. This is changed to continue to treat the order as a limit order which fails validation because limit orders are disabled. I'm not sure what the motivation for the previous way of doing things is.

### Test Plan

modified tests
