### PR TITLE
Don't use settlement contract as token owner for bad token test

### DIFF
--- a/crates/autopilot/src/run.rs
+++ b/crates/autopilot/src/run.rs
@@ -268,6 +268,7 @@ pub async fn run(args: Arguments) {
         vault.as_ref(),
         uniswapv3_factory.as_ref(),
         &base_tokens,
+        eth.contracts().settlement().address(),
     )
     .await
     .expect("failed to initialize token owner finders");

--- a/crates/orderbook/src/run.rs
+++ b/crates/orderbook/src/run.rs
@@ -219,6 +219,7 @@ pub async fn run(args: Arguments) {
         vault.as_ref(),
         uniswapv3_factory.as_ref(),
         &base_tokens,
+        settlement_contract.address(),
     )
     .await
     .expect("failed to initialize token owner finders");

--- a/crates/shared/src/bad_token/trace_call.rs
+++ b/crates/shared/src/bad_token/trace_call.rs
@@ -627,6 +627,7 @@ mod tests {
         let settlement = contracts::GPv2Settlement::deployed(&web3).await.unwrap();
         let finder = Arc::new(TokenOwnerFinder {
             web3: web3.clone(),
+            settlement_contract: Default::default(),
             proposers: vec![
                 Arc::new(UniswapLikePairProviderFinder {
                     inner: uniswap_v2::UniV2BaselineSourceParameters::from_baseline_source(
@@ -705,6 +706,7 @@ mod tests {
         );
         let finder = Arc::new(TokenOwnerFinder {
             web3: web3.clone(),
+            settlement_contract: settlement.address(),
             proposers: vec![univ3],
         });
         let token_cache = super::TraceCallDetector {
@@ -831,6 +833,7 @@ mod tests {
         let finder = Arc::new(TokenOwnerFinder {
             web3: web3.clone(),
             proposers: vec![solver_token_finder],
+            settlement_contract: settlement.address(),
         });
         let token_cache = TraceCallDetector {
             web3,

--- a/crates/shared/src/bad_token/trace_call.rs
+++ b/crates/shared/src/bad_token/trace_call.rs
@@ -627,7 +627,7 @@ mod tests {
         let settlement = contracts::GPv2Settlement::deployed(&web3).await.unwrap();
         let finder = Arc::new(TokenOwnerFinder {
             web3: web3.clone(),
-            settlement_contract: Default::default(),
+            settlement_contract: settlement.address(),
             proposers: vec![
                 Arc::new(UniswapLikePairProviderFinder {
                     inner: uniswap_v2::UniV2BaselineSourceParameters::from_baseline_source(


### PR DESCRIPTION
# Description
The bad token test finds an address that holds a good amount of tokens and tries to send some amount of that to the settlement contract and back again. Afterwards it checks that when we send X tokens the receiver actually got X tokens and not some smaller amount to filter out tokens with fee on transfer behavior.

Because the token balance assertion is `if owner sends X tokens to the settlement contract the settlement_contract has X tokens more` it obviously fails when `owner == settlement_contract` because the balance for good tokens will also not change flagging them incorrectly as fee on transfer tokens.

# Changes
Filter out the settlement contract in the `TokenFinder` implementation.