### PR TITLE
Enable Simulation-Based ERC-1271 Signature Validation

### DIFF
--- a/crates/autopilot/src/lib.rs
+++ b/crates/autopilot/src/lib.rs
@@ -175,7 +175,7 @@ pub async fn main(args: arguments::Arguments) {
         simulation_web3.clone(),
         args.shared
             .tenderly
-            .get_api_instance(&http_factory, "balance_fetching".into())
+            .get_api_instance(&http_factory, "signature_validating".into())
             .unwrap(),
     );
 

--- a/crates/autopilot/src/lib.rs
+++ b/crates/autopilot/src/lib.rs
@@ -36,7 +36,7 @@ use {
         order_quoting::OrderQuoter,
         price_estimation::factory::{self, PriceEstimatorFactory, PriceEstimatorSource},
         recent_block_cache::CacheConfig,
-        signature_validator::Web3SignatureValidator,
+        signature_validator,
         sources::{
             balancer_v2::{
                 pool_fetching::BalancerContracts,
@@ -165,7 +165,19 @@ pub async fn main(args: arguments::Arguments) {
         .or_else(|| shared::network::block_interval(&network, chain_id))
         .expect("unknown network block interval");
 
-    let signature_validator = Arc::new(Web3SignatureValidator::new(web3.clone()));
+    let signature_validator = args.shared.signatures.validator(
+        signature_validator::Contracts {
+            chain_id,
+            settlement: settlement_contract.address(),
+            vault_relayer,
+        },
+        web3.clone(),
+        simulation_web3.clone(),
+        args.shared
+            .tenderly
+            .get_api_instance(&http_factory, "balance_fetching".into())
+            .unwrap(),
+    );
 
     let balance_fetcher = args.shared.balances.cached(
         account_balances::Contracts {

--- a/crates/orderbook/src/run.rs
+++ b/crates/orderbook/src/run.rs
@@ -38,7 +38,7 @@ use {
             PriceEstimating,
         },
         recent_block_cache::CacheConfig,
-        signature_validator::Web3SignatureValidator,
+        signature_validator,
         sources::{
             self,
             balancer_v2::{
@@ -109,7 +109,19 @@ pub async fn run(args: Arguments) {
         .expect("Failed to retrieve network version ID");
     let network_name = network_name(&network, chain_id);
 
-    let signature_validator = Arc::new(Web3SignatureValidator::new(web3.clone()));
+    let signature_validator = args.shared.signatures.validator(
+        signature_validator::Contracts {
+            chain_id,
+            settlement: settlement_contract.address(),
+            vault_relayer,
+        },
+        web3.clone(),
+        simulation_web3.clone(),
+        args.shared
+            .tenderly
+            .get_api_instance(&http_factory, "balance_fetching".into())
+            .unwrap(),
+    );
 
     let vault = match args.shared.balancer_v2_vault_address {
         Some(address) => Some(contracts::BalancerV2Vault::with_deployment_info(

--- a/crates/orderbook/src/run.rs
+++ b/crates/orderbook/src/run.rs
@@ -119,7 +119,7 @@ pub async fn run(args: Arguments) {
         simulation_web3.clone(),
         args.shared
             .tenderly
-            .get_api_instance(&http_factory, "balance_fetching".into())
+            .get_api_instance(&http_factory, "signature_validating".into())
             .unwrap(),
     );
 

--- a/crates/shared/src/arguments.rs
+++ b/crates/shared/src/arguments.rs
@@ -7,6 +7,7 @@ use {
         gas_price_estimation::GasEstimatorType,
         price_estimation::PriceEstimators,
         rate_limiter::RateLimitingStrategy,
+        signature_validator,
         sources::{
             balancer_v2::BalancerFactoryKind,
             uniswap_v2::UniV2BaselineSourceParameters,
@@ -148,6 +149,9 @@ pub struct Arguments {
 
     #[clap(flatten)]
     pub balances: account_balances::Arguments,
+
+    #[clap(flatten)]
+    pub signatures: signature_validator::Arguments,
 
     #[clap(flatten)]
     pub logging: LoggingArguments,
@@ -403,6 +407,7 @@ impl Display for Arguments {
         write!(f, "{}", self.current_block)?;
         write!(f, "{}", self.tenderly)?;
         write!(f, "{}", self.balances)?;
+        write!(f, "{}", self.signatures)?;
         writeln!(f, "log_filter: {}", self.logging.log_filter)?;
         writeln!(
             f,

--- a/crates/shared/src/signature_validator.rs
+++ b/crates/shared/src/signature_validator.rs
@@ -1,3 +1,4 @@
+mod arguments;
 mod simulation;
 mod web3;
 
@@ -9,7 +10,11 @@ use {
     thiserror::Error,
 };
 
-pub use self::{simulation::Validator as SimulationValidator, web3::Web3SignatureValidator};
+pub use self::{
+    arguments::*,
+    simulation::Validator as SimulationSignatureValidator,
+    web3::Web3SignatureValidator,
+};
 
 /// Structure used to represent a signature.
 #[derive(Clone, Debug, Eq, PartialEq)]

--- a/crates/shared/src/signature_validator/arguments.rs
+++ b/crates/shared/src/signature_validator/arguments.rs
@@ -1,0 +1,115 @@
+use {
+    super::{SignatureValidating, SimulationSignatureValidator, Web3SignatureValidator},
+    crate::{
+        arguments::{display_option, CodeSimulatorKind},
+        code_simulation::{CodeSimulating, TenderlyCodeSimulator, Web3ThenTenderly},
+        tenderly_api::TenderlyApi,
+    },
+    ethcontract::H160,
+    ethrpc::Web3,
+    std::{
+        fmt::{self, Display, Formatter},
+        sync::Arc,
+    },
+};
+
+/// Arguments related to the token owner finder.
+#[derive(clap::Parser)]
+#[group(skip)]
+pub struct Arguments {
+    /// The ERC-1271 signature validation strategy to use.
+    #[clap(long, env, default_value = "web3", value_enum)]
+    pub eip1271_signature_validator: Strategy,
+
+    /// The code simulation implementation to use. Can be one of `Web3`,
+    /// `Tenderly` or `Web3ThenTenderly`.
+    #[clap(long, env, value_enum)]
+    pub eip1271_signature_validator_simulator: Option<CodeSimulatorKind>,
+}
+
+/// Support token owner finding strategies.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, clap::ValueEnum)]
+pub enum Strategy {
+    /// Use basic Ethereum RPC requests to simulate `isValidSignature` calls.
+    ///
+    /// Note that this strategy does not properly support signatures for orders
+    /// with custom interactions.
+    Web3,
+
+    /// Use code simulation techniques to simulate `isValidSignature` calls.
+    ///
+    /// This strategy fully supports signature verification for orders with
+    /// custom interactions.
+    Simulation,
+}
+
+/// Contracts required for balance simulation.
+pub struct Contracts {
+    pub chain_id: u64,
+    pub settlement: H160,
+    pub vault_relayer: H160,
+}
+
+impl Arguments {
+    pub fn validator(
+        &self,
+        contracts: Contracts,
+        web3: Web3,
+        simulation_web3: Option<Web3>,
+        tenderly: Option<Arc<dyn TenderlyApi>>,
+    ) -> Arc<dyn SignatureValidating> {
+        match self.eip1271_signature_validator {
+            Strategy::Web3 => Arc::new(Web3SignatureValidator::new(web3)),
+            Strategy::Simulation => {
+                let web3_simulator =
+                    move || simulation_web3.expect("simulation web3 not configured");
+                let tenderly_simulator = move || {
+                    TenderlyCodeSimulator::new(
+                        tenderly.expect("tenderly api not configured"),
+                        contracts.chain_id,
+                    )
+                };
+
+                let simulator = match self
+                    .eip1271_signature_validator_simulator
+                    .expect("ERC-1271 signature validator simulator not configured")
+                {
+                    CodeSimulatorKind::Web3 => {
+                        Arc::new(web3_simulator()) as Arc<dyn CodeSimulating>
+                    }
+                    CodeSimulatorKind::Tenderly => Arc::new(tenderly_simulator()),
+                    CodeSimulatorKind::Web3ThenTenderly => Arc::new(Web3ThenTenderly::new(
+                        web3_simulator(),
+                        tenderly_simulator(),
+                    )),
+                };
+
+                Arc::new(SimulationSignatureValidator::new(
+                    simulator,
+                    contracts.settlement,
+                    contracts.vault_relayer,
+                ))
+            }
+        }
+    }
+}
+
+impl Display for Arguments {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        writeln!(
+            f,
+            "eip1271_signature_validator: {:?}",
+            self.eip1271_signature_validator
+        )?;
+        display_option(
+            f,
+            "eip1271_signature_validator_simulator",
+            &self
+                .eip1271_signature_validator_simulator
+                .as_ref()
+                .map(|value| format!("{value:?}")),
+        )?;
+
+        Ok(())
+    }
+}


### PR DESCRIPTION
Follow up to #1827 

This PR adds the required simulation options to enable simulation-based ERC-1271 signature verification in order to support smart contract orders that do required setup as pre-hooks.

An example of this would be to have a Composable CoW order be created as a pre-hook and traded in the same transaction. With account abstraction, this would allow for gasless smart orders!

### Test Plan

Will share a manual test once completed. Tx hash or it didn't happen!
