### PR TITLE
Tokio console

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[build]
+rustflags = ["--cfg", "tokio_unstable"]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1267,6 +1267,44 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b6a852b24ab71dffc585bcb46eaf7959d175cb865a7152e35b348d1b2960422"
 
 [[package]]
+name = "console-api"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a257c22cd7e487dd4a13d413beabc512c5052f0bc048db0da6a84c3d8a6142fd"
+dependencies = [
+ "futures-core",
+ "prost",
+ "prost-types",
+ "tonic",
+ "tracing-core",
+]
+
+[[package]]
+name = "console-subscriber"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31c4cc54bae66f7d9188996404abdf7fdfa23034ef8e43478c8810828abad758"
+dependencies = [
+ "console-api",
+ "crossbeam-channel",
+ "crossbeam-utils",
+ "futures-task",
+ "hdrhistogram",
+ "humantime",
+ "prost",
+ "prost-types",
+ "serde",
+ "serde_json",
+ "thread_local",
+ "tokio",
+ "tokio-stream",
+ "tonic",
+ "tracing",
+ "tracing-core",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1395,6 +1433,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33480d6946193aa8033910124896ca395333cae7e2d1113d1fef6c3272217df2"
+dependencies = [
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -2234,6 +2281,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "hdrhistogram"
+version = "7.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "765c9198f173dd59ce26ff9f95ef0aafd0a0fe01fb9d72841bc5066a4c06511d"
+dependencies = [
+ "base64 0.21.7",
+ "byteorder",
+ "flate2",
+ "nom",
+ "num-traits",
+]
+
+[[package]]
 name = "headers"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2469,6 +2529,18 @@ dependencies = [
  "rustls-native-certs",
  "tokio",
  "tokio-rustls 0.24.1",
+]
+
+[[package]]
+name = "hyper-timeout"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbb958482e8c7be4bc3cf272a766a2b0bf1a6755e7a6ae777f017a31d11b13b1"
+dependencies = [
+ "hyper",
+ "pin-project-lite",
+ "tokio",
+ "tokio-io-timeout",
 ]
 
 [[package]]
@@ -3112,6 +3184,7 @@ name = "observe"
 version = "0.1.0"
 dependencies = [
  "atty",
+ "console-subscriber",
  "futures",
  "once_cell",
  "pin-project-lite",
@@ -3497,6 +3570,38 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "prost"
+version = "0.12.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "deb1435c188b76130da55f17a466d252ff7b1418b2ad3e037d127b94e3411f29"
+dependencies = [
+ "bytes",
+ "prost-derive",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.12.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81bddcdb20abf9501610992b6759a4c888aef7d1a7247ef75e2404275ac24af1"
+dependencies = [
+ "anyhow",
+ "itertools 0.12.1",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.66",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.12.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9091c90b0a32608e984ff2fa4091273cbdd755d54935c51d520887f4a1dbd5b0"
+dependencies = [
+ "prost",
 ]
 
 [[package]]
@@ -4797,7 +4902,18 @@ dependencies = [
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
+ "tracing",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "tokio-io-timeout"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30b74022ada614a1b4834de765f9bb43877f910cc8ce4be40e89042c9223a8bf"
+dependencies = [
+ "pin-project-lite",
+ "tokio",
 ]
 
 [[package]]
@@ -4914,6 +5030,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "tonic"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76c4eb7a4e9ef9d4763600161f12f5070b92a578e1b634db88a6887844c91a13"
+dependencies = [
+ "async-stream",
+ "async-trait",
+ "axum",
+ "base64 0.21.7",
+ "bytes",
+ "h2",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "hyper",
+ "hyper-timeout",
+ "percent-encoding",
+ "pin-project",
+ "prost",
+ "tokio",
+ "tokio-stream",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
 name = "tower"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4921,9 +5064,13 @@ checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
 dependencies = [
  "futures-core",
  "futures-util",
+ "indexmap 1.9.3",
  "pin-project",
  "pin-project-lite",
+ "rand",
+ "slab",
  "tokio",
+ "tokio-util",
  "tower-layer",
  "tower-service",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ tempfile = "3.10.1"
 time = { version = "0.3.36", features = ["macros"] }
 thiserror = "1.0.61"
 toml = "0.8.14"
-tokio = "1.38.0"
+tokio = { version = "1.38.0", features = ["tracing"] }
 tokio-stream = { version = "0.1.15", features = ["sync"] }
 tracing = "0.1.40"
 tracing-subscriber = "0.3.18"

--- a/README.md
+++ b/README.md
@@ -117,6 +117,17 @@ ANVIL_IP_ADDR=0.0.0.0 anvil \
   --timestamp 1577836800
 ```
 
+### Profiling
+
+In order to attach [tokio-console](https://github.com/tokio-rs/console) to the running process, compile the binary using `RUSTFLAGS="--cfg tokio_unstable"`.
+
+Then in another shell, simply run
+
+```
+cargo install --locked tokio-console
+tokio-console
+```
+
 ## Running the Services Locally
 
 ### Prerequisites

--- a/README.md
+++ b/README.md
@@ -119,9 +119,9 @@ ANVIL_IP_ADDR=0.0.0.0 anvil \
 
 ### Profiling
 
-In order to attach [tokio-console](https://github.com/tokio-rs/console) to the running process, compile the binary using `RUSTFLAGS="--cfg tokio_unstable"`.
+The most important binaries support [tokio-console](https://github.com/tokio-rs/console) to allow you a could look inside the tokio runtime.
 
-Then in another shell, simply run
+Simply enable the feature by passing `--enable-tokio-console true` when running a binary and then in another shell, run
 
 ```
 cargo install --locked tokio-console

--- a/crates/alerter/src/lib.rs
+++ b/crates/alerter/src/lib.rs
@@ -382,7 +382,7 @@ struct Arguments {
 
 pub async fn start(args: impl Iterator<Item = String>) {
     let args = Arguments::parse_from(args);
-    observe::tracing::initialize("alerter=debug", tracing::Level::ERROR.into());
+    observe::tracing::initialize("alerter=debug", tracing::Level::ERROR.into(), false);
     observe::panic_hook::install();
     observe::metrics::setup_registry(Some("gp_v2_alerter".to_string()), None);
     tracing::info!("running alerter with {:#?}", args);

--- a/crates/autopilot/src/run.rs
+++ b/crates/autopilot/src/run.rs
@@ -101,6 +101,7 @@ pub async fn start(args: impl Iterator<Item = String>) {
     observe::tracing::initialize(
         args.shared.logging.log_filter.as_str(),
         args.shared.logging.log_stderr_threshold,
+        args.shared.logging.enable_tokio_console,
     );
     observe::panic_hook::install();
     tracing::info!("running autopilot with validated arguments:\n{}", args);

--- a/crates/driver/src/infra/cli.rs
+++ b/crates/driver/src/infra/cli.rs
@@ -17,6 +17,11 @@ pub struct Args {
     )]
     pub log: String,
 
+    /// Captures metrics of the tokio runtime to inspect behavior of individual
+    /// tasks.
+    #[clap(long, env, action = clap::ArgAction::Set, default_value = "false")]
+    pub enable_tokio_console: bool,
+
     /// The node RPC API endpoint.
     #[clap(long, env)]
     pub ethrpc: Url,

--- a/crates/driver/src/infra/observe/mod.rs
+++ b/crates/driver/src/infra/observe/mod.rs
@@ -1,4 +1,5 @@
-//! This module implements the observability for the driver. It exposes
+//! T
+//! his module implements the observability for the driver. It exposes
 //! functions which represent events that are meaningful to the system. These
 //! functions are called when the corresponding events occur. They log the event
 //! and update the metrics, if the event is worth measuring.
@@ -32,8 +33,8 @@ mod metrics;
 
 /// Setup the observability. The log argument configures the tokio tracing
 /// framework.
-pub fn init(log: &str) {
-    observe::tracing::initialize_reentrant(log);
+pub fn init(log: &str, with_tokio_console: bool) {
+    observe::tracing::initialize_reentrant(log, with_tokio_console);
     metrics::init();
 }
 

--- a/crates/driver/src/infra/observe/mod.rs
+++ b/crates/driver/src/infra/observe/mod.rs
@@ -1,5 +1,4 @@
-//! T
-//! his module implements the observability for the driver. It exposes
+//! This module implements the observability for the driver. It exposes
 //! functions which represent events that are meaningful to the system. These
 //! functions are called when the corresponding events occur. They log the event
 //! and update the metrics, if the event is worth measuring.

--- a/crates/driver/src/run.rs
+++ b/crates/driver/src/run.rs
@@ -42,7 +42,7 @@ pub async fn run(
 /// Run the driver. This function exists to avoid multiple monomorphizations of
 /// the `run` code, which bloats the binaries and increases compile times.
 async fn run_with(args: cli::Args, addr_sender: Option<oneshot::Sender<SocketAddr>>) {
-    crate::infra::observe::init(&args.log);
+    crate::infra::observe::init(&args.log, args.enable_tokio_console);
 
     let ethrpc = ethrpc(&args).await;
     let web3 = ethrpc.web3().clone();

--- a/crates/driver/src/tests/setup/mod.rs
+++ b/crates/driver/src/tests/setup/mod.rs
@@ -751,6 +751,7 @@ impl Setup {
     pub async fn done(self) -> Test {
         observe::tracing::initialize_reentrant(
             "driver=trace,driver::tests::setup::blockchain=debug",
+            false,
         );
 
         if let Some(name) = self.name.as_ref() {

--- a/crates/e2e/src/setup/mod.rs
+++ b/crates/e2e/src/setup/mod.rs
@@ -158,7 +158,7 @@ async fn run<F, Fut, T>(
     Fut: Future<Output = ()>,
     T: AsRef<str>,
 {
-    observe::tracing::initialize_reentrant(&with_default_filters(filters).join(","));
+    observe::tracing::initialize_reentrant(&with_default_filters(filters).join(","), false);
     observe::panic_hook::install();
 
     // The mutex guarantees that no more than a test at a time is running on

--- a/crates/ethrpc/src/current_block/mod.rs
+++ b/crates/ethrpc/src/current_block/mod.rs
@@ -323,7 +323,7 @@ mod tests {
     #[tokio::test]
     #[ignore]
     async fn mainnet() {
-        observe::tracing::initialize_reentrant("shared=debug");
+        observe::tracing::initialize_reentrant("shared=debug", false);
         let node = std::env::var("NODE_URL").unwrap().parse().unwrap();
         let receiver = current_block_stream(node, Duration::from_secs(1))
             .await

--- a/crates/observe/Cargo.toml
+++ b/crates/observe/Cargo.toml
@@ -6,7 +6,8 @@ edition = "2021"
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-atty = "0.2.14"
+atty = "0.2"
+console-subscriber = "0.3.0"
 futures = { workspace = true }
 once_cell = { workspace = true }
 pin-project-lite = "0.2.14"

--- a/crates/observe/src/panic_hook.rs
+++ b/crates/observe/src/panic_hook.rs
@@ -37,7 +37,7 @@ mod tests {
     #[test]
     #[ignore]
     fn manual_thread() {
-        crate::tracing::initialize("info", tracing::level_filters::LevelFilter::OFF);
+        crate::tracing::initialize("info", tracing::level_filters::LevelFilter::OFF, false);
 
         // Should print panic trace log but not kill the process.
         let handle = std::thread::spawn(|| panic!("you should see this message"));
@@ -55,7 +55,7 @@ mod tests {
     #[tokio::test(flavor = "multi_thread")]
     #[ignore]
     async fn manual_tokio() {
-        crate::tracing::initialize("info", tracing::level_filters::LevelFilter::OFF);
+        crate::tracing::initialize("info", tracing::level_filters::LevelFilter::OFF, false);
 
         let handle = tokio::task::spawn(async { panic!("you should see this message") });
         assert!(handle.await.is_err());

--- a/crates/orderbook/src/ipfs.rs
+++ b/crates/orderbook/src/ipfs.rs
@@ -89,7 +89,7 @@ mod tests {
     #[tokio::test]
     #[ignore]
     async fn not_found() {
-        observe::tracing::initialize_reentrant("orderbook::ipfs=trace");
+        observe::tracing::initialize_reentrant("orderbook::ipfs=trace", false);
         let ipfs = Ipfs::new(Default::default(), "https://ipfs.io".parse().unwrap(), None);
         let cid = "Qma4Dwke5h8mgJyZMDRvKqM3RF7c6Mxcj3fR4um9UGaNF7";
         let result = ipfs.fetch(cid).await.unwrap();

--- a/crates/orderbook/src/run.rs
+++ b/crates/orderbook/src/run.rs
@@ -53,6 +53,7 @@ pub async fn start(args: impl Iterator<Item = String>) {
     observe::tracing::initialize(
         args.shared.logging.log_filter.as_str(),
         args.shared.logging.log_stderr_threshold,
+        args.shared.logging.enable_tokio_console,
     );
     tracing::info!("running order book with validated arguments:\n{}", args);
     observe::panic_hook::install();

--- a/crates/refunder/src/lib.rs
+++ b/crates/refunder/src/lib.rs
@@ -25,6 +25,7 @@ pub async fn start(args: impl Iterator<Item = String>) {
     observe::tracing::initialize(
         args.logging.log_filter.as_str(),
         args.logging.log_stderr_threshold,
+        args.logging.enable_tokio_console,
     );
     observe::panic_hook::install();
     tracing::info!("running refunder with validated arguments:\n{}", args);

--- a/crates/shared/src/arguments.rs
+++ b/crates/shared/src/arguments.rs
@@ -34,6 +34,11 @@ macro_rules! logging_args_with_default_filter {
 
             #[clap(long, env, default_value = "error")]
             pub log_stderr_threshold: LevelFilter,
+
+            /// Captures metrics of the tokio runtime to inspect behavior of individual
+            /// tasks.
+            #[clap(long, env, action = clap::ArgAction::Set, default_value = "false")]
+            pub enable_tokio_console: bool,
         }
 
         impl ::std::fmt::Display for $struct_name {
@@ -41,10 +46,12 @@ macro_rules! logging_args_with_default_filter {
                 let Self {
                     log_filter,
                     log_stderr_threshold,
+                    enable_tokio_console,
                 } = self;
 
                 writeln!(f, "log_filter: {}", log_filter)?;
                 writeln!(f, "log_stderr_threshold: {}", log_stderr_threshold)?;
+                writeln!(f, "enable_tokio_console: {}", enable_tokio_console)?;
                 Ok(())
             }
         }

--- a/crates/shared/src/bad_token/trace_call.rs
+++ b/crates/shared/src/bad_token/trace_call.rs
@@ -693,7 +693,7 @@ mod tests {
     #[tokio::test]
     #[ignore]
     async fn mainnet_univ3() {
-        observe::tracing::initialize_reentrant("shared=debug");
+        observe::tracing::initialize_reentrant("shared=debug", false);
         let http = create_env_test_transport();
         let web3 = Web3::new(http);
         let base_tokens = vec![testlib::tokens::WETH];

--- a/crates/shared/src/maintenance.rs
+++ b/crates/shared/src/maintenance.rs
@@ -214,7 +214,7 @@ mod tests {
 
     #[tokio::test]
     async fn block_stream_retries_failed_blocks() {
-        observe::tracing::initialize("debug", tracing::Level::ERROR.into());
+        observe::tracing::initialize("debug", tracing::Level::ERROR.into(), false);
 
         let mut mock_maintenance = MockMaintaining::new();
         let mut sequence = Sequence::new();

--- a/crates/solvers/src/infra/cli.rs
+++ b/crates/solvers/src/infra/cli.rs
@@ -17,6 +17,11 @@ pub struct Args {
     )]
     pub log: String,
 
+    /// Captures metrics of the tokio runtime to inspect behavior of individual
+    /// tasks.
+    #[clap(long, env, action = clap::ArgAction::Set, default_value = "false")]
+    pub enable_tokio_console: bool,
+
     /// The socket address to bind to.
     #[arg(long, env, default_value = "127.0.0.1:7872")]
     pub addr: SocketAddr,

--- a/crates/solvers/src/run.rs
+++ b/crates/solvers/src/run.rs
@@ -25,7 +25,7 @@ pub async fn run(
 }
 
 async fn run_with(args: cli::Args, bind: Option<oneshot::Sender<SocketAddr>>) {
-    observe::tracing::initialize_reentrant(&args.log);
+    observe::tracing::initialize_reentrant(&args.log, args.enable_tokio_console);
     tracing::info!("running solver engine with {args:#?}");
 
     let solver = match args.command {


### PR DESCRIPTION
# Description
This PR attempts to bring back the [tokio console](https://github.com/tokio-rs/console) integration from https://github.com/cowprotocol/services/pull/1915 which can be useful to debug specific tasks.
The first time we tried to add the tokio console we no longer saw all the logs. They got drop mysteriously. Since then a lot of time has passed and possibly this is no longer an issue. To stay on the cautious side I changed the original PR to make the console an opt-in feature. That way we don't have to recompile the whole binary and redeploy it. We just have to remove the `--enable-tokio-console true` flag.

BTW if you are running `tmux` and it doesn't look like on the screenshots (e.g. graphs in the detail views are missing) the culprit is likely a misconfiguration in your `.tmux.config` file.

## How to test
* install tui with `cargo install --locked tokio-console`
* run for example orderbook with `--enable-tokio-console`
* run `tokio-console`
* enjoy information about each active task

<img width="858" alt="Screenshot 2024-06-28 at 12 37 03" src="https://github.com/cowprotocol/services/assets/19190235/dcc36470-44c3-4bd5-8585-c6e4b0b25cc3">
<img width="865" alt="Screenshot 2024-06-28 at 12 37 11" src="https://github.com/cowprotocol/services/assets/19190235/4df40cfd-0362-4dbe-b412-eaf261d58dca">
