### PR TITLE
Add metrics for the shadow autopilot

### DIFF
--- a/crates/autopilot/src/run.rs
+++ b/crates/autopilot/src/run.rs
@@ -672,6 +672,8 @@ async fn shadow_mode(args: Arguments) -> ! {
         .await
     };
 
+    let _ = shared::metrics::serve_metrics(Arc::new(shadow::Liveness), args.metrics_address);
+
     let shadow = shadow::RunLoop::new(
         orderbook,
         drivers,


### PR DESCRIPTION
# Description
When changing the shadow infra over to the colocated architecture, we need to also create a replacement for the shadow [solver dashboard](https://g-0263500beb.grafana-workspace.eu-central-1.amazonaws.com/d/AGoBVqH7z/gpv2-shadow-traffic-staging?orgId=1). This PR prepares this.

# Changes
<!-- List of detailed changes (how the change is accomplished) -->

- [ ] Implement dummy liveness check for shadow runloop
- [ ] Serve metrics in shadow mode
- [ ] Record a few more metrics (mainly the winner in each auction + total orders in the book)

## How to test
Running locally and checking http://localhost:9589/metrics

Will update the dashboard once this is merged.