### PR TITLE
Draft: New competition loop

### DIFF
--- a/crates/autopilot/src/domain/competition/mod.rs
+++ b/crates/autopilot/src/domain/competition/mod.rs
@@ -4,6 +4,8 @@ use {
     std::collections::HashMap,
 };
 
+pub mod runloop;
+
 type SolutionId = u64;
 
 pub struct Solution {

--- a/crates/autopilot/src/domain/competition/runloop.rs
+++ b/crates/autopilot/src/domain/competition/runloop.rs
@@ -1,0 +1,23 @@
+use {crate::infra, futures::StreamExt};
+
+pub async fn runloop(eth: &infra::Ethereum, _config: &infra::config::Config) -> ! {
+    // use config to determine the runloop's time intervals
+    // time intervals need to be split between the different tasks
+    // 1. Buidl auction
+    // 2. Solving time
+    // 3. Settling time
+    // 4. Small buffer time
+
+    let mut block_stream = ethrpc::current_block::into_stream(eth.current_block().clone());
+    while let Some(_block) = block_stream.next().await {
+        // replace true with logic: should auction be executed in this block?
+        if true {
+            // auction can outlive 1 block time
+            tokio::spawn(auction());
+        }
+    }
+
+    panic!("block stream ended unexpectedly");
+}
+
+async fn auction() {}

--- a/crates/autopilot/src/infra/config/mod.rs
+++ b/crates/autopilot/src/infra/config/mod.rs
@@ -1,0 +1,9 @@
+use chrono::Duration;
+
+#[derive(Debug, Default)]
+pub struct Config {
+    pub block_time: Duration,
+    // Auction lasts up to `auction_block_size` blocks.
+    pub auction_blocks_duration: usize,
+    // rest of the config
+}

--- a/crates/autopilot/src/infra/mod.rs
+++ b/crates/autopilot/src/infra/mod.rs
@@ -1,4 +1,5 @@
 pub mod blockchain;
+pub mod config;
 pub mod persistence;
 pub mod shadow;
 pub mod solvers;

--- a/crates/autopilot/src/run.rs
+++ b/crates/autopilot/src/run.rs
@@ -495,7 +495,7 @@ pub async fn run(args: Arguments) {
         AutoUpdatingTokenList::from_configuration(market_makable_token_list_configuration).await;
 
     let run = RunLoop {
-        eth,
+        eth: eth.clone(),
         solvable_orders_cache,
         drivers: args
             .drivers
@@ -510,6 +510,7 @@ pub async fn run(args: Arguments) {
         persistence: persistence.clone(),
         liveness: liveness.clone(),
     };
+    crate::domain::competition::runloop::runloop(&eth, &infra::config::Config::default()).await;
     run.run_forever().await;
     unreachable!("run loop exited");
 }


### PR DESCRIPTION
# Description
New competition loop is meant to eventually replace `autopilot::runloop.rs`.

New competition loop is supposed to run concurrently with legacy runloop so we could properly test two important parts:
1. Properly define time intervals for all different tasks one auction run is constituted of and it's synchronisation with block issuance.
2. Auction buidl time optimizations.

Other tasks like solving, competing, settling will have to be run either by legacy or new runloop (not both at the same time).

# Changes
<!-- List of detailed changes (how the change is accomplished) -->

- [ ] ...
- [ ] ...

<!--
## Related Issues

Fixes #
-->