### PR TITLE
Autopilot refactor 1/3: Support surplus capturing orders

### DIFF
--- a/crates/autopilot/src/domain/auction/order.rs
+++ b/crates/autopilot/src/domain/auction/order.rs
@@ -27,10 +27,6 @@ pub struct Order {
     pub signature: Signature,
 }
 
-// uid as 56 bytes: 32 for orderDigest, 20 for ownerAddress and 4 for validTo
-#[derive(Copy, Clone, PartialEq, Hash, Eq)]
-pub struct OrderUid(pub [u8; 56]);
-
 impl Order {
     pub fn is_limit_order(&self) -> bool {
         matches!(self.class, Class::Limit)
@@ -40,6 +36,25 @@ impl Order {
     /// are supposed to compute a reasonable fee themselves.
     pub fn solver_determines_fee(&self) -> bool {
         self.is_limit_order()
+    }
+}
+
+// uid as 56 bytes: 32 for orderDigest, 20 for ownerAddress and 4 for validTo
+#[derive(Copy, Clone, PartialEq, Hash, Eq)]
+pub struct OrderUid(pub [u8; 56]);
+
+impl OrderUid {
+    pub fn owner(&self) -> eth::Address {
+        self.parts().1.into()
+    }
+
+    /// Splits an order UID into its parts.
+    fn parts(&self) -> (H256, H160, u32) {
+        (
+            H256::from_slice(&self.0[0..32]),
+            H160::from_slice(&self.0[32..52]),
+            u32::from_le_bytes(self.0[52..].try_into().unwrap()),
+        )
     }
 }
 

--- a/crates/autopilot/src/domain/settlement/auction.rs
+++ b/crates/autopilot/src/domain/settlement/auction.rs
@@ -20,3 +20,22 @@ pub struct Auction {
     /// surplus if settled.
     pub surplus_capturing_jit_order_owners: Vec<domain::eth::Address>,
 }
+
+impl Auction {
+    /// Protocol defines rules whether an order is eligible to contribute to the
+    /// surplus of a settlement.
+    pub fn is_surplus_capturing(&self, order: &domain::OrderUid) -> bool {
+        // All orders in the auction contribute to surplus
+        if self.orders.contains_key(order) {
+            return true;
+        }
+        // Some JIT orders contribute to surplus, for example COW AMM orders
+        if self
+            .surplus_capturing_jit_order_owners
+            .contains(&order.owner())
+        {
+            return true;
+        }
+        false
+    }
+}

--- a/crates/autopilot/src/domain/settlement/mod.rs
+++ b/crates/autopilot/src/domain/settlement/mod.rs
@@ -2,7 +2,10 @@
 //!
 //! A winning solution becomes a [`Settlement`] once it is executed on-chain.
 
-use crate::{domain::eth, infra};
+use {
+    super::competition,
+    crate::{domain::eth, infra},
+};
 
 mod auction;
 mod solution;
@@ -30,6 +33,11 @@ impl Settlement {
         let auction = persistence.get_auction(solution.auction_id()).await?;
 
         Ok(Self { solution, auction })
+    }
+
+    /// CIP38 score calculation
+    pub fn score(&self) -> Result<competition::Score, solution::error::Score> {
+        self.solution.score(&self.auction)
     }
 }
 

--- a/crates/autopilot/src/domain/settlement/solution/mod.rs
+++ b/crates/autopilot/src/domain/settlement/solution/mod.rs
@@ -150,8 +150,12 @@ pub mod error {
 #[cfg(test)]
 mod tests {
     use {
-        crate::domain::{auction, eth},
+        crate::{
+            domain,
+            domain::{auction, eth},
+        },
         hex_literal::hex,
+        std::collections::HashMap,
     };
 
     // https://etherscan.io/tx/0xc48dc0d43ffb43891d8c3ad7bcf05f11465518a2610869b20b0b4ccb61497634
@@ -255,14 +259,22 @@ mod tests {
             ),
         ]);
 
+        let auction = super::super::Auction {
+            prices,
+            deadline: eth::BlockNo(0),
+            surplus_capturing_jit_order_owners: vec![],
+            id: 0,
+            orders: HashMap::from([(domain::OrderUid(hex!("10dab31217bb6cc2ace0fe601c15d342f7626a1ee5ef0495449800e73156998740a50cf069e992aa4536211b23f286ef88752187ffffffff")), vec![])]),
+        };
+
         // surplus (score) read from https://api.cow.fi/mainnet/api/v1/solver_competition/by_tx_hash/0xc48dc0d43ffb43891d8c3ad7bcf05f11465518a2610869b20b0b4ccb61497634
         assert_eq!(
-            solution.native_surplus(&prices).unwrap().0,
+            solution.native_surplus(&auction).unwrap().0,
             eth::U256::from(52937525819789126u128)
         );
         // fee read from "executedSurplusFee" https://api.cow.fi/mainnet/api/v1/orders/0x10dab31217bb6cc2ace0fe601c15d342f7626a1ee5ef0495449800e73156998740a50cf069e992aa4536211b23f286ef88752187ffffffff
         assert_eq!(
-            solution.native_fee(&prices).unwrap().0,
+            solution.native_fee(&auction.prices).unwrap().0,
             eth::U256::from(6890975030480504u128)
         );
     }

