### PR TITLE
Use OnceCell to manage liquidity source initialization

### DIFF
--- a/crates/solver/src/liquidity_collector.rs
+++ b/crates/solver/src/liquidity_collector.rs
@@ -2,9 +2,9 @@ use {
     crate::liquidity::Liquidity,
     anyhow::Result,
     model::TokenPair,
+    once_cell::sync::OnceCell,
     shared::{baseline_solver::BaseTokens, recent_block_cache::Block},
     std::{collections::HashSet, future::Future, sync::Arc, time::Duration},
-    tokio::sync::Mutex,
     tracing::Instrument,
 };
 
@@ -51,7 +51,7 @@ impl LiquidityCollecting for LiquidityCollector {
 /// succeeds. Until the liquidity source has been initialised no liquidity will
 /// be provided.
 pub struct BackgroundInitLiquiditySource<L> {
-    liquidity_source: Arc<Mutex<Option<L>>>,
+    liquidity_source: Arc<OnceCell<L>>,
 }
 
 impl<L> BackgroundInitLiquiditySource<L> {
@@ -67,7 +67,7 @@ impl<L> BackgroundInitLiquiditySource<L> {
             .liquidity_enabled
             .with_label_values(&[label])
             .set(0);
-        let liquidity_source: Arc<Mutex<Option<L>>> = Default::default();
+        let liquidity_source = Arc::new(OnceCell::new());
         let inner = liquidity_source.clone();
         let inner_label = label.to_owned();
         tokio::task::spawn(
@@ -82,7 +82,13 @@ impl<L> BackgroundInitLiquiditySource<L> {
                             tokio::time::sleep(retry_init_timeout).await;
                         }
                         Ok(source) => {
-                            let _ = inner.lock().await.insert(source);
+                            if inner.set(source).is_err() {
+                                // should never happen but if it does we want to know about it ASAP
+                                tracing::error!(
+                                    source = inner_label,
+                                    "liquidity source already initialized"
+                                );
+                            }
                             tracing::debug!("successfully initialised liquidity source");
                             Metrics::get()
                                 .liquidity_enabled
@@ -110,15 +116,8 @@ where
         pairs: HashSet<TokenPair>,
         at_block: Block,
     ) -> Result<Vec<Liquidity>> {
-        // Use `try_lock` to not block caller when the lock is currently being held for
-        // a potentially very slow init logic.
-        let liquidity_source = match self.liquidity_source.try_lock() {
-            Ok(lock) => lock,
-            Err(_) => return Ok(vec![]),
-        };
-
-        match &*liquidity_source {
-            Some(initialised_source) => initialised_source.get_liquidity(pairs, at_block).await,
+        match self.liquidity_source.get() {
+            Some(source) => source.get_liquidity(pairs, at_block).await,
             None => Ok(vec![]),
         }
     }

--- a/crates/solver/src/liquidity_collector.rs
+++ b/crates/solver/src/liquidity_collector.rs
@@ -88,12 +88,14 @@ impl<L> BackgroundInitLiquiditySource<L> {
                                     source = inner_label,
                                     "liquidity source already initialized"
                                 );
+                            } else {
+                                tracing::debug!("successfully initialised liquidity source");
+                                Metrics::get()
+                                    .liquidity_enabled
+                                    .with_label_values(&[&inner_label])
+                                    .inc();
                             }
-                            tracing::debug!("successfully initialised liquidity source");
-                            Metrics::get()
-                                .liquidity_enabled
-                                .with_label_values(&[&inner_label])
-                                .inc();
+
                             break;
                         }
                     }


### PR DESCRIPTION
# Description
We currently have an issue that some solvers receive only uni v2 based liquidity and usually at most 1 solvers receives balancer or uni v3 based liquidity. This is caused by the too simplistic initialization logic inside `BackgroundInitLiquiditySource`. It was written at a time when it would not be queried in parallel (for which the implementation would be fine) but for the new driver (which can query it multiple times in parallel) it results in wrong liquidity availability.
The issue is basically that the old code used `try_lock` because it assumed only the background task running a (potentially) slow initialization logic could use it in parallel. In that case we wanted to return an empty result early.
However with the new code an initialized liquidity source might be locked because it is currently used by another task.

# Changes
The new logic uses `OnceCell` to manage the access to the underlying data source. It enforces that it can only be initialized once and therefore doesn't has to take a lock on `.get()` request. Now multiple solvers can use the liquidity source in parallel and therefore receive the juicy uni v3 and balancer v2 liquidity.