### PR TITLE
[Easy] Fix clippy for rust v1.78

### DIFF
--- a/crates/driver/src/domain/competition/mod.rs
+++ b/crates/driver/src/domain/competition/mod.rs
@@ -206,7 +206,7 @@ impl Competition {
             })
             .unzip();
 
-        *self.settlement.lock().unwrap() = settlement.clone();
+        self.settlement.lock().unwrap().clone_from(&settlement);
 
         let settlement = match settlement {
             Some(settlement) => settlement,

--- a/crates/shared/src/recent_block_cache.rs
+++ b/crates/shared/src/recent_block_cache.rs
@@ -618,7 +618,7 @@ mod tests {
             TestValue::new(2, "1"),
             TestValue::new(3, "1"),
         ];
-        *values.lock().unwrap() = initial_values.clone();
+        values.lock().unwrap().clone_from(&initial_values);
 
         let result = cache
             .fetch(test_keys(0..2), Block::Number(block_number))
@@ -638,7 +638,7 @@ mod tests {
             TestValue::new(2, "2"),
             TestValue::new(3, "2"),
         ];
-        *values.lock().unwrap() = updated_values.clone();
+        values.lock().unwrap().clone_from(&updated_values);
         cache.update_cache_at_block(block_number).await.unwrap();
         values.lock().unwrap().clear();
 

--- a/crates/shared/src/sources/balancer_v2/pool_fetching/pool_storage.rs
+++ b/crates/shared/src/sources/balancer_v2/pool_fetching/pool_storage.rs
@@ -499,7 +499,7 @@ mod tests {
 
         // Everything old from block 3 on is gone.
         for pool_id in pool_ids.iter().take(6).skip(3) {
-            assert!(pool_store.pools.get(pool_id).is_none());
+            assert!(!pool_store.pools.contains_key(pool_id));
         }
         for token in tokens.iter().take(7).skip(4) {
             assert!(pool_store.pools_by_token.get(token).unwrap().is_empty());
@@ -513,8 +513,7 @@ mod tests {
 
         assert!(pool_store
             .pools_by_token
-            .get(&new_pool.common.tokens[0])
-            .is_some());
+            .contains_key(&new_pool.common.tokens[0]));
         assert_eq!(pool_store.last_event_block(), new_pool.common.block_created);
     }
 


### PR DESCRIPTION
# Description
Lint fails on most recent master with newest rust version

# Changes
Fix clippy warnings

## How to test
CI

<!--
## Related Issues

Fixes #
-->