### PR TITLE
Rename fee policies

### DIFF
--- a/crates/autopilot/src/boundary/order.rs
+++ b/crates/autopilot/src/boundary/order.rs
@@ -2,7 +2,7 @@ use {crate::domain, shared::remaining_amounts};
 
 pub fn to_domain(
     order: model::order::Order,
-    fee_policies: Vec<domain::fee::Policy>,
+    protocol_fees: Vec<domain::fee::Policy>,
 ) -> domain::Order {
     let remaining_order = remaining_amounts::Order::from(order.clone());
     let order_is_untouched = remaining_order.executed_amount.is_zero();
@@ -15,6 +15,7 @@ pub fn to_domain(
         buy_amount: order.data.buy_amount,
         solver_fee: order.metadata.full_fee_amount,
         user_fee: order.data.fee_amount,
+        protocol_fees,
         valid_to: order.data.valid_to,
         kind: order.data.kind.into(),
         receiver: order.data.receiver,
@@ -35,6 +36,5 @@ pub fn to_domain(
         class: order.metadata.class.into(),
         app_data: order.data.app_data.into(),
         signature: order.signature.into(),
-        fee_policies,
     }
 }

--- a/crates/autopilot/src/domain/auction/order.rs
+++ b/crates/autopilot/src/domain/auction/order.rs
@@ -12,6 +12,7 @@ pub struct Order {
     pub buy_amount: U256,
     pub solver_fee: U256,
     pub user_fee: U256,
+    pub protocol_fees: Vec<fee::Policy>,
     pub kind: Kind,
     pub class: Class,
     pub valid_to: u32,
@@ -27,7 +28,6 @@ pub struct Order {
     pub buy_token_balance: BuyTokenDestination,
     pub app_data: AppDataHash,
     pub signature: Signature,
-    pub fee_policies: Vec<fee::Policy>,
 }
 
 // uid as 56 bytes: 32 for orderDigest, 20 for ownerAddress and 4 for validTo

--- a/crates/autopilot/src/infra/persistence/dto/order.rs
+++ b/crates/autopilot/src/infra/persistence/dto/order.rs
@@ -24,6 +24,7 @@ pub struct Order {
     pub solver_fee: U256,
     #[serde_as(as = "HexOrDecimalU256")]
     pub user_fee: U256,
+    pub protocol_fees: Vec<FeePolicy>,
     pub valid_to: u32,
     pub kind: boundary::OrderKind,
     pub receiver: Option<H160>,
@@ -40,7 +41,6 @@ pub struct Order {
     pub app_data: boundary::AppDataHash,
     #[serde(flatten)]
     pub signature: boundary::Signature,
-    pub fee_policies: Vec<FeePolicy>,
 }
 
 pub fn from_domain(order: domain::Order) -> Order {
@@ -52,6 +52,7 @@ pub fn from_domain(order: domain::Order) -> Order {
         buy_amount: order.buy_amount,
         solver_fee: order.solver_fee,
         user_fee: order.user_fee,
+        protocol_fees: order.protocol_fees.into_iter().map(Into::into).collect(),
         valid_to: order.valid_to,
         kind: order.kind.into(),
         receiver: order.receiver,
@@ -69,7 +70,6 @@ pub fn from_domain(order: domain::Order) -> Order {
         class: order.class.into(),
         app_data: order.app_data.into(),
         signature: order.signature.into(),
-        fee_policies: order.fee_policies.into_iter().map(Into::into).collect(),
     }
 }
 
@@ -82,6 +82,7 @@ pub fn to_domain(order: Order) -> domain::Order {
         buy_amount: order.buy_amount,
         solver_fee: order.solver_fee,
         user_fee: order.user_fee,
+        protocol_fees: order.protocol_fees.into_iter().map(Into::into).collect(),
         valid_to: order.valid_to,
         kind: order.kind.into(),
         receiver: order.receiver,
@@ -99,7 +100,6 @@ pub fn to_domain(order: Order) -> domain::Order {
         class: order.class.into(),
         app_data: order.app_data.into(),
         signature: order.signature.into(),
-        fee_policies: order.fee_policies.into_iter().map(Into::into).collect(),
     }
 }
 

--- a/crates/autopilot/src/solvable_orders.rs
+++ b/crates/autopilot/src/solvable_orders.rs
@@ -77,7 +77,7 @@ pub struct SolvableOrdersCache {
     ethflow_contract_address: Option<H160>,
     weth: H160,
     limit_order_price_factor: BigDecimal,
-    fee_policy: domain::ProtocolFee,
+    protocol_fee: domain::ProtocolFee,
 }
 
 type Balances = HashMap<Query, U256>;
@@ -102,7 +102,7 @@ impl SolvableOrdersCache {
         ethflow_contract_address: Option<H160>,
         weth: H160,
         limit_order_price_factor: BigDecimal,
-        fee_policy: domain::ProtocolFee,
+        protocol_fee: domain::ProtocolFee,
     ) -> Arc<Self> {
         let self_ = Arc::new(Self {
             min_order_validity_period,
@@ -120,7 +120,7 @@ impl SolvableOrdersCache {
             ethflow_contract_address,
             weth,
             limit_order_price_factor,
-            fee_policy,
+            protocol_fee,
         });
         tokio::task::spawn(
             update_task(Arc::downgrade(&self_), update_interval, current_block)
@@ -240,8 +240,8 @@ impl SolvableOrdersCache {
                 .into_iter()
                 .map(|order| {
                     let quote = db_solvable_orders.quotes.get(&order.metadata.uid.into());
-                    let fee_policies = self.fee_policy.get(&order, quote);
-                    boundary::order::to_domain(order, fee_policies)
+                    let protocol_fees = self.protocol_fee.get(&order, quote);
+                    boundary::order::to_domain(order, protocol_fees)
                 })
                 .collect(),
             prices,

--- a/crates/driver/openapi.yml
+++ b/crates/driver/openapi.yml
@@ -258,7 +258,7 @@ components:
         signature:
           description: Hex encoded bytes with `0x` prefix.
           type: string
-        feePolicies:
+        protocolFees:
           description: |
             Any protocol fee policies that apply to the order.
 

--- a/crates/driver/src/domain/competition/order/mod.rs
+++ b/crates/driver/src/domain/competition/order/mod.rs
@@ -43,7 +43,7 @@ pub struct Order {
     /// The types of fees the protocol collects from the winning solver.
     /// Unless otherwise configured, the driver modifies solutions to take
     /// sufficient fee in the form of positive slippage.
-    pub fee_policies: Vec<FeePolicy>,
+    pub protocol_fees: Vec<FeePolicy>,
 }
 
 /// An amount denominated in the sell token of an [`Order`].
@@ -458,7 +458,7 @@ mod tests {
                 data: Default::default(),
                 signer: Default::default(),
             },
-            fee_policies: Default::default(),
+            protocol_fees: Default::default(),
         };
 
         assert_eq!(

--- a/crates/driver/src/domain/competition/solution/fee.rs
+++ b/crates/driver/src/domain/competition/solution/fee.rs
@@ -70,11 +70,11 @@ impl Fulfillment {
 
     fn protocol_fee(&self, prices: ClearingPrices) -> Result<eth::U256, Error> {
         // TODO: support multiple fee policies
-        if self.order().fee_policies.len() > 1 {
+        if self.order().protocol_fees.len() > 1 {
             return Err(Error::MultipleFeePolicies);
         }
 
-        match self.order().fee_policies.first() {
+        match self.order().protocol_fees.first() {
             Some(FeePolicy::PriceImprovement {
                 factor,
                 max_volume_factor,

--- a/crates/driver/src/domain/quote.rs
+++ b/crates/driver/src/domain/quote.rs
@@ -131,7 +131,7 @@ impl Order {
                     data: Default::default(),
                     signer: Default::default(),
                 },
-                fee_policies: Default::default(),
+                protocol_fees: Default::default(),
             }],
             [
                 auction::Token {

--- a/crates/driver/src/infra/api/routes/solve/dto/auction.rs
+++ b/crates/driver/src/infra/api/routes/solve/dto/auction.rs
@@ -115,8 +115,8 @@ impl Auction {
                         data: order.signature.into(),
                         signer: order.owner.into(),
                     },
-                    fee_policies: order
-                        .fee_policies
+                    protocol_fees: order
+                        .protocol_fees
                         .into_iter()
                         .map(|policy| match policy {
                             FeePolicy::PriceImprovement {
@@ -230,6 +230,7 @@ struct Order {
     solver_fee: eth::U256,
     #[serde_as(as = "serialize::U256")]
     user_fee: eth::U256,
+    protocol_fees: Vec<FeePolicy>,
     valid_to: u32,
     kind: Kind,
     receiver: Option<eth::H160>,
@@ -250,7 +251,6 @@ struct Order {
     signing_scheme: SigningScheme,
     #[serde_as(as = "serialize::Hex")]
     signature: Vec<u8>,
-    fee_policies: Vec<FeePolicy>,
 }
 
 #[derive(Debug, Deserialize)]

--- a/crates/driver/src/tests/setup/driver.rs
+++ b/crates/driver/src/tests/setup/driver.rs
@@ -73,6 +73,16 @@ pub fn solve_req(test: &Test) -> serde_json::Value {
             "buyAmount": quote.buy_amount().to_string(),
             "solverFee": quote.order.user_fee.to_string(),
             "userFee": quote.order.user_fee.to_string(),
+            "protocolFees": match quote.order.kind {
+                order::Kind::Market => json!([]),
+                order::Kind::Liquidity => json!([]),
+                order::Kind::Limit { .. } => json!([{
+                    "priceImprovement": {
+                        "factor": 0.0,
+                        "maxVolumeFactor": 0.06
+                    }
+                }]),
+            },
             "validTo": u32::try_from(time::now().timestamp()).unwrap() + quote.order.valid_for.0,
             "kind": match quote.order.side {
                 order::Side::Sell => "sell",
@@ -94,16 +104,6 @@ pub fn solve_req(test: &Test) -> serde_json::Value {
             "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
             "signingScheme": "eip712",
             "signature": format!("0x{}", hex::encode(quote.order_signature(&test.blockchain))),
-            "feePolicies": match quote.order.kind {
-                order::Kind::Market => json!([]),
-                order::Kind::Liquidity => json!([]),
-                order::Kind::Limit { .. } => json!([{
-                    "priceImprovement": {
-                        "factor": 0.0,
-                        "maxVolumeFactor": 0.06
-                    }
-                }]),
-            },
         }));
     }
     for fulfillment in test.fulfillments.iter() {

--- a/crates/orderbook/src/dto/order.rs
+++ b/crates/orderbook/src/dto/order.rs
@@ -26,6 +26,7 @@ pub struct Order {
     pub solver_fee: U256,
     #[serde_as(as = "HexOrDecimalU256")]
     pub user_fee: U256,
+    pub protocol_fees: Vec<FeePolicy>,
     pub valid_to: u32,
     pub kind: OrderKind,
     pub receiver: Option<H160>,
@@ -42,7 +43,6 @@ pub struct Order {
     pub app_data: AppDataHash,
     #[serde(flatten)]
     pub signature: Signature,
-    pub fee_policies: Vec<FeePolicy>,
 }
 
 #[serde_as]


### PR DESCRIPTION
# Description
Fixes https://github.com/cowprotocol/services/issues/2256

Simple renaming from `fee_policies` to `protocol_fees` to make sure the reader knows that the policies are used for protocol fee calculation.