### PR TITLE
Quote overrides tx origin

### DIFF
--- a/crates/autopilot/src/run.rs
+++ b/crates/autopilot/src/run.rs
@@ -420,7 +420,6 @@ pub async fn run(args: Arguments) {
             gas_price: gas_price_estimator.clone(),
         },
     )
-    .await
     .expect("failed to initialize price estimator factory");
 
     let native_price_estimator = price_estimator_factory

--- a/crates/driver/src/domain/quote.rs
+++ b/crates/driver/src/domain/quote.rs
@@ -27,6 +27,8 @@ pub struct Quote {
     pub interactions: Vec<eth::Interaction>,
     pub solver: eth::Address,
     pub gas: Option<eth::Gas>,
+    /// Which `tx.origin` is required to make the quote simulation pass.
+    pub tx_origin: Option<eth::Address>,
 }
 
 impl Quote {
@@ -52,6 +54,7 @@ impl Quote {
             interactions: boundary::quote::encode_interactions(eth, solution.interactions())?,
             solver: solution.solver().address(),
             gas: solution.gas(),
+            tx_origin: *solution.solver().quote_tx_origin(),
         })
     }
 }

--- a/crates/driver/src/infra/api/routes/quote/dto/quote.rs
+++ b/crates/driver/src/infra/api/routes/quote/dto/quote.rs
@@ -22,6 +22,7 @@ impl Quote {
                 .collect(),
             solver: quote.solver.0,
             gas: quote.gas.map(|gas| gas.0.as_u64()),
+            tx_origin: quote.tx_origin.map(|addr| addr.0),
         }
     }
 }
@@ -36,6 +37,8 @@ pub struct Quote {
     solver: eth::H160,
     #[serde(skip_serializing_if = "Option::is_none")]
     gas: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    tx_origin: Option<eth::H160>,
 }
 
 #[serde_as]

--- a/crates/driver/src/infra/config/file/load.rs
+++ b/crates/driver/src/infra/config/file/load.rs
@@ -92,6 +92,7 @@ pub async fn load(chain: eth::ChainId, path: &Path) -> infra::Config {
                 },
                 s3: config.s3.map(Into::into),
                 solver_native_token: config.manage_native_token.to_domain(),
+                quote_tx_origin: config.quote_tx_origin.map(eth::Address),
             }
         }))
         .await,

--- a/crates/driver/src/infra/config/file/mod.rs
+++ b/crates/driver/src/infra/config/file/mod.rs
@@ -261,6 +261,10 @@ struct SolverConfig {
     /// Whether the native token is wrapped or not when sent to the solvers
     #[serde(default)]
     manage_native_token: ManageNativeToken,
+
+    /// Which `tx.origin` is required to make a quote simulation pass.
+    #[serde(default)]
+    quote_tx_origin: Option<eth::H160>,
 }
 
 #[derive(Clone, Copy, Debug, Default, Deserialize, PartialEq, Serialize)]

