### PR TITLE
Partial json assertion macro

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2917,6 +2917,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
+ "shared",
  "strum",
  "web3",
 ]

--- a/crates/model/Cargo.toml
+++ b/crates/model/Cargo.toml
@@ -30,4 +30,5 @@ web3 = { workspace = true, features = ["signing"] }
 
 [dev-dependencies]
 serde_json = { workspace = true }
+shared = { path = "../shared" }
 maplit = { workspace = true }

--- a/crates/model/src/auction.rs
+++ b/crates/model/src/auction.rs
@@ -58,6 +58,7 @@ mod tests {
         crate::order::{OrderMetadata, OrderUid},
         maplit::btreemap,
         serde_json::json,
+        shared::assert_json_matches,
     };
 
     #[test]
@@ -80,7 +81,7 @@ mod tests {
         };
         let auction = AuctionWithId { id: 0, auction };
 
-        assert_eq!(
+        assert_json_matches!(
             serde_json::to_value(&auction).unwrap(),
             json!({
                 "id": 0,
@@ -94,7 +95,7 @@ mod tests {
                     "0x0101010101010101010101010101010101010101": "1",
                     "0x0202020202020202020202020202020202020202": "2",
                 },
-            }),
+            })
         );
         assert_eq!(
             serde_json::from_value::<AuctionWithId>(serde_json::to_value(&auction).unwrap())

--- a/crates/model/src/order.rs
+++ b/crates/model/src/order.rs
@@ -1035,6 +1035,7 @@ mod tests {
         primitive_types::H256,
         secp256k1::{PublicKey, Secp256k1, SecretKey},
         serde_json::json,
+        shared::assert_json_matches,
         web3::signing::keccak256,
     };
 
@@ -1132,7 +1133,7 @@ mod tests {
         let deserialized: Order = serde_json::from_value(value.clone()).unwrap();
         assert_eq!(deserialized, expected);
         let serialized = serde_json::to_value(expected).unwrap();
-        assert_eq!(serialized, value);
+        assert_json_matches!(serialized, value);
     }
 
     #[test]
@@ -1195,7 +1196,7 @@ mod tests {
                 "from": from,
             });
 
-            assert_eq!(json!(order), order_json);
+            assert_json_matches!(json!(order), order_json);
             assert_eq!(order, serde_json::from_value(order_json).unwrap());
         }
     }
