### PR TITLE
Ethflow order events

### DIFF
--- a/crates/database/src/onchain_invalidations.rs
+++ b/crates/database/src/onchain_invalidations.rs
@@ -1,5 +1,11 @@
 use {
-    crate::{events::EventIndex, OrderUid, PgTransaction},
+    crate::{
+        events::EventIndex,
+        order_events::{insert_order_event, OrderEvent, OrderEventLabel},
+        OrderUid,
+        PgTransaction,
+    },
+    chrono::Utc,
     sqlx::{Executor, PgConnection},
 };
 
@@ -16,6 +22,15 @@ pub async fn insert_onchain_invalidations(
 ) -> Result<(), sqlx::Error> {
     for (index, event) in events {
         insert_onchain_invalidation(ex, index, event).await?;
+        insert_order_event(
+            ex,
+            &OrderEvent {
+                label: OrderEventLabel::Cancelled,
+                timestamp: Utc::now(),
+                order_uid: event.clone(),
+            },
+        )
+        .await?;
     }
     Ok(())
 }

--- a/crates/database/src/onchain_invalidations.rs
+++ b/crates/database/src/onchain_invalidations.rs
@@ -29,7 +29,7 @@ pub async fn insert_onchain_invalidations(
                 // It would be more correct to use the timestamp of the event's block, but passing
                 // this is more involved, and now() should be good enough.
                 timestamp: Utc::now(),
-                order_uid: event.clone(),
+                order_uid: *event,
             },
         )
         .await?;

--- a/crates/database/src/onchain_invalidations.rs
+++ b/crates/database/src/onchain_invalidations.rs
@@ -26,6 +26,8 @@ pub async fn insert_onchain_invalidations(
             ex,
             &OrderEvent {
                 label: OrderEventLabel::Cancelled,
+                // It would be more correct to use the timestamp of the event's block, but passing
+                // this is more involved, and now() should be good enough.
                 timestamp: Utc::now(),
                 order_uid: event.clone(),
             },

--- a/crates/database/src/orders.rs
+++ b/crates/database/src/orders.rs
@@ -111,7 +111,7 @@ pub async fn insert_orders_and_ignore_conflicts(
             ex,
             &OrderEvent {
                 label: OrderEventLabel::Created,
-                timestamp: Utc::now(),
+                timestamp: order.creation_timestamp,
                 order_uid: order.uid,
             },
         )

--- a/crates/database/src/orders.rs
+++ b/crates/database/src/orders.rs
@@ -2,6 +2,7 @@ use {
     crate::{
         auction::AuctionId,
         onchain_broadcasted_orders::OnchainOrderPlacementError,
+        order_events::{insert_order_event, OrderEvent, OrderEventLabel},
         Address,
         AppId,
         OrderUid,
@@ -106,6 +107,15 @@ pub async fn insert_orders_and_ignore_conflicts(
 ) -> Result<(), sqlx::Error> {
     for order in orders {
         insert_order_and_ignore_conflicts(ex, order).await?;
+        insert_order_event(
+            ex,
+            &OrderEvent {
+                label: OrderEventLabel::Created,
+                timestamp: Utc::now(),
+                order_uid: order.uid,
+            },
+        )
+        .await?;
     }
     Ok(())
 }

--- a/crates/e2e/tests/e2e/ethflow.rs
+++ b/crates/e2e/tests/e2e/ethflow.rs
@@ -191,7 +191,7 @@ async fn eth_flow_indexing_after_refund(web3: Web3) {
     // Check order events
     let events = crate::database::events_of_order(
         services.db(),
-        &dummy_order.uid(&onchain.contracts()).await,
+        &dummy_order.uid(onchain.contracts()).await,
     )
     .await;
     assert_eq!(events.first().unwrap().label, OrderEventLabel::Created);

--- a/crates/e2e/tests/e2e/ethflow.rs
+++ b/crates/e2e/tests/e2e/ethflow.rs
@@ -1,7 +1,6 @@
 use {
     anyhow::bail,
     autopilot::database::onchain_order_events::ethflow_events::WRAP_ALL_SELECTOR,
-    chrono::{TimeZone, Utc},
     contracts::{CoWSwapEthFlow, ERC20Mintable, WETH9},
     database::order_events::OrderEventLabel,
     e2e::{nodes::local_node::TestNodeApi, setup::*, tx, tx_value},
@@ -124,7 +123,7 @@ async fn eth_flow_indexing_after_refund(web3: Web3) {
     let mut onchain = OnchainComponents::deploy(web3.clone()).await;
 
     let [solver] = onchain.make_solvers(to_wei(2)).await;
-    let [refunder, trader, dummy_trader] = onchain.make_accounts(to_wei(2)).await;
+    let [trader, dummy_trader] = onchain.make_accounts(to_wei(2)).await;
     let [dai] = onchain
         .deploy_tokens_with_weth_uni_v2_pools(to_wei(DAI_PER_ETH * 1000), to_wei(1000))
         .await;
@@ -133,9 +132,7 @@ async fn eth_flow_indexing_after_refund(web3: Web3) {
     services.start_autopilot(vec![]);
     services.start_api(vec![]).await;
 
-    // Create an order that only exists to be refunded, which triggers an event in
-    // the eth-flow contract that is not included in the ABI of
-    // `CoWSwapOnchainOrders`.
+    // Create an order that only exists to be cancelled.
     let valid_to = timestamp_of_current_block_in_seconds(&web3).await.unwrap() + 60;
     let dummy_order = ExtendedEthFlowOrder::from_quote(
         &test_submit_quote(
@@ -153,14 +150,11 @@ async fn eth_flow_indexing_after_refund(web3: Web3) {
     .include_slippage_bps(300);
     sumbit_order(&dummy_order, dummy_trader.account(), onchain.contracts()).await;
     web3.api::<TestNodeApi<_>>()
-        .set_next_block_timestamp(
-            &Utc.timestamp_millis_opt((valid_to as i64 + 1) * 1_000)
-                .unwrap(),
-        )
+        .mine_pending_block()
         .await
-        .expect("Must be able to set block timestamp");
+        .unwrap();
     dummy_order
-        .mine_order_invalidation(refunder.account(), &onchain.contracts().ethflow)
+        .mine_order_invalidation(dummy_trader.account(), &onchain.contracts().ethflow)
         .await;
 
     // Create the actual order that should be picked up by the services and matched.


### PR DESCRIPTION
# Description
We are trying to collect events throughout the lifecycle of all orders for analytics and alerting reasons. It seems that we have missed native ETH flow orders (which get indexed inside the autopilot) leading to inconsistent lifecycles for some orders (e.g. missing creation or cancellation events)

# Changes

- [x] insert an order event when parsing onchain order creations
- [x] insert an order event when parsing onchain order invalidations

## How to test
Adjusted the ethflow e2e test