### PR TITLE
[Easy] Unify driver's slippage and timout config

### DIFF
--- a/crates/driver/src/infra/config/file/load.rs
+++ b/crates/driver/src/infra/config/file/load.rs
@@ -57,8 +57,8 @@ pub async fn load(network: &blockchain::Network, path: &Path) -> infra::Config {
                 endpoint: config.endpoint,
                 name: config.name.into(),
                 slippage: solver::Slippage {
-                    relative: config.relative_slippage,
-                    absolute: config.absolute_slippage.map(eth::Ether),
+                    relative: config.slippage.relative,
+                    absolute: config.slippage.absolute.map(eth::Ether),
                 },
                 liquidity: if config.skip_liquidity {
                     solver::Liquidity::Skip

--- a/crates/driver/src/infra/config/file/mod.rs
+++ b/crates/driver/src/infra/config/file/mod.rs
@@ -168,13 +168,8 @@ struct SolverConfig {
     /// running behind a single driver.
     name: String,
 
-    /// The relative slippage factor allowed by the solver.
-    #[serde_as(as = "serde_with::DisplayFromStr")]
-    relative_slippage: bigdecimal::BigDecimal,
-
-    /// The absolute slippage allowed by the solver.
-    #[serde_as(as = "Option<serialize::U256>")]
-    absolute_slippage: Option<eth::U256>,
+    #[serde(flatten)]
+    slippage: Slippage,
 
     /// Whether or not to skip fetching liquidity for this solver.
     #[serde(default)]
@@ -184,7 +179,7 @@ struct SolverConfig {
     account: Account,
 
     /// Timeout configuration for the solver.
-    #[serde(default)]
+    #[serde(default, flatten)]
     timeouts: Timeouts,
 }
 
@@ -204,26 +199,34 @@ enum Account {
 }
 
 #[serde_as]
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Default)]
 #[serde(rename_all = "kebab-case", deny_unknown_fields)]
 struct Timeouts {
-    /// Maximum time allocated for http request/reponse to propagate through
+    /// Maximum time allocated for http request/response to propagate through
     /// network.
+    #[serde(default = "default_http_time_buffer_milliseconds")]
     http_time_buffer_milliseconds: u64,
 
     /// Maximum time allocated for solver engines to return the solutions back
     /// to the driver, in percentage of total driver deadline.
     /// Expected value [0, 1]
+    #[serde(default = "default_solving_share_of_deadline")]
     solving_share_of_deadline: f64,
 }
 
-impl Default for Timeouts {
-    fn default() -> Self {
-        Self {
-            http_time_buffer_milliseconds: default_http_time_buffer_milliseconds(),
-            solving_share_of_deadline: default_solving_share_of_deadline(),
-        }
-    }
+#[serde_as]
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "kebab-case", deny_unknown_fields)]
+struct Slippage {
+    /// The relative slippage factor allowed by the solver.
+    #[serde(rename = "relative-slippage")]
+    #[serde_as(as = "serde_with::DisplayFromStr")]
+    relative: bigdecimal::BigDecimal,
+
+    /// The absolute slippage allowed by the solver.
+    #[serde(rename = "absolute-slippage")]
+    #[serde_as(as = "Option<serialize::U256>")]
+    absolute: Option<eth::U256>,
 }
 
 #[derive(Debug, Default, Deserialize)]

--- a/crates/driver/src/infra/config/file/mod.rs
+++ b/crates/driver/src/infra/config/file/mod.rs
@@ -202,14 +202,15 @@ enum Account {
 #[derive(Debug, Deserialize, Default)]
 #[serde(rename_all = "kebab-case", deny_unknown_fields)]
 struct Timeouts {
-    /// Maximum time allocated for http request/response to propagate through
-    /// network.
+    /// Absolute time allocated from the total auction deadline for
+    /// request/response roundtrip between autopilot and driver.
     #[serde(default = "default_http_time_buffer_milliseconds")]
     http_time_buffer_milliseconds: u64,
 
     /// Maximum time allocated for solver engines to return the solutions back
-    /// to the driver, in percentage of total driver deadline.
-    /// Expected value [0, 1]
+    /// to the driver, in percentage of total driver deadline (after network
+    /// buffer). Remaining time is spent on encoding and postprocessing the
+    /// returned solutions. Expected value [0, 1]
     #[serde(default = "default_solving_share_of_deadline")]
     solving_share_of_deadline: f64,
 }


### PR DESCRIPTION
# Description
We have two "grouped" configuration parameters on the driver's solver-engine config: Slippage and Timeouts. Currently one is specified as a sub-struct while the other one is flattened into the top level struct.

From a data model perspective, I think grouping related config fields together helps us keep the high level config clean. At the same time, configuring the nested config in `toml` leads to verbose files a la

```toml
[[solver]]
name = "mysolver" # Arbitrary name given to this solver, must be unique
endpoint = "http://0.0.0.0:7872/"
absolute-slippage = "40000000000000000" # Denominated in wei, optional
relative-slippage = "0.1" # Percentage in the [0, 1] range
account = "0xB9332b6301e5983272c30dd5b48a4e3B1664511b"

[solver.timeouts]
http-time-buffer-milliseconds = 500
solving-share-of-deadline = 0.9
```

In any case we should unify the approaches. In this PR I went for flat config files, but nested structs.

# Changes
<!-- List of detailed changes (how the change is accomplished) -->

- [ ] Make slippage a subtype on the high level config struct
- [ ] Flatten the Timeouts struct so that it can be configured the same way slippage can

## How to test
The following config can be run locally:

```toml
[[solver]]
name = "mysolver1" # Arbitrary name given to this solver, must be unique
endpoint = "http://0.0.0.0:7872/"
absolute-slippage = "40000000000000000" # Denominated in wei, optional
relative-slippage = "0.1" # Percentage in the [0, 1] range
account = "0xB9332b6301e5983272c30dd5b48a4e3B1664511b"
solving-share-of-deadline = 0.9
```