### PR TITLE
Deprecate order meta data available balance

### DIFF
--- a/crates/autopilot/src/solvable_orders.rs
+++ b/crates/autopilot/src/solvable_orders.rs
@@ -213,11 +213,7 @@ impl SolvableOrdersCache {
             new_balances.insert(query, balance);
         }
 
-        let mut orders = solvable_orders(orders, &new_balances, self.ethflow_contract_address);
-        for order in &mut orders {
-            let query = Query::from_order(order);
-            order.metadata.available_balance = new_balances.get(&query).copied();
-        }
+        let orders = solvable_orders(orders, &new_balances, self.ethflow_contract_address);
         counter.checkpoint("insufficient_balance", &orders);
 
         // create auction

--- a/crates/model/src/order.rs
+++ b/crates/model/src/order.rs
@@ -580,6 +580,7 @@ pub struct OrderMetadata {
     pub creation_date: DateTime<Utc>,
     pub owner: H160,
     pub uid: OrderUid,
+    /// deprecated, always set to null
     #[serde_as(as = "Option<DecimalU256>")]
     pub available_balance: Option<U256>,
     #[derivative(Debug(format_with = "debug_biguint_to_string"))]
@@ -902,7 +903,7 @@ mod tests {
             "creationDate": "1970-01-01T00:00:03Z",
             "owner": "0x0000000000000000000000000000000000000001",
             "uid": "0x1111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
-            "availableBalance": "100",
+            "availableBalance": null,
             "executedBuyAmount": "3",
             "executedSellAmount": "5",
             "executedSellAmountBeforeFees": "4",
@@ -946,7 +947,7 @@ mod tests {
                 }),
                 owner: H160::from_low_u64_be(1),
                 uid: OrderUid([17u8; 56]),
-                available_balance: Some(100.into()),
+                available_balance: None,
                 executed_buy_amount: BigUint::from_bytes_be(&[3]),
                 executed_sell_amount: BigUint::from_bytes_be(&[5]),
                 executed_sell_amount_before_fees: 4.into(),

--- a/crates/orderbook/openapi.yml
+++ b/crates/orderbook/openapi.yml
@@ -582,9 +582,10 @@ components:
         uid:
           $ref: "#/components/schemas/UID"
         availableBalance:
-          description: "Amount of sellToken available for the settlement contract to spend on behalf of the owner. Null if API was unable to fetch balance or if the order status isn't Open."
+          description: Unused field that is currently always set to null and will be removed in the future.
           $ref: "#/components/schemas/TokenAmount"
           nullable: true
+          deprecated: true
         executedSellAmount:
           description: "The total amount of sellToken that has been executed for this order including fees."
           $ref: "#/components/schemas/BigUint"


### PR DESCRIPTION
This field serves no purpose. We are soon going to need a new similar field to communicate the available balance for partially fillable orders. I want to give the new field a different name to avoid confusion.

Potential problems:
Is the frontend using this field? After grepping their repos for this field, I don't think so.

### Test Plan

CI
