### PR TITLE
Allow Balancer SOR solver on Gnosis Chain

### DIFF
--- a/crates/shared/src/balancer_sor_api.rs
+++ b/crates/shared/src/balancer_sor_api.rs
@@ -5,7 +5,7 @@
 
 use {
     crate::price_estimation::PriceEstimationError,
-    anyhow::{ensure, Context, Result},
+    anyhow::{Context, Result},
     ethcontract::{H160, H256, U256},
     model::{order::OrderKind, u256_decimal},
     num::BigInt,

--- a/crates/shared/src/balancer_sor_api.rs
+++ b/crates/shared/src/balancer_sor_api.rs
@@ -31,8 +31,6 @@ pub struct DefaultBalancerSorApi {
 impl DefaultBalancerSorApi {
     /// Creates a new Balancer SOR API instance.
     pub fn new(client: Client, base_url: impl IntoUrl, chain_id: u64) -> Result<Self> {
-        ensure!(chain_id == 1, "Balancer SOR API only supported on Mainnet",);
-
         let url = crate::url::join(&base_url.into_url()?, &chain_id.to_string());
         Ok(Self { client, url })
     }


### PR DESCRIPTION
It seems that the old Balancer SOR API is actually working on Gnosis Chain now. This would help us with a bunch of headaches around Karpatekey's liquidity provision needs as the SOR solver supports all Balancer pools.

### Test Plan

Run with orderbook on GChain with just Baseline and BalancerSor as estimators. See that selling WETH for wxDAI works (with Balancer being the winning solver). 

### Release notes

Once merged I plan to enable Balancer as a solver (and then price estimator) on staging
