### PR TITLE
[EASY] Rename auction id

### DIFF
--- a/crates/autopilot/src/boundary/order.rs
+++ b/crates/autopilot/src/boundary/order.rs
@@ -16,7 +16,7 @@ pub fn to_domain(
         user_fee: order.data.fee_amount,
         protocol_fees,
         valid_to: order.data.valid_to,
-        kind: order.data.kind.into(),
+        side: order.data.kind.into(),
         receiver: order.data.receiver,
         owner: order.metadata.owner,
         partially_fillable: order.data.partially_fillable,

--- a/crates/autopilot/src/domain/auction/mod.rs
+++ b/crates/autopilot/src/domain/auction/mod.rs
@@ -15,10 +15,10 @@ pub struct Auction {
     pub prices: BTreeMap<H160, U256>,
 }
 
-pub type AuctionId = i64;
+pub type Id = i64;
 
 #[derive(Clone, Debug)]
 pub struct AuctionWithId {
-    pub id: AuctionId,
+    pub id: Id,
     pub auction: Auction,
 }

--- a/crates/autopilot/src/domain/auction/order.rs
+++ b/crates/autopilot/src/domain/auction/order.rs
@@ -13,7 +13,7 @@ pub struct Order {
     pub buy_amount: U256,
     pub user_fee: U256,
     pub protocol_fees: Vec<fee::Policy>,
-    pub kind: Kind,
+    pub side: Side,
     pub class: Class,
     pub valid_to: u32,
     pub receiver: Option<H160>,
@@ -65,7 +65,7 @@ impl fmt::Debug for OrderUid {
 }
 
 #[derive(Clone, Debug, PartialEq)]
-pub enum Kind {
+pub enum Side {
     Buy,
     Sell,
 }

--- a/crates/autopilot/src/domain/mod.rs
+++ b/crates/autopilot/src/domain/mod.rs
@@ -6,7 +6,6 @@ pub use {
     auction::{
         order::{Order, OrderUid},
         Auction,
-        AuctionId,
         AuctionWithId,
     },
     fee::ProtocolFee,

--- a/crates/autopilot/src/infra/persistence/dto/fee_policy.rs
+++ b/crates/autopilot/src/infra/persistence/dto/fee_policy.rs
@@ -2,7 +2,7 @@ use crate::{boundary, domain};
 
 #[derive(Debug, Clone, PartialEq, sqlx::FromRow)]
 pub struct FeePolicy {
-    pub auction_id: domain::AuctionId,
+    pub auction_id: domain::auction::Id,
     pub order_uid: boundary::database::OrderUid,
     pub kind: FeePolicyKind,
     pub surplus_factor: Option<f64>,
@@ -12,7 +12,7 @@ pub struct FeePolicy {
 
 impl FeePolicy {
     pub fn from_domain(
-        auction_id: domain::AuctionId,
+        auction_id: domain::auction::Id,
         order_uid: domain::OrderUid,
         policy: domain::fee::Policy,
     ) -> Self {

--- a/crates/autopilot/src/infra/persistence/dto/fee_policy.rs
+++ b/crates/autopilot/src/infra/persistence/dto/fee_policy.rs
@@ -2,7 +2,7 @@ use crate::{boundary, domain};
 
 #[derive(Debug, Clone, PartialEq, sqlx::FromRow)]
 pub struct FeePolicy {
-    pub auction_id: domain::auction::Id,
+    pub auction_id: database::auction::AuctionId,
     pub order_uid: boundary::database::OrderUid,
     pub kind: FeePolicyKind,
     pub surplus_factor: Option<f64>,

--- a/crates/autopilot/src/infra/persistence/dto/order.rs
+++ b/crates/autopilot/src/infra/persistence/dto/order.rs
@@ -51,7 +51,7 @@ pub fn from_domain(order: domain::Order) -> Order {
         user_fee: order.user_fee,
         protocol_fees: order.protocol_fees.into_iter().map(Into::into).collect(),
         valid_to: order.valid_to,
-        kind: order.kind.into(),
+        kind: order.side.into(),
         receiver: order.receiver,
         owner: order.owner,
         partially_fillable: order.partially_fillable,
@@ -80,7 +80,7 @@ pub fn to_domain(order: Order) -> domain::Order {
         user_fee: order.user_fee,
         protocol_fees: order.protocol_fees.into_iter().map(Into::into).collect(),
         valid_to: order.valid_to,
-        kind: order.kind.into(),
+        side: order.kind.into(),
         receiver: order.receiver,
         owner: order.owner,
         partially_fillable: order.partially_fillable,
@@ -111,16 +111,16 @@ impl From<domain::OrderUid> for boundary::OrderUid {
     }
 }
 
-impl From<domain::auction::order::Kind> for boundary::OrderKind {
-    fn from(kind: domain::auction::order::Kind) -> Self {
+impl From<domain::auction::order::Side> for boundary::OrderKind {
+    fn from(kind: domain::auction::order::Side) -> Self {
         match kind {
-            domain::auction::order::Kind::Buy => Self::Buy,
-            domain::auction::order::Kind::Sell => Self::Sell,
+            domain::auction::order::Side::Buy => Self::Buy,
+            domain::auction::order::Side::Sell => Self::Sell,
         }
     }
 }
 
-impl From<boundary::OrderKind> for domain::auction::order::Kind {
+impl From<boundary::OrderKind> for domain::auction::order::Side {
     fn from(kind: boundary::OrderKind) -> Self {
         match kind {
             boundary::OrderKind::Buy => Self::Buy,

--- a/crates/autopilot/src/infra/persistence/mod.rs
+++ b/crates/autopilot/src/infra/persistence/mod.rs
@@ -36,7 +36,7 @@ impl Persistence {
     pub async fn replace_current_auction(
         &self,
         auction: domain::Auction,
-    ) -> Result<domain::AuctionId, Error> {
+    ) -> Result<domain::auction::Id, Error> {
         let auction = dto::auction::from_domain(auction.clone());
         self.postgres
             .replace_current_auction(&auction)
@@ -61,7 +61,7 @@ impl Persistence {
     /// Saves the given auction to storage for debugging purposes.
     ///
     /// There is no intention to retrieve this data programmatically.
-    fn archive_auction(&self, id: domain::AuctionId, instance: dto::auction::Auction) {
+    fn archive_auction(&self, id: domain::auction::Id, instance: dto::auction::Auction) {
         let Some(uploader) = self.s3.clone() else {
             return;
         };
@@ -119,7 +119,7 @@ impl Persistence {
     /// Saves the given fee policies to the DB as a single batch.
     pub async fn store_fee_policies(
         &self,
-        auction_id: domain::AuctionId,
+        auction_id: domain::auction::Id,
         fee_policies: Vec<(domain::OrderUid, Vec<domain::fee::Policy>)>,
     ) -> anyhow::Result<()> {
         let fee_policies = fee_policies

--- a/crates/autopilot/src/infra/solvers/dto/solve.rs
+++ b/crates/autopilot/src/infra/solvers/dto/solve.rs
@@ -18,7 +18,7 @@ use {
 
 impl Request {
     pub fn new(
-        id: domain::AuctionId,
+        id: domain::auction::Id,
         auction: &domain::Auction,
         trusted_tokens: &HashSet<H160>,
         score_cap: U256,

--- a/crates/autopilot/src/run_loop.rs
+++ b/crates/autopilot/src/run_loop.rs
@@ -111,7 +111,7 @@ impl RunLoop {
         Some(domain::AuctionWithId { id, auction })
     }
 
-    async fn single_run(&self, auction_id: domain::AuctionId, auction: domain::Auction) {
+    async fn single_run(&self, auction_id: domain::auction::Id, auction: domain::Auction) {
         tracing::info!(?auction_id, "solving");
 
         let auction = self.remove_in_flight_orders(auction).await;
@@ -301,7 +301,7 @@ impl RunLoop {
     /// Runs the solver competition, making all configured drivers participate.
     async fn competition(
         &self,
-        id: domain::AuctionId,
+        id: domain::auction::Id,
         auction: &domain::Auction,
     ) -> Vec<Participant<'_>> {
         let request = solve::Request::new(
@@ -391,7 +391,7 @@ impl RunLoop {
     async fn reveal(
         &self,
         driver: &infra::Driver,
-        auction: domain::AuctionId,
+        auction: domain::auction::Id,
         solution_id: u64,
     ) -> Result<reveal::Response, RevealError> {
         let response = driver
@@ -571,7 +571,7 @@ impl Metrics {
         Metrics::instance(metrics::get_storage_registry()).unwrap()
     }
 
-    fn auction(auction_id: domain::AuctionId) {
+    fn auction(auction_id: domain::auction::Id) {
         Self::get().auction.set(auction_id)
     }
 

--- a/crates/autopilot/src/shadow.rs
+++ b/crates/autopilot/src/shadow.rs
@@ -30,7 +30,7 @@ pub struct RunLoop {
     orderbook: infra::shadow::Orderbook,
     drivers: Vec<infra::Driver>,
     trusted_tokens: AutoUpdatingTokenList,
-    auction: domain::AuctionId,
+    auction: domain::auction::Id,
     block: u64,
     score_cap: U256,
     solve_deadline: Duration,
@@ -112,7 +112,7 @@ impl RunLoop {
         Some(auction)
     }
 
-    async fn single_run(&self, id: domain::AuctionId, auction: domain::Auction) {
+    async fn single_run(&self, id: domain::auction::Id, auction: domain::Auction) {
         tracing::info!("solving");
         Metrics::get().auction.set(id);
         Metrics::get().orders.set(auction.orders.len() as _);
@@ -186,7 +186,7 @@ impl RunLoop {
     /// Runs the solver competition, making all configured drivers participate.
     async fn competition(
         &self,
-        id: domain::AuctionId,
+        id: domain::auction::Id,
         auction: &domain::Auction,
     ) -> Vec<Participant<'_>> {
         let request = solve::Request::new(


### PR DESCRIPTION
# Description
Part 1 of https://github.com/cowprotocol/services/pull/2436

# Changes
<!-- List of detailed changes (how the change is accomplished) -->

- [ ] Rename order kind to side to align with the driver calls it.
- [ ] Use `auction::Id` instead of `AuctionId`