### PR TITLE
Include Additional Hook Gas In Quoted Fee

### DIFF
--- a/crates/autopilot/src/database/auction.rs
+++ b/crates/autopilot/src/database/auction.rs
@@ -1,7 +1,7 @@
 use {
     super::Postgres,
     anyhow::{Context, Result},
-    database::{auction::AuctionId, quotes::QuoteKind},
+    database::auction::AuctionId,
     futures::{StreamExt, TryStreamExt},
     model::{auction::Auction, order::Order},
 };
@@ -49,7 +49,6 @@ impl QuoteStoring for Postgres {
         &self,
         params: QuoteSearchParameters,
         expiration: DateTime<Utc>,
-        quote_kind: QuoteKind,
     ) -> Result<Option<(QuoteId, QuoteData)>> {
         let _timer = super::Metrics::get()
             .database_queries
@@ -57,7 +56,7 @@ impl QuoteStoring for Postgres {
             .start_timer();
 
         let mut ex = self.0.acquire().await?;
-        let params = create_db_search_parameters(params, expiration, quote_kind);
+        let params = create_db_search_parameters(params, expiration);
         let quote = database::quotes::find(&mut ex, &params)
             .await
             .context("failed finding quote by parameters")?;

--- a/crates/autopilot/src/database/onchain_order_events.rs
+++ b/crates/autopilot/src/database/onchain_order_events.rs
@@ -20,7 +20,7 @@ use {
         orders::{insert_quotes, Order, OrderClass},
         PgTransaction,
     },
-    ethcontract::{Event as EthContractEvent, H160, U256},
+    ethcontract::{Event as EthContractEvent, H160},
     futures::{stream, StreamExt},
     itertools::multiunzip,
     model::{
@@ -557,7 +557,7 @@ async fn get_quote(
         fee_amount: order_data.fee_amount,
         kind: order_data.kind,
         signing_scheme: quote_signing_scheme,
-        additional_gas: U256::zero(),
+        additional_gas: 0,
         // Verified quotes always have prices that are at most as good as unverified quotes but can
         // be lower.
         // If the best quote we can find or compute on the fly for this order suggests a worse
@@ -572,7 +572,6 @@ async fn get_quote(
         &parameters.clone(),
         Some(*quote_id),
         order_data.fee_amount,
-        &Default::default(),
     )
     .await
     .map_err(onchain_order_placement_error_from)

--- a/crates/autopilot/src/database/onchain_order_events.rs
+++ b/crates/autopilot/src/database/onchain_order_events.rs
@@ -20,7 +20,7 @@ use {
         orders::{insert_quotes, Order, OrderClass},
         PgTransaction,
     },
-    ethcontract::{Event as EthContractEvent, H160},
+    ethcontract::{Event as EthContractEvent, H160, U256},
     futures::{stream, StreamExt},
     itertools::multiunzip,
     model::{
@@ -556,6 +556,8 @@ async fn get_quote(
         buy_amount: order_data.buy_amount,
         fee_amount: order_data.fee_amount,
         kind: order_data.kind,
+        signing_scheme: quote_signing_scheme,
+        additional_gas: U256::zero(),
         // Verified quotes always have prices that are at most as good as unverified quotes but can
         // be lower.
         // If the best quote we can find or compute on the fly for this order suggests a worse

--- a/crates/e2e/tests/e2e/setup/onchain_components.rs
+++ b/crates/e2e/tests/e2e/setup/onchain_components.rs
@@ -126,7 +126,8 @@ where
         .clone()
         .estimate_gas()
         .await
-        .expect("transaction reverted when estimating gas");
+        .expect("transaction reverted when estimating gas")
+        .as_u64();
     Hook {
         target: tx.to.unwrap(),
         call_data: tx.data.unwrap().0,

--- a/crates/model/src/order.rs
+++ b/crates/model/src/order.rs
@@ -4,6 +4,7 @@
 use {
     crate::{
         app_id::AppDataHash,
+        bytes_hex::BytesHex,
         interaction::InteractionData,
         quote::QuoteId,
         signature::{self, EcdsaSignature, EcdsaSigningScheme, Signature},
@@ -53,24 +54,24 @@ impl Hooks {
         self.pre.is_empty() && self.post.is_empty()
     }
 
-    pub fn gas_limit(&self) -> U256 {
+    pub fn gas_limit(&self) -> u64 {
         std::iter::empty()
             .chain(&self.pre)
             .chain(&self.post)
-            .fold(U256::zero(), |total, hook| {
-                total.saturating_add(hook.gas_limit)
-            })
+            .fold(0_u64, |total, hook| total.saturating_add(hook.gas_limit))
     }
 }
 
 /// A user-specified hook.
+#[serde_as]
 #[derive(Clone, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Hook {
     pub target: H160,
-    #[serde(with = "crate::bytes_hex")]
+    #[serde_as(as = "BytesHex")]
     pub call_data: Vec<u8>,
-    pub gas_limit: U256,
+    #[serde_as(as = "DisplayFromStr")]
+    pub gas_limit: u64,
 }
 
 impl Debug for Hook {

--- a/crates/orderbook/src/database/quotes.rs
+++ b/crates/orderbook/src/database/quotes.rs
@@ -2,7 +2,6 @@ use {
     super::Postgres,
     anyhow::{Context, Result},
     chrono::{DateTime, Utc},
-    database::quotes::QuoteKind,
     model::quote::QuoteId,
     shared::{
         event_storing_helpers::{create_db_search_parameters, create_quote_row},
@@ -39,7 +38,6 @@ impl QuoteStoring for Postgres {
         &self,
         params: QuoteSearchParameters,
         expiration: DateTime<Utc>,
-        quote_kind: QuoteKind,
     ) -> Result<Option<(QuoteId, QuoteData)>> {
         let _timer = super::Metrics::get()
             .database_queries
@@ -47,7 +45,7 @@ impl QuoteStoring for Postgres {
             .start_timer();
 
         let mut ex = self.pool.acquire().await?;
-        let params = create_db_search_parameters(params, expiration, quote_kind);
+        let params = create_db_search_parameters(params, expiration);
         let quote = database::quotes::find(&mut ex, &params)
             .await
             .context("failed finding quote by parameters")?;

--- a/crates/shared/src/event_storing_helpers.rs
+++ b/crates/shared/src/event_storing_helpers.rs
@@ -1,12 +1,12 @@
 use {
     crate::{
         db_order_conversions::order_kind_into,
-        order_quoting::{QuoteData, QuoteSearchParameters},
+        order_quoting::{quote_kind_from_signing_scheme, QuoteData, QuoteSearchParameters},
     },
     chrono::{DateTime, Utc},
     database::{
         byte_array::ByteArray,
-        quotes::{Quote as DbQuote, QuoteKind, QuoteSearchParameters as DbQuoteSearchParameters},
+        quotes::{Quote as DbQuote, QuoteSearchParameters as DbQuoteSearchParameters},
     },
     number_conversions::u256_to_big_decimal,
 };
@@ -31,7 +31,6 @@ pub fn create_quote_row(data: QuoteData) -> DbQuote {
 pub fn create_db_search_parameters(
     params: QuoteSearchParameters,
     expiration: DateTime<Utc>,
-    quote_kind: QuoteKind,
 ) -> DbQuoteSearchParameters {
     DbQuoteSearchParameters {
         sell_token: ByteArray(params.sell_token.0),
@@ -41,6 +40,6 @@ pub fn create_db_search_parameters(
         buy_amount: u256_to_big_decimal(&params.buy_amount),
         kind: order_kind_into(params.kind),
         expiration,
-        quote_kind,
+        quote_kind: quote_kind_from_signing_scheme(&params.signing_scheme),
     }
 }

--- a/crates/shared/src/order_quoting.rs
+++ b/crates/shared/src/order_quoting.rs
@@ -896,8 +896,11 @@ mod tests {
                 from: H160([3; 20]),
                 ..Default::default()
             }),
-            signing_scheme: QuoteSigningScheme::Eip712,
-            additional_gas: 0,
+            signing_scheme: QuoteSigningScheme::Eip1271 {
+                onchain_order: false,
+                verification_gas_limit: 1,
+            },
+            additional_gas: 2,
         };
         let gas_price = GasPrice1559 {
             base_fee_per_gas: 1.5,
@@ -1006,8 +1009,8 @@ mod tests {
                 },
                 sell_amount: 100.into(),
                 buy_amount: 42.into(),
-                fee_amount: 15.into(),
-                full_fee_amount: 30.into(),
+                fee_amount: 30.into(),
+                full_fee_amount: 60.into(),
             }
         );
     }

--- a/crates/shared/src/order_quoting.rs
+++ b/crates/shared/src/order_quoting.rs
@@ -137,6 +137,7 @@ pub struct QuoteParameters {
     pub side: OrderQuoteSide,
     pub verification: Option<Verification>,
     pub signing_scheme: QuoteSigningScheme,
+    pub additional_gas: U256,
 }
 
 impl QuoteParameters {
@@ -361,6 +362,8 @@ pub struct QuoteSearchParameters {
     pub buy_amount: U256,
     pub fee_amount: U256,
     pub kind: OrderKind,
+    pub signing_scheme: QuoteSigningScheme,
+    pub additional_gas: U256,
     /// If this is `Some` the quotes are expected to pass simulations using the
     /// contained parameters.
     pub verification: Option<Verification>,
@@ -685,6 +688,8 @@ impl From<&OrderQuoteRequest> for QuoteParameters {
             side: request.side,
             verification,
             signing_scheme: request.signing_scheme,
+            // TODO get from request
+            additional_gas: U256::zero(),
         }
     }
 }
@@ -759,6 +764,7 @@ mod tests {
                 ..Default::default()
             }),
             signing_scheme: QuoteSigningScheme::Eip712,
+            additional_gas: U256::zero(),
         };
         let gas_price = GasPrice1559 {
             base_fee_per_gas: 1.5,
@@ -884,6 +890,7 @@ mod tests {
                 ..Default::default()
             }),
             signing_scheme: QuoteSigningScheme::Eip712,
+            additional_gas: U256::zero(),
         };
         let gas_price = GasPrice1559 {
             base_fee_per_gas: 1.5,
@@ -1012,6 +1019,7 @@ mod tests {
                 ..Default::default()
             }),
             signing_scheme: QuoteSigningScheme::Eip712,
+            additional_gas: U256::zero(),
         };
         let gas_price = GasPrice1559 {
             base_fee_per_gas: 1.5,
@@ -1140,6 +1148,7 @@ mod tests {
                 ..Default::default()
             }),
             signing_scheme: QuoteSigningScheme::Eip712,
+            additional_gas: U256::zero(),
         };
         let gas_price = GasPrice1559 {
             base_fee_per_gas: 1.,
@@ -1208,6 +1217,7 @@ mod tests {
                 ..Default::default()
             }),
             signing_scheme: QuoteSigningScheme::Eip712,
+            additional_gas: U256::zero(),
         };
         let gas_price = GasPrice1559 {
             base_fee_per_gas: 1.,
@@ -1276,6 +1286,8 @@ mod tests {
             buy_amount: 40.into(),
             fee_amount: 15.into(),
             kind: OrderKind::Sell,
+            signing_scheme: QuoteSigningScheme::Eip712,
+            additional_gas: U256::zero(),
             verification: Some(Verification {
                 from: H160([3; 20]),
                 ..Default::default()
@@ -1363,6 +1375,8 @@ mod tests {
             buy_amount: 40.into(),
             fee_amount: 30.into(),
             kind: OrderKind::Sell,
+            signing_scheme: QuoteSigningScheme::Eip712,
+            additional_gas: U256::zero(),
             verification: Some(Verification {
                 from: H160([3; 20]),
                 ..Default::default()
@@ -1439,6 +1453,8 @@ mod tests {
             buy_amount: 42.into(),
             fee_amount: 30.into(),
             kind: OrderKind::Buy,
+            signing_scheme: QuoteSigningScheme::Eip712,
+            additional_gas: U256::zero(),
             verification: Some(Verification {
                 from: H160([3; 20]),
                 ..Default::default()


### PR DESCRIPTION
This PR includes the additional hook `gas_limit` added in #1644 into the quoted fee amount.

### Test Plan

Existing tests continue to pass (including E2E test which uses hooks). Also, modified a unit test to consider additional gas costs from signature verification and hooks.
