### PR TITLE
CoinGecko: Fix xdai native prices

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -29,6 +29,17 @@ checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "ahash"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "891477e0c6a8957309ee5c45a6368af3ae14bb510732d2684ffa19af310920f9"
+dependencies = [
+ "getrandom",
+ "once_cell",
+ "version_check",
+]
+
+[[package]]
+name = "ahash"
 version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
@@ -483,7 +494,7 @@ version = "1.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "724119d8fd2d2638b9979673f3b5c2979fa388c9ca27815e3cb5ad6234fac3f5"
 dependencies = [
- "ahash",
+ "ahash 0.8.11",
  "aws-credential-types 1.2.0",
  "aws-runtime",
  "aws-sigv4 1.2.1",
@@ -1141,6 +1152,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "borsh"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6362ed55def622cddc70a4746a68554d7b687713770de539e59a739b249f8ed"
+dependencies = [
+ "borsh-derive",
+ "cfg_aliases",
+]
+
+[[package]]
+name = "borsh-derive"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3ef8005764f53cd4dca619f5bf64cafd4664dada50ece25e4d81de54c80cc0b"
+dependencies = [
+ "once_cell",
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.66",
+ "syn_derive",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1151,6 +1186,28 @@ name = "byte-slice-cast"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3ac9f8b63eca6fd385229b3675f6cc0dc5c8a5c8a54a59d4f52ffd670d87b0c"
+
+[[package]]
+name = "bytecheck"
+version = "0.6.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23cdc57ce23ac53c931e88a43d06d070a6fd142f2617be5855eb75efc9beb1c2"
+dependencies = [
+ "bytecheck_derive",
+ "ptr_meta",
+ "simdutf8",
+]
+
+[[package]]
+name = "bytecheck_derive"
+version = "0.6.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3db406d29fbcd95542e92559bed4d8ad92636d1ca8b3b72ede10b4bcc010e659"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
 
 [[package]]
 name = "byteorder"
@@ -1207,6 +1264,12 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
@@ -2235,6 +2298,9 @@ name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+dependencies = [
+ "ahash 0.7.8",
+]
 
 [[package]]
 name = "hashbrown"
@@ -2242,7 +2308,7 @@ version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 dependencies = [
- "ahash",
+ "ahash 0.8.11",
  "allocator-api2",
 ]
 
@@ -3475,6 +3541,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro-error"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+dependencies = [
+ "proc-macro-error-attr",
+ "proc-macro2",
+ "quote",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "version_check",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3531,6 +3620,26 @@ name = "psl-types"
 version = "2.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33cb294fe86a74cbcf50d4445b37da762029549ebeea341421c7c70370f86cac"
+
+[[package]]
+name = "ptr_meta"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0738ccf7ea06b608c10564b31debd4f5bc5e197fc8bfe088f68ae5ce81e7a4f1"
+dependencies = [
+ "ptr_meta_derive",
+]
+
+[[package]]
+name = "ptr_meta_derive"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16b845dbfca988fa33db069c0e230574d15a3088f147a87b64c7589eb662c9ac"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
 
 [[package]]
 name = "publicsuffix"
@@ -3702,6 +3811,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adad44e29e4c806119491a7f06f03de4d1af22c3a680dd47f1e6e179439d1f56"
 
 [[package]]
+name = "rend"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71fe3824f5629716b1589be05dacd749f6aa084c87e00e016714a8cdfccc997c"
+dependencies = [
+ "bytecheck",
+]
+
+[[package]]
 name = "reqwest"
 version = "0.11.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3776,6 +3894,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "rkyv"
+version = "0.7.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cba464629b3394fc4dbc6f940ff8f5b4ff5c7aef40f29166fd4ad12acbc99c0"
+dependencies = [
+ "bitvec",
+ "bytecheck",
+ "bytes",
+ "hashbrown 0.12.3",
+ "ptr_meta",
+ "rend",
+ "rkyv_derive",
+ "seahash",
+ "tinyvec",
+ "uuid",
+]
+
+[[package]]
+name = "rkyv_derive"
+version = "0.7.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7dddfff8de25e6f62b9d64e6e432bf1c6736c57d20323e15ee10435fbda7c65"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "rlp"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3803,6 +3950,22 @@ dependencies = [
  "spki",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "rust_decimal"
+version = "1.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1790d1c4c0ca81211399e0e0af16333276f375209e71a37b67698a373db5b47a"
+dependencies = [
+ "arrayvec",
+ "borsh",
+ "bytes",
+ "num-traits",
+ "rand",
+ "rkyv",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -3950,6 +4113,12 @@ dependencies = [
  "ring 0.17.8",
  "untrusted 0.9.0",
 ]
+
+[[package]]
+name = "seahash"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
 
 [[package]]
 name = "secp256k1"
@@ -4174,6 +4343,7 @@ dependencies = [
  "rate-limit",
  "regex",
  "reqwest",
+ "rust_decimal",
  "secp256k1",
  "serde",
  "serde_json",
@@ -4210,6 +4380,12 @@ dependencies = [
  "digest",
  "rand_core",
 ]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f27f6278552951f1f2b8cf9da965d10969b2efdea95a6ec47987ab46edfe263a"
 
 [[package]]
 name = "slab"
@@ -4399,7 +4575,7 @@ version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24ba59a9342a3d9bab6c56c118be528b27c9b60e490080e9711a04dccac83ef6"
 dependencies = [
- "ahash",
+ "ahash 0.8.11",
  "atoi",
  "bigdecimal",
  "byteorder",
@@ -4654,6 +4830,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "syn_derive"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1329189c02ff984e9736652b1631330da25eaa6bc639089ed4915d25446cbe7b"
+dependencies = [
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.66",
 ]
 
 [[package]]

--- a/crates/autopilot/src/run.rs
+++ b/crates/autopilot/src/run.rs
@@ -329,7 +329,9 @@ pub async fn run(args: Arguments) {
         .native_price_estimator(
             args.native_price_estimators.as_slice(),
             args.native_price_estimation_results_required,
+            eth.contracts().weth().clone(),
         )
+        .await
         .unwrap();
     let price_estimator = price_estimator_factory
         .price_estimator(

--- a/crates/orderbook/src/run.rs
+++ b/crates/orderbook/src/run.rs
@@ -276,7 +276,9 @@ pub async fn run(args: Arguments) {
         .native_price_estimator(
             args.native_price_estimators.as_slice(),
             args.fast_price_estimation_results_required,
+            native_token.clone(),
         )
+        .await
         .unwrap();
     let price_estimator = price_estimator_factory
         .price_estimator(

--- a/crates/shared/Cargo.toml
+++ b/crates/shared/Cargo.toml
@@ -45,6 +45,7 @@ prometheus = { workspace = true }
 prometheus-metric-storage = { workspace = true }
 rate-limit = { path = "../rate-limit" }
 reqwest = { workspace = true, features = ["cookies", "gzip", "json"] }
+rust_decimal = "1.35.0"
 secp256k1 = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/shared/src/price_estimation/native/coingecko.rs
+++ b/crates/shared/src/price_estimation/native/coingecko.rs
@@ -3,8 +3,10 @@ use {
     crate::price_estimation::PriceEstimationError,
     anyhow::{anyhow, Result},
     futures::{future::BoxFuture, FutureExt},
+    lazy_static::lazy_static,
     primitive_types::H160,
     reqwest::{Client, StatusCode},
+    rust_decimal::prelude::ToPrimitive,
     serde::Deserialize,
     std::collections::HashMap,
     url::Url,
@@ -25,6 +27,18 @@ pub struct CoinGecko {
     base_url: Url,
     api_key: Option<String>,
     chain: String,
+    native_price: NativePrice,
+}
+
+enum NativePrice {
+    Eth,
+    Other(Token),
+}
+
+lazy_static! {
+    static ref WXDAI_TOKEN_ADDRESS: H160 = "0xe91d153e0b41518a2ce8dd3d7944fa863463a97d"
+        .parse()
+        .unwrap();
 }
 
 impl CoinGecko {
@@ -37,10 +51,10 @@ impl CoinGecko {
         api_key: Option<String>,
         chain_id: u64,
     ) -> Result<Self> {
-        let chain = match chain_id {
-            1 => "ethereum".to_string(),
-            100 => "xdai".to_string(),
-            42161 => "arbitrum-one".to_string(),
+        let (chain, native_price) = match chain_id {
+            1 => ("ethereum".to_string(), NativePrice::Eth),
+            100 => ("xdai".to_string(), NativePrice::Other(*WXDAI_TOKEN_ADDRESS)),
+            42161 => ("arbitrum-one".to_string(), NativePrice::Eth),
             n => anyhow::bail!("unsupported network {n}"),
         };
         Ok(Self {
@@ -48,57 +62,90 @@ impl CoinGecko {
             base_url,
             api_key,
             chain,
+            native_price,
         })
+    }
+
+    pub async fn send_request_price_in_eth(&self, token: Token) -> NativePriceEstimateResult {
+        let mut url = crate::url::join(&self.base_url, &self.chain);
+        url.query_pairs_mut()
+            .append_pair("contract_addresses", &format!("{:#x}", token))
+            .append_pair("vs_currencies", "eth")
+            .append_pair("precision", "full");
+        let mut builder = self.client.get(url.clone());
+        if let Some(ref api_key) = self.api_key {
+            builder = builder.header(Self::AUTHORIZATION, api_key)
+        }
+        observe::coingecko_request(&url);
+        let response = builder.send().await.map_err(|e| {
+            PriceEstimationError::EstimatorInternal(anyhow!(
+                "failed to sent CoinGecko price request: {e:?}"
+            ))
+        })?;
+        if !response.status().is_success() {
+            let status = response.status();
+            return match status {
+                StatusCode::TOO_MANY_REQUESTS => Err(PriceEstimationError::RateLimited),
+                status => Err(PriceEstimationError::EstimatorInternal(anyhow!(
+                    "failed to retrieve prices from CoinGecko: error with status code {status}."
+                ))),
+            };
+        }
+        let response = response.text().await;
+        observe::coingecko_response(&url, response.as_deref());
+        let response = response.map_err(|e| {
+            PriceEstimationError::EstimatorInternal(anyhow!(
+                "failed to fetch native CoinGecko prices: {e:?}"
+            ))
+        })?;
+        let prices = serde_json::from_str::<Response>(&response)
+            .map_err(|e| {
+                PriceEstimationError::EstimatorInternal(anyhow!(
+                    "failed to parse native CoinGecko prices from {response:?}: {e:?}"
+                ))
+            })?
+            .0;
+
+        let price = prices
+            .get(&token)
+            .ok_or(PriceEstimationError::NoLiquidity)?;
+        Ok(price.eth)
     }
 }
 
 impl NativePriceEstimating for CoinGecko {
     fn estimate_native_price(&self, token: Token) -> BoxFuture<'_, NativePriceEstimateResult> {
         async move {
-            let mut url = crate::url::join(&self.base_url, &self.chain);
-            url.query_pairs_mut()
-                .append_pair("contract_addresses", &format!("{:#x}", token))
-                .append_pair("vs_currencies", "eth")
-                .append_pair("precision", "full");
-            let mut builder = self.client.get(url.clone());
-            if let Some(ref api_key) = self.api_key {
-                builder = builder.header(Self::AUTHORIZATION, api_key)
+            match self.native_price {
+                NativePrice::Eth => self.send_request_price_in_eth(token).await,
+                NativePrice::Other(native_price_token) => {
+                    let token_eth = rust_decimal::Decimal::try_from(
+                        self.send_request_price_in_eth(token).await?,
+                    )
+                    .map_err(|e| {
+                        PriceEstimationError::EstimatorInternal(anyhow!(
+                            "failed to parse requested token in ETH to rust decimal: {e:?}"
+                        ))
+                    })?;
+                    let native_price_token_eth = rust_decimal::Decimal::try_from(
+                        self.send_request_price_in_eth(native_price_token).await?,
+                    )
+                    .map_err(|e| {
+                        PriceEstimationError::EstimatorInternal(anyhow!(
+                            "failed to parse native price token in ETH to rust decimal: {e:?}"
+                        ))
+                    })?;
+                    let token_in_native_price =
+                        token_eth.checked_div(native_price_token_eth).ok_or(
+                            PriceEstimationError::EstimatorInternal(anyhow!("division by zero")),
+                        )?;
+                    token_in_native_price
+                        .to_f64()
+                        .ok_or(PriceEstimationError::EstimatorInternal(anyhow!(
+                            "failed to parse result to f64"
+                        )))
+                }
             }
-            observe::coingecko_request(&url);
-            let response = builder.send().await.map_err(|e| {
-                PriceEstimationError::EstimatorInternal(anyhow!(
-                    "failed to sent CoinGecko price request: {e:?}"
-                ))
-            })?;
-            if !response.status().is_success() {
-                let status = response.status();
-                return match status {
-                    StatusCode::TOO_MANY_REQUESTS => Err(PriceEstimationError::RateLimited),
-                    status => Err(PriceEstimationError::EstimatorInternal(anyhow!(
-                        "failed to retrieve prices from CoinGecko: error with status code \
-                         {status}."
-                    ))),
-                };
-            }
-            let response = response.text().await;
-            observe::coingecko_response(&url, response.as_deref());
-            let response = response.map_err(|e| {
-                PriceEstimationError::EstimatorInternal(anyhow!(
-                    "failed to fetch native CoinGecko prices: {e:?}"
-                ))
-            })?;
-            let prices = serde_json::from_str::<Response>(&response)
-                .map_err(|e| {
-                    PriceEstimationError::EstimatorInternal(anyhow!(
-                        "failed to parse native CoinGecko prices from {response:?}: {e:?}"
-                    ))
-                })?
-                .0;
-
-            let price = prices
-                .get(&token)
-                .ok_or(PriceEstimationError::NoLiquidity)?;
-            Ok(price.eth)
         }
         .boxed()
     }
@@ -143,6 +190,20 @@ mod tests {
         let estimated_price = instance.estimate_native_price(native_token).await.unwrap();
         // Since the WETH precise price against ETH is not always exact to 1.0 (it can
         // vary slightly)
+        assert!((0.95..=1.05).contains(&estimated_price));
+    }
+
+    #[tokio::test]
+    #[ignore]
+    async fn works_xdai() {
+        // USDT
+        let native_token = H160::from_str("0x4ECaBa5870353805a9F068101A40E0f32ed605C6").unwrap();
+        let instance =
+            CoinGecko::new(Client::default(), Url::parse(BASE_URL).unwrap(), None, 100).unwrap();
+
+        let estimated_price = instance.estimate_native_price(native_token).await.unwrap();
+        // Since the USDT precise price against XDAI is not always exact to 1.0
+        // (it can vary slightly)
         assert!((0.95..=1.05).contains(&estimated_price));
     }
 }


### PR DESCRIPTION
# Description
CoinGecko does not support fetching native prices for xdai (meaning prices of tokens against wxDai price). So, it is needed to calculate the native price by also fetching the wxDai native price.

# Changes
- For xdai network, do two requests in order to properly calculate the native price

## How to test
1. Unit test