### PR TITLE
Workaround for nightly build

### DIFF
--- a/crates/contracts/build.rs
+++ b/crates/contracts/build.rs
@@ -558,11 +558,15 @@ fn generate_contract_with_config(
 
     println!("cargo:rerun-if-changed={}", path.display());
 
-    config(ContractBuilder::new().visibility_modifier("pub"))
-        .generate(&contract)
-        .unwrap()
-        .write_to_file(Path::new(&dest).join(format!("{name}.rs")))
-        .unwrap();
+    config(
+        ContractBuilder::new()
+            .rustfmt(false)
+            .visibility_modifier("pub"),
+    )
+    .generate(&contract)
+    .unwrap()
+    .write_to_file(Path::new(&dest).join(format!("{name}.rs")))
+    .unwrap();
 }
 
 fn addr(s: &str) -> Address {

--- a/crates/contracts/build.rs
+++ b/crates/contracts/build.rs
@@ -560,6 +560,7 @@ fn generate_contract_with_config(
 
     config(
         ContractBuilder::new()
+            // for some reason formatting the generate code is broken on nightly
             .rustfmt(false)
             .visibility_modifier("pub"),
     )


### PR DESCRIPTION
# Description
Our backend fails to compile using the nightly compiler. For some reason formatting the code generated for our contract bindings fails with `rustfmt` on nightly.
Usually I would say that we should not change our code base to appease the nightly compiler but in this case we only stop formatting auto generate code that nobody (?) looks at anyway. And since this issue seems to have blocked some people in the past I think it's an OK trade-off.

# Changes
- [x] stop formatting auto generated contract bindings

## How to test
`cargo +nightly build` does not fail