### PR TITLE
[TRIVIAL] Fix default gas price arguments

### DIFF
--- a/crates/driver/src/infra/config/file/mod.rs
+++ b/crates/driver/src/infra/config/file/mod.rs
@@ -120,8 +120,9 @@ fn default_additional_tip_percentage() -> f64 {
     0.05
 }
 
+/// 1000 gwei
 fn default_gas_price_cap() -> f64 {
-    1e9
+    1e12
 }
 
 fn default_target_confirm_time_secs() -> u64 {
@@ -136,8 +137,9 @@ fn default_max_confirm_time_secs() -> u64 {
     120
 }
 
+/// 3 gwei
 fn default_max_additional_tip() -> f64 {
-    3.0
+    3e9
 }
 
 fn default_soft_cancellations_flag() -> bool {


### PR DESCRIPTION
# Description
I noticed that no additional tip was added to MEVBlocker gas prices on staging.

The reason was that the argument `max_additional_tip` was expressed in gwei instead of wei, and this is fixed [here](https://github.com/cowprotocol/infrastructure/pull/791/commits/1b0492a8cbbb8b0bdd49aaa2a80b90de2ae0a4f2).

This PR makes similar updates to the default values.