### PR TITLE
Support custom `/solve` endpoints

### DIFF
--- a/crates/driver/src/tests/setup/driver.rs
+++ b/crates/driver/src/tests/setup/driver.rs
@@ -219,7 +219,7 @@ async fn create_config_file(
             file,
             r#"[[solver]]
                name = "{}"
-               endpoint = "http://{}"
+               endpoint = "http://{}/solve"
                absolute-slippage = "{}"
                relative-slippage = "{}"
                account = "0x{}"

--- a/crates/e2e/src/setup/colocation.rs
+++ b/crates/e2e/src/setup/colocation.rs
@@ -52,7 +52,7 @@ async fn start_solver(config_file: TempPath, solver_name: String) -> Url {
     });
 
     let solver_addr = bind_receiver.await.unwrap();
-    format!("http://{solver_addr}").parse().unwrap()
+    format!("http://{solver_addr}/solve").parse().unwrap()
 }
 
 pub struct SolverEngine {

--- a/crates/shared/src/url.rs
+++ b/crates/shared/src/url.rs
@@ -13,6 +13,19 @@ pub fn join(url: &Url, mut path: &str) -> Url {
     Url::parse(&format!("{url}/{path}")).unwrap()
 }
 
+/// Replaces the last path segment of the URL with the new endpoint.
+/// Returns an error if `url` has an empty path meaning nothing can be replaced.
+pub fn replace_endpoint(mut url: Url, new_endpoint: &str) -> Result<Url> {
+    if url.path() == "/" || url.path().is_empty() {
+        anyhow::bail!("url has no endpoint to replace: {url}");
+    }
+    url.path_segments_mut()
+        .map_err(|_| anyhow::anyhow!("cannot be a base url"))?
+        .pop()
+        .push(new_endpoint);
+    Ok(url)
+}
+
 /// Splits a URL right where the path begins into base and endpoint.
 /// https://my.solver.xyz/solve/1?param=1#fragment=some
 /// becomes
@@ -68,5 +81,23 @@ mod tests {
         round_trip("https://my.solver.xyz?param1=1&param2=2#fragment=1&fragment2=2");
         // base (with auth) + path
         round_trip("https://user:pass@my.solver.xyz/solve/1");
+    }
+
+    #[test]
+    fn replaces_endpoints() {
+        let url =
+            "https://user:pass@my.solver.xyz:1234/solve?param1=1&param2=2#fragment=1&fragment2=2"
+                .parse()
+                .unwrap();
+        let replaced = replace_endpoint(url, "notify");
+        let expected =
+            "https://user:pass@my.solver.xyz:1234/notify?param1=1&param2=2#fragment=1&fragment2=2"
+                .parse()
+                .unwrap();
+        assert_eq!(replaced.unwrap(), expected);
+
+        let url = "https://user:pass@my.solver.xyz:1234".parse().unwrap();
+        let replaced = replace_endpoint(url, "notify");
+        assert!(replaced.is_err());
     }
 }


### PR DESCRIPTION
# Description
Currently there are some solvers which only expose a quoting endpoint on `/quote` for example.
Long term we want to be able to keep using these endpoints without jumping through any additional hoops.

# Changes
Instead of providing `base_url` and let the `driver` automatically add `/solve` and `/notify` depending on the endpoint we now provide the complete `solve` endpoint use that as is during `/solve` requests and only replace the last path segment with `/notify` during notify requests.

## How to test
Updated e2e and driver tests
added new unit test for `replace_endpoint` function