### PR TITLE
Filter Empty Liquidity Sources

### DIFF
--- a/crates/solver/src/liquidity.rs
+++ b/crates/solver/src/liquidity.rs
@@ -73,6 +73,17 @@ impl Liquidity {
             Liquidity::Concentrated(amm) => Some(amm.pool.address),
         }
     }
+
+    pub fn is_empty(&self) -> bool {
+        match self {
+            Liquidity::ConstantProduct(amm) => amm.is_empty(),
+            Liquidity::BalancerWeighted(amm) => amm.is_empty(),
+            Liquidity::BalancerStable(amm) => amm.is_empty(),
+            // This should probably check balances of the limit order...
+            Liquidity::LimitOrder(_) => false,
+            Liquidity::Concentrated(_) => false,
+        }
+    }
 }
 
 /// A trait associating some liquidity model to how it is executed and encoded
@@ -296,6 +307,12 @@ impl ConstantProductOrder {
             settlement_handling,
         }
     }
+
+    pub fn is_empty(&self) -> bool {
+        // Empty if less than 1 WEI.
+        // TODO - this could be improved with a price feed...
+        self.reserves.1 < 1 || self.reserves.0 < 1
+    }
 }
 
 impl std::fmt::Debug for ConstantProductOrder {
@@ -331,6 +348,12 @@ impl std::fmt::Debug for WeightedProductOrder {
     }
 }
 
+impl WeightedProductOrder {
+    fn is_empty(&self) -> bool {
+        false
+    }
+}
+
 #[derive(Clone)]
 #[cfg_attr(test, derive(Derivative))]
 #[cfg_attr(test, derivative(PartialEq))]
@@ -353,6 +376,10 @@ impl StablePoolOrder {
             amplification_parameter: self.amplification_parameter,
         }
         .reserves_without_bpt()
+    }
+
+    fn is_empty(&self) -> bool {
+        false
     }
 }
 

--- a/crates/solver/src/liquidity_collector.rs
+++ b/crates/solver/src/liquidity_collector.rs
@@ -40,6 +40,8 @@ impl LiquidityCollecting for LiquidityCollector {
             .into_iter()
             .flatten()
             .flatten()
+            // Filter empty liquidity
+            .filter(|pool| pool.is_empty())
             .collect();
         tracing::debug!("got {} AMMs", amms.len());
         Ok(amms)


### PR DESCRIPTION
If approved, this PR closes #2349. This is intended to provide the routes necessary to filter empty liquidity sources. It really just amounts to implementing `is_empty` on `Liquidity` but each liquidity source will have its own definition of emptiness. 

In this draft we naively implement the method for every source as "NOT EMPTY" except for `ConstantProduct` pools where we filter out any pool having one or more token reserves equal to 0 WEI. The logic of each of these would benefit from passing relevant token prices to the method calls along with a configurable USD value associated with 
"emptiness".

I was thinking that prices might already exist somewhere in the program's runtime so we could just route them into here (seeking further guidance on how the backend devs plan to approach this). 

cc @MartinquaXD (as the creator of the linked issue)
