### PR TITLE
Implement hacky support for soft cancellations

### DIFF
--- a/crates/driver/src/infra/config/file/load.rs
+++ b/crates/driver/src/infra/config/file/load.rs
@@ -88,9 +88,11 @@ pub async fn load(path: &Path) -> infra::Config {
                     file::Mempool::Flashbots {
                         url,
                         max_additional_tip,
+                        use_soft_cancellations,
                     } => mempool::Kind::Flashbots {
                         url: url.to_owned(),
                         max_additional_tip: *max_additional_tip,
+                        use_soft_cancellations: *use_soft_cancellations,
                     },
                 },
             })

--- a/crates/driver/src/infra/config/file/mod.rs
+++ b/crates/driver/src/infra/config/file/mod.rs
@@ -89,6 +89,15 @@ enum Mempool {
         /// Flashbots above regular gas price estimation.
         #[serde(default = "default_max_additional_flashbots_tip")]
         max_additional_tip: f64,
+        /// Configures whether the submission logic is allowed to assume the
+        /// submission nodes implement soft cancellations. With soft
+        /// cancellations you don't have to submit a no-op transaction to
+        /// replace another transaction in the mempool. Instead you can just
+        /// issue another transaction with the same sender and nonce and
+        /// the submission node will no longer propagate the previous
+        /// transactions
+        #[serde(default = "default_soft_cancellations_flag")]
+        use_soft_cancellations: bool,
     },
 }
 
@@ -114,6 +123,10 @@ fn default_max_confirm_time_secs() -> u64 {
 
 fn default_max_additional_flashbots_tip() -> f64 {
     3.0
+}
+
+fn default_soft_cancellations_flag() -> bool {
+    false
 }
 
 #[serde_as]

--- a/crates/driver/src/infra/config/file/mod.rs
+++ b/crates/driver/src/infra/config/file/mod.rs
@@ -91,11 +91,9 @@ enum Mempool {
         max_additional_tip: f64,
         /// Configures whether the submission logic is allowed to assume the
         /// submission nodes implement soft cancellations. With soft
-        /// cancellations you don't have to submit a no-op transaction to
-        /// replace another transaction in the mempool. Instead you can just
-        /// issue another transaction with the same sender and nonce and
-        /// the submission node will no longer propagate the previous
-        /// transactions
+        /// cancellations a cancellation transaction doesn't have to get mined
+        /// to have an effect. On arrival in the node all pending transactions
+        /// with the same sender and nonce will get discarded immediately.
         #[serde(default = "default_soft_cancellations_flag")]
         use_soft_cancellations: bool,
     },

--- a/crates/solver/src/arguments.rs
+++ b/crates/solver/src/arguments.rs
@@ -203,6 +203,15 @@ pub struct Arguments {
     )]
     pub flashbots_api_url: Vec<Url>,
 
+    /// Configures whether the submission logic is allowed to assume the
+    /// submission nodes implement soft cancellations. With soft
+    /// cancellations you don't have to submit a no-op transaction to
+    /// replace another transaction in the mempool. Instead you can just issue
+    /// another transaction with the same sender and nonce and the
+    /// submission node will no longer propagate the previous transactions
+    #[clap(long, env, action = clap::ArgAction::Set, default_value = "false")]
+    pub use_soft_cancellations: bool,
+
     /// Maximum additional tip in gwei that we are willing to give to eden above
     /// regular gas price estimation
     #[clap(

--- a/crates/solver/src/arguments.rs
+++ b/crates/solver/src/arguments.rs
@@ -204,11 +204,10 @@ pub struct Arguments {
     pub flashbots_api_url: Vec<Url>,
 
     /// Configures whether the submission logic is allowed to assume the
-    /// submission nodes implement soft cancellations. With soft
-    /// cancellations you don't have to submit a no-op transaction to
-    /// replace another transaction in the mempool. Instead you can just issue
-    /// another transaction with the same sender and nonce and the
-    /// submission node will no longer propagate the previous transactions
+    /// submission nodes implement soft cancellations. With soft cancellations a
+    /// cancellation transaction doesn't have to get mined to have an effect. On
+    /// arrival in the node all pending transactions with the same sender and
+    /// nonce will get discarded immediately.
     #[clap(long, env, action = clap::ArgAction::Set, default_value = "false")]
     pub use_soft_cancellations: bool,
 

--- a/crates/solver/src/run.rs
+++ b/crates/solver/src/run.rs
@@ -452,6 +452,7 @@ pub async fn run(args: Arguments) {
                     max_additional_tip: args.max_additional_eden_tip,
                     additional_tip_percentage_of_max_fee: args.additional_tip_percentage,
                     sub_tx_pool: submitted_transactions.add_sub_pool(Strategy::Eden),
+                    use_soft_cancellations: false,
                 }))
             }
             TransactionStrategyArg::Flashbots => {
@@ -463,6 +464,7 @@ pub async fn run(args: Arguments) {
                         max_additional_tip: args.max_additional_flashbot_tip,
                         additional_tip_percentage_of_max_fee: args.additional_tip_percentage,
                         sub_tx_pool: submitted_transactions.add_sub_pool(Strategy::Flashbots),
+                        use_soft_cancellations: args.use_soft_cancellations,
                     }))
                 }
             }
