### PR TITLE
Reduce memory used for balancer v2 liquidity

### DIFF
--- a/crates/driver/src/boundary/liquidity/balancer/v2/mod.rs
+++ b/crates/driver/src/boundary/liquidity/balancer/v2/mod.rs
@@ -57,7 +57,7 @@ fn to_interaction(
         // change this assumption, we would need to change it there as well.
         GPv2Settlement::at(&web3, receiver.0),
         BalancerV2Vault::at(&web3, pool.vault.into()),
-        Arc::new(Allowances::empty(receiver.0)),
+        Allowances::empty(receiver.0),
     );
 
     let interaction = handler.swap(

--- a/crates/solver/src/settlement_simulation.rs
+++ b/crates/solver/src/settlement_simulation.rs
@@ -527,10 +527,10 @@ mod tests {
                     .unwrap(),
                 contract.clone(),
                 balancer_vault,
-                Arc::new(Allowances::new(
+                Allowances::new(
                     contract.address(),
                     hashmap! {"0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48".parse().unwrap()=> U256::from_dec_str("18000000000000000000000000").unwrap()},
-                )),
+                ),
             )),
         };
 


### PR DESCRIPTION
# Description
The new driver is using a huge amount of memory. One low hanging fruit is to slightly redesign the internals of balancer v2 liquidity. Currently all those stable and weighted pools contain big pieces of data that don't change and are duplicated.
For other liquidity sources this was handled by having an `Inner` component that contains that data which is shared with `Arc`s across all liquidity components.

# Changes
This PR applies that same pattern for balancer stable and weighted pools.

## How to test
Just the compiler since it's only a minor refactor