### PR TITLE
`driver`: return calldata in response of `/settle`

### DIFF
--- a/crates/autopilot/src/driver_api.rs
+++ b/crates/autopilot/src/driver_api.rs
@@ -1,5 +1,5 @@
 use {
-    crate::driver_model::{execute, solve},
+    crate::driver_model::{settle, solve},
     anyhow::{anyhow, Context, Result},
     reqwest::Client,
     shared::http_client::response_body_with_size_limit,
@@ -30,12 +30,11 @@ impl Driver {
         self.request_response("solve", Some(request)).await
     }
 
-    pub async fn execute(
+    pub async fn settle(
         &self,
         solution_id: &str,
-        _request: &execute::Request,
-    ) -> Result<execute::Response> {
-        // TODO: should be execute
+        _request: &settle::Request,
+    ) -> Result<settle::Response> {
         self.request_response(&format!("settle/{solution_id}"), Option::<&()>::None)
             .await
     }

--- a/crates/autopilot/src/driver_model.rs
+++ b/crates/autopilot/src/driver_model.rs
@@ -131,7 +131,7 @@ pub mod solve {
     }
 }
 
-pub mod execute {
+pub mod settle {
     use {
         derivative::Derivative,
         model::{bytes_hex, order::OrderUid, u256_decimal},
@@ -155,15 +155,17 @@ pub mod execute {
     #[derive(Clone, Debug, Default, Deserialize)]
     #[serde(rename_all = "camelCase", deny_unknown_fields)]
     pub struct Response {
-        pub account: H160,
-        pub nonce: u64,
-        #[serde_as(as = "BTreeMap<_, DisplayFromStr>")]
-        pub clearing_prices: BTreeMap<H160, U256>,
-        pub trades: Vec<Trade>,
-        pub internalized_interactions: Vec<InternalizedInteraction>,
+        pub calldata: Calldata,
+    }
+
+    #[serde_as]
+    #[derive(Clone, Debug, Default, Deserialize)]
+    #[serde(rename_all = "camelCase", deny_unknown_fields)]
+    pub struct Calldata {
         #[serde(with = "bytes_hex")]
-        pub calldata: Vec<u8>,
-        pub signature: String,
+        pub internalized: Vec<u8>,
+        #[serde(with = "bytes_hex")]
+        pub uninternalized: Vec<u8>,
     }
 
     #[derive(Clone, Debug, Default, Deserialize)]

--- a/crates/autopilot/src/run_loop.rs
+++ b/crates/autopilot/src/run_loop.rs
@@ -6,7 +6,7 @@ use {
         },
         driver_api::Driver,
         driver_model::{
-            execute,
+            settle,
             solve::{self, Class},
         },
         solvable_orders::SolvableOrdersCache,
@@ -301,12 +301,12 @@ impl RunLoop {
         driver: &Driver,
         solution: &solve::Response,
     ) -> Result<()> {
-        let request = execute::Request {
+        let request = settle::Request {
             auction_id: id,
             transaction_identifier: id.to_be_bytes().into(),
         };
         let _response = driver
-            .execute(&solution.id, &request)
+            .settle(&solution.id, &request)
             .await
             .context("execute")?;
         // TODO: React to deadline expiring.

--- a/crates/driver/src/domain/competition/solution/settlement.rs
+++ b/crates/driver/src/domain/competition/solution/settlement.rs
@@ -247,13 +247,16 @@ impl Settlement {
         Ok((access_list, gas))
     }
 
-    /// The onchain transaction representing this settlement.
-    pub fn tx(
+    /// The calldata for this settlement.
+    pub fn calldata(
         &self,
         contract: &contracts::GPv2Settlement,
         internalization: Internalization,
-    ) -> eth::Tx {
-        self.boundary.tx(self.id, contract, internalization)
+    ) -> Vec<u8> {
+        self.boundary
+            .tx(self.id, contract, internalization)
+            .input
+            .into()
     }
 
     // TODO(#1494): score() should be defined on Solution rather than Settlement.

--- a/crates/driver/src/infra/api/routes/settle.rs
+++ b/crates/driver/src/infra/api/routes/settle.rs
@@ -1,6 +1,14 @@
-use crate::infra::{
-    api::{Error, State},
-    observe,
+use {
+    crate::{
+        domain::competition,
+        infra::{
+            api::{Error, State},
+            observe,
+        },
+        util::serialize,
+    },
+    serde::Serialize,
+    serde_with::serde_as,
 };
 
 pub(in crate::infra::api) fn settle(router: axum::Router<State>) -> axum::Router<State> {
@@ -10,11 +18,40 @@ pub(in crate::infra::api) fn settle(router: axum::Router<State>) -> axum::Router
 async fn route(
     state: axum::extract::State<State>,
     axum::extract::Path(solution_id): axum::extract::Path<u64>,
-) -> Result<(), (hyper::StatusCode, axum::Json<Error>)> {
+) -> Result<axum::Json<Calldata>, (hyper::StatusCode, axum::Json<Error>)> {
     let competition = state.competition();
     let solution_id = solution_id.into();
     observe::settling(state.solver().name(), solution_id);
     let result = competition.settle(solution_id).await;
     observe::settled(state.solver().name(), solution_id, &result);
-    result.map_err(Into::into)
+    let calldata = result?;
+    Ok(axum::Json(Calldata::new(calldata)))
+}
+
+#[serde_as]
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct Calldata {
+    calldata: CalldataInner,
+}
+
+#[serde_as]
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct CalldataInner {
+    #[serde_as(as = "serialize::Hex")]
+    internalized: Vec<u8>,
+    #[serde_as(as = "serialize::Hex")]
+    uninternalized: Vec<u8>,
+}
+
+impl Calldata {
+    pub fn new(calldata: competition::Calldata) -> Self {
+        Self {
+            calldata: CalldataInner {
+                internalized: calldata.internalized.into(),
+                uninternalized: calldata.uninternalized.into(),
+            },
+        }
+    }
 }

--- a/crates/driver/src/infra/mempool/mod.rs
+++ b/crates/driver/src/infra/mempool/mod.rs
@@ -12,7 +12,7 @@ pub use crate::boundary::mempool::{Config, GlobalTxPool, HighRisk, Kind, Mempool
 pub async fn execute(
     mempools: &[Mempool],
     solver: &Solver,
-    settlement: Settlement,
+    settlement: &Settlement,
 ) -> Result<(), Error> {
     if mempools.is_empty() {
         return Err(Error::AllMempoolsFailed);

--- a/crates/driver/src/infra/observe/mod.rs
+++ b/crates/driver/src/infra/observe/mod.rs
@@ -143,10 +143,14 @@ pub fn settling(solver: &solver::Name, id: settlement::Id) {
 }
 
 /// Observe the result of the settlement process.
-pub fn settled(solver: &solver::Name, id: settlement::Id, result: &Result<(), competition::Error>) {
+pub fn settled(
+    solver: &solver::Name,
+    id: settlement::Id,
+    result: &Result<competition::Calldata, competition::Error>,
+) {
     match result {
-        Ok(()) => {
-            tracing::info!(%solver, ?id, "settled");
+        Ok(calldata) => {
+            tracing::info!(%solver, ?id, ?calldata, "settled");
             metrics::get()
                 .settlements
                 .with_label_values(&[solver.as_str(), "Success"])


### PR DESCRIPTION
Fixes #1632.

Return the internalized and uninternalized calldata in the `/settle` response body.

### Test Plan

Updated automated tests.