### PR TITLE
Fix clippy warnings for Rust 1.72.0

### DIFF
--- a/crates/autopilot/src/on_settlement_event_updater.rs
+++ b/crates/autopilot/src/on_settlement_event_updater.rs
@@ -316,34 +316,34 @@ mod tests {
 
         assert!(!updater.update().await.unwrap());
 
-        let query = r#"
+        let query = r"
 INSERT INTO settlements (block_number, log_index, solver, tx_hash, tx_from, tx_nonce)
 VALUES (15875801, 405, '\x', '\x0e9d0f4ea243ac0f02e1d3ecab3fea78108d83bfca632b30e9bc4acb22289c5a', NULL, NULL)
-    ;"#;
+    ;";
         updater.db.0.execute(query).await.unwrap();
 
-        let query = r#"
+        let query = r"
 INSERT INTO auction_transaction (auction_id, tx_from, tx_nonce)
 VALUES (0, '\xa21740833858985e4d801533a808786d3647fb83', 4701)
-    ;"#;
+    ;";
         updater.db.0.execute(query).await.unwrap();
 
-        let query = r#"
+        let query = r"
 INSERT INTO auction_prices (auction_id, token, price)
 VALUES (0, '\x056fd409e1d7a124bd7017459dfea2f387b6d5cd', 6347795727933475088343330979840),
         (0, '\x6b175474e89094c44da98b954eedeac495271d0f', 634671683530053),
         (0, '\xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48', 634553336916241343152390144)
-            ;"#;
+            ;";
 
         updater.db.0.execute(query).await.unwrap();
 
         assert!(updater.update().await.unwrap());
 
-        let query = r#"
+        let query = r"
 SELECT tx_from, tx_nonce
 FROM settlements
 WHERE block_number = 15875801 AND log_index = 405
-        ;"#;
+        ;";
         let (tx_from, tx_nonce): (Vec<u8>, i64) = sqlx::query_as(query)
             .fetch_one(&updater.db.0)
             .await
@@ -354,10 +354,10 @@ WHERE block_number = 15875801 AND log_index = 405
         );
         assert_eq!(tx_nonce, 4701);
 
-        let query = r#"
+        let query = r"
 SELECT auction_id, tx_from, tx_nonce
 FROM auction_transaction
-        ;"#;
+        ;";
         let (auction_id, tx_from, tx_nonce): (i64, Vec<u8>, i64) = sqlx::query_as(query)
             .fetch_one(&updater.db.0)
             .await

--- a/crates/e2e/src/setup/services.rs
+++ b/crates/e2e/src/setup/services.rs
@@ -93,7 +93,7 @@ impl<'a> Services<'a> {
         .into_iter()
         .chain(self.api_autopilot_solver_arguments())
         .chain(Self::api_autopilot_arguments())
-        .chain(extra_args.into_iter());
+        .chain(extra_args);
 
         let args = autopilot::arguments::Arguments::try_parse_from(args).unwrap();
         tokio::task::spawn(autopilot::main(args));
@@ -133,7 +133,7 @@ impl<'a> Services<'a> {
         ]
         .into_iter()
         .chain(self.api_autopilot_solver_arguments())
-        .chain(extra_args.into_iter());
+        .chain(extra_args);
 
         let args = solver::arguments::Arguments::try_parse_from(args).unwrap();
         tokio::task::spawn(solver::run::run(args));
@@ -162,7 +162,7 @@ impl<'a> Services<'a> {
         ]
         .into_iter()
         .chain(self.api_autopilot_solver_arguments())
-        .chain(extra_args.into_iter());
+        .chain(extra_args);
 
         let args = solver::arguments::Arguments::try_parse_from(args).unwrap();
         tokio::task::spawn(solver::run::run(args));

--- a/crates/model/src/quote.rs
+++ b/crates/model/src/quote.rs
@@ -536,7 +536,7 @@ mod tests {
                 "appDataHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
             }),
         ];
-        let expected_errors = vec![
+        let expected_errors = [
             "ECDSA-signed orders cannot be on-chain",
             "ECDSA-signed orders cannot be on-chain",
             "ECDSA-signed orders cannot be on-chain",

--- a/crates/shared/src/account_balances/cached.rs
+++ b/crates/shared/src/account_balances/cached.rs
@@ -182,7 +182,7 @@ impl BalanceFetching for CachingBalanceFetcher {
             }
         }
 
-        cached.extend(missing.into_iter().zip(new_balances.into_iter()));
+        cached.extend(missing.into_iter().zip(new_balances));
         cached.sort_by_key(|(i, _)| *i);
         cached.into_iter().map(|(_, balance)| balance).collect()
     }

