### PR TITLE
Initialize IPFS metrics

### DIFF
--- a/crates/orderbook/src/ipfs_app_data.rs
+++ b/crates/orderbook/src/ipfs_app_data.rs
@@ -22,12 +22,19 @@ struct Metrics {
 
 impl IpfsAppData {
     pub fn new(ipfs: Ipfs) -> Self {
+        let metrics = Metrics::instance(global_metrics::get_metric_storage_registry()).unwrap();
+        // Initialize metrics.
+        for outcome in &["error", "found", "missing"] {
+            for source in &["cache", "node"] {
+                metrics.ipfs_app_data.with_label_values(&[outcome, source]);
+            }
+        }
         Self {
             ipfs,
             cache: Mutex::new(TimedSizedCache::with_size_and_lifespan_and_refresh(
                 1000, 600, false,
             )),
-            metrics: Metrics::instance(global_metrics::get_metric_storage_registry()).unwrap(),
+            metrics,
         }
     }
 


### PR DESCRIPTION
As usual with metrics where we know the label values beforehand, it is good behavior to initialize them.

### Test Plan

manual test
