### PR TITLE
Update database with solver fees in sell token

### DIFF
--- a/crates/autopilot/src/on_settlement_event_updater.rs
+++ b/crates/autopilot/src/on_settlement_event_updater.rs
@@ -176,7 +176,10 @@ impl OnSettlementEventUpdater {
                         fee,
                         gas_used,
                         effective_gas_price,
-                        order_executions,
+                        order_executions: order_executions
+                            .iter()
+                            .map(|fees| (fees.order, fees.sell))
+                            .collect(),
                     });
                 }
                 Err(err) if matches!(err, DecodingError::InvalidSelector) => {


### PR DESCRIPTION
[Context](https://cowservices.slack.com/archives/C0375NV72SC/p1686134241231889).

#1425 unintentionally changed the unit of the `surplus_fee` column to be Ether. This PR fixes that.

### Test Plan

CI, it looks like there are no tests for this code 😞. I would like to add some in a follow up because of the time-sensitive nature of this hotfix.
