### PR TITLE
fix: legacy quoter support

### DIFF
--- a/crates/e2e/src/setup/services.rs
+++ b/crates/e2e/src/setup/services.rs
@@ -89,7 +89,7 @@ impl<'a> Services<'a> {
     fn api_autopilot_arguments() -> impl Iterator<Item = String> {
         [
             "--price-estimators=None".to_string(),
-            "--native-price-estimators=test_solver".to_string(),
+            "--native-price-estimators=test_quoter".to_string(),
             "--amount-to-estimate-prices-with=1000000000000000000".to_string(),
             "--block-stream-poll-interval=1s".to_string(),
             "--trade-simulator=Web3".to_string(),
@@ -182,12 +182,12 @@ impl<'a> Services<'a> {
             None,
             vec![
                 "--drivers=test_solver|http://localhost:11088/test_solver".to_string(),
-                "--price-estimation-drivers=test_solver|http://localhost:11088/test_solver"
+                "--price-estimation-drivers=test_quoter|http://localhost:11088/test_solver"
                     .to_string(),
             ],
         );
         self.start_api(vec![
-            "--price-estimation-drivers=test_solver|http://localhost:11088/test_solver".to_string(),
+            "--price-estimation-drivers=test_quoter|http://localhost:11088/test_solver".to_string(),
         ])
         .await;
     }
@@ -228,7 +228,11 @@ impl<'a> Services<'a> {
         );
         self.start_autopilot(
             Some(Duration::from_secs(11)),
-            vec!["--drivers=test_solver|http://localhost:11088/test_solver".to_string()],
+            vec![
+                "--drivers=test_solver|http://localhost:11088/test_solver".to_string(),
+                "--price-estimation-drivers=test_quoter|http://localhost:11088/test_quoter"
+                    .to_string(),
+            ],
         );
         self.start_api(vec![
             "--price-estimation-drivers=test_quoter|http://localhost:11088/test_quoter".to_string(),

--- a/crates/e2e/tests/e2e/buffers.rs
+++ b/crates/e2e/tests/e2e/buffers.rs
@@ -64,12 +64,12 @@ async fn onchain_settlement_without_liquidity(web3: Web3) {
                 token_b = token_b.address()
             ),
             "--drivers=test_solver|http://localhost:11088/test_solver".to_string(),
-            "--price-estimation-drivers=test_solver|http://localhost:11088/test_solver".to_string(),
+            "--price-estimation-drivers=test_quoter|http://localhost:11088/test_solver".to_string(),
         ],
     );
     services
         .start_api(vec![
-            "--price-estimation-drivers=test_solver|http://localhost:11088/test_solver".to_string(),
+            "--price-estimation-drivers=test_quoter|http://localhost:11088/test_solver".to_string(),
         ])
         .await;
 

--- a/crates/e2e/tests/e2e/limit_orders.rs
+++ b/crates/e2e/tests/e2e/limit_orders.rs
@@ -447,7 +447,7 @@ async fn too_many_limit_orders_test(web3: Web3) {
     services
         .start_api(vec![
             "--max-limit-orders-per-user=1".into(),
-            "--price-estimation-drivers=test_solver|http://localhost:11088/test_solver".to_string(),
+            "--price-estimation-drivers=test_quoter|http://localhost:11088/test_solver".to_string(),
         ])
         .await;
 

--- a/crates/e2e/tests/e2e/onchain_settlement.rs
+++ b/crates/e2e/tests/e2e/onchain_settlement.rs
@@ -92,7 +92,7 @@ async fn onchain_settlement(web3: Web3) {
     );
     services
         .start_api(vec![
-            "--price-estimation-drivers=test_solver|http://localhost:11088/test_solver".to_string(),
+            "--price-estimation-drivers=test_quoter|http://localhost:11088/test_solver".to_string(),
         ])
         .await;
 
@@ -136,7 +136,7 @@ async fn onchain_settlement(web3: Web3) {
         None,
         vec![
             "--drivers=test_solver|http://localhost:11088/test_solver".to_string(),
-            "--price-estimation-drivers=test_solver|http://localhost:11088/test_solver".to_string(),
+            "--price-estimation-drivers=test_quoter|http://localhost:11088/test_solver".to_string(),
         ],
     );
 

--- a/crates/e2e/tests/e2e/order_cancellation.rs
+++ b/crates/e2e/tests/e2e/order_cancellation.rs
@@ -60,12 +60,12 @@ async fn order_cancellation(web3: Web3) {
     services.start_autopilot(
         None,
         vec![
-            "--price-estimation-drivers=test_solver|http://localhost:11088/test_solver".to_string(),
+            "--price-estimation-drivers=test_quoter|http://localhost:11088/test_solver".to_string(),
         ],
     );
     services
         .start_api(vec![
-            "--price-estimation-drivers=test_solver|http://localhost:11088/test_solver".to_string(),
+            "--price-estimation-drivers=test_quoter|http://localhost:11088/test_solver".to_string(),
         ])
         .await;
 

--- a/crates/e2e/tests/e2e/protocol_fee.rs
+++ b/crates/e2e/tests/e2e/protocol_fee.rs
@@ -292,14 +292,14 @@ async fn execute_test(
         None,
         vec![
             "--drivers=test_solver|http://localhost:11088/test_solver".to_string(),
-            "--price-estimation-drivers=test_solver|http://localhost:11088/test_solver".to_string(),
+            "--price-estimation-drivers=test_quoter|http://localhost:11088/test_solver".to_string(),
             "--fee-policy-skip-market-orders=false".to_string(),
             fee_policy.to_string(),
         ],
     );
     services
         .start_api(vec![
-            "--price-estimation-drivers=test_solver|http://localhost:11088/test_solver".to_string(),
+            "--price-estimation-drivers=test_quoter|http://localhost:11088/test_solver".to_string(),
         ])
         .await;
 

--- a/crates/e2e/tests/e2e/solver_competition.rs
+++ b/crates/e2e/tests/e2e/solver_competition.rs
@@ -63,11 +63,11 @@ async fn solver_competition(web3: Web3) {
         vec![
             "--drivers=test_solver|http://localhost:11088/test_solver,solver2|http://localhost:11088/solver2"
                 .to_string(),
-            "--price-estimation-drivers=test_solver|http://localhost:11088/test_solver,solver2|http://localhost:11088/solver2".to_string(),
+            "--price-estimation-drivers=test_quoter|http://localhost:11088/test_solver,solver2|http://localhost:11088/solver2".to_string(),
         ],
     );
     services.start_api(vec![
-        "--price-estimation-drivers=test_solver|http://localhost:11088/test_solver,solver2|http://localhost:11088/solver2".to_string(),
+        "--price-estimation-drivers=test_quoter|http://localhost:11088/test_solver,solver2|http://localhost:11088/solver2".to_string(),
     ]).await;
 
     // Place Order


### PR DESCRIPTION
# Description
Since #2330, the api and autopilot use `test_solver` as an estimator. However, in order to support solvers that quote via a different endpoint, we need to make it more flexible.

# Changes
- api and autopilot look for an estimator called `test_quoter`
- in the standard case we still point `test_quoter` to the same endpoint
- in the legacy case, we point `test_quoter` to the solver's `quote` endpoint

## How to test
All e2e tests run