### PR TITLE
Notify about tx hash instead of block hash

### DIFF
--- a/crates/solver/src/driver.rs
+++ b/crates/solver/src/driver.rs
@@ -508,7 +508,7 @@ impl Driver {
                     winning_solver.notify_auction_result(
                         auction_id,
                         AuctionResult::SubmittedOnchain(SubmissionResult::Success(
-                            receipt.block_hash.unwrap_or_default(),
+                            receipt.transaction_hash,
                         )),
                     );
                     Some(receipt.transaction_hash)


### PR DESCRIPTION
For some reason the notification about a successfully mined solution contained a block hash which is fairly useless.
This PR notifies about the tx hash instead which can be easily found on etherscan.

### Test Plan
compiler
