### PR TITLE
Ceil buy amount computation in settlement encoder

### DIFF
--- a/crates/solver/src/settlement/settlement_encoder.rs
+++ b/crates/solver/src/settlement/settlement_encoder.rs
@@ -353,7 +353,7 @@ impl SettlementEncoder {
                 let buy_amount = sell_amount
                     .checked_mul(uniform_sell_price)
                     .context("buy_amount computation failed")?
-                    .checked_div(uniform_buy_price)
+                    .checked_ceil_div(&uniform_buy_price)
                     .context("buy_amount computation failed")?;
                 (executed_amount, buy_amount)
             }


### PR DESCRIPTION
# Description

See #2457 for the discussion.

The settlement contract computes the buy amount for sell orders by rounding up the division of the uniform buy price (cf. https://github.com/cowprotocol/contracts/blob/main/src/contracts/GPv2Settlement.sol#L389-L391).

The fact that the settlement encoder doesn't do this can lead to solutions getting rejected by the driver, which would be perfectly fine from the settlement contract's point of view.

# Changes

- [x] use `checked_ceil_div` instead of `checked div`

## How to test
Existing unit tests (may need some updates, waiting for CI to tell me)

## Related Issues

Fixes #2457