### PR TITLE
Hook Up Pre- and Post- Interactions

### DIFF
--- a/crates/database/src/orders.rs
+++ b/crates/database/src/orders.rs
@@ -75,30 +75,6 @@ pub enum BuyTokenDestination {
     Internal,
 }
 
-/// Time during the `settle()` call when an interaction should be executed.
-#[derive(Clone, Copy, Debug, Default, Eq, PartialEq, sqlx::Type)]
-#[sqlx(type_name = "ExecutionTime")]
-#[sqlx(rename_all = "lowercase")]
-pub enum ExecutionTime {
-    /// Interaction that gets executed before sell tokens get transferred from
-    /// user to settlement contract.
-    #[default]
-    Pre,
-    /// Interaction that gets executed after buy tokens got sent from the
-    /// settlement contract to the user.
-    Post,
-}
-
-/// One row in the `interactions` table.
-#[derive(Clone, Debug, Default, Eq, PartialEq, sqlx::FromRow)]
-pub struct Interaction {
-    pub target: Address,
-    pub value: BigDecimal,
-    pub data: Vec<u8>,
-    pub index: i32,
-    pub execution: ExecutionTime,
-}
-
 /// One row in the `orders` table.
 #[derive(Clone, Debug, Default, Eq, PartialEq, sqlx::FromRow)]
 pub struct Order {
@@ -275,6 +251,69 @@ pub fn is_duplicate_record_error(err: &sqlx::Error) -> bool {
         }
     }
     false
+}
+
+/// Time during the `settle()` call when an interaction should be executed.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq, sqlx::Type)]
+#[sqlx(type_name = "ExecutionTime")]
+#[sqlx(rename_all = "lowercase")]
+pub enum ExecutionTime {
+    /// Interaction that gets executed before sell tokens get transferred from
+    /// user to settlement contract.
+    #[default]
+    Pre,
+    /// Interaction that gets executed after buy tokens got sent from the
+    /// settlement contract to the user.
+    Post,
+}
+
+/// One row in the `interactions` table.
+#[derive(Clone, Debug, Default, Eq, PartialEq, sqlx::FromRow)]
+pub struct Interaction {
+    pub target: Address,
+    pub value: BigDecimal,
+    pub data: Vec<u8>,
+    pub index: i32,
+    pub execution: ExecutionTime,
+}
+
+pub async fn insert_interactions(
+    ex: &mut PgConnection,
+    order: &OrderUid,
+    interactions: &[Interaction],
+) -> Result<(), sqlx::Error> {
+    for interaction in interactions {
+        insert_interaction(ex, order, interaction).await?;
+    }
+    Ok(())
+}
+
+pub async fn insert_interaction(
+    ex: &mut PgConnection,
+    order: &OrderUid,
+    interaction: &Interaction,
+) -> Result<(), sqlx::Error> {
+    const QUERY: &str = r#"
+INSERT INTO interactions (
+    order_uid,
+    index,
+    target,
+    value,
+    data,
+    execution
+)
+VALUES ($1, $2, $3, $4, $5, $6)
+    "#;
+    sqlx::query(QUERY)
+        .bind(&order)
+        .bind(&interaction.index)
+        .bind(&interaction.target)
+        .bind(&interaction.value)
+        .bind(&interaction.data)
+        .bind(&interaction.execution)
+        .execute(ex)
+        .await?;
+    Ok(())
 }
 
 /// One row in the `order_quotes` table.
