### PR TITLE
Add Solver Fee Fields to DTOs

### DIFF
--- a/crates/driver/src/infra/solver/dto/solution.rs
+++ b/crates/driver/src/infra/solver/dto/solution.rs
@@ -25,6 +25,7 @@ impl Solution {
                 .into_iter()
                 .map(|trade| match trade {
                     Trade::Fulfillment(fulfillment) => {
+                        let _ = fulfillment.fee;
                         Ok(competition::solution::Trade::Fulfillment(
                             competition::solution::trade::Fulfillment {
                                 order: auction
@@ -209,6 +210,8 @@ struct Fulfillment {
     order: [u8; 56],
     #[serde_as(as = "serialize::U256")]
     executed_amount: eth::U256,
+    #[serde_as(as = "Option<serialize::U256>")]
+    fee: Option<eth::U256>,
 }
 
 #[serde_as]

--- a/crates/shared/src/http_solver/model.rs
+++ b/crates/shared/src/http_solver/model.rs
@@ -256,12 +256,15 @@ pub struct SettledBatchAuctionMetadataModel {
     pub result: Option<String>,
 }
 
+#[serde_as]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct ExecutedOrderModel {
-    #[serde(with = "u256_decimal")]
+    #[serde_as(as = "DecimalU256")]
     pub exec_sell_amount: U256,
-    #[serde(with = "u256_decimal")]
+    #[serde_as(as = "DecimalU256")]
     pub exec_buy_amount: U256,
+    #[serde_as(as = "Option<DecimalU256>")]
+    pub exec_fee_amount: Option<U256>,
     pub cost: Option<TokenAmount>,
     pub fee: Option<TokenAmount>,
     // Orders which need to be executed in a specific order have an `exec_plan` (e.g. 0x limit

--- a/crates/shared/src/price_estimation/http.rs
+++ b/crates/shared/src/price_estimation/http.rs
@@ -463,6 +463,7 @@ mod tests {
                     0 => ExecutedOrderModel {
                         exec_sell_amount: 50.into(),
                         exec_buy_amount: 200.into(),
+                        exec_fee_amount: None,
                         cost: None,
                         fee: None,
                         exec_plan: None,
@@ -613,6 +614,7 @@ mod tests {
                     0 => ExecutedOrderModel {
                         exec_sell_amount: 100.into(),
                         exec_buy_amount: 100.into(),
+                        exec_fee_amount: None,
                         cost: Some(TokenAmount {
                             amount: 100_000.into(),
                             token: native_token

--- a/crates/solver/src/solver/http_solver/settlement.rs
+++ b/crates/solver/src/solver/http_solver/settlement.rs
@@ -553,6 +553,7 @@ mod tests {
         let executed_order = ExecutedOrderModel {
             exec_buy_amount: 6.into(),
             exec_sell_amount: 7.into(),
+            exec_fee_amount: None,
             cost: Default::default(),
             fee: Default::default(),
             exec_plan: None,

--- a/crates/solvers/openapi.yml
+++ b/crates/solvers/openapi.yml
@@ -568,6 +568,8 @@ components:
             - $ref: "#/components/schemas/Fulfillment"
             - $ref: "#/components/schemas/JitTrade"
         - type: object
+          required:
+            - executedAmount
           properties:
             executedAmount:
               description: |
@@ -575,6 +577,11 @@ components:
                 "sellToken" for sell orders, and "buyToken" for buy orders.
               allOf:
                 - $ref: "#/components/schemas/TokenAmount"
+            fee:
+              description: |
+                The sell token amount that should be taken as a fee for this
+                trade. This only gets returned for partially fillable limit
+                orders and only refers to the actual amount filled by the trade.
 
     LiquidityInteraction:
       description: |


### PR DESCRIPTION
Trivial PR that splits out from #1366 the new fields in the solution DTOs required for including fee amounts from external solvers. This will be needed by the Gnosis solvers for communicating the solver fees.

### Test Plan

Rust compiler.
