### PR TITLE
[Easy] Configure autodeploy request timeout

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -62,3 +62,4 @@ jobs:
           tag: ${{ secrets.AUTODEPLOY_TAG }}
           url: ${{ secrets.AUTODEPLOY_URL }}
           token: ${{ secrets.AUTODEPLOY_TOKEN }}
+          timeout: 600000 # 10 minutes


### PR DESCRIPTION
# Description
I noticed our auto-deploy jobs are frequently timing out in the services repo: https://github.com/cowprotocol/services/actions/workflows/deploy.yaml, which is due to our k8s deployment being too slow (currently [~7 minutes](https://production-6de61f.kb.eu-central-1.aws.cloud.es.io/app/r/s/DylSb)) for all pods to restart. https://github.com/cowprotocol/autodeploy-action/pull/39 made the timeout for the requests configurable (before it was hardcoded to 6 minutes). This PR uses this config value.

# Changes
- [ ] Set the timeout to 10 minutes

## How to test
Observe deploy job succeeding after this PR is merged.