### PR TITLE
Fix Format String for Price Estimator Instrumentation

### DIFF
--- a/crates/shared/src/price_estimation/factory.rs
+++ b/crates/shared/src/price_estimation/factory.rs
@@ -165,7 +165,7 @@ impl<'a> PriceEstimatorFactory<'a> {
                 .price_estimation_rate_limiter
                 .clone()
                 .unwrap_or_default(),
-            format!("{name:?}_estimator"),
+            format!("{name}_estimator"),
         ))
     }
 
@@ -182,7 +182,7 @@ impl<'a> PriceEstimatorFactory<'a> {
 
         let fast = instrument(estimator, name);
         let optimal = match verified {
-            Some(verified) => instrument(verified, format!("{name:?}_verified")),
+            Some(verified) => instrument(verified, format!("{name}_verified")),
             None => fast.clone(),
         };
 


### PR DESCRIPTION
#1521 introduced a regression where we were incorrectly formatting price estimator labels for metrics. This PR fixes that issue.

### Test Plan
Run the orderbook locally and check the metrics:

```
% curl -s 'http://localhost:9586/metrics' | rg -i oneinch 
gp_v2_api_competition_price_estimator_queries_won{estimator_type="OneInch",order_kind="sell"} 1
gp_v2_api_price_estimates{estimator_type="OneInch",result="failure"} 0
gp_v2_api_price_estimates{estimator_type="OneInch",result="success"} 0
gp_v2_api_price_estimates{estimator_type="OneInch_verified",result="failure"} 0
gp_v2_api_price_estimates{estimator_type="OneInch_verified",result="success"} 1
gp_v2_api_rate_limiter_rate_limited_requests{endpoint="OneInch_estimator"} 0
gp_v2_api_rate_limiter_requests_dropped{endpoint="OneInch_estimator"} 0
gp_v2_api_rate_limiter_successful_requests{endpoint="OneInch_estimator"} 1
```
