### PR TITLE
Properly classify http_solver timeout errors

### DIFF
--- a/crates/shared/src/api.rs
+++ b/crates/shared/src/api.rs
@@ -250,7 +250,7 @@ impl IntoWarpReply for PriceEstimationError {
                 StatusCode::BAD_REQUEST,
             ),
             Self::UnsupportedOrderType => {
-                tracing::error!("PriceEstimaton::UnsupportedOrderType");
+                tracing::error!("PriceEstimation::UnsupportedOrderType");
                 internal_error_reply()
             }
             Self::RateLimited => internal_error_reply(),

--- a/crates/shared/src/price_estimation/http.rs
+++ b/crates/shared/src/price_estimation/http.rs
@@ -218,6 +218,7 @@ impl HttpPriceEstimator {
             .await
             .map_err(|err| match err {
                 ApiError::RateLimited => PriceEstimationError::RateLimited,
+                ApiError::DeadlineExceeded => PriceEstimationError::DeadlineExceeded,
                 ApiError::Other(err) => PriceEstimationError::Other(err),
             })
         };


### PR DESCRIPTION
So we don't error log on those somewhat expected errors (currently classified at "Other"). Probably needs a hotfix to get alerts channel under control.