### PR TITLE
Use nextest for CI

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -33,10 +33,12 @@ jobs:
       # Shrink artifact size by not including debug info. Makes build faster and shrinks cache.
       CARGO_PROFILE_DEV_DEBUG: 0
       CARGO_PROFILE_TEST_DEBUG: 0
+      CARGO_TERM_COLOR: always
     steps:
       - uses: actions/checkout@v3
       - uses: Swatinem/rust-cache@v2
-      - run: cargo test
+      - uses: taiki-e/install-action@nextest
+      - run: cargo nextest run
 
   test-db:
     timeout-minutes: 60
@@ -45,6 +47,7 @@ jobs:
       # Shrink artifact size by not including debug info. Makes build faster and shrinks cache.
       CARGO_PROFILE_DEV_DEBUG: 0
       CARGO_PROFILE_TEST_DEBUG: 0
+      CARGO_TERM_COLOR: always
     steps:
       - uses: actions/checkout@v3
       - uses: Swatinem/rust-cache@v2
@@ -52,10 +55,11 @@ jobs:
       # wait for the build process to be done before proceeding.
       - run: cargo build -p orderbook -p database --tests &
       - uses: yu-ichiro/spin-up-docker-compose-action@v1
+      - uses: taiki-e/install-action@nextest
         with:
           file: docker-compose.yaml
           up-opts: -d db migrations
-      - run: cargo test postgres -p orderbook -p database -- --ignored --test-threads 1
+      - run: cargo nextest run postgres -p orderbook -p database --test-threads 1 --run-ignored ignored-only
 
   test-local-node:
     timeout-minutes: 60
@@ -64,6 +68,7 @@ jobs:
       # Shrink artifact size by not including debug info. Makes build faster and shrinks cache.
       CARGO_PROFILE_DEV_DEBUG: 0
       CARGO_PROFILE_TEST_DEBUG: 0
+      CARGO_TERM_COLOR: always
     steps:
       - uses: actions/checkout@v3
       - uses: Swatinem/rust-cache@v2
@@ -71,10 +76,11 @@ jobs:
       # wait for the build process to be done before proceeding.
       - run: cargo build -p e2e --tests &
       - uses: yu-ichiro/spin-up-docker-compose-action@v1
+      - uses: taiki-e/install-action@nextest
         with:
           file: docker-compose.yaml
           up-opts: -d db migrations chain
-      - run: cargo test -p e2e local_node -- --ignored --test-threads 1 --nocapture
+      - run: cargo nextest run -p e2e local_node --test-threads 1 --failure-output final --run-ignored ignored-only
 
   test-driver:
     timeout-minutes: 60
@@ -83,14 +89,16 @@ jobs:
       # Shrink artifact size by not including debug info. Makes build faster and shrinks cache.
       CARGO_PROFILE_DEV_DEBUG: 0
       CARGO_PROFILE_TEST_DEBUG: 0
+      CARGO_TERM_COLOR: always
     steps:
       - uses: actions/checkout@v3
       - uses: foundry-rs/foundry-toolchain@v1
       - uses: Swatinem/rust-cache@v2
+      - uses: taiki-e/install-action@nextest
       # Build the driver's tests.
       - run: cargo build -p driver --tests
       # Don't spawn any docker containers. The driver's tests will spawn anvil itself.
-      - run: cargo test -p driver -- --ignored
+      - run: cargo nextest run -p driver --run-ignored ignored-only
 
   openapi:
     timeout-minutes: 60

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -54,8 +54,8 @@ jobs:
       # Start the build process in the background. The following cargo test command will automatically
       # wait for the build process to be done before proceeding.
       - run: cargo build -p orderbook -p database --tests &
-      - uses: yu-ichiro/spin-up-docker-compose-action@v1
       - uses: taiki-e/install-action@nextest
+      - uses: yu-ichiro/spin-up-docker-compose-action@v1
         with:
           file: docker-compose.yaml
           up-opts: -d db migrations
@@ -75,8 +75,8 @@ jobs:
       # Start the build process in the background. The following cargo test command will automatically
       # wait for the build process to be done before proceeding.
       - run: cargo build -p e2e --tests &
-      - uses: yu-ichiro/spin-up-docker-compose-action@v1
       - uses: taiki-e/install-action@nextest
+      - uses: yu-ichiro/spin-up-docker-compose-action@v1
         with:
           file: docker-compose.yaml
           up-opts: -d db migrations chain

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -38,6 +38,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: Swatinem/rust-cache@v2
       - uses: taiki-e/install-action@nextest
+      - run: cargo build --tests
       - run: cargo nextest run
 
   test-db:

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -81,7 +81,7 @@ jobs:
       - uses: yu-ichiro/spin-up-docker-compose-action@v1
         with:
           file: docker-compose.yaml
-          up-opts: -d db migrations chain
+          up-opts: -d db migrations
       - run: cargo nextest run -p e2e local_node --test-threads 1 --failure-output final --run-ignored ignored-only
 
   test-driver:


### PR DESCRIPTION
# Description
[`nextest`](https://nexte.st/) is overall nicer than the built-in `cargo test`. It's faster, has more knobs to tweak and specifically built with CI in mind.

# Changes
CI should be running the same tests. The only difference is that some test jobs no longer output all the logs but only the logs of failed tests which I find pretty useful because those logs can get very noisy.

## How to test
inspect new [output](https://github.com/cowprotocol/services/actions/runs/6638204181/job/18034529435?pr=2014) of the CI jobs