### PR TITLE
Verify quotes based on zeroex RFQ orders even if the simulation fails

### DIFF
--- a/crates/autopilot/src/run.rs
+++ b/crates/autopilot/src/run.rs
@@ -420,6 +420,7 @@ pub async fn run(args: Arguments) {
             gas_price: gas_price_estimator.clone(),
         },
     )
+    .await
     .expect("failed to initialize price estimator factory");
 
     let native_price_estimator = price_estimator_factory

--- a/crates/e2e/tests/e2e/main.rs
+++ b/crates/e2e/tests/e2e/main.rs
@@ -20,6 +20,7 @@ mod partial_fill;
 mod partially_fillable_balance;
 mod partially_fillable_pool;
 mod protocol_fee;
+mod quote_verification;
 mod quoting;
 mod refunder;
 mod replace_order;

--- a/crates/e2e/tests/e2e/quote_verification.rs
+++ b/crates/e2e/tests/e2e/quote_verification.rs
@@ -31,6 +31,7 @@ async fn forked_node_mainnet_verify_zeroex_quote() {
 /// The block number from which we will fetch state for the forked tests.
 const FORK_BLOCK_MAINNET: u64 = 19796077;
 
+/// Tests that quotes based on zeroex RFQ orders get verified.
 async fn forked_mainnet_verify_zeroex_quote(web3: Web3) {
     let block_stream = ethrpc::current_block::current_block_stream(
         Arc::new(web3.clone()),

--- a/crates/e2e/tests/e2e/quote_verification.rs
+++ b/crates/e2e/tests/e2e/quote_verification.rs
@@ -1,0 +1,120 @@
+use {
+    contracts::IZeroEx,
+    e2e::setup::{run_forked_test_with_block_number, OnchainComponents},
+    ethcontract::H160,
+    ethrpc::Web3,
+    model::order::{BuyTokenDestination, OrderKind, SellTokenSource},
+    number::nonzero::U256 as NonZeroU256,
+    shared::{
+        price_estimation::{
+            trade_verifier::{PriceQuery, TradeVerifier, TradeVerifying},
+            Estimate,
+            Verification,
+        },
+        trade_finding::{Interaction, Trade},
+    },
+    std::{str::FromStr, sync::Arc},
+};
+
+#[tokio::test]
+#[ignore]
+async fn forked_node_mainnet_verify_zeroex_quote() {
+    run_forked_test_with_block_number(
+        forked_mainnet_verify_zeroex_quote,
+        std::env::var("FORK_URL_MAINNET")
+            .expect("FORK_URL_MAINNET must be set to run forked tests"),
+        FORK_BLOCK_MAINNET,
+    )
+    .await;
+}
+
+/// The block number from which we will fetch state for the forked tests.
+const FORK_BLOCK_MAINNET: u64 = 19796077;
+
+async fn forked_mainnet_verify_zeroex_quote(web3: Web3) {
+    let block_stream = ethrpc::current_block::current_block_stream(
+        Arc::new(web3.clone()),
+        std::time::Duration::from_millis(1_000),
+    )
+    .await
+    .unwrap();
+    let onchain = OnchainComponents::deployed(web3.clone()).await;
+
+    let verifier = TradeVerifier::new(
+        Arc::new(web3.clone()),
+        Arc::new(web3.clone()),
+        block_stream,
+        onchain.contracts().gp_settlement.address(),
+        onchain.contracts().weth.address(),
+        0.0,
+        Some(IZeroEx::deployed(&web3).await.unwrap()),
+    );
+
+    let verify_trade = |signature| {
+        let verifier = verifier.clone();
+        async move {
+            let signature_hex = hex::decode(signature).unwrap();
+            let arguments_hex = hex::decode("000000000000000000000000c02aaa39b223fe8d0a0e5c4f27ead9083c756cc20000000000000000000000002260fac5e5542a773aa44fbcfedf7c193bc2c599000000000000000000000000000000000000000000000000e357b42c3a9d8ccf0000000000000000000000000000000000000000000000000000000004d0e79e000000000000000000000000a69babef1ca67a37ffaf7a485dfff3382056e78c0000000000000000000000009008d19f58aabd9ed0d60971565aa8510560ab41000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000066360af101ffffffffffffffffffffffffffffffffffffff0f3f47f166360a8d0000003f0000000000000000000000000000000000000000000000000000000000000003000000000000000000000000000000000000000000000000000000000000001c66b3383f287dd9c85ad90e7c5a576ea4ba1bdf5a001d794a9afa379e6b2517b47e487a1aef32e75af432cbdbd301ada42754eaeac21ec4ca744afd92732f47540000000000000000000000000000000000000000000000000000000004d0c80f").unwrap();
+            verifier
+                .verify(
+                    &PriceQuery {
+                        sell_token: H160::from_str("0x2260fac5e5542a773aa44fbcfedf7c193bc2c599")
+                            .unwrap(),
+                        buy_token: H160::from_str("0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2")
+                            .unwrap(),
+                        kind: OrderKind::Sell,
+                        in_amount: NonZeroU256::new(12.into()).unwrap(),
+                    },
+                    &Verification {
+                        from: H160::from_str("0x73688c2b34bf6c09c125fed02fe92d17a94b897a").unwrap(),
+                        receiver: H160::from_str("0x73688c2b34bf6c09c125fed02fe92d17a94b897a")
+                            .unwrap(),
+                        pre_interactions: vec![],
+                        post_interactions: vec![],
+                        sell_token_source: SellTokenSource::Erc20,
+                        buy_token_destination: BuyTokenDestination::Erc20,
+                    },
+                    Trade {
+                        out_amount: 16380122291179526144u128.into(),
+                        gas_estimate: Some(225000),
+                        interactions: vec![Interaction {
+                            target: H160::from_str("0xdef1c0ded9bec7f1a1670819833240f027b25eff")
+                                .unwrap(),
+                            data: signature_hex.into_iter().chain(arguments_hex).collect(),
+                            value: 0.into(),
+                        }],
+                        solver: H160::from_str("0xe3067c7c27c1038de4e8ad95a83b927d23dfbd99")
+                            .unwrap(),
+                    },
+                )
+                .await
+        }
+    };
+
+    let verified_quote = Estimate {
+        out_amount: 16380122291179526144u128.into(),
+        gas: 225000,
+        solver: H160::from_str("0xe3067c7c27c1038de4e8ad95a83b927d23dfbd99").unwrap(),
+        verified: true,
+    };
+
+    // trades using `fillRfqOrder()` get verified even if the simulation fails
+    // See <https://www.4byte.directory/signatures/?bytes4_signature=0xaa77476c>
+    let verification = verify_trade("aa77476c").await;
+    assert_eq!(&verification.unwrap(), &verified_quote);
+
+    // trades using `fillOrKillRfqOrder()` get verified even if the simulation fails
+    // See <https://www.4byte.directory/signatures/?bytes4_signature=0x438cdfc5>
+    let verification = verify_trade("438cdfc5").await;
+    assert_eq!(&verification.unwrap(), &verified_quote);
+
+    // trades using any other functions do not get verified when failing to simulate
+    let verification = verify_trade("11111111").await;
+    assert_eq!(
+        verification.unwrap(),
+        Estimate {
+            verified: false,
+            ..verified_quote
+        }
+    );
+}

--- a/crates/e2e/tests/e2e/quote_verification.rs
+++ b/crates/e2e/tests/e2e/quote_verification.rs
@@ -32,6 +32,8 @@ async fn forked_node_mainnet_verify_zeroex_quote() {
 const FORK_BLOCK_MAINNET: u64 = 19796077;
 
 /// Tests that quotes based on zeroex RFQ orders get verified.
+/// Based on an RFQ quote we saw on prod:
+/// https://www.tdly.co/shared/simulation/7402de5e-e524-4e24-9af8-50d0a38c105b
 async fn forked_mainnet_verify_zeroex_quote(web3: Web3) {
     let block_stream = ethrpc::current_block::current_block_stream(
         Arc::new(web3.clone()),

--- a/crates/orderbook/src/run.rs
+++ b/crates/orderbook/src/run.rs
@@ -375,6 +375,7 @@ pub async fn run(args: Arguments) {
             gas_price: gas_price_estimator.clone(),
         },
     )
+    .await
     .expect("failed to initialize price estimator factory");
 
     let native_price_estimator = price_estimator_factory

--- a/crates/shared/src/trade_finding.rs
+++ b/crates/shared/src/trade_finding.rs
@@ -6,7 +6,7 @@ pub mod external;
 use {
     crate::price_estimation::{PriceEstimationError, Query},
     anyhow::Result,
-    contracts::{dummy_contract, ERC20},
+    contracts::{dummy_contract, IZeroEx, ERC20},
     derivative::Derivative,
     ethcontract::{contract::MethodBuilder, tokens::Tokenize, web3::Transport, Bytes, H160, U256},
     model::interaction::InteractionData,
@@ -83,6 +83,23 @@ impl Trade {
     /// Converts a trade into a set of interactions for settlements.
     pub fn encode(&self) -> Vec<EncodedInteraction> {
         self.interactions.iter().map(|i| i.encode()).collect()
+    }
+
+    /// Returns whether the trade would get facilitated by a market maker via a
+    /// zeroex RFQ order.
+    pub fn uses_zeroex_rfq_liquidity(&self, zeroex: &IZeroEx) -> bool {
+        /// Public functions on [`IZeroEx`] which are used to settle RFQ orders.
+        const RFQ_FUNCTIONS: &[&str] = &["fillRfqOrder", "fillOrKillRfqOrder"];
+        let abi = &IZeroEx::raw_contract().interface.abi;
+
+        let calls_function = |i: &Interaction, fun| {
+            let signature = &abi.function(fun).unwrap().short_signature();
+            i.data.starts_with(signature.as_slice())
+        };
+
+        self.interactions.iter().any(|i| {
+            i.target == zeroex.address() && RFQ_FUNCTIONS.iter().any(|fun| calls_function(i, fun))
+        })
     }
 }
 


### PR DESCRIPTION
# Description
Quoters with market maker integration currently quote by returning an interaction that calls `fillRfqOrder()` on the zeroex contract with an order they just signed for that specific quote.
However, at least 1 relevant quoter currently signs zeroex orders with `txOrigin: 0x0000` which makes the orders invalid ([code](https://github.com/0xProject/protocol/blob/development/contracts/zero-ex/contracts/src/features/native_orders/NativeOrdersInfo.sol#L77-L80)). The proper solution would be to underwrite orders that set `txOrigin` to literally any other value and adjust the test for that but since the solvers will be slow to adjust to this (signaled on telegram) we need a temporary workaround if we want to rollout quote verification on prod mainnet again without losing essential quoters.

The actual long term fix will come in a follow up PR.

# Changes
If a simulation fails the `TradeVerifier` checks if the trade contains interactions calling `fillRfqOrder()` or `fillOrKillRfqOrder()` and considers it verified anyway.

## How to test
Added a forked node e2e test that replays one of the problematic quotes we [saw in prod](https://production-6de61f.kb.eu-central-1.aws.cloud.es.io/app/discover#/context/c0e240e0-d9b3-11ed-b0e6-e361adffce0b/PhgZQ48B0pqFYaDRQAtQ?_g=(filters:!())&_a=(columns:!(log),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!t,index:c0e240e0-d9b3-11ed-b0e6-e361adffce0b,key:kubernetes.labels.app_kubernetes_io%2Fcomponent,negate:!t,params:(query:controller),type:phrase),query:(match_phrase:(kubernetes.labels.app_kubernetes_io%2Fcomponent:controller))),('$state':(store:appState),meta:(alias:!n,disabled:!t,index:c0e240e0-d9b3-11ed-b0e6-e361adffce0b,key:kubernetes.labels.network,negate:!f,params:(query:mainnet),type:phrase),query:(match_phrase:(kubernetes.labels.network:mainnet)))))) and asserts that it would now pass the verification.