### PR TITLE
Optimize rows count metrics

### DIFF
--- a/crates/autopilot/src/database.rs
+++ b/crates/autopilot/src/database.rs
@@ -104,7 +104,7 @@ pub async fn database_metrics(db: Postgres) -> ! {
         if let Err(err) = db.update_database_metrics().await {
             tracing::error!(?err, "failed to update table rows metric");
         }
-        tokio::time::sleep(Duration::from_secs(60)).await;
+        tokio::time::sleep(Duration::from_secs(60 * 5)).await;
     }
 }
 

--- a/crates/autopilot/src/database.rs
+++ b/crates/autopilot/src/database.rs
@@ -28,9 +28,16 @@ impl Postgres {
         let metrics = Metrics::get();
 
         // update table row metrics
-        for &table in database::ALL_TABLES {
+        for &table in database::TABLES {
             let mut ex = self.0.acquire().await?;
             let count = count_rows_in_table(&mut ex, table).await?;
+            metrics.table_rows.with_label_values(&[table]).set(count);
+        }
+
+        // update table row metrics
+        for &table in database::LARGE_TABLES {
+            let mut ex = self.0.acquire().await?;
+            let count = count_rough_rows_in_table(&mut ex, table).await?;
             metrics.table_rows.with_label_values(&[table]).set(count);
         }
 
@@ -47,6 +54,11 @@ impl Postgres {
 
 async fn count_rows_in_table(ex: &mut PgConnection, table: &str) -> sqlx::Result<i64> {
     let query = format!("SELECT COUNT(*) FROM {table};");
+    sqlx::query_scalar(&query).fetch_one(ex).await
+}
+
+async fn count_rough_rows_in_table(ex: &mut PgConnection, table: &str) -> sqlx::Result<i64> {
+    let query = format!("SELECT reltuples FROM pg_class WHERE relname='{table}';");
     sqlx::query_scalar(&query).fetch_one(ex).await
 }
 

--- a/crates/autopilot/src/database.rs
+++ b/crates/autopilot/src/database.rs
@@ -37,7 +37,7 @@ impl Postgres {
         // update table row metrics
         for &table in database::LARGE_TABLES {
             let mut ex = self.0.acquire().await?;
-            let count = count_rough_rows_in_table(&mut ex, table).await?;
+            let count = estimate_rows_in_table(&mut ex, table).await?;
             metrics.table_rows.with_label_values(&[table]).set(count);
         }
 
@@ -57,7 +57,7 @@ async fn count_rows_in_table(ex: &mut PgConnection, table: &str) -> sqlx::Result
     sqlx::query_scalar(&query).fetch_one(ex).await
 }
 
-async fn count_rough_rows_in_table(ex: &mut PgConnection, table: &str) -> sqlx::Result<i64> {
+async fn estimate_rows_in_table(ex: &mut PgConnection, table: &str) -> sqlx::Result<i64> {
     let query = format!("SELECT reltuples FROM pg_class WHERE relname='{table}';");
     sqlx::query_scalar(&query).fetch_one(ex).await
 }

--- a/crates/autopilot/src/database.rs
+++ b/crates/autopilot/src/database.rs
@@ -104,7 +104,7 @@ pub async fn database_metrics(db: Postgres) -> ! {
         if let Err(err) = db.update_database_metrics().await {
             tracing::error!(?err, "failed to update table rows metric");
         }
-        tokio::time::sleep(Duration::from_secs(60 * 5)).await;
+        tokio::time::sleep(Duration::from_secs(60)).await;
     }
 }
 

--- a/crates/database/src/lib.rs
+++ b/crates/database/src/lib.rs
@@ -44,10 +44,9 @@ use {
 
 pub type PgTransaction<'a> = sqlx::Transaction<'a, sqlx::Postgres>;
 
-/// The names of all tables we use in the db.
-pub const ALL_TABLES: &[&str] = &[
+/// The names of tables we use in the db.
+pub const TABLES: &[&str] = &[
     "orders",
-    "order_events",
     "trades",
     "invalidations",
     "quotes",
@@ -69,10 +68,20 @@ pub const ALL_TABLES: &[&str] = &[
     "app_data",
 ];
 
+/// The names of potentially big volume tables we use in the db.
+pub const LARGE_TABLES: &[&str] = &["order_events"];
+
+pub fn all_tables() -> Vec<&'static str> {
+    let mut combined = Vec::with_capacity(TABLES.len() + LARGE_TABLES.len());
+    combined.extend_from_slice(TABLES);
+    combined.extend_from_slice(LARGE_TABLES);
+    combined
+}
+
 /// Delete all data in the database. Only used by tests.
 #[allow(non_snake_case)]
 pub async fn clear_DANGER_(ex: &mut PgTransaction<'_>) -> sqlx::Result<()> {
-    for table in ALL_TABLES {
+    for table in all_tables() {
         ex.execute(format!("TRUNCATE {table};").as_str()).await?;
     }
     Ok(())

--- a/crates/database/src/lib.rs
+++ b/crates/database/src/lib.rs
@@ -71,11 +71,8 @@ pub const TABLES: &[&str] = &[
 /// The names of potentially big volume tables we use in the db.
 pub const LARGE_TABLES: &[&str] = &["order_events"];
 
-pub fn all_tables() -> Vec<&'static str> {
-    let mut combined = Vec::with_capacity(TABLES.len() + LARGE_TABLES.len());
-    combined.extend_from_slice(TABLES);
-    combined.extend_from_slice(LARGE_TABLES);
-    combined
+pub fn all_tables() -> impl Iterator<Item = &'static str> {
+    TABLES.iter().copied().chain(LARGE_TABLES.iter().copied())
 }
 
 /// Delete all data in the database. Only used by tests.


### PR DESCRIPTION
# Description
Noticed that the rows count query for the `order_events` table takes **150-200+ seconds** both in staging and prod. The proposal is to try out using rough row count estimation for large tables.

# Changes
`SELECT COUNT(*) ...` is replaced with `SELECT reltuples FROM pg_class WHERE relname='{table}';` for the `order_events` table.

## How to test
Will analyze metrics to understand how often Postgres updates the statistics without manually triggering `ANALYZE`. 

## Further optimization

In case statistics update happens often enough, the same approach could be considered for other tables where very often row count update is not necessary.