### PR TITLE
Promote log to debug

### DIFF
--- a/crates/autopilot/src/on_settlement_event_updater.rs
+++ b/crates/autopilot/src/on_settlement_event_updater.rs
@@ -154,7 +154,7 @@ impl OnSettlementEventUpdater {
                 auction_external_prices.clone(),
             )?;
 
-            tracing::trace!(
+            tracing::debug!(
                 ?auction_id,
                 ?auction_external_prices,
                 ?orders,

--- a/crates/solver/src/settlement_post_processing/mod.rs
+++ b/crates/solver/src/settlement_post_processing/mod.rs
@@ -146,7 +146,7 @@ impl PostProcessing for PostProcessingPipeline {
                 .await
                 .map_or_else(
                     |err| {
-                        tracing::warn!("Failed to compute score: {}", err);
+                        tracing::warn!(?err, "failed to compute score");
                         None
                     },
                     Some,

--- a/crates/solver/src/settlement_post_processing/mod.rs
+++ b/crates/solver/src/settlement_post_processing/mod.rs
@@ -143,7 +143,14 @@ impl PostProcessing for PostProcessingPipeline {
                     prices,
                     &solver_account.address(),
                 )
-                .await,
+                .await
+                .map_or_else(
+                    |err| {
+                        tracing::warn!("Failed to compute score: {}", err);
+                        None
+                    },
+                    Some,
+                ),
                 ..optimized_solution
             },
             _ => optimized_solution,

--- a/crates/solver/src/settlement_post_processing/optimize_score.rs
+++ b/crates/solver/src/settlement_post_processing/optimize_score.rs
@@ -48,10 +48,8 @@ pub async fn compute_score(
         .map(Score::Score);
 
     tracing::debug!(
-        "solver {} objective value {}, score {:?}",
-        solver,
-        inputs.objective_value(),
-        score
+        ?solver, ?score, objective_value = %inputs.objective_value(),
+        "computed score",
     );
 
     score

--- a/crates/solver/src/settlement_post_processing/optimize_score.rs
+++ b/crates/solver/src/settlement_post_processing/optimize_score.rs
@@ -5,6 +5,7 @@ use {
         settlement::Settlement,
         solver::score_computation::ScoreCalculator,
     },
+    anyhow::{anyhow, Result},
     ethcontract::Address,
     gas_estimation::GasPrice1559,
     num::{BigRational, FromPrimitive},
@@ -18,7 +19,7 @@ pub async fn compute_score(
     gas_price: GasPrice1559,
     prices: &ExternalPrices,
     solver: &Address,
-) -> Option<Score> {
+) -> Result<Score> {
     let gas_amount = settlement_simulator
         .estimate_gas(settlement.clone())
         .await
@@ -27,13 +28,17 @@ pub async fn compute_score(
             // This is because the gas estimation is not accurate enough and does not take
             // the EVM gas refund into account.
             gas_amount * 9 / 10
-        })
-        .ok()?;
+        })?;
 
     let inputs = Inputs::from_settlement(
         settlement,
         prices,
-        BigRational::from_f64(gas_price.effective_gas_price())?,
+        BigRational::from_f64(gas_price.effective_gas_price()).ok_or_else(|| {
+            anyhow!(
+                "gas price {} fails conversion to BigRational",
+                gas_price.effective_gas_price()
+            )
+        })?,
         &gas_amount,
     );
     let nmb_orders = settlement.trades().count();
@@ -42,12 +47,12 @@ pub async fn compute_score(
         .calculate(&inputs, nmb_orders)
         .map(Score::Score);
 
-    tracing::trace!(
+    tracing::debug!(
         "solver {} objective value {}, score {:?}",
         solver,
         inputs.objective_value(),
         score
     );
 
-    score.ok()
+    score
 }


### PR DESCRIPTION
I want to remove the temporary `log_filter` configuration we introduced for CIP20 observations: https://github.com/cowprotocol/infrastructure/blob/73a3e20ad270a9af279bd9a09dde08d9ea825831/services/Pulumi.yaml#L19

But before that, let's promote the `OnSettlementEventUpdater ` logs from `trace` to `debug` since I always want to have this log for debugging purposes.

Edit: also improving the logs for score calculator (related to issue with Baseline solver fallback to objective value).
