### PR TITLE
[HotFix] Fix KMS submission for private submission strategies

### DIFF
--- a/crates/solver/src/settlement_submission.rs
+++ b/crates/solver/src/settlement_submission.rs
@@ -308,7 +308,7 @@ impl SolutionSubmitter {
     ) -> Result<SubmissionReceipt, SubmissionError> {
         match strategy {
             TransactionStrategy::Eden(_) | TransactionStrategy::Flashbots(_) => {
-                if !matches!(account, Account::Offline(..)) {
+                if !matches!(account, Account::Offline(..) | Account::Kms(..)) {
                     return Err(SubmissionError::from(anyhow!(
                         "Submission to private network requires offline account for signing"
                     )));

--- a/crates/solver/src/settlement_submission/submitter/common.rs
+++ b/crates/solver/src/settlement_submission/submitter/common.rs
@@ -2,7 +2,6 @@ use {
     super::super::submitter::TransactionHandle,
     anyhow::Result,
     ethcontract::transaction::{Transaction, TransactionBuilder},
-    futures::FutureExt,
     shared::ethrpc::{Web3, Web3Transport},
     web3::{api::Namespace, types::Bytes},
 };
@@ -27,7 +26,7 @@ impl PrivateNetwork {
         &self,
         tx: TransactionBuilder<Web3Transport>,
     ) -> Result<TransactionHandle> {
-        let (raw_signed_transaction, tx_hash) = match tx.build().now_or_never().unwrap().unwrap() {
+        let (raw_signed_transaction, tx_hash) = match tx.build().await.unwrap() {
             Transaction::Request(_) => unreachable!("verified offline account was used"),
             Transaction::Raw { bytes, hash } => (bytes.0, hash),
         };

--- a/crates/solver/src/settlement_submission/submitter/common.rs
+++ b/crates/solver/src/settlement_submission/submitter/common.rs
@@ -26,7 +26,7 @@ impl PrivateNetwork {
         &self,
         tx: TransactionBuilder<Web3Transport>,
     ) -> Result<TransactionHandle> {
-        let (raw_signed_transaction, tx_hash) = match tx.build().await.unwrap() {
+        let (raw_signed_transaction, tx_hash) = match tx.build().await? {
             Transaction::Request(_) => unreachable!("verified offline account was used"),
             Transaction::Raw { bytes, hash } => (bytes.0, hash),
         };


### PR DESCRIPTION
Fixes the fact that we cannot settle private mempool transactions with KMS keys. I overlooked and didn't test this codepath during development. Thanks to @vkgnosis for pointing me to the relevant change.

My plan is to hotfix prod so we can continue the key rotation as planned.

### Test Plan

Locally ran the driver against the staging orderbook with the Legacy solver KMS key (in flashbots only mode). Got this successfult settlement: [0x5537310468560e1954877d8c25a281264010429cdd58e8b90a1f29df6b26513f](https://etherscan.io/tx/0x5537310468560e1954877d8c25a281264010429cdd58e8b90a1f29df6b26513f)
