### PR TITLE
fix: dockerfile missing slash

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry --mount=type=cache,targe
     cp target/release/driver / && \
     cp target/release/orderbook / && \
     cp target/release/refunder / && \
-    cp target/release/solvers
+    cp target/release/solvers /
 
 # Create an intermediate image to extract the binaries
 FROM docker.io/debian:bookworm-slim as intermediate


### PR DESCRIPTION
# Description

Missing slash in the deploy docker.

# Changes

- [x] Fixes missing slash

## How to test
1. Check the CI/CD builds the deploy correctly.