### PR TITLE
Add block_number to order_execution

### DIFF
--- a/crates/autopilot/src/database/on_settlement_event_updater.rs
+++ b/crates/autopilot/src/database/on_settlement_event_updater.rs
@@ -69,6 +69,7 @@ impl super::Postgres {
                     ex,
                     &ByteArray(order.0),
                     settlement_update.auction_id,
+                    settlement_update.block_number,
                     &u256_to_big_decimal(&executed_fee),
                 )
                 .await

--- a/crates/database/src/events.rs
+++ b/crates/database/src/events.rs
@@ -72,7 +72,7 @@ pub async fn delete(
     ex.execute(sqlx::query(QUERY_PRESIGNATURES).bind(delete_from_block_number))
         .await?;
 
-    // Observations and order executions are not events but data deducted from the
+    // Observations and order executions are not events but data derived from the
     // onchain data. The reason we delete them here is that we want to keep the
     // database state consistent.
 

--- a/crates/database/src/events.rs
+++ b/crates/database/src/events.rs
@@ -68,13 +68,21 @@ pub async fn delete(
     ex.execute(sqlx::query(QUERY_SETTLEMENTS).bind(delete_from_block_number))
         .await?;
 
+    const QUERY_PRESIGNATURES: &str = "DELETE FROM presignature_events WHERE block_number >= $1;";
+    ex.execute(sqlx::query(QUERY_PRESIGNATURES).bind(delete_from_block_number))
+        .await?;
+
+    // Observations and order executions are not events but data deducted from the
+    // onchain data. The reason we delete them here is that we want to keep the
+    // database state consistent.
+
     const QUERY_OBSERVATIONS: &str =
         "DELETE FROM settlement_observations WHERE block_number >= $1;";
     ex.execute(sqlx::query(QUERY_OBSERVATIONS).bind(delete_from_block_number))
         .await?;
 
-    const QUERY_PRESIGNATURES: &str = "DELETE FROM presignature_events WHERE block_number >= $1;";
-    ex.execute(sqlx::query(QUERY_PRESIGNATURES).bind(delete_from_block_number))
+    const QUERY_ORDER_EXECUTIONS: &str = "DELETE FROM order_execution WHERE block_number >= $1;";
+    ex.execute(sqlx::query(QUERY_ORDER_EXECUTIONS).bind(delete_from_block_number))
         .await?;
 
     Ok(())

--- a/crates/database/src/order_execution.rs
+++ b/crates/database/src/order_execution.rs
@@ -8,19 +8,21 @@ pub async fn save(
     ex: &mut PgConnection,
     order: &OrderUid,
     auction: AuctionId,
+    block_number: i64,
     executed_fee: &BigDecimal,
 ) -> Result<(), sqlx::Error> {
     const QUERY: &str = r#"
-INSERT INTO order_execution (order_uid, auction_id, reward, surplus_fee)
-VALUES ($1, $2, $3, $4)
+INSERT INTO order_execution (order_uid, auction_id, reward, surplus_fee, block_number)
+VALUES ($1, $2, $3, $4, $5)
 ON CONFLICT (order_uid, auction_id)
-DO UPDATE SET reward = $3, surplus_fee = $4
+DO UPDATE SET reward = $3, surplus_fee = $4, block_number = $5
 ;"#;
     sqlx::query(QUERY)
         .bind(order)
         .bind(auction)
         .bind(0.) // reward is deprecated but saved for historical analysis
         .bind(Some(executed_fee))
+        .bind(block_number)
         .execute(ex)
         .await?;
     Ok(())
@@ -37,7 +39,7 @@ mod tests {
         let mut db = db.begin().await.unwrap();
         crate::clear_DANGER_(&mut db).await.unwrap();
 
-        save(&mut db, &Default::default(), 0, &Default::default())
+        save(&mut db, &Default::default(), 1, 0, &Default::default())
             .await
             .unwrap();
     }

--- a/crates/database/src/orders.rs
+++ b/crates/database/src/orders.rs
@@ -1815,7 +1815,7 @@ mod tests {
         assert_eq!(order.executed_surplus_fee, 0.into());
 
         let fee: BigDecimal = 1.into();
-        crate::order_execution::save(&mut db, &order_uid, 0, &fee)
+        crate::order_execution::save(&mut db, &order_uid, 1, 0, &fee)
             .await
             .unwrap();
 

--- a/database/README.md
+++ b/database/README.md
@@ -188,6 +188,7 @@ Contains metainformation for trades, required for reward computations that canno
  reward       | double  | not null | revert adjusted solver rewards, deprecated in favor of [CIP-20](https://snapshot.org/#/cow.eth/proposal/0x2d3f9bd1ea72dca84b03e97dda3efc1f4a42a772c54bd2037e8b62e7d09a491f)
  surplus\_fee | numeric | nullable | dynamic fee computed by the protocol that should get taken from the surplus of a trade, this value only applies and is set for fill-or-kill limit orders.
  solver\_fee  | numeric | nullable | value that is used for objective value computations. This either contains a fee equal to the execution cost of this trade computed by a solver (only applies to partially fillable limit orders) or the solver\_fee computed by the backend adjusted for this trades fill amount (solver\_fees computed by the backend may include subsidies).
+ block\_number| bigint  | not null | block in which the order was executed
 
 Indexes:
 - PRIMARY KEY: btree(`order_uid`, `auction_id`)

--- a/database/sql/V059__add_block_number_order_execution.sql
+++ b/database/sql/V059__add_block_number_order_execution.sql
@@ -1,8 +1,11 @@
 ALTER TABLE order_execution
-    ADD COLUMN block_number bigint NOT NULL;
+    ADD COLUMN block_number bigint NOT NULL DEFAULT 0;
 
 -- Populate block_number for existing records
 UPDATE order_execution
-SET block_number = COALESCE(settlements.block_number, 0)
+SET block_number = settlements.block_number
 FROM settlements
 WHERE order_execution.auction_id = settlements.auction_id;
+
+ALTER TABLE order_execution
+    ALTER COLUMN block_number DROP DEFAULT;

--- a/database/sql/V059__add_block_number_order_execution.sql
+++ b/database/sql/V059__add_block_number_order_execution.sql
@@ -1,0 +1,8 @@
+ALTER TABLE order_execution
+    ADD COLUMN block_number bigint NOT NULL DEFAULT 0;
+
+-- Populate block_number for existing records
+UPDATE order_execution
+SET block_number = settlements.block_number
+FROM settlements
+WHERE order_execution.auction_id = settlements.auction_id;

--- a/database/sql/V059__add_block_number_order_execution.sql
+++ b/database/sql/V059__add_block_number_order_execution.sql
@@ -1,8 +1,8 @@
 ALTER TABLE order_execution
-    ADD COLUMN block_number bigint NOT NULL DEFAULT 0;
+    ADD COLUMN block_number bigint NOT NULL;
 
 -- Populate block_number for existing records
 UPDATE order_execution
-SET block_number = settlements.block_number
+SET block_number = COALESCE(settlements.block_number, 0)
 FROM settlements
 WHERE order_execution.auction_id = settlements.auction_id;


### PR DESCRIPTION
# Description
Adds `block_number` column to db table `order_execution`.

This is to make the table reorg friendly, meaning, whenever reorg happens, event updater will also delete all entries in this table that are from reorged block.

This enables us to remove the delay of 64 blocks in the `OnSettlementEventUpdater` component. Removal will be implemented in a separate PR so that it can be easily reverted if need be.