### PR TITLE
Share token fetcher

### DIFF
--- a/crates/driver/src/infra/api/mod.rs
+++ b/crates/driver/src/infra/api/mod.rs
@@ -41,6 +41,8 @@ impl Api {
                 .layer(tower_http::trace::TraceLayer::new_for_http()),
         );
 
+        let tokens = tokens::Fetcher::new(self.eth.clone());
+
         // Add the metrics endpoint.
         app = routes::metrics(app);
 
@@ -68,7 +70,7 @@ impl Api {
                     settlement: Default::default(),
                 },
                 liquidity: self.liquidity.clone(),
-                tokens: tokens::Fetcher::new(self.eth.clone()),
+                tokens: tokens.clone(),
             })));
             let path = format!("/{name}");
             observe::mounting_solver(&name, &path);


### PR DESCRIPTION
I noticed that every `Solver` has its own `tokens::Fetcher` instance which doesn't really make sense.
The token info fetching cache is append only and will always receive the same data across different `Solver` instance. Also all solvers will end up fetching the info for the same tokens so it makes the most sense to have 1 instance globally to let solvers profit off of a shared cache.