### PR TITLE
Rust v1.77.0

### DIFF
--- a/crates/driver/src/infra/simulator/tenderly/mod.rs
+++ b/crates/driver/src/infra/simulator/tenderly/mod.rs
@@ -101,6 +101,7 @@ pub struct Simulation {
     pub access_list: eth::AccessList,
 }
 
+#[allow(dead_code)]
 #[derive(Debug)]
 pub struct SimulationId(String);
 

--- a/crates/model/src/quote.rs
+++ b/crates/model/src/quote.rs
@@ -495,7 +495,7 @@ mod tests {
                 *expected_quote_responses.get(i).unwrap()
             );
         }
-        let invalid_json = vec![
+        let invalid_json = [
             json!({
                 "from": "0x0000000000000000000000000000000000000000",
                 "sellToken": "0x0000000000000000000000000000000000000001",

--- a/crates/observe/src/future.rs
+++ b/crates/observe/src/future.rs
@@ -34,6 +34,7 @@ pin_project! {
 #[derive(Debug)]
 enum State {
     NeverPolled,
+    #[allow(dead_code)]
     Running(prometheus::HistogramTimer),
     Done,
 }

--- a/crates/shared/src/sources/balancer_v2/pools/common.rs
+++ b/crates/shared/src/sources/balancer_v2/pools/common.rs
@@ -316,7 +316,7 @@ fn share_common_pool_state(
     let result = fut.inspect(|pool_result| {
         // We can't clone `anyhow::Error` so just clone the pool data and use
         // an empty `()` error.
-        let pool_result = pool_result.as_ref().map(Clone::clone).map_err(|_| ());
+        let pool_result = pool_result.as_ref().cloned().map_err(|_| ());
         // Ignore error if the shared future was dropped.
         let _ = pool_sender.send(pool_result);
     });


### PR DESCRIPTION
Fixes all the warnings on the latest stable version. A separate issue should probably be created to remove all the `dead_code` annotations. Also, not a fan of unfixed versions.