### PR TITLE
Adjust the simulation block number

### DIFF
--- a/crates/shared/src/http_solver/model.rs
+++ b/crates/shared/src/http_solver/model.rs
@@ -416,9 +416,11 @@ pub struct TransactionWithError {
 #[derivative(Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct SimulatedTransaction {
-    /// The simulation was done on top of all transactions from the given block
-    /// number
+    /// The simulation was done at the beginning of the block
     pub block_number: u64,
+    /// Index of the transaction inside the block the transaction was simulated
+    /// on
+    pub tx_index: u64,
     /// Is transaction simulated with internalized interactions or without
     pub internalization: InternalizationStrategy,
     /// Which storage the settlement tries to access. Contains `None` if some
@@ -1077,6 +1079,7 @@ mod tests {
                     storage_keys: vec![H256::from_low_u64_be(2)]
                 }]),
                 block_number: 15848799,
+                tx_index: 0,
                 from: H160::from_str("0x9008D19f58AAbD9eD0D60971565AA8510560ab41").unwrap(),
                 to: H160::from_str("0x9008D19f58AAbD9eD0D60971565AA8510560ab41").unwrap(),
                 data: vec![19, 250, 73],
@@ -1093,6 +1096,7 @@ mod tests {
                     ]
                 }],
                 "blockNumber": 15848799,
+                "txIndex": 0,
                 "data": "0x13fa49",
                 "from": "0x9008d19f58aabd9ed0d60971565aa8510560ab41",
                 "to": "0x9008d19f58aabd9ed0d60971565aa8510560ab41",

--- a/crates/solver/src/settlement_rater.rs
+++ b/crates/solver/src/settlement_rater.rs
@@ -134,7 +134,10 @@ impl SettlementRater {
                         transaction: SimulatedTransaction {
                             internalization,
                             access_list,
-                            block_number,
+                            // simulating on block X and tx index A is equal to simulating on block
+                            // X+1 and tx index 0.
+                            block_number: block_number + 1,
+                            tx_index: 0,
                             to: self.settlement_contract.address(),
                             from: solver.account().address(),
                             data: call_data(settlement.clone().encode(internalization)),


### PR DESCRIPTION
Increases the reported block number by 1 to avoid misunderstanding (with external solvers) of the block height on which the simulation was done. 
At the same time, `tx_index` is explicitly provided.

Discussion: https://cowservices.slack.com/archives/C036JAGRQ04/p1682065321347269
