### PR TITLE
Move TradeVerifier into separate file and add trait

### DIFF
--- a/crates/shared/src/order_quoting.rs
+++ b/crates/shared/src/order_quoting.rs
@@ -688,6 +688,7 @@ mod tests {
                         out_amount: 42.into(),
                         gas: 3,
                         solver: H160([1; 20]),
+                        verified: false,
                     })
                 }
                 .boxed()
@@ -820,6 +821,7 @@ mod tests {
                         out_amount: 42.into(),
                         gas: 3,
                         solver: H160([1; 20]),
+                        verified: false,
                     })
                 }
                 .boxed()
@@ -950,6 +952,7 @@ mod tests {
                         out_amount: 100.into(),
                         gas: 3,
                         solver: H160([1; 20]),
+                        verified: false,
                     })
                 }
                 .boxed()
@@ -1067,6 +1070,7 @@ mod tests {
                     out_amount: 100.into(),
                     gas: 200,
                     solver: H160([1; 20]),
+                    verified: false,
                 })
             }
             .boxed()
@@ -1136,6 +1140,7 @@ mod tests {
                     out_amount: 100.into(),
                     gas: 200,
                     solver: H160([1; 20]),
+                    verified: false,
                 })
             }
             .boxed()

--- a/crates/shared/src/price_estimation.rs
+++ b/crates/shared/src/price_estimation.rs
@@ -487,7 +487,7 @@ pub struct Estimate {
     pub gas: u64,
     /// Address of the solver that provided the quote.
     pub solver: H160,
-    /// Did we verify the correctness of this estimates properties?
+    /// Did we verify the correctness of this estimate's properties?
     pub verified: bool,
 }
 

--- a/crates/shared/src/price_estimation.rs
+++ b/crates/shared/src/price_estimation.rs
@@ -40,6 +40,7 @@ pub mod oneinch;
 pub mod paraswap;
 pub mod sanitized;
 pub mod trade_finder;
+pub mod trade_verifier;
 pub mod zeroex;
 
 #[derive(Clone, Debug)]
@@ -486,6 +487,8 @@ pub struct Estimate {
     pub gas: u64,
     /// Address of the solver that provided the quote.
     pub solver: H160,
+    /// Did we verify the correctness of this estimates properties?
+    pub verified: bool,
 }
 
 impl Estimate {

--- a/crates/shared/src/price_estimation/balancer_sor.rs
+++ b/crates/shared/src/price_estimation/balancer_sor.rs
@@ -74,6 +74,7 @@ impl BalancerSor {
             out_amount: quote.return_amount,
             gas: SETTLEMENT_SINGLE_TRADE + (quote.swaps.len() as u64) * GAS_PER_BALANCER_SWAP,
             solver: self.solver,
+            verified: false,
         })
     }
 }

--- a/crates/shared/src/price_estimation/baseline.rs
+++ b/crates/shared/src/price_estimation/baseline.rs
@@ -78,6 +78,7 @@ impl PriceEstimating for BaselinePriceEstimator {
                 out_amount,
                 gas,
                 solver: self.solver,
+                verified: false,
             })
         }
         .boxed()

--- a/crates/shared/src/price_estimation/external.rs
+++ b/crates/shared/src/price_estimation/external.rs
@@ -1,6 +1,7 @@
 use {
     super::{
-        trade_finder::{TradeEstimator, TradeVerifier},
+        trade_finder::TradeEstimator,
+        trade_verifier::TradeVerifying,
         PriceEstimateResult,
         PriceEstimating,
         Query,
@@ -32,7 +33,7 @@ impl ExternalPriceEstimator {
         ))
     }
 
-    pub fn verified(&self, verifier: TradeVerifier) -> Self {
+    pub fn verified(&self, verifier: Arc<dyn TradeVerifying>) -> Self {
         Self(self.0.clone().with_verifier(verifier))
     }
 }

--- a/crates/shared/src/price_estimation/http.rs
+++ b/crates/shared/src/price_estimation/http.rs
@@ -259,6 +259,7 @@ impl HttpPriceEstimator {
             },
             gas,
             solver: self.solver,
+            verified: false,
         })
     }
 

--- a/crates/shared/src/price_estimation/native.rs
+++ b/crates/shared/src/price_estimation/native.rs
@@ -100,6 +100,7 @@ mod tests {
                     out_amount: 123_456_789_000_000_000u128.into(),
                     gas: 0,
                     solver: H160([1; 20]),
+                    verified: false,
                 })
             }
             .boxed()

--- a/crates/shared/src/price_estimation/oneinch.rs
+++ b/crates/shared/src/price_estimation/oneinch.rs
@@ -1,6 +1,7 @@
 use {
     super::{
-        trade_finder::{TradeEstimator, TradeVerifier},
+        trade_finder::TradeEstimator,
+        trade_verifier::TradeVerifying,
         PriceEstimateResult,
         PriceEstimating,
         Query,
@@ -38,7 +39,7 @@ impl OneInchPriceEstimator {
         ))
     }
 
