### PR TITLE
Fix Legacy Solver

### DIFF
--- a/crates/solvers/src/boundary/legacy.rs
+++ b/crates/solvers/src/boundary/legacy.rs
@@ -405,9 +405,12 @@ fn to_domain_solution(
                         order::Side::Buy => execution.exec_buy_amount,
                         order::Side::Sell => execution.exec_sell_amount,
                     },
-                    match execution.exec_fee_amount {
-                        Some(fee) => solution::Fee::Surplus(fee),
-                        None => solution::Fee::Protocol,
+                    match order.solver_determines_fee() {
+                        true => execution
+                            .exec_fee_amount
+                            .map(solution::Fee::Surplus)
+                            .context("no surplus fee")?,
+                        false => solution::Fee::Protocol,
                     },
                 )
                 .context("invalid trade execution")?,

--- a/crates/solvers/src/tests/legacy/market_order.rs
+++ b/crates/solvers/src/tests/legacy/market_order.rs
@@ -91,6 +91,7 @@ async fn quote() {
                 "0": {
                     "exec_sell_amount": "133700000000000000",
                     "exec_buy_amount": "6000000000000000000000",
+                    "exec_fee_amount": "6900000000000000"
                 }
             },
             "prices": {
@@ -295,6 +296,7 @@ async fn solve() {
                 "0": {
                     "exec_sell_amount": "133700000000000000",
                     "exec_buy_amount": "6000000000000000000000",
+                    "exec_fee_amount": "6900000000000000",
                 }
             },
             "prices": {


### PR DESCRIPTION
# Description
Solvers already submit self computed fee amounts even for orders that still work with a protocol specified fee (e.g. market orders). See this barter response for instance: http://jsonblob.com/1164883806913421312

The code currently rejects those solutions with "invalid trade execution" errors. This PR makes the legacy adapter compliant with the current system where we ignore the fee_amount for orders that don't require them (rather than erroring if it specified)

# Changes

- Instead of erroring when a surplus fee is specified although the solver doesn't determine the fee we now always use the protocol fee instead
- adjust unit test to demonstrate the response is now accepted

## How to test
Unit test

Fixes #1996 