### PR TITLE
Configuration To Skip Liquidity Fetching for Solver

### DIFF
--- a/crates/driver/src/domain/quote.rs
+++ b/crates/driver/src/domain/quote.rs
@@ -74,7 +74,10 @@ impl Order {
         liquidity: &infra::liquidity::Fetcher,
         tokens: &infra::tokens::Fetcher,
     ) -> Result<Quote, Error> {
-        let liquidity = liquidity.fetch(&self.liquidity_pairs()).await;
+        let liquidity = match solver.liquidity() {
+            solver::Liquidity::Fetch => liquidity.fetch(&self.liquidity_pairs()).await,
+            solver::Liquidity::Skip => Default::default(),
+        };
         let timeout = self.deadline.timeout()?;
         let solutions = solver
             .solve(&self.fake_auction(eth, tokens).await?, &liquidity, timeout)

--- a/crates/driver/src/infra/config/file/load.rs
+++ b/crates/driver/src/infra/config/file/load.rs
@@ -60,6 +60,11 @@ pub async fn load(network: &blockchain::Network, path: &Path) -> infra::Config {
                     relative: config.relative_slippage,
                     absolute: config.absolute_slippage.map(Into::into),
                 },
+                liquidity: if config.skip_liquidity {
+                    solver::Liquidity::Skip
+                } else {
+                    solver::Liquidity::Fetch
+                },
                 account,
             }
         }))

--- a/crates/driver/src/infra/config/file/mod.rs
+++ b/crates/driver/src/infra/config/file/mod.rs
@@ -164,6 +164,10 @@ struct SolverConfig {
     #[serde_as(as = "Option<serialize::U256>")]
     absolute_slippage: Option<eth::U256>,
 
+    /// Whether or not to skip fetching liquidity for this solver.
+    #[serde(default)]
+    skip_liquidity: bool,
+
     /// The account which should be used to sign settlements for this solver.
     account: Account,
 }

--- a/crates/driver/src/infra/solver/mod.rs
+++ b/crates/driver/src/infra/solver/mod.rs
@@ -48,6 +48,16 @@ pub struct Slippage {
     pub absolute: Option<eth::Ether>,
 }
 
+#[derive(Clone, Copy, Debug)]
+pub enum Liquidity {
+    /// Liquidity should be fetched and included in the auction sent to this
+    /// solver.
+    Fetch,
+    /// The solver does not need liquidity, so fetching can be skipped for this
+    /// solver.
+    Skip,
+}
+
 /// Solvers are controlled by the driver. Their job is to search for solutions
 /// to auctions. They do this in various ways, often by analyzing different AMMs
 /// on the Ethereum blockchain.
@@ -65,6 +75,8 @@ pub struct Config {
     pub name: Name,
     /// The acceptable slippage for this solver.
     pub slippage: Slippage,
+    /// Whether or not liquidity is used by this solver.
+    pub liquidity: Liquidity,
     /// The private key of this solver, used for settlement submission.
     pub account: ethcontract::Account,
 }
@@ -99,6 +111,11 @@ impl Solver {
     /// The slippage configuration of this solver.
     pub fn slippage(&self) -> &Slippage {
         &self.config.slippage
+    }
+
+    /// The liquidity configuration of this solver
+    pub fn liquidity(&self) -> Liquidity {
+        self.config.liquidity
     }
 
     /// The blockchain address of this solver.


### PR DESCRIPTION
# Description

This PR makes a **hacky** (but IMO pragmatic) change proposal to the driver. In particular, in our current setup we share a `driver` instance across solvers that both use and don't use liquidity. This is an issue because solvers that don't need liquidity will end up waiting for liquidity that they don't use, increasing solving and quoting latency for those solvers.

The way this was imagined to work was to set up separate `driver` instances for solvers with different liquidity requirements. However, the downside to this is that those multiple `driver` instances don't share other valuable caches (balances, token infos, etc.). In addition, this adds additional complexity in the infrastructure setup (multiple drivers to deploy, multiple drivers as sources for logs, etc.).

The solution is simple, add an "all or nothing" flag to each solver configured in the `driver` to control whether or not to invoke the liquidity fetcher for that solver. This allows us to use a single `driver` instance, while not increasing latency for `/solve`-ing and `/quote`-ing with solvers that don't care at all about liquidity.

# Changes

1. Adds a new per-solver configuration option 
2. Skips fetching liquidity if this configuration option is enabled for a particular solver when quoting and solving.

## How to test

Rust compiler. Logic was simple enough that I did not an driver test for it. That being said, we should probably have one, but the current driver test setup is very much geared towards actually computing solutions (which we don't care about here) and would need a slightly different setup to make a test for this possible.