### PR TITLE
[trivial] Fix quote verification when receiver is 0 address

### DIFF
--- a/crates/shared/src/price_estimation/trade_verifier.rs
+++ b/crates/shared/src/price_estimation/trade_verifier.rs
@@ -308,7 +308,15 @@ fn add_balance_queries(
 ) -> EncodedSettlement {
     let (token, owner) = match query.kind {
         // track how much `buy_token` the `receiver` actually got
-        OrderKind::Sell => (query.buy_token, verification.receiver),
+        OrderKind::Sell => {
+            let receiver = match verification.receiver == H160::zero() {
+                // Settlement contract sends fund to owner if receiver is the 0 address.
+                true => verification.from,
+                false => verification.receiver,
+            };
+
+            (query.buy_token, receiver)
+        }
         // track how much `sell_token` the settlement contract actually spent
         OrderKind::Buy => (query.sell_token, settlement_contract),
     };


### PR DESCRIPTION
# Description
When the an order has `receiver: 0x000..000` the smart contract will send the proceeds to the owner of the order (see [here](https://github.com/cowprotocol/contracts/blob/main/src/contracts/libraries/GPv2Order.sol#L102-L107)).
This was currently not respected in the simulation logic when tracking the funds of the `receiver`.

# Changes
Track balances of `owner` when `receiver == 0x0000`.
I specifically did not want to overwrite the owner in the `Verification` struct because that would diverge the execution of the simulation from what would actually happen more.

Example simulation from xdai: https://dashboard.tenderly.co/gp-v2/production/simulator/fe44ac0d-21a6-46ba-b0a8-b7edebe059ad
Noticed via alert: https://cowservices.slack.com/archives/C0371SB243E/p1709656851339479