### PR TITLE
Silence alert for dust orders

### DIFF
--- a/crates/driver/src/boundary/settlement.rs
+++ b/crates/driver/src/boundary/settlement.rs
@@ -113,7 +113,7 @@ impl Settlement {
                 .normalize_limit_order(solver::order_balance_filter::BalancedOrder::full(
                     boundary_order,
                 ))
-                .map_err(Error::Boundary)?;
+                .map_err(|err| Error::Boundary(err.into()))?;
             settlement
                 .with_liquidity(&boundary_limit_order, execution)
                 .map_err(Error::Boundary)?;

--- a/crates/driver/src/boundary/settlement.rs
+++ b/crates/driver/src/boundary/settlement.rs
@@ -113,7 +113,7 @@ impl Settlement {
                 .normalize_limit_order(solver::order_balance_filter::BalancedOrder::full(
                     boundary_order,
                 ))
-                .map_err(|err| Error::Boundary(err.into()))?;
+                .map_err(Error::Boundary)?;
             settlement
                 .with_liquidity(&boundary_limit_order, execution)
                 .map_err(Error::Boundary)?;

--- a/crates/shared/src/remaining_amounts.rs
+++ b/crates/shared/src/remaining_amounts.rs
@@ -68,16 +68,19 @@ impl Remaining {
                 .checked_add(order.data.fee_amount)
                 .context("overflow sell + fee amount")?;
 
-            let execution = if sell_balance >= sell && executed.is_zero() {
+            let execution = if executed.is_zero() {
                 ratio::one()
             } else {
                 ratio::zero()
             };
 
-            Ok(Self {
-                execution,
-                balance: ratio::one(),
-            })
+            let balance = if sell_balance >= sell {
+                ratio::one()
+            } else {
+                ratio::zero()
+            };
+
+            Ok(Self { execution, balance })
         }
     }
 

--- a/crates/shared/src/remaining_amounts.rs
+++ b/crates/shared/src/remaining_amounts.rs
@@ -1,6 +1,7 @@
 use {
     anyhow::{Context, Result},
     model::order::{Order, OrderKind},
+    num::rational::Ratio,
     primitive_types::U256,
 };
 
@@ -12,31 +13,18 @@ use {
 /// Works like the smart contract by taking intermediate overflows into account
 /// for partially fillable orders.
 pub struct Remaining {
-    numerator: U256,
-    denominator: U256,
+    execution: Ratio<U256>,
+    balance: Ratio<U256>,
 }
 
 impl Remaining {
-    pub fn from_partially_fillable(total: U256, executed: U256) -> Result<Self> {
-        Ok(Self {
-            numerator: total
-                .checked_sub(executed)
-                .context("executed larger than total")?,
-            denominator: total,
-        })
-    }
-
-    pub fn from_fill_or_kill(has_executed: bool) -> Self {
-        // fill-or-kill orders do not have their amounts scaled in the contract so using
-        // the partially fillable logic would be wrong because it could error in
-        // `remaining` when the contract wouldn't.
-        Self {
-            numerator: if has_executed { 0.into() } else { 1.into() },
-            denominator: 1.into(),
-        }
-    }
-
+    /// Returns a ratio of an order assuming it has sufficient balance.
     pub fn from_order(order: &Order) -> Result<Self> {
+        Self::from_order_with_balance(order, U256::MAX)
+    }
+
+    /// Returns a ratio of an order with the specified available balance.
+    pub fn from_order_with_balance(order: &Order, sell_balance: U256) -> Result<Self> {
         let (total, executed) = match order.data.kind {
             OrderKind::Buy => (
                 order.data.buy_amount,
@@ -48,19 +36,77 @@ impl Remaining {
                 order.metadata.executed_sell_amount_before_fees,
             ),
         };
+
         if order.data.partially_fillable {
-            Self::from_partially_fillable(total, executed)
+            let execution = Ratio::new_raw(
+                total
+                    .checked_sub(executed)
+                    .context("executed larger than total")?,
+                total,
+            );
+
+            let sell_amount = ratio::scalar_mul(&execution, order.data.sell_amount)
+                .context("overflow scaling sell amount for execution")?;
+            let fee_amount = ratio::scalar_mul(&execution, order.data.fee_amount)
+                .context("overflow scaling fee amount for execution")?;
+
+            let need = sell_amount
+                .checked_add(fee_amount)
+                .context("partially fillable need calculation overflow")?;
+
+            let balance = if sell_balance < need {
+                Ratio::new_raw(sell_balance, need)
+            } else {
+                ratio::one()
+            };
+
+            Ok(Self { execution, balance })
         } else {
-            Ok(Self::from_fill_or_kill(!executed.is_zero()))
+            let sell = order
+                .data
+                .sell_amount
+                .checked_add(order.data.fee_amount)
+                .context("overflow sell + fee amount")?;
+
+            let execution = if sell_balance >= sell && executed.is_zero() {
+                ratio::one()
+            } else {
+                ratio::zero()
+            };
+
+            Ok(Self {
+                execution,
+                balance: ratio::one(),
+            })
         }
     }
 
     /// Returns Err if the contract would error due to intermediate overflow.
     pub fn remaining(&self, total: U256) -> Result<U256> {
-        total
-            .checked_mul(self.numerator)
-            .and_then(|product| product.checked_div(self.denominator))
-            .context("overflow")
+        ratio::scalar_mul(
+            &self.balance,
+            ratio::scalar_mul(&self.execution, total)
+                .context("overflow scaling for order execution")?,
+        )
+        .context("overflow scaling for available balance")
+    }
+}
+
+mod ratio {
+    use {ethcontract::U256, num::rational::Ratio};
+
+    pub fn one() -> Ratio<U256> {
+        Ratio::new_raw(1.into(), 1.into())
+    }
+
+    pub fn zero() -> Ratio<U256> {
+        Ratio::new_raw(0.into(), 1.into())
+    }
+
+    pub fn scalar_mul(ratio: &Ratio<U256>, scalar: U256) -> Option<U256> {
+        scalar
+            .checked_mul(*ratio.numer())
+            .and_then(|product| product.checked_div(*ratio.denom()))
     }
 }
 
@@ -177,8 +223,7 @@ mod tests {
             },
             ..Default::default()
         };
-        let remaining = Remaining::from_order(&order).unwrap();
-        assert!(remaining.remaining(U256::MAX).is_err());
+        assert!(Remaining::from_order(&order).is_err());
 
         // Partially filled order overflowing executed amount.
         let order = Order {
@@ -222,9 +267,109 @@ mod tests {
             },
             ..Default::default()
         };
-        let remaining = Remaining::from_order(&order).unwrap();
-        assert!(remaining.remaining(1.into()).is_err());
-        assert!(remaining.remaining(1000.into()).is_err());
-        assert!(remaining.remaining(U256::MAX).is_err());
+        assert!(Remaining::from_order(&order).is_err());
+    }
+
+    #[test]
+    fn scale_order_by_available_balance() {
+        // Fill-or-kill orders without balance scale to 0 if there is
+        // insufficient balance.
+        let order = Order {
+            data: OrderData {
+                sell_amount: 1000.into(),
+                buy_amount: 2000.into(),
+                fee_amount: 337.into(),
+                kind: OrderKind::Sell,
+                partially_fillable: false,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let remaining =
+            Remaining::from_order_with_balance(&order, order.data.sell_amount - 1).unwrap();
+        assert_eq!(remaining.remaining(1000.into()).unwrap(), 0.into());
+
+        // A partially fillable order that has not been executed at all scales
+        // to the available balance.
+        let order = Order {
+            data: OrderData {
+                sell_amount: 800.into(),
+                buy_amount: 2000.into(),
+                fee_amount: 200.into(),
+                kind: OrderKind::Sell,
+                partially_fillable: true,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        {
+            // More than enough balance for the full order.
+            let remaining = Remaining::from_order_with_balance(&order, 5000.into()).unwrap();
+            assert_eq!(remaining.remaining(800.into()).unwrap(), 800.into());
+        }
+        {
+            // Not enough balance for the full order.
+            let remaining = Remaining::from_order_with_balance(&order, 500.into()).unwrap();
+            assert_eq!(remaining.remaining(800.into()).unwrap(), 400.into());
+        }
+
+        // A partially fillable order that has has been partially executed scales
+        // to the remaining execution and available balance.
+        let order = Order {
+            data: OrderData {
+                sell_amount: 800.into(),
+                buy_amount: 2000.into(),
+                fee_amount: 200.into(),
+                kind: OrderKind::Sell,
+                partially_fillable: true,
+                ..Default::default()
+            },
+            metadata: OrderMetadata {
+                executed_sell_amount_before_fees: 400.into(),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        {
+            // More than enough balance for the full order.
+            let remaining = Remaining::from_order_with_balance(&order, 5000.into()).unwrap();
+            assert_eq!(remaining.remaining(800.into()).unwrap(), 400.into());
+        }
+        {
+            // Not enough balance for the full order.
+            let remaining = Remaining::from_order_with_balance(&order, 250.into()).unwrap();
+            assert_eq!(remaining.remaining(800.into()).unwrap(), 200.into());
+        }
+    }
+
+    #[test]
+    fn support_scaling_for_large_orders_with_partial_balance() {
+        let u = <U256 as From<u128>>::from;
+        let order = Order {
+            data: OrderData {
+                sell_amount: u(10).pow(u(30)),
+                buy_amount: 1.into(),
+                kind: OrderKind::Sell,
+                partially_fillable: true,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let balance = order.data.sell_amount - 1;
+
+        // Note that we need to scale because of remaining balance, and that
+        // we would overflow with these numbers:
+        assert!((order.data.sell_amount * order.data.sell_amount)
+            .checked_mul(balance)
+            .is_none());
+
+        // However, `Remaining` supports these large orders with large partial
+        // balances as scaling for remaining execution and available balance are
+        // done separately.
+        let remaining = Remaining::from_order_with_balance(&order, balance).unwrap();
+        assert_eq!(
+            remaining.remaining(order.data.sell_amount).unwrap(),
+            balance
+        );
     }
 }

--- a/crates/solver/src/driver.rs
+++ b/crates/solver/src/driver.rs
@@ -8,7 +8,7 @@ use {
         auction_preprocessing,
         driver_logger::DriverLogger,
         in_flight_orders::InFlightOrders,
-        liquidity::order_converter::OrderConverter,
+        liquidity::order_converter::{OrderConversionError, OrderConverter},
         liquidity_collector::{LiquidityCollecting, LiquidityCollector},
         metrics::SolverMetrics,
         order_balance_filter::OrderBalanceFilter,
@@ -300,8 +300,14 @@ impl Driver {
         let orders = orders
             .into_iter()
             .filter_map(|order| {
+                let uid = order.order.metadata.uid;
+                let partially_fillable = order.order.data.partially_fillable;
                 match self.order_converter.normalize_limit_order(order) {
                     Ok(order) => Some(order),
+                    Err(OrderConversionError::ZeroAmount) if partially_fillable => {
+                        tracing::debug!(order = %uid, "skipping dust order");
+                        None
+                    }
                     Err(err) => {
                         // This should never happen unless we are getting malformed
                         // orders from the API - so raise an alert if this happens.

--- a/crates/solver/src/order_balance_filter.rs
+++ b/crates/solver/src/order_balance_filter.rs
@@ -82,12 +82,7 @@ fn solvable_orders(
                 result.push(BalancedOrder::full(order));
                 continue;
             }
-            // TODO: This is overly pessimistic for partially filled orders where the needed
-            // balance is lower. For partially fillable orders that cannot be
-            // fully filled because of the balance we could also give them as
-            // much balance as possible instead of skipping. For that we first
-            // need a way to communicate this to the solver. We could repurpose
-            // availableBalance for this.
+
             let needed_balance = match max_transfer_out_amount(&order) {
                 // Should only ever happen if a partially fillable order has been filled completely
                 Ok(balance) if balance.is_zero() => continue,


### PR DESCRIPTION
#1439 introduced alert noise when encountering partially fillable orders that scale to 0 amounts.

This PR modifies the auction building process to filter out these orders before hand (there is no point in including them in the auction if they can't be executed anyway).

Note that this is achieved by modifying the existing `remaining_amount::Remaining` logic to scale by both remaining execution and available balance. One implementation note is that we **do not** put these in the same ratio, but instead scale in two steps. This is to prevent filtering out large orders with large partial balance, and would affect [existing orders](https://explorer.cow.fi/orders/0xbf386c0e1913c11edfdf6d267ea716b72fc3a3bd6002eef116d1c42b86b17b3a10ccd4136471c7c266a9fc4569622989fb4cab9964b6c2f4?tab=overview)).

Note that one other approach would be to use a `BigRational` instead of `Ratio<U256>`. The reason we don't do this is the same for why were using `Ratio<U256>` for scaling for remaining execution in the first place: the smart contract scales amounts by this ratio when computing executed amounts, so we could potentially revert - this helps guard against those cases.

### Test Plan

Added some new unit tests to:
- Verify the balance scaling logic for both partially fillable and fill-or-kill orders
- Added a test to document why we split `execution` scaling and `balance` scaling into two separate ratios.