### PR TITLE
Use Trade Verification With Driver Quotes

### DIFF
--- a/crates/shared/src/price_estimation.rs
+++ b/crates/shared/src/price_estimation.rs
@@ -3,6 +3,7 @@ use crate::bad_token::TokenQuality;
 pub mod balancer_sor;
 pub mod baseline;
 pub mod competition;
+pub mod external;
 pub mod factory;
 pub mod gas;
 pub mod http;

--- a/crates/shared/src/price_estimation/external.rs
+++ b/crates/shared/src/price_estimation/external.rs
@@ -1,0 +1,42 @@
+use {
+    super::{
+        trade_finder::{TradeEstimator, TradeVerifier},
+        PriceEstimateResult,
+        PriceEstimating,
+        Query,
+    },
+    crate::{rate_limiter::RateLimiter, trade_finding::external::ExternalTradeFinder},
+    ethcontract::H160,
+    reqwest::{Client, Url},
+    std::sync::Arc,
+};
+
+pub struct ExternalPriceEstimator(TradeEstimator);
+
+impl ExternalPriceEstimator {
+    pub fn new(
+        driver: Url,
+        client: Client,
+        rate_limiter: Arc<RateLimiter>,
+        settlement: H160,
+    ) -> Self {
+        Self(TradeEstimator::new(
+            settlement,
+            Arc::new(ExternalTradeFinder::new(driver, client)),
+            rate_limiter,
+        ))
+    }
+
+    pub fn verified(&self, verifier: TradeVerifier) -> Self {
+        Self(self.0.clone().with_verifier(verifier))
+    }
+}
+
+impl PriceEstimating for ExternalPriceEstimator {
+    fn estimates<'a>(
+        &'a self,
+        queries: &'a [Query],
+    ) -> futures::stream::BoxStream<'_, (usize, PriceEstimateResult)> {
+        self.0.estimates(queries)
+    }
+}

--- a/crates/shared/src/price_estimation/trade_finder.rs
+++ b/crates/shared/src/price_estimation/trade_finder.rs
@@ -205,6 +205,7 @@ impl TradeVerifier {
             Err(err) => bail!(err),
         };
         let output = SettleOutput::decode(&return_data)?;
+        tracing::debug!(?output, "trade simulated");
 
         let trader_amounts = output
             .trader_amounts()


### PR DESCRIPTION
Follow up to #1520 

This PR changes the co-located driver estimator to use the same trade verification machinery as our other price estimators.

### Test Plan

Manual test, same as #1520 but with `--trade-simulator Web3 --simulation-node-url "$NODE_URL"`
