### PR TITLE
Support Composable Stable Pools in Solvers

### DIFF
--- a/crates/shared/src/price_estimation/http.rs
+++ b/crates/shared/src/price_estimation/http.rs
@@ -355,13 +355,11 @@ impl HttpPriceEstimator {
                 Ok(AmmModel {
                     parameters: AmmParameters::Stable(StablePoolParameters {
                         reserves: pool
-                            .reserves
-                            .iter()
-                            .map(|(token, state)| (*token, state.balance))
+                            .reserves_without_bpt()
+                            .map(|(token, state)| (token, state.balance))
                             .collect(),
                         scaling_rates: pool
-                            .reserves
-                            .into_iter()
+                            .reserves_without_bpt()
                             .map(|(token, state)| {
                                 Ok((token, compute_scaling_rate(state.scaling_factor)?))
                             })

--- a/crates/shared/src/sources/balancer_v2/pools/common.rs
+++ b/crates/shared/src/sources/balancer_v2/pools/common.rs
@@ -259,7 +259,7 @@ pub struct PoolState {
 }
 
 /// Common pool token state information that is shared among all pool types.
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct TokenState {
     pub balance: U256,
     pub scaling_factor: Bfp,

--- a/crates/shared/src/sources/balancer_v2/pools/liquidity_bootstrapping.rs
+++ b/crates/shared/src/sources/balancer_v2/pools/liquidity_bootstrapping.rs
@@ -182,7 +182,7 @@ mod tests {
             swap_fee,
             tokens: tokens
                 .iter()
-                .map(|(address, token)| (*address, token.common.clone()))
+                .map(|(address, token)| (*address, token.common))
                 .collect(),
         };
 

--- a/crates/shared/src/sources/balancer_v2/swap.rs
+++ b/crates/shared/src/sources/balancer_v2/swap.rs
@@ -152,11 +152,13 @@ struct BalancesWithIndices {
 }
 
 impl<'a> StablePoolRef<'a> {
-    /// Composable stable pools have their own BPT tokens as a registered token
-    /// and, when doing "regular swaps" skips the BPT token.
-    ///
     /// This method returns an iterator over the stable pool reserves while
-    /// filtering out the BPT token for the pool (i.e. the pool address).
+    /// filtering out the BPT token for the pool (i.e. the pool address). This
+    /// is used because composable stable pools include their own BPT token
+    /// (i.e. the ERC-20 at the pool address) in its registered tokens (i.e. the
+    /// ERC-20s that can be swapped over the Balancer V2 Vault), however, this
+    /// token is ignored when computing input and output amounts for regular
+    /// swaps.
     ///
     /// <https://etherscan.io/address/0xf9ac7B9dF2b3454E841110CcE5550bD5AC6f875F#code#F2#L278>
     pub fn reserves_without_bpt(&self) -> impl Iterator<Item = (H160, TokenState)> + 'a {

--- a/crates/shared/src/sources/balancer_v2/swap.rs
+++ b/crates/shared/src/sources/balancer_v2/swap.rs
@@ -138,6 +138,7 @@ impl BaselineSolvable for WeightedPoolRef<'_> {
 /// Stable pool data as a reference used for computing input and output amounts.
 #[derive(Debug)]
 pub struct StablePoolRef<'a> {
+    pub address: H160,
     pub reserves: &'a BTreeMap<H160, TokenState>,
     pub swap_fee: Bfp,
     pub amplification_parameter: AmplificationParameter,
@@ -150,7 +151,22 @@ struct BalancesWithIndices {
     balances: Vec<Bfp>,
 }
 
-impl StablePoolRef<'_> {
+impl<'a> StablePoolRef<'a> {
+    /// Composable stable pools have their own BPT tokens as a registered token
+    /// and, when doing "regular swaps" skips the BPT token.
+    ///
+    /// This method returns an iterator over the stable pool reserves while
+    /// filtering out the BPT token for the pool (i.e. the pool address).
+    ///
+    /// <https://etherscan.io/address/0xf9ac7B9dF2b3454E841110CcE5550bD5AC6f875F#code#F2#L278>
+    pub fn reserves_without_bpt(&self) -> impl Iterator<Item = (H160, TokenState)> + 'a {
+        let bpt = self.address;
+        self.reserves
+            .iter()
+            .map(|(token, state)| (*token, *state))
+            .filter(move |&(token, _)| token != bpt)
+    }
+
     fn upscale_balances_with_token_indices(
         &self,
         in_token: &H160,
@@ -158,11 +174,12 @@ impl StablePoolRef<'_> {
     ) -> Result<BalancesWithIndices, Error> {
         let mut balances = vec![];
         let (mut token_index_in, mut token_index_out) = (0, 0);
-        for (index, (token, balance)) in self.reserves.iter().enumerate() {
-            if token == in_token {
+
+        for (index, (token, balance)) in self.reserves_without_bpt().enumerate() {
+            if token == *in_token {
                 token_index_in = index;
             }
-            if token == out_token {
+            if token == *out_token {
                 token_index_out = index;
             }
             balances.push(balance.upscaled_balance()?)
@@ -178,15 +195,14 @@ impl StablePoolRef<'_> {
         self.amplification_parameter
             .with_base(*stable_math::AMP_PRECISION)
     }
-}
 
-impl BaselineSolvable for StablePoolRef<'_> {
-    /// Stable pools use the BaseGeneralPool.sol for these methods, called from
-    /// within `onSwap` https://github.com/balancer-labs/balancer-v2-monorepo/blob/589542001aeca5bdc120404874fe0137f6a4c749/pkg/pool-utils/contracts/BaseGeneralPool.sol#L31-L44
-
-    /// This comes from `swapGivenIn`
-    /// https://github.com/balancer-labs/balancer-v2-monorepo/blob/589542001aeca5bdc120404874fe0137f6a4c749/pkg/pool-utils/contracts/BaseGeneralPool.sol#L46-L63
-    fn get_amount_out(&self, out_token: H160, (in_amount, in_token): (U256, H160)) -> Option<U256> {
+    /// Comes from `_onRegularSwap(true, ...)`:
+    /// https://etherscan.io/address/0xf9ac7B9dF2b3454E841110CcE5550bD5AC6f875F#code#F2#L270
+    fn regular_swap_given_in(
+        &self,
+        out_token: H160,
+        (in_amount, in_token): (U256, H160),
+    ) -> Option<U256> {
         let in_reserves = self.reserves.get(&in_token)?;
         let out_reserves = self.reserves.get(&out_token)?;
         let BalancesWithIndices {
@@ -208,9 +224,13 @@ impl BaselineSolvable for StablePoolRef<'_> {
         out_reserves.downscale_down(out_amount).ok()
     }
 
-    /// Comes from `swapGivenOut`:
-    /// https://github.com/balancer-labs/balancer-v2-monorepo/blob/589542001aeca5bdc120404874fe0137f6a4c749/pkg/pool-utils/contracts/BaseGeneralPool.sol#L65-L82
-    fn get_amount_in(&self, in_token: H160, (out_amount, out_token): (U256, H160)) -> Option<U256> {
+    /// Comes from `_onRegularSwap(false, ...)`:
+    /// https://etherscan.io/address/0xf9ac7B9dF2b3454E841110CcE5550bD5AC6f875F#code#F2#L270
+    fn regular_swap_given_out(
+        &self,
+        in_token: H160,
+        (out_amount, out_token): (U256, H160),
+    ) -> Option<U256> {
         let in_reserves = self.reserves.get(&in_token)?;
         let out_reserves = self.reserves.get(&out_token)?;
         let BalancesWithIndices {
@@ -229,11 +249,36 @@ impl BaselineSolvable for StablePoolRef<'_> {
         )
         .ok()?;
         let amount_in_before_fee = in_reserves.downscale_up(in_amount).ok()?;
-        let in_amount = add_swap_fee_amount(amount_in_before_fee, self.swap_fee).ok()?;
+        add_swap_fee_amount(amount_in_before_fee, self.swap_fee).ok()
+    }
 
-        converge_in_amount(in_amount, out_amount, |x| {
-            self.get_amount_out(out_token, (x, in_token))
-        })
+    /// Comes from `_swapWithBpt`:
+    // https://etherscan.io/address/0xf9ac7B9dF2b3454E841110CcE5550bD5AC6f875F#code#F2#L301
+    fn swap_with_bpt(&self) -> Option<U256> {
+        // TODO: We currently do not implement swapping with BPT for composable
+        // stable pools.
+        None
+    }
+}
+
+impl BaselineSolvable for StablePoolRef<'_> {
+    fn get_amount_out(&self, out_token: H160, (in_amount, in_token): (U256, H160)) -> Option<U256> {
+        if in_token == self.address || out_token == self.address {
+            self.swap_with_bpt()
+        } else {
+            self.regular_swap_given_in(out_token, (in_amount, in_token))
+        }
+    }
+
+    fn get_amount_in(&self, in_token: H160, (out_amount, out_token): (U256, H160)) -> Option<U256> {
+        if in_token == self.address || out_token == self.address {
+            self.swap_with_bpt()
+        } else {
+            let in_amount = self.regular_swap_given_out(in_token, (out_amount, out_token))?;
+            converge_in_amount(in_amount, out_amount, |x| {
+                self.get_amount_out(out_token, (x, in_token))
+            })
+        }
     }
 
     fn gas_cost(&self) -> usize {
@@ -303,10 +348,16 @@ impl BaselineSolvable for WeightedPool {
 impl StablePool {
     fn as_pool_ref(&self) -> StablePoolRef {
         StablePoolRef {
+            address: self.common.address,
             reserves: &self.reserves,
             swap_fee: self.common.swap_fee,
             amplification_parameter: self.amplification_parameter,
         }
+    }
+
+    /// See [`StablePoolRef::reserves_without_bpt`].
+    pub fn reserves_without_bpt(&self) -> impl Iterator<Item = (H160, TokenState)> + '_ {
+        self.as_pool_ref().reserves_without_bpt()
     }
 }
 

--- a/crates/solver/src/liquidity.rs
+++ b/crates/solver/src/liquidity.rs
@@ -346,6 +346,19 @@ pub struct StablePoolOrder {
     pub settlement_handling: Arc<dyn SettlementHandling<Self>>,
 }
 
+impl StablePoolOrder {
+    /// See [`shared::sources::balancer_v2::swap::StablePoolRef::reserves_without_bpt`].
+    pub fn reserves_without_bpt(&self) -> impl Iterator<Item = (H160, TokenState)> + '_ {
+        shared::sources::balancer_v2::swap::StablePoolRef {
+            address: self.address,
+            reserves: &self.reserves,
+            swap_fee: self.fee,
+            amplification_parameter: self.amplification_parameter,
+        }
+        .reserves_without_bpt()
+    }
+}
+
 impl std::fmt::Debug for StablePoolOrder {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "Stable Pool AMM {:?}", self.reserves.keys())

--- a/crates/solver/src/solver/http_solver/instance_creation.rs
+++ b/crates/solver/src/solver/http_solver/instance_creation.rs
@@ -321,15 +321,13 @@ fn amm_models(liquidity: &[Liquidity], gas_model: &GasModel) -> BTreeMap<H160, A
                 Liquidity::BalancerStable(amm) => AmmModel {
                     parameters: AmmParameters::Stable(StablePoolParameters {
                         reserves: amm
-                            .reserves
-                            .iter()
-                            .map(|(token, state)| (*token, state.balance))
+                            .reserves_without_bpt()
+                            .map(|(token, state)| (token, state.balance))
                             .collect(),
                         scaling_rates: amm
-                            .reserves
-                            .iter()
+                            .reserves_without_bpt()
                             .map(|(token, state)| {
-                                Ok((*token, compute_scaling_rate(state.scaling_factor)?))
+                                Ok((token, compute_scaling_rate(state.scaling_factor)?))
                             })
                             .collect::<Result<_>>()
                             .with_context(|| {

--- a/crates/solvers/src/tests/baseline/bal_liquidity.rs
+++ b/crates/solvers/src/tests/baseline/bal_liquidity.rs
@@ -392,3 +392,132 @@ async fn stable() {
         }),
     );
 }
+
+#[tokio::test]
+async fn composable_stable_v4() {
+    let engine = tests::SolverEngine::new(
+        "baseline",
+        tests::Config::String(
+            r#"
+                chain-id = "100"
+                base-tokens = []
+                max-hops = 0
+                max-partial-attempts = 1
+            "#
+            .to_owned(),
+        ),
+    )
+    .await;
+
+    let solution = engine
+        .solve(json!({
+            "id": "1",
+            "tokens": {
+                "0x4b1e2c2762667331bc91648052f646d1b0d35984": {
+                    "decimals": 18,
+                    "symbol": "agEUR",
+                    "referencePrice": "1090118822951692177",
+                    "availableBalance": "0",
+                    "trusted": false
+                },
+                "0x5c78d05b8ecf97507d1cf70646082c54faa4da95": {
+                    "decimals": 18,
+                    "symbol": "bb-agEUR-EURe",
+                    "referencePrice": "10915976478387159906",
+                    "availableBalance": "0",
+                    "trusted": false
+                },
+                "0xcb444e90d8198415266c6a2724b7900fb12fc56e": {
+                    "decimals": 18,
+                    "symbol": "EURe",
+                    "referencePrice": "10917431192660550458",
+                    "availableBalance": "0",
+                    "trusted": true
+                },
+                "0xe91d153e0b41518a2ce8dd3d7944fa863463a97d": {
+                    "decimals": 18,
+                    "symbol": "wxDAI",
+                    "referencePrice": "1000000000000000000",
+                    "availableBalance": "0",
+                    "trusted": true
+                },
+            },
+            "orders": [
+                {
+                    "uid": "0x0101010101010101010101010101010101010101010101010101010101010101\
+                              0101010101010101010101010101010101010101\
+                              01010101",
+                    "sellToken": "0x4b1e2c2762667331bc91648052f646d1b0d35984",
+                    "buyToken": "0xcb444e90d8198415266c6a2724b7900fb12fc56e",
+                    "sellAmount": "10000000000000000000",
+                    "buyAmount": "9500000000000000000",
+                    "feeAmount": "0",
+                    "kind": "sell",
+                    "partiallyFillable": false,
+                    "class": "market",
+                },
+            ],
+            "liquidity": [
+                {
+                    "kind": "stable",
+                    "tokens": {
+                        "0x4b1e2c2762667331bc91648052f646d1b0d35984": {
+                            "balance": "126041615528606990697699",
+                            "scalingFactor": "1",
+                        },
+                        "0x5c78d05b8ecf97507d1cf70646082c54faa4da95": {
+                            "balance": "2596148429267369423681023550322451",
+                            "scalingFactor": "1",
+                        },
+                        "0xcb444e90d8198415266c6a2724b7900fb12fc56e": {
+                            "balance": "170162457652825667152980",
+                            "scalingFactor": "1",
+                        },
+                    },
+                    "fee": "0.0001",
+                    "amplificationParameter": "100.0",
+                    "id": "0",
+                    "address": "0x5c78d05b8ecf97507d1cf70646082c54faa4da95",
+                    "gasEstimate": "183520",
+                },
+            ],
+            "effectiveGasPrice": "1000000000",
+            "deadline": "2106-01-01T00:00:00.000Z"
+        }))
+        .await;
+
+    assert_eq!(
+        solution,
+        json!({
+            "solutions": [
+                {
+                    "id": 0,
+                    "prices": {
+                        "0x4b1e2c2762667331bc91648052f646d1b0d35984": "10029862202766050434",
+                        "0xcb444e90d8198415266c6a2724b7900fb12fc56e": "10000000000000000000"
+                    },
+                    "trades": [
+                        {
+                            "kind": "fulfillment",
+                            "order": "0x0101010101010101010101010101010101010101010101010101010101010101\
+                                        0101010101010101010101010101010101010101\
+                                        01010101",
+                            "executedAmount": "10000000000000000000"
+                        }
+                    ],
+                    "interactions": [
+                        {
+                            "kind": "liquidity",
+                            "internalize": false,
+                            "id": "0",
+                            "inputToken": "0x4b1e2c2762667331bc91648052f646d1b0d35984",
+                            "outputToken": "0xcb444e90d8198415266c6a2724b7900fb12fc56e",
+                            "inputAmount": "10000000000000000000",
+                            "outputAmount": "10029862202766050434"
+                        },
+                    ]
+                },
+            ]
+        }),
+    );
+}

--- a/crates/solvers/src/tests/baseline/buy_order_rounding.rs
+++ b/crates/solvers/src/tests/baseline/buy_order_rounding.rs
@@ -633,3 +633,139 @@ async fn same_path() {
         }),
     );
 }
+
+#[tokio::test]
+async fn balancer_stable() {
+    let engine = tests::SolverEngine::new(
+        "baseline",
+        tests::Config::String(
+            r#"
+                chain-id = "100"
+                base-tokens = []
+                max-hops = 0
+                max-partial-attempts = 1
+            "#
+            .to_owned(),
+        ),
+    )
+    .await;
+
+    let solution = engine
+        .solve(json!({
+            "id": "1",
+            "tokens": {
+                "0x4b1e2c2762667331bc91648052f646d1b0d35984": {
+                    "decimals": 18,
+                    "symbol": "agEUR",
+                    "referencePrice": "1090118822951692177",
+                    "availableBalance": "0",
+                    "trusted": false
+                },
+                "0x5c78d05b8ecf97507d1cf70646082c54faa4da95": {
+                    "decimals": 18,
+                    "symbol": "bb-agEUR-EURe",
+                    "referencePrice": "10915976478387159906",
+                    "availableBalance": "0",
+                    "trusted": false
+                },
+                "0xcb444e90d8198415266c6a2724b7900fb12fc56e": {
+                    "decimals": 18,
+                    "symbol": "EURe",
+                    "referencePrice": "10917431192660550458",
+                    "availableBalance": "0",
+                    "trusted": true
+                },
+                "0xe91d153e0b41518a2ce8dd3d7944fa863463a97d": {
+                    "decimals": 18,
+                    "symbol": "wxDAI",
+                    "referencePrice": "1000000000000000000",
+                    "availableBalance": "0",
+                    "trusted": true
+                },
+            },
+            "orders": [
+                {
+                    "uid": "0x0101010101010101010101010101010101010101010101010101010101010101\
+                              0101010101010101010101010101010101010101\
+                              01010101",
+                    "sellToken": "0x4b1e2c2762667331bc91648052f646d1b0d35984",
+                    "buyToken": "0xcb444e90d8198415266c6a2724b7900fb12fc56e",
+                    "sellAmount": "10500000000000000000",
+                    "buyAmount": "10000000000000000000",
+                    "feeAmount": "0",
+                    "kind": "buy",
+                    "partiallyFillable": false,
+                    "class": "market",
+                },
+            ],
+            "liquidity": [
+                {
+                    "kind": "stable",
+                    "tokens": {
+                        "0x4b1e2c2762667331bc91648052f646d1b0d35984": {
+                            "balance": "126041615528606990697699",
+                            "scalingFactor": "1",
+                        },
+                        "0x5c78d05b8ecf97507d1cf70646082c54faa4da95": {
+                            "balance": "2596148429267369423681023550322451",
+                            "scalingFactor": "1",
+                        },
+                        "0xcb444e90d8198415266c6a2724b7900fb12fc56e": {
+                            "balance": "170162457652825667152980",
+                            "scalingFactor": "1",
+                        },
+                    },
+                    "fee": "0.0001",
+                    "amplificationParameter": "100.0",
+                    "id": "0",
+                    "address": "0x5c78d05b8ecf97507d1cf70646082c54faa4da95",
+                    "gasEstimate": "183520",
+                },
+            ],
+            "effectiveGasPrice": "1000000000",
+            "deadline": "2106-01-01T00:00:00.000Z"
+        }))
+        .await;
+
+    // Here:
+    //
+    // ```
+    // get_amount_in(1.0) = 9.970226684231795303
+    // get_amount_out(9.970226684231795303) = 9.999999999999999999
+    // get_amount_out(9.970226684231795304) = 1.0
+    // ```
+    assert_eq!(
+        solution,
+        json!({
+            "solutions": [
+                {
+                    "id": 0,
+                    "prices": {
+                        "0x4b1e2c2762667331bc91648052f646d1b0d35984": "10000000000000000000",
+                        "0xcb444e90d8198415266c6a2724b7900fb12fc56e": "9970226684231795304"
+                    },
+                    "trades": [
+                        {
+                            "kind": "fulfillment",
+                            "order": "0x0101010101010101010101010101010101010101010101010101010101010101\
+                                        0101010101010101010101010101010101010101\
+                                        01010101",
+                            "executedAmount": "10000000000000000000"
+                        }
+                    ],
+                    "interactions": [
+                        {
+                            "kind": "liquidity",
+                            "internalize": false,
+                            "id": "0",
+                            "inputToken": "0x4b1e2c2762667331bc91648052f646d1b0d35984",
+                            "outputToken": "0xcb444e90d8198415266c6a2724b7900fb12fc56e",
+                            "inputAmount": "9970226684231795304",
+                            "outputAmount": "10000000000000000000"
+                        },
+                    ]
+                },
+            ]
+        }),
+    );
+}


### PR DESCRIPTION
This PR adds composable stable pool support in the `solvers` crate. Specifically:

* It adds logic for the baseline solver to be able to compute input and output amounts for composable stable pools.
* It adds conversion logic for composable stable pools so that they can be supported as regular stable pools by legacy HTTP solvers (a.k.a. Quasimodo).

Composable stable pools are very similar to regular stable pools with the exception of:
* scaling factors are "dynamic" (see #1810 PR which adds indexing logic to fetch these dynamic scaling factors). This is not a problem for our current stable pool implementation, since #1802 already implements the required changes to allow for arbitrary scaling factors.
* they always include their own BPT token in the pool tokens. Note that these BPT tokens as pool tokens are swappable at the Vault level, but do not use the "Curve" algorithm for computing input and output amounts when doing so. Also worth noting that swapping non-BPT tokens from the composable stable pools works by just ignoring the BPT token altogether (see link in comment in code for source) and use the implemented "Curve" formula. This means that our existing stable pool math works when swapping non-BPT tokens over the composable stable pool for both the baseline and Quasimodo solvers (🎉).

This PR does not add support for swapping BPT tokens over composable stable pools.

### Test Plan

E2E baseline tests to check the math.

<details><summary><code>tests::baseline::bal_liquidity::stable</code></summary>

Command:
```sh
python3 -c "print($(curl -s https://rpc.gnosischain.com/ -X POST -H 'content-type: application/json' --data '@-' <<JSON | jq -r '.result'
{
  "jsonrpc": "2.0",
  "method": "eth_call",
  "params": [{
    "from": "0xBA12222222228d8Ba445958a75a0704d566BF2C8",
    "to": "0x5c78d05b8ecf97507d1cf70646082c54faa4da95",
    "data": "0x01ec954a000000000000000000000000000000000000000000000000000000000000008000000000000000000000000000000000000000000000000000000000000001c00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000000000000000000000000000004b1e2c2762667331bc91648052f646d1b0d35984000000000000000000000000cb444e90d8198415266c6a2724b7900fb12fc56e0000000000000000000000000000000000000000000000008ac7230489e800005c78d05b8ecf97507d1cf70646082c54faa4da950000000000000000000000300000000000000000000000000000000000000000000000000000000001c404a50000000000000000000000009008d19f58aabd9ed0d60971565aa8510560ab410000000000000000000000009008d19f58aabd9ed0d60971565aa8510560ab41000000000000000000000000000000000000000000000000000000000000012000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000003000000000000000000000000000000000000000000001ab0bacb962b228984e30000000000000000000000000000000000007ffffffffffd97f4f6d6cfce7713000000000000000000000000000000000000000000002408867aebe7bbe02c54"
  }, "latest"],
  "id": 0
}
JSON
))"
```

Output:
```
10029862202766050434
```

</details>

<details><summary><code>tests::baseline::buy_order_rounding::balancer_stable</code></summary>

Command to compute input amount:
```sh
python3 -c "print($(curl -s https://rpc.gnosischain.com/ -X POST -H 'content-type: application/json' --data '@-' <<JSON | jq -r '.result'
{
  "jsonrpc": "2.0",
  "method": "eth_call",
  "params": [{
    "from": "0xBA12222222228d8Ba445958a75a0704d566BF2C8",
    "to": "0x5c78d05b8ecf97507d1cf70646082c54faa4da95",
    "data": "0x01ec954a000000000000000000000000000000000000000000000000000000000000008000000000000000000000000000000000000000000000000000000000000001c00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000010000000000000000000000004b1e2c2762667331bc91648052f646d1b0d35984000000000000000000000000cb444e90d8198415266c6a2724b7900fb12fc56e0000000000000000000000000000000000000000000000008ac7230489e800005c78d05b8ecf97507d1cf70646082c54faa4da950000000000000000000000300000000000000000000000000000000000000000000000000000000001c404a50000000000000000000000009008d19f58aabd9ed0d60971565aa8510560ab410000000000000000000000009008d19f58aabd9ed0d60971565aa8510560ab41000000000000000000000000000000000000000000000000000000000000012000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000003000000000000000000000000000000000000000000001ab0bacb962b228984e30000000000000000000000000000000000007ffffffffffd97f4f6d6cfce7713000000000000000000000000000000000000000000002408867aebe7bbe02c54"
  }, "latest"],
  "id": 0
}
JSON
))"
```

Output:
```
9970226684231795303
```

Command to check output amounts when converging:
```sh
python3 -c "print($(curl -s https://rpc.gnosischain.com/ -X POST -H 'content-type: application/json' --data '@-' <<JSON | jq -r '.result'
{
  "jsonrpc": "2.0",
  "method": "eth_call",
  "params": [{
    "from": "0xBA12222222228d8Ba445958a75a0704d566BF2C8",
    "to": "0x5c78d05b8ecf97507d1cf70646082c54faa4da95",
    "data": "0x01ec954a000000000000000000000000000000000000000000000000000000000000008000000000000000000000000000000000000000000000000000000000000001c0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000000000000000000000000000000cb444e90d8198415266c6a2724b7900fb12fc56e0000000000000000000000004b1e2c2762667331bc91648052f646d1b0d359840000000000000000000000000000000000000000000000008a5d5c5843c1c2675c78d05b8ecf97507d1cf70646082c54faa4da950000000000000000000000300000000000000000000000000000000000000000000000000000000001c404a50000000000000000000000009008d19f58aabd9ed0d60971565aa8510560ab410000000000000000000000009008d19f58aabd9ed0d60971565aa8510560ab41000000000000000000000000000000000000000000000000000000000000012000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000003000000000000000000000000000000000000000000001ab0bacb962b228984e30000000000000000000000000000000000007ffffffffffd97f4f6d6cfce7713000000000000000000000000000000000000000000002408867aebe7bbe02c54"
  }, "latest"],
  "id": 0
}
JSON
))"

python3 -c "print($(curl -s https://rpc.gnosischain.com/ -X POST -H 'content-type: application/json' --data '@-' <<JSON | jq -r '.result'
{
  "jsonrpc": "2.0",
  "method": "eth_call",
  "params": [{
    "from": "0xBA12222222228d8Ba445958a75a0704d566BF2C8",
    "to": "0x5c78d05b8ecf97507d1cf70646082c54faa4da95",
    "data": "0x01ec954a000000000000000000000000000000000000000000000000000000000000008000000000000000000000000000000000000000000000000000000000000001c0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000000000000000000000000000000cb444e90d8198415266c6a2724b7900fb12fc56e0000000000000000000000004b1e2c2762667331bc91648052f646d1b0d359840000000000000000000000000000000000000000000000008a5d5c5843c1c2685c78d05b8ecf97507d1cf70646082c54faa4da950000000000000000000000300000000000000000000000000000000000000000000000000000000001c404a50000000000000000000000009008d19f58aabd9ed0d60971565aa8510560ab410000000000000000000000009008d19f58aabd9ed0d60971565aa8510560ab41000000000000000000000000000000000000000000000000000000000000012000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000003000000000000000000000000000000000000000000001ab0bacb962b228984e30000000000000000000000000000000000007ffffffffffd97f4f6d6cfce7713000000000000000000000000000000000000000000002408867aebe7bbe02c54"
  }, "latest"],
  "id": 0
}
JSON
))"
```

Output:
```
9999999999999999999
10000000000000000000
```

</details>