### PR TITLE
fix: dockerfile for deploy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,9 +18,7 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry --mount=type=cache,targe
     cp target/release/driver / && \
     cp target/release/orderbook / && \
     cp target/release/refunder / && \
-    cp target/release/solvers / && \
-    cp -r database/sql /sql && \
-    cp -r database/flyway.conf /flyway.conf
+    cp target/release/solvers
 
 # Create an intermediate image to extract the binaries
 FROM docker.io/debian:bookworm-slim as intermediate


### PR DESCRIPTION
# Description

#2426 introduce a bug as these files are no longer available in `cargo-build`, nor are they needed.

# Changes

- [x] Fix `cargo-build` intermediate image generation

## How to test
1. CI/CD