### PR TITLE
Reorganize dex solver config loading

### DIFF
--- a/crates/solvers/src/infra/config/balancer/mod.rs
+++ b/crates/solvers/src/infra/config/balancer/mod.rs
@@ -1,8 +1,0 @@
-use crate::{domain::dex::slippage, infra::dex};
-
-pub mod file;
-
-pub struct Config {
-    pub sor: dex::balancer::Config,
-    pub slippage: slippage::Limits,
-}

--- a/crates/solvers/src/infra/config/dex/balancer/file.rs
+++ b/crates/solvers/src/infra/config/dex/balancer/file.rs
@@ -1,0 +1,54 @@
+use {
+    crate::{
+        domain::eth,
+        infra::{config::dex::file, contracts, dex},
+    },
+    ethereum_types::H160,
+    serde::Deserialize,
+    serde_with::serde_as,
+    std::path::Path,
+};
+
+#[serde_as]
+#[derive(Deserialize)]
+#[serde(rename_all = "kebab-case", deny_unknown_fields)]
+struct Config {
+    /// The URL of the Balancer SOR API.
+    #[serde_as(as = "serde_with::DisplayFromStr")]
+    endpoint: reqwest::Url,
+
+    /// Optional Balancer V2 Vault contract address. If not specified, the
+    /// default Vault contract address will be used.
+    vault: Option<H160>,
+
+    /// Optional CoW Protocol Settlement contract address. If not specified,
+    /// the default Settlement contract address will be used.
+    settlement: Option<H160>,
+}
+
+/// Load the driver configuration from a TOML file.
+///
+/// # Panics
+///
+/// This method panics if the config is invalid or on I/O errors.
+pub async fn load(path: &Path) -> super::Config {
+    let config: Config = file::parse(path).await;
+
+    // Balancer SOR solver only supports mainnet.
+    let contracts = contracts::Contracts::for_chain(eth::ChainId::Mainnet);
+
+    super::Config {
+        sor: dex::balancer::Config {
+            endpoint: config.endpoint,
+            vault: config
+                .vault
+                .map(eth::ContractAddress)
+                .unwrap_or(contracts.balancer_vault),
+            settlement: config
+                .settlement
+                .map(eth::ContractAddress)
+                .unwrap_or(contracts.settlement),
+        },
+        base: file::load_base_config(path).await,
+    }
+}

