### PR TITLE
Move order pre processing into solvers

### DIFF
--- a/crates/solver/src/auction_preprocessing.rs
+++ b/crates/solver/src/auction_preprocessing.rs
@@ -1,8 +1,10 @@
 //! Submodule containing helper methods to pre-process auction data before
 //! passing it on to the solvers.
 
-use crate::liquidity::LimitOrder;
+use model::order::Order;
 
-pub fn has_at_least_one_user_order(orders: &[LimitOrder]) -> bool {
-    orders.iter().any(|order| !order.is_liquidity_order())
+pub fn has_at_least_one_user_order(orders: &[Order]) -> bool {
+    orders
+        .iter()
+        .any(|order| !order.metadata.is_liquidity_order)
 }

--- a/crates/solver/src/liquidity/order_converter.rs
+++ b/crates/solver/src/liquidity/order_converter.rs
@@ -19,6 +19,7 @@ use {
     std::sync::Arc,
 };
 
+#[derive(Clone)]
 pub struct OrderConverter {
     pub native_token: WETH9,
 }
@@ -43,9 +44,8 @@ impl OrderConverter {
             available_sell_token_balance,
         }: BalancedOrder,
     ) -> Result<LimitOrder> {
-        let native_token = self.native_token.clone();
         let buy_token = if order.data.buy_token == BUY_ETH_ADDRESS {
-            native_token.address()
+            self.native_token.address()
         } else {
             order.data.buy_token
         };
@@ -91,7 +91,7 @@ impl OrderConverter {
             solver_fee,
             settlement_handling: Arc::new(OrderSettlementHandler {
                 order,
-                native_token,
+                native_token: self.native_token.clone(),
             }),
             exchange: Exchange::GnosisProtocol,
         })

--- a/crates/solver/src/liquidity/slippage.rs
+++ b/crates/solver/src/liquidity/slippage.rs
@@ -2,7 +2,7 @@
 
 use {
     super::{AmmOrderExecution, LimitOrder},
-    crate::solver::{Auction, SolverType},
+    crate::solver::SolverType,
     anyhow::{anyhow, Context as _, Result},
     clap::{Parser, ValueEnum as _},
     ethcontract::{H160, U256},
@@ -316,10 +316,6 @@ impl SlippageCalculator {
             prices,
             calculator: self,
         }
-    }
-
-    pub fn auction_context<'a>(&'a self, auction: &'a Auction) -> SlippageContext<'a> {
-        self.context(&auction.external_prices)
     }
 
     /// Computes the capped slippage amount for the specified token price and

