### PR TITLE
Fix CI after foundry update

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -108,8 +108,6 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
       - run: rustup toolchain install stable --profile minimal
       - uses: foundry-rs/foundry-toolchain@v1
-        with:
-          version: nightly-f479e945c6be78bb902df12f9d683c3bb55e3fb0
       - uses: Swatinem/rust-cache@v2
       # Start the build process in the background. The following cargo test command will automatically
       # wait for the build process to be done before proceeding.

--- a/crates/e2e/src/nodes/mod.rs
+++ b/crates/e2e/src/nodes/mod.rs
@@ -36,7 +36,7 @@ impl Node {
             "--gas-limit",
             "10000000",
             "--base-fee",
-            "0",
+            "1",
             "--balance",
             "1000000",
             "--chain-id",

--- a/crates/e2e/src/setup/mod.rs
+++ b/crates/e2e/src/setup/mod.rs
@@ -58,7 +58,7 @@ where
 
 static NODE_MUTEX: Mutex<()> = Mutex::new(());
 
-const DEFAULT_FILTERS: [&str; 9] = [
+const DEFAULT_FILTERS: &[&str] = &[
     "warn",
     "autopilot=debug",
     "driver=debug",
@@ -74,7 +74,7 @@ fn with_default_filters<T>(custom_filters: impl IntoIterator<Item = T>) -> Vec<S
 where
     T: AsRef<str>,
 {
-    let mut default_filters: Vec<_> = DEFAULT_FILTERS.into_iter().map(String::from).collect();
+    let mut default_filters: Vec<_> = DEFAULT_FILTERS.iter().map(|s| s.to_string()).collect();
     default_filters.extend(custom_filters.into_iter().map(|f| f.as_ref().to_owned()));
 
     default_filters

--- a/crates/e2e/tests/e2e/protocol_fee.rs
+++ b/crates/e2e/tests/e2e/protocol_fee.rs
@@ -231,6 +231,9 @@ async fn combined_protocol_fees(web3: Web3) {
         )
         .await
         .unwrap();
+        // Only proceed with test once the quote changes significantly (2x) to avoid
+        // progressing due to tiny fluctuations in gas price which would lead to
+        // errors down the line.
         new_market_order_quote.quote.buy_amount > market_quote_before.quote.buy_amount * 2
     })
     .await

--- a/crates/e2e/tests/e2e/protocol_fee.rs
+++ b/crates/e2e/tests/e2e/protocol_fee.rs
@@ -231,7 +231,7 @@ async fn combined_protocol_fees(web3: Web3) {
         )
         .await
         .unwrap();
-        new_market_order_quote.quote.buy_amount != market_quote_before.quote.buy_amount
+        new_market_order_quote.quote.buy_amount > market_quote_before.quote.buy_amount * 2
     })
     .await
     .expect("Timeout waiting for eviction of the cached liquidity");


### PR DESCRIPTION
# Description
https://github.com/foundry-rs/foundry/issues/8035 changed `anvil` to compute the gas price differently. This seems like a breaking change since under some conditions the new logic computes a different gas price than the original one.

This broke 2 of our tests which both involve waiting for the system to flush out cached liquidity data to generate new quotes. For `e2e::e2e quoting::local_node_test` it was enough to just bump the `--base-fee` to `1` (without breaking any other test) and for `e2e::e2e protocol_fee::local_node_combined_protocol_fees` I needed to make the condition to detect flushed liquidity stricter.
Instead of waiting for any change in quotes (which are now triggered too early because of tiny changes in the gas price) we now wait for the quote to be at least twice as good as the old quote.

# Changes
- bump `--base-fee` to `1` in `anvil` args
- stricter synchronization logic for `e2e::e2e protocol_fee::local_node_combined_protocol_fees`
- use nightly version of foundry again in CI