### PR TITLE
Fix score deserialization

### DIFF
--- a/crates/shared/src/http_solver/model.rs
+++ b/crates/shared/src/http_solver/model.rs
@@ -229,17 +229,7 @@ where
     D: Deserializer<'de>,
 {
     let value: Value = Deserialize::deserialize(deserializer)?;
-    match &value {
-        Value::Object(map)
-            if !map.contains_key("score")
-                && !map.contains_key("scoreDiscount")
-                && !map.contains_key("success_probability")
-                && !map.contains_key("gas_amount") =>
-        {
-            Ok(Score::default())
-        }
-        _ => serde_json::from_value(value).map_err(serde::de::Error::custom),
-    }
+    Ok(serde_json::from_value(value).unwrap_or(Score::default()))
 }
 
 impl Score {


### PR DESCRIPTION
Fix after https://github.com/cowprotocol/services/pull/1846

One of the solvers is sending `score: null` and it fails deserialization. This PR lands on a much simpler logic to support this edge case.