### PR TITLE
Autopilot: Allow empty whitelisted addresses

### DIFF
--- a/crates/autopilot/src/arguments.rs
+++ b/crates/autopilot/src/arguments.rs
@@ -210,7 +210,7 @@ pub struct Arguments {
     /// List of addresses which are exempt from the protocol
     /// fees
     #[clap(long, env, use_value_delimiter = true)]
-    pub protocol_fee_exempt_addresses: Vec<H160>,
+    pub protocol_fee_exempt_addresses: Option<Vec<H160>>,
 
     /// Arguments for uploading information to S3.
     #[clap(flatten)]

--- a/crates/autopilot/src/domain/fee/mod.rs
+++ b/crates/autopilot/src/domain/fee/mod.rs
@@ -65,7 +65,7 @@ impl ProtocolFees {
     pub fn new(
         fee_policies: &[arguments::FeePolicy],
         fee_policy_max_partner_fee: FeeFactor,
-        protocol_fee_exempt_addresses: &[H160],
+        protocol_fee_exempt_addresses: Option<&[H160]>,
     ) -> Self {
         Self {
             fee_policies: fee_policies
@@ -74,9 +74,13 @@ impl ProtocolFees {
                 .map(ProtocolFee::from)
                 .collect(),
             protocol_fee_exempt_addresses: protocol_fee_exempt_addresses
-                .iter()
-                .cloned()
-                .collect::<HashSet<_>>(),
+                .map(|protocol_fee_exempt_addresses| {
+                    protocol_fee_exempt_addresses
+                        .iter()
+                        .cloned()
+                        .collect::<HashSet<_>>()
+                })
+                .unwrap_or_default(),
             max_partner_fee: fee_policy_max_partner_fee,
         }
     }

--- a/crates/autopilot/src/run.rs
+++ b/crates/autopilot/src/run.rs
@@ -561,7 +561,7 @@ pub async fn run(args: Arguments) {
         domain::ProtocolFees::new(
             &args.fee_policies,
             args.fee_policy_max_partner_fee,
-            args.protocol_fee_exempt_addresses.as_slice(),
+            args.protocol_fee_exempt_addresses.as_deref(),
         ),
     );
 


### PR DESCRIPTION
# Description
Autopilot: Allow empty whitelisted addresses

# Changes
- Allow not providing whitelisted addresses for fee exempt

## How to test
1. e2e tests