### PR TITLE
Optional gas estimate on solution

### DIFF
--- a/crates/autopilot/src/infra/solvers/dto/solve.rs
+++ b/crates/autopilot/src/infra/solvers/dto/solve.rs
@@ -103,6 +103,7 @@ pub struct Solution {
     pub orders: HashMap<boundary::OrderUid, TradedAmounts>,
     #[serde_as(as = "HashMap<_, HexOrDecimalU256>")]
     pub clearing_prices: HashMap<H160, U256>,
+    pub gas_used: Option<u64>,
 }
 
 #[derive(Clone, Debug, Default, Deserialize)]

--- a/crates/autopilot/src/infra/solvers/dto/solve.rs
+++ b/crates/autopilot/src/infra/solvers/dto/solve.rs
@@ -103,7 +103,7 @@ pub struct Solution {
     pub orders: HashMap<boundary::OrderUid, TradedAmounts>,
     #[serde_as(as = "HashMap<_, HexOrDecimalU256>")]
     pub clearing_prices: HashMap<H160, U256>,
-    pub gas_used: Option<u64>,
+    pub gas: Option<u64>,
 }
 
 #[derive(Clone, Debug, Default, Deserialize)]

--- a/crates/driver/openapi.yml
+++ b/crates/driver/openapi.yml
@@ -382,9 +382,6 @@ components:
             type: object
             additionalProperties:
               $ref: "#/components/schemas/BigUint"
-          gas:
-            type: integer
-            description: How many units of gas this solution is estimated to cost.
     Solution:
       description: Request to the settle and reveal endpoint.
       type: object

--- a/crates/driver/openapi.yml
+++ b/crates/driver/openapi.yml
@@ -292,6 +292,9 @@ components:
             solver:
               description: The address of the solver that quoted this order.
               $ref: "#/components/schemas/Address"
+            gasUsed:
+              type: integer
+              description: How many units of gas this trade is estimated to cost.
         - $ref: "#/components/schemas/Error"
     DateTime:
       description: An ISO 8601 UTC date time string.
@@ -379,6 +382,9 @@ components:
             type: object
             additionalProperties:
               $ref: "#/components/schemas/BigUint"
+          gasUsed:
+            type: integer
+            description: How many units of gas this solution is estimated to cost.
     Solution:
       description: Request to the settle and reveal endpoint.
       type: object

--- a/crates/driver/openapi.yml
+++ b/crates/driver/openapi.yml
@@ -292,7 +292,7 @@ components:
             solver:
               description: The address of the solver that quoted this order.
               $ref: "#/components/schemas/Address"
-            gasUsed:
+            gas:
               type: integer
               description: How many units of gas this trade is estimated to cost.
         - $ref: "#/components/schemas/Error"
@@ -382,7 +382,7 @@ components:
             type: object
             additionalProperties:
               $ref: "#/components/schemas/BigUint"
-          gasUsed:
+          gas:
             type: integer
             description: How many units of gas this solution is estimated to cost.
     Solution:

--- a/crates/driver/src/domain/competition/mod.rs
+++ b/crates/driver/src/domain/competition/mod.rs
@@ -181,6 +181,7 @@ impl Competition {
                         score,
                         trades: settlement.orders(),
                         prices: settlement.prices(),
+                        gas_used: Some(settlement.gas.estimate),
                     },
                     settlement,
                 )
@@ -358,6 +359,7 @@ pub struct Solved {
     pub score: Score,
     pub trades: HashMap<order::Uid, Amounts>,
     pub prices: HashMap<eth::TokenAddress, eth::TokenAmount>,
+    pub gas_used: Option<eth::Gas>,
 }
 
 #[derive(Debug, Default)]

--- a/crates/driver/src/domain/competition/mod.rs
+++ b/crates/driver/src/domain/competition/mod.rs
@@ -181,7 +181,7 @@ impl Competition {
                         score,
                         trades: settlement.orders(),
                         prices: settlement.prices(),
-                        gas_used: Some(settlement.gas.estimate),
+                        gas: Some(settlement.gas.estimate),
                     },
                     settlement,
                 )
@@ -359,7 +359,7 @@ pub struct Solved {
     pub score: Score,
     pub trades: HashMap<order::Uid, Amounts>,
     pub prices: HashMap<eth::TokenAddress, eth::TokenAmount>,
-    pub gas_used: Option<eth::Gas>,
+    pub gas: Option<eth::Gas>,
 }
 
 #[derive(Debug, Default)]

