### PR TITLE
Revert "Query the graph in smaller chunks (#1719)"

### DIFF
--- a/crates/autopilot/src/lib.rs
+++ b/crates/autopilot/src/lib.rs
@@ -342,7 +342,7 @@ pub async fn main(args: arguments::Arguments) {
                 args.shared.max_pools_to_initialize_cache,
             )
             .await
-            .expect("error initializing Uniswap V3 pool fetcher"),
+            .expect("error innitializing Uniswap V3 pool fetcher"),
         ))
     } else {
         None

--- a/crates/shared/src/sources/balancer_v2/graph_api.rs
+++ b/crates/shared/src/sources/balancer_v2/graph_api.rs
@@ -22,7 +22,7 @@ use {
 
 /// The page size when querying pools.
 #[cfg(not(test))]
-const QUERY_PAGE_SIZE: usize = 100;
+const QUERY_PAGE_SIZE: usize = 1000;
 #[cfg(test)]
 const QUERY_PAGE_SIZE: usize = 10;
 

--- a/crates/shared/src/subgraph.rs
+++ b/crates/shared/src/subgraph.rs
@@ -9,7 +9,7 @@ use {
     thiserror::Error,
 };
 
-pub const QUERY_PAGE_SIZE: usize = 100;
+pub const QUERY_PAGE_SIZE: usize = 1000;
 const MAX_NUMBER_OF_RETRIES: usize = 10;
 
 /// A general client for querying subgraphs.


### PR DESCRIPTION
This reverts commit 95bb44c0d31f9afe6f23601fb5dbecc5f3cd8326 (#1719).
That commit did not have the promised effect. I already proposed a new change (#1736) but IMO that is too big to include without running it staging first so I opened this PR just to revert the bad changes.