### PR TITLE
Add stale bot workflow

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,17 @@
+name: Nag Stale Pull Requests
+on:
+  schedule:
+    - cron: '0 0 * * *'  # Run every day at midnight
+jobs:
+  close_stale_prs:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Close stale pull requests
+        uses: actions/stale@v5
+        with:
+          days-before-stale: 7
+          days-before-issue-stale: 60
+          days-before-close: 7
+          stale-pr-message: 'This pull request has been marked as stale because it has been inactive a while. Please update this pull request or it will be automatically closed.'
+          stale-issue-message: 'This issue has been marked as stale because it has been inactive a while. Please update this issue or it will be automatically closed.'
+          stale-pr-label: stale


### PR DESCRIPTION
# Description
In an effort to help us drive half finished PRs to completion fast, I'm proposing to enable the following github action which will nag us if a PR is open for more than 7 days and automatically close issues after another 7 days.

# Changes

- [x] New workflow file