### PR TITLE
Add default values for arbitrum

### DIFF
--- a/crates/shared/src/network.rs
+++ b/crates/shared/src/network.rs
@@ -9,7 +9,7 @@ pub fn network_name(chain_id: u64) -> &'static str {
         5 => "Ethereum / Goerli",
         100 => "xDAI",
         11155111 => "Ethereum / Sepolia",
-        42161 => "Arbitrum / Mainnet",
+        42161 => "Arbitrum One",
         _ => panic!("Unknown network (chain_id={chain_id})"),
     }
 }

--- a/crates/shared/src/network.rs
+++ b/crates/shared/src/network.rs
@@ -11,17 +11,20 @@ pub fn network_name(chain_id: u64) -> &'static str {
         5 => "Ethereum / Goerli",
         100 => "xDAI",
         11155111 => "Ethereum / Sepolia",
+        42161 => "Arbitrum / Mainnet",
         _ => panic!("Unknown network (chain_id={chain_id})"),
     }
 }
 
 /// The expected time between blocks on the network.
 pub fn block_interval(chain_id: u64) -> Option<Duration> {
-    Some(Duration::from_secs(match chain_id {
-        1 => 12,
-        5 => 12,
-        100 => 5,
-        11155111 => 12,
+    match chain_id {
+        1 => Duration::from_secs(12),
+        5 => Duration::from_secs(12),
+        100 => Duration::from_secs(5),
+        11155111 => Duration::from_secs(12),
+        42161 => Duration::from_millis(250),
         _ => return None,
-    }))
+    }
+    .into()
 }

--- a/crates/shared/src/network.rs
+++ b/crates/shared/src/network.rs
@@ -1,5 +1,3 @@
-use std::time::Duration;
-
 /// Maps ChainId to the network name.
 /// If the output is from a known network, it represents the canonical name of
 /// the network on CoW Protocol.
@@ -14,17 +12,4 @@ pub fn network_name(chain_id: u64) -> &'static str {
         42161 => "Arbitrum / Mainnet",
         _ => panic!("Unknown network (chain_id={chain_id})"),
     }
-}
-
-/// The expected time between blocks on the network.
-pub fn block_interval(chain_id: u64) -> Option<Duration> {
-    match chain_id {
-        1 => Duration::from_secs(12),
-        5 => Duration::from_secs(12),
-        100 => Duration::from_secs(5),
-        11155111 => Duration::from_secs(12),
-        42161 => Duration::from_millis(250),
-        _ => return None,
-    }
-    .into()
 }

--- a/crates/shared/src/price_estimation/native.rs
+++ b/crates/shared/src/price_estimation/native.rs
@@ -15,8 +15,8 @@ pub type NativePriceEstimateResult = Result<NativePrice, PriceEstimationError>;
 
 pub fn default_amount_to_estimate_native_prices_with(chain_id: u64) -> Option<U256> {
     match chain_id {
-        // Mainnet, Göŕli, Sepolia
-        1 | 5 | 11155111 => Some(10u128.pow(18).into()),
+        // Mainnet, Göŕli, Sepolia, Arbitrum
+        1 | 5 | 11155111 | 42161 => Some(10u128.pow(18).into()),
         // Gnosis chain
         100 => Some(10u128.pow(21).into()),
         _ => None,

--- a/crates/shared/src/sources.rs
+++ b/crates/shared/src/sources.rs
@@ -50,6 +50,14 @@ pub fn defaults_for_chain(chain_id: u64) -> Result<Vec<BaselineSource>> {
             BaselineSource::Baoswap,
             BaselineSource::Swapr,
         ],
+        42161 => vec![
+            BaselineSource::UniswapV2,
+            BaselineSource::SushiSwap,
+            BaselineSource::Swapr,
+            BaselineSource::BalancerV2,
+            BaselineSource::ZeroEx,
+            BaselineSource::UniswapV3,
+        ],
         11155111 => vec![BaselineSource::TestnetUniswapV2],
         _ => bail!("unsupported chain {:#x}", chain_id),
     })

--- a/crates/solvers/src/domain/eth/chain.rs
+++ b/crates/solvers/src/domain/eth/chain.rs
@@ -7,6 +7,7 @@ pub enum ChainId {
     Goerli = 5,
     Gnosis = 100,
     Sepolia = 11155111,
+    Arbitrum = 42161,
 }
 
 impl ChainId {
@@ -23,6 +24,7 @@ impl ChainId {
             5 => Ok(Self::Goerli),
             100 => Ok(Self::Gnosis),
             11155111 => Ok(Self::Sepolia),
+            42161 => Ok(Self::Arbitrum),
             _ => Err(UnsupportedChain),
         }
     }
@@ -34,6 +36,7 @@ impl ChainId {
             ChainId::Goerli => "5",
             ChainId::Gnosis => "100",
             ChainId::Sepolia => "11155111",
+            ChainId::Arbitrum => "42161",
         }
     }
 

--- a/crates/solvers/src/domain/eth/chain.rs
+++ b/crates/solvers/src/domain/eth/chain.rs
@@ -7,7 +7,7 @@ pub enum ChainId {
     Goerli = 5,
     Gnosis = 100,
     Sepolia = 11155111,
-    Arbitrum = 42161,
+    ArbitrumOne = 42161,
 }
 
 impl ChainId {
@@ -24,7 +24,7 @@ impl ChainId {
             5 => Ok(Self::Goerli),
             100 => Ok(Self::Gnosis),
             11155111 => Ok(Self::Sepolia),
-            42161 => Ok(Self::Arbitrum),
+            42161 => Ok(Self::ArbitrumOne),
             _ => Err(UnsupportedChain),
         }
     }
@@ -36,7 +36,7 @@ impl ChainId {
             ChainId::Goerli => "5",
             ChainId::Gnosis => "100",
             ChainId::Sepolia => "11155111",
-            ChainId::Arbitrum => "42161",
+            ChainId::ArbitrumOne => "42161",
         }
     }
 


### PR DESCRIPTION
# Changes
Adds arbitrum as a supported chain in the backend and sets reasonable defaults for it to make it the backend start up with a minimal configuration.

## How to test
Already deployed on arbitrum staging stack and used to settle an order.