### PR TITLE
Turn verification error into estimator error

### DIFF
--- a/crates/shared/src/price_estimation/trade_finder.rs
+++ b/crates/shared/src/price_estimation/trade_finder.rs
@@ -86,7 +86,7 @@ impl Inner {
             return verifier
                 .verify(&price_query, verification, trade.clone())
                 .await
-                .map_err(PriceEstimationError::ProtocolInternal);
+                .map_err(PriceEstimationError::EstimatorInternal);
         }
 
         if query.verification.is_some() {


### PR DESCRIPTION
# Description
I initially classified errors coming from verification incorrectly. `ProtocolErrors` will actually get logged as errors which leads to these [alerts](https://cowservices.slack.com/archives/C0371SB243E/p1709821653091049).
However, if we have to discard a quote because it's actually not good the estimator is actually at fault.
Those errors will not lead to alerts. Also the user will receive a `400` response (no liquidity) instead of `500` (internal server error).

# Changes
Turned `TooInaccurate` error into an `EstimatorError` instead of `ProtocolError`.