### PR TITLE
Fee tests

### DIFF
--- a/crates/driver/src/tests/cases/protocol_fees.rs
+++ b/crates/driver/src/tests/cases/protocol_fees.rs
@@ -224,7 +224,7 @@ async fn price_improvement_fee_buy_out_of_market_order() {
 
 #[tokio::test]
 #[ignore]
-async fn price_improvement_fee_sell_out_market_order() {
+async fn price_improvement_fee_sell_out_of_market_order() {
     let quote_sell_amount = 50000000000000000000u128;
     let quote_buy_amount = 45000000000000000000u128;
     let fee_policy = FeePolicy::PriceImprovement {

--- a/crates/driver/src/tests/cases/protocol_fees.rs
+++ b/crates/driver/src/tests/cases/protocol_fees.rs
@@ -99,7 +99,8 @@ async fn surplus_protocol_fee_buy_order_not_capped() {
             side: order::Side::Buy,
         },
         execution: Execution {
-            // 20 ETH surplus in sell token (after network fee), half of which is kept by the driver
+            // 20 ETH surplus in sell token (after network fee), half of which is kept by the
+            // protocol
             solver: Amounts {
                 sell: 30.ether().into_wei(),
                 buy: 40.ether().into_wei(),
@@ -132,7 +133,7 @@ async fn surplus_protocol_fee_sell_order_not_capped() {
             side: order::Side::Sell,
         },
         execution: Execution {
-            // 20 ETH surplus, half of which gets captured by the settlement contract
+            // 20 ETH surplus, half of which gets captured by the protocol
             solver: Amounts {
                 sell: 50.ether().into_wei(),
                 buy: 60.ether().into_wei(),
@@ -225,7 +226,7 @@ async fn volume_protocol_fee_buy_order() {
             side: order::Side::Buy,
         },
         execution: Execution {
-            // Half of the solver proposed sell volume is kept in the driver
+            // Half of the solver proposed sell volume is kept by the protocol
             solver: Amounts {
                 sell: 30.ether().into_wei(),
                 buy: 40.ether().into_wei(),
@@ -254,7 +255,7 @@ async fn volume_protocol_fee_sell_order() {
             side: order::Side::Sell,
         },
         execution: Execution {
-            // 10% of the solver proposed buy value is kept in the settlement contract
+            // 10% of the solver proposed buy value is kept by the protocol
             solver: Amounts {
                 sell: 50.ether().into_wei(),
                 buy: 50.ether().into_wei(),
@@ -330,8 +331,7 @@ async fn price_improvement_fee_sell_in_market_order_not_capped() {
             side: order::Side::Sell,
         },
         execution: Execution {
-            // Receive 10 ETH more than quoted, half of which gets captured by the settlement
-            // contract
+            // Receive 10 ETH more than quoted, half of which gets captured by the protocol
             solver: Amounts {
                 sell: 50.ether().into_wei(),
                 buy: 60.ether().into_wei(),
@@ -408,8 +408,7 @@ async fn price_improvement_fee_sell_out_of_market_order_not_capped() {
             side: order::Side::Sell,
         },
         execution: Execution {
-            // Receive 10 ETH more than quoted, half of which gets captured by the settlement
-            // contract
+            // Receive 10 ETH more than quoted, half of which gets captured by the protocol
             solver: Amounts {
                 sell: 50.ether().into_wei(),
                 buy: 60.ether().into_wei(),

--- a/crates/driver/src/tests/cases/protocol_fees.rs
+++ b/crates/driver/src/tests/cases/protocol_fees.rs
@@ -180,7 +180,7 @@ async fn surplus_protocol_fee_buy_order_capped() {
 async fn surplus_protocol_fee_sell_order_capped() {
     let fee_policy = Policy::Surplus {
         factor: 0.5,
-        // high enough so we don't get capped by volume fee
+        // log enough so we get capped by volume fee
         max_volume_factor: 0.1,
     };
     let test_case = TestCase {

--- a/crates/driver/src/tests/cases/protocol_fees.rs
+++ b/crates/driver/src/tests/cases/protocol_fees.rs
@@ -192,7 +192,7 @@ async fn volume_protocol_fee_sell_order() {
 
 #[tokio::test]
 #[ignore]
-async fn price_improvement_fee_buy_out_market_order() {
+async fn price_improvement_fee_buy_out_of_market_order() {
     let quote_sell_amount = 50000000000000000000u128;
     let quote_buy_amount = 45000000000000000000u128;
     let fee_policy = FeePolicy::PriceImprovement {

--- a/crates/driver/src/tests/cases/protocol_fees.rs
+++ b/crates/driver/src/tests/cases/protocol_fees.rs
@@ -181,7 +181,7 @@ async fn price_improvement_fee_buy_out_of_market_order() {
         quote: PriceImprovementQuote {
             sell_amount: 50000000000000000000u128.into(),
             buy_amount: 35000000000000000000u128.into(),
-            fee: 1000000000000000000u128.into(),
+            network_fee: 1000000000000000000u128.into(),
         },
     };
     let order_sell_amount = 50000000000000000000u128.into();
@@ -210,7 +210,7 @@ async fn price_improvement_fee_sell_out_of_market_order() {
         quote: PriceImprovementQuote {
             sell_amount: 50000000000000000000u128.into(),
             buy_amount: 35000000000000000000u128.into(),
-            fee: 1000000000000000000u128.into(),
+            network_fee: 1000000000000000000u128.into(),
         },
     };
     let order_sell_amount = 50000000000000000000u128.into();
@@ -240,7 +240,7 @@ async fn price_improvement_fee_buy_in_market_order() {
         quote: PriceImprovementQuote {
             sell_amount: 50000000000000000000u128.into(),
             buy_amount: 40000000000000000000u128.into(),
-            fee: 1000000000000000000u128.into(),
+            network_fee: 1000000000000000000u128.into(),
         },
     };
     let order_sell_amount = 50000000000000000000u128.into();
@@ -269,7 +269,7 @@ async fn price_improvement_fee_sell_in_market_order() {
         quote: PriceImprovementQuote {
             sell_amount: 50000000000000000000u128.into(),
             buy_amount: 40000000000000000000u128.into(),
-            fee: 1000000000000000000u128.into(),
+            network_fee: 1000000000000000000u128.into(),
         },
     };
     let order_sell_amount: eth::U256 = 50000000000000000000u128.into();

--- a/crates/driver/src/tests/cases/protocol_fees.rs
+++ b/crates/driver/src/tests/cases/protocol_fees.rs
@@ -398,7 +398,7 @@ async fn price_improvement_fee_sell_out_of_market_order() {
         order: Order {
             amounts: Amounts {
                 sell: 50.ether().into_wei(),
-                // Willing to receive more than quoted (out-market)
+                // Demanding to receive more than quoted (out-market)
                 buy: 50.ether().into_wei(),
             },
             side: order::Side::Sell,

--- a/crates/driver/src/tests/cases/protocol_fees.rs
+++ b/crates/driver/src/tests/cases/protocol_fees.rs
@@ -10,6 +10,7 @@ use crate::{
             ab_solution,
             ExpectedOrderAmounts,
             FeePolicy,
+            PriceImprovementQuote,
             Test,
         },
     },
@@ -184,6 +185,134 @@ async fn volume_protocol_fee_sell_order() {
         executed: 40.ether().into_wei(),
         executed_sell_amount: 50.ether().into_wei(),
         executed_buy_amount: 20.ether().into_wei(),
+    };
+
+    protocol_fee_test_case(test_case).await;
+}
+
+#[tokio::test]
+#[ignore]
+async fn price_improvement_fee_buy_out_market_order() {
+    let quote_sell_amount = 21000000000000000000u128;
+    let quote_buy_amount = 18000000000000000000u128;
+    let fee_policy = FeePolicy::PriceImprovement {
+        factor: 0.5,
+        // high enough so we don't get capped by volume fee
+        max_volume_factor: 1.0,
+        quote: PriceImprovementQuote {
+            sell_amount: quote_sell_amount.into(),
+            buy_amount: quote_buy_amount.into(),
+            fee: 1000000000000000000u128.into(),
+        },
+    };
+    let executed_buy = 17143028023069342830u128;
+    let test_case = TestCase {
+        order_side: order::Side::Buy,
+        fee_policy,
+        order_sell_amount: 20000000000000000000u128.into(),
+        solver_fee: Some(10000000000000000000u128.into()),
+        quote_sell_amount: quote_sell_amount.into(),
+        quote_buy_amount: quote_buy_amount.into(),
+        executed: executed_buy.into(),
+        executed_sell_amount: 20476294902986820618u128.into(),
+        // executed buy amount should match order buy amount
+        executed_buy_amount: executed_buy.into(),
+    };
+
+    protocol_fee_test_case(test_case).await;
+}
+
+#[tokio::test]
+#[ignore]
+async fn price_improvement_fee_sell_out_market_order() {
+    let quote_sell_amount = 21000000000000000000u128;
+    let quote_buy_amount = 18000000000000000000u128;
+    let fee_policy = FeePolicy::PriceImprovement {
+        factor: 0.5,
+        // high enough so we don't get capped by volume fee
+        max_volume_factor: 1.0,
+        quote: PriceImprovementQuote {
+            sell_amount: quote_sell_amount.into(),
+            buy_amount: quote_buy_amount.into(),
+            fee: 1000000000000000000u128.into(),
+        },
+    };
+    let order_sell_amount = 20000000000000000000u128;
+    let test_case = TestCase {
+        order_side: order::Side::Sell,
+        fee_policy,
+        order_sell_amount: order_sell_amount.into(),
+        solver_fee: Some(10000000000000000000u128.into()),
+        quote_sell_amount: quote_sell_amount.into(),
+        quote_buy_amount: quote_buy_amount.into(),
+        executed: 10000000000000000000u128.into(),
+        // executed sell amount should match order sell amount
+        executed_sell_amount: order_sell_amount.into(),
+        executed_buy_amount: 16753332193352853234u128.into(),
+    };
+
+    protocol_fee_test_case(test_case).await;
+}
+
+#[tokio::test]
+#[ignore]
+async fn price_improvement_fee_buy_in_market_order() {
+    let quote_sell_amount = 17000000000000000000u128;
+    let quote_buy_amount = 10000000000000000000u128;
+    let fee_policy = FeePolicy::PriceImprovement {
+        factor: 0.5,
+        // high enough so we don't get capped by volume fee
+        max_volume_factor: 1.0,
+        quote: PriceImprovementQuote {
+            sell_amount: quote_sell_amount.into(),
+            buy_amount: quote_buy_amount.into(),
+            fee: 1000000000000000000u128.into(),
+        },
+    };
+    let executed_buy_amount = 11764354070151352996u128;
+    let test_case = TestCase {
+        order_side: order::Side::Buy,
+        fee_policy,
+        order_sell_amount: 20000000000000000000u128.into(),
+        solver_fee: Some(10000000000000000000u128.into()),
+        quote_sell_amount: quote_sell_amount.into(),
+        quote_buy_amount: quote_buy_amount.into(),
+        executed: executed_buy_amount.into(),
+        executed_sell_amount: 20587918663136217696u128.into(),
+        // executed buy amount should match order buy amount
+        executed_buy_amount: executed_buy_amount.into(),
+    };
+
+    protocol_fee_test_case(test_case).await;
+}
+
+#[tokio::test]
+#[ignore]
+async fn price_improvement_fee_sell_in_market_order() {
+    let quote_sell_amount = 9000000000000000000u128;
+    let quote_buy_amount = 25000000000000000000u128;
+    let fee_policy = FeePolicy::PriceImprovement {
+        factor: 0.5,
+        // high enough so we don't get capped by volume fee
+        max_volume_factor: 1.0,
+        quote: PriceImprovementQuote {
+            sell_amount: quote_sell_amount.into(),
+            buy_amount: quote_buy_amount.into(),
+            fee: 1000000000000000000u128.into(),
+        },
+    };
+    let order_sell_amount = 10000000000000000000u128;
+    let test_case = TestCase {
+        order_side: order::Side::Sell,
+        fee_policy,
+        order_sell_amount: order_sell_amount.into(),
+        solver_fee: Some(5000000000000000000u128.into()),
+        quote_sell_amount: quote_sell_amount.into(),
+        quote_buy_amount: quote_buy_amount.into(),
+        executed: 5000000000000000000u128.into(),
+        // executed sell amount should match order sell amount
+        executed_sell_amount: order_sell_amount.into(),
+        executed_buy_amount: 26388750430470970935u128.into(),
     };
 
     protocol_fee_test_case(test_case).await;

--- a/crates/driver/src/tests/cases/protocol_fees.rs
+++ b/crates/driver/src/tests/cases/protocol_fees.rs
@@ -62,9 +62,11 @@ async fn protocol_fee_test_case(test_case: TestCase) {
         .buy_amount(test_case.order.amounts.buy)
         // Expected amounts already account for network fee, so it doesn't matter for the math.
         // However, it cannot be zero, otherwise the order would be perceived as a StaticFee orders (which cannot have Protocol Fees)
+        // todo: can be cleaned up after https://github.com/cowprotocol/services/issues/2507
         .solver_fee(Some(test_case.execution.driver.sell / 100))
         .side(test_case.order.side)
         .fee_policy(test_case.fee_policy)
+        // Surplus is configured explicitly via executed/quoted amounts
         .no_surplus()
         .expected_amounts(expected_amounts);
 
@@ -311,8 +313,8 @@ async fn price_improvement_fee_sell_in_market_order() {
         factor: 0.5,
         max_volume_factor: 1.0,
         quote: Quote {
-            sell: 50.ether().into_wei(),
-            buy: 51.ether().into_wei(),
+            sell: 49.ether().into_wei(),
+            buy: 50.ether().into_wei(),
             network_fee: 1.ether().into_wei(),
         },
     };
@@ -387,8 +389,8 @@ async fn price_improvement_fee_sell_out_of_market_order() {
         factor: 0.5,
         max_volume_factor: 1.0,
         quote: Quote {
-            sell: 50.ether().into_wei(),
-            buy: 41.ether().into_wei(),
+            sell: 49.ether().into_wei(),
+            buy: 40.ether().into_wei(),
             network_fee: 1.ether().into_wei(),
         },
     };

--- a/crates/driver/src/tests/cases/protocol_fees.rs
+++ b/crates/driver/src/tests/cases/protocol_fees.rs
@@ -28,7 +28,8 @@ struct Execution {
 }
 
 struct Order {
-    amounts: Amounts,
+    sell_amount: eth::U256,
+    buy_amount: eth::U256,
     side: order::Side,
 }
 
@@ -58,8 +59,8 @@ async fn protocol_fee_test_case(test_case: TestCase) {
 
     let order = ab_order()
         .kind(order::Kind::Limit)
-        .sell_amount(test_case.order.amounts.sell)
-        .buy_amount(test_case.order.amounts.buy)
+        .sell_amount(test_case.order.sell_amount)
+        .buy_amount(test_case.order.buy_amount)
         // Expected amounts already account for network fee, so it doesn't matter for the math.
         // However, it cannot be zero, otherwise the order would be perceived as a StaticFee orders (which cannot have Protocol Fees)
         // todo: can be cleaned up after https://github.com/cowprotocol/services/issues/2507
@@ -92,10 +93,8 @@ async fn surplus_protocol_fee_buy_order_not_capped() {
     let test_case = TestCase {
         fee_policy,
         order: Order {
-            amounts: Amounts {
-                sell: 50.ether().into_wei(),
-                buy: 40.ether().into_wei(),
-            },
+            sell_amount: 50.ether().into_wei(),
+            buy_amount: 40.ether().into_wei(),
             side: order::Side::Buy,
         },
         execution: Execution {
@@ -126,10 +125,8 @@ async fn surplus_protocol_fee_sell_order_not_capped() {
     let test_case = TestCase {
         fee_policy,
         order: Order {
-            amounts: Amounts {
-                sell: 50.ether().into_wei(),
-                buy: 40.ether().into_wei(),
-            },
+            sell_amount: 50.ether().into_wei(),
+            buy_amount: 40.ether().into_wei(),
             side: order::Side::Sell,
         },
         execution: Execution {
@@ -158,10 +155,8 @@ async fn surplus_protocol_fee_buy_order_capped() {
     let test_case = TestCase {
         fee_policy,
         order: Order {
-            amounts: Amounts {
-                sell: 50.ether().into_wei(),
-                buy: 40.ether().into_wei(),
-            },
+            sell_amount: 50.ether().into_wei(),
+            buy_amount: 40.ether().into_wei(),
             side: order::Side::Buy,
         },
         execution: Execution {
@@ -191,10 +186,8 @@ async fn surplus_protocol_fee_sell_order_capped() {
     let test_case = TestCase {
         fee_policy,
         order: Order {
-            amounts: Amounts {
-                sell: 50.ether().into_wei(),
-                buy: 40.ether().into_wei(),
-            },
+            sell_amount: 50.ether().into_wei(),
+            buy_amount: 40.ether().into_wei(),
             side: order::Side::Sell,
         },
         execution: Execution {
@@ -219,10 +212,8 @@ async fn volume_protocol_fee_buy_order() {
     let test_case = TestCase {
         fee_policy,
         order: Order {
-            amounts: Amounts {
-                sell: 50.ether().into_wei(),
-                buy: 40.ether().into_wei(),
-            },
+            sell_amount: 50.ether().into_wei(),
+            buy_amount: 40.ether().into_wei(),
             side: order::Side::Buy,
         },
         execution: Execution {
@@ -248,10 +239,8 @@ async fn volume_protocol_fee_sell_order() {
     let test_case = TestCase {
         fee_policy,
         order: Order {
-            amounts: Amounts {
-                sell: 50.ether().into_wei(),
-                buy: 40.ether().into_wei(),
-            },
+            sell_amount: 50.ether().into_wei(),
+            buy_amount: 40.ether().into_wei(),
             side: order::Side::Sell,
         },
         execution: Execution {
@@ -284,11 +273,9 @@ async fn price_improvement_fee_buy_in_market_order_not_capped() {
     let test_case = TestCase {
         fee_policy,
         order: Order {
-            amounts: Amounts {
-                // Willing to sell more than quoted (in-market)
-                sell: 60.ether().into_wei(),
-                buy: 40.ether().into_wei(),
-            },
+            // Demanding to sell more than quoted (in-market)
+            sell_amount: 60.ether().into_wei(),
+            buy_amount: 40.ether().into_wei(),
             side: order::Side::Buy,
         },
         execution: Execution {
@@ -323,11 +310,9 @@ async fn price_improvement_fee_sell_in_market_order_not_capped() {
     let test_case = TestCase {
         fee_policy,
         order: Order {
-            amounts: Amounts {
-                sell: 50.ether().into_wei(),
-                // Willing to receive less than quoted (in-market)
-                buy: 40.ether().into_wei(),
-            },
+            sell_amount: 50.ether().into_wei(),
+            // Demanding to receive less than quoted (in-market)
+            buy_amount: 40.ether().into_wei(),
             side: order::Side::Sell,
         },
         execution: Execution {
@@ -361,11 +346,9 @@ async fn price_improvement_fee_buy_out_of_market_order_not_capped() {
     let test_case = TestCase {
         fee_policy,
         order: Order {
-            amounts: Amounts {
-                // Willing to sell less than quoted (out-market)
-                sell: 50.ether().into_wei(),
-                buy: 40.ether().into_wei(),
-            },
+            // Demanding to sell less than quoted (out-market)
+            sell_amount: 50.ether().into_wei(),
+            buy_amount: 40.ether().into_wei(),
             side: order::Side::Buy,
         },
         execution: Execution {
@@ -400,11 +383,9 @@ async fn price_improvement_fee_sell_out_of_market_order_not_capped() {
     let test_case = TestCase {
         fee_policy,
         order: Order {
-            amounts: Amounts {
-                sell: 50.ether().into_wei(),
-                // Demanding to receive more than quoted (out-market)
-                buy: 50.ether().into_wei(),
-            },
+            sell_amount: 50.ether().into_wei(),
+            // Demanding to receive more than quoted (out-market)
+            buy_amount: 50.ether().into_wei(),
             side: order::Side::Sell,
         },
         execution: Execution {
@@ -438,11 +419,9 @@ async fn price_improvement_fee_buy_in_market_order_capped() {
     let test_case = TestCase {
         fee_policy,
         order: Order {
-            amounts: Amounts {
-                // Willing to sell more than quoted (in-market)
-                sell: 60.ether().into_wei(),
-                buy: 40.ether().into_wei(),
-            },
+            // Demanding to sell more than quoted (in-market)
+            sell_amount: 60.ether().into_wei(),
+            buy_amount: 40.ether().into_wei(),
             side: order::Side::Buy,
         },
         execution: Execution {
@@ -477,11 +456,9 @@ async fn price_improvement_fee_sell_in_market_order_capped() {
     let test_case = TestCase {
         fee_policy,
         order: Order {
-            amounts: Amounts {
-                sell: 50.ether().into_wei(),
-                // Willing to receive less than quoted (in-market)
-                buy: 40.ether().into_wei(),
-            },
+            sell_amount: 50.ether().into_wei(),
+            // Demanding to receive less than quoted (in-market)
+            buy_amount: 40.ether().into_wei(),
             side: order::Side::Sell,
         },
         execution: Execution {
@@ -515,11 +492,9 @@ async fn price_improvement_fee_buy_out_of_market_order_capped() {
     let test_case = TestCase {
         fee_policy,
         order: Order {
-            amounts: Amounts {
-                // Willing to sell less than quoted (out-market)
-                sell: 50.ether().into_wei(),
-                buy: 40.ether().into_wei(),
-            },
+            // Demanding to sell less than quoted (out-market)
+            sell_amount: 50.ether().into_wei(),
+            buy_amount: 40.ether().into_wei(),
             side: order::Side::Buy,
         },
         execution: Execution {
@@ -554,11 +529,9 @@ async fn price_improvement_fee_sell_out_of_market_order_capped() {
     let test_case = TestCase {
         fee_policy,
         order: Order {
-            amounts: Amounts {
-                sell: 50.ether().into_wei(),
-                // Demanding to receive more than quoted (out-market)
-                buy: 50.ether().into_wei(),
-            },
+            sell_amount: 50.ether().into_wei(),
+            // Demanding to receive more than quoted (out-market)
+            buy_amount: 50.ether().into_wei(),
             side: order::Side::Sell,
         },
         execution: Execution {

--- a/crates/driver/src/tests/cases/protocol_fees.rs
+++ b/crates/driver/src/tests/cases/protocol_fees.rs
@@ -162,8 +162,7 @@ async fn surplus_protocol_fee_buy_order_capped() {
             side: order::Side::Buy,
         },
         execution: Execution {
-            // 20 ETH surplus in sell token (after network fee), half of it could be kept in driver,
-            // but it is capped buy a max volume factor applied to the sell amount
+            // Fee is capped at 10% of solver proposed sell volume
             solver: Amounts {
                 sell: 30.ether().into_wei(),
                 buy: 40.ether().into_wei(),

--- a/crates/driver/src/tests/cases/protocol_fees.rs
+++ b/crates/driver/src/tests/cases/protocol_fees.rs
@@ -195,8 +195,7 @@ async fn surplus_protocol_fee_sell_order_capped() {
             side: order::Side::Sell,
         },
         execution: Execution {
-            // 20 ETH surplus, half of which could be captured by the settlement contract, but it is
-            // capped buy a max volume factor applied to the buy amount
+            // Fee is capped at 10% of solver proposed buy volume
             solver: Amounts {
                 sell: 50.ether().into_wei(),
                 buy: 60.ether().into_wei(),
@@ -224,7 +223,7 @@ async fn volume_protocol_fee_buy_order() {
             side: order::Side::Buy,
         },
         execution: Execution {
-            // Half of the volume(sell amount) is kept in the driver
+            // Half of the solver proposed sell volume is kept in the driver
             solver: Amounts {
                 sell: 30.ether().into_wei(),
                 buy: 40.ether().into_wei(),
@@ -253,7 +252,7 @@ async fn volume_protocol_fee_sell_order() {
             side: order::Side::Sell,
         },
         execution: Execution {
-            // 0.1 of the volume(buy amount) is kept in the settlement contract
+            // 10% of the solver proposed buy value is kept in the settlement contract
             solver: Amounts {
                 sell: 50.ether().into_wei(),
                 buy: 50.ether().into_wei(),

--- a/crates/driver/src/tests/cases/protocol_fees.rs
+++ b/crates/driver/src/tests/cases/protocol_fees.rs
@@ -193,30 +193,30 @@ async fn volume_protocol_fee_sell_order() {
 #[tokio::test]
 #[ignore]
 async fn price_improvement_fee_buy_out_of_market_order() {
-    let quote_sell_amount = 50000000000000000000u128;
-    let quote_buy_amount = 45000000000000000000u128;
+    let quote_sell_amount = 50000000000000000000u128.into();
+    let quote_buy_amount = 35000000000000000000u128.into();
+    let fee: eth::U256 = 1000000000000000000u128.into();
     let fee_policy = FeePolicy::PriceImprovement {
         factor: 0.5,
-        // high enough so we don't get capped by volume fee
         max_volume_factor: 1.0,
         quote: PriceImprovementQuote {
-            sell_amount: quote_sell_amount.into(),
-            buy_amount: quote_buy_amount.into(),
-            fee: 1000000000000000000u128.into(),
+            sell_amount: quote_sell_amount,
+            buy_amount: quote_buy_amount,
+            fee,
         },
     };
+    let order_sell_amount = 50000000000000000000u128.into();
+    let order_buy_amount = 40000000000000000000u128.into();
     let test_case = TestCase {
         order_side: order::Side::Buy,
         fee_policy,
-        order_sell_amount: 50000000000000000000u128.into(),
-        solver_fee: Some(10000000000000000000u128.into()),
-        quote_sell_amount: quote_sell_amount.into(),
-        quote_buy_amount: quote_buy_amount.into(),
-        executed: quote_buy_amount.into(),
-        // sell amount + quote fee * factor
-        executed_sell_amount: 50500000000000000000u128.into(),
-        // executed buy amount should match quote buy amount
-        executed_buy_amount: quote_buy_amount.into(),
+        order_sell_amount,
+        solver_fee: Some(fee),
+        quote_sell_amount: order_sell_amount,
+        quote_buy_amount: order_buy_amount,
+        executed: order_buy_amount,
+        executed_sell_amount: 54142857142857142857u128.into(),
+        executed_buy_amount: order_buy_amount,
     };
 
     protocol_fee_test_case(test_case).await;
@@ -225,30 +225,30 @@ async fn price_improvement_fee_buy_out_of_market_order() {
 #[tokio::test]
 #[ignore]
 async fn price_improvement_fee_sell_out_of_market_order() {
-    let quote_sell_amount = 50000000000000000000u128;
-    let quote_buy_amount = 45000000000000000000u128;
+    let quote_sell_amount = 50000000000000000000u128.into();
+    let quote_buy_amount = 35000000000000000000u128.into();
+    let fee: eth::U256 = 1000000000000000000u128.into();
     let fee_policy = FeePolicy::PriceImprovement {
         factor: 0.5,
-        // high enough so we don't get capped by volume fee
         max_volume_factor: 1.0,
         quote: PriceImprovementQuote {
-            sell_amount: quote_sell_amount.into(),
-            buy_amount: quote_buy_amount.into(),
-            fee: 1000000000000000000u128.into(),
+            sell_amount: quote_sell_amount,
+            buy_amount: quote_buy_amount,
+            fee,
         },
     };
-    let order_sell_amount = 50000000000000000000u128;
+    let order_sell_amount = 50000000000000000000u128.into();
+    let order_buy_amount = 40000000000000000000u128.into();
     let test_case = TestCase {
         order_side: order::Side::Sell,
         fee_policy,
-        order_sell_amount: order_sell_amount.into(),
-        solver_fee: Some(10000000000000000000u128.into()),
-        quote_sell_amount: quote_sell_amount.into(),
-        quote_buy_amount: quote_buy_amount.into(),
-        executed: 40000000000000000000u128.into(),
-        // executed sell amount should match order sell amount
-        executed_sell_amount: order_sell_amount.into(),
-        executed_buy_amount: 44558823529411764706u128.into(),
+        order_sell_amount,
+        solver_fee: Some(fee),
+        quote_sell_amount: order_sell_amount,
+        quote_buy_amount: order_buy_amount,
+        executed: order_sell_amount - fee,
+        executed_sell_amount: order_sell_amount,
+        executed_buy_amount: 37156862745098039215u128.into(),
     };
 
     protocol_fee_test_case(test_case).await;
@@ -257,29 +257,30 @@ async fn price_improvement_fee_sell_out_of_market_order() {
 #[tokio::test]
 #[ignore]
 async fn price_improvement_fee_buy_in_market_order() {
-    let quote_sell_amount = 50000000000000000000u128;
-    let quote_buy_amount = 45000000000000000000u128;
+    let quote_sell_amount: eth::U256 = 50000000000000000000u128.into();
+    let quote_buy_amount: eth::U256 = 40000000000000000000u128.into();
+    let fee = 1000000000000000000u128.into();
     let fee_policy = FeePolicy::PriceImprovement {
         factor: 0.5,
-        // high enough so we don't get capped by volume fee
         max_volume_factor: 1.0,
         quote: PriceImprovementQuote {
-            sell_amount: quote_sell_amount.into(),
-            buy_amount: quote_buy_amount.into(),
-            fee: 20000000000000000000u128.into(),
+            sell_amount: quote_sell_amount,
+            buy_amount: quote_buy_amount,
+            fee,
         },
     };
+    let order_sell_amount = 50000000000000000000u128.into();
+    let order_buy_amount = 35000000000000000000u128.into();
     let test_case = TestCase {
         order_side: order::Side::Buy,
         fee_policy,
-        order_sell_amount: 50000000000000000000u128.into(),
-        solver_fee: Some(10000000000000000000u128.into()),
-        quote_sell_amount: quote_sell_amount.into(),
-        quote_buy_amount: quote_buy_amount.into(),
-        executed: quote_buy_amount.into(),
-        executed_sell_amount: 60000000000000000000u128.into(),
-        // executed buy amount should match order buy amount
-        executed_buy_amount: quote_buy_amount.into(),
+        order_sell_amount: quote_sell_amount,
+        solver_fee: Some(fee),
+        quote_sell_amount: order_sell_amount,
+        quote_buy_amount: order_buy_amount,
+        executed: order_buy_amount,
+        executed_sell_amount: order_sell_amount,
+        executed_buy_amount: order_buy_amount,
     };
 
     protocol_fee_test_case(test_case).await;
@@ -288,30 +289,30 @@ async fn price_improvement_fee_buy_in_market_order() {
 #[tokio::test]
 #[ignore]
 async fn price_improvement_fee_sell_in_market_order() {
-    let quote_sell_amount = 50000000000000000000u128;
-    let quote_buy_amount = 45000000000000000000u128;
+    let quote_sell_amount: eth::U256 = 50000000000000000000u128.into();
+    let quote_buy_amount: eth::U256 = 40000000000000000000u128.into();
+    let fee = 1000000000000000000u128.into();
     let fee_policy = FeePolicy::PriceImprovement {
         factor: 0.5,
-        // high enough so we don't get capped by volume fee
         max_volume_factor: 1.0,
         quote: PriceImprovementQuote {
-            sell_amount: quote_sell_amount.into(),
-            buy_amount: quote_buy_amount.into(),
-            fee: 20000000000000000000u128.into(),
+            sell_amount: quote_sell_amount,
+            buy_amount: quote_buy_amount,
+            fee,
         },
     };
-    let order_sell_amount = 50000000000000000000u128;
+    let order_sell_amount: eth::U256 = 50000000000000000000u128.into();
+    let order_buy_amount: eth::U256 = 35000000000000000000u128.into();
     let test_case = TestCase {
         order_side: order::Side::Sell,
         fee_policy,
-        order_sell_amount: order_sell_amount.into(),
-        solver_fee: Some(10000000000000000000u128.into()),
-        quote_sell_amount: quote_sell_amount.into(),
-        quote_buy_amount: quote_buy_amount.into(),
-        executed: 40000000000000000000u128.into(),
-        // executed sell amount should match order sell amount
-        executed_sell_amount: order_sell_amount.into(),
-        executed_buy_amount: 38571428571428571429u128.into(),
+        order_sell_amount,
+        solver_fee: Some(fee),
+        quote_sell_amount: order_sell_amount,
+        quote_buy_amount: order_buy_amount,
+        executed: order_sell_amount - fee,
+        executed_sell_amount: order_sell_amount,
+        executed_buy_amount: order_buy_amount,
     };
 
     protocol_fee_test_case(test_case).await;

--- a/crates/driver/src/tests/cases/protocol_fees.rs
+++ b/crates/driver/src/tests/cases/protocol_fees.rs
@@ -263,6 +263,7 @@ async fn volume_protocol_fee_sell_order() {
 async fn price_improvement_fee_buy_in_market_order_not_capped() {
     let fee_policy = Policy::PriceImprovement {
         factor: 0.5,
+        // high enough so we don't get capped by volume fee
         max_volume_factor: 1.0,
         quote: Quote {
             sell: 49.ether().into_wei(),

--- a/crates/driver/src/tests/cases/protocol_fees.rs
+++ b/crates/driver/src/tests/cases/protocol_fees.rs
@@ -193,8 +193,8 @@ async fn volume_protocol_fee_sell_order() {
 #[tokio::test]
 #[ignore]
 async fn price_improvement_fee_buy_out_market_order() {
-    let quote_sell_amount = 21000000000000000000u128;
-    let quote_buy_amount = 18000000000000000000u128;
+    let quote_sell_amount = 50000000000000000000u128;
+    let quote_buy_amount = 45000000000000000000u128;
     let fee_policy = FeePolicy::PriceImprovement {
         factor: 0.5,
         // high enough so we don't get capped by volume fee
@@ -205,18 +205,18 @@ async fn price_improvement_fee_buy_out_market_order() {
             fee: 1000000000000000000u128.into(),
         },
     };
-    let executed_buy = 17143028023069342830u128;
     let test_case = TestCase {
         order_side: order::Side::Buy,
         fee_policy,
-        order_sell_amount: 20000000000000000000u128.into(),
+        order_sell_amount: 50000000000000000000u128.into(),
         solver_fee: Some(10000000000000000000u128.into()),
         quote_sell_amount: quote_sell_amount.into(),
         quote_buy_amount: quote_buy_amount.into(),
-        executed: executed_buy.into(),
-        executed_sell_amount: 20476294902986820618u128.into(),
-        // executed buy amount should match order buy amount
-        executed_buy_amount: executed_buy.into(),
+        executed: quote_buy_amount.into(),
+        // sell amount + quote fee * factor
+        executed_sell_amount: 50500000000000000000u128.into(),
+        // executed buy amount should match quote buy amount
+        executed_buy_amount: quote_buy_amount.into(),
     };
 
     protocol_fee_test_case(test_case).await;
@@ -225,8 +225,8 @@ async fn price_improvement_fee_buy_out_market_order() {
 #[tokio::test]
 #[ignore]
 async fn price_improvement_fee_sell_out_market_order() {
-    let quote_sell_amount = 21000000000000000000u128;
-    let quote_buy_amount = 18000000000000000000u128;
+    let quote_sell_amount = 50000000000000000000u128;
+    let quote_buy_amount = 45000000000000000000u128;
     let fee_policy = FeePolicy::PriceImprovement {
         factor: 0.5,
         // high enough so we don't get capped by volume fee
@@ -237,7 +237,7 @@ async fn price_improvement_fee_sell_out_market_order() {
             fee: 1000000000000000000u128.into(),
         },
     };
-    let order_sell_amount = 20000000000000000000u128;
+    let order_sell_amount = 50000000000000000000u128;
     let test_case = TestCase {
         order_side: order::Side::Sell,
         fee_policy,
@@ -245,10 +245,10 @@ async fn price_improvement_fee_sell_out_market_order() {
         solver_fee: Some(10000000000000000000u128.into()),
         quote_sell_amount: quote_sell_amount.into(),
         quote_buy_amount: quote_buy_amount.into(),
-        executed: 10000000000000000000u128.into(),
+        executed: 40000000000000000000u128.into(),
         // executed sell amount should match order sell amount
         executed_sell_amount: order_sell_amount.into(),
-        executed_buy_amount: 16753332193352853234u128.into(),
+        executed_buy_amount: 44558823529411764706u128.into(),
     };
 
     protocol_fee_test_case(test_case).await;
@@ -257,8 +257,8 @@ async fn price_improvement_fee_sell_out_market_order() {
 #[tokio::test]
 #[ignore]
 async fn price_improvement_fee_buy_in_market_order() {
-    let quote_sell_amount = 17000000000000000000u128;
-    let quote_buy_amount = 10000000000000000000u128;
+    let quote_sell_amount = 50000000000000000000u128;
+    let quote_buy_amount = 45000000000000000000u128;
     let fee_policy = FeePolicy::PriceImprovement {
         factor: 0.5,
         // high enough so we don't get capped by volume fee
@@ -266,21 +266,20 @@ async fn price_improvement_fee_buy_in_market_order() {
         quote: PriceImprovementQuote {
             sell_amount: quote_sell_amount.into(),
             buy_amount: quote_buy_amount.into(),
-            fee: 1000000000000000000u128.into(),
+            fee: 20000000000000000000u128.into(),
         },
     };
-    let executed_buy_amount = 11764354070151352996u128;
     let test_case = TestCase {
         order_side: order::Side::Buy,
         fee_policy,
-        order_sell_amount: 20000000000000000000u128.into(),
+        order_sell_amount: 50000000000000000000u128.into(),
         solver_fee: Some(10000000000000000000u128.into()),
         quote_sell_amount: quote_sell_amount.into(),
         quote_buy_amount: quote_buy_amount.into(),
-        executed: executed_buy_amount.into(),
-        executed_sell_amount: 20587918663136217696u128.into(),
+        executed: quote_buy_amount.into(),
+        executed_sell_amount: 60000000000000000000u128.into(),
         // executed buy amount should match order buy amount
-        executed_buy_amount: executed_buy_amount.into(),
+        executed_buy_amount: quote_buy_amount.into(),
     };
 
     protocol_fee_test_case(test_case).await;
@@ -289,8 +288,8 @@ async fn price_improvement_fee_buy_in_market_order() {
 #[tokio::test]
 #[ignore]
 async fn price_improvement_fee_sell_in_market_order() {
-    let quote_sell_amount = 9000000000000000000u128;
-    let quote_buy_amount = 25000000000000000000u128;
+    let quote_sell_amount = 50000000000000000000u128;
+    let quote_buy_amount = 45000000000000000000u128;
     let fee_policy = FeePolicy::PriceImprovement {
         factor: 0.5,
         // high enough so we don't get capped by volume fee
@@ -298,21 +297,21 @@ async fn price_improvement_fee_sell_in_market_order() {
         quote: PriceImprovementQuote {
             sell_amount: quote_sell_amount.into(),
             buy_amount: quote_buy_amount.into(),
-            fee: 1000000000000000000u128.into(),
+            fee: 20000000000000000000u128.into(),
         },
     };
-    let order_sell_amount = 10000000000000000000u128;
+    let order_sell_amount = 50000000000000000000u128;
     let test_case = TestCase {
         order_side: order::Side::Sell,
         fee_policy,
         order_sell_amount: order_sell_amount.into(),
-        solver_fee: Some(5000000000000000000u128.into()),
+        solver_fee: Some(10000000000000000000u128.into()),
         quote_sell_amount: quote_sell_amount.into(),
         quote_buy_amount: quote_buy_amount.into(),
-        executed: 5000000000000000000u128.into(),
+        executed: 40000000000000000000u128.into(),
         // executed sell amount should match order sell amount
         executed_sell_amount: order_sell_amount.into(),
-        executed_buy_amount: 26388750430470970935u128.into(),
+        executed_buy_amount: 38571428571428571429u128.into(),
     };
 
     protocol_fee_test_case(test_case).await;

--- a/crates/driver/src/tests/setup/blockchain.rs
+++ b/crates/driver/src/tests/setup/blockchain.rs
@@ -61,7 +61,7 @@ pub struct Pool {
 impl Pool {
     /// Use the Uniswap constant AMM formula to calculate the output amount
     /// based on the input.
-    fn out(&self, input: Asset) -> eth::U256 {
+    pub fn out_given_in(&self, input: Asset) -> eth::U256 {
         let (input_reserve, output_reserve) = if input.token == self.reserve_a.token {
             (self.reserve_a.amount, self.reserve_b.amount)
         } else {
@@ -69,6 +69,20 @@ impl Pool {
         };
         output_reserve * input.amount * eth::U256::from(997)
             / (input_reserve * eth::U256::from(1000) + input.amount * eth::U256::from(997))
+    }
+
+    /// Use the Uniswap constant AMM formula to calculate the input amount
+    /// based on the output.
+    pub fn in_given_out(&self, output: Asset) -> eth::U256 {
+        let (input_reserve, output_reserve) = if output.token == self.reserve_b.token {
+            (self.reserve_a.amount, self.reserve_b.amount)
+        } else {
+            (self.reserve_b.amount, self.reserve_a.amount)
+        };
+
+        ((input_reserve * output.amount * eth::U256::from(1000))
+            / ((output_reserve - output.amount) * eth::U256::from(997)))
+            + 1
     }
 }
 
@@ -81,6 +95,7 @@ pub struct Solution {
 #[derive(Debug, Clone)]
 pub struct Fulfillment {
     pub quoted_order: QuotedOrder,
+    pub execution: Execution,
     pub interactions: Vec<Interaction>,
 }
 
@@ -88,6 +103,13 @@ pub struct Fulfillment {
 #[derive(Debug, Clone)]
 pub struct QuotedOrder {
     pub order: Order,
+    pub buy: eth::U256,
+    pub sell: eth::U256,
+}
+
+/// An execution of a trade with buy and sell amounts
+#[derive(Debug, Clone)]
+pub struct Execution {
     pub buy: eth::U256,
     pub sell: eth::U256,
 }
@@ -523,20 +545,41 @@ impl Blockchain {
             .expect("could not find uniswap pair for order")
     }
 
-    /// Quote an order using a UniswapV2 pool. This determines the buy and sell
-    /// amount of the order.
-    pub async fn quote(&self, order: &Order) -> QuotedOrder {
-        let pair = self.find_pair(order);
+    /// Quote an order using a UniswapV2 pool unless it already has concrete
+    /// amounts. This determines the buy and sell amount of the
+    /// order in the auction.
+    pub fn quote(&self, order: &Order) -> QuotedOrder {
         let executed_sell = order.sell_amount;
-        let executed_buy = pair.pool.out(Asset {
-            amount: order.sell_amount,
-            token: order.sell_token,
-        });
+        let executed_buy = order.buy_amount.unwrap_or(self.execution(order).buy);
         QuotedOrder {
             order: order.clone(),
             buy: executed_buy,
             sell: executed_sell,
         }
+    }
+
+    /// Compute the execution of an order given the available liquidity
+    pub fn execution(&self, order: &Order) -> Execution {
+        let pair = self.find_pair(order);
+        let (sell, buy) = match (order.side, order.buy_amount) {
+            // For buy order with explicitly specified amounts, use the buy amount
+            (order::Side::Buy, Some(buy_amount)) => (
+                pair.pool.in_given_out(Asset {
+                    amount: buy_amount,
+                    token: order.buy_token,
+                }),
+                buy_amount,
+            ),
+            // Otherwise assume the full sell amount to compute the execution
+            (_, _) => (
+                order.sell_amount,
+                pair.pool.out_given_in(Asset {
+                    amount: order.sell_amount,
+                    token: order.sell_token,
+                }),
+            ),
+        };
+        Execution { sell, buy }
     }
 
     /// Set up the blockchain context and return the interactions needed to
@@ -554,7 +597,7 @@ impl Blockchain {
             let buy_token =
                 contracts::ERC20::at(&self.web3, self.get_token_wrapped(order.buy_token));
             let pair = self.find_pair(order);
-            let quote = self.quote(order).await;
+            let execution = self.execution(order);
 
             // Fund the trader account with tokens needed for the solution.
             let trader_account = ethcontract::Account::Offline(
@@ -571,7 +614,7 @@ impl Blockchain {
                         .unwrap()
                         .mint(
                             self.trader_address,
-                            "1e-7".ether().into_wei() * quote.sell + order.user_fee,
+                            "1e-7".ether().into_wei() * execution.sell + order.user_fee,
                         )
                         .from(trader_account.clone())
                         .send(),
@@ -596,16 +639,16 @@ impl Blockchain {
 
             // Create the interactions fulfilling the order.
             let transfer_interaction = sell_token
-                .transfer(pair.contract.address(), quote.sell)
+                .transfer(pair.contract.address(), execution.sell)
                 .tx
                 .data
                 .unwrap()
                 .0;
             let (amount_a_out, amount_b_out) = if pair.token_a == order.sell_token {
-                (0.into(), quote.buy)
+                (0.into(), execution.buy)
             } else {
                 // Surplus fees stay in the contract.
-                (quote.sell - quote.order.surplus_fee(), 0.into())
+                (execution.sell - order.surplus_fee(), 0.into())
             };
             let (amount_0_out, amount_1_out) =
                 if self.get_token(pair.token_a) < self.get_token(pair.token_b) {
@@ -626,7 +669,8 @@ impl Blockchain {
                 .unwrap()
                 .0;
             fulfillments.push(Fulfillment {
-                quoted_order: quote.clone(),
+                quoted_order: self.quote(&order),
+                execution: execution.clone(),
                 interactions: vec![
                     Interaction {
                         address: sell_token.address(),
@@ -652,11 +696,11 @@ impl Blockchain {
                         inputs: vec![eth::Asset {
                             token: sell_token.address().into(),
                             // Surplus fees stay in the contract.
-                            amount: (quote.sell - quote.order.surplus_fee()).into(),
+                            amount: (execution.sell - order.surplus_fee()).into(),
                         }],
                         outputs: vec![eth::Asset {
                             token: buy_token.address().into(),
-                            amount: quote.buy.into(),
+                            amount: execution.buy.into(),
                         }],
                         internalize: order.internalize,
                     },

--- a/crates/driver/src/tests/setup/blockchain.rs
+++ b/crates/driver/src/tests/setup/blockchain.rs
@@ -669,7 +669,7 @@ impl Blockchain {
                 .unwrap()
                 .0;
             fulfillments.push(Fulfillment {
-                quoted_order: self.quote(&order),
+                quoted_order: self.quote(order),
                 execution: execution.clone(),
                 interactions: vec![
                     Interaction {

--- a/crates/driver/src/tests/setup/fee.rs
+++ b/crates/driver/src/tests/setup/fee.rs
@@ -1,0 +1,66 @@
+use {crate::domain::eth, serde_json::json, serde_with::serde_as};
+
+#[serde_as]
+#[derive(Debug, Clone, PartialEq, serde::Serialize)]
+#[serde(rename_all = "camelCase", tag = "kind")]
+pub struct Quote {
+    /// How much tokens the trader is expected to buy
+    pub buy: eth::U256,
+    /// How much tokens the user is expected to sell (excluding network fee)
+    pub sell: eth::U256,
+    /// The expected network fee, which is expected to be taken as
+    /// additional sell amount.
+    pub network_fee: eth::U256,
+}
+
+#[serde_as]
+#[derive(Debug, Clone, PartialEq, serde::Serialize)]
+#[serde(rename_all = "camelCase", tag = "kind")]
+pub enum Policy {
+    #[serde(rename_all = "camelCase")]
+    Surplus { factor: f64, max_volume_factor: f64 },
+    #[serde(rename_all = "camelCase")]
+    PriceImprovement {
+        factor: f64,
+        max_volume_factor: f64,
+        quote: Quote,
+    },
+    #[serde(rename_all = "camelCase")]
+    Volume { factor: f64 },
+}
+
+impl Policy {
+    pub fn to_json_value(&self) -> serde_json::Value {
+        match self {
+            Policy::Surplus {
+                factor,
+                max_volume_factor,
+            } => json!({
+                "surplus": {
+                    "factor": factor,
+                    "maxVolumeFactor": max_volume_factor
+                }
+            }),
+            Policy::PriceImprovement {
+                factor,
+                max_volume_factor,
+                quote,
+            } => json!({
+                "priceImprovement": {
+                    "factor": factor,
+                    "maxVolumeFactor": max_volume_factor,
+                    "quote": {
+                        "sellAmount": quote.sell,
+                        "buyAmount": quote.buy,
+                        "fee": quote.network_fee,
+                    }
+                }
+            }),
+            Policy::Volume { factor } => json!({
+                "volume": {
+                    "factor": factor
+                }
+            }),
+        }
+    }
+}

--- a/crates/driver/src/tests/setup/mod.rs
+++ b/crates/driver/src/tests/setup/mod.rs
@@ -42,6 +42,7 @@ use {
 
 mod blockchain;
 mod driver;
+pub mod fee;
 mod solver;
 
 #[derive(Debug, Clone, Copy)]
@@ -70,75 +71,6 @@ pub enum Score {
     },
     #[serde(rename_all = "camelCase")]
     RiskAdjusted { success_probability: f64 },
-}
-
-pub mod fee {
-    use {crate::domain::eth, serde_json::json, serde_with::serde_as};
-
-    #[serde_as]
-    #[derive(Debug, Clone, PartialEq, serde::Serialize)]
-    #[serde(rename_all = "camelCase", tag = "kind")]
-    pub struct Quote {
-        /// How much tokens the trader is expected to buy
-        pub buy: eth::U256,
-        /// How much tokens the user is expected to sell (excluding network fee)
-        pub sell: eth::U256,
-        /// The expected network fee, which is expected to be taken as
-        /// additional sell amount.
-        pub network_fee: eth::U256,
-    }
-
-    #[serde_as]
-    #[derive(Debug, Clone, PartialEq, serde::Serialize)]
-    #[serde(rename_all = "camelCase", tag = "kind")]
-    pub enum Policy {
-        #[serde(rename_all = "camelCase")]
-        Surplus { factor: f64, max_volume_factor: f64 },
-        #[serde(rename_all = "camelCase")]
-        PriceImprovement {
-            factor: f64,
-            max_volume_factor: f64,
-            quote: Quote,
-        },
-        #[serde(rename_all = "camelCase")]
-        Volume { factor: f64 },
-    }
-
-    impl Policy {
-        pub fn to_json_value(&self) -> serde_json::Value {
-            match self {
-                Policy::Surplus {
-                    factor,
-                    max_volume_factor,
-                } => json!({
-                    "surplus": {
-                        "factor": factor,
-                        "maxVolumeFactor": max_volume_factor
-                    }
-                }),
-                Policy::PriceImprovement {
-                    factor,
-                    max_volume_factor,
-                    quote,
-                } => json!({
-                    "priceImprovement": {
-                        "factor": factor,
-                        "maxVolumeFactor": max_volume_factor,
-                        "quote": {
-                            "sellAmount": quote.sell,
-                            "buyAmount": quote.buy,
-                            "fee": quote.network_fee,
-                        }
-                    }
-                }),
-                Policy::Volume { factor } => json!({
-                    "volume": {
-                        "factor": factor
-                    }
-                }),
-            }
-        }
-    }
 }
 
 impl Default for Score {

--- a/crates/driver/src/tests/setup/mod.rs
+++ b/crates/driver/src/tests/setup/mod.rs
@@ -31,7 +31,6 @@ use {
     futures::future::join_all,
     hyper::StatusCode,
     secp256k1::SecretKey,
-    serde_json::json,
     serde_with::serde_as,
     std::{
         collections::{HashMap, HashSet},
@@ -73,63 +72,71 @@ pub enum Score {
     RiskAdjusted { success_probability: f64 },
 }
 
-#[serde_as]
-#[derive(Debug, Clone, PartialEq, serde::Serialize)]
-#[serde(rename_all = "camelCase", tag = "kind")]
-pub struct PriceImprovementQuote {
-    pub buy_amount: eth::U256,
-    pub sell_amount: eth::U256,
-    pub network_fee: eth::U256,
-}
+pub mod fee {
+    use {crate::domain::eth, serde_json::json, serde_with::serde_as};
 
-#[serde_as]
-#[derive(Debug, Clone, PartialEq, serde::Serialize)]
-#[serde(rename_all = "camelCase", tag = "kind")]
-pub enum FeePolicy {
-    #[serde(rename_all = "camelCase")]
-    Surplus { factor: f64, max_volume_factor: f64 },
-    #[serde(rename_all = "camelCase")]
-    PriceImprovement {
-        factor: f64,
-        max_volume_factor: f64,
-        quote: PriceImprovementQuote,
-    },
-    #[serde(rename_all = "camelCase")]
-    Volume { factor: f64 },
-}
+    #[serde_as]
+    #[derive(Debug, Clone, PartialEq, serde::Serialize)]
+    #[serde(rename_all = "camelCase", tag = "kind")]
+    pub struct Quote {
+        /// How much tokens the trader is expected to buy
+        pub buy: eth::U256,
+        /// How much tokens the user is expected to sell (excluding network fee)
+        pub sell: eth::U256,
+        /// The expected network fee, which is expected to be taken as
+        /// additional sell amount.
+        pub network_fee: eth::U256,
+    }
 
-impl FeePolicy {
-    pub fn to_json_value(&self) -> serde_json::Value {
-        match self {
-            FeePolicy::Surplus {
-                factor,
-                max_volume_factor,
-            } => json!({
-                "surplus": {
-                    "factor": factor,
-                    "maxVolumeFactor": max_volume_factor
-                }
-            }),
-            FeePolicy::PriceImprovement {
-                factor,
-                max_volume_factor,
-                quote,
-            } => json!({
-                "priceImprovement": {
-                    "factor": factor,
-                    "maxVolumeFactor": max_volume_factor,
-                    "quote": {
-                        "sellAmount": quote.sell_amount,
-                        "buyAmount": quote.buy_amount,
-                        "fee": quote.network_fee,
+    #[serde_as]
+    #[derive(Debug, Clone, PartialEq, serde::Serialize)]
+    #[serde(rename_all = "camelCase", tag = "kind")]
+    pub enum Policy {
+        #[serde(rename_all = "camelCase")]
+        Surplus { factor: f64, max_volume_factor: f64 },
+        #[serde(rename_all = "camelCase")]
+        PriceImprovement {
+            factor: f64,
+            max_volume_factor: f64,
+            quote: Quote,
+        },
+        #[serde(rename_all = "camelCase")]
+        Volume { factor: f64 },
+    }
+
+    impl Policy {
+        pub fn to_json_value(&self) -> serde_json::Value {
+            match self {
+                Policy::Surplus {
+                    factor,
+                    max_volume_factor,
+                } => json!({
+                    "surplus": {
+                        "factor": factor,
+                        "maxVolumeFactor": max_volume_factor
                     }
-                }
-            }),
-            FeePolicy::Volume { factor } => json!({
-                "volume": {
-                    "factor": factor
-                }
-            }),
+                }),
+                Policy::PriceImprovement {
+                    factor,
+                    max_volume_factor,
+                    quote,
+                } => json!({
+                    "priceImprovement": {
+                        "factor": factor,
+                        "maxVolumeFactor": max_volume_factor,
+                        "quote": {
+                            "sellAmount": quote.sell,
+                            "buyAmount": quote.buy,
+                            "fee": quote.network_fee,
+                        }
+                    }
+                }),
+                Policy::Volume { factor } => json!({
+                    "volume": {
+                        "factor": factor
+                    }
+                }),
+            }
         }
     }
 }
@@ -168,6 +175,9 @@ pub struct Order {
     pub name: &'static str,
 
     pub sell_amount: eth::U256,
+    /// The explicit limit buy amount for the order. If None, it will be derived
+    /// from the order's quote.
+    pub buy_amount: Option<eth::U256>,
     pub sell_token: &'static str,
     pub buy_token: &'static str,
 
@@ -196,7 +206,7 @@ pub struct Order {
     /// Should the trader account be funded with enough tokens to place this
     /// order? True by default.
     pub funded: bool,
-    pub fee_policy: FeePolicy,
+    pub fee_policy: fee::Policy,
 }
 
 impl Order {
@@ -286,15 +296,8 @@ impl Order {
         }
     }
 
-    pub fn fee_policy(self, fee_policy: FeePolicy) -> Self {
+    pub fn fee_policy(self, fee_policy: fee::Policy) -> Self {
         Self { fee_policy, ..self }
-    }
-
-    pub fn executed(self, executed_price: eth::U256) -> Self {
-        Self {
-            executed: Some(executed_price),
-            ..self
-        }
     }
 
     pub fn expected_amounts(self, expected_amounts: ExpectedOrderAmounts) -> Self {
@@ -311,6 +314,13 @@ impl Order {
         }
     }
 
+    pub fn buy_amount(self, buy_amount: eth::U256) -> Self {
+        Self {
+            buy_amount: Some(buy_amount),
+            ..self
+        }
+    }
+
     fn surplus_fee(&self) -> eth::U256 {
         match self.kind {
             order::Kind::Limit => self.solver_fee.unwrap_or_default(),
@@ -323,6 +333,7 @@ impl Default for Order {
     fn default() -> Self {
         Self {
             sell_amount: Default::default(),
+            buy_amount: None,
             sell_token: Default::default(),
             buy_token: Default::default(),
             internalize: Default::default(),
@@ -338,7 +349,7 @@ impl Default for Order {
             expected_amounts: Default::default(),
             filtered: Default::default(),
             funded: true,
-            fee_policy: FeePolicy::Surplus {
+            fee_policy: fee::Policy::Surplus {
                 factor: 0.0,
                 max_volume_factor: 0.06,
             },
@@ -831,7 +842,7 @@ impl Setup {
         }
         let mut quotes = Vec::new();
         for order in orders {
-            let quote = blockchain.quote(&order).await;
+            let quote = blockchain.quote(&order);
             quotes.push(quote);
         }
         let solvers_with_address = join_all(self.solvers.iter().map(|solver| async {

--- a/crates/driver/src/tests/setup/mod.rs
+++ b/crates/driver/src/tests/setup/mod.rs
@@ -76,9 +76,24 @@ pub enum Score {
 #[serde_as]
 #[derive(Debug, Clone, PartialEq, serde::Serialize)]
 #[serde(rename_all = "camelCase", tag = "kind")]
+pub struct PriceImprovementQuote {
+    pub buy_amount: eth::U256,
+    pub sell_amount: eth::U256,
+    pub fee: eth::U256,
+}
+
+#[serde_as]
+#[derive(Debug, Clone, PartialEq, serde::Serialize)]
+#[serde(rename_all = "camelCase", tag = "kind")]
 pub enum FeePolicy {
     #[serde(rename_all = "camelCase")]
     Surplus { factor: f64, max_volume_factor: f64 },
+    #[serde(rename_all = "camelCase")]
+    PriceImprovement {
+        factor: f64,
+        max_volume_factor: f64,
+        quote: PriceImprovementQuote,
+    },
     #[serde(rename_all = "camelCase")]
     Volume { factor: f64 },
 }
@@ -93,6 +108,21 @@ impl FeePolicy {
                 "surplus": {
                     "factor": factor,
                     "maxVolumeFactor": max_volume_factor
+                }
+            }),
+            FeePolicy::PriceImprovement {
+                factor,
+                max_volume_factor,
+                quote,
+            } => json!({
+                "priceImprovement": {
+                    "factor": factor,
+                    "maxVolumeFactor": max_volume_factor,
+                    "quote": {
+                        "sellAmount": quote.sell_amount,
+                        "buyAmount": quote.buy_amount,
+                        "fee": quote.fee,
+                    }
                 }
             }),
             FeePolicy::Volume { factor } => json!({

--- a/crates/driver/src/tests/setup/mod.rs
+++ b/crates/driver/src/tests/setup/mod.rs
@@ -79,7 +79,7 @@ pub enum Score {
 pub struct PriceImprovementQuote {
     pub buy_amount: eth::U256,
     pub sell_amount: eth::U256,
-    pub fee: eth::U256,
+    pub network_fee: eth::U256,
 }
 
 #[serde_as]
@@ -121,7 +121,7 @@ impl FeePolicy {
                     "quote": {
                         "sellAmount": quote.sell_amount,
                         "buyAmount": quote.buy_amount,
-                        "fee": quote.fee,
+                        "fee": quote.network_fee,
                     }
                 }
             }),

--- a/crates/driver/src/tests/setup/solver.rs
+++ b/crates/driver/src/tests/setup/solver.rs
@@ -110,13 +110,13 @@ impl Solver {
                     config
                         .blockchain
                         .get_token_wrapped(fulfillment.quoted_order.order.sell_token),
-                    fulfillment.quoted_order.buy.to_string(),
+                    fulfillment.execution.buy.to_string(),
                 );
                 prices_json.insert(
                     config
                         .blockchain
                         .get_token_wrapped(fulfillment.quoted_order.order.buy_token),
-                    (fulfillment.quoted_order.sell - fulfillment.quoted_order.order.surplus_fee())
+                    (fulfillment.execution.sell - fulfillment.quoted_order.order.surplus_fee())
                         .to_string(),
                 );
                 {
@@ -129,10 +129,10 @@ impl Solver {
                     let executed_amount = match fulfillment.quoted_order.order.executed {
                         Some(executed) => executed.to_string(),
                         None => match fulfillment.quoted_order.order.side {
-                            order::Side::Sell => (fulfillment.quoted_order.sell_amount()
+                            order::Side::Sell => (fulfillment.execution.sell
                                 - fulfillment.quoted_order.order.surplus_fee())
                             .to_string(),
-                            order::Side::Buy => fulfillment.quoted_order.buy_amount().to_string(),
+                            order::Side::Buy => fulfillment.execution.buy.to_string(),
                         },
                     };
                     let fee = fulfillment
@@ -169,7 +169,7 @@ impl Solver {
             .iter()
             .flat_map(|s| s.fulfillments.iter())
             .flat_map(|f| {
-                let quote = &f.quoted_order;
+                let quote = &f;
                 let build_token = |token_name: String| async move {
                     let token = config.blockchain.get_token_wrapped(token_name.as_str());
                     let contract = contracts::ERC20::at(&config.blockchain.web3, token);
@@ -188,8 +188,8 @@ impl Solver {
                     )
                 };
                 [
-                    build_token(quote.order.sell_token.to_string()),
-                    build_token(quote.order.buy_token.to_string()),
+                    build_token(quote.quoted_order.order.sell_token.to_string()),
+                    build_token(quote.quoted_order.order.buy_token.to_string()),
                 ]
             });
         let tokens_json = futures::future::join_all(build_tokens)


### PR DESCRIPTION
# Description
Proposal on how to improve the readability of #2467 

It only implements two surplus and one price improvement test case as an example, the others still need to be converted.

# Changes
- [x] Decouple `quoted_order` amounts from `execution` amounts. This makes it so that a test case can specify a concrete limit price (`QuotedOrders` currently always use the AMM to compute their buy amounts).
- [x] Implement `in_given_out` on pool to correctly compute the executed amounts for buy orders.
- [x] Remove unnecessary executed method (will likely need this one for partial fill tests)
- [x] Comment on why we expect the values we expect 
- [x] Small naming improvements so that the `TestCase` is easier to read

## How to test
Driver tests