### PR TITLE
Settlement merge flag

### DIFF
--- a/crates/driver/example.toml
+++ b/crates/driver/example.toml
@@ -1,9 +1,11 @@
 [[solver]]
-name = "mysolver" # Arbitrary name given to this solver, must be unique
-endpoint = "http://0.0.0.0:7872"
+name = "mysolver1" # Arbitrary name given to this solver, must be unique
+endpoint = "https://sepolia.infura.io/v3/9d410fb4c1864d22afa37cf8797aa417"
 absolute-slippage = "40000000000000000" # Denominated in wei, optional
 relative-slippage = "0.1" # Percentage in the [0, 1] range
 account = "0x0000000000000000000000000000000000000000000000000000000000000001" # The private key of the solver
+#TODO:
+merge = true # Whether to merge solutions or not when solver returns multiple solutions
 
 # [[solver]] # And so on, specify as many solvers as needed
 # name = "othersolver"
@@ -20,7 +22,7 @@ revert-protection = true
 
 [[submission.mempool]]
 mempool = "mev-blocker"
-url = "https://your.custom.rpc.endpoint"
+url = "https://sepolia.infura.io/v3/9d410fb4c1864d22afa37cf8797aa417"
 max-additional-tip = "5000000000"
 additional-tip-percentage = 0.05
 use-soft-cancellations = true

--- a/crates/driver/example.toml
+++ b/crates/driver/example.toml
@@ -5,7 +5,7 @@ absolute-slippage = "40000000000000000" # Denominated in wei, optional
 relative-slippage = "0.1" # Percentage in the [0, 1] range
 account = "0x0000000000000000000000000000000000000000000000000000000000000001" # The private key of the solver
 #TODO:
-merge = true # Whether to merge solutions or not when solver returns multiple solutions
+skip-merge = true # Whether to merge solutions or not when solver returns multiple solutions
 
 # [[solver]] # And so on, specify as many solvers as needed
 # name = "othersolver"

--- a/crates/driver/example.toml
+++ b/crates/driver/example.toml
@@ -1,6 +1,6 @@
 [[solver]]
 name = "mysolver1" # Arbitrary name given to this solver, must be unique
-endpoint = "https://sepolia.infura.io/v3/9d410fb4c1864d22afa37cf8797aa417"
+endpoint = "http://0.0.0.0:7872"
 absolute-slippage = "40000000000000000" # Denominated in wei, optional
 relative-slippage = "0.1" # Percentage in the [0, 1] range
 account = "0x0000000000000000000000000000000000000000000000000000000000000001" # The private key of the solver
@@ -22,7 +22,7 @@ revert-protection = true
 
 [[submission.mempool]]
 mempool = "mev-blocker"
-url = "https://sepolia.infura.io/v3/9d410fb4c1864d22afa37cf8797aa417"
+url = "https://your.custom.rpc.endpoint"
 max-additional-tip = "5000000000"
 additional-tip-percentage = 0.05
 use-soft-cancellations = true

--- a/crates/driver/src/infra/config/file/load.rs
+++ b/crates/driver/src/infra/config/file/load.rs
@@ -77,6 +77,11 @@ pub async fn load(chain: eth::ChainId, path: &Path) -> infra::Config {
                     solver::Liquidity::Fetch
                 },
                 account,
