### PR TITLE
Filter jit orders for settlement throughput metric

### DIFF
--- a/crates/autopilot/src/run_loop.rs
+++ b/crates/autopilot/src/run_loop.rs
@@ -565,22 +565,6 @@ impl RunLoop {
 
         auction
     }
-
-    fn report_unsettled_orders(auction: &domain::Auction, solutions: &[Participant]) {
-        if solutions.len() < 2 {
-            return;
-        }
-        // Extract the winning settlement
-        let settled = solutions
-            .last()
-            .expect("early return above")
-            .solution
-            .order_ids()
-            .collect::<HashSet<_>>();
-
-        // Check remaining settlements for orders that had
-        solutions[0..solutions.len() - 1].flat_map(|p| p.solution.orders.filters)
-    }
 }
 
 /// Orders settled in the previous auction that might still be in-flight.


### PR DESCRIPTION
# Description
We have been seeing an increasing number of alerts about insufficient settlement throughput (specifically on Gnosis Chain). From what I can tell this is mainly due to jit orders with tiny amounts not being considered by more sophisticated (external) solvers and thus increasing this metric.

The easiest fix is to simply exclude those orders from the metric.

Alternatively, we could also define a "surplus threshold" and ignore orders that have very little surplus. However, I think since these jit orders are passive liquidity and our "settlement throughput" metric intends to be user facing, filtering these orders out completely seems like a good and simpler choice

# Changes
- [x] Add filter to remove all orders that were not part of the auction

## How to test
Once deployed in prod, expect much reduced logs of the form