### PR TITLE
Solver Computed Surplus Fees

### DIFF
--- a/crates/solvers/src/api/dto/solution.rs
+++ b/crates/solvers/src/api/dto/solution.rs
@@ -35,6 +35,7 @@ impl Solution {
                     solution::Trade::Fulfillment(trade) => Trade::Fulfillment(Fulfillment {
                         order: trade.order().uid.0,
                         executed_amount: trade.executed().amount,
+                        fee: trade.fee().map(|fee| fee.amount),
                     }),
                     solution::Trade::Jit(trade) => {
                         let (signing_scheme, signature) = match &trade.order.signature {
@@ -163,6 +164,9 @@ struct Fulfillment {
     order: [u8; 56],
     #[serde_as(as = "serialize::U256")]
     executed_amount: U256,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde_as(as = "Option<serialize::U256>")]
+    fee: Option<U256>,
 }
 
 #[serde_as]

--- a/crates/solvers/src/api/dto/solution.rs
+++ b/crates/solvers/src/api/dto/solution.rs
@@ -35,7 +35,7 @@ impl Solution {
                     solution::Trade::Fulfillment(trade) => Trade::Fulfillment(Fulfillment {
                         order: trade.order().uid.0,
                         executed_amount: trade.executed().amount,
-                        fee: trade.fee().map(|fee| fee.amount),
+                        fee: trade.surplus_fee().map(|fee| fee.amount),
                     }),
                     solution::Trade::Jit(trade) => {
                         let (signing_scheme, signature) = match &trade.order.signature {

--- a/crates/solvers/src/boundary/legacy.rs
+++ b/crates/solvers/src/boundary/legacy.rs
@@ -388,7 +388,10 @@ fn to_domain_solution(
                         order::Side::Buy => execution.exec_buy_amount,
                         order::Side::Sell => execution.exec_sell_amount,
                     },
-                    execution.exec_fee_amount,
+                    match execution.exec_fee_amount {
+                        Some(fee) => solution::Fee::Surplus(fee),
+                        None => solution::Fee::Protocol,
+                    },
                 )
                 .context("invalid trade execution")?,
             )),

--- a/crates/solvers/src/boundary/legacy.rs
+++ b/crates/solvers/src/boundary/legacy.rs
@@ -382,12 +382,13 @@ fn to_domain_solution(
             .context("solution contains order not part of auction")?
         {
             Order::Protocol(order) => trades.push(solution::Trade::Fulfillment(
-                solution::Fulfillment::partial(
+                solution::Fulfillment::new(
                     (*order).clone(),
                     match order.side {
                         order::Side::Buy => execution.exec_buy_amount,
                         order::Side::Sell => execution.exec_sell_amount,
                     },
+                    execution.exec_fee_amount,
                 )
                 .context("invalid trade execution")?,
             )),

--- a/crates/solvers/src/domain/auction.rs
+++ b/crates/solvers/src/domain/auction.rs
@@ -33,6 +33,17 @@ pub struct Token {
 #[derive(Clone, Copy, Debug)]
 pub struct Price(pub eth::Ether);
 
+impl Price {
+    /// The base Ether amount for pricing.
+    const BASE: u128 = 10_u128.pow(18);
+
+    /// Computes an amount equivalent in value to the specified [`eth::Ether`]
+    /// at the given price.
+    pub fn ether_value(&self, eth: eth::Ether) -> Option<U256> {
+        eth.0.checked_mul(Self::BASE.into())?.checked_div(self.0 .0)
+    }
+}
+
 /// The estimated effective gas price that will likely be used for executing the
 /// settlement transaction.
 #[derive(Clone, Copy, Debug)]

--- a/crates/solvers/src/domain/dex/mod.rs
+++ b/crates/solvers/src/domain/dex/mod.rs
@@ -4,7 +4,7 @@
 
 use {
     crate::{
-        domain::{eth, order, solution},
+        domain::{auction, eth, order, solution},
         util,
     },
     ethereum_types::U256,
@@ -89,6 +89,9 @@ pub struct Swap {
 }
 
 impl Swap {
+    /// An approximation for the overhead of executing a trade in a settlement.
+    const SETTLEMENT_OVERHEAD: u64 = 106_391;
+
     pub fn allowance(&self) -> solution::Allowance {
         solution::Allowance {
             spender: self.allowance.spender.0,
@@ -101,20 +104,82 @@ impl Swap {
 
     /// Constructs a single order `solution::Solution` for this swap. Returns
     /// `None` if the swap is not valid for the specified order.
-    pub fn into_solution(self, order: order::Order) -> Option<solution::Solution> {
-        if !self.matches_order(&order) || !self.respects_price(&order) {
+    pub fn into_solution(
+        self,
+        order: order::Order,
+        sell_price: auction::Price,
+        gas: auction::GasPrice,
+    ) -> Option<solution::Solution> {
+        if (order.sell.token, order.buy.token) != (self.input.token, self.output.token) {
             return None;
         }
 
+        let fee = if order.has_solver_fee() {
+            // TODO: If the order has signed `fee` amount already, we should
+            // discount it from the surplus fee. ATM, users would pay both a
+            // full order fee as well as a solver computed fee. Note that this
+            // is fine for now, since there is no way to create limit orders
+            // with non-zero fees.
+            Some(
+                sell_price.ether_value(eth::Ether(
+                    self.gas
+                        .0
+                        .checked_add(Self::SETTLEMENT_OVERHEAD.into())?
+                        .checked_mul(gas.0 .0)?,
+                ))?,
+            )
+        } else {
+            None
+        };
+
+        // Compute total executed sell and buy amounts accounting for solver
+        // fees. That is, the total amount of sell tokens transferred into the
+        // contract and the total buy tokens transferred out of the contract.
+        let (sell, buy) = match order.side {
+            order::Side::Buy => (
+                self.input.amount.checked_add(fee.unwrap_or_default())?,
+                self.output.amount,
+            ),
+            order::Side::Sell => {
+                // We want to collect fees in the sell token, so we need to sell
+                // `fee` more than the DEX swap. However, we don't allow
+                // transferring more than `order.sell.amount` (guaranteed by the
+                // Smart Contract), so we need to cap our executed amount to the
+                // order's limit sell amount and compute the executed buy amount
+                // accordingly.
+                let sell = self
+                    .input
+                    .amount
+                    .checked_add(fee.unwrap_or_default())?
+                    .min(order.sell.amount);
+                let buy = util::math::div_ceil(
+                    sell.checked_sub(fee.unwrap_or_default())?
+                        .checked_mul(self.output.amount)?,
+                    self.input.amount,
+                )?;
+                (sell, buy)
+            }
+        };
+
+        // Check order's limit price is satisfied accounting for solver
+        // specified fees.
+        if order.sell.amount.checked_mul(buy)? < order.buy.amount.checked_mul(sell)? {
+            return None;
+        }
+
+        let executed = match order.side {
+            order::Side::Buy => buy,
+            order::Side::Sell => sell.checked_sub(fee.unwrap_or_default())?,
+        };
         let allowance = self.allowance();
         Some(solution::Solution {
             prices: solution::ClearingPrices::new([
-                (self.input.token, self.output.amount),
-                (self.output.token, self.input.amount),
+                (order.sell.token, buy),
+                (order.buy.token, sell.checked_sub(fee.unwrap_or_default())?),
             ]),
-            trades: vec![solution::Trade::Fulfillment(solution::Fulfillment::fill(
-                order,
-            ))],
+            trades: vec![solution::Trade::Fulfillment(solution::Fulfillment::new(
+                order, executed, fee,
+            )?)],
             interactions: vec![solution::Interaction::Custom(solution::CustomInteraction {
                 target: self.call.to.0,
                 value: eth::Ether::default(),
@@ -125,30 +190,6 @@ impl Swap {
                 allowances: vec![allowance],
             })],
         })
-    }
-
-    fn matches_order(&self, order: &order::Order) -> bool {
-        let (swap_amount, order_amount) = match order.side {
-            order::Side::Buy => (self.output.amount, order.buy.amount),
-            order::Side::Sell => (self.input.amount, order.sell.amount),
-        };
-
-        let correct_tokens =
-            (order.sell.token, order.buy.token) == (self.input.token, self.output.token);
-        let correct_amount = match order.partially_fillable {
-            true => swap_amount <= order_amount,
-            false => swap_amount == order_amount,
-        };
-
-        correct_tokens && correct_amount
-    }
-
-    fn respects_price(&self, order: &order::Order) -> bool {
-        // Note the use of checked multiplication - this is consistent with the
-        // on-chain limit price check.
-        let sell = order.sell.amount.checked_mul(self.output.amount);
-        let buy = order.buy.amount.checked_mul(self.input.amount);
-        matches!((sell, buy), (Some(sell), Some(buy)) if sell >= buy)
     }
 }
 

--- a/crates/solvers/src/domain/dex/slippage.rs
+++ b/crates/solvers/src/domain/dex/slippage.rs
@@ -124,6 +124,14 @@ impl Prices {
                 .filter_map(|(address, token)| Some((*address, token.reference_price?))),
         )
     }
+
+    /// Returns the reference price, in Ether for the specified token.
+    pub fn reference_price(&self, token: eth::TokenAddress) -> Option<auction::Price> {
+        self.0
+            .get(&token)
+            .and_then(conv::decimal_to_ether)
+            .map(auction::Price)
+    }
 }
 
 #[cfg(test)]

--- a/crates/solvers/src/domain/order.rs
+++ b/crates/solvers/src/domain/order.rs
@@ -27,6 +27,11 @@ impl Order {
             amount: self.fee.0,
         }
     }
+
+    /// Returns `true` if the order expects a solver-computed fee.
+    pub fn has_solver_fee(&self) -> bool {
+        self.partially_fillable && self.class == Class::Limit
+    }
 }
 
 /// UID of an order.

--- a/crates/solvers/src/domain/solution.rs
+++ b/crates/solvers/src/domain/solution.rs
@@ -34,22 +34,24 @@ pub enum Trade {
 pub struct Fulfillment {
     order: order::Order,
     executed: U256,
-    fee: Option<U256>,
+    fee: Fee,
 }
 
 impl Fulfillment {
     /// Creates a new order filled to the specified amount. Returns `None` if
     /// the fill amount is incompatible with the order.
-    pub fn new(order: order::Order, executed: U256, fee: Option<U256>) -> Option<Self> {
-        if fee.is_some() != order.has_solver_fee() {
+    pub fn new(order: order::Order, executed: U256, fee: Fee) -> Option<Self> {
+        if matches!(fee, Fee::Surplus(_)) != order.has_solver_fee() {
             return None;
         }
 
-        let fill = match order.side {
-            order::Side::Buy => order.buy.amount,
-            order::Side::Sell => order.sell.amount,
+        let (fill, full) = match order.side {
+            order::Side::Buy => (order.buy.amount, executed),
+            order::Side::Sell => (
+                order.sell.amount,
+                executed.checked_add(fee.surplus().unwrap_or_default())?,
+            ),
         };
-        let full = executed.checked_add(fee.unwrap_or_default())?;
         if (!order.partially_fillable && full != fill) || (order.partially_fillable && full > fill)
         {
             return None;
@@ -68,7 +70,7 @@ impl Fulfillment {
             order::Side::Buy => order.buy.amount,
             order::Side::Sell => order.sell.amount,
         };
-        Self::new(order, executed, None)
+        Self::new(order, executed, Fee::Protocol)
     }
 
     /// Get a reference to the traded order.
@@ -92,11 +94,34 @@ impl Fulfillment {
     /// Returns the solver computed fee that was charged to the order as an
     /// asset (token address and amount). Returns `None` if the fulfillment
     /// does not include a solver computed fee.
-    pub fn fee(&self) -> Option<eth::Asset> {
+    pub fn surplus_fee(&self) -> Option<eth::Asset> {
         Some(eth::Asset {
             token: self.order.sell.token,
-            amount: self.fee?,
+            amount: self.fee.surplus()?,
         })
+    }
+}
+
+/// The fee that is charged to a user for executing an order.
+#[derive(Clone, Copy, Debug)]
+pub enum Fee {
+    /// A protocol computed fee.
+    ///
+    /// That is, the fee is charged from the order's `fee_amount` that is
+    /// included in the auction being solved.
+    Protocol,
+
+    /// An additional surplus fee that is charged by the solver.
+    Surplus(U256),
+}
+
+impl Fee {
+    /// Returns the dynamic component for the fee.
+    pub fn surplus(&self) -> Option<U256> {
+        match self {
+            Fee::Protocol => None,
+            Fee::Surplus(fee) => Some(*fee),
+        }
     }
 }
 

--- a/crates/solvers/src/domain/solver/baseline.rs
+++ b/crates/solvers/src/domain/solver/baseline.rs
@@ -50,7 +50,7 @@ impl Baseline {
                     ]),
                     trades: vec![solution::Trade::Fulfillment(solution::Fulfillment::fill(
                         order.clone(),
-                    ))],
+                    )?)],
                     interactions: route
                         .segments
                         .iter()

--- a/crates/solvers/src/tests/dex/mod.rs
+++ b/crates/solvers/src/tests/dex/mod.rs
@@ -1,3 +1,4 @@
 //! Test cases that are specific to the dex solver but not the underlying APIs.
 
 mod partial_fill;
+mod wrong_execution;

--- a/crates/solvers/src/tests/dex/partial_fill.rs
+++ b/crates/solvers/src/tests/dex/partial_fill.rs
@@ -120,12 +120,11 @@ async fn tested_amounts_decrease() {
                 "sellToken": "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
                 "buyToken": "0xba100000625a3754423978a60c9317c58a424e3D",
                 "sellAmount": "16000000000000000000",
-                "buyAmount": "3641580551073046209760",
-                // Let's just assume 0 fee to not further complicate the math.
+                "buyAmount": "3630944624685908136768",
                 "feeAmount": "0",
                 "kind": "sell",
                 "partiallyFillable": true,
-                "class": "market",
+                "class": "limit",
                 "reward": 0.
             }
         ],
@@ -211,7 +210,8 @@ async fn tested_amounts_decrease() {
             },
             "trades": [
                 {
-                    "executedAmount": "16000000000000000000",
+                    "executedAmount": "1000000000000000000",
+                    "fee": "2929245000000000",
                     "kind": "fulfillment",
                     "order": "0x2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a"
                 }
@@ -301,7 +301,7 @@ async fn tested_amounts_wrap_around() {
                 "feeAmount": "0",
                 "kind": "buy",
                 "partiallyFillable": true,
-                "class": "market",
+                "class": "limit",
                 "reward": 0.
             }
         ],
@@ -321,4 +321,367 @@ async fn tested_amounts_wrap_around() {
             }),
         );
     }
+}
+
+/// Test that matches a partially fillable in such a way that there isn't enough
+/// sell amount left to extract the user's surplus fee. The expectation here is
+/// that we shift part of the fee into the buy token (i.e. transfer out less
+/// than we receive from the swap).
+#[tokio::test]
+async fn moves_surplus_fee_to_buy_token() {
+    // shared::tracing::initialize_reentrant("solvers=trace");
+    let api = mock::http::setup(vec![
+        mock::http::Expectation::Post {
+            path: mock::http::Path::Any,
+            req: json!({
+                "sellToken": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+                "buyToken": "0xba100000625a3754423978a60c9317c58a424e3d",
+                "orderKind": "sell",
+                "amount": "2000000000000000000",
+                "gasPrice": "6000000000000",
+            }),
+            res: json!({
+                "tokenAddresses": [],
+                "swaps": [],
+                "swapAmount": "0",
+                "swapAmountForSwaps": "0",
+                "returnAmount": "0",
+                "returnAmountFromSwaps": "0",
+                "returnAmountConsideringFees": "0",
+                "tokenIn": "0x0000000000000000000000000000000000000000",
+                "tokenOut": "0x0000000000000000000000000000000000000000",
+                "marketSp": "0",
+            }),
+        },
+        mock::http::Expectation::Post {
+            path: mock::http::Path::Any,
+            req: json!({
+                "sellToken": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+                "buyToken": "0xba100000625a3754423978a60c9317c58a424e3d",
+                "orderKind": "sell",
+                "amount": "1000000000000000000",
+                "gasPrice": "6000000000000",
+            }),
+            res: json!({
+                "tokenAddresses": [
+                    "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+                    "0xba100000625a3754423978a60c9317c58a424e3d"
+                ],
+                "swaps": [
+                    {
+                        "poolId": "0x5c6ee304399dbdb9c8ef030ab642b10820\
+                            db8f56000200000000000000000014",
+                        "assetInIndex": 0,
+                        "assetOutIndex": 1,
+                        "amount": "1000000000000000000",
+                        "userData": "0x",
+                        "returnAmount": "227598784442065388110"
+                    }
+                ],
+                "swapAmount": "1000000000000000000",
+                "swapAmountForSwaps": "1000000000000000000",
+                "returnAmount": "227598784442065388110",
+                "returnAmountFromSwaps": "227598784442065388110",
+                "returnAmountConsideringFees": "227307710853355710706",
+                "tokenIn": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+                "tokenOut": "0xba100000625a3754423978a60c9317c58a424e3d",
+                "marketSp": "0.004393607339632106",
+            }),
+        },
+    ])
+    .await;
+
+    let engine = tests::SolverEngine::new("balancer", balancer::config(&api.address)).await;
+
+    let auction = json!({
+        "id": null,
+        "tokens": {
+            "0xba100000625a3754423978a60c9317c58a424e3D": {
+                "decimals": 18,
+                "symbol": "BAL",
+                "referencePrice": "4000000000000000",
+                "availableBalance": "0",
+                "trusted": true
+            },
+            "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2": {
+                "decimals": 18,
+                "symbol": "WETH",
+                "referencePrice": "1000000000000000000",
+                "availableBalance": "0",
+                "trusted": true
+            },
+            "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee": {
+                "decimals": 18,
+                "symbol": "ETH",
+                "referencePrice": "1000000000000000000",
+                "availableBalance": "0",
+                "trusted": true
+            },
+        },
+        "orders": [
+            {
+                "uid": "0x2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a\
+                          2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a\
+                          2a2a2a2a",
+                "sellToken": "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
+                "buyToken": "0xba100000625a3754423978a60c9317c58a424e3D",
+                "sellAmount": "2000000000000000000",
+                "buyAmount": "1",
+                "feeAmount": "0",
+                "kind": "sell",
+                "partiallyFillable": true,
+                "class": "limit",
+                "reward": 0.
+            }
+        ],
+        "liquidity": [],
+        "effectiveGasPrice": "6000000000000",
+        "deadline": "2106-01-01T00:00:00.000Z"
+    });
+
+    // The first try doesn't match.
+    let solution = engine.solve(auction.clone()).await;
+    assert_eq!(
+        solution,
+        json!({
+            "prices": {},
+            "trades": [],
+            "interactions": [],
+        }),
+    );
+
+    let solution = engine.solve(auction.clone()).await;
+    assert_eq!(
+        solution,
+        json!({
+            "interactions": [
+                {
+                    "allowances": [
+                        {
+                            "amount": "1000000000000000000",
+                            "spender": "0xba12222222228d8ba445958a75a0704d566bf2c8",
+                            "token": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"
+                        }
+                    ],
+                    "callData": "0x945bcec90000000000000000000000000000000000000000000\
+                        00000000000000000000000000000000000000000000000000000000000000\
+                        00000000000000000000120000000000000000000000000000000000000000\
+                        00000000000000000000002200000000000000000000000009008d19f58aab\
+                        d9ed0d60971565aa8510560ab4100000000000000000000000000000000000\
+                        000000000000000000000000000000000000000000000000000009008d19f5\
+                        8aabd9ed0d60971565aa8510560ab410000000000000000000000000000000\
+                        00000000000000000000000000000000000000000000000000000000000000\
+                        00000000000000000000000000000000280800000000000000000000000000\
+                        00000000000000000000000000000000000000000000000000000000000000\
+                        00000000000000000000000000000000000000100000000000000000000000\
+                        000000000000000000000000000000000000000205c6ee304399dbdb9c8ef0\
+                        30ab642b10820db8f560002000000000000000000140000000000000000000\
+                        00000000000000000000000000000000000000000000000000000000000000\
+                        00000000000000000000000000000000000000000000001000000000000000\
+                        0000000000000000000000000000000000de0b6b3a76400000000000000000\
+                        0000000000000000000000000000000000000000000000000a000000000000\
+                        00000000000000000000000000000000000000000000000000000000000000\
+                        00000000000000000000000000000000000000000000000000000020000000\
+                        00000000000000000c02aaa39b223fe8d0a0e5c4f27ead9083c756cc200000\
+                        0000000000000000000ba100000625a3754423978a60c9317c58a424e3d000\
+                        00000000000000000000000000000000000000000000000000000000000020\
+                        000000000000000000000000000000000000000000000000de0b6b3a764000\
+                        0fffffffffffffffffffffffffffffffffffffffffffffff3c9049e4e47ca5\
+                        0ec",
+                    "inputs": [
+                        {
+                            "amount": "1000000000000000000",
+                            "token": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"
+                        }
+                    ],
+                    "internalize": false,
+                    "kind": "custom",
+                    "outputs": [
+                        {
+                            "amount": "227598784442065388110",
+                            "token": "0xba100000625a3754423978a60c9317c58a424e3d"
+                        }
+                    ],
+                    "target": "0xba12222222228d8ba445958a75a0704d566bf2c8",
+                    "value": "0"
+                }
+            ],
+            "prices": {
+                "0xba100000625a3754423978a60c9317c58a424e3d": "828302000000000000",
+                "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2": "188520528350931645103"
+            },
+            "trades": [
+                {
+                    "executedAmount": "828302000000000000",
+                    "fee": "1171698000000000000",
+                    "kind": "fulfillment",
+                    "order": "0x2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a"
+                }
+            ]
+        })
+    );
+}
+
+/// Test that documents how we deal with partially fillable market orders. In
+/// particular, we assume that there is no solver fee to compute and that the
+/// pre-agreed upon "feeAmount" is sufficient. In practice, this isn't expected
+/// to happen, and this test is mostly included to document expected behaviour
+/// in the case of these orders.
+#[tokio::test]
+async fn market() {
+    let api = mock::http::setup(vec![mock::http::Expectation::Post {
+        path: mock::http::Path::Any,
+        req: json!({
+            "sellToken": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+            "buyToken": "0xba100000625a3754423978a60c9317c58a424e3d",
+            "orderKind": "sell",
+            "amount": "1000000000000000000",
+            "gasPrice": "15000000000",
+        }),
+        res: json!({
+            "tokenAddresses": [
+                "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+                "0xba100000625a3754423978a60c9317c58a424e3d"
+            ],
+            "swaps": [
+                {
+                    "poolId": "0x5c6ee304399dbdb9c8ef030ab642b10820\
+                        db8f56000200000000000000000014",
+                    "assetInIndex": 0,
+                    "assetOutIndex": 1,
+                    "amount": "1000000000000000000",
+                    "userData": "0x",
+                    "returnAmount": "227598784442065388110"
+                }
+            ],
+            "swapAmount": "1000000000000000000",
+            "swapAmountForSwaps": "1000000000000000000",
+            "returnAmount": "227598784442065388110",
+            "returnAmountFromSwaps": "227598784442065388110",
+            "returnAmountConsideringFees": "227307710853355710706",
+            "tokenIn": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+            "tokenOut": "0xba100000625a3754423978a60c9317c58a424e3d",
+            "marketSp": "0.004393607339632106",
+        }),
+    }])
+    .await;
+
+    let engine = tests::SolverEngine::new("balancer", balancer::config(&api.address)).await;
+
+    let solution = engine
+        .solve(json!({
+            "id": null,
+            "tokens": {
+                "0xba100000625a3754423978a60c9317c58a424e3D": {
+                    "decimals": 18,
+                    "symbol": "BAL",
+                    "referencePrice": "4327903683155778",
+                    "availableBalance": "0",
+                    "trusted": true
+                },
+                "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2": {
+                    "decimals": 18,
+                    "symbol": "WETH",
+                    "referencePrice": "1000000000000000000",
+                    "availableBalance": "0",
+                    "trusted": true
+                },
+                "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee": {
+                    "decimals": 18,
+                    "symbol": "ETH",
+                    "referencePrice": "1000000000000000000",
+                    "availableBalance": "0",
+                    "trusted": true
+                },
+            },
+            "orders": [
+                {
+                    "uid": "0x2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a\
+                              2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a\
+                              2a2a2a2a",
+                    "sellToken": "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
+                    "buyToken": "0xba100000625a3754423978a60c9317c58a424e3D",
+                    "sellAmount": "1000000000000000000",
+                    "buyAmount": "227598784442065388110",
+                    "feeAmount": "10000000000000000",
+                    "kind": "sell",
+                    "partiallyFillable": true,
+                    "class": "market",
+                    "reward": 0.
+                }
+            ],
+            "liquidity": [],
+            "effectiveGasPrice": "15000000000",
+            "deadline": "2106-01-01T00:00:00.000Z"
+        }))
+        .await;
+
+    assert_eq!(
+        solution,
+        json!({
+            "interactions": [
+                {
+                    "allowances": [
+                        {
+                            "amount": "1000000000000000000",
+                            "spender": "0xba12222222228d8ba445958a75a0704d566bf2c8",
+                            "token": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"
+                        }
+                    ],
+                    "callData": "0x945bcec90000000000000000000000000000000000000000000\
+                        00000000000000000000000000000000000000000000000000000000000000\
+                        00000000000000000000120000000000000000000000000000000000000000\
+                        00000000000000000000002200000000000000000000000009008d19f58aab\
+                        d9ed0d60971565aa8510560ab4100000000000000000000000000000000000\
+                        000000000000000000000000000000000000000000000000000009008d19f5\
+                        8aabd9ed0d60971565aa8510560ab410000000000000000000000000000000\
+                        00000000000000000000000000000000000000000000000000000000000000\
+                        00000000000000000000000000000000280800000000000000000000000000\
+                        00000000000000000000000000000000000000000000000000000000000000\
+                        00000000000000000000000000000000000000100000000000000000000000\
+                        000000000000000000000000000000000000000205c6ee304399dbdb9c8ef0\
+                        30ab642b10820db8f560002000000000000000000140000000000000000000\
+                        00000000000000000000000000000000000000000000000000000000000000\
+                        00000000000000000000000000000000000000000000001000000000000000\
+                        0000000000000000000000000000000000de0b6b3a76400000000000000000\
+                        0000000000000000000000000000000000000000000000000a000000000000\
+                        00000000000000000000000000000000000000000000000000000000000000\
+                        00000000000000000000000000000000000000000000000000000020000000\
+                        00000000000000000c02aaa39b223fe8d0a0e5c4f27ead9083c756cc200000\
+                        0000000000000000000ba100000625a3754423978a60c9317c58a424e3d000\
+                        00000000000000000000000000000000000000000000000000000000000020\
+                        000000000000000000000000000000000000000000000000de0b6b3a764000\
+                        0fffffffffffffffffffffffffffffffffffffffffffffff3c9049e4e47ca5\
+                        0ec",
+                    "inputs": [
+                        {
+                            "amount": "1000000000000000000",
+                            "token": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"
+                        }
+                    ],
+                    "internalize": false,
+                    "kind": "custom",
+                    "outputs": [
+                        {
+                            "amount": "227598784442065388110",
+                            "token": "0xba100000625a3754423978a60c9317c58a424e3d"
+                        }
+                    ],
+                    "target": "0xba12222222228d8ba445958a75a0704d566bf2c8",
+                    "value": "0"
+                }
+            ],
+            "prices": {
+                "0xba100000625a3754423978a60c9317c58a424e3d": "1000000000000000000",
+                "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2": "227598784442065388110"
+            },
+            "trades": [
+                {
+                    "executedAmount": "1000000000000000000",
+                    "kind": "fulfillment",
+                    "order": "0x2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a"
+                }
+            ]
+        })
+    );
 }

--- a/crates/solvers/src/tests/dex/wrong_execution.rs
+++ b/crates/solvers/src/tests/dex/wrong_execution.rs
@@ -1,0 +1,143 @@
+use {
+    crate::tests::{self, balancer, mock},
+    serde_json::json,
+};
+
+struct Case {
+    input_amount: &'static str,
+    output_amount: &'static str,
+    side: &'static str,
+}
+
+/// Test that verifies that attempting to settle an order when the DEX swap
+/// whose amounts do not match the input order fails to produce a solution, even
+/// if it can satisfy the order's limit price.
+#[tokio::test]
+async fn test() {
+    for Case {
+        input_amount,
+        output_amount,
+        side,
+    } in [
+        Case {
+            input_amount: "1000000000000000001",
+            output_amount: "227598784442065388110",
+            side: "sell",
+        },
+        Case {
+            input_amount: "999999999999999999",
+            output_amount: "227598784442065388110",
+            side: "sell",
+        },
+        Case {
+            input_amount: "1000000000000000000",
+            output_amount: "227598784442065388111",
+            side: "buy",
+        },
+        Case {
+            input_amount: "1000000000000000000",
+            output_amount: "227598784442065388109",
+            side: "buy",
+        },
+    ] {
+        let api = mock::http::setup(vec![mock::http::Expectation::Post {
+            path: mock::http::Path::Any,
+            req: json!({
+                "sellToken": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+                "buyToken": "0xba100000625a3754423978a60c9317c58a424e3d",
+                "orderKind": side,
+                "amount": if side == "sell" {
+                    "1000000000000000000"
+                } else {
+                    "227598784442065388110"
+                },
+                "gasPrice": "15000000000",
+            }),
+            res: json!({
+                "tokenAddresses": [
+                    "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+                    "0xba100000625a3754423978a60c9317c58a424e3d"
+                ],
+                "swaps": [
+                    {
+                        "poolId": "0x5c6ee304399dbdb9c8ef030ab642b10820\
+                            db8f56000200000000000000000014",
+                        "assetInIndex": 0,
+                        "assetOutIndex": 1,
+                        "amount": input_amount,
+                        "userData": "0x",
+                        "returnAmount": output_amount,
+                    }
+                ],
+                "swapAmount": input_amount,
+                "swapAmountForSwaps": input_amount,
+                "returnAmount": output_amount,
+                "returnAmountFromSwaps": output_amount,
+                "returnAmountConsideringFees": output_amount,
+                "tokenIn": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+                "tokenOut": "0xba100000625a3754423978a60c9317c58a424e3d",
+                "marketSp": "0.004393607339632106",
+            }),
+        }])
+        .await;
+
+        let engine = tests::SolverEngine::new("balancer", balancer::config(&api.address)).await;
+
+        let solution = engine
+            .solve(json!({
+                "id": null,
+                "tokens": {
+                    "0xba100000625a3754423978a60c9317c58a424e3D": {
+                        "decimals": 18,
+                        "symbol": "BAL",
+                        "referencePrice": "4327903683155778",
+                        "availableBalance": "0",
+                        "trusted": true
+                    },
+                    "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2": {
+                        "decimals": 18,
+                        "symbol": "WETH",
+                        "referencePrice": "1000000000000000000",
+                        "availableBalance": "0",
+                        "trusted": true
+                    },
+                    "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee": {
+                        "decimals": 18,
+                        "symbol": "ETH",
+                        "referencePrice": "1000000000000000000",
+                        "availableBalance": "0",
+                        "trusted": true
+                    },
+                },
+                "orders": [
+                    {
+                        "uid": "0x2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a\
+                                  2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a\
+                                  2a2a2a2a",
+                        "sellToken": "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
+                        "buyToken": "0xba100000625a3754423978a60c9317c58a424e3D",
+                        "sellAmount": "1000000000000000000",
+                        "buyAmount": "227598784442065388110",
+                        "feeAmount": "10000000000000000",
+                        "kind": side,
+                        "partiallyFillable": false,
+                        "class": "market",
+                        "reward": 0.
+                    }
+                ],
+                "liquidity": [],
+                "effectiveGasPrice": "15000000000",
+                "deadline": "2106-01-01T00:00:00.000Z"
+            }))
+            .await;
+
+        assert_eq!(
+            solution,
+            json!({
+                "prices": {},
+                "trades": [],
+                "interactions": [],
+            }),
+        );
+    }
+}

--- a/crates/solvers/src/util/math.rs
+++ b/crates/solvers/src/util/math.rs
@@ -1,0 +1,20 @@
+use ethereum_types::U256;
+
+/// Perform a ceiled U256 integer division.
+///
+/// Returns `None` when dividing by `0`.
+pub fn div_ceil(q: U256, d: U256) -> Option<U256> {
+    if d.is_zero() {
+        return None;
+    }
+
+    let (r, rem) = q.div_mod(d);
+    if rem.is_zero() {
+        Some(r)
+    } else {
+        Some(
+            r.checked_add(U256::one())
+                .expect("unexpected ceiled division overflow"),
+        )
+    }
+}

--- a/crates/solvers/src/util/mod.rs
+++ b/crates/solvers/src/util/mod.rs
@@ -1,3 +1,4 @@
 pub mod conv;
 pub mod fmt;
+pub mod math;
 pub mod serialize;


### PR DESCRIPTION
Fixes #1292.

This PR adds surplus fee computation to the DEX solvers for partially fillable limit orders. In particular, it also adjusts the limit prices so that the UCP reflects the "actual traded amounts" without the fees.

### Test Plan

Added E2E tests for partially fillable limit order fee logic.
