### PR TITLE
Fix Quasilabs URL configuration

### DIFF
--- a/crates/shared/src/url.rs
+++ b/crates/shared/src/url.rs
@@ -1,7 +1,4 @@
-use {
-    anyhow::{Context, Result},
-    url::Url,
-};
+use {anyhow::Result, url::Url};
 
 /// Join a path with a URL, ensuring that there is only one slash between them.
 /// It doesn't matter if the URL ends with a slash or the path starts with one.
@@ -23,16 +20,9 @@ pub fn join(url: &Url, mut path: &str) -> Url {
 /// Path that were split like this can be joined to the original URL using
 /// [`join`].
 pub fn split_at_path(url: &Url) -> Result<(Url, String)> {
-    let base = format!(
-        "{}://{}{}/",
-        url.scheme(),
-        url.host().context("URL should have a host")?,
-        url.port()
-            .map(|port| format!(":{port}"))
-            .unwrap_or_default()
-    )
-    .parse()
-    .expect("stripping off the path is always safe");
+    let base = format!("{}://{}/", url.scheme(), url.authority(),)
+        .parse()
+        .expect("stripping off the path is always safe");
     let endpoint = format!(
         "{}{}{}",
         url.path(),
@@ -76,5 +66,7 @@ mod tests {
         round_trip("http://my.solver.xyz");
         // base + multiple params + multiple fragments
         round_trip("https://my.solver.xyz?param1=1&param2=2#fragment=1&fragment2=2");
+        // base (with auth) + path
+        round_trip("https://user:pass@my.solver.xyz/solve/1");
     }
 }

--- a/crates/shared/src/url.rs
+++ b/crates/shared/src/url.rs
@@ -20,7 +20,7 @@ pub fn join(url: &Url, mut path: &str) -> Url {
 /// Path that were split like this can be joined to the original URL using
 /// [`join`].
 pub fn split_at_path(url: &Url) -> Result<(Url, String)> {
-    let base = format!("{}://{}/", url.scheme(), url.authority(),)
+    let base = format!("{}://{}/", url.scheme(), url.authority())
         .parse()
         .expect("stripping off the path is always safe");
     let endpoint = format!(


### PR DESCRIPTION
# Description
During colocation prod test, quasilabs endpoint was misconfigured. In the meantime, I also noticed that it is misconfigured in the staging also.

Quasilabs is the only solver that has endpoint authorization defined as `https://user:pass@host.com/solve`. Based on the current splitting of paths, user and pass get lost. This PR keeps the user and pass as part of the `base`.

# Changes
<!-- List of detailed changes (how the change is accomplished) -->

- [ ] Changed the way we do url split.

## How to test
Updated unit test.