### PR TITLE
Use simulated gas for score computation

### DIFF
--- a/crates/solvers/src/domain/dex/mod.rs
+++ b/crates/solvers/src/domain/dex/mod.rs
@@ -4,7 +4,7 @@
 
 use {
     crate::{
-        domain::{auction, eth, order, solution},
+        domain::{self, auction, eth, order, solution},
         infra,
         util,
     },
@@ -107,7 +107,7 @@ impl Swap {
         order: order::Order,
         gas_price: auction::GasPrice,
         sell_token: Option<auction::Price>,
-        score: solution::Score,
+        risk: &domain::Risk,
         simulator: &infra::dex::Simulator,
     ) -> Option<solution::Solution> {
         let gas = if order.class == order::Class::Limit {
@@ -123,6 +123,7 @@ impl Swap {
             // since it doesn't really play a role in the final solution.
             self.gas
         };
+        let score = solution::Score::RiskAdjusted(risk.success_probability(gas, gas_price, 1));
 
         let allowance = self.allowance();
         let interactions = vec![solution::Interaction::Custom(solution::CustomInteraction {

--- a/crates/solvers/src/domain/solver/dex/mod.rs
+++ b/crates/solvers/src/domain/solver/dex/mod.rs
@@ -121,10 +121,8 @@ impl Dex {
 
         let uid = order.uid;
         let sell = tokens.reference_price(&order.sell.token);
-        let score =
-            solution::Score::RiskAdjusted(self.risk.success_probability(swap.gas, gas_price, 1));
         let Some(solution) = swap
-            .into_solution(order.clone(), gas_price, sell, score, &self.simulator)
+            .into_solution(order.clone(), gas_price, sell, &self.risk, &self.simulator)
             .await
         else {
             tracing::debug!("no solution for swap");


### PR DESCRIPTION
# Description
@sunce86 [suggested](https://github.com/cowprotocol/services/pull/1960/files#r1363834421) to use the more accurate simulated gas amount for DEX swaps for the gas computation.

# Changes
Instead of computing the score before turning the swap into a solution (which is where we get the accurate gas) we now also compute the score when turning the swap into a solution.