### PR TITLE
Deprecate `mandatory` field

### DIFF
--- a/crates/autopilot/src/driver_model.rs
+++ b/crates/autopilot/src/driver_model.rs
@@ -62,6 +62,7 @@ pub mod solve {
     #[derive(Clone, Debug, Default, Serialize)]
     #[serde(rename_all = "camelCase")]
     pub struct Request {
+        #[serde_as(as = "DisplayFromStr")]
         pub id: i64,
         pub tokens: Vec<Token>,
         pub orders: Vec<Order>,

--- a/crates/driver/src/boundary/settlement.rs
+++ b/crates/driver/src/boundary/settlement.rs
@@ -185,7 +185,7 @@ impl Settlement {
         );
         let tx = builder.into_inner();
         let mut input = tx.data.unwrap().0;
-        input.extend(auction_id.0.to_be_bytes());
+        input.extend(auction_id.to_be_bytes());
         eth::Tx {
             from: self.solver,
             to: tx.to.unwrap().into(),

--- a/crates/driver/src/domain/competition/auction.rs
+++ b/crates/driver/src/domain/competition/auction.rs
@@ -11,7 +11,8 @@ use {
 /// solving them.
 #[derive(Debug)]
 pub struct Auction {
-    pub id: Id,
+    /// [`None`] if this auction applies to a quote.
+    pub id: Option<Id>,
     pub tokens: Vec<Token>,
     pub orders: Vec<competition::Order>,
     pub gas_price: eth::GasPrice,

--- a/crates/driver/src/domain/competition/auction.rs
+++ b/crates/driver/src/domain/competition/auction.rs
@@ -103,7 +103,7 @@ impl TryFrom<i64> for Id {
     type Error = InvalidId;
 
     fn try_from(value: i64) -> Result<Self, Self::Error> {
-        if value >= 0 {
+        if (Self::MIN..=Self::MAX).contains(&value) {
             Ok(Self(value))
         } else {
             Err(InvalidId)

--- a/crates/driver/src/domain/competition/auction.rs
+++ b/crates/driver/src/domain/competition/auction.rs
@@ -89,11 +89,6 @@ impl From<Deadline> for chrono::DateTime<chrono::Utc> {
 pub struct Id(i64);
 
 impl Id {
-    // The largest valid auction ID.
-    pub const MAX: i64 = i64::MAX;
-    // The smallest valid auction ID.
-    pub const MIN: i64 = 0;
-
     pub fn to_be_bytes(self) -> [u8; 8] {
         self.0.to_be_bytes()
     }
@@ -103,7 +98,7 @@ impl TryFrom<i64> for Id {
     type Error = InvalidId;
 
     fn try_from(value: i64) -> Result<Self, Self::Error> {
-        if (Self::MIN..=Self::MAX).contains(&value) {
+        if value >= 0 {
             Ok(Self(value))
         } else {
             Err(InvalidId)

--- a/crates/driver/src/domain/competition/solution/settlement.rs
+++ b/crates/driver/src/domain/competition/solution/settlement.rs
@@ -120,7 +120,7 @@ impl Settlement {
         // Encode the solution into a settlement.
         let boundary = boundary::Settlement::encode(eth, &solution, auction).await?;
         Self::new(
-            auction.id.unwrap(),
+            auction.id,
             [(solution.id, solution)].into(),
             boundary,
             eth,

--- a/crates/driver/src/domain/competition/solution/settlement.rs
+++ b/crates/driver/src/domain/competition/solution/settlement.rs
@@ -120,7 +120,7 @@ impl Settlement {
         // Encode the solution into a settlement.
         let boundary = boundary::Settlement::encode(eth, &solution, auction).await?;
         Self::new(
-            auction.id,
+            auction.id.unwrap(),
             [(solution.id, solution)].into(),
             boundary,
             eth,

--- a/crates/driver/src/domain/quote.rs
+++ b/crates/driver/src/domain/quote.rs
@@ -1,4 +1,5 @@
 use {
+    super::competition::auction,
     crate::{
         boundary,
         domain::{
@@ -13,6 +14,7 @@ use {
         },
         util::{self, conv},
     },
+    rand::Rng,
     std::{collections::HashSet, iter},
 };
 
@@ -93,8 +95,12 @@ impl Order {
     }
 
     fn fake_auction(&self, gas_price: eth::GasPrice) -> competition::Auction {
+        let random_id = rand::thread_rng()
+            .gen_range(auction::Id::MIN..=auction::Id::MAX)
+            .try_into()
+            .unwrap();
         competition::Auction {
-            id: None,
+            id: random_id,
             tokens: Default::default(),
             orders: vec![competition::Order {
                 uid: Default::default(),

--- a/crates/driver/src/domain/quote.rs
+++ b/crates/driver/src/domain/quote.rs
@@ -94,7 +94,7 @@ impl Order {
 
     fn fake_auction(&self, gas_price: eth::GasPrice) -> competition::Auction {
         competition::Auction {
-            id: 0.try_into().unwrap(),
+            id: None,
             tokens: Default::default(),
             orders: vec![competition::Order {
                 uid: Default::default(),

--- a/crates/driver/src/domain/quote.rs
+++ b/crates/driver/src/domain/quote.rs
@@ -1,5 +1,4 @@
 use {
-    super::competition::auction,
     crate::{
         boundary,
         domain::{
@@ -14,7 +13,6 @@ use {
         },
         util::{self, conv},
     },
-    rand::Rng,
     std::{collections::HashSet, iter},
 };
 
@@ -95,12 +93,8 @@ impl Order {
     }
 
     fn fake_auction(&self, gas_price: eth::GasPrice) -> competition::Auction {
-        let random_id = rand::thread_rng()
-            .gen_range(auction::Id::MIN..=auction::Id::MAX)
-            .try_into()
-            .unwrap();
         competition::Auction {
-            id: random_id,
+            id: 0.try_into().unwrap(),
             tokens: Default::default(),
             orders: vec![competition::Order {
                 uid: Default::default(),

--- a/crates/driver/src/infra/api/routes/solve/dto/auction.rs
+++ b/crates/driver/src/infra/api/routes/solve/dto/auction.rs
@@ -1,6 +1,10 @@
 use {
     crate::{
-        domain::{competition, competition::order, eth},
+        domain::{
+            competition,
+            competition::{auction, order},
+            eth,
+        },
         infra::Ethereum,
         util::serialize,
     },
@@ -12,7 +16,7 @@ use {
 impl Auction {
     pub async fn into_domain(self, eth: &Ethereum) -> Result<competition::Auction, Error> {
         Ok(competition::Auction {
-            id: Some((self.id as u64).into()),
+            id: self.id.try_into()?,
             tokens: self
                 .tokens
                 .into_iter()
@@ -142,10 +146,17 @@ pub enum Error {
     GasPrice(#[source] crate::infra::blockchain::Error),
 }
 
+impl From<auction::InvalidId> for Error {
+    fn from(_value: auction::InvalidId) -> Self {
+        Self::InvalidAuctionId
+    }
+}
+
 #[serde_as]
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct Auction {
+    #[serde_as(as = "serde_with::DisplayFromStr")]
     id: i64,
     tokens: Vec<Token>,
     orders: Vec<Order>,

--- a/crates/driver/src/infra/api/routes/solve/dto/auction.rs
+++ b/crates/driver/src/infra/api/routes/solve/dto/auction.rs
@@ -16,7 +16,7 @@ use {
 impl Auction {
     pub async fn into_domain(self, eth: &Ethereum) -> Result<competition::Auction, Error> {
         Ok(competition::Auction {
-            id: self.id.try_into()?,
+            id: Some(self.id.try_into()?),
             tokens: self
                 .tokens
                 .into_iter()

--- a/crates/driver/src/infra/solver/dto/auction.rs
+++ b/crates/driver/src/infra/solver/dto/auction.rs
@@ -34,7 +34,7 @@ impl Auction {
             .collect();
 
         Self {
-            id: auction.id.as_ref().map(ToString::to_string),
+            id: auction.id.to_string(),
             orders: auction
                 .orders
                 .iter()
@@ -122,7 +122,7 @@ impl Auction {
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Auction {
-    id: Option<String>,
+    id: String,
     tokens: HashMap<eth::H160, Token>,
     orders: Vec<Order>,
     liquidity: Vec<Liquidity>,

--- a/crates/driver/src/infra/solver/dto/auction.rs
+++ b/crates/driver/src/infra/solver/dto/auction.rs
@@ -34,7 +34,7 @@ impl Auction {
             .collect();
 
         Self {
-            id: auction.id.to_string(),
+            id: auction.id.as_ref().map(ToString::to_string),
             orders: auction
                 .orders
                 .iter()
@@ -122,7 +122,7 @@ impl Auction {
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Auction {
-    id: String,
+    id: Option<String>,
     tokens: HashMap<eth::H160, Token>,
     orders: Vec<Order>,
     liquidity: Vec<Liquidity>,

--- a/crates/driver/src/tests/setup/driver.rs
+++ b/crates/driver/src/tests/setup/driver.rs
@@ -112,11 +112,8 @@ pub fn solve_req(test: &Test) -> serde_json::Value {
             "trusted": test.trusted.contains(fulfillment.quote.order.buy_token),
         }));
     }
-    // TODO Just noticed: the solver auction ID is a string, the driver auction ID
-    // is a number. We should reconcile this. I think both should be numbers, due to
-    // the way they're being encoded in the settlement.
     json!({
-        "id": 1,
+        "id": "1",
         "tokens": tokens_json,
         "orders": orders_json,
         "deadline": test.deadline,

--- a/crates/driver/src/tests/setup/solver.rs
+++ b/crates/driver/src/tests/setup/solver.rs
@@ -199,7 +199,7 @@ impl Solver {
                         .0
                         .to_string();
                     let expected = json!({
-                        "id": config.quote.then(|| 1),
+                        "id": if config.quote { None } else { Some("1") },
                         "tokens": tokens_json,
                         "orders": orders_json,
                         "liquidity": [],

--- a/crates/driver/src/tests/setup/solver.rs
+++ b/crates/driver/src/tests/setup/solver.rs
@@ -199,13 +199,14 @@ impl Solver {
                         .0
                         .to_string();
                     let expected = json!({
-                        "id": if config.quote { None } else { Some("1") },
+                        "id": config.quote.then(|| 1),
                         "tokens": tokens_json,
                         "orders": orders_json,
                         "liquidity": [],
                         "effectiveGasPrice": effective_gas_price,
                         "deadline": config.deadline - auction::Deadline::time_buffer() - infra::Solver::http_time_buffer(),
                     });
+                    assert_eq!(req, expected, "unexpected /solve request");
                     let mut state = state.0.lock().unwrap();
                     assert!(!state.called, "solve was already called");
                     state.called = true;

--- a/crates/driver/src/tests/setup/solver.rs
+++ b/crates/driver/src/tests/setup/solver.rs
@@ -208,7 +208,6 @@ impl Solver {
                     });
                     let mut state = state.0.lock().unwrap();
                     assert!(!state.called, "solve was already called");
-                    assert_eq!(req, expected, "solve request has unexpected body");
                     state.called = true;
                     axum::response::Json(json!({
                         "solutions": solutions_json,

--- a/crates/shared/src/http_solver/model.rs
+++ b/crates/shared/src/http_solver/model.rs
@@ -43,8 +43,10 @@ pub struct OrderModel {
     pub fee: TokenAmount,
     pub cost: TokenAmount,
     pub is_liquidity_order: bool,
-    /// [DEPRECATED] All orders are always mature
+    /// [DEPRECATED] All orders are always mature.
     pub is_mature: bool,
+    /// [DEPRECATED] Mandatory flag is not useful enough to warrant keeping
+    /// around.
     #[serde(default)]
     pub mandatory: bool,
     /// Signals if the order will be executed as an atomic unit. In that case

--- a/crates/shared/src/price_estimation/http.rs
+++ b/crates/shared/src/price_estimation/http.rs
@@ -132,7 +132,7 @@ impl HttpPriceEstimator {
                     token: self.native_token,
                 },
                 is_liquidity_order: false,
-                mandatory: true,
+                mandatory: false,
                 has_atomic_execution: false,
                 reward: 0., // irrelevant for price estimation
                 is_mature: true, // irrelevant for price estimation

--- a/crates/solvers/src/api/dto/auction.rs
+++ b/crates/solvers/src/api/dto/auction.rs
@@ -16,7 +16,7 @@ impl Auction {
     /// Converts a data transfer object into its domain object representation.
     pub fn to_domain(&self) -> Result<auction::Auction, Error> {
         Ok(auction::Auction {
-            id: self.id.clone().map(auction::Id),
+            id: auction::Id(self.id),
             tokens: auction::Tokens(
                 self.tokens
                     .iter()
@@ -84,7 +84,8 @@ impl Auction {
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct Auction {
-    id: Option<String>,
+    #[serde_as(as = "DisplayFromStr")]
+    id: i64,
     tokens: HashMap<H160, Token>,
     orders: Vec<Order>,
     liquidity: Vec<Liquidity>,

--- a/crates/solvers/src/api/dto/auction.rs
+++ b/crates/solvers/src/api/dto/auction.rs
@@ -16,7 +16,7 @@ impl Auction {
     /// Converts a data transfer object into its domain object representation.
     pub fn to_domain(&self) -> Result<auction::Auction, Error> {
         Ok(auction::Auction {
-            id: auction::Id(self.id),
+            id: self.id.map(auction::Id),
             tokens: auction::Tokens(
                 self.tokens
                     .iter()
@@ -84,8 +84,8 @@ impl Auction {
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct Auction {
-    #[serde_as(as = "DisplayFromStr")]
-    id: i64,
+    #[serde_as(as = "Option<DisplayFromStr>")]
+    id: Option<i64>,
     tokens: HashMap<H160, Token>,
     orders: Vec<Order>,
     liquidity: Vec<Liquidity>,
@@ -242,7 +242,7 @@ impl WeightedProductPool {
                 })
                 .collect::<Result<Vec<_>, Error>>()?;
             liquidity::weighted_product::Reserves::new(entries)
-                .ok_or("duplicate weighted token addresss")?
+                .ok_or("duplicate weighted token addresses")?
         };
 
         Ok(liquidity::Liquidity {
@@ -297,7 +297,7 @@ impl StablePool {
                     })
                 })
                 .collect::<Result<Vec<_>, Error>>()?;
-            liquidity::stable::Reserves::new(entries).ok_or("duplicate stable token addresss")?
+            liquidity::stable::Reserves::new(entries).ok_or("duplicate stable token addresses")?
         };
 
         Ok(liquidity::Liquidity {

--- a/crates/solvers/src/boundary/legacy.rs
+++ b/crates/solvers/src/boundary/legacy.rs
@@ -133,7 +133,7 @@ fn to_boundary_auction(
             .collect(),
         metadata: Some(MetadataModel {
             environment: None,
-            auction_id: auction.id.as_ref().and_then(|id| id.0.parse().ok()),
+            auction_id: Some(auction.id.0),
             run_id: None,
             gas_price: Some(gas.gas_price),
             native_token: Some(weth.0),
@@ -172,9 +172,7 @@ fn to_boundary_auction(
                 cost: gas.gp_order_cost(),
                 is_liquidity_order: order.class == order::Class::Liquidity,
                 is_mature: true,
-                // Auctions for a /quote request don't have an id and always contain exactly a
-                // single user order that is mandatory to be matched.
-                mandatory: auction.id.is_none(),
+                mandatory: false,
                 has_atomic_execution: false,
                 reward: 0.,
             },

--- a/crates/solvers/src/boundary/legacy.rs
+++ b/crates/solvers/src/boundary/legacy.rs
@@ -133,7 +133,7 @@ fn to_boundary_auction(
             .collect(),
         metadata: Some(MetadataModel {
             environment: None,
-            auction_id: Some(auction.id.0),
+            auction_id: auction.id.as_ref().map(|id| id.0),
             run_id: None,
             gas_price: Some(gas.gas_price),
             native_token: Some(weth.0),

--- a/crates/solvers/src/domain/auction.rs
+++ b/crates/solvers/src/domain/auction.rs
@@ -7,7 +7,7 @@ use {
 /// The auction that the solvers need to find solutions to.
 #[derive(Debug)]
 pub struct Auction {
-    pub id: Option<Id>,
+    pub id: Id,
     pub tokens: Tokens,
     pub orders: Vec<order::Order>,
     pub liquidity: Vec<liquidity::Liquidity>,
@@ -35,7 +35,7 @@ impl Tokens {
 
 /// The ID of an auction.
 #[derive(Clone, Debug)]
-pub struct Id(pub String);
+pub struct Id(pub i64);
 
 #[derive(Debug)]
 pub struct Token {

--- a/crates/solvers/src/domain/auction.rs
+++ b/crates/solvers/src/domain/auction.rs
@@ -7,7 +7,8 @@ use {
 /// The auction that the solvers need to find solutions to.
 #[derive(Debug)]
 pub struct Auction {
-    pub id: Id,
+    /// [`None`] if the auction applies to a quote.
+    pub id: Option<Id>,
     pub tokens: Tokens,
     pub orders: Vec<order::Order>,
     pub liquidity: Vec<liquidity::Liquidity>,

--- a/crates/solvers/src/tests/balancer/market_order.rs
+++ b/crates/solvers/src/tests/balancer/market_order.rs
@@ -48,7 +48,7 @@ async fn sell() {
 
     let solution = engine
         .solve(json!({
-            "id": null,
+            "id": "1",
             "tokens": {
                 "0xba100000625a3754423978a60c9317c58a424e3D": {
                     "decimals": 18,
@@ -202,7 +202,7 @@ async fn buy() {
 
     let solution = engine
         .solve(json!({
-            "id": null,
+            "id": "1",
             "tokens": {
                 "0xba100000625a3754423978a60c9317c58a424e3D": {
                     "decimals": 18,

--- a/crates/solvers/src/tests/balancer/not_found.rs
+++ b/crates/solvers/src/tests/balancer/not_found.rs
@@ -37,7 +37,7 @@ async fn test() {
 
     let solution = engine
         .solve(json!({
-            "id": null,
+            "id": "1",
             "tokens": {},
             "orders": [
                 {

--- a/crates/solvers/src/tests/balancer/out_of_price.rs
+++ b/crates/solvers/src/tests/balancer/out_of_price.rs
@@ -51,7 +51,7 @@ async fn sell() {
 
     let solution = engine
         .solve(json!({
-            "id": null,
+            "id": "1",
             "tokens": {
                 "0xba100000625a3754423978a60c9317c58a424e3D": {
                     "decimals": 18,
@@ -140,7 +140,7 @@ async fn buy() {
 
     let solution = engine
         .solve(json!({
-            "id": null,
+            "id": "1",
             "tokens": {
                 "0xba100000625a3754423978a60c9317c58a424e3D": {
                     "decimals": 18,

--- a/crates/solvers/src/tests/baseline/direct_swap.rs
+++ b/crates/solvers/src/tests/baseline/direct_swap.rs
@@ -13,7 +13,7 @@ async fn test() {
 
     let solution = engine
         .solve(json!({
-            "id": null,
+            "id": "1",
             "tokens": {
                 "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2": {
                     "decimals": 18,

--- a/crates/solvers/src/tests/baseline/partial_fill.rs
+++ b/crates/solvers/src/tests/baseline/partial_fill.rs
@@ -13,7 +13,7 @@ async fn test() {
 
     let solution = engine
         .solve(json!({
-            "id": null,
+            "id": "1",
             "tokens": {
                 "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2": {
                     "decimals": 18,

--- a/crates/solvers/src/tests/dex/partial_fill.rs
+++ b/crates/solvers/src/tests/dex/partial_fill.rs
@@ -97,7 +97,7 @@ async fn tested_amounts_adjust_depending_on_response() {
     let engine = tests::SolverEngine::new("balancer", balancer::config(&api.address)).await;
 
     let auction = json!({
-        "id": null,
+        "id": "1",
         "tokens": {
             "0xba100000625a3754423978a60c9317c58a424e3D": {
                 "decimals": 18,
@@ -275,7 +275,7 @@ async fn tested_amounts_wrap_around() {
     let engine = tests::SolverEngine::new("balancer", balancer::config(&api.address)).await;
 
     let auction = json!({
-        "id": null,
+        "id": "1",
         "tokens": {
             "0xba100000625a3754423978a60c9317c58a424e3D": {
                 "decimals": 18,
@@ -402,7 +402,7 @@ async fn moves_surplus_fee_to_buy_token() {
     let engine = tests::SolverEngine::new("balancer", balancer::config(&api.address)).await;
 
     let auction = json!({
-        "id": null,
+        "id": "1",
         "tokens": {
             "0xba100000625a3754423978a60c9317c58a424e3D": {
                 "decimals": 18,
@@ -575,7 +575,7 @@ async fn insufficient_room_for_surplus_fee() {
 
     let solution = engine
         .solve(json!({
-            "id": null,
+            "id": "1",
             "tokens": {
                 "0xba100000625a3754423978a60c9317c58a424e3D": {
                     "decimals": 18,
@@ -676,7 +676,7 @@ async fn market() {
 
     let solution = engine
         .solve(json!({
-            "id": null,
+            "id": "1",
             "tokens": {
                 "0xba100000625a3754423978a60c9317c58a424e3D": {
                     "decimals": 18,

--- a/crates/solvers/src/tests/dex/wrong_execution.rs
+++ b/crates/solvers/src/tests/dex/wrong_execution.rs
@@ -85,7 +85,7 @@ async fn test() {
 
         let solution = engine
             .solve(json!({
-                "id": null,
+                "id": "1",
                 "tokens": {
                     "0xba100000625a3754423978a60c9317c58a424e3D": {
                         "decimals": 18,

--- a/crates/solvers/src/tests/legacy/concentrated_liquidity.rs
+++ b/crates/solvers/src/tests/legacy/concentrated_liquidity.rs
@@ -48,7 +48,7 @@ async fn test() {
                 },
             },
             "metadata": {
-                "auction_id": null,
+                "auction_id": 1,
                 "environment": null,
                 "gas_price": 15000000000.0,
                 "native_token": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -92,7 +92,7 @@ async fn test() {
 
     let solution = engine
         .solve(json!({
-            "id": null,
+            "id": "1",
             "tokens": {},
             "orders": [],
             "liquidity": [

--- a/crates/solvers/src/tests/legacy/jit_order.rs
+++ b/crates/solvers/src/tests/legacy/jit_order.rs
@@ -13,7 +13,7 @@ async fn test() {
         req: json!({
             "amms": {},
             "metadata": {
-                "auction_id": null,
+                "auction_id": 1,
                 "environment": null,
                 "gas_price": 15000000000.0,
                 "native_token": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -79,7 +79,7 @@ async fn test() {
 
     let solution = engine
         .solve(json!({
-            "id": null,
+            "id": "1",
             "tokens": {},
             "orders": [],
             "liquidity": [],

--- a/crates/solvers/src/tests/legacy/market_order.rs
+++ b/crates/solvers/src/tests/legacy/market_order.rs
@@ -12,10 +12,11 @@ async fn quote() {
     let legacy_solver = mock::http::setup(vec![mock::http::Expectation::Post {
         path: mock::http::Path::glob(
             "solve\
-             [?]instance_name=*_Mainnet_1_0\
+             [?]instance_name=*_Mainnet_1_1\
                &time_limit=*\
                &max_nr_exec_orders=100\
-               &use_internal_buffers=true"
+               &use_internal_buffers=true\
+               &auction_id=1"
         ),
         req: json!({
             "amms": {
@@ -35,7 +36,7 @@ async fn quote() {
                 }
             },
             "metadata": {
-                "auction_id": null,
+                "auction_id": 1,
                 "environment": null,
                 "gas_price": 15000000000.0,
                 "native_token": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -59,9 +60,7 @@ async fn quote() {
                     "is_liquidity_order": false,
                     "is_mature": true,
                     "is_sell_order": true,
-                    // Mandatory is true when request contains no auction id because that marks a
-                    // /quote request.
-                    "mandatory": true,
+                    "mandatory": false,
                     "reward": 0.,
                     "sell_amount": "133700000000000000",
                     "sell_token": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"
@@ -120,7 +119,7 @@ async fn quote() {
 
     let solution = engine
         .solve(json!({
-            "id": null,
+            "id": "1",
             "tokens": {
                 "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2": {
                     "decimals": 18,

--- a/crates/solvers/src/tests/naive/extract_deepest_pool.rs
+++ b/crates/solvers/src/tests/naive/extract_deepest_pool.rs
@@ -17,7 +17,7 @@ async fn test() {
 
     let solution = engine
         .solve(json!({
-            "id": null,
+            "id": "1",
             "tokens": {},
             "orders": [
                 {

--- a/crates/solvers/src/tests/naive/filters_out_of_price_orders.rs
+++ b/crates/solvers/src/tests/naive/filters_out_of_price_orders.rs
@@ -9,7 +9,7 @@ async fn sell_orders_on_both_sides() {
 
     let solution = engine
         .solve(json!({
-            "id": null,
+            "id": "1",
             "tokens": {},
             "orders": [
                 // Unreasonable order a -> b

--- a/crates/solvers/src/tests/naive/limit_order_price.rs
+++ b/crates/solvers/src/tests/naive/limit_order_price.rs
@@ -9,7 +9,7 @@ async fn test() {
 
     let solution = engine
         .solve(json!({
-            "id": null,
+            "id": "1",
             "tokens": {},
             "orders": [
                 {

--- a/crates/solvers/src/tests/naive/matches_orders.rs
+++ b/crates/solvers/src/tests/naive/matches_orders.rs
@@ -9,7 +9,7 @@ async fn sell_orders_on_both_sides() {
 
     let solution = engine
         .solve(json!({
-            "id": null,
+            "id": "1",
             "tokens": {},
             "orders": [
                 {
@@ -108,7 +108,7 @@ async fn sell_orders_on_one_side() {
 
     let solution = engine
         .solve(json!({
-            "id": null,
+            "id": "1",
             "tokens": {},
             "orders": [
                 {
@@ -207,7 +207,7 @@ async fn buy_orders_on_both_sides() {
 
     let solution = engine
         .solve(json!({
-            "id": null,
+            "id": "1",
             "tokens": {},
             "orders": [
                 {
@@ -306,7 +306,7 @@ async fn buy_and_sell_orders() {
 
     let solution = engine
         .solve(json!({
-            "id": null,
+            "id": "1",
             "tokens": {},
             "orders": [
                 {

--- a/crates/solvers/src/tests/naive/reserves_too_small.rs
+++ b/crates/solvers/src/tests/naive/reserves_too_small.rs
@@ -9,7 +9,7 @@ async fn test() {
 
     let solution = engine
         .solve(json!({
-            "id": null,
+            "id": "1",
             "tokens": {},
             "orders": [
                 {

--- a/crates/solvers/src/tests/naive/rounds_prices_in_favour_of_traders.rs
+++ b/crates/solvers/src/tests/naive/rounds_prices_in_favour_of_traders.rs
@@ -16,7 +16,7 @@ async fn test() {
 
     let solution = engine
         .solve(json!({
-            "id": null,
+            "id": "1",
             "tokens": {},
             "orders": [
                 {

--- a/crates/solvers/src/tests/naive/swap_less_than_reserves.rs
+++ b/crates/solvers/src/tests/naive/swap_less_than_reserves.rs
@@ -14,7 +14,7 @@ async fn test() {
 
     let solution = engine
         .solve(json!({
-            "id": null,
+            "id": "1",
             "tokens": {},
             "orders": [
                 {

--- a/crates/solvers/src/tests/naive/without_pool.rs
+++ b/crates/solvers/src/tests/naive/without_pool.rs
@@ -9,7 +9,7 @@ async fn test() {
 
     let solution = engine
         .solve(json!({
-            "id": null,
+            "id": "1",
             "tokens": {},
             "orders": [
                 {

--- a/crates/solvers/src/tests/oneinch/market_order.rs
+++ b/crates/solvers/src/tests/oneinch/market_order.rs
@@ -123,7 +123,7 @@ async fn sell() {
 
     let solution = engine
         .solve(json!({
-            "id": null,
+            "id": "1",
             "tokens": {
                 "0xe41d2489571d322189246dafa5ebde1f4699f498": {
                     "decimals": 18,
@@ -260,7 +260,7 @@ async fn buy_not_supported() {
 
     let solution = engine
         .solve(json!({
-            "id": null,
+            "id": "1",
             "tokens": {
                 "0xe41d2489571d322189246dafa5ebde1f4699f498": {
                     "decimals": 18,

--- a/crates/solvers/src/tests/oneinch/not_found.rs
+++ b/crates/solvers/src/tests/oneinch/not_found.rs
@@ -63,7 +63,7 @@ async fn test() {
 
     let solution = engine
         .solve(json!({
-            "id": null,
+            "id": "1",
             "tokens": {},
             "orders": [
                 {

--- a/crates/solvers/src/tests/oneinch/out_of_price.rs
+++ b/crates/solvers/src/tests/oneinch/out_of_price.rs
@@ -126,7 +126,7 @@ async fn sell() {
 
     let solution = engine
         .solve(json!({
-            "id": null,
+            "id": "1",
             "tokens": {
                 "0xe41d2489571d322189246dafa5ebde1f4699f498": {
                     "decimals": 18,

--- a/crates/solvers/src/tests/paraswap/market_order.rs
+++ b/crates/solvers/src/tests/paraswap/market_order.rs
@@ -152,7 +152,7 @@ async fn sell() {
 
     let solution = engine
         .solve(json!({
-            "id": null,
+            "id": "1",
             "tokens": {
                 "0xe41d2489571d322189246dafa5ebde1f4699f498": {
                     "decimals": 18,
@@ -403,7 +403,7 @@ async fn buy() {
 
     let solution = engine
         .solve(json!({
-            "id": null,
+            "id": "1",
             "tokens": {
                 "0xe41d2489571d322189246dafa5ebde1f4699f498": {
                     "decimals": 18,

--- a/crates/solvers/src/tests/paraswap/not_found.rs
+++ b/crates/solvers/src/tests/paraswap/not_found.rs
@@ -20,7 +20,7 @@ async fn test() {
 
     let solution = engine
         .solve(json!({
-            "id": null,
+            "id": "1",
             "tokens": {
                 "0xe41d2489571d322189246dafa5ebde1f4699f498": {
                     "decimals": 18,

--- a/crates/solvers/src/tests/paraswap/out_of_price.rs
+++ b/crates/solvers/src/tests/paraswap/out_of_price.rs
@@ -155,7 +155,7 @@ async fn sell() {
 
     let solution = engine
         .solve(json!({
-            "id": null,
+            "id": "1",
             "tokens": {
                 "0xe41d2489571d322189246dafa5ebde1f4699f498": {
                     "decimals": 18,
@@ -364,7 +364,7 @@ async fn buy() {
 
     let solution = engine
         .solve(json!({
-            "id": null,
+            "id": "1",
             "tokens": {
                 "0xe41d2489571d322189246dafa5ebde1f4699f498": {
                     "decimals": 18,

--- a/crates/solvers/src/tests/zeroex/market_order.rs
+++ b/crates/solvers/src/tests/zeroex/market_order.rs
@@ -92,7 +92,7 @@ async fn sell() {
 
     let solution = engine
         .solve(json!({
-            "id": null,
+            "id": "1",
             "tokens": {
                 "0xe41d2489571d322189246dafa5ebde1f4699f498": {
                     "decimals": 18,
@@ -270,7 +270,7 @@ async fn buy() {
 
     let solution = engine
         .solve(json!({
-            "id": null,
+            "id": "1",
             "tokens": {
                 "0xe41d2489571d322189246dafa5ebde1f4699f498": {
                     "decimals": 18,

--- a/crates/solvers/src/tests/zeroex/not_found.rs
+++ b/crates/solvers/src/tests/zeroex/not_found.rs
@@ -30,7 +30,7 @@ async fn test() {
 
     let solution = engine
         .solve(json!({
-            "id": null,
+            "id": "1",
             "tokens": {},
             "orders": [
                 {

--- a/crates/solvers/src/tests/zeroex/options.rs
+++ b/crates/solvers/src/tests/zeroex/options.rs
@@ -200,7 +200,7 @@ enable-slippage-protection = true
 
     let solution = engine
         .solve(json!({
-            "id": null,
+            "id": "1",
             "tokens": {
                 "0xe41d2489571d322189246dafa5ebde1f4699f498": {
                     "decimals": 18,

--- a/crates/solvers/src/tests/zeroex/out_of_price.rs
+++ b/crates/solvers/src/tests/zeroex/out_of_price.rs
@@ -83,7 +83,7 @@ async fn sell() {
 
     let solution = engine
         .solve(json!({
-            "id": null,
+            "id": "1",
             "tokens": {
                 "0xe41d2489571d322189246dafa5ebde1f4699f498": {
                     "decimals": 18,
@@ -202,7 +202,7 @@ async fn buy() {
 
     let solution = engine
         .solve(json!({
-            "id": null,
+            "id": "1",
             "tokens": {
                 "0xe41d2489571d322189246dafa5ebde1f4699f498": {
                     "decimals": 18,


### PR DESCRIPTION
Deprecate the `mandatory` flag since it was only used by Quasimodo and it's not useful enough to keep around for this very specific use case. Ensure that all auction IDs are encoded as strings.

### Test Plan

Automated tests. Will eventually be tested on staging as well.