### PR TITLE
Dont reset node during test

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -73,7 +73,7 @@ jobs:
       - uses: yu-ichiro/spin-up-docker-compose-action@v1
         with:
           file: docker-compose.yaml
-          up-opts: -d db migrations chain
+          up-opts: -d db migrations
       - run: cargo test -p e2e local_node -- --ignored --test-threads 1 --nocapture
 
   test-driver:

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -66,6 +66,7 @@ jobs:
       CARGO_PROFILE_TEST_DEBUG: 0
     steps:
       - uses: actions/checkout@v3
+      - uses: foundry-rs/foundry-toolchain@v1
       - uses: Swatinem/rust-cache@v2
       # Start the build process in the background. The following cargo test command will automatically
       # wait for the build process to be done before proceeding.

--- a/crates/e2e/src/nodes/forked_node.rs
+++ b/crates/e2e/src/nodes/forked_node.rs
@@ -1,48 +1,10 @@
 use {
-    super::TestNode,
     ethcontract::H160,
-    reqwest::{IntoUrl, Url},
+    reqwest::Url,
     serde_json::json,
     std::fmt::Debug,
     web3::{api::Namespace, helpers::CallFuture, Transport},
 };
-
-pub struct Forker<T> {
-    forked_node_api: ForkedNodeApi<T>,
-    fork_url: Url,
-}
-
-impl<T: Transport> Forker<T> {
-    pub async fn new(web3: &web3::Web3<T>, solver_address: H160, fork_url: impl IntoUrl) -> Self {
-        let fork_url = fork_url.into_url().expect("Invalid fork URL");
-
-        let forked_node_api = web3.api::<ForkedNodeApi<_>>();
-        forked_node_api
-            .fork(&fork_url)
-            .await
-            .expect("Test network must support anvil_reset");
-
-        forked_node_api
-            .impersonate(&solver_address)
-            .await
-            .expect("Test network must support anvil_impersonateAccount");
-
-        Self {
-            forked_node_api,
-            fork_url,
-        }
-    }
-}
-
-#[async_trait::async_trait(?Send)]
-impl<T: Transport> TestNode for Forker<T> {
-    async fn reset(&self) {
-        self.forked_node_api
-            .fork(&self.fork_url)
-            .await
-            .expect("Test network must support anvil_reset");
-    }
-}
 
 #[derive(Debug, Clone)]
 pub struct ForkedNodeApi<T> {

--- a/crates/e2e/src/nodes/local_node.rs
+++ b/crates/e2e/src/nodes/local_node.rs
@@ -1,39 +1,9 @@
 use {
-    super::TestNode,
     chrono::{DateTime, Utc},
     ethcontract::{H160, U256},
     std::fmt::Debug,
     web3::{api::Namespace, helpers::CallFuture, Transport},
 };
-
-pub struct Resetter<T> {
-    test_node_api: TestNodeApi<T>,
-    snapshot_id: U256,
-}
-
-impl<T: Transport> Resetter<T> {
-    pub async fn new(web3: &web3::Web3<T>) -> Self {
-        let test_node_api = web3.api::<TestNodeApi<_>>();
-        let snapshot_id = test_node_api
-            .snapshot()
-            .await
-            .expect("Test network must support evm_snapshot");
-        Self {
-            test_node_api,
-            snapshot_id,
-        }
-    }
-}
-
-#[async_trait::async_trait(?Send)]
-impl<T: Transport> TestNode for Resetter<T> {
-    async fn reset(&self) {
-        self.test_node_api
-            .revert(&self.snapshot_id)
-            .await
-            .expect("Test network must support evm_revert");
-    }
-}
 
 #[derive(Debug, Clone)]
 pub struct TestNodeApi<T> {

--- a/crates/e2e/src/nodes/mod.rs
+++ b/crates/e2e/src/nodes/mod.rs
@@ -1,9 +1,113 @@
 pub mod forked_node;
 pub mod local_node;
 
+/// The default node URL that should be used for e2e tests.
 pub const NODE_HOST: &str = "http://127.0.0.1:8545";
 
-#[async_trait::async_trait(?Send)]
-pub trait TestNode {
-    async fn reset(&self);
+/// A blockchain node for development purposes. Dropping this type will
+/// terminate the node.
+pub struct Node {
+    process: Option<tokio::process::Child>,
+}
+
+impl Node {
+    /// Spawns a new node that is forked from the given URL. It also
+    /// impersonates the given `solver` address.
+    pub async fn forked(fork: impl reqwest::IntoUrl) -> Self {
+        Self::spawn_process(&["--port", "8545", "--fork-url", fork.as_str()]).await
+    }
+
+    /// Spawns a new local test net with some default parameters.
+    pub async fn new() -> Self {
+        Self::spawn_process(&[
+            "--port",
+            "8545",
+            "--gas-price",
+            "1",
+            "--gas-limit",
+            "10000000",
+            "--base-fee",
+            "0",
+            "--balance",
+            "1000000",
+            "--chain-id",
+            "1",
+            "--timestamp",
+            "1577836800",
+        ])
+        .await
+    }
+
+    /// Spawn a new node instance using the list of given arguments.
+    async fn spawn_process(args: &[&str]) -> Self {
+        use tokio::io::AsyncBufReadExt as _;
+
+        // Allow using some custom logic to spawn `anvil` by setting `ANVIL_COMMAND`.
+        // For example if you set up a command that spins up a docker container.
+        let command = std::env::var("ANVIL_COMMAND").unwrap_or("anvil".to_string());
+
+        let mut process = tokio::process::Command::new(command)
+            .args(args)
+            .stdout(std::process::Stdio::piped())
+            .spawn()
+            .unwrap();
+
+        let stdout = process.stdout.take().unwrap();
+        let (sender, receiver) = tokio::sync::oneshot::channel::<String>();
+
+        tokio::task::spawn(async move {
+            let mut sender = Some(sender);
+            const NEEDLE: &str = "Listening on ";
+            let mut reader = tokio::io::BufReader::new(stdout).lines();
+            while let Some(line) = reader.next_line().await.unwrap() {
+                tracing::trace!(line);
+                if let Some(addr) = line.strip_prefix(NEEDLE) {
+                    match sender.take() {
+                        Some(sender) => sender.send(format!("http://{addr}")).unwrap(),
+                        None => tracing::error!(addr, "detected multiple anvil endpoints"),
+                    }
+                }
+            }
+        });
+
+        let _url = tokio::time::timeout(tokio::time::Duration::from_secs(1), receiver)
+            .await
+            .expect("finding anvil URL timed out")
+            .unwrap();
+        Self {
+            process: Some(process),
+        }
+    }
+
+    /// Most reliable way to kill the process. If you get the chance to manually
+    /// clean up the [`Node`] do it because the [`Drop::drop`]
+    /// implementation can not be as reliable due to missing async support.
+    pub async fn kill(&mut self) {
+        let mut process = match self.process.take() {
+            Some(node) => node,
+            // Somebody already called `Node::kill()`
+            None => return,
+        };
+
+        if let Err(err) = process.kill().await {
+            tracing::error!(?err, "failed to kill node process");
+        }
+    }
+}
+
+impl Drop for Node {
+    fn drop(&mut self) {
+        let mut process = match self.process.take() {
+            Some(process) => process,
+            // Somebody already called `Node::kill()`
+            None => return,
+        };
+
+        // This only sends SIGKILL to the process but does not wait for the process to
+        // actually terminate. But since `anvil` is fairly well behaved that
+        // should be good enough.
+        if let Err(err) = process.start_kill() {
+            tracing::error!(?err, "failed to kill node process");
+        }
+    }
 }

--- a/crates/e2e/src/nodes/mod.rs
+++ b/crates/e2e/src/nodes/mod.rs
@@ -11,8 +11,7 @@ pub struct Node {
 }
 
 impl Node {
-    /// Spawns a new node that is forked from the given URL. It also
-    /// impersonates the given `solver` address.
+    /// Spawns a new node that is forked from the given URL.
     pub async fn forked(fork: impl reqwest::IntoUrl) -> Self {
         Self::spawn_process(&["--port", "8545", "--fork-url", fork.as_str()]).await
     }
@@ -105,7 +104,7 @@ impl Drop for Node {
 
         // This only sends SIGKILL to the process but does not wait for the process to
         // actually terminate. But since `anvil` is fairly well behaved that
-        // should be good enough.
+        // should be good enough in many cases.
         if let Err(err) = process.start_kill() {
             tracing::error!(?err, "failed to kill node process");
         }

--- a/crates/e2e/src/setup/mod.rs
+++ b/crates/e2e/src/setup/mod.rs
@@ -14,7 +14,7 @@ use {
         io::Write,
         iter::empty,
         panic::{self, AssertUnwindSafe},
-        sync::Mutex,
+        sync::{Arc, Mutex},
         time::Duration,
     },
     tempfile::TempPath,
@@ -148,16 +148,15 @@ async fn run<F, Fut, T>(
     // it but rather in the locked state.
     let _lock = NODE_MUTEX.lock();
 
+    let node = Arc::new(Mutex::new(Some(Node::new().await)));
+    let node_panic_handle = node.clone();
+    observe::panic_hook::prepend_panic_handler(Box::new(move |_| {
+        // Drop node in panic handler because `.catch_unwind()` does not catch all
+        // panics
+        let _ = node_panic_handle.lock().unwrap().take();
+    }));
     let http = create_test_transport(NODE_HOST);
     let web3 = Web3::new(http);
-
-    let test_node: Box<dyn TestNode> =
-        if let (Some(fork_url), Some(solver_address)) = (fork_url, solver_address) {
-            Box::new(Forker::new(&web3, solver_address, fork_url).await)
-        } else {
-            Box::new(Resetter::new(&web3).await)
-        };
-
     services::clear_database().await;
 
     // Hack: the closure may actually be unwind unsafe; moreover, `catch_unwind`
@@ -166,10 +165,107 @@ async fn run<F, Fut, T>(
     // is supposed to be used in a test environment.
     let result = AssertUnwindSafe(f(web3.clone())).catch_unwind().await;
 
-    test_node.reset().await;
+    let node = node.lock().unwrap().take();
+    if let Some(mut node) = node {
+        node.kill().await;
+    }
     services::clear_database().await;
 
     if let Err(err) = result {
         panic::resume_unwind(err);
+    }
+}
+
+/// A blockchain node for development purposes. Dropping this type will
+/// terminate the node.
+struct Node {
+    process: Option<tokio::process::Child>,
+}
+
+impl Node {
+    /// Spawn a new node instance.
+    async fn new() -> Self {
+        use tokio::io::AsyncBufReadExt as _;
+
+        // Allow using some custom logic to spawn `anvil` by setting `ANVIL_COMMAND`.
+        // For example if you set up a command that spins up a docker container.
+        let command = std::env::var("ANVIL_COMMAND").unwrap_or("anvil".to_string());
+
+        let mut process = tokio::process::Command::new(command)
+            .arg("--port")
+            .arg("8545")
+            .arg("--gas-price")
+            .arg("1")
+            .arg("--gas-limit")
+            .arg("10000000")
+            .arg("--base-fee")
+            .arg("0")
+            .arg("--balance")
+            .arg("1000000")
+            .arg("--chain-id")
+            .arg("1")
+            .arg("--timestamp")
+            .arg("1577836800")
+            .stdout(std::process::Stdio::piped())
+            .spawn()
+            .unwrap();
+
+        let stdout = process.stdout.take().unwrap();
+        let (sender, receiver) = tokio::sync::oneshot::channel::<String>();
+
+        tokio::task::spawn(async move {
+            let mut sender = Some(sender);
+            const NEEDLE: &str = "Listening on ";
+            let mut reader = tokio::io::BufReader::new(stdout).lines();
+            while let Some(line) = reader.next_line().await.unwrap() {
+                tracing::trace!(line);
+                if let Some(addr) = line.strip_prefix(NEEDLE) {
+                    match sender.take() {
+                        Some(sender) => sender.send(format!("http://{addr}")).unwrap(),
+                        None => tracing::error!(addr, "detected multiple anvil endpoints"),
+                    }
+                }
+            }
+        });
+
+        let _url = tokio::time::timeout(tokio::time::Duration::from_secs(1), receiver)
+            .await
+            .expect("finding anvil URL timed out")
+            .unwrap();
+        Self {
+            process: Some(process),
+        }
+    }
+
+    /// Most reliable way to kill the process. If you get the chance to manually
+    /// clean up the [`Node`] do it because the [`Drop::drop`]
+    /// implementation can not be as reliable due to missing async support.
+    async fn kill(&mut self) {
+        let mut process = match self.process.take() {
+            Some(node) => node,
+            // Somebody already called `Node::kill()`
+            None => return,
+        };
+
+        if let Err(err) = process.kill().await {
+            tracing::error!(?err, "failed to kill node process");
+        }
+    }
+}
+
+impl Drop for Node {
+    fn drop(&mut self) {
+        let mut process = match self.process.take() {
+            Some(process) => process,
+            // Somebody already called `Node::kill()`
+            None => return,
+        };
+
+        // This only sends SIGKILL to the process but does not wait for the process to
+        // actually terminate. But since `anvil` is fairly well behaved that
+        // should be good enough.
+        if let Err(err) = process.start_kill() {
+            tracing::error!("failed to kill anvil: {err:?}");
+        }
     }
 }

--- a/crates/observe/src/panic_hook.rs
+++ b/crates/observe/src/panic_hook.rs
@@ -17,6 +17,19 @@ pub fn install() {
     std::panic::set_hook(Box::new(new_hook));
 }
 
+/// Installs a panic handler that executes [`handler`] plus whatever panic
+/// handler was already set up.
+/// This can be useful to make absolutely sure to clean up some resources like
+/// running processes on a panic.
+pub fn prepend_panic_handler(handler: Box<dyn Fn(&std::panic::PanicInfo) + Send + Sync>) {
+    let previous_hook = std::panic::take_hook();
+    let new_hook = move |info: &std::panic::PanicInfo| {
+        handler(info);
+        previous_hook(info);
+    };
+    std::panic::set_hook(Box::new(new_hook));
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -33,14 +33,5 @@ services:
         source: ./database/sql/
         target: /flyway/sql
 
-  chain:
-    image: ghcr.io/foundry-rs/foundry:latest
-    restart: always
-    entrypoint: /usr/local/bin/anvil --gas-price 1 --gas-limit 10000000 --base-fee 0 --balance 1000000 --chain-id 1 --timestamp 1577836800
-    environment:
-      - ANVIL_IP_ADDR=0.0.0.0
-    ports:
-      - 8545:8545
-
 volumes:
   postgres:


### PR DESCRIPTION
# Description
Ever since we replaced `hardhat` with `anvil` we got flaky tests.
The issue seems to be related to deadlocks inside `anvil`. It's possible that these deadlocks could be related to running the same node instance for all tests and resetting it over and over again.

# Changes
Drop `anvil` from the `docker-compose` file and instead spawn a fresh `anvil` instance for every `e2e` test.

## How to test
Rerun CI a couple of times and :pray: that we don't see flaky errors?