### PR TITLE
Fix new clippy warnings

### DIFF
--- a/crates/refunder/src/refund_service.rs
+++ b/crates/refunder/src/refund_service.rs
@@ -134,7 +134,6 @@ impl RefundService {
 
         batch.execute_all(MAX_BATCH_SIZE).await;
         let uid_with_latest_refundablility = futures::future::join_all(futures).await;
-        type TupleWithRefundStatus = (Vec<(OrderUid, RefundStatus)>, Vec<(OrderUid, RefundStatus)>);
         let mut to_be_refunded_uids = Vec::new();
         let mut invalid_uids = Vec::new();
         for (uid, refund_status) in uid_with_latest_refundablility.into_iter().flatten() {

--- a/crates/shared/src/api.rs
+++ b/crates/shared/src/api.rs
@@ -293,7 +293,7 @@ mod tests {
             }),
         );
         assert_eq!(
-            serde_json::to_value(&Error {
+            serde_json::to_value(Error {
                 error_type: "foo",
                 description: "bar",
                 data: Some(json!(42)),

--- a/crates/shared/src/balancer_sor_api.rs
+++ b/crates/shared/src/balancer_sor_api.rs
@@ -246,7 +246,7 @@ mod tests {
     #[test]
     fn serialize_query() {
         assert_eq!(
-            serde_json::to_value(&Query {
+            serde_json::to_value(Query {
                 sell_token: addr!("ba100000625a3754423978a60c9317c58a424e3d"),
                 buy_token: addr!("6b175474e89094c44da98b954eedeac495271d0f"),
                 order_kind: OrderKind::Sell,

--- a/crates/shared/src/http_solver/model.rs
+++ b/crates/shared/src/http_solver/model.rs
@@ -660,7 +660,7 @@ mod tests {
             }),
         };
 
-        let result = serde_json::to_value(&model).unwrap();
+        let result = serde_json::to_value(model).unwrap();
 
         let expected = json!({
           "tokens": {
@@ -1071,7 +1071,7 @@ mod tests {
     #[test]
     fn serialize_simulated_transaction() {
         assert_eq!(
-            serde_json::to_value(&SimulatedTransaction {
+            serde_json::to_value(SimulatedTransaction {
                 access_list: Some(vec![AccessListItem {
                     address: H160::from_low_u64_be(1),
                     storage_keys: vec![H256::from_low_u64_be(2)]
@@ -1106,7 +1106,7 @@ mod tests {
     #[test]
     fn serialize_rejection_non_bufferable_tokens_used() {
         assert_eq!(
-            serde_json::to_value(&SolverRejectionReason::NonBufferableTokensUsed(
+            serde_json::to_value(SolverRejectionReason::NonBufferableTokensUsed(
                 [H160::from_low_u64_be(1), H160::from_low_u64_be(2)]
                     .into_iter()
                     .collect()
@@ -1121,7 +1121,7 @@ mod tests {
     #[test]
     fn serialize_rejection_too_high_score() {
         assert_eq!(
-            serde_json::to_value(&SolverRejectionReason::TooHighScore {
+            serde_json::to_value(SolverRejectionReason::TooHighScore {
                 surplus: 1300.into(),
                 fees: 37.into(),
                 max_score: 1337.into(),

--- a/crates/shared/src/subgraph.rs
+++ b/crates/shared/src/subgraph.rs
@@ -191,7 +191,7 @@ mod tests {
     #[test]
     fn serialize_query() {
         assert_eq!(
-            serde_json::to_value(&Query {
+            serde_json::to_value(Query {
                 query: r#"foo {
                 }"#,
                 variables: Some(json_map! {

--- a/crates/solver/src/solver/optimizing_solver.rs
+++ b/crates/solver/src/solver/optimizing_solver.rs
@@ -69,15 +69,12 @@ mod tests {
         contracts::WETH9,
         ethcontract::PrivateKey,
         futures::FutureExt,
-        hex_literal::hex,
         primitive_types::H160,
         shared::dummy_contract,
     };
 
     #[tokio::test]
     async fn optimizes_solutions() {
-        const PRIVATE_KEY: [u8; 32] =
-            hex!("0000000000000000000000000000000000000000000000000000000000000001");
         let account = Account::Offline(PrivateKey::from_raw([0x1; 32]).unwrap(), None);
 
         let mut inner = MockSolver::new();


### PR DESCRIPTION
As usual the new rust version comes with new clippy lints.
Running `cargo clippy --fix` took care of all warnings.

### Test Plan
CI