### PR TITLE
Drop access list from `eth::Tx` `Debug` impl

### DIFF
--- a/crates/driver/src/domain/eth/mod.rs
+++ b/crates/driver/src/domain/eth/mod.rs
@@ -328,8 +328,7 @@ impl std::fmt::Debug for Tx {
             .field("from", &self.from)
             .field("to", &self.to)
             .field("value", &self.value)
-            .field("input", &hex::encode(&self.input.0))
-            .field("access_list", &self.access_list)
+            .field("input", &self.input)
             .finish()
     }
 }

--- a/crates/driver/src/domain/eth/mod.rs
+++ b/crates/driver/src/domain/eth/mod.rs
@@ -313,13 +313,25 @@ impl From<H256> for TxId {
 }
 
 /// An onchain transaction.
-#[derive(Clone, Debug)]
+#[derive(Clone)]
 pub struct Tx {
     pub from: Address,
     pub to: Address,
     pub value: Ether,
     pub input: Bytes<Vec<u8>>,
     pub access_list: AccessList,
+}
+
+impl std::fmt::Debug for Tx {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Tx")
+            .field("from", &self.from)
+            .field("to", &self.to)
+            .field("value", &self.value)
+            .field("input", &hex::encode(&self.input.0))
+            .field("access_list", &self.access_list)
+            .finish()
+    }
 }
 
 impl Tx {

--- a/crates/driver/src/domain/eth/mod.rs
+++ b/crates/driver/src/domain/eth/mod.rs
@@ -313,25 +313,13 @@ impl From<H256> for TxId {
 }
 
 /// An onchain transaction.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct Tx {
     pub from: Address,
     pub to: Address,
     pub value: Ether,
     pub input: Bytes<Vec<u8>>,
     pub access_list: AccessList,
-}
-
-impl std::fmt::Debug for Tx {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("Tx")
-            .field("from", &self.from)
-            .field("to", &self.to)
-            .field("value", &self.value)
-            .field("input", &hex::encode(&self.input.0))
-            .field("access_list", &self.access_list)
-            .finish()
-    }
 }
 
 impl Tx {


### PR DESCRIPTION
# Description
Drop the `access_list` field from the `Debug` impl because it's pretty noisy and not very helpful for debugging purposes.