### PR TITLE
Move hooks to metadata field

### DIFF
--- a/crates/e2e/tests/e2e/app_data.rs
+++ b/crates/e2e/tests/e2e/app_data.rs
@@ -108,7 +108,7 @@ async fn app_data(web3: Web3) {
     assert_eq!(order3_.metadata.full_app_data.as_deref(), Some(app_data));
 
     // invalid app data
-    let invalid_app_data = r#"{"backend":"invalid"}"#;
+    let invalid_app_data = r#"{"metadata":"invalid"}"#;
     let order4 = create_order(OrderCreationAppData::Full {
         full: invalid_app_data.to_string(),
     });

--- a/crates/e2e/tests/e2e/colocation_hooks.rs
+++ b/crates/e2e/tests/e2e/colocation_hooks.rs
@@ -72,7 +72,7 @@ async fn test(web3: Web3) {
         kind: OrderKind::Sell,
         app_data: OrderCreationAppData::Full {
             full: json!({
-                "backend": {
+                "metadata": {
                     "hooks": {
                         "pre": [permit, steal_cow],
                         "post": [steal_weth],

--- a/crates/e2e/tests/e2e/hooks.rs
+++ b/crates/e2e/tests/e2e/hooks.rs
@@ -66,7 +66,7 @@ async fn test(web3: Web3) {
         kind: OrderKind::Sell,
         app_data: OrderCreationAppData::Full {
             full: json!({
-                "backend": {
+                "metadata": {
                     "hooks": {
                         "pre": [permit, steal_cow],
                         "post": [steal_weth],

--- a/crates/e2e/tests/e2e/quoting.rs
+++ b/crates/e2e/tests/e2e/quoting.rs
@@ -76,7 +76,7 @@ async fn test(web3: Web3) {
         .submit_quote(&OrderQuoteRequest {
             app_data: OrderCreationAppData::Full {
                 full: serde_json::to_string(&json!({
-                    "backend": {
+                    "metadata": {
                         "hooks": {
                             "pre": [
                                 {
@@ -110,7 +110,7 @@ async fn test(web3: Web3) {
             },
             app_data: OrderCreationAppData::Full {
                 full: serde_json::to_string(&json!({
-                    "backend": {
+                    "metadata": {
                         "hooks": {
                             "pre": [
                                 {

--- a/crates/model/src/app_id.rs
+++ b/crates/model/src/app_id.rs
@@ -15,6 +15,12 @@ use {
 #[derive(Clone, Copy, Default, Eq, Hash, PartialEq)]
 pub struct AppDataHash(pub [u8; 32]);
 
+impl AppDataHash {
+    pub fn is_zero(&self) -> bool {
+        *self == Self::default()
+    }
+}
+
 impl Debug for AppDataHash {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         write!(f, "0x{}", hex::encode(self.0))

--- a/crates/model/src/order.rs
+++ b/crates/model/src/order.rs
@@ -42,9 +42,11 @@ pub struct Interactions {
 
 /// Order hooks are user-specified Ethereum calls that get executed as part of
 /// a pre- or post- interaction.
-#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Eq, PartialEq, Deserialize, Serialize)]
 pub struct Hooks {
+    #[serde(default)]
     pub pre: Vec<Hook>,
+    #[serde(default)]
     pub post: Vec<Hook>,
 }
 
@@ -63,7 +65,7 @@ impl Hooks {
 
 /// A user-specified hook.
 #[serde_as]
-#[derive(Clone, Deserialize, Serialize)]
+#[derive(Clone, Eq, PartialEq, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Hook {
     pub target: H160,

--- a/crates/orderbook/openapi.yml
+++ b/crates/orderbook/openapi.yml
@@ -707,7 +707,7 @@ components:
 
                 The field must be the encoding of a valid JSON object. The JSON object can contain
                 arbitrary application specific data (JSON key values). The optional key `backend` is
-                special. It **MUST** conform to the schema documented in `BackendAppData`.
+                special. It **MUST** conform to the schema documented in `ProtocolAppData`.
 
                 The intended use of the other keys of the object is follow the standardized format
                 defined [here](https://github.com/cowprotocol/app-data). Example:
@@ -743,7 +743,7 @@ components:
         - partiallyFillable
         - signingScheme
         - signature
-    BackendAppData:
+    ProtocolAppData:
       type: object
     OrderMetaData:
       description: |

--- a/crates/orderbook/src/orderbook.rs
+++ b/crates/orderbook/src/orderbook.rs
@@ -24,6 +24,7 @@ use {
     },
     primitive_types::H160,
     shared::{
+        app_data,
         metrics::LivenessChecking,
         order_validation::{OrderValidating, ValidationError},
     },
@@ -209,6 +210,11 @@ impl Orderbook {
         &self,
         contract_app_data: &AppDataHash,
     ) -> Result<Option<String>> {
+        // we reserve the 0 app data to indicate empty app data.
+        if contract_app_data.is_zero() {
+            return Ok(Some(app_data::EMPTY.to_string()));
+        }
+
         if let Some(app_data) = self
             .database
             .get_full_app_data(contract_app_data)

--- a/crates/shared/Cargo.toml
+++ b/crates/shared/Cargo.toml
@@ -59,3 +59,4 @@ web3 = { workspace = true }
 [dev-dependencies]
 regex = { workspace = true }
 testlib = { path = "../testlib" }
+tokio = { workspace = true, features = ["rt-multi-thread"] }

--- a/crates/shared/src/app_data/compat.rs
+++ b/crates/shared/src/app_data/compat.rs
@@ -1,0 +1,14 @@
+use {super::ProtocolAppData, model::order::Hooks, serde::Deserialize};
+
+/// The legacy `backend` app data object.
+#[derive(Debug, Default, Deserialize)]
+pub struct BackendAppData {
+    #[serde(default)]
+    pub hooks: Hooks,
+}
+
+impl From<BackendAppData> for ProtocolAppData {
+    fn from(value: BackendAppData) -> Self {
+        Self { hooks: value.hooks }
+    }
+}

--- a/crates/shared/src/order_quoting.rs
+++ b/crates/shared/src/order_quoting.rs
@@ -100,7 +100,7 @@ impl QuoteHandler {
                 side: request.side,
                 verification,
                 signing_scheme: request.signing_scheme,
-                additional_gas: app_data.inner.backend.hooks.gas_limit(),
+                additional_gas: app_data.inner.protocol.hooks.gas_limit(),
             }
         };
 


### PR DESCRIPTION
As discussed in [Slack](https://cowservices.slack.com/archives/C0375NV72SC/p1690365762570749) this PR changes the backend to use the `metadata` field for specifying hooks and deprecates the `backend`.

For simplicity's sake, we decided to ignore the `backend` field entirely if the `metadata` field is specified. While this is technically breaking behaviour, AFAICT, all uses of "hooks" have been without `metadata` being specified at all (following the [documentation](https://docs.cow.fi/overview/cow-hooks/cow-hooks-example)).

### Test Plan

Added comprehensive unit tests. Adjusted E2E tests to use "metadata" field.
