### PR TITLE
Fix missing descriptions from OpenApi schema

### DIFF
--- a/crates/driver/openapi.yml
+++ b/crates/driver/openapi.yml
@@ -164,7 +164,7 @@ components:
         preInteractions:
           type: array
           items:
-            $ref: '#/components/schemas/Interaction'
+            $ref: "#/components/schemas/Interaction"
         sellTokenBalance:
           type: string
           enum: ["erc20", "internal", "external"]
@@ -216,31 +216,31 @@ components:
           $ref: "#/components/schemas/TokenAmount"
     QuoteResponse:
       anyOf:
-      - description: |
-          Successful Quote
+        - description: |
+            Successful Quote
 
-          The Solver knows how to fill the request with these parameters.
+            The Solver knows how to fill the request with these parameters.
 
-          If the request was of type `buy` then the response's buy amount has the same value as the
-          request's amount and the sell amount was filled in by the server. Vice versa for type
-          `sell`.
-        type: object
-        properties:
-          sellAmount:
-            $ref: "#/components/schemas/TokenAmount"
-          buyAmount:
-            $ref: "#/components/schemas/TokenAmount"
-          gas:
-            type: integer
-      - description: |
-          Unfillable Quote
+            If the request was of type `buy` then the response's buy amount has the same value as the
+            request's amount and the sell amount was filled in by the server. Vice versa for type
+            `sell`.
+          type: object
+          properties:
+            sellAmount:
+              $ref: "#/components/schemas/TokenAmount"
+            buyAmount:
+              $ref: "#/components/schemas/TokenAmount"
+            gas:
+              type: integer
+        - description: |
+            Unfillable Quote
 
-          This is not an error. The server handled the request correctly but could not create a
-          quote. For example, this Solver might not be aware of any liquidity between the tokens.
-        type: object
-        properties:
-          unfillableReason:
-            type: string
+            This is not an error. The server handled the request correctly but could not create a
+            quote. For example, this Solver might not be aware of any liquidity between the tokens.
+          type: object
+          properties:
+            unfillableReason:
+              type: string
     SolveRequest:
       description: Request to the solve endpoint.
       type: object
@@ -344,12 +344,12 @@ components:
                 description: Mapping of hex token address to amount.
                 type: object
                 additionalProperties:
-                    $ref: "#/components/schemas/TokenAmount"
+                  $ref: "#/components/schemas/TokenAmount"
               outputs:
                 description: Mapping of token address to amount.
                 type: object
                 additionalProperties:
-                    $ref: "#/components/schemas/TokenAmount"
+                  $ref: "#/components/schemas/TokenAmount"
         calldata:
           description: hex encoded
           type: string

--- a/crates/driver/openapi.yml
+++ b/crates/driver/openapi.yml
@@ -117,7 +117,8 @@ components:
         address:
           $ref: "#/components/schemas/Address"
         price:
-          $ref: "#/components/schemas/TokenAmount"
+          allOf:
+            - $ref: "#/components/schemas/TokenAmount"
           description: |
             The reference price denominated in native token (i.e. 1e18 represents a token that
             trades one to one with the native token). These prices are used for solution competition
@@ -174,7 +175,8 @@ components:
           type: string
           enum: ["market", "limit", "liquidity"]
         surplusFee:
-          $ref: "#/components/schemas/TokenAmount"
+          allOf:
+            - $ref: "#/components/schemas/TokenAmount"
           nullable: true
         appData:
           description: 32 bytes encoded as hex with `0x` prefix.

--- a/crates/orderbook/openapi.yml
+++ b/crates/orderbook/openapi.yml
@@ -409,7 +409,8 @@ components:
               If orders are placed as onchain orders, the owner of the order might
               be a smart contract, but not the user placing the order. The
               actual user will be provided in this field
-          $ref: "#/components/schemas/Address"
+          allOf:
+            - $ref: "#/components/schemas/Address"
         placementError:
           description: |
               Describes the error, if the order placement was not
@@ -428,7 +429,8 @@ components:
           description: |
             Specifies in which transaction the order was refunded. If
             this field is null the order was not yet refunded.
-          $ref: "#/components/schemas/TransactionHash"
+          allOf:
+            - $ref: "#/components/schemas/TransactionHash"
           nullable: true
         userValidTo:
           description: |
@@ -471,22 +473,27 @@ components:
       properties:
         sellToken:
           description: "ERC20 token to be sold"
