### PR TITLE
Remove score discount

### DIFF
--- a/crates/driver/src/boundary/settlement.rs
+++ b/crates/driver/src/boundary/settlement.rs
@@ -211,9 +211,6 @@ impl Settlement {
     ) -> Result<competition::Score> {
         let score = match self.inner.score {
             http_solver::model::Score::Solver { score } => score,
-            http_solver::model::Score::Discount { .. } => {
-                unreachable!("discounted score no longer supported")
-            }
             http_solver::model::Score::RiskAdjusted {
                 success_probability,
                 gas_amount,

--- a/crates/model/src/solver_competition.rs
+++ b/crates/model/src/solver_competition.rs
@@ -133,6 +133,7 @@ pub enum Score {
     ProtocolWithSolverRisk(U256),
     /// The score is calculated by the protocol, by applying a discount to the
     /// `Self::Protocol` value.
+    /// [DEPRECATED] Kept to not brake the solver competition API.
     #[serde(rename = "scoreDiscounted")]
     #[serde(with = "u256_decimal")]
     Discounted(U256),

--- a/crates/shared/src/http_solver/model.rs
+++ b/crates/shared/src/http_solver/model.rs
@@ -197,15 +197,6 @@ pub enum Score {
         score: U256,
     },
     /// This option is used to indicate that the solver did not provide a score.
-    /// Instead, the score should be computed by the protocol.
-    /// To have more flexibility, the protocol score can be tweaked by the
-    /// solver by providing a discount.
-    Discount {
-        #[serde(with = "u256_decimal")]
-        #[serde(rename = "scoreDiscount")]
-        score_discount: U256,
-    },
-    /// This option is used to indicate that the solver did not provide a score.
     /// Instead, the score should be computed by the protocol given the success
     /// probability and optionally the amount of gas this settlement will take.
     RiskAdjusted {
@@ -255,16 +246,6 @@ impl Score {
                 success_probability: p_left * p_right,
                 gas_amount: gas_left
                     .and_then(|left| gas_right.and_then(|right| left.checked_add(right))),
-            }),
-            (
-                Score::Discount {
-                    score_discount: left,
-                },
-                Score::Discount {
-                    score_discount: right,
-                },
-            ) => Some(Score::Discount {
-                score_discount: left.checked_add(*right)?,
             }),
             _ => None,
         }
@@ -954,27 +935,6 @@ mod tests {
             deserialized.score,
             Score::Solver {
                 score: 20_000_000_000_000_000u128.into()
-            }
-        );
-    }
-
-    #[test]
-    fn decode_score_discount() {
-        let solution = r#"
-            {
-                "tokens": {},
-                "orders": {},
-                "scoreDiscount": "1337",
-                "metadata": {},
-                "ref_token": "0xc778417e063141139fce010982780140aa0cd5ab",
-                "prices": {}
-            }
-        "#;
-        let deserialized = serde_json::from_str::<SettledBatchAuctionModel>(solution).unwrap();
-        assert_eq!(
-            deserialized.score,
-            Score::Discount {
-                score_discount: 1337.into()
             }
         );
     }

--- a/crates/solver/src/settlement_rater.rs
+++ b/crates/solver/src/settlement_rater.rs
@@ -260,14 +260,11 @@ impl SettlementRating for SettlementRater {
         let objective_value = inputs.objective_value();
         let score = match settlement.score {
             http_solver::model::Score::Solver { score } => Score::Solver(score),
-            http_solver::model::Score::Discount { score_discount } => Score::Discounted(
-                big_rational_to_u256(&objective_value)?.saturating_sub(score_discount),
-            ),
             http_solver::model::Score::RiskAdjusted {
                 success_probability,
                 ..
             } => Score::ProtocolWithSolverRisk(self.score_calculator.compute_score(
-                &inputs.objective_value(),
+                &objective_value,
                 &inputs.gas_cost(),
                 success_probability,
             )?),

--- a/crates/solvers/src/boundary/legacy.rs
+++ b/crates/solvers/src/boundary/legacy.rs
@@ -535,9 +535,6 @@ fn to_domain_solution(
             .collect(),
         score: match model.score {
             Score::Solver { score } => solution::Score::Solver(score),
-            Score::Discount { .. } => {
-                return Err(anyhow::anyhow!("score_discount no longer supported"))
-            }
             Score::RiskAdjusted {
                 success_probability,
                 ..


### PR DESCRIPTION
# Description
Implements https://github.com/cowprotocol/services/issues/1898
Implemented in a separate PR so it doesn't gets merged too soon (next week release is too soon for this change _I think_)

# Changes
<!-- List of detailed changes (how the change is accomplished) -->

As per [discussion](https://cowservices.slack.com/archives/C036JAGRQ04/p1695637642640269), score discount is deprecated.

# Release Notes
To be merged next week, so it becomes a part of weekly release ~10th of October @harisang 