### PR TITLE
Add chain_id to /notify query string

### DIFF
--- a/crates/shared/src/http_solver.rs
+++ b/crates/shared/src/http_solver.rs
@@ -234,12 +234,16 @@ impl HttpSolverApi for DefaultHttpSolverApi {
         // `/notify` should be a sibling of the `/solve` endpoint
         url.path_segments_mut().unwrap().pop().push("notify");
 
+        let chain_id = self.chain_id;
         let client = self.client.clone();
         let config_api_key = self.config.api_key.clone();
         tracing::debug!(solver_name = self.name, ?result, "notify auction result");
         let future = async move {
             url.query_pairs_mut()
                 .append_pair("auction_id", auction_id.to_string().as_str());
+
+            url.query_pairs_mut()
+                .append_pair("chain_id", chain_id.to_string().as_str());
 
             let mut request = client
                 .post(url)


### PR DESCRIPTION
# Description
Add `chain_id` to the query variables on the `/notify` request. We would appreciate this for the Enso solver as all of our infra is multi chain by default. With this we can monitor which chain the notification relates to.

Originally I wanted to add a `metadata` field to the `AuctionResult`, but this accomplishes the same thing and requires no model changes.

# Changes
Add `chain_id` to the query variables on the `/notify` request.

## How to test
Couldn't find an existing `/notify` tests, if they do exist please let me know and I can add some assertions. It is also just a really small change...

## Related Issues

https://github.com/cowprotocol/services/issues/1891#issuecomment-1779295895