### PR TITLE
Index Composable Stable Pools

### DIFF
--- a/crates/driver/src/boundary/liquidity/balancer/v2/mod.rs
+++ b/crates/driver/src/boundary/liquidity/balancer/v2/mod.rs
@@ -9,6 +9,7 @@ use {
     },
     anyhow::{Context, Result},
     contracts::{
+        BalancerV2ComposableStablePoolFactory,
         BalancerV2LiquidityBootstrappingPoolFactory,
         BalancerV2StablePoolFactoryV2,
         BalancerV2Vault,
@@ -149,6 +150,18 @@ async fn init_liquidity(
                     (
                         BalancerFactoryKind::LiquidityBootstrapping,
                         BalancerV2LiquidityBootstrappingPoolFactory::at(&web3, factory.into())
+                            .raw_instance()
+                            .clone(),
+                    )
+                })
+                .collect::<Vec<_>>(),
+            config
+                .composable_stable
+                .iter()
+                .map(|&factory| {
+                    (
+                        BalancerFactoryKind::ComposableStable,
+                        BalancerV2ComposableStablePoolFactory::at(&web3, factory.into())
                             .raw_instance()
                             .clone(),
                     )

--- a/crates/driver/src/infra/config/file/load.rs
+++ b/crates/driver/src/infra/config/file/load.rs
@@ -162,6 +162,7 @@ pub async fn load(network: &blockchain::Network, path: &Path) -> infra::Config {
                         weighted_v3plus,
                         stable,
                         liquidity_bootstrapping,
+                        composable_stable,
                         pool_deny_list,
                     } => liquidity::config::BalancerV2 {
                         vault: vault.into(),
@@ -175,6 +176,10 @@ pub async fn load(network: &blockchain::Network, path: &Path) -> infra::Config {
                             .collect(),
                         stable: stable.into_iter().map(eth::ContractAddress::from).collect(),
                         liquidity_bootstrapping: liquidity_bootstrapping
+                            .into_iter()
+                            .map(eth::ContractAddress::from)
+                            .collect(),
+                        composable_stable: composable_stable
                             .into_iter()
                             .map(eth::ContractAddress::from)
                             .collect(),

--- a/crates/driver/src/infra/config/file/mod.rs
+++ b/crates/driver/src/infra/config/file/mod.rs
@@ -349,6 +349,9 @@ enum BalancerV2Config {
         /// offerings.
         liquidity_bootstrapping: Vec<eth::H160>,
 
+        /// The composable stable pool factory contract addresses.
+        composable_stable: Vec<eth::H160>,
+
         /// Deny listed Balancer V2 pools.
         #[serde(default)]
         pool_deny_list: Vec<eth::H256>,

--- a/crates/driver/src/infra/liquidity/config.rs
+++ b/crates/driver/src/infra/liquidity/config.rs
@@ -147,6 +147,9 @@ pub struct BalancerV2 {
     /// Liquidity bootstrapping pool factory addresses.
     pub liquidity_bootstrapping: Vec<eth::ContractAddress>,
 
+    /// Composable stable pool factory addresses.
+    pub composable_stable: Vec<eth::ContractAddress>,
+
     /// Deny listed Balancer V2 pools.
     ///
     /// Since pools allow for custom controllers and logic, it is possible for
@@ -183,6 +186,16 @@ impl BalancerV2 {
                 contracts::BalancerV2LiquidityBootstrappingPoolFactory::raw_contract(),
                 contracts::BalancerV2NoProtocolFeeLiquidityBootstrappingPoolFactory::raw_contract(),
             ]),
+            // TODO(nlordell): For now, we don't index these pools by default,
+            // they can be enabled once they are tested and verified to be
+            // correctly supported.
+            // composable_stable: factory_addresses(&[
+            //     contracts::BalancerV2ComposableStablePoolFactory::raw_contract(),
+            //     contracts::BalancerV2ComposableStablePoolFactoryV3::raw_contract(),
+            //     contracts::BalancerV2ComposableStablePoolFactoryV4::raw_contract(),
+            //     contracts::BalancerV2ComposableStablePoolFactoryV5::raw_contract(),
+            // ]),
+            composable_stable: Vec::new(),
             pool_deny_list: Vec::new(),
         })
     }

--- a/crates/shared/src/sources/balancer_v2/graph_api.rs
+++ b/crates/shared/src/sources/balancer_v2/graph_api.rs
@@ -166,6 +166,7 @@ pub enum PoolType {
     Stable,
     Weighted,
     LiquidityBootstrapping,
+    ComposableStable,
 }
 
 /// Token data for pools.
@@ -193,6 +194,7 @@ mod pools_query {
                         "Stable",
                         "Weighted",
                         "LiquidityBootstrapping",
+                        "ComposableStable",
                     ]
                 }
             ) {
@@ -314,6 +316,23 @@ mod tests {
                             },
                         ],
                     },
