### PR TITLE
Refactor score calculation

### DIFF
--- a/crates/driver/src/boundary/mod.rs
+++ b/crates/driver/src/boundary/mod.rs
@@ -25,6 +25,7 @@
 pub mod liquidity;
 pub mod mempool;
 pub mod quote;
+pub mod score;
 pub mod settlement;
 
 // The [`anyhow::Error`] type is re-exported because the legacy code mostly
@@ -35,6 +36,7 @@ pub use {
     contracts,
     mempool::Mempool,
     model::order::OrderData,
+    score::Score,
     settlement::Settlement,
     shared::ethrpc::Web3,
 };

--- a/crates/driver/src/boundary/mod.rs
+++ b/crates/driver/src/boundary/mod.rs
@@ -36,7 +36,7 @@ pub use {
     contracts,
     mempool::Mempool,
     model::order::OrderData,
-    score::Score,
+    score::ScoreCalculator,
     settlement::Settlement,
     shared::ethrpc::Web3,
 };

--- a/crates/driver/src/boundary/mod.rs
+++ b/crates/driver/src/boundary/mod.rs
@@ -36,7 +36,6 @@ pub use {
     contracts,
     mempool::Mempool,
     model::order::OrderData,
-    score::ScoreCalculator,
     settlement::Settlement,
     shared::ethrpc::Web3,
 };

--- a/crates/driver/src/boundary/score.rs
+++ b/crates/driver/src/boundary/score.rs
@@ -2,15 +2,16 @@ use {
     crate::{
         domain::{
             self,
-            competition::{self, score},
+            competition::{
+                self,
+                score::{self, SuccessProbability},
+            },
             eth,
         },
         util::conv::u256::U256Ext,
     },
     solver::settlement_rater::{ScoreCalculator, ScoringError},
 };
