### PR TITLE
Set high default gas for access list estimation

### DIFF
--- a/crates/driver/src/infra/blockchain/mod.rs
+++ b/crates/driver/src/infra/blockchain/mod.rs
@@ -123,6 +123,8 @@ impl Ethereum {
 
     /// Create access list used by a transaction.
     pub async fn create_access_list(&self, tx: eth::Tx) -> Result<eth::AccessList, Error> {
+        const DEFAULT_GAS: u64 = 8_000_000;
+
         let tx = web3::types::TransactionRequest {
             from: tx.from.into(),
             to: Some(tx.to.into()),
@@ -130,6 +132,9 @@ impl Ethereum {
             value: Some(tx.value.into()),
             data: Some(tx.input.into()),
             access_list: Some(tx.access_list.into()),
+            // Specifically set high gas because some nodes don't pick a sensible value if omitted.
+            // And since we are only interested in access lists a very high value is fine.
+            gas: Some(DEFAULT_GAS.into()),
             ..Default::default()
         };
         let json = self

--- a/crates/driver/src/infra/blockchain/mod.rs
+++ b/crates/driver/src/infra/blockchain/mod.rs
@@ -123,7 +123,7 @@ impl Ethereum {
 
     /// Create access list used by a transaction.
     pub async fn create_access_list(&self, tx: eth::Tx) -> Result<eth::AccessList, Error> {
-        const DEFAULT_GAS: u64 = 8_000_000;
+        const MAX_BLOCK_SIZE: u64 = 30_000_000;
 
         let tx = web3::types::TransactionRequest {
             from: tx.from.into(),
@@ -134,7 +134,7 @@ impl Ethereum {
             access_list: Some(tx.access_list.into()),
             // Specifically set high gas because some nodes don't pick a sensible value if omitted.
             // And since we are only interested in access lists a very high value is fine.
-            gas: Some(DEFAULT_GAS.into()),
+            gas: Some(MAX_BLOCK_SIZE.into()),
             ..Default::default()
         };
         let json = self


### PR DESCRIPTION
# Description
Today we started seeing simulation errors caused by:
> 2024-02-15T10:16:19.713Z ERROR request{id="9"}:/solve{solver=mysolver auction_id=4076}: driver::infra::observe: discarded solution: settlement encoding id=Id(0) err=Simulation(Other(Blockchain(Web3(Rpc(Error { code: ServerError(-32000), message: "failed to apply transaction: 0xa5c722a26ff6b2b573f98e1d3f14285feb469411fa300139e9b7d25995ad756f err: intrinsic gas too low: have 21000, want 32220", data: None })))))

Usually when you create a tx to simulate or create access lists for you only set the `gas` value if you want to avoid the tx costing more than that. If you leave it empty "a sensible default" should be picked by the node. It looks like that logic stopped working for some reason (still unclear why because AFAIK we didn't update any relevant infra that could cause that)

# Changes
To avoid that we now set the `gas` value very high whenever we compute an access list using the `web3` node (that code path is also taken when the `enso` simulator is configured). Setting a very high value here is not concerning since we don't actually execute any transaction so a weird tx gobbling up all our ETH for gas is not a problem.

## How to test
I reproduced the issue locally by using our alchemy nodes as our RPC and `enso` as the simulator.
Without the fix I got `intrinsic gas too low` for transactions that pay out to a regular user and `out of gas` for tx paying out ETH to smart contracts.
With the fix applied both simulations worked again.