### PR TITLE
Record Unused AppData Metrics 

### DIFF
--- a/crates/autopilot/src/database.rs
+++ b/crates/autopilot/src/database.rs
@@ -24,13 +24,23 @@ impl Postgres {
         Ok(Self(PgPool::connect(url).await?))
     }
 
-    pub async fn update_table_rows_metric(&self) -> sqlx::Result<()> {
+    pub async fn update_database_metrics(&self) -> sqlx::Result<()> {
         let metrics = Metrics::get();
+
+        // update table row metrics
         for &table in database::ALL_TABLES {
             let mut ex = self.0.acquire().await?;
             let count = count_rows_in_table(&mut ex, table).await?;
             metrics.table_rows.with_label_values(&[table]).set(count);
         }
+
+        // update unused app data metric
+        {
+            let mut ex = self.0.acquire().await?;
+            let count = count_unused_app_data(&mut ex).await?;
+            metrics.unused_app_data.set(count);
+        }
+
         Ok(())
     }
 }
@@ -40,11 +50,31 @@ async fn count_rows_in_table(ex: &mut PgConnection, table: &str) -> sqlx::Result
     sqlx::query_scalar(&query).fetch_one(ex).await
 }
 
+async fn count_unused_app_data(ex: &mut PgConnection) -> sqlx::Result<i64> {
+    let query = r#"
+        SELECT
+            COUNT(*)
+        FROM app_data AS a
+        LEFT JOIN orders o
+            ON a.contract_app_data = o.app_data
+        WHERE
+            o.app_data IS NULL
+        ;
+    "#;
+    sqlx::query_scalar(query).fetch_one(ex).await
+}
+
 #[derive(prometheus_metric_storage::MetricStorage)]
 struct Metrics {
     /// Number of rows in db tables.
     #[metric(labels("table"))]
     table_rows: prometheus::IntGaugeVec,
+
+    /// Number of unused app data entries.
+    ///
+    /// These are entries in the `app_data` table that do not have a
+    /// corresponding order in the `orders` table.
+    unused_app_data: prometheus::IntGauge,
 
     /// Timing of db queries.
     #[metric(name = "autopilot_database_queries", labels("type"))]
@@ -59,7 +89,7 @@ impl Metrics {
 
 pub async fn database_metrics(db: Postgres) -> ! {
     loop {
-        if let Err(err) = db.update_table_rows_metric().await {
+        if let Err(err) = db.update_database_metrics().await {
             tracing::error!(?err, "failed to update table rows metric");
         }
         tokio::time::sleep(Duration::from_secs(60)).await;


### PR DESCRIPTION
Follow-up to #1704 .

Describe context of what this change does, why it is needed and how it is accomplished

### Test Plan

Run the `autopilot` and `orderbook` locally and:
```
% curl -s 'http://localhost:9589/metrics' | rg unused_app_data | rg -v '^#'
gp_v2_autopilot_unused_app_data 0
% curl -s 'http://localhost:8080/api/v1/app_data/0x586e9b1e1681ba3ebad5ff5e6f673d3e3aa129fcdb76f92083dbc386cdde4312' -X PUT --data-raw '{"hello":"world"}' > /dev/null
% sleep 60
% curl -s 'http://localhost:9589/metrics' | rg unused_app_data | rg -v '^#'
gp_v2_autopilot_unused_app_data 1
```