### PR TITLE
Autopilot refactor 2/3: Build Observation object

### DIFF
--- a/crates/autopilot/src/domain/eth/mod.rs
+++ b/crates/autopilot/src/domain/eth/mod.rs
@@ -51,6 +51,18 @@ impl TokenAmount {
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, From, Into)]
 pub struct SellTokenAmount(pub U256);
 
+impl From<TokenAmount> for SellTokenAmount {
+    fn from(value: TokenAmount) -> Self {
+        Self(value.0)
+    }
+}
+
+impl From<SellTokenAmount> for TokenAmount {
+    fn from(value: SellTokenAmount) -> Self {
+        Self(value.0)
+    }
+}
+
 /// Gas amount in gas units.
 ///
 /// The amount of Ether that is paid in transaction fees is proportional to this

--- a/crates/autopilot/src/domain/settlement/mod.rs
+++ b/crates/autopilot/src/domain/settlement/mod.rs
@@ -55,7 +55,7 @@ impl Settlement {
     pub fn observation(&self) -> Observation {
         Observation {
             gas: self.transaction.gas,
-            effective_gas_price: self.transaction.effective_gas_price,
+            gas_price: self.transaction.effective_gas_price,
             surplus: self.solution.native_surplus(&self.auction),
             fee: self.solution.native_fee(&self.auction.prices),
             order_fees: self.solution.fees(),

--- a/crates/autopilot/src/domain/settlement/mod.rs
+++ b/crates/autopilot/src/domain/settlement/mod.rs
@@ -8,9 +8,15 @@ use {
 };
 
 mod auction;
+mod observation;
 mod solution;
 mod transaction;
-pub use {auction::Auction, solution::Solution, transaction::Transaction};
+pub use {
+    auction::Auction,
+    observation::Observation,
+    solution::Solution,
+    transaction::Transaction,
+};
 
 /// A solution together with the `Auction` for which it was picked as a winner
 /// and executed on-chain.
@@ -20,24 +26,40 @@ pub use {auction::Auction, solution::Solution, transaction::Transaction};
 #[derive(Debug)]
 pub struct Settlement {
     solution: Solution,
+    transaction: Transaction,
     auction: Auction,
 }
 
 impl Settlement {
     pub async fn new(
-        tx: &Transaction,
+        transaction: Transaction,
         domain_separator: &eth::DomainSeparator,
         persistence: &infra::Persistence,
     ) -> Result<Self, Error> {
-        let solution = Solution::new(&tx.input, domain_separator)?;
+        let solution = Solution::new(&transaction.input, domain_separator)?;
         let auction = persistence.get_auction(solution.auction_id()).await?;
 
-        Ok(Self { solution, auction })
+        Ok(Self {
+            solution,
+            transaction,
+            auction,
+        })
     }
 
     /// CIP38 score calculation
     pub fn score(&self) -> Result<competition::Score, solution::error::Score> {
         self.solution.score(&self.auction)
+    }
+
+    /// Returns the observation of the settlement.
+    pub fn observation(&self) -> Observation {
+        Observation {
+            gas: self.transaction.gas,
+            effective_gas_price: self.transaction.effective_gas_price,
+            surplus: self.solution.native_surplus(&self.auction),
+            fee: self.solution.native_fee(&self.auction.prices),
+            order_fees: self.solution.fees(),
+        }
     }
 }
 

--- a/crates/autopilot/src/domain/settlement/observation.rs
+++ b/crates/autopilot/src/domain/settlement/observation.rs
@@ -14,7 +14,7 @@ pub struct Observation {
     /// The gas used by the settlement.
     pub gas: eth::Gas,
     /// The effective gas price at the time of settlement.
-    pub effective_gas_price: eth::EffectiveGasPrice,
+    pub gas_price: eth::EffectiveGasPrice,
     /// Total surplus expressed in native token.
     pub surplus: eth::Ether,
     /// Total fee expressed in native token.

--- a/crates/autopilot/src/domain/settlement/observation.rs
+++ b/crates/autopilot/src/domain/settlement/observation.rs
@@ -1,0 +1,25 @@
+//! Aggregated type containing all important information about the mined
+//! settlement, including the surplus and fees.
+//!
+//! Observation is a snapshot of the settlement state, which purpose is to save
+//! the state of the settlement to the persistence layer.
+
+use {
+    crate::domain::{self, eth},
+    std::collections::HashMap,
+};
+
+#[derive(Debug, Clone)]
+pub struct Observation {
+    /// The gas used by the settlement.
+    pub gas: eth::Gas,
+    /// The effective gas price at the time of settlement.
+    pub effective_gas_price: eth::EffectiveGasPrice,
+    /// Total surplus expressed in native token.
+    pub surplus: eth::Ether,
+    /// Total fee expressed in native token.
+    pub fee: eth::Ether,
+    /// Per order fees denominated in sell token. Contains all orders from the
+    /// settlement
+    pub order_fees: HashMap<domain::OrderUid, Option<eth::SellTokenAmount>>,
+}

--- a/crates/autopilot/src/domain/settlement/solution/trade.rs
+++ b/crates/autopilot/src/domain/settlement/solution/trade.rs
@@ -164,7 +164,6 @@ impl Trade {
                 .checked_div(&self.prices.uniform.sell.into())
                 .ok_or(error::Math::DivisionByZero)?,
         }
-        .0
         .into();
         Ok(fee_in_sell_token)
     }

--- a/crates/autopilot/src/on_settlement_event_updater.rs
+++ b/crates/autopilot/src/on_settlement_event_updater.rs
@@ -191,7 +191,7 @@ impl Inner {
             };
             let domain_separator = self.eth.contracts().settlement_domain_separator();
             let settlement = domain::settlement::Settlement::new(
-                &transaction,
+                transaction,
                 domain_separator,
                 &self.persistence,
             )
@@ -199,7 +199,7 @@ impl Inner {
 
             tracing::info!(
                 "settlement object {:?}",
-                settlement.map(|settlement| settlement.score())
+                settlement.map(|settlement| (settlement.observation(), settlement.score()))
             );
         }
 


### PR DESCRIPTION
# Description
Ports building observation data which is supposed to be saved to the database.

Equivalent to: https://github.com/cowprotocol/services/blob/main/crates/autopilot/src/on_settlement_event_updater.rs#L243-L260

## How to test
Added Observation object printing to `OnSettlementEventUpdater`