### PR TITLE
Port Partial Fills to Legacy Baseline

### DIFF
--- a/crates/solver/src/liquidity/slippage.rs
+++ b/crates/solver/src/liquidity/slippage.rs
@@ -170,6 +170,11 @@ pub struct SlippageContext<'a> {
 }
 
 impl<'a> SlippageContext<'a> {
+    /// Returns the external prices used for the slippage context.
+    pub fn prices(&self) -> &ExternalPrices {
+        self.prices
+    }
+
     /// Computes the slippage amount for the specified token amount.
     pub fn slippage(&self, token: H160, amount: U256) -> Result<SlippageAmount> {
         let (relative, absolute) = self.calculator.compute(

--- a/crates/solver/src/solver/single_order_solver.rs
+++ b/crates/solver/src/solver/single_order_solver.rs
@@ -359,7 +359,7 @@ impl SingleOrderSettlement {
         for interaction in self.interactions {
             settlement.encoder.append_to_execution_plan(interaction);
         }
-        Ok(Some(settlement))
+        Ok(Some(dbg!(settlement)))
     }
 }
 

--- a/crates/solver/src/solver/single_order_solver.rs
+++ b/crates/solver/src/solver/single_order_solver.rs
@@ -359,7 +359,7 @@ impl SingleOrderSettlement {
         for interaction in self.interactions {
             settlement.encoder.append_to_execution_plan(interaction);
         }
-        Ok(Some(dbg!(settlement)))
+        Ok(Some(settlement))
     }
 }
 

--- a/crates/solvers/src/domain/solver/baseline.rs
+++ b/crates/solvers/src/domain/solver/baseline.rs
@@ -90,20 +90,22 @@ impl Baseline {
             1
         };
 
-        (0..n).map(move |i| {
-            let divisor = U256::one() << i;
-            Request {
-                sell: eth::Asset {
-                    token: sell.token,
-                    amount: sell.amount / divisor,
-                },
-                buy: eth::Asset {
-                    token: buy.token,
-                    amount: buy.amount / divisor,
-                },
-                side,
-            }
-        })
+        (0..n)
+            .map(move |i| {
+                let divisor = U256::one() << i;
+                Request {
+                    sell: eth::Asset {
+                        token: sell.token,
+                        amount: sell.amount / divisor,
+                    },
+                    buy: eth::Asset {
+                        token: buy.token,
+                        amount: buy.amount / divisor,
+                    },
+                    side,
+                }
+            })
+            .filter(|r| !r.sell.amount.is_zero() && !r.buy.amount.is_zero())
     }
 }
 


### PR DESCRIPTION
This PR ports the changes from #1390 to the legacy baseline solver.

### Test Plan

Existing baseline solver tests (unit and E2E) continue to pass, so nothing appears to be broken. E2E in a follow up PR.
