### PR TITLE
Configure alerter with 0x API Key

### DIFF
--- a/crates/alerter/src/lib.rs
+++ b/crates/alerter/src/lib.rs
@@ -105,13 +105,15 @@ fn convert_eth_to_weth(token: H160) -> H160 {
 struct ZeroExApi {
     base: Url,
     client: Client,
+    api_key: String,
 }
 
 impl ZeroExApi {
-    pub fn new(client: Client) -> Self {
+    pub fn new(client: Client, api_key: String) -> Self {
         Self {
             base: "https://api.0x.org".parse().unwrap(),
             client,
+            api_key,
         }
     }
 
@@ -142,6 +144,7 @@ impl ZeroExApi {
         let response: Response = self
             .client
             .get(url.clone())
+            .header("0x-api-key", self.api_key.clone())
             .send()
             .await?
             .error_for_status()?
@@ -373,6 +376,9 @@ struct Arguments {
     /// can rate limit us.
     #[clap(long, env, default_value = "0.2", value_parser = shared::arguments::duration_from_seconds)]
     api_get_order_min_interval: Duration,
+
+    #[clap(long, env)]
+    api_key: String,
 }
 
 pub async fn start(args: impl Iterator<Item = String>) {
@@ -395,7 +401,7 @@ async fn run(args: Arguments) {
 
     let mut alerter = Alerter::new(
         OrderBookApi::new(client.clone(), &args.orderbook_api),
-        ZeroExApi::new(client),
+        ZeroExApi::new(client, args.api_key),
         AlertConfig {
             time_without_trade: args.time_without_trade,
             min_order_solvable_time: args.min_order_age,

--- a/crates/alerter/src/lib.rs
+++ b/crates/alerter/src/lib.rs
@@ -378,7 +378,7 @@ struct Arguments {
     api_get_order_min_interval: Duration,
 
     #[clap(long, env)]
-    api_key: String,
+    zero_ex_api_key: String,
 }
 
 pub async fn start(args: impl Iterator<Item = String>) {
@@ -401,7 +401,7 @@ async fn run(args: Arguments) {
 
     let mut alerter = Alerter::new(
         OrderBookApi::new(client.clone(), &args.orderbook_api),
-        ZeroExApi::new(client, args.api_key),
+        ZeroExApi::new(client, args.zero_ex_api_key),
         AlertConfig {
             time_without_trade: args.time_without_trade,
             min_order_solvable_time: args.min_order_age,


### PR DESCRIPTION
# Description
I was looking into why we did not receive an emergency alert during the MEVBlocker outage last week. It turns out that our alert pod broke when 0x started requiring API keys.

As a consequence, all our API calls received 401 errors and we thus didn't identify any solutions as unsettleable. This issue was raises as an alert in the barn alert channel (since the alerter itself only runs in staging), but didn't catch attention.

It didn't show up before, because the alerter only attempts to query 0x when there are no settlements for a longer period of time (which usually doesn't happen). Therefore this issue could only be identified when an outage was actually in progress.

This PR focusses on fixing the use of the 0x API. I think we should also revisit how we ensure that the alert pod is working correctly, but I don't have a great idea how off the top of my head. Maybe we can log "error" into a metric which itself could be used for prod or emergency alerts.

# Changes

- [ ] Configure binary with a mandatory API key and use this in 0x requests

## How to test
Local curl test that the query with the correct API key set returns 200 instead of 401
