### PR TITLE
Verify Solver Account Balances

### DIFF
--- a/crates/solver/src/settlement_submission.rs
+++ b/crates/solver/src/settlement_submission.rs
@@ -39,7 +39,13 @@ use {
     web3::types::TransactionReceipt,
 };
 
-const ESTIMATE_GAS_LIMIT_FACTOR: f64 = 1.2;
+/// Computes a gas limit from a gas estimate that account for some buffer in
+/// case racing state changes result in slightly more heavy computation at
+/// execution time.
+pub fn gas_limit_for_estimate(gas_estimate: U256) -> U256 {
+    const ESTIMATE_GAS_LIMIT_FACTOR: f64 = 1.2;
+    U256::from_f64_lossy(gas_estimate.to_f64_lossy() * ESTIMATE_GAS_LIMIT_FACTOR)
+}
 
 #[derive(Debug)]
 pub struct SubTxPool {

--- a/crates/solver/src/settlement_submission.rs
+++ b/crates/solver/src/settlement_submission.rs
@@ -39,7 +39,7 @@ use {
     web3::types::TransactionReceipt,
 };
 
-/// Computes a gas limit from a gas estimate that account for some buffer in
+/// Computes a gas limit from a gas estimate that accounts for some buffer in
 /// case racing state changes result in slightly more heavy computation at
 /// execution time.
 pub fn gas_limit_for_estimate(gas_estimate: U256) -> U256 {

--- a/crates/solver/src/settlement_submission/submitter.rs
+++ b/crates/solver/src/settlement_submission/submitter.rs
@@ -21,11 +21,12 @@ pub mod flashbots_api;
 pub mod public_mempool_api;
 
 use {
-    super::{SubTxPoolRef, SubmissionError, ESTIMATE_GAS_LIMIT_FACTOR},
+    super::{SubTxPoolRef, SubmissionError},
     crate::{
         settlement::Settlement,
         settlement_access_list::{estimate_settlement_access_list, AccessListEstimating},
         settlement_simulation::settle_method_builder,
+        settlement_submission::gas_limit_for_estimate,
     },
     anyhow::{anyhow, ensure, Context, Result},
     contracts::GPv2Settlement,
@@ -410,9 +411,7 @@ impl<'a> Submitter<'a> {
                     self.gas_price_estimator.clone()
                 }
             };
-            // Account for some buffer in the gas limit in case racing state changes result
-            // in slightly more heavy computation at execution time.
-            let gas_limit = params.gas_estimate.to_f64_lossy() * ESTIMATE_GAS_LIMIT_FACTOR;
+            let gas_limit = gas_limit_for_estimate(params.gas_estimate).to_f64_lossy();
             let time_limit = target_confirm_time.saturating_duration_since(Instant::now());
             let gas_price = match estimator.estimate_with_limits(gas_limit, time_limit).await {
                 Ok(gas_price) => gas_price,

--- a/crates/solver/src/settlement_submission/submitter.rs
+++ b/crates/solver/src/settlement_submission/submitter.rs
@@ -173,7 +173,7 @@ impl GasPriceEstimating for SubmitterGasPriceEstimator<'_> {
             .min(estimate.max_fee_per_gas);
         estimate = estimate.ceil();
 
-        ensure!(estimate.is_valid(), "invalid gas estimate {estimate:?}");
+        ensure!(estimate.is_valid(), "gas estimate exceeds cap {estimate:?}");
         Ok(estimate)
     }
 }

--- a/crates/solver/src/solver.rs
+++ b/crates/solver/src/solver.rs
@@ -183,7 +183,15 @@ pub struct Simulation {
 
 pub struct SimulationWithError {
     pub simulation: Simulation,
-    pub error: ExecutionError,
+    pub error: SimulationError,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum SimulationError {
+    #[error("web3 error: {0:?}")]
+    Web3(#[from] ExecutionError),
+    #[error("insufficient balance: needs {needs} has {has}")]
+    InsufficientBalance { needs: U256, has: U256 },
 }
 
 #[derive(Copy, Clone, Debug, Eq, Hash, PartialEq, clap::ValueEnum)]


### PR DESCRIPTION
Together with #1363 this supersedes #1361.

#1363 introduced a change where we compute the absolute maximum `max_fee_per_gas` we are willing to pay per solver run. With that change, we can now, deterministically, decide upfront if a solver account has sufficient Ether to submit a settlement accounting for gas spikes.

Historically, we relied on `eth_estimateGas` RPC call failing when a solver had insufficient funds, however, this behavior is node-dependent and cannot be relied on (See https://github.com/cowprotocol/services/pull/1361#issuecomment-1477951819 for more details).

In this PR we change the settlement raking to additional query solver balances and ensure that the settlement can be executed even if the `max_fee_per_gas` is charged.

The equivalent fix in the co-located driver was implemented in #1365.

### Test Plan

Unfortunately, unit testing this code is very hard 😞. However, the actual happy path will get exercised in end-to-end tests. Please carefully review the math here.