@@ -1023,21 +1062,21 @@ mod tests {
 
         let order = Order::default();
         insert_order(&mut db, &order).await.unwrap();
-        let post_interaction_1 = Interaction {
+        let post_interaction_0 = Interaction {
             execution: ExecutionTime::Post,
             ..Default::default()
         };
-        let post_interaction_2 = Interaction {
+        let post_interaction_1 = Interaction {
             target: ByteArray([1; 20]),
             value: BigDecimal::new(10.into(), 1),
             data: vec![0u8, 1u8],
             index: 1,
             execution: ExecutionTime::Post,
         };
-        insert_or_overwrite_interaction(&mut db, &post_interaction_1, &order.uid)
+        insert_interaction(&mut db, &order.uid, &post_interaction_0)
             .await
             .unwrap();
-        insert_or_overwrite_interaction(&mut db, &post_interaction_2, &order.uid)
+        insert_or_overwrite_interaction(&mut db, &post_interaction_1, &order.uid)
             .await
             .unwrap();
         let order_ = single_full_order(&mut db, &order.uid)
@@ -1073,17 +1112,21 @@ mod tests {
         let post_interactions = read_order_interactions(&mut db, &order.uid, ExecutionTime::Post)
             .await
             .unwrap();
-        assert_eq!(*post_interactions.get(0).unwrap(), post_interaction_1);
-        assert_eq!(*post_interactions.get(1).unwrap(), post_interaction_2);
+        assert_eq!(*post_interactions.get(0).unwrap(), post_interaction_0);
+        assert_eq!(*post_interactions.get(1).unwrap(), post_interaction_1);
 
-        let post_interaction_overwrite = Interaction {
+        let post_interaction_overwrite_0 = Interaction {
             target: ByteArray([2; 20]),
             value: BigDecimal::new(100.into(), 1),
             data: vec![0u8, 2u8],
             index: 0,
             execution: ExecutionTime::Post,
         };
-        insert_or_overwrite_interaction(&mut db, &post_interaction_overwrite, &order.uid)
+        let post_interaction_overwrite_1 = Interaction {
+            index: 1,
+            ..post_interaction_overwrite_0.clone()
+        };
+        insert_or_overwrite_interaction(&mut db, &post_interaction_overwrite_0, &order.uid)
             .await
             .unwrap();
         let post_interactions = read_order_interactions(&mut db, &order.uid, ExecutionTime::Post)
@@ -1091,9 +1134,16 @@ mod tests {
             .unwrap();
         assert_eq!(
             *post_interactions.get(0).unwrap(),
-            post_interaction_overwrite
+            post_interaction_overwrite_0
         );
-        assert_eq!(*post_interactions.get(1).unwrap(), post_interaction_2);
+        assert_eq!(*post_interactions.get(1).unwrap(), post_interaction_1);
+
+        // Duplicate key!
+        assert!(
+            insert_interaction(&mut db, &order.uid, &post_interaction_overwrite_1)
+                .await
+                .is_err()
+        );
     }
 
     #[tokio::test]
@@ -1105,18 +1155,18 @@ mod tests {
 
         let order = Order::default();
         insert_order(&mut db, &order).await.unwrap();
-        let pre_interaction_1 = Interaction::default();
-        let pre_interaction_2 = Interaction {
+        let pre_interaction_0 = Interaction::default();
+        let pre_interaction_1 = Interaction {
             target: ByteArray([1; 20]),
             value: BigDecimal::new(10.into(), 1),
             data: vec![0u8, 1u8],
             index: 1,
             execution: ExecutionTime::Pre,
         };
-        insert_or_overwrite_interaction(&mut db, &pre_interaction_1, &order.uid)
+        insert_interaction(&mut db, &order.uid, &pre_interaction_0)
             .await
             .unwrap();
-        insert_or_overwrite_interaction(&mut db, &pre_interaction_2, &order.uid)
+        insert_or_overwrite_interaction(&mut db, &pre_interaction_1, &order.uid)
             .await
             .unwrap();
         let order_ = single_full_order(&mut db, &order.uid)
@@ -1152,24 +1202,38 @@ mod tests {
         let pre_interactions = read_order_interactions(&mut db, &order.uid, ExecutionTime::Pre)
             .await
             .unwrap();
-        assert_eq!(*pre_interactions.get(0).unwrap(), pre_interaction_1);
-        assert_eq!(*pre_interactions.get(1).unwrap(), pre_interaction_2);
+        assert_eq!(*pre_interactions.get(0).unwrap(), pre_interaction_0);
+        assert_eq!(*pre_interactions.get(1).unwrap(), pre_interaction_1);
 
-        let pre_interaction_overwrite = Interaction {
+        let pre_interaction_overwrite_0 = Interaction {
             target: ByteArray([2; 20]),
             value: BigDecimal::new(100.into(), 1),
             data: vec![0u8, 2u8],
             index: 0,
             execution: ExecutionTime::Pre,
         };
-        insert_or_overwrite_interaction(&mut db, &pre_interaction_overwrite, &order.uid)
+        let pre_interaction_overwrite_1 = Interaction {
+            index: 1,
+            ..pre_interaction_overwrite_0.clone()
+        };
+        insert_or_overwrite_interaction(&mut db, &pre_interaction_overwrite_0, &order.uid)
             .await
             .unwrap();
         let pre_interactions = read_order_interactions(&mut db, &order.uid, ExecutionTime::Pre)
             .await
             .unwrap();
-        assert_eq!(*pre_interactions.get(0).unwrap(), pre_interaction_overwrite);
-        assert_eq!(*pre_interactions.get(1).unwrap(), pre_interaction_2);
+        assert_eq!(
+            *pre_interactions.get(0).unwrap(),
+            pre_interaction_overwrite_0
+        );
+        assert_eq!(*pre_interactions.get(1).unwrap(), pre_interaction_1);
+
+        // Duplicate key!
+        assert!(
+            insert_interaction(&mut db, &order.uid, &pre_interaction_overwrite_1)
+                .await
+                .is_err()
+        );
     }
 
     #[tokio::test]

--- a/crates/model/src/order.rs
+++ b/crates/model/src/order.rs
@@ -40,6 +40,16 @@ pub struct Interactions {
     pub post: Vec<InteractionData>,
 }
 
+impl Interactions {
+    pub fn is_empty(&self) -> bool {
+        self.all().next().is_none()
+    }
+
+    pub fn all(&self) -> impl Iterator<Item = &'_ InteractionData> + '_ {
+        self.pre.iter().chain(self.post.iter())
+    }
+}
+
 /// An order that is returned when querying the orderbook.
 ///
 /// Contains extra fields that are populated by the orderbook.

--- a/crates/orderbook/src/api/post_order.rs
+++ b/crates/orderbook/src/api/post_order.rs
@@ -87,6 +87,13 @@ impl IntoWarpReply for PartialValidationErrorWrapper {
                 ),
                 StatusCode::BAD_REQUEST,
             ),
+            PartialValidationError::UnsupportedCustomInteraction => with_status(
+                error(
+                    "UnsupportedCustomInteraction",
+                    "The specified custom pre- or post- interaction is unsupported",
+                ),
+                StatusCode::BAD_REQUEST,
+            ),
             PartialValidationError::Other(err) => {
                 tracing::error!(?err, "PartialValidatonError");
                 shared::api::internal_error_reply()

--- a/crates/shared/src/app_data.rs
+++ b/crates/shared/src/app_data.rs
@@ -1,6 +1,6 @@
 use {
     anyhow::{anyhow, Context, Result},
-    model::app_id::AppDataHash,
+    model::{app_id::AppDataHash, order::Interactions},
     serde::Deserialize,
     serde_json::Value,
 };
@@ -12,7 +12,10 @@ pub struct ValidatedAppData {
 }
 
 #[derive(Debug, Default, Deserialize)]
-pub struct BackendAppData {}
+pub struct BackendAppData {
+    #[serde(default)]
+    pub interactions: Interactions,
+}
 
 #[derive(Clone)]
 pub struct Validator {

--- a/crates/shared/src/trade_finding.rs
+++ b/crates/shared/src/trade_finding.rs
@@ -11,6 +11,7 @@ use {
     anyhow::Result,
     contracts::ERC20,
     ethcontract::{contract::MethodBuilder, tokens::Tokenize, web3::Transport, Bytes, H160, U256},
+    model::interaction::InteractionData,
     serde::Serialize,
     thiserror::Error,
 };
@@ -104,6 +105,16 @@ impl Interaction {
 
     pub fn encode(&self) -> EncodedInteraction {
         (self.target, self.value, Bytes(self.data.clone()))
+    }
+}
+
+impl From<InteractionData> for Interaction {
+    fn from(interaction: InteractionData) -> Self {
+        Self {
+            target: interaction.target,
+            value: interaction.value,
+            data: interaction.call_data,
+        }
     }
 }
 


### PR DESCRIPTION
This PR adds the remaining glue code to enable pre-interactions. Namely:
- Parse custom interactions from app data
- Store custom interactions in the database

### Test Plan

Added some unit tests for the DB operations, and E2E test introduced in #1604.

### Release Notes

**This should not be enabled on Mainnet/Gnosis Chain until we properly trampoline the user interactions!**.