-    pub fn verified(&self, verifier: TradeVerifier) -> Self {
+    pub fn verified(&self, verifier: Arc<dyn TradeVerifying>) -> Self {
         Self(self.0.clone().with_verifier(verifier))
     }
 }

--- a/crates/shared/src/price_estimation/paraswap.rs
+++ b/crates/shared/src/price_estimation/paraswap.rs
@@ -1,6 +1,7 @@
 use {
     super::{
-        trade_finder::{TradeEstimator, TradeVerifier},
+        trade_finder::TradeEstimator,
+        trade_verifier::TradeVerifying,
         PriceEstimateResult,
         PriceEstimating,
         Query,
@@ -38,7 +39,7 @@ impl ParaswapPriceEstimator {
         ))
     }
 
-    pub fn verified(&self, verifier: TradeVerifier) -> Self {
+    pub fn verified(&self, verifier: Arc<dyn TradeVerifying>) -> Self {
         Self(self.0.clone().with_verifier(verifier))
     }
 }

--- a/crates/shared/src/price_estimation/sanitized.rs
+++ b/crates/shared/src/price_estimation/sanitized.rs
@@ -66,6 +66,7 @@ impl PriceEstimating for SanitizedPriceEstimator {
                     out_amount: query.in_amount.get(),
                     gas: 0,
                     solver: Default::default(),
+                    verified: true,
                 };
                 tracing::debug!(?query, ?estimation, "generate trivial price estimation");
                 return Ok(estimation);
@@ -77,6 +78,7 @@ impl PriceEstimating for SanitizedPriceEstimator {
                     out_amount: query.in_amount.get(),
                     gas: GAS_PER_WETH_UNWRAP,
                     solver: Default::default(),
+                    verified: true,
                 };
                 tracing::debug!(?query, ?estimation, "generate trivial unwrap estimation");
                 return Ok(estimation);
@@ -88,6 +90,7 @@ impl PriceEstimating for SanitizedPriceEstimator {
                     out_amount: query.in_amount.get(),
                     gas: GAS_PER_WETH_WRAP,
                     solver: Default::default(),
+                    verified: true,
                 };
                 tracing::debug!(?query, ?estimation, "generate trivial wrap estimation");
                 return Ok(estimation);
@@ -181,6 +184,7 @@ mod tests {
                     out_amount: 1.into(),
                     gas: 100,
                     solver: Default::default(),
+                    verified: false,
                 }),
             ),
             // `sanitized_estimator` will replace `buy_token` with `native_token` before querying
@@ -201,6 +205,7 @@ mod tests {
                     //Query with ETH as the buy_token.
                     gas: GAS_PER_WETH_UNWRAP + 100,
                     solver: Default::default(),
+                    verified: false,
                 }),
             ),
             // Will cause buffer overflow of gas price in `sanitized_estimator`.
@@ -235,6 +240,7 @@ mod tests {
                     //Query with ETH as the sell_token.
                     gas: GAS_PER_WETH_WRAP + 100,
                     solver: Default::default(),
+                    verified: false,
                 }),
             ),
             // Can be estimated by `sanitized_estimator` because `buy_token` and `sell_token` are
@@ -252,6 +258,7 @@ mod tests {
                     out_amount: 1.into(),
                     gas: 0,
                     solver: Default::default(),
+                    verified: true,
                 }),
             ),
             // Can be estimated by `sanitized_estimator` because both tokens are the native token.
@@ -268,6 +275,7 @@ mod tests {
                     out_amount: 1.into(),
                     gas: 0,
                     solver: Default::default(),
+                    verified: true,
                 }),
             ),
             // Can be estimated by `sanitized_estimator` because it is a native token unwrap.
@@ -285,6 +293,7 @@ mod tests {
                     // Sanitized estimator will report a 1:1 estimate when unwrapping native token.
                     gas: GAS_PER_WETH_UNWRAP,
                     solver: Default::default(),
+                    verified: true,
                 }),
             ),
             // Can be estimated by `sanitized_estimator` because it is a native token wrap.
@@ -302,6 +311,7 @@ mod tests {
                     // Sanitized estimator will report a 1:1 estimate when wrapping native token.
                     gas: GAS_PER_WETH_WRAP,
                     solver: Default::default(),
+                    verified: true,
                 }),
             ),
             // Will throw `UnsupportedToken` error in `sanitized_estimator`.
@@ -365,6 +375,7 @@ mod tests {
                         out_amount: 1.into(),
                         gas: 100,
                         solver: Default::default(),
+                        verified: false,
                     })
                 }
                 .boxed()
@@ -379,6 +390,7 @@ mod tests {
                         out_amount: 1.into(),
                         gas: 100,
                         solver: Default::default(),
+                        verified: false,
                     })
                 }
                 .boxed()
