### PR TITLE
Fix parsing score_cap

### DIFF
--- a/crates/autopilot/src/arguments.rs
+++ b/crates/autopilot/src/arguments.rs
@@ -170,7 +170,7 @@ pub struct Arguments {
     pub additional_deadline_for_rewards: usize,
 
     /// Cap used for CIP20 score calculation. Defaults to 0.01 ETH.
-    #[clap(long, env, default_value = "10000000000000000", value_parser = shared::arguments::parse_u256)]
+    #[clap(long, env, default_value = "0.01", value_parser = shared::arguments::wei_from_ether)]
     pub score_cap: U256,
 
     /// The amount of time that the autopilot waits looking for a settlement

--- a/crates/autopilot/src/arguments.rs
+++ b/crates/autopilot/src/arguments.rs
@@ -170,7 +170,7 @@ pub struct Arguments {
     pub additional_deadline_for_rewards: usize,
 
     /// Cap used for CIP20 score calculation. Defaults to 0.01 ETH.
-    #[clap(long, env, default_value = "10000000000000000")]
+    #[clap(long, env, default_value = "10000000000000000", value_parser = shared::arguments::parse_u256)]
     pub score_cap: U256,
 
     /// The amount of time that the autopilot waits looking for a settlement

--- a/crates/shared/src/arguments.rs
+++ b/crates/shared/src/arguments.rs
@@ -532,12 +532,6 @@ pub fn wei_from_gwei(s: &str) -> anyhow::Result<f64> {
     Ok(in_gwei * 1e9)
 }
 
-// default values are expected to be expressed in decimal format
-pub fn parse_u256(s: &str) -> anyhow::Result<U256> {
-    let in_decimal = s.parse::<BigDecimal>()?;
-    number::conversions::big_decimal_to_u256(&in_decimal).context("invalid U256 value")
-}
-
 impl FromStr for ExternalSolver {
     type Err = anyhow::Error;
 
@@ -673,13 +667,5 @@ mod test {
             "name|http://localhost:8080|0x0101010101010101010101010101010101010101|true|1"
         )
         .is_err());
-    }
-
-    #[test]
-    fn parse_u256_test() {
-        assert_eq!(
-            parse_u256("10000000000000000").unwrap(),
-            U256::from(10_000_000_000_000_000u64)
-        );
     }
 }

--- a/crates/shared/src/arguments.rs
+++ b/crates/shared/src/arguments.rs
@@ -532,6 +532,12 @@ pub fn wei_from_gwei(s: &str) -> anyhow::Result<f64> {
     Ok(in_gwei * 1e9)
 }
 
+// default values are expected to be expressed in decimal format
+pub fn parse_u256(s: &str) -> anyhow::Result<U256> {
+    let in_decimal = s.parse::<BigDecimal>()?;
+    number::conversions::big_decimal_to_u256(&in_decimal).context("invalid U256 value")
+}
+
 impl FromStr for ExternalSolver {
     type Err = anyhow::Error;
 
@@ -667,5 +673,13 @@ mod test {
             "name|http://localhost:8080|0x0101010101010101010101010101010101010101|true|1"
         )
         .is_err());
+    }
+
+    #[test]
+    fn parse_u256_test() {
+        assert_eq!(
+            parse_u256("10000000000000000").unwrap(),
+            U256::from(10_000_000_000_000_000u64)
+        );
     }
 }

--- a/crates/solver/src/arguments.rs
+++ b/crates/solver/src/arguments.rs
@@ -320,7 +320,7 @@ pub struct Arguments {
     pub risk_params: risk_computation::Arguments,
 
     /// Cap used for CIP20 score calculation. Defaults to 0.01 ETH.
-    #[clap(long, env, default_value = "10000000000000000")]
+    #[clap(long, env, default_value = "10000000000000000", value_parser = shared::arguments::parse_u256)]
     pub score_cap: U256,
 
     /// Should we skip settlements with non-positive score for solver

--- a/crates/solver/src/arguments.rs
+++ b/crates/solver/src/arguments.rs
@@ -320,7 +320,7 @@ pub struct Arguments {
     pub risk_params: risk_computation::Arguments,
 
     /// Cap used for CIP20 score calculation. Defaults to 0.01 ETH.
-    #[clap(long, env, default_value = "10000000000000000", value_parser = shared::arguments::parse_u256)]
+    #[clap(long, env, default_value = "0.01", value_parser = shared::arguments::wei_from_ether)]
     pub score_cap: U256,
 
     /// Should we skip settlements with non-positive score for solver


### PR DESCRIPTION
# Description
@fhenneke noticed that our `score_cap` is [parsed wrongly](https://production-6de61f.kb.eu-central-1.aws.cloud.es.io/app/discover#/doc/c0e240e0-d9b3-11ed-b0e6-e361adffce0b/cowlogs-prod-2023.11.01?id=icFRiosBGP6wkTcjJhYX).

Value `1e16` is parsed as `18446744073709551616` due to decimal/hexadecimal misconfiguration.