### PR TITLE
Legacy API translation inside driver

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1668,6 +1668,7 @@ dependencies = [
  "serde_with",
  "shared",
  "solver",
+ "solvers",
  "tap",
  "tempfile",
  "thiserror",

--- a/crates/driver/Cargo.toml
+++ b/crates/driver/Cargo.toml
@@ -66,6 +66,7 @@ gas-estimation = { workspace = true }
 model = { path = "../model" }
 observe = { path = "../observe" }
 shared = { path = "../shared" }
+solvers = { path = "../solvers" }
 solver = { path = "../solver" }
 tracing = { workspace = true }
 warp = { workspace = true }

--- a/crates/driver/src/infra/config/file/load.rs
+++ b/crates/driver/src/infra/config/file/load.rs
@@ -86,6 +86,7 @@ pub async fn load(chain: eth::ChainId, path: &Path) -> infra::Config {
                         .try_into()
                         .unwrap(),
                 },
+                use_legacy_interface: config.use_legacy_interface,
             }
         }))
         .await,

--- a/crates/driver/src/infra/config/file/mod.rs
+++ b/crates/driver/src/infra/config/file/mod.rs
@@ -185,6 +185,11 @@ struct SolverConfig {
     /// Timeout configuration for the solver.
     #[serde(default, flatten)]
     timeouts: Timeouts,
+
+    /// If enabled requests get converted to the legacy format
+    /// and responses back to the current format.
+    #[serde(default)]
+    use_legacy_interface: bool,
 }
 
 #[serde_as]

--- a/crates/solvers/src/api/mod.rs
+++ b/crates/solvers/src/api/mod.rs
@@ -6,7 +6,7 @@ use {
     tokio::sync::oneshot,
 };
 
-mod routes;
+pub(crate) mod routes;
 
 const REQUEST_BODY_LIMIT: usize = 10 * 1024 * 1024;
 

--- a/crates/solvers/src/api/routes/mod.rs
+++ b/crates/solvers/src/api/routes/mod.rs
@@ -2,8 +2,8 @@ use serde::Serialize;
 
 mod healthz;
 mod metrics;
-mod notify;
-mod solve;
+pub(crate) mod notify;
+pub(crate) mod solve;
 
 pub(super) use {healthz::healthz, metrics::metrics, notify::notify, solve::solve};
 

--- a/crates/solvers/src/api/routes/notify/mod.rs
+++ b/crates/solvers/src/api/routes/notify/mod.rs
@@ -1,6 +1,6 @@
 use {crate::domain::solver::Solver, std::sync::Arc, tracing::Instrument};
 
-mod dto;
+pub(crate) mod dto;
 
 pub async fn notify(
     state: axum::extract::State<Arc<Solver>>,

--- a/crates/solvers/src/api/routes/solve/mod.rs
+++ b/crates/solvers/src/api/routes/solve/mod.rs
@@ -1,6 +1,6 @@
 use {super::Response, tracing::Instrument};
 
-mod dto;
+pub(crate) mod dto;
 
 use {crate::domain::solver::Solver, std::sync::Arc};
 

--- a/crates/solvers/src/lib.rs
+++ b/crates/solvers/src/lib.rs
@@ -12,3 +12,13 @@ mod tests;
 mod util;
 
 pub use self::run::{run, start};
+
+pub mod legacy_adapter {
+    pub use super::{
+        boundary::legacy::{legacy_notify, legacy_solve},
+        domain::{
+            eth::{ChainId, WethAddress},
+            solver::legacy::Config,
+        },
+    };
+}


### PR DESCRIPTION
# Description
Currently we need the `legacy` solvers instance to convert a new API call into the old format and convert the response back. This means at the moment we have to spawn 1 pod per legacy solver endpoint (e.g. `/solve` and `/quote` can require separate instances).

# Changes
Exports the conversion logic from the `solvers` crate and makes use of it in the `driver` to not require a whole new process to do the conversion.

## How to test
TODO: manual test and maybe testing in staging