### PR TITLE
[EASY] Remove untagged enum property

### DIFF
--- a/crates/driver/src/infra/config/file/mod.rs
+++ b/crates/driver/src/infra/config/file/mod.rs
@@ -588,7 +588,7 @@ fn default_http_timeout() -> Duration {
 }
 
 #[derive(Clone, Debug, Deserialize, Default)]
-#[serde(untagged, deny_unknown_fields)]
+#[serde(rename_all = "kebab-case", deny_unknown_fields)]
 pub enum GasEstimatorType {
     #[default]
     Native,


### PR DESCRIPTION
# Description
The gas estimator type seemingly can't be deserialized with the `untagged` attribute.
While I was at it I also made sure variants get renamed to kebab cast

# Changes
* remove untagged property
* renamed variants to kebab case

## How to test
tested change locally. The strings "web3" and "native" can now be deserialized.