### PR TITLE
[Trivial] Bump autodeploy version

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -55,7 +55,7 @@ jobs:
           tags: ${{ steps.meta_migration.outputs.tags }}
           labels: ${{ steps.meta_migration.outputs.labels }}
 
-      - uses: cowprotocol/autodeploy-action@v1
+      - uses: cowprotocol/autodeploy-action@v2
         if: ${{ github.ref == 'refs/heads/main' }}
         with:
           images: ghcr.io/cowprotocol/services:main


### PR DESCRIPTION
So that specifying a timeout actually does something ([current state](https://github.com/cowprotocol/services/actions/runs/7090939360/job/19301626088)), the current version doesn't include https://github.com/cowprotocol/autodeploy-action/pull/39