### PR TITLE
Remove SubmissionPreference

### DIFF
--- a/crates/shared/src/http_solver/model.rs
+++ b/crates/shared/src/http_solver/model.rs
@@ -268,8 +268,6 @@ pub struct SettledBatchAuctionModel {
     pub approvals: Vec<ApprovalModel>,
     #[serde(default)]
     pub interaction_data: Vec<InteractionData>,
-    #[serde(default)]
-    pub submitter: SubmissionPreference,
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(flatten)]
     pub score: Option<Score>,
@@ -520,15 +518,6 @@ pub enum InternalizationStrategy {
     EncodeAllInteractions,
     #[serde(rename = "Enabled")]
     SkipInternalizableInteraction,
-}
-
-/// Searchers can override submission strategy of the protocol
-#[derive(Debug, Clone, Default, Deserialize, PartialEq, Eq, Serialize)]
-pub enum SubmissionPreference {
-    #[default]
-    ProtocolDefault,
-    Flashbots,
-    PublicMempool,
 }
 
 #[cfg(test)]
@@ -1023,25 +1012,6 @@ mod tests {
             }
         "#;
         assert!(serde_json::from_str::<SettledBatchAuctionModel>(x).is_ok());
-    }
-
-    #[test]
-    fn decode_submitter_flashbots() {
-        let solution = r#"
-            {
-                "tokens": {},
-                "orders": {},
-                "metadata": {
-                    "environment": null
-                },
-                "ref_token": null,
-                "prices": {},
-                "uniswaps": {},
-                "submitter": "Flashbots"
-            }
-        "#;
-        let deserialized = serde_json::from_str::<SettledBatchAuctionModel>(solution).unwrap();
-        assert_eq!(deserialized.submitter, SubmissionPreference::Flashbots);
     }
 
     #[test]

--- a/crates/solver/src/solver/http_solver/settlement.rs
+++ b/crates/solver/src/solver/http_solver/settlement.rs
@@ -151,7 +151,6 @@ struct IntermediateSettlement<'a> {
     executions: Vec<Execution>, // executions are sorted by execution coordinate.
     prices: HashMap<H160, U256>,
     slippage: SlippageContext<'a>,
-    submitter: SubmissionPreference,
     score: Option<Score>,
     // Causes either an error or a fee of 0 whenever a fee is expected but none was provided.
     enforce_correct_fees: bool,
@@ -238,7 +237,6 @@ impl<'a> IntermediateSettlement<'a> {
             settled.interaction_data,
             [executed_limit_orders, foreign_liquidity_orders].concat(),
         );
-        let submitter = settled.submitter;
         let score = settled.score;
 
         if duplicate_coordinates(&executions) {
@@ -252,7 +250,6 @@ impl<'a> IntermediateSettlement<'a> {
             prices,
             approvals,
             slippage,
-            submitter,
             score,
             enforce_correct_fees,
         })
@@ -260,7 +257,6 @@ impl<'a> IntermediateSettlement<'a> {
 
     fn into_settlement(self) -> Result<Settlement> {
         let mut settlement = Settlement::new(self.prices);
-        settlement.submitter = self.submitter;
         settlement.score = self.score;
 
         // Make sure to always add approval interactions **before** any


### PR DESCRIPTION
I came across this field when checking what else needs to be ported to colocated driver.

This field is not used in colocated world and I would rather remove it since it is not used anymore (no solver is sending it) (and there is not much sense for it to exist). 

Colocated driver is supposed to determine the submission strategies based on revert risk. And we also landed on a pretty decent public mempool + Mevblocker setup.
