### PR TITLE
[PROPOSAL] Remove direct From/Into boilerplate

### DIFF
--- a/crates/autopilot/src/decoded_settlement.rs
+++ b/crates/autopilot/src/decoded_settlement.rs
@@ -6,6 +6,7 @@ use {
     app_data::AppDataHash,
     bigdecimal::{Signed, Zero},
     contracts::GPv2Settlement,
+    derive_more::From,
     ethcontract::{common::FunctionExt, tokens::Tokenize, Address, Bytes, U256},
     model::{
         order::{BuyTokenDestination, OrderData, OrderKind, OrderUid, SellTokenSource},
@@ -100,7 +101,7 @@ impl DecodedTrade {
 /// Trade flags are encoded in a 256-bit integer field. For more information on
 /// how flags are encoded see:
 /// <https://github.com/cowprotocol/contracts/blob/v1.0.0/src/contracts/libraries/GPv2Trade.sol#L58-L94>
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq, From)]
 pub struct TradeFlags(pub U256);
 
 impl TradeFlags {
@@ -146,12 +147,6 @@ impl TradeFlags {
             0b11 => SigningScheme::PreSign,
             _ => unreachable!(),
         }
-    }
-}
-
-impl From<U256> for TradeFlags {
-    fn from(value: U256) -> Self {
-        Self(value)
     }
 }
 

--- a/crates/driver/src/domain/competition/order/mod.rs
+++ b/crates/driver/src/domain/competition/order/mod.rs
@@ -6,6 +6,7 @@ use {
         util::{self, conv::u256::U256Ext, Bytes},
     },
     bigdecimal::Zero,
+    derive_more::{From, Into},
     model::order::{BuyTokenDestination, SellTokenSource},
     num::CheckedDiv,
 };
@@ -47,14 +48,8 @@ pub struct Order {
 }
 
 /// An amount denominated in the sell token of an [`Order`].
-#[derive(Clone, Copy, Debug, Default, Eq, Ord, PartialEq, PartialOrd)]
+#[derive(Clone, Copy, Debug, Default, Eq, Ord, PartialEq, PartialOrd, From, Into)]
 pub struct SellAmount(pub eth::U256);
