### PR TITLE
Allow missing fees on cheap chains

### DIFF
--- a/crates/solver/src/arguments.rs
+++ b/crates/solver/src/arguments.rs
@@ -361,7 +361,7 @@ pub struct Arguments {
     /// filllable limit orders or set the fee to 0. This can make sense on
     /// chains where we are not so concerned about the fee (e.g. gc,
     /// goerli).
-    #[clap(long, env, action = clap::ArgAction::Set, default_value = "false")]
+    #[clap(long, env, action = clap::ArgAction::Set, default_value = "true")]
     pub enforce_correct_fees_for_partially_fillable_limit_orders: bool,
 }
 

--- a/crates/solver/src/arguments.rs
+++ b/crates/solver/src/arguments.rs
@@ -357,9 +357,10 @@ pub struct Arguments {
     #[clap(long, env)]
     pub ethflow_contract: Option<H160>,
 
-    /// Controls whether we discard solutions with partially filllable limit
-    /// orders or set the fee to 0. This can make sense on chains where we
-    /// are not so concerned about the fee (e.g. gc, goerli).
+    /// Controls whether we discard solutions without a fee for partially
+    /// filllable limit orders or set the fee to 0. This can make sense on
+    /// chains where we are not so concerned about the fee (e.g. gc,
+    /// goerli).
     #[clap(long, env, action = clap::ArgAction::Set, default_value = "false")]
     pub enforce_correct_fees_for_partially_fillable_limit_orders: bool,
 }

--- a/crates/solver/src/arguments.rs
+++ b/crates/solver/src/arguments.rs
@@ -356,6 +356,12 @@ pub struct Arguments {
     /// disabled.
     #[clap(long, env)]
     pub ethflow_contract: Option<H160>,
+
+    /// Controls whether we discard solutions with partially filllable limit
+    /// orders or set the fee to 0. This can make sense on chains where we
+    /// are not so concerned about the fee (e.g. gc, goerli).
+    #[clap(long, env, action = clap::ArgAction::Set, default_value = "false")]
+    pub allow_missing_fees_for_partially_fillable_limit_orders: bool,
 }
 
 impl std::fmt::Display for Arguments {
@@ -501,6 +507,11 @@ impl std::fmt::Display for Arguments {
             self.process_partially_fillable_liquidity_orders
         )?;
         display_option(f, "ethflow_contract", &self.ethflow_contract)?;
+        writeln!(
+            f,
+            "allow_missing_fees_for_partially_fillable_limit_orders: {:?}",
+            self.allow_missing_fees_for_partially_fillable_limit_orders
+        )?;
         Ok(())
     }
 }

