### PR TITLE
Update `HooksTrampoline` Address

### DIFF
--- a/crates/contracts/build.rs
+++ b/crates/contracts/build.rs
@@ -436,7 +436,7 @@ fn main() {
         builder
             .add_network_str(MAINNET, "0x01DcB88678aedD0C4cC9552B20F4718550250574")
             .add_network_str(GOERLI, "0x01DcB88678aedD0C4cC9552B20F4718550250574")
-            .add_network_str(GNOSIS, "0xD49Fa4e610d489aB98008bC4424B9F7276fF34bA")
+            .add_network_str(GNOSIS, "0x01DcB88678aedD0C4cC9552B20F4718550250574")
     });
     generate_contract("IUniswapLikeRouter");
     generate_contract("IUniswapLikePair");


### PR DESCRIPTION
Since the Shapella hardfork landed on Gnosis Chain, we no longer need a different address for the hooks trampoline 🎉. 

For more context see https://github.com/cowprotocol/hooks-trampoline/pull/6.

### Test Plan

Contract code is identical on Mainnet and Gnosis Chain.

```shell
rpc='{ "id": 1,"jsonrpc": "2.0","method": "eth_getCode", "params": ["0x01dcb88678aedd0c4cc9552b20f4718550250574", "latest"] }'
diff -u --color \
  <(curl -s https://mainnet.infura.io/v3/$INFURA_PROJECT_ID --data "$rpc" | jq '.result') \
  <(curl -s https://rpc.gnosischain.com/ --data "$rpc" | jq '.result')
```