### PR TITLE
Add index on auction id

### DIFF
--- a/database/README.md
+++ b/database/README.md
@@ -318,6 +318,7 @@ During the solver competition solvers promise a solution of a certain quality. I
 
 Indexes:
 - PRIMARY KEY: btree(`block_number`, `log_index`)
+- settlements\_auction\_id: btree(`auction_id`)
 
 ### settlement\_scores
 

--- a/database/sql/V062__settlements_auction_id_index.sql
+++ b/database/sql/V062__settlements_auction_id_index.sql
@@ -1,0 +1,2 @@
+-- Optimization for when we JOIN settlements on auction_id.
+CREATE INDEX settlements_auction_id ON settlements (auction_id);

--- a/database/sql/V062__settlements_auction_id_index.sql
+++ b/database/sql/V062__settlements_auction_id_index.sql
@@ -1,2 +1,2 @@
 -- Optimization for when we JOIN settlements on auction_id.
-CREATE INDEX settlements_auction_id ON settlements (auction_id);
+CREATE INDEX settlements_auction_id ON settlements USING BTREE (auction_id);


### PR DESCRIPTION
# Description
@fhenneke [reported](https://github.com/cowprotocol/solver-rewards/pull/337) that the batch rewards query takes forever once we removed the `auction_transaction` table.
https://github.com/cowprotocol/solver-rewards/pull/334

This should be fixed by adding the index on `auction_id` on `settlements` table.

## How to test
Execute batch rewards on staging db to verify the speed.