### PR TITLE
Properly classify Paraswap rate limits

### DIFF
--- a/crates/shared/src/trade_finding/paraswap.rs
+++ b/crates/shared/src/trade_finding/paraswap.rs
@@ -174,7 +174,11 @@ impl From<ParaswapResponseError> for TradeError {
     fn from(err: ParaswapResponseError) -> Self {
         match err {
             ParaswapResponseError::InsufficientLiquidity(_) => Self::NoLiquidity,
-            _ => Self::Other(err.into()),
+            ParaswapResponseError::RateLimited => Self::RateLimited,
+            ParaswapResponseError::Request(_)
+            | ParaswapResponseError::Json(_)
+            | ParaswapResponseError::Retryable(_)
+            | ParaswapResponseError::Other(_) => Self::Other(err.into()),
         }
     }
 }


### PR DESCRIPTION
Paraswap rate limit responses are currently not properly converted into rate limit errors. This PR replaces the catch all case in the enum to make sure the compiler forces us to think about this conversion if we add another Paraswap error type.
