### PR TITLE
Crash on Failed UniV3 Initialization

### DIFF
--- a/crates/autopilot/src/lib.rs
+++ b/crates/autopilot/src/lib.rs
@@ -326,24 +326,17 @@ pub async fn main(args: arguments::Arguments) {
         None
     };
     let uniswap_v3_pool_fetcher = if baseline_sources.contains(&BaselineSource::UniswapV3) {
-        match UniswapV3PoolFetcher::new(
-            chain_id,
-            web3.clone(),
-            http_factory.create(),
-            block_retriever,
-            args.shared.max_pools_to_initialize_cache,
-        )
-        .await
-        {
-            Ok(uniswap_v3_pool_fetcher) => Some(Arc::new(uniswap_v3_pool_fetcher)),
-            Err(err) => {
-                tracing::error!(
-                    "failed to create UniswapV3 pool fetcher in autopilot: {}",
-                    err,
-                );
-                None
-            }
-        }
+        Some(Arc::new(
+            UniswapV3PoolFetcher::new(
+                chain_id,
+                web3.clone(),
+                http_factory.create(),
+                block_retriever,
+                args.shared.max_pools_to_initialize_cache,
+            )
+            .await
+            .expect("error innitializing Uniswap V3 pool fetcher"),
+        ))
     } else {
         None
     };

--- a/crates/orderbook/src/run.rs
+++ b/crates/orderbook/src/run.rs
@@ -284,24 +284,17 @@ pub async fn run(args: Arguments) {
         None
     };
     let uniswap_v3_pool_fetcher = if baseline_sources.contains(&BaselineSource::UniswapV3) {
-        match UniswapV3PoolFetcher::new(
-            chain_id,
-            web3.clone(),
-            http_factory.create(),
-            block_retriver,
-            args.shared.max_pools_to_initialize_cache,
-        )
-        .await
-        {
-            Ok(uniswap_v3_pool_fetcher) => Some(Arc::new(uniswap_v3_pool_fetcher)),
-            Err(err) => {
-                tracing::error!(
-                    "failed to create UniswapV3 pool fetcher in orderbook: {}",
-                    err,
-                );
-                None
-            }
-        }
+        Some(Arc::new(
+            UniswapV3PoolFetcher::new(
+                chain_id,
+                web3.clone(),
+                http_factory.create(),
+                block_retriver,
+                args.shared.max_pools_to_initialize_cache,
+            )
+            .await
+            .expect("error innitializing Uniswap V3 pool fetcher"),
+        ))
     } else {
         None
     };


### PR DESCRIPTION
Fixes #1336.

@sunce86 discovered that, when Uniswap V3 fails to initialize, we will have an alert but just continue running the services with Uniswap V3 liquidity (despite it being configured).

This PR changes the initialization logic to crash on such event. This makes it:
1. A much louder error, less likely to go unnoticed. If pods start crash-looping, then UniV3 liquidity can always be disabled, making resolving this issue also more explicit (i.e. the on-call will know if we are running without UniV3).
2. More in line with the configuration, so if you configure Uniswap V3 liquidity, you will have Uniswap V3 liquidity


### Test Plan

CI
