### PR TITLE
(Proposal):  Remove additional_deadline_for_rewards

### DIFF
--- a/crates/autopilot/src/arguments.rs
+++ b/crates/autopilot/src/arguments.rs
@@ -160,13 +160,6 @@ pub struct Arguments {
     #[clap(long, env, default_value = "5")]
     pub submission_deadline: usize,
 
-    /// The maximum number of blocks to wait for a settlement to appear on
-    /// chain, in addition to the submission deadline. This is used to ensure
-    /// that the settlement mined at the very end on the deadline and reorged,
-    /// is still considered for payout.
-    #[clap(long, env, default_value = "5")]
-    pub additional_deadline_for_rewards: usize,
-
     /// The amount of time that the autopilot waits looking for a settlement
     /// transaction onchain after the driver acknowledges the receipt of a
     /// settlement.
@@ -258,7 +251,6 @@ impl std::fmt::Display for Arguments {
             trusted_tokens_update_interval,
             drivers,
             submission_deadline,
-            additional_deadline_for_rewards,
             shadow,
             solve_deadline,
             fee_policies,
@@ -317,11 +309,6 @@ impl std::fmt::Display for Arguments {
         )?;
         display_list(f, "drivers", drivers.iter())?;
         writeln!(f, "submission_deadline: {}", submission_deadline)?;
-        writeln!(
-            f,
-            "additional_deadline_for_rewards: {}",
-            additional_deadline_for_rewards
-        )?;
         display_option(f, "shadow", shadow)?;
         writeln!(f, "solve_deadline: {:?}", solve_deadline)?;
         writeln!(f, "fee_policies: {:?}", fee_policies)?;

--- a/crates/autopilot/src/run.rs
+++ b/crates/autopilot/src/run.rs
@@ -497,7 +497,6 @@ pub async fn run(args: Arguments) {
             .collect(),
         market_makable_token_list,
         submission_deadline: args.submission_deadline as u64,
-        additional_deadline_for_rewards: args.additional_deadline_for_rewards as u64,
         max_settlement_transaction_wait: args.max_settlement_transaction_wait,
         solve_deadline: args.solve_deadline,
         in_flight_orders: Default::default(),

--- a/crates/autopilot/src/run_loop.rs
+++ b/crates/autopilot/src/run_loop.rs
@@ -47,7 +47,6 @@ pub struct RunLoop {
     pub solvable_orders_cache: Arc<SolvableOrdersCache>,
     pub market_makable_token_list: AutoUpdatingTokenList,
     pub submission_deadline: u64,
-    pub additional_deadline_for_rewards: u64,
     pub max_settlement_transaction_wait: Duration,
     pub solve_deadline: Duration,
     pub in_flight_orders: Arc<Mutex<Option<InFlightOrders>>>,
@@ -166,9 +165,7 @@ impl RunLoop {
 
             let mut prices = BTreeMap::new();
             let mut fee_policies = Vec::new();
-            let block_deadline = competition_simulation_block
-                + self.submission_deadline
-                + self.additional_deadline_for_rewards;
+            let block_deadline = competition_simulation_block + self.submission_deadline;
             let call_data = revealed.calldata.internalized.clone();
             let uninternalized_call_data = revealed.calldata.uninternalized.clone();
 


### PR DESCRIPTION
# Description
It seems the field `additional_deadline_for_rewards` is not used anywhere. It is used to calculate the `block_deadline` which is stored in the database as part of the competition. But it seems it has no other effect. Maybe is it legacy code?

# Changes
Fully remove `additional_deadline_for_rewards`.

## How to test
1. Regression tests