### PR TITLE
Send `/notification` when solver returns empty solution

### DIFF
--- a/crates/shared/src/http_solver/model.rs
+++ b/crates/shared/src/http_solver/model.rs
@@ -356,6 +356,9 @@ pub enum SolverRejectionReason {
     /// The solver didn't return a successful response
     RunError(SolverRunError),
 
+    /// The solver returned an empty solution
+    EmptySolution,
+
     /// The solution candidate didn't include any user orders
     NoUserOrders,
 

--- a/crates/solver/src/settlement_ranker.rs
+++ b/crates/solver/src/settlement_ranker.rs
@@ -60,6 +60,12 @@ impl SettlementRanker {
         let name = solver.name();
         match settlements {
             Ok(settlements) => {
+                if settlements.is_empty() {
+                    solver.notify_auction_result(
+                        auction_id,
+                        AuctionResult::Rejected(SolverRejectionReason::NoUserOrders),
+                    );
+                }
                 let settlements: Vec<_> = settlements.into_iter().filter_map(|settlement| {
                     tracing::debug!(solver_name = %name, ?settlement, "found solution");
 

--- a/crates/solver/src/settlement_ranker.rs
+++ b/crates/solver/src/settlement_ranker.rs
@@ -63,7 +63,7 @@ impl SettlementRanker {
                 if settlements.is_empty() {
                     solver.notify_auction_result(
                         auction_id,
-                        AuctionResult::Rejected(SolverRejectionReason::NoUserOrders),
+                        AuctionResult::Rejected(SolverRejectionReason::EmptySolution),
                     );
                 }
                 let settlements: Vec<_> = settlements.into_iter().filter_map(|settlement| {


### PR DESCRIPTION
I [found a bug](https://cowservices.slack.com/archives/C0361CDD1FZ/p1689175111103549) while on call.

### Test Plan

Beads & prayer