### PR TITLE
Update Flyway to 10.7.1

### DIFF
--- a/docker/Dockerfile.migration
+++ b/docker/Dockerfile.migration
@@ -1,4 +1,4 @@
-FROM docker.io/flyway/flyway:7.5.3
+FROM docker.io/flyway/flyway:10.7.1
 
 COPY database/sql sql/
 COPY database/flyway.conf conf/


### PR DESCRIPTION
# Description
The current version doesn't work on ARM architecture. I had to update to v8, but we can probably jump directly to the latest version.

## How to test
Local/CI runs