### PR TITLE
Sum up executed fees

### DIFF
--- a/crates/database/src/orders.rs
+++ b/crates/database/src/orders.rs
@@ -519,8 +519,8 @@ array(Select (p.target, p.value, p.data) from interactions p where p.order_uid =
     where eth_o.uid = o.uid limit 1) as ethflow_data,
 (SELECT onchain_o.sender from onchain_placed_orders onchain_o where onchain_o.uid = o.uid limit 1) as onchain_user,
 (SELECT onchain_o.placement_error from onchain_placed_orders onchain_o where onchain_o.uid = o.uid limit 1) as onchain_placement_error,
-(SELECT surplus_fee FROM order_execution oe WHERE oe.order_uid = o.uid ORDER BY oe.auction_id DESC LIMIT 1) as executed_surplus_fee,
-(SELECT solver_fee FROM order_execution oe WHERE oe.order_uid = o.uid ORDER BY oe.auction_id DESC LIMIT 1) as executed_solver_fee,
+COALESCE((SELECT SUM(surplus_fee) FROM order_execution oe WHERE oe.order_uid = o.uid), 0) as executed_surplus_fee,
+COALESCE((SELECT SUM(solver_fee) FROM order_execution oe WHERE oe.order_uid = o.uid), 0) as executed_solver_fee,
 (SELECT full_app_data FROM app_data ad WHERE o.app_data = ad.contract_app_data LIMIT 1) as full_app_data
 "#;
 
@@ -1822,7 +1822,7 @@ mod tests {
             .await
             .unwrap()
             .unwrap();
-        assert_eq!(order.executed_surplus_fee, None);
+        assert_eq!(order.executed_surplus_fee, Some(0.into()));
 
         let fee: BigDecimal = 1.into();
         let solver_fee: BigDecimal = 2.into();

--- a/crates/database/src/orders.rs
+++ b/crates/database/src/orders.rs
@@ -455,8 +455,8 @@ pub struct FullOrder {
     pub ethflow_data: Option<(Option<TransactionHash>, i64)>,
     pub onchain_user: Option<Address>,
     pub onchain_placement_error: Option<OnchainOrderPlacementError>,
-    pub executed_surplus_fee: Option<BigDecimal>,
-    pub executed_solver_fee: Option<BigDecimal>,
+    pub executed_surplus_fee: BigDecimal,
+    pub executed_solver_fee: BigDecimal,
     pub full_app_data: Option<Vec<u8>>,
 }
 
@@ -1822,7 +1822,7 @@ mod tests {
             .await
             .unwrap()
             .unwrap();
-        assert_eq!(order.executed_surplus_fee, Some(0.into()));
+        assert_eq!(order.executed_surplus_fee, 0.into());
 
         let fee: BigDecimal = 1.into();
         let solver_fee: BigDecimal = 2.into();
@@ -1834,8 +1834,8 @@ mod tests {
             .await
             .unwrap()
             .unwrap();
-        assert_eq!(order.executed_surplus_fee, Some(fee));
-        assert_eq!(order.executed_solver_fee, Some(solver_fee));
+        assert_eq!(order.executed_surplus_fee, fee);
+        assert_eq!(order.executed_solver_fee, solver_fee);
     }
 
     #[tokio::test]

--- a/crates/e2e/tests/e2e/partially_fillable_pool.rs
+++ b/crates/e2e/tests/e2e/partially_fillable_pool.rs
@@ -133,8 +133,7 @@ async fn test(web3: Web3) {
             }) => executed_surplus_fee,
             _ => unreachable!(),
         };
-        executed_surplus_fee.is_some()
-            && executed_surplus_fee.unwrap() != Default::default()
+        !executed_surplus_fee.is_zero()
             && order.metadata.executed_buy_amount != Default::default()
             && order.metadata.executed_sell_amount != Default::default()
     };

--- a/crates/model/src/order.rs
+++ b/crates/model/src/order.rs
@@ -906,8 +906,8 @@ impl OrderClass {
 #[derive(Eq, PartialEq, Clone, Copy, Debug, Default, Hash, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct LimitOrderClass {
-    #[serde_as(as = "Option<DecimalU256>")]
-    pub executed_surplus_fee: Option<U256>,
+    #[serde_as(as = "DecimalU256")]
+    pub executed_surplus_fee: U256,
 }
 
 impl OrderKind {
@@ -1088,7 +1088,7 @@ mod tests {
             metadata: OrderMetadata {
                 creation_date: Utc.timestamp_millis_opt(3_000).unwrap(),
                 class: OrderClass::Limit(LimitOrderClass {
-                    executed_surplus_fee: Some(1.into()),
+                    executed_surplus_fee: 1.into(),
                 }),
                 owner: H160::from_low_u64_be(1),
                 uid: OrderUid([17u8; 56]),

--- a/crates/shared/src/db_order_conversions.rs
+++ b/crates/shared/src/db_order_conversions.rs
@@ -208,10 +208,9 @@ pub fn order_class_from(order: &FullOrderDb) -> OrderClass {
         DbOrderClass::Market => OrderClass::Market,
         DbOrderClass::Liquidity => OrderClass::Liquidity,
         DbOrderClass::Limit => OrderClass::Limit(LimitOrderClass {
-            executed_surplus_fee: order
-                .executed_surplus_fee
-                .as_ref()
-                .and_then(big_decimal_to_u256),
+            executed_surplus_fee: big_decimal_to_u256(&order.executed_surplus_fee).expect(
+                "executed fees can't exceed sell_token amount which definitely fits into U256",
+            ),
         }),
     }
 }


### PR DESCRIPTION
Our executed fee values in the order metadata were not accurate for partially fillable limit orders with multiple fills.
Now we are summing the executed fees for all trade executions so it should be good now.
