### PR TITLE
Immediately open simulation url

### DIFF
--- a/crates/shared/src/tenderly_api.rs
+++ b/crates/shared/src/tenderly_api.rs
@@ -114,7 +114,8 @@ impl TenderlyApi for TenderlyHttpApi {
             curl -X POST --header \"X-ACCESS-KEY: $TENDERLY_API_KEY\" --json '{body}' {request_url} \
             | jq -r \".simulation.id\" \
             | read SIMULATION_ID; \
-            echo {simulation_url}",
+            echo {simulation_url} \
+            | xargs xdg-open",
         );
 
         Ok(())


### PR DESCRIPTION
# Description
The new simulation request logs are working nicely already. This PR just makes it slightly more ergonomic by immediately opening the URL in your default browser so you don't have to copy and paste it.

- [x] tested manually