### PR TITLE
Simulate/AccessList generation with None instead of Some(0) gas price

### DIFF
--- a/crates/driver/src/infra/blockchain/mod.rs
+++ b/crates/driver/src/infra/blockchain/mod.rs
@@ -132,7 +132,6 @@ impl Ethereum {
         let tx = web3::types::TransactionRequest {
             from: tx.from.into(),
             to: Some(tx.to.into()),
-            gas_price: Some(eth::U256::zero()),
             value: Some(tx.value.into()),
             data: Some(tx.input.into()),
             access_list: Some(tx.access_list.into()),
@@ -169,7 +168,6 @@ impl Ethereum {
                 web3::types::CallRequest {
                     from: Some(tx.from.into()),
                     to: Some(tx.to.into()),
-                    gas_price: Some(eth::U256::zero()),
                     value: Some(tx.value.into()),
                     data: Some(tx.input.clone().into()),
                     access_list: Some(tx.access_list.clone().into()),


### PR DESCRIPTION
# Description
Otherwise, we get "gasPrice must be non-zero after london fork" when simulating against geth nodes ([code](https://github.com/ethereum/go-ethereum/blob/86a1f0c39494c8f5caddf6bd9fbddd4bdfa944fd/internal/ethapi/transaction_args.go#L220))

# Changes
- [x] Change Some(0) => None

## How to test
CI still passes

<!--
## Related Issues

Fixes #
-->