-
-impl From<eth::U256> for SellAmount {
-    fn from(value: eth::U256) -> Self {
-        Self(value)
-    }
-}
 
 impl From<eth::TokenAmount> for SellAmount {
     fn from(value: eth::TokenAmount) -> Self {
@@ -62,28 +57,10 @@ impl From<eth::TokenAmount> for SellAmount {
     }
 }
 
-impl From<SellAmount> for eth::U256 {
-    fn from(sell_amount: SellAmount) -> Self {
-        sell_amount.0
-    }
-}
-
 /// An amount denominated in the sell token for [`Side::Sell`] [`Order`]s, or in
 /// the buy token for [`Side::Buy`] [`Order`]s.
-#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, From, Into)]
 pub struct TargetAmount(pub eth::U256);
-
-impl From<eth::U256> for TargetAmount {
-    fn from(value: eth::U256) -> Self {
-        Self(value)
-    }
-}
-
-impl From<TargetAmount> for eth::U256 {
-    fn from(value: TargetAmount) -> Self {
-        value.0
-    }
-}
 
 impl From<eth::TokenAmount> for TargetAmount {
     fn from(value: eth::TokenAmount) -> Self {
@@ -370,14 +347,8 @@ impl From<BuyTokenBalance> for BuyTokenDestination {
 }
 
 /// The address which placed the order.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Into)]
 pub struct Trader(eth::Address);
-
-impl From<Trader> for eth::Address {
-    fn from(value: Trader) -> Self {
-        value.0
-    }
-}
 
 /// A just-in-time order. JIT orders are added at solving time by the solver to
 /// generate a more optimal solution for the auction. Very similar to a regular

--- a/crates/driver/src/domain/eth/allowance.rs
+++ b/crates/driver/src/domain/eth/allowance.rs
@@ -1,4 +1,7 @@
-use super::{Address, TokenAddress, U256};
+use {
+    super::{Address, TokenAddress, U256},
+    derive_more::{From, Into},
+};
 
 /// An ERC20 allowance.
 ///
@@ -15,24 +18,12 @@ pub struct Allowance {
 
 /// An allowance that's already in effect, this essentially models the result of
 /// the allowance() method, see https://eips.ethereum.org/EIPS/eip-20#methods.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, Into, From)]
 pub struct Existing(pub Allowance);
 
-impl From<Allowance> for Existing {
-    fn from(inner: Allowance) -> Self {
-        Self(inner)
-    }
-}
-
 /// An allowance that is required for some action.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Into, From)]
 pub struct Required(pub Allowance);
-
-impl From<Allowance> for Required {
-    fn from(inner: Allowance) -> Self {
-        Self(inner)
-    }
-}
 
 impl Required {
     /// Check if this allowance needs to be approved, and if so, return the

--- a/crates/driver/src/domain/eth/gas.rs
+++ b/crates/driver/src/domain/eth/gas.rs
@@ -1,7 +1,7 @@
 use {
     super::{Ether, U256},
     bigdecimal::Zero,
-    derive_more::Display,
+    derive_more::{Display, From, Into},
     std::{ops, ops::Add},
 };
 
@@ -9,24 +9,12 @@ use {
 ///
 /// The amount of Ether that is paid in transaction fees is proportional to this
 /// amount as well as the transaction's [`EffectiveGasPrice`].
-#[derive(Debug, Default, Display, Clone, Copy, Ord, Eq, PartialOrd, PartialEq)]
+#[derive(Debug, Default, Display, Clone, Copy, Ord, Eq, PartialOrd, PartialEq, From, Into)]
 pub struct Gas(pub U256);
-
-impl From<U256> for Gas {
-    fn from(value: U256) -> Self {
-        Self(value)
-    }
-}
 
 impl From<u64> for Gas {
     fn from(value: u64) -> Self {
         Self(value.into())
-    }
-}
-
-impl From<Gas> for U256 {
-    fn from(value: Gas) -> Self {
-        value.0
     }
 }
 

--- a/crates/driver/src/domain/eth/mod.rs
+++ b/crates/driver/src/domain/eth/mod.rs
@@ -1,5 +1,6 @@
 use {
     crate::util::Bytes,
+    derive_more::{From, Into},
     itertools::Itertools,
     std::{
         collections::{HashMap, HashSet},
@@ -31,7 +32,7 @@ pub const ETH_TOKEN: TokenAddress = TokenAddress(ContractAddress(H160([0xee; 20]
 /// Chain ID as defined by EIP-155.
 ///
 /// https://eips.ethereum.org/EIPS/eip-155
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Into)]
 pub struct ChainId(pub u64);
 
 impl std::fmt::Display for ChainId {
@@ -43,12 +44,6 @@ impl std::fmt::Display for ChainId {
 impl From<U256> for ChainId {
     fn from(value: U256) -> Self {
         Self(value.as_u64())
-    }
-}
-
-impl From<ChainId> for u64 {
-    fn from(value: ChainId) -> Self {
-        value.0
     }
 }
 
@@ -108,48 +103,18 @@ impl From<AccessList> for web3::types::AccessList {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Into, From)]
 struct StorageKey(pub H256);
 
-impl From<H256> for StorageKey {
-    fn from(value: H256) -> Self {
-        Self(value)
-    }
-}
-
 /// An address. Can be an EOA or a smart contract address.
-#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, From, Into)]
 pub struct Address(pub H160);
-
-impl From<H160> for Address {
-    fn from(value: H160) -> Self {
-        Self(value)
-    }
-}
-
-impl From<Address> for H160 {
-    fn from(value: Address) -> Self {
-        value.0
-    }
-}
 
 // TODO This type should probably use Ethereum::is_contract to verify during
 // construction that it does indeed point to a contract
 /// A smart contract address.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Into, From)]
 pub struct ContractAddress(pub H160);
-
-impl From<H160> for ContractAddress {
-    fn from(value: H160) -> Self {
-        Self(value)
-    }
-}
-
-impl From<ContractAddress> for H160 {
-    fn from(value: ContractAddress) -> Self {
-        value.0
-    }
-}
 
 impl From<ContractAddress> for Address {
     fn from(value: ContractAddress) -> Self {
@@ -177,7 +142,7 @@ impl TokenAddress {
 /// An ERC20 token amount.
 ///
 /// https://eips.ethereum.org/EIPS/eip-20
-#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, From, Into)]
 pub struct TokenAmount(pub U256);
 
 impl TokenAmount {
@@ -248,18 +213,6 @@ impl num::CheckedDiv for TokenAmount {
     }
 }
 
-impl From<U256> for TokenAmount {
-    fn from(value: U256) -> Self {
-        Self(value)
-    }
-}
-
-impl From<TokenAmount> for U256 {
-    fn from(value: TokenAmount) -> Self {
-        value.0
-    }
-}
-
 impl From<u128> for TokenAmount {
     fn from(value: u128) -> Self {
         Self(value.into())
@@ -297,14 +250,8 @@ impl std::fmt::Display for TokenAmount {
 }
 
 /// The address of the WETH contract.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, From, Into)]
 pub struct WethAddress(pub TokenAddress);
-
-impl From<WethAddress> for TokenAddress {
-    fn from(value: WethAddress) -> Self {
-        value.0
-    }
-}
 
 impl From<H160> for WethAddress {
     fn from(value: H160) -> Self {
@@ -339,26 +286,14 @@ pub struct Asset {
 }
 
 /// An amount of native Ether tokens denominated in wei.
-#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
+#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd, From, Into)]
 pub struct Ether(pub U256);
-
-impl From<U256> for Ether {
-    fn from(value: U256) -> Self {
-        Self(value)
-    }
-}
 
 impl From<Ether> for num::BigInt {
     fn from(value: Ether) -> Self {
         let mut bytes = [0; 32];
         value.0.to_big_endian(&mut bytes);
         num::BigUint::from_bytes_be(&bytes).into()
-    }
-}
-
-impl From<Ether> for U256 {
-    fn from(value: Ether) -> Self {
-        value.0
     }
 }
 
@@ -393,14 +328,8 @@ impl std::iter::Sum for Ether {
 }
 
 /// Block number.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, From, Into)]
 pub struct BlockNo(pub u64);
-
-impl From<u64> for BlockNo {
-    fn from(value: u64) -> Self {
-        Self(value)
-    }
-}
 
 /// An onchain transaction which interacts with a smart contract.
 #[derive(Debug, Clone, Eq, PartialEq)]
@@ -422,14 +351,8 @@ impl Into<model::interaction::InteractionData> for Interaction {
 }
 
 /// A transaction ID, AKA transaction hash.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, From, Into)]
 pub struct TxId(pub H256);
-
-impl From<H256> for TxId {
-    fn from(value: H256) -> Self {
-        Self(value)
-    }
-}
 
 pub enum TxStatus {
     /// The transaction has been included and executed successfully.

--- a/crates/driver/src/domain/liquidity/balancer/v2/mod.rs
+++ b/crates/driver/src/domain/liquidity/balancer/v2/mod.rs
@@ -1,4 +1,7 @@
-use crate::domain::eth;
+use {
+    crate::domain::eth,
+    derive_more::{From, Into},
+};
 
 pub mod stable;
 pub mod weighted;
@@ -9,25 +12,13 @@ pub mod weighted;
 /// * 0..20: the address of the pool
 /// * 20..22: the pool specialization
 /// * 22..32: the pool nonce
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, From, Into)]
 pub struct Id(pub eth::H256);
 
 impl Id {
     /// Extracts the pool address configured in the ID.
     pub fn address(&self) -> eth::ContractAddress {
         eth::H160::from_slice(&self.0[..20]).into()
-    }
-}
-
-impl From<eth::H256> for Id {
-    fn from(value: eth::H256) -> Self {
-        Self(value)
-    }
-}
-
-impl From<Id> for eth::H256 {
-    fn from(value: Id) -> Self {
-        value.0
     }
 }
 

--- a/crates/driver/src/domain/liquidity/mod.rs
+++ b/crates/driver/src/domain/liquidity/mod.rs
@@ -1,7 +1,11 @@
 // TODO Remove dead_code
 #![allow(dead_code)]
 
-use {crate::domain::eth, std::cmp::Ordering};
+use {
+    crate::domain::eth,
+    derive_more::{From, Into},
+    std::cmp::Ordering,
+};
 
 pub mod balancer;
 pub mod swapr;
@@ -17,20 +21,8 @@ pub struct Liquidity {
     pub kind: Kind,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, From, Into)]
 pub struct Id(pub usize);
-
-impl From<usize> for Id {
-    fn from(value: usize) -> Self {
-        Self(value)
-    }
-}
-
-impl From<Id> for usize {
-    fn from(value: Id) -> Self {
-        value.0
-    }
-}
 
 impl PartialEq<usize> for Id {
     fn eq(&self, other: &usize) -> bool {

--- a/crates/driver/src/infra/solver/mod.rs
+++ b/crates/driver/src/infra/solver/mod.rs
@@ -18,6 +18,7 @@ use {
         util,
     },
     anyhow::Result,
+    derive_more::{From, Into},
     num::BigRational,
     reqwest::header::HeaderName,
     std::collections::HashMap,
@@ -35,18 +36,12 @@ const SOLVER_RESPONSE_MAX_BYTES: usize = 10_000_000;
 /// The solver name. The user can configure this to be anything that they like.
 /// The name uniquely identifies each solver in case there's more than one of
 /// them.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, From, Into)]
 pub struct Name(pub String);
 
 impl Name {
     pub fn as_str(&self) -> &str {
         &self.0
-    }
-}
-
-impl From<String> for Name {
-    fn from(inner: String) -> Self {
-        Self(inner)
     }
 }
 

--- a/crates/driver/src/util/time.rs
+++ b/crates/driver/src/util/time.rs
@@ -1,20 +1,10 @@
+use derive_more::{From, Into};
+
 /// A Unix timestamp denominated in seconds since epoch.
 ///
 /// https://en.wikipedia.org/wiki/Unix_time
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, From, Into)]
 pub struct Timestamp(pub u32);
-
-impl From<u32> for Timestamp {
-    fn from(inner: u32) -> Self {
-        Self(inner)
-    }
-}
-
-impl From<Timestamp> for u32 {
-    fn from(timestamp: Timestamp) -> Self {
-        timestamp.0
-    }
-}
 
 impl Timestamp {
     pub const MAX: Self = Self(u32::MAX);


### PR DESCRIPTION
# Description
Proposal: Remove all the unnecessary `From/Into` implementations which can be easily derived with `derive_more` crate (already part of the dependencies).