### PR TITLE
Add Balancer subgraph on Sepolia

### DIFF
--- a/crates/shared/src/sources/uniswap_v3/graph_api.rs
+++ b/crates/shared/src/sources/uniswap_v3/graph_api.rs
@@ -4,7 +4,7 @@
 use {
     crate::{
         event_handling::MAX_REORG_BLOCK_COUNT,
-        subgraph::{ContainsId, SubgraphClient},
+        subgraph::{ContainsId, GraphUrl, StandardGraphUrlParams, SubgraphClient},
     },
     anyhow::{bail, Result},
     ethcontract::{H160, U256},
@@ -112,7 +112,13 @@ impl UniV3SubgraphClient {
             1 => "uniswap-v3",
             _ => bail!("unsupported chain {}", chain_id),
         };
-        Ok(Self(SubgraphClient::new("uniswap", subgraph_name, client)?))
+        Ok(Self(SubgraphClient::new(
+            GraphUrl::Standard(StandardGraphUrlParams {
+                org: "uniswap".into(),
+                name: subgraph_name.into(),
+            }),
+            client,
+        )))
     }
 
     async fn get_pools(&self, query: &str, variables: Map<String, Value>) -> Result<Vec<PoolData>> {


### PR DESCRIPTION
# Description
Changes how subgraphs are initialized to account for the fact that Sepolia uses a different URL format in its subgraph ([source](https://docs.balancer.fi/reference/subgraph/#subgraphs)).

# Changes

- Introduced standard parameter formats for the two standard ways to access subgraphs.
- Added Sepolia.

## How to test

Ignored unit tests in relevant files.

<details><summary>cargo test -p shared -- sources::balancer_v2::graph_api::tests::balancer_subgraph_query --exact --nocapture --ignored</summary>

```
    Finished test [unoptimized + debuginfo] target(s) in 10.20s
     Running unittests src/lib.rs (target/debug/deps/shared-7dfb0bde6a737d97)

running 1 test
### Mainnet
Retrieved 1380 total pools at block 18735816
- 396 Weighted pools from factory 0x8e9aa87e45e92bad84d5f8dd1bff34fb92637de9
- 14 Weighted pools from factory 0xcc508a455f5b0073973107db6a878ddbdab957bc
- 81 Weighted pools from factory 0x897888115ada5773e02aa29f775430bfb5f34c51
- 13 ComposableStable pools from factory 0xf9ac7b9df2b3454e841110cce5550bd5ac6f875f
- 64 LiquidityBootstrapping pools from factory 0x751a0bc0e3f75b38e01cf25bfce7ff36de1c87de
- 37 Weighted pools from factory 0x5dd94da3644ddd055fcf6b3e1aa310bb7801eb8b
- 4 Stable pools from factory 0xc66ba2b6595d3613ccab350c886ace23866ede24
- 40 ComposableStable pools from factory 0xdb8d758bcb971e482b2c45f7f8a7740283a1bd3a
- 1 ComposableStable pools from factory 0x85a80afee867adf27b50bdb7b76da70f1e853062
- 600 LiquidityBootstrapping pools from factory 0x0f3e0c4218b7b0108a3643cfe9d3ec0d4f57c54e
- 26 ComposableStable pools from factory 0xdba127fbc23fb20f5929c546af220a991b5c6e01
- 80 Weighted pools from factory 0xa5bf2ddf098bb0ef6d120c98217dd6b141c74ee0
- 11 Stable pools from factory 0x8df6efec5547e31b0eb7d1291b511ff8a2bf987c
- 13 ComposableStable pools from factory 0xfada0f4547ab2de89d1304a668c39b3e09aa7c76
### Goerli
test sources::balancer_v2::graph_api::tests::balancer_subgraph_query has been running for over 60 seconds
Retrieved 1607 total pools at block 10174196
- 27 Weighted pools from factory 0x94f68b54191f62f781fe8298a8a5fa3ed772d227
- 13 ComposableStable pools from factory 0xb848f50141f3d4255b37ac288c25c109104f2158
- 14 ComposableStable pools from factory 0xbfd9769b061e57e478690299011a028194d66e3c
- 7 Stable pools from factory 0xd360b8afb3d7463be823be1ec3c33aa173ebe86e
- 24 Stable pools from factory 0x44afeb87c871d8fea9398a026dea2bd3a13f5769
- 3 ComposableStable pools from factory 0x1802953277fd955f9a254b80aa0582f193cf1d77
- 54 Weighted pools from factory 0xa5bf2ddf098bb0ef6d120c98217dd6b141c74ee0
- 91 Weighted pools from factory 0x230a59f4d9adc147480f03b0d3fffecd56c3289a
- 168 LiquidityBootstrapping pools from factory 0xb48cc42c45d262534e46d5965a9ac496f1b7a830
- 7 ComposableStable pools from factory 0x4bdcc2fb18aeb9e2d281b0278d946445070eada7
- 408 Weighted pools from factory 0x8e9aa87e45e92bad84d5f8dd1bff34fb92637de9
- 15 ComposableStable pools from factory 0x85a80afee867adf27b50bdb7b76da70f1e853062
- 57 Weighted pools from factory 0x26575a44755e0aaa969fdda1e4291df22c5624ea
- 719 LiquidityBootstrapping pools from factory 0xb0c726778c3ae4b3454d85557a48e8fa502bdd6a
### Sepolia
Retrieved 46 total pools at block 4841346
- 4 ComposableStable pools from factory 0xa523f47a933d5020b23629ddf689695aa94612dc
- 2 ComposableStable pools from factory 0xa3fd20e29358c056b727657e83dfd139abbc9924
- 34 Weighted pools from factory 0x7920bfa1b2041911b354747ca7a6cdd2dfc50cfd
- 6 LiquidityBootstrapping pools from factory 0x45ffd460cc6642b8d8fb12373dfd77ceb0f4932b
test sources::balancer_v2::graph_api::tests::balancer_subgraph_query ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 388 filtered out; finished in 80.63s
```
</details>


<details><summary>cargo test -p shared -- sources::uniswap_v3::graph_api::tests --nocapture --ignored</summary>

```
    Finished test [unoptimized + debuginfo] target(s) in 0.13s
     Running unittests src/lib.rs (target/debug/deps/shared-7dfb0bde6a737d97)

running 4 tests
[crates/shared/src/sources/uniswap_v3/graph_api.rs:543] result = [
  <truncated>
]
test sources::uniswap_v3::graph_api::tests::get_ticks_by_pools_ids_test ... ok
Retrieved 7494 total pools at block 18735824
test sources::uniswap_v3::graph_api::tests::get_registered_pools_test ... ok
test sources::uniswap_v3::graph_api::tests::get_pools_by_pool_ids_test ... ok

test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 385 filtered out; finished in 34.12s
```
</details>