### PR TITLE
Unify HTTP handling in the solvers crate

### DIFF
--- a/crates/solvers/src/infra/dex/paraswap/mod.rs
+++ b/crates/solvers/src/infra/dex/paraswap/mod.rs
@@ -54,17 +54,17 @@ impl ParaSwap {
             },
             input: eth::Asset {
                 token: order.sell,
-                amount: price.src_amount()?,
+                amount: price.src_amount,
             },
             output: eth::Asset {
                 token: order.buy,
-                amount: price.dest_amount()?,
+                amount: price.dest_amount,
             },
             allowance: dex::Allowance {
-                spender: eth::ContractAddress(price.token_transfer_proxy()?),
-                amount: dex::Amount::new(price.src_amount()?),
+                spender: eth::ContractAddress(price.token_transfer_proxy),
+                amount: dex::Amount::new(price.src_amount),
             },
-            gas: eth::Gas(price.gas_cost()?),
+            gas: eth::Gas(price.gas_cost),
         })
     }
 
@@ -74,17 +74,13 @@ impl ParaSwap {
         order: &dex::Order,
         tokens: &auction::Tokens,
     ) -> Result<dto::Price, Error> {
-        let request = self
-            .client
-            .get(util::url::join(&self.config.endpoint, "prices"))
-            .query(&dto::PriceQuery::new(&self.config, order, tokens)?)
-            .build()?;
-        tracing::trace!("Querying ParaSwap price API: {request:?}");
-        let response = self.client.execute(request).await?;
-        let status = response.status();
-        let text = response.text().await?;
-        tracing::trace!(%status, %text, "Response from ParaSwap price API");
-        let price = serde_json::from_str::<dto::Response<dto::Price>>(&text)?.into_result()?;
+        let price = util::http::roundtrip!(
+            <dto::Price, dto::Error>;
+            self.client
+                .get(util::url::join(&self.config.endpoint, "prices"))
+                .query(&dto::PriceQuery::new(&self.config, order, tokens)?)
+        )
+        .await?;
         Ok(price)
     }
 
@@ -97,22 +93,16 @@ impl ParaSwap {
         slippage: &dex::Slippage,
     ) -> Result<dto::Transaction, Error> {
         let body = dto::TransactionBody::new(price, &self.config, order, tokens, slippage)?;
-        let request = self
-            .client
-            .post(util::url::join(
-                &self.config.endpoint,
-                "transactions/1?ignoreChecks=true",
-            ))
-            .json(&body)
-            .build()?;
-        let body = serde_json::to_string(&body)?;
-        tracing::trace!(?request, %body, "Querying ParaSwap transaction API");
-        let response = self.client.execute(request).await?;
-        let status = response.status();
-        let text = response.text().await?;
-        tracing::trace!(%status, %text, "Response from ParaSwap transaction API");
-        let transaction =
-            serde_json::from_str::<dto::Response<dto::Transaction>>(&text)?.into_result()?;
+        let transaction = util::http::roundtrip!(
+            <dto::Transaction, dto::Error>;
+            self.client
+                .post(util::url::join(
+                    &self.config.endpoint,
+                    "transactions/1?ignoreChecks=true",
+                ))
+                .json(&body)
+        )
+        .await?;
         Ok(transaction)
     }
 }
