### PR TITLE
Pass Custom Interactions for EIP-1271 Signature Validation

### DIFF
--- a/crates/autopilot/src/solvable_orders.rs
+++ b/crates/autopilot/src/solvable_orders.rs
@@ -316,6 +316,7 @@ async fn filter_invalid_signature_orders(
                     signer,
                     hash,
                     signature: signature.clone(),
+                    interactions: order.interactions.pre.clone(),
                 })
             }
             _ => None,
@@ -715,7 +716,17 @@ mod tests {
         futures::{FutureExt, StreamExt},
         maplit::{btreemap, hashset},
         mockall::predicate::eq,
-        model::order::{LimitOrderClass, OrderBuilder, OrderData, OrderMetadata, OrderUid},
+        model::{
+            interaction::InteractionData,
+            order::{
+                Interactions,
+                LimitOrderClass,
+                OrderBuilder,
+                OrderData,
+                OrderMetadata,
+                OrderUid,
+            },
+        },
         primitive_types::H160,
         shared::{
             bad_token::list_based::ListBasedDetector,
@@ -887,6 +898,18 @@ mod tests {
                     uid: OrderUid::from_parts(H256([1; 32]), H160([11; 20]), 1),
                     ..Default::default()
                 },
+                interactions: Interactions {
+                    pre: vec![InteractionData {
+                        target: H160([0xe1; 20]),
+                        value: U256::zero(),
+                        call_data: vec![1, 2],
+                    }],
+                    post: vec![InteractionData {
+                        target: H160([0xe2; 20]),
+                        value: U256::zero(),
+                        call_data: vec![3, 4],
+                    }],
+                },
                 ..Default::default()
             },
             Order {
@@ -895,6 +918,18 @@ mod tests {
                     ..Default::default()
                 },
                 signature: Signature::Eip1271(vec![2, 2]),
+                interactions: Interactions {
+                    pre: vec![InteractionData {
+                        target: H160([0xe3; 20]),
+                        value: U256::zero(),
+                        call_data: vec![5, 6],
+                    }],
+                    post: vec![InteractionData {
+                        target: H160([0xe4; 20]),
+                        value: U256::zero(),
+                        call_data: vec![7, 9],
+                    }],
+                },
                 ..Default::default()
             },
             Order {
@@ -930,16 +965,23 @@ mod tests {
                     signer: H160([22; 20]),
                     hash: [2; 32],
                     signature: vec![2, 2],
+                    interactions: vec![InteractionData {
+                        target: H160([0xe3; 20]),
+                        value: U256::zero(),
+                        call_data: vec![5, 6],
+                    }],
                 },
                 SignatureCheck {
                     signer: H160([44; 20]),
                     hash: [4; 32],
                     signature: vec![4, 4, 4, 4],
+                    interactions: vec![],
                 },
                 SignatureCheck {
                     signer: H160([55; 20]),
                     hash: [5; 32],
                     signature: vec![5, 5, 5, 5, 5],
+                    interactions: vec![],
                 },
             ]))
             .returning(|_| vec![Ok(()), Err(SignatureValidationError::Invalid), Ok(())]);

--- a/crates/shared/src/signature_validator.rs
+++ b/crates/shared/src/signature_validator.rs
@@ -1,21 +1,14 @@
+mod web3;
+
 use {
-    crate::{
-        ethcontract_error::EthcontractErrorType,
-        ethrpc::{Web3, MAX_BATCH_SIZE},
-    },
-    contracts::ERC1271SignatureValidator,
-    ethcontract::{
-        batch::CallBatch,
-        errors::{ExecutionError, MethodError},
-        Bytes,
-    },
-    futures::future,
+    ethcontract::Bytes,
     hex_literal::hex,
+    model::interaction::InteractionData,
     primitive_types::H160,
     thiserror::Error,
 };
 
-const TRANSACTION_INITIALIZATION_GAS_AMOUNT: u64 = 21_000u64;
+pub use self::web3::Web3SignatureValidator;
 
 /// Structure used to represent a signature.
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -23,6 +16,7 @@ pub struct SignatureCheck {
     pub signer: H160,
     pub hash: [u8; 32],
     pub signature: Vec<u8>,
+    pub interactions: Vec<InteractionData>,
 }
 
 #[derive(Debug, Error)]
