### PR TITLE
[Solution Submission] Return as soon as tx has been submitted to mempool

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry --mount=type=cache,targe
     cp target/release/driver / && \
     cp target/release/orderbook / && \
     cp target/release/refunder / && \
-    cp target/release/solvers
+    cp target/release/solvers /
 
 # Create an intermediate image to extract the binaries
 FROM docker.io/debian:bookworm-slim as intermediate

--- a/crates/driver/src/infra/mempool/mod.rs
+++ b/crates/driver/src/infra/mempool/mod.rs
@@ -57,6 +57,8 @@ impl Inner {
         Self { config, transport }
     }
 
+    /// Submits a transaction to the mempool. Returns optimistically as soon as
+    /// the transaction is pending.
     pub async fn submit(
         &self,
         tx: eth::Tx,
@@ -74,6 +76,7 @@ impl Inner {
             .value(tx.value.0)
             .gas(gas.limit.0)
             .access_list(web3::types::AccessList::from(tx.access_list))
+            .resolve(ethcontract::transaction::ResolveCondition::Pending)
             .send()
             .await
             .map(|result| eth::TxId(result.hash()))


### PR DESCRIPTION
# Description
Might make #2431 obsolete.

While debugging why we sometimes end up with un-cancelled settlement transactions, I noticed that some runloops don't show any logs from the driver's `settle` call indicating some kind of stuckness ([logs](https://production-6de61f.kb.eu-central-1.aws.cloud.es.io/app/r/s/GJFG4)).

It turns out that the default behavior of `ethcontracts` when sending transactions is to wait for inclusion (cf. [code](https://docs.rs/ethcontract/latest/src/ethcontract/transaction.rs.html#66)).

The logic however was written under the assumption that we return as soon as the tx has been submitted to the mempool (and is still pending). Otherwise, we wouldn't be able to e.g. cancel the tx as soon as we see it failing simulations.

# Changes
- [x] Set resolve condition to `pending`

## How to test
Existing test suite (re-enabling native submission logic after this PR should longer show stuck transactions)