### PR TITLE
Fix score deserialization

### DIFF
--- a/crates/autopilot/src/driver_model.rs
+++ b/crates/autopilot/src/driver_model.rs
@@ -144,6 +144,7 @@ pub mod solve {
         /// it in subsequent requests (reveal, settle).
         #[serde_as(as = "serde_with::DisplayFromStr")]
         pub solution_id: u64,
+        #[serde_as(as = "HexOrDecimalU256")]
         pub score: U256,
         /// Address used by the driver to submit the settlement onchain.
         pub submission_address: H160,


### PR DESCRIPTION
# Description
Fixes https://github.com/cowprotocol/services/issues/1951

The issue was that the decimal was interpreted as hex, so decimal `16442840735913131` becomes `25671225992463593777 `