### PR TITLE
Cache IPFS app data

### DIFF
--- a/crates/orderbook/src/ipfs.rs
+++ b/crates/orderbook/src/ipfs.rs
@@ -1,7 +1,7 @@
 use {
-    anyhow::{anyhow, Context, Result},
-    model::app_id::AppDataHash,
-    reqwest::{Client, StatusCode},
+    anyhow::{Context, Result},
+    reqwest::{Client, ClientBuilder, StatusCode},
+    std::time::Duration,
     url::Url,
 };
 
@@ -12,10 +12,10 @@ pub struct Ipfs {
 }
 
 impl Ipfs {
-    pub fn new(client: Client, base: Url, query: Option<String>) -> Self {
+    pub fn new(client: ClientBuilder, base: Url, query: Option<String>) -> Self {
         assert!(!base.cannot_be_a_base());
         Self {
-            client,
+            client: client.timeout(Duration::from_secs(5)).build().unwrap(),
             base,
             query,
         }
@@ -29,19 +29,24 @@ impl Ipfs {
     /// - The public cloudflare gateway responds "524" after 20 seconds.
     /// - A private Pinata gateway responds "404 Not Found" after 2 minutes.
     ///
-    /// This function treats all status codes except "200 OK" as errors and you
-    /// likely want to use it with a timeout.
-    pub async fn fetch(&self, cid: &str) -> Result<Vec<u8>> {
+    /// This function treats timeouts and all status codes except "200 OK" as
+    /// Ok(None).
+    pub async fn fetch(&self, cid: &str) -> Result<Option<Vec<u8>>> {
         let url = self.prepare_url(cid);
-        let response = self.client.get(url).send().await.context("send")?;
+        let response = match self.client.get(url).send().await {
+            Ok(response) => response,
+            Err(err) if err.is_timeout() => return Ok(None),
+            result @ Err(_) => return Err(result.context("send").unwrap_err()),
+        };
         let status = response.status();
         let body = response.bytes().await.context("body")?;
         match status {
-            StatusCode::OK => Ok(body.into()),
+            StatusCode::OK => Ok(Some(body.into())),
             _ => {
-                let body_text = String::from_utf8_lossy(&body);
-                let body_text: &str = &body_text;
-                Err(anyhow!("status {status}, body {body_text:?}"))
+                let body = String::from_utf8_lossy(&body);
+                let body: &str = &body;
+                tracing::trace!(%status, %body, "IPFS not found");
+                Ok(None)
             }
         }
     }
@@ -55,56 +60,6 @@ impl Ipfs {
     }
 }
 
-/// Tries to find full app data corresponding to the contract app data on IPFS.
-///
-/// A return value of `Some` indicates that either the old or new CID format was
-/// found on IPFS and points to valid utf-8.
-///
-/// A return value of `None` indicates that neither CID was found. This might be
-/// a temporary condition as IPFS is a decentralized network.
-pub async fn full_app_data_from_ipfs(
-    ipfs: &Ipfs,
-    contract_app_data: &AppDataHash,
-) -> Option<String> {
-    let old = old_app_data_cid(contract_app_data);
-    let new = new_app_data_cid(contract_app_data);
-    let fetch = |cid: String| async move {
-        let result = ipfs.fetch(&cid).await;
-        match &result {
-            Ok(_) => {
-                tracing::debug!("found full app data for {contract_app_data:?} at CID {cid}");
-            }
-            Err(err) => {
-                tracing::debug!("no full app data for {contract_app_data:?} at CID {cid}: {err:?}");
-            }
-        };
-        let result = String::from_utf8(result?);
-        if result.is_err() {
-            tracing::debug!("CID {cid} doesn't point to utf-8");
-        }
-        result.map_err(anyhow::Error::from)
-    };
-    futures::future::select_ok([std::pin::pin!(fetch(old)), std::pin::pin!(fetch(new))])
-        .await
-        .ok()
-        .map(|(ok, _rest)| ok)
-}
-
-fn new_app_data_cid(contract_app_data: &AppDataHash) -> String {
-    let raw_cid = app_data_hash::create_ipfs_cid(&contract_app_data.0);
-    multibase::encode(multibase::Base::Base32Lower, raw_cid)
-}
-
-fn old_app_data_cid(contract_app_data: &AppDataHash) -> String {
-    let mut raw_cid = [0u8; 4 + 32];
-    raw_cid[0] = 1; // cid version
-    raw_cid[1] = 0x70; // dag-pb
-    raw_cid[2] = 0x12; // sha2-256
-    raw_cid[3] = 32; // hash length
-    raw_cid[4..].copy_from_slice(&contract_app_data.0);
-    multibase::encode(multibase::Base::Base32Lower, raw_cid)
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -114,7 +69,7 @@ mod tests {
     async fn public_gateway() {
         let ipfs = Ipfs::new(Default::default(), "https://ipfs.io".parse().unwrap(), None);
         let cid = "Qma4Dwke5h8mgJyZMDRvKqM3RF7c6Mxcj3fR4um9UGaNF6";
-        let content = ipfs.fetch(cid).await.unwrap();
+        let content = ipfs.fetch(cid).await.unwrap().unwrap();
         let content = std::str::from_utf8(&content).unwrap();
         println!("{content}");
     }
@@ -126,24 +81,18 @@ mod tests {
         let query = std::env::var("query").unwrap();
         let ipfs = Ipfs::new(Default::default(), url.parse().unwrap(), Some(query));
         let cid = "Qma4Dwke5h8mgJyZMDRvKqM3RF7c6Mxcj3fR4um9UGaNF6";
-        let content = ipfs.fetch(cid).await.unwrap();
+        let content = ipfs.fetch(cid).await.unwrap().unwrap();
         let content = std::str::from_utf8(&content).unwrap();
         println!("{content}");
     }
 
-    // Can be compared with CID explorer to make sure CIDs encode the right data.
-    #[test]
-    fn cid() {
-        let hash = AppDataHash(hex_literal::hex!(
-            "8af4e8c9973577b08ac21d17d331aade86c11ebcc5124744d621ca8365ec9424"
-        ));
-        let cid = new_app_data_cid(&hash);
-        println!("{cid}");
-
-        let hash = AppDataHash(hex_literal::hex!(
-            "AE16F2D8B960FFE3DE70E074CECFB24441D4CDC67E8A68566B9E6CE3037CB41D"
-        ));
-        let cid = old_app_data_cid(&hash);
-        println!("{cid}");
+    #[tokio::test]
+    #[ignore]
+    async fn not_found() {
+        shared::tracing::initialize_reentrant("orderbook::ipfs=trace");
+        let ipfs = Ipfs::new(Default::default(), "https://ipfs.io".parse().unwrap(), None);
+        let cid = "Qma4Dwke5h8mgJyZMDRvKqM3RF7c6Mxcj3fR4um9UGaNF7";
+        let result = ipfs.fetch(cid).await.unwrap();
+        assert!(result.is_none());
     }
 }

--- a/crates/orderbook/src/ipfs_app_data.rs
+++ b/crates/orderbook/src/ipfs_app_data.rs
@@ -1,0 +1,120 @@
+use {
+    crate::ipfs::Ipfs,
+    anyhow::Result,
+    cached::{Cached, TimedSizedCache},
+    model::app_id::AppDataHash,
+    std::sync::Mutex,
+};
+
+pub struct IpfsAppData {
+    ipfs: Ipfs,
+    cache: Mutex<TimedSizedCache<AppDataHash, Option<String>>>,
+}
+
+impl IpfsAppData {
+    pub fn new(ipfs: Ipfs) -> Self {
+        Self {
+            ipfs,
+            cache: Mutex::new(TimedSizedCache::with_size_and_lifespan_and_refresh(
+                1000, 600, false,
+            )),
+        }
+    }
+
+    /// Tries to find full app data corresponding to the contract app data on
+    /// IPFS.
+    ///
+    /// A return value of `Some` indicates that either the old or new CID format
+    /// was found on IPFS and points to valid utf-8.
+    ///
+    /// A return value of `None` indicates that neither CID was found. This
+    /// might be a temporary condition as IPFS is a decentralized network.
+    ///
+    /// A return value of `Err` indicates an error communication with the IPFS
+    /// gateway.
+    async fn fetch_raw(&self, contract_app_data: &AppDataHash) -> Result<Option<String>> {
+        let old = old_app_data_cid(contract_app_data);
+        let new = new_app_data_cid(contract_app_data);
+        let fetch = |cid: String| async move {
+            let result = self.ipfs.fetch(&cid).await;
+            let result = match result {
+                Ok(Some(result)) => {
+                    tracing::debug!(?contract_app_data, %cid, "found full app data");
+                    result
+                }
+                Ok(None) => {
+                    tracing::debug!(?contract_app_data, %cid,"no full app data");
+                    return Ok(None);
+                }
+                Err(err) => {
+                    tracing::warn!(?contract_app_data, %cid, ?err, "failed full app data");
+                    return Err(err);
+                }
+            };
+            match String::from_utf8(result) {
+                Ok(result) => Ok(Some(result)),
+                Err(err) => {
+                    tracing::debug!(?err, %cid, "CID doesn't point to utf-8");
+                    Ok(None)
+                }
+            }
+        };
+        futures::future::select_ok([std::pin::pin!(fetch(old)), std::pin::pin!(fetch(new))])
+            .await
+            .map(|(ok, _rest)| ok)
+    }
+
+    pub async fn fetch(&self, contract_app_data: &AppDataHash) -> Result<Option<String>> {
+        if let Some(cached) = self
+            .cache
+            .lock()
+            .unwrap()
+            .cache_get(contract_app_data)
+            .cloned()
+        {
+            return Ok(cached);
+        }
+        let result = self.fetch_raw(contract_app_data).await?;
+        self.cache
+            .lock()
+            .unwrap()
+            .cache_set(*contract_app_data, result.clone());
+        Ok(result)
+    }
+}
+
+fn new_app_data_cid(contract_app_data: &AppDataHash) -> String {
+    let raw_cid = app_data_hash::create_ipfs_cid(&contract_app_data.0);
+    multibase::encode(multibase::Base::Base32Lower, raw_cid)
+}
+
+fn old_app_data_cid(contract_app_data: &AppDataHash) -> String {
+    let mut raw_cid = [0u8; 4 + 32];
+    raw_cid[0] = 1; // cid version
+    raw_cid[1] = 0x70; // dag-pb
+    raw_cid[2] = 0x12; // sha2-256
+    raw_cid[3] = 32; // hash length
+    raw_cid[4..].copy_from_slice(&contract_app_data.0);
+    multibase::encode(multibase::Base::Base32Lower, raw_cid)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Can be compared with CID explorer to make sure CIDs encode the right data.
+    #[test]
+    fn cid() {
+        let hash = AppDataHash(hex_literal::hex!(
+            "8af4e8c9973577b08ac21d17d331aade86c11ebcc5124744d621ca8365ec9424"
+        ));
+        let cid = new_app_data_cid(&hash);
+        println!("{cid}");
+
+        let hash = AppDataHash(hex_literal::hex!(
+            "AE16F2D8B960FFE3DE70E074CECFB24441D4CDC67E8A68566B9E6CE3037CB41D"
+        ));
+        let cid = old_app_data_cid(&hash);
+        println!("{cid}");
+    }
+}

--- a/crates/orderbook/src/lib.rs
+++ b/crates/orderbook/src/lib.rs
@@ -15,6 +15,7 @@ pub mod app_data;
 pub mod arguments;
 pub mod database;
 mod ipfs;
+mod ipfs_app_data;
 pub mod orderbook;
 pub mod run;
 pub mod solver_competition;

--- a/crates/orderbook/src/run.rs
+++ b/crates/orderbook/src/run.rs
@@ -4,6 +4,7 @@ use {
         arguments::Arguments,
         database::Postgres,
         ipfs::Ipfs,
+        ipfs_app_data::IpfsAppData,
         orderbook::Orderbook,
         serve_api,
         verify_deployed_contract_constants,
@@ -484,18 +485,17 @@ pub async fn run(args: Arguments) {
         .with_custom_interactions(args.enable_custom_interactions)
         .with_verified_quotes(args.price_estimation.trade_simulator.is_some()),
     );
-    let ipfs = args.ipfs_gateway.map(|url| {
-        Ipfs::new(
-            http_factory
-                .builder()
-                .timeout(Duration::from_secs(5))
-                .build()
-                .unwrap(),
-            url,
-            args.ipfs_pinata_auth
-                .map(|auth| format!("pinataGatewayToken={auth}")),
-        )
-    });
+    let ipfs = args
+        .ipfs_gateway
+        .map(|url| {
+            Ipfs::new(
+                http_factory.builder(),
+                url,
+                args.ipfs_pinata_auth
+                    .map(|auth| format!("pinataGatewayToken={auth}")),
+            )
+        })
+        .map(IpfsAppData::new);
     let orderbook = Arc::new(Orderbook::new(
         domain_separator,
         settlement_contract.address(),


### PR DESCRIPTION
I observed automated order creation through our API with an order that has no full app data. The order later fails validation. This puts pressure on our IPFS gateway because we have to check whether the app data exists every time. This PR relives some of this pressure by caching IPFS app data.

This PR contains several changes:
- Move IPFS app data fetching from the ipfs module to a dedicated ipfs_app_data module.
- Refactor IPFS code to not treat all reqwest errors as missing app data. Missing app data is only the result when the request and response fetching is successful with a status code that isn't 200.
- Add a cache to the ipfs_app_data module.

### Test Plan

existing tests and observe Pinata request counts later
