### PR TITLE
Kebab case for submission args and updated example.toml

### DIFF
--- a/crates/driver/example.toml
+++ b/crates/driver/example.toml
@@ -11,8 +11,19 @@ account = "0x0000000000000000000000000000000000000000000000000000000000000001" #
 # relative-slippage = "0.1"
 # account = "0x0000000000000000000000000000000000000000000000000000000000000002"
 
+[submission]
+gas-price-cap = 1e12
+additional-tip-percentage = 0.05
+
 [[submission.mempool]]
 mempool = "public"
+revert-protection = true
+
+[[submission.mempool]]
+mempool = "mev-blocker"
+url = "https://your.custom.rpc.endpoint"
+max-additional-tip = 5.0
+use-soft-cancellations = true
 
 [contracts] # Optionally override the contract addresses, necessary on less popular blockchains
 gp-v2-settlement = "0x9008D19f58AAbD9eD0D60971565AA8510560ab41"

--- a/crates/driver/src/infra/config/file/load.rs
+++ b/crates/driver/src/infra/config/file/load.rs
@@ -226,7 +226,7 @@ pub async fn load(network: &blockchain::Network, path: &Path) -> infra::Config {
                             mempool::RevertProtection::Disabled
                         })
                     }
-                    file::Mempool::MEVBlocker {
+                    file::Mempool::MevBlocker {
                         url,
                         max_additional_tip,
                         use_soft_cancellations,

--- a/crates/driver/src/infra/config/file/mod.rs
+++ b/crates/driver/src/infra/config/file/mod.rs
@@ -89,8 +89,9 @@ struct SubmissionConfig {
 
 #[derive(Debug, Deserialize)]
 #[serde(tag = "mempool")]
-#[serde(rename_all = "kebab-case")]
+#[serde(rename_all = "kebab-case", deny_unknown_fields)]
 enum Mempool {
+    #[serde(rename_all = "kebab-case")]
     Public {
         /// Don't submit transactions with high revert risk (i.e. transactions
         /// that interact with on-chain AMMs) to the public mempool.
@@ -99,7 +100,8 @@ enum Mempool {
         #[serde(default)]
         revert_protection: bool,
     },
-    MEVBlocker {
+    #[serde(rename_all = "kebab-case")]
+    MevBlocker {
         /// The MEVBlocker URL to use.
         url: Url,
         /// Maximum additional tip in Gwei that we are willing to give to


### PR DESCRIPTION
# Description
We struggled a lot with correctly configuring the submission arguments because they were not parsed the same way other arguments were. This PR makes handling of those args the same as other args.

# Changes
- rename `MEVBlocker` -> `MevBlocker` such that the kebab-case version is now `mev-blocker` and not `m-e-v-blocker`
- use `deny_unknown_arguments` because that would have helped noticing that we are setting arguments that don't even get used
- apply `#[serde(rename_all = "kebab-case")]` to submission strategy enum fields to turn expected arguments from snake_case to kebab-case (like for everything else)
- updated `example.toml` to mention all arguments correctly

## How to test
Run the driver locally with the example file and see that it gets correctly parsed