### PR TITLE
Move token info fetching entirely into driver

### DIFF
--- a/crates/autopilot/src/driver_model.rs
+++ b/crates/autopilot/src/driver_model.rs
@@ -78,8 +78,6 @@ pub mod solve {
         #[serde_as(as = "Option<DecimalU256>")]
         pub price: Option<U256>,
         pub trusted: bool,
-        pub decimals: Option<u8>,
-        pub symbol: Option<String>,
     }
 
     #[serde_as]

--- a/crates/autopilot/src/lib.rs
+++ b/crates/autopilot/src/lib.rs
@@ -609,7 +609,6 @@ pub async fn main(args: arguments::Arguments) {
             market_makable_token_list,
             submission_deadline: args.submission_deadline as u64,
             additional_deadline_for_rewards: args.additional_deadline_for_rewards as u64,
-            token_info: token_info_fetcher,
         };
         run.run_forever().await;
         unreachable!("run loop exited");

--- a/crates/driver/src/domain/competition/auction.rs
+++ b/crates/driver/src/domain/competition/auction.rs
@@ -123,7 +123,6 @@ pub struct Token {
     pub symbol: Option<String>,
     pub address: eth::TokenAddress,
     pub price: Option<Price>,
-    // TODO Set this field correctly, currently it isn't being passed into the driver.
     /// The balance of this token available in our settlement contract.
     pub available_balance: eth::U256,
     /// Is this token well-known and trusted by the protocol?

--- a/crates/driver/src/domain/quote.rs
+++ b/crates/driver/src/domain/quote.rs
@@ -131,19 +131,19 @@ impl Order {
             }],
             [
                 auction::Token {
-                    decimals: sell_token_metadata.and_then(|i| i.decimals),
-                    symbol: sell_token_metadata.and_then(|i| i.symbol.clone()),
+                    decimals: sell_token_metadata.and_then(|m| m.decimals),
+                    symbol: sell_token_metadata.and_then(|m| m.symbol.clone()),
                     address: self.tokens.sell,
                     price: None,
-                    available_balance: Default::default(),
+                    available_balance: sell_token_metadata.map(|m| m.balance.0).unwrap_or_default(),
                     trusted: false,
                 },
                 auction::Token {
-                    decimals: buy_token_metadata.and_then(|i| i.decimals),
-                    symbol: buy_token_metadata.and_then(|i| i.symbol.clone()),
+                    decimals: buy_token_metadata.and_then(|m| m.decimals),
+                    symbol: buy_token_metadata.and_then(|m| m.symbol.clone()),
                     address: self.tokens.buy,
                     price: None,
-                    available_balance: Default::default(),
+                    available_balance: buy_token_metadata.map(|m| m.balance.0).unwrap_or_default(),
                     trusted: false,
                 },
             ]

