### PR TITLE
Remove Legacy Builtin Price Estimator

### DIFF
--- a/crates/shared/src/price_estimation.rs
+++ b/crates/shared/src/price_estimation.rs
@@ -99,11 +99,8 @@ pub enum PriceEstimatorKind {
     Baseline,
     Paraswap,
     ZeroEx,
-    Quasimodo,
     OneInch,
-    Yearn,
     BalancerSor,
-    Raven,
 }
 
 #[derive(Copy, Clone, Debug, Hash, Eq, PartialEq)]
@@ -131,11 +128,8 @@ impl FromStr for PriceEstimator {
             "Baseline" => PriceEstimatorKind::Baseline,
             "Paraswap" => PriceEstimatorKind::Paraswap,
             "ZeroEx" => PriceEstimatorKind::ZeroEx,
-            "Quasimodo" => PriceEstimatorKind::Quasimodo,
             "OneInch" => PriceEstimatorKind::OneInch,
-            "Yearn" => PriceEstimatorKind::Yearn,
             "BalancerSor" => PriceEstimatorKind::BalancerSor,
-            "Raven" => PriceEstimatorKind::Raven,
             estimator => {
                 anyhow::bail!("failed to convert to PriceEstimatorKind: {estimator}")
             }
@@ -624,24 +618,12 @@ mod tests {
             estimator(PriceEstimatorKind::ZeroEx, address(1))
         );
         assert_eq!(
-            parsed("Quasimodo|0x0000000000000000000000000000000000000001"),
-            estimator(PriceEstimatorKind::Quasimodo, address(1))
-        );
-        assert_eq!(
             parsed("OneInch|0x0000000000000000000000000000000000000001"),
             estimator(PriceEstimatorKind::OneInch, address(1))
         );
         assert_eq!(
-            parsed("Yearn|0x0000000000000000000000000000000000000001"),
-            estimator(PriceEstimatorKind::Yearn, address(1))
-        );
-        assert_eq!(
             parsed("BalancerSor|0x0000000000000000000000000000000000000001"),
             estimator(PriceEstimatorKind::BalancerSor, address(1))
-        );
-        assert_eq!(
-            parsed("Raven|0x0000000000000000000000000000000000000001"),
-            estimator(PriceEstimatorKind::Raven, address(1))
         );
     }
 }

--- a/crates/shared/src/price_estimation/factory.rs
+++ b/crates/shared/src/price_estimation/factory.rs
@@ -234,51 +234,12 @@ impl<'a> PriceEstimatorFactory<'a> {
             PriceEstimatorKind::ZeroEx => {
                 self.create_estimator_entry::<ZeroExPriceEstimator>(&name, estimator.address)
             }
-            PriceEstimatorKind::Quasimodo => self.create_estimator_entry::<HttpPriceEstimator>(
-                &name,
-                HttpPriceEstimatorParams {
-                    base: self
-                        .args
-                        .quasimodo_solver_url
-                        .clone()
-                        .context("quasimodo solver url not specified")?,
-                    solve_path: "solve".to_owned(),
-                    use_liquidity: true,
-                    solver: estimator.address,
-                },
-            ),
             PriceEstimatorKind::OneInch => {
                 self.create_estimator_entry::<OneInchPriceEstimator>(&name, estimator.address)
             }
-            PriceEstimatorKind::Yearn => self.create_estimator_entry::<HttpPriceEstimator>(
-                &name,
-                HttpPriceEstimatorParams {
-                    base: self
-                        .args
-                        .yearn_solver_url
-                        .clone()
-                        .context("yearn solver url not specified")?,
-                    solve_path: self.args.yearn_solver_path.clone(),
-                    use_liquidity: false,
-                    solver: estimator.address,
-                },
-            ),
             PriceEstimatorKind::BalancerSor => {
                 self.create_estimator_entry::<BalancerSor>(&name, estimator.address)
             }
-            PriceEstimatorKind::Raven => self.create_estimator_entry::<HttpPriceEstimator>(
-                &name,
-                HttpPriceEstimatorParams {
-                    base: self
-                        .args
-                        .raven_solver_url
-                        .clone()
-                        .context("raven solver url not specified")?,
-                    solve_path: self.args.raven_solver_path.clone(),
-                    use_liquidity: false,
-                    solver: estimator.address,
-                },
-            ),
         }
     }
 


### PR DESCRIPTION
This is a follow up to #1715 where we added a new `--price-estimation-legacy-solvers` flag to specify legacy HTTP solvers to use as price estimators. As such, the "builtin" estimators `Quasimodo`, `Yearn` and `Raven` are no longer needed.

This PR deprecates the aforementioned builtin estimators in favor of the new `--price-estimation-legacy-solvers` flag.

### Test Plan

Rust CI - we are removing code, so nothing to test!

### Release notes

https://github.com/cowprotocol/infrastructure/pull/596 already does the required changes in order to no longer rely on the "builtin" versions of these legacy price estimators - those changes have already been applied.
