### PR TITLE
Auction ID to `solvers` Tracing Span

### DIFF
--- a/crates/solvers/src/api/dto/auction.rs
+++ b/crates/solvers/src/api/dto/auction.rs
@@ -16,7 +16,10 @@ impl Auction {
     /// Converts a data transfer object into its domain object representation.
     pub fn to_domain(&self) -> Result<auction::Auction, Error> {
         Ok(auction::Auction {
-            id: self.id.map(auction::Id),
+            id: match self.id {
+                Some(id) => auction::Id::Solve(id),
+                None => auction::Id::Quote,
+            },
             tokens: auction::Tokens(
                 self.tokens
                     .iter()

--- a/crates/solvers/src/api/mod.rs
+++ b/crates/solvers/src/api/mod.rs
@@ -62,7 +62,7 @@ async fn solve(
         let auction_id = auction.id;
         let solutions = state
             .solve(auction)
-            .instrument(tracing::info_span!("auction", %auction_id))
+            .instrument(tracing::info_span!("auction", id = %auction_id))
             .await;
 
         tracing::trace!(?solutions);

--- a/crates/solvers/src/api/mod.rs
+++ b/crates/solvers/src/api/mod.rs
@@ -59,7 +59,11 @@ async fn solve(
 
         tracing::trace!(?auction);
 
-        let solutions = state.solve(auction).await;
+        let auction_id = auction.id;
+        let solutions = state
+            .solve(auction)
+            .instrument(tracing::info_span!("auction", %auction_id))
+            .await;
 
         tracing::trace!(?solutions);
 

--- a/crates/solvers/src/boundary/legacy.rs
+++ b/crates/solvers/src/boundary/legacy.rs
@@ -134,7 +134,10 @@ fn to_boundary_auction(
             .collect(),
         metadata: Some(MetadataModel {
             environment: None,
-            auction_id: auction.id.as_ref().map(|id| id.0),
+            auction_id: match auction.id {
+                auction::Id::Solve(id) => Some(id),
+                auction::Id::Quote => None,
+            },
             run_id: None,
             gas_price: Some(gas.gas_price),
             native_token: Some(weth.0),

--- a/crates/solvers/src/domain/auction.rs
+++ b/crates/solvers/src/domain/auction.rs
@@ -1,14 +1,17 @@
 use {
     crate::domain::{eth, liquidity, order},
     ethereum_types::U256,
-    std::{collections::HashMap, time::Duration},
+    std::{
+        collections::HashMap,
+        fmt::{self, Display, Formatter},
+        time::Duration,
+    },
 };
 
 /// The auction that the solvers need to find solutions to.
 #[derive(Debug)]
 pub struct Auction {
-    /// [`None`] if the auction applies to a quote.
-    pub id: Option<Id>,
+    pub id: Id,
     pub tokens: Tokens,
     pub orders: Vec<order::Order>,
     pub liquidity: Vec<liquidity::Liquidity>,
@@ -35,8 +38,24 @@ impl Tokens {
 }
 
 /// The ID of an auction.
-#[derive(Clone, Debug)]
-pub struct Id(pub i64);
+#[derive(Clone, Copy, Debug)]
+pub enum Id {
+    /// An auction as part of an official solver competition, that could
+    /// translate to an on-chain settlement transaction.
+    Solve(i64),
+    /// An auction that is used for computing a price quote and will not get
+    /// executed on chain.
+    Quote,
+}
+
+impl Display for Id {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        match self {
+            Id::Solve(id) => write!(f, "{id}"),
+            Id::Quote => f.write_str("quote"),
+        }
+    }
+}
 
 #[derive(Debug)]
 pub struct Token {

--- a/crates/solvers/src/domain/solver/baseline.rs
+++ b/crates/solvers/src/domain/solver/baseline.rs
@@ -65,9 +65,13 @@ impl Baseline {
         // the real async things. For larger settlements, this can block in the
         // 100s of ms.
         let inner = self.0.clone();
-        tokio::task::spawn_blocking(move || inner.solve(auction))
-            .await
-            .expect("baseline solver unexpected panic")
+        let span = tracing::Span::current();
+        tokio::task::spawn_blocking(move || {
+            let _entered = span.enter();
+            inner.solve(auction)
+        })
+        .await
+        .expect("baseline solver unexpected panic")
     }
 }
 

--- a/crates/solvers/src/domain/solver/naive.rs
+++ b/crates/solvers/src/domain/solver/naive.rs
@@ -22,7 +22,9 @@ impl Naive {
         // Make sure to push the CPU-heavy code to a separate thread in order to
         // not lock up the [`tokio`] runtime and cause it to slow down handling
         // the real async things.
+        let span = tracing::Span::current();
         tokio::task::spawn_blocking(move || {
+            let _entered = span.enter();
             let groups = group_by_token_pair(&auction);
             groups
                 .values()


### PR DESCRIPTION
# Description

It turns out that we forgot to add `auction=$id` tracing spans to the `solvers` API handler. This PR does that to make debugging easier.

Note that we need to manually get the current span and move it into the new thread (and can't use `tracing::Instrumented::in_current_span`) because the blocking task gets executed on a separate thread outside of the `tokio` thread-pool which doesn't properly propagate spans.

# Changes

- [x] Modified the `auction::Id` abstraction to no longer use `Option` but have a more explicit enum type to better document the semantics of auction IDs (either it is a quote, or an auction with a specific numeric ID), instead of implying that `None` was used for quoting. This also helps in the logs filter out by spans when things are run as part of a quote and as part of an actual solver competition.
- [x] Added tracing span to the `solvers` API endpoint

## How to test

Run locally to see the span:

```
2023-10-11T15:14:17.261Z TRACE request{id="9"}:/solve:auction{id=quote}: solvers::domain::solver::baseline: finding route order=0x0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000 request=Request { sell: Asset { amount: 1000000000000000000, token: TokenAddress(0xe91d153e0b41518a2ce8dd3d7944fa863463a97d) }, buy: Asset { amount: 1, token: TokenAddress(0xddafbb505ad214d7b80b1f830fccc89b60fb7a83) }, side: Sell }
```