--- a/crates/solvers/src/infra/config/dex/balancer/file.rs
+++ b/crates/solvers/src/infra/config/dex/balancer/file.rs
@@ -11,7 +11,7 @@ use {
 
 #[serde_as]
 #[derive(Deserialize)]
-#[serde(rename_all = "kebab-case")]
+#[serde(rename_all = "kebab-case", deny_unknown_fields)]
 struct Config {
     /// The URL of the Balancer SOR API.
     #[serde_as(as = "serde_with::DisplayFromStr")]
@@ -32,7 +32,7 @@ struct Config {
 ///
 /// This method panics if the config is invalid or on I/O errors.
 pub async fn load(path: &Path) -> super::Config {
-    let config: Config = file::parse(path).await;
+    let (base, config) = file::load::<Config>(path).await;
 
     // Balancer SOR solver only supports mainnet.
     let contracts = contracts::Contracts::for_chain(eth::ChainId::Mainnet);
@@ -49,6 +49,6 @@ pub async fn load(path: &Path) -> super::Config {
                 .map(eth::ContractAddress)
                 .unwrap_or(contracts.settlement),
         },
-        base: file::load_base_config(path).await,
+        base,
     }
 }

--- a/crates/solvers/src/infra/config/dex/balancer/file.rs
+++ b/crates/solvers/src/infra/config/dex/balancer/file.rs
@@ -11,7 +11,7 @@ use {
 
 #[serde_as]
 #[derive(Deserialize)]
-#[serde(rename_all = "kebab-case", deny_unknown_fields)]
+#[serde(rename_all = "kebab-case")]
 struct Config {
     /// The URL of the Balancer SOR API.
     #[serde_as(as = "serde_with::DisplayFromStr")]

--- a/crates/solvers/src/infra/config/dex/balancer/mod.rs
+++ b/crates/solvers/src/infra/config/dex/balancer/mod.rs
@@ -1,0 +1,6 @@
+pub mod file;
+
+pub struct Config {
+    pub sor: crate::infra::dex::balancer::Config,
+    pub base: super::BaseConfig,
+}

--- a/crates/solvers/src/infra/config/dex/balancer/mod.rs
+++ b/crates/solvers/src/infra/config/dex/balancer/mod.rs
@@ -2,5 +2,5 @@ pub mod file;
 
 pub struct Config {
     pub sor: crate::infra::dex::balancer::Config,
-    pub base: super::BaseConfig,
+    pub base: super::Config,
 }

--- a/crates/solvers/src/infra/config/dex/file.rs
+++ b/crates/solvers/src/infra/config/dex/file.rs
@@ -51,7 +51,7 @@ fn default_smallest_partial_fill() -> eth::U256 {
     eth::U256::exp10(16) // 0.01 ETH
 }
 
-/// Load the base solver configuration from a TOML file.
+/// Deserializes the given TOML file to a `T`.
 ///
 /// # Panics
 ///
@@ -65,6 +65,11 @@ pub async fn parse<T: DeserializeOwned>(path: &Path) -> T {
         .unwrap_or_else(|_| panic!("TOML syntax error while reading {path:?}"))
 }
 
+/// Loads the base solver configuration from a TOML file.
+///
+/// # Panics
+///
+/// This method panics if the config is invalid or on I/O errors.
 pub async fn load_base_config(path: &Path) -> super::BaseConfig {
     let config: Config = parse(path).await;
 

--- a/crates/solvers/src/infra/config/dex/file.rs
+++ b/crates/solvers/src/infra/config/dex/file.rs
@@ -42,27 +42,18 @@ fn default_smallest_partial_fill() -> eth::U256 {
     eth::U256::exp10(16) // 0.01 ETH
 }
 
-/// Deserializes the given TOML file to a `T`.
-///
-/// # Panics
-///
-/// This method panics if the config is invalid or on I/O errors.
-async fn parse<T: DeserializeOwned>(path: &Path) -> T {
-    let data = fs::read_to_string(path)
-        .await
-        .unwrap_or_else(|e| panic!("I/O error while reading {path:?}: {e:?}"));
-
-    toml::de::from_str::<T>(&data)
-        .unwrap_or_else(|_| panic!("TOML syntax error while reading {path:?}"))
-}
-
 /// Loads the base solver configuration from a TOML file.
 ///
 /// # Panics
 ///
 /// This method panics if the config is invalid or on I/O errors.
 pub async fn load<T: DeserializeOwned>(path: &Path) -> (super::Config, T) {
-    let config: Config = parse(path).await;
+    let data = fs::read_to_string(path)
+        .await
+        .unwrap_or_else(|e| panic!("I/O error while reading {path:?}: {e:?}"));
+
+    let config = toml::de::from_str::<Config>(&data)
+        .unwrap_or_else(|_| panic!("TOML syntax error while reading {path:?}"));
 
     let dex: T = config
         .dex

--- a/crates/solvers/src/infra/config/dex/file.rs
+++ b/crates/solvers/src/infra/config/dex/file.rs
@@ -16,7 +16,7 @@ use {
 
 #[serde_as]
 #[derive(Deserialize)]
-#[serde(rename_all = "kebab-case", deny_unknown_fields)]
+#[serde(rename_all = "kebab-case")]
 struct Config {
     /// The relative slippage allowed by the solver.
     #[serde(default = "default_relative_slippage")]

--- a/crates/solvers/src/infra/config/dex/file.rs
+++ b/crates/solvers/src/infra/config/dex/file.rs
@@ -3,11 +3,9 @@
 use {
     crate::{
         domain::{dex::slippage, eth},
-        infra::contracts,
         util::conv,
     },
     bigdecimal::BigDecimal,
-    ethereum_types::H160,
     serde::{de::DeserializeOwned, Deserialize},
     serde_with::serde_as,
     std::path::Path,
@@ -31,16 +29,6 @@ struct Config {
     /// least.
     #[serde(default = "default_smallest_partial_fill")]
     smallest_partial_fill: eth::U256,
-}
-
-fn default_endpoint() -> reqwest::Url {
-    "https://api.0x.org/swap/v1/".parse().unwrap()
-}
-
-fn default_affiliate() -> H160 {
-    contracts::Contracts::for_chain(eth::ChainId::Mainnet)
-        .settlement
-        .0
 }
 
 fn default_relative_slippage() -> BigDecimal {

--- a/crates/solvers/src/infra/config/dex/file.rs
+++ b/crates/solvers/src/infra/config/dex/file.rs
@@ -1,12 +1,14 @@
+//! Configuration parameters that get shared across all dex solvers.
+
 use {
     crate::{
         domain::{dex::slippage, eth},
-        infra::{contracts, dex},
+        infra::contracts,
         util::conv,
     },
     bigdecimal::BigDecimal,
     ethereum_types::H160,
-    serde::Deserialize,
+    serde::{de::DeserializeOwned, Deserialize},
     serde_with::serde_as,
     std::path::Path,
     tokio::fs,
@@ -16,18 +18,6 @@ use {
 #[derive(Deserialize)]
 #[serde(rename_all = "kebab-case", deny_unknown_fields)]
 struct Config {
-    /// The URL of the Balancer SOR API.
-    #[serde_as(as = "serde_with::DisplayFromStr")]
-    endpoint: reqwest::Url,
-
-    /// Optional Balancer V2 Vault contract address. If not specified, the
-    /// default Vault contract address will be used.
-    vault: Option<H160>,
-
-    /// Optional CoW Protocol Settlement contract address. If not specified,
-    /// the default Settlement contract address will be used.
-    settlement: Option<H160>,
-
     /// The relative slippage allowed by the solver.
     #[serde(default = "default_relative_slippage")]
     #[serde_as(as = "serde_with::DisplayFromStr")]
@@ -36,39 +26,49 @@ struct Config {
     /// The absolute slippage allowed by the solver.
     #[serde_as(as = "Option<serde_with::DisplayFromStr>")]
     absolute_slippage: Option<BigDecimal>,
+
+    /// The amount of eth a partially fillable order should be filled for at
+    /// least.
+    #[serde(default = "default_smallest_partial_fill")]
+    smallest_partial_fill: eth::U256,
+}
+
+fn default_endpoint() -> reqwest::Url {
+    "https://api.0x.org/swap/v1/".parse().unwrap()
+}
+
+fn default_affiliate() -> H160 {
+    contracts::Contracts::for_chain(eth::ChainId::Mainnet)
+        .settlement
+        .0
 }
 
 fn default_relative_slippage() -> BigDecimal {
     BigDecimal::new(1.into(), 2) // 1%
 }
 
-/// Load the driver configuration from a TOML file.
+fn default_smallest_partial_fill() -> eth::U256 {
+    eth::U256::exp10(16) // 0.01 ETH
+}
+
+/// Load the base solver configuration from a TOML file.
 ///
 /// # Panics
 ///
 /// This method panics if the config is invalid or on I/O errors.
-pub async fn load(path: &Path) -> super::Config {
+pub async fn parse<T: DeserializeOwned>(path: &Path) -> T {
     let data = fs::read_to_string(path)
         .await
         .unwrap_or_else(|e| panic!("I/O error while reading {path:?}: {e:?}"));
-    let config = toml::de::from_str::<Config>(&data)
-        .unwrap_or_else(|_| panic!("TOML syntax error while reading {path:?}"));
 
-    // Balancer SOR solver only supports mainnet.
-    let contracts = contracts::Contracts::for_chain(eth::ChainId::Mainnet);
+    toml::de::from_str::<T>(&data)
+        .unwrap_or_else(|_| panic!("TOML syntax error while reading {path:?}"))
+}
 
-    super::Config {
-        sor: dex::balancer::Config {
-            endpoint: config.endpoint,
-            vault: config
-                .vault
-                .map(eth::ContractAddress)
-                .unwrap_or(contracts.balancer_vault),
-            settlement: config
-                .settlement
-                .map(eth::ContractAddress)
-                .unwrap_or(contracts.settlement),
-        },
+pub async fn load_base_config(path: &Path) -> super::BaseConfig {
+    let config: Config = parse(path).await;
+
+    super::BaseConfig {
         slippage: slippage::Limits::new(
             config.relative_slippage,
             config.absolute_slippage.map(|value| {
@@ -76,5 +76,6 @@ pub async fn load(path: &Path) -> super::Config {
             }),
         )
         .expect("invalid slippage limits"),
+        smallest_partial_fill: eth::Ether(config.smallest_partial_fill),
     }
 }

--- a/crates/solvers/src/infra/config/dex/mod.rs
+++ b/crates/solvers/src/infra/config/dex/mod.rs
@@ -4,7 +4,7 @@ pub mod zeroex;
 
 use crate::domain::{dex::slippage, eth};
 
-pub struct BaseConfig {
+pub struct Config {
     pub slippage: slippage::Limits,
     pub smallest_partial_fill: eth::Ether,
 }

--- a/crates/solvers/src/infra/config/dex/mod.rs
+++ b/crates/solvers/src/infra/config/dex/mod.rs
@@ -1,0 +1,10 @@
+pub mod balancer;
+mod file;
+pub mod zeroex;
+
+use crate::domain::{dex::slippage, eth};
+
+pub struct BaseConfig {
+    pub slippage: slippage::Limits,
+    pub smallest_partial_fill: eth::Ether,
+}

--- a/crates/solvers/src/infra/config/dex/zeroex/file.rs
+++ b/crates/solvers/src/infra/config/dex/zeroex/file.rs
@@ -11,7 +11,7 @@ use {
 
 #[serde_as]
 #[derive(Deserialize)]
-#[serde(rename_all = "kebab-case")]
+#[serde(rename_all = "kebab-case", deny_unknown_fields)]
 struct Config {
     /// The versioned URL endpoint for the 0x swap API.
     #[serde(default = "default_endpoint")]
@@ -56,7 +56,7 @@ fn default_affiliate() -> H160 {
 ///
 /// This method panics if the config is invalid or on I/O errors.
 pub async fn load(path: &Path) -> super::Config {
-    let config = file::parse::<Config>(path).await;
+    let (base, config) = file::load::<Config>(path).await;
 
     super::Config {
         zeroex: zeroex::Config {
@@ -66,6 +66,6 @@ pub async fn load(path: &Path) -> super::Config {
             affiliate: config.affiliate,
             enable_slippage_protection: config.enable_slippage_protection,
         },
-        base: file::load_base_config(path).await,
+        base,
     }
 }

--- a/crates/solvers/src/infra/config/dex/zeroex/file.rs
+++ b/crates/solvers/src/infra/config/dex/zeroex/file.rs
@@ -11,7 +11,7 @@ use {
 
 #[serde_as]
 #[derive(Deserialize)]
-#[serde(rename_all = "kebab-case", deny_unknown_fields)]
+#[serde(rename_all = "kebab-case")]
 struct Config {
     /// The versioned URL endpoint for the 0x swap API.
     #[serde(default = "default_endpoint")]

--- a/crates/solvers/src/infra/config/dex/zeroex/file.rs
+++ b/crates/solvers/src/infra/config/dex/zeroex/file.rs
@@ -1,15 +1,12 @@
 use {
     crate::{
-        domain::{dex::slippage, eth},
-        infra::{contracts, dex::zeroex},
-        util::conv,
+        domain::eth,
+        infra::{config::dex::file, contracts, dex::zeroex},
     },
-    bigdecimal::BigDecimal,
     ethereum_types::H160,
     serde::Deserialize,
     serde_with::serde_as,
     std::path::Path,
-    tokio::fs,
 };
 
 #[serde_as]
@@ -41,15 +38,6 @@ struct Config {
     /// would get with on-chain liquidity pools.
     #[serde(default)]
     enable_slippage_protection: bool,
-
-    /// The relative slippage allowed by the solver.
-    #[serde(default = "default_relative_slippage")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
-    relative_slippage: BigDecimal,
-
-    /// The absolute slippage allowed by the solver.
-    #[serde_as(as = "Option<serde_with::DisplayFromStr>")]
-    absolute_slippage: Option<BigDecimal>,
 }
 
 fn default_endpoint() -> reqwest::Url {
@@ -62,21 +50,13 @@ fn default_affiliate() -> H160 {
         .0
 }
 
-fn default_relative_slippage() -> BigDecimal {
-    BigDecimal::new(1.into(), 2) // 1%
-}
-
 /// Load the 0x solver configuration from a TOML file.
 ///
 /// # Panics
 ///
 /// This method panics if the config is invalid or on I/O errors.
 pub async fn load(path: &Path) -> super::Config {
-    let data = fs::read_to_string(path)
-        .await
-        .unwrap_or_else(|e| panic!("I/O error while reading {path:?}: {e:?}"));
-    let config = toml::de::from_str::<Config>(&data)
-        .unwrap_or_else(|_| panic!("TOML syntax error while reading {path:?}"));
+    let config = file::parse::<Config>(path).await;
 
     super::Config {
         zeroex: zeroex::Config {
@@ -86,12 +66,6 @@ pub async fn load(path: &Path) -> super::Config {
             affiliate: config.affiliate,
             enable_slippage_protection: config.enable_slippage_protection,
         },
-        slippage: slippage::Limits::new(
-            config.relative_slippage,
-            config.absolute_slippage.map(|value| {
-                conv::decimal_to_ether(&value).expect("invalid absolute slippage Ether value")
-            }),
-        )
-        .expect("invalid slippage limits"),
+        base: file::load_base_config(path).await,
     }
 }

--- a/crates/solvers/src/infra/config/dex/zeroex/mod.rs
+++ b/crates/solvers/src/infra/config/dex/zeroex/mod.rs
@@ -2,5 +2,5 @@ pub mod file;
 
 pub struct Config {
     pub zeroex: crate::infra::dex::zeroex::Config,
-    pub base: super::BaseConfig,
+    pub base: super::Config,
 }

--- a/crates/solvers/src/infra/config/dex/zeroex/mod.rs
+++ b/crates/solvers/src/infra/config/dex/zeroex/mod.rs
@@ -1,0 +1,6 @@
+pub mod file;
+
+pub struct Config {
+    pub zeroex: crate::infra::dex::zeroex::Config,
+    pub base: super::BaseConfig,
+}

--- a/crates/solvers/src/infra/config/mod.rs
+++ b/crates/solvers/src/infra/config/mod.rs
@@ -1,4 +1,5 @@
-pub mod balancer;
 pub mod baseline;
+mod dex;
 pub mod legacy;
-pub mod zeroex;
+
+pub use dex::{balancer, zeroex};

--- a/crates/solvers/src/infra/config/zeroex/mod.rs
+++ b/crates/solvers/src/infra/config/zeroex/mod.rs
@@ -1,8 +1,0 @@
-use crate::{domain::dex::slippage, infra::dex};
-
-pub mod file;
-
-pub struct Config {
-    pub zeroex: dex::zeroex::Config,
-    pub slippage: slippage::Limits,
-}

--- a/crates/solvers/src/run.rs
+++ b/crates/solvers/src/run.rs
@@ -38,14 +38,14 @@ pub async fn run(
                 dex: dex::Dex::ZeroEx(
                     dex::zeroex::ZeroEx::new(config.zeroex).expect("invalid 0x configuration"),
                 ),
-                slippage: config.slippage,
+                slippage: config.base.slippage,
             })
         }
         cli::Command::Balancer { config } => {
             let config = config::balancer::file::load(&config).await;
             Solver::Dex(solver::Dex {
                 dex: dex::Dex::Balancer(dex::balancer::Sor::new(config.sor)),
-                slippage: config.slippage,
+                slippage: config.base.slippage,
             })
         }
     };

--- a/crates/solvers/src/tests/balancer/mod.rs
+++ b/crates/solvers/src/tests/balancer/mod.rs
@@ -8,6 +8,7 @@ mod out_of_price;
 pub fn config(solver_addr: &SocketAddr) -> tests::Config {
     tests::Config::String(format!(
         r"
+[dex]
 endpoint = 'http://{solver_addr}/sor'
         ",
     ))

--- a/crates/solvers/src/tests/zeroex/mod.rs
+++ b/crates/solvers/src/tests/zeroex/mod.rs
@@ -9,6 +9,7 @@ mod out_of_price;
 pub fn config(solver_addr: &SocketAddr) -> tests::Config {
     tests::Config::String(format!(
         r"
+[dex]
 endpoint = 'http://{solver_addr}/swap/v1/'
         ",
     ))

--- a/crates/solvers/src/tests/zeroex/options.rs
+++ b/crates/solvers/src/tests/zeroex/options.rs
@@ -181,12 +181,13 @@ async fn test() {
         "zeroex",
         tests::Config::String(format!(
             "
+relative-slippage = '0.1'
+[dex]
 endpoint = 'http://{api}/swap/v1/'
 api-key = 'abc123'
 excluded-sources = ['Uniswap_V2', 'Balancer_V2']
 affiliate = '0x0123456789012345678901234567890123456789'
 enable-slippage-protection = true
-relative-slippage = '0.1'
             "
         )),
     )


### PR DESCRIPTION
Reorganized the directory structure responsible for loading configs for dex solvers to be more in line with the file structure of their logic.
This makes it so that config loading and the solver implementation are composed of 2 parts.
1. logic that is shared across all dex solvers
2. logic that only relates to each solver's dex API

Also adds a new argument which controls how we handle partially fillable orders required for [this](https://github.com/cowprotocol/services/pull/1358#issuecomment-1479201711).

### Test Plan
CI
