### PR TITLE
Insert default auciton id when we cannot decode it from the auction

### DIFF
--- a/crates/autopilot/src/on_settlement_event_updater.rs
+++ b/crates/autopilot/src/on_settlement_event_updater.rs
@@ -126,7 +126,9 @@ impl OnSettlementEventUpdater {
         let (auction_id, auction_data) =
             match Self::recover_auction_id_from_calldata(&mut ex, &transaction).await? {
                 AuctionIdRecoveryStatus::InvalidCalldata => {
-                    return Ok(false);
+                    // To not get stuck on indexing the same transaction over and over again, we
+                    // insert the default auction ID (0)
+                    (Default::default(), None)
                 }
                 AuctionIdRecoveryStatus::DoNotAddAuctionData(auction_id) => (auction_id, None),
                 AuctionIdRecoveryStatus::AddAuctionData(auction_id, settlement) => (

--- a/crates/e2e/tests/e2e/univ2.rs
+++ b/crates/e2e/tests/e2e/univ2.rs
@@ -64,6 +64,22 @@ async fn test(web3: Web3) {
     );
     let uid = services.create_order(&order).await.unwrap();
 
+    // Mine a trivial settlement (not encoding auction ID). This mimics fee
+    // withdrawals and asserts we can handle these gracefully.
+    tx!(
+        solver.account(),
+        onchain.contracts().gp_settlement.settle(
+            Default::default(),
+            Default::default(),
+            Default::default(),
+            [
+                vec![(trader.address(), U256::from(0), Default::default())],
+                Default::default(),
+                Default::default()
+            ],
+        )
+    );
+
     tracing::info!("Waiting for trade.");
     let trade_happened =
         || async { token.balance_of(trader.address()).call().await.unwrap() != 0.into() };


### PR DESCRIPTION
# Description
We got stuck indexing https://etherscan.io/tx/0x45a80857fb7c7e56375617ac7a5427903a95a2ff41f302ce3527a91fcee695b4 because we cannot decode the auction id from the calldata (it's not encoded).

# Changes
- [x] Insert the default auciton ID and not auction data in case we cannot recover the auction ID from calldata

## How to test
Added an e2e test which is failing on current main.