### PR TITLE
Colocation logging improvements

### DIFF
--- a/crates/driver/src/domain/competition/solution/settlement.rs
+++ b/crates/driver/src/domain/competition/solution/settlement.rs
@@ -7,7 +7,7 @@ use {
             eth,
             mempools,
         },
-        infra::{blockchain::Ethereum, Simulator},
+        infra::{blockchain::Ethereum, observe, Simulator},
         util::conv::u256::U256Ext,
     },
     bigdecimal::Signed,
@@ -241,8 +241,9 @@ impl Settlement {
         let tx = tx.set_access_list(access_list.clone());
 
         // Simulate the settlement using the full access list and get the gas used.
-        let gas = simulator.gas(tx).await?;
+        let gas = simulator.gas(tx.clone()).await?;
 
+        observe::simulated(&tx, gas);
         Ok((access_list, gas))
     }
 


### PR DESCRIPTION
# Description

Ideally we can query a specific auction ID in kibana and get from a concise overview of what happened in the auction only by looking at INFO + logs (DEBUG may be somewhat noisy, TRACE is off by default).

Currently when looking e.g. at [this auction](https://production-6de61f.kb.eu-central-1.aws.cloud.es.io/app/r/s/8yS6J) we can see a lot of noisy info logs telling us about solvers submitting empty solutions, and their solver engines receiving the auction and fetching liquidity.

At the same time, we don't see information about the runners up solutions (unless they fail) in order to be able to easily reproduce them in Tenderly or Phalcon.

This PR improves this

# Changes
- Log auction ID in execute call (this allows to get the auction_id from the tx_hash in a single INFO level request)
- demote some noisy logs from info to debug
- Add a log for successfully simulated solution candidate (not just the winning one)

## How to test
1. Run system with only INFO logs and see relevant information in a concise way

## Related Issues

Fixes #1952 