### PR TITLE
Dex partial fill

### DIFF
--- a/crates/solvers/src/domain/solver/dex/mod.rs
+++ b/crates/solvers/src/domain/solver/dex/mod.rs
@@ -1,0 +1,2 @@
+pub mod partial_fill_handler;
+pub mod solver;

--- a/crates/solvers/src/domain/solver/dex/partial_fill_handler.rs
+++ b/crates/solvers/src/domain/solver/dex/partial_fill_handler.rs
@@ -1,0 +1,88 @@
+use {
+    crate::domain::{eth, order},
+    std::{
+        collections::HashMap,
+        sync::Mutex,
+        time::{Duration, Instant},
+    },
+};
+
+/// Manages the search for a fillable amount for partially fillable orders.
+#[derive(Debug, Default)]
+pub struct PartialFiller {
+    /// Maps which fill amount should be tried next for a given order. For sell
+    /// orders the amount refers to the `sell` asset and for buy orders it
+    /// refers to the `buy` asset.
+    amounts: Mutex<HashMap<order::Uid, CacheEntry>>,
+}
+
+impl PartialFiller {
+    /// Returns which `executed_amount` should be tried next for the given
+    /// order.
+    pub fn next_fill_amount(&self, order: &order::Order) -> eth::Asset {
+        let mut total_execution = match order.side {
+            order::Side::Buy => order.buy,
+            order::Side::Sell => order.sell,
+        };
+
+        if !order.partially_fillable {
+            return total_execution;
+        }
+
+        let now = Instant::now();
+        let next_amount = match self.amounts.lock().unwrap().entry(order.uid) {
+            std::collections::hash_map::Entry::Vacant(entry) => {
+                entry.insert(CacheEntry {
+                    next_amount: total_execution.amount,
+                    last_requested: now,
+                });
+                total_execution.amount
+            }
+            std::collections::hash_map::Entry::Occupied(mut entry) => {
+                let entry = entry.get_mut();
+                entry.last_requested = now;
+                // `total_execution.amount` might be lower than what we wanted to try next if
+                // some other solver partially filled the order in the mean time.
+                entry.next_amount = entry.next_amount.min(total_execution.amount);
+                entry.next_amount
+            }
+        };
+
+        total_execution.amount = next_amount;
+        total_execution
+    }
+
+    /// Adjusts the next fill amount that should be tried. Always halfes the
+    /// last tried amount.
+    // TODO: make use of `price_impact` provided by some APIs to get a more optimal
+    // next try.
+    pub fn reduce_next_try(&self, uid: order::Uid) {
+        self.amounts
+            .lock()
+            .unwrap()
+            .entry(uid)
+            .and_modify(|entry| entry.next_amount /= 2);
+    }
+
+    /// Removes entries that have not been requested for a long time. This
+    /// allows us to remove orders that got settled by other solvers which
+    /// we are not able to notice.
+    pub fn collect_garbage(&self) {
+        const MAX_AGE: Duration = Duration::from_secs(60 * 10);
+        let now = Instant::now();
+
+        self.amounts
+            .lock()
+            .unwrap()
+            .retain(|_, entry| now.duration_since(entry.last_requested) < MAX_AGE)
+    }
+}
+
+#[derive(Debug)]
+struct CacheEntry {
+    next_amount: eth::U256,
+    last_requested: Instant,
+}
+
+// TODO Figure out current problems
+// Don't reduce fillable amount indefinitely and when to reset?

