### PR TITLE
Fine grained metrics for RPC calls

### DIFF
--- a/crates/driver/src/boundary/liquidity/balancer/v2/mod.rs
+++ b/crates/driver/src/boundary/liquidity/balancer/v2/mod.rs
@@ -80,7 +80,7 @@ pub fn collector(
     block_retriever: Arc<dyn BlockRetrieving>,
     config: &infra::liquidity::config::BalancerV2,
 ) -> Box<dyn LiquidityCollecting> {
-    let eth = Arc::new(eth.clone());
+    let eth = Arc::new(eth.with_metric_label("balancerV2".into()));
     let config = Arc::new(config.clone());
     let init = move || {
         let eth = eth.clone();

--- a/crates/driver/src/boundary/liquidity/swapr.rs
+++ b/crates/driver/src/boundary/liquidity/swapr.rs
@@ -43,8 +43,9 @@ pub async fn collector(
     blocks: &CurrentBlockStream,
     config: &infra::liquidity::config::Swapr,
 ) -> Result<Box<dyn LiquidityCollecting>> {
+    let eth = eth.with_metric_label("swapr".into());
     boundary::liquidity::uniswap::v2::collector_with_reader(
-        eth,
+        &eth,
         blocks,
         &infra::liquidity::config::UniswapV2 {
             router: config.router,

--- a/crates/driver/src/boundary/liquidity/uniswap/v2.rs
+++ b/crates/driver/src/boundary/liquidity/uniswap/v2.rs
@@ -115,7 +115,8 @@ pub async fn collector(
     blocks: &CurrentBlockStream,
     config: &infra::liquidity::config::UniswapV2,
 ) -> Result<Box<dyn LiquidityCollecting>> {
-    collector_with_reader(eth, blocks, config, DefaultPoolReader::new).await
+    let eth = eth.with_metric_label("uniswapV2".into());
+    collector_with_reader(&eth, blocks, config, DefaultPoolReader::new).await
 }
 
 pub(in crate::boundary::liquidity) async fn collector_with_reader<R, F>(

--- a/crates/driver/src/boundary/liquidity/uniswap/v3.rs
+++ b/crates/driver/src/boundary/liquidity/uniswap/v3.rs
@@ -104,7 +104,7 @@ pub fn collector(
     block_retriever: Arc<dyn BlockRetrieving>,
     config: &infra::liquidity::config::UniswapV3,
 ) -> Box<dyn LiquidityCollecting> {
-    let eth = Arc::new(eth.clone());
+    let eth = Arc::new(eth.with_metric_label("uniswapV3".into()));
     let config = Arc::new(Clone::clone(config));
     let init = move || {
         let eth = eth.clone();

--- a/crates/driver/src/boundary/liquidity/zeroex.rs
+++ b/crates/driver/src/boundary/liquidity/zeroex.rs
@@ -11,6 +11,7 @@ pub async fn collector(
     blocks: CurrentBlockStream,
     config: &infra::liquidity::config::ZeroEx,
 ) -> anyhow::Result<Box<dyn LiquidityCollecting>> {
+    let eth = eth.with_metric_label("zeroex".into());
     let settlement = eth.contracts().settlement().clone();
     let web3 = settlement.raw_instance().web3().clone();
     let contract = contracts::IZeroEx::deployed(&web3).await?;

--- a/crates/driver/src/domain/competition/mod.rs
+++ b/crates/driver/src/domain/competition/mod.rs
@@ -361,11 +361,12 @@ async fn merge_settlements(
     eth: &Ethereum,
     simulator: &Simulator,
 ) {
+    let eth = eth.with_metric_label("mergeSettlements".into());
     let mut new = std::pin::pin!(new);
     while let Some(settlement) = new.next().await {
         // Try to merge [`settlement`] into some settlements.
         for other in merged.iter_mut() {
-            match other.merge(&settlement, eth, simulator).await {
+            match other.merge(&settlement, &eth, simulator).await {
                 Ok(m) => {
                     *other = m;
                     observe::merged(&settlement, other);

--- a/crates/driver/src/domain/competition/solution/settlement.rs
+++ b/crates/driver/src/domain/competition/solution/settlement.rs
@@ -223,7 +223,8 @@ impl Settlement {
         auction: &competition::Auction,
         revert_protection: &mempools::RevertProtection,
     ) -> Result<competition::Score, score::Error> {
-        let quality = self.boundary.quality(eth, auction)?;
+        let eth = eth.with_metric_label("scoringSolution".into());
+        let quality = self.boundary.quality(&eth, auction)?;
 
         let score = match self.boundary.score() {
             competition::SolverScore::Solver(score) => score.try_into()?,

--- a/crates/driver/src/infra/api/mod.rs
+++ b/crates/driver/src/infra/api/mod.rs
@@ -47,8 +47,8 @@ impl Api {
                 .layer(tower_http::trace::TraceLayer::new_for_http()),
         );
 
-        let tokens = tokens::Fetcher::new(self.eth.clone());
-        let pre_processor = domain::competition::AuctionProcessor::new(Arc::new(self.eth.clone()));
+        let tokens = tokens::Fetcher::new(&self.eth);
+        let pre_processor = domain::competition::AuctionProcessor::new(&self.eth);
 
         // Add the metrics and healthz endpoints.
         app = routes::metrics(app);

--- a/crates/driver/src/infra/blockchain/mod.rs
+++ b/crates/driver/src/infra/blockchain/mod.rs
@@ -47,6 +47,10 @@ impl Rpc {
 #[derive(Clone)]
 pub struct Ethereum {
     web3: DynWeb3,
+    inner: Arc<Inner>,
+}
+
+struct Inner {
     chain: eth::ChainId,
     contracts: Contracts,
     gas: Arc<GasPriceEstimator>,
@@ -65,35 +69,43 @@ impl Ethereum {
         addresses: contracts::Addresses,
         gas: Arc<GasPriceEstimator>,
     ) -> Self {
-        let Rpc {
-            web3,
-            chain: network,
-        } = rpc;
-        let contracts = Contracts::new(&web3, network, addresses)
+        let Rpc { web3, chain } = rpc;
+        let contracts = Contracts::new(&web3, chain, addresses)
             .await
             .expect("could not initialize important smart contracts");
 
         Self {
-            current_block: ethrpc::current_block::current_block_stream(
-                Arc::new(web3.clone()),
-                std::time::Duration::from_millis(500),
-            )
-            .await
-            .expect("couldn't initialize current block stream"),
+            inner: Arc::new(Inner {
+                current_block: ethrpc::current_block::current_block_stream(
+                    Arc::new(web3.clone()),
+                    std::time::Duration::from_millis(500),
+                )
+                .await
+                .expect("couldn't initialize current block stream"),
+                chain,
+                contracts,
+                gas,
+            }),
             web3,
-            chain: network,
-            contracts,
-            gas,
         }
     }
 
     pub fn network(&self) -> eth::ChainId {
-        self.chain
+        self.inner.chain
+    }
+
+    /// Clones self and returns an instance that captures metrics extended with
+    /// the provided label.
+    pub fn with_metric_label(&self, label: String) -> Self {
+        Self {
+            web3: ethrpc::instrumented::instrument_with_label(&self.web3, label),
+            ..self.clone()
+        }
     }
 
     /// Onchain smart contract bindings.
     pub fn contracts(&self) -> &Contracts {
-        &self.contracts
+        &self.inner.contracts
     }
 
     /// Create a contract instance at the specified address.
@@ -110,7 +122,7 @@ impl Ethereum {
     /// Returns a type that monitors the block chain to inform about the current
     /// block.
     pub fn current_block(&self) -> &CurrentBlockStream {
-        &self.current_block
+        &self.inner.current_block
     }
 
     /// Create access list used by a transaction.
@@ -146,7 +158,7 @@ impl Ethereum {
     }
 
     pub fn boundary_gas_estimator(&self) -> Arc<dyn GasPriceEstimating> {
-        self.gas.gas.clone()
+        self.inner.gas.gas.clone()
     }
 
     /// Estimate gas used by a transaction.
@@ -171,11 +183,11 @@ impl Ethereum {
     }
 
     pub async fn gas_price(&self) -> Result<eth::GasPrice, Error> {
-        self.gas.estimate().await
+        self.inner.gas.estimate().await
     }
 
     pub fn gas_limit(&self) -> eth::Gas {
-        self.current_block.borrow().gas_limit.into()
+        self.inner.current_block.borrow().gas_limit.into()
     }
 
     /// Returns the current [`eth::Ether`] balance of the specified account.
@@ -220,8 +232,8 @@ impl fmt::Debug for Ethereum {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.debug_struct("Ethereum")
             .field("web3", &self.web3)
-            .field("network", &self.chain)
-            .field("contracts", &self.contracts)
+            .field("chain", &self.inner.chain)
+            .field("contracts", &self.inner.contracts)
             .field("gas", &"Arc<NativeGasEstimator>")
             .finish()
     }

--- a/crates/driver/src/infra/liquidity/fetcher.rs
+++ b/crates/driver/src/infra/liquidity/fetcher.rs
@@ -33,7 +33,8 @@ impl Fetcher {
     /// Creates a new liquidity fetcher for the specified Ethereum instance and
     /// configuration.
     pub async fn new(eth: &Ethereum, config: &infra::liquidity::Config) -> Result<Self, Error> {
-        let inner = boundary::liquidity::Fetcher::new(eth, config).await?;
+        let eth = eth.with_metric_label("liquidity".into());
+        let inner = boundary::liquidity::Fetcher::new(&eth, config).await?;
         Ok(Self {
             inner: Arc::new(inner),
         })

--- a/crates/driver/src/infra/simulator/mod.rs
+++ b/crates/driver/src/infra/simulator/mod.rs
@@ -29,9 +29,10 @@ pub enum Config {
 
 impl Simulator {
     /// Simulate transactions on [Tenderly](https://tenderly.co/).
-    pub fn tenderly(config: tenderly::Config, network_id: eth::ChainId, eth: Ethereum) -> Self {
+    pub fn tenderly(config: tenderly::Config, chain: eth::ChainId, eth: Ethereum) -> Self {
+        let eth = eth.with_metric_label("tenderlySimulator".into());
         Self {
-            inner: Inner::Tenderly(tenderly::Tenderly::new(config, network_id)),
+            inner: Inner::Tenderly(tenderly::Tenderly::new(config, chain)),
             eth,
             disable_access_lists: false,
             disable_gas: None,
@@ -40,6 +41,7 @@ impl Simulator {
 
     /// Simulate transactions using the Ethereum RPC API.
     pub fn ethereum(eth: Ethereum) -> Self {
+        let eth = eth.with_metric_label("web3Simulator".into());
         Self {
             inner: Inner::Ethereum,
             eth,
@@ -51,6 +53,7 @@ impl Simulator {
     /// Simulate transactions using the [Enso Simulator](https://github.com/EnsoFinance/transaction-simulator).
     /// Uses Ethereum RPC API to generate access lists.
     pub fn enso(config: enso::Config, eth: Ethereum) -> Self {
+        let eth = eth.with_metric_label("ensoSimulator".into());
         Self {
             inner: Inner::Enso(enso::Enso::new(
                 config,

--- a/crates/driver/src/infra/tokens.rs
+++ b/crates/driver/src/infra/tokens.rs
@@ -28,7 +28,8 @@ pub struct Metadata {
 pub struct Fetcher(Arc<Inner>);
 
 impl Fetcher {
-    pub fn new(eth: Ethereum) -> Self {
+    pub fn new(eth: &Ethereum) -> Self {
+        let eth = eth.with_metric_label("tokenInfos".into());
         let block_stream = eth.current_block().clone();
         let inner = Arc::new(Inner {
             eth,

--- a/crates/ethrpc/src/instrumented.rs
+++ b/crates/ethrpc/src/instrumented.rs
@@ -1,0 +1,150 @@
+use {
+    ethcontract::jsonrpc as jsonrpc_core,
+    futures::{future::BoxFuture, FutureExt},
+    jsonrpc_core::types::{Call, Value},
+    std::sync::Arc,
+    web3::{error::Error as Web3Error, BatchTransport, RequestId, Transport},
+};
+
+#[derive(prometheus_metric_storage::MetricStorage, Clone, Debug)]
+#[metric(subsystem = "rpc")]
+struct Metrics {
+    /// Number of inflight RPC requests for ethereum node.
+    #[metric(labels("component", "method"))]
+    requests_inflight: prometheus::IntGaugeVec,
+
+    /// Number of completed RPC requests for ethereum node.
+    #[metric(labels("component", "method"))]
+    requests_complete: prometheus::IntCounterVec,
+
+    /// Execution time for each RPC request (batches are counted as one
+    /// request).
+    #[metric(labels("component", "method"))]
+    requests_duration_seconds: prometheus::HistogramVec,
+
+    /// Number of RPC requests initiated within a batch request
+    #[metric(labels("component", "method"))]
+    inner_batch_requests_initiated: prometheus::IntCounterVec,
+}
+
+impl Metrics {
+    #[must_use]
+    fn on_request_start(&self, label: &str, method: &str) -> impl Drop {
+        let requests_inflight = self.requests_inflight.with_label_values(&[label, method]);
+        let requests_complete = self.requests_complete.with_label_values(&[label, method]);
+        let requests_duration_seconds = self
+            .requests_duration_seconds
+            .with_label_values(&[label, method]);
+
+        requests_inflight.inc();
+        let timer = requests_duration_seconds.start_timer();
+
+        scopeguard::guard(timer, move |timer| {
+            requests_inflight.dec();
+            requests_complete.inc();
+            timer.stop_and_record();
+        })
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct InstrumentedTransport<T>(Arc<Inner<T>>);
+
+impl<T> InstrumentedTransport<T> {
+    pub fn new(label: String, transport: T) -> Self {
+        Self(Arc::new(Inner {
+            metrics: Metrics::instance(observe::metrics::get_storage_registry()).unwrap(),
+            transport,
+            label,
+        }))
+    }
+}
+
+impl<T> InstrumentedTransport<T>
+where
+    T: Clone,
+{
+    pub fn with_additional_label(&self, label: String) -> Self {
+        Self(Arc::new(Inner {
+            label: format!("{}_{label}", self.0.label),
+            transport: self.0.transport.clone(),
+            metrics: self.0.metrics,
+        }))
+    }
+}
+
+#[derive(Debug)]
+struct Inner<T> {
+    metrics: &'static Metrics,
+    transport: T,
+    label: String,
+}
+
+type RpcResult = Result<Value, Web3Error>;
+
+impl<T> Transport for InstrumentedTransport<T>
+where
+    T: Transport + Sync + Send + 'static,
+    <T as Transport>::Out: Send,
+{
+    type Out = BoxFuture<'static, RpcResult>;
+
+    fn prepare(&self, method: &str, params: Vec<Value>) -> (RequestId, Call) {
+        self.0.transport.prepare(method, params)
+    }
+
+    fn send(&self, id: RequestId, call: Call) -> Self::Out {
+        let inner = self.0.clone();
+
+        async move {
+            let _guard = inner
+                .metrics
+                .on_request_start(&inner.label, method_name(&call));
+            inner.transport.send(id, call).await
+        }
+        .boxed()
+    }
+}
+
+impl<T> BatchTransport for InstrumentedTransport<T>
+where
+    T: BatchTransport + Sync + Send + 'static,
+    <T as BatchTransport>::Batch: Send,
+    InstrumentedTransport<T>: Transport + Sync + Send + 'static,
+{
+    type Batch = BoxFuture<'static, Result<Vec<RpcResult>, Web3Error>>;
+
+    fn send_batch<R>(&self, requests: R) -> Self::Batch
+    where
+        R: IntoIterator<Item = (RequestId, Call)>,
+    {
+        // TODO: Can we get rid of this clone?
+        // Do we even need the `BatchTransport` impl here?
+        let inner = self.0.clone();
+        let requests: Vec<_> = requests.into_iter().collect();
+
+        async move {
+            let _guard = inner.metrics.on_request_start(&inner.label, "batch");
+            let metrics = inner.metrics;
+            let label = &inner.label;
+
+            let requests = requests.into_iter().inspect(move |(_id, call)| {
+                metrics
+                    .inner_batch_requests_initiated
+                    .with_label_values(&[label, method_name(call)])
+                    .inc()
+            });
+
+            inner.transport.send_batch(requests).await
+        }
+        .boxed()
+    }
+}
+
+fn method_name(call: &Call) -> &str {
+    match call {
+        Call::MethodCall(method) => &method.method,
+        Call::Notification(notification) => &notification.method,
+        Call::Invalid { .. } => "invalid",
+    }
+}

--- a/crates/ethrpc/src/instrumented.rs
+++ b/crates/ethrpc/src/instrumented.rs
@@ -118,8 +118,6 @@ impl BatchTransport for InstrumentedTransport {
     where
         R: IntoIterator<Item = (RequestId, Call)>,
     {
-        // TODO: Can we get rid of this clone?
-        // Do we even need the `BatchTransport` impl here?
         let inner = self.0.clone();
         let requests: Vec<_> = requests.into_iter().collect();
 

--- a/crates/ethrpc/src/lib.rs
+++ b/crates/ethrpc/src/lib.rs
@@ -3,6 +3,7 @@ pub mod current_block;
 pub mod dummy;
 pub mod extensions;
 pub mod http;
+pub mod instrumented;
 pub mod mock;
 pub mod multicall;
 

--- a/crates/ethrpc/src/lib.rs
+++ b/crates/ethrpc/src/lib.rs
@@ -76,20 +76,23 @@ pub fn web3(
         Some(config) => Web3Transport::new(BufferedTransport::with_config(http, config)),
         None => Web3Transport::new(http),
     };
-
-    Web3::new(transport)
+    let instrumented = instrumented::InstrumentedTransport::new(name.to_string(), transport);
+    Web3::new(Web3Transport::new(instrumented))
 }
 
 /// Convenience method to create a transport from a URL.
 pub fn create_test_transport(url: &str) -> Web3Transport {
-    Web3Transport::new(HttpTransport::new(
+    let http_transport = HttpTransport::new(
         Client::builder()
             .timeout(Duration::from_secs(10))
             .build()
             .unwrap(),
         url.try_into().unwrap(),
-        "".to_string(),
-    ))
+        "test".into(),
+    );
+    let dyn_transport = Web3Transport::new(http_transport);
+    let instrumented = instrumented::InstrumentedTransport::new("test".into(), dyn_transport);
+    Web3Transport::new(instrumented)
 }
 
 /// Like above but takes url from the environment NODE_URL.


### PR DESCRIPTION
# Description
Currently we don't have a good understanding of which subsystem or tasks issue lots of RPC requests. To address this I slightly changed how metrics get collected in the `ethrpc` transport implementation.

# Changes
- move metrics from `http` transport into `instrumented` and make it composable
- move constant internals of `Ethereum` struct into `Arc`ed `Inner` to allow cheap copies
- instrumented `driver` calls as a PoC for the approach (if you'd like I can pull that out into a separate PR)

Overall the `Transport` and `BatchTransport` traits don't compose very well so the implementation ended up a bit weird. But overall I think it's mostly reasonable.

Instead of collecting all metrics under the same label we can now construct hierarchical metrics for RPC requests. These hierarchical metrics look like e.g. `base_liquidity_swapr`.
If we want to have a grafana dashboard tracking the individual subsystems we can select labels using regex patterns. For example `base_liquidity.*` would match `most` instrumented requests coming from the liquidity fetching logic.
It's actually just `most` reqeusts because specifically requests issued using `Ethereum::Inner::Contracts` cannot differentiate which subsystem actually issued them. But overall the number of untracked RPC requests is small enough that we can already get good insights into the worst offenders.

## How to test
Ran `driver` locally with shadow mode and `curl`ed the metrics after some time.

<details>
<summary>collected metrics</summary>

```
# HELP driver_rpc_inner_batch_requests_initiated Number of RPC requests initiated within a batch request
# TYPE driver_rpc_inner_batch_requests_initiated counter
driver_rpc_inner_batch_requests_initiated{component="base",method="eth_call"} 5284
driver_rpc_inner_batch_requests_initiated{component="base",method="eth_getBlockByNumber"} 594
# HELP driver_rpc_requests_complete Number of completed RPC requests for ethereum node.
# TYPE driver_rpc_requests_complete counter
driver_rpc_requests_complete{component="base",method="batch"} 670
driver_rpc_requests_complete{component="base",method="eth_call"} 27516
driver_rpc_requests_complete{component="base",method="eth_chainId"} 1
driver_rpc_requests_complete{component="base",method="eth_feeHistory"} 286
driver_rpc_requests_complete{component="base",method="eth_getBlockByNumber"} 1086
driver_rpc_requests_complete{component="base",method="net_version"} 1
driver_rpc_requests_complete{component="base_auctionPreProcessing_orderBalances",method="eth_call"} 136323
driver_rpc_requests_complete{component="base_ensoSimulator",method="eth_createAccessList"} 2
driver_rpc_requests_complete{component="base_liquidity_swapr",method="eth_call"} 17993
driver_rpc_requests_complete{component="base_liquidity_uniswapV2",method="eth_call"} 190739
driver_rpc_requests_complete{component="base_tokenInfos",method="eth_call"} 28697
# HELP driver_rpc_requests_duration_seconds Execution time for each RPC request (batches are counted as one
# TYPE driver_rpc_requests_duration_seconds histogram
driver_rpc_requests_duration_seconds_bucket{component="base",method="batch",le="0.005"} 0
driver_rpc_requests_duration_seconds_bucket{component="base",method="batch",le="0.01"} 0
driver_rpc_requests_duration_seconds_bucket{component="base",method="batch",le="0.025"} 0
driver_rpc_requests_duration_seconds_bucket{component="base",method="batch",le="0.05"} 469
driver_rpc_requests_duration_seconds_bucket{component="base",method="batch",le="0.1"} 534
driver_rpc_requests_duration_seconds_bucket{component="base",method="batch",le="0.25"} 591
driver_rpc_requests_duration_seconds_bucket{component="base",method="batch",le="0.5"} 606
driver_rpc_requests_duration_seconds_bucket{component="base",method="batch",le="1"} 627
driver_rpc_requests_duration_seconds_bucket{component="base",method="batch",le="2.5"} 655
driver_rpc_requests_duration_seconds_bucket{component="base",method="batch",le="5"} 670
driver_rpc_requests_duration_seconds_bucket{component="base",method="batch",le="10"} 670
driver_rpc_requests_duration_seconds_bucket{component="base",method="batch",le="+Inf"} 670
driver_rpc_requests_duration_seconds_sum{component="base",method="batch"} 148.57874805599994
driver_rpc_requests_duration_seconds_count{component="base",method="batch"} 670
driver_rpc_requests_duration_seconds_bucket{component="base",method="eth_call",le="0.005"} 0
driver_rpc_requests_duration_seconds_bucket{component="base",method="eth_call",le="0.01"} 0
driver_rpc_requests_duration_seconds_bucket{component="base",method="eth_call",le="0.025"} 0
driver_rpc_requests_duration_seconds_bucket{component="base",method="eth_call",le="0.05"} 6
driver_rpc_requests_duration_seconds_bucket{component="base",method="eth_call",le="0.1"} 2679
driver_rpc_requests_duration_seconds_bucket{component="base",method="eth_call",le="0.25"} 9475
driver_rpc_requests_duration_seconds_bucket{component="base",method="eth_call",le="0.5"} 18958
driver_rpc_requests_duration_seconds_bucket{component="base",method="eth_call",le="1"} 26687
driver_rpc_requests_duration_seconds_bucket{component="base",method="eth_call",le="2.5"} 27516
driver_rpc_requests_duration_seconds_bucket{component="base",method="eth_call",le="5"} 27516
driver_rpc_requests_duration_seconds_bucket{component="base",method="eth_call",le="10"} 27516
driver_rpc_requests_duration_seconds_bucket{component="base",method="eth_call",le="+Inf"} 27516
driver_rpc_requests_duration_seconds_sum{component="base",method="eth_call"} 12692.109633597007
driver_rpc_requests_duration_seconds_count{component="base",method="eth_call"} 27516
driver_rpc_requests_duration_seconds_bucket{component="base",method="eth_chainId",le="0.005"} 0
driver_rpc_requests_duration_seconds_bucket{component="base",method="eth_chainId",le="0.01"} 0
driver_rpc_requests_duration_seconds_bucket{component="base",method="eth_chainId",le="0.025"} 0
driver_rpc_requests_duration_seconds_bucket{component="base",method="eth_chainId",le="0.05"} 1
driver_rpc_requests_duration_seconds_bucket{component="base",method="eth_chainId",le="0.1"} 1
driver_rpc_requests_duration_seconds_bucket{component="base",method="eth_chainId",le="0.25"} 1
driver_rpc_requests_duration_seconds_bucket{component="base",method="eth_chainId",le="0.5"} 1
driver_rpc_requests_duration_seconds_bucket{component="base",method="eth_chainId",le="1"} 1
driver_rpc_requests_duration_seconds_bucket{component="base",method="eth_chainId",le="2.5"} 1
driver_rpc_requests_duration_seconds_bucket{component="base",method="eth_chainId",le="5"} 1
driver_rpc_requests_duration_seconds_bucket{component="base",method="eth_chainId",le="10"} 1
driver_rpc_requests_duration_seconds_bucket{component="base",method="eth_chainId",le="+Inf"} 1
driver_rpc_requests_duration_seconds_sum{component="base",method="eth_chainId"} 0.034170252
driver_rpc_requests_duration_seconds_count{component="base",method="eth_chainId"} 1
driver_rpc_requests_duration_seconds_bucket{component="base",method="eth_feeHistory",le="0.005"} 0
driver_rpc_requests_duration_seconds_bucket{component="base",method="eth_feeHistory",le="0.01"} 0
driver_rpc_requests_duration_seconds_bucket{component="base",method="eth_feeHistory",le="0.025"} 0
driver_rpc_requests_duration_seconds_bucket{component="base",method="eth_feeHistory",le="0.05"} 129
driver_rpc_requests_duration_seconds_bucket{component="base",method="eth_feeHistory",le="0.1"} 138
driver_rpc_requests_duration_seconds_bucket{component="base",method="eth_feeHistory",le="0.25"} 149
driver_rpc_requests_duration_seconds_bucket{component="base",method="eth_feeHistory",le="0.5"} 248
driver_rpc_requests_duration_seconds_bucket{component="base",method="eth_feeHistory",le="1"} 266
driver_rpc_requests_duration_seconds_bucket{component="base",method="eth_feeHistory",le="2.5"} 279
driver_rpc_requests_duration_seconds_bucket{component="base",method="eth_feeHistory",le="5"} 286
driver_rpc_requests_duration_seconds_bucket{component="base",method="eth_feeHistory",le="10"} 286
driver_rpc_requests_duration_seconds_bucket{component="base",method="eth_feeHistory",le="+Inf"} 286
driver_rpc_requests_duration_seconds_sum{component="base",method="eth_feeHistory"} 100.93049837100003
driver_rpc_requests_duration_seconds_count{component="base",method="eth_feeHistory"} 286
driver_rpc_requests_duration_seconds_bucket{component="base",method="eth_getBlockByNumber",le="0.005"} 0
driver_rpc_requests_duration_seconds_bucket{component="base",method="eth_getBlockByNumber",le="0.01"} 0
driver_rpc_requests_duration_seconds_bucket{component="base",method="eth_getBlockByNumber",le="0.025"} 0
driver_rpc_requests_duration_seconds_bucket{component="base",method="eth_getBlockByNumber",le="0.05"} 878
driver_rpc_requests_duration_seconds_bucket{component="base",method="eth_getBlockByNumber",le="0.1"} 927
driver_rpc_requests_duration_seconds_bucket{component="base",method="eth_getBlockByNumber",le="0.25"} 971
driver_rpc_requests_duration_seconds_bucket{component="base",method="eth_getBlockByNumber",le="0.5"} 1008
driver_rpc_requests_duration_seconds_bucket{component="base",method="eth_getBlockByNumber",le="1"} 1039
driver_rpc_requests_duration_seconds_bucket{component="base",method="eth_getBlockByNumber",le="2.5"} 1063
driver_rpc_requests_duration_seconds_bucket{component="base",method="eth_getBlockByNumber",le="5"} 1086
driver_rpc_requests_duration_seconds_bucket{component="base",method="eth_getBlockByNumber",le="10"} 1086
driver_rpc_requests_duration_seconds_bucket{component="base",method="eth_getBlockByNumber",le="+Inf"} 1086
driver_rpc_requests_duration_seconds_sum{component="base",method="eth_getBlockByNumber"} 188.7850250819999
driver_rpc_requests_duration_seconds_count{component="base",method="eth_getBlockByNumber"} 1086
driver_rpc_requests_duration_seconds_bucket{component="base",method="net_version",le="0.005"} 0
driver_rpc_requests_duration_seconds_bucket{component="base",method="net_version",le="0.01"} 0
driver_rpc_requests_duration_seconds_bucket{component="base",method="net_version",le="0.025"} 0
driver_rpc_requests_duration_seconds_bucket{component="base",method="net_version",le="0.05"} 0
driver_rpc_requests_duration_seconds_bucket{component="base",method="net_version",le="0.1"} 0
driver_rpc_requests_duration_seconds_bucket{component="base",method="net_version",le="0.25"} 1
driver_rpc_requests_duration_seconds_bucket{component="base",method="net_version",le="0.5"} 1
driver_rpc_requests_duration_seconds_bucket{component="base",method="net_version",le="1"} 1
driver_rpc_requests_duration_seconds_bucket{component="base",method="net_version",le="2.5"} 1
driver_rpc_requests_duration_seconds_bucket{component="base",method="net_version",le="5"} 1
driver_rpc_requests_duration_seconds_bucket{component="base",method="net_version",le="10"} 1
driver_rpc_requests_duration_seconds_bucket{component="base",method="net_version",le="+Inf"} 1
driver_rpc_requests_duration_seconds_sum{component="base",method="net_version"} 0.132709335
driver_rpc_requests_duration_seconds_count{component="base",method="net_version"} 1
driver_rpc_requests_duration_seconds_bucket{component="base_auctionPreProcessing_orderBalances",method="eth_call",le="0.005"} 0
driver_rpc_requests_duration_seconds_bucket{component="base_auctionPreProcessing_orderBalances",method="eth_call",le="0.01"} 0
driver_rpc_requests_duration_seconds_bucket{component="base_auctionPreProcessing_orderBalances",method="eth_call",le="0.025"} 0
driver_rpc_requests_duration_seconds_bucket{component="base_auctionPreProcessing_orderBalances",method="eth_call",le="0.05"} 0
driver_rpc_requests_duration_seconds_bucket{component="base_auctionPreProcessing_orderBalances",method="eth_call",le="0.1"} 0
driver_rpc_requests_duration_seconds_bucket{component="base_auctionPreProcessing_orderBalances",method="eth_call",le="0.25"} 13893
driver_rpc_requests_duration_seconds_bucket{component="base_auctionPreProcessing_orderBalances",method="eth_call",le="0.5"} 26996
driver_rpc_requests_duration_seconds_bucket{component="base_auctionPreProcessing_orderBalances",method="eth_call",le="1"} 50613
driver_rpc_requests_duration_seconds_bucket{component="base_auctionPreProcessing_orderBalances",method="eth_call",le="2.5"} 118035
driver_rpc_requests_duration_seconds_bucket{component="base_auctionPreProcessing_orderBalances",method="eth_call",le="5"} 136323
driver_rpc_requests_duration_seconds_bucket{component="base_auctionPreProcessing_orderBalances",method="eth_call",le="10"} 136323
driver_rpc_requests_duration_seconds_bucket{component="base_auctionPreProcessing_orderBalances",method="eth_call",le="+Inf"} 136323
driver_rpc_requests_duration_seconds_sum{component="base_auctionPreProcessing_orderBalances",method="eth_call"} 198457.36899567765
driver_rpc_requests_duration_seconds_count{component="base_auctionPreProcessing_orderBalances",method="eth_call"} 136323
driver_rpc_requests_duration_seconds_bucket{component="base_ensoSimulator",method="eth_createAccessList",le="0.005"} 0
driver_rpc_requests_duration_seconds_bucket{component="base_ensoSimulator",method="eth_createAccessList",le="0.01"} 0
driver_rpc_requests_duration_seconds_bucket{component="base_ensoSimulator",method="eth_createAccessList",le="0.025"} 0
driver_rpc_requests_duration_seconds_bucket{component="base_ensoSimulator",method="eth_createAccessList",le="0.05"} 2
driver_rpc_requests_duration_seconds_bucket{component="base_ensoSimulator",method="eth_createAccessList",le="0.1"} 2
driver_rpc_requests_duration_seconds_bucket{component="base_ensoSimulator",method="eth_createAccessList",le="0.25"} 2
driver_rpc_requests_duration_seconds_bucket{component="base_ensoSimulator",method="eth_createAccessList",le="0.5"} 2
driver_rpc_requests_duration_seconds_bucket{component="base_ensoSimulator",method="eth_createAccessList",le="1"} 2
driver_rpc_requests_duration_seconds_bucket{component="base_ensoSimulator",method="eth_createAccessList",le="2.5"} 2
driver_rpc_requests_duration_seconds_bucket{component="base_ensoSimulator",method="eth_createAccessList",le="5"} 2
driver_rpc_requests_duration_seconds_bucket{component="base_ensoSimulator",method="eth_createAccessList",le="10"} 2
driver_rpc_requests_duration_seconds_bucket{component="base_ensoSimulator",method="eth_createAccessList",le="+Inf"} 2
driver_rpc_requests_duration_seconds_sum{component="base_ensoSimulator",method="eth_createAccessList"} 0.07739375200000001
driver_rpc_requests_duration_seconds_count{component="base_ensoSimulator",method="eth_createAccessList"} 2
driver_rpc_requests_duration_seconds_bucket{component="base_liquidity_swapr",method="eth_call",le="0.005"} 8
driver_rpc_requests_duration_seconds_bucket{component="base_liquidity_swapr",method="eth_call",le="0.01"} 20
driver_rpc_requests_duration_seconds_bucket{component="base_liquidity_swapr",method="eth_call",le="0.025"} 48
driver_rpc_requests_duration_seconds_bucket{component="base_liquidity_swapr",method="eth_call",le="0.05"} 426
driver_rpc_requests_duration_seconds_bucket{component="base_liquidity_swapr",method="eth_call",le="0.1"} 1356
driver_rpc_requests_duration_seconds_bucket{component="base_liquidity_swapr",method="eth_call",le="0.25"} 4037
driver_rpc_requests_duration_seconds_bucket{component="base_liquidity_swapr",method="eth_call",le="0.5"} 7592
driver_rpc_requests_duration_seconds_bucket{component="base_liquidity_swapr",method="eth_call",le="1"} 17077
driver_rpc_requests_duration_seconds_bucket{component="base_liquidity_swapr",method="eth_call",le="2.5"} 17993
driver_rpc_requests_duration_seconds_bucket{component="base_liquidity_swapr",method="eth_call",le="5"} 17993
driver_rpc_requests_duration_seconds_bucket{component="base_liquidity_swapr",method="eth_call",le="10"} 17993
driver_rpc_requests_duration_seconds_bucket{component="base_liquidity_swapr",method="eth_call",le="+Inf"} 17993
driver_rpc_requests_duration_seconds_sum{component="base_liquidity_swapr",method="eth_call"} 10359.996136319947
driver_rpc_requests_duration_seconds_count{component="base_liquidity_swapr",method="eth_call"} 17993
driver_rpc_requests_duration_seconds_bucket{component="base_liquidity_uniswapV2",method="eth_call",le="0.005"} 3
driver_rpc_requests_duration_seconds_bucket{component="base_liquidity_uniswapV2",method="eth_call",le="0.01"} 12
driver_rpc_requests_duration_seconds_bucket{component="base_liquidity_uniswapV2",method="eth_call",le="0.025"} 48
driver_rpc_requests_duration_seconds_bucket{component="base_liquidity_uniswapV2",method="eth_call",le="0.05"} 1980
driver_rpc_requests_duration_seconds_bucket{component="base_liquidity_uniswapV2",method="eth_call",le="0.1"} 14850
driver_rpc_requests_duration_seconds_bucket{component="base_liquidity_uniswapV2",method="eth_call",le="0.25"} 39338
driver_rpc_requests_duration_seconds_bucket{component="base_liquidity_uniswapV2",method="eth_call",le="0.5"} 94306
driver_rpc_requests_duration_seconds_bucket{component="base_liquidity_uniswapV2",method="eth_call",le="1"} 178434
driver_rpc_requests_duration_seconds_bucket{component="base_liquidity_uniswapV2",method="eth_call",le="2.5"} 190719
driver_rpc_requests_duration_seconds_bucket{component="base_liquidity_uniswapV2",method="eth_call",le="5"} 190739
driver_rpc_requests_duration_seconds_bucket{component="base_liquidity_uniswapV2",method="eth_call",le="10"} 190739
driver_rpc_requests_duration_seconds_bucket{component="base_liquidity_uniswapV2",method="eth_call",le="+Inf"} 190739
driver_rpc_requests_duration_seconds_sum{component="base_liquidity_uniswapV2",method="eth_call"} 106140.00105148232
driver_rpc_requests_duration_seconds_count{component="base_liquidity_uniswapV2",method="eth_call"} 190739
driver_rpc_requests_duration_seconds_bucket{component="base_tokenInfos",method="eth_call",le="0.005"} 0
driver_rpc_requests_duration_seconds_bucket{component="base_tokenInfos",method="eth_call",le="0.01"} 0
driver_rpc_requests_duration_seconds_bucket{component="base_tokenInfos",method="eth_call",le="0.025"} 0
driver_rpc_requests_duration_seconds_bucket{component="base_tokenInfos",method="eth_call",le="0.05"} 938
driver_rpc_requests_duration_seconds_bucket{component="base_tokenInfos",method="eth_call",le="0.1"} 6250
driver_rpc_requests_duration_seconds_bucket{component="base_tokenInfos",method="eth_call",le="0.25"} 17259
driver_rpc_requests_duration_seconds_bucket{component="base_tokenInfos",method="eth_call",le="0.5"} 23555
driver_rpc_requests_duration_seconds_bucket{component="base_tokenInfos",method="eth_call",le="1"} 26986
driver_rpc_requests_duration_seconds_bucket{component="base_tokenInfos",method="eth_call",le="2.5"} 28697
driver_rpc_requests_duration_seconds_bucket{component="base_tokenInfos",method="eth_call",le="5"} 28697
driver_rpc_requests_duration_seconds_bucket{component="base_tokenInfos",method="eth_call",le="10"} 28697
driver_rpc_requests_duration_seconds_bucket{component="base_tokenInfos",method="eth_call",le="+Inf"} 28697
driver_rpc_requests_duration_seconds_sum{component="base_tokenInfos",method="eth_call"} 8747.220767478982
driver_rpc_requests_duration_seconds_count{component="base_tokenInfos",method="eth_call"} 28697
# HELP driver_rpc_requests_inflight Number of inflight RPC requests for ethereum node.
# TYPE driver_rpc_requests_inflight gauge
driver_rpc_requests_inflight{component="base",method="batch"} 0
driver_rpc_requests_inflight{component="base",method="eth_call"} 0
driver_rpc_requests_inflight{component="base",method="eth_chainId"} 0
driver_rpc_requests_inflight{component="base",method="eth_feeHistory"} 0
driver_rpc_requests_inflight{component="base",method="eth_getBlockByNumber"} 0
driver_rpc_requests_inflight{component="base",method="net_version"} 0
driver_rpc_requests_inflight{component="base_auctionPreProcessing_orderBalances",method="eth_call"} 0
driver_rpc_requests_inflight{component="base_ensoSimulator",method="eth_createAccessList"} 0
driver_rpc_requests_inflight{component="base_liquidity_swapr",method="eth_call"} 0
driver_rpc_requests_inflight{component="base_liquidity_uniswapV2",method="eth_call"} 0
driver_rpc_requests_inflight{component="base_tokenInfos",method="eth_call"} 0

```
</details>