### PR TITLE
Allow fetching prices for a short period of time

### DIFF
--- a/crates/autopilot/src/solvable_orders.rs
+++ b/crates/autopilot/src/solvable_orders.rs
@@ -781,9 +781,7 @@ mod tests {
         native_price_estimator
             .expect_estimate_native_price()
             .withf(move |token| *token == token1)
-            .returning(|_| {
-                async { Ok(2.) }.boxed()
-            });
+            .returning(|_| async { Ok(2.) }.boxed());
         native_price_estimator
             .expect_estimate_native_price()
             .times(1)


### PR DESCRIPTION
# Description
Currently the autopilot exclusively fetches cached prices when building an auction. That leads to multiple problems:
1. on restarts all price fetching happens in the background task which has a limited throughput (although native price estimates are very cheap to do most of the time)
2. on restarts we have 1 auction build cycle which is essentially wasted because there are no prices cached at all
3. when a user creates an order trading a new token it will not be included in the next auction because the price fetching for the new token has to be scheduled for the next auction first

# Changes
Change code to allow fetching new prices for a limited period of time. I went for 4 seconds which is still very low low but long enough to allow even the slowest price estimators to return a response (to address problem `3`). Since this delay is very low I didn't bother making this value configurable.

## How to test
e2e tests should still pass
I also built a hacky custom benchmark that specifically checks the behavior when restarting the prod mainnet autopilot and the new approach performed strictly better than the current one. However, this benchmark was not 100% representative so it would still be good to keep an eye on restart performance when this gets merged.