### PR TITLE
Propagate the surplus capturing JIT-order owners to the solvers

### DIFF
--- a/crates/driver/src/infra/solver/dto/auction.rs
+++ b/crates/driver/src/infra/solver/dto/auction.rs
@@ -21,7 +21,6 @@ use {
         interaction::InteractionData,
         order::{BuyTokenDestination, SellTokenSource},
     },
-    primitive_types::H160,
     serde::Serialize,
     serde_with::serde_as,
     std::collections::{BTreeMap, HashMap},
@@ -309,6 +308,12 @@ impl Auction {
             tokens,
             effective_gas_price: auction.gas_price().effective().into(),
             deadline: auction.deadline().solvers(),
+            surplus_capturing_jit_order_owners: auction
+                .surplus_capturing_jit_order_owners()
+                .iter()
+                .cloned()
+                .map(Into::into)
+                .collect::<Vec<_>>(),
         }
     }
 }
@@ -324,6 +329,7 @@ pub struct Auction {
     #[serde_as(as = "serialize::U256")]
     effective_gas_price: eth::U256,
     deadline: chrono::DateTime<chrono::Utc>,
+    surplus_capturing_jit_order_owners: Vec<eth::H160>,
 }
 
 #[serde_as]
@@ -349,8 +355,8 @@ struct Order {
     valid_to: u32,
     kind: Kind,
     #[serde(skip_serializing_if = "Option::is_none")]
-    receiver: Option<H160>,
-    owner: H160,
+    receiver: Option<eth::H160>,
+    owner: eth::H160,
     partially_fillable: bool,
     pre_interactions: Vec<InteractionData>,
     post_interactions: Vec<InteractionData>,

--- a/crates/driver/src/tests/setup/solver.rs
+++ b/crates/driver/src/tests/setup/solver.rs
@@ -331,6 +331,7 @@ impl Solver {
                         "liquidity": [],
                         "effectiveGasPrice": effective_gas_price,
                         "deadline": config.deadline.solvers(),
+                        "surplusCapturingJitOrderOwners": [],
                     });
                     assert_eq!(req, expected, "unexpected /solve request");
                     let mut state = state.0.lock().unwrap();

--- a/crates/solvers-dto/src/auction.rs
+++ b/crates/solvers-dto/src/auction.rs
@@ -21,6 +21,7 @@ pub struct Auction {
     #[serde_as(as = "HexOrDecimalU256")]
     pub effective_gas_price: U256,
     pub deadline: chrono::DateTime<chrono::Utc>,
+    pub surplus_capturing_jit_order_owners: Vec<H160>,
 }
 
 #[serde_as]

--- a/crates/solvers/openapi.yml
+++ b/crates/solvers/openapi.yml
@@ -619,6 +619,7 @@ components:
         - liquidity
         - effectiveGasPrice
         - deadline
+        - surplusCapturingJitOrderOwners
       properties:
         id:
           description: |
@@ -658,6 +659,12 @@ components:
             by the caller.
           allOf:
             - $ref: "#/components/schemas/DateTime"
+        surplusCapturingJitOrderOwners:
+          type: array
+          items:
+            $ref: "#/components/schemas/Address"
+          description: |
+            List of addresses on whose surplus will count towards the objective value of their solution (unlike other orders that were created by the solver).
 
     JitOrder:
       description: |

--- a/crates/solvers/src/tests/baseline/bal_liquidity.rs
+++ b/crates/solvers/src/tests/baseline/bal_liquidity.rs
@@ -95,7 +95,8 @@ async fn weighted() {
                 },
             ],
             "effectiveGasPrice": "1000000000",
-            "deadline": "2106-01-01T00:00:00.000Z"
+            "deadline": "2106-01-01T00:00:00.000Z",
+            "surplusCapturingJitOrderOwners": []
         }))
         .await;
 
@@ -238,7 +239,8 @@ async fn weighted_v3plus() {
                 },
             ],
             "effectiveGasPrice": "1000000000",
-            "deadline": "2106-01-01T00:00:00.000Z"
+            "deadline": "2106-01-01T00:00:00.000Z",
+            "surplusCapturingJitOrderOwners": []
         }))
         .await;
 
@@ -398,7 +400,8 @@ async fn stable() {
                 },
             ],
             "effectiveGasPrice": "1000000000",
-            "deadline": "2106-01-01T00:00:00.000Z"
+            "deadline": "2106-01-01T00:00:00.000Z",
+            "surplusCapturingJitOrderOwners": []
         }))
         .await;
 
@@ -573,7 +576,8 @@ async fn composable_stable_v4() {
                 },
             ],
             "effectiveGasPrice": "1000000000",
-            "deadline": "2106-01-01T00:00:00.000Z"
+            "deadline": "2106-01-01T00:00:00.000Z",
+            "surplusCapturingJitOrderOwners": []
         }))
         .await;
 