+                    {
+                        "poolType": "ComposableStable",
+                        "address": "0x2222222222222222222222222222222222222222",
+                        "id": "0x1111111111111111111111111111111111111111111111111111111111111111",
+                        "factory": "0x5555555555555555555555555555555555555555",
+                        "swapEnabled": true,
+                        "tokens": [
+                            {
+                                "address": "0x3333333333333333333333333333333333333333",
+                                "decimals": 3,
+                            },
+                            {
+                                "address": "0x4444444444444444444444444444444444444444",
+                                "decimals": 4,
+                            },
+                        ],
+                    },
                 ],
             }))
             .unwrap(),
@@ -373,6 +392,25 @@ mod tests {
                                 address: H160([0x44; 20]),
                                 decimals: 4,
                                 weight: Some(Bfp::from_wei(500_000_000_000_000_000u128.into())),
+                            },
+                        ],
+                    },
+                    PoolData {
+                        pool_type: PoolType::ComposableStable,
+                        id: H256([0x11; 32]),
+                        address: H160([0x22; 20]),
+                        factory: H160([0x55; 20]),
+                        swap_enabled: true,
+                        tokens: vec![
+                            Token {
+                                address: H160([0x33; 20]),
+                                decimals: 3,
+                                weight: None,
+                            },
+                            Token {
+                                address: H160([0x44; 20]),
+                                decimals: 4,
+                                weight: None,
                             },
                         ],
                     },

--- a/crates/shared/src/sources/balancer_v2/pools.rs
+++ b/crates/shared/src/sources/balancer_v2/pools.rs
@@ -8,6 +8,7 @@
 //! types by just implementing the required `BalancerFactory` trait.
 
 pub mod common;
+pub mod composable_stable;
 pub mod liquidity_bootstrapping;
 pub mod stable;
 pub mod weighted;

