### PR TITLE
Init liquidity in background

### DIFF
--- a/crates/driver/src/boundary/liquidity/balancer/v2/mod.rs
+++ b/crates/driver/src/boundary/liquidity/balancer/v2/mod.rs
@@ -88,7 +88,11 @@ pub fn collector(
         async move { init_liquidity(&eth, &block_stream, block_retriever.clone(), &config).await }
     };
     const TEN_MINUTES: std::time::Duration = std::time::Duration::from_secs(10 * 60);
-    Box::new(BackgroundInitLiquiditySource::new("balancer-v2", init, TEN_MINUTES)) as Box<_>
+    Box::new(BackgroundInitLiquiditySource::new(
+        "balancer-v2",
+        init,
+        TEN_MINUTES,
+    )) as Box<_>
 }
 
 async fn init_liquidity(

--- a/crates/driver/src/boundary/liquidity/balancer/v2/mod.rs
+++ b/crates/driver/src/boundary/liquidity/balancer/v2/mod.rs
@@ -7,6 +7,7 @@ use {
         },
         infra::{self, blockchain::Ethereum},
     },
+    anyhow::{Context, Result},
     contracts::{
         BalancerV2LiquidityBootstrappingPoolFactory,
         BalancerV2StablePoolFactory,
@@ -27,7 +28,7 @@ use {
     solver::{
         interactions::allowances::Allowances,
         liquidity::{balancer_v2, balancer_v2::BalancerV2Liquidity},
-        liquidity_collector::LiquidityCollecting,
+        liquidity_collector::{BackgroundInitLiquiditySource, LiquidityCollecting},
     },
     std::sync::Arc,
 };
@@ -71,12 +72,31 @@ fn to_interaction(
     }
 }
 
