### PR TITLE
[Easy] Remove lifetime from NativePriceEstimating trait

### DIFF
--- a/crates/orderbook/src/api/get_native_price.rs
+++ b/crates/orderbook/src/api/get_native_price.rs
@@ -31,7 +31,7 @@ pub fn get_native_price(
     get_native_prices_request().and_then(move |token: H160| {
         let estimator = estimator.clone();
         async move {
-            let result = estimator.estimate_native_price(&token).await;
+            let result = estimator.estimate_native_price(token).await;
             let reply = match result {
                 Ok(price) => with_status(
                     warp::reply::json(&PriceResponse::from(price)),

--- a/crates/shared/src/order_quoting.rs
+++ b/crates/shared/src/order_quoting.rs
@@ -546,12 +546,12 @@ impl OrderQuoter {
                 .map_err(PriceEstimationError::ProtocolInternal),
             self.price_estimator.estimate(trade_query.clone()),
             self.native_price_estimator
-                .estimate_native_price(&parameters.sell_token),
+                .estimate_native_price(parameters.sell_token),
             // We don't care about the native price of the buy_token for the quote but we need it
             // when we build the auction. To prevent creating orders which we can't settle later on
             // we make the native buy_token price a requirement here as well.
             self.native_price_estimator
-                .estimate_native_price(&parameters.buy_token),
+                .estimate_native_price(parameters.buy_token),
         )?;
 
         let (quoted_sell_amount, quoted_buy_amount) = match &parameters.side {

--- a/crates/shared/src/price_estimation/native.rs
+++ b/crates/shared/src/price_estimation/native.rs
@@ -25,9 +25,9 @@ pub trait NativePriceEstimating: Send + Sync {
     ///
     /// Prices are denominated in native token (i.e. the amount of native token
     /// that is needed to buy 1 unit of the specified token).
-    fn estimate_native_price<'a>(
-        &'a self,
-        token: &'a H160,
+    fn estimate_native_price(
+        &self,
+        token: H160,
     ) -> futures::future::BoxFuture<'_, NativePriceEstimateResult>;
 }
 
@@ -64,12 +64,12 @@ impl NativePriceEstimator {
 }
 
 impl NativePriceEstimating for NativePriceEstimator {
-    fn estimate_native_price<'a>(
-        &'a self,
-        token: &'a H160,
+    fn estimate_native_price(
+        &self,
+        token: H160,
     ) -> futures::future::BoxFuture<'_, NativePriceEstimateResult> {
-        async {
-            let query = Arc::new(self.query(token));
+        async move {
+            let query = Arc::new(self.query(&token));
             let estimate = self.inner.estimate(query.clone()).await?;
             Ok(estimate.price_in_buy_token_f64(&query))
         }
@@ -108,7 +108,7 @@ mod tests {
         };
 
         let result = native_price_estimator
-            .estimate_native_price(&H160::from_low_u64_be(3))
+            .estimate_native_price(H160::from_low_u64_be(3))
             .await;
         assert_eq!(result.unwrap(), 1. / 0.123456789);
     }
@@ -129,7 +129,7 @@ mod tests {
         };
 
         let result = native_price_estimator
-            .estimate_native_price(&H160::from_low_u64_be(2))
+            .estimate_native_price(H160::from_low_u64_be(2))
             .await;
         assert!(matches!(result, Err(PriceEstimationError::NoLiquidity)));
     }


### PR DESCRIPTION
H160 implements `Copy` (so we don't care about passing it by reference) and this will make generalizing over this train in the RacingPriceEstimator much easier.

### Test Plan

CI