### PR TITLE
Add legacy solvers requests compression config

### DIFF
--- a/crates/solvers/config/example.legacy.toml
+++ b/crates/solvers/config/example.legacy.toml
@@ -1,3 +1,4 @@
 chain-id = "1"
 solver-name = "CoW Solver"
 endpoint = "https://solver.cow.fi"
+gzip-requests = false

--- a/crates/solvers/src/boundary/legacy.rs
+++ b/crates/solvers/src/boundary/legacy.rs
@@ -73,7 +73,7 @@ impl Legacy {
                 chain_id: config.chain_id.value().as_u64(),
                 base,
                 client: reqwest::Client::new(),
-                gzip_requests: false,
+                gzip_requests: config.gzip_requests,
                 solve_path,
                 config: SolverConfig {
                     // Note that we unconditionally set this to "true". This is

--- a/crates/solvers/src/domain/solver/legacy.rs
+++ b/crates/solvers/src/domain/solver/legacy.rs
@@ -17,6 +17,7 @@ pub struct Config {
     pub solver_name: String,
     pub chain_id: eth::ChainId,
     pub endpoint: Url,
+    pub gzip_requests: bool,
 }
 
 pub struct Legacy(boundary::legacy::Legacy);

--- a/crates/solvers/src/infra/config/legacy.rs
+++ b/crates/solvers/src/infra/config/legacy.rs
@@ -25,6 +25,9 @@ struct Config {
 
     /// The URL of the endpoint that responds to solve requests.
     endpoint: String,
+
+    /// Enabled requests compression
+    gzip_requests: bool,
 }
 
 /// Load the driver configuration from a TOML file.
@@ -44,5 +47,6 @@ pub async fn load(path: &Path) -> legacy::Config {
         solver_name: config.solver_name,
         chain_id: config.chain_id,
         endpoint: Url::parse(&config.endpoint).unwrap(),
+        gzip_requests: config.gzip_requests,
     }
 }

--- a/crates/solvers/src/infra/config/legacy.rs
+++ b/crates/solvers/src/infra/config/legacy.rs
@@ -27,6 +27,7 @@ struct Config {
     endpoint: String,
 
     /// Enabled requests compression
+    #[serde(default)]
     gzip_requests: bool,
 }
 

--- a/crates/solvers/src/tests/legacy/mod.rs
+++ b/crates/solvers/src/tests/legacy/mod.rs
@@ -12,6 +12,7 @@ pub fn config(solver_addr: &SocketAddr) -> tests::Config {
 solver-name = 'legacy_solver'
 endpoint = 'http://{solver_addr}/solve'
 chain-id = '1'
+gzip-requests = false
         ",
     ))
 }


### PR DESCRIPTION
# Description
Adds an ability to configure GZIP compression of HTTP requests in each legacy solver.

# Changes
A new boolean `gzip_requests` config field.
k8s manifest PR https://github.com/cowprotocol/infrastructure/pull/859 which is required to be deployed first

## How to test
TBD: would it be possible to test it in staging with any solver?

## Related Issues
Fixes #916