### PR TITLE
Add receiver to order model

### DIFF
--- a/crates/shared/src/http_solver/model.rs
+++ b/crates/shared/src/http_solver/model.rs
@@ -43,6 +43,7 @@ pub struct OrderModel {
     pub fee: TokenAmount,
     pub cost: TokenAmount,
     pub is_liquidity_order: bool,
+    pub receiver: H160,
     /// [DEPRECATED] All orders are always mature
     pub is_mature: bool,
     #[serde(default)]
@@ -527,6 +528,7 @@ mod tests {
         let native_token = H160([0xee; 20]);
         let buy_token = H160::from_low_u64_be(1337);
         let sell_token = H160::from_low_u64_be(43110);
+        let receiver = H160::from_low_u64_be(4369);
         let order_model = OrderModel {
             id: Some(OrderUid::default()),
             sell_token,
@@ -534,6 +536,7 @@ mod tests {
             sell_amount: U256::from(1),
             buy_amount: U256::from(2),
             allow_partial_fill: false,
+            receiver,
             is_sell_order: true,
             fee: TokenAmount {
                 amount: U256::from(2),
@@ -697,6 +700,7 @@ mod tests {
                 "token": "0x000000000000000000000000000000000000a866",
               },
               "is_liquidity_order": false,
+              "receiver": "0x0000000000000000000000000000000000001111",
               "cost": {
                 "amount": "1",
                 "token": "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",

--- a/crates/shared/src/price_estimation/http.rs
+++ b/crates/shared/src/price_estimation/http.rs
@@ -133,6 +133,7 @@ impl HttpPriceEstimator {
                 has_atomic_execution: false,
                 reward: 0., // irrelevant for price estimation
                 is_mature: true, // irrelevant for price estimation
+                receiver: Default::default(), // could be relevant if we send more than one order at once for estimation
             },
         };
 

--- a/crates/solver/src/liquidity.rs
+++ b/crates/solver/src/liquidity.rs
@@ -179,6 +179,7 @@ pub struct LimitOrder {
     pub buy_amount: U256,
     pub kind: OrderKind,
     pub partially_fillable: bool,
+    pub receiver: H160,
     /// The fee that should be used for objective value computations.
     /// Takes partiall fill into account.
     pub solver_fee: U256,
@@ -262,6 +263,7 @@ impl Default for LimitOrder {
             buy_amount: Default::default(),
             kind: Default::default(),
             partially_fillable: Default::default(),
+            receiver: Default::default(),
             solver_fee: Default::default(),
             settlement_handling: tests::CapturingSettlementHandler::arc(),
             id: Default::default(),

--- a/crates/solver/src/liquidity/order_converter.rs
+++ b/crates/solver/src/liquidity/order_converter.rs
@@ -16,6 +16,7 @@ use {
     contracts::WETH9,
     ethcontract::U256,
     model::order::{LimitOrderClass, Order, OrderClass, BUY_ETH_ADDRESS},
+    primitive_types::H160,
     std::sync::Arc,
 };
 
@@ -80,6 +81,8 @@ impl OrderConverter {
             "order with 0 amounts",
         );
 
+        let receiver = order.data.receiver.unwrap_or_else(H160::zero);
+
         Ok(LimitOrder {
             id,
             sell_token: order.data.sell_token,
@@ -88,6 +91,7 @@ impl OrderConverter {
             buy_amount,
             kind: order.data.kind,
             partially_fillable: order.data.partially_fillable,
+            receiver,
             solver_fee,
             settlement_handling: Arc::new(OrderSettlementHandler {
                 order,

--- a/crates/solver/src/liquidity/zeroex.rs
+++ b/crates/solver/src/liquidity/zeroex.rs
@@ -67,6 +67,7 @@ impl ZeroExLiquidity {
             buy_amount: record.metadata.remaining_fillable_taker_amount.into(),
             kind: OrderKind::Buy,
             partially_fillable: true,
+            receiver: record.order.sender,
             solver_fee: U256::zero(),
             settlement_handling: Arc::new(OrderSettlementHandler {
                 order: record.order,

--- a/crates/solver/src/solver/http_solver/instance_creation.rs
+++ b/crates/solver/src/solver/http_solver/instance_creation.rs
@@ -266,6 +266,7 @@ fn order_models(
                     },
                     cost,
                     is_liquidity_order: order.is_liquidity_order(),
+                    receiver: order.receiver,
                     mandatory: false,
                     has_atomic_execution: !matches!(order.exchange, Exchange::GnosisProtocol),
                     reward: 0.,

--- a/crates/solvers/src/boundary/legacy.rs
+++ b/crates/solvers/src/boundary/legacy.rs
@@ -177,6 +177,7 @@ fn to_boundary_auction(
                 mandatory: auction.id.is_none(),
                 has_atomic_execution: false,
                 reward: 0.,
+                receiver: H160::zero(),
             },
         );
     }
@@ -302,6 +303,7 @@ fn to_boundary_auction(
                         mandatory: false,
                         has_atomic_execution: true,
                         reward: 0.,
+                        receiver: H160::zero(),
                     },
                 );
                 continue;

--- a/crates/solvers/src/boundary/naive.rs
+++ b/crates/solvers/src/boundary/naive.rs
@@ -107,6 +107,7 @@ pub fn solve(
                 },
             }),
             exchange: Exchange::GnosisProtocol,
+            receiver: H160::zero(),
         })
         .collect_vec();
 

--- a/crates/solvers/src/tests/legacy/market_order.rs
+++ b/crates/solvers/src/tests/legacy/market_order.rs
@@ -62,6 +62,7 @@ async fn quote() {
                     // Mandatory is true when request contains no auction id because that marks a
                     // /quote request.
                     "mandatory": true,
+                    "receiver": "0x0000000000000000000000000000000000000000",
                     "reward": 0.,
                     "sell_amount": "133700000000000000",
                     "sell_token": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"
@@ -262,6 +263,7 @@ async fn solve() {
                     "is_mature": true,
                     "is_sell_order": true,
                     "mandatory": false,
+                    "receiver": "0x0000000000000000000000000000000000000000",
                     "reward": 0.,
                     "sell_amount": "133700000000000000",
                     "sell_token": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"


### PR DESCRIPTION
This adds the receiver address to the `OrderModel` which is sent to solvers. This will allow solvers to combine outputs which go to the same receiver address.