### PR TITLE
Account for unstable order of `select_all`

### DIFF
--- a/crates/shared/src/price_estimation/competition.rs
+++ b/crates/shared/src/price_estimation/competition.rs
@@ -454,7 +454,10 @@ mod tests {
         third
             .expect_estimate()
             .times(1)
-            .returning(move |_| async { Ok(estimate(3)) }.boxed());
+            .returning(move |_| async {
+                tokio::task::yield_now().await;
+                Ok(estimate(3))
+            }.boxed());
 
         let mut fourth = MockPriceEstimating::new();
         fourth.expect_estimate().times(1).returning(move |_| {

--- a/crates/shared/src/price_estimation/competition.rs
+++ b/crates/shared/src/price_estimation/competition.rs
@@ -451,13 +451,13 @@ mod tests {
         });
 
         let mut third = MockPriceEstimating::new();
-        third
-            .expect_estimate()
-            .times(1)
-            .returning(move |_| async {
+        third.expect_estimate().times(1).returning(move |_| {
+            async {
                 tokio::task::yield_now().await;
                 Ok(estimate(3))
-            }.boxed());
+            }
+            .boxed()
+        });
 
         let mut fourth = MockPriceEstimating::new();
         fourth.expect_estimate().times(1).returning(move |_| {


### PR DESCRIPTION
The docs for `select_all` say:
> There are no guarantees provided on the order of the list with the remaining futures. They might be swapped around, reversed, or completely random.

When simplifying the price API I was not aware of this and didn't take any precautions to account for any unstable order of the returned futures.

I checked the implementation of `select_all` and it uses `Vec::swap_remove()` under the hood which definitely messes with the order of the returned futures and the indices.
It is possible that this is the reason why we saw weird 95th percentile quoting latency. The new code returns the index along side the quote result and does not use the index returned by `select_all` at all.