### PR TITLE
Reduce Error-ness of not Finding Solutions

### DIFF
--- a/crates/driver/src/infra/api/routes/solve/dto/solved.rs
+++ b/crates/driver/src/infra/api/routes/solve/dto/solved.rs
@@ -9,16 +9,17 @@ use {
 };
 
 impl Solved {
-    pub fn new(solved: competition::Solved, solver: &Solver) -> Self {
-        let solution = Solution::new(0, solved, solver);
-        Self {
-            solutions: vec![solution],
-        }
+    pub fn new(solved: Option<competition::Solved>, solver: &Solver) -> Self {
+        let solutions = solved
+            .into_iter()
+            .map(|solved| Solution::new(0, solved, solver))
+            .collect();
+        Self { solutions }
     }
 }
 
 #[serde_as]
-#[derive(Debug, Serialize)]
+#[derive(Debug, Default, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Solved {
     solutions: Vec<Solution>,

--- a/crates/driver/src/infra/observe/mod.rs
+++ b/crates/driver/src/infra/observe/mod.rs
@@ -192,7 +192,7 @@ pub fn solved(solver: &solver::Name, result: &Result<Option<Solved>, competition
                 .inc();
         }
         Ok(None) => {
-            tracing::info!("no solution found");
+            tracing::debug!("no solution found");
             metrics::get()
                 .solutions
                 .with_label_values(&[solver.as_str(), "SolutionNotFound"])

--- a/crates/driver/src/infra/observe/mod.rs
+++ b/crates/driver/src/infra/observe/mod.rs
@@ -182,13 +182,20 @@ pub fn settled(solver: &solver::Name, result: &Result<competition::Settled, comp
 }
 
 /// Observe the result of solving an auction.
-pub fn solved(solver: &solver::Name, result: &Result<Solved, competition::Error>) {
+pub fn solved(solver: &solver::Name, result: &Result<Option<Solved>, competition::Error>) {
     match result {
-        Ok(solved) => {
+        Ok(Some(solved)) => {
             tracing::info!(?solved, "solved auction");
             metrics::get()
                 .solutions
                 .with_label_values(&[solver.as_str(), "Success"])
+                .inc();
+        }
+        Ok(None) => {
+            tracing::info!("no solution found");
+            metrics::get()
+                .solutions
+                .with_label_values(&[solver.as_str(), "SolutionNotFound"])
                 .inc();
         }
         Err(err) => {
@@ -306,7 +313,6 @@ pub fn quoting(order: &quote::Order) {
 fn competition_error(err: &competition::Error) -> &'static str {
     match err {
         competition::Error::SolutionNotAvailable => "SolutionNotAvailable",
-        competition::Error::SolutionNotFound => "SolutionNotFound",
         competition::Error::DeadlineExceeded(_) => "DeadlineExceeded",
         competition::Error::Solver(solver::Error::Http(_)) => "SolverHttpError",
         competition::Error::Solver(solver::Error::Deserialize(_)) => "SolverDeserializeError",

--- a/crates/driver/src/tests/cases/asset_flow.rs
+++ b/crates/driver/src/tests/cases/asset_flow.rs
@@ -38,7 +38,7 @@ async fn matrix() {
                     .await;
 
                 // TODO When we add metrics, assert that an invalid asset flow error is traced.
-                test.solve().await.err().kind("SolutionNotFound");
+                test.solve().await.ok().empty();
             }
         }
     }
@@ -110,7 +110,7 @@ async fn negative_sum() {
         .await;
 
     // TODO When we add metrics, assert that an invalid asset flow error is traced.
-    test.solve().await.err().kind("SolutionNotFound");
+    test.solve().await.ok().empty();
 }
 
 /// Test that asset flow verification passes when sums of flows are positive.

--- a/crates/driver/src/tests/cases/internalization.rs
+++ b/crates/driver/src/tests/cases/internalization.rs
@@ -42,7 +42,7 @@ async fn untrusted_internalization() {
 
     // TODO When we add metrics, assert that an untrusted internalization error is
     // traced.
-    solve.err().kind("SolutionNotFound");
+    solve.ok().empty();
 }
 
 /// Check that verification fails if the solution contains internalized

--- a/crates/driver/src/tests/cases/negative_scores.rs
+++ b/crates/driver/src/tests/cases/negative_scores.rs
@@ -18,7 +18,7 @@ async fn no_valid_solutions() {
 
     let solve = test.solve().await;
 
-    solve.err().kind("SolutionNotFound");
+    solve.ok().empty();
 }
 
 #[tokio::test]

--- a/crates/driver/src/tests/cases/settle.rs
+++ b/crates/driver/src/tests/cases/settle.rs
@@ -32,3 +32,18 @@ async fn matrix() {
         }
     }
 }
+
+/// Checks that settling without a solution returns an error.
+#[tokio::test]
+#[ignore]
+async fn solution_not_available() {
+    let test = tests::setup()
+        .name("solution not available")
+        .pool(ab_pool())
+        .order(ab_order())
+        .solution(ab_solution())
+        .done()
+        .await;
+
+    test.settle().await.err().kind("SolutionNotAvailable");
+}

--- a/crates/driver/src/tests/cases/solver_balance.rs
+++ b/crates/driver/src/tests/cases/solver_balance.rs
@@ -18,5 +18,5 @@ async fn test() {
 
     let solve = test.solve().await;
 
-    solve.err().kind("SolutionNotFound");
+    solve.ok().empty();
 }


### PR DESCRIPTION
# Description

We recently added the ability for a driver to return multiple solutions. With this, we should no longer return an error when no solutions are found but an empty vector.

This was prompted by the general noisiness in metrics and logs for "regular" behaviour for the solvers.

# Changes

- [x] Return empty solutions list when none is found instead of an error.

## How to test

Driver tests assert an "OK" response with empty solutions instead of errors.