### PR TITLE
Unbuffered block stream

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1923,6 +1923,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tracing",
+ "url",
  "web3",
 ]
 

--- a/crates/autopilot/src/infra/blockchain/mod.rs
+++ b/crates/autopilot/src/infra/blockchain/mod.rs
@@ -4,8 +4,9 @@ use {
     ethcontract::dyns::DynWeb3,
     ethrpc::current_block::CurrentBlockStream,
     primitive_types::{H256, U256},
-    std::{sync::Arc, time::Duration},
+    std::time::Duration,
     thiserror::Error,
+    url::Url,
 };
 
 pub mod contracts;
@@ -32,6 +33,7 @@ impl From<U256> for ChainId {
 pub struct Rpc {
     web3: DynWeb3,
     chain: ChainId,
+    url: Url,
 }
 
 impl Rpc {
@@ -41,7 +43,11 @@ impl Rpc {
         let web3 = boundary::buffered_web3_client(url);
         let chain = web3.eth().chain_id().await?.into();
 
-        Ok(Self { web3, chain })
+        Ok(Self {
+            web3,
+            chain,
+            url: url.clone(),
+        })
     }
 
     /// Returns the chain id for the RPC connection.
@@ -72,16 +78,13 @@ impl Ethereum {
     /// Since this type is essential for the program this method will panic on
     /// any initialization error.
     pub async fn new(rpc: Rpc, addresses: contracts::Addresses, poll_interval: Duration) -> Self {
-        let Rpc { web3, chain } = rpc;
+        let Rpc { web3, chain, url } = rpc;
         let contracts = Contracts::new(&web3, &chain, addresses).await;
 
         Self {
-            current_block: ethrpc::current_block::current_block_stream(
-                Arc::new(web3.clone()),
-                poll_interval,
-            )
-            .await
-            .expect("couldn't initialize current block stream"),
+            current_block: ethrpc::current_block::current_block_stream(url, poll_interval)
+                .await
+                .expect("couldn't initialize current block stream"),
             web3,
             chain,
             contracts,

--- a/crates/e2e/tests/e2e/quote_verification.rs
+++ b/crates/e2e/tests/e2e/quote_verification.rs
@@ -35,12 +35,14 @@ const FORK_BLOCK_MAINNET: u64 = 19796077;
 /// integrations. Based on an RFQ quote we saw on prod:
 /// https://www.tdly.co/shared/simulation/7402de5e-e524-4e24-9af8-50d0a38c105b
 async fn test_bypass_verification_for_rfq_quotes(web3: Web3) {
-    let block_stream = ethrpc::current_block::current_block_stream(
-        Arc::new(web3.clone()),
-        std::time::Duration::from_millis(1_000),
-    )
-    .await
-    .unwrap();
+    let url = std::env::var("FORK_URL_MAINNET")
+        .expect("FORK_URL_MAINNET must be set to run forked tests")
+        .parse()
+        .unwrap();
+    let block_stream =
+        ethrpc::current_block::current_block_stream(url, std::time::Duration::from_millis(1_000))
+            .await
+            .unwrap();
     let onchain = OnchainComponents::deployed(web3.clone()).await;
 
     let verifier = TradeVerifier::new(

--- a/crates/ethrpc/Cargo.toml
+++ b/crates/ethrpc/Cargo.toml
@@ -33,6 +33,7 @@ web3 = { workspace = true }
 contracts = { path = "../contracts" }
 ethcontract = { workspace = true }
 tracing = { workspace = true }
+url = { workspace = true }
 
 [dev-dependencies]
 maplit = { workspace = true }

--- a/crates/orderbook/src/run.rs
+++ b/crates/orderbook/src/run.rs
@@ -253,7 +253,7 @@ pub async fn run(args: Arguments) {
     let current_block_stream = args
         .shared
         .current_block
-        .stream(web3.clone())
+        .stream(args.shared.node_url.clone())
         .await
         .unwrap();
 

--- a/crates/shared/src/current_block.rs
+++ b/crates/shared/src/current_block.rs
@@ -12,6 +12,7 @@ use {
         sync::Arc,
         time::Duration,
     },
+    url::Url,
 };
 
 /// Command line arguments for creating global block stream.
@@ -34,8 +35,8 @@ impl Arguments {
         Arc::new(web3)
     }
 
-    pub async fn stream(&self, web3: Web3) -> Result<CurrentBlockStream> {
-        current_block_stream(self.retriever(web3), self.block_stream_poll_interval).await
+    pub async fn stream(&self, rpc: Url) -> Result<CurrentBlockStream> {
+        current_block_stream(rpc, self.block_stream_poll_interval).await
     }
 }
 

--- a/crates/shared/src/price_estimation/http.rs
+++ b/crates/shared/src/price_estimation/http.rs
@@ -788,14 +788,11 @@ mod tests {
 
         let client = Client::new();
 
-        let transport = HttpTransport::new(
-            client.clone(),
-            crate::url::join(
-                &Url::parse("https://mainnet.infura.io/v3/").unwrap(),
-                &infura_project_id,
-            ),
-            "main".into(),
+        let url = crate::url::join(
+            &Url::parse("https://mainnet.infura.io/v3/").unwrap(),
+            &infura_project_id,
         );
+        let transport = HttpTransport::new(client.clone(), url.clone(), "main".into());
         let web3 = Web3::new(DynTransport::new(transport));
         let chain_id = web3.eth().chain_id().await.unwrap().as_u64();
         let version = chain_id.to_string();
@@ -812,7 +809,7 @@ mod tests {
                 .await
                 .unwrap()
                 .pool_fetching,
-                current_block_stream(Arc::new(web3.clone()), Duration::from_secs(1))
+                current_block_stream(url, Duration::from_secs(1))
                     .await
                     .unwrap(),
             )


### PR DESCRIPTION
# Description
On networks with a very high block frequency we can get into troubles when using the auto batching http transport for the RPC requests.

# Changes
With this PR we construct an fresh unbuffered `Web3` instance specifically for the `CurrentBlockStream`.

## How to test
e2e tests should still work