### PR TITLE
Fix soft cancellations support

### DIFF
--- a/crates/solver/src/settlement_submission/submitter.rs
+++ b/crates/solver/src/settlement_submission/submitter.rs
@@ -497,6 +497,12 @@ impl<'a> Submitter<'a> {
                 if gas_price.max_priority_fee_per_gas < replacement_price.max_priority_fee_per_gas
                     || gas_price.max_fee_per_gas < replacement_price.max_fee_per_gas
                 {
+                    tracing::debug!(
+                        ?gas_price,
+                        ?replacement_price,
+                        sleep = ?params.retry_interval,
+                        "keep waiting for gas price to increase enough"
+                    );
                     tokio::time::sleep(params.retry_interval).await;
                     continue;
                 }

--- a/crates/solver/src/settlement_submission/submitter.rs
+++ b/crates/solver/src/settlement_submission/submitter.rs
@@ -295,6 +295,15 @@ impl<'a> Submitter<'a> {
                                 // simply "forget" the submitted tx by clearing `transactions`.
                                 tracing::debug!("clear list of pending tx hashes due to soft cancellation");
                                 transactions.clear();
+                                // The regular logic only updates the `submitted_transactions` if
+                                // `!transactions.is_empty()`. Since we just cleared the vector we
+                                // have to forcefully update the `submitted_transactions` here to
+                                // really discard the known tx for the next submission loop.
+                                self.submitted_transactions.update(
+                                    self.account.address(),
+                                    self.nonce,
+                                    vec![]
+                                );
                             } else {
                                 transactions.push((handle, gas_price));
                             }


### PR DESCRIPTION
Follow up fix to https://github.com/cowprotocol/services/pull/1544 (please read that one for more context)

That PR only cleared `transactions` after a soft cancellations because I thought that `submitted_transactions` would always be overwritten with `transactions` afterwards.
However, this actually only happens when `transactions` is not empty which means the previous PR didn't have an effect.

Now we clear `transactions` to avoid waiting for any tx that will never be mined and we forcefully update `submitted_transactions` to actually ensure that we will not wait for the gas price to increase during the next submission of the same solver.

This PR also adds a log that states whenever we are waiting for the gas price to increase since this would have been useful debugging information a couple of times.
