### PR TITLE
Rename `priceImprovement` to `Surplus`

### DIFF
--- a/crates/autopilot/src/arguments.rs
+++ b/crates/autopilot/src/arguments.rs
@@ -347,15 +347,15 @@ impl std::fmt::Display for Arguments {
 pub struct FeePolicy {
     /// Type of fee policy to use. Examples:
     ///
-    /// - Price improvement without cap
-    /// price_improvement:0.5:1.0
+    /// - Surplus without cap
+    /// surplus:0.5:1.0
     ///
-    /// - Price improvement with cap:
-    /// price_improvement:0.5:0.06
+    /// - Surplus with cap:
+    /// surplus:0.5:0.06
     ///
     /// - Volume based:
     /// volume:0.1
-    #[clap(long, env, default_value = "priceImprovement:0.0:1.0")]
+    #[clap(long, env, default_value = "surplus:0.0:1.0")]
     pub fee_policy_kind: FeePolicyKind,
 
     /// Should protocol fees be collected or skipped for orders whose
@@ -368,10 +368,10 @@ pub struct FeePolicy {
 impl FeePolicy {
     pub fn to_domain(self) -> domain::fee::Policy {
         match self.fee_policy_kind {
-            FeePolicyKind::PriceImprovement {
+            FeePolicyKind::Surplus {
                 factor,
                 max_volume_factor,
-            } => domain::fee::Policy::PriceImprovement {
+            } => domain::fee::Policy::Surplus {
                 factor,
                 max_volume_factor,
             },
@@ -382,9 +382,8 @@ impl FeePolicy {
 
 #[derive(clap::Parser, Debug, Clone)]
 pub enum FeePolicyKind {
-    /// How much of the order's price improvement over max(limit price,
-    /// best_bid) should be taken as a protocol fee.
-    PriceImprovement { factor: f64, max_volume_factor: f64 },
+    /// How much of the order's surplus should be taken as a protocol fee.
+    Surplus { factor: f64, max_volume_factor: f64 },
     /// How much of the order's volume should be taken as a protocol fee.
     Volume { factor: f64 },
 }
@@ -396,18 +395,18 @@ impl FromStr for FeePolicyKind {
         let mut parts = s.split(':');
         let kind = parts.next().ok_or("missing fee policy kind")?;
         match kind {
-            "priceImprovement" => {
+            "surplus" => {
                 let factor = parts
                     .next()
-                    .ok_or("missing price improvement factor")?
+                    .ok_or("missing surplus factor")?
                     .parse::<f64>()
-                    .map_err(|e| format!("invalid price improvement factor: {}", e))?;
+                    .map_err(|e| format!("invalid surplus factor: {}", e))?;
                 let max_volume_factor = parts
                     .next()
                     .ok_or("missing max volume factor")?
                     .parse::<f64>()
                     .map_err(|e| format!("invalid max volume factor: {}", e))?;
-                Ok(Self::PriceImprovement {
+                Ok(Self::Surplus {
                     factor,
                     max_volume_factor,
                 })

--- a/crates/autopilot/src/domain/fee/mod.rs
+++ b/crates/autopilot/src/domain/fee/mod.rs
@@ -63,19 +63,17 @@ impl ProtocolFee {
 
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub enum Policy {
-    /// If the order receives more than expected (positive deviation from
-    /// quoted amounts) pay the protocol a factor of the achieved
-    /// improvement. The fee is taken in `sell` token for `buy`
-    /// orders and in `buy` token for `sell` orders.
-    PriceImprovement {
-        /// Factor of price improvement the protocol charges as a fee.
-        /// Price improvement is the difference between executed price and
-        /// limit price or quoted price (whichever is better)
+    /// If the order receives more than limit price, take the protocol fee as a
+    /// percentage of the difference. The fee is taken in `sell` token for
+    /// `buy` orders and in `buy` token for `sell` orders.
+    Surplus {
+        /// Factor of surplus the protocol charges as a fee.
+        /// Surplus is the difference between executed price and limit price
         ///
-        /// E.g. if a user received 2000USDC for 1ETH while having been
-        /// quoted 1990USDC, their price improvement is 10USDC.
-        /// A factor of 0.5 requires the solver to pay 5USDC to
-        /// the protocol for settling this order.
+        /// E.g. if a user received 2000USDC for 1ETH while having a limit price
+        /// of 1990USDC, their surplus is 10USDC. A factor of 0.5
+        /// requires the solver to pay 5USDC to the protocol for
+        /// settling this order.
         factor: f64,
         /// Cap protocol fee with a percentage of the order's volume.
         max_volume_factor: f64,

--- a/crates/autopilot/src/infra/persistence/dto/order.rs
+++ b/crates/autopilot/src/infra/persistence/dto/order.rs
@@ -270,7 +270,7 @@ impl From<boundary::EcdsaSignature> for domain::auction::order::EcdsaSignature {
 #[serde(rename_all = "camelCase")]
 pub enum FeePolicy {
     #[serde(rename_all = "camelCase")]
-    PriceImprovement { factor: f64, max_volume_factor: f64 },
+    Surplus { factor: f64, max_volume_factor: f64 },
     #[serde(rename_all = "camelCase")]
     Volume { factor: f64 },
 }
@@ -278,10 +278,10 @@ pub enum FeePolicy {
 impl From<domain::fee::Policy> for FeePolicy {
     fn from(policy: domain::fee::Policy) -> Self {
         match policy {
-            domain::fee::Policy::PriceImprovement {
+            domain::fee::Policy::Surplus {
                 factor,
                 max_volume_factor,
-            } => Self::PriceImprovement {
+            } => Self::Surplus {
                 factor,
                 max_volume_factor,
             },
@@ -293,10 +293,10 @@ impl From<domain::fee::Policy> for FeePolicy {
 impl From<FeePolicy> for domain::fee::Policy {
     fn from(policy: FeePolicy) -> Self {
         match policy {
-            FeePolicy::PriceImprovement {
+            FeePolicy::Surplus {
                 factor,
                 max_volume_factor,
-            } => Self::PriceImprovement {
+            } => Self::Surplus {
                 factor,
                 max_volume_factor,
             },

--- a/crates/driver/openapi.yml
+++ b/crates/driver/openapi.yml
@@ -418,16 +418,16 @@ components:
         The solver should make sure the fee policy is applied when computing their solution.
       type: object
       oneOf:
-        - $ref: "#/components/schemas/PriceImprovementFee"
+        - $ref: "#/components/schemas/SurplusFee"
         - $ref: "#/components/schemas/VolumeFee"
-    PriceImprovementFee:
+    SurplusFee:
       description: |
-        If the order receives more than expected (positive deviation from quoted amounts) pay the protocol a factor of the achieved improvement.
+        If the order receives more than limit price, pay the protocol a factor of the difference.
       type: object
       properties:
         kind:
           type: string
-          enum: ["priceImprovement"]
+          enum: ["surplus"]
         maxVolumeFactor:
           description: Never charge more than that percentage of the order volume.
           type: number

--- a/crates/driver/src/domain/competition/order/fees.rs
+++ b/crates/driver/src/domain/competition/order/fees.rs
@@ -1,16 +1,14 @@
 #[derive(Clone, Debug)]
 pub enum FeePolicy {
-    /// If the order receives more than expected (positive deviation from quoted
-    /// amounts) pay the protocol a factor of the achieved improvement.
-    /// The fee is taken in `sell` token for `buy` orders and in `buy`
-    /// token for `sell` orders.
-    PriceImprovement {
-        /// Factor of price improvement the protocol charges as a fee.
-        /// Price improvement is the difference between executed price and
-        /// limit price or quoted price (whichever is better)
+    /// If the order receives more than limit price, take the protocol fee as a
+    /// percentage of the difference. The fee is taken in `sell` token for
+    /// `buy` orders and in `buy` token for `sell` orders.
+    Surplus {
+        /// Factor of surplus the protocol charges as a fee.
+        /// Surplus is the difference between executed price and limit price
         ///
-        /// E.g. if a user received 2000USDC for 1ETH while having been quoted
-        /// 1990USDC, their price improvement is 10USDC. A factor of 0.5
+        /// E.g. if a user received 2000USDC for 1ETH while having a limit price
+        /// of 1990USDC, their surplus is 10USDC. A factor of 0.5
         /// requires the solver to pay 5USDC to the protocol for
         /// settling this order.
         factor: f64,

--- a/crates/driver/src/infra/api/routes/solve/dto/auction.rs
+++ b/crates/driver/src/infra/api/routes/solve/dto/auction.rs
@@ -119,10 +119,10 @@ impl Auction {
                         .fee_policies
                         .into_iter()
                         .map(|policy| match policy {
-                            FeePolicy::PriceImprovement {
+                            FeePolicy::Surplus {
                                 factor,
                                 max_volume_factor,
-                            } => competition::order::FeePolicy::PriceImprovement {
+                            } => competition::order::FeePolicy::Surplus {
                                 factor,
                                 max_volume_factor,
                             },
@@ -309,7 +309,7 @@ enum Class {
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 enum FeePolicy {
     #[serde(rename_all = "camelCase")]
-    PriceImprovement { factor: f64, max_volume_factor: f64 },
+    Surplus { factor: f64, max_volume_factor: f64 },
     #[serde(rename_all = "camelCase")]
     Volume { factor: f64 },
 }

--- a/crates/driver/src/tests/setup/driver.rs
+++ b/crates/driver/src/tests/setup/driver.rs
@@ -98,7 +98,7 @@ pub fn solve_req(test: &Test) -> serde_json::Value {
                 order::Kind::Market => json!([]),
                 order::Kind::Liquidity => json!([]),
                 order::Kind::Limit { .. } => json!([{
-                    "priceImprovement": {
+                    "surplus": {
                         "factor": 0.0,
                         "maxVolumeFactor": 0.06
                     }

--- a/crates/e2e/tests/e2e/protocol_fee.rs
+++ b/crates/e2e/tests/e2e/protocol_fee.rs
@@ -15,14 +15,14 @@ use {
 
 #[tokio::test]
 #[ignore]
-async fn local_node_price_improvement_fee_sell_order() {
-    run_test(price_improvement_fee_sell_order_test).await;
+async fn local_node_surplus_fee_sell_order() {
+    run_test(surplus_fee_sell_order_test).await;
 }
 
 #[tokio::test]
 #[ignore]
-async fn local_node_price_improvement_fee_sell_order_capped() {
-    run_test(price_improvement_fee_sell_order_capped_test).await;
+async fn local_node_surplus_fee_sell_order_capped() {
+    run_test(surplus_fee_sell_order_capped_test).await;
 }
 
 #[tokio::test]
@@ -33,14 +33,14 @@ async fn local_node_volume_fee_sell_order() {
 
 #[tokio::test]
 #[ignore]
-async fn local_node_price_improvement_fee_buy_order() {
-    run_test(price_improvement_fee_buy_order_test).await;
+async fn local_node_surplus_fee_buy_order() {
+    run_test(surplus_fee_buy_order_test).await;
 }
 
 #[tokio::test]
 #[ignore]
-async fn local_node_price_improvement_fee_buy_order_capped() {
-    run_test(price_improvement_fee_buy_order_capped_test).await;
+async fn local_node_surplus_fee_buy_order_capped() {
+    run_test(surplus_fee_buy_order_capped_test).await;
 }
 
 #[tokio::test]
@@ -49,8 +49,8 @@ async fn local_node_volume_fee_buy_order() {
     run_test(volume_fee_buy_order_test).await;
 }
 
-async fn price_improvement_fee_sell_order_test(web3: Web3) {
-    let fee_policy = FeePolicyKind::PriceImprovement {
+async fn surplus_fee_sell_order_test(web3: Web3) {
+    let fee_policy = FeePolicyKind::Surplus {
         factor: 0.3,
         max_volume_factor: 1.0,
     };
@@ -82,8 +82,8 @@ async fn price_improvement_fee_sell_order_test(web3: Web3) {
     .await;
 }
 
-async fn price_improvement_fee_sell_order_capped_test(web3: Web3) {
-    let fee_policy = FeePolicyKind::PriceImprovement {
+async fn surplus_fee_sell_order_capped_test(web3: Web3) {
+    let fee_policy = FeePolicyKind::Surplus {
         factor: 1.0,
         max_volume_factor: 0.1,
     };
@@ -132,8 +132,8 @@ async fn volume_fee_sell_order_test(web3: Web3) {
     .await;
 }
 
-async fn price_improvement_fee_buy_order_test(web3: Web3) {
-    let fee_policy = FeePolicyKind::PriceImprovement {
+async fn surplus_fee_buy_order_test(web3: Web3) {
+    let fee_policy = FeePolicyKind::Surplus {
         factor: 0.3,
         max_volume_factor: 1.0,
     };
@@ -161,8 +161,8 @@ async fn price_improvement_fee_buy_order_test(web3: Web3) {
     .await;
 }
 
-async fn price_improvement_fee_buy_order_capped_test(web3: Web3) {
-    let fee_policy = FeePolicyKind::PriceImprovement {
+async fn surplus_fee_buy_order_capped_test(web3: Web3) {
+    let fee_policy = FeePolicyKind::Surplus {
         factor: 1.0,
         max_volume_factor: 0.1,
     };
@@ -353,9 +353,8 @@ async fn execute_test(
 }
 
 enum FeePolicyKind {
-    /// How much of the order's price improvement over max(limit price,
-    /// best_bid) should be taken as a protocol fee.
-    PriceImprovement { factor: f64, max_volume_factor: f64 },
+    /// How much of the order's surplus should be taken as a protocol fee.
+    Surplus { factor: f64, max_volume_factor: f64 },
     /// How much of the order's volume should be taken as a protocol fee.
     Volume { factor: f64 },
 }
@@ -363,12 +362,12 @@ enum FeePolicyKind {
 impl std::fmt::Display for FeePolicyKind {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match self {
-            FeePolicyKind::PriceImprovement {
+            FeePolicyKind::Surplus {
                 factor,
                 max_volume_factor,
             } => write!(
                 f,
-                "--fee-policy-kind=priceImprovement:{}:{}",
+                "--fee-policy-kind=surplus:{}:{}",
                 factor, max_volume_factor
             ),
             FeePolicyKind::Volume { factor } => {

--- a/crates/orderbook/src/dto/order.rs
+++ b/crates/orderbook/src/dto/order.rs
@@ -50,7 +50,7 @@ pub struct Order {
 #[serde(rename_all = "camelCase")]
 pub enum FeePolicy {
     #[serde(rename_all = "camelCase")]
-    PriceImprovement { factor: f64, max_volume_factor: f64 },
+    Surplus { factor: f64, max_volume_factor: f64 },
     #[serde(rename_all = "camelCase")]
     Volume { factor: f64 },
 }


### PR DESCRIPTION
# Description
Renames FeePolicy variant from `priceImprovement` to `surplus`, since it better explains the current implementation of the protocol fee in the driver.

Context: 
https://github.com/cowprotocol/services/pull/2213#pullrequestreview-1814990012
https://cowservices.slack.com/archives/C05N1FNP3MX/p1704971316558629

I expect shadow solver to fail again until next release.