### PR TITLE
Draft: Eliminate the order class in post order #2469

### DIFF
--- a/crates/e2e/tests/e2e/limit_orders.rs
+++ b/crates/e2e/tests/e2e/limit_orders.rs
@@ -155,7 +155,7 @@ async fn single_limit_order_test(web3: Web3) {
     );
     let order_id = services.create_order(&order).await.unwrap();
     let limit_order = services.get_order(&order_id).await.unwrap();
-    assert_eq!(limit_order.metadata.class, OrderClass::Limit);
+    assert_eq!(limit_order.metadata.class, OrderClass::Market);
 
     // Drive solution
     tracing::info!("Waiting for trade.");
@@ -252,9 +252,8 @@ async fn two_limit_orders_test(web3: Web3) {
         SecretKeyRef::from(&SecretKey::from_slice(trader_a.private_key()).unwrap()),
     );
     let order_id = services.create_order(&order_a).await.unwrap();
-
     let limit_order = services.get_order(&order_id).await.unwrap();
-    assert!(limit_order.metadata.class.is_limit());
+    assert_eq!(limit_order.metadata.class, OrderClass::Market);
 
     let order_b = OrderCreation {
         sell_token: token_b.address(),
@@ -271,9 +270,8 @@ async fn two_limit_orders_test(web3: Web3) {
         SecretKeyRef::from(&SecretKey::from_slice(trader_b.private_key()).unwrap()),
     );
     let order_id = services.create_order(&order_b).await.unwrap();
-
     let limit_order = services.get_order(&order_id).await.unwrap();
-    assert!(limit_order.metadata.class.is_limit());
+    assert_eq!(limit_order.metadata.class, OrderClass::Market);
 
     wait_for_condition(TIMEOUT, || async { services.solvable_orders().await == 2 })
         .await
@@ -364,9 +362,9 @@ async fn mixed_limit_and_market_orders_test(web3: Web3) {
 
     let order_a = OrderCreation {
         sell_token: token_a.address(),
-        sell_amount: to_wei(10),
+        sell_amount: to_wei(1),
         buy_token: token_b.address(),
-        buy_amount: to_wei(5),
+        buy_amount: to_wei(1),
         valid_to: model::time::now_in_epoch_seconds() + 300,
         kind: OrderKind::Sell,
         ..Default::default()
@@ -419,7 +417,7 @@ async fn mixed_limit_and_market_orders_test(web3: Web3) {
 
     let balance_after_a = token_b.balance_of(trader_a.address()).call().await.unwrap();
     let balance_after_b = token_a.balance_of(trader_b.address()).call().await.unwrap();
-    assert!(balance_after_a.checked_sub(balance_before_a).unwrap() >= to_wei(5));
+    assert!(balance_after_a.checked_sub(balance_before_a).unwrap() >= to_wei(1));
     assert!(balance_after_b.checked_sub(balance_before_b).unwrap() >= to_wei(2));
 }
 

--- a/crates/e2e/tests/e2e/partially_fillable_balance.rs
+++ b/crates/e2e/tests/e2e/partially_fillable_balance.rs
@@ -96,7 +96,7 @@ async fn test(web3: Web3) {
     let auction = services.get_auction().await.auction;
     let order = auction.orders.into_iter().next().unwrap();
     assert!(order.partially_fillable);
-    assert!(matches!(order.class, OrderClass::Limit));
+    assert!(matches!(order.class, OrderClass::Market));
     assert_eq!(order.user_fee, 0.into());
 
     tracing::info!("Waiting for trade.");

--- a/crates/shared/src/order_quoting.rs
+++ b/crates/shared/src/order_quoting.rs
@@ -8,7 +8,7 @@ use {
     crate::{
         db_order_conversions::order_kind_from,
         fee::FeeParameters,
-        order_validation::PreOrderData,
+        order_validation::{PreOrderClass, PreOrderData},
         price_estimation::Verification,
     },
     anyhow::{Context, Result},
@@ -18,7 +18,7 @@ use {
     futures::TryFutureExt as _,
     gas_estimation::GasPriceEstimating,
     model::{
-        order::{OrderClass, OrderKind},
+        order::OrderKind,
         quote::{OrderQuoteRequest, OrderQuoteSide, QuoteId, QuoteSigningScheme, SellAmount},
     },
     number::conversions::big_decimal_to_u256,
@@ -543,7 +543,7 @@ impl From<&OrderQuoteRequest> for PreOrderData {
             buy_token_balance: quote_request.buy_token_balance,
             sell_token_balance: quote_request.sell_token_balance,
             signing_scheme: quote_request.signing_scheme.into(),
-            class: OrderClass::Market,
+            class: PreOrderClass::Market,
         }
     }
 }


### PR DESCRIPTION
# Description
Since all the user orders are limit orders, eliminate the order class from the post order.

# Changes
- eliminate the order class from the `PreOrder` (since all the user orders should be `limit` orders)
- decide if an user order is `limit` or `market` based on its quote value on order submit time
- count the limit of user limits orders based on the order class in the database (since now it should really match its real order)
- keep `liquidity`, it is complex to remove it and it should be done in follow up MRs.

## How to test
1. unit test
2. e2e test
## Related Issues

Fixes #2469