### PR TITLE
Colocation notify - ObjectiveValueNonPositive improve logging

### DIFF
--- a/crates/driver/src/domain/competition/score.rs
+++ b/crates/driver/src/domain/competition/score.rs
@@ -47,7 +47,7 @@ impl std::ops::Sub<GasCost> for Quality {
                 eth::NonZeroU256::new(self.0 - other.0 .0).unwrap(),
             ))
         } else {
-            Err(risk::Error::ObjectiveValueNonPositive)
+            Err(risk::Error::ObjectiveValueNonPositive(self, other))
         }
     }
 }
@@ -92,9 +92,13 @@ pub enum Error {
 pub mod risk {
     //! Contains functionality and error types for scores that are based on
     //! success probability.
+
     use {
-        super::Score,
-        crate::{boundary, domain::eth},
+        super::{Quality, Score},
+        crate::{
+            boundary,
+            domain::{eth, eth::GasCost},
+        },
     };
 
     impl Score {
@@ -146,8 +150,8 @@ pub mod risk {
         /// and protocol. Score calculator does not make sense for such
         /// solutions, since score calculator is expected to return
         /// value (0, ObjectiveValue]
-        #[error("objective value is non-positive")]
-        ObjectiveValueNonPositive,
+        #[error("objective value is non-positive, quality {0:?}, gas cost {1:?}")]
+        ObjectiveValueNonPositive(Quality, GasCost),
         #[error(transparent)]
         Boundary(#[from] boundary::Error),
     }

--- a/crates/driver/src/infra/notify/mod.rs
+++ b/crates/driver/src/infra/notify/mod.rs
@@ -43,9 +43,12 @@ pub fn scoring_failed(
         )) => notification::Kind::ScoringFailed(
             notification::ScoreKind::SuccessProbabilityOutOfRange(*success_probability),
         ),
-        score::Error::RiskAdjusted(score::risk::Error::ObjectiveValueNonPositive) => {
-            notification::Kind::ScoringFailed(notification::ScoreKind::ObjectiveValueNonPositive)
-        }
+        score::Error::RiskAdjusted(score::risk::Error::ObjectiveValueNonPositive(
+            quality,
+            gas_cost,
+        )) => notification::Kind::ScoringFailed(
+            notification::ScoreKind::ObjectiveValueNonPositive(*quality, *gas_cost),
+        ),
         score::Error::RiskAdjusted(score::risk::Error::Boundary(_)) => return,
         score::Error::Boundary(_) => return,
     };

--- a/crates/driver/src/infra/notify/notification.rs
+++ b/crates/driver/src/infra/notify/notification.rs
@@ -1,7 +1,7 @@
 use {
     crate::domain::{
         competition::{auction, score::Quality, solution, Score},
-        eth::{self, Ether, TokenAddress},
+        eth::{self, Ether, GasCost, TokenAddress},
     },
     std::collections::BTreeSet,
 };
@@ -53,11 +53,11 @@ pub enum ScoreKind {
     /// [0, 1]
     /// [ONLY APPLICABLE TO SCORES BASED ON SUCCESS PROBABILITY]
     SuccessProbabilityOutOfRange(f64),
-    /// Objective value is defined as surplus + fees - gas costs. Protocol
-    /// doesn't allow solutions that cost more than they bring to the users and
-    /// protocol.
+    /// Objective value is defined as quality (surplus + fees) - gas costs.
+    /// Protocol doesn't allow solutions that cost more than they bring to
+    /// the users and protocol.
     /// [ONLY APPLICABLE TO SCORES BASED ON SUCCESS PROBABILITY]
-    ObjectiveValueNonPositive,
+    ObjectiveValueNonPositive(Quality, GasCost),
 }
 
 type TransactionHash = eth::TxId;

--- a/crates/driver/src/infra/solver/dto/notification.rs
+++ b/crates/driver/src/infra/solver/dto/notification.rs
@@ -39,9 +39,13 @@ impl Notification {
                 )) => Kind::ScoringFailed(ScoreKind::SuccessProbabilityOutOfRange {
                     probability: success_probability,
                 }),
-                notify::Kind::ScoringFailed(notify::ScoreKind::ObjectiveValueNonPositive) => {
-                    Kind::ScoringFailed(ScoreKind::ObjectiveValueNonPositive)
-                }
+                notify::Kind::ScoringFailed(notify::ScoreKind::ObjectiveValueNonPositive(
+                    quality,
+                    gas_cost,
+                )) => Kind::ScoringFailed(ScoreKind::ObjectiveValueNonPositive {
+                    quality: quality.0,
+                    gas_cost: gas_cost.0 .0,
+                }),
                 notify::Kind::NonBufferableTokensUsed(tokens) => Kind::NonBufferableTokensUsed {
                     tokens: tokens.into_iter().map(|token| token.0 .0).collect(),
                 },
@@ -107,7 +111,13 @@ pub enum ScoreKind {
     SuccessProbabilityOutOfRange {
         probability: f64,
     },
-    ObjectiveValueNonPositive,
+    #[serde(rename_all = "camelCase")]
+    ObjectiveValueNonPositive {
+        #[serde_as(as = "serialize::U256")]
+        quality: eth::U256,
+        #[serde_as(as = "serialize::U256")]
+        gas_cost: eth::U256,
+    },
 }
 
 #[serde_as]

--- a/crates/shared/src/http_solver/model.rs
+++ b/crates/shared/src/http_solver/model.rs
@@ -457,7 +457,19 @@ pub enum SolverRejectionReason {
     NonPositiveScore,
 
     /// Objective value is too low.
-    ObjectiveValueNonPositive,
+    /// [TODO] Remove once the colocation is finalized.
+    #[serde(rename = "objectiveValueNonPositive")]
+    ObjectiveValueNonPositiveLegacy,
+
+    /// Objective value is too low.
+    #[serde(rename_all = "camelCase")]
+    #[serde(rename = "objectiveValueNonPositive")]
+    ObjectiveValueNonPositiveColocated {
+        #[serde_as(as = "HexOrDecimalU256")]
+        quality: U256,
+        #[serde_as(as = "HexOrDecimalU256")]
+        gas_cost: U256,
+    },
 
     /// Success probability is out of the allowed range [0, 1]
     SuccessProbabilityOutOfRange,
@@ -1207,6 +1219,52 @@ mod tests {
             .unwrap(),
             json!({
                 "nonBufferableTokensUsed": ["0x0000000000000000000000000000000000000001", "0x0000000000000000000000000000000000000002"],
+            }),
+        );
+    }
+
+    #[test]
+    fn serialize_objective_value_non_positive_legacy() {
+        let auction_result =
+            AuctionResult::Rejected(SolverRejectionReason::ObjectiveValueNonPositiveLegacy);
+
+        assert_eq!(
+            serde_json::to_value(auction_result).unwrap(),
+            json!({
+                "rejected": "objectiveValueNonPositive",
+            }),
+        );
+    }
+
+    #[test]
+    fn serialize_objective_value_non_positive_colocated() {
+        let auction_result =
+            AuctionResult::Rejected(SolverRejectionReason::ObjectiveValueNonPositiveColocated {
+                quality: U256::from(1),
+                gas_cost: U256::from(2),
+            });
+
+        assert_eq!(
+            serde_json::to_value(auction_result).unwrap(),
+            json!({
+                "rejected": {
+                    "objectiveValueNonPositive": {
+                        "quality": "1",
+                        "gasCost": "2",
+                    },
+                }
+            }),
+        );
+    }
+
+    #[test]
+    fn serialize_non_positive_score() {
+        let auction_result = AuctionResult::Rejected(SolverRejectionReason::NonPositiveScore);
+
+        assert_eq!(
+            serde_json::to_value(auction_result).unwrap(),
+            json!({
+                "rejected": "nonPositiveScore",
             }),
         );
     }

--- a/crates/solver/src/settlement_ranker.rs
+++ b/crates/solver/src/settlement_ranker.rs
@@ -220,7 +220,7 @@ impl SettlementRanker {
                     );
                     let reason = match error {
                         ScoringError::ObjectiveValueNonPositive(_) => {
-                            Some(SolverRejectionReason::ObjectiveValueNonPositive)
+                            Some(SolverRejectionReason::ObjectiveValueNonPositiveLegacy)
                         }
                         ScoringError::SuccessProbabilityOutOfRange(_) => {
                             Some(SolverRejectionReason::SuccessProbabilityOutOfRange)

--- a/crates/solvers/src/api/routes/notify/dto/notification.rs
+++ b/crates/solvers/src/api/routes/notify/dto/notification.rs
@@ -21,9 +21,12 @@ impl Notification {
             kind: match &self.kind {
                 Kind::Timeout => notification::Kind::Timeout,
                 Kind::EmptySolution => notification::Kind::EmptySolution,
-                Kind::ScoringFailed(ScoreKind::ObjectiveValueNonPositive) => {
+                Kind::ScoringFailed(ScoreKind::ObjectiveValueNonPositive { quality, gas_cost }) => {
                     notification::Kind::ScoringFailed(
-                        notification::ScoreKind::ObjectiveValueNonPositive,
+                        notification::ScoreKind::ObjectiveValueNonPositive(
+                            (*quality).into(),
+                            (*gas_cost).into(),
+                        ),
                     )
                 }
                 Kind::ScoringFailed(ScoreKind::ZeroScore) => {
@@ -114,7 +117,13 @@ pub enum ScoreKind {
     SuccessProbabilityOutOfRange {
         probability: f64,
     },
-    ObjectiveValueNonPositive,
+    #[serde(rename_all = "camelCase")]
+    ObjectiveValueNonPositive {
+        #[serde_as(as = "serialize::U256")]
+        quality: U256,
+        #[serde_as(as = "serialize::U256")]
+        gas_cost: U256,
+    },
 }
 
 #[serde_as]

--- a/crates/solvers/src/boundary/legacy.rs
+++ b/crates/solvers/src/boundary/legacy.rs
@@ -583,8 +583,11 @@ fn to_boundary_auction_result(notification: &notification::Notification) -> (i64
             AuctionResult::Rejected(SolverRejectionReason::RunError(SolverRunError::Timeout))
         }
         Kind::EmptySolution => AuctionResult::Rejected(SolverRejectionReason::NoUserOrders),
-        Kind::ScoringFailed(ScoreKind::ObjectiveValueNonPositive) => {
-            AuctionResult::Rejected(SolverRejectionReason::ObjectiveValueNonPositive)
+        Kind::ScoringFailed(ScoreKind::ObjectiveValueNonPositive(quality, gas_cost)) => {
+            AuctionResult::Rejected(SolverRejectionReason::ObjectiveValueNonPositiveColocated {
+                quality: quality.0,
+                gas_cost: gas_cost.0,
+            })
         }
         Kind::ScoringFailed(ScoreKind::ZeroScore) => {
             AuctionResult::Rejected(SolverRejectionReason::NonPositiveScore)

--- a/crates/solvers/src/domain/notification.rs
+++ b/crates/solvers/src/domain/notification.rs
@@ -47,7 +47,7 @@ pub enum ScoreKind {
     ZeroScore,
     ScoreHigherThanQuality(Score, Quality),
     SuccessProbabilityOutOfRange(SuccessProbability),
-    ObjectiveValueNonPositive,
+    ObjectiveValueNonPositive(Quality, GasCost),
 }
 
 #[derive(Debug, Copy, Clone)]
@@ -63,6 +63,15 @@ impl From<eth::U256> for Score {
 pub struct Quality(pub eth::U256);
 
 impl From<eth::U256> for Quality {
+    fn from(value: eth::U256) -> Self {
+        Self(value)
+    }
+}
+
+#[derive(Debug, Copy, Clone)]
+pub struct GasCost(pub eth::U256);
+
+impl From<eth::U256> for GasCost {
     fn from(value: eth::U256) -> Self {
         Self(value)
     }


### PR DESCRIPTION
# Description
Follow-up PR for https://github.com/cowprotocol/services/pull/2022 for easier review.
Enriches the `ObjectiveValueNonPositive` error with `Quality` and `GasCost`.
It was a bit tricky to make the same error variant be supported from both the legacy driver and colocated driver, so I decided to make a new variant `ObjectiveValueNonPositiveColocated` which will be serialized as `objectiveValueNonPositive` but with additional fields. Not a super clean solution, but what is important is that the `driver` - `solvers` interface is clean.