### PR TITLE
Add Raven as legacy http price estimator

### DIFF
--- a/crates/shared/src/price_estimation.rs
+++ b/crates/shared/src/price_estimation.rs
@@ -219,7 +219,7 @@ pub struct Arguments {
     /// The API endpoint to call the Raven solver for price estimation
     #[clap(long, env)]
     pub raven_solver_url: Option<Url>,
-   
+
     /// The API path to use for solving.
     #[clap(long, env, default_value = "solve")]
     pub raven_solver_path: String,

--- a/crates/shared/src/price_estimation.rs
+++ b/crates/shared/src/price_estimation.rs
@@ -103,6 +103,7 @@ pub enum PriceEstimatorKind {
     OneInch,
     Yearn,
     BalancerSor,
+    Raven,
 }
 
 #[derive(Copy, Clone, Debug, Hash, Eq, PartialEq)]
@@ -134,6 +135,7 @@ impl FromStr for PriceEstimator {
             "OneInch" => PriceEstimatorKind::OneInch,
             "Yearn" => PriceEstimatorKind::Yearn,
             "BalancerSor" => PriceEstimatorKind::BalancerSor,
+            "Raven" => PriceEstimatorKind::Raven,
             estimator => {
                 anyhow::bail!("failed to convert to PriceEstimatorKind: {estimator}")
             }
@@ -214,6 +216,14 @@ pub struct Arguments {
     #[clap(long, env, default_value = "solve")]
     pub yearn_solver_path: String,
 
+    /// The API endpoint to call the Raven solver for price estimation
+    #[clap(long, env)]
+     pub raven_solver_url: Option<Url>,
+   
+    /// The API path to use for solving.
+    #[clap(long, env, default_value = "solve")]
+    pub raven_solver_path: String,
+
     /// The API endpoint for the Balancer SOR API for solving.
     #[clap(long, env)]
     pub balancer_sor_url: Option<Url>,
@@ -292,6 +302,8 @@ impl Display for Arguments {
         display_option(f, "quasimodo_solver_url", &self.quasimodo_solver_url)?;
         display_option(f, "yearn_solver_url", &self.yearn_solver_url)?;
         writeln!(f, "yearn_solver_path: {}", self.yearn_solver_path)?;
+        display_option(f, "raven_solver_url", &self.raven_solver_url)?;
+        writeln!(f, "raven_solver_path: {}", self.raven_solver_path)?;
         display_option(f, "balancer_sor_url", &self.balancer_sor_url)?;
         display_option(
             f,
@@ -626,6 +638,10 @@ mod tests {
         assert_eq!(
             parsed("BalancerSor|0x0000000000000000000000000000000000000001"),
             estimator(PriceEstimatorKind::BalancerSor, address(1))
+        );
+        assert_eq!(
+            parsed("Raven|0x0000000000000000000000000000000000000001"),
+            estimator(PriceEstimatorKind::Raven, address(1))
         );
     }
 }

--- a/crates/shared/src/price_estimation.rs
+++ b/crates/shared/src/price_estimation.rs
@@ -218,7 +218,7 @@ pub struct Arguments {
 
     /// The API endpoint to call the Raven solver for price estimation
     #[clap(long, env)]
-     pub raven_solver_url: Option<Url>,
+    pub raven_solver_url: Option<Url>,
    
     /// The API path to use for solving.
     #[clap(long, env, default_value = "solve")]

--- a/crates/shared/src/price_estimation/factory.rs
+++ b/crates/shared/src/price_estimation/factory.rs
@@ -247,6 +247,19 @@ impl<'a> PriceEstimatorFactory<'a> {
             PriceEstimatorKind::BalancerSor => {
                 self.create_estimator_entry::<BalancerSor>(&name, estimator.address)
             }
+            PriceEstimatorKind::Raven => self.create_estimator_entry::<HttpPriceEstimator>(
+                &name,
+                HttpPriceEstimatorParams {
+                    base: self
+                        .args
+                        .raven_solver_url
+                        .clone()
+                        .context("raven solver url not specified")?,
+                    solve_path: self.args.raven_solver_path.clone(),
+                    use_liquidity: false,
+                    solver: estimator.address,
+                },
+            ),
         }
     }
 


### PR DESCRIPTION
This PR adds Raven as a legacy http price estimator, so that it can be enabled in production. This should be viewed as a temporary solution until we move to the colocated driver solution.

