### PR TITLE
[Trivial] Improve autopilot logging to debug execution speed

### DIFF
--- a/crates/autopilot/src/database/onchain_order_events.rs
+++ b/crates/autopilot/src/database/onchain_order_events.rs
@@ -40,7 +40,6 @@ use {
         signature::SigningScheme,
         DomainSeparator,
     },
-    num::iter::Range,
     number::conversions::u256_to_big_decimal,
     shared::{
         db_order_conversions::{
@@ -332,7 +331,12 @@ impl<T: Send + Sync + Clone, W: Send + Sync> OnchainOrderParser<T, W> {
         // failed, then the quote is not needed.
         insert_quotes(
             transaction,
-            quotes.into_iter().flatten().collect::<Vec<_>>().as_slice(),
+            quotes
+                .clone()
+                .into_iter()
+                .flatten()
+                .collect::<Vec<_>>()
+                .as_slice(),
         )
         .await
         .context("appending quotes for onchain orders failed")?;

--- a/crates/autopilot/src/database/onchain_order_events.rs
+++ b/crates/autopilot/src/database/onchain_order_events.rs
@@ -215,7 +215,12 @@ impl<T: Sync + Send + Clone, W: Sync + Send + Clone> EventStoring<ContractEvent>
         // failed, then the quote is not needed.
         insert_quotes(
             &mut transaction,
-            quotes.into_iter().flatten().collect::<Vec<_>>().as_slice(),
+            quotes
+                .clone()
+                .into_iter()
+                .flatten()
+                .collect::<Vec<_>>()
+                .as_slice(),
         )
         .await
         .context("appending quotes for onchain orders failed")?;
@@ -228,8 +233,8 @@ impl<T: Sync + Send + Clone, W: Sync + Send + Clone> EventStoring<ContractEvent>
         for order in &invalided_order_uids {
             tracing::debug!(?order, "invalidated order");
         }
-        for order in &orders {
-            tracing::debug!(order =? order.uid, "upserted order");
+        for (order, quote) in orders.iter().zip(quotes.iter()) {
+            tracing::debug!(order =? order.uid, ?quote, "upserted order");
         }
 
         Ok(())

--- a/crates/autopilot/src/run_loop.rs
+++ b/crates/autopilot/src/run_loop.rs
@@ -269,7 +269,7 @@ impl RunLoop {
                 competition_table,
             };
 
-            tracing::info!(?competition, "saving competition");
+            tracing::trace!(?competition, "saving competition");
             if let Err(err) = self.persistence.save_competition(&competition).await {
                 tracing::error!(?err, "failed to save competition");
                 return;


### PR DESCRIPTION
# Description
It is currently very hard to retrieve a native ETH flow orders quote. At the same time the autopilot is flooded with relatively useless "saving order competition logs" (this data is better visualised using the [API](https://api.cow.fi/docs/#/default/get_api_v1_solver_competition__auction_id_)

# Changes
- [x] Demote solver competition saving to trace
- [x] Add quote to the log that prints when an on chain order is processed.

## How to test
Run code locally, see new logs