### PR TITLE
[Hotfix] Extend solver engine request body limit

### DIFF
--- a/crates/solvers/src/api/mod.rs
+++ b/crates/solvers/src/api/mod.rs
@@ -8,6 +8,8 @@ use {
 
 mod routes;
 
+const REQUEST_BODY_LIMIT: usize = 10 * 1024 * 1024;
+
 pub struct Api {
     pub addr: SocketAddr,
     pub solver: Solver,
@@ -20,6 +22,9 @@ impl Api {
         shutdown: impl Future<Output = ()> + Send + 'static,
     ) -> Result<(), hyper::Error> {
         let app = axum::Router::new()
+            .layer(tower::ServiceBuilder::new().layer(
+                tower_http::limit::RequestBodyLimitLayer::new(REQUEST_BODY_LIMIT),
+            ))
             .route("/metrics", axum::routing::get(routes::metrics))
             .route("/healthz", axum::routing::get(routes::healthz))
             .route("/solve", axum::routing::post(routes::solve))


### PR DESCRIPTION
# Description
We are seeing 413 repsonses between the driver and solver engine in prod. Default limit seems to be 2MB ([docs](https://docs.rs/axum/latest/axum/extract/struct.DefaultBodyLimit.html))

# Changes
- [ ] Explicitly set the limit larger (10MB)

## How to test
No longer see 413 errors in shadow