### PR TITLE
[TRIVIAL] Move commit to bottom of OnSettlementEventUpdater

### DIFF
--- a/crates/autopilot/src/on_settlement_event_updater.rs
+++ b/crates/autopilot/src/on_settlement_event_updater.rs
@@ -177,11 +177,6 @@ impl Inner {
 
         tracing::debug!(?hash, ?update, "updating settlement details for tx");
 
-        Postgres::update_settlement_details(&mut ex, update.clone())
-            .await
-            .with_context(|| format!("insert_settlement_details: {update:?}"))?;
-        ex.commit().await?;
-
         {
             // temporary to debug and compare with current implementation
             // TODO: use instead of current implementation
@@ -202,6 +197,11 @@ impl Inner {
                 settlement.map(|settlement| (settlement.observation()))
             );
         }
+
+        Postgres::update_settlement_details(&mut ex, update.clone())
+            .await
+            .with_context(|| format!("insert_settlement_details: {update:?}"))?;
+        ex.commit().await?;
 
         Ok(true)
     }


### PR DESCRIPTION
# Description
Moves committing to database bellow the temporary added code that builds the domain::Settlement because domain:Settlement reports `WrongEnvironment` for each settlement if settlement is already processed (saved to database).

This is needed to test the new Settlement code.