### PR TITLE
Fix check for market price

### DIFF
--- a/crates/autopilot/src/domain/fee/mod.rs
+++ b/crates/autopilot/src/domain/fee/mod.rs
@@ -51,6 +51,7 @@ impl ProtocolFee {
                     &order.data.buy_amount,
                     &quote.buy_amount,
                     &quote.sell_amount,
+                    &quote.fee,
                 ) {
                     vec![self.policy]
                 } else {

--- a/crates/autopilot/src/domain/quote/mod.rs
+++ b/crates/autopilot/src/domain/quote/mod.rs
@@ -5,4 +5,5 @@ pub struct Quote {
     pub order_uid: OrderUid,
     pub sell_amount: U256,
     pub buy_amount: U256,
+    pub fee: U256,
 }

--- a/crates/autopilot/src/infra/persistence/dto/quote.rs
+++ b/crates/autopilot/src/infra/persistence/dto/quote.rs
@@ -1,6 +1,7 @@
 use {
     crate::{boundary, domain},
     number::conversions::big_decimal_to_u256,
+    primitive_types::U256,
 };
 
 pub fn into_domain(
@@ -10,6 +11,16 @@ pub fn into_domain(
         order_uid: domain::OrderUid(quote.order_uid.0),
         sell_amount: big_decimal_to_u256(&quote.sell_amount).ok_or(AmountOverflow)?,
         buy_amount: big_decimal_to_u256(&quote.buy_amount).ok_or(AmountOverflow)?,
+        fee: {
+            let gas_amount = U256::from_f64_lossy(quote.gas_amount);
+            let gas_price = U256::from_f64_lossy(quote.gas_price);
+            let sell_token_price = U256::from_f64_lossy(quote.sell_token_price);
+            gas_amount
+                .checked_mul(gas_price)
+                .ok_or(AmountOverflow)?
+                .checked_div(sell_token_price)
+                .ok_or(AmountOverflow)?
+        },
     })
 }
 

--- a/crates/autopilot/src/infra/persistence/dto/quote.rs
+++ b/crates/autopilot/src/infra/persistence/dto/quote.rs
@@ -4,26 +4,28 @@ use {
     primitive_types::U256,
 };
 
-pub fn into_domain(
-    quote: boundary::database::orders::Quote,
-) -> Result<domain::Quote, AmountOverflow> {
+pub fn into_domain(quote: boundary::database::orders::Quote) -> Result<domain::Quote, Error> {
     Ok(domain::Quote {
         order_uid: domain::OrderUid(quote.order_uid.0),
-        sell_amount: big_decimal_to_u256(&quote.sell_amount).ok_or(AmountOverflow)?,
-        buy_amount: big_decimal_to_u256(&quote.buy_amount).ok_or(AmountOverflow)?,
+        sell_amount: big_decimal_to_u256(&quote.sell_amount).ok_or(Error::AmountOverflow)?,
+        buy_amount: big_decimal_to_u256(&quote.buy_amount).ok_or(Error::AmountOverflow)?,
         fee: {
             let gas_amount = U256::from_f64_lossy(quote.gas_amount);
             let gas_price = U256::from_f64_lossy(quote.gas_price);
             let sell_token_price = U256::from_f64_lossy(quote.sell_token_price);
             gas_amount
                 .checked_mul(gas_price)
-                .ok_or(AmountOverflow)?
+                .ok_or(Error::AmountOverflow)?
                 .checked_div(sell_token_price)
-                .ok_or(AmountOverflow)?
+                .ok_or(Error::DivisionByZero)?
         },
     })
 }
 
 #[derive(Debug, thiserror::Error)]
-#[error("invalid conversion from database to domain")]
-pub struct AmountOverflow;
+pub enum Error {
+    #[error("amount overflow")]
+    AmountOverflow,
+    #[error("division by zero with sell_token_price")]
+    DivisionByZero,
+}

--- a/crates/shared/src/order_validation.rs
+++ b/crates/shared/src/order_validation.rs
@@ -745,6 +745,7 @@ impl OrderValidating for OrderValidator {
                     &quote_parameters.buy_amount,
                     &quote.sell_amount,
                     &quote.buy_amount,
+                    &quote.fee_amount,
                 ) =>
             {
                 tracing::debug!(%uid, ?owner, ?class, "order being flagged as outside market price");
@@ -981,8 +982,9 @@ pub fn is_order_outside_market_price(
     buy_amount: &U256,
     quote_sell_amount: &U256,
     quote_buy_amount: &U256,
+    quote_fee_amount: &U256,
 ) -> bool {
-    sell_amount.full_mul(*quote_buy_amount) < quote_sell_amount.full_mul(*buy_amount)
+    sell_amount.full_mul(*quote_buy_amount) < (quote_sell_amount+quote_fee_amount).full_mul(*buy_amount)
 }
 
 pub fn convert_signing_scheme_into_quote_signing_scheme(
@@ -2414,8 +2416,9 @@ mod tests {
     #[test]
     fn detects_market_orders() {
         let quote = Quote {
-            sell_amount: 100.into(),
+            sell_amount: 90.into(),
             buy_amount: 100.into(),
+            fee_amount: 10.into(),
             ..Default::default()
         };
 
@@ -2425,6 +2428,7 @@ mod tests {
             &"100".into(),
             &quote.sell_amount,
             &quote.buy_amount,
+            &quote.fee_amount,
         ));
         // willing to buy less than market price
         assert!(!is_order_outside_market_price(
@@ -2432,6 +2436,7 @@ mod tests {
             &"90".into(),
             &quote.sell_amount,
             &quote.buy_amount,
+            &quote.fee_amount,
         ));
         // wanting to buy more than market price
         assert!(is_order_outside_market_price(
@@ -2439,6 +2444,7 @@ mod tests {
             &"1000".into(),
             &quote.sell_amount,
             &quote.buy_amount,
+            &quote.fee_amount,
         ));
     }
 }

--- a/crates/shared/src/order_validation.rs
+++ b/crates/shared/src/order_validation.rs
@@ -984,7 +984,8 @@ pub fn is_order_outside_market_price(
     quote_buy_amount: &U256,
     quote_fee_amount: &U256,
 ) -> bool {
-    sell_amount.full_mul(*quote_buy_amount) < (quote_sell_amount+quote_fee_amount).full_mul(*buy_amount)
+    sell_amount.full_mul(*quote_buy_amount)
+        < (quote_sell_amount + quote_fee_amount).full_mul(*buy_amount)
 }
 
 pub fn convert_signing_scheme_into_quote_signing_scheme(


### PR DESCRIPTION
# Description
For an order with signed data
sell_amount = 100
buy amount = whatever

we get the quote response back (that get stored into db):
sell_amount = 90
buy_amount = whatever
fee_amount = 10

When checking if the order is within market price for fee policy, we decided to compare with quote that includes the fee_amount, so that we avoid a case where user submits an order which is out-of-market (meaning can't be fulfilled at the moment of creation) but, because of the fee_amount that is ignored, is considered in-market and therefore excluded from protocol fee taking.

To summarize, if order signed sell_amount is expressed as sell_amount_before_fee, then we also need to compare it to quote sell amount expressed as before fee.