### PR TITLE
No Simulation for Cancelled Settlement Transactions

### DIFF
--- a/crates/solver/src/driver_logger.rs
+++ b/crates/solver/src/driver_logger.rs
@@ -131,7 +131,7 @@ impl DriverLogger {
                 tracing::warn!(settlement_id, ?err, "Failed to submit settlement",);
                 self.metrics
                     .settlement_submitted(err.as_outcome(), solver_name);
-                if let Some(transaction_hash) = err.transaction_hash() {
+                if let Some(transaction_hash) = err.revert_transaction_hash() {
                     if let Err(err) = self.metric_access_list_gas_saved(transaction_hash).await {
                         tracing::debug!(?err, "access list metric not saved");
                     }

--- a/crates/solver/src/settlement_submission.rs
+++ b/crates/solver/src/settlement_submission.rs
@@ -406,12 +406,13 @@ impl SubmissionError {
         }
     }
 
-    pub fn transaction_hash(&self) -> Option<H256> {
+    /// Returns the transaction hash of a reverted on-chain settlement.
+    pub fn revert_transaction_hash(&self) -> Option<H256> {
         match self {
             Self::SimulationRevert(_) => None,
             Self::Timeout => None,
             Self::Revert(hash) => Some(*hash),
-            Self::Canceled(hash) => Some(*hash),
+            Self::Canceled(_) => None,
             Self::Disabled(_) => None,
             Self::Other(_) => None,
         }


### PR DESCRIPTION
We currently are estimating transactions with and without access lists for cancelled transactions which is negatively impacting our access list metrics.

However, it does not make sense to do this - cancelled transactions don't pay for access lists, so it should not impact the total performance of including vs not including access lists.

### Test Plan

CI
