### PR TITLE
Refactor ERC-20 Interactions in Driver

### DIFF
--- a/crates/driver/src/boundary/quote.rs
+++ b/crates/driver/src/boundary/quote.rs
@@ -37,15 +37,15 @@ pub fn encode_interactions(
             settlement
                 .encoder
                 .append_to_execution_plan(Arc::new(Erc20ApproveInteraction {
-                    token: eth.contract_at(allowance.0.spender.token.into()),
-                    spender: allowance.0.spender.address.into(),
+                    token: eth.contract_at(allowance.0.token.into()),
+                    spender: allowance.0.spender.into(),
                     amount: eth::U256::zero(),
                 }));
             settlement
                 .encoder
                 .append_to_execution_plan(Arc::new(Erc20ApproveInteraction {
-                    token: eth.contract_at(allowance.0.spender.token.into()),
-                    spender: allowance.0.spender.address.into(),
+                    token: eth.contract_at(allowance.0.token.into()),
+                    spender: allowance.0.spender.into(),
                     amount: eth::U256::max_value(),
                 }));
         }

--- a/crates/driver/src/boundary/settlement.rs
+++ b/crates/driver/src/boundary/settlement.rs
@@ -123,8 +123,8 @@ impl Settlement {
             settlement
                 .encoder
                 .append_to_execution_plan(Arc::new(Erc20ApproveInteraction {
-                    token: eth.contract_at(approval.0.spender.token.into()),
-                    spender: approval.0.spender.address.into(),
+                    token: eth.contract_at(approval.0.token.into()),
+                    spender: approval.0.spender.into(),
                     amount: approval.0.amount,
                 }));
         }

--- a/crates/driver/src/domain/competition/solution/interaction.rs
+++ b/crates/driver/src/domain/competition/solution/interaction.rs
@@ -39,7 +39,7 @@ impl Interaction {
         }
     }
 
