### PR TITLE
Introduce boundary component for settlement event indexing

### DIFF
--- a/crates/autopilot/src/boundary/events/mod.rs
+++ b/crates/autopilot/src/boundary/events/mod.rs
@@ -1,0 +1,1 @@
+pub mod settlement;

--- a/crates/autopilot/src/boundary/events/settlement.rs
+++ b/crates/autopilot/src/boundary/events/settlement.rs
@@ -1,0 +1,43 @@
+use {
+    crate::database::Postgres,
+    anyhow::Result,
+    ethrpc::current_block::RangeInclusive,
+    shared::{event_handling::EventStoring, impl_event_retrieving},
+};
+
+impl_event_retrieving! {
+    pub GPv2SettlementContract for contracts::gpv2_settlement
+}
+
+pub struct Indexer {
+    db: Postgres,
+}
+
+impl Indexer {
+    pub fn new(db: Postgres) -> Self {
+        Self { db }
+    }
+}
+
+#[async_trait::async_trait]
+impl EventStoring<contracts::gpv2_settlement::Event> for Indexer {
+    async fn last_event_block(&self) -> Result<u64> {
+        let store: &dyn EventStoring<contracts::gpv2_settlement::Event> = &self.db;
+        store.last_event_block().await
+    }
+
+    async fn replace_events(
+        &mut self,
+        events: Vec<ethcontract::Event<contracts::gpv2_settlement::Event>>,
+        range: RangeInclusive<u64>,
+    ) -> Result<()> {
+        self.db.replace_events(events, range).await
+    }
+
+    async fn append_events(
+        &mut self,
+        events: Vec<ethcontract::Event<contracts::gpv2_settlement::Event>>,
+    ) -> Result<()> {
+        self.db.append_events(events).await
+    }
+}

--- a/crates/autopilot/src/boundary/mod.rs
+++ b/crates/autopilot/src/boundary/mod.rs
@@ -27,6 +27,7 @@ pub use {
     shared::order_validation::{is_order_outside_market_price, Amounts},
 };
 
+pub mod events;
 pub mod order;
 
 /// Builds a web3 client that bufferes requests and sends them in a

--- a/crates/autopilot/src/event_updater.rs
+++ b/crates/autopilot/src/event_updater.rs
@@ -1,10 +1,8 @@
 use {
     anyhow::Result,
-    contracts::gpv2_settlement,
     ethrpc::current_block::{BlockNumberHash, BlockRetrieving},
     shared::{
         event_handling::{EventHandler, EventRetrieving, EventStoring},
-        impl_event_retrieving,
         maintenance::Maintaining,
     },
     std::sync::Arc,
@@ -15,10 +13,6 @@ pub struct EventUpdater<
     Database: EventStoring<<W as EventRetrieving>::Event>,
     W: EventRetrieving + Send + Sync,
 >(Mutex<EventHandler<W, Database>>);
-
-impl_event_retrieving! {
-    pub GPv2SettlementContract for gpv2_settlement
-}
 
 impl<Database, W> EventUpdater<Database, W>
 where

--- a/crates/autopilot/src/run.rs
+++ b/crates/autopilot/src/run.rs
@@ -1,6 +1,7 @@
 use {
     crate::{
         arguments::Arguments,
+        boundary,
         database::{
             ethflow_events::event_retriever::EthFlowRefundRetriever,
             onchain_order_events::{
@@ -11,7 +12,7 @@ use {
             Postgres,
         },
         domain,
-        event_updater::{EventUpdater, GPv2SettlementContract},
+        event_updater::EventUpdater,
         infra::{self},
         run_loop::RunLoop,
         shadow,
@@ -448,8 +449,10 @@ pub async fn run(args: Arguments) {
         None
     };
     let event_updater = Arc::new(EventUpdater::new(
-        GPv2SettlementContract::new(eth.contracts().settlement().clone()),
-        db.clone(),
+        boundary::events::settlement::GPv2SettlementContract::new(
+            eth.contracts().settlement().clone(),
+        ),
+        boundary::events::settlement::Indexer::new(db.clone()),
         block_retriever.clone(),
         skip_event_sync_start,
     ));


### PR DESCRIPTION
# Description

Preparation for moving settlement indexing logic into the domain. This PR creates a boundary component which speaks the legacy `EventStoring` interface and will be able to call into the domain. For now, it keeps calling the legacy implementation (inside the database module)

# Changes
- [x] Implement boundary component that implements `EventStoring` for `GPv2Setllement` events
- [x] Simply forwards calls to existing db implementation

## How to test
Existing tests

Part of #2275 