### PR TITLE
Simulate Balances with PreInteractions In Driver

### DIFF
--- a/crates/driver/src/domain/competition/auction.rs
+++ b/crates/driver/src/domain/competition/auction.rs
@@ -3,13 +3,9 @@ use {
     crate::{
         domain::{
             competition::{self, solution},
-            eth::{self},
+            eth,
         },
-        infra::{
-            blockchain,
-            observe::{self},
-            Ethereum,
-        },
+        infra::{blockchain, observe, Ethereum},
     },
     futures::future::join_all,
     itertools::Itertools,
@@ -97,34 +93,47 @@ impl Auction {
             ))
         });
 
-        // Fetch balances of each token for each trader.
-        // Has to be separate closure due to compiler bug.
-        let f = |order: &competition::Order| -> (order::Trader, eth::TokenAddress) {
-            (order.trader(), order.sell.token)
-        };
-        let tokens_by_trader = self.orders.iter().map(f).unique();
-        let mut balances: HashMap<
-            (order::Trader, eth::TokenAddress),
-            Result<eth::TokenAmount, crate::infra::blockchain::Error>,
-        > = join_all(tokens_by_trader.map(|(trader, token)| async move {
-            let contract = eth.erc20(token);
-            let balance = contract.balance(trader.into()).await;
-            ((trader, token), balance)
-        }))
+        // Collect trader/token/source/interaction tuples for fetching available
+        // balances. Note that we are pessimistic here, if a trader is selling
+        // the same token with the same source in two different orders using a
+        // different set of pre-interactions, then we fetch the balance as if no
+        // pre-interactions were specified. This is done to avoid creating
+        // dependencies between orders (i.e. order 1 is required for executing
+        // order 2) which we currently cannot express with the solver interface.
+        let traders = self
+            .orders()
+            .iter()
+            .group_by(|order| (order.trader(), order.sell.token, order.sell_token_balance))
+            .into_iter()
+            .map(|((trader, token, source), mut orders)| {
+                let interactions = orders
+                    .next()
+                    .map(|order| &order.pre_interactions[..])
+                    .unwrap_or_default();
+                if orders.all(|order| order.pre_interactions == interactions) {
+                    (trader, token, source, interactions)
+                } else {
+                    (trader, token, source, Default::default())
+                }
+            })
+            .collect::<Vec<_>>();
+
+        let mut balances = join_all(traders.into_iter().map(
+            |(trader, token, source, interactions)| async move {
+                let balance = eth
+                    .erc20(token)
+                    .tradable_balance(trader.into(), source, interactions)
+                    .await;
+                ((trader, token, source), balance)
+            },
+        ))
         .await
         .into_iter()