-    /// Returns the ERC20 allowances required for executing this interaction
+    /// Returns the ERC20 approvals required for executing this interaction
     /// onchain.
     pub fn allowances(&self) -> Vec<eth::allowance::Required> {
         match self {
@@ -54,10 +54,8 @@ impl Interaction {
                     liquidity::Kind::ZeroEx(_) => todo!(),
                 };
                 vec![eth::Allowance {
-                    spender: eth::allowance::Spender {
-                        address,
-                        token: interaction.input.token,
-                    },
+                    token: interaction.input.token,
+                    spender: address,
                     amount: interaction.input.amount.into(),
                 }
                 .into()]

--- a/crates/driver/src/domain/eth/allowance.rs
+++ b/crates/driver/src/domain/eth/allowance.rs
@@ -1,20 +1,16 @@
-use super::{Address, TokenAddress};
+use super::{Address, TokenAddress, U256};
 
 /// An ERC20 allowance.
 ///
 /// https://eips.ethereum.org/EIPS/eip-20
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Allowance {
-    pub spender: Spender,
-    pub amount: super::U256,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct Spender {
-    /// The spender address.
-    pub address: Address,
-    /// The token being spent.
+    /// The token for the allowance.
     pub token: TokenAddress,
+    /// The spender address.
+    pub spender: Address,
+    /// The amount for the allowance.
+    pub amount: U256,
 }
 
 /// An allowance that's already in effect, this essentially models the result of
@@ -60,7 +56,7 @@ impl Approval {
     /// [`U256::max_value`].
     pub fn max(self) -> Self {
         Self(Allowance {
-            amount: super::U256::max_value(),
+            amount: U256::max_value(),
             ..self.0
         })
     }

--- a/crates/driver/src/infra/blockchain/mod.rs
+++ b/crates/driver/src/infra/blockchain/mod.rs
@@ -9,6 +9,7 @@ use {
 };
 
 pub mod contracts;
+pub mod token;
 
 pub use self::contracts::Contracts;
 
@@ -61,22 +62,6 @@ impl Ethereum {
     /// Create a contract instance at the specified address.
     pub fn contract_at<T: ContractAt>(&self, address: eth::ContractAddress) -> T {
         T::at(self, address)
-    }
-
-    /// Fetch the ERC20 allowance for the spender. See the allowance method in
-    /// EIP-20.
-    ///
-    /// https://eips.ethereum.org/EIPS/eip-20#methods
-    pub async fn allowance(
-        &self,
-        owner: eth::Address,
-        spender: eth::allowance::Spender,
-    ) -> Result<eth::allowance::Existing, Error> {
-        let amount = contracts::ERC20::at(&self.web3, spender.token.into())
-            .allowance(owner.0, spender.address.0)
-            .call()
-            .await?;
-        Ok(eth::Allowance { spender, amount }.into())
     }
 
     /// Check if a smart contract is deployed to the given address.
@@ -153,6 +138,11 @@ impl Ethereum {
             .await
             .map(Into::into)
             .map_err(Into::into)
+    }
+
+    /// Returns a [`token::Erc20`] for the specified address.
+    pub fn erc20(&self, address: eth::TokenAddress) -> token::Erc20 {
+        token::Erc20::new(self.contract_at(address.into()))
     }
 }
 

--- a/crates/driver/src/infra/blockchain/token.rs
+++ b/crates/driver/src/infra/blockchain/token.rs
@@ -1,0 +1,85 @@
+use {super::Error, crate::domain::eth};
+
+/// An ERC-20 token.
+///
+/// https://eips.ethereum.org/EIPS/eip-20
+pub struct Erc20 {
+    contract: contracts::ERC20,
+}
+
+impl Erc20 {
+    pub(super) fn new(contract: contracts::ERC20) -> Self {
+        Self { contract }
+    }
+
+    /// Returns the [`eth::TokenAddress`] of the ERC20.
+    pub fn address(&self) -> eth::TokenAddress {
+        self.contract.address().into()
+    }
+
+    /// Fetch the ERC20 allowance for the spender. See the allowance method in
+    /// EIP-20.
+    ///
+    /// https://eips.ethereum.org/EIPS/eip-20#methods
+    pub async fn allowance(
+        &self,
+        owner: eth::Address,
+        spender: eth::Address,
+    ) -> Result<eth::allowance::Existing, Error> {
+        let amount = self.contract.allowance(owner.0, spender.0).call().await?;
+        Ok(eth::Allowance {
+            token: self.contract.address().into(),
+            spender,
+            amount,
+        }
+        .into())
+    }
+
+    /// Fetch the ERC20 token decimals. Returns `None` if the token does not
+    /// implement this optional method. See the decimals method in EIP-20.
+    ///
+    /// https://eips.ethereum.org/EIPS/eip-20#methods
+    pub async fn decimals(&self) -> Result<Option<u8>, Error> {
+        match self.contract.decimals().call().await {
+            Ok(decimals) => Ok(Some(decimals)),
+            Err(err) if is_contract_error(&err) => Ok(None),
+            Err(err) => Err(err.into()),
+        }
+    }
+
+    /// Fetch the ERC20 token symbol. Returns `None` if the token does not
+    /// implement this optional method. See the symbol method in EIP-20.
+    ///
+    /// https://eips.ethereum.org/EIPS/eip-20#methods
+    pub async fn symbol(&self) -> Result<Option<String>, Error> {
+        match self.contract.symbol().call().await {
+            Ok(symbol) => Ok(Some(symbol)),
+            Err(err) if is_contract_error(&err) => Ok(None),
+            Err(err) => Err(err.into()),
+        }
+    }
+
+    /// Fetch the ERC20 balance of the specified account. Returns the current
+    /// balance as an [`eth::TokenAmount`]. See the balanceOf method in EIP-20.
+    ///
+    /// https://eips.ethereum.org/EIPS/eip-20#methods
+    pub async fn balance(&self, holder: eth::Address) -> Result<eth::TokenAmount, Error> {
+        self.contract
+            .balance_of(holder.0)
+            .call()
+            .await
+            .map(Into::into)
+            .map_err(Into::into)
+    }
+}
+
+/// Returns `true` if a [`ethcontract::errors::MethodError`] is the result of
+/// some on-chain computation error.
+fn is_contract_error(err: &ethcontract::errors::MethodError) -> bool {
+    // Assume that any error that isn't a `Web3` error is a "contract error",
+    // this can mean things like:
+    // - The contract call reverted
+    // - The returndata cannot be decoded
+    // - etc.
+    !matches!(&err.inner, ethcontract::errors::ExecutionError::Web3(_))
+}

--- a/crates/driver/src/infra/blockchain/token.rs
+++ b/crates/driver/src/infra/blockchain/token.rs
@@ -20,7 +20,7 @@ impl Erc20 {
     /// Fetch the ERC20 allowance for the spender. See the allowance method in
     /// EIP-20.
     ///
-    /// https://eips.ethereum.org/EIPS/eip-20#methods
+    /// https://eips.ethereum.org/EIPS/eip-20#allowance
     pub async fn allowance(
         &self,
         owner: eth::Address,
@@ -38,7 +38,7 @@ impl Erc20 {
     /// Fetch the ERC20 token decimals. Returns `None` if the token does not
     /// implement this optional method. See the decimals method in EIP-20.
     ///
-    /// https://eips.ethereum.org/EIPS/eip-20#methods
+    /// https://eips.ethereum.org/EIPS/eip-20#decimals
     pub async fn decimals(&self) -> Result<Option<u8>, Error> {
         match self.contract.decimals().call().await {
             Ok(decimals) => Ok(Some(decimals)),
@@ -50,7 +50,7 @@ impl Erc20 {
     /// Fetch the ERC20 token symbol. Returns `None` if the token does not
     /// implement this optional method. See the symbol method in EIP-20.
     ///
-    /// https://eips.ethereum.org/EIPS/eip-20#methods
+    /// https://eips.ethereum.org/EIPS/eip-20#symbol
     pub async fn symbol(&self) -> Result<Option<String>, Error> {
         match self.contract.symbol().call().await {
             Ok(symbol) => Ok(Some(symbol)),
@@ -62,7 +62,7 @@ impl Erc20 {
     /// Fetch the ERC20 balance of the specified account. Returns the current
     /// balance as an [`eth::TokenAmount`]. See the balanceOf method in EIP-20.
     ///
-    /// https://eips.ethereum.org/EIPS/eip-20#methods
+    /// https://eips.ethereum.org/EIPS/eip-20#balanceof
     pub async fn balance(&self, holder: eth::Address) -> Result<eth::TokenAmount, Error> {
         self.contract
             .balance_of(holder.0)

--- a/crates/driver/src/infra/solver/dto/solution.rs
+++ b/crates/driver/src/infra/solver/dto/solution.rs
@@ -33,7 +33,9 @@ impl Solutions {
                                     .iter()
                                     .find(|order| order.uid == fulfillment.order)
                                     // TODO this error should reference the UID
-                                    .ok_or(super::Error("invalid order UID specified in fulfillment"))?
+                                    .ok_or(super::Error(
+                                        "invalid order UID specified in fulfillment"
+                                    ))?
                                     .clone();
 
                                 competition::solution::trade::Fulfillment::new(
@@ -141,10 +143,8 @@ impl Solutions {
                                             .into_iter()
                                             .map(|allowance| {
                                                 eth::Allowance {
-                                                    spender: eth::allowance::Spender {
-                                                        address: allowance.spender.into(),
-                                                        token: allowance.token.into(),
-                                                    },
+                                                    token: allowance.token.into(),
+                                                    spender: allowance.spender.into(),
                                                     amount: allowance.amount,
                                                 }
                                                 .into()
@@ -198,7 +198,10 @@ impl Solutions {
                     solver.clone(),
                     solution.risk.into(),
                     weth,
-                ).map_err(|competition::solution::InvalidClearingPrices| super::Error("invalid clearing prices"))
+                )
+                .map_err(|competition::solution::InvalidClearingPrices| {
+                    super::Error("invalid clearing prices")
+                })
             })
             .collect()
     }

--- a/crates/driver/src/infra/tokens.rs
+++ b/crates/driver/src/infra/tokens.rs
@@ -1,6 +1,8 @@
 use {
-    crate::{domain::eth, infra::Ethereum},
-    anyhow::Result,
+    crate::{
+        domain::eth,
+        infra::{blockchain, Ethereum},
+    },
     std::{
         collections::{HashMap, HashSet},
         sync::{Arc, RwLock},
@@ -44,71 +46,25 @@ struct Inner {
 }
 
 impl Inner {
-    /// Returns the token's decimals. Returns `None` if the token does not
-    /// implement this optional method.
-    async fn decimals(&self, token: eth::TokenAddress) -> Result<Option<u8>> {
-        let erc20 = self.eth.contract_at::<contracts::ERC20>(token.0);
-        match erc20.methods().decimals().call().await {
-            // the token does not implement the optional `decimals()` method
-            Err(ethcontract::errors::MethodError {
-                inner: ethcontract::errors::ExecutionError::Revert(_),
-                ..
-            }) => Ok(None),
-            Err(err) => Err(err.into()),
-            Ok(decimals) => Ok(Some(decimals)),
-        }
-    }
-
-    /// Returns the token's symbol. Returns `None` if the token does not
-    /// implement this optional method.
-    async fn symbol(&self, token: eth::TokenAddress) -> Result<Option<String>> {
-        let erc20 = self.eth.contract_at::<contracts::ERC20>(token.0);
-        match erc20.methods().symbol().call().await {
-            // the token does not implement the optional `symbol()` method
-            Err(ethcontract::errors::MethodError {
-                inner: ethcontract::errors::ExecutionError::Revert(_),
-                ..
-            }) => Ok(None),
-            Err(err) => Err(err.into()),
-            Ok(decimals) => Ok(Some(decimals)),
-        }
-    }
-
-    /// Returns the current [`eth::TokenAmount`] balance of the specified
-    /// account for a given token.
-    async fn balance(
-        &self,
-        holder: eth::Address,
-        token: eth::TokenAddress,
-    ) -> Result<eth::TokenAmount> {
-        let erc20 = self.eth.contract_at::<contracts::ERC20>(token.0);
-        erc20
-            .methods()
-            .balance_of(holder.0)
-            .call()
-            .await
-            .map(Into::into)
-            .map_err(Into::into)
-    }
-
     /// Fetches `Metadata` of the requested tokens from a node.
     async fn fetch_token_infos(
         &self,
         tokens: HashSet<eth::TokenAddress>,
-    ) -> Vec<Result<(eth::TokenAddress, Metadata)>> {
+    ) -> Vec<Result<(eth::TokenAddress, Metadata), blockchain::Error>> {
         let settlement = self.eth.contracts().settlement().address().into();
         let futures = tokens.into_iter().map(|token| async move {
+            let token = self.eth.erc20(token);
             // Use `try_join` because these calls get batched under the hood
             // so if one of them fails the others will as well.
             // Also this way we won't get incomplete data for a token.
             let (decimals, symbol, balance) = futures::future::try_join3(
-                self.decimals(token),
-                self.symbol(token),
-                self.balance(settlement, token),
+                token.decimals(),
+                token.symbol(),
+                token.balance(settlement),
             )
             .await?;
             Ok((
-                token,
+                token.address(),
                 Metadata {
                     decimals,
                     symbol,
@@ -119,13 +75,7 @@ impl Inner {
         futures::future::join_all(futures).await
     }
 
-    /// Returns the `Metadata` for the given tokens. Note that the result will
-    /// not contain data for tokens that encountered errors while fetching
-    /// the data.
-    pub async fn get(
-        &self,
-        addresses: &[eth::TokenAddress],
-    ) -> HashMap<eth::TokenAddress, Metadata> {
+    async fn get(&self, addresses: &[eth::TokenAddress]) -> HashMap<eth::TokenAddress, Metadata> {
         let to_fetch: HashSet<_> = {
             let cache = self.cache.read().unwrap();
 


### PR DESCRIPTION
This PR just proposes a small refactor in the `driver` to make code that uses ERC-20s easier. I also flattened the `Spender` type, since having the token tied to the spender felt a bit awkward.

It introduces a `blockchain::token::Erc20` type for fetching ERC-20 token information.

### Test Plan

Rust CI - tests continue to pass.
