### PR TITLE
Fix bumping the gas price for simulation

### DIFF
--- a/crates/solver/src/settlement_access_list.rs
+++ b/crates/solver/src/settlement_access_list.rs
@@ -90,6 +90,7 @@ pub async fn estimate_settlement_access_list(
                     web3.eth().block_number().await?.as_u64(),
                     &web3.net().version().await?,
                     tx.clone(),
+                    None,
                     None
                 );
                 tracing::debug!(%simulation_link, ?order_uid, "generating partial access list for trade");
@@ -129,6 +130,7 @@ pub async fn estimate_settlement_access_list(
         web3.eth().block_number().await?.as_u64(),
         &web3.net().version().await?,
         tx.clone(),
+        None,
         Some(partial_access_list.clone()),
     );
     tracing::trace!(?settlement, %simulation_link, "generating access list for settlement");

--- a/crates/solver/src/settlement_ranker.rs
+++ b/crates/solver/src/settlement_ranker.rs
@@ -28,12 +28,6 @@ use {
 
 type SolverResult = (Arc<dyn Solver>, Result<Vec<Settlement>, SolverRunError>);
 
-// We require from solvers to have a bit more ETH balance then needed
-// at the moment of simulating the transaction, to cover the potential increase
-// of the cost of sending transaction onchain, because of the sudden gas price
-// increase. To simulate this sudden increase of gas price during simulation, we
-// artificially multiply the gas price with this factor.
-const SOLVER_BALANCE_MULTIPLIER: f64 = 3.;
 pub struct SettlementRanker {
     pub metrics: Arc<dyn SolverMetrics>,
     pub settlement_rater: Arc<dyn SettlementRating>,
@@ -148,8 +142,6 @@ impl SettlementRanker {
         gas_price: GasPrice1559,
         auction_id: AuctionId,
     ) -> Result<(Vec<RatedSolverSettlement>, Vec<SimulationWithError>)> {
-        let gas_price = gas_price.bump(SOLVER_BALANCE_MULTIPLIER);
-
         let solver_settlements =
             self.get_legal_settlements(settlements, external_prices, auction_id);
 

--- a/crates/solver/src/settlement_rater.rs
+++ b/crates/solver/src/settlement_rater.rs
@@ -30,12 +30,16 @@ use {
     web3::types::AccessList,
 };
 
-// We require from solvers to have a bit more ETH balance then needed
-// at the moment of simulating the transaction, to cover the potential increase
-// of the cost of sending transaction onchain, because of the sudden gas price
-// increase. To simulate this sudden increase of gas price during simulation, we
-// artificially multiply the gas price with this factor.
-const SOLVER_BALANCE_MULTIPLIER: f64 = 5.;
+/// We require from solvers to have a bit more ETH balance then needed
+/// at the moment of simulating the transaction, to cover the potential increase
+/// of the cost of sending transaction onchain, because of the sudden gas price
+/// increase. To simulate this sudden increase of gas price during simulation,
+/// we artificially multiply the gas price with this factor.
+///
+/// We chose the multiplier of 3.25 to be approximately equal to the maximum
+/// increase in the ERC-1559 base gas price over 10 blocks, or ~120s. This maps
+/// exactly to the timeout we allow for any given transaction.
+const SOLVER_BALANCE_MULTIPLIER: f64 = 3.25;
 
 type SolverSettlement = (Arc<dyn Solver>, Settlement);
 pub type RatedSolverSettlement = (Arc<dyn Solver>, RatedSettlement, Option<AccessList>);

--- a/crates/solver/src/settlement_submission/dry_run.rs
+++ b/crates/solver/src/settlement_submission/dry_run.rs
@@ -22,7 +22,7 @@ pub async fn log_settlement(
     let network = web3.net().version().await?;
     let settlement = settlement.encode(InternalizationStrategy::SkipInternalizableInteraction);
     let settlement = settle_method_builder(contract, settlement, account).tx;
-    let simulation_link = tenderly_link(current_block.as_u64(), &network, settlement, None);
+    let simulation_link = tenderly_link(current_block.as_u64(), &network, settlement, None, None);
 
     tracing::info!("not submitting transaction in dry-run mode");
     tracing::debug!("transaction simulation: {}", simulation_link);


### PR DESCRIPTION
Fixes https://github.com/cowprotocol/services/pull/924 which is not working properly. 
Let's observe the example:

```
max_fee: 200
max_tip: 5
base_fee: 100
```

When the node executes the `eth_estimateGas` with the given gas price, it uses `effective_gas_price` to check if account balance is enough to execute the transaction. In this case, effective gas price is 105.

The code `let gas_price = gas_price.bump(SOLVER_BALANCE_MULTIPLIER)` only bumps the `max_tip`, so the effective gas price is now 115 (which is not want we want).

This PR fixes this so the effective gas price after bumping is 525.

Related to the [issue](https://cowservices.slack.com/archives/C036PMLUPQF/p1678625544766379?thread_ts=1678615853.015859&cid=C036PMLUPQF) we had with Raven solver when it ran out of funds during a volatile gas price network conditions.

