### PR TITLE
Pass CoW AMM configs via args

### DIFF
--- a/crates/autopilot/src/arguments.rs
+++ b/crates/autopilot/src/arguments.rs
@@ -222,6 +222,17 @@ pub struct Arguments {
     /// `order_events` database table.
     #[clap(long, env, default_value = "30d", value_parser = humantime::parse_duration)]
     pub order_events_cleanup_threshold: Duration,
+
+    /// Configurations for indexing CoW AMMs. Supplied in the form of:
+    /// "<factory1>|<helper1>|<block1>,<factory2>|<helper2>,<block2>"
+    /// - factory is contract address emmiting CoW AMM deployment events.
+    /// - helper is a contract address to interface with pools deployed by the
+    ///   factory
+    /// - block is the block at which indexing should start (should be 1 block
+    ///   before
+    /// the deployment of the factory)
+    #[clap(long, env, use_value_delimiter = true)]
+    pub cow_amm_configs: Vec<CowAmmConfig>,
 }
 
 impl std::fmt::Display for Arguments {
@@ -265,6 +276,7 @@ impl std::fmt::Display for Arguments {
             max_settlement_transaction_wait,
             s3,
             protocol_fee_exempt_addresses,
+            cow_amm_configs,
         } = self;
 
         write!(f, "{}", shared)?;
@@ -346,6 +358,7 @@ impl std::fmt::Display for Arguments {
             max_settlement_transaction_wait
         )?;
         writeln!(f, "s3: {:?}", s3)?;
+        writeln!(f, "cow_amm_configs: {:?}", cow_amm_configs)?;
         Ok(())
     }
 }
@@ -462,6 +475,49 @@ impl FromStr for FeePolicy {
         Ok(FeePolicy {
             fee_policy_kind,
             fee_policy_order_class,
+        })
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct CowAmmConfig {
+    /// Which contract to index for CoW AMM deployment events.
+    pub factory: H160,
+    /// Which helper contract to use for interfacing with the indexed CoW AMMs.
+    pub helper: H160,
+    /// At which block indexing should start on the factory.
+    pub index_start: u64,
+}
+
+impl FromStr for CowAmmConfig {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let mut parts = s.split('|');
+        let factory = parts
+            .next()
+            .context("config is missing factory")?
+            .parse()
+            .context("could not parse factory as H160")?;
+        let helper = parts
+            .next()
+            .context("config is missing helper")?
+            .parse()
+            .context("could not parse helper as H160")?;
+        let index_start = parts
+            .next()
+            .context("context is missing index_start")?
+            .parse()
+            .context("could not parse index_start as u64")?;
+        anyhow::ensure!(
+            parts.next().is_none(),
+            "supplied too many arguments for cow amm config"
+        );
+
+        Ok(Self {
+            factory,
+            helper,
+            index_start,
         })
     }
 }

