### PR TITLE
Add route for full app data fetching

### DIFF
--- a/crates/e2e/tests/e2e/setup/services.rs
+++ b/crates/e2e/tests/e2e/setup/services.rs
@@ -6,6 +6,7 @@ use {
     clap::Parser,
     ethcontract::H256,
     model::{
+        app_id::AppDataHash,
         auction::AuctionWithId,
         order::{Order, OrderCreation, OrderUid},
         quote::{OrderQuoteRequest, OrderQuoteResponse},
@@ -261,6 +262,26 @@ impl<'a> Services<'a> {
 
         match status {
             StatusCode::OK => Ok(serde_json::from_str(&body).unwrap()),
+            code => Err((code, body)),
+        }
+    }
+
+    pub async fn get_app_data(
+        &self,
+        app_data: AppDataHash,
+    ) -> Result<String, (StatusCode, String)> {
+        let response = self
+            .http
+            .get(format!("{API_HOST}/api/v1/app_data/by_hash/{app_data:?}"))
+            .send()
+            .await
+            .unwrap();
+
+        let status = response.status();
+        let body = response.text().await.unwrap();
+
+        match status {
+            StatusCode::OK => Ok(body),
             code => Err((code, body)),
         }
     }

--- a/crates/e2e/tests/e2e/setup/services.rs
+++ b/crates/e2e/tests/e2e/setup/services.rs
@@ -272,7 +272,7 @@ impl<'a> Services<'a> {
     ) -> Result<String, (StatusCode, String)> {
         let response = self
             .http
-            .get(format!("{API_HOST}/api/v1/app_data/by_hash/{app_data:?}"))
+            .get(format!("{API_HOST}/api/v1/app_data/{app_data:?}"))
             .send()
             .await
             .unwrap();

--- a/crates/orderbook/openapi.yml
+++ b/crates/orderbook/openapi.yml
@@ -375,7 +375,7 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/VersionResponse"
-  /api/v1/app_data/by_hash/{app_data_hash}:
+  /api/v1/app_data/{app_data_hash}:
     get:
       summary: Retrieve full app data from contract app data hash.
       parameters:

--- a/crates/orderbook/openapi.yml
+++ b/crates/orderbook/openapi.yml
@@ -375,6 +375,22 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/VersionResponse"
+  /api/v1/app_data/by_hash/{app_data_hash}:
+    get:
+      summary: Retrieve full app data from contract app data hash.
+      parameters:
+        - in: path
+          name: app_data_hash
+          schema:
+            $ref: "#/components/schemas/AppDataHash"
+          required: true
+      responses:
+        200:
+          description: Full app data
+          content:
+            application/json: {}
+        404:
+          description: App data hash doesn't exist.
 components:
   schemas:
     TransactionHash:

--- a/crates/orderbook/openapi.yml
+++ b/crates/orderbook/openapi.yml
@@ -390,7 +390,7 @@ paths:
           content:
             application/json: {}
         404:
-          description: App data hash doesn't exist.
+          description: No full app data stored for this hash.
 components:
   schemas:
     TransactionHash:

--- a/crates/orderbook/src/api/get_app_data.rs
+++ b/crates/orderbook/src/api/get_app_data.rs
@@ -1,0 +1,43 @@
+use {
+    crate::database::Postgres,
+    anyhow::Result,
+    model::app_id::AppDataHash,
+    reqwest::StatusCode,
+    std::convert::Infallible,
+    warp::{
+        reply::{with_header, with_status},
+        Filter,
+        Rejection,
+        Reply,
+    },
+};
+
+pub fn request() -> impl Filter<Extract = (AppDataHash,), Error = Rejection> + Clone {
+    warp::path!("v1" / "app_data" / "by_hash" / AppDataHash).and(warp::get())
+}
+
+pub fn get(
+    database: Postgres,
+) -> impl Filter<Extract = (Box<dyn Reply>,), Error = Rejection> + Clone {
+    request().and_then(move |contract_app_data: AppDataHash| {
+        let database = database.clone();
+        async move {
+            let result = database.get_full_app_data(&contract_app_data).await;
+            Result::<_, Infallible>::Ok(match result {
+                Ok(Some(response)) => {
+                    let response = with_status(response, StatusCode::OK);
+                    let response = with_header(response, "Content-Type", "application/json");
+                    Box::new(response) as Box<dyn Reply>
+                }
+                Ok(None) => Box::new(with_status(
+                    "full app data not found",
+                    StatusCode::NOT_FOUND,
+                )),
+                Err(err) => {
+                    tracing::error!(?err, "get_app_data_by_hash");
+                    Box::new(shared::api::internal_error_reply())
+                }
+            })
+        }
+    })
+}

--- a/crates/orderbook/src/api/get_app_data.rs
+++ b/crates/orderbook/src/api/get_app_data.rs
@@ -13,7 +13,7 @@ use {
 };
 
 pub fn request() -> impl Filter<Extract = (AppDataHash,), Error = Rejection> + Clone {
-    warp::path!("v1" / "app_data" / "by_hash" / AppDataHash).and(warp::get())
+    warp::path!("v1" / "app_data" / AppDataHash).and(warp::get())
 }
 
 pub fn get(

--- a/crates/orderbook/src/api/get_trades.rs
+++ b/crates/orderbook/src/api/get_trades.rs
@@ -1,11 +1,14 @@
 use {
-    crate::database::trades::{TradeFilter, TradeRetrieving},
+    crate::database::{
+        trades::{TradeFilter, TradeRetrieving},
+        Postgres,
+    },
     anyhow::{Context, Result},
     model::order::OrderUid,
     primitive_types::H160,
     serde::Deserialize,
     shared::api::{error, ApiReply},
-    std::{convert::Infallible, sync::Arc},
+    std::convert::Infallible,
     warp::{hyper::StatusCode, reply::with_status, Filter, Rejection},
 };
 
@@ -47,9 +50,7 @@ fn get_trades_request(
         .map(|query: Query| query.validate())
 }
 
-pub fn get_trades(
-    db: Arc<dyn TradeRetrieving>,
-) -> impl Filter<Extract = (ApiReply,), Error = Rejection> + Clone {
+pub fn get_trades(db: Postgres) -> impl Filter<Extract = (ApiReply,), Error = Rejection> + Clone {
     get_trades_request().and_then(move |request_result| {
         let database = db.clone();
         async move {

--- a/crates/orderbook/src/database.rs
+++ b/crates/orderbook/src/database.rs
@@ -1,3 +1,4 @@
+mod app_data;
 pub mod auctions;
 pub mod orders;
 pub mod quotes;

--- a/crates/orderbook/src/database/app_data.rs
+++ b/crates/orderbook/src/database/app_data.rs
@@ -1,0 +1,26 @@
+use {
+    anyhow::{Context, Result},
+    database::byte_array::ByteArray,
+    model::app_id::AppDataHash,
+};
+
+impl super::Postgres {
+    pub async fn get_full_app_data(
+        &self,
+        contract_app_data: &AppDataHash,
+    ) -> Result<Option<String>> {
+        let _timer = super::Metrics::get()
+            .database_queries
+            .with_label_values(&["get_full_app_data"])
+            .start_timer();
+
+        let mut ex = self.pool.acquire().await?;
+        let full_app_data =
+            match database::app_data::fetch(&mut ex, &ByteArray(contract_app_data.0)).await? {
+                Some(inner) => inner,
+                None => return Ok(None),
+            };
+        let full_app_data = String::from_utf8(full_app_data).context("app data is not utf-8")?;
+        Ok(Some(full_app_data))
+    }
+}

--- a/crates/orderbook/src/lib.rs
+++ b/crates/orderbook/src/lib.rs
@@ -6,13 +6,12 @@ pub mod run;
 pub mod solver_competition;
 
 use {
-    crate::{database::trades::TradeRetrieving, orderbook::Orderbook},
+    crate::{database::Postgres, orderbook::Orderbook},
     anyhow::{anyhow, Context as _, Result},
     contracts::GPv2Settlement,
     futures::Future,
     model::DomainSeparator,
     shared::{order_quoting::QuoteHandler, price_estimation::native::NativePriceEstimating},
-    solver_competition::SolverCompetitionStoring,
     std::{net::SocketAddr, sync::Arc},
     tokio::{task, task::JoinHandle},
     warp::Filter,
@@ -20,12 +19,11 @@ use {
 
 #[allow(clippy::too_many_arguments)]
 pub fn serve_api(
-    database: Arc<dyn TradeRetrieving>,
+    database: Postgres,
     orderbook: Arc<Orderbook>,
     quotes: Arc<QuoteHandler>,
     address: SocketAddr,
     shutdown_receiver: impl Future<Output = ()> + Send + 'static,
-    solver_competition: Arc<dyn SolverCompetitionStoring>,
     solver_competition_auth: Option<String>,
     native_price_estimator: Arc<dyn NativePriceEstimating>,
 ) -> JoinHandle<()> {
@@ -33,7 +31,6 @@ pub fn serve_api(
         database,
         orderbook,
         quotes,
-        solver_competition,
         solver_competition_auth,
         native_price_estimator,
     )


### PR DESCRIPTION
Part of the new app data design. Allows fetching full app data by contract app data hash. You could already get an order's full app data through its order uid but now you can also do so without knowing the order.

### Test Plan

CI
