### PR TITLE
Additional Autopilot Logs

### DIFF
--- a/crates/autopilot/src/solvable_orders.rs
+++ b/crates/autopilot/src/solvable_orders.rs
@@ -233,10 +233,13 @@ impl SolvableOrdersCache {
         };
         counter.record(&auction.orders);
 
-        if self.store_in_db {
+        let id = if self.store_in_db {
             let id = self.database.replace_current_auction(&auction).await?;
-            tracing::info!(auction = %id, %block, "new auction");
-        }
+            tracing::info!(auction = %id, %block, "stored new auction in database");
+            Some(id)
+        } else {
+            None
+        };
 
         *self.cache.lock().unwrap() = Inner {
             auction: Some(auction),
@@ -249,7 +252,7 @@ impl SolvableOrdersCache {
             balances: new_balances,
         };
 
-        tracing::debug!(%block, "updated current cached auction");
+        tracing::debug!(%block, ?id, "updated current auction cache");
         Ok(())
     }
 

--- a/crates/autopilot/src/solvable_orders.rs
+++ b/crates/autopilot/src/solvable_orders.rs
@@ -234,7 +234,8 @@ impl SolvableOrdersCache {
         counter.record(&auction.orders);
 
         if self.store_in_db {
-            let _id = self.database.replace_current_auction(&auction).await?;
+            let id = self.database.replace_current_auction(&auction).await?;
+            tracing::info!(auction = %id, %block, "new auction");
         }
 
         *self.cache.lock().unwrap() = Inner {
@@ -248,6 +249,7 @@ impl SolvableOrdersCache {
             balances: new_balances,
         };
 
+        tracing::debug!(%block, "updated current cached auction");
         Ok(())
     }
 


### PR DESCRIPTION
In debugging timing/race conditions issues with auction building and event indexing (specifically, orders appearing in auctions after trades have already happened) - I added a few new logs to help with this.

Specifically, we now log when we update the `autopilot` solvable orders cache, as well as when we store the new auction in the database to be served by the orderbook API. This should help in debugging the aforementioned race conditions.

### Test Plan

CI.
