### PR TITLE
[ON HOLD] Refactor order_execution table

### DIFF
--- a/crates/autopilot/src/database/on_settlement_event_updater.rs
+++ b/crates/autopilot/src/database/on_settlement_event_updater.rs
@@ -113,15 +113,12 @@ impl super::Postgres {
 
             if insert_succesful || matches!(auction_data.auction_id, AuctionId::Centralized(_)) {
                 // update order executions for orders with solver computed fees (limit orders)
-                // for limit orders, fee is called surplus_fee and is determined by the solver
-                // therefore, when transaction is settled onchain we calculate the fee and save
-                // it to DB
-                for order_execution in auction_data.order_executions {
-                    database::order_execution::update_surplus_fee(
+                for (order_uid, executed_fee) in auction_data.order_executions {
+                    database::order_execution::update_executed_fee(
                         ex,
-                        &ByteArray(order_execution.0 .0), // order uid
+                        &ByteArray(order_uid.0),
                         auction_data.auction_id.assume_verified(),
-                        &u256_to_big_decimal(&order_execution.1), // order fee
+                        &u256_to_big_decimal(&executed_fee),
                     )
                     .await
                     .context("insert_missing_order_executions")?;

--- a/crates/autopilot/src/run_loop.rs
+++ b/crates/autopilot/src/run_loop.rs
@@ -182,10 +182,10 @@ impl RunLoop {
                 match auction_order {
                     Some(auction_order) => {
                         let executed_fee = match auction_order.solver_determines_fee() {
-                            // we don't know the surplus fee in advance. will be populated
+                            // we don't know the executed fee in advance. will be populated
                             // after the transaction containing the order is mined
-                            true => ExecutedFee::Surplus,
-                            false => ExecutedFee::Solver(auction_order.metadata.solver_fee),
+                            true => ExecutedFee::SolverDetermined,
+                            false => ExecutedFee::UserFee(auction_order.metadata.solver_fee),
                         };
                         order_executions.push(OrderExecution {
                             order_id: *order_id,

--- a/crates/model/src/solver_competition.rs
+++ b/crates/model/src/solver_competition.rs
@@ -45,9 +45,7 @@ pub struct Transaction {
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct Execution {
     #[serde_as(as = "Option<HexOrDecimalU256>")]
-    pub surplus_fee: Option<U256>,
-    #[serde_as(as = "HexOrDecimalU256")]
-    pub solver_fee: U256,
+    pub executed_fee: Option<U256>,
 }
 
 /// Stored directly in the database and turned into SolverCompetitionAPI for the

--- a/crates/orderbook/src/database/orders.rs
+++ b/crates/orderbook/src/database/orders.rs
@@ -568,8 +568,7 @@ mod tests {
             ethflow_data: None,
             onchain_user: None,
             onchain_placement_error: None,
-            executed_surplus_fee: Default::default(),
-            executed_solver_fee: Default::default(),
+            executed_fee: Default::default(),
             full_app_data: Default::default(),
         };
 

--- a/crates/orderbook/src/database/solver_competition.rs
+++ b/crates/orderbook/src/database/solver_competition.rs
@@ -40,13 +40,15 @@ impl SolverCompetitionStoring for Postgres {
         .context("upsert_auction_transaction")?;
 
         for (order, execution) in request.executions {
-            let surplus_fee = execution.surplus_fee.as_ref().map(u256_to_big_decimal);
             database::order_execution::save(
                 &mut ex,
                 &ByteArray(order.0),
                 request.auction,
-                surplus_fee.as_ref(),
-                Some(&u256_to_big_decimal(&execution.solver_fee)),
+                execution
+                    .executed_fee
+                    .as_ref()
+                    .map(u256_to_big_decimal)
+                    .as_ref(),
             )
             .await
             .context("order_execution::save")?;

--- a/crates/solver/src/driver.rs
+++ b/crates/solver/src/driver.rs
@@ -420,8 +420,10 @@ impl Driver {
                 .user_trades()
                 .map(|trade| {
                     let execution = Execution {
-                        surplus_fee: trade.surplus_fee(),
-                        solver_fee: trade.solver_fee,
+                        executed_fee: match trade.order.solver_determines_fee() {
+                            true => None,
+                            false => Some(trade.solver_fee),
+                        },
                     };
                     (trade.order.metadata.uid, execution)
                 })

--- a/crates/solver/src/settlement.rs
+++ b/crates/solver/src/settlement.rs
@@ -24,6 +24,8 @@ pub struct Trade {
     pub order: Order,
     pub executed_amount: U256,
     /// The fee amount used for objective value computations.
+    /// Taken either from the order as user_fee or from the solver as
+    /// solver_fee.
     pub solver_fee: U256,
 }
 

--- a/database/sql/V057__update_order_execution.sql
+++ b/database/sql/V057__update_order_execution.sql
@@ -1,0 +1,12 @@
+-- solver_fee was added in V049__add_full_fee_amount.sql
+-- Limit order's fee is no longer calculated beforehand, but provided by the solvers at the time of solving. However, under colocation, this fee is not reported to the autopilot but calculated from the onchain calldata.
+
+ALTER TABLE order_execution 
+  DROP COLUMN solver_fee;
+
+-- Rename surplus_fee to executed_fee as it will represent the general fee paid to the solvers due to network fees.
+-- For market orders, this fee can be fetched from the orders table (but we can keep the duplicate here for completness).
+-- For limit orders, fee is expected to be calculated after the transaction mined, and then this field will be updated from autopilot.
+
+ALTER TABLE order_execution
+  RENAME surplus_fee TO executed_fee;


### PR DESCRIPTION
# Description
Fixes https://github.com/cowprotocol/services/issues/2100

Reviewing should be started by checking the changes in the `order_execution` table.
This table contains two columns for fees: `surplus_fee` and `solver_fee`, which are populated in a several, very non-understandable ways.

### Surplus fee
`surplus_fee` refers to the fee determined by solvers at the time of solving, exclusively for limit orders. Then we adjust the clearing prices of the settlement to take into consideration this fee (so this is something observable from the calldata itself, we don't need to store at it the time of solving).
Before colocation, `order_execution::surplus_fee` was populated from `solver` crate at the time of execution, but we later override it in autopilot (which has a background task for updating the `surplus_fee` by observing onchain settlement).
After colocation, autopilot set's `surplus_fee` to `None`, during execution, but populates it after in the mentioned background task.

### Solver fee
`solver_fee` was added to fix the bug we had for limit orders, where clients of our database were reading the `surplus_fee` field for limit orders when the `surplus_fee` was not calculated by solvers but the autopilot, iteratively, and was known upfront (before solving). In the meantime we removed that functionality, and continued using this field as a fee for market orders (which is known upfront, constant and already readable from `orders` table).

### What now?
This PR suggests completely dropping the terminology `surplus_fee` and `solver_fee` and merging those into `executed_fee`.
We rename the `order_execution::surplus_fee` to `order_execution::executed_fee` (so we keep the data in that column) and we drop `order_execution::solver_fee`, but:
1. For future trades, we can store the fee for market orders into `executed_fee`, for completness.
2. For history trades, for backward compatibility, we fallback to reading from `orders` table. (I might consider executing the script on database to copy that data so we can drop the backward compatibility hack).

## How to test
TODO! Since the change is tedious, will need to triple check everything works, but for now the idea seems legit.