### PR TITLE
Combine onchain order event handling logic

### DIFF
--- a/crates/autopilot/src/database/onchain_order_events.rs
+++ b/crates/autopilot/src/database/onchain_order_events.rs
@@ -40,7 +40,6 @@ use {
         signature::SigningScheme,
         DomainSeparator,
     },
-    num::iter::Range,
     number::conversions::u256_to_big_decimal,
     shared::{
         db_order_conversions::{

--- a/crates/autopilot/src/database/onchain_order_events.rs
+++ b/crates/autopilot/src/database/onchain_order_events.rs
@@ -156,19 +156,6 @@ impl<T: Sync + Send + Clone, W: Sync + Send + Clone> EventStoring<ContractEvent>
         events: Vec<EthContractEvent<ContractEvent>>,
         range: RangeInclusive<u64>,
     ) -> Result<()> {
-        let order_placement_events = events
-            .clone()
-            .into_iter()
-            .filter(|EthContractEvent { data, .. }| {
-                matches!(data, ContractEvent::OrderPlacement(_))
-            })
-            .collect();
-        let invalidation_events = get_invalidation_events(events)?;
-        let invalided_order_uids = extract_invalidated_order_uids(invalidation_events)?;
-        let (custom_onchain_data, quotes, broadcasted_order_data, orders) = self
-            .extract_custom_and_general_order_data(order_placement_events)
-            .await?;
-
         let _timer = DatabaseMetrics::get()
             .database_queries
             .with_label_values(&["replace_onchain_order_events"])
@@ -176,71 +163,26 @@ impl<T: Sync + Send + Clone, W: Sync + Send + Clone> EventStoring<ContractEvent>
 
         let mut transaction = self.db.pool.begin().await?;
 
-        database::onchain_broadcasted_orders::mark_as_reorged(
-            &mut transaction,
-            i64::try_from(*range.start()).unwrap_or(i64::MAX),
-        )
-        .await
-        .context("mark_onchain_order_events failed")?;
+        self.delete_events(events.clone(), &mut transaction, range)
+            .await?;
+        self.insert_events(events, &mut transaction).await?;
 
-        database::onchain_invalidations::delete_invalidations(
-            &mut transaction,
-            i64::try_from(*range.start()).unwrap_or(i64::MAX),
-        )
-        .await
-        .context("invalidating_onchain_order_events failed")?;
-
-        database::onchain_invalidations::insert_onchain_invalidations(
-            &mut transaction,
-            invalided_order_uids.as_slice(),
-        )
-        .await
-        .context("insert_onchain_invalidations failed")?;
-
-        self.custom_onchain_data_parser
-            .append_custom_order_info_to_db(&mut transaction, custom_onchain_data)
-            .await
-            .context("append_custom_onchain_orders failed")?;
-
-        database::onchain_broadcasted_orders::append(
-            &mut transaction,
-            broadcasted_order_data.as_slice(),
-        )
-        .await
-        .context("append_onchain_orders failed")?;
-
-        // We only need to insert quotes for orders that will be included in an
-        // auction (they are needed to compute solver rewards). If placement
-        // failed, then the quote is not needed.
-        insert_quotes(
-            &mut transaction,
-            quotes.into_iter().flatten().collect::<Vec<_>>().as_slice(),
-        )
-        .await
-        .context("appending quotes for onchain orders failed")?;
-
-        database::orders::insert_orders_and_ignore_conflicts(&mut transaction, orders.as_slice())
-            .await
-            .context("insert_orders failed")?;
         transaction.commit().await.context("commit")?;
-
-        for order in &invalided_order_uids {
-            tracing::debug!(?order, "invalidated order");
-        }
-        for order in &orders {
-            tracing::debug!(order =? order.uid, "upserted order");
-        }
 
         Ok(())
     }
 
     async fn append_events(&mut self, events: Vec<EthContractEvent<ContractEvent>>) -> Result<()> {
-        // Appending events is equivalent to replacing events out of range.
-        self.replace_events(
-            events,
-            RangeInclusive::try_new(u64::MAX, u64::MAX).expect("valid range"),
-        )
-        .await
+        let _timer = DatabaseMetrics::get()
+            .database_queries
+            .with_label_values(&["append_onchain_order_events"])
+            .start_timer();
+
+        let mut transaction = self.db.pool.begin().await?;
+        self.insert_events(events, &mut transaction).await?;
+        transaction.commit().await.context("commit")?;
+
+        Ok(())
     }
 
     async fn last_event_block(&self) -> Result<u64> {
@@ -324,6 +266,91 @@ impl<T: Send + Sync + Clone, W: Send + Sync> OnchainOrderParser<T, W> {
             },
         );
         Ok(multiunzip(data_tuple))
+    }
+
+    async fn delete_events(
+        &self,
+        events: Vec<EthContractEvent<ContractEvent>>,
+        transaction: &mut sqlx::Transaction<'static, sqlx::Postgres>,
+        range: RangeInclusive<u64>,
+    ) -> Result<()> {
+        let invalidation_events = get_invalidation_events(events)?;
+        let invalided_order_uids = extract_invalidated_order_uids(invalidation_events)?;
+        database::onchain_broadcasted_orders::mark_as_reorged(
+            transaction,
+            i64::try_from(*range.start()).unwrap_or(i64::MAX),
+        )
+        .await
+        .context("mark_onchain_order_events failed")?;
+
+        database::onchain_invalidations::delete_invalidations(
+            transaction,
+            i64::try_from(*range.start()).unwrap_or(i64::MAX),
+        )
+        .await
+        .context("invalidating_onchain_order_events failed")?;
+
+        database::onchain_invalidations::insert_onchain_invalidations(
+            transaction,
+            invalided_order_uids.as_slice(),
+        )
+        .await
+        .context("insert_onchain_invalidations failed")?;
+
+        for order in &invalided_order_uids {
+            tracing::debug!(?order, "invalidated order");
+        }
+
+        Ok(())
+    }
+
+    async fn insert_events(
+        &self,
+        events: Vec<EthContractEvent<ContractEvent>>,
+        transaction: &mut sqlx::Transaction<'static, sqlx::Postgres>,
+    ) -> Result<()> {
+        let order_placement_events = events
+            .clone()
+            .into_iter()
+            .filter(|EthContractEvent { data, .. }| {
+                matches!(data, ContractEvent::OrderPlacement(_))
+            })
+            .collect();
+        let (custom_onchain_data, quotes, broadcasted_order_data, orders) = self
+            .extract_custom_and_general_order_data(order_placement_events)
+            .await?;
+
+        self.custom_onchain_data_parser
+            .append_custom_order_info_to_db(transaction, custom_onchain_data)
+            .await
+            .context("append_custom_onchain_orders failed")?;
+
+        database::onchain_broadcasted_orders::append(
+            transaction,
+            broadcasted_order_data.as_slice(),
+        )
+        .await
+        .context("append_onchain_orders failed")?;
+
+        // We only need to insert quotes for orders that will be included in an
+        // auction (they are needed to compute solver rewards). If placement
+        // failed, then the quote is not needed.
+        insert_quotes(
+            transaction,
+            quotes.into_iter().flatten().collect::<Vec<_>>().as_slice(),
+        )
+        .await
+        .context("appending quotes for onchain orders failed")?;
+
+        database::orders::insert_orders_and_ignore_conflicts(transaction, orders.as_slice())
+            .await
+            .context("insert_orders failed")?;
+
+        for order in &orders {
+            tracing::debug!(order =? order.uid, "upserted order");
+        }
+
+        Ok(())
     }
 }
 

