### PR TITLE
Add Default Price Estimator

### DIFF
--- a/crates/autopilot/src/arguments.rs
+++ b/crates/autopilot/src/arguments.rs
@@ -5,7 +5,7 @@ use {
         arguments::{display_list, display_option},
         bad_token::token_owner_finder,
         http_client,
-        price_estimation,
+        price_estimation::{self, PriceEstimators},
     },
     std::{net::SocketAddr, num::NonZeroUsize, time::Duration},
     url::Url,
@@ -82,14 +82,8 @@ pub struct Arguments {
 
     /// Which estimators to use to estimate token prices in terms of the chain's
     /// native token.
-    #[clap(
-        long,
-        env,
-        value_enum,
-        use_value_delimiter = true,
-        default_value = "Baseline"
-    )]
-    pub native_price_estimators: Vec<shared::price_estimation::PriceEstimator>,
+    #[clap(long, env, default_value_t)]
+    pub native_price_estimators: PriceEstimators,
 
     /// The minimum amount of time in seconds an order has to be valid for.
     #[clap(
@@ -221,7 +215,7 @@ impl std::fmt::Display for Arguments {
         writeln!(f, "pool_cache_lru_size: {}", self.pool_cache_lru_size)?;
         writeln!(
             f,
-            "native_price_estimators: {:?}",
+            "native_price_estimators: {}",
             self.native_price_estimators
         )?;
         writeln!(

--- a/crates/autopilot/src/lib.rs
+++ b/crates/autopilot/src/lib.rs
@@ -398,13 +398,13 @@ pub async fn main(args: arguments::Arguments) {
 
     let price_estimator = price_estimator_factory
         .price_estimator(
-            &args.order_quoting.price_estimators,
+            args.order_quoting.price_estimators.as_slice(),
             &args.order_quoting.price_estimation_drivers,
         )
         .unwrap();
     let native_price_estimator = price_estimator_factory
         .native_price_estimator(
-            &args.native_price_estimators,
+            args.native_price_estimators.as_slice(),
             &args.order_quoting.price_estimation_drivers,
         )
         .unwrap();

--- a/crates/orderbook/src/arguments.rs
+++ b/crates/orderbook/src/arguments.rs
@@ -5,7 +5,7 @@ use {
         arguments::{display_option, display_secret_option},
         bad_token::token_owner_finder,
         http_client,
-        price_estimation::{self, PriceEstimator},
+        price_estimation::{self, PriceEstimators},
     },
     std::{net::SocketAddr, num::NonZeroUsize, time::Duration},
 };
@@ -90,14 +90,8 @@ pub struct Arguments {
 
     /// Which estimators to use to estimate token prices in terms of the chain's
     /// native token.
-    #[clap(
-        long,
-        env,
-        value_enum,
-        use_value_delimiter = true,
-        default_value = "Baseline"
-    )]
-    pub native_price_estimators: Vec<PriceEstimator>,
+    #[clap(long, env, default_value_t)]
+    pub native_price_estimators: PriceEstimators,
 
     /// How many successful price estimates for each order will cause a fast
     /// price estimation to return its result early.
@@ -227,7 +221,7 @@ impl std::fmt::Display for Arguments {
         )?;
         writeln!(
             f,
-            "native_price_estimators: {:?}",
+            "native_price_estimators: {}",
             self.native_price_estimators
         )?;
         writeln!(

--- a/crates/orderbook/src/run.rs
+++ b/crates/orderbook/src/run.rs
@@ -368,20 +368,20 @@ pub async fn run(args: Arguments) {
 
     let price_estimator = price_estimator_factory
         .price_estimator(
-            &args.order_quoting.price_estimators,
+            args.order_quoting.price_estimators.as_slice(),
             &args.order_quoting.price_estimation_drivers,
         )
         .unwrap();
     let fast_price_estimator = price_estimator_factory
         .fast_price_estimator(
-            &args.order_quoting.price_estimators,
+            args.order_quoting.price_estimators.as_slice(),
             args.fast_price_estimation_results_required,
             &args.order_quoting.price_estimation_drivers,
         )
         .unwrap();
     let native_price_estimator = price_estimator_factory
         .native_price_estimator(
-            &args.native_price_estimators,
+            args.native_price_estimators.as_slice(),
             &args.order_quoting.price_estimation_drivers,
         )
         .unwrap();

--- a/crates/shared/src/arguments.rs
+++ b/crates/shared/src/arguments.rs
@@ -55,7 +55,13 @@ pub struct Driver {
 // as both crates can create orders
 #[derive(clap::Parser)]
 pub struct OrderQuotingArguments {
-    #[clap(long, env, value_enum, use_value_delimiter = true)]
+    #[clap(
+        long,
+        env,
+        value_enum,
+        use_value_delimiter = true,
+        default_value = "Baseline"
+    )]
     pub price_estimators: Vec<PriceEstimator>,
 
     /// A list of external drivers used for price estimation in the following

--- a/crates/shared/src/arguments.rs
+++ b/crates/shared/src/arguments.rs
@@ -8,7 +8,7 @@ use {
         ethrpc,
         fee_subsidy::cow_token::SubsidyTiers,
         gas_price_estimation::GasEstimatorType,
-        price_estimation::PriceEstimator,
+        price_estimation::PriceEstimators,
         rate_limiter::RateLimitingStrategy,
         sources::{
             balancer_v2::BalancerFactoryKind,
@@ -55,14 +55,8 @@ pub struct Driver {
 // as both crates can create orders
 #[derive(clap::Parser)]
 pub struct OrderQuotingArguments {
-    #[clap(
-        long,
-        env,
-        value_enum,
-        use_value_delimiter = true,
-        default_value = "Baseline"
-    )]
-    pub price_estimators: Vec<PriceEstimator>,
+    #[clap(long, env, default_value_t)]
+    pub price_estimators: PriceEstimators,
 
     /// A list of external drivers used for price estimation in the following
     /// format: `<NAME>|<URL>,<NAME>|<URL>`
@@ -375,7 +369,7 @@ impl Display for OrderQuotingArguments {
         writeln!(f, "min_discounted_fee: {}", self.min_discounted_fee)?;
         writeln!(f, "fee_factor: {}", self.fee_factor)?;
         writeln!(f, "cow_fee_factors: {:?}", self.cow_fee_factors)?;
-        writeln!(f, "price_estimators: {:?}", self.price_estimators)?;
+        writeln!(f, "price_estimators: {}", self.price_estimators)?;
         display_list(
             f,
             "price_estimation_drivers",

--- a/crates/shared/src/price_estimation.rs
+++ b/crates/shared/src/price_estimation.rs
@@ -73,7 +73,7 @@ impl Display for PriceEstimators {
             }
             Ok(())
         } else {
-            return f.write_str("None");
+            f.write_str("None")
         }
     }
 }

--- a/crates/shared/src/price_estimation.rs
+++ b/crates/shared/src/price_estimation.rs
@@ -1,19 +1,3 @@
-pub mod balancer_sor;
-pub mod baseline;
-pub mod competition;
-pub mod external;
-pub mod factory;
-pub mod gas;
-pub mod http;
-pub mod instrumented;
-pub mod native;
-pub mod native_price_cache;
-pub mod oneinch;
-pub mod paraswap;
-pub mod sanitized;
-pub mod trade_finder;
-pub mod zeroex;
-
 use {
     crate::{
         arguments::{display_option, CodeSimulatorKind},
@@ -34,11 +18,81 @@ use {
         fmt::{self, Display, Formatter},
         future::Future,
         hash::Hash,
+        str::FromStr,
         sync::Arc,
         time::{Duration, Instant},
     },
     thiserror::Error,
 };
+
+pub mod balancer_sor;
+pub mod baseline;
+pub mod competition;
+pub mod external;
+pub mod factory;
+pub mod gas;
+pub mod http;
+pub mod instrumented;
+pub mod native;
+pub mod native_price_cache;
+pub mod oneinch;
+pub mod paraswap;
+pub mod sanitized;
+pub mod trade_finder;
+pub mod zeroex;
+
+#[derive(Clone, Debug)]
+pub struct PriceEstimators(Vec<PriceEstimator>);
+
+impl PriceEstimators {
+    fn none() -> Self {
+        Self(Vec::new())
+    }
+
+    pub fn as_slice(&self) -> &[PriceEstimator] {
+        &self.0
+    }
+}
+
+impl Default for PriceEstimators {
+    fn default() -> Self {
+        Self(vec![PriceEstimator {
+            kind: PriceEstimatorKind::Baseline,
+            address: H160::zero(),
+        }])
+    }
+}
+
+impl Display for PriceEstimators {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        let mut it = self.as_slice().iter();
+        if let Some(PriceEstimator { kind, address }) = it.next() {
+            write!(f, "{kind:?}|{address:?}")?;
+            for PriceEstimator { kind, address } in it {
+                write!(f, ",{kind:?}|{address:?}")?;
+            }
+            Ok(())
+        } else {
+            return f.write_str("None");
+        }
+    }
+}
+
+impl FromStr for PriceEstimators {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        if s == "None" {
+            return Ok(Self::none());
+        }
+
+        Ok(Self(
+            s.split(',')
+                .map(PriceEstimator::from_str)
+                .collect::<Result<_>>()?,
+        ))
+    }
+}
 
 #[derive(Copy, Clone, Debug, Hash, Eq, PartialEq)]
 pub enum PriceEstimatorKind {
@@ -64,7 +118,7 @@ impl PriceEstimator {
     }
 }
 
-impl std::str::FromStr for PriceEstimator {
+impl FromStr for PriceEstimator {
     type Err = anyhow::Error;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {


### PR DESCRIPTION
Fixes #1696.

It looks like we had a regression which caused `cargo run (orderbook|autopilot)` with no arguments to crash on startup. This PR addresses the issue.

Note that, since we plan on co-locating all estimators in the very near future, I also added logic for parsing `--(native-)?price-estimators None` such that it yields no price estimator (similar to the `--baseline-sources None` argument).

### Test Plan

```
% cargo run -p orderbook --
...
price_estimators: Baseline|0x0000000000000000000000000000000000000000
native_price_estimators: Baseline|0x0000000000000000000000000000000000000000
...
% cargo run -p orderbook -- --price-estimators None --native-price-estimators None
...
price_estimators: None
native_price_estimators: None
...
% cargo run -p orderbook -- --price-estimators 'Baseline|0x1111111111111111111111111111111111111111,OneInch|0x2222222222222222222222222222222222222222' --native-price-estimators 'Baseline|0x1111111111111111111111111111111111111111,ZeroEx|0x3333333333333333333333333333333333333333'
...
price_estimators: Baseline|0x1111111111111111111111111111111111111111,OneInch|0x2222222222222222222222222222222222222222
native_price_estimators: Baseline|0x1111111111111111111111111111111111111111,ZeroEx|0x3333333333333333333333333333333333333333
...
% cargo run -p autopilot --
...
price_estimators: Baseline|0x0000000000000000000000000000000000000000
native_price_estimators: Baseline|0x0000000000000000000000000000000000000000
...
% cargo run -p autopilot -- --price-estimators None --native-price-estimators None
...
price_estimators: None
native_price_estimators: None
...
% cargo run -p autopilot -- --price-estimators 'Baseline|0x1111111111111111111111111111111111111111,OneInch|0x2222222222222222222222222222222222222222' --native-price-estimators 'Baseline|0x1111111111111111111111111111111111111111,ZeroEx|0x3333333333333333333333333333333333333333'
...
price_estimators: Baseline|0x1111111111111111111111111111111111111111,OneInch|0x2222222222222222222222222222222222222222
native_price_estimators: Baseline|0x1111111111111111111111111111111111111111,ZeroEx|0x3333333333333333333333333333333333333333
...
```
