### PR TITLE
Update Solver/driver api

### DIFF
--- a/crates/driver/openapi.yml
+++ b/crates/driver/openapi.yml
@@ -154,7 +154,7 @@ components:
           $ref: "#/components/schemas/Address"
         value:
           $ref: "#/components/schemas/TokenAmount"
-        calldata:
+        callData:
           description: Hex encoded bytes with `0x` prefix.
           type: string
     Token:


### PR DESCRIPTION
It seems there is a typo in the specification of the new solver/driver api. For custom interactions, I believe the driver is expecting an entry that is `callData` while in the api description we write `calldata`. This has already caused errors with some solver migrating to the new api.

Not sure if this is the only change that is needed so would appreciate some reviews.