### PR TITLE
Remove AuctionId::Centralized

### DIFF
--- a/crates/autopilot/src/database/auction_transaction.rs
+++ b/crates/autopilot/src/database/auction_transaction.rs
@@ -47,19 +47,4 @@ impl super::Postgres {
         )
         .await
     }
-
-    pub async fn get_auction_id(
-        &self,
-        tx_from: H160,
-        tx_nonce: i64,
-    ) -> Result<Option<i64>, sqlx::Error> {
-        let _timer = super::Metrics::get()
-            .database_queries
-            .with_label_values(&["get_auction_id"])
-            .start_timer();
-
-        let mut ex = self.pool.acquire().await?;
-        database::auction_transaction::get_auction_id(&mut ex, &ByteArray(tx_from.0), tx_nonce)
-            .await
-    }
 }

--- a/crates/autopilot/src/database/on_settlement_event_updater.rs
+++ b/crates/autopilot/src/database/on_settlement_event_updater.rs
@@ -9,6 +9,7 @@ use {
 
 /// Executed network fee for the gas costs. This fee is solver determined.
 type ExecutedFee = U256;
+pub type AuctionId = i64;
 
 #[derive(Debug, Default, Clone)]
 pub struct AuctionData {
@@ -18,40 +19,6 @@ pub struct AuctionData {
     pub surplus: U256,
     pub fee: U256,
     pub order_executions: Vec<(OrderUid, ExecutedFee)>,
-}
-
-#[derive(Debug, Clone)]
-pub enum AuctionId {
-    /// We were able to recover this ID from our DB which means that it was
-    /// submitted by us when the protocol was not yet using colocated
-    /// drivers. This ID can therefore be trusted.
-    Centralized(i64),
-    /// This ID had to be recovered from the calldata of a settlement call. That
-    /// means it was submitted by a colocated driver. Because these drivers
-    /// could submit a solution at any time and with wrong or malicious IDs
-    /// this can not be trusted. For DB updates that modify existing
-    /// data based on these IDs we have to ensure they can only be executed once
-    /// (the first time we see this ID). That is required to prevent
-    /// malicious drivers from overwriting data for already settled
-    /// auctions.
-    Colocated(i64),
-}
-
-impl AuctionId {
-    /// Returns the underlying `auction_id` assuming the caller verified that
-    /// the next DB update will not run into problems with this ID.
-    pub fn assume_verified(&self) -> i64 {
-        match &self {
-            Self::Centralized(id) => *id,
-            Self::Colocated(id) => *id,
-        }
-    }
-}
-
-impl Default for AuctionId {
-    fn default() -> Self {
-        Self::Colocated(0)
-    }
 }
 
 #[derive(Debug, Default, Clone)]
@@ -90,7 +57,7 @@ impl super::Postgres {
             // solutions.
             let insert_succesful = database::auction_transaction::try_insert_auction_transaction(
                 ex,
-                auction_data.auction_id.assume_verified(),
+                auction_data.auction_id,
                 &ByteArray(settlement_update.tx_from.0),
                 settlement_update.tx_nonce,
             )
@@ -113,12 +80,12 @@ impl super::Postgres {
             .await
             .context("insert_settlement_observations")?;
 
-            if insert_succesful || matches!(auction_data.auction_id, AuctionId::Centralized(_)) {
+            if insert_succesful {
                 for (order, executed_fee) in auction_data.order_executions {
                     database::order_execution::save(
                         ex,
                         &ByteArray(order.0),
-                        auction_data.auction_id.assume_verified(),
+                        auction_data.auction_id,
                         &u256_to_big_decimal(&executed_fee),
                     )
                     .await

--- a/crates/database/src/solver_competition.rs
+++ b/crates/database/src/solver_competition.rs
@@ -139,7 +139,7 @@ mod tests {
         .await
         .unwrap();
 
-        crate::auction_transaction::upsert_auction_transaction(&mut db, id, &tx_from, tx_nonce)
+        crate::auction_transaction::try_insert_auction_transaction(&mut db, id, &tx_from, tx_nonce)
             .await
             .unwrap();
 

--- a/crates/model/src/solver_competition.rs
+++ b/crates/model/src/solver_competition.rs
@@ -4,51 +4,8 @@ use {
     primitive_types::{H160, H256, U256},
     serde::{Deserialize, Serialize},
     serde_with::serde_as,
-    std::collections::{BTreeMap, HashSet},
+    std::collections::BTreeMap,
 };
-
-/// As a temporary measure the driver informs the api about per competition data
-/// that should be stored in the database. This goes to the api through an
-/// unlisted and authenticated http endpoint because we do not want the driver
-/// to have a database connection. Once autopilot is handling the competition
-/// this will no longer be needed.
-#[serde_as]
-#[derive(Clone, Debug, Default, Deserialize, Serialize)]
-pub struct Request {
-    pub auction: AuctionId,
-    pub transaction: Transaction,
-    pub competition: SolverCompetitionDB,
-    pub executions: Vec<(OrderUid, Execution)>,
-    pub scores: Scores,
-    pub participants: HashSet<H160>,  // solver addresses
-    pub prices: BTreeMap<H160, U256>, // external prices for auction
-}
-
-#[serde_as]
-#[derive(Clone, Debug, Default, Deserialize, Serialize)]
-pub struct Scores {
-    pub winner: H160,
-    #[serde_as(as = "HexOrDecimalU256")]
-    pub winning_score: U256,
-    #[serde_as(as = "HexOrDecimalU256")]
-    pub reference_score: U256,
-    pub block_deadline: u64,
-}
-
-#[derive(Clone, Debug, Default, Deserialize, Serialize)]
-pub struct Transaction {
-    pub account: H160,
-    pub nonce: u64,
-}
-
-#[serde_as]
-#[derive(Clone, Debug, Default, Deserialize, Serialize)]
-pub struct Execution {
-    #[serde_as(as = "Option<HexOrDecimalU256>")]
-    pub surplus_fee: Option<U256>,
-    #[serde_as(as = "HexOrDecimalU256")]
-    pub scoring_fee: U256,
-}
 
 /// Stored directly in the database and turned into SolverCompetitionAPI for the
 /// `/solver_competition` endpoint.
@@ -101,16 +58,6 @@ pub struct SolverSettlement {
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde_as(as = "Option<BytesHex>")]
     pub uninternalized_call_data: Option<Vec<u8>>,
-}
-
-#[derive(Clone, Debug, Default, Deserialize, Serialize, PartialEq)]
-#[serde(rename_all = "camelCase")]
-pub struct Objective {
-    pub total: f64,
-    pub surplus: f64,
-    pub fees: f64,
-    pub cost: f64,
-    pub gas: u64,
 }
 
 #[serde_as]

--- a/crates/orderbook/src/solver_competition.rs
+++ b/crates/orderbook/src/solver_competition.rs
@@ -17,9 +17,6 @@ pub enum Identifier {
 #[cfg_attr(test, mockall::automock)]
 #[async_trait::async_trait]
 pub trait SolverCompetitionStoring: Send + Sync {
-    /// Saves a new solver competition entry.
-    async fn handle_request(&self, request: model::solver_competition::Request) -> Result<()>;
-
     /// Retrieves a solver competition entry by ID.
     ///
     /// Returns a `NotFound` error if no solver competition with that ID could

--- a/crates/solver/src/driver/solver_settlements.rs
+++ b/crates/solver/src/driver/solver_settlements.rs
@@ -1,5 +1,6 @@
 use {
-    crate::{driver::solver_competition::Score, settlement::Settlement},
+    crate::settlement::Settlement,
+    model::solver_competition::Score,
     num::BigRational,
     primitive_types::U256,
 };

--- a/crates/solver/src/run.rs
+++ b/crates/solver/src/run.rs
@@ -548,11 +548,6 @@ pub async fn run(args: Arguments) {
         http_factory.create(),
         args.shared.solver_competition_auth.clone(),
     );
-    let network_time_between_blocks = args
-        .shared
-        .network_block_interval
-        .or_else(|| shared::network::block_interval(&network_id, chain_id))
-        .expect("unknown network block interval");
 
     let balance_fetcher = account_balances::fetcher(
         &web3,
@@ -576,8 +571,6 @@ pub async fn run(args: Arguments) {
         web3,
         network_id,
         args.solver_time_limit,
-        network_time_between_blocks,
-        args.additional_mining_deadline,
         args.skip_non_positive_score_settlements,
         current_block_stream.clone(),
         solution_submitter,


### PR DESCRIPTION
# Description
Further simplifies `OnSettlementEventUpdater` -> removes AuctionId::Centralized variant as we no longer expect for this component to ever reindex events from before colocation activation.

Also led to cleaning up the unused functions for `auction_transaction` table.
Which again led to cleaning up the solver competition model.