### PR TITLE
CIP20: Filter out non-positive score settlements

### DIFF
--- a/crates/shared/src/http_solver/model.rs
+++ b/crates/shared/src/http_solver/model.rs
@@ -373,7 +373,7 @@ pub enum SolverRejectionReason {
     /// re-create simulation locally
     SimulationFailure(TransactionWithError),
 
-    /// The solution don't have a positive score. Currently this can happen
+    /// The solution doesn't have a positive score. Currently this can happen
     /// only if the objective value is negative.
     NonPositiveScore,
 }

--- a/crates/shared/src/http_solver/model.rs
+++ b/crates/shared/src/http_solver/model.rs
@@ -372,6 +372,10 @@ pub enum SolverRejectionReason {
     /// The solution didn't pass simulation. Includes all data needed to
     /// re-create simulation locally
     SimulationFailure(TransactionWithError),
+
+    /// The solution don't have a positive score. Currently this can happen
+    /// only if the objective value is negative.
+    NonPositiveScore,
 }
 
 #[derive(Debug, Serialize)]

--- a/crates/solver/src/arguments.rs
+++ b/crates/solver/src/arguments.rs
@@ -334,7 +334,8 @@ pub struct Arguments {
     #[clap(flatten)]
     pub score_params: score_computation::Arguments,
 
-    /// Should we skip settlements with non-positive score for solver competition?
+    /// Should we skip settlements with non-positive score for solver
+    /// competition?
     #[clap(long, env, default_value = "true")]
     pub skip_non_positive_score_settlements: bool,
 }

--- a/crates/solver/src/arguments.rs
+++ b/crates/solver/src/arguments.rs
@@ -336,7 +336,7 @@ pub struct Arguments {
 
     /// Should we skip settlements with non-positive score for solver
     /// competition?
-    #[clap(long, env, default_value = "true")]
+    #[clap(long, env, action = clap::ArgAction::Set, default_value = "true")]
     pub skip_non_positive_score_settlements: bool,
 }
 

--- a/crates/solver/src/arguments.rs
+++ b/crates/solver/src/arguments.rs
@@ -334,9 +334,9 @@ pub struct Arguments {
     #[clap(flatten)]
     pub score_params: score_computation::Arguments,
 
-    /// Should we skip settlements with zero score for submission
+    /// Should we skip settlements with non-positive score for solver competition?
     #[clap(long, env, default_value = "true")]
-    pub skip_zero_score_settlements: bool,
+    pub skip_non_positive_score_settlements: bool,
 }
 
 impl std::fmt::Display for Arguments {
@@ -469,7 +469,7 @@ impl std::fmt::Display for Arguments {
             self.additional_mining_deadline
         )?;
         writeln!(f, "{}", self.score_params)?;
-        writeln!(f, "{}", self.skip_zero_score_settlements)?;
+        writeln!(f, "{}", self.skip_non_positive_score_settlements)?;
         Ok(())
     }
 }

--- a/crates/solver/src/arguments.rs
+++ b/crates/solver/src/arguments.rs
@@ -334,7 +334,7 @@ pub struct Arguments {
     #[clap(flatten)]
     pub score_params: score_computation::Arguments,
 
-    /// Should we consider settlements with zero score for submission
+    /// Should we skip settlements with zero score for submission
     #[clap(long, env, default_value = "true")]
     pub skip_zero_score_settlements: bool,
 }

--- a/crates/solver/src/arguments.rs
+++ b/crates/solver/src/arguments.rs
@@ -333,6 +333,10 @@ pub struct Arguments {
 
     #[clap(flatten)]
     pub score_params: score_computation::Arguments,
+
+    /// Should we consider settlements with zero score for submission
+    #[clap(long, env, default_value = "true")]
+    pub skip_zero_score_settlements: bool,
 }
 
 impl std::fmt::Display for Arguments {
@@ -465,6 +469,7 @@ impl std::fmt::Display for Arguments {
             self.additional_mining_deadline
         )?;
         writeln!(f, "{}", self.score_params)?;
+        writeln!(f, "{}", self.skip_zero_score_settlements)?;
         Ok(())
     }
 }

