### PR TITLE
Fetch full app data from IPFS when not specified

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -541,6 +541,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "base-x"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cbbc9d0964165b47557570cce6c952866c2678457aca742aafc9fb771d30270"
+
+[[package]]
 name = "base64"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1055,6 +1061,32 @@ checksum = "a4aab4dbc9f7611d8b55048a3a16d2d010c2c8334e46304b40ac1cc14bf3b48e"
 dependencies = [
  "darling_core 0.14.4",
  "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "data-encoding"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2e66c9d817f1720209181c316d28635c050fa304f9c79e47a520882661b7308"
+
+[[package]]
+name = "data-encoding-macro"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c904b33cc60130e1aeea4956ab803d08a3f4a0ca82d64ed757afac3891f2bb99"
+dependencies = [
+ "data-encoding",
+ "data-encoding-macro-internal",
+]
+
+[[package]]
+name = "data-encoding-macro-internal"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fdf3fce3ce863539ec1d7fd1b6dcc3c645663376b43ed376bbf887733e4f772"
+dependencies = [
+ "data-encoding",
  "syn 1.0.109",
 ]
 
@@ -2383,6 +2415,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "multibase"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b3539ec3c1f04ac9748a260728e855f261b4977f5c3406612c884564f329404"
+dependencies = [
+ "base-x",
+ "data-encoding",
+ "data-encoding-macro",
+]
+
+[[package]]
 name = "native-tls"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2592,6 +2635,7 @@ name = "orderbook"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "app-data-hash",
  "async-trait",
  "bigdecimal",
  "cached",
@@ -2608,6 +2652,7 @@ dependencies = [
  "maplit",
  "mockall",
  "model",
+ "multibase",
  "num",
  "number-conversions",
  "primitive-types 0.10.1",

--- a/crates/orderbook/Cargo.toml
+++ b/crates/orderbook/Cargo.toml
@@ -17,6 +17,7 @@ path = "src/main.rs"
 
 [dependencies]
 anyhow = { workspace = true }
+app-data-hash = { path = "../app-data-hash" }
 async-trait = { workspace = true }
 bigdecimal = { workspace = true }
 cached = { workspace = true }
@@ -32,6 +33,7 @@ hex = { workspace = true }
 hex-literal = { workspace = true }
 maplit = { workspace = true }
 model = { path = "../model" }
+multibase = "0.9"
 num = { workspace = true }
 number-conversions = { path = "../number-conversions" }
 primitive-types = { workspace = true }

--- a/crates/orderbook/src/arguments.rs
+++ b/crates/orderbook/src/arguments.rs
@@ -2,7 +2,7 @@ use {
     primitive_types::H160,
     reqwest::Url,
     shared::{
-        arguments::display_option,
+        arguments::{display_option, display_secret_option},
         bad_token::token_owner_finder,
         http_client,
         price_estimation::{self, PriceEstimatorType},
@@ -163,6 +163,15 @@ pub struct Arguments {
     /// Enable support for orders with custom pre- and post-interactions.
     #[clap(long, env, action = clap::ArgAction::Set, default_value = "false")]
     pub enable_custom_interactions: bool,
+
+    /// If set, the orderbook will use this IPFS gateway to fetch full app data
+    /// for orders that only specify the contract app data hash.
+    #[clap(long, env)]
+    pub ipfs_gateway: Option<Url>,
+
+    /// Authentication key for Pinata IPFS gateway.
+    #[clap(long, env)]
+    pub ipfs_pinata_auth: Option<String>,
 }
 
 impl std::fmt::Display for Arguments {
@@ -242,6 +251,8 @@ impl std::fmt::Display for Arguments {
             "enable_custom_interactions: {:?}",
             self.enable_custom_interactions
         )?;
+        writeln!(f, "ipfs_gateway: {:?}", self.ipfs_gateway)?;
+        display_secret_option(f, "ipfs_pinata_auth", &self.ipfs_pinata_auth)?;
 
         Ok(())
     }

--- a/crates/orderbook/src/ipfs.rs
+++ b/crates/orderbook/src/ipfs.rs
@@ -1,0 +1,162 @@
+use {
+    anyhow::{anyhow, Context, Result},
+    futures::future::Either,
+    model::app_id::AppDataHash,
+    reqwest::{Client, StatusCode},
+    url::Url,
+};
+
+pub struct Ipfs {
+    client: Client,
+    base: Url,
+    query: Option<String>,
+}
+
+impl Ipfs {
+    pub fn new(client: Client, base: Url, query: Option<String>) -> Self {
+        assert!(!base.cannot_be_a_base());
+        Self {
+            client,
+            base,
+            query,
+        }
+    }
+
+    /// IPFS gateway behavior when a CID cannot be found is inconsistent and can
+    /// be confusing:
+    ///
+    /// - The public ipfs.io gateway responds "504 Gateway Timeout" after 2
+    ///   minutes.
+    /// - The public cloudflare gateway responds "524" after 20 seconds.
+    /// - A private Pinata gateway responds "404 Not Found" after 2 minutes.
+    ///
+    /// This function treats all status codes except "200 OK" as errors and you
+    /// likely want to use it with a timeout.
+    pub async fn fetch(&self, cid: &str) -> Result<Vec<u8>> {
+        let url = self.prepare_url(cid);
+        let response = self.client.get(url).send().await.context("send")?;
+        let status = response.status();
+        let body = response.bytes().await.context("body")?;
+        match status {
+            StatusCode::OK => Ok(body.into()),
+            _ => {
+                let body_text = String::from_utf8_lossy(&body);
+                let body_text: &str = &body_text;
+                Err(anyhow!("status {status}, body {body_text:?}"))
+            }
+        }
+    }
+
+    fn prepare_url(&self, cid: &str) -> Url {
+        let mut url = self.base.clone();
+        let mut path = url.path_segments_mut().unwrap();
+        path.push("ipfs");
+        path.push(cid);
+        std::mem::drop(path);
+        if let Some(query) = &self.query {
+            url.set_query(Some(query.as_str()));
+        }
+        url
+    }
+}
+
+/// Tries to find full app data corresponding to the contract app data on IPFS.
+///
+/// A return value of `Some` indicates that either the old or new CID format was
+/// found on IPFS and points to valid utf-8.
+///
+/// A return value of `None` indicates that neither CID was found. This might be
+/// a temporary condition as IPFS is a decentralized network.
+pub async fn full_app_data_from_ipfs(
+    ipfs: &Ipfs,
+    contract_app_data: &AppDataHash,
+) -> Option<String> {
+    let old = old_app_data_cid(contract_app_data);
+    let new = new_app_data_cid(contract_app_data);
+    let fetch = |cid: String| async move {
+        let data = match ipfs.fetch(&cid).await {
+            Ok(data) => {
+                tracing::debug!("found full app data for {contract_app_data:?} at CID {cid}");
+                data
+            }
+            Err(err) => {
+                tracing::debug!("no full app data for {contract_app_data:?} at CID {cid}: {err:?}");
+                return None;
+            }
+        };
+        match String::from_utf8(data) {
+            Ok(data) => Some(data),
+            Err(_) => {
+                tracing::debug!("CID {cid} doesn't point to utf-8");
+                None
+            }
+        }
+    };
+    match futures::future::select(std::pin::pin!(fetch(old)), std::pin::pin!(fetch(new))).await {
+        Either::Left((complete, pending)) | Either::Right((complete, pending)) => {
+            if complete.is_some() {
+                complete
+            } else {
+                pending.await
+            }
+        }
+    }
+}
+
+fn new_app_data_cid(contract_app_data: &AppDataHash) -> String {
+    let raw_cid = app_data_hash::create_ipfs_cid(&contract_app_data.0);
+    multibase::encode(multibase::Base::Base32Lower, raw_cid)
+}
+
+fn old_app_data_cid(contract_app_data: &AppDataHash) -> String {
+    let mut raw_cid = [0u8; 4 + 32];
+    raw_cid[0] = 1; // cid version
+    raw_cid[1] = 0x70; // dag-pb
+    raw_cid[2] = 0x12; // sha2-256
+    raw_cid[3] = 32; // hash length
+    raw_cid[4..].copy_from_slice(&contract_app_data.0);
+    multibase::encode(multibase::Base::Base32Lower, raw_cid)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    #[ignore]
+    async fn public_gateway() {
+        let ipfs = Ipfs::new(Default::default(), "https://ipfs.io".parse().unwrap(), None);
+        let cid = "Qma4Dwke5h8mgJyZMDRvKqM3RF7c6Mxcj3fR4um9UGaNF6";
+        let content = ipfs.fetch(cid).await.unwrap();
+        let content = std::str::from_utf8(&content).unwrap();
+        println!("{content}");
+    }
+
+    #[tokio::test]
+    #[ignore]
+    async fn private_gateway() {
+        let url = std::env::var("url").unwrap();
+        let query = std::env::var("query").unwrap();
+        let ipfs = Ipfs::new(Default::default(), url.parse().unwrap(), Some(query));
+        let cid = "Qma4Dwke5h8mgJyZMDRvKqM3RF7c6Mxcj3fR4um9UGaNF6";
+        let content = ipfs.fetch(cid).await.unwrap();
+        let content = std::str::from_utf8(&content).unwrap();
+        println!("{content}");
+    }
+
+    // Can be compared with CID explorer to make sure CIDs encode the right data.
+    #[test]
+    fn cid() {
+        let hash = AppDataHash(hex_literal::hex!(
+            "8af4e8c9973577b08ac21d17d331aade86c11ebcc5124744d621ca8365ec9424"
+        ));
+        let cid = new_app_data_cid(&hash);
+        println!("{cid}");
+
+        let hash = AppDataHash(hex_literal::hex!(
+            "AE16F2D8B960FFE3DE70E074CECFB24441D4CDC67E8A68566B9E6CE3037CB41D"
+        ));
+        let cid = old_app_data_cid(&hash);
+        println!("{cid}");
+    }
+}

--- a/crates/orderbook/src/lib.rs
+++ b/crates/orderbook/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod api;
 pub mod arguments;
 pub mod database;
+mod ipfs;
 pub mod orderbook;
 pub mod run;
 pub mod solver_competition;

--- a/crates/orderbook/src/run.rs
+++ b/crates/orderbook/src/run.rs
@@ -2,6 +2,7 @@ use {
     crate::{
         arguments::Arguments,
         database::Postgres,
+        ipfs::Ipfs,
         orderbook::Orderbook,
         serve_api,
         verify_deployed_contract_constants,
@@ -465,11 +466,20 @@ pub async fn run(args: Arguments) {
         .with_custom_interactions(args.enable_custom_interactions)
         .with_verified_quotes(args.price_estimation.trade_simulator.is_some()),
     );
+    let ipfs = args.ipfs_gateway.map(|url| {
+        Ipfs::new(
+            http_factory.create(),
+            url,
+            args.ipfs_pinata_auth
+                .map(|auth| format!("pinataGatewayToken={auth}")),
+        )
+    });
     let orderbook = Arc::new(Orderbook::new(
         domain_separator,
         settlement_contract.address(),
         postgres.clone(),
         order_validator.clone(),
+        ipfs,
     ));
 
     let mut maintainers = vec![pool_fetcher as Arc<dyn Maintaining>];


### PR DESCRIPTION
We want to continue to support IPFS based app data even when on order creation only the contract app data hash is specified. This PR changes how orders with only a contract app data hash are handled.

Before:
Order is accepted and we may or may not already have corresponding full app data in the database.

Now:
First try to find existing app data in database. If it doesn't exist try to find it on IPFS with the old and new method of CID generation. If it still doesn't exist then continue as before without full app data. If it does exist, then don't try to verify the hash of the found full app data because this might be the old way of storing on IPFS, which we cannot validate. Or it might be hardcoded app data that doesn't correspond to any IPFS data. Do verify that the schema is as expected.

The last step is a breaking change. Before this PR we would accept an order that has a contract app data hash that resolves to an IPFS document that isn't json (or not utf-8). We would accept it because we didn't have the full app data to validate. With this PR, when we find the full app data, we will validate the schema.

### Test Plan

CI e2e test, after merge I will configure our pinata ipfs gateway and do a manual test
