### PR TITLE
Fix Gnosis solvers score computation since revert cost is now zero

### DIFF
--- a/crates/solver/src/solver/score_computation.rs
+++ b/crates/solver/src/solver/score_computation.rs
@@ -51,8 +51,7 @@ impl ScoreCalculator {
             - self.gas_price_factor * gas_price / 10_000_000_000.
             - self.nmb_orders_factor * nmb_orders as f64;
         let success_probability = 1. / (1. + exponent.exp());
-        let score = success_probability * (surplus + fees - gas_amount * gas_price)
-            - (1. - success_probability) * 21000. * gas_price;
+        let score = success_probability * (surplus + fees - gas_amount * gas_price);
         tracing::trace!(
             ?surplus,
             ?fees,
@@ -196,6 +195,6 @@ mod tests {
             .unwrap()
             .calculate(&inputs, nmb_orders)
             .unwrap();
-        assert_eq!(score, 231414764258305056u128.into());
+        assert_eq!(score, 231484104402230912u128.into());
     }
 }

--- a/crates/solver/src/solver/score_computation.rs
+++ b/crates/solver/src/solver/score_computation.rs
@@ -195,6 +195,6 @@ mod tests {
             .unwrap()
             .calculate(&inputs, nmb_orders)
             .unwrap();
-        assert_eq!(score, 231484104402230912u128.into());
+        assert_eq!(score, 231484104402245472u128.into());
     }
 }


### PR DESCRIPTION
This PR readjusts the score computation for Gnosis solvers, since we now have zero cost whenever a transaction fails. This is due to MEV Blocker and the soft cancellations we can now do.

See also relevant discussion on [Slack](https://cowservices.slack.com/archives/C0375NV72SC/p1684508285452079).