### PR TITLE
Add Sepolia testnet

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ Run an `autopilot` with:
 
 ```sh
 cargo run --bin autopilot -- \
-  --skip-event-sync \
+  --skip-event-sync true \
   --node-url <YOUR_NODE_URL>
 ```
 

--- a/crates/contracts/artifacts/TestnetUniswapV2Router02.json
+++ b/crates/contracts/artifacts/TestnetUniswapV2Router02.json
@@ -1,0 +1,1 @@
+IUniswapLikeRouter.json

--- a/crates/contracts/build.rs
+++ b/crates/contracts/build.rs
@@ -13,6 +13,7 @@ mod paths;
 const MAINNET: &str = "1";
 const GOERLI: &str = "5";
 const GNOSIS: &str = "100";
+const SEPOLIA: &str = "11155111";
 
 fn main() {
     // NOTE: This is a workaround for `rerun-if-changed` directives for
@@ -49,6 +50,15 @@ fn main() {
                     address: addr("0x40a50cf069e992aa4536211b23f286ef88752187"),
                     // <https://gnosisscan.io/tx/0x6280e079f454fbb5de3c52beddd64ca2b5be0a4b3ec74edfd5f47e118347d4fb>
                     deployment_information: Some(DeploymentInformation::BlockNumber(25414331)),
+                },
+            )
+            .add_network(
+                SEPOLIA,
+                Network {
+                    // <https://github.com/cowprotocol/ethflowcontract/blob/v1.1.0-artifacts/networks.prod.json#L11-L14>
+                    address: addr("0x0b7795E18767259CC253a2dF471db34c72B49516"),
+                    // <https://sepolia.etherscan.io/tx/0x558a7608a770b5c4f68fffa9b02e7908a40f61b557b435ea768a4c62cb79ae25>
+                    deployment_information: Some(DeploymentInformation::BlockNumber(4718739)),
                 },
             )
     });
@@ -93,11 +103,20 @@ fn main() {
                     deployment_information: Some(DeploymentInformation::BlockNumber(24821598)),
                 },
             )
