### PR TITLE
Allow native price estimators to be arbitrary strings

### DIFF
--- a/crates/autopilot/src/arguments.rs
+++ b/crates/autopilot/src/arguments.rs
@@ -80,7 +80,9 @@ pub struct Arguments {
     pub pool_cache_lru_size: NonZeroUsize,
 
     /// Which estimators to use to estimate token prices in terms of the chain's
-    /// native token.
+    /// native token. Estimators with the same name need to also be specified as
+    /// built-in, legacy or external price estimators (lookup happens in this
+    /// order in case of name collisions)
     #[clap(long, env, default_value_t)]
     pub native_price_estimators: NativePriceEstimators,
 

--- a/crates/shared/src/price_estimation/factory.rs
+++ b/crates/shared/src/price_estimation/factory.rs
@@ -273,11 +273,11 @@ impl<'a> PriceEstimatorFactory<'a> {
                             )
                         },
                     )
-                    .find(|external| external.0 == estimator.name())
+                    .find(|external| external.0 == estimator)
                     .ok_or(anyhow!(
                         "Couldn't find generic price estimator with name {} to instantiate native \
                          estimator",
-                        estimator.name()
+                        estimator
                     ))
             }
             NativePriceEstimatorSource::OneInchSpotPriceApi => Ok((
@@ -372,7 +372,7 @@ impl<'a> PriceEstimatorFactory<'a> {
             .map(|stage| {
                 stage
                     .iter()
-                    .map(|&source| self.create_native_estimator(source, external))
+                    .map(|source| self.create_native_estimator(source.clone(), external))
                     .collect::<Result<Vec<_>>>()
             })
             .collect::<Result<Vec<Vec<_>>>>()?;


### PR DESCRIPTION
In order to configure colocated driver price estimators (which as far as the orderbook/autopilot are concerned are merely strings) we need to allow for less strict typing when specifying NativePriceEstimators. Basically a native price estimator is either a builtin static typed one or just an arbitrary string, which the factory later hopes to find in one of the many ways generic price estimator can be specified in the current code base (builtin, legacy and co-located).

### Test Plan

run the orderbook with `--native-price-estimators Baseline,mysolver --price-estimators Baseline --price-estimation-drivers 'mysolver|http://localhost:11088/mysolver'` 

Make a request, observe

```
2023-09-25T17:48:58.344Z DEBUG request{id="1"}: shared::price_estimation::competition: new price estimate query=0x6810e776880c02933d47db1b9fc05908e5386b96 result=Ok(0.05978147189654011) estimator="Baseline"
2023-09-25T17:48:58.509Z DEBUG request{id="1"}: shared::price_estimation::competition: new price estimate query=0x6810e776880c02933d47db1b9fc05908e5386b96 result=Err(EstimatorInternal(Solver engine returned an invalid response)) estimator="mysolver"
2023-09-25T17:48:58.509Z DEBUG request{id="1"}: shared::price_estimation::competition: winning price estimate query=0x6810e776880c02933d47db1b9fc05908e5386b96 result=Ok(0.05978147189654011) estimator="Baseline"
```