### PR TITLE
Store market order events only pt1

### DIFF
--- a/crates/autopilot/src/database/order_events.rs
+++ b/crates/autopilot/src/database/order_events.rs
@@ -40,7 +40,7 @@ async fn store_order_events(
             label: *label,
         };
 
-        order_events::insert_order_event(&mut ex, &event).await?
+        order_events::insert_order_event_if_exists(&mut ex, &event).await?
     }
     ex.commit().await?;
     Ok(())

--- a/crates/database/src/order_events.rs
+++ b/crates/database/src/order_events.rs
@@ -83,7 +83,7 @@ pub async fn insert_order_event_if_exists(
         WHERE EXISTS (
             SELECT 1
             FROM order_events
-            WHERE uid = $1
+            WHERE order_uid = $1
         )
     "#;
     sqlx::query(QUERY)


### PR DESCRIPTION
# Description
Partly closes pt3 of the issue https://github.com/cowprotocol/services/issues/1977:
> only store events for market orders as these are the orders for which we want to guarantee very fast execution anyway


# Changes

- [ ] Inserts order events for newly created market orders only.
- [ ] For the time being, the system will continue to update order events for both the newly implemented logic (market orders) and the existing logic (non-market orders). This is a transitional measure. A new function `insert_order_event_if_exists` has been introduced to facilitate this dual support. The need for maintaining updates on old non-market orders persists until the database is purged of entries older than the default threshold of 30 days. This cleanup process is detailed in the [autopilot crate](https://github.com/cowprotocol/services/blob/02bfbbfbfe1a14bddc4b3ad4dca70a980492b803/crates/autopilot/src/arguments.rs#L216-L219).

## How to test
New database tests have been introduced to verify the correct implementation of the changes.

## Further implementation

After the 30-day period, following the release of this PR, the optimizations should be considered:

- Limit the insertion of order event updates strictly to market orders.
- Optimize Order Identification: To further streamline the process, either modify the driver's API to include the order `class` with the order `uid` in the `/reveal` endpoint([link](https://github.com/cowprotocol/services/blob/02bfbbfbfe1a14bddc4b3ad4dca70a980492b803/crates/autopilot/src/driver_model.rs#L186-L191)) or continue utilizing `insert_order_event_if_exists` where it is required.