--- a/crates/solver/src/metrics.rs
+++ b/crates/solver/src/metrics.rs
@@ -1,8 +1,5 @@
 use {
-    crate::{
-        liquidity::{LimitOrder, Liquidity},
-        settlement::Revertable,
-    },
+    crate::{liquidity::Liquidity, settlement::Revertable},
     anyhow::Result,
     ethcontract::U256,
     model::order::{Order, OrderClass},
@@ -98,7 +95,7 @@ impl SolverSimulationOutcome {
 }
 
 pub trait SolverMetrics: Send + Sync {
-    fn orders_fetched(&self, orders: &[LimitOrder]);
+    fn orders_fetched(&self, orders: &[Order]);
     fn liquidity_fetched(&self, liquidity: &[Liquidity]);
     fn settlement_computed(&self, solver_type: &str, response: &str, start: Instant);
     fn order_settled(&self, order: &Order, solver: &str);
@@ -217,10 +214,10 @@ impl Metrics {
 }
 
 impl SolverMetrics for Metrics {
-    fn orders_fetched(&self, orders: &[LimitOrder]) {
+    fn orders_fetched(&self, orders: &[Order]) {
         let user_orders = orders
             .iter()
-            .filter(|order| !order.is_liquidity_order())
+            .filter(|order| !order.metadata.is_liquidity_order)
             .count();
         let liquidity_orders = orders.len() - user_orders;
 
@@ -394,7 +391,7 @@ impl LivenessChecking for Metrics {
 pub struct NoopMetrics {}
 
 impl SolverMetrics for NoopMetrics {
-    fn orders_fetched(&self, _liquidity: &[LimitOrder]) {}
+    fn orders_fetched(&self, _liquidity: &[Order]) {}
 
     fn liquidity_fetched(&self, _liquidity: &[Liquidity]) {}
 

--- a/crates/solver/src/settlement_simulation.rs
+++ b/crates/solver/src/settlement_simulation.rs
@@ -689,7 +689,7 @@ mod tests {
             parsed_response.unwrap(),
             &settlement_context,
             Arc::new(MockAllowanceManaging::new()),
-            Arc::new(OrderConverter::test(H160([0x42; 20]))),
+            &OrderConverter::test(H160([0x42; 20])),
             SlippageContext::default(),
             &Default::default(),
             true,

--- a/crates/solver/src/solver/http_solver/settlement.rs
+++ b/crates/solver/src/solver/http_solver/settlement.rs
@@ -39,7 +39,7 @@ pub async fn convert_settlement(
     settled: SettledBatchAuctionModel,
     context: &SettlementContext,
     allowance_manager: Arc<dyn AllowanceManaging>,
-    order_converter: Arc<OrderConverter>,
+    order_converter: &OrderConverter,
     slippage: SlippageContext<'_>,
     domain: &DomainSeparator,
     enforce_correct_fees: bool,
@@ -217,7 +217,7 @@ impl<'a> IntermediateSettlement<'a> {
         settled: SettledBatchAuctionModel,
         context: &SettlementContext,
         allowance_manager: Arc<dyn AllowanceManaging>,
-        order_converter: Arc<OrderConverter>,
+        order_converter: &OrderConverter,
         slippage: SlippageContext<'a>,
         domain: &DomainSeparator,
         enforce_correct_fees: bool,
@@ -322,7 +322,7 @@ fn match_prepared_and_settled_orders(
 }
 
 fn convert_foreign_liquidity_orders(
-    order_converter: Arc<OrderConverter>,
+    order_converter: &OrderConverter,
     foreign_liquidity_orders: Vec<ExecutedLiquidityOrderModel>,
     domain: &DomainSeparator,
 ) -> Result<Vec<ExecutedLimitOrder>> {
@@ -707,7 +707,7 @@ mod tests {
             settled,
             &prepared,
             Arc::new(MockAllowanceManaging::new()),
-            Arc::new(OrderConverter::test(weth)),
+            &OrderConverter::test(weth),
             SlippageContext::default(),
             &Default::default(),
             true,

--- a/crates/solver/src/solver/single_order_solver.rs
+++ b/crates/solver/src/solver/single_order_solver.rs
@@ -1,7 +1,12 @@
 use {
     super::SolverInfo,
     crate::{
-        liquidity::{LimitOrder, LimitOrderExecution, LimitOrderId},
+        liquidity::{
+            order_converter::OrderConverter,
+            LimitOrder,
+            LimitOrderExecution,
+            LimitOrderId,
+        },
         metrics::SolverMetrics,
         settlement::Settlement,
         settlement_rater::{Rating, SettlementRating},
@@ -15,7 +20,7 @@ use {
     model::order::OrderKind,
     num::{CheckedDiv, ToPrimitive},
     number_conversions::u256_to_big_rational,
-    primitive_types::U256,
+    primitive_types::{H160, U256},
     rand::prelude::SliceRandom,
     shared::{
         arguments::display_option,
@@ -165,9 +170,12 @@ pub struct SingleOrderSolver {
     rate_limiter: Arc<RateLimiter>,
     fills: fills::Fills,
     settlement_rater: Arc<dyn SettlementRating>,
+    ethflow_contract: Option<H160>,
+    order_converter: OrderConverter,
 }
 
 impl SingleOrderSolver {
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         inner: Box<dyn SingleOrderSolving>,
         metrics: Arc<dyn SolverMetrics>,
@@ -176,6 +184,8 @@ impl SingleOrderSolver {
         arguments: Arguments,
         smallest_fill: U256,
         settlement_rater: Arc<dyn SettlementRating>,
+        ethflow_contract: Option<H160>,
+        order_converter: OrderConverter,
     ) -> Self {
         let rate_limiter = arguments.rate_limiter(inner.name());
         Self {
@@ -187,6 +197,8 @@ impl SingleOrderSolver {
             rate_limiter,
             fills: fills::Fills::new(smallest_fill),
             settlement_rater,
+            ethflow_contract,
+            order_converter,
         }
     }
 
@@ -259,10 +271,11 @@ impl SingleOrderSolver {
     async fn finalize_settlement(
         &self,
         intermediate: SingleOrderSettlement,
-        auction: &Auction,
+        external_prices: &ExternalPrices,
+        gas_price: f64,
         id: usize,
     ) -> Result<Option<Settlement>> {
-        let settlement = intermediate.into_settlement(&auction.external_prices, &0.into());
+        let settlement = intermediate.into_settlement(external_prices, &0.into());
         let settlement = match settlement {
             Ok(Some(settlement)) => settlement,
             Err(err) => return Err(err),
@@ -277,11 +290,11 @@ impl SingleOrderSolver {
                     account: self.account().clone(),
                 },
                 settlement,
-                &auction.external_prices,
+                external_prices,
                 GasPrice1559 {
-                    base_fee_per_gas: auction.gas_price,
+                    base_fee_per_gas: gas_price,
                     // factor in 1 block of maximal gas increase
-                    max_fee_per_gas: auction.gas_price * 1.125,
+                    max_fee_per_gas: gas_price * 1.125,
                     max_priority_fee_per_gas: 0.,
                 },
                 id,
@@ -295,10 +308,10 @@ impl SingleOrderSolver {
 
         let gas_cost = simulation
             .gas_estimate
-            .checked_mul(U256::from_f64_lossy(auction.gas_price))
+            .checked_mul(U256::from_f64_lossy(gas_price))
             .ok_or_else(|| anyhow::anyhow!("overflow during gas cost computation"))?;
 
-        intermediate.into_settlement(&auction.external_prices, &gas_cost)
+        intermediate.into_settlement(external_prices, &gas_cost)
     }
 }
 
@@ -316,12 +329,25 @@ enum SolveResult {
 
 #[async_trait::async_trait]
 impl Solver for SingleOrderSolver {
-    async fn solve(&self, auction: Auction) -> Result<Vec<Settlement>> {
-        let mut orders = get_prioritized_orders(
-            &auction.orders,
-            &auction.external_prices,
-            &self.order_prioritization_config,
+    async fn solve(
+        &self,
+        Auction {
+            orders,
+            balances,
+            external_prices,
+            gas_price,
+            deadline,
+            ..
+        }: Auction,
+    ) -> Result<Vec<Settlement>> {
+        let orders = super::balance_and_convert_orders(
+            self.ethflow_contract,
+            &self.order_converter,
+            &balances,
+            orders,
         );
+        let mut orders =
+            get_prioritized_orders(&orders, &external_prices, &self.order_prioritization_config);
         tracing::trace!(solver = self.name(), ?orders, "prioritized orders");
 
         let mut settlements = Vec::new();
@@ -331,7 +357,7 @@ impl Solver for SingleOrderSolver {
             while let Some(order) = orders.pop_front() {
                 let span = tracing::info_span!("solve", id =? order.id, solver = self.name());
                 match self
-                    .solve_single_order(order, &auction.external_prices, auction.gas_price)
+                    .solve_single_order(order, &external_prices, gas_price)
                     .instrument(span)
                     .await
                 {
@@ -356,7 +382,7 @@ impl Solver for SingleOrderSolver {
             let mut index = 0;
             while let Some(intermediate) = rx.recv().await {
                 match self
-                    .finalize_settlement(intermediate, &auction, index)
+                    .finalize_settlement(intermediate, &external_prices, gas_price, index)
                     .await
                 {
                     Ok(Some(settlement)) => {
@@ -373,13 +399,8 @@ impl Solver for SingleOrderSolver {
 
         // Subtract a small amount of time to ensure that the driver doesn't reach the
         // deadline first.
-        let timeout = tokio::time::sleep_until(
-            auction
-                .deadline
-                .checked_sub(Duration::from_secs(1))
-                .unwrap()
-                .into(),
-        );
+        let timeout =
+            tokio::time::sleep_until(deadline.checked_sub(Duration::from_secs(1)).unwrap().into());
 
         // open new scope for solve->finalize pipeline to make borrow checker happy
         {
@@ -410,7 +431,7 @@ impl Solver for SingleOrderSolver {
 
         merge::merge_settlements(
             self.max_merged_settlements,
-            &auction.external_prices,
+            &external_prices,
             &mut settlements,
         );
 
@@ -656,14 +677,9 @@ mod tests {
     use {
         super::*,
         crate::{
-            liquidity::{
-                order_converter::OrderConverter,
-                tests::CapturingSettlementHandler,
-                LimitOrderId,
-                LiquidityOrderId,
-            },
+            liquidity::{order_converter::OrderConverter, LimitOrderId, LiquidityOrderId},
             metrics::NoopMetrics,
-            order_balance_filter::BalancedOrder,
+            order_balance_filter::{max_balance, BalancedOrder},
             settlement::TradeExecution,
             settlement_rater::MockSettlementRating,
         },
@@ -696,13 +712,14 @@ mod tests {
             rate_limiter: RateLimiter::test(),
             fills: fills::Fills::new(1.into()),
             settlement_rater: Arc::new(settlement_rating),
+            ethflow_contract: None,
+            order_converter: OrderConverter::test(Default::default()),
         }
     }
 
     #[tokio::test]
     async fn merges() {
         let native = H160::from_low_u64_be(0);
-        let converter = OrderConverter::test(native);
         let buy_order = Order {
             data: OrderData {
                 sell_token: H160::from_low_u64_be(1),
@@ -733,14 +750,8 @@ mod tests {
             },
             ..Default::default()
         };
-        let orders = [&buy_order, &sell_order]
-            .iter()
-            .map(|order| {
-                converter
-                    .normalize_limit_order(BalancedOrder::full(Order::clone(order)))
-                    .unwrap()
-            })
-            .collect::<Vec<_>>();
+        let orders: Vec<Order> = vec![buy_order.clone(), sell_order.clone()];
+        let balances = max_balance(&orders);
 
         let mut inner = MockSingleOrderSolving::new();
         inner
@@ -792,6 +803,7 @@ mod tests {
             .solve(Auction {
                 external_prices,
                 orders,
+                balances,
                 ..Default::default()
             })
             .await
@@ -837,14 +849,19 @@ mod tests {
             });
 
         let solver = test_solver(inner);
-        let handler = Arc::new(CapturingSettlementHandler::default());
-        let order = LimitOrder {
-            settlement_handling: handler.clone(),
+        let orders = vec![Order {
+            data: OrderData {
+                sell_amount: 1.into(),
+                buy_amount: 1.into(),
+                ..Default::default()
+            },
             ..Default::default()
-        };
+        }];
+        let balances = max_balance(&orders);
         solver
             .solve(Auction {
-                orders: vec![order],
+                orders,
+                balances,
                 ..Default::default()
             })
             .await
@@ -863,14 +880,19 @@ mod tests {
             .in_sequence(&mut seq);
 
         let solver = test_solver(inner);
-        let handler = Arc::new(CapturingSettlementHandler::default());
-        let order = || LimitOrder {
-            settlement_handling: handler.clone(),
+        let orders = vec![Order {
+            data: OrderData {
+                sell_amount: 1.into(),
+                buy_amount: 1.into(),
+                ..Default::default()
+            },
             ..Default::default()
-        };
+        }];
+        let balances = max_balance(&orders);
         solver
             .solve(Auction {
-                orders: vec![order()],
+                orders,
+                balances,
                 ..Default::default()
             })
             .await
@@ -889,14 +911,22 @@ mod tests {
             .in_sequence(&mut seq);
 
         let solver = test_solver(inner);
-        let handler = Arc::new(CapturingSettlementHandler::default());
-        let order = || LimitOrder {
-            settlement_handling: handler.clone(),
-            ..Default::default()
-        };
+        let orders = vec![
+            Order {
+                data: OrderData {
+                    sell_amount: 1.into(),
+                    buy_amount: 1.into(),
+                    ..Default::default()
+                },
+                ..Default::default()
+            };
+            3
+        ];
+        let balances = max_balance(&orders);
         solver
             .solve(Auction {
-                orders: vec![order(), order(), order()],
+                orders,
+                balances,
                 ..Default::default()
             })
             .await


### PR DESCRIPTION
Part of https://github.com/cowprotocol/services/issues/1378 .

Currently we do order pre processing in the driver run loop. There we decide what orders are assigned what balance and normalize them (convert from `model::Order` to  `solver::LimitOrder`). This is in tension with letting solvers do the balance assignment. Previously all solvers expected pre-filtered `LimitOrder`s, now some solvers (external http solvers) expect raw orders with the extra information needed for balance assignment.

This PR moves the pre processing from the driver run loop into the individual solvers. The order type in `solver::Auction` is changed to `model::Order` from `solver::LimitOrder`. The logic is still the same as before (same balance filtering). It has only moved and is now run by every `solver::Solver`. In another PR we can then change the balance filtering for external http solvers.

I also had to change the `SingleOrderSolving` trait slightly. It doesn't make sense to pass the full `solver::Auction` in, so now  we only pass the pieces that were needed (external prices, gas price). This is done in a separate commit in the same PR.

### Test Plan

existing tests still pass
