### PR TITLE
Hotfix: Make OrderWithQuote as inner join in order not to get nullable quotes

### DIFF
--- a/crates/database/src/orders.rs
+++ b/crates/database/src/orders.rs
@@ -739,14 +739,14 @@ pub async fn user_orders_with_quote(
         " o_quotes.buy_amount as quote_buy_amount, o.buy_amount as order_buy_amount,",
         " o.fee_amount as order_fee_amount, o_quotes.gas_amount as quote_gas_amount,",
         " o_quotes.gas_price as quote_gas_price, o_quotes.sell_token_price as quote_sell_token_price",
-        " FROM order_quotes o_quotes",
-        " LEFT JOIN (",
+        " FROM (",
             " SELECT *",
             " FROM (", OPEN_ORDERS,
             " AND owner = $2",
             " AND class = 'limit'",
             " ) AS subquery",
-        " ) AS o ON o_quotes.order_uid = o.uid"
+        " ) AS o",
+        " INNER JOIN order_quotes o_quotes ON o.uid = o_quotes.order_uid"
     );
     sqlx::query_as::<_, OrderWithQuote>(QUERY)
         .bind(min_valid_to)


### PR DESCRIPTION
# Description
Do an `inner join` instead of `left join` in order not to have nullable quotes in case they do not exist.

This query will be removed with https://github.com/cowprotocol/services/issues/2469 

# Changes
Do an `inner join` instead of `left join` in order not to have nullable quotes in case they do not exist. This way it does not error in case of missing quote (it won't be counted, as it is a liquidity order anyway).

## How to test
1. CI
2. e2e

