### PR TITLE
Fetch Recent Liquidity for Quotes

### DIFF
--- a/crates/driver/src/boundary/liquidity/mod.rs
+++ b/crates/driver/src/boundary/liquidity/mod.rs
@@ -129,7 +129,7 @@ impl Fetcher {
     pub async fn fetch(
         &self,
         pairs: &HashSet<liquidity::TokenPair>,
-        allow_stale: bool,
+        when: infra::liquidity::When,
     ) -> Result<Vec<liquidity::Liquidity>> {
         let pairs = pairs
             .iter()
@@ -139,13 +139,14 @@ impl Fetcher {
             })
             .collect();
 
-        let at_block = if allow_stale {
-            recent_block_cache::Block::Recent
-        } else {
-            let block_number = self.blocks.borrow().number;
-            recent_block_cache::Block::Number(block_number)
+        let block = match when {
+            infra::liquidity::When::Recent => recent_block_cache::Block::Recent,
+            infra::liquidity::When::Latest => {
+                let block_number = self.blocks.borrow().number;
+                recent_block_cache::Block::Number(block_number)
+            }
         };
-        let liquidity = self.inner.get_liquidity(pairs, at_block).await?;
+        let liquidity = self.inner.get_liquidity(pairs, block).await?;
 
         let liquidity = liquidity
             .into_iter()

--- a/crates/driver/src/boundary/liquidity/mod.rs
+++ b/crates/driver/src/boundary/liquidity/mod.rs
@@ -129,7 +129,7 @@ impl Fetcher {
     pub async fn fetch(
         &self,
         pairs: &HashSet<liquidity::TokenPair>,
-        when: infra::liquidity::When,
+        block: infra::liquidity::AtBlock,
     ) -> Result<Vec<liquidity::Liquidity>> {
         let pairs = pairs
             .iter()
@@ -139,9 +139,9 @@ impl Fetcher {
             })
             .collect();
 
-        let block = match when {
-            infra::liquidity::When::Recent => recent_block_cache::Block::Recent,
-            infra::liquidity::When::Latest => {
+        let block = match block {
+            infra::liquidity::AtBlock::Recent => recent_block_cache::Block::Recent,
+            infra::liquidity::AtBlock::Latest => {
                 let block_number = self.blocks.borrow().number;
                 recent_block_cache::Block::Number(block_number)
             }

--- a/crates/driver/src/domain/competition/mod.rs
+++ b/crates/driver/src/domain/competition/mod.rs
@@ -49,7 +49,10 @@ impl Competition {
     pub async fn solve(&self, auction: &Auction) -> Result<Solved, Error> {
         let liquidity = self
             .liquidity
-            .fetch(&auction.liquidity_pairs(), infra::liquidity::When::Latest)
+            .fetch(
+                &auction.liquidity_pairs(),
+                infra::liquidity::AtBlock::Latest,
+            )
             .await;
 
         // Fetch the solutions from the solver.

--- a/crates/driver/src/domain/competition/mod.rs
+++ b/crates/driver/src/domain/competition/mod.rs
@@ -2,7 +2,7 @@ use {
     self::solution::settlement,
     super::{eth, Mempools},
     crate::{
-        domain::{competition::solution::Settlement, liquidity},
+        domain::competition::solution::Settlement,
         infra::{
             self,
             blockchain::Ethereum,
@@ -49,19 +49,7 @@ impl Competition {
     pub async fn solve(&self, auction: &Auction) -> Result<Solved, Error> {
         let liquidity = self
             .liquidity
-            .fetch(
-                &auction
-                    .orders()
-                    .iter()
-                    .filter_map(|order| match order.kind {
-                        order::Kind::Market | order::Kind::Limit { .. } => {
-                            liquidity::TokenPair::new(order.sell.token, order.buy.token).ok()
-                        }
-                        order::Kind::Liquidity => None,
-                    })
-                    .collect(),
-                infra::liquidity::When::Latest,
-            )
+            .fetch(&auction.liquidity_pairs(), infra::liquidity::When::Latest)
             .await;
 
         // Fetch the solutions from the solver.

--- a/crates/driver/src/domain/competition/mod.rs
+++ b/crates/driver/src/domain/competition/mod.rs
@@ -60,7 +60,7 @@ impl Competition {
                         order::Kind::Liquidity => None,
                     })
                     .collect(),
-                false,
+                infra::liquidity::When::Latest,
             )
             .await;
 

--- a/crates/driver/src/domain/quote.rs
+++ b/crates/driver/src/domain/quote.rs
@@ -75,7 +75,7 @@ impl Order {
         tokens: &infra::tokens::Fetcher,
     ) -> Result<Quote, Error> {
         let liquidity = liquidity
-            .fetch(&self.liquidity_pairs(), infra::liquidity::When::Recent)
+            .fetch(&self.liquidity_pairs(), infra::liquidity::AtBlock::Recent)
             .await;
         let timeout = self.deadline.timeout()?;
         let solutions = solver

--- a/crates/driver/src/domain/quote.rs
+++ b/crates/driver/src/domain/quote.rs
@@ -74,7 +74,9 @@ impl Order {
         liquidity: &infra::liquidity::Fetcher,
         tokens: &infra::tokens::Fetcher,
     ) -> Result<Quote, Error> {
-        let liquidity = liquidity.fetch(&self.liquidity_pairs(), true).await;
+        let liquidity = liquidity
+            .fetch(&self.liquidity_pairs(), infra::liquidity::When::Recent)
+            .await;
         let timeout = self.deadline.timeout()?;
         let solutions = solver
             .solve(&self.fake_auction(eth, tokens).await?, &liquidity, timeout)

--- a/crates/driver/src/infra/liquidity/fetcher.rs
+++ b/crates/driver/src/infra/liquidity/fetcher.rs
@@ -13,11 +13,11 @@ pub struct Fetcher {
     inner: Arc<boundary::liquidity::Fetcher>,
 }
 
-/// Specifies for when liquidity should be fetched.
-pub enum When {
-    /// Fetches some recent liquidity. This will prefer reusing cached liquidity
-    /// even if it is stale by a few blocks instead of fetching the absolute
-    /// latest state from the blockchain.
+/// Specifies at which block liquidity should be fetched.
+pub enum AtBlock {
+    /// Fetches liquidity at a recent block. This will prefer reusing cached
+    /// liquidity even if it is stale by a few blocks instead of fetching the
+    /// absolute latest state from the blockchain.
     ///
     /// This is useful for quoting where we want an up-to-date, but not
     /// necessarily exactly correct price. In the context of quote verification,
@@ -44,10 +44,10 @@ impl Fetcher {
     pub async fn fetch(
         &self,
         pairs: &HashSet<liquidity::TokenPair>,
-        when: When,
+        block: AtBlock,
     ) -> Vec<liquidity::Liquidity> {
         observe::fetching_liquidity();
-        match self.inner.fetch(pairs, when).await {
+        match self.inner.fetch(pairs, block).await {
             Ok(liquidity) => {
                 observe::fetched_liquidity(&liquidity);
                 liquidity

--- a/crates/driver/src/infra/liquidity/mod.rs
+++ b/crates/driver/src/infra/liquidity/mod.rs
@@ -15,5 +15,5 @@ pub mod fetcher;
 
 pub use self::{
     config::Config,
-    fetcher::{Fetcher, When},
+    fetcher::{AtBlock, Fetcher},
 };

--- a/crates/driver/src/infra/liquidity/mod.rs
+++ b/crates/driver/src/infra/liquidity/mod.rs
@@ -13,4 +13,7 @@
 pub mod config;
 pub mod fetcher;
 
-pub use self::{config::Config, fetcher::Fetcher};
+pub use self::{
+    config::Config,
+    fetcher::{Fetcher, When},
+};

--- a/crates/e2e/tests/e2e/colocation_quoting.rs
+++ b/crates/e2e/tests/e2e/colocation_quoting.rs
@@ -1,0 +1,85 @@
+use {
+    e2e::{setup::*, tx, tx_value},
+    ethcontract::U256,
+    model::quote::{OrderQuoteRequest, OrderQuoteSide, SellAmount},
+    number::nonzero::U256 as NonZeroU256,
+    shared::ethrpc::Web3,
+};
+
+#[tokio::test]
+#[ignore]
+async fn local_node_uses_stale_liquidity() {
+    run_test(uses_stale_liquidity).await;
+}
+
+async fn uses_stale_liquidity(web3: Web3) {
+    tracing::info!("Setting up chain state.");
+    let mut onchain = OnchainComponents::deploy(web3.clone()).await;
+
+    let [solver] = onchain.make_solvers(to_wei(10)).await;
+    let [trader] = onchain.make_accounts(to_wei(2)).await;
+    let [token] = onchain
+        .deploy_tokens_with_weth_uni_v2_pools(to_wei(1_000), to_wei(1_000))
+        .await;
+
+    tx!(
+        trader.account(),
+        onchain
+            .contracts()
+            .weth
+            .approve(onchain.contracts().allowance, to_wei(1))
+    );
+    tx_value!(
+        trader.account(),
+        to_wei(1),
+        onchain.contracts().weth.deposit()
+    );
+
+    tracing::info!("Starting services.");
+    let solver_endpoint = colocation::start_solver(onchain.contracts().weth.address()).await;
+    colocation::start_driver(onchain.contracts(), &solver_endpoint, &solver);
+
+    let services = Services::new(onchain.contracts()).await;
+    services.start_autopilot(vec![
+        "--enable-colocation=true".to_string(),
+        "--drivers=http://localhost:11088/test_solver".to_string(),
+    ]);
+    services
+        .start_api(vec![
+            "--price-estimation-drivers=solver|http://localhost:11088/test_solver".to_string(),
+        ])
+        .await;
+
+    let quote = OrderQuoteRequest {
+        from: trader.address(),
+        sell_token: onchain.contracts().weth.address(),
+        buy_token: token.address(),
+        side: OrderQuoteSide::Sell {
+            sell_amount: SellAmount::AfterFee {
+                value: NonZeroU256::new(to_wei(1)).unwrap(),
+            },
+        },
+        ..Default::default()
+    };
+
+    tracing::info!("performining initial quote");
+    let first = services.submit_quote(&quote).await.unwrap();
+
+    // Now, we want to manually unbalance the pools and assert that the quote
+    // doesn't change (as the price estimation will use stale pricing data).
+    onchain
+        .mint_token_to_weth_uni_v2_pool(&token, to_wei(1_000))
+        .await;
+
+    tracing::info!("performining second quote, which should match first");
+    let second = services.submit_quote(&quote).await.unwrap();
+    assert_eq!(first.quote.buy_amount, second.quote.buy_amount);
+
+    tracing::info!("waiting for liquidity state to update");
+    wait_for_condition(TIMEOUT, || async {
+        let next = services.submit_quote(&quote).await.unwrap();
+        next.quote.buy_amount != first.quote.buy_amount
+    })
+    .await
+    .unwrap();
+}

--- a/crates/e2e/tests/e2e/main.rs
+++ b/crates/e2e/tests/e2e/main.rs
@@ -8,6 +8,7 @@ mod app_data;
 mod colocation_ethflow;
 mod colocation_hooks;
 mod colocation_partial_fill;
+mod colocation_quoting;
 mod colocation_univ2;
 mod database;
 mod eth_integration;


### PR DESCRIPTION
# Description

This PR was my take on recent liquidity fetching for the driver. Unfortunately, I did not see #1924 when I started working on it, but I believe some of my proposed changes are worthwhile including, so I rebased it onto the aforementioned PR.

In particular, this PR (just like the one its based on) uses recent instead of latest liquidity for quoting. This improves latency of quotes.

# Changes

- [x] Introduce a `liquidity::When` enum to specify when to fetch liquidity for (latest vs recent) instead of using a `bool` flag.
- [x] Add an E2E test to verify this. Note that this kind of E2E test is imperfect (since it involves timings, which is never great), but it is capturing the expected behavior of quotes (and because the cache update loop is long enough, it doesn't fail the many times I ran it).

## How to test

E2E test that verifies liquidity cache is not being updated for the `/quote` request.