@@ -393,6 +405,7 @@ mod tests {
                         out_amount: 1.into(),
                         gas: u64::MAX,
                         solver: Default::default(),
+                        verified: false,
                     })
                 }
                 .boxed()
@@ -407,6 +420,7 @@ mod tests {
                         out_amount: 1.into(),
                         gas: 100,
                         solver: Default::default(),
+                        verified: false,
                     })
                 }
                 .boxed()

--- a/crates/shared/src/price_estimation/trade_finder.rs
+++ b/crates/shared/src/price_estimation/trade_finder.rs
@@ -4,41 +4,21 @@
 use {
     super::{
         rate_limited,
+        trade_verifier::{PriceQuery, TradeVerifying},
         Estimate,
         PriceEstimateResult,
         PriceEstimating,
         PriceEstimationError,
         Query,
-        Verification,
     },
     crate::{
-        code_fetching::CodeFetching,
-        code_simulation::CodeSimulating,
-        encoded_settlement::{encode_trade, EncodedSettlement},
-        interaction::EncodedInteraction,
         request_sharing::RequestSharing,
-        trade_finding::{Interaction, Trade, TradeError, TradeFinding},
+        trade_finding::{TradeError, TradeFinding},
     },
-    anyhow::{anyhow, Context, Result},
-    contracts::{
-        deployed_bytecode,
-        dummy_contract,
-        support::{Solver, Trader},
-        GPv2Settlement,
-        WETH9,
-    },
-    ethcontract::{tokens::Tokenize, Bytes, H160, U256},
-    ethrpc::extensions::StateOverride,
+    anyhow::{anyhow, Result},
     futures::future::{BoxFuture, FutureExt as _},
-    maplit::hashmap,
-    model::{
-        order::{OrderData, OrderKind, BUY_ETH_ADDRESS},
-        signature::{Signature, SigningScheme},
-    },
-    number::nonzero::U256 as NonZeroU256,
     rate_limit::RateLimiter,
     std::sync::Arc,
-    web3::{ethabi::Token, types::CallRequest},
 };
 
 /// A `TradeFinding`-based price estimator with request sharing and rate
