### PR TITLE
Always enable limit orders

### DIFF
--- a/crates/e2e/src/setup/services.rs
+++ b/crates/e2e/src/setup/services.rs
@@ -114,7 +114,6 @@ impl<'a> Services<'a> {
         let args = [
             "orderbook".to_string(),
             "--enable-custom-interactions=true".to_string(),
-            "--allow-placing-partially-fillable-limit-orders=true".to_string(),
             format!(
                 "--hooks-contract-address={:?}",
                 self.contracts.hooks.address()

--- a/crates/orderbook/src/arguments.rs
+++ b/crates/orderbook/src/arguments.rs
@@ -121,14 +121,6 @@ pub struct Arguments {
     #[clap(long, env, default_value = "24")]
     pub solvable_orders_max_update_age_blocks: u64,
 
-    /// Note that fill or kill liquidity limit orders are always allowed.
-    #[clap(long, env, action = clap::ArgAction::Set, default_value = "true")]
-    pub allow_placing_fill_or_kill_limit_orders: bool,
-
-    /// Note that partially fillable liquidity limit orders are always allowed.
-    #[clap(long, env, action = clap::ArgAction::Set, default_value = "true")]
-    pub allow_placing_partially_fillable_limit_orders: bool,
-
     /// Max number of limit orders per user.
     #[clap(long, env, default_value = "10")]
     pub max_limit_orders_per_user: u64,
@@ -183,8 +175,6 @@ impl std::fmt::Display for Arguments {
             solvable_orders_max_update_age_blocks,
             native_price_estimators,
             fast_price_estimation_results_required,
-            allow_placing_fill_or_kill_limit_orders,
-            allow_placing_partially_fillable_limit_orders,
             max_limit_orders_per_user,
             enable_custom_interactions,
             ipfs_gateway,
@@ -243,16 +233,6 @@ impl std::fmt::Display for Arguments {
             f,
             "fast_price_estimation_results_required: {}",
             fast_price_estimation_results_required
-        )?;
-        writeln!(
-            f,
-            "allow_placing_fill_or_kill_limit_orders: {}",
-            allow_placing_fill_or_kill_limit_orders
-        )?;
-        writeln!(
-            f,
-            "allow_placing_partially_fillable_limit_orders: {}",
-            allow_placing_partially_fillable_limit_orders
         )?;
         writeln!(
             f,

--- a/crates/orderbook/src/run.rs
+++ b/crates/orderbook/src/run.rs
@@ -474,8 +474,6 @@ pub async fn run(args: Arguments) {
             Arc::new(CachedCodeFetcher::new(Arc::new(web3.clone()))),
             app_data_validator.clone(),
         )
-        .with_fill_or_kill_limit_orders(args.allow_placing_fill_or_kill_limit_orders)
-        .with_partially_fillable_limit_orders(args.allow_placing_partially_fillable_limit_orders)
         .with_eth_smart_contract_payments(args.enable_eth_smart_contract_payments)
         .with_custom_interactions(args.enable_custom_interactions)
         .with_verified_quotes(args.price_estimation.trade_simulator.is_some()),


### PR DESCRIPTION
# Description
Limit orders are now a critical part of the service. Being able to disable the feature is no longer useful.

# Changes
Delete dead code

## How to test
CI, tests should still pass