### PR TITLE
Remove `infra::time::Now` from `driver`

### DIFF
--- a/crates/driver/src/domain/competition/auction.rs
+++ b/crates/driver/src/domain/competition/auction.rs
@@ -1,10 +1,7 @@
 use {
-    crate::{
-        domain::{
-            competition::{self, solution},
-            eth,
-        },
-        infra::time,
+    crate::domain::{
+        competition::{self, solution},
+        eth,
     },
     std::{num::ParseIntError, str::FromStr},
     thiserror::Error,
@@ -71,8 +68,8 @@ pub struct Deadline(chrono::DateTime<chrono::Utc>);
 
 impl Deadline {
     /// Computes the timeout for solving an auction.
-    pub fn timeout(self, now: time::Now) -> Result<solution::SolverTimeout, DeadlineExceeded> {
-        solution::SolverTimeout::new(self.into(), Self::time_buffer(), now).ok_or(DeadlineExceeded)
+    pub fn timeout(self) -> Result<solution::SolverTimeout, DeadlineExceeded> {
+        solution::SolverTimeout::new(self.into(), Self::time_buffer()).ok_or(DeadlineExceeded)
     }
 
     pub fn time_buffer() -> chrono::Duration {

--- a/crates/driver/src/domain/competition/mod.rs
+++ b/crates/driver/src/domain/competition/mod.rs
@@ -8,7 +8,6 @@ use {
             mempool,
             observe,
             solver::{self, Solver},
-            time,
             Mempool,
             Simulator,
         },
@@ -41,7 +40,6 @@ pub struct Competition {
     pub eth: Ethereum,
     pub liquidity: infra::liquidity::Fetcher,
     pub simulator: Simulator,
-    pub now: time::Now,
     pub mempools: Vec<Mempool>,
     pub settlement: Mutex<Option<Settlement>>,
 }
@@ -79,7 +77,7 @@ impl Competition {
         // Fetch the solutions from the solver.
         let solutions = self
             .solver
-            .solve(auction, &liquidity, auction.deadline.timeout(self.now)?)
+            .solve(auction, &liquidity, auction.deadline.timeout()?)
             .await?;
 
         // Empty solutions aren't useful, so discard them.

--- a/crates/driver/src/domain/competition/solution/mod.rs
+++ b/crates/driver/src/domain/competition/solution/mod.rs
@@ -6,7 +6,6 @@ use {
             eth,
         },
         infra::{
-            self,
             blockchain::{self, Ethereum},
             simulator,
             solver::Solver,
@@ -216,14 +215,13 @@ impl SolverTimeout {
     pub fn new(
         deadline: chrono::DateTime<chrono::Utc>,
         buffer: chrono::Duration,
-        now: time::Now,
     ) -> Option<SolverTimeout> {
-        let deadline = deadline - now.now() - buffer;
+        let deadline = deadline - time::now() - buffer;
         deadline.to_std().map(Self).ok()
     }
 
-    pub fn deadline(self, now: infra::time::Now) -> chrono::DateTime<chrono::Utc> {
-        now.now() + chrono::Duration::from_std(self.0).expect("reasonable solver timeout")
+    pub fn deadline(self) -> chrono::DateTime<chrono::Utc> {
+        time::now() + chrono::Duration::from_std(self.0).expect("reasonable solver timeout")
     }
 }
 

--- a/crates/driver/src/domain/quote.rs
+++ b/crates/driver/src/domain/quote.rs
@@ -10,7 +10,6 @@ use {
             self,
             blockchain::{self, Ethereum},
             solver::{self, Solver},
-            time,
         },
         util::{self, conv},
     },
@@ -74,11 +73,10 @@ impl Order {
         eth: &Ethereum,
         solver: &Solver,
         liquidity: &infra::liquidity::Fetcher,
-        now: time::Now,
     ) -> Result<Quote, Error> {
         let liquidity = liquidity.fetch(&self.liquidity_pairs()).await;
         let gas_price = eth.gas_price().await?;
-        let timeout = self.deadline.timeout(now)?;
+        let timeout = self.deadline.timeout()?;
         let solutions = solver
             .solve(&self.fake_auction(gas_price), &liquidity, timeout)
             .await?;
@@ -173,8 +171,8 @@ pub struct Deadline(chrono::DateTime<chrono::Utc>);
 
 impl Deadline {
     /// Computes the timeout for solving an auction.
-    pub fn timeout(self, now: time::Now) -> Result<solution::SolverTimeout, DeadlineExceeded> {
-        solution::SolverTimeout::new(self.into(), Self::time_buffer(), now).ok_or(DeadlineExceeded)
+    pub fn timeout(self) -> Result<solution::SolverTimeout, DeadlineExceeded> {
+        solution::SolverTimeout::new(self.into(), Self::time_buffer()).ok_or(DeadlineExceeded)
     }
 
     pub fn time_buffer() -> chrono::Duration {

--- a/crates/driver/src/infra/api/mod.rs
+++ b/crates/driver/src/infra/api/mod.rs
@@ -1,7 +1,7 @@
 use {
     crate::{
         domain,
-        infra::{self, liquidity, observe, solver::Solver, time, Ethereum, Mempool, Simulator},
+        infra::{liquidity, observe, solver::Solver, Ethereum, Mempool, Simulator},
     },
     error::Error,
     futures::Future,
@@ -20,7 +20,6 @@ pub struct Api {
     pub simulator: Simulator,
     pub eth: Ethereum,
     pub mempools: Vec<Mempool>,
-    pub now: infra::time::Now,
     pub addr: SocketAddr,
     /// If this channel is specified, the bound address will be sent to it. This
     /// allows the driver to bind to 0.0.0.0:0 during testing.
@@ -63,12 +62,10 @@ impl Api {
                     eth: self.eth.clone(),
                     liquidity: self.liquidity.clone(),
                     simulator: self.simulator.clone(),
-                    now: self.now,
                     mempools: self.mempools.clone(),
                     settlement: Default::default(),
                 },
                 liquidity: self.liquidity.clone(),
-                now: self.now,
             })));
             let path = format!("/{name}");
             observe::mounting_solver(&name, &path);
@@ -103,10 +100,6 @@ impl State {
     fn liquidity(&self) -> &liquidity::Fetcher {
         &self.0.liquidity
     }
-
-    fn now(&self) -> time::Now {
-        self.0.now
-    }
 }
 
 #[derive(Debug)]
@@ -115,5 +108,4 @@ struct Inner {
     solver: Solver,
     competition: domain::Competition,
     liquidity: liquidity::Fetcher,
-    now: time::Now,
 }

--- a/crates/driver/src/infra/api/routes/quote/mod.rs
+++ b/crates/driver/src/infra/api/routes/quote/mod.rs
@@ -21,7 +21,7 @@ async fn route(
     })?;
     observe::quoting(state.solver().name(), &order);
     let quote = order
-        .quote(state.eth(), state.solver(), state.liquidity(), state.now())
+        .quote(state.eth(), state.solver(), state.liquidity())
         .await;
     observe::quoted(state.solver().name(), &order, &quote);
     Ok(axum::response::Json(dto::Quote::new(&quote?)))

--- a/crates/driver/src/infra/solver/dto/auction.rs
+++ b/crates/driver/src/infra/solver/dto/auction.rs
@@ -1,7 +1,6 @@
 use {
     crate::{
         domain::{competition, competition::order, eth, liquidity},
-        infra,
         util::serialize,
     },
     number_conversions::rational_to_big_decimal,
@@ -16,7 +15,6 @@ impl Auction {
         liquidity: &[liquidity::Liquidity],
         timeout: competition::SolverTimeout,
         weth: eth::WethAddress,
-        now: infra::time::Now,
     ) -> Self {
         let mut tokens: HashMap<eth::H160, _> = auction
             .tokens
@@ -115,7 +113,7 @@ impl Auction {
                 .collect(),
             tokens,
             effective_gas_price: auction.gas_price.effective().into(),
-            deadline: timeout.deadline(now),
+            deadline: timeout.deadline(),
         }
     }
 }

--- a/crates/driver/src/infra/solver/mod.rs
+++ b/crates/driver/src/infra/solver/mod.rs
@@ -6,7 +6,7 @@ use {
             eth,
             liquidity,
         },
-        infra::{self, blockchain::Ethereum},
+        infra::blockchain::Ethereum,
         util,
     },
     std::collections::HashSet,
@@ -57,7 +57,6 @@ pub struct Solver {
     client: reqwest::Client,
     config: Config,
     eth: Ethereum,
-    now: infra::time::Now,
 }
 
 #[derive(Debug, Clone)]
@@ -72,7 +71,7 @@ pub struct Config {
 }
 
 impl Solver {
-    pub fn new(config: Config, eth: Ethereum, now: infra::time::Now) -> Self {
+    pub fn new(config: Config, eth: Ethereum) -> Self {
         let mut headers = reqwest::header::HeaderMap::new();
         headers.insert(
             reqwest::header::CONTENT_TYPE,
@@ -87,7 +86,6 @@ impl Solver {
                 .unwrap(),
             config,
             eth,
-            now,
         }
     }
 
@@ -120,10 +118,8 @@ impl Solver {
     ) -> Result<Vec<Solution>, Error> {
         // Fetch the solutions from the solver.
         let weth = self.eth.contracts().weth_address();
-        let body = serde_json::to_string(&dto::Auction::new(
-            auction, liquidity, timeout, weth, self.now,
-        ))
-        .unwrap();
+        let body =
+            serde_json::to_string(&dto::Auction::new(auction, liquidity, timeout, weth)).unwrap();
         observe::solver_request(self.name(), &self.config.endpoint, &body);
         let req = self
             .client

--- a/crates/driver/src/infra/time.rs
+++ b/crates/driver/src/infra/time.rs
@@ -1,17 +1,13 @@
 /// The current time.
-#[derive(Debug, Clone, Copy)]
-pub enum Now {
-    /// Return the time according to this machine's clock.
-    Real,
-    /// Always return the same time. Used for testing.
-    Fake(chrono::DateTime<chrono::Utc>),
+#[cfg(not(test))]
+pub fn now() -> chrono::DateTime<chrono::Utc> {
+    chrono::Utc::now()
 }
 
-impl Now {
-    pub fn now(&self) -> chrono::DateTime<chrono::Utc> {
-        match self {
-            Self::Real => chrono::Utc::now(),
-            Self::Fake(time) => time.to_owned(),
-        }
-    }
+/// During tests, the time is fixed.
+#[cfg(test)]
+pub fn now() -> chrono::DateTime<chrono::Utc> {
+    use std::sync::OnceLock;
+    static TIME: OnceLock<chrono::DateTime<chrono::Utc>> = OnceLock::new();
+    TIME.get_or_init(chrono::Utc::now).to_owned()
 }

--- a/crates/driver/src/tests/setup/blockchain.rs
+++ b/crates/driver/src/tests/setup/blockchain.rs
@@ -2,7 +2,7 @@ use {
     super::{Asset, Order},
     crate::{
         domain::{competition::order, eth},
-        infra,
+        infra::time,
         tests::{self, boundary},
     },
     ethcontract::{dyns::DynWeb3, transport::DynTransport, Web3},
@@ -111,26 +111,22 @@ impl Quote {
     }
 
     /// The UID of the order.
-    pub fn order_uid(
-        &self,
-        blockchain: &Blockchain,
-        now: infra::time::Now,
-    ) -> tests::boundary::OrderUid {
-        self.boundary(blockchain, now).uid()
+    pub fn order_uid(&self, blockchain: &Blockchain) -> tests::boundary::OrderUid {
+        self.boundary(blockchain).uid()
     }
 
     /// The signature of the order.
-    pub fn order_signature(&self, blockchain: &Blockchain, now: infra::time::Now) -> Vec<u8> {
-        self.boundary(blockchain, now).signature()
+    pub fn order_signature(&self, blockchain: &Blockchain) -> Vec<u8> {
+        self.boundary(blockchain).signature()
     }
 
-    fn boundary(&self, blockchain: &Blockchain, now: infra::time::Now) -> tests::boundary::Order {
+    fn boundary(&self, blockchain: &Blockchain) -> tests::boundary::Order {
         tests::boundary::Order {
             sell_token: blockchain.get_token(self.order.sell_token),
             buy_token: blockchain.get_token(self.order.buy_token),
             sell_amount: self.sell_amount(),
             buy_amount: self.buy_amount(),
-            valid_to: u32::try_from(now.now().timestamp()).unwrap() + self.order.valid_for.0,
+            valid_to: u32::try_from(time::now().timestamp()).unwrap() + self.order.valid_for.0,
             user_fee: self.order.user_fee,
             side: self.order.side,
             secret_key: blockchain.trader_secret_key,

--- a/crates/driver/src/tests/setup/solver.rs
+++ b/crates/driver/src/tests/setup/solver.rs
@@ -2,7 +2,7 @@ use {
     super::{blockchain, blockchain::Blockchain},
     crate::{
         domain::competition::{auction, order},
-        infra::{self, blockchain::contracts::Addresses, Ethereum},
+        infra::{blockchain::contracts::Addresses, Ethereum},
         tests::hex_address,
     },
     itertools::Itertools,
@@ -27,7 +27,6 @@ pub struct Config<'a> {
     pub trusted: &'a HashSet<&'static str>,
     pub quotes: &'a [super::blockchain::Quote],
     pub deadline: chrono::DateTime<chrono::Utc>,
-    pub now: infra::time::Now,
     /// Is this a test for the /quote endpoint?
     pub quote: bool,
 }
@@ -51,7 +50,7 @@ impl Solver {
                 quote.order.buy_token
             };
             orders_json.push(json!({
-                "uid": if config.quote { Default::default() } else { quote.order_uid(config.blockchain, config.now) },
+                "uid": if config.quote { Default::default() } else { quote.order_uid(config.blockchain) },
                 "sellToken": hex_address(config.blockchain.get_token(sell_token)),
                 "buyToken": hex_address(config.blockchain.get_token(buy_token)),
                 "sellAmount": match quote.order.side {
@@ -117,7 +116,7 @@ impl Solver {
                 );
                 trades_json.push(json!({
                     "kind": "fulfillment",
-                    "order": if config.quote { Default::default() } else { fulfillment.quote.order_uid(config.blockchain, config.now) },
+                    "order": if config.quote { Default::default() } else { fulfillment.quote.order_uid(config.blockchain) },
                     "executedAmount":
                         match fulfillment.quote.order.executed {
                             Some(executed) => executed.to_string(),

--- a/crates/e2e/tests/e2e/setup/colocation.rs
+++ b/crates/e2e/tests/e2e/setup/colocation.rs
@@ -78,6 +78,6 @@ mempool = "public"
 
     tokio::task::spawn(async move {
         let _config_file = config_file;
-        driver::run(args.into_iter(), driver::infra::time::Now::Real, None).await;
+        driver::run(args.into_iter(), None).await;
     })
 }


### PR DESCRIPTION
Use `OnceLock` and `#[cfg]` attributes for tests instead. Makes the code a lot easier to read and alleviates the pain of having to pass the `Now` object all over the place.