### PR TITLE
Update OpenAPI solver competition path

### DIFF
--- a/crates/orderbook/openapi.yml
+++ b/crates/orderbook/openapi.yml
@@ -393,6 +393,10 @@ components:
       description: A big unsigned integer encoded in decimal.
       type: string
       example: "1234567890"
+    CallData:
+      description: Data sent to a contract in a transaction encoded as a hex with `0x` prefix.
+      type: string
+      example: "0xca11da7a"
     TokenAmount:
       description: Amount of a token. uint256 encoded in decimal.
       type: string
@@ -679,14 +683,29 @@ components:
           description: |
             The solvable orders included in the auction.
         prices:
-          type: object
-          additionalProperties:
-            $ref: "#/components/schemas/BigUint"
+          $ref: "#/components/schemas/AuctionPrices"
+    CompetitionAuction:
+      description: |
+        The components that describe a batch auction for the solver competition.
+      type: object
+      properties:
+        orders:
+          type: array
+          items:
+            $ref: "#/components/schemas/UID"
           description: |
-            The reference prices for all traded tokens in the auction as a mapping from token
-            addresses to a price denominated in native token (i.e. 1e18 represents a token that
-            trades one to one with the native token). These prices are used for solution competition
-            for computing surplus and converting fees to native token.
+            The uids of the orders included in the auction.
+        prices:
+          $ref: "#/components/schemas/AuctionPrices"
+    AuctionPrices:
+      description: |
+        The reference prices for all traded tokens in the auction as a mapping from token
+        addresses to a price denominated in native token (i.e. 1e18 represents a token that
+        trades one to one with the native token). These prices are used for solution competition
+        for computing surplus and converting fees to native token.
+      type: object
+      additionalProperties:
+        $ref: "#/components/schemas/BigUint"
     OrderCancellations:
       description: |
         EIP-712 signature of struct OrderCancellations { orderUid: bytes[] } from the order's owner
@@ -782,6 +801,8 @@ components:
         Bytes 0 to 32 are the order digest, bytes 30 to 52 the owner address
         and bytes 52..56 valid to,
       type: string
+      # ENS order
+      example: "0xff2e2e54d178997f173266817c1e9ed6fee1a1aae4b43971c53b543cffcc2969845c6f5599fbb25dbdd1b9b013daf85c03f3c63763e4bc4a"
     SigningScheme:
       description: How was the order signed?
       type: string
@@ -1074,6 +1095,8 @@ components:
           type: integer
         competitionSimulationBlock:
           type: integer
+        auction:
+          $ref: "#/components/schemas/CompetitionAuction"
         solutions:
           type: array
           description: Maps from solver name to object describing that solver's settlement.
@@ -1085,6 +1108,11 @@ components:
         solver:
           type: string
           description: name of the solver
+        solverAddress:
+          type: string
+          description: |
+            The address used by the solver to execute the settlement onchain.
+            This field is missing for old settlements, the zero address has been used instead.
         objective:
           type: object
           properties:
@@ -1099,7 +1127,14 @@ components:
               type: number
             gas:
               type: integer
-        prices:
+        score:
+          allOf:
+            - $ref: "#/components/schemas/BigUint"
+          description: |
+            The score of the current auction as defined in CIP-20.
+            It is null for old auctions.
+          nullable: true
+        clearingPrices:
           type: object
           additionalProperties:
             $ref: "#/components/schemas/BigUint"
@@ -1116,8 +1151,16 @@ components:
               executedAmount:
                 $ref: "#/components/schemas/BigUint"
         callData:
-          description: hex encoded transaction calldata
-          type: string
+          allOf:
+            - $ref: "#/components/schemas/CallData"
+          description: Transaction call data that is executed onchain if the settlement is executed.
+        uninternalizedCallData:
+          allOf:
+            - $ref: "#/components/schemas/CallData"
+          description: |
+            Full call data as generated from the original solver output.
+            It can be different from the executed transaction if part of the settlements are internalized (use internal liquidity in lieu of trading against onchain liquidity).
+            This field is omitted in case it coincides with callData.
     VersionResponse:
       description: |
         The version of the codebase that is currently running.


### PR DESCRIPTION
I've noticed that the solver competition path is outdated and I tried to fill in the blanks.

### Test Plan

Double check that my changes match the code.

You can plop `crates/orderbook/openapi.yml` into [this website](https://editor.swagger.io/) to see the new changes.

<details><summary>Resulting schema</summary>

![image](https://user-images.githubusercontent.com/58218759/232026156-f5601fcb-d6cc-4d54-bbfd-16b9d5e5099b.png)
</details>