### PR TITLE
Always capture backtrace on panic

### DIFF
--- a/crates/shared/src/tracing.rs
+++ b/crates/shared/src/tracing.rs
@@ -61,6 +61,6 @@ fn set_tracing_subscriber(env_filter: &str, stderr_threshold: LevelFilter) {
 fn tracing_panic_hook(panic: &PanicInfo) {
     let thread = std::thread::current();
     let name = thread.name().unwrap_or("<unnamed>");
-    let backtrace = std::backtrace::Backtrace::capture();
+    let backtrace = std::backtrace::Backtrace::force_capture();
     tracing::error!("thread '{name}' {panic}\nstack backtrace:\n{backtrace}");
 }


### PR DESCRIPTION
Context https://github.com/cowprotocol/oncall/issues/13 .

`Backtrace::capture` doesn't capture a backtrace if the environment variable RUST_LIB_BACKTRACE is set to 0 because capturing a backtrace is slow.  This PR switches to `force_captures` which does what the name implies. This is fine because this code isn't performance sensitive because it only runs just before killing the process after a panic anyway.