### PR TITLE
Use BigInt to compute unit

### DIFF
--- a/crates/shared/src/price_estimation/native/oneinch.rs
+++ b/crates/shared/src/price_estimation/native/oneinch.rs
@@ -140,7 +140,8 @@ async fn get_current_prices(
                 tracing::debug!(?token, "could not fetch decimals; discarding spot price");
                 return None;
             };
-            let unit = num::BigRational::from_integer(num::BigInt::from(10u64).pow(decimals.into()));
+            let unit =
+                num::BigRational::from_integer(num::BigInt::from(10u64).pow(decimals.into()));
             let normalized_price = u256_to_big_rational(&price) / unit;
             Some((token, normalized_price.to_f64()?))
         })

--- a/crates/shared/src/price_estimation/native/oneinch.rs
+++ b/crates/shared/src/price_estimation/native/oneinch.rs
@@ -140,7 +140,7 @@ async fn get_current_prices(
                 tracing::debug!(?token, "could not fetch decimals; discarding spot price");
                 return None;
             };
-            let unit = num::BigRational::from_integer(10u64.pow(decimals.into()).into());
+            let unit = num::BigRational::from_integer(num::BigInt::from(10u64).pow(decimals.into()));
             let normalized_price = u256_to_big_rational(&price) / unit;
             Some((token, normalized_price.to_f64()?))
         })


### PR DESCRIPTION
# Description
Follow up to https://github.com/cowprotocol/services/pull/2603.
10**24 doesn't fit into a `u64` so we were still dividing by the wrong base.

# Changes
compute base using big int which does not result in an over flow see [here](https://play.rust-lang.org/?version=stable&mode=debug&edition=2021&gist=6321e0b405f0e6ff0f469b5a8ecedbc1).

## How to test
tested using rust playground ☝️ 