### PR TITLE
Price estimator url builder

### DIFF
--- a/crates/shared/src/price_estimation/native/oneinch.rs
+++ b/crates/shared/src/price_estimation/native/oneinch.rs
@@ -107,7 +107,8 @@ async fn get_current_prices(
     chain: u64,
     token_info: &dyn TokenInfoFetching,
 ) -> Result<HashMap<Token, f64>> {
-    let mut builder = client.get(format!("{}/price/v1.1/{}", base_url, chain));
+    let url = crate::url::join(&base_url, &format!("/price/v1.1/{}", chain));
+    let mut builder = client.get(url);
     if let Some(api_key) = api_key {
         builder = builder.header(AUTHORIZATION, api_key)
     }


### PR DESCRIPTION
Mateo recently noticed [this log](https://production-6de61f.kb.eu-central-1.aws.cloud.es.io/app/discover#/doc/ea511870-d9b3-11ed-a9d0-a17451f01cc1/cowlogs-staging-2024.07.25?id=s-oB6pABT_Eo1UawFh3u) where url wasn't really correct. We should avoid using plain `format!` macro when building URLs. So far, noticed that in price estimators.