### PR TITLE
Fix 1inch solver not classifying rate limit errors properly

### DIFF
--- a/crates/shared/src/oneinch_api.rs
+++ b/crates/shared/src/oneinch_api.rs
@@ -595,7 +595,7 @@ impl Cache {
         &self,
         disabled_protocols: &[String],
         api: &dyn OneInchClient,
-    ) -> Result<Option<Vec<String>>> {
+    ) -> Result<Option<Vec<String>>, OneInchError> {
         if disabled_protocols.is_empty() {
             return Ok(None);
         }
@@ -620,15 +620,14 @@ impl Cache {
         Ok(Some(allowed_protocols))
     }
 
-    pub async fn spender(&self, api: &dyn OneInchClient) -> Result<Spender> {
-        Ok(self
-            .0
+    pub async fn spender(&self, api: &dyn OneInchClient) -> Result<Spender, OneInchError> {
+        self.0
             .spender
             .get_or_update(move || {
                 tracing::debug!("updating cached spender address");
                 api.get_spender()
             })
-            .await?)
+            .await
     }
 }
 


### PR DESCRIPTION
Prod mainnet got an alert about high 1nch SingleOrderSolver errors. I investigated this alert. One reason is that the code was not detecting rate limit errors in some case. Some functions making requests to the 1nch api were returning a generic anyhow::Error instead of the specific 1inch error, which distinguishes between rate limit errors and other errors. Both error types are convertible into SettlementError, which is used in the function calling the changed function, so either way the code compiles.

An example of this can be seen in [this](https://production-6de61f.kb.eu-central-1.aws.cloud.es.io/app/r/s/xKw6u) log. Despite/Because being rate limit we make requests to their api effectively in a hot loop. We can't parse the response but classify the error as retryable.

### Test Plan

Observe metrics afterwards
