### PR TITLE
Stop Rate Limited Single Order Solver

### DIFF
--- a/crates/solver/src/solver/single_order_solver.rs
+++ b/crates/solver/src/solver/single_order_solver.rs
@@ -204,17 +204,17 @@ impl SingleOrderSolver {
             }
             Err(SettlementError::RateLimited) => {
                 self.metrics.single_order_solver_failed(name);
-                tracing::warn!(%name, "rate limited");
-                return SolveResult::Failed;
+                tracing::warn!("rate limited");
+                return SolveResult::RateLimited;
             }
             Err(SettlementError::Retryable(err)) => {
                 self.metrics.single_order_solver_failed(name);
-                tracing::warn!(%name, ?err, "retryable error");
+                tracing::warn!(?err, "retryable error");
                 return SolveResult::Retryable(order);
             }
             Err(SettlementError::Other(err)) => {
                 self.metrics.single_order_solver_failed(name);
-                tracing::warn!(%name, ?err, "failed");
+                tracing::warn!(?err, "failed");
                 return SolveResult::Failed;
             }
         };
@@ -237,7 +237,7 @@ impl SingleOrderSolver {
                 SolveResult::Solved(settlement)
             }
             Some(Err(err)) => {
-                tracing::warn!(%name, ?err, "encoding error");
+                tracing::warn!(?err, "encoding error");
                 SolveResult::Failed
             }
             None => {
@@ -251,12 +251,16 @@ impl SingleOrderSolver {
 }
 
 enum SolveResult {
+    /// Found a solution for the order.
+    Solved(Settlement),
+
     /// No solution but order could be retried.
     Retryable(LimitOrder),
     /// No solution and retrying would not help.
     Failed,
-    /// Found a solution for the order.
-    Solved(Settlement),
+    /// The single solver solver is rate limiting, back off until the next
+    /// auction (as all single order solves will fail anyway).
+    RateLimited,
 }
 
 #[async_trait::async_trait]
@@ -267,7 +271,7 @@ impl Solver for SingleOrderSolver {
             &auction.external_prices,
             &self.order_prioritization_config,
         );
-        tracing::trace!(name = self.name(), ?orders, "prioritized orders");
+        tracing::trace!(solver = self.name(), ?orders, "prioritized orders");
 
         let mut settlements = Vec::new();
         let settle = async {
@@ -278,9 +282,16 @@ impl Solver for SingleOrderSolver {
                     .instrument(span)
                     .await
                 {
+                    SolveResult::Solved(settlement) => settlements.push(settlement),
                     SolveResult::Failed => continue,
                     SolveResult::Retryable(order) => orders.push_back(order),
-                    SolveResult::Solved(settlement) => settlements.push(settlement),
+                    SolveResult::RateLimited => {
+                        tracing::warn!(
+                            solver = %self.name(),
+                            "rate limited; backing off until next auction"
+                        );
+                        break;
+                    }
                 }
             }
         };
@@ -741,11 +752,6 @@ mod tests {
         inner
             .expect_try_settle_order()
             .times(1)
-            .returning(|_, _| Err(SettlementError::RateLimited))
-            .in_sequence(&mut seq);
-        inner
-            .expect_try_settle_order()
-            .times(1)
             .returning(|_, _| Err(SettlementError::Other(anyhow!(""))))
             .in_sequence(&mut seq);
 
@@ -757,7 +763,33 @@ mod tests {
         };
         solver
             .solve(Auction {
-                orders: vec![order(), order()],
+                orders: vec![order()],
+                ..Default::default()
+            })
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn stops_trying_when_rate_limited() {
+        let mut inner = MockSingleOrderSolving::new();
+        let mut seq = Sequence::new();
+        inner.expect_name().return_const("");
+        inner
+            .expect_try_settle_order()
+            .times(1)
+            .returning(|_, _| Err(SettlementError::RateLimited))
+            .in_sequence(&mut seq);
+
+        let solver = test_solver(inner);
+        let handler = Arc::new(CapturingSettlementHandler::default());
+        let order = || LimitOrder {
+            settlement_handling: handler.clone(),
+            ..Default::default()
+        };
+        solver
+            .solve(Auction {
+                orders: vec![order(), order(), order()],
                 ..Default::default()
             })
             .await


### PR DESCRIPTION
In #1442 we introduced rate limiting logic to single order solvers. This was done to allow single order solvers to recover in the face of too many orders (single order solvers were entering a "death spiral", where at some point within an auction, it would get rate limited and continue single order solving for the remaining orders in the book, making the problem even worse).

The fix helped in that we are no longer sending requests to external APIs for some time when rate limited, however, it caused issues with the single order solver success metrics. Specifically, when a solver gets rate limited, it will fail all orders until the rate limit backoff timeout is done. This causes solvers that are being rate limited at some point in an auction to have inflated error numbers (since the single order solve finishes very quickly, and the solver will run through the entire orderbook like before, but without actually making requests to the 3rd party service that is rate limiting us).

This PR changes the single order solver logic to always back-off the remainder of an auction.

### Test Plan

Added new unit test to verify logic.
