### PR TITLE
[Easy] Only void solutions that fail due to reverts

### DIFF
--- a/crates/driver/src/infra/observe/mod.rs
+++ b/crates/driver/src/infra/observe/mod.rs
@@ -20,7 +20,7 @@ use {
             quote::{self, Quote},
             Liquidity,
         },
-        infra::solver,
+        infra::{simulator, solver},
         util::http,
     },
     ethrpc::current_block::BlockInfo,
@@ -167,7 +167,7 @@ pub fn score(settlement: &Settlement, score: &competition::Score) {
 
 // Observe that the winning settlement started failing upon arrival of a new
 // block
-pub fn winner_voided(block: BlockInfo, err: &simulator::Error) {
+pub fn winner_voided(block: BlockInfo, err: &simulator::RevertError) {
     tracing::warn!(block = block.number, ?err, "solution reverts on new block");
 }
 

--- a/crates/driver/src/infra/observe/mod.rs
+++ b/crates/driver/src/infra/observe/mod.rs
@@ -20,7 +20,7 @@ use {
             quote::{self, Quote},
             Liquidity,
         },
-        infra::{simulator, solver},
+        infra::solver,
         util::http,
     },
     ethrpc::current_block::BlockInfo,


### PR DESCRIPTION
# Description
Once a solver is done merging and post-processing solutions, we continue simulating their best solution candidate upon arrival of new blocks to make sure they are still valid. We void the solution candidate if simulation fails.

However, simulation may fail for two reasons:
1. An actual revert
2. Some other error (e.g. HTTP errors or the like)

While both are lethal for generating to solution candidate in the first place (as we need to get the gas estimate from the simulation for ranking), only actual reverts should cause a solution to be evicted in the final phase. In case we have a network error, we can just be "optimistic" and assume the outcome of the simulation hasn't changed.

# Changes
- [ ] Only void solution if simulation error is an actual revert

## How to test
CI and 🤞 as we don't have a way to test/mock simulations as part of e2e tests and this issue seems to be too narrow to warrant its own high level test.