### PR TITLE
Encode post interactions

### DIFF
--- a/crates/solver/src/settlement/settlement_encoder.rs
+++ b/crates/solver/src/settlement/settlement_encoder.rs
@@ -1183,12 +1183,41 @@ pub mod tests {
                     ..Default::default()
                 },
                 33.into(),
-                13.into(),
+                5.into(),
             )
             .unwrap();
 
-        assert_eq!(encoder.pre_interactions, vec![pre_interaction]);
-        assert_eq!(encoder.post_interactions, vec![post_interaction]);
+        // add second trade to verify that interactions get appended and not just set
+        encoder
+            .add_trade(
+                Order {
+                    data: OrderData {
+                        sell_token: token(1),
+                        sell_amount: 66.into(),
+                        buy_token: token(3),
+                        buy_amount: 22.into(),
+                        kind: OrderKind::Sell,
+                        ..Default::default()
+                    },
+                    interactions: Interactions {
+                        pre: vec![pre_interaction.clone()],
+                        post: vec![post_interaction.clone()],
+                    },
+                    ..Default::default()
+                },
+                66.into(),
+                5.into(),
+            )
+            .unwrap();
+
+        assert_eq!(
+            encoder.pre_interactions,
+            vec![pre_interaction.clone(), pre_interaction]
+        );
+        assert_eq!(
+            encoder.post_interactions,
+            vec![post_interaction.clone(), post_interaction]
+        );
     }
 
     #[test]


### PR DESCRIPTION
Fixes #1484 

In order to actually execute post-interactions the `SettlementEncoder` needs to be aware of them. This is mostly a copy-and-paste job since it already knows about pre-interactions for EthFlow orders.

### Test Plan

Added unit test to verify that merging treats post interactions correctly
Added unit test that verifies that `add_trade()` correctly adds pre- and post-interactions to the settlement.
