### PR TITLE
Add flag to prefer verified quotes

### DIFF
--- a/crates/shared/src/price_estimation.rs
+++ b/crates/shared/src/price_estimation.rs
@@ -287,6 +287,13 @@ pub struct Arguments {
     #[clap(long, env)]
     pub trade_simulator: Option<CodeSimulatorKind>,
 
+    /// If this is enabled a price estimate we were able to verify will always
+    /// be seen as better than an unverified one even if it might report a worse
+    /// out amount. The reason is that unverified price estimates could be too
+    /// good to be true.
+    #[clap(long, env, action = clap::ArgAction::Set, default_value = "false")]
+    pub prefer_verified_quotes: bool,
+
     /// Flag to enable saving Tenderly simulations in the dashboard for
     /// successful trade simulations.
     #[clap(long, env, action = clap::ArgAction::Set, default_value = "false")]
@@ -327,6 +334,7 @@ impl Display for Arguments {
             zeroex_only_estimate_buy_queries,
             one_inch_api_key,
             trade_simulator,
+            prefer_verified_quotes,
             one_inch_url,
         } = self;
 
@@ -362,7 +370,7 @@ impl Display for Arguments {
         )?;
         display_option(
             f,
-            "amount_to_estimate_prices_with",
+            "amount_to_estimate_prices_with: {}",
             amount_to_estimate_prices_with,
         )?;
         display_option(f, "balancer_sor_url", balancer_sor_url)?;
@@ -374,6 +382,7 @@ impl Display for Arguments {
                 .as_ref()
                 .map(|value| format!("{value:?}")),
         )?;
+        writeln!(f, "prefer_verified_quotes: {}", prefer_verified_quotes)?;
         writeln!(
             f,
             "tenderly_save_successful_trade_simulations: {}",

--- a/crates/shared/src/price_estimation/competition/mod.rs
+++ b/crates/shared/src/price_estimation/competition/mod.rs
@@ -32,7 +32,6 @@ pub struct CompetitionEstimator<T> {
     stages: Vec<PriceEstimationStage<T>>,
     usable_results_for_early_return: NonZeroUsize,
     ranking: PriceRanking,
-    // TODO drop this flag and always prefer verified when feature is stable
     prefer_verified_estimates: bool,
 }
 

--- a/crates/shared/src/price_estimation/competition/mod.rs
+++ b/crates/shared/src/price_estimation/competition/mod.rs
@@ -32,6 +32,8 @@ pub struct CompetitionEstimator<T> {
     stages: Vec<PriceEstimationStage<T>>,
     usable_results_for_early_return: NonZeroUsize,
     ranking: PriceRanking,
+    // TODO drop this flag and always prefer verified when feature is stable
+    prefer_verified_estimates: bool,
 }
 
 impl<T: Send + Sync + 'static> CompetitionEstimator<T> {
@@ -42,6 +44,17 @@ impl<T: Send + Sync + 'static> CompetitionEstimator<T> {
             stages,
             usable_results_for_early_return: NonZeroUsize::MAX,
             ranking,
+            prefer_verified_estimates: false,
+        }
+    }
+
+    /// Configures if verified price estimates should be ranked higher than
+    /// unverified ones even if the price is worse.
+    /// Per default verified quotes do not get preferred.
+    pub fn prefer_verified_estimates(self, prefer: bool) -> Self {
+        Self {
+            prefer_verified_estimates: prefer,
+            ..self
         }
     }
 
@@ -526,6 +539,7 @@ mod tests {
             ],
             usable_results_for_early_return: NonZeroUsize::new(2).unwrap(),
             ranking: PriceRanking::MaxOutAmount,
+            prefer_verified_estimates: false,
         };
 
         racing.estimate(query).await.unwrap();

