### PR TITLE
Extend Balance Fetching API To Allow Pre-Interactions

### DIFF
--- a/crates/shared/src/account_balances.rs
+++ b/crates/shared/src/account_balances.rs
@@ -5,7 +5,10 @@ mod web3;
 
 use {
     anyhow::Result,
-    model::order::{Order, SellTokenSource},
+    model::{
+        interaction::InteractionData,
+        order::{Order, SellTokenSource},
+    },
     primitive_types::{H160, U256},
 };
 
@@ -16,11 +19,12 @@ pub use self::{
     web3::Web3BalanceFetcher,
 };
 
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq)]
 pub struct Query {
     pub owner: H160,
     pub token: H160,
     pub source: SellTokenSource,
+    pub interactions: Vec<InteractionData>,
 }
 
 impl Query {
@@ -29,6 +33,7 @@ impl Query {
             owner: o.metadata.owner,
             token: o.data.sell_token,
             source: o.data.sell_token_balance,
+            interactions: o.interactions.pre.clone(),
         }
     }
 }
@@ -62,9 +67,7 @@ pub trait BalanceFetching: Send + Sync {
     // can perform more extensive tests.
     async fn can_transfer(
         &self,
-        token: H160,
-        from: H160,
+        query: &Query,
         amount: U256,
-        source: SellTokenSource,
     ) -> Result<(), TransferSimulationError>;
 }

