### PR TITLE
Omit empty filter log

### DIFF
--- a/crates/autopilot/src/solvable_orders.rs
+++ b/crates/autopilot/src/solvable_orders.rs
@@ -605,7 +605,9 @@ impl OrderFilterCounter {
         for order_uid in filtered_orders.keys() {
             self.orders.remove(order_uid).unwrap();
         }
-        tracing::debug!(%reason, orders = ?filtered_orders, "filtered orders");
+        if !filtered_orders.is_empty() {
+            tracing::debug!(%reason, orders = ?filtered_orders, "filtered orders");
+        }
         filtered_orders.into_keys().collect()
     }
 


### PR DESCRIPTION
# Changes
https://github.com/cowprotocol/services/pull/2354 collapsed these logs into one but did not check that there was even an order filtered out. This led to many logs stating that no order was filtered out for a given reason.