### PR TITLE
Per solver liquidity

### DIFF
--- a/crates/driver/example.toml
+++ b/crates/driver/example.toml
@@ -41,13 +41,6 @@ base-tokens = [
 # router = "0xb9960d9bca016e9748be75dd52f02188b9d0829f"
 # pool-code = "0xd306a548755b9295ee49cc729e13ca4a45e00199bbd890fa146da43a50571776"
 
-# [[liquidity.uniswap-v2]] # Uniswap V2 configuration
-# preset = "uniswap-v2" # or "sushi-swap", "honeyswap", "baoswap", "pancake-swap", etc.
-
-# [[liquidity.uniswap-v2]] # Custom Uniswap V2 configuration
-# router = "0x7a250d5630B4cF539739dF2C5dAcb4c659F2488D"
-# pool-code = "0x96e8ac4277198ff8b6f785478aa9a39f403cb768dd02cbee326c3e7da348845f"
-
 # [[liquidity.balancer-v2]] # Balancer V2 configuration
 # preset = "balancer-v2"
 # pool-deny-list = [] # optional
@@ -61,9 +54,9 @@ base-tokens = [
 
 # [[liquidity.uniswap-v3]] # Uniswap V3 configuration
 # preset = "uniswap-v3"
-# max_pools_to_initialize = 100 # how many of the deepest pools to initialise on startup
+# max-pools-to-initialize = 100 # how many of the deepest pools to initialise on startup
 
 # [[liquidity.uniswap-v3]] # Custom Uniswap V3 configuration
 # router = "0xE592427A0AEce92De3Edee1F18E0157C05861564"
-# max_pools_to_initialize = 100 # how many of the deepest pools to initialise on startup
+# max-pools-to-initialize = 100 # how many of the deepest pools to initialise on startup
 

--- a/crates/driver/example.toml
+++ b/crates/driver/example.toml
@@ -4,6 +4,9 @@ endpoint = "http://0.0.0.0:7872"
 absolute-slippage = "40000000000000000" # Denominated in wei, optional
 relative-slippage = "0.1" # Percentage in the [0, 1] range
 account = "0x0000000000000000000000000000000000000000000000000000000000000001" # The private key of the solver
+# Optional flag to control whether the driver actually sends any liquidity to the solver.
+# This is only needed if you are running a single driver for multiple solvers that have different expectations.
+# requires-driver-liquidity = false
 
 # [[solver]] # And so on, specify as many solvers as needed
 # name = "othersolver"

--- a/crates/driver/src/domain/quote.rs
+++ b/crates/driver/src/domain/quote.rs
@@ -76,7 +76,10 @@ impl Order {
         liquidity: &infra::liquidity::Fetcher,
         tokens: &infra::tokens::Fetcher,
     ) -> Result<Quote, Error> {
-        let liquidity = liquidity.fetch(&self.liquidity_pairs()).await;
+        let liquidity = match solver.requires_driver_liquidity() {
+            true => liquidity.fetch(&self.liquidity_pairs()).await,
+            false => vec![],
+        };
         let gas_price = eth.gas_price().await?;
         let timeout = self.deadline.timeout()?;
         let fake_auction = self

--- a/crates/driver/src/infra/config/file/load.rs
+++ b/crates/driver/src/infra/config/file/load.rs
@@ -41,6 +41,7 @@ pub async fn load(path: &Path) -> infra::Config {
                     absolute: config.absolute_slippage.map(Into::into),
                 },
                 account,
+                requires_driver_liquidity: config.requires_driver_liquidity,
             }
         }))
         .await,

--- a/crates/driver/src/infra/config/file/mod.rs
+++ b/crates/driver/src/infra/config/file/mod.rs
@@ -135,6 +135,10 @@ fn default_soft_cancellations_flag() -> bool {
     false
 }
 
+fn default_solver_specific_liquidity() -> bool {
+    true
+}
+
 #[serde_as]
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "kebab-case", deny_unknown_fields)]
@@ -157,6 +161,11 @@ struct SolverConfig {
 
     /// The account which should be used to sign settlements for this solver.
     account: Account,
+
+    /// Whether or not this specific solver relies on the liquidity provided by
+    /// the driver.
+    #[serde(default = "default_solver_specific_liquidity")]
+    requires_driver_liquidity: bool,
 }
 
 #[serde_as]

--- a/crates/driver/src/infra/solver/mod.rs
+++ b/crates/driver/src/infra/solver/mod.rs
@@ -68,6 +68,10 @@ pub struct Config {
     pub slippage: Slippage,
     /// The private key of this solver, used for settlement submission.
     pub account: ethcontract::Account,
+    /// Should the collected liquidity not be sent with the `/solve` request?
+    /// This option only makes sense if you run a single driver for multiple
+    /// solvers.
+    pub requires_driver_liquidity: bool,
 }
 
 impl Solver {
@@ -154,6 +158,19 @@ impl Solver {
         observe::solutions(&solutions);
         Ok(solutions)
     }
+
+    /// Whether the solver needs any provided liquidity to work.
+    pub fn requires_driver_liquidity(&self) -> bool {
+        self.config.requires_driver_liquidity
+    }
+}
+
+#[derive(Copy, Debug, Clone)]
+pub enum Liquidity {
+    /// The solver relies on liquidity provided by the driver.
+    Required,
+    /// The solver does not rely on any liquidity the driver provides.
+    Ignored,
 }
 
 #[derive(Debug, Error)]


### PR DESCRIPTION
External solvers already complained that they would rather not receive any liquidity in their `/solve` requests.
This PR makes it so that we can control that behavior on a per-solver bases in the driver's `config.toml` file.

I preferred this approach because this distinction only makes sense if you have a single driver serving multiple solvers. We will most likely be the only ones doing that and our solvers don't support only a subset of liquidity so this simple flag is sufficient.

### Test Plan
Manual local test