### PR TITLE
Fix Wrong Owner Message to Include Full Address

### DIFF
--- a/crates/orderbook/src/api/post_order.rs
+++ b/crates/orderbook/src/api/post_order.rs
@@ -126,7 +126,7 @@ impl IntoWarpReply for ValidationErrorWrapper {
                 error(
                     "WrongOwner",
                     format!(
-                        "recovered signer {signer} from signing hash {message:?} does not match \
+                        "recovered signer {signer:?} from signing hash {message:?} does not match \
                          from address"
                     ),
                 ),


### PR DESCRIPTION
#1524 changed the error messages for signature errors. This PR adjusts one of them to use the full address instead of a partial one. The address type's `Display` implementation only shows the first and last two bytes of the address, so this changes the message to use the `Debug` implementation for string formatting so the full address is included in the error.

### Test Plan

CI.
