### PR TITLE
Insert order events in batches

### DIFF
--- a/crates/autopilot/src/periodic_db_cleanup.rs
+++ b/crates/autopilot/src/periodic_db_cleanup.rs
@@ -105,13 +105,7 @@ mod tests {
             label: OrderEventLabel::Created,
         };
 
-        database::order_events::insert_order_event(&mut ex, &event_a)
-            .await
-            .unwrap();
-        database::order_events::insert_order_event(&mut ex, &event_b)
-            .await
-            .unwrap();
-        database::order_events::insert_order_event(&mut ex, &event_c)
+        database::order_events::insert_order_events_batch(&mut ex, &[event_a, event_b, event_c])
             .await
             .unwrap();
 


### PR DESCRIPTION
# Description
Since `order_events` insert operation takes much time, it is considered to try batching.

# Changes
Split incoming order events into batches with size 500 by default. If the approach shows a positive impact, it will be moved to config.

## How to test
Using logs, compare with the previous metrics.