### PR TITLE
Support never missing a block using the `CurrentBlockStream`

### DIFF
--- a/crates/autopilot/src/infra/blockchain/mod.rs
+++ b/crates/autopilot/src/infra/blockchain/mod.rs
@@ -86,7 +86,7 @@ impl Ethereum {
         let contracts = Contracts::new(&web3, &chain, addresses).await;
 
         Self {
-            current_block: ethrpc::current_block::current_block_stream(url, poll_interval)
+            current_block: CurrentBlockStream::new(url, poll_interval)
                 .await
                 .expect("couldn't initialize current block stream"),
             web3,

--- a/crates/autopilot/src/run_loop.rs
+++ b/crates/autopilot/src/run_loop.rs
@@ -61,7 +61,7 @@ impl RunLoop {
         let mut last_block = None;
         loop {
             if let Some(domain::AuctionWithId { id, auction }) = self.next_auction().await {
-                let current_block = self.eth.current_block().borrow().hash;
+                let current_block = self.eth.current_block().current().hash;
                 // Only run the solvers if the auction or block has changed.
                 let previous = last_auction.replace(auction.clone());
                 if previous.as_ref() != Some(&auction)
@@ -130,7 +130,7 @@ impl RunLoop {
             solutions.sort_unstable_by_key(|participant| participant.solution.score().get().0);
             solutions
         };
-        let competition_simulation_block = self.eth.current_block().borrow().number;
+        let competition_simulation_block = self.eth.current_block().current().number;
 
         // TODO: Keep going with other solutions until some deadline.
         if let Some(Participant { driver, solution }) = solutions.last() {
@@ -457,11 +457,11 @@ impl RunLoop {
         auction_id: i64,
         max_blocks_wait: u64,
     ) -> Result<H256, SettleError> {
-        let current = self.eth.current_block().borrow().number;
+        let current = self.eth.current_block().current().number;
         let deadline = current.saturating_add(max_blocks_wait);
         tracing::debug!(%current, %deadline, %auction_id, "waiting for tag");
         loop {
-            if self.eth.current_block().borrow().number > deadline {
+            if self.eth.current_block().current().number > deadline {
                 break;
             }
 

--- a/crates/autopilot/src/solvable_orders.rs
+++ b/crates/autopilot/src/solvable_orders.rs
@@ -425,7 +425,7 @@ async fn update_task(
                 break;
             }
         };
-        let block = current_block.borrow().number;
+        let block = current_block.current().number;
         match cache.update(block).await {
             Ok(()) => {
                 cache.track_auction_update("success");

--- a/crates/driver/src/boundary/liquidity/mod.rs
+++ b/crates/driver/src/boundary/liquidity/mod.rs
@@ -148,7 +148,7 @@ impl Fetcher {
         let block = match block {
             infra::liquidity::AtBlock::Recent => recent_block_cache::Block::Recent,
             infra::liquidity::AtBlock::Latest => {
-                let block_number = self.blocks.borrow().number;
+                let block_number = self.blocks.current().number;
                 recent_block_cache::Block::Number(block_number)
             }
         };

--- a/crates/driver/src/domain/competition/mod.rs
+++ b/crates/driver/src/domain/competition/mod.rs
@@ -226,8 +226,7 @@ impl Competition {
         if let Ok(remaining) = auction.deadline().driver().remaining() {
             let score_ref = &mut score;
             let simulate_on_new_blocks = async move {
-                let mut stream =
-                    ethrpc::current_block::into_stream(self.eth.current_block().clone());
+                let mut stream = self.eth.current_block().clone().watch_stream();
                 while let Some(block) = stream.next().await {
                     if let Err(infra::simulator::Error::Revert(err)) =
                         self.simulate_settlement(&settlement).await
@@ -326,7 +325,7 @@ impl Competition {
             return Err(infra::simulator::Error::Revert(RevertError {
                 err: SimulatorError::GasExceeded(gas_needed_for_tx, settlement.gas.limit),
                 tx: tx.clone(),
-                block: self.eth.current_block().borrow().number.into(),
+                block: self.eth.current_block().current().number.into(),
             }));
         }
         Ok(())

--- a/crates/driver/src/domain/mempools.rs
+++ b/crates/driver/src/domain/mempools.rs
@@ -7,7 +7,6 @@ use {
         domain::{competition::solution::Settlement, eth::TxStatus},
         infra::{self, observe, solver::Solver, Ethereum},
     },
-    ethrpc::current_block::into_stream,
     futures::{future::select_ok, FutureExt, StreamExt},
     thiserror::Error,
     tracing::Instrument,
@@ -95,7 +94,7 @@ impl Mempools {
         // Instantiate block stream and skip the current block before we submit the
         // settlement. This way we only run iterations in blocks that can potentially
         // include the settlement.
-        let mut block_stream = into_stream(self.ethereum.current_block().clone());
+        let mut block_stream = self.ethereum.current_block().clone().watch_stream();
         block_stream.next().await;
 
         let hash = mempool.submit(tx.clone(), settlement.gas, solver).await?;

--- a/crates/driver/src/infra/blockchain/mod.rs
+++ b/crates/driver/src/infra/blockchain/mod.rs
@@ -82,12 +82,9 @@ impl Ethereum {
 
         Self {
             inner: Arc::new(Inner {
-                current_block: ethrpc::current_block::current_block_stream(
-                    url,
-                    std::time::Duration::from_millis(500),
-                )
-                .await
-                .expect("couldn't initialize current block stream"),
+                current_block: CurrentBlockStream::new(url, std::time::Duration::from_millis(500))
+                    .await
+                    .expect("couldn't initialize current block stream"),
                 chain,
                 contracts,
                 gas,
@@ -193,7 +190,7 @@ impl Ethereum {
     }
 
     pub fn block_gas_limit(&self) -> eth::Gas {
-        self.inner.current_block.borrow().gas_limit.into()
+        self.inner.current_block.current().gas_limit.into()
     }
 
     /// Returns the current [`eth::Ether`] balance of the specified account.

--- a/crates/driver/src/infra/observe/mod.rs
+++ b/crates/driver/src/infra/observe/mod.rs
@@ -391,7 +391,7 @@ pub fn order_excluded_from_auction(
 
 /// Observe that a settlement was simulated
 pub fn simulated(eth: &Ethereum, tx: &eth::Tx, gas: &Result<Gas, simulator::Error>) {
-    let block: eth::BlockNo = eth.current_block().borrow().number.into();
+    let block: eth::BlockNo = eth.current_block().current().number.into();
     match gas {
         Ok(gas) => tracing::debug!(block = ?block, gas = ?gas.0, ?tx, "simulated settlement"),
         Err(err) => tracing::debug!(block = ?block, ?err, "simulated settlement"),

--- a/crates/driver/src/infra/simulator/enso/mod.rs
+++ b/crates/driver/src/infra/simulator/enso/mod.rs
@@ -41,7 +41,7 @@ impl Enso {
     }
 
     pub(super) async fn simulate(&self, tx: eth::Tx) -> Result<eth::Gas, Error> {
-        let current_block = *self.current_block.current();
+        let current_block = self.current_block.current();
 
         let (block_number, block_timestamp) = match self.network_block_interval {
             None => (None, None), // use default values which result in simulation on `latest`

--- a/crates/driver/src/infra/simulator/enso/mod.rs
+++ b/crates/driver/src/infra/simulator/enso/mod.rs
@@ -41,7 +41,7 @@ impl Enso {
     }
 
     pub(super) async fn simulate(&self, tx: eth::Tx) -> Result<eth::Gas, Error> {
-        let current_block = *self.current_block.borrow();
+        let current_block = *self.current_block.current();
 
         let (block_number, block_timestamp) = match self.network_block_interval {
             None => (None, None), // use default values which result in simulation on `latest`

--- a/crates/driver/src/infra/simulator/mod.rs
+++ b/crates/driver/src/infra/simulator/mod.rs
@@ -85,7 +85,7 @@ impl Simulator {
         if self.disable_access_lists {
             return Ok(tx.access_list.clone());
         }
-        let block = self.eth.current_block().borrow().number.into();
+        let block = self.eth.current_block().current().number.into();
         let access_list = match &self.inner {
             Inner::Tenderly(tenderly) => {
                 tenderly
@@ -113,7 +113,7 @@ impl Simulator {
         if let Some(gas) = self.disable_gas {
             return Ok(gas);
         }
-        let block = self.eth.current_block().borrow().number.into();
+        let block = self.eth.current_block().current().number.into();
         Ok(match &self.inner {
             Inner::Tenderly(tenderly) => {
                 tenderly

--- a/crates/driver/src/infra/tokens.rs
+++ b/crates/driver/src/infra/tokens.rs
@@ -4,7 +4,7 @@ use {
         infra::{blockchain, Ethereum},
     },
     anyhow::Result,
-    ethrpc::current_block::{self, CurrentBlockStream},
+    ethrpc::current_block::CurrentBlockStream,
     futures::{FutureExt, StreamExt},
     itertools::Itertools,
     model::order::BUY_ETH_ADDRESS,
@@ -57,7 +57,7 @@ impl Fetcher {
 /// Runs a single cache update cycle whenever a new block arrives until the
 /// fetcher is dropped.
 async fn update_task(blocks: CurrentBlockStream, inner: std::sync::Weak<Inner>) {
-    let mut stream = current_block::into_stream(blocks);
+    let mut stream = blocks.watch_stream();
     while stream.next().await.is_some() {
         let inner = match inner.upgrade() {
             Some(inner) => inner,

--- a/crates/e2e/tests/e2e/quote_verification.rs
+++ b/crates/e2e/tests/e2e/quote_verification.rs
@@ -39,10 +39,12 @@ async fn test_bypass_verification_for_rfq_quotes(web3: Web3) {
         .expect("FORK_URL_MAINNET must be set to run forked tests")
         .parse()
         .unwrap();
-    let block_stream =
-        ethrpc::current_block::current_block_stream(url, std::time::Duration::from_millis(1_000))
-            .await
-            .unwrap();
+    let block_stream = ethrpc::current_block::CurrentBlockStream::new(
+        url,
+        std::time::Duration::from_millis(1_000),
+    )
+    .await
+    .unwrap();
     let onchain = OnchainComponents::deployed(web3.clone()).await;
 
     let verifier = TradeVerifier::new(

--- a/crates/ethrpc/src/current_block/mod.rs
+++ b/crates/ethrpc/src/current_block/mod.rs
@@ -193,13 +193,6 @@ impl TryFrom<Block<H256>> for BlockInfo {
     }
 }
 
-/// A method for creating a block stream with an initial value that never
-/// observes any new blocks. This is useful for testing and creating "mock"
-/// components.
-pub fn mock_stream(block: BlockInfo) -> CurrentBlockStream {
-    CurrentBlockStream(Arc::new(BlockStreamInner::new(block)))
-}
-
 /// Trait for abstracting the retrieval of the block information such as the
 /// latest block number.
 #[async_trait::async_trait]

--- a/crates/ethrpc/src/current_block/mod.rs
+++ b/crates/ethrpc/src/current_block/mod.rs
@@ -52,10 +52,9 @@ impl BlockStreamInner {
 pub struct CurrentBlockStream(Arc<BlockStreamInner>);
 
 impl CurrentBlockStream {
-    /// Returns a reference to the current block. Keeping this reference
-    /// alive locks a mutex so it should be used as shortly as possible.
-    pub fn current(&self) -> watch::Ref<'_, BlockInfo> {
-        self.0.watch_receiver.borrow()
+    /// Returns the most recently seen block.
+    pub fn current(&self) -> BlockInfo {
+        *self.0.watch_receiver.borrow()
     }
 
     /// Returns a stream that always yields the most recent block (if unseen).

--- a/crates/ethrpc/src/current_block/mod.rs
+++ b/crates/ethrpc/src/current_block/mod.rs
@@ -70,8 +70,9 @@ impl CurrentBlockStream {
     /// This stream also yields blocks that got reorged so it's not guaranteed
     /// that the block number increases monotonically but at least it does not
     /// go back in time since reorgs never "take away" blocks.
-    /// 
-    /// Panics if it gets polled after having more than [`MAX_SIZE`] buffered blocks.
+    ///
+    /// Panics if it gets polled after having more than [`MAX_SIZE`] buffered
+    /// blocks.
     pub fn buffering_stream(&self) -> impl Stream<Item = BlockInfo> {
         let receiver = self.0.broadcast_sender.subscribe();
         BroadcastStream::new(receiver).map(Result::unwrap)

--- a/crates/shared/src/current_block.rs
+++ b/crates/shared/src/current_block.rs
@@ -4,7 +4,7 @@ use {
     anyhow::Result,
     clap::Parser,
     ethrpc::{
-        current_block::{current_block_stream, BlockRetrieving, CurrentBlockStream},
+        current_block::{BlockRetrieving, CurrentBlockStream},
         Web3,
     },
     std::{
@@ -36,7 +36,7 @@ impl Arguments {
     }
 
     pub async fn stream(&self, rpc: Url) -> Result<CurrentBlockStream> {
-        current_block_stream(rpc, self.block_stream_poll_interval).await
+        CurrentBlockStream::new(rpc, self.block_stream_poll_interval).await
     }
 }
 

--- a/crates/shared/src/maintenance.rs
+++ b/crates/shared/src/maintenance.rs
@@ -1,6 +1,6 @@
 use {
     anyhow::{ensure, Result},
-    ethrpc::current_block::{self, BlockInfo, CurrentBlockStream},
+    ethrpc::current_block::{BlockInfo, CurrentBlockStream},
     futures::{future::join_all, Stream, StreamExt as _},
     std::{sync::Arc, time::Duration},
     tokio::time,
@@ -124,7 +124,7 @@ impl ServiceMaintenance {
     }
 
     pub async fn run_maintenance_on_new_block(self, current_block_stream: CurrentBlockStream) -> ! {
-        self.run_maintenance_for_blocks(current_block::into_stream(current_block_stream))
+        self.run_maintenance_for_blocks(current_block_stream.buffering_stream())
             .instrument(tracing::info_span!("service_maintenance"))
             .await;
         panic!("block stream unexpectedly dropped");

--- a/crates/shared/src/maintenance.rs
+++ b/crates/shared/src/maintenance.rs
@@ -124,7 +124,7 @@ impl ServiceMaintenance {
     }
 
     pub async fn run_maintenance_on_new_block(self, current_block_stream: CurrentBlockStream) -> ! {
-        self.run_maintenance_for_blocks(current_block_stream.buffering_stream())
+        self.run_maintenance_for_blocks(current_block_stream.watch_stream())
             .instrument(tracing::info_span!("service_maintenance"))
             .await;
         panic!("block stream unexpectedly dropped");

--- a/crates/shared/src/price_estimation/native/oneinch.rs
+++ b/crates/shared/src/price_estimation/native/oneinch.rs
@@ -2,7 +2,7 @@ use {
     super::{NativePrice, NativePriceEstimateResult, NativePriceEstimating},
     crate::{price_estimation::PriceEstimationError, token_info::TokenInfoFetching},
     anyhow::{anyhow, Context, Result},
-    ethrpc::current_block::{into_stream, CurrentBlockStream},
+    ethrpc::current_block::CurrentBlockStream,
     futures::{future::BoxFuture, FutureExt, StreamExt},
     num::ToPrimitive,
     number::{conversions::u256_to_big_rational, serialization::HexOrDecimalU256},
@@ -61,7 +61,7 @@ impl OneInch {
     ) {
         let prices = self.prices.clone();
         tokio::task::spawn(async move {
-            let mut block_stream = into_stream(current_block);
+            let mut block_stream = current_block.watch_stream();
             loop {
                 let current_prices = get_current_prices(
                     &client,

--- a/crates/shared/src/price_estimation/trade_verifier.rs
+++ b/crates/shared/src/price_estimation/trade_verifier.rs
@@ -134,7 +134,7 @@ impl TradeVerifier {
             )
             .tx;
 
-        let block = *self.block_stream.current();
+        let block = self.block_stream.current();
 
         let call = CallRequest {
             // Initiate tx as solver so gas doesn't get deducted from user's ETH.

--- a/crates/shared/src/price_estimation/trade_verifier.rs
+++ b/crates/shared/src/price_estimation/trade_verifier.rs
@@ -134,7 +134,7 @@ impl TradeVerifier {
             )
             .tx;
 
-        let block = *self.block_stream.borrow();
+        let block = *self.block_stream.current();
 
         let call = CallRequest {
             // Initiate tx as solver so gas doesn't get deducted from user's ETH.

--- a/crates/shared/src/recent_block_cache.rs
+++ b/crates/shared/src/recent_block_cache.rs
@@ -464,9 +464,10 @@ where
 mod tests {
     use {
         super::*,
-        ethrpc::current_block::{mock_stream, BlockInfo},
+        ethrpc::current_block::BlockInfo,
         futures::FutureExt,
         std::sync::Arc,
+        tokio::sync::watch,
     };
 
     #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
@@ -538,10 +539,13 @@ mod tests {
             TestValue::new(3, "c"),
         ]);
         let block_number = 10u64;
-        let block_stream = mock_stream(BlockInfo {
-            number: block_number,
-            ..Default::default()
-        });
+        let block_stream = CurrentBlockStream::test_impl(
+            watch::channel(BlockInfo {
+                number: block_number,
+                ..Default::default()
+            })
+            .1,
+        );
         let cache = RecentBlockCache::new(
             CacheConfig {
                 number_of_entries_to_auto_update: NonZeroUsize::new(1).unwrap(),
@@ -595,10 +599,13 @@ mod tests {
         let fetcher = FakeCacheFetcher::default();
         let values = fetcher.0.clone();
         let block_number = 10u64;
-        let block_stream = mock_stream(BlockInfo {
-            number: block_number,
-            ..Default::default()
-        });
+        let block_stream = CurrentBlockStream::test_impl(
+            watch::channel(BlockInfo {
+                number: block_number,
+                ..Default::default()
+            })
+            .1,
+        );
         let cache = RecentBlockCache::new(
             CacheConfig {
                 number_of_entries_to_auto_update: NonZeroUsize::new(4).unwrap(),
@@ -657,10 +664,13 @@ mod tests {
         let fetcher = FakeCacheFetcher::default();
         let values = fetcher.0.clone();
         let block_number = 10u64;
-        let block_stream = mock_stream(BlockInfo {
-            number: block_number,
-            ..Default::default()
-        });
+        let block_stream = CurrentBlockStream::test_impl(
+            watch::channel(BlockInfo {
+                number: block_number,
+                ..Default::default()
+            })
+            .1,
+        );
         let cache = RecentBlockCache::new(
             CacheConfig {
                 number_of_entries_to_auto_update: NonZeroUsize::new(2).unwrap(),
@@ -714,10 +724,13 @@ mod tests {
         let fetcher = FakeCacheFetcher::default();
         let values = fetcher.0.clone();
         let block_number = 10u64;
-        let block_stream = mock_stream(BlockInfo {
-            number: block_number,
-            ..Default::default()
-        });
+        let block_stream = CurrentBlockStream::test_impl(
+            watch::channel(BlockInfo {
+                number: block_number,
+                ..Default::default()
+            })
+            .1,
+        );
         let cache = RecentBlockCache::new(
             CacheConfig {
                 number_of_entries_to_auto_update: NonZeroUsize::new(2).unwrap(),
@@ -831,10 +844,13 @@ mod tests {
     async fn respects_max_age_limit_for_recent() {
         let fetcher = FakeCacheFetcher::default();
         let block_number = 10u64;
-        let block_stream = mock_stream(BlockInfo {
-            number: block_number,
-            ..Default::default()
-        });
+        let block_stream = CurrentBlockStream::test_impl(
+            watch::channel(BlockInfo {
+                number: block_number,
+                ..Default::default()
+            })
+            .1,
+        );
         let cache = RecentBlockCache::new(
             CacheConfig {
                 number_of_blocks_to_cache: NonZeroU64::new(5).unwrap(),

--- a/crates/shared/src/trade_finding/external.rs
+++ b/crates/shared/src/trade_finding/external.rs
@@ -61,7 +61,7 @@ impl ExternalTradeFinder {
         if query.block_dependent {
             request = request.header(
                 "X-Current-Block-Hash",
-                self.block_stream.borrow().hash.to_string(),
+                self.block_stream.current().hash.to_string(),
             )
         }
 

--- a/crates/shared/src/zeroex_api.rs
+++ b/crates/shared/src/zeroex_api.rs
@@ -9,7 +9,7 @@ use {
     chrono::{DateTime, NaiveDateTime, TimeZone, Utc},
     derivative::Derivative,
     ethcontract::{H160, H256, U256},
-    ethrpc::current_block::{BlockInfo, CurrentBlockStream},
+    ethrpc::current_block::CurrentBlockStream,
     number::serialization::HexOrDecimalU256,
     reqwest::{
         header::{HeaderMap, HeaderValue},
@@ -23,6 +23,7 @@ use {
     serde_with::{serde_as, DisplayFromStr},
     std::{collections::HashSet, sync::Arc},
     thiserror::Error,
+    tokio::sync::watch,
 };
 
 const ORDERS_MAX_PAGE_SIZE: usize = 1_000;
@@ -269,7 +270,7 @@ impl DefaultZeroExApi {
     /// default URL) and `ZEROEX_API_KEY` (falling back to no API key) from the
     /// local environment when creating the API client.
     pub fn test() -> Self {
-        let block_stream = ethrpc::current_block::mock_stream(BlockInfo::default());
+        let block_stream = CurrentBlockStream::test_impl(watch::channel(Default::default()).1);
         Self::new(
             Client::builder(),
             std::env::var("ZEROEX_URL").unwrap_or_else(|_| Self::DEFAULT_URL.to_string()),

--- a/crates/shared/src/zeroex_api.rs
+++ b/crates/shared/src/zeroex_api.rs
@@ -23,7 +23,6 @@ use {
     serde_with::{serde_as, DisplayFromStr},
     std::{collections::HashSet, sync::Arc},
     thiserror::Error,
-    tokio::sync::watch,
 };
 
 const ORDERS_MAX_PAGE_SIZE: usize = 1_000;
@@ -270,7 +269,7 @@ impl DefaultZeroExApi {
     /// default URL) and `ZEROEX_API_KEY` (falling back to no API key) from the
     /// local environment when creating the API client.
     pub fn test() -> Self {
-        let (_, block_stream) = watch::channel(BlockInfo::default());
+        let block_stream = ethrpc::current_block::mock_stream(BlockInfo::default());
         Self::new(
             Client::builder(),
             std::env::var("ZEROEX_URL").unwrap_or_else(|_| Self::DEFAULT_URL.to_string()),
@@ -387,7 +386,7 @@ impl DefaultZeroExApi {
             if set_current_block_header {
                 request = request.header(
                     "X-Current-Block-Hash",
-                    self.block_stream.borrow().hash.to_string(),
+                    self.block_stream.current().hash.to_string(),
                 );
             };
             if let Some(id) = observe::request_id::get_task_local_storage() {

--- a/crates/solver/src/liquidity/zeroex.rs
+++ b/crates/solver/src/liquidity/zeroex.rs
@@ -12,7 +12,7 @@ use {
     anyhow::Result,
     arc_swap::ArcSwap,
     contracts::{GPv2Settlement, IZeroEx},
-    ethrpc::current_block::{into_stream, CurrentBlockStream},
+    ethrpc::current_block::CurrentBlockStream,
     futures::StreamExt,
     itertools::Itertools,
     model::{order::OrderKind, TokenPair},
@@ -100,7 +100,7 @@ impl ZeroExLiquidity {
         orderbook_cache: Arc<OrderbookCache>,
         gpv2_address: H160,
     ) {
-        let mut block_stream = into_stream(blocks_stream);
+        let mut block_stream = blocks_stream.watch_stream();
         while block_stream.next().await.is_some() {
             let queries = &[
                 // orders fillable by anyone


### PR DESCRIPTION
# Description
The `CurrentBlockStream` only yields the current block whenever it gets polled. This is problematic if whatever task that runs based on that stream takes longer than the average block time. In that case we would completely miss 1 block.
For the vast majority of use cases this is fine but the event indexing logic also runs based on that stream and there it's extremely important that we don't miss any blocks.

# Changes
Replaced the type alias `CurrentBlockStream` with a new type. The new type is able to support both use cases (watch latest block and watch all blocks) and has an API that is more explicit in what it does.

I used the new feature that yields all the blocks for the event indexing and left the current behavior for everything since we don't need to see all blocks there.

## How to test
Should be covered by existing tests