### PR TITLE
Add CLI arg for allowing orders with custom interactions

### DIFF
--- a/crates/orderbook/src/arguments.rs
+++ b/crates/orderbook/src/arguments.rs
@@ -159,6 +159,10 @@ pub struct Arguments {
     /// Enable buy ETH orders paying to smart contract wallets.
     #[clap(long, env, action = clap::ArgAction::Set, default_value = "false")]
     pub enable_eth_smart_contract_payments: bool,
+
+    /// Enable support for orders with custom pre- and post-interactions.
+    #[clap(long, env, action = clap::ArgAction::Set, default_value = "false")]
+    pub enable_custom_interactions: bool,
 }
 
 impl std::fmt::Display for Arguments {
@@ -232,6 +236,11 @@ impl std::fmt::Display for Arguments {
             f,
             "max_limit_orders_per_user: {}",
             self.max_limit_orders_per_user
+        )?;
+        writeln!(
+            f,
+            "enable_custom_interactions: {:?}",
+            self.enable_custom_interactions
         )?;
 
         Ok(())

--- a/crates/orderbook/src/run.rs
+++ b/crates/orderbook/src/run.rs
@@ -462,7 +462,8 @@ pub async fn run(args: Arguments) {
         )
         .with_fill_or_kill_limit_orders(args.allow_placing_fill_or_kill_limit_orders)
         .with_partially_fillable_limit_orders(args.allow_placing_partially_fillable_limit_orders)
-        .with_eth_smart_contract_payments(args.enable_eth_smart_contract_payments),
+        .with_eth_smart_contract_payments(args.enable_eth_smart_contract_payments)
+        .with_custom_interactions(args.enable_custom_interactions),
     );
     let orderbook = Arc::new(Orderbook::new(
         domain_separator,

--- a/crates/shared/src/order_validation.rs
+++ b/crates/shared/src/order_validation.rs
@@ -216,6 +216,7 @@ pub struct OrderValidator {
     max_limit_orders_per_user: u64,
     pub code_fetcher: Arc<dyn CodeFetching>,
     pub enable_eth_smart_contract_payments: bool,
+    enable_custom_interactions: bool,
 }
 
 #[derive(Debug, Eq, PartialEq, Default)]
@@ -299,6 +300,7 @@ impl OrderValidator {
             max_limit_orders_per_user,
             code_fetcher,
             enable_eth_smart_contract_payments: false,
+            enable_custom_interactions: false,
         }
     }
 
@@ -314,6 +316,11 @@ impl OrderValidator {
 
     pub fn with_eth_smart_contract_payments(mut self, enable: bool) -> Self {
         self.enable_eth_smart_contract_payments = enable;
+        self
+    }
+
+    pub fn with_custom_interactions(mut self, enable: bool) -> Self {
+        self.enable_custom_interactions = enable;
         self
     }
 


### PR DESCRIPTION
Fixes: #1487 

Adds a CLI argument that controls whether we allow quoting and creating orders with custom interactions and already makes it available in the `OrderValidator`.
This flag currently doesn't do anything but I thought it would be nice if it already existed in the needed places for when we start working on the actual feature.

### Test Plan
Argument logged at startup:
```
...
max_limit_orders_per_user: 10
enable_custom_interactions: false
```

`--help` text
```
      --enable-custom-interactions <ENABLE_CUSTOM_INTERACTIONS>
          Enable support for orders with custom pre- and post-interactions

          [env: ENABLE_CUSTOM_INTERACTIONS=]
          [default: false]
          [possible values: true, false]
```