### PR TITLE
Revert "Enums camel case serialization (#2056)"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,4 @@
 
 /target
 /.vscode
-/.idea
 **/testing.*.toml

--- a/crates/autopilot/src/driver_model.rs
+++ b/crates/autopilot/src/driver_model.rs
@@ -23,7 +23,7 @@ pub mod quote {
     }
 
     #[derive(Clone, Debug, Default, Serialize)]
-    #[serde(rename_all = "camelCase")]
+    #[serde(rename_all = "lowercase")]
     pub enum Kind {
         #[default]
         Buy,
@@ -123,7 +123,7 @@ pub mod solve {
     }
 
     #[derive(Clone, Debug, Serialize, Deserialize)]
-    #[serde(rename_all = "camelCase")]
+    #[serde(rename_all = "lowercase")]
     pub enum Class {
         Market,
         Limit,

--- a/crates/driver/src/infra/api/routes/quote/dto/order.rs
+++ b/crates/driver/src/infra/api/routes/quote/dto/order.rs
@@ -36,7 +36,7 @@ pub struct Order {
 }
 
 #[derive(Debug, Deserialize)]
-#[serde(rename_all = "camelCase", deny_unknown_fields)]
+#[serde(rename_all = "lowercase", deny_unknown_fields)]
 enum Kind {
     Sell,
     Buy,

--- a/crates/driver/src/infra/api/routes/solve/dto/auction.rs
+++ b/crates/driver/src/infra/api/routes/solve/dto/auction.rs
@@ -254,7 +254,7 @@ struct Order {
 }
 
 #[derive(Debug, Deserialize)]
-#[serde(rename_all = "camelCase", deny_unknown_fields)]
+#[serde(rename_all = "lowercase", deny_unknown_fields)]
 enum Kind {
     Sell,
     Buy,
@@ -272,7 +272,7 @@ struct Interaction {
 }
 
 #[derive(Debug, Default, Deserialize)]
-#[serde(rename_all = "camelCase", deny_unknown_fields)]
+#[serde(rename_all = "lowercase", deny_unknown_fields)]
 enum SellTokenBalance {
     #[default]
     Erc20,
@@ -281,7 +281,7 @@ enum SellTokenBalance {
 }
 
 #[derive(Debug, Default, Deserialize)]
-#[serde(rename_all = "camelCase", deny_unknown_fields)]
+#[serde(rename_all = "lowercase", deny_unknown_fields)]
 enum BuyTokenBalance {
     #[default]
     Erc20,
@@ -289,7 +289,7 @@ enum BuyTokenBalance {
 }
 
 #[derive(Debug, Deserialize)]
-#[serde(rename_all = "camelCase", deny_unknown_fields)]
+#[serde(rename_all = "lowercase", deny_unknown_fields)]
 enum SigningScheme {
     Eip712,
     EthSign,
@@ -298,7 +298,7 @@ enum SigningScheme {
 }
 
 #[derive(Debug, Deserialize)]
-#[serde(rename_all = "camelCase", deny_unknown_fields)]
+#[serde(rename_all = "lowercase", deny_unknown_fields)]
 enum Class {
     Market,
     Limit,

--- a/crates/driver/src/infra/solver/dto/auction.rs
+++ b/crates/driver/src/infra/solver/dto/auction.rs
@@ -238,14 +238,14 @@ struct Order {
 }
 
 #[derive(Debug, Serialize)]
-#[serde(rename_all = "camelCase")]
+#[serde(rename_all = "lowercase")]
 enum Kind {
     Sell,
     Buy,
 }
 
 #[derive(Debug, Serialize)]
-#[serde(rename_all = "camelCase")]
+#[serde(rename_all = "lowercase")]
 enum Class {
     Market,
     Limit,
@@ -268,7 +268,7 @@ struct Token {
 // TODO Remove dead_code
 #[allow(dead_code, clippy::enum_variant_names)]
 #[derive(Debug, Serialize)]
-#[serde(tag = "kind", rename_all = "camelCase")]
+#[serde(tag = "kind", rename_all = "lowercase")]
 enum Liquidity {
     ConstantProduct(ConstantProductPool),
     WeightedProduct(WeightedProductPool),
@@ -326,7 +326,7 @@ struct WeightedProductReserve {
 }
 
 #[derive(Debug, Serialize)]
-#[serde(rename_all = "camelCase")]
+#[serde(rename_all = "lowercase")]
 enum WeightedProductVersion {
     V0,
     V3Plus,

--- a/crates/driver/src/infra/solver/dto/notification.rs
+++ b/crates/driver/src/infra/solver/dto/notification.rs
@@ -95,7 +95,7 @@ pub struct Notification {
 
 #[serde_as]
 #[derive(Debug, Serialize)]
-#[serde(rename_all = "camelCase")]
+#[serde(rename_all = "lowercase")]
 pub enum Kind {
     Timeout,
     EmptySolution,
@@ -129,7 +129,7 @@ pub struct Tx {
 
 #[serde_as]
 #[derive(Debug, Serialize)]
-#[serde(rename_all = "camelCase")]
+#[serde(rename_all = "lowercase")]
 pub enum ScoreKind {
     ZeroScore,
     ScoreHigherThanQuality {
@@ -152,7 +152,7 @@ pub enum ScoreKind {
 
 #[serde_as]
 #[derive(Debug, Serialize)]
-#[serde(rename_all = "camelCase")]
+#[serde(rename_all = "lowercase")]
 pub enum Settlement {
     Success { transaction: eth::H256 },
     Revert { transaction: eth::H256 },

--- a/crates/driver/src/infra/solver/dto/solution.rs
+++ b/crates/driver/src/infra/solver/dto/solution.rs
@@ -234,7 +234,7 @@ pub struct Solution {
 }
 
 #[derive(Debug, Deserialize)]
-#[serde(tag = "kind", rename_all = "camelCase", deny_unknown_fields)]
+#[serde(tag = "kind", rename_all = "lowercase", deny_unknown_fields)]
 enum Trade {
     Fulfillment(Fulfillment),
     Jit(JitTrade),
@@ -287,14 +287,14 @@ struct JitOrder {
 }
 
 #[derive(Debug, Deserialize)]
-#[serde(rename_all = "camelCase", deny_unknown_fields)]
+#[serde(rename_all = "lowercase", deny_unknown_fields)]
 enum Kind {
     Sell,
     Buy,
 }
 
 #[derive(Debug, Deserialize)]
-#[serde(tag = "kind", rename_all = "camelCase", deny_unknown_fields)]
+#[serde(tag = "kind", rename_all = "lowercase", deny_unknown_fields)]
 enum Interaction {
     Liquidity(LiquidityInteraction),
     Custom(CustomInteraction),
@@ -350,7 +350,7 @@ struct Allowance {
 }
 
 #[derive(Debug, Default, Deserialize)]
-#[serde(rename_all = "camelCase", deny_unknown_fields)]
+#[serde(rename_all = "lowercase", deny_unknown_fields)]
 enum SellTokenBalance {
     #[default]
     Erc20,
@@ -359,7 +359,7 @@ enum SellTokenBalance {
 }
 
 #[derive(Debug, Default, Deserialize)]
-#[serde(rename_all = "camelCase", deny_unknown_fields)]
+#[serde(rename_all = "lowercase", deny_unknown_fields)]
 enum BuyTokenBalance {
     #[default]
     Erc20,
@@ -367,7 +367,7 @@ enum BuyTokenBalance {
 }
 
 #[derive(Debug, Deserialize)]
-#[serde(rename_all = "camelCase", deny_unknown_fields)]
+#[serde(rename_all = "lowercase", deny_unknown_fields)]
 enum SigningScheme {
     Eip712,
     EthSign,
@@ -377,7 +377,7 @@ enum SigningScheme {
 
 #[serde_as]
 #[derive(Debug, Deserialize)]
-#[serde(rename_all = "camelCase", deny_unknown_fields)]
+#[serde(rename_all = "lowercase", deny_unknown_fields)]
 pub enum Score {
     Solver {
         #[serde_as(as = "serialize::U256")]

--- a/crates/driver/src/tests/setup/mod.rs
+++ b/crates/driver/src/tests/setup/mod.rs
@@ -1,4 +1,4 @@
-//! Framework for setting up tests .
+//! Framework for setting up tests.
 
 use {
     self::{blockchain::Fulfillment, driver::Driver, solver::Solver},
@@ -56,7 +56,7 @@ pub enum Partial {
 
 #[serde_as]
 #[derive(Debug, Clone, serde::Serialize)]
-#[serde(rename_all = "camelCase")]
+#[serde(rename_all = "lowercase")]
 pub enum Score {
     Solver {
         #[serde_as(as = "serialize::U256")]

--- a/crates/solvers/openapi.yml
+++ b/crates/solvers/openapi.yml
@@ -243,7 +243,7 @@ components:
       properties:
         kind:
           type: string
-          enum: [constantProduct]
+          enum: [constantproduct]
         tokens:
           description: |
             A mapping of token address to its reserve amounts.
@@ -264,7 +264,7 @@ components:
       properties:
         kind:
           type: string
-          enum: [weightedProduct]
+          enum: [weightedproduct]
         tokens:
           description: |
             A mapping of token address to its reserve amounts with weights.
@@ -329,7 +329,7 @@ components:
       properties:
         kind:
           type: string
-          enum: [concentratedLiquidity]
+          enum: [concentratedliquidity]
         tokens:
           type: array
           items:
@@ -364,7 +364,7 @@ components:
       properties:
         kind:
           type: string
-          enum: [limitOrder]
+          enum: [limitorder]
         hash:
           $ref: "#/components/schemas/Digest"
         makerToken:

--- a/crates/solvers/src/api/routes/notify/dto/notification.rs
+++ b/crates/solvers/src/api/routes/notify/dto/notification.rs
@@ -105,7 +105,7 @@ pub struct Notification {
 
 #[serde_as]
 #[derive(Debug, Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[serde(rename_all = "lowercase")]
 pub enum Kind {
     Timeout,
     EmptySolution,
@@ -139,7 +139,7 @@ pub struct Tx {
 
 #[serde_as]
 #[derive(Debug, Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[serde(rename_all = "lowercase")]
 pub enum ScoreKind {
     ZeroScore,
     ScoreHigherThanQuality {
@@ -162,7 +162,7 @@ pub enum ScoreKind {
 
 #[serde_as]
 #[derive(Debug, Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[serde(rename_all = "lowercase")]
 pub enum Settlement {
     Success { transaction: H256 },
     Revert { transaction: H256 },

--- a/crates/solvers/src/api/routes/solve/dto/auction.rs
+++ b/crates/solvers/src/api/routes/solve/dto/auction.rs
@@ -117,14 +117,14 @@ struct Order {
 }
 
 #[derive(Debug, Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[serde(rename_all = "lowercase")]
 enum Kind {
     Sell,
     Buy,
 }
 
 #[derive(Debug, Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[serde(rename_all = "lowercase")]
 enum Class {
     Market,
     Limit,
@@ -146,7 +146,7 @@ struct Token {
 
 #[allow(clippy::enum_variant_names)]
 #[derive(Debug, Deserialize)]
-#[serde(tag = "kind", rename_all = "camelCase", deny_unknown_fields)]
+#[serde(tag = "kind", rename_all = "lowercase", deny_unknown_fields)]
 enum Liquidity {
     ConstantProduct(ConstantProductPool),
     WeightedProduct(WeightedProductPool),
@@ -227,7 +227,7 @@ struct WeightedProductReserve {
 }
 
 #[derive(Debug, Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[serde(rename_all = "lowercase")]
 enum WeightedProductVersion {
     V0,
     V3Plus,

--- a/crates/solvers/src/api/routes/solve/dto/solution.rs
+++ b/crates/solvers/src/api/routes/solve/dto/solution.rs
@@ -161,7 +161,7 @@ struct Solution {
 }
 
 #[derive(Debug, Serialize)]
-#[serde(tag = "kind", rename_all = "camelCase")]
+#[serde(tag = "kind", rename_all = "lowercase")]
 enum Trade {
     Fulfillment(Fulfillment),
     Jit(JitTrade),
@@ -216,14 +216,14 @@ struct JitOrder {
 }
 
 #[derive(Debug, Serialize)]
-#[serde(rename_all = "camelCase")]
+#[serde(rename_all = "lowercase")]
 enum Kind {
     Sell,
     Buy,
 }
 
 #[derive(Debug, Serialize)]
-#[serde(tag = "kind", rename_all = "camelCase")]
+#[serde(tag = "kind", rename_all = "lowercase")]
 enum Interaction {
     Liquidity(LiquidityInteraction),
     Custom(CustomInteraction),
@@ -293,7 +293,7 @@ struct Allowance {
 }
 
 #[derive(Debug, Default, Serialize)]
-#[serde(rename_all = "camelCase")]
+#[serde(rename_all = "lowercase")]
 enum SellTokenBalance {
     #[default]
     Erc20,
@@ -302,7 +302,7 @@ enum SellTokenBalance {
 }
 
 #[derive(Debug, Default, Serialize)]
-#[serde(rename_all = "camelCase")]
+#[serde(rename_all = "lowercase")]
 enum BuyTokenBalance {
     #[default]
     Erc20,
@@ -310,7 +310,7 @@ enum BuyTokenBalance {
 }
 
 #[derive(Debug, Serialize)]
-#[serde(rename_all = "camelCase")]
+#[serde(rename_all = "lowercase")]
 enum SigningScheme {
     Eip712,
     EthSign,
@@ -321,7 +321,7 @@ enum SigningScheme {
 /// A score for a solution. The score is used to rank solutions.
 #[serde_as]
 #[derive(Debug, Serialize)]
-#[serde(rename_all = "camelCase")]
+#[serde(rename_all = "lowercase")]
 pub enum Score {
     Solver {
         #[serde_as(as = "serialize::U256")]

--- a/crates/solvers/src/infra/dex/balancer/dto.rs
+++ b/crates/solvers/src/infra/dex/balancer/dto.rs
@@ -9,7 +9,7 @@ use {
 };
 
 #[derive(Debug, Serialize)]
-#[serde(rename_all = "camelCase")]
+#[serde(rename_all = "lowercase")]
 pub enum OrderKind {
     Sell,
     Buy,

--- a/crates/solvers/src/tests/balancer/market_order.rs
+++ b/crates/solvers/src/tests/balancer/market_order.rs
@@ -156,7 +156,7 @@ async fn sell() {
                     }
                 ],
                 "score": {
-                    "riskAdjusted": 0.5
+                    "riskadjusted": 0.5
                 }
             }]
         }),
@@ -313,7 +313,7 @@ async fn buy() {
                     }
                 ],
                 "score": {
-                    "riskAdjusted": 0.5
+                    "riskadjusted": 0.5
                 }
             }]
         }),

--- a/crates/solvers/src/tests/baseline/bal_liquidity.rs
+++ b/crates/solvers/src/tests/baseline/bal_liquidity.rs
@@ -62,7 +62,7 @@ async fn weighted() {
             ],
             "liquidity": [
                 {
-                    "kind": "weightedProduct",
+                    "kind": "weightedproduct",
                     "tokens": {
                         "0x6810e776880c02933d47db1b9fc05908e5386b96": {
                             "balance": "11260752191375725565253",
@@ -117,7 +117,7 @@ async fn weighted() {
                     },
                 ],
                 "score": {
-                    "riskAdjusted": 0.5
+                    "riskadjusted": 0.5
                 }
             }]
         }),
@@ -177,7 +177,7 @@ async fn weighted_v3plus() {
             ],
             "liquidity": [
                 {
-                    "kind": "weightedProduct",
+                    "kind": "weightedproduct",
                     "tokens": {
                         "0x177127622c4a00f3d409b75571e12cb3c8973d3c": {
                             "balance": "5089632258314443812936111",
@@ -194,7 +194,7 @@ async fn weighted_v3plus() {
                     "id": "0",
                     "address": "0x21d4c792ea7e38e0d0819c2011a2b1cb7252bd99",
                     "gasEstimate": "88892",
-                    "version": "v3Plus",
+                    "version": "v3plus",
                 },
             ],
             "effectiveGasPrice": "1000000000",
@@ -232,7 +232,7 @@ async fn weighted_v3plus() {
                     },
                 ],
                 "score": {
-                    "riskAdjusted": 0.5
+                    "riskadjusted": 0.5
                 }
             }]
         }),
@@ -370,7 +370,7 @@ async fn stable() {
                         },
                     ],
                     "score": {
-                        "riskAdjusted": 0.5
+                        "riskadjusted": 0.5
                     }
                 },
                 {
@@ -400,7 +400,7 @@ async fn stable() {
                         },
                     ],
                     "score": {
-                        "riskAdjusted": 0.5
+                        "riskadjusted": 0.5
                     }
                 },
             ]
@@ -533,7 +533,7 @@ async fn composable_stable_v4() {
                         },
                     ],
                     "score": {
-                        "riskAdjusted": 0.5
+                        "riskadjusted": 0.5
                     }
                 },
             ]

--- a/crates/solvers/src/tests/baseline/buy_order_rounding.rs
+++ b/crates/solvers/src/tests/baseline/buy_order_rounding.rs
@@ -47,7 +47,7 @@ async fn uniswap() {
             ],
             "liquidity": [
                 {
-                    "kind": "constantProduct",
+                    "kind": "constantproduct",
                     "tokens": {
                         "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48": {
                             "balance": "30493445841295"
@@ -101,7 +101,7 @@ async fn uniswap() {
                     }
                 ],
                 "score": {
-                    "riskAdjusted": 0.5
+                    "riskadjusted": 0.5
                 }
             }]
         }),
@@ -169,7 +169,7 @@ async fn balancer_weighted() {
             "liquidity": [
                 // A xCOW -> xGNO -> wxDAI path with a good price.
                 {
-                    "kind": "constantProduct",
+                    "kind": "constantproduct",
                     "tokens": {
                         "0x9c58bacc331c9aa871afd802db6379a98e80cedb": {
                             "balance": "9661963829146095661"
@@ -184,7 +184,7 @@ async fn balancer_weighted() {
                     "gasEstimate": "90171"
                 },
                 {
-                    "kind": "weightedProduct",
+                    "kind": "weightedproduct",
                     "tokens": {
                         "0x177127622c4a00f3d409b75571e12cb3c8973d3c": {
                             "balance": "1963528800698237927834721",
@@ -205,7 +205,7 @@ async fn balancer_weighted() {
                 },
                 // A fake xCOW -> wxDAI path with a BAD price.
                 {
-                    "kind": "constantProduct",
+                    "kind": "constantproduct",
                     "tokens": {
                         "0x177127622c4a00f3d409b75571e12cb3c8973d3c": {
                             "balance": "1000000000000000000000000000"
@@ -266,7 +266,7 @@ async fn balancer_weighted() {
                     },
                 ],
                 "score": {
-                    "riskAdjusted": 0.5
+                    "riskadjusted": 0.5
                 }
             }]
         }),
@@ -326,7 +326,7 @@ async fn balancer_weighted_v3plus() {
             ],
             "liquidity": [
                 {
-                    "kind": "weightedProduct",
+                    "kind": "weightedproduct",
                     "tokens": {
                         "0x177127622c4a00f3d409b75571e12cb3c8973d3c": {
                             "balance": "18764168403990393422000071",
@@ -343,7 +343,7 @@ async fn balancer_weighted_v3plus() {
                     "id": "0",
                     "address": "0x21d4c792ea7e38e0d0819c2011a2b1cb7252bd99",
                     "gasEstimate": "88892",
-                    "version": "v3Plus",
+                    "version": "v3plus",
                 },
             ],
             "effectiveGasPrice": "1000000000",
@@ -381,7 +381,7 @@ async fn balancer_weighted_v3plus() {
                     },
                 ],
                 "score": {
-                    "riskAdjusted": 0.5
+                    "riskadjusted": 0.5
                 }
             }]
         }),
@@ -441,7 +441,7 @@ async fn distant_convergence() {
             ],
             "liquidity": [
                 {
-                    "kind": "weightedProduct",
+                    "kind": "weightedproduct",
                     "tokens": {
                         "0x177127622c4a00f3d409b75571e12cb3c8973d3c": {
                             "balance": "5089632258314443812936111",
@@ -458,7 +458,7 @@ async fn distant_convergence() {
                     "id": "0",
                     "address": "0x21d4c792ea7e38e0d0819c2011a2b1cb7252bd99",
                     "gasEstimate": "88892",
-                    "version": "v3Plus",
+                    "version": "v3plus",
                 },
             ],
             "effectiveGasPrice": "1000000000",
@@ -496,7 +496,7 @@ async fn distant_convergence() {
                     },
                 ],
                 "score": {
-                    "riskAdjusted": 0.5
+                    "riskadjusted": 0.5
                 }
             }]
         }),
@@ -556,7 +556,7 @@ async fn same_path() {
             ],
             "liquidity": [
                 {
-                    "kind": "weightedProduct",
+                    "kind": "weightedproduct",
                     "tokens": {
                         "0x177127622c4a00f3d409b75571e12cb3c8973d3c": {
                             "balance": "1963528800698237927834721",
@@ -576,7 +576,7 @@ async fn same_path() {
                     "version": "v0",
                 },
                 {
-                    "kind": "constantProduct",
+                    "kind": "constantproduct",
                     "tokens": {
                         "0x177127622c4a00f3d409b75571e12cb3c8973d3c": {
                             "balance": "1000000000000000000000000000"
@@ -646,7 +646,7 @@ async fn same_path() {
                     },
                 ],
                 "score": {
-                    "riskAdjusted": 0.5
+                    "riskadjusted": 0.5
                 }
             }]
         }),
@@ -785,7 +785,7 @@ async fn balancer_stable() {
                         },
                     ],
                     "score": {
-                        "riskAdjusted": 0.5
+                        "riskadjusted": 0.5
                     }
                 },
             ]

--- a/crates/solvers/src/tests/baseline/direct_swap.rs
+++ b/crates/solvers/src/tests/baseline/direct_swap.rs
@@ -47,7 +47,7 @@ async fn test() {
             ],
             "liquidity": [
                 {
-                    "kind": "constantProduct",
+                    "kind": "constantproduct",
                     "tokens": {
                         "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2": {
                             "balance": "3828187314911751990"
@@ -97,7 +97,7 @@ async fn test() {
                     }
                 ],
                 "score": {
-                    "riskAdjusted": 0.5
+                    "riskadjusted": 0.5
                 }
             }]
         }),

--- a/crates/solvers/src/tests/baseline/internalization.rs
+++ b/crates/solvers/src/tests/baseline/internalization.rs
@@ -47,7 +47,7 @@ async fn trusted_token() {
             ],
             "liquidity": [
                 {
-                    "kind": "constantProduct",
+                    "kind": "constantproduct",
                     "tokens": {
                         "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2": {
                             "balance": "3828187314911751990"
@@ -97,7 +97,7 @@ async fn trusted_token() {
                     }
                 ],
                 "score": {
-                    "riskAdjusted": 0.5
+                    "riskadjusted": 0.5
                 }
             }]
         }),
@@ -148,7 +148,7 @@ async fn untrusted_sell_token() {
             ],
             "liquidity": [
                 {
-                    "kind": "constantProduct",
+                    "kind": "constantproduct",
                     "tokens": {
                         "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2": {
                             "balance": "3828187314911751990"
@@ -198,7 +198,7 @@ async fn untrusted_sell_token() {
                     }
                 ],
                 "score": {
-                    "riskAdjusted": 0.5
+                    "riskadjusted": 0.5
                 }
             }]
         }),
@@ -249,7 +249,7 @@ async fn insufficient_balance() {
             ],
             "liquidity": [
                 {
-                    "kind": "constantProduct",
+                    "kind": "constantproduct",
                     "tokens": {
                         "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2": {
                             "balance": "3828187314911751990"
@@ -299,7 +299,7 @@ async fn insufficient_balance() {
                     }
                 ],
                 "score": {
-                    "riskAdjusted": 0.5
+                    "riskadjusted": 0.5
                 }
             }]
         }),

--- a/crates/solvers/src/tests/baseline/partial_fill.rs
+++ b/crates/solvers/src/tests/baseline/partial_fill.rs
@@ -47,7 +47,7 @@ async fn test() {
             ],
             "liquidity": [
                 {
-                    "kind": "constantProduct",
+                    "kind": "constantproduct",
                     "tokens": {
                         "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2": {
                             "balance": "3828187314911751990"
@@ -98,7 +98,7 @@ async fn test() {
                     }
                 ],
                 "score": {
-                    "riskAdjusted": 0.5
+                    "riskadjusted": 0.5
                 }
             }]
         }),

--- a/crates/solvers/src/tests/dex/partial_fill.rs
+++ b/crates/solvers/src/tests/dex/partial_fill.rs
@@ -246,7 +246,7 @@ endpoint = 'http://{}/sor'
                     }
                 ],
                 "score": {
-                    "riskAdjusted": 0.5
+                    "riskadjusted": 0.5
                 }
             }]
         })
@@ -580,7 +580,7 @@ endpoint = 'http://{}/sor'
                     }
                 ],
                 "score": {
-                    "riskAdjusted": 0.5
+                    "riskadjusted": 0.5
                 }
             }]
         })
@@ -847,7 +847,7 @@ async fn market() {
                     }
                 ],
                 "score": {
-                    "riskAdjusted": 0.5
+                    "riskadjusted": 0.5
                 }
             }]
         })

--- a/crates/solvers/src/tests/legacy/attaching_approvals.rs
+++ b/crates/solvers/src/tests/legacy/attaching_approvals.rs
@@ -147,7 +147,7 @@ async fn test() {
                     },
                 ],
                 "score": {
-                    "riskAdjusted": 1.0
+                    "riskadjusted": 1.0
                 }
             }]
         }),

--- a/crates/solvers/src/tests/legacy/concentrated_liquidity.rs
+++ b/crates/solvers/src/tests/legacy/concentrated_liquidity.rs
@@ -97,7 +97,7 @@ async fn test() {
             "orders": [],
             "liquidity": [
                 {
-                    "kind": "concentratedLiquidity",
+                    "kind": "concentratedliquidity",
                     "id": "0",
                     "address": "0x97b744df0b59d93A866304f97431D8EfAd29a08d",
                     "gasEstimate": "110000",
@@ -139,7 +139,7 @@ async fn test() {
                     }
                 ],
                 "score": {
-                    "riskAdjusted": 1.0
+                    "riskadjusted": 1.0
                 }
             }]
         }),

--- a/crates/solvers/src/tests/legacy/jit_order.rs
+++ b/crates/solvers/src/tests/legacy/jit_order.rs
@@ -128,7 +128,7 @@ async fn test() {
                 ],
                 "interactions": [],
                 "score": {
-                    "riskAdjusted": 1.0
+                    "riskadjusted": 1.0
                 }
             }]
         }),

