### PR TITLE
Revert "Make UniswapV3 state clones cheap"

### DIFF
--- a/crates/driver/src/boundary/liquidity/uniswap/v3.rs
+++ b/crates/driver/src/boundary/liquidity/uniswap/v3.rs
@@ -34,30 +34,32 @@ use {
 };
 
 pub fn to_domain(id: liquidity::Id, pool: ConcentratedLiquidity) -> Result<liquidity::Liquidity> {
+    anyhow::ensure!(
+        pool.pool.tokens.len() == 2,
+        "Uniswap V3 pools should have exactly 2 tokens",
+    );
+
     let handler = pool
         .settlement_handling
         .as_any()
         .downcast_ref::<uniswap_v3::UniswapV3SettlementHandler>()
         .expect("downcast uniswap settlement handler");
 
-    let pool = pool.pool.read_lock();
-
-    anyhow::ensure!(
-        pool.tokens.len() == 2,
-        "Uniswap V3 pools should have exactly 2 tokens",
-    );
-
     Ok(liquidity::Liquidity {
         id,
-        gas: eth::Gas(pool.gas_stats.mean_gas),
+        gas: eth::Gas(pool.pool.gas_stats.mean_gas),
         kind: liquidity::Kind::UniswapV3(Pool {
             router: handler.inner.router.address().into(),
-            address: pool.address.into(),
-            tokens: liquidity::TokenPair::new(pool.tokens[0].id.into(), pool.tokens[1].id.into())?,
-            sqrt_price: SqrtPrice(pool.state.sqrt_price),
-            liquidity: Liquidity(pool.state.liquidity.as_u128()),
-            tick: Tick(pool.state.tick.clone().try_into()?),
+            address: pool.pool.address.into(),
+            tokens: liquidity::TokenPair::new(
+                pool.pool.tokens[0].id.into(),
+                pool.pool.tokens[1].id.into(),
+            )?,
+            sqrt_price: SqrtPrice(pool.pool.state.sqrt_price),
+            liquidity: Liquidity(pool.pool.state.liquidity.as_u128()),
+            tick: Tick(pool.pool.state.tick.try_into()?),
             liquidity_net: pool
+                .pool
                 .state
                 .liquidity_net
                 .iter()
@@ -65,7 +67,7 @@ pub fn to_domain(id: liquidity::Id, pool: ConcentratedLiquidity) -> Result<liqui
                     Ok((Tick(key.try_into()?), LiquidityNet(value.try_into()?)))
                 })
                 .collect::<Result<BTreeMap<_, _>>>()?,
-            fee: Fee(pool.state.fee),
+            fee: Fee(pool.pool.state.fee),
         }),
     })
 }

--- a/crates/shared/src/http_solver/model.rs
+++ b/crates/shared/src/http_solver/model.rs
@@ -1,7 +1,7 @@
 use {
     crate::{
         interaction::{EncodedInteraction, Interaction},
-        sources::uniswap_v3::pool_fetching::PoolInfoHandle,
+        sources::uniswap_v3::pool_fetching::PoolInfo,
     },
     derivative::Derivative,
     ethcontract::{Bytes, H160},
@@ -117,7 +117,7 @@ pub struct StablePoolParameters {
 #[serde_as]
 #[derive(Clone, Debug, Default, Serialize)]
 pub struct ConcentratedPoolParameters {
-    pub pool: PoolInfoHandle,
+    pub pool: PoolInfo,
 }
 
 #[serde_as]
@@ -471,7 +471,7 @@ pub enum InternalizationStrategy {
 mod tests {
     use {
         super::*,
-        crate::sources::uniswap_v3::{graph_api::Token, pool_fetching::PoolInfo},
+        crate::sources::uniswap_v3::graph_api::Token,
         app_data::AppDataHash,
         ethcontract::H256,
         maplit::btreemap,
@@ -625,8 +625,7 @@ mod tests {
                         },
                     ],
                     ..Default::default()
-                }
-                .into(),
+                },
             }),
             fee: BigRational::new(3.into(), 1000.into()),
             cost: TokenAmount {

--- a/crates/shared/src/price_estimation/http.rs
+++ b/crates/shared/src/price_estimation/http.rs
@@ -206,7 +206,7 @@ impl HttpTradeFinder {
                 AmmParameters::WeightedProduct(params) => tokens.extend(params.reserves.keys()),
                 AmmParameters::Stable(params) => tokens.extend(params.reserves.keys()),
                 AmmParameters::Concentrated(params) => {
-                    tokens.extend(params.pool.read_lock().tokens.iter().map(|token| token.id))
+                    tokens.extend(params.pool.tokens.iter().map(|token| token.id))
                 }
             }
         }
