### PR TITLE
[Easy] Fix executed amount reporting for native ETH

### DIFF
--- a/crates/driver/src/domain/competition/solution/settlement.rs
+++ b/crates/driver/src/domain/competition/solution/settlement.rs
@@ -310,13 +310,13 @@ impl Settlement {
             .fold(Default::default(), |mut acc, solution| {
                 for trade in solution.user_trades() {
                     let order = acc.entry(trade.order().uid).or_default();
-                    order.sell = trade.sell_amount(&solution.prices).unwrap_or_else(|| {
+                    order.sell = trade.sell_amount(&solution.prices, solution.weth).unwrap_or_else(|| {
                         // This should never happen, returning 0 is better than panicking, but we
                         // should still alert.
                         tracing::error!(uid = ?trade.order().uid, "could not compute sell_amount");
                         0.into()
                     });
-                    order.buy = trade.buy_amount(&solution.prices).unwrap_or_else(|| {
+                    order.buy = trade.buy_amount(&solution.prices, solution.weth).unwrap_or_else(|| {
                         // This should never happen, returning 0 is better than panicking, but we
                         // should still alert.
                         tracing::error!(uid = ?trade.order().uid, "could not compute buy_amount");

--- a/crates/driver/src/domain/competition/solution/trade.rs
+++ b/crates/driver/src/domain/competition/solution/trade.rs
@@ -92,14 +92,15 @@ impl Fulfillment {
     pub fn sell_amount(
         &self,
         prices: &HashMap<eth::TokenAddress, eth::U256>,
+        weth: eth::WethAddress,
     ) -> Option<eth::TokenAmount> {
         let before_fee = match self.order.side {
             order::Side::Sell => self.executed.0,
             order::Side::Buy => self
                 .executed
                 .0
-                .checked_mul(*prices.get(&self.order.buy.token)?)?
-                .checked_div(*prices.get(&self.order.sell.token)?)?,
+                .checked_mul(*prices.get(&self.order.buy.token.wrap(weth))?)?
+                .checked_div(*prices.get(&self.order.sell.token.wrap(weth))?)?,
         };
         Some(eth::TokenAmount(
             before_fee.checked_add(self.solver_fee().0)?,
@@ -110,14 +111,15 @@ impl Fulfillment {
     pub fn buy_amount(
         &self,
         prices: &HashMap<eth::TokenAddress, eth::U256>,
+        weth: eth::WethAddress,
     ) -> Option<eth::TokenAmount> {
         let amount = match self.order.side {
             order::Side::Buy => self.executed.0,
             order::Side::Sell => self
                 .executed
                 .0
-                .checked_mul(*prices.get(&self.order.sell.token)?)?
-                .checked_div(*prices.get(&self.order.buy.token)?)?,
+                .checked_mul(*prices.get(&self.order.sell.token.wrap(weth))?)?
+                .checked_div(*prices.get(&self.order.buy.token.wrap(weth))?)?,
         };
         Some(eth::TokenAmount(amount))
     }


### PR DESCRIPTION
# Description
We are getting a lot of alerts a la

> 2023-12-08T12:36:52.017Z ERROR request{id="3681"}:/solve{solver=oneinch-solve auction_id=8127130}: driver::domain::competition::solution::settlement: could not compute buy_amount uid=Uid(0xad576385f272c5363324bfed7b925141dd9f93dcd1c6f9569620c8e09c87c1d6743dbd073d951bc1e7ee276eb79a285595993d63657314b5)

for order UIDs that are buying ETH.

This is because those are buying the placeholder address `0xe...e` which isn't part of the price vector. Instead this address needs to be converted to the wrapped token equivalent.

# Changes

- [ ] Also pass Weth address into the sell/buy_amount functions 

## How to test
No more alerts