--- a/crates/shared/src/sources/balancer_v2/pools/composable_stable.rs
+++ b/crates/shared/src/sources/balancer_v2/pools/composable_stable.rs
@@ -1,0 +1,214 @@
+//! Module implementing composable stable pool specific indexing logic.
+
+use {
+    super::{common, FactoryIndexing, PoolIndexing},
+    crate::{
+        ethrpc::Web3CallBatch,
+        sources::balancer_v2::{
+            graph_api::{PoolData, PoolType},
+            swap::fixed_point::Bfp,
+        },
+    },
+    anyhow::Result,
+    contracts::{BalancerV2ComposableStablePool, BalancerV2ComposableStablePoolFactory},
+    ethcontract::BlockId,
+    futures::{future::BoxFuture, FutureExt as _},
+};
+
+pub use super::stable::{AmplificationParameter, PoolState};
+
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct PoolInfo {
+    pub common: common::PoolInfo,
+}
+
+impl PoolIndexing for PoolInfo {
+    fn from_graph_data(pool: &PoolData, block_created: u64) -> Result<Self> {
+        Ok(PoolInfo {
+            common: common::PoolInfo::for_type(PoolType::ComposableStable, pool, block_created)?,
+        })
+    }
+
+    fn common(&self) -> &common::PoolInfo {
+        &self.common
+    }
+}
+
+#[async_trait::async_trait]
+impl FactoryIndexing for BalancerV2ComposableStablePoolFactory {
+    type PoolInfo = PoolInfo;
+    type PoolState = PoolState;
+
+    async fn specialize_pool_info(&self, pool: common::PoolInfo) -> Result<Self::PoolInfo> {
+        Ok(PoolInfo { common: pool })
+    }
+
+    fn fetch_pool_state(
+        &self,
+        pool_info: &Self::PoolInfo,
+        common_pool_state: BoxFuture<'static, common::PoolState>,
+        batch: &mut Web3CallBatch,
+        block: BlockId,
+    ) -> BoxFuture<'static, Result<Option<Self::PoolState>>> {
+        let pool_contract = BalancerV2ComposableStablePool::at(
+            &self.raw_instance().web3(),
+            pool_info.common.address,
+        );
+
+        let scaling_factors = pool_contract
+            .get_scaling_factors()
+            .block(block)
+            .batch_call(batch);
+        let amplification_parameter = pool_contract
+            .get_amplification_parameter()
+            .block(block)
+            .batch_call(batch);
+
+        async move {
+            let common = common_pool_state.await;
+            let scaling_factors = scaling_factors.await?;
+            let amplification_parameter = {
+                let (factor, _, precision) = amplification_parameter.await?;
+                AmplificationParameter::new(factor, precision)?
+            };
+
+            Ok(Some(PoolState {
+                tokens: common
+                    .tokens
+                    .into_iter()
+                    .zip(scaling_factors)
+                    .map(|((address, token), scaling_factor)| {
+                        (
+                            address,
+                            common::TokenState {
+                                scaling_factor: Bfp::from_wei(scaling_factor),
+                                ..token
+                            },
+                        )
+                    })
+                    .collect(),
+                swap_fee: common.swap_fee,
+                amplification_parameter,
+            }))
+        }
+        .boxed()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use {
+        super::*,
+        crate::sources::balancer_v2::graph_api::Token,
+        ethcontract::{H160, H256},
+        ethcontract_mock::Mock,
+        futures::future,
+        maplit::btreemap,
+    };
+
+    #[tokio::test]
+    async fn fetch_pool_state() {
+        let tokens = btreemap! {
+            H160([1; 20]) => common::TokenState {
+                    balance: bfp!("1000.0").as_uint256(),
+                    scaling_factor: Bfp::exp10(0),
+            },
+            H160([2; 20]) => common::TokenState {
+                    balance: bfp!("10.0").as_uint256(),
+                    scaling_factor: bfp!("1.137117595629065656"),
+            },
+            H160([3; 20]) => common::TokenState {
+                    balance: 15_000_000.into(),
+                    scaling_factor: Bfp::exp10(12),
+            },
+        };
+        let swap_fee = bfp!("0.00015");
+        let amplification_parameter =
+            AmplificationParameter::new(200.into(), 10000.into()).unwrap();
+
+        let mock = Mock::new(42);
+        let web3 = mock.web3();
+
+        let pool = mock.deploy(BalancerV2ComposableStablePool::raw_contract().abi.clone());
+        pool.expect_call(
+            BalancerV2ComposableStablePool::signatures().get_amplification_parameter(),
+        )
+        .returns((
+            amplification_parameter.factor(),
+            false,
+            amplification_parameter.precision(),
+        ));
+        pool.expect_call(BalancerV2ComposableStablePool::signatures().get_scaling_factors())
+            .returns(
+                tokens
+                    .values()
+                    .map(|token| token.scaling_factor.as_uint256())
+                    .collect(),
+            );
+
+        let factory = dummy_contract!(BalancerV2ComposableStablePoolFactory, H160::default());
+        let pool_info = PoolInfo {
+            common: common::PoolInfo {
+                id: H256([0x90; 32]),
+                address: pool.address(),
+                tokens: tokens.keys().copied().collect(),
+                scaling_factors: tokens.values().map(|token| token.scaling_factor).collect(),
+                block_created: 1337,
+            },
+        };
+        let common_pool_state = common::PoolState {
+            paused: false,
+            swap_fee,
+            tokens: tokens.clone(),
+        };
+
+        let pool_state = {
+            let mut batch = Web3CallBatch::new(web3.transport().clone());
+            let block = web3.eth().block_number().await.unwrap();
+
+            let pool_state = factory.fetch_pool_state(
+                &pool_info,
+                future::ready(common_pool_state.clone()).boxed(),
+                &mut batch,
+                block.into(),
+            );
+
+            batch.execute_all(100).await;
+            pool_state.await.unwrap()
+        };
+
+        assert_eq!(
+            pool_state,
+            Some(PoolState {
+                tokens,
+                swap_fee,
+                amplification_parameter,
+            })
+        );
+    }
+
+    #[test]
+    fn errors_when_converting_wrong_pool_type() {
+        let pool = PoolData {
+            pool_type: PoolType::Stable,
+            id: H256([2; 32]),
+            address: H160([1; 20]),
+            factory: H160([0xfa; 20]),
+            swap_enabled: true,
+            tokens: vec![
+                Token {
+                    address: H160([0x11; 20]),
+                    decimals: 1,
+                    weight: None,
+                },
+                Token {
+                    address: H160([0x22; 20]),
+                    decimals: 2,
+                    weight: None,
+                },
+            ],
+        };
+
+        assert!(PoolInfo::from_graph_data(&pool, 42).is_err());
+    }
+}

