### PR TITLE
Proper default log level

### DIFF
--- a/crates/solvers/src/infra/cli.rs
+++ b/crates/solvers/src/infra/cli.rs
@@ -10,7 +10,7 @@ use {
 #[command(version)]
 pub struct Args {
     /// The log filter.
-    #[arg(long, env, default_value = "debug")]
+    #[arg(long, env, default_value = "warn,solvers=debug,shared=debug")]
     pub log: String,
 
     /// The socket address to bind to.

--- a/crates/solvers/src/infra/cli.rs
+++ b/crates/solvers/src/infra/cli.rs
@@ -10,7 +10,11 @@ use {
 #[command(version)]
 pub struct Args {
     /// The log filter.
-    #[arg(long, env, default_value = "warn,solvers=debug,shared=debug")]
+    #[arg(
+        long,
+        env,
+        default_value = "warn,solvers=debug,shared=debug,model=debug,solver=debug"
+    )]
     pub log: String,
 
     /// The socket address to bind to.


### PR DESCRIPTION
Currently pods running the new `solvers` are logging lots of debug information of dependencies.
The new default log level will only log warnings and higher of dependencies and debug and higher of any code inside our repo.

### Test Plan
Manually ran solver to see that logs are still being printed