### PR TITLE
Add metrics for the graph based liqudiity in driver

### DIFF
--- a/crates/solver/src/liquidity_collector.rs
+++ b/crates/solver/src/liquidity_collector.rs
@@ -126,7 +126,7 @@ where
 
 #[derive(prometheus_metric_storage::MetricStorage)]
 struct Metrics {
-    /// Tracks whether or now the graph based liquidity is currently enabled.
+    /// Tracks whether or not the graph based liquidity is currently enabled.
     #[metric(labels("source"))]
     liquidity_enabled: prometheus::IntGaugeVec,
 }

--- a/crates/solver/src/liquidity_collector.rs
+++ b/crates/solver/src/liquidity_collector.rs
@@ -181,6 +181,10 @@ mod test {
         };
 
         let source = BackgroundInitLiquiditySource::new("fake", init, Duration::from_millis(10));
+        let gauge = Metrics::get()
+            .liquidity_enabled
+            .with_label_values(&["fake"]);
+        assert_eq!(gauge.get(), 0);
 
         let liquidity = source
             .get_liquidity(Default::default(), Block::Recent)
@@ -197,6 +201,7 @@ mod test {
         let liquidity = source
             .get_liquidity(Default::default(), Block::Recent)
             .await;
-        assert_eq!(liquidity.unwrap_err().to_string(), "I am initialised")
+        assert_eq!(liquidity.unwrap_err().to_string(), "I am initialised");
+        assert_eq!(gauge.get(), 1);
     }
 }


### PR DESCRIPTION
Follow up to #1759

Although we are now automatically retrying to initialise the graph based liquidity it would be nice to some automated alerting system in case it's disabled for a long time.
This PR adds a very simply labled gauge which gets set to 0 when the initialisation wrapper gets created and set to 1 once the liquidity source has been initialised successfully.

### Test Plan
Manually tested driver start up sequence to verify that values of gauges get set correctly after initialisation.
And extended the unit test to include metrics

Fetching `localhost:11088/metrics` returned:
```
# HELP driver_liquidity_enabled Tracks whether or not the graph based liquidity is currently enabled.
# TYPE driver_liquidity_enabled gauge
driver_liquidity_enabled{source="balancer-v2"} 1
driver_liquidity_enabled{source="uniswap-v3"} 1
```