### PR TITLE
Add personal access token to release action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,8 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 0 # Fetch all history for all branches and tags
+          # Requires "Read and Write access to code" permission
+          token: ${{ secrets.RELEASE_ACTION_ACCESS_TOKEN }}
 
       - name: Create Tag
         id: tag_version
@@ -29,8 +31,6 @@ jobs:
           NEW_MINOR=$((MINOR+1))
           NEW_TAG="${MAJOR}.${NEW_MINOR}.0"
           echo ::set-output name=tag::$NEW_TAG
-          git config --local user.email "action@github.com"
-          git config --local user.name "GitHub Action"
           git tag $NEW_TAG
           git push origin --tags
 


### PR DESCRIPTION
# Description
The automated release action didn't trigger a deployment job, because

> When you use GITHUB_TOKEN in your actions, all of the interactions with the repository are on behalf of the Github-actions bot. The operations act by Github-actions bot cannot trigger a new workflow run.

# Changes
- [X] use a personal access token instead of the github access token which triggers the build.

## How to test
Test Repository: https://github.com/fleupold/weekly-release-action/actions