-          $ref: "#/components/schemas/Address"
+          allOf:
+            - $ref: "#/components/schemas/Address"
         buyToken:
           description: "ERC20 token to be bought"
-          $ref: "#/components/schemas/Address"
+          allOf:
+            - $ref: "#/components/schemas/Address"
         receiver:
           description: |
             An optional address to receive the proceeds of the trade instead of the
             owner (i.e. the order signer).
-          $ref: "#/components/schemas/Address"
+          allOf:
+            - $ref: "#/components/schemas/Address"
           nullable: true
         sellAmount:
           description: "Amount of sellToken to be sold in atoms"
-          $ref: "#/components/schemas/TokenAmount"
+          allOf:
+            - $ref: "#/components/schemas/TokenAmount"
         buyAmount:
           description: "Amount of buyToken to be bought in atoms"
-          $ref: "#/components/schemas/TokenAmount"
+          allOf:
+            - $ref: "#/components/schemas/TokenAmount"
         validTo:
           description: Unix timestamp until the order is valid. uint32.
           type: integer
@@ -496,24 +503,30 @@ components:
             also be used to ensure uniqueness between two orders with otherwise the
             exact same parameters.
           type: string
-          $ref: "#/components/schemas/AppData"
+          allOf:
+            - $ref: "#/components/schemas/AppData"
         feeAmount:
           description: "Fees: feeRatio * sellAmount + minimal_fee in atoms"
-          $ref: "#/components/schemas/TokenAmount"
+          allOf:
+            - $ref: "#/components/schemas/TokenAmount"
         kind:
           description: "The kind is either a buy or sell order"
-          $ref: "#/components/schemas/OrderKind"
+          allOf:
+            - $ref: "#/components/schemas/OrderKind"
         partiallyFillable:
           description: Is this a fill-or-kill order or a partially fillable order?
           type: boolean
         sellTokenBalance:
-          $ref: "#/components/schemas/SellTokenSource"
+          allOf:
+            - $ref: "#/components/schemas/SellTokenSource"
           default: "erc20"
         buyTokenBalance:
-          $ref: "#/components/schemas/BuyTokenDestination"
+          allOf:
+            - $ref: "#/components/schemas/BuyTokenDestination"
           default: "erc20"
         signingScheme:
-          $ref: "#/components/schemas/SigningScheme"
+          allOf:
+            - $ref: "#/components/schemas/SigningScheme"
           default: "eip712"
       required:
         - sellToken
@@ -541,7 +554,8 @@ components:
                 the signature. This helps catch errors with invalid signature encodings as the backend
                 might otherwise silently work with an unexpected address that for example does not have
                 any balance.
-              $ref: "#/components/schemas/Address"
+              allOf:
+                - $ref: "#/components/schemas/Address"
               nullable: true
             quoteId:
               description: |
@@ -570,30 +584,37 @@ components:
           $ref: "#/components/schemas/UID"
         availableBalance:
           description: Unused field that is currently always set to null and will be removed in the future.
-          $ref: "#/components/schemas/TokenAmount"
+          allOf:
+            - $ref: "#/components/schemas/TokenAmount"
           nullable: true
           deprecated: true
         executedSellAmount:
           description: "The total amount of sellToken that has been executed for this order including fees."
-          $ref: "#/components/schemas/BigUint"
+          allOf:
+            - $ref: "#/components/schemas/BigUint"
         executedSellAmountBeforeFees:
           description: "The total amount of sellToken that has been executed for this order without fees."
-          $ref: "#/components/schemas/BigUint"
+          allOf:
+            - $ref: "#/components/schemas/BigUint"
         executedBuyAmount:
           description: "The total amount of buyToken that has been executed for this order."
-          $ref: "#/components/schemas/BigUint"
+          allOf:
+            - $ref: "#/components/schemas/BigUint"
         executedFeeAmount:
           description: "The total amount of fees that have been executed for this order."
-          $ref: "#/components/schemas/BigUint"
+          allOf:
+            - $ref: "#/components/schemas/BigUint"
         invalidated:
           description: Has this order been invalidated?
           type: boolean
         status:
           description: Order status
-          $ref: "#/components/schemas/OrderStatus"
+          allOf:
+            - $ref: "#/components/schemas/OrderStatus"
         fullFeeAmount:
           description: "Amount that the signed fee would be without subsidies"
-          $ref: "#/components/schemas/TokenAmount"
+          allOf:
+            - $ref: "#/components/schemas/TokenAmount"
         isLiquidityOrder:
           description: |
             Liquidity orders are functionally the same as normal smart contract orders but are not
