### PR TITLE
[Native Solution Submission] Pending tx nonce management

### DIFF
--- a/crates/driver/src/domain/mempools.rs
+++ b/crates/driver/src/domain/mempools.rs
@@ -234,8 +234,7 @@ impl Mempools {
             .cloned()
         {
             // There is a pending transaction, optimistically cancel it and increment the
-            // nonce for the actual settlement using the public mempool
-            // preferably.
+            // nonce for the actual settlement.
             tracing::info!(
                 ?solver,
                 ?nonce,

--- a/crates/driver/src/domain/mempools.rs
+++ b/crates/driver/src/domain/mempools.rs
@@ -259,7 +259,7 @@ impl Mempools {
         let tx = mempool.submit(tx, gas, solver, nonce).await?;
         tracing::debug!(?tx, ?nonce, "Submitted tx and tracking nonce");
 
-        // Track pending transactions
+        // Track pending transaction
         if let Some(nonce) = nonce {
             self.tx_pool.lock().await.insert(
                 solver.address(),

--- a/crates/driver/src/domain/mempools.rs
+++ b/crates/driver/src/domain/mempools.rs
@@ -240,7 +240,7 @@ impl Mempools {
                 ?nonce,
                 "Cancelling pending transaction from previous auction"
             );
-            self.cancel(mempool, pending.gas_price, &solver, Some(nonce))
+            self.cancel(mempool, pending.gas_price, solver, Some(nonce))
                 .await?;
             Ok(nonce + 1)
         } else {

--- a/crates/driver/src/infra/blockchain/mod.rs
+++ b/crates/driver/src/infra/blockchain/mod.rs
@@ -125,6 +125,10 @@ impl Ethereum {
         &self.inner.current_block
     }
 
+    pub async fn nonce(&self, address: eth::Address) -> Result<eth::U256, Error> {
+        Ok(self.web3.eth().transaction_count(address.0, None).await?)
+    }
+
     /// Create access list used by a transaction.
     pub async fn create_access_list(&self, tx: eth::Tx) -> Result<eth::AccessList, Error> {
         const MAX_BLOCK_SIZE: u64 = 30_000_000;


### PR DESCRIPTION
# Description
We are sometimes running into issues with native solution submission on Gnosis Chain because of a pending transaction with higher gas price.

This PR adds part of the logic we had in the legacy code base (tracking pending transactions with their gas price). However instead of reusing and incrementing the gas price, we cancel the transaction and resubmit at a higher gas price. This should be cheaper since 21k gas a price x will be cheaper than a full settlement (at least 200k gas) at price x*1.15

# Changes
- [x] If there is a public mempool configured, check if there is a pending transaction that needs cancelling
- [x] allow submitting transactions with specific nonce (optional)
- [x] track pending transactions and nonces

The current tracking logic may be a bit rudimentary (ie. it only allows tracking a single transaction). Open for suggestions...

## How to test
Existing e2e tests