### PR TITLE
Configure one inch spot price estimator

### DIFF
--- a/crates/autopilot/src/arguments.rs
+++ b/crates/autopilot/src/arguments.rs
@@ -4,7 +4,7 @@ use {
         arguments::{display_list, display_option},
         bad_token::token_owner_finder,
         http_client,
-        price_estimation::{self, PriceEstimators},
+        price_estimation::{self, NativePriceEstimators},
     },
     std::{net::SocketAddr, num::NonZeroUsize, time::Duration},
     url::Url,
@@ -82,7 +82,7 @@ pub struct Arguments {
     /// Which estimators to use to estimate token prices in terms of the chain's
     /// native token.
     #[clap(long, env, default_value_t)]
-    pub native_price_estimators: PriceEstimators,
+    pub native_price_estimators: NativePriceEstimators,
 
     /// How many successful price estimates for each order will cause a native
     /// price estimation to return its result early. It's possible to pass

--- a/crates/autopilot/src/run.rs
+++ b/crates/autopilot/src/run.rs
@@ -403,7 +403,7 @@ pub async fn run(args: Arguments) {
         .native_price_estimator(
             args.native_price_estimators.as_slice(),
             &PriceEstimatorSource::for_args(
-                &args.order_quoting.price_estimators.as_slice(),
+                args.order_quoting.price_estimators.as_slice(),
                 &args.order_quoting.price_estimation_drivers,
                 &args.order_quoting.price_estimation_legacy_solvers,
             ),

--- a/crates/autopilot/src/run.rs
+++ b/crates/autopilot/src/run.rs
@@ -376,6 +376,7 @@ pub async fn run(args: Arguments) {
                 .await
                 .expect("failed to query solver authenticator address"),
             base_tokens: base_tokens.clone(),
+            block_stream: current_block_stream.clone(),
         },
         factory::Components {
             http_factory: http_factory.clone(),
@@ -400,8 +401,10 @@ pub async fn run(args: Arguments) {
         .unwrap();
     let native_price_estimator = price_estimator_factory
         .native_price_estimator(
+            args.native_price_estimators.as_slice(),
             &PriceEstimatorSource::for_args(
-                args.native_price_estimators.as_slice(),
+                //builtin estimators are passed in separately
+                &[],
                 &args.order_quoting.price_estimation_drivers,
                 &args.order_quoting.price_estimation_legacy_solvers,
             ),

--- a/crates/autopilot/src/run.rs
+++ b/crates/autopilot/src/run.rs
@@ -403,8 +403,7 @@ pub async fn run(args: Arguments) {
         .native_price_estimator(
             args.native_price_estimators.as_slice(),
             &PriceEstimatorSource::for_args(
-                //builtin estimators are passed in separately
-                &[],
+                &args.order_quoting.price_estimators.as_slice(),
                 &args.order_quoting.price_estimation_drivers,
                 &args.order_quoting.price_estimation_legacy_solvers,
             ),

--- a/crates/e2e/src/setup/services.rs
+++ b/crates/e2e/src/setup/services.rs
@@ -51,8 +51,7 @@ impl<'a> Services<'a> {
     fn api_autopilot_arguments() -> impl Iterator<Item = String> {
         [
             "--price-estimators=Baseline|0x0000000000000000000000000000000000000001".to_string(),
-            "--native-price-estimators=Baseline|0x0000000000000000000000000000000000000001"
-                .to_string(),
+            "--native-price-estimators=Baseline".to_string(),
             "--amount-to-estimate-prices-with=1000000000000000000".to_string(),
             "--block-stream-poll-interval-seconds=1".to_string(),
         ]

--- a/crates/orderbook/src/arguments.rs
+++ b/crates/orderbook/src/arguments.rs
@@ -5,7 +5,7 @@ use {
         arguments::{display_option, display_secret_option},
         bad_token::token_owner_finder,
         http_client,
-        price_estimation::{self, PriceEstimators},
+        price_estimation::{self, NativePriceEstimators},
     },
     std::{net::SocketAddr, num::NonZeroUsize, time::Duration},
 };
@@ -91,7 +91,7 @@ pub struct Arguments {
     /// Which estimators to use to estimate token prices in terms of the chain's
     /// native token.
     #[clap(long, env, default_value_t)]
-    pub native_price_estimators: PriceEstimators,
+    pub native_price_estimators: NativePriceEstimators,
 
     /// How many successful price estimates for each order will cause a fast
     /// or native price estimation to return its result early.

--- a/crates/orderbook/src/run.rs
+++ b/crates/orderbook/src/run.rs
@@ -366,6 +366,7 @@ pub async fn run(args: Arguments) {
                 .await
                 .expect("failed to query solver authenticator address"),
             base_tokens: base_tokens.clone(),
+            block_stream: current_block_stream.clone(),
         },
         factory::Components {
             http_factory: http_factory.clone(),
@@ -400,8 +401,9 @@ pub async fn run(args: Arguments) {
         .unwrap();
     let native_price_estimator = price_estimator_factory
         .native_price_estimator(
+            args.native_price_estimators.as_slice(),
             &PriceEstimatorSource::for_args(
-                args.native_price_estimators.as_slice(),
+                &[],
                 &args.order_quoting.price_estimation_drivers,
                 &args.order_quoting.price_estimation_legacy_solvers,
             ),

--- a/crates/orderbook/src/run.rs
+++ b/crates/orderbook/src/run.rs
@@ -403,7 +403,7 @@ pub async fn run(args: Arguments) {
         .native_price_estimator(
             args.native_price_estimators.as_slice(),
             &PriceEstimatorSource::for_args(
-                &args.order_quoting.price_estimators.as_slice(),
+                args.order_quoting.price_estimators.as_slice(),
                 &args.order_quoting.price_estimation_drivers,
                 &args.order_quoting.price_estimation_legacy_solvers,
             ),

--- a/crates/orderbook/src/run.rs
+++ b/crates/orderbook/src/run.rs
@@ -403,8 +403,7 @@ pub async fn run(args: Arguments) {
         .native_price_estimator(
             args.native_price_estimators.as_slice(),
             &PriceEstimatorSource::for_args(
-                //builtin estimators are passed in separately
-                &[],
+                &args.order_quoting.price_estimators.as_slice(),
                 &args.order_quoting.price_estimation_drivers,
                 &args.order_quoting.price_estimation_legacy_solvers,
             ),

--- a/crates/orderbook/src/run.rs
+++ b/crates/orderbook/src/run.rs
@@ -403,6 +403,7 @@ pub async fn run(args: Arguments) {
         .native_price_estimator(
             args.native_price_estimators.as_slice(),
             &PriceEstimatorSource::for_args(
+                //builtin estimators are passed in separately
                 &[],
                 &args.order_quoting.price_estimation_drivers,
                 &args.order_quoting.price_estimation_legacy_solvers,

--- a/crates/shared/src/price_estimation.rs
+++ b/crates/shared/src/price_estimation.rs
@@ -397,6 +397,11 @@ impl Display for Arguments {
             "zeroex_only_estimate_buy_queries: {:?}",
             self.zeroex_only_estimate_buy_queries
         )?;
+        writeln!(
+            f,
+            "one_inch_spot_price_api_key: {:?}",
+            self.one_inch_spot_price_api_key
+        )?;
 
         Ok(())
     }

--- a/crates/shared/src/price_estimation.rs
+++ b/crates/shared/src/price_estimation.rs
@@ -143,7 +143,7 @@ pub struct NativePriceEstimators(Vec<NativePriceEstimator>);
 
 #[derive(Copy, Clone, Debug, Hash, Eq, PartialEq)]
 pub enum NativePriceEstimator {
-    GenericPriceEstimator(PriceEstimatorKind),
+    GenericPriceEstimator(PriceEstimator),
     OneInchSpotPriceApi,
 }
 
@@ -160,7 +160,10 @@ impl NativePriceEstimators {
 impl Default for NativePriceEstimators {
     fn default() -> Self {
         Self(vec![NativePriceEstimator::GenericPriceEstimator(
-            PriceEstimatorKind::Baseline,
+            PriceEstimator {
+                kind: PriceEstimatorKind::Baseline,
+                address: H160::zero(),
+            },
         )])
     }
 }
@@ -201,13 +204,26 @@ impl FromStr for NativePriceEstimator {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let kind = match s {
-            "Baseline" => NativePriceEstimator::GenericPriceEstimator(PriceEstimatorKind::Baseline),
-            "Paraswap" => NativePriceEstimator::GenericPriceEstimator(PriceEstimatorKind::Paraswap),
-            "ZeroEx" => NativePriceEstimator::GenericPriceEstimator(PriceEstimatorKind::ZeroEx),
-            "OneInch" => NativePriceEstimator::GenericPriceEstimator(PriceEstimatorKind::OneInch),
-            "BalancerSor" => {
-                NativePriceEstimator::GenericPriceEstimator(PriceEstimatorKind::BalancerSor)
-            }
+            "Baseline" => NativePriceEstimator::GenericPriceEstimator(PriceEstimator {
+                kind: PriceEstimatorKind::Baseline,
+                address: H160::zero(),
+            }),
+            "Paraswap" => NativePriceEstimator::GenericPriceEstimator(PriceEstimator {
+                kind: PriceEstimatorKind::Paraswap,
+                address: H160::zero(),
+            }),
+            "ZeroEx" => NativePriceEstimator::GenericPriceEstimator(PriceEstimator {
+                kind: PriceEstimatorKind::ZeroEx,
+                address: H160::zero(),
+            }),
+            "OneInch" => NativePriceEstimator::GenericPriceEstimator(PriceEstimator {
+                kind: PriceEstimatorKind::OneInch,
+                address: H160::zero(),
+            }),
+            "BalancerSor" => NativePriceEstimator::GenericPriceEstimator(PriceEstimator {
+                kind: PriceEstimatorKind::BalancerSor,
+                address: H160::zero(),
+            }),
             "OneInchSpotPriceApi" => NativePriceEstimator::OneInchSpotPriceApi,
             estimator => {
                 anyhow::bail!("failed to convert to PriceEstimatorKind: {estimator}")
@@ -329,6 +345,10 @@ pub struct Arguments {
     /// The API key for the 1Inch spot API.
     #[clap(long, env)]
     pub one_inch_spot_price_api_key: Option<String>,
+
+    /// The base URL for the 1Inch spot API.
+    #[clap(long, env)]
+    pub one_inch_spot_price_api_url: Option<Url>,
 }
 
 impl Display for Arguments {

--- a/crates/shared/src/price_estimation/factory.rs
+++ b/crates/shared/src/price_estimation/factory.rs
@@ -6,7 +6,7 @@ use {
         external::ExternalPriceEstimator,
         http::HttpPriceEstimator,
         instrumented::InstrumentedPriceEstimator,
-        native::{self, oneinch::OneInch, NativePriceEstimator},
+        native::{self, NativePriceEstimator},
         native_price_cache::CachingNativePriceEstimator,
         oneinch::OneInchPriceEstimator,
         paraswap::ParaswapPriceEstimator,
@@ -272,7 +272,7 @@ impl<'a> PriceEstimatorFactory<'a> {
             }
             NativePriceEstimatorSource::OneInchSpotPriceApi => Ok((
                 "OneInchSpotPriceApi".into(),
-                Arc::new(OneInch::new(
+                Arc::new(native::OneInch::new(
                     self.components.http_factory.create(),
                     self.args.one_inch_spot_price_api_key.clone(),
                     self.network.chain_id,

--- a/crates/shared/src/price_estimation/factory.rs
+++ b/crates/shared/src/price_estimation/factory.rs
@@ -354,7 +354,7 @@ impl<'a> PriceEstimatorFactory<'a> {
         );
         let native_token_price_estimation_amount = self.native_token_price_estimation_amount()?;
         let mut estimators: Vec<_> = native
-            .into_iter()
+            .iter()
             .map(|source| self.create_native_estimator(*source).unwrap())
             .collect();
         estimators.extend(

--- a/crates/shared/src/price_estimation/native.rs
+++ b/crates/shared/src/price_estimation/native.rs
@@ -7,7 +7,7 @@ use {
     std::sync::Arc,
 };
 
-mod oneinch;
+pub mod oneinch;
 
 pub type NativePriceEstimateResult = Result<f64, PriceEstimationError>;
 

--- a/crates/shared/src/price_estimation/native.rs
+++ b/crates/shared/src/price_estimation/native.rs
@@ -7,7 +7,8 @@ use {
     std::sync::Arc,
 };
 
-pub mod oneinch;
+mod oneinch;
+pub use self::oneinch::OneInch;
 
 pub type NativePriceEstimateResult = Result<f64, PriceEstimationError>;
 

--- a/crates/shared/src/price_estimation/native/oneinch.rs
+++ b/crates/shared/src/price_estimation/native/oneinch.rs
@@ -29,7 +29,6 @@ pub struct OneInch {
 }
 
 impl OneInch {
-    #[allow(dead_code)]
     pub fn new(
         client: Client,
         base_url: Option<Url>,


### PR DESCRIPTION
Now that we have everything set up, we can actually allow configuration of "Native only" price estimators. For this we change the type that the native price estimators value takes to its own type that can be either a generic price estimator or a "native only" one.

We pass all built-in native price estimators separately into the factory method (this allows us to still use the external solvers as backup estimators).

### Test Plan

```
cargo run --bin orderbook -- --node-url <your dappnode>--native-price-estimators Baseline,OneInchSpotPriceApi --baseline-sources UniswapV2 --one-inch-spot-price-api-key <your api key> 
```

And

```
curl localhost:8080/api/v1/token/0x6810e776880c02933d47db1b9fc05908e5386b96/native_price

{"price":0.06223952453884784}
```

observing

```
winning price estimate query=0x6810e776880c02933d47db1b9fc05908e5386b96 result=Ok(0.06223952453884784) estimator="OneInchSpotPriceApi"
```