### PR TITLE
Handle deadline error for colocated driver

### DIFF
--- a/crates/shared/src/api.rs
+++ b/crates/shared/src/api.rs
@@ -241,6 +241,10 @@ impl IntoWarpReply for PriceEstimationError {
                 error("NoLiquidity", "not enough liquidity"),
                 StatusCode::NOT_FOUND,
             ),
+            Self::DeadlineExceeded => with_status(
+                error("DeadlineExceeded", "quoting deadline exceeded"),
+                StatusCode::NOT_FOUND,
+            ),
             Self::ZeroAmount => with_status(
                 error("ZeroAmount", "Please use non-zero amount field"),
                 StatusCode::BAD_REQUEST,

--- a/crates/shared/src/price_estimation.rs
+++ b/crates/shared/src/price_estimation.rs
@@ -334,6 +334,9 @@ pub enum PriceEstimationError {
     #[error("No liquidity")]
     NoLiquidity,
 
+    #[error("Deadline exceeded")]
+    DeadlineExceeded, 
+
     #[error("Zero Amount")]
     ZeroAmount,
 
@@ -367,6 +370,7 @@ impl Clone for PriceEstimationError {
                 reason: reason.clone(),
             },
             Self::NoLiquidity => Self::NoLiquidity,
+            Self::DeadlineExceeded => Self::DeadlineExceeded,
             Self::ZeroAmount => Self::ZeroAmount,
             Self::UnsupportedOrderType => Self::UnsupportedOrderType,
             Self::RateLimited => Self::RateLimited,

--- a/crates/shared/src/price_estimation.rs
+++ b/crates/shared/src/price_estimation.rs
@@ -335,7 +335,7 @@ pub enum PriceEstimationError {
     NoLiquidity,
 
     #[error("Deadline exceeded")]
-    DeadlineExceeded, 
+    DeadlineExceeded,
 
     #[error("Zero Amount")]
     ZeroAmount,

--- a/crates/shared/src/price_estimation/competition.rs
+++ b/crates/shared/src/price_estimation/competition.rs
@@ -334,8 +334,9 @@ fn is_second_error_preferred(a: &PriceEstimationError, b: &PriceEstimationError)
             PriceEstimationError::UnsupportedToken { .. } => 1,
             PriceEstimationError::NoLiquidity => 2,
             PriceEstimationError::Other(_) => 3,
-            PriceEstimationError::UnsupportedOrderType => 4,
-            PriceEstimationError::RateLimited => 5,
+            PriceEstimationError::DeadlineExceeded => 4,
+            PriceEstimationError::UnsupportedOrderType => 5,
+            PriceEstimationError::RateLimited => 6,
             // lowest priority
         }
     }

--- a/crates/shared/src/price_estimation/trade_finder.rs
+++ b/crates/shared/src/price_estimation/trade_finder.rs
@@ -377,6 +377,7 @@ impl From<TradeError> for PriceEstimationError {
         match err {
             TradeError::NoLiquidity => Self::NoLiquidity,
             TradeError::UnsupportedOrderType => Self::UnsupportedOrderType,
+            TradeError::DeadlineExceeded => Self::DeadlineExceeded,
             TradeError::RateLimited => Self::RateLimited,
             TradeError::Other(err) => Self::Other(err),
         }

--- a/crates/shared/src/trade_finding.rs
+++ b/crates/shared/src/trade_finding.rs
@@ -128,6 +128,9 @@ pub enum TradeError {
     #[error("Unsupported Order Type")]
     UnsupportedOrderType,
 
+    #[error("Deadline exceeded")]
+    DeadlineExceeded,
+
     #[error("Rate limited")]
     RateLimited,
 
@@ -140,6 +143,7 @@ impl From<PriceEstimationError> for TradeError {
         match err {
             PriceEstimationError::NoLiquidity => Self::NoLiquidity,
             PriceEstimationError::UnsupportedOrderType => Self::UnsupportedOrderType,
+            PriceEstimationError::DeadlineExceeded => Self::DeadlineExceeded,
             PriceEstimationError::RateLimited => Self::RateLimited,
             PriceEstimationError::Other(err) => Self::Other(err),
             _ => Self::Other(anyhow::anyhow!(err.to_string())),
@@ -152,6 +156,7 @@ impl Clone for TradeError {
         match self {
             Self::NoLiquidity => Self::NoLiquidity,
             Self::UnsupportedOrderType => Self::UnsupportedOrderType,
+            Self::DeadlineExceeded => Self::DeadlineExceeded,
             Self::RateLimited => Self::RateLimited,
             Self::Other(err) => Self::Other(crate::clone_anyhow_error(err)),
         }

--- a/crates/shared/src/trade_finding/external.rs
+++ b/crates/shared/src/trade_finding/external.rs
@@ -121,6 +121,7 @@ impl From<dto::Error> for PriceEstimationError {
     fn from(value: dto::Error) -> Self {
         match value.kind.as_str() {
             "QuotingFailed" => Self::NoLiquidity,
+            "DeadlineExceeded" => Self::DeadlineExceeded,
             _ => Self::Other(anyhow!("{}", value.description)),
         }
     }


### PR DESCRIPTION
Related to the alert https://cowservices.slack.com/archives/C037PB929ME/p1692593972494599

When orderbook sends quote request to colocated driver (that we now use for quoting on staging) and the driver does not respond in a timely manner, `DeadlineExceeded` error is returned back.

For this particular error I think we should have a separate error type in orderbook api since it does not belong to any other type and it shouldn't be traced with `tracing::error` log level since drivers theoretically can spend as much time as they want.
