### PR TITLE
Demote order conversion alert

### DIFF
--- a/crates/solver/src/solver.rs
+++ b/crates/solver/src/solver.rs
@@ -609,10 +609,8 @@ fn balance_and_convert_orders(
         .into_iter()
         .filter_map(|order| match converter.normalize_limit_order(order) {
             Ok(order) => Some(order),
-            // This should never happen unless we are getting malformed
-            // orders from the API - so raise an alert if this happens.
             Err(err) => {
-                tracing::error!(?err, "error normalizing limit order");
+                tracing::debug!(?err, "error normalizing limit order");
                 None
             }
         })


### PR DESCRIPTION
Closes: #1506

We decided that it's not worth to alert on this error. The reason is that after putting an order in the auction in the `autopilot` the circumstances might change enough that it will result in the order being dropped on the `driver` side due to no error.
This could happen because a partial fill for that order is already in-flight which would reduce the fillable amount in the `driver` too much. Also it could be that the user's balance changes when we see a new block which results in the same thing.
The only way to catch that would be to basically do the same conversion and check the `OrderConverter` does before hand to filter those orders out. But if we are fine with discarding those orders without an alert in this pre-test there is no good reason we shouldn't just demote the `error` to a `debug` log directly in the `OrderConverter` and not introduce that pre-test.

### Test Plan
CI
