### PR TITLE
Run loop additional metrics

### DIFF
--- a/crates/autopilot/src/run_loop.rs
+++ b/crates/autopilot/src/run_loop.rs
@@ -128,7 +128,7 @@ impl RunLoop {
     }
 
     async fn single_run(&self, auction_id: domain::auction::Id, auction: &domain::Auction) {
-        let _timer = Metrics::get().single_run_time.start_timer();
+        let single_run_start = Instant::now();
         tracing::info!(?auction_id, "solving");
 
         let auction = self.remove_in_flight_orders(auction.clone()).await;
@@ -348,6 +348,7 @@ impl RunLoop {
                 .filter(|uid| auction_uids.contains(uid))
                 .collect();
             Metrics::matched_unsettled(driver, unsettled_orders);
+            Metrics::single_run_completed(single_run_start.elapsed());
         }
     }
 
@@ -788,6 +789,10 @@ impl Metrics {
         Self::get()
             .competition_storing_time
             .observe(elapsed.as_secs_f64());
+    }
+
+    fn single_run_completed(elapsed: Duration) {
+        Self::get().single_run_time.observe(elapsed.as_secs_f64());
     }
 }
 

--- a/crates/autopilot/src/run_loop.rs
+++ b/crates/autopilot/src/run_loop.rs
@@ -664,7 +664,10 @@ struct Metrics {
     reveal: prometheus::HistogramVec,
 
     /// Tracks the times and results of driver `/settle` requests.
-    #[metric(labels("driver", "result"))]
+    #[metric(
+        labels("driver", "result"),
+        buckets(1, 3, 5, 7, 9, 11, 13, 15, 17, 19, 20, 25, 30, 40)
+    )]
     settle: prometheus::HistogramVec,
 
     /// Tracks the number of orders that were part of some but not the winning
@@ -685,6 +688,7 @@ struct Metrics {
     auction_preprocessing_time: prometheus::Histogram,
 
     /// Total time spent in a single run of the run loop.
+    #[metric(buckets(1, 5, 10, 15, 20, 25, 30, 35, 40))]
     single_run_time: prometheus::Histogram,
 
     /// Time difference between the current block and when the single run

--- a/crates/autopilot/src/run_loop.rs
+++ b/crates/autopilot/src/run_loop.rs
@@ -668,7 +668,7 @@ struct Metrics {
     /// Tracks the times and results of driver `/settle` requests.
     #[metric(
         labels("driver", "result"),
-        buckets(1, 3, 5, 7, 9, 11, 13, 15, 17, 19, 20, 25, 30, 40)
+        buckets(0, 2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22, 25, 30, 40)
     )]
     settle: prometheus::HistogramVec,
 
@@ -683,18 +683,21 @@ struct Metrics {
 
     /// Tracks the time spent in post-processing after the auction has been
     /// solved and before sending a `settle` request.
+    #[metric(buckets(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12))]
     auction_postprocessing_time: prometheus::Histogram,
 
     /// Tracks the time spent in pre-processing before sending a `solve`
     /// request.
+    #[metric(buckets(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12))]
     auction_preprocessing_time: prometheus::Histogram,
 
     /// Total time spent in a single run of the run loop.
-    #[metric(buckets(1, 5, 10, 15, 20, 25, 30, 35, 40))]
+    #[metric(buckets(0, 1, 5, 10, 15, 20, 25, 30, 35, 40))]
     single_run_time: prometheus::Histogram,
 
     /// Time difference between the current block and when the single run
     /// function is started.
+    #[metric(buckets(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12))]
     current_block_delay: prometheus::Histogram,
 }
 

