### PR TITLE
Test that settlements with revert risk aren't submitted via public mempool

### DIFF
--- a/crates/driver/src/infra/blockchain/gas.rs
+++ b/crates/driver/src/infra/blockchain/gas.rs
@@ -72,7 +72,6 @@ impl GasPriceEstimator {
                             .min(estimate.max_fee_per_gas * additional_tip_percentage);
                         estimate.max_fee_per_gas += additional_tip;
                         estimate.max_priority_fee_per_gas += additional_tip;
-                        estimate = estimate.ceil();
                         estimate
                     }
                     None => estimate,

--- a/crates/driver/src/tests/cases/settle.rs
+++ b/crates/driver/src/tests/cases/settle.rs
@@ -47,3 +47,28 @@ async fn solution_not_available() {
 
     test.settle().await.err().kind("SolutionNotAvailable");
 }
+
+/// Checks that settlements with revert risk are not submitted via public
+/// mempool.
+#[tokio::test]
+#[ignore]
+async fn private_rpc_with_high_risk_solution() {
+    let test = tests::setup()
+        .name("private rpc")
+        .pool(ab_pool())
+        .order(ab_order())
+        .solution(ab_solution())
+        .mempools(vec![
+            tests::setup::Mempool::Public,
+            tests::setup::Mempool::Private {
+                url: Some("http://non-existant:8545".to_string()),
+            },
+        ])
+        .done()
+        .await;
+
+    test.solve().await.ok().default_score();
+    // Public cannot be used and private RPC is not available
+    let err = test.settle().await.err();
+    err.kind("FailedToSubmit");
+}

--- a/crates/driver/src/tests/setup/mod.rs
+++ b/crates/driver/src/tests/setup/mod.rs
@@ -295,6 +295,15 @@ pub struct Pool {
     pub amount_b: eth::U256,
 }
 
+#[derive(Debug)]
+pub enum Mempool {
+    Public,
+    Private {
+        /// Uses ethrpc node if None
+        url: Option<String>,
+    },
+}
+
 /// Create a builder for the setup process.
 pub fn setup() -> Setup {
     Setup {
@@ -308,6 +317,7 @@ pub fn setup() -> Setup {
         solvers: vec![test_solver()],
         enable_simulation: true,
         settlement_address: Default::default(),
+        mempools: vec![Mempool::Public],
     }
 }
 
@@ -327,6 +337,8 @@ pub struct Setup {
     enable_simulation: bool,
     /// Ensure the settlement contract is deployed on a specific address?
     settlement_address: Option<eth::H160>,
+    /// Via which mempool the solutions should be submitted
+    mempools: Vec<Mempool>,
 }
 
 /// The validity of a solution.
@@ -556,6 +568,11 @@ impl Setup {
         self
     }
 
+    pub fn mempools(mut self, mempools: Vec<Mempool>) -> Self {
+        self.mempools = mempools;
+        self
+    }
+
     /// Create the test: set up onchain contracts and pools, start a mock HTTP
     /// server for the solver and start the HTTP server for the driver.
     pub async fn done(self) -> Test {
@@ -625,6 +642,7 @@ impl Setup {
             &driver::Config {
                 config_file,
                 enable_simulation: self.enable_simulation,
+                mempools: self.mempools,
             },
             &solvers_with_address,
             &blockchain,


### PR DESCRIPTION
# Description
Integration test for #2337

# Changes
<!-- List of detailed changes (how the change is accomplished) -->

- [x] Introduce mempool for driver tests
- [x] Use native submission by default in tests
- [x] I also needed to remove the ceiling of gas price (as it leads to off-by-one error wrt to the expected gas estimate). I don't think this is an issue as we are talking about 1 atom rounding (which should never make a difference in practice)

## How to test
Checkout `v2.243.1`, see test failing there.

<!--
## Related Issues

Fixes #
-->