### PR TITLE
Avoid Collecting Driver Solutions in RunLoop

### DIFF
--- a/crates/autopilot/src/run_loop.rs
+++ b/crates/autopilot/src/run_loop.rs
@@ -98,13 +98,12 @@ impl RunLoop {
             .flat_map(|(index, response)| {
                 if response.solutions.is_empty() {
                     tracing::debug!(driver = ?self.drivers[index].url, "driver sent zero solutions");
-                    return vec![];
                 }
 
                 response
                     .solutions
                     .into_iter()
-                    .filter_map(|solution| {
+                    .filter_map(move |solution| {
                         if solution.score == U256::zero() {
                             tracing::debug!(
                                 id = ?solution.solution_id,
@@ -116,7 +115,6 @@ impl RunLoop {
                             Some((index, solution))
                         }
                     })
-                    .collect_vec()
             })
             .collect_vec();
 


### PR DESCRIPTION
# Description

Follow up to #1914 

This PR just removes the unnecessary `collect` in the `flat_map` closure.

## How to test

CI.