### PR TITLE
Don't require a `dyn Solver` to simulate and rate a Settlement

### DIFF
--- a/crates/solver/src/driver.rs
+++ b/crates/solver/src/driver.rs
@@ -383,7 +383,7 @@ impl Driver {
             auction: competition_auction,
             solutions: rated_settlements
                 .iter()
-                .map(|(solver, rated_settlement, _)| SolverSettlement {
+                .map(|(solver, rated_settlement)| SolverSettlement {
                     solver: solver.name().to_string(),
                     solver_address: solver.account().address(),
                     objective: Objective {
@@ -429,7 +429,7 @@ impl Driver {
         };
 
         let mut settlement_transaction_attempted = false;
-        if let Some((winning_solver, winning_settlement, _)) = rated_settlements.pop() {
+        if let Some((winning_solver, winning_settlement)) = rated_settlements.pop() {
             tracing::info!(
                 "winning settlement id {} by solver {}: {:?}",
                 winning_settlement.id,
@@ -470,7 +470,7 @@ impl Driver {
                 // second highest score, or 0 if there is only one score (see CIP20)
                 reference_score: rated_settlements
                     .last()
-                    .map(|(_, settlement, _)| settlement.score.score())
+                    .map(|(_, settlement)| settlement.score.score())
                     .unwrap_or_default(),
                 block_deadline: {
                     let deadline = self.solver_time_limit
@@ -547,7 +547,7 @@ impl Driver {
                 &(winning_solver, winning_settlement),
                 rated_settlements
                     .into_iter()
-                    .map(|(solver, settlement, _)| (solver, settlement))
+                    .map(|(solver, settlement)| (solver, settlement))
                     .collect(),
             );
         }

--- a/crates/solver/src/settlement_ranker.rs
+++ b/crates/solver/src/settlement_ranker.rs
@@ -174,7 +174,8 @@ impl SettlementRanker {
         let (mut rated_settlements, errors): (Vec<_>, Vec<_>) = join_all(
             solver_settlements
                 .into_iter()
-                .map(|(solver, settlement)| async {
+                .enumerate()
+                .map(|(i, (solver, settlement))| async move {
                     let simulation = self
                         .settlement_rater
                         .rate_settlement(
@@ -185,6 +186,7 @@ impl SettlementRanker {
                             settlement,
                             external_prices,
                             gas_price,
+                            i,
                         )
                         .await;
                     (solver, simulation)

--- a/crates/solver/src/settlement_ranker.rs
+++ b/crates/solver/src/settlement_ranker.rs
@@ -1,15 +1,20 @@
 use {
     crate::{
-        driver::solver_settlements::{self},
+        driver::solver_settlements::{
+            RatedSettlement,
+            {self},
+        },
         metrics::{SolverMetrics, SolverRunOutcome, SolverSimulationOutcome},
         settlement::{PriceCheckTokens, Settlement},
-        settlement_rater::{RatedSolverSettlement, SettlementRating},
+        settlement_rater::{Rating, SettlementRating},
         settlement_simulation::call_data,
-        solver::{SimulationWithError, Solver},
+        solver::{SimulationWithError, Solver, SolverInfo},
     },
     anyhow::Result,
     ethcontract::U256,
+    futures::future::join_all,
     gas_estimation::GasPrice1559,
+    itertools::Itertools,
     model::auction::AuctionId,
     num::{rational::Ratio, BigInt},
     number_conversions::big_rational_to_u256,
@@ -28,6 +33,7 @@ use {
 };
 
 type SolverResult = (Arc<dyn Solver>, Result<Vec<Settlement>, SolverRunError>);
+pub type RatedSolverSettlement = (Arc<dyn Solver>, RatedSettlement);
 
 pub struct SettlementRanker {
     pub metrics: Arc<dyn SolverMetrics>,
@@ -165,18 +171,39 @@ impl SettlementRanker {
             );
         }
 
-        let (mut rated_settlements, errors) = self
-            .settlement_rater
-            .rate_settlements(solver_settlements, external_prices, gas_price)
-            .await?;
+        let (mut rated_settlements, errors): (Vec<_>, Vec<_>) = join_all(
+            solver_settlements
+                .into_iter()
+                .map(|(solver, settlement)| async {
+                    let simulation = self
+                        .settlement_rater
+                        .rate_settlement(
+                            &SolverInfo {
+                                account: solver.account().clone(),
+                                name: solver.name().to_owned(),
+                            },
+                            settlement,
+                            external_prices,
+                            gas_price,
+                        )
+                        .await;
+                    (solver, simulation)
+                }),
+        )
+        .await
+        .into_iter()
+        .partition_map(|(solver, r)| match r.unwrap() {
+            Rating::Ok(r) => itertools::Either::Left((solver, r)),
+            Rating::Err(err) => itertools::Either::Right((solver, err)),
+        });
 
         tracing::info!(
             "{} settlements passed simulation and {} failed",
             rated_settlements.len(),
             errors.len(),
         );
-        for error in &errors {
-            error.simulation.solver.notify_auction_result(
+        for (solver, error) in &errors {
+            solver.notify_auction_result(
                 auction_id,
                 AuctionResult::Rejected(SolverRejectionReason::SimulationFailure(
                     TransactionWithError {
@@ -189,7 +216,7 @@ impl SettlementRanker {
 
         // Filter out settlements with non-positive score.
         if self.skip_non_positive_score_settlements {
-            rated_settlements.retain(|(solver, settlement, _)| {
+            rated_settlements.retain(|(solver, settlement)| {
                 let positive_score = settlement.score.score() > 0.into();
                 if !positive_score {
                     tracing::debug!(
@@ -207,7 +234,7 @@ impl SettlementRanker {
         }
 
         // Filter out settlements with too high score.
-        rated_settlements.retain(|(solver, settlement, _)| {
+        rated_settlements.retain(|(solver, settlement)| {
             let surplus = big_rational_to_u256(&settlement.surplus).unwrap_or(U256::MAX);
             let fees = big_rational_to_u256(&settlement.solver_fees).unwrap_or(U256::MAX);
             let max_score = surplus.saturating_add(fees);
@@ -233,18 +260,19 @@ impl SettlementRanker {
         // Before sorting, make sure to shuffle the settlements. This is to make sure we
         // don't give preference to any specific solver when there is a score tie.
         rated_settlements.shuffle(&mut rand::thread_rng());
-        rated_settlements.sort_by_key(|s| s.1.score.score());
+        rated_settlements.sort_by_key(|(_, settlement)| settlement.score.score());
 
         rated_settlements
             .iter_mut()
             .rev()
             .enumerate()
-            .for_each(|(i, (solver, settlement, _))| {
+            .for_each(|(i, (solver, settlement))| {
                 self.metrics
                     .settlement_simulation(solver.name(), SolverSimulationOutcome::Success);
                 settlement.ranking = i + 1;
                 solver.notify_auction_result(auction_id, AuctionResult::Ranked(i + 1));
             });
+        let errors = errors.into_iter().map(|(_, error)| error).collect();
         Ok((rated_settlements, errors))
     }
 }

--- a/crates/solver/src/settlement_rater.rs
+++ b/crates/solver/src/settlement_rater.rs
@@ -9,14 +9,12 @@ use {
             simulate_and_estimate_gas_at_current_block,
         },
         settlement_submission::gas_limit_for_estimate,
-        solver::{SettlementWithSolver, Simulation, SimulationError, SimulationWithError, Solver},
+        solver::{Simulation, SimulationError, SimulationWithError, SolverInfo},
     },
     anyhow::{Context, Result},
     contracts::GPv2Settlement,
-    ethcontract::errors::ExecutionError,
-    futures::{future, future::join_all},
+    ethcontract::{errors::ExecutionError, Account},
     gas_estimation::GasPrice1559,
-    itertools::{Either, Itertools},
     model::solver_competition::Score,
     num::BigRational,
     number_conversions::big_rational_to_u256,
@@ -27,16 +25,9 @@ use {
         external_prices::ExternalPrices,
         http_solver::model::{InternalizationStrategy, SimulatedTransaction},
     },
-    std::{
-        borrow::Borrow,
-        collections::{HashMap, HashSet},
-        sync::Arc,
-    },
+    std::{borrow::Borrow, sync::Arc},
     web3::types::AccessList,
 };
-
-type SolverSettlement = (Arc<dyn Solver>, Settlement);
-pub type RatedSolverSettlement = (Arc<dyn Solver>, RatedSettlement, Option<AccessList>);
 
 struct SimulationSuccess {
     pub simulation: Simulation,
@@ -50,19 +41,24 @@ struct SimulationFailure {
 
 enum SimulationResult {
     Ok(SimulationSuccess),
-    Err(SimulationFailure)
+    Err(SimulationFailure),
+}
+
+pub enum Rating {
+    Ok(RatedSettlement),
+    Err(SimulationWithError),
 }
 
 #[mockall::automock]
 #[async_trait::async_trait]
 pub trait SettlementRating: Send + Sync {
-    /// Rate settlements, ignoring those for which the rating procedure failed.
-    async fn rate_settlements(
+    async fn rate_settlement(
         &self,
-        settlements: Vec<SolverSettlement>,
+        solver: &SolverInfo,
+        settlement: Settlement,
         prices: &ExternalPrices,
         gas_price: GasPrice1559,
-    ) -> Result<(Vec<RatedSolverSettlement>, Vec<SimulationWithError>)>;
+    ) -> Result<Rating>;
 }
 
 pub struct SettlementRater {
@@ -73,238 +69,189 @@ pub struct SettlementRater {
 }
 
 impl SettlementRater {
-    async fn append_access_lists(
+    async fn generate_access_list(
         &self,
-        solver_settlements: Vec<(Arc<dyn Solver>, Settlement)>,
+        account: &Account,
+        settlement: &Settlement,
         gas_price: GasPrice1559,
         internalization: InternalizationStrategy,
-    ) -> Vec<SettlementWithSolver> {
-        join_all(
-            solver_settlements
-                .into_iter()
-                .map(|(solver, settlement)| async {
-                    let tx = settle_method(
-                        gas_price,
-                        &self.settlement_contract,
-                        settlement.clone().encode(internalization),
-                        solver.account().clone(),
-                    )
-                    .tx;
-                    let access_list = estimate_settlement_access_list(
-                        self.access_list_estimator.borrow(),
-                        self.code_fetcher.borrow(),
-                        self.web3.clone(),
-                        solver.account().clone(),
-                        &settlement,
-                        &tx,
-                    )
-                    .await
-                    .ok();
-                    (solver, settlement, access_list)
-                }),
+    ) -> Option<AccessList> {
+        let tx = settle_method(
+            gas_price,
+            &self.settlement_contract,
+            settlement.clone().encode(internalization),
+            account.clone(),
+        )
+        .tx;
+        estimate_settlement_access_list(
+            self.access_list_estimator.borrow(),
+            self.code_fetcher.borrow(),
+            self.web3.clone(),
+            account.clone(),
+            settlement,
+            &tx,
         )
         .await
+        .ok()
     }
 
     /// Simulates the settlements and returns the gas used (or reason for
     /// revert) as well as the access list for each settlement.
-    async fn simulate_settlements(
+    async fn simulate_settlement(
         &self,
-        settlements: Vec<(Arc<dyn Solver>, Settlement)>,
+        solver: &SolverInfo,
+        settlement: &Settlement,
         gas_price: GasPrice1559,
         internalization: InternalizationStrategy,
-    ) -> Result<Vec<SimulationResult>> {
-        let settlements = self
-            .append_access_lists(settlements, gas_price, internalization)
+    ) -> Result<SimulationResult> {
+        let access_list = self
+            .generate_access_list(&solver.account, settlement, gas_price, internalization)
             .await;
         let block_number = self.web3.eth().block_number().await?.as_u64();
-        let simulations = simulate_and_estimate_gas_at_current_block(
-            settlements.iter().map(|(solver, settlement, access_list)| {
-                (
-                    solver.account().clone(),
-                    settlement.clone().encode(internalization),
-                    access_list.clone(),
-                )
-            }),
+        let simulation_result = simulate_and_estimate_gas_at_current_block(
+            std::iter::once((
+                solver.account.clone(),
+                settlement.clone().encode(internalization),
+                access_list.clone(),
+            )),
             &self.settlement_contract,
             gas_price,
         )
         .await
-        .context("failed to simulate settlements")?;
+        .context("failed to simulate settlements")?
+        .pop()
+        .expect("yields exactly 1 item");
 
-        let details: Vec<_> = settlements
-            .into_iter()
-            .zip(simulations.into_iter())
-            .map(
-                |((solver, settlement, access_list), simulation_result)| {
-                    let simulation = Simulation {
-                        transaction: SimulatedTransaction {
-                            internalization,
-                            access_list,
-                            block_number,
-                            to: self.settlement_contract.address(),
-                            from: solver.account().address(),
-                            data: call_data(settlement.clone().encode(internalization)),
-                            max_fee_per_gas: U256::from_f64_lossy(gas_price.max_fee_per_gas),
-                            max_priority_fee_per_gas: U256::from_f64_lossy(
-                                gas_price.max_priority_fee_per_gas,
-                            ),
-                        },
-                        settlement,
-                        solver,
-                    };
+        let simulation = Simulation {
+            transaction: SimulatedTransaction {
+                internalization,
+                access_list,
+                block_number,
+                to: self.settlement_contract.address(),
+                from: solver.account.address(),
+                data: call_data(settlement.clone().encode(internalization)),
+                max_fee_per_gas: U256::from_f64_lossy(gas_price.max_fee_per_gas),
+                max_priority_fee_per_gas: U256::from_f64_lossy(gas_price.max_priority_fee_per_gas),
+            },
+            settlement: settlement.clone(),
+            solver: solver.clone(),
+        };
 
-                    match simulation_result {
-                        Ok(gas_estimate) => SimulationResult::Ok(SimulationSuccess { simulation, gas_estimate }),
-                        Err(error) => SimulationResult::Err(SimulationFailure { simulation, error }),
-                    }
-                }
-            )
-            .collect();
-        Ok(details)
+        let result = match simulation_result {
+            Ok(gas_estimate) => SimulationResult::Ok(SimulationSuccess {
+                simulation,
+                gas_estimate,
+            }),
+            Err(error) => SimulationResult::Err(SimulationFailure { simulation, error }),
+        };
+        Ok(result)
     }
 }
 
 #[async_trait::async_trait]
 impl SettlementRating for SettlementRater {
-    async fn rate_settlements(
+    async fn rate_settlement(
         &self,
-        settlements: Vec<SolverSettlement>,
+        solver: &SolverInfo,
+        settlement: Settlement,
         prices: &ExternalPrices,
         gas_price: GasPrice1559,
-    ) -> Result<(Vec<RatedSolverSettlement>, Vec<SimulationWithError>)> {
+    ) -> Result<Rating> {
         // first simulate settlements without internalizations to make sure they pass
-        let simulations = self
-            .simulate_settlements(
-                settlements,
+        let simulation_result = self
+            .simulate_settlement(
+                solver,
+                &settlement,
                 gas_price,
                 InternalizationStrategy::EncodeAllInteractions,
             )
             .await?;
 
-        // split simulations into succeeded and failed groups, then do the rating only
-        // for succeeded settlements
-        let (settlements, simulations_failed): (Vec<_>, Vec<_>) = simulations
-            .into_iter()
-            .partition_map(|simulation| match simulation {
-                SimulationResult::Ok(simulation) => Either::Left((
-                    simulation.simulation.solver,
-                    simulation.simulation.settlement,
-                )),
-                SimulationResult::Err(_) => Either::Right(simulation),
-            });
+        if let SimulationResult::Err(err) = simulation_result {
+            return Ok(Rating::Err(SimulationWithError {
+                simulation: err.simulation,
+                error: err.error.into(),
+            }));
+        }
 
         // since rating is done with internalizations, repeat the simulations for
         // previously succeeded simulations
-        let mut simulations = self
-            .simulate_settlements(
-                settlements,
+        let simulation_result = self
+            .simulate_settlement(
+                solver,
+                &settlement,
                 gas_price,
                 InternalizationStrategy::SkipInternalizableInteraction,
             )
             .await?;
 
-        let effective_gas_price =
-            BigRational::from_float(gas_price.effective_gas_price()).expect("Invalid gas price.");
-
-        let rate_settlement = |id, settlement: Settlement, gas_estimate: U256| {
-            let earned_fees = settlement.total_earned_fees(prices);
-            let inputs = crate::objective_value::Inputs::from_settlement(
-                &settlement,
-                prices,
-                effective_gas_price.clone(),
-                &gas_estimate,
-            );
-            let objective_value = inputs.objective_value();
-            let score = match &settlement.score {
-                Some(score) => match score {
-                    shared::http_solver::model::Score::Score(score) => Score::Solver(*score),
-                    shared::http_solver::model::Score::Discount(discount) => Score::Discounted(
-                        big_rational_to_u256(&objective_value)
-                            .unwrap_or_default()
-                            .saturating_sub(*discount),
-                    ),
-                },
-                None => Score::Protocol(big_rational_to_u256(&objective_value).unwrap_or_default()),
-            };
-            RatedSettlement {
-                id,
-                settlement,
-                surplus: inputs.surplus_given,
-                earned_fees,
-                solver_fees: inputs.solver_fees,
-                gas_estimate,
-                gas_price: effective_gas_price.clone(),
-                objective_value,
-                score,
-                ranking: Default::default(),
+        let simulation = match simulation_result {
+            SimulationResult::Ok(success) => success,
+            SimulationResult::Err(err) => {
+                return Ok(Rating::Err(SimulationWithError {
+                    simulation: err.simulation,
+                    error: err.error.into(),
+                }))
             }
         };
 
-        let solver_balances = future::join_all(
-            simulations
-                .iter()
-                .filter_map(|result| match result {
-                    SimulationResult::Ok(s) => Some(s.simulation.solver.account().address()),
-                    _ => None
-                })
-                .collect::<HashSet<_>>()
-                .into_iter()
-                .map(|solver_address| {
-                    let web3 = self.web3.clone();
-                    async move {
-                        (
-                            solver_address,
-                            web3.eth()
-                                .balance(solver_address, None)
-                                .await
-                                .unwrap_or_default(),
-                        )
-                    }
-                }),
-        )
-        .await
-        .into_iter()
-        .collect::<HashMap<_, _>>();
+        let effective_gas_price =
+            BigRational::from_float(gas_price.effective_gas_price()).expect("Invalid gas price.");
 
-        simulations.extend(simulations_failed);
-        Ok((simulations.into_iter().enumerate()).partition_map(
-            |(
-                i,
-                simulation_result
-            )| {
-                match simulation_result {
-                    SimulationResult::Ok(success) => {
-                        let gas_limit = gas_limit_for_estimate(success.gas_estimate);
-                        let required_balance = gas_limit
-                            .saturating_mul(U256::from_f64_lossy(gas_price.max_fee_per_gas));
-                        let solver_balance = solver_balances
-                            .get(&success.simulation.solver.account().address())
-                            .copied()
-                            .unwrap_or_default();
+        let solver_balance = self
+            .web3
+            .eth()
+            .balance(solver.account.address(), None)
+            .await
+            .unwrap_or_default();
 
-                        if solver_balance >= required_balance {
-                            Either::Left((
-                                success.simulation.solver,
-                                rate_settlement(i, success.simulation.settlement, success.gas_estimate),
-                                success.simulation.transaction.access_list,
-                            ))
-                        } else {
-                            Either::Right(SimulationWithError {
-                                simulation: success.simulation,
-                                error: SimulationError::InsufficientBalance {
-                                    needs: required_balance,
-                                    has: solver_balance,
-                                },
-                            })
-                        }
-                    }
-                    SimulationResult::Err(error) => Either::Right(SimulationWithError {
-                        simulation: error.simulation,
-                        error: error.error.into(),
-                    }),
-                }
+        let gas_limit = gas_limit_for_estimate(simulation.gas_estimate);
+        let required_balance =
+            gas_limit.saturating_mul(U256::from_f64_lossy(gas_price.max_fee_per_gas));
+
+        if solver_balance < required_balance {
+            return Ok(Rating::Err(SimulationWithError {
+                simulation: simulation.simulation,
+                error: SimulationError::InsufficientBalance {
+                    needs: required_balance,
+                    has: solver_balance,
+                },
+            }));
+        }
+
+        let earned_fees = settlement.total_earned_fees(prices);
+        let inputs = crate::objective_value::Inputs::from_settlement(
+            &settlement,
+            prices,
+            effective_gas_price.clone(),
+            &simulation.gas_estimate,
+        );
+        let objective_value = inputs.objective_value();
+        let score = match &settlement.score {
+            Some(score) => match score {
+                shared::http_solver::model::Score::Score(score) => Score::Solver(*score),
+                shared::http_solver::model::Score::Discount(discount) => Score::Discounted(
+                    big_rational_to_u256(&objective_value)
+                        .unwrap_or_default()
+                        .saturating_sub(*discount),
+                ),
             },
-        ))
+            None => Score::Protocol(big_rational_to_u256(&objective_value).unwrap_or_default()),
+        };
+
+        let rated_settlement = RatedSettlement {
+            // TODO refactor or pass in?
+            id: Default::default(),
+            settlement,
+            surplus: inputs.surplus_given,
+            earned_fees,
+            solver_fees: inputs.solver_fees,
+            gas_estimate: simulation.gas_estimate,
+            gas_price: effective_gas_price.clone(),
+            objective_value,
+            score,
+            ranking: Default::default(),
+        };
+        Ok(Rating::Ok(rated_settlement))
     }
 }

--- a/crates/solver/src/settlement_rater.rs
+++ b/crates/solver/src/settlement_rater.rs
@@ -96,8 +96,8 @@ impl SettlementRater {
         .ok()
     }
 
-    /// Simulates the settlements and returns the gas used (or reason for
-    /// revert) as well as the access list for each settlement.
+    /// Simulates the settlement and returns the gas used or the reason for a
+    /// revert.
     async fn simulate_settlement(
         &self,
         solver: &SolverInfo,

--- a/crates/solver/src/settlement_rater.rs
+++ b/crates/solver/src/settlement_rater.rs
@@ -58,6 +58,7 @@ pub trait SettlementRating: Send + Sync {
         settlement: Settlement,
         prices: &ExternalPrices,
         gas_price: GasPrice1559,
+        id: usize,
     ) -> Result<Rating>;
 }
 
@@ -156,6 +157,7 @@ impl SettlementRating for SettlementRater {
         settlement: Settlement,
         prices: &ExternalPrices,
         gas_price: GasPrice1559,
+        id: usize,
     ) -> Result<Rating> {
         // first simulate settlements without internalizations to make sure they pass
         let simulation_result = self
@@ -240,8 +242,7 @@ impl SettlementRating for SettlementRater {
         };
 
         let rated_settlement = RatedSettlement {
-            // TODO refactor or pass in?
-            id: Default::default(),
+            id,
             settlement,
             surplus: inputs.surplus_given,
             earned_fees,

--- a/crates/solver/src/solver.rs
+++ b/crates/solver/src/solver.rs
@@ -175,9 +175,17 @@ pub type Solvers = Vec<Arc<dyn Solver>>;
 /// A single settlement and a solver that produced it.
 pub type SettlementWithSolver = (Arc<dyn Solver>, Settlement, Option<AccessList>);
 
+#[derive(Debug, Clone)]
+pub struct SolverInfo {
+    /// Identifier used for metrics and logging.
+    pub name: String,
+    /// Address used for simulating settlements of that solver.
+    pub account: Account,
+}
+
 pub struct Simulation {
     pub settlement: Settlement,
-    pub solver: Arc<dyn Solver>,
+    pub solver: SolverInfo,
     pub transaction: SimulatedTransaction,
 }
 


### PR DESCRIPTION
We recently noticed that the `1Inch` solver does not compute a fee for partially fillable limit orders.
To fix that I want to be able to simulate a settlement in the context of the `SingleOrderSolver`. This will allow us to get the exact gas used for a given settlement and will enable a bunch of other nice things like knowing before settlement merging which solutions work and which are the best. This would allow us to trivially merge the best solutions across all dex solvers to have a single more competitive gnosis solver (which also respects the rules that every solver should only submit a single solution)

Because the `SingleOrderSolver` does not store a `dyn Solver` we can't pass that to the `SettlementRater`.
I saw 2 options:
1. Adjust the `SettlementRater` to not take a `dyn Solver`
2. Build some sort of wrapper or new type that implements the `Solver` trait so I can use the `SettlementRater` as is.

Although `1` would have been very easy it seemed quite hacky so I went with `2`. (Feel free to comment if you disagree with the choice)

### Test Plan
Existing tests, CI