--- a/crates/autopilot/src/arguments.rs
+++ b/crates/autopilot/src/arguments.rs
@@ -506,7 +506,7 @@ impl FromStr for CowAmmConfig {
             .context("could not parse helper as H160")?;
         let index_start = parts
             .next()
-            .context("context is missing index_start")?
+            .context("config is missing index_start")?
             .parse()
             .context("could not parse index_start as u64")?;
         anyhow::ensure!(

--- a/crates/autopilot/src/infra/blockchain/contracts.rs
+++ b/crates/autopilot/src/infra/blockchain/contracts.rs
@@ -1,14 +1,8 @@
-use {
-    super::ChainId,
-    crate::domain,
-    ethcontract::{dyns::DynWeb3, errors::DeployError},
-    primitive_types::H160,
-};
+use {super::ChainId, crate::domain, ethcontract::dyns::DynWeb3, primitive_types::H160};
 
 #[derive(Debug, Clone)]
 pub struct Contracts {
     settlement: contracts::GPv2Settlement,
-    cow_amm_legacy_helper: Option<contracts::CowAmmLegacyHelper>,
     weth: contracts::WETH9,
     chainalysis_oracle: Option<contracts::ChainalysisOracle>,
 
@@ -41,12 +35,6 @@ impl Contracts {
             ),
         );
 
-        let cow_amm_legacy_helper = match contracts::CowAmmLegacyHelper::deployed(web3).await {
-            Err(DeployError::NotFound(_)) => None,
-            Err(err) => panic!("failed to find deployed contract: {:?}", err),
-            Ok(contract) => Some(contract),
-        };
-
         let weth = contracts::WETH9::at(
             web3,
             address_for(contracts::WETH9::raw_contract(), addresses.weth),
@@ -78,16 +66,11 @@ impl Contracts {
             chainalysis_oracle,
             settlement_domain_separator,
             authenticator,
-            cow_amm_legacy_helper,
         }
     }
 
     pub fn settlement(&self) -> &contracts::GPv2Settlement {
         &self.settlement
-    }
-
-    pub fn cow_amm_legacy_helper(&self) -> Option<&contracts::CowAmmLegacyHelper> {
-        self.cow_amm_legacy_helper.as_ref()
     }
 
     pub fn settlement_domain_separator(&self) -> &domain::eth::DomainSeparator {

--- a/crates/autopilot/src/run.rs
+++ b/crates/autopilot/src/run.rs
@@ -359,14 +359,11 @@ pub async fn run(args: Arguments) {
         block_retriever.clone(),
         skip_event_sync_start,
     ));
+
     let cow_amm_registry = cow_amm::Registry::new(web3.clone(), eth.current_block().clone());
-    if let Some(cow_amm_factory) = eth.contracts().cow_amm_legacy_helper() {
+    for config in &args.cow_amm_configs {
         cow_amm_registry
-            .add_listener(
-                contracts::deployment_block!(cow_amm_factory).unwrap(),
-                cow_amm_factory.address(),
-                cow_amm_factory.address(),
-            )
+            .add_listener(config.index_start, config.factory, config.helper)
             .await;
     }
 

--- a/crates/autopilot/src/run_loop.rs
+++ b/crates/autopilot/src/run_loop.rs
@@ -307,7 +307,7 @@ impl RunLoop {
     ) -> Vec<Participant<'_>> {
         let mut surplus_capturing_jit_order_owners = self
             .cow_amm_registry
-            .cow_amms()
+            .amms()
             .await
             .into_iter()
             .map(|cow_amm| *cow_amm.address())

--- a/crates/autopilot/src/solvable_orders.rs
+++ b/crates/autopilot/src/solvable_orders.rs
@@ -211,7 +211,7 @@ impl SolvableOrdersCache {
             entry.insert(weth_price);
         }
 
-        let cow_amms = self.cow_amm_registry.cow_amms().await;
+        let cow_amms = self.cow_amm_registry.amms().await;
         let cow_amm_tokens = cow_amms
             .iter()
             .flat_map(|cow_amm| cow_amm.traded_tokens())

--- a/crates/cow-amm/src/cache.rs
+++ b/crates/cow-amm/src/cache.rs
@@ -7,7 +7,7 @@ use {
     tokio::sync::RwLock,
 };
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub(crate) struct Storage(Arc<Inner>);
 
 impl Storage {
@@ -28,6 +28,7 @@ impl Storage {
     }
 }
 
+#[derive(Debug)]
 struct Inner {
     /// Store indexed data associated to the indexed events type id.
     /// That type erasure allows us to index multiple concrete contracts

--- a/crates/cow-amm/src/registry.rs
+++ b/crates/cow-amm/src/registry.rs
@@ -56,7 +56,7 @@ impl Registry {
     }
 
     /// Returns all the deployed CoW AMMs
-    pub async fn cow_amms(&self) -> Vec<Arc<Amm>> {
+    pub async fn amms(&self) -> Vec<Arc<Amm>> {
         let mut result = vec![];
         let lock = self.storage.read().await;
         for cache in &*lock {

--- a/crates/cow-amm/src/registry.rs
+++ b/crates/cow-amm/src/registry.rs
@@ -12,7 +12,7 @@ use {
 };
 
 /// CoW AMM indexer which stores events in-memory.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct Registry {
     web3: Web3,
     current_block_stream: CurrentBlockStream,

--- a/crates/driver/example.toml
+++ b/crates/driver/example.toml
@@ -32,7 +32,7 @@ use-soft-cancellations = true
 [contracts] # Optionally override the contract addresses, necessary on less popular blockchains
 gp-v2-settlement = "0x9008D19f58AAbD9eD0D60971565AA8510560ab41"
 weth = "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2"
-[contracts.cow-amms]
+[[contracts.cow-amms]]
 # address of factory creating new CoW AMMs
 factory = "0x86f3df416979136cb4fdea2c0886301b911c163b"
 # address of contract to help interfacing with the created CoW AMMs

--- a/crates/driver/example.toml
+++ b/crates/driver/example.toml
@@ -32,6 +32,13 @@ use-soft-cancellations = true
 [contracts] # Optionally override the contract addresses, necessary on less popular blockchains
 gp-v2-settlement = "0x9008D19f58AAbD9eD0D60971565AA8510560ab41"
 weth = "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2"
+[contracts.cow-amms]
+# address of factory creating new CoW AMMs
+factory = "0x86f3df416979136cb4fdea2c0886301b911c163b"
+# address of contract to help interfacing with the created CoW AMMs
+helper = "0x86f3df416979136cb4fdea2c0886301b911c163b"
+# at which block the driver should start indexing the factory (1 block before deployment)
+index-start = 20188649
 
 [liquidity]
 base-tokens = [

--- a/crates/driver/src/domain/competition/auction.rs
+++ b/crates/driver/src/domain/competition/auction.rs
@@ -346,7 +346,7 @@ impl AuctionProcessor {
         tokens: &Tokens,
         eligible_for_surplus: &HashSet<eth::Address>,
     ) -> Vec<Order> {
-        let cow_amms = eth.contracts().cow_amms().cow_amms().await;
+        let cow_amms = eth.contracts().cow_amm_registry().amms().await;
         let results: Vec<_> = futures::future::join_all(
             cow_amms
                 .into_iter()

--- a/crates/driver/src/domain/competition/auction.rs
+++ b/crates/driver/src/domain/competition/auction.rs
@@ -346,7 +346,7 @@ impl AuctionProcessor {
         tokens: &Tokens,
         eligible_for_surplus: &HashSet<eth::Address>,
     ) -> Vec<Order> {
-        let cow_amms = eth.cow_amms().await;
+        let cow_amms = eth.contracts().cow_amms().cow_amms().await;
         let results: Vec<_> = futures::future::join_all(
             cow_amms
                 .into_iter()

--- a/crates/driver/src/infra/blockchain/contracts.rs
+++ b/crates/driver/src/infra/blockchain/contracts.rs
@@ -14,7 +14,7 @@ pub struct Contracts {
 
     /// The domain separator for settlement contract used for signing orders.
     settlement_domain_separator: eth::DomainSeparator,
-    cow_amms: cow_amm::Registry,
+    cow_amm_registry: cow_amm::Registry,
 }
 
 #[derive(Debug, Default, Clone)]
@@ -64,9 +64,9 @@ impl Contracts {
                 .0,
         );
 
-        let cow_amms = cow_amm::Registry::new(web3.clone(), block_stream);
+        let cow_amm_registry = cow_amm::Registry::new(web3.clone(), block_stream);
         for config in addresses.cow_amms {
-            cow_amms
+            cow_amm_registry
                 .add_listener(config.index_start, config.factory, config.helper)
                 .await;
         }
@@ -77,7 +77,7 @@ impl Contracts {
             vault,
             weth,
             settlement_domain_separator,
-            cow_amms,
+            cow_amm_registry,
         })
     }
 
@@ -105,8 +105,8 @@ impl Contracts {
         &self.settlement_domain_separator
     }
 
-    pub fn cow_amms(&self) -> &cow_amm::Registry {
-        &self.cow_amms
+    pub fn cow_amm_registry(&self) -> &cow_amm::Registry {
+        &self.cow_amm_registry
     }
 }
 

--- a/crates/driver/src/infra/blockchain/contracts.rs
+++ b/crates/driver/src/infra/blockchain/contracts.rs
@@ -1,6 +1,7 @@
 use {
     crate::{domain::eth, infra::blockchain::Ethereum},
-    ethcontract::{dyns::DynWeb3, errors::DeployError},
+    ethcontract::dyns::DynWeb3,
+    ethrpc::current_block::CurrentBlockStream,
     thiserror::Error,
 };
 
@@ -13,13 +14,14 @@ pub struct Contracts {
 
     /// The domain separator for settlement contract used for signing orders.
     settlement_domain_separator: eth::DomainSeparator,
-    cow_amm_legacy_helper: Option<contracts::CowAmmLegacyHelper>,
+    cow_amms: cow_amm::Registry,
 }
 
-#[derive(Debug, Default, Clone, Copy)]
+#[derive(Debug, Default, Clone)]
 pub struct Addresses {
     pub settlement: Option<eth::ContractAddress>,
     pub weth: Option<eth::ContractAddress>,
+    pub cow_amms: Vec<CowAmmConfig>,
 }
 
 impl Contracts {
@@ -27,6 +29,7 @@ impl Contracts {
         web3: &DynWeb3,
         chain: eth::ChainId,
         addresses: Addresses,
+        block_stream: CurrentBlockStream,
     ) -> Result<Self, Error> {
         let address_for = |contract: &ethcontract::Contract,
                            address: Option<eth::ContractAddress>| {
@@ -61,11 +64,12 @@ impl Contracts {
                 .0,
         );
 
-        let cow_amm_legacy_helper = match contracts::CowAmmLegacyHelper::deployed(web3).await {
-            Err(DeployError::NotFound(_)) => None,
-            Err(err) => panic!("failed to find deployed contract: {:?}", err),
-            Ok(contract) => Some(contract),
-        };
+        let cow_amms = cow_amm::Registry::new(web3.clone(), block_stream);
+        for config in addresses.cow_amms {
+            cow_amms
+                .add_listener(config.index_start, config.factory, config.helper)
+                .await;
+        }
 
         Ok(Self {
             settlement,
@@ -73,7 +77,7 @@ impl Contracts {
             vault,
             weth,
             settlement_domain_separator,
-            cow_amm_legacy_helper,
+            cow_amms,
         })
     }
 
@@ -101,9 +105,19 @@ impl Contracts {
         &self.settlement_domain_separator
     }
 
-    pub fn cow_amm_legacy_helper(&self) -> Option<&contracts::CowAmmLegacyHelper> {
-        self.cow_amm_legacy_helper.as_ref()
+    pub fn cow_amms(&self) -> &cow_amm::Registry {
+        &self.cow_amms
     }
+}
+
+#[derive(Debug, Clone)]
+pub struct CowAmmConfig {
+    /// Which contract to index for CoW AMM deployment events.
+    pub factory: eth::H160,
+    /// Which helper contract to use for interfacing with the indexed CoW AMMs.
+    pub helper: eth::H160,
+    /// At which block indexing should start on the factory.
+    pub index_start: u64,
 }
 
 /// Returns the address of a contract for the specified network, or `None` if

--- a/crates/driver/src/infra/blockchain/mod.rs
+++ b/crates/driver/src/infra/blockchain/mod.rs
@@ -61,7 +61,6 @@ struct Inner {
     contracts: Contracts,
     gas: Arc<GasPriceEstimator>,
     current_block: CurrentBlockStream,
-    cow_amms: cow_amm::Registry,
 }
 
 impl Ethereum {
@@ -77,25 +76,15 @@ impl Ethereum {
         gas: Arc<GasPriceEstimator>,
     ) -> Self {
         let Rpc { web3, chain, url } = rpc;
-        let contracts = Contracts::new(&web3, chain, addresses)
-            .await
-            .expect("could not initialize important smart contracts");
 
         let current_block_stream =
             ethrpc::current_block::current_block_stream(url, std::time::Duration::from_millis(500))
                 .await
                 .expect("couldn't initialize current block stream");
 
-        let cow_amms = cow_amm::Registry::new(web3.clone(), current_block_stream.clone());
-        if let Some(contract) = contracts.cow_amm_legacy_helper() {
-            cow_amms
-                .add_listener(
-                    ::contracts::deployment_block!(contract).unwrap(),
-                    contract.address(),
-                    contract.address(),
-                )
-                .await;
-        }
+        let contracts = Contracts::new(&web3, chain, addresses, current_block_stream.clone())
+            .await
+            .expect("could not initialize important smart contracts");
 
         Self {
             inner: Arc::new(Inner {
@@ -103,7 +92,6 @@ impl Ethereum {
                 chain,
                 contracts,
                 gas,
-                cow_amms,
             }),
             web3,
         }
@@ -260,10 +248,6 @@ impl Ethereum {
             .await
             .ok()
             .map(|gas| gas.effective().0 .0)
-    }
-
-    pub async fn cow_amms(&self) -> Vec<Arc<cow_amm::Amm>> {
-        self.inner.cow_amms.cow_amms().await
     }
 }
 

--- a/crates/driver/src/infra/config/file/load.rs
+++ b/crates/driver/src/infra/config/file/load.rs
@@ -317,6 +317,16 @@ pub async fn load(chain: eth::ChainId, path: &Path) -> infra::Config {
         contracts: blockchain::contracts::Addresses {
             settlement: config.contracts.gp_v2_settlement.map(Into::into),
             weth: config.contracts.weth.map(Into::into),
+            cow_amms: config
+                .contracts
+                .cow_amms
+                .into_iter()
+                .map(|cfg| blockchain::contracts::CowAmmConfig {
+                    index_start: cfg.index_start,
+                    factory: cfg.factory,
+                    helper: cfg.helper,
+                })
+                .collect(),
         },
         disable_access_list_simulation: config.disable_access_list_simulation,
         disable_gas_simulation: config.disable_gas_simulation.map(Into::into),

--- a/crates/driver/src/infra/config/file/mod.rs
+++ b/crates/driver/src/infra/config/file/mod.rs
@@ -321,6 +321,7 @@ struct ContractsConfig {
 
     /// List of all cow amm factories the driver should generate
     /// rebalancing orders for.
+    #[serde(default)]
     cow_amms: Vec<CowAmmConfig>,
 }
 

--- a/crates/driver/src/infra/config/file/mod.rs
+++ b/crates/driver/src/infra/config/file/mod.rs
@@ -318,6 +318,21 @@ struct ContractsConfig {
 
     /// Override the default address of the WETH contract.
     weth: Option<eth::H160>,
+
+    /// List of all cow amm factories the driver should generate
+    /// rebalancing orders for.
+    cow_amms: Vec<CowAmmConfig>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "kebab-case", deny_unknown_fields)]
+pub struct CowAmmConfig {
+    /// Which contract to index for CoW AMM deployment events.
+    pub factory: eth::H160,
+    /// Which helper contract to use for interfacing with the indexed CoW AMMs.
+    pub helper: eth::H160,
+    /// At which block indexing should start on the factory.
+    pub index_start: u64,
 }
 
 #[derive(Debug, Deserialize)]

--- a/crates/driver/src/run.rs
+++ b/crates/driver/src/run.rs
@@ -132,7 +132,7 @@ async fn ethereum(config: &infra::Config, ethrpc: blockchain::Rpc) -> Ethereum {
             .await
             .expect("initialize gas price estimator"),
     );
-    Ethereum::new(ethrpc, config.contracts, gas).await
+    Ethereum::new(ethrpc, config.contracts.clone(), gas).await
 }
 
 async fn solvers(config: &config::Config, eth: &Ethereum) -> Vec<Solver> {

--- a/crates/driver/src/tests/setup/solver.rs
+++ b/crates/driver/src/tests/setup/solver.rs
@@ -304,6 +304,7 @@ impl Solver {
             Addresses {
                 settlement: Some(config.blockchain.settlement.address().into()),
                 weth: Some(config.blockchain.weth.address().into()),
+                cow_amms: vec![],
             },
             gas,
         )

--- a/crates/e2e/tests/e2e/cow_amm.rs
+++ b/crates/e2e/tests/e2e/cow_amm.rs
@@ -452,6 +452,7 @@ async fn cow_amm_driver_support(web3: Web3) {
                 "--drivers=test_solver|http://localhost:11088/test_solver,mock_solver|http://localhost:11088/mock_solver".to_string(),
                 "--price-estimation-drivers=test_solver|http://localhost:11088/test_solver"
                     .to_string(),
+                "--cow-amm-configs=0x86f3df416979136cb4fdea2c0886301b911c163b|0x86f3df416979136cb4fdea2c0886301b911c163b|20188649".to_string()
             ],
         )
         .await;


### PR DESCRIPTION
# Description
Currently we try to automatically load the `CowAmmLegacyHelper` contract in the autopilot and driver. This is convenient in terms of writing code but does not allow to disable indexing cow amms.
This is particularly problematic if the staging and prod driver generate orders for the same CoW AMMs. In that case these 2 environments are racing each other which could lead to many reverts when both environments try to rebalance the same CoW AMM.

# Changes
Now we can pass the cow amm configs (start_block, factory, helper) via configuration parameters.
This allows us to also run the driver without generating orders in staging and also adds the necessary features to support the balancer pools out of the gate.
Now as soon as the helper contract is ready we can just update the configs in the infra and start rebalancing the new pools.

## How to test
New config arguments are tested in existing e2e test