### PR TITLE
Fix broken API in shadow solver

### DIFF
--- a/crates/model/src/order.rs
+++ b/crates/model/src/order.rs
@@ -36,6 +36,7 @@ pub const BUY_ETH_ADDRESS: H160 = H160([0xee; 20]);
 #[derive(Eq, PartialEq, Clone, Debug, Default, Deserialize, Serialize)]
 pub struct Interactions {
     pub pre: Vec<InteractionData>,
+    #[serde(default)]
     pub post: Vec<InteractionData>,
 }
 


### PR DESCRIPTION
#1482 broke the shadow solver by not introducing the `post` interactions field on the order in a backwards compatible way.

### Test Plan
Ran solver locally connected to the prod orderbook
