### PR TITLE
Add metrics for dropped quotes

### DIFF
--- a/crates/shared/src/price_estimation.rs
+++ b/crates/shared/src/price_estimation.rs
@@ -163,6 +163,12 @@ pub struct Arguments {
     /// trade and enables metrics accordingly.
     #[clap(long, env, action = clap::ArgAction::Set, default_value = "false")]
     pub enable_quote_predictions: bool,
+
+    /// Determines how confident we want to be that we quote the best price.
+    /// If the value is < 1 we may skip sending quote requests to price
+    /// estimators that perform poorly for the given trade.
+    #[clap(long, env, default_value = "1")]
+    pub quote_prediction_confidence: f64,
 }
 
 impl Display for Arguments {

--- a/crates/shared/src/price_estimation/factory.rs
+++ b/crates/shared/src/price_estimation/factory.rs
@@ -330,7 +330,9 @@ impl<'a> PriceEstimatorFactory<'a> {
         let competition_estimator = CompetitionPriceEstimator::new(estimators);
         Ok(Arc::new(self.sanitized(
             match self.args.enable_quote_predictions {
-                true => competition_estimator.with_predictions(),
+                true => {
+                    competition_estimator.with_predictions(self.args.quote_prediction_confidence)
+                }
                 false => competition_estimator,
             },
         )))
@@ -366,10 +368,13 @@ impl<'a> PriceEstimatorFactory<'a> {
         let competition_estimator = CompetitionPriceEstimator::new(estimators);
         let native_estimator = Arc::new(CachingNativePriceEstimator::new(
             Box::new(NativePriceEstimator::new(
-                Arc::new(self.sanitized(match self.args.enable_quote_predictions {
-                    true => competition_estimator.with_predictions(),
-                    false => competition_estimator,
-                })),
+                Arc::new(
+                    self.sanitized(match self.args.enable_quote_predictions {
+                        true => competition_estimator
+                            .with_predictions(self.args.quote_prediction_confidence),
+                        false => competition_estimator,
+                    }),
+                ),
                 self.network.native_token,
                 self.native_token_price_estimation_amount()?,
             )),


### PR DESCRIPTION
Related to #1428

This PR adds another CLI argument determining how confident we want to be that we provide the best price. This PR still doesn't actually drop any requests. We just simulate how many requests we would actually drop and how often we would still report the best price.
Hopefully this experiment shows that we can drop lots of price estimation requests if we only require a very high confidence of providing the best price. But it's even possible that we could drop a bunch of requests if we set the required confidence to 100%.

In the final implementation we should still add a chance to send requests to solvers we normally not send requests just in case they win a requests every now and again.

### Test Plan
CI