### PR TITLE
Be explicit about fillable amount error

### DIFF
--- a/crates/solver/src/solver/single_order_solver.rs
+++ b/crates/solver/src/solver/single_order_solver.rs
@@ -191,9 +191,12 @@ impl SingleOrderSolver {
 
     async fn solve_single_order(&self, order: LimitOrder, auction: &Auction) -> SolveResult {
         let name = self.inner.name();
-        let Some(fill) = self.fills.order(&order, &auction.external_prices) else {
-            tracing::warn!(?order.id, "failed to compute fill; skipping order");
-            return SolveResult::Failed;
+        let fill = match self.fills.order(&order, &auction.external_prices) {
+            Ok(fill) => fill,
+            Err(err) => {
+                tracing::warn!(?order.id, ?err, "failed to compute fill; skipping order");
+                return SolveResult::Failed;
+            }
         };
 
         let single = match self


### PR DESCRIPTION
Noticed while on call debugging. This is cleaner and doesn't rely on trace logs being enabled because we already log when an order is excluded here. Noticed while on call debugging.

I'm not implementing the full error trait through ThisError because it isn't needed here and is more work.

### Test Plan

none
