### PR TITLE
Update gas when setting score with gas

### DIFF
--- a/crates/solvers/src/domain/solution.rs
+++ b/crates/solvers/src/domain/solution.rs
@@ -39,6 +39,7 @@ impl Solution {
         Self { score, ..self }
     }
 
+    /// Sets the provided gas and computes the risk adjusted score accordingly.
     pub fn with_risk_adjusted_score(
         self,
         risk: &Risk,
@@ -46,9 +47,13 @@ impl Solution {
         gas_price: auction::GasPrice,
     ) -> Self {
         let nmb_orders = self.trades.len();
-        self.with_score(Score::RiskAdjusted(SuccessProbability(
+        let scored = self.with_score(Score::RiskAdjusted(SuccessProbability(
             risk.success_probability(gas, gas_price, nmb_orders),
-        )))
+        )));
+        Self {
+            gas: Some(gas),
+            ..scored
+        }
     }
 
     /// Returns `self` with eligible interactions internalized using the

--- a/crates/solvers/src/tests/naive/extract_deepest_pool.rs
+++ b/crates/solvers/src/tests/naive/extract_deepest_pool.rs
@@ -125,7 +125,8 @@ async fn test() {
                 "score": {
                     "kind": "riskAdjusted",
                     "successProbability": 0.5,
-                }
+                },
+                "gas": 94391,
             }]
         }),
     );

--- a/crates/solvers/src/tests/naive/filters_out_of_price_orders.rs
+++ b/crates/solvers/src/tests/naive/filters_out_of_price_orders.rs
@@ -125,7 +125,8 @@ async fn sell_orders_on_both_sides() {
                 "score": {
                     "kind": "riskAdjusted",
                     "successProbability": 0.5,
-                }
+                },
+                "gas": 259417,
             }]
         }),
     );

--- a/crates/solvers/src/tests/naive/matches_orders.rs
+++ b/crates/solvers/src/tests/naive/matches_orders.rs
@@ -105,7 +105,8 @@ async fn sell_orders_on_both_sides() {
                 "score": {
                     "kind": "riskAdjusted",
                     "successProbability": 0.5,
-                }
+                },
+                "gas": 259417,
             }]
         }),
     );
@@ -213,7 +214,8 @@ async fn sell_orders_on_one_side() {
                 "score": {
                     "kind": "riskAdjusted",
                     "successProbability": 0.5,
-                }
+                },
+                "gas": 259417,
             }]
         }),
     );
@@ -321,7 +323,8 @@ async fn buy_orders_on_both_sides() {
                 "score": {
                     "kind": "riskAdjusted",
                     "successProbability": 0.5,
-                }
+                },
+                "gas": 259417,
             }]
         }),
     );
@@ -429,7 +432,8 @@ async fn buy_and_sell_orders() {
                 "score": {
                     "kind": "riskAdjusted",
                     "successProbability": 0.5,
-                }
+                },
+                "gas": 259417,
             }]
         }),
     );

--- a/crates/solvers/src/tests/naive/reserves_too_small.rs
+++ b/crates/solvers/src/tests/naive/reserves_too_small.rs
@@ -98,7 +98,8 @@ async fn test() {
                 "score": {
                     "kind": "riskAdjusted",
                     "successProbability": 0.5,
-                }
+                },
+                "gas": 204391,
             }]
         }),
     );

--- a/crates/solvers/src/tests/naive/rounds_prices_in_favour_of_traders.rs
+++ b/crates/solvers/src/tests/naive/rounds_prices_in_favour_of_traders.rs
@@ -112,7 +112,8 @@ async fn test() {
                 "score": {
                     "kind": "riskAdjusted",
                     "successProbability": 0.5,
-                }
+                },
+                "gas": 259417,
             }]
         }),
     );

--- a/crates/solvers/src/tests/naive/without_pool.rs
+++ b/crates/solvers/src/tests/naive/without_pool.rs
@@ -95,7 +95,8 @@ async fn test() {
                 "score": {
                     "kind": "riskAdjusted",
                     "successProbability": 0.5,
-                }
+                },
+                "gas": 259417,
             }]
         }),
     );


### PR DESCRIPTION
# Description
When computing a score for a solution using a gas estimate we should also update the gas estimate of the whole settlement not just the score.

## How to test
Adjusted naive solver e2e tests