### PR TITLE
Quote creation timestamp

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1546,6 +1546,7 @@ dependencies = [
  "bigdecimal",
  "chrono",
  "const_format",
+ "derivative",
  "futures",
  "hex",
  "hex-literal",

--- a/crates/autopilot/src/database/onchain_order_events.rs
+++ b/crates/autopilot/src/database/onchain_order_events.rs
@@ -480,6 +480,7 @@ async fn parse_general_onchain_order_placement_data<'a>(
                     sell_amount: u256_to_big_decimal(&quote.sell_amount),
                     buy_amount: u256_to_big_decimal(&quote.buy_amount),
                     solver: ByteArray(quote.data.solver.0),
+                    creation_timestamp: quote.data.creation,
                 }),
                 Err(err) => {
                     let err_label = err.to_metrics_label();
@@ -1261,6 +1262,7 @@ mod test {
             sell_amount: u256_to_big_decimal(&quote.sell_amount),
             buy_amount: u256_to_big_decimal(&quote.buy_amount),
             solver: ByteArray(quote.data.solver.0),
+            creation_timestamp: quote.data.creation,
         };
         assert_eq!(result.1, vec![Some(expected_quote)]);
         assert_eq!(

--- a/crates/database/Cargo.toml
+++ b/crates/database/Cargo.toml
@@ -9,6 +9,7 @@ license = "MIT OR Apache-2.0"
 bigdecimal = { workspace = true }
 chrono = { workspace = true, features = ["clock"] }
 const_format = "0.2.32"
+derivative = { workspace = true }
 futures = { workspace = true }
 hex = { workspace = true }
 sqlx = { workspace = true }

--- a/crates/orderbook/src/database/orders.rs
+++ b/crates/orderbook/src/database/orders.rs
@@ -208,6 +208,7 @@ async fn insert_quote(
         sell_amount: u256_to_big_decimal(&quote.sell_amount),
         buy_amount: u256_to_big_decimal(&quote.buy_amount),
         solver: ByteArray(quote.data.solver.0),
+        creation_timestamp: quote.data.creation,
     };
     database::orders::insert_quote(ex, &quote)
         .await

--- a/crates/shared/src/event_storing_helpers.rs
+++ b/crates/shared/src/event_storing_helpers.rs
@@ -25,6 +25,7 @@ pub fn create_quote_row(data: QuoteData) -> DbQuote {
         expiration_timestamp: data.expiration,
         quote_kind: data.quote_kind,
         solver: ByteArray(data.solver.0),
+        creation_timestamp: data.creation,
     }
 }
 

--- a/crates/shared/src/order_quoting.rs
+++ b/crates/shared/src/order_quoting.rs
@@ -162,6 +162,7 @@ pub struct QuoteData {
     pub quoted_buy_amount: U256,
     pub fee_parameters: FeeParameters,
     pub kind: OrderKind,
+    pub creation: DateTime<Utc>,
     pub expiration: DateTime<Utc>,
     /// Since different quote kinds have different expirations,
     /// we need to store the quote kind to prevent missuse of quotes.
@@ -189,6 +190,7 @@ impl TryFrom<QuoteRow> for QuoteData {
                 sell_token_price: row.sell_token_price,
             },
             kind: order_kind_from(row.order_kind),
+            creation: row.creation_timestamp,
             expiration: row.expiration_timestamp,
             quote_kind: row.quote_kind,
             solver: H160(row.solver.0),
@@ -442,6 +444,7 @@ impl OrderQuoter {
             quote_kind,
             solver: trade_estimate.solver,
             verified: trade_estimate.verified,
+            creation: Utc::now(),
         };
 
         Ok(quote)
@@ -768,6 +771,7 @@ mod tests {
                 quote_kind: QuoteKind::Standard,
                 solver: H160([1; 20]),
                 verified: false,
+                creation: Default::default(),
             }))
             .returning(|_| Ok(1337));
 
@@ -804,6 +808,7 @@ mod tests {
                     quote_kind: QuoteKind::Standard,
                     solver: H160([1; 20]),
                     verified: false,
+                    creation: Default::default(),
                 },
                 sell_amount: 70.into(),
                 buy_amount: 29.into(),
@@ -903,6 +908,7 @@ mod tests {
                 quote_kind: QuoteKind::Standard,
                 solver: H160([1; 20]),
                 verified: false,
+                creation: Default::default(),
             }))
             .returning(|_| Ok(1337));
 
@@ -939,6 +945,7 @@ mod tests {
                     quote_kind: QuoteKind::Standard,
                     solver: H160([1; 20]),
                     verified: false,
+                    creation: Default::default(),
                 },
                 sell_amount: 100.into(),
                 buy_amount: 42.into(),
@@ -1033,6 +1040,7 @@ mod tests {
                 quote_kind: QuoteKind::Standard,
                 solver: H160([1; 20]),
                 verified: false,
+                creation: Default::default(),
             }))
             .returning(|_| Ok(1337));
 
@@ -1069,6 +1077,7 @@ mod tests {
                     quote_kind: QuoteKind::Standard,
                     solver: H160([1; 20]),
                     verified: false,
+                    creation: Default::default(),
                 },
                 sell_amount: 100.into(),
                 buy_amount: 42.into(),
