### PR TITLE
Parse /settle errors and only warn about them

### DIFF
--- a/crates/autopilot/src/run_loop.rs
+++ b/crates/autopilot/src/run_loop.rs
@@ -289,7 +289,7 @@ impl RunLoop {
                 Ok(()) => Metrics::settle_ok(driver),
                 Err(err) => {
                     Metrics::settle_err(driver, &err);
-                    tracing::error!(?err, driver = %driver.name, "settlement failed");
+                    tracing::warn!(?err, driver = %driver.name, "settlement failed");
                 }
             }
         }


### PR DESCRIPTION
# Description
https://github.com/cowprotocol/services/pull/1999 had the unfortunate side effect that we spammed a few [alerts](https://cowservices.slack.com/archives/C037PB929ME/p1697812387457109) whenever the driver was not able to settle a solution.

# Changes
We now only `warn` whenever we can't parse the success response. We didn't introduce, expect and parse any specific error format because eventually drivers will be run externally and maybe not all of them run a driver compliant with the error response spec all the time.
If we simply print the parsing error we'll get all the data we can get out of the response anyway.