### PR TITLE
Migrate to `humantime`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1643,6 +1643,8 @@ dependencies = [
  "gas-estimation",
  "hex",
  "hex-literal",
+ "humantime",
+ "humantime-serde",
  "hyper",
  "indexmap 2.0.0",
  "itertools 0.11.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -55,6 +55,7 @@ dependencies = [
  "anyhow",
  "chrono",
  "clap",
+ "humantime",
  "model",
  "number",
  "observe",
@@ -251,6 +252,7 @@ dependencies = [
  "gas-estimation",
  "hex",
  "hex-literal",
+ "humantime",
  "itertools 0.11.0",
  "maplit",
  "mockall",
@@ -2371,6 +2373,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4a1e36c821dbe04574f602848a19f742f4fb3c98d40449f11bcad18d6b17421"
 
 [[package]]
+name = "humantime"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
+
+[[package]]
+name = "humantime-serde"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57a3db5ea5923d99402c94e9feb261dc5ee9b4efa158b0315f788cf549cc200c"
+dependencies = [
+ "humantime",
+ "serde",
+]
+
+[[package]]
 name = "hyper"
 version = "0.14.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3121,6 +3139,7 @@ dependencies = [
  "gas-estimation",
  "hex",
  "hex-literal",
+ "humantime",
  "hyper",
  "maplit",
  "mockall",
@@ -3483,6 +3502,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "futures",
+ "humantime",
  "observe",
  "prometheus",
  "prometheus-metric-storage",
@@ -3515,6 +3535,7 @@ dependencies = [
  "ethrpc",
  "futures",
  "gas-estimation",
+ "humantime",
  "lazy_static",
  "model",
  "number",
@@ -4010,6 +4031,7 @@ dependencies = [
  "gas-estimation",
  "hex",
  "hex-literal",
+ "humantime",
  "itertools 0.11.0",
  "lazy_static",
  "maplit",
@@ -4130,6 +4152,7 @@ dependencies = [
  "gas-estimation",
  "hex",
  "hex-literal",
+ "humantime",
  "itertools 0.11.0",
  "jsonrpc-core",
  "lazy_static",
@@ -4174,6 +4197,7 @@ dependencies = [
  "futures",
  "glob",
  "hex",
+ "humantime-serde",
  "hyper",
  "itertools 0.11.0",
  "model",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ futures = "0.3"
 gas-estimation = { git = "https://github.com/cowprotocol/gas-estimation", tag = "v0.7.3", features = ["web3_", "tokio_"] }
 hex = { version = "0.4", default-features = false }
 hex-literal = "0.4"
+humantime = "2.1.0"
 itertools = "0.11"
 lazy_static = "1"
 maplit = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ gas-estimation = { git = "https://github.com/cowprotocol/gas-estimation", tag = 
 hex = { version = "0.4", default-features = false }
 hex-literal = "0.4"
 humantime = "2.1.0"
-humantime-serde = "1.0.0"
+humantime-serde = "1.1.1"
 itertools = "0.11"
 lazy_static = "1"
 maplit = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ gas-estimation = { git = "https://github.com/cowprotocol/gas-estimation", tag = 
 hex = { version = "0.4", default-features = false }
 hex-literal = "0.4"
 humantime = "2.1.0"
+humantime-serde = "1.0.0"
 itertools = "0.11"
 lazy_static = "1"
 maplit = "1"

--- a/crates/alerter/Cargo.toml
+++ b/crates/alerter/Cargo.toml
@@ -9,6 +9,7 @@ license = "MIT OR Apache-2.0"
 anyhow = { workspace = true }
 chrono = { workspace = true }
 clap = { workspace = true }
+humantime = { workspace = true }
 observe = { path = "../observe" }
 model = { path = "../model" }
 number = { path = "../number" }

--- a/crates/alerter/src/lib.rs
+++ b/crates/alerter/src/lib.rs
@@ -329,8 +329,8 @@ struct Arguments {
     #[clap(
         long,
         env,
-        default_value = "30",
-        value_parser = shared::arguments::duration_from_seconds,
+        default_value = "30s",
+        value_parser = humantime::parse_duration,
     )]
     update_interval: Duration,
 
@@ -338,8 +338,8 @@ struct Arguments {
     #[clap(
         long,
         env,
-        default_value = "600",
-        value_parser = shared::arguments::duration_from_seconds,
+        default_value = "10m",
+        value_parser = humantime::parse_duration,
     )]
     time_without_trade: Duration,
 
@@ -347,8 +347,8 @@ struct Arguments {
     #[clap(
         long,
         env,
-        default_value = "180",
-        value_parser = shared::arguments::duration_from_seconds,
+        default_value = "3m",
+        value_parser = humantime::parse_duration,
     )]
     min_order_age: Duration,
 
@@ -356,8 +356,8 @@ struct Arguments {
     #[clap(
         long,
         env,
-        default_value = "1800",
-        value_parser = shared::arguments::duration_from_seconds,
+        default_value = "30m",
+        value_parser = humantime::parse_duration,
     )]
     min_alert_interval: Duration,
 
@@ -374,7 +374,7 @@ struct Arguments {
 
     /// Minimum time between get order requests to the api. Without this the api
     /// can rate limit us.
-    #[clap(long, env, default_value = "0.2", value_parser = shared::arguments::duration_from_seconds)]
+    #[clap(long, env, default_value = "200ms", value_parser = humantime::parse_duration)]
     api_get_order_min_interval: Duration,
 
     #[clap(long, env)]

--- a/crates/autopilot/Cargo.toml
+++ b/crates/autopilot/Cargo.toml
@@ -30,6 +30,7 @@ gas-estimation = { workspace = true }
 observe = { path = "../observe" }
 hex = { workspace = true }
 hex-literal = { workspace = true }
+humantime = { workspace = true }
 itertools = { workspace = true }
 maplit = { workspace = true }
 model = { path = "../model" }

--- a/crates/autopilot/src/arguments.rs
+++ b/crates/autopilot/src/arguments.rs
@@ -69,7 +69,7 @@ pub struct Arguments {
     #[clap(long, env, use_value_delimiter = true)]
     pub unsupported_tokens: Vec<H160>,
 
-    /// The amount of time in seconds a classification of a token into good or
+    /// The amount of time a classification of a token into good or
     /// bad is valid for.
     #[clap(
         long,
@@ -97,7 +97,7 @@ pub struct Arguments {
     #[clap(long, env, default_value = "2")]
     pub native_price_estimation_results_required: NonZeroUsize,
 
-    /// The minimum amount of time in seconds an order has to be valid for.
+    /// The minimum amount of time an order has to be valid for.
     #[clap(
         long,
         env,
@@ -199,7 +199,7 @@ pub struct Arguments {
     #[clap(long, env)]
     pub shadow: Option<Url>,
 
-    /// Time in seconds solvers have to compute a score per auction.
+    /// Time solvers have to compute a score per auction.
     #[clap(
         long,
         env,

--- a/crates/autopilot/src/arguments.rs
+++ b/crates/autopilot/src/arguments.rs
@@ -6,12 +6,7 @@ use {
         http_client,
         price_estimation::{self, NativePriceEstimators},
     },
-    std::{
-        net::SocketAddr,
-        num::{NonZeroUsize, ParseFloatError},
-        str::FromStr,
-        time::Duration,
-    },
+    std::{net::SocketAddr, num::NonZeroUsize, str::FromStr, time::Duration},
     url::Url,
 };
 
@@ -79,8 +74,8 @@ pub struct Arguments {
     #[clap(
         long,
         env,
-        default_value = "600",
-        value_parser = shared::arguments::duration_from_seconds,
+        default_value = "10m",
+        value_parser = humantime::parse_duration,
     )]
     pub token_quality_cache_expiry: Duration,
 
@@ -106,8 +101,8 @@ pub struct Arguments {
     #[clap(
         long,
         env,
-        default_value = "60",
-        value_parser = shared::arguments::duration_from_seconds,
+        default_value = "1m",
+        value_parser = humantime::parse_duration,
     )]
     pub min_order_validity_period: Duration,
 
@@ -120,8 +115,8 @@ pub struct Arguments {
     #[clap(
         long,
         env,
-        default_value = "300",
-        value_parser = shared::arguments::duration_from_seconds,
+        default_value = "5m",
+        value_parser = humantime::parse_duration,
     )]
     pub max_auction_age: Duration,
 
@@ -129,7 +124,7 @@ pub struct Arguments {
     pub limit_order_price_factor: f64,
 
     /// The time between auction updates.
-    #[clap(long, env, default_value = "10", value_parser = shared::arguments::duration_from_seconds)]
+    #[clap(long, env, default_value = "10s", value_parser = humantime::parse_duration)]
     pub auction_update_interval: Duration,
 
     /// Fee scaling factor for objective value. This controls the constant
@@ -153,8 +148,8 @@ pub struct Arguments {
     #[clap(
         long,
         env,
-        default_value = "3600",
-        value_parser = shared::arguments::duration_from_seconds,
+        default_value = "1h",
+        value_parser = humantime::parse_duration,
     )]
     pub trusted_tokens_update_interval: Duration,
 
@@ -188,8 +183,8 @@ pub struct Arguments {
     #[clap(
         long,
         env,
-        default_value = "60",
-        value_parser = shared::arguments::duration_from_seconds,
+        default_value = "1m",
+        value_parser = humantime::parse_duration,
     )]
     pub max_settlement_transaction_wait: Duration,
 
@@ -208,8 +203,8 @@ pub struct Arguments {
     #[clap(
         long,
         env,
-        default_value = "15",
-        value_parser = shared::arguments::duration_from_seconds,
+        default_value = "15s",
+        value_parser = humantime::parse_duration,
     )]
     pub solve_deadline: Duration,
 
@@ -219,12 +214,12 @@ pub struct Arguments {
 
     /// Time interval in days between each cleanup operation of the
     /// `order_events` database table.
-    #[clap(long, env, default_value = "1", value_parser = duration_from_days)]
+    #[clap(long, env, default_value = "1d", value_parser = humantime::parse_duration)]
     pub order_events_cleanup_interval: Duration,
 
     /// Age threshold in days for order events to be eligible for cleanup in the
     /// `order_events` database table.
-    #[clap(long, env, default_value = "30", value_parser = duration_from_days)]
+    #[clap(long, env, default_value = "30d", value_parser = humantime::parse_duration)]
     pub order_events_cleanup_threshold: Duration,
 }
 
@@ -373,9 +368,4 @@ impl FromStr for FeePolicyKind {
             _ => Err(format!("invalid fee policy kind: {}", kind)),
         }
     }
-}
-
-fn duration_from_days(s: &str) -> Result<Duration, ParseFloatError> {
-    let days = s.parse::<f64>()?;
-    Ok(Duration::from_secs_f64(days * 86_400.0))
 }

