### PR TITLE
[TRIVIAL] Remove orderbook's `axum` dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3287,7 +3287,6 @@ dependencies = [
  "app-data",
  "app-data-hash",
  "async-trait",
- "axum",
  "bigdecimal",
  "cached",
  "chrono",

--- a/crates/orderbook/Cargo.toml
+++ b/crates/orderbook/Cargo.toml
@@ -16,7 +16,6 @@ name = "orderbook"
 path = "src/main.rs"
 
 [dependencies]
-axum = { workspace = true }
 anyhow = { workspace = true }
 app-data = { path = "../app-data" }
 app-data-hash = { path = "../app-data-hash" }


### PR DESCRIPTION
Removes `axum` dependency from the orderbook crate since it is not used there.