### PR TITLE
Enable Rate Limiter Configuration for Blockscout

### DIFF
--- a/crates/shared/src/bad_token/token_owner_finder.rs
+++ b/crates/shared/src/bad_token/token_owner_finder.rs
@@ -225,10 +225,14 @@ pub async fn init(
     }
 
     if finders.contains(&TokenOwnerFindingStrategy::Blockscout) {
-        proposers.push(Arc::new(BlockscoutTokenOwnerFinder::try_with_network(
+        let mut blockscout = BlockscoutTokenOwnerFinder::try_with_network(
             http_factory.configure(|builder| builder.timeout(args.blockscout_http_timeout)),
             chain_id,
-        )?));
+        )?;
+        if let Some(strategy) = args.token_owner_finder_rate_limiter.clone() {
+            blockscout.with_rate_limiter(strategy);
+        }
+        proposers.push(Arc::new(blockscout));
     }
 
     if finders.contains(&TokenOwnerFindingStrategy::Ethplorer) {


### PR DESCRIPTION
Fixes #1335.

This PR adds rate limiting support to the Blockscout API. We reuse the rate limiting strategy arguments that are shared for all token owner finders. If we find that we require more specialization, then we should split the arguments into separate pieces.

### Test Plan

Compiler.

### Release notes

We can re-enable the Blockscout token owner finder API once this PR lands.