--- a/crates/shared/src/price_estimation/competition/quote.rs
+++ b/crates/shared/src/price_estimation/competition/quote.rs
@@ -36,7 +36,15 @@ impl PriceEstimating for CompetitionEstimator<Arc<dyn PriceEstimating>> {
             let winner = results
                 .into_iter()
                 .filter(|(_index, r)| r.is_err() || gas_is_reasonable(r))
-                .max_by(|a, b| compare_quote_result(&query, &a.1, &b.1, &context))
+                .max_by(|a, b| {
+                    compare_quote_result(
+                        &query,
+                        &a.1,
+                        &b.1,
+                        &context,
+                        self.prefer_verified_estimates,
+                    )
+                })
                 .with_context(|| "all price estimates reported 0 gas cost")
                 .map_err(PriceEstimationError::EstimatorInternal)?;
             self.report_winner(&query, query.kind, winner)
@@ -50,13 +58,14 @@ fn compare_quote_result(
     a: &PriceEstimateResult,
     b: &PriceEstimateResult,
     context: &RankingContext,
+    prefer_verified_estimates: bool,
 ) -> Ordering {
     match (a, b) {
         (Ok(a), Ok(b)) => {
-            // prefer verified over unverified quotes
-            match (a.verified, b.verified) {
-                (true, false) => Ordering::Greater,
-                (false, true) => Ordering::Less,
+            match (prefer_verified_estimates, a.verified, b.verified) {
+                // prefer verified over unverified quotes
+                (true, true, false) => Ordering::Greater,
+                (true, false, true) => Ordering::Less,
                 _ => compare_quote(query, a, b, context),
             }
         }
@@ -178,6 +187,7 @@ mod tests {
         ranking: PriceRanking,
         kind: OrderKind,
         estimates: Vec<PriceEstimateResult>,
+        prefer_verified_estimates: bool,
     ) -> PriceEstimateResult {
         fn estimator(estimate: PriceEstimateResult) -> Arc<dyn PriceEstimating> {
             let mut estimator = MockPriceEstimating::new();
@@ -195,7 +205,8 @@ mod tests {
                 .map(|(i, e)| (format!("estimator_{i}"), estimator(e)))
                 .collect()],
             ranking.clone(),
-        );
+        )
+        .prefer_verified_estimates(prefer_verified_estimates);
 
         priority
             .estimate(Arc::new(Query {
@@ -221,6 +232,7 @@ mod tests {
                 // User effectively receives `99_999` `buy_token`.
                 price(107_999, 2_000),
             ],
+            false,
         )
         .await;
         assert_eq!(best, price(104_000, 1_000));
@@ -234,6 +246,7 @@ mod tests {
                 // User effectively pays `100_002` `sell_token`.
                 price(92_002, 2_000),
             ],
+            false,
         )
         .await;
         assert_eq!(best, price(96_000, 1_000));
@@ -257,6 +270,7 @@ mod tests {
                 // gets discarded because it quotes 0 gas.
                 price(104_000, 0),
             ],
+            false,
         )
         .await;
         assert_eq!(best, price(104_000, 1_000));
@@ -273,6 +287,7 @@ mod tests {
                 // gets discarded because it quotes 0 gas.
                 price(99_000, 0),
             ],
+            false,
         )
         .await;
         assert_eq!(best, price(96_000, 1_000));
@@ -290,6 +305,7 @@ mod tests {
                 error(PriceEstimationError::RateLimited),
                 error(PriceEstimationError::ProtocolInternal(anyhow::anyhow!("!"))),
             ],
+            false,
         )
         .await;
         assert_eq!(best, error(PriceEstimationError::RateLimited));
@@ -305,6 +321,7 @@ mod tests {
                 price(1, 1_000_000),
                 error(PriceEstimationError::RateLimited),
             ],
+            false,
         )
         .await;
         assert_eq!(best, price(1, 1_000_000));
@@ -312,20 +329,41 @@ mod tests {
 
     #[tokio::test]
     async fn prefer_verified_over_unverified() {
-        // Both out_amount and gas are worse but we still prefer this quote
-        // because we at least verified that it's actually accurate.
-        let preferred_quote = Ok(Estimate {
+        let worse_verified_quote = Ok(Estimate {
             out_amount: 900_000.into(),
             gas: 2_000,
             verified: true,
             ..Default::default()
         });
+        let better_unverified_quote = Ok(Estimate {
+            out_amount: 1_000_000.into(),
+            gas: 1_000,
+            verified: false,
+            ..Default::default()
+        });
+
         let best = best_response(
             PriceRanking::MaxOutAmount,
             OrderKind::Sell,
-            vec![price(1_000_000, 1_000), preferred_quote.clone()],
+            vec![
+                better_unverified_quote.clone(),
+                worse_verified_quote.clone(),
+            ],
+            true,
         )
         .await;
-        assert_eq!(best, preferred_quote);
+        assert_eq!(best, worse_verified_quote.clone());
+
+        let best = best_response(
+            PriceRanking::MaxOutAmount,
+            OrderKind::Sell,
+            vec![
+                better_unverified_quote.clone(),
+                worse_verified_quote.clone(),
+            ],
+            false,
+        )
+        .await;
+        assert_eq!(best, better_unverified_quote);
     }
 }

--- a/crates/shared/src/price_estimation/factory.rs
+++ b/crates/shared/src/price_estimation/factory.rs
@@ -342,7 +342,8 @@ impl<'a> PriceEstimatorFactory<'a> {
         let competition_estimator = CompetitionEstimator::new(
             vec![estimators],
             PriceRanking::BestBangForBuck { native, gas },
-        );
+        )
+        .prefer_verified_estimates(self.args.prefer_verified_quotes);
         Ok(Arc::new(self.sanitized(Arc::new(competition_estimator))))
     }
 
@@ -388,6 +389,7 @@ impl<'a> PriceEstimatorFactory<'a> {
 
         let competition_estimator =
             CompetitionEstimator::new(estimators, PriceRanking::MaxOutAmount)
+                .prefer_verified_estimates(self.args.prefer_verified_quotes)
                 .with_early_return(results_required);
         let native_estimator = Arc::new(CachingNativePriceEstimator::new(
             Box::new(competition_estimator),


### PR DESCRIPTION
# Description
To roll out quote verification to prod we might want to toggle the verification process and acting on the verified flag with 2 separate knobs.
This PR adds the knob to prefer verified quotes in the price competition.

# Changes
Add new CLI flag

## How to test
Added unit test for sorting logic