### PR TITLE
Add EthFlow Order Debug Logs

### DIFF
--- a/crates/autopilot/src/database/onchain_order_events.rs
+++ b/crates/autopilot/src/database/onchain_order_events.rs
@@ -54,6 +54,7 @@ use {
     },
     web3::types::U64,
 };
+
 pub struct OnchainOrderParser<EventData: Send + Sync, EventRow: Send + Sync> {
     db: Postgres,
     web3: Web3,
@@ -220,6 +221,14 @@ impl<T: Sync + Send + Clone, W: Sync + Send + Clone> EventStoring<ContractEvent>
             .await
             .context("insert_orders failed")?;
         transaction.commit().await.context("commit")?;
+
+        for order in &invalided_order_uids {
+            tracing::debug!(?order, "invalidated order");
+        }
+        for order in &orders {
+            tracing::debug!(order =? order.uid, "upserted order");
+        }
+
         Ok(())
     }
 


### PR DESCRIPTION
Since EthFlow order creation timestamps are block timestamps, we don't have an easy way to determine the exact insertion time of an EthFlow order into the database. This PR adds a log statement that would indirectly give us the exact system time for each EthFlow order that is indexed into the orderbook database.

### Test Plan

CI