--- a/crates/solvers/src/tests/legacy/market_order.rs
+++ b/crates/solvers/src/tests/legacy/market_order.rs
@@ -155,7 +155,7 @@ async fn quote() {
             ],
             "liquidity": [
                 {
-                    "kind": "constantProduct",
+                    "kind": "constantproduct",
                     "tokens": {
                         "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2": {
                             "balance": "3828187314911751990"
@@ -205,7 +205,7 @@ async fn quote() {
                     }
                 ],
                 "score": {
-                    "riskAdjusted": 1.0
+                    "riskadjusted": 1.0
                 }
             }]
         }),
@@ -360,7 +360,7 @@ async fn solve() {
             ],
             "liquidity": [
                 {
-                    "kind": "constantProduct",
+                    "kind": "constantproduct",
                     "tokens": {
                         "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2": {
                             "balance": "3828187314911751990"
@@ -410,7 +410,7 @@ async fn solve() {
                     }
                 ],
                 "score": {
-                    "riskAdjusted": 1.0
+                    "riskadjusted": 1.0
                 }
             }]
         }),

--- a/crates/solvers/src/tests/naive/extract_deepest_pool.rs
+++ b/crates/solvers/src/tests/naive/extract_deepest_pool.rs
@@ -40,7 +40,7 @@ async fn test() {
             ],
             "liquidity": [
                 {
-                    "kind": "constantProduct",
+                    "kind": "constantproduct",
                     "tokens": {
                         "0x0101010101010101010101010101010101010101": {
                             "balance": "100"
@@ -55,7 +55,7 @@ async fn test() {
                     "gasEstimate": "0"
                 },
                 {
-                    "kind": "constantProduct",
+                    "kind": "constantproduct",
                     "tokens": {
                         "0x0101010101010101010101010101010101010101": {
                             "balance": "10000000"
@@ -70,7 +70,7 @@ async fn test() {
                     "gasEstimate": "0"
                 },
                 {
-                    "kind": "constantProduct",
+                    "kind": "constantproduct",
                     "tokens": {
                         "0x0303030303030303030303030303030303030303": {
                             "balance": "10000000000000000"
@@ -120,7 +120,7 @@ async fn test() {
                     },
                 ],
                 "score": {
-                    "riskAdjusted": 0.5
+                    "riskadjusted": 0.5
                 }
             }]
         }),

--- a/crates/solvers/src/tests/naive/filters_out_of_price_orders.rs
+++ b/crates/solvers/src/tests/naive/filters_out_of_price_orders.rs
@@ -75,7 +75,7 @@ async fn sell_orders_on_both_sides() {
             ],
             "liquidity": [
                 {
-                    "kind": "constantProduct",
+                    "kind": "constantproduct",
                     "tokens": {
                         "0x000000000000000000000000000000000000000a": {
                             "balance": "1000000000000000000000000"
@@ -122,7 +122,7 @@ async fn sell_orders_on_both_sides() {
                 ],
                 "interactions": [],
                 "score": {
-                    "riskAdjusted": 0.5
+                    "riskadjusted": 0.5
                 }
             }]
         }),

--- a/crates/solvers/src/tests/naive/limit_order_price.rs
+++ b/crates/solvers/src/tests/naive/limit_order_price.rs
@@ -32,7 +32,7 @@ async fn test() {
             ],
             "liquidity": [
                 {
-                    "kind": "constantProduct",
+                    "kind": "constantproduct",
                     "tokens": {
                         "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48": {
                             "balance": "36338096110368"

--- a/crates/solvers/src/tests/naive/matches_orders.rs
+++ b/crates/solvers/src/tests/naive/matches_orders.rs
@@ -45,7 +45,7 @@ async fn sell_orders_on_both_sides() {
             ],
             "liquidity": [
                 {
-                    "kind": "constantProduct",
+                    "kind": "constantproduct",
                     "tokens": {
                         "0x000000000000000000000000000000000000000a": {
                             "balance": "1000000000000000000000"
@@ -102,7 +102,7 @@ async fn sell_orders_on_both_sides() {
                     },
                 ],
                 "score": {
-                    "riskAdjusted": 0.5
+                    "riskadjusted": 0.5
                 }
             }]
         }),
@@ -151,7 +151,7 @@ async fn sell_orders_on_one_side() {
             ],
             "liquidity": [
                 {
-                    "kind": "constantProduct",
+                    "kind": "constantproduct",
                     "tokens": {
                         "0x000000000000000000000000000000000000000a": {
                             "balance": "1000000000000000000000000"
@@ -208,7 +208,7 @@ async fn sell_orders_on_one_side() {
                     },
                 ],
                 "score": {
-                    "riskAdjusted": 0.5
+                    "riskadjusted": 0.5
                 }
             }]
         }),
@@ -257,7 +257,7 @@ async fn buy_orders_on_both_sides() {
             ],
             "liquidity": [
                 {
-                    "kind": "constantProduct",
+                    "kind": "constantproduct",
                     "tokens": {
                         "0x000000000000000000000000000000000000000a": {
                             "balance": "1000000000000000000000"
@@ -314,7 +314,7 @@ async fn buy_orders_on_both_sides() {
                     },
                 ],
                 "score": {
-                    "riskAdjusted": 0.5
+                    "riskadjusted": 0.5
                 }
             }]
         }),
@@ -363,7 +363,7 @@ async fn buy_and_sell_orders() {
             ],
             "liquidity": [
                 {
-                    "kind": "constantProduct",
+                    "kind": "constantproduct",
                     "tokens": {
                         "0x000000000000000000000000000000000000000a": {
                             "balance": "1000000000000000000000"
@@ -420,7 +420,7 @@ async fn buy_and_sell_orders() {
                     },
                 ],
                 "score": {
-                    "riskAdjusted": 0.5
+                    "riskadjusted": 0.5
                 }
             }]
         }),

--- a/crates/solvers/src/tests/naive/reserves_too_small.rs
+++ b/crates/solvers/src/tests/naive/reserves_too_small.rs
@@ -45,7 +45,7 @@ async fn test() {
             ],
             "liquidity": [
                 {
-                    "kind": "constantProduct",
+                    "kind": "constantproduct",
                     "tokens": {
                         "0x000000000000000000000000000000000000000a": {
                             "balance": "25000075"
@@ -95,7 +95,7 @@ async fn test() {
                     },
                 ],
                 "score": {
-                    "riskAdjusted": 0.5
+                    "riskadjusted": 0.5
                 }
             }]
         }),

--- a/crates/solvers/src/tests/naive/rounds_prices_in_favour_of_traders.rs
+++ b/crates/solvers/src/tests/naive/rounds_prices_in_favour_of_traders.rs
@@ -52,7 +52,7 @@ async fn test() {
             ],
             "liquidity": [
                 {
-                    "kind": "constantProduct",
+                    "kind": "constantproduct",
                     "tokens": {
                         "0x000000000000000000000000000000000000000a": {
                             "balance": "1000000000000000000"
@@ -109,7 +109,7 @@ async fn test() {
                     },
                 ],
                 "score": {
-                    "riskAdjusted": 0.5
+                    "riskadjusted": 0.5
                 }
             }]
         }),

--- a/crates/solvers/src/tests/naive/swap_less_than_reserves.rs
+++ b/crates/solvers/src/tests/naive/swap_less_than_reserves.rs
@@ -50,7 +50,7 @@ async fn test() {
             ],
             "liquidity": [
                 {
-                    "kind": "constantProduct",
+                    "kind": "constantproduct",
                     "tokens": {
                         "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48": {
                             "balance": "32275540"

--- a/crates/solvers/src/tests/naive/without_pool.rs
+++ b/crates/solvers/src/tests/naive/without_pool.rs
@@ -45,7 +45,7 @@ async fn test() {
             ],
             "liquidity": [
                 {
-                    "kind": "constantProduct",
+                    "kind": "constantproduct",
                     "tokens": {
                         "0x000000000000000000000000000000000000000a": {
                             "balance": "1000001000000000000000000"
@@ -92,7 +92,7 @@ async fn test() {
                 ],
                 "interactions": [],
                 "score": {
-                    "riskAdjusted": 0.5
+                    "riskadjusted": 0.5
                 }
             }]
         }),

--- a/crates/solvers/src/tests/oneinch/market_order.rs
+++ b/crates/solvers/src/tests/oneinch/market_order.rs
@@ -207,7 +207,7 @@ async fn sell() {
                 }
               ],
               "score": {
-                "riskAdjusted": 0.5
+                "riskadjusted": 0.5
               }
             }
           ]

--- a/crates/solvers/src/tests/paraswap/market_order.rs
+++ b/crates/solvers/src/tests/paraswap/market_order.rs
@@ -236,7 +236,7 @@ async fn sell() {
                 }
               ],
               "score": {
-                "riskAdjusted": 0.5
+                "riskadjusted": 0.5
               }
             }
           ]
@@ -490,7 +490,7 @@ async fn buy() {
                 }
               ],
               "score": {
-                "riskAdjusted": 0.5
+                "riskadjusted": 0.5
               }
             }
           ]

--- a/crates/solvers/src/tests/zeroex/market_order.rs
+++ b/crates/solvers/src/tests/zeroex/market_order.rs
@@ -187,7 +187,7 @@ async fn sell() {
                     },
                 ],
                 "score": {
-                    "riskAdjusted": 0.5
+                    "riskadjusted": 0.5
                 }
             }]
         }),
@@ -368,7 +368,7 @@ async fn buy() {
                     },
                 ],
                 "score": {
-                    "riskAdjusted": 0.5
+                    "riskadjusted": 0.5
                 }
             }]
         }),

--- a/crates/solvers/src/tests/zeroex/options.rs
+++ b/crates/solvers/src/tests/zeroex/options.rs
@@ -294,7 +294,7 @@ enable-slippage-protection = true
                     },
                 ],
                 "score": {
-                    "riskAdjusted": 0.5
+                    "riskadjusted": 0.5
                 }
             }]
         }),


### PR DESCRIPTION
This reverts commit a8435334945ff7b2cdcdf21cce6f402ce392452a.

# Description
Looks like we broke staging. I think we might have changed the casing for enums that can come from the DB which still have the old versions.