### PR TITLE
[DRAFT] Append tx to simulation error

### DIFF
--- a/crates/driver/src/domain/eth/mod.rs
+++ b/crates/driver/src/domain/eth/mod.rs
@@ -313,13 +313,26 @@ impl From<H256> for TxId {
 }
 
 /// An onchain transaction.
-#[derive(Clone, Debug)]
+#[derive(Clone)]
 pub struct Tx {
     pub from: Address,
     pub to: Address,
     pub value: Ether,
     pub input: Bytes<Vec<u8>>,
     pub access_list: AccessList,
+}
+
+impl std::fmt::Debug for Tx {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{:?} -> {:?} ({:?} ETH) {}",
+            self.from,
+            self.to,
+            self.value,
+            hex::encode(&self.input.0)
+        )
+    }
 }
 
 impl Tx {


### PR DESCRIPTION
# Description
Prerequisite for https://github.com/cowprotocol/services/pull/1980

Adds tx data to simulation error so the clients can try to reproduce the simulation.

I think we are interested in this info in most (if not all) cases when our simulation fail. 
TODO: Probably not interested when error is not revert related. Will implement this tomorrow.