### PR TITLE
Parametrize Paraswap UI

### DIFF
--- a/crates/shared/src/arguments.rs
+++ b/crates/shared/src/arguments.rs
@@ -228,7 +228,7 @@ pub struct Arguments {
     pub pool_cache_delay_between_retries_seconds: Duration,
 
     /// The ParaSwap API base url to use.
-    #[clap(long, env, default_value = "https://apiv5.paraswap.io")]
+    #[clap(long, env, default_value = super::paraswap_api::DEFAULT_URL)]
     pub paraswap_api_url: String,
 
     /// Special partner authentication for Paraswap API (allowing higher rater

--- a/crates/shared/src/arguments.rs
+++ b/crates/shared/src/arguments.rs
@@ -227,6 +227,10 @@ pub struct Arguments {
     #[clap(long, env, default_value = "1", value_parser = duration_from_seconds)]
     pub pool_cache_delay_between_retries_seconds: Duration,
 
+    /// The ParaSwap API base url to use.
+    #[clap(long, env, default_value = "https://apiv5.paraswap.io")]
+    pub paraswap_api_url: String,
+
     /// Special partner authentication for Paraswap API (allowing higher rater
     /// limits)
     #[clap(long, env)]

--- a/crates/shared/src/paraswap_api.rs
+++ b/crates/shared/src/paraswap_api.rs
@@ -55,9 +55,7 @@ impl ParaswapApi for DefaultParaswapApi {
             query,
             partner: &self.partner,
         };
-        let request = query
-            .into_request(&self.client, &self.base_url, &self.partner)
-            .send();
+        let request = query.into_request(&self.client, &self.base_url).send();
         let response = request.await?;
         let status = response.status();
         let response_text = response.text().await?;
@@ -315,14 +313,12 @@ struct TransactionBuilderQueryWithPartner<'a> {
 }
 
 impl TransactionBuilderQueryWithPartner<'_> {
-    pub fn into_request(self, client: &Client, base_url: &str, partner: &str) -> RequestBuilder {
+    pub fn into_request(self, client: &Client, base_url: &str) -> RequestBuilder {
         let mut url = crate::url::join(
             &Url::parse(base_url).expect("invalid base url"),
             "/transactions/1",
         );
-        url.query_pairs_mut()
-            .append_pair("ignoreChecks", "true")
-            .append_pair("partner", partner);
+        url.query_pairs_mut().append_pair("ignoreChecks", "true");
 
         tracing::trace!("Paraswap API (transaction) query url: {}", url);
         client.post(url).json(&self)
@@ -414,7 +410,7 @@ mod tests {
 
         let client = Client::new();
         let transaction_response = transaction_query
-            .into_request(&client, "https://apiv5.paraswap.io", "Test")
+            .into_request(&client, "https://apiv5.paraswap.io")
             .send()
             .await
             .unwrap();
@@ -473,7 +469,7 @@ mod tests {
 
         let client = Client::new();
         let transaction_response = transaction_query
-            .into_request(&client, "https://apiv5.paraswap.io", "Test")
+            .into_request(&client, "https://apiv5.paraswap.io")
             .send()
             .await
             .unwrap();

--- a/crates/shared/src/paraswap_api.rs
+++ b/crates/shared/src/paraswap_api.rs
@@ -16,6 +16,8 @@ use {
     thiserror::Error,
 };
 
+pub const DEFAULT_URL: &str = "https://apiv5.paraswap.io";
+
 /// Mockable implementation of the API for unit test
 #[async_trait::async_trait]
 #[mockall::automock]
@@ -373,7 +375,7 @@ mod tests {
             exclude_dexs: None,
         };
 
-        let url = price_query.into_url("https://apiv5.paraswap.io", "cowswap");
+        let url = price_query.into_url(DEFAULT_URL, "cowswap");
         println!("{url}");
         let price_response: PriceResponse = reqwest::get(url)
             .await
@@ -410,7 +412,7 @@ mod tests {
 
         let client = Client::new();
         let transaction_response = transaction_query
-            .into_request(&client, "https://apiv5.paraswap.io")
+            .into_request(&client, DEFAULT_URL)
             .send()
             .await
             .unwrap();
@@ -438,13 +440,12 @@ mod tests {
             exclude_dexs: Some(vec!["ParaSwapPool4".to_string()]),
         };
 
-        let price_response: PriceResponse =
-            reqwest::get(price_query.into_url("https://apiv5.paraswap.io", "Test"))
-                .await
-                .expect("price query failed")
-                .json()
-                .await
-                .expect("Response is not json");
+        let price_response: PriceResponse = reqwest::get(price_query.into_url(DEFAULT_URL, "Test"))
+            .await
+            .expect("price query failed")
+            .json()
+            .await
+            .expect("Response is not json");
 
         println!(
             "Price Response: {}",
@@ -469,7 +470,7 @@ mod tests {
 
         let client = Client::new();
         let transaction_response = transaction_query
-            .into_request(&client, "https://apiv5.paraswap.io")
+            .into_request(&client, DEFAULT_URL)
             .send()
             .await
             .unwrap();
@@ -494,7 +495,7 @@ mod tests {
             exclude_dexs: Some(vec!["Foo".to_string(), "Bar".to_string()]),
         };
 
-        assert_eq!(&query.into_url("https://apiv5.paraswap.io", "Test").to_string(), "https://apiv5.paraswap.io/prices?partner=Test&srcToken=0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee&destToken=0x6810e776880c02933d47db1b9fc05908e5386b96&srcDecimals=18&destDecimals=8&amount=1000000000000000000&side=SELL&network=1&excludeDEXS=Foo%2CBar");
+        assert_eq!(&query.into_url(DEFAULT_URL, "Test").to_string(), "https://apiv5.paraswap.io/prices?partner=Test&srcToken=0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee&destToken=0x6810e776880c02933d47db1b9fc05908e5386b96&srcDecimals=18&destDecimals=8&amount=1000000000000000000&side=SELL&network=1&excludeDEXS=Foo%2CBar");
     }
 
     #[test]
@@ -754,17 +755,16 @@ mod tests {
             exclude_dexs: None,
         };
 
-        let price_response: PriceResponse =
-            reqwest::get(price_query.into_url("https://apiv5.paraswap.io", "Test"))
-                .await
-                .expect("price query failed")
-                .json()
-                .await
-                .expect("Response is not json");
+        let price_response: PriceResponse = reqwest::get(price_query.into_url(DEFAULT_URL, "Test"))
+            .await
+            .expect("price query failed")
+            .json()
+            .await
+            .expect("Response is not json");
 
         let api = DefaultParaswapApi {
             client: Client::new(),
-            base_url: "https://apiv5.paraswap.io".into(),
+            base_url: DEFAULT_URL.into(),
             partner: "Test".into(),
         };
 

--- a/crates/shared/src/price_estimation/factory.rs
+++ b/crates/shared/src/price_estimation/factory.rs
@@ -390,6 +390,7 @@ impl PriceEstimatorCreating for ParaswapPriceEstimator {
         Ok(ParaswapPriceEstimator::new(
             Arc::new(DefaultParaswapApi {
                 client: factory.components.http_factory.create(),
+                base_url: factory.shared_args.paraswap_api_url.clone(),
                 partner: factory
                     .shared_args
                     .paraswap_partner

--- a/crates/shared/src/price_estimation/paraswap.rs
+++ b/crates/shared/src/price_estimation/paraswap.rs
@@ -72,6 +72,7 @@ mod tests {
         let tokens = TokenInfoFetcher { web3 };
         let paraswap = DefaultParaswapApi {
             client: Client::new(),
+            base_url: "https://apiv5.paraswap.io".to_string(),
             partner: "Test".to_string(),
         };
         let estimator = ParaswapPriceEstimator::new(

--- a/crates/shared/src/trade_finding/paraswap.rs
+++ b/crates/shared/src/trade_finding/paraswap.rs
@@ -244,6 +244,7 @@ mod tests {
         let tokens = TokenInfoFetcher { web3 };
         let paraswap = DefaultParaswapApi {
             client: Client::new(),
+            base_url: "https://apiv5.paraswap.io".to_string(),
             partner: "Test".to_string(),
         };
         let finder = ParaswapTradeFinder::new(

--- a/crates/solver/src/run.rs
+++ b/crates/solver/src/run.rs
@@ -354,6 +354,7 @@ pub async fn run(args: Arguments) {
         args.shared.disabled_one_inch_protocols,
         args.shared.disabled_paraswap_dexs,
         args.shared.paraswap_partner,
+        args.shared.paraswap_api_url,
         &http_factory,
         metrics.clone(),
         zeroex_api.clone(),

--- a/crates/solver/src/solver.rs
+++ b/crates/solver/src/solver.rs
@@ -371,6 +371,7 @@ pub async fn create(
     disabled_one_inch_protocols: Vec<String>,
     disabled_paraswap_dexs: Vec<String>,
     paraswap_partner: Option<String>,
+    paraswap_api_url: String,
     http_factory: &HttpClientFactory,
     solver_metrics: Arc<dyn SolverMetrics>,
     zeroex_api: Arc<dyn ZeroExApi>,
@@ -545,6 +546,7 @@ pub async fn create(
                     disabled_paraswap_dexs.clone(),
                     http_factory.create(),
                     paraswap_partner.clone(),
+                    paraswap_api_url.clone(),
                     slippage_calculator,
                 )))),
                 SolverType::BalancerSor => shared(single_order(Box::new(BalancerSorSolver::new(

--- a/crates/solver/src/solver/paraswap_solver.rs
+++ b/crates/solver/src/solver/paraswap_solver.rs
@@ -61,6 +61,7 @@ impl ParaswapSolver {
         disabled_paraswap_dexs: Vec<String>,
         client: Client,
         partner: Option<String>,
+        base_url: String,
         slippage_calculator: SlippageCalculator,
     ) -> Self {
         let allowance_fetcher = AllowanceManager::new(web3, settlement_contract.address());
@@ -72,6 +73,7 @@ impl ParaswapSolver {
             allowance_fetcher: Box::new(allowance_fetcher),
             client: Box::new(DefaultParaswapApi {
                 client,
+                base_url,
                 partner: partner.unwrap_or_else(|| REFERRER.into()),
             }),
             disabled_paraswap_dexs,
@@ -564,6 +566,7 @@ mod tests {
             vec![],
             Client::new(),
             None,
+            "https://apiv5.paraswap.io".into(),
             SlippageCalculator::default(),
         );
 


### PR DESCRIPTION
To allow configuring a reverse proxy to fine-tune how many requests we send to their API.

I also noticed that we weren't yet sending the partner field on transaction building requests.

### Test Plan

CI