@@ -608,20 +629,24 @@ components:
           description: |
             For ethflow orders - order that are placed onchain with native eth -, this field
             contains a struct with two variables user_valid_to and is_refunded
-          $ref: "#/components/schemas/EthflowData"
+          allOf:
+            - $ref: "#/components/schemas/EthflowData"
         onchainUser:
           description: |
             This represents the actual trader of an on-chain order.
             In that case, the owner would be the EthFlow contract in the case of EthFlow orders and not the actual trader.
-          $ref: "#/components/schemas/Address"
+          allOf:
+            - $ref: "#/components/schemas/Address"
         onchainOrderData:
           description: |
             There is some data only available for orders that are placed onchain. This data
             can be found in this object
-          $ref: "#/components/schemas/OnchainOrderData"
+          allOf:
+            - $ref: "#/components/schemas/OnchainOrderData"
         executedSurplusFee:
           description: "Surplus fee that the limit order was executed with."
-          $ref: "#/components/schemas/BigUint"
+          allOf:
+            - $ref: "#/components/schemas/BigUint"
           nullable: true
       required:
         - creationDate
@@ -701,9 +726,11 @@ components:
             $ref: "#/components/schemas/UID"
         signature:
           description: "OrderCancellation signed by owner"
-          $ref: "#/components/schemas/EcdsaSignature"
+          allOf:
+            - $ref: "#/components/schemas/EcdsaSignature"
         signingScheme:
-          $ref: "#/components/schemas/EcdsaSigningScheme"
+          allOf:
+            - $ref: "#/components/schemas/EcdsaSigningScheme"
       required:
         - signature
         - signingScheme
@@ -714,7 +741,8 @@ components:
       properties:
         signature:
           description: "OrderCancellation signed by owner"
-          $ref: "#/components/schemas/EcdsaSignature"
+          allOf:
+            - $ref: "#/components/schemas/EcdsaSignature"
         signingScheme:
           $ref: "#/components/schemas/EcdsaSigningScheme"
       required:
@@ -733,28 +761,36 @@ components:
           type: integer
         orderUid:
           description: "Unique ID of the order matched by this trade."
-          $ref: "#/components/schemas/UID"
+          allOf:
+            - $ref: "#/components/schemas/UID"
         owner:
           description: "Address of trader."
-          $ref: "#/components/schemas/Address"
+          allOf:
+            - $ref: "#/components/schemas/Address"
         sellToken:
           description: "Address of token sold."
-          $ref: "#/components/schemas/Address"
+          allOf:
+            - $ref: "#/components/schemas/Address"
         buyToken:
           description: "Address of token bought."
-          $ref: "#/components/schemas/Address"
+          allOf:
+            - $ref: "#/components/schemas/Address"
         sellAmount:
           description: "Total amount of sellToken that has been executed for this trade (including fees)."
-          $ref: "#/components/schemas/TokenAmount"
+          allOf:
+            - $ref: "#/components/schemas/TokenAmount"
         sellAmountBeforeFees:
           description: "The total amount of sellToken that has been executed for this order without fees."
-          $ref: "#/components/schemas/BigUint"
+          allOf:
+            - $ref: "#/components/schemas/BigUint"
         buyAmount:
           description: "Total amount of buyToken received in this trade."
-          $ref: "#/components/schemas/TokenAmount"
+          allOf:
+            - $ref: "#/components/schemas/TokenAmount"
         txHash:
           description: "Hash of the corresponding settlement transaction containing the trade (if available)."
-          $ref: "#/components/schemas/TransactionHash"
+          allOf:
+            - $ref: "#/components/schemas/TransactionHash"
           nullable: true
       required:
         - blockNumber
@@ -912,7 +948,8 @@ components:
               description: |
                 The total amount that is available for the order. From this value, the fee
                 is deducted and the buy amount is calculated.
-              $ref: "#/components/schemas/TokenAmount"
+              allOf:
+              - $ref: "#/components/schemas/TokenAmount"
           required:
             - kind
             - sellAmountBeforeFee
@@ -924,7 +961,8 @@ components:
               enum: [sell]
             sellAmountAfterFee:
               description: The sell amount for the order.
-              $ref: "#/components/schemas/TokenAmount"
+              allOf:
+                - $ref: "#/components/schemas/TokenAmount"
           required:
             - kind
             - sellAmountAfterFee
