### PR TITLE
Filter out useless pools

### DIFF
--- a/crates/shared/src/sources/balancer_v2/graph_api.rs
+++ b/crates/shared/src/sources/balancer_v2/graph_api.rs
@@ -197,6 +197,7 @@ mod pools_query {
                         "LiquidityBootstrapping",
                         "ComposableStable",
                     ]
+                    totalLiquidity_gt: "1" # 1$ value of tokens
                 }
             ) {
                 poolType


### PR DESCRIPTION
# Description
Fixes https://github.com/cowprotocol/services/issues/2204

By filtering out pools that basically don't have meaningful liquidity we reduce the number of pools from ~1300 to ~500 and also eliminate problematic pools (with old problematic tokens).

## How to test
Play with unit test `balancer_subgraph_query`