### PR TITLE
Correctly exclude paraswap dexs

### DIFF
--- a/crates/solvers/config/example.paraswap.toml
+++ b/crates/solvers/config/example.paraswap.toml
@@ -4,7 +4,8 @@ relative-slippage = "0.001" # Percentage in the [0, 1] range
 risk-parameters = [0,0,0,0]
 
 [dex]
-exclude-dexs = [] # which dexs to ignore as liquidity sources
+# these 2 dexs should always be excluded because they are incompatible with `ignoreChecks`
+exclude-dexs = ["ParaSwapPool","ParaSwapLimitOrders"] # which dexs to ignore as liquidity sources
 address = "0xdd2e786980CD58ACc5F64807b354c981f4094936" # public address of the solver
 endpoint = "https://apiv5.paraswap.io" # paraswap API URL to use
 partner = "$YOUR_PARTNER_ID"

--- a/crates/solvers/src/infra/dex/paraswap/dto.rs
+++ b/crates/solvers/src/infra/dex/paraswap/dto.rs
@@ -40,7 +40,7 @@ pub struct PriceQuery {
     pub side: Side,
 
     /// The list of DEXs to exclude from the computed price route.
-    #[serde(skip_serializing_if = "Vec::is_empty")]
+    #[serde(skip_serializing_if = "Vec::is_empty", rename = "excludeDEXS")]
     #[serde_as(as = "serialize::CommaSeparated")]
     pub exclude_dexs: Vec<String>,
 

--- a/crates/solvers/src/tests/paraswap/market_order.rs
+++ b/crates/solvers/src/tests/paraswap/market_order.rs
@@ -11,7 +11,7 @@ async fn sell() {
     let api = mock::http::setup(vec![
         mock::http::Expectation::Get {
             path: mock::http::Path::exact(
-                "prices?srcToken=0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2&destToken=0xe41d2489571d322189246dafa5ebde1f4699f498&srcDecimals=18&destDecimals=18&amount=1000000000000000000&side=SELL&excludeDexs=UniswapV2&network=1&partner=cow",
+                "prices?srcToken=0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2&destToken=0xe41d2489571d322189246dafa5ebde1f4699f498&srcDecimals=18&destDecimals=18&amount=1000000000000000000&side=SELL&excludeDEXS=UniswapV2&network=1&partner=cow",
             ),
             res: json!({
               "priceRoute": {
@@ -249,7 +249,7 @@ async fn buy() {
     let api = mock::http::setup(vec![
         mock::http::Expectation::Get {
             path: mock::http::Path::exact(
-                "prices?srcToken=0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2&destToken=0xe41d2489571d322189246dafa5ebde1f4699f498&srcDecimals=18&destDecimals=18&amount=1000000000000000000000&side=BUY&excludeDexs=UniswapV2&network=1&partner=cow",
+                "prices?srcToken=0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2&destToken=0xe41d2489571d322189246dafa5ebde1f4699f498&srcDecimals=18&destDecimals=18&amount=1000000000000000000000&side=BUY&excludeDEXS=UniswapV2&network=1&partner=cow",
             ),
             res: json!({
               "priceRoute": {

--- a/crates/solvers/src/tests/paraswap/out_of_price.rs
+++ b/crates/solvers/src/tests/paraswap/out_of_price.rs
@@ -14,7 +14,7 @@ async fn sell() {
     let api = mock::http::setup(vec![
         mock::http::Expectation::Get {
             path: mock::http::Path::exact(
-                "prices?srcToken=0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2&destToken=0xe41d2489571d322189246dafa5ebde1f4699f498&srcDecimals=18&destDecimals=18&amount=1000000000000000000&side=SELL&excludeDexs=UniswapV2&network=1&partner=cow",
+                "prices?srcToken=0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2&destToken=0xe41d2489571d322189246dafa5ebde1f4699f498&srcDecimals=18&destDecimals=18&amount=1000000000000000000&side=SELL&excludeDEXS=UniswapV2&network=1&partner=cow",
             ),
             res: json!({
               "priceRoute": {
@@ -207,7 +207,7 @@ async fn buy() {
     let api = mock::http::setup(vec![
         mock::http::Expectation::Get {
             path: mock::http::Path::exact(
-                "prices?srcToken=0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2&destToken=0xe41d2489571d322189246dafa5ebde1f4699f498&srcDecimals=18&destDecimals=18&amount=1000000000000000000000&side=BUY&excludeDexs=UniswapV2&network=1&partner=cow",
+                "prices?srcToken=0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2&destToken=0xe41d2489571d322189246dafa5ebde1f4699f498&srcDecimals=18&destDecimals=18&amount=1000000000000000000000&side=BUY&excludeDEXS=UniswapV2&network=1&partner=cow",
             ),
             res: json!({
               "priceRoute": {


### PR DESCRIPTION
# Description
The paraswap solver issues a lot of [warnings](https://production-6de61f.kb.eu-central-1.aws.cloud.es.io/app/discover#/?_g=(filters:!(),refreshInterval:(pause:!t,value:0),time:(from:'2023-10-19T09:19:08.195Z',to:'2023-10-19T09:28:29.622Z'))&_a=(columns:!(log),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:ea511870-d9b3-11ed-a9d0-a17451f01cc1,key:kubernetes.container_name,negate:!f,params:(query:paraswap),type:phrase),query:(match_phrase:(kubernetes.container_name:paraswap)))),grid:(columns:('@timestamp':(width:164))),index:ea511870-d9b3-11ed-a9d0-a17451f01cc1,interval:auto,query:(language:kuery,query:'log:%20%22It%20is%20not%20allowed%20to%20have%20limit-orders%20Dex%20or%20paraswappool%20Dex%20in%20route%22'),sort:!(!('@timestamp',desc)))):
```
It is not allowed to have limit-orders Dex or paraswappool Dex in route and
'ignoreChecks=true' together. Consider requesting the price with excluded
limit-orders if you want to use 'ignoreChecks': &excludeDEXS=ParaSwapPool,ParaSwapLimitOrders
```
We already had the machinery required to append those excluded dexs as a query parameter but we didn't get the capitalization right which lead to the argument being ignored by the paraswap API.

One thing to note is that only the `/prices` API supports disabling dexs but not the `/transactions` API.

# Changes
* changes the serialized query parameter `excludeDexs` to `excludeDEXS`.
* also mentions which 2 dexs always have to be excluded in the example config file

## How to test
Run paraswap in colocated mode to see that the warnings stop.