### PR TITLE
`driver`: rename a few types

### DIFF
--- a/crates/driver/src/infra/api/routes/settle.rs
+++ b/crates/driver/src/infra/api/routes/settle.rs
@@ -44,11 +44,11 @@ struct CalldataInner {
 }
 
 impl Calldata {
-    pub fn new(calldata: competition::Calldata) -> Self {
+    pub fn new(calldata: competition::Settled) -> Self {
         Self {
             calldata: CalldataInner {
-                internalized: calldata.internalized.into(),
-                uninternalized: calldata.uninternalized.into(),
+                internalized: calldata.internalized_calldata.into(),
+                uninternalized: calldata.uninternalized_calldata.into(),
             },
         }
     }

--- a/crates/driver/src/infra/api/routes/solve/dto/solution.rs
+++ b/crates/driver/src/infra/api/routes/solve/dto/solution.rs
@@ -12,7 +12,7 @@ use {
 };
 
 impl Solution {
-    pub fn new(reveal: competition::Reveal, solver: &Solver) -> Self {
+    pub fn new(reveal: competition::Solved, solver: &Solver) -> Self {
         Self {
             score: reveal.score.into(),
             submission_address: solver.address().into(),

--- a/crates/driver/src/infra/observe/mod.rs
+++ b/crates/driver/src/infra/observe/mod.rs
@@ -13,8 +13,8 @@ use {
                 auction,
                 solution::{self, Settlement},
                 Auction,
-                Reveal,
                 Solution,
+                Solved,
             },
             eth,
             quote::{self, Quote},
@@ -148,7 +148,7 @@ pub fn settling(solver: &solver::Name, auction_id: Option<auction::Id>) {
 pub fn settled(
     solver: &solver::Name,
     auction_id: Option<auction::Id>,
-    result: &Result<competition::Calldata, competition::Error>,
+    result: &Result<competition::Settled, competition::Error>,
 ) {
     match result {
         Ok(calldata) => {
@@ -172,7 +172,7 @@ pub fn settled(
 pub fn solved(
     solver: &solver::Name,
     auction: &Auction,
-    result: &Result<Reveal, competition::Error>,
+    result: &Result<Solved, competition::Error>,
 ) {
     match result {
         Ok(reveal) => {


### PR DESCRIPTION
Rename `competition::Reveal` into `competition::Solved` and `competition::Calldata` into `competition::Settled`.