### PR TITLE
Increase partial fill attempt after success

### DIFF
--- a/crates/solver/src/solver/single_order_solver.rs
+++ b/crates/solver/src/solver/single_order_solver.rs
@@ -176,7 +176,13 @@ impl SingleOrderSolver {
                 )
                 .transpose()
         }) {
-            Some(Ok(settlement)) => SolveResult::Solved(settlement),
+            Some(Ok(settlement)) => {
+                if let Some(order_uid) = order.id.order_uid() {
+                    // Maybe some liquidity appeared that enables a bigger fill.
+                    self.fills.increase_next_try(order_uid);
+                }
+                SolveResult::Solved(settlement)
+            }
             Some(Err(err)) => {
                 tracing::warn!(%name, ?err, "encoding error");
                 SolveResult::Failed

--- a/crates/solver/src/solver/single_order_solver/fills.rs
+++ b/crates/solver/src/solver/single_order_solver/fills.rs
@@ -55,12 +55,14 @@ impl Fills {
                 entry.insert(CacheEntry {
                     next_amount: total_amount,
                     last_requested: now,
+                    total_amount,
                 });
                 total_amount
             }
             std::collections::hash_map::Entry::Occupied(mut entry) => {
                 let entry = entry.get_mut();
                 entry.last_requested = now;
+                entry.total_amount = total_amount;
 
                 if entry.next_amount < smallest_fill {
                     tracing::trace!(
@@ -103,7 +105,21 @@ impl Fills {
     pub fn reduce_next_try(&self, uid: OrderUid) {
         self.amounts.lock().unwrap().entry(uid).and_modify(|entry| {
             entry.next_amount /= 2;
-            tracing::trace!(next_try =? entry.next_amount, "adjusted next fill amount");
+            tracing::trace!(next_try =? entry.next_amount, "decreased next fill amount");
+        });
+    }
+
+    /// Adjusts the next fill amount that should be tried. Doubles the amount to
+    /// try. This is useful in case the onchain liquidity changed and now
+    /// allows for bigger fills.
+    pub fn increase_next_try(&self, uid: OrderUid) {
+        self.amounts.lock().unwrap().entry(uid).and_modify(|entry| {
+            entry.next_amount = entry
+                .next_amount
+                .checked_mul(2.into())
+                .unwrap_or(entry.total_amount)
+                .min(entry.total_amount);
+            tracing::trace!(next_try =? entry.next_amount, "increased next fill amount");
         });
     }
 
@@ -125,4 +141,5 @@ impl Fills {
 struct CacheEntry {
     next_amount: U256,
     last_requested: Instant,
+    total_amount: U256,
 }

--- a/crates/solvers/src/domain/solver/dex/solver.rs
+++ b/crates/solvers/src/domain/solver/dex/solver.rs
@@ -94,12 +94,16 @@ impl Dex {
             tracing::warn!(token = ?order.sell.token.0, "missing sell token price");
             return None;
         };
+        let uid = order.uid;
         let Some(solution) = swap.into_solution(order, gas, sell) else {
             tracing::debug!("no solution for swap");
             return None;
         };
 
         tracing::debug!("solved");
+        // Maybe some liquidity appeared that enables a bigger fill.
+        self.fills.increase_next_try(uid);
+
         Some(solution)
     }
 }


### PR DESCRIPTION
It's possible that a partially fillable order can only be solved for a small portion with the given liquidity. We'll try lower and lower amounts until we eventually find that fill amount. If then some big trade happens on-chain which lowers the price on a key liquidity pool it could be that a way bigger partial fill is then possible.
In order to find out we need to increase the tried fill amount after a successful attempt. This was originally suggested by @fedgiac [here](https://github.com/cowprotocol/services/pull/1358#pullrequestreview-1354254330).

One unfortunate thing is that this also causes us to flip-flop between finding some solution and finding no solution in case no new liquidity appeared and we just happened to find the biggest possible fill amount. I hope this is not a huge problem, though.

### Test Plan
Adjusted e2e test in the `solvers` crate
