### PR TITLE
Don't Error on Partially Fillable Limit Order Missing Surplus Fee

### DIFF
--- a/crates/solver/src/liquidity/order_converter.rs
+++ b/crates/solver/src/liquidity/order_converter.rs
@@ -38,7 +38,7 @@ impl OrderConverter {
         let solver_fee = remaining.remaining(order.metadata.solver_fee)?;
 
         let sell_amount = match &order.metadata.class {
-            OrderClass::Limit(limit) => {
+            OrderClass::Limit(limit) if !order.data.partially_fillable => {
                 compute_synthetic_order_amounts_for_limit_order(&order, limit)?
             }
             _ => order.data.sell_amount,


### PR DESCRIPTION
This PR changes the order converter to not require surplus fees for partially fillable limit orders.

### Test Plan

Alerts will go away in barn.
