### PR TITLE
Filter Out Invalid Uniswap V2 Pools

### DIFF
--- a/crates/driver/src/boundary/liquidity/mod.rs
+++ b/crates/driver/src/boundary/liquidity/mod.rs
@@ -121,7 +121,7 @@ impl Fetcher {
             .filter_map(|(index, liquidity)| {
                 let id = liquidity::Id(index);
                 match liquidity {
-                    Liquidity::ConstantProduct(pool) => Some(uniswap::v2::to_domain(id, pool)),
+                    Liquidity::ConstantProduct(pool) => uniswap::v2::to_domain(id, pool),
                     Liquidity::BalancerWeighted(_) => unreachable!(),
                     Liquidity::BalancerStable(_) => unreachable!(),
                     Liquidity::LimitOrder(_) => unreachable!(),

--- a/crates/driver/src/boundary/liquidity/uniswap/v2.rs
+++ b/crates/driver/src/boundary/liquidity/uniswap/v2.rs
@@ -43,9 +43,9 @@ pub fn to_domain(id: liquidity::Id, pool: ConstantProductOrder) -> Option<liquid
         .downcast_ref::<uniswap_v2::Inner>()
         .expect("downcast uniswap settlement handler");
 
-    // Trading on Uniswap V2 pools where the reserves overflows `uint96`s does
+    // Trading on Uniswap V2 pools where the reserves overflows `uint112`s does
     // not work, so filter these pools out.
-    let max = (1_u128 << 96) - 1;
+    let max = 2_u128.pow(112) - 1;
     if pool.reserves.0 > max || pool.reserves.1 > max {
         return None;
     }

--- a/crates/driver/src/boundary/liquidity/uniswap/v2.rs
+++ b/crates/driver/src/boundary/liquidity/uniswap/v2.rs
@@ -31,7 +31,7 @@ use {
     tracing::Instrument,
 };
 
-pub fn to_domain(id: liquidity::Id, pool: ConstantProductOrder) -> liquidity::Liquidity {
+pub fn to_domain(id: liquidity::Id, pool: ConstantProductOrder) -> Option<liquidity::Liquidity> {
     assert!(
         *pool.fee.numer() == 3 && *pool.fee.denom() == 1000,
         "uniswap pools have constant fees",
@@ -43,7 +43,14 @@ pub fn to_domain(id: liquidity::Id, pool: ConstantProductOrder) -> liquidity::Li
         .downcast_ref::<uniswap_v2::Inner>()
         .expect("downcast uniswap settlement handler");
 
-    liquidity::Liquidity {
+    // Trading on Uniswap V2 pools where the reserves overflows `uint96`s does
+    // not work, so filter these pools out.
+    let max = (1_u128 << 96) - 1;
+    if pool.reserves.0 > max || pool.reserves.1 > max {
+        return None;
+    }
+
+    Some(liquidity::Liquidity {
         id,
         gas: price_estimation::gas::GAS_PER_UNISWAP.into(),
         kind: liquidity::Kind::UniswapV2(liquidity::uniswap::v2::Pool {
@@ -61,7 +68,7 @@ pub fn to_domain(id: liquidity::Id, pool: ConstantProductOrder) -> liquidity::Li
             )
             .expect("invalid uniswap token pair"),
         }),
-    }
+    })
 }
 
 pub fn to_interaction(

--- a/crates/solvers/src/api/dto/auction.rs
+++ b/crates/solvers/src/api/dto/auction.rs
@@ -183,7 +183,7 @@ impl ConstantProductPool {
                 .collect_tuple()
                 .ok_or("invalid number of constant product tokens")?;
             liquidity::constant_product::Reserves::new(a, b)
-                .ok_or("duplicate constant product token address")?
+                .ok_or("invalid constant product pool reserves")?
         };
 
         Ok(liquidity::Liquidity {

--- a/crates/solvers/src/api/mod.rs
+++ b/crates/solvers/src/api/mod.rs
@@ -53,6 +53,8 @@ async fn solve(
         }
     };
 
+    tracing::trace!(?auction);
+
     let solutions = state
         .solve(auction)
         .await
@@ -60,6 +62,8 @@ async fn solve(
         .next()
         .map(|solution| dto::Solutions::from_domain(&[solution]))
         .unwrap_or_default();
+
+    tracing::trace!(?solutions);
 
     (
         axum::http::StatusCode::OK,

--- a/crates/solvers/src/domain/liquidity/constant_product.rs
+++ b/crates/solvers/src/domain/liquidity/constant_product.rs
@@ -40,9 +40,9 @@ impl Reserves {
     /// Returns `None` if the assets are denominated in the same token or if the
     /// balances are larger than the maximum allowed values.
     pub fn new(a: eth::Asset, b: eth::Asset) -> Option<Self> {
-        // UniswapV2-Like constant product pools are limited to uint96 values
+        // UniswapV2-Like constant product pools are limited to uint112 values
         // for token reserves - so verify this invariant.
-        let max = (U256::one() << 96) - 1;
+        let max = U256::from(2_u128.pow(112) - 1);
         if a.amount > max || b.amount > max {
             return None;
         }


### PR DESCRIPTION
This PR fixes an issue where the `driver` was sending invalid UniV2 pools to the solver engine. The engine expects ~~`uint96`~~ `uint112` reserves, but it is possible to set up a pools that has more reserves than that (effectively bricking it).

### Test Plan

Ran locally on Goerli and swapped with WETH <> `0xdc31ee1784292379fbb2964b3b9c4124d8f89c60` pool.
