### PR TITLE
Notify timeout early

### DIFF
--- a/crates/solvers/src/boundary/legacy.rs
+++ b/crates/solvers/src/boundary/legacy.rs
@@ -92,7 +92,7 @@ impl Legacy {
 
     pub async fn solve(&self, auction: &auction::Auction) -> Result<solution::Solution, Error> {
         let (mapping, auction_model) =
-            to_boundary_auction(&auction, self.weth, self.solver.network_name.clone());
+            to_boundary_auction(auction, self.weth, self.solver.network_name.clone());
         let solving_time = auction.deadline.remaining().context("no time to solve")?;
         let solution = self.solver.solve(&auction_model, solving_time).await?;
         to_domain_solution(&solution, mapping).map_err(Into::into)

--- a/crates/solvers/src/boundary/legacy.rs
+++ b/crates/solvers/src/boundary/legacy.rs
@@ -8,6 +8,7 @@ use {
             notification::{self, Kind, ScoreKind, Settlement},
             order,
             solution,
+            solver::legacy::Error,
         },
     },
     anyhow::{Context as _, Result},
@@ -89,18 +90,30 @@ impl Legacy {
         }
     }
 
-    pub async fn solve(&self, auction: auction::Auction) -> Result<solution::Solution> {
+    pub async fn solve(&self, auction: &auction::Auction) -> Result<solution::Solution, Error> {
         let (mapping, auction_model) =
             to_boundary_auction(&auction, self.weth, self.solver.network_name.clone());
         let solving_time = auction.deadline.remaining().context("no time to solve")?;
         let solution = self.solver.solve(&auction_model, solving_time).await?;
-        to_domain_solution(&solution, mapping)
+        to_domain_solution(&solution, mapping).map_err(Into::into)
     }
 
     pub fn notify(&self, notification: notification::Notification) {
         let (auction_id, auction_result) = to_boundary_auction_result(&notification);
         self.solver
             .notify_auction_result(auction_id, auction_result);
+    }
+}
+
+impl From<shared::http_solver::Error> for Error {
+    fn from(value: shared::http_solver::Error) -> Self {
+        match value {
+            shared::http_solver::Error::DeadlineExceeded => Error::Timeout,
+            shared::http_solver::Error::RateLimited => {
+                Error::Other(anyhow::anyhow!("rate limited"))
+            }
+            shared::http_solver::Error::Other(err) => Error::Other(err),
+        }
     }
 }
 

--- a/crates/solvers/src/domain/solver/legacy.rs
+++ b/crates/solvers/src/domain/solver/legacy.rs
@@ -27,10 +27,13 @@ impl Legacy {
     }
 
     pub async fn solve(&self, auction: auction::Auction) -> Vec<solution::Solution> {
-        match self.0.solve(auction).await {
+        match self.0.solve(&auction).await {
             Ok(solution) => vec![solution.with_id(solution::Id(0))],
             Err(err) => {
                 tracing::warn!(?err, "failed to solve auction");
+                if err.is_timeout() {
+                    self.notify_timeout(auction.id)
+                }
                 vec![]
             }
         }
@@ -38,5 +41,27 @@ impl Legacy {
 
     pub fn notify(&self, notification: notification::Notification) {
         self.0.notify(notification);
+    }
+
+    fn notify_timeout(&self, auction_id: auction::Id) {
+        self.notify(notification::Notification {
+            auction_id,
+            solution_id: None,
+            kind: notification::Kind::Timeout,
+        })
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    #[error("timeout")]
+    Timeout,
+    #[error(transparent)]
+    Other(#[from] anyhow::Error),
+}
+
+impl Error {
+    fn is_timeout(&self) -> bool {
+        matches!(self, Self::Timeout)
     }
 }


### PR DESCRIPTION
# Description
Timeouts in legacy solvers are handled inside `solvers` crate and in those cases empty solutions vector is sent to `driver`, leading to these errors being classified in the `driver` as `empty` solutions instead of `timeout`. The consequence of this is that legacy solvers are not properly notified.

This PR sends the `timeout` notification directly from within `legacy` solver so there is no ambiguity. Note that there is no way for `driver` to know this is a `timeout`, so additional `empty` notification will be sent, but afterwards, so it can be ignored by `legacy` solvers.