### PR TITLE
Fix liveness probe

### DIFF
--- a/crates/autopilot/src/run_loop.rs
+++ b/crates/autopilot/src/run_loop.rs
@@ -105,6 +105,8 @@ impl RunLoop {
             Class::Liquidity => true,
             Class::Limit => false,
         }) {
+            // Updating liveness probe to not report unhealthy due to this optimization
+            self.liveness.auction();
             tracing::debug!("skipping empty auction");
             return None;
         }


### PR DESCRIPTION
# Description
The newly added code for the liveness probe reports unhealthy if we skip too many empty auctions after another.

# Changes
Also update last processes auction timestamp when we skip an auction because it's empty.