### PR TITLE
Refactor order remaining amount module

### DIFF
--- a/crates/autopilot/src/solvable_orders.rs
+++ b/crates/autopilot/src/solvable_orders.rs
@@ -436,7 +436,8 @@ fn filter_dust_orders(
             return false;
         };
 
-        let Ok(remaining) = remaining_amounts::Remaining::from_order_with_balance(order, balance)
+        let Ok(remaining) =
+            remaining_amounts::Remaining::from_order_with_balance(&order.into(), balance)
         else {
             return false;
         };

--- a/crates/shared/Cargo.toml
+++ b/crates/shared/Cargo.toml
@@ -59,3 +59,4 @@ web3 = { workspace = true }
 [dev-dependencies]
 regex = { workspace = true }
 testlib = { path = "../testlib" }
+tokio = { workspace = true, features = ["rt-multi-thread"] }

--- a/crates/solver/src/liquidity/order_converter.rs
+++ b/crates/solver/src/liquidity/order_converter.rs
@@ -51,7 +51,7 @@ impl OrderConverter {
         };
 
         let remaining = shared::remaining_amounts::Remaining::from_order_with_balance(
-            &order,
+            &(&order).into(),
             available_sell_token_balance,
         )?;
 

--- a/crates/solver/src/order_balance_filter.rs
+++ b/crates/solver/src/order_balance_filter.rs
@@ -155,7 +155,7 @@ fn sort_orders_for_balance_priority(orders: &mut [Order], external_prices: &Exte
 ///
 /// Returns `Err` on overflow.
 fn max_transfer_out_amount(order: &Order) -> Result<U256> {
-    let remaining = shared::remaining_amounts::Remaining::from_order(order)?;
+    let remaining = shared::remaining_amounts::Remaining::from_order(&order.into())?;
     let sell = remaining.remaining(order.data.sell_amount)?;
     let fee = remaining.remaining(order.data.fee_amount)?;
     sell.checked_add(fee).context("add")

--- a/crates/solver/src/settlement/settlement_encoder.rs
+++ b/crates/solver/src/settlement/settlement_encoder.rs
@@ -740,7 +740,7 @@ impl PricedTrade<'_> {
 }
 
 pub fn verify_executed_amount(order: &Order, executed: U256) -> Result<()> {
-    let remaining = shared::remaining_amounts::Remaining::from_order(order)?;
+    let remaining = shared::remaining_amounts::Remaining::from_order(&order.into())?;
     let valid_executed_amount = match (order.data.partially_fillable, order.data.kind) {
         (true, OrderKind::Sell) => executed <= remaining.remaining(order.data.sell_amount)?,
         (true, OrderKind::Buy) => executed <= remaining.remaining(order.data.buy_amount)?,


### PR DESCRIPTION
Instead of passing in a full model::Order I create a new type holding exactly what parts of the full order are needed. This makes this module more reusable and makes it more clear which fields are relevant.

### Test Plan

CI
