### PR TITLE
Move duplicated ids check to competition::solve

### DIFF
--- a/crates/driver/src/domain/competition/mod.rs
+++ b/crates/driver/src/domain/competition/mod.rs
@@ -68,6 +68,18 @@ impl Competition {
             .solve(auction, &liquidity, auction.deadline().timeout()?)
             .await?;
 
+        // Discard solutions that don't have unique ID.
+        let mut ids = HashSet::new();
+        let solutions = solutions.into_iter().filter(|solution| {
+            if !ids.insert(solution.id()) {
+                observe::duplicated_solution_id(self.solver.name(), solution.id());
+                notify::duplicated_solution_id(&self.solver, auction.id(), solution.id());
+                false
+            } else {
+                true
+            }
+        });
+
         // Empty solutions aren't useful, so discard them.
         let solutions = solutions.into_iter().filter(|solution| {
             if solution.is_empty() {

--- a/crates/driver/src/domain/competition/mod.rs
+++ b/crates/driver/src/domain/competition/mod.rs
@@ -81,7 +81,7 @@ impl Competition {
         });
 
         // Empty solutions aren't useful, so discard them.
-        let solutions = solutions.into_iter().filter(|solution| {
+        let solutions = solutions.filter(|solution| {
             if solution.is_empty() {
                 observe::empty_solution(self.solver.name(), solution.id());
                 notify::empty_solution(&self.solver, auction.id(), solution.id());

--- a/crates/driver/src/infra/observe/mod.rs
+++ b/crates/driver/src/infra/observe/mod.rs
@@ -61,8 +61,12 @@ pub fn fetching_liquidity_failed(err: &boundary::Error) {
     tracing::warn!(?err, "failed to fetch liquidity");
 }
 
-pub fn duplicated_solution_id(id: solution::Id) {
-    tracing::warn!(?id, "duplicated solution id");
+pub fn duplicated_solution_id(solver: &solver::Name, id: solution::Id) {
+    tracing::debug!(?id, "discarded solution: duplicated solution id");
+    metrics::get()
+        .dropped_solutions
+        .with_label_values(&[solver.as_str(), "DuplicatedSolutionId"])
+        .inc();
 }
 
 /// Observe the solutions returned by the solver.

--- a/crates/driver/src/infra/observe/mod.rs
+++ b/crates/driver/src/infra/observe/mod.rs
@@ -62,10 +62,10 @@ pub fn fetching_liquidity_failed(err: &boundary::Error) {
 }
 
 pub fn duplicated_solution_id(solver: &solver::Name, id: solution::Id) {
-    tracing::debug!(?id, "discarded solution: duplicated solution id");
+    tracing::debug!(?id, "discarded solution: duplicated id");
     metrics::get()
         .dropped_solutions
-        .with_label_values(&[solver.as_str(), "DuplicatedSolutionId"])
+        .with_label_values(&[solver.as_str(), "DuplicateId"])
         .inc();
 }
 
@@ -94,10 +94,10 @@ pub fn encoding(id: solution::Id) {
 
 /// Observe that settlement encoding failed.
 pub fn encoding_failed(solver: &solver::Name, id: solution::Id, err: &solution::Error) {
-    tracing::info!(?id, ?err, "discarded solution: settlement encoding failed");
+    tracing::info!(?id, ?err, "discarded solution: settlement encoding");
     metrics::get()
         .dropped_solutions
-        .with_label_values(&[solver.as_str(), "SettlementEncodingFailed"])
+        .with_label_values(&[solver.as_str(), "SettlementEncoding"])
         .inc();
 }
 
@@ -131,10 +131,10 @@ pub fn scoring(settlement: &Settlement) {
 
 /// Observe that scoring failed.
 pub fn scoring_failed(solver: &solver::Name, err: &score::Error) {
-    tracing::info!(%solver, ?err, "discarded solution: scoring failed");
+    tracing::info!(%solver, ?err, "discarded solution: scoring");
     metrics::get()
         .dropped_solutions
-        .with_label_values(&[solver.as_str(), "ScoringFailed"])
+        .with_label_values(&[solver.as_str(), "Scoring"])
         .inc();
 }
 

--- a/crates/driver/src/infra/solver/mod.rs
+++ b/crates/driver/src/infra/solver/mod.rs
@@ -13,7 +13,6 @@ use {
         infra::blockchain::Ethereum,
         util,
     },
-    std::collections::HashSet,
     tap::TapFallible,
     thiserror::Error,
     tracing::Instrument,
@@ -170,16 +169,6 @@ impl Solver {
         let res: dto::Solutions = serde_json::from_str(&res)
             .tap_err(|err| tracing::warn!(res, ?err, "failed to parse solver response"))?;
         let solutions = res.into_domain(auction, liquidity, weth, self.clone())?;
-
-        // Ensure that solution IDs are unique.
-        let mut ids = HashSet::new();
-        for solution in &solutions {
-            if !ids.insert(solution.id()) {
-                super::observe::duplicated_solution_id(solution.id());
-                notify::duplicated_solution_id(self, auction.id(), solution.id());
-                return Err(Error::DuplicatedSolutionId);
-            }
-        }
 
         super::observe::solutions(&solutions);
         Ok(solutions)


### PR DESCRIPTION
# Description
Pretty fix: moves the check to main competition::solve where all the checks are done.

# Changes
- [ ] Solutions are filtered instead of failing early for all solutions.
- [ ] Added metric and fixed log for a check to be searchable with `discarded solution:` prefix