### PR TITLE
Rank by surplus tests

### DIFF
--- a/crates/driver/src/tests/cases/protocol_fees.rs
+++ b/crates/driver/src/tests/cases/protocol_fees.rs
@@ -1,18 +1,22 @@
-use crate::{
-    domain::{competition::order, eth},
-    tests::{
-        self,
-        cases::EtherExt,
-        setup::{
-            ab_adjusted_pool,
-            ab_liquidity_quote,
-            ab_order,
-            ab_solution,
-            fee::{Policy, Quote},
-            ExpectedOrderAmounts,
-            Test,
+use {
+    crate::{
+        domain::{competition::order, eth},
+        tests::{
+            self,
+            cases::EtherExt,
+            setup::{
+                ab_adjusted_pool,
+                ab_liquidity_quote,
+                ab_order,
+                ab_solution,
+                fee::{Policy, Quote},
+                test_solver,
+                ExpectedOrderAmounts,
+                Test,
+            },
         },
     },
+    chrono::{DateTime, Utc},
 };
 
 struct Amounts {
@@ -37,6 +41,17 @@ struct TestCase {
     order: Order,
     fee_policy: Policy,
     execution: Execution,
+    expected_score: eth::U256,
+}
+
+// because of rounding errors, it's good enough to check that the expected value
+// is within a very narrow range of the executed value
+fn is_approximately_equal(executed_value: eth::U256, expected_value: eth::U256) -> bool {
+    let lower =
+        expected_value * eth::U256::from(99999999999u128) / eth::U256::from(100000000000u128); // in percents = 99.999999999%
+    let upper =
+        expected_value * eth::U256::from(100000000001u128) / eth::U256::from(100000000000u128); // in percents = 100.000000001%
+    executed_value >= lower && executed_value <= upper
 }
 
 async fn protocol_fee_test_case(test_case: TestCase) {
@@ -83,10 +98,18 @@ async fn protocol_fee_test_case(test_case: TestCase) {
         .pool(pool)
         .order(order.clone())
         .solution(ab_solution())
+        .solvers(vec![
+            test_solver().rank_by_surplus_date(DateTime::<Utc>::MIN_UTC)
+        ])
         .done()
         .await;
 
-    test.solve().await.ok().orders(&[order]);
+    let result = test.solve().await.ok();
+    assert!(is_approximately_equal(
+        result.score(),
+        test_case.expected_score
+    ));
+    result.orders(&[order]);
 }
 
 #[tokio::test]
@@ -116,6 +139,7 @@ async fn surplus_protocol_fee_buy_order_not_capped() {
                 buy: 40.ether().into_wei(),
             },
         },
+        expected_score: 20.ether().into_wei(),
     };
 
     protocol_fee_test_case(test_case).await;
@@ -127,7 +151,7 @@ async fn surplus_protocol_fee_sell_order_not_capped() {
     let fee_policy = Policy::Surplus {
         factor: 0.5,
         // high enough so we don't get capped by volume fee
-        max_volume_factor: 1.0,
+        max_volume_factor: 0.9,
     };
     let test_case = TestCase {
         fee_policy,
@@ -147,6 +171,7 @@ async fn surplus_protocol_fee_sell_order_not_capped() {
                 buy: 50.ether().into_wei(),
             },
         },
+        expected_score: 20.ether().into_wei(),
     };
     protocol_fee_test_case(test_case).await;
 }
@@ -178,6 +203,7 @@ async fn surplus_protocol_fee_partial_buy_order_not_capped() {
                 buy: 20.ether().into_wei(),
             },
         },
+        expected_score: 10.ether().into_wei(),
     };
 
     protocol_fee_test_case(test_case).await;
@@ -189,7 +215,7 @@ async fn surplus_protocol_fee_partial_sell_order_not_capped() {
     let fee_policy = Policy::Surplus {
         factor: 0.5,
         // high enough so we don't get capped by volume fee
-        max_volume_factor: 1.0,
+        max_volume_factor: 0.9,
     };
     let test_case = TestCase {
         fee_policy,
@@ -209,6 +235,7 @@ async fn surplus_protocol_fee_partial_sell_order_not_capped() {
                 buy: 25.ether().into_wei(),
             },
         },
+        expected_score: 10.ether().into_wei(),
     };
     protocol_fee_test_case(test_case).await;
 }
@@ -239,6 +266,7 @@ async fn surplus_protocol_fee_buy_order_capped() {
                 buy: 40.ether().into_wei(),
             },
         },
+        expected_score: 20.ether().into_wei(),
     };
     protocol_fee_test_case(test_case).await;
 }