--- a/crates/driver/src/domain/competition/solution/mod.rs
+++ b/crates/driver/src/domain/competition/solution/mod.rs
@@ -42,7 +42,7 @@ pub struct Solution {
     solver: Solver,
     score: SolverScore,
     weth: eth::WethAddress,
-    gas_used: Option<eth::Gas>,
+    gas: Option<eth::Gas>,
 }
 
 impl Solution {
@@ -55,7 +55,7 @@ impl Solution {
         solver: Solver,
         score: SolverScore,
         weth: eth::WethAddress,
-        gas_used: Option<eth::Gas>,
+        gas: Option<eth::Gas>,
     ) -> Result<Self, error::Solution> {
         let solution = Self {
             id,
@@ -65,7 +65,7 @@ impl Solution {
             solver,
             score,
             weth,
-            gas_used,
+            gas,
         };
 
         // Check that the solution includes clearing prices for all user trades.
@@ -125,8 +125,8 @@ impl Solution {
         &self.score
     }
 
-    pub fn gas_used(&self) -> Option<eth::Gas> {
-        self.gas_used
+    pub fn gas(&self) -> Option<eth::Gas> {
+        self.gas
     }
 
     /// JIT score calculation as per CIP38

--- a/crates/driver/src/domain/competition/solution/mod.rs
+++ b/crates/driver/src/domain/competition/solution/mod.rs
@@ -42,9 +42,11 @@ pub struct Solution {
     solver: Solver,
     score: SolverScore,
     weth: eth::WethAddress,
+    gas_used: Option<eth::Gas>,
 }
 
 impl Solution {
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         id: Id,
         trades: Vec<Trade>,
@@ -53,6 +55,7 @@ impl Solution {
         solver: Solver,
         score: SolverScore,
         weth: eth::WethAddress,
+        gas_used: Option<eth::Gas>,
     ) -> Result<Self, error::Solution> {
         let solution = Self {
             id,
@@ -62,6 +65,7 @@ impl Solution {
             solver,
             score,
             weth,
+            gas_used,
         };
 
         // Check that the solution includes clearing prices for all user trades.
@@ -119,6 +123,10 @@ impl Solution {
 
     pub fn score(&self) -> &SolverScore {
         &self.score
+    }
+
+    pub fn gas_used(&self) -> Option<eth::Gas> {
+        self.gas_used
     }
 
     /// JIT score calculation as per CIP38

--- a/crates/driver/src/domain/quote.rs
+++ b/crates/driver/src/domain/quote.rs
@@ -26,7 +26,7 @@ pub struct Quote {
     pub amount: eth::U256,
     pub interactions: Vec<eth::Interaction>,
     pub solver: eth::Address,
-    pub gas_used: Option<eth::Gas>,
+    pub gas: Option<eth::Gas>,
 }
 
 impl Quote {
@@ -51,7 +51,7 @@ impl Quote {
             amount,
             interactions: boundary::quote::encode_interactions(eth, solution.interactions())?,
             solver: solution.solver().address(),
-            gas_used: solution.gas_used(),
+            gas: solution.gas(),
         })
     }
 }

--- a/crates/driver/src/domain/quote.rs
+++ b/crates/driver/src/domain/quote.rs
@@ -26,6 +26,7 @@ pub struct Quote {
     pub amount: eth::U256,
     pub interactions: Vec<eth::Interaction>,
     pub solver: eth::Address,
+    pub gas_used: Option<eth::Gas>,
 }
 
 impl Quote {
@@ -50,6 +51,7 @@ impl Quote {
             amount,
             interactions: boundary::quote::encode_interactions(eth, solution.interactions())?,
             solver: solution.solver().address(),
+            gas_used: solution.gas_used(),
         })
     }
 }

--- a/crates/driver/src/infra/api/routes/quote/dto/quote.rs
+++ b/crates/driver/src/infra/api/routes/quote/dto/quote.rs
@@ -21,6 +21,7 @@ impl Quote {
                 })
                 .collect(),
             solver: quote.solver.0,
+            gas_used: quote.gas_used.map(|gas| gas.0.as_u64()),
         }
     }
 }
@@ -33,6 +34,7 @@ pub struct Quote {
     amount: eth::U256,
     interactions: Vec<Interaction>,
     solver: eth::H160,
+    gas_used: Option<u64>,
 }
 
 #[serde_as]

--- a/crates/driver/src/infra/api/routes/quote/dto/quote.rs
+++ b/crates/driver/src/infra/api/routes/quote/dto/quote.rs
@@ -34,6 +34,7 @@ pub struct Quote {
     amount: eth::U256,
     interactions: Vec<Interaction>,
     solver: eth::H160,
+    #[serde(skip_serializing_if = "Option::is_none")]
     gas: Option<u64>,
 }
 

