### PR TITLE
Configure Account Balance Fetching Implementation

### DIFF
--- a/crates/autopilot/src/arguments.rs
+++ b/crates/autopilot/src/arguments.rs
@@ -44,11 +44,6 @@ pub struct Arguments {
     #[clap(long, env)]
     pub tracing_node_url: Option<Url>,
 
-    /// An Ethereum node URL that supports `eth_call`s with state overrides to
-    /// be used exclusively for trade simulations.
-    #[clap(long, env)]
-    pub simulation_node_url: Option<Url>,
-
     #[clap(long, env, default_value = "0.0.0.0:9589")]
     pub metrics_address: SocketAddr,
 
@@ -207,7 +202,6 @@ impl std::fmt::Display for Arguments {
         write!(f, "{}", self.token_owner_finder)?;
         write!(f, "{}", self.price_estimation)?;
         display_option(f, "tracing_node_url", &self.tracing_node_url)?;
-        display_option(f, "simulation_node_url", &self.simulation_node_url)?;
         writeln!(f, "ethflow_contract: {:?}", self.ethflow_contract)?;
         writeln!(
             f,

--- a/crates/orderbook/src/arguments.rs
+++ b/crates/orderbook/src/arguments.rs
@@ -32,11 +32,6 @@ pub struct Arguments {
     #[clap(long, env)]
     pub tracing_node_url: Option<Url>,
 
-    /// An Ethereum node URL that supports `eth_call`s with state overrides to
-    /// be used exclusively for trade simulations.
-    #[clap(long, env)]
-    pub simulation_node_url: Option<Url>,
-
     #[clap(long, env, default_value = "0.0.0.0:8080")]
     pub bind_address: SocketAddr,
 
@@ -173,7 +168,6 @@ impl std::fmt::Display for Arguments {
         write!(f, "{}", self.token_owner_finder)?;
         write!(f, "{}", self.price_estimation)?;
         display_option(f, "tracing_node_url", &self.tracing_node_url)?;
-        display_option(f, "simulation_node_url", &self.simulation_node_url)?;
         writeln!(f, "bind_address: {}", self.bind_address)?;
         writeln!(f, "db_url: SECRET")?;
         writeln!(

--- a/crates/shared/src/account_balances.rs
+++ b/crates/shared/src/account_balances.rs
@@ -1,3 +1,4 @@
+mod arguments;
 mod cached;
 mod simulation;
 mod web3;
@@ -8,7 +9,12 @@ use {
     primitive_types::{H160, U256},
 };
 
-pub use self::{cached::CachingBalanceFetcher, web3::Web3BalanceFetcher};
+pub use self::{
+    arguments::{Arguments, Contracts, Strategy},
+    cached::CachingBalanceFetcher,
+    simulation::Balances as SimulationBalanceFetcher,
+    web3::Web3BalanceFetcher,
+};
 
 #[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]
 pub struct Query {

--- a/crates/shared/src/account_balances/arguments.rs
+++ b/crates/shared/src/account_balances/arguments.rs
@@ -1,0 +1,137 @@
+use {
+    super::{BalanceFetching, CachingBalanceFetcher, SimulationBalanceFetcher, Web3BalanceFetcher},
+    crate::{
+        arguments::{display_option, CodeSimulatorKind},
+        code_simulation::{CodeSimulating, TenderlyCodeSimulator, Web3ThenTenderly},
+        current_block::CurrentBlockStream,
+        ethrpc::Web3,
+        tenderly_api::TenderlyApi,
+    },
+    ethcontract::H160,
+    std::{
+        fmt::{self, Display, Formatter},
+        sync::Arc,
+    },
+};
+
+/// Arguments related to the token owner finder.
+#[derive(clap::Parser)]
+#[group(skip)]
+pub struct Arguments {
+    /// The account balance simulation strategy to use.
+    #[clap(long, env, default_value = "web3", value_enum)]
+    pub account_balances: Strategy,
+
+    /// The code simulation implementation to use. Can be one of `Web3`,
+    /// `Tenderly` or `Web3ThenTenderly`.
+    #[clap(long, env, value_enum)]
+    pub account_balances_simulator: Option<CodeSimulatorKind>,
+}
+
+/// Support token owner finding strategies.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, clap::ValueEnum)]
+pub enum Strategy {
+    /// Use basic Ethereum RPC requests to query balances and allowances.
+    ///
+    /// Note that this strategy does not properly support fetching balances for
+    /// orders with custom interactions.
+    Web3,
+
+    /// Use code simulation techniques to query balances and allowances.
+    ///
+    /// This strategy fully supports fetching balances for orders with custom
+    /// interactions.
+    Simulation,
+}
+
+/// Contracts required for balance simulation.
+pub struct Contracts {
+    pub chain_id: u64,
+    pub settlement: H160,
+    pub vault_relayer: H160,
+    pub vault: Option<H160>,
+}
+
+impl Arguments {
+    pub fn fetcher(
+        &self,
+        contracts: Contracts,
+        web3: Web3,
+        simulation_web3: Option<Web3>,
+        tenderly: Option<Arc<dyn TenderlyApi>>,
+    ) -> Arc<dyn BalanceFetching> {
+        match self.account_balances {
+            Strategy::Web3 => Arc::new(Web3BalanceFetcher::new(
+                web3,
+                contracts.vault,
+                contracts.vault_relayer,
+                contracts.settlement,
+            )),
+            Strategy::Simulation => {
+                let web3_simulator =
+                    move || simulation_web3.expect("simulation web3 not configured");
+                let tenderly_simulator = move || {
+                    TenderlyCodeSimulator::new(
+                        tenderly.expect("tenderly api not configured"),
+                        contracts.chain_id,
+                    )
+                };
+
+                let simulator = match self
+                    .account_balances_simulator
+                    .expect("account balances simulator not configured")
+                {
+                    CodeSimulatorKind::Web3 => {
+                        Arc::new(web3_simulator()) as Arc<dyn CodeSimulating>
+                    }
+                    CodeSimulatorKind::Tenderly => Arc::new(tenderly_simulator()),
+                    CodeSimulatorKind::Web3ThenTenderly => Arc::new(Web3ThenTenderly::new(
+                        web3_simulator(),
+                        tenderly_simulator(),
+                    )),
+                };
+
+                Arc::new(SimulationBalanceFetcher::new(
+                    simulator,
+                    contracts.settlement,
+                    contracts.vault_relayer,
+                    contracts.vault,
+                ))
+            }
+        }
+    }
+
+    pub fn cached(
+        &self,
+        contracts: Contracts,
+        web3: Web3,
+        simulation_web3: Option<Web3>,
+        tenderly: Option<Arc<dyn TenderlyApi>>,
+        blocks: CurrentBlockStream,
+    ) -> Arc<CachingBalanceFetcher> {
+        let cached = Arc::new(CachingBalanceFetcher::new(self.fetcher(
+            contracts,
+            web3,
+            simulation_web3,
+            tenderly,
+        )));
+        cached.spawn_background_task(blocks);
+        cached
+    }
+}
+
+impl Display for Arguments {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        writeln!(f, "account_balances: {:?}", self.account_balances)?;
+        display_option(
+            f,
+            "account_balances_simulator",
+            &self
+                .account_balances_simulator
+                .as_ref()
+                .map(|value| format!("{value:?}")),
+        )?;
+
+        Ok(())
+    }
+}

--- a/crates/shared/src/account_balances/simulation.rs
+++ b/crates/shared/src/account_balances/simulation.rs
@@ -22,7 +22,7 @@ pub struct Balances {
 }
 
 impl Balances {
-    pub fn _new(
+    pub fn new(
         simulator: Arc<dyn CodeSimulating>,
         settlement: H160,
         vault_relayer: H160,
@@ -79,10 +79,14 @@ impl Balances {
         };
 
         let output = self.simulator.simulate(call, overrides).await?;
-        Simulation::decode(&output)
+        let simulation = Simulation::decode(&output)?;
+
+        tracing::trace!(?query, ?amount, ?simulation, "simulated balances");
+        Ok(simulation)
     }
 }
 
+#[derive(Debug)]
 struct Simulation {
     token_balance: U256,
     allowance: U256,
@@ -169,7 +173,7 @@ mod tests {
     #[ignore]
     #[tokio::test]
     async fn test_for_user() {
-        let balances = Balances::_new(
+        let balances = Balances::new(
             Arc::new(Web3::new(ethrpc::create_env_test_transport())),
             addr!("9008d19f58aabd9ed0d60971565aa8510560ab41"),
             addr!("C92E8bdf79f0507f65a392b0ab4667716BFE0110"),

--- a/crates/shared/src/account_balances/web3.rs
+++ b/crates/shared/src/account_balances/web3.rs
@@ -21,10 +21,11 @@ pub struct Web3BalanceFetcher {
 impl Web3BalanceFetcher {
     pub fn new(
         web3: Web3,
-        vault: Option<BalancerV2Vault>,
+        vault: Option<H160>,
         vault_relayer: H160,
         settlement_contract: H160,
     ) -> Self {
+        let vault = vault.map(|address| contracts::BalancerV2Vault::at(&web3, address));
         Self {
             web3,
             vault,
@@ -405,7 +406,7 @@ mod tests {
 
         let fetcher = Web3BalanceFetcher::new(
             web3,
-            Some(vault.clone()),
+            Some(vault.address()),
             allowance_target.address(),
             H160::from_low_u64_be(1),
         );
@@ -504,7 +505,7 @@ mod tests {
 
         let fetcher = Web3BalanceFetcher::new(
             web3,
-            Some(vault.clone()),
+            Some(vault.address()),
             allowance_target.address(),
             H160::from_low_u64_be(1),
         );

--- a/crates/shared/src/arguments.rs
+++ b/crates/shared/src/arguments.rs
@@ -159,7 +159,7 @@ pub struct Arguments {
     pub node_url: Url,
 
     /// An Ethereum node URL that supports `eth_call`s with state overrides to
-    /// be used exclusively for trade simulations.
+    /// be used for simulations.
     #[clap(long, env)]
     pub simulation_node_url: Option<Url>,
 

--- a/crates/shared/src/arguments.rs
+++ b/crates/shared/src/arguments.rs
@@ -3,6 +3,7 @@
 
 use {
     crate::{
+        account_balances,
         current_block,
         ethrpc,
         fee_subsidy::cow_token::SubsidyTiers,
@@ -148,11 +149,19 @@ pub struct Arguments {
     pub tenderly: tenderly_api::Arguments,
 
     #[clap(flatten)]
+    pub balances: account_balances::Arguments,
+
+    #[clap(flatten)]
     pub logging: LoggingArguments,
 
     /// The Ethereum node URL to connect to.
     #[clap(long, env, default_value = "http://localhost:8545")]
     pub node_url: Url,
+
+    /// An Ethereum node URL that supports `eth_call`s with state overrides to
+    /// be used exclusively for trade simulations.
+    #[clap(long, env)]
+    pub simulation_node_url: Option<Url>,
 
     /// The expected chain ID that the services are expected to run against.
     /// This can be optionally specified in order to check at startup whether
@@ -302,6 +311,15 @@ pub struct Arguments {
     pub balancer_v2_vault_address: Option<H160>,
 }
 
+/// The kind of EVM code simulator to use.
+#[derive(Copy, Clone, Debug, Hash, Eq, PartialEq, clap::ValueEnum)]
+#[clap(rename_all = "verbatim")]
+pub enum CodeSimulatorKind {
+    Web3,
+    Tenderly,
+    Web3ThenTenderly,
+}
+
 pub fn display_secret_option<T>(
     f: &mut Formatter<'_>,
     name: &str,
@@ -378,6 +396,7 @@ impl Display for Arguments {
         write!(f, "{}", self.ethrpc)?;
         write!(f, "{}", self.current_block)?;
         write!(f, "{}", self.tenderly)?;
+        write!(f, "{}", self.balances)?;
         writeln!(f, "log_filter: {}", self.logging.log_filter)?;
         writeln!(
             f,
@@ -386,6 +405,7 @@ impl Display for Arguments {
         )?;
         writeln!(f, "node_url: {}", self.node_url)?;
         display_option(f, "chain_id", &self.chain_id)?;
+        display_option(f, "simulation_node_url", &self.simulation_node_url)?;
         writeln!(f, "gas_estimators: {:?}", self.gas_estimators)?;
         display_secret_option(f, "blocknative_api_key", &self.blocknative_api_key)?;
         writeln!(f, "base_tokens: {:?}", self.base_tokens)?;

--- a/crates/shared/src/price_estimation.rs
+++ b/crates/shared/src/price_estimation.rs
@@ -16,7 +16,7 @@ pub mod zeroex;
 
 use {
     crate::{
-        arguments::display_option,
+        arguments::{display_option, CodeSimulatorKind},
         bad_token::{BadTokenDetecting, TokenQuality},
         conversions::U256Ext,
         rate_limiter::{RateLimiter, RateLimitingStrategy},
@@ -58,14 +58,6 @@ impl PriceEstimatorType {
     pub fn name(&self) -> String {
         format!("{self:?}")
     }
-}
-
-#[derive(Copy, Clone, Debug, Hash, Eq, PartialEq, ValueEnum)]
-#[clap(rename_all = "verbatim")]
-pub enum TradeValidatorKind {
-    Web3,
-    Tenderly,
-    Web3ThenTenderly,
 }
 
 /// Shared price estimation configuration arguments.
@@ -152,7 +144,7 @@ pub struct Arguments {
     /// parameter to be set. The `Tenderly` simulator requires `--tenderly-*`
     /// parameters to be set.
     #[clap(long, env)]
-    pub trade_simulator: Option<TradeValidatorKind>,
+    pub trade_simulator: Option<CodeSimulatorKind>,
 
     /// Flag to enable saving Tenderly simulations in the dashboard for failed
     /// trade simulations. This helps debugging reverted quote simulations.

--- a/crates/shared/src/price_estimation/factory.rs
+++ b/crates/shared/src/price_estimation/factory.rs
@@ -16,10 +16,9 @@ use {
         Arguments,
         PriceEstimating,
         PriceEstimatorType,
-        TradeValidatorKind,
     },
     crate::{
-        arguments::{self, Driver},
+        arguments::{self, CodeSimulatorKind, Driver},
         bad_token::BadTokenDetecting,
         balancer_sor_api::DefaultBalancerSorApi,
         baseline_solver::BaseTokens,
@@ -115,14 +114,14 @@ impl<'a> PriceEstimatorFactory<'a> {
                 };
 
                 let simulator = match kind {
-                    TradeValidatorKind::Web3 => {
+                    CodeSimulatorKind::Web3 => {
                         Arc::new(web3_simulator()?) as Arc<dyn CodeSimulating>
                     }
-                    TradeValidatorKind::Tenderly => Arc::new(
+                    CodeSimulatorKind::Tenderly => Arc::new(
                         tenderly_simulator()?
                             .save(false, args.tenderly_save_failed_trade_simulations),
                     ),
-                    TradeValidatorKind::Web3ThenTenderly => {
+                    CodeSimulatorKind::Web3ThenTenderly => {
                         Arc::new(code_simulation::Web3ThenTenderly::new(
                             web3_simulator()?,
                             tenderly_simulator()?,


### PR DESCRIPTION
Follow up to #1586

This PR adds the required configuration options to setup a simulation based balance fetcher in the services. Note that this still needs to be done for the `driver`.

### Test Plan

Ran locally and verified the balance simulation logs when trying to create an order for a token for which I had no balance (but some allowance):

```
2023-06-14T15:03:05.197Z TRACE request{id=7}: shared::account_balances::simulation: simulated balances query=Query { owner: 0xdbc682d0ec19bd276fd6c2af4e0189b584bb31e1, token: 0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48, source: Erc20 } amount=Some(1000000000) simulation=Simulation { token_balance: 0, allowance: 115792089237316195423570985008687907853269984665640564039457584007912951809973, effective_balance: 0, can_transfer: false }
```