### PR TITLE
Make Driver EIP-1559 Aware

### DIFF
--- a/crates/driver/src/boundary/settlement.rs
+++ b/crates/driver/src/boundary/settlement.rs
@@ -182,7 +182,7 @@ impl Settlement {
                 })
                 .collect(),
         )?;
-        let gas_price = u256_to_big_rational(&auction.gas_price.into());
+        let gas_price = u256_to_big_rational(&auction.gas_price.effective().into());
         let inputs = solver::objective_value::Inputs::from_settlement(
             &self.inner,
             &prices,

--- a/crates/driver/src/domain/competition/auction.rs
+++ b/crates/driver/src/domain/competition/auction.rs
@@ -21,7 +21,7 @@ pub struct Auction {
     pub id: Option<Id>,
     pub tokens: Vec<Token>,
     pub orders: Vec<competition::Order>,
-    pub gas_price: eth::EffectiveGasPrice,
+    pub gas_price: eth::GasPrice,
     pub deadline: Deadline,
 }
 

--- a/crates/driver/src/domain/eth/gas.rs
+++ b/crates/driver/src/domain/eth/gas.rs
@@ -31,13 +31,13 @@ impl From<Gas> for U256 {
 #[derive(Debug, Clone, Copy)]
 pub struct GasPrice {
     /// The maximum total fee that should be charged.
-    pub max: MaxFeePerGas,
+    pub max: FeePerGas,
     /// The maximum priority fee (i.e. the tip to the block proposer) that
     /// can be charged.
-    pub tip: MaxPriorityFeePerGas,
+    pub tip: FeePerGas,
     /// The current base gas price that will be charged to all accounts on the
     /// next block.
-    pub base: BaseFeePerGas,
+    pub base: FeePerGas,
 }
 
 impl GasPrice {
@@ -60,65 +60,28 @@ impl From<EffectiveGasPrice> for GasPrice {
     }
 }
 
-/// The `max_fee_per_gas` as defined by EIP-1559.
-///
-/// https://eips.ethereum.org/EIPS/eip-1559#specification
+/// A measurement of an of Ether to pay as fees for a single gas unit. This is
+/// `{max,max_priority,base}_fee_per_gas` as defined by EIP-1559.
 #[derive(Debug, Clone, Copy)]
-pub struct MaxFeePerGas(pub Ether);
+pub struct FeePerGas(pub Ether);
 
-impl From<U256> for MaxFeePerGas {
+impl From<U256> for FeePerGas {
     fn from(value: U256) -> Self {
         Self(value.into())
     }
 }
 
-impl From<MaxFeePerGas> for U256 {
-    fn from(value: MaxFeePerGas) -> Self {
+impl From<FeePerGas> for U256 {
+    fn from(value: FeePerGas) -> Self {
         value.0.into()
     }
 }
 
-impl ops::Mul<MaxFeePerGas> for Gas {
+impl ops::Mul<FeePerGas> for Gas {
     type Output = Ether;
 
-    fn mul(self, rhs: MaxFeePerGas) -> Self::Output {
+    fn mul(self, rhs: FeePerGas) -> Self::Output {
         (self.0 * rhs.0 .0).into()
-    }
-}
-
-/// The `max_priority_fee_per_gas` as defined by EIP-1559.
-///
-/// https://eips.ethereum.org/EIPS/eip-1559#specification
-#[derive(Debug, Clone, Copy)]
-pub struct MaxPriorityFeePerGas(pub Ether);
-
-impl From<U256> for MaxPriorityFeePerGas {
-    fn from(value: U256) -> Self {
-        Self(value.into())
-    }
-}
-
-impl From<MaxPriorityFeePerGas> for U256 {
-    fn from(value: MaxPriorityFeePerGas) -> Self {
-        value.0.into()
-    }
-}
-
-/// The `base_fee_per_gas` as defined by EIP-1559.
-///
-/// https://eips.ethereum.org/EIPS/eip-1559#specification
-#[derive(Debug, Clone, Copy)]
-pub struct BaseFeePerGas(pub Ether);
-
-impl From<U256> for BaseFeePerGas {
-    fn from(value: U256) -> Self {
-        Self(value.into())
-    }
-}
-
-impl From<BaseFeePerGas> for U256 {
-    fn from(value: BaseFeePerGas) -> Self {
-        value.0.into()
     }
 }
 

--- a/crates/driver/src/domain/eth/gas.rs
+++ b/crates/driver/src/domain/eth/gas.rs
@@ -1,0 +1,141 @@
+use {
+    super::{Ether, U256},
+    std::ops,
+};
+
+/// Gas amount.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct Gas(pub U256);
+
+impl From<U256> for Gas {
+    fn from(value: U256) -> Self {
+        Self(value)
+    }
+}
+
+impl From<u64> for Gas {
+    fn from(value: u64) -> Self {
+        Self(value.into())
+    }
+}
+
+impl From<Gas> for U256 {
+    fn from(value: Gas) -> Self {
+        value.0
+    }
+}
+
+/// An EIP-1559 gas price estimate.
+///
+/// https://eips.ethereum.org/EIPS/eip-1559#specification
+#[derive(Debug, Clone, Copy)]
+pub struct GasPrice {
+    /// The maximum total fee that should be charged.
+    pub max: MaxFeePerGas,
+    /// The maximum priority fee (i.e. the tip to the block proposer) that
+    /// can be charged.
+    pub tip: MaxPriorityFeePerGas,
+    /// The current base gas price that will be charged to all accounts on the
+    /// next block.
+    pub base: BaseFeePerGas,
+}
+
+impl GasPrice {
+    /// Returns the estimated [`EffectiveGasPrice`] for the gas price estimate.
+    pub fn effective(&self) -> EffectiveGasPrice {
+        U256::from(self.max)
+            .min(U256::from(self.base).saturating_add(self.tip.into()))
+            .into()
+    }
+}
+
+impl From<EffectiveGasPrice> for GasPrice {
+    fn from(value: EffectiveGasPrice) -> Self {
+        let value = value.0 .0;
+        Self {
+            max: value.into(),
+            tip: value.into(),
+            base: value.into(),
+        }
+    }
+}
+
+/// The `max_fee_per_gas` as defined by EIP-1559.
+///
+/// https://eips.ethereum.org/EIPS/eip-1559#specification
+#[derive(Debug, Clone, Copy)]
+pub struct MaxFeePerGas(pub Ether);
+
+impl From<U256> for MaxFeePerGas {
+    fn from(value: U256) -> Self {
+        Self(value.into())
+    }
+}
+
+impl From<MaxFeePerGas> for U256 {
+    fn from(value: MaxFeePerGas) -> Self {
+        value.0.into()
+    }
+}
+
+impl ops::Mul<MaxFeePerGas> for Gas {
+    type Output = Ether;
+
+    fn mul(self, rhs: MaxFeePerGas) -> Self::Output {
+        (self.0 * rhs.0 .0).into()
+    }
+}
+
+/// The `max_priority_fee_per_gas` as defined by EIP-1559.
+///
+/// https://eips.ethereum.org/EIPS/eip-1559#specification
+#[derive(Debug, Clone, Copy)]
+pub struct MaxPriorityFeePerGas(pub Ether);
+
+impl From<U256> for MaxPriorityFeePerGas {
+    fn from(value: U256) -> Self {
+        Self(value.into())
+    }
+}
+
+impl From<MaxPriorityFeePerGas> for U256 {
+    fn from(value: MaxPriorityFeePerGas) -> Self {
+        value.0.into()
+    }
+}
+
+/// The `base_fee_per_gas` as defined by EIP-1559.
+///
+/// https://eips.ethereum.org/EIPS/eip-1559#specification
+#[derive(Debug, Clone, Copy)]
+pub struct BaseFeePerGas(pub Ether);
+
+impl From<U256> for BaseFeePerGas {
+    fn from(value: U256) -> Self {
+        Self(value.into())
+    }
+}
+
+impl From<BaseFeePerGas> for U256 {
+    fn from(value: BaseFeePerGas) -> Self {
+        value.0.into()
+    }
+}
+
+/// The `effective_gas_price` as defined by EIP-1559.
+///
+/// https://eips.ethereum.org/EIPS/eip-1559#specification
+#[derive(Debug, Clone, Copy)]
+pub struct EffectiveGasPrice(pub Ether);
+
+impl From<U256> for EffectiveGasPrice {
+    fn from(value: U256) -> Self {
+        Self(value.into())
+    }
+}
+
+impl From<EffectiveGasPrice> for U256 {
+    fn from(value: EffectiveGasPrice) -> Self {
+        value.0.into()
+    }
+}

--- a/crates/driver/src/domain/eth/mod.rs
+++ b/crates/driver/src/domain/eth/mod.rs
@@ -11,7 +11,7 @@ pub use {
     allowance::Allowance,
     eip712::{DomainFields, DomainSeparator},
     ethcontract::PrivateKey,
-    gas::{BaseFeePerGas, EffectiveGasPrice, Gas, GasPrice, MaxFeePerGas, MaxPriorityFeePerGas},
+    gas::{EffectiveGasPrice, FeePerGas, Gas, GasPrice},
     primitive_types::{H160, H256, U256},
 };
 

--- a/crates/driver/src/domain/eth/mod.rs
+++ b/crates/driver/src/domain/eth/mod.rs
@@ -5,11 +5,13 @@ use {
 
 pub mod allowance;
 mod eip712;
+mod gas;
 
 pub use {
     allowance::Allowance,
     eip712::{DomainFields, DomainSeparator},
     ethcontract::PrivateKey,
+    gas::{BaseFeePerGas, EffectiveGasPrice, Gas, GasPrice, MaxFeePerGas, MaxPriorityFeePerGas},
     primitive_types::{H160, H256, U256},
 };
 
@@ -49,46 +51,6 @@ impl From<String> for NetworkId {
 impl std::fmt::Display for NetworkId {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.0)
-    }
-}
-
-/// Gas amount.
-#[derive(Debug, Default, Clone, Copy)]
-pub struct Gas(pub U256);
-
-impl From<U256> for Gas {
-    fn from(value: U256) -> Self {
-        Self(value)
-    }
-}
-
-impl From<u64> for Gas {
-    fn from(value: u64) -> Self {
-        Self(value.into())
-    }
-}
-
-impl From<Gas> for U256 {
-    fn from(value: Gas) -> Self {
-        value.0
-    }
-}
-
-/// `effective_gas_price` as defined by EIP-1559.
-///
-/// https://eips.ethereum.org/EIPS/eip-1559#specification
-#[derive(Debug, Clone, Copy)]
-pub struct EffectiveGasPrice(pub Ether);
-
-impl From<U256> for EffectiveGasPrice {
-    fn from(value: U256) -> Self {
-        Self(value.into())
-    }
-}
-
-impl From<EffectiveGasPrice> for U256 {
-    fn from(value: EffectiveGasPrice) -> Self {
-        value.0.into()
     }
 }
 

--- a/crates/driver/src/domain/quote.rs
+++ b/crates/driver/src/domain/quote.rs
@@ -116,7 +116,7 @@ impl Order {
                 },
                 reward: FAKE_AUCTION_REWARD,
             }],
-            gas_price: self.gas_price,
+            gas_price: self.gas_price.into(),
             deadline: Default::default(),
         }
     }

--- a/crates/driver/src/infra/solver/dto/auction.rs
+++ b/crates/driver/src/infra/solver/dto/auction.rs
@@ -114,7 +114,7 @@ impl Auction {
                 })
                 .collect(),
             tokens,
-            effective_gas_price: auction.gas_price.into(),
+            effective_gas_price: auction.gas_price.effective().into(),
             deadline: timeout.deadline(now),
         }
     }

