### PR TITLE
No alert if reorg happens

### DIFF
--- a/crates/autopilot/src/on_settlement_event_updater.rs
+++ b/crates/autopilot/src/on_settlement_event_updater.rs
@@ -107,12 +107,9 @@ impl OnSettlementEventUpdater {
         let hash = H256(event.tx_hash.0);
         tracing::debug!("updating settlement details for tx {hash:?}");
 
-        let transaction = match self.eth.transaction(hash).await? {
-            Some(tx) => tx,
-            None => {
-                tracing::warn!(?hash, "no tx found, reorg happened");
-                return Ok(false);
-            }
+        let Some(transaction) = self.eth.transaction(hash).await? else {
+            tracing::warn!(?hash, "no tx found, reorg happened");
+            return Ok(false);
         };
 
         let (auction_id, auction_data) =

--- a/crates/autopilot/src/on_settlement_event_updater.rs
+++ b/crates/autopilot/src/on_settlement_event_updater.rs
@@ -107,11 +107,13 @@ impl OnSettlementEventUpdater {
         let hash = H256(event.tx_hash.0);
         tracing::debug!("updating settlement details for tx {hash:?}");
 
-        let transaction = self
-            .eth
-            .transaction(hash)
-            .await?
-            .with_context(|| format!("no tx {hash:?}"))?;
+        let transaction = match self.eth.transaction(hash).await? {
+            Some(tx) => tx,
+            None => {
+                tracing::warn!(?hash, "no tx found, reorg happened");
+                return Ok(false);
+            }
+        };
 
         let (auction_id, auction_data) =
             match Self::recover_auction_id_from_calldata(&mut ex, &transaction).await? {


### PR DESCRIPTION
# Description
Related to staging alert: https://cowservices.slack.com/archives/C037PB929ME/p1707099846201309

Since `EventHandler` and `OnSettlementEventUpdater` are racing to update on each new block, in case the reorg happens and `OnSettlementEventUpdater` is faster, it will potentially catch an event containing tx hash that was reorged.

This PR lowers the severity of this issue (we don't want slack alerts for this). This is a temporary fix until we make event handling pipelined.