### PR TITLE
Upload New AppData to IPFS

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1688,7 +1688,7 @@ dependencies = [
  "tempfile",
  "thiserror",
  "tokio",
- "toml",
+ "toml 0.7.6",
  "tower",
  "tower-http",
  "tracing",
@@ -3405,12 +3405,12 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-crate"
-version = "1.3.1"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f4c021e1093a56626774e81216a4ce732a735e5bad4868a03f3ed65ca0c3919"
+checksum = "e17d47ce914bf4de440332250b0edd23ce48c005f59fab39d3335866b114f11a"
 dependencies = [
- "once_cell",
- "toml_edit",
+ "thiserror",
+ "toml 0.5.11",
 ]
 
 [[package]]
@@ -4245,7 +4245,7 @@ dependencies = [
  "tempfile",
  "thiserror",
  "tokio",
- "toml",
+ "toml 0.7.6",
  "tower",
  "tower-http",
  "tracing",
@@ -4800,6 +4800,15 @@ dependencies = [
  "slab",
  "tokio",
  "tracing",
+]
+
+[[package]]
+name = "toml"
+version = "0.5.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
+dependencies = [
+ "serde",
 ]
 
 [[package]]

--- a/crates/app-data/src/app_data.rs
+++ b/crates/app-data/src/app_data.rs
@@ -18,7 +18,7 @@ pub struct ValidatedAppData {
     pub protocol: ProtocolAppData,
 }
 
-#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq)]
+#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ProtocolAppData {
     #[serde(default)]
@@ -28,12 +28,12 @@ pub struct ProtocolAppData {
     pub partner_fee: Option<PartnerFee>,
 }
 
-#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq)]
+#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
 pub struct ReplacedOrder {
     pub uid: OrderUid,
 }
 
-#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq)]
+#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
 pub struct PartnerFee {
     pub bps: u64,
     pub recipient: H160,

--- a/crates/orderbook/Cargo.toml
+++ b/crates/orderbook/Cargo.toml
@@ -17,7 +17,7 @@ path = "src/main.rs"
 
 [dependencies]
 anyhow = { workspace = true }
-app-data = { path = "../app-data" }
+app-data = { path = "../app-data", features = ["test_helpers"] }
 app-data-hash = { path = "../app-data-hash" }
 async-trait = { workspace = true }
 bigdecimal = { workspace = true }

--- a/crates/orderbook/Cargo.toml
+++ b/crates/orderbook/Cargo.toml
@@ -17,7 +17,7 @@ path = "src/main.rs"
 
 [dependencies]
 anyhow = { workspace = true }
-app-data = { path = "../app-data", features = ["test_helpers"] }
+app-data = { path = "../app-data" }
 app-data-hash = { path = "../app-data-hash" }
 async-trait = { workspace = true }
 bigdecimal = { workspace = true }

--- a/crates/orderbook/src/app_data.rs
+++ b/crates/orderbook/src/app_data.rs
@@ -60,7 +60,13 @@ impl Registry {
             .insert_full_app_data(&validated.hash, &validated.document)
             .await
         {
-            Ok(()) => Ok((Registered::New, validated.hash)),
+            Ok(()) => {
+                // Post New AppData to IPFS after successful insert.
+                if let Some(ipfs) = &self.ipfs {
+                    let _ = ipfs.post_app_data(validated.clone()).await;
+                };
+                Ok((Registered::New, validated.hash))
+            }
             Err(InsertError::Duplicate) => Ok((Registered::AlreadyExisted, validated.hash)),
             Err(InsertError::Mismatch(existing)) => Err(RegisterError::DataMismatch { existing }),
             Err(InsertError::Other(err)) => Err(RegisterError::Other(err)),

--- a/crates/orderbook/src/ipfs.rs
+++ b/crates/orderbook/src/ipfs.rs
@@ -1,6 +1,7 @@
 use {
-    anyhow::{Context, Result},
+    anyhow::{anyhow, Context, Result},
     reqwest::{Client, ClientBuilder, StatusCode},
+    serde::{Deserialize, Serialize},
     std::time::Duration,
     url::Url,
 };
@@ -8,16 +9,32 @@ use {
 pub struct Ipfs {
     client: Client,
     base: Url,
-    query: Option<String>,
+    auth_token: Option<String>,
+}
+
+#[derive(Serialize, Deserialize, Debug, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct PinByHashRequest {
+    pub hash_to_pin: String,
+    pub pinata_metadata: String,
+}
+
+#[derive(Debug, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct PinResponse {
+    pub id: String,
+    pub ipfs_hash: String,
+    pub status: String,
+    pub name: Option<String>,
 }
 
 impl Ipfs {
-    pub fn new(client: ClientBuilder, base: Url, query: Option<String>) -> Self {
+    pub fn new(client: ClientBuilder, base: Url, auth_token: Option<String>) -> Self {
         assert!(!base.cannot_be_a_base());
         Self {
             client: client.timeout(Duration::from_secs(5)).build().unwrap(),
             base,
-            query,
+            auth_token,
         }
     }
 
@@ -53,10 +70,39 @@ impl Ipfs {
 
     fn prepare_url(&self, cid: &str) -> Url {
         let mut url = shared::url::join(&self.base, &format!("ipfs/{cid}"));
-        if let Some(query) = &self.query {
-            url.set_query(Some(query.as_str()));
+        if let Some(jwt) = &self.auth_token {
+            url.set_query(Some(&format!("pinataGatewayToken={}", jwt)));
         }
         url
+    }
+
+    pub async fn add(&self, data: PinByHashRequest) -> Result<PinResponse> {
+        let url = format!("{}pinning/pinByHash", self.base);
+        let jwt = if let Some(jwt) = &self.auth_token {
+            jwt
+        } else {
+            return Err(anyhow!("Can't post without valid JSON web token"));
+        };
+        let resp = self
+            .client
+            .post(url)
+            .header("Authorization", format!("Bearer {}", jwt))
+            .header("Content-Type", "application/json")
+            .json(&data)
+            .send()
+            .await?;
+
+        if resp.status().is_success() {
+            let data = resp.text().await?;
+            let response: PinResponse = serde_json::from_str(&data)?;
+            tracing::debug!("AppData pinned to IPFS with CID: {}", response.ipfs_hash);
+            Ok(response)
+        } else {
+            Err(anyhow!(
+                "Error posting AppData to IPFS: {:?}",
+                resp.text().await
+            ))
+        }
     }
 }
 
@@ -94,5 +140,29 @@ mod tests {
         let cid = "Qma4Dwke5h8mgJyZMDRvKqM3RF7c6Mxcj3fR4um9UGaNF7";
         let result = ipfs.fetch(cid).await.unwrap();
         assert!(result.is_none());
+    }
+
+    #[tokio::test]
+    #[ignore]
+    async fn post_ipfs_doc() {
+        observe::tracing::initialize_reentrant("orderbook::ipfs=trace");
+        let auth = std::env::var("pinata_auth").ok();
+        let ipfs = Ipfs::new(
+            Default::default(),
+            "https://api.pinata.cloud".parse().unwrap(),
+            auth,
+        );
+        // Format of pin_metadata this MUST BE as follows:
+        // {"keyvalues":{"appData":"{\"appCode\":\"CoW Swap\"}"}}
+        // Where the inner appData field is an escaped JSON string.
+        let pin_data = PinByHashRequest {
+            hash_to_pin: "bafkrwih2jqcare44k37njjzoez3bxrxdt4p72nen5fiftlsiyoghqkrbmu".into(),
+            pinata_metadata:  r#"{"keyvalues":{"appData":"{\"appCode\":\"CoW Swap\",\"environment\":\"production\"}"}}"#.into()
+        };
+        let result = ipfs.add(pin_data).await;
+        assert_eq!(
+            result.unwrap().ipfs_hash,
+            "bafkrwih2jqcare44k37njjzoez3bxrxdt4p72nen5fiftlsiyoghqkrbmu"
+        )
     }
 }

--- a/crates/orderbook/src/ipfs.rs
+++ b/crates/orderbook/src/ipfs.rs
@@ -78,6 +78,7 @@ impl Ipfs {
 
     pub async fn add(&self, data: PinByHashRequest) -> Result<PinResponse> {
         let url = format!("{}pinning/pinByHash", self.base);
+        // Prevent upload attempt when `auth_token is None`.
         let jwt = if let Some(jwt) = &self.auth_token {
             jwt
         } else {


### PR DESCRIPTION
This PR closes #2302 by implementing a `post_app_data` method on the `IpfsAppData` structure (which internally calls a newly implemented `Ipfs.add`. This is just a raw http-request `POST` request to this [Pinata Endpoint](https://docs.pinata.cloud/api-reference/endpoint/pin-by-cid).

This is done by introducing a structure with correctly formatted payload that is accepted by the API endpoint (see unit tests for the specific format). Constructor method are in place to manufacture the specific format and all possible routes are tested (however only the expected payload format is included in a test that isn't ignored).

### Notes on Decisions Made
1. At first, I considered using the [ipfs-api crate](https://crates.io/crates/ipfs-api) for this, but the use case was a bit too "niche" with the CID being specifically built on the `appDataHash`.
2. I also looked into @vkgnosis's previous work on the matter [here](https://github.com/cowprotocol/ipfs-block-put), but it only pins the CID.
3. Still not sure exactly which endpoint was supposed to be used (e.g. [PinFileToIPFS](https://docs.pinata.cloud/api-reference/endpoint/pin-file-to-ipfs), [PinJSON](https://docs.pinata.cloud/api-reference/endpoint/pin-json-to-ipfs), but chose [PinByCID](https://docs.pinata.cloud/api-reference/endpoint/pin-by-cid)). The code introduced here results in a successful call to the endpoint, but all the posts are still in a "Pending State" of "searching".... as if they don't exist.

:warning: This endpoint is tightly bound to https://www.pinata.cloud/ who seem to have these "proprietary" endpoints. I looked into using [Infura](https://www.infura.io/product/ipfs), but apparently their IPFS endpoint is "temporarily down".

cc @fleupold (as the creator or the related issue).