--- a/crates/autopilot/src/run_loop.rs
+++ b/crates/autopilot/src/run_loop.rs
@@ -695,7 +695,7 @@ struct Metrics {
 
     /// Time difference between the current block and when the single run
     /// function is started.
-    single_run_delay: prometheus::Histogram,
+    current_block_delay: prometheus::Histogram,
 }
 
 impl Metrics {
@@ -819,7 +819,7 @@ impl Metrics {
             .map(|d| d.as_secs())
         {
             Ok(now) => Self::get()
-                .single_run_delay
+                .current_block_delay
                 .observe((now - init_block_timestamp) as f64),
             Err(err) => tracing::error!(?err, "failed to get current time"),
         }

--- a/crates/autopilot/src/solvable_orders.rs
+++ b/crates/autopilot/src/solvable_orders.rs
@@ -52,10 +52,11 @@ pub struct Metrics {
     auction_update: IntCounterVec,
 
     /// Time taken to update the solvable orders cache.
+    #[metric(buckets(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12))]
     auction_update_total_time: Histogram,
 
     /// Time spent on auction update individual stage.
-    #[metric(labels("stage"))]
+    #[metric(labels("stage"), buckets(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12))]
     auction_update_stage_time: HistogramVec,
 
     /// Auction creations.

--- a/crates/autopilot/src/solvable_orders.rs
+++ b/crates/autopilot/src/solvable_orders.rs
@@ -47,6 +47,7 @@ pub struct Metrics {
     auction_update_total_time: Histogram,
 
     /// Time spent on auction update individual stage.
+    #[metric( labels("stage"))]
     auction_update_stage_time: HistogramVec,
 
     /// Auction creations.

--- a/crates/autopilot/src/solvable_orders.rs
+++ b/crates/autopilot/src/solvable_orders.rs
@@ -154,7 +154,7 @@ impl SolvableOrdersCache {
     /// the case in unit tests, then concurrent calls might overwrite each
     /// other's results.
     pub async fn update(&self, block: u64) -> Result<()> {
-        let _timer = self.metrics.auction_update_time.start_timer();
+        let start = Instant::now();
         let min_valid_to = now_in_epoch_seconds() + self.min_order_validity_period.as_secs() as u32;
         let db_solvable_orders = self.persistence.solvable_orders(min_valid_to).await?;
 
@@ -308,6 +308,9 @@ impl SolvableOrdersCache {
         };
 
         tracing::debug!(%block, "updated current auction cache");
+        self.metrics
+            .auction_update_time
+            .observe(start.elapsed().as_secs_f64());
         Ok(())
     }
 


### PR DESCRIPTION
# Description
> In order to move towards one price per token per block we need to remove inefficiencies in our run loop to make sure it can run within 2-4s (to leave sufficient time for the solvers).

# Changes

Achieves the following:
1. **How long after the block's timestamp does the run loop start**: `single_run_delay` metric.
2. **How long does it take until solve is called on the solvers:** `auction_preprocessing_time` metric.
3. **How long does solver take:** This can be done using the existing `solve` metrics(by calculating the MAX value among solvers for the last N seconds).
4. **How long does reveal take:** Seems like the current `reveal` metric wasn't used, so I updated its type to `Histogram`.
5. **How long does post-processing (writing the competition to the DB) take:** `auction_postprocessing_time` metric.
6. **How long does settle take:** The existing histogram metric was updated by incrementing the counter by the elapsed time and used in the following queries only.
```
Dashboard: Alerts (Prod), Panel: Failing Settlements
Query: sum by (network) (rate(gp_v2_autopilot_runloop_settle{result="success"}[10m])) / sum by (network) (rate(gp_v2_autopilot_runloop_settle{}[10m]))

Dashboard: Alerts (Prod), Panel: Failing Settlements
Query: ((sum by (network) (rate(gp_v2_autopilot_runloop_settle{result="success"}[10m])) / sum by (network) (rate(gp_v2_autopilot_runloop_settle{}[10m])))) and (sum by (network) (rate(gp_v2_autopilot_runloop_settle{}[10m])*600) > 5)
```
Now it records individual elapsed times and the existing queries should continue to work after appending `_sum` postfix to the metric name.

Also, I added `single_run_time` and `auction_update_time` metrics for better visibility to avoid accumulating all the values from different sources. So the total round trip could be calculated as `single_run_time` + `auction_update_time`.

I used separate Histogram metrics since that might be not really suitable to have all of them on a single panel due to different values(from milliseconds to 5-10 seconds or so).

## How to test
The plan was to deploy a temp image on staging.

## Related Issues

Fixes #2859 