### PR TITLE
OpenAPI: Add surplusCapturingJitOrderOwners to /solve in the driver

### DIFF
--- a/crates/driver/openapi.yml
+++ b/crates/driver/openapi.yml
@@ -336,7 +336,7 @@ components:
           items:
             $ref: "#/components/schemas/Address"
           description: |
-            List of surplus capturing JIT-order owners.
+            List of addresses on whose surplus will count towards the objective value of their solution (unlike other orders that were created by the solver).
     SolveResponse:
       description: |
         Response of the solve endpoint.


### PR DESCRIPTION
# Description
Add missing surplusCapturingJitOrderOwners to /solve in the driver api doc