### PR TITLE
Use explicit relative path for migrations folder in docker-compose

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -30,7 +30,7 @@ services:
       FLYWAY_URL: jdbc:postgresql://db/?user=$USER&password=
     volumes:
       - type: bind
-        source: database/sql/
+        source: ./database/sql/
         target: /flyway/sql
 
   chain:


### PR DESCRIPTION
# Description

If I run `docker-compose up` in my system, I get an error:

<details><summary>Cannot create container for service migrations: invalid mount config for type "bind": invalid mount path: 'database/sql' mount path must be absolute</summary>

```
$ docker-compose up
Creating network "services_default" with the default driver
Creating services_chain_1 ... 
Creating services_adminer_1 ... 
Creating services_chain_1      ... done
Creating services_adminer_1    ... done

Creating services_db_1         ... done

ERROR: for migrations  Cannot create container for service migrations: invalid mount config for type "bind": invalid mount path: 'database/sql' mount path must be absolute
ERROR: Encountered errors while bringing up the project.
```
</details>

# Changes

The path is now explicitly relative. This makes `docker-compose` work on my system and according to my understanding of [these docs](https://github.com/compose-spec/compose-spec/blob/38143970dd693f321e9af012894a7da4e4244292/spec.md#short-syntax-5) it's recommended way to write down relative paths.

## How to test

Please run `docker-compose` up in your system to make sure this PR isn't breaking any local setup.
CI.