### PR TITLE
chore: update appData fields to QuoteRequest openapi definition

### DIFF
--- a/crates/orderbook/openapi.yml
+++ b/crates/orderbook/openapi.yml
@@ -469,7 +469,7 @@ components:
       description: 20 byte Ethereum address encoded as a hex with `0x` prefix.
       type: string
       example: "0x6810e776880c02933d47db1b9fc05908e5386b96"
-    AppDataDocument:
+    AppData:
       description: |
         The string encoding of a JSON object representing some `appData`. The
         format of the JSON expected in the `appData` field is defined
@@ -487,7 +487,7 @@ components:
       type: object
       properties:
         fullAppData:
-          $ref: "#/components/schemas/AppDataDocument"
+          $ref: "#/components/schemas/AppData"
       required:
         - appData
     BigUint:
@@ -713,7 +713,7 @@ components:
           anyOf:
             - title: Full App Data
               allOf:
-                - $ref: "#/components/schemas/AppDataDocument"
+                - $ref: "#/components/schemas/AppData"
               description: |
                 **Short**:
 
@@ -1251,7 +1251,7 @@ components:
                 hex encoded string for backwards compatibility.
                 When the first format is used, it's possible to provide the derived appDataHash field.
               oneOf:
-                - $ref: "#/components/schemas/AppDataDocument"
+                - $ref: "#/components/schemas/AppData"
                 - $ref: "#/components/schemas/AppDataHash"
             appDataHash:
               description: |

--- a/crates/orderbook/openapi.yml
+++ b/crates/orderbook/openapi.yml
@@ -401,7 +401,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/AppDataDocument"
+                $ref: "#/components/schemas/AppDataObject"
         404:
           description: No full `appData` stored for this hash.
     put:
@@ -421,7 +421,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/AppDataDocument"
+              $ref: "#/components/schemas/AppDataObject"
       responses:
         200:
           description: The full `appData` already exists.
@@ -469,7 +469,7 @@ components:
       description: 20 byte Ethereum address encoded as a hex with `0x` prefix.
       type: string
       example: "0x6810e776880c02933d47db1b9fc05908e5386b96"
-    AppData:
+    AppDataDocument:
       description: |
         The string encoding of a JSON object representing some `appData`. The
         format of the JSON expected in the `appData` field is defined
@@ -477,15 +477,17 @@ components:
       type: string
       example: "{\"version\":\"0.9.0\",\"metadata\":{}}"
     AppDataHash:
-      description: 32 bytes encoded as hex with `0x` prefix.
+      description: |
+        32 bytes encoded as hex with `0x` prefix.
+        It's expected to be the hash of the stringified JSON object representing the `appData`.
       type: string
       example: "0x0000000000000000000000000000000000000000000000000000000000000000"
-    AppDataDocument:
+    AppDataObject:
       description: An `appData` document that is registered with the API.
       type: object
       properties:
         fullAppData:
-          $ref: "#/components/schemas/AppData"
+          $ref: "#/components/schemas/AppDataDocument"
       required:
         - appData
     BigUint:
@@ -706,11 +708,12 @@ components:
           nullable: true
         appData:
           description: |
-            This field comes in two forms for backward compatibility. The first form (`appDataHash`)
-            will eventually stop being accepted.
+            This field comes in two forms for backward compatibility. The hash form will eventually 
+            stop being accepted.
           anyOf:
-            - $ref: "#/components/schemas/AppDataHash"
             - title: Full App Data
+              allOf:
+                - $ref: "#/components/schemas/AppDataDocument"
               description: |
                 **Short**:
 
@@ -746,6 +749,7 @@ components:
 
                 The total byte size of this field's UTF-8 encoded bytes is limited to 1000.
               type: string
+            - $ref: "#/components/schemas/AppDataHash"
         appDataHash:
           description: |
            May be set for debugging purposes. If set, this field is compared to what the backend
@@ -1247,11 +1251,15 @@ components:
                 hex encoded string for backwards compatibility.
                 When the first format is used, it's possible to provide the derived appDataHash field.
               oneOf:
-                - $ref: "#/components/schemas/AppData"
+                - $ref: "#/components/schemas/AppDataDocument"
                 - $ref: "#/components/schemas/AppDataHash"
             appDataHash:
-              $ref: "#/components/schemas/AppDataHash"
-              nullable: true
+              description: |
+                The hash of the stringified JSON appData doc.
+                If present, `appData` field must be set with the aforementioned data where this hash is derived from.
+                In case they differ, the call will fail.
+              anyOf:
+                - $ref: "#/components/schemas/AppDataHash"
             partiallyFillable:
               description: Is the order fill-or-kill or partially fillable?
               type: boolean

--- a/crates/orderbook/openapi.yml
+++ b/crates/orderbook/openapi.yml
@@ -1282,11 +1282,6 @@ components:
             - sellToken
             - buyToken
             - from
-          dependencies:
-            appDataHash:
-              properties:
-                appData:
-                  $ref: "#/components/schemas/AppData"
     OrderQuoteResponse:
       description: |
         An order quoted by the backend that can be directly signed and

--- a/crates/orderbook/openapi.yml
+++ b/crates/orderbook/openapi.yml
@@ -469,6 +469,13 @@ components:
       description: 20 byte Ethereum address encoded as a hex with `0x` prefix.
       type: string
       example: "0x6810e776880c02933d47db1b9fc05908e5386b96"
+    AppData:
+      description: |
+        The string encoding of a JSON object representing some `appData`. The
+        format of the JSON expected in the `appData` field is defined
+        [here](https://github.com/cowprotocol/app-data).
+      type: string
+      example: "{\"version\":\"0.9.0\",\"metadata\":{}}"
     AppDataHash:
       description: 32 bytes encoded as hex with `0x` prefix.
       type: string
@@ -478,11 +485,7 @@ components:
       type: object
       properties:
         fullAppData:
-          description: |
-            The string encoding of a JSON object representing some `appData`. The
-            format of the JSON expected in the `appData` field is defined
-            [here](https://github.com/cowprotocol/app-data).
-          type: string
+          $ref: "#/components/schemas/AppData"
       required:
         - appData
     BigUint:
@@ -1238,7 +1241,17 @@ components:
                 - $ref: "#/components/schemas/Address"
               nullable: true
             appData:
+              description: |
+                AppData which will be assigned to the order.
+                Expects either a string JSON doc as defined on [AppData](https://github.com/cowprotocol/app-data) or a
+                hex encoded string for backwards compatibility.
+                When the first format is used, it's possible to provide the derived appDataHash field.
+              oneOf:
+                - $ref: "#/components/schemas/AppData"
+                - $ref: "#/components/schemas/AppDataHash"
+            appDataHash:
               $ref: "#/components/schemas/AppDataHash"
+              nullable: true
             partiallyFillable:
               description: Is the order fill-or-kill or partially fillable?
               type: boolean
@@ -1269,6 +1282,11 @@ components:
             - sellToken
             - buyToken
             - from
+          dependencies:
+            appDataHash:
+              properties:
+                appData:
+                  $ref: "#/components/schemas/AppData"
     OrderQuoteResponse:
       description: |
         An order quoted by the backend that can be directly signed and


### PR DESCRIPTION
# Summary

This PR updates the openapi definition for QuoteRequest to match the code https://github.com/cowprotocol/services/blob/main/crates/model/src/order.rs#L455-L473

It adds the optional `appDataHash` when `appData` is set to a stringified JSON with the full appData.

### Test Plan

Unit tests
Locally generate the types on the SDK repo