### PR TITLE
Rank by surplus price improvement

### DIFF
--- a/crates/driver/src/domain/competition/mod.rs
+++ b/crates/driver/src/domain/competition/mod.rs
@@ -366,6 +366,11 @@ pub struct Amounts {
     pub buy: eth::TokenAmount,
 }
 
+pub struct PriceLimits {
+    pub sell: eth::TokenAmount,
+    pub buy: eth::TokenAmount,
+}
+
 /// Winning solution information revealed to the protocol by the driver before
 /// the onchain settlement happens. Calldata is first time revealed at this
 /// point.

--- a/crates/driver/src/domain/competition/solution/fee.rs
+++ b/crates/driver/src/domain/competition/solution/fee.rs
@@ -204,7 +204,7 @@ impl Fulfillment {
 /// - test_adjust_quote_to_out_market_buy_order_limits
 /// - test_adjust_quote_to_in_market_sell_order_limits
 /// - test_adjust_quote_to_in_market_buy_order_limits
-fn adjust_quote_to_order_limits(
+pub fn adjust_quote_to_order_limits(
     order_sell_amount: eth::U256,
     order_buy_amount: eth::U256,
     order_side: Side,

--- a/crates/driver/src/domain/competition/solution/fee.rs
+++ b/crates/driver/src/domain/competition/solution/fee.rs
@@ -211,7 +211,7 @@ pub fn adjust_quote_to_order_limits(
     quote_sell_amount: eth::U256,
     quote_buy_amount: eth::U256,
     quote_fee_amount: eth::U256,
-) -> Result<(eth::U256, eth::U256), Error> {
+) -> Result<(eth::U256, eth::U256), Math> {
     let quote_sell_amount = quote_sell_amount
         .checked_add(quote_fee_amount)
         .ok_or(Math::Overflow)?;

--- a/crates/driver/src/domain/competition/solution/scoring.rs
+++ b/crates/driver/src/domain/competition/solution/scoring.rs
@@ -81,14 +81,6 @@ impl Trade {
     ///
     /// Denominated in NATIVE token
     fn score(&self, prices: &auction::Prices) -> Result<eth::Ether, Error> {
-        tracing::info!(
-            "newlog self.native_surplus(prices)={:?}",
-            self.native_surplus(prices)
-        );
-        tracing::info!(
-            "newlog self.native_protocol_fee(prices)={:?}",
-            self.native_protocol_fee(prices)
-        );
         Ok(self.native_surplus(prices)? + self.native_protocol_fee(prices)?)
     }
 
@@ -164,7 +156,6 @@ impl Trade {
         let surplus = self
             .surplus_over_limit_price(limit_sell_amount, limit_buy_amount)
             .ok_or(Error::Surplus(self.sell, self.buy))?;
-        tracing::info!("newlog surplus={:?}", surplus);
         let price = prices
             .get(&surplus.token)
             .ok_or(Error::MissingPrice(surplus.token))?;

--- a/crates/driver/src/domain/competition/solution/scoring.rs
+++ b/crates/driver/src/domain/competition/solution/scoring.rs
@@ -4,7 +4,10 @@ use {
         order::{self, Side},
     },
     crate::domain::{
-        competition::{auction, solution::fee::adjust_quote_to_order_limits},
+        competition::{
+            auction,
+            solution::{fee, fee::adjust_quote_to_order_limits},
+        },
         eth::{self, TokenAmount},
     },
 };
@@ -135,12 +138,16 @@ impl Trade {
                 max_volume_factor: _,
                 quote,
             }) => adjust_quote_to_order_limits(
-                self.sell.amount.0,
-                self.buy.amount.0,
-                self.side,
-                quote.sell.amount.0,
-                quote.buy.amount.0,
-                quote.fee.amount.0,
+                fee::Order {
+                    sell_amount: self.sell.amount.0,
+                    buy_amount: self.buy.amount.0,
+                    side: self.side,
+                },
+                fee::Quote {
+                    sell_amount: quote.sell.amount.0,
+                    buy_amount: quote.buy.amount.0,
+                    fee_amount: quote.fee.amount.0,
+                },
             )
             .map_err(|e| e.into()),
             _ => Ok((self.sell.amount.0, self.buy.amount.0)),

--- a/crates/driver/src/domain/competition/solution/scoring.rs
+++ b/crates/driver/src/domain/competition/solution/scoring.rs
@@ -81,6 +81,14 @@ impl Trade {
     ///
     /// Denominated in NATIVE token
     fn score(&self, prices: &auction::Prices) -> Result<eth::Ether, Error> {
+        tracing::info!(
+            "newlog self.native_surplus(prices)={:?}",
+            self.native_surplus(prices)
+        );
+        tracing::info!(
+            "newlog self.native_protocol_fee(prices)={:?}",
+            self.native_protocol_fee(prices)
+        );
         Ok(self.native_surplus(prices)? + self.native_protocol_fee(prices)?)
     }
 
@@ -140,6 +148,7 @@ impl Trade {
     /// Denominated in NATIVE token
     fn native_surplus(&self, prices: &auction::Prices) -> Result<eth::Ether, Error> {
         let surplus = self.surplus().ok_or(Error::Surplus(self.sell, self.buy))?;
+        tracing::info!("newlog surplus={:?}", surplus);
         let price = prices
             .get(&surplus.token)
             .ok_or(Error::MissingPrice(surplus.token))?;

--- a/crates/driver/src/domain/competition/solution/scoring.rs
+++ b/crates/driver/src/domain/competition/solution/scoring.rs
@@ -143,30 +143,12 @@ impl Trade {
     ///
     /// Denominated in NATIVE token
     fn native_surplus(&self, prices: &auction::Prices) -> Result<eth::Ether, Error> {
-        let limit = match self.policies.first() {
-            Some(order::FeePolicy::PriceImprovement {
-                factor: _,
-                max_volume_factor: _,
-                quote,
-            }) => adjust_quote_to_order_limits(
-                fee::Order {
-                    sell_amount: self.sell.amount.0,
-                    buy_amount: self.buy.amount.0,
-                    side: self.side,
-                },
-                fee::Quote {
-                    sell_amount: quote.sell.amount.0,
-                    buy_amount: quote.buy.amount.0,
-                    fee_amount: quote.fee.amount.0,
-                },
-            )?,
-            _ => PriceLimits {
-                sell: self.sell.amount,
-                buy: self.buy.amount,
-            },
+        let price_limits = PriceLimits {
+            sell: self.sell.amount,
+            buy: self.buy.amount,
         };
         let surplus = self
-            .surplus(limit)
+            .surplus(price_limits)
             .ok_or(Error::Surplus(self.sell, self.buy))?;
         let price = prices
             .get(&surplus.token)

--- a/crates/driver/src/domain/competition/solution/scoring.rs
+++ b/crates/driver/src/domain/competition/solution/scoring.rs
@@ -97,7 +97,7 @@ impl Trade {
     }
 
     /// Surplus based on custom clearing prices returns the surplus after all
-    /// fees have been applied.
+    /// fees have been applied and calculated over the price limits.
     ///
     /// Denominated in SURPLUS token
     fn surplus(&self, price_limits: PriceLimits) -> Option<eth::Asset> {

--- a/crates/driver/src/domain/competition/solution/scoring.rs
+++ b/crates/driver/src/domain/competition/solution/scoring.rs
@@ -17,7 +17,7 @@ use {
             solution::{fee, fee::adjust_quote_to_order_limits},
             Amounts,
         },
-        eth::{self, TokenAmount},
+        eth::{self},
     },
 };
 
@@ -193,10 +193,11 @@ impl Trade {
                     sell: self.sell.amount,
                     buy: self.buy.amount,
                 };
-                Ok(std::cmp::min(
-                    self.surplus_fee(limit, factor)?.amount,
-                    self.volume_fee(max_volume_factor)?.amount,
-                ))
+                let fee = std::cmp::min(
+                    self.surplus_fee(limit, *factor)?.amount,
+                    self.volume_fee(*max_volume_factor)?.amount,
+                );
+                Ok::<eth::TokenAmount, Error>(fee)
             }
             order::FeePolicy::PriceImprovement {
                 factor,
@@ -215,10 +216,11 @@ impl Trade {
                         fee_amount: quote.fee.amount.0,
                     },
                 )?;
-                Ok(std::cmp::min(
-                    self.surplus_fee(limit, factor)?.amount,
-                    self.volume_fee(max_volume_factor)?.amount,
-                ))
+                let fee = std::cmp::min(
+                    self.surplus_fee(limit, *factor)?.amount,
+                    self.volume_fee(*max_volume_factor)?.amount,
+                );
+                Ok(fee)
             }
             order::FeePolicy::Volume { factor } => Ok(self.volume_fee(*factor)?.amount),
         };
@@ -309,7 +311,7 @@ impl Trade {
                 .checked_div(self.custom_price.sell)
                 .ok_or(Math::DivisionByZero)?,
         }
-            .into();
+        .into();
         let factor = match self.side {
             Side::Sell => factor / (1.0 - factor),
             Side::Buy => factor / (1.0 + factor),

--- a/crates/driver/src/tests/cases/protocol_fees.rs
+++ b/crates/driver/src/tests/cases/protocol_fees.rs
@@ -86,7 +86,7 @@ async fn protocol_fee_test_case(test_case: TestCase) {
 #[ignore]
 async fn surplus_protocol_fee_buy_order_not_capped() {
     let fee_policy = Policy::Surplus {
-        factor: 0.5,
+        factor: 0.2,
         // high enough so we don't get capped by volume fee
         max_volume_factor: 1.0,
     };
@@ -98,14 +98,14 @@ async fn surplus_protocol_fee_buy_order_not_capped() {
             side: order::Side::Buy,
         },
         execution: Execution {
-            // 20 ETH surplus in sell token (after network fee), half of which is kept by the
+            // 10 ETH surplus in sell token (after network fee), half of which is kept by the
             // protocol
             solver: Amounts {
-                sell: 30.ether().into_wei(),
+                sell: 40.ether().into_wei(),
                 buy: 40.ether().into_wei(),
             },
             driver: Amounts {
-                sell: 40.ether().into_wei(),
+                sell: 42.ether().into_wei(),
                 buy: 40.ether().into_wei(),
             },
         },
@@ -118,7 +118,7 @@ async fn surplus_protocol_fee_buy_order_not_capped() {
 #[ignore]
 async fn surplus_protocol_fee_sell_order_not_capped() {
     let fee_policy = Policy::Surplus {
-        factor: 0.5,
+        factor: 0.4,
         // high enough so we don't get capped by volume fee
         max_volume_factor: 1.0,
     };
@@ -130,14 +130,14 @@ async fn surplus_protocol_fee_sell_order_not_capped() {
             side: order::Side::Sell,
         },
         execution: Execution {
-            // 20 ETH surplus, half of which gets captured by the protocol
+            // 10 ETH surplus, half of which gets captured by the protocol
             solver: Amounts {
                 sell: 50.ether().into_wei(),
-                buy: 60.ether().into_wei(),
+                buy: 50.ether().into_wei(),
             },
             driver: Amounts {
                 sell: 50.ether().into_wei(),
-                buy: 50.ether().into_wei(),
+                buy: 46.ether().into_wei(),
             },
         },
     };
@@ -262,7 +262,7 @@ async fn volume_protocol_fee_sell_order() {
 #[ignore]
 async fn price_improvement_fee_buy_in_market_order_not_capped() {
     let fee_policy = Policy::PriceImprovement {
-        factor: 0.5,
+        factor: 0.2,
         // high enough so we don't get capped by volume fee
         max_volume_factor: 1.0,
         quote: Quote {
@@ -286,7 +286,7 @@ async fn price_improvement_fee_buy_in_market_order_not_capped() {
                 buy: 40.ether().into_wei(),
             },
             driver: Amounts {
-                sell: 45.ether().into_wei(),
+                sell: 42.ether().into_wei(),
                 buy: 40.ether().into_wei(),
             },
         },
@@ -299,12 +299,12 @@ async fn price_improvement_fee_buy_in_market_order_not_capped() {
 #[ignore]
 async fn price_improvement_fee_sell_in_market_order_not_capped() {
     let fee_policy = Policy::PriceImprovement {
-        factor: 0.5,
+        factor: 0.4,
         // high enough so we don't get capped by volume fee
         max_volume_factor: 1.0,
         quote: Quote {
             sell: 49.ether().into_wei(),
-            buy: 50.ether().into_wei(),
+            buy: 40.ether().into_wei(),
             network_fee: 1.ether().into_wei(),
         },
     };
@@ -313,18 +313,18 @@ async fn price_improvement_fee_sell_in_market_order_not_capped() {
         order: Order {
             sell_amount: 50.ether().into_wei(),
             // Demanding to receive less than quoted (in-market)
-            buy_amount: 40.ether().into_wei(),
+            buy_amount: 30.ether().into_wei(),
             side: order::Side::Sell,
         },
         execution: Execution {
             // Receive 10 ETH more than quoted, half of which gets captured by the protocol
             solver: Amounts {
                 sell: 50.ether().into_wei(),
-                buy: 60.ether().into_wei(),
+                buy: 50.ether().into_wei(),
             },
             driver: Amounts {
                 sell: 50.ether().into_wei(),
-                buy: 55.ether().into_wei(),
+                buy: 46.ether().into_wei(),
             },
         },
     };

--- a/crates/driver/src/tests/cases/protocol_fees.rs
+++ b/crates/driver/src/tests/cases/protocol_fees.rs
@@ -86,7 +86,7 @@ async fn protocol_fee_test_case(test_case: TestCase) {
 #[ignore]
 async fn surplus_protocol_fee_buy_order_not_capped() {
     let fee_policy = Policy::Surplus {
-        factor: 0.2,
+        factor: 0.5,
         // high enough so we don't get capped by volume fee
         max_volume_factor: 1.0,
     };
@@ -98,14 +98,14 @@ async fn surplus_protocol_fee_buy_order_not_capped() {
             side: order::Side::Buy,
         },
         execution: Execution {
-            // 10 ETH surplus in sell token (after network fee), half of which is kept by the
+            // 20 ETH surplus in sell token (after network fee), half of which is kept by the
             // protocol
             solver: Amounts {
-                sell: 40.ether().into_wei(),
+                sell: 30.ether().into_wei(),
                 buy: 40.ether().into_wei(),
             },
             driver: Amounts {
-                sell: 42.ether().into_wei(),
+                sell: 40.ether().into_wei(),
                 buy: 40.ether().into_wei(),
             },
         },
@@ -118,7 +118,7 @@ async fn surplus_protocol_fee_buy_order_not_capped() {
 #[ignore]
 async fn surplus_protocol_fee_sell_order_not_capped() {
     let fee_policy = Policy::Surplus {
-        factor: 0.4,
+        factor: 0.5,
         // high enough so we don't get capped by volume fee
         max_volume_factor: 1.0,
     };
@@ -130,14 +130,14 @@ async fn surplus_protocol_fee_sell_order_not_capped() {
             side: order::Side::Sell,
         },
         execution: Execution {
-            // 10 ETH surplus, half of which gets captured by the protocol
+            // 20 ETH surplus, half of which gets captured by the protocol
             solver: Amounts {
                 sell: 50.ether().into_wei(),
-                buy: 50.ether().into_wei(),
+                buy: 60.ether().into_wei(),
             },
             driver: Amounts {
                 sell: 50.ether().into_wei(),
-                buy: 46.ether().into_wei(),
+                buy: 50.ether().into_wei(),
             },
         },
     };
@@ -262,7 +262,7 @@ async fn volume_protocol_fee_sell_order() {
 #[ignore]
 async fn price_improvement_fee_buy_in_market_order_not_capped() {
     let fee_policy = Policy::PriceImprovement {
-        factor: 0.2,
+        factor: 0.5,
         // high enough so we don't get capped by volume fee
         max_volume_factor: 1.0,
         quote: Quote {
@@ -286,7 +286,7 @@ async fn price_improvement_fee_buy_in_market_order_not_capped() {
                 buy: 40.ether().into_wei(),
             },
             driver: Amounts {
-                sell: 42.ether().into_wei(),
+                sell: 45.ether().into_wei(),
                 buy: 40.ether().into_wei(),
             },
         },
@@ -299,12 +299,12 @@ async fn price_improvement_fee_buy_in_market_order_not_capped() {
 #[ignore]
 async fn price_improvement_fee_sell_in_market_order_not_capped() {
     let fee_policy = Policy::PriceImprovement {
-        factor: 0.4,
+        factor: 0.5,
         // high enough so we don't get capped by volume fee
         max_volume_factor: 1.0,
         quote: Quote {
             sell: 49.ether().into_wei(),
-            buy: 40.ether().into_wei(),
+            buy: 50.ether().into_wei(),
             network_fee: 1.ether().into_wei(),
         },
     };
@@ -313,18 +313,18 @@ async fn price_improvement_fee_sell_in_market_order_not_capped() {
         order: Order {
             sell_amount: 50.ether().into_wei(),
             // Demanding to receive less than quoted (in-market)
-            buy_amount: 30.ether().into_wei(),
+            buy_amount: 40.ether().into_wei(),
             side: order::Side::Sell,
         },
         execution: Execution {
             // Receive 10 ETH more than quoted, half of which gets captured by the protocol
             solver: Amounts {
                 sell: 50.ether().into_wei(),
-                buy: 50.ether().into_wei(),
+                buy: 60.ether().into_wei(),
             },
             driver: Amounts {
                 sell: 50.ether().into_wei(),
-                buy: 46.ether().into_wei(),
+                buy: 55.ether().into_wei(),
             },
         },
     };


### PR DESCRIPTION
# Description
Rank by surplus implementation for the Price Improvement fee policy.

# Changes
To properly calculate both `native_surplus ` and `native_protocol_fee`, the `surplus` function was refactored into `surplus_over_limit_price` where limit sel/buy amounts should be provided explicitly. 
`fee::adjust_quote_to_order_limits` function is used to adjust the limit amounts in case of the Price Improvement fee policy.

# Current limitations

Either my understanding is incorrect or `fee_from_volume` function doesn't work correctly for the `max_volume_factor=1.0`. For the sell order kind, it returns `inf` and for the buy, the factor is adjusted into `0.5`, which is not really expected.

## How to test
I tested it by adding some logs and running protocol fee driver tests.

## Related Issues

Fixes #2466