### PR TITLE
[EASY] Avoid empty update

### DIFF
--- a/crates/shared/src/sources/uniswap_v3/pool_fetching.rs
+++ b/crates/shared/src/sources/uniswap_v3/pool_fetching.rs
@@ -221,6 +221,9 @@ impl PoolsCheckpointHandler {
     async fn update_missing_pools(&self) -> Result<()> {
         let (missing_pools, block_number) = {
             let checkpoint = self.pools_checkpoint.lock().unwrap();
+            if checkpoint.missing_pools.is_empty() {
+                return Ok(());
+            }
             (checkpoint.missing_pools.clone(), checkpoint.block_number)
         };
         tracing::debug!("currently missing pools are {:?}", missing_pools);


### PR DESCRIPTION
# Description
The task to fetch the missing uni v3 pools currently also does stuff when all pools have been fetched.
These calls take 80ms-150ms and and issue at least 3 logs the don't add anything.

# Changes
Early return when no pools need to be fetched.