### PR TITLE
Move driver_api to `infra`

### DIFF
--- a/crates/autopilot/src/boundary/mod.rs
+++ b/crates/autopilot/src/boundary/mod.rs
@@ -1,7 +1,10 @@
 pub use {
-    crate::database::{
-        competition::Competition,
-        order_events::{store_order_events, OrderEventLabel},
+    crate::{
+        database::{
+            competition::Competition,
+            order_events::{store_order_events, OrderEventLabel},
+        },
+        driver_model::{reveal, settle, solve},
     },
     database::orders::Quote as DatabaseQuote,
     model::{

--- a/crates/autopilot/src/infra/mod.rs
+++ b/crates/autopilot/src/infra/mod.rs
@@ -1,5 +1,6 @@
 pub mod blockchain;
 pub mod persistence;
 pub mod shadow;
+pub mod solvers;
 
-pub use {blockchain::Ethereum, persistence::Persistence};
+pub use {blockchain::Ethereum, persistence::Persistence, solvers::Driver};

--- a/crates/autopilot/src/lib.rs
+++ b/crates/autopilot/src/lib.rs
@@ -3,7 +3,6 @@ pub mod boundary;
 pub mod database;
 pub mod decoded_settlement;
 pub mod domain;
-pub mod driver_api;
 pub mod driver_model;
 pub mod event_updater;
 pub mod infra;
@@ -13,5 +12,6 @@ pub mod run;
 pub mod run_loop;
 pub mod shadow;
 pub mod solvable_orders;
+pub mod util;
 
 pub use self::run::{run, start};

--- a/crates/autopilot/src/run.rs
+++ b/crates/autopilot/src/run.rs
@@ -11,7 +11,6 @@ use {
             Postgres,
         },
         domain,
-        driver_api::Driver,
         event_updater::{EventUpdater, GPv2SettlementContract},
         infra::{self},
         run_loop::RunLoop,
@@ -597,7 +596,11 @@ pub async fn run(args: Arguments) {
     let run = RunLoop {
         eth,
         solvable_orders_cache,
-        drivers: args.drivers.into_iter().map(Driver::new).collect(),
+        drivers: args
+            .drivers
+            .into_iter()
+            .map(|driver| infra::Driver::new(driver.url, driver.name))
+            .collect(),
         market_makable_token_list,
         submission_deadline: args.submission_deadline as u64,
         additional_deadline_for_rewards: args.additional_deadline_for_rewards as u64,
@@ -620,7 +623,11 @@ async fn shadow_mode(args: Arguments) -> ! {
         args.shadow.expect("missing shadow mode configuration"),
     );
 
-    let drivers = args.drivers.into_iter().map(Driver::new).collect();
+    let drivers = args
+        .drivers
+        .into_iter()
+        .map(|driver| infra::Driver::new(driver.url, driver.name))
+        .collect();
 
     let trusted_tokens = {
         let web3 = shared::ethrpc::web3(

--- a/crates/autopilot/src/shadow.rs
+++ b/crates/autopilot/src/shadow.rs
@@ -10,7 +10,6 @@
 use {
     crate::{
         domain::{self, auction::order::Class},
-        driver_api::Driver,
         driver_model::{
             reveal,
             solve::{self},
@@ -38,7 +37,7 @@ impl LivenessChecking for Liveness {
 
 pub struct RunLoop {
     orderbook: infra::shadow::Orderbook,
-    drivers: Vec<Driver>,
+    drivers: Vec<infra::Driver>,
     trusted_tokens: AutoUpdatingTokenList,
     auction: domain::AuctionId,
     block: u64,
@@ -49,7 +48,7 @@ pub struct RunLoop {
 impl RunLoop {
     pub fn new(
         orderbook: infra::shadow::Orderbook,
-        drivers: Vec<Driver>,
+        drivers: Vec<infra::Driver>,
         trusted_tokens: AutoUpdatingTokenList,
         score_cap: U256,
         solve_deadline: Duration,
@@ -214,7 +213,7 @@ impl RunLoop {
     /// Computes a driver's solutions in the shadow competition.
     async fn participate(
         &self,
-        driver: &Driver,
+        driver: &infra::Driver,
         request: &solve::Request,
     ) -> Result<Solution, Error> {
         let proposed = tokio::time::timeout(self.solve_deadline, driver.solve(request))
@@ -257,7 +256,7 @@ impl RunLoop {
 }
 
 struct Participant<'a> {
-    driver: &'a Driver,
+    driver: &'a infra::Driver,
     solution: Result<Solution, Error>,
 }
 

--- a/crates/autopilot/src/util/mod.rs
+++ b/crates/autopilot/src/util/mod.rs
@@ -1,0 +1,14 @@
+use url::Url;
+
+/// Joins a path with a URL, ensuring that there is only one slash between them.
+/// It doesn't matter if the URL ends with a slash or the path starts with one.
+pub fn join(url: &Url, mut path: &str) -> Url {
+    let mut url = url.to_string();
+    while url.ends_with('/') {
+        url.pop();
+    }
+    while path.starts_with('/') {
+        path = &path[1..]
+    }
+    Url::parse(&format!("{url}/{path}")).unwrap()
+}


### PR DESCRIPTION
# Description
Third part of the https://github.com/cowprotocol/services/pull/2188

Moves driver_api to a separate `solvers` module in `infra`.

Next up, moving the driver dtos into `infra`.