--- a/crates/shared/src/account_balances/web3.rs
+++ b/crates/shared/src/account_balances/web3.rs
@@ -495,20 +495,18 @@ mod tests {
             .await
             .unwrap();
 
-        assert!(matches!(
-            fetcher
-                .can_transfer(
-                    &Query {
-                        token: token.address(),
-                        owner: trader.address(),
-                        source: SellTokenSource::External,
-                        interactions: vec![],
-                    },
-                    100.into(),
-                )
-                .await,
-            Ok(_),
-        ));
+        assert!(fetcher
+            .can_transfer(
+                &Query {
+                    token: token.address(),
+                    owner: trader.address(),
+                    source: SellTokenSource::External,
+                    interactions: vec![],
+                },
+                100.into(),
+            )
+            .await
+            .is_ok());
         assert!(matches!(
             fetcher
                 .can_transfer(

--- a/crates/shared/src/event_handling.rs
+++ b/crates/shared/src/event_handling.rs
@@ -609,7 +609,7 @@ mod tests {
         }
 
         async fn append_events(&mut self, events: Vec<EthcontractEvent<T>>) -> Result<()> {
-            self.events.extend(events.into_iter());
+            self.events.extend(events);
             Ok(())
         }
 

--- a/crates/shared/src/sources/balancer_v2/swap/stable_math.rs
+++ b/crates/shared/src/sources/balancer_v2/swap/stable_math.rs
@@ -358,7 +358,7 @@ mod tests {
     #[test]
     fn invariant_converges_at_extreme_values() {
         let amp = 5000.;
-        let balances: Vec<Bfp> = vec!["0.00001", "1200000", "300"]
+        let balances: Vec<Bfp> = ["0.00001", "1200000", "300"]
             .iter()
             .map(|x| Bfp::from_str(x).unwrap())
             .collect();

--- a/crates/shared/src/sources/uniswap_v3/pool_fetching.rs
+++ b/crates/shared/src/sources/uniswap_v3/pool_fetching.rs
@@ -205,9 +205,7 @@ impl PoolsCheckpointHandler {
                     existing_pools.keys(),
                     missing_pools
                 );
-                pools_checkpoint
-                    .missing_pools
-                    .extend(missing_pools.into_iter());
+                pools_checkpoint.missing_pools.extend(missing_pools);
                 (existing_pools, pools_checkpoint.block_number)
             }
             None => Default::default(),

--- a/crates/solver/src/settlement.rs
+++ b/crates/solver/src/settlement.rs
@@ -259,7 +259,7 @@ pub enum PriceCheckTokens {
 impl From<Option<Vec<H160>>> for PriceCheckTokens {
     fn from(token_list: Option<Vec<H160>>) -> Self {
         if let Some(tokens) = token_list {
-            PriceCheckTokens::Tokens(HashSet::from_iter(tokens.into_iter()))
+            PriceCheckTokens::Tokens(HashSet::from_iter(tokens))
         } else {
             PriceCheckTokens::All
         }

--- a/crates/solver/src/settlement/settlement_encoder.rs
+++ b/crates/solver/src/settlement/settlement_encoder.rs
@@ -292,8 +292,8 @@ impl SettlementEncoder {
                 )?
             }
         };
-        self.pre_interactions.extend(interactions.pre.into_iter());
-        self.post_interactions.extend(interactions.post.into_iter());
+        self.pre_interactions.extend(interactions.pre);
+        self.post_interactions.extend(interactions.post);
         Ok(execution)
     }
 
@@ -484,8 +484,8 @@ impl SettlementEncoder {
     /// Returns the total surplus denominated in the native asset for this
     /// solution.
     pub fn total_surplus(&self, external_prices: &ExternalPrices) -> Option<BigRational> {
-        self.user_trades().fold(Some(num::zero()), |acc, trade| {
-            Some(acc? + trade.surplus_in_native_token(external_prices)?)
+        self.user_trades().try_fold(num::zero(), |acc, trade| {
+            Some(acc + trade.surplus_in_native_token(external_prices)?)
         })
     }
 

--- a/crates/solver/src/solver/http_solver/buffers.rs
+++ b/crates/solver/src/solver/http_solver/buffers.rs
@@ -84,7 +84,7 @@ impl BufferRetrieving for BufferRetriever {
             .chain(
                 tokens_without_eth
                     .into_iter()
-                    .zip(join_all(futures).await.into_iter())
+                    .zip(join_all(futures).await)
                     .map(|(&address, balance)| {
                         (address, balance.map_err(BufferRetrievalError::Erc20))
                     }),

--- a/crates/solver/src/solver/naive_solver.rs
+++ b/crates/solver/src/solver/naive_solver.rs
@@ -112,7 +112,7 @@ fn settle_pair(
             return None;
         }
     };
-    multi_order_solver::solve(slippage, orders.into_iter(), uniswap)
+    multi_order_solver::solve(slippage, orders, uniswap)
 }
 
 fn organize_orders_by_token_pair(orders: Vec<LimitOrder>) -> HashMap<TokenPair, Vec<LimitOrder>> {

--- a/crates/solver/src/solver/single_order_solver.rs
+++ b/crates/solver/src/solver/single_order_solver.rs
@@ -623,7 +623,7 @@ fn get_prioritized_orders(
     let market = prioritize_orders(market, prices, order_prioritization_config);
     let limit = prioritize_orders(limit, prices, order_prioritization_config);
 
-    market.into_iter().chain(limit.into_iter()).collect()
+    market.into_iter().chain(limit).collect()
 }
 
 /// Returns the `native_sell_amount / native_buy_amount` of the given order


### PR DESCRIPTION
Fixes new clippy lints of `Rust 1.72.0`.
Mostly:
* remove unnecessary `#` from string literals
* use `try_fold()` instead of `fold()`
* omit `.into_iter()` when function takes `T: IntoIterator`
* don't use `vec![]` when simply array is enough