-pub async fn collector(
+pub fn collector(
+    eth: &Ethereum,
+    block_stream: CurrentBlockStream,
+    block_retriever: Arc<dyn BlockRetrieving>,
+    config: &infra::liquidity::config::BalancerV2,
+) -> Box<dyn LiquidityCollecting> {
+    let eth = Arc::new(eth.clone());
+    let config = Arc::new(config.clone());
+    let init = move || {
+        let eth = eth.clone();
+        let block_stream = block_stream.clone();
+        let block_retriever = block_retriever.clone();
+        let config = config.clone();
+        async move { init_liquidity(&eth, &block_stream, block_retriever.clone(), &config).await }
+    };
+    const TEN_MINUTES: std::time::Duration = std::time::Duration::from_secs(10 * 60);
+    Box::new(BackgroundInitLiquiditySource::new(init, TEN_MINUTES)) as Box<_>
+}
+
+async fn init_liquidity(
     eth: &Ethereum,
     block_stream: &CurrentBlockStream,
     block_retriever: Arc<dyn BlockRetrieving>,
     config: &infra::liquidity::config::BalancerV2,
-) -> Box<dyn LiquidityCollecting> {
+) -> Result<impl LiquidityCollecting> {
     let web3 = boundary::web3(eth);
     let contracts = BalancerContracts {
         vault: BalancerV2Vault::at(&web3, config.vault.into()),
@@ -139,10 +159,10 @@ pub async fn collector(
             config.pool_deny_list.clone(),
         )
         .await
-        .expect("failed to create Balancer pool fetcher"),
+        .context("failed to create balancer pool fetcher")?,
     );
 
-    Box::new(BalancerV2Liquidity::new(
+    Ok(BalancerV2Liquidity::new(
         web3,
         balancer_pool_fetcher,
         eth.contracts().settlement().clone(),

--- a/crates/driver/src/boundary/liquidity/balancer/v2/mod.rs
+++ b/crates/driver/src/boundary/liquidity/balancer/v2/mod.rs
@@ -88,7 +88,7 @@ pub fn collector(
         async move { init_liquidity(&eth, &block_stream, block_retriever.clone(), &config).await }
     };
     const TEN_MINUTES: std::time::Duration = std::time::Duration::from_secs(10 * 60);
-    Box::new(BackgroundInitLiquiditySource::new(init, TEN_MINUTES)) as Box<_>
+    Box::new(BackgroundInitLiquiditySource::new("balancer-v2", init, TEN_MINUTES)) as Box<_>
 }
 
 async fn init_liquidity(

--- a/crates/driver/src/boundary/liquidity/mod.rs
+++ b/crates/driver/src/boundary/liquidity/mod.rs
@@ -88,22 +88,19 @@ impl Fetcher {
         .into_iter()
         .try_collect()?;
 
-        let bal_v2: Vec<_> = future::join_all(config.balancer_v2.iter().map(|config| {
-            balancer::v2::collector(eth, &block_stream, block_retriever.clone(), config)
-        }))
-        .await
-        .into_iter()
-        .collect();
+        let bal_v2: Vec<_> = config
+            .balancer_v2
+            .iter()
+            .map(|config| {
+                balancer::v2::collector(eth, block_stream.clone(), block_retriever.clone(), config)
+            })
+            .collect();
 
-        let uni_v3: Vec<_> = future::join_all(
-            config
-                .uniswap_v3
-                .iter()
-                .map(|config| uniswap::v3::collector(eth, block_retriever.clone(), config)),
-        )
-        .await
-        .into_iter()
-        .collect();
+        let uni_v3: Vec<_> = config
+            .uniswap_v3
+            .iter()
+            .map(|config| uniswap::v3::collector(eth, block_retriever.clone(), config))
+            .collect();
 
         let base_tokens = BaseTokens::new(
             eth.contracts().weth().address(),

--- a/crates/driver/src/boundary/liquidity/uniswap/v3.rs
+++ b/crates/driver/src/boundary/liquidity/uniswap/v3.rs
@@ -118,7 +118,11 @@ pub fn collector(
         async move { init_liquidity(&eth, block_retriever.clone(), &config).await }
     };
     const TEN_MINUTES: std::time::Duration = std::time::Duration::from_secs(10 * 60);
-    Box::new(BackgroundInitLiquiditySource::new("uniswap-v3", init, TEN_MINUTES)) as Box<_>
+    Box::new(BackgroundInitLiquiditySource::new(
+        "uniswap-v3",
+        init,
+        TEN_MINUTES,
+    )) as Box<_>
 }
 
 async fn init_liquidity(

--- a/crates/driver/src/boundary/liquidity/uniswap/v3.rs
+++ b/crates/driver/src/boundary/liquidity/uniswap/v3.rs
@@ -10,6 +10,7 @@ use {
         },
         infra::{self, blockchain::Ethereum},
     },
+    anyhow::Context,
     contracts::{GPv2Settlement, UniswapV3SwapRouter},
     itertools::Itertools,
     shared::{
@@ -24,7 +25,7 @@ use {
             uniswap_v3::{self, UniswapV3Liquidity, UniswapV3SettlementHandler},
             ConcentratedLiquidity,
         },
-        liquidity_collector::LiquidityCollecting,
+        liquidity_collector::{BackgroundInitLiquiditySource, LiquidityCollecting},
     },
     std::{
         collections::BTreeMap,
@@ -103,11 +104,28 @@ pub fn to_interaction(
         .unwrap()
 }
 
-pub async fn collector(
+pub fn collector(
     eth: &Ethereum,
     block_retriever: Arc<dyn BlockRetrieving>,
     config: &infra::liquidity::config::UniswapV3,
 ) -> Box<dyn LiquidityCollecting> {
+    let eth = Arc::new(eth.clone());
+    let config = Arc::new(Clone::clone(config));
+    let init = move || {
+        let eth = eth.clone();
+        let block_retriever = block_retriever.clone();
+        let config = config.clone();
+        async move { init_liquidity(&eth, block_retriever.clone(), &config).await }
+    };
+    const TEN_MINUTES: std::time::Duration = std::time::Duration::from_secs(10 * 60);
+    Box::new(BackgroundInitLiquiditySource::new(init, TEN_MINUTES)) as Box<_>
+}
+
+async fn init_liquidity(
+    eth: &Ethereum,
+    block_retriever: Arc<dyn BlockRetrieving>,
+    config: &infra::liquidity::config::UniswapV3,
+) -> anyhow::Result<impl LiquidityCollecting> {
     let web3 = boundary::web3(eth);
     let router = UniswapV3SwapRouter::at(&web3, config.router.0);
 
@@ -120,10 +138,10 @@ pub async fn collector(
             config.max_pools_to_initialize,
         )
         .await
-        .unwrap(),
+        .context("failed to initialise UniswapV3 liquidity")?,
     );
 
-    Box::new(UniswapV3Liquidity::new(
+    Ok(UniswapV3Liquidity::new(
         router,
         eth.contracts().settlement().clone(),
         web3,

--- a/crates/driver/src/boundary/liquidity/uniswap/v3.rs
+++ b/crates/driver/src/boundary/liquidity/uniswap/v3.rs
@@ -118,7 +118,7 @@ pub fn collector(
         async move { init_liquidity(&eth, block_retriever.clone(), &config).await }
     };
     const TEN_MINUTES: std::time::Duration = std::time::Duration::from_secs(10 * 60);
-    Box::new(BackgroundInitLiquiditySource::new(init, TEN_MINUTES)) as Box<_>
+    Box::new(BackgroundInitLiquiditySource::new("uniswap-v3", init, TEN_MINUTES)) as Box<_>
 }
 
 async fn init_liquidity(

--- a/crates/driver/src/infra/liquidity/config.rs
+++ b/crates/driver/src/infra/liquidity/config.rs
@@ -124,7 +124,7 @@ impl UniswapV3 {
     pub fn uniswap_v3(network: &eth::NetworkId) -> Option<Self> {
         Some(Self {
             router: deployment_address(contracts::UniswapV3SwapRouter::raw_contract(), network)?,
-            max_pools_to_initialize: 50,
+            max_pools_to_initialize: 100,
         })
     }
 }

--- a/crates/solver/src/liquidity_collector.rs
+++ b/crates/solver/src/liquidity_collector.rs
@@ -3,7 +3,8 @@ use {
     anyhow::Result,
     model::TokenPair,
     shared::{baseline_solver::BaseTokens, recent_block_cache::Block},
-    std::{collections::HashSet, sync::Arc},
+    std::{collections::HashSet, future::Future, sync::Arc, time::Duration},
+    tokio::sync::Mutex,
 };
 
 #[mockall::automock]
@@ -41,5 +42,71 @@ impl LiquidityCollecting for LiquidityCollector {
             .collect();
         tracing::debug!("got {} AMMs", amms.len());
         Ok(amms)
+    }
+}
+
+/// A liquidity source which might not be initialised on creation. Instead
+/// initialisation gets retried in a background task over and over until it
+/// succeeds. Until the liquidity source has been initialised no liquidity will
+/// be provided.
+pub struct BackgroundInitLiquiditySource<L> {
+    liquidity_source: Arc<Mutex<Option<L>>>,
+}
+
+impl<L> BackgroundInitLiquiditySource<L> {
+    /// Creates a new liquidity source which might only be initialized at a
+    /// later point in time.
+    pub fn new<I, F>(init: I, retry_init_timeout: Duration) -> Self
+    where
+        I: Fn() -> F + Send + Sync + 'static,
+        F: Future<Output = Result<L>> + Send,
+        L: LiquidityCollecting + 'static,
+    {
+        let liquidity_source: Arc<Mutex<Option<L>>> = Default::default();
+        let inner = liquidity_source.clone();
+        tokio::task::spawn(async move {
+            loop {
+                match init().await {
+                    Err(err) => {
+                        tracing::warn!(
+                            "failed to initialise liquidity source; next init attempt in \
+                             {retry_init_timeout:?}: {err:?}"
+                        );
+                        tokio::time::sleep(retry_init_timeout).await;
+                    }
+                    Ok(source) => {
+                        let _ = inner.lock().await.insert(source);
+                        tracing::debug!("successfully initialised liquidity source");
+                        break;
+                    }
+                }
+            }
+        });
+
+        Self { liquidity_source }
+    }
+}
+
+#[async_trait::async_trait]
+impl<L> LiquidityCollecting for BackgroundInitLiquiditySource<L>
+where
+    L: LiquidityCollecting,
+{
+    async fn get_liquidity(
+        &self,
+        pairs: HashSet<TokenPair>,
+        at_block: Block,
+    ) -> Result<Vec<Liquidity>> {
+        // Use `try_lock` to not block caller when the lock is currently being held for
+        // a potentially very slow init logic.
+        let liquidity_source = match self.liquidity_source.try_lock() {
+            Ok(lock) => lock,
+            Err(_) => return Ok(vec![]),
+        };
+
+        match &*liquidity_source {
+            Some(initialised_source) => initialised_source.get_liquidity(pairs, at_block).await,
+            None => Ok(vec![]),
+        }
     }
 }


### PR DESCRIPTION
Fixes #1525

When we restart the services we need to initialize `BalancerV2` and `UniswapV3` liquidity. That uses the graph and this is very unreliable. So far the process has been:
1. restart service and 🙏 that the graph works
2. see that it doesn't and disable `UniswapV3` and `BalancerV2`
3. periodically check if the graph works again to re-enable the liquidity

With this change we move liquidity initialization into a background task that retries until it succeeds.

### Test Plan
Unit test to verify logic
Manual test to verify logs
