### PR TITLE
Debug univ3 maintenance times

### DIFF
--- a/crates/shared/src/sources/uniswap_v3/graph_api.rs
+++ b/crates/shared/src/sources/uniswap_v3/graph_api.rs
@@ -175,10 +175,12 @@ impl UniV3SubgraphClient {
         ids: &[H160],
         block_number: u64,
     ) -> Result<Vec<PoolData>> {
+        let start = std::time::Instant::now();
         let (pools, ticks) = futures::try_join!(
             self.get_pools_by_pool_ids(ids, block_number),
             self.get_ticks_by_pools_ids(ids, block_number)
         )?;
+        tracing::debug!(requested = ids.len(), time = ?start.elapsed(), "fetched pool ticks");
 
         // group ticks by pool ids
         let mut ticks_mapped = HashMap::new();

--- a/crates/shared/src/sources/uniswap_v3/graph_api.rs
+++ b/crates/shared/src/sources/uniswap_v3/graph_api.rs
@@ -175,12 +175,10 @@ impl UniV3SubgraphClient {
         ids: &[H160],
         block_number: u64,
     ) -> Result<Vec<PoolData>> {
-        let start = std::time::Instant::now();
         let (pools, ticks) = futures::try_join!(
             self.get_pools_by_pool_ids(ids, block_number),
             self.get_ticks_by_pools_ids(ids, block_number)
         )?;
-        tracing::debug!(requested = ids.len(), time = ?start.elapsed(), "fetched pool ticks");
 
         // group ticks by pool ids
         let mut ticks_mapped = HashMap::new();


### PR DESCRIPTION
# Description
When restarting a pod we sometimes get alerts stating that the last block that we successfully ran our maintenance tasks on lags behind the most recent block we saw.
This [log](https://production-6de61f.kb.eu-central-1.aws.cloud.es.io/app/discover#/?_g=(filters:!(),refreshInterval:(pause:!t,value:0),time:(from:'2023-11-01T09:59:38.245Z',to:'2023-11-01T10:05:23.271Z'))&_a=(columns:!(log),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:c0e240e0-d9b3-11ed-b0e6-e361adffce0b,key:kubernetes.container_name,negate:!f,params:(query:mainnet-solver-prod),type:phrase),query:(match_phrase:(kubernetes.container_name:mainnet-solver-prod)))),grid:(columns:('@timestamp':(width:164))),index:c0e240e0-d9b3-11ed-b0e6-e361adffce0b,interval:auto,query:(language:kuery,query:'mainnet%20and%20log:%20%22service_maintenance:maintenance%22%20and%20log:%20%22warn%22%20or%20log:%20%22currently%20missing%20pools%20are%22'),sort:!(!('@timestamp',desc)))) seems to indicate that slow univ3 maintenance updates might have something to do with the alerts. Usually when we restart a pod we only get a few pools and continue querying pools whenever we see orders that require them. Since this is more likely to happen when we start the pod getting errors after a restart seems reasonable.

# Changes
Only adds a log stating how many pools we tried to get, how long the request took and whether it was successful.
This should give us enough information to continue debugging those alerts.