### PR TITLE
Observability To Colocated Auction Runloop

### DIFF
--- a/crates/autopilot/src/run_loop.rs
+++ b/crates/autopilot/src/run_loop.rs
@@ -322,7 +322,11 @@ impl RunLoop {
                 }
                 Err(err) => {
                     Metrics::get().solve_err(driver, start, &err);
-                    tracing::warn!(?err, driver = %driver.url, "solve error");
+                    if matches!(err, SolveError::NoSolutions) {
+                        tracing::debug!(driver = %driver.url, "solver found no solution");
+                    } else {
+                        tracing::warn!(?err, driver = %driver.url, "solve error");
+                    }
                     return solutions;
                 }
             } {

--- a/crates/autopilot/src/run_loop.rs
+++ b/crates/autopilot/src/run_loop.rs
@@ -614,7 +614,7 @@ enum SolveError {
 }
 
 #[derive(Debug, thiserror::Error)]
-#[error("the proposed a 0-score solution")]
+#[error("the solver proposed a 0-score solution")]
 struct ZeroScoreError;
 
 #[derive(Debug, thiserror::Error)]

--- a/crates/autopilot/src/shadow.rs
+++ b/crates/autopilot/src/shadow.rs
@@ -269,8 +269,8 @@ impl Error {
     fn label(&self) -> &str {
         match self {
             Error::Timeout => "timeout",
-            Error::NoSolutions => "no solutions",
-            Error::ZeroScore => "empty",
+            Error::NoSolutions => "no_solutions",
+            Error::ZeroScore => "zero_score",
             Error::Mismatch => "mismatch",
             Error::Solve(_) => "error",
             Error::Reveal(_) => "error",
@@ -284,7 +284,7 @@ struct Metrics {
     /// Tracks the last seen auction.
     auction: prometheus::IntGauge,
 
-    /// Tracks the result of every refunding loops.
+    /// Tracks the result of every driver.
     #[metric(labels("driver", "result"))]
     results: prometheus::IntCounterVec,
 


### PR DESCRIPTION
# Description

This PR refactors the autopilot runloop to add some additional observability to the solver competition. This will allow us to have a better idea of how individual solvers are behaving.

As a note on the code and how to record metrics - I created methods on the `Metrics` type in order to increment/observe things. I'm not 100% happy with this, but wanted to see what others think in terms of legibility. 

# Changes

- [x] Added gauge for last auction ID seen in the runloop.
- [x] Specific error types for all driver interactions
- [x] Added metrics counters for results of driver interactions (solving, revealing and settling), and specifically a histogram for `solve` timings.

## How to test

The code should be covered by existing E2E tests in the services.