--- a/crates/driver/src/infra/solver/mod.rs
+++ b/crates/driver/src/infra/solver/mod.rs
@@ -127,6 +127,8 @@ pub struct Config {
     pub s3: Option<S3>,
     /// Whether the native token is wrapped or not when sent to the solvers
     pub solver_native_token: ManageNativeToken,
+    /// Which `tx.origin` is required to make quote verification pass.
+    pub quote_tx_origin: Option<eth::Address>,
 }
 
 impl Solver {
@@ -199,6 +201,10 @@ impl Solver {
 
     pub fn solver_native_token(&self) -> ManageNativeToken {
         self.config.solver_native_token
+    }
+
+    pub fn quote_tx_origin(&self) -> &Option<eth::Address> {
+        &self.config.quote_tx_origin
     }
 
     /// Make a POST request instructing the solver to solve an auction.

--- a/crates/e2e/tests/e2e/quote_verification.rs
+++ b/crates/e2e/tests/e2e/quote_verification.rs
@@ -17,7 +17,7 @@ use {
 
 #[tokio::test]
 #[ignore]
-async fn local_node_bypass_verification_for_rfq_quotes() {
+async fn forked_node_bypass_verification_for_rfq_quotes() {
     run_forked_test_with_block_number(
         test_bypass_verification_for_rfq_quotes,
         std::env::var("FORK_URL_MAINNET")

--- a/crates/e2e/tests/e2e/quote_verification.rs
+++ b/crates/e2e/tests/e2e/quote_verification.rs
@@ -50,8 +50,7 @@ async fn forked_mainnet_verify_zeroex_quote(web3: Web3) {
         onchain.contracts().gp_settlement.address(),
         onchain.contracts().weth.address(),
         0.0,
-    )
-    .await;
+    );
 
     let verify_trade = |signature| {
         let verifier = verifier.clone();
@@ -88,6 +87,7 @@ async fn forked_mainnet_verify_zeroex_quote(web3: Web3) {
                         }],
                         solver: H160::from_str("0xe3067c7c27c1038de4e8ad95a83b927d23dfbd99")
                             .unwrap(),
+                        tx_origin: Some(H160::zero()),
                     },
                 )
                 .await

--- a/crates/e2e/tests/e2e/quote_verification.rs
+++ b/crates/e2e/tests/e2e/quote_verification.rs
@@ -17,9 +17,9 @@ use {
 
 #[tokio::test]
 #[ignore]
-async fn forked_node_mainnet_verify_zeroex_quote() {
+async fn local_node_bypass_verification_for_rfq_quotes() {
     run_forked_test_with_block_number(
-        forked_mainnet_verify_zeroex_quote,
+        test_bypass_verification_for_rfq_quotes,
         std::env::var("FORK_URL_MAINNET")
             .expect("FORK_URL_MAINNET must be set to run forked tests"),
         FORK_BLOCK_MAINNET,
@@ -30,10 +30,11 @@ async fn forked_node_mainnet_verify_zeroex_quote() {
 /// The block number from which we will fetch state for the forked tests.
 const FORK_BLOCK_MAINNET: u64 = 19796077;
 
-/// Tests that quotes based on zeroex RFQ orders that require `tx.origin` to be
-/// 0x0000 get verified. Based on an RFQ quote we saw on prod:
+/// Tests that quotes requesting `tx_origin: 0x0000` bypass the verification
+/// because those are currently used by some solvers to provide market maker
+/// integrations. Based on an RFQ quote we saw on prod:
 /// https://www.tdly.co/shared/simulation/7402de5e-e524-4e24-9af8-50d0a38c105b
-async fn forked_mainnet_verify_zeroex_quote(web3: Web3) {
+async fn test_bypass_verification_for_rfq_quotes(web3: Web3) {
     let block_stream = ethrpc::current_block::current_block_stream(
         Arc::new(web3.clone()),
         std::time::Duration::from_millis(1_000),
@@ -52,11 +53,9 @@ async fn forked_mainnet_verify_zeroex_quote(web3: Web3) {
         0.0,
     );
 
-    let verify_trade = |signature| {
+    let verify_trade = |tx_origin| {
         let verifier = verifier.clone();
         async move {
-            let signature_hex = hex::decode(signature).unwrap();
-            let arguments_hex = hex::decode("000000000000000000000000c02aaa39b223fe8d0a0e5c4f27ead9083c756cc20000000000000000000000002260fac5e5542a773aa44fbcfedf7c193bc2c599000000000000000000000000000000000000000000000000e357b42c3a9d8ccf0000000000000000000000000000000000000000000000000000000004d0e79e000000000000000000000000a69babef1ca67a37ffaf7a485dfff3382056e78c0000000000000000000000009008d19f58aabd9ed0d60971565aa8510560ab41000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000066360af101ffffffffffffffffffffffffffffffffffffff0f3f47f166360a8d0000003f0000000000000000000000000000000000000000000000000000000000000003000000000000000000000000000000000000000000000000000000000000001c66b3383f287dd9c85ad90e7c5a576ea4ba1bdf5a001d794a9afa379e6b2517b47e487a1aef32e75af432cbdbd301ada42754eaeac21ec4ca744afd92732f47540000000000000000000000000000000000000000000000000000000004d0c80f").unwrap();
             verifier
                 .verify(
                     &PriceQuery {
@@ -82,12 +81,12 @@ async fn forked_mainnet_verify_zeroex_quote(web3: Web3) {
                         interactions: vec![Interaction {
                             target: H160::from_str("0xdef1c0ded9bec7f1a1670819833240f027b25eff")
                                 .unwrap(),
-                            data: signature_hex.into_iter().chain(arguments_hex).collect(),
+                            data: hex::decode("aa77476c000000000000000000000000c02aaa39b223fe8d0a0e5c4f27ead9083c756cc20000000000000000000000002260fac5e5542a773aa44fbcfedf7c193bc2c599000000000000000000000000000000000000000000000000e357b42c3a9d8ccf0000000000000000000000000000000000000000000000000000000004d0e79e000000000000000000000000a69babef1ca67a37ffaf7a485dfff3382056e78c0000000000000000000000009008d19f58aabd9ed0d60971565aa8510560ab41000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000066360af101ffffffffffffffffffffffffffffffffffffff0f3f47f166360a8d0000003f0000000000000000000000000000000000000000000000000000000000000003000000000000000000000000000000000000000000000000000000000000001c66b3383f287dd9c85ad90e7c5a576ea4ba1bdf5a001d794a9afa379e6b2517b47e487a1aef32e75af432cbdbd301ada42754eaeac21ec4ca744afd92732f47540000000000000000000000000000000000000000000000000000000004d0c80f").unwrap(),
                             value: 0.into(),
                         }],
                         solver: H160::from_str("0xe3067c7c27c1038de4e8ad95a83b927d23dfbd99")
                             .unwrap(),
-                        tx_origin: Some(H160::zero()),
+                        tx_origin,
                     },
                 )
                 .await
@@ -101,18 +100,14 @@ async fn forked_mainnet_verify_zeroex_quote(web3: Web3) {
         verified: true,
     };
 
-    // trades using `fillRfqOrder()` get verified even if the simulation fails
-    // See <https://www.4byte.directory/signatures/?bytes4_signature=0xaa77476c>
-    let verification = verify_trade("aa77476c").await;
+    // `tx_origin: 0x0000` is currently used to bypass quote verification due to an
+    // implementation detail of zeroex RFQ orders.
+    // TODO: remove with #2693
+    let verification = verify_trade(Some(H160::zero())).await;
     assert_eq!(&verification.unwrap(), &verified_quote);
 
-    // trades using `fillOrKillRfqOrder()` get verified even if the simulation fails
-    // See <https://www.4byte.directory/signatures/?bytes4_signature=0x438cdfc5>
-    let verification = verify_trade("438cdfc5").await;
-    assert_eq!(&verification.unwrap(), &verified_quote);
-
-    // trades using any other functions do not get verified when failing to simulate
-    let verification = verify_trade("11111111").await;
+    // Trades using any other `tx_origin` can not bypass the verification.
+    let verification = verify_trade(None).await;
     assert_eq!(
         verification.unwrap(),
         Estimate {

--- a/crates/orderbook/src/run.rs
+++ b/crates/orderbook/src/run.rs
@@ -375,7 +375,6 @@ pub async fn run(args: Arguments) {
             gas_price: gas_price_estimator.clone(),
         },
     )
-    .await
     .expect("failed to initialize price estimator factory");
 
     let native_price_estimator = price_estimator_factory

--- a/crates/shared/src/price_estimation/factory.rs
+++ b/crates/shared/src/price_estimation/factory.rs
@@ -96,14 +96,14 @@ impl PriceEstimatorSource {
 }
 
 impl<'a> PriceEstimatorFactory<'a> {
-    pub async fn new(
+    pub fn new(
         args: &'a Arguments,
         shared_args: &'a arguments::Arguments,
         network: Network,
         components: Components,
     ) -> Result<Self> {
         Ok(Self {
-            trade_verifier: Self::trade_verifier(args, shared_args, &network, &components).await,
+            trade_verifier: Self::trade_verifier(args, shared_args, &network, &components),
             args,
             shared_args,
             network,
@@ -112,7 +112,7 @@ impl<'a> PriceEstimatorFactory<'a> {
         })
     }
 
-    async fn trade_verifier(
+    fn trade_verifier(
         args: &'a Arguments,
         shared_args: &arguments::Arguments,
         network: &Network,
@@ -139,18 +139,15 @@ impl<'a> PriceEstimatorFactory<'a> {
             ethrpc::instrumented::instrument_with_label(&network.web3, "codeFetching".into());
         let code_fetcher = Arc::new(CachedCodeFetcher::new(Arc::new(code_fetcher)));
 
-        Some(Arc::new(
-            TradeVerifier::new(
-                web3,
-                simulator,
-                code_fetcher,
-                network.block_stream.clone(),
-                network.settlement,
-                network.native_token,
-                args.quote_inaccuracy_limit,
-            )
-            .await,
-        ))
+        Some(Arc::new(TradeVerifier::new(
+            web3,
+            simulator,
+            code_fetcher,
+            network.block_stream.clone(),
+            network.settlement,
+            network.native_token,
+            args.quote_inaccuracy_limit,
+        )))
     }
 
     fn native_token_price_estimation_amount(&self) -> Result<NonZeroU256> {

--- a/crates/shared/src/price_estimation/http.rs
+++ b/crates/shared/src/price_estimation/http.rs
@@ -296,6 +296,7 @@ impl HttpTradeFinder {
                 })
                 .collect(),
             solver: self.solver,
+            tx_origin: None,
         })
     }
 

--- a/crates/shared/src/trade_finding/external.rs
+++ b/crates/shared/src/trade_finding/external.rs
@@ -114,6 +114,7 @@ impl From<dto::Quote> for Trade {
                 })
                 .collect(),
             solver: quote.solver,
+            tx_origin: quote.tx_origin,
         }
     }
 }
@@ -180,6 +181,8 @@ mod dto {
         pub interactions: Vec<Interaction>,
         pub solver: H160,
         pub gas: Option<u64>,
+        #[serde(default)]
+        pub tx_origin: Option<H160>,
     }
 
     #[serde_as]


### PR DESCRIPTION
# Description
Fixes https://github.com/cowprotocol/services/issues/2692

# Changes
Removes all the zeroex specific RFQ interaction detection again. Technically it was more correct before but this is a lot of code to generically detect a case which we know only happens for a single solver which should resolve the issue end of month so let's not overthink it.

Now we can configure in the `driver` per solver which `tx_origin` should be used to verify the quotes. That way external solvers can tell us for which random address they sign their quotes for and we just configure it in the infra config.

## How to test
Adjusted existing test