--- a/crates/driver/src/infra/api/routes/quote/dto/quote.rs
+++ b/crates/driver/src/infra/api/routes/quote/dto/quote.rs
@@ -21,7 +21,7 @@ impl Quote {
                 })
                 .collect(),
             solver: quote.solver.0,
-            gas_used: quote.gas_used.map(|gas| gas.0.as_u64()),
+            gas: quote.gas.map(|gas| gas.0.as_u64()),
         }
     }
 }
@@ -34,7 +34,7 @@ pub struct Quote {
     amount: eth::U256,
     interactions: Vec<Interaction>,
     solver: eth::H160,
-    gas_used: Option<u64>,
+    gas: Option<u64>,
 }
 
 #[serde_as]

--- a/crates/driver/src/infra/api/routes/solve/dto/solved.rs
+++ b/crates/driver/src/infra/api/routes/solve/dto/solved.rs
@@ -50,7 +50,7 @@ impl Solution {
                 .into_iter()
                 .map(|(k, v)| (k.into(), v.into()))
                 .collect(),
-            gas_used: solved.gas_used.map(|gas| gas.0.as_u64()),
+            gas: solved.gas.map(|gas| gas.0.as_u64()),
         }
     }
 }
@@ -84,5 +84,5 @@ pub struct Solution {
     orders: HashMap<OrderId, TradedAmounts>,
     #[serde_as(as = "HashMap<_, serialize::U256>")]
     clearing_prices: HashMap<eth::H160, eth::U256>,
-    gas_used: Option<u64>,
+    gas: Option<u64>,
 }

--- a/crates/driver/src/infra/api/routes/solve/dto/solved.rs
+++ b/crates/driver/src/infra/api/routes/solve/dto/solved.rs
@@ -50,6 +50,7 @@ impl Solution {
                 .into_iter()
                 .map(|(k, v)| (k.into(), v.into()))
                 .collect(),
+            gas_used: solved.gas_used.map(|gas| gas.0.as_u64()),
         }
     }
 }
@@ -83,4 +84,5 @@ pub struct Solution {
     orders: HashMap<OrderId, TradedAmounts>,
     #[serde_as(as = "HashMap<_, serialize::U256>")]
     clearing_prices: HashMap<eth::H160, eth::U256>,
+    gas_used: Option<u64>,
 }

--- a/crates/driver/src/infra/api/routes/solve/dto/solved.rs
+++ b/crates/driver/src/infra/api/routes/solve/dto/solved.rs
@@ -50,7 +50,6 @@ impl Solution {
                 .into_iter()
                 .map(|(k, v)| (k.into(), v.into()))
                 .collect(),
-            gas: solved.gas.map(|gas| gas.0.as_u64()),
         }
     }
 }
@@ -84,5 +83,4 @@ pub struct Solution {
     orders: HashMap<OrderId, TradedAmounts>,
     #[serde_as(as = "HashMap<_, serialize::U256>")]
     clearing_prices: HashMap<eth::H160, eth::U256>,
-    gas: Option<u64>,
 }

--- a/crates/driver/src/infra/solver/dto/solution.rs
+++ b/crates/driver/src/infra/solver/dto/solution.rs
@@ -205,6 +205,7 @@ impl Solutions {
                         },
                     },
                     weth,