-
-type SuccessProbability = f64;
 
 #[derive(Debug, Clone)]
 pub struct Score {
@@ -41,7 +42,7 @@ impl Score {
         match self.inner.compute_score(
             &objective_value.to_big_rational(),
             &gas_cost,
-            success_probability,
+            success_probability.0,
         ) {
             Ok(score) => Ok(score.into()),
             Err(ScoringError::ObjectiveValueNonPositive(_)) => {

--- a/crates/driver/src/boundary/score.rs
+++ b/crates/driver/src/boundary/score.rs
@@ -1,7 +1,6 @@
 use {
     crate::{
         domain::{
-            self,
             competition::{
                 self,
                 score::{self, SuccessProbability},
@@ -10,51 +9,30 @@ use {
         },
         util::conv::u256::U256Ext,
     },
-    solver::settlement_rater::ScoringError,
+    solver::settlement_rater::{ScoreCalculator, ScoringError},
 };
 
-#[derive(Debug, Clone)]
-pub struct ScoreCalculator {
-    pub inner: solver::settlement_rater::ScoreCalculator,
-}
-
-impl ScoreCalculator {
-    pub fn new(score_cap: eth::U256, revert_protection: &domain::RevertProtection) -> Self {
-        Self {
-            inner: solver::settlement_rater::ScoreCalculator::new(
-                score_cap.to_big_rational(),
-                matches!(revert_protection, domain::RevertProtection::Disabled),
-            ),
+pub fn score(
+    score_cap: eth::U256,
+    objective_value: eth::U256,
+    success_probability: SuccessProbability,
+    failure_cost: eth::U256,
+) -> Result<competition::Score, score::Error> {
+    match ScoreCalculator::new(score_cap.to_big_rational()).compute_score(
+        &objective_value.to_big_rational(),
+        failure_cost.to_big_rational(),
+        success_probability.0,
+    ) {
+        Ok(score) => Ok(score.into()),
+        Err(ScoringError::ObjectiveValueNonPositive(_)) => {
+            Err(score::Error::ObjectiveValueNonPositive)
         }
-    }
-
-    pub fn score(
-        &self,
-        objective_value: eth::U256,
-        gas: eth::Gas,
-        gas_price: eth::GasPrice,
-        success_probability: SuccessProbability,
-    ) -> Result<competition::Score, score::Error> {
-        let gas = gas.0.to_big_rational();
-        let gas_price = eth::U256::from(gas_price.effective()).to_big_rational();
-        let gas_cost = gas * gas_price;
-
-        match self.inner.compute_score(
-            &objective_value.to_big_rational(),
-            &gas_cost,
-            success_probability.0,
-        ) {
-            Ok(score) => Ok(score.into()),
-            Err(ScoringError::ObjectiveValueNonPositive(_)) => {
-                Err(score::Error::ObjectiveValueNonPositive)
-            }
-            Err(ScoringError::ScoreHigherThanObjective(_)) => {
-                Err(score::Error::ScoreHigherThanObjective)
-            }
-            Err(ScoringError::SuccessProbabilityOutOfRange(_)) => Err(score::Error::Boundary(
-                anyhow::anyhow!("unreachable, should have been checked by solvers"),
-            )),
-            Err(ScoringError::InternalError(err)) => Err(score::Error::Boundary(err)),
+        Err(ScoringError::ScoreHigherThanObjective(_)) => {
+            Err(score::Error::ScoreHigherThanObjective)
         }
+        Err(ScoringError::SuccessProbabilityOutOfRange(_)) => Err(score::Error::Boundary(
+            anyhow::anyhow!("unreachable, should have been checked by solvers"),
+        )),
+        Err(ScoringError::InternalError(err)) => Err(score::Error::Boundary(err)),
     }
 }

--- a/crates/driver/src/boundary/score.rs
+++ b/crates/driver/src/boundary/score.rs
@@ -1,0 +1,57 @@
+use {crate::domain::competition, solver::settlement_rater::ScoringError};
+use {
+    crate::{
+        domain::{self, competition::score, eth},
+        util::conv::u256::U256Ext,
+    },
+    //anyhow::Result,
+    solver::settlement_rater::ScoreCalculator,
+};
+
+type SuccessProbability = f64;
+
+#[derive(Debug, Clone)]
+pub struct Score {
+    pub inner: ScoreCalculator,
+}
+
+impl Score {
+    pub fn new(score_cap: eth::U256, revert_protection: &domain::RevertProtection) -> Self {
+        Self {
+            inner: ScoreCalculator::new(
+                score_cap.to_big_rational(),
+                matches!(revert_protection, domain::RevertProtection::Disabled),
+            ),
+        }
+    }
+
+    pub fn score(
+        &self,
+        objective_value: eth::U256,
+        gas: eth::Gas,
+        gas_price: eth::GasPrice,
+        success_probability: SuccessProbability,
+    ) -> Result<competition::Score, score::Error> {
+        let gas = gas.0.to_big_rational();
+        let gas_price = eth::U256::from(gas_price.effective()).to_big_rational();
+        let gas_cost = gas * gas_price;
+
+        match self.inner.compute_score(
+            &objective_value.to_big_rational(),
+            &gas_cost,
+            success_probability,
+        ) {
+            Ok(score) => Ok(score.into()),
+            Err(ScoringError::ObjectiveValueNonPositive(_)) => {
+                Err(score::Error::ObjectiveValueNonPositive)
+            }
+            Err(ScoringError::ScoreHigherThanObjective(_)) => {
+                Err(score::Error::ScoreHigherThanObjective)
+            }
+            Err(ScoringError::SuccessProbabilityOutOfRange(_)) => Err(score::Error::Boundary(
+                anyhow::anyhow!("unreachable, should have been checked by solvers"),
+            )),
+            Err(ScoringError::InternalError(err)) => Err(score::Error::Boundary(err)),
+        }
+    }
+}

--- a/crates/driver/src/boundary/score.rs
+++ b/crates/driver/src/boundary/score.rs
@@ -10,18 +10,18 @@ use {
         },
         util::conv::u256::U256Ext,
     },
-    solver::settlement_rater::{ScoreCalculator, ScoringError},
+    solver::settlement_rater::ScoringError,
 };
 
 #[derive(Debug, Clone)]
-pub struct Score {
-    pub inner: ScoreCalculator,
+pub struct ScoreCalculator {
+    pub inner: solver::settlement_rater::ScoreCalculator,
 }
 
-impl Score {
+impl ScoreCalculator {
     pub fn new(score_cap: eth::U256, revert_protection: &domain::RevertProtection) -> Self {
         Self {
-            inner: ScoreCalculator::new(
+            inner: solver::settlement_rater::ScoreCalculator::new(
                 score_cap.to_big_rational(),
                 matches!(revert_protection, domain::RevertProtection::Disabled),
             ),

--- a/crates/driver/src/boundary/score.rs
+++ b/crates/driver/src/boundary/score.rs
@@ -1,11 +1,13 @@
-use {crate::domain::competition, solver::settlement_rater::ScoringError};
 use {
     crate::{
-        domain::{self, competition::score, eth},
+        domain::{
+            self,
+            competition::{self, score},
+            eth,
+        },
         util::conv::u256::U256Ext,
     },
-    //anyhow::Result,
-    solver::settlement_rater::ScoreCalculator,
+    solver::settlement_rater::{ScoreCalculator, ScoringError},
 };
 
 type SuccessProbability = f64;

--- a/crates/driver/src/boundary/settlement.rs
+++ b/crates/driver/src/boundary/settlement.rs
@@ -160,7 +160,7 @@ impl Settlement {
             competition::SolverScore::Solver(score) => http_solver::model::Score::Solver { score },
             competition::SolverScore::RiskAdjusted(success_probability) => {
                 http_solver::model::Score::RiskAdjusted {
-                    success_probability,
+                    success_probability: success_probability.0,
                     gas_amount: None,
                 }
             }
@@ -234,7 +234,9 @@ impl Settlement {
             http_solver::model::Score::RiskAdjusted {
                 success_probability,
                 ..
-            } => competition::SolverScore::RiskAdjusted(success_probability),
+            } => competition::SolverScore::RiskAdjusted(competition::score::SuccessProbability(
+                success_probability,
+            )),
         }
     }
 

--- a/crates/driver/src/boundary/settlement.rs
+++ b/crates/driver/src/boundary/settlement.rs
@@ -220,9 +220,11 @@ impl Settlement {
                 .collect(),
         )?;
         let gas_price = eth::U256::from(auction.gas_price().effective()).to_big_rational();
-        let objective_value =
-            self.inner
-                .objective_value(&prices, &gas_price, &gas.0.to_big_rational());
+        let objective_value = {
+            let surplus = self.inner.total_surplus(&prices);
+            let solver_fees = self.inner.total_solver_fees(&prices);
+            surplus + solver_fees - gas_price * gas.0.to_big_rational()
+        };
         eth::U256::from_big_rational(&objective_value)
     }
 

--- a/crates/driver/src/domain/competition/mod.rs
+++ b/crates/driver/src/domain/competition/mod.rs
@@ -1,6 +1,6 @@
 use {
     self::solution::settlement,
-    super::{eth, Mempools},
+    super::Mempools,
     crate::{
         domain::competition::solution::Settlement,
         infra::{
@@ -21,11 +21,13 @@ use {
 
 pub mod auction;
 pub mod order;
+pub mod score;
 pub mod solution;
 
 pub use {
     auction::Auction,
     order::Order,
+    score::Score,
     solution::{Solution, SolverScore, SolverTimeout},
 };
 
@@ -230,23 +232,6 @@ impl Competition {
             .unwrap()
             .as_ref()
             .map(|s| s.auction_id)
-    }
-}
-
-/// Represents a single value suitable for comparing/ranking solutions.
-/// This is a final score that is observed by the autopilot.
-#[derive(Debug, Default, PartialEq, Eq, PartialOrd, Ord, Copy, Clone)]
-pub struct Score(pub eth::U256);
-
-impl From<Score> for eth::U256 {
-    fn from(value: Score) -> Self {
-        value.0
-    }
-}
-
-impl From<eth::U256> for Score {
-    fn from(value: eth::U256) -> Self {
-        Self(value)
     }
 }
 

--- a/crates/driver/src/domain/competition/score.rs
+++ b/crates/driver/src/domain/competition/score.rs
@@ -1,0 +1,47 @@
+use crate::{
+    boundary,
+    domain::{eth, mempools},
+};
+
+impl Score {
+    pub fn new(
+        score_cap: eth::U256,
+        revert_protection: &mempools::RevertProtection,
+        objective_value: eth::U256,
+        gas: eth::Gas,
+        gas_price: eth::GasPrice,
+        success_probability: SuccessProbability,
+    ) -> Result<Self, Error> {
+        let boundary = boundary::Score::new(score_cap, revert_protection);
+        boundary.score(objective_value, gas, gas_price, success_probability)
+    }
+}
+
+/// Represents a single value suitable for comparing/ranking solutions.
+/// This is a final score that is observed by the autopilot.
+#[derive(Debug, Default, PartialEq, Eq, PartialOrd, Ord, Copy, Clone)]
+pub struct Score(pub eth::U256);
+
+impl From<Score> for eth::U256 {
+    fn from(value: Score) -> Self {
+        value.0
+    }
+}
+
+impl From<eth::U256> for Score {
+    fn from(value: eth::U256) -> Self {
+        Self(value)
+    }
+}
+
+type SuccessProbability = f64;
+
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    #[error("objective value is non-positive")]
+    ObjectiveValueNonPositive,
+    #[error("objective value is higher than the objective")]
+    ScoreHigherThanObjective,
+    #[error("invalid objective value")]
+    Boundary(#[from] boundary::Error),
+}

--- a/crates/driver/src/domain/competition/score.rs
+++ b/crates/driver/src/domain/competition/score.rs
@@ -12,7 +12,7 @@ impl Score {
         gas_price: eth::GasPrice,
         success_probability: SuccessProbability,
     ) -> Result<Self, Error> {
-        let boundary = boundary::Score::new(score_cap, revert_protection);
+        let boundary = boundary::ScoreCalculator::new(score_cap, revert_protection);
         boundary.score(objective_value, gas, gas_price, success_probability)
     }
 }

--- a/crates/driver/src/domain/competition/score.rs
+++ b/crates/driver/src/domain/competition/score.rs
@@ -1,19 +1,18 @@
-use crate::{
-    boundary,
-    domain::{eth, mempools},
-};
+use crate::{boundary, domain::eth};
 
 impl Score {
     pub fn new(
         score_cap: eth::U256,
-        revert_protection: &mempools::RevertProtection,
         objective_value: eth::U256,
-        gas: eth::Gas,
-        gas_price: eth::GasPrice,
         success_probability: SuccessProbability,
+        failure_cost: eth::U256,
     ) -> Result<Self, Error> {
-        let boundary = boundary::ScoreCalculator::new(score_cap, revert_protection);
-        boundary.score(objective_value, gas, gas_price, success_probability)
+        boundary::score::score(
+            score_cap,
+            objective_value,
+            success_probability,
+            failure_cost,
+        )
     }
 }
 

--- a/crates/driver/src/domain/competition/score.rs
+++ b/crates/driver/src/domain/competition/score.rs
@@ -34,7 +34,9 @@ impl From<eth::U256> for Score {
     }
 }
 
-type SuccessProbability = f64;
+/// Represents the probability that a solution will be successfully settled.
+#[derive(Debug, Clone)]
+pub struct SuccessProbability(pub f64);
 
 #[derive(Debug, thiserror::Error)]
 pub enum Error {

--- a/crates/driver/src/domain/competition/solution/mod.rs
+++ b/crates/driver/src/domain/competition/solution/mod.rs
@@ -1,4 +1,5 @@
 use {
+    super::score::SuccessProbability,
     crate::{
         boundary,
         domain::{
@@ -282,9 +283,6 @@ impl SolverTimeout {
         Self(self.0 - duration)
     }
 }
-
-/// Represents the probability that a solution will be successfully settled.
-type SuccessProbability = f64;
 
 /// Carries information how the score should be calculated.
 #[derive(Debug, Clone)]

--- a/crates/driver/src/domain/competition/solution/settlement.rs
+++ b/crates/driver/src/domain/competition/solution/settlement.rs
@@ -287,7 +287,7 @@ impl Settlement {
             return Err(score::Error::ScoreHigherThanObjective);
         }
 
-        if score == eth::U256::zero().into() {
+        if score.0.is_zero() {
             return Err(score::Error::ObjectiveValueNonPositive);
         }
 

--- a/crates/driver/src/infra/observe/mod.rs
+++ b/crates/driver/src/infra/observe/mod.rs
@@ -10,6 +10,7 @@ use {
         domain::{
             competition::{
                 self,
+                score,
                 solution::{self, Settlement},
                 Auction,
                 Solution,
@@ -120,7 +121,7 @@ pub fn scoring(settlement: &Settlement) {
 }
 
 /// Observe that scoring failed.
-pub fn scoring_failed(solver: &solver::Name, err: &boundary::Error) {
+pub fn scoring_failed(solver: &solver::Name, err: &score::Error) {
     tracing::info!(%solver, ?err, "discarded solution: scoring failed");
     metrics::get()
         .dropped_solutions

--- a/crates/driver/src/infra/solver/dto/solution.rs
+++ b/crates/driver/src/infra/solver/dto/solution.rs
@@ -199,7 +199,9 @@ impl Solutions {
                     match solution.score {
                         Score::Solver(score) => competition::solution::SolverScore::Solver(score),
                         Score::RiskAdjusted(success_probability) => {
-                            competition::solution::SolverScore::RiskAdjusted(success_probability)
+                            competition::solution::SolverScore::RiskAdjusted(
+                                competition::score::SuccessProbability(success_probability),
+                            )
                         }
                     },
                     weth,

--- a/crates/driver/src/tests/cases/score_competition.rs
+++ b/crates/driver/src/tests/cases/score_competition.rs
@@ -11,14 +11,14 @@ async fn solver_score_winner() {
     let test = setup()
         .pool(ab_pool())
         .order(ab_order())
-        .solution(ab_solution().score(Score::Solver(2992421280589416499u128.into()))) // not higher than objective value
+        .solution(ab_solution().score(Score::Solver(2902421280589416499u128.into()))) // not higher than objective value
         .solution(ab_solution().score(Score::RiskAdjusted(0.4)))
         .done()
         .await;
 
     assert_eq!(
         test.solve().await.ok().score(),
-        2992421280589416499u128.into()
+        2902421280589416499u128.into()
     );
     test.reveal().await.ok().orders(&[ab_order().name]);
 }

--- a/crates/driver/src/tests/cases/score_competition.rs
+++ b/crates/driver/src/tests/cases/score_competition.rs
@@ -1,7 +1,7 @@
 //! Test that driver properly does competition.
 
 use crate::tests::{
-    cases::{DEFAULT_SCORE_MAX, DEFAULT_SCORE_MIN},
+    cases::DEFAULT_SCORE_MIN,
     setup::{ab_order, ab_pool, ab_solution, setup, Score},
 };
 
@@ -11,12 +11,15 @@ async fn solver_score_winner() {
     let test = setup()
         .pool(ab_pool())
         .order(ab_order())
-        .solution(ab_solution().score(Score::Solver(3000000000000000000u128.into()))) // not higher than objective value
-        .solution(ab_solution().score(Score::RiskAdjusted(0.6))) // 2982421280589416499
+        .solution(ab_solution().score(Score::Solver(2992421280589416499u128.into()))) // not higher than objective value
+        .solution(ab_solution().score(Score::RiskAdjusted(0.4)))
         .done()
         .await;
 
-    assert_eq!(test.solve().await.ok().score(), DEFAULT_SCORE_MAX.into());
+    assert_eq!(
+        test.solve().await.ok().score(),
+        2992421280589416499u128.into()
+    );
     test.reveal().await.ok().orders(&[ab_order().name]);
 }
 

--- a/crates/driver/src/tests/cases/score_competition.rs
+++ b/crates/driver/src/tests/cases/score_competition.rs
@@ -11,8 +11,8 @@ async fn solver_score_winner() {
     let test = setup()
         .pool(ab_pool())
         .order(ab_order())
-        .solution(ab_solution().score(Score::Solver(DEFAULT_SCORE_MAX.into())))
-        .solution(ab_solution().score(Score::RiskAdjusted(0.6)))
+        .solution(ab_solution().score(Score::Solver(3000000000000000000u128.into()))) // not higher than objective value
+        .solution(ab_solution().score(Score::RiskAdjusted(0.6))) // 2982421280589416499
         .done()
         .await;
 

--- a/crates/solver/src/run.rs
+++ b/crates/solver/src/run.rs
@@ -349,13 +349,11 @@ pub async fn run(args: Arguments) {
         settlement_contract: settlement_contract.clone(),
         web3: web3.clone(),
         code_fetcher: code_fetcher.clone(),
-        score_calculator: ScoreCalculator::new(
-            u256_to_big_rational(&args.score_cap),
-            args.transaction_strategy.iter().any(|s| {
-                matches!(s, TransactionStrategyArg::PublicMempool)
-                    && !args.disable_high_risk_public_mempool_transactions
-            }),
-        ),
+        score_calculator: ScoreCalculator::new(u256_to_big_rational(&args.score_cap)),
+        consider_cost_failure: args.transaction_strategy.iter().any(|s| {
+            matches!(s, TransactionStrategyArg::PublicMempool)
+                && !args.disable_high_risk_public_mempool_transactions
+        }),
     });
 
     let solver = crate::solver::create(

--- a/crates/solver/src/settlement.rs
+++ b/crates/solver/src/settlement.rs
@@ -502,6 +502,17 @@ impl Settlement {
             None
         }
     }
+
+    pub fn objective_value(
+        &self,
+        external_prices: &ExternalPrices,
+        gas_price: &BigRational,
+        gas_amount: &BigRational,
+    ) -> BigRational {
+        let surplus = self.total_surplus(external_prices);
+        let solver_fees = self.total_solver_fees(external_prices);
+        surplus + solver_fees - gas_price * gas_amount
+    }
 }
 
 // The difference between what you were willing to sell (executed_amount *

--- a/crates/solver/src/settlement.rs
+++ b/crates/solver/src/settlement.rs
@@ -502,17 +502,6 @@ impl Settlement {
             None
         }
     }
-
-    pub fn objective_value(
-        &self,
-        external_prices: &ExternalPrices,
-        gas_price: &BigRational,
-        gas_amount: &BigRational,
-    ) -> BigRational {
-        let surplus = self.total_surplus(external_prices);
-        let solver_fees = self.total_solver_fees(external_prices);
-        surplus + solver_fees - gas_price * gas_amount
-    }
 }
 
 // The difference between what you were willing to sell (executed_amount *

--- a/crates/solvers/src/api/dto/solution.rs
+++ b/crates/solvers/src/api/dto/solution.rs
@@ -135,7 +135,7 @@ impl Solutions {
                         .collect(),
                     score: match solution.score.clone() {
                         solution::Score::Solver(score) => Score::Solver(score),
-                        solution::Score::RiskAdjusted(score) => Score::RiskAdjusted(score),
+                        solution::Score::RiskAdjusted(score) => Score::RiskAdjusted(score.0),
                     },
                 })
                 .collect(),

--- a/crates/solvers/src/boundary/legacy.rs
+++ b/crates/solvers/src/boundary/legacy.rs
@@ -539,7 +539,7 @@ fn to_domain_solution(
             Score::RiskAdjusted {
                 success_probability,
                 ..
-            } => solution::Score::RiskAdjusted(success_probability),
+            } => solution::Score::RiskAdjusted(solution::SuccessProbability(success_probability)),
         },
     })
 }

--- a/crates/solvers/src/domain/solution.rs
+++ b/crates/solvers/src/domain/solution.rs
@@ -29,9 +29,9 @@ impl Solution {
         gas_price: auction::GasPrice,
     ) -> Self {
         let nmb_orders = self.trades.len();
-        self.with_score(Score::RiskAdjusted(
+        self.with_score(Score::RiskAdjusted(SuccessProbability(
             risk.success_probability(gas, gas_price, nmb_orders),
-        ))
+        )))
     }
 
     /// Returns `self` with eligible interactions internalized using the
@@ -373,7 +373,8 @@ pub struct Allowance {
 }
 
 /// Represents the probability that a solution will be successfully settled.
-type SuccessProbability = f64;
+#[derive(Debug, Clone)]
+pub struct SuccessProbability(pub f64);
 
 /// A score for a solution. The score is used to rank solutions.
 #[derive(Debug, Clone)]
@@ -389,7 +390,7 @@ pub enum Score {
 
 impl Default for Score {
     fn default() -> Self {
-        Self::RiskAdjusted(1.0)
+        Self::RiskAdjusted(SuccessProbability(1.0))
     }
 }
 

--- a/crates/solvers/src/domain/solver/baseline.rs
+++ b/crates/solvers/src/domain/solver/baseline.rs
@@ -122,10 +122,9 @@ impl Inner {
                             output.amount = cmp::min(output.amount, order.buy.amount);
                         }
 
-                        let score = solution::Score::RiskAdjusted(self.risk.success_probability(
-                            route.gas(),
-                            auction.gas_price,
-                            1,
+                        let score = solution::Score::RiskAdjusted(solution::SuccessProbability(
+                            self.risk
+                                .success_probability(route.gas(), auction.gas_price, 1),
                         ));
 
                         Some(

--- a/crates/solvers/src/domain/solver/dex/mod.rs
+++ b/crates/solvers/src/domain/solver/dex/mod.rs
@@ -121,8 +121,9 @@ impl Dex {
 
         let uid = order.uid;
         let sell = tokens.reference_price(&order.sell.token);
-        let score =
-            solution::Score::RiskAdjusted(self.risk.success_probability(swap.gas, gas_price, 1));
+        let score = solution::Score::RiskAdjusted(solution::SuccessProbability(
+            self.risk.success_probability(swap.gas, gas_price, 1),
+        ));
         let Some(solution) = swap
             .into_solution(order.clone(), gas_price, sell, score, &self.simulator)
             .await


### PR DESCRIPTION
# Description
No new functionality (actually fixes bug, because before this we did not check the validity of score if provided by solver as is, we did the checks only for risk adjusted scores).

Moves out score calculation out of the boundary settlement.
A step forward for https://github.com/cowprotocol/services/issues/1973 and prerequisite for implementing task #4 from https://github.com/cowprotocol/services/issues/1891

# Changes
- Added objective_value calculation on boundary settlement
- Added score forwarding on boundary settlement
- With these two, score calculation is moved out to domain::settlement
- Score calculator moved to boundary::score and used by ☝️ 
- These two allowed to define domain::score::Error and propagate errors properly.