### PR TITLE
Multiple Balancer Weighted Pool Versions

### DIFF
--- a/crates/driver/src/boundary/liquidity/balancer/v2/mod.rs
+++ b/crates/driver/src/boundary/liquidity/balancer/v2/mod.rs
@@ -13,6 +13,7 @@ use {
         BalancerV2StablePoolFactory,
         BalancerV2Vault,
         BalancerV2WeightedPoolFactory,
+        BalancerV2WeightedPoolFactoryV3,
         GPv2Settlement,
     },
     shared::{
@@ -112,6 +113,18 @@ async fn init_liquidity(
                     (
                         BalancerFactoryKind::Weighted,
                         BalancerV2WeightedPoolFactory::at(&web3, factory.into())
+                            .raw_instance()
+                            .clone(),
+                    )
+                })
+                .collect::<Vec<_>>(),
+            config
+                .weighted_v3plus
+                .iter()
+                .map(|&factory| {
+                    (
+                        BalancerFactoryKind::WeightedV3,
+                        BalancerV2WeightedPoolFactoryV3::at(&web3, factory.into())
                             .raw_instance()
                             .clone(),
                     )

--- a/crates/driver/src/boundary/liquidity/balancer/v2/weighted.rs
+++ b/crates/driver/src/boundary/liquidity/balancer/v2/weighted.rs
@@ -6,6 +6,7 @@ use {
             liquidity::{self, balancer},
         },
     },
+    shared::sources::balancer_v2::pool_fetching::WeightedPoolVersion,
     solver::liquidity::{balancer_v2, WeightedProductOrder},
 };
 
@@ -38,6 +39,10 @@ pub fn to_domain(id: liquidity::Id, pool: WeightedProductOrder) -> Result<liquid
                     .collect::<Result<_>>()?,
             )?,
             fee: pool.fee.as_uint256().into(),
+            version: match pool.version {
+                WeightedPoolVersion::V0 => balancer::v2::weighted::Version::V0,
+                WeightedPoolVersion::V3Plus => balancer::v2::weighted::Version::V3Plus,
+            },
         }),
     })
 }

