### PR TITLE
Adjustments to Token Info Fetcher

### DIFF
--- a/crates/autopilot/src/run.rs
+++ b/crates/autopilot/src/run.rs
@@ -299,7 +299,7 @@ pub async fn run(args: Arguments) {
         .expect("failed to create pool cache"),
     );
     let block_retriever = args.shared.current_block.retriever(web3.clone());
-    let token_info_fetcher = Arc::new(CachedTokenInfoFetcher::new(Box::new(TokenInfoFetcher {
+    let token_info_fetcher = Arc::new(CachedTokenInfoFetcher::new(Arc::new(TokenInfoFetcher {
         web3: web3.clone(),
     })));
     let balancer_pool_fetcher = if baseline_sources.contains(&BaselineSource::BalancerV2) {

--- a/crates/driver/src/boundary/liquidity/balancer/v2/mod.rs
+++ b/crates/driver/src/boundary/liquidity/balancer/v2/mod.rs
@@ -172,7 +172,7 @@ async fn init_liquidity(
         .flatten()
         .collect(),
     };
-    let token_info_fetcher = Arc::new(CachedTokenInfoFetcher::new(Box::new(TokenInfoFetcher {
+    let token_info_fetcher = Arc::new(CachedTokenInfoFetcher::new(Arc::new(TokenInfoFetcher {
         web3: web3.clone(),
     })));
 

--- a/crates/orderbook/src/run.rs
+++ b/crates/orderbook/src/run.rs
@@ -280,7 +280,7 @@ pub async fn run(args: Arguments) {
         .expect("failed to create pool cache"),
     );
     let block_retriever = args.shared.current_block.retriever(web3.clone());
-    let token_info_fetcher = Arc::new(CachedTokenInfoFetcher::new(Box::new(TokenInfoFetcher {
+    let token_info_fetcher = Arc::new(CachedTokenInfoFetcher::new(Arc::new(TokenInfoFetcher {
         web3: web3.clone(),
     })));
     let balancer_pool_fetcher = if baseline_sources.contains(&BaselineSource::BalancerV2) {

--- a/crates/shared/src/sources/balancer_v2/pool_fetching.rs
+++ b/crates/shared/src/sources/balancer_v2/pool_fetching.rs
@@ -531,7 +531,7 @@ mod tests {
                 .await
                 .unwrap();
         let token_info_fetcher =
-            Arc::new(CachedTokenInfoFetcher::new(Box::new(TokenInfoFetcher {
+            Arc::new(CachedTokenInfoFetcher::new(Arc::new(TokenInfoFetcher {
                 web3: web3.clone(),
             })));
         let block_stream = ethrpc::current_block::current_block_stream(

--- a/crates/shared/src/token_info.rs
+++ b/crates/shared/src/token_info.rs
@@ -1,13 +1,20 @@
 use {
-    crate::ethrpc::Web3,
+    crate::{ethcontract_error::EthcontractErrorType, ethrpc::Web3},
+    anyhow::Result,
     async_trait::async_trait,
     contracts::ERC20,
-    ethcontract::{batch::CallBatch, H160},
-    std::{collections::HashMap, sync::Arc},
-    tokio::sync::Mutex,
+    ethcontract::{errors::MethodError, H160},
+    futures::{
+        future::{BoxFuture, Shared},
+        FutureExt,
+    },
+    model::order::BUY_ETH_ADDRESS,
+    std::{
+        collections::HashMap,
+        sync::{Arc, Mutex},
+    },
+    thiserror::Error,
 };
-
-const MAX_BATCH_SIZE: usize = 100;
 
 #[cfg_attr(test, derive(Eq, PartialEq))]
 #[derive(Clone, Debug, Default)]
@@ -16,65 +23,100 @@ pub struct TokenInfo {
     pub symbol: Option<String>,
 }
 
-pub struct TokenInfoFetcher {
-    pub web3: Web3,
-}
+#[derive(Clone, Debug, Error)]
+#[error("error fetching token info: {0}")]
+pub struct Error(String);
 
 #[mockall::automock]
 #[async_trait]
 pub trait TokenInfoFetching: Send + Sync {
+    /// Retrieves information for a token.
+    async fn get_token_info(&self, address: H160) -> Result<TokenInfo, Error>;
+
     /// Retrieves all token information.
     /// Default implementation calls get_token_info for each token and ignores
     /// errors.
     async fn get_token_infos(&self, addresses: &[H160]) -> HashMap<H160, TokenInfo>;
 }
 
-#[async_trait]
-impl TokenInfoFetching for TokenInfoFetcher {
-    async fn get_token_infos(&self, addresses: &[H160]) -> HashMap<H160, TokenInfo> {
-        let mut batch = CallBatch::new(self.web3.transport());
-        let futures = addresses
-            .iter()
-            .map(|address| {
-                let erc20 = ERC20::at(&self.web3, *address);
-                (
-                    erc20.methods().decimals().batch_call(&mut batch),
-                    erc20.methods().symbol().batch_call(&mut batch),
-                )
-            })
-            .collect::<Vec<_>>();
+pub struct TokenInfoFetcher {
+    pub web3: Web3,
+}
 
-        batch.execute_all(MAX_BATCH_SIZE).await;
-        let mut resolved_futures = Vec::with_capacity(futures.len());
-        for (decimals, symbol) in futures {
-            resolved_futures.push((decimals.await, symbol.await));
+impl TokenInfoFetcher {
+    async fn fetch_token(&self, address: H160) -> Result<TokenInfo, Error> {
+        if address == BUY_ETH_ADDRESS {
+            let chain = self
+                .web3
+                .eth()
+                .chain_id()
+                .await
+                .map_err(|err| Error(err.to_string()))?;
+            return Ok(TokenInfo {
+                decimals: Some(18),
+                symbol: match chain.as_u64() {
+                    1 | 5 => Some("ETH".to_string()),
+                    100 => Some("xDAI".to_string()),
+                    _ => None,
+                },
+            });
         }
-        addresses
-            .iter()
-            .zip(resolved_futures)
-            .map(|(address, (decimals, symbol))| {
-                if decimals.is_err() {
-                    tracing::trace!("Failed to fetch token info for token {}", address);
-                }
-                (
-                    *address,
-                    TokenInfo {
-                        decimals: decimals.ok(),
-                        symbol: symbol.ok(),
-                    },
-                )
-            })
-            .collect()
+
+        let erc20 = ERC20::at(&self.web3, address);
+        let (decimals, symbol) = futures::join!(
+            erc20.methods().decimals().call(),
+            erc20.methods().symbol().call(),
+        );
+
+        Ok(TokenInfo {
+            decimals: classify_error(decimals)?,
+            symbol: classify_error(symbol)?,
+        })
     }
 }
 
+fn classify_error<T>(result: Result<T, MethodError>) -> Result<Option<T>, Error> {
+    match result {
+        Ok(value) => Ok(Some(value)),
+        Err(err) => match EthcontractErrorType::classify(&err) {
+            EthcontractErrorType::Node => Err(Error(err.to_string())),
+            EthcontractErrorType::Contract => Ok(None),
+        },
+    }
+}
+
+#[async_trait]
+impl TokenInfoFetching for TokenInfoFetcher {
+    async fn get_token_info(&self, address: H160) -> Result<TokenInfo, Error> {
+        let info = self.fetch_token(address).await;
+        if let Err(err) = &info {
+            tracing::debug!(?err, token = ?address, "failed to fetch token info");
+        }
+        info
+    }
+
+    async fn get_token_infos(&self, addresses: &[H160]) -> HashMap<H160, TokenInfo> {
+        futures::future::join_all(addresses.iter().copied().map(|address| async move {
+            (
+                address,
+                self.get_token_info(address).await.unwrap_or_default(),
+            )
+        }))
+        .await
+        .into_iter()
+        .collect()
+    }
+}
+
+type SharedTokenInfo = Shared<BoxFuture<'static, Result<TokenInfo, Error>>>;
+
 pub struct CachedTokenInfoFetcher {
-    inner: Box<dyn TokenInfoFetching>,
-    cache: Arc<Mutex<HashMap<H160, TokenInfo>>>,
+    inner: Arc<dyn TokenInfoFetching>,
+    cache: Arc<Mutex<HashMap<H160, SharedTokenInfo>>>,
 }
 
 impl CachedTokenInfoFetcher {
-    pub fn new(inner: Box<dyn TokenInfoFetching>) -> Self {
+    pub fn new(inner: Arc<dyn TokenInfoFetching>) -> Self {
         Self {
             inner,
             cache: Arc::new(Mutex::new(HashMap::new())),
@@ -82,92 +124,113 @@ impl CachedTokenInfoFetcher {
     }
 }
 
-#[async_trait]
-impl TokenInfoFetching for CachedTokenInfoFetcher {
-    async fn get_token_infos(&self, addresses: &[H160]) -> HashMap<H160, TokenInfo> {
-        let mut cache = self.cache.lock().await;
-
-        // Compute set of requested addresses that are not in cache.
-        let to_fetch: Vec<H160> = addresses
-            .iter()
-            .filter(|address| !cache.contains_key(address))
-            .cloned()
-            .collect();
-
-        // Fetch token infos not yet in cache.
-        if !to_fetch.is_empty() {
-            let fetched = self.inner.get_token_infos(to_fetch.as_slice()).await;
-
-            // Add valid token infos to cache.
-            cache.extend(
-                fetched
-                    .into_iter()
-                    .filter(|(_, token_info)| token_info.decimals.is_some()),
-            );
+impl CachedTokenInfoFetcher {
+    async fn fetch_token(&self, address: H160) -> Result<TokenInfo, Error> {
+        let fetch = {
+            let mut cache = self.cache.lock().unwrap();
+            cache
+                .entry(address)
+                .or_insert({
+                    let inner = self.inner.clone();
+                    async move { inner.get_token_info(address).await }
+                        .boxed()
+                        .shared()
+                })
+                .clone()
         };
 
-        // Return token infos from the cache.
-        addresses
-            .iter()
-            .map(|address| {
-                if cache.contains_key(address) {
-                    (*address, cache[address].clone())
-                } else {
-                    (
-                        *address,
-                        TokenInfo {
-                            decimals: None,
-                            symbol: None,
-                        },
-                    )
-                }
-            })
-            .collect()
+        let info = fetch.await;
+        if info.is_err() {
+            let mut cache = self.cache.lock().unwrap();
+            if let Some(Err(_)) = cache.get(&address).and_then(|fetch| fetch.peek()) {
+                cache.remove(&address);
+            }
+        }
+
+        info
+    }
+}
+
+#[async_trait]
+impl TokenInfoFetching for CachedTokenInfoFetcher {
+    async fn get_token_info(&self, address: H160) -> Result<TokenInfo, Error> {
+        self.fetch_token(address).await
+    }
+
+    async fn get_token_infos(&self, addresses: &[H160]) -> HashMap<H160, TokenInfo> {
+        futures::future::join_all(addresses.iter().copied().map(|address| async move {
+            (
+                address,
+                self.get_token_info(address).await.unwrap_or_default(),
+            )
+        }))
+        .await
+        .into_iter()
+        .collect()
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use {super::*, maplit::hashmap};
+    use {super::*, maplit::hashmap, mockall::predicate::*};
 
     #[tokio::test]
     async fn cached_token_info_fetcher() {
-        let address0 = H160::zero();
-        let address1 = H160::from_low_u64_be(1);
+        let address = H160::from_low_u64_be;
 
         let mut mock_token_info_fetcher = MockTokenInfoFetching::new();
         mock_token_info_fetcher
-            .expect_get_token_infos()
+            .expect_get_token_info()
+            .with(eq(address(0)))
             .times(1)
             .return_once(move |_| {
-                hashmap! {
-                    address0 => TokenInfo { decimals: Some(18), symbol: Some("CAT".to_string()) },
-                }
+                Ok(TokenInfo {
+                    decimals: Some(18),
+                    symbol: Some("CAT".to_string()),
+                })
             });
         mock_token_info_fetcher
-            .expect_get_token_infos()
-            .times(2)
-            .returning(|_| {
-                hashmap! {
-                    H160::from_low_u64_be(1) => TokenInfo { decimals: None, symbol: None },
-                }
+            .expect_get_token_info()
+            .with(eq(address(1)))
+            .times(1)
+            .return_once(move |_| {
+                Ok(TokenInfo {
+                    decimals: None,
+                    symbol: None,
+                })
             });
+        mock_token_info_fetcher
+            .expect_get_token_info()
+            .with(eq(address(2)))
+            .times(2)
+            .returning(|_| Err(Error("some error".to_string())));
+
         let cached_token_info_fetcher =
-            CachedTokenInfoFetcher::new(Box::new(mock_token_info_fetcher));
+            CachedTokenInfoFetcher::new(Arc::new(mock_token_info_fetcher));
 
-        // Fetching a cached item should work.
-        let token_infos = cached_token_info_fetcher.get_token_infos(&[address0]).await;
-        assert!(token_infos.contains_key(&address0) && token_infos[&address0].decimals == Some(18));
+        // Fetches tokens, using `TokenInfo::default()` for the failed token.
+        let addresses = [address(0), address(1), address(2)];
+        let token_infos = cached_token_info_fetcher.get_token_infos(&addresses).await;
+        assert_eq!(
+            token_infos,
+            hashmap! {
+                address(0) => TokenInfo {
+                    decimals: Some(18),
+                    symbol: Some("CAT".to_string()),
+                },
+                address(1) => TokenInfo {
+                    decimals: None,
+                    symbol: None,
+                },
+                address(2) => TokenInfo::default(),
+            }
+        );
 
-        // Should panic because of the times(1) constraint above, unless the cache is
-        // working as expected.
-        cached_token_info_fetcher.get_token_infos(&[address0]).await;
-
-        // Fetching an item that is unavailable should work.
-        let token_infos = cached_token_info_fetcher.get_token_infos(&[address1]).await;
-        assert!(token_infos.contains_key(&address1) && token_infos[&address1].decimals.is_none());
-
-        // Should try to refetch the item thus satisfying the times(2) constraint above.
-        cached_token_info_fetcher.get_token_infos(&[address1]).await;
+        // Fetch again, if the the two token 0 and 1 are fetched again (i.e. the
+        // cache is not working) then this will panic because of the `times(1)`
+        // constraint on our mock fetcher. Note that token 2 gets fetched again
+        // because it failed to fetch the first time.
+        let cached_token_infos = cached_token_info_fetcher.get_token_infos(&addresses).await;
+        assert_eq!(token_infos, cached_token_infos);
     }
 }

--- a/crates/shared/src/token_info.rs
+++ b/crates/shared/src/token_info.rs
@@ -46,19 +46,9 @@ pub struct TokenInfoFetcher {
 impl TokenInfoFetcher {
     async fn fetch_token(&self, address: H160) -> Result<TokenInfo, Error> {
         if address == BUY_ETH_ADDRESS {
-            let chain = self
-                .web3
-                .eth()
-                .chain_id()
-                .await
-                .map_err(|err| Error(err.to_string()))?;
             return Ok(TokenInfo {
                 decimals: Some(18),
-                symbol: match chain.as_u64() {
-                    1 | 5 => Some("ETH".to_string()),
-                    100 => Some("xDAI".to_string()),
-                    _ => None,
-                },
+                symbol: Some("NATIVE_ASSET".to_string()),
             });
         }
 

--- a/crates/solver/src/run.rs
+++ b/crates/solver/src/run.rs
@@ -144,7 +144,7 @@ pub async fn run(args: Arguments) {
     ));
 
     let block_retriever = args.shared.current_block.retriever(web3.clone());
-    let token_info_fetcher = Arc::new(CachedTokenInfoFetcher::new(Box::new(TokenInfoFetcher {
+    let token_info_fetcher = Arc::new(CachedTokenInfoFetcher::new(Arc::new(TokenInfoFetcher {
         web3: web3.clone(),
     })));
     let gas_price_estimator = Arc::new(


### PR DESCRIPTION
# Description

In debugging with @fleupold on Friday, we noticed that the token info fetcher was potentially locking up concurrent quotes for certain price estimators, notably the ParaSwap and Quasimodo estimator that make use of token information (decimals specifically). This is caused by two things:

1. The token info cache will hold an `async` Mutex for the entire fetching of token information.
2. We are querying token info for `0xeee...eee` in the autopilot which will always fail and not get included in the cache, meaning it will always hold the lock for a node roundtrip.

The combination of these two issue causes quotes that need token information to execute not fully concurrently. In particular, if quote 1 would need token info for A and quote 2 for B, then quote 2 will need to wait for token info of A to finish fetching before starting to fetch token info of B (even though they can run in parallel).

# Changes

- [x] Implement exception for `0xeee...eee` address.
- [x] Only don't cache results on node failures and not on contract failures (i.e. if a contract doesn't have `decimals`, then we will cache this fact instead of querying every time).
- [x] Allow concurrent access to the cache, using `futures::Shared`. I didn't opt for using `RequestSharing` as it didn't quite fit and the semantics are slightly different.

## How to test

Added new test to verify the logic

## Related Issues

- Fixed https://github.com/cowprotocol/services/issues/1923