### PR TITLE
Revert 1863

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -58,7 +58,7 @@ jobs:
       - uses: cowprotocol/autodeploy-action@v1
         if: ${{ github.ref == 'refs/heads/main' }}
         with:
-          images: ghcr.io%2Fcowprotocol%2Fservices:main # escaping / as %2F to not confuse the autodeploy-action API routing
+          images: ghcr.io/cowprotocol/services:main
           tag: ${{ secrets.AUTODEPLOY_TAG }}
           url: ${{ secrets.AUTODEPLOY_URL }}
           token: ${{ secrets.AUTODEPLOY_TOKEN }}


### PR DESCRIPTION
It's not working as we are not passing the escaped string into the handler which doesn't yield any matches. @nlordell created a better fix here: https://github.com/cowprotocol/autodeploy-action/pulls
