### PR TITLE
Remove number-conversion dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1645,7 +1645,6 @@ dependencies = [
  "mockall",
  "model",
  "num",
- "number-conversions",
  "primitive-types",
  "prometheus",
  "prometheus-metric-storage",

--- a/crates/driver/Cargo.toml
+++ b/crates/driver/Cargo.toml
@@ -59,7 +59,6 @@ contracts = { path = "../contracts" }
 ethcontract = { workspace = true }
 gas-estimation = { workspace = true }
 model = { path = "../model" }
-number-conversions = { path = "../number-conversions" }
 shared = { path = "../shared" }
 solver = { path = "../solver" }
 tracing = { workspace = true }

--- a/crates/driver/src/boundary/settlement.rs
+++ b/crates/driver/src/boundary/settlement.rs
@@ -14,6 +14,7 @@ use {
             liquidity,
         },
         infra::Ethereum,
+        util::conv::u256::U256Ext,
     },
     anyhow::{anyhow, ensure, Context, Result},
     bigdecimal::Signed,
@@ -35,7 +36,6 @@ use {
         signature::EcdsaSignature,
         DomainSeparator,
     },
-    number_conversions::{big_rational_to_u256, u256_to_big_rational},
     shared::{
         external_prices::ExternalPrices,
         http_solver::model::{InternalizationStrategy, TokenAmount},
@@ -213,7 +213,7 @@ impl Settlement {
                 })
                 .collect(),
         )?;
-        let gas_price = u256_to_big_rational(&auction.gas_price().effective().into());
+        let gas_price = eth::U256::from(auction.gas_price().effective()).to_big_rational();
         let inputs = solver::objective_value::Inputs::from_settlement(
             &self.inner,
             &prices,
@@ -221,7 +221,7 @@ impl Settlement {
             &gas.into(),
         );
         ensure!(!inputs.objective_value().is_negative(), "negative score");
-        let objective_value = big_rational_to_u256(&inputs.objective_value())?;
+        let objective_value = eth::U256::from_big_rational(&inputs.objective_value())?;
         Ok((objective_value - self.risk.0).into())
     }
 

--- a/crates/driver/src/domain/competition/order/mod.rs
+++ b/crates/driver/src/domain/competition/order/mod.rs
@@ -1,7 +1,7 @@
 use crate::{
     domain::eth,
     infra::{blockchain, Ethereum},
-    util::{self, conv, Bytes},
+    util::{self, conv::u256::U256Ext, Bytes},
 };
 
 pub mod signature;
