### PR TITLE
More precise fee calculation in baseline solver

### DIFF
--- a/crates/e2e/src/setup/colocation.rs
+++ b/crates/e2e/src/setup/colocation.rs
@@ -12,7 +12,6 @@ weth = "{weth:?}"
 base-tokens = []
 max-hops = 1
 max-partial-attempts = 5
-native-token-price-estimation-amount = "100000000000000000"
         "#,
     ));
 

--- a/crates/solvers/config/example.baseline.toml
+++ b/crates/solvers/config/example.baseline.toml
@@ -4,5 +4,4 @@ chain-id = "1"
 base-tokens = []
 max-hops = 0
 max-partial-attempts = 5
-native-token-price-estimation-amount = "100000000000000000"
 # solution-gas-offset = 106391 # rough estimate of the settlement overhead

--- a/crates/solvers/src/domain/solver/baseline.rs
+++ b/crates/solvers/src/domain/solver/baseline.rs
@@ -158,11 +158,11 @@ impl Inner {
                 let gas_cost = eth::Ether(gas.0.checked_mul(auction.gas_price.0 .0)?);
                 let sell_token = user_order.get().sell.token;
                 let fee = match auction.tokens.reference_price(&sell_token) {
-                    Some(price) => Some(price.ether_value(gas_cost)?),
+                    Some(price) => price.ether_value(gas_cost),
                     None if sell_token == self.weth.0.into() => {
                         // Early return if the sell token is native token
                         let price = auction::Price(eth::Ether(eth::U256::exp10(18)));
-                        Some(price.ether_value(gas_cost)?)
+                        price.ether_value(gas_cost)
                     }
                     None => boundary_solver
                         .route(

--- a/crates/solvers/src/infra/config/baseline.rs
+++ b/crates/solvers/src/infra/config/baseline.rs
@@ -43,11 +43,6 @@ struct Config {
     /// computed trade route to arrive at a gas estimate for a whole settlement.
     #[serde(default = "default_gas_offset")]
     solution_gas_offset: i64,
-
-    /// The amount of the native token to use to estimate native price of a
-    /// token
-    #[serde_as(as = "serialize::U256")]
-    native_token_price_estimation_amount: eth::U256,
 }
 
 /// Load the driver configuration from a TOML file.
@@ -83,7 +78,6 @@ pub async fn load(path: &Path) -> baseline::Config {
         max_hops: config.max_hops,
         max_partial_attempts: config.max_partial_attempts,
         solution_gas_offset: config.solution_gas_offset.into(),
-        native_token_price_estimation_amount: config.native_token_price_estimation_amount,
     }
 }
 

--- a/crates/solvers/src/tests/baseline/bal_liquidity.rs
+++ b/crates/solvers/src/tests/baseline/bal_liquidity.rs
@@ -12,7 +12,6 @@ async fn weighted() {
                 base-tokens = []
                 max-hops = 0
                 max-partial-attempts = 1
-                native-token-price-estimation-amount = "100000000000000000"
             "#
             .to_owned(),
         ),
@@ -144,7 +143,6 @@ async fn weighted_v3plus() {
                 base-tokens = []
                 max-hops = 0
                 max-partial-attempts = 1
-                native-token-price-estimation-amount = "1000000000000000000"
             "#
             .to_owned(),
         ),
@@ -285,7 +283,6 @@ async fn stable() {
                 base-tokens = []
                 max-hops = 0
                 max-partial-attempts = 1
-                native-token-price-estimation-amount = "100000000000000000"
             "#
             .to_owned(),
         ),
@@ -473,7 +470,6 @@ async fn composable_stable_v4() {
                 base-tokens = []
                 max-hops = 0
                 max-partial-attempts = 1
-                native-token-price-estimation-amount = "1000000000000000000"
             "#
             .to_owned(),
         ),

--- a/crates/solvers/src/tests/baseline/buy_order_rounding.rs
+++ b/crates/solvers/src/tests/baseline/buy_order_rounding.rs
@@ -128,7 +128,6 @@ async fn balancer_weighted() {
                 base-tokens = ["0x9c58bacc331c9aa871afd802db6379a98e80cedb"]
                 max-hops = 1
                 max-partial-attempts = 1
-                native-token-price-estimation-amount = "1000000000000000000"
             "#
             .to_owned(),
         ),
@@ -305,7 +304,6 @@ async fn balancer_weighted_v3plus() {
                 base-tokens = []
                 max-hops = 0
                 max-partial-attempts = 1
-                native-token-price-estimation-amount = "1000000000000000000"
             "#
             .to_owned(),
         ),
@@ -446,7 +444,6 @@ async fn distant_convergence() {
                 base-tokens = []
                 max-hops = 0
                 max-partial-attempts = 1
-                native-token-price-estimation-amount = "1000000000000000000"
             "#
             .to_owned(),
         ),
@@ -587,7 +584,6 @@ async fn same_path() {
                 base-tokens = ["0x9c58bacc331c9aa871afd802db6379a98e80cedb"]
                 max-hops = 0
                 max-partial-attempts = 1
-                native-token-price-estimation-amount = "1000000000000000000"
             "#
             .to_owned(),
         ),
@@ -764,7 +760,6 @@ async fn balancer_stable() {
                 base-tokens = []
                 max-hops = 0
                 max-partial-attempts = 1
-                native-token-price-estimation-amount = "1000000000000000000"
             "#
             .to_owned(),
         ),

--- a/crates/solvers/src/tests/baseline/limit_order_quoting.rs
+++ b/crates/solvers/src/tests/baseline/limit_order_quoting.rs
@@ -12,7 +12,6 @@ async fn sell_order() {
                 base-tokens = []
                 max-hops = 0
                 max-partial-attempts = 1
-                native-token-price-estimation-amount = "1000000000000000000"
             "#
             .to_owned(),
         ),
@@ -154,7 +153,6 @@ async fn buy_order() {
                 base-tokens = []
                 max-hops = 0
                 max-partial-attempts = 1
-                native-token-price-estimation-amount = "1000000000000000000"
             "#
             .to_owned(),
         ),

--- a/crates/solvers/src/tests/baseline/limit_order_quoting.rs
+++ b/crates/solvers/src/tests/baseline/limit_order_quoting.rs
@@ -114,8 +114,8 @@ async fn sell_order() {
             "solutions": [{
                 "id": 0,
                 "prices": {
-                    "0x177127622c4a00f3d409b75571e12cb3c8973d3c": "995857692278744911",
-                    "0x9c58bacc331c9aa871afd802db6379a98e80cedb": "1656483497858673768805"
+                    "0x177127622c4a00f3d409b75571e12cb3c8973d3c": "995861833732385891",
+                    "0x9c58bacc331c9aa871afd802db6379a98e80cedb": "1656490386643754830243"
                 },
                 "trades": [
                     {
@@ -123,8 +123,8 @@ async fn sell_order() {
                         "order": "0x2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a\
                                     2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a\
                                     2a2a2a2a",
-                        "executedAmount": "995857692278744911",
-                        "fee": "4142307721255089"
+                        "executedAmount": "995861833732385891",
+                        "fee": "4138166267614109"
                     }
                 ],
                 "interactions": [
@@ -266,7 +266,7 @@ async fn buy_order() {
                                     2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a\
                                     2a2a2a2a",
                         "executedAmount": "1000000000000000000",
-                        "fee": "4142307721255089"
+                        "fee": "4138166267614109"
                     }
                 ],
                 "interactions": [

--- a/playground/baseline.toml
+++ b/playground/baseline.toml
@@ -11,4 +11,3 @@ base-tokens = [
 ]
 max-hops = 2
 max-partial-attempts = 5
-native-token-price-estimation-amount = "100000000000000000" # 0.1 ETH


### PR DESCRIPTION
# Description
For quote requests (aka reference token price is None), fee is now calculated using the actual gas cost needed to cover the network expense, instead of using the random 1ETH amount which might not be appropriate for some cases: for example, when liquidity of the sell token is small and 1ETH significantly moves the price (or it is not even achievable) while actual realistic 0.01ETH gas cost moves the price far less.

Additional change is that we no longer return solutions with fee=0 (related to https://github.com/cowprotocol/services/issues/2624). This was happening for quotes where sell amounts are smaller than the network fee. For example, quote selling 5 usdc for weth while the network fee is 20$ should not return a valid quote.

## How to test
Existing quote with limit orders tests. Note how the `fee` and `executed` fields changed only slightly due to high liquidity of the tokens.

Fixes https://github.com/cowprotocol/services/issues/2624