### PR TITLE
Relax PreSign Balance Exception

### DIFF
--- a/crates/shared/src/order_validation.rs
+++ b/crates/shared/src/order_validation.rs
@@ -520,7 +520,8 @@ impl OrderValidating for OrderValidator {
             Ok(_) => (),
             Err(
                 TransferSimulationError::InsufficientAllowance
-                | TransferSimulationError::InsufficientBalance,
+                | TransferSimulationError::InsufficientBalance
+                | TransferSimulationError::TransferFailed,
             ) if signing_scheme == SigningScheme::PreSign => {
                 // We have an exception for pre-sign orders where they do not
                 // require sufficient balance or allowance. The idea, is that


### PR DESCRIPTION
This PR relaxes the pre-sign balance check exception to also include `TransferFailed`. From looking at the [initial PR that added this exception](https://github.com/gnosis/gp-v2-services/pull/1587) there is no indication of why this would be an issue.

This will enable special orders with "virtual" balances (such as Agave flash loan orders) to work with the API.

### Test Plan

CI
