### PR TITLE
[Easy] Set max gas_limit for a settlement at 1/2 block gas limit

### DIFF
--- a/crates/driver/src/domain/competition/solution/settlement.rs
+++ b/crates/driver/src/domain/competition/solution/settlement.rs
@@ -418,16 +418,21 @@ impl Gas {
             eth::U256::from_f64_lossy(eth::U256::to_f64_lossy(estimate.into()) * GAS_LIMIT_FACTOR)
                 .into();
 
-        // The block gas limit may fluctuate between blocks (validators trying to
-        // upvote/downvote the limit), thus add a bit margin to not run into
-        // GasLimitExceeded errors. The maximum deviation per block is 1/1024 so using
-        // 1% buffer will make that even with 10 consecutive blocks in which the gas
-        // limit decreased maximally will not exceed the limit.
-        let block_limit = eth::Gas(block_limit.0 * 99 / 100);
+        // We don't allow for solutions to take up more than half of the block's gas
+        // limit. This is to ensure that block producers attempt to include the
+        // settlement transaction in the next block as long as it is reasonably
+        // priced. If we were to allow for solutions very close to the block
+        // gas limit, validators may discard the settlement transaction unless it is
+        // paying a very high priority fee. This is because the default block
+        // building algorithm picks the highest paying transaction whose gas limit
+        // will not exceed the remaining space in the block next and ignore transactions
+        // whose gas limit exceed the remaining space (without simulating the actual
+        // gas required).
+        let max_gas = eth::Gas(block_limit.0 / 2);
 
         Self {
             estimate,
-            limit: std::cmp::min(block_limit, estimate_with_buffer),
+            limit: std::cmp::min(max_gas, estimate_with_buffer),
             price,
         }
     }


### PR DESCRIPTION
# Description
Especially on Gnosis Chain we sometimes have very large settlements (e.g. https://gnosisscan.io/tx/0xa7a3230bcd139b050c192cb4dceada5af94caf6bb2c9f29a4736240e4df4ab74). Our current strategy is to set the gas limit to 2x the estimated gas to allow in fluctuations between estimated and actually required gas (this approach stems from a time when we used `eth_estimateGas` which wasn't very accurate).

The default block building algorithm works roughly like this:
- While remaining space in the block
- Pick the highest paying transaction from the public mempool whose gas limit doesn't exceed remaining block space
- Try to include it and update remaining space with actually used gas

Importantly, block producers don't simulate or try to estimate the actual gas usage before deciding whether to include a transaction or not. For large transaction like the one shared above, this means that if there is only 98% of block space left (ie 1M gas worth of txs paid more priority fee than us), the proposer will not even attempt to insert our transaction.

This is leading to slow execution times and a lot of expired settlements in Gnosis Chain

# Changes
- [x] Limit block gas limit to half of total block gas limit

## How to test
CI