### PR TITLE
Classify orders with invalid signature as invalid

### DIFF
--- a/crates/alerter/src/lib.rs
+++ b/crates/alerter/src/lib.rs
@@ -221,7 +221,11 @@ impl Alerter {
             .await
             .context("solvable_orders")?
             .into_iter()
-            .filter(|order| !order.is_liquidity_order() && !order.partially_fillable)
+            .filter(|order| {
+                !order.is_liquidity_order()
+                    && !order.partially_fillable
+                    && !matches!(order.status, OrderStatus::PresignaturePending)
+            })
             .map(|order| {
                 let existing_time = self.open_orders.get(&order.uid).and_then(|o| o.1);
                 (order.uid, (order, existing_time))

--- a/crates/autopilot/src/solvable_orders.rs
+++ b/crates/autopilot/src/solvable_orders.rs
@@ -267,11 +267,19 @@ fn filter_banned_user_orders(mut orders: Vec<Order>, banned_users: &HashSet<H160
     orders
 }
 
-/// Filters EIP-1271 orders whose signatures are no longer validating.
+/// Filters unsigned PreSign and EIP-1271 orders whose signatures are no longer
+/// validating.
 async fn filter_invalid_signature_orders(
-    orders: Vec<Order>,
+    mut orders: Vec<Order>,
     signature_validator: &dyn SignatureValidating,
 ) -> Vec<Order> {
+    orders.retain(|order| {
+        !matches!(
+            order.metadata.status,
+            model::order::OrderStatus::PresignaturePending
+        )
+    });
+
     let checks = orders
         .iter()
         .filter_map(|order| match &order.signature {

--- a/crates/database/src/orders.rs
+++ b/crates/database/src/orders.rs
@@ -1335,19 +1335,19 @@ mod tests {
         }
 
         // not solvable because there is no presignature event.
-        assert!(get_order(&mut db).await.unwrap().presignature_pending == true);
+        assert!(get_order(&mut db).await.unwrap().presignature_pending);
 
         // solvable because once presignature event is observed.
         pre_signature_event(&mut db, 0, order.owner, order.uid, true).await;
-        assert!(get_order(&mut db).await.unwrap().presignature_pending == false);
+        assert!(!get_order(&mut db).await.unwrap().presignature_pending);
 
         // not solvable because "unsigned" presignature event.
         pre_signature_event(&mut db, 1, order.owner, order.uid, false).await;
-        assert!(get_order(&mut db).await.unwrap().presignature_pending == true);
+        assert!(get_order(&mut db).await.unwrap().presignature_pending);
 
         // solvable once again because of new presignature event.
         pre_signature_event(&mut db, 2, order.owner, order.uid, true).await;
-        assert!(get_order(&mut db).await.unwrap().presignature_pending == false);
+        assert!(!get_order(&mut db).await.unwrap().presignature_pending);
     }
 
     #[tokio::test]

--- a/crates/database/src/orders.rs
+++ b/crates/database/src/orders.rs
@@ -699,8 +699,7 @@ WHERE
         WHEN 'buy' THEN sum_buy < buy_amount
     END AND
     (NOT invalidated) AND
-    (onchain_placement_error IS NULL) AND
-    (NOT presignature_pending)
+    (onchain_placement_error IS NULL)
 "#
 );
 

--- a/crates/database/src/orders.rs
+++ b/crates/database/src/orders.rs
@@ -1335,19 +1335,19 @@ mod tests {
         }
 
         // not solvable because there is no presignature event.
-        assert!(get_order(&mut db).await.is_none());
+        assert!(get_order(&mut db).await.unwrap().presignature_pending == true);
 
         // solvable because once presignature event is observed.
         pre_signature_event(&mut db, 0, order.owner, order.uid, true).await;
-        assert!(get_order(&mut db).await.is_some());
+        assert!(get_order(&mut db).await.unwrap().presignature_pending == false);
 
         // not solvable because "unsigned" presignature event.
         pre_signature_event(&mut db, 1, order.owner, order.uid, false).await;
-        assert!(get_order(&mut db).await.is_none());
+        assert!(get_order(&mut db).await.unwrap().presignature_pending == true);
 
         // solvable once again because of new presignature event.
         pre_signature_event(&mut db, 2, order.owner, order.uid, true).await;
-        assert!(get_order(&mut db).await.is_some());
+        assert!(get_order(&mut db).await.unwrap().presignature_pending == false);
     }
 
     #[tokio::test]

--- a/crates/shared/src/db_order_conversions.rs
+++ b/crates/shared/src/db_order_conversions.rs
@@ -38,7 +38,11 @@ use {
 };
 
 pub fn full_order_into_model_order(order: database::orders::FullOrder) -> Result<Order> {
-    let status = OrderStatus::Open;
+    let status = if order.presignature_pending {
+        OrderStatus::PresignaturePending
+    } else {
+        OrderStatus::Open
+    };
     let pre_interactions = extract_interactions(&order, ExecutionTime::Pre)?;
     let post_interactions = extract_interactions(&order, ExecutionTime::Post)?;
     let ethflow_data = if let Some((refund_tx, user_valid_to)) = order.ethflow_data {


### PR DESCRIPTION
# Description
When investigating some outliers in our "Time to happy moo SLI" (e.g. [this order](https://explorer.cow.fi/orders/0x726d843841bc013fe38fc5be3a874d39c1dadea594779aa0e13f8f5aab6f65d897681034cc9fa3e5d562c25ef40a09033cae5380658d45ce?tab=overview)) I noticed that we currently classify presign orders as valid even if they are not yet signed. This is because they are filtered out in the solvable orders SQL query and not inside the solvable orders updating logic

# Changes
- [x] Remove SQL based filter condition that exlcuded pending presingature orders
- [x] Filter those out in the code that also logs why orders have been omitted and records them as invalid (which then should be picked up by the time to happy moo SLI

## How to test
Expect to see accurate time to happy moo metric for order that take some time to be presigned