--- a/crates/solver/src/arguments.rs
+++ b/crates/solver/src/arguments.rs
@@ -361,7 +361,7 @@ pub struct Arguments {
     /// orders or set the fee to 0. This can make sense on chains where we
     /// are not so concerned about the fee (e.g. gc, goerli).
     #[clap(long, env, action = clap::ArgAction::Set, default_value = "false")]
-    pub allow_missing_fees_for_partially_fillable_limit_orders: bool,
+    pub enforce_correct_fees_for_partially_fillable_limit_orders: bool,
 }
 
 impl std::fmt::Display for Arguments {
@@ -509,8 +509,8 @@ impl std::fmt::Display for Arguments {
         display_option(f, "ethflow_contract", &self.ethflow_contract)?;
         writeln!(
             f,
-            "allow_missing_fees_for_partially_fillable_limit_orders: {:?}",
-            self.allow_missing_fees_for_partially_fillable_limit_orders
+            "enforce_correct_fees_for_partially_fillable_limit_orders: {:?}",
+            self.enforce_correct_fees_for_partially_fillable_limit_orders
         )?;
         Ok(())
     }

--- a/crates/solver/src/run.rs
+++ b/crates/solver/src/run.rs
@@ -343,6 +343,7 @@ pub async fn run(args: Arguments) {
         &domain,
         s3_instance_uploader,
         &args.score_params,
+        args.allow_missing_fees_for_partially_fillable_limit_orders,
     )
     .expect("failure creating solvers");
 

--- a/crates/solver/src/run.rs
+++ b/crates/solver/src/run.rs
@@ -343,7 +343,7 @@ pub async fn run(args: Arguments) {
         &domain,
         s3_instance_uploader,
         &args.score_params,
-        args.allow_missing_fees_for_partially_fillable_limit_orders,
+        args.enforce_correct_fees_for_partially_fillable_limit_orders,
     )
     .expect("failure creating solvers");
 

--- a/crates/solver/src/settlement_simulation.rs
+++ b/crates/solver/src/settlement_simulation.rs
@@ -692,7 +692,7 @@ mod tests {
             Arc::new(OrderConverter::test(H160([0x42; 20]))),
             SlippageContext::default(),
             &Default::default(),
-            false,
+            true,
         )
         .await
         .map(|settlement| vec![settlement])

--- a/crates/solver/src/settlement_simulation.rs
+++ b/crates/solver/src/settlement_simulation.rs
@@ -692,6 +692,7 @@ mod tests {
             Arc::new(OrderConverter::test(H160([0x42; 20]))),
             SlippageContext::default(),
             &Default::default(),
+            false,
         )
         .await
         .map(|settlement| vec![settlement])

--- a/crates/solver/src/solver.rs
+++ b/crates/solver/src/solver.rs
@@ -344,7 +344,7 @@ pub fn create(
     domain: &DomainSeparator,
     s3_instance_uploader: Option<Arc<S3InstanceUploader>>,
     score_configuration: &score_computation::Arguments,
-    allow_missing_fees: bool,
+    enforce_correct_fees: bool,
 ) -> Result<Solvers> {
     // Tiny helper function to help out with type inference. Otherwise, all
     // `Box::new(...)` expressions would have to be cast `as Box<dyn Solver>`.
@@ -401,7 +401,7 @@ pub fn create(
             *domain,
             shared_instance_creator.clone(),
             use_liquidity,
-            allow_missing_fees,
+            enforce_correct_fees,
         )
     };
 
@@ -431,7 +431,7 @@ pub fn create(
                 SolverType::Naive => shared(NaiveSolver::new(
                     account,
                     slippage_calculator,
-                    allow_missing_fees,
+                    enforce_correct_fees,
                 )),
                 SolverType::Baseline => shared(BaselineSolver::new(
                     account,
@@ -556,7 +556,7 @@ pub fn naive_solver(account: Account) -> Arc<dyn Solver> {
     Arc::new(NaiveSolver::new(
         account,
         SlippageCalculator::default(),
-        false,
+        true,
     ))
 }
 

--- a/crates/solver/src/solver.rs
+++ b/crates/solver/src/solver.rs
@@ -344,6 +344,7 @@ pub fn create(
     domain: &DomainSeparator,
     s3_instance_uploader: Option<Arc<S3InstanceUploader>>,
     score_configuration: &score_computation::Arguments,
+    allow_missing_fees: bool,
 ) -> Result<Solvers> {
     // Tiny helper function to help out with type inference. Otherwise, all
     // `Box::new(...)` expressions would have to be cast `as Box<dyn Solver>`.
@@ -370,11 +371,6 @@ pub fn create(
         instance_creator,
         s3_instance_uploader,
     ));
-
-    // On some chains (goerli, xdai) the fees are so small that we'd rather have the
-    // solver produce more working solutions than always have accurate fees for
-    // partially fillable limit orders.
-    let allow_missing_fees = [5, 100].iter().any(|id| *id == chain_id);
 
     // Helper function to create http solver instances.
     let create_http_solver = |account: Account,

--- a/crates/solver/src/solver/http_solver.rs
+++ b/crates/solver/src/solver/http_solver.rs
@@ -60,6 +60,7 @@ pub struct HttpSolver {
     // Liquidity information takes up a lot of space in the instance. Only some solvers (only
     // Quasimodo?) uses it so it is wasteful to send it to all of them.
     use_liquidity: bool,
+    allow_missing_fees: bool,
 }
 
 impl HttpSolver {
@@ -75,6 +76,7 @@ impl HttpSolver {
         domain: DomainSeparator,
         instance_cache: Arc<SharedInstanceCreator>,
         use_liquidity: bool,
+        allow_missing_fees: bool,
     ) -> Self {
         Self {
             solver,
@@ -87,6 +89,7 @@ impl HttpSolver {
             domain,
             instance_cache,
             use_liquidity,
+            allow_missing_fees,
         }
     }
 }
@@ -156,6 +159,7 @@ impl Solver for HttpSolver {
             self.order_converter.clone(),
             slippage,
             &self.domain,
+            self.allow_missing_fees,
         )
         .await
         {
@@ -318,6 +322,7 @@ mod tests {
                 None,
             )),
             true,
+            false,
         );
         let base = |x: u128| x * 10u128.pow(18);
         let limit_orders = vec![LimitOrder {

--- a/crates/solver/src/solver/http_solver.rs
+++ b/crates/solver/src/solver/http_solver.rs
@@ -60,7 +60,7 @@ pub struct HttpSolver {
     // Liquidity information takes up a lot of space in the instance. Only some solvers (only
     // Quasimodo?) uses it so it is wasteful to send it to all of them.
     use_liquidity: bool,
-    allow_missing_fees: bool,
+    enforce_correct_fees: bool,
 }
 
 impl HttpSolver {
@@ -76,7 +76,7 @@ impl HttpSolver {
         domain: DomainSeparator,
         instance_cache: Arc<SharedInstanceCreator>,
         use_liquidity: bool,
-        allow_missing_fees: bool,
+        enforce_correct_fees: bool,
     ) -> Self {
         Self {
             solver,
@@ -89,7 +89,7 @@ impl HttpSolver {
             domain,
             instance_cache,
             use_liquidity,
-            allow_missing_fees,
+            enforce_correct_fees,
         }
     }
 }
@@ -159,7 +159,7 @@ impl Solver for HttpSolver {
             self.order_converter.clone(),
             slippage,
             &self.domain,
-            self.allow_missing_fees,
+            self.enforce_correct_fees,
         )
         .await
         {
@@ -322,7 +322,7 @@ mod tests {
                 None,
             )),
             true,
-            false,
+            true,
         );
         let base = |x: u128| x * 10u128.pow(18);
         let limit_orders = vec![LimitOrder {

--- a/crates/solver/src/solver/http_solver/settlement.rs
+++ b/crates/solver/src/solver/http_solver/settlement.rs
@@ -42,6 +42,7 @@ pub async fn convert_settlement(
     order_converter: Arc<OrderConverter>,
     slippage: SlippageContext<'_>,
     domain: &DomainSeparator,
+    allow_missing_fees: bool,
 ) -> Result<Settlement, ConversionError> {
     IntermediateSettlement::new(
         settled,
@@ -50,6 +51,7 @@ pub async fn convert_settlement(
         order_converter,
         slippage,
         domain,
+        allow_missing_fees,
     )
     .await?
     .into_settlement()
@@ -83,15 +85,20 @@ impl Execution {
         settlement: &mut Settlement,
         slippage: &SlippageContext,
         internalizable: bool,
+        allow_missing_fees: bool,
     ) -> Result<()> {
         use Execution::*;
 
         match self {
             LimitOrder(order) => {
                 let solver_fee = match order.order.solver_determines_fee() {
-                    true => order
-                        .executed_fee_amount
-                        .context("no fee for partially fillable limit order")?,
+                    true => {
+                        let fee = order.executed_fee_amount;
+                        match allow_missing_fees {
+                            true => fee.unwrap_or_default(),
+                            false => fee.context("no fee for partially fillable limit order")?,
+                        }
+                    }
                     false => order.order.solver_fee,
                 };
 
@@ -146,6 +153,8 @@ struct IntermediateSettlement<'a> {
     slippage: SlippageContext<'a>,
     submitter: SubmissionPreference,
     score: Option<Score>,
+    // Causes either an error or a fee of 0 whenever a fee is expected but none was provided.
+    allow_missing_fees: bool,
 }
 
 // Conversion error happens during building a settlement from a solution
@@ -211,6 +220,7 @@ impl<'a> IntermediateSettlement<'a> {
         order_converter: Arc<OrderConverter>,
         slippage: SlippageContext<'a>,
         domain: &DomainSeparator,
+        allow_missing_fees: bool,
     ) -> Result<IntermediateSettlement<'a>, ConversionError> {
         let executed_limit_orders =
             match_prepared_and_settled_orders(&context.orders, settled.orders)?;
@@ -244,6 +254,7 @@ impl<'a> IntermediateSettlement<'a> {
             slippage,
             submitter,
             score,
+            allow_missing_fees,
         })
     }
 
@@ -264,7 +275,12 @@ impl<'a> IntermediateSettlement<'a> {
                 .execution_plan()
                 .map(|exec_plan| exec_plan.internal)
                 .unwrap_or_default();
-            execution.add_to_settlement(&mut settlement, &self.slippage, internalizable)?;
+            execution.add_to_settlement(
+                &mut settlement,
+                &self.slippage,
+                internalizable,
+                self.allow_missing_fees,
+            )?;
         }
 
         Ok(settlement)
@@ -692,6 +708,7 @@ mod tests {
             Arc::new(OrderConverter::test(weth)),
             SlippageContext::default(),
             &Default::default(),
+            false,
         )
         .await
         .unwrap();

--- a/crates/solver/src/solver/naive_solver.rs
+++ b/crates/solver/src/solver/naive_solver.rs
@@ -20,19 +20,19 @@ use {
 pub struct NaiveSolver {
     account: Account,
     slippage_calculator: SlippageCalculator,
-    allow_missing_fees: bool,
+    enforce_correct_fees: bool,
 }
 
 impl NaiveSolver {
     pub fn new(
         account: Account,
         slippage_calculator: SlippageCalculator,
-        allow_missing_fees: bool,
+        enforce_correct_fees: bool,
     ) -> Self {
         Self {
             account,
             slippage_calculator,
-            allow_missing_fees,
+            enforce_correct_fees,
         }
     }
 }
@@ -50,7 +50,7 @@ impl Solver for NaiveSolver {
     ) -> Result<Vec<Settlement>> {
         // Filter out partially fillable limit orders until we add support for computing
         // a reasonable `solver_fee` (#1414).
-        orders.retain(|o| !o.solver_determines_fee() || self.allow_missing_fees);
+        orders.retain(|o| !o.solver_determines_fee() || !self.enforce_correct_fees);
         let slippage = self.slippage_calculator.context(&external_prices);
         let uniswaps = extract_deepest_amm_liquidity(&liquidity);
         Ok(settle(slippage, orders, uniswaps))

--- a/crates/solver/src/solver/naive_solver.rs
+++ b/crates/solver/src/solver/naive_solver.rs
@@ -20,13 +20,19 @@ use {
 pub struct NaiveSolver {
     account: Account,
     slippage_calculator: SlippageCalculator,
+    allow_missing_fees: bool,
 }
 
 impl NaiveSolver {
-    pub fn new(account: Account, slippage_calculator: SlippageCalculator) -> Self {
+    pub fn new(
+        account: Account,
+        slippage_calculator: SlippageCalculator,
+        allow_missing_fees: bool,
+    ) -> Self {
         Self {
             account,
             slippage_calculator,
+            allow_missing_fees,
         }
     }
 }
@@ -44,7 +50,7 @@ impl Solver for NaiveSolver {
     ) -> Result<Vec<Settlement>> {
         // Filter out partially fillable limit orders until we add support for computing
         // a reasonable `solver_fee` (#1414).
-        orders.retain(|o| !o.solver_determines_fee());
+        orders.retain(|o| !o.solver_determines_fee() || self.allow_missing_fees);
         let slippage = self.slippage_calculator.context(&external_prices);
         let uniswaps = extract_deepest_amm_liquidity(&liquidity);
         Ok(settle(slippage, orders, uniswaps))


### PR DESCRIPTION
@fleupold requested a hotfix to support an OTC trade on GC. This currently fails because solvers that could facilitate that trade (Naive, Quasimodo) are not participating in the solver competition because their solutions get discarded due to missing fees for partially fillable limit orders.
This PR adds a new CLI argument that either triggers a partially fillable trade without a fee to be discarded or sets the fee to 0.

### Test Plan
compiler