+                    solution.gas_used.map(|gas| eth::Gas(gas.into())),
                 )
                 .map_err(|err| match err {
                     competition::solution::error::Solution::InvalidClearingPrices => {
@@ -236,6 +237,7 @@ pub struct Solution {
     trades: Vec<Trade>,
     interactions: Vec<Interaction>,
     score: Score,
+    gas_used: Option<u64>,
 }
 
 #[derive(Debug, Deserialize)]

--- a/crates/driver/src/infra/solver/dto/solution.rs
+++ b/crates/driver/src/infra/solver/dto/solution.rs
@@ -205,7 +205,7 @@ impl Solutions {
                         },
                     },
                     weth,
-                    solution.gas_used.map(|gas| eth::Gas(gas.into())),
+                    solution.gas.map(|gas| eth::Gas(gas.into())),
                 )
                 .map_err(|err| match err {
                     competition::solution::error::Solution::InvalidClearingPrices => {
@@ -237,7 +237,7 @@ pub struct Solution {
     trades: Vec<Trade>,
     interactions: Vec<Interaction>,
     score: Score,
-    gas_used: Option<u64>,
+    gas: Option<u64>,
 }
 
 #[derive(Debug, Deserialize)]

--- a/crates/driver/src/tests/setup/mod.rs
+++ b/crates/driver/src/tests/setup/mod.rs
@@ -1034,7 +1034,8 @@ impl<'a> SolveOk<'a> {
         assert_eq!(solutions.len(), 1);
         let solution = solutions[0].clone();
         assert!(solution.is_object());
-        assert_eq!(solution.as_object().unwrap().len(), 6);
+        // response contains 1 optional field
+        assert!((5..=6).contains(&solution.as_object().unwrap().len()));
         solution
     }
 

--- a/crates/driver/src/tests/setup/mod.rs
+++ b/crates/driver/src/tests/setup/mod.rs
@@ -1034,7 +1034,7 @@ impl<'a> SolveOk<'a> {
         assert_eq!(solutions.len(), 1);
         let solution = solutions[0].clone();
         assert!(solution.is_object());
-        assert_eq!(solution.as_object().unwrap().len(), 5);
+        assert_eq!(solution.as_object().unwrap().len(), 6);
         solution
     }
 

--- a/crates/e2e/tests/e2e/onchain_settlement.rs
+++ b/crates/e2e/tests/e2e/onchain_settlement.rs
@@ -82,17 +82,25 @@ async fn onchain_settlement(web3: Web3) {
 
     let services = Services::new(onchain.contracts()).await;
     let solver_endpoint = colocation::start_naive_solver().await;
+    let quoter_endpoint = colocation::start_baseline_solver(solver.address()).await;
     colocation::start_driver(
         onchain.contracts(),
-        vec![SolverEngine {
-            name: "test_solver".into(),
-            account: solver,
-            endpoint: solver_endpoint,
-        }],
+        vec![
+            SolverEngine {
+                name: "test_solver".into(),
+                account: solver.clone(),
+                endpoint: solver_endpoint,
+            },
+            SolverEngine {
+                name: "test_quoter".into(),
+                account: solver,
+                endpoint: quoter_endpoint,
+            },
+        ],
     );
     services
         .start_api(vec![
-            "--price-estimation-drivers=test_quoter|http://localhost:11088/test_solver".to_string(),
+            "--price-estimation-drivers=test_quoter|http://localhost:11088/test_quoter".to_string(),
         ])
         .await;
 
@@ -136,7 +144,7 @@ async fn onchain_settlement(web3: Web3) {
         None,
         vec![
             "--drivers=test_solver|http://localhost:11088/test_solver".to_string(),
-            "--price-estimation-drivers=test_quoter|http://localhost:11088/test_solver".to_string(),
+            "--price-estimation-drivers=test_quoter|http://localhost:11088/test_quoter".to_string(),
         ],
     );
 

--- a/crates/shared/src/price_estimation/http.rs
+++ b/crates/shared/src/price_estimation/http.rs
@@ -285,7 +285,7 @@ impl HttpTradeFinder {
                 OrderKind::Buy => settlement.orders[&0].exec_sell_amount,
                 OrderKind::Sell => settlement.orders[&0].exec_buy_amount,
             },
-            gas_estimate,
+            gas_estimate: Some(gas_estimate),
             interactions: settlement
                 .interaction_data
                 .into_iter()
@@ -446,9 +446,10 @@ impl HttpTradeFinder {
 impl TradeFinding for HttpTradeFinder {
     async fn get_quote(&self, query: &Query) -> Result<Quote, TradeError> {
         let price_estimate = self.compute_trade(Arc::new(query.clone())).await?;
+        let gas_estimate = price_estimate.gas_estimate.context("no gas estimate")?;
         Ok(Quote {
             out_amount: price_estimate.out_amount,
-            gas_estimate: price_estimate.gas_estimate,
+            gas_estimate,
             solver: price_estimate.solver,
         })
     }
@@ -464,9 +465,13 @@ impl PriceEstimating for HttpTradeFinder {
     fn estimate(&self, query: Arc<Query>) -> futures::future::BoxFuture<'_, PriceEstimateResult> {
         async {
             let trade = self.compute_trade(query).await?;
+            let gas = trade
+                .gas_estimate
+                .context("no gas estimate")
+                .map_err(PriceEstimationError::EstimatorInternal)?;
             Ok(Estimate {
                 out_amount: trade.out_amount,
-                gas: trade.gas_estimate,
+                gas,
                 solver: trade.solver,
                 verified: false,
             })

--- a/crates/shared/src/trade_finding.rs
+++ b/crates/shared/src/trade_finding.rs
@@ -46,7 +46,7 @@ pub struct Quote {
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
 pub struct Trade {
     pub out_amount: U256,
-    pub gas_estimate: u64,
+    pub gas_estimate: Option<u64>,
     pub interactions: Vec<Interaction>,
     pub solver: H160,
 }
@@ -77,7 +77,7 @@ impl Trade {
 
         Self {
             out_amount,
-            gas_estimate,
+            gas_estimate: Some(gas_estimate),
             interactions,
             solver,
         }
@@ -237,7 +237,7 @@ mod tests {
     fn encode_trade_to_interactions() {
         let trade = Trade {
             out_amount: Default::default(),
-            gas_estimate: 0,
+            gas_estimate: None,
             interactions: vec![
                 Interaction {
                     target: H160([0xaa; 20]),

--- a/crates/shared/src/trade_finding/external.rs
+++ b/crates/shared/src/trade_finding/external.rs
@@ -112,7 +112,7 @@ impl From<dto::Quote> for Trade {
 
         Self {
             out_amount: quote.amount,
-            gas_estimate: quote.gas_used.unwrap_or(TRADE_GAS),
+            gas_estimate: quote.gas.unwrap_or(TRADE_GAS),
             interactions: quote
                 .interactions
                 .into_iter()
@@ -183,7 +183,7 @@ mod dto {
         pub amount: U256,
         pub interactions: Vec<Interaction>,
         pub solver: H160,
-        pub gas_used: Option<u64>,
+        pub gas: Option<u64>,
     }
 
     #[serde_as]

--- a/crates/shared/src/trade_finding/external.rs
+++ b/crates/shared/src/trade_finding/external.rs
@@ -112,7 +112,7 @@ impl From<dto::Quote> for Trade {
 
         Self {
             out_amount: quote.amount,
-            gas_estimate: TRADE_GAS,
+            gas_estimate: quote.gas_used.unwrap_or(TRADE_GAS),
             interactions: quote
                 .interactions
                 .into_iter()
@@ -183,6 +183,7 @@ mod dto {
         pub amount: U256,
         pub interactions: Vec<Interaction>,
         pub solver: H160,
+        pub gas_used: Option<u64>,
     }
 
     #[serde_as]

--- a/crates/shared/src/trade_finding/external.rs
+++ b/crates/shared/src/trade_finding/external.rs
@@ -6,7 +6,7 @@ use {
         request_sharing::RequestSharing,
         trade_finding::{Interaction, Quote, Trade, TradeError, TradeFinding},
     },
-    anyhow::anyhow,
+    anyhow::{anyhow, Context},
     ethrpc::current_block::CurrentBlockStream,
     futures::{future::BoxFuture, FutureExt},
     reqwest::{header, Client},
@@ -101,18 +101,9 @@ impl ExternalTradeFinder {
 
 impl From<dto::Quote> for Trade {
     fn from(quote: dto::Quote) -> Self {
-        // TODO: We are currently deciding on whether or not we need indicative
-        // fee estimates for indicative price estimates. If they are needed,
-        // then this approximation is obviously inaccurate and should be
-        // improved, and would likely involve including gas estimates in quote
-        // responses from the driver or implementing this as a separate API.
-        //
-        // Value guessed from <https://dune.com/queries/1373225>
-        const TRADE_GAS: u64 = 290_000;
-
         Self {
             out_amount: quote.amount,
-            gas_estimate: quote.gas.unwrap_or(TRADE_GAS),
+            gas_estimate: quote.gas,
             interactions: quote
                 .interactions
                 .into_iter()
@@ -142,9 +133,13 @@ impl TradeFinding for ExternalTradeFinder {
         // The driver only has a single endpoint to compute trades so we can simply
         // reuse the same logic here.
         let trade = self.get_trade(query).await?;
+        let gas_estimate = trade
+            .gas_estimate
+            .context("no gas estimate")
+            .map_err(TradeError::Other)?;
         Ok(Quote {
             out_amount: trade.out_amount,
-            gas_estimate: trade.gas_estimate,
+            gas_estimate,
             solver: trade.solver,
         })
     }

--- a/crates/shared/src/trade_finding/oneinch.rs
+++ b/crates/shared/src/trade_finding/oneinch.rs
@@ -372,7 +372,7 @@ mod tests {
             .unwrap();
 
         assert_eq!(trade.out_amount, 808_069_760_400_778_577u128.into());
-        assert!(trade.gas_estimate > 189_386);
+        assert!(trade.gas_estimate.unwrap() > 189_386);
         assert_eq!(
             trade.interactions,
             vec![
@@ -547,7 +547,7 @@ mod tests {
 
         let trade = result.unwrap();
         println!(
-            "1 WETH buys {} GNO, costing {} gas",
+            "1 WETH buys {} GNO, costing {:?} gas",
             trade.out_amount.to_f64_lossy() / 1e18,
             trade.gas_estimate,
         );

--- a/crates/solvers-dto/src/solution.rs
+++ b/crates/solvers-dto/src/solution.rs
@@ -23,6 +23,7 @@ pub struct Solution {
     pub trades: Vec<Trade>,
     pub interactions: Vec<Interaction>,
     pub score: Score,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub gas: Option<u64>,
 }
 

--- a/crates/solvers-dto/src/solution.rs
+++ b/crates/solvers-dto/src/solution.rs
@@ -23,6 +23,7 @@ pub struct Solution {
     pub trades: Vec<Trade>,
     pub interactions: Vec<Interaction>,
     pub score: Score,
+    pub gas: Option<u64>,
 }
 
 #[derive(Debug, Serialize)]

--- a/crates/solvers/openapi.yml
+++ b/crates/solvers/openapi.yml
@@ -842,6 +842,6 @@ components:
                     The revert probability of the solution. Used by the driver to compute a risk-adjusted score.
                   type: number
                   example: 0.9
-        gasUsed:
+        gas:
           type: integer
           description: How many units of gas this solution is estimated to cost.

--- a/crates/solvers/openapi.yml
+++ b/crates/solvers/openapi.yml
@@ -842,3 +842,6 @@ components:
                     The revert probability of the solution. Used by the driver to compute a risk-adjusted score.
                   type: number
                   example: 0.9
+        gasUsed:
+          type: integer
+          description: How many units of gas this solution is estimated to cost.

--- a/crates/solvers/src/api/routes/solve/dto/solution.rs
+++ b/crates/solvers/src/api/routes/solve/dto/solution.rs
@@ -119,6 +119,7 @@ pub fn from_domain(solutions: &[solution::Solution]) -> super::Solutions {
                         success_probability: score.0,
                     },
                 },
+                gas: solution.gas.map(|gas| gas.0.as_u64()),
             })
             .collect(),
     }

--- a/crates/solvers/src/boundary/legacy.rs
+++ b/crates/solvers/src/boundary/legacy.rs
@@ -579,6 +579,7 @@ fn to_domain_solution(
                 return Err(anyhow::anyhow!("solvers not allowed to use surplus score"))
             }
         },
+        gas_used: eth::Gas(290_000.into()),
     })
 }
 

--- a/crates/solvers/src/boundary/legacy.rs
+++ b/crates/solvers/src/boundary/legacy.rs
@@ -579,7 +579,7 @@ fn to_domain_solution(
                 return Err(anyhow::anyhow!("solvers not allowed to use surplus score"))
             }
         },
-        gas_used: eth::Gas(290_000.into()),
+        gas_used: None,
     })
 }
 

--- a/crates/solvers/src/boundary/legacy.rs
+++ b/crates/solvers/src/boundary/legacy.rs
@@ -579,7 +579,7 @@ fn to_domain_solution(
                 return Err(anyhow::anyhow!("solvers not allowed to use surplus score"))
             }
         },
-        gas_used: None,
+        gas: None,
     })
 }
 

--- a/crates/solvers/src/boundary/naive.rs
+++ b/crates/solvers/src/boundary/naive.rs
@@ -138,6 +138,10 @@ pub fn solve(
                 )
             })
             .collect(),
+        gas_used: match swap {
+            Some(_) => liquidity.gas,
+            None => eth::Gas(0.into()),
+        },
         interactions: swap
             .into_iter()
             .map(|(input, output)| {

--- a/crates/solvers/src/boundary/naive.rs
+++ b/crates/solvers/src/boundary/naive.rs
@@ -138,7 +138,7 @@ pub fn solve(
                 )
             })
             .collect(),
-        gas_used: None,
+        gas: None,
         interactions: swap
             .into_iter()
             .map(|(input, output)| {

--- a/crates/solvers/src/boundary/naive.rs
+++ b/crates/solvers/src/boundary/naive.rs
@@ -138,6 +138,10 @@ pub fn solve(
                 )
             })
             .collect(),
+        // We can skip computing a gas estimate here because that is only used by the protocol
+        // when quoting trades. And because the naive solver is not able to solve single order
+        // auctions (which is how we model a /quote request) it can not be used for
+        // quoting anyway.
         gas: None,
         interactions: swap
             .into_iter()

--- a/crates/solvers/src/boundary/naive.rs
+++ b/crates/solvers/src/boundary/naive.rs
@@ -138,10 +138,7 @@ pub fn solve(
                 )
             })
             .collect(),
-        gas_used: match swap {
-            Some(_) => liquidity.gas,
-            None => eth::Gas(0.into()),
-        },
+        gas_used: None,
         interactions: swap
             .into_iter()
             .map(|(input, output)| {

--- a/crates/solvers/src/domain/eth/mod.rs
+++ b/crates/solvers/src/domain/eth/mod.rs
@@ -49,6 +49,14 @@ impl From<U256> for Ether {
 #[derive(Clone, Copy, Debug, Default)]
 pub struct Gas(pub U256);
 
+impl std::ops::Add for Gas {
+    type Output = Self;
+
+    fn add(self, rhs: Self) -> Self::Output {
+        Self(self.0 + rhs.0)
+    }
+}
+
 /// A 256-bit rational type.
 pub type Rational = num::rational::Ratio<U256>;
 

--- a/crates/solvers/src/domain/solution.rs
+++ b/crates/solvers/src/domain/solution.rs
@@ -24,6 +24,7 @@ pub struct Solution {
     pub trades: Vec<Trade>,
     pub interactions: Vec<Interaction>,
     pub score: Score,
+    pub gas_used: eth::Gas,
 }
 
 impl Solution {
@@ -217,6 +218,7 @@ impl Single {
             trades: vec![Trade::Fulfillment(Fulfillment::new(order, executed, fee)?)],
             interactions,
             score,
+            gas_used: self.gas,
         })
     }
 }

--- a/crates/solvers/src/domain/solution.rs
+++ b/crates/solvers/src/domain/solution.rs
@@ -24,7 +24,7 @@ pub struct Solution {
     pub trades: Vec<Trade>,
     pub interactions: Vec<Interaction>,
     pub score: Score,
-    pub gas_used: eth::Gas,
+    pub gas_used: Option<eth::Gas>,
 }
 
 impl Solution {
@@ -218,7 +218,7 @@ impl Single {
             trades: vec![Trade::Fulfillment(Fulfillment::new(order, executed, fee)?)],
             interactions,
             score,
-            gas_used: self.gas,
+            gas_used: Some(self.gas),
         })
     }
 }

--- a/crates/solvers/src/domain/solution.rs
+++ b/crates/solvers/src/domain/solution.rs
@@ -25,7 +25,7 @@ pub struct Solution {
     pub trades: Vec<Trade>,
     pub interactions: Vec<Interaction>,
     pub score: Score,
-    pub gas_used: Option<eth::Gas>,
+    pub gas: Option<eth::Gas>,
 }
 
 impl Solution {
@@ -219,7 +219,7 @@ impl Single {
             trades: vec![Trade::Fulfillment(Fulfillment::new(order, executed, fee)?)],
             interactions,
             score,
-            gas_used: Some(self.gas + eth::Gas(SETTLEMENT_OVERHEAD.into())),
+            gas: Some(self.gas + eth::Gas(SETTLEMENT_OVERHEAD.into())),
         })
     }
 }

--- a/crates/solvers/src/domain/solution.rs
+++ b/crates/solvers/src/domain/solution.rs
@@ -4,6 +4,7 @@ use {
         util,
     },
     ethereum_types::{Address, U256},
+    shared::price_estimation::gas::SETTLEMENT_OVERHEAD,
     std::{collections::HashMap, slice},
 };
 
@@ -218,7 +219,7 @@ impl Single {
             trades: vec![Trade::Fulfillment(Fulfillment::new(order, executed, fee)?)],
             interactions,
             score,
-            gas_used: Some(self.gas),
+            gas_used: Some(self.gas + eth::Gas(SETTLEMENT_OVERHEAD.into())),
         })
     }
 }

--- a/crates/solvers/src/tests/baseline/bal_liquidity.rs
+++ b/crates/solvers/src/tests/baseline/bal_liquidity.rs
@@ -120,7 +120,8 @@ async fn weighted() {
                 "score": {
                     "kind": "riskAdjusted",
                     "successProbability": 0.5,
-                }
+                },
+                "gas": 206391,
             }]
         }),
     );
