### PR TITLE
Make App Data Size Limit Configurable

### DIFF
--- a/crates/orderbook/src/arguments.rs
+++ b/crates/orderbook/src/arguments.rs
@@ -173,6 +173,10 @@ pub struct Arguments {
     /// contract deployment for the current network will be used.
     #[clap(long, env)]
     pub multisend_contract_address: Option<H160>,
+
+    /// Set the maximum size in bytes of order app data.
+    #[clap(long, env, default_value = "8192")]
+    pub app_data_size_limit: usize,
 }
 
 impl std::fmt::Display for Arguments {
@@ -258,6 +262,7 @@ impl std::fmt::Display for Arguments {
             "multisend_contract_address",
             &self.multisend_contract_address.map(|a| format!("{a:?}")),
         )?;
+        writeln!(f, "app_data_size_limit: {}", self.app_data_size_limit)?;
 
         Ok(())
     }

--- a/crates/orderbook/src/run.rs
+++ b/crates/orderbook/src/run.rs
@@ -474,7 +474,7 @@ pub async fn run(args: Arguments) {
             Arc::new(postgres.clone()),
             args.max_limit_orders_per_user,
             Arc::new(CachedCodeFetcher::new(Arc::new(web3.clone()))),
-            shared::app_data::Validator::default(),
+            shared::app_data::Validator::new(args.app_data_size_limit),
         )
         .with_fill_or_kill_limit_orders(args.allow_placing_fill_or_kill_limit_orders)
         .with_partially_fillable_limit_orders(args.allow_placing_partially_fillable_limit_orders)

--- a/crates/shared/src/app_data.rs
+++ b/crates/shared/src/app_data.rs
@@ -22,6 +22,7 @@ pub struct Validator {
     size_limit: usize,
 }
 
+#[cfg(test)]
 impl Default for Validator {
     fn default() -> Self {
         Self { size_limit: 8192 }
@@ -29,6 +30,10 @@ impl Default for Validator {
 }
 
 impl Validator {
+    pub fn new(size_limit: usize) -> Self {
+        Self { size_limit }
+    }
+
     pub fn validate(&self, full_app_data: &[u8]) -> Result<ValidatedAppData> {
         if full_app_data.len() > self.size_limit {
             return Err(anyhow!(


### PR DESCRIPTION
☝️ 

### Test Plan

```
% cargo run -p orderbook
...
app_data_size_limit: 8192
...
```
