### PR TITLE
Fix gas price for rating settlements

### DIFF
--- a/crates/driver/src/boundary/mempool.rs
+++ b/crates/driver/src/boundary/mempool.rs
@@ -119,7 +119,7 @@ impl Mempool {
             .await?;
         let max_fee_per_gas = eth::U256::from(settlement.gas.price).to_f64_lossy();
         let gas_price_estimator = SubmitterGasPriceEstimator {
-            inner: self.gas_price_estimator.as_ref(),
+            inner: self.gas_price_estimator.clone(),
             max_fee_per_gas: max_fee_per_gas.min(self.config.gas_price_cap),
             additional_tip_percentage_of_max_fee: self.config.additional_tip_percentage,
             max_additional_tip: match self.config.kind {

--- a/crates/driver/src/boundary/settlement.rs
+++ b/crates/driver/src/boundary/settlement.rs
@@ -199,6 +199,7 @@ impl Settlement {
         eth: &Ethereum,
         auction: &competition::Auction,
         gas: eth::Gas,
+        gas_price: eth::GasPrice,
     ) -> Result<competition::solution::Score> {
         let prices = ExternalPrices::try_from_auction_prices(
             eth.contracts().weth().address(),
@@ -212,7 +213,7 @@ impl Settlement {
                 })
                 .collect(),
         )?;
-        let gas_price = eth::U256::from(auction.gas_price().effective()).to_big_rational();
+        let gas_price = eth::U256::from(gas_price.effective()).to_big_rational();
         let inputs = solver::objective_value::Inputs::from_settlement(
             &self.inner,
             &prices,

--- a/crates/driver/src/domain/competition/solution/settlement.rs
+++ b/crates/driver/src/domain/competition/solution/settlement.rs
@@ -264,8 +264,10 @@ impl Settlement {
         &self,
         eth: &Ethereum,
         auction: &competition::Auction,
+        gas_price: eth::GasPrice,
     ) -> Result<super::Score, boundary::Error> {
-        self.boundary.score(eth, auction, self.gas.estimate)
+        self.boundary
+            .score(eth, auction, self.gas.estimate, gas_price)
     }
 
     // TODO(#1478): merge() should be defined on Solution rather than Settlement.

--- a/crates/solver/src/arguments.rs
+++ b/crates/solver/src/arguments.rs
@@ -204,15 +204,15 @@ pub struct Arguments {
     )]
     pub max_submission_seconds: Duration,
 
-    /// Maximum additional tip in gwei that we are willing to give to flashbots
-    /// above regular gas price estimation
+    /// Maximum additional tip in gwei that we are willing to give above regular
+    /// gas price estimation, to a private submission network
     #[clap(
         long,
         env,
         default_value = "3",
         value_parser = shared::arguments::wei_from_gwei
     )]
-    pub max_additional_flashbot_tip: f64,
+    pub max_additional_tip: f64,
 
     /// Amount of time to wait before retrying to submit the tx to the ethereum
     /// network
@@ -405,11 +405,7 @@ impl std::fmt::Display for Arguments {
             "max_submission_seconds: {:?}",
             self.max_submission_seconds
         )?;
-        writeln!(
-            f,
-            "max_additional_flashbots_tip: {}",
-            self.max_additional_flashbot_tip
-        )?;
+        writeln!(f, "max_additional_tip: {}", self.max_additional_tip)?;
         writeln!(
             f,
             "submission_retry_interval_seconds: {:?}",

--- a/crates/solver/src/arguments.rs
+++ b/crates/solver/src/arguments.rs
@@ -194,16 +194,6 @@ pub struct Arguments {
     #[clap(long, env, action = clap::ArgAction::Set, default_value = "false")]
     pub use_soft_cancellations: bool,
 
-    /// Maximum additional tip in gwei that we are willing to give to eden above
-    /// regular gas price estimation
-    #[clap(
-        long,
-        env,
-        default_value = "3",
-        value_parser = shared::arguments::wei_from_gwei
-    )]
-    pub max_additional_eden_tip: f64,
-
     /// The maximum time in seconds we spend trying to settle a transaction
     /// through the ethereum network before going to back to solving.
     #[clap(
@@ -410,11 +400,6 @@ impl std::fmt::Display for Arguments {
         writeln!(f, "eden_api_url: {}", self.eden_api_url)?;
         display_list(f, "flashbots_api_url", &self.flashbots_api_url)?;
         writeln!(f, "use_soft_cancellations: {}", self.use_soft_cancellations)?;
-        writeln!(
-            f,
-            "max_additional_eden_tip: {}",
-            self.max_additional_eden_tip
-        )?;
         writeln!(
             f,
             "max_submission_seconds: {:?}",

--- a/crates/solver/src/driver.rs
+++ b/crates/solver/src/driver.rs
@@ -349,7 +349,7 @@ impl Driver {
 
         let submitter_gas_price_estimator = SubmitterGasPriceEstimator {
             inner: self.gas_price_estimator.inner().clone(),
-            max_fee_per_gas: self.gas_price_estimator.gas_price_cap(),
+            max_fee_per_gas: gas_price.max_fee_per_gas,
             additional_tip_percentage_of_max_fee: self.additional_tip_percentage_of_max_fee,
             max_additional_tip: self.max_additional_tip,
         };

--- a/crates/solver/src/driver/gas.rs
+++ b/crates/solver/src/driver/gas.rs
@@ -40,6 +40,14 @@ impl Estimator {
         self.gas_price_cap = gas_price_cap;
         self
     }
+
+    pub fn inner(&self) -> Arc<dyn GasPriceEstimating> {
+        self.inner.clone()
+    }
+
+    pub fn gas_price_cap(&self) -> f64 {
+        self.gas_price_cap
+    }
 }
 
 #[async_trait::async_trait]

--- a/crates/solver/src/driver/gas.rs
+++ b/crates/solver/src/driver/gas.rs
@@ -44,10 +44,6 @@ impl Estimator {
     pub fn inner(&self) -> Arc<dyn GasPriceEstimating> {
         self.inner.clone()
     }
-
-    pub fn gas_price_cap(&self) -> f64 {
-        self.gas_price_cap
-    }
 }
 
 #[async_trait::async_trait]

--- a/crates/solver/src/run.rs
+++ b/crates/solver/src/run.rs
@@ -473,7 +473,7 @@ pub async fn run(args: Arguments) {
                     submit_api: Box::new(
                         EdenApi::new(http_factory.create(), args.eden_api_url.clone()).unwrap(),
                     ),
-                    max_additional_tip: args.max_additional_flashbot_tip, // todo
+                    max_additional_tip: args.max_additional_tip,
                     additional_tip_percentage_of_max_fee: args.additional_tip_percentage,
                     sub_tx_pool: submitted_transactions.add_sub_pool(Strategy::Eden),
                     use_soft_cancellations: false,
@@ -485,7 +485,7 @@ pub async fn run(args: Arguments) {
                         submit_api: Box::new(
                             FlashbotsApi::new(http_factory.create(), flashbots_url).unwrap(),
                         ),
-                        max_additional_tip: args.max_additional_flashbot_tip,
+                        max_additional_tip: args.max_additional_tip,
                         additional_tip_percentage_of_max_fee: args.additional_tip_percentage,
                         sub_tx_pool: submitted_transactions.add_sub_pool(Strategy::Flashbots),
                         use_soft_cancellations: args.use_soft_cancellations,
@@ -558,7 +558,7 @@ pub async fn run(args: Arguments) {
         gas_price_estimator,
         args.gas_price_cap,
         args.additional_tip_percentage,
-        args.max_additional_flashbot_tip,
+        args.max_additional_tip,
         args.settle_interval,
         native_token.address(),
         metrics.clone(),

--- a/crates/solver/src/run.rs
+++ b/crates/solver/src/run.rs
@@ -473,7 +473,7 @@ pub async fn run(args: Arguments) {
                     submit_api: Box::new(
                         EdenApi::new(http_factory.create(), args.eden_api_url.clone()).unwrap(),
                     ),
-                    max_additional_tip: args.max_additional_eden_tip,
+                    max_additional_tip: args.max_additional_flashbot_tip, // todo
                     additional_tip_percentage_of_max_fee: args.additional_tip_percentage,
                     sub_tx_pool: submitted_transactions.add_sub_pool(Strategy::Eden),
                     use_soft_cancellations: false,
@@ -557,6 +557,8 @@ pub async fn run(args: Arguments) {
         solver,
         gas_price_estimator,
         args.gas_price_cap,
+        args.additional_tip_percentage,
+        args.max_additional_flashbot_tip,
         args.settle_interval,
         native_token.address(),
         metrics.clone(),

--- a/crates/solver/src/settlement.rs
+++ b/crates/solver/src/settlement.rs
@@ -245,7 +245,7 @@ pub struct Settlement {
     pub score: Option<Score>,
 }
 
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Debug, Clone, Eq, PartialEq)]
 pub enum Revertable {
     NoRisk,
     HighRisk,

--- a/crates/solver/src/settlement_submission.rs
+++ b/crates/solver/src/settlement_submission.rs
@@ -322,7 +322,7 @@ impl SolutionSubmitter {
             use_soft_cancellations: strategy_args.use_soft_cancellations,
         };
         let gas_price_estimator = SubmitterGasPriceEstimator {
-            inner: self.gas_price_estimator.as_ref(),
+            inner: self.gas_price_estimator.clone(),
             max_fee_per_gas,
             additional_tip_percentage_of_max_fee,
             max_additional_tip,

--- a/crates/solver/src/settlement_submission/submitter.rs
+++ b/crates/solver/src/settlement_submission/submitter.rs
@@ -15,10 +15,7 @@
 // is only at that point that we need to check the hashes individually to the
 // find the one that got mined (if any).
 
-use {
-    crate::settlement::Revertable,
-    std::sync::Arc,
-};
+use {crate::settlement::Revertable, std::sync::Arc};
 
 mod common;
 pub mod eden_api;
@@ -154,8 +151,8 @@ impl SubmitterGasPriceEstimator {
         }
     }
 
+    // Estimator works differently for each settlement depending on the settlement revert risk
     pub fn with_revertable_risk(&self, revertable: Revertable) -> Self {
-        // No extra tip required if there is no revert risk
         let (additional_tip_percentage_of_max_fee, max_additional_tip) =
             if revertable == Revertable::NoRisk {
                 tracing::debug!("Disabling additional tip because of NoRisk settlement");

--- a/crates/solver/src/settlement_submission/submitter.rs
+++ b/crates/solver/src/settlement_submission/submitter.rs
@@ -151,7 +151,8 @@ impl SubmitterGasPriceEstimator {
         }
     }
 
-    // Estimator works differently for each settlement depending on the settlement revert risk
+    // Estimator works differently for each settlement depending on the settlement
+    // revert risk
     pub fn with_revertable_risk(&self, revertable: Revertable) -> Self {
         let (additional_tip_percentage_of_max_fee, max_additional_tip) =
             if revertable == Revertable::NoRisk {


### PR DESCRIPTION
Currently we boost `max_priority_fee_per_gas` by 3 gwei when submitting the transaction with high revert risk.
The problem is that for rating settlements (and objective value computation) we always use non boosted gas price, leading to inaccuracy.


Now rating settlements is done with boosted gas price also.

~~TODO: update colocated driver~~ Done