--- a/crates/driver/src/domain/liquidity/balancer/v2/weighted.rs
+++ b/crates/driver/src/domain/liquidity/balancer/v2/weighted.rs
@@ -25,6 +25,7 @@ pub struct Pool {
     pub id: Id,
     pub reserves: Reserves,
     pub fee: Fee,
+    pub version: Version,
 }
 
 impl Pool {
@@ -135,4 +136,16 @@ impl From<Weight> for eth::U256 {
     fn from(value: Weight) -> Self {
         value.0
     }
+}
+
+/// The weighted pool version. Different Balancer V2 weighted pool versions use
+/// slightly different math.
+#[derive(Clone, Copy, Debug)]
+pub enum Version {
+    /// Weighted pool math from the original Balancer V2 weighted pool
+    /// implementation.
+    V0,
+    /// Weighted pool math for Balancer V2 weighted pools versions 3+. This uses
+    /// a "shortcut" when computing exponentiation for 50/50 and 20/80 pools.
+    V3Plus,
 }

--- a/crates/driver/src/infra/config/file/load.rs
+++ b/crates/driver/src/infra/config/file/load.rs
@@ -159,12 +159,17 @@ pub async fn load(network: &blockchain::Network, path: &Path) -> infra::Config {
                     file::BalancerV2Config::Manual {
                         vault,
                         weighted,
+                        weighted_v3plus,
                         stable,
                         liquidity_bootstrapping,
                         pool_deny_list,
                     } => liquidity::config::BalancerV2 {
                         vault: vault.into(),
                         weighted: weighted
+                            .into_iter()
+                            .map(eth::ContractAddress::from)
+                            .collect(),
+                        weighted_v3plus: weighted_v3plus
                             .into_iter()
                             .map(eth::ContractAddress::from)
                             .collect(),

--- a/crates/driver/src/infra/config/file/mod.rs
+++ b/crates/driver/src/infra/config/file/mod.rs
@@ -337,6 +337,9 @@ enum BalancerV2Config {
         /// The weighted pool factory contract addresses.
         weighted: Vec<eth::H160>,
 
+        /// The weighted pool factory v3+ contract addresses.
+        weighted_v3plus: Vec<eth::H160>,
+
         /// The stable pool factory contract addresses.
         stable: Vec<eth::H160>,
 

--- a/crates/driver/src/infra/liquidity/config.rs
+++ b/crates/driver/src/infra/liquidity/config.rs
@@ -138,6 +138,9 @@ pub struct BalancerV2 {
     /// Weighted pool factory addresses.
     pub weighted: Vec<eth::ContractAddress>,
 
+    /// Weighted pool factory v3+ addresses.
+    pub weighted_v3plus: Vec<eth::ContractAddress>,
+
     /// Stable pool factory addresses.
     pub stable: Vec<eth::ContractAddress>,
 
@@ -169,9 +172,11 @@ impl BalancerV2 {
             vault: deployment_address(contracts::BalancerV2Vault::raw_contract(), network)?,
             weighted: factory_addresses(&[
                 contracts::BalancerV2WeightedPoolFactory::raw_contract(),
+                contracts::BalancerV2WeightedPool2TokensFactory::raw_contract(),
+            ]),
+            weighted_v3plus: factory_addresses(&[
                 contracts::BalancerV2WeightedPoolFactoryV3::raw_contract(),
                 contracts::BalancerV2WeightedPoolFactoryV4::raw_contract(),
-                contracts::BalancerV2WeightedPool2TokensFactory::raw_contract(),
             ]),
             stable: factory_addresses(&[
                 contracts::BalancerV2StablePoolFactory::raw_contract(),

--- a/crates/driver/src/infra/solver/dto/auction.rs
+++ b/crates/driver/src/infra/solver/dto/auction.rs
@@ -170,6 +170,14 @@ impl Auction {
                                 eth::U256::from(pool.fee).to_big_int(),
                                 18,
                             ),
+                            version: match pool.version {
+                                liquidity::balancer::v2::weighted::Version::V0 => {
+                                    WeightedProductVersion::V0
+                                }
+                                liquidity::balancer::v2::weighted::Version::V3Plus => {
+                                    WeightedProductVersion::V3Plus
+                                }
+                            },
                         })
                     }
                     liquidity::Kind::Swapr(pool) => {
@@ -308,6 +316,7 @@ struct WeightedProductPool {
     tokens: IndexMap<eth::H160, WeightedProductReserve>,
     #[serde_as(as = "serde_with::DisplayFromStr")]
     fee: bigdecimal::BigDecimal,
+    version: WeightedProductVersion,
 }
 
 #[serde_as]
@@ -320,6 +329,13 @@ struct WeightedProductReserve {
     scaling_factor: eth::U256,
     #[serde_as(as = "serde_with::DisplayFromStr")]
     weight: bigdecimal::BigDecimal,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "lowercase")]
+enum WeightedProductVersion {
+    V0,
+    V3Plus,
 }
 
 #[serde_as]

--- a/crates/shared/src/sources/balancer_v2/pool_fetching.rs
+++ b/crates/shared/src/sources/balancer_v2/pool_fetching.rs
@@ -62,7 +62,7 @@ use {
 pub use {
     common::TokenState,
     stable::AmplificationParameter,
-    weighted::TokenState as WeightedTokenState,
+    weighted::{TokenState as WeightedTokenState, Version as WeightedPoolVersion},
 };
 pub trait BalancerPoolEvaluating {
     fn properties(&self) -> CommonPoolState;
@@ -80,6 +80,7 @@ pub struct CommonPoolState {
 pub struct WeightedPool {
     pub common: CommonPoolState,
     pub reserves: HashMap<H160, WeightedTokenState>,
+    pub version: WeightedPoolVersion,
 }
 
 impl WeightedPool {
@@ -92,6 +93,7 @@ impl WeightedPool {
                 paused: false,
             },
             reserves: weighted_state.tokens.into_iter().collect(),
+            version: weighted_state.version,
         }
     }
 }
@@ -380,11 +382,11 @@ async fn create_aggregate_pool_fetcher(
     let mut fetchers = Vec::new();
     for (kind, instance) in &contracts.factories {
         let registry = match kind {
-            BalancerFactoryKind::Weighted
-            | BalancerFactoryKind::WeightedV3
-            | BalancerFactoryKind::WeightedV4
-            | BalancerFactoryKind::Weighted2Token => {
+            BalancerFactoryKind::Weighted | BalancerFactoryKind::Weighted2Token => {
                 registry!(BalancerV2WeightedPoolFactory, instance)
+            }
+            BalancerFactoryKind::WeightedV3 | BalancerFactoryKind::WeightedV4 => {
+                registry!(BalancerV2WeightedPoolFactoryV3, instance)
             }
             BalancerFactoryKind::Stable | BalancerFactoryKind::StableV2 => {
                 registry!(BalancerV2StablePoolFactory, instance)

--- a/crates/shared/src/sources/balancer_v2/pool_fetching/registry.rs
+++ b/crates/shared/src/sources/balancer_v2/pool_fetching/registry.rs
@@ -168,6 +168,7 @@ mod tests {
                 kind: PoolKind::Weighted(weighted::PoolState {
                     tokens: Default::default(),
                     swap_fee: Bfp::zero(),
+                    version: Default::default(),
                 }),
             })),
             Ok(PoolStatus::Paused),

--- a/crates/shared/src/sources/balancer_v2/pools/common.rs
+++ b/crates/shared/src/sources/balancer_v2/pools/common.rs
@@ -578,6 +578,7 @@ mod tests {
                     weight: pool_info.weights[2],
                 },
             },
+            version: Default::default(),
         };
 
         let vault = mock.deploy(BalancerV2Vault::raw_contract().abi.clone());
@@ -662,6 +663,7 @@ mod tests {
                 future::ready(Ok(Some(weighted::PoolState {
                     swap_fee: Bfp::zero(),
                     tokens: Default::default(),
+                    version: Default::default(),
                 })))
                 .boxed()
             });

--- a/crates/shared/src/sources/balancer_v2/pools/liquidity_bootstrapping.rs
+++ b/crates/shared/src/sources/balancer_v2/pools/liquidity_bootstrapping.rs
@@ -18,7 +18,7 @@ use {
     futures::{future::BoxFuture, FutureExt as _},
 };
 
-pub use super::weighted::{PoolState, TokenState};
+pub use super::weighted::{PoolState, TokenState, Version};
 
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
 pub struct PoolInfo {
@@ -96,7 +96,11 @@ impl FactoryIndexing for BalancerV2LiquidityBootstrappingPoolFactory {
                 .collect();
             let swap_fee = common.swap_fee;
 
-            Ok(Some(PoolState { tokens, swap_fee }))
+            Ok(Some(PoolState {
+                tokens,
+                swap_fee,
+                version: Version::V0,
+            }))
         }
         .boxed()
     }
@@ -197,7 +201,14 @@ mod tests {
             pool_state.await.unwrap()
         };
 
-        assert_eq!(pool_state, Some(PoolState { tokens, swap_fee }));
+        assert_eq!(
+            pool_state,
+            Some(PoolState {
+                tokens,
+                swap_fee,
+                version: Version::V0
+            })
+        );
     }
 
     #[tokio::test]

--- a/crates/shared/src/sources/balancer_v2/swap/fixed_point.rs
+++ b/crates/shared/src/sources/balancer_v2/swap/fixed_point.rs
@@ -33,6 +33,8 @@ lazy_static! {
     static ref ZERO: Bfp = Bfp(U256::zero());
     static ref EPSILON: Bfp = Bfp(U256::one());
     static ref ONE: Bfp = Bfp(*ONE_18);
+    static ref TWO: Bfp = Bfp(*ONE_18 * 2);
+    static ref FOUR: Bfp = Bfp(*ONE_18 * 4);
     static ref MAX_POW_RELATIVE_ERROR: Bfp = Bfp(10000_usize.into());
 }
 
@@ -182,6 +184,22 @@ impl Bfp {
         let max_error = raw.mul_up(*MAX_POW_RELATIVE_ERROR)?.add(Bfp(1.into()))?;
 
         raw.add(max_error)
+    }
+
+    pub fn pow_up_v3(self, exp: Self) -> Result<Self, Error> {
+        if exp == *ONE {
+            Ok(self)
+        } else if exp == *TWO {
+            self.mul_up(self)
+        } else if exp == *FOUR {
+            let square = self.mul_up(self)?;
+            square.mul_up(square)
+        } else {
+            let raw = Bfp(logexpmath::pow(self.0, exp.0)?);
+            let max_error = raw.mul_up(*MAX_POW_RELATIVE_ERROR)?.add(Bfp(1.into()))?;
+
+            raw.add(max_error)
+        }
     }
 }
 

--- a/crates/solver/src/liquidity.rs
+++ b/crates/solver/src/liquidity.rs
@@ -22,7 +22,12 @@ use {
         http_solver::model::TokenAmount,
         sources::{
             balancer_v2::{
-                pool_fetching::{AmplificationParameter, TokenState, WeightedTokenState},
+                pool_fetching::{
+                    AmplificationParameter,
+                    TokenState,
+                    WeightedPoolVersion,
+                    WeightedTokenState,
+                },
                 swap::fixed_point::Bfp,
             },
             uniswap_v2::pool_fetching::Pool,
@@ -318,6 +323,7 @@ pub struct WeightedProductOrder {
     pub address: H160,
     pub reserves: HashMap<H160, WeightedTokenState>,
     pub fee: Bfp,
+    pub version: WeightedPoolVersion,
     #[cfg_attr(test, derivative(PartialEq = "ignore"))]
     pub settlement_handling: Arc<dyn SettlementHandling<Self>>,
 }
@@ -445,6 +451,7 @@ impl Default for WeightedProductOrder {
             address: Default::default(),
             reserves: Default::default(),
             fee: Bfp::zero(),
+            version: Default::default(),
             settlement_handling: tests::CapturingSettlementHandler::arc(),
         }
     }

--- a/crates/solver/src/liquidity/balancer_v2.rs
+++ b/crates/solver/src/liquidity/balancer_v2.rs
@@ -74,6 +74,7 @@ impl BalancerV2Liquidity {
                 address: pool.common.address,
                 reserves: pool.reserves,
                 fee: pool.common.swap_fee,
+                version: pool.version,
                 settlement_handling: Arc::new(SettlementHandler {
                     pool_id: pool.common.id,
                     settlement: self.settlement.clone(),
@@ -234,6 +235,7 @@ mod tests {
                 StablePool,
                 TokenState,
                 WeightedPool,
+                WeightedPoolVersion,
                 WeightedTokenState,
             },
         },
@@ -286,6 +288,7 @@ mod tests {
                         weight: "0.5".parse().unwrap(),
                     },
                 },
+                version: WeightedPoolVersion::V0,
             },
             WeightedPool {
                 common: CommonPoolState {
@@ -310,6 +313,7 @@ mod tests {
                         weight: "0.5".parse().unwrap(),
                     },
                 },
+                version: WeightedPoolVersion::V3Plus,
             },
         ];
 
@@ -397,12 +401,28 @@ mod tests {
         assert_eq!(stable_orders.len(), 1);
 
         assert_eq!(
-            (&weighted_orders[0].reserves, &weighted_orders[0].fee),
-            (&weighted_pools[0].reserves, &"0.002".parse().unwrap()),
+            (
+                &weighted_orders[0].reserves,
+                &weighted_orders[0].fee,
+                weighted_orders[0].version
+            ),
+            (
+                &weighted_pools[0].reserves,
+                &"0.002".parse().unwrap(),
+                WeightedPoolVersion::V0
+            ),
         );
         assert_eq!(
-            (&weighted_orders[1].reserves, &weighted_orders[1].fee),
-            (&weighted_pools[1].reserves, &"0.001".parse().unwrap()),
+            (
+                &weighted_orders[1].reserves,
+                &weighted_orders[1].fee,
+                weighted_orders[1].version
+            ),
+            (
+                &weighted_pools[1].reserves,
+                &"0.001".parse().unwrap(),
+                WeightedPoolVersion::V3Plus
+            ),
         );
         assert_eq!(
             (&stable_orders[0].reserves, &stable_orders[0].fee),

--- a/crates/solver/src/solver/baseline_solver.rs
+++ b/crates/solver/src/solver/baseline_solver.rs
@@ -378,6 +378,7 @@ fn amm_to_weighted_pool(amm: &WeightedProductOrder) -> WeightedPoolRef {
     WeightedPoolRef {
         reserves: &amm.reserves,
         swap_fee: amm.fee,
+        version: amm.version,
     }
 }
 
@@ -745,6 +746,7 @@ mod tests {
                     },
                 },
                 fee: "0.001".parse().unwrap(),
+                version: Default::default(),
                 settlement_handling: CapturingSettlementHandler::arc(),
             }),
         ];
@@ -815,6 +817,7 @@ mod tests {
             .cloned()
             .collect(),
             fee: Bfp::zero(),
+            version: Default::default(),
             settlement_handling: CapturingSettlementHandler::arc(),
         };
         // When baseline solver goes from the buy token to the sell token it sees that a

--- a/crates/solver/src/solver/http_solver/settlement.rs
+++ b/crates/solver/src/solver/http_solver/settlement.rs
@@ -572,6 +572,7 @@ mod tests {
                     }
                 },
                 fee: "0.03".parse().unwrap(),
+                version: Default::default(),
                 settlement_handling: wp_amm_handler.clone(),
             }),
             Liquidity::BalancerStable(StablePoolOrder {
@@ -857,6 +858,7 @@ mod tests {
                 }
             },
             fee: "0.001".parse().unwrap(),
+            version: Default::default(),
             settlement_handling: CapturingSettlementHandler::arc(),
         };
 

