### PR TITLE
Add flag to driver controlling partially fillable orders

### DIFF
--- a/crates/autopilot/src/arguments.rs
+++ b/crates/autopilot/src/arguments.rs
@@ -151,9 +151,6 @@ pub struct Arguments {
     #[clap(long, env, action = clap::ArgAction::Set, default_value = "true")]
     pub process_fill_or_kill_limit_orders: bool,
 
-    #[clap(long, env, action = clap::ArgAction::Set, default_value = "false")]
-    pub process_partially_fillable_limit_orders: bool,
-
     /// How many quotes the limit order quoter updates in parallel.
     #[clap(long, env, default_value = "5")]
     pub limit_order_quoter_parallelism: usize,
@@ -260,11 +257,6 @@ impl std::fmt::Display for Arguments {
             f,
             "process_fill_or_kill_limit_orders: {:?}",
             self.process_fill_or_kill_limit_orders
-        )?;
-        writeln!(
-            f,
-            "process_partially_fillable_limit_orders: {:?}",
-            self.process_partially_fillable_limit_orders
         )?;
         writeln!(
             f,

--- a/crates/e2e/tests/e2e/colocation_partial_fill.rs
+++ b/crates/e2e/tests/e2e/colocation_partial_fill.rs
@@ -48,7 +48,6 @@ async fn test(web3: Web3) {
     services.start_autopilot(vec![
         "--enable-colocation=true".to_string(),
         "--drivers=http://localhost:11088/test_solver".to_string(),
-        "--process-partially-fillable-limit-orders=true".to_string(),
     ]);
     services
         .start_api(vec![

--- a/crates/e2e/tests/e2e/partially_fillable.rs
+++ b/crates/e2e/tests/e2e/partially_fillable.rs
@@ -70,9 +70,7 @@ async fn test(web3: Web3) {
     );
 
     let services = Services::new(onchain.contracts()).await;
-    services.start_autopilot(vec![
-        "--process-partially-fillable-limit-orders=true".to_string()
-    ]);
+    services.start_autopilot(vec![]);
     services
         .start_api(vec![
             "--allow-placing-partially-fillable-limit-orders=true".to_string()

--- a/crates/solver/src/arguments.rs
+++ b/crates/solver/src/arguments.rs
@@ -351,6 +351,12 @@ pub struct Arguments {
     /// Flag to enable slippage protection for the 0x solver.
     #[clap(long, env, action = clap::ArgAction::Set, default_value = "false")]
     pub zeroex_enable_slippage_protection: bool,
+
+    #[clap(long, env, action = clap::ArgAction::Set, default_value = "true")]
+    pub process_partially_fillable_liquidity_orders: bool,
+
+    #[clap(long, env, action = clap::ArgAction::Set, default_value = "true")]
+    pub process_partially_fillable_limit_orders: bool,
 }
 
 impl std::fmt::Display for Arguments {
@@ -489,6 +495,16 @@ impl std::fmt::Display for Arguments {
             f,
             "zeroex_enable_slippage_protection: {}",
             self.zeroex_enable_slippage_protection
+        )?;
+        writeln!(
+            f,
+            "process_partially_fillable_limit_orders: {:?}",
+            self.process_partially_fillable_limit_orders
+        )?;
+        writeln!(
+            f,
+            "process_partially_fillable_liquidity_orders: {:?}",
+            self.process_partially_fillable_liquidity_orders
         )?;
         Ok(())
     }

--- a/crates/solver/src/run.rs
+++ b/crates/solver/src/run.rs
@@ -534,6 +534,8 @@ pub async fn run(args: Arguments) {
         args.solution_comparison_decimal_cutoff,
         code_fetcher,
         args.auction_rewards_activation_timestamp,
+        args.process_partially_fillable_liquidity_orders,
+        args.process_partially_fillable_limit_orders,
     );
 
     let maintainer = ServiceMaintenance::new(maintainers);


### PR DESCRIPTION
We had an issue where the driver crashed on a partially fillable order. It makes more sense to control this feature in the driver than in the autopilot.

### Test Plan

compiles, e2e tests still work
