### PR TITLE
Don't Match Liquidity Orders Against Onchain Liquidity

### DIFF
--- a/crates/solvers/src/domain/order.rs
+++ b/crates/solvers/src/domain/order.rs
@@ -74,11 +74,11 @@ pub enum Class {
 
 /// A user order, guaranteed to not be a liquidity order.
 ///
-/// Note that the concept of a user order is important enough to
-/// merit its own type. The reason for this is that these orders and liquidity
-/// orders differ in fundamental ways and we do not want to confuse them and
-/// accidentally use a liquidity order where it shouldn't be used. Some of the
-/// notable differences between the order types are:
+/// Note that the concept of a user order is important enough to merit its own
+/// type. The reason for this is that these orders and liquidity orders differ
+/// in fundamental ways and we do not want to confuse them and accidentally use
+/// a liquidity order where it shouldn't be used. Some of the notable
+/// differences between the order types are:
 ///
 /// - Liquidity orders can't be settled directly against on-chain liquidity.
 ///   They are meant to only be used in CoWs to facilitate the trading of other


### PR DESCRIPTION
This PR fixes DEX aggregator API based solvers to not try and solve liquidity orders.

### Test Plan

Rust CI - `UserOrder` logic is already tested.