@@ -343,20 +343,15 @@ impl HttpTradeFinder {
         };
         Ok(pools
             .into_iter()
-            .map(|pool| {
-                let parameters =
-                    AmmParameters::Concentrated(ConcentratedPoolParameters { pool: pool.clone() });
-                let pool = pool.read_lock();
-                AmmModel {
-                    fee: BigRational::from((
-                        BigInt::from(*pool.state.fee.numer()),
-                        BigInt::from(*pool.state.fee.denom()),
-                    )),
-                    cost: gas_model.cost_for_gas(pool.gas_stats.mean_gas),
-                    address: pool.address,
-                    parameters,
-                    mandatory: false,
-                }
+            .map(|pool| AmmModel {
+                fee: BigRational::from((
+                    BigInt::from(*pool.state.fee.numer()),
+                    BigInt::from(*pool.state.fee.denom()),
+                )),
+                cost: gas_model.cost_for_gas(pool.gas_stats.mean_gas),
+                address: pool.address,
+                parameters: AmmParameters::Concentrated(ConcentratedPoolParameters { pool }),
+                mandatory: false,
             })
             .collect())
     }

--- a/crates/shared/src/sources/uniswap_v3/pool_fetching.rs
+++ b/crates/shared/src/sources/uniswap_v3/pool_fetching.rs
@@ -22,9 +22,9 @@ use {
     serde::Serialize,
     serde_with::{serde_as, DisplayFromStr},
     std::{
-        collections::{hash_map::Entry, BTreeMap, HashMap, HashSet},
+        collections::{BTreeMap, HashMap, HashSet},
         ops::Neg,
-        sync::{Arc, Mutex, RwLock},
+        sync::{Arc, Mutex},
     },
 };
 
@@ -34,7 +34,7 @@ pub trait PoolFetching: Send + Sync {
         &self,
         token_pairs: &HashSet<TokenPair>,
         at_block: Block,
-    ) -> Result<Vec<PoolInfoHandle>>;
+    ) -> Result<Vec<PoolInfo>>;
 }
 
 /// Pool data in a format prepared for solvers.
@@ -47,29 +47,6 @@ pub struct PoolInfo {
     pub tokens: Vec<Token>,
     pub state: PoolState,
     pub gas_stats: PoolStats,
-}
-
-/// Cheaply clonable handle to shared pool state to improve performance.
-#[derive(Clone, Debug, Default, Serialize)]
-pub struct PoolInfoHandle(Arc<RwLock<PoolInfo>>);
-
-impl PoolInfoHandle {
-    /// Get reference to inner state by taking a read lock.
-    pub fn read_lock(&self) -> std::sync::RwLockReadGuard<PoolInfo> {
-        self.0.read().unwrap()
-    }
-}
-
-impl PartialEq for PoolInfoHandle {
-    fn eq(&self, other: &Self) -> bool {
-        Arc::ptr_eq(&self.0, &other.0)
-    }
-}
-
-impl From<PoolInfo> for PoolInfoHandle {
-    fn from(pool: PoolInfo) -> Self {
-        Self(Arc::new(RwLock::new(pool)))
-    }
 }
 
 /// Pool state in a format prepared for solvers.
