### PR TITLE
Add Goerli colocation pods to auto deploy

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -58,8 +58,11 @@ jobs:
           pods:
                 "goerli-api-staging,\
                 goerli-autopilot-staging,\
+                goerli-baseline-staging,\
+                goerli-driver-staging,\
+                goerli-naive-staging,\
+                goerli-quasimodo-staging,\
                 goerli-refunder-staging,\
-                goerli-solver-staging,\
                 mainnet-api-staging,\
                 mainnet-autopilot-staging,\
                 mainnet-refunder-staging,\


### PR DESCRIPTION
Fixes failing auto deployments due to Goerli solver changes.

### Test Plan

Running Github actions after merge should resolve failing jobs.

### Release notes

Update auto deploy to include new co-location pods
