### PR TITLE
Enable Composable Stable Pools

### DIFF
--- a/crates/driver/src/infra/config/file/mod.rs
+++ b/crates/driver/src/infra/config/file/mod.rs
@@ -335,21 +335,26 @@ enum BalancerV2Config {
         vault: eth::H160,
 
         /// The weighted pool factory contract addresses.
+        #[serde(default)]
         weighted: Vec<eth::H160>,
 
         /// The weighted pool factory v3+ contract addresses.
+        #[serde(default)]
         weighted_v3plus: Vec<eth::H160>,
 
         /// The stable pool factory contract addresses.
+        #[serde(default)]
         stable: Vec<eth::H160>,
 
         /// The liquidity bootstrapping pool factory contract addresses.
         ///
         /// These are weighted pools with dynamic weights for initial token
         /// offerings.
+        #[serde(default)]
         liquidity_bootstrapping: Vec<eth::H160>,
 
         /// The composable stable pool factory contract addresses.
+        #[serde(default)]
         composable_stable: Vec<eth::H160>,
 
         /// Deny listed Balancer V2 pools.

--- a/crates/driver/src/infra/liquidity/config.rs
+++ b/crates/driver/src/infra/liquidity/config.rs
@@ -186,16 +186,12 @@ impl BalancerV2 {
                 contracts::BalancerV2LiquidityBootstrappingPoolFactory::raw_contract(),
                 contracts::BalancerV2NoProtocolFeeLiquidityBootstrappingPoolFactory::raw_contract(),
             ]),
-            // TODO(nlordell): For now, we don't index these pools by default,
-            // they can be enabled once they are tested and verified to be
-            // correctly supported.
-            // composable_stable: factory_addresses(&[
-            //     contracts::BalancerV2ComposableStablePoolFactory::raw_contract(),
-            //     contracts::BalancerV2ComposableStablePoolFactoryV3::raw_contract(),
-            //     contracts::BalancerV2ComposableStablePoolFactoryV4::raw_contract(),
-            //     contracts::BalancerV2ComposableStablePoolFactoryV5::raw_contract(),
-            // ]),
-            composable_stable: Vec::new(),
+            composable_stable: factory_addresses(&[
+                contracts::BalancerV2ComposableStablePoolFactory::raw_contract(),
+                contracts::BalancerV2ComposableStablePoolFactoryV3::raw_contract(),
+                contracts::BalancerV2ComposableStablePoolFactoryV4::raw_contract(),
+                contracts::BalancerV2ComposableStablePoolFactoryV5::raw_contract(),
+            ]),
             pool_deny_list: Vec::new(),
         })
     }

