### PR TITLE
Cache native price estimates for which there is no liquidity

### DIFF
--- a/crates/autopilot/src/solvable_orders.rs
+++ b/crates/autopilot/src/solvable_orders.rs
@@ -522,10 +522,8 @@ fn get_orders_with_native_prices(
         .get_cached_prices(&traded_tokens)
         .into_iter()
         .flat_map(|(token, result)| {
-            result
-                .ok()
-                .and_then(to_normalized_price)
-                .map(|price| (token, price))
+            let price = to_normalized_price(result.ok()?)?;
+            Some((token, price))
         })
         .collect();
 

--- a/crates/autopilot/src/solvable_orders.rs
+++ b/crates/autopilot/src/solvable_orders.rs
@@ -521,7 +521,12 @@ fn get_orders_with_native_prices(
     let prices: HashMap<_, _> = native_price_estimator
         .get_cached_prices(&traded_tokens)
         .into_iter()
-        .flat_map(|(token, price)| to_normalized_price(price).map(|price| (token, price)))
+        .flat_map(|(token, result)| {
+            result
+                .ok()
+                .and_then(to_normalized_price)
+                .map(|price| (token, price))
+        })
         .collect();
 
     let high_priority_tokens = orders

--- a/crates/shared/src/price_estimation/competition.rs
+++ b/crates/shared/src/price_estimation/competition.rs
@@ -325,9 +325,9 @@ fn is_second_estimate_preferred(query: &Query, a: &Estimate, b: &Estimate) -> bo
 }
 
 fn is_second_error_preferred(a: &PriceEstimationError, b: &PriceEstimationError) -> bool {
-    // Errors are sorted by recoverability. E.g. a rate-limited estimation may yield
-    // Ok if tried again Whereas unsupported order types can never recover
-    // unless code changes. This can be used to decide which errors  we want to
+    // Errors are sorted by recoverability. E.g. a rate-limited estimation may
+    // succeed if tried again, whereas unsupported order types can never recover
+    // unless code changes. This can be used to decide which errors we want to
     // cache
     fn error_to_integer_priority(err: &PriceEstimationError) -> u8 {
         match err {

--- a/crates/shared/src/price_estimation/competition.rs
+++ b/crates/shared/src/price_estimation/competition.rs
@@ -325,18 +325,20 @@ fn is_second_estimate_preferred(query: &Query, a: &Estimate, b: &Estimate) -> bo
 }
 
 fn is_second_error_preferred(a: &PriceEstimationError, b: &PriceEstimationError) -> bool {
-    // NOTE(nlordell): How errors are joined is kind of arbitrary. I decided to
-    // just order them in the following priority.
+    // Errors are sorted by recoverability. E.g. a rate-limited estimation may yield
+    // Ok if tried again Whereas unsupported order types can never recover
+    // unless code changes. This can be used to decide which errors  we want to
+    // cache
     fn error_to_integer_priority(err: &PriceEstimationError) -> u8 {
         match err {
             // highest priority
-            PriceEstimationError::ZeroAmount => 0,
-            PriceEstimationError::UnsupportedToken { .. } => 1,
-            PriceEstimationError::NoLiquidity => 2,
-            PriceEstimationError::Other(_) => 3,
-            PriceEstimationError::DeadlineExceeded => 4,
-            PriceEstimationError::UnsupportedOrderType => 5,
             PriceEstimationError::RateLimited => 6,
+            PriceEstimationError::DeadlineExceeded => 5,
+            PriceEstimationError::Other(_) => 4,
+            PriceEstimationError::UnsupportedToken { .. } => 3,
+            PriceEstimationError::ZeroAmount => 2,
+            PriceEstimationError::NoLiquidity => 1,
+            PriceEstimationError::UnsupportedOrderType => 0,
             // lowest priority
         }
     }
@@ -506,10 +508,10 @@ mod tests {
             PriceEstimationError::Other(err)
                 if err.to_string() == "a" || err.to_string() == "b",
         ));
-        // unsupported token has higher priority than no liquidity
+        // no liquidity has higher priority than unsupported token
         assert!(matches!(
             result[4].as_ref().unwrap_err(),
-            PriceEstimationError::UnsupportedToken { .. },
+            PriceEstimationError::NoLiquidity { .. },
         ));
     }
 

--- a/crates/shared/src/price_estimation/native_price_cache.rs
+++ b/crates/shared/src/price_estimation/native_price_cache.rs
@@ -56,9 +56,11 @@ struct UpdateTask {
     concurrent_requests: usize,
 }
 
+type CacheEntry = Result<f64, PriceEstimationError>;
+
 #[derive(Debug, Clone)]
 struct CachedResult {
-    result: Result<f64, PriceEstimationError>,
+    result: CacheEntry,
     updated_at: Instant,
     requested_at: Instant,
 }
@@ -103,7 +105,7 @@ impl Inner {
         tokens: &[H160],
         max_age: &Duration,
         create_missing_entry: bool,
-    ) -> (Vec<(usize, Result<f64, PriceEstimationError>)>, Vec<usize>) {
+    ) -> (Vec<(usize, CacheEntry)>, Vec<usize>) {
         if tokens.is_empty() {
             return Default::default();
         }

--- a/crates/shared/src/price_estimation/native_price_cache.rs
+++ b/crates/shared/src/price_estimation/native_price_cache.rs
@@ -197,13 +197,16 @@ impl Inner {
 fn should_cache(result: &Result<f64, PriceEstimationError>) -> bool {
     // We don't want to cache errors that we consider transient
     match result {
-        Ok(_) => true,
-        Err(PriceEstimationError::NoLiquidity) => true,
-        Err(PriceEstimationError::ZeroAmount) => true,
-        Err(PriceEstimationError::UnsupportedToken { .. }) => true,
-        Err(PriceEstimationError::UnsupportedOrderType) => true,
-        Err(PriceEstimationError::Other(_)) => false,
-        Err(PriceEstimationError::RateLimited) => false,
+        Ok(_)
+        | Err(PriceEstimationError::NoLiquidity { .. })
+        | Err(PriceEstimationError::UnsupportedToken { .. }) => true,
+        Err(PriceEstimationError::Other(_))
+        | Err(PriceEstimationError::DeadlineExceeded)
+        | Err(PriceEstimationError::RateLimited) => false,
+        Err(PriceEstimationError::ZeroAmount) | Err(PriceEstimationError::UnsupportedOrderType) => {
+            tracing::error!(?result, "Unexpected error in native price cache");
+            false
+        }
     }
 }
 

--- a/crates/shared/src/price_estimation/native_price_cache.rs
+++ b/crates/shared/src/price_estimation/native_price_cache.rs
@@ -1,4 +1,5 @@
 use {
+    super::PriceEstimationError,
     crate::price_estimation::native::{NativePriceEstimateResult, NativePriceEstimating},
     futures::stream::StreamExt,
     itertools::{Either, Itertools},
@@ -41,7 +42,7 @@ impl Metrics {
 pub struct CachingNativePriceEstimator(Arc<Inner>);
 
 struct Inner {
-    cache: Mutex<HashMap<H160, CachedPrice>>,
+    cache: Mutex<HashMap<H160, CachedResult>>,
     high_priority: Mutex<HashSet<H160>>,
     estimator: Box<dyn NativePriceEstimating>,
     max_age: Duration,
@@ -56,8 +57,8 @@ struct UpdateTask {
 }
 
 #[derive(Debug, Clone)]
-struct CachedPrice {
-    price: f64,
+struct CachedResult {
+    result: Result<f64, PriceEstimationError>,
     updated_at: Instant,
     requested_at: Instant,
 }
@@ -67,16 +68,16 @@ impl Inner {
     fn get_cached_price(
         token: &H160,
         now: Instant,
-        cache: &mut MutexGuard<HashMap<H160, CachedPrice>>,
+        cache: &mut MutexGuard<HashMap<H160, CachedResult>>,
         max_age: &Duration,
         create_missing_entry: bool,
-    ) -> Option<f64> {
+    ) -> Option<Result<f64, PriceEstimationError>> {
         match cache.entry(*token) {
             Entry::Occupied(mut entry) => {
                 let entry = entry.get_mut();
                 entry.requested_at = now;
                 let is_recent = now.saturating_duration_since(entry.updated_at) < *max_age;
-                is_recent.then_some(entry.price)
+                is_recent.then_some(entry.result.clone())
             }
             Entry::Vacant(entry) => {
                 if create_missing_entry {
@@ -85,8 +86,8 @@ impl Inner {
                     // This should happen only for prices missing while building the auction.
                     // Otherwise malicious actors could easily cause the cache size to blow up.
                     let outdated_timestamp = now.checked_sub(*max_age).unwrap();
-                    entry.insert(CachedPrice {
-                        price: 0.,
+                    entry.insert(CachedResult {
+                        result: Ok(0.),
                         updated_at: outdated_timestamp,
                         requested_at: now,
                     });
@@ -102,7 +103,7 @@ impl Inner {
         tokens: &[H160],
         max_age: &Duration,
         create_missing_entry: bool,
-    ) -> (Vec<(usize, f64)>, Vec<usize>) {
+    ) -> (Vec<(usize, Result<f64, PriceEstimationError>)>, Vec<usize>) {
         if tokens.is_empty() {
             return Default::default();
         }
@@ -138,7 +139,7 @@ impl Inner {
                     let mut cache = self.cache.lock().unwrap();
                     let price = Self::get_cached_price(token, now, &mut cache, &max_age, false);
                     if let Some(price) = price {
-                        return (index, Ok(price));
+                        return (index, price);
                     }
                 }
 
@@ -151,13 +152,13 @@ impl Inner {
                     .expect("stream yields exactly 1 item");
 
                 // update price in cache
-                if let Ok(price) = result {
+                if should_cache(&result) {
                     let now = Instant::now();
                     let mut cache = self.cache.lock().unwrap();
                     cache.insert(
                         *token,
-                        CachedPrice {
-                            price,
+                        CachedResult {
+                            result: result.clone(),
                             updated_at: now,
                             requested_at: now,
                         },
@@ -190,6 +191,19 @@ impl Inner {
             )
         });
         outdated
+    }
+}
+
+fn should_cache(result: &Result<f64, PriceEstimationError>) -> bool {
+    // We don't want to cache errors that we consider transient
+    match result {
+        Ok(_) => true,
+        Err(PriceEstimationError::NoLiquidity) => true,
+        Err(PriceEstimationError::ZeroAmount) => true,
+        Err(PriceEstimationError::UnsupportedToken { .. }) => true,
+        Err(PriceEstimationError::UnsupportedOrderType) => true,
+        Err(PriceEstimationError::Other(_)) => false,
+        Err(PriceEstimationError::RateLimited) => false,
     }
 }
 
@@ -277,7 +291,10 @@ impl CachingNativePriceEstimator {
     /// Only returns prices that are currently cached. Missing prices will get
     /// prioritized to get fetched during the next cycles of the maintenance
     /// background task.
-    pub fn get_cached_prices(&self, tokens: &[H160]) -> HashMap<H160, f64> {
+    pub fn get_cached_prices(
+        &self,
+        tokens: &[H160],
+    ) -> HashMap<H160, Result<f64, PriceEstimationError>> {
         let (cached_prices, missing_indices) =
             self.0.get_cached_prices(tokens, &self.0.max_age, true);
         Metrics::get()
@@ -286,7 +303,7 @@ impl CachingNativePriceEstimator {
             .inc_by(missing_indices.len() as u64);
         let result = cached_prices
             .iter()
-            .map(|(index, price)| (tokens[*index], *price))
+            .map(|(index, price)| (tokens[*index], price.clone()))
             .collect();
         result
     }
@@ -315,7 +332,7 @@ impl NativePriceEstimating for CachingNativePriceEstimator {
                 .inc_by(cached_prices.len() as u64);
 
             for (index, price) in cached_prices {
-                yield (index, Ok(price));
+                yield (index, price);
             }
 
             if missing_indices.is_empty() {
@@ -378,11 +395,11 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn does_not_cache_failed_estimates() {
+    async fn caches_nonrecoverable_failed_estimates() {
         let mut inner = MockNativePriceEstimating::new();
         inner
             .expect_estimate_native_prices()
-            .times(10)
+            .times(1)
             .returning(move |tokens| {
                 assert_eq!(tokens.len(), 1);
                 futures::stream::iter([(0, Err(PriceEstimationError::NoLiquidity))]).boxed()
@@ -404,6 +421,37 @@ mod tests {
             assert!(matches!(
                 result.as_ref().unwrap_err(),
                 PriceEstimationError::NoLiquidity
+            ));
+        }
+    }
+
+    #[tokio::test]
+    async fn does_not_cache_recoverable_failed_estimates() {
+        let mut inner = MockNativePriceEstimating::new();
+        inner
+            .expect_estimate_native_prices()
+            .times(10)
+            .returning(move |tokens| {
+                assert_eq!(tokens.len(), 1);
+                futures::stream::iter([(0, Err(PriceEstimationError::RateLimited))]).boxed()
+            });
+
+        let estimator = CachingNativePriceEstimator::new(
+            Box::new(inner),
+            Duration::from_millis(30),
+            Default::default(),
+            None,
+            Default::default(),
+            1,
+        );
+
+        for _ in 0..10 {
+            let tokens = &[token(0)];
+            let mut stream = estimator.estimate_native_prices(tokens);
+            let (_, result) = stream.next().await.unwrap();
+            assert!(matches!(
+                result.as_ref().unwrap_err(),
+                PriceEstimationError::RateLimited
             ));
         }
     }
@@ -605,16 +653,16 @@ mod tests {
                 [
                     (
                         t0,
-                        CachedPrice {
-                            price: 0.,
+                        CachedResult {
+                            result: Ok(0.),
                             updated_at: now,
                             requested_at: now,
                         },
                     ),
                     (
                         t1,
-                        CachedPrice {
-                            price: 0.,
+                        CachedResult {
+                            result: Ok(0.),
                             updated_at: now,
                             requested_at: now,
                         },


### PR DESCRIPTION
This should reduce a good chunk of native price estimates we are making to 0x. Currently, we cache native price estimates, but only when the response was a success. This was mainly because we don't want to poison the cache with errors, if there is hope to recover in a subsequent request. 

While this is true for some errors, it is not really true for others. If no price estimator found any liquidity for a token at time t (and none of them were rate limited), it is unlikely they will find liquidity shortly after. Yet, we keep sending out requests to the upstream API as its NoLiquidity response isn't cached anywhere.

This PR changes the priority with which we merge price estimation errors from different estimators into a single top level one (by severity) and then adds logic for which errors should be cached and which ones shouldn't.

My analytics suggest that this is the cause for roughly 1/2-2/3 of native token requests (more during crunch time). I mainly stumbled across this when looking at which tokens we do most native price estimates for (which turned out to be long tail, no name tokens)

<img width="934" alt="image" src="https://github.com/cowprotocol/services/assets/1200333/2a8e2910-ed59-42f1-b4c3-6096f8878626">

<img width="930" alt="image" src="https://github.com/cowprotocol/services/assets/1200333/a66223c3-9e36-4d01-a8f4-32e1c0c3834d">

### Test Plan

Run the orderbook and observe how NoLiquidity estimates now return much faster and increment the "cache hit" counter in the prometheus stats