@@ -40,11 +34,6 @@ pub enum SignatureValidationError {
 #[async_trait::async_trait]
 /// <https://eips.ethereum.org/EIPS/eip-1271>
 pub trait SignatureValidating: Send + Sync {
-    async fn validate_signature(
-        &self,
-        check: SignatureCheck,
-    ) -> Result<(), SignatureValidationError>;
-
     async fn validate_signatures(
         &self,
         checks: Vec<SignatureCheck>,
@@ -58,71 +47,6 @@ pub trait SignatureValidating: Send + Sync {
     ) -> Result<u64, SignatureValidationError>;
 }
 
-pub struct Web3SignatureValidator {
-    web3: Web3,
-}
-
-impl Web3SignatureValidator {
-    pub fn new(web3: Web3) -> Self {
-        Self { web3 }
-    }
-}
-
-#[async_trait::async_trait]
-impl SignatureValidating for Web3SignatureValidator {
-    async fn validate_signature(
-        &self,
-        check: SignatureCheck,
-    ) -> Result<(), SignatureValidationError> {
-        let instance = ERC1271SignatureValidator::at(&self.web3, check.signer);
-        let result = instance
-            .is_valid_signature(Bytes(check.hash), Bytes(check.signature))
-            .call()
-            .await?;
-
-        check_erc1271_result(result)
-    }
-
-    async fn validate_signatures(
-        &self,
-        checks: Vec<SignatureCheck>,
-    ) -> Vec<Result<(), SignatureValidationError>> {
-        let mut batch = CallBatch::new(self.web3.transport().clone());
-        let calls = checks
-            .into_iter()
-            .map(|check| {
-                let instance = ERC1271SignatureValidator::at(&self.web3, check.signer);
-                let call = instance
-                    .is_valid_signature(Bytes(check.hash), Bytes(check.signature))
-                    .batch_call(&mut batch);
-
-                async move { check_erc1271_result(call.await?) }
-            })
-            .collect::<Vec<_>>();
-
-        batch.execute_all(MAX_BATCH_SIZE).await;
-        future::join_all(calls).await
-    }
-
-    async fn validate_signature_and_get_additional_gas(
-        &self,
-        check: SignatureCheck,
-    ) -> Result<u64, SignatureValidationError> {
-        let instance = ERC1271SignatureValidator::at(&self.web3, check.signer);
-        let check = instance.is_valid_signature(Bytes(check.hash), Bytes(check.signature.clone()));
-
-        let (result, gas_estimate) =
-            futures::join!(check.clone().call(), check.m.tx.estimate_gas());
-
-        check_erc1271_result(result?)?;
-
-        // Adjust the estimate we receive by the fixed transaction gas cost.
-        // This is because this cost is not paid by an internal call, but by
-        // the root transaction only.
-        Ok(gas_estimate?.as_u64() - TRANSACTION_INITIALIZATION_GAS_AMOUNT)
-    }
-}
-
 /// The Magical value as defined by EIP-1271
 const MAGICAL_VALUE: [u8; 4] = hex!("1626ba7e");
 
@@ -131,26 +55,5 @@ pub fn check_erc1271_result(result: Bytes<[u8; 4]>) -> Result<(), SignatureValid
         Ok(())
     } else {
         Err(SignatureValidationError::Invalid)
-    }
-}
-
-impl From<MethodError> for SignatureValidationError {
-    fn from(err: MethodError) -> Self {
-        // Classify "contract" errors as invalid signatures instead of node
-        // errors (which may be temporary). This can happen if there is ABI
-        // compability issues or calling an EOA instead of a SC.
-        match EthcontractErrorType::classify(&err) {
-            EthcontractErrorType::Contract => Self::Invalid,
-            _ => Self::Other(err.into()),
-        }
-    }
-}
-
-impl From<ExecutionError> for SignatureValidationError {
-    fn from(err: ExecutionError) -> Self {
-        match EthcontractErrorType::classify(&err) {
-            EthcontractErrorType::Contract => Self::Invalid,
-            _ => Self::Other(err.into()),
-        }
     }
 }