--- a/crates/driver/src/tests/cases/limit_order/buy.rs
+++ b/crates/driver/src/tests/cases/limit_order/buy.rs
@@ -56,7 +56,6 @@ async fn test() {
         owner: admin,
         partially_fillable: false,
     };
-    let gas_price = web3.eth().gas_price().await.unwrap().to_string();
     let now = infra::time::Now::Fake(chrono::Utc::now());
     let deadline = now.now() + chrono::Duration::days(30);
     let interactions = interactions
@@ -126,7 +125,7 @@ async fn test() {
                     }
                 ],
                 "liquidity": [],
-                "effectiveGasPrice": gas_price,
+                "effectiveGasPrice": "247548525",
                 "deadline": deadline - auction::Deadline::time_buffer(),
             }),
             res: json!({
@@ -214,7 +213,7 @@ async fn test() {
     assert!(solution.get("id").is_some());
     assert!(solution.get("score").is_some());
     let score = solution.get("score").unwrap().as_f64().unwrap();
-    approx::assert_relative_eq!(score, -58130959128924.0, max_relative = 0.01);
+    approx::assert_relative_eq!(score, -59208161112450.0, max_relative = 0.01);
 
     let old_token_a = token_a.balance_of(admin).call().await.unwrap();
     let old_token_b = token_b.balance_of(admin).call().await.unwrap();

--- a/crates/driver/src/tests/cases/limit_order/sell.rs
+++ b/crates/driver/src/tests/cases/limit_order/sell.rs
@@ -56,7 +56,6 @@ async fn test() {
         owner: admin,
         partially_fillable: false,
     };
-    let gas_price = web3.eth().gas_price().await.unwrap().to_string();
     let now = infra::time::Now::Fake(chrono::Utc::now());
     let deadline = now.now() + chrono::Duration::days(30);
     let interactions = interactions
@@ -126,7 +125,7 @@ async fn test() {
                     }
                 ],
                 "liquidity": [],
-                "effectiveGasPrice": gas_price,
+                "effectiveGasPrice": "247548525",
                 "deadline": deadline - auction::Deadline::time_buffer(),
             }),
             res: json!({
@@ -214,7 +213,7 @@ async fn test() {
     assert!(solution.get("id").is_some());
     assert!(solution.get("score").is_some());
     let score = solution.get("score").unwrap().as_f64().unwrap();
-    approx::assert_relative_eq!(score, -58130959128924.0, max_relative = 0.01);
+    approx::assert_relative_eq!(score, -59208161112450.0, max_relative = 0.01);
 
     let old_token_a = token_a.balance_of(admin).call().await.unwrap();
     let old_token_b = token_b.balance_of(admin).call().await.unwrap();

--- a/crates/driver/src/tests/cases/quote.rs
+++ b/crates/driver/src/tests/cases/quote.rs
@@ -35,7 +35,7 @@ async fn test() {
     let buy_token = token_b.address();
     let sell_amount = token_a_in_amount;
     let buy_amount = token_b_out_amount;
-    let gas_price = web3.eth().gas_price().await.unwrap().to_string();
+    let gas_price = setup::blockchain::effective_gas_price(&web3).await;
     let now = infra::time::Now::Fake(chrono::Utc::now());
     let deadline = now.now() + chrono::Duration::seconds(2);
     let interactions = uniswap_interactions
@@ -90,7 +90,7 @@ async fn test() {
                     }
                 ],
                 "liquidity": [],
-                "effectiveGasPrice": gas_price,
+                "effectiveGasPrice": gas_price.to_string(),
                 "deadline": deadline - quote::Deadline::time_buffer(),
             }),
             res: json!({
@@ -134,7 +134,7 @@ async fn test() {
                 "buyToken": hex_address(buy_token),
                 "amount": sell_amount.to_string(),
                 "kind": "sell",
-                "effectiveGasPrice": gas_price,
+                "effectiveGasPrice": gas_price.to_string(),
                 "deadline": deadline,
             }),
         )

--- a/crates/driver/src/tests/cases/settle.rs
+++ b/crates/driver/src/tests/cases/settle.rs
@@ -122,7 +122,7 @@ async fn test() {
                     }
                 ],
                 "liquidity": [],
