### PR TITLE
Less noisy mempools logs

### DIFF
--- a/crates/driver/src/boundary/mempool.rs
+++ b/crates/driver/src/boundary/mempool.rs
@@ -84,6 +84,12 @@ impl std::fmt::Debug for Mempool {
     }
 }
 
+impl std::fmt::Display for Mempool {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "Mempool({})", self.config.kind.format_variant())
+    }
+}
+
 impl Mempool {
     pub async fn new(config: Config, eth: Ethereum, pool: GlobalTxPool) -> Result<Self> {
         let gas_price_estimator = Arc::new(

--- a/crates/driver/src/infra/observe/mod.rs
+++ b/crates/driver/src/infra/observe/mod.rs
@@ -284,7 +284,7 @@ pub fn mempool_executed(
         Ok(txid) => {
             tracing::info!(
                 ?txid,
-                ?mempool,
+                %mempool,
                 ?settlement,
                 "sending transaction via mempool succeeded",
             );
@@ -292,7 +292,7 @@ pub fn mempool_executed(
         Err(err) => {
             tracing::warn!(
                 ?err,
-                ?mempool,
+                %mempool,
                 ?settlement,
                 "sending transaction via mempool failed",
             );


### PR DESCRIPTION
# Description
Currently our logs about submitting to the chain are quite noisy.

# Changes
Turn [logs](https://production-6de61f.kb.eu-central-1.aws.cloud.es.io/app/discover#/doc/ea511870-d9b3-11ed-a9d0-a17451f01cc1/cowlogs-staging-2023.10.18?id=T6JwQosBGP6wkTcjXqUM) from:
```
mempool=Mempool { config: Config { additional_tip_percentage: 0.05, gas_price_cap: 1000000000000.0, target_confirm_time: 30s, max_confirm_time: 120s, retry_interval: 2s, kind: MEVBlocker { url: Url { scheme: "https", cannot_be_a_base: false, username: "", password: None, host: Some(Domain("mevblockerrpc.barn.cow.fi")), port: None, path: "/", query: None, fragment: None }, max_additional_tip: 5000000000.0, use_soft_cancellations: true } } }
```
into:
```
mempool=Mempool(MEVBlocker)
```