### PR TITLE
Run order events insertion in parallel

### DIFF
--- a/crates/autopilot/src/run.rs
+++ b/crates/autopilot/src/run.rs
@@ -619,7 +619,7 @@ pub async fn run(args: Arguments) {
                 .await;
         let run = RunLoop {
             solvable_orders_cache,
-            database: db,
+            database: Arc::new(db),
             drivers: args.drivers.into_iter().map(Driver::new).collect(),
             current_block: current_block_stream,
             web3,

--- a/crates/autopilot/src/run_loop.rs
+++ b/crates/autopilot/src/run_loop.rs
@@ -319,7 +319,7 @@ impl RunLoop {
             async move {
                 let start = Instant::now();
                 db.store_order_events(&events).await;
-                tracing::debug!(elapsed=?start.elapsed(), "stored order events");
+                tracing::debug!(elapsed=?start.elapsed(), events_count=events.len(), "stored order events");
             }
             .instrument(tracing::Span::current()),
         );

--- a/crates/autopilot/src/run_loop.rs
+++ b/crates/autopilot/src/run_loop.rs
@@ -315,6 +315,8 @@ impl RunLoop {
             .iter()
             .map(|o| (o.metadata.uid, OrderEventLabel::Ready))
             .collect_vec();
+        // insert into `order_events` table operations takes a while and the result is
+        // ignored, so we run it in the background
         tokio::spawn(
             async move {
                 let start = Instant::now();


### PR DESCRIPTION
# Description
Executes order events db insert operation in parallel in order to propagate the auction among solvers as soon as possible. The same approach could be used in other parts of the application since this operation takes a while.

## How to test
Logs observation

## Related Issues

Relates to https://github.com/cowprotocol/services/issues/2095