### PR TITLE
Change request histogram buckets

### DIFF
--- a/crates/shared/src/api.rs
+++ b/crates/shared/src/api.rs
@@ -49,7 +49,7 @@ struct ApiMetrics {
     requests_rejected: prometheus::IntCounterVec,
 
     /// Execution time for each API request.
-    #[metric(labels("method"))]
+    #[metric(labels("method"), buckets(0.1, 0.5, 1, 2, 4, 6, 8, 10))]
     requests_duration_seconds: prometheus::HistogramVec,
 }
 


### PR DESCRIPTION
We have some alerts about high response times when creating orders. The reason for this is the recently introduced fetching of app data from IPFS. Due to the decentralized nature of IPFS you have to pick some arbitrary cut off time at which you declare data as unavailable. This cut off time is currently 5s.

This interacts with how prometheus histograms work. Histograms have different sized buckets in which observations are sorted. We have buckets for 10ms, 20ms, 1s and so on and then a bucket for 5s and one for 10s. Requests without app data in IPFS take slightly longer than 5 seconds to answer, which makes the calculation of the 95th percentile over estimate. I know this because we also log the exact response times.

This PR changes which buckets we use for API requests. The default, which we have used until now, is     0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0 . I've removed most of the lower values because they are not interesting for us. Instead we have more values between 1 and 10 seconds.

### Test Plan

After merging see more accurate 95th percentile request-response time graphs.
