### PR TITLE
Fix autodeploy

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -58,7 +58,7 @@ jobs:
       - uses: cowprotocol/autodeploy-action@v1
         if: ${{ github.ref == 'refs/heads/main' }}
         with:
-          images: ghcr.io/cowprotocol/services:main
+          images: ghcr.io%2Fcowprotocol%2Fservices:main # escaping / as %2F to not confuse the autodeploy-action API routing
           tag: ${{ secrets.AUTODEPLOY_TAG }}
           url: ${{ secrets.AUTODEPLOY_URL }}
           token: ${{ secrets.AUTODEPLOY_TOKEN }}


### PR DESCRIPTION
Because we are currently getting

```
POST /images/ghcr.io/cowprotocol/services:main/rollout 404
```

and in my original [tests](https://github.com/cowprotocol/k8s-autodeploy/pull/2), I escaped the route as well