### PR TITLE
Add instrument for submission kind

### DIFF
--- a/crates/driver/src/boundary/mempool.rs
+++ b/crates/driver/src/boundary/mempool.rs
@@ -52,10 +52,10 @@ pub enum Kind {
 
 impl Kind {
     /// for instrumentization purposes
-    pub fn format_variant(&self) -> String {
+    pub fn format_variant(&self) -> &'static str {
         match self {
-            Kind::Public(_) => "PublicMempool".to_string(),
-            Kind::MEVBlocker { .. } => "MEVBlocker".to_string(),
+            Kind::Public(_) => "PublicMempool",
+            Kind::MEVBlocker { .. } => "MEVBlocker",
         }
     }
 }


### PR DESCRIPTION
# Description
Adds mempool kind to every submission log, similar to what we have in non-colocated driver.

Didn't want to implement `Debug` nor `Display` just so to avoid any future misusage of ? and % in printing.