--- a/crates/shared/src/sources/balancer_v2/pool_fetching.rs
+++ b/crates/shared/src/sources/balancer_v2/pool_fetching.rs
@@ -186,35 +186,27 @@ pub enum BalancerFactoryKind {
 impl BalancerFactoryKind {
     /// Returns a vector with supported factories for the specified chain ID.
     pub fn for_chain(chain_id: u64) -> Vec<Self> {
-        // TODO(nlordell): For now, we don't index these pools by default, they
-        // can be enabled once they are tested and verified to be correctly
-        // supported.
         match chain_id {
-            // 1 => Self::value_variants().to_owned(),
-            1 => vec![
-                Self::Weighted,
-                Self::WeightedV3,
-                Self::WeightedV4,
-                Self::Weighted2Token,
-                Self::StableV2,
-                Self::LiquidityBootstrapping,
-                Self::NoProtocolFeeLiquidityBootstrapping,
-                // Self::ComposableStable,
-                // Self::ComposableStableV3,
-                // Self::ComposableStableV4,
-                // Self::ComposableStableV5,
-            ],
+            1 => Self::value_variants().to_owned(),
             5 => vec![
                 Self::Weighted,
                 Self::WeightedV3,
                 Self::WeightedV4,
                 Self::Weighted2Token,
                 Self::StableV2,
-                // Self::ComposableStableV3,
-                // Self::ComposableStableV4,
-                // Self::ComposableStableV5,
+                Self::ComposableStable,
+                Self::ComposableStableV3,
+                Self::ComposableStableV4,
+                Self::ComposableStableV5,
             ],
-            100 => vec![Self::WeightedV3, Self::WeightedV4, Self::StableV2],
+            100 => vec![
+                Self::WeightedV3,
+                Self::WeightedV4,
+                Self::StableV2,
+                Self::ComposableStableV3,
+                Self::ComposableStableV4,
+                Self::ComposableStableV5,
+            ],
             _ => Default::default(),
         }
     }


### PR DESCRIPTION
This is a follow up to #1810 which enables composable stable pools by default.

### Test Plan

Use a co-located driver and verify that composable stable pools are indexing and producing solutions!

First, use [the Balancer V2 subgraph](https://thegraph.com/hosted-service/subgraph/balancer-labs/balancer-v2) to identify pools to use for each version of composable stable pool:

```graphql
{
  pools(
    first: 100
    where: {
      factory: "${FACTORY}"
      swapEnabled: true
      isPaused: false
    }
  ) {
    id
    tokens {
      address
      balance
    }
  }
}
```

Then, configure the driver to only have composable stable pool liquidity and issue quotes for these token pairs:

```toml
[[solver]]
name = "baseline"
endpoint = "http://127.0.0.1:7872/"
account = "0x0000000000000000000000000000000000000000000000000000000000000001"
relative-slippage = "0.1"

[[submission.mempool]]
mempool = "public"

[liquidity]
base-tokens = []

[[liquidity.balancer-v2]]
vault = "0xBA12222222228d8Ba445958a75a0704d566BF2C8"
composable-stable = [
  "0xf9ac7B9dF2b3454E841110CcE5550bD5AC6f875F", # v0
  "0xdba127fBc23fb20F5929C546af220A991b5C6e01", # v3
  "0xfADa0f4547AB2de89D1304A668C39B3E09Aa7c76", # v4
  "0xDB8d758BCb971e482B2C45f7F8a7740283A1bd3A", # v5
]
```

Some quotes that I tried:

```shell
# V0
curl -s http://localhost:11088/baseline/quote -H 'Content-Type: application/json' --data '@-' <<JSON | jq
{
  "sellToken": "0x2f4eb100552ef93840d5adc30560e5513dfffacb",
  "buyToken": "0x82698aecc9e28e9bb27608bd52cf57f704bd1b83",
  "amount": "1000000000000000000",
  "kind": "buy",
  "deadline": "2024-03-25T00:00:00.000Z"
}
JSON

# V3
curl -s http://localhost:11088/baseline/quote -H 'Content-Type: application/json' --data '@-' <<JSON | jq
{
  "sellToken": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",  
  "buyToken": "0xf4edfad26ee0d23b69ca93112ecce52704e0006f",
  "amount": "1000000000000000000",
  "kind": "buy",
  "deadline": "2024-03-25T00:00:00.000Z"
}
JSON

# V4
curl -s http://localhost:11088/baseline/quote -H 'Content-Type: application/json' --data '@-' <<JSON | jq
{
  "sellToken": "0x7f39c581f595b53c5cb19bd0b3f8da6c935e2ca0",
  "buyToken": "0xe95a203b1a91a908f9b9ce46459d101078c2c3cb",
  "amount": "1000000000000000000",
  "kind": "buy",
  "deadline": "2024-03-25T00:00:00.000Z"
}
JSON

# V5
curl -s http://localhost:11088/baseline/quote -H 'Content-Type: application/json' --data '@-' <<JSON | jq
{
  "sellToken": "0xa35b1b31ce002fbf2058d22f30f95d405200a15b",
  "buyToken": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
  "amount": "1000000000000000000",
  "kind": "buy",
  "deadline": "2024-03-25T00:00:00.000Z"
}
JSON
```

And some sample simulations with the resulting quote calldata (noting that all but one simulations fail on insufficient balance, but the trace reveals the swap amount computations - these were compared to the Baseline solver logs and revealed to match 🧮):

* V0: <https://dashboard.tenderly.co/shared/simulation/89639006-04ea-420f-a413-3984ef966e28>
* V3: <https://dashboard.tenderly.co/shared/simulation/089f740e-9b15-4665-9269-afa16ca90163>
* V4: <https://dashboard.tenderly.co/shared/simulation/c51970df-5fba-453d-a18b-02d1d3d22505> (in particular this pool has dynamic scaling factors and token rates)
* V5: <https://dashboard.tenderly.co/shared/simulation/c506104e-514b-4ba7-ad25-5dab868de866>

### Release notes

Composable stable pools would be enabled by default for networks that don't specify `--balancer-factories` parameter. Since `mainnet` specifies this, we will need to adjust the configuration in the infrastructure repository.

We should have even better support for EURe now (although the Balancer SOR API already supported this token).