@@ -936,7 +974,8 @@ components:
               enum: [buy]
             buyAmountAfterFee:
               description: The buy amount for the order.
-              $ref: "#/components/schemas/TokenAmount"
+              allOf:
+                - $ref: "#/components/schemas/TokenAmount"
           required:
             - kind
             - buyAmountAfterFee
@@ -964,38 +1003,46 @@ components:
           properties:
             sellToken:
               description: "ERC20 token to be sold"
-              $ref: "#/components/schemas/Address"
+              allOf:
+                - $ref: "#/components/schemas/Address"
             buyToken:
               description: "ERC20 token to be bought"
-              $ref: "#/components/schemas/Address"
+              allOf:
+                - $ref: "#/components/schemas/Address"
             receiver:
               description: |
                 An optional address to receive the proceeds of the trade instead of the
                 owner (i.e. the order signer).
-              $ref: "#/components/schemas/Address"
+              allOf:
+                - $ref: "#/components/schemas/Address"
               nullable: true
             appData:
               description: |
                 Arbitrary application specific data that can be added to an order. This can
                 also be used to ensure uniqueness between two orders with otherwise the
                 exact same parameters.
-              $ref: "#/components/schemas/AppData"
+              allOf:
+                - $ref: "#/components/schemas/AppData"
             partiallyFillable:
               description: Is this a fill-or-kill order or a partially fillable order?
               type: boolean
             sellTokenBalance:
-              $ref: "#/components/schemas/SellTokenSource"
+              allOf:
+                - $ref: "#/components/schemas/SellTokenSource"
               default: "erc20"
             buyTokenBalance:
-              $ref: "#/components/schemas/BuyTokenDestination"
+              allOf:
+                - $ref: "#/components/schemas/BuyTokenDestination"
               default: "erc20"
             from:
               $ref: "#/components/schemas/Address"
             priceQuality:
-              $ref: "#/components/schemas/PriceQuality"
+              allOf:
+                - $ref: "#/components/schemas/PriceQuality"
               default: "optimal"
             signingScheme:
-              $ref: "#/components/schemas/SigningScheme"
+              allOf:
+                - $ref: "#/components/schemas/SigningScheme"
               default: "eip712"
             onchainOrder:
               description: "Flag to signal whether the order is intended for onchain order placement. Only valid for non ECDSA-signed orders"

--- a/crates/orderbook/openapi.yml
+++ b/crates/orderbook/openapi.yml
@@ -439,23 +439,6 @@ components:
       required:
         - refundTxHash
         - userValidTo
-    FeeInformation:
-      description: |
-        Provides the information to calculate the fees.
-      type: object
-      properties:
-        expiration:
-          description: |
-            Expiration date of the offered fee. Order service might not accept
-            the fee after this expiration date. Encoded as ISO 8601 UTC.
-          type: string
-          example: "2020-12-03T18:35:18.814523Z"
-        amount:
-          description: Absolute amount of fee charged per order in specified sellToken
-          $ref: "#/components/schemas/TokenAmount"
-      required:
-        - expiration
-        - amount
     OrderKind:
       description: Is this a buy order or sell order?
       type: string
@@ -737,17 +720,6 @@ components:
       required:
         - signature
         - signingScheme
-    AmountEstimate:
-      description: |
-        Provides the information about an estimated price.
-      type: object
-      properties:
-        amount:
-          description: The estimated amount
-          $ref: "#/components/schemas/TokenAmount"
-        token:
-          description: "The token in which the amount is given"
-          $ref: "#/components/schemas/Address"
     Trade:
       description: |
         Trade data such as executed amounts, fees, order id and block number.
@@ -910,22 +882,6 @@ components:
       required:
         - errorType
         - description
-    FeeAndQuoteSellResponse:
-      type: object
-      properties:
-        fee:
-          $ref: "#/components/schemas/FeeInformation"
-        buyAmountAfterFee:
-          description: The buy amount after deducting the fee.
-          $ref: "#/components/schemas/TokenAmount"
-    FeeAndQuoteBuyResponse:
-      type: object
-      properties:
-        fee:
-          $ref: "#/components/schemas/FeeInformation"
-        sellAmountBeforeFee:
-          description: The sell amount including the fee.
-          $ref: "#/components/schemas/TokenAmount"
     FeeAndQuoteError:
       type: object
       properties:

--- a/crates/orderbook/openapi.yml
+++ b/crates/orderbook/openapi.yml
@@ -406,18 +406,18 @@ components:
       properties:
         sender:
           description: |
-              If orders are placed as onchain orders, the owner of the order might
-              be a smart contract, but not the user placing the order. The
-              actual user will be provided in this field
+            If orders are placed as onchain orders, the owner of the order might
+            be a smart contract, but not the user placing the order. The
+            actual user will be provided in this field
           allOf:
             - $ref: "#/components/schemas/Address"
         placementError:
           description: |
-              Describes the error, if the order placement was not
-              successful. This could happen, for example, if the
-              valid_to is too high, or no valid quote was found or generated
+            Describes the error, if the order placement was not
+            successful. This could happen, for example, if the
+            valid_to is too high, or no valid quote was found or generated
           type: string
-          enum: [ QuoteNotFound, ValidToTooFarInFuture, PreValidationError ]
+          enum: [QuoteNotFound, ValidToTooFarInFuture, PreValidationError]
       required:
         - sender
     EthflowData:
@@ -434,9 +434,9 @@ components:
           nullable: true
         userValidTo:
           description: |
-           Describes the valid to of an order ethflow order.
-           Note that for ethflow orders, the valid_to encoded in the smart
-           contract is max(uint)
+            Describes the valid to of an order ethflow order.
+            Note that for ethflow orders, the valid_to encoded in the smart
+            contract is max(uint)
           type: integer
       required:
         - refundTxHash
@@ -448,7 +448,7 @@ components:
     OrderClass:
       description: Order class
       type: string
-      enum: [ market, limit, liquidity ]
+      enum: [market, limit, liquidity]
     SellTokenSource:
       description: Where should the sell token be drawn from?
       type: string
@@ -949,7 +949,7 @@ components:
                 The total amount that is available for the order. From this value, the fee
                 is deducted and the buy amount is calculated.
               allOf:
-              - $ref: "#/components/schemas/TokenAmount"
+                - $ref: "#/components/schemas/TokenAmount"
           required:
             - kind
             - sellAmountBeforeFee

--- a/crates/solvers/openapi.yml
+++ b/crates/solvers/openapi.yml
@@ -33,7 +33,6 @@ paths:
 
 components:
   schemas:
-
     Address:
       description: |
         An Ethereum public address.
@@ -78,8 +77,7 @@ components:
       example: "1234567890"
 
     DateTime:
-      description:
-        An ISO-8601 formatted date-time.
+      description: An ISO-8601 formatted date-time.
       type: string
       example: "1970-01-01T00:00:00.000Z"
 


### PR DESCRIPTION
I noticed a few small issues with our Swagger and this PR fixes them. I noticed them because they were warnings when using [this editor](https://editor.swagger.io/) for some unrelated changes.

First, some properties are declared but ignored in the schema. This is the case every time a configuration like this is used:
```yaml
schema:
  key: value
  $ref: "#path/to/ref"
```

In this case, regardless of the ref, [`key` is ignored](https://swagger.io/docs/specification/using-ref/#sibling). The correct syntax appears to be:
```yaml
schema:
  key: value
  allOf:
    - $ref: "#path/to/ref"
```

If `key` also appears in the ref, the ref value is ignored. (Actually the [specs](https://spec.openapis.org/oas/v3.0.0.html) don't say what happens in this case, even if they use this in their examples. However, using `allOf` with more than one entries, one of which is repeated in two or more entries, would require you to use a [discriminator](https://spec.openapis.org/oas/v3.0.0.html#discriminator-object), which is imho too much work for our use case.)

Second, it removes some outdated components. I believe they come from old paths.

I also ran the autoformatter, since the changes weren't many.

I didn't fix the error `DELETE operations cannot have a requestBody`. According to what I read from [Swagger repo](https://github.com/swagger-api/swagger-ui/issues/) issue 4425 this is somewhat an issue of their UI. (Even if it's arguably weird according to specs to use `DELETE` with a request body: I imagine that rather than having a single path `/api/v1/orders` it would be semantically better to use `/api/v1/orders/{UID}`, but overall it doesn't matter.)

### Test Plan

Paste the OpenAPI files [here](https://editor.swagger.io/), see (almost no) warnings and that the resulting schemes includes all information with the correct overrides.

<details><summary>Example: `OrderCreation`</summary>

![image](https://user-images.githubusercontent.com/58218759/232061552-ee9ffc26-d9a6-488f-acc1-6783d7a8bd24.png)
</details>