### PR TITLE
Properly propagate errors for zero scores

### DIFF
--- a/crates/driver/src/boundary/score.rs
+++ b/crates/driver/src/boundary/score.rs
@@ -19,13 +19,13 @@ pub fn score(
     objective_value: ObjectiveValue,
     success_probability: SuccessProbability,
     failure_cost: eth::GasCost,
-) -> Result<Score, boundary::Error> {
+) -> Result<Score, score::Error> {
     match ScoreCalculator::new(score_cap.0.get().to_big_rational()).compute_score(
         &objective_value.0.get().to_big_rational(),
         failure_cost.0 .0.to_big_rational(),
         success_probability.0,
     ) {
         Ok(score) => Ok(score.try_into()?),
-        Err(err) => Err(err.into()),
+        Err(err) => Err(boundary::Error::from(err).into()),
     }
 }

--- a/crates/driver/src/domain/competition/score.rs
+++ b/crates/driver/src/domain/competition/score.rs
@@ -1,9 +1,5 @@
 use {
-    self::risk::ObjectiveValue,
-    crate::{
-        boundary,
-        domain::{eth, eth::GasCost},
-    },
+    crate::{boundary, domain::eth},
     std::cmp::Ordering,
 };
 
@@ -34,21 +30,6 @@ pub struct Quality(pub eth::U256);
 impl From<eth::U256> for Quality {
     fn from(value: eth::U256) -> Self {
         Self(value)
-    }
-}
-
-/// ObjectiveValue = Quality - GasCost
-impl std::ops::Sub<GasCost> for Quality {
-    type Output = Result<ObjectiveValue, risk::Error>;
-
-    fn sub(self, other: GasCost) -> Self::Output {
-        if self.0 > other.0 .0 {
-            Ok(ObjectiveValue(
-                eth::NonZeroU256::new(self.0 - other.0 .0).unwrap(),
-            ))
-        } else {
-            Err(risk::Error::ObjectiveValueNonPositive)
-        }
     }
 }
 
@@ -92,9 +73,13 @@ pub enum Error {
 pub mod risk {
     //! Contains functionality and error types for scores that are based on
     //! success probability.
+
     use {
-        super::Score,
-        crate::{boundary, domain::eth},
+        super::{Quality, Score},
+        crate::{
+            boundary,
+            domain::{eth, eth::GasCost},
+        },
     };
 
     impl Score {
@@ -104,13 +89,13 @@ pub mod risk {
             objective_value: ObjectiveValue,
             success_probability: SuccessProbability,
             failure_cost: eth::GasCost,
-        ) -> Result<Self, Error> {
-            Ok(boundary::score::score(
+        ) -> Result<Self, super::Error> {
+            boundary::score::score(
                 score_cap,
                 objective_value,
                 success_probability,
                 failure_cost,
-            )?)
+            )
         }
     }
 
@@ -134,6 +119,22 @@ pub mod risk {
     /// it's defined as Quality - GasCost.
     #[derive(Debug, Default, PartialEq, Eq, PartialOrd, Ord, Copy, Clone)]
     pub struct ObjectiveValue(pub eth::NonZeroU256);
+
+    /// Substitution for constructor of ObjectiveValue
+    /// ObjectiveValue = Quality - GasCost
+    impl std::ops::Sub<GasCost> for Quality {
+        type Output = Result<ObjectiveValue, Error>;
+
+        fn sub(self, other: GasCost) -> Self::Output {
+            if self.0 > other.0 .0 {
+                Ok(ObjectiveValue(
+                    eth::NonZeroU256::new(self.0 - other.0 .0).unwrap(),
+                ))
+            } else {
+                Err(Error::ObjectiveValueNonPositive)
+            }
+        }
+    }
 
     #[derive(Debug, thiserror::Error)]
     pub enum Error {

--- a/crates/driver/src/domain/competition/solution/settlement.rs
+++ b/crates/driver/src/domain/competition/solution/settlement.rs
@@ -271,7 +271,7 @@ impl Settlement {
         let quality = self.boundary.quality(eth, auction)?;
 
         let score = match self.boundary.score() {
-            competition::SolverScore::Solver(score) => competition::Score(score.try_into()?),
+            competition::SolverScore::Solver(score) => score.try_into()?,
             competition::SolverScore::RiskAdjusted(success_probability) => {
                 let gas_cost = self.gas.estimate * auction.gas_price();
                 let success_probability = success_probability.try_into()?;


### PR DESCRIPTION
# Description
Implements proper error handling when building `Score` from `ZeroU256`.
Accidentally, this was done through `eth::NonZeroU256::from` and then the error was converted to `anyhow::Error`, but what we actually want is to convert to `score::Error::ZeroScore`.

It was noticed in [this log](https://production-6de61f.kb.eu-central-1.aws.cloud.es.io/app/discover#/doc/ea511870-d9b3-11ed-a9d0-a17451f01cc1/cowlogs-staging-2023.10.31?id=_bRBh4sBQgsUfyaRQinM).