### PR TITLE
Store the auction with liquidity as a JSON and not as a string

### DIFF
--- a/crates/driver/src/infra/solver/mod.rs
+++ b/crates/driver/src/infra/solver/mod.rs
@@ -216,19 +216,19 @@ impl Solver {
     ) -> Result<Vec<Solution>, Error> {
         // Fetch the solutions from the solver.
         let weth = self.eth.contracts().weth_address();
-        let body = serde_json::to_string(&dto::Auction::new(
+        let auction_dto = dto::Auction::new(
             auction,
             liquidity,
             weth,
             self.config.fee_handler,
             self.config.solver_native_token,
-        ))
-        .unwrap();
+        );
         // Only auctions with IDs are real auctions (/quote requests don't have an ID,
         // and it makes no sense to store them)
         if let Some(id) = auction.id() {
-            self.persistence.archive_auction(id, &body);
+            self.persistence.archive_auction(id, &auction_dto);
         };
+        let body = serde_json::to_string(&auction_dto).unwrap();
         let url = shared::url::join(&self.config.endpoint, "solve");
         super::observe::solver_request(&url, &body);
         let mut req = self


### PR DESCRIPTION
# Description
After checking the changes in staging, @fhenneke requested for the data to be stored as a JSON and not as a serialized string.