### PR TITLE
DRAFT: Replace warp with axum

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -73,7 +73,7 @@ dependencies = [
  "observe",
  "primitive-types",
  "prometheus",
- "reqwest",
+ "reqwest 0.12.5",
  "serde",
  "serde_with",
  "shared",
@@ -251,6 +251,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -303,7 +309,7 @@ dependencies = [
  "prometheus",
  "prometheus-metric-storage",
  "rand",
- "reqwest",
+ "reqwest 0.12.5",
  "s3",
  "serde",
  "serde_json",
@@ -340,7 +346,7 @@ dependencies = [
  "fastrand 1.9.0",
  "hex",
  "http 0.2.12",
- "hyper",
+ "hyper 0.14.29",
  "ring 0.16.20",
  "time",
  "tokio",
@@ -371,7 +377,7 @@ dependencies = [
  "fastrand 2.1.0",
  "hex",
  "http 0.2.12",
- "hyper",
+ "hyper 0.14.29",
  "ring 0.17.8",
  "time",
  "tokio",
@@ -756,7 +762,7 @@ dependencies = [
  "fastrand 1.9.0",
  "http 0.2.12",
  "http-body 0.4.6",
- "hyper",
+ "hyper 0.14.29",
  "hyper-rustls 0.23.2",
  "lazy_static",
  "pin-project-lite",
@@ -789,7 +795,7 @@ dependencies = [
  "futures-core",
  "http 0.2.12",
  "http-body 0.4.6",
- "hyper",
+ "hyper 0.14.29",
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
@@ -886,11 +892,11 @@ dependencies = [
  "aws-smithy-types 1.1.10",
  "bytes",
  "fastrand 2.1.0",
- "h2",
+ "h2 0.3.26",
  "http 0.2.12",
  "http-body 0.4.6",
  "http-body 1.0.0",
- "hyper",
+ "hyper 0.14.29",
  "hyper-rustls 0.24.2",
  "once_cell",
  "pin-project-lite",
@@ -1012,13 +1018,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b829e4e32b91e643de6eafe82b1d90675f5874230191a4ffbc1b336dec4d6bf"
 dependencies = [
  "async-trait",
- "axum-core",
+ "axum-core 0.3.4",
  "bitflags 1.3.2",
  "bytes",
  "futures-util",
  "http 0.2.12",
  "http-body 0.4.6",
- "hyper",
+ "hyper 0.14.29",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustversion",
+ "serde",
+ "sync_wrapper 0.1.2",
+ "tower",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "axum"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a6c9af12842a67734c9a2e355436e5d03b22383ed60cf13cd0c18fbfe3dcbcf"
+dependencies = [
+ "async-trait",
+ "axum-core 0.4.3",
+ "bytes",
+ "futures-util",
+ "http 1.1.0",
+ "http-body 1.0.0",
+ "http-body-util",
+ "hyper 1.4.1",
+ "hyper-util",
  "itoa",
  "matchit",
  "memchr",
@@ -1030,11 +1065,12 @@ dependencies = [
  "serde_json",
  "serde_path_to_error",
  "serde_urlencoded",
- "sync_wrapper",
+ "sync_wrapper 1.0.1",
  "tokio",
  "tower",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -1052,6 +1088,27 @@ dependencies = [
  "rustversion",
  "tower-layer",
  "tower-service",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a15c63fd72d41492dc4f497196f5da1fb04fb7529e631d73630d1b491e47a2e3"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures-util",
+ "http 1.1.0",
+ "http-body 1.0.0",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "rustversion",
+ "sync_wrapper 0.1.2",
+ "tower-layer",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -1415,9 +1472,9 @@ checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
 
 [[package]]
 name = "cookie"
-version = "0.17.0"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7efb37c3e1ccb1ff97164ad95ac1606e8ccd35b3fa0a7d99a304c7f4a428cc24"
+checksum = "4ddef33a339a91ea89fb53151bd0a4689cfce27055c291dfa69945475d22c747"
 dependencies = [
  "percent-encoding",
  "time",
@@ -1426,12 +1483,12 @@ dependencies = [
 
 [[package]]
 name = "cookie_store"
-version = "0.20.0"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "387461abbc748185c3a6e1673d826918b450b87ff22639429c694619a83b6cf6"
+checksum = "4934e6b7e8419148b6ef56950d277af8561060b56afd59e2aadf98b59fce6baa"
 dependencies = [
  "cookie",
- "idna 0.3.0",
+ "idna 0.5.0",
  "log",
  "publicsuffix",
  "serde",
@@ -1746,7 +1803,7 @@ dependencies = [
  "anyhow",
  "app-data",
  "async-trait",
- "axum",
+ "axum 0.7.5",
  "bigdecimal",
  "bytes-hex",
  "chrono",
@@ -1765,7 +1822,7 @@ dependencies = [
  "hex-literal",
  "humantime",
  "humantime-serde",
- "hyper",
+ "hyper 1.4.1",
  "indexmap 2.2.6",
  "itertools 0.12.1",
  "lazy_static",
@@ -1779,7 +1836,7 @@ dependencies = [
  "prometheus",
  "prometheus-metric-storage",
  "rand",
- "reqwest",
+ "reqwest 0.12.5",
  "s3",
  "secp256k1",
  "serde",
@@ -1810,7 +1867,7 @@ dependencies = [
  "app-data-hash",
  "async-trait",
  "autopilot",
- "axum",
+ "axum 0.7.5",
  "chrono",
  "clap",
  "contracts",
@@ -1828,7 +1885,7 @@ dependencies = [
  "orderbook",
  "rand",
  "refunder",
- "reqwest",
+ "reqwest 0.12.5",
  "secp256k1",
  "serde",
  "serde_json",
@@ -2042,7 +2099,7 @@ dependencies = [
  "primitive-types",
  "prometheus",
  "prometheus-metric-storage",
- "reqwest",
+ "reqwest 0.12.5",
  "scopeguard",
  "serde",
  "serde_json",
@@ -2273,7 +2330,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "futures",
- "http 0.2.12",
+ "http 1.1.0",
  "primitive-types",
  "serde",
  "serde_json",
@@ -2323,6 +2380,25 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http 0.2.12",
+ "indexmap 2.2.6",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "h2"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa82e28a107a8cc405f0839610bdc9b15f1e25ec7d696aa5cf173edbcb1486ab"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http 1.1.0",
  "indexmap 2.2.6",
  "slab",
  "tokio",
@@ -2521,12 +2597,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "http-range-header"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "add0ab9360ddbd88cfeb3bd9574a1d85cfdfa14db10b3e21d3700dbc4328758f"
-
-[[package]]
 name = "httparse"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2564,7 +2634,7 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2",
+ "h2 0.3.26",
  "http 0.2.12",
  "http-body 0.4.6",
  "httparse",
@@ -2579,13 +2649,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50dfd22e0e76d0f662d429a5f80fcaf3855009297eab6a0a9f8543834744ba05"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "h2 0.4.5",
+ "http 1.1.0",
+ "http-body 1.0.0",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+ "want",
+]
+
+[[package]]
 name = "hyper-rustls"
 version = "0.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1788965e61b367cd03a62950836d5cd41560c3577d90e40e0819373194d1661c"
 dependencies = [
  "http 0.2.12",
- "hyper",
+ "hyper 0.14.29",
  "log",
  "rustls 0.20.9",
  "rustls-native-certs",
@@ -2601,7 +2692,7 @@ checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
 dependencies = [
  "futures-util",
  "http 0.2.12",
- "hyper",
+ "hyper 0.14.29",
  "log",
  "rustls 0.21.12",
  "rustls-native-certs",
@@ -2610,12 +2701,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-rustls"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ee4be2c948921a1a5320b629c4193916ed787a7f7f293fd3f7f5a6c9de74155"
+dependencies = [
+ "futures-util",
+ "http 1.1.0",
+ "hyper 1.4.1",
+ "hyper-util",
+ "rustls 0.23.12",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls 0.26.0",
+ "tower-service",
+]
+
+[[package]]
 name = "hyper-timeout"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbb958482e8c7be4bc3cf272a766a2b0bf1a6755e7a6ae777f017a31d11b13b1"
 dependencies = [
- "hyper",
+ "hyper 0.14.29",
  "pin-project-lite",
  "tokio",
  "tokio-io-timeout",
@@ -2623,15 +2731,38 @@ dependencies = [
 
 [[package]]
 name = "hyper-tls"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
+checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
 dependencies = [
  "bytes",
- "hyper",
+ "http-body-util",
+ "hyper 1.4.1",
+ "hyper-util",
  "native-tls",
  "tokio",
  "tokio-native-tls",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cde7055719c54e36e95e8719f95883f22072a48ede39db7fc17a4e1d5281e9b9"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http 1.1.0",
+ "http-body 1.0.0",
+ "hyper 1.4.1",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
+ "tower",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -3361,7 +3492,7 @@ dependencies = [
  "hex",
  "hex-literal",
  "humantime",
- "hyper",
+ "hyper 1.4.1",
  "maplit",
  "mockall 0.12.1",
  "model",
@@ -3373,7 +3504,7 @@ dependencies = [
  "primitive-types",
  "prometheus",
  "prometheus-metric-storage",
- "reqwest",
+ "reqwest 0.12.5",
  "secp256k1",
  "serde",
  "serde_json",
@@ -3807,7 +3938,7 @@ dependencies = [
  "observe",
  "prometheus",
  "prometheus-metric-storage",
- "reqwest",
+ "reqwest 0.12.5",
  "thiserror",
  "tokio",
  "tracing",
@@ -3926,19 +4057,59 @@ version = "0.11.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd67538700a17451e7cba03ac727fb961abb7607553461627b97de0b89cf4a62"
 dependencies = [
- "async-compression",
  "base64 0.21.7",
+ "bytes",
+ "encoding_rs",
+ "futures-core",
+ "futures-util",
+ "h2 0.3.26",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "hyper 0.14.29",
+ "ipnet",
+ "js-sys",
+ "log",
+ "mime",
+ "once_cell",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper 0.1.2",
+ "system-configuration",
+ "tokio",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "winreg 0.50.0",
+]
+
+[[package]]
+name = "reqwest"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7d6d2a27d57148378eb5e111173f4276ad26340ecc5c49a4a2152167a2d6a37"
+dependencies = [
+ "async-compression",
+ "base64 0.22.1",
  "bytes",
  "cookie",
  "cookie_store",
  "encoding_rs",
+ "futures-channel",
  "futures-core",
  "futures-util",
- "h2",
- "http 0.2.12",
- "http-body 0.4.6",
- "hyper",
+ "h2 0.4.5",
+ "http 1.1.0",
+ "http-body 1.0.0",
+ "http-body-util",
+ "hyper 1.4.1",
+ "hyper-rustls 0.27.2",
  "hyper-tls",
+ "hyper-util",
  "ipnet",
  "js-sys",
  "log",
@@ -3947,11 +4118,11 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
- "rustls-pemfile",
+ "rustls-pemfile 2.1.3",
  "serde",
  "serde_json",
  "serde_urlencoded",
- "sync_wrapper",
+ "sync_wrapper 1.0.1",
  "system-configuration",
  "tokio",
  "tokio-native-tls",
@@ -3961,7 +4132,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "winreg",
+ "winreg 0.52.0",
 ]
 
 [[package]]
@@ -4123,8 +4294,21 @@ checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
 dependencies = [
  "log",
  "ring 0.17.8",
- "rustls-webpki",
+ "rustls-webpki 0.101.7",
  "sct",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c58f8c84392efc0a126acce10fa59ff7b3d2ac06ab451a33f2741989b806b044"
+dependencies = [
+ "once_cell",
+ "rustls-pki-types",
+ "rustls-webpki 0.102.6",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -4134,7 +4318,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a9aace74cb666635c918e9c12bc0d348266037aa8eb599b5cba565709a8dff00"
 dependencies = [
  "openssl-probe",
- "rustls-pemfile",
+ "rustls-pemfile 1.0.4",
  "schannel",
  "security-framework",
 ]
@@ -4149,12 +4333,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-pemfile"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "196fe16b00e106300d3e45ecfcb764fa292a535d7326a29a5875c579c7417425"
+dependencies = [
+ "base64 0.22.1",
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0a2ce646f8655401bb81e7927b812614bd5d91dbc968696be50603510fcaf0"
+
+[[package]]
 name = "rustls-webpki"
 version = "0.101.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
 dependencies = [
  "ring 0.17.8",
+ "untrusted 0.9.0",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.102.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e6b52d4fda176fd835fdc55a835d4a89b8499cad995885a21149d5ad62f852e"
+dependencies = [
+ "ring 0.17.8",
+ "rustls-pki-types",
  "untrusted 0.9.0",
 ]
 
@@ -4442,7 +4653,7 @@ dependencies = [
  "prometheus-metric-storage",
  "rate-limit",
  "regex",
- "reqwest",
+ "reqwest 0.12.5",
  "rust_decimal",
  "secp256k1",
  "serde",
@@ -4548,7 +4759,7 @@ dependencies = [
  "prometheus-metric-storage",
  "rand",
  "rate-limit",
- "reqwest",
+ "reqwest 0.12.5",
  "serde",
  "serde_json",
  "serde_with",
@@ -4568,7 +4779,7 @@ name = "solvers"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "axum",
+ "axum 0.7.5",
  "bigdecimal",
  "chrono",
  "clap",
@@ -4580,7 +4791,7 @@ dependencies = [
  "futures",
  "hex",
  "hex-literal",
- "hyper",
+ "hyper 1.4.1",
  "itertools 0.12.1",
  "model",
  "num",
@@ -4588,7 +4799,7 @@ dependencies = [
  "prometheus",
  "prometheus-metric-storage",
  "rate-limit",
- "reqwest",
+ "reqwest 0.12.5",
  "s3",
  "serde",
  "serde_json",
@@ -4952,6 +5163,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
 
 [[package]]
+name = "sync_wrapper"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7065abeca94b6a8a577f9bd45aa0867a2238b74e8eb67cf10d492bc39351394"
+
+[[package]]
 name = "system-configuration"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5164,6 +5381,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-rustls"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c7bc40d0e5a97695bb96e27995cd3a08538541b0a846f65bba7a359f36700d4"
+dependencies = [
+ "rustls 0.23.12",
+ "rustls-pki-types",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-stream"
 version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5241,13 +5469,13 @@ checksum = "76c4eb7a4e9ef9d4763600161f12f5070b92a578e1b634db88a6887844c91a13"
 dependencies = [
  "async-stream",
  "async-trait",
- "axum",
+ "axum 0.6.20",
  "base64 0.21.7",
  "bytes",
- "h2",
+ "h2 0.3.26",
  "http 0.2.12",
  "http-body 0.4.6",
- "hyper",
+ "hyper 0.14.29",
  "hyper-timeout",
  "percent-encoding",
  "pin-project",
@@ -5282,17 +5510,15 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.4.4"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61c5bb1d698276a2443e5ecfabc1008bf15a36c12e6a7176e7bf089ea9131140"
+checksum = "1e9cd434a998747dd2c4276bc96ee2e0c7a2eadf3cae88e52be55a05fa9053f5"
 dependencies = [
  "bitflags 2.5.0",
  "bytes",
- "futures-core",
- "futures-util",
- "http 0.2.12",
- "http-body 0.4.6",
- "http-range-header",
+ "http 1.1.0",
+ "http-body 1.0.0",
+ "http-body-util",
  "pin-project-lite",
  "tower-layer",
  "tower-service",
@@ -5561,7 +5787,7 @@ dependencies = [
  "futures-util",
  "headers",
  "http 0.2.12",
- "hyper",
+ "hyper 0.14.29",
  "log",
  "mime",
  "mime_guess",
@@ -5687,7 +5913,7 @@ dependencies = [
  "once_cell",
  "parking_lot",
  "pin-project",
- "reqwest",
+ "reqwest 0.11.27",
  "rlp",
  "secp256k1",
  "serde",
@@ -5909,6 +6135,16 @@ name = "winreg"
 version = "0.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
+dependencies = [
+ "cfg-if",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "winreg"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a277a57398d4bfa075df44f501a17cfdf8542d224f0d36095a2adc7aee4ef0a5"
 dependencies = [
  "cfg-if",
  "windows-sys 0.48.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1112,6 +1112,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "axum-prometheus"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "739e2585f5376f5bdd129324ded72d3261fdd5b7c411a645920328fb5dc875d4"
+dependencies = [
+ "axum 0.7.5",
+ "bytes",
+ "futures-core",
+ "http 1.1.0",
+ "http-body 1.0.0",
+ "matchit",
+ "metrics",
+ "metrics-exporter-prometheus",
+ "once_cell",
+ "pin-project",
+ "tokio",
+ "tower",
+ "tower-http",
+]
+
+[[package]]
 name = "backtrace"
 version = "0.3.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1580,6 +1601,15 @@ name = "crossbeam-channel"
 version = "0.5.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33480d6946193aa8033910124896ca395333cae7e2d1113d1fef6c3272217df2"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -3081,6 +3111,51 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c8640c5d730cb13ebd907d8d04b52f55ac9a2eec55b440c8892f40d56c76c1d"
 
 [[package]]
+name = "metrics"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "884adb57038347dfbaf2d5065887b6cf4312330dc8e94bc30a1a839bd79d3261"
+dependencies = [
+ "ahash 0.8.11",
+ "portable-atomic",
+]
+
+[[package]]
+name = "metrics-exporter-prometheus"
+version = "0.15.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4f0c8427b39666bf970460908b213ec09b3b350f20c0c2eabcbba51704a08e6"
+dependencies = [
+ "base64 0.22.1",
+ "http-body-util",
+ "hyper 1.4.1",
+ "hyper-util",
+ "indexmap 2.2.6",
+ "ipnet",
+ "metrics",
+ "metrics-util",
+ "quanta",
+ "thiserror",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "metrics-util"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4259040465c955f9f2f1a4a8a16dc46726169bca0f88e8fb2dbeced487c3e828"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+ "hashbrown 0.14.5",
+ "metrics",
+ "num_cpus",
+ "quanta",
+ "sketches-ddsketch",
+]
+
+[[package]]
 name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3480,6 +3555,8 @@ dependencies = [
  "app-data",
  "app-data-hash",
  "async-trait",
+ "axum 0.7.5",
+ "axum-prometheus",
  "bigdecimal",
  "cached",
  "chrono",
@@ -3514,6 +3591,8 @@ dependencies = [
  "testlib",
  "thiserror",
  "tokio",
+ "tower",
+ "tower-http",
  "tracing",
  "url",
  "vergen",
@@ -3661,6 +3740,12 @@ name = "pkg-config"
 version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
+
+[[package]]
+name = "portable-atomic"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da544ee218f0d287a911e9c99a39a8c9bc8fcad3cb8db5959940044ecfc67265"
 
 [[package]]
 name = "powerfmt"
@@ -3884,6 +3969,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "quanta"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e5167a477619228a0b284fac2674e3c388cba90631d7b7de620e6f1fcd08da5"
+dependencies = [
+ "crossbeam-utils",
+ "libc",
+ "once_cell",
+ "raw-cpuid",
+ "wasi",
+ "web-sys",
+ "winapi",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3942,6 +4042,15 @@ dependencies = [
  "thiserror",
  "tokio",
  "tracing",
+]
+
+[[package]]
+name = "raw-cpuid"
+version = "11.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb9ee317cfe3fbd54b36a511efc1edd42e216903c9cd575e686dd68a2ba90d8d"
+dependencies = [
+ "bitflags 2.5.0",
 ]
 
 [[package]]
@@ -4621,6 +4730,7 @@ dependencies = [
  "app-data-hash",
  "async-stream",
  "async-trait",
+ "axum 0.7.5",
  "bigdecimal",
  "bytes-hex",
  "cached",
@@ -4698,6 +4808,12 @@ name = "simdutf8"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f27f6278552951f1f2b8cf9da965d10969b2efdea95a6ec47987ab46edfe263a"
+
+[[package]]
+name = "sketches-ddsketch"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85636c14b73d81f541e525f585c0a2109e6744e1565b5c1668e31c70c10ed65c"
 
 [[package]]
 name = "slab"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ members = ["crates/*"]
 anyhow = "=1.0.76"
 async-trait = "0.1.80"
 axum = "0.7.5"
+axum-prometheus = "0.7"
 bigdecimal = "0.3"
 cached = { version = "0.49.3", default-features = false }
 chrono = { version = "0.4.38", default-features = false }
@@ -48,6 +49,7 @@ time = { version = "0.3.36", features = ["macros"] }
 thiserror = "1.0.61"
 toml = "0.8.14"
 tower = "0.4.13"
+tower-http = { version = "0.5", features = ["limit", "trace", "cors"] }
 tokio = { version = "1.38.0", features = ["tracing"] }
 tokio-stream = { version = "0.1.15", features = ["sync"] }
 tracing = "0.1.40"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ members = ["crates/*"]
 [workspace.dependencies]
 anyhow = "=1.0.76"
 async-trait = "0.1.80"
-axum = "0.6"
+axum = "0.7.5"
 bigdecimal = "0.3"
 cached = { version = "0.49.3", default-features = false }
 chrono = { version = "0.4.38", default-features = false }
@@ -23,7 +23,7 @@ hex = { version = "0.4.3", default-features = false }
 hex-literal = "0.4.1"
 humantime = "2.1.0"
 humantime-serde = "1.1.1"
-hyper = "0.14.29"
+hyper = "1.4.1"
 indexmap = "2.2.6"
 itertools = "0.12.1"
 lazy_static = "1.4.0"
@@ -36,7 +36,7 @@ prometheus = "0.13.4"
 prometheus-metric-storage = "0.5.0"
 rand = "0.8.5"
 regex = "1.10.4"
-reqwest = "0.11.27"
+reqwest = "0.12.5"
 secp256k1 = "0.27.0"
 serde = { version = "1.0.203", features = ["derive"] }
 serde_json = "1.0.117"
@@ -47,6 +47,7 @@ tempfile = "3.10.1"
 time = { version = "0.3.36", features = ["macros"] }
 thiserror = "1.0.61"
 toml = "0.8.14"
+tower = "0.4.13"
 tokio = { version = "1.38.0", features = ["tracing"] }
 tokio-stream = { version = "0.1.15", features = ["sync"] }
 tracing = "0.1.40"

--- a/crates/driver/Cargo.toml
+++ b/crates/driver/Cargo.toml
@@ -51,7 +51,7 @@ thiserror = { workspace = true }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread", "signal", "time"] }
 toml = { workspace = true }
 tower = "0.4"
-tower-http = { version = "0.4", features = ["limit", "trace"] }
+tower-http = { version = "0.5", features = ["limit", "trace"] }
 url = { workspace = true, features = ["serde"] }
 web3 = { workspace = true, features = ["http"] }
 

--- a/crates/driver/Cargo.toml
+++ b/crates/driver/Cargo.toml
@@ -51,7 +51,7 @@ thiserror = { workspace = true }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread", "signal", "time"] }
 toml = { workspace = true }
 tower = "0.4"
-tower-http = { version = "0.5", features = ["limit", "trace"] }
+tower-http = { workspace = true }
 url = { workspace = true, features = ["serde"] }
 web3 = { workspace = true, features = ["http"] }
 

--- a/crates/driver/src/tests/setup/solver.rs
+++ b/crates/driver/src/tests/setup/solver.rs
@@ -5,11 +5,7 @@ use {
         Partial,
     },
     crate::{
-        domain::{
-            competition::order,
-            eth,
-            time::{self},
-        },
+        domain::{competition::order, eth, time},
         infra::{self, blockchain::contracts::Addresses, config::file::FeeHandler, Ethereum},
         tests::{hex_address, setup::blockchain::Trade},
     },
@@ -21,6 +17,7 @@ use {
         net::SocketAddr,
         sync::{Arc, Mutex},
     },
+    tokio::net::TcpListener,
     web3::signing::Key,
 };
 
@@ -433,10 +430,12 @@ impl Solver {
             ),
         )
         .with_state(State(state));
-        let server =
-            axum::Server::bind(&"0.0.0.0:0".parse().unwrap()).serve(app.into_make_service());
-        let addr = server.local_addr();
+
+        let listener = TcpListener::bind(&"0.0.0.0:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let server = axum::serve(listener, app);
         tokio::spawn(async move { server.await.unwrap() });
+
         Self { addr }
     }
 }

--- a/crates/e2e/Cargo.toml
+++ b/crates/e2e/Cargo.toml
@@ -37,7 +37,7 @@ sqlx = { workspace = true }
 tempfile = { workspace = true }
 tokio = { workspace = true, features = ["macros", "process"] }
 tower = "0.4"
-tower-http = { version = "0.4", features = ["limit", "trace"] }
+tower-http = { version = "0.5", features = ["limit", "trace"] }
 tracing = { workspace = true }
 warp = { workspace = true }
 web3 = { workspace = true, features = ["http"] }

--- a/crates/e2e/Cargo.toml
+++ b/crates/e2e/Cargo.toml
@@ -36,8 +36,8 @@ solvers-dto = { path = "../solvers-dto" }
 sqlx = { workspace = true }
 tempfile = { workspace = true }
 tokio = { workspace = true, features = ["macros", "process"] }
-tower = "0.4"
-tower-http = { version = "0.5", features = ["limit", "trace"] }
+tower = { workspace = true }
+tower-http = { workspace = true }
 tracing = { workspace = true }
 warp = { workspace = true }
 web3 = { workspace = true, features = ["http"] }

--- a/crates/e2e/src/setup/solver/mock.rs
+++ b/crates/e2e/src/setup/solver/mock.rs
@@ -53,7 +53,8 @@ impl Default for Mock {
             .with_state(state.clone());
 
         let make_svc = observe::make_service_with_task_local_storage!(app);
-        let server = axum::Server::bind(&"0.0.0.0:0".parse().unwrap()).serve(make_svc);
+        let listener = TcpListener::bind(&"0.0.0.0:0").await.unwrap();
+        let server = axum::serve(listener, make_svc);
 
         let mock = Mock {
             state,

--- a/crates/e2e/tests/e2e/cow_amm.rs
+++ b/crates/e2e/tests/e2e/cow_amm.rs
@@ -130,7 +130,7 @@ async fn cow_amm_jit(web3: Web3) {
     // for the actual solver competition. That way we can handcraft a solution
     // for this test and don't have to implement complete support for CoW AMMs
     // in the baseline solver.
-    let mock_solver = Mock::default();
+    let mock_solver = Mock::new().await;
     colocation::start_driver(
         onchain.contracts(),
         vec![
@@ -446,7 +446,7 @@ async fn cow_amm_driver_support(web3: Web3) {
         .is_zero());
 
     // spawn a mock solver so we can later assert things about the received auction
-    let mock_solver = Mock::default();
+    let mock_solver = Mock::new().await;
     colocation::start_driver(
         onchain.contracts(),
         vec![

--- a/crates/e2e/tests/e2e/jit_orders.rs
+++ b/crates/e2e/tests/e2e/jit_orders.rs
@@ -52,7 +52,7 @@ async fn single_limit_order_test(web3: Web3) {
 
     let services = Services::new(onchain.contracts()).await;
 
-    let mock_solver = Mock::default();
+    let mock_solver = Mock::new().await;
 
     // Start system
     colocation::start_driver(

--- a/crates/orderbook/Cargo.toml
+++ b/crates/orderbook/Cargo.toml
@@ -17,6 +17,8 @@ path = "src/main.rs"
 
 [dependencies]
 anyhow = { workspace = true }
+axum = { workspace = true }
+axum-prometheus = { workspace = true }
 app-data = { path = "../app-data" }
 app-data-hash = { path = "../app-data-hash" }
 async-trait = { workspace = true }
@@ -51,6 +53,8 @@ shared = { path = "../shared" }
 sqlx = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread", "signal", "sync", "time"] }
+tower = { workspace = true }
+tower-http = { workspace = true }
 tracing = { workspace = true }
 url = { workspace = true }
 warp = { workspace = true }

--- a/crates/orderbook/src/api/cancel_order.rs
+++ b/crates/orderbook/src/api/cancel_order.rs
@@ -1,56 +1,62 @@
 use {
-    crate::orderbook::{OrderCancellationError, Orderbook},
-    anyhow::Result,
+    super::with_status,
+    crate::orderbook::OrderCancellationError,
+    axum::{http::StatusCode, response::IntoResponse, routing::MethodRouter},
     model::order::{CancellationPayload, OrderCancellation, OrderUid},
-    shared::api::{convert_json_response, extract_payload, IntoWarpReply},
-    std::{convert::Infallible, sync::Arc},
-    warp::{hyper::StatusCode, reply::with_status, Filter, Rejection},
+    shared::api::{convert_json_response, error, ApiReply, IntoApiReply},
 };
 
-pub fn cancel_order_request(
-) -> impl Filter<Extract = (OrderCancellation,), Error = Rejection> + Clone {
-    warp::path!("v1" / "orders" / OrderUid)
-        .and(warp::delete())
-        .and(extract_payload())
-        .map(|uid, payload: CancellationPayload| OrderCancellation {
-            order_uid: uid,
-            signature: payload.signature,
-            signing_scheme: payload.signing_scheme,
-        })
+pub fn route() -> (&'static str, MethodRouter<super::State>) {
+    (ENDPOINT, axum::routing::delete(handler))
 }
 
-impl IntoWarpReply for OrderCancellationError {
-    fn into_warp_reply(self) -> super::ApiReply {
+const ENDPOINT: &str = "/api/v1/orders/:uid";
+async fn handler(
+    state: axum::extract::State<super::State>,
+    order_uid: axum::extract::Path<OrderUid>,
+    payload: axum::extract::Json<CancellationPayload>,
+) -> impl IntoResponse {
+    let request = OrderCancellation {
+        order_uid: *order_uid,
+        signature: payload.signature,
+        signing_scheme: payload.signing_scheme,
+    };
+    let result = state.0.orderbook.cancel_order(request).await;
+    convert_json_response(result.map(|_| "Cancelled"))
+}
+
+impl IntoApiReply for OrderCancellationError {
+    fn into_api_reply(self) -> ApiReply {
         match self {
             Self::InvalidSignature => with_status(
-                super::error("InvalidSignature", "Malformed signature"),
+                error("InvalidSignature", "Malformed signature"),
                 StatusCode::BAD_REQUEST,
             ),
             Self::AlreadyCancelled => with_status(
-                super::error("AlreadyCancelled", "Order is already cancelled"),
+                error("AlreadyCancelled", "Order is already cancelled"),
                 StatusCode::BAD_REQUEST,
             ),
             Self::OrderFullyExecuted => with_status(
-                super::error("OrderFullyExecuted", "Order is fully executed"),
+                error("OrderFullyExecuted", "Order is fully executed"),
                 StatusCode::BAD_REQUEST,
             ),
             Self::OrderExpired => with_status(
-                super::error("OrderExpired", "Order is expired"),
+                error("OrderExpired", "Order is expired"),
                 StatusCode::BAD_REQUEST,
             ),
             Self::OrderNotFound => with_status(
-                super::error("OrderNotFound", "Order not located in database"),
+                error("OrderNotFound", "Order not located in database"),
                 StatusCode::NOT_FOUND,
             ),
             Self::WrongOwner => with_status(
-                super::error(
+                error(
                     "WrongOwner",
                     "Signature recovery's owner doesn't match order's",
                 ),
                 StatusCode::UNAUTHORIZED,
             ),
             Self::OnChainOrder => with_status(
-                super::error("OnChainOrder", "On-chain orders must be cancelled on-chain"),
+                error("OnChainOrder", "On-chain orders must be cancelled on-chain"),
                 StatusCode::BAD_REQUEST,
             ),
             Self::Other(err) => {
@@ -61,112 +67,110 @@ impl IntoWarpReply for OrderCancellationError {
     }
 }
 
-pub fn cancel_order_response(result: Result<(), OrderCancellationError>) -> super::ApiReply {
-    convert_json_response(result.map(|_| "Cancelled"))
-}
+// #[cfg(test)]
+// mod tests {
+//     use {
+//         super::*,
+//         ethcontract::H256,
+//         hex_literal::hex,
+//         model::signature::{EcdsaSignature, EcdsaSigningScheme},
+//         serde_json::json,
+//         warp::{test::request, Reply},
+//     };
 
-pub fn cancel_order(
-    orderbook: Arc<Orderbook>,
-) -> impl Filter<Extract = (super::ApiReply,), Error = Rejection> + Clone {
-    cancel_order_request().and_then(move |order| {
-        let orderbook = orderbook.clone();
-        async move {
-            let result = orderbook.cancel_order(order).await;
-            Result::<_, Infallible>::Ok(cancel_order_response(result))
-        }
-    })
-}
+//     #[test]
+//     fn cancellation_payload_deserialization() {
+//         assert_eq!(
+//             serde_json::from_value::<CancellationPayload>(json!({
+//                 "signature": "0x\
+//
+// 000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f\
+// 202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f\
+// 1b",                 "signingScheme": "eip712"
+//             }))
+//             .unwrap(),
+//             CancellationPayload {
+//                 signature: EcdsaSignature {
+//                     r: H256(hex!(
+//
+// "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f"
+//                     )),
+//                     s: H256(hex!(
+//
+// "202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f"
+//                     )),
+//                     v: 27,
+//                 },
+//                 signing_scheme: EcdsaSigningScheme::Eip712,
+//             },
+//         );
+//     }
 
-#[cfg(test)]
-mod tests {
-    use {
-        super::*,
-        ethcontract::H256,
-        hex_literal::hex,
-        model::signature::{EcdsaSignature, EcdsaSigningScheme},
-        serde_json::json,
-        warp::{test::request, Reply},
-    };
+//     #[tokio::test]
+//     async fn cancel_order_request_ok() {
+//         let filter = cancel_order_request();
+//         let cancellation = OrderCancellation::default();
 
-    #[test]
-    fn cancellation_payload_deserialization() {
-        assert_eq!(
-            serde_json::from_value::<CancellationPayload>(json!({
-                "signature": "0x\
-                    000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f\
-                    202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f\
-                    1b",
-                "signingScheme": "eip712"
-            }))
-            .unwrap(),
-            CancellationPayload {
-                signature: EcdsaSignature {
-                    r: H256(hex!(
-                        "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f"
-                    )),
-                    s: H256(hex!(
-                        "202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f"
-                    )),
-                    v: 27,
-                },
-                signing_scheme: EcdsaSigningScheme::Eip712,
-            },
-        );
-    }
+//         let request = request()
+//             .path(&format!("/v1/orders/{}", cancellation.order_uid))
+//             .method("DELETE")
+//             .header("content-type", "application/json")
+//             .json(&CancellationPayload {
+//                 signature: cancellation.signature,
+//                 signing_scheme: cancellation.signing_scheme,
+//             });
+//         let result = request.filter(&filter).await.unwrap();
+//         assert_eq!(result, cancellation);
+//     }
 
-    #[tokio::test]
-    async fn cancel_order_request_ok() {
-        let filter = cancel_order_request();
-        let cancellation = OrderCancellation::default();
+//     #[test]
+//     fn cancel_order_response_ok() {
+//         let response = cancel_order_response(Ok(())).into_response();
+//         assert_eq!(response.status(), StatusCode::OK);
+//     }
 
-        let request = request()
-            .path(&format!("/v1/orders/{}", cancellation.order_uid))
-            .method("DELETE")
-            .header("content-type", "application/json")
-            .json(&CancellationPayload {
-                signature: cancellation.signature,
-                signing_scheme: cancellation.signing_scheme,
-            });
-        let result = request.filter(&filter).await.unwrap();
-        assert_eq!(result, cancellation);
-    }
+//     #[test]
+//     fn cancel_order_response_err() {
+//         let response =
+//
+// cancel_order_response(Err(OrderCancellationError::InvalidSignature)).
+// into_response();         assert_eq!(response.status(),
+// StatusCode::BAD_REQUEST);
 
-    #[test]
-    fn cancel_order_response_ok() {
-        let response = cancel_order_response(Ok(())).into_response();
-        assert_eq!(response.status(), StatusCode::OK);
-    }
+//         let response =
+//
+// cancel_order_response(Err(OrderCancellationError::OrderFullyExecuted)).
+// into_response();         assert_eq!(response.status(),
+// StatusCode::BAD_REQUEST);
 
-    #[test]
-    fn cancel_order_response_err() {
-        let response =
-            cancel_order_response(Err(OrderCancellationError::InvalidSignature)).into_response();
-        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+//         let response =
+//
+// cancel_order_response(Err(OrderCancellationError::AlreadyCancelled)).
+// into_response();         assert_eq!(response.status(),
+// StatusCode::BAD_REQUEST);
 
-        let response =
-            cancel_order_response(Err(OrderCancellationError::OrderFullyExecuted)).into_response();
-        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+//         let response =
+//
+// cancel_order_response(Err(OrderCancellationError::OrderExpired)).
+// into_response();         assert_eq!(response.status(),
+// StatusCode::BAD_REQUEST);
 
-        let response =
-            cancel_order_response(Err(OrderCancellationError::AlreadyCancelled)).into_response();
-        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+//         let response =
+//
+// cancel_order_response(Err(OrderCancellationError::WrongOwner)).
+// into_response();         assert_eq!(response.status(),
+// StatusCode::UNAUTHORIZED);
 
-        let response =
-            cancel_order_response(Err(OrderCancellationError::OrderExpired)).into_response();
-        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+//         let response =
+//
+// cancel_order_response(Err(OrderCancellationError::OrderNotFound)).
+// into_response();         assert_eq!(response.status(),
+// StatusCode::NOT_FOUND);
 
-        let response =
-            cancel_order_response(Err(OrderCancellationError::WrongOwner)).into_response();
-        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
-
-        let response =
-            cancel_order_response(Err(OrderCancellationError::OrderNotFound)).into_response();
-        assert_eq!(response.status(), StatusCode::NOT_FOUND);
-
-        let response = cancel_order_response(Err(OrderCancellationError::Other(
-            anyhow::Error::msg("test error"),
-        )))
-        .into_response();
-        assert_eq!(response.status(), StatusCode::INTERNAL_SERVER_ERROR);
-    }
-}
+//         let response =
+// cancel_order_response(Err(OrderCancellationError::Other(
+// anyhow::Error::msg("test error"),         )))
+//         .into_response();
+//         assert_eq!(response.status(), StatusCode::INTERNAL_SERVER_ERROR);
+//     }
+// }

--- a/crates/orderbook/src/api/get_native_price.rs
+++ b/crates/orderbook/src/api/get_native_price.rs
@@ -1,14 +1,32 @@
 use {
-    anyhow::Result,
+    super::with_status,
+    axum::{http::StatusCode, routing::MethodRouter},
     ethcontract::H160,
     serde::Serialize,
-    shared::{
-        api::{ApiReply, IntoWarpReply},
-        price_estimation::native::NativePriceEstimating,
-    },
-    std::{convert::Infallible, sync::Arc},
-    warp::{hyper::StatusCode, reply::with_status, Filter, Rejection},
+    shared::api::{ApiReply, IntoApiReply},
 };
+
+pub fn route() -> (&'static str, MethodRouter<super::State>) {
+    (ENDPOINT, axum::routing::get(handler))
+}
+
+const ENDPOINT: &str = "/api/v1/token/:token/native_price";
+async fn handler(
+    state: axum::extract::State<super::State>,
+    token: axum::extract::Path<H160>,
+) -> ApiReply {
+    let result = state
+        .native_price_estimator
+        .estimate_native_price(token.0)
+        .await;
+    match result {
+        Ok(price) => with_status(
+            serde_json::to_value(PriceResponse::from(price)).unwrap(),
+            StatusCode::OK,
+        ),
+        Err(err) => err.into_api_reply(),
+    }
+}
 
 #[derive(Serialize)]
 struct PriceResponse {
@@ -21,45 +39,24 @@ impl From<f64> for PriceResponse {
     }
 }
 
-fn get_native_prices_request() -> impl Filter<Extract = (H160,), Error = Rejection> + Clone {
-    warp::path!("v1" / "token" / H160 / "native_price").and(warp::get())
-}
+// #[cfg(test)]
+// mod tests {
+//     use {super::*, futures::FutureExt, hex_literal::hex,
+// warp::test::request};
 
-pub fn get_native_price(
-    estimator: Arc<dyn NativePriceEstimating>,
-) -> impl Filter<Extract = (ApiReply,), Error = Rejection> + Clone {
-    get_native_prices_request().and_then(move |token: H160| {
-        let estimator = estimator.clone();
-        async move {
-            let result = estimator.estimate_native_price(token).await;
-            let reply = match result {
-                Ok(price) => with_status(
-                    warp::reply::json(&PriceResponse::from(price)),
-                    StatusCode::OK,
-                ),
-                Err(err) => err.into_warp_reply(),
-            };
-            Result::<_, Infallible>::Ok(reply)
-        }
-    })
-}
-
-#[cfg(test)]
-mod tests {
-    use {super::*, futures::FutureExt, hex_literal::hex, warp::test::request};
-
-    #[test]
-    fn native_prices_query() {
-        let path = "/v1/token/0xdac17f958d2ee523a2206206994597c13d831ec7/native_price";
-        let request = request().path(path).method("GET");
-        let result = request
-            .filter(&get_native_prices_request())
-            .now_or_never()
-            .unwrap()
-            .unwrap();
-        assert_eq!(
-            result,
-            H160(hex!("dac17f958d2ee523a2206206994597c13d831ec7"))
-        );
-    }
-}
+//     #[test]
+//     fn native_prices_query() {
+//         let path =
+// "/v1/token/0xdac17f958d2ee523a2206206994597c13d831ec7/native_price";
+//         let request = request().path(path).method("GET");
+//         let result = request
+//             .filter(&get_native_prices_request())
+//             .now_or_never()
+//             .unwrap()
+//             .unwrap();
+//         assert_eq!(
+//             result,
+//             H160(hex!("dac17f958d2ee523a2206206994597c13d831ec7"))
+//         );
+//     }
+// }

--- a/crates/orderbook/src/api/get_order_by_uid.rs
+++ b/crates/orderbook/src/api/get_order_by_uid.rs
@@ -1,16 +1,25 @@
 use {
-    crate::orderbook::Orderbook,
+    super::with_status,
     anyhow::Result,
+    axum::{http::StatusCode, routing::MethodRouter},
     model::order::{Order, OrderUid},
-    std::{convert::Infallible, sync::Arc},
-    warp::{hyper::StatusCode, reply, Filter, Rejection},
+    shared::api::{error, ApiReply},
 };
 
-pub fn get_order_by_uid_request() -> impl Filter<Extract = (OrderUid,), Error = Rejection> + Clone {
-    warp::path!("v1" / "orders" / OrderUid).and(warp::get())
+pub fn route() -> (&'static str, MethodRouter<super::State>) {
+    (ENDPOINT, axum::routing::get(handler))
 }
 
-pub fn get_order_by_uid_response(result: Result<Option<Order>>) -> super::ApiReply {
+const ENDPOINT: &str = "/api/v1/orders/:uid";
+async fn handler(
+    state: axum::extract::State<super::State>,
+    uid: axum::extract::Path<OrderUid>,
+) -> ApiReply {
+    let result = state.orderbook.get_order(&uid.0).await;
+    get_order_by_uid_response(result)
+}
+
+fn get_order_by_uid_response(result: Result<Option<Order>>) -> ApiReply {
     let order = match result {
         Ok(order) => order,
         Err(err) => {
@@ -19,56 +28,45 @@ pub fn get_order_by_uid_response(result: Result<Option<Order>>) -> super::ApiRep
         }
     };
     match order {
-        Some(order) => reply::with_status(reply::json(&order), StatusCode::OK),
-        None => reply::with_status(
-            super::error("NotFound", "Order was not found"),
+        Some(order) => with_status(serde_json::to_value(&order).unwrap(), StatusCode::OK),
+        None => with_status(
+            error("NotFound", "Order was not found"),
             StatusCode::NOT_FOUND,
         ),
     }
 }
 
-pub fn get_order_by_uid(
-    orderbook: Arc<Orderbook>,
-) -> impl Filter<Extract = (super::ApiReply,), Error = Rejection> + Clone {
-    get_order_by_uid_request().and_then(move |uid| {
-        let orderbook = orderbook.clone();
-        async move {
-            let result = orderbook.get_order(&uid).await;
-            Result::<_, Infallible>::Ok(get_order_by_uid_response(result))
-        }
-    })
-}
+// #[cfg(test)]
+// mod tests {
+//     use {
+//         super::*,
+//         shared::api::response_body,
+//         warp::{test::request, Reply},
+//     };
 
-#[cfg(test)]
-mod tests {
-    use {
-        super::*,
-        shared::api::response_body,
-        warp::{test::request, Reply},
-    };
+//     #[tokio::test]
+//     async fn get_order_by_uid_request_ok() {
+//         let uid = OrderUid::default();
+//         let request =
+// request().path(&format!("/v1/orders/{uid}")).method("GET");         let
+// filter = get_order_by_uid_request();         let result =
+// request.filter(&filter).await.unwrap();         assert_eq!(result, uid);
+//     }
 
-    #[tokio::test]
-    async fn get_order_by_uid_request_ok() {
-        let uid = OrderUid::default();
-        let request = request().path(&format!("/v1/orders/{uid}")).method("GET");
-        let filter = get_order_by_uid_request();
-        let result = request.filter(&filter).await.unwrap();
-        assert_eq!(result, uid);
-    }
+//     #[tokio::test]
+//     async fn get_order_by_uid_response_ok() {
+//         let order = Order::default();
+//         let response =
+// get_order_by_uid_response(Ok(Some(order.clone()))).into_response();
+//         assert_eq!(response.status(), StatusCode::OK);
+//         let body = response_body(response).await;
+//         let response_order: Order =
+// serde_json::from_slice(body.as_slice()).unwrap();         assert_eq!
+// (response_order, order);     }
 
-    #[tokio::test]
-    async fn get_order_by_uid_response_ok() {
-        let order = Order::default();
-        let response = get_order_by_uid_response(Ok(Some(order.clone()))).into_response();
-        assert_eq!(response.status(), StatusCode::OK);
-        let body = response_body(response).await;
-        let response_order: Order = serde_json::from_slice(body.as_slice()).unwrap();
-        assert_eq!(response_order, order);
-    }
-
-    #[tokio::test]
-    async fn get_order_by_uid_response_non_existent() {
-        let response = get_order_by_uid_response(Ok(None)).into_response();
-        assert_eq!(response.status(), StatusCode::NOT_FOUND);
-    }
-}
+//     #[tokio::test]
+//     async fn get_order_by_uid_response_non_existent() {
+//         let response = get_order_by_uid_response(Ok(None)).into_response();
+//         assert_eq!(response.status(), StatusCode::NOT_FOUND);
+//     }
+// }

--- a/crates/orderbook/src/api/get_order_status.rs
+++ b/crates/orderbook/src/api/get_order_status.rs
@@ -1,36 +1,29 @@
 use {
-    crate::orderbook::Orderbook,
-    anyhow::Result,
+    super::with_status,
+    axum::{http::StatusCode, routing::MethodRouter},
     model::order::OrderUid,
-    shared::api::ApiReply,
-    std::{convert::Infallible, sync::Arc},
-    warp::{hyper::StatusCode, Filter, Rejection},
+    shared::api::{error, ApiReply},
 };
 
-fn get_status_request() -> impl Filter<Extract = (OrderUid,), Error = Rejection> + Clone {
-    warp::path!("v1" / "orders" / OrderUid / "status").and(warp::get())
+pub fn route() -> (&'static str, MethodRouter<super::State>) {
+    (ENDPOINT, axum::routing::get(handler))
 }
 
-pub fn get_status(
-    orderbook: Arc<Orderbook>,
-) -> impl Filter<Extract = (ApiReply,), Error = Rejection> + Clone {
-    get_status_request().and_then(move |uid| {
-        let orderbook = orderbook.clone();
-        async move {
-            let status = orderbook.get_order_status(&uid).await;
-            Result::<_, Infallible>::Ok(match status {
-                Ok(Some(status)) => {
-                    warp::reply::with_status(warp::reply::json(&status), StatusCode::OK)
-                }
-                Ok(None) => warp::reply::with_status(
-                    super::error("OrderNotFound", "Order not located in database"),
-                    StatusCode::NOT_FOUND,
-                ),
-                Err(err) => {
-                    tracing::error!(?err, "get_order_status");
-                    *Box::new(shared::api::internal_error_reply())
-                }
-            })
+const ENDPOINT: &str = "/api/v1/orders/:uid/status";
+async fn handler(
+    state: axum::extract::State<super::State>,
+    uid: axum::extract::Path<OrderUid>,
+) -> ApiReply {
+    let status = state.orderbook.get_order_status(&uid.0).await;
+    match status {
+        Ok(Some(status)) => with_status(serde_json::to_value(&status).unwrap(), StatusCode::OK),
+        Ok(None) => with_status(
+            error("OrderNotFound", "Order not located in database"),
+            StatusCode::NOT_FOUND,
+        ),
+        Err(err) => {
+            tracing::error!(?err, "get_order_status");
+            shared::api::internal_error_reply()
         }
-    })
+    }
 }

--- a/crates/orderbook/src/api/get_orders_by_tx.rs
+++ b/crates/orderbook/src/api/get_orders_by_tx.rs
@@ -1,48 +1,44 @@
 use {
-    crate::orderbook::Orderbook,
-    anyhow::Result,
+    super::with_status,
+    axum::routing::MethodRouter,
     ethcontract::H256,
     reqwest::StatusCode,
-    shared::api::ApiReply,
-    std::{convert::Infallible, sync::Arc},
-    warp::{reply::with_status, Filter, Rejection},
+    shared::api::{internal_error_reply, ApiReply},
 };
 
-pub fn get_orders_by_tx_request() -> impl Filter<Extract = (H256,), Error = Rejection> + Clone {
-    warp::path!("v1" / "transactions" / H256 / "orders").and(warp::get())
+pub fn route() -> (&'static str, MethodRouter<super::State>) {
+    (ENDPOINT, axum::routing::get(handler))
 }
 
-pub fn get_orders_by_tx(
-    orderbook: Arc<Orderbook>,
-) -> impl Filter<Extract = (ApiReply,), Error = Rejection> + Clone {
-    get_orders_by_tx_request().and_then(move |hash: H256| {
-        let orderbook = orderbook.clone();
-        async move {
-            let result = orderbook.get_orders_for_tx(&hash).await;
-            Result::<_, Infallible>::Ok(match result {
-                Ok(response) => with_status(warp::reply::json(&response), StatusCode::OK),
-                Err(err) => {
-                    tracing::error!(?err, "get_orders_by_tx");
-                    shared::api::internal_error_reply()
-                }
-            })
+const ENDPOINT: &str = "/api/v1/transactions/:tx_hash/orders";
+async fn handler(
+    state: axum::extract::State<super::State>,
+    tx_hash: axum::extract::Path<H256>,
+) -> ApiReply {
+    let result = state.orderbook.get_orders_for_tx(&tx_hash.0).await;
+    match result {
+        Ok(response) => with_status(serde_json::to_value(&response).unwrap(), StatusCode::OK),
+        Err(err) => {
+            tracing::error!(?err, "get_orders_by_tx");
+            internal_error_reply()
         }
-    })
-}
-
-#[cfg(test)]
-mod tests {
-    use {super::*, std::str::FromStr};
-
-    #[tokio::test]
-    async fn request_ok() {
-        let hash_str = "0x0191dbb560e936bd3320d5a505c9c05580a0ebb7e12fe117551ac26e484f295e";
-        let result = warp::test::request()
-            .path(&format!("/v1/transactions/{hash_str}/orders"))
-            .method("GET")
-            .filter(&get_orders_by_tx_request())
-            .await
-            .unwrap();
-        assert_eq!(result.0, H256::from_str(hash_str).unwrap().0);
     }
 }
+
+// #[cfg(test)]
+// mod tests {
+//     use {super::*, std::str::FromStr};
+
+//     #[tokio::test]
+//     async fn request_ok() {
+//         let hash_str =
+// "0x0191dbb560e936bd3320d5a505c9c05580a0ebb7e12fe117551ac26e484f295e";
+//         let result = warp::test::request()
+//             .path(&format!("/v1/transactions/{hash_str}/orders"))
+//             .method("GET")
+//             .filter(&get_orders_by_tx_request())
+//             .await
+//             .unwrap();
+//         assert_eq!(result.0, H256::from_str(hash_str).unwrap().0);
+//     }
+// }

--- a/crates/orderbook/src/api/get_solver_competition.rs
+++ b/crates/orderbook/src/api/get_solver_competition.rs
@@ -1,66 +1,65 @@
 use {
+    super::with_status,
     crate::solver_competition::{Identifier, LoadSolverCompetitionError, SolverCompetitionStoring},
     anyhow::Result,
+    axum::{http::StatusCode, routing::MethodRouter},
     model::{auction::AuctionId, solver_competition::SolverCompetitionAPI},
     primitive_types::H256,
-    reqwest::StatusCode,
-    std::{convert::Infallible, sync::Arc},
-    warp::{
-        reply::{with_status, Json, WithStatus},
-        Filter,
-        Rejection,
-    },
+    shared::api::{error, ApiReply},
 };
 
-fn request_id() -> impl Filter<Extract = (Identifier,), Error = Rejection> + Clone {
-    warp::path!("v1" / "solver_competition" / AuctionId)
-        .and(warp::get())
-        .map(Identifier::Id)
+pub fn latest_route() -> (&'static str, MethodRouter<super::State>) {
+    (LATEST_ENDPOINT, axum::routing::get(latest_handler))
 }
 
-fn request_hash() -> impl Filter<Extract = (Identifier,), Error = Rejection> + Clone {
-    warp::path!("v1" / "solver_competition" / "by_tx_hash" / H256)
-        .and(warp::get())
-        .map(Identifier::Transaction)
+const LATEST_ENDPOINT: &str = "/api/v1/solver_competition/latest";
+async fn latest_handler(state: axum::extract::State<super::State>) -> ApiReply {
+    let result = state.database.load_latest_competition().await;
+    response(result)
 }
 
-fn request_latest() -> impl Filter<Extract = (), Error = Rejection> + Clone {
-    warp::path!("v1" / "solver_competition" / "latest").and(warp::get())
-}
-pub fn get(
-    handler: Arc<dyn SolverCompetitionStoring>,
-) -> impl Filter<Extract = (super::ApiReply,), Error = Rejection> + Clone {
-    request_id()
-        .or(request_hash())
-        .unify()
-        .and_then(move |identifier: Identifier| {
-            let handler = handler.clone();
-            async move {
-                let result = handler.load_competition(identifier).await;
-                Result::<_, Infallible>::Ok(response(result))
-            }
-        })
+pub fn by_auction_id_route() -> (&'static str, MethodRouter<super::State>) {
+    (
+        BY_AUCTION_ID_ENDPOINT,
+        axum::routing::get(by_auction_id_handler),
+    )
 }
 
-pub fn get_latest(
-    handler: Arc<dyn SolverCompetitionStoring>,
-) -> impl Filter<Extract = (super::ApiReply,), Error = Rejection> + Clone {
-    request_latest().and_then(move || {
-        let handler = handler.clone();
-        async move {
-            let result = handler.load_latest_competition().await;
-            Result::<_, Infallible>::Ok(response(result))
-        }
-    })
+const BY_AUCTION_ID_ENDPOINT: &str = "/api/v1/solver_competition/:auction_id";
+async fn by_auction_id_handler(
+    state: axum::extract::State<super::State>,
+    auction_id: axum::extract::Path<AuctionId>,
+) -> ApiReply {
+    let result = state
+        .database
+        .load_competition(Identifier::Id(auction_id.0))
+        .await;
+    response(result)
+}
+
+pub fn by_tx_hash_route() -> (&'static str, MethodRouter<super::State>) {
+    (BY_TX_HASH_ENDPOINT, axum::routing::get(by_tx_hash_handler))
+}
+
+const BY_TX_HASH_ENDPOINT: &str = "/api/v1/solver_competition/by_tx_hash/:tx_hash";
+async fn by_tx_hash_handler(
+    state: axum::extract::State<super::State>,
+    tx_hash: axum::extract::Path<H256>,
+) -> ApiReply {
+    let result = state
+        .database
+        .load_competition(Identifier::Transaction(tx_hash.0))
+        .await;
+    response(result)
 }
 
 fn response(
     result: Result<SolverCompetitionAPI, crate::solver_competition::LoadSolverCompetitionError>,
-) -> WithStatus<Json> {
+) -> ApiReply {
     match result {
-        Ok(response) => with_status(warp::reply::json(&response), StatusCode::OK),
+        Ok(response) => with_status(serde_json::to_value(&response).unwrap(), StatusCode::OK),
         Err(LoadSolverCompetitionError::NotFound) => with_status(
-            super::error("NotFound", "no competition found"),
+            error("NotFound", "no competition found"),
             StatusCode::NOT_FOUND,
         ),
         Err(LoadSolverCompetitionError::Other(err)) => {
@@ -70,45 +69,48 @@ fn response(
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use {
-        super::*,
-        crate::solver_competition::MockSolverCompetitionStoring,
-        warp::{test::request, Reply},
-    };
+// #[cfg(test)]
+// mod tests {
+//     use {
+//         super::*,
+//         crate::solver_competition::MockSolverCompetitionStoring,
+//         warp::{test::request, Reply},
+//     };
 
-    #[tokio::test]
-    async fn test() {
-        let mut storage = MockSolverCompetitionStoring::new();
-        storage
-            .expect_load_competition()
-            .times(2)
-            .returning(|_| Ok(Default::default()));
-        storage
-            .expect_load_competition()
-            .times(1)
-            .return_once(|_| Err(LoadSolverCompetitionError::NotFound));
-        let filter = get(Arc::new(storage));
+//     #[tokio::test]
+//     async fn test() {
+//         let mut storage = MockSolverCompetitionStoring::new();
+//         storage
+//             .expect_load_competition()
+//             .times(2)
+//             .returning(|_| Ok(Default::default()));
+//         storage
+//             .expect_load_competition()
+//             .times(1)
+//             .return_once(|_| Err(LoadSolverCompetitionError::NotFound));
+//         let filter = get(Arc::new(storage));
 
-        let request_ = request().path("/v1/solver_competition/0").method("GET");
-        let response = request_.filter(&filter).await.unwrap().into_response();
-        dbg!(&response);
-        assert_eq!(response.status(), StatusCode::OK);
+//         let request_ =
+// request().path("/v1/solver_competition/0").method("GET");         let
+// response = request_.filter(&filter).await.unwrap().into_response();
+//         dbg!(&response);
+//         assert_eq!(response.status(), StatusCode::OK);
 
-        let request_ = request()
-            .path(
-                "/v1/solver_competition/by_tx_hash/\
-                 0xd51f28edffcaaa76be4a22f6375ad289272c037f3cc072345676e88d92ced8b5",
-            )
-            .method("GET");
-        let response = request_.filter(&filter).await.unwrap().into_response();
-        dbg!(&response);
-        assert_eq!(response.status(), StatusCode::OK);
+//         let request_ = request()
+//             .path(
+//                 "/v1/solver_competition/by_tx_hash/\
+//
+// 0xd51f28edffcaaa76be4a22f6375ad289272c037f3cc072345676e88d92ced8b5",
+//             )
+//             .method("GET");
+//         let response =
+// request_.filter(&filter).await.unwrap().into_response();         dbg!(&
+// response);         assert_eq!(response.status(), StatusCode::OK);
 
-        let request_ = request().path("/v1/solver_competition/1337").method("GET");
-        let response = request_.filter(&filter).await.unwrap().into_response();
-        dbg!(&response);
-        assert_eq!(response.status(), StatusCode::NOT_FOUND);
-    }
-}
+//         let request_ =
+// request().path("/v1/solver_competition/1337").method("GET");         let
+// response = request_.filter(&filter).await.unwrap().into_response();
+//         dbg!(&response);
+//         assert_eq!(response.status(), StatusCode::NOT_FOUND);
+//     }
+// }

--- a/crates/orderbook/src/api/get_trades.rs
+++ b/crates/orderbook/src/api/get_trades.rs
@@ -1,16 +1,44 @@
 use {
-    crate::database::{
-        trades::{TradeFilter, TradeRetrieving},
-        Postgres,
-    },
+    super::with_status,
+    crate::database::trades::{TradeFilter, TradeRetrieving},
     anyhow::{Context, Result},
+    axum::{http::StatusCode, routing::MethodRouter},
     model::order::OrderUid,
     primitive_types::H160,
     serde::Deserialize,
-    shared::api::{error, ApiReply},
-    std::convert::Infallible,
-    warp::{hyper::StatusCode, reply::with_status, Filter, Rejection},
+    shared::api::{error, internal_error_reply, ApiReply},
 };
+
+pub fn route() -> (&'static str, MethodRouter<super::State>) {
+    (ENDPOINT, axum::routing::get(handler))
+}
+
+const ENDPOINT: &str = "/api/v1/trades";
+async fn handler(
+    state: axum::extract::State<super::State>,
+    query: axum::extract::Query<Query>,
+) -> ApiReply {
+    match query.trade_filter() {
+        Ok(trade_filter) => {
+            let result = state
+                .database
+                .trades(&trade_filter)
+                .await
+                .context("get_trades");
+
+            match result {
+                Ok(reply) => with_status(serde_json::to_value(&reply).unwrap(), StatusCode::OK),
+                Err(err) => {
+                    tracing::error!(?err, "get_trades");
+                    internal_error_reply()
+                }
+            }
+        }
+        Err(TradeFilterError::InvalidFilter(msg)) => {
+            with_status(error("InvalidTradeFilter", msg), StatusCode::BAD_REQUEST)
+        }
+    }
+}
 
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -25,16 +53,12 @@ enum TradeFilterError {
 }
 
 impl Query {
-    fn trade_filter(&self) -> TradeFilter {
-        TradeFilter {
-            order_uid: self.order_uid,
-            owner: self.owner,
-        }
-    }
-
-    fn validate(&self) -> Result<TradeFilter, TradeFilterError> {
+    fn trade_filter(&self) -> Result<TradeFilter, TradeFilterError> {
         match (self.order_uid.as_ref(), self.owner.as_ref()) {
-            (Some(_), None) | (None, Some(_)) => Ok(self.trade_filter()),
+            (Some(_), None) | (None, Some(_)) => Ok(TradeFilter {
+                order_uid: self.order_uid,
+                owner: self.owner,
+            }),
             _ => Err(TradeFilterError::InvalidFilter(
                 "Must specify exactly one of owner and order_uid.".to_owned(),
             )),
@@ -42,89 +66,60 @@ impl Query {
     }
 }
 
-fn get_trades_request(
-) -> impl Filter<Extract = (Result<TradeFilter, TradeFilterError>,), Error = Rejection> + Clone {
-    warp::path!("v1" / "trades")
-        .and(warp::get())
-        .and(warp::query::<Query>())
-        .map(|query: Query| query.validate())
-}
+// #[cfg(test)]
+// mod tests {
+//     use {
+//         super::*,
+//         hex_literal::hex,
+//         primitive_types::H160,
+//         warp::test::{request, RequestBuilder},
+//     };
 
-pub fn get_trades(db: Postgres) -> impl Filter<Extract = (ApiReply,), Error = Rejection> + Clone {
-    get_trades_request().and_then(move |request_result| {
-        let database = db.clone();
-        async move {
-            Result::<_, Infallible>::Ok(match request_result {
-                Ok(trade_filter) => {
-                    let result = database.trades(&trade_filter).await.context("get_trades");
-                    match result {
-                        Ok(reply) => with_status(warp::reply::json(&reply), StatusCode::OK),
-                        Err(err) => {
-                            tracing::error!(?err, "get_trades");
-                            shared::api::internal_error_reply()
-                        }
-                    }
-                }
-                Err(TradeFilterError::InvalidFilter(msg)) => {
-                    let err = error("InvalidTradeFilter", msg);
-                    with_status(err, StatusCode::BAD_REQUEST)
-                }
-            })
-        }
-    })
-}
+//     #[tokio::test]
+//     async fn get_trades_request_ok() {
+//         let trade_filter = |request: RequestBuilder| async move {
+//             let filter = get_trades_request();
+//             request.method("GET").filter(&filter).await
+//         };
 
-#[cfg(test)]
-mod tests {
-    use {
-        super::*,
-        hex_literal::hex,
-        primitive_types::H160,
-        warp::test::{request, RequestBuilder},
-    };
+//         let owner =
+// H160::from_slice(&hex!("0000000000000000000000000000000000000001"));
+//         let owner_path = format!("/v1/trades?owner=0x{owner:x}");
+//         let result = trade_filter(request().path(owner_path.as_str()))
+//             .await
+//             .unwrap()
+//             .unwrap();
+//         assert_eq!(result.owner, Some(owner));
+//         assert_eq!(result.order_uid, None);
 
-    #[tokio::test]
-    async fn get_trades_request_ok() {
-        let trade_filter = |request: RequestBuilder| async move {
-            let filter = get_trades_request();
-            request.method("GET").filter(&filter).await
-        };
+//         let uid = OrderUid([1u8; 56]);
+//         let order_uid_path = format!("/v1/trades?orderUid={uid}");
+//         let result = trade_filter(request().path(order_uid_path.as_str()))
+//             .await
+//             .unwrap()
+//             .unwrap();
+//         assert_eq!(result.owner, None);
+//         assert_eq!(result.order_uid, Some(uid));
+//     }
 
-        let owner = H160::from_slice(&hex!("0000000000000000000000000000000000000001"));
-        let owner_path = format!("/v1/trades?owner=0x{owner:x}");
-        let result = trade_filter(request().path(owner_path.as_str()))
-            .await
-            .unwrap()
-            .unwrap();
-        assert_eq!(result.owner, Some(owner));
-        assert_eq!(result.order_uid, None);
+//     #[tokio::test]
+//     async fn get_trades_request_err() {
+//         let trade_filter = |request: RequestBuilder| async move {
+//             let filter = get_trades_request();
+//             request.method("GET").filter(&filter).await
+//         };
 
-        let uid = OrderUid([1u8; 56]);
-        let order_uid_path = format!("/v1/trades?orderUid={uid}");
-        let result = trade_filter(request().path(order_uid_path.as_str()))
-            .await
-            .unwrap()
-            .unwrap();
-        assert_eq!(result.owner, None);
-        assert_eq!(result.order_uid, Some(uid));
-    }
+//         let owner =
+// H160::from_slice(&hex!("0000000000000000000000000000000000000001"));
+//         let uid = OrderUid([1u8; 56]);
+//         let path = format!("/v1/trades?owner=0x{owner:x}&orderUid={uid}");
 
-    #[tokio::test]
-    async fn get_trades_request_err() {
-        let trade_filter = |request: RequestBuilder| async move {
-            let filter = get_trades_request();
-            request.method("GET").filter(&filter).await
-        };
+//         let result =
+// trade_filter(request().path(path.as_str())).await.unwrap();         assert!
+// (result.is_err());
 
-        let owner = H160::from_slice(&hex!("0000000000000000000000000000000000000001"));
-        let uid = OrderUid([1u8; 56]);
-        let path = format!("/v1/trades?owner=0x{owner:x}&orderUid={uid}");
-
-        let result = trade_filter(request().path(path.as_str())).await.unwrap();
-        assert!(result.is_err());
-
-        let path = "/v1/trades";
-        let result = trade_filter(request().path(path)).await.unwrap();
-        assert!(result.is_err());
-    }
-}
+//         let path = "/v1/trades";
+//         let result = trade_filter(request().path(path)).await.unwrap();
+//         assert!(result.is_err());
+//     }
+// }

--- a/crates/orderbook/src/api/get_user_orders.rs
+++ b/crates/orderbook/src/api/get_user_orders.rs
@@ -1,12 +1,55 @@
 use {
-    crate::orderbook::Orderbook,
-    anyhow::Result,
+    crate::api::with_status,
+    axum::{http::StatusCode, routing::MethodRouter},
     primitive_types::H160,
     serde::Deserialize,
-    shared::api::ApiReply,
-    std::{convert::Infallible, sync::Arc},
-    warp::{hyper::StatusCode, reply::with_status, Filter, Rejection},
+    shared::api::{error, internal_error_reply, ApiReply},
 };
+
+pub fn route() -> (&'static str, MethodRouter<super::State>) {
+    (ENDPOINT, axum::routing::get(handler))
+}
+
+const ENDPOINT: &str = "/api/v1/account/:owner/orders";
+async fn handler(
+    state: axum::extract::State<super::State>,
+    owner: axum::extract::Path<H160>,
+    query: Option<axum::extract::Json<Query>>,
+) -> ApiReply {
+    const DEFAULT_OFFSET: u64 = 0;
+    const DEFAULT_LIMIT: u64 = 10;
+    const MIN_LIMIT: u64 = 1;
+    const MAX_LIMIT: u64 = 1000;
+
+    let offset = query
+        .as_ref()
+        .map(|q| q.offset)
+        .flatten()
+        .unwrap_or(DEFAULT_OFFSET);
+    let limit = query
+        .as_ref()
+        .map(|q| q.limit)
+        .flatten()
+        .unwrap_or(DEFAULT_LIMIT);
+
+    if !(MIN_LIMIT..=MAX_LIMIT).contains(&limit) {
+        return with_status(
+            error(
+                "LIMIT_OUT_OF_BOUNDS",
+                format!("The pagination limit is [{MIN_LIMIT},{MAX_LIMIT}]."),
+            ),
+            StatusCode::BAD_REQUEST,
+        );
+    }
+    let result = state.orderbook.get_user_orders(&owner, offset, limit).await;
+    match result {
+        Ok(reply) => with_status(serde_json::to_value(&reply).unwrap(), StatusCode::OK),
+        Err(err) => {
+            tracing::error!(?err, "get_user_orders");
+            internal_error_reply()
+        }
+    }
+}
 
 #[derive(Clone, Copy, Debug, Deserialize)]
 struct Query {
@@ -14,70 +57,32 @@ struct Query {
     limit: Option<u64>,
 }
 
-fn request() -> impl Filter<Extract = (H160, Query), Error = Rejection> + Clone {
-    warp::path!("v1" / "account" / H160 / "orders")
-        .and(warp::get())
-        .and(warp::query::<Query>())
-}
+// #[cfg(test)]
+// mod tests {
+//     use {super::*, shared::addr};
 
-pub fn get_user_orders(
-    orderbook: Arc<Orderbook>,
-) -> impl Filter<Extract = (ApiReply,), Error = Rejection> + Clone {
-    request().and_then(move |owner: H160, query: Query| {
-        let orderbook = orderbook.clone();
-        async move {
-            const DEFAULT_OFFSET: u64 = 0;
-            const DEFAULT_LIMIT: u64 = 10;
-            const MIN_LIMIT: u64 = 1;
-            const MAX_LIMIT: u64 = 1000;
-            let offset = query.offset.unwrap_or(DEFAULT_OFFSET);
-            let limit = query.limit.unwrap_or(DEFAULT_LIMIT);
-            if !(MIN_LIMIT..=MAX_LIMIT).contains(&limit) {
-                return Ok(with_status(
-                    super::error(
-                        "LIMIT_OUT_OF_BOUNDS",
-                        format!("The pagination limit is [{MIN_LIMIT},{MAX_LIMIT}]."),
-                    ),
-                    StatusCode::BAD_REQUEST,
-                ));
-            }
-            let result = orderbook.get_user_orders(&owner, offset, limit).await;
-            Result::<_, Infallible>::Ok(match result {
-                Ok(reply) => with_status(warp::reply::json(&reply), StatusCode::OK),
-                Err(err) => {
-                    tracing::error!(?err, "get_user_orders");
-                    shared::api::internal_error_reply()
-                }
-            })
-        }
-    })
-}
+//     #[tokio::test]
+//     async fn request_() {
+//         let path =
+// "/v1/account/0x0000000000000000000000000000000000000001/orders";         let
+// result = warp::test::request()             .path(path)
+//             .method("GET")
+//             .filter(&request())
+//             .await
+//             .unwrap();
+//         assert_eq!(result.0,
+// addr!("0000000000000000000000000000000000000001"));         assert_eq!
+// (result.1.offset, None);         assert_eq!(result.1.limit, None);
 
-#[cfg(test)]
-mod tests {
-    use {super::*, shared::addr};
-
-    #[tokio::test]
-    async fn request_() {
-        let path = "/v1/account/0x0000000000000000000000000000000000000001/orders";
-        let result = warp::test::request()
-            .path(path)
-            .method("GET")
-            .filter(&request())
-            .await
-            .unwrap();
-        assert_eq!(result.0, addr!("0000000000000000000000000000000000000001"));
-        assert_eq!(result.1.offset, None);
-        assert_eq!(result.1.limit, None);
-
-        let path = "/v1/account/0x0000000000000000000000000000000000000001/orders?offset=1&limit=2";
-        let result = warp::test::request()
-            .path(path)
-            .method("GET")
-            .filter(&request())
-            .await
-            .unwrap();
-        assert_eq!(result.1.offset, Some(1));
-        assert_eq!(result.1.limit, Some(2));
-    }
-}
+//         let path =
+// "/v1/account/0x0000000000000000000000000000000000000001/orders?offset=1&
+// limit=2";         let result = warp::test::request()
+//             .path(path)
+//             .method("GET")
+//             .filter(&request())
+//             .await
+//             .unwrap();
+//         assert_eq!(result.1.offset, Some(1));
+//         assert_eq!(result.1.limit, Some(2));
+//     }
+// }

--- a/crates/orderbook/src/api/post_quote.rs
+++ b/crates/orderbook/src/api/post_quote.rs
@@ -1,71 +1,65 @@
 use {
-    super::post_order::{AppDataValidationErrorWrapper, PartialValidationErrorWrapper},
-    crate::quoter::{OrderQuoteError, QuoteHandler},
-    anyhow::Result,
+    super::{
+        post_order::{AppDataValidationErrorWrapper, PartialValidationErrorWrapper},
+        with_status,
+    },
+    crate::quoter::OrderQuoteError,
+    axum::{http::StatusCode, routing::MethodRouter},
     model::quote::OrderQuoteRequest,
-    reqwest::StatusCode,
     shared::{
-        api::{self, convert_json_response, error, rich_error, ApiReply, IntoWarpReply},
+        api::{convert_json_response, error, rich_error, ApiReply, IntoApiReply},
         order_quoting::CalculateQuoteError,
     },
-    std::{convert::Infallible, sync::Arc},
-    warp::{Filter, Rejection},
 };
 
-fn post_quote_request() -> impl Filter<Extract = (OrderQuoteRequest,), Error = Rejection> + Clone {
-    warp::path!("v1" / "quote")
-        .and(warp::post())
-        .and(api::extract_payload())
+pub fn route() -> (&'static str, MethodRouter<super::State>) {
+    (ENDPOINT, axum::routing::post(handler))
 }
 
-pub fn post_quote(
-    quotes: Arc<QuoteHandler>,
-) -> impl Filter<Extract = (super::ApiReply,), Error = Rejection> + Clone {
-    post_quote_request().and_then(move |request: OrderQuoteRequest| {
-        let quotes = quotes.clone();
-        async move {
-            let result = quotes
-                .calculate_quote(&request)
-                .await
-                .map_err(OrderQuoteErrorWrapper);
-            if let Err(err) = &result {
-                tracing::warn!(?err, ?request, "post_quote error");
-            }
-            Result::<_, Infallible>::Ok(convert_json_response(result))
-        }
-    })
+const ENDPOINT: &str = "/api/v1/quote";
+async fn handler(
+    state: axum::extract::State<super::State>,
+    request: axum::extract::Json<OrderQuoteRequest>,
+) -> ApiReply {
+    let result = state
+        .quoter
+        .calculate_quote(&request)
+        .await
+        .map_err(OrderQuoteErrorWrapper);
+    if let Err(err) = &result {
+        tracing::warn!(?err, ?request, "post_quote error");
+    }
+    convert_json_response(result)
 }
 
 #[derive(Debug)]
-pub struct OrderQuoteErrorWrapper(pub OrderQuoteError);
-impl IntoWarpReply for OrderQuoteErrorWrapper {
-    fn into_warp_reply(self) -> ApiReply {
+struct OrderQuoteErrorWrapper(pub OrderQuoteError);
+impl IntoApiReply for OrderQuoteErrorWrapper {
+    fn into_api_reply(self) -> ApiReply {
         match self.0 {
-            OrderQuoteError::AppData(err) => AppDataValidationErrorWrapper(err).into_warp_reply(),
-            OrderQuoteError::Order(err) => PartialValidationErrorWrapper(err).into_warp_reply(),
+            OrderQuoteError::AppData(err) => AppDataValidationErrorWrapper(err).into_api_reply(),
+            OrderQuoteError::Order(err) => PartialValidationErrorWrapper(err).into_api_reply(),
             OrderQuoteError::CalculateQuote(err) => {
-                CalculateQuoteErrorWrapper(err).into_warp_reply()
+                CalculateQuoteErrorWrapper(err).into_api_reply()
             }
         }
     }
 }
 
-pub struct CalculateQuoteErrorWrapper(CalculateQuoteError);
-impl IntoWarpReply for CalculateQuoteErrorWrapper {
-    fn into_warp_reply(self) -> ApiReply {
+struct CalculateQuoteErrorWrapper(CalculateQuoteError);
+impl IntoApiReply for CalculateQuoteErrorWrapper {
+    fn into_api_reply(self) -> ApiReply {
         match self.0 {
-            CalculateQuoteError::Price(err) => err.into_warp_reply(),
-            CalculateQuoteError::SellAmountDoesNotCoverFee { fee_amount } => {
-                warp::reply::with_status(
-                    rich_error(
-                        "SellAmountDoesNotCoverFee",
-                        "The sell amount for the sell order is lower than the fee.",
-                        serde_json::json!({ "fee_amount": fee_amount }),
-                    ),
-                    StatusCode::BAD_REQUEST,
-                )
-            }
-            CalculateQuoteError::QuoteNotVerified => warp::reply::with_status(
+            CalculateQuoteError::Price(err) => err.into_api_reply(),
+            CalculateQuoteError::SellAmountDoesNotCoverFee { fee_amount } => with_status(
+                rich_error(
+                    "SellAmountDoesNotCoverFee",
+                    "The sell amount for the sell order is lower than the fee.",
+                    serde_json::json!({ "fee_amount": fee_amount }),
+                ),
+                StatusCode::BAD_REQUEST,
+            ),
+            CalculateQuoteError::QuoteNotVerified => with_status(
                 error(
                     "QuoteNotVerified",
                     "No quote for this trade could be verified to be accurate. Orders for this \
@@ -81,237 +75,242 @@ impl IntoWarpReply for CalculateQuoteErrorWrapper {
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use {
-        super::*,
-        anyhow::anyhow,
-        app_data::AppDataHash,
-        chrono::{TimeZone, Utc},
-        ethcontract::H160,
-        model::{
-            order::{BuyTokenDestination, SellTokenSource},
-            quote::{
-                OrderQuote,
-                OrderQuoteResponse,
-                OrderQuoteSide,
-                PriceQuality,
-                QuoteSigningScheme,
-                SellAmount,
-                Validity,
-            },
-        },
-        number::nonzero::U256 as NonZeroU256,
-        reqwest::StatusCode,
-        serde_json::json,
-        shared::{api::response_body, order_quoting::CalculateQuoteError},
-        warp::{test::request, Reply},
-    };
+// #[cfg(test)]
+// mod tests {
+//     use {
+//         super::*,
+//         anyhow::anyhow,
+//         app_data::AppDataHash,
+//         chrono::{TimeZone, Utc},
+//         ethcontract::H160,
+//         model::{
+//             order::{BuyTokenDestination, SellTokenSource},
+//             quote::{
+//                 OrderQuote,
+//                 OrderQuoteResponse,
+//                 OrderQuoteSide,
+//                 PriceQuality,
+//                 QuoteSigningScheme,
+//                 SellAmount,
+//                 Validity,
+//             },
+//         },
+//         number::nonzero::U256 as NonZeroU256,
+//         reqwest::StatusCode,
+//         serde_json::json,
+//         shared::{api::response_body, order_quoting::CalculateQuoteError},
+//         warp::{test::request, Reply},
+//     };
 
-    #[test]
-    fn deserializes_sell_after_fees_quote_request() {
-        assert_eq!(
-            serde_json::from_value::<OrderQuoteRequest>(json!({
-                "from": "0x0101010101010101010101010101010101010101",
-                "sellToken": "0x0202020202020202020202020202020202020202",
-                "buyToken": "0x0303030303030303030303030303030303030303",
-                "kind": "sell",
-                "sellAmountAfterFee": "1337",
-                "validTo": 0x12345678,
-                "appData": "0x9090909090909090909090909090909090909090909090909090909090909090",
-                "partiallyFillable": false,
-                "buyTokenBalance": "internal",
-                "signingScheme": "presign",
-                "priceQuality": "optimal"
-            }))
-            .unwrap(),
-            OrderQuoteRequest {
-                from: H160([0x01; 20]),
-                sell_token: H160([0x02; 20]),
-                buy_token: H160([0x03; 20]),
-                receiver: None,
-                side: OrderQuoteSide::Sell {
-                    sell_amount: SellAmount::AfterFee {
-                        value: NonZeroU256::try_from(1337).unwrap()
-                    },
-                },
-                validity: Validity::To(0x12345678),
-                app_data: AppDataHash([0x90; 32]).into(),
-                sell_token_balance: SellTokenSource::Erc20,
-                buy_token_balance: BuyTokenDestination::Internal,
-                signing_scheme: QuoteSigningScheme::PreSign {
-                    onchain_order: false
-                },
-                price_quality: PriceQuality::Optimal,
-            }
-        );
-    }
+//     #[test]
+//     fn deserializes_sell_after_fees_quote_request() {
+//         assert_eq!(
+//             serde_json::from_value::<OrderQuoteRequest>(json!({
+//                 "from": "0x0101010101010101010101010101010101010101",
+//                 "sellToken": "0x0202020202020202020202020202020202020202",
+//                 "buyToken": "0x0303030303030303030303030303030303030303",
+//                 "kind": "sell",
+//                 "sellAmountAfterFee": "1337",
+//                 "validTo": 0x12345678,
+//                 "appData":
+// "0x9090909090909090909090909090909090909090909090909090909090909090",
+//                 "partiallyFillable": false,
+//                 "buyTokenBalance": "internal",
+//                 "signingScheme": "presign",
+//                 "priceQuality": "optimal"
+//             }))
+//             .unwrap(),
+//             OrderQuoteRequest {
+//                 from: H160([0x01; 20]),
+//                 sell_token: H160([0x02; 20]),
+//                 buy_token: H160([0x03; 20]),
+//                 receiver: None,
+//                 side: OrderQuoteSide::Sell {
+//                     sell_amount: SellAmount::AfterFee {
+//                         value: NonZeroU256::try_from(1337).unwrap()
+//                     },
+//                 },
+//                 validity: Validity::To(0x12345678),
+//                 app_data: AppDataHash([0x90; 32]).into(),
+//                 sell_token_balance: SellTokenSource::Erc20,
+//                 buy_token_balance: BuyTokenDestination::Internal,
+//                 signing_scheme: QuoteSigningScheme::PreSign {
+//                     onchain_order: false
+//                 },
+//                 price_quality: PriceQuality::Optimal,
+//             }
+//         );
+//     }
 
-    #[test]
-    fn deserializes_sell_before_fees_quote_request() {
-        assert_eq!(
-            serde_json::from_value::<OrderQuoteRequest>(json!({
-                "from": "0x0101010101010101010101010101010101010101",
-                "sellToken": "0x0202020202020202020202020202020202020202",
-                "buyToken": "0x0303030303030303030303030303030303030303",
-                "kind": "sell",
-                "sellAmountBeforeFee": "1337",
-                "validFor": 1000,
-                "appData": "0x9090909090909090909090909090909090909090909090909090909090909090",
-                "partiallyFillable": false,
-                "sellTokenBalance": "external",
-                "priceQuality": "fast"
-            }))
-            .unwrap(),
-            OrderQuoteRequest {
-                from: H160([0x01; 20]),
-                sell_token: H160([0x02; 20]),
-                buy_token: H160([0x03; 20]),
-                receiver: None,
-                side: OrderQuoteSide::Sell {
-                    sell_amount: SellAmount::BeforeFee {
-                        value: NonZeroU256::try_from(1337).unwrap()
-                    },
-                },
-                validity: Validity::For(1000),
-                app_data: AppDataHash([0x90; 32]).into(),
-                sell_token_balance: SellTokenSource::External,
-                price_quality: PriceQuality::Fast,
-                ..Default::default()
-            }
-        );
-    }
+//     #[test]
+//     fn deserializes_sell_before_fees_quote_request() {
+//         assert_eq!(
+//             serde_json::from_value::<OrderQuoteRequest>(json!({
+//                 "from": "0x0101010101010101010101010101010101010101",
+//                 "sellToken": "0x0202020202020202020202020202020202020202",
+//                 "buyToken": "0x0303030303030303030303030303030303030303",
+//                 "kind": "sell",
+//                 "sellAmountBeforeFee": "1337",
+//                 "validFor": 1000,
+//                 "appData":
+// "0x9090909090909090909090909090909090909090909090909090909090909090",
+//                 "partiallyFillable": false,
+//                 "sellTokenBalance": "external",
+//                 "priceQuality": "fast"
+//             }))
+//             .unwrap(),
+//             OrderQuoteRequest {
+//                 from: H160([0x01; 20]),
+//                 sell_token: H160([0x02; 20]),
+//                 buy_token: H160([0x03; 20]),
+//                 receiver: None,
+//                 side: OrderQuoteSide::Sell {
+//                     sell_amount: SellAmount::BeforeFee {
+//                         value: NonZeroU256::try_from(1337).unwrap()
+//                     },
+//                 },
+//                 validity: Validity::For(1000),
+//                 app_data: AppDataHash([0x90; 32]).into(),
+//                 sell_token_balance: SellTokenSource::External,
+//                 price_quality: PriceQuality::Fast,
+//                 ..Default::default()
+//             }
+//         );
+//     }
 
-    #[test]
-    fn deserializes_buy_quote_request() {
-        assert_eq!(
-            serde_json::from_value::<OrderQuoteRequest>(json!({
-                "from": "0x0101010101010101010101010101010101010101",
-                "sellToken": "0x0202020202020202020202020202020202020202",
-                "buyToken": "0x0303030303030303030303030303030303030303",
-                "receiver": "0x0404040404040404040404040404040404040404",
-                "kind": "buy",
-                "buyAmountAfterFee": "1337",
-                "validTo": 0x12345678,
-                "appData": "0x9090909090909090909090909090909090909090909090909090909090909090",
-                "partiallyFillable": false,
-            }))
-            .unwrap(),
-            OrderQuoteRequest {
-                from: H160([0x01; 20]),
-                sell_token: H160([0x02; 20]),
-                buy_token: H160([0x03; 20]),
-                receiver: Some(H160([0x04; 20])),
-                side: OrderQuoteSide::Buy {
-                    buy_amount_after_fee: NonZeroU256::try_from(1337).unwrap(),
-                },
-                validity: Validity::To(0x12345678),
-                app_data: AppDataHash([0x90; 32]).into(),
-                ..Default::default()
-            }
-        );
-    }
+//     #[test]
+//     fn deserializes_buy_quote_request() {
+//         assert_eq!(
+//             serde_json::from_value::<OrderQuoteRequest>(json!({
+//                 "from": "0x0101010101010101010101010101010101010101",
+//                 "sellToken": "0x0202020202020202020202020202020202020202",
+//                 "buyToken": "0x0303030303030303030303030303030303030303",
+//                 "receiver": "0x0404040404040404040404040404040404040404",
+//                 "kind": "buy",
+//                 "buyAmountAfterFee": "1337",
+//                 "validTo": 0x12345678,
+//                 "appData":
+// "0x9090909090909090909090909090909090909090909090909090909090909090",
+//                 "partiallyFillable": false,
+//             }))
+//             .unwrap(),
+//             OrderQuoteRequest {
+//                 from: H160([0x01; 20]),
+//                 sell_token: H160([0x02; 20]),
+//                 buy_token: H160([0x03; 20]),
+//                 receiver: Some(H160([0x04; 20])),
+//                 side: OrderQuoteSide::Buy {
+//                     buy_amount_after_fee:
+// NonZeroU256::try_from(1337).unwrap(),                 },
+//                 validity: Validity::To(0x12345678),
+//                 app_data: AppDataHash([0x90; 32]).into(),
+//                 ..Default::default()
+//             }
+//         );
+//     }
 
-    #[test]
-    fn deserialize_minimum_parameters() {
-        assert_eq!(
-            serde_json::from_value::<OrderQuoteRequest>(json!({
-                "from": "0x0101010101010101010101010101010101010101",
-                "sellToken": "0x0202020202020202020202020202020202020202",
-                "buyToken": "0x0303030303030303030303030303030303030303",
-                "kind": "sell",
-                "sellAmountAfterFee": "1337",
-            }))
-            .unwrap(),
-            OrderQuoteRequest {
-                from: H160([0x01; 20]),
-                sell_token: H160([0x02; 20]),
-                buy_token: H160([0x03; 20]),
-                side: OrderQuoteSide::Sell {
-                    sell_amount: SellAmount::AfterFee {
-                        value: NonZeroU256::try_from(1337).unwrap()
-                    },
-                },
-                ..Default::default()
-            }
-        );
-    }
+//     #[test]
+//     fn deserialize_minimum_parameters() {
+//         assert_eq!(
+//             serde_json::from_value::<OrderQuoteRequest>(json!({
+//                 "from": "0x0101010101010101010101010101010101010101",
+//                 "sellToken": "0x0202020202020202020202020202020202020202",
+//                 "buyToken": "0x0303030303030303030303030303030303030303",
+//                 "kind": "sell",
+//                 "sellAmountAfterFee": "1337",
+//             }))
+//             .unwrap(),
+//             OrderQuoteRequest {
+//                 from: H160([0x01; 20]),
+//                 sell_token: H160([0x02; 20]),
+//                 buy_token: H160([0x03; 20]),
+//                 side: OrderQuoteSide::Sell {
+//                     sell_amount: SellAmount::AfterFee {
+//                         value: NonZeroU256::try_from(1337).unwrap()
+//                     },
+//                 },
+//                 ..Default::default()
+//             }
+//         );
+//     }
 
-    #[tokio::test]
-    async fn post_quote_request_ok() {
-        let filter = post_quote_request();
-        let request_payload = OrderQuoteRequest::default();
-        let request = request()
-            .path("/v1/quote")
-            .method("POST")
-            .header("content-type", "application/json")
-            .json(&request_payload);
-        let result = request.filter(&filter).await.unwrap();
-        assert_eq!(result, request_payload);
-    }
+//     #[tokio::test]
+//     async fn post_quote_request_ok() {
+//         let filter = post_quote_request();
+//         let request_payload = OrderQuoteRequest::default();
+//         let request = request()
+//             .path("/v1/quote")
+//             .method("POST")
+//             .header("content-type", "application/json")
+//             .json(&request_payload);
+//         let result = request.filter(&filter).await.unwrap();
+//         assert_eq!(result, request_payload);
+//     }
 
-    #[tokio::test]
-    async fn post_quote_request_err() {
-        let filter = post_quote_request();
-        let request_payload = OrderQuoteRequest::default();
-        // Path is wrong!
-        let request = request()
-            .path("/v1/fee_quote")
-            .method("POST")
-            .header("content-type", "application/json")
-            .json(&request_payload);
-        assert!(request.filter(&filter).await.is_err());
-    }
+//     #[tokio::test]
+//     async fn post_quote_request_err() {
+//         let filter = post_quote_request();
+//         let request_payload = OrderQuoteRequest::default();
+//         // Path is wrong!
+//         let request = request()
+//             .path("/v1/fee_quote")
+//             .method("POST")
+//             .header("content-type", "application/json")
+//             .json(&request_payload);
+//         assert!(request.filter(&filter).await.is_err());
+//     }
 
-    #[tokio::test]
-    async fn post_quote_response_ok() {
-        let quote = OrderQuote {
-            sell_token: Default::default(),
-            buy_token: Default::default(),
-            receiver: None,
-            sell_amount: Default::default(),
-            buy_amount: Default::default(),
-            valid_to: 0,
-            app_data: Default::default(),
-            fee_amount: Default::default(),
-            kind: Default::default(),
-            partially_fillable: false,
-            sell_token_balance: Default::default(),
-            buy_token_balance: Default::default(),
-            signing_scheme: Default::default(),
-        };
-        let order_quote_response = OrderQuoteResponse {
-            quote,
-            from: H160::zero(),
-            expiration: Utc.timestamp_millis_opt(0).unwrap(),
-            id: Some(0),
-            verified: false,
-        };
-        let response = convert_json_response::<OrderQuoteResponse, OrderQuoteErrorWrapper>(Ok(
-            order_quote_response.clone(),
-        ))
-        .into_response();
-        assert_eq!(response.status(), StatusCode::OK);
-        let body = response_body(response).await;
-        let body: serde_json::Value = serde_json::from_slice(body.as_slice()).unwrap();
-        let expected = serde_json::to_value(order_quote_response).unwrap();
-        assert_eq!(body, expected);
-    }
+//     #[tokio::test]
+//     async fn post_quote_response_ok() {
+//         let quote = OrderQuote {
+//             sell_token: Default::default(),
+//             buy_token: Default::default(),
+//             receiver: None,
+//             sell_amount: Default::default(),
+//             buy_amount: Default::default(),
+//             valid_to: 0,
+//             app_data: Default::default(),
+//             fee_amount: Default::default(),
+//             kind: Default::default(),
+//             partially_fillable: false,
+//             sell_token_balance: Default::default(),
+//             buy_token_balance: Default::default(),
+//             signing_scheme: Default::default(),
+//         };
+//         let order_quote_response = OrderQuoteResponse {
+//             quote,
+//             from: H160::zero(),
+//             expiration: Utc.timestamp_millis_opt(0).unwrap(),
+//             id: Some(0),
+//             verified: false,
+//         };
+//         let response = convert_json_response::<OrderQuoteResponse,
+// OrderQuoteErrorWrapper>(Ok(             order_quote_response.clone(),
+//         ))
+//         .into_response();
+//         assert_eq!(response.status(), StatusCode::OK);
+//         let body = response_body(response).await;
+//         let body: serde_json::Value =
+// serde_json::from_slice(body.as_slice()).unwrap();         let expected =
+// serde_json::to_value(order_quote_response).unwrap();         assert_eq!(body,
+// expected);     }
 
-    #[tokio::test]
-    async fn post_quote_response_err() {
-        let response = convert_json_response::<OrderQuoteResponse, OrderQuoteErrorWrapper>(Err(
-            OrderQuoteErrorWrapper(OrderQuoteError::CalculateQuote(CalculateQuoteError::Other(
-                anyhow!("Uh oh - error"),
-            ))),
-        ))
-        .into_response();
-        assert_eq!(response.status(), StatusCode::INTERNAL_SERVER_ERROR);
-        let body = response_body(response).await;
-        let body: serde_json::Value = serde_json::from_slice(body.as_slice()).unwrap();
-        let expected_error = json!({"errorType": "InternalServerError", "description": ""});
-        assert_eq!(body, expected_error);
-        // There are many other FeeAndQuoteErrors, but writing a test for each
-        // would follow the same pattern as this.
-    }
-}
+//     #[tokio::test]
+//     async fn post_quote_response_err() {
+//         let response = convert_json_response::<OrderQuoteResponse,
+// OrderQuoteErrorWrapper>(Err(
+// OrderQuoteErrorWrapper(OrderQuoteError::CalculateQuote(CalculateQuoteError::Other(
+//                 anyhow!("Uh oh - error"),
+//             ))),
+//         ))
+//         .into_response();
+//         assert_eq!(response.status(), StatusCode::INTERNAL_SERVER_ERROR);
+//         let body = response_body(response).await;
+//         let body: serde_json::Value =
+// serde_json::from_slice(body.as_slice()).unwrap();         let expected_error
+// = json!({"errorType": "InternalServerError", "description": ""});
+//         assert_eq!(body, expected_error);
+//         // There are many other FeeAndQuoteErrors, but writing a test for
+// each         // would follow the same pattern as this.
+//     }
+// }

--- a/crates/orderbook/src/api/version.rs
+++ b/crates/orderbook/src/api/version.rs
@@ -1,16 +1,10 @@
-use {
-    reqwest::StatusCode,
-    std::convert::Infallible,
-    warp::{reply::with_status, Filter, Rejection, Reply},
-};
+use axum::{http::StatusCode, routing::MethodRouter};
 
-pub fn version() -> impl Filter<Extract = (Box<dyn Reply>,), Error = Rejection> + Clone {
-    warp::path!("v1" / "version")
-        .and(warp::get())
-        .and_then(|| async {
-            Result::<_, Infallible>::Ok(Box::new(with_status(
-                env!("VERGEN_GIT_DESCRIBE"),
-                StatusCode::OK,
-            )) as Box<dyn Reply>)
-        })
+const ENDPOINT: &str = "/api/v1/version";
+async fn handler() -> (StatusCode, String) {
+    (StatusCode::OK, env!("VERGEN_GIT_DESCRIBE").to_string())
+}
+
+pub fn route() -> (&'static str, MethodRouter<super::State>) {
+    (ENDPOINT, axum::routing::get(handler))
 }

--- a/crates/shared/Cargo.toml
+++ b/crates/shared/Cargo.toml
@@ -12,6 +12,7 @@ doctest = false
 anyhow = { workspace = true }
 app-data = { path = "../app-data" }
 app-data-hash = { path = "../app-data-hash" }
+axum = { workspace = true }
 bytes-hex = { path = "../bytes-hex" }
 async-trait = { workspace = true }
 bigdecimal = { workspace = true }

--- a/crates/shared/src/api.rs
+++ b/crates/shared/src/api.rs
@@ -1,87 +1,22 @@
 use {
     crate::price_estimation::PriceEstimationError,
     anyhow::Result,
-    serde::{de::DeserializeOwned, Serialize},
-    std::{convert::Infallible, fmt::Debug, time::Instant},
-    warp::{
-        filters::BoxedFilter,
-        hyper::StatusCode,
-        reply::{json, with_status, Json, WithStatus},
-        Filter,
-        Rejection,
-        Reply,
-    },
+    axum::response::{IntoResponse, Response},
+    serde::Serialize,
+    std::fmt::Debug,
 };
 
-pub type ApiReply = WithStatus<Json>;
-
-// We turn Rejection into Reply to workaround warp not setting CORS headers on
-// rejections.
-async fn handle_rejection(err: Rejection) -> Result<impl Reply, Infallible> {
-    let response = err.default_response();
-
-    let metrics = ApiMetrics::instance(observe::metrics::get_storage_registry()).unwrap();
-    metrics
-        .requests_rejected
-        .with_label_values(&[response.status().as_str()])
-        .inc();
-
-    Ok(response)
+// should we just keep this shit for now and convert to an axum::Response to not
+// rewrite everything at once?
+// pub type ApiReply = WithStatus<Json>;
+pub struct ApiReply {
+    pub reply: serde_json::Value,
+    pub status: axum::http::StatusCode,
 }
 
-#[derive(prometheus_metric_storage::MetricStorage, Clone, Debug)]
-#[metric(subsystem = "api")]
-struct ApiMetrics {
-    /// Number of completed API requests.
-    #[metric(labels("method", "status_code"))]
-    requests_complete: prometheus::IntCounterVec,
-
-    /// Number of rejected API requests.
-    #[metric(labels("status_code"))]
-    requests_rejected: prometheus::IntCounterVec,
-
-    /// Execution time for each API request.
-    #[metric(labels("method"), buckets(0.1, 0.5, 1, 2, 4, 6, 8, 10))]
-    requests_duration_seconds: prometheus::HistogramVec,
-}
-
-impl ApiMetrics {
-    // Status codes we care about in our application. Populated with:
-    // `rg -oIN 'StatusCode::[A-Z_]+' | sort | uniq`.
-    const INITIAL_STATUSES: &'static [StatusCode] = &[
-        StatusCode::OK,
-        StatusCode::CREATED,
-        StatusCode::BAD_REQUEST,
-        StatusCode::UNAUTHORIZED,
-        StatusCode::FORBIDDEN,
-        StatusCode::NOT_FOUND,
-        StatusCode::INTERNAL_SERVER_ERROR,
-        StatusCode::SERVICE_UNAVAILABLE,
-    ];
-
-    fn reset_requests_rejected(&self) {
-        for status in Self::INITIAL_STATUSES {
-            self.requests_rejected
-                .with_label_values(&[status.as_str()])
-                .reset();
-        }
-    }
-
-    fn reset_requests_complete(&self, method: &str) {
-        for status in Self::INITIAL_STATUSES {
-            self.requests_complete
-                .with_label_values(&[method, status.as_str()])
-                .reset();
-        }
-    }
-
-    fn on_request_completed(&self, method: &str, status: StatusCode, timer: Instant) {
-        self.requests_complete
-            .with_label_values(&[method, status.as_str()])
-            .inc();
-        self.requests_duration_seconds
-            .with_label_values(&[method])
-            .observe(timer.elapsed().as_secs_f64());
+impl IntoResponse for ApiReply {
+    fn into_response(self) -> Response {
+        (self.status, self.reply.to_string()).into_response()
     }
 }
 
@@ -95,15 +30,20 @@ struct Error<'a> {
     data: Option<serde_json::Value>,
 }
 
-pub fn error(error_type: &str, description: impl AsRef<str>) -> Json {
-    json(&Error {
+pub fn error(error_type: &str, description: impl AsRef<str>) -> serde_json::Value {
+    serde_json::to_value(&Error {
         error_type,
         description: description.as_ref(),
         data: None,
     })
+    .unwrap()
 }
 
-pub fn rich_error(error_type: &str, description: impl AsRef<str>, data: impl Serialize) -> Json {
+pub fn rich_error(
+    error_type: &str,
+    description: impl AsRef<str>,
+    data: impl Serialize,
+) -> serde_json::Value {
     let data = match serde_json::to_value(&data) {
         Ok(value) => Some(value),
         Err(err) => {
@@ -112,142 +52,60 @@ pub fn rich_error(error_type: &str, description: impl AsRef<str>, data: impl Ser
         }
     };
 
-    json(&Error {
+    serde_json::to_value(&Error {
         error_type,
         description: description.as_ref(),
         data,
     })
+    .unwrap()
 }
 
 pub fn internal_error_reply() -> ApiReply {
-    with_status(
-        error("InternalServerError", ""),
-        StatusCode::INTERNAL_SERVER_ERROR,
-    )
+    ApiReply {
+        status: axum::http::StatusCode::INTERNAL_SERVER_ERROR,
+        reply: error("InternalServerError", ""),
+    }
 }
 
-pub fn convert_json_response<T, E>(result: Result<T, E>) -> WithStatus<Json>
+pub fn convert_json_response<T, E>(result: Result<T, E>) -> ApiReply
 where
     T: Serialize,
-    E: IntoWarpReply + Debug,
+    E: IntoApiReply + Debug,
 {
     match result {
-        Ok(response) => with_status(warp::reply::json(&response), StatusCode::OK),
-        Err(err) => err.into_warp_reply(),
+        Ok(response) => ApiReply {
+            status: axum::http::StatusCode::OK,
+            reply: serde_json::to_value(&response).unwrap(),
+        },
+        Err(err) => err.into_api_reply(),
     }
 }
 
-pub trait IntoWarpReply {
-    fn into_warp_reply(self) -> ApiReply;
+pub trait IntoApiReply {
+    fn into_api_reply(self) -> ApiReply;
 }
 
-pub async fn response_body(response: warp::hyper::Response<warp::hyper::Body>) -> Vec<u8> {
-    let mut body = response.into_body();
-    let mut result = Vec::new();
-    while let Some(bytes) = futures::StreamExt::next(&mut body).await {
-        result.extend_from_slice(bytes.unwrap().as_ref());
-    }
-    result
-}
-
-const MAX_JSON_BODY_PAYLOAD: u64 = 1024 * 16;
-
-pub fn extract_payload<T: DeserializeOwned + Send>(
-) -> impl Filter<Extract = (T,), Error = Rejection> + Clone {
-    // (rejecting huge payloads)...
-    extract_payload_with_max_size(MAX_JSON_BODY_PAYLOAD)
-}
-
-pub fn extract_payload_with_max_size<T: DeserializeOwned + Send>(
-    max_size: u64,
-) -> impl Filter<Extract = (T,), Error = Rejection> + Clone {
-    warp::body::content_length_limit(max_size).and(warp::body::json())
-}
-
-pub type BoxedRoute = BoxedFilter<(Box<dyn Reply>,)>;
-
-pub fn box_filter<Filter_, Reply_>(filter: Filter_) -> BoxedFilter<(Box<dyn Reply>,)>
-where
-    Filter_: Filter<Extract = (Reply_,), Error = Rejection> + Send + Sync + 'static,
-    Reply_: Reply + Send + 'static,
-{
-    filter.map(|a| Box::new(a) as Box<dyn Reply>).boxed()
-}
-
-/// Sets up basic metrics, cors and proper log tracing for all routes.
-///
-/// # Panics
-///
-/// This method panics if `routes` is empty.
-pub fn finalize_router(
-    routes: Vec<(&'static str, BoxedRoute)>,
-    log_prefix: &'static str,
-) -> impl Filter<Extract = (impl Reply,), Error = Rejection> + Clone {
-    let metrics = ApiMetrics::instance(observe::metrics::get_storage_registry()).unwrap();
-    metrics.reset_requests_rejected();
-    for (method, _) in &routes {
-        metrics.reset_requests_complete(method);
-    }
-
-    let router = routes
-        .into_iter()
-        .fold(
-            Option::<BoxedFilter<(&'static str, Box<dyn Reply>)>>::None,
-            |router, (method, route)| {
-                let route = route.map(move |result| (method, result)).untuple_one();
-                let next = match router {
-                    Some(router) => router.or(route).unify().boxed(),
-                    None => route.boxed(),
-                };
-                Some(next)
-            },
-        )
-        .expect("routes cannot be empty");
-
-    let instrumented =
-        warp::any()
-            .map(Instant::now)
-            .and(router)
-            .map(|timer, method, reply: Box<dyn Reply>| {
-                let response = reply.into_response();
-                metrics.on_request_completed(method, response.status(), timer);
-                response
-            });
-
-    // Final setup
-    let cors = warp::cors()
-        .allow_any_origin()
-        .allow_methods(vec!["GET", "POST", "DELETE", "OPTIONS", "PUT", "PATCH"])
-        .allow_headers(vec!["Origin", "Content-Type", "X-Auth-Token", "X-AppId"]);
-
-    warp::path!("api" / ..)
-        .and(instrumented)
-        .recover(handle_rejection)
-        .with(cors)
-        .with(warp::log::log(log_prefix))
-}
-
-impl IntoWarpReply for PriceEstimationError {
-    fn into_warp_reply(self) -> WithStatus<Json> {
+impl IntoApiReply for PriceEstimationError {
+    fn into_api_reply(self) -> ApiReply {
         match self {
-            Self::UnsupportedToken { token, reason } => with_status(
-                error(
+            Self::UnsupportedToken { token, reason } => ApiReply {
+                status: axum::http::StatusCode::BAD_REQUEST,
+                reply: error(
                     "UnsupportedToken",
                     format!("Token {token:?} is unsupported: {reason:}"),
                 ),
-                StatusCode::BAD_REQUEST,
-            ),
-            Self::UnsupportedOrderType(order_type) => with_status(
-                error(
+            },
+            Self::UnsupportedOrderType(order_type) => ApiReply {
+                status: axum::http::StatusCode::BAD_REQUEST,
+                reply: error(
                     "UnsupportedOrderType",
                     format!("{order_type} not supported"),
                 ),
-                StatusCode::BAD_REQUEST,
-            ),
-            Self::NoLiquidity | Self::RateLimited | Self::EstimatorInternal(_) => with_status(
-                error("NoLiquidity", "no route found"),
-                StatusCode::NOT_FOUND,
-            ),
+            },
+            Self::NoLiquidity | Self::RateLimited | Self::EstimatorInternal(_) => ApiReply {
+                status: axum::http::StatusCode::NOT_FOUND,
+                reply: error("NoLiquidity", "no route found"),
+            },
             Self::ProtocolInternal(err) => {
                 tracing::error!(?err, "PriceEstimationError::Other");
                 internal_error_reply()
@@ -256,65 +114,65 @@ impl IntoWarpReply for PriceEstimationError {
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use {super::*, serde::ser, serde_json::json};
+// #[cfg(test)]
+// mod tests {
+//     use {super::*, serde::ser, serde_json::json};
 
-    #[test]
-    fn rich_errors_skip_unset_data_field() {
-        assert_eq!(
-            serde_json::to_value(&Error {
-                error_type: "foo",
-                description: "bar",
-                data: None,
-            })
-            .unwrap(),
-            json!({
-                "errorType": "foo",
-                "description": "bar",
-            }),
-        );
-        assert_eq!(
-            serde_json::to_value(Error {
-                error_type: "foo",
-                description: "bar",
-                data: Some(json!(42)),
-            })
-            .unwrap(),
-            json!({
-                "errorType": "foo",
-                "description": "bar",
-                "data": 42,
-            }),
-        );
-    }
+//     #[test]
+//     fn rich_errors_skip_unset_data_field() {
+//         assert_eq!(
+//             serde_json::to_value(&Error {
+//                 error_type: "foo",
+//                 description: "bar",
+//                 data: None,
+//             })
+//             .unwrap(),
+//             json!({
+//                 "errorType": "foo",
+//                 "description": "bar",
+//             }),
+//         );
+//         assert_eq!(
+//             serde_json::to_value(Error {
+//                 error_type: "foo",
+//                 description: "bar",
+//                 data: Some(json!(42)),
+//             })
+//             .unwrap(),
+//             json!({
+//                 "errorType": "foo",
+//                 "description": "bar",
+//                 "data": 42,
+//             }),
+//         );
+//     }
 
-    #[tokio::test]
-    async fn rich_errors_handle_serialization_errors() {
-        struct AlwaysErrors;
-        impl Serialize for AlwaysErrors {
-            fn serialize<S>(&self, _: S) -> Result<S::Ok, S::Error>
-            where
-                S: serde::Serializer,
-            {
-                Err(ser::Error::custom("error"))
-            }
-        }
+//     #[tokio::test]
+//     async fn rich_errors_handle_serialization_errors() {
+//         struct AlwaysErrors;
+//         impl Serialize for AlwaysErrors {
+//             fn serialize<S>(&self, _: S) -> Result<S::Ok, S::Error>
+//             where
+//                 S: serde::Serializer,
+//             {
+//                 Err(ser::Error::custom("error"))
+//             }
+//         }
 
-        let body = warp::hyper::body::to_bytes(
-            rich_error("foo", "bar", AlwaysErrors)
-                .into_response()
-                .into_body(),
-        )
-        .await
-        .unwrap();
+//         let body = warp::hyper::body::to_bytes(
+//             rich_error("foo", "bar", AlwaysErrors)
+//                 .into_response()
+//                 .into_body(),
+//         )
+//         .await
+//         .unwrap();
 
-        assert_eq!(
-            serde_json::from_slice::<serde_json::Value>(&body).unwrap(),
-            json!({
-                "errorType": "foo",
-                "description": "bar",
-            })
-        );
-    }
-}
+//         assert_eq!(
+//             serde_json::from_slice::<serde_json::Value>(&body).unwrap(),
+//             json!({
+//                 "errorType": "foo",
+//                 "description": "bar",
+//             })
+//         );
+//     }
+// }

--- a/crates/solvers/Cargo.toml
+++ b/crates/solvers/Cargo.toml
@@ -38,7 +38,7 @@ thiserror = { workspace = true }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread", "signal", "time"] }
 toml = { workspace = true }
 tower = "0.4"
-tower-http = { version = "0.4", features = ["limit", "trace"] }
+tower-http = { version = "0.5", features = ["limit", "trace"] }
 web3 = { workspace = true }
 
 # TODO Once solvers are ported and E2E tests set up, slowly migrate code and

--- a/crates/solvers/Cargo.toml
+++ b/crates/solvers/Cargo.toml
@@ -38,7 +38,7 @@ thiserror = { workspace = true }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread", "signal", "time"] }
 toml = { workspace = true }
 tower = "0.4"
-tower-http = { version = "0.5", features = ["limit", "trace"] }
+tower-http = { workspace = true }
 web3 = { workspace = true }
 
 # TODO Once solvers are ported and E2E tests set up, slowly migrate code and


### PR DESCRIPTION
# Description
Still heavily in progress, just wanted to get it out here to not forget about it over the coming week(s).

# Changes
The `orderbook` currently still use a fork of `warp` which itself does not look very promising for the future. In the driver and other new code we've been using `axum` instead which was quite a nice experience.
This PR will eventually replace all the `warp` code with `axum` and update the existing `axum` (and more generally networking) code to the latest version. This is a pretty good time for this since many of the libraries bumped their dependencies to stable versions (e.g. `hyper`, `http` and `http-body` are now on `v1`).

Note that this PR will fail to compile because we also need to update the dependencies in the `gas-estimation` crate which I only did locally so far to get into the meat of the refactoring.

## How to test
**(locally)** all e2e tests pass again
I still have some existing unit tests for the route handling commented out. I believe this can be converted as well but I'm considering to drop them since more or less all endpoints should be covered by e2e tests instead (many small errors were already caught by e2e tests)

## TODO
[ ] bump dependencies in `gas-estimation` crate
[ ] also use `axum` for zeroex mock server in tests
[ ] appdata endpoint has a request size limit which I still have to port over
[ ] verify that rejected requests (missing handler) set the CORS headers correctly (this is why we had the `warp` fork in the first place)
[ ] verify that metrics work correctly (now managed by a library instead of handrolled)
[ ] double check that error conversion works correctly (no new `error` logs since that would lead to alerts)
[ ] replace handrolled `request_id` logic with layer from `tower-http` (should be a drop-in replacement)
[ ] probably clean up some of the code while I'm at it (e.g. a bunch of `shared` code is only used in `orderbook`)
[ ] actually drop `warp`