@@ -126,18 +116,19 @@ pub enum Error {
     #[error("api error {0}")]
     Api(String),
     #[error(transparent)]
-    Json(#[from] serde_json::Error),
-    #[error(transparent)]
-    Http(#[from] reqwest::Error),
+    Http(util::http::Error),
 }
 
-impl From<dto::Error> for Error {
-    fn from(value: dto::Error) -> Self {
-        match value.error.as_str() {
-            "ESTIMATED_LOSS_GREATER_THAN_MAX_IMPACT"
-            | "No routes found with enough liquidity"
-            | "Too much slippage on quote, please try again" => Self::NotFound,
-            _ => Self::Api(value.error),
+impl From<util::http::RoundtripError<dto::Error>> for Error {
+    fn from(err: util::http::RoundtripError<dto::Error>) -> Self {
+        match err {
+            util::http::RoundtripError::Http(err) => Self::Http(err),
+            util::http::RoundtripError::Api(err) => match err.error.as_str() {
+                "ESTIMATED_LOSS_GREATER_THAN_MAX_IMPACT"
+                | "No routes found with enough liquidity"
+                | "Too much slippage on quote, please try again" => Self::NotFound,
+                _ => Self::Api(err.error),
+            },
         }
     }
 }

--- a/crates/solvers/src/tests/mod.rs
+++ b/crates/solvers/src/tests/mod.rs
@@ -43,7 +43,7 @@ impl SolverEngine {
         let mut args = vec![
             "/test/solvers/path".to_owned(),
             "--addr=0.0.0.0:0".to_owned(),
-            "--log=off".to_owned(),
+            "--log=solvers=trace".to_owned(),
             command.to_owned(),
         ];
         let tempfile = match config {

--- a/crates/solvers/src/util/http.rs
+++ b/crates/solvers/src/util/http.rs
@@ -1,0 +1,111 @@
+//! Module containing utilities for round-tripping HTTP requests.
+//!
+//! Note that this helper is implemented as a macro. This is needed in order to
+//! ensure that we preserve the module path in the log event from the original
+//! callsite instead of all HTTP requests appearing as they are made from this
+//! module.
+
+use {
+    crate::util,
+    reqwest::{Method, RequestBuilder, StatusCode, Url},
+    serde::de::DeserializeOwned,
+    std::str,
+};
+
+macro_rules! roundtrip {
+    (<$t:ty, $e:ty>; $request:expr) => {
+        $crate::util::http::roundtrip_internal::<$t, $e>(
+            $request,
+            |method, url, body, message| {
+                if let Some(body) = body {
+                    tracing::trace!(%method, %url, %body, "{message}");
+                } else {
+                    tracing::trace!(%method, %url, "{message}");
+                }
+            },
+            |status, body, message| {
+                tracing::trace!(%status, %body, "{message}");
+            },
+        )
+    };
+    ($request:expr) => {
+        $crate::util::http::roundtrip!(<_, _>; $request)
+    };
+}
+pub(crate) use roundtrip;
+
+#[doc(hidden)]
+pub async fn roundtrip_internal<T, E>(
+    request: RequestBuilder,
+    log_request: impl FnOnce(&Method, &Url, Option<&str>, &str),
+    log_response: impl FnOnce(StatusCode, &str, &str),
+) -> Result<T, RoundtripError<E>>
+where
+    T: DeserializeOwned,
+    E: DeserializeOwned,
+{
+    let (client, request) = request.build_split();
+    let request = request.map_err(Error::from)?;
+
+    let body = request
+        .body()
+        .and_then(|body| str::from_utf8(body.as_bytes()?).ok());
+
+    log_request(
+        request.method(),
+        request.url(),
+        body,
+        "sending HTTP request",
+    );
+    let response = client.execute(request).await.map_err(Error::from)?;
+
+    let status = response.status();
+    let body = response.text().await.map_err(Error::from)?;
+    log_response(status, &body, "received HTTP response");
+
+    match serde_json::from_str::<T>(&body) {
+        Ok(data) => Ok(data),
+        // We failed to parse the body into the expected data, try to get an
+        // as accurate error as possible:
+        // 1. If the API returned a well-formed error that we can parse, then use that
+        // 2. Otherwise, if it returned a 2xx status code, then this means that we are unable to
+        //    parse a successful response, so return a JSON error
+        // 3. Otherwise, return an HTTP status error with the raw body string.
+        Err(err) => Err(serde_json::from_str(&body)
+            .map(RoundtripError::Api)
+            .unwrap_or_else(|_| {
+                RoundtripError::Http(if status.is_success() {
+                    Error::Json(err)
+                } else {
+                    Error::Status(status, body)
+                })
+            })),
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    #[error(transparent)]
+    Json(#[from] serde_json::Error),
+    #[error(transparent)]
+    Http(#[from] reqwest::Error),
+    #[error("HTTP {0}: {1}")]
+    Status(StatusCode, String),
+}
+
+impl From<RoundtripError<util::serialize::Never>> for Error {
+    fn from(value: RoundtripError<util::serialize::Never>) -> Self {
+        let RoundtripError::Http(err) = value else {
+            unreachable!();
+        };
+        err
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum RoundtripError<E> {
+    #[error(transparent)]
+    Http(#[from] Error),
+    #[error("API error")]
+    Api(E),
+}

--- a/crates/solvers/src/util/mod.rs
+++ b/crates/solvers/src/util/mod.rs
@@ -1,5 +1,6 @@
 pub mod conv;
 pub mod fmt;
+pub mod http;
 pub mod math;
 pub mod serialize;
 pub mod url;

--- a/crates/solvers/src/util/serialize/mod.rs
+++ b/crates/solvers/src/util/serialize/mod.rs
@@ -1,6 +1,7 @@
 mod chain_id;
 mod hex;
+mod never;
 mod str;
 mod u256;
 
-pub use self::{chain_id::ChainId, hex::Hex, str::CommaSeparated, u256::U256};
+pub use self::{chain_id::ChainId, hex::Hex, never::Never, str::CommaSeparated, u256::U256};

--- a/crates/solvers/src/util/serialize/never.rs
+++ b/crates/solvers/src/util/serialize/never.rs
@@ -1,0 +1,25 @@
+use serde::{de, ser, Deserialize, Deserializer, Serialize, Serializer};
+
+/// A type that never deserializes or serializes.
+///
+/// This can be used in situations where a generic type that implements `serde`
+/// traits is required, but you don't want it to actually represent any data.
+pub struct Never;
+
+impl<'de> Deserialize<'de> for Never {
+    fn deserialize<D>(_: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        Err(de::Error::custom("neva eva eva"))
+    }
+}
+
+impl Serialize for Never {
+    fn serialize<S>(&self, _: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        Err(ser::Error::custom("neva eva eva"))
+    }
+}


### PR DESCRIPTION
# Description

This PR unifies HTTP handling in the `solvers` crate in way that:
- All HTTP requests automatically trace relevant information (method, URL, body, status code, etc.) while preserving the callsite's module path in the log event (useful for filtering, so you can enable `trace` JUST for a specific DEX aggregator API for example).
- Improved error handling:
  1. We first try to parse with an API specific error type - this allows us to extract well-formed errors
  2. In the case that we got an HTTP success but failed to parse the response data, emit a JSON error
  3. In the case we got an HTTP error status code, emit an HTTP status error

# Changes
<!-- List of detailed changes (how the change is accomplished) -->

- [x] Added an `util::http::roundtrip` helper that can be used for HTTP requests.
- [x] Refactored existing HTTP requests to use this new utility.

## How to test

CI tests DEX aggregator with mocked services, so we can be confident that it continues to work with this refactor.

## Related Issues

Supersedes #1941 