### PR TITLE
[ON HOLD] Reject solution containing outside-of-auction order

### DIFF
--- a/crates/autopilot/src/domain/settlement/mod.rs
+++ b/crates/autopilot/src/domain/settlement/mod.rs
@@ -32,6 +32,10 @@ impl Settlement {
     /// id.
     const META_DATA_LEN: usize = 8;
 
+    pub fn order_uids(&self) -> impl Iterator<Item = &order::OrderUid> {
+        self.trades.iter().map(|trade| trade.order_uid())
+    }
+
     pub fn native_surplus(&self, prices: &auction::Prices) -> Result<eth::Ether, trade::Error> {
         self.trades
             .iter()

--- a/crates/autopilot/src/domain/settlement/trade.rs
+++ b/crates/autopilot/src/domain/settlement/trade.rs
@@ -43,6 +43,10 @@ impl Trade {
         }
     }
 
+    pub fn order_uid(&self) -> &domain::OrderUid {
+        &self.order_uid
+    }
+
     /// CIP38 score defined as surplus + protocol fee
     ///
     /// Denominated in NATIVE token

--- a/crates/autopilot/src/infra/persistence/mod.rs
+++ b/crates/autopilot/src/infra/persistence/mod.rs
@@ -169,8 +169,8 @@ impl Persistence {
         Ok(prices)
     }
 
-    /// Returns true if all given orders do not exist in the database.
-    pub async fn all_orders_not_exist(
+    /// Returns true if none of the given orders exist in the database.
+    pub async fn orders_do_not_exist(
         &self,
         order_uids: &[domain::OrderUid],
     ) -> Result<bool, Error> {
@@ -182,7 +182,7 @@ impl Persistence {
             .context("begin")
             .map_err(Error::DbError)?;
 
-        let order_exist = database::orders::all_orders_not_exist(
+        let order_exist = database::orders::orders_do_not_exist(
             &mut ex,
             order_uids
                 .iter()

--- a/crates/autopilot/src/infra/persistence/mod.rs
+++ b/crates/autopilot/src/infra/persistence/mod.rs
@@ -6,6 +6,7 @@ use {
     },
     anyhow::Context,
     chrono::Utc,
+    database::byte_array::ByteArray,
     number::conversions::big_decimal_to_u256,
     primitive_types::H256,
     std::{collections::HashMap, sync::Arc},
@@ -166,6 +167,34 @@ impl Persistence {
         }
 
         Ok(prices)
+    }
+
+    /// Returns true if all given orders do not exist in the database.
+    pub async fn all_orders_not_exist(
+        &self,
+        order_uids: &[domain::OrderUid],
+    ) -> Result<bool, Error> {
+        let mut ex = self
+            .postgres
+            .pool
+            .begin()
+            .await
+            .context("begin")
+            .map_err(Error::DbError)?;
+
+        let order_exist = database::orders::all_orders_not_exist(
+            &mut ex,
+            order_uids
+                .iter()
+                .map(|uid| ByteArray(uid.0))
+                .collect::<Vec<_>>()
+                .as_slice(),
+        )
+        .await
+        .context("fetch")
+        .map_err(Error::DbError)?;
+
+        Ok(order_exist)
     }
 }
 

--- a/crates/autopilot/src/run_loop.rs
+++ b/crates/autopilot/src/run_loop.rs
@@ -372,11 +372,7 @@ impl RunLoop {
         auction: &domain::Auction,
         settlement: &Settlement,
     ) -> bool {
-        let auction_orders = auction
-            .orders
-            .iter()
-            .map(|o| OrderUid(o.uid.0))
-            .collect::<HashSet<_>>();
+        let auction_orders = auction.orders.iter().map(|o| o.uid).collect::<HashSet<_>>();
 
         // all JIT orders will be non_auction_orders
         let non_auction_orders = settlement

--- a/crates/autopilot/src/run_loop.rs
+++ b/crates/autopilot/src/run_loop.rs
@@ -383,7 +383,7 @@ impl RunLoop {
 
         // make sure all non-auction orders are also non-database
         self.persistence
-            .all_orders_not_exist(&non_auction_orders)
+            .orders_do_not_exist(&non_auction_orders)
             .await
             .unwrap_or_else(|err| {
                 tracing::warn!(?err, "failed to check if all orders exist");

--- a/crates/database/src/orders.rs
+++ b/crates/database/src/orders.rs
@@ -755,7 +755,7 @@ pub async fn user_orders_with_quote(
         .await
 }
 
-pub async fn all_orders_not_exist(
+pub async fn orders_do_not_exist(
     ex: &mut PgConnection,
     uids: &[OrderUid],
 ) -> Result<bool, sqlx::Error> {
@@ -1929,12 +1929,19 @@ mod tests {
             ..Default::default()
         };
 
-        assert!(all_orders_not_exist(&mut db, &[order1.uid, order2.uid])
+        assert!(orders_do_not_exist(&mut db, &[order1.uid, order2.uid])
             .await
             .unwrap());
 
         insert_order(&mut db, &order2).await.unwrap();
-        assert!(!all_orders_not_exist(&mut db, &[order1.uid, order2.uid])
+
+        assert!(orders_do_not_exist(&mut db, &[order1.uid])
+            .await
+            .unwrap());
+        assert!(!orders_do_not_exist(&mut db, &[order2.uid])
+            .await
+            .unwrap());
+        assert!(!orders_do_not_exist(&mut db, &[order1.uid, order2.uid])
             .await
             .unwrap());
     }

--- a/crates/database/src/orders.rs
+++ b/crates/database/src/orders.rs
@@ -1935,12 +1935,8 @@ mod tests {
 
         insert_order(&mut db, &order2).await.unwrap();
 
-        assert!(orders_do_not_exist(&mut db, &[order1.uid])
-            .await
-            .unwrap());
-        assert!(!orders_do_not_exist(&mut db, &[order2.uid])
-            .await
-            .unwrap());
+        assert!(orders_do_not_exist(&mut db, &[order1.uid]).await.unwrap());
+        assert!(!orders_do_not_exist(&mut db, &[order2.uid]).await.unwrap());
         assert!(!orders_do_not_exist(&mut db, &[order1.uid, order2.uid])
             .await
             .unwrap());


### PR DESCRIPTION
ON HOLD since I want to get back to this once I work more on fetching the offchain data from db that will be used in `OnSettlementEventUpdater`. I already see that I will need a different variation of the `orders_do_not_exist` functionality for that as well.

# Description
Implements first part of the https://github.com/cowprotocol/services/issues/2667#issuecomment-2102239321

Rejects the winning solution if it contains an order that is not part of the auction. Since JIT orders do not satisfy this condition, we also need to make sure that those that are not in the auction, are also not in the database.

## How to test
e2e tests