### PR TITLE
fix: lowercase orderbook CompetitionOrderStatus types to match real output

### DIFF
--- a/crates/orderbook/openapi.yml
+++ b/crates/orderbook/openapi.yml
@@ -1070,13 +1070,13 @@ components:
         type:
           type: string
           enum:
-            - Open
-            - Scheduled
-            - Active
-            - Solved
-            - Executing
-            - Traded
-            - Cancelled
+            - open
+            - scheduled
+            - active
+            - solved
+            - executing
+            - traded
+            - cancelled
         value:
           description: |
             A list of solvers who participated in the latest competition. The presence of executed amounts defines whether the solver provided a solution for the desired order.


### PR DESCRIPTION
# Description

Lower case CompetitionOrderStatus types

Response is lower cased. [Example](https://barn.api.cow.fi/sepolia/api/v1/orders/0x00b398add57a13185949207383bdedecd5fd5f566c7273d62746273eb7565d225b0abe214ab7875562adee331deff0fe1912fe4266acef0c/status):

```
{"type":"traded","value":[{"solver":"baseline","executedAmounts":{"sell":"88000000000000000000","buy":"247730171894119905"}},{"solver":"quasimodo","executedAmounts":{"sell":"88000000000000000000","buy":"250215016055879850"}}]}
```

However, types on open api definition are capital cased:

![image](https://github.com/user-attachments/assets/e9f956e3-5868-4c30-b352-77604c269ad5)

Which makes clients depending on it to derive wrong types.


# Changes
- [ ] Update orderbook openapi definition

## How to test

Check corresponding openapi docs