### PR TITLE
Wait for solve deadline

### DIFF
--- a/crates/autopilot/src/arguments.rs
+++ b/crates/autopilot/src/arguments.rs
@@ -194,6 +194,15 @@ pub struct Arguments {
     /// being specified separately.
     #[clap(long, env)]
     pub shadow: Option<Url>,
+
+    /// Time in seconds solvers have to compute a score per auction.
+    #[clap(
+        long,
+        env,
+        default_value = "15",
+        value_parser = shared::arguments::duration_from_seconds,
+    )]
+    pub solve_deadline: Duration,
 }
 
 impl std::fmt::Display for Arguments {
@@ -253,6 +262,7 @@ impl std::fmt::Display for Arguments {
         )?;
         writeln!(f, "score_cap: {}", self.score_cap)?;
         display_option(f, "shadow", &self.shadow)?;
+        writeln!(f, "solve_deadline: {:?}", self.solve_deadline)?;
         Ok(())
     }
 }

--- a/crates/autopilot/src/run.rs
+++ b/crates/autopilot/src/run.rs
@@ -609,6 +609,7 @@ pub async fn run(args: Arguments) {
             additional_deadline_for_rewards: args.additional_deadline_for_rewards as u64,
             score_cap: args.score_cap,
             max_settlement_transaction_wait: args.max_settlement_transaction_wait,
+            solve_deadline: args.solve_deadline,
         };
         run.run_forever().await;
         unreachable!("run loop exited");
@@ -662,7 +663,13 @@ async fn shadow_mode(args: Arguments) -> ! {
         .await
     };
 
-    let shadow = shadow::RunLoop::new(orderbook, drivers, trusted_tokens, args.score_cap);
+    let shadow = shadow::RunLoop::new(
+        orderbook,
+        drivers,
+        trusted_tokens,
+        args.score_cap,
+        args.solve_deadline,
+    );
     shadow.run_forever().await;
 
     unreachable!("shadow run loop exited");

--- a/crates/driver/src/infra/blockchain/mod.rs
+++ b/crates/driver/src/infra/blockchain/mod.rs
@@ -65,10 +65,10 @@ pub struct Ethereum {
 impl Ethereum {
     /// Access the Ethereum blockchain through an RPC API.
     ///
-    /// # Panics 
+    /// # Panics
     ///
-    /// Since this type is essential for the program this method will panic on any initialization
-    /// error.
+    /// Since this type is essential for the program this method will panic on
+    /// any initialization error.
     pub async fn new(
         rpc: Rpc,
         addresses: contracts::Addresses,

--- a/crates/driver/src/infra/blockchain/mod.rs
+++ b/crates/driver/src/infra/blockchain/mod.rs
@@ -64,26 +64,33 @@ pub struct Ethereum {
 
 impl Ethereum {
     /// Access the Ethereum blockchain through an RPC API.
+    ///
+    /// # Panics 
+    ///
+    /// Since this type is essential for the program this method will panic on any initialization
+    /// error.
     pub async fn new(
         rpc: Rpc,
         addresses: contracts::Addresses,
         gas: Arc<GasPriceEstimator>,
-    ) -> Result<Self, Error> {
+    ) -> Self {
         let Rpc { web3, network } = rpc;
-        let contracts = Contracts::new(&web3, &network.id, addresses).await?;
+        let contracts = Contracts::new(&web3, &network.id, addresses)
+            .await
+            .expect("could not initialize important smart contracts");
 
-        Ok(Self {
+        Self {
             current_block: ethrpc::current_block::current_block_stream(
                 Arc::new(web3.clone()),
                 std::time::Duration::from_millis(500),
             )
             .await
-            .unwrap(),
+            .expect("couldn't initialize current block stream"),
             web3,
             network,
             contracts,
             gas,
-        })
+        }
     }
 
     pub fn network(&self) -> &Network {

--- a/crates/driver/src/run.rs
+++ b/crates/driver/src/run.rs
@@ -133,9 +133,7 @@ async fn ethereum(config: &infra::Config, ethrpc: blockchain::Rpc) -> Ethereum {
             .await
             .expect("initialize gas price estimator"),
     );
-    Ethereum::new(ethrpc, config.contracts, gas)
-        .await
-        .expect("initialize ethereum RPC API")
+    Ethereum::new(ethrpc, config.contracts, gas).await
 }
 
 fn solvers(config: &config::Config, eth: &Ethereum) -> Vec<Solver> {

--- a/crates/driver/src/tests/setup/mod.rs
+++ b/crates/driver/src/tests/setup/mod.rs
@@ -645,7 +645,7 @@ impl Setup {
     }
 
     fn deadline(&self) -> chrono::DateTime<chrono::Utc> {
-        time::now() + chrono::Duration::days(30)
+        time::now() + chrono::Duration::seconds(2)
     }
 }
 

--- a/crates/driver/src/tests/setup/solver.rs
+++ b/crates/driver/src/tests/setup/solver.rs
@@ -208,8 +208,7 @@ impl Solver {
             },
             gas,
         )
-        .await
-        .unwrap();
+        .await;
         let state = Arc::new(Mutex::new(StateInner { called: false }));
         let app = axum::Router::new()
         .route(

--- a/crates/e2e/src/setup/services.rs
+++ b/crates/e2e/src/setup/services.rs
@@ -88,6 +88,7 @@ impl<'a> Services<'a> {
             "--auction-update-interval=1".to_string(),
             format!("--ethflow-contract={:?}", self.contracts.ethflow.address()),
             "--skip-event-sync=true".to_string(),
+            "--solve-deadline=2".to_string(),
         ]
         .into_iter()
         .chain(self.api_autopilot_solver_arguments())


### PR DESCRIPTION
# Description
Fixes #2007. The preferred solution described in that issue was not straight forward to implement.
It expected the `autopilot` to call `/reveal` from the highest scoring solution to the lowest scoring one to simulate it in order to avoid cases where a solver wins the auction with a solution that would revert by now.
The issue was that this requires the `autopilot` to know the address of every solver which would be a significant change.

Instead this PR implements a strategy on the `driver` side that a rational actor would be expected to follow as well.
All solvers know when they have to return a solution at the latest. Because a solution can be more accurate the closer it was computed to the time it is supposed to be executed it makes sense for all solvers to delay their response as much as possible (something might change in the mean time which might enable an even better solution).
This deadline gets propagated to the `solver` engine so ideally it would take as much time computing the optimal solution as possible.
If the solver returns earlier (like some currently do) it still makes sense to assume that other solvers will submit their solution at a later point in time.
In that case the only reasonable action for the `driver` is to wait until the deadline approaches and continuously re-simulate the computed solution whenever a new block gets detected. If in the meantime the solution would start to revert the `driver` would then withhold the computed solution to not accidentally win the auction and get slashed for not submitting it on-chain.

# Changes
`driver` waits until deadline before returning the solution on `/solve` and checks whether it's still viable on every new block. It also updates the score in case the solution still simulates but becomes better or worse (gas usage might change).
Also slightly adjusted to `Ethereum::new()` to panic on any init error since we can't handle those errors anyway because the type is essential to the program.

## How to test
This can be tested by a new e2e test which I would like to implement in a follow up PR when existing e2e tests don't break.