### PR TITLE
Add RPC metrics for api and autopilot

### DIFF
--- a/crates/shared/src/account_balances/simulation.rs
+++ b/crates/shared/src/account_balances/simulation.rs
@@ -27,9 +27,10 @@ impl Balances {
         // properly check if the `source` is not supported for the deployment
         // work without additional code paths :tada:!
         let vault = vault.unwrap_or_default();
+        let web3 = ethrpc::instrumented::instrument_with_label(web3, "balanceFetching".into());
 
         Self {
-            balances: contracts::support::Balances::at(web3, settlement),
+            balances: contracts::support::Balances::at(&web3, settlement),
             settlement,
             vault_relayer,
             vault,

--- a/crates/shared/src/bad_token/token_owner_finder.rs
+++ b/crates/shared/src/bad_token/token_owner_finder.rs
@@ -214,6 +214,7 @@ pub async fn init(
     uniswapv3_factory: Option<&IUniswapV3Factory>,
     base_tokens: &BaseTokens,
 ) -> Result<Arc<dyn TokenOwnerFinding>> {
+    let web3 = ethrpc::instrumented::instrument_with_label(&web3, "tokenOwners".into());
     let finders = args
         .token_owner_finders
         .as_deref()

--- a/crates/shared/src/price_estimation/factory.rs
+++ b/crates/shared/src/price_estimation/factory.rs
@@ -127,6 +127,9 @@ impl<'a> PriceEstimatorFactory<'a> {
                     network
                         .simulation_web3
                         .clone()
+                        .map(|web3| {
+                            ethrpc::instrumented::instrument_with_label(&web3, "simulator".into())
+                        })
                         .context("missing simulation node configuration")
                 };
                 let tenderly_simulator = || -> anyhow::Result<_> {
@@ -153,7 +156,11 @@ impl<'a> PriceEstimatorFactory<'a> {
                         ))
                     }
                 };
-                let code_fetcher = Arc::new(CachedCodeFetcher::new(Arc::new(network.web3.clone())));
+                let code_fetcher = ethrpc::instrumented::instrument_with_label(
+                    &network.web3,
+                    "codeFetching".into(),
+                );
+                let code_fetcher = Arc::new(CachedCodeFetcher::new(Arc::new(code_fetcher)));
 
                 Ok(Arc::new(TradeVerifier::new(
                     simulator,

--- a/crates/shared/src/signature_validator/simulation.rs
+++ b/crates/shared/src/signature_validator/simulation.rs
@@ -21,8 +21,9 @@ pub struct Validator {
 
 impl Validator {
     pub fn new(web3: &Web3, settlement: H160, vault_relayer: H160) -> Self {
+        let web3 = ethrpc::instrumented::instrument_with_label(web3, "signatureValidation".into());
         Self {
-            signatures: contracts::support::Signatures::at(web3, settlement),
+            signatures: contracts::support::Signatures::at(&web3, settlement),
             settlement,
             vault_relayer,
         }

--- a/crates/shared/src/sources/balancer_v2/pool_fetching.rs
+++ b/crates/shared/src/sources/balancer_v2/pool_fetching.rs
@@ -225,13 +225,14 @@ pub struct BalancerContracts {
 
 impl BalancerContracts {
     pub async fn new(web3: &Web3, factory_kinds: Vec<BalancerFactoryKind>) -> Result<Self> {
-        let vault = BalancerV2Vault::deployed(web3)
+        let web3 = ethrpc::instrumented::instrument_with_label(web3, "balancerV2".into());
+        let vault = BalancerV2Vault::deployed(&web3)
             .await
             .context("Cannot retrieve balancer vault")?;
 
         macro_rules! instance {
             ($factory:ident) => {{
-                $factory::deployed(web3)
+                $factory::deployed(&web3)
                     .await
                     .context(format!(
                         "Cannot retrieve Balancer factory {}",
@@ -296,6 +297,7 @@ impl BalancerPoolFetcher {
         contracts: &BalancerContracts,
         deny_listed_pool_ids: Vec<H256>,
     ) -> Result<Self> {
+        let web3 = ethrpc::instrumented::instrument_with_label(&web3, "balancerV2".into());
         let pool_initializer = BalancerSubgraphClient::for_chain(base_url, chain_id, client)?;
         let fetcher = Arc::new(Cache::new(
             create_aggregate_pool_fetcher(

--- a/crates/shared/src/sources/uniswap_v2.rs
+++ b/crates/shared/src/sources/uniswap_v2.rs
@@ -104,7 +104,8 @@ impl UniV2BaselineSourceParameters {
     }
 
     pub async fn into_source(&self, web3: &Web3) -> Result<UniV2BaselineSource> {
-        let router = contracts::IUniswapLikeRouter::at(web3, self.router);
+        let web3 = ethrpc::instrumented::instrument_with_label(web3, "uniswapV2".into());
+        let router = contracts::IUniswapLikeRouter::at(&web3, self.router);
         let factory = router.factory().call().await.context("factory")?;
         let pair_provider = pair_provider::PairProvider {
             factory,

--- a/crates/shared/src/sources/uniswap_v3/pool_fetching.rs
+++ b/crates/shared/src/sources/uniswap_v3/pool_fetching.rs
@@ -273,6 +273,7 @@ impl UniswapV3PoolFetcher {
         block_retriever: Arc<dyn BlockRetrieving>,
         max_pools_to_initialize: usize,
     ) -> Result<Self> {
+        let web3 = ethrpc::instrumented::instrument_with_label(&web3, "uniswapV3".into());
         let checkpoint =
             PoolsCheckpointHandler::new(base_url, chain_id, client, max_pools_to_initialize)
                 .await?;


### PR DESCRIPTION
# Description
Follow up to #2420 also adding RPC metrics for autopilot and api.

## How to test
Ran services locally to see the additional metrics