### PR TITLE
Respect deadline in Baseline solver

### DIFF
--- a/crates/solvers/src/domain/solver/baseline.rs
+++ b/crates/solvers/src/domain/solver/baseline.rs
@@ -157,7 +157,7 @@ impl Inner {
             });
             if let Some(solution) = solution {
                 if sender.send(solution).is_err() {
-                    tracing::trace!("deadline hit, receiver dropped");
+                    tracing::debug!("deadline hit, receiver dropped");
                     break;
                 }
             }

--- a/crates/solvers/src/domain/solver/baseline.rs
+++ b/crates/solvers/src/domain/solver/baseline.rs
@@ -127,8 +127,7 @@ impl Inner {
                                 liquidity: segment.liquidity.clone(),
                                 input: segment.input,
                                 output: segment.output,
-                                // TODO does the baseline solver know about this
-                                // optimization?
+                                // TODO does the baseline solver know about this optimization?
                                 internalize: false,
                             })
                         })

--- a/crates/solvers/src/domain/solver/baseline.rs
+++ b/crates/solvers/src/domain/solver/baseline.rs
@@ -127,11 +127,19 @@ impl Inner {
                                 liquidity: segment.liquidity.clone(),
                                 input: segment.input,
                                 output: segment.output,
+                                // TODO does the baseline solver know about this
+                                // optimization?
                                 internalize: false,
                             })
                         })
                         .collect();
 
+                    // The baseline solver generates a path with swapping
+                    // for exact output token amounts. This leads to
+                    // potential rounding errors for buy orders, where we
+                    // can buy slightly more than intended. Fix this by
+                    // capping the output amount to the order's buy amount
+                    // for buy orders.
                     let mut output = route.output();
                     if let order::Side::Buy = order.side {
                         output.amount = cmp::min(output.amount, order.buy.amount);


### PR DESCRIPTION
# Description
Baseline solver iterates through orders from `auction` and executes some logic for each order in a synchronous way. It checks the deadline before each order. It could happen that the new order logic begins to execute 1ms before the deadline and lasts arbitrary amount of time (500ms?) and significantly break the deadline.

This code adds a checker if the deadline is reached in the main thread, and if it is, ends the background work prematurely and returns whatever was executed up until that point.

## How to test
Example: https://play.rust-lang.org/?version=stable&mode=debug&edition=2021&gist=0e23fa016153883faad8b0e7148b4dfa