--- a/crates/solvers/src/api/dto/auction.rs
+++ b/crates/solvers/src/api/dto/auction.rs
@@ -209,6 +209,7 @@ struct WeightedProductPool {
     gas_estimate: U256,
     tokens: HashMap<H160, WeightedProductReserve>,
     fee: BigDecimal,
+    version: WeightedProductVersion,
 }
 
 #[serde_as]
@@ -220,6 +221,13 @@ struct WeightedProductReserve {
     #[serde_as(as = "serialize::U256")]
     scaling_factor: U256,
     weight: BigDecimal,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "lowercase")]
+enum WeightedProductVersion {
+    V0,
+    V3Plus,
 }
 
 impl WeightedProductPool {
@@ -252,6 +260,10 @@ impl WeightedProductPool {
             state: liquidity::State::WeightedProduct(liquidity::weighted_product::Pool {
                 reserves,
                 fee: conv::decimal_to_rational(&self.fee).ok_or("invalid weighted product fee")?,
+                version: match self.version {
+                    WeightedProductVersion::V0 => liquidity::weighted_product::Version::V0,
+                    WeightedProductVersion::V3Plus => liquidity::weighted_product::Version::V3Plus,
+                },
             }),
         })
     }

--- a/crates/solvers/src/boundary/liquidity/weighted_product.rs
+++ b/crates/solvers/src/boundary/liquidity/weighted_product.rs
@@ -3,7 +3,7 @@ use {
     crate::domain::{eth, liquidity},
     ethereum_types::{H160, H256, U256},
     shared::sources::balancer_v2::{
-        pool_fetching::{CommonPoolState, TokenState, WeightedTokenState},
+        pool_fetching::{CommonPoolState, TokenState, WeightedPoolVersion, WeightedTokenState},
         swap::fixed_point::Bfp,
     },
     std::collections::HashMap,
@@ -48,6 +48,10 @@ pub fn to_boundary_pool(address: H160, pool: &liquidity::weighted_product::Pool)
             paused: false,
         },
         reserves,
