### PR TITLE
Implement a primary and a fallback method for fetching native prices

### DIFF
--- a/crates/autopilot/src/arguments.rs
+++ b/crates/autopilot/src/arguments.rs
@@ -7,7 +7,7 @@ use {
         arguments::{display_list, display_option, ExternalSolver},
         bad_token::token_owner_finder,
         http_client,
-        price_estimation::{self, NativePriceEstimators},
+        price_estimation::{self, NativePriceEstimator, NativePriceEstimators},
     },
     std::{net::SocketAddr, num::NonZeroUsize, str::FromStr, time::Duration},
     url::Url,
@@ -86,12 +86,17 @@ pub struct Arguments {
     #[clap(long, env, default_value = "200")]
     pub pool_cache_lru_size: NonZeroUsize,
 
-    /// Which estimators to use to estimate token prices in terms of the chain's
-    /// native token. Estimators with the same name need to also be specified as
-    /// built-in, legacy or external price estimators (lookup happens in this
-    /// order in case of name collisions)
+    /// Which estimators to use as a fallback to estimate token prices in terms
+    /// of the chain's native token. Estimators with the same name need to
+    /// also be specified as built-in, legacy or external price estimators
+    /// (lookup happens in this order in case of name collisions)
     #[clap(long, env)]
     pub native_price_estimators: NativePriceEstimators,
+
+    /// Which estimator to primary use to estimate token prices in terms of the
+    /// chain's native token.
+    #[clap(long, env)]
+    pub primary_native_price_estimator: Option<Vec<NativePriceEstimator>>,
 
     /// How many successful price estimates for each order will cause a native
     /// price estimation to return its result early. It's possible to pass
@@ -248,6 +253,7 @@ impl std::fmt::Display for Arguments {
             token_quality_cache_expiry,
             pool_cache_lru_size,
             native_price_estimators,
+            primary_native_price_estimator,
             min_order_validity_period,
             banned_users,
             max_auction_age,
@@ -294,6 +300,11 @@ impl std::fmt::Display for Arguments {
         )?;
         writeln!(f, "pool_cache_lru_size: {}", pool_cache_lru_size)?;
         writeln!(f, "native_price_estimators: {}", native_price_estimators)?;
+        writeln!(
+            f,
+            "primary_native_price_estimator: {:?}",
+            primary_native_price_estimator
+        )?;
         writeln!(
             f,
             "min_order_validity_period: {:?}",

--- a/crates/autopilot/src/run.rs
+++ b/crates/autopilot/src/run.rs
@@ -327,6 +327,7 @@ pub async fn run(args: Arguments) {
 
     let native_price_estimator = price_estimator_factory
         .native_price_estimator(
+            args.primary_native_price_estimator.as_deref(),
             args.native_price_estimators.as_slice(),
             args.native_price_estimation_results_required,
         )

--- a/crates/orderbook/src/run.rs
+++ b/crates/orderbook/src/run.rs
@@ -274,6 +274,7 @@ pub async fn run(args: Arguments) {
 
     let native_price_estimator = price_estimator_factory
         .native_price_estimator(
+            None,
             args.native_price_estimators.as_slice(),
             args.fast_price_estimation_results_required,
         )

--- a/crates/shared/src/price_estimation/competition/native.rs
+++ b/crates/shared/src/price_estimation/competition/native.rs
@@ -72,6 +72,7 @@ mod tests {
 
         let priority: CompetitionEstimator<Arc<dyn NativePriceEstimating>> =
             CompetitionEstimator::new(
+                None,
                 vec![estimates
                     .into_iter()
                     .enumerate()

--- a/crates/shared/src/price_estimation/competition/quote.rs
+++ b/crates/shared/src/price_estimation/competition/quote.rs
@@ -204,6 +204,7 @@ mod tests {
         }
 
         let priority: CompetitionEstimator<Arc<dyn PriceEstimating>> = CompetitionEstimator::new(
+            None,
             vec![estimates
                 .into_iter()
                 .enumerate()


### PR DESCRIPTION
# Description
Follow up PR from: https://github.com/cowprotocol/services/pull/2824

Set the option to have a primary method of fetching native prices. If the configuration is present, use only that method to fetch native prices, and use the fallback methods only if the primary method fails.

More PRs are coming after this one. I know these changes aren't ideal, but I don't want to do big PRs (otherwise it takes ages to get merged). I'd rather do small PRs little bit little getting to the target. It is also safer for such big changes.

Please, see my comments below for more clarification.

# Changes
- Add a configuration for setting a primary estimator source
- If the configuration is present, use only that method to fetch native prices
- Use the fallback methods only if the primary method fails
- Refactor the code to avoid code repetition and better abstraction

## How to test
1. Unit test
2. Regression tests

## Related Issues

Fixes partially #2814