### PR TITLE
Verified quotes

### DIFF
--- a/crates/model/src/quote.rs
+++ b/crates/model/src/quote.rs
@@ -16,9 +16,13 @@ use {
 #[derive(Clone, Copy, Debug, Default, Deserialize, Serialize, Eq, PartialEq)]
 #[serde(rename_all = "snake_case")]
 pub enum PriceQuality {
+    /// We pick the best quote of the fastest `n` price estimators.
     Fast,
     #[default]
+    /// We pick the best quote of all price estimators.
     Optimal,
+    /// We pick the best quote of the ones that got verified by simulation.
+    Verified,
 }
 
 #[derive(Eq, PartialEq, Clone, Copy, Debug, Default, Deserialize, Serialize, Hash)]


### PR DESCRIPTION
This PR introduces the undocumented `verified` quote quality that could be used for quoting orders with custom interactions. But this could easily be dropped in case we actually decide to cleanly split price estimation from quoting.
Another alternative would be to automatically generate a verified quote if we detect user interactions on a quote request (TBD).
I also prepared a new `verified` price estimator which we will need regardless of the exact implementation we want to do.

Currently setting a trade verification strategy not only enabled support for the `verified` quote quality but also forces every estimator of the `optimal` price estimation logic to be verified. This wasn't changed by this PR but it's a bit weird to not be able to differentiate these 2 features at the moment so a follow up PR should handle that.

### Test Plan
manual test that `priceQuality: "verified"` gets handled correctly and that it returns an error if no trade verification strategy was configured