### PR TITLE
Enable quote predictions for native price estimator

### DIFF
--- a/crates/shared/src/price_estimation/factory.rs
+++ b/crates/shared/src/price_estimation/factory.rs
@@ -363,9 +363,13 @@ impl<'a> PriceEstimatorFactory<'a> {
         );
         let mut estimators = self.get_estimators(kinds, |entry| &entry.native)?;
         estimators.append(&mut self.get_external_estimators(drivers, |entry| &entry.native)?);
+        let competition_estimator = CompetitionPriceEstimator::new(estimators);
         let native_estimator = Arc::new(CachingNativePriceEstimator::new(
             Box::new(NativePriceEstimator::new(
-                Arc::new(self.sanitized(CompetitionPriceEstimator::new(estimators))),
+                Arc::new(self.sanitized(match self.args.enable_quote_predictions {
+                    true => competition_estimator.with_predictions(),
+                    false => competition_estimator,
+                })),
                 self.network.native_token,
                 self.native_token_price_estimation_amount()?,
             )),


### PR DESCRIPTION
In order to get even more data with https://github.com/cowprotocol/services/pull/1456 we can also collect the price prediction metrics for the native price estimator as it's not able to introduce any bias like the fast price estimator would.
This was really an oversight in the linked PR as I thought the native price estimator would already use the optimal price estimator under the hood. Should have verified that.

### Test Plan
CI