+            .add_network(
+                SEPOLIA,
+                Network {
+                    address: addr("0xBA12222222228d8Ba445958a75a0704d566BF2C8"),
+                    // <https://sepolia.etherscan.io/tx/0xb22509c6725dd69a975ecb96a0c594901eeee6a279cc66d9d5191022a7039ee6>
+                    deployment_information: Some(DeploymentInformation::BlockNumber(3418831)),
+                },
+            )
     });
     generate_contract_with_config("BalancerV2WeightedPoolFactory", |builder| {
         builder
             .contract_mod_override("balancer_v2_weighted_pool_factory")
             .add_network(
+                // <https://docs.balancer.fi/reference/contracts/deployment-addresses/mainnet.html#ungrouped-active-current-contracts>
                 MAINNET,
                 Network {
                     address: addr("0x8E9aa87E45e92bad84D5F8DD1bff34Fb92637dE9"),
@@ -106,6 +125,7 @@ fn main() {
                 },
             )
             .add_network(
+                // <https://docs.balancer.fi/reference/contracts/deployment-addresses/goerli.html#ungrouped-active-current-contracts>
                 GOERLI,
                 Network {
                     address: addr("0x8E9aa87E45e92bad84D5F8DD1bff34Fb92637dE9"),
@@ -113,11 +133,14 @@ fn main() {
                     deployment_information: Some(DeploymentInformation::BlockNumber(4648101)),
                 },
             )
+        // Not available on Sepolia (only version ≥ 4)
+        // <https://docs.balancer.fi/reference/contracts/deployment-addresses/sepolia.html>
     });
     generate_contract_with_config("BalancerV2WeightedPoolFactoryV3", |builder| {
         builder
             .contract_mod_override("balancer_v2_weighted_pool_factory_v3")
             .add_network(
+                // <https://docs.balancer.fi/reference/contracts/deployment-addresses/mainnet.html#ungrouped-active-current-contracts>
                 MAINNET,
                 Network {
                     address: addr("0x5Dd94Da3644DDD055fcf6B3E1aa310Bb7801EB8b"),
@@ -126,6 +149,7 @@ fn main() {
                 },
             )
             .add_network(
+                // <https://docs.balancer.fi/reference/contracts/deployment-addresses/goerli.html#ungrouped-active-current-contracts>
                 GOERLI,
                 Network {
                     address: addr("0x26575A44755E0aaa969FDda1E4291Df22C5624Ea"),
@@ -141,6 +165,8 @@ fn main() {
                     deployment_information: Some(DeploymentInformation::BlockNumber(26226256)),
                 },
             )
+        // Not available on Sepolia (only version ≥ 4)
+        // <https://docs.balancer.fi/reference/contracts/deployment-addresses/sepolia.html>
     });
     generate_contract_with_config("BalancerV2WeightedPoolFactoryV4", |builder| {
         builder
@@ -169,11 +195,21 @@ fn main() {
                     deployment_information: Some(DeploymentInformation::BlockNumber(27055829)),
                 },
             )
+            .add_network(
+                // <https://docs.balancer.fi/reference/contracts/deployment-addresses/sepolia.html#pool-factories>
+                SEPOLIA,
+                Network {
+                    address: addr("0x7920BFa1b2041911b354747CA7A6cDD2dfC50Cfd"),
+                    // <https://sepolia.etherscan.io/tx/0x7dd392b586f1cdecfc635e7dd40ee1444a7836772811e59321fd4873ecfdf3eb>
+                    deployment_information: Some(DeploymentInformation::BlockNumber(3424893)),
+                },
+            )
     });
     generate_contract_with_config("BalancerV2WeightedPool2TokensFactory", |builder| {
         builder
             .contract_mod_override("balancer_v2_weighted_pool_2_tokens_factory")
             .add_network(
+                // <https://docs.balancer.fi/reference/contracts/deployment-addresses/mainnet.html#ungrouped-active-current-contracts>
                 MAINNET,
                 Network {
                     address: addr("0xa5bf2ddf098bb0ef6d120c98217dd6b141c74ee0"),
@@ -182,6 +218,7 @@ fn main() {
                 },
             )
             .add_network(
+                // <https://docs.balancer.fi/reference/contracts/deployment-addresses/goerli.html#ungrouped-active-current-contracts>
                 GOERLI,
                 Network {
                     address: addr("0xa5bf2ddf098bb0ef6d120c98217dd6b141c74ee0"),
@@ -189,11 +226,14 @@ fn main() {
                     deployment_information: Some(DeploymentInformation::BlockNumber(4716924)),
                 },
             )
+        // Not available on Sepolia
+        // <https://docs.balancer.fi/reference/contracts/deployment-addresses/sepolia.html>
     });
     generate_contract_with_config("BalancerV2StablePoolFactoryV2", |builder| {
         builder
             .contract_mod_override("balancer_v2_stable_pool_factory_v2")
             .add_network(
+                // <https://docs.balancer.fi/reference/contracts/deployment-addresses/mainnet.html#ungrouped-active-current-contracts>
                 MAINNET,
                 Network {
                     address: addr("0x8df6efec5547e31b0eb7d1291b511ff8a2bf987c"),
@@ -202,6 +242,7 @@ fn main() {
                 },
             )
             .add_network(
+                // <https://docs.balancer.fi/reference/contracts/deployment-addresses/goerli.html#ungrouped-active-current-contracts>
                 GOERLI,
                 Network {
                     address: addr("0xD360B8afb3d7463bE823bE1Ec3c33aA173EbE86e"),
@@ -217,11 +258,14 @@ fn main() {
                     deployment_information: Some(DeploymentInformation::BlockNumber(25415344)),
                 },
             )
+        // Not available on Sepolia
+        // <https://docs.balancer.fi/reference/contracts/deployment-addresses/sepolia.html>
     });
     generate_contract_with_config("BalancerV2LiquidityBootstrappingPoolFactory", |builder| {
         builder
             .contract_mod_override("balancer_v2_liquidity_bootstrapping_pool_factory")
             .add_network(
+                // <https://docs.balancer.fi/reference/contracts/deployment-addresses/mainnet.html#ungrouped-active-current-contracts>
                 MAINNET,
                 Network {
                     address: addr("0x751A0bC0e3f75b38e01Cf25bFCE7fF36DE1C87DE"),
@@ -229,7 +273,16 @@ fn main() {
                     deployment_information: Some(DeploymentInformation::BlockNumber(12871780)),
                 },
             )
-        // Not deployed on Görli
+            .add_network(
+                GOERLI,
+                Network {
+                    address: addr("0xb48Cc42C45d262534e46d5965a9Ac496F1B7a830"),
+                    // <https://goerli.etherscan.io/tx/0x7dcb9e2026789e194e6e78605ac6a65e00392ba5d73e084d468e3dfbb188ea70>
+                    deployment_information: Some(DeploymentInformation::BlockNumber(6993037)),
+                },
+            )
+        // Not available on Sepolia
+        // <https://docs.balancer.fi/reference/contracts/deployment-addresses/sepolia.html>
     });
     generate_contract_with_config(
         "BalancerV2NoProtocolFeeLiquidityBootstrappingPoolFactory",
@@ -239,6 +292,7 @@ fn main() {
                     "balancer_v2_no_protocol_fee_liquidity_bootstrapping_pool_factory",
                 )
                 .add_network(
+                    // <https://docs.balancer.fi/reference/contracts/deployment-addresses/mainnet.html#ungrouped-active-current-contracts>
                     MAINNET,
                     Network {
                         address: addr("0x0F3e0c4218b7b0108a3643cFe9D3ec0d4F57c54e"),
@@ -246,7 +300,33 @@ fn main() {
                         deployment_information: Some(DeploymentInformation::BlockNumber(13730248)),
                     },
                 )
-            // Not deployed on Görli
+                .add_network(
+                    // <https://docs.balancer.fi/reference/contracts/deployment-addresses/goerli.html#ungrouped-active-current-contracts>
+                    GOERLI,
+                    Network {
+                        address: addr("0xB0C726778C3AE4B3454D85557A48e8fa502bDD6A"),
+                        // <https://goerli.etherscan.io/tx/0x278e68794c90221334e251974d65bbd7733f5fd7ef2617c978bf7c817828ce8d>
+                        deployment_information: Some(DeploymentInformation::BlockNumber(6993471)),
+                    },
+                )
+                .add_network(
+                    // <https://docs.balancer.fi/reference/contracts/deployment-addresses/gnosis.html#ungrouped-active-current-contracts>
+                    GNOSIS,
+                    Network {
+                        address: addr("0x85a80afee867aDf27B50BdB7b76DA70f1E853062"),
+                        // <https://gnosis.blockscout.com/tx/0xbd56fefdb27e4ff1c0852e405f78311d6bc2befabaf6c87a405ab19de8c1506a>
+                        deployment_information: Some(DeploymentInformation::BlockNumber(25415236)),
+                    },
+                )
+                .add_network(
+                    // <https://docs.balancer.fi/reference/contracts/deployment-addresses/sepolia.html#ungrouped-active-current-contracts>
+                    SEPOLIA,
+                    Network {
+                        address: addr("0x45fFd460cC6642B8D8Fb12373DFd77Ceb0f4932B"),
+                        // <https://sepolia.etherscan.io/tx/0xe0e8feb509a8aa8a1eaa0b0c4b34395ff2fd880fb854fbeeccc0af1826e395c9>
+                        deployment_information: Some(DeploymentInformation::BlockNumber(3419649)),
+                    },
+                )
         },
     );
     generate_contract_with_config("BalancerV2ComposableStablePoolFactory", |builder| {
@@ -268,6 +348,9 @@ fn main() {
                     deployment_information: Some(DeploymentInformation::BlockNumber(7542764)),
                 },
             )
+        // Not available on Sepolia and Gnosis Chain
+        // <https://docs.balancer.fi/reference/contracts/deployment-addresses/gnosis.html>
+        // <https://docs.balancer.fi/reference/contracts/deployment-addresses/sepolia.html>
     });
     generate_contract_with_config("BalancerV2ComposableStablePoolFactoryV3", |builder| {
         builder
@@ -296,6 +379,8 @@ fn main() {
                     deployment_information: Some(DeploymentInformation::BlockNumber(26365805)),
                 },
             )
+        // Not available on Sepolia (only version ≥ 4)
+        // <https://docs.balancer.fi/reference/contracts/deployment-addresses/sepolia.html>
     });
     generate_contract_with_config("BalancerV2ComposableStablePoolFactoryV4", |builder| {
         builder
@@ -324,6 +409,15 @@ fn main() {
                     deployment_information: Some(DeploymentInformation::BlockNumber(27056416)),
                 },
             )
+            .add_network(
+                // <https://docs.balancer.fi/reference/contracts/deployment-addresses/sepolia.html#deprecated-contracts>
+                SEPOLIA,
+                Network {
+                    address: addr("0xA3fd20E29358c056B727657E83DFd139abBC9924"),
+                    // <https://sepolia.etherscan.io/tx/0x9313a59ad9a95f2518076cbf4d0dc5f312e0b013a43a7ea4821cae2aa7a50aa2>
+                    deployment_information: Some(DeploymentInformation::BlockNumber(3425277)),
+                },
+            )
     });
     generate_contract_with_config("BalancerV2ComposableStablePoolFactoryV5", |builder| {
         builder
@@ -350,6 +444,15 @@ fn main() {
                     address: addr("0x4bdCc2fb18AEb9e2d281b0278D946445070EAda7"),
                     // <https://gnosisscan.io/tx/0xcbf18b5a0d1f1fca9b30d08ab77d8554567c3bffa7efdd3add273073d20bb1e2>
                     deployment_information: Some(DeploymentInformation::BlockNumber(28900564)),
+                },
+            )
+            .add_network(
+                // <https://docs.balancer.fi/reference/contracts/deployment-addresses/sepolia.html#ungrouped-active-current-contracts>
+                SEPOLIA,
+                Network {
+                    address: addr("0xa523f47A933D5020b23629dDf689695AA94612Dc"),
+                    // <https://sepolia.etherscan.io/tx/0x2c155dde7c480929991dd2a3344d9fdd20252f235370d46d0887b151dc0416bd>
+                    deployment_information: Some(DeploymentInformation::BlockNumber(3872211)),
                 },
             )
     });
@@ -395,6 +498,14 @@ fn main() {
                     deployment_information: Some(DeploymentInformation::BlockNumber(16465099)),
                 },
             )
+            .add_network(
+                SEPOLIA,
+                Network {
+                    address: addr("0x2c4c28DDBdAc9C5E7055b4C863b72eA0149D8aFE"),
+                    // <https://sepolia.etherscan.io/tx/0x73c54c75b3f382304f3adf33e3876c8999fb10df786d4a902733369251033cd1>
+                    deployment_information: Some(DeploymentInformation::BlockNumber(4717469)),
+                },
+            )
     });
     generate_contract_with_config("GPv2Settlement", |builder| {
         builder
@@ -423,6 +534,14 @@ fn main() {
                     deployment_information: Some(DeploymentInformation::BlockNumber(16465100)),
                 },
             )
+            .add_network(
+                SEPOLIA,
+                Network {
+                    address: addr("0x9008D19f58AAbD9eD0D60971565AA8510560ab41"),
+                    // <https://sepolia.etherscan.io/tx/0x6bba22a00ffcff6bca79aced546e18d2a5a4f4e484a4e4dbafab13daf42f718d>
+                    deployment_information: Some(DeploymentInformation::BlockNumber(4717488)),
+                },
+            )
     });
     generate_contract("GnosisSafe");
     generate_contract_with_config("GnosisSafeCompatibilityFallbackHandler", |builder| {
@@ -434,10 +553,12 @@ fn main() {
         builder.add_network_str(GNOSIS, "0x1C232F01118CB8B424793ae03F870aa7D0ac7f77")
     });
     generate_contract_with_config("HooksTrampoline", |builder| {
+        // <https://github.com/cowprotocol/hooks-trampoline/blob/993427166ade6c65875b932f853776299290ac4b/networks.json>
         builder
             .add_network_str(MAINNET, "0x01DcB88678aedD0C4cC9552B20F4718550250574")
             .add_network_str(GOERLI, "0x01DcB88678aedD0C4cC9552B20F4718550250574")
             .add_network_str(GNOSIS, "0x01DcB88678aedD0C4cC9552B20F4718550250574")
+            .add_network_str(SEPOLIA, "0x01DcB88678aedD0C4cC9552B20F4718550250574")
     });
     generate_contract("IUniswapLikeRouter");
     generate_contract("IUniswapLikePair");
@@ -447,49 +568,65 @@ fn main() {
         builder.add_network_str(MAINNET, "0xEfF92A263d31888d860bD50809A8D171709b7b1c")
     });
     generate_contract_with_config("SushiSwapRouter", |builder| {
+        // <https://docs.sushi.com/docs/Products/Classic%20AMM/Deployment%20Addresses>
         builder
             .add_network_str(MAINNET, "0xd9e1cE17f2641f24aE83637ab66a2cca9C378B9F")
             .add_network_str(GOERLI, "0x1b02dA8Cb0d097eB8D57A175b88c7D8b47997506")
             .add_network_str(GNOSIS, "0x1b02dA8Cb0d097eB8D57A175b88c7D8b47997506")
     });
     generate_contract_with_config("SwaprRouter", |builder| {
+        // <https://swapr.gitbook.io/swapr/contracts>
         builder
             .add_network_str(MAINNET, "0xb9960d9bca016e9748be75dd52f02188b9d0829f")
             .add_network_str(GNOSIS, "0xE43e60736b1cb4a75ad25240E2f9a62Bff65c0C0")
     });
     generate_contract("ISwaprPair");
     generate_contract_with_config("UniswapV2Factory", |builder| {
+        // <https://docs.uniswap.org/contracts/v2/reference/smart-contracts/factory>
         builder
             .add_network_str(MAINNET, "0x5C69bEe701ef814a2B6a3EDD4B1652CB9cc5aA6f")
             .add_network_str(GOERLI, "0x5C69bEe701ef814a2B6a3EDD4B1652CB9cc5aA6f")
-            .add_network_str(GNOSIS, "0xA818b4F111Ccac7AA31D0BCc0806d64F2E0737D7")
+        // Not available on Sepolia or Gnosis Chain
     });
     generate_contract_with_config("UniswapV2Router02", |builder| {
+        // <https://docs.uniswap.org/contracts/v2/reference/smart-contracts/router-02>
         builder
             .add_network_str(MAINNET, "0x7a250d5630B4cF539739dF2C5dAcb4c659F2488D")
             .add_network_str(GOERLI, "0x7a250d5630B4cF539739dF2C5dAcb4c659F2488D")
-            .add_network_str(GNOSIS, "0x1b02da8cb0d097eb8d57a175b88c7d8b47997506")
+        // Not available on Sepolia or Gnosis Chain
     });
     generate_contract_with_config("UniswapV3SwapRouter", |builder| {
+        // <https://github.com/Uniswap/v3-periphery/blob/697c2474757ea89fec12a4e6db16a574fe259610/deploys.md>
         builder
             .add_network_str(MAINNET, "0xE592427A0AEce92De3Edee1F18E0157C05861564")
             .add_network_str(GOERLI, "0xE592427A0AEce92De3Edee1F18E0157C05861564")
+            .add_network_str(SEPOLIA, "0xE592427A0AEce92De3Edee1F18E0157C05861564")
+        // Not available on Gnosis Chain
     });
     generate_contract("UniswapV3Pool");
     generate_contract_with_config("WETH9", |builder| {
+        // Note: the WETH address must be consistent with the one used by the ETH-flow
+        // contract
         builder
             .add_network_str(MAINNET, "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2")
             .add_network_str(GOERLI, "0xB4FBF271143F4FBf7B91A5ded31805e42b2208d6")
             .add_network_str(GNOSIS, "0xe91D153E0b41518A2Ce8Dd3D7944Fa863463a97d")
+            .add_network_str(SEPOLIA, "0xfFf9976782d46CC05630D1f6eBAb18b2324d6B14")
     });
     generate_contract_with_config("IUniswapV3Factory", |builder| {
+        // <https://github.com/Uniswap/v3-periphery/blob/697c2474757ea89fec12a4e6db16a574fe259610/deploys.md>
         builder
             .add_network_str(MAINNET, "0x1F98431c8aD98523631AE4a59f267346ea31F984")
             .add_network_str(GOERLI, "0x1F98431c8aD98523631AE4a59f267346ea31F984")
+            .add_network_str(SEPOLIA, "0x1F98431c8aD98523631AE4a59f267346ea31F984")
+        // Not available on Gnosis Chain
     });
     generate_contract_with_config("IZeroEx", |builder| {
+        // <https://docs.0xprotocol.org/en/latest/basics/addresses.html?highlight=contracts#addresses>
+        // <https://github.com/0xProject/protocol/blob/652d4226229c97895ae9350bbf276370ebb38c5e/packages/contract-addresses/addresses.json>
         builder
             .add_network_str(MAINNET, "0xdef1c0ded9bec7f1a1670819833240f027b25eff")
+            .add_network_str(SEPOLIA, "0xdef1c0ded9bec7f1a1670819833240f027b25eff")
             .add_method_alias(
                 "_transformERC20((address,address,address,uint256,uint256,(uint32,bytes)[],bool,\
                  address))",
@@ -517,9 +654,13 @@ fn main() {
             .add_network_str(MAINNET, "0xDEf1CA1fb7FBcDC777520aa7f396b4E015F497aB")
             .add_network_str(GOERLI, "0x91056D4A53E1faa1A84306D4deAEc71085394bC8")
             .add_network_str(GNOSIS, "0x177127622c4A00F3d409B75571e12cB3c8973d3c")
+            .add_network_str(SEPOLIA, "0x0625aFB445C3B6B7B929342a04A22599fd5dBB59")
     });
-    generate_contract_with_config("SolverTrampoline", |builder| {
-        builder.add_network_str("5", "0xd29ae121Ad58479c9Eb8C4F235c618fcF42eCba0")
+
+    // Unofficial Uniswap v2 liquidity on the Sepolia testnet.
+    generate_contract_with_config("TestnetUniswapV2Router02", |builder| {
+        // <https://github.com/eth-clients/sepolia/issues/47#issuecomment-1681562464>
+        builder.add_network_str(SEPOLIA, "0x86dcd3293C53Cf8EFd7303B57beb2a3F671dDE98")
     });
 
     // Support contracts used for trade and token simulations.

--- a/crates/contracts/src/lib.rs
+++ b/crates/contracts/src/lib.rs
@@ -58,9 +58,9 @@ include_contracts! {
     IUniswapV3Factory;
     IZeroEx;
     PancakeRouter;
-    SolverTrampoline;
     SushiSwapRouter;
     SwaprRouter;
+    TestnetUniswapV2Router02;
     UniswapV2Factory;
     UniswapV2Router02;
     UniswapV3Pool;
@@ -93,6 +93,7 @@ mod tests {
     const MAINNET: u64 = 1;
     const GOERLI: u64 = 5;
     const GNOSIS: u64 = 100;
+    const SEPOLIA: u64 = 11155111;
 
     use {
         super::*,
@@ -155,27 +156,31 @@ mod tests {
             }};
         }
 
-        for network in &[MAINNET, GOERLI, GNOSIS] {
+        for network in &[MAINNET, GOERLI, GNOSIS, SEPOLIA] {
             assert_has_deployment_address!(GPv2Settlement for *network);
-            assert_has_deployment_address!(SushiSwapRouter for *network);
             assert_has_deployment_address!(WETH9 for *network);
             assert_has_deployment_address!(CowProtocolToken for *network);
             assert_has_deployment_address!(HooksTrampoline for *network);
+            assert_has_deployment_address!(BalancerV2Vault for *network);
+            assert_has_deployment_address!(BalancerV2NoProtocolFeeLiquidityBootstrappingPoolFactory for *network);
+        }
+        for network in &[MAINNET, GOERLI, GNOSIS] {
+            assert_has_deployment_address!(SushiSwapRouter for *network);
+        }
+        for network in &[MAINNET, GOERLI, SEPOLIA] {
+            assert_has_deployment_address!(UniswapV3SwapRouter for *network);
+            assert_has_deployment_address!(IUniswapV3Factory for *network);
         }
         for network in &[MAINNET, GOERLI] {
-            assert_has_deployment_address!(BalancerV2Vault for *network);
             assert_has_deployment_address!(BalancerV2WeightedPoolFactory for *network);
             assert_has_deployment_address!(BalancerV2WeightedPool2TokensFactory for *network);
             assert_has_deployment_address!(UniswapV2Factory for *network);
             assert_has_deployment_address!(UniswapV2Router02 for *network);
-            assert_has_deployment_address!(UniswapV3SwapRouter for *network);
-            assert_has_deployment_address!(IUniswapV3Factory for *network);
         }
 
         // only mainnet
         assert_has_deployment_address!(BalancerV2StablePoolFactoryV2 for MAINNET);
         assert_has_deployment_address!(BalancerV2LiquidityBootstrappingPoolFactory for MAINNET);
-        assert_has_deployment_address!(BalancerV2NoProtocolFeeLiquidityBootstrappingPoolFactory for MAINNET);
         assert_has_deployment_address!(PancakeRouter for MAINNET);
         assert_has_deployment_address!(IZeroEx for MAINNET);
 
@@ -183,6 +188,9 @@ mod tests {
         assert_has_deployment_address!(BaoswapRouter for GNOSIS);
         assert_has_deployment_address!(HoneyswapRouter for GNOSIS);
         assert_has_deployment_address!(SwaprRouter for GNOSIS);
+
+        // only sepolia
+        assert_has_deployment_address!(TestnetUniswapV2Router02 for SEPOLIA);
     }
 
     #[test]
@@ -198,11 +206,11 @@ mod tests {
             }};
         }
 
-        for network in &[MAINNET, GOERLI, GNOSIS] {
+        for network in &[MAINNET, GOERLI, GNOSIS, SEPOLIA] {
             assert_has_deployment_information!(GPv2Settlement for *network);
+            assert_has_deployment_information!(BalancerV2Vault for *network);
         }
         for network in &[MAINNET, GOERLI] {
-            assert_has_deployment_information!(BalancerV2Vault for *network);
             assert_has_deployment_information!(BalancerV2WeightedPoolFactory for *network);
             assert_has_deployment_information!(BalancerV2WeightedPool2TokensFactory for *network);
         }

--- a/crates/driver/src/infra/config/file/load.rs
+++ b/crates/driver/src/infra/config/file/load.rs
@@ -124,6 +124,9 @@ pub async fn load(network: &blockchain::Network, path: &Path) -> infra::Config {
                         file::UniswapV2Preset::PancakeSwap => {
                             liquidity::config::UniswapV2::pancake_swap(&network.id)
                         }
+                        file::UniswapV2Preset::TestnetUniswapV2 => {
+                            liquidity::config::UniswapV2::testnet_uniswapv2(&network.id)
+                        }
                     }
                     .expect("no Uniswap V2 preset for current network"),
                     file::UniswapV2Config::Manual {

--- a/crates/driver/src/infra/config/file/mod.rs
+++ b/crates/driver/src/infra/config/file/mod.rs
@@ -327,6 +327,7 @@ enum UniswapV2Preset {
     Honeyswap,
     Baoswap,
     PancakeSwap,
+    TestnetUniswapV2,
 }
 
 #[derive(Clone, Debug, Deserialize)]

--- a/crates/driver/src/infra/liquidity/config.rs
+++ b/crates/driver/src/infra/liquidity/config.rs
@@ -93,6 +93,20 @@ impl UniswapV2 {
             missing_pool_cache_time: Duration::from_secs(60 * 60),
         })
     }
+
+    /// Returns the liquidity configuration for liquidity sources only used on
+    /// test networks.
+    pub fn testnet_uniswapv2(network: &eth::NetworkId) -> Option<Self> {
+        Some(Self {
+            router: deployment_address(
+                contracts::TestnetUniswapV2Router02::raw_contract(),
+                network,
+            )?,
+            pool_code: hex!("0efd7612822d579e24a8851501d8c2ad854264a1050e3dfcee8afcca08f80a86")
+                .into(),
+            missing_pool_cache_time: Duration::from_secs(60 * 60),
+        })
+    }
 }
 
 /// Swapr (Uniswap V2 clone with a twist) liquidity fetching options.

--- a/crates/model/src/lib.rs
+++ b/crates/model/src/lib.rs
@@ -165,16 +165,17 @@ mod tests {
     }
 
     #[test]
-    fn domain_separator_goerli() {
+    fn domain_separator_sepolia() {
         let contract_address: H160 = hex!("9008D19f58AAbD9eD0D60971565AA8510560ab41").into(); // new deployment
-        let chain_id: u64 = 5;
-        let domain_separator_goerli = DomainSeparator::new(chain_id, contract_address);
-        // domain separator is taken from goerli deployment at address
+        let chain_id: u64 = 11155111;
+        let domain_separator_sepolia = DomainSeparator::new(chain_id, contract_address);
+        // domain separator is taken from Sepolia deployment at address
         // 0x9008D19f58AAbD9eD0D60971565AA8510560ab41
+        // https://sepolia.etherscan.io/address/0x9008d19f58aabd9ed0d60971565aa8510560ab41#readContract#F2
         let expected_domain_separator = DomainSeparator(hex!(
-            "fb378b35457022ecc5709ae5dafad9393c1387ae6d8ce24913a0c969074c07fb"
+            "daee378bd0eb30ddf479272accf91761e697bc00e067a268f95f1d2732ed230b"
         ));
-        assert_eq!(domain_separator_goerli, expected_domain_separator);
+        assert_eq!(domain_separator_sepolia, expected_domain_separator);
     }
 
     #[test]

--- a/crates/shared/src/bad_token/token_owner_finder/blockscout.rs
+++ b/crates/shared/src/bad_token/token_owner_finder/blockscout.rs
@@ -21,6 +21,7 @@ impl BlockscoutTokenOwnerFinder {
             1 => "https://eth.blockscout.com/api",
             5 => "https://eth-goerli.blockscout.com/api",
             100 => "https://blockscout.com/xdai/mainnet/api",
+            11155111 => "https://eth-sepolia.blockscout.com/api",
             _ => bail!("Unsupported Network"),
         };
 

--- a/crates/shared/src/network.rs
+++ b/crates/shared/src/network.rs
@@ -21,6 +21,7 @@ pub fn block_interval(network_id: &str, chain_id: u64) -> Option<Duration> {
         ("1", 1) => 12,
         ("5", 5) => 12,
         ("100", 100) => 5,
+        ("11155111", 11155111) => 12,
         _ => return None,
     }))
 }

--- a/crates/shared/src/price_estimation/native.rs
+++ b/crates/shared/src/price_estimation/native.rs
@@ -14,7 +14,7 @@ pub type NativePriceEstimateResult = Result<f64, PriceEstimationError>;
 
 pub fn default_amount_to_estimate_native_prices_with(chain_id: u64) -> Option<U256> {
     match chain_id {
-        // Mainnet, Göŕli
+        // Mainnet, Göŕli, Sepolia
         1 | 5 | 11155111 => Some(10u128.pow(18).into()),
         // Gnosis chain
         100 => Some(10u128.pow(21).into()),

--- a/crates/shared/src/price_estimation/native.rs
+++ b/crates/shared/src/price_estimation/native.rs
@@ -15,7 +15,7 @@ pub type NativePriceEstimateResult = Result<f64, PriceEstimationError>;
 pub fn default_amount_to_estimate_native_prices_with(chain_id: u64) -> Option<U256> {
     match chain_id {
         // Mainnet, Göŕli
-        1 | 5 => Some(10u128.pow(18).into()),
+        1 | 5 | 11155111 => Some(10u128.pow(18).into()),
         // Gnosis chain
         100 => Some(10u128.pow(21).into()),
         _ => None,

--- a/crates/shared/src/sources.rs
+++ b/crates/shared/src/sources.rs
@@ -26,6 +26,7 @@ pub enum BaselineSource {
     Swapr,
     ZeroEx,
     UniswapV3,
+    TestnetUniswapV2,
 }
 
 pub fn defaults_for_chain(chain_id: u64) -> Result<Vec<BaselineSource>> {
@@ -38,11 +39,6 @@ pub fn defaults_for_chain(chain_id: u64) -> Result<Vec<BaselineSource>> {
             BaselineSource::ZeroEx,
             BaselineSource::UniswapV3,
         ],
-        4 => vec![
-            BaselineSource::UniswapV2,
-            BaselineSource::SushiSwap,
-            BaselineSource::BalancerV2,
-        ],
         5 => vec![
             BaselineSource::UniswapV2,
             BaselineSource::SushiSwap,
@@ -54,6 +50,7 @@ pub fn defaults_for_chain(chain_id: u64) -> Result<Vec<BaselineSource>> {
             BaselineSource::Baoswap,
             BaselineSource::Swapr,
         ],
+        11155111 => vec![BaselineSource::TestnetUniswapV2],
         _ => bail!("unsupported chain {:#x}", chain_id),
     })
 }

--- a/crates/shared/src/sources/balancer_v2/pool_fetching.rs
+++ b/crates/shared/src/sources/balancer_v2/pool_fetching.rs
@@ -206,6 +206,12 @@ impl BalancerFactoryKind {
                 Self::ComposableStableV4,
                 Self::ComposableStableV5,
             ],
+            11155111 => vec![
+                Self::WeightedV4,
+                Self::ComposableStableV4,
+                Self::ComposableStableV5,
+                Self::NoProtocolFeeLiquidityBootstrapping,
+            ],
             _ => Default::default(),
         }
     }

--- a/crates/solver/src/settlement_submission/submitter.rs
+++ b/crates/solver/src/settlement_submission/submitter.rs
@@ -63,7 +63,7 @@ pub struct SubmitterParams {
     pub deadline: Option<Instant>,
     /// Re-simulate and resend transaction on every retry_interval seconds
     pub retry_interval: Duration,
-    /// Network id (mainnet, rinkeby, goerli, gnosis chain)
+    /// Network id (mainnet, goerli, sepolia, gnosis chain)
     pub network_id: String,
     /// Additional bytes to append to the call data. This is required by the
     /// `driver`.

--- a/crates/solvers/src/domain/eth/chain.rs
+++ b/crates/solvers/src/domain/eth/chain.rs
@@ -6,6 +6,7 @@ pub enum ChainId {
     Mainnet = 1,
     Goerli = 5,
     Gnosis = 100,
+    Sepolia = 11155111,
 }
 
 impl ChainId {
@@ -21,6 +22,7 @@ impl ChainId {
             1 => Ok(Self::Mainnet),
             5 => Ok(Self::Goerli),
             100 => Ok(Self::Gnosis),
+            11155111 => Ok(Self::Sepolia),
             _ => Err(UnsupportedChain),
         }
     }
@@ -31,6 +33,7 @@ impl ChainId {
             ChainId::Mainnet => "1",
             ChainId::Goerli => "5",
             ChainId::Gnosis => "100",
+            ChainId::Sepolia => "11155111",
         }
     }
 


### PR DESCRIPTION
# Description

This PR provides everything needed for making the services work on Sepolia. This almost exclusively means populating the contract crate with relevant addresses on Sepolia and directly related changes.

The main problem with Sepolia is the lack of liquidity, even compared to Görli. The only liquidity source we have available is a third-party Uniswap v2 deployment where I deployed some liquidity myself.
We also have Balancer, but I need to sort things out with the subgraph URL (see [2139](https://github.com/cowprotocol/services/pull/2139)) so this will happen in a later PR.

# Changes

- New contract addresses for Sepolia.
- New Uniswapv2-like liquidity source on Sepolia (`TestnetUniswapV2`) and related ignored test. Router, factory and pair are exactly the same as on vanilla mainnet except for two things:
  - The Sepolia factory has an extra line `bytes32 public constant INIT_CODE_HASH = keccak256(abi.encodePacked(type(UniswapV2Pair).creationCode));`.
  - the [compilation metadata](https://docs.soliditylang.org/en/v0.8.23/metadata.html#encoding-of-the-metadata-hash-in-the-bytecode) is different, which in turn causes the init hash to be different, but this has no impact on the actual functionality of the contract.
- Removed `SolverTrampoline`. It was introduced [here](https://github.com/cowprotocol/services/commit/704fb32e208f130b8adda3626872b1549f1225c0) for [this feature](https://github.com/cowprotocol/services/commit/8b875ed77eb6777f83fdd1e5d5e38de469490718) but it wasn't removed when that feature was removed [here](https://github.com/cowprotocol/services/commit/2ec435c39ea3df2c658128f22e8b1d621edb25d6).
- New comment on how to compute the init code hash of an unknown Uniswapv2 deployment.
- Removed broken Uniswapv2 address on Gnosis Chain (this is address `0x1b02da8cb0d097eb8d57a175b88c7d8b47997506`, which is actually the _Sushiswap_ address and since the init code hash is different it wouldn't be working if enabled).
- Update domain separator test to use new deployment on Sepolia.

## Not included

- Update API urls to include Sepolia (will do that once the API is available).
- Balancer support (because of the subgraph issue).
- Univ3 liquidity (available but I didn't find a subgraph we can trust and I'm unsure what happens if we use an unreliable subgraph).

## How to test

Try to run the entire setup locally. I tried with autopilot, orderbook, baseline solver and driver in colocation mode. [Here](https://sepolia.etherscan.io/tx/0x545bc8df347f2859a45b5e3d869b39c8eea7b9a08be30e7d91a0508152774821) is an executed settlement.

<details><summary>Here is what I did.</summary>


Create the following files.

<details><summary>./sepolia-addressbook-orderbook.env</summary>

```
export NODE_URL='https://ethereum-sepolia.publicnode.com'
export NATIVE_PRICE_ESTIMATORS='Baseline'
export GAS_ESTIMATORS=native
weth_balancer='0x7b79995e5f793a07bc00c21412e50ecae098e7f9'
weth_uniswap='0xfFf9976782d46CC05630D1f6eBAb18b2324d6B14'
export BASE_TOKENS="$weth_uniswap"
export BASELINE_SOURCES='TestnetUniswapV2'
export CHAIN_ID=11155111
export AMOUNT_TO_ESTIMATE_PRICES_WITH=100000000000000000
export ETHFLOW_CONTRACT='0x2671994c7D224ac4799ac2cf6Ef9EF187d42C69f'
export ETHFLOW_INDEXING_START='4718695'
export DRIVERS='baseline|http://127.0.0.1:12345/baseline/'
export ENABLE_COLOCATION=true
```
</details>


<details><summary>./sepolia-baseline-solver-engine.toml</summary>

```
base-tokens = ['0xfFf9976782d46CC05630D1f6eBAb18b2324d6B14']
chain-id = '11155111'
max-hops = 1
max-partial-attempts = 5
risk-parameters = [0, 0, 0, 30]
```
</details>

<details><summary>./sepolia-driver.toml (but you need to add a valid solver secret key here, search in 1password for "Sepolia test solver PK")</summary>

```
[contracts]

[liquidity]
base-tokens = ['0xfFf9976782d46CC05630D1f6eBAb18b2324d6B14']

[[liquidity.uniswap-v2]]
preset = 'testnet-uniswap-v2'

[[solver]]
account = '0x77927c2c3E6977badeAB8bd1d74051d1fEB36f88' # replace address with the actual secret key!
endpoint = 'http://127.0.0.2:23456'
name = 'baseline'
relative-slippage = '0.01'

[submission]
additional-tip-percentage = 0.05
gas-price-cap = 1000000000000.0
max-confirm-time-secs = 120

[[submission.mempool]]
mempool = 'public'
revert-protection = false
```
</details>

Run the following commands (each group in different terminals).

```sh
docker-compose up --build db migrations
```
(You can clear everything with with `docker-compose down --remove-orphans --volumes`.)

```sh
cargo run --bin solvers -- --addr 127.0.0.2:23456 baseline --config ./sepolia-baseline-solver-engine.toml
```

```sh
cargo run --bin driver -- --config ./sepolia-driver.toml --addr '127.0.0.1:12345' --ethrpc 'https://ethereum-sepolia.publicnode.com'
```

```sh
source sepolia-autopilot-orderbook.env  && cargo run --bin orderbook
```

```sh
source sepolia-autopilot-orderbook.env  && cargo run --bin autopilot
```

To create a new order I used the code [here](https://github.com/cowprotocol/contracts/tree/test-sepolia-order). Install and run `export PK=<your own pk>; bash order.sh` after getting a few WETH (at least 2, find them in the team test fund safe [here](https://app.safe.global/transactions/queue?safe=sep:0x01B94B667236a7896aC85D5bccdF23f26b10e6Cc)) and approving the vault relayer.

</details>