### PR TITLE
Log Tenderly Simulation URL

### DIFF
--- a/crates/shared/src/code_simulation.rs
+++ b/crates/shared/src/code_simulation.rs
@@ -133,6 +133,15 @@ impl CodeSimulating for TenderlyCodeSimulator {
             })
             .await?;
 
+        let saved = self.save.on_success && result.transaction.status == true
+            || self.save.on_failure && result.transaction.status == false;
+        if saved {
+            tracing::debug!(
+                url =% self.tenderly.simulation_url(&result.simulation.id),
+                "saved simulation"
+            );
+        }
+
         let trace = result
             .transaction
             .call_trace

--- a/crates/shared/src/code_simulation.rs
+++ b/crates/shared/src/code_simulation.rs
@@ -133,8 +133,8 @@ impl CodeSimulating for TenderlyCodeSimulator {
             })
             .await?;
 
-        let saved = self.save.on_success && result.transaction.status == true
-            || self.save.on_failure && result.transaction.status == false;
+        let saved = self.save.on_success && result.transaction.status
+            || self.save.on_failure && !result.transaction.status;
         if saved {
             tracing::debug!(
                 url =% self.tenderly.simulation_url(&result.simulation.id),

--- a/crates/shared/src/price_estimation.rs
+++ b/crates/shared/src/price_estimation.rs
@@ -232,9 +232,14 @@ pub struct Arguments {
     #[clap(long, env)]
     pub trade_simulator: Option<CodeSimulatorKind>,
 
+    /// Flag to enable saving Tenderly simulations in the dashboard for
+    /// successful trade simulations.
+    #[clap(long, env, action = clap::ArgAction::Set, default_value = "false")]
+    pub tenderly_save_successful_trade_simulations: bool,
+
     /// Flag to enable saving Tenderly simulations in the dashboard for failed
     /// trade simulations. This helps debugging reverted quote simulations.
-    #[clap(long, env)]
+    #[clap(long, env, action = clap::ArgAction::Set, default_value = "false")]
     pub tenderly_save_failed_trade_simulations: bool,
 
     /// Controls if we try to predict the winning price estimator for a given
@@ -306,6 +311,11 @@ impl Display for Arguments {
                 .trade_simulator
                 .as_ref()
                 .map(|value| format!("{value:?}")),
+        )?;
+        writeln!(
+            f,
+            "tenderly_save_successful_trade_simulations: {}",
+            self.tenderly_save_successful_trade_simulations
         )?;
         writeln!(
             f,

--- a/crates/shared/src/price_estimation/factory.rs
+++ b/crates/shared/src/price_estimation/factory.rs
@@ -139,10 +139,10 @@ impl<'a> PriceEstimatorFactory<'a> {
                     CodeSimulatorKind::Web3 => {
                         Arc::new(web3_simulator()?) as Arc<dyn CodeSimulating>
                     }
-                    CodeSimulatorKind::Tenderly => Arc::new(
-                        tenderly_simulator()?
-                            .save(false, args.tenderly_save_failed_trade_simulations),
-                    ),
+                    CodeSimulatorKind::Tenderly => Arc::new(tenderly_simulator()?.save(
+                        args.tenderly_save_successful_trade_simulations,
+                        args.tenderly_save_failed_trade_simulations,
+                    )),
                     CodeSimulatorKind::Web3ThenTenderly => {
                         Arc::new(code_simulation::Web3ThenTenderly::new(
                             web3_simulator()?,


### PR DESCRIPTION
This PR does a few of things:

- Adds `TRACE` logs to Tenderly API implementation (this was used to figure out how the `id` could be extracted from the Tenderly simulation response).
- Parses the `id` field from the simulation result
- Builds and logs the URL for the simulation if it was saved.

### Test Plan

Run the orderbook - make sure to enable saving on trade simulations:

```shell
cargo run -p orderbook -- --trade-simulator Tenderly --tenderly-save-successful-trade-simulations true
```

Then, issue a verified quote:

```shell
curl -s http://localhost:8080/api/v1/quote -X POST -H 'content-type: application/json' --data '@-' <<JSON | jq
{
  "from": "0xa03be496e67ec29bc62f01a428683d7f9c204930",
  "sellToken": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
  "buyToken": "0xDEf1CA1fb7FBcDC777520aa7f396b4E015F497aB",
  "kind": "sell",
  "sellAmountBeforeFee": "100000000000000000000",
  "priceQuality": "verified"
}
JSON
```

Observe the log:
```
2023-09-04T13:30:42.231Z DEBUG request{id="0"}: shared::code_simulation: saved simulation url=https://dashboard.tenderly.co/gp-v2/nick/simulator/00b00269-6b8a-46a2-a640-f8596f1f7302
```
