### PR TITLE
Don't send empty solutions to the driver

### DIFF
--- a/crates/solvers/src/domain/solution.rs
+++ b/crates/solvers/src/domain/solution.rs
@@ -112,6 +112,10 @@ impl Solution {
 
         self
     }
+
+    pub fn is_empty(&self) -> bool {
+        self.trades.is_empty()
+    }
 }
 
 /// A solution for a settling a single order.

--- a/crates/solvers/src/domain/solution.rs
+++ b/crates/solvers/src/domain/solution.rs
@@ -114,7 +114,7 @@ impl Solution {
     }
 
     pub fn is_empty(&self) -> bool {
-        self.trades.is_empty()
+        self.prices.0.is_empty() && self.trades.is_empty() && self.interactions.is_empty()
     }
 }
 

--- a/crates/solvers/src/domain/solver/legacy.rs
+++ b/crates/solvers/src/domain/solver/legacy.rs
@@ -29,7 +29,8 @@ impl Legacy {
 
     pub async fn solve(&self, auction: auction::Auction) -> Vec<solution::Solution> {
         match self.0.solve(&auction).await {
-            Ok(solution) => vec![solution.with_id(solution::Id(0))],
+            Ok(solution) if !solution.is_empty() => vec![solution.with_id(solution::Id(0))],
+            Ok(_) => vec![],
             Err(err) => {
                 tracing::warn!(?err, "failed to solve auction");
                 if err.is_timeout() {

--- a/crates/solvers/src/domain/solver/legacy.rs
+++ b/crates/solvers/src/domain/solver/legacy.rs
@@ -29,8 +29,13 @@ impl Legacy {
 
     pub async fn solve(&self, auction: auction::Auction) -> Vec<solution::Solution> {
         match self.0.solve(&auction).await {
-            Ok(solution) if !solution.is_empty() => vec![solution.with_id(solution::Id(0))],
-            Ok(_) => vec![],
+            Ok(solution) => {
+                if solution.is_empty() {
+                    vec![]
+                } else {
+                    vec![solution]
+                }
+            }
             Err(err) => {
                 tracing::warn!(?err, "failed to solve auction");
                 if err.is_timeout() {


### PR DESCRIPTION
# Description
I don't find empty solutions useful in driver/solvers communication. Currently, all solvers except legacy solvers return empty vector when they can't find a solution, while legacy sends empty solution:

https://production-6de61f.kb.eu-central-1.aws.cloud.es.io/app/r/s/ldj1i

I find it hard to read. Solvers should be consistent.

This PR changes legacy solver to send no solutions to the driver.
I still we should still keep the proper handling of empty solutions in the `driver` since we won't control the solvers forever.