### PR TITLE
Notify solvers on post-processing timed out

### DIFF
--- a/crates/driver/src/domain/competition/mod.rs
+++ b/crates/driver/src/domain/competition/mod.rs
@@ -131,7 +131,8 @@ impl Competition {
         .await
         .is_err()
         {
-            observe::postprocessing_timed_out(&settlements)
+            observe::postprocessing_timed_out(&settlements);
+            notify::postprocessing_timed_out(&self.solver, auction.id())
         }
 
         // Score the settlements.

--- a/crates/driver/src/infra/notify/mod.rs
+++ b/crates/driver/src/infra/notify/mod.rs
@@ -138,3 +138,7 @@ pub fn duplicated_solution_id(
         notification::Kind::DuplicatedSolutionId,
     );
 }
+
+pub fn postprocessing_timed_out(solver: &Solver, auction_id: Option<auction::Id>) {
+    solver.notify(auction_id, None, notification::Kind::PostprocessingTimedOut);
+}

--- a/crates/driver/src/infra/notify/notification.rs
+++ b/crates/driver/src/infra/notify/notification.rs
@@ -43,6 +43,8 @@ pub enum Kind {
     /// Some aspect of the driver logic failed preventing the solution from
     /// participating in the auction.
     DriverError(String),
+    /// On-chain solution postprocessing timed out.
+    PostprocessingTimedOut,
 }
 
 #[derive(Debug)]

--- a/crates/driver/src/infra/solver/dto/notification.rs
+++ b/crates/driver/src/infra/solver/dto/notification.rs
@@ -78,6 +78,7 @@ impl Notification {
                     notify::Settlement::SimulationRevert => Kind::Cancelled,
                     notify::Settlement::Fail => Kind::Fail,
                 },
+                notify::Kind::PostprocessingTimedOut => Kind::PostprocessingTimedOut,
             },
         }
     }
@@ -141,6 +142,7 @@ pub enum Kind {
     },
     Cancelled,
     Fail,
+    PostprocessingTimedOut,
 }
 
 type BlockNo = u64;

--- a/crates/shared/src/http_solver/model.rs
+++ b/crates/shared/src/http_solver/model.rs
@@ -491,6 +491,9 @@ pub enum SolverRejectionReason {
 
     /// Some aspect of the driver logic failed.
     Driver(String),
+
+    /// On-chain solution postprocessing timed out.
+    PostprocessingTimedOut,
 }
 
 #[derive(Debug, Serialize)]

--- a/crates/solvers/openapi.yml
+++ b/crates/solvers/openapi.yml
@@ -56,7 +56,7 @@ paths:
                   description: |
                     The kind of notification.
                   type: string
-                  enum: [Timeout, EmptySolution, DuplicatedSolutionId, SimulationFailed, ZeroScore, ScoreHigherThanQuality, SuccessProbabilityOutOfRange, ObjectiveValueNonPositive, NonBufferableTokensUsed, SolverAccountInsufficientBalance, Success, Revert, Cancelled, Failed]
+                  enum: [Timeout, EmptySolution, DuplicatedSolutionId, SimulationFailed, ZeroScore, ScoreHigherThanQuality, SuccessProbabilityOutOfRange, ObjectiveValueNonPositive, NonBufferableTokensUsed, SolverAccountInsufficientBalance, Success, Revert, Cancelled, Failed, PostprocessingTimedOut]
       responses:
         200:
           description: notification successfully received.

--- a/crates/solvers/src/api/routes/notify/dto/notification.rs
+++ b/crates/solvers/src/api/routes/notify/dto/notification.rs
@@ -91,6 +91,7 @@ impl Notification {
                     notification::Kind::Settled(notification::Settlement::SimulationRevert)
                 }
                 Kind::Fail => notification::Kind::Settled(notification::Settlement::Fail),
+                Kind::PostprocessingTimedOut => notification::Kind::PostprocessingTimedOut,
             },
         }
     }
@@ -155,6 +156,7 @@ pub enum Kind {
     },
     Cancelled,
     Fail,
+    PostprocessingTimedOut,
 }
 
 type BlockNo = u64;

--- a/crates/solvers/src/boundary/legacy.rs
+++ b/crates/solvers/src/boundary/legacy.rs
@@ -656,6 +656,9 @@ fn to_boundary_auction_result(notification: &notification::Notification) -> (i64
         Kind::DriverError(reason) => {
             AuctionResult::Rejected(SolverRejectionReason::Driver(reason.clone()))
         }
+        Kind::PostprocessingTimedOut => {
+            AuctionResult::Rejected(SolverRejectionReason::PostprocessingTimedOut)
+        }
     };
 
     (auction_id, auction_result)

--- a/crates/solvers/src/domain/notification.rs
+++ b/crates/solvers/src/domain/notification.rs
@@ -35,6 +35,7 @@ pub enum Kind {
     SolverAccountInsufficientBalance(RequiredEther),
     Settled(Settlement),
     DriverError(String),
+    PostprocessingTimedOut,
 }
 
 /// The result of winning solver trying to settle the transaction onchain.


### PR DESCRIPTION
# Description
`Seasolver` reported that some solutions were rejected for no visible reason. It turned out that if post-processing is timed out, we currently don't notify solvers about that.

# Changes

Notify solvers on post-processing timed out.

## How to test
TBD