### PR TITLE
Allow TOML error trace

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -70,6 +70,7 @@ jobs:
       CARGO_PROFILE_DEV_DEBUG: 0
       CARGO_PROFILE_TEST_DEBUG: 0
       CARGO_TERM_COLOR: always
+      TOML_TRACE_ERROR: 1      
     steps:
       - uses: actions/checkout@v3
       - uses: foundry-rs/foundry-toolchain@v1
@@ -93,6 +94,7 @@ jobs:
       CARGO_PROFILE_TEST_DEBUG: 0
       CARGO_TERM_COLOR: always
       FORK_URL: https://eth.merkle.io
+      TOML_TRACE_ERROR: 1      
     steps:
       - uses: actions/checkout@v3
       - uses: foundry-rs/foundry-toolchain@v1
@@ -115,6 +117,7 @@ jobs:
       CARGO_PROFILE_DEV_DEBUG: 0
       CARGO_PROFILE_TEST_DEBUG: 0
       CARGO_TERM_COLOR: always
+      TOML_TRACE_ERROR: 1      
     steps:
       - uses: actions/checkout@v3
       - uses: foundry-rs/foundry-toolchain@v1


### PR DESCRIPTION
# Description
TOML parsing errors on CI/CD are not displayed and make it hard to investigate. 

# Changes
This PR will show the parsing error assuming that all the configs used for testing contain dummy data only. 
