### PR TITLE
Use display logging for BigRational

### DIFF
--- a/crates/shared/src/price_estimation/trade_verifier.rs
+++ b/crates/shared/src/price_estimation/trade_verifier.rs
@@ -166,8 +166,8 @@ impl TradeVerifier {
             .context("could not decode simulation output")
             .map_err(Error::SimulationFailed)?;
         tracing::debug!(
-            lost_buy_amount = ?summary.buy_tokens_diff,
-            lost_sell_amount = ?summary.sell_tokens_diff,
+            lost_buy_amount = %summary.buy_tokens_diff,
+            lost_sell_amount = %summary.sell_tokens_diff,
             gas_diff = ?trade.gas_estimate.abs_diff(summary.gas_used.as_u64()),
             time = ?start.elapsed(),
             promised_out_amount = ?trade.out_amount,


### PR DESCRIPTION
# Description
Currently we use `Debug` logging for these `BigRational` which ends up like: `Ratio { numer: 0, denom: 1 }`

# Changes
Switches over to use `Display` formatting which ends up with a regular integer.

## How to test
https://play.rust-lang.org/?version=stable&mode=debug&edition=2021&gist=b3144bb588fa03c517bfc1eeaea378a4