### PR TITLE
Improve native price fetch order

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -29,14 +29,15 @@ checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "ahash"
-version = "0.8.3"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c99f64d1e06488f620f932677e24bc6e2897582980441ae90a671415bd7ec2f"
+checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
 dependencies = [
  "cfg-if",
  "getrandom",
  "once_cell",
  "version_check",
+ "zerocopy",
 ]
 
 [[package]]
@@ -194,7 +195,7 @@ checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.28",
+ "syn 2.0.32",
 ]
 
 [[package]]
@@ -205,7 +206,7 @@ checksum = "bc00ceb34980c03614e35a3a4e218276a0a824e911d07651cd0d858a51e8c0f0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.28",
+ "syn 2.0.32",
 ]
 
 [[package]]
@@ -253,6 +254,7 @@ dependencies = [
  "hex",
  "hex-literal",
  "humantime",
+ "indexmap 2.2.5",
  "itertools 0.11.0",
  "maplit",
  "mockall",
@@ -1247,7 +1249,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.28",
+ "syn 2.0.32",
 ]
 
 [[package]]
@@ -1479,7 +1481,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.28",
+ "syn 2.0.32",
 ]
 
 [[package]]
@@ -1490,7 +1492,7 @@ checksum = "836a9bbc7ad63342d6d6e7b815ccab164bc77a2d95d84bc3117a8c0d5c98e2d5"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.28",
+ "syn 2.0.32",
 ]
 
 [[package]]
@@ -1649,7 +1651,7 @@ dependencies = [
  "humantime",
  "humantime-serde",
  "hyper",
- "indexmap 2.0.0",
+ "indexmap 2.2.5",
  "itertools 0.11.0",
  "lazy_static",
  "maplit",
@@ -1859,7 +1861,7 @@ dependencies = [
  "ethcontract-generate",
  "proc-macro2",
  "quote",
- "syn 2.0.28",
+ "syn 2.0.32",
 ]
 
 [[package]]
@@ -1874,7 +1876,7 @@ dependencies = [
  "ethcontract-common",
  "proc-macro2",
  "quote",
- "syn 2.0.28",
+ "syn 2.0.32",
  "url",
 ]
 
@@ -2108,7 +2110,7 @@ checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.28",
+ "syn 2.0.32",
 ]
 
 [[package]]
@@ -2232,9 +2234,9 @@ checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
 
 [[package]]
 name = "hashbrown"
-version = "0.14.0"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c6201b9ff9fd90a5a3bac2e56a830d0caa509576f0e503818ee82c181b3437a"
+checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
 dependencies = [
  "ahash",
  "allocator-api2",
@@ -2246,7 +2248,7 @@ version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "312f66718a2d7789ffef4f4b7b213138ed9f1eb3aa1d0d82fc99f88fb3ffd26f"
 dependencies = [
- "hashbrown 0.14.0",
+ "hashbrown 0.14.3",
 ]
 
 [[package]]
@@ -2572,12 +2574,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.0.0"
+version = "2.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5477fe2230a79769d8dc68e0eabf5437907c0457a5614a9e8dddb67f65eb65d"
+checksum = "7b0b929d511467233429c45a44ac1dcaa21ba0f5ba11e4879e6ed28ddb4f9df4"
 dependencies = [
  "equivalent",
- "hashbrown 0.14.0",
+ "hashbrown 0.14.3",
  "serde",
 ]
 
@@ -3105,7 +3107,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.28",
+ "syn 2.0.32",
 ]
 
 [[package]]
@@ -3284,7 +3286,7 @@ checksum = "4359fd9c9171ec6e8c62926d6faaf553a8dc3f64e1507e76da7911b4f6a04405"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.28",
+ "syn 2.0.32",
 ]
 
 [[package]]
@@ -3910,7 +3912,7 @@ checksum = "4eca7ac642d82aa35b60049a6eccb4be6be75e599bd2e9adb5f875a737654af2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.28",
+ "syn 2.0.32",
 ]
 
 [[package]]
@@ -3965,7 +3967,7 @@ dependencies = [
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.0.0",
+ "indexmap 2.2.5",
  "serde",
  "serde_json",
  "serde_with_macros",
@@ -3981,7 +3983,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.28",
+ "syn 2.0.32",
 ]
 
 [[package]]
@@ -4063,6 +4065,7 @@ dependencies = [
  "hex",
  "hex-literal",
  "humantime",
+ "indexmap 2.2.5",
  "itertools 0.11.0",
  "lazy_static",
  "maplit",
@@ -4329,7 +4332,7 @@ dependencies = [
  "futures-util",
  "hashlink",
  "hex",
- "indexmap 2.0.0",
+ "indexmap 2.2.5",
  "log",
  "memchr",
  "native-tls",
@@ -4537,7 +4540,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.28",
+ "syn 2.0.32",
 ]
 
 [[package]]
@@ -4559,9 +4562,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.28"
+version = "2.0.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04361975b3f5e348b2189d8dc55bc942f278b2d482a6a0365de5bdd62d351567"
+checksum = "239814284fd6f1a4ffe4ca893952cdd93c224b6a1571c9a9eadd670295c0c9e2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4625,7 +4628,7 @@ checksum = "090198534930841fab3a5d1bb637cde49e339654e606195f8d9c76eeb081dc96"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.28",
+ "syn 2.0.32",
 ]
 
 [[package]]
@@ -4719,7 +4722,7 @@ checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.28",
+ "syn 2.0.32",
 ]
 
 [[package]]
@@ -4822,7 +4825,7 @@ version = "0.19.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8123f27e969974a3dfba720fdb560be359f57b44302d280ba72e76a74480e8a"
 dependencies = [
- "indexmap 2.0.0",
+ "indexmap 2.2.5",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -4897,7 +4900,7 @@ checksum = "5f4f31f56159e98206da9efd823404b79b6ef3143b4a7ab76e67b1751b25a4ab"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.28",
+ "syn 2.0.32",
 ]
 
 [[package]]