+                merging: if config.skip_merge {
+                    solver::Merging::Skip
+                } else {
+                    solver::Merging::Fetch
+                },
                 timeouts: solver::Timeouts {
                     http_delay: chrono::Duration::from_std(config.timeouts.http_time_buffer)
                         .unwrap(),

--- a/crates/driver/src/infra/config/file/mod.rs
+++ b/crates/driver/src/infra/config/file/mod.rs
@@ -152,6 +152,10 @@ fn default_soft_cancellations_flag() -> bool {
     false
 }
 
+fn default_skip_merge_flag() -> bool {
+    false
+}
+
 pub fn default_http_time_buffer() -> Duration {
     Duration::from_millis(500)
 }
@@ -189,10 +193,6 @@ struct SolverConfig {
     /// Timeout configuration for the solver.
     #[serde(default, flatten)]
     timeouts: Timeouts,
-}
-
-fn default_skip_merge_flag() -> bool {
-    false
 }
 
 #[serde_as]

--- a/crates/driver/src/infra/config/file/mod.rs
+++ b/crates/driver/src/infra/config/file/mod.rs
@@ -182,10 +182,19 @@ struct SolverConfig {
     /// The account which should be used to sign settlements for this solver.
     account: Account,
 
+    /// Wheter or not to skip merging the solutions from this solver.
+    #[serde(default = "default_skip_merge_flag")]
+    skip_merge: bool, 
+
     /// Timeout configuration for the solver.
     #[serde(default, flatten)]
     timeouts: Timeouts,
 }
+
+fn default_skip_merge_flag() -> bool {
+    false
+}
+
 
 #[serde_as]
 #[derive(Debug, Deserialize)]

--- a/crates/driver/src/infra/config/file/mod.rs
+++ b/crates/driver/src/infra/config/file/mod.rs
@@ -184,7 +184,7 @@ struct SolverConfig {
 
     /// Wheter or not to skip merging the solutions from this solver.
     #[serde(default = "default_skip_merge_flag")]
-    skip_merge: bool, 
+    skip_merge: bool,
 
     /// Timeout configuration for the solver.
     #[serde(default, flatten)]
@@ -194,7 +194,6 @@ struct SolverConfig {
 fn default_skip_merge_flag() -> bool {
     false
 }
-
 
 #[serde_as]
 #[derive(Debug, Deserialize)]

--- a/crates/driver/src/infra/solver/mod.rs
+++ b/crates/driver/src/infra/solver/mod.rs
@@ -6,8 +6,7 @@ use {
                 auction::{self, Auction},
                 solution::{self, Solution},
             },
-            eth,
-            liquidity,
+            eth, liquidity,
             time::Remaining,
         },
         infra::blockchain::Ethereum,
@@ -141,6 +140,11 @@ impl Solver {
     /// The liquidity configuration of this solver
     pub fn liquidity(&self) -> Liquidity {
         self.config.liquidity
+    }
+
+    /// The merging configuration of this solver
+    pub fn merging(&self) -> Merging {
+        self.config.merging
     }
 
     /// The blockchain address of this solver.

--- a/crates/driver/src/infra/solver/mod.rs
+++ b/crates/driver/src/infra/solver/mod.rs
@@ -65,6 +65,15 @@ pub enum Liquidity {
 }
 
 #[derive(Clone, Copy, Debug)]
+pub enum Merging {
+    /// Merged solutions from this solver should be fetched  
+    Fetch,
+    /// The solver already solves for merged settlements, so merging multiple
+    /// solutions from this solver can be skipped.
+    Skip,
+}
+
+#[derive(Clone, Copy, Debug)]
 pub struct Timeouts {
     /// Maximum time allocated for http request/reponse to propagate through
     /// network.
@@ -93,6 +102,8 @@ pub struct Config {
     pub slippage: Slippage,
     /// Whether or not liquidity is used by this solver.
     pub liquidity: Liquidity,
+    /// Whether or not to skip merging for this solver.
+    pub merging: Merging,
     /// The private key of this solver, used for settlement submission.
     pub account: ethcontract::Account,
     /// How much time to spend for each step of the solving and competition.

--- a/crates/driver/src/tests/cases/example_config.rs
+++ b/crates/driver/src/tests/cases/example_config.rs
@@ -3,7 +3,6 @@ use crate::tests;
 /// Test that the example configuration file is valid by checking that the
 /// driver does not crash when started with this file.
 #[tokio::test]
-#[ignore]
 async fn test() {
     let example_config_file = std::env::current_dir().unwrap().join("example.toml");
     tests::setup()

--- a/crates/driver/src/tests/cases/merge_flag.rs
+++ b/crates/driver/src/tests/cases/merge_flag.rs
@@ -10,7 +10,8 @@ async fn possible() {
         let ab_order = ab_order();
         let cd_order = cd_order();
         let test = setup()
-        .config_file(example_config_file)
+        .config(skipping_config_file)
+        .settlement_address("0x9008D19f58AAbD9eD0D60971565AA8510560ab41")
         .pool(cd_pool())
         .pool(ab_pool())
         .order(ab_order.clone())

--- a/crates/driver/src/tests/cases/merge_flag.rs
+++ b/crates/driver/src/tests/cases/merge_flag.rs
@@ -6,12 +6,27 @@ use crate::tests::{
 // tests that flagging for settlement merge is possible
 #[tokio::test]
 async fn possible() {
-    todo!()
+        let ab_order = ab_order();
+        let cd_order = cd_order();
+        let test = setup()
+        .pool(cd_pool())
+        .pool(ab_pool())
+        .order(ab_order.clone())
+        .order(cd_order.clone())
+        .solution(cd_solution())
+        .solution(ab_solution())
+        .done()
+        .await;
+    test.solve().await.ok().orders(&[ab_order, cd_order]);
+    test.reveal().await.ok().calldata();
+
+
+
 }
 
 
-// tests that flagging is not valid when solution is only one order
-#[tokio::test]
+// tests that flag is not valid when solver already solved for multiple settlements
+// [tokio::test]
 async fn impossible() {
     todo!()
 }

--- a/crates/driver/src/tests/cases/merge_flag.rs
+++ b/crates/driver/src/tests/cases/merge_flag.rs
@@ -6,9 +6,11 @@ use crate::tests::{
 // tests that flagging for settlement merge is possible
 #[tokio::test]
 async fn possible() {
+        let skipping_config_file = std::env::current_dir().unwrap().join("example.toml");
         let ab_order = ab_order();
         let cd_order = cd_order();
         let test = setup()
+        .config_file(example_config_file)
         .pool(cd_pool())
         .pool(ab_pool())
         .order(ab_order.clone())
@@ -36,6 +38,7 @@ async fn possible() {
 // TODO: config has to be changed to fetch to pass
 #[tokio::test]
 async fn impossible() {
+    let fetching_config_file = std::env::current_dir().unwrap().join("example.toml");
     let order = ab_order();
     let test = setup()
         .pool(ab_pool())

--- a/crates/driver/src/tests/cases/merge_flag.rs
+++ b/crates/driver/src/tests/cases/merge_flag.rs
@@ -1,0 +1,17 @@
+use crate::tests::{
+    setup,
+    setup::{ab_order, ab_pool, ab_solution, cd_order, cd_pool, cd_solution, Solution},
+};
+
+// tests that flagging for settlement merge is possible
+#[tokio::test]
+async fn possible() {
+    todo!()
+}
+
+
+// tests that flagging is not valid when solution is only one order
+#[tokio::test]
+async fn impossible() {
+    todo!()
+}

--- a/crates/driver/src/tests/cases/merge_settlements.rs
+++ b/crates/driver/src/tests/cases/merge_settlements.rs
@@ -5,7 +5,6 @@ use crate::tests::{
 
 /// Test that settlements can be merged.
 #[tokio::test]
-#[ignore]
 async fn possible() {
     let ab_order = ab_order();
     let cd_order = cd_order();
@@ -35,7 +34,6 @@ async fn possible() {
 
 /// Test that settlements are not merged if the clearing prices don't permit it.
 #[tokio::test]
-#[ignore]
 async fn impossible() {
     let order = ab_order();
     let test = setup()

--- a/crates/driver/src/tests/cases/mod.rs
+++ b/crates/driver/src/tests/cases/mod.rs
@@ -4,6 +4,7 @@ pub mod buy_eth;
 pub mod example_config;
 pub mod fees;
 pub mod internalization;
+pub mod merge_flag;
 pub mod merge_settlements;
 pub mod multiple_drivers;
 pub mod multiple_solutions;

--- a/crates/driver/src/tests/cases/multiple_solutions.rs
+++ b/crates/driver/src/tests/cases/multiple_solutions.rs
@@ -6,7 +6,6 @@ use crate::tests::{
 /// Test that the best-scoring solution is picked when the /solve endpoint
 /// returns multiple valid solutions.
 #[tokio::test]
-#[ignore]
 async fn valid() {
     let order = ab_order();
     let test = setup()
@@ -24,7 +23,6 @@ async fn valid() {
 /// Test that the invalid solution is discarded when the /solve endpoint
 /// returns multiple solutions.
 #[tokio::test]
-#[ignore]
 async fn invalid() {
     let order = ab_order();
     let test = setup()

--- a/crates/driver/src/tests/setup/driver.rs
+++ b/crates/driver/src/tests/setup/driver.rs
@@ -213,7 +213,7 @@ async fn create_config_file(
             }
         }
     }
-
+//TODO: skip-merge value
     for (solver, addr) in solvers {
         write!(
             file,

--- a/crates/solver/src/settlement.rs
+++ b/crates/solver/src/settlement.rs
@@ -222,6 +222,12 @@ pub struct Settlement {
 }
 
 #[derive(Debug, Eq, PartialEq)]
+pub enum MergeSkippable {
+    Skippable,
+    NotSkippable,
+}
+
+#[derive(Debug, Eq, PartialEq)]
 pub enum Revertable {
     NoRisk,
     HighRisk,
@@ -461,6 +467,15 @@ impl Settlement {
             Revertable::HighRisk
         } else {
             Revertable::NoRisk
+        }
+    }
+
+    // Calculates if settlement should merge multiple solutions  
+    pub fn merge_skippable(&self) -> MergeSkippable {
+        if self.encoder.has_interactions() {
+            MergeSkippable::NotSkippable
+        } else {
+            MergeSkippable::Skippable
         }
     }
 

--- a/crates/solver/src/settlement/settlement_encoder.rs
+++ b/crates/solver/src/settlement/settlement_encoder.rs
@@ -49,6 +49,7 @@ pub struct SettlementEncoder {
     execution_plan: Vec<MaybeInternalizableInteraction>,
     pre_interactions: Vec<InteractionData>,
     post_interactions: Vec<InteractionData>,
+    merges: Vec<InteractionData>,
     unwraps: Vec<UnwrapWethInteraction>,
 }
 
@@ -121,6 +122,7 @@ impl SettlementEncoder {
             execution_plan: Vec::new(),
             pre_interactions: Vec::new(),
             post_interactions: Vec::new(),
+            merges: Vec::new(),
             unwraps: Vec::new(),
         }
     }
@@ -151,6 +153,7 @@ impl SettlementEncoder {
                 .collect(),
             pre_interactions: self.pre_interactions.clone(),
             post_interactions: self.post_interactions.clone(),
+            merges: self.merges.clone(),
             unwraps: self.unwraps.clone(),
         }
     }
@@ -198,6 +201,13 @@ impl SettlementEncoder {
         self.execution_plan
             .iter()
             .any(|(_, internalizable)| !internalizable)
+    }
+    // or has_merges??
+    pub fn is_merged(&self) -> bool {
+        self.execution_plan
+            .iter()
+            .any(|(_, mergable)| !mergable)
+
     }
 
     /// Adds an order trade using the uniform clearing prices for sell and buy


### PR DESCRIPTION
# Description
Addresses #2418 by a flag in `driver` config file as well as checks for settlement merge from `solver`

<!-- List of detailed changes (how the change is accomplished) -->
- `skip-merge` value  in config file
- member functions for checking config value 
- checks if should merge solutions or skip merge using `Fetch`  or  `Skip`
- flags if solution is `MergeSkippable` or not

## How to test
1. Should be possible to skip merging solution when driver is flagged to Skip
2. Should be impossible to skip merging solution when driver is flagged to Fetch

