### PR TITLE
Make times between auction run_loops configurable

### DIFF
--- a/crates/autopilot/src/run.rs
+++ b/crates/autopilot/src/run.rs
@@ -610,6 +610,7 @@ pub async fn run(args: Arguments) {
             additional_deadline_for_rewards: args.additional_deadline_for_rewards as u64,
             score_cap: args.score_cap,
             max_settlement_transaction_wait: args.max_settlement_transaction_wait,
+            min_time_between_runs: args.auction_update_interval,
         };
         run.run_forever().await;
         unreachable!("run loop exited");

--- a/crates/autopilot/src/run.rs
+++ b/crates/autopilot/src/run.rs
@@ -610,7 +610,6 @@ pub async fn run(args: Arguments) {
             additional_deadline_for_rewards: args.additional_deadline_for_rewards as u64,
             score_cap: args.score_cap,
             max_settlement_transaction_wait: args.max_settlement_transaction_wait,
-            min_time_between_runs: args.auction_update_interval,
         };
         run.run_forever().await;
         unreachable!("run loop exited");

--- a/crates/autopilot/src/run_loop.rs
+++ b/crates/autopilot/src/run_loop.rs
@@ -60,19 +60,25 @@ pub struct RunLoop {
     pub additional_deadline_for_rewards: u64,
     pub score_cap: U256,
     pub max_settlement_transaction_wait: Duration,
-    pub min_time_between_runs: Duration,
 }
 
 impl RunLoop {
     pub async fn run_forever(self) -> ! {
+        let mut last_auction_id = None;
+        let mut last_block = None;
         loop {
-            let start = Instant::now();
             if let Some(AuctionWithId { id, auction }) = self.next_auction().await {
-                self.single_run(id, &auction)
-                    .instrument(tracing::info_span!("auction", id))
-                    .await;
+                let current_block = self.current_block.borrow().hash;
+                // Only run the solvers if the auction or block has changed.
+                if last_auction_id.replace(id) != Some(id)
+                    || last_block.replace(current_block) != Some(current_block)
+                {
+                    self.single_run(id, &auction)
+                        .instrument(tracing::info_span!("auction", id))
+                        .await;
+                }
             };
-            tokio::time::sleep(self.min_time_between_runs.saturating_sub(start.elapsed())).await;
+            tokio::time::sleep(Duration::from_secs(1)).await;
         }
     }
 


### PR DESCRIPTION
# Description
We were made aware that we are currently sending *a lot* of auctions on xdai staging. This is because the auctions are mainly empty (or solvers quickly return an empty solution) and then our run_loop sleeps for a hardcoded amount of 1s, which is way to short.

This PR makes this value configurable. It reuses the existing `auction_update_interval` which decides how often we prepare a new auction. Maybe this value should be separate, but at least we shouldn't dispatch auctions more often than we update them (otherwise we may dispatch the same auction multiple times which is likely not going to change the outcome)

# Changes

- Make the sleep between run_loops configurable
- Deduct the time the run loop has take from this value to make sure we don't wait for a long time if a solution was found and mined

## How to test
Run autopilot on an empty orderbook. See new auctions are now created much slower than before
