### PR TITLE
OnSettlementEventUpdater break blockchain dependency

### DIFF
--- a/crates/autopilot/src/infra/blockchain/contracts.rs
+++ b/crates/autopilot/src/infra/blockchain/contracts.rs
@@ -1,0 +1,55 @@
+use {super::NetworkId, ethcontract::dyns::DynWeb3, primitive_types::H160};
+
+#[derive(Debug, Clone)]
+pub struct Contracts {
+    settlement: contracts::GPv2Settlement,
+    weth: contracts::WETH9,
+}
+
+#[derive(Debug, Default, Clone, Copy)]
+pub struct Addresses {
+    pub settlement: Option<H160>,
+    pub weth: Option<H160>,
+}
+
+impl Contracts {
+    pub(super) async fn new(web3: &DynWeb3, network_id: &NetworkId, addresses: Addresses) -> Self {
+        let address_for = |contract: &ethcontract::Contract, address: Option<H160>| {
+            address
+                .or_else(|| deployment_address(contract, network_id))
+                .unwrap()
+        };
+
+        let settlement = contracts::GPv2Settlement::at(
+            web3,
+            address_for(
+                contracts::GPv2Settlement::raw_contract(),
+                addresses.settlement,
+            ),
+        );
+
+        let weth = contracts::WETH9::at(
+            web3,
+            address_for(contracts::WETH9::raw_contract(), addresses.weth),
+        );
+
+        Self { settlement, weth }
+    }
+
+    pub fn settlement(&self) -> &contracts::GPv2Settlement {
+        &self.settlement
+    }
+
+    pub fn weth(&self) -> &contracts::WETH9 {
+        &self.weth
+    }
+}
+
+/// Returns the address of a contract for the specified network, or `None` if
+/// there is no known deployment for the contract on that network.
+pub fn deployment_address(
+    contract: &ethcontract::Contract,
+    network_id: &NetworkId,
+) -> Option<H160> {
+    Some(contract.networks.get(network_id.as_str())?.address)
+}

