### PR TITLE
Rank by surplus activation date

### DIFF
--- a/crates/driver/src/infra/config/file/load.rs
+++ b/crates/driver/src/infra/config/file/load.rs
@@ -87,6 +87,7 @@ pub async fn load(chain: eth::ChainId, path: &Path) -> infra::Config {
                         .unwrap(),
                 },
                 request_headers: config.request_headers,
+                rank_by_surplus_date: config.rank_by_surplus_date,
             }
         }))
         .await,

--- a/crates/driver/src/infra/config/file/mod.rs
+++ b/crates/driver/src/infra/config/file/mod.rs
@@ -188,6 +188,9 @@ struct SolverConfig {
 
     #[serde(default)]
     request_headers: HashMap<String, String>,
+
+    /// Datetime when the CIP38 rank by surplus rules should be activated.
+    rank_by_surplus_date: Option<chrono::DateTime<chrono::Utc>>,
 }
 
 #[serde_as]

--- a/crates/driver/src/infra/solver/mod.rs
+++ b/crates/driver/src/infra/solver/mod.rs
@@ -102,6 +102,8 @@ pub struct Config {
     pub timeouts: Timeouts,
     /// HTTP headers that should be added to every request.
     pub request_headers: HashMap<String, String>,
+    /// Datetime when the CIP38 rank by surplus rules should be activated.
+    pub rank_by_surplus_date: Option<chrono::DateTime<chrono::Utc>>,
 }
 
 impl Solver {
@@ -181,7 +183,13 @@ impl Solver {
         let res = res?;
         let res: dto::Solutions = serde_json::from_str(&res)
             .tap_err(|err| tracing::warn!(res, ?err, "failed to parse solver response"))?;
-        let solutions = res.into_domain(auction, liquidity, weth, self.clone())?;
+        let solutions = res.into_domain(
+            auction,
+            liquidity,
+            weth,
+            self.clone(),
+            self.config.rank_by_surplus_date,
+        )?;
 
         super::observe::solutions(&solutions);
         Ok(solutions)


### PR DESCRIPTION
# Description
Adds config parameter `rank_by_surplus_date` to be able to activate/deactivate the CIP38 ranking via configuration.