### PR TITLE
Add log for fetched events

### DIFF
--- a/crates/shared/src/event_handling.rs
+++ b/crates/shared/src/event_handling.rs
@@ -387,11 +387,13 @@ where
             {
                 match result {
                     Ok(e) => {
-                        tracing::debug!(
-                            "events fetched for block: {:?}, events: {}",
-                            blocks[i],
-                            e.len(),
-                        );
+                        if !e.is_empty() {
+                            tracing::debug!(
+                                "events fetched for block: {:?}, events: {}",
+                                blocks[i],
+                                e.len(),
+                            );
+                        }
                         blocks_filtered.push(blocks[i]);
                         events.extend(e);
                     }

--- a/crates/shared/src/event_handling.rs
+++ b/crates/shared/src/event_handling.rs
@@ -387,6 +387,11 @@ where
             {
                 match result {
                     Ok(e) => {
+                        tracing::debug!(
+                            "events fetched for block: {:?}, events: {}",
+                            blocks[i],
+                            e.len(),
+                        );
                         blocks_filtered.push(blocks[i]);
                         events.extend(e);
                     }


### PR DESCRIPTION
# Description

Related to oncall issue where our system failed to index some settlements/trades. The only reason I could think of at the moment is that it was some intermittent issue with the node which answered with empty Vec of events. All other error execution paths are already covered in the code.