### PR TITLE
Nicer --help text for solver commands

### DIFF
--- a/crates/solvers/src/infra/cli.rs
+++ b/crates/solvers/src/infra/cli.rs
@@ -37,7 +37,7 @@ pub enum Command {
     },
     /// optimistically batch similar orders and get difference from AMMs
     Naive,
-    /// wrapper for solvers implementing the legacy HTTP interface
+    /// forward auction to solver implementing the legacy HTTP interface
     Legacy {
         #[clap(long, env)]
         config: PathBuf,

--- a/crates/solvers/src/infra/cli.rs
+++ b/crates/solvers/src/infra/cli.rs
@@ -42,7 +42,7 @@ pub enum Command {
         #[clap(long, env)]
         config: PathBuf,
     },
-    /// solve individual orders using balancer API
+    /// solve individual orders using Balancer API
     Balancer {
         #[clap(long, env)]
         config: PathBuf,

--- a/crates/solvers/src/infra/cli.rs
+++ b/crates/solvers/src/infra/cli.rs
@@ -30,34 +30,34 @@ pub struct Args {
 #[derive(Subcommand, Debug)]
 #[clap(rename_all = "lowercase")]
 pub enum Command {
-    /// Baseline solver.
+    /// solve individual orders exclusively via provided onchain liquidity
     Baseline {
         #[clap(long, env)]
         config: PathBuf,
     },
-    /// Naive solver.
+    /// optimistically batch similar orders and get difference from AMMs
     Naive,
-    /// Wrapper for solvers implementing the legacy HTTP interface.
+    /// wrapper for solvers implementing the legacy HTTP interface
     Legacy {
         #[clap(long, env)]
         config: PathBuf,
     },
-    /// Balancer SOR solver.
+    /// solve individual orders using balancer API
     Balancer {
         #[clap(long, env)]
         config: PathBuf,
     },
-    /// 0x solver.
+    /// solve individual orders using 0x API
     ZeroEx {
         #[clap(long, env)]
         config: PathBuf,
     },
-    /// 1inch solver.
+    /// solve individual orders using 1Inch API
     OneInch {
         #[clap(long, env)]
         config: PathBuf,
     },
-    // ParaSwap solver.
+    /// solve individual orders using Paraswap API
     ParaSwap {
         #[clap(long, env)]
         config: PathBuf,


### PR DESCRIPTION
I noticed that the doc comment on clap commands is used as a help text. Therefore I added a very basic explanation what kind of strategy each command uses.

### Test Plan
```
cargo run -p solvers -- --help
   Compiling solvers v0.1.0 (/Users/martin/work/backend/main/crates/solvers)
    Finished dev [unoptimized + debuginfo] target(s) in 3.09s
     Running `target/debug/solvers --help`
Run a solver engine

Usage: solvers [OPTIONS] <COMMAND>

Commands:
  baseline  solve individual orders exclusively via provided onchain liquidity
  naive     optimistically batch similar orders and get difference from AMMs
  legacy    forward auction to solver implementing the legacy HTTP interface
  balancer  solve individual orders using Balancer API
  zeroex    solve individual orders using 0x API
  oneinch   solve individual orders using 1Inch API
  paraswap  solve individual orders using Paraswap API
  help      Print this message or the help of the given subcommand(s)

Options:
      --log <LOG>    The log filter [env: LOG=] [default: warn,solvers=debug,shared=debug,model=debug,solver=debug]
      --addr <ADDR>  The socket address to bind to [env: ADDR=] [default: 127.0.0.1:7872]
  -h, --help         Print help
  -V, --version      Print version
```