@@ -237,7 +238,8 @@ async fn weighted_v3plus() {
                 "score": {
                     "kind": "riskAdjusted",
                     "successProbability": 0.5,
-                }
+                },
+                "gas": 206391,
             }]
         }),
     );
@@ -376,8 +378,9 @@ async fn stable() {
                     ],
                     "score": {
                         "kind": "riskAdjusted",
-                    "successProbability": 0.5,
-                    }
+                        "successProbability": 0.5,
+                    },
+                    "gas":  289911,
                 },
                 {
                     "id": 1,
@@ -407,8 +410,9 @@ async fn stable() {
                     ],
                     "score": {
                         "kind": "riskAdjusted",
-                    "successProbability": 0.5,
-                    }
+                        "successProbability": 0.5,
+                    },
+                    "gas":  289911,
                 },
             ]
         }),
@@ -542,8 +546,9 @@ async fn composable_stable_v4() {
                     ],
                     "score": {
                         "kind": "riskAdjusted",
-                    "successProbability": 0.5,
-                    }
+                        "successProbability": 0.5,
+                    },
+                    "gas": 289911,
                 },
             ]
         }),

--- a/crates/solvers/src/tests/baseline/buy_order_rounding.rs
+++ b/crates/solvers/src/tests/baseline/buy_order_rounding.rs
@@ -104,7 +104,8 @@ async fn uniswap() {
                 "score": {
                     "kind": "riskAdjusted",
                     "successProbability": 0.5,
-                }
+                },
+                "gas": 166391,
             }]
         }),
     );
