### PR TITLE
Filter out partially fillable limit orders in NaiveSolver

### DIFF
--- a/crates/solver/src/solver/naive_solver.rs
+++ b/crates/solver/src/solver/naive_solver.rs
@@ -36,12 +36,15 @@ impl Solver for NaiveSolver {
     async fn solve(
         &self,
         Auction {
-            orders,
+            mut orders,
             liquidity,
             external_prices,
             ..
         }: Auction,
     ) -> Result<Vec<Settlement>> {
+        // Filter out partially fillable limit orders until we add support for computing
+        // a reasonable `solver_fee` (#1414).
+        orders.retain(|o| !o.solver_determines_fee());
         let slippage = self.slippage_calculator.context(&external_prices);
         let uniswaps = extract_deepest_amm_liquidity(&liquidity);
         Ok(settle(slippage, orders, uniswaps))


### PR DESCRIPTION
Filters out partially fillable limit orders in the `NaiveSolver` until we properly support computing a reasonable `solver_fee` for them. Discussed in [here](https://cowservices.slack.com/archives/C0361CDD1FZ/p1680600757352139?thread_ts=1680598458.372809&cid=C0361CDD1FZ) and tracked in #1414.

### Test Plan
compiler
