### PR TITLE
Store full app data in separate table

### DIFF
--- a/crates/autopilot/src/database/onchain_order_events.rs
+++ b/crates/autopilot/src/database/onchain_order_events.rs
@@ -644,7 +644,6 @@ fn convert_onchain_order_placement(
         class,
         surplus_fee: Default::default(),
         surplus_fee_timestamp: Default::default(),
-        full_app_data: None,
     };
     let onchain_order_placement_event = OnchainOrderPlacement {
         order_uid: ByteArray(order_uid.0),

--- a/crates/database/src/app_data.rs
+++ b/crates/database/src/app_data.rs
@@ -1,0 +1,84 @@
+use {crate::AppId, sqlx::PgConnection};
+
+/// Tries to associate the contract app data with the full app data.
+///
+/// If this contract app data already existed then the existing full app data is
+/// returned.
+///
+/// If this contract did not already exist, it is inserted and the passed in
+/// full app data is returned.
+pub async fn insert(
+    ex: &mut PgConnection,
+    contract_app_data: &AppId,
+    full_app_data: &[u8],
+) -> Result<Vec<u8>, sqlx::Error> {
+    const QUERY: &str = r#"
+WITH insertion AS (
+    INSERT INTO app_data (contract_app_data, full_app_data)
+    VALUES ($1, $2)
+    -- returns null on conflict
+    ON CONFLICT DO NOTHING
+    -- returns inserted value without conflict
+    RETURNING full_app_data
+)
+SELECT COALESCE(
+    (SELECT full_app_data FROM insertion),
+    (SELECT full_app_data FROM app_data WHERE contract_app_data = $1)
+)
+;"#;
+    sqlx::query_scalar(QUERY)
+        .bind(contract_app_data)
+        .bind(full_app_data)
+        .fetch_one(ex)
+        .await
+}
+
+pub async fn fetch(
+    ex: &mut PgConnection,
+    contract_app_data: &AppId,
+) -> Result<Option<Vec<u8>>, sqlx::Error> {
+    const QUERY: &str = r#"
+SELECT full_app_data
+FROM app_data
+WHERE contract_app_data = $1
+;"#;
+    sqlx::query_scalar(QUERY)
+        .bind(contract_app_data)
+        .fetch_optional(ex)
+        .await
+}
+
+#[cfg(test)]
+mod tests {
+    use {super::*, crate::byte_array::ByteArray, sqlx::Connection};
+
+    #[tokio::test]
+    #[ignore]
+    async fn postgres_app_data() {
+        let mut db = PgConnection::connect("postgresql://").await.unwrap();
+        let mut tx = db.begin().await.unwrap();
+        crate::clear_DANGER_(&mut tx).await.unwrap();
+        tx.commit().await.unwrap();
+
+        let contract = ByteArray([0u8; 32]);
+        // fetch non existant app data
+        let result = fetch(&mut db, &contract).await.unwrap();
+        assert!(result.is_none());
+
+        let full = vec![1u8];
+        let result = insert(&mut db, &contract, &full).await.unwrap();
+        assert_eq!(result, full);
+
+        // now exists
+        let result = fetch(&mut db, &contract).await.unwrap();
+        assert_eq!(result, Some(full.clone()));
+
+        // insert again with same app data
+        let result = insert(&mut db, &contract, &full).await.unwrap();
+        assert_eq!(result, full);
+
+        // insert again with different app data fails
+        let result = insert(&mut db, &contract, &[4, 2]).await.unwrap();
+        assert_eq!(result, full);
+    }
+}

--- a/crates/database/src/lib.rs
+++ b/crates/database/src/lib.rs
@@ -1,6 +1,7 @@
 // https://github.com/rust-lang/rust-clippy/issues/9782
 #![allow(clippy::needless_borrow)]
 
+pub mod app_data;
 pub mod auction;
 pub mod auction_participants;
 pub mod auction_prices;
@@ -65,6 +66,7 @@ pub const ALL_TABLES: &[&str] = &[
     "settlement_observations",
     "auction_prices",
     "auction_participants",
+    "app_data",
 ];
 
 /// Delete all data in the database. Only used by tests.

--- a/crates/orderbook/src/api/post_order.rs
+++ b/crates/orderbook/src/api/post_order.rs
@@ -225,6 +225,15 @@ impl IntoWarpReply for AddOrderError {
                 tracing::error!(?err, "AddOrderError");
                 shared::api::internal_error_reply()
             }
+            err @ AddOrderError::AppDataMismatch { .. } => {
+                tracing::error!(
+                    ?err,
+                    "An order with full app data passed validation but then failed to be inserted \
+                     because we already stored different full app data for the same contract app \
+                     data. This should be impossible."
+                );
+                shared::api::internal_error_reply()
+            }
         }
     }
 }

--- a/database/sql/V052__add_app_data.sql
+++ b/database/sql/V052__add_app_data.sql
@@ -1,0 +1,6 @@
+ALTER TABLE orders DROP COLUMN full_app_data;
+
+CREATE TABLE app_data (
+    contract_app_data bytea PRIMARY KEY,
+    full_app_data bytea NOT NULL
+);


### PR DESCRIPTION
We want to store full app data in indexed by the contract app data that refers to it. This is needed to so that we can have an API route for retrieving full app data by contract app data. This encodes on the database level that a contract app data can only have one associated full app data. This was previously not encoded because we were storing the full app data inline in the orders table.

We do not need to worry about hash collisions because both schemes use cryptographic hashes. A hash collision would be problematic because it would prevent creating an order with valid app data because the contract app data would be the same as a different already existing full app data.

### Test Plan

CI tests that order insertion with and without full app data still works