### PR TITLE
Orderbook memory leak profiler

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,10 +40,10 @@ ENTRYPOINT [ "driver" ]
 
 FROM intermediate as orderbook
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked apt-get update && \
-    apt-get install -y valgrind && \
+    apt-get install -y heaptrack && \
     apt-get clean
 COPY --from=cargo-build /orderbook /usr/local/bin/orderbook
-ENTRYPOINT ["valgrind", "--tool=massif", "/usr/local/bin/orderbook"]
+ENTRYPOINT ["heaptrack", "--output", "/tmp/heaptrack.orderbook.out", "/usr/local/bin/orderbook"]
 
 FROM intermediate as refunder
 COPY --from=cargo-build /refunder /usr/local/bin/refunder

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,8 +39,11 @@ COPY --from=cargo-build /driver /usr/local/bin/driver
 ENTRYPOINT [ "driver" ]
 
 FROM intermediate as orderbook
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked apt-get update && \
+    apt-get install -y valgrind && \
+    apt-get clean \
 COPY --from=cargo-build /orderbook /usr/local/bin/orderbook
-ENTRYPOINT [ "orderbook" ]
+ENTRYPOINT ["valgrind", "--leak-check=full", "--track-origins=yes", "/usr/local/bin/orderbook"]
 
 FROM intermediate as refunder
 COPY --from=cargo-build /refunder /usr/local/bin/refunder

--- a/Dockerfile
+++ b/Dockerfile
@@ -43,7 +43,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked apt-get update && \
     apt-get install -y valgrind && \
     apt-get clean \
 COPY --from=cargo-build /orderbook /usr/local/bin/orderbook
-ENTRYPOINT ["valgrind", "--leak-check=full", "--track-origins=yes", "/usr/local/bin/orderbook"]
+ENTRYPOINT ["valgrind", "--leak-check=full", "--track-origins=yes", "--tool=massif", "/usr/local/bin/orderbook"]
 
 FROM intermediate as refunder
 COPY --from=cargo-build /refunder /usr/local/bin/refunder

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,9 +41,9 @@ ENTRYPOINT [ "driver" ]
 FROM intermediate as orderbook
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked apt-get update && \
     apt-get install -y valgrind && \
-    apt-get clean \
+    apt-get clean
 COPY --from=cargo-build /orderbook /usr/local/bin/orderbook
-ENTRYPOINT ["valgrind", "--leak-check=full", "--track-origins=yes", "--tool=massif", "/usr/local/bin/orderbook"]
+ENTRYPOINT ["valgrind", "--tool=massif", "/usr/local/bin/orderbook"]
 
 FROM intermediate as refunder
 COPY --from=cargo-build /refunder /usr/local/bin/refunder


### PR DESCRIPTION
Runs ~~`valgrind` with `massif`~~`heaptrack` for the orderbook to identify memory leaks.
`valgrind` requires quitting the process to generate a report. `heaptrack` supports live data.
Requires more than 100mi of memory to install, so there is another infra PR(https://github.com/cowprotocol/infrastructure/pull/1523) to test it properly on sepolia first to ensure the performance won't degrade.

More info about the output file https://valgrind.org/docs/manual/ms-manual.html