### PR TITLE
Implement CoinGecko for fetching native prices

### DIFF
--- a/crates/shared/src/price_estimation.rs
+++ b/crates/shared/src/price_estimation.rs
@@ -44,7 +44,7 @@ pub struct NativePriceEstimators(Vec<Vec<NativePriceEstimator>>);
 pub enum NativePriceEstimator {
     Driver(ExternalSolver),
     OneInchSpotPriceApi,
-    CoinGeckoProPriceApi,
+    CoinGecko,
 }
 
 impl Display for NativePriceEstimator {
@@ -52,7 +52,7 @@ impl Display for NativePriceEstimator {
         let formatter = match self {
             NativePriceEstimator::Driver(s) => format!("{}|{}", &s.name, s.url),
             NativePriceEstimator::OneInchSpotPriceApi => "OneInchSpotPriceApi".into(),
-            NativePriceEstimator::CoinGeckoProPriceApi => "CoinGeckoProPriceApi".into(),
+            NativePriceEstimator::CoinGecko => "CoinGecko".into(),
         };
         write!(f, "{}", formatter)
     }
@@ -102,7 +102,7 @@ impl FromStr for NativePriceEstimator {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
             "OneInchSpotPriceApi" => Ok(NativePriceEstimator::OneInchSpotPriceApi),
-            "CoinGeckoProPriceApi" => Ok(NativePriceEstimator::CoinGeckoProPriceApi),
+            "CoinGecko" => Ok(NativePriceEstimator::CoinGecko),
             estimator => Ok(NativePriceEstimator::Driver(ExternalSolver::from_str(
                 estimator,
             )?)),
@@ -187,7 +187,11 @@ pub struct Arguments {
     pub coin_gecko_api_key: Option<String>,
 
     /// The base URL for the CoinGecko API.
-    #[clap(long, env, default_value = "https://api.coingecko.com/api/v3")]
+    #[clap(
+        long,
+        env,
+        default_value = "https://api.coingecko.com/api/v3/simple/token_price"
+    )]
     pub coin_gecko_url: Url,
 
     /// How inaccurate a quote must be before it gets discarded provided as a

--- a/crates/shared/src/price_estimation.rs
+++ b/crates/shared/src/price_estimation.rs
@@ -44,6 +44,7 @@ pub struct NativePriceEstimators(Vec<Vec<NativePriceEstimator>>);
 pub enum NativePriceEstimator {
     Driver(ExternalSolver),
     OneInchSpotPriceApi,
+    CoinGeckoProPriceApi,
 }
 
 impl Display for NativePriceEstimator {
@@ -51,6 +52,7 @@ impl Display for NativePriceEstimator {
         let formatter = match self {
             NativePriceEstimator::Driver(s) => format!("{}|{}", &s.name, s.url),
             NativePriceEstimator::OneInchSpotPriceApi => "OneInchSpotPriceApi".into(),
+            NativePriceEstimator::CoinGeckoProPriceApi => "CoinGeckoProPriceApi".into(),
         };
         write!(f, "{}", formatter)
     }
@@ -100,6 +102,7 @@ impl FromStr for NativePriceEstimator {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
             "OneInchSpotPriceApi" => Ok(NativePriceEstimator::OneInchSpotPriceApi),
+            "CoinGeckoProPriceApi" => Ok(NativePriceEstimator::CoinGeckoProPriceApi),
             estimator => Ok(NativePriceEstimator::Driver(ExternalSolver::from_str(
                 estimator,
             )?)),
@@ -179,6 +182,14 @@ pub struct Arguments {
     #[clap(long, env, default_value = "https://api.1inch.dev/")]
     pub one_inch_url: Url,
 
+    /// The API key for the CoinGecko API.
+    #[clap(long, env)]
+    pub coin_gecko_api_key: Option<String>,
+
+    /// The base URL for the CoinGecko API.
+    #[clap(long, env, default_value = "https://api.coingecko.com/api/v3")]
+    pub coin_gecko_url: Url,
+
     /// How inaccurate a quote must be before it gets discarded provided as a
     /// factor.
     /// E.g. a value of `0.01` means at most 1 percent of the sell or buy tokens
@@ -233,6 +244,8 @@ impl Display for Arguments {
             balancer_sor_url,
             one_inch_api_key,
             one_inch_url,
+            coin_gecko_api_key,
+            coin_gecko_url,
             quote_inaccuracy_limit,
             quote_verification,
             quote_timeout,
@@ -276,6 +289,8 @@ impl Display for Arguments {
         display_option(f, "balancer_sor_url", balancer_sor_url)?;
         display_secret_option(f, "one_inch_spot_price_api_key: {:?}", one_inch_api_key)?;
         writeln!(f, "one_inch_spot_price_api_url: {}", one_inch_url)?;
+        display_secret_option(f, "coin_gecko_api_key: {:?}", coin_gecko_api_key)?;
+        writeln!(f, "coin_gecko_api_url: {}", coin_gecko_url)?;
         writeln!(f, "quote_inaccuracy_limit: {}", quote_inaccuracy_limit)?;
         writeln!(f, "quote_verification: {:?}", quote_verification)?;
         writeln!(f, "quote_timeout: {:?}", quote_timeout)?;

--- a/crates/shared/src/price_estimation/factory.rs
+++ b/crates/shared/src/price_estimation/factory.rs
@@ -205,8 +205,8 @@ impl<'a> PriceEstimatorFactory<'a> {
                     self.components.tokens.clone(),
                 )),
             )),
-            NativePriceEstimatorSource::CoinGeckoProPriceApi => Ok((
-                "CoinGeckoProPriceApi".into(),
+            NativePriceEstimatorSource::CoinGecko => Ok((
+                "CoinGecko".into(),
                 Arc::new(native::CoinGecko::new(
                     self.components.http_factory.create(),
                     self.args.coin_gecko_url.clone(),

--- a/crates/shared/src/price_estimation/factory.rs
+++ b/crates/shared/src/price_estimation/factory.rs
@@ -205,6 +205,15 @@ impl<'a> PriceEstimatorFactory<'a> {
                     self.components.tokens.clone(),
                 )),
             )),
+            NativePriceEstimatorSource::CoinGeckoProPriceApi => Ok((
+                "CoinGeckoProPriceApi".into(),
+                Arc::new(native::CoinGecko::new(
+                    self.components.http_factory.create(),
+                    self.args.coin_gecko_url.clone(),
+                    self.args.coin_gecko_api_key.clone(),
+                    self.network.chain_id,
+                )?),
+            )),
         }
     }
 

--- a/crates/shared/src/price_estimation/native.rs
+++ b/crates/shared/src/price_estimation/native.rs
@@ -7,8 +7,10 @@ use {
     std::sync::Arc,
 };
 
+mod coingecko;
 mod oneinch;
-pub use self::oneinch::OneInch;
+
+pub use self::{coingecko::CoinGecko, oneinch::OneInch};
 
 pub type NativePrice = f64;
 pub type NativePriceEstimateResult = Result<NativePrice, PriceEstimationError>;

--- a/crates/shared/src/price_estimation/native/coingecko.rs
+++ b/crates/shared/src/price_estimation/native/coingecko.rs
@@ -4,7 +4,7 @@ use {
     anyhow::{anyhow, Result},
     futures::{future::BoxFuture, FutureExt},
     primitive_types::H160,
-    reqwest::{header::AUTHORIZATION, Client, StatusCode},
+    reqwest::{Client, StatusCode},
     serde::Deserialize,
     std::collections::HashMap,
     url::Url,
@@ -28,6 +28,9 @@ pub struct CoinGecko {
 }
 
 impl CoinGecko {
+    /// Authorization header for CoinGecko
+    const AUTHORIZATION: &'static str = "x-cg-pro-api-key";
+
     pub fn new(
         client: Client,
         base_url: Url,
@@ -58,7 +61,7 @@ impl NativePriceEstimating for CoinGecko {
             );
             let mut builder = self.client.get(&url);
             if let Some(ref api_key) = self.api_key {
-                builder = builder.header(AUTHORIZATION, api_key)
+                builder = builder.header(Self::AUTHORIZATION, api_key)
             }
             observe::coingecko_request(&url);
             let response = builder.send().await;

--- a/crates/shared/src/price_estimation/native/coingecko.rs
+++ b/crates/shared/src/price_estimation/native/coingecko.rs
@@ -1,0 +1,117 @@
+use {
+    super::{NativePriceEstimateResult, NativePriceEstimating},
+    crate::price_estimation::PriceEstimationError,
+    anyhow::{anyhow, Result},
+    futures::{future::BoxFuture, FutureExt},
+    primitive_types::H160,
+    reqwest::{header::AUTHORIZATION, Client, StatusCode},
+    serde::Deserialize,
+    std::collections::HashMap,
+    url::Url,
+};
+
+#[derive(Debug, Deserialize)]
+struct Response(HashMap<H160, Price>);
+
+#[derive(Debug, Deserialize)]
+struct Price {
+    eth: f64,
+}
+
+type Token = H160;
+
+pub struct CoinGecko {
+    client: Client,
+    base_url: Url,
+    api_key: Option<String>,
+    chain: String,
+}
+
+impl CoinGecko {
+    pub fn new(
+        client: Client,
+        base_url: Url,
+        api_key: Option<String>,
+        chain_id: u64,
+    ) -> Result<Self> {
+        let chain = match chain_id {
+            1 => "ethereum".to_string(),
+            100 => "xdai".to_string(),
+            42161 => "arbitrum-one".to_string(),
+            n => anyhow::bail!("unknown network {n}"),
+        };
+        Ok(Self {
+            client,
+            base_url,
+            api_key,
+            chain,
+        })
+    }
+}
+
+impl NativePriceEstimating for CoinGecko {
+    fn estimate_native_price(&self, token: Token) -> BoxFuture<'_, NativePriceEstimateResult> {
+        async move {
+            let mut builder = self.client.get(format!(
+                "{}/simple/token_price/{}?contract_addresses=0x{token:x}&vs_currencies=eth",
+                self.base_url, self.chain
+            ));
+            if let Some(ref api_key) = self.api_key {
+                builder = builder.header(AUTHORIZATION, api_key)
+            }
+            let response = builder.send().await.map_err(|e| {
+                PriceEstimationError::EstimatorInternal(anyhow!(
+                    "failed to sent CoinGecko price request: {e:?}"
+                ))
+            })?;
+            if !response.status().is_success() {
+                let status = response.status();
+                tracing::warn!(?status, "CoinGecko price request failed",);
+                return match status {
+                    StatusCode::TOO_MANY_REQUESTS => Err(PriceEstimationError::RateLimited),
+                    _ => Err(PriceEstimationError::NoLiquidity),
+                };
+            }
+            let response = response.text().await.map_err(|e| {
+                PriceEstimationError::EstimatorInternal(anyhow!(
+                    "failed to fetch native CoinGecko prices: {e:?}"
+                ))
+            })?;
+            let prices = serde_json::from_str::<Response>(&response)
+                .map_err(|e| {
+                    PriceEstimationError::EstimatorInternal(anyhow!(
+                        "failed to parse native CoinGecko prices from {response:?}: {e:?}"
+                    ))
+                })?
+                .0;
+
+            let price = prices
+                .get(&token)
+                .ok_or(PriceEstimationError::NoLiquidity)?;
+            Ok(price.eth)
+        }
+        .boxed()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use {super::*, std::str::FromStr};
+
+    // It is ok to call this API without an API for local testing purposes as it is
+    // difficulty to hit the rate limit manually
+    const BASE_URL: &str = "https://api.coingecko.com/api/v3";
+
+    #[tokio::test]
+    #[ignore]
+    async fn works() {
+        let native_token = H160::from_str("0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2").unwrap();
+        let instance =
+            CoinGecko::new(Client::default(), Url::parse(BASE_URL).unwrap(), None, 1).unwrap();
+
+        let estimated_price = instance.estimate_native_price(native_token).await.unwrap();
+        // Since the WETH precise price against ETH is not always exact to 1.0 (it can
+        // vary slightly)
+        assert!((0.95..=1.05).contains(&estimated_price));
+    }
+}

--- a/crates/shared/src/price_estimation/native/coingecko.rs
+++ b/crates/shared/src/price_estimation/native/coingecko.rs
@@ -38,7 +38,7 @@ impl CoinGecko {
             1 => "ethereum".to_string(),
             100 => "xdai".to_string(),
             42161 => "arbitrum-one".to_string(),
-            n => anyhow::bail!("unknown network {n}"),
+            n => anyhow::bail!("unsupported network {n}"),
         };
         Ok(Self {
             client,

--- a/crates/shared/src/price_estimation/native/oneinch.rs
+++ b/crates/shared/src/price_estimation/native/oneinch.rs
@@ -8,7 +8,7 @@ use {
     number::{conversions::u256_to_big_rational, serialization::HexOrDecimalU256},
     primitive_types::{H160, U256},
     reqwest::{header::AUTHORIZATION, Client},
-    serde::{Deserialize, Serialize},
+    serde::Deserialize,
     serde_with::serde_as,
     std::{
         collections::HashMap,
@@ -18,7 +18,7 @@ use {
 };
 
 #[serde_as]
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize)]
 struct Response(#[serde_as(as = "HashMap<_, HexOrDecimalU256>")] HashMap<H160, U256>);
 
 type Token = H160;


### PR DESCRIPTION
# Description
Implement a native prices fetch from CoinGecko. As we see in the issue https://github.com/cowprotocol/services/issues/2814, we are getting many orders rejected because we do not have native prices for many tokens. And the cache of outdated tokens keeps growing over time. In order to solve this, we add CoinGecko as a native price fetcher too.

This PR standalone (without infrastructure PR) doesn't have any impact, as CoinGecko must be configured as a native price   estimator source.

The PR can already prove if fetching prices from CoinGecko improves the cache and the order errors rate, but the following changes are needed in upcoming PRs:
- Instead of fetching prices from all the sources at one, have a primary method for fetching prices (CoinGecko) and fallback methods (solvers + 1inch)
- Potentially improve performance by doing bulk requests
- Move the code from autopilot

Please, see my comments below for more clarification.

# Changes
- Add configuration for CoinGeck estimator source
- Implement the trait for fetching native prices for CoinGecko

## How to test
1. Unit test

## Related Issues

### Partially fixes: https://github.com/cowprotocol/services/issues/2814