--- a/crates/driver/src/domain/quote.rs
+++ b/crates/driver/src/domain/quote.rs
@@ -131,16 +131,16 @@ impl Order {
             }],
             [
                 auction::Token {
-                    decimals: sell_token_metadata.map(|i| i.decimals),
-                    symbol: sell_token_metadata.map(|i| i.symbol.clone()),
+                    decimals: sell_token_metadata.and_then(|i| i.decimals),
+                    symbol: sell_token_metadata.and_then(|i| i.symbol.clone()),
                     address: self.tokens.sell,
                     price: None,
                     available_balance: Default::default(),
                     trusted: false,
                 },
                 auction::Token {
-                    decimals: buy_token_metadata.map(|i| i.decimals),
-                    symbol: buy_token_metadata.map(|i| i.symbol.clone()),
+                    decimals: buy_token_metadata.and_then(|i| i.decimals),
+                    symbol: buy_token_metadata.and_then(|i| i.symbol.clone()),
                     address: self.tokens.buy,
                     price: None,
                     available_balance: Default::default(),

--- a/crates/driver/src/infra/api/routes/solve/dto/auction.rs
+++ b/crates/driver/src/infra/api/routes/solve/dto/auction.rs
@@ -5,7 +5,7 @@ use {
             competition::{auction, order},
             eth,
         },
-        infra::Ethereum,
+        infra::{tokens, Ethereum},
         util::serialize,
     },
     itertools::Itertools,
@@ -14,7 +14,18 @@ use {
 };
 
 impl Auction {
-    pub async fn into_domain(self, eth: &Ethereum) -> Result<competition::Auction, Error> {
+    pub async fn into_domain(
+        self,
+        eth: &Ethereum,
+        tokens: &tokens::Fetcher,
+    ) -> Result<competition::Auction, Error> {
+        let token_addresses: Vec<_> = self
+            .tokens
+            .iter()
+            .map(|token| token.address.into())
+            .collect();
+        let token_infos = tokens.get(&token_addresses).await;
+
         competition::Auction::new(
             Some(self.id.try_into()?),
             self.orders
@@ -109,16 +120,17 @@ impl Auction {
                     })
                 })
                 .try_collect::<_, Vec<_>, Error>()?,
-            self.tokens
-                .into_iter()
-                .map(|token| competition::auction::Token {
-                    decimals: token.decimals,
-                    symbol: token.symbol,
+            self.tokens.into_iter().map(|token| {
+                let info = token_infos.get(&token.address.into());
+                competition::auction::Token {
+                    decimals: info.map(|i| i.decimals),
+                    symbol: info.map(|i| i.symbol.clone()),
                     address: token.address.into(),
                     price: token.price.map(Into::into),
-                    available_balance: Default::default(),
+                    available_balance: info.map(|i| i.balance).unwrap_or(0.into()).into(),
                     trusted: token.trusted,
-                }),
+                }
+            }),
             eth.gas_price().await.map_err(Error::GasPrice)?,
             self.deadline.into(),
             eth.contracts().weth_address(),
@@ -176,8 +188,6 @@ struct Token {
     #[serde_as(as = "Option<serialize::U256>")]
     pub price: Option<eth::U256>,
     pub trusted: bool,
-    pub decimals: Option<u8>,
-    pub symbol: Option<String>,
 }
 
 #[serde_as]

--- a/crates/driver/src/infra/api/routes/solve/dto/auction.rs
+++ b/crates/driver/src/infra/api/routes/solve/dto/auction.rs
@@ -123,8 +123,8 @@ impl Auction {
             self.tokens.into_iter().map(|token| {
                 let info = token_infos.get(&token.address.into());
                 competition::auction::Token {
-                    decimals: info.map(|i| i.decimals),
-                    symbol: info.map(|i| i.symbol.clone()),
+                    decimals: info.and_then(|i| i.decimals),
+                    symbol: info.and_then(|i| i.symbol.clone()),
                     address: token.address.into(),
                     price: token.price.map(Into::into),
                     available_balance: info.map(|i| i.balance).unwrap_or(0.into()).into(),

--- a/crates/driver/src/infra/api/routes/solve/mod.rs
+++ b/crates/driver/src/infra/api/routes/solve/mod.rs
@@ -20,9 +20,13 @@ async fn route(
 ) -> Result<axum::Json<dto::Solution>, (hyper::StatusCode, axum::Json<Error>)> {
     let auction_id = auction.id();
     let handle_request = async {
-        let auction = auction.0.into_domain(state.eth()).await.tap_err(|err| {
-            observe::invalid_dto(err, "auction");
-        })?;
+        let auction = auction
+            .0
+            .into_domain(state.eth(), state.tokens())
+            .await
+            .tap_err(|err| {
+                observe::invalid_dto(err, "auction");
+            })?;
         observe::auction(&auction);
         let competition = state.competition();
         let result = competition.solve(&auction).await;

--- a/crates/driver/src/infra/blockchain/mod.rs
+++ b/crates/driver/src/infra/blockchain/mod.rs
@@ -171,8 +171,8 @@ impl Ethereum {
         erc20.methods().symbol().call().await.map_err(Into::into)
     }
 
-    /// Returns the current [`eth::TokenAmount`] balance of the specified account for
-    /// a given token.
+    /// Returns the current [`eth::TokenAmount`] balance of the specified
+    /// account for a given token.
     pub async fn erc20_balance(
         &self,
         holder: eth::Address,

--- a/crates/driver/src/infra/blockchain/mod.rs
+++ b/crates/driver/src/infra/blockchain/mod.rs
@@ -161,14 +161,34 @@ impl Ethereum {
             .map_err(Into::into)
     }
 
-    pub async fn decimals(&self, token: eth::TokenAddress) -> Result<u8, Error> {
+    /// Returns the token's decimals. Returns `None` if the token does not
+    /// implement this optional method.
+    pub async fn decimals(&self, token: eth::TokenAddress) -> Result<Option<u8>, Error> {
         let erc20 = self.contract_at::<contracts::ERC20>(token.0);
-        erc20.methods().decimals().call().await.map_err(Into::into)
+        match erc20.methods().decimals().call().await {
+            // the token does not implement the optional `decimals()` method
+            Err(ethcontract::errors::MethodError {
+                inner: ethcontract::errors::ExecutionError::Revert(_),
+                ..
+            }) => Ok(None),
+            Err(err) => Err(err.into()),
+            Ok(decimals) => Ok(Some(decimals)),
+        }
     }
 
-    pub async fn symbol(&self, token: eth::TokenAddress) -> Result<String, Error> {
+    /// Returns the token's symbol. Returns `None` if the token does not
+    /// implement this optional method.
+    pub async fn symbol(&self, token: eth::TokenAddress) -> Result<Option<String>, Error> {
         let erc20 = self.contract_at::<contracts::ERC20>(token.0);
-        erc20.methods().symbol().call().await.map_err(Into::into)
+        match erc20.methods().symbol().call().await {
+            // the token does not implement the optional `symbol()` method
+            Err(ethcontract::errors::MethodError {
+                inner: ethcontract::errors::ExecutionError::Revert(_),
+                ..
+            }) => Ok(None),
+            Err(err) => Err(err.into()),
+            Ok(decimals) => Ok(Some(decimals)),
+        }
     }
 
     /// Returns the current [`eth::TokenAmount`] balance of the specified

--- a/crates/driver/src/infra/blockchain/mod.rs
+++ b/crates/driver/src/infra/blockchain/mod.rs
@@ -161,14 +161,31 @@ impl Ethereum {
             .map_err(Into::into)
     }
 
-    pub async fn decimals(&self, address: eth::TokenAddress) -> Result<u8, Error> {
-        let erc20 = self.contract_at::<contracts::ERC20>(address.0);
+    pub async fn decimals(&self, token: eth::TokenAddress) -> Result<u8, Error> {
+        let erc20 = self.contract_at::<contracts::ERC20>(token.0);
         erc20.methods().decimals().call().await.map_err(Into::into)
     }
 
-    pub async fn symbol(&self, address: eth::TokenAddress) -> Result<String, Error> {
-        let erc20 = self.contract_at::<contracts::ERC20>(address.0);
+    pub async fn symbol(&self, token: eth::TokenAddress) -> Result<String, Error> {
+        let erc20 = self.contract_at::<contracts::ERC20>(token.0);
         erc20.methods().symbol().call().await.map_err(Into::into)
+    }
+
+    /// Returns the current [`eth::TokenAmount`] balance of the specified account for
+    /// a given token.
+    pub async fn erc20_balance(
+        &self,
+        holder: eth::Address,
+        token: eth::TokenAddress,
+    ) -> Result<eth::TokenAmount, Error> {
+        let erc20 = self.contract_at::<contracts::ERC20>(token.0);
+        erc20
+            .methods()
+            .balance_of(holder.0)
+            .call()
+            .await
+            .map(Into::into)
+            .map_err(Into::into)
     }
 }
 

--- a/crates/driver/src/infra/blockchain/mod.rs
+++ b/crates/driver/src/infra/blockchain/mod.rs
@@ -160,53 +160,6 @@ impl Ethereum {
             .map(Into::into)
             .map_err(Into::into)
     }
-
-    /// Returns the token's decimals. Returns `None` if the token does not
-    /// implement this optional method.
-    pub async fn decimals(&self, token: eth::TokenAddress) -> Result<Option<u8>, Error> {
-        let erc20 = self.contract_at::<contracts::ERC20>(token.0);
-        match erc20.methods().decimals().call().await {
-            // the token does not implement the optional `decimals()` method
-            Err(ethcontract::errors::MethodError {
-                inner: ethcontract::errors::ExecutionError::Revert(_),
-                ..
-            }) => Ok(None),
-            Err(err) => Err(err.into()),
-            Ok(decimals) => Ok(Some(decimals)),
-        }
-    }
-
-    /// Returns the token's symbol. Returns `None` if the token does not
-    /// implement this optional method.
-    pub async fn symbol(&self, token: eth::TokenAddress) -> Result<Option<String>, Error> {
-        let erc20 = self.contract_at::<contracts::ERC20>(token.0);
-        match erc20.methods().symbol().call().await {
-            // the token does not implement the optional `symbol()` method
-            Err(ethcontract::errors::MethodError {
-                inner: ethcontract::errors::ExecutionError::Revert(_),
-                ..
-            }) => Ok(None),
-            Err(err) => Err(err.into()),
-            Ok(decimals) => Ok(Some(decimals)),
-        }
-    }
-
-    /// Returns the current [`eth::TokenAmount`] balance of the specified
-    /// account for a given token.
-    pub async fn erc20_balance(
-        &self,
-        holder: eth::Address,
-        token: eth::TokenAddress,
-    ) -> Result<eth::TokenAmount, Error> {
-        let erc20 = self.contract_at::<contracts::ERC20>(token.0);
-        erc20
-            .methods()
-            .balance_of(holder.0)
-            .call()
-            .await
-            .map(Into::into)
-            .map_err(Into::into)
-    }
 }
 
 impl fmt::Debug for Ethereum {

--- a/crates/driver/src/infra/tokens.rs
+++ b/crates/driver/src/infra/tokens.rs
@@ -6,8 +6,8 @@ use {
 
 #[derive(Clone, Debug)]
 pub struct Metadata {
-    pub decimals: u8,
-    pub symbol: String,
+    pub decimals: Option<u8>,
+    pub symbol: Option<String>,
     /// Current balance of the smart contract.
     pub balance: eth::TokenAmount,
 }

--- a/crates/driver/src/tests/setup/solver.rs
+++ b/crates/driver/src/tests/setup/solver.rs
@@ -160,39 +160,37 @@ impl Solver {
             }));
         }
 
-        let tokens_json = config
+        let build_tokens = config
             .solutions
             .iter()
             .flat_map(|s| s.fulfillments.iter())
             .flat_map(|f| {
                 let quote = &f.quoted_order;
+                let build_token = |token_name: String| async move {
+                    let token = config.blockchain.get_token_wrapped(token_name.as_str());
+                    let contract = contracts::ERC20::at(&config.blockchain.web3, token);
+                    let settlement = config.blockchain.settlement.address();
+                    (
+                        hex_address(token),
+                        json!({
+                            "decimals": contract.decimals().call().await.ok(),
+                            "symbol": contract.symbol().call().await.ok(),
+                            "referencePrice": if config.quote { None } else { Some("1000000000000000000") },
+                            // available balance might break if one test settles 2 auctions after
+                            // another
+                            "availableBalance": contract.balance_of(settlement).call().await.unwrap().to_string(),
+                            "trusted": config.trusted.contains(token_name.as_str()),
+                        }),
+                    )
+                };
                 [
-                    (
-                        hex_address(
-                            config.blockchain.get_token_wrapped(quote.order.sell_token),
-                        ),
-                        json!({
-                            "decimals": null,
-                            "symbol": null,
-                            "referencePrice": if config.quote { None } else { Some("1000000000000000000") },
-                            // TODO put the correct value here
-                            "availableBalance": "0",
-                            "trusted": config.trusted.contains(quote.order.sell_token),
-                        }),
-                    ),
-                    (
-                        hex_address(config.blockchain.get_token_wrapped(quote.order.buy_token)),
-                        json!({
-                            "decimals": null,
-                            "symbol": null,
-                            "referencePrice": if config.quote { None } else { Some("1000000000000000000") },
-                            // TODO put the correct value here
-                            "availableBalance": "0",
-                            "trusted": config.trusted.contains(quote.order.buy_token),
-                        }),
-                    ),
+                    build_token(quote.order.sell_token.to_string()),
+                    build_token(quote.order.buy_token.to_string()),
                 ]
-            })
+            });
+        let tokens_json = futures::future::join_all(build_tokens)
+            .await
+            .into_iter()
             .collect::<HashMap<_, _>>();
 
         let url = config.blockchain.web3_url.parse().unwrap();

--- a/crates/driver/src/tests/setup/solver.rs
+++ b/crates/driver/src/tests/setup/solver.rs
@@ -175,6 +175,7 @@ impl Solver {
                             "decimals": null,
                             "symbol": null,
                             "referencePrice": if config.quote { None } else { Some("1000000000000000000") },
+                            // TODO put the correct value here
                             "availableBalance": "0",
                             "trusted": config.trusted.contains(quote.order.sell_token),
                         }),
@@ -185,6 +186,7 @@ impl Solver {
                             "decimals": null,
                             "symbol": null,
                             "referencePrice": if config.quote { None } else { Some("1000000000000000000") },
+                            // TODO put the correct value here
                             "availableBalance": "0",
                             "trusted": config.trusted.contains(quote.order.buy_token),
                         }),


### PR DESCRIPTION
Follow up to https://github.com/cowprotocol/services/pull/1770

As discussed [here](https://github.com/cowprotocol/services/pull/1770#pullrequestreview-1581196291) it's more correct to move all the fetching of all token metadata that only enables certain optimisations but are not part of the core protocol into the driver.

### Test Plan
e2e tests