### PR TITLE
Few improvements for request sharing

### DIFF
--- a/crates/shared/src/price_estimation/trade_finder.rs
+++ b/crates/shared/src/price_estimation/trade_finder.rs
@@ -61,11 +61,14 @@ impl TradeEstimator {
     }
 
     async fn estimate(&self, query: Arc<Query>) -> Result<Estimate, PriceEstimationError> {
-        let estimate = rate_limited(
-            self.rate_limiter.clone(),
-            self.inner.clone().estimate(query.clone()),
-        );
-        self.sharing.shared(query, estimate.boxed()).await
+        let fut = move |query: &Arc<Query>| {
+            rate_limited(
+                self.rate_limiter.clone(),
+                self.inner.clone().estimate(query.clone()),
+            )
+            .boxed()
+        };
+        self.sharing.shared_or_else(query, fut).await
     }
 }
 

--- a/crates/shared/src/price_estimation/trade_finder.rs
+++ b/crates/shared/src/price_estimation/trade_finder.rs
@@ -87,7 +87,7 @@ impl Inner {
             };
 
             return verifier
-                .verify(&price_query, &query.verification, trade.clone())
+                .verify(&price_query, &query.verification, trade)
                 .await
                 .map_err(PriceEstimationError::EstimatorInternal);
         }

--- a/crates/shared/src/request_sharing.rs
+++ b/crates/shared/src/request_sharing.rs
@@ -151,8 +151,8 @@ mod tests {
             request_label: Default::default(),
         };
 
-        let shared0 = sharing.shared(0, futures::future::ready(0).boxed());
-        let shared1 = sharing.shared(0, async { panic!() }.boxed());
+        let shared0 = sharing.shared_or_else(0, |_| futures::future::ready(0).boxed());
+        let shared1 = sharing.shared_or_else(0, |_| async { panic!() }.boxed());
 
         assert!(shared0.ptr_eq(&shared1));
         assert_eq!(shared0.strong_count().unwrap(), 2);

