### PR TITLE
Consolidate NativeGasEstimators

### DIFF
--- a/crates/autopilot/src/run.rs
+++ b/crates/autopilot/src/run.rs
@@ -35,7 +35,6 @@ use {
         },
         baseline_solver::BaseTokens,
         fee_subsidy::{config::FeeSubsidyConfiguration, FeeSubsidizing},
-        gas_price::InstrumentedGasEstimator,
         http_client::HttpClientFactory,
         maintenance::{Maintaining, ServiceMaintenance},
         metrics::LivenessChecking,
@@ -434,16 +433,6 @@ pub async fn run(args: Arguments) {
     ));
     let mut maintainers: Vec<Arc<dyn Maintaining>> = vec![event_updater, Arc::new(db.clone())];
 
-    let gas_price_estimator = Arc::new(InstrumentedGasEstimator::new(
-        shared::gas_price_estimation::create_priority_estimator(
-            &http_factory,
-            &web3,
-            args.shared.gas_estimators.as_slice(),
-            args.shared.blocknative_api_key.clone(),
-        )
-        .await
-        .expect("failed to create gas price estimator"),
-    ));
     let liquidity_order_owners: HashSet<_> = args
         .order_quoting
         .liquidity_order_owners

--- a/crates/driver/src/boundary/mempool.rs
+++ b/crates/driver/src/boundary/mempool.rs
@@ -96,12 +96,7 @@ impl std::fmt::Display for Mempool {
 }
 
 impl Mempool {
-    pub fn new(
-        config: Config,
-        eth: Ethereum,
-        pool: GlobalTxPool,
-        gas_price_estimator: Arc<dyn GasPriceEstimating>,
-    ) -> Result<Self> {
+    pub fn new(config: Config, eth: Ethereum, pool: GlobalTxPool) -> Result<Self> {
         Ok(match &config.kind {
             Kind::Public(revert_protection) => Self {
                 submit_api: Arc::new(PublicMempoolApi::new(
@@ -112,14 +107,14 @@ impl Mempool {
                     matches!(revert_protection, RevertProtection::Enabled),
                 )),
                 submitted_transactions: pool.add_sub_pool(Strategy::PublicMempool),
-                gas_price_estimator,
+                gas_price_estimator: eth.boundary_gas_estimator(),
                 config,
                 eth,
             },
             Kind::MEVBlocker { url, .. } => Self {
                 submit_api: Arc::new(FlashbotsApi::new(reqwest::Client::new(), url.to_owned())?),
                 submitted_transactions: pool.add_sub_pool(Strategy::Flashbots),
-                gas_price_estimator,
+                gas_price_estimator: eth.boundary_gas_estimator(),
                 config,
                 eth,
             },

--- a/crates/driver/src/infra/blockchain/mod.rs
+++ b/crates/driver/src/infra/blockchain/mod.rs
@@ -12,6 +12,8 @@ pub mod contracts;
 pub mod gas;
 pub mod token;
 
+use gas_estimation::GasPriceEstimating;
+
 pub use self::{contracts::Contracts, gas::GasPriceEstimator};
 
 /// An Ethereum RPC connection.
@@ -144,6 +146,10 @@ impl Ethereum {
         let access_list: web3::types::AccessList =
             serde_json::from_value(json.get("accessList").unwrap().to_owned()).unwrap();
         Ok(access_list.into())
+    }
+
+    pub fn boundary_gas_estimator(&self) -> Arc<dyn GasPriceEstimating> {
+        self.gas.gas.clone()
     }
 
     /// Estimate gas used by a transaction.

--- a/crates/driver/src/run.rs
+++ b/crates/driver/src/run.rs
@@ -15,7 +15,7 @@ use {
         },
     },
     clap::Parser,
-    futures::future::join_all,
+    shared::http_client::HttpClientFactory,
     std::{net::SocketAddr, sync::Arc, time::Duration},
     tokio::sync::oneshot,
 };
@@ -51,6 +51,18 @@ async fn run_with(args: cli::Args, addr_sender: Option<oneshot::Sender<SocketAdd
     tracing::info!("running driver with {config:#?}");
 
     let (shutdown_sender, shutdown_receiver) = tokio::sync::oneshot::channel();
+    let gas_price_estimator = Arc::new(
+        shared::gas_price_estimation::create_priority_estimator(
+            &HttpClientFactory::new(&shared::http_client::Arguments {
+                http_timeout: std::time::Duration::from_secs(10),
+            }),
+            ethrpc.web3(),
+            &[shared::gas_price_estimation::GasEstimatorType::Native],
+            None,
+        )
+        .await
+        .unwrap(),
+    );
     let eth = ethereum(&config, ethrpc).await;
     let tx_pool = mempool::GlobalTxPool::default();
     let serve = Api {
@@ -58,16 +70,19 @@ async fn run_with(args: cli::Args, addr_sender: Option<oneshot::Sender<SocketAdd
         liquidity: liquidity(&config, &eth).await,
         simulator: simulator(&config, &eth),
         mempools: Mempools::new(
-            join_all(
-                config
-                    .mempools
-                    .iter()
-                    .map(|mempool| Mempool::new(mempool.to_owned(), eth.clone(), tx_pool.clone())),
-            )
-            .await
-            .into_iter()
-            .flatten()
-            .collect(),
+            config
+                .mempools
+                .iter()
+                .map(|mempool| {
+                    Mempool::new(
+                        mempool.to_owned(),
+                        eth.clone(),
+                        tx_pool.clone(),
+                        gas_price_estimator.clone(),
+                    )
+                    .unwrap()
+                })
+                .collect(),
         )
         .unwrap(),
         eth,


### PR DESCRIPTION
# Description
We are seeing some issues with `eth_feeHistory` requests timing out. It turns out that both autopilot as well as driver are each creating two instances of the NativeGasEstimator which is making these calls. These instances can be shared within the pod to reduce this type of request.

# Changes

- [x] Share gas estimator instance in autopilot
- [x] Share gas estimator instance in driver

## How to test
CI