### PR TITLE
Remove app data hash based fee subsidy

### DIFF
--- a/crates/autopilot/src/database/onchain_order_events.rs
+++ b/crates/autopilot/src/database/onchain_order_events.rs
@@ -550,7 +550,6 @@ async fn get_quote(
         kind: order_data.kind,
         // Original quote was made from user account, and not necessarily from owner.
         from: order_placement.sender,
-        app_data: order_data.app_data,
     };
     get_quote_and_check_fee(
         quoter,

--- a/crates/autopilot/src/lib.rs
+++ b/crates/autopilot/src/lib.rs
@@ -462,7 +462,6 @@ pub async fn main(args: arguments::Arguments) {
         min_discounted_fee: args.order_quoting.min_discounted_fee,
         fee_factor: args.order_quoting.fee_factor,
         liquidity_order_owners: liquidity_order_owners.clone(),
-        partner_additional_fee_factors: args.order_quoting.partner_additional_fee_factors.clone(),
     }) as Arc<dyn FeeSubsidizing>;
 
     let fee_subsidy = match cow_subsidy {

--- a/crates/orderbook/src/run.rs
+++ b/crates/orderbook/src/run.rs
@@ -403,7 +403,6 @@ pub async fn run(args: Arguments) {
             .iter()
             .copied()
             .collect(),
-        partner_additional_fee_factors: args.order_quoting.partner_additional_fee_factors.clone(),
     }) as Arc<dyn FeeSubsidizing>;
 
     let fee_subsidy = match cow_subsidy {

--- a/crates/shared/src/fee_subsidy.rs
+++ b/crates/shared/src/fee_subsidy.rs
@@ -32,7 +32,6 @@ use {
     anyhow::Result,
     ethcontract::{H160, U256},
     futures::future,
-    model::app_id::AppId,
     std::sync::Arc,
 };
 
@@ -40,9 +39,6 @@ use {
 pub struct SubsidyParameters {
     /// The trader address.
     pub from: H160,
-
-    /// The app data.
-    pub app_data: AppId,
 }
 
 #[derive(Clone, Debug, PartialEq)]

--- a/crates/shared/src/fee_subsidy/config.rs
+++ b/crates/shared/src/fee_subsidy/config.rs
@@ -2,8 +2,7 @@ use {
     super::{FeeSubsidizing, Subsidy, SubsidyParameters},
     anyhow::Result,
     ethcontract::H160,
-    model::app_id::AppId,
-    std::collections::{HashMap, HashSet},
+    std::collections::HashSet,
 };
 
 /// The global configured fee subsidy to use for orders.
@@ -33,12 +32,6 @@ pub struct FeeSubsidyConfiguration {
 
     /// Liquidity order providers that get completely discounted fees.
     pub liquidity_order_owners: HashSet<H160>,
-
-    /// Additional factors per order app ID for computing the subsidized minimum
-    /// fee.
-    ///
-    /// Fee factors are applied **after** flat fee discounts.
-    pub partner_additional_fee_factors: HashMap<AppId, f64>,
 }
 
 impl Default for FeeSubsidyConfiguration {
@@ -48,7 +41,6 @@ impl Default for FeeSubsidyConfiguration {
             fee_factor: 1.,
             min_discounted_fee: 0.,
             liquidity_order_owners: Default::default(),
-            partner_additional_fee_factors: Default::default(),
         }
     }
 }
@@ -61,16 +53,11 @@ impl FeeSubsidizing for FeeSubsidyConfiguration {
         } else {
             1.
         };
-        let partner_factor = self
-            .partner_additional_fee_factors
-            .get(&parameters.app_data)
-            .copied()
-            .unwrap_or(1.);
 
         Ok(Subsidy {
             discount: self.fee_discount,
             min_discounted: self.min_discounted_fee,
-            factor: self.fee_factor * liquidity_factor * partner_factor,
+            factor: self.fee_factor * liquidity_factor,
         })
     }
 }

