### PR TITLE
Fix error handling for signature validator

### DIFF
--- a/crates/shared/src/signature_validator.rs
+++ b/crates/shared/src/signature_validator.rs
@@ -1,5 +1,6 @@
 use {
-    ethcontract::Bytes,
+    crate::ethcontract_error::EthcontractErrorType,
+    ethcontract::{errors::ExecutionError, Bytes},
     ethrpc::Web3,
     hex_literal::hex,
     model::interaction::InteractionData,
@@ -72,4 +73,13 @@ pub fn validator(contracts: Contracts, web3: Web3) -> Arc<dyn SignatureValidatin
         contracts.settlement,
         contracts.vault_relayer,
     ))
+}
+
+impl From<ExecutionError> for SignatureValidationError {
+    fn from(err: ExecutionError) -> Self {
+        match EthcontractErrorType::classify(&err) {
+            EthcontractErrorType::Contract => Self::Invalid,
+            _ => Self::Other(err.into()),
+        }
+    }
 }

--- a/crates/shared/src/signature_validator/simulation.rs
+++ b/crates/shared/src/signature_validator/simulation.rs
@@ -6,7 +6,7 @@
 use {
     super::{SignatureCheck, SignatureValidating, SignatureValidationError},
     anyhow::{Context, Result},
-    ethcontract::{common::abi::Token, tokens::Tokenize, Bytes},
+    ethcontract::{common::abi::Token, errors::ExecutionError, tokens::Tokenize, Bytes},
     ethrpc::Web3,
     futures::future,
     primitive_types::{H160, U256},
@@ -59,7 +59,12 @@ impl Validator {
             tx.data.unwrap(),
         );
 
-        let output = self.web3.eth().call(call, None).await?;
+        let output = self
+            .web3
+            .eth()
+            .call(call, None)
+            .await
+            .map_err(ExecutionError::from)?;
         let simulation = Simulation::decode(&output.0)?;
 
         tracing::trace!(?check, ?simulation, "simulated signatures");

--- a/crates/shared/src/signature_validator/web3.rs
+++ b/crates/shared/src/signature_validator/web3.rs
@@ -106,12 +106,3 @@ impl From<MethodError> for SignatureValidationError {
         }
     }
 }
-
-impl From<ExecutionError> for SignatureValidationError {
-    fn from(err: ExecutionError) -> Self {
-        match EthcontractErrorType::classify(&err) {
-            EthcontractErrorType::Contract => Self::Invalid,
-            _ => Self::Other(err.into()),
-        }
-    }
-}


### PR DESCRIPTION
Context: https://cowservices.slack.com/archives/C0361CDD1FZ/p1694595411953299

We need to convert web3 error first to `ExecutionError` so the reverts are properly classified so that our error conversion method properly classify revert as `SignatureValidationError::Invalid`
