### PR TITLE
CI improvements

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -6,7 +6,7 @@ on:
   push:
     branches: [main]
 jobs:
-  rust-misc:
+  lint:
     timeout-minutes: 60
     runs-on: ubuntu-latest
     steps:
@@ -25,78 +25,87 @@ jobs:
           cargo clippy --version
       - run: cargo +nightly fmt --all -- --check
       - run: cargo clippy --locked --workspace --all-features --all-targets -- -D warnings
-  rust-tests:
+
+  unit-tests:
     timeout-minutes: 60
     runs-on: ubuntu-latest
     env:
       # Shrink artifact size by not including debug info. Makes build faster and shrinks cache.
       CARGO_PROFILE_DEV_DEBUG: 0
       CARGO_PROFILE_TEST_DEBUG: 0
-      FLYWAY_VERSION: 7.3.1
-      FLYWAY_PATH: /home/runner/flyway
-      # Flyway is connecting via TCP/IP (authentication via password), whereas psql connects via Unix-domain sockets (authentication via username)
-      # We set the db password of $USER to this value which is also used by the flyway command
-      FLYWAY_PASSWORD: password
-      # Extra underscore because conflicts with hardhat internally used variables.
-      HARDHAT_VERSION_: 2.6.8
-      HARDHAT_PATH_: /home/runner/hardhat
     steps:
       - uses: actions/checkout@v2
       - uses: Swatinem/rust-cache@v1
-      - name: Cache flyway
-        id: cache-flyway
-        uses: actions/cache@v2
-        with:
-          path: ${{ env.FLYWAY_PATH }}
-          key: ${{ runner.os }}-flyway-${{ env.FLYWAY_VERSION }}
-      - name: Install Flyway
-        if: steps.cache-flyway.outputs.cache-hit != 'true'
-        run: |
-          mkdir --parents ${{ env.FLYWAY_PATH }}
-          cd ${{ env.FLYWAY_PATH }}
-          curl -L https://repo1.maven.org/maven2/org/flywaydb/flyway-commandline/${FLYWAY_VERSION}/flyway-commandline-${FLYWAY_VERSION}.tar.gz -o out.tar.gz
-          tar --strip-components=1 -xzf out.tar.gz
-          rm out.tar.gz
-          ls -al
-      - name: Cache Hardhat
-        id: cache-hardhat
-        uses: actions/cache@v2
-        with:
-          path: ${{ env.HARDHAT_PATH_ }}/node_modules
-          key: ${{ runner.os }}-hardhat-${{ env.HARDHAT_VERSION_ }}
-      - name: Install Hardhat
-        if: steps.cache-hardhat.outputs.cache-hit != 'true'
-        run: |
-          mkdir --parents ${{ env.HARDHAT_PATH_ }}
-          cd ${{ env.HARDHAT_PATH_ }}
-          npm install hardhat@${{ env.HARDHAT_VERSION_ }}
-          ls -al
-      - name: Setup Hardhat
-        working-directory: ${{ env.HARDHAT_PATH_ }}
-        run: |
-          cp ${{ github.workspace }}/docker/hardhat/hardhat.config.js hardhat.config.js
-          node_modules/.bin/hardhat node --hostname 127.0.0.1 &
-      - name: Setup Database
-        run: |
-          sudo systemctl start postgresql.service
-          sudo -u postgres createuser $USER
-          sudo -u postgres createdb $USER
-          psql -c "ALTER USER $USER PASSWORD '$FLYWAY_PASSWORD';"
-          ${{ env.FLYWAY_PATH }}/flyway -url="jdbc:postgresql:///" -user=$USER -locations="filesystem:database/sql/" migrate
-      - run: cargo test --no-run
       - run: cargo test
-      # tests requiring a Postgres instance.
-      - run: cargo test postgres -- --ignored --test-threads 1
-      # tests requiring a local ethereum node
-      # nocapture because tracing output isn't captured by the test runner which makes it confusing
-      # to debug failing e2e tests.
-      - run: cargo test local_node -- --ignored --test-threads 1 --nocapture
-  openapi:
+
+  test-db:
     timeout-minutes: 60
     runs-on: ubuntu-latest
+    env:
+      # Shrink artifact size by not including debug info. Makes build faster and shrinks cache.
+      CARGO_PROFILE_DEV_DEBUG: 0
+      CARGO_PROFILE_TEST_DEBUG: 0
     steps:
       - uses: actions/checkout@v2
