### PR TITLE
Don't depend on shared::price_estimation

### DIFF
--- a/crates/driver/src/boundary/liquidity/balancer/v2/stable.rs
+++ b/crates/driver/src/boundary/liquidity/balancer/v2/stable.rs
@@ -6,14 +6,17 @@ use {
             liquidity::{self, balancer},
         },
     },
-    shared::price_estimation,
     solver::liquidity::{balancer_v2, StablePoolOrder},
 };
+
+/// Median gas used per BalancerSwapGivenOutInteraction.
+// estimated with https://dune.com/queries/639857
+const GAS_PER_SWAP: u64 = 88_892;
 
 pub fn to_domain(id: liquidity::Id, pool: StablePoolOrder) -> Result<liquidity::Liquidity> {
     Ok(liquidity::Liquidity {
         id,
-        gas: price_estimation::gas::GAS_PER_BALANCER_SWAP.into(),
+        gas: GAS_PER_SWAP.into(),
         kind: liquidity::Kind::BalancerV2Stable(balancer::v2::stable::Pool {
             vault: vault(&pool),
             id: pool_id(&pool),

--- a/crates/driver/src/boundary/liquidity/balancer/v2/weighted.rs
+++ b/crates/driver/src/boundary/liquidity/balancer/v2/weighted.rs
@@ -6,14 +6,17 @@ use {
             liquidity::{self, balancer},
         },
     },
-    shared::price_estimation,
     solver::liquidity::{balancer_v2, WeightedProductOrder},
 };
+
+/// Median gas used per BalancerSwapGivenOutInteraction.
+// estimated with https://dune.com/queries/639857
+const GAS_PER_SWAP: u64 = 88_892;
 
 pub fn to_domain(id: liquidity::Id, pool: WeightedProductOrder) -> Result<liquidity::Liquidity> {
     Ok(liquidity::Liquidity {
         id,
-        gas: price_estimation::gas::GAS_PER_BALANCER_SWAP.into(),
+        gas: GAS_PER_SWAP.into(),
         kind: liquidity::Kind::BalancerV2Weighted(balancer::v2::weighted::Pool {
             vault: vault(&pool),
             id: pool_id(&pool),

--- a/crates/driver/src/boundary/liquidity/swapr.rs
+++ b/crates/driver/src/boundary/liquidity/swapr.rs
@@ -6,7 +6,6 @@ use {
     },
     shared::{
         current_block::CurrentBlockStream,
-        price_estimation,
         sources::{swapr::reader::SwaprPoolReader, uniswap_v2::pool_fetching::DefaultPoolReader},
     },
     solver::{liquidity::ConstantProductOrder, liquidity_collector::LiquidityCollecting},
@@ -14,6 +13,10 @@ use {
 
 /// The base unit for basis points, i.e. how many basis points in 100%.
 const BPS_BASE: u32 = 10_000;
+
+/// Median gas used per UniswapInteraction (v2).
+// estimated with https://dune.com/queries/640717
+const GAS_PER_SWAP: u64 = 90_171;
 
 pub fn to_domain(id: liquidity::Id, pool: ConstantProductOrder) -> Result<liquidity::Liquidity> {
     // invalid Swapr fee ratio; does not have exact BPS representation
@@ -26,7 +29,7 @@ pub fn to_domain(id: liquidity::Id, pool: ConstantProductOrder) -> Result<liquid
     let fee = swapr::Fee::new(bps)?;
     Ok(liquidity::Liquidity {
         id,
-        gas: price_estimation::gas::GAS_PER_UNISWAP.into(),
+        gas: GAS_PER_SWAP.into(),
         kind: liquidity::Kind::Swapr(swapr::Pool {
             base: boundary::liquidity::uniswap::v2::to_domain_pool(pool)?,
             fee,

--- a/crates/driver/src/boundary/liquidity/uniswap/v2.rs
+++ b/crates/driver/src/boundary/liquidity/uniswap/v2.rs
@@ -15,7 +15,6 @@ use {
         ethrpc::Web3,
         http_solver::model::TokenAmount,
         maintenance::Maintaining,
-        price_estimation,
         sources::uniswap_v2::{
             pair_provider::PairProvider,
             pool_cache::PoolCache,
@@ -34,6 +33,10 @@ use {
     tracing::Instrument,
 };
 
+/// Median gas used per UniswapInteraction (v2).
+// estimated with https://dune.com/queries/640717
+const GAS_PER_SWAP: u64 = 90_171;
+
 pub fn to_domain(id: liquidity::Id, pool: ConstantProductOrder) -> Result<liquidity::Liquidity> {
     assert!(
         *pool.fee.numer() == 3 && *pool.fee.denom() == 1000,
@@ -42,7 +45,7 @@ pub fn to_domain(id: liquidity::Id, pool: ConstantProductOrder) -> Result<liquid
 
     Ok(liquidity::Liquidity {
         id,
-        gas: price_estimation::gas::GAS_PER_UNISWAP.into(),
+        gas: GAS_PER_SWAP.into(),
         kind: liquidity::Kind::UniswapV2(to_domain_pool(pool)?),
     })
 }


### PR DESCRIPTION
In an effort to reduce the drivers dependencies on `shared` to a minimum I copied over the `GAS_PER_SWAP` constants into the specific liquidity module.

Maybe it would be a good idea to re-evaluate these, though.
