### PR TITLE
Send Order Interactions To Colocated Driver

### DIFF
--- a/crates/autopilot/src/driver_model.rs
+++ b/crates/autopilot/src/driver_model.rs
@@ -49,6 +49,7 @@ pub mod solve {
         chrono::{DateTime, Utc},
         model::{
             app_id::AppDataHash,
+            bytes_hex::BytesHex,
             order::{BuyTokenDestination, OrderKind, OrderUid, SellTokenSource},
             signature::Signature,
             u256_decimal::DecimalU256,
@@ -101,8 +102,8 @@ pub mod solve {
         pub partially_fillable: bool,
         #[serde_as(as = "DecimalU256")]
         pub executed: U256,
-        pub pre_interactions: Vec<()>,
-        pub post_interactions: Vec<()>,
+        pub pre_interactions: Vec<Interaction>,
+        pub post_interactions: Vec<Interaction>,
         pub sell_token_balance: SellTokenSource,
         pub buy_token_balance: BuyTokenDestination,
         pub class: Class,
@@ -119,6 +120,17 @@ pub mod solve {
         Market,
         Limit,
         Liquidity,
+    }
+
+    #[serde_as]
+    #[derive(Clone, Debug, Serialize, Deserialize)]
+    #[serde(rename_all = "camelCase")]
+    pub struct Interaction {
+        pub target: H160,
+        #[serde_as(as = "DecimalU256")]
+        pub value: U256,
+        #[serde_as(as = "BytesHex")]
+        pub call_data: Vec<u8>,
     }
 
     #[derive(Clone, Debug, Default, Deserialize)]

--- a/crates/autopilot/src/run_loop.rs
+++ b/crates/autopilot/src/run_loop.rs
@@ -14,6 +14,7 @@ use {
     itertools::Itertools,
     model::{
         auction::{Auction, AuctionId},
+        interaction::InteractionData,
         order::{LimitOrderClass, OrderClass},
     },
     primitive_types::{H160, H256},
@@ -216,6 +217,17 @@ impl RunLoop {
                             (Class::Limit, surplus_fee)
                         }
                     };
+                    let map_interactions =
+                        |interactions: &[InteractionData]| -> Vec<solve::Interaction> {
+                            interactions
+                                .iter()
+                                .map(|interaction| solve::Interaction {
+                                    target: interaction.target,
+                                    value: interaction.value,
+                                    call_data: interaction.call_data.clone(),
+                                })
+                                .collect()
+                        };
                     solve::Order {
                         uid: order.metadata.uid,
                         sell_token: order.data.sell_token,
@@ -230,8 +242,8 @@ impl RunLoop {
                         owner: order.metadata.owner,
                         partially_fillable: order.data.partially_fillable,
                         executed: Default::default(),
-                        pre_interactions: Default::default(),
-                        post_interactions: Default::default(),
+                        pre_interactions: map_interactions(&order.interactions.pre),
+                        post_interactions: map_interactions(&order.interactions.post),
                         sell_token_balance: order.data.sell_token_balance,
                         buy_token_balance: order.data.buy_token_balance,
                         class,

--- a/crates/driver/openapi.yml
+++ b/crates/driver/openapi.yml
@@ -165,6 +165,10 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/Interaction"
+        postInteractions:
+          type: array
+          items:
+            $ref: "#/components/schemas/Interaction"
         sellTokenBalance:
           type: string
           enum: ["erc20", "internal", "external"]

--- a/crates/driver/src/domain/mempools.rs
+++ b/crates/driver/src/domain/mempools.rs
@@ -27,8 +27,8 @@ impl Mempools {
             let solver = solver.clone();
             let settlement = settlement.clone();
             async move {
-                let result = mempool.execute(&solver, settlement).await;
-                observe::mempool_executed(solver.name(), &mempool, &result);
+                let result = mempool.execute(&solver, settlement.clone()).await;
+                observe::mempool_executed(solver.name(), &mempool, &settlement, &result);
                 result
             }
             .boxed()

--- a/crates/driver/src/infra/observe/mod.rs
+++ b/crates/driver/src/infra/observe/mod.rs
@@ -262,14 +262,21 @@ pub fn solver_response(solver: &solver::Name, endpoint: &Url, res: Result<&str, 
 pub fn mempool_executed(
     solver: &solver::Name,
     mempool: &Mempool,
+    settlement: &Settlement,
     res: &Result<eth::TxId, boundary::Error>,
 ) {
     match res {
         Ok(txid) => {
-            tracing::info!(%solver, ?txid, ?mempool, "sending transaction via mempool succeeded");
+            tracing::info!(
+                %solver, ?txid, ?mempool, ?settlement,
+                "sending transaction via mempool succeeded",
+            );
         }
         Err(err) => {
-            tracing::warn!(%solver, ?err, ?mempool, "sending transaction via mempool failed");
+            tracing::warn!(
+                %solver, ?err, ?mempool, ?settlement,
+                "sending transaction via mempool failed",
+            );
         }
     }
 }

--- a/crates/e2e/tests/e2e/colocation_hooks.rs
+++ b/crates/e2e/tests/e2e/colocation_hooks.rs
@@ -1,0 +1,160 @@
+use {
+    crate::setup::*,
+    ethcontract::U256,
+    model::{
+        order::{OrderCreation, OrderCreationAppData, OrderKind},
+        signature::EcdsaSigningScheme,
+    },
+    secp256k1::SecretKey,
+    serde_json::json,
+    shared::ethrpc::Web3,
+    web3::signing::SecretKeyRef,
+};
+
+#[tokio::test]
+#[ignore]
+async fn local_node_test() {
+    run_test(test).await;
+}
+
+async fn test(web3: Web3) {
+    let mut onchain = OnchainComponents::deploy(web3).await;
+
+    let [solver] = onchain.make_solvers(to_wei(1)).await;
+    let [trader] = onchain.make_accounts(to_wei(1)).await;
+    let cow = onchain
+        .deploy_cow_weth_pool(to_wei(1_000_000), to_wei(1_000), to_wei(1_000))
+        .await;
+
+    // Fund trader accounts
+    cow.fund(trader.address(), to_wei(5)).await;
+
+    // Sign a permit pre-interaction for trading.
+    let permit = cow
+        .permit(&trader, onchain.contracts().allowance, to_wei(5))
+        .await;
+    // Setup a malicious interaction for setting approvals to steal funds from
+    // the settlement contract.
+    let steal_cow = hook_for_transaction(cow.approve(trader.address(), U256::max_value()).tx).await;
+    let steal_weth = hook_for_transaction(
+        onchain
+            .contracts()
+            .weth
+            .approve(trader.address(), U256::max_value())
+            .tx,
+    )
+    .await;
+
+    tracing::info!("Starting services.");
+    let solver_endpoint = colocation::start_solver(onchain.contracts().weth.address()).await;
+    colocation::start_driver(onchain.contracts(), &solver_endpoint, &solver);
+
+    let services = Services::new(onchain.contracts()).await;
+    services.start_autopilot(vec![
+        "--account-balances-optimistic-pre-interaction-handling=true".to_string(),
+        "--enable-colocation=true".to_string(),
+        "--drivers=http://localhost:11088/test_solver".to_string(),
+    ]);
+    services
+        .start_api(vec![
+            "--enable-custom-interactions=true".to_string(),
+            "--account-balances-optimistic-pre-interaction-handling=true".to_string(),
+        ])
+        .await;
+
+    let order = OrderCreation {
+        sell_token: cow.address(),
+        sell_amount: to_wei(4),
+        fee_amount: to_wei(1),
+        buy_token: onchain.contracts().weth.address(),
+        buy_amount: to_wei(3),
+        valid_to: model::time::now_in_epoch_seconds() + 300,
+        kind: OrderKind::Sell,
+        app_data: OrderCreationAppData::Full {
+            full: json!({
+                "backend": {
+                    "hooks": {
+                        "pre": [permit, steal_cow],
+                        "post": [steal_weth],
+                    },
+                },
+            })
+            .to_string(),
+        },
+        ..Default::default()
+    }
+    .sign(
+        EcdsaSigningScheme::Eip712,
+        &onchain.contracts().domain_separator,
+        SecretKeyRef::from(&SecretKey::from_slice(trader.private_key()).unwrap()),
+    );
+    services.create_order(&order).await.unwrap();
+
+    let balance = cow.balance_of(trader.address()).call().await.unwrap();
+    assert_eq!(balance, to_wei(5));
+
+    tracing::info!("Waiting for trade.");
+    let trade_happened = || async {
+        cow.balance_of(trader.address())
+            .call()
+            .await
+            .unwrap()
+            .is_zero()
+    };
+    wait_for_condition(TIMEOUT, trade_happened).await.unwrap();
+
+    // Check matching
+    let balance = onchain
+        .contracts()
+        .weth
+        .balance_of(trader.address())
+        .call()
+        .await
+        .unwrap();
+    assert!(balance >= order.buy_amount);
+
+    tracing::info!("Waiting for auction to be cleared.");
+    let auction_is_empty = || async { services.get_auction().await.auction.orders.is_empty() };
+    wait_for_condition(TIMEOUT, auction_is_empty).await.unwrap();
+
+    // Check malicious custom interactions did not work.
+    let allowance = cow
+        .allowance(
+            onchain.contracts().gp_settlement.address(),
+            trader.address(),
+        )
+        .call()
+        .await
+        .unwrap();
+    assert_eq!(allowance, U256::zero());
+    let allowance = onchain
+        .contracts()
+        .weth
+        .allowance(
+            onchain.contracts().gp_settlement.address(),
+            trader.address(),
+        )
+        .call()
+        .await
+        .unwrap();
+    assert_eq!(allowance, U256::zero());
+
+    // Note that the allowances were set with the `MultiSend` contract! This is
+    // OK since anyone can already trivially set these allowances there by
+    // calling the contract directly, since it has not restrictions on who can
+    // call it.
+    let allowance = cow
+        .allowance(onchain.contracts().multisend.address(), trader.address())
+        .call()
+        .await
+        .unwrap();
+    assert_eq!(allowance, U256::max_value());
+    let allowance = onchain
+        .contracts()
+        .weth
+        .allowance(onchain.contracts().multisend.address(), trader.address())
+        .call()
+        .await
+        .unwrap();
+    assert_eq!(allowance, U256::max_value());
+}

--- a/crates/e2e/tests/e2e/hooks.rs
+++ b/crates/e2e/tests/e2e/hooks.rs
@@ -13,11 +13,11 @@ use {
 
 #[tokio::test]
 #[ignore]
-async fn local_node_pre_interaction() {
-    run_test(pre_interaction).await;
+async fn local_node_test() {
+    run_test(test).await;
 }
 
-async fn pre_interaction(web3: Web3) {
+async fn test(web3: Web3) {
     let mut onchain = OnchainComponents::deploy(web3).await;
 
     let [solver] = onchain.make_solvers(to_wei(1)).await;

--- a/crates/e2e/tests/e2e/main.rs
+++ b/crates/e2e/tests/e2e/main.rs
@@ -9,18 +9,19 @@ mod local_node;
 
 // Each of the following modules contains tests.
 mod app_data;
+mod colocation_hooks;
 mod colocation_partial_fill;
 mod colocation_univ2;
 mod database;
 mod eth_flow;
 mod eth_integration;
+mod hooks;
 mod limit_orders;
 mod onchain_settlement;
 mod order_cancellation;
 mod partially_fillable_balance;
 mod partially_fillable_observed_score;
 mod partially_fillable_pool;
-mod pre_interaction;
 mod quoting;
 mod refunder;
 mod settlement_without_onchain_liquidity;


### PR DESCRIPTION
In debugging why custom order interactions were not working on Goerli for my demo, I realized that we weren't serializing order interactions in the auction that we send to co-located drivers 🤦.

This PR fixes this issue, we now correctly marshal the interactions to the co-located drivers for solving.

### Test Plan

Duplicated the hooks E2E test (formerly named `pre_interaction`, and renamed to `hooks` here, since we now call these hooks, and the E2E test included both pre- and post- hooks, so it was badly named to begin with).
