### PR TITLE
Skip saving executed surplus fee in driver

### DIFF
--- a/crates/solver/src/driver.rs
+++ b/crates/solver/src/driver.rs
@@ -418,7 +418,10 @@ impl Driver {
                 .user_trades()
                 .map(|trade| {
                     let execution = Execution {
-                        surplus_fee: trade.surplus_fee(),
+                        // No need to save the surplus_fee for limit orders before the settlement is
+                        // settled onchain. This is done in the autopilot once the transaction is
+                        // mined.
+                        surplus_fee: None,
                         solver_fee: trade.solver_fee,
                     };
                     (trade.order.metadata.uid, execution)

--- a/crates/solver/src/settlement.rs
+++ b/crates/solver/src/settlement.rs
@@ -27,16 +27,6 @@ pub struct Trade {
     pub solver_fee: U256,
 }
 
-impl Trade {
-    /// Returns the fee taken from the surplus.
-    pub fn surplus_fee(&self) -> Option<U256> {
-        match self.order.solver_determines_fee() {
-            true => Some(self.solver_fee),
-            false => None,
-        }
-    }
-}
-
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
 pub struct TradeExecution {
     pub sell_token: H160,


### PR DESCRIPTION
Noticed that although limit order is open, sometimes when we send order to solvers, this limit order have populated `executed_surplus_fee` [field](https://production-6de61f.kb.eu-central-1.aws.cloud.es.io/app/discover#/doc/ea511870-d9b3-11ed-a9d0-a17451f01cc1/cowlogs-staging-2023.09.11?id=sMeNg4oBQgsUfyaR_GhA). This happens because the limit order was part of the winning settlement in previous auction but did not get mined, however `SolverCompetitionDB` data was saved to database anyway.

This leads to field `Fees` on cow explorer being populated with data even though the order is still `Open`.

This PR skips saving the `surplus_fee` in the driver because it will be populated in the `OnSettlementEventUpdater`.