### PR TITLE
Calculate executed amounts for fulfilled limit orders in the `driver`

### DIFF
--- a/crates/driver/src/domain/competition/order/mod.rs
+++ b/crates/driver/src/domain/competition/order/mod.rs
@@ -143,9 +143,11 @@ impl PartialEq<[u8; 56]> for Uid {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Side {
-    /// Buy an exact amount.
+    /// Buy an exact amount. The sell amount can vary due to e.g. partial fills
+    /// or slippage.
     Buy,
-    /// Sell an exact amount.
+    /// Sell an exact amount. The buy amount can vary due to e.g. partial fills
+    /// or slippage.
     Sell,
 }
 
@@ -184,8 +186,11 @@ pub enum Kind {
     /// Order intended to be immediately executed. This is the "regular" type of
     /// order.
     Market,
-    /// Order intended to be executed possibly far into the future, when the
-    /// price is such that the order can be executed.
+    /// Order intended to be fulfilled possibly far into the future, when the
+    /// price is such that the order can be executed. Because the fulfillment
+    /// can happen any time into the future, it's impossible to calculate
+    /// the order fees ahead of time, so the fees are taken from the order
+    /// surplus instead.
     Limit {
         /// The fee to be taken from the order surplus.
         surplus_fee: SellAmount,

--- a/crates/driver/src/domain/competition/solution/trade.rs
+++ b/crates/driver/src/domain/competition/solution/trade.rs
@@ -131,7 +131,7 @@ impl Trade {
                         sell: eth::Asset {
                             amount: sell
                                 .amount
-                                .checked_mul(executed.0)
+                                .checked_mul(executed.into())
                                 .ok_or(Error::Overflow)?
                                 .checked_div(buy.amount)
                                 .ok_or(Error::Overflow)?,
@@ -146,7 +146,7 @@ impl Trade {
                         buy: eth::Asset {
                             amount: buy
                                 .amount
-                                .checked_mul(executed.0)
+                                .checked_mul(executed.into())
                                 .ok_or(Error::Overflow)?
                                 .checked_div(sell.amount)
                                 .ok_or(Error::Overflow)?,
@@ -155,7 +155,75 @@ impl Trade {
                     },
                 }
             }
-            order::Kind::Limit { .. } => todo!(),
+            order::Kind::Limit { surplus_fee } => {
+                // Warning: calculating executed amounts for limit orders is complex and
+                // confusing. To understand why the calculations work, it is important to note
+                // that the solver doesn't receive limit orders with the same amounts that were
+                // specified by the users when placing the orders. Instead, the sell amount for
+                // each limit order is reduced by the surplus fee, which is the fee taken by
+                // the network to settle the order. These are referred to as "synthetic" limit
+                // orders. The surplus fees are calculated when cutting the auction.
+                //
+                // See also [`order::Kind::Limit`].
+                //
+                // Similar to market orders, the executed amounts for limit orders are
+                // calculated using the clearing prices.
+                let sell_price = clearing_prices
+                    .0
+                    .get(&sell.token)
+                    .ok_or(Error::ClearingPriceMissing)?
+                    .to_owned();
+                let buy_price = clearing_prices
+                    .0
+                    .get(&buy.token)
+                    .ok_or(Error::ClearingPriceMissing)?
+                    .to_owned();
+                match side {
+                    order::Side::Buy => Execution {
+                        buy: eth::Asset {
+                            amount: executed.into(),
+                            token: buy.token,
+                        },
+                        sell: eth::Asset {
+                            amount: executed
+                                .0
+                                .checked_mul(buy_price)
+                                .ok_or(Error::Overflow)?
+                                .checked_div(sell_price)
+                                .ok_or(Error::Overflow)?
+                                // Because of how "synthetic" limit orders are constructed as
+                                // explained above, we need to simply increase the executed sell
+                                // price by the surplus fee. We know that the user placed an order
+                                // big enough to cover the surplus fee.
+                                .checked_add(surplus_fee.into())
+                                .ok_or(Error::Overflow)?,
+                            token: sell.token,
+                        },
+                    },
+                    order::Side::Sell => Execution {
+                        sell: eth::Asset {
+                            amount: executed.into(),
+                            token: sell.token,
+                        },
+                        buy: eth::Asset {
+                            amount: executed
+                                .0
+                                // Because of how "synthetic" limit orders are constructed as
+                                // explained above, the solver received the sell amount
+                                // reduced by the surplus fee. That's why we're have to reduce the
+                                // executed amount by the surplus fee when calculating the
+                                // executed buy amount.
+                                .checked_sub(surplus_fee.into())
+                                .ok_or(Error::Overflow)?
+                                .checked_mul(sell_price)
+                                .ok_or(Error::Overflow)?
+                                .checked_ceil_div(&buy_price)
+                                .ok_or(Error::Overflow)?,
+                            token: buy.token,
+                        },
+                    },
+                }
+            }
         })
     }
 }


### PR DESCRIPTION
Final PR in the asset flow verification chain, following up after https://github.com/cowprotocol/services/pull/1302.

As part of writing the tests for this I discovered that there's an oversight in the driver WRT limit orders. In particular, with our current code "synthetic" limit orders are calculated by the `solver` binary. The autopilot passes the raw limit orders to the driver and the driver simply forwards them to the solver engine. So the amounts are incorrect when they reach the solver engine.

For that reason, this PR has no tests. In the next PR I will add support for limit orders in the driver and add some tests to cover this functionality as well.

(Even if my analysis above is incorrect the correct approach is probably still to have the driver do the surplus fee adjustments, not the autopilot - I think @MartinquaXD might be the best person to confirm this.)

### Test Plan

Follow-up PRs.
