### PR TITLE
Clear Tx Pool after success

### DIFF
--- a/crates/solver/src/settlement_submission.rs
+++ b/crates/solver/src/settlement_submission.rs
@@ -115,6 +115,10 @@ impl SubTxPoolRef {
             .pools
             .insert((sender, nonce), transactions);
     }
+
+    pub fn clear(&self) {
+        self.pools.lock().unwrap()[self.index].pools.clear();
+    }
 }
 
 pub struct SubmissionReceipt {

--- a/crates/solver/src/settlement_submission/submitter.rs
+++ b/crates/solver/src/settlement_submission/submitter.rs
@@ -330,6 +330,11 @@ impl<'a> Submitter<'a> {
                 {
                     tracing::debug!("found mined transaction {:?}", receipt.transaction_hash);
                     track_mined_transactions(&format!("{name}"));
+                    // No need to keep submitted transactions for next auction if tx was found.
+                    // This also protects against reorgs where mined tx is found in one auction but
+                    // the block gets reorged and the tx is again found in the
+                    // next auction.
+                    self.submitted_transactions.clear();
                     return status(receipt);
                 }
                 if Instant::now() + MINED_TX_CHECK_INTERVAL > tx_to_propagate_deadline {


### PR DESCRIPTION
Related to https://cowservices.slack.com/archives/C0361CDD1FZ/p1679661683338699 (last comment summaries the investigation).

In case the tx was mined and found in a first loop, there is no need to keep the internal pool transactions for the next loop.

This PR does not fix the reorg issue, however it does improve the code to the certain point.


