### PR TITLE
Increase gas limit

### DIFF
--- a/crates/driver/src/domain/competition/solution/settlement.rs
+++ b/crates/driver/src/domain/competition/solution/settlement.rs
@@ -419,7 +419,10 @@ impl Gas {
         // Specify a different gas limit than the estimated gas when executing a
         // settlement transaction. This allows the transaction to be resilient
         // to small variations in actual gas usage.
-        const GAS_LIMIT_FACTOR: f64 = 1.2;
+        // Also, some solutions can have significant gas refunds that are refunded at the
+        // end of execution, so we want to increase gas limit enough so those solutions
+        // don't revert with out of gas error.
+        const GAS_LIMIT_FACTOR: f64 = 2.0;
         let limit =
             eth::U256::from_f64_lossy(eth::U256::to_f64_lossy(estimate.into()) * GAS_LIMIT_FACTOR)
                 .into();

--- a/crates/driver/src/domain/competition/solution/settlement.rs
+++ b/crates/driver/src/domain/competition/solution/settlement.rs
@@ -419,9 +419,9 @@ impl Gas {
         // Specify a different gas limit than the estimated gas when executing a
         // settlement transaction. This allows the transaction to be resilient
         // to small variations in actual gas usage.
-        // Also, some solutions can have significant gas refunds that are refunded at the
-        // end of execution, so we want to increase gas limit enough so those solutions
-        // don't revert with out of gas error.
+        // Also, some solutions can have significant gas refunds that are refunded at
+        // the end of execution, so we want to increase gas limit enough so
+        // those solutions don't revert with out of gas error.
         const GAS_LIMIT_FACTOR: f64 = 2.0;
         let limit =
             eth::U256::from_f64_lossy(eth::U256::to_f64_lossy(estimate.into()) * GAS_LIMIT_FACTOR)

--- a/crates/solver/src/settlement_submission.rs
+++ b/crates/solver/src/settlement_submission.rs
@@ -41,9 +41,12 @@ use {
 /// Computes a gas limit from a gas estimate that accounts for some buffer in
 /// case racing state changes result in slightly more heavy computation at
 /// execution time.
+/// Also, some solutions can have significant gas refunds that are refunded at
+/// the end of execution, so we want to increase gas limit enough so those
+/// solutions don't revert with out of gas error.
 pub fn gas_limit_for_estimate(gas_estimate: U256) -> U256 {
-    const ESTIMATE_GAS_LIMIT_FACTOR: f64 = 1.2;
-    U256::from_f64_lossy(gas_estimate.to_f64_lossy() * ESTIMATE_GAS_LIMIT_FACTOR)
+    const GAS_LIMIT_FACTOR: f64 = 2.0;
+    U256::from_f64_lossy(gas_estimate.to_f64_lossy() * GAS_LIMIT_FACTOR)
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
# Description
The point of gas limit factor is to take into consideration possible small changes in gas estimation from block to block during submission.
However, recently seasolver submitted solutions on gnosis chain that have a significant amount of gas refunds. Gas refunds are refunded at the very end of the execution in the EVM, so if the gas limit is set too low, peak gas usage during EVM execution can exceed it and return `OutOfGas` error.

Setting the factor to `2.0` seems safe, since I don't think nothing catastrophic can happen even if we spend double gas in case of an error.

# Changes
Adjusted factor for both submission but also for colocated driver settlement encoding where factor is used to calculate the required eth balance of solver. Although the latter one doesn't seem necessary, I decided to do it anyway for consistency. 