### PR TITLE
Report metrics for matched but unsettled orderes

### DIFF
--- a/crates/autopilot/src/run_loop.rs
+++ b/crates/autopilot/src/run_loop.rs
@@ -293,6 +293,12 @@ impl RunLoop {
                     tracing::warn!(?err, driver = %driver.name, "settlement failed");
                 }
             }
+            let unsettled_orders: Vec<_> = solutions
+                .iter()
+                .flat_map(|p| p.solution.orders.keys())
+                .filter(|uid| !solution.orders.contains_key(uid))
+                .collect();
+            Metrics::matched_unsettled(driver, unsettled_orders.as_slice());
         }
     }
 
@@ -638,6 +644,11 @@ struct Metrics {
     /// Tracks the result of driver `/settle` requests.
     #[metric(labels("driver", "result"))]
     settle: prometheus::IntCounterVec,
+
+    /// Tracks the number of orders that were part of some but not the winning
+    /// solution.
+    #[metric(labels("winner"))]
+    matched_unsettled: prometheus::IntCounterVec,
 }
 
 impl Metrics {
@@ -715,5 +726,15 @@ impl Metrics {
             .settle
             .with_label_values(&[&driver.name, label])
             .inc();
+    }
+
+    fn matched_unsettled(winning: &Driver, unsettled: &[&OrderUid]) {
+        if !unsettled.is_empty() {
+            tracing::debug!(?unsettled, "some orders were matched but not settled");
+        }
+        Self::get()
+            .matched_unsettled
+            .with_label_values(&[&winning.name])
+            .inc_by(unsettled.len() as u64);
     }
 }

--- a/crates/autopilot/src/run_loop.rs
+++ b/crates/autopilot/src/run_loop.rs
@@ -646,8 +646,8 @@ struct Metrics {
     settle: prometheus::IntCounterVec,
 
     /// Tracks the number of orders that were part of some but not the winning
-    /// solution.
-    #[metric(labels("winner"))]
+    /// solution together with the winning driver that did't include it.
+    #[metric(labels("ignored_by"))]
     matched_unsettled: prometheus::IntCounterVec,
 }
 


### PR DESCRIPTION
# Description
Implements logic similar to what we currently have in the solver crate to track how many orders were part of a solution that didn't end up winning. This can be used to populate alerts like [this one](https://g-0263500beb.grafana-workspace.eu-central-1.amazonaws.com/d/oPiE1Ennz/alerts-prod?editPanel=10&tab=query&orgId=1).

https://github.com/cowprotocol/services/blob/1b585b5b08a34fe57e7c53cc6d9514c8daa7d5e6/crates/solver/src/analytics.rs#L19-L47

# Changes
<!-- List of detailed changes (how the change is accomplished) -->

- [ ] Record the same metrics that used to be populated in the legacy solver/driver in the autopilot

## How to test
Observice Grafana