### PR TITLE
Fix solver slippage parsing

### DIFF
--- a/crates/driver/src/infra/config/file/load.rs
+++ b/crates/driver/src/infra/config/file/load.rs
@@ -58,7 +58,7 @@ pub async fn load(network: &blockchain::Network, path: &Path) -> infra::Config {
                 name: config.name.into(),
                 slippage: solver::Slippage {
                     relative: config.relative_slippage,
-                    absolute: config.absolute_slippage.map(Into::into),
+                    absolute: config.absolute_slippage.map(eth::Ether),
                 },
                 liquidity: if config.skip_liquidity {
                     solver::Liquidity::Skip

--- a/crates/solvers/src/infra/config/dex/file.rs
+++ b/crates/solvers/src/infra/config/dex/file.rs
@@ -86,6 +86,5 @@ pub async fn load<T: DeserializeOwned>(path: &Path) -> (super::Config, T) {
             intercept: config.risk_parameters.3,
         },
     };
-    println!("{:?}", config.slippage);
     (config, dex)
 }

--- a/crates/solvers/src/infra/config/dex/file.rs
+++ b/crates/solvers/src/infra/config/dex/file.rs
@@ -4,6 +4,7 @@ use {
     crate::{
         domain::{dex::slippage, eth, Risk},
         infra::config::unwrap_or_log,
+        util::serialize,
     },
     bigdecimal::BigDecimal,
     serde::{de::DeserializeOwned, Deserialize},
@@ -22,7 +23,7 @@ struct Config {
     relative_slippage: BigDecimal,
 
     /// The absolute slippage allowed by the solver.
-    #[serde_as(as = "Option<serde_with::DisplayFromStr>")]
+    #[serde_as(as = "Option<serialize::U256>")]
     absolute_slippage: Option<eth::U256>,
 
     /// The number of concurrent requests to make to the DEX aggregator API.
@@ -32,6 +33,7 @@ struct Config {
     /// The amount of Ether a partially fillable order should be filled for at
     /// least.
     #[serde(default = "default_smallest_partial_fill")]
+    #[serde_as(as = "serialize::U256")]
     smallest_partial_fill: eth::U256,
 
     /// Parameters used to calculate the revert risk of a solution.
@@ -84,6 +86,6 @@ pub async fn load<T: DeserializeOwned>(path: &Path) -> (super::Config, T) {
             intercept: config.risk_parameters.3,
         },
     };
-
+    println!("{:?}", config.slippage);
     (config, dex)
 }


### PR DESCRIPTION
# Description
Slippage tolerance in the solver is parsed using standard U256::from_str which interprets the string in base 16. 40000000000000000 (0.04ETH) thus becomes 73ETH causing us to set very high slippage tolerance.

This PR hot-fixes the parsing to use our custom base 10 serializer.

I noticed that we re-implement U256 parsing both in the driver as well as in the solver (and we recently added an implementation in the number crate). Ideally we unify the use. It’s also a bit confusing that we define slippage in both the driver as well as the solver (it’s needed in the driver to encode the baseline liquidity interactions)

It would also be great if we can get the linter yell at us if we ever try to serialise a U256 with the default serialiser (I’m not sure how to achieve this though) as this has been the cause for many issues now.

## How to test
Load a local solver, print slippage and see it being properly parsed.

<!--
## Related Issues

Fixes #
-->