### PR TITLE
Fix deadline

### DIFF
--- a/crates/driver/src/domain/competition/auction.rs
+++ b/crates/driver/src/domain/competition/auction.rs
@@ -1,5 +1,5 @@
 use {
-    super::{order, Score},
+    super::{order, Order, Score},
     crate::{
         domain::{
             competition::{self, auction},
@@ -119,7 +119,7 @@ pub struct AuctionProcessor(Arc<Mutex<Inner>>);
 
 struct Inner {
     auction: auction::Id,
-    fut: Shared<BoxFuture<'static, Arc<Auction>>>,
+    fut: Shared<BoxFuture<'static, Vec<Order>>>,
     eth: Arc<infra::Ethereum>,
 }
 
@@ -129,7 +129,14 @@ type Balances = HashMap<BalanceGroup, order::SellAmount>;
 impl AuctionProcessor {
     /// Prioritize well priced and filter out unfillable orders from the given
     /// auction.
-    pub fn prioritize(&self, mut auction: Auction) -> Shared<BoxFuture<'static, Arc<Auction>>> {
+    pub async fn prioritize(&self, auction: Auction) -> Auction {
+        Auction {
+            orders: self.prioritize_orders(&auction).await,
+            ..auction
+        }
+    }
+
+    fn prioritize_orders(&self, auction: &Auction) -> Shared<BoxFuture<'static, Vec<Order>>> {
         let new_id = auction
             .id()
             .expect("auctions used for quoting do not have to be prioritized");
@@ -146,16 +153,19 @@ impl AuctionProcessor {
 
         let eth = lock.eth.clone();
         let rt = tokio::runtime::Handle::current();
+        let tokens: Tokens = auction.tokens().clone();
+        let mut orders = auction.orders.clone();
+
         // Use spawn_blocking() because a lot of CPU bound computations are happening
         // and we don't want to block the runtime for too long.
         let fut = tokio::task::spawn_blocking(move || {
             let start = std::time::Instant::now();
-            Self::sort(&mut auction);
+            Self::sort(&mut orders, tokens);
             let mut balances =
-                rt.block_on(async { Self::fetch_balances(&eth, &auction.orders).await });
-            Self::filter_orders(&mut balances, &mut auction.orders, &eth);
+                rt.block_on(async { Self::fetch_balances(&eth, &orders).await });
+            Self::filter_orders(&mut balances, &mut orders, &eth);
             tracing::debug!(auction_id = new_id.0, time =? start.elapsed(), "auction preprocessing done");
-            Arc::new(auction)
+            orders
         })
         .map(|res| {
             res.expect(
@@ -175,8 +185,8 @@ impl AuctionProcessor {
 
     /// Sort orders based on their price achievability using the reference
     /// prices contained in the auction (in the money first).
-    fn sort(auction: &mut Auction) {
-        auction.orders.sort_by_cached_key(|order| {
+    fn sort(orders: &mut Vec<order::Order>, tokens: Tokens) {
+        orders.sort_by_cached_key(|order| {
             // Market orders are preferred over limit orders, as the expectation is that
             // they should be immediately fulfillable. Liquidity orders come last, as they
             // are the most niche and rarely used.
@@ -189,7 +199,7 @@ impl AuctionProcessor {
                 class,
                 // If the orders are of the same kind, then sort by likelihood of fulfillment
                 // based on token prices.
-                order.likelihood(&auction.tokens),
+                order.likelihood(&tokens),
             ))
         });
     }
@@ -341,7 +351,7 @@ impl AuctionProcessor {
 }
 
 /// The tokens that are used in an auction.
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Clone)]
 pub struct Tokens(HashMap<eth::TokenAddress, Token>);
 
 impl Tokens {

--- a/crates/driver/src/domain/competition/auction.rs
+++ b/crates/driver/src/domain/competition/auction.rs
@@ -185,7 +185,7 @@ impl AuctionProcessor {
 
     /// Sort orders based on their price achievability using the reference
     /// prices contained in the auction (in the money first).
-    fn sort(orders: &mut Vec<order::Order>, tokens: Tokens) {
+    fn sort(orders: &mut [order::Order], tokens: Tokens) {
         orders.sort_by_cached_key(|order| {
             // Market orders are preferred over limit orders, as the expectation is that
             // they should be immediately fulfillable. Liquidity orders come last, as they

--- a/crates/driver/src/tests/cases/mod.rs
+++ b/crates/driver/src/tests/cases/mod.rs
@@ -5,6 +5,7 @@ pub mod example_config;
 pub mod fees;
 pub mod internalization;
 pub mod merge_settlements;
+pub mod multiple_drivers;
 pub mod multiple_solutions;
 pub mod negative_scores;
 pub mod order_prioritization;

--- a/crates/driver/src/tests/cases/multiple_drivers.rs
+++ b/crates/driver/src/tests/cases/multiple_drivers.rs
@@ -1,0 +1,18 @@
+//! Test that driver properly works when running multiple instances.
+
+use crate::tests::setup::{ab_order, ab_pool, ab_solution, setup, solver};
+
+#[tokio::test]
+#[ignore]
+async fn separate_deadline() {
+    let test = setup()
+        .pool(ab_pool())
+        .order(ab_order())
+        .solution(ab_solution())
+        .solver(solver().name("second").solving_time_share(0.5))
+        .done()
+        .await;
+
+    test.solve().await.ok();
+    test.solve_with_solver("second").await.ok();
+}

--- a/crates/driver/src/tests/cases/multiple_drivers.rs
+++ b/crates/driver/src/tests/cases/multiple_drivers.rs
@@ -1,6 +1,6 @@
 //! Test that driver properly works when running multiple instances.
 
-use crate::tests::setup::{ab_order, ab_pool, ab_solution, setup, solver};
+use crate::tests::setup::{ab_order, ab_pool, ab_solution, setup, test_solver};
 
 #[tokio::test]
 #[ignore]
@@ -9,7 +9,7 @@ async fn separate_deadline() {
         .pool(ab_pool())
         .order(ab_order())
         .solution(ab_solution())
-        .solver(solver().name("second").solving_time_share(0.5))
+        .solver(test_solver().name("second").solving_time_share(0.5))
         .done()
         .await;
 

--- a/crates/driver/src/tests/setup/driver.rs
+++ b/crates/driver/src/tests/setup/driver.rs
@@ -203,6 +203,8 @@ async fn create_config_file(
                absolute-slippage = "{}"
                relative-slippage = "{}"
                account = "0x{}"
+               solving-share-of-deadline = {}
+               http-time-buffer = "{}ms"
                "#,
             solver.name,
             addr,
@@ -213,6 +215,8 @@ async fn create_config_file(
                 .unwrap_or_default(),
             solver.slippage.relative,
             hex::encode(solver.private_key.secret_bytes()),
+            solver.timeouts.solving_share_of_deadline.get(),
+            solver.timeouts.http_delay.num_milliseconds(),
         )
         .unwrap();
     }

--- a/crates/driver/src/tests/setup/mod.rs
+++ b/crates/driver/src/tests/setup/mod.rs
@@ -268,6 +268,23 @@ impl Solver {
     fn address(&self) -> eth::H160 {
         self.private_key.public_address()
     }
+
+    pub fn name(self, name: &str) -> Self {
+        Self {
+            name: name.to_owned(),
+            ..self
+        }
+    }
+
+    pub fn solving_time_share(self, share: f64) -> Self {
+        Self {
+            timeouts: infra::solver::Timeouts {
+                solving_share_of_deadline: share.try_into().unwrap(),
+                ..self.timeouts
+            },
+            ..self
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -517,6 +534,11 @@ impl Setup {
     /// Add a solution to be returned by the mock solver.
     pub fn solution(mut self, solution: Solution) -> Self {
         self.solutions.push(solution);
+        self
+    }
+
+    pub fn solver(mut self, solver: Solver) -> Self {
+        self.solvers.push(solver);
         self
     }
 


### PR DESCRIPTION
# Description
For performance reason we use a future that is shared across requests for different solver engine instances when prioritising orders. However, this future returns the entire auction instead of just the list of orders. This means that other aspects of the auction, such as deadline are also shared across solver instances.

This leads to solver engines that are configured with a specific deadline to sometimes receive auctions with deadlines that are configured for a different solver engine.

# Changes
- [x] Only share list of orders in the future (not the entire auction)

## How to test
Added an integration test, which is failing before that change

## Related Issues

Fixes #2211