### PR TITLE
Eth flow zero fee fix order class

### DIFF
--- a/crates/autopilot/src/run.rs
+++ b/crates/autopilot/src/run.rs
@@ -524,7 +524,6 @@ pub async fn run(args: Arguments) {
             Box::new(custom_ethflow_order_parser),
             DomainSeparator::new(chain_id, eth.contracts().settlement().address()),
             eth.contracts().settlement().address(),
-            liquidity_order_owners,
         );
         let broadcaster_event_updater = Arc::new(
             EventUpdater::new_skip_blocks_before(

--- a/crates/e2e/tests/e2e/ethflow.rs
+++ b/crates/e2e/tests/e2e/ethflow.rs
@@ -128,10 +128,7 @@ async fn eth_flow_tx_zero_fee(web3: Web3) {
             .get_order(&ethflow_order.uid(onchain.contracts()).await)
             .await
             .unwrap();
-        match order.metadata.class {
-            OrderClass::Limit => order.metadata.executed_surplus_fee > U256::zero(),
-            _ => panic!("unexpected order class"),
-        }
+        order.metadata.executed_surplus_fee > U256::zero()
     };
     wait_for_condition(TIMEOUT, fee_charged).await.unwrap();
 

--- a/crates/e2e/tests/e2e/ethflow.rs
+++ b/crates/e2e/tests/e2e/ethflow.rs
@@ -124,7 +124,10 @@ async fn eth_flow_tx_zero_fee(web3: Web3) {
     // make sure the fee was charged for zero fee limit orders
     let fee_charged = || async {
         onchain.mint_block().await;
-        let order = services.get_order(&ethflow_order.uid(onchain.contracts()).await).await.unwrap();
+        let order = services
+            .get_order(&ethflow_order.uid(onchain.contracts()).await)
+            .await
+            .unwrap();
         match order.metadata.class {
             OrderClass::Limit => order.metadata.executed_surplus_fee > U256::zero(),
             _ => true,

--- a/crates/e2e/tests/e2e/ethflow.rs
+++ b/crates/e2e/tests/e2e/ethflow.rs
@@ -259,6 +259,9 @@ async fn eth_flow_tx_insufficient_fee(web3: Web3) {
         order.metadata.onchain_order_data.unwrap().placement_error,
         Some(OnchainOrderPlacementError::InsufficientFee)
     );
+
+    let auction_is_empty = || async { services.solvable_orders().await == 0 };
+    wait_for_condition(TIMEOUT, auction_is_empty).await.unwrap();
 }
 
 async fn eth_flow_indexing_after_refund(web3: Web3) {

--- a/crates/e2e/tests/e2e/ethflow.rs
+++ b/crates/e2e/tests/e2e/ethflow.rs
@@ -15,6 +15,7 @@ use {
             BuyTokenDestination,
             EthflowData,
             OnchainOrderData,
+            OnchainOrderPlacementError,
             Order,
             OrderBuilder,
             OrderClass,
@@ -50,6 +51,12 @@ const DAI_PER_ETH: u32 = 1_000;
 #[ignore]
 async fn local_node_eth_flow() {
     run_test(eth_flow_tx).await;
+}
+
+#[tokio::test]
+#[ignore]
+async fn local_node_eth_flow_insufficient_fee() {
+    run_test(eth_flow_tx_insufficient_fee).await;
 }
 
 #[tokio::test]
@@ -201,6 +208,57 @@ async fn eth_flow_tx(web3: Web3) {
         onchain.contracts(),
     )
     .await;
+}
+
+async fn eth_flow_tx_insufficient_fee(web3: Web3) {
+    let mut onchain = OnchainComponents::deploy(web3.clone()).await;
+
+    let [solver] = onchain.make_solvers(to_wei(2)).await;
+    let [trader] = onchain.make_accounts(to_wei(2)).await;
+
+    // Create token with Uniswap pool for price estimation
+    let [dai] = onchain
+        .deploy_tokens_with_weth_uni_v2_pools(to_wei(DAI_PER_ETH * 1_000), to_wei(1_000))
+        .await;
+
+    // Get a quote from the services
+    let buy_token = dai.address();
+    let receiver = H160([0x42; 20]);
+    let sell_amount = to_wei(1);
+    let intent = EthFlowTradeIntent {
+        sell_amount,
+        buy_token,
+        receiver,
+    };
+
+    let services = Services::new(onchain.contracts()).await;
+    services.start_protocol(solver).await;
+
+    let quote: OrderQuoteResponse = test_submit_quote(
+        &services,
+        &intent.to_quote_request(trader.account().address(), &onchain.contracts().weth),
+    )
+    .await;
+
+    let valid_to = chrono::offset::Utc::now().timestamp() as u32
+        + timestamp_of_current_block_in_seconds(&web3).await.unwrap()
+        + 3600;
+    let mut ethflow_order =
+        ExtendedEthFlowOrder::from_quote(&quote, valid_to).include_slippage_bps(300);
+    // set a fee amount that is lower than the quoted fee amount
+    ethflow_order.0.fee_amount = 1.into();
+
+    submit_order(&ethflow_order, trader.account(), onchain.contracts()).await;
+
+    let uid = ethflow_order.uid(onchain.contracts()).await;
+    let is_available = || async { services.get_order(&uid).await.is_ok() };
+    wait_for_condition(TIMEOUT, is_available).await.unwrap();
+
+    let order = services.get_order(&uid).await.unwrap();
+    assert_eq!(
+        order.metadata.onchain_order_data.unwrap().placement_error,
+        Some(OnchainOrderPlacementError::InsufficientFee)
+    );
 }
 
 async fn eth_flow_indexing_after_refund(web3: Web3) {

--- a/crates/e2e/tests/e2e/ethflow.rs
+++ b/crates/e2e/tests/e2e/ethflow.rs
@@ -130,7 +130,7 @@ async fn eth_flow_tx_zero_fee(web3: Web3) {
             .unwrap();
         match order.metadata.class {
             OrderClass::Limit => order.metadata.executed_surplus_fee > U256::zero(),
-            _ => true,
+            _ => panic!("unexpected order class"),
         }
     };
     wait_for_condition(TIMEOUT, fee_charged).await.unwrap();

--- a/crates/model/src/order.rs
+++ b/crates/model/src/order.rs
@@ -352,8 +352,14 @@ impl OrderData {
     }
 
     /// Checks if the order is a market order.
-    pub fn within_market(&self, quote_sell_amount: &U256, quote_buy_amount: &U256) -> bool {
-        self.sell_amount.full_mul(*quote_buy_amount) >= quote_sell_amount.full_mul(self.buy_amount)
+    pub fn within_market(
+        &self,
+        quote_sell_amount: &U256,
+        quote_buy_amount: &U256,
+        quote_fee_amount: &U256,
+    ) -> bool {
+        (self.sell_amount + self.fee_amount).full_mul(*quote_buy_amount)
+            >= (quote_sell_amount + quote_fee_amount).full_mul(self.buy_amount)
     }
 }
 

--- a/crates/model/src/order.rs
+++ b/crates/model/src/order.rs
@@ -352,15 +352,19 @@ impl OrderData {
     }
 
     /// Checks if the order is a market order.
-    pub fn within_market(
-        &self,
-        quote_sell_amount: &U256,
-        quote_buy_amount: &U256,
-        quote_fee_amount: &U256,
-    ) -> bool {
-        (self.sell_amount + self.fee_amount).full_mul(*quote_buy_amount)
-            >= (quote_sell_amount + quote_fee_amount).full_mul(self.buy_amount)
+    pub fn within_market(&self, quote: QuoteAmounts) -> bool {
+        (self.sell_amount + self.fee_amount).full_mul(quote.buy)
+            >= (quote.sell + quote.fee).full_mul(self.buy_amount)
     }
+}
+
+/// Defines the quote exchange rate. The quote says it can sell `sell` amount of
+/// sell token and buy `buy` amount of buy token. Additionally, `fee``
+/// denominated in the sell token needs to be payed.
+pub struct QuoteAmounts {
+    pub sell: U256,
+    pub buy: U256,
+    pub fee: U256,
 }
 
 /// An order as provided to the POST order endpoint.


### PR DESCRIPTION
# Description
Fixes https://github.com/cowprotocol/services/issues/2356

# Changes
<!-- List of detailed changes (how the change is accomplished) -->

- [x] Order is `Market` if within market (by comparing to quote) AND if signed `fee_amount` is > 0. 
- [x] Adjust the `within_market` calculation to include fees (as already discussed and fixed in other parts of the system)

## How to test
Adjusted existing tests. Added check for `executed_surplus_fee` for signed zero fee ethflow order.