### PR TITLE
Increase max fee factor for gas price

### DIFF
--- a/crates/driver/src/domain/competition/solution/settlement.rs
+++ b/crates/driver/src/domain/competition/solution/settlement.rs
@@ -360,16 +360,16 @@ impl Gas {
         // Compute an upper bound for `max_fee_per_gas` for the given
         // settlement. We multiply a fixed factor of the current base fee per
         // gas, which is chosen to be the maximum possible increase to the base
-        // fee per gas over 10 blocks, also including the "tip".
+        // fee per gas over 12 blocks, also including the "tip".
         //
         // This is computed as an approximation of:
-        //      MAX_FEE_FACTOR = MAX_INCREASE_PER_BLOCK ** DEADLINE_IN_BLOCKS
-        //                     = 1.125 ** 10
+        // MAX_FEE_FACTOR = MAX_INCREASE_PER_BLOCK ** (DEADLINE_IN_BLOCKS +
+        // SOLVING_TIME) = 1.125 ** (10 + 2) = 1.125 * 12
         //
         // The value of `MAX_GAS_INCREASE_PER_BLOCK` comes from EIP-1559, which
         // dictates that the block base fee can increase by a maximum of 12.5%
         // from one block to another.
-        const MAX_FEE_FACTOR: f64 = 3.25;
+        const MAX_FEE_FACTOR: f64 = 4.2;
         let price = eth::U256::from_f64_lossy(
             eth::U256::to_f64_lossy(price.base.into()) * MAX_FEE_FACTOR
                 + eth::U256::to_f64_lossy(price.tip.into()),

--- a/crates/solver/src/driver/gas.rs
+++ b/crates/solver/src/driver/gas.rs
@@ -62,17 +62,17 @@ impl GasPriceEstimating for Estimator {
             .min(estimate.max_fee_per_gas);
         estimate = estimate.ceil();
 
-        ensure!(estimate.is_valid(), "invalid gas estimate {estimate:?}");
+        ensure!(estimate.is_valid(), "invalid gas estimate {}", estimate);
         Ok(estimate)
     }
 }
 
 /// The factor of `base_fee_per_gas` to use for the `max_fee_per_gas` for gas
 /// price estimates. This is chosen to be the maximum increase in the
-/// `base_fee_per_gas` possible over a period of 10 blocks (which roughly
+/// `base_fee_per_gas` possible over a period of 12 blocks (which roughly
 /// corresponds to the deadline a solver has for mining a transaction on
-/// Mainnet).
-const MAX_FEE_FACTOR: f64 = 3.25;
+/// Mainnet + solvers solving time).
+const MAX_FEE_FACTOR: f64 = 4.2;
 
 #[cfg(test)]
 mod tests {

--- a/crates/solver/src/settlement_submission/submitter.rs
+++ b/crates/solver/src/settlement_submission/submitter.rs
@@ -171,7 +171,7 @@ impl GasPriceEstimating for SubmitterGasPriceEstimator<'_> {
             .min(estimate.max_fee_per_gas);
         estimate = estimate.ceil();
 
-        ensure!(estimate.is_valid(), "invalid gas price estimate {}, cap: {}");
+        ensure!(estimate.is_valid(), "gas estimate exceeds cap {}", estimate);
         Ok(estimate)
     }
 }

--- a/crates/solver/src/settlement_submission/submitter.rs
+++ b/crates/solver/src/settlement_submission/submitter.rs
@@ -171,7 +171,7 @@ impl GasPriceEstimating for SubmitterGasPriceEstimator<'_> {
             .min(estimate.max_fee_per_gas);
         estimate = estimate.ceil();
 
-        ensure!(estimate.is_valid(), "gas estimate exceeds cap {estimate:?}");
+        ensure!(estimate.is_valid(), "invalid gas price estimate {}, cap: {}");
         Ok(estimate)
     }
 }


### PR DESCRIPTION
Related to alert https://cowservices.slack.com/archives/C0371SB243E/p1694457516932509

Yesterday we had more than 10 consecutive full blocks: [18114932](https://etherscan.io/block/18114932) - [18114948](https://etherscan.io/block/18114948)

Need to increase the max fee factor to 4.2 (12 blocks) because we need to also take into consideration the solvers solving time, not just the submission deadline, to estimate the maximal gas price spike increase. The reason being that this is the timeline of the calls:

1. estimate gas price
2. solve auction (13s)
3. enter submission (120s)