### PR TITLE
Solver Engines Should Internalize Using Buffers

### DIFF
--- a/crates/solvers/src/domain/solution.rs
+++ b/crates/solvers/src/domain/solution.rs
@@ -4,7 +4,7 @@ use {
         util,
     },
     ethereum_types::{Address, U256},
-    std::collections::HashMap,
+    std::{collections::HashMap, slice},
 };
 
 /// A solution to an auction.
@@ -17,8 +17,79 @@ pub struct Solution {
 }
 
 impl Solution {
+    /// Returns `self` with a new score.
     pub fn with_score(self, score: Score) -> Self {
         Self { score, ..self }
+    }
+
+    /// Returns `self` with eligible interactions internalized using the
+    /// Settlement contract buffers.
+    ///
+    /// Currently, this internalizes all interactions with input/outputs where
+    /// all input tokens are trusted and the settlement contract has sufficient
+    /// balance to cover the output tokens.
+    pub fn with_buffers_internalizations(mut self, tokens: &auction::Tokens) -> Self {
+        let mut used_buffers = HashMap::new();
+        for interaction in self.interactions.iter_mut() {
+            let (inputs, outputs, internalize) = match interaction {
+                Interaction::Liquidity(interaction) => (
+                    slice::from_mut(&mut interaction.input),
+                    slice::from_mut(&mut interaction.output),
+                    &mut interaction.internalize,
+                ),
+                Interaction::Custom(interaction) => (
+                    &mut interaction.inputs[..],
+                    &mut interaction.outputs[..],
+                    &mut interaction.internalize,
+                ),
+            };
+
+            let trusted_inputs = inputs.iter().all(|input| {
+                matches!(
+                    tokens.get(&input.token),
+                    Some(auction::Token { trusted: true, .. })
+                )
+            });
+            if inputs.is_empty() || outputs.is_empty() || !trusted_inputs {
+                continue;
+            }
+
+            let Some(required_buffers) =
+                outputs.iter().try_fold(HashMap::new(), |mut map, output| {
+                    let entry = map.entry(output.token).or_default();
+                    *entry = output.amount.checked_add(*entry)?;
+                    Some(map)
+                })
+            else {
+                continue;
+            };
+            let sufficient_buffers = required_buffers.iter().all(|(address, amount)| {
+                tokens
+                    .get(address)
+                    .and_then(|token| {
+                        let used = used_buffers.get(address).copied().unwrap_or_default();
+                        let total = amount.checked_add(used)?;
+
+                        Some(token.available_balance >= total)
+                    })
+                    .unwrap_or_default()
+            });
+            if !sufficient_buffers {
+                continue;
+            }
+
+            // Make sure to update the used buffers, this ensures that, if we
+            // have two interactions that use the same token buffers, we don't
+            // end up over-internalizing.
+            for (token, amount) in required_buffers {
+                let used = used_buffers.entry(token).or_default();
+                *used = used.checked_add(amount).expect("overflow verified above");
+            }
+
+            *internalize = true;
+        }
+
+        self
     }
 }
 

--- a/crates/solvers/src/domain/solver/baseline.rs
+++ b/crates/solvers/src/domain/solver/baseline.rs
@@ -113,14 +113,17 @@ impl Inner {
                             output.amount = cmp::min(output.amount, order.buy.amount);
                         }
 
-                        solution::Single {
-                            order: order.clone(),
-                            input: route.input(),
-                            output,
-                            interactions,
-                            gas: route.gas(),
-                        }
-                        .into_solution(auction.gas_price, sell_token)
+                        Some(
+                            solution::Single {
+                                order: order.clone(),
+                                input: route.input(),
+                                output,
+                                interactions,
+                                gas: route.gas(),
+                            }
+                            .into_solution(auction.gas_price, sell_token)?
+                            .with_buffers_internalizations(&auction.tokens),
+                        )
                     })
             })
             .collect()

--- a/crates/solvers/src/domain/solver/dex/mod.rs
+++ b/crates/solvers/src/domain/solver/dex/mod.rs
@@ -117,6 +117,6 @@ impl Dex {
         // Maybe some liquidity appeared that enables a bigger fill.
         self.fills.increase_next_try(uid);
 
-        Some(solution)
+        Some(solution.with_buffers_internalizations(tokens))
     }
 }

