### PR TITLE
Cache balances in driver

### DIFF
--- a/crates/driver/src/domain/eth/balances.rs
+++ b/crates/driver/src/domain/eth/balances.rs
@@ -1,0 +1,95 @@
+use {
+    crate::{
+        domain::{competition::order, eth},
+        infra,
+    },
+    futures::future::join_all,
+    itertools::Itertools,
+    std::{collections::HashMap, sync::Arc},
+    tokio::sync::Mutex,
+};
+
+type BalanceGroup = (order::Trader, eth::TokenAddress, order::SellTokenBalance);
+type Balances = Arc<HashMap<BalanceGroup, order::SellAmount>>;
+
+#[derive(Default, Clone)]
+pub struct Cache(Arc<Mutex<Inner>>);
+
+impl Cache {
+    /// Either returns the cached balances if they are up-to-date or fetches,
+    /// caches and returns the current balances.
+    /// If the return value does not contain a balance for a given order it
+    /// could not be fetched.
+    pub async fn get_or_fetch(
+        &self,
+        ethereum: &infra::Ethereum,
+        orders: &[order::Order],
+    ) -> Balances {
+        let mut lock = self.0.lock().await;
+        let current_block = ethereum.current_block().borrow().number;
+        if lock.cached_at.0 >= current_block {
+            // Check if somebody else already filled the cache by now.
+            return lock.balances.clone();
+        }
+
+        // Collect trader/token/source/interaction tuples for fetching available
+        // balances. Note that we are pessimistic here, if a trader is selling
+        // the same token with the same source in two different orders using a
+        // different set of pre-interactions, then we fetch the balance as if no
+        // pre-interactions were specified. This is done to avoid creating
+        // dependencies between orders (i.e. order 1 is required for executing
+        // order 2) which we currently cannot express with the solver interface.
+        let traders = orders
+            .iter()
+            .group_by(|order| (order.trader(), order.sell.token, order.sell_token_balance))
+            .into_iter()
+            .map(|((trader, token, source), mut orders)| {
+                let first = orders.next().expect("group contains at least 1 order");
+                let mut others = orders;
+                if others.all(|order| order.pre_interactions == first.pre_interactions) {
+                    (trader, token, source, &first.pre_interactions[..])
+                } else {
+                    (trader, token, source, Default::default())
+                }
+            })
+            .collect::<Vec<_>>();
+
+        let balances = join_all(traders.into_iter().map(
+            |(trader, token, source, interactions)| async move {
+                let balance = ethereum
+                    .erc20(token)
+                    .tradable_balance(trader.into(), source, interactions)
+                    .await;
+                (
+                    (trader, token, source),
+                    balance.map(order::SellAmount::from).ok(),
+                )
+            },
+        ))
+        .await
+        .into_iter()
+        .filter_map(|(key, value)| Some((key, value?)))
+        .collect::<HashMap<_, _>>();
+
+        // Cache new balances.
+        let balances = Arc::new(balances);
+        lock.cached_at = eth::BlockNo(current_block);
+        lock.balances = balances.clone();
+
+        balances
+    }
+}
+
+struct Inner {
+    cached_at: eth::BlockNo,
+    balances: Balances,
+}
+
+impl Default for Inner {
+    fn default() -> Self {
+        Self {
+            cached_at: eth::BlockNo(0),
+            balances: Default::default(),
+        }
+    }
+}

--- a/crates/driver/src/domain/eth/mod.rs
+++ b/crates/driver/src/domain/eth/mod.rs
@@ -5,6 +5,7 @@ use {
 };
 
 pub mod allowance;
+pub mod balances;
 mod eip712;
 mod gas;
 

--- a/crates/driver/src/infra/api/mod.rs
+++ b/crates/driver/src/infra/api/mod.rs
@@ -1,7 +1,6 @@
 use {
     crate::{
-        domain,
-        domain::Mempools,
+        domain::{self, eth, Mempools},
         infra::{self, liquidity, solver::Solver, tokens, Ethereum, Simulator},
     },
     error::Error,
@@ -42,6 +41,7 @@ impl Api {
         );
 
         let tokens = tokens::Fetcher::new(self.eth.clone());
+        let balances = eth::balances::Cache::default();
 
         // Add the metrics endpoint.
         app = routes::metrics(app);
@@ -71,6 +71,7 @@ impl Api {
                 },
                 liquidity: self.liquidity.clone(),
                 tokens: tokens.clone(),
+                balances: balances.clone(),
             })));
             let path = format!("/{name}");
             infra::observe::mounting_solver(&name, &path);
@@ -112,6 +113,10 @@ impl State {
     fn tokens(&self) -> &tokens::Fetcher {
         &self.0.tokens
     }
+
+    fn balances(&self) -> &eth::balances::Cache {
+        &self.0.balances
+    }
 }
 
 struct Inner {
@@ -120,4 +125,5 @@ struct Inner {
     competition: domain::Competition,
     liquidity: liquidity::Fetcher,
     tokens: tokens::Fetcher,
+    balances: eth::balances::Cache,
 }

--- a/crates/driver/src/infra/api/routes/solve/mod.rs
+++ b/crates/driver/src/infra/api/routes/solve/mod.rs
@@ -27,7 +27,7 @@ async fn route(
             .tap_err(|err| {
                 observe::invalid_dto(err, "auction");
             })?;
-        let auction = auction.prioritize(state.eth()).await;
+        let auction = auction.prioritize(state.eth(), state.balances()).await;
         observe::auction(&auction);
         let competition = state.competition();
         let result = competition.solve(&auction).await;

--- a/crates/driver/src/infra/observe/mod.rs
+++ b/crates/driver/src/infra/observe/mod.rs
@@ -333,8 +333,8 @@ fn competition_error(err: &competition::Error) -> &'static str {
 }
 
 #[derive(Debug)]
-pub enum OrderExcludedFromAuctionReason<'a> {
-    CouldNotFetchBalance(&'a crate::infra::blockchain::Error),
+pub enum OrderExcludedFromAuctionReason {
+    CouldNotFetchBalance,
     CouldNotCalculateMaxSell,
     InsufficientBalance,
     OrderWithZeroAmountRemaining,


### PR DESCRIPTION
# Description
When the driver receives a `/solve` request it fetches the balances for all traders in the auction. The outcome of this exclusively depends on the current block so duplicating this work for every configured solver does not make sense.
This will result in fewer RPC requests and probably also in a faster auction pre-processing time.
The solvers are not really contending on a lock but they are using the same underlying buffered `Web3` type. This is configured to allow up to 10 parallel batch requests with 20 individual requests each. These 200 requests can probably be easily saturated when 10 solvers fetch balances for ~1000 orders which means there will be some solvers who have to wait for the backpressure to resolve.

# Changes
Introduce shared cache for balances which gets updated when the solver queries the balances for an uncached block.
The cache locks until the update is complete so it will avoid all duplicated requests.
Since the balances might get quite big I decided to return a reference counted balances map instead of cloning it in the critical section. Otherwise these big `.clone()`s might add up to a significant delay as well.

## How to test
should be covered by e2e test