### PR TITLE
Detect Tenderly Simulation Reverts

### DIFF
--- a/crates/driver/src/infra/simulator/tenderly/dto.rs
+++ b/crates/driver/src/infra/simulator/tenderly/dto.rs
@@ -27,6 +27,7 @@ pub struct Request {
 pub struct Response {
     pub transaction: Transaction,
     pub generated_access_list: Option<AccessList>,
+    pub simulation: Simulation,
 }
 
 #[derive(Debug, Deserialize)]
@@ -74,4 +75,9 @@ impl From<AccessList> for eth::AccessList {
             .collect_vec()
             .into()
     }
+}
+
+#[derive(Debug, Deserialize)]
+pub struct Simulation {
+    pub id: String,
 }

--- a/crates/driver/src/infra/simulator/tenderly/dto.rs
+++ b/crates/driver/src/infra/simulator/tenderly/dto.rs
@@ -25,22 +25,14 @@ pub struct Request {
 
 #[derive(Debug, Deserialize)]
 pub struct Response {
-    transaction: Transaction,
-    generated_access_list: Option<AccessList>,
-}
-
-impl From<Response> for super::Simulation {
-    fn from(res: Response) -> Self {
-        Self {
-            gas: res.transaction.gas_used.into(),
-            access_list: res.generated_access_list.unwrap_or_default().into(),
-        }
-    }
+    pub transaction: Transaction,
+    pub generated_access_list: Option<AccessList>,
 }
 
 #[derive(Debug, Deserialize)]
-struct Transaction {
-    gas_used: u64,
+pub struct Transaction {
+    pub status: bool,
+    pub gas_used: u64,
 }
 
 /// Tenderly requires access lists to be serialized with `snake_case` instead


### PR DESCRIPTION
It turns out, we were ignoring whether or not the Tenderly simulation would revert when analyzing the simulation (where the calling code would expect a revert to produce an `Err` and not an `Ok`).

This PR fixes that by inspecting the Tenderly `status` bool from the response.

### Test Plan

Not sure how to test this beyond a manual test. Would be nice to do an E2E test with Tenderly, but that would be prone to sporadic failures.

Some manual testing, here is a [detected revert](https://dashboard.tenderly.co/shared/simulation/ea10454c-fe53-494a-9025-b4f6eec694c5):

```
2023-09-09T12:11:08.252Z  INFO request{id="152"}:/solve{solver=mybologna auction_id=8842275}: driver::infra::observe: discarded solution: settlement encoding failed id=Id(0) err=Simulation(Tenderly(Revert(SimulationId("ea10454c-fe53-494a-9025-b4f6eec694c5"))))
```

Note that we also still save [successful simlutions](https://dashboard.tenderly.co/shared/simulation/1aedb50f-0be0-41a8-89d4-03d739efa5ff) (note that the ID appended to the calldata matches the logs):

```
2023-09-09T12:16:25.117Z  INFO request{id="5"}:/solve{solver=mybologna auction_id=8842307}: driver::infra::observe: solved auction solved=Solved { score: Score(18107573760852102) }
2023-09-09T12:16:25.121Z  INFO request{id="6"}:/reveal{solver=mybologna auction_id=8842307}: driver::infra::observe: revealed calldata=Revealed { orders: {Uid(0xd7a120b7e73001670ed169084dc06951f397c9073efe83324430b6ac813a2e29dbc682d0ec19bd276fd6c2af4e0189b584bb31e164fc6907)}, internalized_calldata: 0x...086ec43, uninternalized_calldata: 0x...086ec43 }
```
