### PR TITLE
Balancer V2 Liquidity Configuration in the Driver

### DIFF
--- a/crates/driver/src/boundary/liquidity/mod.rs
+++ b/crates/driver/src/boundary/liquidity/mod.rs
@@ -80,6 +80,13 @@ impl Fetcher {
         .into_iter()
         .try_collect()?;
 
+        if !config.balancer_v2.is_empty() {
+            todo!(
+                "Balancer V2 liquidity fetcher not implemented: {:?}",
+                config.balancer_v2
+            );
+        }
+
         let uni_v3: Vec<_> = future::join_all(
             config
                 .uniswap_v3

--- a/crates/driver/src/infra/config/file/mod.rs
+++ b/crates/driver/src/infra/config/file/mod.rs
@@ -222,6 +222,10 @@ pub struct LiquidityConfig {
     /// Liquidity provided by a Uniswap V3 compatible contract.
     #[serde(default)]
     pub uniswap_v3: Vec<UniswapV3Config>,
+
+    /// Liquidity provided by a Balancer V2 compatible contract.
+    #[serde(default)]
+    pub balancer_v2: Vec<BalancerV2Config>,
 }
 
 #[derive(Clone, Debug, Deserialize)]
@@ -305,4 +309,35 @@ mod uniswap_v3 {
     pub fn default_max_pools_to_initialize() -> u64 {
         50
     }
+}
+
+#[derive(Clone, Debug, Deserialize)]
+#[serde(untagged, deny_unknown_fields)]
+pub enum BalancerV2Config {
+    #[serde(rename_all = "kebab-case")]
+    Preset { preset: BalancerV2Preset },
+
+    #[serde(rename_all = "kebab-case")]
+    Manual {
+        /// Addresses of Balancer V2 compatible vault contract.
+        vault: eth::H160,
+
+        /// The weighted pool factory contract addresses.
+        weighted: Vec<eth::H160>,
+
+        /// The stable pool factory contract addresses.
+        stable: Vec<eth::H160>,
+
+        /// The liquidity bootstrapping pool factory contract addresses.
+        ///
+        /// These are weighted pools with dynamic weights for initial token
+        /// offerings.
+        liquidity_bootstrapping: Vec<eth::H160>,
+    },
+}
+
+#[derive(Clone, Debug, Deserialize)]
+#[serde(rename_all = "kebab-case", deny_unknown_fields)]
+pub enum BalancerV2Preset {
+    BalancerV2,
 }

--- a/crates/driver/src/run.rs
+++ b/crates/driver/src/run.rs
@@ -203,13 +203,44 @@ async fn liquidity(config: &config::Config, eth: &Ethereum) -> liquidity::Fetche
                         )
                     }
                 }
-                .expect("no Swapr preset for current network"),
+                .expect("no Uniswap V3 preset for current network"),
                 config::file::UniswapV3Config::Manual {
                     router,
                     max_pools_to_initialize,
                 } => liquidity::config::UniswapV3 {
                     router: router.into(),
                     max_pools_to_initialize,
+                },
+            })
+            .collect(),
+        balancer_v2: config
+            .liquidity
+            .balancer_v2
+            .iter()
+            .cloned()
+            .map(|config| match config {
+                config::file::BalancerV2Config::Preset { preset } => match preset {
+                    config::file::BalancerV2Preset::BalancerV2 => {
+                        liquidity::config::BalancerV2::balancer_v2(eth.network_id())
+                    }
+                }
+                .expect("no Balancer V2 preset for current network"),
+                config::file::BalancerV2Config::Manual {
+                    vault,
+                    weighted,
+                    stable,
+                    liquidity_bootstrapping,
+                } => liquidity::config::BalancerV2 {
+                    vault: vault.into(),
+                    weighted: weighted
+                        .into_iter()
+                        .map(eth::ContractAddress::from)
+                        .collect(),
+                    stable: stable.into_iter().map(eth::ContractAddress::from).collect(),
+                    liquidity_bootstrapping: liquidity_bootstrapping
+                        .into_iter()
+                        .map(eth::ContractAddress::from)
+                        .collect(),
                 },
             })
             .collect(),


### PR DESCRIPTION
☝️ 

This PR just introduces Balancer V2 liquidity in the driver.

### Test Plan

Run the driver with Balancer V2 liquidity and watch it crash (with the configuration!):

```
thread 'main' panicked at 'not yet implemented: Balancer V2 liquidity fetcher not implemented: [BalancerV2 { vault: ContractAddress(0xba12222222228d8ba445958a75a0704d566bf2c8), weighted: [ContractAddress(0x8e9aa87e45e92bad84d5f8dd1bff34fb92637de9), ContractAddress(0x5dd94da3644ddd055fcf6b3e1aa310bb7801eb8b), ContractAddress(0x897888115ada5773e02aa29f775430bfb5f34c51), ContractAddress(0xa5bf2ddf098bb0ef6d120c98217dd6b141c74ee0)], stable: [ContractAddress(0xc66ba2b6595d3613ccab350c886ace23866ede24), ContractAddress(0x8df6efec5547e31b0eb7d1291b511ff8a2bf987c)], liquidity_bootstrapping: [ContractAddress(0x751a0bc0e3f75b38e01cf25bfce7ff36de1c87de), ContractAddress(0x0f3e0c4218b7b0108a3643cfe9d3ec0d4f57c54e)] }]', /Users/nlordell/Developer/cowprotocol/services/crates/driver/src/boundary/liquidity/mod.rs:84:13
```
