### PR TITLE
Apply partner fee from appData

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -255,6 +255,7 @@ name = "autopilot"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "app-data",
  "async-trait",
  "bigdecimal",
  "chrono",

--- a/crates/autopilot/Cargo.toml
+++ b/crates/autopilot/Cargo.toml
@@ -15,6 +15,7 @@ name = "autopilot"
 path = "src/main.rs"
 
 [dependencies]
+app-data = { path = "../app-data" }
 anyhow = { workspace = true }
 async-trait = { workspace = true }
 bigdecimal = { workspace = true }

--- a/crates/autopilot/src/domain/fee/policy.rs
+++ b/crates/autopilot/src/domain/fee/policy.rs
@@ -1,8 +1,4 @@
-use {
-    crate::{arguments, boundary, domain},
-    app_data::Validator,
-    prometheus::core::Number,
-};
+use crate::{arguments, boundary, domain};
 
 pub enum Policy {
     Surplus(Surplus),
@@ -103,23 +99,6 @@ impl PriceImprovement {
 
 impl Volume {
     pub fn apply(&self, order: &boundary::Order) -> Option<domain::fee::Policy> {
-        // If the partner fee is specified, it overwrites the current volume fee policy
-        if let Some(validated_app_data) = order
-            .metadata
-            .full_app_data
-            .as_ref()
-            .map(|full_app_data| Validator::new(usize::MAX).validate(full_app_data.as_bytes()))
-            .transpose()
-            .ok()
-            .flatten()
-        {
-            if let Some(partner_fee) = validated_app_data.protocol.partner_fee {
-                return Some(domain::fee::Policy::Volume {
-                    factor: partner_fee.bps.into_f64() / 100.0,
-                });
-            }
-        }
-
         match order.metadata.class {
             boundary::OrderClass::Market => None,
             boundary::OrderClass::Liquidity => None,

--- a/crates/e2e/tests/e2e/limit_orders.rs
+++ b/crates/e2e/tests/e2e/limit_orders.rs
@@ -4,7 +4,7 @@ use {
     e2e::{nodes::forked_node::ForkedNodeApi, setup::*, tx},
     ethcontract::{prelude::U256, H160},
     model::{
-        order::{OrderClass, OrderCreation, OrderCreationAppData, OrderKind},
+        order::{OrderClass, OrderCreation, OrderKind},
         quote::{OrderQuoteRequest, OrderQuoteSide, SellAmount},
         signature::EcdsaSigningScheme,
     },
@@ -263,9 +263,6 @@ async fn two_limit_orders_test(web3: Web3) {
         buy_amount: to_wei(2),
         valid_to: model::time::now_in_epoch_seconds() + 300,
         kind: OrderKind::Sell,
-        app_data: OrderCreationAppData::Full {
-            full: r#"{"version":"1.1.0","metadata":{"partnerFee":{"bps":100, "recipient": "0xb6BAd41ae76A11D10f7b0E664C5007b908bC77C9"}}}"#.to_string(),
-        },
         ..Default::default()
     }
     .sign(

--- a/crates/e2e/tests/e2e/protocol_fee.rs
+++ b/crates/e2e/tests/e2e/protocol_fee.rs
@@ -148,7 +148,10 @@ async fn volume_fee_sell_order_test(web3: Web3) {
 
 async fn partner_fee_sell_order_test(web3: Web3) {
     // Fee policy to be overwritten by the partner fee
-    let fee_policy = FeePolicyKind::Volume { factor: 0.5 };
+    let fee_policy = FeePolicyKind::PriceImprovement {
+        factor: 0.5,
+        max_volume_factor: 1.0,
+    };
     // Without protocol fee:
     // Expected execution is 10000000000000000000 GNO for
     // 9871415430342266811 DAI, with executed_surplus_fee = 167058994203399 GNO
@@ -409,6 +412,10 @@ enum FeePolicyKind {
     Surplus { factor: f64, max_volume_factor: f64 },
     /// How much of the order's volume should be taken as a protocol fee.
     Volume { factor: f64 },
+    /// How much of the order's price improvement should be taken as a protocol
+    /// fee where price improvement is a difference between the executed price
+    /// and the best quote.
+    PriceImprovement { factor: f64, max_volume_factor: f64 },
 }
 
 impl std::fmt::Display for FeePolicyKind {
@@ -424,6 +431,16 @@ impl std::fmt::Display for FeePolicyKind {
             ),
             FeePolicyKind::Volume { factor } => {
                 write!(f, "--fee-policy-kind=volume:{}", factor)
+            }
+            FeePolicyKind::PriceImprovement {
+                factor,
+                max_volume_factor,
+            } => {
+                write!(
+                    f,
+                    "--fee-policy-kind=priceImprovement:{}:{}",
+                    factor, max_volume_factor
+                )
             }
         }
     }

--- a/crates/e2e/tests/e2e/protocol_fee.rs
+++ b/crates/e2e/tests/e2e/protocol_fee.rs
@@ -168,7 +168,7 @@ async fn partner_fee_sell_order_test(web3: Web3) {
         fee_policy,
         OrderKind::Sell,
         Some(OrderCreationAppData::Full {
-            full: r#"{"version":"1.1.0","metadata":{"partnerFee":{"bps":10, "recipient": "0xb6BAd41ae76A11D10f7b0E664C5007b908bC77C9"}}}"#.to_string(),
+            full: r#"{"version":"1.1.0","metadata":{"partnerFee":{"bps":1000, "recipient": "0xb6BAd41ae76A11D10f7b0E664C5007b908bC77C9"}}}"#.to_string(),
         }),
         1000150353094783059u128.into(),
         987306456662572858u128.into(),

--- a/crates/e2e/tests/e2e/protocol_fee.rs
+++ b/crates/e2e/tests/e2e/protocol_fee.rs
@@ -5,7 +5,7 @@ use {
     },
     ethcontract::prelude::U256,
     model::{
-        order::{OrderCreation, OrderKind},
+        order::{OrderCreation, OrderCreationAppData, OrderKind},
         signature::EcdsaSigningScheme,
     },
     secp256k1::SecretKey,
@@ -29,6 +29,12 @@ async fn local_node_surplus_fee_sell_order_capped() {
 #[ignore]
 async fn local_node_volume_fee_sell_order() {
     run_test(volume_fee_sell_order_test).await;
+}
+
+#[tokio::test]
+#[ignore]
+async fn local_node_partner_fee_sell_order() {
+    run_test(partner_fee_sell_order_test).await;
 }
 
 #[tokio::test]
@@ -76,6 +82,7 @@ async fn surplus_fee_sell_order_test(web3: Web3) {
         web3.clone(),
         fee_policy,
         OrderKind::Sell,
+        None,
         1480603400674076736u128.into(),
         1461589542731026166u128.into(),
     )
@@ -105,6 +112,7 @@ async fn surplus_fee_sell_order_capped_test(web3: Web3) {
         web3.clone(),
         fee_policy,
         OrderKind::Sell,
+        None,
         1000150353094783059u128.into(),
         987306456662572858u128.into(),
     )
@@ -131,6 +139,37 @@ async fn volume_fee_sell_order_test(web3: Web3) {
         web3.clone(),
         fee_policy,
         OrderKind::Sell,
+        None,
+        1000150353094783059u128.into(),
+        987306456662572858u128.into(),
+    )
+    .await;
+}
+
+async fn partner_fee_sell_order_test(web3: Web3) {
+    // Fee policy to be overwritten by the partner fee
+    let fee_policy = FeePolicyKind::Volume { factor: 0.5 };
+    // Without protocol fee:
+    // Expected execution is 10000000000000000000 GNO for
+    // 9871415430342266811 DAI, with executed_surplus_fee = 167058994203399 GNO
+    //
+    // With protocol fee:
+    // Expected executed_surplus_fee is 167058994203399 +
+    // 0.1*(10000000000000000000 - 167058994203399) = 1000150353094783059
+    //
+    // Final execution is 10000000000000000000 GNO for 8884273887308040129 DAI, with
+    // executed_surplus_fee = 1000150353094783059 GNO
+    //
+    // Settlement contract balance after execution = 1000150353094783059 GNO =
+    // 1000150353094783059 GNO * 8884273887308040129 / (10000000000000000000 -
+    // 1000150353094783059) = 987306456662572858 DAI
+    execute_test(
+        web3.clone(),
+        fee_policy,
+        OrderKind::Sell,
+        Some(OrderCreationAppData::Full {
+            full: r#"{"version":"1.1.0","metadata":{"partnerFee":{"bps":10, "recipient": "0xb6BAd41ae76A11D10f7b0E664C5007b908bC77C9"}}}"#.to_string(),
+        }),
         1000150353094783059u128.into(),
         987306456662572858u128.into(),
     )
@@ -160,6 +199,7 @@ async fn surplus_fee_buy_order_test(web3: Web3) {
         web3.clone(),
         fee_policy,
         OrderKind::Buy,
+        None,
         1488043031123213136u128.into(),
         1488043031123213136u128.into(),
     )
@@ -184,6 +224,7 @@ async fn surplus_fee_buy_order_capped_test(web3: Web3) {
         web3.clone(),
         fee_policy,
         OrderKind::Buy,
+        None,
         504208401617866820u128.into(),
         504208401617866820u128.into(),
     )
@@ -205,6 +246,7 @@ async fn volume_fee_buy_order_test(web3: Web3) {
         web3.clone(),
         fee_policy,
         OrderKind::Buy,
+        None,
         504208401617866820u128.into(),
         504208401617866820u128.into(),
     )
@@ -223,6 +265,7 @@ async fn execute_test(
     web3: Web3,
     fee_policy: FeePolicyKind,
     order_kind: OrderKind,
+    app_data: Option<OrderCreationAppData>,
     expected_surplus_fee: U256,
     expected_settlement_contract_balance: U256,
 ) {
@@ -314,6 +357,7 @@ async fn execute_test(
         buy_token: token_dai.address(),
         buy_amount: to_wei(5),
         valid_to: model::time::now_in_epoch_seconds() + 300,
+        app_data: app_data.unwrap_or_default(),
         kind: order_kind,
         ..Default::default()
     }


### PR DESCRIPTION
# Description
Apply partner fee specified in the `appData`.

# Changes
- Overwrite any fee policy with the partner fee if specified in the `appData`
- The fee factor is calculated as `bps / 10000`

## How to test
1. e2e test

Fixes #2502