### PR TITLE
Share app data registry

### DIFF
--- a/crates/orderbook/src/run.rs
+++ b/crates/orderbook/src/run.rs
@@ -515,8 +515,10 @@ pub async fn run(args: Arguments) {
     }
 
     check_database_connection(orderbook.as_ref()).await;
-    let quotes =
-        Arc::new(QuoteHandler::new(order_validator, optimal_quoter).with_fast_quoter(fast_quoter));
+    let quotes = Arc::new(
+        QuoteHandler::new(order_validator, optimal_quoter, app_data.clone())
+            .with_fast_quoter(fast_quoter),
+    );
 
     let (shutdown_sender, shutdown_receiver) = tokio::sync::oneshot::channel();
     let serve_api = serve_api(


### PR DESCRIPTION
# Description
Now that everyting is in place (see #2297, #2298) we can also load app data override in the order quoter

# Changes
- [x] Inject the app_data::registry into the quoter
- [x] Load app data override instead of passing None

## How to test
Adjusted the e2e test. Before we were seeing the warning show up twice (for quote and the expected unknown hash), now we no longer see the warning for the quote.

<!--
## Related Issues

Fixes #
-->