### PR TITLE
Store all orders in `order_execution` table

### DIFF
--- a/crates/autopilot/src/on_settlement_event_updater.rs
+++ b/crates/autopilot/src/on_settlement_event_updater.rs
@@ -190,15 +190,7 @@ impl OnSettlementEventUpdater {
                         // executed fees for each order execution
                         let order_executions = all_fees
                             .into_iter()
-                            .zip(order_fees.iter())
-                            .filter_map(|(fee, (_, order_fee))| match order_fee {
-                                // filter out orders with order_fee
-                                // since their fee can already be fetched from the database table
-                                // `orders` so no point in storing the same
-                                // value twice, in another table
-                                Some(_) => None,
-                                None => Some((fee.order, fee.sell)),
-                            })
+                            .map(|fee| (fee.order, fee.sell))
                             .collect();
                         (fee, order_executions)
                     };


### PR DESCRIPTION
# Description
This PR addresses the issue identified in Sepolia where `total_surplus` was not computed correctly due to missing `order_uids` in the `order_execution` table. This miscomputation was a consequence of [recent changes](https://github.com/cowprotocol/services/pull/2190) in the workings of the `order_execution` table. The identified problem impacted the `/api/v1/users/{address}/total_surplus` endpoint, leading to lower-than-expected surplus values. This fix aims to ensure accurate surplus computation by addressing the data retrieval process in the database.

# Changes
After thorough consideration, it was decided to go with the option of reverting the change and saving `order_executions` for all trades. The alternative of building a complicated subquery was deemed overly complex and unnecessary, especially given the context of moving towards a system where all orders are limit orders. This simplification aligns with the future direction and maintains system efficiency.

## How to test

https://github.com/cowprotocol/services/issues/2267

## Related Issues

Fixes #2289