### PR TITLE
Periodic order events table clean up

### DIFF
--- a/crates/autopilot/src/database/order_events.rs
+++ b/crates/autopilot/src/database/order_events.rs
@@ -7,6 +7,7 @@ use {
         order_events::{self, OrderEvent},
     },
     model::order::OrderUid,
+    sqlx::Error,
 };
 
 impl super::Postgres {
@@ -18,6 +19,11 @@ impl super::Postgres {
         if let Err(err) = store_order_events(self, events, Utc::now()).await {
             tracing::warn!(?err, "failed to insert order events");
         }
+    }
+
+    /// Deletes events before the provided timestamp.
+    pub async fn delete_events_before(&self, timestamp: DateTime<Utc>) -> Result<u64, Error> {
+        order_events::delete_order_events_before(&self.0, timestamp).await
     }
 }
 

--- a/crates/autopilot/src/database/order_events.rs
+++ b/crates/autopilot/src/database/order_events.rs
@@ -22,7 +22,7 @@ impl super::Postgres {
     }
 
     /// Deletes events before the provided timestamp.
-    pub async fn delete_events_before(&self, timestamp: DateTime<Utc>) -> Result<u64, Error> {
+    pub async fn delete_order_events_before(&self, timestamp: DateTime<Utc>) -> Result<u64, Error> {
         order_events::delete_order_events_before(&self.0, timestamp).await
     }
 }

--- a/crates/autopilot/src/lib.rs
+++ b/crates/autopilot/src/lib.rs
@@ -5,6 +5,7 @@ pub mod driver_api;
 pub mod driver_model;
 pub mod event_updater;
 pub mod on_settlement_event_updater;
+pub mod periodic_db_cleanup;
 pub mod protocol;
 pub mod run;
 pub mod run_loop;

