### PR TITLE
[Trivial] Fix timeout panic

### DIFF
--- a/crates/driver/src/infra/solver/mod.rs
+++ b/crates/driver/src/infra/solver/mod.rs
@@ -163,7 +163,7 @@ impl Solver {
             .client
             .post(url.clone())
             .body(body)
-            .timeout(auction.deadline().solvers().remaining().unwrap());
+            .timeout(auction.deadline().solvers().remaining().unwrap_or_default());
         if let Some(id) = observe::request_id::get_task_local_storage() {
             req = req.header("X-REQUEST-ID", id);
         }


### PR DESCRIPTION
# Description
We are seeing panics in barn upon unwrapping the deadline when sending the requests to solver. We shouldn't panic if the time is up.

# Changes
- [x] use default zero duration in case `remaining()` errors (which means deadline exceeded)

## How to test
Observe no more panics in barn