### PR TITLE
Match Order Executions To Auction ID

### DIFF
--- a/crates/autopilot/src/on_settlement_event_updater.rs
+++ b/crates/autopilot/src/on_settlement_event_updater.rs
@@ -148,7 +148,7 @@ impl OnSettlementEventUpdater {
                 .with_context(|| {
                     format!("no external prices for auction id {auction_id:?} and tx {hash:?}")
                 })?;
-            let orders = self.db.order_executions_for_tx(&hash).await?;
+            let orders = self.db.order_executions_for_tx(&hash, auction_id).await?;
             let external_prices = ExternalPrices::try_from_auction_prices(
                 self.native_token,
                 auction_external_prices.clone(),

--- a/crates/database/src/orders.rs
+++ b/crates/database/src/orders.rs
@@ -538,7 +538,7 @@ WHERE
     sqlx::query_as(QUERY).bind(tx_hash).fetch(ex)
 }
 
-#[derive(Debug, PartialEq, sqlx::FromRow)]
+#[derive(Debug, Default, PartialEq, sqlx::FromRow)]
 pub struct OrderExecution {
     /// The `solver_fee` that got executed for this specific fill.
     pub executed_solver_fee: Option<BigDecimal>,
@@ -578,12 +578,15 @@ SELECT
     o.signature,
     o.signing_scheme
 FROM order_execution AS oe
+JOIN auction_transaction a ON a.auction_id = oe.auction_id
+JOIN settlements s ON s.tx_from = a.tx_from AND s.tx_nonce = a.tx_nonce
 JOIN orders o ON o.uid = oe.order_uid
 JOIN trades t ON t.order_uid = oe.order_uid
 WHERE
+    s.tx_hash = $1 AND
     t.block_number = (SELECT block_number FROM settlement) AND
     t.log_index BETWEEN (SELECT * from previous_settlement) AND (SELECT log_index FROM settlement)
-    "#
+        "#
     );
     sqlx::query_as(QUERY).bind(tx_hash).fetch(ex)
 }
@@ -2118,10 +2121,12 @@ mod tests {
         )
         .await
         .unwrap();
+
+        let auction_id = 6124819;
         crate::order_execution::save(
             &mut db,
             &order_uid,
-            6124819,
+            auction_id,
             None,
             &bigdecimal(463182886014406361088),
         )
@@ -2147,16 +2152,33 @@ mod tests {
         let transaction_hash = ByteArray(hex!(
             "d2a3b85244bee6043f740ce774bc72ba271b890c4aa939ebe3d859afef445d99"
         ));
+        let event_index = EventIndex {
+            block_number: 17066992,
+            log_index: 300,
+        };
         crate::events::insert_settlement(
             &mut db,
-            &EventIndex {
-                block_number: 17066992,
-                log_index: 300,
-            },
+            &event_index,
             &Settlement {
                 solver: ByteArray(hex!("c9ec550bea1c64d779124b23a26292cc223327b6")),
                 transaction_hash,
             },
+        )
+        .await
+        .unwrap();
+        let tx_from = ByteArray(hex!("c9ec550bea1c64d779124b23a26292cc223327b6"));
+        let tx_nonce = 68785;
+        crate::auction_transaction::insert_settlement_tx_info(
+            &mut db,
+            event_index.block_number,
+            event_index.log_index,
+            &tx_from,
+            tx_nonce,
+        )
+        .await
+        .unwrap();
+        crate::auction_transaction::upsert_auction_transaction(
+            &mut db, auction_id, &tx_from, tx_nonce,
         )
         .await
         .unwrap();
@@ -2178,6 +2200,93 @@ mod tests {
                 signature: hex::decode("4935ea3f24155f6757df94d8c0bc96665d46da51e1a8e39d935967c9216a60912fa50a5393a323d453c78d179d0199ddd58f6d787781e4584357d3e0205a76001c").unwrap(),
                 signing_scheme: SigningScheme::Eip712,
                 owner: ByteArray(hex!("b70cd1ebd3b24aeeaf90c6041446630338536e7f")),
+            }]
+        );
+    }
+
+    #[tokio::test]
+    #[ignore]
+    async fn postgres_order_executions_ignore_previous_auctions() {
+        let bigdecimal = |x: u128| x.to_string().parse().unwrap();
+
+        let mut db = PgConnection::connect("postgresql://").await.unwrap();
+        let mut db = db.begin().await.unwrap();
+        crate::clear_DANGER_(&mut db).await.unwrap();
+
+        let order = Order {
+            class: OrderClass::Limit,
+            kind: OrderKind::Sell,
+            sell_amount: bigdecimal(1),
+            buy_amount: bigdecimal(1),
+            ..Default::default()
+        };
+
+        insert_order(&mut db, &order).await.unwrap();
+
+        crate::order_execution::save(&mut db, &order.uid, 1, None, &bigdecimal(1))
+            .await
+            .unwrap();
+        crate::order_execution::save(&mut db, &order.uid, 42, None, &bigdecimal(42))
+            .await
+            .unwrap();
+
+        crate::events::insert_trade(
+            &mut db,
+            &EventIndex {
+                block_number: 1,
+                log_index: 0,
+            },
+            &Trade {
+                order_uid: order.uid,
+                sell_amount_including_fee: bigdecimal(1),
+                buy_amount: bigdecimal(1),
+                fee_amount: bigdecimal(0),
+            },
+        )
+        .await
+        .unwrap();
+
+        let transaction_hash = ByteArray([0x11; 32]);
+        crate::events::insert_settlement(
+            &mut db,
+            &EventIndex {
+                block_number: 1,
+                log_index: 1,
+            },
+            &Settlement {
+                transaction_hash,
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+
+        crate::auction_transaction::insert_settlement_tx_info(
+            &mut db,
+            1,
+            1,
+            &Default::default(),
+            0,
+        )
+        .await
+        .unwrap();
+        crate::auction_transaction::upsert_auction_transaction(&mut db, 42, &Default::default(), 0)
+            .await
+            .unwrap();
+
+        let executions = order_executions_in_tx(&mut db, &transaction_hash)
+            .try_collect::<Vec<_>>()
+            .await
+            .unwrap();
+        assert_eq!(
+            executions,
+            vec![OrderExecution {
+                executed_solver_fee: Some(bigdecimal(42)),
+                kind: OrderKind::Sell,
+                sell_amount: bigdecimal(1),
+                buy_amount: bigdecimal(1),
+                executed_amount: bigdecimal(1),
+                ..Default::default()
             }]
         );
     }


### PR DESCRIPTION
Fixes #1443.

FoK limit orders can solver fee amount changes per auction. In the case where a limit order is included in solutions from different auctions where the first ones fail to mine, we are left with multiple entries in the `order_execution` table for the same FoK limit order, with potentially different `solver_fee` values.

The current query does not take this into account and would potentially select the `solver_fee` from the wrong auction when computing the observed settlement score.

This PR fixes this by passing in an `auction_id` to the query so only the correct order execution entries are used. Note that **we pass the `auction_id` in** instead of joining tables (like we do in 79f69a7ccc9408bd2e3f91f805c4b5542f52dbb5) because the `auction_transaction` and `settlements` are not updated when this query is run.

### Test Plan

Added unit test.