### PR TITLE
build /notify URL respecting multiple path segments

### DIFF
--- a/crates/shared/src/http_solver.rs
+++ b/crates/shared/src/http_solver.rs
@@ -230,7 +230,9 @@ impl HttpSolverApi for DefaultHttpSolverApi {
     }
 
     fn notify_auction_result(&self, auction_id: AuctionId, result: model::AuctionResult) {
-        let mut url = crate::url::join(&self.base, "notify");
+        let mut url = crate::url::join(&self.base, &self.solve_path);
+        // `/notify` should be a sibling of the `/solve` endpoint
+        url.path_segments_mut().unwrap().pop().push("notify");
 
         let client = self.client.clone();
         let config_api_key = self.config.api_key.clone();


### PR DESCRIPTION
# Description
The current logic to build the `/notify` URL doesn't handle URLs that contain multiple path segments correctly.
Take this http solver URL for example:
`https://miep.cow.solver/1/solve?api_key=1234#row=3`
which consists of the base `https://miep.cow.solver` and the `solve_endpoint` `/1/solve?api_key=1234#row=3`.
The old logic would have computed the notify endpoint to be `https://miep.cow.solver/notify` whereas `https://miep.cow.solver/1/notify?api_key=1234#row=3` actually makes more sense. (`/notify` as a sibling to `/solve`).

# Changes
Always make `/notify` a sibling of `/solve` (including all query parameters and fragments).

## How to test
https://play.rust-lang.org/?version=stable&mode=debug&edition=2021&gist=5d4168862014d3876c28c19153b4267c