### PR TITLE
Also init tracing panic handler in reentrant function

### DIFF
--- a/crates/observe/src/tracing.rs
+++ b/crates/observe/src/tracing.rs
@@ -21,7 +21,10 @@ pub fn initialize_reentrant(env_filter: &str) {
     // The tracing subscriber below is global object so initializing it again in the
     // same process by a different thread would fail.
     static ONCE: Once = Once::new();
-    ONCE.call_once(|| set_tracing_subscriber(env_filter, LevelFilter::ERROR));
+    ONCE.call_once(|| {
+        set_tracing_subscriber(env_filter, LevelFilter::ERROR);
+        std::panic::set_hook(Box::new(tracing_panic_hook));
+    });
 }
 
 fn set_tracing_subscriber(env_filter: &str, stderr_threshold: LevelFilter) {


### PR DESCRIPTION
# Description
Currently panic logs emitted from the driver bleed into the preceeding log because we don't emit the current date which is used by fluentd to split multi line strings.

# Changes
Now we also set the tracing related panic handler when we call the reentrant tracing initialization function.

## How to test
Tested locally by triggering a test panic and checking the logs. (note the timestamp at the start of the log)

```
2024-04-22T14:56:29.840Z ERROR observe::tracing: thread 'main' panicked at /Users/martin/work/backend/main/crates/driver/src/run.rs:46:5:
test panic
stack backtrace:
   0: std::backtrace_rs::backtrace::libunwind::trace
             at /rustc/25ef9e3d85d934b27d9dada2f9dd52b1dc63bb04/library/std/src/../../backtrace/src/backtrace/libunwind.rs:104:5
   1: std::backtrace_rs::backtrace::trace_unsynchronized
             at /rustc/25ef9e3d85d934b27d9dada2f9dd52b1dc63bb04/library/std/src/../../backtrace/src/backtrace/mod.rs:66:5
   2: std::backtrace::Backtrace::create
             at /rustc/25ef9e3d85d934b27d9dada2f9dd52b1dc63bb04/library/std/src/backtrace.rs:331:13
   3: observe::tracing::tracing_panic_hook
             at ./crates/observe/src/tracing.rs:58:21
   4: core::ops::function::Fn::call
             at /rustc/25ef9e3d85d934b27d9dada2f9dd52b1dc63bb04/library/core/src/ops/function.rs:79:5
   5: <alloc::boxed::Box<F,A> as core::ops::function::Fn<Args>>::call
             at /rustc/25ef9e3d85d934b27d9dada2f9dd52b1dc63bb04/library/alloc/src/boxed.rs:2029:9
   6: std::panicking::rust_panic_with_hook
             at /rustc/25ef9e3d85d934b27d9dada2f9dd52b1dc63bb04/library/std/src/panicking.rs:785:13
   7: std::panicking::begin_panic_handler::{{closure}}
             at /rustc/25ef9e3d85d934b27d9dada2f9dd52b1dc63bb04/library/std/src/panicking.rs:651:13
   8: std::sys_common::backtrace::__rust_end_short_backtrace
             at /rustc/25ef9e3d85d934b27d9dada2f9dd52b1dc63bb04/library/std/src/sys_common/backtrace.rs:171:18
   9: rust_begin_unwind
             at /rustc/25ef9e3d85d934b27d9dada2f9dd52b1dc63bb04/library/std/src/panicking.rs:647:5
  10: core::panicking::panic_fmt
             at /rustc/25ef9e3d85d934b27d9dada2f9dd52b1dc63bb04/library/core/src/panicking.rs:72:14
  11: driver::run::run_with::{{closure}}
             at ./crates/driver/src/run.rs:46:5
  12: driver::run::start::{{closure}}
             at ./crates/driver/src/run.rs:25:26
  13: driver::main::{{closure}}
             at ./crates/driver/src/main.rs:3:37
  14: tokio::runtime::park::CachedParkThread::block_on::{{closure}}
             at /Users/martin/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.32.0/src/runtime/park.rs:282:63
  15: tokio::runtime::coop::with_budget
             at /Users/martin/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.32.0/src/runtime/coop.rs:107:5
  16: tokio::runtime::coop::budget
             at /Users/martin/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.32.0/src/runtime/coop.rs:73:5
  17: tokio::runtime::park::CachedParkThread::block_on
             at /Users/martin/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.32.0/src/runtime/park.rs:282:31
  18: tokio::runtime::context::blocking::BlockingRegionGuard::block_on
             at /Users/martin/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.32.0/src/runtime/context/blocking.rs:66:9
  19: tokio::runtime::scheduler::multi_thread::MultiThread::block_on::{{closure}}
             at /Users/martin/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.32.0/src/runtime/scheduler/multi_thread/mod.rs:87:13
  20: tokio::runtime::context::runtime::enter_runtime
             at /Users/martin/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.32.0/src/runtime/context/runtime.rs:65:16
  21: tokio::runtime::scheduler::multi_thread::MultiThread::block_on
             at /Users/martin/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.32.0/src/runtime/scheduler/multi_thread/mod.rs:86:9
  22: tokio::runtime::runtime::Runtime::block_on
             at /Users/martin/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.32.0/src/runtime/runtime.rs:349:45
  23: driver::main
             at ./crates/driver/src/main.rs:3:5
  24: core::ops::function::FnOnce::call_once
             at /rustc/25ef9e3d85d934b27d9dada2f9dd52b1dc63bb04/library/core/src/ops/function.rs:250:5
  25: std::sys_common::backtrace::__rust_begin_short_backtrace
             at /rustc/25ef9e3d85d934b27d9dada2f9dd52b1dc63bb04/library/std/src/sys_common/backtrace.rs:155:18
  26: std::rt::lang_start::{{closure}}
             at /rustc/25ef9e3d85d934b27d9dada2f9dd52b1dc63bb04/library/std/src/rt.rs:166:18
  27: core::ops::function::impls::<impl core::ops::function::FnOnce<A> for &F>::call_once
             at /rustc/25ef9e3d85d934b27d9dada2f9dd52b1dc63bb04/library/core/src/ops/function.rs:284:13
  28: std::panicking::try::do_call
             at /rustc/25ef9e3d85d934b27d9dada2f9dd52b1dc63bb04/library/std/src/panicking.rs:554:40
  29: std::panicking::try
             at /rustc/25ef9e3d85d934b27d9dada2f9dd52b1dc63bb04/library/std/src/panicking.rs:518:19
  30: std::panic::catch_unwind
             at /rustc/25ef9e3d85d934b27d9dada2f9dd52b1dc63bb04/library/std/src/panic.rs:142:14
  31: std::rt::lang_start_internal::{{closure}}
             at /rustc/25ef9e3d85d934b27d9dada2f9dd52b1dc63bb04/library/std/src/rt.rs:148:48
  32: std::panicking::try::do_call
             at /rustc/25ef9e3d85d934b27d9dada2f9dd52b1dc63bb04/library/std/src/panicking.rs:554:40
  33: std::panicking::try
             at /rustc/25ef9e3d85d934b27d9dada2f9dd52b1dc63bb04/library/std/src/panicking.rs:518:19
  34: std::panic::catch_unwind
             at /rustc/25ef9e3d85d934b27d9dada2f9dd52b1dc63bb04/library/std/src/panic.rs:142:14
  35: std::rt::lang_start_internal
             at /rustc/25ef9e3d85d934b27d9dada2f9dd52b1dc63bb04/library/std/src/rt.rs:148:20
  36: std::rt::lang_start
             at /rustc/25ef9e3d85d934b27d9dada2f9dd52b1dc63bb04/library/std/src/rt.rs:165:17
  37: _main
```