### PR TITLE
Do not update surplus fee of partially fillable orders

### DIFF
--- a/crates/database/src/orders.rs
+++ b/crates/database/src/orders.rs
@@ -676,6 +676,7 @@ pub async fn update_fok_limit_order_fees(
             sell_token = $4
             AND buy_token = $5
             AND sell_amount = $6
+            AND NOT partially_fillable
         RETURNING
             uid
     ";


### PR DESCRIPTION
We noticed a partially fillable [order](https://barn.api.cow.fi/mainnet/api/v1/orders/0x514a80473dc24034a1983ec831603f2f100ad7defd1578b077c637f73f3b92ecffab14b181409170378471b13ff2bff5be012c646434b605) had a surplus fee set, which confused a solver. The reason is that the code that updates FOK limit order surplus fees together didn't filter out partially fillable orders.

### Test Plan

did not adjust test