### PR TITLE
Log domain settlement even when using boundary encoding

### DIFF
--- a/crates/driver/src/domain/competition/solution/settlement.rs
+++ b/crates/driver/src/domain/competition/solution/settlement.rs
@@ -124,10 +124,7 @@ impl Settlement {
                             );
                         }
                     }
-                    Err(err) => {
-                        tracing::warn!(?err, "failed to encode domain settlement");
-                        panic!("Check encoding!");
-                    }
+                    Err(err) => tracing::warn!(?err, "failed to encode domain settlement"),
                 };
                 tx
             }

--- a/crates/driver/src/domain/competition/solution/settlement.rs
+++ b/crates/driver/src/domain/competition/solution/settlement.rs
@@ -92,7 +92,7 @@ impl Settlement {
         let tx = match encoding {
             encoding::Strategy::Boundary => {
                 let boundary = boundary::Settlement::encode(eth, &solution, auction).await?;
-                SettlementTx {
+                let tx = SettlementTx {
                     internalized: boundary.tx(
                         auction.id().unwrap(),
                         eth.contracts().settlement(),
@@ -104,7 +104,29 @@ impl Settlement {
                         Internalization::Disable,
                     ),
                     may_revert: boundary.revertable(),
-                }
+                };
+
+                // To prepare rollout, ensure that the domain settlement encoding works and
+                // matches the boundary settlement encoding
+                match encoding::tx(
+                    auction,
+                    &solution,
+                    eth.contracts(),
+                    solution.approvals(eth, Internalization::Enable).await?,
+                    Internalization::Enable,
+                ) {
+                    Ok(domain) => {
+                        if domain.input != tx.internalized.input {
+                            tracing::warn!(
+                                ?domain,
+                                boundary = ?tx.internalized,
+                                "boundary settlement does not match domain settlement"
+                            );
+                        }
+                    }
+                    Err(err) => tracing::warn!(?err, "failed to encode domain settlement"),
+                };
+                tx
             }
             encoding::Strategy::Domain => SettlementTx {
                 internalized: encoding::tx(

--- a/crates/driver/src/domain/competition/solution/settlement.rs
+++ b/crates/driver/src/domain/competition/solution/settlement.rs
@@ -124,7 +124,10 @@ impl Settlement {
                             );
                         }
                     }
-                    Err(err) => tracing::warn!(?err, "failed to encode domain settlement"),
+                    Err(err) => {
+                        tracing::warn!(?err, "failed to encode domain settlement");
+                        panic!("Check encoding!");
+                    }
                 };
                 tx
             }


### PR DESCRIPTION
# Description
This is to ensure we can soft rollout in production (keeping the original encoding but warning cases in which the two don't match)

# Changes
- [x] Log when calldata of both ways to encode doesn't match

## How to test
Run the driver in shadow mode, see solutions being produced and no error log happening

## Related Issues

Prepares rollout of #2215 