### PR TITLE
fix examples

### DIFF
--- a/crates/driver/example.toml
+++ b/crates/driver/example.toml
@@ -1,15 +1,15 @@
 [[solver]]
 name = "mysolver" # Arbitrary name given to this solver, must be unique
-endpoint = "http://0.0.0.0:33219/solve"
+endpoint = "http://0.0.0.0:7872"
 absolute-slippage = "12" # Denominated in wei, optional
 relative-slippage = "0.1" # Percentage in the [0, 1] range
 account = "0x0000000000000000000000000000000000000000000000000000000000000001" # The private key of the solver
 
-[[solver]] # And so on, specify as many solvers as needed
-name = "othersolver"
-endpoint = "http://localhost:1235"
-relative-slippage = "0.1"
-account = "0x0000000000000000000000000000000000000000000000000000000000000002"
+# [[solver]] # And so on, specify as many solvers as needed
+# name = "othersolver"
+# endpoint = "http://localhost:1235"
+# relative-slippage = "0.1"
+# account = "0x0000000000000000000000000000000000000000000000000000000000000002"
 
 [[submission.mempool]]
 mempool = "public"
@@ -44,3 +44,23 @@ base-tokens = [
 # [[liquidity.uniswap-v2]] # Custom Uniswap V2 configuration
 # router = "0x7a250d5630B4cF539739dF2C5dAcb4c659F2488D"
 # pool-code = "0x96e8ac4277198ff8b6f785478aa9a39f403cb768dd02cbee326c3e7da348845f"
+
+# [[liquidity.balancer-v2]] # Balancer V2 configuration
+# preset = "balancer-v2"
+# pool-deny-list = []
+
+# [[liquidity.balancer-v2]] # Custom Balancer V2 configuration
+# vault = "0xBA12222222228d8Ba445958a75a0704d566BF2C8"
+# weighted = [] # weighted pool factory addresses
+# stable = [] # stable pool factory addresses
+# liquidity-bootstrapping = [] # liquidity bootstrapping pool factory addresses
+# pool-deny-list = [] # which pools to ignore
+
+# [[liquidity.uniswap-v3]] # Uniswap V3 configuration
+# preset = "uniswap-v3"
+# max_pools_to_initialize = 100 # how many of the deepest pools to initialise on startup
+
+# [[liquidity.uniswap-v3]] # Custom Uniswap V3 configuration
+# router = "0xE592427A0AEce92De3Edee1F18E0157C05861564"
+# max_pools_to_initialize = 100 # how many of the deepest pools to initialise on startup
+

--- a/crates/driver/example.toml
+++ b/crates/driver/example.toml
@@ -1,7 +1,7 @@
 [[solver]]
 name = "mysolver" # Arbitrary name given to this solver, must be unique
 endpoint = "http://0.0.0.0:7872"
-absolute-slippage = "12" # Denominated in wei, optional
+absolute-slippage = "0.04" # Denominated in whole native tokens, optional
 relative-slippage = "0.1" # Percentage in the [0, 1] range
 account = "0x0000000000000000000000000000000000000000000000000000000000000001" # The private key of the solver
 

--- a/crates/driver/example.toml
+++ b/crates/driver/example.toml
@@ -1,7 +1,7 @@
 [[solver]]
 name = "mysolver" # Arbitrary name given to this solver, must be unique
 endpoint = "http://0.0.0.0:7872"
-absolute-slippage = "0.04" # Denominated in whole native tokens, optional
+absolute-slippage = "40000000000000000" # Denominated in wei, optional
 relative-slippage = "0.1" # Percentage in the [0, 1] range
 account = "0x0000000000000000000000000000000000000000000000000000000000000001" # The private key of the solver
 

--- a/crates/driver/example.toml
+++ b/crates/driver/example.toml
@@ -47,7 +47,7 @@ base-tokens = [
 
 # [[liquidity.balancer-v2]] # Balancer V2 configuration
 # preset = "balancer-v2"
-# pool-deny-list = []
+# pool-deny-list = [] # optional
 
 # [[liquidity.balancer-v2]] # Custom Balancer V2 configuration
 # vault = "0xBA12222222228d8Ba445958a75a0704d566BF2C8"

--- a/crates/solvers/config/example.balancer.toml
+++ b/crates/solvers/config/example.balancer.toml
@@ -1,4 +1,4 @@
-absolute-slippage = "0.04" # Denominated in whole native tokens, optional
+absolute-slippage = "40000000000000000" # Denominated in wei, optional
 relative-slippage = "0.1" # Percentage in the [0, 1] range
 
 [dex]

--- a/crates/solvers/config/example.balancer.toml
+++ b/crates/solvers/config/example.balancer.toml
@@ -1,9 +1,9 @@
-endpoint = "https://balancer.sor.eth/api"
+relative-slippage = "0.1"
+absolute-slippage = "0.02"
 
+[dex]
+endpoint = "https://balancer.sor.eth/api"
 # Optionally specify custom Balancer Vault and CoW Protocol settlement contract
 # address; omitting these values will use the default addresses:
 # vault = "0xBA12222222228d8Ba445958a75a0704d566BF2C8"
 # settlement = "0x9008D19f58AAbD9eD0D60971565AA8510560ab41"
-
-relative_slippage = "0.1"
-absolute_slippage = "0.02"

--- a/crates/solvers/config/example.balancer.toml
+++ b/crates/solvers/config/example.balancer.toml
@@ -1,5 +1,5 @@
-relative-slippage = "0.1"
-absolute-slippage = "0.02"
+absolute-slippage = "0.04" # Denominated in whole native tokens, optional
+relative-slippage = "0.1" # Percentage in the [0, 1] range
 
 [dex]
 endpoint = "https://balancer.sor.eth/api"

--- a/crates/solvers/config/example.oneinch.toml
+++ b/crates/solvers/config/example.oneinch.toml
@@ -1,4 +1,4 @@
-relative-slippage = "0.1"
-absolute-slippage = "12"
+absolute-slippage = "0.04" # Denominated in whole native tokens, optional
+relative-slippage = "0.1" # Percentage in the [0, 1] range
 [dex]
 chain-id = "1"

--- a/crates/solvers/config/example.oneinch.toml
+++ b/crates/solvers/config/example.oneinch.toml
@@ -1,4 +1,4 @@
 relative-slippage = "0.1"
 absolute-slippage = "12"
 [dex]
-chain-id = "5"
+chain-id = "1"

--- a/crates/solvers/config/example.oneinch.toml
+++ b/crates/solvers/config/example.oneinch.toml
@@ -1,4 +1,4 @@
-absolute-slippage = "0.04" # Denominated in whole native tokens, optional
+absolute-slippage = "40000000000000000" # Denominated in wei, optional
 relative-slippage = "0.1" # Percentage in the [0, 1] range
 [dex]
 chain-id = "1"

--- a/crates/solvers/config/example.paraswap.toml
+++ b/crates/solvers/config/example.paraswap.toml
@@ -1,4 +1,4 @@
-absolute-slippage = "0.04" # Denominated in whole native tokens, optional
+absolute-slippage = "40000000000000000" # Denominated in wei, optional
 relative-slippage = "0.1" # Percentage in the [0, 1] range
 [dex]
 exclude-dexs = [] # which dexs to ignore as liquidity sources

--- a/crates/solvers/config/example.paraswap.toml
+++ b/crates/solvers/config/example.paraswap.toml
@@ -1,0 +1,7 @@
+relative-slippage = "0.1"
+absolute-slippage = "12"
+[dex]
+exclude-dexs = [] # which dexs to ignore as liquidity sources
+address = "0x0000000000000000000000000000000000000001" # public address of the solver
+endpoint = "https://apiv5.paraswap.io" # paraswap API URL to use
+# partner = "" # optional partner id to get increased request rates

--- a/crates/solvers/config/example.paraswap.toml
+++ b/crates/solvers/config/example.paraswap.toml
@@ -1,5 +1,5 @@
-relative-slippage = "0.1"
-absolute-slippage = "12"
+absolute-slippage = "0.04" # Denominated in whole native tokens, optional
+relative-slippage = "0.1" # Percentage in the [0, 1] range
 [dex]
 exclude-dexs = [] # which dexs to ignore as liquidity sources
 address = "0x0000000000000000000000000000000000000001" # public address of the solver

--- a/crates/solvers/config/example.zeroex.toml
+++ b/crates/solvers/config/example.zeroex.toml
@@ -1,4 +1,4 @@
-absolute-slippage = "0.04" # Denominated in whole native tokens, optional
+absolute-slippage = "40000000000000000" # Denominated in wei, optional
 relative-slippage = "0.1" # Percentage in the [0, 1] range
 
 [dex]

--- a/crates/solvers/config/example.zeroex.toml
+++ b/crates/solvers/config/example.zeroex.toml
@@ -4,10 +4,10 @@ absolute-slippage = "0.02"
 [dex]
 excluded-sources = ["Balancer_V2"]
 enable-slippage-protection = true
+api-key = "$YOUR_API_KEY"
 
 # Optionally specify a custom 0x API endpoint with an access key.
 # endpoint = "https://gated.api.0x.org/swap/v1/"
-# api-key = "abc123"
 
 # Optionally specify a custom affiliate address.
 # affiliate = "0x9008D19f58AAbD9eD0D60971565AA8510560ab41"

--- a/crates/solvers/config/example.zeroex.toml
+++ b/crates/solvers/config/example.zeroex.toml
@@ -1,5 +1,5 @@
-relative-slippage = "0.1"
-absolute-slippage = "0.02"
+absolute-slippage = "0.04" # Denominated in whole native tokens, optional
+relative-slippage = "0.1" # Percentage in the [0, 1] range
 
 [dex]
 api-key = "$YOUR_API_KEY"

--- a/crates/solvers/config/example.zeroex.toml
+++ b/crates/solvers/config/example.zeroex.toml
@@ -2,6 +2,7 @@ absolute-slippage = "40000000000000000" # Denominated in wei, optional
 relative-slippage = "0.1" # Percentage in the [0, 1] range
 
 [dex]
+# See here how to get a free key: https://0x.org/docs/introduction/getting-started
 api-key = "$YOUR_API_KEY"
 
 # Optionally specify a custom 0x API endpoint

--- a/crates/solvers/config/example.zeroex.toml
+++ b/crates/solvers/config/example.zeroex.toml
@@ -2,12 +2,23 @@ relative-slippage = "0.1"
 absolute-slippage = "0.02"
 
 [dex]
-excluded-sources = ["Balancer_V2"]
-enable-slippage-protection = true
 api-key = "$YOUR_API_KEY"
 
-# Optionally specify a custom 0x API endpoint with an access key.
+# Optionally specify a custom 0x API endpoint
 # endpoint = "https://gated.api.0x.org/swap/v1/"
 
 # Optionally specify a custom affiliate address.
 # affiliate = "0x9008D19f58AAbD9eD0D60971565AA8510560ab41"
+
+# Optionally specify which liquidity sources to exclude
+# excluded_sources = ["Balancer_V2"]
+
+# Optionally specify whether to enable RFQ-T liquidity
+# enable-rfqt = true
+
+# Optionally specify whether to enable slippage protection.
+# The slippage protection
+# considers average negative slippage paid out in MEV when quoting,
+# preferring private market maker orders when they are close to what you
+# would get with on-chain liquidity pools.
+# enable-slippage-protection = true

--- a/crates/solvers/src/infra/config/dex/file.rs
+++ b/crates/solvers/src/infra/config/dex/file.rs
@@ -1,10 +1,7 @@
 //! Configuration parameters that get shared across all dex solvers.
 
 use {
-    crate::{
-        domain::{dex::slippage, eth},
-        util::conv,
-    },
+    crate::domain::{dex::slippage, eth},
     bigdecimal::BigDecimal,
     serde::{de::DeserializeOwned, Deserialize},
     serde_with::serde_as,
@@ -23,7 +20,7 @@ struct Config {
 
     /// The absolute slippage allowed by the solver.
     #[serde_as(as = "Option<serde_with::DisplayFromStr>")]
-    absolute_slippage: Option<BigDecimal>,
+    absolute_slippage: Option<eth::U256>,
 
     /// The amount of Ether a partially fillable order should be filled for at
     /// least.
@@ -64,9 +61,7 @@ pub async fn load<T: DeserializeOwned>(path: &Path) -> (super::Config, T) {
     let config = super::Config {
         slippage: slippage::Limits::new(
             config.relative_slippage,
-            config.absolute_slippage.map(|value| {
-                conv::decimal_to_ether(&value).expect("invalid absolute slippage Ether value")
-            }),
+            config.absolute_slippage.map(eth::Ether),
         )
         .expect("invalid slippage limits"),
         smallest_partial_fill: eth::Ether(config.smallest_partial_fill),

--- a/crates/solvers/src/infra/config/dex/zeroex/file.rs
+++ b/crates/solvers/src/infra/config/dex/zeroex/file.rs
@@ -18,9 +18,9 @@ struct Config {
     #[serde_as(as = "serde_with::DisplayFromStr")]
     endpoint: reqwest::Url,
 
-    /// An optional API key to use. This is needed when configuring 0x to use
+    /// This is needed when configuring 0x to use
     /// the gated API for partners.
-    api_key: Option<String>,
+    api_key: String,
 
     /// The list of excluded liquidity sources. Liquidity from these sources
     /// will not be considered when solving.

--- a/crates/solvers/src/infra/dex/zeroex/mod.rs
+++ b/crates/solvers/src/infra/dex/zeroex/mod.rs
@@ -21,11 +21,9 @@ pub struct Config {
     /// The base URL for the 0x swap API.
     pub endpoint: reqwest::Url,
 
-    /// Optional API key.
-    ///
     /// 0x provides a gated API for partners that requires authentication
     /// by specifying this as header in the HTTP request.
-    pub api_key: Option<String>,
+    pub api_key: String,
 
     /// The list of excluded liquidity sources. Liquidity from these sources
     /// will not be considered when solving.
@@ -48,19 +46,16 @@ pub struct Config {
 
 impl ZeroEx {
     pub fn new(config: Config) -> Result<Self, CreationError> {
-        let client = match config.api_key {
-            Some(key) => {
-                let mut key = reqwest::header::HeaderValue::from_str(&key)?;
-                key.set_sensitive(true);
+        let client = {
+            let mut key = reqwest::header::HeaderValue::from_str(&config.api_key)?;
+            key.set_sensitive(true);
 
-                let mut headers = reqwest::header::HeaderMap::new();
-                headers.insert("0x-api-key", key);
+            let mut headers = reqwest::header::HeaderMap::new();
+            headers.insert("0x-api-key", key);
 
-                reqwest::Client::builder()
-                    .default_headers(headers)
-                    .build()?
-            }
-            None => reqwest::Client::new(),
+            reqwest::Client::builder()
+                .default_headers(headers)
+                .build()?
         };
         let defaults = dto::Query {
             taker_address: Some(config.settlement.0),

--- a/crates/solvers/src/tests/zeroex/mod.rs
+++ b/crates/solvers/src/tests/zeroex/mod.rs
@@ -11,6 +11,7 @@ pub fn config(solver_addr: &SocketAddr) -> tests::Config {
         r"
 [dex]
 endpoint = 'http://{solver_addr}/swap/v1/'
+api-key = 'SUPER_SECRET_API_KEY'
         ",
     ))
 }


### PR DESCRIPTION
For local test I usually like to take one of the existing example configuration files and patch it to my needs.
This showed that some of the examples are outdated or have values that could be improved in terms of ease of use.

Changes include:
* example solver in `driver` config is now compatible with defaults of the `solvers` binary
* documented `balancer-v2` and `uniswap-v3` liquidity in driver
* fixed incorrect format of `balancer` config
* configured `1Inch` to use `mainnet` instead of `goerli`
* added a file for `paraswap`
* made `0x` api key required (without you'll receive these response which fail to parse: `"No API key provided. Please visit https://0x.org/pricing to get a free API key or sign up to a paid plan`)
* made sure `solvers` and `driver` both expect `absolute-slippage` in wei