### PR TITLE
Simplify While Loop in Autopilot RunLoop

### DIFF
--- a/crates/autopilot/src/run_loop.rs
+++ b/crates/autopilot/src/run_loop.rs
@@ -471,16 +471,7 @@ impl RunLoop {
         // We do keep track of hashes we have already seen to reduce load from the node.
 
         let mut seen_transactions: HashSet<H256> = Default::default();
-        while {
-            let block = self.current_block.borrow();
-            let still_time = block.number <= deadline;
-
-            // Take extra care to not accidentally keep the borrow alive within
-            // the `while` body, which would block senders.
-            drop(block);
-
-            still_time
-        } {
+        while self.current_block.borrow().number <= deadline {
             let mut hashes = self
                 .database
                 .recent_settlement_tx_hashes(start..deadline + 1)


### PR DESCRIPTION
# Description

Follow up to https://github.com/cowprotocol/services/pull/1930#discussion_r1349967216.

This PR removes the extra `while` loop logic, as it was unneeded and confusing.

The issue that the comment that existed alluded to was that when you do something like:

```rust
while let ... = thing() {
    // body
}
```

```rust
match thing() {
    _ => {
        // body
    }
}
```

`thing()` is not dropped until the end of the `while` or `match` (even if there is no binding to it in the matched pattern). This results in `Drop::drop` only getting called at the end of the `while`/`match` which may be unexpected and lead to deadlocks.

This is **not** the case here for a couple of reasons:
- We are using a while expression (`while some_bool_express()`) and not while with pattern matching (`while let ... = some_expression()`)
- The `borrow()` is only used as a temporary value as part of the boolean expression and gets dropped immediately.

We can write some [Rust code](https://play.rust-lang.org/?version=stable&mode=debug&edition=2021&gist=ff32cf291c63459b065f9d99488baf90) to prove this:

```rust
mod foo {
    pub struct Foo {
        pub value: u64,
    }

    impl Foo {
        pub fn borrow(&self) -> Bar<'_> {
            Bar(self)
        }
    }

    pub struct Bar<'a>(&'a Foo);

    impl std::ops::Deref for Bar<'_> {
        type Target = Foo;
        fn deref(&self) -> &Self::Target {
            self.0
        }
    }

    impl Drop for Bar<'_> {
        fn drop(&mut self) {
            println!("Bar::drop");
        }
    }
}

fn main() {
    let mut foo = foo::Foo { value: 0 };
    println!("main enter");
    while foo.borrow().value != 42 {
        println!("main inner");
        foo.value = 42;
    }
    println!("main exit");
}
```

Which outputs:

```
main enter
Bar::drop
main inner
Bar::drop
main exit
```

Meaning that `Bar` does indeed get dropped after every `while` expression computation.

# Changes

- [x] Remove unnecessary manual `drop` call in `while` loop expression.

## How to test

See Rust playground link to verify these are the expected Rust semantics.