### PR TITLE
Cow amm encoding

### DIFF
--- a/crates/driver/src/domain/competition/order/mod.rs
+++ b/crates/driver/src/domain/competition/order/mod.rs
@@ -370,6 +370,7 @@ pub struct Jit {
     pub sell_token_balance: SellTokenBalance,
     pub buy_token_balance: BuyTokenBalance,
     pub signature: Signature,
+    pub uid: Uid,
 }
 
 impl Jit {

--- a/crates/driver/src/domain/competition/solution/encoding.rs
+++ b/crates/driver/src/domain/competition/solution/encoding.rs
@@ -124,30 +124,13 @@ pub fn tx(
             }
             super::Trade::Jit(trade) => {
                 (
-                    if auction
-                        .surplus_capturing_jit_order_owners()
-                        .contains(&trade.order().signature.signer)
-                    {
-                        // COW Amm JIT orders are matched at UCP prices
-                        Price {
-                            sell_token: trade.order().sell.token.into(),
-                            sell_price: solution
-                                .clearing_price(trade.order().sell.token)
-                                .ok_or(Error::InvalidClearingPrice(trade.order().sell.token))?,
-                            buy_token: trade.order().buy.token.into(),
-                            buy_price: solution
-                                .clearing_price(trade.order().buy.token)
-                                .ok_or(Error::InvalidClearingPrice(trade.order().buy.token))?,
-                        }
-                    } else {
+                    Price {
                         // Jit orders are matched at limit price, so the sell token is worth
                         // buy.amount and vice versa
-                        Price {
-                            sell_token: trade.order().sell.token.into(),
-                            sell_price: trade.order().buy.amount.into(),
-                            buy_token: trade.order().buy.token.into(),
-                            buy_price: trade.order().sell.amount.into(),
-                        }
+                        sell_token: trade.order().sell.token.into(),
+                        sell_price: trade.order().buy.amount.into(),
+                        buy_token: trade.order().buy.token.into(),
+                        buy_price: trade.order().sell.amount.into(),
                     },
                     Trade {
                         // indices are set below

--- a/crates/driver/src/domain/competition/solution/mod.rs
+++ b/crates/driver/src/domain/competition/solution/mod.rs
@@ -73,17 +73,17 @@ impl Solution {
                 Trade::Fulfillment(fulfillment) => Trade::Fulfillment(fulfillment),
                 Trade::Jit(jit) => {
                     if surplus_capturing_jit_order_owners.contains(&jit.order().signature.signer) {
-                        // COW Amm JIT orders behave like Fulfillment orders. They are surplus
-                        // capturing, pay network fees and contribute to score of a solution.
+                        // Surplus capturing JIT orders behave like Fulfillment orders. They capture
+                        // surplus, pay network fees and contribute to score of a solution.
                         Trade::Fulfillment(
                             Fulfillment::new(
                                 competition::Order {
-                                    uid: jit.order().uid, // todo get
+                                    uid: recover_uid_from_jit_trade_order(&jit),
                                     kind: order::Kind::Limit,
                                     side: jit.order().side,
                                     sell: jit.order().sell,
                                     buy: jit.order().buy,
-                                    signature: jit.order().signature,
+                                    signature: jit.order().signature.clone(),
                                     receiver: Some(jit.order().receiver),
                                     valid_to: jit.order().valid_to,
                                     app_data: jit.order().app_data,

--- a/crates/driver/src/infra/solver/dto/solution.rs
+++ b/crates/driver/src/infra/solver/dto/solution.rs
@@ -61,6 +61,9 @@ impl Solutions {
                             Trade::Jit(jit) => Ok(competition::solution::Trade::Jit(
                                 competition::solution::trade::Jit::new(
                                     competition::order::Jit {
+                                        uid: jit.order.uid(
+                                            &solver.eth.contracts().settlement_domain_separator(),
+                                        )?,
                                         sell: eth::Asset {
                                             amount: jit.order.sell_amount.into(),
                                             token: jit.order.sell_token.into(),
@@ -97,32 +100,9 @@ impl Solutions {
                                                 competition::order::BuyTokenBalance::Internal
                                             }
                                         },
-                                        signature: {
-                                            let mut signature = competition::order::Signature {
-                                                scheme: match jit.order.signing_scheme {
-                                                    SigningScheme::Eip712 => {
-                                                        competition::order::signature::Scheme::Eip712
-                                                    }
-                                                    SigningScheme::EthSign => {
-                                                        competition::order::signature::Scheme::EthSign
-                                                    }
-                                                    SigningScheme::PreSign => {
-                                                        competition::order::signature::Scheme::PreSign
-                                                    }
-                                                    SigningScheme::Eip1271 => {
-                                                        competition::order::signature::Scheme::Eip1271
-                                                    }
-                                                },
-                                                data: jit.order.signature.clone().into(),
-                                                signer: Default::default(),
-                                            };
-
-                                            // Recover the signer from the order signature
-                                            let signer = Self::recover_signer_from_jit_trade_order(&jit, &signature, solver.eth.contracts().settlement_domain_separator())?;
-                                            signature.signer = signer;
-
-                                            signature
-                                        },
+                                        signature: jit.order.signature(
+                                            &solver.eth.contracts().settlement_domain_separator(),
+                                        )?,
                                     },
                                     jit.executed_amount.into(),
                                 )
@@ -233,94 +213,12 @@ impl Solutions {
                     competition::solution::error::Solution::ProtocolFee(err) => {
                         super::Error(format!("could not incorporate protocol fee: {err}"))
                     }
+                    competition::solution::error::Solution::InvalidJitTrade(err) => {
+                        super::Error(format!("invalid jit trade: {err}"))
+                    }
                 })
             })
             .collect()
-    }
-
-    /// Function to recover the signer of a JIT order
-    fn recover_signer_from_jit_trade_order(
-        jit: &JitTrade,
-        signature: &competition::order::Signature,
-        domain: &eth::DomainSeparator,
-    ) -> Result<eth::Address, super::Error> {
-        let order_data = OrderData {
-            sell_token: jit.order.sell_token,
-            buy_token: jit.order.buy_token,
-            receiver: Some(jit.order.receiver),
-            sell_amount: jit.order.sell_amount,
-            buy_amount: jit.order.buy_amount,
-            valid_to: jit.order.valid_to,
-            app_data: AppDataHash(jit.order.app_data),
-            fee_amount: jit.order.fee_amount,
-            kind: match jit.order.kind {
-                Kind::Sell => OrderKind::Sell,
-                Kind::Buy => OrderKind::Buy,
-            },
-            partially_fillable: jit.order.partially_fillable,
-            sell_token_balance: match jit.order.sell_token_balance {
-                SellTokenBalance::Erc20 => SellTokenSource::Erc20,
-                SellTokenBalance::Internal => SellTokenSource::Internal,
-                SellTokenBalance::External => SellTokenSource::External,
-            },
-            buy_token_balance: match jit.order.buy_token_balance {
-                BuyTokenBalance::Erc20 => BuyTokenDestination::Erc20,
-                BuyTokenBalance::Internal => BuyTokenDestination::Internal,
-            },
-        };
-
-        signature
-            .to_boundary_signature()
-            .recover_owner(
-                jit.order.signature.as_slice(),
-                &DomainSeparator(domain.0),
-                &order_data.hash_struct(),
-            )
-            .map_err(|e| super::Error(e.to_string()))
-            .map(Into::into)
-    }
-
-    /// Function to recover the order uid of a JIT order
-    fn recover_uid_from_jit_trade_order(
-        jit: &JitTrade,
-        signature: &competition::order::Signature,
-        domain: &eth::DomainSeparator,
-    ) -> Result<crate::domain::competition::order::Uid, super::Error> {
-        let order_data = OrderData {
-            sell_token: jit.order.sell_token,
-            buy_token: jit.order.buy_token,
-            receiver: Some(jit.order.receiver),
-            sell_amount: jit.order.sell_amount,
-            buy_amount: jit.order.buy_amount,
-            valid_to: jit.order.valid_to,
-            app_data: AppDataHash(jit.order.app_data),
-            fee_amount: jit.order.fee_amount,
-            kind: match jit.order.kind {
-                Kind::Sell => OrderKind::Sell,
-                Kind::Buy => OrderKind::Buy,
-            },
-            partially_fillable: jit.order.partially_fillable,
-            sell_token_balance: match jit.order.sell_token_balance {
-                SellTokenBalance::Erc20 => SellTokenSource::Erc20,
-                SellTokenBalance::Internal => SellTokenSource::Internal,
-                SellTokenBalance::External => SellTokenSource::External,
-            },
-            buy_token_balance: match jit.order.buy_token_balance {
-                BuyTokenBalance::Erc20 => BuyTokenDestination::Erc20,
-                BuyTokenBalance::Internal => BuyTokenDestination::Internal,
-            },
-        };
-
-        let owner = signature
-            .to_boundary_signature()
-            .recover_owner(
-                jit.order.signature.as_slice(),
-                &DomainSeparator(domain.0),
-                &order_data.hash_struct(),
-            )
-            .map_err(|e| super::Error(e.to_string()))?;
-
-        Ok(order_data.uid(&DomainSeparator(domain.0), &owner).0.into())
     }
 }
 
@@ -402,6 +300,76 @@ struct JitOrder {
     signing_scheme: SigningScheme,
     #[serde_as(as = "serialize::Hex")]
     signature: Vec<u8>,
+}
+
+impl JitOrder {
+    fn raw_order_data(&self) -> OrderData {
+        OrderData {
+            sell_token: self.sell_token,
+            buy_token: self.buy_token,
+            receiver: Some(self.receiver),
+            sell_amount: self.sell_amount,
+            buy_amount: self.buy_amount,
+            valid_to: self.valid_to,
+            app_data: AppDataHash(self.app_data),
+            fee_amount: self.fee_amount,
+            kind: match self.kind {
+                Kind::Sell => OrderKind::Sell,
+                Kind::Buy => OrderKind::Buy,
+            },
+            partially_fillable: self.partially_fillable,
+            sell_token_balance: match self.sell_token_balance {
+                SellTokenBalance::Erc20 => SellTokenSource::Erc20,
+                SellTokenBalance::Internal => SellTokenSource::Internal,
+                SellTokenBalance::External => SellTokenSource::External,
+            },
+            buy_token_balance: match self.buy_token_balance {
+                BuyTokenBalance::Erc20 => BuyTokenDestination::Erc20,
+                BuyTokenBalance::Internal => BuyTokenDestination::Internal,
+            },
+        }
+    }
+
+    fn signature(
+        &self,
+        domain_separator: &eth::DomainSeparator,
+    ) -> Result<competition::order::Signature, super::Error> {
+        let mut signature = competition::order::Signature {
+            scheme: match self.signing_scheme {
+                SigningScheme::Eip712 => competition::order::signature::Scheme::Eip712,
+                SigningScheme::EthSign => competition::order::signature::Scheme::EthSign,
+                SigningScheme::PreSign => competition::order::signature::Scheme::PreSign,
+                SigningScheme::Eip1271 => competition::order::signature::Scheme::Eip1271,
+            },
+            data: self.signature.clone().into(),
+            signer: Default::default(),
+        };
+
+        let signer = signature
+            .to_boundary_signature()
+            .recover_owner(
+                self.signature.as_slice(),
+                &DomainSeparator(domain_separator.0),
+                &self.raw_order_data().hash_struct(),
+            )
+            .map_err(|e| super::Error(e.to_string()))?;
+
+        signature.signer = signer.into();
+
+        Ok(signature)
+    }
+
+    fn uid(
+        &self,
+        domain: &eth::DomainSeparator,
+    ) -> Result<crate::domain::competition::order::Uid, super::Error> {
+        let order_data = self.raw_order_data();
+        let signature = self.signature(domain)?;
+        Ok(order_data
+            .uid(&DomainSeparator(domain.0), &signature.signer.into())
+            .0
+            .into())
+    }
 }
 
 #[derive(Debug, Deserialize)]


### PR DESCRIPTION
# Description
Currently surplus capturing JIT orders do not get encoded such that they get surplus. Instead they always trade at their limit price. This is problematic for CoW AMM orders since there is no reason to rebalance CoW AMMs if these trades can't get surplus.

# Changes
Since we are short on time we hackily convert surplus capturing JIT orders into Fulfillments (aka regular orders) when building the solution in the driver. That way they will get encoded the same way regular orders will.

## How to test
The plan is to have a separate PR that implements an e2e test for this. Wanted to open this PR already anyway so people can review while I'm working on the test which will likely take a bit.
Also in case the e2e test takes a bit to get merged due to discussions I'd suggest to merge this PR as soon as the test confirms that the patch is correct. IMO there is no harm in cleaning up the e2e test further and only merging it on Monday or Tuesday.