### PR TITLE
Make simulation curl command compatible with dev container

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -6,4 +6,4 @@ RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
 
 # [Optional] Uncomment this section to install additional OS packages.
 RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
-    && apt-get -y install --no-install-recommends gdb valgrind heaptrack pkg-config
+    && apt-get -y install --no-install-recommends gdb valgrind heaptrack pkg-config xdg-utils

--- a/crates/shared/src/tenderly_api.rs
+++ b/crates/shared/src/tenderly_api.rs
@@ -111,7 +111,7 @@ impl TenderlyApi for TenderlyHttpApi {
         #[rustfmt::skip]
         tracing::debug!(
             "resimulate by setting TENDERLY_API_KEY environment variable and running: \
-            curl -X POST --header \"X-ACCESS-KEY: $TENDERLY_API_KEY\" --json '{body}' {request_url} \
+            curl -X POST -H \"X-ACCESS-KEY: $TENDERLY_API_KEY\" -H \"Content-Type: application/json\" --data '{body}' {request_url} \
             | jq -r \".simulation.id\" \
             | read SIMULATION_ID; \
             echo {simulation_url} \


### PR DESCRIPTION
# Description
The `curl` version installed in the the dev containers does not support the `--json` flag. That's why we use `--data` and set the appropriate header instead.

Also installed `xdg-utils` in the container to get `xdg-open`.

## How to test
Executed a command taken from prod modified according to the PR and successfully ran it in the dev container.