### PR TITLE
Remove fee_objective_scaling_factor

### DIFF
--- a/crates/autopilot/src/arguments.rs
+++ b/crates/autopilot/src/arguments.rs
@@ -120,19 +120,14 @@ pub struct Arguments {
     )]
     pub max_auction_age: Duration,
 
+    /// Used to filter out limit orders with prices that are too far from the
+    /// market price. 0 means no filtering.
     #[clap(long, env, default_value = "0")]
     pub limit_order_price_factor: f64,
 
     /// The time between auction updates.
     #[clap(long, env, default_value = "10s", value_parser = humantime::parse_duration)]
     pub auction_update_interval: Duration,
-
-    /// Fee scaling factor for objective value. This controls the constant
-    /// factor by which order fees are multiplied with. Setting this to a value
-    /// greater than 1.0 makes settlements with negative objective values less
-    /// likely, promoting more aggressive merging of single order settlements.
-    #[clap(long, env, default_value = "1", value_parser = shared::arguments::parse_unbounded_factor)]
-    pub fee_objective_scaling_factor: f64,
 
     /// The URL of a list of tokens our settlement contract is willing to
     /// internalize.
@@ -245,7 +240,6 @@ impl std::fmt::Display for Arguments {
             banned_users,
             max_auction_age,
             limit_order_price_factor,
-            fee_objective_scaling_factor,
             trusted_tokens_url,
             trusted_tokens,
             trusted_tokens_update_interval,
@@ -298,11 +292,6 @@ impl std::fmt::Display for Arguments {
             f,
             "limit_order_price_factor: {:?}",
             limit_order_price_factor
-        )?;
-        writeln!(
-            f,
-            "fee_objective_scaling_factor: {}",
-            fee_objective_scaling_factor
         )?;
         display_option(f, "trusted_tokens_url", trusted_tokens_url)?;
         writeln!(f, "trusted_tokens: {:?}", trusted_tokens)?;

--- a/crates/autopilot/src/run.rs
+++ b/crates/autopilot/src/run.rs
@@ -568,7 +568,6 @@ pub async fn run(args: Arguments) {
             .try_into()
             .expect("limit order price factor can't be converted to BigDecimal"),
         !args.enable_colocation,
-        args.fee_objective_scaling_factor,
     );
     solvable_orders_cache
         .update(block)


### PR DESCRIPTION
# Description
Initiative to simplify autopilot parameters so we can move them to `toml` format.

This factor is 1 for quite some time and there is no plan to use it. Also, with moving to all orders being limit orders, it becomes useless.