### PR TITLE
Hook up new simulation logic

### DIFF
--- a/crates/autopilot/src/database/onchain_order_events.rs
+++ b/crates/autopilot/src/database/onchain_order_events.rs
@@ -47,6 +47,7 @@ use {
             is_order_outside_market_price,
             onchain_order_placement_error_from,
         },
+        price_estimation::Verification,
     },
     std::{
         collections::{HashMap, HashSet},
@@ -557,8 +558,16 @@ async fn get_quote(
         buy_amount: order_data.buy_amount,
         fee_amount: order_data.fee_amount,
         kind: order_data.kind,
-        // Original quote was made from user account, and not necessarily from owner.
-        from: order_placement.sender,
+        verification: Some(Verification {
+            // Original quote was made from user account, and not necessarily from owner.
+            from: order_placement.sender,
+            receiver: order_data.receiver.unwrap_or(order_placement.sender),
+            sell_token_source: SellTokenSource::Erc20,
+            buy_token_destination: BuyTokenDestination::Erc20,
+            // TODO do we have to get custom interactions here?
+            pre_interactions: vec![],
+            post_interactions: vec![],
+        }),
     };
     get_quote_and_check_fee(
         quoter,

--- a/crates/driver/src/domain/quote.rs
+++ b/crates/driver/src/domain/quote.rs
@@ -24,6 +24,7 @@ pub struct Quote {
     /// was a buy order.
     pub amount: eth::U256,
     pub interactions: Vec<eth::Interaction>,
+    pub solver: eth::Address,
 }
 
 impl Quote {
@@ -49,6 +50,7 @@ impl Quote {
         Ok(Self {
             amount,
             interactions: boundary::quote::encode_interactions(eth, &solution.interactions)?,
+            solver: solution.solver.address(),
         })
     }
 }

--- a/crates/driver/src/infra/api/routes/quote/dto/quote.rs
+++ b/crates/driver/src/infra/api/routes/quote/dto/quote.rs
@@ -20,6 +20,7 @@ impl Quote {
                     call_data: interaction.call_data.clone().into(),
                 })
                 .collect(),
+            solver: quote.solver.0,
         }
     }
 }
@@ -31,6 +32,7 @@ pub struct Quote {
     #[serde_as(as = "serialize::U256")]
     amount: eth::U256,
     interactions: Vec<Interaction>,
+    solver: eth::H160,
 }
 
 #[serde_as]