@@ -269,6 +297,7 @@ async fn surplus_protocol_fee_sell_order_capped() {
                 buy: 54.ether().into_wei(),
             },
         },
+        expected_score: 20.ether().into_wei(),
     };
     protocol_fee_test_case(test_case).await;
 }
@@ -299,6 +328,7 @@ async fn surplus_protocol_fee_partial_buy_order_capped() {
                 buy: 20.ether().into_wei(),
             },
         },
+        expected_score: 10.ether().into_wei(),
     };
     protocol_fee_test_case(test_case).await;
 }
@@ -329,6 +359,7 @@ async fn surplus_protocol_fee_partial_sell_order_capped() {
                 buy: 27.ether().into_wei(),
             },
         },
+        expected_score: 10.ether().into_wei(),
     };
     protocol_fee_test_case(test_case).await;
 }
@@ -355,6 +386,7 @@ async fn volume_protocol_fee_buy_order() {
                 buy: 40.ether().into_wei(),
             },
         },
+        expected_score: 20.ether().into_wei(),
     };
     protocol_fee_test_case(test_case).await;
 }
@@ -381,6 +413,7 @@ async fn volume_protocol_fee_sell_order() {
                 buy: 45.ether().into_wei(),
             },
         },
+        expected_score: 10.ether().into_wei(),
     };
     protocol_fee_test_case(test_case).await;
 }
@@ -407,6 +440,7 @@ async fn volume_protocol_fee_partial_buy_order() {
                 buy: 20.ether().into_wei(),
             },
         },
+        expected_score: 10.ether().into_wei(),
     };
     protocol_fee_test_case(test_case).await;
 }
@@ -433,6 +467,7 @@ async fn volume_protocol_fee_partial_sell_order() {
                 buy: 27.ether().into_wei(),
             },
         },
+        expected_score: 10.ether().into_wei(),
     };
     protocol_fee_test_case(test_case).await;
 }
@@ -469,6 +504,7 @@ async fn price_improvement_fee_buy_in_market_order_not_capped() {
                 buy: 40.ether().into_wei(),
             },
         },
+        expected_score: 20.ether().into_wei(),
     };
     protocol_fee_test_case(test_case).await;
 }
@@ -479,7 +515,7 @@ async fn price_improvement_fee_sell_in_market_order_not_capped() {
     let fee_policy = Policy::PriceImprovement {
         factor: 0.5,
         // high enough so we don't get capped by volume fee
-        max_volume_factor: 1.0,
+        max_volume_factor: 0.9,
         quote: Quote {
             sell: 49.ether().into_wei(),
             buy: 50.ether().into_wei(),
@@ -505,6 +541,7 @@ async fn price_improvement_fee_sell_in_market_order_not_capped() {
                 buy: 55.ether().into_wei(),
             },
         },
+        expected_score: 20.ether().into_wei(),
     };
     protocol_fee_test_case(test_case).await;
 }
@@ -541,6 +578,7 @@ async fn price_improvement_fee_buy_out_of_market_order_not_capped() {
                 buy: 40.ether().into_wei(),
             },
         },
+        expected_score: 10.ether().into_wei(),
     };
     protocol_fee_test_case(test_case).await;
 }
@@ -551,7 +589,7 @@ async fn price_improvement_fee_sell_out_of_market_order_not_capped() {
     let fee_policy = Policy::PriceImprovement {
         factor: 0.5,
         // high enough so we don't get capped by volume fee
-        max_volume_factor: 1.0,
+        max_volume_factor: 0.9,
         quote: Quote {
             sell: 49.ether().into_wei(),
             buy: 40.ether().into_wei(),
@@ -577,6 +615,7 @@ async fn price_improvement_fee_sell_out_of_market_order_not_capped() {
                 buy: 55.ether().into_wei(),
             },
         },
+        expected_score: 10.ether().into_wei(),
     };
     protocol_fee_test_case(test_case).await;
 }
@@ -613,6 +652,7 @@ async fn price_improvement_fee_buy_in_market_order_capped() {
                 buy: 40.ether().into_wei(),
             },
         },
+        expected_score: 20.ether().into_wei(),
     };
     protocol_fee_test_case(test_case).await;
 }
@@ -649,6 +689,7 @@ async fn price_improvement_fee_sell_in_market_order_capped() {
                 buy: 57.ether().into_wei(),
             },
         },
+        expected_score: 20.ether().into_wei(),
     };
     protocol_fee_test_case(test_case).await;
 }
@@ -685,6 +726,7 @@ async fn price_improvement_fee_buy_out_of_market_order_capped() {
                 buy: 40.ether().into_wei(),
             },
         },
