### PR TITLE
[TRIVIAL] Remove unnecessary minting in tests

### DIFF
--- a/crates/e2e/src/setup/onchain_components.rs
+++ b/crates/e2e/src/setup/onchain_components.rs
@@ -475,23 +475,6 @@ impl OnchainComponents {
             .unwrap();
     }
 
-    /// We will only index events when they are 64 blocks old so we don't have
-    /// to throw out indexed data on reorgs.
-    /// This function executes enough transactions to ensure that all events
-    /// before calling this function are old enough to be indexed.
-    pub async fn mint_blocks_past_reorg_threshold(&self) {
-        tracing::info!("mining blocks to get past the reorg safety threshold for indexing events");
-
-        let current_block = || async { self.web3.eth().block_number().await.unwrap() };
-        let target = current_block().await + 65;
-        // Simply issuing n transactions may not result in n blocks being mined.
-        // Therefore we continually call `evm_mine` until we can confirm the block
-        // number increased the expected number of times.
-        while current_block().await <= target {
-            let _ = self.web3.transport().execute("evm_mine", vec![]).await;
-        }
-    }
-
     pub async fn mint_block(&self) {
         tracing::info!("mining block");
         self.web3

--- a/crates/e2e/tests/e2e/partial_fill.rs
+++ b/crates/e2e/tests/e2e/partial_fill.rs
@@ -89,8 +89,6 @@ async fn test(web3: Web3) {
             .contains(&buy_balance.as_u128())
     );
 
-    onchain.mint_blocks_past_reorg_threshold().await;
-
     let settlement_event_processed = || async {
         onchain.mint_block().await;
         let order = services.get_order(&uid).await.unwrap();

--- a/crates/e2e/tests/e2e/partially_fillable_pool.rs
+++ b/crates/e2e/tests/e2e/partially_fillable_pool.rs
@@ -117,7 +117,6 @@ async fn test(web3: Web3) {
             .contains(&buy_balance.as_u128())
     );
 
-    onchain.mint_blocks_past_reorg_threshold().await;
     let metadata_updated = || async {
         onchain.mint_block().await;
         let order = services.get_order(&uid).await.unwrap();

--- a/crates/e2e/tests/e2e/protocol_fee.rs
+++ b/crates/e2e/tests/e2e/protocol_fee.rs
@@ -329,7 +329,6 @@ async fn execute_test(
         .await
         .unwrap();
 
-    onchain.mint_blocks_past_reorg_threshold().await;
     let metadata_updated = || async {
         onchain.mint_block().await;
         let order = services.get_order(&uid).await.unwrap();

--- a/crates/e2e/tests/e2e/solver_competition.rs
+++ b/crates/e2e/tests/e2e/solver_competition.rs
@@ -93,8 +93,6 @@ async fn solver_competition(web3: Web3) {
         || async { token_a.balance_of(trader.address()).call().await.unwrap() == U256::zero() };
     wait_for_condition(TIMEOUT, trade_happened).await.unwrap();
 
-    onchain.mint_blocks_past_reorg_threshold().await;
-
     let indexed_trades = || async {
         onchain.mint_block().await;
         match services.get_trades(&uid).await.unwrap().first() {

--- a/crates/e2e/tests/e2e/univ2.rs
+++ b/crates/e2e/tests/e2e/univ2.rs
@@ -105,8 +105,6 @@ async fn test(web3: Web3) {
         .await
         .unwrap();
 
-    onchain.mint_blocks_past_reorg_threshold().await;
-
     let cip_20_data_updated = || async {
         onchain.mint_block().await;
         let data = match crate::database::most_recent_cip_20_data(services.db()).await {


### PR DESCRIPTION
# Description
Since https://github.com/cowprotocol/services/pull/2340 is stable, we can remove the waiting for 64 blocks in tests.

## How to test
Updated tests