+        version: match pool.version {
+            liquidity::weighted_product::Version::V0 => WeightedPoolVersion::V0,
+            liquidity::weighted_product::Version::V3Plus => WeightedPoolVersion::V3Plus,
+        },
     })
 }
 

--- a/crates/solvers/src/domain/liquidity/weighted_product.rs
+++ b/crates/solvers/src/domain/liquidity/weighted_product.rs
@@ -8,6 +8,7 @@ use {
 pub struct Pool {
     pub reserves: Reserves,
     pub fee: eth::Rational,
+    pub version: Version,
 }
 
 /// A reprensentation of BalancerV2-like weighted pool reserves.
@@ -65,4 +66,16 @@ pub struct Reserve {
     pub asset: eth::Asset,
     pub weight: eth::Rational,
     pub scale: liquidity::ScalingFactor,
+}
+
+/// The version of the weighted product math to use. Different versions have
+/// slightly different rounding properties.
+#[derive(Copy, Clone, Debug)]
+pub enum Version {
+    /// Weighted pool math from the original Balancer V2 weighted pool
+    /// implementation.
+    V0,
+    /// Weighted pool math for Balancer V2 weighted pools versions 3+. This uses
+    /// a "shortcut" when computing exponentiation for 50/50 and 20/80 pools.
+    V3Plus,
 }

--- a/crates/solvers/src/tests/baseline/bal_liquidity.rs
+++ b/crates/solvers/src/tests/baseline/bal_liquidity.rs
@@ -1,0 +1,232 @@
+//! Test cases to verify baseline computation of Balancer V2 liquidity.
+
+use {crate::tests, serde_json::json};
+
+#[tokio::test]
+async fn weighted() {
+    let engine = tests::SolverEngine::new(
+        "baseline",
+        tests::Config::String(
+            r#"
+                chain-id = "1"
+                base-tokens = []
+                max-hops = 0
+                max-partial-attempts = 1
+            "#
+            .to_owned(),
+        ),
+    )
+    .await;
+
+    let solution = engine
+        .solve(json!({
+            "id": "1",
+            "tokens": {
+                "0x6810e776880c02933d47db1b9fc05908e5386b96": {
+                    "decimals": 18,
+                    "symbol": "GNO",
+                    "referencePrice": "59970737022467696",
+                    "availableBalance": "0",
+                    "trusted": true
+                },
+                "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2": {
+                    "decimals": 18,
+                    "symbol": "WETH",
+                    "referencePrice": "1000000000000000000",
+                    "availableBalance": "0",
+                    "trusted": true
+                },
+                "0xdef1ca1fb7fbcdc777520aa7f396b4e015f497ab": {
+                    "decimals": 18,
+                    "symbol": "COW",
+                    "referencePrice": "35756662383952",
+                    "availableBalance": "0",
+                    "trusted": true
+                },
+            },
+            "orders": [
+                {
+                    "uid": "0x2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a\
+                              2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a\
+                              2a2a2a2a",
+                    "sellToken": "0x6810e776880c02933d47db1b9fc05908e5386b96",
+                    "buyToken": "0xdef1ca1fb7fbcdc777520aa7f396b4e015f497ab",
+                    "sellAmount": "1000000000000000000",
+                    "buyAmount": "1",
+                    "feeAmount": "0",
+                    "kind": "sell",
+                    "partiallyFillable": false,
+                    "class": "market",
+                }
+            ],
+            "liquidity": [
+                {
+                    "kind": "weightedproduct",
+                    "tokens": {
+                        "0x6810e776880c02933d47db1b9fc05908e5386b96": {
+                            "balance": "11260752191375725565253",
+                            "scalingFactor": "1000000000000000000",
+                            "weight": "0.5",
+                        },
+                        "0xdef1ca1fb7fbcdc777520aa7f396b4e015f497ab": {
+                            "balance": "18764168403990393422000071",
+                            "scalingFactor": "1000000000000000000",
+                            "weight": "0.5",
+                        }
+                    },
+                    "fee": "0.005",
+                    "id": "0",
+                    "address": "0x92762b42a06dcdddc5b7362cfb01e631c4d44b40",
+                    "gasEstimate": "88892",
+                    "version": "v0",
+                },
+            ],
+            "effectiveGasPrice": "1000000000",
+            "deadline": "2106-01-01T00:00:00.000Z"
+        }))
+        .await;
+
+    assert_eq!(
+        solution,
+        json!({
+            "solutions": [{
+                "id": 0,
+                "prices": {
+                    "0x6810e776880c02933d47db1b9fc05908e5386b96": "1657855325872947866705",
+                    "0xdef1ca1fb7fbcdc777520aa7f396b4e015f497ab": "1000000000000000000"
+                },
+                "trades": [
+                    {
+                        "kind": "fulfillment",
+                        "order": "0x2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a\
+                                    2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a\
+                                    2a2a2a2a",
+                        "executedAmount": "1000000000000000000"
+                    }
+                ],
+                "interactions": [
+                    {
+                        "kind": "liquidity",
+                        "internalize": false,
+                        "id": "0",
+                        "inputToken": "0x6810e776880c02933d47db1b9fc05908e5386b96",
+                        "outputToken": "0xdef1ca1fb7fbcdc777520aa7f396b4e015f497ab",
+                        "inputAmount": "1000000000000000000",
+                        "outputAmount": "1657855325872947866705"
+                    },
+                ]
+            }]
+        }),
+    );
+}
+
+#[tokio::test]
+async fn weighted_v3plus() {
+    let engine = tests::SolverEngine::new(
+        "baseline",
+        tests::Config::String(
+            r#"
+                chain-id = "100"
+                base-tokens = []
+                max-hops = 0
+                max-partial-attempts = 1
+            "#
+            .to_owned(),
+        ),
+    )
+    .await;
+
+    let solution = engine
+        .solve(json!({
+            "id": "1",
+            "tokens": {
+                "0x177127622c4a00f3d409b75571e12cb3c8973d3c": {
+                    "decimals": 18,
+                    "symbol": "xCOW",
+                    "referencePrice": null,
+                    "availableBalance": "0",
+                    "trusted": true
+                },
+                "0x9c58bacc331c9aa871afd802db6379a98e80cedb": {
+                    "decimals": 18,
+                    "symbol": "xGNO",
+                    "referencePrice": null,
+                    "availableBalance": "0",
+                    "trusted": true
+                },
+            },
+            "orders": [
+                {
+                    "uid": "0x2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a\
+                              2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a\
+                              2a2a2a2a",
+                    "sellToken": "0x9c58bacc331c9aa871afd802db6379a98e80cedb",
+                    "buyToken": "0x177127622c4a00f3d409b75571e12cb3c8973d3c",
+                    "sellAmount": "1000000000000000000",
+                    "buyAmount": "1",
+                    "feeAmount": "0",
+                    "kind": "sell",
+                    "partiallyFillable": false,
+                    "class": "market",
+                }
+            ],
+            "liquidity": [
+                {
+                    "kind": "weightedproduct",
+                    "tokens": {
+                        "0x177127622c4a00f3d409b75571e12cb3c8973d3c": {
+                            "balance": "5089632258314443812936111",
+                            "scalingFactor": "1000000000000000000",
+                            "weight": "0.5",
+                        },
+                        "0x9c58bacc331c9aa871afd802db6379a98e80cedb": {
+                            "balance": "3043530764763263654069",
+                            "scalingFactor": "1000000000000000000",
+                            "weight": "0.5",
+                        }
+                    },
+                    "fee": "0.005",
+                    "id": "0",
+                    "address": "0x21d4c792ea7e38e0d0819c2011a2b1cb7252bd99",
+                    "gasEstimate": "88892",
+                    "version": "v3plus",
+                },
+            ],
+            "effectiveGasPrice": "1000000000",
+            "deadline": "2106-01-01T00:00:00.000Z"
+        }))
+        .await;
+
+    assert_eq!(
+        solution,
+        json!({
+            "solutions": [{
+                "id": 0,
+                "prices": {
+                    "0x177127622c4a00f3d409b75571e12cb3c8973d3c": "1000000000000000000",
+                    "0x9c58bacc331c9aa871afd802db6379a98e80cedb": "1663373703594405548696"
+                },
+                "trades": [
+                    {
+                        "kind": "fulfillment",
+                        "order": "0x2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a\
+                                    2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a\
+                                    2a2a2a2a",
+                        "executedAmount": "1000000000000000000"
+                    }
+                ],
+                "interactions": [
+                    {
+                        "kind": "liquidity",
+                        "internalize": false,
+                        "id": "0",
+                        "inputToken": "0x9c58bacc331c9aa871afd802db6379a98e80cedb",
+                        "outputToken": "0x177127622c4a00f3d409b75571e12cb3c8973d3c",
+                        "inputAmount": "1000000000000000000",
+                        "outputAmount": "1663373703594405548696"
+                    },
+                ]
+            }]
+        }),
+    );
+}

--- a/crates/solvers/src/tests/baseline/mod.rs
+++ b/crates/solvers/src/tests/baseline/mod.rs
@@ -1,5 +1,6 @@
 //! Baseline solver test cases.
 
+mod bal_liquidity;
 mod buy_order_rounding;
 mod direct_swap;
 mod partial_fill;


### PR DESCRIPTION
Fixes #1763 

Currently, there are 4 versions of weighted pools:
* **original** (called `v0` in code): The original weighted pool implementation with the original weighted pool math. This is what was already implemented in Rust.
* **v2**: This version uses the same math as the original, but was deprecated because of a security issue (in fact, we do not index these pools at all).
* **v3**: This version introduces a few new features. Notably, they modify the `FixedPoint::pow{Up,Down}` functions to early exit on specific inputs (for example, `FixedPoint::powUp(a, 1.0)` will just return `a`, where previously it would do math to compute the exponentiation which resulted in a small error).
* **v4**: Uses `CREATE2` for pool creation, the math is identical to V3.

As you can see, between V0 and V3+, the math for computing input and output amounts changed. This PR adds a "version" field to Balancer weighted pools that models the version of the weighted pool implementations above. This version is used to decide which weighted math calculation version should be used for the pool.

### Test Plan

Added new E2E tests that verify input and output amount computations for Balancer weighted pools V3.

#### Verifying Test Case Values


<details><summary><code>tests::baseline::bal_liquidity::weighted</code></summary>

Command:
```sh
python3 -c "print($(curl -s https://mainnet.infura.io/v3/$INFURA_PROJECT_ID -X POST -H 'content-type: application/json' --data '@-' <<JSON | jq -r '.result'
{
  "jsonrpc": "2.0",
  "method": "eth_call",
  "params": [{
    "from": "0xBA12222222228d8Ba445958a75a0704d566BF2C8",
    "to": "0x92762b42a06dcdddc5b7362cfb01e631c4d44b40",
    "data": "0x9d2c110c000000000000000000000000000000000000000000000000000000000000006000000000000000000000000000000000000000000000026272545808bbac15450000000000000000000000000000000000000000000f85779b802c3ee5b6afc700000000000000000000000000000000000000000000000000000000000000000000000000000000000000006810e776880c02933d47db1b9fc05908e5386b96000000000000000000000000def1ca1fb7fbcdc777520aa7f396b4e015f497ab0000000000000000000000000000000000000000000000000de0b6b3a764000092762b42a06dcdddc5b7362cfb01e631c4d44b40000200000000000000000182000000000000000000000000000000000000000000000000000000000111d8310000000000000000000000009008d19f58aabd9ed0d60971565aa8510560ab410000000000000000000000009008d19f58aabd9ed0d60971565aa8510560ab4100000000000000000000000000000000000000000000000000000000000001200000000000000000000000000000000000000000000000000000000000000000"
  }, "latest"],
  "id": 0
}
JSON
))"
```

Output:
```
1657855325872947866705
```

</details>

<details><summary><code>tests::baseline::bal_liquidity::weighted_v3plus</code></summary>

Command:
```sh
python3 -c "print($(curl -s https://rpc.gnosischain.com/ -X POST -H 'content-type: application/json' --data '@-' <<JSON | jq -r '.result'
{
  "jsonrpc": "2.0",
  "method": "eth_call",
  "params": [{
    "from": "0xBA12222222228d8Ba445958a75a0704d566BF2C8",
    "to": "0x21d4c792ea7e38e0d0819c2011a2b1cb7252bd99",
    "data": "0x9d2c110c00000000000000000000000000000000000000000000000000000000000000600000000000000000000000000000000000000000000000a4fd79613c2f4bd8b50000000000000000000000000000000000000000000435c584802d92015299af00000000000000000000000000000000000000000000000000000000000000000000000000000000000000009c58bacc331c9aa871afd802db6379a98e80cedb000000000000000000000000177127622c4a00f3d409b75571e12cb3c8973d3c0000000000000000000000000000000000000000000000000de0b6b3a764000021d4c792ea7e38e0d0819c2011a2b1cb7252bd9900020000000000000000001e0000000000000000000000000000000000000000000000000000000001c2a9e10000000000000000000000009008d19f58aabd9ed0d60971565aa8510560ab410000000000000000000000009008d19f58aabd9ed0d60971565aa8510560ab4100000000000000000000000000000000000000000000000000000000000001200000000000000000000000000000000000000000000000000000000000000000"
  }, "latest"],
  "id": 0
}
JSON
))"
```

Output:
```
1663373703594405548696
```

</details>

<details><summary><code>tests::baseline::buy_order_rounding::balancer_weighted_v3plus</code></summary>

Command:
```sh
python3 -c "print($(curl -s https://rpc.gnosischain.com/ -X POST -H 'content-type: application/json' --data '@-' <<JSON | jq -r '.result'
{
  "jsonrpc": "2.0",
  "method": "eth_call",
  "params": [{
    "from": "0xBA12222222228d8Ba445958a75a0704d566BF2C8",
    "to": "0x21d4c792ea7e38e0d0819c2011a2b1cb7252bd99",
    "data": "0x9d2c110c000000000000000000000000000000000000000000000000000000000000006000000000000000000000000000000000000000000000026272545808bbac15450000000000000000000000000000000000000000000f85779b802c3ee5b6afc700000000000000000000000000000000000000000000000000000000000000010000000000000000000000009c58bacc331c9aa871afd802db6379a98e80cedb000000000000000000000000177127622c4a00f3d409b75571e12cb3c8973d3c00000000000000000000000000000000000000000000003635c9adc5dea0000021d4c792ea7e38e0d0819c2011a2b1cb7252bd9900020000000000000000001e0000000000000000000000000000000000000000000000000000000001c2a9e10000000000000000000000009008d19f58aabd9ed0d60971565aa8510560ab410000000000000000000000009008d19f58aabd9ed0d60971565aa8510560ab4100000000000000000000000000000000000000000000000000000000000001200000000000000000000000000000000000000000000000000000000000000000"
  }, "latest"],
  "id": 0
}
JSON
))"
```

Output:
```
603167793526702182
```

</details>
