### PR TITLE
Extend SingleOrderSolver Interface With Gas Estimate

### DIFF
--- a/crates/solver/src/solver/balancer_sor_solver.rs
+++ b/crates/solver/src/solver/balancer_sor_solver.rs
@@ -24,6 +24,7 @@ use {
     shared::{
         balancer_sor_api::{BalancerSorApi, Error as BalancerError, Query, Quote},
         interaction::{EncodedInteraction, Interaction},
+        price_estimation::gas,
     },
     std::sync::Arc,
 };
@@ -127,6 +128,10 @@ impl SingleOrderSolving for BalancerSorSolver {
             sell_token_price: quoted_buy_amount,
             buy_token_price: quoted_sell_amount,
             interactions: Vec::new(),
+            gas_estimate: quote
+                .swaps
+                .iter()
+                .fold(U256::zero(), |acc, _| acc + gas::GAS_PER_BALANCER_SWAP),
         };
 
         if let Some(approval) = self

--- a/crates/solver/src/solver/oneinch_solver.rs
+++ b/crates/solver/src/solver/oneinch_solver.rs
@@ -139,13 +139,16 @@ impl OneInchSolver {
             tracing::debug!("execution does not respect order");
             return Ok(None);
         }
+
         let (sell_token_price, buy_token_price) = (swap.to_token_amount, swap.from_token_amount);
+        let gas_estimate = swap.tx.gas.into();
         interactions.push(Box::new(swap));
 
         Ok(Some(SingleOrderSettlement {
             sell_token_price,
             buy_token_price,
             interactions,
+            gas_estimate,
         }))
     }
 }

--- a/crates/solver/src/solver/paraswap_solver.rs
+++ b/crates/solver/src/solver/paraswap_solver.rs
@@ -119,6 +119,7 @@ impl SingleOrderSolving for ParaswapSolver {
             sell_token_price: price_response.dest_amount,
             buy_token_price: price_response.src_amount,
             interactions: Vec::new(),
+            gas_estimate: price_response.gas_cost.into(),
         };
         if let Some(approval) = self
             .allowance_fetcher

--- a/crates/solver/src/solver/single_order_solver.rs
+++ b/crates/solver/src/solver/single_order_solver.rs
@@ -1,10 +1,8 @@
-use crate::liquidity::LimitOrderExecution;
-
 mod merge;
 
 use {
     crate::{
-        liquidity::{LimitOrder, LimitOrderId},
+        liquidity::{LimitOrder, LimitOrderExecution, LimitOrderId},
         metrics::SolverMetrics,
         settlement::Settlement,
         solver::{Auction, Solver},
@@ -221,6 +219,7 @@ pub struct SingleOrderSettlement {
     pub sell_token_price: U256,
     pub buy_token_price: U256,
     pub interactions: Vec<Box<dyn Interaction>>,
+    pub gas_estimate: U256,
 }
 
 impl SingleOrderSettlement {
@@ -427,6 +426,7 @@ mod tests {
                         4.into(),
                         Bytes(vec![5]),
                     ))],
+                    gas_estimate: U256::zero(),
                 })),
                 OrderKind::Sell => Ok(Some(SingleOrderSettlement {
                     sell_token_price: 6.into(),
@@ -436,6 +436,7 @@ mod tests {
                         9.into(),
                         Bytes(vec![10]),
                     ))],
+                    gas_estimate: U256::zero(),
                 })),
             });
         inner.expect_name().returning(|| "");

--- a/crates/solver/src/solver/zeroex_solver.rs
+++ b/crates/solver/src/solver/zeroex_solver.rs
@@ -159,6 +159,7 @@ impl SingleOrderSolving for ZeroExSolver {
                 sell_token_price: swap.price.buy_amount,
                 buy_token_price: swap.price.sell_amount,
                 interactions: Vec::new(),
+                gas_estimate: swap.price.estimated_gas.into(),
             };
             if let Some(approval) = &approval {
                 settlement.interactions.push(Box::new(*approval));


### PR DESCRIPTION
This PR extends the `SingleOrderSolver` interface to provide a gas estimate along with its single order solution.

### Test Plan

Compiler
