### PR TITLE
Enforce timeout for DEX solver price estimators

### DIFF
--- a/crates/driver/src/boundary/liquidity/zeroex.rs
+++ b/crates/driver/src/boundary/liquidity/zeroex.rs
@@ -18,7 +18,7 @@ pub async fn collector(
         http_timeout: config.http_timeout,
     });
     let api = Arc::new(DefaultZeroExApi::new(
-        http_client_factory,
+        http_client_factory.builder(),
         config.base_url.clone(),
         config.api_key.clone(),
         blocks,

--- a/crates/shared/src/trade_finding.rs
+++ b/crates/shared/src/trade_finding.rs
@@ -16,6 +16,12 @@ use {
     thiserror::Error,
 };
 
+/// Returns the default time limit used for quoting with external co-located
+/// solvers.
+pub fn time_limit() -> chrono::Duration {
+    chrono::Duration::seconds(5)
+}
+
 /// Find a trade for a token pair.
 ///
 /// This is similar to the `PriceEstimating` interface, but it expects calldata

--- a/crates/shared/src/trade_finding/external.rs
+++ b/crates/shared/src/trade_finding/external.rs
@@ -42,7 +42,7 @@ impl ExternalTradeFinder {
     /// Queries the `/quote` endpoint of the configured driver and deserializes
     /// the result into a Quote or Trade.
     async fn shared_query(&self, query: &Query) -> Result<Trade, TradeError> {
-        let deadline = chrono::Utc::now() + Self::time_limit();
+        let deadline = chrono::Utc::now() + super::time_limit();
         let order = dto::Order {
             sell_token: query.sell_token,
             buy_token: query.buy_token,
@@ -96,12 +96,6 @@ impl ExternalTradeFinder {
             .shared(query.clone(), future.boxed())
             .await
             .map_err(TradeError::from)
-    }
-
-    /// Returns the default time limit used for quoting with external co-located
-    /// solvers.
-    fn time_limit() -> chrono::Duration {
-        chrono::Duration::seconds(5)
     }
 }
 

--- a/crates/solver/src/run.rs
+++ b/crates/solver/src/run.rs
@@ -290,7 +290,7 @@ pub async fn run(args: Arguments) {
 
     let zeroex_api = Arc::new(
         DefaultZeroExApi::new(
-            &http_factory,
+            http_factory.builder(),
             args.shared
                 .zeroex_url
                 .as_deref()


### PR DESCRIPTION
# Description
We are currently using the default HTTP timeout (10s) for non-external price estimators (1Inch, 0x, Paraswap, Balancer) which may lead to bad quote latencies in case their APIs are facing issues (cf. recent alerts)

# Changes
- [x] Lift `time_limit` method, which is used for external quoters to trade_estimation module
- [x] Change 0x constructor to work with ClientBuilders (so we can configure a manual timeout before)
- [x] Configure clients for DEX quoters with `time_limit()`

## How to test
We don't have unit tests covering this and usually third party APIs are much faster than this, so this is hard to test. Basically we expect to see a slight increase in worst case quote latency once deployed.
