### PR TITLE
Store quotes for limit orders

### DIFF
--- a/crates/autopilot/src/database/onchain_order_events.rs
+++ b/crates/autopilot/src/database/onchain_order_events.rs
@@ -573,7 +573,7 @@ async fn get_quote(
         quoter,
         &parameters.clone(),
         Some(*quote_id),
-        order_data.fee_amount,
+        Some(order_data.fee_amount),
     )
     .await
     .map_err(onchain_order_placement_error_from)


### PR DESCRIPTION
# Description
Fixes https://github.com/cowprotocol/services/issues/2078

# Changes
<!-- List of detailed changes (how the change is accomplished) -->

- [ ] Limit orders are no longer skipped when the quote is determined and stored into database.

## How to test
Will observe the behavior on staging to make sure the quotes are stored.