### PR TITLE
Revert storing fees change

### DIFF
--- a/crates/autopilot/src/database/fee_policies.rs
+++ b/crates/autopilot/src/database/fee_policies.rs
@@ -62,38 +62,6 @@ mod tests {
         let (auction_id, order_uid) = (1, ByteArray([1; 56]));
 
         // surplus fee policy without caps
-        let fee_policy_1 = domain::fee::Policy::Surplus {
-            factor: 0.1,
-            max_volume_factor: 1.0,
-        };
-        // surplus fee policy with caps
-        let fee_policy_2 = domain::fee::Policy::Surplus {
-            factor: 0.2,
-            max_volume_factor: 0.05,
-        };
-        // volume based fee policy
-        let fee_policy_3 = domain::fee::Policy::Volume { factor: 0.06 };
-        // price improvement fee policy
-        let fee_policy_4 = domain::fee::Policy::PriceImprovement {
-            factor: 0.1,
-            max_volume_factor: 1.0,
-            quote: domain::fee::Quote {
-                sell_amount: 10.into(),
-                buy_amount: 20.into(),
-                fee: 1.into(),
-            },
-        };
-        let input_policies = vec![fee_policy_1, fee_policy_2, fee_policy_3, fee_policy_4];
-
-        insert_batch(
-            &mut db,
-            auction_id,
-            vec![(domain::OrderUid(order_uid.0), input_policies)],
-        )
-        .await
-        .unwrap();
-
-        // surplus fee policy without caps
         let fee_policy_1 = dto::FeePolicy {
             auction_id,
             order_uid,
@@ -137,9 +105,23 @@ mod tests {
             price_improvement_factor: Some(0.1),
             price_improvement_max_volume_factor: Some(1.0),
         };
-        let expected = vec![fee_policy_1, fee_policy_2, fee_policy_3, fee_policy_4];
+
+        insert_batch(
+            &mut db,
+            vec![
+                fee_policy_1.clone(),
+                fee_policy_2.clone(),
+                fee_policy_3.clone(),
+                fee_policy_4.clone(),
+            ],
+        )
+        .await
+        .unwrap();
 
         let output = fetch(&mut db, 1, order_uid).await.unwrap();
-        assert_eq!(output, expected);
+        assert_eq!(
+            output,
+            vec![fee_policy_1, fee_policy_2, fee_policy_3, fee_policy_4]
+        );
     }
 }

--- a/crates/autopilot/src/database/fee_policies.rs
+++ b/crates/autopilot/src/database/fee_policies.rs
@@ -1,24 +1,17 @@
 use {
-    crate::{domain, infra::persistence::dto},
+    crate::infra::persistence::dto,
     sqlx::{PgConnection, QueryBuilder},
 };
 
 pub async fn insert_batch(
     ex: &mut PgConnection,
-    auction_id: domain::auction::Id,
-    fee_policies: impl IntoIterator<Item = (domain::OrderUid, Vec<domain::fee::Policy>)>,
+    fee_policies: impl IntoIterator<Item = dto::FeePolicy>,
 ) -> Result<(), sqlx::Error> {
     let mut query_builder = QueryBuilder::new(
         "INSERT INTO fee_policies (auction_id, order_uid, kind, surplus_factor, \
          surplus_max_volume_factor, volume_factor, price_improvement_factor, \
          price_improvement_max_volume_factor)",
     );
-
-    let fee_policies = fee_policies.into_iter().flat_map(|(order_uid, policies)| {
-        policies
-            .into_iter()
-            .map(move |policy| dto::FeePolicy::from_domain(auction_id, order_uid, policy))
-    });
 
     query_builder.push_values(fee_policies, |mut b, fee_policy| {
         b.push_bind(fee_policy.auction_id)


### PR DESCRIPTION
# Description
Reverts part of the https://github.com/cowprotocol/services/pull/2470

Apparently, in cases when there is no protocol fee, storing empty vectors is problematic with new code. Old code was skipping saving fee policies if policies do not exist.

https://production-6de61f.kb.eu-central-1.aws.cloud.es.io/app/discover#/doc/ea511870-d9b3-11ed-a9d0-a17451f01cc1/cowlogs-staging-2024.03.08?id=pWAOH44B0oMg6dJLt5-x

Should be merged before next weekly release!

## How to test
Ran locally few e2e tests.