### PR TITLE
Fix order likelihood logic

### DIFF
--- a/crates/driver/src/domain/competition/auction.rs
+++ b/crates/driver/src/domain/competition/auction.rs
@@ -336,7 +336,7 @@ impl AuctionProcessor {
 
 /// The tokens that are used in an auction.
 #[derive(Debug, Default)]
-pub struct Tokens(HashMap<eth::TokenAddress, Token>);
+pub struct Tokens(pub HashMap<eth::TokenAddress, Token>);
 
 impl Tokens {
     pub fn get(&self, address: eth::TokenAddress) -> Token {

--- a/crates/driver/src/domain/competition/auction.rs
+++ b/crates/driver/src/domain/competition/auction.rs
@@ -336,7 +336,7 @@ impl AuctionProcessor {
 
 /// The tokens that are used in an auction.
 #[derive(Debug, Default)]
-pub struct Tokens(pub HashMap<eth::TokenAddress, Token>);
+pub struct Tokens(HashMap<eth::TokenAddress, Token>);
 
 impl Tokens {
     pub fn get(&self, address: eth::TokenAddress) -> Token {

--- a/crates/driver/src/domain/competition/order/mod.rs
+++ b/crates/driver/src/domain/competition/order/mod.rs
@@ -219,9 +219,9 @@ impl Order {
             (Some(buy_price), Some(sell_price)) => {
                 let buy = buy_price.apply(self.buy.amount);
                 let sell = sell_price.apply(self.sell.amount);
-                buy.0
+                sell.0
                     .to_big_rational()
-                    .checked_div(&sell.0.to_big_rational())
+                    .checked_div(&buy.0.to_big_rational())
                     .unwrap_or_else(num::BigRational::zero)
             }
             _ => num::BigRational::zero(),
@@ -410,7 +410,10 @@ impl Jit {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use {
+        super::*,
+        crate::domain::competition::auction::{Price, Token, Tokens},
+    };
 
     #[test]
     fn order_scaling() {
@@ -500,5 +503,113 @@ mod tests {
         assert_eq!(order(1, 1000, Some(buy(500))).available(weth).buy, buy(500));
 
         assert_eq!(order(0, 0, Some(sell(0))).available(weth).sell, sell(0));
+    }
+
+    #[test]
+    fn order_likelihood() {
+        let sell = |amount: u64| eth::Asset {
+            token: eth::H160::from_low_u64_be(0x5e11).into(),
+            amount: eth::U256::from(amount).into(),
+        };
+        let buy = |amount: u64| eth::Asset {
+            token: eth::H160::from_low_u64_be(0xbbbb).into(),
+            amount: eth::U256::from(amount).into(),
+        };
+        let order = |buy_amount, sell_amount| Order {
+            uid: Default::default(),
+            receiver: Default::default(),
+            valid_to: util::Timestamp(u32::MAX),
+            buy: buy(buy_amount),
+            sell: sell(sell_amount),
+            side: Side::Sell,
+            fee: Default::default(),
+            kind: Kind::Limit,
+            app_data: Default::default(),
+            partial: Partial::No,
+            pre_interactions: Default::default(),
+            post_interactions: Default::default(),
+            sell_token_balance: SellTokenBalance::Erc20,
+            buy_token_balance: BuyTokenBalance::Erc20,
+            signature: Signature {
+                scheme: signature::Scheme::PreSign,
+                data: Default::default(),
+                signer: Default::default(),
+            },
+        };
+
+        let tokens = Tokens(maplit::hashmap! {
+            sell(0).token => Token {
+                decimals: Some(18),
+                symbol: Some("Sell".into()),
+                address: sell(0).token,
+                price: Some(Price::new(10_000_000.into()).unwrap()),
+                available_balance: eth::U256::zero(),
+                trusted: false,
+            },
+            buy(0).token => Token {
+                decimals: Some(18),
+                symbol: Some("Buy".into()),
+                address: buy(0).token,
+                price: Some(Price::new(10_000_000.into()).unwrap()),
+                available_balance: eth::U256::zero(),
+                trusted: false,
+            },
+        });
+
+        // Equal orders have equal likelihood
+        assert_eq!(
+            order(10, 10).likelihood(&tokens),
+            order(10, 10).likelihood(&tokens)
+        );
+
+        // Buying 1 with 10 is more likely to fill than buying 10 with 10
+        assert!(order(1, 10).likelihood(&tokens) > order(10, 10).likelihood(&tokens));
+
+        // Buying 10 with 1 is less likely to fill than buying 10 with 10
+        assert!(order(10, 1).likelihood(&tokens) < order(10, 10).likelihood(&tokens));
+
+        // Buying something worth 10 is more likely to fill than buying the same amount
+        // worth 11
+        let alternative_tokens = Tokens(maplit::hashmap! {
+            sell(0).token => Token {
+                decimals: Some(18),
+                symbol: Some("Sell".into()),
+                address: sell(0).token,
+                price: Some(Price::new(10_000_000.into()).unwrap()),
+                available_balance: eth::U256::zero(),
+                trusted: false,
+            },
+            buy(0).token => Token {
+                decimals: Some(18),
+                symbol: Some("Buy".into()),
+                address: buy(0).token,
+                price: Some(Price::new(11_000_000.into()).unwrap()),
+                available_balance: eth::U256::zero(),
+                trusted: false,
+            },
+        });
+        assert!(order(5, 5).likelihood(&tokens) > order(5, 5).likelihood(&alternative_tokens));
+
+        // Selling something worth 10 is more likely to fill than selling
+        // the same amount worth 9
+        let alternative_tokens = Tokens(maplit::hashmap! {
+            sell(0).token => Token {
+                decimals: Some(18),
+                symbol: Some("Sell".into()),
+                address: sell(0).token,
+                price: Some(Price::new(9_000_000.into()).unwrap()),
+                available_balance: eth::U256::zero(),
+                trusted: false,
+            },
+            buy(0).token => Token {
+                decimals: Some(18),
+                symbol: Some("Buy".into()),
+                address: buy(0).token,
+                price: Some(Price::new(10_000_000.into()).unwrap()),
+                available_balance: eth::U256::zero(),
+                trusted: false,
+            },
+        });
+        assert!(order(5, 5).likelihood(&tokens) > order(5, 5).likelihood(&alternative_tokens));
     }
 }

--- a/crates/driver/src/tests/cases/merge_settlements.rs
+++ b/crates/driver/src/tests/cases/merge_settlements.rs
@@ -10,8 +10,8 @@ async fn possible() {
     let test = setup()
         .pool(cd_pool())
         .pool(ab_pool())
-        .order(cd_order())
         .order(ab_order())
+        .order(cd_order())
         .solution(cd_solution())
         .solution(ab_solution())
         .done()
@@ -40,8 +40,8 @@ async fn possible() {
 async fn impossible() {
     let test = setup()
         .pool(ab_pool())
-        .order(ab_order().rename("reduced order").reduce_amount(1000000000000000u128.into()))
         .order(ab_order())
+        .order(ab_order().rename("reduced order").reduce_amount(1000000000000000u128.into()))
         // These two solutions result in different clearing prices (due to different surplus),
         // so they can't be merged.
         .solution(ab_solution())

--- a/crates/driver/src/tests/cases/negative_scores.rs
+++ b/crates/driver/src/tests/cases/negative_scores.rs
@@ -26,8 +26,8 @@ async fn no_valid_solutions() {
 async fn one_valid_solution() {
     let test = setup()
         .pool(ab_pool())
-        .order(ab_order().rename("no surplus").no_surplus())
         .order(ab_order())
+        .order(ab_order().rename("no surplus").no_surplus())
         .solution(ab_solution())
         // This solution has no surplus, and hence a negative score, so it gets skipped.
         .solution(Solution {

--- a/crates/driver/src/tests/cases/order_prioritization.rs
+++ b/crates/driver/src/tests/cases/order_prioritization.rs
@@ -10,19 +10,15 @@ async fn sorting() {
     let test = setup()
         .pool(ab_pool())
         // Orders with better price ratios come first.
-        .order(
-            ab_order()
-                .reduce_amount(1000000000000000u128.into()),
-        )
-        .order(ab_order().rename("second order"))
+        .order(ab_order())
+        .order(ab_order().reduce_amount(1000000000000000u128.into()).rename("second order"))
         // Limit orders come after market orders.
         .order(
             ab_order()
                 .rename("third order")
                 .limit()
-                .reduce_amount(1000000000000000u128.into()),
         )
-        .order(ab_order().rename("fourth order").limit())
+        .order(ab_order().reduce_amount(1000000000000000u128.into()).rename("fourth order").limit())
         .solution(ab_solution())
         .done()
         .await;
@@ -40,11 +36,8 @@ async fn filtering() {
     let test = setup()
         .pool(ab_pool())
         // Orders with better price ratios come first.
-        .order(
-            ab_order()
-                .reduce_amount(1000000000000000u128.into()),
-        )
-        .order(ab_order().rename("second order"))
+        .order(ab_order())
+        .order(ab_order().reduce_amount(1000000000000000u128.into()).rename("second order"))
         // Filter out the next order, because the trader doesn't have enough balance to cover it.
         .order(
             ab_order()
@@ -56,7 +49,7 @@ async fn filtering() {
         // fulfill the previous orders.
         .order(
             Order {
-                sell_amount: 4999899999900002000000000000000u128.into(),
+                sell_amount: 4999999999900002000000000000000u128.into(),
                 surplus_factor: 1.into(),
                 ..ab_order()
             }


### PR DESCRIPTION
# Description

I noticed that when placing a too optimistically quoted order on Gnosis Chain (which cannot fill) and later placing another more realistic order on top, the second order only gets filled once the first one is expired or cancelled. This is because the driver filters out the second order as it looks like the user only has balance for the first. However, in theory we should sort orders by their expected chance of filling (taking the external auction prices into account), meaning the second order with a more lax limit price should have priority over the first order:

https://github.com/cowprotocol/services/blob/fd7f12dded72359c087be6f3c04b898241c3eb20/crates/driver/src/domain/competition/auction.rs#L176-L195

The root cause seems to be that likelihood wasn't implemented correctly, which this PR ixes

# Changes
- Add unit tests for the likelihood method
- Inverse the ratio that is returned by the method to comply with its documentation (higher value means higher likelihood)

## How to test
Unit tests, also redo the test where we set an order with extremely tight slippage tolerance that doesn't fill and place a higher slippage order afterwards.

<!--
## Related Issues

Fixes #
-->