### PR TITLE
Uniform Caching of 1Inch Spender

### DIFF
--- a/crates/autopilot/src/solvable_orders.rs
+++ b/crates/autopilot/src/solvable_orders.rs
@@ -422,10 +422,8 @@ fn filter_dust_orders(
             return false;
         };
 
-        let Ok(remaining) = remaining_amounts::Remaining::from_order_with_balance(
-            order,
-            balance
-        ) else {
+        let Ok(remaining) = remaining_amounts::Remaining::from_order_with_balance(order, balance)
+        else {
             return false;
         };
 

--- a/crates/e2e/tests/e2e/eth_flow.rs
+++ b/crates/e2e/tests/e2e/eth_flow.rs
@@ -215,7 +215,8 @@ async fn test_submit_quote(
             model::quote::SellAmount::AfterFee {
                 value: sell_amount_after_fees,
             },
-    } = quote.side else {
+    } = quote.side
+    else {
         panic!("untested!");
     };
 

--- a/crates/shared/src/arguments.rs
+++ b/crates/shared/src/arguments.rs
@@ -261,7 +261,7 @@ pub struct Arguments {
     pub disabled_one_inch_protocols: Vec<String>,
 
     /// The 1Inch REST API URL to use.
-    #[structopt(long, env, default_value = "https://api.1inch.exchange/")]
+    #[structopt(long, env, default_value = "https://api.1inch.io/")]
     pub one_inch_url: Url,
 
     /// Which address should receive the rewards for referring trades to 1Inch.

--- a/crates/shared/src/oneinch_api.rs
+++ b/crates/shared/src/oneinch_api.rs
@@ -491,7 +491,7 @@ pub struct OneInchClientImpl {
 }
 
 impl OneInchClientImpl {
-    pub const DEFAULT_URL: &'static str = "https://api.1inch.exchange/";
+    pub const DEFAULT_URL: &'static str = "https://api.1inch.io/";
     // 1: mainnet, 100: gnosis chain
     pub const SUPPORTED_CHAINS: &'static [u64] = &[1, 100];
 
@@ -696,7 +696,7 @@ mod tests {
 
     #[test]
     fn swap_query_serialization() {
-        let base_url = Url::parse("https://api.1inch.exchange/").unwrap();
+        let base_url = Url::parse("https://api.1inch.io/").unwrap();
         let url = SwapQuery {
             from_address: addr!("00000000219ab540356cBB839Cbe05303d7705Fa"),
             slippage: Slippage::percentage(0.5).unwrap(),
@@ -723,7 +723,7 @@ mod tests {
 
         assert_eq!(
             url.as_str(),
-            "https://api.1inch.exchange/v5.0/1/swap\
+            "https://api.1inch.io/v5.0/1/swap\
                 ?fromTokenAddress=0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee\
                 &toTokenAddress=0x111111111117dc0aa78b770fa6a738034120c302\
                 &amount=1000000000000000000\
@@ -734,7 +734,7 @@ mod tests {
 
     #[test]
     fn swap_query_serialization_options_parameters() {
-        let base_url = Url::parse("https://api.1inch.exchange/").unwrap();
+        let base_url = Url::parse("https://api.1inch.io/").unwrap();
         let url = SwapQuery {
             from_address: addr!("00000000219ab540356cBB839Cbe05303d7705Fa"),
             slippage: Slippage::percentage(0.5).unwrap(),
@@ -764,7 +764,7 @@ mod tests {
 
         assert_eq!(
             url.as_str(),
-            "https://api.1inch.exchange/v5.0/1/swap\
+            "https://api.1inch.io/v5.0/1/swap\
                 ?fromTokenAddress=0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee\
                 &toTokenAddress=0x111111111117dc0aa78b770fa6a738034120c302\
                 &amount=1000000000000000000\
@@ -796,14 +796,14 @@ mod tests {
                 "name": "Ethereum",
                 "decimals": 18,
                 "address": "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
-                "logoURI": "https://tokens.1inch.exchange/0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee.png"
+                "logoURI": "https://tokens.1inch.io/0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee.png"
               },
               "toToken": {
                 "symbol": "1INCH",
                 "name": "1INCH Token",
                 "decimals": 18,
                 "address": "0x111111111117dc0aa78b770fa6a738034120c302",
-                "logoURI": "https://tokens.1inch.exchange/0x111111111117dc0aa78b770fa6a738034120c302.png"
+                "logoURI": "https://tokens.1inch.io/0x111111111117dc0aa78b770fa6a738034120c302.png"
               },
               "toTokenAmount": "501739725821378713485",
               "fromTokenAmount": "1000000000000000000",
@@ -999,7 +999,7 @@ mod tests {
 
     #[test]
     fn sell_order_quote_query_serialization() {
-        let base_url = Url::parse("https://api.1inch.exchange/").unwrap();
+        let base_url = Url::parse("https://api.1inch.io/").unwrap();
         let url = SellOrderQuoteQuery {
             from_token_address: addr!("EeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE"),
             to_token_address: addr!("111111111117dc0aa78b770fa6a738034120c302"),
@@ -1018,7 +1018,7 @@ mod tests {
 
         assert_eq!(
             url.as_str(),
-            "https://api.1inch.exchange/v5.0/1/quote\
+            "https://api.1inch.io/v5.0/1/quote\
                 ?fromTokenAddress=0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee\
                 &toTokenAddress=0x111111111117dc0aa78b770fa6a738034120c302\
                 &amount=1000000000000000000"
@@ -1027,7 +1027,7 @@ mod tests {
 
     #[test]
     fn sell_order_quote_query_serialization_optional_parameters() {
-        let base_url = Url::parse("https://api.1inch.exchange/").unwrap();
+        let base_url = Url::parse("https://api.1inch.io/").unwrap();
         let url = SellOrderQuoteQuery {
             from_token_address: addr!("EeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE"),
             to_token_address: addr!("111111111117dc0aa78b770fa6a738034120c302"),
@@ -1049,7 +1049,7 @@ mod tests {
 
         assert_eq!(
             url.as_str(),
-            "https://api.1inch.exchange/v5.0/1/quote\
+            "https://api.1inch.io/v5.0/1/quote\
                 ?fromTokenAddress=0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee\
                 &toTokenAddress=0x111111111117dc0aa78b770fa6a738034120c302\
                 &amount=1000000000000000000\

--- a/crates/shared/src/price_estimation/competition.rs
+++ b/crates/shared/src/price_estimation/competition.rs
@@ -101,7 +101,9 @@ impl HistoricalWinners {
         required_confidence: f64,
     ) -> Vec<Prediction> {
         let lock = self.0.read().unwrap();
-        let Some(competition) = lock.get(quote) else { return vec![]; };
+        let Some(competition) = lock.get(quote) else {
+            return vec![];
+        };
         if competition.total_quotes < 100 {
             // Not enough data to generate a meaningful prediction.
             return vec![];

--- a/crates/solvers/src/infra/dex/oneinch/mod.rs
+++ b/crates/solvers/src/infra/dex/oneinch/mod.rs
@@ -47,7 +47,7 @@ pub enum Liquidity {
     Exclude(Vec<String>),
 }
 
-pub const DEFAULT_URL: &str = "https://api.1inch.exchange/v5.0/1/";
+pub const DEFAULT_URL: &str = "https://api.1inch.io/v5.0/1/";
 
 impl OneInch {
     pub async fn new(config: Config) -> Result<Self, Error> {


### PR DESCRIPTION
This PR refactors the 1Inch cache to support multiple properties. Previously, the `ProtocolCache` was only used for caching `v5.0/1/liquidity-sources` requests, but it is now also caches `v5.0/1/spender` as well.

One additional notable change in behaviour is that we use a `tokio::sync::Mutex` instead of a `std::sync::Mutex`. This allows us to hold onto the `Mutex` lock across the API call. This effectively changes the behaviour such that that multiple concurrent calls to `v5.0/1/liquidity-sources` and `v5.0/1/spender` will be shared (they will `await` for the lock to be released which only happens after the API call finishes when the cache is out of date).

I moved the spender caching code over instead of using `TimedCache` because:
- We don't need to allocate a hash map for caching a single entry
- Allows for sub-second max age
- Code is pretty much just as simple as it was before

Additionally, I added some more logs to the cache (we now log on cache misses in code) to help with observability.

### Test Plan

CI, unit tests verify caching works.