--- a/crates/solvers/src/tests/baseline/buy_order_rounding.rs
+++ b/crates/solvers/src/tests/baseline/buy_order_rounding.rs
@@ -75,7 +75,8 @@ async fn uniswap() {
                 }
             ],
             "effectiveGasPrice": "15000000000",
-            "deadline": "2106-01-01T00:00:00.000Z"
+            "deadline": "2106-01-01T00:00:00.000Z",
+            "surplusCapturingJitOrderOwners": []
         }))
         .await;
 
@@ -247,7 +248,8 @@ async fn balancer_weighted() {
                 },
             ],
             "effectiveGasPrice": "1000000000",
-            "deadline": "2106-01-01T00:00:00.000Z"
+            "deadline": "2106-01-01T00:00:00.000Z",
+            "surplusCapturingJitOrderOwners": []
         }))
         .await;
 
@@ -401,7 +403,8 @@ async fn balancer_weighted_v3plus() {
                 },
             ],
             "effectiveGasPrice": "1000000000",
-            "deadline": "2106-01-01T00:00:00.000Z"
+            "deadline": "2106-01-01T00:00:00.000Z",
+            "surplusCapturingJitOrderOwners": []
         }))
         .await;
 
@@ -544,7 +547,8 @@ async fn distant_convergence() {
                 },
             ],
             "effectiveGasPrice": "1000000000",
-            "deadline": "2106-01-01T00:00:00.000Z"
+            "deadline": "2106-01-01T00:00:00.000Z",
+            "surplusCapturingJitOrderOwners": []
         }))
         .await;
 
@@ -703,7 +707,8 @@ async fn same_path() {
                 },
             ],
             "effectiveGasPrice": "1000000000",
-            "deadline": "2106-01-01T00:00:00.000Z"
+            "deadline": "2106-01-01T00:00:00.000Z",
+            "surplusCapturingJitOrderOwners": []
         }))
         .await;
 
@@ -866,7 +871,8 @@ async fn balancer_stable() {
                 },
             ],
             "effectiveGasPrice": "1000000000",
-            "deadline": "2106-01-01T00:00:00.000Z"
+            "deadline": "2106-01-01T00:00:00.000Z",
+            "surplusCapturingJitOrderOwners": []
         }))
         .await;
 

--- a/crates/solvers/src/tests/baseline/direct_swap.rs
+++ b/crates/solvers/src/tests/baseline/direct_swap.rs
@@ -75,7 +75,8 @@ async fn test() {
                 }
             ],
             "effectiveGasPrice": "15000000000",
-            "deadline": "2106-01-01T00:00:00.000Z"
+            "deadline": "2106-01-01T00:00:00.000Z",
+            "surplusCapturingJitOrderOwners": []
         }))
         .await;
 

--- a/crates/solvers/src/tests/baseline/internalization.rs
+++ b/crates/solvers/src/tests/baseline/internalization.rs
@@ -75,7 +75,8 @@ async fn trusted_token() {
                 }
             ],
             "effectiveGasPrice": "15000000000",
-            "deadline": "2106-01-01T00:00:00.000Z"
+            "deadline": "2106-01-01T00:00:00.000Z",
+            "surplusCapturingJitOrderOwners": []
         }))
         .await;
 
@@ -188,7 +189,8 @@ async fn untrusted_sell_token() {
                 }
             ],
             "effectiveGasPrice": "15000000000",
-            "deadline": "2106-01-01T00:00:00.000Z"
+            "deadline": "2106-01-01T00:00:00.000Z",
+            "surplusCapturingJitOrderOwners": []
         }))
         .await;
 
@@ -301,7 +303,8 @@ async fn insufficient_balance() {
                 }
             ],
             "effectiveGasPrice": "15000000000",
-            "deadline": "2106-01-01T00:00:00.000Z"
+            "deadline": "2106-01-01T00:00:00.000Z",
+            "surplusCapturingJitOrderOwners": []
         }))
         .await;
 

--- a/crates/solvers/src/tests/baseline/limit_order_quoting.rs
+++ b/crates/solvers/src/tests/baseline/limit_order_quoting.rs
@@ -104,7 +104,8 @@ async fn sell_order() {
                 },
             ],
             "effectiveGasPrice": "1000000000",
-            "deadline": "2106-01-01T00:00:00.000Z"
+            "deadline": "2106-01-01T00:00:00.000Z",
+            "surplusCapturingJitOrderOwners": []
         }))
         .await;
 
@@ -248,7 +249,8 @@ async fn buy_order() {
                 },
             ],
             "effectiveGasPrice": "1000000000",
-            "deadline": "2106-01-01T00:00:00.000Z"
+            "deadline": "2106-01-01T00:00:00.000Z",
+            "surplusCapturingJitOrderOwners": []
         }))
         .await;
 

--- a/crates/solvers/src/tests/baseline/partial_fill.rs
+++ b/crates/solvers/src/tests/baseline/partial_fill.rs
@@ -75,7 +75,8 @@ async fn test() {
                 }
             ],
             "effectiveGasPrice": "15000000000",
