### PR TITLE
Add workaround to get actual web3 instance instead of dummy version

### DIFF
--- a/crates/driver/src/infra/blockchain/token.rs
+++ b/crates/driver/src/infra/blockchain/token.rs
@@ -1,7 +1,7 @@
 use {
     super::{Error, Ethereum},
     crate::domain::{competition::order, eth},
-    contracts::{dummy_contract, BalancerV2Vault},
+    contracts::BalancerV2Vault,
     futures::TryFutureExt,
 };
 
@@ -151,6 +151,7 @@ impl Erc20 {
         source: order::SellTokenBalance,
     ) -> Result<eth::TokenAmount, Error> {
         use order::SellTokenBalance::*;
+        let web3 = self.token.raw_instance().web3();
 
         let usable_balance = match source {
             Erc20 => {
@@ -160,7 +161,7 @@ impl Erc20 {
                 std::cmp::min(balance.0, allowance.0.amount)
             }
             External => {
-                let vault = dummy_contract!(BalancerV2Vault, self.vault);
+                let vault = BalancerV2Vault::at(&web3, self.vault.0);
                 let balance = self.balance(trader);
                 let approved = vault
                     .methods()
@@ -176,7 +177,7 @@ impl Erc20 {
                 }
             }
             Internal => {
-                let vault = dummy_contract!(BalancerV2Vault, self.vault);
+                let vault = BalancerV2Vault::at(&web3, self.vault.0);
                 let balance = vault
                     .methods()
                     .get_internal_balance(trader.0, vec![self.token.address()])


### PR DESCRIPTION
# Description
Using a dummy web3 to send RPC requests causes [panics](https://production-6de61f.kb.eu-central-1.aws.cloud.es.io/app/discover#/?_g=(filters:!(),refreshInterval:(pause:!t,value:0),time:(from:now-1h,to:now))&_a=(columns:!(log),filters:!(),grid:(columns:('@timestamp':(width:164))),index:c0e240e0-d9b3-11ed-b0e6-e361adffce0b,interval:auto,query:(language:kuery,query:'mainnet%20and%20(log:%20%22panicked%22)'),sort:!(!('@timestamp',desc)))).
Instead we use a somewhat ugly way to get at the web3 instance that was used to build the ERC20 token instance.