### PR TITLE
Zero surplus fee for market orders

### DIFF
--- a/crates/autopilot/src/on_settlement_event_updater.rs
+++ b/crates/autopilot/src/on_settlement_event_updater.rs
@@ -190,7 +190,12 @@ impl OnSettlementEventUpdater {
                         // executed fees for each order execution
                         let order_executions = all_fees
                             .into_iter()
-                            .map(|fee| (fee.order, fee.sell))
+                            .zip(order_fees.iter())
+                            .map(|(fee, (_, order_fee))| match order_fee {
+                                Some(_) => (fee.order, 0.into()), /* market orders have no
+                                                                    * surplus fee */
+                                None => (fee.order, fee.sell),
+                            })
                             .collect();
                         (fee, order_executions)
                     };

--- a/crates/autopilot/src/on_settlement_event_updater.rs
+++ b/crates/autopilot/src/on_settlement_event_updater.rs
@@ -192,8 +192,8 @@ impl OnSettlementEventUpdater {
                             .into_iter()
                             .zip(order_fees.iter())
                             .map(|(fee, (_, order_fee))| match order_fee {
-                                Some(_) => (fee.order, 0.into()), /* market orders have no
-                                                                    * surplus fee */
+                                // market orders have no surplus fee
+                                Some(_) => (fee.order, 0.into()),
                                 None => (fee.order, fee.sell),
                             })
                             .collect();


### PR DESCRIPTION
# Description
Follow up for https://github.com/cowprotocol/services/pull/2305

My oversight where I suggested to just remove the filter. What we actually want to do here is to still have all order executions to be saved to db table `order_executions` (to have properly calculation of `/api/v1/users/{address}/total_surplus`) but also, save the surplus_fee of 0 for market orders because they don't have the surplus fee.