### PR TITLE
Fix storing settlement observations

### DIFF
--- a/crates/autopilot/src/database/on_settlement_event_updater.rs
+++ b/crates/autopilot/src/database/on_settlement_event_updater.rs
@@ -95,8 +95,9 @@ impl super::Postgres {
             .await
             .context("failed to insert auction_transaction")?;
 
-            // It's always fine to store a settlement observation.
-            database::settlement_observations::insert(
+            // in case of deep reindexing we might already have the observation, so just
+            // overwrite it
+            database::settlement_observations::upsert(
                 ex,
                 Observation {
                     block_number: settlement_update.block_number,


### PR DESCRIPTION
# Description
Fixes current issue we have in gnosis chain staging, where deep reindexing happened and on_settlement_event_handler doesn't handle it properly. 