### PR TITLE
Fix large table count query

### DIFF
--- a/crates/autopilot/src/database.rs
+++ b/crates/autopilot/src/database.rs
@@ -58,7 +58,7 @@ async fn count_rows_in_table(ex: &mut PgConnection, table: &str) -> sqlx::Result
 }
 
 async fn estimate_rows_in_table(ex: &mut PgConnection, table: &str) -> sqlx::Result<i64> {
-    let query = format!("SELECT reltuples FROM pg_class WHERE relname='{table}';");
+    let query = format!("SELECT reltuples::bigint FROM pg_class WHERE relname='{table}';");
     sqlx::query_scalar(&query).fetch_one(ex).await
 }
 


### PR DESCRIPTION
# Description
The current query returns a value in an unexpected format.

# Changes
Cast the returned value to a type that can be converted to `i64`.

## How to test
Ran the modified query in `pgadmin` to check that the type returned from it is the same as is returned from the regular `count(*)` query.