### PR TITLE
[Easy] Avoid GasLimitExceeded errors on Gnosis Chain

### DIFF
--- a/crates/driver/src/domain/competition/solution/settlement.rs
+++ b/crates/driver/src/domain/competition/solution/settlement.rs
@@ -388,8 +388,10 @@ impl Gas {
 
         // The block gas limit may fluctuate between blocks (validators trying to
         // upvote/downvote the limit), thus add a bit margin to not run into
-        // GasLimitExceeded errors.
-        let block_limit = eth::Gas(block_limit.0 * 90 / 100);
+        // GasLimitExceeded errors. The maximum deviation per block is 1/1024 so using
+        // 1% buffer will make that even with 10 consecutive blocks in which the gas
+        // limit decreased maximally will not exceed the limit.
+        let block_limit = eth::Gas(block_limit.0 * 99 / 100);
 
         Self {
             estimate,

--- a/crates/driver/src/infra/blockchain/mod.rs
+++ b/crates/driver/src/infra/blockchain/mod.rs
@@ -186,7 +186,7 @@ impl Ethereum {
         self.inner.gas.estimate().await
     }
 
-    pub fn gas_limit(&self) -> eth::Gas {
+    pub fn block_gas_limit(&self) -> eth::Gas {
         self.inner.current_block.borrow().gas_limit.into()
     }
 

--- a/crates/driver/src/tests/cases/settle.rs
+++ b/crates/driver/src/tests/cases/settle.rs
@@ -1,10 +1,13 @@
-use crate::{
-    domain::competition::order,
-    tests::{
-        self,
-        cases::DEFAULT_SOLVER_FEE,
-        setup::{ab_order, ab_pool, ab_solution},
+use {
+    crate::{
+        domain::competition::order,
+        tests::{
+            self,
+            cases::DEFAULT_SOLVER_FEE,
+            setup::{ab_order, ab_pool, ab_solution},
+        },
     },
+    web3::Transport,
 };
 
 /// Run a matrix of tests for all meaningful combinations of order kind and
@@ -86,6 +89,20 @@ async fn high_gas_limit() {
         .done()
         .await;
 
+    // Set to 30M for solving purposes
+    test.web3()
+        .transport()
+        .execute("evm_setBlockGasLimit", vec![serde_json::json!(30_000_000)])
+        .await
+        .unwrap();
+
     test.solve().await.ok();
+
+    // Assume validators downvoted gas limit to 29M, solution still passes
+    test.web3()
+        .transport()
+        .execute("evm_setBlockGasLimit", vec![serde_json::json!(29_000_000)])
+        .await
+        .unwrap();
     test.settle().await.ok().await;
 }

--- a/crates/driver/src/tests/cases/settle.rs
+++ b/crates/driver/src/tests/cases/settle.rs
@@ -98,10 +98,10 @@ async fn high_gas_limit() {
 
     test.solve().await.ok();
 
-    // Assume validators downvoted gas limit to 29M, solution still settles
+    // Assume validators downvoted gas limit to 29.9M, solution still settles
     test.web3()
         .transport()
-        .execute("evm_setBlockGasLimit", vec![serde_json::json!(29_000_000)])
+        .execute("evm_setBlockGasLimit", vec![serde_json::json!(29_900_000)])
         .await
         .unwrap();
     test.settle().await.ok().await;

--- a/crates/driver/src/tests/cases/settle.rs
+++ b/crates/driver/src/tests/cases/settle.rs
@@ -98,7 +98,7 @@ async fn high_gas_limit() {
 
     test.solve().await.ok();
 
-    // Assume validators downvoted gas limit to 29M, solution still passes
+    // Assume validators downvoted gas limit to 29M, solution still settles
     test.web3()
         .transport()
         .execute("evm_setBlockGasLimit", vec![serde_json::json!(29_000_000)])

--- a/crates/driver/src/tests/setup/mod.rs
+++ b/crates/driver/src/tests/setup/mod.rs
@@ -26,7 +26,7 @@ use {
         util::{self, serialize},
     },
     bigdecimal::FromPrimitive,
-    ethcontract::BlockId,
+    ethcontract::{dyns::DynTransport, BlockId},
     futures::future::join_all,
     hyper::StatusCode,
     secp256k1::SecretKey,
@@ -1004,6 +1004,10 @@ impl Test {
                 .unwrap(),
         );
         balances
+    }
+
+    pub fn web3(&self) -> &web3::Web3<DynTransport> {
+        &self.blockchain.web3
     }
 }
 


### PR DESCRIPTION
# Description
<!--- Describe your changes to provide context for reviewers, including why it is needed -->

Gnosis Chain recently [voted](https://forum.gnosis.io/t/proposal-to-mitigate-nft-spam-on-gnosis-chain-reduced-block-gas-limit/7450) the gas limit down from 30M to 17M. However, it seems as if some validators are still running with higher target gas limits, thus occasionally upvoting the gas limit again (cf. [this block](https://gnosisscan.io/block/32712562) for instance with limit 17016600).

This can lead to issues with our solution submission logic in case of very large settlements (>1/2 block gas limit). Normally we specify the limit of the settlement transaction at 2x the extimated gas amount (capped at the block gas limit). If the most recent block had 17.01M gas capacity, we chose a cap of 17.01M which may get rejected if the next block's validator has their node configured with a 17M gas limit.

Cf. [these logs](https://production-6de61f.kb.eu-central-1.aws.cloud.es.io/app/r/s/wltG7) for an example.

# Changes
<!-- List of detailed changes (how the change is accomplished) -->

- [x] Add 1% buffer when limiting the maximum gas amount (should be enough for 10 consecutive downvoted blocks)
- [x] Minor naming changes to make it more explicit what gas_limit we are returning

## How to test
Adjusted existing test (doesn't pass on main)