### PR TITLE
Reenable formatting for generated contract rust bindings

### DIFF
--- a/crates/contracts/build.rs
+++ b/crates/contracts/build.rs
@@ -564,16 +564,11 @@ fn generate_contract_with_config(
 
     println!("cargo:rerun-if-changed={}", path.display());
 
-    config(
-        ContractBuilder::new()
-            // for some reason formatting the generate code is broken on nightly
-            .rustfmt(false)
-            .visibility_modifier("pub"),
-    )
-    .generate(&contract)
-    .unwrap()
-    .write_to_file(Path::new(&dest).join(format!("{name}.rs")))
-    .unwrap();
+    config(ContractBuilder::new().visibility_modifier("pub"))
+        .generate(&contract)
+        .unwrap()
+        .write_to_file(Path::new(&dest).join(format!("{name}.rs")))
+        .unwrap();
 }
 
 fn addr(s: &str) -> Address {

--- a/crates/contracts/rustfmt.toml
+++ b/crates/contracts/rustfmt.toml
@@ -1,0 +1,2 @@
+# Applying our custom formatting to the generated code is broken.
+# That's why we specifically unset those rules for this directory.


### PR DESCRIPTION
# Description
Generating contract bindings was broken on nightly for a while. Our easy fix at the time was to simply not format the code at all: https://github.com/cowprotocol/services/pull/1982.

# Changes
What I found out since then is that we only run into issues with our custom formatting rules that we apply to the entire code base. Since having the auto generated code be formatted is pretty neat in case you actually have to look at the code I disabled our custom rules by creating an empty `rustfmt.toml` file in the affected directory.

## How to test
`(cd crates/contracts; cargo run --bin vendor --features bin)`
and
`(cd crates/contracts; cargo +nightly run --bin vendor --features bin)`
Both produce formatted rust bindings for our smart contracts.