### PR TITLE
Better error messages when failing to retrieve Balancer factory

### DIFF
--- a/crates/shared/src/sources/balancer_v2/pool_fetching.rs
+++ b/crates/shared/src/sources/balancer_v2/pool_fetching.rs
@@ -201,11 +201,20 @@ pub struct BalancerContracts {
 
 impl BalancerContracts {
     pub async fn new(web3: &Web3, factory_kinds: Vec<BalancerFactoryKind>) -> Result<Self> {
-        let vault = BalancerV2Vault::deployed(web3).await?;
+        let vault = BalancerV2Vault::deployed(web3)
+            .await
+            .context("Cannot retrieve balancer vault")?;
 
         macro_rules! instance {
             ($factory:ident) => {{
-                $factory::deployed(web3).await?.raw_instance().clone()
+                $factory::deployed(web3)
+                    .await
+                    .context(format!(
+                        "Cannot retrieve Balancer factory {}",
+                        stringify!($factory)
+                    ))?
+                    .raw_instance()
+                    .clone()
             }};
         }
 


### PR DESCRIPTION
Small QOL PR to make panic debugging quicker.

### Test Plan

```
$ export NODE_URL='an xdai node'
$ export BALANCER_FACTORIES='Weighted'
$ export BASELINE_SOURCES='BalancerV2'
$ cargo  run --bin orderbook -- 
[...]
2023-05-18T10:58:28.526Z ERROR shared::tracing: thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: Cannot retrieve Balancer factory BalancerV2WeightedPoolFactory

Caused by:
    could not find deployed contract for network 100', /home/fedgiac/code/gnosis/services/crates/orderbook/src/run.rs:266:72
```