### PR TITLE
Implement Display for logging arguments

### DIFF
--- a/crates/refunder/src/arguments.rs
+++ b/crates/refunder/src/arguments.rs
@@ -82,6 +82,7 @@ impl std::fmt::Display for Arguments {
 
         write!(f, "{}", http_client)?;
         write!(f, "{}", ethrpc)?;
+        write!(f, "{}", logging)?;
         writeln!(f, "min_validity_duration: {:?}", min_validity_duration)?;
         writeln!(f, "min_slippage_bps: {}", min_slippage_bps)?;
         let _intentionally_ignored = db_url;
@@ -92,8 +93,6 @@ impl std::fmt::Display for Arguments {
         let _intentionally_ignored = refunder_pk;
         writeln!(f, "refunder_pk: SECRET")?;
         writeln!(f, "metrics_port: {}", metrics_port)?;
-        writeln!(f, "log_filter: {}", logging.log_filter)?;
-        writeln!(f, "log_stderr_threshold: {}", logging.log_stderr_threshold)?;
         Ok(())
     }
 }

--- a/crates/shared/src/arguments.rs
+++ b/crates/shared/src/arguments.rs
@@ -36,6 +36,19 @@ macro_rules! logging_args_with_default_filter {
             #[clap(long, env, default_value = "error")]
             pub log_stderr_threshold: LevelFilter,
         }
+
+        impl ::std::fmt::Display for $struct_name {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                let Self {
+                    log_filter,
+                    log_stderr_threshold,
+                } = self;
+
+                writeln!(f, "log_filter: {}", log_filter)?;
+                writeln!(f, "log_stderr_threshold: {}", log_stderr_threshold)?;
+                Ok(())
+            }
+        }
     };
 }
 
@@ -459,8 +472,7 @@ impl Display for Arguments {
         write!(f, "{}", ethrpc)?;
         write!(f, "{}", current_block)?;
         write!(f, "{}", tenderly)?;
-        writeln!(f, "log_filter: {}", logging.log_filter)?;
-        writeln!(f, "log_stderr_threshold: {}", logging.log_stderr_threshold)?;
+        write!(f, "{}", logging)?;
         writeln!(f, "node_url: {}", node_url)?;
         writeln!(f, "graph_api_base_url: {}", graph_api_base_url)?;
         display_option(f, "chain_id", chain_id)?;


### PR DESCRIPTION
# Description

Reduce code repetition by implementing `Display` on the logging argument rather than printing out each field of the struct each time.

# Changes

- New `Display` implementation
- Removed custom printout on base `Display` implementation

## How to test

Run something with just default arguments, for example:

<details><summary>cargo run --bin autopilot</summary>

```
2024-01-03T10:35:41.879Z  INFO autopilot::run: running autopilot with validated arguments:
ethrpc_max_batch_size: 100
ethrpc_max_concurrent_requests: 10
ethrpc_batch_delay: 0ns
block_stream_poll_interval: 5s
tenderly_user: None
tenderly_project: None
tenderly_api_key: None
log_filter: warn,autopilot=debug,driver=debug,orderbook=debug,solver=debug,shared=debug
log_stderr_threshold: error
node_url: http://localhost:8545/
[...]
```
</details>