### PR TITLE
Make TokenOwnerFinding urls configurable

### DIFF
--- a/crates/shared/src/bad_token/token_owner_finder.rs
+++ b/crates/shared/src/bad_token/token_owner_finder.rs
@@ -80,11 +80,11 @@ pub struct Arguments {
     #[clap(long, env, value_parser = duration_from_seconds, default_value = "45")]
     pub blockscout_http_timeout: Duration,
 
-    // Override the default blockscout API url for this network
+    /// Override the default blockscout API url for this network
     #[clap(long, env)]
     pub blockscout_api_url: Option<Url>,
 
-    // Override the default ethplorer API url
+    /// Override the default ethplorer API url
     #[clap(long, env)]
     pub ethplorer_api_url: Option<Url>,
 

--- a/crates/shared/src/bad_token/token_owner_finder.rs
+++ b/crates/shared/src/bad_token/token_owner_finder.rs
@@ -80,6 +80,14 @@ pub struct Arguments {
     #[clap(long, env, value_parser = duration_from_seconds, default_value = "45")]
     pub blockscout_http_timeout: Duration,
 
+    // Override the default blockscout API url for this network
+    #[clap(long, env)]
+    pub blockscout_api_url: Option<Url>,
+
+    // Override the default ethplorer API url
+    #[clap(long, env)]
+    pub ethplorer_api_url: Option<Url>,
+
     /// The Ethplorer token holder API key.
     #[clap(long, env)]
     pub ethplorer_api_key: Option<String>,
@@ -173,6 +181,8 @@ impl Display for Arguments {
             "blockscout_http_timeout: {:?}",
             self.blockscout_http_timeout,
         )?;
+        display_option(f, "blockscout_api_url: {:?}", &self.blockscout_api_url)?;
+        display_secret_option(f, "ethplorer_api_url", &self.ethplorer_api_url)?;
         display_secret_option(f, "ethplorer_api_key", &self.ethplorer_api_key)?;
         display_option(
             f,
@@ -245,6 +255,9 @@ pub async fn init(
             http_factory.configure(|builder| builder.timeout(args.blockscout_http_timeout)),
             chain_id,
         )?;
+        if let Some(base_url) = args.blockscout_api_url.clone() {
+            blockscout.with_base_url(base_url);
+        }
         if let Some(strategy) = args.token_owner_finder_rate_limiter.clone() {
             blockscout.with_rate_limiter(strategy);
         }
@@ -257,6 +270,9 @@ pub async fn init(
             args.ethplorer_api_key.clone(),
             chain_id,
         )?;
+        if let Some(base_url) = args.ethplorer_api_url.clone() {
+            ethplorer.with_base_url(base_url);
+        }
         if let Some(strategy) = args.token_owner_finder_rate_limiter.clone() {
             ethplorer.with_rate_limiter(strategy);
         }

--- a/crates/shared/src/bad_token/token_owner_finder.rs
+++ b/crates/shared/src/bad_token/token_owner_finder.rs
@@ -181,8 +181,8 @@ impl Display for Arguments {
             "blockscout_http_timeout: {:?}",
             self.blockscout_http_timeout,
         )?;
-        display_option(f, "blockscout_api_url: {:?}", &self.blockscout_api_url)?;
-        display_secret_option(f, "ethplorer_api_url", &self.ethplorer_api_url)?;
+        display_option(f, "blockscout_api_url", &self.blockscout_api_url)?;
+        display_option(f, "ethplorer_api_url", &self.ethplorer_api_url)?;
         display_secret_option(f, "ethplorer_api_key", &self.ethplorer_api_key)?;
         display_option(
             f,

--- a/crates/shared/src/bad_token/token_owner_finder/blockscout.rs
+++ b/crates/shared/src/bad_token/token_owner_finder/blockscout.rs
@@ -31,6 +31,11 @@ impl BlockscoutTokenOwnerFinder {
         })
     }
 
+    pub fn with_base_url(&mut self, base_url: Url) -> &mut Self {
+        self.base = base_url;
+        self
+    }
+
     pub fn with_rate_limiter(&mut self, strategy: RateLimitingStrategy) -> &mut Self {
         self.rate_limiter = Some(RateLimiter::from_strategy(
             strategy,

--- a/crates/shared/src/bad_token/token_owner_finder/ethplorer.rs
+++ b/crates/shared/src/bad_token/token_owner_finder/ethplorer.rs
@@ -9,7 +9,7 @@ use {
     serde::Deserialize,
 };
 
-const BASE: &str = "https://api.ethplorer.io/getTopTokenHolders/";
+const BASE: &str = "https://api.ethplorer.io";
 const FREE_API_KEY: &str = "freekey";
 
 pub struct EthplorerTokenOwnerFinder {
@@ -40,13 +40,18 @@ impl EthplorerTokenOwnerFinder {
         })
     }
 
+    pub fn with_base_url(&mut self, base_url: Url) -> &mut Self {
+        self.base = base_url;
+        self
+    }
+
     pub fn with_rate_limiter(&mut self, strategy: RateLimitingStrategy) -> &mut Self {
         self.rate_limiter = Some(RateLimiter::from_strategy(strategy, "ethplorer".to_owned()));
         self
     }
 
     async fn query_owners(&self, token: H160) -> Result<Vec<H160>> {
-        let mut url = crate::url::join(&self.base, &format!("{token:?}"));
+        let mut url = crate::url::join(&self.base, &format!("getTopTokenHolders/{token:?}"));
         // We technically only need one candidate, returning the top 2 in case there
         // is a race condition and tokens have just been transferred out.
         url.query_pairs_mut().append_pair("limit", "2");


### PR DESCRIPTION
This will allow us to reverse proxy and smoothen them to reduce rate limits.

### Test Plan

run with `--token-owner-finders ethplorer,blockscout --ethplorer-api-url https://api.ethplorer.io --blockscout-api-url https://eth.blockscout.com`

### Release notes

Requires config value to be set to our reverse proxy in both staging and prod