@@ -273,7 +274,8 @@ async fn balancer_weighted() {
                 "score": {
                     "kind": "riskAdjusted",
                     "successProbability": 0.5,
-                }
+                },
+                "gas": 266391,
             }]
         }),
     );
@@ -390,7 +392,8 @@ async fn balancer_weighted_v3plus() {
                 "score": {
                     "kind": "riskAdjusted",
                     "successProbability": 0.5,
-                }
+                },
+                "gas": 206391,
             }]
         }),
     );
@@ -507,7 +510,8 @@ async fn distant_convergence() {
                 "score": {
                     "kind": "riskAdjusted",
                     "successProbability": 0.5,
-                }
+                },
+                "gas": 206391,
             }]
         }),
     );
@@ -660,7 +664,8 @@ async fn same_path() {
                 "score": {
                     "kind": "riskAdjusted",
                     "successProbability": 0.5,
-                }
+                },
+                "gas": 166391,
             }]
         }),
     );
@@ -800,8 +805,9 @@ async fn balancer_stable() {
                     ],
                     "score": {
                         "kind": "riskAdjusted",
-                    "successProbability": 0.5,
-                    }
+                        "successProbability": 0.5,
+                    },
+                    "gas": 289911,
                 },
             ]
         }),

--- a/crates/solvers/src/tests/baseline/direct_swap.rs
+++ b/crates/solvers/src/tests/baseline/direct_swap.rs
@@ -100,7 +100,8 @@ async fn test() {
                 "score": {
                     "kind": "riskAdjusted",
                     "successProbability": 0.5,
-                }
+                },
+                "gas": 166391,
             }]
         }),
     );

