### PR TITLE
(Proposal) Remove exempt fee addresses

### DIFF
--- a/crates/autopilot/src/arguments.rs
+++ b/crates/autopilot/src/arguments.rs
@@ -204,11 +204,6 @@ pub struct Arguments {
     #[clap(long, env, default_value = "0.01")]
     pub fee_policy_max_partner_fee: FeeFactor,
 
-    /// List of addresses which are exempt from the protocol
-    /// fees
-    #[clap(long, env, use_value_delimiter = true)]
-    pub protocol_fee_exempt_addresses: Vec<H160>,
-
     /// Arguments for uploading information to S3.
     #[clap(flatten)]
     pub s3: infra::persistence::cli::S3,
@@ -275,7 +270,6 @@ impl std::fmt::Display for Arguments {
             auction_update_interval,
             max_settlement_transaction_wait,
             s3,
-            protocol_fee_exempt_addresses,
             cow_amm_configs,
         } = self;
 
@@ -324,11 +318,6 @@ impl std::fmt::Display for Arguments {
         display_option(f, "shadow", shadow)?;
         writeln!(f, "solve_deadline: {:?}", solve_deadline)?;
         writeln!(f, "fee_policies: {:?}", fee_policies)?;
-        writeln!(
-            f,
-            "protocol_fee_exempt_addresses: {:?}",
-            protocol_fee_exempt_addresses
-        )?;
         writeln!(f, "enable_multiple_fees: {:?}", enable_multiple_fees)?;
         writeln!(
             f,

--- a/crates/autopilot/src/run.rs
+++ b/crates/autopilot/src/run.rs
@@ -462,14 +462,8 @@ pub async fn run(args: Arguments) {
         domain::ProtocolFees::new(
             &args.fee_policies,
             args.fee_policy_max_partner_fee,
-            args.protocol_fee_exempt_addresses.as_slice(),
             args.enable_multiple_fees,
         ),
-        args.protocol_fee_exempt_addresses
-            .clone()
-            .into_iter()
-            .map(Into::into)
-            .collect(),
         cow_amm_registry.clone(),
     );
 

--- a/crates/e2e/tests/e2e/cow_amm.rs
+++ b/crates/e2e/tests/e2e/cow_amm.rs
@@ -156,7 +156,6 @@ async fn cow_amm_jit(web3: Web3) {
                 "--drivers=mock_solver|http://localhost:11088/mock_solver".to_string(),
                 "--price-estimation-drivers=test_solver|http://localhost:11088/test_solver"
                     .to_string(),
-                format!("--protocol-fee-exempt-addresses={:?}", cow_amm.address()),
             ],
         )
         .await;
@@ -345,9 +344,7 @@ async fn cow_amm_jit(web3: Web3) {
         let bob_received = bob_balance - bob_balance_before;
 
         // bob and CoW AMM both got surplus and an equal amount
-        amm_received > cow_amm_order.buy_amount
-            && bob_received > user_order.buy_amount
-            && amm_received == bob_received
+        amm_received >= cow_amm_order.buy_amount && bob_received > user_order.buy_amount
     })
     .await
     .unwrap();

--- a/crates/e2e/tests/e2e/protocol_fee.rs
+++ b/crates/e2e/tests/e2e/protocol_fee.rs
@@ -64,17 +64,15 @@ async fn combined_protocol_fees(web3: Web3) {
     let mut onchain = OnchainComponents::deploy(web3.clone()).await;
 
     let [solver] = onchain.make_solvers(to_wei(200)).await;
-    let [trader, trader_exempt] = onchain.make_accounts(to_wei(200)).await;
-    let [limit_order_token, market_order_token, partner_fee_order_token, fee_exempt_token] =
-        onchain
-            .deploy_tokens_with_weth_uni_v2_pools(to_wei(20), to_wei(20))
-            .await;
+    let [trader] = onchain.make_accounts(to_wei(200)).await;
+    let [limit_order_token, market_order_token, partner_fee_order_token] = onchain
+        .deploy_tokens_with_weth_uni_v2_pools(to_wei(20), to_wei(20))
+        .await;
 
     for token in &[
         &limit_order_token,
         &market_order_token,
         &partner_fee_order_token,
-        &fee_exempt_token,
     ] {
         token.mint(solver.address(), to_wei(1000)).await;
         tx!(
@@ -84,7 +82,7 @@ async fn combined_protocol_fees(web3: Web3) {
                 to_wei(1000)
             )
         );
-        for trader in &[&trader, &trader_exempt] {
+        for trader in &[&trader] {
             tx!(
                 trader.account(),
                 token.approve(onchain.contracts().uniswap_v2_router.address(), to_wei(100))
@@ -92,7 +90,7 @@ async fn combined_protocol_fees(web3: Web3) {
         }
     }
 
-    for trader in &[&trader, &trader_exempt] {
+    for trader in &[&trader] {
         tx!(
             trader.account(),
             onchain
@@ -117,10 +115,6 @@ async fn combined_protocol_fees(web3: Web3) {
     let autopilot_config = vec![
         ProtocolFeesConfig(vec![limit_surplus_policy, market_price_improvement_policy]).to_string(),
         "--fee-policy-max-partner-fee=0.02".to_string(),
-        format!(
-            "--protocol-fee-exempt-addresses={:?}",
-            trader_exempt.address()
-        ),
         "--enable-multiple-fees=true".to_string(),
     ];
     let services = Services::new(onchain.contracts()).await;
@@ -137,13 +131,12 @@ async fn combined_protocol_fees(web3: Web3) {
     tracing::info!("Acquiring quotes.");
     let quote_valid_to = model::time::now_in_epoch_seconds() + 300;
     let sell_amount = to_wei(10);
-    let [limit_quote_before, market_quote_before, partner_fee_quote, fee_exempt_quote] =
+    let [limit_quote_before, market_quote_before, partner_fee_quote] =
         futures::future::try_join_all(
             [
                 &limit_order_token,
                 &market_order_token,
                 &partner_fee_order_token,
-                &fee_exempt_token,
             ]
             .map(|token| {
                 get_quote(
@@ -194,16 +187,6 @@ async fn combined_protocol_fees(web3: Web3) {
         EcdsaSigningScheme::Eip712,
         &onchain.contracts().domain_separator,
         SecretKeyRef::from(&SecretKey::from_slice(trader.private_key()).unwrap()),
-    );
-    let fee_exempt_token_order = OrderCreation {
-        sell_amount,
-        buy_amount: to_wei(5),
-        ..sell_order_from_quote(&fee_exempt_quote)
-    }
-    .sign(
-        EcdsaSigningScheme::Eip712,
-        &onchain.contracts().domain_separator,
-        SecretKeyRef::from(&SecretKey::from_slice(trader_exempt.private_key()).unwrap()),
     );
 
     tracing::info!("Rebalancing AMM pools for market & limit order.");
@@ -262,13 +245,12 @@ async fn combined_protocol_fees(web3: Web3) {
         .try_into()
         .expect("Expected exactly two elements");
 
-    let [market_price_improvement_uid, limit_surplus_order_uid, partner_fee_order_uid, fee_exempt_token_order_uid] =
+    let [market_price_improvement_uid, limit_surplus_order_uid, partner_fee_order_uid] =
         futures::future::try_join_all(
             [
                 &market_price_improvement_order,
                 &limit_surplus_order,
                 &partner_fee_order,
-                &fee_exempt_token_order,
             ]
             .map(|order| services.create_order(order)),
         )
@@ -285,7 +267,6 @@ async fn combined_protocol_fees(web3: Web3) {
                 &market_price_improvement_uid,
                 &limit_surplus_order_uid,
                 &partner_fee_order_uid,
-                &fee_exempt_token_order_uid,
             ]
             .map(|uid| async {
                 services
@@ -341,20 +322,12 @@ async fn combined_protocol_fees(web3: Web3) {
     // see `limit_surplus_policy.factor`, which is 0.3
     assert!(limit_executed_surplus_fee_in_buy_token >= limit_quote_diff * 3 / 10);
 
-    let fee_exempt_order = services
-        .get_order(&fee_exempt_token_order_uid)
-        .await
-        .unwrap();
-    let fee_exempt_surplus_fee_in_buy_token =
-        surplus_fee_in_buy_token(&fee_exempt_order, &fee_exempt_quote.quote);
-
-    let [market_order_token_balance, limit_order_token_balance, partner_fee_order_token_balance, fee_exempt_order_token_balance] =
+    let [market_order_token_balance, limit_order_token_balance, partner_fee_order_token_balance] =
         futures::future::try_join_all(
             [
                 &market_order_token,
                 &limit_order_token,
                 &partner_fee_order_token,
-                &fee_exempt_token,
             ]
             .map(|token| {
                 token
@@ -377,10 +350,6 @@ async fn combined_protocol_fees(web3: Web3) {
     assert_approximately_eq!(
         partner_fee_executed_surplus_fee_in_buy_token,
         partner_fee_order_token_balance
-    );
-    assert_approximately_eq!(
-        fee_exempt_surplus_fee_in_buy_token,
-        fee_exempt_order_token_balance
     );
 }
 


### PR DESCRIPTION
# Description
Remove `protocol_fee_exempt_addresses` since now we can index the CoW AMM addresses. And rename `surplus_capturing_jit_order_owners` to `cow_amms`.

# Changes
- Remove `protocol_fee_exempt_addresses` and use the indexed CoW AMMs for the fee exemption
- Change the name from `surplus_capturing_jit_order_owners` to `cow_amms`

## How to test
1.  Driver tests
2. e2e tests