### PR TITLE
Fix refunder

### DIFF
--- a/crates/database/src/ethflow_orders.rs
+++ b/crates/database/src/ethflow_orders.rs
@@ -132,7 +132,7 @@ AND eo.valid_to < $1
 AND o.sell_amount = oq.sell_amount
 AND (
     CASE
-        WHEN oq.buy_amount = 0 THEN TRUE
+        WHEN oq.buy_amount = 0 THEN FALSE
         ELSE (1.0 - o.buy_amount / oq.buy_amount) >= $3
     END
 )

--- a/crates/database/src/ethflow_orders.rs
+++ b/crates/database/src/ethflow_orders.rs
@@ -116,9 +116,15 @@ pub async fn refundable_orders(
     min_validity_duration: i64,
     min_slippage: f64,
 ) -> Result<Vec<EthOrderPlacement>, sqlx::Error> {
-    /// constraint oq.buy_amount > 0 added to avoid division by zero since table
-    /// order_quotes contains entries with buy_amount = 0 (see
-    /// V021__store_full_quotes.sql)
+    // condition (1.0 - o.buy_amount / GREATEST(oq.buy_amount,1)) >= $3 is added to
+    // skip refunding orders that have unrealistic slippage set. Those orders are
+    // unlikely to be filled so we don't want to be responsible for refunding them.
+    // Note that orders created with our UI should have realistic slippage in most
+    // cases.
+    //
+    // GREATEST(oq.buy_amount,1) added to avoid division by zero since
+    // table order_quotes contains entries with buy_amount = 0 (see
+    // V021__store_full_quotes.sql)
     const QUERY: &str = r#"
 SELECT eo.uid, eo.valid_to from orders o
 INNER JOIN ethflow_orders eo on eo.uid = o.uid 
@@ -133,8 +139,7 @@ AND o.partially_fillable = false
 AND t.order_uid is null
 AND eo.valid_to < $1
 AND o.sell_amount = oq.sell_amount
-AND oq.buy_amount > 0
-AND (1.0 - o.buy_amount / oq.buy_amount) >= $3
+AND (1.0 - o.buy_amount / GREATEST(oq.buy_amount,1)) >= $3
 AND eo.valid_to - extract(epoch from creation_timestamp)::int > $2
     "#;
     sqlx::query_as(QUERY)

--- a/crates/database/src/ethflow_orders.rs
+++ b/crates/database/src/ethflow_orders.rs
@@ -130,7 +130,12 @@ AND o.partially_fillable = false
 AND t.order_uid is null
 AND eo.valid_to < $1
 AND o.sell_amount = oq.sell_amount
-AND (1.0 - o.buy_amount / oq.buy_amount) >= $3
+AND (
+    CASE
+        WHEN oq.buy_amount = 0 THEN TRUE
+        ELSE (1.0 - o.buy_amount / oq.buy_amount) >= $3
+    END
+)
 AND eo.valid_to - extract(epoch from creation_timestamp)::int > $2
     "#;
     sqlx::query_as(QUERY)

--- a/crates/database/src/ethflow_orders.rs
+++ b/crates/database/src/ethflow_orders.rs
@@ -124,7 +124,7 @@ pub async fn refundable_orders(
     //
     // GREATEST(oq.buy_amount,1) added to avoid division by zero since
     // table order_quotes contains entries with buy_amount = 0 (see
-    // V021__store_full_quotes.sql)
+    // https://github.com/cowprotocol/services/pull/1767#issuecomment-1680825756)
     const QUERY: &str = r#"
 SELECT eo.uid, eo.valid_to from orders o
 INNER JOIN ethflow_orders eo on eo.uid = o.uid 

--- a/crates/database/src/ethflow_orders.rs
+++ b/crates/database/src/ethflow_orders.rs
@@ -132,7 +132,7 @@ AND eo.valid_to < $1
 AND o.sell_amount = oq.sell_amount
 AND (
     CASE
-        WHEN oq.buy_amount = 0 THEN FALSE
+        WHEN oq.buy_amount = 0 THEN TRUE
         ELSE (1.0 - o.buy_amount / oq.buy_amount) >= $3
     END
 )

--- a/crates/solver/src/solver/http_solver/settlement.rs
+++ b/crates/solver/src/solver/http_solver/settlement.rs
@@ -99,7 +99,7 @@ impl Execution {
                             false => fee.unwrap_or_default(),
                         }
                     }
-                    false => order.order.solver_fee,
+                    false => order.order.solver_fee,    
                 };
 
                 let execution = LimitOrderExecution {

--- a/crates/solver/src/solver/http_solver/settlement.rs
+++ b/crates/solver/src/solver/http_solver/settlement.rs
@@ -99,7 +99,7 @@ impl Execution {
                             false => fee.unwrap_or_default(),
                         }
                     }
-                    false => order.order.solver_fee,    
+                    false => order.order.solver_fee,
                 };
 
                 let execution = LimitOrderExecution {


### PR DESCRIPTION
Refunder is failing to fetch refundable orders due to an entry in the database table `order_quotes` with `buy_amount = 0`.
I am not sure if this quote is even valid, I guess it is.

This PR adds division by zero protection. Orders with `buy_amount = 0` will be skipped.

Deeper explanation what is probably happening is https://github.com/cowprotocol/services/pull/1767#issuecomment-1680825756

### Release notes

Requires hotfix to unblock refunder (if we don't want to manually fix prod database)

