### PR TITLE
Remove Unused Decimal Cutoff Flag

### DIFF
--- a/crates/solver/src/arguments.rs
+++ b/crates/solver/src/arguments.rs
@@ -319,13 +319,6 @@ pub struct Arguments {
     #[clap(long, env, use_value_delimiter = true)]
     pub token_list_restriction_for_price_checks: Option<Vec<H160>>,
 
-    /// When comparing the objective value of different solutions, ignore the N
-    /// least significant digits in base 10. Note, that objective values are
-    /// computed in wei. A value of 15 would consider solutions with with
-    /// objective value 0.0012 ETH and 0.0016 ETH equivalent.
-    #[clap(long, env, default_value = "0")]
-    pub solution_comparison_decimal_cutoff: u16,
-
     #[clap(flatten)]
     pub s3_upload: S3UploadArguments,
 

--- a/crates/solver/src/driver.rs
+++ b/crates/solver/src/driver.rs
@@ -107,7 +107,6 @@ impl Driver {
         max_settlement_price_deviation: Option<Ratio<BigInt>>,
         token_list_restriction_for_price_checks: PriceCheckTokens,
         tenderly: Option<Arc<dyn TenderlyApi>>,
-        solution_comparison_decimal_cutoff: u16,
         process_partially_fillable_liquidity_orders: bool,
         process_partially_fillable_limit_orders: bool,
         settlement_rater: Arc<dyn SettlementRating>,
@@ -121,7 +120,6 @@ impl Driver {
             token_list_restriction_for_price_checks,
             metrics: metrics.clone(),
             settlement_rater,
-            decimal_cutoff: solution_comparison_decimal_cutoff,
             skip_non_positive_score_settlements,
         };
 

--- a/crates/solver/src/run.rs
+++ b/crates/solver/src/run.rs
@@ -579,7 +579,6 @@ pub async fn run(args: Arguments) {
             .tenderly
             .get_api_instance(&http_factory, "driver".to_owned())
             .expect("failed to create Tenderly API"),
-        args.solution_comparison_decimal_cutoff,
         args.process_partially_fillable_liquidity_orders,
         args.process_partially_fillable_limit_orders,
         settlement_rater,

--- a/crates/solver/src/settlement_ranker.rs
+++ b/crates/solver/src/settlement_ranker.rs
@@ -42,7 +42,6 @@ pub struct SettlementRanker {
     // for everyone.
     pub max_settlement_price_deviation: Option<Ratio<BigInt>>,
     pub token_list_restriction_for_price_checks: PriceCheckTokens,
-    pub decimal_cutoff: u16,
     pub skip_non_positive_score_settlements: bool,
 }
 


### PR DESCRIPTION
This PR removes the unused `--solution-comparison-decimal-cutoff` flag.

### Test Plan

CI.
