### PR TITLE
Don't pay additional tip for non revertable transactions

### DIFF
--- a/crates/driver/src/boundary/mempool.rs
+++ b/crates/driver/src/boundary/mempool.rs
@@ -150,11 +150,15 @@ impl Mempool {
             inner: self.gas_price_estimator.as_ref(),
             max_fee_per_gas: max_fee_per_gas.min(self.config.gas_price_cap),
             additional_tip_percentage_of_max_fee: self.config.additional_tip_percentage,
-            max_additional_tip: match self.config.kind {
-                Kind::Public(_) => 0.,
-                Kind::MEVBlocker {
-                    max_additional_tip, ..
-                } => max_additional_tip,
+            max_additional_tip: match (&self.config.kind, settlement.boundary.revertable()) {
+                (
+                    Kind::MEVBlocker {
+                        max_additional_tip, ..
+                    },
+                    true,
+                ) => *max_additional_tip,
+                (Kind::MEVBlocker { .. }, false) => 0.,
+                (Kind::Public(_), _) => 0.,
             },
         };
         let use_soft_cancellations = match self.config.kind {

--- a/crates/driver/src/boundary/settlement.rs
+++ b/crates/driver/src/boundary/settlement.rs
@@ -48,6 +48,7 @@ use {
             AmmOrderExecution,
             LimitOrderExecution,
         },
+        settlement::Revertable,
         settlement_simulation::settle_method_builder,
     },
     std::{collections::HashMap, sync::Arc},
@@ -255,7 +256,7 @@ impl Settlement {
     }
 
     pub fn revertable(&self) -> bool {
-        self.inner.revertable()
+        self.inner.revertable() != Revertable::NoRisk
     }
 }
 

--- a/crates/driver/src/boundary/settlement.rs
+++ b/crates/driver/src/boundary/settlement.rs
@@ -253,6 +253,10 @@ impl Settlement {
             .map(|(&token, &amount)| (token.into(), amount.into()))
             .collect()
     }
+
+    pub fn revertable(&self) -> bool {
+        self.inner.revertable()
+    }
 }
 
 fn to_boundary_order(order: &competition::Order) -> Order {


### PR DESCRIPTION
# Description
We are currently paying a pretty high tip for some [trivial settlements](https://etherscan.io/tx/0x25f2edcb2473120ce0583277af48a1241fc30629649856ebcd34ce23e9b04bbb) that are submitted via the public mempool (since they don't carry revert risk). 
While we do enforce 0 additional tip for public mempool submission, we also submit each trivial transaction via the MEVBlocker mempool strategy, which allows setting a higher tip.

If a transaction is available to a builder with both a high and a low tip, a profit maximizing builder will always chose the high tipping one.

# Changes
- [ ] Also limit the max additional tip at 0 for non revertable settlements that are submitted via the public mempool

## How to test
Not really e2e testable since we cannot cover MEVBlocker behavior, but we should see cheaper settlements for internalized trades in staging