+        expected_score: 10.ether().into_wei(),
     };
     protocol_fee_test_case(test_case).await;
 }
@@ -721,6 +763,7 @@ async fn price_improvement_fee_sell_out_of_market_order_capped() {
                 buy: 57.ether().into_wei(),
             },
         },
+        expected_score: 10.ether().into_wei(),
     };
     protocol_fee_test_case(test_case).await;
 }
@@ -757,6 +800,7 @@ async fn price_improvement_fee_partial_buy_in_market_order_not_capped() {
                 buy: 20.ether().into_wei(),
             },
         },
+        expected_score: 15.ether().into_wei(),
     };
     protocol_fee_test_case(test_case).await;
 }
@@ -767,7 +811,7 @@ async fn price_improvement_fee_partial_sell_in_market_order_not_capped() {
     let fee_policy = Policy::PriceImprovement {
         factor: 0.5,
         // high enough so we don't get capped by volume fee
-        max_volume_factor: 1.0,
+        max_volume_factor: 0.9,
         quote: Quote {
             sell: 49.ether().into_wei(),
             buy: 50.ether().into_wei(),
@@ -793,6 +837,7 @@ async fn price_improvement_fee_partial_sell_in_market_order_not_capped() {
                 buy: 25.ether().into_wei(),
             },
         },
+        expected_score: 14.ether().into_wei(),
     };
     protocol_fee_test_case(test_case).await;
 }
@@ -829,6 +874,7 @@ async fn price_improvement_fee_partial_buy_out_of_market_order_not_capped() {
                 buy: 20.ether().into_wei(),
             },
         },
+        expected_score: 10.ether().into_wei(),
     };
     protocol_fee_test_case(test_case).await;
 }
@@ -839,7 +885,7 @@ async fn price_improvement_fee_partial_sell_out_of_market_order_not_capped() {
     let fee_policy = Policy::PriceImprovement {
         factor: 0.5,
         // high enough so we don't get capped by volume fee
-        max_volume_factor: 1.0,
+        max_volume_factor: 0.9,
         quote: Quote {
             sell: 49.ether().into_wei(),
             buy: 40.ether().into_wei(),
@@ -865,6 +911,7 @@ async fn price_improvement_fee_partial_sell_out_of_market_order_not_capped() {
                 buy: 25.ether().into_wei(),
             },
         },
+        expected_score: 10.ether().into_wei(),
     };
     protocol_fee_test_case(test_case).await;
 }
@@ -901,6 +948,7 @@ async fn price_improvement_fee_partial_buy_in_market_order_capped() {
                 buy: 20.ether().into_wei(),
             },
         },
+        expected_score: 14.ether().into_wei(),
     };
     protocol_fee_test_case(test_case).await;
 }
@@ -937,6 +985,7 @@ async fn price_improvement_fee_partial_sell_in_market_order_capped() {
                 buy: 27.ether().into_wei(),
             },
         },
+        expected_score: 14.ether().into_wei(),
     };
     protocol_fee_test_case(test_case).await;
 }
@@ -973,6 +1022,7 @@ async fn price_improvement_fee_partial_buy_out_of_market_order_capped() {
                 buy: 20.ether().into_wei(),
             },
         },
+        expected_score: 10.ether().into_wei(),
     };
     protocol_fee_test_case(test_case).await;
 }
@@ -1009,6 +1059,7 @@ async fn price_improvement_fee_partial_sell_out_of_market_order_capped() {
                 buy: 27.ether().into_wei(),
             },
         },
+        expected_score: 10.ether().into_wei(),
     };
     protocol_fee_test_case(test_case).await;
 }

--- a/crates/driver/src/tests/cases/protocol_fees.rs
+++ b/crates/driver/src/tests/cases/protocol_fees.rs
@@ -823,7 +823,7 @@ async fn price_improvement_fee_partial_sell_in_market_order_not_capped() {
         order: Order {
             sell_amount: 50.ether().into_wei(),
             // Demanding to receive less than quoted (in-market)
-            buy_amount: 40.ether().into_wei(),
+            buy_amount: 25.ether().into_wei(),
             side: order::Side::Sell,
         },
         execution: Execution {
@@ -837,7 +837,7 @@ async fn price_improvement_fee_partial_sell_in_market_order_not_capped() {
                 buy: 25.ether().into_wei(),
             },
         },
-        expected_score: 14.ether().into_wei(),
+        expected_score: 20.ether().into_wei(),
     };
     protocol_fee_test_case(test_case).await;
 }
