### PR TITLE
Gas estimator driver config

### DIFF
--- a/crates/driver/src/infra/blockchain/gas.rs
+++ b/crates/driver/src/infra/blockchain/gas.rs
@@ -4,11 +4,12 @@
 /// private submission networks are used.
 use {
     super::Error,
+    crate::infra::config::file::GasEstimatorType,
     crate::{domain::eth, infra::mempool},
     ethcontract::dyns::DynWeb3,
     gas_estimation::{nativegasestimator::NativeGasEstimator, GasPriceEstimating},
+    std::sync::Arc,
 };
-use {crate::infra::config::file::GasEstimatorType, std::sync::Arc};
 
 type MaxAdditionalTip = eth::U256;
 type AdditionalTipPercentage = f64;

--- a/crates/driver/src/infra/config/file/load.rs
+++ b/crates/driver/src/infra/config/file/load.rs
@@ -321,5 +321,6 @@ pub async fn load(chain: eth::ChainId, path: &Path) -> infra::Config {
         disable_access_list_simulation: config.disable_access_list_simulation,
         disable_gas_simulation: config.disable_gas_simulation.map(Into::into),
         encoding: config.encoding,
+        gas_estimator: config.gas_estimator,
     }
 }

--- a/crates/driver/src/infra/config/file/mod.rs
+++ b/crates/driver/src/infra/config/file/mod.rs
@@ -31,6 +31,10 @@ struct Config {
     #[serde_as(as = "Option<serialize::U256>")]
     disable_gas_simulation: Option<eth::U256>,
 
+    /// Defines the gas estimator to use.
+    #[serde(default)]
+    gas_estimator: GasEstimatorType,
+
     /// Parameters related to settlement submission.
     #[serde(default)]
     submission: SubmissionConfig,
@@ -581,4 +585,12 @@ fn default_zeroex_base_url() -> String {
 
 fn default_http_timeout() -> Duration {
     Duration::from_secs(10)
+}
+
+#[derive(Clone, Debug, Deserialize, Default)]
+#[serde(untagged, deny_unknown_fields)]
+pub enum GasEstimatorType {
+    #[default]
+    Native,
+    Web3,
 }

--- a/crates/driver/src/infra/config/mod.rs
+++ b/crates/driver/src/infra/config/mod.rs
@@ -6,6 +6,8 @@ use crate::{
 pub mod file;
 pub use file::encoding;
 
+use crate::infra::config::file::GasEstimatorType;
+
 /// Configuration of infrastructural components.
 #[derive(Debug)]
 pub struct Config {
@@ -14,6 +16,7 @@ pub struct Config {
     pub solvers: Vec<solver::Config>,
     pub liquidity: liquidity::Config,
     pub simulator: Option<simulator::Config>,
+    pub gas_estimator: GasEstimatorType,
     pub mempools: Vec<mempool::Config>,
     pub contracts: blockchain::contracts::Addresses,
     pub encoding: encoding::Strategy,

--- a/crates/driver/src/infra/config/mod.rs
+++ b/crates/driver/src/infra/config/mod.rs
@@ -1,12 +1,11 @@
+pub use file::encoding;
+
 use crate::{
     domain::eth,
-    infra::{blockchain, liquidity, mempool, simulator, solver},
+    infra::{blockchain, config::file::GasEstimatorType, liquidity, mempool, simulator, solver},
 };
 
 pub mod file;
-pub use file::encoding;
-
-use crate::infra::config::file::GasEstimatorType;
 
 /// Configuration of infrastructural components.
 #[derive(Debug)]

--- a/crates/driver/src/run.rs
+++ b/crates/driver/src/run.rs
@@ -129,7 +129,7 @@ async fn ethrpc(args: &cli::Args) -> blockchain::Rpc {
 
 async fn ethereum(config: &infra::Config, ethrpc: blockchain::Rpc) -> Ethereum {
     let gas = Arc::new(
-        blockchain::GasPriceEstimator::new(ethrpc.web3(), &config.mempools)
+        blockchain::GasPriceEstimator::new(ethrpc.web3(), &config.gas_estimator, &config.mempools)
             .await
             .expect("initialize gas price estimator"),
     );

--- a/crates/driver/src/tests/setup/solver.rs
+++ b/crates/driver/src/tests/setup/solver.rs
@@ -286,6 +286,7 @@ impl Solver {
         let gas = Arc::new(
             infra::blockchain::GasPriceEstimator::new(
                 rpc.web3(),
+                &Default::default(),
                 &[infra::mempool::Config {
                     min_priority_fee: Default::default(),
                     gas_price_cap: eth::U256::MAX,


### PR DESCRIPTION
### Background

In the process of adapting for Arbitrum compatibility, we encountered issues with gas price estimation. The default gas price estimator in our driver provided values significantly higher than what the RPC endpoint returns, resulting in orders being created with insufficient fees. This discrepancy led to solvers being unable to find profitable solutions due to excessively high gas prices.

The gas price estimator in the driver is currently hardcoded, while the autopilot/orderbook allows for flexible selection of the gas price estimator. This inconsistency has caused orders to be created with a low fee while solvers receive instructions based on a much higher gas price, preventing them from finding viable solutions.

### Changes

This change will allow us to use a Web3-based estimator, which provides more accurate gas prices for Arbitrum. 