### PR TITLE
Fix Driver Quotes from Protocol

### DIFF
--- a/crates/driver/openapi.yml
+++ b/crates/driver/openapi.yml
@@ -215,7 +215,7 @@ components:
         amount:
           $ref: "#/components/schemas/TokenAmount"
     QuoteResponse:
-      anyOf:
+      oneOf:
         - description: |
             Successful Quote
 
@@ -226,21 +226,13 @@ components:
             `sell`.
           type: object
           properties:
-            sellAmount:
+            amount:
               $ref: "#/components/schemas/TokenAmount"
-            buyAmount:
-              $ref: "#/components/schemas/TokenAmount"
-            gas:
-              type: integer
-        - description: |
-            Unfillable Quote
-
-            This is not an error. The server handled the request correctly but could not create a
-            quote. For example, this Solver might not be aware of any liquidity between the tokens.
-          type: object
-          properties:
-            unfillableReason:
-              type: string
+            interactions:
+              type: array
+              items:
+                $ref: "#/components/schemas/Interaction"
+        - $ref: "#/components/schemas/Error"
     SolveRequest:
       description: Request to the solve endpoint.
       type: object
@@ -359,6 +351,16 @@ components:
             Signature confirming that the Solver promised to execute this auction.
 
             TODO: Decide what is signed and how it is signed.
+          type: string
+    Error:
+      description: Response on API errors.
+      type: object
+      properties:
+        kind:
+          description: The kind of error.
+          type: string
+        description:
+          description: Text describing the error.
           type: string
   responses:
     BadRequest:

--- a/crates/driver/src/domain/quote.rs
+++ b/crates/driver/src/domain/quote.rs
@@ -136,16 +136,16 @@ impl Order {
 
     /// The asset being sold, or a very large value if this is a buy, to
     /// facilitate surplus.
-    ///
-    /// Note that we intentionally do not use [`eth::U256::max_value()`] as an
-    /// order with this would cause overflows with the smart contract, so buy
-    /// orders requiring excessively large sell amounts would not work anyway.
     fn sell(&self) -> eth::Asset {
         match self.side {
             order::Side::Sell => eth::Asset {
                 amount: self.amount.into(),
                 token: self.tokens.sell,
             },
+            // Note that we intentionally do not use [`eth::U256::max_value()`]
+            // as an order with this would cause overflows with the Smart
+            // Contract, so buy orders requiring excessively large sell amounts
+            // would not work anyway.
             order::Side::Buy => eth::Asset {
                 amount: eth::U256::one() << 192,
                 token: self.tokens.sell,
@@ -223,6 +223,7 @@ pub enum Error {
     QuotingFailed,
     #[error("{0:?}")]
     DeadlineExceeded(#[from] DeadlineExceeded),
+    /// Encountered an unexpected error reading blockchain data.
     #[error("blockchain error: {0:?}")]
     Blockchain(#[from] blockchain::Error),
     #[error("solver error: {0:?}")]

--- a/crates/driver/src/infra/api/error.rs
+++ b/crates/driver/src/infra/api/error.rs
@@ -1,9 +1,6 @@
 use {
     crate::{
-        domain::{
-            competition::{self},
-            quote,
-        },
+        domain::{competition, quote},
         infra::api,
     },
     serde::Serialize,
@@ -22,6 +19,7 @@ enum Kind {
     InvalidAuctionId,
     MissingSurplusFee,
     QuoteSameTokens,
+    BlockchainFailed,
 }
 
 #[derive(Debug, Serialize)]
@@ -44,6 +42,7 @@ impl From<Kind> for (hyper::StatusCode, axum::Json<Error>) {
             Kind::InvalidAuctionId => "Invalid ID specified in the auction",
             Kind::MissingSurplusFee => "Auction contains a limit order with no surplus fee",
             Kind::QuoteSameTokens => "Invalid quote with same buy and sell tokens",
+            Kind::BlockchainFailed => "Failed to read data from the blockchain",
         };
         (
             hyper::StatusCode::BAD_REQUEST,
@@ -60,6 +59,7 @@ impl From<quote::Error> for (hyper::StatusCode, axum::Json<Error>) {
         let error = match value {
             quote::Error::QuotingFailed => Kind::QuotingFailed,
             quote::Error::DeadlineExceeded(_) => Kind::DeadlineExceeded,
+            quote::Error::Blockchain(_) => Kind::BlockchainFailed,
             quote::Error::Solver(_) => Kind::SolverFailed,
             quote::Error::Boundary(_) => Kind::Unknown,
         };

--- a/crates/driver/src/infra/api/error.rs
+++ b/crates/driver/src/infra/api/error.rs
@@ -19,7 +19,6 @@ enum Kind {
     InvalidAuctionId,
     MissingSurplusFee,
     QuoteSameTokens,
-    BlockchainFailed,
 }
 
 #[derive(Debug, Serialize)]
@@ -42,7 +41,6 @@ impl From<Kind> for (hyper::StatusCode, axum::Json<Error>) {
             Kind::InvalidAuctionId => "Invalid ID specified in the auction",
             Kind::MissingSurplusFee => "Auction contains a limit order with no surplus fee",
             Kind::QuoteSameTokens => "Invalid quote with same buy and sell tokens",
-            Kind::BlockchainFailed => "Failed to read data from the blockchain",
         };
         (
             hyper::StatusCode::BAD_REQUEST,
@@ -59,8 +57,8 @@ impl From<quote::Error> for (hyper::StatusCode, axum::Json<Error>) {
         let error = match value {
             quote::Error::QuotingFailed => Kind::QuotingFailed,
             quote::Error::DeadlineExceeded(_) => Kind::DeadlineExceeded,
-            quote::Error::Blockchain(_) => Kind::BlockchainFailed,
             quote::Error::Solver(_) => Kind::SolverFailed,
+            quote::Error::Blockchain(_) => Kind::Unknown,
             quote::Error::Boundary(_) => Kind::Unknown,
         };
         error.into()

--- a/crates/driver/src/infra/api/routes/quote/dto/order.rs
+++ b/crates/driver/src/infra/api/routes/quote/dto/order.rs
@@ -17,7 +17,6 @@ impl Order {
                 Kind::Sell => competition::order::Side::Sell,
                 Kind::Buy => competition::order::Side::Buy,
             },
-            gas_price: self.effective_gas_price.into(),
             deadline: self.deadline.into(),
         })
     }
@@ -32,8 +31,6 @@ pub struct Order {
     #[serde_as(as = "serialize::U256")]
     amount: eth::U256,
     kind: Kind,
-    #[serde_as(as = "serialize::U256")]
-    effective_gas_price: eth::U256,
     deadline: chrono::DateTime<chrono::Utc>,
 }
 

--- a/crates/driver/src/tests/cases/quote.rs
+++ b/crates/driver/src/tests/cases/quote.rs
@@ -138,7 +138,6 @@ async fn test() {
                 "buyToken": hex_address(buy_token),
                 "amount": sell_amount.to_string(),
                 "kind": "sell",
-                "effectiveGasPrice": gas_price.to_string(),
                 "deadline": deadline,
             }),
         )

--- a/crates/shared/src/arguments.rs
+++ b/crates/shared/src/arguments.rs
@@ -74,7 +74,7 @@ pub struct OrderQuotingArguments {
     /// not regular user orders.
     ///
     /// These orders have special semantics such as not being considered in the
-    /// settlements objective funtion, not receiving any surplus, and being
+    /// settlements objective function, not receiving any surplus, and being
     /// allowed to place partially fillable orders.
     #[clap(long, env, use_value_delimiter = true)]
     pub liquidity_order_owners: Vec<H160>,

--- a/crates/shared/src/trade_finding.rs
+++ b/crates/shared/src/trade_finding.rs
@@ -11,7 +11,6 @@ use {
     anyhow::Result,
     contracts::ERC20,
     ethcontract::{contract::MethodBuilder, tokens::Tokenize, web3::Transport, Bytes, H160, U256},
-    serde::Deserialize,
     thiserror::Error,
 };
 
@@ -27,14 +26,14 @@ pub trait TradeFinding: Send + Sync + 'static {
 }
 
 /// A quote.
-#[derive(Clone, Debug, Default, Eq, PartialEq, Deserialize)]
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
 pub struct Quote {
     pub out_amount: U256,
     pub gas_estimate: u64,
 }
 
 /// A trade.
-#[derive(Clone, Debug, Default, Eq, PartialEq, Deserialize)]
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
 pub struct Trade {
     pub out_amount: U256,
     pub gas_estimate: u64,
@@ -78,7 +77,7 @@ impl Trade {
 }
 
 /// Data for a raw GPv2 interaction.
-#[derive(Clone, Debug, Default, Eq, PartialEq, Deserialize)]
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
 pub struct Interaction {
     pub target: H160,
     pub value: U256,

--- a/crates/shared/src/trade_finding/external.rs
+++ b/crates/shared/src/trade_finding/external.rs
@@ -87,9 +87,10 @@ impl ExternalTradeFinder {
             .map_err(TradeError::from)
     }
 
-    /// Returns the default time limit used for quoting with external drivers.
+    /// Returns the default time limit used for quoting with external co-located
+    /// solvers.
     fn time_limit() -> chrono::Duration {
-        chrono::Duration::seconds(3)
+        chrono::Duration::seconds(5)
     }
 }
 

--- a/crates/shared/src/trade_finding/external.rs
+++ b/crates/shared/src/trade_finding/external.rs
@@ -1,4 +1,5 @@
 //! A trade finder that uses an external driver.
+
 use {
     crate::{
         price_estimation::{
@@ -11,7 +12,7 @@ use {
         },
         rate_limiter::RateLimiter,
         request_sharing::RequestSharing,
-        trade_finding::{Quote, Trade, TradeError, TradeFinding},
+        trade_finding::{Interaction, Quote, Trade, TradeError, TradeFinding},
     },
     anyhow::Context,
     futures::{future::BoxFuture, stream::BoxStream, FutureExt, StreamExt},
@@ -41,7 +42,7 @@ impl ExternalTradeFinder {
     #[allow(dead_code)]
     pub fn new(driver: Url, client: Client, rate_limiter: Arc<RateLimiter>) -> Self {
         Self {
-            quote_endpoint: driver.join("/quote").unwrap(),
+            quote_endpoint: driver.join("quote").unwrap(),
             sharing: Default::default(),
             rate_limiter,
             client,
@@ -51,8 +52,16 @@ impl ExternalTradeFinder {
     /// Queries the `/quote` endpoint of the configured driver and deserializes
     /// the result into a Quote or Trade.
     async fn shared_query(&self, query: &Query) -> Result<Trade, TradeError> {
-        let body = serde_json::to_string(&query).context("failed to encode body")?;
+        let deadline = chrono::Utc::now() + Self::time_limit();
+        let order = dto::Order {
+            sell_token: query.sell_token,
+            buy_token: query.buy_token,
+            amount: query.in_amount,
+            kind: query.kind,
+            deadline,
+        };
 
+        let body = serde_json::to_string(&order).context("failed to encode body")?;
         let request = self
             .client
             .post(self.quote_endpoint.clone())
@@ -66,7 +75,9 @@ impl ExternalTradeFinder {
                 return Err(PriceEstimationError::RateLimited);
             }
             let text = response.text().await.map_err(PriceEstimationError::from)?;
-            serde_json::from_str::<Trade>(&text).map_err(PriceEstimationError::from)
+            serde_json::from_str::<dto::Quote>(&text)
+                .map(Trade::from)
+                .map_err(PriceEstimationError::from)
         };
 
         let future = rate_limited(self.rate_limiter.clone(), future);
@@ -74,6 +85,38 @@ impl ExternalTradeFinder {
             .shared(*query, future.boxed())
             .await
             .map_err(TradeError::from)
+    }
+
+    /// Returns the default time limit used for quoting with external drivers.
+    fn time_limit() -> chrono::Duration {
+        chrono::Duration::seconds(3)
+    }
+}
+
+impl From<dto::Quote> for Trade {
+    fn from(quote: dto::Quote) -> Self {
+        // TODO: We are currently deciding on whether or not we need indicative
+        // fee estimates for indicative price estimates. If they are needed,
+        // then this approximation is obviously inaccurate and should be
+        // improved, and would likely involve including gas estimates in quote
+        // responses from the driver or implementing this as a separate API.
+        //
+        // Value guessed from <https://dune.com/queries/1373225>
+        const TRADE_GAS: u64 = 290_000;
+
+        Self {
+            out_amount: quote.amount,
+            gas_estimate: TRADE_GAS,
+            interactions: quote
+                .interactions
+                .into_iter()
+                .map(|interaction| Interaction {
+                    target: interaction.target,
+                    value: interaction.value,
+                    data: interaction.call_data,
+                })
+                .collect(),
+        }
     }
 }
 
@@ -111,5 +154,48 @@ impl PriceEstimating for ExternalTradeFinder {
             })
             .enumerate()
             .boxed()
+    }
+}
+
+// TODO: Use the trade finder estimator implementation
+
+mod dto {
+    use {
+        ethcontract::{H160, U256},
+        model::{bytes_hex::BytesHex, order::OrderKind, u256_decimal::DecimalU256},
+        serde::{Deserialize, Serialize},
+        serde_with::serde_as,
+    };
+
+    #[serde_as]
+    #[derive(Clone, Debug, Serialize)]
+    #[serde(rename_all = "camelCase")]
+    pub struct Order {
+        pub sell_token: H160,
+        pub buy_token: H160,
+        #[serde_as(as = "DecimalU256")]
+        pub amount: U256,
+        pub kind: OrderKind,
+        pub deadline: chrono::DateTime<chrono::Utc>,
+    }
+
+    #[serde_as]
+    #[derive(Clone, Debug, Deserialize)]
+    #[serde(rename_all = "camelCase")]
+    pub struct Quote {
+        #[serde_as(as = "DecimalU256")]
+        pub amount: U256,
+        pub interactions: Vec<Interaction>,
+    }
+
+    #[serde_as]
+    #[derive(Clone, Debug, Deserialize)]
+    #[serde(rename_all = "camelCase")]
+    pub struct Interaction {
+        pub target: H160,
+        #[serde_as(as = "DecimalU256")]
+        pub value: U256,
+        #[serde_as(as = "BytesHex")]
+        pub call_data: Vec<u8>,
     }
 }

--- a/crates/solvers/src/domain/dex/mod.rs
+++ b/crates/solvers/src/domain/dex/mod.rs
@@ -105,7 +105,7 @@ impl Swap {
         self,
         order: order::Order,
         gas_price: auction::GasPrice,
-        sell_token: auction::Price,
+        sell_token: Option<auction::Price>,
     ) -> Option<solution::Solution> {
         let allowance = self.allowance();
         let interactions = vec![solution::Interaction::Custom(solution::CustomInteraction {

--- a/crates/solvers/src/domain/solution.rs
+++ b/crates/solvers/src/domain/solution.rs
@@ -38,7 +38,7 @@ impl Single {
     pub fn into_solution(
         self,
         gas_price: auction::GasPrice,
-        sell_token: auction::Price,
+        sell_token: Option<auction::Price>,
     ) -> Option<Solution> {
         let Self {
             order,
@@ -59,7 +59,7 @@ impl Single {
             // is fine for now, since there is no way to create limit orders
             // with non-zero fees.
             Fee::Surplus(
-                sell_token.ether_value(eth::Ether(
+                sell_token?.ether_value(eth::Ether(
                     swap.0
                         .checked_add(Self::SETTLEMENT_OVERHEAD.into())?
                         .checked_mul(gas_price.0 .0)?,

--- a/crates/solvers/src/domain/solver/baseline.rs
+++ b/crates/solvers/src/domain/solver/baseline.rs
@@ -51,7 +51,7 @@ impl Baseline {
             .orders
             .iter()
             .filter_map(|order| {
-                let sell_token = auction.tokens.reference_price(&order.sell.token)?;
+                let sell_token = auction.tokens.reference_price(&order.sell.token);
                 self.requests_for_order(UserOrder::new(order)?)
                     .find_map(|request| {
                         tracing::trace!(?request, "finding route");
@@ -124,11 +124,13 @@ pub struct Request {
 }
 
 /// A trading route.
+#[derive(Debug)]
 pub struct Route<'a> {
     segments: Vec<Segment<'a>>,
 }
 
 /// A segment in a trading route.
+#[derive(Debug)]
 pub struct Segment<'a> {
     pub liquidity: &'a liquidity::Liquidity,
     // TODO: There is no type-level guarantee here that both `input.token` and

--- a/crates/solvers/src/domain/solver/dex/mod.rs
+++ b/crates/solvers/src/domain/solver/dex/mod.rs
@@ -90,11 +90,8 @@ impl Dex {
             }
         };
 
-        let Some(sell) = tokens.reference_price(&order.sell.token) else {
-            tracing::warn!(token = ?order.sell.token.0, "missing sell token price");
-            return None;
-        };
         let uid = order.uid;
+        let sell = tokens.reference_price(&order.sell.token);
         let Some(solution) = swap.into_solution(order, gas_price, sell) else {
             tracing::debug!("no solution for swap");
             return None;


### PR DESCRIPTION
A while ago we added support for getting price estimates in both the `autopilot` and `orderbook`. Because of code drift, this was no longer working. This PR fixes inconsistencies so that price estimation works from a co-located driver.

### Test Plan

Manual local test. Will introduce an E2E test in a follow up.

1. Run a `driver` + `solvers baseline`
2. Run `orderbook --baseline-sources None --price-estimation-drivers 'colocated|http://localhost:11088/solver/'`
3. Make a quote:
   ```
   % curl -s http://localhost:8080/api/v1/quote -X POST -H 'content-type: application/json' --data '@-' <<JSON | jq
   {
     "from": "0x0000000000000000000000000000000000000000",
     "sellToken": "0x6b175474e89094c44da98b954eedeac495271d0f",
     "buyToken": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
     "kind": "sell",
     "sellAmountBeforeFee": "1000000000000000000000"
   }
   JSON
   {
     "quote": {
       "sellToken": "0x6b175474e89094c44da98b954eedeac495271d0f",
       "buyToken": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
       "receiver": null,
       "sellAmount": "947036788242884435968",
       "buyAmount": "525985313588220421",
       "validTo": 1684337704,
       "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
       "feeAmount": "52963211757115564032",
       "kind": "sell",
       "partiallyFillable": false,
       "sellTokenBalance": "erc20",
       "buyTokenBalance": "erc20",
       "signingScheme": "eip712"
     },
     "from": "0x0000000000000000000000000000000000000000",
     "expiration": "2023-05-17T15:06:04.005931Z",
     "id": 115
   }
   ```
