### PR TITLE
API endpoint for total surplus

### DIFF
--- a/crates/orderbook/src/api.rs
+++ b/crates/orderbook/src/api.rs
@@ -6,6 +6,7 @@ mod get_native_price;
 mod get_order_by_uid;
 mod get_orders_by_tx;
 mod get_solver_competition;
+mod get_total_surplus;
 mod get_trades;
 mod get_user_orders;
 mod post_order;
@@ -91,6 +92,7 @@ pub fn handle_all_routes(
             box_filter(get_native_price::get_native_price(native_price_estimator)),
         ),
         ("v1/get_app_data", get_app_data::get(database).boxed()),
+        ("v1/get_total_surplus", box_filter(get_total_surplus::get())),
     ];
 
     finalize_router(routes, "orderbook::api::request_summary")

--- a/crates/orderbook/src/api/get_total_surplus.rs
+++ b/crates/orderbook/src/api/get_total_surplus.rs
@@ -1,0 +1,22 @@
+use {
+    primitive_types::H160,
+    serde_json::json,
+    std::convert::Infallible,
+    warp::{http::StatusCode, reply::with_status, Filter, Rejection},
+};
+
+// TODO This endpoint is not documented for now because we don't want to
+// stabilize it quite yet. Once we're sure this is what we want, we should add
+// it to the openapi spec.
+pub fn get() -> impl Filter<Extract = (super::ApiReply,), Error = Rejection> + Clone {
+    warp::path!("v1" / "users" / H160 / "total_surplus")
+        .and(warp::get())
+        .and_then(move |_| async {
+            Result::<_, Infallible>::Ok(with_status(
+                warp::reply::json(&json!({
+                    "totalSurplus": 42_133_700_000_000_000_000_u128.to_string(),
+                })),
+                StatusCode::OK,
+            ))
+        })
+}


### PR DESCRIPTION
Implement API endpoint to calculate total surplus.

### Test Plan

Tried to test manually but for some reason I get this error:
```
2023-06-26T14:56:32.229Z ERROR shared::tracing: thread 'main' panicked at 'error innitializing Uniswap V3 pool fetcher: error
 sending request for url (https://api.thegraph.com/subgraphs/name/uniswap/uniswap-v3): operation timed out
```
It seems like this API is down at the moment?