### PR TITLE
Log soft cancellations flag on startup

### DIFF
--- a/crates/solver/src/arguments.rs
+++ b/crates/solver/src/arguments.rs
@@ -434,6 +434,7 @@ impl std::fmt::Display for Arguments {
         )?;
         writeln!(f, "eden_api_url: {}", self.eden_api_url)?;
         display_list(f, "flashbots_api_url", &self.flashbots_api_url)?;
+        writeln!(f, "use_soft_cancellations: {}", self.use_soft_cancellations)?;
         writeln!(
             f,
             "max_additional_eden_tip: {}",


### PR DESCRIPTION
Adds logging of the `use_soft_cancellations` CLI flag that I forgot in #1544.

### Test Plan
CI