### PR TITLE
Emit logs for not finding settlement tx in time

### DIFF
--- a/crates/autopilot/src/run_loop.rs
+++ b/crates/autopilot/src/run_loop.rs
@@ -433,6 +433,8 @@ impl RunLoop {
                 .collect_vec();
             self.database.store_order_events(&events).await;
             tracing::debug!("settled in tx {:?}", tx.hash);
+        } else {
+            tracing::warn!("could not find a mined transaction in time");
         }
 
         Ok(())


### PR DESCRIPTION
# Description
We are currently not finding a lot of settlement transactions after telling the driver to settle but don't have a simple log that ties those missing transactions to auction ids.

# Changes
added a log