### PR TITLE
Update Blockscout url

### DIFF
--- a/crates/shared/src/bad_token/token_owner_finder/blockscout.rs
+++ b/crates/shared/src/bad_token/token_owner_finder/blockscout.rs
@@ -9,8 +9,6 @@ use {
     serde::Deserialize,
 };
 
-const BASE: &str = "https://blockscout.com/";
-
 pub struct BlockscoutTokenOwnerFinder {
     client: Client,
     base: Url,
@@ -19,18 +17,15 @@ pub struct BlockscoutTokenOwnerFinder {
 
 impl BlockscoutTokenOwnerFinder {
     pub fn try_with_network(client: Client, network_id: u64) -> Result<Self> {
-        let network = match network_id {
-            1 => "eth/",
-            100 => "xdai/",
+        let base_url = match network_id {
+            1 => "https://eth.blockscout.com/api",
+            100 => "https://blockscout.com/xdai/mainnet/api",
             _ => bail!("Unsupported Network"),
         };
 
         Ok(Self {
             client,
-            base: crate::url::join(
-                &Url::parse(BASE).unwrap(),
-                &format!("{network}/mainnet/api"),
-            ),
+            base: Url::parse(base_url)?,
             rate_limiter: None,
         })
     }


### PR DESCRIPTION
Fixes the blockscout errors that we currently see in our stack.

The mainnet API is no longer at `https://blockscout.com/eth/mainnet/` and has permanently moved to `https://eth.blockscout.com/api`. The xdai endpoint is getting an extra `/` at the end due to a recent change (#1606) in the way we handle URL strings.

We see these errors in our logs
![image](https://github.com/cowprotocol/services/assets/7795956/c6bb315d-0e48-4c8d-a0e0-d2eefc870d34)


### Test Plan

Did manual tests by calling both xdai and mainnet paths.

```
https://blockscout.com/xdai/mainnet/api?module=token&action=getTokenHolders&contractaddress=0xd152bb8f047fec087b0f961739d4391574228fe2

https://eth.blockscout.com/api?module=token&action=getTokenHolders&contractaddress=0x5b685863494c33f344081f75e5430c260c224a32
```

### Release notes

Update Blockscout URL's for mainnet and xdai
