### PR TITLE
[EASY] Add warning logs when missing price estimate for a query/token

### DIFF
--- a/crates/shared/src/price_estimation/competition/mod.rs
+++ b/crates/shared/src/price_estimation/competition/mod.rs
@@ -121,12 +121,24 @@ impl<T: Send + Sync + 'static> CompetitionEstimator<T> {
                     elapsed = ?start.elapsed(),
                     "new price estimate"
                 );
+                if let Err(ref e) = result {
+                    tracing::warn!(?query,
+                        ?e,
+                        estimator = name,
+                        requests = requests.len(),
+                        elapsed = ?start.elapsed(),
+                        "failed to get price estimate");
+                }
                 results.push((estimator_index, result));
 
                 if missing_results(&results) == 0 {
                     break 'outer;
                 }
             }
+        }
+
+        if results.is_empty() {
+            tracing::warn!(?query, elapsed = ?start.elapsed(), "no price estimate found");
         }
 
         results


### PR DESCRIPTION
# Description
In order to fully get to the root of the issue https://github.com/cowprotocol/services/issues/2814, I would like to add a warning trace for the cases in which a native price for a token couldn't be estimated.

What I want to achieve with that is to know in more details if the high number of `missing_price` failures we have is because the prices aren't available or because the internal logic does not allow fast cache update (or a combination).