### PR TITLE
Create Market order events only

### DIFF
--- a/crates/autopilot/src/database/order_events.rs
+++ b/crates/autopilot/src/database/order_events.rs
@@ -1,13 +1,14 @@
 pub use database::order_events::OrderEventLabel;
 use {
     anyhow::{Context, Result},
+    async_trait::async_trait,
     chrono::{DateTime, Utc},
     database::{
         byte_array::ByteArray,
         order_events::{self, OrderEvent},
     },
     model::order::OrderUid,
-    sqlx::Error,
+    sqlx::{Error, PgConnection},
 };
 
 impl super::Postgres {
@@ -16,8 +17,14 @@ impl super::Postgres {
     /// elaborate error handling is not necessary because this is just
     /// debugging information.
     pub async fn store_order_events(&self, events: &[(OrderUid, OrderEventLabel)]) {
-        if let Err(err) = store_order_events(self, events, Utc::now()).await {
+        if let Err(err) = store_all_order_events(self, events, Utc::now()).await {
             tracing::warn!(?err, "failed to insert order events");
+        }
+    }
+
+    pub async fn store_market_order_events(&self, events: &[(OrderUid, OrderEventLabel)]) {
+        if let Err(err) = store_market_order_events(self, events, Utc::now()).await {
+            tracing::warn!(?err, "failed to insert market order events");
         }
     }
 
@@ -27,10 +34,46 @@ impl super::Postgres {
     }
 }
 
-async fn store_order_events(
+#[async_trait]
+pub trait OrderEventPersister {
+    async fn insert_order_event(
+        &self,
+        conn: &mut PgConnection,
+        event: &OrderEvent,
+    ) -> Result<(), Error>;
+}
+
+struct RegularOrderEventPersister;
+
+#[async_trait]
+impl OrderEventPersister for RegularOrderEventPersister {
+    async fn insert_order_event(
+        &self,
+        conn: &mut PgConnection,
+        event: &OrderEvent,
+    ) -> Result<(), Error> {
+        order_events::insert_order_event(conn, event).await
+    }
+}
+
+struct MarketOrderEventPersister;
+
+#[async_trait]
+impl OrderEventPersister for MarketOrderEventPersister {
+    async fn insert_order_event(
+        &self,
+        conn: &mut PgConnection,
+        event: &OrderEvent,
+    ) -> Result<(), Error> {
+        order_events::insert_market_order_event(conn, event).await
+    }
+}
+
+async fn store_order_events_generic(
     db: &super::Postgres,
     events: &[(OrderUid, OrderEventLabel)],
     timestamp: DateTime<Utc>,
+    persister: &impl OrderEventPersister,
 ) -> Result<()> {
     let mut ex = db.0.begin().await.context("begin transaction")?;
     for (uid, label) in events {
@@ -40,8 +83,24 @@ async fn store_order_events(
             label: *label,
         };
 
-        order_events::insert_order_event(&mut ex, &event).await?
+        persister.insert_order_event(&mut ex, &event).await?;
     }
     ex.commit().await?;
     Ok(())
+}
+
+async fn store_all_order_events(
+    db: &super::Postgres,
+    events: &[(OrderUid, OrderEventLabel)],
+    timestamp: DateTime<Utc>,
+) -> Result<()> {
+    store_order_events_generic(db, events, timestamp, &RegularOrderEventPersister).await
+}
+
+async fn store_market_order_events(
+    db: &super::Postgres,
+    events: &[(OrderUid, OrderEventLabel)],
+    timestamp: DateTime<Utc>,
+) -> Result<()> {
+    store_order_events_generic(db, events, timestamp, &MarketOrderEventPersister).await
 }

--- a/crates/autopilot/src/database/order_events.rs
+++ b/crates/autopilot/src/database/order_events.rs
@@ -22,6 +22,8 @@ impl super::Postgres {
         }
     }
 
+    /// Inserts the given events with the current timestamp into the DB for the
+    /// market orders only.
     pub async fn store_market_order_events(&self, events: &[(OrderUid, OrderEventLabel)]) {
         if let Err(err) = store_market_order_events(self, events, Utc::now()).await {
             tracing::warn!(?err, "failed to insert market order events");

--- a/crates/autopilot/src/database/order_events.rs
+++ b/crates/autopilot/src/database/order_events.rs
@@ -71,7 +71,7 @@ impl OrderEventPersister for MarketOrderEventPersister {
     }
 }
 
-async fn store_order_events_generic(
+async fn store_order_events(
     db: &super::Postgres,
     events: &[(OrderUid, OrderEventLabel)],
     timestamp: DateTime<Utc>,
@@ -96,7 +96,7 @@ async fn store_all_order_events(
     events: &[(OrderUid, OrderEventLabel)],
     timestamp: DateTime<Utc>,
 ) -> Result<()> {
-    store_order_events_generic(db, events, timestamp, &RegularOrderEventPersister).await
+    store_order_events(db, events, timestamp, &RegularOrderEventPersister).await
 }
 
 async fn store_market_order_events(
@@ -104,5 +104,5 @@ async fn store_market_order_events(
     events: &[(OrderUid, OrderEventLabel)],
     timestamp: DateTime<Utc>,
 ) -> Result<()> {
-    store_order_events_generic(db, events, timestamp, &MarketOrderEventPersister).await
+    store_order_events(db, events, timestamp, &MarketOrderEventPersister).await
 }

--- a/crates/autopilot/src/solvable_orders.rs
+++ b/crates/autopilot/src/solvable_orders.rs
@@ -632,6 +632,7 @@ impl OrderFilterCounter {
     }
 
     /// Creates a new checkpoint from the current remaining orders.
+    /// Returns market order uids only.
     fn checkpoint(&mut self, reason: Reason, orders: &[Order]) -> Vec<OrderUid> {
         let filtered_orders = orders
             .iter()
@@ -645,7 +646,13 @@ impl OrderFilterCounter {
             self.orders.remove(order).unwrap();
             tracing::debug!(%order, ?class, %reason, "filtered order")
         }
-        filtered_orders.into_keys().collect()
+        filtered_orders
+            .iter()
+            .filter_map(|(order_uid, class)| match class {
+                OrderClass::Market => Some(*order_uid),
+                _ => None,
+            })
+            .collect()
     }
 
     /// Records the filter counter to metrics.

--- a/crates/autopilot/src/solvable_orders.rs
+++ b/crates/autopilot/src/solvable_orders.rs
@@ -647,9 +647,9 @@ impl OrderFilterCounter {
             tracing::debug!(%order, ?class, %reason, "filtered order")
         }
         filtered_orders
-            .iter()
+            .into_iter()
             .filter_map(|(order_uid, class)| match class {
-                OrderClass::Market => Some(*order_uid),
+                OrderClass::Market => Some(order_uid),
                 _ => None,
             })
             .collect()

--- a/crates/orderbook/src/orderbook.rs
+++ b/crates/orderbook/src/orderbook.rs
@@ -336,7 +336,9 @@ impl Orderbook {
 
         // order is already known to exist in DB at this point, and signer is
         // known to be correct!
-        self.database.cancel_order(&order, Utc::now()).await?;
+        self.database
+            .cancel_order(&order.metadata.uid, Utc::now())
+            .await?;
 
         tracing::debug!(order_uid =% order.metadata.uid, "order cancelled");
         Metrics::on_order_operation(&order, OrderOperation::Cancelled);

--- a/crates/orderbook/src/orderbook.rs
+++ b/crates/orderbook/src/orderbook.rs
@@ -336,9 +336,7 @@ impl Orderbook {
 
         // order is already known to exist in DB at this point, and signer is
         // known to be correct!
-        self.database
-            .cancel_order(&order.metadata.uid, Utc::now())
-            .await?;
+        self.database.cancel_order(&order, Utc::now()).await?;
 
         tracing::debug!(order_uid =% order.metadata.uid, "order cancelled");
         Metrics::on_order_operation(&order, OrderOperation::Cancelled);


### PR DESCRIPTION
# Description
Closes pt3 of the issue https://github.com/cowprotocol/services/issues/1977:
> only store events for market orders as these are the orders for which we want to guarantee very fast execution anyway

# Changes
- [ ] Stores events for market orders only
- [ ] Filters market order in the code where possible and uses a regular insert query. When the orders data is received without the order `class`, a more complex insert query is used, checking `class` in the `orders` table. The separation is used since the insert with subquery takes around x1000 more time to execute

## How to test
New database tests have been introduced to verify the correct implementation of the changes. A manual check can be used in staging.