### PR TITLE
Fix NonExistentPoolMap

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1555,16 +1555,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "delay_map"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4355c25cbf99edcb6b4a0e906f6bdc6956eda149e84455bea49696429b2f8e8"
-dependencies = [
- "futures",
- "tokio-util",
-]
-
-[[package]]
 name = "der"
 version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2746,6 +2736,12 @@ dependencies = [
  "pkg-config",
  "vcpkg",
 ]
+
+[[package]]
+name = "linked-hash-map"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
 name = "linux-raw-sys"
@@ -4147,7 +4143,6 @@ dependencies = [
  "clap",
  "contracts",
  "database",
- "delay_map",
  "derivative",
  "ethcontract",
  "ethcontract-mock",
@@ -4187,6 +4182,7 @@ dependencies = [
  "tokio-stream",
  "tracing",
  "tracing-subscriber",
+ "ttl_cache",
  "url",
  "warp",
  "web3",
@@ -4885,7 +4881,6 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "pin-project-lite",
- "slab",
  "tokio",
 ]
 
@@ -5049,6 +5044,15 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "ttl_cache"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4189890526f0168710b6ee65ceaedf1460c48a14318ceec933cb26baa492096a"
+dependencies = [
+ "linked-hash-map",
+]
 
 [[package]]
 name = "typenum"

--- a/crates/shared/Cargo.toml
+++ b/crates/shared/Cargo.toml
@@ -20,7 +20,7 @@ chrono = { workspace = true, features = ["clock"] }
 clap = { workspace = true }
 contracts = { path = "../contracts" }
 database = { path = "../database" }
-delay_map = "0.3"
+ttl_cache = "0.5"
 derivative = { workspace = true }
 ethcontract = { workspace = true }
 ethrpc = { path = "../ethrpc" }

--- a/crates/shared/src/sources/uniswap_v2.rs
+++ b/crates/shared/src/sources/uniswap_v2.rs
@@ -116,11 +116,8 @@ impl UniV2BaselineSourceParameters {
             PoolReadingStyle::Default => Box::new(pool_reader),
             PoolReadingStyle::Swapr => Box::new(SwaprPoolReader(pool_reader)),
         };
-        let fetcher = pool_fetching::PoolFetcher {
-            pool_reader,
-            web3: web3.clone(),
-            non_existent_pools: Default::default(),
-        };
+        let fetcher =
+            pool_fetching::PoolFetcher::new(pool_reader, web3.clone(), Default::default());
         Ok(UniV2BaselineSource {
             router,
             pair_provider,

--- a/crates/shared/src/sources/uniswap_v2/pool_fetching.rs
+++ b/crates/shared/src/sources/uniswap_v2/pool_fetching.rs
@@ -15,7 +15,7 @@ use {
     },
     model::TokenPair,
     num::rational::Ratio,
-    std::{collections::HashSet, sync::RwLock, time::Duration, usize},
+    std::{collections::HashSet, sync::RwLock, time::Duration},
     ttl_cache::TtlCache,
 };
 


### PR DESCRIPTION
# Description
We have been using [HashSetDelay](https://docs.rs/delay_map/latest/delay_map/hashset_delay/struct.HashSetDelay.html) incorrectly. The expiration time is only respected if the set is turned into a stream and awaited on (it will return `Err` for expired items).

This interface is very clunky and doesn't really serve our use case.

# Changes
<!-- List of detailed changes (how the change is accomplished) -->

- [ ] Replace HashSetDelay with TtlCache which has a much more intuitive interface

## How to test
Existing tests pass. Also, in the next PR I will add an e2e test that actually relies on the non-existent pool cache to be reset (as liquidity appears throughout the lifetime of the test)