--- a/crates/model/src/quote.rs
+++ b/crates/model/src/quote.rs
@@ -16,9 +16,13 @@ use {
 #[derive(Clone, Copy, Debug, Default, Deserialize, Serialize, Eq, PartialEq)]
 #[serde(rename_all = "snake_case")]
 pub enum PriceQuality {
+    /// We pick the best quote of the fastest `n` price estimators.
     Fast,
     #[default]
+    /// We pick the best quote of all price estimators.
     Optimal,
+    /// Quotes may by discarde when they failed to be verified by simulation.
+    Verified,
 }
 
 #[derive(Eq, PartialEq, Clone, Copy, Debug, Default, Deserialize, Serialize, Hash)]

--- a/crates/orderbook/src/run.rs
+++ b/crates/orderbook/src/run.rs
@@ -463,7 +463,7 @@ pub async fn run(args: Arguments) {
         .with_partially_fillable_limit_orders(args.allow_placing_partially_fillable_limit_orders)
         .with_eth_smart_contract_payments(args.enable_eth_smart_contract_payments)
         .with_custom_interactions(args.enable_custom_interactions)
-        .with_verified_quotes(args.price_estimation.trade_simulator.is_some())
+        .with_verified_quotes(args.price_estimation.trade_simulator.is_some()),
     );
     let orderbook = Arc::new(Orderbook::new(
         domain_separator,

--- a/crates/orderbook/src/run.rs
+++ b/crates/orderbook/src/run.rs
@@ -462,7 +462,8 @@ pub async fn run(args: Arguments) {
         .with_fill_or_kill_limit_orders(args.allow_placing_fill_or_kill_limit_orders)
         .with_partially_fillable_limit_orders(args.allow_placing_partially_fillable_limit_orders)
         .with_eth_smart_contract_payments(args.enable_eth_smart_contract_payments)
-        .with_custom_interactions(args.enable_custom_interactions),
+        .with_custom_interactions(args.enable_custom_interactions)
+        .with_verified_quotes(args.price_estimation.trade_simulator.is_some())
     );
     let orderbook = Arc::new(Orderbook::new(
         domain_separator,

--- a/crates/shared/src/order_quoting.rs
+++ b/crates/shared/src/order_quoting.rs
@@ -10,6 +10,7 @@ use {
         db_order_conversions::order_kind_from,
         fee_subsidy::{FeeParameters, FeeSubsidizing, Subsidy, SubsidyParameters},
         order_validation::{OrderValidating, PartialValidationError, PreOrderData},
+        price_estimation::Verification,
     },
     anyhow::{Context, Result},
     chrono::{DateTime, Duration, TimeZone as _, Utc},
@@ -143,8 +144,11 @@ impl QuoteParameters {
         // Treat quotes with `from: 0` as if they didn't specify a `from` address
         // for price quotes. This is because the 0 address typically has special
         // semantics and causes issues with trade simulations.
-        let from = if self.from != H160::zero() {
-            Some(self.from)
+        let verification = if self.from != H160::zero() {
+            Some(Verification {
+                from: self.from,
+                ..Default::default()
+            })
         } else {
             None
         };
@@ -161,7 +165,7 @@ impl QuoteParameters {
         };
 
         price_estimation::Query {
-            from,
+            verification,
             sell_token: self.sell_token,
             buy_token: self.buy_token,
             in_amount,
@@ -749,7 +753,10 @@ mod tests {
             .expect_estimates()
             .withf(|q| {
                 q == [price_estimation::Query {
-                    from: Some(H160([3; 20])),
+                    verification: Some(Verification {
+                        from: H160([3; 20]),
+                        ..Default::default()
+                    }),
                     sell_token: H160([1; 20]),
                     buy_token: H160([2; 20]),
                     in_amount: 100.into(),
@@ -865,7 +872,10 @@ mod tests {
             .expect_estimates()
             .withf(|q| {
                 q == [price_estimation::Query {
-                    from: Some(H160([3; 20])),
+                    verification: Some(Verification {
+                        from: H160([3; 20]),
+                        ..Default::default()
+                    }),
                     sell_token: H160([1; 20]),
                     buy_token: H160([2; 20]),
                     in_amount: 100.into(),
@@ -984,7 +994,10 @@ mod tests {
             .expect_estimates()
             .withf(|q| {
                 q == [price_estimation::Query {
-                    from: Some(H160([3; 20])),
+                    verification: Some(Verification {
+                        from: H160([3; 20]),
+                        ..Default::default()
+                    }),
                     sell_token: H160([1; 20]),
                     buy_token: H160([2; 20]),
                     in_amount: 42.into(),

--- a/crates/shared/src/order_quoting.rs
+++ b/crates/shared/src/order_quoting.rs
@@ -358,6 +358,8 @@ pub struct QuoteSearchParameters {
     pub buy_amount: U256,
     pub fee_amount: U256,
     pub kind: OrderKind,
+    /// If this is `Some` the quotes are expected to pass simulations using the
+    /// contained parameters.
     pub verification: Option<Verification>,
 }
 

--- a/crates/shared/src/order_quoting.rs
+++ b/crates/shared/src/order_quoting.rs
@@ -662,7 +662,14 @@ impl From<&OrderQuoteRequest> for PreOrderData {
 
 impl From<&OrderQuoteRequest> for QuoteParameters {
     fn from(request: &OrderQuoteRequest) -> Self {
-        let verification = if request.from == Default::default() {
+        // The `from` address is currently mandatory for quote requests. However, when
+        // the user did not connect their wallet they still want to get prices
+        // so in that case the field currently gets populated with the 0
+        // address. Using this address in quote verifications will definitely
+        // cause reverts in the simulation so we make an exception here.
+        // TODO: Get rid of this when quotes and price estimates use different
+        // endpoints.
+        let verification = if request.from == H160::zero() {
             None
         } else {
             Some(Verification {

--- a/crates/shared/src/order_validation.rs
+++ b/crates/shared/src/order_validation.rs
@@ -510,18 +510,15 @@ impl OrderValidating for OrderValidator {
             .await
             .map_err(ValidationError::Partial)?;
 
-        let verification = match order.from {
-            Some(from) => Some(Verification {
-                from,
-                receiver: order.receiver.unwrap_or(from),
-                sell_token_source: order.sell_token_balance,
-                buy_token_destination: order.buy_token_balance,
-                // TODO get these from the request
-                pre_interactions: vec![],
-                post_interactions: vec![],
-            }),
-            None => None,
-        };
+        let verification = Some(Verification {
+            from: owner,
+            receiver: order.receiver.unwrap_or(owner),
+            sell_token_source: order.sell_token_balance,
+            buy_token_destination: order.buy_token_balance,
+            // TODO get these from the request
+            pre_interactions: vec![],
+            post_interactions: vec![],
+        });
 
         let quote_parameters = QuoteSearchParameters {
             sell_token: data.sell_token,

--- a/crates/shared/src/order_validation.rs
+++ b/crates/shared/src/order_validation.rs
@@ -221,6 +221,7 @@ pub struct OrderValidator {
     pub enable_eth_smart_contract_payments: bool,
     enable_custom_interactions: bool,
     app_data_validator: crate::app_data::Validator,
+    request_verified_quotes: bool,
 }
 
 #[derive(Debug, Eq, PartialEq, Default)]
@@ -307,6 +308,7 @@ impl OrderValidator {
             enable_eth_smart_contract_payments: false,
             enable_custom_interactions: false,
             app_data_validator,
+            request_verified_quotes: false,
         }
     }
 
@@ -327,6 +329,11 @@ impl OrderValidator {
 
     pub fn with_custom_interactions(mut self, enable: bool) -> Self {
         self.enable_custom_interactions = enable;
+        self
+    }
+
+    pub fn with_verified_quotes(mut self, enable: bool) -> Self {
+        self.request_verified_quotes = enable;
         self
     }
 
@@ -510,7 +517,7 @@ impl OrderValidating for OrderValidator {
             .await
             .map_err(ValidationError::Partial)?;
 
-        let verification = Some(Verification {
+        let verification = self.request_verified_quotes.then_some(Verification {
             from: owner,
             receiver: order.receiver.unwrap_or(owner),
             sell_token_source: order.sell_token_balance,

--- a/crates/shared/src/price_estimation.rs
+++ b/crates/shared/src/price_estimation.rs
@@ -1,5 +1,3 @@
-use crate::bad_token::TokenQuality;
-
 pub mod balancer_sor;
 pub mod baseline;
 pub mod competition;
@@ -19,15 +17,16 @@ pub mod zeroex;
 use {
     crate::{
         arguments::display_option,
-        bad_token::BadTokenDetecting,
+        bad_token::{BadTokenDetecting, TokenQuality},
         conversions::U256Ext,
         rate_limiter::{RateLimiter, RateLimitingStrategy},
+        trade_finding::Interaction,
     },
     anyhow::Result,
     clap::ValueEnum,
     ethcontract::{H160, U256},
     futures::{stream::BoxStream, StreamExt},
-    model::order::OrderKind,
+    model::order::{BuyTokenDestination, OrderKind, SellTokenSource},
     num::BigRational,
     reqwest::Url,
     serde::{Deserialize, Serialize},
@@ -299,14 +298,31 @@ impl Clone for PriceEstimationError {
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash, Default, Serialize)]
 pub struct Query {
-    /// Optional `from` address that would be executing the query.
-    pub from: Option<H160>,
     pub sell_token: H160,
     pub buy_token: H160,
     /// For OrderKind::Sell amount is in sell_token and for OrderKind::Buy in
     /// buy_token.
     pub in_amount: U256,
     pub kind: OrderKind,
+    pub verification: Option<Verification>,
+}
+
+/// Conditions under which a given price estimate needs to work in order to be
+/// viable.
+#[derive(Clone, Debug, PartialEq, Eq, Hash, Default, Serialize)]
+pub struct Verification {
+    /// This address needs to have the `sell_token`.
+    pub from: H160,
+    /// This address will receive the `buy_token`.
+    pub receiver: H160,
+    /// These interactions will be executed before the trade.
+    pub pre_interactions: Vec<Interaction>,
+    /// These interactions will be executed after the trade.
+    pub post_interactions: Vec<Interaction>,
+    /// `sell_token` will be taken via this approach.
+    pub sell_token_source: SellTokenSource,
+    /// `buy_token` will be sent via this approach.
+    pub buy_token_destination: BuyTokenDestination,
 }
 
 #[derive(Copy, Clone, Debug, Default, Eq, PartialEq, Deserialize)]

--- a/crates/shared/src/price_estimation.rs
+++ b/crates/shared/src/price_estimation.rs
@@ -304,6 +304,8 @@ pub struct Query {
     /// buy_token.
     pub in_amount: U256,
     pub kind: OrderKind,
+    /// If this is `Some` the quotes are expected to pass simulations using the
+    /// contained parameters.
     pub verification: Option<Verification>,
 }
 

--- a/crates/shared/src/price_estimation.rs
+++ b/crates/shared/src/price_estimation.rs
@@ -297,7 +297,7 @@ impl Clone for PriceEstimationError {
     }
 }
 
-#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, Default, Serialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash, Default, Serialize)]
 pub struct Query {
     /// Optional `from` address that would be executing the query.
     pub from: Option<H160>,

--- a/crates/shared/src/price_estimation/balancer_sor.rs
+++ b/crates/shared/src/price_estimation/balancer_sor.rs
@@ -61,7 +61,7 @@ impl BalancerSor {
             }
         };
         let future = super::rate_limited(self.rate_limiter.clone(), future);
-        let future = self.sharing.shared(*query, future.boxed());
+        let future = self.sharing.shared(query.clone(), future.boxed());
         let quote = future.await?;
         Ok(Estimate {
             out_amount: quote.return_amount,

--- a/crates/shared/src/price_estimation/balancer_sor.rs
+++ b/crates/shared/src/price_estimation/balancer_sor.rs
@@ -117,7 +117,7 @@ mod tests {
         let gas = Arc::new(FixedGasPriceEstimator(1e7));
         let estimator = BalancerSor::new(api, rate_limiter, gas);
         let query = Query {
-            from: None,
+            verification: None,
             sell_token: testlib::tokens::WETH,
             buy_token: testlib::tokens::DAI,
             in_amount: U256::from_f64_lossy(1e18),

--- a/crates/shared/src/price_estimation/baseline.rs
+++ b/crates/shared/src/price_estimation/baseline.rs
@@ -370,7 +370,7 @@ mod tests {
         assert!(single_estimate(
             &estimator,
             &Query {
-                from: None,
+                verification: None,
                 sell_token: token_a,
                 buy_token: token_b,
                 in_amount: 1.into(),
@@ -409,7 +409,7 @@ mod tests {
         assert!(single_estimate(
             &estimator,
             &Query {
-                from: None,
+                verification: None,
                 sell_token: token_a,
                 buy_token: token_b,
                 in_amount: 1.into(),
@@ -452,7 +452,7 @@ mod tests {
         assert!(single_estimate(
             &estimator,
             &Query {
-                from: None,
+                verification: None,
                 sell_token: token_a,
                 buy_token: token_b,
                 in_amount: 100.into(),
@@ -464,7 +464,7 @@ mod tests {
         assert!(single_estimate(
             &estimator,
             &Query {
-                from: None,
+                verification: None,
                 sell_token: token_a,
                 buy_token: token_b,
                 in_amount: 100.into(),
@@ -524,7 +524,7 @@ mod tests {
         );
 
         let query = Query {
-            from: None,
+            verification: None,
             sell_token: token_a,
             buy_token: token_b,
             in_amount: 100.into(),
@@ -538,7 +538,7 @@ mod tests {
         );
 
         let query = Query {
-            from: None,
+            verification: None,
             sell_token: token_b,
             buy_token: token_a,
             in_amount: 100.into(),
@@ -595,7 +595,7 @@ mod tests {
             let intermediate = single_estimate(
                 &estimator,
                 &Query {
-                    from: None,
+                    verification: None,
                     sell_token: token_a,
                     buy_token: token_b,
                     in_amount: 1.into(),
@@ -609,7 +609,7 @@ mod tests {
             let direct = single_estimate(
                 &estimator,
                 &Query {
-                    from: None,
+                    verification: None,
                     sell_token: token_b,
                     buy_token: token_a,
                     in_amount: 10.into(),
@@ -686,7 +686,7 @@ mod tests {
                 single_estimate(
                     &estimator,
                     &Query {
-                        from: None,
+                        verification: None,
                         sell_token: sell,
                         buy_token: buy,
                         in_amount: 10.into(),
@@ -713,7 +713,7 @@ mod tests {
                 single_estimate(
                     &estimator,
                     &Query {
-                        from: None,
+                        verification: None,
                         sell_token: sell,
                         buy_token: buy,
                         in_amount: 10.into(),
@@ -766,7 +766,7 @@ mod tests {
 
         let gas_price = 1000000000000000.0;
         let query = Query {
-            from: None,
+            verification: None,
             sell_token: token_a,
             buy_token: token_c,
             in_amount: 10u128.pow(19).into(),

--- a/crates/shared/src/price_estimation/competition.rs
+++ b/crates/shared/src/price_estimation/competition.rs
@@ -605,11 +605,12 @@ mod tests {
             ("first".to_owned(), Arc::new(first)),
             ("second".to_owned(), Arc::new(second)),
         ]);
-        let queries = &[Query {
+        let query = Query {
             sell_token: H160::from_low_u64_be(1),
             buy_token: H160::from_low_u64_be(2),
             ..Default::default()
-        }; 2];
+        };
+        let queries = &[query.clone(), query];
         let mut stream = estimator.estimates(queries);
 
         let (i, result) = stream.next().await.unwrap();

--- a/crates/shared/src/price_estimation/competition.rs
+++ b/crates/shared/src/price_estimation/competition.rs
@@ -403,35 +403,35 @@ mod tests {
     async fn works() {
         let queries = [
             Query {
-                from: None,
+                verification: None,
                 sell_token: H160::from_low_u64_le(0),
                 buy_token: H160::from_low_u64_le(1),
                 in_amount: 1.into(),
                 kind: OrderKind::Buy,
             },
             Query {
-                from: None,
+                verification: None,
                 sell_token: H160::from_low_u64_le(2),
                 buy_token: H160::from_low_u64_le(3),
                 in_amount: 1.into(),
                 kind: OrderKind::Sell,
             },
             Query {
-                from: None,
+                verification: None,
                 sell_token: H160::from_low_u64_le(2),
                 buy_token: H160::from_low_u64_le(3),
                 in_amount: 1.into(),
                 kind: OrderKind::Buy,
             },
             Query {
-                from: None,
+                verification: None,
                 sell_token: H160::from_low_u64_le(3),
                 buy_token: H160::from_low_u64_le(4),
                 in_amount: 1.into(),
                 kind: OrderKind::Buy,
             },
             Query {
-                from: None,
+                verification: None,
                 sell_token: H160::from_low_u64_le(5),
                 buy_token: H160::from_low_u64_le(6),
                 in_amount: 1.into(),
@@ -511,14 +511,14 @@ mod tests {
     async fn racing_estimator_returns_early() {
         let queries = [
             Query {
-                from: None,
+                verification: None,
                 sell_token: H160::from_low_u64_le(0),
                 buy_token: H160::from_low_u64_le(1),
                 in_amount: 1.into(),
                 kind: OrderKind::Buy,
             },
             Query {
-                from: None,
+                verification: None,
                 sell_token: H160::from_low_u64_le(2),
                 buy_token: H160::from_low_u64_le(3),
                 in_amount: 1.into(),

--- a/crates/shared/src/price_estimation/http.rs
+++ b/crates/shared/src/price_estimation/http.rs
@@ -495,7 +495,7 @@ mod tests {
 
         let sell_order = estimator
             .estimate(&Query {
-                from: None,
+                verification: None,
                 sell_token: H160::from_low_u64_be(0),
                 buy_token: H160::from_low_u64_be(1),
                 in_amount: 100.into(),
@@ -507,7 +507,7 @@ mod tests {
 
         let buy_order = estimator
             .estimate(&Query {
-                from: None,
+                verification: None,
                 sell_token: H160::from_low_u64_be(0),
                 buy_token: H160::from_low_u64_be(1),
                 in_amount: 100.into(),
@@ -547,7 +547,7 @@ mod tests {
         );
         let err = estimator
             .estimate(&Query {
-                from: None,
+                verification: None,
                 sell_token: H160::from_low_u64_be(0),
                 buy_token: H160::from_low_u64_be(1),
                 in_amount: 100.into(),
@@ -592,7 +592,7 @@ mod tests {
 
         let err = estimator
             .estimate(&Query {
-                from: None,
+                verification: None,
                 sell_token: H160::from_low_u64_be(0),
                 buy_token: H160::from_low_u64_be(1),
                 in_amount: 100.into(),
@@ -686,7 +686,7 @@ mod tests {
         );
 
         let query = Query {
-            from: None,
+            verification: None,
             sell_token: H160::from_low_u64_be(0),
             buy_token: H160::from_low_u64_be(1),
             in_amount: 100.into(),
@@ -817,7 +817,7 @@ mod tests {
 
         let result = estimator
             .estimate(&Query {
-                from: None,
+                verification: None,
                 sell_token: t1.1,
                 buy_token: t2.1,
                 in_amount: amount1,
@@ -838,7 +838,7 @@ mod tests {
 
         let result = estimator
             .estimate(&Query {
-                from: None,
+                verification: None,
                 sell_token: t1.1,
                 buy_token: t2.1,
                 in_amount: amount2,

--- a/crates/shared/src/price_estimation/http.rs
+++ b/crates/shared/src/price_estimation/http.rs
@@ -221,7 +221,7 @@ impl HttpPriceEstimator {
         let settlement_future = rate_limited(self.rate_limiter.clone(), settlement_future);
         let settlement = self
             .sharing
-            .shared(*query, settlement_future.boxed())
+            .shared(query.clone(), settlement_future.boxed())
             .await?;
 
         if !settlement.orders.contains_key(&0) {

--- a/crates/shared/src/price_estimation/instrumented.rs
+++ b/crates/shared/src/price_estimation/instrumented.rs
@@ -89,14 +89,14 @@ mod tests {
     async fn records_metrics_for_each_query() {
         let queries = [
             Query {
-                from: None,
+                verification: None,
                 sell_token: H160([1; 20]),
                 buy_token: H160([2; 20]),
                 in_amount: 3.into(),
                 kind: OrderKind::Sell,
             },
             Query {
-                from: None,
+                verification: None,
                 sell_token: H160([4; 20]),
                 buy_token: H160([5; 20]),
                 in_amount: 6.into(),

--- a/crates/shared/src/price_estimation/instrumented.rs
+++ b/crates/shared/src/price_estimation/instrumented.rs
@@ -105,10 +105,11 @@ mod tests {
         ];
 
         let mut estimator = MockPriceEstimating::new();
+        let expected_queries = queries.clone();
         estimator
             .expect_estimates()
             .times(1)
-            .withf(move |q| q == queries)
+            .withf(move |q| q == expected_queries)
             .returning(|_| {
                 futures::stream::iter([
                     Ok(Estimate::default()),

--- a/crates/shared/src/price_estimation/native.rs
+++ b/crates/shared/src/price_estimation/native.rs
@@ -53,11 +53,11 @@ impl NativePriceEstimator {
 
     fn query(&self, token: &H160) -> Query {
         Query {
-            from: None,
             sell_token: *token,
             buy_token: self.native_token,
             in_amount: self.price_estimation_amount,
             kind: OrderKind::Buy,
+            verification: None,
         }
     }
 }

--- a/crates/shared/src/price_estimation/oneinch.rs
+++ b/crates/shared/src/price_estimation/oneinch.rs
@@ -111,7 +111,7 @@ mod tests {
 
         let est = estimator
             .estimate(&Query {
-                from: None,
+                verification: None,
                 sell_token: testlib::tokens::WETH,
                 buy_token: testlib::tokens::GNO,
                 in_amount: 1_000_000_000_000_000_000u128.into(),
@@ -134,7 +134,7 @@ mod tests {
 
         let est = estimator
             .estimate(&Query {
-                from: None,
+                verification: None,
                 sell_token: testlib::tokens::WETH,
                 buy_token: testlib::tokens::GNO,
                 in_amount: 1_000_000_000_000_000_000u128.into(),
@@ -169,7 +169,7 @@ mod tests {
 
         let est = estimator
             .estimate(&Query {
-                from: None,
+                verification: None,
                 sell_token: testlib::tokens::WETH,
                 buy_token: testlib::tokens::GNO,
                 in_amount: 1_000_000_000_000_000_000u128.into(),
@@ -195,7 +195,7 @@ mod tests {
 
         let est = estimator
             .estimate(&Query {
-                from: None,
+                verification: None,
                 sell_token: testlib::tokens::WETH,
                 buy_token: testlib::tokens::GNO,
                 in_amount: 1_000_000_000_000_000_000u128.into(),
@@ -221,7 +221,7 @@ mod tests {
 
         let result = estimator
             .estimate(&Query {
-                from: None,
+                verification: None,
                 sell_token: weth,
                 buy_token: gno,
                 in_amount: 10u128.pow(18).into(),

--- a/crates/shared/src/price_estimation/paraswap.rs
+++ b/crates/shared/src/price_estimation/paraswap.rs
@@ -83,7 +83,7 @@ mod tests {
         let weth = testlib::tokens::WETH;
         let gno = testlib::tokens::GNO;
         let query = Query {
-            from: None,
+            verification: None,
             sell_token: weth,
             buy_token: gno,
             in_amount: 10u128.pow(18).into(),

--- a/crates/shared/src/price_estimation/sanitized.rs
+++ b/crates/shared/src/price_estimation/sanitized.rs
@@ -247,7 +247,7 @@ mod tests {
             // This is the common case (Tokens are supported, distinct and not ETH).
             // Will be estimated by the wrapped_estimator.
             Query {
-                from: None,
+                verification: None,
                 sell_token: H160::from_low_u64_le(1),
                 buy_token: H160::from_low_u64_le(2),
                 in_amount: 1.into(),
@@ -257,7 +257,7 @@ mod tests {
             // `wrapped_estimator`.
             // `sanitized_estimator` will add cost of unwrapping ETH to Estimate.
             Query {
-                from: None,
+                verification: None,
                 sell_token: H160::from_low_u64_le(1),
                 buy_token: BUY_ETH_ADDRESS,
                 in_amount: 1.into(),
@@ -265,7 +265,7 @@ mod tests {
             },
             // Will cause buffer overflow of gas price in `sanitized_estimator`.
             Query {
-                from: None,
+                verification: None,
                 sell_token: H160::from_low_u64_le(1),
                 buy_token: BUY_ETH_ADDRESS,
                 in_amount: U256::MAX,
@@ -275,7 +275,7 @@ mod tests {
             // `wrapped_estimator`.
             // `sanitized_estimator` will add cost of wrapping ETH to Estimate.
             Query {
-                from: None,
+                verification: None,
                 sell_token: BUY_ETH_ADDRESS,
                 buy_token: H160::from_low_u64_le(1),
                 in_amount: 1.into(),
@@ -284,7 +284,7 @@ mod tests {
             // Can be estimated by `sanitized_estimator` because `buy_token` and `sell_token` are
             // identical.
             Query {
-                from: None,
+                verification: None,
                 sell_token: H160::from_low_u64_le(1),
                 buy_token: H160::from_low_u64_le(1),
                 in_amount: 1.into(),
@@ -292,7 +292,7 @@ mod tests {
             },
             // Can be estimated by `sanitized_estimator` because both tokens are the native token.
             Query {
-                from: None,
+                verification: None,
                 sell_token: BUY_ETH_ADDRESS,
                 buy_token: BUY_ETH_ADDRESS,
                 in_amount: 1.into(),
@@ -300,7 +300,7 @@ mod tests {
             },
             // Can be estimated by `sanitized_estimator` because it is a native token unwrap.
             Query {
-                from: None,
+                verification: None,
                 sell_token: native_token,
                 buy_token: BUY_ETH_ADDRESS,
                 in_amount: 1.into(),
@@ -308,7 +308,7 @@ mod tests {
             },
             // Can be estimated by `sanitized_estimator` because it is a native token wrap.
             Query {
-                from: None,
+                verification: None,
                 sell_token: BUY_ETH_ADDRESS,
                 buy_token: native_token,
                 in_amount: 1.into(),
@@ -316,7 +316,7 @@ mod tests {
             },
             // Will throw `UnsupportedToken` error in `sanitized_estimator`.
             Query {
-                from: None,
+                verification: None,
                 sell_token: BAD_TOKEN,
                 buy_token: H160::from_low_u64_le(1),
                 in_amount: 1.into(),
@@ -324,7 +324,7 @@ mod tests {
             },
             // Will throw `UnsupportedToken` error in `sanitized_estimator`.
             Query {
-                from: None,
+                verification: None,
                 sell_token: H160::from_low_u64_le(1),
                 buy_token: BAD_TOKEN,
                 in_amount: 1.into(),
@@ -332,7 +332,7 @@ mod tests {
             },
             // Will throw `ZeroAmount` error in `sanitized_estimator`.
             Query {
-                from: None,
+                verification: None,
                 sell_token: H160::from_low_u64_le(1),
                 buy_token: H160::from_low_u64_le(2),
                 in_amount: 0.into(),
@@ -480,7 +480,7 @@ mod tests {
         let queries = [
             // difficult
             Query {
-                from: None,
+                verification: None,
                 sell_token: H160::from_low_u64_le(1),
                 buy_token: H160::from_low_u64_le(2),
                 in_amount: 1.into(),
@@ -488,7 +488,7 @@ mod tests {
             },
             //easy
             Query {
-                from: None,
+                verification: None,
                 sell_token: H160::from_low_u64_le(1),
                 buy_token: H160::from_low_u64_le(1),
                 in_amount: 1.into(),

--- a/crates/shared/src/price_estimation/sanitized.rs
+++ b/crates/shared/src/price_estimation/sanitized.rs
@@ -137,7 +137,7 @@ impl PriceEstimating for SanitizedPriceEstimator {
     ) -> futures::stream::BoxStream<'_, (usize, super::PriceEstimateResult)> {
         let stream = async_stream::stream! {
             // Handle easy estimates first.
-            let mut queries: Vec<(usize, Query)> = queries.iter().copied().enumerate().collect();
+            let mut queries: Vec<(usize, Query)> = queries.iter().cloned().enumerate().collect();
             for easy in self.estimate_easy_queries(&mut queries).await {
                 yield easy;
             }
@@ -182,7 +182,7 @@ impl PriceEstimating for SanitizedPriceEstimator {
                 .collect();
 
             let inner_queries: Vec<Query> =
-                difficult_queries.iter().map(|query| query.query).collect();
+                difficult_queries.iter().map(|query| query.query.clone()).collect();
             let mut stream = self.inner.estimates(&inner_queries);
 
             while let Some((i, mut estimate)) = stream.next().await {
@@ -342,21 +342,21 @@ mod tests {
 
         let expected_forwarded_queries = [
             // SanitizedPriceEstimator will simply forward the Query in the common case
-            queries[0],
+            queries[0].clone(),
             Query {
                 // SanitizedPriceEstimator replaces ETH buy token with native token
                 buy_token: native_token,
-                ..queries[1]
+                ..queries[1].clone()
             },
             Query {
                 // SanitizedPriceEstimator replaces ETH buy token with native token
                 buy_token: native_token,
-                ..queries[2]
+                ..queries[2].clone()
             },
             Query {
                 // SanitizedPriceEstimator replaces ETH sell token with native token
                 sell_token: native_token,
-                ..queries[3]
+                ..queries[3].clone()
             },
         ];
 
@@ -496,7 +496,7 @@ mod tests {
             },
         ];
 
-        let expected_forwarded_queries = [queries[0]];
+        let expected_forwarded_queries = [queries[0].clone()];
 
         let mut wrapped_estimator = Box::new(MockPriceEstimating::new());
         wrapped_estimator

--- a/crates/shared/src/price_estimation/trade_finder.rs
+++ b/crates/shared/src/price_estimation/trade_finder.rs
@@ -112,7 +112,9 @@ impl Inner {
             (_, verification) => {
                 if verification.is_some() {
                     // TODO turn this into a hard error when everything else is set up
-                    tracing::warn!("verified quote was requested by no verification scheme was configured");
+                    tracing::warn!(
+                        "verified quote was requested by no verification scheme was configured"
+                    );
                 }
                 let quote = self.finder.get_quote(&query).await?;
                 Ok(Estimate {

--- a/crates/shared/src/price_estimation/trade_finder.rs
+++ b/crates/shared/src/price_estimation/trade_finder.rs
@@ -369,7 +369,7 @@ impl PriceEstimating for TradeEstimator {
         }));
 
         futures::stream::iter(queries)
-            .then(|query| self.estimate(*query))
+            .then(|query| self.estimate(query.clone()))
             .enumerate()
             .boxed()
     }

--- a/crates/shared/src/price_estimation/trade_finder.rs
+++ b/crates/shared/src/price_estimation/trade_finder.rs
@@ -9,6 +9,7 @@ use {
         PriceEstimating,
         PriceEstimationError,
         Query,
+        Verification,
     },
     crate::{
         code_fetching::CodeFetching,
@@ -33,7 +34,7 @@ use {
     },
     maplit::hashmap,
     model::{
-        order::{BuyTokenDestination, OrderData, OrderKind, SellTokenSource, BUY_ETH_ADDRESS},
+        order::{OrderData, OrderKind, BUY_ETH_ADDRESS},
         signature::{Signature, SigningScheme},
     },
     std::sync::Arc,
@@ -84,61 +85,35 @@ impl TradeEstimator {
     }
 
     async fn estimate(&self, query: Query) -> Result<Estimate, PriceEstimationError> {
-        let owner = query.from.unwrap_or_default();
-        if query.from.is_none() {
-            tracing::warn!(
-                "trade verification requires a 'from' and 'receiver' address.assuming 0x000...000 \
-                 for now."
-            );
-        }
-
-        let quote_query = QuoteQuery {
-            sell_token: query.sell_token,
-            buy_token: query.buy_token,
-            kind: query.kind,
-            in_amount: query.in_amount,
-            // TODO drop this trait implementation when we actually split quotes from price
-            // estimates because trade verificaton requires data that doesn't exist for
-            // price estimation requests.
-            // Until then we try to keep this implementation as usable as posible.
-            from: owner,
-            receiver: owner,
-            pre_interactions: vec![],
-            post_interactions: vec![],
-            sell_token_source: Default::default(),
-            buy_token_destination: Default::default(),
-        };
         let estimate = rate_limited(
             self.rate_limiter.clone(),
-            self.inner.clone().estimate(quote_query),
+            self.inner.clone().estimate(query.clone()),
         );
         self.sharing.shared(query, estimate.boxed()).await
     }
 }
 
 impl Inner {
-    async fn estimate(
-        self: Arc<Self>,
-        query: QuoteQuery,
-    ) -> Result<Estimate, PriceEstimationError> {
-        let finder_query = Query {
-            from: Some(query.from),
-            sell_token: query.sell_token,
-            buy_token: query.buy_token,
-            kind: query.kind,
-            in_amount: query.in_amount,
-        };
-
-        match &self.verifier {
-            Some(verifier) => {
-                let trade = self.finder.get_trade(&finder_query).await?;
+    async fn estimate(self: Arc<Self>, query: Query) -> Result<Estimate, PriceEstimationError> {
+        match (&self.verifier, &query.verification) {
+            (Some(verifier), Some(verification)) => {
+                let trade = self.finder.get_trade(&query).await?;
+                let price_query = PriceQuery {
+                    sell_token: query.sell_token,
+                    buy_token: query.buy_token,
+                    in_amount: query.in_amount,
+                    kind: query.kind,
+                };
                 verifier
-                    .verify(query, trade)
+                    .verify(&price_query, verification, trade)
                     .await
                     .map_err(PriceEstimationError::Other)
             }
-            None => {
-                let quote = self.finder.get_quote(&finder_query).await?;
+            (None, Some(_)) => Err(PriceEstimationError::Other(anyhow::anyhow!(
+                "verified quote was requested by not verification scheme was configured"
+            ))),
+            _ => {
+                let quote = self.finder.get_quote(&query).await?;
                 Ok(Estimate {
                     out_amount: quote.out_amount,
                     gas: quote.gas_estimate,
@@ -152,7 +127,12 @@ fn encode_interactions(interactions: &[Interaction]) -> Vec<EncodedInteraction> 
     interactions.iter().map(|i| i.encode()).collect()
 }
 
-fn encode_settlement(query: &QuoteQuery, trade: &Trade, native_token: H160) -> EncodedSettlement {
+fn encode_settlement(
+    query: &PriceQuery,
+    verification: &Verification,
+    trade: &Trade,
+    native_token: H160,
+) -> EncodedSettlement {
     let mut trade_interactions = encode_interactions(&trade.interactions);
     if query.buy_token == BUY_ETH_ADDRESS {
         // Because the `driver` manages `WETH` unwraps under the hood the `TradeFinder`
@@ -188,21 +168,21 @@ fn encode_settlement(query: &QuoteQuery, trade: &Trade, native_token: H160) -> E
         sell_amount,
         buy_token: query.buy_token,
         buy_amount,
-        receiver: Some(query.receiver),
+        receiver: Some(verification.receiver),
         valid_to: u32::MAX,
         app_data: Default::default(),
         fee_amount: 0.into(),
         kind: query.kind,
         partially_fillable: false,
-        sell_token_balance: query.sell_token_source,
-        buy_token_balance: query.buy_token_destination,
+        sell_token_balance: verification.sell_token_source,
+        buy_token_balance: verification.buy_token_destination,
     };
 
     let fake_signature = Signature::default_with(SigningScheme::Eip1271);
     let encoded_trade = encode_trade(
         &fake_order,
         &fake_signature,
-        query.from,
+        verification.from,
         0,
         1,
         &query.in_amount,
@@ -213,9 +193,9 @@ fn encode_settlement(query: &QuoteQuery, trade: &Trade, native_token: H160) -> E
         clearing_prices,
         trades: vec![encoded_trade],
         interactions: [
-            encode_interactions(&query.pre_interactions),
+            encode_interactions(&verification.pre_interactions),
             trade_interactions,
-            encode_interactions(&query.post_interactions),
+            encode_interactions(&verification.post_interactions),
         ],
     }
 }
@@ -225,13 +205,14 @@ fn encode_settlement(query: &QuoteQuery, trade: &Trade, native_token: H160) -> E
 /// These balances will get used to compute an accurate price for the trade.
 fn add_balance_queries(
     mut settlement: EncodedSettlement,
-    query: &QuoteQuery,
+    query: &PriceQuery,
+    verification: &Verification,
     settlement_contract: H160,
     solver: &Solver,
 ) -> EncodedSettlement {
     let (token, owner) = match query.kind {
         // track how much `buy_token` the `receiver` actually got
-        OrderKind::Sell => (query.buy_token, query.receiver),
+        OrderKind::Sell => (query.buy_token, verification.receiver),
         // track how much `sell_token` the settlement contract actually spent
         OrderKind::Buy => (query.sell_token, settlement_contract),
     };
@@ -263,11 +244,17 @@ impl TradeVerifier {
         }
     }
 
-    async fn verify(&self, query: QuoteQuery, trade: Trade) -> Result<Estimate> {
+    async fn verify(
+        &self,
+        query: &PriceQuery,
+        verification: &Verification,
+        trade: Trade,
+    ) -> Result<Estimate> {
         let solver = dummy_contract!(Solver, trade.solver);
 
-        let settlement = encode_settlement(&query, &trade, self.native_token);
-        let settlement = add_balance_queries(settlement, &query, self.settlement, &solver);
+        let settlement = encode_settlement(query, verification, &trade, self.native_token);
+        let settlement =
+            add_balance_queries(settlement, query, verification, self.settlement, &solver);
 
         let settlement_contract = dummy_contract!(GPv2Settlement, self.settlement);
         let settlement = settlement_contract
@@ -288,11 +275,11 @@ impl TradeVerifier {
         let simulation = solver
             .methods()
             .swap(
-                query.from,
+                verification.from,
                 query.sell_token,
                 sell_amount,
                 self.native_token,
-                query.receiver,
+                verification.receiver,
                 Bytes(settlement.data.unwrap().0),
             )
             .tx;
@@ -308,7 +295,7 @@ impl TradeVerifier {
 
         // Set up helper contracts impersonating trader and solver.
         let mut overrides = hashmap! {
-            query.from => StateOverride {
+            verification.from => StateOverride {
                 code: Some(deployed_bytecode!(Trader)),
                 ..Default::default()
             },
@@ -318,7 +305,7 @@ impl TradeVerifier {
             },
         };
 
-        let trader_impl = self.code_fetcher.code(query.from).await?;
+        let trader_impl = self.code_fetcher.code(verification.from).await?;
         if !trader_impl.0.is_empty() {
             // Store `owner` implementation so `Trader` helper contract can proxy to it.
             overrides.insert(
@@ -338,6 +325,7 @@ impl TradeVerifier {
         };
         tracing::debug!(
             ?query,
+            ?verification,
             promised_gas = trade.gas_estimate,
             promised_out_amount =? trade.out_amount,
             ?verified,
@@ -386,19 +374,13 @@ impl From<TradeError> for PriceEstimationError {
     }
 }
 
-#[derive(Clone, Debug, Hash, Eq, PartialEq)]
-pub struct QuoteQuery {
-    pub from: H160,
-    pub receiver: H160,
+#[derive(Debug)]
+pub struct PriceQuery {
     pub sell_token: H160,
     // This should be `BUY_ETH_ADDRESS` if you actually want to trade `ETH`
     pub buy_token: H160,
     pub kind: OrderKind,
     pub in_amount: U256,
-    pub pre_interactions: Vec<Interaction>,
-    pub post_interactions: Vec<Interaction>,
-    pub sell_token_source: SellTokenSource,
-    pub buy_token_destination: BuyTokenDestination,
 }
 
 /// Output of `Trader::settle` smart contract call.

--- a/crates/shared/src/price_estimation/trade_finder.rs
+++ b/crates/shared/src/price_estimation/trade_finder.rs
@@ -264,14 +264,7 @@ impl TradeVerifier {
     }
 
     async fn verify(&self, query: QuoteQuery, trade: Trade) -> Result<Estimate> {
-        // TODO: add solver address to [`Trade`]; for now we simply use Quasilab's
-        // address
-        let solver = dummy_contract!(
-            Solver,
-            H160(hex_literal::hex!(
-                "1e8D9a45175B2a4122F7827ce1eA3B08327b2ba0"
-            ))
-        );
+        let solver = dummy_contract!(Solver, trade.solver);
 
         let settlement = encode_settlement(&query, &trade, self.native_token);
         let settlement = add_balance_queries(settlement, &query, self.settlement, &solver);

--- a/crates/shared/src/price_estimation/trade_finder.rs
+++ b/crates/shared/src/price_estimation/trade_finder.rs
@@ -109,10 +109,11 @@ impl Inner {
                     .await
                     .map_err(PriceEstimationError::Other)
             }
-            (None, Some(_)) => Err(PriceEstimationError::Other(anyhow::anyhow!(
-                "verified quote was requested by not verification scheme was configured"
-            ))),
-            _ => {
+            (_, verification) => {
+                if verification.is_some() {
+                    // TODO turn this into a hard error when everything else is set up
+                    tracing::warn!("verified quote was requested by no verification scheme was configured");
+                }
                 let quote = self.finder.get_quote(&query).await?;
                 Ok(Estimate {
                     out_amount: quote.out_amount,

--- a/crates/shared/src/price_estimation/zeroex.rs
+++ b/crates/shared/src/price_estimation/zeroex.rs
@@ -102,7 +102,7 @@ mod tests {
         let est = single_estimate(
             &estimator,
             &Query {
-                from: None,
+                verification: None,
                 sell_token: weth,
                 buy_token: gno,
                 in_amount: 100000000000000000u64.into(),
@@ -151,7 +151,7 @@ mod tests {
         let est = single_estimate(
             &estimator,
             &Query {
-                from: None,
+                verification: None,
                 sell_token: weth,
                 buy_token: gno,
                 in_amount: 100000000000000000u64.into(),
@@ -194,21 +194,21 @@ mod tests {
             &estimator,
             &[
                 Query {
-                    from: None,
+                    verification: None,
                     sell_token: weth,
                     buy_token: gno,
                     in_amount: 100000000000000000u64.into(),
                     kind: OrderKind::Sell,
                 },
                 Query {
-                    from: None,
+                    verification: None,
                     sell_token: weth,
                     buy_token: gno,
                     in_amount: 100000000000000000u64.into(),
                     kind: OrderKind::Buy,
                 },
                 Query {
-                    from: None,
+                    verification: None,
                     sell_token: weth,
                     buy_token: gno,
                     in_amount: 100000000000000000u64.into(),
@@ -245,7 +245,7 @@ mod tests {
         let result = single_estimate(
             &estimator,
             &Query {
-                from: None,
+                verification: None,
                 sell_token: weth,
                 buy_token: gno,
                 in_amount: 10u128.pow(18).into(),

--- a/crates/shared/src/trade_finding.rs
+++ b/crates/shared/src/trade_finding.rs
@@ -38,7 +38,7 @@ pub struct Trade {
     pub out_amount: U256,
     pub gas_estimate: u64,
     pub interactions: Vec<Interaction>,
-    // TODO add solver address for simulations
+    pub solver: H160,
 }
 
 impl Trade {
@@ -68,6 +68,9 @@ impl Trade {
             out_amount,
             gas_estimate,
             interactions,
+            // TODO replace this if we want to have verified quotes of non-colocated price
+            // estimators
+            solver: Default::default(),
         }
     }
 
@@ -210,6 +213,7 @@ mod tests {
                     data: vec![5, 6, 7, 8],
                 },
             ],
+            solver: Default::default(),
         };
 
         assert_eq!(

--- a/crates/shared/src/trade_finding.rs
+++ b/crates/shared/src/trade_finding.rs
@@ -11,6 +11,7 @@ use {
     anyhow::Result,
     contracts::ERC20,
     ethcontract::{contract::MethodBuilder, tokens::Tokenize, web3::Transport, Bytes, H160, U256},
+    serde::Serialize,
     thiserror::Error,
 };
 
@@ -81,7 +82,7 @@ impl Trade {
 }
 
 /// Data for a raw GPv2 interaction.
-#[derive(Clone, Debug, Default, Eq, PartialEq, Hash)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash, Default, Serialize)]
 pub struct Interaction {
     pub target: H160,
     pub value: U256,

--- a/crates/shared/src/trade_finding/external.rs
+++ b/crates/shared/src/trade_finding/external.rs
@@ -102,6 +102,7 @@ impl From<dto::Quote> for Trade {
                     data: interaction.call_data,
                 })
                 .collect(),
+            solver: quote.solver,
         }
     }
 }
@@ -150,6 +151,7 @@ mod dto {
         #[serde_as(as = "DecimalU256")]
         pub amount: U256,
         pub interactions: Vec<Interaction>,
+        pub solver: H160,
     }
 
     #[serde_as]

--- a/crates/shared/src/trade_finding/external.rs
+++ b/crates/shared/src/trade_finding/external.rs
@@ -67,7 +67,7 @@ impl ExternalTradeFinder {
         };
 
         self.sharing
-            .shared(*query, future.boxed())
+            .shared(query.clone(), future.boxed())
             .await
             .map_err(TradeError::from)
     }

--- a/crates/shared/src/trade_finding/oneinch.rs
+++ b/crates/shared/src/trade_finding/oneinch.rs
@@ -71,7 +71,7 @@ impl OneInchTradeFinder {
         allowed_protocols: Option<Vec<String>>,
     ) -> BoxShared<Result<Quote, TradeError>> {
         let query = InternalQuery {
-            data: *query,
+            data: query.clone(),
             allowed_protocols,
         };
 

--- a/crates/shared/src/trade_finding/oneinch.rs
+++ b/crates/shared/src/trade_finding/oneinch.rs
@@ -189,7 +189,11 @@ impl Inner {
                 query.sell_token,
                 query.buy_token,
                 query.in_amount,
-                query.from.unwrap_or_default(),
+                query
+                    .verification
+                    .as_ref()
+                    .map(|v| v.from)
+                    .unwrap_or_default(),
                 allowed_protocols,
                 Slippage::ONE_PERCENT,
                 self.referrer_address,
@@ -275,7 +279,7 @@ mod tests {
 
         let quote = estimator
             .get_quote(&Query {
-                from: None,
+                verification: None,
                 sell_token: testlib::tokens::WETH,
                 buy_token: testlib::tokens::GNO,
                 in_amount: 1_000_000_000_000_000_000u128.into(),
@@ -361,7 +365,7 @@ mod tests {
 
         let trade = estimator
             .get_trade(&Query {
-                from: None,
+                verification: None,
                 sell_token: testlib::tokens::WETH,
                 buy_token: testlib::tokens::GNO,
                 in_amount: 1_000_000_000_000_000_000u128.into(),
@@ -414,7 +418,7 @@ mod tests {
 
         let est = estimator
             .get_trade(&Query {
-                from: None,
+                verification: None,
                 sell_token: testlib::tokens::WETH,
                 buy_token: testlib::tokens::GNO,
                 in_amount: 1_000_000_000_000_000_000u128.into(),
@@ -445,7 +449,7 @@ mod tests {
 
         let est = estimator
             .get_trade(&Query {
-                from: None,
+                verification: None,
                 sell_token: testlib::tokens::WETH,
                 buy_token: testlib::tokens::GNO,
                 in_amount: 1_000_000_000_000_000_000u128.into(),
@@ -473,7 +477,7 @@ mod tests {
 
         let est = estimator
             .get_trade(&Query {
-                from: None,
+                verification: None,
                 sell_token: testlib::tokens::WETH,
                 buy_token: testlib::tokens::GNO,
                 in_amount: 1_000_000_000_000_000_000u128.into(),
@@ -527,7 +531,7 @@ mod tests {
 
         let result = estimator
             .get_trade(&Query {
-                from: None,
+                verification: None,
                 sell_token: weth,
                 buy_token: gno,
                 in_amount: 10u128.pow(18).into(),

--- a/crates/shared/src/trade_finding/paraswap.rs
+++ b/crates/shared/src/trade_finding/paraswap.rs
@@ -130,7 +130,11 @@ impl Inner {
             src_decimals: decimals(&quote.tokens, &query.sell_token)?,
             dest_decimals: decimals(&quote.tokens, &query.buy_token)?,
             price_route: quote.price.price_route_raw.take(),
-            user_address: query.from.unwrap_or(Self::DEFAULT_USER),
+            user_address: query
+                .verification
+                .as_ref()
+                .map(|v| v.from)
+                .unwrap_or(Self::DEFAULT_USER),
         };
 
         let tx = self.paraswap.transaction(tx_query).await?;
@@ -236,7 +240,7 @@ mod tests {
 
         let trade = finder
             .get_trade(&Query {
-                from: None,
+                verification: None,
                 sell_token: testlib::tokens::WETH,
                 buy_token: testlib::tokens::COW,
                 in_amount: 10u128.pow(18).into(),

--- a/crates/shared/src/trade_finding/paraswap.rs
+++ b/crates/shared/src/trade_finding/paraswap.rs
@@ -58,9 +58,9 @@ impl ParaswapTradeFinder {
     }
 
     fn shared_quote(&self, query: &Query) -> BoxShared<Result<InternalQuote, TradeError>> {
-        self.sharing.shared_or_else(*query, |_| {
+        self.sharing.shared_or_else(query.clone(), |_| {
             let inner = self.inner.clone();
-            let query = *query;
+            let query = query.clone();
             async move { inner.quote(&query).await }.boxed()
         })
     }

--- a/crates/shared/src/trade_finding/zeroex.rs
+++ b/crates/shared/src/trade_finding/zeroex.rs
@@ -37,9 +37,9 @@ impl ZeroExTradeFinder {
     }
 
     fn shared_quote(&self, query: &Query) -> BoxShared<Result<Trade, TradeError>> {
-        self.sharing.shared_or_else(*query, |_| {
+        self.sharing.shared_or_else(query.clone(), |_| {
             let inner = self.inner.clone();
-            let query = *query;
+            let query = query.clone();
             async move { inner.quote(&query).await }.boxed()
         })
     }

--- a/crates/shared/src/trade_finding/zeroex.rs
+++ b/crates/shared/src/trade_finding/zeroex.rs
@@ -167,7 +167,7 @@ mod tests {
 
         let trade = trader
             .get_trade(&Query {
-                from: None,
+                verification: None,
                 sell_token: weth,
                 buy_token: gno,
                 in_amount: 100000000000000000u64.into(),
@@ -245,7 +245,7 @@ mod tests {
 
         let trade = trader
             .get_trade(&Query {
-                from: None,
+                verification: None,
                 sell_token: weth,
                 buy_token: gno,
                 in_amount: 100000000000000000u64.into(),
@@ -290,7 +290,7 @@ mod tests {
 
         let trade = trader
             .get_trade(&Query {
-                from: None,
+                verification: None,
                 sell_token: weth,
                 buy_token: gno,
                 in_amount: 10u128.pow(18).into(),


### PR DESCRIPTION
Closes #1512 

I now have a rough game plan for verified quotes.
Instead of introducing a new price quality `verified` (#1512) we implicitly verify all quotes where `from` is set. All the other pieces of data (besides custom interactions) already exist in the request so we can easily bundle the data that is only needed for verification into a struct which is optional. Only if the struct is `Some` we do verifications.
Also with this new idea I would rather make every individual price estimator decide whether it supports trade verification (and return an error if it doesn't) than creating a new price estimator hierarchy that doesn't contain the ones that don't support quote verification.

Things left over which should be doable in separate PRs:
1. Make remaining estimators aware of new verification logic (`Balancer`, `Naive`, `Baseline`, `Quasimodo`, `Yearn`).
2. Make public solver address configurable with price estimators
3. Handle quotes for selling/buying native `ETH` (currently results in quotes for `WETH` which might cause custom interactions to fail)
4. Turn verification warnings into hard errors when feature is done


### Test Plan
Manual tests
