### PR TITLE
Query the graph in smaller chunks

### DIFF
--- a/crates/autopilot/src/lib.rs
+++ b/crates/autopilot/src/lib.rs
@@ -342,7 +342,7 @@ pub async fn main(args: arguments::Arguments) {
                 args.shared.max_pools_to_initialize_cache,
             )
             .await
-            .expect("error innitializing Uniswap V3 pool fetcher"),
+            .expect("error initializing Uniswap V3 pool fetcher"),
         ))
     } else {
         None

--- a/crates/shared/src/sources/balancer_v2/graph_api.rs
+++ b/crates/shared/src/sources/balancer_v2/graph_api.rs
@@ -22,7 +22,7 @@ use {
 
 /// The page size when querying pools.
 #[cfg(not(test))]
-const QUERY_PAGE_SIZE: usize = 1000;
+const QUERY_PAGE_SIZE: usize = 100;
 #[cfg(test)]
 const QUERY_PAGE_SIZE: usize = 10;
 

--- a/crates/shared/src/subgraph.rs
+++ b/crates/shared/src/subgraph.rs
@@ -9,7 +9,7 @@ use {
     thiserror::Error,
 };
 
-pub const QUERY_PAGE_SIZE: usize = 1000;
+pub const QUERY_PAGE_SIZE: usize = 100;
 const MAX_NUMBER_OF_RETRIES: usize = 10;
 
 /// A general client for querying subgraphs.


### PR DESCRIPTION
Related to https://github.com/cowprotocol/services/issues/1525

It happens quite often that we have to disable the graph based liquidity due to issues during its initialization phase.
IMO the "correct" solution would be to design a system that is able to check for new pools in the background (e.g. even if initialization works I think we currently wouldn't notice new pools being deployed while the system is running).
But since all the initialization errors are due to the graph timing out I think it would be a reasonable quick fix to simply query the graph in smaller batches.
Since we use pod roll over initialization speed is less important than reliability anyway.
