### PR TITLE
Adjust /solve time buckets

### DIFF
--- a/crates/autopilot/src/run_loop.rs
+++ b/crates/autopilot/src/run_loop.rs
@@ -649,7 +649,9 @@ struct Metrics {
     /// Tracks the duration of successful driver `/solve` requests.
     #[metric(
         labels("driver", "result"),
-        buckets(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15)
+        buckets(
+            0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20
+        )
     )]
     solve: prometheus::HistogramVec,
 

--- a/crates/autopilot/src/run_loop.rs
+++ b/crates/autopilot/src/run_loop.rs
@@ -647,7 +647,10 @@ struct Metrics {
     auction: prometheus::IntGauge,
 
     /// Tracks the duration of successful driver `/solve` requests.
-    #[metric(labels("driver", "result"))]
+    #[metric(
+        labels("driver", "result"),
+        buckets(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15)
+    )]
     solve: prometheus::HistogramVec,
 
     /// Tracks driver solutions.


### PR DESCRIPTION
# Description
We already have a grafana dashboard to track the time every driver spends in `/solve` but the default prometheus histogram buckets are not really suitable to get useful information out of this metric.

# Changes
Adjust the metric to have 1 bucket for every second in the deadline.