### PR TITLE
[EASY] Separate log for disabled mempool

### DIFF
--- a/crates/driver/src/infra/observe/mod.rs
+++ b/crates/driver/src/infra/observe/mod.rs
@@ -325,6 +325,12 @@ pub fn mempool_executed(
                 "sending transaction via mempool succeeded",
             );
         }
+        Err(mempools::Error::Disabled) => {
+            tracing::debug!(
+                %mempool,
+                "sending transaction via mempool disabled",
+            );
+        }
         Err(err) => {
             tracing::warn!(
                 ?err,


### PR DESCRIPTION
# Description
A separate log for when the mempool is disabled is nice to have - to avoid printing WARN log and the whole settlement data, and since it's not an actual error.