@@ -933,7 +933,7 @@ async fn price_improvement_fee_partial_buy_in_market_order_capped() {
         fee_policy,
         order: Order {
             // Demanding to sell more than quoted (in-market)
-            sell_amount: 60.ether().into_wei(),
+            sell_amount: 75.ether().into_wei(),
             buy_amount: 50.ether().into_wei(),
             side: order::Side::Buy,
         },
@@ -948,7 +948,7 @@ async fn price_improvement_fee_partial_buy_in_market_order_capped() {
                 buy: 20.ether().into_wei(),
             },
         },
-        expected_score: 14.ether().into_wei(),
+        expected_score: 20.ether().into_wei(),
     };
     protocol_fee_test_case(test_case).await;
 }
@@ -971,7 +971,7 @@ async fn price_improvement_fee_partial_sell_in_market_order_capped() {
         order: Order {
             sell_amount: 50.ether().into_wei(),
             // Demanding to receive less than quoted (in-market)
-            buy_amount: 40.ether().into_wei(),
+            buy_amount: 25.ether().into_wei(),
             side: order::Side::Sell,
         },
         execution: Execution {
@@ -985,7 +985,7 @@ async fn price_improvement_fee_partial_sell_in_market_order_capped() {
                 buy: 27.ether().into_wei(),
             },
         },
-        expected_score: 14.ether().into_wei(),
+        expected_score: 20.ether().into_wei(),
     };
     protocol_fee_test_case(test_case).await;
 }

--- a/crates/driver/src/tests/cases/protocol_fees.rs
+++ b/crates/driver/src/tests/cases/protocol_fees.rs
@@ -46,6 +46,7 @@ struct TestCase {
 
 // because of rounding errors, it's good enough to check that the expected value
 // is within a very narrow range of the executed value
+#[cfg(test)]
 fn is_approximately_equal(executed_value: eth::U256, expected_value: eth::U256) -> bool {
     let lower =
         expected_value * eth::U256::from(99999999999u128) / eth::U256::from(100000000000u128); // in percents = 99.999999999%
@@ -54,6 +55,7 @@ fn is_approximately_equal(executed_value: eth::U256, expected_value: eth::U256) 
     executed_value >= lower && executed_value <= upper
 }
 
+#[cfg(test)]
 async fn protocol_fee_test_case(test_case: TestCase) {
     let test_name = format!(
         "Protocol Fee: {:?} {:?}",

--- a/crates/driver/src/tests/setup/driver.rs
+++ b/crates/driver/src/tests/setup/driver.rs
@@ -228,6 +228,7 @@ async fn create_config_file(
                account = "0x{}"
                solving-share-of-deadline = {}
                http-time-buffer = "{}ms"
+               {}
                "#,
             solver.name,
             addr,
@@ -240,6 +241,10 @@ async fn create_config_file(
             hex::encode(solver.private_key.secret_bytes()),
             solver.timeouts.solving_share_of_deadline.get(),
             solver.timeouts.http_delay.num_milliseconds(),
+            solver.rank_by_surplus_date.map_or_else(
+                || "".to_string(),
+                |timestamp| format!("rank-by-surplus-date = \"{}\"", timestamp.to_rfc3339())
+            ),
         )
         .unwrap();
     }

--- a/crates/driver/src/tests/setup/mod.rs
+++ b/crates/driver/src/tests/setup/mod.rs
@@ -315,6 +315,8 @@ pub struct Solver {
     slippage: infra::solver::Slippage,
     /// The fraction of time used for solving
     timeouts: infra::solver::Timeouts,
+    /// Datetime when the CIP38 rank by surplus rules should be activated.
+    rank_by_surplus_date: Option<chrono::DateTime<chrono::Utc>>,
 }
 
 pub fn test_solver() -> Solver {
@@ -334,6 +336,7 @@ pub fn test_solver() -> Solver {
             http_delay: chrono::Duration::from_std(default_http_time_buffer()).unwrap(),
             solving_share_of_deadline: default_solving_share_of_deadline().try_into().unwrap(),
         },
+        rank_by_surplus_date: None,
     }
 }
 
@@ -361,6 +364,13 @@ impl Solver {
 
     pub fn balance(self, balance: eth::U256) -> Self {
         Self { balance, ..self }
+    }
+
+    pub fn rank_by_surplus_date(self, rank_by_surplus_date: chrono::DateTime<chrono::Utc>) -> Self {
+        Self {
+            rank_by_surplus_date: Some(rank_by_surplus_date),
+            ..self
+        }
     }
 }
 


### PR DESCRIPTION
# Changes

- [x] Surplus
- [x] PriceImprovement
- [x] Volume

Scoring doesn't support `factor=1.0`, so some of the test values were changed.

## Related Issues

Fixes #2522