### PR TITLE
Docker build caching

### DIFF
--- a/.github/workflows/build-with-cache.yaml
+++ b/.github/workflows/build-with-cache.yaml
@@ -1,0 +1,49 @@
+name: build with cache
+on:
+  push:
+    branches: [main]
+    tags: [v*]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          # Without this the fetch depth defaults to 1, which only includes the most recent commit. We want to know the full history so that `git describe` can give more information when it is invoked in the orderbook's crate build script.
+          fetch-depth: '0'
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2.0.0
+
+      - uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Services image metadata
+        id: meta_services
+        uses: docker/metadata-action@v4
+        with:
+          images: ghcr.io/${{ github.repository }}
+          labels: |
+            org.opencontainers.image.licenses=GPL-3.0-or-later
+          # Add suffix to not override the main build
+          flavor: |
+            suffix=-cache,onlatest=true
+
+      - name: Services image build
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          file: docker/Dockerfile-cache.binary
+          push: true
+          tags: ${{ steps.meta_services.outputs.tags }}
+          labels: ${{ steps.meta_services.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/docker/Dockerfile-cache.binary
+++ b/docker/Dockerfile-cache.binary
@@ -11,7 +11,7 @@ COPY --from=planner /app/recipe.json recipe.json
 RUN cargo chef cook --release --recipe-path recipe.json
 # Build application
 COPY . .
-RUN cargo build --release
+RUN CARGO_PROFILE_RELEASE_DEBUG=1 cargo build --release
 
 FROM debian:bullseye-slim AS runtime
 WORKDIR /app

--- a/docker/Dockerfile-cache.binary
+++ b/docker/Dockerfile-cache.binary
@@ -1,0 +1,30 @@
+FROM lukemathwalker/cargo-chef:latest-rust-1 AS chef
+WORKDIR /app
+
+FROM chef AS planner
+COPY . .
+RUN cargo chef prepare --recipe-path recipe.json
+
+FROM chef AS builder 
+COPY --from=planner /app/recipe.json recipe.json
+# Build dependencies - this is the caching Docker layer!
+RUN cargo chef cook --release --recipe-path recipe.json
+# Build application
+COPY . .
+RUN cargo build --release
+
+FROM debian:bullseye-slim AS runtime
+WORKDIR /app
+
+RUN apt-get update && apt-get install -y ca-certificates tini && apt-get clean
+
+COPY --from=builder /app/target/release/alerter /usr/local/bin/alerter
+COPY --from=builder /app/target/release/autopilot /usr/local/bin/autopilot
+COPY --from=builder /app/target/release/driver /usr/local/bin/driver
+COPY --from=builder /app/target/release/orderbook /usr/local/bin/orderbook
+COPY --from=builder /app/target/release/refunder /usr/local/bin/refunder
+COPY --from=builder /app/target/release/solver /usr/local/bin/solver
+COPY --from=builder /app/target/release/solvers /usr/local/bin/solvers
+
+CMD echo "Specify binary..."
+ENTRYPOINT ["/usr/bin/tini", "--"]


### PR DESCRIPTION
Adds a new GitHub Action and a Dockerfile to use cargo-chef for caching builds. This adds the suffix `-cache` to all the tags in the images created using this action so that they can be tested well before we move to cargo-chef.

### Test Plan

The plan is to merge this PR, check the build times, test the new images for a while, see if everything works correctly, and later replace the original deploy action.

I've also tested this in my [repository actions](https://github.com/ahhda/services/actions)

We can see a build time improvement of ~3x (from 30 mins in general to 11 min). Also, the image size goes from 1.9GB to ~300MB.

![Screenshot 2023-08-09 at 12 53 46 PM](https://github.com/cowprotocol/services/assets/7795956/7a6d2566-a10d-49e3-a5b4-c1a44a5a1806)
