### PR TITLE
Fix Asset Flow Verification

### DIFF
--- a/crates/driver/src/domain/competition/order/mod.rs
+++ b/crates/driver/src/domain/competition/order/mod.rs
@@ -261,9 +261,11 @@ pub enum Kind {
     /// price is such that the order can be executed. Because the fulfillment
     /// can happen any time into the future, it's impossible to calculate
     /// the order fees ahead of time, so the fees are taken from the order
-    /// surplus instead. (The order surplus is the additional money that the
-    /// solver managed to solve for, above what the user specified in the
-    /// order.)
+    /// surplus instead.
+    ///
+    /// The order surplus is the additional money that the solver managed to
+    /// solve for, above what the user specified in the order. The exact amount
+    /// of fees that are taken is determined by the solver.
     Limit,
     /// An order submitted by a privileged user, which provides liquidity for
     /// our settlement contract.


### PR DESCRIPTION
This PR fixes asset flow verification issue that was causing partially fillable limit order to not settle.

The reason for this is two-fold:
- The existing asset flow verification algorithm was originally implemented with fill-or-kill limit orders in mind. This means it was under the assumption that the solvers were seeing the "synthetic" orders with the protocol-computed fee amount already discounted from the order. This means that the `Execution` that was being computed was the "real" input/output amount with the protocol computed surplus fees "staying" the settlement contract (for the purpose of asset flow verification). 
- Now surplus fees are computed by solvers and the algorithm that the solver uses **makes it so the fee stays in the buy token when then order is fully executed**. This means that we would actually "over-trade" in sell token, and send less than the final output amount that we would receive. This resulted in asset flow verification failing (negative sell token flow, despite a positive buy token flow to compensate it). 

The fix is to not pretend that solver computed fees stay in the smart contract. This leads the asset flow verification to be slightly optimistic, but not fail for valid settlements.

### Test Plan

Tests continue to pass (expected as we made asset flow verification slightly more lenient).