--- a/crates/shared/src/request_sharing.rs
+++ b/crates/shared/src/request_sharing.rs
@@ -160,10 +160,12 @@ mod tests {
 
         let shared0 = sharing.shared(0, futures::future::ready(0).boxed());
         let shared1 = sharing.shared(0, async { panic!() }.boxed());
-        // Would use Arc::ptr_eq but Shared doesn't implement it.
+
+        assert!(shared0.ptr_eq(&shared1));
         assert_eq!(shared0.strong_count().unwrap(), 2);
         assert_eq!(shared1.strong_count().unwrap(), 2);
         assert_eq!(shared0.weak_count().unwrap(), 1);
+
         // complete first shared
         assert_eq!(shared0.now_or_never().unwrap(), 0);
         assert_eq!(shared1.strong_count().unwrap(), 1);

--- a/crates/shared/src/trade_finding/external.rs
+++ b/crates/shared/src/trade_finding/external.rs
@@ -10,7 +10,6 @@ use {
     ethrpc::current_block::CurrentBlockStream,
     futures::{future::BoxFuture, FutureExt},
     reqwest::{header, Client},
-    std::sync::Arc,
     url::Url,
 };
 
@@ -30,7 +29,7 @@ pub struct ExternalTradeFinder {
     block_stream: CurrentBlockStream,
 
     /// Timeout of the quote request to the driver.
-    timeout: Arc<std::time::Duration>,
+    timeout: std::time::Duration,
 }
 
 impl ExternalTradeFinder {
@@ -45,67 +44,70 @@ impl ExternalTradeFinder {
             sharing: RequestSharing::labelled(format!("tradefinder_{}", driver)),
             client,
             block_stream,
-            timeout: Arc::new(timeout),
+            timeout,
         }
     }
 
     /// Queries the `/quote` endpoint of the configured driver and deserializes
     /// the result into a Quote or Trade.
     async fn shared_query(&self, query: &Query) -> Result<Trade, TradeError> {
-        let deadline = chrono::Utc::now() + *self.timeout;
-        let order = dto::Order {
-            sell_token: query.sell_token,
-            buy_token: query.buy_token,
-            amount: query.in_amount.get(),
-            kind: query.kind,
-            deadline,
-        };
+        let fut = move |query: &Query| {
+            let order = dto::Order {
+                sell_token: query.sell_token,
+                buy_token: query.buy_token,
+                amount: query.in_amount.get(),
+                kind: query.kind,
+                deadline: chrono::Utc::now() + self.timeout,
+            };
+            let block_dependent = query.block_dependent;
+            let id = observe::request_id::get_task_local_storage();
+            let timeout = self.timeout;
+            let client = self.client.clone();
+            let quote_endpoint = self.quote_endpoint.clone();
+            let block_hash = self.block_stream.borrow().hash;
 
-        let mut request = self
-            .client
-            .get(self.quote_endpoint.clone())
-            .query(&order)
-            .header(header::CONTENT_TYPE, "application/json")
-            .header(header::ACCEPT, "application/json");
+            async move {
+                let mut request = client
+                    .get(quote_endpoint)
+                    .query(&order)
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .header(header::ACCEPT, "application/json");
 
-        if query.block_dependent {
-            request = request.header(
-                "X-Current-Block-Hash",
-                self.block_stream.borrow().hash.to_string(),
-            )
-        }
+                if block_dependent {
+                    request = request.header("X-Current-Block-Hash", block_hash.to_string())
+                }
 
-        if let Some(id) = observe::request_id::get_task_local_storage() {
-            request = request.header("X-REQUEST-ID", id);
-        }
+                if let Some(id) = id {
+                    request = request.header("X-REQUEST-ID", id);
+                }
 
-        let timeout = self.timeout.clone();
-        let future = async move {
-            let response = request
-                .timeout(*timeout)
-                .send()
-                .await
-                .map_err(|err| PriceEstimationError::EstimatorInternal(anyhow!(err)))?;
-            if response.status() == 429 {
-                return Err(PriceEstimationError::RateLimited);
+                let response = request
+                    .timeout(timeout)
+                    .send()
+                    .await
+                    .map_err(|err| PriceEstimationError::EstimatorInternal(anyhow!(err)))?;
+                if response.status() == 429 {
+                    return Err(PriceEstimationError::RateLimited);
+                }
+                let text = response
+                    .text()
+                    .await
+                    .map_err(|err| PriceEstimationError::EstimatorInternal(anyhow!(err)))?;
+                serde_json::from_str::<dto::Quote>(&text)
+                    .map(Trade::from)
+                    .map_err(|err| {
+                        if let Ok(err) = serde_json::from_str::<dto::Error>(&text) {
+                            PriceEstimationError::from(err)
+                        } else {
+                            PriceEstimationError::EstimatorInternal(anyhow!(err))
+                        }
+                    })
             }
-            let text = response
-                .text()
-                .await
-                .map_err(|err| PriceEstimationError::EstimatorInternal(anyhow!(err)))?;
-            serde_json::from_str::<dto::Quote>(&text)
-                .map(Trade::from)
-                .map_err(|err| {
-                    if let Ok(err) = serde_json::from_str::<dto::Error>(&text) {
-                        PriceEstimationError::from(err)
-                    } else {
-                        PriceEstimationError::EstimatorInternal(anyhow!(err))
-                    }
-                })
+            .boxed()
         };
 
         self.sharing
-            .shared(query.clone(), future.boxed())
+            .shared_or_else(query.clone(), fut)
             .await
             .map_err(TradeError::from)
     }


### PR DESCRIPTION
# Description
This PR ended up being a small collection of improvements all related to request sharing in the hopes of improving the memory leak situation.

# Changes
- replace all uses of `.shared()` with `.shared_or_else()` to delay the construction of shared futures as much as possible (might result in a reduction of the leaked memory 🤞)
- drop `.shared()` altogether because it's less powerful than `.shared_or_else()` and can use excessive memory
- finally the unit test is able to assert that the original future and shared cached future indeed point to the same underlying future
- added a metric to count all cached items across all individual request sharing structs
    Either this shows a constant increase which suggests that we leak memory by not cleaning up the map (and keeping strong references to the shared futures)
    Or we do everything right and the memory somehow gets leaked in the shared future destructor

## How to test
functionality didn't really change so existing tests should still pass