### PR TITLE
Remove partial fill flag on quote request

### DIFF
--- a/crates/e2e/tests/e2e/ethflow.rs
+++ b/crates/e2e/tests/e2e/ethflow.rs
@@ -698,7 +698,6 @@ impl EthFlowTradeIntent {
             },
             buy_token_balance: BuyTokenDestination::Erc20,
             sell_token_balance: SellTokenSource::Erc20,
-            partially_fillable: false,
             price_quality: PriceQuality::Optimal,
         }
     }

--- a/crates/model/src/quote.rs
+++ b/crates/model/src/quote.rs
@@ -131,8 +131,6 @@ pub struct OrderQuoteRequest {
     #[serde(flatten, deserialize_with = "deserialize_optional_app_data")]
     pub app_data: OrderCreationAppData,
     #[serde(default)]
-    pub partially_fillable: bool,
-    #[serde(default)]
     pub sell_token_balance: SellTokenSource,
     #[serde(default)]
     pub buy_token_balance: BuyTokenDestination,

--- a/crates/model/src/quote.rs
+++ b/crates/model/src/quote.rs
@@ -332,7 +332,6 @@ mod tests {
                 "buyAmountAfterFee": "1",
                 "validFor": 1800,
                 "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
-                "partiallyFillable": false,
                 "sellTokenBalance": "erc20",
                 "buyTokenBalance": "erc20",
                 "signingScheme": "eip712",

--- a/crates/orderbook/openapi.yml
+++ b/crates/orderbook/openapi.yml
@@ -1385,9 +1385,6 @@ components:
                 In case they differ, the call will fail.
               anyOf:
                 - $ref: "#/components/schemas/AppDataHash"
-            partiallyFillable:
-              description: Is the order fill-or-kill or partially fillable?
-              type: boolean
             sellTokenBalance:
               allOf:
                 - $ref: "#/components/schemas/SellTokenSource"

--- a/crates/orderbook/src/api/post_quote.rs
+++ b/crates/orderbook/src/api/post_quote.rs
@@ -129,7 +129,6 @@ mod tests {
                 },
                 validity: Validity::To(0x12345678),
                 app_data: AppDataHash([0x90; 32]).into(),
-                partially_fillable: false,
                 sell_token_balance: SellTokenSource::Erc20,
                 buy_token_balance: BuyTokenDestination::Internal,
                 signing_scheme: QuoteSigningScheme::PreSign {
@@ -168,7 +167,6 @@ mod tests {
                 },
                 validity: Validity::For(1000),
                 app_data: AppDataHash([0x90; 32]).into(),
-                partially_fillable: false,
                 sell_token_balance: SellTokenSource::External,
                 price_quality: PriceQuality::Fast,
                 ..Default::default()
@@ -201,7 +199,6 @@ mod tests {
                 },
                 validity: Validity::To(0x12345678),
                 app_data: AppDataHash([0x90; 32]).into(),
-                partially_fillable: false,
                 ..Default::default()
             }
         );

--- a/crates/orderbook/src/quoter.rs
+++ b/crates/orderbook/src/quoter.rs
@@ -125,7 +125,7 @@ impl QuoteHandler {
                 },
                 fee_amount: quote.fee_amount,
                 kind: quote.data.kind,
-                partially_fillable: request.partially_fillable,
+                partially_fillable: false,
                 sell_token_balance: request.sell_token_balance,
                 buy_token_balance: request.buy_token_balance,
                 signing_scheme: request.signing_scheme.into(),

--- a/crates/shared/src/order_quoting.rs
+++ b/crates/shared/src/order_quoting.rs
@@ -582,7 +582,7 @@ impl From<&OrderQuoteRequest> for PreOrderData {
             buy_token: quote_request.buy_token,
             receiver: quote_request.receiver.unwrap_or(owner),
             valid_to: quote_request.validity.actual_valid_to(),
-            partially_fillable: quote_request.partially_fillable,
+            partially_fillable: false,
             buy_token_balance: quote_request.buy_token_balance,
             sell_token_balance: quote_request.sell_token_balance,
             signing_scheme: quote_request.signing_scheme.into(),


### PR DESCRIPTION
# Description
We received some questions via discord that were struggling getting quote requests to work with swagger because of the following error "UnuspportedOrderType".

The reason for this is that in our swagger definition `partiallyFillable` defaults to true, however in code it is required to be set to false (we hardcode the order type for quotes to `Market` [here](https://github.com/cowprotocol/services/blob/130ef0b1a7b75a62a2731860b26a02f7a51a4cdb/crates/shared/src/order_quoting.rs#L589) and market orders cannot be partially fillable due to fees).

Given that the field carries no entropy, this PR removes `partiallyFillable` from the `OrderQuoteRequest` and it's documentation to avoid this confusion going forward.

# Changes
- [x] Remove partially fillable flag from `OrderQuoteRequest` and assume it to be `false` elsewhere in code

## How to test
Existing unit test