### PR TITLE
Implement total surplus query

### DIFF
--- a/crates/orderbook/src/api.rs
+++ b/crates/orderbook/src/api.rs
@@ -91,8 +91,14 @@ pub fn handle_all_routes(
             "v1/get_native_price",
             box_filter(get_native_price::get_native_price(native_price_estimator)),
         ),
-        ("v1/get_app_data", get_app_data::get(database).boxed()),
-        ("v1/get_total_surplus", box_filter(get_total_surplus::get())),
+        (
+            "v1/get_app_data",
+            get_app_data::get(database.clone()).boxed(),
+        ),
+        (
+            "v1/get_total_surplus",
+            box_filter(get_total_surplus::get(database)),
+        ),
     ];
 
     finalize_router(routes, "orderbook::api::request_summary")

--- a/crates/orderbook/src/database.rs
+++ b/crates/orderbook/src/database.rs
@@ -3,6 +3,7 @@ pub mod auctions;
 pub mod orders;
 pub mod quotes;
 pub mod solver_competition;
+pub mod total_surplus;
 pub mod trades;
 
 use {anyhow::Result, sqlx::PgPool};

--- a/crates/orderbook/src/database/total_surplus.rs
+++ b/crates/orderbook/src/database/total_surplus.rs
@@ -10,10 +10,10 @@ use {
 async fn fetch_total_surplus(ex: &mut PgConnection, user: &Address) -> Result<f64, sqlx::Error> {
     const TOTAL_SURPLUS_QUERY: &str = r#"
 WITH regular_orders AS (
-    SELECT ARRAY_AGG(uid) AS ids FROM orders WHERE owner = '\x5fc79e21ceca2aa0f7a0aac71ef3ddde8f004e9e'
+    SELECT ARRAY_AGG(uid) AS ids FROM orders WHERE owner = $1
 ),
 onchain_orders AS (
-    SELECT ARRAY_AGG(uid) AS ids FROM onchain_placed_orders WHERE sender = '\x5fc79e21ceca2aa0f7a0aac71ef3ddde8f004e9e'
+    SELECT ARRAY_AGG(uid) AS ids FROM onchain_placed_orders WHERE sender = $1
 ),
 trade_components AS (
     SELECT

--- a/crates/orderbook/src/database/total_surplus.rs
+++ b/crates/orderbook/src/database/total_surplus.rs
@@ -36,7 +36,7 @@ trade_components AS (
     JOIN trades t ON o.uid = t.order_uid
     JOIN order_execution oe ON o.uid = oe.order_uid
     -- use this weird construction instead of `where owner=address or sender=address` to help postgres make efficient use of indices
-    where uid = ANY(array_cat((select ids from regular_orders), (select ids from onchain_orders)))
+    WHERE uid = ANY(ARRAY_CAT((SELECT ids FROM regular_orders), (SELECT ids FROM onchain_orders)))
 ),
 trade_surplus AS (
     SELECT

--- a/crates/orderbook/src/database/total_surplus.rs
+++ b/crates/orderbook/src/database/total_surplus.rs
@@ -9,47 +9,46 @@ use {
 /// and **NOT** quoted price) since march 2023.
 async fn fetch_total_surplus(ex: &mut PgConnection, user: &Address) -> Result<f64, sqlx::Error> {
     const TOTAL_SURPLUS_QUERY: &str = r#"
-with trade_components as (
-    select
-       case kind
+WITH trade_components AS (
+    SELECT
+       CASE kind
           -- so much was actually bought
-          when 'sell' then t.buy_amount
+          WHEN 'sell' THEN t.buy_amount
           -- so much was actually converted to buy tokens
-          when 'buy' then t.sell_amount - t.fee_amount
-       end as trade_amount,
-       case kind
+          WHEN 'buy' THEN t.sell_amount - t.fee_amount
+       END AS trade_amount,
+       CASE kind
           -- so much had to be bought at least (given exeucted amount and limit price)
-          when 'sell' then (t.sell_amount - t.fee_amount) * o.buy_amount / o.sell_amount
+          WHEN 'sell' THEN (t.sell_amount - t.fee_amount) * o.buy_amount / o.sell_amount
           -- so much could be converted to buy_token at most (given executed amount and limit price)
-          when 'buy' then t.buy_amount * o.sell_amount / o.buy_amount
-       end as limit_amount,
+          WHEN 'buy' THEN t.buy_amount * o.sell_amount / o.buy_amount
+       END AS limit_amount,
        o.kind,
-       (select price from auction_prices ap where ap.token = o.sell_token and ap.auction_id = oe.auction_id) as native_sell_price,
-       (select price from auction_prices ap where ap.token = o.buy_token and ap.auction_id = oe.auction_id) as native_buy_price
-    from orders o
-    join trades t on o.uid = t.order_uid
-    join order_quotes oq on o.uid = oq.order_uid
-    left join onchain_placed_orders opo on opo.uid = o.uid
-    join order_execution oe on o.uid = oe.order_uid
-    where
+       (SELECT price FROM auction_prices ap WHERE ap.token = o.sell_token AND ap.auction_id = oe.auction_id) AS native_sell_price,
+       (SELECT price FROM auction_prices ap WHERE ap.token = o.buy_token AND ap.auction_id = oe.auction_id) AS native_buy_price
+    FROM orders o
+    JOIN trades t ON o.uid = t.order_uid
+    LEFT JOIN onchain_placed_orders opo ON opo.uid = o.uid
+    JOIN order_execution oe ON o.uid = oe.order_uid
+    WHERE
         o.owner = $1
         or opo.sender = $1
 ),
-trade_surplus as (
-    select
-        case kind
+trade_surplus AS (
+    SELECT
+        CASE kind
             -- amounts refer to tokens bought; more is better
-            when 'sell' then (trade_amount - limit_amount) * native_buy_price
+            WHEN 'sell' THEN (trade_amount - limit_amount) * native_buy_price
             -- amounts refer to tokens sold; less is better
-            when 'buy' then (limit_amount - trade_amount) * native_sell_price
-        end / power(10, 18) as surplus_in_wei,
+            WHEN 'buy' THEN (limit_amount - trade_amount) * native_sell_price
+        END / POWER(10, 18) AS surplus_in_wei,
         limit_amount,
         trade_amount
-    from trade_components
+    FROM trade_components
 )
-select
-   sum(surplus_in_wei) as total_surplus_in_wei
-from trade_surplus
+SELECT
+   SUM(surplus_in_wei) AS total_surplus_in_wei
+FROM trade_surplus
 "#;
 
     sqlx::query_scalar(TOTAL_SURPLUS_QUERY)

--- a/crates/orderbook/src/database/total_surplus.rs
+++ b/crates/orderbook/src/database/total_surplus.rs
@@ -1,0 +1,72 @@
+use {
+    anyhow::{Context, Result},
+    database::{byte_array::ByteArray, Address},
+    primitive_types::{H160, U256},
+    sqlx::PgConnection,
+};
+
+/// Computes a user's total surplus received (price improvement over limit price
+/// and **NOT** quoted price) since march 2023.
+async fn fetch_total_surplus(ex: &mut PgConnection, user: &Address) -> Result<i64, sqlx::Error> {
+    const TOTAL_SURPLUS_QUERY: &str = r#"
+with trade_components as (
+    select
+       case kind
+          -- so much was actually bought
+          when 'sell' then t.buy_amount
+          -- so much was actually converted to buy tokens
+          when 'buy' then t.sell_amount - t.fee_amount
+       end as trade_amount,
+       case kind
+          -- so much had to be bought at least (given exeucted amount and limit price)
+          when 'sell' then (t.sell_amount - t.fee_amount) * o.buy_amount / o.sell_amount
+          -- so much could be converted to buy_token at most (given executed amount and limit price)
+          when 'buy' then t.buy_amount * o.sell_amount / o.buy_amount
+       end as limit_amount,
+       o.kind,
+       (select price from auction_prices where ap.token = o.sell_token and ap.auction_id = oe.auction_id) as native_sell_price,
+       (select price from auction_prices where ap.token = o.buy_token and ap.auction_id = oe.auction_id) as native_buy_price
+    from orders o
+    join trades t on o.uid = t.order_uid
+    join order_quotes oq on o.uid = oq.order_uid
+    left join onchain_placed_orders opo on opo.uid = o.uid
+    join order_execution oe on o.uid = oe.order_uid
+    where
+        o.owner = $1
+        or opo.sender = $1
+),
+trade_surplus as (
+    select
+        case kind
+            -- amounts refer to tokens bought; more is better
+            when 'sell' then (trade_amount - limit_amount) * native_buy_price
+            -- amounts refer to tokens sold; less is better
+            when 'buy' then (limit_amount - trade_amount) * native_sell_price
+        end / power(10, 18) as surplus_in_wei,
+        limit_amount,
+        trade_amount
+    from trade_components
+)
+select
+   sum(surplus_in_wei) as total_surplus_in_wei
+from trade_surplus
+"#;
+
+    sqlx::query_scalar(TOTAL_SURPLUS_QUERY)
+        .bind(user)
+        .fetch_one(ex)
+        .await
+}
+
+impl super::Postgres {
+    pub async fn total_surplus(&self, user: &H160) -> Result<U256> {
+        let _timer = super::Metrics::get()
+            .database_queries
+            .with_label_values(&["get_total_surplus"])
+            .start_timer();
+
+        let mut ex = self.pool.acquire().await?;
+        let surplus = fetch_total_surplus(&mut ex, &ByteArray(user.0)).await?;
+        U256::try_from(surplus).context("failed to convert surplus to U256")
+    }
+}


### PR DESCRIPTION
Adds the actual query to compute the total surplus of a user (since march 2023) for the hackathon project.

Currently only tested manually by comparing the surplus % to what the explorer shows for a given order and doing a request with `curl`.
To unblock the remaining hackathon team I want to merge this PR quickly and deliver tests in a follow up PR.
```
time curl http://localhost:8080/api/v1/users/0x5fc79e21ceca2aa0f7a0aac71ef3ddde8f004e9e/total_surplus
{"totalSurplus":"4202924650702963200"}
curl   0.00s user 0.01s system 2% cpu 0.349 total
```