-            "deadline": "2106-01-01T00:00:00.000Z"
+            "deadline": "2106-01-01T00:00:00.000Z",
+            "surplusCapturingJitOrderOwners": []
         }))
         .await;
 

--- a/crates/solvers/src/tests/naive/extract_deepest_pool.rs
+++ b/crates/solvers/src/tests/naive/extract_deepest_pool.rs
@@ -97,6 +97,7 @@ async fn test() {
             ],
             "effectiveGasPrice": "0",
             "deadline": "2106-01-01T00:00:00.000Z",
+            "surplusCapturingJitOrderOwners": []
         }))
         .await;
 

--- a/crates/solvers/src/tests/naive/filters_out_of_price_orders.rs
+++ b/crates/solvers/src/tests/naive/filters_out_of_price_orders.rs
@@ -133,6 +133,7 @@ async fn sell_orders_on_both_sides() {
             ],
             "effectiveGasPrice": "15000000000",
             "deadline": "2106-01-01T00:00:00.000Z",
+            "surplusCapturingJitOrderOwners": []
         }))
         .await;
 

--- a/crates/solvers/src/tests/naive/limit_order_price.rs
+++ b/crates/solvers/src/tests/naive/limit_order_price.rs
@@ -57,6 +57,7 @@ async fn test() {
             ],
             "effectiveGasPrice": "15000000000",
             "deadline": "2106-01-01T00:00:00.000Z",
+            "surplusCapturingJitOrderOwners": []
         }))
         .await;
 

--- a/crates/solvers/src/tests/naive/matches_orders.rs
+++ b/crates/solvers/src/tests/naive/matches_orders.rs
@@ -81,6 +81,7 @@ async fn sell_orders_on_both_sides() {
             ],
             "effectiveGasPrice": "15000000000",
             "deadline": "2106-01-01T00:00:00.000Z",
+            "surplusCapturingJitOrderOwners": []
         }))
         .await;
 
@@ -206,6 +207,7 @@ async fn sell_orders_on_one_side() {
             ],
             "effectiveGasPrice": "15000000000",
             "deadline": "2106-01-01T00:00:00.000Z",
+            "surplusCapturingJitOrderOwners": []
         }))
         .await;
 
@@ -331,6 +333,7 @@ async fn buy_orders_on_both_sides() {
             ],
             "effectiveGasPrice": "15000000000",
             "deadline": "2106-01-01T00:00:00.000Z",
+            "surplusCapturingJitOrderOwners": []
         }))
         .await;
 
@@ -456,6 +459,7 @@ async fn buy_and_sell_orders() {
             ],
             "effectiveGasPrice": "15000000000",
             "deadline": "2106-01-01T00:00:00.000Z",
+            "surplusCapturingJitOrderOwners": []
         }))
         .await;
 

--- a/crates/solvers/src/tests/naive/reserves_too_small.rs
+++ b/crates/solvers/src/tests/naive/reserves_too_small.rs
@@ -81,6 +81,7 @@ async fn test() {
             ],
             "effectiveGasPrice": "15000000000",
             "deadline": "2106-01-01T00:00:00.000Z",
+            "surplusCapturingJitOrderOwners": []
         }))
         .await;
 

--- a/crates/solvers/src/tests/naive/rounds_prices_in_favour_of_traders.rs
+++ b/crates/solvers/src/tests/naive/rounds_prices_in_favour_of_traders.rs
@@ -88,6 +88,7 @@ async fn test() {
             ],
             "effectiveGasPrice": "15000000000",
             "deadline": "2106-01-01T00:00:00.000Z",
+            "surplusCapturingJitOrderOwners": []
         }))
         .await;
 

--- a/crates/solvers/src/tests/naive/swap_less_than_reserves.rs
+++ b/crates/solvers/src/tests/naive/swap_less_than_reserves.rs
@@ -86,6 +86,7 @@ async fn test() {
             ],
             "effectiveGasPrice": "15000000000",
             "deadline": "2106-01-01T00:00:00.000Z",
+            "surplusCapturingJitOrderOwners": []
         }))
         .await;
 

--- a/crates/solvers/src/tests/naive/without_pool.rs
+++ b/crates/solvers/src/tests/naive/without_pool.rs
@@ -81,6 +81,7 @@ async fn test() {
             ],
             "effectiveGasPrice": "15000000000",
             "deadline": "2106-01-01T00:00:00.000Z",
+            "surplusCapturingJitOrderOwners": []
         }))
         .await;
 


### PR DESCRIPTION
# Description
The solvers would need to know the JIT-order surplus capturing addresses (see e.g. https://github.com/cowprotocol/services/issues/2715#issuecomment-2130855593). For that the owner addresses are propagated to the solvers in the auction json.


# Changes
Propagate the list of surplus capturing JIT-order owners to the solvers in the auction json.

## How to test
1. Regression tests