### PR TITLE
Add estimator name to trace

### DIFF
--- a/crates/shared/src/price_estimation/instrumented.rs
+++ b/crates/shared/src/price_estimation/instrumented.rs
@@ -3,6 +3,7 @@ use {
     futures::future::FutureExt,
     prometheus::{HistogramVec, IntCounterVec},
     std::{sync::Arc, time::Instant},
+    tracing::Instrument,
 };
 
 /// An instrumented price estimator.
@@ -52,6 +53,7 @@ impl PriceEstimating for InstrumentedPriceEstimator {
 
             estimate
         }
+        .instrument(tracing::info_span!("estimator", name = &self.name,))
         .boxed()
     }
 }


### PR DESCRIPTION
# Description
Currently it's a bit finicky to figure out which logs where emitted from which estimator in the orderbook/autopilot.
This PR adds the estimator name to all logs emitted by an instrumented estimator.