### PR TITLE
Filter in-flight orders

### DIFF
--- a/crates/autopilot/src/run.rs
+++ b/crates/autopilot/src/run.rs
@@ -630,6 +630,7 @@ pub async fn run(args: Arguments) {
             score_cap: args.score_cap,
             max_settlement_transaction_wait: args.max_settlement_transaction_wait,
             solve_deadline: args.solve_deadline,
+            in_flight_orders: Default::default(),
         };
         run.run_forever().await;
         unreachable!("run loop exited");


### PR DESCRIPTION
# Description
Although the `autopilot` currently waits until the `driver` reports that the settlement was mined the auction of the next run loop might not yet be aware that the orders of the previous settlement were solved.
If a solver then tries to solve those orders again it will run into simulation failures.

# Changes
We now filter out in-flight orders from the auction if it was built before the block where the in-flight orders were settled.