### PR TITLE
Configurable autopilot wait time until settlement is detected onchain

### DIFF
--- a/crates/autopilot/src/arguments.rs
+++ b/crates/autopilot/src/arguments.rs
@@ -173,6 +173,17 @@ pub struct Arguments {
     #[clap(long, env, default_value = "10000000000000000")]
     pub score_cap: U256,
 
+    /// The amount of time that the autopilot waits looking for a settlement
+    /// transaction onchain after a settlement has been confirmed by the
+    /// driver.
+    #[clap(
+        long,
+        env,
+        default_value = "60",
+        value_parser = shared::arguments::duration_from_seconds,
+    )]
+    pub max_settlement_transaction_wait: Duration,
+
     /// Run the autopilot in a shadow mode by specifying an upstream CoW
     /// protocol deployment to pull auctions from. This will cause the autopilot
     /// to start a run loop where it performs solver competition on driver,

--- a/crates/autopilot/src/arguments.rs
+++ b/crates/autopilot/src/arguments.rs
@@ -174,8 +174,8 @@ pub struct Arguments {
     pub score_cap: U256,
 
     /// The amount of time that the autopilot waits looking for a settlement
-    /// transaction onchain after a settlement has been confirmed by the
-    /// driver.
+    /// transaction onchain after the driver acknowledges the receipt of a
+    /// settlement.
     #[clap(
         long,
         env,

--- a/crates/autopilot/src/run.rs
+++ b/crates/autopilot/src/run.rs
@@ -609,6 +609,7 @@ pub async fn run(args: Arguments) {
             submission_deadline: args.submission_deadline as u64,
             additional_deadline_for_rewards: args.additional_deadline_for_rewards as u64,
             score_cap: args.score_cap,
+            max_settlement_transaction_wait: args.max_settlement_transaction_wait,
         };
         run.run_forever().await;
         unreachable!("run loop exited");


### PR DESCRIPTION
# Description

The autopilot waits until a transaction is found onchain after submitting a transaction to the driver. The waiting time is now configurable.
The default value is the former hardcoded value: we can merge this PR before adding a new variable to our configurations.

## How to test
Changes are untested, however this shouldn't be an issue since the changes are small and simple.

## Related Issues

Closes #881.