### PR TITLE
Remove unused argument quasimodo_solver_url from price estimation

### DIFF
--- a/crates/shared/src/price_estimation.rs
+++ b/crates/shared/src/price_estimation.rs
@@ -272,10 +272,6 @@ pub struct Arguments {
     #[clap(long, env, value_parser = U256::from_dec_str)]
     pub amount_to_estimate_prices_with: Option<U256>,
 
-    /// The API endpoint to call the Quasimodo solver for price estimation
-    #[clap(long, env)]
-    pub quasimodo_solver_url: Option<Url>,
-
     /// The API endpoint for the Balancer SOR API for solving.
     #[clap(long, env)]
     pub balancer_sor_url: Option<Url>,
@@ -351,7 +347,6 @@ impl Display for Arguments {
             "amount_to_estimate_prices_with",
             &self.amount_to_estimate_prices_with,
         )?;
-        display_option(f, "quasimodo_solver_url", &self.quasimodo_solver_url)?;
         display_option(f, "balancer_sor_url", &self.balancer_sor_url)?;
         display_option(
             f,


### PR DESCRIPTION
# Description

I wanted to know how this parameter is used and I realized it isn't.

It's still a valid argument for the `solver` binary however.

# Changes

- Remove price estimator argument `quasimodo_solver_url`.

## How to test

Code compiles.