### PR TITLE
[Trivial] filter out empty solutions when quoting

### DIFF
--- a/crates/driver/src/domain/quote.rs
+++ b/crates/driver/src/domain/quote.rs
@@ -98,7 +98,7 @@ impl Order {
             // first solution
             solutions
                 .into_iter()
-                .next()
+                .find(|solution| !solution.is_empty())
                 .ok_or(QuotingFailed::NoSolutions)?,
         )
     }


### PR DESCRIPTION
# Description
We are seeing a lot of WARN logs for orders that can't be quoted a la:

> driver::infra::observe: failed to quote order order=Order { tokens: Tokens { sell: TokenAddress(ContractAddress(0xf939e0a03fb07f59a73314e73794be0e57ac1b4e)), buy: TokenAddress(ContractAddress(0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2)) }, amount: TargetAmount(100000000000000000), side: Buy, deadline: Deadline { driver: 2023-11-23T07:58:46.894119698Z, solvers: 2023-11-23T07:58:45.995982488Z } } err=QuotingFailed(ClearingSellMissing)

This is because some solvers instead of returning no solution return the "trivial" solution if they cannot solve the auciton:

> solvers::api::routes::solve: auction_id=Quote solutions=[Solution { id: Id(0), prices: ClearingPrices({}), trades: [], interactions: [], score: RiskAdjusted(SuccessProbability(1.0)) }]

Since this warning looks a bit cryptic and we already do have an error for NoSolutions, this PR makes it that we instead show

> /quote{solver=baseline}: driver::infra::observe: failed to quote order order=Order { tokens: Tokens { sell: TokenAddress(ContractAddress(0x15f74458ae0bfdaa1a96ca1aa779d715cc1eefe4)), buy: TokenAddress(ContractAddress(0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2)) }, amount: TargetAmount(100000000000000000), side: Buy, deadline: Deadline { driver: 2023-11-23T08:04:36.803626137Z, solvers: 2023-11-23T08:04:35.904046019Z } } err=QuotingFailed(NoSolutions)

# Changes
Filter out empty solutions before passing them to create an invalid quote.

## How to test
Run locally, get a quote which cannot be filled, observe logs

<!--
## Related Issues

Fixes #
-->