### PR TITLE
Set gas price for quote simulations

### DIFF
--- a/crates/driver/src/infra/blockchain/mod.rs
+++ b/crates/driver/src/infra/blockchain/mod.rs
@@ -163,7 +163,6 @@ impl Ethereum {
 
     /// Estimate gas used by a transaction.
     pub async fn estimate_gas(&self, tx: &eth::Tx) -> Result<eth::Gas, Error> {
-
         self.web3
             .eth()
             .estimate_gas(

--- a/crates/driver/src/infra/blockchain/mod.rs
+++ b/crates/driver/src/infra/blockchain/mod.rs
@@ -227,7 +227,7 @@ impl Ethereum {
             .map_err(Into::into)
     }
 
-    async fn simulation_gas_price(&self) -> Option<eth::U256> {
+    pub(super) async fn simulation_gas_price(&self) -> Option<eth::U256> {
         // Some nodes don't pick a reasonable default value when you don't specify a gas
         // price and default to 0. Additionally some sneaky tokens have special code
         // paths that detect that case to try to behave differently during simulations

--- a/crates/driver/src/infra/blockchain/mod.rs
+++ b/crates/driver/src/infra/blockchain/mod.rs
@@ -235,7 +235,12 @@ impl Ethereum {
         // default value we estimate the current gas price upfront. But because it's
         // extremely rare that tokens behave that way we are fine with falling back to
         // the node specific fallback value instead of failing the whole call.
-        self.web3.eth().gas_price().await.ok()
+        self.inner
+            .gas
+            .estimate()
+            .await
+            .ok()
+            .map(|gas| gas.effective().0 .0)
     }
 }
 

--- a/crates/driver/src/infra/simulator/mod.rs
+++ b/crates/driver/src/infra/simulator/mod.rs
@@ -29,10 +29,10 @@ pub enum Config {
 
 impl Simulator {
     /// Simulate transactions on [Tenderly](https://tenderly.co/).
-    pub fn tenderly(config: tenderly::Config, chain: eth::ChainId, eth: Ethereum) -> Self {
+    pub fn tenderly(config: tenderly::Config, eth: Ethereum) -> Self {
         let eth = eth.with_metric_label("tenderlySimulator".into());
         Self {
-            inner: Inner::Tenderly(tenderly::Tenderly::new(config, chain)),
+            inner: Inner::Tenderly(tenderly::Tenderly::new(config, eth.clone())),
             eth,
             disable_access_lists: false,
             disable_gas: None,

--- a/crates/driver/src/infra/simulator/tenderly/dto.rs
+++ b/crates/driver/src/infra/simulator/tenderly/dto.rs
@@ -21,6 +21,7 @@ pub struct Request {
     pub generate_access_list: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub access_list: Option<AccessList>,
+    pub gas_price: u64,
 }
 
 #[derive(Debug, Deserialize)]

--- a/crates/driver/src/infra/simulator/tenderly/mod.rs
+++ b/crates/driver/src/infra/simulator/tenderly/mod.rs
@@ -69,13 +69,7 @@ impl Tenderly {
         tx: &eth::Tx,
         generate_access_list: GenerateAccessList,
     ) -> Result<Simulation, Error> {
-        let gas_price = self
-            .eth
-            .gas_price()
-            .await
-            .ok()
-            .map(|gas| gas.effective().0 .0.as_u64())
-            .unwrap_or_default();
+        let gas_price = self.eth.simulation_gas_price().await;
 
         let res: dto::Response = self
             .client
@@ -94,7 +88,7 @@ impl Tenderly {
                 } else {
                     Some(tx.access_list.clone().into())
                 },
-                gas_price,
+                gas_price: gas_price.unwrap_or_default().as_u64(),
             })
             .send()
             .await?

--- a/crates/driver/src/run.rs
+++ b/crates/driver/src/run.rs
@@ -99,7 +99,6 @@ fn simulator(config: &infra::Config, eth: &Ethereum) -> Simulator {
                 save: tenderly.save,
                 save_if_fails: tenderly.save_if_fails,
             },
-            eth.network(),
             eth.to_owned(),
         ),
         Some(infra::simulator::Config::Enso(enso)) => Simulator::enso(

--- a/crates/ethrpc/src/current_block/mod.rs
+++ b/crates/ethrpc/src/current_block/mod.rs
@@ -50,6 +50,7 @@ pub struct BlockInfo {
     pub parent_hash: H256,
     pub timestamp: u64,
     pub gas_limit: U256,
+    pub gas_price: U256,
 }
 
 impl TryFrom<Block<H256>> for BlockInfo {
@@ -62,6 +63,7 @@ impl TryFrom<Block<H256>> for BlockInfo {
             parent_hash: value.parent_hash,
             timestamp: value.timestamp.as_u64(),
             gas_limit: value.gas_limit,
+            gas_price: value.base_fee_per_gas.context("no gas price")?,
         })
     }
 }

--- a/crates/shared/src/price_estimation/trade_verifier.rs
+++ b/crates/shared/src/price_estimation/trade_verifier.rs
@@ -134,12 +134,15 @@ impl TradeVerifier {
             )
             .tx;
 
+        let block = *self.block_stream.borrow();
+
         let call = CallRequest {
             // Initiate tx as solver so gas doesn't get deducted from user's ETH.
             from: Some(solver.address()),
             to: Some(solver.address()),
             data: simulation.data,
             gas: Some(Self::DEFAULT_GAS.into()),
+            gas_price: Some(block.gas_price),
             ..Default::default()
         };
 
@@ -148,10 +151,9 @@ impl TradeVerifier {
             .await
             .map_err(Error::SimulationFailed)?;
 
-        let block = self.block_stream.borrow().number;
         let output = self
             .simulator
-            .simulate(call, overrides, Some(block))
+            .simulate(call, overrides, Some(block.number))
             .await
             .context("failed to simulate quote")
             .map_err(Error::SimulationFailed);


### PR DESCRIPTION
# Description
Fixes https://github.com/cowprotocol/services/issues/2696
Usually if you don't set a gas price for an `eth_call` "a sane default" should be picked by the node. This either does not work with the nodes we use or simulating with state overrides is an exception to the rule.

# Changes
Read gas price in `CurrentBlockStream` and use the gas price of the most recent block for quote simulations.

## How to test
e2e tests should still work as the gas price should not affect the gas used computed during the verification simulation.