### PR TITLE
Allow custom timeout for e2e services' http client

### DIFF
--- a/crates/e2e/src/setup/services.rs
+++ b/crates/e2e/src/setup/services.rs
@@ -31,6 +31,37 @@ pub const VERSION_ENDPOINT: &str = "/api/v1/version";
 pub const SOLVER_COMPETITION_ENDPOINT: &str = "/api/v1/solver_competition";
 const LOCAL_DB_URL: &str = "postgresql://";
 
+pub struct ServicesBuilder {
+    timeout: Duration,
+}
+
+impl Default for ServicesBuilder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl ServicesBuilder {
+    pub fn new() -> Self {
+        Self {
+            timeout: Duration::from_secs(10),
+        }
+    }
+
+    pub fn with_timeout(mut self, timeout: Duration) -> Self {
+        self.timeout = timeout;
+        self
+    }
+
+    pub async fn build(self, contracts: &Contracts) -> Services {
+        Services {
+            contracts,
+            http: Client::builder().timeout(self.timeout).build().unwrap(),
+            db: sqlx::PgPool::connect(LOCAL_DB_URL).await.unwrap(),
+        }
+    }
+}
+
 /// Wrapper over offchain services.
 /// Exposes various utility methods for tests.
 pub struct Services<'a> {
@@ -51,12 +82,8 @@ impl<'a> Services<'a> {
         }
     }
 
-    pub async fn new_with_timeout(contracts: &'a Contracts, timeout: Duration) -> Services<'a> {
-        Self {
-            contracts,
-            http: Client::builder().timeout(timeout).build().unwrap(),
-            db: sqlx::PgPool::connect(LOCAL_DB_URL).await.unwrap(),
-        }
+    pub fn builder() -> ServicesBuilder {
+        ServicesBuilder::new()
     }
 
     fn api_autopilot_arguments() -> impl Iterator<Item = String> {

--- a/crates/e2e/src/setup/services.rs
+++ b/crates/e2e/src/setup/services.rs
@@ -51,6 +51,14 @@ impl<'a> Services<'a> {
         }
     }
 
+    pub async fn new_with_timeout(contracts: &'a Contracts, timeout: Duration) -> Services<'a> {
+        Self {
+            contracts,
+            http: Client::builder().timeout(timeout).build().unwrap(),
+            db: sqlx::PgPool::connect(LOCAL_DB_URL).await.unwrap(),
+        }
+    }
+
     fn api_autopilot_arguments() -> impl Iterator<Item = String> {
         [
             "--price-estimators=Baseline|0x0000000000000000000000000000000000000001".to_string(),


### PR DESCRIPTION
# Description
Allow custom timeout for the http client in `e2e`'s `services`. This means we can use the helper functions in `services` without needing to copy them into our own codebase and change the timeout.

# Changes
 -  `new_with_timeout` constructor added to `Services` impl. 

## How to test
Tested in Enso's e2e tests.