### PR TITLE
Speed up token meta data look up

### DIFF
--- a/crates/driver/src/infra/api/routes/solve/mod.rs
+++ b/crates/driver/src/infra/api/routes/solve/mod.rs
@@ -30,7 +30,7 @@ async fn route(
             .tap_err(|err| {
                 observe::invalid_dto(err, "auction");
             })?;
-        tracing::debug!(elapsed=?start.elapsed(), auction_id=%auction_id, "auction task execution time");
+        tracing::debug!(elapsed = ?start.elapsed(), "auction task execution time");
         let auction = state.pre_processor().prioritize(auction).await;
         let competition = state.competition();
         let result = competition.solve(&auction).await;

--- a/crates/driver/src/infra/tokens.rs
+++ b/crates/driver/src/infra/tokens.rs
@@ -157,6 +157,8 @@ impl Inner {
             return;
         }
 
+        // Take exclusive lock because everybody will call this function for the same tokens
+        // so this a simple way to avoid sending duplicate requests.
         let mut cache = self.cache.write().await;
         if tokens.iter().all(|address| cache.contains_key(address)) {
             // Somebody else might have already cached all the data in the meantime.

--- a/crates/driver/src/infra/tokens.rs
+++ b/crates/driver/src/infra/tokens.rs
@@ -9,6 +9,7 @@ use {
     std::{collections::HashMap, sync::Arc},
     tokio::sync::RwLock,
     tracing::Instrument,
+    model::order::BUY_ETH_ADDRESS,
 };
 
 #[derive(Clone, Debug)]
@@ -172,7 +173,9 @@ impl Inner {
             // Compute set of requested addresses that are not in cache.
             addresses
                 .iter()
-                .filter(|address| !cache.contains_key(*address))
+                // BUY_ETH_ADDRESS is just a marker and not a real address. We'll never be able to
+                // fetch data for it so ignore it to avoid taking exclusive locks all the time.
+                .filter(|address| !cache.contains_key(*address) && address.0.0 != BUY_ETH_ADDRESS)
                 .cloned()
                 .unique()
                 .collect()


### PR DESCRIPTION
# Description
We've noticed weird delays between the autopilot sending an auction and the driver being ready to start working on it.
The linked issue suggests that we spend a lot of time converting the auction and enriching it with token meta data.
This should be super fast because all the data should be cached at all times.
However, was one token that caused it all to break down: `0xeeeee...` (the address we use to denote the chains native token)

This is roughly what happened:
1. every driver receives auction
2. every driver collects all the addresses for which we don't have cached metadata
3. this always yielded `0xeeee...` (it's not a real token so we never get data when calling ERC20 functions on it)
4. every driver wasted some time sending RPC requests for `0xeeee`
5. every driver tried to take an exclusive lock to write no data (empty vec) to the cache

Overall this wasted time with unnecessary network requests and serially taking an exclusive lock for all drivers.

# Changes
* most importantly filter out `0xeee`
* avoid sending duplicate RPC requests by holding an exclusive lock while fetching missing token meta data
* don't send RPC requests if some other driver cached the data in the mean time
* moved logging of token balance update task out of the critical section

All changes combined results in us now spending a couple microseconds on getting cached balances instead of seconds.
And because this was the bulk of the work captured by the log `auction task execution time` we reduced that time to ~11ms.

## How to test
e2e tests should still pass and manual test confirmed the reduced latency.

Fixes [#](https://github.com/cowprotocol/services/issues/2133)