### PR TITLE
Metrics + logs for single order simulation failures

### DIFF
--- a/crates/solvers/src/domain/dex/mod.rs
+++ b/crates/solvers/src/domain/dex/mod.rs
@@ -115,6 +115,7 @@ impl Swap {
                 Ok(value) => value,
                 Err(err) => {
                     tracing::warn!(?err, "gas simulation failed");
+                    infra::metrics::solve_error("SimulationFailed");
                     return None;
                 }
             }

--- a/crates/solvers/src/infra/dex/simulator.rs
+++ b/crates/solvers/src/infra/dex/simulator.rs
@@ -82,6 +82,7 @@ impl Simulator {
                 },
             ),
         ]);
+        tracing::debug!(?call, "simulate swap gas usage");
 
         let return_data = self
             .web3


### PR DESCRIPTION
# Description
We seem to be getting a lot of simulation errors for some single order solvers (cf. https://production-6de61f.kb.eu-central-1.aws.cloud.es.io/app/r/s/g0A07)

Currently, those are not logged in any metrics (which would allow alerting on those) and we don't log the actual call we are trying to execute

# Changes
- [ ] Record a metric if gas estimation fails
- [ ] Write a log with the calldata of the simulation

## How to test
Run locally