--- a/crates/shared/src/order_validation.rs
+++ b/crates/shared/src/order_validation.rs
@@ -1,5 +1,6 @@
 use {
     crate::{
+        account_balances,
         account_balances::{BalanceFetching, TransferSimulationError},
         bad_token::{BadTokenDetecting, TokenQuality},
         code_fetching::CodeFetching,
@@ -586,7 +587,16 @@ impl OrderValidating for OrderValidator {
         // If not, run extra queries for additional information.
         match self
             .balance_fetcher
-            .can_transfer(data.sell_token, owner, min_balance, data.sell_token_balance)
+            .can_transfer(
+                &account_balances::Query {
+                    token: data.sell_token,
+                    owner,
+                    source: data.sell_token_balance,
+                    // TODO(nlordell): Read from app-data
+                    interactions: vec![],
+                },
+                min_balance,
+            )
             .await
         {
             Ok(_) => (),
@@ -1204,7 +1214,7 @@ mod tests {
             .returning(|_| Ok(TokenQuality::Good));
         balance_fetcher
             .expect_can_transfer()
-            .returning(|_, _, _, _| Ok(()));
+            .returning(|_, _| Ok(()));
 
         let mut signature_validating = MockSignatureValidating::new();
         signature_validating
@@ -1357,7 +1367,7 @@ mod tests {
             .returning(|_| Ok(TokenQuality::Good));
         balance_fetcher
             .expect_can_transfer()
-            .returning(|_, _, _, _| Ok(()));
+            .returning(|_, _| Ok(()));
 
         let mut signature_validating = MockSignatureValidating::new();
         signature_validating
@@ -1425,7 +1435,7 @@ mod tests {
             .returning(|_| Ok(TokenQuality::Good));
         balance_fetcher
             .expect_can_transfer()
-            .returning(|_, _, _, _| Ok(()));
+            .returning(|_, _| Ok(()));
         let mut limit_order_counter = MockLimitOrderCounting::new();
         limit_order_counter.expect_count().returning(|_| Ok(0u64));
         let validator = OrderValidator::new(
@@ -1475,7 +1485,7 @@ mod tests {
             .returning(|_| Ok(TokenQuality::Good));
         balance_fetcher
             .expect_can_transfer()
-            .returning(|_, _, _, _| Ok(()));
+            .returning(|_, _| Ok(()));
         let mut limit_order_counter = MockLimitOrderCounting::new();
         limit_order_counter.expect_count().returning(|_| Ok(0u64));
         let validator = OrderValidator::new(
@@ -1537,7 +1547,7 @@ mod tests {
             .returning(|_| Ok(TokenQuality::Good));
         balance_fetcher
             .expect_can_transfer()
-            .returning(|_, _, _, _| Ok(()));
+            .returning(|_, _| Ok(()));
         let mut limit_order_counter = MockLimitOrderCounting::new();
         limit_order_counter.expect_count().returning(|_| Ok(0u64));
         let validator = OrderValidator::new(
@@ -1590,7 +1600,7 @@ mod tests {
             .returning(|_| Ok(TokenQuality::Good));
         balance_fetcher
             .expect_can_transfer()
-            .returning(|_, _, _, _| Ok(()));
+            .returning(|_, _| Ok(()));
         let mut limit_order_counter = MockLimitOrderCounting::new();
         limit_order_counter.expect_count().returning(|_| Ok(0u64));
         let validator = OrderValidator::new(
@@ -1638,7 +1648,7 @@ mod tests {
             .returning(|_| Ok(TokenQuality::Good));
         balance_fetcher
             .expect_can_transfer()
-            .returning(|_, _, _, _| Ok(()));
+            .returning(|_, _| Ok(()));
         let mut limit_order_counter = MockLimitOrderCounting::new();
         limit_order_counter.expect_count().returning(|_| Ok(0u64));
         let validator = OrderValidator::new(
@@ -1688,7 +1698,7 @@ mod tests {
         });
         balance_fetcher
             .expect_can_transfer()
-            .returning(|_, _, _, _| Ok(()));
+            .returning(|_, _| Ok(()));
         let mut limit_order_counter = MockLimitOrderCounting::new();
         limit_order_counter.expect_count().returning(|_| Ok(0u64));
         let validator = OrderValidator::new(
@@ -1742,7 +1752,7 @@ mod tests {
             .returning(|_| Ok(TokenQuality::Good));
         balance_fetcher
             .expect_can_transfer()
-            .returning(|_, _, _, _| Ok(()));
+            .returning(|_, _| Ok(()));
         let mut limit_order_counter = MockLimitOrderCounting::new();
         limit_order_counter.expect_count().returning(|_| Ok(0u64));
         let validator = OrderValidator::new(
@@ -1790,7 +1800,7 @@ mod tests {
             .returning(|_| Ok(TokenQuality::Good));
         balance_fetcher
             .expect_can_transfer()
-            .returning(|_, _, _, _| Err(TransferSimulationError::InsufficientBalance));
+            .returning(|_, _| Err(TransferSimulationError::InsufficientBalance));
         let mut limit_order_counter = MockLimitOrderCounting::new();
         limit_order_counter.expect_count().returning(|_| Ok(0u64));
         let validator = OrderValidator::new(
@@ -1839,7 +1849,7 @@ mod tests {
             .returning(|_| Ok(TokenQuality::Good));
         balance_fetcher
             .expect_can_transfer()
-            .returning(|_, _, _, _| Ok(()));
+            .returning(|_, _| Ok(()));
         signature_validator
             .expect_validate_signature_and_get_additional_gas()
             .returning(|_| Err(SignatureValidationError::Invalid));
@@ -1901,7 +1911,7 @@ mod tests {
                 .returning(|_| Ok(TokenQuality::Good));
             balance_fetcher
                 .expect_can_transfer()
-                .returning(move |_, _, _, _| Err(create_error()));
+                .returning(move |_, _| Err(create_error()));
             let mut limit_order_counter = MockLimitOrderCounting::new();
             limit_order_counter.expect_count().returning(|_| Ok(0u64));
             let validator = OrderValidator::new(


### PR DESCRIPTION
This PR adds interactions to the balance fetching API in order to correctly compute effective user balance including potential pre-interactions (such as signed EIP-2612 permit transactions).

One notable code smell is that we skip balance checks for FoK limit orders with custom interactions. This should be OK, where we will at worst include some additional fee queries for orders that don't actually need them (because of missing balances). I also noticed, on an unrelated point, that we don't verify quotes for FoK limit order surplus fees.

### Test Plan

CI, no real logic change, just piping data through.
