### PR TITLE
Quote fee adjustment

### DIFF
--- a/crates/autopilot/src/infra/persistence/dto/quote.rs
+++ b/crates/autopilot/src/infra/persistence/dto/quote.rs
@@ -1,25 +1,46 @@
 use {
     crate::{boundary, domain},
-    number::conversions::big_decimal_to_u256,
-    primitive_types::U256,
+    bigdecimal::{
+        num_traits::{CheckedDiv, CheckedMul},
+        FromPrimitive,
+    },
+    num::BigRational,
+    number::conversions::{big_decimal_to_u256, big_rational_to_u256},
 };
 
-pub fn into_domain(
-    quote: boundary::database::orders::Quote,
-) -> Result<domain::Quote, AmountOverflow> {
+pub fn into_domain(quote: boundary::database::orders::Quote) -> Result<domain::Quote, QuoteError> {
+    let gas_amount = BigRational::from_f64(quote.gas_amount).ok_or(QuoteError::InvalidInput)?;
+    let gas_price = BigRational::from_f64(quote.gas_price).ok_or(QuoteError::InvalidInput)?;
+    let sell_token_price =
+        BigRational::from_f64(quote.sell_token_price).ok_or(QuoteError::InvalidInput)?;
+    let fee = big_rational_to_u256(
+        &gas_amount
+            .checked_mul(&gas_price)
+            .ok_or(QuoteError::AmountOverflow)?
+            .checked_div(&sell_token_price)
+            .ok_or(QuoteError::DivisionByZero)?,
+    )
+    .map_err(QuoteError::Error)?;
     Ok(domain::Quote {
         order_uid: domain::OrderUid(quote.order_uid.0),
         sell_amount: big_decimal_to_u256(&quote.sell_amount)
-            .ok_or(AmountOverflow)?
+            .ok_or(QuoteError::AmountOverflow)?
             .into(),
         buy_amount: big_decimal_to_u256(&quote.buy_amount)
-            .ok_or(AmountOverflow)?
+            .ok_or(QuoteError::AmountOverflow)?
             .into(),
-        fee: U256::from_f64_lossy(quote.gas_amount * quote.gas_price / quote.sell_token_price)
-            .into(),
+        fee: fee.into(),
     })
 }
 
 #[derive(Debug, thiserror::Error)]
-#[error("amount overflow")]
-pub struct AmountOverflow;
+pub enum QuoteError {
+    #[error("amount overflow")]
+    AmountOverflow,
+    #[error("invalid input")]
+    InvalidInput,
+    #[error("division by zero")]
+    DivisionByZero,
+    #[error(transparent)]
+    Error(#[from] anyhow::Error),
+}

--- a/crates/autopilot/src/infra/persistence/dto/quote.rs
+++ b/crates/autopilot/src/infra/persistence/dto/quote.rs
@@ -16,7 +16,7 @@ pub fn into_domain(quote: boundary::database::orders::Quote) -> Result<domain::Q
     let fee = big_rational_to_u256(
         &gas_amount
             .checked_mul(&gas_price)
-            .ok_or(QuoteError::AmountOverflow)?
+            .ok_or(QuoteError::BigRationalOverflow)?
             .checked_div(&sell_token_price)
             .ok_or(QuoteError::DivisionByZero)?,
     )
@@ -24,10 +24,10 @@ pub fn into_domain(quote: boundary::database::orders::Quote) -> Result<domain::Q
     Ok(domain::Quote {
         order_uid: domain::OrderUid(quote.order_uid.0),
         sell_amount: big_decimal_to_u256(&quote.sell_amount)
-            .ok_or(QuoteError::U256AmountOverflow)?
+            .ok_or(QuoteError::U256Overflow)?
             .into(),
         buy_amount: big_decimal_to_u256(&quote.buy_amount)
-            .ok_or(QuoteError::U256AmountOverflow)?
+            .ok_or(QuoteError::U256Overflow)?
             .into(),
         fee: fee.into(),
     })
@@ -35,10 +35,10 @@ pub fn into_domain(quote: boundary::database::orders::Quote) -> Result<domain::Q
 
 #[derive(Debug, thiserror::Error)]
 pub enum QuoteError {
-    #[error("amount overflow")]
-    AmountOverflow,
+    #[error("BigRational amount overflow")]
+    BigRationalOverflow,
     #[error("U256 amount overflow")]
-    U256AmountOverflow,
+    U256Overflow,
     #[error("invalid BigRational input")]
     InvalidInput,
     #[error("division by zero")]

--- a/crates/autopilot/src/infra/persistence/dto/quote.rs
+++ b/crates/autopilot/src/infra/persistence/dto/quote.rs
@@ -24,10 +24,10 @@ pub fn into_domain(quote: boundary::database::orders::Quote) -> Result<domain::Q
     Ok(domain::Quote {
         order_uid: domain::OrderUid(quote.order_uid.0),
         sell_amount: big_decimal_to_u256(&quote.sell_amount)
-            .ok_or(QuoteError::AmountOverflow)?
+            .ok_or(QuoteError::U256AmountOverflow)?
             .into(),
         buy_amount: big_decimal_to_u256(&quote.buy_amount)
-            .ok_or(QuoteError::AmountOverflow)?
+            .ok_or(QuoteError::U256AmountOverflow)?
             .into(),
         fee: fee.into(),
     })
@@ -37,7 +37,9 @@ pub fn into_domain(quote: boundary::database::orders::Quote) -> Result<domain::Q
 pub enum QuoteError {
     #[error("amount overflow")]
     AmountOverflow,
-    #[error("invalid input")]
+    #[error("U256 amount overflow")]
+    U256AmountOverflow,
+    #[error("invalid BigRational input")]
     InvalidInput,
     #[error("division by zero")]
     DivisionByZero,

--- a/crates/orderbook/src/database/fee_policies.rs
+++ b/crates/orderbook/src/database/fee_policies.rs
@@ -1,11 +1,14 @@
 use {
     anyhow::Context,
-    bigdecimal::{num_traits::CheckedDiv, FromPrimitive},
+    bigdecimal::{
+        num_traits::{CheckedDiv, CheckedMul},
+        FromPrimitive,
+    },
     database::{auction::AuctionId, OrderUid},
     model::fee_policy::{FeePolicy, Quote},
     num::BigRational,
     number::conversions::{big_decimal_to_u256, big_rational_to_u256},
-    std::{collections::HashMap, ops::Mul},
+    std::collections::HashMap,
 };
 
 impl super::Postgres {
@@ -93,7 +96,8 @@ fn fee_policy_from(
                 .context("invalid quote sell token price")?;
             let fee = big_rational_to_u256(
                 &gas_amount
-                    .mul(gas_price)
+                    .checked_mul(&gas_price)
+                    .context("gas amount and gas price multiplication overflow")?
                     .checked_div(&sell_token_price)
                     .context("invalid price improvement quote fee value")?,
             )?;


### PR DESCRIPTION
While testing https://github.com/cowprotocol/services/issues/2642, @fhenneke noticed a discrepancy in the quote fee amount between the new API and Auction JSON, where the former looks more correct since it doesn't use `f64` calculation: https://github.com/cowprotocol/services/blob/quote-fee-adjustment/crates/orderbook/src/database/fee_policies.rs#L91-L103

The same calculation approach is now used in both places.