### PR TITLE
[TRIVIAL] Rename Flashbots in Colocated Driver

### DIFF
--- a/crates/driver/src/boundary/mempool.rs
+++ b/crates/driver/src/boundary/mempool.rs
@@ -41,8 +41,8 @@ pub struct Config {
 pub enum Kind {
     /// The public mempool of the [`Ethereum`] node.
     Public(HighRisk),
-    /// The Flashbots private mempool.
-    Flashbots {
+    /// The MEVBlocker private mempool.
+    MEVBlocker {
         url: reqwest::Url,
         max_additional_tip: f64,
         use_soft_cancellations: bool,
@@ -100,7 +100,7 @@ impl Mempool {
                 config,
                 eth,
             },
-            Kind::Flashbots { url, .. } => Self {
+            Kind::MEVBlocker { url, .. } => Self {
                 submit_api: Arc::new(FlashbotsApi::new(reqwest::Client::new(), url.to_owned())?),
                 submitted_transactions: pool.add_sub_pool(Strategy::Flashbots),
                 gas_price_estimator,
@@ -124,14 +124,14 @@ impl Mempool {
             additional_tip_percentage_of_max_fee: self.config.additional_tip_percentage,
             max_additional_tip: match self.config.kind {
                 Kind::Public(_) => 0.,
-                Kind::Flashbots {
+                Kind::MEVBlocker {
                     max_additional_tip, ..
                 } => max_additional_tip,
             },
         };
         let use_soft_cancellations = match self.config.kind {
             Kind::Public(_) => false,
-            Kind::Flashbots {
+            Kind::MEVBlocker {
                 use_soft_cancellations,
                 ..
             } => use_soft_cancellations,

--- a/crates/driver/src/boundary/mempool.rs
+++ b/crates/driver/src/boundary/mempool.rs
@@ -40,7 +40,7 @@ pub struct Config {
 #[derive(Debug, Clone)]
 pub enum Kind {
     /// The public mempool of the [`Ethereum`] node.
-    Public(HighRisk),
+    Public(RevertProtection),
     /// The MEVBlocker private mempool.
     MEVBlocker {
         url: reqwest::Url,
@@ -50,7 +50,7 @@ pub enum Kind {
 }
 
 #[derive(Debug, Clone, Copy)]
-pub enum HighRisk {
+pub enum RevertProtection {
     Enabled,
     Disabled,
 }
@@ -87,13 +87,13 @@ impl Mempool {
             .await?,
         );
         Ok(match &config.kind {
-            Kind::Public(high_risk) => Self {
+            Kind::Public(revert_protection) => Self {
                 submit_api: Arc::new(PublicMempoolApi::new(
                     vec![SubmissionNode::new(
                         SubmissionNodeKind::Broadcast,
                         boundary::web3(&eth),
                     )],
-                    matches!(high_risk, HighRisk::Disabled),
+                    matches!(revert_protection, RevertProtection::Enabled),
                 )),
                 submitted_transactions: pool.add_sub_pool(Strategy::PublicMempool),
                 gas_price_estimator,

--- a/crates/driver/src/domain/mempools.rs
+++ b/crates/driver/src/domain/mempools.rs
@@ -41,7 +41,7 @@ impl Mempools {
         if self.0.iter().any(|mempool| {
             matches!(
                 mempool.config().kind,
-                infra::mempool::Kind::Public(infra::mempool::HighRisk::Enabled)
+                infra::mempool::Kind::Public(infra::mempool::RevertProtection::Disabled)
             )
         }) {
             RevertProtection::Disabled

--- a/crates/driver/src/infra/blockchain/gas.rs
+++ b/crates/driver/src/infra/blockchain/gas.rs
@@ -25,11 +25,11 @@ impl GasPriceEstimator {
             .map_err(Error::Gas)?;
         let additional_tip = mempools
             .iter()
-            .find(|mempool| matches!(mempool.kind, mempool::Kind::Flashbots { .. }))
+            .find(|mempool| matches!(mempool.kind, mempool::Kind::MEVBlocker { .. }))
             .map(|mempool| {
                 (
                     match mempool.kind {
-                        mempool::Kind::Flashbots {
+                        mempool::Kind::MEVBlocker {
                             max_additional_tip, ..
                         } => max_additional_tip,
                         _ => unreachable!(),

--- a/crates/driver/src/infra/config/file/load.rs
+++ b/crates/driver/src/infra/config/file/load.rs
@@ -219,13 +219,13 @@ pub async fn load(network: &blockchain::Network, path: &Path) -> infra::Config {
                     config.submission.retry_interval_secs,
                 ),
                 kind: match mempool {
-                    file::Mempool::Public {
-                        disable_high_risk_public_mempool_transactions,
-                    } => mempool::Kind::Public(if *disable_high_risk_public_mempool_transactions {
-                        mempool::HighRisk::Disabled
-                    } else {
-                        mempool::HighRisk::Enabled
-                    }),
+                    file::Mempool::Public { revert_protection } => {
+                        mempool::Kind::Public(if *revert_protection {
+                            mempool::RevertProtection::Enabled
+                        } else {
+                            mempool::RevertProtection::Disabled
+                        })
+                    }
                     file::Mempool::MEVBlocker {
                         url,
                         max_additional_tip,

--- a/crates/driver/src/infra/config/file/load.rs
+++ b/crates/driver/src/infra/config/file/load.rs
@@ -226,11 +226,11 @@ pub async fn load(network: &blockchain::Network, path: &Path) -> infra::Config {
                     } else {
                         mempool::HighRisk::Enabled
                     }),
-                    file::Mempool::Flashbots {
+                    file::Mempool::MEVBlocker {
                         url,
                         max_additional_tip,
                         use_soft_cancellations,
-                    } => mempool::Kind::Flashbots {
+                    } => mempool::Kind::MEVBlocker {
                         url: url.to_owned(),
                         max_additional_tip: *max_additional_tip,
                         use_soft_cancellations: *use_soft_cancellations,

--- a/crates/driver/src/infra/config/file/mod.rs
+++ b/crates/driver/src/infra/config/file/mod.rs
@@ -97,7 +97,7 @@ enum Mempool {
         /// This can be enabled to avoid MEV when private transaction
         /// submission strategies are available.
         #[serde(default)]
-        disable_high_risk_public_mempool_transactions: bool,
+        revert_protection: bool,
     },
     MEVBlocker {
         /// The MEVBlocker URL to use.

--- a/crates/driver/src/infra/config/file/mod.rs
+++ b/crates/driver/src/infra/config/file/mod.rs
@@ -82,7 +82,7 @@ struct SubmissionConfig {
     max_confirm_time_secs: u64,
 
     /// The mempools to submit settlement transactions to. Can be the public
-    /// mempool of a node or the private Flashbots mempool.
+    /// mempool of a node or the private MEVBlocker mempool.
     #[serde(rename = "mempool", default)]
     mempools: Vec<Mempool>,
 }
@@ -99,12 +99,12 @@ enum Mempool {
         #[serde(default)]
         disable_high_risk_public_mempool_transactions: bool,
     },
-    Flashbots {
-        /// The Flashbots URL to use.
+    MEVBlocker {
+        /// The MEVBlocker URL to use.
         url: Url,
         /// Maximum additional tip in Gwei that we are willing to give to
-        /// Flashbots above regular gas price estimation.
-        #[serde(default = "default_max_additional_flashbots_tip")]
+        /// MEVBlocker above regular gas price estimation.
+        #[serde(default = "default_max_additional_tip")]
         max_additional_tip: f64,
         /// Configures whether the submission logic is allowed to assume the
         /// submission nodes implement soft cancellations. With soft
@@ -136,7 +136,7 @@ fn default_max_confirm_time_secs() -> u64 {
     120
 }
 
-fn default_max_additional_flashbots_tip() -> f64 {
+fn default_max_additional_tip() -> f64 {
     3.0
 }
 

--- a/crates/driver/src/infra/mempool/mod.rs
+++ b/crates/driver/src/infra/mempool/mod.rs
@@ -1,1 +1,1 @@
-pub use crate::boundary::mempool::{Config, GlobalTxPool, HighRisk, Kind, Mempool};
+pub use crate::boundary::mempool::{Config, GlobalTxPool, Kind, Mempool, RevertProtection};


### PR DESCRIPTION
# Description
Renames `Flashbots` submission to `MEVBlocker` in `driver` crate. Now the `Flashbots` is only mentioned in `boundary` part of the `driver` which is allowed.