### PR TITLE
Configurable http time buffer

### DIFF
--- a/crates/driver/src/infra/config/file/load.rs
+++ b/crates/driver/src/infra/config/file/load.rs
@@ -66,6 +66,9 @@ pub async fn load(network: &blockchain::Network, path: &Path) -> infra::Config {
                     solver::Liquidity::Fetch
                 },
                 account,
+                http_time_buffer: chrono::Duration::milliseconds(
+                    config.http_time_buffer_miliseconds.try_into().unwrap(),
+                ),
             }
         }))
         .await,

--- a/crates/driver/src/infra/config/file/mod.rs
+++ b/crates/driver/src/infra/config/file/mod.rs
@@ -148,6 +148,10 @@ fn default_soft_cancellations_flag() -> bool {
     false
 }
 
+fn default_http_time_buffer_miliseconds() -> u64 {
+    1500
+}
+
 #[serde_as]
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "kebab-case", deny_unknown_fields)]
@@ -174,6 +178,11 @@ struct SolverConfig {
 
     /// The account which should be used to sign settlements for this solver.
     account: Account,
+
+    /// Maximum time allocated to wait for a solver response to propagate to the
+    /// driver.
+    #[serde(default = "default_http_time_buffer_miliseconds")]
+    http_time_buffer_miliseconds: u64,
 }
 
 #[serde_as]

--- a/crates/driver/src/infra/config/file/mod.rs
+++ b/crates/driver/src/infra/config/file/mod.rs
@@ -148,7 +148,7 @@ fn default_soft_cancellations_flag() -> bool {
     false
 }
 
-fn default_http_time_buffer_miliseconds() -> u64 {
+fn default_http_time_buffer_milliseconds() -> u64 {
     1500
 }
 
@@ -181,7 +181,7 @@ struct SolverConfig {
 
     /// Maximum time allocated to wait for a solver response to propagate to the
     /// driver.
-    #[serde(default = "default_http_time_buffer_miliseconds")]
+    #[serde(default = "default_http_time_buffer_milliseconds")]
     http_time_buffer_miliseconds: u64,
 }
 

--- a/crates/driver/src/infra/solver/mod.rs
+++ b/crates/driver/src/infra/solver/mod.rs
@@ -85,13 +85,12 @@ pub struct Config {
     pub liquidity: Liquidity,
     /// The private key of this solver, used for settlement submission.
     pub account: ethcontract::Account,
+    /// Maximum time allocated to wait for a solver response to propagate to the
+    /// driver.
+    pub http_time_buffer: chrono::Duration,
 }
 
 impl Solver {
-    pub fn http_time_buffer() -> chrono::Duration {
-        chrono::Duration::milliseconds(500)
-    }
-
     pub fn new(config: Config, eth: Ethereum) -> Self {
         let mut headers = reqwest::header::HeaderMap::new();
         headers.insert(
@@ -149,7 +148,7 @@ impl Solver {
             liquidity,
             // Reduce the timeout by a small buffer to account for network latency. Otherwise the
             // HTTP timeout might happen before the solver times out its search algorithm.
-            timeout.reduce(Self::http_time_buffer()),
+            timeout.reduce(self.config.http_time_buffer),
             weth,
         ))
         .unwrap();

--- a/crates/driver/src/tests/setup/solver.rs
+++ b/crates/driver/src/tests/setup/solver.rs
@@ -230,7 +230,7 @@ impl Solver {
                         "orders": orders_json,
                         "liquidity": [],
                         "effectiveGasPrice": effective_gas_price,
-                        "deadline": config.deadline - auction::Deadline::time_buffer() - infra::Solver::http_time_buffer(),
+                        "deadline": config.deadline - auction::Deadline::time_buffer() - chrono::Duration::seconds(1),
                     });
                     assert_eq!(req, expected, "unexpected /solve request");
                     let mut state = state.0.lock().unwrap();

--- a/crates/driver/src/tests/setup/solver.rs
+++ b/crates/driver/src/tests/setup/solver.rs
@@ -230,7 +230,7 @@ impl Solver {
                         "orders": orders_json,
                         "liquidity": [],
                         "effectiveGasPrice": effective_gas_price,
-                        "deadline": config.deadline - auction::Deadline::time_buffer() - chrono::Duration::milliseconds(500),
+                        "deadline": config.deadline - auction::Deadline::time_buffer() - chrono::Duration::milliseconds(1500),
                     });
                     assert_eq!(req, expected, "unexpected /solve request");
                     let mut state = state.0.lock().unwrap();

--- a/crates/driver/src/tests/setup/solver.rs
+++ b/crates/driver/src/tests/setup/solver.rs
@@ -230,7 +230,7 @@ impl Solver {
                         "orders": orders_json,
                         "liquidity": [],
                         "effectiveGasPrice": effective_gas_price,
-                        "deadline": config.deadline - auction::Deadline::time_buffer() - chrono::Duration::seconds(1),
+                        "deadline": config.deadline - auction::Deadline::time_buffer() - chrono::Duration::milliseconds(500),
                     });
                     assert_eq!(req, expected, "unexpected /solve request");
                     let mut state = state.0.lock().unwrap();


### PR DESCRIPTION
# Description
Makes the solver http time buffer configurable. 

This indeed seems like a value we want to setup once and never touch again, which why I don't feel strong to add parameter for this (instead of just updating the hard coded value). 

OTOH, we need this configurable at least until further notice.