### PR TITLE
[Logging] Improve single order solver logs

### DIFF
--- a/crates/solver/src/driver.rs
+++ b/crates/solver/src/driver.rs
@@ -1,3 +1,5 @@
+use tracing::info_span;
+
 use crate::settlement_rater::SettlementRating;
 
 pub mod gas;
@@ -27,12 +29,7 @@ use {
         auction::{AuctionId, AuctionWithId},
         order::OrderUid,
         solver_competition::{
-            self,
-            CompetitionAuction,
-            Execution,
-            Objective,
-            SolverCompetitionDB,
-            SolverSettlement,
+            self, CompetitionAuction, Execution, Objective, SolverCompetitionDB, SolverSettlement,
         },
         TokenPair,
     },
@@ -177,8 +174,10 @@ impl Driver {
             let metrics = &self.metrics;
             async move {
                 let start_time = Instant::now();
+                let span = info_span!("solver", solver = solver.name());
                 let result =
                     match tokio::time::timeout_at(auction.deadline.into(), solver.solve(auction))
+                        .instrument(span)
                         .await
                     {
                         Ok(inner) => {

--- a/crates/solver/src/driver.rs
+++ b/crates/solver/src/driver.rs
@@ -1,6 +1,4 @@
-use tracing::info_span;
-
-use crate::settlement_rater::SettlementRating;
+use {crate::settlement_rater::SettlementRating, tracing::info_span};
 
 pub mod gas;
 pub mod solver_settlements;
@@ -29,7 +27,12 @@ use {
         auction::{AuctionId, AuctionWithId},
         order::OrderUid,
         solver_competition::{
-            self, CompetitionAuction, Execution, Objective, SolverCompetitionDB, SolverSettlement,
+            self,
+            CompetitionAuction,
+            Execution,
+            Objective,
+            SolverCompetitionDB,
+            SolverSettlement,
         },
         TokenPair,
     },

--- a/crates/solver/src/solver/single_order_solver.rs
+++ b/crates/solver/src/solver/single_order_solver.rs
@@ -2,7 +2,10 @@ use {
     super::SolverInfo,
     crate::{
         liquidity::{
-            order_converter::OrderConverter, LimitOrder, LimitOrderExecution, LimitOrderId,
+            order_converter::OrderConverter,
+            LimitOrder,
+            LimitOrderExecution,
+            LimitOrderId,
         },
         metrics::SolverMetrics,
         settlement::Settlement,
@@ -711,7 +714,8 @@ mod tests {
         num::{BigRational, FromPrimitive},
         primitive_types::H160,
         shared::{
-            http_solver::model::InternalizationStrategy, price_estimation::gas::SETTLEMENT_OVERHEAD,
+            http_solver::model::InternalizationStrategy,
+            price_estimation::gas::SETTLEMENT_OVERHEAD,
         },
         std::{collections::HashMap, sync::Arc},
     };

--- a/crates/solver/src/solver/single_order_solver.rs
+++ b/crates/solver/src/solver/single_order_solver.rs
@@ -1,11 +1,10 @@
+use super::SimulationWithError;
+
 use {
     super::SolverInfo,
     crate::{
         liquidity::{
-            order_converter::OrderConverter,
-            LimitOrder,
-            LimitOrderExecution,
-            LimitOrderId,
+            order_converter::OrderConverter, LimitOrder, LimitOrderExecution, LimitOrderId,
         },
         metrics::SolverMetrics,
         settlement::Settlement,
@@ -202,115 +201,6 @@ impl SingleOrderSolver {
         }
     }
 
-    async fn solve_instrumented(
-        &self,
-        Auction {
-            orders,
-            balances,
-            external_prices,
-            gas_price,
-            deadline,
-            ..
-        }: Auction,
-    ) -> Result<Vec<Settlement>> {
-        let orders = super::balance_and_convert_orders(
-            self.ethflow_contract,
-            &self.order_converter,
-            balances,
-            orders,
-        );
-        let mut orders =
-            get_prioritized_orders(&orders, &external_prices, &self.order_prioritization_config);
-        tracing::trace!(?orders, "prioritized orders");
-
-        let mut settlements = Vec::new();
-        let (tx, mut rx) = mpsc::unbounded_channel::<SingleOrderSettlement>();
-
-        let solve = async {
-            while let Some(order) = orders.pop_front() {
-                let span = tracing::info_span!("solve", id =? order.id);
-                match self
-                    .solve_single_order(order, &external_prices, gas_price)
-                    .instrument(span)
-                    .await
-                {
-                    SolveResult::Failed => continue,
-                    SolveResult::Retryable(order) => orders.push_back(order),
-                    SolveResult::Solved(settlement) => {
-                        let _ = tx.send(settlement);
-                    }
-                    SolveResult::RateLimited => {
-                        tracing::warn!(
-                            solver = %self.name(),
-                            "rate limited; backing off until next auction"
-                        );
-                        break;
-                    }
-                }
-            }
-            drop(tx);
-        };
-
-        let finalize = async {
-            let mut index = 0;
-            while let Some(intermediate) = rx.recv().await {
-                match self
-                    .finalize_settlement(intermediate, &external_prices, gas_price, index)
-                    .await
-                {
-                    Ok(Some(settlement)) => {
-                        settlements.push(settlement);
-                    }
-                    Ok(None) => (),
-                    Err(err) => {
-                        tracing::warn!(?err, "failed to finalize intermediate settlement");
-                    }
-                }
-                index += 1;
-            }
-        };
-
-        // Subtract a small amount of time to ensure that the driver doesn't reach the
-        // deadline first.
-        let timeout =
-            tokio::time::sleep_until(deadline.checked_sub(Duration::from_secs(1)).unwrap().into());
-
-        // open new scope for solve->finalize pipeline to make borrow checker happy
-        {
-            let solve = solve.fuse();
-            futures::pin_mut!(solve);
-            futures::pin_mut!(finalize);
-            futures::pin_mut!(timeout);
-            loop {
-                tokio::select! {
-                    // if `solve` stops early there are still settlements to be finalized
-                    _ = &mut solve => (),
-                    // all possible settlements have been finalized
-                    _ = &mut finalize => break,
-                    // we reached the timeout and should return the results ASAP
-                    _ = &mut timeout => break,
-                }
-            }
-        }
-
-        self.fills.collect_garbage();
-
-        // Shuffle so that in the case a buggy solver keeps returning some amount
-        // of invalid settlements first we have a chance to make progress.
-        settlements.shuffle(&mut rand::thread_rng());
-        // Keep at most this many settlements to not overwhelm the node with too many
-        // simulations.
-        settlements.truncate(self.max_settlements_per_solver);
-
-        merge::merge_settlements(
-            self.max_merged_settlements,
-            &external_prices,
-            &mut settlements,
-        );
-
-        Ok(settlements)
-    }
-
     async fn solve_single_order(
         &self,
         order: LimitOrder,
@@ -419,11 +309,9 @@ impl SingleOrderSolver {
 
         let simulation = match result {
             Rating::Ok(simulation) => simulation,
-            Rating::Err(err) => {
-                return Err(err.error).context(format!(
-                    "failed to rate the settlement: {:?}",
-                    err.simulation.transaction
-                ))
+            Rating::Err(SimulationWithError { error, simulation }) => {
+                tracing::debug!(?error, ?simulation.transaction, "failed to simulate settlement");
+                return Err(error).context("failed to simulate the settlement");
             }
         };
 
@@ -450,9 +338,113 @@ enum SolveResult {
 
 #[async_trait::async_trait]
 impl Solver for SingleOrderSolver {
-    async fn solve(&self, auction: Auction) -> Result<Vec<Settlement>> {
-        let span = tracing::info_span!("", solver = self.name());
-        self.solve_instrumented(auction).instrument(span).await
+    async fn solve(
+        &self,
+        Auction {
+            orders,
+            balances,
+            external_prices,
+            gas_price,
+            deadline,
+            ..
+        }: Auction,
+    ) -> Result<Vec<Settlement>> {
+        let orders = super::balance_and_convert_orders(
+            self.ethflow_contract,
+            &self.order_converter,
+            balances,
+            orders,
+        );
+        let mut orders =
+            get_prioritized_orders(&orders, &external_prices, &self.order_prioritization_config);
+        tracing::trace!(?orders, "prioritized orders");
+
+        let mut settlements = Vec::new();
+        let (tx, mut rx) = mpsc::unbounded_channel::<SingleOrderSettlement>();
+
+        let solve = async {
+            while let Some(order) = orders.pop_front() {
+                let span = tracing::info_span!("order", id =? order.id);
+                match self
+                    .solve_single_order(order, &external_prices, gas_price)
+                    .instrument(span)
+                    .await
+                {
+                    SolveResult::Failed => continue,
+                    SolveResult::Retryable(order) => orders.push_back(order),
+                    SolveResult::Solved(settlement) => {
+                        let _ = tx.send(settlement);
+                    }
+                    SolveResult::RateLimited => {
+                        tracing::warn!(
+                            solver = %self.name(),
+                            "rate limited; backing off until next auction"
+                        );
+                        break;
+                    }
+                }
+            }
+            drop(tx);
+        };
+
+        let finalize = async {
+            let mut index = 0;
+            while let Some(intermediate) = rx.recv().await {
+                match self
+                    .finalize_settlement(intermediate, &external_prices, gas_price, index)
+                    .await
+                {
+                    Ok(Some(settlement)) => {
+                        settlements.push(settlement);
+                    }
+                    Ok(None) => (),
+                    Err(err) => {
+                        tracing::warn!(?err, "failed to finalize intermediate settlement");
+                    }
+                }
+                index += 1;
+            }
+        };
+
+        // Subtract a small amount of time to ensure that the driver doesn't reach the
+        // deadline first.
+        let timeout =
+            tokio::time::sleep_until(deadline.checked_sub(Duration::from_secs(1)).unwrap().into());
+
+        // open new scope for solve->finalize pipeline to make borrow checker happy
+        {
+            let solve = solve.fuse();
+            futures::pin_mut!(solve);
+            futures::pin_mut!(finalize);
+            futures::pin_mut!(timeout);
+            loop {
+                tokio::select! {
+                    // if `solve` stops early there are still settlements to be finalized
+                    _ = &mut solve => (),
+                    // all possible settlements have been finalized
+                    _ = &mut finalize => break,
+                    // we reached the timeout and should return the results ASAP
+                    _ = &mut timeout => break,
+                }
+            }
+        }
+
+        self.fills.collect_garbage();
+
+        // Shuffle so that in the case a buggy solver keeps returning some amount
+        // of invalid settlements first we have a chance to make progress.
+        settlements.shuffle(&mut rand::thread_rng());
+        // Keep at most this many settlements to not overwhelm the node with too many
+        // simulations.
+        settlements.truncate(self.max_settlements_per_solver);
+
+        merge::merge_settlements(
+            self.max_merged_settlements,
+            &external_prices,
+            &mut settlements,
+        );
+
+        Ok(settlements)
     }
 
     fn account(&self) -> &Account {
@@ -714,8 +706,7 @@ mod tests {
         num::{BigRational, FromPrimitive},
         primitive_types::H160,
         shared::{
-            http_solver::model::InternalizationStrategy,
-            price_estimation::gas::SETTLEMENT_OVERHEAD,
+            http_solver::model::InternalizationStrategy, price_estimation::gas::SETTLEMENT_OVERHEAD,
         },
         std::{collections::HashMap, sync::Arc},
     };

--- a/crates/solver/src/solver/single_order_solver.rs
+++ b/crates/solver/src/solver/single_order_solver.rs
@@ -2,10 +2,7 @@ use {
     super::SolverInfo,
     crate::{
         liquidity::{
-            order_converter::OrderConverter,
-            LimitOrder,
-            LimitOrderExecution,
-            LimitOrderId,
+            order_converter::OrderConverter, LimitOrder, LimitOrderExecution, LimitOrderId,
         },
         metrics::SolverMetrics,
         settlement::Settlement,
@@ -353,6 +350,7 @@ impl Solver for SingleOrderSolver {
         }: Auction,
     ) -> Result<Vec<Settlement>> {
         let solver_span = tracing::info_span!("", solver = self.name());
+        let _e = solver_span.enter();
         let orders = super::balance_and_convert_orders(
             self.ethflow_contract,
             &self.order_converter,
@@ -710,8 +708,7 @@ mod tests {
         num::{BigRational, FromPrimitive},
         primitive_types::H160,
         shared::{
-            http_solver::model::InternalizationStrategy,
-            price_estimation::gas::SETTLEMENT_OVERHEAD,
+            http_solver::model::InternalizationStrategy, price_estimation::gas::SETTLEMENT_OVERHEAD,
         },
         std::{collections::HashMap, sync::Arc},
     };

--- a/crates/solver/src/solver/single_order_solver.rs
+++ b/crates/solver/src/solver/single_order_solver.rs
@@ -1,10 +1,11 @@
-use super::SimulationWithError;
-
 use {
-    super::SolverInfo,
+    super::{SimulationWithError, SolverInfo},
     crate::{
         liquidity::{
-            order_converter::OrderConverter, LimitOrder, LimitOrderExecution, LimitOrderId,
+            order_converter::OrderConverter,
+            LimitOrder,
+            LimitOrderExecution,
+            LimitOrderId,
         },
         metrics::SolverMetrics,
         settlement::Settlement,
@@ -706,7 +707,8 @@ mod tests {
         num::{BigRational, FromPrimitive},
         primitive_types::H160,
         shared::{
-            http_solver::model::InternalizationStrategy, price_estimation::gas::SETTLEMENT_OVERHEAD,
+            http_solver::model::InternalizationStrategy,
+            price_estimation::gas::SETTLEMENT_OVERHEAD,
         },
         std::{collections::HashMap, sync::Arc},
     };


### PR DESCRIPTION
Context: https://cowservices.slack.com/archives/C0361CDD1FZ/p1684230417712809

Trivial PR, that mainly
1. Sets a parent span as a first line in the single order solver so that subsequent logs that are related to a solver but not an order can still be associated with a particular solver instance
2. Logs the simulated transaction in case we are unable to rate a single order settlement, which should make it easy to reproduce what was the error.

I think it would be good to merge this in the next release so we can debug some of the unsatisfying auctions we saw this week more reliably.