--- a/crates/autopilot/src/periodic_db_cleanup.rs
+++ b/crates/autopilot/src/periodic_db_cleanup.rs
@@ -31,23 +31,24 @@ impl OrderEventsCleaner {
 
     pub async fn run_forever(self) -> ! {
         let mut interval = time::interval(self.config.cleanup_interval);
+        println!("starting");
+        interval.tick().await; // Initial tick to start the interval
+
         loop {
             let timestamp: DateTime<Utc> = Utc::now() - self.config.event_age_threshold;
-            match self.db.delete_events_before(timestamp).await {
+            println!("removing before {}", timestamp);
+            match self.db.delete_order_events_before(timestamp).await {
                 Ok(affected_rows_count) => {
-                    tracing::debug!(
-                        "deleted {:?} order events before {}",
-                        affected_rows_count,
-                        timestamp
-                    );
-                    Metrics::get()
-                        .last_order_events_cleanup_run
-                        .set(Utc::now().timestamp())
+                    tracing::debug!(affected_rows_count, timestamp = %timestamp.to_string(), "deleted order events");
+                    println!("removed {}", affected_rows_count);
+                    Metrics::get().order_events_cleanup_total.inc()
                 }
                 Err(err) => {
+                    println!("failed to remove {}", err);
                     tracing::warn!(?err, "failed to delete order events before {}", timestamp)
                 }
             }
+            println!("loop done");
             interval.tick().await;
         }
     }
@@ -55,9 +56,9 @@ impl OrderEventsCleaner {
 
 #[derive(prometheus_metric_storage::MetricStorage)]
 struct Metrics {
-    /// Timestamp of the last successful `order_events` table cleanup.
+    /// The total number of successful `order_events` table cleanups
     #[metric(name = "periodic_db_cleanup")]
-    last_order_events_cleanup_run: prometheus::IntGauge,
+    order_events_cleanup_total: prometheus::IntCounter,
 }
 
 impl Metrics {
@@ -74,25 +75,31 @@ mod tests {
             byte_array::ByteArray,
             order_events::{OrderEvent, OrderEventLabel},
         },
-        sqlx::PgConnection,
+        itertools::Itertools,
+        sqlx::{PgConnection, Row},
     };
 
     #[tokio::test]
     #[ignore]
-    async fn postgres_count_rows_in_table_() {
+    async fn order_events_cleaner_flow() {
         let db = Postgres::new("postgresql://").await.unwrap();
         let mut ex = db.0.begin().await.unwrap();
         database::clear_DANGER_(&mut ex).await.unwrap();
 
+        let now = Utc::now();
         let event_a = OrderEvent {
             order_uid: ByteArray([1; 56]),
-            timestamp: Utc::now() - chrono::Duration::days(31),
+            timestamp: now - chrono::Duration::minutes(2),
             label: OrderEventLabel::Created,
         };
-        let latest_timestamp = Utc::now() - chrono::Duration::days(29);
         let event_b = OrderEvent {
             order_uid: ByteArray([2; 56]),
-            timestamp: latest_timestamp,
+            timestamp: now - chrono::Duration::minutes(1),
+            label: OrderEventLabel::Created,
+        };
+        let event_c = OrderEvent {
+            order_uid: ByteArray([3; 56]),
+            timestamp: now,
             label: OrderEventLabel::Created,
         };
 
@@ -102,33 +109,75 @@ mod tests {
         database::order_events::insert_order_event(&mut ex, &event_b)
             .await
             .unwrap();
+        database::order_events::insert_order_event(&mut ex, &event_c)
+            .await
+            .unwrap();
 
-        let count = order_events_before_timestamp_count(
-            &mut ex,
-            latest_timestamp + chrono::Duration::days(1),
-        )
-        .await;
-        assert_eq!(count, 2u64);
+        let ids = order_event_ids_before(&mut ex, Utc::now()).await;
+        assert_eq!(ids.len(), 3);
+        assert!(ids.contains(&event_a.order_uid));
+        assert!(ids.contains(&event_b.order_uid));
+        assert!(ids.contains(&event_c.order_uid));
 
-        let count = order_events_before_timestamp_count(&mut ex, latest_timestamp).await;
-        assert_eq!(count, 1u64);
+        let config =
+            OrderEventsCleanerConfig::new(Duration::from_secs(15), Duration::from_secs(90));
+        let cleaner = OrderEventsCleaner::new(config, db);
 
-        async fn order_events_before_timestamp_count(
-            ex: &mut PgConnection,
-            timestamp: DateTime<Utc>,
-        ) -> u64 {
-            const QUERY: &str = r#"
-                SELECT COUNT(1)
+        time::pause();
+        tokio::task::spawn(cleaner.run_forever());
+
+        // deleted `order_a` only right after the initialization
+        time::advance(Duration::from_secs(1)).await;
+        let ids = order_event_ids_before(&mut ex, Utc::now()).await;
+        assert_eq!(ids.len(), 2);
+        assert!(!ids.contains(&event_a.order_uid));
+        assert!(ids.contains(&event_b.order_uid));
+        assert!(ids.contains(&event_c.order_uid));
+
+        // nothing deleted after the first interval
+        time::advance(Duration::from_secs(15)).await;
+        let ids = order_event_ids_before(&mut ex, Utc::now()).await;
+        assert_eq!(ids.len(), 2);
+        assert!(!ids.contains(&event_a.order_uid));
+        assert!(ids.contains(&event_b.order_uid));
+        assert!(ids.contains(&event_c.order_uid));
+
+        // deleted `event_b` only
+        time::advance(Duration::from_secs(15)).await;
+        let ids = order_event_ids_before(&mut ex, Utc::now()).await;
+        assert_eq!(ids.len(), 1);
+        assert!(!ids.contains(&event_b.order_uid));
+        assert!(ids.contains(&event_c.order_uid));
+
+        // deleted `event_c` only
+        time::advance(Duration::from_secs(60)).await;
+        let ids = order_event_ids_before(&mut ex, Utc::now()).await;
+        assert_eq!(ids.len(), 1);
+        assert!(!ids.contains(&event_b.order_uid));
+        assert!(ids.contains(&event_c.order_uid));
+    }
+
+    async fn order_event_ids_before(
+        ex: &mut PgConnection,
+        timestamp: DateTime<Utc>,
+    ) -> Vec<ByteArray<56>> {
+        const QUERY: &str = r#"
+                SELECT order_uid, timestamp
                 FROM order_events
                 WHERE timestamp < $1
-                "#;
-            let count: i64 = sqlx::query_scalar(QUERY)
-                .bind(timestamp)
-                .fetch_one(ex)
-                .await
-                .unwrap();
-
-            count as u64
-        }
+            "#;
+        sqlx::query(QUERY)
+            .bind(timestamp)
+            .fetch_all(ex)
+            .await
+            .unwrap()
+            .iter()
+            .map(|row| {
+                let timestamp: DateTime<Utc> = row.try_get(1).unwrap();
+                let order_uid: ByteArray<56> = row.try_get(0).unwrap();
+                println!("timestamp={}, order_uid={:?}", timestamp, order_uid);
+                order_uid
+            })
+            .collect_vec()
     }
 }

--- a/crates/autopilot/src/periodic_db_cleanup.rs
+++ b/crates/autopilot/src/periodic_db_cleanup.rs
@@ -1,0 +1,67 @@
+use {
+    crate::database::Postgres,
+    chrono::{DateTime, Utc},
+    std::time::Duration,
+    tokio::time,
+};
+
+pub struct OrderEventsCleanerConfig {
+    cleanup_interval: Duration,
+    event_age_threshold: chrono::Duration,
+}
+
+impl OrderEventsCleanerConfig {
+    pub fn new(cleanup_interval: Duration, event_age_threshold: Duration) -> Self {
+        OrderEventsCleanerConfig {
+            cleanup_interval,
+            event_age_threshold: chrono::Duration::from_std(event_age_threshold).unwrap(),
+        }
+    }
+}
+
+pub struct OrderEventsCleaner {
+    config: OrderEventsCleanerConfig,
+    db: Postgres,
+}
+
+impl OrderEventsCleaner {
+    pub fn new(config: OrderEventsCleanerConfig, db: Postgres) -> Self {
+        OrderEventsCleaner { config, db }
+    }
+
+    pub async fn run_forever(self) -> ! {
+        let mut interval = time::interval(self.config.cleanup_interval);
+        loop {
+            let timestamp: DateTime<Utc> = Utc::now() - self.config.event_age_threshold;
+            match self.db.delete_events_before(timestamp).await {
+                Ok(affected_rows_count) => {
+                    tracing::debug!(
+                        "deleted {:?} order events before {}",
+                        affected_rows_count,
+                        timestamp
+                    );
+                    Metrics::get()
+                        .last_order_events_cleanup_run
+                        .set(Utc::now().timestamp())
+                }
+                Err(err) => {
+                    tracing::warn!(?err, "failed to delete order events before {}", timestamp)
+                }
+            }
+            interval.tick().await;
+        }
+    }
+}
+
+#[derive(prometheus_metric_storage::MetricStorage)]
+struct Metrics {
+    /// Timestamp of the last successful `order_events` table cleanup.
+    #[metric(name = "periodic_db_cleanup", labels("type"))]
+    last_order_events_cleanup_run: prometheus::IntGauge,
+}
+
+impl Metrics {
+    fn get() -> &'static Self {
+        Metrics::instance(observe::metrics::get_storage_registry()).unwrap()
+    }
+}

--- a/crates/autopilot/src/periodic_db_cleanup.rs
+++ b/crates/autopilot/src/periodic_db_cleanup.rs
@@ -31,9 +31,9 @@ impl OrderEventsCleaner {
 
     pub async fn run_forever(self) -> ! {
         let mut interval = time::interval(self.config.cleanup_interval);
-        interval.tick().await; // Initial tick to start the interval
-
         loop {
+            interval.tick().await;
+
             let timestamp: DateTime<Utc> = Utc::now() - self.config.event_age_threshold;
             match self.db.delete_order_events_before(timestamp).await {
                 Ok(affected_rows_count) => {
@@ -44,7 +44,6 @@ impl OrderEventsCleaner {
                     tracing::warn!(?err, "failed to delete order events before {}", timestamp)
                 }
             }
-            interval.tick().await;
         }
     }
 }

--- a/crates/autopilot/src/periodic_db_cleanup.rs
+++ b/crates/autopilot/src/periodic_db_cleanup.rs
@@ -73,6 +73,14 @@ mod tests {
         sqlx::{PgPool, Row},
     };
 
+    // Note: `tokio::time::advance` was not used in these tests. While it is a
+    // useful tool for controlling time flow in asynchronous tests, it causes
+    // complications when used with `sqlx::PgPool`. Specifically, pausing or
+    // advancing time with `tokio::time::advance` can interfere with the pool's
+    // ability to acquire database connections, leading to panics and unpredictable
+    // behavior in tests. Given these issues, tests were designed without
+    // manipulating the timer, to maintain stability and reliability in the
+    // database connection handling.
     #[tokio::test]
     #[ignore]
     async fn order_events_cleaner_flow() {

--- a/crates/autopilot/src/periodic_db_cleanup.rs
+++ b/crates/autopilot/src/periodic_db_cleanup.rs
@@ -84,12 +84,12 @@ mod tests {
         let now = Utc::now();
         let event_a = OrderEvent {
             order_uid: ByteArray([1; 56]),
-            timestamp: now - chrono::Duration::milliseconds(3000),
+            timestamp: now - chrono::Duration::milliseconds(300),
             label: OrderEventLabel::Created,
         };
         let event_b = OrderEvent {
             order_uid: ByteArray([2; 56]),
-            timestamp: now - chrono::Duration::milliseconds(1000),
+            timestamp: now - chrono::Duration::milliseconds(100),
             label: OrderEventLabel::Created,
         };
         let event_c = OrderEvent {
@@ -117,13 +117,13 @@ mod tests {
         assert!(ids.contains(&event_c.order_uid));
 
         let config =
-            OrderEventsCleanerConfig::new(Duration::from_millis(500), Duration::from_millis(2000));
+            OrderEventsCleanerConfig::new(Duration::from_millis(50), Duration::from_millis(200));
         let cleaner = OrderEventsCleaner::new(config, db.clone());
 
         tokio::task::spawn(cleaner.run_forever());
 
         // delete `order_a` after the initialization
-        time::sleep(Duration::from_millis(200)).await;
+        time::sleep(Duration::from_millis(20)).await;
         let ids = order_event_ids_before(&db.0).await;
         assert_eq!(ids.len(), 2);
         assert!(!ids.contains(&event_a.order_uid));
@@ -131,7 +131,7 @@ mod tests {
         assert!(ids.contains(&event_c.order_uid));
 
         // nothing deleted after the first interval
-        time::sleep(Duration::from_millis(500)).await;
+        time::sleep(Duration::from_millis(50)).await;
         let ids = order_event_ids_before(&db.0).await;
         assert_eq!(ids.len(), 2);
         assert!(!ids.contains(&event_a.order_uid));
@@ -139,14 +139,14 @@ mod tests {
         assert!(ids.contains(&event_c.order_uid));
 
         // delete `event_b` only
-        time::sleep(Duration::from_millis(1000)).await;
+        time::sleep(Duration::from_millis(100)).await;
         let ids = order_event_ids_before(&db.0).await;
         assert_eq!(ids.len(), 1);
         assert!(!ids.contains(&event_b.order_uid));
         assert!(ids.contains(&event_c.order_uid));
 
         // delete `event_c`
-        time::sleep(Duration::from_millis(2000)).await;
+        time::sleep(Duration::from_millis(200)).await;
         let ids = order_event_ids_before(&db.0).await;
         assert!(ids.is_empty());
     }

--- a/crates/autopilot/src/periodic_db_cleanup.rs
+++ b/crates/autopilot/src/periodic_db_cleanup.rs
@@ -56,7 +56,7 @@ impl OrderEventsCleaner {
 #[derive(prometheus_metric_storage::MetricStorage)]
 struct Metrics {
     /// Timestamp of the last successful `order_events` table cleanup.
-    #[metric(name = "periodic_db_cleanup", labels("type"))]
+    #[metric(name = "periodic_db_cleanup")]
     last_order_events_cleanup_run: prometheus::IntGauge,
 }
 

--- a/crates/database/src/lib.rs
+++ b/crates/database/src/lib.rs
@@ -47,6 +47,7 @@ pub type PgTransaction<'a> = sqlx::Transaction<'a, sqlx::Postgres>;
 /// The names of all tables we use in the db.
 pub const ALL_TABLES: &[&str] = &[
     "orders",
+    "order_events",
     "trades",
     "invalidations",
     "quotes",

--- a/crates/database/src/order_events.rs
+++ b/crates/database/src/order_events.rs
@@ -4,7 +4,7 @@
 use {
     crate::OrderUid,
     chrono::Utc,
-    sqlx::{types::chrono::DateTime, PgConnection},
+    sqlx::{types::chrono::DateTime, PgConnection, PgPool},
 };
 
 /// Describes what kind of event was registered for an order.
@@ -65,4 +65,20 @@ VALUES ($1, $2, $3)
         .execute(ex)
         .await
         .map(|_| ())
+}
+
+/// Deletes rows before the provided timestamp from the `order_events` table.
+pub async fn delete_order_events_before(
+    pool: &PgPool,
+    timestamp: DateTime<Utc>,
+) -> Result<u64, sqlx::Error> {
+    const QUERY: &str = r#"
+DELETE FROM order_events
+WHERE timestamp < $1
+"#;
+    sqlx::query(QUERY)
+        .bind(timestamp)
+        .execute(pool)
+        .await
+        .map(|result| result.rows_affected())
 }

--- a/crates/database/src/order_events.rs
+++ b/crates/database/src/order_events.rs
@@ -51,13 +51,13 @@ pub async fn insert_order_event(
     event: &OrderEvent,
 ) -> Result<(), sqlx::Error> {
     const QUERY: &str = r#"
-INSERT INTO order_events (
-    order_uid,
-    timestamp,
-    label
-)
-VALUES ($1, $2, $3)
-"#;
+        INSERT INTO order_events (
+            order_uid,
+            timestamp,
+            label
+        )
+        VALUES ($1, $2, $3)
+    "#;
     sqlx::query(QUERY)
         .bind(event.order_uid)
         .bind(event.timestamp)
@@ -73,9 +73,9 @@ pub async fn delete_order_events_before(
     timestamp: DateTime<Utc>,
 ) -> Result<u64, sqlx::Error> {
     const QUERY: &str = r#"
-DELETE FROM order_events
-WHERE timestamp < $1
-"#;
+        DELETE FROM order_events
+        WHERE timestamp < $1
+    "#;
     sqlx::query(QUERY)
         .bind(timestamp)
         .execute(pool)

--- a/database/sql/V057__add_timestamp_index_to_order_events.sql
+++ b/database/sql/V057__add_timestamp_index_to_order_events.sql
@@ -1,2 +1,0 @@
--- Adds an index on the 'timestamp' column of 'order_events' table to facilitate efficient periodic cleanups.
-CREATE INDEX order_events_by_timestamp ON order_events (timestamp);

--- a/database/sql/V057__add_timestamp_index_to_order_events.sql
+++ b/database/sql/V057__add_timestamp_index_to_order_events.sql
@@ -1,0 +1,2 @@
+-- Adds an index on the 'timestamp' column of 'order_events' table to facilitate efficient periodic cleanups.
+CREATE INDEX order_events_by_timestamp ON order_events (timestamp);


### PR DESCRIPTION
# Description
Add a background task that periodically drops order events from DB that are very old (configurable).

# Changes

- [ ] Configurable interval and threshold of the cleaning task
- [ ] Adds a new metric in order to create a separate alerting when the clean-up wasn't successful for a long period of time

## How to test
Added integro-test


## Related Issues
Implements the first task of the #1977