### PR TITLE
Add workflow dispatch to docker build

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -3,6 +3,7 @@ on:
   push:
     branches: [main]
     tags: [v*]
+  workflow_dispatch:
 
 jobs:
   deploy:


### PR DESCRIPTION
# Description
This change will allow us to build arbitrary branches in the repo to test branches on staging before merge.

# Changes
- [x] Add workflow dispatch action to docker build

## How to test
1. Fork the repo
2. Go to actions > deploy > Run workflow
3. Example [here](https://github.com/ahhda/services/actions/runs/7476869122)
![Screenshot 2024-01-10 at 8 40 57 PM](https://github.com/cowprotocol/services/assets/7795956/201c0ff7-34c0-43e5-9fde-e02878957b28)
