### PR TITLE
Log call data as hex string

### DIFF
--- a/crates/model/src/format.rs
+++ b/crates/model/src/format.rs
@@ -1,0 +1,9 @@
+pub fn debug_optional_bytes(
+    bytes: &Option<impl AsRef<[u8]>>,
+    formatter: &mut std::fmt::Formatter,
+) -> Result<(), std::fmt::Error> {
+    match bytes {
+        Some(bytes) => formatter.write_fmt(format_args!("0x{}", hex::encode(bytes.as_ref()))),
+        None => formatter.write_str("None"),
+    }
+}

--- a/crates/model/src/lib.rs
+++ b/crates/model/src/lib.rs
@@ -148,6 +148,16 @@ pub struct SolvableOrders {
     pub latest_settlement_block: u64,
 }
 
+fn debug_optional_bytes(
+    bytes: &Option<impl AsRef<[u8]>>,
+    formatter: &mut std::fmt::Formatter,
+) -> Result<(), std::fmt::Error> {
+    match bytes {
+        Some(bytes) => formatter.write_fmt(format_args!("0x{}", hex::encode(bytes.as_ref()))),
+        None => formatter.write_str("None"),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use {

--- a/crates/model/src/lib.rs
+++ b/crates/model/src/lib.rs
@@ -3,6 +3,7 @@
 pub mod app_data;
 pub mod auction;
 pub mod bytes_hex;
+mod format;
 pub mod interaction;
 pub mod order;
 pub mod quote;
@@ -146,16 +147,6 @@ impl DomainSeparator {
 pub struct SolvableOrders {
     pub orders: Vec<order::Order>,
     pub latest_settlement_block: u64,
-}
-
-fn debug_optional_bytes(
-    bytes: &Option<impl AsRef<[u8]>>,
-    formatter: &mut std::fmt::Formatter,
-) -> Result<(), std::fmt::Error> {
-    match bytes {
-        Some(bytes) => formatter.write_fmt(format_args!("0x{}", hex::encode(bytes.as_ref()))),
-        None => formatter.write_str("None"),
-    }
 }
 
 #[cfg(test)]

--- a/crates/model/src/solver_competition.rs
+++ b/crates/model/src/solver_competition.rs
@@ -1,5 +1,6 @@
 use {
     crate::{auction::AuctionId, bytes_hex::BytesHex, order::OrderUid},
+    derivative::Derivative,
     number::serialization::HexOrDecimalU256,
     primitive_types::{H160, H256, U256},
     serde::{Deserialize, Serialize},
@@ -39,7 +40,8 @@ pub struct CompetitionAuction {
 }
 
 #[serde_as]
-#[derive(Clone, Debug, Default, Deserialize, Serialize, PartialEq)]
+#[derive(Clone, Default, Deserialize, Serialize, PartialEq, Derivative)]
+#[derivative(Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct SolverSettlement {
     pub solver: String,
@@ -54,9 +56,11 @@ pub struct SolverSettlement {
     pub orders: Vec<Order>,
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde_as(as = "Option<BytesHex>")]
+    #[derivative(Debug(format_with = "crate::debug_optional_bytes"))]
     pub call_data: Option<Vec<u8>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde_as(as = "Option<BytesHex>")]
+    #[derivative(Debug(format_with = "crate::debug_optional_bytes"))]
     pub uninternalized_call_data: Option<Vec<u8>>,
 }
 

--- a/crates/model/src/solver_competition.rs
+++ b/crates/model/src/solver_competition.rs
@@ -56,11 +56,11 @@ pub struct SolverSettlement {
     pub orders: Vec<Order>,
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde_as(as = "Option<BytesHex>")]
-    #[derivative(Debug(format_with = "crate::debug_optional_bytes"))]
+    #[derivative(Debug(format_with = "crate::format::debug_optional_bytes"))]
     pub call_data: Option<Vec<u8>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde_as(as = "Option<BytesHex>")]
-    #[derivative(Debug(format_with = "crate::debug_optional_bytes"))]
+    #[derivative(Debug(format_with = "crate::format::debug_optional_bytes"))]
     pub uninternalized_call_data: Option<Vec<u8>>,
 }
 


### PR DESCRIPTION
# Changes
Some of the logs still contained calldata logged as an array of integers instead of a hex string. This is fixed by using `Derivative` to only overwrite the `Debug` implementation of these fields specifically.
For this I copied and slightly adjusted 1 helper function from the `shared` crate to not make the `model` crate depend on `shared` just for that.


## How to test
Look into the logs of the local node tests.