### PR TITLE
Fix auction gas price

### DIFF
--- a/crates/driver/src/infra/blockchain/gas.rs
+++ b/crates/driver/src/infra/blockchain/gas.rs
@@ -7,7 +7,6 @@ use {
     crate::{domain::eth, infra::mempool},
     ethcontract::dyns::DynWeb3,
     gas_estimation::{nativegasestimator::NativeGasEstimator, GasPriceEstimating},
-    std::sync::Arc,
 };
 
 type MaxAdditionalTip = f64;
@@ -15,17 +14,15 @@ type AdditionalTipPercentage = f64;
 type AdditionalTip = (MaxAdditionalTip, AdditionalTipPercentage);
 
 pub struct GasPriceEstimator {
-    gas: Arc<NativeGasEstimator>,
+    gas: NativeGasEstimator,
     additional_tip: Option<AdditionalTip>,
 }
 
 impl GasPriceEstimator {
     pub async fn new(web3: &DynWeb3, mempools: &[mempool::Config]) -> Result<Self, Error> {
-        let gas = Arc::new(
-            NativeGasEstimator::new(web3.transport().clone(), None)
-                .await
-                .map_err(Error::Gas)?,
-        );
+        let gas = NativeGasEstimator::new(web3.transport().clone(), None)
+            .await
+            .map_err(Error::Gas)?;
         let additional_tip = mempools
             .iter()
             .find(|mempool| matches!(mempool.kind, mempool::Kind::Flashbots { .. }))

--- a/crates/driver/src/infra/blockchain/gas.rs
+++ b/crates/driver/src/infra/blockchain/gas.rs
@@ -1,3 +1,5 @@
+use anyhow::ensure;
+
 /// Wrapper around the gas estimation library.
 /// Also allows to add additional tip to the gas price. This is used to
 /// increase the chance of a transaction being included in a block, in case
@@ -54,11 +56,10 @@ impl GasPriceEstimator {
             .map(|mut estimate| {
                 let estimate = match self.additional_tip {
                     Some((max_additional_tip, additional_tip_percentage)) => {
-                        estimate.max_priority_fee_per_gas += max_additional_tip
+                        let additional_tip = max_additional_tip
                             .min(estimate.max_fee_per_gas * additional_tip_percentage);
-                        estimate.max_priority_fee_per_gas = estimate
-                            .max_priority_fee_per_gas
-                            .min(estimate.max_fee_per_gas);
+                        estimate.max_fee_per_gas += additional_tip;
+                        estimate.max_priority_fee_per_gas += additional_tip;
                         estimate = estimate.ceil();
                         estimate
                     }

--- a/crates/driver/src/infra/blockchain/gas.rs
+++ b/crates/driver/src/infra/blockchain/gas.rs
@@ -1,0 +1,78 @@
+/// Wrapper around the gas estimation library.
+/// Also llows to add additional tip to the gas price. This is used to
+/// increase the chance of a transaction being included in a block, in case
+/// private submission networks are used.
+use {
+    super::Error,
+    crate::{domain::eth, infra::mempool},
+    ethcontract::dyns::DynWeb3,
+    gas_estimation::{nativegasestimator::NativeGasEstimator, GasPriceEstimating},
+    std::sync::Arc,
+};
+
+type MaxAdditionalTip = f64;
+type AdditionalTipPercentage = f64;
+type AdditionalTip = (MaxAdditionalTip, AdditionalTipPercentage);
+
+pub struct GasPriceEstimator {
+    gas: Arc<NativeGasEstimator>,
+    additional_tip: Option<AdditionalTip>,
+}
+
+impl GasPriceEstimator {
+    pub async fn new(web3: &DynWeb3, mempools: &[mempool::Config]) -> Result<Self, Error> {
+        let gas = Arc::new(
+            NativeGasEstimator::new(web3.transport().clone(), None)
+                .await
+                .map_err(Error::Gas)?,
+        );
+        let additional_tip = mempools
+            .iter()
+            .find(|mempool| matches!(mempool.kind, mempool::Kind::Flashbots { .. }))
+            .map(|mempool| {
+                (
+                    match mempool.kind {
+                        mempool::Kind::Flashbots {
+                            max_additional_tip, ..
+                        } => max_additional_tip,
+                        _ => unreachable!(),
+                    },
+                    mempool.additional_tip_percentage,
+                )
+            });
+        Ok(Self {
+            gas,
+            additional_tip,
+        })
+    }
+
+    /// Estimates the gas price for a transaction.
+    /// If additional tip is configured, it will be added to the gas price. This
+    /// is to increase the chance of a transaction being included in a block, in
+    /// case private submission networks are used.
+    pub async fn estimate(&self) -> Result<eth::GasPrice, Error> {
+        self.gas
+            .estimate()
+            .await
+            .map(|mut estimate| {
+                let estimate = match self.additional_tip {
+                    Some((max_additional_tip, additional_tip_percentage)) => {
+                        estimate.max_priority_fee_per_gas += max_additional_tip
+                            .min(estimate.max_fee_per_gas * additional_tip_percentage);
+                        estimate.max_priority_fee_per_gas = estimate
+                            .max_priority_fee_per_gas
+                            .min(estimate.max_fee_per_gas);
+                        estimate = estimate.ceil();
+                        estimate
+                    }
+                    None => estimate,
+                };
+                eth::GasPrice {
+                    max: eth::U256::from_f64_lossy(estimate.max_fee_per_gas).into(),
+                    tip: eth::U256::from_f64_lossy(estimate.max_priority_fee_per_gas).into(),
+                    base: eth::U256::from_f64_lossy(estimate.base_fee_per_gas).into(),
+                }
+            })
+            .map_err(Error::Gas)
+    }
+}

--- a/crates/driver/src/infra/blockchain/gas.rs
+++ b/crates/driver/src/infra/blockchain/gas.rs
@@ -1,5 +1,3 @@
-use anyhow::ensure;
-
 /// Wrapper around the gas estimation library.
 /// Also allows to add additional tip to the gas price. This is used to
 /// increase the chance of a transaction being included in a block, in case

--- a/crates/driver/src/infra/blockchain/gas.rs
+++ b/crates/driver/src/infra/blockchain/gas.rs
@@ -1,5 +1,5 @@
 /// Wrapper around the gas estimation library.
-/// Also llows to add additional tip to the gas price. This is used to
+/// Also allows to add additional tip to the gas price. This is used to
 /// increase the chance of a transaction being included in a block, in case
 /// private submission networks are used.
 use {

--- a/crates/driver/src/infra/blockchain/mod.rs
+++ b/crates/driver/src/infra/blockchain/mod.rs
@@ -1,6 +1,5 @@
 use {
     self::contracts::ContractAt,
-    super::mempool,
     crate::{boundary, domain::eth},
     ethcontract::dyns::DynWeb3,
     std::{fmt, sync::Arc},
@@ -45,6 +44,11 @@ impl Rpc {
     pub fn network(&self) -> &Network {
         &self.network
     }
+
+    /// Returns a reference to the underlying web3 client.
+    pub fn web3(&self) -> &DynWeb3 {
+        &self.web3
+    }
 }
 
 /// The Ethereum blockchain.
@@ -61,11 +65,10 @@ impl Ethereum {
     pub async fn new(
         rpc: Rpc,
         addresses: contracts::Addresses,
-        mempools: &[mempool::Config],
+        gas: Arc<GasPriceEstimator>,
     ) -> Result<Self, Error> {
         let Rpc { web3, network } = rpc;
         let contracts = Contracts::new(&web3, &network.id, addresses).await?;
-        let gas = Arc::new(GasPriceEstimator::new(&web3, mempools).await?);
 
         Ok(Self {
             web3,

--- a/crates/driver/src/infra/config/file/load.rs
+++ b/crates/driver/src/infra/config/file/load.rs
@@ -37,7 +37,6 @@ pub async fn load(network: &blockchain::Network, path: &Path) -> infra::Config {
     );
 
     infra::Config {
-        score_cap: config.score_cap,
         solvers: join_all(config.solvers.into_iter().map(|config| async move {
             let account = match config.account {
                 file::Account::PrivateKey(private_key) => ethcontract::Account::Offline(

--- a/crates/driver/src/infra/config/file/mod.rs
+++ b/crates/driver/src/infra/config/file/mod.rs
@@ -47,9 +47,6 @@ struct Config {
 
     #[serde(default)]
     liquidity: LiquidityConfig,
-
-    #[serde(default = "default_score_cap")]
-    score_cap: eth::U256,
 }
 
 #[derive(Debug, Default, Deserialize)]
@@ -142,10 +139,6 @@ fn default_max_additional_flashbots_tip() -> f64 {
 
 fn default_soft_cancellations_flag() -> bool {
     false
-}
-
-fn default_score_cap() -> eth::U256 {
-    10_000_000_000_000_000u128.into() // 0.01 ETH
 }
 
 #[serde_as]

--- a/crates/driver/src/infra/config/mod.rs
+++ b/crates/driver/src/infra/config/mod.rs
@@ -1,9 +1,6 @@
-use {
-    crate::{
-        domain::eth,
-        infra::{blockchain, liquidity, mempool, simulator, solver},
-    },
-    primitive_types::U256,
+use crate::{
+    domain::eth,
+    infra::{blockchain, liquidity, mempool, simulator, solver},
 };
 
 pub mod file;
@@ -11,7 +8,6 @@ pub mod file;
 /// Configuration of infrastructural components.
 #[derive(Debug)]
 pub struct Config {
-    pub score_cap: U256,
     pub disable_access_list_simulation: bool,
     pub disable_gas_simulation: Option<eth::Gas>,
     pub solvers: Vec<solver::Config>,

--- a/crates/driver/src/run.rs
+++ b/crates/driver/src/run.rs
@@ -122,7 +122,7 @@ async fn ethrpc(args: &cli::Args) -> blockchain::Rpc {
 
 async fn ethereum(config: &infra::Config, ethrpc: blockchain::Rpc) -> Ethereum {
     let gas = Arc::new(
-        blockchain::gas::GasPriceEstimator::new(ethrpc.web3(), &config.mempools)
+        blockchain::GasPriceEstimator::new(ethrpc.web3(), &config.mempools)
             .await
             .expect("initialize gas price estimator"),
     );

--- a/crates/driver/src/run.rs
+++ b/crates/driver/src/run.rs
@@ -121,7 +121,7 @@ async fn ethrpc(args: &cli::Args) -> blockchain::Rpc {
 }
 
 async fn ethereum(config: &infra::Config, ethrpc: blockchain::Rpc) -> Ethereum {
-    Ethereum::new(ethrpc, config.contracts)
+    Ethereum::new(ethrpc, config.contracts, &config.mempools)
         .await
         .expect("initialize ethereum RPC API")
 }

--- a/crates/driver/src/run.rs
+++ b/crates/driver/src/run.rs
@@ -16,7 +16,7 @@ use {
     },
     clap::Parser,
     futures::future::join_all,
-    std::{net::SocketAddr, time::Duration},
+    std::{net::SocketAddr, sync::Arc, time::Duration},
     tokio::sync::oneshot,
 };
 
@@ -121,7 +121,12 @@ async fn ethrpc(args: &cli::Args) -> blockchain::Rpc {
 }
 
 async fn ethereum(config: &infra::Config, ethrpc: blockchain::Rpc) -> Ethereum {
-    Ethereum::new(ethrpc, config.contracts, &config.mempools)
+    let gas = Arc::new(
+        blockchain::gas::GasPriceEstimator::new(ethrpc.web3(), &config.mempools)
+            .await
+            .expect("initialize gas price estimator"),
+    );
+    Ethereum::new(ethrpc, config.contracts, gas)
         .await
         .expect("initialize ethereum RPC API")
 }

--- a/crates/driver/src/tests/setup/solver.rs
+++ b/crates/driver/src/tests/setup/solver.rs
@@ -200,7 +200,7 @@ impl Solver {
                 settlement: Some(config.blockchain.settlement.address().into()),
                 weth: Some(config.blockchain.weth.address().into()),
             },
-            &vec![],
+            &[],
         )
         .await
         .unwrap();

--- a/crates/driver/src/tests/setup/solver.rs
+++ b/crates/driver/src/tests/setup/solver.rs
@@ -194,13 +194,19 @@ impl Solver {
             .collect::<HashMap<_, _>>();
 
         let url = config.blockchain.web3_url.parse().unwrap();
+        let rpc = infra::blockchain::Rpc::new(&url).await.unwrap();
+        let gas = Arc::new(
+            infra::blockchain::GasPriceEstimator::new(rpc.web3(), &[])
+                .await
+                .unwrap(),
+        );
         let eth = Ethereum::new(
-            infra::blockchain::Rpc::new(&url).await.unwrap(),
+            rpc,
             Addresses {
                 settlement: Some(config.blockchain.settlement.address().into()),
                 weth: Some(config.blockchain.weth.address().into()),
             },
-            &[],
+            gas,
         )
         .await
         .unwrap();

--- a/crates/driver/src/tests/setup/solver.rs
+++ b/crates/driver/src/tests/setup/solver.rs
@@ -200,6 +200,7 @@ impl Solver {
                 settlement: Some(config.blockchain.settlement.address().into()),
                 weth: Some(config.blockchain.weth.address().into()),
             },
+            &vec![],
         )
         .await
         .unwrap();

--- a/crates/solver/src/settlement_submission/submitter.rs
+++ b/crates/solver/src/settlement_submission/submitter.rs
@@ -162,10 +162,13 @@ impl GasPriceEstimating for SubmitterGasPriceEstimator<'_> {
             .estimate_with_limits(gas_limit, time_limit)
             .await?;
 
-        estimate.max_fee_per_gas = estimate.max_fee_per_gas.min(self.max_fee_per_gas);
-        estimate.max_priority_fee_per_gas += self
+        let additional_tip = self
             .max_additional_tip
             .min(estimate.max_fee_per_gas * self.additional_tip_percentage_of_max_fee);
+        estimate.max_priority_fee_per_gas += additional_tip;
+        estimate.max_fee_per_gas += additional_tip;
+        // ensure limits are not violated
+        estimate.max_fee_per_gas = estimate.max_fee_per_gas.min(self.max_fee_per_gas);
         estimate.max_priority_fee_per_gas = estimate
             .max_priority_fee_per_gas
             .min(estimate.max_fee_per_gas);

--- a/crates/solver/src/settlement_submission/submitter.rs
+++ b/crates/solver/src/settlement_submission/submitter.rs
@@ -162,16 +162,16 @@ impl GasPriceEstimating for SubmitterGasPriceEstimator<'_> {
             .estimate_with_limits(gas_limit, time_limit)
             .await?;
 
-        let additional_tip = self
-            .max_additional_tip
-            .min(estimate.max_fee_per_gas * self.additional_tip_percentage_of_max_fee);
-        estimate.max_priority_fee_per_gas += additional_tip;
-        estimate.max_fee_per_gas += additional_tip;
-        // ensure limits are not violated
-        estimate.max_fee_per_gas = estimate.max_fee_per_gas.min(self.max_fee_per_gas);
-        estimate.max_priority_fee_per_gas = estimate
-            .max_priority_fee_per_gas
-            .min(estimate.max_fee_per_gas);
+        let additional_tip = self.max_additional_tip.min(
+            estimate.max_fee_per_gas.min(self.max_fee_per_gas)
+                * self.additional_tip_percentage_of_max_fee,
+        );
+
+        estimate.max_fee_per_gas =
+            (estimate.max_fee_per_gas + additional_tip).min(self.max_fee_per_gas);
+        estimate.max_priority_fee_per_gas =
+            (estimate.max_priority_fee_per_gas + additional_tip).min(estimate.max_fee_per_gas);
+
         estimate = estimate.ceil();
 
         ensure!(estimate.is_valid(), "gas estimate exceeds cap {estimate}");


### PR DESCRIPTION
# Description
Fixes task 2 from https://github.com/cowprotocol/services/issues/1893
Alternative to https://github.com/cowprotocol/services/pull/1840

# Changes
Based on the configuration of the driver, if private networks are used for settlement submission, auction `gas_price` needs to be boosted. This is to set the same value of `gas_price` for ranking the solutions, as well as for the starting value for settlement submission (what will be the end value of gas price is something we don't know in advance).

`score_cap` removal not related to this PR, I just noticed that it's a dead code (in previous PR `score_cap` was moved to `autopilot`).

I decided not to waste time fixing this for the non-colocated driver, since the colocation will be activated soon and this issue is not high priority one.