### PR TITLE
Decrease log level to trace

### DIFF
--- a/crates/shared/src/http_solver.rs
+++ b/crates/shared/src/http_solver.rs
@@ -183,7 +183,7 @@ impl HttpSolverApi for DefaultHttpSolverApi {
             request = request.body(body);
         };
         // temporary log, not needed once the code is stable for colocation
-        tracing::debug!(
+        tracing::trace!(
             "http request url: {}, timeout: {:?}, body: {:?}",
             query,
             timeout,
@@ -196,7 +196,7 @@ impl HttpSolverApi for DefaultHttpSolverApi {
                 .await
                 .context("response body")?;
         let text = std::str::from_utf8(&response_body).context("failed to decode response body")?;
-        tracing::debug!(body = %text, "http response");
+        tracing::trace!(body = %text, "http response");
         let context = || format!("request query {query}, response body {text}");
         if status == StatusCode::TOO_MANY_REQUESTS {
             return Err(Error::RateLimited);


### PR DESCRIPTION
Reduces noisy logs to `trace` so they can easily be turned off when they are no longer need (suggested [here](https://github.com/cowprotocol/services/pull/1686#issuecomment-1645794201)).

### Test Plan
CI
