### PR TITLE
Additional fixes for driver multiple solutions

### DIFF
--- a/crates/autopilot/src/driver_model.rs
+++ b/crates/autopilot/src/driver_model.rs
@@ -137,8 +137,8 @@ pub mod solve {
     #[derive(Clone, Debug, Default, Deserialize)]
     #[serde(rename_all = "camelCase", deny_unknown_fields)]
     pub struct Solution {
-        /// Unique ID of the solution, used to identify it in subsequent
-        /// requests (reveal, settle).
+        /// Unique ID of the solution (per driver competition), used to identify
+        /// it in subsequent requests (reveal, settle).
         #[serde_as(as = "serde_with::DisplayFromStr")]
         pub solution_id: u64,
         pub score: U256,
@@ -164,7 +164,7 @@ pub mod reveal {
     #[derive(Clone, Debug, Default, Serialize)]
     #[serde(rename_all = "camelCase")]
     pub struct Request {
-        /// Unique ID of the solution to reveal.
+        /// Unique ID of the solution (per driver competition), to reveal.
         #[serde_as(as = "serde_with::DisplayFromStr")]
         pub solution_id: u64,
     }
@@ -198,7 +198,7 @@ pub mod settle {
     #[derive(Clone, Debug, Default, Serialize)]
     #[serde(rename_all = "camelCase")]
     pub struct Request {
-        /// Unique ID of the solution to settle.
+        /// Unique ID of the solution (per driver competition), to settle.
         #[serde_as(as = "serde_with::DisplayFromStr")]
         pub solution_id: u64,
     }

--- a/crates/driver/src/infra/api/routes/reveal/dto/solution.rs
+++ b/crates/driver/src/infra/api/routes/reveal/dto/solution.rs
@@ -5,7 +5,7 @@ use {serde::Deserialize, serde_with::serde_as};
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct Solution {
     #[allow(dead_code)]
-    /// Unique ID of the solution to reveal.
+    /// Unique ID of the solution (per driver competition), to reveal.
     #[serde_as(as = "serde_with::DisplayFromStr")]
     solution_id: u64,
 }

--- a/crates/driver/src/infra/api/routes/settle/dto/solution.rs
+++ b/crates/driver/src/infra/api/routes/settle/dto/solution.rs
@@ -5,7 +5,7 @@ use {serde::Deserialize, serde_with::serde_as};
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct Solution {
     #[allow(dead_code)]
-    /// Unique ID of the solution to settle.
+    /// Unique ID of the solution (per driver competition), to settle.
     #[serde_as(as = "serde_with::DisplayFromStr")]
     solution_id: u64,
 }

--- a/crates/driver/src/infra/api/routes/solve/dto/solved.rs
+++ b/crates/driver/src/infra/api/routes/solve/dto/solved.rs
@@ -38,8 +38,8 @@ impl Solution {
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Solution {
-    /// Unique ID of the solution, used to identify it in subsequent requests
-    /// (reveal, settle).
+    /// Unique ID of the solution (per driver competition), used to identify it
+    /// in subsequent requests (reveal, settle).
     #[serde_as(as = "serde_with::DisplayFromStr")]
     solution_id: u64,
     #[serde_as(as = "serialize::U256")]


### PR DESCRIPTION
# Description
Follow up PR addressing the comments: https://github.com/cowprotocol/services/pull/1909#discussion_r1345260527

Solution ID can be unique:
1. Across multiple drivers (hard to implement)
2. Across multiple competitions in a single driver
3. In single competition in a single driver

Currently, solution ID is unique in a single competition (3), which seems enough for now, but if we need it to be unique across multiple competitions in a single driver it can be implemented without changing the `autopilot/driver` interface, since it is a `driver`s implementation detail.

# Changes

- [x] `Request` no longer optional.
- [x] Add comments for solution ID.