### PR TITLE
[PoC] Working support for transfers (don't merge!)

### DIFF
--- a/crates/autopilot/src/solvable_orders.rs
+++ b/crates/autopilot/src/solvable_orders.rs
@@ -562,7 +562,10 @@ async fn filter_unsupported_tokens(
     // async. So either this manual iteration or conversion to stream.
     let mut index = 0;
     'outer: while index < orders.len() {
-        for token in orders[index].data.token_pair().unwrap() {
+        for &token in [orders[index].data.buy_token, orders[index].data.sell_token]
+            .iter()
+            .dedup()
+        {
             if !bad_token.detect(token).await?.is_good() {
                 orders.swap_remove(index);
                 continue 'outer;

--- a/crates/driver/src/domain/quote.rs
+++ b/crates/driver/src/domain/quote.rs
@@ -75,11 +75,17 @@ impl Order {
         liquidity: &infra::liquidity::Fetcher,
         tokens: &infra::tokens::Fetcher,
     ) -> Result<Quote, Error> {
+        let pairs = self.liquidity_pairs();
+
         let liquidity = match solver.liquidity() {
             solver::Liquidity::Fetch => {
-                liquidity
-                    .fetch(&self.liquidity_pairs(), infra::liquidity::AtBlock::Recent)
-                    .await
+                if pairs.is_none() {
+                    Default::default()
+                } else {
+                    liquidity
+                        .fetch(&pairs.unwrap(), infra::liquidity::AtBlock::Recent)
+                        .await
+                }
             }
             solver::Liquidity::Skip => Default::default(),
         };
@@ -204,10 +210,9 @@ impl Order {
     }
 
     /// Returns the token pairs to fetch liquidity for.
-    fn liquidity_pairs(&self) -> HashSet<liquidity::TokenPair> {
-        let pair = liquidity::TokenPair::new(self.tokens.sell(), self.tokens.buy())
-            .expect("sell != buy by construction");
-        iter::once(pair).collect()
+    fn liquidity_pairs(&self) -> Option<HashSet<liquidity::TokenPair>> {
+        let pair = liquidity::TokenPair::new(self.tokens.sell(), self.tokens.buy()).ok()?;
+        Some(iter::once(pair).collect())
     }
 }
 
@@ -222,11 +227,8 @@ pub struct Tokens {
 impl Tokens {
     /// Creates a new instance of [`Tokens`], verifying that the input buy and
     /// sell tokens are distinct.
-    pub fn new(sell: eth::TokenAddress, buy: eth::TokenAddress) -> Result<Self, SameTokens> {
-        if sell == buy {
-            return Err(SameTokens);
-        }
-        Ok(Self { sell, buy })
+    pub fn new(sell: eth::TokenAddress, buy: eth::TokenAddress) -> Self {
+        Self { sell, buy }
     }
 
     pub fn sell(&self) -> eth::TokenAddress {

--- a/crates/driver/src/infra/api/routes/quote/dto/order.rs
+++ b/crates/driver/src/infra/api/routes/quote/dto/order.rs
@@ -9,17 +9,16 @@ use {
 };
 
 impl Order {
-    pub fn into_domain(self, timeouts: Timeouts) -> Result<quote::Order, Error> {
-        Ok(quote::Order {
-            tokens: quote::Tokens::new(self.sell_token.into(), self.buy_token.into())
-                .map_err(|quote::SameTokens| Error::SameTokens)?,
+    pub fn into_domain(self, timeouts: Timeouts) -> quote::Order {
+        quote::Order {
+            tokens: quote::Tokens::new(self.sell_token.into(), self.buy_token.into()),
             amount: self.amount.into(),
             side: match self.kind {
                 Kind::Sell => competition::order::Side::Sell,
                 Kind::Buy => competition::order::Side::Buy,
             },
             deadline: time::Deadline::new(self.deadline, timeouts),
-        })
+        }
     }
 }
 

--- a/crates/driver/src/infra/api/routes/quote/mod.rs
+++ b/crates/driver/src/infra/api/routes/quote/mod.rs
@@ -3,7 +3,6 @@ use {
         api::{Error, State},
         observe,
     },
-    tap::TapFallible,
     tracing::Instrument,
 };
 
@@ -20,9 +19,7 @@ async fn route(
     order: axum::extract::Query<dto::Order>,
 ) -> Result<axum::Json<dto::Quote>, (hyper::StatusCode, axum::Json<Error>)> {
     let handle_request = async {
-        let order = order.0.into_domain(state.timeouts()).tap_err(|err| {
-            observe::invalid_dto(err, "order");
-        })?;
+        let order = order.0.into_domain(state.timeouts());
         observe::quoting(&order);
         let quote = order
             .quote(

--- a/crates/orderbook/openapi.yml
+++ b/crates/orderbook/openapi.yml
@@ -1193,7 +1193,6 @@ components:
               InsufficientValidTo,
               ExcessiveValidTo,
               InvalidNativeSellToken,
-              SameBuyAndSellToken,
               UnsupportedToken,
               InvalidAppData,
               AppDataHashMismatch,

--- a/crates/orderbook/src/api/post_order.rs
+++ b/crates/orderbook/src/api/post_order.rs
@@ -72,13 +72,6 @@ impl IntoWarpReply for PartialValidationErrorWrapper {
                 ),
                 StatusCode::BAD_REQUEST,
             ),
-            PartialValidationError::SameBuyAndSellToken => with_status(
-                error(
-                    "SameBuyAndSellToken",
-                    "Buy token is the same as the sell token.",
-                ),
-                StatusCode::BAD_REQUEST,
-            ),
             PartialValidationError::UnsupportedToken { token, reason } => with_status(
                 error(
                     "UnsupportedToken",

--- a/crates/shared/src/price_estimation/baseline.rs
+++ b/crates/shared/src/price_estimation/baseline.rs
@@ -298,7 +298,7 @@ fn pools_vec_to_map(pools: Vec<Pool>) -> Pools {
 fn estimate_gas(path_len: usize) -> u64 {
     let hops = match path_len.checked_sub(1) {
         Some(len) => len,
-        None => return 0,
+        None => 0,
     };
     // Can be reduced to one erc20 transfer when #675 is fixed.
     let per_hop = gas::ERC20_TRANSFER * 2 + 40_000;

--- a/crates/shared/src/price_estimation/sanitized.rs
+++ b/crates/shared/src/price_estimation/sanitized.rs
@@ -61,16 +61,16 @@ impl PriceEstimating for SanitizedPriceEstimator {
             self.handle_bad_tokens(&query).await?;
 
             // buy_token == sell_token => 1 to 1 conversion
-            if query.buy_token == query.sell_token {
-                let estimation = Estimate {
-                    out_amount: query.in_amount.get(),
-                    gas: 0,
-                    solver: Default::default(),
-                    verified: true,
-                };
-                tracing::debug!(?query, ?estimation, "generate trivial price estimation");
-                return Ok(estimation);
-            }
+            //if query.buy_token == query.sell_token {
+            //    let estimation = Estimate {
+            //        out_amount: query.in_amount.get(),
+            //        gas: 0,
+            //        solver: Default::default(),
+            //        verified: true,
+            //    };
+            //    tracing::debug!(?query, ?estimation, "generate trivial price estimation");
+            //    return Ok(estimation);
+            //}
 
             // sell WETH for ETH => 1 to 1 conversion with cost for unwrapping
             if query.sell_token == self.native_token && query.buy_token == BUY_ETH_ADDRESS {

--- a/crates/solvers/src/boundary/baseline.rs
+++ b/crates/solvers/src/boundary/baseline.rs
@@ -38,6 +38,9 @@ impl<'a> Solver<'a> {
         request: baseline::Request,
         max_hops: usize,
     ) -> Option<baseline::Route<'a>> {
+        if request.sell.token == request.buy.token {
+            return Some(baseline::Route::new(vec![]));
+        }
         let candidates = self.base_tokens.path_candidates_with_hops(
             request.sell.token.0,
             request.buy.token.0,
@@ -95,7 +98,7 @@ impl<'a> Solver<'a> {
                 .max_by_key(|(_, buy)| buy.value)?,
         };
 
-        baseline::Route::new(segments)
+        Some(baseline::Route::new(segments))
     }
 
     fn traverse_path(

--- a/playground/driver.toml
+++ b/playground/driver.toml
@@ -6,8 +6,8 @@ relative-slippage = "0.1" # Percentage in the [0, 1] range
 account = "0x2a871d0798f97d79848a013d4936a73bf4cc922c825d33c1cf7073dff6d409c6" # Known test private key
 
 [submission]
-gas-price-cap = 1e12
-additional-tip-percentage = 0.05
+gas-price-cap = "1000000000000"
+#additional-tip-percentage = 0.05
 
 [[submission.mempool]]
 mempool = "public"


### PR DESCRIPTION
# Description
Just a draft PR with all experimental changes to make same-token orders work, built with the valuable help of @harisang and @fhenneke.

A local forked-node setup on mainnet with the baseline solver:
- Returns quotes for same-token orders with reasonable fee.
- Allows creating orders with same buy and sell token.
- Fills orders if the specified fee amount is that returned by the quote. The filled fee is consistent with the current gas price.

Note that the code is very horrible and any change is just there to make things work.
There are many things that should be carefully considered in an actual PR for this feature, notably `PriceEstimating::estimate` should probably split into two functions based on the purpose of the price estimation.


