### PR TITLE
Fix "calldata" typo in solver/driver api description

### DIFF
--- a/crates/solvers/openapi.yml
+++ b/crates/solvers/openapi.yml
@@ -821,7 +821,7 @@ components:
         - kind
         - target
         - value
-        - calldata
+        - callData
         - inputs
         - outputs
       properties:
@@ -832,7 +832,7 @@ components:
           $ref: "#/components/schemas/Address"
         value:
           $ref: "#/components/schemas/TokenAmount"
-        calldata:
+        callData:
           description: |
             The EVM calldata bytes.
           type: string
@@ -874,7 +874,7 @@ components:
           $ref: "#/components/schemas/Address"
         value:
           $ref: "#/components/schemas/TokenAmount"
-        calldata:
+        callData:
           description: Hex encoded bytes with `0x` prefix.
           type: string
 
@@ -932,7 +932,7 @@ components:
           $ref: "#/components/schemas/Address"
         value:
           $ref: "#/components/schemas/TokenAmount"
-        calldata:
+        callData:
           type: array
           items:
             $ref: "#/components/schemas/CallData"


### PR DESCRIPTION
This has created confusion to multiple solver teams. Hope this PR does what it is supposed to.