### PR TITLE
Fix decimals for OneInchSpotPrice estimator

### DIFF
--- a/crates/shared/src/price_estimation/factory.rs
+++ b/crates/shared/src/price_estimation/factory.rs
@@ -296,6 +296,7 @@ impl<'a> PriceEstimatorFactory<'a> {
                     self.args.one_inch_api_key.clone(),
                     self.network.chain_id,
                     self.network.block_stream.clone(),
+                    self.components.tokens.clone(),
                 )),
             )),
         }

--- a/crates/shared/src/price_estimation/native.rs
+++ b/crates/shared/src/price_estimation/native.rs
@@ -10,7 +10,8 @@ use {
 mod oneinch;
 pub use self::oneinch::OneInch;
 
-pub type NativePriceEstimateResult = Result<f64, PriceEstimationError>;
+pub type NativePrice = f64;
+pub type NativePriceEstimateResult = Result<NativePrice, PriceEstimationError>;
 
 pub fn default_amount_to_estimate_native_prices_with(chain_id: u64) -> Option<U256> {
     match chain_id {

--- a/crates/shared/src/price_estimation/native/oneinch.rs
+++ b/crates/shared/src/price_estimation/native/oneinch.rs
@@ -1,5 +1,5 @@
 use {
-    super::{NativePriceEstimateResult, NativePriceEstimating},
+    super::{NativePrice, NativePriceEstimateResult, NativePriceEstimating},
     crate::{price_estimation::PriceEstimationError, token_info::TokenInfoFetching},
     anyhow::{anyhow, Context, Result},
     ethrpc::current_block::{into_stream, CurrentBlockStream},
@@ -19,13 +19,12 @@ use {
 
 #[serde_as]
 #[derive(Debug, Deserialize, Serialize)]
-struct Response(#[serde_as(as = "HashMap<_, HexOrDecimalU256>")] HashMap<Token, PriceInWei>);
+struct Response(#[serde_as(as = "HashMap<_, HexOrDecimalU256>")] HashMap<H160, U256>);
 
 type Token = H160;
-type PriceInWei = U256;
 
 pub struct OneInch {
-    prices: Arc<Mutex<HashMap<Token, f64>>>,
+    prices: Arc<Mutex<HashMap<Token, NativePrice>>>,
 }
 
 impl OneInch {


### PR DESCRIPTION
# Description
OneInchSpotPrice estimator assumes that all tokens have 18 decimals. In order for `NativePriceEstimateResult` to be populated as expected, we need to divide the response by number of the decimals for each specific token.

USDC example: https://production-6de61f.kb.eu-central-1.aws.cloud.es.io/app/r/s/EFIxv
Here we can see that result was divided by 1e18 instead of 1e6, since USDC has 6 decimals.

# Changes
<!-- List of detailed changes (how the change is accomplished) -->

- [ ] Added token info fetching to OneInchSpotPrice estimator
- [ ] ...

## How to test
Existing tests