--- a/crates/shared/src/order_quoting.rs
+++ b/crates/shared/src/order_quoting.rs
@@ -18,7 +18,6 @@ use {
     futures::TryFutureExt as _,
     gas_estimation::GasPriceEstimating,
     model::{
-        app_id::AppId,
         order::{OrderClass, OrderKind},
         quote::{
             OrderQuote,
@@ -136,7 +135,6 @@ pub struct QuoteParameters {
     pub buy_token: H160,
     pub side: OrderQuoteSide,
     pub from: H160,
-    pub app_data: AppId,
     pub signing_scheme: QuoteSigningScheme,
 }
 
@@ -369,7 +367,6 @@ pub struct QuoteSearchParameters {
     pub fee_amount: U256,
     pub kind: OrderKind,
     pub from: H160,
-    pub app_data: AppId,
 }
 
 impl QuoteSearchParameters {
@@ -541,7 +538,6 @@ impl OrderQuoting for OrderQuoter {
             self.fee_subsidy
                 .subsidy(SubsidyParameters {
                     from: parameters.from,
-                    app_data: parameters.app_data,
                 })
                 .map_err(From::from),
         )?;
@@ -594,7 +590,6 @@ impl OrderQuoting for OrderQuoter {
 
         let subsidy = SubsidyParameters {
             from: parameters.from,
-            app_data: parameters.app_data,
         };
 
         let now = self.now.now();
@@ -670,7 +665,6 @@ impl From<&OrderQuoteRequest> for QuoteParameters {
             buy_token: request.buy_token,
             side: request.side,
             from: request.from,
-            app_data: request.app_data,
             signing_scheme: request.signing_scheme,
         }
     }
@@ -742,7 +736,6 @@ mod tests {
                 sell_amount: SellAmount::BeforeFee { value: 100.into() },
             },
             from: H160([3; 20]),
-            app_data: AppId([4; 32]),
             signing_scheme: QuoteSigningScheme::Eip712,
         };
         let gas_price = GasPrice1559 {
@@ -859,7 +852,6 @@ mod tests {
                 sell_amount: SellAmount::AfterFee { value: 100.into() },
             },
             from: H160([3; 20]),
-            app_data: AppId([4; 32]),
             signing_scheme: QuoteSigningScheme::Eip712,
         };
         let gas_price = GasPrice1559 {
@@ -979,7 +971,6 @@ mod tests {
                 buy_amount_after_fee: 42.into(),
             },
             from: H160([3; 20]),
-            app_data: AppId([4; 32]),
             signing_scheme: QuoteSigningScheme::Eip712,
         };
         let gas_price = GasPrice1559 {
@@ -1099,7 +1090,6 @@ mod tests {
                 sell_amount: SellAmount::BeforeFee { value: 100.into() },
             },
             from: H160([3; 20]),
-            app_data: AppId([4; 32]),
             signing_scheme: QuoteSigningScheme::Eip712,
         };
         let gas_price = GasPrice1559 {
@@ -1164,7 +1154,6 @@ mod tests {
                 },
             },
             from: H160([3; 20]),
-            app_data: AppId([4; 32]),
             signing_scheme: QuoteSigningScheme::Eip712,
         };
         let gas_price = GasPrice1559 {
@@ -1234,7 +1223,6 @@ mod tests {
             fee_amount: 15.into(),
             kind: OrderKind::Sell,
             from: H160([3; 20]),
-            app_data: AppId([4; 32]),
         };
 
         let mut storage = MockQuoteStoring::new();
@@ -1317,7 +1305,6 @@ mod tests {
             fee_amount: 30.into(),
             kind: OrderKind::Sell,
             from: H160([3; 20]),
-            app_data: AppId([4; 32]),
         };
 
         let mut storage = MockQuoteStoring::new();
@@ -1389,7 +1376,6 @@ mod tests {
             fee_amount: 30.into(),
             kind: OrderKind::Buy,
             from: H160([3; 20]),
-            app_data: AppId([4; 32]),
         };
 
         let mut storage = MockQuoteStoring::new();

--- a/crates/shared/src/order_validation.rs
+++ b/crates/shared/src/order_validation.rs
@@ -476,7 +476,6 @@ impl OrderValidating for OrderValidator {
             fee_amount: order.data.fee_amount,
             kind: order.data.kind,
             from: owner,
-            app_data: order.data.app_data,
         };
         let quote = if class == OrderClass::Market {
             let quote = get_quote_and_check_fee(
@@ -739,7 +738,6 @@ pub async fn get_quote_and_check_fee(
                     },
                 },
                 from: quote_search_parameters.from,
-                app_data: quote_search_parameters.app_data,
                 signing_scheme,
             };
 
@@ -823,7 +821,6 @@ mod tests {
         maplit::hashset,
         mockall::predicate::{always, eq},
         model::{
-            app_id::AppId,
             order::OrderBuilder,
             quote::default_verification_gas_limit,
             signature::EcdsaSigningScheme,
@@ -1895,7 +1892,6 @@ mod tests {
             fee_amount: 6.into(),
             kind: OrderKind::Buy,
             from: H160([0xf0; 20]),
-            app_data: AppId([5; 32]),
         };
         let quote_data = Quote {
             fee_amount: 6.into(),
@@ -1949,7 +1945,6 @@ mod tests {
             buy_token: H160([2; 20]),
             kind: OrderKind::Sell,
             from,
-            app_data: AppId([5; 32]),
             ..Default::default()
         };
         let quote_data = Quote {
@@ -1968,7 +1963,6 @@ mod tests {
                     },
                 },
                 from,
-                app_data: quote_search_parameters.app_data,
                 signing_scheme: QuoteSigningScheme::Eip712,
             }))
             .returning({


### PR DESCRIPTION
Related to https://github.com/cowprotocol/services/issues/1465 . With the meaning of app data changing, it doesn't make sense to award a subsidy to an arbitrary app data hash value because the value is a hash of something else and not freely chooseable.

If we wanted to keep app id (which is not app data hash) based subsidies then we would need to do that through the full app data. But this feature in general makes little sense because anyone could pick an app id that has a subsidy even when they're not actually coming from that app. So it makes more sense to remove. I don't think we're actively using this anyway. In the infra configuration I see one value which has last been mentioned on Slack more than a year ago.

Follow ups:
- Remove this configuration from the infra repo.

### Test Plan

CI
