### PR TITLE
Don't submit risky settlements in public mempool for domain submissions

### DIFF
--- a/crates/driver/src/infra/mempool/mod.rs
+++ b/crates/driver/src/infra/mempool/mod.rs
@@ -82,4 +82,11 @@ impl Inner {
     pub fn config(&self) -> &Config {
         &self.config
     }
+
+    pub fn may_revert(&self) -> bool {
+        match &self.config.kind {
+            Kind::Public(_) => true,
+            Kind::MEVBlocker { .. } => false,
+        }
+    }
 }

--- a/crates/driver/src/infra/notify/mod.rs
+++ b/crates/driver/src/infra/notify/mod.rs
@@ -116,7 +116,7 @@ pub fn executed(
         Ok(hash) => notification::Settlement::Success(hash.clone()),
         Err(Error::Revert(hash)) => notification::Settlement::Revert(hash.clone()),
         Err(Error::SimulationRevert) => notification::Settlement::SimulationRevert,
-        Err(Error::Other(_) | Error::Expired) => notification::Settlement::Fail,
+        Err(Error::Other(_) | Error::Expired | Error::Disabled) => notification::Settlement::Fail,
     };
 
     solver.notify(

--- a/crates/driver/src/infra/observe/mod.rs
+++ b/crates/driver/src/infra/observe/mod.rs
@@ -339,6 +339,7 @@ pub fn mempool_executed(
         Err(mempools::Error::Revert(_) | mempools::Error::SimulationRevert) => "Revert",
         Err(mempools::Error::Expired) => "Expired",
         Err(mempools::Error::Other(_)) => "Other",
+        Err(mempools::Error::Disabled) => "Disabled",
     };
     metrics::get()
         .mempool_submission


### PR DESCRIPTION
# Description
We are seeing some risky settlements being submitted via the public mempool in staging (e.g. https://etherscan.io/tx/0xb47602e564a46203b3df944677aae6f5436d22219c0b1c4b136501eaee15d163)

This is because the new submission logic doesn't ensure we don't submit revertable transactions via MEVBlocker only.

# Changes
- [x] Skip public mempool submission for revertable settlements

## How to test
Unfortunately MEVBlocker submission isn't covered by end to end test and neither driver tests.