-      - run: npm install @apidevtools/swagger-cli
-      - run: node_modules/.bin/swagger-cli validate crates/orderbook/openapi.yml
-      - run: node_modules/.bin/swagger-cli validate crates/driver/openapi.yml
-      - run: node_modules/.bin/swagger-cli validate crates/solvers/openapi.yml
+      - uses: Swatinem/rust-cache@v1
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: nightly
+          components: rustfmt
+      # Start the build process in the background. The following cargo test command will automatically
+      # wait for the build process to be done before proceeding.
+      - run: cargo build -p orderbook -p database --tests &
+      - uses: yu-ichiro/spin-up-docker-compose-action@v1
+        with:
+          file: docker-compose.yaml
+          up-opts: -d db migrations
+      - run: cargo test postgres -p orderbook -p database -- --ignored --test-threads 1
+
+  test-local-node:
+    timeout-minutes: 60
+    runs-on: ubuntu-latest
+    env:
+      # Shrink artifact size by not including debug info. Makes build faster and shrinks cache.
+      CARGO_PROFILE_DEV_DEBUG: 0
+      CARGO_PROFILE_TEST_DEBUG: 0
+    steps:
+      - uses: actions/checkout@v2
+      - uses: Swatinem/rust-cache@v1
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: nightly
+          components: rustfmt
+      # Start the build process in the background. The following cargo test command will automatically
+      # wait for the build process to be done before proceeding.
+      - run: cargo build -p e2e --tests &
+      - uses: yu-ichiro/spin-up-docker-compose-action@v1
+        with:
+          file: docker-compose.yaml
+          up-opts: -d db migrations hardhat
+      - run: cargo test -p e2e local_node -- --ignored --test-threads 1 --nocapture
+
+  test-driver:
+    timeout-minutes: 60
+    runs-on: ubuntu-latest
+    env:
+      # Shrink artifact size by not including debug info. Makes build faster and shrinks cache.
+      CARGO_PROFILE_DEV_DEBUG: 0
+      CARGO_PROFILE_TEST_DEBUG: 0
+    steps:
+      - uses: actions/checkout@v2
+      - uses: Swatinem/rust-cache@v1
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: nightly
+          components: rustfmt
+      # Start the build process in the background. The following cargo test command will automatically
+      # wait for the build process to be done before proceeding.
+      - run: cargo build -p driver --tests &
+      - uses: yu-ichiro/spin-up-docker-compose-action@v1
+        with:
+          file: docker-compose.yaml
+          up-opts: -d dev-geth
+      - run: cargo test -p driver -- --ignored

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -109,3 +109,13 @@ jobs:
           file: docker-compose.yaml
           up-opts: -d dev-geth
       - run: cargo test -p driver -- --ignored
+
+  openapi:
+    timeout-minutes: 60
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: npm install @apidevtools/swagger-cli
+      - run: node_modules/.bin/swagger-cli validate crates/orderbook/openapi.yml
+      - run: node_modules/.bin/swagger-cli validate crates/driver/openapi.yml
+      - run: node_modules/.bin/swagger-cli validate crates/solvers/openapi.yml

--- a/docker/hardhat/Dockerfile
+++ b/docker/hardhat/Dockerfile
@@ -1,5 +1,7 @@
 FROM node:16-alpine3.15
 
+RUN apk update && apk add python3 make g++
+
 RUN mkdir hardhat
 WORKDIR hardhat
 RUN npm init -y


### PR DESCRIPTION
Fixes https://github.com/cowprotocol/services/issues/1105.

Add driver tests to CI. Start using `docker-compose` in CI instead of translating the compose setup into a GitHub workflow. This has a few benefits: it ensures that the local environment setup is on-par with the CI environment setup, it removes the burden of maintaining two different environment setup flows, and it tests the docker-compose setup in CI so it's impossible to commit code with a broken docker-compose.

There is one issue: because dev-geth is part of this repo, it needs to be built from scratch every time the dev-geth compose service is started. This adds up to 10 minutes to the CI pipeline. The solution to this problem is to extract dev-geth into its own repository, with its own release schedule and push the docker image to the registry. This way the dev-geth code will not need to get rebuilt all the time. I opened [an issue](https://github.com/cowprotocol/services/issues/1505) for this.
