### PR TITLE
Don't set maxAllowance for solver provided liquidity

### DIFF
--- a/crates/driver/src/domain/competition/solution/interaction.rs
+++ b/crates/driver/src/domain/competition/solution/interaction.rs
@@ -53,10 +53,15 @@ impl Interaction {
                     liquidity::Kind::Swapr(pool) => pool.base.router.into(),
                     liquidity::Kind::ZeroEx(pool) => pool.zeroex.address().into(),
                 };
+                // As a gas optimization, we always approve the max amount possible. This
+                // minimizes the number of approvals necessary, and therefore
+                // minimizes the approval fees over time. This is a
+                // potential security issue, but we assume that the router contract for protocol
+                // indexed liquidity to be safe.
                 vec![eth::Allowance {
                     token: interaction.input.token,
                     spender: address,
-                    amount: interaction.input.amount.into(),
+                    amount: eth::U256::max_value(),
                 }
                 .into()]
             }

--- a/crates/driver/src/domain/competition/solution/mod.rs
+++ b/crates/driver/src/domain/competition/solution/mod.rs
@@ -180,15 +180,9 @@ impl Solution {
                     .map(|existing| (required, existing))
             }))
             .await?;
-        let approvals = allowances.into_iter().filter_map(|(required, existing)| {
-            required
-                .approval(&existing)
-                // As a gas optimization, we always approve the max amount possible. This minimizes
-                // the number of approvals necessary, and therefore minimizes the approval fees over time. This is a
-                // potential security issue, but its effects are minimized and only exploitable if
-                // solvers use insecure contracts.
-                .map(eth::allowance::Approval::max)
-        });
+        let approvals = allowances
+            .into_iter()
+            .filter_map(|(required, existing)| required.approval(&existing));
         Ok(approvals)
     }
 


### PR DESCRIPTION
# Description
We currently override solver specified approval amounts with `U256::max`. This has caused issues in the past when a malicious allowance lead to the draining of the internal buffers and a debate around whether the driver or the solver is at fault arose (ie. if the protocol doesn't override the solver specified allowance the remaining amount to withdraw from buffers might be minimal).

# Changes
- [x] Don't override allowance amounts in the solution
- [x] However specify max amounts when encoding baseline liquidity into an interaction

This keeps the status quo, but only for protocol indexed liquidity (which we keep very minimal and can audit) while leaving it up to solvers to audit other liquidity sources.

## How to test
CI