### PR TITLE
Remove usage of `net` RPC module

### DIFF
--- a/.clippy.toml
+++ b/.clippy.toml
@@ -1,0 +1,3 @@
+disallowed-methods = [
+    { path = "web3::api::Net::version", reason = "Calling `eth().chain_id().await?.to_string()` is equivalent and is better supported." }
+]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1806,9 +1806,9 @@ dependencies = [
 
 [[package]]
 name = "ethcontract"
-version = "0.25.4"
+version = "0.25.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c28ee036fde35000df46c82ec67f2e9f5a6ebc53093e0af2a9b045cce9818acf"
+checksum = "762a89cc55c19c68066d5510a51df2d03857c99ccccd8a1c72916db669e1d8e2"
 dependencies = [
  "arrayvec",
  "aws-config 0.55.3",
@@ -1833,9 +1833,9 @@ dependencies = [
 
 [[package]]
 name = "ethcontract-common"
-version = "0.25.4"
+version = "0.25.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "422d0b0977f0855eaeab796ff5502302f5ac33ae96209c0ea81b0aa164dd370e"
+checksum = "4f1a4ffc732f4496733866edb14201e48ac5b4f5c5360aa02f1966e0a3343ced"
 dependencies = [
  "ethabi",
  "hex",
@@ -1849,9 +1849,9 @@ dependencies = [
 
 [[package]]
 name = "ethcontract-derive"
-version = "0.25.4"
+version = "0.25.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e68257cfdf589ae3f9d2edd348072e2bf105fa87288fc0a7f5e090e20a2acd4"
+checksum = "53e1ad278c8fcbb25cb9a59fc9f9ef5d613f9f15bb9c87a0b12ee081116a230d"
 dependencies = [
  "anyhow",
  "ethcontract-common",
@@ -1863,9 +1863,9 @@ dependencies = [
 
 [[package]]
 name = "ethcontract-generate"
-version = "0.25.4"
+version = "0.25.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c013062a68f3e5d6fa2db391134cfc5fb0ee64d8d15d6205d79ec7cf7e8ffa4"
+checksum = "6d6c427efdae115a35cb1111671b2db9a71e4ca22336019facb5d93d97f9b5b2"
 dependencies = [
  "Inflector",
  "anyhow",

--- a/crates/contracts/src/lib.rs
+++ b/crates/contracts/src/lib.rs
@@ -113,7 +113,7 @@ mod tests {
         type Out = Ready<Web3Result<Value>>;
 
         fn prepare(&self, method: &str, params: Vec<Value>) -> (RequestId, Call) {
-            assert_eq!(method, "net_version");
+            assert_eq!(method, "eth_chainId");
             assert_eq!(params.len(), 0);
             (
                 0,
@@ -128,7 +128,7 @@ mod tests {
         }
 
         fn send(&self, _id: RequestId, _request: Call) -> Self::Out {
-            future::ready(Ok(json!(format!("{}", self.0))))
+            future::ready(Ok(json!(format!("{:x}", self.0))))
         }
     }
 
@@ -141,7 +141,7 @@ mod tests {
         {
             future::ready(Ok(requests
                 .into_iter()
-                .map(|_| Ok(json!(format!("{}", self.0))))
+                .map(|_| Ok(json!(format!("{:x}", self.0))))
                 .collect()))
         }
     }

--- a/crates/e2e/src/setup/deploy.rs
+++ b/crates/e2e/src/setup/deploy.rs
@@ -31,7 +31,12 @@ pub struct Contracts {
 
 impl Contracts {
     pub async fn deployed(web3: &Web3) -> Self {
-        let network_id = web3.net().version().await.expect("get network ID failed");
+        let network_id = web3
+            .eth()
+            .chain_id()
+            .await
+            .expect("get network ID failed")
+            .to_string();
         tracing::info!("connected to forked test network {}", network_id);
 
         let gp_settlement = GPv2Settlement::deployed(web3).await.unwrap();
@@ -65,7 +70,12 @@ impl Contracts {
     }
 
     pub async fn deploy(web3: &Web3) -> Self {
-        let network_id = web3.net().version().await.expect("get network ID failed");
+        let network_id = web3
+            .eth()
+            .chain_id()
+            .await
+            .expect("get network ID failed")
+            .to_string();
         tracing::info!("connected to test network {}", network_id);
 
         let accounts: Vec<Address> = web3.eth().accounts().await.expect("get accounts failed");

--- a/crates/shared/src/bad_token/trace_call.rs
+++ b/crates/shared/src/bad_token/trace_call.rs
@@ -451,7 +451,7 @@ mod tests {
         // shared::transport=debug", tracing::level_filters::LevelFilter::OFF);
         let http = create_env_test_transport();
         let web3 = Web3::new(http);
-        let version = web3.net().version().await.unwrap();
+        let version = web3.eth().chain_id().await.unwrap().to_string();
 
         let base_tokens = &[
             testlib::tokens::WETH,

--- a/crates/shared/src/code_simulation.rs
+++ b/crates/shared/src/code_simulation.rs
@@ -268,7 +268,7 @@ mod tests {
 
     async fn test_simulators() -> Vec<Arc<dyn CodeSimulating>> {
         let web3 = Web3::new(create_env_test_transport());
-        let network_id = web3.net().version().await.unwrap();
+        let network_id = web3.eth().chain_id().await.unwrap().to_string();
 
         vec![
             Arc::new(web3.clone()),
@@ -372,7 +372,7 @@ mod tests {
     #[ignore]
     async fn tenderly_state_override_conversion() {
         let web3 = Web3::new(create_env_test_transport());
-        let network_id = web3.net().version().await.unwrap();
+        let network_id = web3.eth().chain_id().await.unwrap().to_string();
         let tenderly = TenderlyCodeSimulator::new(TenderlyHttpApi::test_from_env(), network_id)
             .save(true, true);
 

--- a/crates/shared/src/gas_price_estimation.rs
+++ b/crates/shared/src/gas_price_estimation.rs
@@ -53,7 +53,7 @@ pub async fn create_priority_estimator(
     blocknative_api_key: Option<String>,
 ) -> Result<impl GasPriceEstimating> {
     let client = || Client(http_factory.create());
-    let network_id = web3.net().version().await?;
+    let network_id = web3.eth().chain_id().await?.to_string();
     let mut estimators = Vec::<Box<dyn GasPriceEstimating>>::new();
 
     for estimator_type in estimator_types {

--- a/crates/shared/src/price_estimation/http.rs
+++ b/crates/shared/src/price_estimation/http.rs
@@ -799,7 +799,7 @@ mod tests {
         );
         let web3 = Web3::new(DynTransport::new(transport));
         let chain_id = web3.eth().chain_id().await.unwrap().as_u64();
-        let version = web3.net().version().await.unwrap();
+        let version = chain_id.to_string();
 
         let pools = Arc::new(
             PoolCache::new(

--- a/crates/shared/src/sources/swapr/reader.rs
+++ b/crates/shared/src/sources/swapr/reader.rs
@@ -104,7 +104,7 @@ mod tests {
     async fn fetch_swapr_pool() {
         let transport = create_env_test_transport();
         let web3 = Web3::new(transport);
-        let version = web3.net().version().await.unwrap();
+        let version = web3.eth().chain_id().await.unwrap().to_string();
         let pool_fetcher = uniswap_v2::UniV2BaselineSourceParameters::from_baseline_source(
             BaselineSource::Swapr,
             &version,

--- a/crates/shared/src/sources/uniswap_v2.rs
+++ b/crates/shared/src/sources/uniswap_v2.rs
@@ -201,7 +201,7 @@ mod tests {
         token1: H160,
         expected_pool_address: H160,
     ) {
-        let version_ = web3.net().version().await.unwrap();
+        let version_ = web3.eth().chain_id().await.unwrap().to_string();
         assert_eq!(version_, version, "wrong node for test");
         let source = UniV2BaselineSourceParameters::from_baseline_source(source, version)
             .unwrap()
@@ -218,7 +218,7 @@ mod tests {
     async fn baseline_mainnet() {
         let http = crate::ethrpc::create_env_test_transport();
         let web3 = Web3::new(http);
-        let version = web3.net().version().await.unwrap();
+        let version = web3.eth().chain_id().await.unwrap().to_string();
         assert_eq!(version, "1", "test must be run with mainnet node");
         let test = |source, token0, token1, expected| {
             test_baseline_source(&web3, "1", source, token0, token1, expected)
@@ -252,7 +252,7 @@ mod tests {
     async fn baseline_sepolia() {
         let http = crate::ethrpc::create_env_test_transport();
         let web3 = Web3::new(http);
-        let version = web3.net().version().await.unwrap();
+        let version = web3.eth().chain_id().await.unwrap().to_string();
         assert_eq!(version, "11155111", "test must be run with mainnet node");
         let test = |source, token0, token1, expected| {
             test_baseline_source(&web3, "11155111", source, token0, token1, expected)
@@ -273,7 +273,7 @@ mod tests {
     async fn baseline_xdai() {
         let http = crate::ethrpc::create_env_test_transport();
         let web3 = Web3::new(http);
-        let version = web3.net().version().await.unwrap();
+        let version = web3.eth().chain_id().await.unwrap().to_string();
         assert_eq!(version, "100", "test must be run with xdai node");
         let test = |source, token0, token1, expected| {
             test_baseline_source(&web3, "100", source, token0, token1, expected)

--- a/crates/solver/src/settlement_access_list.rs
+++ b/crates/solver/src/settlement_access_list.rs
@@ -88,7 +88,7 @@ pub async fn estimate_settlement_access_list(
                     .value(1.into());
                 let simulation_link = tenderly_link(
                     web3.eth().block_number().await?.as_u64(),
-                    &web3.net().version().await?,
+                    &web3.eth().chain_id().await?.to_string(),
                     tx.clone(),
                     None,
                     None
@@ -128,7 +128,7 @@ pub async fn estimate_settlement_access_list(
 
     let simulation_link = tenderly_link(
         web3.eth().block_number().await?.as_u64(),
-        &web3.net().version().await?,
+        &web3.eth().chain_id().await?.to_string(),
         tx.clone(),
         None,
         Some(partial_access_list.clone()),

--- a/crates/solver/src/settlement_submission.rs
+++ b/crates/solver/src/settlement_submission.rs
@@ -211,7 +211,7 @@ impl SolutionSubmitter {
             }
         }
 
-        let network_id = self.web3.net().version().await?;
+        let network_id = self.web3.eth().chain_id().await?.to_string();
         let mut futures = self
             .transaction_strategies
             .iter()

--- a/crates/solver/src/settlement_submission/dry_run.rs
+++ b/crates/solver/src/settlement_submission/dry_run.rs
@@ -19,7 +19,7 @@ pub async fn log_settlement(
 ) -> Result<TransactionReceipt> {
     let web3 = contract.raw_instance().web3();
     let current_block = web3.eth().block_number().await?;
-    let network = web3.net().version().await?;
+    let network = web3.eth().chain_id().await?.to_string();
     let settlement = settlement.encode(InternalizationStrategy::SkipInternalizableInteraction);
     let settlement = settle_method_builder(contract, settlement, account).tx;
     let simulation_link = tenderly_link(current_block.as_u64(), &network, settlement, None, None);

--- a/crates/solver/src/settlement_submission/submitter/public_mempool_api.rs
+++ b/crates/solver/src/settlement_submission/submitter/public_mempool_api.rs
@@ -199,10 +199,11 @@ impl SubmissionNode {
 
 pub async fn validate_submission_node(node: &Web3, expected_network_id: &String) -> Result<()> {
     let node_network_id = node
-        .net()
-        .version()
+        .eth()
+        .chain_id()
         .await
-        .context("Unable to retrieve network id on startup")?;
+        .context("Unable to retrieve network id on startup")?
+        .to_string();
     ensure!(
         &node_network_id == expected_network_id,
         "Network id doesn't match expected network id"


### PR DESCRIPTION
# Description
Fixes: https://github.com/cowprotocol/services/issues/2414

# Changes
* replaces all `.net().version()` calls with `.eth().chain_id().await?.to_string()`
* adds custom clippy lint forbidding the old `version()` function
* updates the dependencies to make use of `ethcontract` [0.25.5](https://github.com/cowprotocol/ethcontract-rs/releases/tag/v0.25.5) which applies the same change

## How to test
Locally ran the services with `https://freerpc.merkle.io/` as the RPC which was previously not possible because that didn't expose the `net` module.

Checked that the clippy lint works:
```
    Checking orderbook v0.1.0 (/Users/martin/work/backend/side/crates/orderbook)
    Checking autopilot v0.1.0 (/Users/martin/work/backend/side/crates/autopilot)
warning: use of a disallowed method `web3::api::Net::version`
   --> crates/autopilot/src/run.rs:204:19
    |
204 |       let network = web3
    |  ___________________^
205 | |         .net()
206 | |         .version()
    | |__________________^
    |
    = note: Calling `eth().chain_id().await?.to_string()` is equivalent and is better supported. (from clippy.toml)
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#disallowed_methods
    = note: `#[warn(clippy::disallowed_methods)]` on by default
```