### PR TITLE
[TRIVIAL] Remove solvers auction log

### DIFF
--- a/crates/solvers/src/api/routes/solve/mod.rs
+++ b/crates/solvers/src/api/routes/solve/mod.rs
@@ -23,8 +23,6 @@ pub async fn solve(
             }
         };
 
-        tracing::trace!(?auction);
-
         let auction_id = auction.id;
         let solutions = state
             .solve(auction)


### PR DESCRIPTION
# Description
Removes logging the whole auction in solvers crate since it's overwhelming the logs.

Related to https://github.com/cowprotocol/infrastructure/pull/1147#pullrequestreview-1898466895