### PR TITLE
[EASY] Instrument currentblockstream web3 instance again

### DIFF
--- a/crates/ethrpc/src/current_block/mod.rs
+++ b/crates/ethrpc/src/current_block/mod.rs
@@ -1,5 +1,5 @@
 use {
-    crate::{http::HttpTransport, Web3, Web3Transport},
+    crate::{http::HttpTransport, instrumented::instrument_with_label, Web3, Web3Transport},
     anyhow::{anyhow, ensure, Context as _, Result},
     futures::StreamExt,
     primitive_types::{H256, U256},
@@ -90,6 +90,7 @@ pub async fn current_block_stream(url: Url, poll_interval: Duration) -> Result<C
         url,
         "block_stream".into(),
     )));
+    let web3 = instrument_with_label(&web3, "base_currentBlockStream".into());
     let first_block = web3.current_block().await?;
     tracing::debug!(number=%first_block.number, hash=?first_block.hash, "polled block");
 


### PR DESCRIPTION
# Description
When building a fresh unbuffered web3 transport for the current block stream in #2707 I forgot to instrument it which means we can no longer see how many requests originate from that component.

# Changes
Instruments the block stream instance again (now even with a custom component label)

## How to test
Ran locally and checked the generated metrics:
```
curl http://localhost:9586/metrics | rg currentBlockStream                                                          ─╯
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 24985  100 24985    0     0  6557k      0 --:--:-- --:--:-- --:--:-- 8133k
gp_v2_api_rpc_requests_complete{component="base_currentBlockStream",method="eth_getBlockByNumber"} 4
gp_v2_api_rpc_requests_duration_seconds_bucket{component="base_currentBlockStream",method="eth_getBlockByNumber",le="0.005"} 0
gp_v2_api_rpc_requests_duration_seconds_bucket{component="base_currentBlockStream",method="eth_getBlockByNumber",le="0.01"} 0
gp_v2_api_rpc_requests_duration_seconds_bucket{component="base_currentBlockStream",method="eth_getBlockByNumber",le="0.025"} 0
gp_v2_api_rpc_requests_duration_seconds_bucket{component="base_currentBlockStream",method="eth_getBlockByNumber",le="0.05"} 3
gp_v2_api_rpc_requests_duration_seconds_bucket{component="base_currentBlockStream",method="eth_getBlockByNumber",le="0.1"} 3
gp_v2_api_rpc_requests_duration_seconds_bucket{component="base_currentBlockStream",method="eth_getBlockByNumber",le="0.25"} 4
gp_v2_api_rpc_requests_duration_seconds_bucket{component="base_currentBlockStream",method="eth_getBlockByNumber",le="0.5"} 4
gp_v2_api_rpc_requests_duration_seconds_bucket{component="base_currentBlockStream",method="eth_getBlockByNumber",le="1"} 4
gp_v2_api_rpc_requests_duration_seconds_bucket{component="base_currentBlockStream",method="eth_getBlockByNumber",le="2.5"} 4
gp_v2_api_rpc_requests_duration_seconds_bucket{component="base_currentBlockStream",method="eth_getBlockByNumber",le="5"} 4
gp_v2_api_rpc_requests_duration_seconds_bucket{component="base_currentBlockStream",method="eth_getBlockByNumber",le="10"} 4
gp_v2_api_rpc_requests_duration_seconds_bucket{component="base_currentBlockStream",method="eth_getBlockByNumber",le="+Inf"} 4
gp_v2_api_rpc_requests_duration_seconds_sum{component="base_currentBlockStream",method="eth_getBlockByNumber"} 0.239647374
gp_v2_api_rpc_requests_duration_seconds_count{component="base_currentBlockStream",method="eth_getBlockByNumber"} 4
gp_v2_api_rpc_requests_inflight{component="base_currentBlockStream",method="eth_getBlockByNumber"} 0
```