-        .collect();
+        .collect::<HashMap<_, _>>();
 
         self.orders.retain(|order| {
-            // TODO: We should use balance fetching that takes interactions into account
-            // from `crates/shared/src/account_balances/simulation.rs` instead of hardcoding
-            // an Ethflow exception. https://github.com/cowprotocol/services/issues/1595
-            if Some(order.signature.signer.0) == eth.contracts().ethflow_address().map(|a| a.0) {
-                return true;
-            }
-
             let remaining_balance = match balances
-                .get_mut(&(order.trader(), order.sell.token))
+                .get_mut(&(order.trader(), order.sell.token, order.sell_token_balance))
                 .unwrap()
             {
                 Ok(balance) => &mut balance.0,

--- a/crates/driver/src/domain/competition/auction.rs
+++ b/crates/driver/src/domain/competition/auction.rs
@@ -106,12 +106,10 @@ impl Auction {
             .group_by(|order| (order.trader(), order.sell.token, order.sell_token_balance))
             .into_iter()
             .map(|((trader, token, source), mut orders)| {
-                let interactions = orders
-                    .next()
-                    .map(|order| &order.pre_interactions[..])
-                    .unwrap_or_default();
-                if orders.all(|order| order.pre_interactions == interactions) {
-                    (trader, token, source, interactions)
+                let first = orders.next().expect("group contains at least 1 order");
+                let mut others = orders;
+                if others.all(|order| order.pre_interactions == first.pre_interactions) {
+                    (trader, token, source, &first.pre_interactions[..])
                 } else {
                     (trader, token, source, Default::default())
                 }

--- a/crates/driver/src/domain/competition/order/mod.rs
+++ b/crates/driver/src/domain/competition/order/mod.rs
@@ -273,15 +273,27 @@ pub enum Kind {
 }
 
 /// [Balancer V2](https://docs.balancer.fi/) integration, used for settlement encoding.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, Eq, Hash, PartialEq)]
 pub enum SellTokenBalance {
     Erc20,
     Internal,
     External,
 }
 
+impl SellTokenBalance {
+    /// Returns the hash value for the specified source.
+    pub fn hash(&self) -> eth::H256 {
+        let name = match self {
+            Self::Erc20 => "erc20",
+            Self::Internal => "internal",
+            Self::External => "external",
+        };
+        eth::H256(web3::signing::keccak256(name.as_bytes()))
+    }
+}
+
 /// [Balancer V2](https://docs.balancer.fi/) integration, used for settlement encoding.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, Eq, Hash, PartialEq)]
 pub enum BuyTokenBalance {
     Erc20,
     Internal,

--- a/crates/driver/src/domain/eth/mod.rs
+++ b/crates/driver/src/domain/eth/mod.rs
@@ -295,7 +295,7 @@ impl From<i32> for Ether {
 pub struct BlockNo(pub u64);
 
 /// An onchain transaction which interacts with a smart contract.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Eq, PartialEq)]
 pub struct Interaction {
     pub target: Address,
     pub value: Ether,

--- a/crates/driver/src/infra/config/file/load.rs
+++ b/crates/driver/src/infra/config/file/load.rs
@@ -244,7 +244,6 @@ pub async fn load(network: &blockchain::Network, path: &Path) -> infra::Config {
         contracts: blockchain::contracts::Addresses {
             settlement: config.contracts.gp_v2_settlement.map(Into::into),
             weth: config.contracts.weth.map(Into::into),
-            ethflow: config.contracts.ethflow.map(Into::into),
         },
         disable_access_list_simulation: config.disable_access_list_simulation,
         disable_gas_simulation: config.disable_gas_simulation.map(Into::into),

--- a/crates/driver/src/infra/config/file/mod.rs
+++ b/crates/driver/src/infra/config/file/mod.rs
@@ -188,11 +188,6 @@ struct ContractsConfig {
 
     /// Override the default address of the WETH contract.
     weth: Option<eth::H160>,
-
-    /// Sets the Ethflow contract address. Without this we cannot detect Ethflow
-    /// orders, which leads to such orders not being solved because it appears
-    /// that the user doesn't have enough sell token balance.
-    ethflow: Option<eth::H160>,
 }
 
 #[derive(Debug, Deserialize)]

--- a/crates/driver/src/infra/observe/mod.rs
+++ b/crates/driver/src/infra/observe/mod.rs
@@ -324,5 +324,5 @@ pub fn order_excluded_from_auction(
     order: &competition::Order,
     reason: OrderExcludedFromAuctionReason,
 ) {
-    tracing::trace!(uid=?order.uid, ?reason,"order excluded from auction");
+    tracing::trace!(uid=?order.uid, ?reason, "order excluded from auction");
 }

--- a/crates/driver/src/tests/cases/example_config.rs
+++ b/crates/driver/src/tests/cases/example_config.rs
@@ -6,5 +6,9 @@ use crate::tests;
 #[ignore]
 async fn test() {
     let example_config_file = std::env::current_dir().unwrap().join("example.toml");
-    tests::setup().config(example_config_file).done().await;
+    tests::setup()
+        .config(example_config_file)
+        .settlement_address("0x9008D19f58AAbD9eD0D60971565AA8510560ab41")
+        .done()
+        .await;
 }

--- a/crates/driver/src/tests/setup/mod.rs
+++ b/crates/driver/src/tests/setup/mod.rs
@@ -263,6 +263,7 @@ pub fn setup() -> Setup {
         quote: Default::default(),
         fund_solver: true,
         enable_simulation: true,
+        settlement_address: Default::default(),
     }
 }
 
@@ -280,6 +281,8 @@ pub struct Setup {
     fund_solver: bool,
     /// Should simulation be enabled? True by default.
     enable_simulation: bool,
+    /// Ensure the settlement contract is deployed on a specific address?
+    settlement_address: Option<eth::H160>,
 }
 
 /// The validity of a solution.
@@ -504,6 +507,12 @@ impl Setup {
         self
     }
 
+    /// Ensure that the settlement contract is deployed to a specific address.
+    pub fn settlement_address(mut self, address: &str) -> Self {
+        self.settlement_address = Some(address.parse().unwrap());
+        self
+    }
+
     /// Create the test: set up onchain contracts and pools, start a mock HTTP
     /// server for the solver and start the HTTP server for the driver.
     pub async fn done(self) -> Test {
@@ -553,6 +562,7 @@ impl Setup {
             solver_address,
             solver_secret_key,
             fund_solver: self.fund_solver,
+            settlement_address: self.settlement_address,
         })
         .await;
         let mut solutions = Vec::new();

--- a/crates/driver/src/tests/setup/solver.rs
+++ b/crates/driver/src/tests/setup/solver.rs
@@ -199,7 +199,6 @@ impl Solver {
             Addresses {
                 settlement: Some(config.blockchain.settlement.address().into()),
                 weth: Some(config.blockchain.weth.address().into()),
-                ethflow: config.blockchain.ethflow,
             },
         )
         .await

--- a/crates/e2e/tests/e2e/colocation_ethflow.rs
+++ b/crates/e2e/tests/e2e/colocation_ethflow.rs
@@ -1,0 +1,310 @@
+use {
+    crate::ethflow::{EthFlowOrderOnchainStatus, EthFlowTradeIntent, ExtendedEthFlowOrder},
+    autopilot::database::onchain_order_events::ethflow_events::WRAP_ALL_SELECTOR,
+    contracts::ERC20Mintable,
+    e2e::setup::*,
+    ethcontract::{Account, H160, U256},
+    ethrpc::{current_block::timestamp_of_current_block_in_seconds, Web3},
+    model::{
+        order::{EthflowData, OnchainOrderData, Order, OrderClass, OrderUid},
+        quote::{OrderQuoteRequest, OrderQuoteResponse, OrderQuoteSide},
+        trade::Trade,
+    },
+    reqwest::Client,
+};
+
+const DAI_PER_ETH: u32 = 1_000;
+
+#[tokio::test]
+#[ignore]
+async fn local_node_eth_flow() {
+    run_test(eth_flow_tx).await;
+}
+
+async fn eth_flow_tx(web3: Web3) {
+    let mut onchain = OnchainComponents::deploy(web3.clone()).await;
+
+    let [solver] = onchain.make_solvers(to_wei(2)).await;
+    let [trader] = onchain.make_accounts(to_wei(2)).await;
+
+    // Create token with Uniswap pool for price estimation
+    let [dai] = onchain
+        .deploy_tokens_with_weth_uni_v2_pools(to_wei(DAI_PER_ETH * 1_000), to_wei(1_000))
+        .await;
+
+    // Get a quote from the services
+    let buy_token = dai.address();
+    let receiver = H160([0x42; 20]);
+    let sell_amount = to_wei(1);
+    let intent = EthFlowTradeIntent {
+        sell_amount,
+        buy_token,
+        receiver,
+    };
+
+    let solver_endpoint = colocation::start_solver(onchain.contracts().weth.address()).await;
+    colocation::start_driver(onchain.contracts(), &solver_endpoint, &solver);
+
+    let services = Services::new(onchain.contracts()).await;
+    services.start_autopilot(vec![
+        "--enable-colocation=true".to_string(),
+        "--drivers=http://localhost:11088/test_solver".to_string(),
+    ]);
+    services.start_api(vec![]).await;
+
+    let quote: OrderQuoteResponse = test_submit_quote(
+        &services,
+        &intent.to_quote_request(&onchain.contracts().ethflow, &onchain.contracts().weth),
+    )
+    .await;
+
+    let valid_to = chrono::offset::Utc::now().timestamp() as u32
+        + timestamp_of_current_block_in_seconds(&web3).await.unwrap()
+        + 3600;
+    let ethflow_order =
+        ExtendedEthFlowOrder::from_quote(&quote, valid_to).include_slippage_bps(300);
+
+    sumbit_order(&ethflow_order, trader.account(), onchain.contracts()).await;
+
+    test_order_availability_in_api(
+        &services,
+        &ethflow_order,
+        &trader.address(),
+        onchain.contracts(),
+    )
+    .await;
+
+    tracing::info!("waiting for trade");
+    wait_for_condition(TIMEOUT, || async { services.solvable_orders().await == 1 })
+        .await
+        .unwrap();
+
+    test_order_was_settled(&services, &ethflow_order, &web3).await;
+
+    test_trade_availability_in_api(
+        services.client(),
+        &ethflow_order,
+        &trader.address(),
+        onchain.contracts(),
+    )
+    .await;
+}
+
+async fn test_submit_quote(
+    services: &Services<'_>,
+    quote: &OrderQuoteRequest,
+) -> OrderQuoteResponse {
+    let response = services.submit_quote(quote).await.unwrap();
+
+    assert!(response.id.is_some());
+    // Ideally the fee would be nonzero, but this is not the case in the test
+    // environment assert_ne!(response.quote.fee_amount, 0.into());
+    // Amount is reasonable (±10% from real price)
+    let approx_output: U256 = response.quote.sell_amount * DAI_PER_ETH;
+    assert!(response.quote.buy_amount.gt(&(approx_output * 9u64 / 10)));
+    assert!(response.quote.buy_amount.lt(&(approx_output * 11u64 / 10)));
+
+    let OrderQuoteSide::Sell {
+        sell_amount:
+            model::quote::SellAmount::AfterFee {
+                value: sell_amount_after_fees,
+            },
+    } = quote.side
+    else {
+        panic!("untested!");
+    };
+
+    assert_eq!(response.quote.sell_amount, sell_amount_after_fees.get());
+
+    response
+}
+
+async fn sumbit_order(ethflow_order: &ExtendedEthFlowOrder, user: &Account, contracts: &Contracts) {
+    assert_eq!(
+        ethflow_order.status(contracts).await,
+        EthFlowOrderOnchainStatus::Free
+    );
+
+    let result = ethflow_order
+        .mine_order_creation(user, &contracts.ethflow)
+        .await;
+    assert_eq!(result.as_receipt().unwrap().status, Some(1.into()));
+    assert_eq!(
+        ethflow_order.status(contracts).await,
+        EthFlowOrderOnchainStatus::Created(user.address(), ethflow_order.0.valid_to)
+    );
+}
+
+async fn test_order_availability_in_api(
+    services: &Services<'_>,
+    order: &ExtendedEthFlowOrder,
+    owner: &H160,
+    contracts: &Contracts,
+) {
+    tracing::info!("Waiting for order to show up in API.");
+    let uid = order.uid(contracts).await;
+    let is_available = || async { services.get_order(&uid).await.is_ok() };
+    wait_for_condition(TIMEOUT, is_available).await.unwrap();
+
+    test_orders_query(services, order, owner, contracts).await;
+
+    // Api returns eth flow orders for both eth-flow contract address and actual
+    // owner
+    for address in [owner, &contracts.ethflow.address()] {
+        test_account_query(address, services.client(), order, owner, contracts).await;
+    }
+
+    wait_for_condition(TIMEOUT, || async { services.solvable_orders().await == 1 })
+        .await
+        .unwrap();
+
+    test_auction_query(services, order, owner, contracts).await;
+}
+
+async fn test_trade_availability_in_api(
+    client: &Client,
+    order: &ExtendedEthFlowOrder,
+    owner: &H160,
+    contracts: &Contracts,
+) {
+    test_trade_query(
+        &TradeQuery::ByUid(order.uid(contracts).await),
+        client,
+        contracts,
+    )
+    .await;
+
+    // Api returns eth flow orders for both eth-flow contract address and actual
+    // owner
+    for address in [owner, &contracts.ethflow.address()] {
+        test_trade_query(&TradeQuery::ByOwner(*address), client, contracts).await;
+    }
+}
+
+async fn test_order_was_settled(
+    services: &Services<'_>,
+    ethflow_order: &ExtendedEthFlowOrder,
+    web3: &Web3,
+) {
+    let auction_is_empty = || async { services.solvable_orders().await == 0 };
+    wait_for_condition(TIMEOUT, auction_is_empty).await.unwrap();
+
+    let buy_token = ERC20Mintable::at(web3, ethflow_order.0.buy_token);
+    let receiver_buy_token_balance = buy_token
+        .balance_of(ethflow_order.0.receiver)
+        .call()
+        .await
+        .expect("Unable to get token balance");
+    assert!(receiver_buy_token_balance >= ethflow_order.0.buy_amount);
+}
+
+async fn test_orders_query(
+    services: &Services<'_>,
+    order: &ExtendedEthFlowOrder,
+    owner: &H160,
+    contracts: &Contracts,
+) {
+    let response = services
+        .get_order(&order.uid(contracts).await)
+        .await
+        .unwrap();
+    test_order_parameters(&response, order, owner, contracts).await;
+}
+
+async fn test_account_query(
+    queried_account: &H160,
+    client: &Client,
+    order: &ExtendedEthFlowOrder,
+    owner: &H160,
+    contracts: &Contracts,
+) {
+    let query = client
+        .get(&format!(
+            "{API_HOST}{ACCOUNT_ENDPOINT}/{queried_account:?}/orders",
+        ))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(query.status(), 200);
+    let response = query.json::<Vec<Order>>().await.unwrap();
+    assert_eq!(response.len(), 1);
+    test_order_parameters(&response[0], order, owner, contracts).await;
+}
+
+async fn test_auction_query(
+    services: &Services<'_>,
+    order: &ExtendedEthFlowOrder,
+    owner: &H160,
+    contracts: &Contracts,
+) {
+    let response = services.get_auction().await;
+    assert_eq!(response.auction.orders.len(), 1);
+    test_order_parameters(&response.auction.orders[0], order, owner, contracts).await;
+}
+
+enum TradeQuery {
+    ByUid(OrderUid),
+    ByOwner(H160),
+}
+
+async fn test_trade_query(query_type: &TradeQuery, client: &Client, contracts: &Contracts) {
+    let query = client
+        .get(&format!("{API_HOST}{TRADES_ENDPOINT}",))
+        .query(&[match query_type {
+            TradeQuery::ByUid(uid) => ("orderUid", format!("{uid:?}")),
+            TradeQuery::ByOwner(owner) => ("owner", format!("{owner:?}")),
+        }])
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(query.status(), 200);
+    let response = query.json::<Vec<Trade>>().await.unwrap();
+    assert_eq!(response.len(), 1);
+
+    // Expected values from actual EIP1271 order instead of eth-flow order
+    assert_eq!(response[0].owner, contracts.ethflow.address());
+    assert_eq!(response[0].sell_token, contracts.weth.address());
+}
+
+async fn test_order_parameters(
+    response: &Order,
+    order: &ExtendedEthFlowOrder,
+    owner: &H160,
+    contracts: &Contracts,
+) {
+    // Expected values from actual EIP1271 order instead of eth-flow order
+    assert_eq!(response.data.valid_to, u32::MAX);
+    assert_eq!(response.metadata.owner, contracts.ethflow.address());
+    assert_eq!(response.data.sell_token, contracts.weth.address());
+
+    // Specific parameters return the missing values
+    assert_eq!(
+        response.metadata.ethflow_data,
+        Some(EthflowData {
+            user_valid_to: order.0.valid_to as i64,
+            refund_tx_hash: None,
+        })
+    );
+    assert_eq!(
+        response.metadata.onchain_order_data,
+        Some(OnchainOrderData {
+            sender: *owner,
+            placement_error: None,
+        })
+    );
+
+    assert_eq!(response.metadata.class, OrderClass::Market);
+
+    assert!(order
+        .is_valid_cowswap_signature(&response.signature, contracts)
+        .await
+        .is_ok());
+
+    // Requires wrapping first
+    assert_eq!(response.interactions.pre.len(), 1);
+    assert_eq!(
+        response.interactions.pre[0].target,
+        contracts.ethflow.address()
+    );
+    assert_eq!(response.interactions.pre[0].call_data, WRAP_ALL_SELECTOR);
+}

--- a/crates/e2e/tests/e2e/ethflow.rs
+++ b/crates/e2e/tests/e2e/ethflow.rs
@@ -570,15 +570,15 @@ impl From<(H160, u32)> for EthFlowOrderOnchainStatus {
     }
 }
 
-struct EthFlowTradeIntent {
-    sell_amount: U256,
-    buy_token: H160,
-    receiver: H160,
+pub struct EthFlowTradeIntent {
+    pub sell_amount: U256,
+    pub buy_token: H160,
+    pub receiver: H160,
 }
 
 impl EthFlowTradeIntent {
     // How a user trade intent is converted into a quote request by the frontend
-    fn to_quote_request(&self, ethflow: &CoWSwapEthFlow, weth: &WETH9) -> OrderQuoteRequest {
+    pub fn to_quote_request(&self, ethflow: &CoWSwapEthFlow, weth: &WETH9) -> OrderQuoteRequest {
         OrderQuoteRequest {
             from: ethflow.address(),
             // Even if the user sells ETH, we request a quote for WETH

--- a/crates/e2e/tests/e2e/main.rs
+++ b/crates/e2e/tests/e2e/main.rs
@@ -5,12 +5,13 @@
 
 // Each of the following modules contains tests.
 mod app_data;
+mod colocation_ethflow;
 mod colocation_hooks;
 mod colocation_partial_fill;
 mod colocation_univ2;
 mod database;
-mod eth_flow;
 mod eth_integration;
+mod ethflow;
 mod hooks;
 mod limit_orders;
 mod onchain_settlement;

--- a/crates/e2e/tests/e2e/refunder.rs
+++ b/crates/e2e/tests/e2e/refunder.rs
@@ -1,5 +1,5 @@
 use {
-    crate::eth_flow::{EthFlowOrderOnchainStatus, ExtendedEthFlowOrder},
+    crate::ethflow::{EthFlowOrderOnchainStatus, ExtendedEthFlowOrder},
     chrono::{TimeZone, Utc},
     e2e::{nodes::local_node::TestNodeApi, setup::*},
     ethcontract::{H160, U256},


### PR DESCRIPTION
This PR adds balance simulation to the driver.

This enables the `driver` to continue to work with orders that require pre-interactions for setting up balances (such as EthFlow). In addition - the pesky EthFlow exception was removed from the `driver` crate entirely 🎉! In fact, the `driver` no longer cares at all about the EthFlow contract address.

### Test Plan

Added E2E test to verify that EthFlow orders are still executed. They use pre-interactions to ensure the balance is available, so we check that our new simulation logic actually works! Existing hooks E2E test continues to pass.


<details><summary>You can also apply this patch to make the test fail:</summary>

```diff
diff --git a/crates/driver/src/domain/competition/auction.rs b/crates/driver/src/domain/competition/auction.rs
index 144b0562..4377d46e 100644
--- a/crates/driver/src/domain/competition/auction.rs
+++ b/crates/driver/src/domain/competition/auction.rs
@@ -119,10 +119,10 @@ impl Auction {
             .collect::<Vec<_>>();
 
         let mut balances = join_all(traders.into_iter().map(
-            |(trader, token, source, interactions)| async move {
+            |(trader, token, source, _interactions)| async move {
                 let balance = eth
                     .erc20(token)
-                    .tradable_balance(trader.into(), source, interactions)
+                    .balance(trader.into())
                     .await;
                 ((trader, token, source), balance)
             },

```

</details>