### PR TITLE
Fix notify dto

### DIFF
--- a/crates/driver/src/infra/solver/dto/notification.rs
+++ b/crates/driver/src/infra/solver/dto/notification.rs
@@ -89,6 +89,7 @@ impl Notification {
 pub struct Notification {
     auction_id: Option<String>,
     solution_id: Option<u64>,
+    #[serde(flatten)]
     kind: Kind,
 }
 

--- a/crates/driver/src/infra/solver/mod.rs
+++ b/crates/driver/src/infra/solver/mod.rs
@@ -203,7 +203,9 @@ impl Solver {
             req = req.header("X-REQUEST-ID", id);
         }
         let future = async move {
-            let _ = util::http::send(SOLVER_RESPONSE_MAX_BYTES, req).await;
+            if let Err(error) = util::http::send(SOLVER_RESPONSE_MAX_BYTES, req).await {
+                tracing::warn!(?error, "failed to notify solver");
+            }
         };
         tokio::task::spawn(future.in_current_span());
     }

--- a/crates/solvers/Cargo.toml
+++ b/crates/solvers/Cargo.toml
@@ -36,7 +36,7 @@ thiserror = "1"
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "signal", "time"] }
 toml = "0.7"
 tower = "0.4"
-tower-http = { version = "0.4", features = ["trace"] }
+tower-http = { version = "0.4", features = ["limit", "trace"] }
 web3 = "0.19"
 
 # TODO Once solvers are ported and E2E tests set up, slowly migrate code and

--- a/crates/solvers/src/api/routes/notify/dto/notification.rs
+++ b/crates/solvers/src/api/routes/notify/dto/notification.rs
@@ -98,7 +98,7 @@ impl Notification {
 
 #[serde_as]
 #[derive(Debug, Deserialize)]
-#[serde(rename_all = "camelCase", deny_unknown_fields)]
+#[serde(rename_all = "camelCase")]
 pub struct Notification {
     #[serde_as(as = "Option<DisplayFromStr>")]
     auction_id: Option<i64>,


### PR DESCRIPTION
# Description
Notification calls from the driver to solver engines are currently failing due to:

> Failed to deserialize the JSON body into the target type: invalid type: map, expected variant identifier at line 1 column 143

I broke this with #2192 where I missed adding the flatten directive on the driver dto.

# Changes
- [x] Fix dto on both sides (we can no longer deny_unknow_fields due to this [serde bug](https://github.com/serde-rs/serde/issues/1600))
- [x] Warn if the notify call is not successful

## How to test
Run e.g. the partial fill colocation test case. See warning before adjusting the dto and now no longer see it.
