### PR TITLE
Classify "Bad USD price" as a liquidity error

### DIFF
--- a/crates/shared/src/paraswap_api.rs
+++ b/crates/shared/src/paraswap_api.rs
@@ -121,9 +121,8 @@ where
             }
             "ESTIMATED_LOSS_GREATER_THAN_MAX_IMPACT"
             | "No routes found with enough liquidity"
-            | "Too much slippage on quote, please try again" => {
-                Err(ParaswapResponseError::InsufficientLiquidity(message))
-            }
+            | "Too much slippage on quote, please try again"
+            | "Bad USD price" => Err(ParaswapResponseError::InsufficientLiquidity(message)),
             _ => Err(ParaswapResponseError::Other(anyhow::anyhow!(message))),
         },
     }


### PR DESCRIPTION
Prod mainnet got an alert about high Paraswap SingleOrderSolver errors. I investigated this alert. One reason for it is that Paraswap often returns the error "Bad USD price" [example](https://production-6de61f.kb.eu-central-1.aws.cloud.es.io/app/r/s/bsMlf) . It is unclear what this error means but it does not make sense to treat it as an error that justifies a warning. It is likely something like a liquidity error.

### Test Plan

Did not write a test for this because it involved too much mocking. After merging we should observe the Paraswap error metric going down.
