### PR TITLE
Colocation notify - solver engine timeout

### DIFF
--- a/crates/driver/src/domain/competition/mod.rs
+++ b/crates/driver/src/domain/competition/mod.rs
@@ -69,7 +69,6 @@ impl Competition {
             .await
             .tap_err(|err| {
                 if err.is_timeout() {
-                    observe::solver_timeout(self.solver.name(), auction.id());
                     notify::solver_timeout(&self.solver, auction.id());
                 }
             })?;

--- a/crates/driver/src/infra/notify/mod.rs
+++ b/crates/driver/src/infra/notify/mod.rs
@@ -9,8 +9,16 @@ pub use notification::{Kind, Notification, ScoreKind, Settlement};
 
 use crate::domain::{competition::score, eth, mempools::Error};
 
+pub fn solver_timeout(solver: &Solver, auction_id: Option<auction::Id>) {
+    solver.notify(auction_id, None, notification::Kind::Timeout);
+}
+
 pub fn empty_solution(solver: &Solver, auction_id: Option<auction::Id>, solution: solution::Id) {
-    solver.notify(auction_id, solution, notification::Kind::EmptySolution);
+    solver.notify(
+        auction_id,
+        Some(solution),
+        notification::Kind::EmptySolution,
+    );
 }
 
 pub fn scoring_failed(
@@ -44,7 +52,7 @@ pub fn scoring_failed(
         score::Error::Boundary(_) => return,
     };
 
-    solver.notify(auction_id, solution_id.unwrap(), notification);
+    solver.notify(auction_id, solution_id, notification);
 }
 
 pub fn encoding_failed(
@@ -57,14 +65,14 @@ pub fn encoding_failed(
         solution::Error::UntrustedInternalization(tokens) => {
             solver.notify(
                 auction_id,
-                solution_id,
+                Some(solution_id),
                 notification::Kind::NonBufferableTokensUsed(tokens.clone()),
             );
         }
         solution::Error::SolverAccountInsufficientBalance(required) => {
             solver.notify(
                 auction_id,
-                solution_id,
+                Some(solution_id),
                 notification::Kind::SolverAccountInsufficientBalance(*required),
             );
         }
@@ -97,7 +105,7 @@ pub fn executed(
 
     solver.notify(
         Some(auction_id),
-        solution_id.unwrap(),
+        solution_id,
         notification::Kind::Settled(kind),
     );
 }
@@ -109,7 +117,7 @@ pub fn duplicated_solution_id(
 ) {
     solver.notify(
         auction_id,
-        solution_id,
+        Some(solution_id),
         notification::Kind::DuplicatedSolutionId,
     );
 }

--- a/crates/driver/src/infra/notify/notification.rs
+++ b/crates/driver/src/infra/notify/notification.rs
@@ -10,7 +10,7 @@ use {
 #[derive(Debug)]
 pub struct Notification {
     pub auction_id: Option<auction::Id>,
-    pub solution_id: solution::Id,
+    pub solution_id: Option<solution::Id>,
     pub kind: Kind,
 }
 
@@ -19,6 +19,8 @@ pub type TokensUsed = BTreeSet<TokenAddress>;
 
 #[derive(Debug)]
 pub enum Kind {
+    /// Solver engine timed out.
+    Timeout,
     /// The solution doesn't contain any user orders.
     EmptySolution,
     /// Solution received from solver engine don't have unique id.

--- a/crates/driver/src/infra/observe/metrics.rs
+++ b/crates/driver/src/infra/observe/metrics.rs
@@ -16,9 +16,6 @@ pub struct Metrics {
     /// The results of the quoting process.
     #[metric(labels("solver", "result"))]
     pub quotes: prometheus::IntCounterVec,
-    /// Number of timeouts per solver engine.
-    #[metric(labels("solver"))]
-    pub timeout: prometheus::IntCounterVec,
 }
 
 /// Setup the metrics registry.

--- a/crates/driver/src/infra/observe/metrics.rs
+++ b/crates/driver/src/infra/observe/metrics.rs
@@ -16,6 +16,9 @@ pub struct Metrics {
     /// The results of the quoting process.
     #[metric(labels("solver", "result"))]
     pub quotes: prometheus::IntCounterVec,
+    /// Number of timeouts per solver engine.
+    #[metric(labels("solver"))]
+    pub timeout: prometheus::IntCounterVec,
 }
 
 /// Setup the metrics registry.

--- a/crates/driver/src/infra/observe/mod.rs
+++ b/crates/driver/src/infra/observe/mod.rs
@@ -10,7 +10,6 @@ use {
         domain::{
             competition::{
                 self,
-                auction,
                 score,
                 solution::{self, Settlement},
                 Auction,
@@ -60,14 +59,6 @@ pub fn fetched_liquidity(liquidity: &[Liquidity]) {
 /// Observe that fetching liquidity failed.
 pub fn fetching_liquidity_failed(err: &boundary::Error) {
     tracing::warn!(?err, "failed to fetch liquidity");
-}
-
-pub fn solver_timeout(solver: &solver::Name, auction_id: Option<auction::Id>) {
-    tracing::debug!(%solver, auction_id = %auction_id.unwrap_or(auction::Id(0)), "solver engine timeout");
-    metrics::get()
-        .timeout
-        .with_label_values(&[solver.as_str()])
-        .inc();
 }
 
 pub fn duplicated_solution_id(solver: &solver::Name, id: solution::Id) {

--- a/crates/driver/src/infra/solver/dto/notification.rs
+++ b/crates/driver/src/infra/solver/dto/notification.rs
@@ -15,13 +15,14 @@ use {
 impl Notification {
     pub fn new(
         auction_id: Option<auction::Id>,
-        solution_id: solution::Id,
+        solution_id: Option<solution::Id>,
         kind: notify::Kind,
     ) -> Self {
         Self {
             auction_id: auction_id.as_ref().map(ToString::to_string),
-            solution_id: solution_id.0,
+            solution_id: solution_id.map(|id| id.0),
             kind: match kind {
+                notify::Kind::Timeout => Kind::Timeout,
                 notify::Kind::EmptySolution => Kind::EmptySolution,
                 notify::Kind::ScoringFailed(notify::ScoreKind::ObjectiveValueNonPositive) => {
                     Kind::ScoringFailed(ScoreKind::ObjectiveValueNonPositive)
@@ -70,7 +71,7 @@ impl Notification {
 #[serde(rename_all = "camelCase")]
 pub struct Notification {
     auction_id: Option<String>,
-    solution_id: u64,
+    solution_id: Option<u64>,
     kind: Kind,
 }
 
@@ -78,6 +79,7 @@ pub struct Notification {
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "lowercase")]
 pub enum Kind {
+    Timeout,
     EmptySolution,
     DuplicatedSolutionId,
     ScoringFailed(ScoreKind),

--- a/crates/driver/src/infra/solver/mod.rs
+++ b/crates/driver/src/infra/solver/mod.rs
@@ -178,7 +178,7 @@ impl Solver {
     pub fn notify(
         &self,
         auction_id: Option<auction::Id>,
-        solution_id: solution::Id,
+        solution_id: Option<solution::Id>,
         kind: notify::Kind,
     ) {
         let body =
@@ -202,8 +202,15 @@ pub enum Error {
     Http(#[from] util::http::Error),
     #[error("JSON deserialization error: {0:?}")]
     Deserialize(#[from] serde_json::Error),
-    #[error("solution id is not unique")]
-    DuplicatedSolutionId,
     #[error("solver dto error: {0}")]
     Dto(#[from] dto::Error),
+}
+
+impl Error {
+    pub fn is_timeout(&self) -> bool {
+        match self {
+            Self::Http(util::http::Error::Response(err)) => err.is_timeout(),
+            _ => false,
+        }
+    }
 }

--- a/crates/solvers/src/api/routes/notify/dto/notification.rs
+++ b/crates/solvers/src/api/routes/notify/dto/notification.rs
@@ -17,8 +17,9 @@ impl Notification {
                 Some(id) => auction::Id::Solve(id),
                 None => auction::Id::Quote,
             },
-            solution_id: self.solution_id.into(),
+            solution_id: self.solution_id.map(Into::into),
             kind: match &self.kind {
+                Kind::Timeout => notification::Kind::Timeout,
                 Kind::EmptySolution => notification::Kind::EmptySolution,
                 Kind::ScoringFailed(ScoreKind::ObjectiveValueNonPositive) => {
                     notification::Kind::ScoringFailed(
@@ -78,7 +79,7 @@ impl Notification {
 pub struct Notification {
     #[serde_as(as = "Option<DisplayFromStr>")]
     auction_id: Option<i64>,
-    solution_id: u64,
+    solution_id: Option<u64>,
     kind: Kind,
 }
 
@@ -86,6 +87,7 @@ pub struct Notification {
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum Kind {
+    Timeout,
     EmptySolution,
     DuplicatedSolutionId,
     ScoringFailed(ScoreKind),

--- a/crates/solvers/src/domain/notification.rs
+++ b/crates/solvers/src/domain/notification.rs
@@ -12,7 +12,7 @@ use {
 #[derive(Debug)]
 pub struct Notification {
     pub auction_id: auction::Id,
-    pub solution_id: solution::Id,
+    pub solution_id: Option<solution::Id>,
     pub kind: Kind,
 }
 
@@ -22,6 +22,7 @@ pub type TokensUsed = BTreeSet<TokenAddress>;
 /// All types of notifications solvers can be informed about.
 #[derive(Debug)]
 pub enum Kind {
+    Timeout,
     EmptySolution,
     DuplicatedSolutionId,
     ScoringFailed(ScoreKind),

--- a/crates/solvers/src/domain/solution.rs
+++ b/crates/solvers/src/domain/solution.rs
@@ -7,7 +7,7 @@ use {
     std::{collections::HashMap, slice},
 };
 
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Copy, Clone)]
 pub struct Id(pub u64);
 
 impl From<u64> for Id {


### PR DESCRIPTION
# Description
Populates `SolverRejectionReason::RunError(SolverRunError::Timeout)`.
The easiest way to implement this was to use already handled timeout from the http request sent from `driver` to `solvers`.

# Changes
<!-- List of detailed changes (how the change is accomplished) -->

- [ ] Added notify call in case solver engine timeouts (this is mostly needed for `legacy` solvers, others (`baseline`, `naive`, `dex`) handle timeout themselves). 
- [ ] `Solution_id` made optional since there is no sense to define it for `Timeout`.
- [ ] Removed some old unnecessary code for duplicated ids