### PR TITLE
Downgrade anyhow

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/*"]
 
 [workspace.dependencies]
-anyhow = "1.0.82"
+anyhow = "1.0.76"
 async-trait = "0.1.80"
 axum = "0.6"
 bigdecimal = "0.3"


### PR DESCRIPTION
# Description
After a long session of debugging together, @MartinquaXD discovered that the latest anyhow is always printing the full trace.

# Changes
Revert back to anyhow 1.0.76

## How to test
1. regression tests
