### PR TITLE
Add Flag For Specifying only Buy Orders for 0x Estimator

### DIFF
--- a/crates/shared/src/price_estimation.rs
+++ b/crates/shared/src/price_estimation.rs
@@ -172,6 +172,11 @@ pub struct Arguments {
     /// more price estimators will not be asked for a quote.
     #[clap(long, env, default_value = "1")]
     pub quote_prediction_confidence: f64,
+
+    /// Use 0x estimator for only buy orders. This flag can be enabled to reduce
+    /// request pressure on the 0x API.
+    #[clap(long, env, action = clap::ArgAction::Set, default_value = "false")]
+    pub zeroex_only_estimate_buy_queries: bool,
 }
 
 impl Display for Arguments {
@@ -232,6 +237,11 @@ impl Display for Arguments {
             f,
             "enable_quote_predictions: {:?}",
             self.enable_quote_predictions
+        )?;
+        writeln!(
+            f,
+            "zeroex_only_estimate_buy_queries: {:?}",
+            self.zeroex_only_estimate_buy_queries
         )?;
 
         Ok(())

--- a/crates/shared/src/price_estimation/factory.rs
+++ b/crates/shared/src/price_estimation/factory.rs
@@ -211,9 +211,10 @@ impl<'a> PriceEstimatorFactory<'a> {
             PriceEstimatorType::Paraswap => {
                 self.create_estimator_entry::<ParaswapPriceEstimator>(&name, ())
             }
-            PriceEstimatorType::ZeroEx => {
-                self.create_estimator_entry::<ZeroExPriceEstimator>(&name, ())
-            }
+            PriceEstimatorType::ZeroEx => self.create_estimator_entry::<ZeroExPriceEstimator>(
+                &name,
+                self.args.zeroex_only_estimate_buy_queries,
+            ),
             PriceEstimatorType::Quasimodo => self.create_estimator_entry::<HttpPriceEstimator>(
                 &name,
                 HttpPriceEstimatorParams {
@@ -428,15 +429,16 @@ impl PriceEstimatorCreating for ParaswapPriceEstimator {
     }
 }
 impl PriceEstimatorCreating for ZeroExPriceEstimator {
-    type Params = ();
+    type Params = bool;
 
-    fn init(factory: &PriceEstimatorFactory, name: &str, _: Self::Params) -> Result<Self> {
+    fn init(factory: &PriceEstimatorFactory, name: &str, buy_only: Self::Params) -> Result<Self> {
         Ok(ZeroExPriceEstimator::new(
             factory.components.zeroex.clone(),
             factory.shared_args.disabled_zeroex_sources.clone(),
             factory.rate_limiter(name),
             factory.network.settlement,
-        ))
+        )
+        .buy_only(buy_only))
     }
 
     fn verified(&self, verifier: &TradeVerifier) -> Option<Self> {

--- a/crates/shared/src/price_estimation/factory.rs
+++ b/crates/shared/src/price_estimation/factory.rs
@@ -211,10 +211,9 @@ impl<'a> PriceEstimatorFactory<'a> {
             PriceEstimatorType::Paraswap => {
                 self.create_estimator_entry::<ParaswapPriceEstimator>(&name, ())
             }
-            PriceEstimatorType::ZeroEx => self.create_estimator_entry::<ZeroExPriceEstimator>(
-                &name,
-                self.args.zeroex_only_estimate_buy_queries,
-            ),
+            PriceEstimatorType::ZeroEx => {
+                self.create_estimator_entry::<ZeroExPriceEstimator>(&name, ())
+            }
             PriceEstimatorType::Quasimodo => self.create_estimator_entry::<HttpPriceEstimator>(
                 &name,
                 HttpPriceEstimatorParams {
@@ -429,16 +428,16 @@ impl PriceEstimatorCreating for ParaswapPriceEstimator {
     }
 }
 impl PriceEstimatorCreating for ZeroExPriceEstimator {
-    type Params = bool;
+    type Params = ();
 
-    fn init(factory: &PriceEstimatorFactory, name: &str, buy_only: Self::Params) -> Result<Self> {
+    fn init(factory: &PriceEstimatorFactory, name: &str, _: Self::Params) -> Result<Self> {
         Ok(ZeroExPriceEstimator::new(
             factory.components.zeroex.clone(),
             factory.shared_args.disabled_zeroex_sources.clone(),
             factory.rate_limiter(name),
             factory.network.settlement,
-        )
-        .buy_only(buy_only))
+            factory.args.zeroex_only_estimate_buy_queries,
+        ))
     }
 
     fn verified(&self, verifier: &TradeVerifier) -> Option<Self> {

--- a/crates/shared/src/price_estimation/trade_finder.rs
+++ b/crates/shared/src/price_estimation/trade_finder.rs
@@ -986,7 +986,7 @@ mod tests {
         );
 
         let zeroex_api = DefaultZeroExApi::test();
-        let finder = ZeroExTradeFinder::new(Arc::new(zeroex_api), vec![]);
+        let finder = ZeroExTradeFinder::new(Arc::new(zeroex_api), vec![], false);
 
         let estimator = TradeEstimator::new(
             testlib::protocol::SETTLEMENT,

--- a/crates/shared/src/price_estimation/zeroex.rs
+++ b/crates/shared/src/price_estimation/zeroex.rs
@@ -3,6 +3,7 @@ use {
         trade_finder::{TradeEstimator, TradeVerifier},
         PriceEstimateResult,
         PriceEstimating,
+        PriceEstimationError,
         Query,
     },
     crate::{
@@ -11,10 +12,15 @@ use {
         zeroex_api::ZeroExApi,
     },
     ethcontract::H160,
+    futures::StreamExt,
+    model::order::OrderKind,
     std::sync::Arc,
 };
 
-pub struct ZeroExPriceEstimator(TradeEstimator);
+pub struct ZeroExPriceEstimator {
+    inner: TradeEstimator,
+    buy_only: bool,
+}
 
 impl ZeroExPriceEstimator {
     pub fn new(
@@ -23,15 +29,26 @@ impl ZeroExPriceEstimator {
         rate_limiter: Arc<RateLimiter>,
         settlement: H160,
     ) -> Self {
-        Self(TradeEstimator::new(
-            settlement,
-            Arc::new(ZeroExTradeFinder::new(api, excluded_sources)),
-            rate_limiter,
-        ))
+        Self {
+            inner: TradeEstimator::new(
+                settlement,
+                Arc::new(ZeroExTradeFinder::new(api, excluded_sources)),
+                rate_limiter,
+            ),
+            buy_only: false,
+        }
     }
 
     pub fn verified(&self, verifier: TradeVerifier) -> Self {
-        Self(self.0.clone().with_verifier(verifier))
+        Self {
+            inner: self.inner.clone().with_verifier(verifier),
+            buy_only: self.buy_only,
+        }
+    }
+
+    pub fn buy_only(mut self, value: bool) -> Self {
+        self.buy_only = value;
+        self
     }
 }
 
@@ -40,7 +57,28 @@ impl PriceEstimating for ZeroExPriceEstimator {
         &'a self,
         queries: &'a [Query],
     ) -> futures::stream::BoxStream<'_, (usize, PriceEstimateResult)> {
-        self.0.estimates(queries)
+        if !self.buy_only {
+            self.inner.estimates(queries)
+        } else {
+            async_stream::stream! {
+                let (sell, buy) = queries
+                    .iter()
+                    .copied()
+                    .enumerate()
+                    .partition::<Vec<_>, _>(|(_, query)| query.kind == OrderKind::Sell);
+
+                for (index, _) in sell {
+                    yield (index, Err(PriceEstimationError::UnsupportedOrderType));
+                }
+
+                let buy_queries = buy.iter().map(|(_, query)| *query).collect::<Vec<_>>();
+                for await (index, result) in self.inner.estimates(&buy_queries) {
+                    let (real_index, _) = buy[index];
+                    yield (real_index, result);
+                }
+            }
+            .boxed()
+        }
     }
 }
 
@@ -49,7 +87,7 @@ mod tests {
     use {
         super::*,
         crate::{
-            price_estimation::single_estimate,
+            price_estimation::{single_estimate, vec_estimates},
             zeroex_api::{DefaultZeroExApi, MockZeroExApi, PriceResponse, SwapResponse},
         },
         ethcontract::futures::FutureExt as _,
@@ -165,6 +203,74 @@ mod tests {
 
         assert_eq!(est.out_amount, 8986186353137488u64.into());
         assert!(est.gas > 111000);
+    }
+
+    #[tokio::test]
+    async fn filter_out_sell_estimates() {
+        let mut zeroex_api = MockZeroExApi::new();
+
+        zeroex_api.expect_get_swap().return_once(|_| {
+            async move {
+                Ok(SwapResponse {
+                    price: PriceResponse {
+                        sell_amount: 8986186353137488u64.into(),
+                        buy_amount: 100000000000000000u64.into(),
+                        allowance_target: addr!("def1c0ded9bec7f1a1670819833240f027b25eff"),
+                        price: 0.089_861_863_531_374_87,
+                        estimated_gas: 111000,
+                    },
+                    ..Default::default()
+                })
+            }
+            .boxed()
+        });
+
+        let weth = testlib::tokens::WETH;
+        let gno = testlib::tokens::GNO;
+
+        let estimator = create_estimator(Arc::new(zeroex_api)).buy_only(true);
+
+        let estimates = vec_estimates(
+            &estimator,
+            &[
+                Query {
+                    from: None,
+                    sell_token: weth,
+                    buy_token: gno,
+                    in_amount: 100000000000000000u64.into(),
+                    kind: OrderKind::Sell,
+                },
+                Query {
+                    from: None,
+                    sell_token: weth,
+                    buy_token: gno,
+                    in_amount: 100000000000000000u64.into(),
+                    kind: OrderKind::Buy,
+                },
+                Query {
+                    from: None,
+                    sell_token: weth,
+                    buy_token: gno,
+                    in_amount: 100000000000000000u64.into(),
+                    kind: OrderKind::Sell,
+                },
+            ],
+        )
+        .await;
+
+        assert_eq!(estimates.len(), 3);
+        assert!(matches!(
+            &estimates[0],
+            Err(PriceEstimationError::UnsupportedOrderType)
+        ));
+        assert!(matches!(
+            &estimates[1],
+            Ok(est) if est.out_amount.as_u64() == 8986186353137488u64
+        ));
+        assert!(matches!(
+            &estimates[2],
+            Err(PriceEstimationError::UnsupportedOrderType)
+        ));
     }
 
     #[tokio::test]


### PR DESCRIPTION
This PR adjusts the 0x price estimator to only respond to buy orders when a "buy only" flag is set. This allows us to reduce load on the 0x API for the requests that it is more important for serving.

### Test Plan

Added a unit test, also did a manual test running the orderbook locally with 0x sell orders disabled and saw that quotes were failing on "unsupported order type".
