### PR TITLE
Enso access lists

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -55,7 +55,7 @@ jobs:
           tags: ${{ steps.meta_migration.outputs.tags }}
           labels: ${{ steps.meta_migration.outputs.labels }}
 
-      - uses: cowprotocol/autodeploy-action@v1
+      - uses: cowprotocol/autodeploy-action@v2
         if: ${{ github.ref == 'refs/heads/main' }}
         with:
           images: ghcr.io/cowprotocol/services:main

--- a/crates/driver/src/domain/eth/mod.rs
+++ b/crates/driver/src/domain/eth/mod.rs
@@ -354,6 +354,7 @@ impl std::fmt::Debug for Tx {
             .field("to", &self.to)
             .field("value", &self.value)
             .field("input", &self.input)
+            .field("access_list", &self.access_list)
             .finish()
     }
 }

--- a/crates/driver/src/infra/simulator/enso/dto.rs
+++ b/crates/driver/src/infra/simulator/enso/dto.rs
@@ -19,6 +19,34 @@ pub struct Request {
     pub gas_limit: u64,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub block_number: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub access_list: Option<AccessList>,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(transparent)]
+pub struct AccessList(Vec<AccessListItem>);
+
+impl From<eth::AccessList> for AccessList {
+    fn from(value: eth::AccessList) -> Self {
+        Self(
+            web3::types::AccessList::from(value)
+                .into_iter()
+                .map(|item| AccessListItem {
+                    address: item.address,
+                    storage_keys: item.storage_keys,
+                })
+                .collect(),
+        )
+    }
+}
+
+#[serde_as]
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AccessListItem {
+    pub address: eth::H160,
+    pub storage_keys: Vec<eth::H256>,
 }
 
 #[serde_as]

--- a/crates/driver/src/infra/simulator/enso/mod.rs
+++ b/crates/driver/src/infra/simulator/enso/mod.rs
@@ -37,6 +37,11 @@ impl Enso {
                 value: tx.value.into(),
                 gas_limit: GAS_LIMIT,
                 block_number: None,
+                access_list: if tx.access_list.is_empty() {
+                    None
+                } else {
+                    Some(tx.access_list.into())
+                },
             })
             .send()
             .await?


### PR DESCRIPTION
# Description
Without this settlements that are sending the native asset to a smart contract fail simulations, because they run out of gas.

Access lists are supported by temper: https://github.com/EnsoFinance/temper