### PR TITLE
Prioritize newer orders in auction

### DIFF
--- a/crates/autopilot/src/solvable_orders.rs
+++ b/crates/autopilot/src/solvable_orders.rs
@@ -329,6 +329,8 @@ async fn filter_invalid_signature_orders(
 /// Removes orders that can't possibly be settled because there isn't enough
 /// balance.
 fn orders_with_balance(mut orders: Vec<Order>, balances: &Balances) -> Vec<Order> {
+    // Prefer newer orders over older ones.
+    orders.sort_by_key(|order| std::cmp::Reverse(order.metadata.creation_date));
     orders.retain(|order| {
         let balance = match balances.get(&Query::from_order(order)) {
             None => return false,


### PR DESCRIPTION
# Description
When we build the auction in the autopilot we filter out orders that are unlikely to be filled to shrink the auction to a more manageable size.
One step is to filter out fill-or-kill orders where the owner doesn't have enough sell_token for all of the open orders. The new logic sorts orders by `creation_timestamp` (desc) to first use the user's existing balance on recent orders rather than old ones. 

Fixes: #1997