@@ -1255,6 +1264,7 @@ mod tests {
                 quote_kind: QuoteKind::Standard,
                 solver: H160([1; 20]),
                 verified: false,
+                creation: Default::default(),
             }))
         });
 
@@ -1288,6 +1298,7 @@ mod tests {
                     quote_kind: QuoteKind::Standard,
                     solver: H160([1; 20]),
                     verified: false,
+                    creation: Default::default(),
                 },
                 sell_amount: 85.into(),
                 // Allows for "out-of-price" buy amounts. This means that order
@@ -1335,6 +1346,7 @@ mod tests {
                 quote_kind: QuoteKind::Standard,
                 solver: H160([1; 20]),
                 verified: false,
+                creation: Default::default(),
             }))
         });
 
@@ -1368,6 +1380,7 @@ mod tests {
                     quote_kind: QuoteKind::Standard,
                     solver: H160([1; 20]),
                     verified: false,
+                    creation: Default::default(),
                 },
                 sell_amount: 100.into(),
                 buy_amount: 42.into(),
@@ -1416,6 +1429,7 @@ mod tests {
                         quote_kind: QuoteKind::Standard,
                         solver: H160([1; 20]),
                         verified: false,
+                        creation: Default::default(),
                     },
                 )))
             });
@@ -1450,6 +1464,7 @@ mod tests {
                     quote_kind: QuoteKind::Standard,
                     solver: H160([1; 20]),
                     verified: false,
+                    creation: Default::default(),
                 },
                 sell_amount: 100.into(),
                 buy_amount: 42.into(),

--- a/database/README.md
+++ b/database/README.md
@@ -191,15 +191,16 @@ Indexes:
 
 Quotes that an order was created with. These quotes get stored persistently and can be used to evaluate how accurate the quoted fee predicted the execution cost that actually happened on-chain.
 
- Colmun             | Type    | Nullable | Details
---------------------|---------|----------|--------
- order\_uid         | bytea   | not null | order that this quote belongs to
- gas\_amount        | double  | not null | estimated gas used by the quote used to create this order with
- gas\_price         | double  | not null | gas price at the time of order creation
- sell\_token\_price | double  | not null | ether-denominated price of sell\_token at the time of quoting. The ether value of `x` sell\_tokens is `x * sell_token_price`.
- sell\_amount       | numeric | not null | sell\_amount of the quote used to create the order with
- buy\_amount        | numeric | not null | buy\_amount of the quote used to create the order with
- solver             | bytea   | not null | public address of the solver that provided this quote
+ Colmun              | Type        | Nullable | Details
+---------------------|-------------|----------|--------
+ order\_uid          | bytea       | not null | order that this quote belongs to
+ gas\_amount         | double      | not null | estimated gas used by the quote used to create this order with
+ gas\_price          | double      | not null | gas price at the time of order creation
+ sell\_token\_price  | double      | not null | ether-denominated price of sell\_token at the time of quoting. The ether value of `x` sell\_tokens is `x * sell_token_price`.
+ sell\_amount        | numeric     | not null | sell\_amount of the quote used to create the order with
+ buy\_amount         | numeric     | not null | buy\_amount of the quote used to create the order with
+ solver              | bytea       | not null | public address of the solver that provided this quote
+ creation\_timestamp | timestamptz | not null | when the original quote was created
 
 Indexes:
 - PRIMARY KEY: btree(`order_uid`)
@@ -293,6 +294,7 @@ Stores quotes in order to determine whether it makes sense to allow a user to cr
  sell\_amount          | numeric            | not null | amount that should be sold at most
  buy\_token            | bytea              | not null | address of token that should be bought
  buy\_amount           | numeric            | not null | amount that should be bought at least
+ creation\_timestamp   | timestamptz        | not null | when the quote was created
  expiration\_timestamp | timestamptz        | not null | when the quote should no longer be considered valid. Invalid quotes will get deleted shortly
  order\_kind           | [enum](#orderkind) | not null | trade semantics for the quoted order
  gas\_amount           | double             | not null | estimation of gas used to execute the order according to the quote

--- a/database/sql/V068__add_creation_timestamp_to_quotes.sql
+++ b/database/sql/V068__add_creation_timestamp_to_quotes.sql
@@ -1,0 +1,1 @@
+ALTER TABLE quotes ADD COLUMN creation_timestamp timestamptz NOT NULL DEFAULT now();

--- a/database/sql/V069__add_creation_timestamp_to_order_quotest.sql
+++ b/database/sql/V069__add_creation_timestamp_to_order_quotest.sql
@@ -1,0 +1,1 @@
+ALTER TABLE order_quotes ADD COLUMN creation_timestamp timestamptz NOT NULL DEFAULT now();


### PR DESCRIPTION
# Description
Prerequisite for https://github.com/cowprotocol/services/issues/2813. Quote creation timestamp is required to fulfill the following:
> Inside the single order solver, keep sorting orders by likelihood but also put orders that were quoted in the last couple of minutes by the current solver ahead of the queue, as they are likely going to execute.

# Changes

Adds `creation_timestamp` column to the `quotes` table. Also, adds the same column to the `order_quotes` table, which contains the same value. The alternative solution would be adding `quote_id` and joining the tables to avoid data duplication, but I look in favor of denormalization.

## How to test
Existing tests.