### PR TITLE
[Trivial] Sort clearing price vector

### DIFF
--- a/crates/driver/src/boundary/settlement.rs
+++ b/crates/driver/src/boundary/settlement.rs
@@ -72,7 +72,7 @@ impl Settlement {
 
         let mut settlement = solver::settlement::Settlement::new(
             solution
-                .clearing_prices()?
+                .clearing_prices()
                 .into_iter()
                 .map(|asset| (asset.token.into(), asset.amount.into()))
                 .collect(),

--- a/crates/driver/src/domain/competition/solution/encoding.rs
+++ b/crates/driver/src/domain/competition/solution/encoding.rs
@@ -13,6 +13,7 @@ use {
         util::Bytes,
     },
     allowance::Allowance,
+    itertools::Itertools,
 };
 
 /// The type of strategy used to encode the solution.
@@ -55,7 +56,7 @@ pub fn tx(
     let mut native_unwrap = eth::TokenAmount(eth::U256::zero());
 
     // Encode uniform clearing price vector
-    for (token, price) in solution.prices.clone() {
+    for (&token, &price) in solution.prices.iter().sorted() {
         tokens.push(token.into());
         clearing_prices.push(price);
     }

--- a/crates/driver/src/domain/competition/solution/encoding.rs
+++ b/crates/driver/src/domain/competition/solution/encoding.rs
@@ -56,9 +56,13 @@ pub fn tx(
     let mut native_unwrap = eth::TokenAmount(eth::U256::zero());
 
     // Encode uniform clearing price vector
-    for (&token, &price) in solution.prices.iter().sorted() {
-        tokens.push(token.into());
-        clearing_prices.push(price);
+    for asset in solution
+        .clearing_prices()
+        .iter()
+        .sorted_by_cached_key(|asset| asset.token)
+    {
+        tokens.push(asset.token.into());
+        clearing_prices.push(asset.amount.into());
     }
 
     // Encode trades with custom clearing prices

--- a/crates/driver/src/domain/competition/solution/mod.rs
+++ b/crates/driver/src/domain/competition/solution/mod.rs
@@ -326,7 +326,7 @@ impl Solution {
     ///
     /// The rule which relates two prices for tokens X and Y is:
     /// amount_x * price_x = amount_y * price_y
-    pub fn clearing_prices(&self) -> Result<Vec<eth::Asset>, Error> {
+    pub fn clearing_prices(&self) -> Vec<eth::Asset> {
         let prices = self.prices.iter().map(|(&token, &amount)| eth::Asset {
             token,
             amount: amount.into(),
@@ -359,12 +359,12 @@ impl Solution {
                 amount: self.prices[&self.weth.into()].to_owned().into(),
             });
 
-            return Ok(prices);
+            return prices;
         }
 
         // TODO: We should probably filter out all unused prices to save gas.
 
-        Ok(prices.collect_vec())
+        prices.collect_vec()
     }
 
     /// Clearing price for the given token.

--- a/crates/driver/src/domain/competition/solution/settlement.rs
+++ b/crates/driver/src/domain/competition/solution/settlement.rs
@@ -321,7 +321,6 @@ impl Settlement {
     pub fn prices(&self) -> HashMap<eth::TokenAddress, eth::TokenAmount> {
         self.solution
             .clearing_prices()
-            .expect("settlement cannot exist without prices")
             .iter()
             .map(|asset| (asset.token, asset.amount))
             .collect()


### PR DESCRIPTION
# Description
This is not technically required for correct encoding, however, we are currently seeing a lot of "boundary settlement does not match domain settlement domain" warnings, not because the encoding is different, but because clearing prices are sorted in the legacy encoding:

https://github.com/cowprotocol/services/blob/1f019389f5fa8e873d785bba13b0a51c1833b6ad/crates/solver/src/settlement/settlement_encoder.rs#L113

# Changes
- [x] also sort tokens in domain encoding logic
- [x] access prices via `clearing_prices` so that `0xee...ee` also gets wrapped in the uniform vector.
- [x] Noticed clearing_prices in infallible (adjust message signature)

## How to test
Run in shadow mode and see warning log not show up even if trade doesn't happen to sell the lexicographically smaller token.

<!--
## Related Issues

Fixes #
-->