### PR TITLE
Always enable all signature types

### DIFF
--- a/crates/e2e/src/setup/services.rs
+++ b/crates/e2e/src/setup/services.rs
@@ -113,8 +113,6 @@ impl<'a> Services<'a> {
     pub async fn start_api(&self, extra_args: Vec<String>) {
         let args = [
             "orderbook".to_string(),
-            "--enable-presign-orders=true".to_string(),
-            "--enable-eip1271-orders=true".to_string(),
             "--enable-custom-interactions=true".to_string(),
             "--allow-placing-partially-fillable-limit-orders=true".to_string(),
             format!(

--- a/crates/orderbook/openapi.yml
+++ b/crates/orderbook/openapi.yml
@@ -1205,7 +1205,6 @@ components:
               TransferEthToContract,
               InvalidNativeSellToken,
               SameBuyAndSellToken,
-              UnsupportedSignature,
               UnsupportedToken,
               UnsupportedCustomInteraction
               InvalidAppData,
@@ -1264,7 +1263,6 @@ components:
               UnsupportedBuyTokenDestination,
               UnsupportedSellTokenSource,
               UnsupportedOrderType,
-              UnsupportedSignature,
             ]
         description:
           type: string

--- a/crates/orderbook/src/api/post_order.rs
+++ b/crates/orderbook/src/api/post_order.rs
@@ -81,10 +81,6 @@ impl IntoWarpReply for PartialValidationErrorWrapper {
                 ),
                 StatusCode::BAD_REQUEST,
             ),
-            PartialValidationError::UnsupportedSignature => with_status(
-                error("UnsupportedSignature", "signing scheme is not supported"),
-                StatusCode::BAD_REQUEST,
-            ),
             PartialValidationError::UnsupportedToken { token, reason } => with_status(
                 error(
                     "UnsupportedToken",

--- a/crates/orderbook/src/arguments.rs
+++ b/crates/orderbook/src/arguments.rs
@@ -112,21 +112,9 @@ pub struct Arguments {
     #[clap(long, env, default_value = "200")]
     pub pool_cache_lru_size: NonZeroUsize,
 
-    /// Enable EIP-1271 orders.
-    #[clap(long, env, action = clap::ArgAction::Set, default_value = "false")]
-    pub enable_eip1271_orders: bool,
-
     /// Skip EIP-1271 order signature validation on creation.
     #[clap(long, env, action = clap::ArgAction::Set, default_value = "false")]
     pub eip1271_skip_creation_validation: bool,
-
-    /// Enable pre-sign orders. Pre-sign orders are accepted into the database
-    /// without a valid signature, so this flag allows this feature to be
-    /// turned off if malicious users are abusing the database by inserting
-    /// a bunch of order rows that won't ever be valid. This flag can be
-    /// removed once DDoS protection is implemented.
-    #[clap(long, env, action = clap::ArgAction::Set, default_value = "false")]
-    pub enable_presign_orders: bool,
 
     /// If solvable orders haven't been successfully updated in this many blocks
     /// attempting to get them errors and our liveness check fails.
@@ -191,9 +179,7 @@ impl std::fmt::Display for Arguments {
             banned_users,
             allowed_tokens,
             pool_cache_lru_size,
-            enable_eip1271_orders,
             eip1271_skip_creation_validation,
-            enable_presign_orders,
             solvable_orders_max_update_age_blocks,
             native_price_estimators,
             fast_price_estimation_results_required,
@@ -242,13 +228,11 @@ impl std::fmt::Display for Arguments {
         writeln!(f, "banned_users: {:?}", banned_users)?;
         writeln!(f, "allowed_tokens: {:?}", allowed_tokens)?;
         writeln!(f, "pool_cache_lru_size: {}", pool_cache_lru_size)?;
-        writeln!(f, "enable_eip1271_orders: {}", enable_eip1271_orders)?;
         writeln!(
             f,
             "eip1271_skip_creation_validation: {}",
             eip1271_skip_creation_validation
         )?;
-        writeln!(f, "enable_presign_orders: {}", enable_presign_orders)?;
         writeln!(
             f,
             "solvable_orders_max_update_age_blocks: {}",

--- a/crates/orderbook/src/run.rs
+++ b/crates/orderbook/src/run.rs
@@ -32,7 +32,7 @@ use {
         metrics::{serve_metrics, DEFAULT_METRICS_PORT},
         network::network_name,
         order_quoting::{self, OrderQuoter, QuoteHandler},
-        order_validation::{OrderValidPeriodConfiguration, OrderValidator, SignatureConfiguration},
+        order_validation::{OrderValidPeriodConfiguration, OrderValidator},
         price_estimation::{
             factory::{self, PriceEstimatorFactory, PriceEstimatorSource},
             native::NativePriceEstimating,
@@ -424,11 +424,6 @@ pub async fn run(args: Arguments) {
         max_market: args.max_order_validity_period,
         max_limit: args.max_limit_order_validity_period,
     };
-    let signature_configuration = SignatureConfiguration {
-        eip1271: args.enable_eip1271_orders,
-        eip1271_skip_creation_validation: args.eip1271_skip_creation_validation,
-        presign: args.enable_presign_orders,
-    };
 
     let create_quoter = |price_estimator: Arc<dyn PriceEstimating>| {
         Arc::new(OrderQuoter::new(
@@ -467,7 +462,7 @@ pub async fn run(args: Arguments) {
                 .copied()
                 .collect(),
             validity_configuration,
-            signature_configuration,
+            args.eip1271_skip_creation_validation,
             bad_token_detector.clone(),
             hooks_contract,
             optimal_quoter.clone(),


### PR DESCRIPTION
# Description
Whenever we implement a new feature we make usually enable it by setting a CLI flag.
However, at some point the flags are thoroughly tested and do not get disabled anymore.
IMO there is no longer a need to temporarily disable eip-1271 or presign signatures so I disabled their feature flags.

# Changes
Delete dead code

## How to test
Test should still pass