### PR TITLE
Configured k8s-autodeploy on the new CoW staging cluster

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -55,20 +55,20 @@ jobs:
       - uses: cowprotocol/autodeploy-action@v1
         if: ${{ github.ref == 'refs/heads/main' }}
         with:
-          pods: "dfusion-v2-autopilot-goerli,\
-                 dfusion-v2-api-goerli,\
-                 dfusion-v2-solver-goerli,\
-                 dfusion-v2-refunder-goerli,\
-                 dfusion-v2-autopilot-mainnet,\
-                 dfusion-v2-api-mainnet,\
-                 dfusion-v2-solver-mainnet,\
-                 dfusion-v2-refunder-mainnet,\
-                 dfusion-v2-autopilot-xdai,\
-                 dfusion-v2-api-xdai,\
-                 dfusion-v2-solver-xdai,\
-                 dfusion-v2-refunder-xdai,\
-                 dfusion-v2-solver-shadow,\
-                 dfusion-v2-alerter-mainnet"
+          pods:
+                "goerli-api-staging,\
+                goerli-autopilot-staging,\
+                goerli-refunder-staging,\
+                goerli-solver-staging,\
+                mainnet-api-staging,\
+                mainnet-autopilot-staging,\
+                mainnet-refunder-staging,\
+                mainnet-solver-staging,\
+                shadow-solver,\
+                xdai-api-staging,\
+                xdai-autopilot-staging,\
+                xdai-refunder-staging,\
+                xdai-solver-staging"
           tag: ${{ secrets.AUTODEPLOY_TAG }}
           url: ${{ secrets.AUTODEPLOY_URL }}
           token: ${{ secrets.AUTODEPLOY_TOKEN }}


### PR DESCRIPTION
Fixes k8s-autodeployer URL so we can automatically deploy new images on the new CoW staging cluster.

I've changed the deployment names ("pods" - will probably add/remove in the future) and webhook (now secrets.AUTODEPLOY_URL="https://auto.barn.cow.fi").
The k8s-autodeploy is up & running on the new CoW staging cluster. secrets.AUTODEPLOY_TOKEN remains unchanged.

### Test Plan

I've tested as extensively as possible locally with `act` and it works as expected. It would be great if we could do a dry-run with a newly built image and see if it actually restarts the deployments.

### Release notes

Nothing new, just configs.