### PR TITLE
Log calldata as hex string

### DIFF
--- a/crates/shared/src/trade_finding.rs
+++ b/crates/shared/src/trade_finding.rs
@@ -10,11 +10,11 @@ use {
     crate::price_estimation::{PriceEstimationError, Query},
     anyhow::Result,
     contracts::{dummy_contract, ERC20},
+    derivative::Derivative,
     ethcontract::{contract::MethodBuilder, tokens::Tokenize, web3::Transport, Bytes, H160, U256},
     model::interaction::InteractionData,
     serde::Serialize,
     thiserror::Error,
-    derivative::Derivative,
 };
 
 /// Returns the default time limit used for quoting with external co-located

--- a/crates/shared/src/trade_finding.rs
+++ b/crates/shared/src/trade_finding.rs
@@ -14,6 +14,7 @@ use {
     model::interaction::InteractionData,
     serde::Serialize,
     thiserror::Error,
+    derivative::Derivative,
 };
 
 /// Returns the default time limit used for quoting with external co-located
@@ -89,10 +90,12 @@ impl Trade {
 }
 
 /// Data for a raw GPv2 interaction.
-#[derive(Clone, Debug, PartialEq, Eq, Hash, Default, Serialize)]
+#[derive(Clone, PartialEq, Eq, Hash, Default, Serialize, Derivative)]
+#[derivative(Debug)]
 pub struct Interaction {
     pub target: H160,
     pub value: U256,
+    #[derivative(Debug(format_with = "crate::debug_bytes"))]
     pub data: Vec<u8>,
 }
 


### PR DESCRIPTION
# Description
Currently the interactions inside the verification struct don't get logged as hex string (e.g. [here](https://production-6de61f.kb.eu-central-1.aws.cloud.es.io/app/discover#/doc/c0e240e0-d9b3-11ed-b0e6-e361adffce0b/cowlogs-prod-2024.02.29?id=TpHs9I0B0oMg6dJLZ2f5)).

# Changes
Start logging them as hex string.