### PR TITLE
[EASY] Print filtered order count

### DIFF
--- a/crates/autopilot/src/solvable_orders.rs
+++ b/crates/autopilot/src/solvable_orders.rs
@@ -665,7 +665,11 @@ impl OrderFilterCounter {
             self.orders.remove(order_uid).unwrap();
         }
         if !filtered_orders.is_empty() {
-            tracing::debug!(%reason, orders = ?filtered_orders, "filtered orders");
+            tracing::debug!(
+                %reason,
+                count = filtered_orders.len(),
+                orders = ?filtered_orders, "filtered orders"
+            );
         }
         filtered_orders.into_keys().collect()
     }


### PR DESCRIPTION
# Description
Currently it's a bit hard to see from the logs whether orders filtered for a specific reason increase, decrease or stay constant.

# Changes
Not only log which orders got filtered for a reason but also how many in total.