### PR TITLE
Add Request ID header to quote requests for easier debugging

### DIFF
--- a/crates/shared/src/oneinch_api.rs
+++ b/crates/shared/src/oneinch_api.rs
@@ -598,6 +598,9 @@ where
             block_stream.borrow().hash.to_string(),
         );
     };
+    if let Some(id) = observe::request_id::get_task_local_storage() {
+        request = request.header("X-REQUEST-ID", id);
+    }
 
     let response = request.send().await?;
     let status_code = response.status();

--- a/crates/shared/src/paraswap_api.rs
+++ b/crates/shared/src/paraswap_api.rs
@@ -59,6 +59,9 @@ impl ParaswapApi for DefaultParaswapApi {
                 self.block_stream.borrow().hash.to_string(),
             );
         };
+        if let Some(id) = observe::request_id::get_task_local_storage() {
+            request = request.header("X-REQUEST-ID", id);
+        }
 
         let response = request.send().await?;
         let status = response.status();

--- a/crates/shared/src/paraswap_api.rs
+++ b/crates/shared/src/paraswap_api.rs
@@ -87,6 +87,9 @@ impl ParaswapApi for DefaultParaswapApi {
                 self.block_stream.borrow().hash.to_string(),
             );
         };
+        if let Some(id) = observe::request_id::get_task_local_storage() {
+            request = request.header("X-REQUEST-ID", id);
+        }
         let response = request.send().await?;
         let status = response.status();
         let response_text = response.text().await?;

--- a/crates/shared/src/zeroex_api.rs
+++ b/crates/shared/src/zeroex_api.rs
@@ -542,6 +542,9 @@ impl DefaultZeroExApi {
                     self.block_stream.borrow().hash.to_string(),
                 );
             };
+            if let Some(id) = observe::request_id::get_task_local_storage() {
+                request = request.header("X-REQUEST-ID", id);
+            }
 
             let response = request.send().await.map_err(ZeroExResponseError::Send)?;
 


### PR DESCRIPTION
# Description
It is a bit difficult to debug quote requests from our reverse proxy right now as the requests don't pass in the request id header used in our backend. This PR sets the `X-REQUEST-ID` header in the request so that it can be logged in nginx for easier debugging.

# Changes
- [x] Add request_id to oneinch, paraswap and zeroex requests
