### PR TITLE
Support Partially Fillable Orders in Baseline

### DIFF
--- a/crates/e2e/tests/e2e/colocation_univ2.rs
+++ b/crates/e2e/tests/e2e/colocation_univ2.rs
@@ -90,6 +90,7 @@ async fn start_solver(weth: H160) -> Url {
 weth = "{weth:?}"
 base-tokens = []
 max-hops = 0
+max-partial-attempts = 5
         "#,
     ));
     let args = vec![

--- a/crates/solvers/config/example.baseline.toml
+++ b/crates/solvers/config/example.baseline.toml
@@ -3,3 +3,4 @@ chain-id = "1"
 #weth = "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2"
 base-tokens = []
 max-hops = 0
+max-partial-attempts = 5

--- a/crates/solvers/src/domain/dex/mod.rs
+++ b/crates/solvers/src/domain/dex/mod.rs
@@ -89,9 +89,6 @@ pub struct Swap {
 }
 
 impl Swap {
-    /// An approximation for the overhead of executing a trade in a settlement.
-    const SETTLEMENT_OVERHEAD: u64 = 106_391;
-
     pub fn allowance(&self) -> solution::Allowance {
         solution::Allowance {
             spender: self.allowance.spender.0,
@@ -107,90 +104,28 @@ impl Swap {
     pub fn into_solution(
         self,
         order: order::Order,
-        sell_price: auction::Price,
-        gas: auction::GasPrice,
+        gas_price: auction::GasPrice,
+        sell_token: auction::Price,
     ) -> Option<solution::Solution> {
-        if (order.sell.token, order.buy.token) != (self.input.token, self.output.token) {
-            return None;
-        }
-
-        let fee = if order.has_solver_fee() {
-            // TODO: If the order has signed `fee` amount already, we should
-            // discount it from the surplus fee. ATM, users would pay both a
-            // full order fee as well as a solver computed fee. Note that this
-            // is fine for now, since there is no way to create limit orders
-            // with non-zero fees.
-            solution::Fee::Surplus(
-                sell_price.ether_value(eth::Ether(
-                    self.gas
-                        .0
-                        .checked_add(Self::SETTLEMENT_OVERHEAD.into())?
-                        .checked_mul(gas.0 .0)?,
-                ))?,
-            )
-        } else {
-            solution::Fee::Protocol
-        };
-        let surplus_fee = fee.surplus().unwrap_or_default();
-
-        // Compute total executed sell and buy amounts accounting for solver
-        // fees. That is, the total amount of sell tokens transferred into the
-        // contract and the total buy tokens transferred out of the contract.
-        let (sell, buy) = match order.side {
-            order::Side::Buy => (
-                self.input.amount.checked_add(surplus_fee)?,
-                self.output.amount,
-            ),
-            order::Side::Sell => {
-                // We want to collect fees in the sell token, so we need to sell
-                // `fee` more than the DEX swap. However, we don't allow
-                // transferring more than `order.sell.amount` (guaranteed by the
-                // Smart Contract), so we need to cap our executed amount to the
-                // order's limit sell amount and compute the executed buy amount
-                // accordingly.
-                let sell = self
-                    .input
-                    .amount
-                    .checked_add(surplus_fee)?
-                    .min(order.sell.amount);
-                let buy = util::math::div_ceil(
-                    sell.checked_sub(surplus_fee)?
-                        .checked_mul(self.output.amount)?,
-                    self.input.amount,
-                )?;
-                (sell, buy)
-            }
-        };
-
-        // Check order's limit price is satisfied accounting for solver
-        // specified fees.
-        if order.sell.amount.checked_mul(buy)? < order.buy.amount.checked_mul(sell)? {
-            return None;
-        }
-
-        let executed = match order.side {
-            order::Side::Buy => buy,
-            order::Side::Sell => sell.checked_sub(surplus_fee)?,
-        };
         let allowance = self.allowance();
-        Some(solution::Solution {
-            prices: solution::ClearingPrices::new([
-                (order.sell.token, buy),
-                (order.buy.token, sell.checked_sub(surplus_fee)?),
-            ]),
-            trades: vec![solution::Trade::Fulfillment(solution::Fulfillment::new(
-                order, executed, fee,
-            )?)],
-            interactions: vec![solution::Interaction::Custom(solution::CustomInteraction {
-                target: self.call.to.0,
-                value: eth::Ether::default(),
-                calldata: self.call.calldata,
-                inputs: vec![self.input],
-                outputs: vec![self.output],
-                internalize: false,
-                allowances: vec![allowance],
-            })],
-        })
+        let interactions = vec![solution::Interaction::Custom(solution::CustomInteraction {
+            target: self.call.to.0,
+            value: eth::Ether::default(),
+            calldata: self.call.calldata,
+            inputs: vec![self.input],
+            outputs: vec![self.output],
+            internalize: false,
+            allowances: vec![allowance],
+        })];
+
+        solution::Single {
+            order,
+            input: self.input,
+            output: self.output,
+            interactions,
+            gas: self.gas,
+        }
+        .into_solution(gas_price, sell_token)
     }
 }
 

--- a/crates/solvers/src/domain/solver/baseline.rs
+++ b/crates/solvers/src/domain/solver/baseline.rs
@@ -10,6 +10,7 @@ use {
         boundary,
         domain::{auction, eth, liquidity, order, solution},
     },
+    ethereum_types::U256,
     std::collections::HashSet,
 };
 
@@ -27,6 +28,10 @@ pub struct Baseline {
     /// - A value of 2 indicates: `A -> B -> C -> D`
     /// - etc.
     pub max_hops: usize,
+    /// The maximum number of attempts to solve a partially fillable order.
+    /// Basically we continuously halve the amount to execute until we find a
+    /// valid solution or exceed this count.
+    pub max_partial_attempts: usize,
 }
 
 impl Baseline {
@@ -40,34 +45,74 @@ impl Baseline {
             .orders
             .iter()
             .filter_map(|order| {
-                let route =
-                    boundary_solver.route(order::NonLiquidity::new(order)?, self.max_hops)?;
+                let sell_token = auction.tokens.get(&order.sell.token)?.reference_price?;
+                self.requests_for_order(order::NonLiquidity::new(order)?)
+                    .find_map(|request| {
+                        tracing::trace!(?request, "finding route");
 
-                Some(solution::Solution {
-                    prices: solution::ClearingPrices::new([
-                        (order.sell.token, route.output().amount),
-                        (order.buy.token, route.input().amount),
-                    ]),
-                    trades: vec![solution::Trade::Fulfillment(solution::Fulfillment::fill(
-                        order.clone(),
-                    )?)],
-                    interactions: route
-                        .segments
-                        .iter()
-                        .map(|segment| {
-                            solution::Interaction::Liquidity(solution::LiquidityInteraction {
-                                liquidity: segment.liquidity.clone(),
-                                input: segment.input,
-                                output: segment.output,
-                                // TODO does the baseline solver know about this optimization?
-                                internalize: false,
+                        let route = boundary_solver.route(request, self.max_hops)?;
+                        let interactions = route
+                            .segments
+                            .iter()
+                            .map(|segment| {
+                                solution::Interaction::Liquidity(solution::LiquidityInteraction {
+                                    liquidity: segment.liquidity.clone(),
+                                    input: segment.input,
+                                    output: segment.output,
+                                    // TODO does the baseline solver know about this
+                                    // optimization?
+                                    internalize: false,
+                                })
                             })
-                        })
-                        .collect(),
-                })
+                            .collect();
+
+                        solution::Single {
+                            order: order.clone(),
+                            input: route.input(),
+                            output: route.output(),
+                            interactions,
+                            gas: route.gas(),
+                        }
+                        .into_solution(auction.gas_price, sell_token)
+                    })
             })
             .collect()
     }
+
+    fn requests_for_order(&self, order: order::NonLiquidity) -> impl Iterator<Item = Request> {
+        let order::Order {
+            sell, buy, side, ..
+        } = order.get().clone();
+
+        let n = if order.get().partially_fillable {
+            self.max_partial_attempts
+        } else {
+            1
+        };
+
+        (0..n).map(move |i| {
+            let divisor = U256::one() << i;
+            Request {
+                sell: eth::Asset {
+                    token: sell.token,
+                    amount: sell.amount / divisor,
+                },
+                buy: eth::Asset {
+                    token: buy.token,
+                    amount: buy.amount / divisor,
+                },
+                side,
+            }
+        })
+    }
+}
+
+/// A baseline routing request.
+#[derive(Debug)]
+pub struct Request {
+    pub sell: eth::Asset,
+    pub buy: eth::Asset,
+    pub side: order::Side,
 }
 
 /// A trading route.
@@ -86,6 +131,7 @@ pub struct Segment<'a> {
     // logic, so I think it is fine for now.
     pub input: eth::Asset,
     pub output: eth::Asset,
+    pub gas: eth::Gas,
 }
 
 impl<'a> Route<'a> {
@@ -105,5 +151,11 @@ impl<'a> Route<'a> {
             .last()
             .expect("route has at least one segment by construction")
             .output
+    }
+
+    fn gas(&self) -> eth::Gas {
+        eth::Gas(self.segments.iter().fold(U256::zero(), |acc, segment| {
+            acc.saturating_add(segment.gas.0)
+        }))
     }
 }

--- a/crates/solvers/src/domain/solver/dex/solver.rs
+++ b/crates/solvers/src/domain/solver/dex/solver.rs
@@ -90,11 +90,11 @@ impl Dex {
             }
         };
 
-        let Some(sell_price) = prices.reference_price(order.sell.token) else {
+        let Some(sell) = prices.reference_price(order.sell.token) else {
             tracing::warn!(token = ?order.sell.token.0, "missing sell token price");
             return None;
         };
-        let Some(solution) = swap.into_solution(order, sell_price, gas) else {
+        let Some(solution) = swap.into_solution(order, gas, sell) else {
             tracing::debug!("no solution for swap");
             return None;
         };

--- a/crates/solvers/src/infra/config/baseline/file.rs
+++ b/crates/solvers/src/infra/config/baseline/file.rs
@@ -29,6 +29,10 @@ struct Config {
     /// The maximum number of hops to consider when finding the optimal trading
     /// path.
     max_hops: usize,
+
+    /// The maximum number of pieces to divide partially fillable limit orders
+    /// when trying to solve it against baseline liquidity.
+    max_partial_attempts: usize,
 }
 
 /// Load the driver configuration from a TOML file.
@@ -62,5 +66,6 @@ pub async fn load(path: &Path) -> super::Config {
             .map(eth::TokenAddress)
             .collect(),
         max_hops: config.max_hops,
+        max_partial_attempts: config.max_partial_attempts,
     }
 }

--- a/crates/solvers/src/infra/config/baseline/mod.rs
+++ b/crates/solvers/src/infra/config/baseline/mod.rs
@@ -6,4 +6,5 @@ pub struct Config {
     pub weth: eth::WethAddress,
     pub base_tokens: Vec<eth::TokenAddress>,
     pub max_hops: usize,
+    pub max_partial_attempts: usize,
 }

--- a/crates/solvers/src/run.rs
+++ b/crates/solvers/src/run.rs
@@ -25,6 +25,7 @@ pub async fn run(
                 weth: baseline.weth,
                 base_tokens: baseline.base_tokens.into_iter().collect(),
                 max_hops: baseline.max_hops,
+                max_partial_attempts: baseline.max_partial_attempts,
             })
         }
         cli::Command::Naive => Solver::Naive(solver::Naive),

--- a/crates/solvers/src/tests/baseline/mod.rs
+++ b/crates/solvers/src/tests/baseline/mod.rs
@@ -1,3 +1,4 @@
 //! Baseline solver test cases.
 
 mod direct_swap;
+mod partial_fill;

--- a/crates/solvers/src/tests/baseline/partial_fill.rs
+++ b/crates/solvers/src/tests/baseline/partial_fill.rs
@@ -1,0 +1,101 @@
+//! Simple test case that verifies that the baseline solver can settle a
+//! partially fillable limit order with a Uniswap V2 pool.
+
+use {crate::tests, serde_json::json};
+
+#[tokio::test]
+async fn test() {
+    let engine = tests::SolverEngine::new(
+        "baseline",
+        tests::Config::File("config/example.baseline.toml".into()),
+    )
+    .await;
+
+    let solution = engine
+        .solve(json!({
+            "id": null,
+            "tokens": {
+                "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2": {
+                    "decimals": 18,
+                    "symbol": "WETH",
+                    "referencePrice": "1000000000000000000",
+                    "availableBalance": "1412206645170290748",
+                    "trusted": true
+                },
+                "0xDEf1CA1fb7FBcDC777520aa7f396b4E015F497aB": {
+                    "decimals": 18,
+                    "symbol": "COW",
+                    "referencePrice": "53125132573502",
+                    "availableBalance": "740264138483556450389",
+                    "trusted": true
+                }
+            },
+            "orders": [
+                {
+                    "uid": "0x2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a\
+                              2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a\
+                              2a2a2a2a",
+                    "sellToken": "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
+                    "buyToken": "0xDEf1CA1fb7FBcDC777520aa7f396b4E015F497aB",
+                    "sellAmount": "1000000000000000000",
+                    "buyAmount": "40000000000000000000000",
+                    "feeAmount": "0",
+                    "kind": "sell",
+                    "partiallyFillable": true,
+                    "class": "limit",
+                    "reward": 0.
+                }
+            ],
+            "liquidity": [
+                {
+                    "kind": "constantproduct",
+                    "tokens": {
+                        "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2": {
+                            "balance": "3828187314911751990"
+                        },
+                        "0xDEf1CA1fb7FBcDC777520aa7f396b4E015F497aB": {
+                            "balance": "179617892578796375604692"
+                        }
+                    },
+                    "fee": "0.003",
+                    "id": "0",
+                    "address": "0x97b744df0b59d93A866304f97431D8EfAd29a08d",
+                    "gasEstimate": "110000"
+                }
+            ],
+            "effectiveGasPrice": "15000000000",
+            "deadline": "2106-01-01T00:00:00.000Z"
+        }))
+        .await;
+
+    assert_eq!(
+        solution,
+        json!({
+            "prices": {
+                "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2": "20694705425542464884657",
+                "0xdef1ca1fb7fbcdc777520aa7f396b4e015f497ab": "500000000000000000"
+            },
+            "trades": [
+                {
+                    "kind": "fulfillment",
+                    "order": "0x2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a\
+                                2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a\
+                                2a2a2a2a",
+                    "executedAmount": "500000000000000000",
+                    "fee": "2495865000000000"
+                }
+            ],
+            "interactions": [
+                {
+                    "kind": "liquidity",
+                    "internalize": false,
+                    "id": "0",
+                    "inputToken": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+                    "outputToken": "0xdef1ca1fb7fbcdc777520aa7f396b4e015f497ab",
+                    "inputAmount": "500000000000000000",
+                    "outputAmount": "20694705425542464884657"
+                }
+            ]
+        }),
+    );
+}


### PR DESCRIPTION
In the context of co-location, the Baseline solver is treated differently than DEX aggregator solves (mostly because it is synchronous and fast and doesn't have to deal with many things like rate limiting, etc.).

Because of this, we can have a specialized implementation for partially fillable orders where we attempt multiple swaps at different prices in a single `solve` loop instead of doing it over multiple auctions.

### Test Plan

Added an E2E test that successfully solves a partially fillable limit order with the baseline solver 🎉.