@@ -1216,7 +1217,7 @@ mod tests {
         let json = json!({
             "appData": hash_hex,
         });
-        assert_eq!(json!(s), json);
+        assert_json_matches!(json!(s), json);
         assert_eq!(serde_json::from_value::<S>(json).unwrap(), s);
 
         let s = S {
@@ -1227,7 +1228,7 @@ mod tests {
         let json = json!({
                 "appData": "a",
         });
-        assert_eq!(json!(s), json);
+        assert_json_matches!(json!(s), json);
         assert_eq!(serde_json::from_value::<S>(json).unwrap(), s);
 
         let s = S {
@@ -1240,7 +1241,7 @@ mod tests {
                 "appData": "a",
                 "appDataHash": hash_hex,
         });
-        assert_eq!(json!(s), json);
+        assert_json_matches!(json!(s), json);
         assert_eq!(serde_json::from_value::<S>(json).unwrap(), s);
     }
 

--- a/crates/model/src/quote.rs
+++ b/crates/model/src/quote.rs
@@ -318,11 +318,11 @@ impl OrderQuoteRequest {
 
 #[cfg(test)]
 mod tests {
-    use {super::*, serde_json::json};
+    use {super::*, serde_json::json, shared::assert_json_matches};
 
     #[test]
     fn serialize_defaults() {
-        assert_eq!(
+        assert_json_matches!(
             json!(OrderQuoteRequest::default()),
             json!({
                 "from": "0x0000000000000000000000000000000000000000",

--- a/crates/model/src/ratio_as_decimal.rs
+++ b/crates/model/src/ratio_as_decimal.rs
@@ -63,15 +63,16 @@ mod tests {
         super::*,
         num::{BigRational, Zero},
         serde_json::{json, value::Serializer},
+        shared::assert_json_matches,
     };
 
     #[test]
     fn serializer() {
-        assert_eq!(
+        assert_json_matches!(
             serialize(&BigRational::from_float(1.2).unwrap(), Serializer).unwrap(),
             json!("1.1999999999999999555910790149937383830547332763671875")
         );
-        assert_eq!(
+        assert_json_matches!(
             serialize(
                 &BigRational::new(1.into(), 3.into()),
                 Serializer
@@ -79,11 +80,11 @@ mod tests {
             .unwrap(),
             json!("0.3333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333")
         );
-        assert_eq!(
+        assert_json_matches!(
             serialize(&BigRational::zero(), Serializer).unwrap(),
             json!("0")
         );
-        assert_eq!(
+        assert_json_matches!(
             serialize(&BigRational::new((-1).into(), 1.into()), Serializer).unwrap(),
             json!("-1")
         );

--- a/crates/model/src/signature.rs
+++ b/crates/model/src/signature.rs
@@ -422,7 +422,7 @@ impl<'de> Deserialize<'de> for EcdsaSignature {
 
 #[cfg(test)]
 mod tests {
-    use {super::*, serde_json::json};
+    use {super::*, serde_json::json, shared::assert_json_matches};
 
     #[test]
     fn onchain_signatures_cannot_recover_owners() {
@@ -550,7 +550,7 @@ mod tests {
             ),
         ] {
             assert_eq!(signature, serde_json::from_value(json.clone()).unwrap());
-            assert_eq!(json, json!(signature));
+            assert_json_matches!(json, json!(signature));
         }
     }
 

--- a/crates/model/src/solver_competition.rs
+++ b/crates/model/src/solver_competition.rs
@@ -127,7 +127,7 @@ pub enum Order {
 
 #[cfg(test)]
 mod tests {
-    use {super::*, maplit::btreemap};
+    use {super::*, maplit::btreemap, shared::assert_json_matches};
 
     #[test]
     fn serialize() {
@@ -226,7 +226,7 @@ mod tests {
         };
 
         let serialized = serde_json::to_value(&orig).unwrap();
-        assert_eq!(correct, serialized);
+        assert_json_matches!(correct, serialized);
         let deserialized: SolverCompetitionAPI = serde_json::from_value(correct).unwrap();
         assert_eq!(orig, deserialized);
     }

--- a/crates/model/src/trade.rs
+++ b/crates/model/src/trade.rs
@@ -32,7 +32,7 @@ pub struct Trade {
 
 #[cfg(test)]
 mod tests {
-    use {super::*, serde_json::json};
+    use {super::*, serde_json::json, shared::assert_json_matches};
 
     #[test]
     fn deserialization_and_back() {
@@ -65,7 +65,7 @@ mod tests {
         let deserialized: Trade = serde_json::from_value(value.clone()).unwrap();
         assert_eq!(deserialized, expected);
         let serialized = serde_json::to_value(expected).unwrap();
-        assert_eq!(serialized, value);
+        assert_json_matches!(serialized, value);
     }
 
     #[test]

--- a/crates/shared/src/lib.rs
+++ b/crates/shared/src/lib.rs
@@ -38,6 +38,7 @@ pub mod sources;
 pub mod subgraph;
 pub mod submitter_constants;
 pub mod tenderly_api;
+pub mod test_utils;
 pub mod token_info;
 pub mod token_list;
 pub mod trace_many;

--- a/crates/shared/src/sources/uniswap_v3/pool_fetching.rs
+++ b/crates/shared/src/sources/uniswap_v3/pool_fetching.rs
@@ -496,6 +496,7 @@ impl Maintaining for UniswapV3PoolFetcher {
 mod tests {
     use {
         super::*,
+        crate::assert_json_matches,
         contracts::uniswap_v3_pool::event_data::{Burn, Mint, Swap},
         ethcontract::EventMetadata,
         serde_json::json,
@@ -570,7 +571,7 @@ mod tests {
         };
 
         let serialized = serde_json::to_value(pool).unwrap();
-        assert_eq!(json, serialized);
+        assert_json_matches!(json, serialized, []);
     }
 
     #[test]

--- a/crates/shared/src/sources/uniswap_v3/pool_fetching.rs
+++ b/crates/shared/src/sources/uniswap_v3/pool_fetching.rs
@@ -571,7 +571,7 @@ mod tests {
         };
 
         let serialized = serde_json::to_value(pool).unwrap();
-        assert_json_matches!(json, serialized, []);
+        assert_json_matches!(json, serialized);
     }
 
     #[test]

--- a/crates/shared/src/tenderly_api.rs
+++ b/crates/shared/src/tenderly_api.rs
@@ -359,7 +359,7 @@ mod tests {
             "generate_access_list": true
         });
 
-        assert_json_matches!(serde_json::to_value(&request).unwrap(), json, []);
+        assert_json_matches!(serde_json::to_value(&request).unwrap(), json);
         assert_eq!(
             serde_json::from_value::<SimulationRequest>(json).unwrap(),
             request

--- a/crates/shared/src/tenderly_api.rs
+++ b/crates/shared/src/tenderly_api.rs
@@ -334,7 +334,7 @@ impl Metrics {
 
 #[cfg(test)]
 mod tests {
-    use {super::*, hex_literal::hex, serde_json::json};
+    use {super::*, crate::assert_json_matches, hex_literal::hex, serde_json::json};
 
     #[test]
     fn serialize_deserialize_simulation_request() {
@@ -359,7 +359,7 @@ mod tests {
             "generate_access_list": true
         });
 
-        assert_eq!(serde_json::to_value(&request).unwrap(), json);
+        assert_json_matches!(serde_json::to_value(&request).unwrap(), json, []);
         assert_eq!(
             serde_json::from_value::<SimulationRequest>(json).unwrap(),
             request

--- a/crates/shared/src/test_utils.rs
+++ b/crates/shared/src/test_utils.rs
@@ -246,12 +246,25 @@ mod tests {
 
     #[test]
     #[should_panic(
-        expected = "JSON did not match. Error: Mismatch at user.profile.name: String(\"Alice\") \
-                    != String(\"Bob\")\nActual JSON: {\n  \"user\": {\n    \"id\": 123,\n    \
-                    \"profile\": {\n      \"name\": \"Alice\",\n      \"timestamp\": \
-                    \"2021-01-01T12:00:00Z\"\n    }\n  }\n}\nExpected JSON: {\n  \"user\": {\n    \
-                    \"id\": 123,\n    \"profile\": {\n      \"name\": \"Bob\",\n      \
-                    \"timestamp\": \"2021-01-01T12:00:00Z\"\n    }\n  }\n}"
+        expected = r#"JSON did not match. Error: Mismatch at user.profile.name: String("Alice") != String("Bob")
+Actual JSON: {
+  "user": {
+    "id": 123,
+    "profile": {
+      "name": "Alice",
+      "timestamp": "2021-01-01T12:00:00Z"
+    }
+  }
+}
+Expected JSON: {
+  "user": {
+    "id": 123,
+    "profile": {
+      "name": "Bob",
+      "timestamp": "2021-01-01T12:00:00Z"
+    }
+  }
+}"#
     )]
     fn test_json_matches_excluding_failure() {
         let json_a = json!({
@@ -277,12 +290,24 @@ mod tests {
 
     #[test]
     #[should_panic(
-        expected = "JSON did not match. Error: Key missing in expected JSON at \
-                    user.profile.name\nActual JSON: {\n  \"user\": {\n    \"id\": 123,\n    \
-                    \"profile\": {\n      \"name\": \"Alice\",\n      \"timestamp\": \
-                    \"2021-01-01T12:00:00Z\"\n    }\n  }\n}\nExpected JSON: {\n  \"user\": {\n    \
-                    \"id\": 123,\n    \"profile\": {\n      \"timestamp\": \
-                    \"2021-01-01T12:00:00Z\"\n    }\n  }\n}"
+        expected = r#"JSON did not match. Error: Key missing in expected JSON at user.profile.name
+Actual JSON: {
+  "user": {
+    "id": 123,
+    "profile": {
+      "name": "Alice",
+      "timestamp": "2021-01-01T12:00:00Z"
+    }
+  }
+}
+Expected JSON: {
+  "user": {
+    "id": 123,
+    "profile": {
+      "timestamp": "2021-01-01T12:00:00Z"
+    }
+  }
+}"#
     )]
     fn test_json_matches_excluding_key_is_missing() {
         let json_a = json!({
@@ -306,13 +331,26 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "JSON did not match. Error: Key missing in actual JSON at \
-                               user.profile.name\nActual JSON: {\n  \"user\": {\n    \"id\": \
-                               123,\n    \"profile\": {\n      \"timestamp\": \
-                               \"2021-01-01T12:00:00Z\"\n    }\n  }\n}\nExpected JSON: {\n  \
-                               \"user\": {\n    \"id\": 123,\n    \"profile\": {\n      \
-                               \"name\": \"Alice\",\n      \"timestamp\": \
-                               \"2021-01-01T12:00:00Z\"\n    }\n  }\n}")]
+    #[should_panic(
+        expected = r#"JSON did not match. Error: Key missing in actual JSON at user.profile.name
+Actual JSON: {
+  "user": {
+    "id": 123,
+    "profile": {
+      "timestamp": "2021-01-01T12:00:00Z"
+    }
+  }
+}
+Expected JSON: {
+  "user": {
+    "id": 123,
+    "profile": {
+      "name": "Alice",
+      "timestamp": "2021-01-01T12:00:00Z"
+    }
+  }
+}"#
+    )]
     fn test_json_matches_excluding_key_is_missing_reversed() {
         let json_a = json!({
             "user": {

--- a/crates/shared/src/test_utils.rs
+++ b/crates/shared/src/test_utils.rs
@@ -1,0 +1,266 @@
+use {anyhow::anyhow, std::collections::HashSet};
+/// Asserts that two JSON values are equal, excluding specified paths.
+///
+/// This macro is used to compare two JSON values for equality while ignoring
+/// certain paths in the JSON structure. The paths to be ignored are specified
+/// as a list of dot-separated strings. If the two JSON values are not equal
+/// (excluding the ignored paths), the macro will panic with a detailed error
+/// message indicating the location of the discrepancy.
+///
+/// # Arguments
+///
+/// * `$actual` - The actual JSON value obtained in a test.
+/// * `$expected` - The expected JSON value for comparison.
+/// * `$exclude_paths` - An array of dot-separated strings specifying the paths
+///   to be ignored during comparison.
+///
+/// # Panics
+///
+/// The macro panics if the actual and expected JSON values are not equal,
+/// excluding the ignored paths.
+///
+/// # Examples
+///
+/// ```
+/// let actual = json!({"user": {"id": 1, "name": "Alice", "email": "alice@example.com"}});
+/// let expected = json!({"user": {"id": 1, "name": "Alice", "email": "bob@example.com"}});
+/// assert_json_matches!(actual, expected, ["user.email"]);
+/// ```
+#[macro_export]
+macro_rules! assert_json_matches {
+    ($actual:expr, $expected:expr, $exclude_paths:expr) => {{
+        let exclude_paths = $crate::test_utils::parse_field_paths(&$exclude_paths);
+        $crate::test_utils::json_matches_excluding(&$actual, &$expected, &exclude_paths)
+            .expect("JSON did not match with the exclusion of specified paths");
+    }};
+}
+
+/// Parses dot-separated field paths into a set of paths.
+pub fn parse_field_paths(paths: &[&str]) -> HashSet<Vec<String>> {
+    paths
+        .iter()
+        .map(|path| path.split('.').map(String::from).collect())
+        .collect()
+}
+
+/// Recursively compares two JSON values, excluding specified paths, and returns
+/// detailed errors using anyhow.
+pub fn json_matches_excluding(
+    actual: &serde_json::Value,
+    expected: &serde_json::Value,
+    exclude_paths: &HashSet<Vec<String>>,
+) -> anyhow::Result<()> {
+    /// A helper function that recursively compares two JSON values using
+    /// Depth-First Search (DFS) traversal. It utilizes a `current_path`
+    /// accumulator to maintain the current path within the JSON structure,
+    /// which is then compared against the `exclude_paths` parameter.
+    /// During the backtracking process, the function updates the `current_path`
+    /// accumulator to reflect the current position in the JSON structure.
+    fn compare_jsons(
+        actual: &serde_json::Value,
+        expected: &serde_json::Value,
+        exclude_paths: &HashSet<Vec<String>>,
+        current_path: &mut Vec<String>,
+    ) -> anyhow::Result<()> {
+        match (actual, expected) {
+            (serde_json::Value::Object(map_a), serde_json::Value::Object(map_b)) => {
+                let keys: HashSet<_> = map_a.keys().chain(map_b.keys()).cloned().collect();
+                for key in keys {
+                    current_path.push(key.clone());
+
+                    if exclude_paths.contains(current_path) {
+                        current_path.pop();
+                        continue;
+                    }
+
+                    match (map_a.get(&key), map_b.get(&key)) {
+                        (Some(value_a), Some(value_b)) => {
+                            if let Err(e) =
+                                compare_jsons(value_a, value_b, exclude_paths, current_path)
+                            {
+                                current_path.pop();
+                                return Err(e);
+                            }
+                        }
+                        (None, Some(_)) => {
+                            let error_msg = format!(
+                                "Key missing in actual JSON at {}",
+                                current_path.join("."),
+                            );
+                            current_path.pop();
+                            return Err(anyhow!(error_msg));
+                        }
+                        (Some(_), None) => {
+                            let error_msg = format!(
+                                "Key missing in expected JSON at {}",
+                                current_path.join("."),
+                            );
+                            current_path.pop();
+                            return Err(anyhow!(error_msg));
+                        }
+                        (None, None) => unreachable!(),
+                    }
+
+                    current_path.pop();
+                }
+                Ok(())
+            }
+            _ => {
+                if actual != expected {
+                    Err(anyhow!(
+                        "Mismatch at {}: {:?} != {:?}",
+                        current_path.join("."),
+                        actual,
+                        expected
+                    ))
+                } else {
+                    Ok(())
+                }
+            }
+        }
+    }
+
+    let mut current_path = vec![];
+    compare_jsons(actual, expected, exclude_paths, &mut current_path)
+}
+
+#[cfg(test)]
+mod tests {
+    use {super::*, maplit::hashset, serde_json::json};
+
+    #[test]
+    fn test_parse_field_paths() {
+        let paths = ["user.profile.name", "user.settings"];
+        let parsed_paths = parse_field_paths(&paths);
+        let expected_paths: HashSet<Vec<String>> = hashset! {
+            vec!["user".to_string(), "profile".to_string(), "name".to_string()],
+            vec!["user".to_string(), "settings".to_string()],
+        };
+        assert_eq!(parsed_paths, expected_paths)
+    }
+
+    #[test]
+    fn test_json_matches_excluding_no_exclusions() {
+        let json_a = json!({
+            "user": {
+                "id": 123,
+                "profile": {
+                    "name": "Alice"
+                }
+            }
+        });
+        let json_b = json!({
+            "user": {
+                "id": 123,
+                "profile": {
+                    "name": "Alice"
+                }
+            }
+        });
+        assert_json_matches!(json_a, json_b, [])
+    }
+
+    #[test]
+    fn test_json_matches_excluding_with_exclusions() {
+        let json_a = json!({
+            "user": {
+                "id": 123,
+                "profile": {
+                    "name": "Alice",
+                    "timestamp": "2021-01-01T12:00:00Z"
+                },
+                "enabled": true,
+            }
+        });
+        let json_b = json!({
+            "user": {
+                "id": 123,
+                "profile": {
+                    "name": "Alice",
+                    "timestamp": "2022-01-01T12:00:00Z"
+                },
+                "enabled": false,
+            }
+        });
+        assert_json_matches!(json_a, json_b, ["user.profile.timestamp", "user.enabled"])
+    }
+
+    #[test]
+    #[should_panic(
+        expected = "JSON did not match with the exclusion of specified paths: Mismatch at \
+                    user.profile.name: String(\"Alice\") != String(\"Bob\")"
+    )]
+    fn test_json_matches_excluding_failure() {
+        let json_a = json!({
+            "user": {
+                "id": 123,
+                "profile": {
+                    "name": "Alice",
+                    "timestamp": "2021-01-01T12:00:00Z"
+                }
+            }
+        });
+        let json_b = json!({
+            "user": {
+                "id": 123,
+                "profile": {
+                    "name": "Bob",
+                    "timestamp": "2021-01-01T12:00:00Z"
+                }
+            }
+        });
+        assert_json_matches!(json_a, json_b, [])
+    }
+
+    #[test]
+    #[should_panic(
+        expected = "JSON did not match with the exclusion of specified paths: Key missing in \
+                    expected JSON at user.profile.name"
+    )]
+    fn test_json_matches_excluding_key_is_missing() {
+        let json_a = json!({
+            "user": {
+                "id": 123,
+                "profile": {
+                    "name": "Alice",
+                    "timestamp": "2021-01-01T12:00:00Z"
+                }
+            }
+        });
+        let json_b = json!({
+            "user": {
+                "id": 123,
+                "profile": {
+                    "timestamp": "2021-01-01T12:00:00Z"
+                }
+            }
+        });
+        assert_json_matches!(json_a, json_b, [])
+    }
+
+    #[test]
+    #[should_panic(
+        expected = "JSON did not match with the exclusion of specified paths: Key missing in \
+                    actual JSON at user.profile.name"
+    )]
+    fn test_json_matches_excluding_key_is_missing_reversed() {
+        let json_a = json!({
+            "user": {
+                "id": 123,
+                "profile": {
+                    "timestamp": "2021-01-01T12:00:00Z"
+                }
+            }
+        });
+        let json_b = json!({
+            "user": {
+                "id": 123,
+                "profile": {
+                    "name": "Alice",
+                    "timestamp": "2021-01-01T12:00:00Z"
+                }
+            }
+        });
+        assert_json_matches!(json_a, json_b, [])
+    }
+}

--- a/crates/shared/src/test_utils.rs
+++ b/crates/shared/src/test_utils.rs
@@ -22,9 +22,9 @@ use {anyhow::anyhow, std::collections::HashSet};
 /// # Examples
 ///
 /// ```
-/// let actual = json!({"user": {"id": 1, "name": "Alice", "email": "alice@example.com"}});
-/// let expected = json!({"user": {"id": 1, "name": "Alice", "email": "bob@example.com"}});
-/// assert_json_matches!(actual, expected, ["user.email"]);
+/// let actual = serde_json::json!({"user": {"id": 1, "name": "Alice", "email": "alice@example.com"}});
+/// let expected = serde_json::json!({"user": {"id": 1, "name": "Alice", "email": "bob@example.com"}});
+/// shared::assert_json_matches!(actual, expected, ["user.email"]);
 /// ```
 #[macro_export]
 macro_rules! assert_json_matches {


### PR DESCRIPTION
[As suggested in another PR](https://github.com/gnosis/solvers/pull/39#discussion_r1645701146), extracts partial json assertion macro into the `shared` crate to use across crates/repos.

> This pull request's key enhancement is the introduction of macros for partially asserting the contents of POST requests. This method allows us to validate the request structure and static fields while excluding the dynamically generated random values from the assertion checks.

Also, this macro produces meaningful error instead of generic `left json is not equal to right json`, which saves some time when dealing with json structure changes and failing tests.

Once merged, [this PR](https://github.com/gnosis/solvers/pull/39) can be closed.