### PR TITLE
Introduce Web3 Code Simulator with Tenderly Fallback

### DIFF
--- a/crates/shared/src/price_estimation.rs
+++ b/crates/shared/src/price_estimation.rs
@@ -65,6 +65,7 @@ impl PriceEstimatorType {
 pub enum TradeValidatorKind {
     Web3,
     Tenderly,
+    Web3ThenTenderly,
 }
 
 /// Shared price estimation configuration arguments.


### PR DESCRIPTION
Fixes #1341 

This PR introduces a web3 trade simulator that falls back to Tenderly on failures. One pain-point of using the `Web3` simulator is that it makes debugging failed simulations very hard. This PR introduces a fallback mechanism such that only failed simulations go to Tenderly. This way, we save Tenderly credits but keep debugging easy!

### Test Plan

Manual test, was able to create a [simulation on Tenderly](https://dashboard.tenderly.co/public/safe/safe-apps/simulator/7dec4cdd-ab30-4b9d-93c4-2d5883364803) for debugging.