### PR TITLE
Baseline: Converge To Sufficient Sell Amount

### DIFF
--- a/crates/shared/src/baseline_solver.rs
+++ b/crates/shared/src/baseline_solver.rs
@@ -2,9 +2,13 @@
 //! onchain liquidity.
 
 use {
+    crate::conversions::U256Ext,
     ethcontract::{H160, U256},
     model::TokenPair,
-    std::collections::{HashMap, HashSet},
+    std::{
+        cmp,
+        collections::{HashMap, HashSet},
+    },
 };
 
 /// The maximum number of hops to use when trading with AMMs along a path.
@@ -68,15 +72,15 @@ pub fn estimate_buy_amount<'a, L: BaselineSolvable>(
                 let (best_liquidity, amount) = liquidity
                     .get(&TokenPair::new(*current, previous)?)?
                     .iter()
-                    .map(|liquidity| {
-                        (
+                    .filter_map(|liquidity| {
+                        Some((
                             liquidity,
-                            liquidity.get_amount_out(*current, (amount, previous)),
-                        )
+                            liquidity.get_amount_out(*current, (amount, previous))?,
+                        ))
                     })
-                    .max_by(|(_, amount_a), (_, amount_b)| amount_a.cmp(amount_b))?;
+                    .max_by_key(|(_, amount)| *amount)?;
                 path.push(best_liquidity);
-                Some((amount?, *current, path))
+                Some((amount, *current, path))
             },
         )
         .map(|(amount, _, liquidity)| Estimate {
@@ -93,6 +97,39 @@ pub fn estimate_sell_amount<'a, L: BaselineSolvable>(
     path: &[H160],
     liquidity: &'a HashMap<TokenPair, Vec<L>>,
 ) -> Option<Estimate<'a, U256, L>> {
+    // Some baseline liquidity is "unstable", where if you compute an input
+    // amount large enough to buy X tokens, selling the computed amount over the
+    // same pool in the exact same state will yield X-𝛿 tokens. To work around
+    // this, for each hop,  to converge to some `sell` amount >= the required
+    // buy amount.
+    let get_amount_in =
+        |liquidity: &L, in_token: H160, (exact_out_amount, out_token): (U256, H160)| {
+            /// Upper bound on number of iterations to find a sufficiently high
+            /// sell amount.
+            const MAX_ITERATIONS: usize = 3;
+
+            let mut in_amount = liquidity.get_amount_in(in_token, (exact_out_amount, out_token))?;
+            for _ in 0..MAX_ITERATIONS {
+                let out_amount = liquidity.get_amount_out(out_token, (in_amount, in_token))?;
+                dbg!(in_amount, out_amount);
+                if out_amount >= exact_out_amount {
+                    return Some(in_amount);
+                }
+
+                // The computed output amount is not enough; so scale the sell
+                // amount up a bit.
+                let bump = cmp::max(
+                    (exact_out_amount - out_amount)
+                        .checked_mul(in_amount)?
+                        .checked_ceil_div(&out_amount)?,
+                    U256::from(1),
+                );
+                in_amount = in_amount.checked_add(bump)?;
+            }
+
+            None
+        };
+
     let buy_token = path.last()?;
     path.iter()
         .rev()
@@ -104,19 +141,16 @@ pub fn estimate_sell_amount<'a, L: BaselineSolvable>(
                 let (best_liquidity, amount) = liquidity
                     .get(&TokenPair::new(*current, previous)?)?
                     .iter()
-                    .map(|liquidity| {
-                        (
+                    .filter_map(|liquidity| {
+                        Some((
                             liquidity,
-                            liquidity.get_amount_in(*current, (amount, previous)),
-                        )
+                            get_amount_in(liquidity, *current, (amount, previous))?,
+                            //liquidity.get_amount_in(*current, (amount, previous))?,
+                        ))
                     })
-                    .min_by(|(_, amount_a), (_, amount_b)| {
-                        amount_a
-                            .unwrap_or_else(U256::max_value)
-                            .cmp(&amount_b.unwrap_or_else(U256::max_value))
-                    })?;
+                    .min_by_key(|(_, amount)| *amount)?;
                 path.push(best_liquidity);
-                Some((amount?, *current, path))
+                Some((amount, *current, path))
             },
         )
         .map(|(amount, _, liquidity)| Estimate {

--- a/crates/shared/src/baseline_solver.rs
+++ b/crates/shared/src/baseline_solver.rs
@@ -100,8 +100,8 @@ pub fn estimate_sell_amount<'a, L: BaselineSolvable>(
     // Some baseline liquidity is "unstable", where if you compute an input
     // amount large enough to buy X tokens, selling the computed amount over the
     // same pool in the exact same state will yield X-𝛿 tokens. To work around
-    // this, for each hop,  to converge to some `sell` amount >= the required
-    // buy amount.
+    // this, for each hop, we try to converge to some sell amount >= the
+    // required buy amount.
     let get_amount_in =
         |liquidity: &L, in_token: H160, (exact_out_amount, out_token): (U256, H160)| {
             /// Upper bound on number of iterations to find a sufficiently high
@@ -111,7 +111,6 @@ pub fn estimate_sell_amount<'a, L: BaselineSolvable>(
             let mut in_amount = liquidity.get_amount_in(in_token, (exact_out_amount, out_token))?;
             for _ in 0..MAX_ITERATIONS {
                 let out_amount = liquidity.get_amount_out(out_token, (in_amount, in_token))?;
-                dbg!(in_amount, out_amount);
                 if out_amount >= exact_out_amount {
                     return Some(in_amount);
                 }
@@ -145,7 +144,6 @@ pub fn estimate_sell_amount<'a, L: BaselineSolvable>(
                         Some((
                             liquidity,
                             get_amount_in(liquidity, *current, (amount, previous))?,
-                            //liquidity.get_amount_in(*current, (amount, previous))?,
                         ))
                     })
                     .min_by_key(|(_, amount)| *amount)?;

--- a/crates/solvers/src/tests/baseline/buy_order_rounding.rs
+++ b/crates/solvers/src/tests/baseline/buy_order_rounding.rs
@@ -220,11 +220,8 @@ async fn balancer() {
         }))
         .await;
 
-    // We end up using the liquidity with a bad price because the baseline
-    // solver can't build a solution using the Balancer liquidity. This because
-    // Balancer weighted pools are "unstable", where if you compute an input
-    // amount large enough to buy X tokens, selling the computed amount over
-    // the same pool in the exact same state will yield X-𝛿 tokens.
+    // Note that the interaction executes slightly more than the buy order's
+    // amount. This is inevitable because of rounding.
     assert_eq!(
         solution,
         json!({
@@ -232,7 +229,7 @@ async fn balancer() {
                 "id": 0,
                 "prices": {
                     "0x177127622c4a00f3d409b75571e12cb3c8973d3c": "1000000000000000000",
-                    "0xe91d153e0b41518a2ce8dd3d7944fa863463a97d": "1004013040121365096289871"
+                    "0xe91d153e0b41518a2ce8dd3d7944fa863463a97d": "15503270361046562907"
                 },
                 "trades": [
                     {
@@ -247,12 +244,21 @@ async fn balancer() {
                     {
                         "kind": "liquidity",
                         "internalize": false,
-                        "id": "2",
+                        "id": "1",
                         "inputToken": "0x177127622c4a00f3d409b75571e12cb3c8973d3c",
+                        "outputToken": "0x9c58bacc331c9aa871afd802db6379a98e80cedb",
+                        "inputAmount": "15503270361046562907",
+                        "outputAmount": "9056454904358278"
+                    },
+                    {
+                        "kind": "liquidity",
+                        "internalize": false,
+                        "id": "0",
+                        "inputToken": "0x9c58bacc331c9aa871afd802db6379a98e80cedb",
                         "outputToken": "0xe91d153e0b41518a2ce8dd3d7944fa863463a97d",
-                        "inputAmount": "1004013040121365096289871",
-                        "outputAmount": "1000000000000000000"
-                    }
+                        "inputAmount": "9056454904358278",
+                        "outputAmount": "1000000000000082826"
+                    },
                 ]
             }]
         }),

--- a/crates/solvers/src/tests/baseline/buy_order_rounding.rs
+++ b/crates/solvers/src/tests/baseline/buy_order_rounding.rs
@@ -229,7 +229,7 @@ async fn balancer() {
                 "id": 0,
                 "prices": {
                     "0x177127622c4a00f3d409b75571e12cb3c8973d3c": "1000000000000000000",
-                    "0xe91d153e0b41518a2ce8dd3d7944fa863463a97d": "15503270361046562907"
+                    "0xe91d153e0b41518a2ce8dd3d7944fa863463a97d": "15503270361046566989"
                 },
                 "trades": [
                     {
@@ -247,7 +247,7 @@ async fn balancer() {
                         "id": "1",
                         "inputToken": "0x177127622c4a00f3d409b75571e12cb3c8973d3c",
                         "outputToken": "0x9c58bacc331c9aa871afd802db6379a98e80cedb",
-                        "inputAmount": "15503270361046562907",
+                        "inputAmount": "15503270361046566989",
                         "outputAmount": "9056454904358278"
                     },
                     {
@@ -258,6 +258,151 @@ async fn balancer() {
                         "outputToken": "0xe91d153e0b41518a2ce8dd3d7944fa863463a97d",
                         "inputAmount": "9056454904358278",
                         "outputAmount": "1000000000000082826"
+                    },
+                ]
+            }]
+        }),
+    );
+}
+
+#[tokio::test]
+async fn same_path() {
+    let engine = tests::SolverEngine::new(
+        "baseline",
+        tests::Config::String(
+            r#"
+                chain-id = "100"
+                base-tokens = ["0x9c58bacc331c9aa871afd802db6379a98e80cedb"]
+                max-hops = 0
+                max-partial-attempts = 1
+            "#
+            .to_owned(),
+        ),
+    )
+    .await;
+
+    let solution = engine
+        .solve(json!({
+            "id": "1",
+            "tokens": {
+                "0x177127622c4a00f3d409b75571e12cb3c8973d3c": {
+                    "decimals": 18,
+                    "symbol": "xCOW",
+                    "referencePrice": null,
+                    "availableBalance": "0",
+                    "trusted": true
+                },
+                "0x9c58bacc331c9aa871afd802db6379a98e80cedb": {
+                    "decimals": 18,
+                    "symbol": "xGNO",
+                    "referencePrice": null,
+                    "availableBalance": "0",
+                    "trusted": true
+                },
+            },
+            "orders": [
+                {
+                    "uid": "0x2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a\
+                              2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a\
+                              2a2a2a2a",
+                    "sellToken": "0x177127622c4a00f3d409b75571e12cb3c8973d3c",
+                    "buyToken": "0x9c58bacc331c9aa871afd802db6379a98e80cedb",
+                    "sellAmount": "16000000000000000000",
+                    "buyAmount": "9056454904357528",
+                    "feeAmount": "0",
+                    "kind": "buy",
+                    "partiallyFillable": false,
+                    "class": "market",
+                }
+            ],
+            "liquidity": [
+                {
+                    "kind": "weightedproduct",
+                    "tokens": {
+                        "0x177127622c4a00f3d409b75571e12cb3c8973d3c": {
+                            "balance": "1963528800698237927834721",
+                            "scalingFactor": "1000000000000000000",
+                            "weight": "0.5",
+                        },
+                        "0x9c58bacc331c9aa871afd802db6379a98e80cedb": {
+                            "balance": "1152796145430714835825",
+                            "scalingFactor": "1000000000000000000",
+                            "weight": "0.5",
+                        }
+                    },
+                    "fee": "0.005",
+                    "id": "0",
+                    "address": "0x21d4c792ea7e38e0d0819c2011a2b1cb7252bd99",
+                    "gasEstimate": "0"
+                },
+                {
+                    "kind": "constantproduct",
+                    "tokens": {
+                        "0x177127622c4a00f3d409b75571e12cb3c8973d3c": {
+                            "balance": "1000000000000000000000000000"
+                        },
+                        "0x9c58bacc331c9aa871afd802db6379a98e80cedb": {
+                            "balance": "585921934616708391829053"
+                        }
+                    },
+                    "fee": "0.003",
+                    "id": "1",
+                    "address": "0x9090909090909090909090909090909090909090",
+                    "gasEstimate": "0"
+                },
+            ],
+            "effectiveGasPrice": "1000000000",
+            "deadline": "2106-01-01T00:00:00.000Z"
+        }))
+        .await;
+
+    // Lets get down to the math!
+    // --------------------------
+    //
+    // Balancer V2 weighted pools are unstable - this means that when computing
+    // `get_amount_out(TOK0, (get_amount_in(TOK1, (a, TOK0)), TOK1)) < a`,
+    // meaning that we actually need to sell a bit more than computed in order
+    // to cover the buy order. Specifically, in this example:
+    // - the computed input amount is `15503270361045187239 xCOW`
+    // - the corresponding output amount is `9056454904357125 xGNO` (`403` less than
+    //   what is actually needed)
+    // - the optimal input amount is `15503270361046529181 xCOW`, such that this
+    //   amount -1 would result in an output amount that is not enough to cover the
+    //   order
+    //
+    // Interestingly, in the same path, we have an constant product pool (i.e.
+    // Uniswap-like pool) L1 which if used for a solution would result in
+    // selling an amount that is higher than the computed input amount for the
+    // Balancer pool, but lower than its optimal input amount.
+    //
+    // This tests asserts that we use L1 in the solution.
+    assert_eq!(
+        solution,
+        json!({
+            "solutions": [{
+                "id": 0,
+                "prices": {
+                    "0x177127622c4a00f3d409b75571e12cb3c8973d3c": "9056454904357528",
+                    "0x9c58bacc331c9aa871afd802db6379a98e80cedb": "15503270361045187242"
+                },
+                "trades": [
+                    {
+                        "kind": "fulfillment",
+                        "order": "0x2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a\
+                                    2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a\
+                                    2a2a2a2a",
+                        "executedAmount": "9056454904357528"
+                    }
+                ],
+                "interactions": [
+                    {
+                        "kind": "liquidity",
+                        "internalize": false,
+                        "id": "1",
+                        "inputToken": "0x177127622c4a00f3d409b75571e12cb3c8973d3c",
+                        "outputToken": "0x9c58bacc331c9aa871afd802db6379a98e80cedb",
+                        "inputAmount": "15503270361045187242",
+                        "outputAmount": "9056454904357528"
                     },
                 ]
             }]


### PR DESCRIPTION
Follow up to #1761

This PR adjusts the Baseline solver algorithm to iterate on progressively larger sell amounts in an attempt to traverse from an order's sell token to its buy token ensuring that the executed buy amount is enough to cover the buy order.

This is needed because some baseline liquidity (notable Balancer weighed pools) are "unstable", meaning that if we compute the input amount `X` required for an exact output amount `Y`, then using the exact same pool state compute the output amount `Y'` for an exact input amount `X`, it can happen that `Y' < Y`, meaning that the executed interactions would not generate enough tokens to cover the buy order.

### Test Plan

Adjusted E2E test to demonstrate that the path with the better price (over an unstable Balancer pool) is used.
