### PR TITLE
[Trivial] Do not log full auction

### DIFF
--- a/crates/driver/src/infra/observe/mod.rs
+++ b/crates/driver/src/infra/observe/mod.rs
@@ -40,7 +40,7 @@ pub fn init(log: &str) {
 
 /// Observe a received auction.
 pub fn auction(auction: &Auction) {
-    tracing::debug!(?auction, "received auction");
+    tracing::debug!(id=?auction.id(), "received auction");
 }
 
 /// Observe that liquidity fetching is about to start.


### PR DESCRIPTION
# Description
This log is creating issues with Kibana ([context](https://cowservices.slack.com/archives/C036PMLUPQF/p1701088972191479)). Moreover it is redundant (printed once per driver) and the same information can be recovered from the autopilot who also logs the current auction.