--- a/crates/shared/src/signature_validator/web3.rs
+++ b/crates/shared/src/signature_validator/web3.rs
@@ -1,0 +1,103 @@
+use {
+    super::{check_erc1271_result, SignatureCheck, SignatureValidating, SignatureValidationError},
+    crate::{
+        ethcontract_error::EthcontractErrorType,
+        ethrpc::{Web3, MAX_BATCH_SIZE},
+    },
+    contracts::ERC1271SignatureValidator,
+    ethcontract::{
+        batch::CallBatch,
+        errors::{ExecutionError, MethodError},
+        Bytes,
+    },
+    futures::future,
+};
+
+const TRANSACTION_INITIALIZATION_GAS_AMOUNT: u64 = 21_000u64;
+
+pub struct Web3SignatureValidator {
+    web3: Web3,
+}
+
+impl Web3SignatureValidator {
+    pub fn new(web3: Web3) -> Self {
+        Self { web3 }
+    }
+}
+
+#[async_trait::async_trait]
+impl SignatureValidating for Web3SignatureValidator {
+    async fn validate_signatures(
+        &self,
+        checks: Vec<SignatureCheck>,
+    ) -> Vec<Result<(), SignatureValidationError>> {
+        let mut batch = CallBatch::new(self.web3.transport().clone());
+        let calls = checks
+            .into_iter()
+            .map(|check| {
+                if !check.interactions.is_empty() {
+                    tracing::warn!(
+                        ?check,
+                        "verifying ERC-1271 signatures with interactions is not fully supported"
+                    );
+                }
+
+                let instance = ERC1271SignatureValidator::at(&self.web3, check.signer);
+                let call = instance
+                    .is_valid_signature(Bytes(check.hash), Bytes(check.signature))
+                    .batch_call(&mut batch);
+
+                async move { check_erc1271_result(call.await?) }
+            })
+            .collect::<Vec<_>>();
+
+        batch.execute_all(MAX_BATCH_SIZE).await;
+        future::join_all(calls).await
+    }
+
+    async fn validate_signature_and_get_additional_gas(
+        &self,
+        check: SignatureCheck,
+    ) -> Result<u64, SignatureValidationError> {
+        if !check.interactions.is_empty() {
+            tracing::warn!(
+                ?check,
+                "verifying ERC-1271 signatures with interactions is not fully supported"
+            );
+        }
+
+        let instance = ERC1271SignatureValidator::at(&self.web3, check.signer);
+        let check = instance.is_valid_signature(Bytes(check.hash), Bytes(check.signature.clone()));
+
+        let (result, gas_estimate) =
+            futures::join!(check.clone().call(), check.m.tx.estimate_gas());
+
+        check_erc1271_result(result?)?;
+
+        // Adjust the estimate we receive by the fixed transaction gas cost.
+        // This is because this cost is not paid by an internal call, but by
+        // the root transaction only.
+        Ok(gas_estimate?.as_u64() - TRANSACTION_INITIALIZATION_GAS_AMOUNT)
+    }
+}
+
+impl From<MethodError> for SignatureValidationError {
+    fn from(err: MethodError) -> Self {
+        // Classify "contract" errors as invalid signatures instead of node
+        // errors (which may be temporary). This can happen if there is ABI
+        // compability issues or calling an EOA instead of a SC.
+        match EthcontractErrorType::classify(&err) {
+            EthcontractErrorType::Contract => Self::Invalid,
+            _ => Self::Other(err.into()),
+        }
+    }
+}
+
+impl From<ExecutionError> for SignatureValidationError {
+    fn from(err: ExecutionError) -> Self {
+        match EthcontractErrorType::classify(&err) {
+            EthcontractErrorType::Contract => Self::Invalid,
+            _ => Self::Other(err.into()),
+        }
+    }
+}


### PR DESCRIPTION
This PR starts implementing #1599,

Specifically, it adds an `interactions` key to the checks done by the signature validator component, which will be needed for considering ERC-1271 signatures that become valid from a pre-interaction (for example, a JIT Composable CoW order creation transaction). 

I also removed the `SignatureValidating::validate_signature` method as it was not used anywhere.

### Test Plan

Unit tests verify new logic.