--- a/crates/autopilot/src/domain/settlement/solution/trade.rs
+++ b/crates/autopilot/src/domain/settlement/solution/trade.rs
@@ -6,6 +6,7 @@ use {
             auction::{self, order},
             eth,
             fee,
+            settlement,
         },
         util::conv::U256Ext,
     },
@@ -45,19 +46,11 @@ impl Trade {
         }
     }
 
-    pub fn order_uid(&self) -> &domain::OrderUid {
-        &self.order_uid
-    }
-
     /// CIP38 score defined as surplus + protocol fee
     ///
     /// Denominated in NATIVE token
-    pub fn score(
-        &self,
-        prices: &auction::Prices,
-        policies: &[fee::Policy],
-    ) -> Result<eth::Ether, Error> {
-        Ok(self.native_surplus(prices)? + self.native_protocol_fee(prices, policies)?)
+    pub fn score(&self, auction: &settlement::Auction) -> Result<eth::Ether, Error> {
+        Ok(self.native_surplus(auction)? + self.native_protocol_fee(auction)?)
     }
 
     /// A general surplus function.
@@ -118,9 +111,14 @@ impl Trade {
     /// fees have been applied.
     ///
     /// Denominated in NATIVE token
-    pub fn native_surplus(&self, prices: &auction::Prices) -> Result<eth::Ether, Error> {
+    pub fn native_surplus(&self, auction: &settlement::Auction) -> Result<eth::Ether, Error> {
+        if !self.is_surplus_capturing(auction) {
+            return Ok(Zero::zero());
+        }
+
         let surplus = self.surplus_over_limit_price()?;
-        let price = prices
+        let price = auction
+            .prices
             .get(&surplus.token)
             .ok_or(Error::MissingPrice(surplus.token))?;
 
@@ -217,7 +215,7 @@ impl Trade {
     /// the protocol fee from the trade.
     ///
     /// Note how the custom prices are expressed over actual traded amounts.
-    pub fn calculate_custom_prices(
+    fn calculate_custom_prices(
         &self,
         protocol_fee: eth::TokenAmount,
     ) -> Result<ClearingPrices, error::Math> {
@@ -418,13 +416,16 @@ impl Trade {
     /// Protocol fee is defined by fee policies attached to the order.
     ///
     /// Denominated in NATIVE token
-    fn native_protocol_fee(
-        &self,
-        prices: &auction::Prices,
-        policies: &[fee::Policy],
-    ) -> Result<eth::Ether, Error> {
-        let protocol_fee = self.protocol_fees(policies)?;
-        let price = prices
+    fn native_protocol_fee(&self, auction: &settlement::Auction) -> Result<eth::Ether, Error> {
+        let protocol_fee = self.protocol_fees(
+            auction
+                .orders
+                .get(&self.order_uid)
+                .map(|value| value.as_slice())
+                .unwrap_or_default(),
+        )?;
+        let price = auction
+            .prices
             .get(&protocol_fee.token)
             .ok_or(Error::MissingPrice(protocol_fee.token))?;
 
@@ -436,6 +437,26 @@ impl Trade {
             order::Side::Buy => self.sell.token,
             order::Side::Sell => self.buy.token,
         }
+    }
+
+    /// Protocol defines rules whether a trade is eligible to contribute to the
+    /// surplus of a settlement.
+    ///
+    /// This property is always evaluated in the context of an auction
+    /// accociated to a settlement.
+    fn is_surplus_capturing(&self, auction: &settlement::Auction) -> bool {
+        // All orders in the auction contribute to surplus
+        if auction.orders.contains_key(&self.order_uid) {
+            return true;
+        }
+        // Some JIT orders contribute to surplus, for example COW AMM orders
+        if auction
+            .surplus_capturing_jit_order_owners
+            .contains(&self.order_uid.owner())
+        {
+            return true;
+        }
+        false
     }
 }
 

--- a/crates/autopilot/src/domain/settlement/solution/trade.rs
+++ b/crates/autopilot/src/domain/settlement/solution/trade.rs
@@ -112,7 +112,7 @@ impl Trade {
     ///
     /// Denominated in NATIVE token
     pub fn native_surplus(&self, auction: &settlement::Auction) -> Result<eth::Ether, Error> {
-        if !self.is_surplus_capturing(auction) {
+        if !auction.is_surplus_capturing(&self.order_uid) {
             return Ok(Zero::zero());
         }
 
@@ -437,26 +437,6 @@ impl Trade {
             order::Side::Buy => self.sell.token,
             order::Side::Sell => self.buy.token,
         }
-    }
-
-    /// Protocol defines rules whether a trade is eligible to contribute to the
-    /// surplus of a settlement.
-    ///
-    /// This property is always evaluated in the context of an auction
-    /// accociated to a settlement.
-    fn is_surplus_capturing(&self, auction: &settlement::Auction) -> bool {
-        // All orders in the auction contribute to surplus
-        if auction.orders.contains_key(&self.order_uid) {
-            return true;
-        }
-        // Some JIT orders contribute to surplus, for example COW AMM orders
-        if auction
-            .surplus_capturing_jit_order_owners
-            .contains(&self.order_uid.owner())
-        {
-            return true;
-        }
-        false
     }
 }
 

--- a/crates/autopilot/src/on_settlement_event_updater.rs
+++ b/crates/autopilot/src/on_settlement_event_updater.rs
@@ -198,6 +198,11 @@ impl Inner {
             .await;
 
             tracing::info!(?settlement, "settlement object");
+
+            if let Ok(settlement) = settlement {
+                let score = settlement.score();
+                tracing::info!(?score, "settlement score");
+            }
         }
 
         Ok(true)

--- a/crates/autopilot/src/on_settlement_event_updater.rs
+++ b/crates/autopilot/src/on_settlement_event_updater.rs
@@ -197,12 +197,10 @@ impl Inner {
             )
             .await;
 
-            tracing::info!(?settlement, "settlement object");
-
-            if let Ok(settlement) = settlement {
-                let score = settlement.score();
-                tracing::info!(?score, "settlement score");
-            }
+            tracing::info!(
+                "settlement object {:?}",
+                settlement.map(|settlement| settlement.score())
+            );
         }
 
         Ok(true)


### PR DESCRIPTION
# Description
Ports [newest changes](https://github.com/cowprotocol/services/blob/main/crates/autopilot/src/on_settlement_event_updater.rs#L241-L244) for surplus calculation to new domain objects used for surplus calculation.

We have two rules:
1. Only orders that were part of the `Auction` are eligible for contributing to surplus of a settlement.
2. Other than that, orders are eligible if their owner is part of the `Auction`.

## How to test
Will have a test where score will be compared to driver computed score once all PRs are merged.

<!--
## Related Issues

Fixes #
-->