### PR TITLE
Create a surplus capturing JIT order listener

### DIFF
--- a/crates/autopilot/src/domain/mod.rs
+++ b/crates/autopilot/src/domain/mod.rs
@@ -4,6 +4,7 @@ pub mod eth;
 pub mod fee;
 pub mod quote;
 pub mod settlement;
+mod surplus_capturing_jit_order_owners;
 
 pub use {
     auction::{
@@ -13,4 +14,5 @@ pub use {
     },
     fee::ProtocolFees,
     quote::Quote,
+    surplus_capturing_jit_order_owners::SurplusCapturingJitOrderOwners,
 };

--- a/crates/autopilot/src/domain/surplus_capturing_jit_order_owners.rs
+++ b/crates/autopilot/src/domain/surplus_capturing_jit_order_owners.rs
@@ -1,0 +1,77 @@
+use {
+    crate::domain::eth::Address,
+    contracts::cow_amm_constant_product_factory::Event as CowAMMProductFactoryEvent,
+    primitive_types::H160,
+    std::{collections::HashSet, sync::Arc},
+    tokio::sync::{broadcast, RwLock},
+};
+
+/// Surplus capturing JIT order owners
+/// The list of owners is initialized with the values specified in the autopilot
+/// configuration file, and it is updated with all the CoW AMM owners which are
+/// deployed by the CoW AMM product factory contract by listening to the events
+/// emitted by such contract
+pub struct SurplusCapturingJitOrderOwners {
+    /// The order owners that capture surplus for JIT orders
+    surplus_capturing_jit_order_owners: Arc<RwLock<HashSet<Address>>>,
+}
+
+impl SurplusCapturingJitOrderOwners {
+    pub fn new(
+        surplus_capturing_jit_order_owners_configuration: &[H160],
+        receiver: Option<
+            broadcast::Receiver<
+                ethcontract::Event<contracts::cow_amm_constant_product_factory::Event>,
+            >,
+        >,
+    ) -> Self {
+        let inner = Self {
+            surplus_capturing_jit_order_owners: Arc::new(RwLock::new(
+                surplus_capturing_jit_order_owners_configuration
+                    .iter()
+                    .cloned()
+                    .map(Into::into)
+                    .collect(),
+            )),
+        };
+        if let Some(receiver) = receiver {
+            inner.listen_for_updates(receiver);
+        }
+        inner
+    }
+
+    pub async fn is_surplus_capturing_jit_order_owner(&self, owner: &Address) -> bool {
+        self.surplus_capturing_jit_order_owners
+            .read()
+            .await
+            .contains(owner)
+    }
+
+    pub async fn get_all(&self) -> Vec<Address> {
+        let owners = self.surplus_capturing_jit_order_owners.read().await;
+        owners.clone().into_iter().collect()
+    }
+
+    fn listen_for_updates(
+        &self,
+        mut receiver: broadcast::Receiver<ethcontract::Event<CowAMMProductFactoryEvent>>,
+    ) {
+        let surplus_capturing_jit_order_owners = self.surplus_capturing_jit_order_owners.clone();
+        tokio::spawn(async move {
+            loop {
+                match receiver.recv().await {
+                    Ok(event) => {
+                        if let CowAMMProductFactoryEvent::Deployed(ref deployed_event) = event.data
+                        {
+                            let mut owners = surplus_capturing_jit_order_owners.write().await;
+                            owners.insert(deployed_event.amm.into());
+                        }
+                    }
+                    Err(e) => {
+                        tracing::error!(?e, "error receiving a CoW AMM product factory event");
+                    }
+                }
+            }
+        });
+    }
+}

--- a/crates/autopilot/src/infra/solvers/dto/solve.rs
+++ b/crates/autopilot/src/infra/solvers/dto/solve.rs
@@ -1,7 +1,7 @@
 use {
     crate::{
         boundary,
-        domain,
+        domain::{self},
         infra::persistence::{dto, dto::order::Order},
     },
     chrono::{DateTime, Utc},
@@ -22,7 +22,7 @@ impl Request {
         auction: &domain::Auction,
         trusted_tokens: &HashSet<H160>,
         time_limit: Duration,
-        surplus_capturing_jit_order_owners: &HashSet<H160>,
+        surplus_capturing_jit_order_owners: Vec<H160>,
     ) -> Self {
         Self {
             id,
@@ -48,10 +48,7 @@ impl Request {
                 .unique_by(|token| token.address)
                 .collect(),
             deadline: Utc::now() + chrono::Duration::from_std(time_limit).unwrap(),
-            surplus_capturing_jit_order_owners: surplus_capturing_jit_order_owners
-                .iter()
-                .cloned()
-                .collect::<Vec<_>>(),
+            surplus_capturing_jit_order_owners,
         }
     }
 }


### PR DESCRIPTION
# Description
Follow up PR for https://github.com/cowprotocol/services/pull/2775
Implements a listener for the CoW AMM product factory events. It updates in real time the list of whitelisted owners whose surplus is counted for the score (CoW AMM onwers).

# Changes
- Added listener logic to the previous PR
- Custom struct to keep track of the surplus capturing JIT order owners

## How to test
1. Regression test from PR: https://github.com/cowprotocol/services/pull/2775
