### PR TITLE
More reliable forked_node tests

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -95,9 +95,9 @@ jobs:
       CARGO_PROFILE_DEV_DEBUG: 0
       CARGO_PROFILE_TEST_DEBUG: 0
       CARGO_TERM_COLOR: always
-      FORK_URL_MAINNET: "${{ secrets.FORK_URL_MAINNET }}"
-      FORK_URL_GNOSIS: "${{ secrets.FORK_URL_GNOSIS }}"
-      TOML_TRACE_ERROR: 1      
+      FORK_URL_MAINNET: ${{ secrets.FORK_URL_MAINNET }}
+      FORK_URL_GNOSIS: ${{ secrets.FORK_URL_GNOSIS }}
+      TOML_TRACE_ERROR: 1
     steps:
       - uses: actions/checkout@v3
       - uses: foundry-rs/foundry-toolchain@v1

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -110,7 +110,7 @@ jobs:
         with:
           file: docker-compose.yaml
           up-opts: -d db migrations
-      - run: cargo nextest run -p e2e forked_node --test-threads 1 --failure-output final --run-ignored ignored-only
+      - run: cargo nextest run -p e2e forked_node --test-threads 1 --nocapture --run-ignored ignored-only
 
   test-driver:
     timeout-minutes: 60

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -93,8 +93,8 @@ jobs:
       CARGO_PROFILE_DEV_DEBUG: 0
       CARGO_PROFILE_TEST_DEBUG: 0
       CARGO_TERM_COLOR: always
-      FORK_URL_MAINNET: ${{ secrets.FORK_URL_MAINNET }}
-      FORK_URL_GNOSIS: ${{ secrets.FORK_URL_GNOSIS }}
+      FORK_URL_MAINNET: "${{ secrets.FORK_URL_MAINNET }}"
+      FORK_URL_GNOSIS: "${{ secrets.FORK_URL_GNOSIS }}"
       TOML_TRACE_ERROR: 1      
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -88,6 +88,8 @@ jobs:
   test-forked-node:
     timeout-minutes: 60
     runs-on: ubuntu-latest
+    concurrency:
+      group: archive_node
     env:
       # Shrink artifact size by not including debug info. Makes build faster and shrinks cache.
       CARGO_PROFILE_DEV_DEBUG: 0

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -110,7 +110,7 @@ jobs:
         with:
           file: docker-compose.yaml
           up-opts: -d db migrations
-      - run: cargo nextest run -p e2e forked_node --test-threads 1 --nocapture --run-ignored ignored-only
+      - run: cargo nextest run -p e2e forked_node --nocapture --run-ignored ignored-only
 
   test-driver:
     timeout-minutes: 60

--- a/crates/e2e/src/nodes/mod.rs
+++ b/crates/e2e/src/nodes/mod.rs
@@ -82,7 +82,7 @@ impl Node {
             }
         });
 
-        let _url = tokio::time::timeout(tokio::time::Duration::from_secs(5), receiver)
+        let _url = tokio::time::timeout(tokio::time::Duration::from_secs(20), receiver)
             .await
             .expect("finding anvil URL timed out")
             .unwrap();


### PR DESCRIPTION
# Changes
- increase `anvil` start up timeout to `20s` because for some reason it can be super slow using a xdai fork url
- introduced a concurrency group for the forked node test since we experienced some rate limiting from the archive node RPC we use for mainnet
- use `--nocapture` for forked node tests to always get the entire logs to make it easier to debug when something unexpected happens

## How to test
forked tests should hopefully pass in CI