### PR TITLE
fix: openapi typo

### DIFF
--- a/crates/orderbook/openapi.yml
+++ b/crates/orderbook/openapi.yml
@@ -1081,7 +1081,7 @@ components:
               InsufficientValidTo,
               ExcessiveValidTo,
               TransferEthToContract,
-              InvalidNativeSellToken
+              InvalidNativeSellToken,
               SameBuyAndSellToken,
               UnsupportedSignature,
               UnsupportedToken,


### PR DESCRIPTION
# Description
This PR fixes a typo in an `openapi.yml` enum. This is required for generation by downstream consumers. 

# Changes

- [x] Fixed typo

## How to test

1. Verify tests continue to pass.