### PR TITLE
Isolate Settlement Encoding logic

### DIFF
--- a/crates/driver/src/domain/competition/mod.rs
+++ b/crates/driver/src/domain/competition/mod.rs
@@ -246,17 +246,13 @@ impl Competition {
             .ok_or(Error::SolutionNotAvailable)?;
         Ok(Revealed {
             internalized_calldata: settlement
-                .calldata(
-                    self.eth.contracts().settlement(),
-                    settlement::Internalization::Enable,
-                )
-                .into(),
+                .transaction(settlement::Internalization::Enable)
+                .input
+                .clone(),
             uninternalized_calldata: settlement
-                .calldata(
-                    self.eth.contracts().settlement(),
-                    settlement::Internalization::Disable,
-                )
-                .into(),
+                .transaction(settlement::Internalization::Disable)
+                .input
+                .clone(),
         })
     }
 
@@ -282,17 +278,13 @@ impl Competition {
             Err(_) => Err(Error::SubmissionError),
             Ok(tx_hash) => Ok(Settled {
                 internalized_calldata: settlement
-                    .calldata(
-                        self.eth.contracts().settlement(),
-                        settlement::Internalization::Enable,
-                    )
-                    .into(),
+                    .transaction(settlement::Internalization::Enable)
+                    .input
+                    .clone(),
                 uninternalized_calldata: settlement
-                    .calldata(
-                        self.eth.contracts().settlement(),
-                        settlement::Internalization::Disable,
-                    )
-                    .into(),
+                    .transaction(settlement::Internalization::Disable)
+                    .input
+                    .clone(),
                 tx_hash,
             }),
         }
@@ -313,16 +305,11 @@ impl Competition {
         settlement: &Settlement,
     ) -> Result<(), infra::simulator::Error> {
         self.simulator
-            .gas(eth::Tx {
-                from: self.solver.address(),
-                to: settlement.solver(),
-                value: eth::Ether(0.into()),
-                input: crate::util::Bytes(settlement.calldata(
-                    self.eth.contracts().settlement(),
-                    settlement::Internalization::Enable,
-                )),
-                access_list: settlement.access_list.clone(),
-            })
+            .gas(
+                settlement
+                    .transaction(settlement::Internalization::Enable)
+                    .clone(),
+            )
             .await
             .map(|_| ())
     }


### PR DESCRIPTION
# Description
In order to move the settlement encoding logic from the boundar module/legacy solver crate into the domain it helps to first isolate the call to encode into a single place. This will then allow us to wrap this invocation behind a conditional config variable to control the rollout (once implemented)

# Changes

- [x] Instead of storing a `boundary::Settlement` on `domain::Settlement` store a struct that references `domain::eth::Tx` directly (one for internalized interactions, one for uninternalised interactions repr)
- [x] Find alternatives for the remaining calls to `settlement.boundary` (most of them are already exposed on the solution directly)

## How to test
CI

## Related Issues

First step of #2215 