### PR TITLE
Send zero fee for FOK limit orders

### DIFF
--- a/crates/solver/src/liquidity/order_converter.rs
+++ b/crates/solver/src/liquidity/order_converter.rs
@@ -66,7 +66,10 @@ impl OrderConverter {
 
         // The reported fee amount that is used for objective computation is the
         // order's full full amount scaled by a constant factor.
-        let solver_fee = remaining.remaining(order.metadata.solver_fee)?;
+        let solver_fee = match order.solver_determines_fee() {
+            true => 0.into(),
+            false => remaining.remaining(order.metadata.solver_fee)?,
+        };
         let sell_amount = remaining.remaining(sell_amount)?;
         let buy_amount = remaining.remaining(order.data.buy_amount)?;
         ensure!(


### PR DESCRIPTION
Fixes https://github.com/cowprotocol/services/issues/1757

For FOK limit orders solver_fee sent to solvers should be zero since it is expected to be provided by solvers.
