### PR TITLE
Actually sort descending 🙈

### DIFF
--- a/crates/driver/src/domain/competition/mod.rs
+++ b/crates/driver/src/domain/competition/mod.rs
@@ -1,6 +1,9 @@
 use {
     self::solution::settlement,
-    super::{time, time::Remaining, Mempools},
+    super::{
+        time::{self, Remaining},
+        Mempools,
+    },
     crate::{
         domain::{competition::solution::Settlement, eth},
         infra::{
@@ -16,6 +19,7 @@ use {
     futures::{stream::FuturesUnordered, StreamExt},
     itertools::Itertools,
     std::{
+        cmp::Reverse,
         collections::{HashMap, HashSet},
         sync::Mutex,
     },
@@ -348,10 +352,12 @@ fn merge(solutions: impl Iterator<Item = Solution>, auction: &Auction) -> Vec<So
 
     // Sort merged solutions descending by score.
     merged.sort_by_key(|solution| {
-        solution
-            .scoring(&auction.prices())
-            .map(|score| score.0)
-            .unwrap_or_default()
+        Reverse(
+            solution
+                .scoring(&auction.prices())
+                .map(|score| score.0)
+                .unwrap_or_default(),
+        )
     });
     merged
 }


### PR DESCRIPTION
# Description
It turns out we were not actually sorting solutions in descending but in ascending score when merging them. This is not an issue per se as - given enough time - all solutions get simulated and the one with the highest score gets picked (for this there are tests).

However, if there are a lot of solution candidates (more than we have time to encode), the ordering matters for prioritisation.

# Changes
- [x] Reverse sorting 

## How to test
Since this aspect only happens when we run out of time it's quite hard to test. Not sure if it's necessary. If you have an idea please let me know.