@@ -480,6 +482,7 @@ pub async fn run(args: Arguments) {
                     max_additional_tip: 0.,
                     additional_tip_percentage_of_max_fee: 0.,
                     sub_tx_pool: submitted_transactions.add_sub_pool(Strategy::PublicMempool),
+                    use_soft_cancellations: false,
                 }))
             }
             TransactionStrategyArg::Gelato => {

--- a/crates/solver/src/settlement_submission.rs
+++ b/crates/solver/src/settlement_submission.rs
@@ -151,6 +151,7 @@ pub struct StrategyArgs {
     pub max_additional_tip: f64,
     pub additional_tip_percentage_of_max_fee: f64,
     pub sub_tx_pool: SubTxPoolRef,
+    pub use_soft_cancellations: bool,
 }
 
 pub enum TransactionStrategy {
@@ -340,6 +341,7 @@ impl SolutionSubmitter {
             retry_interval: self.retry_interval,
             network_id,
             additional_call_data: Default::default(),
+            use_soft_cancellations: strategy_args.use_soft_cancellations,
         };
         let gas_price_estimator = SubmitterGasPriceEstimator {
             inner: self.gas_price_estimator.as_ref(),
@@ -503,6 +505,7 @@ mod tests {
                 max_additional_tip: Default::default(),
                 additional_tip_percentage_of_max_fee: Default::default(),
                 sub_tx_pool: Default::default(),
+                use_soft_cancellations: false,
             }
         }
     }

--- a/crates/solver/src/settlement_submission/submitter.rs
+++ b/crates/solver/src/settlement_submission/submitter.rs
@@ -278,9 +278,7 @@ impl<'a> Submitter<'a> {
                         .await
                     {
                         Ok(handle) => {
-                            if !use_soft_cancellations {
-                                transactions.push((handle, gas_price));
-                            } else {
+                            if use_soft_cancellations {
                                 // If the submission node supports soft cancellations it will
                                 // simply discard all transactions with the same `sender` and
                                 // `nonce` from the internal mempool when it sees the
@@ -297,6 +295,8 @@ impl<'a> Submitter<'a> {
                                 // simply "forget" the submitted tx by clearing `transactions`.
                                 tracing::debug!("clear list of pending tx hashes due to soft cancellation");
                                 transactions.clear();
+                            } else {
+                                transactions.push((handle, gas_price));
                             }
                         }
                         Err(err) => tracing::warn!("cancellation failed: {:?}", err),


### PR DESCRIPTION
[Context](https://cowservices.slack.com/archives/C0361CDD1FZ/p1684746958813839) on slack.
Simply enabling soft cancellations in our MevBlocker proxy is not sufficient to avoid subtle bugs in our submission logic with that feature. We also have to add actual support for it.

The basic problem seems to be this:
1. solver wins auction
2. we start to submit the tx
3. tx start to revert so we cancel the tx
4. cancellation does not get mined (I assume due to the inner workings of MevBlocker + soft cancellations)
5. same solver wins again
6. we want to submit the next solution but we remember that the previous cancellation has not been mined yet and the gas price didn't increase enough that "normal" nodes would replace the tx so we just don't submit anything for 2 minutes (or however long it takes for the gas price to increase enough)

Since `MevBlocker` supports soft cancellations we can pretend there is no pending tx waiting to be mined.
So when the same solver wins then next auction again we will not wait for the gas price to increase by 12.5% before starting to submit the winning tx.

### Test Plan
CI