--- a/crates/autopilot/src/database/onchain_order_events.rs
+++ b/crates/autopilot/src/database/onchain_order_events.rs
@@ -178,14 +178,14 @@ impl<T: Sync + Send + Clone, W: Sync + Send + Clone> EventStoring<ContractEvent>
 
         database::onchain_broadcasted_orders::mark_as_reorged(
             &mut transaction,
-            *range.start() as i64,
+            i64::try_from(*range.start()).unwrap_or(i64::MAX),
         )
         .await
         .context("mark_onchain_order_events failed")?;
 
         database::onchain_invalidations::delete_invalidations(
             &mut transaction,
-            *range.start() as i64,
+            i64::try_from(*range.start()).unwrap_or(i64::MAX),
         )
         .await
         .context("invalidating_onchain_order_events failed")?;


### PR DESCRIPTION
# Description
When looking into adding a log statement when on chain orders are parsed (to debug time to happy moo), I noticed that the `append_events` and `replace_events` logic in the on chain order handler use exactly the same code except for the following block, which is only present in `replace_events`:

```rust
database::onchain_broadcasted_orders::mark_as_reorged(
    &mut transaction,
    *range.start() as i64,
)
.await
.context("mark_onchain_order_events failed")?;

database::onchain_invalidations::delete_invalidations(
    &mut transaction,
    *range.start() as i64,
)
.await
.context("invalidating_onchain_order_events failed")?;
```

Combining this logic remove code duplication and allows for easier adjusting of the logic.

# Changes
- [x] Replace the `append_events` logic by calling `replace_events` with an range that doesn't affect any orders.

## How to test
CI

# Additional Notes to Reviewers

Please double check my reasoning that `replace_events` indeed mirror the exact logic from `append_events`