### PR TITLE
Add pkg-config

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -6,4 +6,4 @@ RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
 
 # [Optional] Uncomment this section to install additional OS packages.
 RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
-    && apt-get -y install --no-install-recommends gdb valgrind heaptrack
+    && apt-get -y install --no-install-recommends gdb valgrind heaptrack pkg-config


### PR DESCRIPTION
# Description
This additional package is required to successfully compile the `openssl-sys` crate.