### PR TITLE
Update openapi docs for priceQuality

### DIFF
--- a/crates/orderbook/openapi.yml
+++ b/crates/orderbook/openapi.yml
@@ -508,6 +508,10 @@ components:
       description: |
         How good should the price estimate be?
 
+        Fast: The price estimate is chosen among the fastest N price estimates.
+        Optimal: The price estimate is chosen among all price estimates.
+        Verified: The price estimate is chosen among all verified/simulated price estimates.
+
         **NOTE**: Orders are supposed to be created from `verified` price estimates.
       type: string
       enum: [fast, optimal, verified]

--- a/crates/orderbook/openapi.yml
+++ b/crates/orderbook/openapi.yml
@@ -508,9 +508,9 @@ components:
       description: |
         How good should the price estimate be?
 
-        **NOTE**: Orders are supposed to be created from `optimal` price estimates.
+        **NOTE**: Orders are supposed to be created from `verified` price estimates.
       type: string
-      enum: [fast, optimal]
+      enum: [fast, optimal, verified]
     OrderStatus:
       description: The current order status.
       type: string
@@ -1196,7 +1196,7 @@ components:
             priceQuality:
               allOf:
                 - $ref: "#/components/schemas/PriceQuality"
-              default: "optimal"
+              default: "verified"
             signingScheme:
               allOf:
                 - $ref: "#/components/schemas/SigningScheme"


### PR DESCRIPTION
Updates the `PriceQuality` enum.

Lately we introduced the variant `verified` which means that specific quote needs to be verified/simulated in order to be accepted as valid. 

Related to [slack](https://cowservices.slack.com/archives/C036G0J90BU/p1690299239980499) discussion.
