### PR TITLE
[EASY] Fix surplus scoring error

### DIFF
--- a/crates/driver/src/domain/competition/solution/scoring.rs
+++ b/crates/driver/src/domain/competition/solution/scoring.rs
@@ -149,7 +149,7 @@ impl Trade {
         };
         let surplus = self
             .surplus(price_limits)
-            .ok_or(Error::Surplus(self.sell, self.buy))?;
+            .ok_or(Error::Surplus(self.executed, self.custom_price.clone()))?;
         let price = prices
             .get(&surplus.token)
             .ok_or(Error::MissingPrice(surplus.token))?;
@@ -235,7 +235,7 @@ impl Trade {
         //     fee = surplus_after_fee * factor / (1 - factor)
         let surplus = self
             .surplus(price_limits)
-            .ok_or(Error::Surplus(self.sell, self.buy))?;
+            .ok_or(Error::Surplus(self.executed, self.custom_price.clone()))?;
         let fee = surplus
             .amount
             .apply_factor(factor / (1.0 - factor))
@@ -347,8 +347,8 @@ pub enum Error {
     MultipleFeePolicies,
     #[error("fee policy not implemented yet")]
     UnimplementedFeePolicy,
-    #[error("failed to calculate surplus for trade sell {0:?} buy {1:?}")]
-    Surplus(eth::Asset, eth::Asset),
+    #[error("failed to calculate surplus for trade executed {0:?}, custom price {1:?}")]
+    Surplus(order::TargetAmount, CustomClearingPrices),
     #[error("missing native price for token {0:?}")]
     MissingPrice(eth::TokenAddress),
     #[error(transparent)]


### PR DESCRIPTION
# Description
Instead of printing order sell and buy tokens and amounts (which can be derived from other logs), now we print executed amount and custom prices which give sufficient data to reconstruct the whole surplus calculation and see what went wrong.

This is related to a few surplus calculation errors that happened in prod, which are most likely caused by solving market order at the very own limit order price, causing our price conversions to return smaller amounts due to potential rounding error, and consequently, cheched_sub returning None on those very small differences.

This change would give us more light on what actually happens.

Not launch blocking.