### PR TITLE
Remove GnosisSafe gas estimator

### DIFF
--- a/crates/shared/src/arguments.rs
+++ b/crates/shared/src/arguments.rs
@@ -177,7 +177,6 @@ pub struct Arguments {
     /// a previous one fails. Individual estimators support different
     /// networks. `EthGasStation`: supports mainnet.
     /// `GasNow`: supports mainnet.
-    /// `GnosisSafe`: supports mainnet and goerli.
     /// `Web3`: supports every network.
     /// `Native`: supports every network.
     #[clap(

--- a/crates/shared/src/gas_price_estimation.rs
+++ b/crates/shared/src/gas_price_estimation.rs
@@ -8,7 +8,6 @@ use {
         GasNowGasStation,
         GasPrice1559,
         GasPriceEstimating,
-        GnosisSafeGasStation,
         PriorityGasPriceEstimating,
         Transport,
     },
@@ -22,7 +21,6 @@ use {
 pub enum GasEstimatorType {
     EthGasStation,
     GasNow,
-    GnosisSafe,
     Web3,
     BlockNative,
     Native,
@@ -92,9 +90,6 @@ pub async fn create_priority_estimator(
                 ensure!(is_mainnet(&network_id), "GasNow only supports mainnet");
                 estimators.push(Box::new(GasNowGasStation::new(client())))
             }
-            GasEstimatorType::GnosisSafe => estimators.push(Box::new(
-                GnosisSafeGasStation::with_network_id(&network_id, client())?,
-            )),
             GasEstimatorType::Web3 => estimators.push(Box::new(web3.clone())),
             GasEstimatorType::Native => {
                 match NativeGasEstimator::new(web3.transport().clone(), None).await {


### PR DESCRIPTION
# Description
Since the GnosisSafe isn't working and is not available as a gas estimator anymore (as detailed [here](https://github.com/cowprotocol/gas-estimation/pull/12)), I removed all code related to it.

# Changes

- Remove GnosisSafe gas estimator code 

## How to test
CI.

## Related Issues

This PR should not be merged before [this](https://github.com/cowprotocol/infrastructure/pull/909) is.
Related to issue #2094. 