@@ -52,16 +32,8 @@ pub struct TradeEstimator {
 #[derive(Clone)]
 struct Inner {
     finder: Arc<dyn TradeFinding>,
-    verifier: Option<TradeVerifier>,
-}
-
-/// A trade verifier.
-#[derive(Clone)]
-pub struct TradeVerifier {
-    simulator: Arc<dyn CodeSimulating>,
-    code_fetcher: Arc<dyn CodeFetching>,
-    settlement: H160,
-    native_token: H160,
+    // TODO: Make this required when verification is stable
+    verifier: Option<Arc<dyn TradeVerifying>>,
 }
 
 impl TradeEstimator {
@@ -80,7 +52,7 @@ impl TradeEstimator {
         }
     }
 
-    pub fn with_verifier(mut self, verifier: TradeVerifier) -> Self {
+    pub fn with_verifier(mut self, verifier: Arc<dyn TradeVerifying>) -> Self {
         self.inner = Arc::new(Inner {
             verifier: Some(verifier),
             ..arc_unwrap_or_clone(self.inner)
@@ -102,251 +74,44 @@ impl Inner {
         self: Arc<Self>,
         query: Arc<Query>,
     ) -> Result<Estimate, PriceEstimationError> {
-        match (&self.verifier, &query.verification) {
-            (Some(verifier), Some(verification)) => {
-                let trade = self.finder.get_trade(&query).await?;
-                let price_query = PriceQuery {
-                    sell_token: query.sell_token,
-                    buy_token: query.buy_token,
-                    in_amount: query.in_amount,
-                    kind: query.kind,
-                };
-                verifier
-                    .verify(&price_query, verification, trade)
-                    .await
-                    .map_err(PriceEstimationError::EstimatorInternal)
-            }
-            (_, verification) => {
-                if verification.is_some() {
-                    // TODO turn this into a hard error when everything else is set up
-                    tracing::warn!(
-                        "verified quote was requested but no verification scheme was configured"
-                    );
+        if let (Some(verifier), Some(verification)) = (&self.verifier, &query.verification) {
+            let trade = self.finder.get_trade(&query).await?;
+            let price_query = PriceQuery {
+                sell_token: query.sell_token,
+                buy_token: query.buy_token,
+                in_amount: query.in_amount,
+                kind: query.kind,
+            };
+
+            let verified_quote = verifier
+                .verify(&price_query, verification, trade.clone())
+                .await;
+
+            return match verified_quote {
+                Ok(quote) => Ok(quote.into()),
+                Err(err) => {
+                    tracing::warn!(?err, "failed verification; returning unverified estimate");
+                    Ok(Estimate {
+                        out_amount: trade.out_amount,
+                        gas: trade.gas_estimate,
+                        solver: trade.solver,
+                        verified: false,
+                    })
                 }
-                let quote = self.finder.get_quote(&query).await?;
-                Ok(Estimate {
-                    out_amount: quote.out_amount,
-                    gas: quote.gas_estimate,
-                    solver: quote.solver,
-                })
-            }
-        }
-    }
-}
-
-fn encode_interactions(interactions: &[Interaction]) -> Vec<EncodedInteraction> {
-    interactions.iter().map(|i| i.encode()).collect()
-}
-
-fn encode_settlement(
-    query: &PriceQuery,
-    verification: &Verification,
-    trade: &Trade,
-    native_token: H160,
-) -> EncodedSettlement {
-    let mut trade_interactions = encode_interactions(&trade.interactions);
-    if query.buy_token == BUY_ETH_ADDRESS {
-        // Because the `driver` manages `WETH` unwraps under the hood the `TradeFinder`
-        // does not have to emit unwraps to pay out `ETH` in a trade.
-        // However, for the simulation to be successful this has to happen so we do it
-        // ourselves here.
-        let buy_amount = match query.kind {
-            OrderKind::Sell => trade.out_amount,
-            OrderKind::Buy => query.in_amount.get(),
-        };
-        let weth = dummy_contract!(WETH9, native_token);
-        let calldata = weth.methods().withdraw(buy_amount).tx.data.unwrap().0;
-        trade_interactions.push((native_token, 0.into(), Bytes(calldata)));
-        tracing::trace!("adding unwrap interaction for paying out ETH");
-    }
-
-    let tokens = vec![query.sell_token, query.buy_token];
-    let clearing_prices = match query.kind {
-        OrderKind::Sell => vec![trade.out_amount, query.in_amount.get()],
-        OrderKind::Buy => vec![query.in_amount.get(), trade.out_amount],
-    };
-
-    // Configure the most disadvantageous trade possible (while taking possible
-    // overflows into account). Should the trader not receive the amount promised by
-    // the [`Trade`] the simulation will still work and we can compute the actual
-    // [`Trade::out_amount`] afterwards.
-    let (sell_amount, buy_amount) = match query.kind {
-        OrderKind::Sell => (query.in_amount.get(), 0.into()),
-        OrderKind::Buy => (
-            trade.out_amount.max(U256::from(u128::MAX)),
-            query.in_amount.get(),
-        ),
-    };
-    let fake_order = OrderData {
-        sell_token: query.sell_token,
-        sell_amount,
-        buy_token: query.buy_token,
-        buy_amount,
-        receiver: Some(verification.receiver),
-        valid_to: u32::MAX,
-        app_data: Default::default(),
-        fee_amount: 0.into(),
-        kind: query.kind,
-        partially_fillable: false,
-        sell_token_balance: verification.sell_token_source,
-        buy_token_balance: verification.buy_token_destination,
-    };
-
-    let fake_signature = Signature::default_with(SigningScheme::Eip1271);
-    let encoded_trade = encode_trade(
-        &fake_order,
-        &fake_signature,
-        verification.from,
-        0,
-        1,
-        &query.in_amount.get(),
-    );
-
-    EncodedSettlement {
-        tokens,
-        clearing_prices,
-        trades: vec![encoded_trade],
-        interactions: [
-            encode_interactions(&verification.pre_interactions),
-            trade_interactions,
-            encode_interactions(&verification.post_interactions),
-        ],
-    }
-}
-
-/// Adds the interactions that are only needed to query important balances
-/// throughout the simulation.
-/// These balances will get used to compute an accurate price for the trade.
-fn add_balance_queries(
-    mut settlement: EncodedSettlement,
-    query: &PriceQuery,
-    verification: &Verification,
-    settlement_contract: H160,
-    solver: &Solver,
-) -> EncodedSettlement {
-    let (token, owner) = match query.kind {
-        // track how much `buy_token` the `receiver` actually got
-        OrderKind::Sell => (query.buy_token, verification.receiver),
-        // track how much `sell_token` the settlement contract actually spent
-        OrderKind::Buy => (query.sell_token, settlement_contract),
-    };
-    let query_balance = solver.methods().store_balance(token, owner);
-    let query_balance = Bytes(query_balance.tx.data.unwrap().0);
-    let interaction = (solver.address(), 0.into(), query_balance);
-    // query balance right after we receive all `sell_token`
-    settlement.interactions[1].insert(0, interaction.clone());
-    // query balance right after we payed out all `buy_token`
-    settlement.interactions[2].insert(0, interaction);
-    settlement
-}
-
-impl TradeVerifier {
-    const DEFAULT_GAS: u64 = 8_000_000;
-    const TRADER_IMPL: H160 = addr!("0000000000000000000000000000000000010000");
-
-    pub fn new(
-        simulator: Arc<dyn CodeSimulating>,
-        code_fetcher: Arc<dyn CodeFetching>,
-        settlement: H160,
-        native_token: H160,
-    ) -> Self {
-        Self {
-            simulator,
-            code_fetcher,
-            settlement,
-            native_token,
-        }
-    }
-
-    async fn verify(
-        &self,
-        query: &PriceQuery,
-        verification: &Verification,
-        trade: Trade,
-    ) -> Result<Estimate> {
-        let solver = dummy_contract!(Solver, trade.solver);
-
-        let settlement = encode_settlement(query, verification, &trade, self.native_token);
-        let settlement =
-            add_balance_queries(settlement, query, verification, self.settlement, &solver);
-
-        let settlement_contract = dummy_contract!(GPv2Settlement, self.settlement);
-        let settlement = settlement_contract
-            .methods()
-            .settle(
-                settlement.tokens,
-                settlement.clearing_prices,
-                settlement.trades,
-                settlement.interactions,
-            )
-            .tx;
-
-        let sell_amount = match query.kind {
-            OrderKind::Sell => query.in_amount.get(),
-            OrderKind::Buy => trade.out_amount,
-        };
-
-        let simulation = solver
-            .methods()
-            .swap(
-                verification.from,
-                query.sell_token,
-                sell_amount,
-                self.native_token,
-                verification.receiver,
-                Bytes(settlement.data.unwrap().0),
-            )
-            .tx;
-
-        let call = CallRequest {
-            // Initiate tx as solver so gas doesn't get deducted from user's ETH.
-            from: Some(solver.address()),
-            to: Some(solver.address()),
-            data: simulation.data,
-            gas: Some(Self::DEFAULT_GAS.into()),
-            ..Default::default()
-        };
-
-        // Set up helper contracts impersonating trader and solver.
-        let mut overrides = hashmap! {
-            verification.from => StateOverride {
-                code: Some(deployed_bytecode!(Trader)),
-                ..Default::default()
-            },
-            solver.address() => StateOverride {
-                code: Some(deployed_bytecode!(Solver)),
-                ..Default::default()
-            },
-        };
-
-        let trader_impl = self.code_fetcher.code(verification.from).await?;
-        if !trader_impl.0.is_empty() {
-            // Store `owner` implementation so `Trader` helper contract can proxy to it.
-            overrides.insert(
-                Self::TRADER_IMPL,
-                StateOverride {
-                    code: Some(trader_impl),
-                    ..Default::default()
-                },
-            );
+            };
         }
 
-        let output = self.simulator.simulate(call, overrides).await?;
-        let summary = SettleOutput::decode(&output)?;
-        let verified = Estimate {
-            out_amount: summary.out_amount(query.kind)?,
-            gas: summary.gas_used.as_u64(),
-            solver: trade.solver,
-        };
-        tracing::debug!(
-            ?query,
-            ?verification,
-            promised_gas = trade.gas_estimate,
-            promised_out_amount =? trade.out_amount,
-            ?verified,
-            "verified quote"
-        );
-        Ok(verified)
+        if query.verification.is_some() {
+            tracing::warn!("verified quote requested but no verifier configured");
+        }
+
+        let quote = self.finder.get_quote(&query).await?;
+        Ok(Estimate {
+            out_amount: quote.out_amount,
+            gas: quote.gas_estimate,
+            solver: quote.solver,
+            verified: false,
+        })
     }
 }
 
@@ -375,51 +140,6 @@ impl From<TradeError> for PriceEstimationError {
             TradeError::RateLimited => Self::RateLimited,
             TradeError::Other(err) => Self::EstimatorInternal(err),
         }
-    }
-}
-
-#[derive(Debug)]
-pub struct PriceQuery {
-    pub sell_token: H160,
-    // This should be `BUY_ETH_ADDRESS` if you actually want to trade `ETH`
-    pub buy_token: H160,
-    pub kind: OrderKind,
-    pub in_amount: NonZeroU256,
-}
-
-/// Output of `Trader::settle` smart contract call.
-#[derive(Debug)]
-struct SettleOutput {
-    /// Gas used for the `settle()` call.
-    gas_used: U256,
-    /// Balances queried during the simulation in the order specified during the
-    /// simulation set up.
-    queried_balances: Vec<U256>,
-}
-
-impl SettleOutput {
-    fn decode(output: &[u8]) -> Result<Self> {
-        let function = Solver::raw_contract().abi.function("swap").unwrap();
-        let tokens = function.decode_output(output).context("decode")?;
-        let (gas_used, queried_balances) = Tokenize::from_token(Token::Tuple(tokens))?;
-        Ok(Self {
-            gas_used,
-            queried_balances,
-        })
-    }
-
-    /// Computes the actual [`Trade::out_amount`] based on the simulation.
-    fn out_amount(&self, kind: OrderKind) -> Result<U256> {
-        let balances = &self.queried_balances;
-        let balance_before = balances.first().context("no balance before settlement")?;
-        let balance_after = balances.get(1).context("no balance after settlement")?;
-        let out_amount = match kind {
-            // for sell orders we track the buy_token amount which increases during the settlement
-            OrderKind::Sell => balance_after.checked_sub(*balance_before),
-            // for buy orders we track the sell_token amount which decreases during the settlement
-            OrderKind::Buy => balance_before.checked_sub(*balance_after),
-        };
-        out_amount.context("underflow during out_amount computation")
     }
 }
 

--- a/crates/shared/src/price_estimation/trade_verifier.rs
+++ b/crates/shared/src/price_estimation/trade_verifier.rs
@@ -29,8 +29,8 @@ use {
 
 #[async_trait::async_trait]
 pub trait TradeVerifying: Send + Sync + 'static {
-    /// Verifies that the proposed [`Trade`] actually fulfills the [`PriceQuery`]
-    /// and returns a price [`Estimate`] that is trustworthy.
+    /// Verifies that the proposed [`Trade`] actually fulfills the
+    /// [`PriceQuery`] and returns a price [`Estimate`] that is trustworthy.
     async fn verify(
         &self,
         query: &PriceQuery,

--- a/crates/shared/src/price_estimation/trade_verifier.rs
+++ b/crates/shared/src/price_estimation/trade_verifier.rs
@@ -1,0 +1,332 @@
+use {
+    super::{Estimate, Verification},
+    crate::{
+        code_fetching::CodeFetching,
+        code_simulation::CodeSimulating,
+        encoded_settlement::{encode_trade, EncodedSettlement},
+        interaction::EncodedInteraction,
+        trade_finding::{Interaction, Trade},
+    },
+    anyhow::{Context, Result},
+    contracts::{
+        deployed_bytecode,
+        dummy_contract,
+        support::{Solver, Trader},
+        GPv2Settlement,
+        WETH9,
+    },
+    ethcontract::{tokens::Tokenize, Bytes, H160, U256},
+    ethrpc::extensions::StateOverride,
+    maplit::hashmap,
+    model::{
+        order::{OrderData, OrderKind, BUY_ETH_ADDRESS},
+        signature::{Signature, SigningScheme},
+    },
+    number::nonzero::U256 as NonZeroU256,
+    std::sync::Arc,
+    web3::{ethabi::Token, types::CallRequest},
+};
+
+#[async_trait::async_trait]
+pub trait TradeVerifying: Send + Sync + 'static {
+    /// Verifies that the proposed [`Trade`] acually fulfills the [`PriceQuery`]
+    /// and returns a price [`Estimate`] that is trustworthy.
+    async fn verify(
+        &self,
+        query: &PriceQuery,
+        verification: &Verification,
+        trade: Trade,
+    ) -> Result<VerifiedEstimate>;
+}
+
+#[derive(Copy, Clone, Debug, Default, Eq, PartialEq)]
+pub struct VerifiedEstimate {
+    pub out_amount: U256,
+    pub gas: u64,
+    pub solver: H160,
+}
+
+impl From<VerifiedEstimate> for Estimate {
+    fn from(estimate: VerifiedEstimate) -> Self {
+        Self {
+            out_amount: estimate.out_amount,
+            gas: estimate.gas,
+            solver: estimate.solver,
+            verified: true,
+        }
+    }
+}
+
+/// Component that verifies a trade is actually executable by simulating it
+/// and determines a price estimate based off of that simulation.
+#[derive(Clone)]
+pub struct TradeVerifier {
+    simulator: Arc<dyn CodeSimulating>,
+    code_fetcher: Arc<dyn CodeFetching>,
+    settlement: H160,
+    native_token: H160,
+}
+
+impl TradeVerifier {
+    const DEFAULT_GAS: u64 = 8_000_000;
+    const TRADER_IMPL: H160 = addr!("0000000000000000000000000000000000010000");
+
+    pub fn new(
+        simulator: Arc<dyn CodeSimulating>,
+        code_fetcher: Arc<dyn CodeFetching>,
+        settlement: H160,
+        native_token: H160,
+    ) -> Self {
+        Self {
+            simulator,
+            code_fetcher,
+            settlement,
+            native_token,
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl TradeVerifying for TradeVerifier {
+    async fn verify(
+        &self,
+        query: &PriceQuery,
+        verification: &Verification,
+        trade: Trade,
+    ) -> Result<VerifiedEstimate> {
+        let solver = dummy_contract!(Solver, trade.solver);
+
+        let settlement = encode_settlement(query, verification, &trade, self.native_token);
+        let settlement =
+            add_balance_queries(settlement, query, verification, self.settlement, &solver);
+
+        let settlement_contract = dummy_contract!(GPv2Settlement, self.settlement);
+        let settlement = settlement_contract
+            .methods()
+            .settle(
+                settlement.tokens,
+                settlement.clearing_prices,
+                settlement.trades,
+                settlement.interactions,
+            )
+            .tx;
+
+        let sell_amount = match query.kind {
+            OrderKind::Sell => query.in_amount.get(),
+            OrderKind::Buy => trade.out_amount,
+        };
+
+        let simulation = solver
+            .methods()
+            .swap(
+                verification.from,
+                query.sell_token,
+                sell_amount,
+                self.native_token,
+                verification.receiver,
+                Bytes(settlement.data.unwrap().0),
+            )
+            .tx;
+
+        let call = CallRequest {
+            // Initiate tx as solver so gas doesn't get deducted from user's ETH.
+            from: Some(solver.address()),
+            to: Some(solver.address()),
+            data: simulation.data,
+            gas: Some(Self::DEFAULT_GAS.into()),
+            ..Default::default()
+        };
+
+        // Set up helper contracts impersonating trader and solver.
+        let mut overrides = hashmap! {
+            verification.from => StateOverride {
+                code: Some(deployed_bytecode!(Trader)),
+                ..Default::default()
+            },
+            solver.address() => StateOverride {
+                code: Some(deployed_bytecode!(Solver)),
+                ..Default::default()
+            },
+        };
+
+        let trader_impl = self.code_fetcher.code(verification.from).await?;
+        if !trader_impl.0.is_empty() {
+            // Store `owner` implementation so `Trader` helper contract can proxy to it.
+            overrides.insert(
+                Self::TRADER_IMPL,
+                StateOverride {
+                    code: Some(trader_impl),
+                    ..Default::default()
+                },
+            );
+        }
+
+        let output = self.simulator.simulate(call, overrides).await?;
+        let summary = SettleOutput::decode(&output)?;
+        let verified = VerifiedEstimate {
+            out_amount: summary.out_amount(query.kind)?,
+            gas: summary.gas_used.as_u64(),
+            solver: trade.solver,
+        };
+        tracing::debug!(
+            ?query,
+            ?verification,
+            promised_gas = trade.gas_estimate,
+            promised_out_amount =? trade.out_amount,
+            ?verified,
+            "verified quote"
+        );
+        Ok(verified)
+    }
+}
+
+fn encode_interactions(interactions: &[Interaction]) -> Vec<EncodedInteraction> {
+    interactions.iter().map(|i| i.encode()).collect()
+}
+
+fn encode_settlement(
+    query: &PriceQuery,
+    verification: &Verification,
+    trade: &Trade,
+    native_token: H160,
+) -> EncodedSettlement {
+    let mut trade_interactions = encode_interactions(&trade.interactions);
+    if query.buy_token == BUY_ETH_ADDRESS {
+        // Because the `driver` manages `WETH` unwraps under the hood the `TradeFinder`
+        // does not have to emit unwraps to pay out `ETH` in a trade.
+        // However, for the simulation to be successful this has to happen so we do it
+        // ourselves here.
+        let buy_amount = match query.kind {
+            OrderKind::Sell => trade.out_amount,
+            OrderKind::Buy => query.in_amount.get(),
+        };
+        let weth = dummy_contract!(WETH9, native_token);
+        let calldata = weth.methods().withdraw(buy_amount).tx.data.unwrap().0;
+        trade_interactions.push((native_token, 0.into(), Bytes(calldata)));
+        tracing::trace!("adding unwrap interaction for paying out ETH");
+    }
+
+    let tokens = vec![query.sell_token, query.buy_token];
+    let clearing_prices = match query.kind {
+        OrderKind::Sell => vec![trade.out_amount, query.in_amount.get()],
+        OrderKind::Buy => vec![query.in_amount.get(), trade.out_amount],
+    };
+
+    // Configure the most disadvantageous trade possible (while taking possible
+    // overflows into account). Should the trader not receive the amount promised by
+    // the [`Trade`] the simulation will still work and we can compute the actual
+    // [`Trade::out_amount`] afterwards.
+    let (sell_amount, buy_amount) = match query.kind {
+        OrderKind::Sell => (query.in_amount.get(), 0.into()),
+        OrderKind::Buy => (
+            trade.out_amount.max(U256::from(u128::MAX)),
+            query.in_amount.get(),
+        ),
+    };
+    let fake_order = OrderData {
+        sell_token: query.sell_token,
+        sell_amount,
+        buy_token: query.buy_token,
+        buy_amount,
+        receiver: Some(verification.receiver),
+        valid_to: u32::MAX,
+        app_data: Default::default(),
+        fee_amount: 0.into(),
+        kind: query.kind,
+        partially_fillable: false,
+        sell_token_balance: verification.sell_token_source,
+        buy_token_balance: verification.buy_token_destination,
+    };
+
+    let fake_signature = Signature::default_with(SigningScheme::Eip1271);
+    let encoded_trade = encode_trade(
+        &fake_order,
+        &fake_signature,
+        verification.from,
+        0,
+        1,
+        &query.in_amount.get(),
+    );
+
+    EncodedSettlement {
+        tokens,
+        clearing_prices,
+        trades: vec![encoded_trade],
+        interactions: [
+            encode_interactions(&verification.pre_interactions),
+            trade_interactions,
+            encode_interactions(&verification.post_interactions),
+        ],
+    }
+}
+
+/// Adds the interactions that are only needed to query important balances
+/// throughout the simulation.
+/// These balances will get used to compute an accurate price for the trade.
+fn add_balance_queries(
+    mut settlement: EncodedSettlement,
+    query: &PriceQuery,
+    verification: &Verification,
+    settlement_contract: H160,
+    solver: &Solver,
+) -> EncodedSettlement {
+    let (token, owner) = match query.kind {
+        // track how much `buy_token` the `receiver` actually got
+        OrderKind::Sell => (query.buy_token, verification.receiver),
+        // track how much `sell_token` the settlement contract actually spent
+        OrderKind::Buy => (query.sell_token, settlement_contract),
+    };
+    let query_balance = solver.methods().store_balance(token, owner);
+    let query_balance = Bytes(query_balance.tx.data.unwrap().0);
+    let interaction = (solver.address(), 0.into(), query_balance);
+    // query balance right after we receive all `sell_token`
+    settlement.interactions[1].insert(0, interaction.clone());
+    // query balance right after we payed out all `buy_token`
+    settlement.interactions[2].insert(0, interaction);
+    settlement
+}
+
+/// Output of `Trader::settle` smart contract call.
+#[derive(Debug)]
+struct SettleOutput {
+    /// Gas used for the `settle()` call.
+    gas_used: U256,
+    /// Balances queried during the simulation in the order specified during the
+    /// simulation set up.
+    queried_balances: Vec<U256>,
+}
+
+impl SettleOutput {
+    fn decode(output: &[u8]) -> Result<Self> {
+        let function = Solver::raw_contract().abi.function("swap").unwrap();
+        let tokens = function.decode_output(output).context("decode")?;
+        let (gas_used, queried_balances) = Tokenize::from_token(Token::Tuple(tokens))?;
+        Ok(Self {
+            gas_used,
+            queried_balances,
+        })
+    }
+
+    /// Computes the actual [`Trade::out_amount`] based on the simulation.
+    fn out_amount(&self, kind: OrderKind) -> Result<U256> {
+        let balances = &self.queried_balances;
+        let balance_before = balances.first().context("no balance before settlement")?;
+        let balance_after = balances.get(1).context("no balance after settlement")?;
+        let out_amount = match kind {
+            // for sell orders we track the buy_token amount which increases during the settlement
+            OrderKind::Sell => balance_after.checked_sub(*balance_before),
+            // for buy orders we track the sell_token amount which decreases during the settlement
+            OrderKind::Buy => balance_before.checked_sub(*balance_after),
+        };
+        out_amount.context("underflow during out_amount computation")
+    }
+}
+
+#[derive(Debug)]
+pub struct PriceQuery {
+    pub sell_token: H160,
+    // This should be `BUY_ETH_ADDRESS` if you actually want to trade `ETH`
+    pub buy_token: H160,
+    pub kind: OrderKind,
+    pub in_amount: NonZeroU256,
+}

--- a/crates/shared/src/price_estimation/trade_verifier.rs
+++ b/crates/shared/src/price_estimation/trade_verifier.rs
@@ -29,7 +29,7 @@ use {
 
 #[async_trait::async_trait]
 pub trait TradeVerifying: Send + Sync + 'static {
-    /// Verifies that the proposed [`Trade`] acually fulfills the [`PriceQuery`]
+    /// Verifies that the proposed [`Trade`] actually fulfills the [`PriceQuery`]
     /// and returns a price [`Estimate`] that is trustworthy.
     async fn verify(
         &self,

--- a/crates/shared/src/price_estimation/zeroex.rs
+++ b/crates/shared/src/price_estimation/zeroex.rs
@@ -1,6 +1,7 @@
 use {
     super::{
-        trade_finder::{TradeEstimator, TradeVerifier},
+        trade_finder::TradeEstimator,
+        trade_verifier::TradeVerifying,
         PriceEstimateResult,
         PriceEstimating,
         Query,
@@ -33,7 +34,7 @@ impl ZeroExPriceEstimator {
         ))
     }
 
-    pub fn verified(&self, verifier: TradeVerifier) -> Self {
+    pub fn verified(&self, verifier: Arc<dyn TradeVerifying>) -> Self {
         Self(self.0.clone().with_verifier(verifier))
     }
 }


### PR DESCRIPTION
# Description
Mostly moves code around and introduces trait for trade verification which will later be used for unit tests.
Also adds the `verified` flag to quotes but at this point this flag is not yet used for anything.

## How to test
Originally part of https://github.com/cowprotocol/services/pull/2271 and changes were manually tested there.
CI

Fixes: https://github.com/cowprotocol/services/issues/2310