### PR TITLE
feat: arbitrum one docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ ANVIL_IP_ADDR=0.0.0.0 anvil \
 
 Reading the state of the blockchain requires issuing RPC calls to an ethereum node. This can be a testnet you are running locally, some "real" node you have access to or the most convenient thing is to use a third-party service like [infura](https://infura.io/) to get access to an ethereum node which we recommend.
 After you made a free infura account they offer you "endpoints" for the mainnet and different testnets. We will refer those as `node-urls`.
-Because services are only run on Mainnet, Görli, Sepolia, and Gnosis Chain you need to select one of those.
+Because services are only run on Mainnet, Gnosis Chain, Arbitrum One and Sepolia you need to select one of those.
 
 Note that the `node-url` is sensitive data. The `orderbook` and `solver` executables allow you to pass it with the `--node-url` parameter. This is very convenient for our examples but to minimize the possibility of sharing this information by accident you should consider setting the `NODE_URL` environment variable so you don't have to pass the `--node-url` argument to the executables.
 
@@ -178,16 +178,16 @@ The `solver-account` is responsible for signing transactions. Solutions for sett
 
 To make things more interesting and see some real orders you can connect the `solver` to our real `orderbook` service. There are several orderbooks for production and staging environments on different networks. Find the `orderbook-url` corresponding to your `node-url` which suits your purposes and connect your solver to it with `--orderbook-url <URL>`.
 
-| Orderbook URL                       | Network      | Environment |
-|-------------------------------------|--------------|-------------|
-| https://barn.api.cow.fi/mainnet/api | Mainnet      | Staging     |
-| https://api.cow.fi/mainnet/api      | Mainnet      | Production  |
-| https://barn.api.cow.fi/goerli/api  | Görli        | Staging     |
-| https://api.cow.fi/goerli/api       | Görli        | Production  |
-| https://barn.api.cow.fi/sepolia/api | Sepolia      | Staging     |
-| https://api.cow.fi/sepolia/api      | Sepolia      | Production  |
-| https://barn.api.cow.fi/xdai/api    | Gnosis Chain | Staging     |
-| https://api.cow.fi/xdai/api         | Gnosis Chain | Production  |
+| Orderbook URL                              | Network      | Environment |
+|--------------------------------------------|--------------|-------------|
+| <https://barn.api.cow.fi/mainnet/api>      | Mainnet      | Staging     |
+| <https://api.cow.fi/mainnet/api>           | Mainnet      | Production  |
+| <https://barn.api.cow.fi/xdai/api>         | Gnosis Chain | Staging     |
+| <https://api.cow.fi/xdai/api>              | Gnosis Chain | Production  |
+| <https://barn.api.cow.fi/arbitrum_one/api> | Arbitrum One | Staging     |
+| <https://api.cow.fi/arbitrum_one/api>      | Arbitrum One | Production  |
+| <https://barn.api.cow.fi/sepolia/api>      | Sepolia      | Staging     |
+| <https://api.cow.fi/sepolia/api>           | Sepolia      | Production  |
 
 Always make sure that the `solver` and the `orderbook` it connects to are configured to use the same network.
 

--- a/crates/orderbook/openapi.yml
+++ b/crates/orderbook/openapi.yml
@@ -7,18 +7,18 @@ servers:
     url: https://api.cow.fi/mainnet
   - description: Mainnet (Staging)
     url: https://barn.api.cow.fi/mainnet
-  - description: Görli (Prod)
-    url: https://api.cow.fi/goerli
-  - description: Görli (Staging)
-    url: https://barn.api.cow.fi/goerli
-  - description: Sepolia (Prod)
-    url: https://api.cow.fi/sepolia
-  - description: Sepolia (Staging)
-    url: https://barn.api.cow.fi/sepolia
   - description: Gnosis Chain (Prod)
     url: https://api.cow.fi/xdai
   - description: Gnosis Chain (Staging)
     url: https://barn.api.cow.fi/xdai
+  - description: Arbitrum One (Prod)
+    url: https://api.cow.fi/arbitrum_one
+  - description: Arbitrum One (Staging)
+    url: https://barn.api.cow.fi/arbitrum_one
+  - description: Sepolia (Prod)
+    url: https://api.cow.fi/sepolia
+  - description: Sepolia (Staging)
+    url: https://barn.api.cow.fi/sepolia
   - description: Local
     url: http://localhost:8080
 paths:
@@ -485,7 +485,7 @@ components:
         format of the JSON expected in the `appData` field is defined
         [here](https://github.com/cowprotocol/app-data).
       type: string
-      example: "{\"version\":\"0.9.0\",\"metadata\":{}}"
+      example: '{"version":"0.9.0","metadata":{}}'
     AppDataHash:
       description: |
         32 bytes encoded as hex with `0x` prefix.
@@ -762,10 +762,10 @@ components:
             - $ref: "#/components/schemas/AppDataHash"
         appDataHash:
           description: |
-           May be set for debugging purposes. If set, this field is compared to what the backend
-           internally calculates as the app data hash based on the contents of `appData`. If the
-           hash does not match, an error is returned. If this field is set, then `appData` **MUST** be
-           a string encoding of a JSON object.
+            May be set for debugging purposes. If set, this field is compared to what the backend
+            internally calculates as the app data hash based on the contents of `appData`. If the
+            hash does not match, an error is returned. If this field is set, then `appData` **MUST** be
+            a string encoding of a JSON object.
           allOf:
             - $ref: "#/components/schemas/AppDataHash"
           nullable: true
@@ -935,7 +935,7 @@ components:
           description: |
             Currently executed amount of sell/buy token, depending on the order kind.
           allOf:
-          - $ref: "#/components/schemas/TokenAmount"
+            - $ref: "#/components/schemas/TokenAmount"
         preInteractions:
           description: |
             The pre-interactions that need to be executed before the first execution of the order.
@@ -1564,6 +1564,6 @@ components:
     FeePolicy:
       description: Defines the ways to calculate the protocol fee.
       oneOf:
-        - $ref: '#/components/schemas/Surplus'
-        - $ref: '#/components/schemas/Volume'
-        - $ref: '#/components/schemas/PriceImprovement'
+        - $ref: "#/components/schemas/Surplus"
+        - $ref: "#/components/schemas/Volume"
+        - $ref: "#/components/schemas/PriceImprovement"

--- a/crates/shared/src/bad_token/token_owner_finder/blockscout.rs
+++ b/crates/shared/src/bad_token/token_owner_finder/blockscout.rs
@@ -22,7 +22,7 @@ impl BlockscoutTokenOwnerFinder {
             5 => "https://eth-goerli.blockscout.com/api",
             100 => "https://blockscout.com/xdai/mainnet/api",
             11155111 => "https://eth-sepolia.blockscout.com/api",
-            // TODO: should arb1 be here too?
+            42161 => "https://arbitrum.blockscout.com/api",
             _ => bail!("Unsupported Network"),
         };
 

--- a/crates/shared/src/bad_token/token_owner_finder/blockscout.rs
+++ b/crates/shared/src/bad_token/token_owner_finder/blockscout.rs
@@ -22,6 +22,7 @@ impl BlockscoutTokenOwnerFinder {
             5 => "https://eth-goerli.blockscout.com/api",
             100 => "https://blockscout.com/xdai/mainnet/api",
             11155111 => "https://eth-sepolia.blockscout.com/api",
+            // TODO: should arb1 be here too?
             _ => bail!("Unsupported Network"),
         };
 


### PR DESCRIPTION
# Description

Update docs regarding Arbitrum one and remove Goerli references.
Also added arb1 endpoint to blockscout config.

# Changes

- [x] Add arbitrum one to ordebook openapi
- [x] Remove goerli from ordebook openapi
- [x] Sort orderbook openapi urls by chain type (mainnet, side chains, l2s, test chains)
- [x] Same thing, but for README
- [x] Add arb1 endpoint to blockscout config

## How to test

1. Check readme
2. Check api docs