### PR TITLE
Rank by surplus switch with config

### DIFF
--- a/crates/driver/src/domain/competition/mod.rs
+++ b/crates/driver/src/domain/competition/mod.rs
@@ -173,10 +173,13 @@ impl Competition {
             .map(|settlement| {
                 observe::scoring(&settlement);
                 (
-                    settlement.old_score(&self.eth, auction, &self.mempools.revert_protection()),
+                    if self.solver.cip38_activated(auction.deadline().driver()) {
+                        settlement.score(&self.eth, auction)
+                    } else {
+                        settlement.old_score(&self.eth, auction, &self.mempools.revert_protection())
+                    },
                     settlement,
-                ) // todo CIP38 remove
-                  //(settlement.score(&self.eth, auction), settlement)
+                )
             })
             .collect_vec();
 

--- a/crates/driver/src/infra/config/file/load.rs
+++ b/crates/driver/src/infra/config/file/load.rs
@@ -86,6 +86,7 @@ pub async fn load(network: &blockchain::Network, path: &Path) -> infra::Config {
                         .try_into()
                         .unwrap(),
                 },
+                cip38_activation: config.cip38_activation,
             }
         }))
         .await,

--- a/crates/driver/src/infra/config/file/mod.rs
+++ b/crates/driver/src/infra/config/file/mod.rs
@@ -180,6 +180,10 @@ struct SolverConfig {
     /// Timeout configuration for the solver.
     #[serde(default, flatten)]
     timeouts: Timeouts,
+
+    /// Datetime when the CIP38 should be activated.
+    #[serde(default)]
+    cip38_activation: Option<chrono::DateTime<chrono::Utc>>,
 }
 
 #[serde_as]

--- a/crates/driver/src/infra/solver/mod.rs
+++ b/crates/driver/src/infra/solver/mod.rs
@@ -97,6 +97,8 @@ pub struct Config {
     pub account: ethcontract::Account,
     /// How much time to spend for each step of the solving and competition.
     pub timeouts: Timeouts,
+    /// Whether or not the CIP-38 rules should be activated.
+    pub cip38_activation: Option<chrono::DateTime<chrono::Utc>>,
 }
 
 impl Solver {
@@ -145,6 +147,13 @@ impl Solver {
     /// Timeout configuration for this solver.
     pub fn timeouts(&self) -> Timeouts {
         self.config.timeouts
+    }
+
+    /// Whether or not the CIP-38 rules are activated.
+    pub fn cip38_activated(&self, current: chrono::DateTime<chrono::Utc>) -> bool {
+        self.config
+            .cip38_activation
+            .is_some_and(|activation| current > activation)
     }
 
     /// Make a POST request instructing the solver to solve an auction.


### PR DESCRIPTION
# Description
Temporary config to deterministically switch all drivers to rank by surplus at the same time.

# Changes
Added configuration parameter to driver.

## How to test
Existing tests passing. 

Also tested locally e2e test by adding parameter `cip38-activation = "2022-02-21T12:34:56Z"` to driver configuration to test the cip38 activation and proper score calculation.