### PR TITLE
Fix Settlement Merging for EthFlow Orders

### DIFF
--- a/crates/solver/src/settlement/settlement_encoder.rs
+++ b/crates/solver/src/settlement/settlement_encoder.rs
@@ -1128,6 +1128,50 @@ pub mod tests {
     }
 
     #[test]
+    fn merge_preserves_pre_interactions() {
+        let mut encoder0 = SettlementEncoder::new(Default::default());
+        encoder0.pre_interactions.push(InteractionData {
+            target: H160([1; 20]),
+            value: U256::zero(),
+            call_data: vec![0xa],
+        });
+
+        let mut encoder1 = SettlementEncoder::new(Default::default());
+        encoder1.pre_interactions.push(InteractionData {
+            target: H160([1; 20]),
+            value: U256::zero(),
+            call_data: vec![0xa],
+        });
+        encoder1.pre_interactions.push(InteractionData {
+            target: H160([2; 20]),
+            value: U256::one(),
+            call_data: vec![0xb],
+        });
+
+        let merged = encoder0.merge(encoder1).unwrap();
+        assert_eq!(
+            merged.pre_interactions,
+            vec![
+                InteractionData {
+                    target: H160([1; 20]),
+                    value: U256::zero(),
+                    call_data: vec![0xa],
+                },
+                InteractionData {
+                    target: H160([1; 20]),
+                    value: U256::zero(),
+                    call_data: vec![0xa],
+                },
+                InteractionData {
+                    target: H160([2; 20]),
+                    value: U256::one(),
+                    call_data: vec![0xb],
+                },
+            ]
+        );
+    }
+
+    #[test]
     fn merge_fails_because_price_is_different() {
         let prices = hashmap! { token(1) => 1.into(), token(2) => 2.into() };
         let encoder0 = SettlementEncoder::new(prices);

--- a/crates/solver/src/settlement/settlement_encoder.rs
+++ b/crates/solver/src/settlement/settlement_encoder.rs
@@ -649,6 +649,7 @@ impl SettlementEncoder {
         self.sort_tokens_and_update_indices();
 
         self.execution_plan.append(&mut other.execution_plan);
+        self.pre_interactions.append(&mut other.pre_interactions);
 
         for unwrap in other.unwraps {
             self.add_unwrap(unwrap);


### PR DESCRIPTION
This PR fixes a bug in settlement merging where pre-interactions were being dropped. This caused an issue with EthFlow orders specifically, as merged settlements would fail because the EthFlow contract did not have enough WETH for the transfer in.

### Test Plan

Added a unit test.
