### PR TITLE
Sli order events

### DIFF
--- a/crates/autopilot/src/database.rs
+++ b/crates/autopilot/src/database.rs
@@ -6,6 +6,7 @@ pub mod ethflow_events;
 mod events;
 pub mod on_settlement_event_updater;
 pub mod onchain_order_events;
+pub mod order_events;
 pub mod orders;
 mod quotes;
 pub mod recent_settlements;

--- a/crates/autopilot/src/database/order_events.rs
+++ b/crates/autopilot/src/database/order_events.rs
@@ -12,7 +12,7 @@ use {
 
 impl super::Postgres {
     /// Stores the given order event for all passed [`OrderUid`]s in a
-    /// background thread to not block the process.
+    /// background task to not block the thread.
     pub fn store_order_events(&self, uids: Vec<OrderUid>, label: OrderEventLabel) {
         if uids.is_empty() {
             return;

--- a/crates/autopilot/src/database/order_events.rs
+++ b/crates/autopilot/src/database/order_events.rs
@@ -1,0 +1,59 @@
+pub use database::order_events::OrderEventLabel;
+use {
+    anyhow::{Context, Result},
+    chrono::{DateTime, Utc},
+    database::{
+        byte_array::ByteArray,
+        order_events::{self, OrderEvent},
+    },
+    model::order::OrderUid,
+    sqlx::PgConnection,
+    tracing::Instrument,
+};
+
+impl super::Postgres {
+    /// Stores the given order event for all passed [`OrderUid`]s in a
+    /// background thread to not block the process.
+    pub fn store_order_events(&self, uids: Vec<OrderUid>, label: OrderEventLabel) {
+        if uids.is_empty() {
+            return;
+        }
+
+        let now = Utc::now();
+        let db = self.0.clone();
+        let insert = async move {
+            let mut ex = db.acquire().await.context("acquire")?;
+            store_order_events(&mut ex, &uids, now, label)
+                .await
+                .context("store events")
+        };
+        tokio::task::spawn(
+            async move {
+                if let Err(err) = insert.await {
+                    tracing::warn!(?label, ?err, "failed to store order events");
+                }
+            }
+            .instrument(tracing::Span::current()),
+        );
+    }
+}
+
+async fn store_order_events(
+    ex: &mut PgConnection,
+    uids: &[OrderUid],
+    timestamp: DateTime<Utc>,
+    label: OrderEventLabel,
+) -> Result<()> {
+    for uid in uids {
+        order_events::insert_order_event(
+            ex,
+            &OrderEvent {
+                order_uid: ByteArray(uid.0),
+                timestamp,
+                label,
+            },
+        )
+        .await?;
+    }
+    Ok(())
+}

--- a/crates/autopilot/src/run_loop.rs
+++ b/crates/autopilot/src/run_loop.rs
@@ -353,7 +353,7 @@ impl RunLoop {
             // This could be a while loop. It isn't, because some care must be taken to not
             // accidentally keep the borrow alive, which would block senders. Technically
             // this is fine with while conditions but this is clearer.
-            if self.current_block.borrow().number <= deadline {
+            if self.current_block.borrow().number > deadline {
                 break;
             }
             let mut hashes = self

--- a/crates/autopilot/src/solvable_orders.rs
+++ b/crates/autopilot/src/solvable_orders.rs
@@ -3,6 +3,7 @@ use {
     anyhow::Result,
     bigdecimal::BigDecimal,
     chrono::Utc,
+    database::order_events::OrderEventLabel,
     itertools::Itertools,
     model::{
         auction::Auction,
@@ -168,17 +169,25 @@ impl SolvableOrdersCache {
         let mut counter = OrderFilterCounter::new(self.metrics, &db_solvable_orders.orders);
 
         let orders = filter_banned_user_orders(db_solvable_orders.orders, &self.banned_users);
-        counter.checkpoint("banned_user", &orders);
+        let removed = counter.checkpoint("banned_user", &orders);
+        self.database
+            .store_order_events(removed, OrderEventLabel::Invalid);
 
         let orders = filter_unsupported_tokens(orders, self.bad_token_detector.as_ref()).await?;
-        counter.checkpoint("unsupported_token", &orders);
+        let removed = counter.checkpoint("unsupported_token", &orders);
+        self.database
+            .store_order_events(removed, OrderEventLabel::Invalid);
 
         let orders =
             filter_invalid_signature_orders(orders, self.signature_validator.as_ref()).await;
-        counter.checkpoint("invalid_signature", &orders);
+        let removed = counter.checkpoint("invalid_signature", &orders);
+        self.database
+            .store_order_events(removed, OrderEventLabel::Invalid);
 
         let orders = filter_fok_limit_orders_with_insufficient_sell_amount(orders);
-        counter.checkpoint("insufficient_sell", &orders);
+        let removed = counter.checkpoint("insufficient_sell", &orders);
+        self.database
+            .store_order_events(removed, OrderEventLabel::Invalid);
 
         // If we update due to an explicit notification we can reuse existing balances
         // as they cannot have changed.
@@ -210,10 +219,14 @@ impl SolvableOrdersCache {
         }
 
         let orders = orders_with_balance(orders, &new_balances, self.ethflow_contract_address);
-        counter.checkpoint("insufficient_balance", &orders);
+        let removed = counter.checkpoint("insufficient_balance", &orders);
+        self.database
+            .store_order_events(removed, OrderEventLabel::Invalid);
 
         let orders = filter_dust_orders(orders, &new_balances, self.ethflow_contract_address);
-        counter.checkpoint("dust_order", &orders);
+        let removed = counter.checkpoint("dust_order", &orders);
+        self.database
+            .store_order_events(removed, OrderEventLabel::Filtered);
 
         // create auction
         let (orders, prices) = get_orders_with_native_prices(
@@ -221,13 +234,19 @@ impl SolvableOrdersCache {
             &self.native_price_estimator,
             self.metrics,
         );
-        counter.checkpoint("missing_price", &orders);
+        let removed = counter.checkpoint("missing_price", &orders);
+        self.database
+            .store_order_events(removed, OrderEventLabel::Filtered);
 
         let orders = filter_mispriced_limit_orders(orders, &prices, &self.limit_order_price_factor);
-        counter.checkpoint("out_of_market", &orders);
+        let removed = counter.checkpoint("out_of_market", &orders);
+        self.database
+            .store_order_events(removed, OrderEventLabel::Filtered);
 
         let orders = apply_fee_objective_scaling_factor(orders, &self.fee_objective_scaling_factor);
-        counter.checkpoint("fee_scaling_overflow", &orders);
+        let removed = counter.checkpoint("fee_scaling_overflow", &orders);
+        self.database
+            .store_order_events(removed, OrderEventLabel::Filtered);
 
         let auction = Auction {
             block,
@@ -666,7 +685,7 @@ impl OrderFilterCounter {
     }
 
     /// Creates a new checkpoint from the current remaining orders.
-    fn checkpoint(&mut self, reason: Reason, orders: &[Order]) {
+    fn checkpoint(&mut self, reason: Reason, orders: &[Order]) -> Vec<OrderUid> {
         let filtered_orders = orders
             .iter()
             .fold(self.orders.clone(), |mut order_uids, order| {
@@ -675,10 +694,11 @@ impl OrderFilterCounter {
             });
 
         *self.counts.entry(reason).or_default() += filtered_orders.len();
-        for (order, class) in filtered_orders {
+        for (order, class) in &filtered_orders {
             self.orders.remove(&order).unwrap();
             tracing::debug!(%order, ?class, %reason, "filtered order")
         }
+        filtered_orders.into_keys().collect()
     }
 
     /// Records the filter counter to metrics.

--- a/crates/autopilot/src/solvable_orders.rs
+++ b/crates/autopilot/src/solvable_orders.rs
@@ -695,7 +695,7 @@ impl OrderFilterCounter {
 
         *self.counts.entry(reason).or_default() += filtered_orders.len();
         for (order, class) in &filtered_orders {
-            self.orders.remove(&order).unwrap();
+            self.orders.remove(order).unwrap();
             tracing::debug!(%order, ?class, %reason, "filtered order")
         }
         filtered_orders.into_keys().collect()

--- a/crates/database/src/lib.rs
+++ b/crates/database/src/lib.rs
@@ -11,6 +11,7 @@ pub mod ethflow_orders;
 pub mod events;
 pub mod onchain_broadcasted_orders;
 pub mod onchain_invalidations;
+pub mod order_events;
 pub mod order_execution;
 pub mod orders;
 pub mod quotes;

--- a/crates/database/src/order_events.rs
+++ b/crates/database/src/order_events.rs
@@ -39,7 +39,8 @@ pub enum OrderEventLabel {
 pub struct OrderEvent {
     /// Which order this event belongs to
     pub order_uid: OrderUid,
-    /// When the event was noticed and **NOT** when it was inserted into the DB
+    /// When the event was noticed and not necessarily when it was inserted into
+    /// the DB
     pub timestamp: DateTime<Utc>,
     /// What kind of event happened
     pub label: OrderEventLabel,

--- a/crates/database/src/order_events.rs
+++ b/crates/database/src/order_events.rs
@@ -1,0 +1,68 @@
+//! Stores timestamped events of every order throughout its lifecycle.
+//! This information gets used to compuate service level indicators.
+
+use {
+    crate::OrderUid,
+    chrono::Utc,
+    sqlx::{types::chrono::DateTime, PgConnection},
+};
+
+/// Describes what kind of event was registered for an order.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, sqlx::Type)]
+#[sqlx(type_name = "OrderEventLabel")]
+#[sqlx(rename_all = "lowercase")]
+pub enum OrderEventLabel {
+    /// Order was added to the orderbook.
+    Created,
+    /// Order was included in an auction and got sent to the solvers.
+    Ready,
+    /// Order was filtered from the auction and did not get sent to the solvers.
+    Filtered,
+    /// Order can not be settled on-chain. (e.g. user is missing funds,
+    /// PreSign or EIP-1271 signature is invalid, etc.)
+    Invalid,
+    /// Order was included in the winning settlement and is in the process of
+    /// being submitted on-chain.
+    Executing,
+    /// Order was included in a settlement that did not win.
+    Considered,
+    /// Order was settled on-chain.
+    Traded,
+    /// Order was cancelled by the user.
+    Cancelled,
+}
+
+/// Contains a single event of the life cycle of an order and when it was
+/// registered.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, sqlx::Type)]
+#[sqlx(type_name = "")]
+pub struct OrderEvent {
+    /// Which order this event belongs to
+    pub order_uid: OrderUid,
+    /// When the event was noticed and **NOT** when it was inserted into the DB
+    pub timestamp: DateTime<Utc>,
+    /// What kind of event happened
+    pub label: OrderEventLabel,
+}
+
+/// Inserts a row into the `order_events` table.
+pub async fn insert_order_event(
+    ex: &mut PgConnection,
+    event: &OrderEvent,
+) -> Result<(), sqlx::Error> {
+    const QUERY: &str = r#"
+INSERT INTO order_events (
+    order_uid,
+    timestamp,
+    label
+)
+VALUES ($1, $2, $3)
+"#;
+    sqlx::query(QUERY)
+        .bind(&event.order_uid)
+        .bind(&event.timestamp)
+        .bind(&event.label)
+        .execute(ex)
+        .await
+        .map(|_| ())
+}

--- a/crates/database/src/order_events.rs
+++ b/crates/database/src/order_events.rs
@@ -24,7 +24,7 @@ pub enum OrderEventLabel {
     /// Order was included in the winning settlement and is in the process of
     /// being submitted on-chain.
     Executing,
-    /// Order was included in a settlement that did not win.
+    /// Order was included in a valid settlement.
     Considered,
     /// Order was settled on-chain.
     Traded,

--- a/crates/database/src/order_events.rs
+++ b/crates/database/src/order_events.rs
@@ -35,7 +35,6 @@ pub enum OrderEventLabel {
 /// Contains a single event of the life cycle of an order and when it was
 /// registered.
 #[derive(Clone, Copy, Debug, Eq, PartialEq, sqlx::Type)]
-#[sqlx(type_name = "")]
 pub struct OrderEvent {
     /// Which order this event belongs to
     pub order_uid: OrderUid,

--- a/database/README.md
+++ b/database/README.md
@@ -14,13 +14,13 @@ Associates the 32 bytes contract app data with the corresponding full app data.
 
 See [here](https://github.com/cowprotocol/services/issues/1465) for more details. In this table the contract app data is either the old unixfs based scheme, or the new keccak scheme. The new scheme can be validated by keccak-256 hashing the full app data, which should produce the contract app data. The old scheme cannot be validated.
 
-Column             | Type  | Nullable | Details
--------------------|-------|----------|-------
+Column               | Type  | Nullable | Details
+---------------------|-------|----------|-------
  contract\_app\_data | bytea | not null | 32 bytes. Referenced by `orders.app_data`.
  full\_app\_data     | bytea | not null | Is utf-8 but not stored as string because the raw bytes are important for hashing.
 
 Indexes:
-- "app\_data\_pkey" PRIMARY KEY, btree (contract_app_data)
+- "app\_data\_pkey" PRIMARY KEY, btree (`contract_app_data`)
 
 ### auction\_participants
 
@@ -163,6 +163,16 @@ Indexes:
 - PRIMARY KEY: btree(`uid`)
 - event\_index: btree(`block_number`, `index`)
 - order\_sender: hash(sender)
+
+### order\_events
+
+Stores timestamped events throughout an order's life cycle. This information is used to get detailed metrics on a per order basis.
+
+ Column           | Type                     | Nullable | Details
+------------------|--------------------------|----------|--------
+ order\_uid       | bytea                    | not null | order this event belongs to
+ timestamp        | timestamptz              | not null | when the event was registered
+ label            | [enum](#ordereventlabel) | not null | which event happened exactly
 
 ### order\_execution
 
@@ -376,6 +386,19 @@ Indexes:
  invalid\_order\_data            | unused
  insufficient\_fee               | the proposed fee is less than quoted fee
  other                           | some unexpected error happened
+
+#### ordereventlabel
+
+ Value      | Meaning
+------------|--------
+ created    | order was added to the orderbook
+ ready      | order was included in an auction and sent to solvers
+ filtered   | order was filtered from the auction and not sent to solvers
+ invalid    | order can not be settled on-chain (e.g. user is missing funds, PreSign or EIP-1271 signature is invalid, etc.)
+ executing  | order was included in the winning solution and is in the process of being submitted on-chain
+ considered | order was not in the winning solution but in another valid solution
+ traded     | order was traded on-chain
+ cancelled  | user cancelled the order
 
 #### orderkind
 

--- a/database/README.md
+++ b/database/README.md
@@ -174,6 +174,9 @@ Stores timestamped events throughout an order's life cycle. This information is 
  timestamp        | timestamptz              | not null | when the event was registered
  label            | [enum](#ordereventlabel) | not null | which event happened exactly
 
+Indexes:
+- order\_events\_by\_uid: btree(`order_uid`, `timestamp`)
+
 ### order\_execution
 
 Contains metainformation for trades, required for reward computations that cannot be recovered from the blockchain and are not stored in a persistent manner somewhere else.

--- a/database/README.md
+++ b/database/README.md
@@ -396,7 +396,7 @@ Indexes:
  filtered   | order was filtered from the auction and not sent to solvers
  invalid    | order can not be settled on-chain (e.g. user is missing funds, PreSign or EIP-1271 signature is invalid, etc.)
  executing  | order was included in the winning solution and is in the process of being submitted on-chain
- considered | order was not in the winning solution but in another valid solution
+ considered | order was in a valid solution
  traded     | order was traded on-chain
  cancelled  | user cancelled the order
 

--- a/database/sql/V054__store_order_events.sql
+++ b/database/sql/V054__store_order_events.sql
@@ -1,0 +1,16 @@
+CREATE TYPE OrderEventLabel AS ENUM (
+  'created',
+  'ready',
+  'filtered',
+  'invalid',
+  'executing',
+  'considered',
+  'traded',
+  'cancelled'
+);
+
+CREATE TABLE order_events (
+    order_uid bytea NOT NULL,
+    timestamp timestamptz NOT NULL,
+    label OrderEventLabel NOT NULL
+);

--- a/database/sql/V054__store_order_events.sql
+++ b/database/sql/V054__store_order_events.sql
@@ -9,8 +9,15 @@ CREATE TYPE OrderEventLabel AS ENUM (
   'cancelled'
 );
 
+-- This table stores timestamped events for every order to get per order metrics
+-- for service level indicators (SLIs).
+-- More info: https://github.com/cowprotocol/services/issues/1582
 CREATE TABLE order_events (
     order_uid bytea NOT NULL,
     timestamp timestamptz NOT NULL,
     label OrderEventLabel NOT NULL
 );
+
+-- Add index on `order_uid` and `timestamp` to quickly get events for an order
+-- (and a given time frame if required).
+CREATE INDEX order_events_by_uid ON order_events USING BTREE (order_uid, timestamp);


### PR DESCRIPTION
Fixes #1582 

This PR implements storing timestamped events throughout the life cycle of every order.
In the autopilot all events get uploaded in a background task to not block the protocol unnecessarily. This is probably overkill in some places but I wanted to have a simple API that gets the job done.

### Test Plan
It seems we currently don't have the tools required to test DB state when running an e2e test so I modified an existing e2e test that simply settles an order and checked my local DB afterwards. Looked good enough to merge but should be followed up with a PR implementing and actual e2e test for that.

![Screenshot 2023-07-04 at 15 18 58](https://github.com/cowprotocol/services/assets/19190235/2198dc12-47de-436a-8282-3bd2383fbe47)