@@ -163,8 +163,9 @@ impl Order {
             (Some(buy_price), Some(sell_price)) => {
                 let buy = buy_price.apply(self.buy.amount);
                 let sell = sell_price.apply(self.sell.amount);
-                conv::u256::to_big_rational(buy.0)
-                    .checked_div(&conv::u256::to_big_rational(sell.0))
+                buy.0
+                    .to_big_rational()
+                    .checked_div(&sell.0.to_big_rational())
                     .unwrap_or_else(num::BigRational::zero)
             }
             _ => num::BigRational::zero(),

--- a/crates/driver/src/domain/competition/solution/trade.rs
+++ b/crates/driver/src/domain/competition/solution/trade.rs
@@ -1,9 +1,9 @@
-use {
-    crate::domain::{
+use crate::{
+    domain::{
         competition::{self, order},
         eth,
     },
-    shared::conversions::U256Ext,
+    util::conv::u256::U256Ext,
 };
 
 /// A trade which executes an order as part of this solution.

--- a/crates/driver/src/domain/quote.rs
+++ b/crates/driver/src/domain/quote.rs
@@ -12,7 +12,7 @@ use {
             blockchain::{self, Ethereum},
             solver::{self, Solver},
         },
-        util::{self, conv},
+        util::{self, conv::u256::U256Ext},
     },
     std::{collections::HashSet, iter},
 };
@@ -36,16 +36,14 @@ impl Quote {
             .clearing_price(order.tokens.buy)
             .ok_or(QuotingFailed::ClearingBuyMissing)?;
         let amount = match order.side {
-            order::Side::Sell => conv::u256::from_big_rational(
-                &(conv::u256::to_big_rational(order.amount.into())
-                    * conv::u256::to_big_rational(sell_price)
-                    / conv::u256::to_big_rational(buy_price)),
-            ),
-            order::Side::Buy => conv::u256::from_big_rational(
-                &(conv::u256::to_big_rational(order.amount.into())
-                    * conv::u256::to_big_rational(buy_price)
-                    / conv::u256::to_big_rational(sell_price)),
-            ),
+            order::Side::Sell => eth::U256::from_big_rational(
+                &(eth::U256::from(order.amount).to_big_rational() * sell_price.to_big_rational()
+                    / buy_price.to_big_rational()),
+            )?,
+            order::Side::Buy => eth::U256::from_big_rational(
+                &(eth::U256::from(order.amount).to_big_rational() * buy_price.to_big_rational()
+                    / sell_price.to_big_rational()),
+            )?,
         };
         Ok(Self {
             amount,

--- a/crates/driver/src/infra/solver/dto/auction.rs
+++ b/crates/driver/src/infra/solver/dto/auction.rs
@@ -1,10 +1,12 @@
 use {
     crate::{
         domain::{competition, competition::order, eth, liquidity},
-        util::serialize,
+        util::{
+            conv::{rational_to_big_decimal, u256::U256Ext},
+            serialize,
+        },
     },
     indexmap::IndexMap,
-    number_conversions::{rational_to_big_decimal, u256_to_big_int},
     serde::Serialize,
     serde_with::serde_as,
     std::collections::{BTreeMap, HashMap},
@@ -134,10 +136,13 @@ impl Auction {
                             })
                             .collect(),
                         amplification_parameter: rational_to_big_decimal(&num::BigRational::new(
-                            u256_to_big_int(&pool.amplification_parameter.factor()),
-                            u256_to_big_int(&pool.amplification_parameter.precision()),
+                            pool.amplification_parameter.factor().to_big_int(),
+                            pool.amplification_parameter.precision().to_big_int(),
                         )),
-                        fee: bigdecimal::BigDecimal::new(u256_to_big_int(&pool.fee.into()), 18),
+                        fee: bigdecimal::BigDecimal::new(
+                            eth::U256::from(pool.fee).to_big_int(),
+                            18,
+                        ),
                     }),
                     liquidity::Kind::BalancerV2Weighted(pool) => {
                         Liquidity::WeightedProduct(WeightedProductPool {
@@ -154,14 +159,17 @@ impl Auction {
                                             balance: r.asset.amount.into(),
                                             scaling_factor: r.scale.factor(),
                                             weight: bigdecimal::BigDecimal::new(
-                                                u256_to_big_int(&r.weight.into()),
+                                                eth::U256::from(r.weight).to_big_int(),
                                                 18,
                                             ),
                                         },
                                     )
                                 })
                                 .collect(),
-                            fee: bigdecimal::BigDecimal::new(u256_to_big_int(&pool.fee.into()), 18),
+                            fee: bigdecimal::BigDecimal::new(
+                                eth::U256::from(pool.fee).to_big_int(),
+                                18,
+                            ),
                         })
                     }
                     liquidity::Kind::Swapr(pool) => {

--- a/crates/driver/src/util/conv/mod.rs
+++ b/crates/driver/src/util/conv/mod.rs
@@ -1,1 +1,11 @@
 pub mod u256;
+
+pub fn rational_to_big_decimal<T>(value: &num::rational::Ratio<T>) -> bigdecimal::BigDecimal
+where
+    T: Clone,
+    num::BigInt: From<T>,
+{
+    let numer = num::BigInt::from(value.numer().clone());
+    let denom = num::BigInt::from(value.denom().clone());
+    bigdecimal::BigDecimal::new(numer, 0) / bigdecimal::BigDecimal::new(denom, 0)
+}

--- a/crates/driver/src/util/conv/u256.rs
+++ b/crates/driver/src/util/conv/u256.rs
@@ -1,31 +1,56 @@
-use {crate::domain::eth, bigdecimal::Zero};
+use {crate::domain::eth, anyhow::Result, bigdecimal::Zero};
 
-fn to_big_uint(value: eth::U256) -> num::BigUint {
-    let mut bytes = [0; 32];
-    value.to_big_endian(&mut bytes);
-    num::BigUint::from_bytes_be(&bytes)
+pub trait U256Ext: Sized {
+    fn to_big_int(&self) -> num::BigInt;
+    fn to_big_uint(&self) -> num::BigUint;
+    fn to_big_rational(&self) -> num::BigRational;
+
+    fn checked_ceil_div(&self, other: &Self) -> Option<Self>;
+    fn ceil_div(&self, other: &Self) -> Self;
+
+    fn from_big_int(input: &num::BigInt) -> Result<Self>;
+    fn from_big_uint(input: &num::BigUint) -> Result<Self>;
+    fn from_big_rational(value: &num::BigRational) -> Result<Self>;
 }
 
-pub fn to_big_int(value: eth::U256) -> num::BigInt {
-    num::BigInt::from_biguint(num::bigint::Sign::Plus, to_big_uint(value))
-}
+impl U256Ext for eth::U256 {
+    fn to_big_int(&self) -> num::BigInt {
+        num::BigInt::from_biguint(num::bigint::Sign::Plus, self.to_big_uint())
+    }
 
-pub fn to_big_rational(value: eth::U256) -> num::BigRational {
-    num::BigRational::new(to_big_int(value), 1.into())
-}
+    fn to_big_uint(&self) -> num::BigUint {
+        let mut bytes = [0; 32];
+        self.to_big_endian(&mut bytes);
+        num::BigUint::from_bytes_be(&bytes)
+    }
 
-fn from_big_uint(input: &num::BigUint) -> eth::U256 {
-    let bytes = input.to_bytes_be();
-    assert!(bytes.len() <= 32, "too large");
-    eth::U256::from_big_endian(&bytes)
-}
+    fn to_big_rational(&self) -> num::BigRational {
+        num::BigRational::new(self.to_big_int(), 1.into())
+    }
 
-fn from_big_int(input: &num::BigInt) -> eth::U256 {
-    assert!(input.sign() != num::bigint::Sign::Minus, "negative");
-    from_big_uint(input.magnitude())
-}
+    fn checked_ceil_div(&self, other: &Self) -> Option<Self> {
+        self.checked_add(other.checked_sub(1.into())?)?
+            .checked_div(*other)
+    }
 
-pub fn from_big_rational(value: &num::BigRational) -> eth::U256 {
-    assert!(*value.denom() != num::BigInt::zero(), "zero denominator");
-    from_big_int(&(value.numer() / value.denom()))
+    fn ceil_div(&self, other: &Self) -> Self {
+        self.checked_ceil_div(other)
+            .expect("ceiling division arithmetic error")
+    }
+
+    fn from_big_int(input: &num::BigInt) -> Result<eth::U256> {
+        anyhow::ensure!(input.sign() != num::bigint::Sign::Minus, "negative");
+        Self::from_big_uint(input.magnitude())
+    }
+
+    fn from_big_uint(input: &num::BigUint) -> Result<Self> {
+        let bytes = input.to_bytes_be();
+        anyhow::ensure!(bytes.len() <= 32, "too large");
+        Ok(eth::U256::from_big_endian(&bytes))
+    }
+
+    fn from_big_rational(value: &num::BigRational) -> Result<Self> {
+        anyhow::ensure!(*value.denom() != num::BigInt::zero(), "zero denominator");
+        Self::from_big_int(&(value.numer() / value.denom()))
+    }
 }


### PR DESCRIPTION
The driver should rely less and less on shared crates.
This PR removes the dependency on the `number-conversion` crate.
Also instead of having free functions for everything I moved the conversion logic into the `U256Ext` trait to make things a bit nicer to read (hopefully).

`conv::u256` and the remaining code relied on 3 functions that were still missing in the driver crate. These have been copied from `number-conversions`.

### Test Plan
CI, e2e tests
