### PR TITLE
More logging for verified quotes

### DIFF
--- a/crates/shared/src/price_estimation/factory.rs
+++ b/crates/shared/src/price_estimation/factory.rs
@@ -158,6 +158,7 @@ impl<'a> PriceEstimatorFactory<'a> {
                 Ok(Arc::new(TradeVerifier::new(
                     simulator,
                     code_fetcher,
+                    network.block_stream.clone(),
                     network.settlement,
                     network.native_token,
                 )))

--- a/crates/shared/src/tenderly_api.rs
+++ b/crates/shared/src/tenderly_api.rs
@@ -107,9 +107,10 @@ impl TenderlyApi for TenderlyHttpApi {
         let simulation_url = crate::url::join(&self.dashboard, "simulator/$SIMULATION_ID");
         let body = serde_json::to_string(&simulation)?;
         tracing::error!(
-            "resimulate by running: curl -X POST --header \"X-ACCESS-KEY: $TENDERLY_API_KEY\" \
-             --json '{body}' {request_url} | jq -r \".simulation.id\" | read SIMULATION_ID; echo \
-             {}",
+            "resimulate by setting TENDERLY_API_KEY environment variable and running:\
+            curl -X POST --header \"X-ACCESS-KEY: $TENDERLY_API_KEY\" \
+             --json '{body}' {request_url} | jq -r \".simulation.id\" | read SIMULATION_ID;\
+             echo {}",
             simulation_url.to_string(),
         );
         Ok(())

--- a/crates/shared/src/tenderly_api.rs
+++ b/crates/shared/src/tenderly_api.rs
@@ -107,10 +107,9 @@ impl TenderlyApi for TenderlyHttpApi {
         let simulation_url = crate::url::join(&self.dashboard, "simulator/$SIMULATION_ID");
         let body = serde_json::to_string(&simulation)?;
         tracing::error!(
-            "resimulate by setting TENDERLY_API_KEY environment variable and running:\
-            curl -X POST --header \"X-ACCESS-KEY: $TENDERLY_API_KEY\" \
-             --json '{body}' {request_url} | jq -r \".simulation.id\" | read SIMULATION_ID;\
-             echo {}",
+            "resimulate by setting TENDERLY_API_KEY environment variable and running:curl -X POST \
+             --header \"X-ACCESS-KEY: $TENDERLY_API_KEY\" --json '{body}' {request_url} | jq -r \
+             \".simulation.id\" | read SIMULATION_ID;echo {}",
             simulation_url.to_string(),
         );
         Ok(())

--- a/crates/shared/src/tenderly_api.rs
+++ b/crates/shared/src/tenderly_api.rs
@@ -104,14 +104,19 @@ impl TenderlyApi for TenderlyHttpApi {
 
     fn log(&self, simulation: SimulationRequest) -> Result<()> {
         let request_url = crate::url::join(&self.api, "simulate");
-        let simulation_url = crate::url::join(&self.dashboard, "simulator/$SIMULATION_ID");
+        let simulation_url =
+            crate::url::join(&self.dashboard, "simulator/$SIMULATION_ID").to_string();
         let body = serde_json::to_string(&simulation)?;
+
+        #[rustfmt::skip]
         tracing::error!(
-            "resimulate by setting TENDERLY_API_KEY environment variable and running:curl -X POST \
-             --header \"X-ACCESS-KEY: $TENDERLY_API_KEY\" --json '{body}' {request_url} | jq -r \
-             \".simulation.id\" | read SIMULATION_ID;echo {}",
-            simulation_url.to_string(),
+            "resimulate by setting TENDERLY_API_KEY environment variable and running: \
+            curl -X POST --header \"X-ACCESS-KEY: $TENDERLY_API_KEY\" --json '{body}' {request_url} \
+            | jq -r \".simulation.id\" \
+            | read SIMULATION_ID; \
+            echo {simulation_url}",
         );
+
         Ok(())
     }
 

--- a/crates/shared/src/tenderly_api.rs
+++ b/crates/shared/src/tenderly_api.rs
@@ -109,7 +109,7 @@ impl TenderlyApi for TenderlyHttpApi {
         let body = serde_json::to_string(&simulation)?;
 
         #[rustfmt::skip]
-        tracing::error!(
+        tracing::debug!(
             "resimulate by setting TENDERLY_API_KEY environment variable and running: \
             curl -X POST --header \"X-ACCESS-KEY: $TENDERLY_API_KEY\" --json '{body}' {request_url} \
             | jq -r \".simulation.id\" \


### PR DESCRIPTION
# Description
It's possible that we see either failed simulations or simulations that return vastly different `out_amount` or `gas` costs. For these it would be useful to manually check with tenderly to make sure that this was not a logic error in our code.

Initially I just wanted to just log the calldata and block so you can manually recreate the simulation with tenderly but then I remembered that we also use 2 fake contracts in the simulation which would be super annoying (maybe impossible?) to set up using the tenderly UI.

We already had code that immediately simulated a tx using tenderly and only logged a link to the simulation but IIRC indiscriminately creating simulations with tenderly was pretty expensive and we don't really know upfront which simulations might be interesting to look at so we would have to log everything.
Instead I adjusted the `Web3ThenTenderly` code simulation implementation such that it first simulates using web3 and afterwards logs a shell command that creates the simulation on tenderly and spits out a link afterwards.
This is free until we actually manually trigger the simulation when debugging something. The only unfortunate thing is that these logs can get quite long so it could be that we run into issues with Kibana.

# Changes
- reorders logged data from most relevant to least relevant
- logs latency introduced by verification
- command to recreate simulation with tenderly

## How to test
Used a local test setup to produce the new log and checked it out on [tenderly](https://dashboard.tenderly.co/devcow/project/simulator/fcb67f32-50e6-4e55-a9d0-a59fd651bcf7?trace=0.1.17.0).

<img width="1920" alt="Screenshot 2024-02-09 at 00 40 11" src="https://github.com/cowprotocol/services/assets/19190235/fd16dc44-579a-4b02-90c4-8a7784067d69">
