### PR TITLE
[Trivial] log deadline

### DIFF
--- a/crates/driver/src/domain/time.rs
+++ b/crates/driver/src/domain/time.rs
@@ -1,5 +1,6 @@
 use {
     crate::infra::{
+        observe,
         solver::Timeouts,
         {self},
     },
@@ -20,7 +21,7 @@ pub struct Deadline {
 impl Deadline {
     pub fn new(deadline: chrono::DateTime<chrono::Utc>, timeouts: Timeouts) -> Self {
         let deadline = deadline - timeouts.http_delay;
-        Self {
+        let deadline = Self {
             driver: deadline,
             solvers: {
                 let now = infra::time::now();
@@ -28,7 +29,9 @@ impl Deadline {
                 now + duration * (timeouts.solving_share_of_deadline.get() * 100.0).round() as i32
                     / 100
             },
-        }
+        };
+        observe::deadline(&deadline, &timeouts);
+        deadline
     }
 
     /// Remaining time until the deadline for driver to return solution to

--- a/crates/driver/src/infra/observe/mod.rs
+++ b/crates/driver/src/infra/observe/mod.rs
@@ -4,7 +4,7 @@
 //! and update the metrics, if the event is worth measuring.
 
 use {
-    super::{simulator, Ethereum, Mempool},
+    super::{simulator, solver::Timeouts, Ethereum, Mempool},
     crate::{
         boundary,
         domain::{
@@ -18,6 +18,7 @@ use {
             eth::{self, Gas},
             mempools,
             quote::{self, Quote},
+            time::Deadline,
             Liquidity,
         },
         infra::solver,
@@ -363,6 +364,10 @@ fn competition_error(err: &competition::Error) -> &'static str {
         competition::Error::Solver(solver::Error::Dto(_)) => "SolverDtoError",
         competition::Error::SubmissionError => "SubmissionError",
     }
+}
+
+pub fn deadline(deadline: &Deadline, timeouts: &Timeouts) {
+    tracing::debug!(?deadline, ?timeouts, "computed deadline");
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
# Description
Despite increasing the auction-solving share the average solving time for external solvers didn't increase. This PR adds a debug log that should allow us further pin down where the issue lies.

# Changes
<!-- List of detailed changes (how the change is accomplished) -->

- [x] Print deadline when it is computed

## How to test
Observe log statement locally.

## Related Issues
#2211 