--- a/crates/solvers/src/tests/baseline/internalization.rs
+++ b/crates/solvers/src/tests/baseline/internalization.rs
@@ -100,7 +100,8 @@ async fn trusted_token() {
                 "score": {
                     "kind": "riskAdjusted",
                     "successProbability": 0.5,
-                }
+                },
+                "gas": 166391,
             }]
         }),
     );
@@ -203,7 +204,8 @@ async fn untrusted_sell_token() {
                 "score": {
                     "kind": "riskAdjusted",
                     "successProbability": 0.5,
-                }
+                },
+                "gas": 166391,
             }]
         }),
     );
@@ -306,7 +308,8 @@ async fn insufficient_balance() {
                 "score": {
                     "kind": "riskAdjusted",
                     "successProbability": 0.5,
-                }
+                },
+                "gas": 166391,
             }]
         }),
     );

--- a/crates/solvers/src/tests/baseline/partial_fill.rs
+++ b/crates/solvers/src/tests/baseline/partial_fill.rs
@@ -101,7 +101,8 @@ async fn test() {
                 "score": {
                     "kind": "riskAdjusted",
                     "successProbability": 0.5,
-                }
+                },
+                "gas": 166391,
             }]
         }),
     );


### PR DESCRIPTION
# Description
Fixes: https://github.com/cowprotocol/services/issues/2516

# Changes
Introduce `gas` field to let solvers tell us how much gas they estimate the execution of the quote or settlement to cost. Now if a solver does not provide a gas estimate but we can also not estimate the gas on our own by simulating we discard the quote entirely.

Note that I didn't add any gas estimation logic for the `naive` solver since we currently only need the `gas` estimate for quotes which `naive` is not able to generate.
For good support we also need to patch the `solvers` repository to add gas estimates provided by dex APIs in their solution.

## How to test
Adjusted e2e tests to make them pass again.