### PR TITLE
Competition price estimator metrics

### DIFF
--- a/crates/shared/src/price_estimation/competition.rs
+++ b/crates/shared/src/price_estimation/competition.rs
@@ -115,11 +115,16 @@ impl RacingCompetitionPriceEstimator {
     ) -> Self {
         assert!(!inner.is_empty());
         Self {
-            competition: (successful_results_for_early_return.get() >= inner.len())
-                .then_some(Default::default()),
             inner,
             successful_results_for_early_return,
+            competition: None,
         }
+    }
+
+    /// Enables predicting the winning quote and gathering of related metrics.
+    pub fn with_preditions(mut self) -> Self {
+        self.competition = Some(Default::default());
+        self
     }
 }
 
@@ -230,6 +235,12 @@ impl CompetitionPriceEstimator {
         Self {
             inner: RacingCompetitionPriceEstimator::new(inner, number_of_estimators),
         }
+    }
+
+    /// Enables predicting the winning quote and gathering of related metrics.
+    pub fn with_preditions(mut self) -> Self {
+        self.inner.competition = Some(Default::default());
+        self
     }
 }
 

--- a/crates/shared/src/price_estimation/factory.rs
+++ b/crates/shared/src/price_estimation/factory.rs
@@ -327,9 +327,9 @@ impl<'a> PriceEstimatorFactory<'a> {
     ) -> Result<Arc<dyn PriceEstimating>> {
         let mut estimators = self.get_estimators(kinds, |entry| &entry.optimal)?;
         estimators.append(&mut self.get_external_estimators(drivers, |entry| &entry.optimal)?);
-        Ok(Arc::new(
-            self.sanitized(CompetitionPriceEstimator::new(estimators)),
-        ))
+        Ok(Arc::new(self.sanitized(
+            CompetitionPriceEstimator::new(estimators).with_preditions(),
+        )))
     }
 
     pub fn fast_price_estimator(


### PR DESCRIPTION
First work on #1428 

Implements the logic for collecting stats on which estimator regularly wins which kind of trade. Also we already start to make predictions (if we have enough data). But since we don't know how accurate our predictions would be we don't act upon them yet and instead only collect metrics. I expect the metrics introduced in this PR are probably not fine grained enough to properly evaluate the idea but it's a first step.

Because the price estimators currently only have their name as an identifier I used that in our stats as well. But because we store possibly every estimator name once per trade we can might use a lot of memory so I decided to only store ref counted Strings instead.

### Test Plan
CI, manual test for metrics (todo)