@@ -5145,7 +5148,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.28",
+ "syn 2.0.32",
  "wasm-bindgen-shared",
 ]
 
@@ -5179,7 +5182,7 @@ checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.28",
+ "syn 2.0.32",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -5394,6 +5397,26 @@ name = "xmlparser"
 version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d25c75bf9ea12c4040a97f829154768bbbce366287e2dc044af160cd79a13fd"
+
+[[package]]
+name = "zerocopy"
+version = "0.7.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74d4d3961e53fa4c9a25a8637fc2bfaf2595b3d3ae34875568a5cf64787716be"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.7.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ce1b18ccd8e73a9321186f97e46f9f04b778851177567b1975109d26a08d2a6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.32",
+]
 
 [[package]]
 name = "zeroize"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ hex = { version = "0.4", default-features = false }
 hex-literal = "0.4"
 humantime = "2.1.0"
 humantime-serde = "1.1.1"
+indexmap = "2.2.5"
 itertools = "0.11"
 lazy_static = "1"
 maplit = "1"

--- a/crates/autopilot/Cargo.toml
+++ b/crates/autopilot/Cargo.toml
@@ -31,6 +31,7 @@ observe = { path = "../observe" }
 hex = { workspace = true }
 hex-literal = { workspace = true }
 humantime = { workspace = true }
+indexmap = { workspace = true }
 itertools = { workspace = true }
 maplit = { workspace = true }
 model = { path = "../model" }

--- a/crates/autopilot/src/solvable_orders.rs
+++ b/crates/autopilot/src/solvable_orders.rs
@@ -489,8 +489,8 @@ fn get_orders_with_native_prices(
         }
     });
 
-    let high_priority_tokens = prioritize_missing_prices(filtered);
-    native_price_estimator.replace_high_priority(high_priority_tokens);
+    let tokens_by_priority = prioritize_missing_prices(filtered);
+    native_price_estimator.replace_high_priority(tokens_by_priority);
 
     // Record separate metrics just for missing native token prices for market
     // orders, as they should be prioritized.

--- a/crates/autopilot/src/solvable_orders.rs
+++ b/crates/autopilot/src/solvable_orders.rs
@@ -534,10 +534,12 @@ fn prioritize_missing_prices(mut orders: Vec<Order>) -> IndexSet<H160> {
     }
 
     // popular tokens at the start
-    let mut most_used_tokens = most_used_tokens.into_iter().collect::<Vec<_>>();
-    most_used_tokens.sort_by_key(|entry| std::cmp::Reverse(entry.1));
+    let most_used_tokens = most_used_tokens
+        .into_iter()
+        .sorted_by_key(|entry| std::cmp::Reverse(entry.1))
+        .map(|(token, _)| token);
 
-    high_priority_tokens.extend(most_used_tokens.into_iter().map(|(token, _)| token));
+    high_priority_tokens.extend(most_used_tokens);
     high_priority_tokens
 }
 

--- a/crates/autopilot/src/solvable_orders.rs
+++ b/crates/autopilot/src/solvable_orders.rs
@@ -508,10 +508,13 @@ fn get_orders_with_native_prices(
 /// often. That way we have the chance to make a majority of orders solvable
 /// with very few fetch requests.
 fn prioritize_missing_prices(mut orders: Vec<Order>) -> IndexSet<H160> {
+    /// How old an order can be at most to be considered a market order.
+    const MARKET_ORDER_AGE_MINUTES: i64 = 30;
+    let market_order_age = chrono::Duration::minutes(MARKET_ORDER_AGE_MINUTES);
+    let now = chrono::Utc::now();
+
     // newer orders at the start
     orders.sort_by_key(|o| std::cmp::Reverse(o.metadata.creation_date));
-    let now = chrono::Utc::now();
-    let market_order_age = chrono::Duration::minutes(30);
 
     let mut high_priority_tokens = IndexSet::new();
     let mut most_used_tokens = HashMap::<H160, usize>::new();

--- a/crates/shared/Cargo.toml
+++ b/crates/shared/Cargo.toml
@@ -31,6 +31,7 @@ observe = { path = "../observe" }
 hex = { workspace = true }
 hex-literal = { workspace = true }
 humantime = { workspace = true }
+indexmap = { workspace = true }
 itertools = { workspace = true }
 lazy_static = { workspace = true }
 maplit = { workspace = true }


### PR DESCRIPTION
# Description
Currently restarting the services can be a risky and unpredictable thing. The reason is that for an order to be part of the auction we need to have the buy and sell token's native prices. When we restart the system the native price cache is empty and we need to populate it again to make existing orders appear in newly built auctions.

We already had some code that prioritizes fetching prices of tokens traded by `Market` orders. However, since we made all orders `Limit` orders this optimization became useless.

Until we reclassify limit orders as market orders (if they were in market at the time of creation) we need some other way to prioritize native prices again.

# Changes
Assume orders created in the last 30 minutes (hardcoded; but I think that's okay) are market orders. For those orders the more recent ones have a higher priority. The reasoning was that if we run into that case chances are most users are already unhappy. If we prioritize most recent orders then we maximize the chance that at least some users are not very unhappy.
For the remaining orders we prioritize tokens that will cover the most orders. That way we can make the most orders usable with the fewest requests. (Technically for small orderbooks this is not quite correct because we always need both prices for an order to be included in the auction but I guess given our size this should not be an issue)

I added `indexmap` to have a map/set that remember insertion order and is fast to iterate.

## How to test
e2e, unit tests

## Related Issues
#2417 (completely different idea that would solve a superset of this problem)