--- a/crates/autopilot/src/infra/blockchain/mod.rs
+++ b/crates/autopilot/src/infra/blockchain/mod.rs
@@ -72,6 +72,7 @@ pub struct Ethereum {
     web3: DynWeb3,
     network: Network,
     current_block: CurrentBlockStream,
+    settlement: contracts::GPv2Settlement,
 }
 
 impl Ethereum {
@@ -81,7 +82,11 @@ impl Ethereum {
     ///
     /// Since this type is essential for the program this method will panic on
     /// any initialization error.
-    pub async fn new(rpc: Rpc, poll_interval: Duration) -> Self {
+    pub async fn new(
+        rpc: Rpc,
+        settlement: contracts::GPv2Settlement,
+        poll_interval: Duration,
+    ) -> Self {
         let Rpc { web3, network } = rpc;
 
         Self {
@@ -93,6 +98,7 @@ impl Ethereum {
             .expect("couldn't initialize current block stream"),
             web3,
             network,
+            settlement,
         }
     }
 
@@ -104,6 +110,11 @@ impl Ethereum {
     /// current and new blocks.
     pub fn current_block(&self) -> &CurrentBlockStream {
         &self.current_block
+    }
+
+    /// Returns a reference to the deployed settlement contract.
+    pub fn settlement_contract(&self) -> &contracts::GPv2Settlement {
+        &self.settlement
     }
 
     pub async fn transaction(&self, hash: H256) -> Result<Option<web3::types::Transaction>, Error> {

--- a/crates/autopilot/src/infra/blockchain/mod.rs
+++ b/crates/autopilot/src/infra/blockchain/mod.rs
@@ -5,7 +5,6 @@ use {
     primitive_types::{H256, U256},
     std::{sync::Arc, time::Duration},
     thiserror::Error,
-    web3::types::TransactionReceipt,
 };
 
 /// Chain ID as defined by EIP-155.
@@ -107,10 +106,18 @@ impl Ethereum {
         &self.current_block
     }
 
+    pub async fn transaction(&self, hash: H256) -> Result<Option<web3::types::Transaction>, Error> {
+        self.web3
+            .eth()
+            .transaction(hash.into())
+            .await
+            .map_err(Into::into)
+    }
+
     pub async fn transaction_receipt(
         &self,
         hash: H256,
-    ) -> Result<Option<TransactionReceipt>, Error> {
+    ) -> Result<Option<web3::types::TransactionReceipt>, Error> {
         self.web3
             .eth()
             .transaction_receipt(hash)

--- a/crates/autopilot/src/on_settlement_event_updater.rs
+++ b/crates/autopilot/src/on_settlement_event_updater.rs
@@ -37,32 +37,29 @@ use {
             Postgres,
         },
         decoded_settlement::{DecodedSettlement, DecodingError},
+        infra,
     },
     anyhow::{anyhow, Context, Result},
     contracts::GPv2Settlement,
-    ethrpc::{
-        current_block::{into_stream, CurrentBlockStream},
-        Web3,
-    },
     futures::StreamExt,
     model::DomainSeparator,
     primitive_types::{H160, H256},
     shared::{event_handling::MAX_REORG_BLOCK_COUNT, external_prices::ExternalPrices},
     sqlx::PgConnection,
-    web3::types::{Transaction, TransactionId},
+    web3::types::Transaction,
 };
 
 pub struct OnSettlementEventUpdater {
-    pub web3: Web3,
+    pub eth: infra::Ethereum,
     pub contract: GPv2Settlement,
     pub native_token: H160,
     pub db: Postgres,
 }
 
 impl OnSettlementEventUpdater {
-    pub async fn run_forever(self, block_stream: CurrentBlockStream) -> ! {
-        let mut current_block = *block_stream.borrow();
-        let mut block_stream = into_stream(block_stream);
+    pub async fn run_forever(self) -> ! {
+        let mut current_block = self.eth.current_block().borrow().to_owned();
+        let mut block_stream = ethrpc::current_block::into_stream(self.eth.current_block().clone());
         loop {
             match self.update(current_block.number).await {
                 Ok(true) => {
@@ -118,11 +115,9 @@ impl OnSettlementEventUpdater {
         tracing::debug!("updating settlement details for tx {hash:?}");
 
         let transaction = self
-            .web3
-            .eth()
-            .transaction(TransactionId::Hash(hash))
-            .await
-            .with_context(|| format!("get tx {hash:?}"))?
+            .eth
+            .transaction(hash)
+            .await?
             .with_context(|| format!("no tx {hash:?}"))?;
         let tx_from = transaction
             .from
@@ -154,8 +149,7 @@ impl OnSettlementEventUpdater {
         // well.
         if let Some(auction_id) = auction_id {
             let receipt = self
-                .web3
-                .eth()
+                .eth
                 .transaction_receipt(hash)
                 .await?
                 .with_context(|| format!("no receipt {hash:?}"))?;
@@ -303,109 +297,5 @@ impl OnSettlementEventUpdater {
             }
             (Some(_), false) => Ok(Some(auction_id)),
         }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use {
-        super::*,
-        database::{auction_prices::AuctionPrice, settlement_observations::Observation},
-        sqlx::Executor,
-    };
-
-    #[tokio::test]
-    #[ignore]
-    async fn manual_node_test() {
-        // TODO update test
-        observe::tracing::initialize_reentrant("autopilot=trace");
-        let db = Postgres::with_defaults().await.unwrap();
-        database::clear_DANGER(&db.pool).await.unwrap();
-        let transport = shared::ethrpc::create_env_test_transport();
-        let web3 = Web3::new(transport);
-
-        let contract = contracts::GPv2Settlement::deployed(&web3).await.unwrap();
-        let native_token = contracts::WETH9::deployed(&web3).await.unwrap().address();
-        let updater = OnSettlementEventUpdater {
-            web3,
-            db,
-            native_token,
-            contract,
-        };
-
-        assert!(!updater.update(15875900).await.unwrap());
-
-        let query = r"
-INSERT INTO settlements (block_number, log_index, solver, tx_hash, tx_from, tx_nonce)
-VALUES (15875801, 405, '\x', '\x0e9d0f4ea243ac0f02e1d3ecab3fea78108d83bfca632b30e9bc4acb22289c5a', NULL, NULL)
-    ;";
-        updater.db.pool.execute(query).await.unwrap();
-
-        let query = r"
-INSERT INTO auction_transaction (auction_id, tx_from, tx_nonce)
-VALUES (0, '\xa21740833858985e4d801533a808786d3647fb83', 4701)
-    ;";
-        updater.db.pool.execute(query).await.unwrap();
-
-        let query = r"
-INSERT INTO auction_prices (auction_id, token, price)
-VALUES (0, '\x056fd409e1d7a124bd7017459dfea2f387b6d5cd', 6347795727933475088343330979840),
-        (0, '\x6b175474e89094c44da98b954eedeac495271d0f', 634671683530053),
-        (0, '\xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48', 634553336916241343152390144)
-            ;";
-
-        updater.db.pool.execute(query).await.unwrap();
-
-        assert!(updater.update(15875900).await.unwrap());
-
-        let query = r"
-SELECT tx_from, tx_nonce
-FROM settlements
-WHERE block_number = 15875801 AND log_index = 405
-        ;";
-        let (tx_from, tx_nonce): (Vec<u8>, i64) = sqlx::query_as(query)
-            .fetch_one(&updater.db.pool)
-            .await
-            .unwrap();
-        assert_eq!(
-            tx_from,
-            hex_literal::hex!("a21740833858985e4d801533a808786d3647fb83")
-        );
-        assert_eq!(tx_nonce, 4701);
-
-        let query = r"
-SELECT auction_id, tx_from, tx_nonce
-FROM auction_transaction
-        ;";
-        let (auction_id, tx_from, tx_nonce): (i64, Vec<u8>, i64) = sqlx::query_as(query)
-            .fetch_one(&updater.db.pool)
-            .await
-            .unwrap();
-        assert_eq!(auction_id, 0);
-        assert_eq!(
-            tx_from,
-            hex_literal::hex!("a21740833858985e4d801533a808786d3647fb83")
-        );
-        assert_eq!(tx_nonce, 4701);
-
-        // assert that the prices are updated
-        let query = r#"SELECT * FROM auction_prices;"#;
-        let prices: Vec<AuctionPrice> = sqlx::query_as(query)
-            .fetch_all(&updater.db.pool)
-            .await
-            .unwrap();
-        assert_eq!(prices.len(), 2);
-
-        // assert that the observations are updated
-        let query = r#"SELECT * FROM settlement_observations;"#;
-        let observation: Observation = sqlx::query_as(query)
-            .fetch_one(&updater.db.pool)
-            .await
-            .unwrap();
-        assert_eq!(observation.gas_used, 179155.into());
-        assert_eq!(observation.effective_gas_price, 19789368758u64.into());
-        assert_eq!(observation.surplus, 5150444803867862u64.into());
-
-        assert!(!updater.update(15875900).await.unwrap());
     }
 }

--- a/crates/autopilot/src/on_settlement_event_updater.rs
+++ b/crates/autopilot/src/on_settlement_event_updater.rs
@@ -42,7 +42,7 @@ use {
     anyhow::{anyhow, Context, Result},
     futures::StreamExt,
     model::DomainSeparator,
-    primitive_types::{H160, H256},
+    primitive_types::H256,
     shared::{event_handling::MAX_REORG_BLOCK_COUNT, external_prices::ExternalPrices},
     sqlx::PgConnection,
     web3::types::Transaction,
@@ -50,7 +50,6 @@ use {
 
 pub struct OnSettlementEventUpdater {
     pub eth: infra::Ethereum,
-    pub native_token: H160,
     pub db: Postgres,
 }
 
@@ -128,7 +127,8 @@ impl OnSettlementEventUpdater {
 
         let domain_separator = DomainSeparator(
             self.eth
-                .settlement_contract()
+                .contracts()
+                .settlement()
                 .domain_separator()
                 .call()
                 .await?
@@ -170,7 +170,7 @@ impl OnSettlementEventUpdater {
                 format!("no external prices for auction id {auction_id:?} and tx {hash:?}")
             })?;
             let external_prices = ExternalPrices::try_from_auction_prices(
-                self.native_token,
+                self.eth.contracts().weth().address(),
                 auction_external_prices.clone(),
             )?;
 

--- a/crates/autopilot/src/run.rs
+++ b/crates/autopilot/src/run.rs
@@ -557,14 +557,14 @@ pub async fn run(args: Arguments) {
 
     let on_settlement_event_updater =
         crate::on_settlement_event_updater::OnSettlementEventUpdater {
-            web3: web3.clone(),
+            eth: eth.clone(),
             contract: settlement_contract,
             native_token: native_token.address(),
             db: db.clone(),
         };
     tokio::task::spawn(
         on_settlement_event_updater
-            .run_forever(eth.current_block().clone())
+            .run_forever()
             .instrument(tracing::info_span!("on_settlement_event_updater")),
     );
 


### PR DESCRIPTION
# Description
First small step towards moving OnSettlementEventUpdater to `domain`.

This PR breaks the blockchain dependency and uses `infra::Ethereum` object.

Some of the following steps:
1. Break db dependency
2. Move `DecodedSettlement` to `domain`
3. Refactor `OnSettlementEventUpdater::update`: extract CIP20 data construction, create `domain::Transaction` object that will contain subset of onchain transaction data and used to build `DecodedSettlement` using `eth::Ethereum` etc...

# Changes
<!-- List of detailed changes (how the change is accomplished) -->

- [ ] Extracted contracts functionality into separate infra module
- [ ] Using `infra::Ethereum` instead of `web3` and contracts