### PR TITLE
New AppData Get/Put Format

### DIFF
--- a/crates/autopilot/src/database/onchain_order_events.rs
+++ b/crates/autopilot/src/database/onchain_order_events.rs
@@ -24,7 +24,7 @@ use {
     futures::{stream, StreamExt},
     itertools::multiunzip,
     model::{
-        app_id::AppDataHash,
+        app_data::AppDataHash,
         order::{BuyTokenDestination, OrderData, OrderKind, OrderUid, SellTokenSource},
         signature::SigningScheme,
         DomainSeparator,
@@ -730,7 +730,7 @@ mod test {
         maplit::hashset,
         mockall::predicate::{always, eq},
         model::{
-            app_id::AppDataHash,
+            app_data::AppDataHash,
             order::{BuyTokenDestination, OrderData, OrderKind, SellTokenSource},
             signature::SigningScheme,
             DomainSeparator,

--- a/crates/autopilot/src/driver_model.rs
+++ b/crates/autopilot/src/driver_model.rs
@@ -48,7 +48,7 @@ pub mod solve {
     use {
         chrono::{DateTime, Utc},
         model::{
-            app_id::AppDataHash,
+            app_data::AppDataHash,
             bytes_hex::BytesHex,
             order::{BuyTokenDestination, OrderKind, OrderUid, SellTokenSource},
             signature::Signature,

--- a/crates/driver/src/boundary/settlement.rs
+++ b/crates/driver/src/boundary/settlement.rs
@@ -18,7 +18,7 @@ use {
     anyhow::{anyhow, ensure, Context, Result},
     bigdecimal::Signed,
     model::{
-        app_id::AppDataHash,
+        app_data::AppDataHash,
         interaction::InteractionData,
         order::{
             BuyTokenDestination,

--- a/crates/e2e/tests/e2e/app_data.rs
+++ b/crates/e2e/tests/e2e/app_data.rs
@@ -2,7 +2,7 @@ use {
     crate::setup::*,
     ethcontract::prelude::U256,
     model::{
-        app_id::AppDataHash,
+        app_data::AppDataHash,
         order::{OrderCreation, OrderCreationAppData, OrderKind},
         signature::EcdsaSigningScheme,
     },

--- a/crates/e2e/tests/e2e/order_cancellation.rs
+++ b/crates/e2e/tests/e2e/order_cancellation.rs
@@ -3,7 +3,7 @@ use {
     database::order_events::OrderEventLabel,
     ethcontract::prelude::U256,
     model::{
-        app_id::AppDataHash,
+        app_data::AppDataHash,
         order::{
             CancellationPayload,
             OrderCancellation,

--- a/crates/e2e/tests/e2e/setup/services.rs
+++ b/crates/e2e/tests/e2e/setup/services.rs
@@ -6,7 +6,7 @@ use {
     clap::Parser,
     ethcontract::H256,
     model::{
-        app_id::AppDataHash,
+        app_data::{AppDataDocument, AppDataHash},
         auction::AuctionWithId,
         order::{Order, OrderCreation, OrderUid},
         quote::{OrderQuoteRequest, OrderQuoteResponse},
@@ -273,10 +273,10 @@ impl<'a> Services<'a> {
         }
     }
 
-    pub async fn get_app_data(
+    pub async fn get_app_data_document(
         &self,
         app_data: AppDataHash,
-    ) -> Result<String, (StatusCode, String)> {
+    ) -> Result<AppDataDocument, (StatusCode, String)> {
         let response = self
             .http
             .get(format!("{API_HOST}/api/v1/app_data/{app_data:?}"))
@@ -288,20 +288,27 @@ impl<'a> Services<'a> {
         let body = response.text().await.unwrap();
 
         match status {
-            StatusCode::OK => Ok(body),
+            StatusCode::OK => Ok(serde_json::from_str(&body).unwrap()),
             code => Err((code, body)),
         }
     }
 
-    pub async fn put_app_data(
+    pub async fn get_app_data(
         &self,
         app_data: AppDataHash,
-        full_app_data: &str,
+    ) -> Result<String, (StatusCode, String)> {
+        Ok(self.get_app_data_document(app_data).await?.app_data)
+    }
+
+    pub async fn put_app_data_document(
+        &self,
+        app_data: AppDataHash,
+        document: AppDataDocument,
     ) -> Result<(), (StatusCode, String)> {
         let response = self
             .http
             .put(format!("{API_HOST}/api/v1/app_data/{app_data:?}"))
-            .body(full_app_data.to_owned())
+            .json(&document)
             .send()
             .await
             .unwrap();
@@ -314,6 +321,20 @@ impl<'a> Services<'a> {
         } else {
             Err((status, body))
         }
+    }
+
+    pub async fn put_app_data(
+        &self,
+        app_data: AppDataHash,
+        full_app_data: &str,
+    ) -> Result<(), (StatusCode, String)> {
+        self.put_app_data_document(
+            app_data,
+            AppDataDocument {
+                app_data: full_app_data.to_owned(),
+            },
+        )
+        .await
     }
 
     pub fn client(&self) -> &Client {

--- a/crates/e2e/tests/e2e/setup/services.rs
+++ b/crates/e2e/tests/e2e/setup/services.rs
@@ -297,7 +297,7 @@ impl<'a> Services<'a> {
         &self,
         app_data: AppDataHash,
     ) -> Result<String, (StatusCode, String)> {
-        Ok(self.get_app_data_document(app_data).await?.app_data)
+        Ok(self.get_app_data_document(app_data).await?.full_app_data)
     }
 
     pub async fn put_app_data_document(
@@ -331,7 +331,7 @@ impl<'a> Services<'a> {
         self.put_app_data_document(
             app_data,
             AppDataDocument {
-                app_data: full_app_data.to_owned(),
+                full_app_data: full_app_data.to_owned(),
             },
         )
         .await

--- a/crates/e2e/tests/e2e/smart_contract_orders.rs
+++ b/crates/e2e/tests/e2e/smart_contract_orders.rs
@@ -3,7 +3,7 @@ use {
     contracts::{GnosisSafe, GnosisSafeCompatibilityFallbackHandler, GnosisSafeProxy},
     ethcontract::{Bytes, H160, H256, U256},
     model::{
-        app_id::AppDataHash,
+        app_data::AppDataHash,
         order::{OrderCreation, OrderCreationAppData, OrderKind, OrderStatus, OrderUid},
         signature::{hashed_eip712_message, Signature},
     },

--- a/crates/model/src/app_data.rs
+++ b/crates/model/src/app_data.rs
@@ -8,6 +8,14 @@ use {
     },
 };
 
+/// A JSON object used to represent app data documents for uploading and
+/// retrieving from the API services.
+#[derive(Clone, Debug, Default, Deserialize, Serialize, Eq, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct AppDataDocument {
+    pub app_data: String,
+}
+
 /// On the contract level orders have 32 bytes of generic data that are freely
 /// choosable by the user. On the services level this is a hash of an app data
 /// json document, which associates arbitrary information with an order while

--- a/crates/model/src/app_data.rs
+++ b/crates/model/src/app_data.rs
@@ -13,7 +13,7 @@ use {
 #[derive(Clone, Debug, Default, Deserialize, Serialize, Eq, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct AppDataDocument {
-    pub app_data: String,
+    pub full_app_data: String,
 }
 
 /// On the contract level orders have 32 bytes of generic data that are freely

--- a/crates/model/src/lib.rs
+++ b/crates/model/src/lib.rs
@@ -3,7 +3,7 @@
 
 //! Contains models that are shared between the orderbook and the solver.
 
-pub mod app_id;
+pub mod app_data;
 pub mod auction;
 pub mod bytes_hex;
 pub mod interaction;

--- a/crates/model/src/order.rs
+++ b/crates/model/src/order.rs
@@ -3,7 +3,7 @@
 
 use {
     crate::{
-        app_id::AppDataHash,
+        app_data::AppDataHash,
         bytes_hex::BytesHex,
         interaction::InteractionData,
         quote::QuoteId,

--- a/crates/model/src/quote.rs
+++ b/crates/model/src/quote.rs
@@ -1,6 +1,6 @@
 use {
     crate::{
-        app_id::AppDataHash,
+        app_data::AppDataHash,
         order::{BuyTokenDestination, OrderCreationAppData, OrderKind, SellTokenSource},
         signature::SigningScheme,
         time,

--- a/crates/orderbook/openapi.yml
+++ b/crates/orderbook/openapi.yml
@@ -474,13 +474,14 @@ components:
       type: string
       example: "0x0000000000000000000000000000000000000000000000000000000000000000"
     AppDataDocument:
-      description: An `appData` document that is registed with the API.
+      description: An `appData` document that is registered with the API.
       type: object
       properties:
         appData:
           description: |
             The string encoding of a JSON object representing some `appData`. The
-            format of this `appData` is defined [here](https://github.com/cowprotocol/app-data).
+            format of the JSON expected in the `appData` field is defined
+            [here](https://github.com/cowprotocol/app-data).
           type: string
       required:
         - appData

--- a/crates/orderbook/openapi.yml
+++ b/crates/orderbook/openapi.yml
@@ -477,7 +477,7 @@ components:
       description: An `appData` document that is registered with the API.
       type: object
       properties:
-        appData:
+        fullAppData:
           description: |
             The string encoding of a JSON object representing some `appData`. The
             format of the JSON expected in the `appData` field is defined

--- a/crates/orderbook/openapi.yml
+++ b/crates/orderbook/openapi.yml
@@ -399,7 +399,9 @@ paths:
         200:
           description: Full `appData`.
           content:
-            application/json: {}
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AppDataDocument"
         404:
           description: No full `appData` stored for this hash.
     put:
@@ -413,6 +415,13 @@ paths:
           schema:
             $ref: "#/components/schemas/AppDataHash"
           required: true
+      requestBody:
+        description: The `appData` document to upload.
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/AppDataDocument"
       responses:
         200:
           description: The full `appData` already exists.
@@ -464,6 +473,17 @@ components:
       description: 32 bytes encoded as hex with `0x` prefix.
       type: string
       example: "0x0000000000000000000000000000000000000000000000000000000000000000"
+    AppDataDocument:
+      description: An `appData` document that is registed with the API.
+      type: object
+      properties:
+        appData:
+          description: |
+            The string encoding of a JSON object representing some `appData`. The
+            format of this `appData` is defined [here](https://github.com/cowprotocol/app-data).
+          type: string
+      required:
+        - appData
     BigUint:
       description: A big unsigned integer encoded in decimal.
       type: string

--- a/crates/orderbook/src/api/get_app_data.rs
+++ b/crates/orderbook/src/api/get_app_data.rs
@@ -21,7 +21,9 @@ pub fn get(
             Result::<_, Infallible>::Ok(match result {
                 Ok(Some(response)) => {
                     let response = reply::with_status(
-                        reply::json(&AppDataDocument { app_data: response }),
+                        reply::json(&AppDataDocument {
+                            full_app_data: response,
+                        }),
                         StatusCode::OK,
                     );
                     Box::new(response) as Box<dyn Reply>

--- a/crates/orderbook/src/api/get_app_data.rs
+++ b/crates/orderbook/src/api/get_app_data.rs
@@ -1,15 +1,10 @@
 use {
     crate::database::Postgres,
     anyhow::Result,
-    model::app_id::AppDataHash,
+    model::app_data::{AppDataDocument, AppDataHash},
     reqwest::StatusCode,
     std::convert::Infallible,
-    warp::{
-        reply::{with_header, with_status},
-        Filter,
-        Rejection,
-        Reply,
-    },
+    warp::{reply, Filter, Rejection, Reply},
 };
 
 pub fn request() -> impl Filter<Extract = (AppDataHash,), Error = Rejection> + Clone {
@@ -25,11 +20,13 @@ pub fn get(
             let result = database.get_full_app_data(&contract_app_data).await;
             Result::<_, Infallible>::Ok(match result {
                 Ok(Some(response)) => {
-                    let response = with_status(response, StatusCode::OK);
-                    let response = with_header(response, "Content-Type", "application/json");
+                    let response = reply::with_status(
+                        reply::json(&AppDataDocument { app_data: response }),
+                        StatusCode::OK,
+                    );
                     Box::new(response) as Box<dyn Reply>
                 }
-                Ok(None) => Box::new(with_status(
+                Ok(None) => Box::new(reply::with_status(
                     "full app data not found",
                     StatusCode::NOT_FOUND,
                 )),

--- a/crates/orderbook/src/api/post_quote.rs
+++ b/crates/orderbook/src/api/post_quote.rs
@@ -80,7 +80,7 @@ mod tests {
         chrono::{TimeZone, Utc},
         ethcontract::{H160, U256},
         model::{
-            app_id::AppDataHash,
+            app_data::AppDataHash,
             order::{BuyTokenDestination, SellTokenSource},
             quote::{
                 OrderQuote,

--- a/crates/orderbook/src/api/put_app_data.rs
+++ b/crates/orderbook/src/api/put_app_data.rs
@@ -39,7 +39,9 @@ pub fn filter(
     request(registry.size_limit()).and_then(move |hash, document: AppDataDocument| {
         let registry = registry.clone();
         async move {
-            let result = registry.register(hash, document.app_data.as_bytes()).await;
+            let result = registry
+                .register(hash, document.full_app_data.as_bytes())
+                .await;
             Result::<_, Infallible>::Ok(response(hash, result))
         }
     })

--- a/crates/orderbook/src/api/put_app_data.rs
+++ b/crates/orderbook/src/api/put_app_data.rs
@@ -1,20 +1,20 @@
 use {
     crate::app_data,
     anyhow::Result,
-    model::app_id::AppDataHash,
+    model::app_data::{AppDataDocument, AppDataHash},
     reqwest::StatusCode,
     shared::api::{internal_error_reply, IntoWarpReply},
     std::{convert::Infallible, sync::Arc},
-    warp::{hyper::body::Bytes, reply, Filter, Rejection},
+    warp::{body, reply, Filter, Rejection},
 };
 
 fn request(
     max_size: usize,
-) -> impl Filter<Extract = (AppDataHash, Bytes), Error = Rejection> + Clone {
+) -> impl Filter<Extract = (AppDataHash, AppDataDocument), Error = Rejection> + Clone {
     warp::path!("v1" / "app_data" / AppDataHash)
         .and(warp::put())
-        .and(warp::body::content_length_limit(max_size as _))
-        .and(warp::body::bytes())
+        .and(body::content_length_limit(max_size as _))
+        .and(body::json())
 }
 
 fn response(
@@ -36,10 +36,10 @@ fn response(
 pub fn filter(
     registry: Arc<app_data::Registry>,
 ) -> impl Filter<Extract = (super::ApiReply,), Error = Rejection> + Clone {
-    request(registry.size_limit()).and_then(move |hash, document: Bytes| {
+    request(registry.size_limit()).and_then(move |hash, document: AppDataDocument| {
         let registry = registry.clone();
         async move {
-            let result = registry.register(hash, &document).await;
+            let result = registry.register(hash, document.app_data.as_bytes()).await;
             Result::<_, Infallible>::Ok(response(hash, result))
         }
     })

--- a/crates/orderbook/src/app_data.rs
+++ b/crates/orderbook/src/app_data.rs
@@ -1,6 +1,6 @@
 use {
     crate::database::{app_data::InsertError, Postgres},
-    model::app_id::AppDataHash,
+    model::app_data::AppDataHash,
     shared::app_data,
 };
 

--- a/crates/orderbook/src/database/app_data.rs
+++ b/crates/orderbook/src/database/app_data.rs
@@ -1,7 +1,7 @@
 use {
     anyhow::{Context, Result},
     database::byte_array::ByteArray,
-    model::app_id::AppDataHash,
+    model::app_data::AppDataHash,
     std::string::FromUtf8Error,
 };
 

--- a/crates/orderbook/src/database/orders.rs
+++ b/crates/orderbook/src/database/orders.rs
@@ -11,7 +11,7 @@ use {
     ethcontract::H256,
     futures::{stream::TryStreamExt, FutureExt, StreamExt},
     model::{
-        app_id::AppDataHash,
+        app_data::AppDataHash,
         order::{
             EthflowData,
             Interactions,

--- a/crates/orderbook/src/ipfs_app_data.rs
+++ b/crates/orderbook/src/ipfs_app_data.rs
@@ -2,7 +2,7 @@ use {
     crate::ipfs::Ipfs,
     anyhow::Result,
     cached::{Cached, TimedSizedCache},
-    model::app_id::AppDataHash,
+    model::app_data::AppDataHash,
     std::sync::Mutex,
 };
 

--- a/crates/orderbook/src/orderbook.rs
+++ b/crates/orderbook/src/orderbook.rs
@@ -7,7 +7,7 @@ use {
     chrono::Utc,
     ethcontract::H256,
     model::{
-        app_id::AppDataHash,
+        app_data::AppDataHash,
         auction::AuctionWithId,
         order::{
             Order,
@@ -441,7 +441,7 @@ mod tests {
         ethcontract::H160,
         mockall::predicate::eq,
         model::{
-            app_id::AppDataHash,
+            app_data::AppDataHash,
             order::{OrderData, OrderMetadata},
             signature::Signature,
         },

--- a/crates/shared/src/app_data.rs
+++ b/crates/shared/src/app_data.rs
@@ -1,6 +1,6 @@
 use {
     anyhow::{anyhow, Context, Result},
-    model::{app_id::AppDataHash, order::Hooks},
+    model::{app_data::AppDataHash, order::Hooks},
     serde::Deserialize,
 };
 

--- a/crates/shared/src/db_order_conversions.rs
+++ b/crates/shared/src/db_order_conversions.rs
@@ -14,7 +14,7 @@ use {
     },
     ethcontract::{H160, H256},
     model::{
-        app_id::AppDataHash,
+        app_data::AppDataHash,
         interaction::InteractionData,
         order::{
             BuyTokenDestination,

--- a/crates/shared/src/http_solver/model.rs
+++ b/crates/shared/src/http_solver/model.rs
@@ -486,7 +486,7 @@ mod tests {
         ethcontract::H256,
         maplit::btreemap,
         model::{
-            app_id::AppDataHash,
+            app_data::AppDataHash,
             order::{OrderKind, SellTokenSource},
         },
         serde_json::json,

--- a/crates/shared/src/order_validation.rs
+++ b/crates/shared/src/order_validation.rs
@@ -22,7 +22,7 @@ use {
     database::onchain_broadcasted_orders::OnchainOrderPlacementError,
     ethcontract::{Bytes, H160, H256, U256},
     model::{
-        app_id::AppDataHash,
+        app_data::AppDataHash,
         interaction::InteractionData,
         order::{
             BuyTokenDestination,


### PR DESCRIPTION
As discussed [in Slack](https://cowservices.slack.com/archives/C0375NV72SC/p1690808347200279?thread_ts=1690297997.334099&cid=C0375NV72SC), it was suggested that the `GET`/`PUT` `api/v1/app_data/{hash}` APIs operate on:

```json
{
  "fullAppData": "..."
}
```

My motivation for this change is to make the API less ambiguous. For example, conceptually an HTTP request/response with `Content-Type: application/json` implies that the content is, well, JSON and it becomes ambiguous whether things like spaces, trailing newlines, etc. matter or not. In fact many HTTP client utilities may make this assumption as well and end up doing things like adding new lines, re-serializing to be smaller by omitting whitespace, automatically parse the JSON content, etc. As such, we now return the aforementioned JSON format, so that the exact string serialization used for the app-data is guaranteed to be preserved. It is also nice as it keeps our API entirely JSON (with no more exceptions for the `appData` routes).

### Test Plan

E2E tests adjusted for new format.

### Release notes

This is a breaking API change, but this should be fairly unused as it was just introduced, so I consider this a low risk break. 
