### PR TITLE
Add request id header for rpc requests

### DIFF
--- a/crates/ethrpc/src/http.rs
+++ b/crates/ethrpc/src/http.rs
@@ -72,16 +72,19 @@ async fn execute_rpc<T: DeserializeOwned>(
 ) -> Result<T, Web3Error> {
     let body = serde_json::to_string(&request)?;
     tracing::trace!(name = %inner.name, %id, %body, "executing request");
-    let response = client
+    let mut request = client
         .post(inner.url.clone())
         .header(header::CONTENT_TYPE, "application/json")
-        .body(body)
-        .send()
-        .await
-        .map_err(|err: reqwest::Error| {
-            tracing::warn!(name = %inner.name, %id, %err, "failed to send request");
-            Web3Error::Transport(TransportError::Message(err.to_string()))
-        })?;
+        .header("X-RPC-REQUEST-ID", id.to_string())
+        .body(body);
+    if let Some(request_id) = observe::request_id::get_task_local_storage() {
+        request = request.header("X-REQUEST-ID", request_id);
+    }
+
+    let response = request.send().await.map_err(|err: reqwest::Error| {
+        tracing::warn!(name = %inner.name, %id, %err, "failed to send request");
+        Web3Error::Transport(TransportError::Message(err.to_string()))
+    })?;
     let status = response.status();
     let text = response.text().await.map_err(|err: reqwest::Error| {
         tracing::warn!(name = %inner.name, %id, %err, "failed to get response body");


### PR DESCRIPTION
# Description
Add a request id header for the RPC requests.

# Changes
<!-- List of detailed changes (how the change is accomplished) -->
This PR adds the following request HTTP headers on RPC requests:
- `X-RPC-Request-Id` - The unique ID of the RPC request.
- `X-Request-Id` - The top level request id passed as a request header for the RPC request generated.

## How to test
<!--- Include details of how to test your changes, including any pre-requisites. If no unit tests are included, please explain why and how to test manually
1.
2.
3.
-->
I couldn't find a suitable way to test this. Maybe, it would be useful to create tests for the RPC request execution and assert that those headers are been sending.

## Related Issues

Fixes #2519