### PR TITLE
Pass token info to `driver`

### DIFF
--- a/crates/autopilot/src/driver_model.rs
+++ b/crates/autopilot/src/driver_model.rs
@@ -78,6 +78,8 @@ pub mod solve {
         #[serde_as(as = "Option<DisplayFromStr>")]
         pub price: Option<U256>,
         pub trusted: bool,
+        pub decimals: Option<u8>,
+        pub symbol: Option<String>,
     }
 
     #[serde_as]

--- a/crates/autopilot/src/lib.rs
+++ b/crates/autopilot/src/lib.rs
@@ -638,6 +638,7 @@ pub async fn main(args: arguments::Arguments) {
             market_makable_token_list,
             submission_deadline: args.submission_deadline as u64,
             additional_deadline_for_rewards: args.additional_deadline_for_rewards as u64,
+            token_info: token_info_fetcher,
         };
         run.run_forever().await;
         unreachable!("run loop exited");

--- a/crates/driver/src/domain/competition/auction.rs
+++ b/crates/driver/src/domain/competition/auction.rs
@@ -35,6 +35,7 @@ pub struct Token {
     pub symbol: Option<String>,
     pub address: eth::TokenAddress,
     pub price: Option<Price>,
+    // TODO Set this field correctly, currently it isn't being passed into the driver.
     /// The balance of this token available in our settlement contract.
     pub available_balance: eth::U256,
     /// Is this token well-known and trusted by the protocol?

--- a/crates/driver/src/infra/api/routes/solve/dto/auction.rs
+++ b/crates/driver/src/infra/api/routes/solve/dto/auction.rs
@@ -21,8 +21,8 @@ impl Auction {
                 .tokens
                 .into_iter()
                 .map(|token| competition::auction::Token {
-                    decimals: None,
-                    symbol: None,
+                    decimals: token.decimals,
+                    symbol: token.symbol,
                     address: token.address.into(),
                     price: token.price.map(Into::into),
                     available_balance: Default::default(),
@@ -171,6 +171,8 @@ struct Token {
     #[serde_as(as = "Option<serialize::U256>")]
     pub price: Option<eth::U256>,
     pub trusted: bool,
+    pub decimals: Option<u8>,
+    pub symbol: Option<String>,
 }
 
 #[serde_as]


### PR DESCRIPTION
There were problems with the ParaSwap solver indicating that token decimals are missing. This was because the autopilot wasn't passing the token info to the driver correctly.

### Test Plan

CI still passes, will test this again on staging at some point.
