### PR TITLE
Activate auction rewards based on timestamp

### DIFF
--- a/crates/solver/src/arguments.rs
+++ b/crates/solver/src/arguments.rs
@@ -5,6 +5,7 @@ use {
         settlement_access_list::AccessListEstimatorType,
         solver::{single_order_solver, ExternalSolverArg, SolverAccountArg, SolverType},
     },
+    chrono::{DateTime, Utc},
     primitive_types::H160,
     reqwest::Url,
     shared::{
@@ -311,8 +312,8 @@ pub struct Arguments {
 
     /// Enable ranking of settlements by score
     /// /// CIP20 TODO - remove after transition period is over
-    #[clap(long, env, default_value = "false")]
-    pub enable_auction_rewards: bool,
+    #[clap(long, env, default_value = "2023-03-14T00:00:00+00:00")]
+    pub auction_rewards_activation_timestamp: DateTime<Utc>,
 
     /// Additional time to wait for a transaction to appear onchain before
     /// considering the solution invalid and setting the reward to 0.
@@ -444,7 +445,11 @@ impl std::fmt::Display for Arguments {
             self.token_list_restriction_for_price_checks
         )?;
         writeln!(f, "{}", self.s3_upload)?;
-        writeln!(f, "enable_auction_rewards: {}", self.enable_auction_rewards)?;
+        writeln!(
+            f,
+            "auction_rewards_activation_timestamp: {}",
+            self.auction_rewards_activation_timestamp
+        )?;
         writeln!(
             f,
             "additional_mining_deadline: {:?}",
@@ -462,4 +467,18 @@ pub enum TransactionStrategyArg {
     Flashbots,
     Gelato,
     DryRun,
+}
+
+#[cfg(test)]
+mod tests {
+    use {super::*, chrono::NaiveDate, std::str::FromStr};
+
+    #[test]
+    fn test_parsing_date_time() {
+        let dt = DateTime::<Utc>::from_utc(NaiveDate::from_ymd(2023, 3, 14).and_hms(0, 0, 0), Utc);
+        let stringified = dt.to_rfc3339();
+        println!("stringified: {}", stringified);
+        let dt2 = DateTime::<Utc>::from_str(&stringified).unwrap();
+        assert_eq!(dt, dt2);
+    }
 }

--- a/crates/solver/src/driver.rs
+++ b/crates/solver/src/driver.rs
@@ -17,6 +17,7 @@ use {
         solver::{Auction, Solver, Solvers},
     },
     anyhow::{anyhow, Context, Result},
+    chrono::{DateTime, Utc},
     contracts::GPv2Settlement,
     ethcontract::Account,
     futures::future::join_all,
@@ -101,7 +102,7 @@ impl Driver {
         tenderly: Option<Arc<dyn TenderlyApi>>,
         solution_comparison_decimal_cutoff: u16,
         code_fetcher: Arc<dyn CodeFetching>,
-        enable_auction_rewards: bool,
+        auction_rewards_activation_timestamp: DateTime<Utc>,
     ) -> Self {
         let settlement_rater = Arc::new(SettlementRater {
             access_list_estimator: solution_submitter.access_list_estimator.clone(),
@@ -116,7 +117,7 @@ impl Driver {
             metrics: metrics.clone(),
             settlement_rater,
             decimal_cutoff: solution_comparison_decimal_cutoff,
-            enable_auction_rewards,
+            auction_rewards_activation_timestamp,
         };
 
         let logger = DriverLogger {

--- a/crates/solver/src/run.rs
+++ b/crates/solver/src/run.rs
@@ -533,7 +533,7 @@ pub async fn run(args: Arguments) {
             .expect("failed to create Tenderly API"),
         args.solution_comparison_decimal_cutoff,
         code_fetcher,
-        args.enable_auction_rewards,
+        args.auction_rewards_activation_timestamp,
     );
 
     let maintainer = ServiceMaintenance::new(maintainers);

--- a/crates/solver/src/settlement_ranker.rs
+++ b/crates/solver/src/settlement_ranker.rs
@@ -8,6 +8,7 @@ use {
         solver::{SimulationWithError, Solver},
     },
     anyhow::Result,
+    chrono::{DateTime, Utc},
     gas_estimation::GasPrice1559,
     model::auction::AuctionId,
     num::{rational::Ratio, BigInt, BigRational, CheckedDiv, FromPrimitive},
@@ -41,7 +42,7 @@ pub struct SettlementRanker {
     pub max_settlement_price_deviation: Option<Ratio<BigInt>>,
     pub token_list_restriction_for_price_checks: PriceCheckTokens,
     pub decimal_cutoff: u16,
-    pub enable_auction_rewards: bool,
+    pub auction_rewards_activation_timestamp: DateTime<Utc>,
 }
 
 impl SettlementRanker {
@@ -198,7 +199,7 @@ impl SettlementRanker {
         // objective value tie.
         rated_settlements.shuffle(&mut rand::thread_rng());
 
-        if self.enable_auction_rewards {
+        if Utc::now() > self.auction_rewards_activation_timestamp {
             rated_settlements.sort_by_key(|s| s.1.score.score());
 
             rated_settlements.iter_mut().rev().enumerate().for_each(


### PR DESCRIPTION
Parameter `auction_rewards_activation_timestamp` defines the time when we switch to ranking the solutions by score.

Current plan is the following:
1. This PR becomes part of the next week release which is applied on Monday 13th of March.
2. 14th of March at 00.00am ranking by score is activated.
3. 14th of March at ~ 09.00am solver rewards script is executed for the past week ending with 14th of March 00.00am (ranking by objective_value)
4. 21st of March at ~ 09.00am solver rewards script is executed for the dates 14-21 March (ranking by score).

With this change, there is no need to do configuration changes (apply release) on 14th of March at 00.00am.

~One concern I have is the timezone considered by solver rewards script. @bh2smith do you know which one is used? Here I assumed Utc.~