### PR TITLE
Settlement score mandatory

### DIFF
--- a/crates/shared/src/http_solver/model.rs
+++ b/crates/shared/src/http_solver/model.rs
@@ -14,7 +14,8 @@ use {
     num::BigRational,
     number::u256_decimal::{self, DecimalU256},
     primitive_types::{H256, U256},
-    serde::{Deserialize, Serialize},
+    serde::{Deserialize, Deserializer, Serialize},
+    serde_json::Value,
     serde_with::serde_as,
     std::collections::{BTreeMap, BTreeSet, HashMap},
     web3::types::AccessList,
@@ -223,6 +224,24 @@ impl Default for Score {
     }
 }
 
+fn deserialize_optional_score<'de, D>(deserializer: D) -> Result<Score, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let value: Value = Deserialize::deserialize(deserializer)?;
+    match &value {
+        Value::Object(map)
+            if !map.contains_key("score")
+                && !map.contains_key("scoreDiscount")
+                && !map.contains_key("success_probability")
+                && !map.contains_key("gas_amount") =>
+        {
+            Ok(Score::default())
+        }
+        _ => serde_json::from_value(value).map_err(serde::de::Error::custom),
+    }
+}
+
 impl Score {
     // Returns a new merged score, if possible. Currently only supports merging
     // scores of same variant.
@@ -279,9 +298,8 @@ pub struct SettledBatchAuctionModel {
     pub interaction_data: Vec<InteractionData>,
     #[serde(default)]
     pub submitter: SubmissionPreference,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    #[serde(flatten)]
-    pub score: Option<Score>,
+    #[serde(flatten, deserialize_with = "deserialize_optional_score")]
+    pub score: Score,
     pub metadata: Option<SettledBatchAuctionMetadataModel>,
 }
 
@@ -946,9 +964,9 @@ mod tests {
         let deserialized = serde_json::from_str::<SettledBatchAuctionModel>(solution).unwrap();
         assert_eq!(
             deserialized.score,
-            Some(Score::Solver {
+            Score::Solver {
                 score: 20_000_000_000_000_000u128.into()
-            })
+            }
         );
     }
 
@@ -967,9 +985,9 @@ mod tests {
         let deserialized = serde_json::from_str::<SettledBatchAuctionModel>(solution).unwrap();
         assert_eq!(
             deserialized.score,
-            Some(Score::Discount {
+            Score::Discount {
                 score_discount: 1337.into()
-            })
+            }
         );
     }
 
@@ -990,10 +1008,10 @@ mod tests {
             serde_json::from_str::<SettledBatchAuctionModel>(solution_with_gas)
                 .unwrap()
                 .score,
-            Some(Score::RiskAdjusted {
+            Score::RiskAdjusted {
                 success_probability: 0.9,
                 gas_amount: Some(4269.into())
-            })
+            }
         );
 
         let solution_without_gas = r#"
@@ -1010,10 +1028,10 @@ mod tests {
             serde_json::from_str::<SettledBatchAuctionModel>(solution_without_gas)
                 .unwrap()
                 .score,
-            Some(Score::RiskAdjusted {
+            Score::RiskAdjusted {
                 success_probability: 0.9,
                 gas_amount: None
-            })
+            }
         );
     }
 

--- a/crates/shared/src/http_solver/model.rs
+++ b/crates/shared/src/http_solver/model.rs
@@ -214,6 +214,15 @@ pub enum Score {
     },
 }
 
+impl Default for Score {
+    fn default() -> Self {
+        Score::RiskAdjusted {
+            success_probability: 1.0,
+            gas_amount: None,
+        }
+    }
+}
+
 impl Score {
     // Returns a new merged score, if possible. Currently only supports merging
     // scores of same variant.

--- a/crates/solver/src/settlement.rs
+++ b/crates/solver/src/settlement.rs
@@ -242,7 +242,7 @@ pub struct Settlement {
     pub encoder: SettlementEncoder,
     pub submitter: SubmissionPreference, /* todo - extract submitter and score into a separate
                                           * struct */
-    pub score: Option<Score>,
+    pub score: Score,
 }
 
 #[derive(Debug, Eq, PartialEq)]
@@ -477,10 +477,10 @@ impl Settlement {
         Ok(Self {
             encoder: merged,
             submitter: self.submitter,
-            score: match (self.score, other.score) {
-                (Some(left), Some(right)) => left.merge(&right),
-                _ => None,
-            },
+            score: self
+                .score
+                .merge(&other.score)
+                .ok_or(anyhow::anyhow!("score merge failed"))?,
         })
     }
 

--- a/crates/solver/src/solver/http_solver/settlement.rs
+++ b/crates/solver/src/solver/http_solver/settlement.rs
@@ -261,7 +261,7 @@ impl<'a> IntermediateSettlement<'a> {
     fn into_settlement(self) -> Result<Settlement> {
         let mut settlement = Settlement::new(self.prices);
         settlement.submitter = self.submitter;
-        settlement.score = self.score;
+        settlement.score = self.score.unwrap_or_default();
 
         // Make sure to always add approval interactions **before** any
         // interactions from the execution plan - the execution plan typically

--- a/crates/solver/src/solver/http_solver/settlement.rs
+++ b/crates/solver/src/solver/http_solver/settlement.rs
@@ -152,7 +152,7 @@ struct IntermediateSettlement<'a> {
     prices: HashMap<H160, U256>,
     slippage: SlippageContext<'a>,
     submitter: SubmissionPreference,
-    score: Option<Score>,
+    score: Score,
     // Causes either an error or a fee of 0 whenever a fee is expected but none was provided.
     enforce_correct_fees: bool,
 }
@@ -261,7 +261,7 @@ impl<'a> IntermediateSettlement<'a> {
     fn into_settlement(self) -> Result<Settlement> {
         let mut settlement = Settlement::new(self.prices);
         settlement.submitter = self.submitter;
-        settlement.score = self.score.unwrap_or_default();
+        settlement.score = self.score;
 
         // Make sure to always add approval interactions **before** any
         // interactions from the execution plan - the execution plan typically


### PR DESCRIPTION
After https://github.com/cowprotocol/services/pull/1843, this is another initiative to make `Settlement` cleaner for the needs of porting the risk/score calculation to colocated driver.

Now the `score` is non-optional, with the default value `Score::RiskAdjusted` which is equivalent to `score: None` (from the POV how the protocol handles `score: None`) but more explicit.

Note: ~~Initially I wanted to make the score non optional in the `SettledBatchAuctionModel` during deserialization, but I couldn't make piece between #[flatten] and #[default] on untagged enum. If anyone knows about any workaround let me know.~~ Added custom deserializator 
