### PR TITLE
Bump Max Gas For Simulation

### DIFF
--- a/crates/solver/src/settlement_rater.rs
+++ b/crates/solver/src/settlement_rater.rs
@@ -275,7 +275,7 @@ fn gas_price_for_simulation(gas_price: &GasPrice1559) -> GasPrice1559 {
     let max_priority_fee_per_gas = bumped_effective_gas_price - gas_price.base_fee_per_gas;
 
     GasPrice1559 {
-        max_fee_per_gas: gas_price.max_fee_per_gas.max(bumped_effective_gas_price),
+        max_fee_per_gas: gas_price.max_fee_per_gas * SOLVER_BALANCE_MULTIPLIER,
         max_priority_fee_per_gas,
         base_fee_per_gas: gas_price.base_fee_per_gas,
     }
@@ -295,7 +295,11 @@ mod tests {
         let bumped_gas_price = gas_price_for_simulation(&gas_price);
         assert_eq!(
             gas_price.effective_gas_price() * SOLVER_BALANCE_MULTIPLIER,
-            bumped_gas_price.effective_gas_price()
+            bumped_gas_price.effective_gas_price(),
+        );
+        assert_eq!(
+            gas_price.max_fee_per_gas * SOLVER_BALANCE_MULTIPLIER,
+            bumped_gas_price.max_fee_per_gas,
         );
     }
 }


### PR DESCRIPTION
This PR is a follow up to #1354 

Specifically, for EIP-1559, an account needs to have sufficient ETH for `max_fee_per_gas` for the transaction to be executable. This PR changes the `gas_price_for_simulation` to be correct for EIP-1559.

This implementation is not ideal, since the `max_fee_per_gas` is now much higher than it needs to be (see https://github.com/cowprotocol/services/issues/1360 and https://github.com/cowprotocol/services/pull/1354#discussion_r1141915999).

### Test Plan

Adjusted unit test passes.
