### PR TITLE
Refactor Driver Configuration Initialization

### DIFF
--- a/crates/driver/src/boundary/liquidity/balancer/v2/mod.rs
+++ b/crates/driver/src/boundary/liquidity/balancer/v2/mod.rs
@@ -152,7 +152,7 @@ async fn init_liquidity(
 
     let balancer_pool_fetcher = Arc::new(
         BalancerPoolFetcher::new(
-            eth.chain_id().into(),
+            eth.network().chain.into(),
             block_retriever.clone(),
             token_info_fetcher.clone(),
             boundary::liquidity::cache_config(),

--- a/crates/driver/src/boundary/liquidity/uniswap/v3.rs
+++ b/crates/driver/src/boundary/liquidity/uniswap/v3.rs
@@ -135,7 +135,7 @@ async fn init_liquidity(
 
     let pool_fetcher = Arc::new(
         UniswapV3PoolFetcher::new(
-            eth.chain_id().0.as_u64(),
+            eth.network().chain.into(),
             web3.clone(),
             boundary::liquidity::http_client(),
             block_retriever,

--- a/crates/driver/src/boundary/mempool.rs
+++ b/crates/driver/src/boundary/mempool.rs
@@ -158,7 +158,7 @@ impl Mempool {
                     gas_estimate: settlement.gas.estimate.into(),
                     deadline: Some(std::time::Instant::now() + self.config.max_confirm_time),
                     retry_interval: self.config.retry_interval,
-                    network_id: self.eth.network_id().to_string(),
+                    network_id: self.eth.network().id.to_string(),
                     additional_call_data: settlement.auction_id.to_be_bytes().into_iter().collect(),
                     use_soft_cancellations,
                 },

--- a/crates/driver/src/boundary/settlement.rs
+++ b/crates/driver/src/boundary/settlement.rs
@@ -73,7 +73,7 @@ impl Settlement {
 
         let settlement_contract = eth.contracts().settlement();
         let domain = order::signature::domain_separator(
-            eth.chain_id(),
+            eth.network().chain,
             settlement_contract.clone().address().into(),
         );
 

--- a/crates/driver/src/domain/eth/mod.rs
+++ b/crates/driver/src/domain/eth/mod.rs
@@ -27,7 +27,7 @@ pub const ETH_TOKEN: TokenAddress = TokenAddress(ContractAddress(H160([0xee; 20]
 /// Chain ID as defined by EIP-155.
 ///
 /// https://eips.ethereum.org/EIPS/eip-155
-#[derive(Debug, Clone, Copy)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct ChainId(pub U256);
 
 impl From<U256> for ChainId {

--- a/crates/driver/src/infra/blockchain/mod.rs
+++ b/crates/driver/src/infra/blockchain/mod.rs
@@ -27,9 +27,9 @@ pub struct Network {
 }
 
 impl Rpc {
-    /// Instantiate an RPC connection to an Ethereum (or Ethereum-compatible)
-    /// node at the specifed URL.
-    pub async fn connect(url: &url::Url) -> Result<Self, Error> {
+    /// Instantiate an RPC client to an Ethereum (or Ethereum-compatible) node
+    /// at the specifed URL.
+    pub async fn new(url: &url::Url) -> Result<Self, Error> {
         let web3 = boundary::buffered_web3_client(url);
         let id = web3.net().version().await?.into();
         let chain = web3.eth().chain_id().await?.into();

--- a/crates/driver/src/infra/blockchain/mod.rs
+++ b/crates/driver/src/infra/blockchain/mod.rs
@@ -13,24 +13,53 @@ pub mod token;
 
 pub use self::contracts::Contracts;
 
+/// An Ethereum RPC connection.
+pub struct Rpc {
+    web3: DynWeb3,
+    network: Network,
+}
+
+/// Network information for an Ethereum blockchain connection.
+#[derive(Clone, Debug)]
+pub struct Network {
+    pub id: eth::NetworkId,
+    pub chain: eth::ChainId,
+}
+
+impl Rpc {
+    /// Instantiate an RPC connection to an Ethereum (or Ethereum-compatible)
+    /// node at the specifed URL.
+    pub async fn connect(url: &url::Url) -> Result<Self, Error> {
+        let web3 = boundary::buffered_web3_client(url);
+        let id = web3.net().version().await?.into();
+        let chain = web3.eth().chain_id().await?.into();
+
+        Ok(Self {
+            web3,
+            network: Network { id, chain },
+        })
+    }
+
+    /// Returns the network information for the RPC connection.
+    pub fn network(&self) -> &Network {
+        &self.network
+    }
+}
+
 /// The Ethereum blockchain.
 #[derive(Clone)]
 pub struct Ethereum {
     web3: DynWeb3,
-    chain_id: eth::ChainId,
-    network_id: eth::NetworkId,
+    network: Network,
     contracts: Contracts,
     gas: Arc<NativeGasEstimator>,
 }
 
 impl Ethereum {
-    /// Access the Ethereum blockchain through an RPC API hosted at the given
-    /// URL.
-    pub async fn ethrpc(url: &url::Url, addresses: contracts::Addresses) -> Result<Self, Error> {
-        let web3 = boundary::buffered_web3_client(url);
-        let chain_id = web3.eth().chain_id().await?.into();
-        let network_id = web3.net().version().await?.into();
-        let contracts = Contracts::new(&web3, &network_id, addresses);
+    /// Access the Ethereum blockchain through an RPC API.
+    pub async fn new(rpc: Rpc, addresses: contracts::Addresses) -> Result<Self, Error> {
+        let Rpc { web3, network } = rpc;
+        let contracts = Contracts::new(&web3, &network.id, addresses);
         let gas = Arc::new(
             NativeGasEstimator::new(web3.transport().clone(), None)
                 .await
@@ -39,19 +68,14 @@ impl Ethereum {
 
         Ok(Self {
             web3,
-            chain_id,
-            network_id,
+            network,
             contracts,
             gas,
         })
     }
 
-    pub fn chain_id(&self) -> eth::ChainId {
-        self.chain_id
-    }
-
-    pub fn network_id(&self) -> &eth::NetworkId {
-        &self.network_id
+    pub fn network(&self) -> &Network {
+        &self.network
     }
 
     /// Onchain smart contract bindings.
@@ -150,8 +174,7 @@ impl fmt::Debug for Ethereum {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.debug_struct("Ethereum")
             .field("web3", &self.web3)
-            .field("chain_id", &self.chain_id)
-            .field("network_id", &self.network_id)
+            .field("network", &self.network)
             .field("contracts", &self.contracts)
             .field("gas", &"Arc<NativeGasEstimator>")
             .finish()

--- a/crates/driver/src/infra/config/file/load.rs
+++ b/crates/driver/src/infra/config/file/load.rs
@@ -1,22 +1,33 @@
 use {
-    crate::infra::{self, config::file, mempool, simulator, solver},
+    crate::{
+        domain::eth,
+        infra::{self, blockchain, config::file, liquidity, mempool, simulator, solver},
+    },
     futures::future::join_all,
     std::path::Path,
     tokio::fs,
 };
 
-/// Load the driver configuration from a TOML file.
+/// Load the driver configuration from a TOML file for the specifed Ethereum
+/// network.
 ///
 /// # Panics
 ///
 /// This method panics if the config is invalid or on I/O errors.
-pub async fn load(path: &Path) -> infra::Config {
+pub async fn load(network: &blockchain::Network, path: &Path) -> infra::Config {
     let data = fs::read_to_string(path)
         .await
         .unwrap_or_else(|e| panic!("I/O error while reading {path:?}: {e:?}"));
     // Not printing detailed error because it could leak private keys.
     let config: file::Config = toml::de::from_str(&data)
         .unwrap_or_else(|_| panic!("TOML syntax error while reading {path:?}"));
+
+    assert_eq!(
+        config.chain_id.map(eth::ChainId).unwrap_or(network.chain),
+        network.chain,
+        "The configured chain ID does not match connected Ethereum node"
+    );
+
     infra::Config {
         solvers: join_all(config.solvers.into_iter().map(|config| async move {
             let account = match config.account {
@@ -44,7 +55,129 @@ pub async fn load(path: &Path) -> infra::Config {
             }
         }))
         .await,
-        liquidity: config.liquidity,
+        liquidity: liquidity::Config {
+            base_tokens: config
+                .liquidity
+                .base_tokens
+                .iter()
+                .copied()
+                .map(eth::TokenAddress::from)
+                .collect(),
+            uniswap_v2: config
+                .liquidity
+                .uniswap_v2
+                .iter()
+                .cloned()
+                .map(|config| match config {
+                    file::UniswapV2Config::Preset { preset } => match preset {
+                        file::UniswapV2Preset::UniswapV2 => {
+                            liquidity::config::UniswapV2::uniswap_v2(&network.id)
+                        }
+                        file::UniswapV2Preset::SushiSwap => {
+                            liquidity::config::UniswapV2::sushi_swap(&network.id)
+                        }
+                        file::UniswapV2Preset::Honeyswap => {
+                            liquidity::config::UniswapV2::honeyswap(&network.id)
+                        }
+                        file::UniswapV2Preset::Baoswap => {
+                            liquidity::config::UniswapV2::baoswap(&network.id)
+                        }
+                        file::UniswapV2Preset::PancakeSwap => {
+                            liquidity::config::UniswapV2::pancake_swap(&network.id)
+                        }
+                    }
+                    .expect("no Uniswap V2 preset for current network"),
+                    file::UniswapV2Config::Manual { router, pool_code } => {
+                        liquidity::config::UniswapV2 {
+                            router: router.into(),
+                            pool_code: pool_code.into(),
+                        }
+                    }
+                })
+                .collect(),
+            swapr: config
+                .liquidity
+                .swapr
+                .iter()
+                .cloned()
+                .map(|config| match config {
+                    file::SwaprConfig::Preset { preset } => match preset {
+                        file::SwaprPreset::Swapr => liquidity::config::Swapr::swapr(&network.id),
+                    }
+                    .expect("no Swapr preset for current network"),
+                    file::SwaprConfig::Manual { router, pool_code } => liquidity::config::Swapr {
+                        router: router.into(),
+                        pool_code: pool_code.into(),
+                    },
+                })
+                .collect(),
+            uniswap_v3: config
+                .liquidity
+                .uniswap_v3
+                .iter()
+                .cloned()
+                .map(|config| match config {
+                    file::UniswapV3Config::Preset {
+                        preset,
+                        max_pools_to_initialize,
+                    } => liquidity::config::UniswapV3 {
+                        max_pools_to_initialize,
+                        ..match preset {
+                            file::UniswapV3Preset::UniswapV3 => {
+                                liquidity::config::UniswapV3::uniswap_v3(&network.id)
+                            }
+                        }
+                        .expect("no Uniswap V3 preset for current network")
+                    },
+                    file::UniswapV3Config::Manual {
+                        router,
+                        max_pools_to_initialize,
+                    } => liquidity::config::UniswapV3 {
+                        router: router.into(),
+                        max_pools_to_initialize,
+                    },
+                })
+                .collect(),
+            balancer_v2: config
+                .liquidity
+                .balancer_v2
+                .iter()
+                .cloned()
+                .map(|config| match config {
+                    file::BalancerV2Config::Preset {
+                        preset,
+                        pool_deny_list,
+                    } => liquidity::config::BalancerV2 {
+                        pool_deny_list: pool_deny_list.clone(),
+                        ..match preset {
+                            file::BalancerV2Preset::BalancerV2 => {
+                                liquidity::config::BalancerV2::balancer_v2(&network.id)
+                            }
+                        }
+                        .expect("no Balancer V2 preset for current network")
+                    },
+                    file::BalancerV2Config::Manual {
+                        vault,
+                        weighted,
+                        stable,
+                        liquidity_bootstrapping,
+                        pool_deny_list,
+                    } => liquidity::config::BalancerV2 {
+                        vault: vault.into(),
+                        weighted: weighted
+                            .into_iter()
+                            .map(eth::ContractAddress::from)
+                            .collect(),
+                        stable: stable.into_iter().map(eth::ContractAddress::from).collect(),
+                        liquidity_bootstrapping: liquidity_bootstrapping
+                            .into_iter()
+                            .map(eth::ContractAddress::from)
+                            .collect(),
+                        pool_deny_list: pool_deny_list.clone(),
+                    },
+                })
+                .collect(),
+        },
         mempools: config
             .submission
             .mempools
@@ -89,7 +222,10 @@ pub async fn load(path: &Path) -> infra::Config {
             save: config.save,
             save_if_fails: config.save_if_fails,
         }),
-        contracts: config.contracts,
+        contracts: blockchain::contracts::Addresses {
+            settlement: config.contracts.gp_v2_settlement.map(Into::into),
+            weth: config.contracts.weth.map(Into::into),
+        },
         disable_access_list_simulation: config.disable_access_list_simulation,
         disable_gas_simulation: config.disable_gas_simulation.map(Into::into),
     }

--- a/crates/driver/src/infra/config/file/mod.rs
+++ b/crates/driver/src/infra/config/file/mod.rs
@@ -14,6 +14,12 @@ pub use load::load;
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "kebab-case", deny_unknown_fields)]
 struct Config {
+    /// Optionally specify the chain ID that that driver is configured for.
+    /// Note that the actual chain ID is fetched from the configured Ethereum
+    /// RPC endpoint, and the driver will exit if it does not match this
+    /// value.
+    chain_id: Option<eth::U256>,
+
     /// Disable access list simulation, useful for environments that don't
     /// support this, such as less popular blockchains.
     #[serde(default)]
@@ -50,32 +56,32 @@ struct SubmissionConfig {
     /// to miners above regular gas price estimation. Expects a floating point
     /// value between 0 and 1.
     #[serde(default = "default_additional_tip_percentage")]
-    pub additional_tip_percentage: f64,
+    additional_tip_percentage: f64,
 
     /// The maximum gas price in Gwei the solver is willing to pay in a
     /// settlement.
     #[serde(default = "default_gas_price_cap")]
-    pub gas_price_cap: f64,
+    gas_price_cap: f64,
 
     /// The target confirmation time for settlement transactions used
     /// to estimate gas price. Specified in seconds.
     #[serde(default = "default_target_confirm_time_secs")]
-    pub target_confirm_time_secs: u64,
+    target_confirm_time_secs: u64,
 
     /// Amount of time to wait before retrying to submit the tx to
     /// the ethereum network. Specified in seconds.
     #[serde(default = "default_retry_interval_secs")]
-    pub retry_interval_secs: u64,
+    retry_interval_secs: u64,
 
     /// The maximum time to spend trying to settle a transaction through the
     /// Ethereum network before giving up. Specified in seconds.
     #[serde(default = "default_max_confirm_time_secs")]
-    pub max_confirm_time_secs: u64,
+    max_confirm_time_secs: u64,
 
     /// The mempools to submit settlement transactions to. Can be the public
     /// mempool of a node or the private Flashbots mempool.
     #[serde(rename = "mempool", default)]
-    pub mempools: Vec<Mempool>,
+    mempools: Vec<Mempool>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -172,12 +178,12 @@ enum Account {
 
 #[derive(Debug, Default, Deserialize)]
 #[serde(rename_all = "kebab-case", deny_unknown_fields)]
-pub struct ContractsConfig {
+struct ContractsConfig {
     /// Override the default address of the GPv2Settlement contract.
-    pub gp_v2_settlement: Option<eth::H160>,
+    gp_v2_settlement: Option<eth::H160>,
 
     /// Override the default address of the WETH contract.
-    pub weth: Option<eth::H160>,
+    weth: Option<eth::H160>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -205,32 +211,32 @@ struct TenderlyConfig {
 
 #[derive(Clone, Debug, Default, Deserialize)]
 #[serde(rename_all = "kebab-case", deny_unknown_fields)]
-pub struct LiquidityConfig {
+struct LiquidityConfig {
     /// Additional tokens for which liquidity is always fetched, regardless of
     /// whether or not the token appears in the auction.
     #[serde(default)]
-    pub base_tokens: Vec<eth::H160>,
+    base_tokens: Vec<eth::H160>,
 
     /// Liquidity provided by a Uniswap V2 compatible contract.
     #[serde(default)]
-    pub uniswap_v2: Vec<UniswapV2Config>,
+    uniswap_v2: Vec<UniswapV2Config>,
 
     /// Liquidity provided by a Swapr compatible contract.
     #[serde(default)]
-    pub swapr: Vec<SwaprConfig>,
+    swapr: Vec<SwaprConfig>,
 
     /// Liquidity provided by a Uniswap V3 compatible contract.
     #[serde(default)]
-    pub uniswap_v3: Vec<UniswapV3Config>,
+    uniswap_v3: Vec<UniswapV3Config>,
 
     /// Liquidity provided by a Balancer V2 compatible contract.
     #[serde(default)]
-    pub balancer_v2: Vec<BalancerV2Config>,
+    balancer_v2: Vec<BalancerV2Config>,
 }
 
 #[derive(Clone, Debug, Deserialize)]
 #[serde(untagged, deny_unknown_fields)]
-pub enum UniswapV2Config {
+enum UniswapV2Config {
     #[serde(rename_all = "kebab-case")]
     Preset { preset: UniswapV2Preset },
 
@@ -246,7 +252,7 @@ pub enum UniswapV2Config {
 
 #[derive(Clone, Debug, Deserialize)]
 #[serde(rename_all = "kebab-case")]
-pub enum UniswapV2Preset {
+enum UniswapV2Preset {
     UniswapV2,
     SushiSwap,
     Honeyswap,
@@ -256,7 +262,7 @@ pub enum UniswapV2Preset {
 
 #[derive(Clone, Debug, Deserialize)]
 #[serde(untagged, deny_unknown_fields)]
-pub enum SwaprConfig {
+enum SwaprConfig {
     #[serde(rename_all = "kebab-case")]
     Preset { preset: SwaprPreset },
 
@@ -272,13 +278,13 @@ pub enum SwaprConfig {
 
 #[derive(Clone, Debug, Deserialize)]
 #[serde(rename_all = "kebab-case", deny_unknown_fields)]
-pub enum SwaprPreset {
+enum SwaprPreset {
     Swapr,
 }
 
 #[derive(Clone, Debug, Deserialize)]
 #[serde(untagged, deny_unknown_fields)]
-pub enum UniswapV3Config {
+enum UniswapV3Config {
     #[serde(rename_all = "kebab-case")]
     Preset {
         preset: UniswapV3Preset,
@@ -301,7 +307,7 @@ pub enum UniswapV3Config {
 
 #[derive(Clone, Debug, Deserialize)]
 #[serde(rename_all = "kebab-case", deny_unknown_fields)]
-pub enum UniswapV3Preset {
+enum UniswapV3Preset {
     UniswapV3,
 }
 
@@ -313,7 +319,7 @@ mod uniswap_v3 {
 
 #[derive(Clone, Debug, Deserialize)]
 #[serde(untagged, deny_unknown_fields)]
-pub enum BalancerV2Config {
+enum BalancerV2Config {
     #[serde(rename_all = "kebab-case")]
     Preset {
         preset: BalancerV2Preset,
@@ -348,6 +354,6 @@ pub enum BalancerV2Config {
 
 #[derive(Clone, Debug, Deserialize)]
 #[serde(rename_all = "kebab-case", deny_unknown_fields)]
-pub enum BalancerV2Preset {
+enum BalancerV2Preset {
     BalancerV2,
 }

--- a/crates/driver/src/infra/config/mod.rs
+++ b/crates/driver/src/infra/config/mod.rs
@@ -1,9 +1,6 @@
-use {
-    self::file::{ContractsConfig, LiquidityConfig},
-    crate::{
-        domain::eth,
-        infra::{mempool, simulator, solver},
-    },
+use crate::{
+    domain::eth,
+    infra::{blockchain, liquidity, mempool, simulator, solver},
 };
 
 pub mod file;
@@ -14,8 +11,8 @@ pub struct Config {
     pub disable_access_list_simulation: bool,
     pub disable_gas_simulation: Option<eth::Gas>,
     pub solvers: Vec<solver::Config>,
-    pub liquidity: LiquidityConfig,
+    pub liquidity: liquidity::Config,
     pub tenderly: Option<simulator::tenderly::Config>,
     pub mempools: Vec<mempool::Config>,
-    pub contracts: ContractsConfig,
+    pub contracts: blockchain::contracts::Addresses,
 }

--- a/crates/driver/src/run.rs
+++ b/crates/driver/src/run.rs
@@ -1,7 +1,7 @@
 use {
     crate::{
         boundary,
-        domain::{eth, Mempools},
+        domain::Mempools,
         infra::{
             self,
             blockchain::{self, Ethereum},
@@ -38,10 +38,12 @@ pub async fn run(
 ) {
     let args = cli::Args::parse_from(args);
     observe::init(&args.log);
-    let config = config::file::load(&args.config).await;
+
+    let ethrpc = ethrpc(&args).await;
+    let config = config::file::load(ethrpc.network(), &args.config).await;
 
     let (shutdown_sender, shutdown_receiver) = tokio::sync::oneshot::channel();
-    let eth = ethereum(&config, &args).await;
+    let eth = ethereum(&config, ethrpc).await;
     let tx_pool = mempool::GlobalTxPool::default();
     let serve = Api {
         solvers: solvers(&config, &eth),
@@ -92,7 +94,7 @@ fn simulator(config: &infra::Config, eth: &Ethereum) -> Simulator {
                 save: tenderly.save,
                 save_if_fails: tenderly.save_if_fails,
             },
-            eth.network_id().to_owned(),
+            eth.network().id.clone(),
         ),
         None => Simulator::ethereum(eth.to_owned()),
     };
@@ -105,16 +107,16 @@ fn simulator(config: &infra::Config, eth: &Ethereum) -> Simulator {
     simulator
 }
 
-async fn ethereum(config: &infra::Config, args: &cli::Args) -> Ethereum {
-    Ethereum::ethrpc(
-        &args.ethrpc,
-        blockchain::contracts::Addresses {
-            settlement: config.contracts.gp_v2_settlement.map(Into::into),
-            weth: config.contracts.weth.map(Into::into),
-        },
-    )
-    .await
-    .expect("initialize ethereum RPC API")
+async fn ethrpc(args: &cli::Args) -> blockchain::Rpc {
+    blockchain::Rpc::connect(&args.ethrpc)
+        .await
+        .expect("connect ethereum RPC")
+}
+
+async fn ethereum(config: &infra::Config, ethrpc: blockchain::Rpc) -> Ethereum {
+    Ethereum::new(ethrpc, config.contracts)
+        .await
+        .expect("initialize ethereum RPC API")
 }
 
 fn solvers(config: &config::Config, eth: &Ethereum) -> Vec<Solver> {
@@ -126,134 +128,7 @@ fn solvers(config: &config::Config, eth: &Ethereum) -> Vec<Solver> {
 }
 
 async fn liquidity(config: &config::Config, eth: &Ethereum) -> liquidity::Fetcher {
-    let config = liquidity::Config {
-        base_tokens: config
-            .liquidity
-            .base_tokens
-            .iter()
-            .copied()
-            .map(eth::TokenAddress::from)
-            .collect(),
-        uniswap_v2: config
-            .liquidity
-            .uniswap_v2
-            .iter()
-            .cloned()
-            .map(|config| match config {
-                config::file::UniswapV2Config::Preset { preset } => match preset {
-                    config::file::UniswapV2Preset::UniswapV2 => {
-                        liquidity::config::UniswapV2::uniswap_v2(eth.network_id())
-                    }
-                    config::file::UniswapV2Preset::SushiSwap => {
-                        liquidity::config::UniswapV2::sushi_swap(eth.network_id())
-                    }
-                    config::file::UniswapV2Preset::Honeyswap => {
-                        liquidity::config::UniswapV2::honeyswap(eth.network_id())
-                    }
-                    config::file::UniswapV2Preset::Baoswap => {
-                        liquidity::config::UniswapV2::baoswap(eth.network_id())
-                    }
-                    config::file::UniswapV2Preset::PancakeSwap => {
-                        liquidity::config::UniswapV2::pancake_swap(eth.network_id())
-                    }
-                }
-                .expect("no Uniswap V2 preset for current network"),
-                config::file::UniswapV2Config::Manual { router, pool_code } => {
-                    liquidity::config::UniswapV2 {
-                        router: router.into(),
-                        pool_code: pool_code.into(),
-                    }
-                }
-            })
-            .collect(),
-        swapr: config
-            .liquidity
-            .swapr
-            .iter()
-            .cloned()
-            .map(|config| match config {
-                config::file::SwaprConfig::Preset { preset } => match preset {
-                    config::file::SwaprPreset::Swapr => {
-                        liquidity::config::Swapr::swapr(eth.network_id())
-                    }
-                }
-                .expect("no Swapr preset for current network"),
-                config::file::SwaprConfig::Manual { router, pool_code } => {
-                    liquidity::config::Swapr {
-                        router: router.into(),
-                        pool_code: pool_code.into(),
-                    }
-                }
-            })
-            .collect(),
-        uniswap_v3: config
-            .liquidity
-            .uniswap_v3
-            .iter()
-            .cloned()
-            .map(|config| match config {
-                config::file::UniswapV3Config::Preset {
-                    preset,
-                    max_pools_to_initialize,
-                } => liquidity::config::UniswapV3 {
-                    max_pools_to_initialize,
-                    ..match preset {
-                        config::file::UniswapV3Preset::UniswapV3 => {
-                            liquidity::config::UniswapV3::uniswap_v3(eth.network_id())
-                        }
-                    }
-                    .expect("no Uniswap V3 preset for current network")
-                },
-                config::file::UniswapV3Config::Manual {
-                    router,
-                    max_pools_to_initialize,
-                } => liquidity::config::UniswapV3 {
-                    router: router.into(),
-                    max_pools_to_initialize,
-                },
-            })
-            .collect(),
-        balancer_v2: config
-            .liquidity
-            .balancer_v2
-            .iter()
-            .cloned()
-            .map(|config| match config {
-                config::file::BalancerV2Config::Preset {
-                    preset,
-                    pool_deny_list,
-                } => liquidity::config::BalancerV2 {
-                    pool_deny_list: pool_deny_list.clone(),
-                    ..match preset {
-                        config::file::BalancerV2Preset::BalancerV2 => {
-                            liquidity::config::BalancerV2::balancer_v2(eth.network_id())
-                        }
-                    }
-                    .expect("no Balancer V2 preset for current network")
-                },
-                config::file::BalancerV2Config::Manual {
-                    vault,
-                    weighted,
-                    stable,
-                    liquidity_bootstrapping,
-                    pool_deny_list,
-                } => liquidity::config::BalancerV2 {
-                    vault: vault.into(),
-                    weighted: weighted
-                        .into_iter()
-                        .map(eth::ContractAddress::from)
-                        .collect(),
-                    stable: stable.into_iter().map(eth::ContractAddress::from).collect(),
-                    liquidity_bootstrapping: liquidity_bootstrapping
-                        .into_iter()
-                        .map(eth::ContractAddress::from)
-                        .collect(),
-                    pool_deny_list: pool_deny_list.clone(),
-                },
-            })
-            .collect(),
-    };
-    liquidity::Fetcher::new(eth, &config)
+    liquidity::Fetcher::new(eth, &config.liquidity)
         .await
         .expect("initialize liquidity fetcher")
 }

--- a/crates/driver/src/run.rs
+++ b/crates/driver/src/run.rs
@@ -108,7 +108,7 @@ fn simulator(config: &infra::Config, eth: &Ethereum) -> Simulator {
 }
 
 async fn ethrpc(args: &cli::Args) -> blockchain::Rpc {
-    blockchain::Rpc::connect(&args.ethrpc)
+    blockchain::Rpc::new(&args.ethrpc)
         .await
         .expect("connect ethereum RPC")
 }

--- a/crates/driver/src/tests/setup/solver.rs
+++ b/crates/driver/src/tests/setup/solver.rs
@@ -194,8 +194,8 @@ impl Solver {
             .collect::<HashMap<_, _>>();
 
         let url = config.blockchain.web3_url.parse().unwrap();
-        let eth = Ethereum::ethrpc(
-            &url,
+        let eth = Ethereum::new(
+            infra::blockchain::Rpc::connect(&url).await.unwrap(),
             Addresses {
                 settlement: Some(config.blockchain.settlement.address().into()),
                 weth: Some(config.blockchain.weth.address().into()),

--- a/crates/driver/src/tests/setup/solver.rs
+++ b/crates/driver/src/tests/setup/solver.rs
@@ -195,7 +195,7 @@ impl Solver {
 
         let url = config.blockchain.web3_url.parse().unwrap();
         let eth = Ethereum::new(
-            infra::blockchain::Rpc::connect(&url).await.unwrap(),
+            infra::blockchain::Rpc::new(&url).await.unwrap(),
             Addresses {
                 settlement: Some(config.blockchain.settlement.address().into()),
                 weth: Some(config.blockchain.weth.address().into()),


### PR DESCRIPTION
This PR does a refactor for a code smell that was irking me for a while.

The `config::file` module contains _private_ types used just for parsing TOML configurations for the driver and turning them into their `infra::${component}::Config` counterparts. This separation follows a pattern we have in the `driver` code where we separate DTOs and data models from the actual types used within the codebase (it adds boilerplate, but I am in general fond of this).

There were 2 exceptions to the above rule: contract addresses and liquidity configuration. This is because the default configuration values for these are **network dependent**. This PR changes configuration file loading to be network aware, and makes all of the `config::file` module types private (as they should be IMO). For this, w

As a bonus on top, we check that the Ethereum RPC connection's network matches the configuration file (this helps prevent misconfiguration, our other processes make use of this technique as well).

### Test Plan

CI continues to pass 🎉.