--- a/crates/solvers/src/domain/solver/naive.rs
+++ b/crates/solvers/src/domain/solver/naive.rs
@@ -27,6 +27,7 @@ impl Naive {
             groups
                 .values()
                 .filter_map(|group| boundary::naive::solve(&group.orders, group.liquidity))
+                .map(|solution| solution.with_buffers_internalizations(&auction.tokens))
                 .collect()
         })
         .await

--- a/crates/solvers/src/tests/balancer/market_order.rs
+++ b/crates/solvers/src/tests/balancer/market_order.rs
@@ -62,7 +62,7 @@ async fn sell() {
                     "symbol": "WETH",
                     "referencePrice": "1000000000000000000",
                     "availableBalance": "482725140468789680",
-                    "trusted": true
+                    "trusted": false
                 },
             },
             "orders": [
@@ -264,7 +264,7 @@ async fn buy() {
                 "interactions": [
                     {
                         "kind": "custom",
-                        "internalize": false,
+                        "internalize": true,
                         "target": "0xba12222222228d8ba445958a75a0704d566bf2c8",
                         "value": "0",
                         "callData": "0x945bcec9\

--- a/crates/solvers/src/tests/baseline/buy_order_rounding.rs
+++ b/crates/solvers/src/tests/baseline/buy_order_rounding.rs
@@ -92,7 +92,7 @@ async fn uniswap() {
                 "interactions": [
                     {
                         "kind": "liquidity",
-                        "internalize": false,
+                        "internalize": true,
                         "id": "0",
                         "inputToken": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
                         "outputToken": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",

--- a/crates/solvers/src/tests/baseline/internalization.rs
+++ b/crates/solvers/src/tests/baseline/internalization.rs
@@ -1,4 +1,4 @@
-//! Simple test case that verifies that the baseline solver internalization
+//! Simple test case that verifies that the baseline solver internalizes
 //! eligible interactions using Settlement contract buffers.
 
 use {crate::tests, serde_json::json};

--- a/crates/solvers/src/tests/baseline/internalization.rs
+++ b/crates/solvers/src/tests/baseline/internalization.rs
@@ -1,0 +1,307 @@
+//! Simple test case that verifies that the baseline solver internalization
+//! eligible interactions using Settlement contract buffers.
+
+use {crate::tests, serde_json::json};
+
+#[tokio::test]
+async fn trusted_token() {
+    let engine = tests::SolverEngine::new(
+        "baseline",
+        tests::Config::File("config/example.baseline.toml".into()),
+    )
+    .await;
+
+    let solution = engine
+        .solve(json!({
+            "id": "1",
+            "tokens": {
+                "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2": {
+                    "decimals": 18,
+                    "symbol": "WETH",
+                    "referencePrice": "1000000000000000000",
+                    "availableBalance": "1412206645170290748",
+                    "trusted": true
+                },
+                "0xDEf1CA1fb7FBcDC777520aa7f396b4E015F497aB": {
+                    "decimals": 18,
+                    "symbol": "COW",
+                    "referencePrice": "53125132573502",
+                    "availableBalance": "78402641384835564507389",
+                    "trusted": true
+                }
+            },
+            "orders": [
+                {
+                    "uid": "0x2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a\
+                              2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a\
+                              2a2a2a2a",
+                    "sellToken": "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
+                    "buyToken": "0xDEf1CA1fb7FBcDC777520aa7f396b4E015F497aB",
+                    "sellAmount": "133700000000000000",
+                    "buyAmount": "6000000000000000000000",
+                    "feeAmount": "4200000000000000",
+                    "kind": "sell",
+                    "partiallyFillable": false,
+                    "class": "market",
+                }
+            ],
+            "liquidity": [
+                {
+                    "kind": "constantproduct",
+                    "tokens": {
+                        "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2": {
+                            "balance": "3828187314911751990"
+                        },
+                        "0xDEf1CA1fb7FBcDC777520aa7f396b4E015F497aB": {
+                            "balance": "179617892578796375604692"
+                        }
+                    },
+                    "fee": "0.003",
+                    "id": "0",
+                    "address": "0x97b744df0b59d93A866304f97431D8EfAd29a08d",
+                    "gasEstimate": "110000"
+                }
+            ],
+            "effectiveGasPrice": "15000000000",
+            "deadline": "2106-01-01T00:00:00.000Z"
+        }))
+        .await;
+
+    assert_eq!(
+        solution,
+        json!({
+            "solutions": [{
+                "id": 0,
+                "prices": {
+                    "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2": "6043910341261930467761",
+                    "0xdef1ca1fb7fbcdc777520aa7f396b4e015f497ab": "133700000000000000"
+                },
+                "trades": [
+                    {
+                        "kind": "fulfillment",
+                        "order": "0x2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a\
+                                    2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a\
+                                    2a2a2a2a",
+                        "executedAmount": "133700000000000000"
+                    }
+                ],
+                "interactions": [
+                    {
+                        "kind": "liquidity",
+                        "internalize": true,
+                        "id": "0",
+                        "inputToken": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+                        "outputToken": "0xdef1ca1fb7fbcdc777520aa7f396b4e015f497ab",
+                        "inputAmount": "133700000000000000",
+                        "outputAmount": "6043910341261930467761"
+                    }
+                ],
+                "score": {
+                    "riskadjusted": 1.0
+                }
+            }]
+        }),
+    );
+}
+
+#[tokio::test]
+async fn untrusted_sell_token() {
+    let engine = tests::SolverEngine::new(
+        "baseline",
+        tests::Config::File("config/example.baseline.toml".into()),
+    )
+    .await;
+
+    let solution = engine
+        .solve(json!({
+            "id": "1",
+            "tokens": {
+                "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2": {
+                    "decimals": 18,
+                    "symbol": "WETH",
+                    "referencePrice": "1000000000000000000",
+                    "availableBalance": "1412206645170290748",
+                    "trusted": false
+                },
+                "0xDEf1CA1fb7FBcDC777520aa7f396b4E015F497aB": {
+                    "decimals": 18,
+                    "symbol": "COW",
+                    "referencePrice": "53125132573502",
+                    "availableBalance": "78402641384835564507389",
+                    "trusted": true
+                }
+            },
+            "orders": [
+                {
+                    "uid": "0x2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a\
+                              2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a\
+                              2a2a2a2a",
+                    "sellToken": "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
+                    "buyToken": "0xDEf1CA1fb7FBcDC777520aa7f396b4E015F497aB",
+                    "sellAmount": "133700000000000000",
+                    "buyAmount": "6000000000000000000000",
+                    "feeAmount": "4200000000000000",
+                    "kind": "sell",
+                    "partiallyFillable": false,
+                    "class": "market",
+                }
+            ],
+            "liquidity": [
+                {
+                    "kind": "constantproduct",
+                    "tokens": {
+                        "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2": {
+                            "balance": "3828187314911751990"
+                        },
+                        "0xDEf1CA1fb7FBcDC777520aa7f396b4E015F497aB": {
+                            "balance": "179617892578796375604692"
+                        }
+                    },
+                    "fee": "0.003",
+                    "id": "0",
+                    "address": "0x97b744df0b59d93A866304f97431D8EfAd29a08d",
+                    "gasEstimate": "110000"
+                }
+            ],
+            "effectiveGasPrice": "15000000000",
+            "deadline": "2106-01-01T00:00:00.000Z"
+        }))
+        .await;
+
+    assert_eq!(
+        solution,
+        json!({
+            "solutions": [{
+                "id": 0,
+                "prices": {
+                    "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2": "6043910341261930467761",
+                    "0xdef1ca1fb7fbcdc777520aa7f396b4e015f497ab": "133700000000000000"
+                },
+                "trades": [
+                    {
+                        "kind": "fulfillment",
+                        "order": "0x2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a\
+                                    2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a\
+                                    2a2a2a2a",
+                        "executedAmount": "133700000000000000"
+                    }
+                ],
+                "interactions": [
+                    {
+                        "kind": "liquidity",
+                        "internalize": false,
+                        "id": "0",
+                        "inputToken": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+                        "outputToken": "0xdef1ca1fb7fbcdc777520aa7f396b4e015f497ab",
+                        "inputAmount": "133700000000000000",
+                        "outputAmount": "6043910341261930467761"
+                    }
+                ],
+                "score": {
+                    "riskadjusted": 1.0
+                }
+            }]
+        }),
+    );
+}
+
+#[tokio::test]
+async fn insufficient_balance() {
+    let engine = tests::SolverEngine::new(
+        "baseline",
+        tests::Config::File("config/example.baseline.toml".into()),
+    )
+    .await;
+
+    let solution = engine
+        .solve(json!({
+            "id": "1",
+            "tokens": {
+                "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2": {
+                    "decimals": 18,
+                    "symbol": "WETH",
+                    "referencePrice": "1000000000000000000",
+                    "availableBalance": "1412206645170290748",
+                    "trusted": true
+                },
+                "0xDEf1CA1fb7FBcDC777520aa7f396b4E015F497aB": {
+                    "decimals": 18,
+                    "symbol": "COW",
+                    "referencePrice": "53125132573502",
+                    "availableBalance": "0",
+                    "trusted": true
+                }
+            },
+            "orders": [
+                {
+                    "uid": "0x2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a\
+                              2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a\
+                              2a2a2a2a",
+                    "sellToken": "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
+                    "buyToken": "0xDEf1CA1fb7FBcDC777520aa7f396b4E015F497aB",
+                    "sellAmount": "133700000000000000",
+                    "buyAmount": "6000000000000000000000",
+                    "feeAmount": "4200000000000000",
+                    "kind": "sell",
+                    "partiallyFillable": false,
+                    "class": "market",
+                }
+            ],
+            "liquidity": [
+                {
+                    "kind": "constantproduct",
+                    "tokens": {
+                        "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2": {
+                            "balance": "3828187314911751990"
+                        },
+                        "0xDEf1CA1fb7FBcDC777520aa7f396b4E015F497aB": {
+                            "balance": "179617892578796375604692"
+                        }
+                    },
+                    "fee": "0.003",
+                    "id": "0",
+                    "address": "0x97b744df0b59d93A866304f97431D8EfAd29a08d",
+                    "gasEstimate": "110000"
+                }
+            ],
+            "effectiveGasPrice": "15000000000",
+            "deadline": "2106-01-01T00:00:00.000Z"
+        }))
+        .await;
+
+    assert_eq!(
+        solution,
+        json!({
+            "solutions": [{
+                "id": 0,
+                "prices": {
+                    "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2": "6043910341261930467761",
+                    "0xdef1ca1fb7fbcdc777520aa7f396b4e015f497ab": "133700000000000000"
+                },
+                "trades": [
+                    {
+                        "kind": "fulfillment",
+                        "order": "0x2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a\
+                                    2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a\
+                                    2a2a2a2a",
+                        "executedAmount": "133700000000000000"
+                    }
+                ],
+                "interactions": [
+                    {
+                        "kind": "liquidity",
+                        "internalize": false,
+                        "id": "0",
+                        "inputToken": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+                        "outputToken": "0xdef1ca1fb7fbcdc777520aa7f396b4e015f497ab",
+                        "inputAmount": "133700000000000000",
+                        "outputAmount": "6043910341261930467761"
+                    }
+                ],
+                "score": {
+                    "riskadjusted": 1.0
+                }
+            }]
+        }),
+    );
+}

--- a/crates/solvers/src/tests/baseline/mod.rs
+++ b/crates/solvers/src/tests/baseline/mod.rs
@@ -4,3 +4,4 @@ mod bal_liquidity;
 mod buy_order_rounding;
 mod direct_swap;
 mod partial_fill;
+mod internalization;

--- a/crates/solvers/src/tests/baseline/mod.rs
+++ b/crates/solvers/src/tests/baseline/mod.rs
@@ -3,5 +3,5 @@
 mod bal_liquidity;
 mod buy_order_rounding;
 mod direct_swap;
-mod partial_fill;
 mod internalization;
+mod partial_fill;

--- a/crates/solvers/src/tests/paraswap/market_order.rs
+++ b/crates/solvers/src/tests/paraswap/market_order.rs
@@ -466,7 +466,7 @@ async fn buy() {
                       "token": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"
                     }
                   ],
-                  "internalize": false,
+                  "internalize": true,
                   "kind": "custom",
                   "outputs": [
                     {

--- a/crates/solvers/src/tests/zeroex/market_order.rs
+++ b/crates/solvers/src/tests/zeroex/market_order.rs
@@ -332,7 +332,7 @@ async fn buy() {
                 "interactions": [
                     {
                         "kind": "custom",
-                        "internalize": false,
+                        "internalize": true,
                         "target": "0xdef1c0ded9bec7f1a1670819833240f027b25eff",
                         "value": "0",
                         "callData": "0xd9627aa4\


### PR DESCRIPTION
# Description

Built-in solver engines (baseline, DEX aggregator, etc.) under the legacy `solver` would internalize interactions for eligible tokens when the settlement contract had sufficient buffers.

This PR adds this functionality to the co-located solver engines.

# Changes

- [x] Added `domain` logic for internalizing interactions for a full settlement.
- [x] Internalize interactions with internal buffers for solutions from the `baseline`, `naive` and DEX aggregator solvers (but **not** for the `legacy` solver adapter).
- [x] Added solver tests to verify this logic.

## How to test

CI, added new tests, adjusted old tests which now internalize interactions (as expected).