### PR TITLE
[DRAFT] Solver competition orders moved to /solve

### DIFF
--- a/crates/autopilot/src/driver_model.rs
+++ b/crates/autopilot/src/driver_model.rs
@@ -60,6 +60,7 @@ pub mod solve {
         primitive_types::{H160, U256},
         serde::{Deserialize, Serialize},
         serde_with::{serde_as, DisplayFromStr},
+        std::collections::HashMap,
     };
 
     #[serde_as]
@@ -139,6 +140,16 @@ pub mod solve {
     #[serde_as]
     #[derive(Clone, Debug, Default, Deserialize)]
     #[serde(rename_all = "camelCase", deny_unknown_fields)]
+    pub struct OrderAmounts {
+        #[serde_as(as = "HexOrDecimalU256")]
+        pub in_amount: U256,
+        #[serde_as(as = "HexOrDecimalU256")]
+        pub out_amount: U256,
+    }
+
+    #[serde_as]
+    #[derive(Clone, Debug, Default, Deserialize)]
+    #[serde(rename_all = "camelCase", deny_unknown_fields)]
     pub struct Solution {
         /// Unique ID of the solution (per driver competition), used to identify
         /// it in subsequent requests (reveal, settle).
@@ -148,6 +159,7 @@ pub mod solve {
         pub score: U256,
         /// Address used by the driver to submit the settlement onchain.
         pub submission_address: H160,
+        pub orders: HashMap<OrderUid, OrderAmounts>,
     }
 
     #[derive(Clone, Debug, Default, Deserialize)]
@@ -159,7 +171,7 @@ pub mod solve {
 
 pub mod reveal {
     use {
-        model::{bytes_hex, order::OrderUid},
+        model::bytes_hex,
         serde::{Deserialize, Serialize},
         serde_with::serde_as,
     };
@@ -186,7 +198,6 @@ pub mod reveal {
     #[derive(Clone, Debug, Default, Deserialize)]
     #[serde(rename_all = "camelCase", deny_unknown_fields)]
     pub struct Response {
-        pub orders: Vec<OrderUid>,
         pub calldata: Calldata,
     }
 }

--- a/crates/autopilot/src/run_loop.rs
+++ b/crates/autopilot/src/run_loop.rs
@@ -235,16 +235,16 @@ impl RunLoop {
                             // fields) Not all fields can be populated in the colocated world
                             ..Default::default()
                         };
+                        settlement.orders = participant
+                            .solution
+                            .orders()
+                            .iter()
+                            .map(|(id, order)| Order {
+                                id: *id,
+                                executed_amount: order.out_amount,
+                            })
+                            .collect();
                         if is_winner {
-                            settlement.orders = participant
-                                .solution
-                                .orders()
-                                .iter()
-                                .map(|(id, order)| Order {
-                                    id: *id,
-                                    executed_amount: order.out_amount,
-                                })
-                                .collect();
                             settlement.call_data = revealed.calldata.internalized.clone();
                             settlement.uninternalized_call_data =
                                 Some(revealed.calldata.uninternalized.clone());

--- a/crates/driver/src/domain/eth/mod.rs
+++ b/crates/driver/src/domain/eth/mod.rs
@@ -191,7 +191,7 @@ impl TokenAddress {
 /// An ERC20 token amount.
 ///
 /// https://eips.ethereum.org/EIPS/eip-20
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct TokenAmount(pub U256);
 
 impl From<U256> for TokenAmount {

--- a/crates/driver/src/infra/api/routes/reveal/dto/revealed.rs
+++ b/crates/driver/src/infra/api/routes/reveal/dto/revealed.rs
@@ -1,8 +1,5 @@
 use {
-    crate::{
-        domain::{competition, competition::order},
-        util::serialize,
-    },
+    crate::{domain::competition, util::serialize},
     serde::Serialize,
     serde_with::serde_as,
 };
@@ -10,7 +7,6 @@ use {
 impl Revealed {
     pub fn new(reveal: competition::Revealed) -> Self {
         Self {
-            orders: reveal.orders.into_iter().map(Into::into).collect(),
             calldata: Calldata {
                 internalized: reveal.internalized_calldata.into(),
                 uninternalized: reveal.uninternalized_calldata.into(),
@@ -23,8 +19,6 @@ impl Revealed {
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Revealed {
-    #[serde_as(as = "Vec<serialize::Hex>")]
-    orders: Vec<[u8; order::UID_LEN]>,
     calldata: Calldata,
 }
 

--- a/crates/driver/src/infra/api/routes/solve/dto/solved.rs
+++ b/crates/driver/src/infra/api/routes/solve/dto/solved.rs
@@ -1,11 +1,12 @@
 use {
     crate::{
-        domain::{competition, eth},
+        domain::{competition, competition::order, eth},
         infra::Solver,
         util::serialize,
     },
     serde::Serialize,
     serde_with::serde_as,
+    std::collections::HashMap,
 };
 
 impl Solved {
@@ -31,9 +32,34 @@ impl Solution {
             solution_id,
             score: solved.score.into(),
             submission_address: solver.address().into(),
+            orders: solved
+                .orders
+                .into_iter()
+                .map(|(order_id, amounts)| {
+                    (
+                        order_id.into(),
+                        OrderAmounts {
+                            in_amount: amounts.in_amount.into(),
+                            out_amount: amounts.out_amount.into(),
+                        },
+                    )
+                })
+                .collect(),
         }
     }
 }
+
+#[serde_as]
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct OrderAmounts {
+    #[serde_as(as = "serialize::U256")]
+    pub in_amount: eth::U256,
+    #[serde_as(as = "serialize::U256")]
+    pub out_amount: eth::U256,
+}
+
+type OrderId = [u8; order::UID_LEN];
 
 #[serde_as]
 #[derive(Debug, Serialize)]
@@ -46,4 +72,6 @@ pub struct Solution {
     #[serde_as(as = "serialize::U256")]
     score: eth::U256,
     submission_address: eth::H160,
+    #[serde_as(as = "HashMap<serialize::Hex, _>")]
+    orders: HashMap<OrderId, OrderAmounts>,
 }


### PR DESCRIPTION
# Description
Implements only the part

> orders they intend to execute and their in/out amounts

from https://github.com/cowprotocol/services/issues/1949

Orders are no longer sent as a reponse to `/reveal` but as a response to `/solve`. I also added in/out amounts for each order.