### PR TITLE
Fix Paraswap solver not classying liquidity errors properly

### DIFF
--- a/crates/solver/src/solver/paraswap_solver.rs
+++ b/crates/solver/src/solver/paraswap_solver.rs
@@ -153,7 +153,7 @@ impl ParaswapSolver {
         &self,
         order: &LimitOrder,
         token_info: &HashMap<H160, TokenInfo>,
-    ) -> Result<PriceResponse> {
+    ) -> Result<PriceResponse, ParaswapResponseError> {
         let (amount, side) = match order.kind {
             model::order::OrderKind::Buy => (order.buy_amount, Side::Buy),
             model::order::OrderKind::Sell => (order.sell_amount, Side::Sell),


### PR DESCRIPTION
Prod mainnet got an alert about high Paraswap SingleOrderSolver errors. I investigated this alert. The reason for it is that errors from the /price route were not classified into benign errors properly.  The function querying the price endpoint was returning a generic anyhow::Error instead of the specific Paraswap error, which distinguishes between liquidity errors and other errors. Both error types are convertible into SettlementError, which is used in the function calling the changed function, so either way the code compiles.

An example of this can be seen in [this](https://production-6de61f.kb.eu-central-1.aws.cloud.es.io/app/r/s/sCcAk) log. This error is a liquidity error and is detected `paraswap_api.rs` but we did not log it as benign later.

### Test Plan

Did not write a test for this because it involved too much mocking. After merging we should observe the Paraswap error metric going down.