--- a/crates/shared/src/sources/balancer_v2/pools/liquidity_bootstrapping.rs
+++ b/crates/shared/src/sources/balancer_v2/pools/liquidity_bootstrapping.rs
@@ -123,21 +123,21 @@ mod tests {
             H160([1; 20]) => TokenState {
                 common: common::TokenState {
                     balance: bfp!("1000.0").as_uint256(),
-                    scaling_factor: bfp!("1"),
+                    scaling_factor: Bfp::exp10(0),
                 },
                 weight: bfp!("0.5"),
             },
             H160([2; 20]) => TokenState {
                 common: common::TokenState {
                     balance: bfp!("10.0").as_uint256(),
-                    scaling_factor: bfp!("1"),
+                    scaling_factor: Bfp::exp10(0),
                 },
                 weight: bfp!("0.3"),
             },
             H160([3; 20]) => TokenState {
                 common: common::TokenState {
                     balance: 15_000_000.into(),
-                    scaling_factor: bfp!("1000000000000"),
+                    scaling_factor: Bfp::exp10(12),
                 },
                 weight: bfp!("0.2"),
             },
@@ -244,11 +244,11 @@ mod tests {
             tokens: btreemap! {
                 H160([1; 20]) => common::TokenState {
                     balance: 0.into(),
-                    scaling_factor: 1.into(),
+                    scaling_factor: Bfp::exp10(0),
                 },
                 H160([1; 20]) => common::TokenState {
                     balance: 0.into(),
-                    scaling_factor: 1.into(),
+                    scaling_factor: Bfp::exp10(0),
                 },
             },
         };


### PR DESCRIPTION
This PR adds indexing logic for composable stable pools. Notably, composable stable pools need to fetch their scaling factors, as they are "dynamic" and change on chain as a result of their "rate providers" changing.

Note that I left some "TODOs" for enabling composable stable pools on startup by default. These are removed in #1812. 

### Test Plan

Added a unit test to verify indexing logic.
