### PR TITLE
CIP20: Filter out too high scores

### DIFF
--- a/crates/shared/src/http_solver/model.rs
+++ b/crates/shared/src/http_solver/model.rs
@@ -376,6 +376,18 @@ pub enum SolverRejectionReason {
     /// The solution doesn't have a positive score. Currently this can happen
     /// only if the objective value is negative.
     NonPositiveScore,
+
+    /// The solution has a score that is too high. This can happen if the
+    /// score is higher than the maximum score (surplus + fees)
+    #[serde(rename_all = "camelCase")]
+    TooHighScore {
+        #[serde(with = "u256_decimal")]
+        surplus: U256,
+        #[serde(with = "u256_decimal")]
+        fees: U256,
+        #[serde(with = "u256_decimal")]
+        max_score: U256,
+    },
 }
 
 #[derive(Debug, Serialize)]
@@ -1099,6 +1111,25 @@ mod tests {
             .unwrap(),
             json!({
                 "nonBufferableTokensUsed": ["0x0000000000000000000000000000000000000001", "0x0000000000000000000000000000000000000002"],
+            }),
+        );
+    }
+
+    #[test]
+    fn serialize_rejection_too_high_score() {
+        assert_eq!(
+            serde_json::to_value(&SolverRejectionReason::TooHighScore {
+                surplus: 1300.into(),
+                fees: 37.into(),
+                max_score: 1337.into()
+            })
+            .unwrap(),
+            json!({
+                "tooHighScore": {
+                    "surplus": "1300",
+                    "fees": "37",
+                    "maxScore": "1337",
+                },
             }),
         );
     }

--- a/crates/shared/src/http_solver/model.rs
+++ b/crates/shared/src/http_solver/model.rs
@@ -387,6 +387,8 @@ pub enum SolverRejectionReason {
         fees: U256,
         #[serde(with = "u256_decimal")]
         max_score: U256,
+        #[serde(with = "u256_decimal")]
+        submitted_score: U256,
     },
 }
 
@@ -1121,7 +1123,8 @@ mod tests {
             serde_json::to_value(&SolverRejectionReason::TooHighScore {
                 surplus: 1300.into(),
                 fees: 37.into(),
-                max_score: 1337.into()
+                max_score: 1337.into(),
+                submitted_score: 1338.into(),
             })
             .unwrap(),
             json!({
@@ -1129,6 +1132,7 @@ mod tests {
                     "surplus": "1300",
                     "fees": "37",
                     "maxScore": "1337",
+                    "submittedScore": "1338",
                 },
             }),
         );

--- a/crates/solver/src/settlement_ranker.rs
+++ b/crates/solver/src/settlement_ranker.rs
@@ -9,9 +9,11 @@ use {
     },
     anyhow::Result,
     chrono::{DateTime, Utc},
+    ethcontract::U256,
     gas_estimation::GasPrice1559,
     model::auction::AuctionId,
     num::{rational::Ratio, BigInt, BigRational, CheckedDiv, FromPrimitive},
+    number_conversions::big_rational_to_u256,
     rand::prelude::SliceRandom,
     shared::{
         external_prices::ExternalPrices,
@@ -205,6 +207,32 @@ impl SettlementRanker {
                     self.metrics.settlement_non_positive_score(solver.name());
                 }
                 positive_score
+            });
+        }
+
+        // Filter out settlements with too high score.
+        if Utc::now() > self.auction_rewards_activation_timestamp {
+            // CIP20 activated
+            rated_settlements.retain(|(solver, settlement, _)| {
+                let surplus = big_rational_to_u256(&settlement.surplus).unwrap_or(U256::MAX);
+                let fees = big_rational_to_u256(&settlement.solver_fees).unwrap_or(U256::MAX);
+                let max_score = surplus.saturating_add(fees);
+                let valid_score = settlement.score.score() < max_score;
+                if !valid_score {
+                    tracing::debug!(
+                        solver_name = %solver.name(),
+                        "settlement filtered for having too high score",
+                    );
+                    solver.notify_auction_result(
+                        auction_id,
+                        AuctionResult::Rejected(SolverRejectionReason::TooHighScore {
+                            surplus,
+                            fees,
+                            max_score,
+                        }),
+                    );
+                }
+                valid_score
             });
         }
 

--- a/crates/solver/src/settlement_ranker.rs
+++ b/crates/solver/src/settlement_ranker.rs
@@ -229,6 +229,7 @@ impl SettlementRanker {
                             surplus,
                             fees,
                             max_score,
+                            submitted_score: settlement.score.score(),
                         }),
                     );
                 }


### PR DESCRIPTION
Solver team decided to filter out the scores that are too high (breaking the social consensus).

Whole explanation can be read here https://cowservices.slack.com/archives/C035N0YEB6J/p1680111646093119
