### PR TITLE
Compute Available Partial Target Amount

### DIFF
--- a/crates/driver/src/domain/competition/auction.rs
+++ b/crates/driver/src/domain/competition/auction.rs
@@ -168,7 +168,7 @@ impl Auction {
 
             let used_sell = match order.partial {
                 order::Partial::Yes { .. } => max_sell.min(*remaining_balance),
-                order::Partial::No if max_sell < *remaining_balance => max_sell,
+                order::Partial::No if max_sell <= *remaining_balance => max_sell,
                 _ => U256::zero(),
             };
             if used_sell.is_zero() {

--- a/crates/driver/src/domain/competition/auction.rs
+++ b/crates/driver/src/domain/competition/auction.rs
@@ -130,6 +130,14 @@ impl Auction {
         .into_iter()
         .collect::<HashMap<_, _>>();
 
+        // The auction that we receive from the `autopilot` assumes that there
+        // is sufficient balance to completely cover all the orders. **This is
+        // not the case** (as the protocol should not chose which limit orders
+        // get filled for some given sell token balance). This loop goes through
+        // the priority sorted orders and allocates the available user balance
+        // to each order, and potentially scaling the order's `available` amount
+        // down in case the available user balance is only enough to partially
+        // cover the rest of the order.
         self.orders.retain_mut(|order| {
             let remaining_balance = match balances
                 .get_mut(&(order.trader(), order.sell.token, order.sell_token_balance))

--- a/crates/driver/src/domain/competition/solution/trade.rs
+++ b/crates/driver/src/domain/competition/solution/trade.rs
@@ -44,8 +44,8 @@ impl Fulfillment {
             };
 
             match order.partial {
-                order::Partial::Yes { executed: already } => {
-                    order::TargetAmount(already.0 + executed.0 + surplus_fee.0) <= order.target()
+                order::Partial::Yes { available } => {
+                    order::TargetAmount(executed.0 + surplus_fee.0) <= available
                 }
                 order::Partial::No => {
                     order::TargetAmount(executed.0 + surplus_fee.0) == order.target()

--- a/crates/driver/src/infra/api/routes/solve/dto/auction.rs
+++ b/crates/driver/src/infra/api/routes/solve/dto/auction.rs
@@ -59,7 +59,14 @@ impl Auction {
                         app_data: order.app_data.into(),
                         partial: if order.partially_fillable {
                             competition::order::Partial::Yes {
-                                executed: order.executed.into(),
+                                available: match order.kind {
+                                    Kind::Sell => {
+                                        order.sell_amount.saturating_sub(order.executed).into()
+                                    }
+                                    Kind::Buy => {
+                                        order.buy_amount.saturating_sub(order.executed).into()
+                                    }
+                                },
                             }
                         } else {
                             competition::order::Partial::No

--- a/crates/driver/src/infra/api/routes/solve/dto/solution.rs
+++ b/crates/driver/src/infra/api/routes/solve/dto/solution.rs
@@ -1,9 +1,6 @@
 use {
     crate::{
-        domain::{
-            competition::{self},
-            eth,
-        },
+        domain::{competition, eth},
         infra::Solver,
         util::serialize,
     },

--- a/crates/driver/src/infra/observe/mod.rs
+++ b/crates/driver/src/infra/observe/mod.rs
@@ -15,7 +15,7 @@ use {
                 Solution,
                 Solved,
             },
-            eth::{self},
+            eth,
             quote::{self, Quote},
             Liquidity,
         },
@@ -317,7 +317,9 @@ fn competition_error(err: &competition::Error) -> &'static str {
 #[derive(Debug)]
 pub enum OrderExcludedFromAuctionReason<'a> {
     CouldNotFetchBalance(&'a crate::infra::blockchain::Error),
-    CouldNotCalculateRemainingAmount(&'a anyhow::Error),
+    CouldNotCalculateMaxSell,
+    InsufficientBalance,
+    OrderWithZeroAmountRemaining,
 }
 
 pub fn order_excluded_from_auction(

--- a/crates/driver/src/tests/cases/asset_flow.rs
+++ b/crates/driver/src/tests/cases/asset_flow.rs
@@ -3,7 +3,7 @@ use crate::{
     tests::{
         self,
         cases::DEFAULT_SOLVER_FEE,
-        setup::{ab_order, ab_pool, ab_solution, ExecutionDiff, Order, Solution},
+        setup::{ab_order, ab_pool, ab_solution, ExecutionDiff, Order, Partial, Solution},
     },
 };
 
@@ -182,7 +182,7 @@ async fn mix() {
             sell_token: "A",
             buy_token: "B",
             side: order::Side::Buy,
-            partial: order::Partial::Yes {
+            partial: Partial::Yes {
                 executed: Default::default(),
             },
             kind: order::Kind::Liquidity,

--- a/crates/driver/src/tests/setup/blockchain.rs
+++ b/crates/driver/src/tests/setup/blockchain.rs
@@ -1,5 +1,5 @@
 use {
-    super::{Asset, Order},
+    super::{Asset, Order, Partial},
     crate::{
         domain::{
             competition::order,
@@ -133,7 +133,7 @@ impl QuotedOrder {
             secret_key: blockchain.trader_secret_key,
             domain_separator: blockchain.domain_separator,
             owner: blockchain.trader_address,
-            partially_fillable: matches!(self.order.partial, order::Partial::Yes { .. }),
+            partially_fillable: matches!(self.order.partial, Partial::Yes { .. }),
         }
     }
 }

--- a/crates/driver/src/tests/setup/driver.rs
+++ b/crates/driver/src/tests/setup/driver.rs
@@ -2,6 +2,7 @@ use {
     super::{
         blockchain::Blockchain,
         solver::{self, Solver},
+        Partial,
         Test,
     },
     crate::{
@@ -84,10 +85,10 @@ pub fn solve_req(test: &Test) -> serde_json::Value {
                 order::Side::Buy => "buy",
             },
             "owner": hex_address(test.trader_address),
-            "partiallyFillable": matches!(quote.order.partial, order::Partial::Yes { .. }),
+            "partiallyFillable": matches!(quote.order.partial, Partial::Yes { .. }),
             "executed": match quote.order.partial {
-                order::Partial::Yes { executed } => executed.0.to_string(),
-                order::Partial::No => "0".to_owned(),
+                Partial::Yes { executed } => executed.to_string(),
+                Partial::No => "0".to_owned(),
             },
             "preInteractions": [],
             "postInteractions": [],

--- a/crates/driver/src/tests/setup/mod.rs
+++ b/crates/driver/src/tests/setup/mod.rs
@@ -44,6 +44,15 @@ pub struct Asset {
     amount: eth::U256,
 }
 
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub enum Partial {
+    #[default]
+    No,
+    Yes {
+        executed: eth::U256,
+    },
+}
+
 /// Set up a difference between the placed order amounts and the amounts
 /// executed by the solver. This is useful for testing e.g. asset flow
 /// verification. See [`crate::domain::competition::solution::Settlement`].
@@ -86,7 +95,7 @@ pub struct Order {
 
     pub internalize: bool,
     pub side: order::Side,
-    pub partial: order::Partial,
+    pub partial: Partial,
     pub valid_for: util::Timestamp,
     pub kind: order::Kind,
 
@@ -228,7 +237,7 @@ impl Default for Order {
             buy_token: Default::default(),
             internalize: Default::default(),
             side: order::Side::Sell,
-            partial: order::Partial::No,
+            partial: Default::default(),
             valid_for: 100.into(),
             kind: order::Kind::Market,
             user_fee: Default::default(),

--- a/crates/driver/src/tests/setup/solver.rs
+++ b/crates/driver/src/tests/setup/solver.rs
@@ -1,5 +1,5 @@
 use {
-    super::{blockchain, blockchain::Blockchain},
+    super::{blockchain, blockchain::Blockchain, Partial},
     crate::{
         domain::competition::{auction, order},
         infra::{self, blockchain::contracts::Addresses, Ethereum},
@@ -66,7 +66,7 @@ impl Solver {
                     order::Side::Sell => "sell",
                     order::Side::Buy => "buy",
                 },
-                "partiallyFillable": matches!(quote.order.partial, order::Partial::Yes { .. }),
+                "partiallyFillable": matches!(quote.order.partial, Partial::Yes { .. }),
                 "class": match quote.order.kind {
                     _ if config.quote => "market",
                     order::Kind::Market => "market",

--- a/crates/driver/src/util/math.rs
+++ b/crates/driver/src/util/math.rs
@@ -1,0 +1,18 @@
+use ethereum_types::U256;
+
+/// Computes `x * q / d` rounding down.
+///
+/// Returns `None` if `d` is `0` or if the result overflows a 256-bit integer.
+pub fn mul_ratio(x: U256, q: U256, d: U256) -> Option<U256> {
+    x.full_mul(q).checked_div(d.into())?.try_into().ok()
+}
+
+/// Computes `x * q / d` rounding up.
+///
+/// Returns `None` if `d` is `0` or if the result overflows a 256-bit integer.
+pub fn mul_ratio_ceil(x: U256, q: U256, d: U256) -> Option<U256> {
+    let p = x.full_mul(q);
+    let result = U256::try_from(p.checked_div(d.into())?).ok()?;
+    let round_up = !p.checked_rem(d.into())?.is_zero();
+    result.checked_add((round_up as u8).into())
+}

--- a/crates/driver/src/util/mod.rs
+++ b/crates/driver/src/util/mod.rs
@@ -1,6 +1,7 @@
 mod bytes;
 pub mod conv;
 pub mod http;
+pub mod math;
 pub mod serialize;
 mod time;
 


### PR DESCRIPTION
In implementing E2E tests for #1861, I noticed that we weren't storing the allocated balances with the orders in any way. This means that if we had some small amount of balance enough to cover 

This PR changes that. Specifically, we refactored the `domain::order::Partial` to carry around the available target amount instead of the executed amount. This encodes both:
- How much of the order is remaining because of previous executions
- How much of the order was allocated based on the user's remaining balance

As an added bonus, we better differentiate between different reason for orders to be excluded in the prioritization phase, namely:
- We now log when an order is excluded because of missing balance
- We now log when an order is excluded because scaling to remaining amount and balance leads to an order with 0 amounts.

### Test Plan

Rust CI (logic changes isolated to the order prioritization which is partially covered by tests).

Full testing requires #1861 as well, which will be rebased onto this PR.
