### PR TITLE
Fix already recorded data for auction_id

### DIFF
--- a/crates/autopilot/src/domain/settlement/mod.rs
+++ b/crates/autopilot/src/domain/settlement/mod.rs
@@ -37,9 +37,18 @@ impl Settlement {
         persistence: &infra::Persistence,
     ) -> Result<Self, Error> {
         let solution = Solution::new(&transaction.input, domain_separator)?;
-        let auction = persistence
-            .get_unprocessed_auction(solution.auction_id())
-            .await?;
+
+        if persistence
+            .auction_has_settlement(solution.auction_id())
+            .await?
+        {
+            // This settlement has already been processed by another environment.
+            //
+            // TODO: remove once https://github.com/cowprotocol/services/issues/2848 is resolved and ~270 days are passed since bumping.
+            return Err(Error::WrongEnvironment);
+        }
+
+        let auction = persistence.get_auction(solution.auction_id()).await?;
 
         Ok(Self {
             solution,
@@ -69,6 +78,10 @@ impl Settlement {
 pub enum Error {
     #[error(transparent)]
     Solution(#[from] solution::Error),
+    #[error("settlement refers to an auction from a different environment")]
+    WrongEnvironment,
+    #[error("connection to the persistence layer failed: {0}")]
+    PersistenceConnection(#[from] infra::persistence::Error),
     #[error(transparent)]
     Auction(#[from] infra::persistence::error::Auction),
 }

--- a/crates/autopilot/src/domain/settlement/mod.rs
+++ b/crates/autopilot/src/domain/settlement/mod.rs
@@ -37,7 +37,9 @@ impl Settlement {
         persistence: &infra::Persistence,
     ) -> Result<Self, Error> {
         let solution = Solution::new(&transaction.input, domain_separator)?;
-        let auction = persistence.get_auction(solution.auction_id()).await?;
+        let auction = persistence
+            .get_unprocessed_auction(solution.auction_id())
+            .await?;
 
         Ok(Self {
             solution,

--- a/crates/autopilot/src/infra/persistence/mod.rs
+++ b/crates/autopilot/src/infra/persistence/mod.rs
@@ -160,8 +160,31 @@ impl Persistence {
             .map_err(Error::DbError)
     }
 
-    /// Get auction if it doesn't have associated settlements.
-    pub async fn get_unprocessed_auction(
+    /// Checks if an auction already has an accociated settlement.
+    ///
+    /// This function is used to detect processing of a staging settlement on
+    /// production and vice versa, because staging and production environments
+    /// don't have a disjunctive sets of auction ids.
+    pub async fn auction_has_settlement(
+        &self,
+        auction_id: domain::auction::Id,
+    ) -> Result<bool, Error> {
+        let _timer = Metrics::get()
+            .database_queries
+            .with_label_values(&["auction_has_settlement"])
+            .start_timer();
+
+        let mut ex = self.postgres.pool.begin().await.context("begin")?;
+
+        Ok(
+            database::settlements::already_processed(&mut ex, auction_id)
+                .await
+                .context("fetch already_processed")?,
+        )
+    }
+
+    /// Get auction data.
+    pub async fn get_auction(
         &self,
         auction_id: domain::auction::Id,
     ) -> Result<domain::settlement::Auction, error::Auction> {
@@ -184,14 +207,6 @@ impl Persistence {
             .map_err(error::Auction::DbError)?
             .ok_or(error::Auction::Missing)
             .map(|scores| (scores.block_deadline as u64).into())?;
-
-        if database::settlements::already_processed(&mut ex, auction_id)
-            .await
-            .context("fetch already_processed")
-            .map_err(error::Auction::DbError)?
-        {
-            return Err(error::Auction::AlreadyProcessed);
-        }
 
         let prices = database::auction_prices::fetch(&mut ex, auction_id)
             .await
@@ -319,8 +334,6 @@ pub mod error {
         DbError(#[source] anyhow::Error),
         #[error("auction data not found in the database")]
         Missing,
-        #[error("auction exists but already processed")]
-        AlreadyProcessed,
         #[error("failed dto conversion from database: {0} for order: {1}")]
         FeePolicy(dto::fee_policy::Error, domain::OrderUid),
         #[error(transparent)]

--- a/crates/autopilot/src/on_settlement_event_updater.rs
+++ b/crates/autopilot/src/on_settlement_event_updater.rs
@@ -312,19 +312,19 @@ impl Inner {
                 );
                 Ok(AuctionIdRecoveryStatus::DoNotAddAuctionData(auction_id))
             }
+            (Some(_), true) => {
+                tracing::warn!(
+                    auction_id,
+                    "settlement data already recorded for this auction"
+                );
+                Ok(AuctionIdRecoveryStatus::DoNotAddAuctionData(auction_id))
+            }
             (Some(score), _) if score.winner.0 != tx_from.0 => {
                 tracing::warn!(
                     auction_id,
                     ?tx_from,
                     winner = ?score.winner,
                     "solution submitted by solver other than the winner"
-                );
-                Ok(AuctionIdRecoveryStatus::DoNotAddAuctionData(auction_id))
-            }
-            (Some(_), true) => {
-                tracing::warn!(
-                    auction_id,
-                    "settlement data already recorded for this auction"
                 );
                 Ok(AuctionIdRecoveryStatus::DoNotAddAuctionData(auction_id))
             }


### PR DESCRIPTION
# Description
Second and third match cases substituted place (code diff shows it a bit unfortunately). 

`settlement data already recorded for this auction` should have a higher priority. The example when this is important is when staging (which is frontrunning production with `auction_id` by ~270 days) reports `solution submitted by solver other than the winner` in cases when it processes production tx with an `auction_id` that is already processed by staging 270 days ago:

https://production-6de61f.kb.eu-central-1.aws.cloud.es.io/app/r/s/nsx2A

Instead, it should first check if the settlement is already processed and skip the settlement, while `solution submitted by solver other than the winner` is a serious violation that should indicate something is wrong (although we currently don't act on it).