--- a/crates/autopilot/src/run.rs
+++ b/crates/autopilot/src/run.rs
@@ -287,7 +287,7 @@ pub async fn run(args: Arguments) {
         number_of_entries_to_auto_update: args.pool_cache_lru_size,
         maximum_recent_block_age: args.shared.pool_cache_maximum_recent_block_age,
         max_retries: args.shared.pool_cache_maximum_retries,
-        delay_between_retries: args.shared.pool_cache_delay_between_retries_seconds,
+        delay_between_retries: args.shared.pool_cache_delay_between_retries,
     };
     let pool_fetcher = Arc::new(
         PoolCache::new(
@@ -481,15 +481,15 @@ pub async fn run(args: Arguments) {
         Arc::new(db.clone()),
         order_quoting::Validity {
             eip1271_onchain_quote: chrono::Duration::from_std(
-                args.order_quoting.eip1271_onchain_quote_validity_seconds,
+                args.order_quoting.eip1271_onchain_quote_validity,
             )
             .unwrap(),
             presign_onchain_quote: chrono::Duration::from_std(
-                args.order_quoting.presign_onchain_quote_validity_seconds,
+                args.order_quoting.presign_onchain_quote_validity,
             )
             .unwrap(),
             standard_quote: chrono::Duration::from_std(
-                args.order_quoting.standard_offchain_quote_validity_seconds,
+                args.order_quoting.standard_offchain_quote_validity,
             )
             .unwrap(),
         },

--- a/crates/driver/Cargo.toml
+++ b/crates/driver/Cargo.toml
@@ -25,6 +25,8 @@ ethrpc = { path = "../ethrpc" }
 futures = "0.3"
 hex = "0.4"
 hex-literal = "0.4"
+humantime = { workspace = true }
+humantime-serde = { workspace = true }
 hyper = "0.14"
 lazy_static = { workspace = true }
 indexmap = { version = "2", features = ["serde"] }

--- a/crates/driver/src/boundary/liquidity/mod.rs
+++ b/crates/driver/src/boundary/liquidity/mod.rs
@@ -61,7 +61,7 @@ impl Fetcher {
     /// Creates a new fetcher for the specified configuration.
     pub async fn new(eth: &Ethereum, config: &infra::liquidity::Config) -> Result<Self> {
         let blocks = current_block::Arguments {
-            block_stream_poll_interval_seconds: BLOCK_POLL_INTERVAL,
+            block_stream_poll_interval: BLOCK_POLL_INTERVAL,
         };
 
         let block_stream = blocks.stream(boundary::web3(eth)).await?;

--- a/crates/driver/src/infra/config/file/load.rs
+++ b/crates/driver/src/infra/config/file/load.rs
@@ -6,7 +6,7 @@ use {
     futures::future::join_all,
     lazy_static::lazy_static,
     reqwest::Url,
-    std::{path::Path, time::Duration},
+    std::path::Path,
     tokio::fs,
 };
 
@@ -78,13 +78,8 @@ pub async fn load(network: &blockchain::Network, path: &Path) -> infra::Config {
                 },
                 account,
                 timeouts: solver::Timeouts {
-                    http_delay: chrono::Duration::milliseconds(
-                        config
-                            .timeouts
-                            .http_time_buffer_milliseconds
-                            .try_into()
-                            .unwrap(),
-                    ),
+                    http_delay: chrono::Duration::from_std(config.timeouts.http_time_buffer)
+                        .unwrap(),
                     solving_share_of_deadline: config
                         .timeouts
                         .solving_share_of_deadline
@@ -132,13 +127,11 @@ pub async fn load(network: &blockchain::Network, path: &Path) -> infra::Config {
                     file::UniswapV2Config::Manual {
                         router,
                         pool_code,
-                        missing_pool_cache_time_seconds,
+                        missing_pool_cache_time,
                     } => liquidity::config::UniswapV2 {
                         router: router.into(),
                         pool_code: pool_code.into(),
-                        missing_pool_cache_time: Duration::from_secs(
-                            missing_pool_cache_time_seconds,
-                        ),
+                        missing_pool_cache_time,
                     },
                 })
                 .collect(),
@@ -155,13 +148,11 @@ pub async fn load(network: &blockchain::Network, path: &Path) -> infra::Config {
                     file::SwaprConfig::Manual {
                         router,
                         pool_code,
-                        missing_pool_cache_time_seconds,
+                        missing_pool_cache_time,
                     } => liquidity::config::Swapr {
                         router: router.into(),
                         pool_code: pool_code.into(),
-                        missing_pool_cache_time: Duration::from_secs(
-                            missing_pool_cache_time_seconds,
-                        ),
+                        missing_pool_cache_time,
                     },
                 })
                 .collect(),
@@ -257,15 +248,9 @@ pub async fn load(network: &blockchain::Network, path: &Path) -> infra::Config {
             .map(|mempool| mempool::Config {
                 additional_tip_percentage: config.submission.additional_tip_percentage,
                 gas_price_cap: config.submission.gas_price_cap,
-                target_confirm_time: std::time::Duration::from_secs(
-                    config.submission.target_confirm_time_secs,
-                ),
-                max_confirm_time: std::time::Duration::from_secs(
-                    config.submission.max_confirm_time_secs,
-                ),
-                retry_interval: std::time::Duration::from_secs(
-                    config.submission.retry_interval_secs,
-                ),
+                target_confirm_time: config.submission.target_confirm_time,
+                max_confirm_time: config.submission.max_confirm_time,
+                retry_interval: config.submission.retry_interval,
                 kind: match mempool {
                     file::Mempool::Public => {
                         // If there is no private mempool, revert protection is

--- a/crates/driver/src/infra/config/file/mod.rs
+++ b/crates/driver/src/infra/config/file/mod.rs
@@ -1,14 +1,14 @@
+pub use load::load;
 use {
     crate::{domain::eth, util::serialize},
     reqwest::Url,
     serde::Deserialize,
     serde_with::serde_as,
     solver::solver::Arn,
+    std::time::Duration,
 };
 
 mod load;
-
-pub use load::load;
 
 #[serde_as]
 #[derive(Debug, Deserialize)]
@@ -67,19 +67,19 @@ struct SubmissionConfig {
     gas_price_cap: f64,
 
     /// The target confirmation time for settlement transactions used
-    /// to estimate gas price. Specified in seconds.
-    #[serde(default = "default_target_confirm_time_secs")]
-    target_confirm_time_secs: u64,
+    /// to estimate gas price.
+    #[serde(with = "humantime_serde", default = "default_target_confirm_time")]
+    target_confirm_time: Duration,
 
     /// Amount of time to wait before retrying to submit the tx to
-    /// the ethereum network. Specified in seconds.
-    #[serde(default = "default_retry_interval_secs")]
-    retry_interval_secs: u64,
+    /// the ethereum network.
+    #[serde(with = "humantime_serde", default = "default_retry_interval")]
+    retry_interval: Duration,
 
     /// The maximum time to spend trying to settle a transaction through the
-    /// Ethereum network before giving up. Specified in seconds.
-    #[serde(default = "default_max_confirm_time_secs")]
-    max_confirm_time_secs: u64,
+    /// Ethereum network before giving up.
+    #[serde(with = "humantime_serde", default = "default_max_confirm_time")]
+    max_confirm_time: Duration,
 
     /// The mempools to submit settlement transactions to. Can be the public
     /// mempool of a node or the private MEVBlocker mempool.
@@ -119,16 +119,16 @@ fn default_gas_price_cap() -> f64 {
     1e12
 }
 
-fn default_target_confirm_time_secs() -> u64 {
-    30
+fn default_target_confirm_time() -> Duration {
+    Duration::from_secs(30)
 }
 
-fn default_retry_interval_secs() -> u64 {
-    2
+fn default_retry_interval() -> Duration {
+    Duration::from_secs(2)
 }
 
-fn default_max_confirm_time_secs() -> u64 {
-    120
+fn default_max_confirm_time() -> Duration {
+    Duration::from_secs(120)
 }
 
 /// 3 gwei
@@ -140,8 +140,8 @@ fn default_soft_cancellations_flag() -> bool {
     false
 }
 
-pub fn default_http_time_buffer_milliseconds() -> u64 {
-    500
+pub fn default_http_time_buffer() -> Duration {
+    Duration::from_millis(500)
 }
 
 pub fn default_solving_share_of_deadline() -> f64 {
@@ -196,8 +196,8 @@ enum Account {
 struct Timeouts {
     /// Absolute time allocated from the total auction deadline for
     /// request/response roundtrip between autopilot and driver.
-    #[serde(default = "default_http_time_buffer_milliseconds")]
-    http_time_buffer_milliseconds: u64,
+    #[serde(with = "humantime_serde", default = "default_http_time_buffer")]
+    http_time_buffer: Duration,
 
     /// Maximum time allocated for solver engines to return the solutions back
     /// to the driver, in percentage of total driver deadline (after network
@@ -307,7 +307,8 @@ enum UniswapV2Config {
         /// How long liquidity should not be fetched for a token pair that
         /// didn't return useful liquidity before allowing to fetch it
         /// again.
-        missing_pool_cache_time_seconds: u64,
+        #[serde(with = "humantime_serde")]
+        missing_pool_cache_time: Duration,
     },
 }
 
@@ -339,7 +340,8 @@ enum SwaprConfig {
         /// How long liquidity should not be fetched for a token pair that
         /// didn't return useful liquidity before allowing to fetch it
         /// again.
-        missing_pool_cache_time_seconds: u64,
+        #[serde(with = "humantime_serde")]
+        missing_pool_cache_time: Duration,
     },
 }
 

--- a/crates/driver/src/tests/setup/solver.rs
+++ b/crates/driver/src/tests/setup/solver.rs
@@ -5,10 +5,7 @@ use {
         infra::{
             self,
             blockchain::contracts::Addresses,
-            config::file::{
-                default_http_time_buffer_milliseconds,
-                default_solving_share_of_deadline,
-            },
+            config::file::{default_http_time_buffer, default_solving_share_of_deadline},
             Ethereum,
         },
         tests::hex_address,
@@ -217,9 +214,7 @@ impl Solver {
             gas,
         )
         .await;
-        let http_delay = chrono::Duration::milliseconds(
-            default_http_time_buffer_milliseconds().try_into().unwrap(),
-        );
+        let http_delay = chrono::Duration::from_std(default_http_time_buffer()).unwrap();
         let timeouts = infra::solver::Timeouts {
             http_delay,
             solving_share_of_deadline: default_solving_share_of_deadline().try_into().unwrap(),

--- a/crates/e2e/src/setup/colocation.rs
+++ b/crates/e2e/src/setup/colocation.rs
@@ -78,7 +78,7 @@ graph-api-base-url = "https://api.thegraph.com/subgraphs/name/"
 [[liquidity.uniswap-v2]]
 router = "{:?}"
 pool-code = "{:?}"
-missing-pool-cache-time = 10m
+missing-pool-cache-time = "10m"
 
 [submission]
 gas-price-cap = 1000000000000

--- a/crates/e2e/src/setup/colocation.rs
+++ b/crates/e2e/src/setup/colocation.rs
@@ -78,7 +78,7 @@ graph-api-base-url = "https://api.thegraph.com/subgraphs/name/"
 [[liquidity.uniswap-v2]]
 router = "{:?}"
 pool-code = "{:?}"
-missing-pool-cache-time-seconds = 3600
+missing-pool-cache-time = 10m
 
 [submission]
 gas-price-cap = 1000000000000

--- a/crates/e2e/src/setup/colocation.rs
+++ b/crates/e2e/src/setup/colocation.rs
@@ -78,7 +78,7 @@ graph-api-base-url = "https://api.thegraph.com/subgraphs/name/"
 [[liquidity.uniswap-v2]]
 router = "{:?}"
 pool-code = "{:?}"
-missing-pool-cache-time = "10m"
+missing-pool-cache-time = "1h"
 
 [submission]
 gas-price-cap = 1000000000000

--- a/crates/e2e/src/setup/services.rs
+++ b/crates/e2e/src/setup/services.rs
@@ -53,7 +53,7 @@ impl<'a> Services<'a> {
             "--price-estimators=Baseline|0x0000000000000000000000000000000000000001".to_string(),
             "--native-price-estimators=Baseline".to_string(),
             "--amount-to-estimate-prices-with=1000000000000000000".to_string(),
-            "--block-stream-poll-interval-seconds=1".to_string(),
+            "--block-stream-poll-interval=1s".to_string(),
         ]
         .into_iter()
     }
@@ -61,7 +61,7 @@ impl<'a> Services<'a> {
     fn api_autopilot_solver_arguments(&self) -> impl Iterator<Item = String> {
         [
             "--baseline-sources=None".to_string(),
-            "--network-block-interval=1".to_string(),
+            "--network-block-interval=1s".to_string(),
             "--solver-competition-auth=super_secret_key".to_string(),
             format!(
                 "--custom-univ2-baseline-sources={:?}|{:?}",
@@ -85,10 +85,10 @@ impl<'a> Services<'a> {
     pub fn start_autopilot(&self, extra_args: Vec<String>) {
         let args = [
             "autopilot".to_string(),
-            "--auction-update-interval=1".to_string(),
+            "--auction-update-interval=1s".to_string(),
             format!("--ethflow-contract={:?}", self.contracts.ethflow.address()),
             "--skip-event-sync=true".to_string(),
-            "--solve-deadline=2".to_string(),
+            "--solve-deadline=2s".to_string(),
         ]
         .into_iter()
         .chain(self.api_autopilot_solver_arguments())
@@ -127,7 +127,7 @@ impl<'a> Services<'a> {
         let args = [
             "solver".to_string(),
             format!("--solver-account={}", hex::encode(private_key)),
-            "--settle-interval=1".to_string(),
+            "--settle-interval=1s".to_string(),
             format!("--transaction-submission-nodes={NODE_HOST}"),
             format!("--ethflow-contract={:?}", self.contracts.ethflow.address()),
         ]
@@ -158,7 +158,7 @@ impl<'a> Services<'a> {
             ),
             "--solvers=None".to_string(),
             format!("--solver-account={:#x}", solver_account),
-            "--settle-interval=1".to_string(),
+            "--settle-interval=1s".to_string(),
             format!("--transaction-submission-nodes={NODE_HOST}"),
             format!("--ethflow-contract={:?}", self.contracts.ethflow.address()),
         ]

--- a/crates/orderbook/Cargo.toml
+++ b/crates/orderbook/Cargo.toml
@@ -30,6 +30,7 @@ futures = { workspace = true }
 gas-estimation = { workspace = true }
 hex = { workspace = true }
 hex-literal = { workspace = true }
+humantime = { workspace = true }
 hyper = "0.14"
 maplit = { workspace = true }
 model = { path = "../model" }

--- a/crates/orderbook/src/arguments.rs
+++ b/crates/orderbook/src/arguments.rs
@@ -44,8 +44,8 @@ pub struct Arguments {
     #[clap(
         long,
         env,
-        default_value = "60",
-        value_parser = shared::arguments::duration_from_seconds,
+        default_value = "1m",
+        value_parser = humantime::parse_duration,
     )]
     pub min_order_validity_period: Duration,
 
@@ -55,8 +55,8 @@ pub struct Arguments {
     #[clap(
         long,
         env,
-        default_value = "10800",
-        value_parser = shared::arguments::duration_from_seconds,
+        default_value = "3h",
+        value_parser = humantime::parse_duration,
     )]
     pub max_order_validity_period: Duration,
 
@@ -65,8 +65,8 @@ pub struct Arguments {
     #[clap(
         long,
         env,
-        default_value = "31536000",
-        value_parser = shared::arguments::duration_from_seconds,
+        default_value = "1y",
+        value_parser = humantime::parse_duration,
     )]
     pub max_limit_order_validity_period: Duration,
 
@@ -75,8 +75,8 @@ pub struct Arguments {
     #[clap(
         long,
         env,
-        default_value = "600",
-        value_parser = shared::arguments::duration_from_seconds,
+        default_value = "10m",
+        value_parser = humantime::parse_duration,
     )]
     pub token_quality_cache_expiry: Duration,
 

--- a/crates/orderbook/src/run.rs
+++ b/crates/orderbook/src/run.rs
@@ -269,7 +269,7 @@ pub async fn run(args: Arguments) {
         number_of_entries_to_auto_update: args.pool_cache_lru_size,
         maximum_recent_block_age: args.shared.pool_cache_maximum_recent_block_age,
         max_retries: args.shared.pool_cache_maximum_retries,
-        delay_between_retries: args.shared.pool_cache_delay_between_retries_seconds,
+        delay_between_retries: args.shared.pool_cache_delay_between_retries,
     };
     let pool_fetcher = Arc::new(
         PoolCache::new(
@@ -462,15 +462,15 @@ pub async fn run(args: Arguments) {
             Arc::new(postgres.clone()),
             order_quoting::Validity {
                 eip1271_onchain_quote: chrono::Duration::from_std(
-                    args.order_quoting.eip1271_onchain_quote_validity_seconds,
+                    args.order_quoting.eip1271_onchain_quote_validity,
                 )
                 .unwrap(),
                 presign_onchain_quote: chrono::Duration::from_std(
-                    args.order_quoting.presign_onchain_quote_validity_seconds,
+                    args.order_quoting.presign_onchain_quote_validity,
                 )
                 .unwrap(),
                 standard_quote: chrono::Duration::from_std(
-                    args.order_quoting.standard_offchain_quote_validity_seconds,
+                    args.order_quoting.standard_offchain_quote_validity,
                 )
                 .unwrap(),
             },

--- a/crates/rate-limit/Cargo.toml
+++ b/crates/rate-limit/Cargo.toml
@@ -8,6 +8,7 @@ license = "MIT OR Apache-2.0"
 [dependencies]
 anyhow = { workspace = true }
 futures = { workspace = true }
+humantime = { workspace = true }
 observe = { path = "../observe" }
 prometheus = { workspace = true }
 prometheus-metric-storage = { workspace = true }

--- a/crates/rate-limit/src/lib.rs
+++ b/crates/rate-limit/src/lib.rs
@@ -3,7 +3,6 @@ use {
     std::{
         fmt::{Display, Formatter},
         future::Future,
-        num::ParseFloatError,
         str::FromStr,
         sync::{Arc, Mutex, MutexGuard},
         time::{Duration, Instant},
@@ -71,8 +70,10 @@ impl FromStr for Strategy {
         let back_off_growth_factor: f64 = back_off_growth_factor
             .parse()
             .context("parsing back_off_growth_factor")?;
-        let min_back_off = duration_from_seconds(min_back_off).context("parsing min_back_off")?;
-        let max_back_off = duration_from_seconds(max_back_off).context("parsing max_back_off")?;
+        let min_back_off =
+            humantime::parse_duration(min_back_off).context("parsing min_back_off")?;
+        let max_back_off =
+            humantime::parse_duration(max_back_off).context("parsing max_back_off")?;
         Self::try_new(back_off_growth_factor, min_back_off, max_back_off)
     }
 }
@@ -279,10 +280,6 @@ pub mod back_off {
     pub fn on_http_429(response: &Result<Response, reqwest::Error>) -> bool {
         matches!(response, Ok(response) if response.status() == 429)
     }
-}
-
-fn duration_from_seconds(s: &str) -> Result<Duration, ParseFloatError> {
-    Ok(Duration::from_secs_f64(s.parse()?))
 }
 
 #[cfg(test)]

--- a/crates/refunder/Cargo.toml
+++ b/crates/refunder/Cargo.toml
@@ -16,6 +16,7 @@ ethcontract = { workspace = true }
 ethrpc = { path = "../ethrpc" }
 futures = {workspace = true}
 gas-estimation = { workspace = true }
+humantime = { workspace = true }
 lazy_static = { workspace = true }
 model = { path = "../model" }
 number = { path = "../number" }

--- a/crates/refunder/src/arguments.rs
+++ b/crates/refunder/src/arguments.rs
@@ -25,8 +25,8 @@ pub struct Arguments {
     #[clap(
         long,
         env,
-        default_value = "120",
-        value_parser = shared::arguments::duration_from_seconds,
+        default_value = "2m",
+        value_parser = humantime::parse_duration,
     )]
     pub min_validity_duration: Duration,
 

--- a/crates/shared/Cargo.toml
+++ b/crates/shared/Cargo.toml
@@ -30,6 +30,7 @@ gas-estimation = { workspace = true }
 observe = { path = "../observe" }
 hex = { workspace = true }
 hex-literal = { workspace = true }
+humantime = { workspace = true }
 itertools = { workspace = true }
 lazy_static = { workspace = true }
 maplit = { workspace = true }

--- a/crates/shared/src/arguments.rs
+++ b/crates/shared/src/arguments.rs
@@ -17,7 +17,7 @@ use {
     ethcontract::{H160, H256, U256},
     std::{
         fmt::{self, Display, Formatter},
-        num::{NonZeroU64, ParseFloatError},
+        num::NonZeroU64,
         str::FromStr,
         time::Duration,
     },
@@ -88,8 +88,8 @@ pub struct OrderQuotingArguments {
     #[clap(
         long,
         env,
-        default_value = "600",
-        value_parser = duration_from_seconds,
+        default_value = "10m",
+        value_parser = humantime::parse_duration,
     )]
     pub eip1271_onchain_quote_validity_seconds: Duration,
 
@@ -97,8 +97,8 @@ pub struct OrderQuotingArguments {
     #[clap(
         long,
         env,
-        default_value = "600",
-        value_parser = duration_from_seconds,
+        default_value = "10m",
+        value_parser = humantime::parse_duration,
     )]
     pub presign_onchain_quote_validity_seconds: Duration,
 
@@ -107,8 +107,8 @@ pub struct OrderQuotingArguments {
     #[clap(
         long,
         env,
-        default_value = "60",
-        value_parser = duration_from_seconds,
+        default_value = "1m",
+        value_parser = humantime::parse_duration,
     )]
     pub standard_offchain_quote_validity_seconds: Duration,
 
@@ -230,7 +230,7 @@ pub struct Arguments {
     pub pool_cache_maximum_retries: u32,
 
     /// How long to sleep in seconds between retries in the pool cache.
-    #[clap(long, env, default_value = "1", value_parser = duration_from_seconds)]
+    #[clap(long, env, default_value = "1s", value_parser = humantime::parse_duration)]
     pub pool_cache_delay_between_retries_seconds: Duration,
 
     /// The ParaSwap API base url to use.
@@ -295,8 +295,8 @@ pub struct Arguments {
     #[clap(
         long,
         env,
-        default_value = "30",
-        value_parser = duration_from_seconds,
+        default_value = "30s",
+        value_parser = humantime::parse_duration,
     )]
     pub liquidity_fetcher_max_age_update: Duration,
 
@@ -305,7 +305,7 @@ pub struct Arguments {
     pub max_pools_to_initialize_cache: usize,
 
     /// The time in seconds between new blocks on the network.
-    #[clap(long, env, value_parser = duration_from_seconds)]
+    #[clap(long, env, value_parser = humantime::parse_duration)]
     pub network_block_interval: Option<Duration>,
 
     /// Override address of the settlement contract.
@@ -518,10 +518,6 @@ pub fn parse_percentage_factor(s: &str) -> Result<f64> {
     let percentage_factor = f64::from_str(s)?;
     ensure!(percentage_factor.is_finite() && (0. ..=1.0).contains(&percentage_factor));
     Ok(percentage_factor)
-}
-
-pub fn duration_from_seconds(s: &str) -> Result<Duration, ParseFloatError> {
-    Ok(Duration::from_secs_f64(s.parse()?))
 }
 
 pub fn wei_from_ether(s: &str) -> anyhow::Result<U256> {

--- a/crates/shared/src/arguments.rs
+++ b/crates/shared/src/arguments.rs
@@ -91,7 +91,7 @@ pub struct OrderQuotingArguments {
         default_value = "10m",
         value_parser = humantime::parse_duration,
     )]
-    pub eip1271_onchain_quote_validity_seconds: Duration,
+    pub eip1271_onchain_quote_validity: Duration,
 
     /// The time period an PRESIGN-quote request is valid.
     #[clap(
@@ -100,7 +100,7 @@ pub struct OrderQuotingArguments {
         default_value = "10m",
         value_parser = humantime::parse_duration,
     )]
-    pub presign_onchain_quote_validity_seconds: Duration,
+    pub presign_onchain_quote_validity: Duration,
 
     /// The time period a regular offchain-quote request (ethsign/eip712) is
     /// valid.
@@ -110,7 +110,7 @@ pub struct OrderQuotingArguments {
         default_value = "1m",
         value_parser = humantime::parse_duration,
     )]
-    pub standard_offchain_quote_validity_seconds: Duration,
+    pub standard_offchain_quote_validity: Duration,
 
     /// A flat fee discount denominated in the network's native token (i.e.
     /// Ether for Mainnet).
@@ -231,7 +231,7 @@ pub struct Arguments {
 
     /// How long to sleep in seconds between retries in the pool cache.
     #[clap(long, env, default_value = "1s", value_parser = humantime::parse_duration)]
-    pub pool_cache_delay_between_retries_seconds: Duration,
+    pub pool_cache_delay_between_retries: Duration,
 
     /// The ParaSwap API base url to use.
     #[clap(long, env, default_value = super::paraswap_api::DEFAULT_URL)]
@@ -304,7 +304,7 @@ pub struct Arguments {
     #[clap(long, env, default_value = "100")]
     pub max_pools_to_initialize_cache: usize,
 
-    /// The time in seconds between new blocks on the network.
+    /// The time between new blocks on the network.
     #[clap(long, env, value_parser = humantime::parse_duration)]
     pub network_block_interval: Option<Duration>,
 
@@ -374,12 +374,12 @@ impl Display for OrderQuotingArguments {
         writeln!(
             f,
             "eip1271_onchain_quote_validity_second: {:?}",
-            self.eip1271_onchain_quote_validity_seconds
+            self.eip1271_onchain_quote_validity
         )?;
         writeln!(
             f,
             "presign_onchain_quote_validity_second: {:?}",
-            self.presign_onchain_quote_validity_seconds
+            self.presign_onchain_quote_validity
         )?;
         writeln!(f, "fee_discount: {}", self.fee_discount)?;
         writeln!(f, "min_discounted_fee: {}", self.min_discounted_fee)?;
@@ -437,8 +437,8 @@ impl Display for Arguments {
         )?;
         writeln!(
             f,
-            "pool_cache_delay_between_retries_seconds: {:?}",
-            self.pool_cache_delay_between_retries_seconds
+            "pool_cache_delay_between_retries: {:?}",
+            self.pool_cache_delay_between_retries
         )?;
         display_secret_option(f, "paraswap_partner", &self.paraswap_partner)?;
         display_list(f, "disabled_paraswap_dexs", &self.disabled_paraswap_dexs)?;

--- a/crates/shared/src/bad_token/token_owner_finder.rs
+++ b/crates/shared/src/bad_token/token_owner_finder.rs
@@ -15,7 +15,7 @@ use {
         },
     },
     crate::{
-        arguments::{display_list, display_option, display_secret_option, duration_from_seconds},
+        arguments::{display_list, display_option, display_secret_option},
         bad_token::token_owner_finder::{
             ethplorer::EthplorerTokenOwnerFinder,
             solvers::{
@@ -109,7 +109,7 @@ pub struct Arguments {
     /// Interval in seconds between consecutive queries to update the solver
     /// token owner pairs. Values should be in pair with
     /// `solver_token_owners_urls`
-    #[clap(long, env, use_value_delimiter = true, value_parser = duration_from_seconds)]
+    #[clap(long, env, use_value_delimiter = true, value_parser = humantime::parse_duration)]
     pub solver_token_owners_cache_update_intervals: Vec<Duration>,
 }
 

--- a/crates/shared/src/current_block.rs
+++ b/crates/shared/src/current_block.rs
@@ -26,7 +26,7 @@ pub struct Arguments {
         default_value = "5s",
         value_parser = humantime::parse_duration,
     )]
-    pub block_stream_poll_interval_seconds: Duration,
+    pub block_stream_poll_interval: Duration,
 }
 
 impl Arguments {
@@ -35,11 +35,7 @@ impl Arguments {
     }
 
     pub async fn stream(&self, web3: Web3) -> Result<CurrentBlockStream> {
-        current_block_stream(
-            self.retriever(web3),
-            self.block_stream_poll_interval_seconds,
-        )
-        .await
+        current_block_stream(self.retriever(web3), self.block_stream_poll_interval).await
     }
 }
 
@@ -47,8 +43,8 @@ impl Display for Arguments {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         writeln!(
             f,
-            "block_stream_poll_interval_seconds: {:?}",
-            self.block_stream_poll_interval_seconds
+            "block_stream_poll_interval: {:?}",
+            self.block_stream_poll_interval
         )?;
 
         Ok(())

--- a/crates/shared/src/current_block.rs
+++ b/crates/shared/src/current_block.rs
@@ -1,7 +1,6 @@
 //! Global block stream arguments.
 
 use {
-    crate::arguments::duration_from_seconds,
     anyhow::Result,
     clap::Parser,
     ethrpc::{
@@ -24,8 +23,8 @@ pub struct Arguments {
     #[clap(
         long,
         env,
-        default_value = "5",
-        value_parser = duration_from_seconds,
+        default_value = "5s",
+        value_parser = humantime::parse_duration,
     )]
     pub block_stream_poll_interval_seconds: Duration,
 }

--- a/crates/shared/src/ethrpc.rs
+++ b/crates/shared/src/ethrpc.rs
@@ -6,7 +6,7 @@ pub use ethrpc::{
     Web3Transport,
 };
 use {
-    crate::{arguments::duration_from_seconds, http_client::HttpClientFactory},
+    crate::http_client::HttpClientFactory,
     reqwest::Url,
     std::{
         fmt::{self, Display, Formatter},
@@ -32,7 +32,7 @@ pub struct Arguments {
 
     /// Buffering "nagle" delay to wait for additional requests before sending
     /// out an incomplete batch.
-    #[clap(long, env, value_parser = duration_from_seconds, default_value = "0")]
+    #[clap(long, env, value_parser = humantime::parse_duration, default_value = "0s")]
     pub ethrpc_batch_delay: Duration,
 }
 

--- a/crates/shared/src/http_client.rs
+++ b/crates/shared/src/http_client.rs
@@ -1,5 +1,4 @@
 use {
-    crate::arguments::duration_from_seconds,
     anyhow::{anyhow, Result},
     reqwest::{Client, ClientBuilder, Response},
     std::{
@@ -62,8 +61,8 @@ pub struct Arguments {
     #[clap(
         long,
         env,
-        default_value = "10",
-        value_parser = duration_from_seconds,
+        default_value = "10s",
+        value_parser = humantime::parse_duration,
     )]
     pub http_timeout: Duration,
 }

--- a/crates/shared/src/price_estimation.rs
+++ b/crates/shared/src/price_estimation.rs
@@ -247,14 +247,14 @@ pub struct Arguments {
     /// How long before expiry the native price cache should try to update the
     /// price in the background. This is useful to make sure that prices are
     /// usable at all times. This value has to be smaller than
-    /// `--native-price-cache-max-age-secs`.
+    /// `--native-price-cache-max-age`.
     #[clap(
         long,
         env,
         default_value = "2s",
         value_parser = humantime::parse_duration,
     )]
-    pub native_price_prefetch_time_secs: Duration,
+    pub native_price_prefetch_time: Duration,
 
     /// How many cached native token prices can be updated at most in one
     /// maintenance cycle.
@@ -334,7 +334,7 @@ impl Display for Arguments {
         writeln!(
             f,
             "native_price_prefetch_time_secs: {:?}",
-            self.native_price_prefetch_time_secs
+            self.native_price_prefetch_time
         )?;
         writeln!(
             f,

--- a/crates/shared/src/price_estimation.rs
+++ b/crates/shared/src/price_estimation.rs
@@ -221,8 +221,8 @@ pub struct Arguments {
     /// entirely. Needs to be passed as
     /// "<back_off_growth_factor>,<min_back_off>,<max_back_off>".
     /// back_off_growth_factor: f64 >= 1.0
-    /// min_back_off: f64 in seconds
-    /// max_back_off: f64 in seconds
+    /// min_back_off: Duration
+    /// max_back_off: Duration
     #[clap(long, env, verbatim_doc_comment)]
     pub price_estimation_rate_limiter: Option<Strategy>,
 
@@ -230,8 +230,8 @@ pub struct Arguments {
     #[clap(
         long,
         env,
-        default_value = "1",
-        value_parser = crate::arguments::duration_from_seconds,
+        default_value = "1s",
+        value_parser = humantime::parse_duration,
     )]
     pub native_price_cache_refresh_secs: Duration,
 
@@ -239,8 +239,8 @@ pub struct Arguments {
     #[clap(
         long,
         env,
-        default_value = "30",
-        value_parser = crate::arguments::duration_from_seconds,
+        default_value = "30s",
+        value_parser = humantime::parse_duration,
     )]
     pub native_price_cache_max_age_secs: Duration,
 
@@ -251,8 +251,8 @@ pub struct Arguments {
     #[clap(
         long,
         env,
-        default_value = "2",
-        value_parser = crate::arguments::duration_from_seconds,
+        default_value = "2s",
+        value_parser = humantime::parse_duration,
     )]
     pub native_price_prefetch_time_secs: Duration,
 

--- a/crates/shared/src/price_estimation.rs
+++ b/crates/shared/src/price_estimation.rs
@@ -233,7 +233,7 @@ pub struct Arguments {
         default_value = "1s",
         value_parser = humantime::parse_duration,
     )]
-    pub native_price_cache_refresh_secs: Duration,
+    pub native_price_cache_refresh: Duration,
 
     /// How long cached native prices stay valid.
     #[clap(
@@ -242,7 +242,7 @@ pub struct Arguments {
         default_value = "30s",
         value_parser = humantime::parse_duration,
     )]
-    pub native_price_cache_max_age_secs: Duration,
+    pub native_price_cache_max_age: Duration,
 
     /// How long before expiry the native price cache should try to update the
     /// price in the background. This is useful to make sure that prices are
@@ -323,17 +323,17 @@ impl Display for Arguments {
         )?;
         writeln!(
             f,
-            "native_price_cache_refresh_secs: {:?}",
-            self.native_price_cache_refresh_secs
+            "native_price_cache_refresh: {:?}",
+            self.native_price_cache_refresh
         )?;
         writeln!(
             f,
-            "native_price_cache_max_age_secs: {:?}",
-            self.native_price_cache_max_age_secs
+            "native_price_cache_max_age: {:?}",
+            self.native_price_cache_max_age
         )?;
         writeln!(
             f,
-            "native_price_prefetch_time_secs: {:?}",
+            "native_price_prefetch_time: {:?}",
             self.native_price_prefetch_time
         )?;
         writeln!(

--- a/crates/shared/src/price_estimation/factory.rs
+++ b/crates/shared/src/price_estimation/factory.rs
@@ -371,7 +371,7 @@ impl<'a> PriceEstimatorFactory<'a> {
         results_required: NonZeroUsize,
     ) -> Result<Arc<CachingNativePriceEstimator>> {
         anyhow::ensure!(
-            self.args.native_price_cache_max_age_secs > self.args.native_price_prefetch_time,
+            self.args.native_price_cache_max_age > self.args.native_price_prefetch_time,
             "price cache prefetch time needs to be less than price cache max age"
         );
 
@@ -392,8 +392,8 @@ impl<'a> PriceEstimatorFactory<'a> {
         );
         let native_estimator = Arc::new(CachingNativePriceEstimator::new(
             Box::new(competition_estimator),
-            self.args.native_price_cache_max_age_secs,
-            self.args.native_price_cache_refresh_secs,
+            self.args.native_price_cache_max_age,
+            self.args.native_price_cache_refresh,
             Some(self.args.native_price_cache_max_update_size),
             self.args.native_price_prefetch_time,
             self.args.native_price_cache_concurrent_requests,

--- a/crates/shared/src/price_estimation/factory.rs
+++ b/crates/shared/src/price_estimation/factory.rs
@@ -371,7 +371,7 @@ impl<'a> PriceEstimatorFactory<'a> {
         results_required: NonZeroUsize,
     ) -> Result<Arc<CachingNativePriceEstimator>> {
         anyhow::ensure!(
-            self.args.native_price_cache_max_age_secs > self.args.native_price_prefetch_time_secs,
+            self.args.native_price_cache_max_age_secs > self.args.native_price_prefetch_time,
             "price cache prefetch time needs to be less than price cache max age"
         );
 
@@ -395,7 +395,7 @@ impl<'a> PriceEstimatorFactory<'a> {
             self.args.native_price_cache_max_age_secs,
             self.args.native_price_cache_refresh_secs,
             Some(self.args.native_price_cache_max_update_size),
-            self.args.native_price_prefetch_time_secs,
+            self.args.native_price_prefetch_time,
             self.args.native_price_cache_concurrent_requests,
         ));
         Ok(native_estimator)

--- a/crates/solver/Cargo.toml
+++ b/crates/solver/Cargo.toml
@@ -32,6 +32,7 @@ gas-estimation = { workspace = true }
 observe = { path = "../observe" }
 hex = { workspace = true }
 hex-literal = { workspace = true }
+humantime = { workspace = true }
 itertools = { workspace = true }
 jsonrpc-core = "18"
 lazy_static = { workspace = true }

--- a/crates/solver/src/arguments.rs
+++ b/crates/solver/src/arguments.rs
@@ -59,8 +59,8 @@ pub struct Arguments {
     #[clap(
         long,
         env,
-        default_value = "30",
-        value_parser = shared::arguments::duration_from_seconds,
+        default_value = "30s",
+        value_parser = humantime::parse_duration,
     )]
     pub target_confirm_time: Duration,
 
@@ -73,8 +73,8 @@ pub struct Arguments {
     #[clap(
         long,
         env,
-        default_value = "10",
-        value_parser = shared::arguments::duration_from_seconds,
+        default_value = "10s",
+        value_parser = humantime::parse_duration,
     )]
     pub settle_interval: Duration,
 
@@ -116,8 +116,8 @@ pub struct Arguments {
     #[clap(
         long,
         env,
-        default_value = "30",
-        value_parser = shared::arguments::duration_from_seconds,
+        default_value = "30s",
+        value_parser = humantime::parse_duration,
     )]
     pub solver_time_limit: Duration,
 
@@ -134,8 +134,8 @@ pub struct Arguments {
     #[clap(
         long,
         env,
-        default_value = "3600",
-        value_parser = shared::arguments::duration_from_seconds,
+        default_value = "1h",
+        value_parser = humantime::parse_duration,
     )]
     pub market_makable_token_list_update_interval: Duration,
 
@@ -209,8 +209,8 @@ pub struct Arguments {
     #[clap(
         long,
         env,
-        default_value = "120",
-        value_parser = shared::arguments::duration_from_seconds,
+        default_value = "2m",
+        value_parser = humantime::parse_duration,
     )]
     pub max_submission_seconds: Duration,
 
@@ -229,8 +229,8 @@ pub struct Arguments {
     #[clap(
         long,
         env,
-        default_value = "2",
-        value_parser = shared::arguments::duration_from_seconds,
+        default_value = "2s",
+        value_parser = humantime::parse_duration,
     )]
     pub submission_retry_interval_seconds: Duration,
 
@@ -309,8 +309,8 @@ pub struct Arguments {
     #[clap(
         long,
         env,
-        default_value = "60",
-        value_parser = shared::arguments::duration_from_seconds,
+        default_value = "1m",
+        value_parser = humantime::parse_duration,
     )]
     pub additional_mining_deadline: Duration,
 

--- a/crates/solver/src/arguments.rs
+++ b/crates/solver/src/arguments.rs
@@ -212,7 +212,7 @@ pub struct Arguments {
         default_value = "2m",
         value_parser = humantime::parse_duration,
     )]
-    pub max_submission: Duration,
+    pub max_submission_time: Duration,
 
     /// Maximum additional tip in gwei that we are willing to give to flashbots
     /// above regular gas price estimation
@@ -415,7 +415,7 @@ impl std::fmt::Display for Arguments {
             "max_additional_eden_tip: {}",
             self.max_additional_eden_tip
         )?;
-        writeln!(f, "max_submission: {:?}", self.max_submission)?;
+        writeln!(f, "max_submission_time: {:?}", self.max_submission_time)?;
         writeln!(
             f,
             "max_additional_flashbots_tip: {}",

--- a/crates/solver/src/arguments.rs
+++ b/crates/solver/src/arguments.rs
@@ -64,7 +64,7 @@ pub struct Arguments {
     )]
     pub target_confirm_time: Duration,
 
-    /// Specify the interval in seconds between consecutive driver run loops.
+    /// Specify the interval between consecutive driver run loops.
     ///
     /// This is typically a low value to prevent busy looping in case of some
     /// internal driver error, but can be set to a larger value for running
@@ -204,7 +204,7 @@ pub struct Arguments {
     )]
     pub max_additional_eden_tip: f64,
 
-    /// The maximum time in seconds we spend trying to settle a transaction
+    /// The maximum time we spend trying to settle a transaction
     /// through the ethereum network before going to back to solving.
     #[clap(
         long,
@@ -212,7 +212,7 @@ pub struct Arguments {
         default_value = "2m",
         value_parser = humantime::parse_duration,
     )]
-    pub max_submission_seconds: Duration,
+    pub max_submission: Duration,
 
     /// Maximum additional tip in gwei that we are willing to give to flashbots
     /// above regular gas price estimation
@@ -232,7 +232,7 @@ pub struct Arguments {
         default_value = "2s",
         value_parser = humantime::parse_duration,
     )]
-    pub submission_retry_interval_seconds: Duration,
+    pub submission_retry_interval: Duration,
 
     /// Additional tip in percentage of max_fee_per_gas we are willing to give
     /// to miners above regular gas price estimation
@@ -415,11 +415,7 @@ impl std::fmt::Display for Arguments {
             "max_additional_eden_tip: {}",
             self.max_additional_eden_tip
         )?;
-        writeln!(
-            f,
-            "max_submission_seconds: {:?}",
-            self.max_submission_seconds
-        )?;
+        writeln!(f, "max_submission: {:?}", self.max_submission)?;
         writeln!(
             f,
             "max_additional_flashbots_tip: {}",
@@ -427,8 +423,8 @@ impl std::fmt::Display for Arguments {
         )?;
         writeln!(
             f,
-            "submission_retry_interval_seconds: {:?}",
-            self.submission_retry_interval_seconds
+            "submission_retry_interval: {:?}",
+            self.submission_retry_interval
         )?;
         writeln!(
             f,

--- a/crates/solver/src/run.rs
+++ b/crates/solver/src/run.rs
@@ -169,7 +169,7 @@ pub async fn run(args: Arguments) {
         number_of_blocks_to_cache: args.shared.pool_cache_blocks,
         maximum_recent_block_age: args.shared.pool_cache_maximum_recent_block_age,
         max_retries: args.shared.pool_cache_maximum_retries,
-        delay_between_retries: args.shared.pool_cache_delay_between_retries_seconds,
+        delay_between_retries: args.shared.pool_cache_delay_between_retries,
         ..Default::default()
     };
     let baseline_sources = args.shared.baseline_sources.unwrap_or_else(|| {
@@ -537,8 +537,8 @@ pub async fn run(args: Arguments) {
         contract: settlement_contract.clone(),
         gas_price_estimator: gas_price_estimator.clone(),
         target_confirm_time: args.target_confirm_time,
-        max_confirm_time: args.max_submission_seconds,
-        retry_interval: args.submission_retry_interval_seconds,
+        max_confirm_time: args.max_submission,
+        retry_interval: args.submission_retry_interval,
         transaction_strategies,
         access_list_estimator,
         code_fetcher,

--- a/crates/solver/src/run.rs
+++ b/crates/solver/src/run.rs
@@ -537,7 +537,7 @@ pub async fn run(args: Arguments) {
         contract: settlement_contract.clone(),
         gas_price_estimator: gas_price_estimator.clone(),
         target_confirm_time: args.target_confirm_time,
-        max_confirm_time: args.max_submission,
+        max_confirm_time: args.max_submission_time,
         retry_interval: args.submission_retry_interval,
         transaction_strategies,
         access_list_estimator,

--- a/crates/solver/src/settlement_submission/submitter.rs
+++ b/crates/solver/src/settlement_submission/submitter.rs
@@ -61,7 +61,7 @@ pub struct SubmitterParams {
     pub gas_estimate: U256,
     /// Maximum duration of a single run loop
     pub deadline: Option<Instant>,
-    /// Re-simulate and resend transaction on every retry_interval seconds
+    /// Re-simulate and resend transaction on every retry_interval
     pub retry_interval: Duration,
     /// Network id (mainnet, goerli, sepolia, gnosis chain)
     pub network_id: String,

--- a/crates/solvers/Cargo.toml
+++ b/crates/solvers/Cargo.toml
@@ -21,7 +21,7 @@ ethereum-types = "0.14"
 ethrpc = { path = "../ethrpc" }
 futures = "0.3"
 hex = "0.4"
-humantime-serde = "1.0"
+humantime-serde = { workspace = true }
 hyper = "0.14"
 itertools = "0.11"
 num = "0.4"

--- a/crates/solvers/Cargo.toml
+++ b/crates/solvers/Cargo.toml
@@ -21,6 +21,7 @@ ethereum-types = "0.14"
 ethrpc = { path = "../ethrpc" }
 futures = "0.3"
 hex = "0.4"
+humantime-serde = "1.0"
 hyper = "0.14"
 itertools = "0.11"
 num = "0.4"

--- a/crates/solvers/src/infra/config/dex/file.rs
+++ b/crates/solvers/src/infra/config/dex/file.rs
@@ -54,12 +54,12 @@ struct Config {
     back_off_growth_factor: f64,
 
     /// Minimum back-off time in seconds for rate limiting.
-    #[serde(default = "default_min_back_off")]
-    min_back_off: u64,
+    #[serde(with = "humantime_serde", default = "default_min_back_off")]
+    min_back_off: Duration,
 
     /// Maximum back-off time in seconds for rate limiting.
-    #[serde(default = "default_max_back_off")]
-    max_back_off: u64,
+    #[serde(with = "humantime_serde", default = "default_max_back_off")]
+    max_back_off: Duration,
 
     /// Settings specific to the wrapped dex API.
     dex: toml::Value,
@@ -81,12 +81,12 @@ fn default_back_off_growth_factor() -> f64 {
     2.0
 }
 
-fn default_min_back_off() -> u64 {
-    1
+fn default_min_back_off() -> Duration {
+    Duration::from_secs(1)
 }
 
-fn default_max_back_off() -> u64 {
-    8
+fn default_max_back_off() -> Duration {
+    Duration::from_secs(8)
 }
 
 /// Loads the base solver configuration from a TOML file.
@@ -144,8 +144,8 @@ pub async fn load<T: DeserializeOwned>(path: &Path) -> (super::Config, T) {
         },
         rate_limiting_strategy: Strategy::try_new(
             config.back_off_growth_factor,
-            Duration::from_secs(config.min_back_off),
-            Duration::from_secs(config.max_back_off),
+            config.min_back_off,
+            config.max_back_off,
         )
         .unwrap(),
     };


### PR DESCRIPTION
# Description
Fully closes the https://github.com/cowprotocol/services/issues/2085. Since DEX solvers are about to migrate to a separate repo, it's a good time to change the config format. It will be much more difficult later.

# Changes
Use `humantime` to parse `Duration` config params.

## How to test
e2e + staging

## Related Issues

Fixes #2085