### PR TITLE
Configure 0x For Tests

### DIFF
--- a/crates/shared/src/price_estimation/zeroex.rs
+++ b/crates/shared/src/price_estimation/zeroex.rs
@@ -61,7 +61,6 @@ mod tests {
         ethcontract::futures::FutureExt as _,
         model::order::OrderKind,
         number::nonzero::U256 as NonZeroU256,
-        reqwest::Client,
     };
 
     fn create_estimator(api: Arc<dyn ZeroExApi>, buy_only: bool) -> ZeroExPriceEstimator {
@@ -249,7 +248,7 @@ mod tests {
         let weth = testlib::tokens::WETH;
         let gno = testlib::tokens::GNO;
 
-        let zeroex_api = DefaultZeroExApi::with_default_url(Client::new());
+        let zeroex_api = DefaultZeroExApi::default();
         let estimator = create_estimator(Arc::new(zeroex_api), false);
 
         let result = single_estimate(

--- a/crates/shared/src/price_estimation/zeroex.rs
+++ b/crates/shared/src/price_estimation/zeroex.rs
@@ -248,7 +248,7 @@ mod tests {
         let weth = testlib::tokens::WETH;
         let gno = testlib::tokens::GNO;
 
-        let zeroex_api = DefaultZeroExApi::default();
+        let zeroex_api = DefaultZeroExApi::test();
         let estimator = create_estimator(Arc::new(zeroex_api), false);
 
         let result = single_estimate(

--- a/crates/shared/src/trade_finding/zeroex.rs
+++ b/crates/shared/src/trade_finding/zeroex.rs
@@ -295,7 +295,7 @@ mod tests {
         let weth = testlib::tokens::WETH;
         let gno = testlib::tokens::GNO;
 
-        let zeroex_api = DefaultZeroExApi::default();
+        let zeroex_api = DefaultZeroExApi::test();
         let trader = create_trader(Arc::new(zeroex_api));
 
         let trade = trader

--- a/crates/shared/src/trade_finding/zeroex.rs
+++ b/crates/shared/src/trade_finding/zeroex.rs
@@ -134,7 +134,6 @@ mod tests {
         crate::zeroex_api::{DefaultZeroExApi, MockZeroExApi, PriceResponse, SwapResponse},
         hex_literal::hex,
         number::nonzero::U256 as NonZeroU256,
-        reqwest::Client,
         std::time::Duration,
     };
 
@@ -296,7 +295,7 @@ mod tests {
         let weth = testlib::tokens::WETH;
         let gno = testlib::tokens::GNO;
 
-        let zeroex_api = DefaultZeroExApi::with_default_url(Client::new());
+        let zeroex_api = DefaultZeroExApi::default();
         let trader = create_trader(Arc::new(zeroex_api));
 
         let trade = trader

--- a/crates/shared/src/zeroex_api.rs
+++ b/crates/shared/src/zeroex_api.rs
@@ -390,9 +390,18 @@ impl DefaultZeroExApi {
         })
     }
 
-    /// Create a 0x HTTP API client using the default URL and HTTP client.
+    /// Create a 0x HTTP API client for testing using the default HTTP client.
+    ///
+    /// This method will attempt to read the `ZEROEX_URL` (falling back to the
+    /// default URL) and `ZEROEX_API_KEY` (falling back to no API key) from the
+    /// local environment when creating the API client.
     pub fn test() -> Self {
-        Self::new(&HttpClientFactory::default(), Self::DEFAULT_URL, None).unwrap()
+        Self::new(
+            &HttpClientFactory::default(),
+            std::env::var("ZEROEX_URL").unwrap_or_else(|_| Self::DEFAULT_URL.to_string()),
+            std::env::var("ZEROEX_API_KEY").ok(),
+        )
+        .unwrap()
     }
 
     /// Retrieves specific page of current limit orders.
@@ -407,18 +416,6 @@ impl DefaultZeroExApi {
             .append_pair("page", &page.to_string())
             .append_pair("perPage", &results_per_page.to_string());
         self.request(url).await
-    }
-}
-
-#[cfg(test)]
-impl Default for DefaultZeroExApi {
-    fn default() -> Self {
-        Self::new(
-            &HttpClientFactory::default(),
-            std::env::var("ZEROEX_URL").unwrap_or_else(|_| Self::DEFAULT_URL.to_string()),
-            std::env::var("ZEROEX_API_KEY").ok(),
-        )
-        .unwrap()
     }
 }
 
@@ -584,7 +581,7 @@ mod tests {
     #[tokio::test]
     #[ignore]
     async fn zeroex_swap() {
-        let zeroex_client = DefaultZeroExApi::default();
+        let zeroex_client = DefaultZeroExApi::test();
         let swap_query = SwapQuery {
             sell_token: testlib::tokens::WETH,
             buy_token: testlib::tokens::USDC,
@@ -624,7 +621,7 @@ mod tests {
     #[tokio::test]
     #[ignore]
     async fn excluded_sources() {
-        let zeroex = DefaultZeroExApi::default();
+        let zeroex = DefaultZeroExApi::test();
         let query = SwapQuery {
             sell_token: testlib::tokens::WETH,
             buy_token: addr!("c011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f"), // SNX
@@ -650,7 +647,7 @@ mod tests {
     #[tokio::test]
     #[ignore]
     async fn test_get_orders() {
-        let api = DefaultZeroExApi::default();
+        let api = DefaultZeroExApi::test();
         let result = api.get_orders(&OrdersQuery::default()).await;
         dbg!(&result);
         assert!(result.is_ok());
@@ -659,7 +656,7 @@ mod tests {
     #[tokio::test]
     #[ignore]
     async fn test_get_orders_paginated_with_empty_result() {
-        let api = DefaultZeroExApi::default();
+        let api = DefaultZeroExApi::test();
         // `get_orders()` relies on `get_orders_with_pagination()` not producing and
         // error instead of an response with 0 records. To test that we request
         // a page which should never have a any records and check that it

--- a/crates/shared/src/zeroex_api.rs
+++ b/crates/shared/src/zeroex_api.rs
@@ -390,14 +390,6 @@ impl DefaultZeroExApi {
         })
     }
 
-    /// Create a new 0x HTTP API client using the default URL.
-    pub fn with_default_url(client: Client) -> Self {
-        Self {
-            client,
-            base_url: Self::DEFAULT_URL.parse().unwrap(),
-        }
-    }
-
     /// Create a 0x HTTP API client using the default URL and HTTP client.
     pub fn test() -> Self {
         Self::new(&HttpClientFactory::default(), Self::DEFAULT_URL, None).unwrap()
@@ -418,9 +410,15 @@ impl DefaultZeroExApi {
     }
 }
 
+#[cfg(test)]
 impl Default for DefaultZeroExApi {
     fn default() -> Self {
-        Self::with_default_url(Client::new())
+        Self::new(
+            &HttpClientFactory::default(),
+            std::env::var("ZEROEX_URL").unwrap_or_else(|_| Self::DEFAULT_URL.to_string()),
+            std::env::var("ZEROEX_API_KEY").ok(),
+        )
+        .unwrap()
     }
 }
 

--- a/crates/solver/src/solver/zeroex_solver.rs
+++ b/crates/solver/src/solver/zeroex_solver.rs
@@ -225,7 +225,7 @@ mod tests {
             web3,
             settlement,
             chain_id,
-            Arc::new(DefaultZeroExApi::default()),
+            Arc::new(DefaultZeroExApi::test()),
             Default::default(),
             SlippageCalculator::default(),
         )
@@ -268,7 +268,7 @@ mod tests {
             web3,
             settlement,
             chain_id,
-            Arc::new(DefaultZeroExApi::default()),
+            Arc::new(DefaultZeroExApi::test()),
             Default::default(),
             SlippageCalculator::default(),
         )
@@ -425,7 +425,7 @@ mod tests {
             web3,
             settlement,
             chain_id,
-            Arc::new(DefaultZeroExApi::default()),
+            Arc::new(DefaultZeroExApi::test()),
             Default::default(),
             SlippageCalculator::default(),
         )


### PR DESCRIPTION
In trying to run the orderbook locally to reproduce an issue, I discovered that since 0x changed their API to require an access key, we can no longer run some of the tests.

This PR fixes that by changing the 0x API `Default` implementation to read the URL and API key from environment variables.

### Test Plan

Running the 0x tests with a configured API key now work.
