### PR TITLE
[TRIVIAL] Simplify estimator logs

### DIFF
--- a/crates/shared/src/price_estimation/factory.rs
+++ b/crates/shared/src/price_estimation/factory.rs
@@ -156,7 +156,7 @@ impl<'a> PriceEstimatorFactory<'a> {
 
         let fast = instrument(estimator, name);
         let optimal = match verified {
-            Some(verified) => instrument(verified, format!("{name}_verified")),
+            Some(verified) => instrument(verified, name),
             None => fast.clone(),
         };
 


### PR DESCRIPTION
# Changes
When quote verification was fresh it made sense to have special logging for verified estimators to debug things. But now all estimators are always verified and the `_verified` postfix makes it so that you don't get to see all the logs in kibana when you just search for `<estimator>` (`<estimator>_verified` logs would not show up).