--- a/crates/solvers/src/domain/solver/dex/solver.rs
+++ b/crates/solvers/src/domain/solver/dex/solver.rs
@@ -5,7 +5,7 @@ use {
     crate::{
         domain::{
             auction,
-            dex::{self, slippage},
+            dex::slippage,
             order,
             solution,
             solver::dex::partial_fill_handler::PartialFiller,
@@ -70,9 +70,8 @@ impl Dex {
         gas: auction::GasPrice,
     ) -> Option<solution::Solution> {
         let swap = {
-            let next_fill_amount = self.partial_fill_handler.next_fill_amount(&order);
-            let order = dex::Order::new(&order);
-            let slippage = self.slippage.relative(&next_fill_amount, prices);
+            let order = self.partial_fill_handler.dex_order(&order);
+            let slippage = self.slippage.relative(&order.amount(), prices);
             self.dex.swap(&order, &slippage, gas).await
         };
 

--- a/crates/solvers/src/domain/solver/mod.rs
+++ b/crates/solvers/src/domain/solver/mod.rs
@@ -5,7 +5,7 @@ pub mod dex;
 pub mod legacy;
 pub mod naive;
 
-pub use self::{baseline::Baseline, dex::Dex, legacy::Legacy, naive::Naive};
+pub use self::{baseline::Baseline, dex::solver::Dex, legacy::Legacy, naive::Naive};
 
 pub enum Solver {
     Baseline(Baseline),

--- a/crates/solvers/src/run.rs
+++ b/crates/solvers/src/run.rs
@@ -34,19 +34,19 @@ pub async fn run(
         }
         cli::Command::ZeroEx { config } => {
             let config = config::zeroex::file::load(&config).await;
-            Solver::Dex(solver::Dex {
-                dex: dex::Dex::ZeroEx(
+            Solver::Dex(solver::Dex::new(
+                dex::Dex::ZeroEx(
                     dex::zeroex::ZeroEx::new(config.zeroex).expect("invalid 0x configuration"),
                 ),
-                slippage: config.slippage,
-            })
+                config.slippage,
+            ))
         }
         cli::Command::Balancer { config } => {
             let config = config::balancer::file::load(&config).await;
-            Solver::Dex(solver::Dex {
-                dex: dex::Dex::Balancer(dex::balancer::Sor::new(config.sor)),
-                slippage: config.slippage,
-            })
+            Solver::Dex(solver::Dex::new(
+                dex::Dex::Balancer(dex::balancer::Sor::new(config.sor)),
+                config.slippage,
+            ))
         }
     };
 

--- a/crates/solvers/src/tests/dex/mod.rs
+++ b/crates/solvers/src/tests/dex/mod.rs
@@ -1,0 +1,3 @@
+//! Test cases that are specific to the dex solver but not the underlying APIs.
+
+mod partial_fill;

--- a/crates/solvers/src/tests/dex/partial_fill.rs
+++ b/crates/solvers/src/tests/dex/partial_fill.rs
@@ -1,0 +1,212 @@
+//! Tests that dex solvers can make progress on partially fillable orders across
+//! multiple requests. We are using the balancer API here because that's the
+//! easies to mock.
+
+use {
+    crate::tests::{self, balancer, mock},
+    serde_json::json,
+};
+
+#[tokio::test]
+async fn test() {
+    let inner_request = |amount| {
+        json!({
+            "sellToken": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+            "buyToken": "0xba100000625a3754423978a60c9317c58a424e3d",
+            "orderKind": "sell",
+            "amount": amount,
+            "gasPrice": "15000000000",
+        })
+    };
+
+    // response returned when no route could be found
+    let inner_response_error = json!({
+        "tokenAddresses": [],
+        "swaps": [],
+        "swapAmount": "0",
+        "swapAmountForSwaps": "0",
+        "returnAmount": "0",
+        "returnAmountFromSwaps": "0",
+        "returnAmountConsideringFees": "0",
+        "tokenIn": "0x0000000000000000000000000000000000000000",
+        "tokenOut": "0x0000000000000000000000000000000000000000",
+        "marketSp": "0",
+    });
+
+    let api = mock::http::setup(vec![mock::http::Expectation::Post {
+        path: mock::http::Path::Any,
+        req: inner_request("16000000000000000000"),
+        res: inner_response_error.clone(),
+    },
+    mock::http::Expectation::Post {
+        path: mock::http::Path::Any,
+        req: inner_request("8000000000000000000"),
+        res: inner_response_error.clone(),
+    },
+    mock::http::Expectation::Post {
+        path: mock::http::Path::Any,
+        req: inner_request("4000000000000000000"),
+        res: inner_response_error.clone(),
+    },
+    mock::http::Expectation::Post {
+        path: mock::http::Path::Any,
+        req: inner_request("2000000000000000000"),
+        res: inner_response_error.clone(),
+    },
+    mock::http::Expectation::Post {
+        path: mock::http::Path::Any,
+        req: inner_request("1000000000000000000"),
+        res: json!({
+            "tokenAddresses": [
+                "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+                "0xba100000625a3754423978a60c9317c58a424e3d"
+            ],
+            "swaps": [
+                {
+                    "poolId": "0x5c6ee304399dbdb9c8ef030ab642b10820db8f56000200000000000000000014",
+                    "assetInIndex": 0,
+                    "assetOutIndex": 1,
+                    "amount": "1000000000000000000",
+                    "userData": "0x",
+                    "returnAmount": "227598784442065388110"
+                }
+            ],
+            "swapAmount": "1000000000000000000",
+            "swapAmountForSwaps": "1000000000000000000",
+            "returnAmount": "227598784442065388110",
+            "returnAmountFromSwaps": "227598784442065388110",
+            "returnAmountConsideringFees": "227307710853355710706",
+            "tokenIn": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+            "tokenOut": "0xba100000625a3754423978a60c9317c58a424e3d",
+            "marketSp": "0.004393607339632106",
+        }),
+    }])
+    .await;
+
+    let engine = tests::SolverEngine::new("balancer", balancer::config(&api)).await;
+
+    let auction = json!({
+        "id": null,
+        "tokens": {
+            "0xba100000625a3754423978a60c9317c58a424e3D": {
+                "decimals": 18,
+                "symbol": "BAL",
+                "referencePrice": "4327903683155778",
+                "availableBalance": "1583034704488033979459",
+                "trusted": true
+            },
+            "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2": {
+                "decimals": 18,
+                "symbol": "WETH",
+                "referencePrice": "1000000000000000000",
+                "availableBalance": "482725140468789680",
+                "trusted": true
+            },
+        },
+        "orders": [
+            {
+                "uid": "0x2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a\
+                          2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a\
+                          2a2a2a2a",
+                "sellToken": "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
+                "buyToken": "0xba100000625a3754423978a60c9317c58a424e3D",
+                "sellAmount": "16000000000000000000",
+                "buyAmount": "3641580551073046209760",
+                // Let's just assume 0 fee to not further complicate the math.
+                "feeAmount": "0",
+                "kind": "sell",
+                "partiallyFillable": true,
+                "class": "market",
+                "reward": 0.
+            }
+        ],
+        "liquidity": [],
+        "effectiveGasPrice": "15000000000",
+        "deadline": "2106-01-01T00:00:00.000Z"
+    });
+
+    for _ in 0..4 {
+        let solution = engine.solve(auction.clone()).await;
+
+        // No solution could be found so we'll try with a lower fill amount next time.
+        assert_eq!(
+            solution,
+            json!({
+                "prices": {},
+                "trades": [],
+                "interactions": [],
+            }),
+        );
+    }
+
+    let solution = engine.solve(auction.clone()).await;
+
+    assert_eq!(
+        solution,
+        json!({
+            "interactions": [
+                {
+                    "allowances": [
+                        {
+                            "amount": "1000000000000000000",
+                            "spender": "0xba12222222228d8ba445958a75a0704d566bf2c8",
+                            "token": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"
+                        }
+                    ],
+                    "calldata": "0x945bcec90000000000000000000000000000000000000000000\
+                        00000000000000000000000000000000000000000000000000000000000000\
+                        00000000000000000000120000000000000000000000000000000000000000\
+                        00000000000000000000002200000000000000000000000009008d19f58aab\
+                        d9ed0d60971565aa8510560ab4100000000000000000000000000000000000\
+                        000000000000000000000000000000000000000000000000000009008d19f5\
+                        8aabd9ed0d60971565aa8510560ab410000000000000000000000000000000\
+                        00000000000000000000000000000000000000000000000000000000000000\
+                        00000000000000000000000000000000280800000000000000000000000000\
+                        00000000000000000000000000000000000000000000000000000000000000\
+                        00000000000000000000000000000000000000100000000000000000000000\
+                        000000000000000000000000000000000000000205c6ee304399dbdb9c8ef0\
+                        30ab642b10820db8f560002000000000000000000140000000000000000000\
+                        00000000000000000000000000000000000000000000000000000000000000\
+                        00000000000000000000000000000000000000000000001000000000000000\
+                        0000000000000000000000000000000000de0b6b3a76400000000000000000\
+                        0000000000000000000000000000000000000000000000000a000000000000\
+                        00000000000000000000000000000000000000000000000000000000000000\
+                        00000000000000000000000000000000000000000000000000000020000000\
+                        00000000000000000c02aaa39b223fe8d0a0e5c4f27ead9083c756cc200000\
+                        0000000000000000000ba100000625a3754423978a60c9317c58a424e3d000\
+                        00000000000000000000000000000000000000000000000000000000000020\
+                        000000000000000000000000000000000000000000000000de0b6b3a764000\
+                        0fffffffffffffffffffffffffffffffffffffffffffffff3c9049e4e47ca5\
+                        0ec",
+                    "inputs": [
+                        {
+                            "amount": "1000000000000000000",
+                            "token": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"
+                        }
+                    ],
+                    "internalize": false,
+                    "kind": "custom",
+                    "outputs": [
+                        {
+                            "amount": "227598784442065388110",
+                            "token": "0xba100000625a3754423978a60c9317c58a424e3d"
+                        }
+                    ],
+                    "target": "0xba12222222228d8ba445958a75a0704d566bf2c8",
+                    "value": "0"
+                }
+            ],
+            "prices": {
+                "0xba100000625a3754423978a60c9317c58a424e3d": "1000000000000000000",
+                "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2": "227598784442065388110"
+            },
+            "trades": [
+                {
+                    "executedAmount": "16000000000000000000",
+                    "kind": "fulfillment",
+                    "order": "0x2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a"
+                }
+            ]
+        })
+    );
+}

--- a/crates/solvers/src/tests/mock/http.rs
+++ b/crates/solvers/src/tests/mock/http.rs
@@ -61,7 +61,11 @@ pub enum Expectation {
 }
 
 /// Set up an mock external HTTP API.
-pub async fn setup(expectations: Vec<Expectation>) -> SocketAddr {
+pub async fn setup(mut expectations: Vec<Expectation>) -> SocketAddr {
+    // Reverse expectations so test can specify them in natural order while allowing
+    // us to simply `.pop()` the last element.
+    expectations.reverse();
+
     let state = Arc::new(Mutex::new(expectations));
     let app = axum::Router::new()
         .route(

--- a/crates/solvers/src/tests/mod.rs
+++ b/crates/solvers/src/tests/mod.rs
@@ -12,6 +12,7 @@ use {
 
 mod balancer;
 mod baseline;
+mod dex;
 mod legacy;
 mod mock;
 mod naive;


### PR DESCRIPTION
Implements #1292 for the new solvers of the colocated driver.

We can potentially waste lots of requests on partially fillable orders that are out of the price range. To keep the used requests fair across partially fillable and fok orders I decided to track which amounts we already tried for each order and half that when the API was not able to find a swap.

Things that could still be improved (but in a later PR):
* lower bound for the amounts we try to fill (e.g. it wouldn't make sense to fill an order for a few wei)
* use the price impact reported by some APIs to improve our next guess
* possible allow for a configurable number of requests per order per `/solve` request

Btw, happy to hear your suggestions for better names. 🙈  

### Test Plan

Added e2e test using a mocked balancer API