### PR TITLE
Account For Hooks While Quoting

### DIFF
--- a/crates/e2e/tests/e2e/eth_flow.rs
+++ b/crates/e2e/tests/e2e/eth_flow.rs
@@ -7,7 +7,6 @@ use {
     ethcontract::{transaction::TransactionResult, Account, Bytes, H160, H256, U256},
     hex_literal::hex,
     model::{
-        app_id::AppDataHash,
         order::{
             BuyTokenDestination,
             EthflowData,
@@ -15,6 +14,7 @@ use {
             Order,
             OrderBuilder,
             OrderClass,
+            OrderCreationAppData,
             OrderKind,
             OrderUid,
             SellTokenSource,
@@ -425,7 +425,7 @@ impl ExtendedEthFlowOrder {
             receiver: quote.receiver.expect("eth-flow order without receiver"),
             sell_amount: quote.sell_amount,
             buy_amount: quote.buy_amount,
-            app_data: ethcontract::Bytes(quote.app_data.0),
+            app_data: ethcontract::Bytes(quote.app_data.hash().0),
             fee_amount: quote.fee_amount,
             valid_to, // note: valid to in the quote is always unlimited
             partially_fillable: quote.partially_fillable,
@@ -588,7 +588,7 @@ impl EthFlowTradeIntent {
             buy_token: self.buy_token,
             receiver: Some(self.receiver),
             validity: Validity::For(3600),
-            app_data: AppDataHash([0x42; 32]),
+            app_data: OrderCreationAppData::default(),
             signing_scheme: QuoteSigningScheme::Eip1271 {
                 onchain_order: true,
                 verification_gas_limit: 0,

--- a/crates/e2e/tests/e2e/main.rs
+++ b/crates/e2e/tests/e2e/main.rs
@@ -21,6 +21,7 @@ mod partially_fillable_balance;
 mod partially_fillable_observed_score;
 mod partially_fillable_pool;
 mod pre_interaction;
+mod quoting;
 mod refunder;
 mod settlement_without_onchain_liquidity;
 mod smart_contract_orders;

--- a/crates/e2e/tests/e2e/order_cancellation.rs
+++ b/crates/e2e/tests/e2e/order_cancellation.rs
@@ -9,7 +9,6 @@ use {
             OrderCancellation,
             OrderCancellations,
             OrderCreation,
-            OrderCreationAppData,
             OrderStatus,
             OrderUid,
             SignedOrderCancellations,
@@ -61,7 +60,7 @@ async fn order_cancellation(web3: Web3) {
             side: OrderQuoteSide::Sell {
                 sell_amount: SellAmount::AfterFee { value: to_wei(1) },
             },
-            app_data: AppDataHash([salt; 32]),
+            app_data: AppDataHash([salt; 32]).into(),
             ..Default::default()
         };
         async move {
@@ -75,9 +74,7 @@ async fn order_cancellation(web3: Web3) {
                 buy_token: quote.buy_token,
                 buy_amount: (quote.buy_amount * 99) / 100,
                 valid_to: quote.valid_to,
-                app_data: OrderCreationAppData::Hash {
-                    hash: quote.app_data,
-                },
+                app_data: quote.app_data,
                 ..Default::default()
             }
             .sign(

--- a/crates/e2e/tests/e2e/quoting.rs
+++ b/crates/e2e/tests/e2e/quoting.rs
@@ -1,0 +1,111 @@
+use {
+    crate::setup::*,
+    ethcontract::prelude::U256,
+    model::{
+        order::OrderCreationAppData,
+        quote::{OrderQuoteRequest, OrderQuoteSide, QuoteSigningScheme, SellAmount},
+    },
+    serde_json::json,
+    shared::ethrpc::Web3,
+};
+
+#[tokio::test]
+#[ignore]
+async fn local_node_test() {
+    run_test(test).await;
+}
+
+// Test that quoting works as expected
+async fn test(web3: Web3) {
+    tracing::info!("Setting up chain state.");
+    let mut onchain = OnchainComponents::deploy(web3).await;
+
+    let [solver] = onchain.make_solvers(to_wei(10)).await;
+    let [trader] = onchain.make_accounts(to_wei(10)).await;
+    let [token] = onchain
+        .deploy_tokens_with_weth_uni_v2_pools(to_wei(1_000), to_wei(1_000))
+        .await;
+
+    tx!(
+        trader.account(),
+        onchain
+            .contracts()
+            .weth
+            .approve(onchain.contracts().allowance, to_wei(3))
+    );
+    tx_value!(
+        trader.account(),
+        to_wei(3),
+        onchain.contracts().weth.deposit()
+    );
+
+    tracing::info!("Starting services.");
+    let solver_endpoint = colocation::start_solver(onchain.contracts().weth.address()).await;
+    colocation::start_driver(onchain.contracts(), &solver_endpoint, &solver);
+
+    let services = Services::new(onchain.contracts()).await;
+    services
+        .start_api(vec!["--enable-custom-interactions=true".to_string()])
+        .await;
+
+    tracing::info!("Quoting order");
+    let request = OrderQuoteRequest {
+        from: trader.address(),
+        sell_token: onchain.contracts().weth.address(),
+        buy_token: token.address(),
+        side: OrderQuoteSide::Sell {
+            sell_amount: SellAmount::BeforeFee { value: to_wei(1) },
+        },
+        ..Default::default()
+    };
+
+    let with_eip1271 = services
+        .submit_quote(&OrderQuoteRequest {
+            signing_scheme: QuoteSigningScheme::Eip1271 {
+                onchain_order: false,
+                verification_gas_limit: 50_000,
+            },
+            ..request.clone()
+        })
+        .await
+        .unwrap();
+
+    let with_hooks = services
+        .submit_quote(&OrderQuoteRequest {
+            app_data: OrderCreationAppData::Full {
+                full: serde_json::to_string(&json!({
+                    "backend": {
+                        "hooks": {
+                            "pre": [
+                                {
+                                    "target": "0x0000000000000000000000000000000000000000",
+                                    "callData": "0x",
+                                    "gasLimit": "5000",
+                                },
+                            ],
+                            "post": [
+                                {
+                                    "target": "0x0000000000000000000000000000000000000000",
+                                    "callData": "0x",
+                                    "gasLimit": "5000",
+                                },
+                            ],
+                        },
+                    },
+                }))
+                .unwrap(),
+            },
+            ..request.clone()
+        })
+        .await
+        .unwrap();
+
+    let base = services.submit_quote(&request).await.unwrap();
+
+    tracing::debug!(?with_eip1271, ?with_hooks, ?base, "Computed quotes.");
+
+    assert!(base.quote.fee_amount < with_eip1271.quote.fee_amount);
+    assert!(base.quote.fee_amount < with_hooks.quote.fee_amount);
+
+    // TODO: test verified quotes, requires state overrides support.
+}

--- a/crates/e2e/tests/e2e/setup/mod.rs
+++ b/crates/e2e/tests/e2e/setup/mod.rs
@@ -72,10 +72,11 @@ where
 {
     let filters = [
         "warn",
-        "e2e=debug",
         "autopilot=debug",
         "driver=debug",
+        "e2e=debug",
         "orderbook=debug",
+        "shared=debug",
         "solver=debug",
         "solvers=debug",
         "orderbook::api::request_summary=off",

--- a/crates/orderbook/src/api/post_quote.rs
+++ b/crates/orderbook/src/api/post_quote.rs
@@ -1,5 +1,5 @@
 use {
-    super::post_order::PartialValidationErrorWrapper,
+    super::post_order::{AppDataValidationErrorWrapper, PartialValidationErrorWrapper},
     anyhow::Result,
     model::quote::OrderQuoteRequest,
     reqwest::StatusCode,
@@ -40,9 +40,8 @@ pub struct OrderQuoteErrorWrapper(pub OrderQuoteError);
 impl IntoWarpReply for OrderQuoteErrorWrapper {
     fn into_warp_reply(self) -> ApiReply {
         match self.0 {
-            OrderQuoteError::Validation(err) => {
-                PartialValidationErrorWrapper(err).into_warp_reply()
-            }
+            OrderQuoteError::AppData(err) => AppDataValidationErrorWrapper(err).into_warp_reply(),
+            OrderQuoteError::Order(err) => PartialValidationErrorWrapper(err).into_warp_reply(),
             OrderQuoteError::CalculateQuote(err) => {
                 CalculateQuoteErrorWrapper(err).into_warp_reply()
             }
@@ -128,7 +127,7 @@ mod tests {
                     sell_amount: SellAmount::AfterFee { value: 1337.into() },
                 },
                 validity: Validity::To(0x12345678),
-                app_data: AppDataHash([0x90; 32]),
+                app_data: AppDataHash([0x90; 32]).into(),
                 partially_fillable: false,
                 sell_token_balance: SellTokenSource::Erc20,
                 buy_token_balance: BuyTokenDestination::Internal,
@@ -165,7 +164,7 @@ mod tests {
                     sell_amount: SellAmount::BeforeFee { value: 1337.into() },
                 },
                 validity: Validity::For(1000),
-                app_data: AppDataHash([0x90; 32]),
+                app_data: AppDataHash([0x90; 32]).into(),
                 partially_fillable: false,
                 sell_token_balance: SellTokenSource::External,
                 price_quality: PriceQuality::Fast,
@@ -198,7 +197,7 @@ mod tests {
                     buy_amount_after_fee: U256::from(1337),
                 },
                 validity: Validity::To(0x12345678),
-                app_data: AppDataHash([0x90; 32]),
+                app_data: AppDataHash([0x90; 32]).into(),
                 partially_fillable: false,
                 ..Default::default()
             }

--- a/crates/shared/src/order_validation.rs
+++ b/crates/shared/src/order_validation.rs
@@ -67,6 +67,14 @@ pub trait OrderValidating: Send + Sync {
     ///     - buy & sell tokens passed "bad token" detection,
     async fn partial_validate(&self, order: PreOrderData) -> Result<(), PartialValidationError>;
 
+    /// This validates an order's app-data and returns TODONOW
+    fn validate_app_data(
+        &self,
+        app_data: &OrderCreationAppData,
+        full_app_data_override: &Option<String>,
+        order_partially_fillable: bool,
+    ) -> Result<OrderAppData, AppDataValidationError>;
+
     /// This is the full order validation performed at the time of order
     /// placement (i.e. once all the required fields on an Order are
     /// provided). Specifically, verifying that
@@ -104,7 +112,6 @@ pub enum PartialValidationError {
     UnsupportedOrderType,
     UnsupportedSignature,
     UnsupportedToken { token: H160, reason: String },
-    UnsupportedCustomInteraction,
     Other(anyhow::Error),
 }
 
@@ -115,8 +122,19 @@ impl From<OrderValidToError> for PartialValidationError {
 }
 
 #[derive(Debug)]
+pub enum AppDataValidationError {
+    Mismatch {
+        provided: AppDataHash,
+        actual: AppDataHash,
+    },
+    Invalid(anyhow::Error),
+    UnsupportedCustomInteraction,
+}
+
+#[derive(Debug)]
 pub enum ValidationError {
     Partial(PartialValidationError),
+    AppData(AppDataValidationError),
     /// The quote ID specified with the order could not be found.
     QuoteNotFound,
     /// The quote specified by ID is invalid. Either it doesn't match the order
@@ -141,12 +159,13 @@ pub enum ValidationError {
     ZeroAmount,
     IncompatibleSigningScheme,
     TooManyLimitOrders,
-    InvalidAppData(anyhow::Error),
-    AppDataHashMismatch {
-        provided: AppDataHash,
-        actual: AppDataHash,
-    },
     Other(anyhow::Error),
+}
+
+impl From<AppDataValidationError> for ValidationError {
+    fn from(value: AppDataValidationError) -> Self {
+        Self::AppData(value)
+    }
 }
 
 pub fn onchain_order_placement_error_from(error: ValidationError) -> OnchainOrderPlacementError {
@@ -286,6 +305,11 @@ impl PreOrderData {
             },
         }
     }
+}
+
+pub struct OrderAppData {
+    pub inner: ValidatedAppData,
+    pub interactions: Interactions,
 }
 
 impl OrderValidator {
@@ -489,27 +513,25 @@ impl OrderValidating for OrderValidator {
         Ok(())
     }
 
-    async fn validate_and_construct_order(
+    fn validate_app_data(
         &self,
-        order: OrderCreation,
-        domain_separator: &DomainSeparator,
-        settlement_contract: H160,
-        full_app_data_override: Option<String>,
-    ) -> Result<(Order, Option<Quote>), ValidationError> {
-        // Happens before signature verification because a miscalculated app data hash
-        // by the API user would lead to being unable to validate the signature below.
-        let validate = |app_data: &String| -> Result<_, ValidationError> {
+        app_data: &OrderCreationAppData,
+        full_app_data_override: &Option<String>,
+        order_partially_fillable: bool,
+    ) -> Result<OrderAppData, AppDataValidationError> {
+        let validate = |app_data: &str| -> Result<_, AppDataValidationError> {
             let app_data = self
                 .app_data_validator
                 .validate(app_data.as_bytes())
-                .map_err(ValidationError::InvalidAppData)?;
+                .map_err(AppDataValidationError::Invalid)?;
             Ok(app_data)
         };
-        let app_data = match &order.app_data {
+
+        let app_data = match app_data {
             OrderCreationAppData::Both { full, expected } => {
                 let validated = validate(full)?;
                 if validated.hash != *expected {
-                    return Err(ValidationError::AppDataHashMismatch {
+                    return Err(AppDataValidationError::Mismatch {
                         provided: *expected,
                         actual: validated.hash,
                     });
@@ -517,9 +539,9 @@ impl OrderValidating for OrderValidator {
                 validated
             }
             OrderCreationAppData::Hash { hash } => {
-                // Eventually we're not going to accept orders that set only a hash and where we
-                // can't find full app data elsewhere.
-                let backend = if let Some(full) = &full_app_data_override {
+                // Eventually we're not going to accept orders that set only a
+                // hash and where we can't find full app data elsewhere.
+                let backend = if let Some(full) = full_app_data_override {
                     validate(full)?.backend
                 } else {
                     BackendAppData::default()
@@ -537,23 +559,40 @@ impl OrderValidating for OrderValidator {
         if !app_data.backend.hooks.is_empty() {
             // custom interactions are disabled
             if !self.enable_custom_interactions {
-                return Err(ValidationError::Partial(
-                    PartialValidationError::UnsupportedCustomInteraction,
-                ));
+                return Err(AppDataValidationError::UnsupportedCustomInteraction);
             }
             // custom interactions are not allowed for partially fillable orders
-            if order.partially_fillable {
-                return Err(ValidationError::Partial(
-                    PartialValidationError::UnsupportedCustomInteraction,
-                ));
+            if order_partially_fillable {
+                return Err(AppDataValidationError::UnsupportedCustomInteraction);
             }
         }
         let interactions = self.custom_interactions(&app_data.backend.hooks);
 
+        Ok(OrderAppData {
+            inner: app_data,
+            interactions,
+        })
+    }
+
+    async fn validate_and_construct_order(
+        &self,
+        order: OrderCreation,
+        domain_separator: &DomainSeparator,
+        settlement_contract: H160,
+        full_app_data_override: Option<String>,
+    ) -> Result<(Order, Option<Quote>), ValidationError> {
+        // Happens before signature verification because a miscalculated app data hash
+        // by the API user would lead to being unable to validate the signature below.
+        let app_data = self.validate_app_data(
+            &order.app_data,
+            &full_app_data_override,
+            order.partially_fillable,
+        )?;
+
         let owner = order.verify_owner(domain_separator)?;
         let signing_scheme = order.signature.scheme();
         let data = OrderData {
-            app_data: app_data.hash,
+            app_data: app_data.inner.hash,
             ..order.data()
         };
         let uid = data.uid(domain_separator, &owner);
@@ -573,7 +612,7 @@ impl OrderValidating for OrderValidator {
                         signer: owner,
                         hash,
                         signature: signature.to_owned(),
-                        interactions: interactions.pre.clone(),
+                        interactions: app_data.interactions.pre.clone(),
                     })
                     .await
                     .map_err(|err| match err {
@@ -603,17 +642,13 @@ impl OrderValidating for OrderValidator {
             .await
             .map_err(ValidationError::Partial)?;
 
-        let map_interactions =
-            |interactions: &[InteractionData]| -> Vec<trade_finding::Interaction> {
-                interactions.iter().cloned().map(Into::into).collect()
-            };
         let verification = self.request_verified_quotes.then_some(Verification {
             from: owner,
             receiver: order.receiver.unwrap_or(owner),
             sell_token_source: order.sell_token_balance,
             buy_token_destination: order.buy_token_balance,
-            pre_interactions: map_interactions(&interactions.pre),
-            post_interactions: map_interactions(&interactions.post),
+            pre_interactions: trade_finding::map_interactions(&app_data.interactions.pre),
+            post_interactions: trade_finding::map_interactions(&app_data.interactions.post),
         });
 
         let quote_parameters = QuoteSearchParameters {
@@ -628,7 +663,7 @@ impl OrderValidating for OrderValidator {
                 true,
                 verification_gas_limit,
             )?,
-            additional_gas: app_data.backend.hooks.gas_limit(),
+            additional_gas: app_data.inner.backend.hooks.gas_limit(),
             verification,
         };
         let quote = if class == OrderClass::Market {
@@ -668,7 +703,7 @@ impl OrderValidating for OrderValidator {
                     token: data.sell_token,
                     owner,
                     source: data.sell_token_balance,
-                    interactions: interactions.pre.clone(),
+                    interactions: app_data.interactions.pre.clone(),
                 },
                 min_balance,
             )
@@ -741,7 +776,7 @@ impl OrderValidating for OrderValidator {
             },
             signature: order.signature.clone(),
             data,
-            interactions,
+            interactions: app_data.interactions,
         };
 
         Ok((order, quote))

--- a/crates/shared/src/order_validation.rs
+++ b/crates/shared/src/order_validation.rs
@@ -67,7 +67,9 @@ pub trait OrderValidating: Send + Sync {
     ///     - buy & sell tokens passed "bad token" detection,
     async fn partial_validate(&self, order: PreOrderData) -> Result<(), PartialValidationError>;
 
-    /// This validates an order's app-data and returns TODONOW
+    /// This validates an order's app-data and returns the parsed
+    /// `BackendAppData` value along with the corresponding rendered
+    /// interactions that were specified in the `app_data`.
     fn validate_app_data(
         &self,
         app_data: &OrderCreationAppData,

--- a/crates/shared/src/trade_finding.rs
+++ b/crates/shared/src/trade_finding.rs
@@ -158,6 +158,10 @@ impl Clone for TradeError {
     }
 }
 
+pub fn map_interactions(interactions: &[InteractionData]) -> Vec<Interaction> {
+    interactions.iter().cloned().map(Into::into).collect()
+}
+
 #[cfg(test)]
 mod tests {
     use {super::*, hex_literal::hex};


### PR DESCRIPTION
This PR changes the `api/v1/quote` request to accept full app-data instead of just app-data hashes. This allows quoting to account for order hooks (i.e. custom interactions) when computing fees.

### Test Plan

Added new E2E test that verifies quoting logic with additional gas costs.
