### PR TITLE
[Trivial] Record mempool submission metrics in driver

### DIFF
--- a/crates/driver/src/infra/observe/metrics.rs
+++ b/crates/driver/src/infra/observe/metrics.rs
@@ -16,6 +16,9 @@ pub struct Metrics {
     /// The results of the quoting process.
     #[metric(labels("solver", "result"))]
     pub quotes: prometheus::IntCounterVec,
+    /// The results of the mempool submission.
+    #[metric(labels("mempool", "result"))]
+    pub mempool_submission: prometheus::IntCounterVec,
 }
 
 /// Setup the metrics registry.

--- a/crates/driver/src/infra/observe/mod.rs
+++ b/crates/driver/src/infra/observe/mod.rs
@@ -333,6 +333,15 @@ pub fn mempool_executed(
             );
         }
     }
+    let result = match res {
+        Ok(_) => "Success",
+        Err(mempools::Error::Revert(_) | mempools::Error::SimulationRevert) => "Revert",
+        Err(mempools::Error::Other(_)) => "Other",
+    };
+    metrics::get()
+        .mempool_submission
+        .with_label_values(&[&mempool.to_string(), result])
+        .inc();
 }
 
 /// Observe that an invalid DTO was received.


### PR DESCRIPTION
# Description
Needed to replace this [alert](https://cowservices.slack.com/archives/C036ZGSCJNP/p1701783487316099)

Note, that this doesn't include information about the solver that is submitting the solution. I don't think this is necessarily required, so I didn't add it.