### PR TITLE
Update for 1.76

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -11,6 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+      - run: rustup toolchain install stable --profile minimal
       - uses: Swatinem/rust-cache@v2
       - uses: actions-rs/toolchain@v1
         with:
@@ -45,6 +46,7 @@ jobs:
       CARGO_TERM_COLOR: always
     steps:
       - uses: actions/checkout@v3
+      - run: rustup toolchain install stable --profile minimal
       - uses: Swatinem/rust-cache@v2
       - uses: taiki-e/install-action@nextest
       - run: cargo build --tests
@@ -60,6 +62,7 @@ jobs:
       CARGO_TERM_COLOR: always
     steps:
       - uses: actions/checkout@v3
+      - run: rustup toolchain install stable --profile minimal
       - uses: Swatinem/rust-cache@v2
       # Start the build process in the background. The following cargo test command will automatically
       # wait for the build process to be done before proceeding.
@@ -82,6 +85,7 @@ jobs:
       TOML_TRACE_ERROR: 1      
     steps:
       - uses: actions/checkout@v3
+      - run: rustup toolchain install stable --profile minimal
       - uses: foundry-rs/foundry-toolchain@v1
       - uses: Swatinem/rust-cache@v2
       # Start the build process in the background. The following cargo test command will automatically
@@ -109,6 +113,7 @@ jobs:
       TOML_TRACE_ERROR: 1
     steps:
       - uses: actions/checkout@v3
+      - run: rustup toolchain install stable --profile minimal
       - uses: foundry-rs/foundry-toolchain@v1
       - uses: Swatinem/rust-cache@v2
       # Start the build process in the background. The following cargo test command will automatically
@@ -132,6 +137,7 @@ jobs:
       TOML_TRACE_ERROR: 1      
     steps:
       - uses: actions/checkout@v3
+      - run: rustup toolchain install stable --profile minimal
       - uses: foundry-rs/foundry-toolchain@v1
       - uses: Swatinem/rust-cache@v2
       - uses: taiki-e/install-action@nextest

--- a/crates/driver/src/domain/competition/auction.rs
+++ b/crates/driver/src/domain/competition/auction.rs
@@ -233,10 +233,11 @@ impl AuctionProcessor {
                 }
             };
 
-            let max_sell = match {
+            let available_sell_amount = {
                 let available = order.available(weth);
                 available.sell.amount.0.checked_add(available.user_fee.0)
-            } {
+            };
+            let max_sell = match available_sell_amount {
                 Some(amount) => order::SellAmount(amount),
                 None => {
                     observe::order_excluded_from_auction(

--- a/crates/orderbook/src/ipfs_app_data.rs
+++ b/crates/orderbook/src/ipfs_app_data.rs
@@ -99,10 +99,11 @@ impl IpfsAppData {
             return Ok(cached);
         }
 
-        let result = match {
+        let fetched = {
             let _timer = self.metrics.fetches.start_timer();
             self.fetch_raw(contract_app_data).await
-        } {
+        };
+        let result = match fetched {
             Ok(result) => result,
             Err(err) => {
                 metric.with_label_values(&["error", "node"]).inc();

--- a/crates/shared/src/price_estimation/trade_finder.rs
+++ b/crates/shared/src/price_estimation/trade_finder.rs
@@ -55,7 +55,7 @@ impl TradeEstimator {
     pub fn with_verifier(mut self, verifier: Arc<dyn TradeVerifying>) -> Self {
         self.inner = Arc::new(Inner {
             verifier: Some(verifier),
-            ..arc_unwrap_or_clone(self.inner)
+            ..Arc::unwrap_or_clone(self.inner)
         });
         self
     }
@@ -141,11 +141,4 @@ impl From<TradeError> for PriceEstimationError {
             TradeError::Other(err) => Self::EstimatorInternal(err),
         }
     }
-}
-
-fn arc_unwrap_or_clone<T>(arc: Arc<T>) -> T
-where
-    T: Clone,
-{
-    Arc::try_unwrap(arc).unwrap_or_else(|arc| (*arc).clone())
 }

--- a/crates/solver/src/solver/single_order_solver.rs
+++ b/crates/solver/src/solver/single_order_solver.rs
@@ -655,10 +655,11 @@ fn prioritize_orders(
     // Chose `user_orders.len()` distinct items from `user_orders` weighted by the
     // viability of the order. This effectively sorts the orders by viability
     // with a slight randomness to not get stuck on bad orders.
-    match orders.choose_multiple_weighted(&mut rng, orders.len(), |order| {
+    let weighted_order = orders.choose_multiple_weighted(&mut rng, orders.len(), |order| {
         let price_viability = estimate_price_viability(order, prices);
         order_prioritization_config.apply_weight_constraints(price_viability)
-    }) {
+    });
+    match weighted_order {
         Ok(weighted_user_orders) => weighted_user_orders.into_iter().cloned().collect(),
         Err(err) => {
             // if weighted sorting by viability fails we fall back to shuffling randomly


### PR DESCRIPTION
# Description
New rust version => new enforced clippy warnings

# Changes
- broke up overly complex match statements
- replace hand rolled `Arc::unwrap_or_clone()` with newly stabilized function
- added github run step before using `rust-cache` as recommended [here](https://github.com/Swatinem/rust-cache/blob/master/README.md?plain=1#L11-L13) to ensure we are using the latest stable version

## How to test
CI