### PR TITLE
Native prices: Implement batching 1/2

### DIFF
--- a/crates/autopilot/src/solvable_orders.rs
+++ b/crates/autopilot/src/solvable_orders.rs
@@ -845,6 +845,7 @@ mod tests {
             None,
             Default::default(),
             1,
+            None,
         );
         let metrics = Metrics::instance(observe::metrics::get_storage_registry()).unwrap();
 
@@ -852,7 +853,7 @@ mod tests {
         // background task to fetch the missing prices so we'll have them in the
         // next call.
         let (filtered_orders, prices) =
-            get_orders_with_native_prices(orders.clone(), &native_price_estimator, metrics);
+            get_orders_with_native_prices(orders.clone(), &native_price_estimator, metrics).await;
         assert!(filtered_orders.is_empty());
         assert!(prices.is_empty());
 
@@ -861,7 +862,7 @@ mod tests {
 
         // Now we have all the native prices we want.
         let (filtered_orders, prices) =
-            get_orders_with_native_prices(orders.clone(), &native_price_estimator, metrics);
+            get_orders_with_native_prices(orders.clone(), &native_price_estimator, metrics).await;
 
         assert_eq!(filtered_orders, [orders[2].clone()]);
         assert_eq!(

--- a/crates/shared/src/price_estimation/factory.rs
+++ b/crates/shared/src/price_estimation/factory.rs
@@ -325,6 +325,7 @@ impl<'a> PriceEstimatorFactory<'a> {
             Some(self.args.native_price_cache_max_update_size),
             self.args.native_price_prefetch_time,
             self.args.native_price_cache_concurrent_requests,
+            None,
         ));
         Ok(native_estimator)
     }

--- a/crates/shared/src/price_estimation/native_price_cache.rs
+++ b/crates/shared/src/price_estimation/native_price_cache.rs
@@ -1,14 +1,20 @@
 use {
     super::PriceEstimationError,
     crate::price_estimation::native::{NativePriceEstimateResult, NativePriceEstimating},
+    anyhow::anyhow,
+    async_trait::async_trait,
     futures::{FutureExt, StreamExt},
     indexmap::IndexSet,
     primitive_types::H160,
     prometheus::{IntCounter, IntCounterVec, IntGauge},
     std::{
-        collections::{hash_map::Entry, HashMap},
-        sync::{Arc, Mutex, MutexGuard, Weak},
+        collections::{hash_map::Entry, HashMap, HashSet},
+        sync::{Arc, Mutex, Weak},
         time::{Duration, Instant},
+    },
+    tokio::{
+        sync::{mpsc, Mutex as TokioMutex, MutexGuard},
+        time::{interval, sleep},
     },
     tracing::Instrument,
 };
@@ -24,6 +30,134 @@ struct Metrics {
     native_price_cache_background_updates: IntCounter,
     /// number of items in cache that are outdated
     native_price_cache_outdated_entries: IntGauge,
+}
+
+/// Trait for fetching a batch of native price estimates.
+#[mockall::automock]
+#[async_trait]
+pub trait NativePriceBatchFetcher: Sync + Send {
+    /// Maximum batch size the `fetch_native_prices()` can take
+    fn max_batch_size(&self) -> usize;
+
+    /// Fetches a batch of native price estimates. It fetches a maximum of
+    /// `max_batch_size()` elements
+    ///
+    /// It returns a HashMap which maps the token with its price
+    async fn fetch_native_prices(
+        &self,
+        tokens: &HashSet<H160>,
+    ) -> Result<HashMap<H160, f64>, PriceEstimationError>;
+}
+
+struct Batching {
+    period: Duration,
+    cache: Arc<TokioMutex<HashMap<H160, CachedResult>>>,
+    sender: mpsc::UnboundedSender<H160>,
+}
+
+impl Batching {
+    /// Maximum number of tries for fetching the price from the cache
+    const MAX_TRIES: usize = 3;
+
+    fn new(
+        cache: Arc<TokioMutex<HashMap<H160, CachedResult>>>,
+        period: Duration,
+        fetcher: Arc<dyn NativePriceBatchFetcher>,
+    ) -> Self {
+        let (sender, receiver) = mpsc::unbounded_channel::<H160>();
+
+        tokio::task::spawn(Self::run(receiver, cache.clone(), fetcher, period));
+
+        Self {
+            period,
+            cache,
+            sender,
+        }
+    }
+
+    async fn run(
+        mut receiver: mpsc::UnboundedReceiver<H160>,
+        cache: Arc<TokioMutex<HashMap<H160, CachedResult>>>,
+        fetcher: Arc<dyn NativePriceBatchFetcher>,
+        period: Duration,
+    ) {
+        let mut interval = interval(period);
+        loop {
+            // Wait for the internal tick
+            interval.tick().await;
+
+            let mut tokens = HashSet::new();
+
+            // Collect up to `MAX_BATCH_SIZE` tokens from the receiver
+            for _ in 0..fetcher.max_batch_size() {
+                match receiver.try_recv() {
+                    Ok(token) => {
+                        tokens.insert(token);
+                    }
+                    // No more messages to process
+                    Err(mpsc::error::TryRecvError::Empty) => break,
+                    Err(mpsc::error::TryRecvError::Disconnected) => {
+                        tracing::error!("native price batching: disconnected");
+                        continue;
+                    }
+                }
+            }
+
+            if !tokens.is_empty() {
+                // Call the fetcher with the collected addresses
+                match fetcher.fetch_native_prices(&tokens).await {
+                    Ok(results) => {
+                        let now = Instant::now();
+                        // Update the cache with the fetched results
+                        let mut cache_lock = cache.lock().await;
+                        for (address, result) in results {
+                            let cached_result = CachedResult {
+                                result: Ok(result),
+                                updated_at: now,
+                                requested_at: now,
+                            };
+                            cache_lock
+                                .entry(address)
+                                .and_modify(|entry| *entry = cached_result.clone())
+                                .or_insert(cached_result);
+                        }
+                    }
+                    Err(e) => {
+                        tracing::error!(?e, "failed to fetch native prices");
+                        continue;
+                    }
+                }
+            }
+        }
+    }
+
+    async fn request_native_price(&self, token: &H160) -> Result<(), PriceEstimationError> {
+        self.sender.send(*token).map_err(|e| {
+            PriceEstimationError::ProtocolInternal(anyhow!(
+                "failed to append a new token to the queue: {e:?}"
+            ))
+        })
+    }
+
+    async fn blocking_estimate_prices_and_update_cache(
+        &self,
+        token: &H160,
+    ) -> Result<Option<f64>, PriceEstimationError> {
+        // Sends the token for requesting price
+        self.request_native_price(token).await?;
+
+        for _ in 0..Self::MAX_TRIES {
+            // Check if the value is already in the cache
+            {
+                if let Some(price) = self.cache.lock().await.get(token) {
+                    return price.result.clone().map(Some);
+                }
+            }
+            sleep(self.period).await;
+        }
+
+        Ok(None)
+    }
 }
 
 impl Metrics {
@@ -42,10 +176,11 @@ impl Metrics {
 pub struct CachingNativePriceEstimator(Arc<Inner>);
 
 struct Inner {
-    cache: Mutex<HashMap<H160, CachedResult>>,
+    cache: Arc<TokioMutex<HashMap<H160, CachedResult>>>,
     high_priority: Mutex<IndexSet<H160>>,
     estimator: Box<dyn NativePriceEstimating>,
     max_age: Duration,
+    batching: Option<Batching>,
 }
 
 struct UpdateTask {
@@ -99,6 +234,25 @@ impl Inner {
         }
     }
 
+    async fn blocking_estimate_prices_and_update_cache(
+        &self,
+        token: &H160,
+        max_age: Duration,
+    ) -> Result<Option<f64>, PriceEstimationError> {
+        if let Some(batching) = self.batching.as_ref() {
+            batching
+                .blocking_estimate_prices_and_update_cache(token)
+                .await
+        } else {
+            // If the batching is not configured, use the legacy method
+            self.estimate_prices_and_update_cache(&[*token], max_age, 1)
+                .next()
+                .await
+                .map(|(_, price)| price)
+                .transpose()
+        }
+    }
+
     /// Checks cache for the given tokens one by one. If the price is already
     /// cached it gets returned. If it's not in the cache a new price
     /// estimation request gets issued. We check the cache before each
@@ -117,7 +271,7 @@ impl Inner {
                 {
                     // check if price is cached by now
                     let now = Instant::now();
-                    let mut cache = self.cache.lock().unwrap();
+                    let mut cache = self.cache.lock().await;
                     let price = Self::get_cached_price(*token, now, &mut cache, &max_age, false);
                     if let Some(price) = price {
                         return (index, price);
@@ -129,7 +283,7 @@ impl Inner {
                 // update price in cache
                 if should_cache(&result) {
                     let now = Instant::now();
-                    let mut cache = self.cache.lock().unwrap();
+                    let mut cache = self.cache.lock().await;
                     cache.insert(
                         *token,
                         CachedResult {
@@ -148,11 +302,11 @@ impl Inner {
     }
 
     /// Tokens with highest priority first.
-    fn sorted_tokens_to_update(&self, max_age: Duration, now: Instant) -> Vec<H160> {
+    async fn sorted_tokens_to_update(&self, max_age: Duration, now: Instant) -> Vec<H160> {
         let mut outdated: Vec<_> = self
             .cache
             .lock()
-            .unwrap()
+            .await
             .iter()
             .filter(|(_, cached)| now.saturating_duration_since(cached.updated_at) > max_age)
             .map(|(token, cached)| (*token, cached.requested_at))
@@ -192,10 +346,10 @@ impl UpdateTask {
         let metrics = Metrics::get();
         metrics
             .native_price_cache_size
-            .set(i64::try_from(inner.cache.lock().unwrap().len()).unwrap_or(i64::MAX));
+            .set(i64::try_from(inner.cache.lock().await.len()).unwrap_or(i64::MAX));
 
         let max_age = inner.max_age.saturating_sub(self.prefetch_time);
-        let mut outdated_entries = inner.sorted_tokens_to_update(max_age, Instant::now());
+        let mut outdated_entries = inner.sorted_tokens_to_update(max_age, Instant::now()).await;
 
         metrics
             .native_price_cache_outdated_entries
@@ -241,12 +395,16 @@ impl CachingNativePriceEstimator {
         update_size: Option<usize>,
         prefetch_time: Duration,
         concurrent_requests: usize,
+        fetcher: Option<Arc<dyn NativePriceBatchFetcher>>,
     ) -> Self {
+        let cache: Arc<TokioMutex<HashMap<H160, CachedResult>>> = Default::default();
         let inner = Arc::new(Inner {
             estimator,
-            cache: Default::default(),
+            cache: cache.clone(),
             high_priority: Default::default(),
             max_age,
+            batching: fetcher
+                .map(|fetcher| Batching::new(cache.clone(), Duration::from_millis(50), fetcher)),
         });
 
         let update_task = UpdateTask {
@@ -266,12 +424,12 @@ impl CachingNativePriceEstimator {
     /// Only returns prices that are currently cached. Missing prices will get
     /// prioritized to get fetched during the next cycles of the maintenance
     /// background task.
-    pub fn get_cached_prices(
+    pub async fn get_cached_prices(
         &self,
         tokens: &[H160],
     ) -> HashMap<H160, Result<f64, PriceEstimationError>> {
         let now = Instant::now();
-        let mut cache = self.0.cache.lock().unwrap();
+        let mut cache = self.0.cache.lock().await;
         let mut results = HashMap::default();
         for token in tokens {
             let cached = Inner::get_cached_price(*token, now, &mut cache, &self.0.max_age, true);
@@ -300,7 +458,7 @@ impl NativePriceEstimating for CachingNativePriceEstimator {
         async move {
             let cached = {
                 let now = Instant::now();
-                let mut cache = self.0.cache.lock().unwrap();
+                let mut cache = self.0.cache.lock().await;
                 Inner::get_cached_price(token, now, &mut cache, &self.0.max_age, false)
             };
 
@@ -315,11 +473,9 @@ impl NativePriceEstimating for CachingNativePriceEstimator {
             }
 
             self.0
-                .estimate_prices_and_update_cache(&[token], self.0.max_age, 1)
-                .next()
-                .await
-                .unwrap()
-                .1
+                .blocking_estimate_prices_and_update_cache(&token, self.0.max_age)
+                .await?
+                .ok_or(PriceEstimationError::NoLiquidity)
         }
         .boxed()
     }
@@ -333,12 +489,57 @@ mod tests {
             native::{MockNativePriceEstimating, NativePriceEstimating},
             PriceEstimationError,
         },
-        futures::FutureExt,
+        futures::{future::try_join_all, FutureExt},
         num::ToPrimitive,
     };
 
     fn token(u: u64) -> H160 {
         H160::from_low_u64_be(u)
+    }
+
+    #[tokio::test]
+    async fn caches_from_batch_request_successful_estimates() {
+        let mut inner = MockNativePriceEstimating::new();
+        inner
+            .expect_estimate_native_price()
+            // Because it gets the value from the batch estimator, it does not need to do this call at all
+            .never();
+
+        let mut native_price_batch_fetcher = MockNativePriceBatchFetcher::new();
+        native_price_batch_fetcher
+            .expect_max_batch_size()
+            .returning(|| 20);
+        native_price_batch_fetcher
+            .expect_fetch_native_prices()
+            // We expect this to be requested just one, because for the second call it fetches the cached one
+            .times(1)
+            .returning(|input| {
+                Ok(input
+                    .iter()
+                    .map(|token| (*token, 1.0))
+                    .collect::<HashMap<_, _>>())
+            });
+        let fetcher: Arc<dyn NativePriceBatchFetcher> = Arc::new(native_price_batch_fetcher);
+
+        let estimator = CachingNativePriceEstimator::new(
+            Box::new(inner),
+            // The maintenance cache updater runs every 250 ms
+            Duration::from_millis(250),
+            Default::default(),
+            None,
+            Default::default(),
+            1,
+            Some(fetcher),
+        );
+
+        // We wait some time so the maintenance has run at least one
+        sleep(Duration::from_millis(100)).await;
+
+        for _ in 0..10 {
+            // Launch requests and see we get the response `1` from the native batch fetcher instead of the one from the maintenance job
+            let result = estimator.estimate_native_price(token(0)).await;
+            assert!(result.as_ref().unwrap().to_i64().unwrap() == 1);
+        }
     }
 
     #[tokio::test]
@@ -356,12 +557,200 @@ mod tests {
             None,
             Default::default(),
             1,
+            None,
         );
 
         for _ in 0..10 {
             let result = estimator.estimate_native_price(token(0)).await;
             assert!(result.as_ref().unwrap().to_i64().unwrap() == 1);
         }
+    }
+
+    #[tokio::test]
+    async fn batching_successful_estimates() {
+        let mut native_price_batch_fetcher = MockNativePriceBatchFetcher::new();
+        native_price_batch_fetcher
+            .expect_max_batch_size()
+            .returning(|| 20);
+        native_price_batch_fetcher
+            .expect_fetch_native_prices()
+            // We expect this to be requested just one, because for the second call it fetches the cached one
+            .times(1)
+            .returning(|input| {
+                Ok(input
+                    .iter()
+                    .map(|token| (*token, 1.0))
+                    .collect::<HashMap<_, _>>())
+            });
+        let cache: Arc<TokioMutex<HashMap<H160, CachedResult>>> = Default::default();
+        let batching = Batching::new(
+            cache.clone(),
+            Duration::from_nanos(10),
+            Arc::new(native_price_batch_fetcher),
+        );
+
+        let result = batching
+            .blocking_estimate_prices_and_update_cache(&token(0))
+            .await
+            .expect("valid result")
+            .unwrap();
+
+        assert_eq!(result.to_i64().unwrap(), 1);
+        let cached_price = cache.lock().await.get(&token(0)).unwrap().clone();
+        // Check the cache was updated successfully
+        assert_eq!(cached_price.result.unwrap().to_i64().unwrap(), 1);
+
+        // Another request, but since the value is cached, it should not   request
+        // `fetch_native_prices()`
+        let result = batching
+            .blocking_estimate_prices_and_update_cache(&token(0))
+            .await
+            .expect("valid result")
+            .unwrap();
+
+        assert_eq!(result.to_i64().unwrap(), 1);
+        let cached_price = cache.lock().await.get(&token(0)).unwrap().clone();
+        // Check the cache was updated successfully
+        assert_eq!(cached_price.result.unwrap().to_i64().unwrap(), 1);
+    }
+
+    #[tokio::test]
+    async fn batching_unsuccessful_estimates() {
+        let mut native_price_batch_fetcher = MockNativePriceBatchFetcher::new();
+        native_price_batch_fetcher
+            .expect_max_batch_size()
+            .returning(|| 20);
+        native_price_batch_fetcher
+            .expect_fetch_native_prices()
+            // We expect this to be requested just one
+            .times(1)
+            .returning(|_| {
+                Err(PriceEstimationError::NoLiquidity)
+            });
+        let cache: Arc<TokioMutex<HashMap<H160, CachedResult>>> = Default::default();
+        let batching = Batching::new(
+            cache.clone(),
+            Duration::from_nanos(10),
+            Arc::new(native_price_batch_fetcher),
+        );
+
+        let result = batching
+            .blocking_estimate_prices_and_update_cache(&token(0))
+            .await
+            .expect("valid result");
+
+        assert_eq!(result, None);
+        let cached_price = cache.lock().await.get(&token(0)).cloned();
+        // Check the cache was NOT updated successfully
+        assert_eq!(cached_price.map(|price| price.result), None);
+    }
+
+    // Function to check batching of many tokens
+    async fn check_batching_many(
+        batching: Arc<Batching>,
+        cache: Arc<TokioMutex<HashMap<H160, CachedResult>>>,
+        tokens_requested: usize,
+    ) {
+        let mut futures = Vec::with_capacity(tokens_requested);
+        for i in 0..tokens_requested {
+            let batching = batching.clone();
+            futures.push(tokio::spawn(async move {
+                batching
+                    .blocking_estimate_prices_and_update_cache(&token(i.try_into().unwrap()))
+                    .await
+                    .expect("valid result")
+            }));
+        }
+
+        let mut results = try_join_all(futures).await.expect("valid futures");
+
+        while let Some(result) = results.pop() {
+            let result = result.unwrap();
+            assert_eq!(result.to_i64().unwrap(), 1);
+        }
+
+        let cache = cache.lock().await;
+        for i in 0..tokens_requested {
+            let cached_price = cache
+                .get(&token(i.try_into().unwrap()))
+                .cloned()
+                .unwrap()
+                .result;
+            assert_eq!(cached_price.unwrap().to_i64().unwrap(), 1);
+        }
+    }
+
+    #[tokio::test]
+    async fn batching_many_in_one_batch_successful_estimates() {
+        let tokens_requested = 20;
+        let mut native_price_batch_fetcher = MockNativePriceBatchFetcher::new();
+        native_price_batch_fetcher
+            .expect_max_batch_size()
+            .returning(|| 20);
+        native_price_batch_fetcher
+            .expect_fetch_native_prices()
+            // We expect this to be requested exactly one time because the max batch is 20, so all petitions fit into one batch request
+            .times(1)
+            .returning(|input| {
+                Ok(input
+                    .iter()
+                    .map(|token| (*token, 1.0))
+                    .collect::<HashMap<_, _>>())
+            });
+        let cache: Arc<TokioMutex<HashMap<H160, CachedResult>>> = Default::default();
+        let batching = Arc::new(Batching::new(
+            cache.clone(),
+            Duration::from_millis(100),
+            Arc::new(native_price_batch_fetcher),
+        ));
+
+        check_batching_many(batching, cache, tokens_requested).await;
+    }
+
+    #[tokio::test]
+    async fn batching_many_in_two_batch_successful_estimates() {
+        let tokens_requested = 21;
+        let mut native_price_batch_fetcher = MockNativePriceBatchFetcher::new();
+        native_price_batch_fetcher
+            .expect_max_batch_size()
+            .returning(|| 20);
+        native_price_batch_fetcher
+            .expect_fetch_native_prices()
+            // We expect this to be requested exactly two times because the max batch is 20, so all petitions fit into one batch request
+            .times(2)
+            .returning(|input| {
+                Ok(input
+                    .iter()
+                    .map(|token| (*token, 1.0))
+                    .collect::<HashMap<_, _>>())
+            });
+        let cache: Arc<TokioMutex<HashMap<H160, CachedResult>>> = Default::default();
+        let batching = Arc::new(Batching::new(
+            cache.clone(),
+            Duration::from_millis(100),
+            Arc::new(native_price_batch_fetcher),
+        ));
+
+        check_batching_many(batching, cache, tokens_requested).await;
+    }
+
+    #[tokio::test]
+    async fn batching_no_calls() {
+        let mut native_price_batch_fetcher = MockNativePriceBatchFetcher::new();
+        native_price_batch_fetcher
+            .expect_max_batch_size()
+            .returning(|| 20);
+        native_price_batch_fetcher
+            .expect_fetch_native_prices()
+            // We are testing the native prices are never called
+            .never();
+        let cache: Arc<TokioMutex<HashMap<H160, CachedResult>>> = Default::default();
+        let _batching = Arc::new(Batching::new(
+            cache.clone(),
+            Duration::from_nanos(50),
+            Arc::new(native_price_batch_fetcher),
+        ));
+        sleep(Duration::from_millis(250)).await;
     }
 
     #[tokio::test]
@@ -379,6 +768,7 @@ mod tests {
             None,
             Default::default(),
             1,
+            None,
         );
 
         for _ in 0..10 {
@@ -405,6 +795,7 @@ mod tests {
             None,
             Default::default(),
             1,
+            None,
         );
 
         for _ in 0..10 {
@@ -459,6 +850,7 @@ mod tests {
             Some(1),
             Duration::default(),
             1,
+            None,
         );
 
         // fill cache with 2 different queries
@@ -497,6 +889,7 @@ mod tests {
             None,
             Duration::default(),
             1,
+            None,
         );
 
         let tokens: Vec<_> = (0..10).map(H160::from_low_u64_be).collect();
@@ -542,6 +935,7 @@ mod tests {
             None,
             Duration::default(),
             BATCH_SIZE,
+            None,
         );
 
         let tokens: Vec<_> = (0..BATCH_SIZE as u64).map(H160::from_low_u64_be).collect();
@@ -562,13 +956,13 @@ mod tests {
         }
     }
 
-    #[test]
-    fn outdated_entries_prioritized() {
+    #[tokio::test]
+    async fn outdated_entries_prioritized() {
         let t0 = H160::from_low_u64_be(0);
         let t1 = H160::from_low_u64_be(1);
         let now = Instant::now();
         let inner = Inner {
-            cache: Mutex::new(
+            cache: Arc::new(TokioMutex::new(
                 [
                     (
                         t0,
@@ -589,21 +983,26 @@ mod tests {
                 ]
                 .into_iter()
                 .collect(),
-            ),
+            )),
             high_priority: Default::default(),
             estimator: Box::new(MockNativePriceEstimating::new()),
             max_age: Default::default(),
+            batching: None,
         };
 
         let now = now + Duration::from_secs(1);
 
         *inner.high_priority.lock().unwrap() = std::iter::once(t0).collect();
-        let tokens = inner.sorted_tokens_to_update(Duration::from_secs(0), now);
+        let tokens = inner
+            .sorted_tokens_to_update(Duration::from_secs(0), now)
+            .await;
         assert_eq!(tokens[0], t0);
         assert_eq!(tokens[1], t1);
 
         *inner.high_priority.lock().unwrap() = std::iter::once(t1).collect();
-        let tokens = inner.sorted_tokens_to_update(Duration::from_secs(0), now);
+        let tokens = inner
+            .sorted_tokens_to_update(Duration::from_secs(0), now)
+            .await;
         assert_eq!(tokens[0], t1);
         assert_eq!(tokens[1], t0);
     }

--- a/crates/shared/src/price_estimation/native_price_cache.rs
+++ b/crates/shared/src/price_estimation/native_price_cache.rs
@@ -536,7 +536,8 @@ mod tests {
         sleep(Duration::from_millis(100)).await;
 
         for _ in 0..10 {
-            // Launch requests and see we get the response `1` from the native batch fetcher instead of the one from the maintenance job
+            // Launch requests and see we get the response `1` from the native batch fetcher
+            // instead of the one from the maintenance job
             let result = estimator.estimate_native_price(token(0)).await;
             assert!(result.as_ref().unwrap().to_i64().unwrap() == 1);
         }


### PR DESCRIPTION
# Description
Implements a batching system with a quick cache. 
The implementation has a blocking function `blocking_estimate_prices_and_update_cache()` that belongs to a struct which runs a thread. The thread runs every X ms and will do a bulk fetch to whatever provider implements the trait `NativePriceBatchFetcher` for all the requested non-cached tokens in `blocking_estimate_prices_and_update_cache()`.
If the token is cached, it is not requested. The function `blocking_estimate_prices_and_update_cache()` has a timeout of three times the period of the batching requests (to respect Nyquist-Shannon theorem of sampling speed + the batch request has a limit of tokens per batch), which guarantees (in majority of the cases) that the token was fetched in one of the X ms rounds. 
If the token prices doesn't exist, the timeout indicates No Liquidity. 

The batching system as it is right now CANNOT be activated, it needs the upcoming PR (2/2) in which it will be implemented:
- CoinGecko implementing the trait `NativePriceBatchFetcher`
- Adding a configuration to enable the batching system and setting up the estimator + period time

# Changes
- Define trait `NativePriceBatchFetcher` , which is to be implemented by CoinGecko in the PR part 2/2
- Define the `Batching` system which does batching requests every X ms (if needed)

## How to test
1. Unit test