### PR TITLE
[Trivial] Set Paraswap partner in price query

### DIFF
--- a/crates/solvers/src/infra/dex/paraswap/dto.rs
+++ b/crates/solvers/src/infra/dex/paraswap/dto.rs
@@ -46,6 +46,9 @@ pub struct PriceQuery {
 
     /// The network ID.
     pub network: String,
+
+    /// The partner name
+    pub partner: String,
 }
 
 impl PriceQuery {
@@ -70,6 +73,7 @@ impl PriceQuery {
             amount: order.amount.get(),
             exclude_dexs: config.exclude_dexs.clone(),
             network: "1".to_owned(),
+            partner: config.partner.clone(),
         })
     }
 }

--- a/crates/solvers/src/tests/paraswap/market_order.rs
+++ b/crates/solvers/src/tests/paraswap/market_order.rs
@@ -11,7 +11,7 @@ async fn sell() {
     let api = mock::http::setup(vec![
         mock::http::Expectation::Get {
             path: mock::http::Path::exact(
-                "prices?srcToken=0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2&destToken=0xe41d2489571d322189246dafa5ebde1f4699f498&srcDecimals=18&destDecimals=18&amount=1000000000000000000&side=SELL&excludeDexs=UniswapV2&network=1",
+                "prices?srcToken=0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2&destToken=0xe41d2489571d322189246dafa5ebde1f4699f498&srcDecimals=18&destDecimals=18&amount=1000000000000000000&side=SELL&excludeDexs=UniswapV2&network=1&partner=cow",
             ),
             res: json!({
               "priceRoute": {
@@ -249,7 +249,7 @@ async fn buy() {
     let api = mock::http::setup(vec![
         mock::http::Expectation::Get {
             path: mock::http::Path::exact(
-                "prices?srcToken=0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2&destToken=0xe41d2489571d322189246dafa5ebde1f4699f498&srcDecimals=18&destDecimals=18&amount=1000000000000000000000&side=BUY&excludeDexs=UniswapV2&network=1",
+                "prices?srcToken=0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2&destToken=0xe41d2489571d322189246dafa5ebde1f4699f498&srcDecimals=18&destDecimals=18&amount=1000000000000000000000&side=BUY&excludeDexs=UniswapV2&network=1&partner=cow",
             ),
             res: json!({
               "priceRoute": {

--- a/crates/solvers/src/tests/paraswap/out_of_price.rs
+++ b/crates/solvers/src/tests/paraswap/out_of_price.rs
@@ -207,7 +207,7 @@ async fn buy() {
     let api = mock::http::setup(vec![
         mock::http::Expectation::Get {
             path: mock::http::Path::exact(
-                "prices?srcToken=0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2&destToken=0xe41d2489571d322189246dafa5ebde1f4699f498&srcDecimals=18&destDecimals=18&amount=1000000000000000000000&side=BUY&excludeDexs=UniswapV2&network=1",
+                "prices?srcToken=0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2&destToken=0xe41d2489571d322189246dafa5ebde1f4699f498&srcDecimals=18&destDecimals=18&amount=1000000000000000000000&side=BUY&excludeDexs=UniswapV2&network=1&partner=cow",
             ),
             res: json!({
               "priceRoute": {

--- a/crates/solvers/src/tests/paraswap/out_of_price.rs
+++ b/crates/solvers/src/tests/paraswap/out_of_price.rs
@@ -14,7 +14,7 @@ async fn sell() {
     let api = mock::http::setup(vec![
         mock::http::Expectation::Get {
             path: mock::http::Path::exact(
-                "prices?srcToken=0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2&destToken=0xe41d2489571d322189246dafa5ebde1f4699f498&srcDecimals=18&destDecimals=18&amount=1000000000000000000&side=SELL&excludeDexs=UniswapV2&network=1",
+                "prices?srcToken=0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2&destToken=0xe41d2489571d322189246dafa5ebde1f4699f498&srcDecimals=18&destDecimals=18&amount=1000000000000000000&side=SELL&excludeDexs=UniswapV2&network=1&partner=cow",
             ),
             res: json!({
               "priceRoute": {


### PR DESCRIPTION
# Description
We are seeing a lot of rate limits in the Paraswap solver likely because we are not setting the partner in the price query. This PR fixes this. We were already setting it in the transaction query.