### PR TITLE
Index Traded order event labels based on on-chain data

### DIFF
--- a/crates/autopilot/src/database/on_settlement_event_updater.rs
+++ b/crates/autopilot/src/database/on_settlement_event_updater.rs
@@ -75,9 +75,7 @@ impl super::Postgres {
                 .iter()
                 .map(|(order_uid, _)| auction::order::OrderUid::from(*order_uid))
                 .collect::<Vec<_>>();
-            store_order_events(ex, order_uids, OrderEventLabel::Traded, Utc::now())
-                .await
-                .context("store_order_events")?;
+            store_order_events(ex, order_uids, OrderEventLabel::Traded, Utc::now()).await;
             for (order, executed_fee) in auction_data.order_executions {
                 database::order_execution::save(
                     ex,

--- a/crates/autopilot/src/database/on_settlement_event_updater.rs
+++ b/crates/autopilot/src/database/on_settlement_event_updater.rs
@@ -73,9 +73,8 @@ impl super::Postgres {
             let order_uids = auction_data
                 .order_executions
                 .iter()
-                .map(|(order_uid, _)| *order_uid)
-                .map(Into::into)
-                .collect::<Vec<auction::order::OrderUid>>();
+                .map(|(order_uid, _)| auction::order::OrderUid::from(*order_uid))
+                .collect::<Vec<_>>();
             store_order_events(ex, order_uids, OrderEventLabel::Traded, Utc::now())
                 .await
                 .context("store_order_events")?;

--- a/crates/autopilot/src/database/on_settlement_event_updater.rs
+++ b/crates/autopilot/src/database/on_settlement_event_updater.rs
@@ -1,6 +1,12 @@
 use {
+    crate::{database::order_events::store_order_events, domain::auction},
     anyhow::{Context, Result},
-    database::{byte_array::ByteArray, settlement_observations::Observation},
+    chrono::Utc,
+    database::{
+        byte_array::ByteArray,
+        order_events::OrderEventLabel,
+        settlement_observations::Observation,
+    },
     ethcontract::U256,
     model::order::OrderUid,
     number::conversions::u256_to_big_decimal,
@@ -64,6 +70,15 @@ impl super::Postgres {
             .await
             .context("insert_settlement_observations")?;
 
+            let order_uids = auction_data
+                .order_executions
+                .iter()
+                .map(|(order_uid, _)| *order_uid)
+                .map(Into::into)
+                .collect::<Vec<auction::order::OrderUid>>();
+            store_order_events(ex, order_uids, OrderEventLabel::Traded, Utc::now())
+                .await
+                .context("store_order_events")?;
             for (order, executed_fee) in auction_data.order_executions {
                 database::order_execution::save(
                     ex,

--- a/crates/autopilot/src/infra/persistence/mod.rs
+++ b/crates/autopilot/src/infra/persistence/mod.rs
@@ -104,7 +104,6 @@ impl Persistence {
         let db = self.postgres.clone();
         tokio::spawn(
             async move {
-
                 let store_order_events_inner = async {
                     let start = Instant::now();
                     let events_count = order_uids.len();
@@ -114,17 +113,16 @@ impl Persistence {
                     Ok::<(Instant, usize), anyhow::Error>((start, events_count))
                 };
 
-        match store_order_events_inner.await {
-            Ok((start, events_count)) => {
-                tracing::debug!(elapsed=?start.elapsed(), ?events_count, "stored order events");
+                match store_order_events_inner.await {
+                    Ok((start, events_count)) => {
+                        tracing::debug!(elapsed=?start.elapsed(), ?events_count, "stored order events");
+                    }
+                    Err(err) => {
+                        tracing::warn!(?err, "failed to insert order events");
+                    }
+                }
             }
-            Err(err) => {
-                tracing::warn!(?err, "failed to insert order events");
-            }
-        }
-
-            }
-                .instrument(tracing::Span::current()),
+            .instrument(tracing::Span::current()),
         );
     }
 

--- a/crates/autopilot/src/infra/persistence/mod.rs
+++ b/crates/autopilot/src/infra/persistence/mod.rs
@@ -104,9 +104,7 @@ impl Persistence {
         tokio::spawn(
             async move {
                 let mut tx = db.pool.acquire().await.expect("failed to acquire tx");
-                store_order_events(&mut tx, order_uids, label, Utc::now())
-                    .await
-                    .expect("store_order_events");
+                store_order_events(&mut tx, order_uids, label, Utc::now()).await;
             }
             .instrument(tracing::Span::current()),
         );

--- a/crates/autopilot/src/run_loop.rs
+++ b/crates/autopilot/src/run_loop.rs
@@ -424,10 +424,6 @@ impl RunLoop {
             tx_hash,
             orders: solved.orders.keys().copied().collect(),
         });
-
-        let order_uids = solved.orders.keys().copied().collect();
-        self.persistence
-            .store_order_events(order_uids, OrderEventLabel::Traded);
         tracing::debug!(?tx_hash, "solution settled");
 
         Ok(())


### PR DESCRIPTION
# Description
Currently we are indexing the Traded events after the driver reports that it settled the solution. However, it can happen that the solver thinks it failed to submit a solution but actually succeeded.

# Changes
Index order event labels when we are indexing the on-chain events.

## How to test
1. regression tests

## Related Issues
Fixes #2530