@@ -133,7 +110,7 @@ impl TryFrom<PoolData> for PoolInfo {
 #[derive(Default)]
 struct PoolsCheckpoint {
     /// Pools state.
-    pools: HashMap<H160, PoolInfoHandle>,
+    pools: HashMap<H160, PoolInfo>,
     /// Block number for which `pools` field was populated.
     block_number: u64,
     /// Pools that don't exist in `pools` field, therefore need to be
@@ -192,7 +169,7 @@ impl PoolsCheckpointHandler {
             .get_pools_with_ticks_by_ids(&pool_ids, registered_pools.fetched_block_number)
             .await?
             .into_iter()
-            .filter_map(|pool| Some((pool.id, PoolInfo::try_from(pool).ok()?.into())))
+            .filter_map(|pool| Some((pool.id, pool.try_into().ok()?)))
             .collect::<HashMap<_, _>>();
         let pools_checkpoint = Mutex::new(PoolsCheckpoint {
             pools,
@@ -210,7 +187,7 @@ impl PoolsCheckpointHandler {
     /// For a given list of token pairs, fetches the pools for the ones that
     /// exist in the checkpoint. For the ones that don't exist, flag as
     /// missing and expect to exist after the next maintenance run.
-    fn get(&self, token_pairs: &HashSet<TokenPair>) -> (HashMap<H160, PoolInfoHandle>, u64) {
+    fn get(&self, token_pairs: &HashSet<TokenPair>) -> (HashMap<H160, PoolInfo>, u64) {
         let mut pool_ids = token_pairs
             .iter()
             .filter_map(|pair| self.pools_by_token_pair.get(pair))
@@ -222,7 +199,7 @@ impl PoolsCheckpointHandler {
         match pool_ids.peek() {
             Some(_) => {
                 let mut pools_checkpoint = self.pools_checkpoint.lock().unwrap();
-                let (existing_pools, missing_pools): (HashMap<H160, PoolInfoHandle>, Vec<H160>) =
+                let (existing_pools, missing_pools): (HashMap<H160, PoolInfo>, Vec<H160>) =
                     pool_ids.partition_map(|pool_id| match pools_checkpoint.pools.get(pool_id) {
                         Some(entry) => Either::Left((*pool_id, entry.clone())),
                         _ => Either::Right(pool_id),
@@ -264,9 +241,7 @@ impl PoolsCheckpointHandler {
         let mut checkpoint = self.pools_checkpoint.lock().unwrap();
         for pool in pools? {
             checkpoint.missing_pools.remove(&pool.id);
-            checkpoint
-                .pools
-                .insert(pool.id, PoolInfo::try_from(pool)?.into());
+            checkpoint.pools.insert(pool.id, pool.try_into()?);
         }
 
         tracing::debug!("number of cached pools is {}", checkpoint.pools.len());
@@ -358,7 +333,7 @@ impl PoolFetching for UniswapV3PoolFetcher {
         &self,
         token_pairs: &HashSet<TokenPair>,
         at_block: Block,
-    ) -> Result<Vec<PoolInfoHandle>> {
+    ) -> Result<Vec<PoolInfo>> {
         let block_number = match at_block {
             Block::Recent => self
                 .events
@@ -407,23 +382,19 @@ impl PoolFetching for UniswapV3PoolFetcher {
         // return only pools which current liquidity is positive
         Ok(checkpoint
             .into_values()
-            .filter(|pool| pool.read_lock().state.liquidity > U256::zero())
+            .filter(|pool| pool.state.liquidity > U256::zero())
             .collect())
     }
 }
 
 /// For a given checkpoint, append events to get a new checkpoint
-fn append_events(pools: &mut HashMap<H160, PoolInfoHandle>, events: Vec<Event<UniswapV3Event>>) {
+fn append_events(pools: &mut HashMap<H160, PoolInfo>, events: Vec<Event<UniswapV3Event>>) {
     for event in events {
         let address = event
             .meta
             .expect("metadata must exist for mined blocks")
             .address;
-
-        if let Entry::Occupied(entry) = pools.entry(address) {
-            let mut current = entry.get().0.write().unwrap();
-            let pool = &mut current.state;
-
+        if let Some(pool) = pools.get_mut(&address).map(|pool| &mut pool.state) {
             match event.data {
                 UniswapV3Event::Burn(burn) => {
                     let tick_lower = BigInt::from(burn.tick_lower);
@@ -520,233 +491,229 @@ impl Maintaining for UniswapV3PoolFetcher {
 
 #[cfg(test)]
 mod tests {
-    // use {
-    //     super::*,
-    //     contracts::uniswap_v3_pool::event_data::{Burn, Mint, Swap},
-    //     ethcontract::EventMetadata,
-    //     serde_json::json,
-    //     std::str::FromStr,
-    // };
+    use {
+        super::*,
+        contracts::uniswap_v3_pool::event_data::{Burn, Mint, Swap},
+        ethcontract::EventMetadata,
+        serde_json::json,
+        std::str::FromStr,
+    };
 
-    // #[test]
-    // fn encode_decode_pool_info() {
-    //     let json = json!({
-    //         "tokens": [
-    //             {
-    //                 "id": "0xbef81556ef066ec840a540595c8d12f516b6378f",
-    //                 "decimals": "18",
-    //             },
-    //             {
-    //                 "id": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
-    //                 "decimals": "18",
-    //             }
-    //         ],
-    //         "state": {
-    //             "sqrt_price": "792216481398733702759960397",
-    //             "liquidity": "303015134493562686441",
-    //             "tick": "-92110",
-    //             "liquidity_net":
-    //                 {
-    //                     "-122070": "104713649338178916454" ,
-    //                     "-77030": "1182024318125220460617" ,
-    //                     "67260": "5812623076452005012674" ,
-    //                 }
-    //             ,
-    //         },
-    //         "gas_stats": {
-    //             "mean": "300000",
-    //         }
-    //     });
+    #[test]
+    fn encode_decode_pool_info() {
+        let json = json!({
+            "tokens": [
+                {
+                    "id": "0xbef81556ef066ec840a540595c8d12f516b6378f",
+                    "decimals": "18",
+                },
+                {
+                    "id": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+                    "decimals": "18",
+                }
+            ],
+            "state": {
+                "sqrt_price": "792216481398733702759960397",
+                "liquidity": "303015134493562686441",
+                "tick": "-92110",
+                "liquidity_net":
+                    {
+                        "-122070": "104713649338178916454" ,
+                        "-77030": "1182024318125220460617" ,
+                        "67260": "5812623076452005012674" ,
+                    }
+                ,
+            },
+            "gas_stats": {
+                "mean": "300000",
+            }
+        });
 
-    //     let pool = PoolInfo {
-    //         address:
-    // H160::from_str("0x0001fcbba8eb491c3ccfeddc5a5caba1a98c4c28").unwrap(),
-    //         tokens: vec![
-    //             Token {
-    //                 id:
-    // H160::from_str("0xbef81556ef066ec840a540595c8d12f516b6378f").unwrap(),
-    //                 decimals: 18,
-    //             },
-    //             Token {
-    //                 id:
-    // H160::from_str("0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2").unwrap(),
-    //                 decimals: 18,
-    //             },
-    //         ],
-    //         state: PoolState {
-    //             sqrt_price:
-    // U256::from_dec_str("792216481398733702759960397").unwrap(),
-    //             liquidity:
-    // U256::from_dec_str("303015134493562686441").unwrap(),
-    // tick: BigInt::from_str("-92110").unwrap(),             liquidity_net:
-    // BTreeMap::from([                 (
-    //                     BigInt::from_str("-122070").unwrap(),
-    //                     BigInt::from_str("104713649338178916454").unwrap(),
-    //                 ),
-    //                 (
-    //                     BigInt::from_str("-77030").unwrap(),
-    //                     BigInt::from_str("1182024318125220460617").unwrap(),
-    //                 ),
-    //                 (
-    //                     BigInt::from_str("67260").unwrap(),
-    //                     BigInt::from_str("5812623076452005012674").unwrap(),
-    //                 ),
-    //             ]),
-    //             fee: Ratio::new(10_000u32, 1_000_000u32),
-    //         },
-    //         gas_stats: PoolStats {
-    //             mean_gas: U256::from(300000),
-    //         },
-    //     };
+        let pool = PoolInfo {
+            address: H160::from_str("0x0001fcbba8eb491c3ccfeddc5a5caba1a98c4c28").unwrap(),
+            tokens: vec![
+                Token {
+                    id: H160::from_str("0xbef81556ef066ec840a540595c8d12f516b6378f").unwrap(),
+                    decimals: 18,
+                },
+                Token {
+                    id: H160::from_str("0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2").unwrap(),
+                    decimals: 18,
+                },
+            ],
+            state: PoolState {
+                sqrt_price: U256::from_dec_str("792216481398733702759960397").unwrap(),
+                liquidity: U256::from_dec_str("303015134493562686441").unwrap(),
+                tick: BigInt::from_str("-92110").unwrap(),
+                liquidity_net: BTreeMap::from([
+                    (
+                        BigInt::from_str("-122070").unwrap(),
+                        BigInt::from_str("104713649338178916454").unwrap(),
+                    ),
+                    (
+                        BigInt::from_str("-77030").unwrap(),
+                        BigInt::from_str("1182024318125220460617").unwrap(),
+                    ),
+                    (
+                        BigInt::from_str("67260").unwrap(),
+                        BigInt::from_str("5812623076452005012674").unwrap(),
+                    ),
+                ]),
+                fee: Ratio::new(10_000u32, 1_000_000u32),
+            },
+            gas_stats: PoolStats {
+                mean_gas: U256::from(300000),
+            },
+        };
 
-    //     let serialized = serde_json::to_value(pool).unwrap();
-    //     assert_eq!(json, serialized);
-    // }
+        let serialized = serde_json::to_value(pool).unwrap();
+        assert_eq!(json, serialized);
+    }
 
-    // #[test]
-    // fn append_events_test_empty() {
-    //     let pools = HashMap::from([(H160::from_low_u64_be(1),
-    // Default::default())]);     let mut new_pools = pools.clone();
-    //     let events = vec![];
-    //     append_events(&mut new_pools, events);
-    //     assert_eq!(new_pools, pools);
-    // }
+    #[test]
+    fn append_events_test_empty() {
+        let pools = HashMap::from([(H160::from_low_u64_be(1), Default::default())]);
+        let mut new_pools = pools.clone();
+        let events = vec![];
+        append_events(&mut new_pools, events);
+        assert_eq!(new_pools, pools);
+    }
 
-    // #[test]
-    // fn append_events_test_swap() {
-    //     let address = H160::from_low_u64_be(1);
-    //     let pool = Arc::new(PoolInfo {
-    //         address,
-    //         ..Default::default()
-    //     });
-    //     let mut pools = HashMap::from([(address, pool)]);
+    #[test]
+    fn append_events_test_swap() {
+        let address = H160::from_low_u64_be(1);
+        let pool = PoolInfo {
+            address,
+            ..Default::default()
+        };
+        let mut pools = HashMap::from([(address, pool)]);
 
-    //     let event = Event {
-    //         data: UniswapV3Event::Swap(Swap {
-    //             sqrt_price_x96: 1.into(),
-    //             liquidity: 2,
-    //             tick: 3,
-    //             ..Default::default()
-    //         }),
-    //         meta: Some(EventMetadata {
-    //             address,
-    //             ..Default::default()
-    //         }),
-    //     };
-    //     append_events(&mut pools, vec![event]);
+        let event = Event {
+            data: UniswapV3Event::Swap(Swap {
+                sqrt_price_x96: 1.into(),
+                liquidity: 2,
+                tick: 3,
+                ..Default::default()
+            }),
+            meta: Some(EventMetadata {
+                address,
+                ..Default::default()
+            }),
+        };
+        append_events(&mut pools, vec![event]);
 
-    //     assert_eq!(pools[&address].state.tick, BigInt::from(3));
-    //     assert_eq!(pools[&address].state.liquidity, U256::from(2));
-    //     assert_eq!(pools[&address].state.sqrt_price, U256::from(1));
-    // }
+        assert_eq!(pools[&address].state.tick, BigInt::from(3));
+        assert_eq!(pools[&address].state.liquidity, U256::from(2));
+        assert_eq!(pools[&address].state.sqrt_price, U256::from(1));
+    }
 
-    // #[test]
-    // fn append_events_test_burn() {
-    //     let address = H160::from_low_u64_be(1);
-    //     let pool = Arc::new(PoolInfo {
-    //         address,
-    //         ..Default::default()
-    //     });
-    //     let mut pools = HashMap::from([(address, pool)]);
+    #[test]
+    fn append_events_test_burn() {
+        let address = H160::from_low_u64_be(1);
+        let pool = PoolInfo {
+            address,
+            ..Default::default()
+        };
+        let mut pools = HashMap::from([(address, pool)]);
 
-    //     // add first burn event
-    //     let event = Event {
-    //         data: UniswapV3Event::Burn(Burn {
-    //             tick_lower: 100000,
-    //             tick_upper: 110000,
-    //             amount: 12345,
-    //             ..Default::default()
-    //         }),
-    //         meta: Some(EventMetadata {
-    //             address,
-    //             ..Default::default()
-    //         }),
-    //     };
-    //     append_events(&mut pools, vec![event]);
-    //     assert_eq!(
-    //         pools[&address].state.liquidity_net,
-    //         BTreeMap::from([
-    //             (BigInt::from(100_000), BigInt::from(-12345)),
-    //             (BigInt::from(110_000), BigInt::from(12345))
-    //         ])
-    //     );
+        // add first burn event
+        let event = Event {
+            data: UniswapV3Event::Burn(Burn {
+                tick_lower: 100000,
+                tick_upper: 110000,
+                amount: 12345,
+                ..Default::default()
+            }),
+            meta: Some(EventMetadata {
+                address,
+                ..Default::default()
+            }),
+        };
+        append_events(&mut pools, vec![event]);
+        assert_eq!(
+            pools[&address].state.liquidity_net,
+            BTreeMap::from([
+                (BigInt::from(100_000), BigInt::from(-12345)),
+                (BigInt::from(110_000), BigInt::from(12345))
+            ])
+        );
 
-    //     // add second burn event
-    //     let event = Event {
-    //         data: UniswapV3Event::Burn(Burn {
-    //             tick_lower: 105000,
-    //             tick_upper: 110000,
-    //             amount: 54321,
-    //             ..Default::default()
-    //         }),
-    //         meta: Some(EventMetadata {
-    //             address,
-    //             ..Default::default()
-    //         }),
-    //     };
-    //     append_events(&mut pools, vec![event]);
-    //     assert_eq!(
-    //         pools[&address].state.liquidity_net,
-    //         BTreeMap::from([
-    //             (BigInt::from(100_000), BigInt::from(-12345)),
-    //             (BigInt::from(105_000), BigInt::from(-54321)),
-    //             (BigInt::from(110_000), BigInt::from(66666))
-    //         ])
-    //     );
-    // }
+        // add second burn event
+        let event = Event {
+            data: UniswapV3Event::Burn(Burn {
+                tick_lower: 105000,
+                tick_upper: 110000,
+                amount: 54321,
+                ..Default::default()
+            }),
+            meta: Some(EventMetadata {
+                address,
+                ..Default::default()
+            }),
+        };
+        append_events(&mut pools, vec![event]);
+        assert_eq!(
+            pools[&address].state.liquidity_net,
+            BTreeMap::from([
+                (BigInt::from(100_000), BigInt::from(-12345)),
+                (BigInt::from(105_000), BigInt::from(-54321)),
+                (BigInt::from(110_000), BigInt::from(66666))
+            ])
+        );
+    }
 
-    // #[test]
-    // fn append_events_test_mint() {
-    //     let address = H160::from_low_u64_be(1);
-    //     let pool = Arc::new(PoolInfo {
-    //         address,
-    //         ..Default::default()
-    //     });
-    //     let mut pools = HashMap::from([(address, pool)]);
+    #[test]
+    fn append_events_test_mint() {
+        let address = H160::from_low_u64_be(1);
+        let pool = PoolInfo {
+            address,
+            ..Default::default()
+        };
+        let mut pools = HashMap::from([(address, pool)]);
 
-    //     // add first mint event
-    //     let event = Event {
-    //         data: UniswapV3Event::Mint(Mint {
-    //             tick_lower: 100000,
-    //             tick_upper: 110000,
-    //             amount: 12345,
-    //             ..Default::default()
-    //         }),
-    //         meta: Some(EventMetadata {
-    //             address,
-    //             ..Default::default()
-    //         }),
-    //     };
-    //     append_events(&mut pools, vec![event]);
-    //     assert_eq!(
-    //         pools[&address].state.liquidity_net,
-    //         BTreeMap::from([
-    //             (BigInt::from(100_000), BigInt::from(12345)),
-    //             (BigInt::from(110_000), BigInt::from(-12345))
-    //         ])
-    //     );
+        // add first mint event
+        let event = Event {
+            data: UniswapV3Event::Mint(Mint {
+                tick_lower: 100000,
+                tick_upper: 110000,
+                amount: 12345,
+                ..Default::default()
+            }),
+            meta: Some(EventMetadata {
+                address,
+                ..Default::default()
+            }),
+        };
+        append_events(&mut pools, vec![event]);
+        assert_eq!(
+            pools[&address].state.liquidity_net,
+            BTreeMap::from([
+                (BigInt::from(100_000), BigInt::from(12345)),
+                (BigInt::from(110_000), BigInt::from(-12345))
+            ])
+        );
 
-    //     // add second burn event
-    //     let event = Event {
-    //         data: UniswapV3Event::Mint(Mint {
-    //             tick_lower: 105000,
-    //             tick_upper: 110000,
-    //             amount: 54321,
-    //             ..Default::default()
-    //         }),
-    //         meta: Some(EventMetadata {
-    //             address,
-    //             ..Default::default()
-    //         }),
-    //     };
-    //     append_events(&mut pools, vec![event]);
-    //     assert_eq!(
-    //         pools[&address].state.liquidity_net,
-    //         BTreeMap::from([
-    //             (BigInt::from(100_000), BigInt::from(12345)),
-    //             (BigInt::from(105_000), BigInt::from(54321)),
-    //             (BigInt::from(110_000), BigInt::from(-66666))
-    //         ])
-    //     );
-    // }
+        // add second burn event
+        let event = Event {
+            data: UniswapV3Event::Mint(Mint {
+                tick_lower: 105000,
+                tick_upper: 110000,
+                amount: 54321,
+                ..Default::default()
+            }),
+            meta: Some(EventMetadata {
+                address,
+                ..Default::default()
+            }),
+        };
+        append_events(&mut pools, vec![event]);
+        assert_eq!(
+            pools[&address].state.liquidity_net,
+            BTreeMap::from([
+                (BigInt::from(100_000), BigInt::from(12345)),
+                (BigInt::from(105_000), BigInt::from(54321)),
+                (BigInt::from(110_000), BigInt::from(-66666))
+            ])
+        );
+    }
 }

--- a/crates/solver/src/liquidity.rs
+++ b/crates/solver/src/liquidity.rs
@@ -29,7 +29,7 @@ use {
                 swap::fixed_point::Bfp,
             },
             uniswap_v2::pool_fetching::Pool,
-            uniswap_v3::pool_fetching::PoolInfoHandle,
+            uniswap_v3::pool_fetching::PoolInfo,
         },
     },
     std::{collections::BTreeMap, sync::Arc},
@@ -68,7 +68,7 @@ impl Liquidity {
             Liquidity::BalancerWeighted(amm) => Some(amm.address),
             Liquidity::BalancerStable(amm) => Some(amm.address),
             Liquidity::LimitOrder(_) => None,
-            Liquidity::Concentrated(amm) => Some(amm.pool.read_lock().address),
+            Liquidity::Concentrated(amm) => Some(amm.pool.address),
         }
     }
 }
@@ -442,7 +442,7 @@ impl Settleable for StablePoolOrder {
 #[cfg_attr(test, derivative(PartialEq))]
 pub struct ConcentratedLiquidity {
     pub tokens: TokenPair,
-    pub pool: PoolInfoHandle,
+    pub pool: PoolInfo,
     #[cfg_attr(test, derivative(PartialEq = "ignore"))]
     pub settlement_handling: Arc<dyn SettlementHandling<Self>>,
 }

--- a/crates/solver/src/liquidity/uniswap_v3.rs
+++ b/crates/solver/src/liquidity/uniswap_v3.rs
@@ -129,8 +129,6 @@ impl LiquidityCollecting for UniswapV3Liquidity {
         let mut tokens = HashSet::new();
         let mut result = Vec::new();
         for pool in self.pool_fetcher.fetch(&pairs, block).await? {
-            let pool_cloned = pool.clone();
-            let pool = pool.read_lock();
             ensure!(
                 pool.tokens.len() == 2,
                 "two tokens required for uniswap v3 pools"
@@ -147,7 +145,7 @@ impl LiquidityCollecting for UniswapV3Liquidity {
                     inner: self.inner.clone(),
                     fee: ratio_to_u32(pool.state.fee)?,
                 }),
-                pool: pool_cloned,
+                pool,
             }))
         }
         self.cache_allowances(tokens).await?;

--- a/crates/solvers/src/boundary/legacy.rs
+++ b/crates/solvers/src/boundary/legacy.rs
@@ -334,8 +334,7 @@ fn to_boundary_auction(
                             gas_stats: PoolStats {
                                 mean_gas: liquidity.gas.0,
                             },
-                        }
-                        .into(),
+                        },
                     }),
                     to_big_rational(&state.fee.0),
                 )


### PR DESCRIPTION
Reverts cowprotocol/services#2629

There are 2 code paths which append events to a given checkpoint state:
1. during maintenance (where we actually update the one big cached state that we maintain)
2. when fetching liquidity and the current state is later than the checkpoint state

Previously this was no issue because `2` cloned the relevant state so the underlying cached state was unaffected.
With the PR that now gets reverted both code paths modify the same underlying state which means some updates can be applied multiple times which corrupts the underlying state.