### PR TITLE
Add block number to simulation error

### DIFF
--- a/crates/driver/src/domain/competition/mod.rs
+++ b/crates/driver/src/domain/competition/mod.rs
@@ -224,6 +224,14 @@ impl Competition {
                         tracing::warn!(block = block.number, ?err, "solution reverts on new block");
                         *score_ref = None;
                         *self.settlement.lock().unwrap() = None;
+                        if let Some(id) = settlement.notify_id() {
+                            notify::encoding_failed(
+                                &self.solver,
+                                auction.id(),
+                                id,
+                                &solution::Error::from(err),
+                            );
+                        }
                         return;
                     }
                 }

--- a/crates/driver/src/domain/competition/mod.rs
+++ b/crates/driver/src/domain/competition/mod.rs
@@ -225,12 +225,7 @@ impl Competition {
                         *score_ref = None;
                         *self.settlement.lock().unwrap() = None;
                         if let Some(id) = settlement.notify_id() {
-                            notify::encoding_failed(
-                                &self.solver,
-                                auction.id(),
-                                id,
-                                &solution::Error::from(err),
-                            );
+                            notify::simulation_failed(&self.solver, auction.id(), id, &err);
                         }
                         return;
                     }

--- a/crates/driver/src/infra/notify/mod.rs
+++ b/crates/driver/src/infra/notify/mod.rs
@@ -92,15 +92,12 @@ pub fn simulation_failed(
     solution_id: solution::Id,
     err: &simulator::Error,
 ) {
-    match err {
-        simulator::Error::Revert(error) => {
-            solver.notify(
-                auction_id,
-                Some(solution_id),
-                notification::Kind::SimulationFailed(error.block, error.tx.clone()),
-            );
-        }
-        _ => (),
+    if let simulator::Error::Revert(error) = err {
+        solver.notify(
+            auction_id,
+            Some(solution_id),
+            notification::Kind::SimulationFailed(error.block, error.tx.clone()),
+        );
     }
 }
 

--- a/crates/driver/src/infra/notify/mod.rs
+++ b/crates/driver/src/infra/notify/mod.rs
@@ -73,8 +73,8 @@ pub fn encoding_failed(
         }
         solution::Error::Blockchain(_) => return,
         solution::Error::Boundary(_) => return,
-        solution::Error::Simulation(simulator::Error::WithTx(error)) => {
-            notification::Kind::SimulationFailed(error.tx.clone())
+        solution::Error::Simulation(simulator::Error::Revert(error)) => {
+            notification::Kind::SimulationFailed(error.block, error.tx.clone())
         }
         solution::Error::Simulation(simulator::Error::Basic(_)) => return,
         solution::Error::AssetFlow(missmatch) => notification::Kind::AssetFlow(missmatch.clone()),

--- a/crates/driver/src/infra/notify/mod.rs
+++ b/crates/driver/src/infra/notify/mod.rs
@@ -73,10 +73,10 @@ pub fn encoding_failed(
         }
         solution::Error::Blockchain(_) => return,
         solution::Error::Boundary(_) => return,
-        solution::Error::Simulation(simulator::Error::Revert(error)) => {
-            notification::Kind::SimulationFailed(error.block, error.tx.clone())
+        solution::Error::Simulation(error) => {
+            simulation_failed(solver, auction_id, solution_id, error);
+            return;
         }
-        solution::Error::Simulation(simulator::Error::Basic(_)) => return,
         solution::Error::AssetFlow(missmatch) => notification::Kind::AssetFlow(missmatch.clone()),
         solution::Error::Execution(_) => return,
         solution::Error::FailingInternalization => return,
@@ -84,6 +84,24 @@ pub fn encoding_failed(
     };
 
     solver.notify(auction_id, Some(solution_id), notification);
+}
+
+pub fn simulation_failed(
+    solver: &Solver,
+    auction_id: Option<auction::Id>,
+    solution_id: solution::Id,
+    err: &simulator::Error,
+) {
+    match err {
+        simulator::Error::Revert(error) => {
+            solver.notify(
+                auction_id,
+                Some(solution_id),
+                notification::Kind::SimulationFailed(error.block, error.tx.clone()),
+            );
+        }
+        _ => (),
+    }
 }
 
 pub fn executed(

--- a/crates/driver/src/infra/notify/notification.rs
+++ b/crates/driver/src/infra/notify/notification.rs
@@ -29,7 +29,7 @@ pub enum Kind {
     /// Solution received from solver engine don't have unique id.
     DuplicatedSolutionId,
     /// Failed simulation during competition.
-    SimulationFailed(Transaction),
+    SimulationFailed(eth::BlockNo, Transaction),
     /// No valid score could be computed for the solution.
     ScoringFailed(ScoreKind),
     /// Solution aimed to internalize tokens that are not considered safe to

--- a/crates/driver/src/infra/simulator/mod.rs
+++ b/crates/driver/src/infra/simulator/mod.rs
@@ -14,6 +14,7 @@ pub mod tenderly;
 #[derive(Debug, Clone)]
 pub struct Simulator {
     inner: Inner,
+    eth: Ethereum,
     disable_access_lists: bool,
     /// If this is [`Some`], every gas estimate will return this fixed
     /// gas value.
@@ -29,9 +30,10 @@ pub enum Config {
 
 impl Simulator {
     /// Simulate transactions on [Tenderly](https://tenderly.co/).
-    pub fn tenderly(config: tenderly::Config, network_id: eth::NetworkId) -> Self {
+    pub fn tenderly(config: tenderly::Config, network_id: eth::NetworkId, eth: Ethereum) -> Self {
         Self {
             inner: Inner::Tenderly(tenderly::Tenderly::new(config, network_id)),
+            eth,
             disable_access_lists: false,
             disable_gas: None,
         }
@@ -40,7 +42,8 @@ impl Simulator {
     /// Simulate transactions using the Ethereum RPC API.
     pub fn ethereum(eth: Ethereum) -> Self {
         Self {
-            inner: Inner::Ethereum(eth),
+            inner: Inner::Ethereum,
+            eth,
             disable_access_lists: false,
             disable_gas: None,
         }
@@ -50,7 +53,8 @@ impl Simulator {
     /// Uses Ethereum RPC API to generate access lists.
     pub fn enso(config: enso::Config, eth: Ethereum) -> Self {
         Self {
-            inner: Inner::Enso(enso::Enso::new(config, eth.network().chain), eth),
+            inner: Inner::Enso(enso::Enso::new(config, eth.network().chain)),
+            eth,
             disable_access_lists: false,
             disable_gas: None,
         }
@@ -75,22 +79,25 @@ impl Simulator {
         if self.disable_access_lists {
             return Ok(tx.access_list);
         }
+        let block: eth::BlockNo = self.eth.current_block().borrow().number.into();
         let access_list = match &self.inner {
             Inner::Tenderly(tenderly) => {
                 tenderly
                     .simulate(tx.clone(), tenderly::GenerateAccessList::Yes)
                     .await
-                    .map_err(with_tx(tx.clone()))?
+                    .map_err(with(tx.clone(), block))?
                     .access_list
             }
-            Inner::Ethereum(ethereum) => ethereum
+            Inner::Ethereum => self
+                .eth
                 .create_access_list(tx.clone())
                 .await
-                .map_err(with_tx(tx.clone()))?,
-            Inner::Enso(_, ethereum) => ethereum
+                .map_err(with(tx.clone(), block))?,
+            Inner::Enso(_) => self
+                .eth
                 .create_access_list(tx.clone())
                 .await
-                .map_err(with_tx(tx.clone()))?,
+                .map_err(with(tx.clone(), block))?,
         };
         Ok(tx.access_list.merge(access_list))
     }
@@ -100,24 +107,26 @@ impl Simulator {
         if let Some(gas) = self.disable_gas {
             return Ok(gas);
         }
+        let block: eth::BlockNo = self.eth.current_block().borrow().number.into();
         Ok(match &self.inner {
             Inner::Tenderly(tenderly) => {
                 tenderly
                     .simulate(tx.clone(), tenderly::GenerateAccessList::No)
                     .measure("tenderly_simulate_gas")
                     .await
-                    .map_err(with_tx(tx))?
+                    .map_err(with(tx, block))?
                     .gas
             }
-            Inner::Ethereum(ethereum) => ethereum
+            Inner::Ethereum => self
+                .eth
                 .estimate_gas(tx.clone())
                 .await
-                .map_err(with_tx(tx))?,
-            Inner::Enso(enso, _) => enso
+                .map_err(with(tx, block))?,
+            Inner::Enso(enso) => enso
                 .simulate(tx.clone())
                 .measure("enso_simulate_gas")
                 .await
-                .map_err(with_tx(tx))?,
+                .map_err(with(tx, block))?,
         })
     }
 }
@@ -125,8 +134,8 @@ impl Simulator {
 #[derive(Debug, Clone)]
 enum Inner {
     Tenderly(tenderly::Tenderly),
-    Ethereum(Ethereum),
-    Enso(enso::Enso, Ethereum),
+    Ethereum,
+    Enso(enso::Enso),
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -140,10 +149,11 @@ pub enum SimulatorError {
 }
 
 #[derive(Debug, thiserror::Error)]
-#[error("err: {err:?}, tx: {tx:?}")]
-pub struct WithTxError {
+#[error("block: {block:?},  err: {err:?}, tx: {tx:?}")]
+pub struct RevertError {
     pub err: SimulatorError,
     pub tx: eth::Tx,
+    pub block: eth::BlockNo,
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -153,10 +163,10 @@ pub enum Error {
     /// If a transaction reverted, forward that transaction together with the
     /// error.
     #[error(transparent)]
-    WithTx(#[from] WithTxError),
+    Revert(#[from] RevertError),
 }
 
-fn with_tx<E>(tx: eth::Tx) -> impl FnOnce(E) -> Error
+fn with<E>(tx: eth::Tx, block: eth::BlockNo) -> impl FnOnce(E) -> Error
 where
     E: Into<SimulatorError>,
 {
@@ -185,7 +195,7 @@ where
             SimulatorError::Enso(enso::Error::Revert(_)) => Some(tx),
         };
         match tx {
-            Some(tx) => Error::WithTx(WithTxError { err, tx }),
+            Some(tx) => Error::Revert(RevertError { err, tx, block }),
             None => Error::Basic(err),
         }
     }

--- a/crates/driver/src/infra/simulator/mod.rs
+++ b/crates/driver/src/infra/simulator/mod.rs
@@ -79,7 +79,7 @@ impl Simulator {
         if self.disable_access_lists {
             return Ok(tx.access_list);
         }
-        let block: eth::BlockNo = self.eth.current_block().borrow().number.into();
+        let block = self.eth.current_block().borrow().number.into();
         let access_list = match &self.inner {
             Inner::Tenderly(tenderly) => {
                 tenderly
@@ -107,7 +107,7 @@ impl Simulator {
         if let Some(gas) = self.disable_gas {
             return Ok(gas);
         }
-        let block: eth::BlockNo = self.eth.current_block().borrow().number.into();
+        let block = self.eth.current_block().borrow().number.into();
         Ok(match &self.inner {
             Inner::Tenderly(tenderly) => {
                 tenderly

--- a/crates/driver/src/infra/solver/dto/notification.rs
+++ b/crates/driver/src/infra/solver/dto/notification.rs
@@ -25,13 +25,16 @@ impl Notification {
             kind: match kind {
                 notify::Kind::Timeout => Kind::Timeout,
                 notify::Kind::EmptySolution => Kind::EmptySolution,
-                notify::Kind::SimulationFailed(tx) => Kind::SimulationFailed(Tx {
-                    from: tx.from.into(),
-                    to: tx.to.into(),
-                    input: tx.input.into(),
-                    value: tx.value.into(),
-                    access_list: tx.access_list.into(),
-                }),
+                notify::Kind::SimulationFailed(block, tx) => Kind::SimulationFailed(
+                    block.0,
+                    Tx {
+                        from: tx.from.into(),
+                        to: tx.to.into(),
+                        input: tx.input.into(),
+                        value: tx.value.into(),
+                        access_list: tx.access_list.into(),
+                    },
+                ),
                 notify::Kind::ScoringFailed(notify::ScoreKind::ZeroScore) => {
                     Kind::ScoringFailed(ScoreKind::ZeroScore)
                 }
@@ -100,7 +103,7 @@ pub enum Kind {
     Timeout,
     EmptySolution,
     DuplicatedSolutionId,
-    SimulationFailed(Tx),
+    SimulationFailed(BlockNo, Tx),
     ScoringFailed(ScoreKind),
     NonBufferableTokensUsed {
         tokens: BTreeSet<eth::H160>,
@@ -114,6 +117,8 @@ pub enum Kind {
     },
     Settled(Settlement),
 }
+
+type BlockNo = u64;
 
 #[serde_as]
 #[derive(Debug, Serialize)]

--- a/crates/driver/src/run.rs
+++ b/crates/driver/src/run.rs
@@ -103,6 +103,7 @@ fn simulator(config: &infra::Config, eth: &Ethereum) -> Simulator {
                 save_if_fails: tenderly.save_if_fails,
             },
             eth.network().id.clone(),
+            eth.to_owned(),
         ),
         Some(infra::simulator::Config::Enso(enso)) => Simulator::enso(
             simulator::enso::Config {

--- a/crates/solvers/src/api/routes/notify/dto/notification.rs
+++ b/crates/solvers/src/api/routes/notify/dto/notification.rs
@@ -23,13 +23,16 @@ impl Notification {
             kind: match &self.kind {
                 Kind::Timeout => notification::Kind::Timeout,
                 Kind::EmptySolution => notification::Kind::EmptySolution,
-                Kind::SimulationFailed(tx) => notification::Kind::SimulationFailed(eth::Tx {
-                    from: tx.from.into(),
-                    to: tx.to.into(),
-                    input: tx.input.clone().into(),
-                    value: tx.value.into(),
-                    access_list: tx.access_list.clone(),
-                }),
+                Kind::SimulationFailed(block, tx) => notification::Kind::SimulationFailed(
+                    *block,
+                    eth::Tx {
+                        from: tx.from.into(),
+                        to: tx.to.into(),
+                        input: tx.input.clone().into(),
+                        value: tx.value.into(),
+                        access_list: tx.access_list.clone(),
+                    },
+                ),
                 Kind::ScoringFailed(ScoreKind::ObjectiveValueNonPositive { quality, gas_cost }) => {
                     notification::Kind::ScoringFailed(
                         notification::ScoreKind::ObjectiveValueNonPositive(
@@ -113,7 +116,7 @@ pub enum Kind {
     Timeout,
     EmptySolution,
     DuplicatedSolutionId,
-    SimulationFailed(Tx),
+    SimulationFailed(BlockNo, Tx),
     ScoringFailed(ScoreKind),
     NonBufferableTokensUsed {
         tokens: BTreeSet<H160>,
@@ -127,6 +130,8 @@ pub enum Kind {
     },
     Settled(Settlement),
 }
+
+type BlockNo = u64;
 
 #[serde_as]
 #[derive(Debug, Deserialize)]

--- a/crates/solvers/src/boundary/legacy.rs
+++ b/crates/solvers/src/boundary/legacy.rs
@@ -588,8 +588,6 @@ fn to_domain_solution(
     })
 }
 
-const UNKNOWN_BLOCK_NUMBER: u64 = 0;
-
 fn to_boundary_auction_result(notification: &notification::Notification) -> (i64, AuctionResult) {
     let auction_id = match notification.auction_id {
         auction::Id::Solve(id) => id,
@@ -601,7 +599,7 @@ fn to_boundary_auction_result(notification: &notification::Notification) -> (i64
             AuctionResult::Rejected(SolverRejectionReason::RunError(SolverRunError::Timeout))
         }
         Kind::EmptySolution => AuctionResult::Rejected(SolverRejectionReason::NoUserOrders),
-        Kind::SimulationFailed(tx) => AuctionResult::Rejected(
+        Kind::SimulationFailed(block_number, tx) => AuctionResult::Rejected(
             SolverRejectionReason::SimulationFailure(TransactionWithError {
                 error: "".to_string(),
                 transaction: SimulatedTransaction {
@@ -609,7 +607,7 @@ fn to_boundary_auction_result(notification: &notification::Notification) -> (i64
                     to: tx.to.into(),
                     data: tx.input.clone().into(),
                     internalization: InternalizationStrategy::Unknown,
-                    block_number: UNKNOWN_BLOCK_NUMBER, // todo #2018
+                    block_number: *block_number,
                     tx_index: Default::default(),
                     access_list: Default::default(),
                     max_fee_per_gas: Default::default(),

--- a/crates/solvers/src/domain/notification.rs
+++ b/crates/solvers/src/domain/notification.rs
@@ -11,6 +11,7 @@ type RequiredEther = Ether;
 type TokensUsed = BTreeSet<TokenAddress>;
 type TransactionHash = eth::H256;
 type Transaction = eth::Tx;
+type BlockNo = u64;
 type Missmatches = HashMap<eth::TokenAddress, num::BigInt>;
 
 /// The notification about important events happened in driver, that solvers
@@ -28,7 +29,7 @@ pub enum Kind {
     Timeout,
     EmptySolution,
     DuplicatedSolutionId,
-    SimulationFailed(Transaction),
+    SimulationFailed(BlockNo, Transaction),
     ScoringFailed(ScoreKind),
     NonBufferableTokensUsed(TokensUsed),
     SolverAccountInsufficientBalance(RequiredEther),


### PR DESCRIPTION
# Description
Fixes https://github.com/cowprotocol/services/issues/2018

# Changes
<!-- List of detailed changes (how the change is accomplished) -->

- [ ] Added block number to each simulation failure. The block number is approximately fetched from the `web3`. 
- [ ] Used this block number for `notify` calls
- [ ] Extracted `notify::simulation_failure` as it is important enough to have it's own function

