### PR TITLE
chore: add missing comma to orderbook openapi OrderPostError enum

### DIFF
--- a/crates/orderbook/openapi.yml
+++ b/crates/orderbook/openapi.yml
@@ -1225,7 +1225,7 @@ components:
               TransferSimulationFailed,
               ZeroAmount,
               IncompatibleSigningScheme,
-              TooManyLimitOrders
+              TooManyLimitOrders,
               UnsupportedBuyTokenDestination,
               UnsupportedSellTokenSource,
               UnsupportedOrderType,


### PR DESCRIPTION
# Description

CoW SDK auto-generate TS types based on OpenApi definition from this repo.

I've noticed something weird today: https://github.com/cowprotocol/cow-sdk/blob/d0d86a9de2be23e72c2f74f3136ef2d8736c7fb1/src/order-book/generated/models/OrderPostError.ts#L27

```
TOO_MANY_LIMIT_ORDERS_UNSUPPORTED_BUY_TOKEN_DESTINATION = 'TooManyLimitOrders UnsupportedBuyTokenDestination'
```

All because of a missing `,`.

I'm surprised that's not a YAML error, my IDE didn't complain about it either 🤷 

# Changes
- [x] Added a comma to orderbook openapi yaml definition

## How to test

At this point I guess only visual inspection, not sure there are any linters running against this file.