-                "effectiveGasPrice": "243044758",
+                "effectiveGasPrice": "247548525",
                 "deadline": deadline - auction::Deadline::time_buffer(),
             }),
             res: json!({

--- a/crates/driver/src/tests/cases/solve.rs
+++ b/crates/driver/src/tests/cases/solve.rs
@@ -16,7 +16,6 @@ async fn test() {
     crate::boundary::initialize_tracing("driver=trace");
     // Set up the uniswap swap.
     let setup::blockchain::Uniswap {
-        web3,
         settlement,
         token_a,
         token_b,
@@ -31,6 +30,7 @@ async fn test() {
         solver_address,
         geth,
         solver_secret_key,
+        ..
     } = setup::blockchain::uniswap::setup().await;
 
     // Values for the auction.
@@ -52,7 +52,6 @@ async fn test() {
         owner: admin,
         partially_fillable: false,
     };
-    let gas_price = web3.eth().gas_price().await.unwrap().to_string();
     let now = infra::time::Now::Fake(chrono::Utc::now());
     let deadline = now.now() + chrono::Duration::days(30);
     let interactions = interactions
@@ -122,7 +121,7 @@ async fn test() {
                     }
                 ],
                 "liquidity": [],
-                "effectiveGasPrice": gas_price,
+                "effectiveGasPrice": "247548525",
                 "deadline": deadline - auction::Deadline::time_buffer(),
             }),
             res: json!({
@@ -209,5 +208,5 @@ async fn test() {
     assert!(result.get("id").is_some());
     assert!(result.get("score").is_some());
     let score = result.get("score").unwrap().as_f64().unwrap();
-    approx::assert_relative_eq!(score, -57863609895124.0, max_relative = 0.01);
+    approx::assert_relative_eq!(score, -58935857734950.0, max_relative = 0.01);
 }

--- a/crates/driver/src/tests/cases/verify_asset_flow/limit.rs
+++ b/crates/driver/src/tests/cases/verify_asset_flow/limit.rs
@@ -62,7 +62,7 @@ async fn sell_too_low() {
         owner: admin,
         partially_fillable: false,
     };
-    let gas_price = web3.eth().gas_price().await.unwrap().to_string();
+    let gas_price = setup::blockchain::effective_gas_price(&web3).await;
     let now = infra::time::Now::Fake(chrono::Utc::now());
     let deadline = now.now() + chrono::Duration::days(30);
     let interactions = interactions
@@ -132,7 +132,7 @@ async fn sell_too_low() {
                     }
                 ],
                 "liquidity": [],
-                "effectiveGasPrice": gas_price,
+                "effectiveGasPrice": gas_price.to_string(),
                 "deadline": deadline - auction::Deadline::time_buffer(),
             }),
             res: json!({
@@ -271,7 +271,7 @@ async fn buy_too_high() {
         owner: admin,
         partially_fillable: false,
     };
-    let gas_price = web3.eth().gas_price().await.unwrap().to_string();
+    let gas_price = setup::blockchain::effective_gas_price(&web3).await;
     let now = infra::time::Now::Fake(chrono::Utc::now());
     let deadline = now.now() + chrono::Duration::days(30);
     let interactions = interactions
@@ -341,7 +341,7 @@ async fn buy_too_high() {
                     }
                 ],
                 "liquidity": [],
-                "effectiveGasPrice": gas_price,
+                "effectiveGasPrice": gas_price.to_string(),
                 "deadline": deadline - auction::Deadline::time_buffer(),
             }),
             res: json!({

--- a/crates/driver/src/tests/cases/verify_asset_flow/liquidity.rs
+++ b/crates/driver/src/tests/cases/verify_asset_flow/liquidity.rs
@@ -249,7 +249,7 @@ async fn test() {
             owner: admin,
             partially_fillable: false,
         };
-        let gas_price = web3.eth().gas_price().await.unwrap().to_string();
+        let gas_price = setup::blockchain::effective_gas_price(&web3).await;
         let now = infra::time::Now::Fake(chrono::Utc::now());
         let deadline = now.now() + chrono::Duration::days(30);
         let interactions = interactions
@@ -361,7 +361,7 @@ async fn test() {
                     },
                     "orders": orders,
                     "liquidity": [],
-                    "effectiveGasPrice": gas_price,
+                    "effectiveGasPrice": gas_price.to_string(),
                     "deadline": deadline - auction::Deadline::time_buffer(),
                 }),
                 res: json!({

--- a/crates/driver/src/tests/cases/verify_asset_flow/market.rs
+++ b/crates/driver/src/tests/cases/verify_asset_flow/market.rs
@@ -213,7 +213,7 @@ async fn test() {
             owner: admin,
             partially_fillable: false,
         };
-        let gas_price = web3.eth().gas_price().await.unwrap().to_string();
+        let gas_price = setup::blockchain::effective_gas_price(&web3).await;
         let now = infra::time::Now::Fake(chrono::Utc::now());
         let deadline = now.now() + chrono::Duration::days(30);
         let interactions = interactions
@@ -291,7 +291,7 @@ async fn test() {
                         }
                     ],
                     "liquidity": [],
-                    "effectiveGasPrice": gas_price,
+                    "effectiveGasPrice": gas_price.to_string(),
                     "deadline": deadline - auction::Deadline::time_buffer(),
                 }),
                 res: json!({

--- a/crates/driver/src/tests/cases/verify_internalization.rs
+++ b/crates/driver/src/tests/cases/verify_internalization.rs
@@ -55,7 +55,7 @@ async fn valid_internalization() {
         owner: admin,
         partially_fillable: false,
     };
-    let gas_price = web3.eth().gas_price().await.unwrap().to_string();
+    let gas_price = setup::blockchain::effective_gas_price(&web3).await;
     let now = infra::time::Now::Fake(chrono::Utc::now());
     let deadline = now.now() + chrono::Duration::days(30);
     let interactions = interactions
@@ -125,7 +125,7 @@ async fn valid_internalization() {
                     }
                 ],
                 "liquidity": [],
-                "effectiveGasPrice": gas_price,
+                "effectiveGasPrice": gas_price.to_string(),
                 "deadline": deadline - auction::Deadline::time_buffer(),
             }),
             res: json!({
@@ -256,7 +256,7 @@ async fn invalid_internalization() {
         owner: admin,
         partially_fillable: false,
     };
-    let gas_price = web3.eth().gas_price().await.unwrap().to_string();
+    let gas_price = setup::blockchain::effective_gas_price(&web3).await;
     let now = infra::time::Now::Fake(chrono::Utc::now());
     let deadline = now.now() + chrono::Duration::days(30);
     let interactions = interactions
@@ -326,7 +326,7 @@ async fn invalid_internalization() {
                     }
                 ],
                 "liquidity": [],
-                "effectiveGasPrice": gas_price,
+                "effectiveGasPrice": gas_price.to_string(),
                 "deadline": deadline - auction::Deadline::time_buffer(),
             }),
             res: json!({


### PR DESCRIPTION
Related to #1360

This PR makes the driver EIP-1559 aware internally. Previously, it would just make use of `effective_gas_price` everywhere. However, there are EIP-1559 specific requirements that require a more complete gas estimate picture.

This PR is a required step for implementing #1360 and fixing account balance checks before committing to a settlement.

### Test Plan

Unit tests continue to pass after adjusting for new gas price estimates. Note that `eth_gasPrice` RPC call is different than an EIP-1559 price estimate, which we do using the `gas_estimation::NativeGasEstimator` crate.

I also change E2E tests that assert a specific score to also assert a specific effective gas price, since the two are correlated.
