### PR TITLE
Add new GetBlockAndCall Strategy

### DIFF
--- a/crates/shared/src/current_block/arguments.rs
+++ b/crates/shared/src/current_block/arguments.rs
@@ -1,7 +1,13 @@
 //! Global block stream arguments.
 
 use {
-    super::{current_block_stream, eth_call, BlockRetrieving, CurrentBlockStream},
+    super::{
+        current_block_stream,
+        eth_call,
+        get_block_and_call,
+        BlockRetrieving,
+        CurrentBlockStream,
+    },
     crate::{arguments::duration_from_seconds, ethrpc::Web3},
     anyhow::Result,
     clap::{Parser, ValueEnum},
@@ -37,6 +43,7 @@ pub struct Arguments {
 pub enum BlockRetrieverStrategy {
     #[default]
     GetBlock,
+    GetBlockAndCall,
     EthCall,
 }
 
@@ -44,6 +51,9 @@ impl Arguments {
     pub fn retriever(&self, web3: Web3) -> Arc<dyn BlockRetrieving> {
         match self.block_stream_retriever_strategy {
             BlockRetrieverStrategy::GetBlock => Arc::new(web3),
+            BlockRetrieverStrategy::GetBlockAndCall => {
+                Arc::new(get_block_and_call::BlockRetriever(web3))
+            }
             BlockRetrieverStrategy::EthCall => Arc::new(eth_call::BlockRetriever(web3)),
         }
     }

--- a/crates/shared/src/current_block/get_block_and_call.rs
+++ b/crates/shared/src/current_block/get_block_and_call.rs
@@ -15,7 +15,7 @@ use {
 /// for nodes where `eth_getBlockBy*` and `eth_blockNumber` calls return the
 /// latest block for which a header is available even if the state isn't.
 ///
-/// However, some nodes (notably Nethermind) to **not** support `eth_call` on
+/// However, some nodes (notably Nethermind) do **not** support `eth_call` on
 /// the pending block, which is required for the `eth_call` based fetcher to
 /// work. As a work-around, we issue simultaneous `eth_call` and `eth_getBlock`
 /// requests to fetch the full block header (which includes the hash) and

--- a/crates/shared/src/current_block/get_block_and_call.rs
+++ b/crates/shared/src/current_block/get_block_and_call.rs
@@ -1,0 +1,113 @@
+use {
+    super::{eth_call, BlockInfo, BlockNumberHash, BlockRetrieving, RangeInclusive},
+    crate::ethrpc::Web3,
+    anyhow::{bail, Context, Result},
+    contracts::support::FetchBlock,
+    web3::{
+        transports::Batch,
+        types::{BlockNumber, CallRequest},
+    },
+};
+
+/// A hybrid `eth_getBlock` and `eth_call` based block fetcher.
+///
+/// This is similar to the `eth_call` based fetcher, in that it can be used
+/// for nodes where `eth_getBlockBy*` and `eth_blockNumber` calls return the
+/// latest block for which a header is available even if the state isn't.
+///
+/// However, some nodes (notably Nethermind) to **not** support `eth_call` on
+/// the pending block, which is required for the `eth_call` based fetcher to
+/// work. As a work-around, we issue simultaneous `eth_call` and `eth_getBlock`
+/// requests to fetch the full block header (which includes the hash) and
+/// simulate code on the latest block for which there is state. This gives us
+/// the best of both worlds at the cost of an extra request per "poll".
+pub struct BlockRetriever(pub Web3);
+
+#[async_trait::async_trait]
+impl BlockRetrieving for BlockRetriever {
+    async fn current_block(&self) -> Result<BlockInfo> {
+        let (return_data, block) = {
+            let batch = web3::Web3::new(Batch::new(self.0.transport().clone()));
+
+            let return_data = batch.eth().call(
+                CallRequest {
+                    data: Some(bytecode!(FetchBlock)),
+                    ..Default::default()
+                },
+                Some(BlockNumber::Latest.into()),
+            );
+            let block = batch.eth().block(BlockNumber::Latest.into());
+
+            batch.transport().submit_batch().await?;
+
+            (
+                return_data.await?.0,
+                block.await?.context("missing latest block")?,
+            )
+        };
+
+        let call = eth_call::decode(
+            return_data
+                .as_slice()
+                .try_into()
+                .context("unexpected block fetch return length")?,
+        )?;
+        let fetch = BlockInfo::try_from(block)?;
+
+        // The `FetchBlock` contract works by returning `block.number - 1`, its
+        // hash, and its parent's hash. This means that, if we call it with
+        // `latest`, then `call.number` will be the block `latest - 1`.
+        //
+        // We accept a few cases here:
+        // 1. If `call.number + 1 >= fetch.number`, this means that the state for the
+        //    `fetch.number` block is available (as the `eth_call` executed on that
+        //    block or later). Hence, `Ok(fetch)` is the current block.
+        // 2. If `call.number + 1 == fetch.number - 1`, then there is a 2 block
+        //    differential between `call` and `fetch`, meaning that the `fetch.number`
+        //    block header is available but not its state, so return the `fetch.number -
+        //    1` as the current block.
+        // 3. Unexpectedly large differential between `call` and `fetch`.
+        if call.number.saturating_add(1) >= fetch.number {
+            Ok(fetch)
+        } else if call.number.saturating_add(1) == fetch.number.saturating_sub(1) {
+            Ok(BlockInfo {
+                number: fetch.number.saturating_sub(1),
+                hash: fetch.parent_hash,
+                parent_hash: call.hash,
+            })
+        } else {
+            bail!("large differential between eth_getBlock {fetch:?} and eth_call {call:?}");
+        }
+    }
+
+    async fn block(&self, number: u64) -> Result<BlockNumberHash> {
+        self.0.block(number).await
+    }
+
+    async fn blocks(&self, range: RangeInclusive<u64>) -> Result<Vec<BlockNumberHash>> {
+        self.0.blocks(range).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use {super::*, crate::ethrpc::create_env_test_transport};
+
+    #[ignore]
+    #[tokio::test]
+    async fn node() {
+        let retriever = BlockRetriever(Web3::new(create_env_test_transport()));
+
+        let mut block = Option::<u64>::None;
+        for _ in 0..3 {
+            loop {
+                let current = retriever.current_block().await.unwrap();
+                if block.is_none() || matches!(block, Some(b) if b < current.number) {
+                    println!("current block: {current:#?}");
+                    block = Some(current.number);
+                    break;
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
This PR adds a new `GetBlockAndCall` "block fetching strategy".

This combines the `eth_call` strategy (which ensures that there is block state for the `latest` block) and the `eth_getBlock` strategy (to read the latest block hash - since the EVM defines `blockhash(block.number) == bytes32(0)`).

This is needed as the existing `eth_call` strategy relies on simulating on the `pending` block (so that `block.number - 1 == latest`, we do this so that `blockhash(block.number - 1) == blockhash(latest)` is available). However, this is [not supported on Nethermind](https://github.com/NethermindEth/nethermind/issues/5810). In addition, `eth_call` on `pending` is potentially going to be no longer supported on RPC nodes, meaning that the `eth_call` strategy will likely stop working some time in the future as well.

### Test Plan

Manual test that can be run with:

```
% export NODE_URL="<our CoW Nethermind node>"
% cargo test -p shared -- --ignored --nocapture get_block_and_call
    Finished test [unoptimized + debuginfo] target(s) in 0.28s
     Running unittests src/lib.rs (target/debug/deps/shared-4867f6d8cb7cdd00)

running 1 test
current block: BlockInfo {
    number: 17827743,
    hash: 0x63c9d2bf67514f7314180aa962c936dc02a395fd16a98b46b46d8fdbd9d2ad36,
    parent_hash: 0x6ef7403e15c55b9befcfbdfd682f38b8c4900d5b4e535ecf5e1e0678f51b1e05,
}
current block: BlockInfo {
    number: 17827744,
    hash: 0xbb1ed91800b87d90bc704ff1b7e431fdc5ce958bc40be2742b21e5b2a16cee01,
    parent_hash: 0x63c9d2bf67514f7314180aa962c936dc02a395fd16a98b46b46d8fdbd9d2ad36,
}
current block: BlockInfo {
    number: 17827745,
    hash: 0x503d125c7c3d31eff91e86f04b1d29febb45a9c2f263d181cbda808e434fd4a0,
    parent_hash: 0xbb1ed91800b87d90bc704ff1b7e431fdc5ce958bc40be2742b21e5b2a16cee01,
}
test current_block::get_block_and_call::tests::node ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 414 filtered out; finished in 23.08s
```

Note that the hashes match Etherscan, and we seem to be slightly ahead of Etherscan in seeing new blocks (refreshing right when a new block is noticed by the service, the new block does not yet show up on Etherscan):

<img width="774" alt="image" src="https://github.com/cowprotocol/services/assets/4210206/eb337395-eddb-4e43-8179-dd40ef3a5a40">

