### PR TITLE
Add /reveal to driver

### DIFF
--- a/crates/autopilot/src/driver_api.rs
+++ b/crates/autopilot/src/driver_api.rs
@@ -1,5 +1,5 @@
 use {
-    crate::driver_model::{settle, solve},
+    crate::driver_model::{reveal, settle, solve},
     anyhow::{anyhow, Context, Result},
     reqwest::Client,
     shared::http_client::response_body_with_size_limit,
@@ -28,6 +28,10 @@ impl Driver {
 
     pub async fn solve(&self, request: &solve::Request) -> Result<solve::Response> {
         self.request_response("solve", Some(request)).await
+    }
+
+    pub async fn reveal(&self) -> Result<reveal::Response> {
+        self.request_response("reveal", Option::<&()>::None).await
     }
 
     pub async fn settle(&self) -> Result<settle::Response> {

--- a/crates/autopilot/src/driver_model.rs
+++ b/crates/autopilot/src/driver_model.rs
@@ -46,7 +46,6 @@ pub mod quote {
 
 pub mod solve {
     use {
-        super::settle::Calldata,
         chrono::{DateTime, Utc},
         model::{
             app_data::AppDataHash,
@@ -142,6 +141,29 @@ pub mod solve {
         pub score: U256,
         /// Address used by the driver to submit the settlement onchain.
         pub submission_address: H160,
+    }
+}
+
+pub mod reveal {
+    use {
+        model::{bytes_hex, order::OrderUid},
+        serde::Deserialize,
+        serde_with::serde_as,
+    };
+
+    #[serde_as]
+    #[derive(Clone, Debug, Default, Deserialize)]
+    #[serde(rename_all = "camelCase", deny_unknown_fields)]
+    pub struct Calldata {
+        #[serde(with = "bytes_hex")]
+        pub internalized: Vec<u8>,
+        #[serde(with = "bytes_hex")]
+        pub uninternalized: Vec<u8>,
+    }
+
+    #[derive(Clone, Debug, Default, Deserialize)]
+    #[serde(deny_unknown_fields)]
+    pub struct Response {
         pub orders: Vec<OrderUid>,
         pub calldata: Calldata,
     }

--- a/crates/autopilot/src/run_loop.rs
+++ b/crates/autopilot/src/run_loop.rs
@@ -5,10 +5,13 @@ use {
             Postgres,
         },
         driver_api::Driver,
-        driver_model::solve::{self, Class},
+        driver_model::{
+            reveal,
+            solve::{self, Class},
+        },
         solvable_orders::SolvableOrdersCache,
     },
-    anyhow::{anyhow, Context, Result},
+    anyhow::{anyhow, ensure, Context, Result},
     chrono::Utc,
     database::order_events::OrderEventLabel,
     itertools::Itertools,
@@ -94,11 +97,6 @@ impl RunLoop {
         solutions.sort_unstable_by_key(|solution| solution.1.score);
         let competition_simulation_block = self.current_block.borrow().number;
 
-        let events: Vec<_> = solutions
-            .iter()
-            .flat_map(|(_, s)| s.orders.iter().map(|o| (*o, OrderEventLabel::Considered)))
-            .collect();
-
         // TODO: Keep going with other solutions until some deadline.
         if let Some((index, solution)) = solutions.last() {
             // The winner has score 0 so all solutions are empty.
@@ -106,7 +104,22 @@ impl RunLoop {
                 return;
             }
 
+            tracing::info!(url = %self.drivers[*index].url, "revealing with solver");
+            let revealed = match self.reveal(id, &self.drivers[*index]).await {
+                Ok(result) => result,
+                Err(err) => {
+                    tracing::error!(?err, "solver {index} failed to settle");
+                    return;
+                }
+            };
+
+            let events = revealed
+                .orders
+                .iter()
+                .map(|o| (*o, OrderEventLabel::Considered))
+                .collect::<Vec<_>>();
             self.database.store_order_events(&events).await;
+
             let auction_id = id;
             let winner = solution.submission_address;
             let winning_score = solution.score;
@@ -123,13 +136,13 @@ impl RunLoop {
             let block_deadline = competition_simulation_block
                 + self.submission_deadline
                 + self.additional_deadline_for_rewards;
-            let call_data = solution.calldata.internalized.clone();
-            let uninternalized_call_data = solution.calldata.uninternalized.clone();
+            let call_data = revealed.calldata.internalized.clone();
+            let uninternalized_call_data = revealed.calldata.uninternalized.clone();
             // Save order executions for all orders in the solution. Surplus fees for
             // partial limit orders will be saved after settling the order
             // onchain.
             let mut order_executions = vec![];
-            for order_id in &solution.orders {
+            for order_id in &revealed.orders {
                 let auction_order = auction
                     .orders
                     .iter()
@@ -187,26 +200,41 @@ impl RunLoop {
                 },
                 solutions: solutions
                     .iter()
-                    .map(|(index, response)| SolverSettlement {
-                        solver_address: response.submission_address,
-                        score: Some(Score::Solver(response.score)),
-                        ranking: Some(solutions.len() - index),
-                        orders: response
-                            .orders
-                            .iter()
-                            .map(|o| Order {
-                                id: *o,
-                                // TODO: revisit once colocation is enabled (remove not populated
-                                // fields) Not all fields can be
-                                // populated in the colocated world
-                                ..Default::default()
-                            })
-                            .collect(),
-                        call_data: response.calldata.internalized.clone(),
-                        uninternalized_call_data: Some(response.calldata.uninternalized.clone()),
-                        // TODO: revisit once colocation is enabled (remove not populated fields)
-                        // Not all fields can be populated in the colocated world
-                        ..Default::default()
+                    .map(|(index, response)| {
+                        let (orders, call_data, uninternalized_call_data) =
+                            if solutions.len() - index == 1 {
+                                // populate only for winning solution
+                                (
+                                    revealed
+                                        .orders
+                                        .iter()
+                                        .map(|o| Order {
+                                            id: *o,
+                                            // TODO: revisit once colocation is enabled (remove not
+                                            // populated
+                                            // fields) Not all fields can be
+                                            // populated in the colocated world
+                                            ..Default::default()
+                                        })
+                                        .collect(),
+                                    revealed.calldata.internalized.clone(),
+                                    Some(revealed.calldata.uninternalized.clone()),
+                                )
+                            } else {
+                                (vec![], vec![], None)
+                            };
+                        SolverSettlement {
+                            solver_address: response.submission_address,
+                            score: Some(Score::Solver(response.score)),
+                            ranking: Some(solutions.len() - index),
+                            orders,
+                            call_data,
+                            uninternalized_call_data,
+                            // TODO: revisit once colocation is enabled (remove not populated
+                            // fields) Not all fields can be populated
+                            // in the colocated world
+                            ..Default::default()
+                        }
                     })
                     .collect(),
                 // TODO: revisit once colocation is enabled (remove not populated fields)
@@ -234,7 +262,10 @@ impl RunLoop {
             }
 
             tracing::info!(url = %self.drivers[*index].url, "settling with solver");
-            match self.settle(id, &self.drivers[*index], solution).await {
+            match self
+                .settle(id, &self.drivers[*index], solution, &revealed)
+                .await
+            {
                 Ok(()) => (),
                 Err(err) => {
                     tracing::error!(?err, "solver {index} failed to settle");
@@ -386,15 +417,26 @@ impl RunLoop {
             .collect()
     }
 
+    /// Ask the winning solver to reveal their solution.
+    async fn reveal(&self, id: AuctionId, driver: &Driver) -> Result<reveal::Response> {
+        let response = driver.reveal().await.context("reveal")?;
+        ensure!(
+            response.calldata.internalized.ends_with(&id.to_be_bytes()),
+            "reveal auction id missmatch"
+        );
+        Ok(response)
+    }
+
     /// Execute the solver's solution. Returns Ok when the corresponding
     /// transaction has been mined.
     async fn settle(
         &self,
         id: AuctionId,
         driver: &Driver,
-        solution: &solve::Response,
+        solve: &solve::Response,
+        reveal: &reveal::Response,
     ) -> Result<()> {
-        let events = solution
+        let events = reveal
             .orders
             .iter()
             .map(|uid| (*uid, OrderEventLabel::Executing))
@@ -404,11 +446,11 @@ impl RunLoop {
         driver.settle().await.context("settle")?;
         // TODO: React to deadline expiring.
         let transaction = self
-            .wait_for_settlement_transaction(id, solution.submission_address)
+            .wait_for_settlement_transaction(id, solve.submission_address)
             .await
             .context("wait for settlement transaction")?;
         if let Some(tx) = transaction {
-            let events = solution
+            let events = reveal
                 .orders
                 .iter()
                 .map(|uid| (*uid, OrderEventLabel::Traded))

--- a/crates/autopilot/src/run_loop.rs
+++ b/crates/autopilot/src/run_loop.rs
@@ -108,7 +108,7 @@ impl RunLoop {
             let revealed = match self.reveal(id, &self.drivers[*index]).await {
                 Ok(result) => result,
                 Err(err) => {
-                    tracing::error!(?err, "solver {index} failed to settle");
+                    tracing::error!(?err, "solver {index} failed to reveal");
                     return;
                 }
             };
@@ -119,7 +119,6 @@ impl RunLoop {
                 .map(|o| (*o, OrderEventLabel::Considered))
                 .collect::<Vec<_>>();
             self.database.store_order_events(&events).await;
-
             let auction_id = id;
             let winner = solution.submission_address;
             let winning_score = solution.score;

--- a/crates/driver/src/domain/competition/mod.rs
+++ b/crates/driver/src/domain/competition/mod.rs
@@ -180,8 +180,9 @@ impl Competition {
             .settlement
             .lock()
             .unwrap()
-            .take()
-            .ok_or(Error::SolutionNotFound)?;
+            .as_ref()
+            .cloned()
+            .ok_or(Error::SolutionNotAvailable)?;
         Ok(Revealed {
             orders: settlement.orders(),
             internalized_calldata: settlement

--- a/crates/driver/src/infra/api/mod.rs
+++ b/crates/driver/src/infra/api/mod.rs
@@ -54,6 +54,7 @@ impl Api {
             let router = routes::info(router);
             let router = routes::quote(router);
             let router = routes::solve(router);
+            let router = routes::reveal(router);
             let router = routes::settle(router);
             let router = router.with_state(State(Arc::new(Inner {
                 eth: self.eth.clone(),

--- a/crates/driver/src/infra/api/routes/mod.rs
+++ b/crates/driver/src/infra/api/routes/mod.rs
@@ -1,6 +1,7 @@
 mod info;
 mod metrics;
 mod quote;
+mod reveal;
 mod settle;
 mod solve;
 
@@ -8,6 +9,7 @@ pub(super) use {
     info::info,
     metrics::metrics,
     quote::{quote, OrderError},
+    reveal::reveal,
     settle::settle,
     solve::{solve, AuctionError},
 };

--- a/crates/driver/src/infra/api/routes/reveal.rs
+++ b/crates/driver/src/infra/api/routes/reveal.rs
@@ -1,0 +1,57 @@
+use {
+    crate::{
+        domain::{competition, competition::order},
+        infra::{
+            api::{Error, State},
+            observe,
+        },
+        util::serialize,
+    },
+    serde::Serialize,
+    serde_with::serde_as,
+};
+
+pub(in crate::infra::api) fn reveal(router: axum::Router<State>) -> axum::Router<State> {
+    router.route("/reveal", axum::routing::post(route))
+}
+
+async fn route(
+    state: axum::extract::State<State>,
+) -> Result<axum::Json<Solution>, (hyper::StatusCode, axum::Json<Error>)> {
+    let competition = state.competition();
+    observe::revealing(state.solver().name(), competition.auction_id());
+    let result = competition.reveal().await;
+    observe::revealed(state.solver().name(), competition.auction_id(), &result);
+    let calldata = result?;
+    Ok(axum::Json(Solution::new(calldata)))
+}
+
+impl Solution {
+    pub fn new(reveal: competition::Revealed) -> Self {
+        Self {
+            orders: reveal.orders.into_iter().map(Into::into).collect(),
+            calldata: Calldata {
+                internalized: reveal.internalized_calldata.into(),
+                uninternalized: reveal.uninternalized_calldata.into(),
+            },
+        }
+    }
+}
+
+#[serde_as]
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct Calldata {
+    #[serde_as(as = "serialize::Hex")]
+    internalized: Vec<u8>,
+    #[serde_as(as = "serialize::Hex")]
+    uninternalized: Vec<u8>,
+}
+
+#[serde_as]
+#[derive(Debug, Serialize)]
+pub struct Solution {
+    #[serde_as(as = "Vec<serialize::Hex>")]
+    orders: Vec<[u8; order::UID_LEN]>,
+    calldata: Calldata,
+}

--- a/crates/driver/src/infra/api/routes/reveal.rs
+++ b/crates/driver/src/infra/api/routes/reveal.rs
@@ -22,8 +22,8 @@ async fn route(
     observe::revealing(state.solver().name(), competition.auction_id());
     let result = competition.reveal().await;
     observe::revealed(state.solver().name(), competition.auction_id(), &result);
-    let calldata = result?;
-    Ok(axum::Json(Solution::new(calldata)))
+    let result = result?;
+    Ok(axum::Json(Solution::new(result)))
 }
 
 impl Solution {

--- a/crates/driver/src/infra/api/routes/solve/dto/solution.rs
+++ b/crates/driver/src/infra/api/routes/solve/dto/solution.rs
@@ -1,7 +1,7 @@
 use {
     crate::{
         domain::{
-            competition::{self, order},
+            competition::{self},
             eth,
         },
         infra::Solver,
@@ -16,23 +16,8 @@ impl Solution {
         Self {
             score: reveal.score.into(),
             submission_address: solver.address().into(),
-            orders: reveal.orders.into_iter().map(Into::into).collect(),
-            calldata: Calldata {
-                internalized: reveal.internalized_calldata.into(),
-                uninternalized: reveal.uninternalized_calldata.into(),
-            },
         }
     }
-}
-
-#[serde_as]
-#[derive(Debug, Serialize)]
-#[serde(rename_all = "camelCase")]
-struct Calldata {
-    #[serde_as(as = "serialize::Hex")]
-    internalized: Vec<u8>,
-    #[serde_as(as = "serialize::Hex")]
-    uninternalized: Vec<u8>,
 }
 
 #[serde_as]
@@ -41,7 +26,4 @@ pub struct Solution {
     #[serde_as(as = "serialize::U256")]
     score: eth::U256,
     submission_address: eth::H160,
-    #[serde_as(as = "Vec<serialize::Hex>")]
-    orders: Vec<[u8; order::UID_LEN]>,
-    calldata: Calldata,
 }

--- a/crates/driver/src/infra/observe/metrics.rs
+++ b/crates/driver/src/infra/observe/metrics.rs
@@ -7,6 +7,9 @@ pub struct Metrics {
     /// The results of the solving process.
     #[metric(labels("solver", "result"))]
     pub solutions: prometheus::IntCounterVec,
+    /// The results of the reveal process.
+    #[metric(labels("solver", "result"))]
+    pub reveals: prometheus::IntCounterVec,
     /// The results of the settlement process.
     #[metric(labels("solver", "result"))]
     pub settlements: prometheus::IntCounterVec,

--- a/crates/driver/src/infra/observe/mod.rs
+++ b/crates/driver/src/infra/observe/mod.rs
@@ -139,6 +139,33 @@ pub fn score(solver: &solver::Name, settlement: &Settlement, score: &solution::S
     );
 }
 
+pub fn revealing(solver: &solver::Name, auction_id: Option<auction::Id>) {
+    tracing::trace!(%solver, ?auction_id, "revealing");
+}
+
+pub fn revealed(
+    solver: &solver::Name,
+    auction_id: Option<auction::Id>,
+    result: &Result<competition::Revealed, competition::Error>,
+) {
+    match result {
+        Ok(calldata) => {
+            tracing::info!(%solver, ?calldata, ?auction_id, "revealed");
+            metrics::get()
+                .reveals
+                .with_label_values(&[solver.as_str(), "Success"])
+                .inc();
+        }
+        Err(err) => {
+            tracing::warn!(%solver, ?auction_id, ?err, "failed to reveal");
+            metrics::get()
+                .reveals
+                .with_label_values(&[solver.as_str(), competition_error(err)])
+                .inc();
+        }
+    }
+}
+
 /// Observe that the settlement process is about to start.
 pub fn settling(solver: &solver::Name, auction_id: Option<auction::Id>) {
     tracing::trace!(%solver, ?auction_id, "settling");


### PR DESCRIPTION
Fixes https://github.com/cowprotocol/services/issues/1744

Calldata is no longer received from `/solve` but from `/reveal`. Also, took the chance and moved the `orders` to `/reveal` also. 

The consequence of this is that we save the `calldata` and `orders` for winning solution only. 


