### PR TITLE
Run CI on HEAD commit instead of merge commit

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -11,6 +11,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
       - run: rustup toolchain install stable --profile minimal
       - uses: Swatinem/rust-cache@v2
       - uses: actions-rs/toolchain@v1
@@ -31,6 +33,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
       - uses: ethanis/nitpicker@v1
         with:
           nitpicks: ".github/nitpicks.yml"
@@ -46,6 +50,8 @@ jobs:
       CARGO_TERM_COLOR: always
     steps:
       - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
       - run: rustup toolchain install stable --profile minimal
       - uses: Swatinem/rust-cache@v2
       - uses: taiki-e/install-action@nextest
@@ -62,6 +68,8 @@ jobs:
       CARGO_TERM_COLOR: always
     steps:
       - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
       - run: rustup toolchain install stable --profile minimal
       - uses: Swatinem/rust-cache@v2
       # Start the build process in the background. The following cargo test command will automatically
@@ -85,6 +93,8 @@ jobs:
       TOML_TRACE_ERROR: 1      
     steps:
       - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
       - run: rustup toolchain install stable --profile minimal
       - uses: foundry-rs/foundry-toolchain@v1
       - uses: Swatinem/rust-cache@v2
@@ -113,6 +123,8 @@ jobs:
       TOML_TRACE_ERROR: 1
     steps:
       - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
       - run: rustup toolchain install stable --profile minimal
       - uses: foundry-rs/foundry-toolchain@v1
       - uses: Swatinem/rust-cache@v2
@@ -137,6 +149,8 @@ jobs:
       TOML_TRACE_ERROR: 1      
     steps:
       - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
       - run: rustup toolchain install stable --profile minimal
       - uses: foundry-rs/foundry-toolchain@v1
       - uses: Swatinem/rust-cache@v2
@@ -151,6 +165,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
       - run: npm install @apidevtools/swagger-cli
       - run: node_modules/.bin/swagger-cli validate crates/orderbook/openapi.yml
       - run: node_modules/.bin/swagger-cli validate crates/driver/openapi.yml


### PR DESCRIPTION
# Description
When running CI on PR github does something unexpected. It does actually **NOT** run on the last commit of the PR (i.e. HEAD) but rather checks out the target branch (usually `main`) and merges the HEAD into it.
Most of the time this either works without issues or results in a merge conflict causing the CI to not start at all.

However, when the HEAD commit can be merged into the target branch without merge conflicts **BUT WITH BREAKING CHANGES NEVERTHELESS** you get build or test execution issues that can not be reproduced by just using your branch locally.

For more info check out the investigation on [slack](https://cowservices.slack.com/archives/C0375NV72SC/p1712179673286249?thread_ts=1712177157.374909&cid=C0375NV72SC).

# Changes
Configures checkout action to pull HEAD instead of the merge commit.

## How to test
Check the job history of this https://github.com/cowprotocol/services/pull/2591.
First it didn't work because the `main` branch made `start_autopilot` async without causing a merge conflict. But with this patch it actually ran the CI on the commit one would intuitively expect.
Note that github still doesn't let you merge the PR if it's not up-to-date so I don't really see any downside using the HEAD commit here.