### PR TITLE
Avoid double balance caching race condition

### DIFF
--- a/crates/shared/src/api.rs
+++ b/crates/shared/src/api.rs
@@ -48,7 +48,7 @@ struct ApiMetrics {
 impl ApiMetrics {
     // Status codes we care about in our application. Populated with:
     // `rg -oIN 'StatusCode::[A-Z_]+' | sort | uniq`.
-    const INITIAL_STATUSES: &[StatusCode] = &[
+    const INITIAL_STATUSES: &'static [StatusCode] = &[
         StatusCode::OK,
         StatusCode::CREATED,
         StatusCode::BAD_REQUEST,


### PR DESCRIPTION
# Description
While working on dockerizing the e2e tests I noticed that we can run into an annoying race condition caused by caching balances in 2 places (balancer fetcher and solvable orders).
Given this scenario:
1. start solvable orders block
2. it notices a new block appeared so it asks the balance fetcher for the new balances
3. balancer fetcher did not yet see the new block so it returns the old unchanged balances
4. solvable orders caches old balances

This case is not a big deal in production but I'm fairly confident this causes our flaky e2e tests. Because those e2e tests only produce blocks when a tx needs to get mined we can encounter the scenario where that test waits for an order to be settled which will never happen because the `autopilot` never noticed that the user has the required balances by now.

# Changes
Removes caching in the `SolvableOrdersCache` because we already have a cache in the balance fetcher. Also we wouldn't really want to build new auction on the same block anyway so we shouldn't even be able to use balances cached by the `SolvableOrderCache`.

## How to test
e2e tests still pass