### PR TITLE
Metrics for request sharing

### DIFF
--- a/crates/shared/src/price_estimation/balancer_sor.rs
+++ b/crates/shared/src/price_estimation/balancer_sor.rs
@@ -39,7 +39,7 @@ impl BalancerSor {
     ) -> Self {
         Self {
             api,
-            sharing: Default::default(),
+            sharing: RequestSharing::labelled("BalancerSoR".into()),
             rate_limiter,
             gas,
             solver,

--- a/crates/shared/src/price_estimation/http.rs
+++ b/crates/shared/src/price_estimation/http.rs
@@ -90,7 +90,7 @@ impl HttpPriceEstimator {
     ) -> Self {
         Self {
             api,
-            sharing: Default::default(),
+            sharing: RequestSharing::labelled("http_ersimator".into()),
             pools,
             balancer_pools,
             uniswap_v3_pools,
@@ -804,7 +804,7 @@ mod tests {
                     ..Default::default()
                 },
             }),
-            sharing: Default::default(),
+            sharing: RequestSharing::labelled("Test".into()),
             pools,
             balancer_pools: Some(balancer_pool_fetcher),
             token_info,

--- a/crates/shared/src/price_estimation/trade_finder.rs
+++ b/crates/shared/src/price_estimation/trade_finder.rs
@@ -71,7 +71,7 @@ impl TradeEstimator {
                 finder,
                 verifier: None,
             }),
-            sharing: Default::default(),
+            sharing: RequestSharing::labelled("TradeEstimator".into()),
             rate_limiter,
         }
     }
@@ -344,7 +344,7 @@ impl Clone for TradeEstimator {
     fn clone(&self) -> Self {
         Self {
             inner: self.inner.clone(),
-            sharing: Default::default(),
+            sharing: self.sharing.clone(),
             rate_limiter: self.rate_limiter.clone(),
         }
     }

--- a/crates/shared/src/request_sharing.rs
+++ b/crates/shared/src/request_sharing.rs
@@ -3,6 +3,7 @@ use {
         future::{BoxFuture, Shared, WeakShared},
         FutureExt,
     },
+    prometheus::IntCounterVec,
     std::{future::Future, sync::Mutex},
 };
 
@@ -19,6 +20,7 @@ use {
 /// while one of them is already in flight.
 pub struct RequestSharing<Request, Fut: Future> {
     in_flight: Mutex<Vec<(Request, WeakShared<Fut>)>>,
+    request_label: String,
 }
 
 /// Request sharing for boxed futures.
@@ -28,11 +30,19 @@ pub type BoxRequestSharing<Request, Response> =
 /// A boxed shared future.
 pub type BoxShared<T> = Shared<BoxFuture<'static, T>>;
 
-impl<Request, Fut: Future> Default for RequestSharing<Request, Fut> {
-    fn default() -> Self {
+impl<Request, Fut: Future> RequestSharing<Request, Fut> {
+    pub fn labelled(request_label: String) -> Self {
         Self {
             in_flight: Default::default(),
+            request_label,
         }
+    }
+}
+
+/// Returns a shallow copy (without any pending requests)
+impl<Request, Fut: Future> Clone for RequestSharing<Request, Fut> {
+    fn clone(&self) -> Self {
+        Self::labelled(self.request_label.clone())
     }
 }
 
@@ -86,8 +96,17 @@ where
         });
 
         if let Some(existing) = existing {
+            Metrics::get()
+                .request_sharing_access
+                .with_label_values(&[&self.request_label, "hits"])
+                .inc();
             return existing;
         }
+
+        Metrics::get()
+            .request_sharing_access
+            .with_label_values(&[&self.request_label, "misses"])
+            .inc();
 
         let shared = future(&request).shared();
         // unwrap because downgrade only returns None if the Shared has already
@@ -97,13 +116,26 @@ where
     }
 }
 
+#[derive(prometheus_metric_storage::MetricStorage)]
+struct Metrics {
+    /// Request sharing hits & misses
+    #[metric(labels("request_label", "result"))]
+    request_sharing_access: IntCounterVec,
+}
+
+impl Metrics {
+    fn get() -> &'static Self {
+        Metrics::instance(global_metrics::get_metric_storage_registry()).unwrap()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
 
     #[test]
     fn shares_request() {
-        let sharing = RequestSharing::default();
+        let sharing = RequestSharing::labelled("test".into());
         let shared0 = sharing.shared(0, futures::future::ready(0).boxed());
         let shared1 = sharing.shared(0, async { panic!() }.boxed());
         // Would use Arc::ptr_eq but Shared doesn't implement it.

--- a/crates/shared/src/trade_finding/external.rs
+++ b/crates/shared/src/trade_finding/external.rs
@@ -30,7 +30,7 @@ impl ExternalTradeFinder {
     pub fn new(driver: Url, client: Client) -> Self {
         Self {
             quote_endpoint: crate::url::join(&driver, "quote"),
-            sharing: Default::default(),
+            sharing: RequestSharing::labelled("ExternalTradeFinder".into()),
             client,
         }
     }

--- a/crates/shared/src/trade_finding/oneinch.rs
+++ b/crates/shared/src/trade_finding/oneinch.rs
@@ -13,7 +13,7 @@ use {
             SwapQuery,
         },
         price_estimation::gas,
-        request_sharing::{BoxRequestSharing, BoxShared},
+        request_sharing::{BoxRequestSharing, BoxShared, RequestSharing},
     },
     futures::FutureExt as _,
     model::order::OrderKind,
@@ -54,7 +54,7 @@ impl OneInchTradeFinder {
                 referrer_address,
                 solver,
             )),
-            sharing: Default::default(),
+            sharing: RequestSharing::labelled("OneInch".into()),
         }
     }
 

--- a/crates/shared/src/trade_finding/paraswap.rs
+++ b/crates/shared/src/trade_finding/paraswap.rs
@@ -11,7 +11,7 @@ use {
             TransactionBuilderQuery,
         },
         price_estimation::gas,
-        request_sharing::{BoxRequestSharing, BoxShared},
+        request_sharing::{BoxRequestSharing, BoxShared, RequestSharing},
         token_info::{TokenInfo, TokenInfoFetching},
         trade_finding::{Interaction, Trade},
     },
@@ -56,7 +56,7 @@ impl ParaswapTradeFinder {
                 disabled_paraswap_dexs,
                 solver,
             },
-            sharing: Default::default(),
+            sharing: RequestSharing::labelled("Paraswap".into()),
         }
     }
 

--- a/crates/shared/src/trade_finding/zeroex.rs
+++ b/crates/shared/src/trade_finding/zeroex.rs
@@ -4,7 +4,7 @@ use {
     super::{Interaction, Quote, Trade, TradeError, TradeFinding},
     crate::{
         price_estimation::{gas, Query},
-        request_sharing::{BoxRequestSharing, BoxShared},
+        request_sharing::{BoxRequestSharing, BoxShared, RequestSharing},
         zeroex_api::{SwapQuery, ZeroExApi, ZeroExResponseError},
     },
     futures::FutureExt as _,
@@ -40,7 +40,7 @@ impl ZeroExTradeFinder {
                 buy_only,
                 solver,
             },
-            sharing: Default::default(),
+            sharing: RequestSharing::labelled("ZeroEx".into()),
         }
     }
 


### PR DESCRIPTION
In order to assess ways to reduce the number of requests we are making, I'd like to measure how effective our request sharing is (and if it should potentially be replaced by a longer lasting cache that always drives in-flight requests to the end and keeps them at least until the next block arrives)

### Test Plan

CI and then expect metrics to show up in Grafana
