### PR TITLE
[DRAFT] Colocation notify

### DIFF
--- a/crates/driver/src/domain/competition/mod.rs
+++ b/crates/driver/src/domain/competition/mod.rs
@@ -6,6 +6,7 @@ use {
         infra::{
             self,
             blockchain::Ethereum,
+            notify,
             observe,
             solver::{self, Solver},
             Simulator,
@@ -69,6 +70,7 @@ impl Competition {
         let solutions = solutions.into_iter().filter(|solution| {
             if solution.is_empty() {
                 observe::empty_solution(self.solver.name(), solution.id());
+                notify::empty_solution(&self.solver, auction.id());
                 false
             } else {
                 true
@@ -90,7 +92,11 @@ impl Competition {
             .into_iter()
             .filter_map(|(id, result)| {
                 result
-                    .tap_err(|err| observe::encoding_failed(self.solver.name(), id, err))
+                    .tap_err(|err| {
+                        observe::encoding_failed(self.solver.name(), id, err);
+                        //notify::encoding_failed(&self.solver, auction.id(),
+                        // id);
+                    })
                     .ok()
             })
             .collect_vec();
@@ -150,7 +156,10 @@ impl Competition {
             .into_iter()
             .filter_map(|(result, settlement)| {
                 result
-                    .tap_err(|err| observe::scoring_failed(self.solver.name(), err))
+                    .tap_err(|err| {
+                        observe::scoring_failed(self.solver.name(), err);
+                        notify::scoring_failed(&self.solver, auction.id());
+                    })
                     .ok()
                     .map(|score| (score, settlement))
             })

--- a/crates/driver/src/domain/competition/mod.rs
+++ b/crates/driver/src/domain/competition/mod.rs
@@ -94,8 +94,7 @@ impl Competition {
                 result
                     .tap_err(|err| {
                         observe::encoding_failed(self.solver.name(), id, err);
-                        //notify::encoding_failed(&self.solver, auction.id(),
-                        // id);
+                        notify::encoding_failed(&self.solver, auction.id(), id, err);
                     })
                     .ok()
             })

--- a/crates/driver/src/infra/mod.rs
+++ b/crates/driver/src/infra/mod.rs
@@ -4,6 +4,7 @@ pub mod cli;
 pub mod config;
 pub mod liquidity;
 pub mod mempool;
+pub mod notify;
 pub mod observe;
 pub mod simulator;
 pub mod solver;

--- a/crates/driver/src/infra/notify/mod.rs
+++ b/crates/driver/src/infra/notify/mod.rs
@@ -1,0 +1,23 @@
+use {super::Solver, crate::domain::competition};
+
+mod notification;
+
+pub use notification::{Kind, Notification};
+
+pub fn empty_solution(solver: &Solver, auction_id: Option<competition::auction::Id>) {
+    // prepare data for notification
+
+    solver.notify(auction_id, notification::Kind::EmptySolution);
+}
+
+pub fn price_violation(solver: &Solver, auction_id: Option<competition::auction::Id>) {
+    // prepare data for notification
+
+    solver.notify(auction_id, notification::Kind::PriceViolation);
+}
+
+pub fn scoring_failed(solver: &Solver, auction_id: Option<competition::auction::Id>) {
+    // prepare data for notification
+
+    solver.notify(auction_id, notification::Kind::ScoringFailed);
+}

--- a/crates/driver/src/infra/notify/mod.rs
+++ b/crates/driver/src/infra/notify/mod.rs
@@ -1,23 +1,37 @@
-use {super::Solver, crate::domain::competition};
+use {
+    super::Solver,
+    crate::domain::competition::{auction, solution},
+};
 
 mod notification;
 
 pub use notification::{Kind, Notification};
 
-pub fn empty_solution(solver: &Solver, auction_id: Option<competition::auction::Id>) {
-    // prepare data for notification
-
+pub fn empty_solution(solver: &Solver, auction_id: Option<auction::Id>) {
     solver.notify(auction_id, notification::Kind::EmptySolution);
 }
 
-pub fn price_violation(solver: &Solver, auction_id: Option<competition::auction::Id>) {
-    // prepare data for notification
-
+pub fn price_violation(solver: &Solver, auction_id: Option<auction::Id>) {
     solver.notify(auction_id, notification::Kind::PriceViolation);
 }
 
-pub fn scoring_failed(solver: &Solver, auction_id: Option<competition::auction::Id>) {
-    // prepare data for notification
-
+pub fn scoring_failed(solver: &Solver, auction_id: Option<auction::Id>) {
     solver.notify(auction_id, notification::Kind::ScoringFailed);
+}
+
+pub fn encoding_failed(
+    solver: &Solver,
+    auction_id: Option<auction::Id>,
+    solution_id: solution::Id,
+    err: solution::Error,
+) {
+    match err {
+        solution::Error::UntrustedInternalization => {
+            solver.notify(auction_id, notification::Kind::UntrustedInternalization);
+        }
+        solution::Error::InsufficientBalance => {
+            solver.notify(auction_id, notification::Kind::InsufficientBalance);
+        }
+        _ => (),
+    }
 }

--- a/crates/driver/src/infra/notify/notification.rs
+++ b/crates/driver/src/infra/notify/notification.rs
@@ -16,25 +16,31 @@ pub enum Kind {
     PriceViolation,
     /// No valid score could be computed for the solution.
     ScoringFailed,
-    // /// The solution didn't pass simulation. Includes all data needed to
-    // /// re-create simulation locally
-    // SimulationFailure(TransactionWithError),
-    // /// Objective value is too low.
-    // ObjectiveValueNonPositive,
-    // /// The solution doesn't have a positive score. Currently this can happen
-    // /// only if the objective value is negative.
-    // NonPositiveScore,
-    // /// The solution has a score that is too high. This can happen if the
-    // /// score is higher than the maximum score (surplus + fees)
-    // #[serde(rename_all = "camelCase")]
-    // TooHighScore {
-    //     #[serde_as(as = "HexOrDecimalU256")]
-    //     surplus: U256,
-    //     #[serde_as(as = "HexOrDecimalU256")]
-    //     fees: U256,
-    //     #[serde_as(as = "HexOrDecimalU256")]
-    //     max_score: U256,
-    //     #[serde_as(as = "HexOrDecimalU256")]
-    //     submitted_score: U256,
-    // },
+    /// Solution aimed to internalize untrusted token/s.
+    UntrustedInternalization, /* NonBufferableTokensUsed */
+    /// Solver don't have enough balance to submit the solution.
+    InsufficientBalance, /* /// The solution didn't pass simulation. Includes all data
+                          * needed to
+                          * /// re-create simulation locally
+                          * SimulationFailure(TransactionWithError),
+                          * /// Objective value is too low.
+                          * ObjectiveValueNonPositive,
+                          * /// The solution doesn't have a positive score. Currently this
+                          * can happen
+                          * /// only if the objective value is negative.
+                          * NonPositiveScore,
+                          * /// The solution has a score that is too high. This can happen
+                          * if the
+                          * /// score is higher than the maximum score (surplus + fees)
+                          * #[serde(rename_all = "camelCase")]
+                          * TooHighScore {
+                          *     #[serde_as(as = "HexOrDecimalU256")]
+                          *     surplus: U256,
+                          *     #[serde_as(as = "HexOrDecimalU256")]
+                          *     fees: U256,
+                          *     #[serde_as(as = "HexOrDecimalU256")]
+                          *     max_score: U256,
+                          *     #[serde_as(as = "HexOrDecimalU256")]
+                          *     submitted_score: U256,
+                          * }, */
 }

--- a/crates/driver/src/infra/notify/notification.rs
+++ b/crates/driver/src/infra/notify/notification.rs
@@ -1,0 +1,40 @@
+use crate::domain::competition;
+
+/// A notification is sent to the solvers in case a solution failed validation.
+#[derive(Debug)]
+pub struct Notification {
+    pub auction_id: Option<competition::auction::Id>,
+    pub kind: Kind,
+}
+
+#[derive(Debug)]
+pub enum Kind {
+    /// The solution doesn't contain any user orders.
+    EmptySolution, // NoUserOrders,
+    /// The solution violated a price constraint (ie. max deviation to external
+    /// price vector)
+    PriceViolation,
+    /// No valid score could be computed for the solution.
+    ScoringFailed,
+    // /// The solution didn't pass simulation. Includes all data needed to
+    // /// re-create simulation locally
+    // SimulationFailure(TransactionWithError),
+    // /// Objective value is too low.
+    // ObjectiveValueNonPositive,
+    // /// The solution doesn't have a positive score. Currently this can happen
+    // /// only if the objective value is negative.
+    // NonPositiveScore,
+    // /// The solution has a score that is too high. This can happen if the
+    // /// score is higher than the maximum score (surplus + fees)
+    // #[serde(rename_all = "camelCase")]
+    // TooHighScore {
+    //     #[serde_as(as = "HexOrDecimalU256")]
+    //     surplus: U256,
+    //     #[serde_as(as = "HexOrDecimalU256")]
+    //     fees: U256,
+    //     #[serde_as(as = "HexOrDecimalU256")]
+    //     max_score: U256,
+    //     #[serde_as(as = "HexOrDecimalU256")]
+    //     submitted_score: U256,
+    // },
+}

--- a/crates/driver/src/infra/solver/dto/mod.rs
+++ b/crates/driver/src/infra/solver/dto/mod.rs
@@ -1,9 +1,10 @@
 //! DTOs modeling the HTTP REST interface of the solver.
 
 mod auction;
+mod notification;
 mod solution;
 
-pub use {auction::Auction, solution::Solutions};
+pub use {auction::Auction, notification::Notification, solution::Solutions};
 
 #[derive(Debug, thiserror::Error)]
 #[error("{0}")]

--- a/crates/driver/src/infra/solver/dto/notification.rs
+++ b/crates/driver/src/infra/solver/dto/notification.rs
@@ -12,6 +12,8 @@ impl Notification {
                 notify::Kind::EmptySolution => Kind::EmptySolution,
                 notify::Kind::PriceViolation => Kind::PriceViolation,
                 notify::Kind::ScoringFailed => Kind::ScoringFailed,
+                notify::Kind::UntrustedInternalization => Kind::UntrustedInternalization,
+                notify::Kind::InsufficientBalance => Kind::InsufficientBalance,
             },
         }
     }
@@ -32,5 +34,7 @@ pub enum Kind {
     EmptySolution,
     PriceViolation,
     ScoringFailed,
+    UntrustedInternalization,
+    InsufficientBalance,
     // .. todo
 }

--- a/crates/driver/src/infra/solver/dto/notification.rs
+++ b/crates/driver/src/infra/solver/dto/notification.rs
@@ -1,0 +1,36 @@
+use {
+    crate::{domain::competition, infra::notify},
+    serde::Serialize,
+    serde_with::serde_as,
+};
+
+impl Notification {
+    pub fn new(auction_id: Option<competition::auction::Id>, kind: notify::Kind) -> Self {
+        Self {
+            auction_id: auction_id.as_ref().map(ToString::to_string),
+            kind: match kind {
+                notify::Kind::EmptySolution => Kind::EmptySolution,
+                notify::Kind::PriceViolation => Kind::PriceViolation,
+                notify::Kind::ScoringFailed => Kind::ScoringFailed,
+            },
+        }
+    }
+}
+
+#[serde_as]
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Notification {
+    auction_id: Option<String>,
+    kind: Kind,
+}
+
+#[serde_as]
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub enum Kind {
+    EmptySolution,
+    PriceViolation,
+    ScoringFailed,
+    // .. todo
+}


### PR DESCRIPTION
In progress...

Just a sketch what the changes would look like...

Most of the checks should be done in `solvers` crate.
Some checks are done in `driver`, like checking user orders existence, scores, simulations..

`Driver` calls `/notify` in a fire and forget manner to avoid `.await`-ing for each notification.