--- a/crates/solver/src/driver.rs
+++ b/crates/solver/src/driver.rs
@@ -92,7 +92,7 @@ impl Driver {
         solver_time_limit: Duration,
         block_time: Duration,
         additional_mining_deadline: Duration,
-        skip_zero_score_settlements: bool,
+        skip_non_positive_score_settlements: bool,
         block_stream: CurrentBlockStream,
         solution_submitter: SolutionSubmitter,
         api: OrderBookApi,
@@ -119,7 +119,7 @@ impl Driver {
             settlement_rater,
             decimal_cutoff: solution_comparison_decimal_cutoff,
             auction_rewards_activation_timestamp,
-            skip_zero_score_settlements,
+            skip_non_positive_score_settlements,
         };
 
         let logger = DriverLogger {
@@ -393,7 +393,6 @@ impl Driver {
         };
 
         let mut settlement_transaction_attempted = false;
-
         // In transition period last settlement is not necessarily the one with the
         // highest score. So we need to use the score ranking to determine the winner.
         // CIP20 TODO - add to if statement below, once the transition period is over.

--- a/crates/solver/src/driver.rs
+++ b/crates/solver/src/driver.rs
@@ -66,6 +66,7 @@ pub struct Driver {
     solver_time_limit: Duration,
     block_time: Duration,
     additional_mining_deadline: Duration,
+    skip_zero_score_settlements: bool,
     block_stream: CurrentBlockStream,
     solution_submitter: SolutionSubmitter,
     run_id: u64,
@@ -92,6 +93,7 @@ impl Driver {
         solver_time_limit: Duration,
         block_time: Duration,
         additional_mining_deadline: Duration,
+        skip_zero_score_settlements: bool,
         block_stream: CurrentBlockStream,
         solution_submitter: SolutionSubmitter,
         api: OrderBookApi,
@@ -139,6 +141,7 @@ impl Driver {
             solver_time_limit,
             block_time,
             additional_mining_deadline,
+            skip_zero_score_settlements,
             block_stream,
             solution_submitter,
             run_id: 0,
@@ -391,6 +394,18 @@ impl Driver {
         };
 
         let mut settlement_transaction_attempted = false;
+
+        if Utc::now() > self.settlement_ranker.auction_rewards_activation_timestamp // CIP20 activated
+        && self.skip_zero_score_settlements
+        {
+            // After ranking the settlements and saving the whole competition data,
+            // filter out the settlements with a score of 0, since we don't want to submit
+            // settlements with a score of 0 (settlements with negative objective values)
+            rated_settlements
+                .retain(|(_, rated_settlement, _)| rated_settlement.score.score() > 0.into());
+            DriverLogger::print_settlements(&rated_settlements);
+        }
+
         // In transition period last settlement is not necessarily the one with the
         // highest score. So we need to use the score ranking to determine the winner.
         // CIP20 TODO - add to if statement below, once the transition period is over.

--- a/crates/solver/src/metrics.rs
+++ b/crates/solver/src/metrics.rs
@@ -103,6 +103,7 @@ pub trait SolverMetrics: Send + Sync {
     fn settlement_computed(&self, solver_type: &str, response: &str, start: Instant);
     fn order_settled(&self, order: &Order, solver: &str);
     fn settlement_simulation(&self, solver: &str, outcome: SolverSimulationOutcome);
+    fn settlement_invalid_score(&self, solver: &str);
     fn solver_run(&self, outcome: SolverRunOutcome, solver: &str);
     fn single_order_solver_succeeded(&self, solver: &str);
     fn single_order_solver_failed(&self, solver: &str);
@@ -138,6 +139,9 @@ struct Storage {
     /// Settlement simulation counts
     #[metric(labels("result", "solver_type"))]
     settlement_simulations: IntCounterVec,
+    /// Settlement invalid score counts
+    #[metric(labels("solver_type"))]
+    settlement_invalid_scores: IntCounterVec,
     /// Settlement submission counts
     #[metric(labels("result", "solver_type"))]
     settlement_submissions: IntCounterVec,
@@ -284,6 +288,13 @@ impl SolverMetrics for Metrics {
             .inc()
     }
 
+    fn settlement_invalid_score(&self, solver: &str) {
+        self.metrics
+            .settlement_invalid_scores
+            .with_label_values(&[solver])
+            .inc()
+    }
+
     fn solver_run(&self, outcome: SolverRunOutcome, solver: &str) {
         self.metrics
             .solver_runs
@@ -416,6 +427,8 @@ impl SolverMetrics for NoopMetrics {
     fn transaction_gas_price(&self, _: U256) {}
 
     fn settlement_simulation(&self, _: &str, _: SolverSimulationOutcome) {}
+
+    fn settlement_invalid_score(&self, _: &str) {}
 }
 
 #[cfg(test)]

--- a/crates/solver/src/metrics.rs
+++ b/crates/solver/src/metrics.rs
@@ -103,7 +103,7 @@ pub trait SolverMetrics: Send + Sync {
     fn settlement_computed(&self, solver_type: &str, response: &str, start: Instant);
     fn order_settled(&self, order: &Order, solver: &str);
     fn settlement_simulation(&self, solver: &str, outcome: SolverSimulationOutcome);
-    fn settlement_invalid_score(&self, solver: &str);
+    fn settlement_non_positive_score(&self, solver: &str);
     fn solver_run(&self, outcome: SolverRunOutcome, solver: &str);
     fn single_order_solver_succeeded(&self, solver: &str);
     fn single_order_solver_failed(&self, solver: &str);
@@ -139,9 +139,9 @@ struct Storage {
     /// Settlement simulation counts
     #[metric(labels("result", "solver_type"))]
     settlement_simulations: IntCounterVec,
-    /// Settlement invalid score counts
+    /// Settlement non-positive score counts
     #[metric(labels("solver_type"))]
-    settlement_invalid_scores: IntCounterVec,
+    settlement_non_positive_scores: IntCounterVec,
     /// Settlement submission counts
     #[metric(labels("result", "solver_type"))]
     settlement_submissions: IntCounterVec,
@@ -288,9 +288,9 @@ impl SolverMetrics for Metrics {
             .inc()
     }
 
-    fn settlement_invalid_score(&self, solver: &str) {
+    fn settlement_non_positive_score(&self, solver: &str) {
         self.metrics
-            .settlement_invalid_scores
+            .settlement_non_positive_scores
             .with_label_values(&[solver])
             .inc()
     }
@@ -428,7 +428,7 @@ impl SolverMetrics for NoopMetrics {
 
     fn settlement_simulation(&self, _: &str, _: SolverSimulationOutcome) {}
 
-    fn settlement_invalid_score(&self, _: &str) {}
+    fn settlement_non_positive_score(&self, _: &str) {}
 }
 
 #[cfg(test)]

--- a/crates/solver/src/run.rs
+++ b/crates/solver/src/run.rs
@@ -520,6 +520,7 @@ pub async fn run(args: Arguments) {
         args.solver_time_limit,
         network_time_between_blocks,
         args.additional_mining_deadline,
+        args.skip_zero_score_settlements,
         current_block_stream.clone(),
         solution_submitter,
         api,

--- a/crates/solver/src/run.rs
+++ b/crates/solver/src/run.rs
@@ -520,7 +520,7 @@ pub async fn run(args: Arguments) {
         args.solver_time_limit,
         network_time_between_blocks,
         args.additional_mining_deadline,
-        args.skip_zero_score_settlements,
+        args.skip_non_positive_score_settlements,
         current_block_stream.clone(),
         solution_submitter,
         api,

--- a/crates/solver/src/settlement_ranker.rs
+++ b/crates/solver/src/settlement_ranker.rs
@@ -43,7 +43,7 @@ pub struct SettlementRanker {
     pub token_list_restriction_for_price_checks: PriceCheckTokens,
     pub decimal_cutoff: u16,
     pub auction_rewards_activation_timestamp: DateTime<Utc>,
-    pub skip_zero_score_settlements: bool,
+    pub skip_non_positive_score_settlements: bool,
 }
 
 impl SettlementRanker {
@@ -197,7 +197,7 @@ impl SettlementRanker {
 
         // Filter out settlements with non-positive score.
         if Utc::now() > self.auction_rewards_activation_timestamp // CIP20 activated
-        && self.skip_zero_score_settlements
+        && self.skip_non_positive_score_settlements
         {
             rated_settlements.retain(|(solver, settlement, _)| {
                 let positive_score = settlement.score.score() > 0.into();

--- a/crates/solver/src/settlement_ranker.rs
+++ b/crates/solver/src/settlement_ranker.rs
@@ -43,6 +43,7 @@ pub struct SettlementRanker {
     pub token_list_restriction_for_price_checks: PriceCheckTokens,
     pub decimal_cutoff: u16,
     pub auction_rewards_activation_timestamp: DateTime<Utc>,
+    pub skip_zero_score_settlements: bool,
 }
 
 impl SettlementRanker {
@@ -192,6 +193,27 @@ impl SettlementRanker {
                     },
                 )),
             );
+        }
+
+        // Filter out settlements with non-positive score.
+        if Utc::now() > self.auction_rewards_activation_timestamp // CIP20 activated
+        && self.skip_zero_score_settlements
+        {
+            rated_settlements.retain(|(solver, settlement, _)| {
+                let positive_score = settlement.score.score() > 0.into();
+                if !positive_score {
+                    tracing::debug!(
+                        solver_name = %solver.name(),
+                        "settlement filtered for having non-positive score",
+                    );
+                    solver.notify_auction_result(
+                        auction_id,
+                        AuctionResult::Rejected(SolverRejectionReason::NonPositiveScore),
+                    );
+                    self.metrics.settlement_invalid_score(solver.name());
+                }
+                positive_score
+            });
         }
 
         // Before sorting, make sure to shuffle the settlements. This is to make sure we

--- a/crates/solver/src/settlement_ranker.rs
+++ b/crates/solver/src/settlement_ranker.rs
@@ -210,7 +210,7 @@ impl SettlementRanker {
                         auction_id,
                         AuctionResult::Rejected(SolverRejectionReason::NonPositiveScore),
                     );
-                    self.metrics.settlement_invalid_score(solver.name());
+                    self.metrics.settlement_non_positive_score(solver.name());
                 }
                 positive_score
             });


### PR DESCRIPTION
Do not consider non-positive zero score settlements for solver competition.
Settlement has non-positive score in two cases
- solver provided zero score
- solver did not provide score -> fallback to objective_value which is negative or zero (with or without discount doesn't matter)

Put under parameter so we can easily disable this if there are a lot of auctions with no positive winner score.