### PR TITLE
Fix comparison of price estimation errors

### DIFF
--- a/crates/shared/src/price_estimation/competition.rs
+++ b/crates/shared/src/price_estimation/competition.rs
@@ -342,7 +342,7 @@ fn is_second_error_preferred(a: &PriceEstimationError, b: &PriceEstimationError)
             // lowest priority
         }
     }
-    error_to_integer_priority(b) < error_to_integer_priority(a)
+    error_to_integer_priority(b) > error_to_integer_priority(a)
 }
 
 #[derive(prometheus_metric_storage::MetricStorage, Clone, Debug)]
@@ -406,6 +406,17 @@ mod tests {
         std::time::Duration,
         tokio::time::sleep,
     };
+
+    #[test]
+    fn is_second_error_preferred_test() {
+        let a = PriceEstimationError::UnsupportedOrderType;
+        let b = PriceEstimationError::NoLiquidity;
+        let c = PriceEstimationError::RateLimited;
+
+        assert!(is_second_error_preferred(&a, &b));
+        assert!(is_second_error_preferred(&a, &c));
+        assert!(is_second_error_preferred(&b, &c));
+    }
 
     #[tokio::test]
     async fn works() {


### PR DESCRIPTION
Small fix over https://github.com/cowprotocol/services/pull/1790

I noticed that after merging this PR we started getting alerts `PriceEstimaton::UnsupportedOrderType`:
https://cowservices.slack.com/archives/C037PB929ME/p1692718845796679

From the [logs](https://production-6de61f.kb.eu-central-1.aws.cloud.es.io/app/r/s/jsUrh), it is clear that for this specific quote, there were several `NoLiquidity` errors and 1 `UnsupportedOrderType` from 1Inch. In this case, `NoLiquidity` should have won and not `UnsupportedOrderType`

This PR reverts the change in behavior of price estimation errors comparison.
