### PR TITLE
Port Partial Fills to Legacy Solver

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3392,6 +3392,7 @@ dependencies = [
  "async-stream",
  "async-trait",
  "atty",
+ "bigdecimal",
  "cached",
  "chrono",
  "clap",

--- a/crates/shared/Cargo.toml
+++ b/crates/shared/Cargo.toml
@@ -13,6 +13,7 @@ anyhow = { workspace = true }
 async-stream = "0.3"
 async-trait = { workspace = true }
 atty = "0.2"
+bigdecimal = { workspace = true }
 cached = { workspace = true }
 chrono = { workspace = true, features = ["clock"] }
 clap = { workspace = true }

--- a/crates/shared/src/arguments.rs
+++ b/crates/shared/src/arguments.rs
@@ -17,6 +17,7 @@ use {
         tenderly_api,
     },
     anyhow::{anyhow, ensure, Context, Result},
+    bigdecimal::BigDecimal,
     ethcontract::{H160, H256, U256},
     model::app_id::AppId,
     std::{
@@ -509,8 +510,10 @@ pub fn duration_from_seconds(s: &str) -> Result<Duration, ParseFloatError> {
     Ok(Duration::from_secs_f64(s.parse()?))
 }
 
-pub fn wei_from_base_unit(s: &str) -> anyhow::Result<U256> {
-    Ok(U256::from_dec_str(s)? * U256::exp10(18))
+pub fn wei_from_ether(s: &str) -> anyhow::Result<U256> {
+    let in_ether = s.parse::<BigDecimal>()?;
+    let base = BigDecimal::new(1.into(), -18);
+    number_conversions::big_decimal_to_u256(&(in_ether * base)).context("invalid Ether value")
 }
 
 pub fn wei_from_gwei(s: &str) -> anyhow::Result<f64> {

--- a/crates/solver/src/arguments.rs
+++ b/crates/solver/src/arguments.rs
@@ -12,6 +12,7 @@ use {
         },
     },
     chrono::{DateTime, Utc},
+    ethcontract::U256,
     primitive_types::H160,
     reqwest::Url,
     shared::{
@@ -275,6 +276,10 @@ pub struct Arguments {
     /// The maximum number of settlements the driver considers per solver.
     #[clap(long, env, default_value = "20")]
     pub max_settlements_per_solver: usize,
+
+    /// The smallest possible amount in Ether to consider for a partial order.
+    #[clap(long, env, default_value = "20", value_parser = shared::arguments::wei_from_ether)]
+    pub smallest_partial_fill: U256,
 
     /// Factor how much of the WETH buffer should be unwrapped if ETH buffer is
     /// not big enough to settle ETH buy orders.

--- a/crates/solver/src/arguments.rs
+++ b/crates/solver/src/arguments.rs
@@ -278,7 +278,7 @@ pub struct Arguments {
     pub max_settlements_per_solver: usize,
 
     /// The smallest possible amount in Ether to consider for a partial order.
-    #[clap(long, env, default_value = "20", value_parser = shared::arguments::wei_from_ether)]
+    #[clap(long, env, default_value = "0.01", value_parser = shared::arguments::wei_from_ether)]
     pub smallest_partial_fill: U256,
 
     /// Factor how much of the WETH buffer should be unwrapped if ETH buffer is

--- a/crates/solver/src/run.rs
+++ b/crates/solver/src/run.rs
@@ -328,6 +328,7 @@ pub async fn run(args: Arguments) {
         order_converter.clone(),
         args.max_settlements_per_solver,
         args.max_merged_settlements,
+        args.smallest_partial_fill,
         &args.slippage,
         market_makable_token_list,
         &args.order_prioritization,

--- a/crates/solver/src/solver.rs
+++ b/crates/solver/src/solver.rs
@@ -305,6 +305,7 @@ pub fn create(
     order_converter: Arc<OrderConverter>,
     max_settlements_per_solver: usize,
     max_merged_settlements: usize,
+    smallest_partial_fill: U256,
     slippage_configuration: &slippage::Arguments,
     market_makable_token_list: AutoUpdatingTokenList,
     order_prioritization_config: &single_order_solver::Arguments,
@@ -378,6 +379,7 @@ pub fn create(
                     max_merged_settlements,
                     max_settlements_per_solver,
                     order_prioritization_config.clone(),
+                    smallest_partial_fill,
                 )
             };
 

--- a/crates/solver/src/solver/single_order_solver.rs
+++ b/crates/solver/src/solver/single_order_solver.rs
@@ -279,13 +279,13 @@ impl SingleOrderSettlement {
         // Compute the surplus fee that needs to be incorporated into the prices
         // and solver fee which will be used for scoring.
         let (surplus_fee, solver_fee) = if order.solver_determines_fee() {
+            let gas_estimate = self.gas_estimate + gas::SETTLEMENT_OVERHEAD;
+            let gas_cost = gas_estimate * U256::from_f64_lossy(gas_price);
+
             let fee = number_conversions::big_rational_to_u256(
                 &prices
                     .try_get_token_amount(
-                        &number_conversions::u256_to_big_rational(
-                            &((self.gas_estimate + gas::SETTLEMENT_OVERHEAD)
-                                * U256::from_f64_lossy(gas_price)),
-                        ),
+                        &number_conversions::u256_to_big_rational(&gas_cost),
                         order.sell_token,
                     )
                     .context("failed to compute solver fee")?,

--- a/crates/solver/src/solver/single_order_solver.rs
+++ b/crates/solver/src/solver/single_order_solver.rs
@@ -359,7 +359,7 @@ impl SingleOrderSettlement {
         for interaction in self.interactions {
             settlement.encoder.append_to_execution_plan(interaction);
         }
-        Ok(Some(dbg!(settlement)))
+        Ok(Some(settlement))
     }
 }
 

--- a/crates/solver/src/solver/single_order_solver/fills.rs
+++ b/crates/solver/src/solver/single_order_solver/fills.rs
@@ -1,0 +1,125 @@
+use {
+    crate::liquidity::LimitOrder,
+    ethcontract::U256,
+    model::order::{OrderKind, OrderUid},
+    num::BigRational,
+    shared::external_prices::ExternalPrices,
+    std::{
+        collections::HashMap,
+        sync::Mutex,
+        time::{Duration, Instant},
+    },
+};
+
+/// Manages the search for a fillable amount for all order types but
+/// specifically for partially fillable orders.
+#[derive(Debug)]
+pub struct Fills {
+    /// Maps which fill amount should be tried next for a given order. For sell
+    /// orders the amount refers to the `sell` asset and for buy orders it
+    /// refers to the `buy` asset.
+    amounts: Mutex<HashMap<OrderUid, CacheEntry>>,
+    /// The smallest value in ETH we consider trying a partially fillable order
+    /// with. If we move below this threshold we'll restart from 100% fill
+    /// amount to not eventually converge at 0.
+    smallest_fill: BigRational,
+}
+
+impl Fills {
+    pub fn new(smallest_fill: U256) -> Self {
+        Self {
+            amounts: Default::default(),
+            smallest_fill: number_conversions::u256_to_big_rational(&smallest_fill),
+        }
+    }
+
+    /// Returns which dex query should be tried for the given order. Takes
+    /// information of previous partial fill attempts into account.
+    pub fn order(&self, order: &LimitOrder, prices: &ExternalPrices) -> Option<LimitOrder> {
+        if !order.partially_fillable {
+            return Some(order.clone());
+        }
+
+        let (token, total_amount) = match order.kind {
+            OrderKind::Buy => (order.buy_token, order.buy_amount),
+            OrderKind::Sell => (order.sell_token, order.sell_amount),
+        };
+
+        let smallest_fill = prices.try_get_token_amount(&self.smallest_fill, token)?;
+        let smallest_fill = number_conversions::big_rational_to_u256(&smallest_fill).ok()?;
+        tracing::trace!(?smallest_fill, "least amount worth filling");
+
+        let now = Instant::now();
+
+        let amount = match self.amounts.lock().unwrap().entry(order.id.order_uid()?) {
+            std::collections::hash_map::Entry::Vacant(entry) => {
+                entry.insert(CacheEntry {
+                    next_amount: total_amount,
+                    last_requested: now,
+                });
+                total_amount
+            }
+            std::collections::hash_map::Entry::Occupied(mut entry) => {
+                let entry = entry.get_mut();
+                entry.last_requested = now;
+
+                if entry.next_amount < smallest_fill {
+                    tracing::trace!("target fill got too small; starting over");
+                    entry.next_amount = total_amount;
+                } else if entry.next_amount > total_amount {
+                    tracing::trace!("partially filled; adjusting to new total amount");
+                    entry.next_amount = total_amount;
+                }
+
+                entry.next_amount
+            }
+        };
+
+        if amount < smallest_fill {
+            tracing::trace!(?amount, "order no longer worth filling");
+            return None;
+        }
+
+        let (sell_amount, buy_amount) = match order.kind {
+            OrderKind::Buy => (order.sell_amount, amount),
+            OrderKind::Sell => (amount, order.buy_amount),
+        };
+
+        tracing::trace!(?amount, "trying to partially fill order");
+        Some(LimitOrder {
+            sell_amount,
+            buy_amount,
+            ..order.clone()
+        })
+    }
+
+    /// Adjusts the next fill amount that should be tried. Always halves the
+    /// last tried amount.
+    // TODO: make use of `price_impact` provided by some APIs to get a more optimal
+    // next try.
+    pub fn reduce_next_try(&self, uid: OrderUid) {
+        self.amounts.lock().unwrap().entry(uid).and_modify(|entry| {
+            entry.next_amount /= 2;
+            tracing::trace!(next_try =? entry.next_amount, "adjusted next fill amount");
+        });
+    }
+
+    /// Removes entries that have not been requested for a long time. This
+    /// allows us to remove orders that got settled by other solvers which
+    /// we are not able to notice.
+    pub fn collect_garbage(&self) {
+        const MAX_AGE: Duration = Duration::from_secs(60 * 10);
+        let now = Instant::now();
+
+        self.amounts
+            .lock()
+            .unwrap()
+            .retain(|_, entry| now.duration_since(entry.last_requested) < MAX_AGE)
+    }
+}
+
+#[derive(Debug)]
+struct CacheEntry {
+    next_amount: U256,
+    last_requested: Instant,
+}

--- a/crates/solver/src/solver/zeroex_solver.rs
+++ b/crates/solver/src/solver/zeroex_solver.rs
@@ -169,7 +169,12 @@ impl SingleOrderSolving for ZeroExSolver {
         };
 
         let Some(settlement) = create_settlement()
-            .into_settlement(auction, &order, order.full_execution_amount())
+            .into_settlement(
+                &order,
+                order.full_execution_amount(),
+                &auction.external_prices,
+                auction.gas_price,
+            )
             .context("into_settlement")?
         else {
             return Ok(None);

--- a/crates/solver/src/solver/zeroex_solver.rs
+++ b/crates/solver/src/solver/zeroex_solver.rs
@@ -168,9 +168,12 @@ impl SingleOrderSolving for ZeroExSolver {
             settlement
         };
 
-        let settlement = create_settlement()
-            .into_settlement(&order)
-            .context("into_settlement")?;
+        let Some(settlement) = create_settlement()
+            .into_settlement(auction, &order, order.full_execution_amount())
+            .context("into_settlement")?
+        else {
+            return Ok(None);
+        };
 
         let gas_price = BigRational::from_float(auction.gas_price).expect("Invalid gas price.");
         let inputs = crate::objective_value::Inputs::from_settlement(


### PR DESCRIPTION
This PR ports some of the logic from the co-located solver into the legacy solver. Namely:
- Managing fills between solver runs
- Computing settlements given a single order settlement and gas price estimates.

Since the math for the latter is quite tricky, I added a unit test to verify things are working as expected.

### Test Plan

Added a unit test. Full partially fillable E2E test coming up.
