### PR TITLE
fix: openapi for duplicated orders

### DIFF
--- a/crates/orderbook/openapi.yml
+++ b/crates/orderbook/openapi.yml
@@ -1060,7 +1060,7 @@ components:
           type: string
           enum:
             [
-              DuplicateOrder,
+              DuplicatedOrder,
               QuoteNotFound,
               InvalidQuote,
               MissingFrom,
@@ -1125,7 +1125,7 @@ components:
               OrderFullyExecuted,
               OrderExpired,
               OnChainOrder,
-              DuplicateOrder,
+              DuplicatedOrder,
               InsufficientFee,
               InsufficientAllowance,
               InsufficientBalance,


### PR DESCRIPTION
# Description
Fixes the OpenAPI yaml description for down-stream consumers.

# Changes

- [x] Corrected `DuplicatedOrder` response

## How to test

1. Attempt to place the same order twice.
2. Observe correct API response per `openapi.yml`.

## Related Issues

Fixes #1928 