### PR TITLE
Fairness check

### DIFF
--- a/crates/autopilot/src/domain/competition/mod.rs
+++ b/crates/autopilot/src/domain/competition/mod.rs
@@ -98,7 +98,7 @@ impl Solution {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Copy, Clone)]
 pub struct TradedAmounts {
     /// The effective amount that left the user's wallet including all fees.
     pub sell: eth::TokenAmount,

--- a/crates/autopilot/src/infra/solvers/mod.rs
+++ b/crates/autopilot/src/infra/solvers/mod.rs
@@ -1,6 +1,6 @@
 use {
     self::dto::{reveal, settle, solve},
-    crate::util,
+    crate::{domain::eth, util},
     anyhow::{anyhow, Context, Result},
     reqwest::{Client, StatusCode},
     std::time::Duration,
@@ -15,14 +15,19 @@ const RESPONSE_TIME_LIMIT: Duration = Duration::from_secs(60);
 pub struct Driver {
     pub name: String,
     pub url: Url,
+    // An optional threshold used to check "fairness" of provided solutions. If specified, a
+    // winning solution should be discarded if it contains at least one order, which
+    // another driver solved with surplus exceeding this driver's surplus by `threshold`
+    pub fairness_threshold: Option<eth::Ether>,
     client: Client,
 }
 
 impl Driver {
-    pub fn new(url: Url, name: String) -> Self {
+    pub fn new(url: Url, name: String, fairness_threshold: Option<eth::Ether>) -> Self {
         Self {
             name,
             url,
+            fairness_threshold,
             client: Client::builder()
                 .timeout(RESPONSE_TIME_LIMIT)
                 .build()

--- a/crates/autopilot/src/run.rs
+++ b/crates/autopilot/src/run.rs
@@ -506,7 +506,13 @@ pub async fn run(args: Arguments) {
         drivers: args
             .drivers
             .into_iter()
-            .map(|driver| infra::Driver::new(driver.url, driver.name))
+            .map(|driver| {
+                infra::Driver::new(
+                    driver.url,
+                    driver.name,
+                    driver.fairness_threshold.map(Into::into),
+                )
+            })
             .collect(),
         market_makable_token_list,
         submission_deadline: args.submission_deadline as u64,
@@ -532,7 +538,13 @@ async fn shadow_mode(args: Arguments) -> ! {
     let drivers = args
         .drivers
         .into_iter()
-        .map(|driver| infra::Driver::new(driver.url, driver.name))
+        .map(|driver| {
+            infra::Driver::new(
+                driver.url,
+                driver.name,
+                driver.fairness_threshold.map(Into::into),
+            )
+        })
         .collect();
 
     let trusted_tokens = {

--- a/crates/autopilot/src/run_loop.rs
+++ b/crates/autopilot/src/run_loop.rs
@@ -452,7 +452,7 @@ impl RunLoop {
                     Some(best_execution) => best_execution,
                     None => return false,
                 };
-                improvement_in_buy(&best_execution, &winning_execution)
+                improvement_in_buy(best_execution, winning_execution)
                     .and_then(|improvement_in_buy| {
                         warn!(
                             ?uid,

--- a/crates/autopilot/src/run_loop.rs
+++ b/crates/autopilot/src/run_loop.rs
@@ -27,7 +27,6 @@ use {
         SolverCompetitionDB,
         SolverSettlement,
     },
-    num::{CheckedDiv, CheckedMul, CheckedSub, Zero},
     primitive_types::H256,
     rand::seq::SliceRandom,
     shared::token_list::AutoUpdatingTokenList,
@@ -478,7 +477,7 @@ impl RunLoop {
                     );
                     return false;
                 };
-                buy_price.in_eth(improvement) > fairness_threshold
+                buy_price.in_eth(improvement.into()) > fairness_threshold
             });
         !unfair
     }

--- a/crates/autopilot/src/run_loop.rs
+++ b/crates/autopilot/src/run_loop.rs
@@ -432,14 +432,18 @@ impl RunLoop {
                 .unwrap_or_default()
         };
 
-        // Find best execution per order
+        // Record best execution per order
         let mut best_executions = HashMap::new();
         for other in remaining {
             for (uid, execution) in other.solution.orders() {
-                let best_execution = best_executions.entry(uid).or_insert(execution);
-                if !improvement_in_buy(execution, best_execution).is_zero() {
-                    *best_execution = execution;
-                }
+                best_executions
+                    .entry(uid)
+                    .and_modify(|best_execution| {
+                        if !improvement_in_buy(execution, best_execution).is_zero() {
+                            *best_execution = *execution;
+                        }
+                    })
+                    .or_insert(*execution);
             }
         }
 

--- a/crates/autopilot/src/run_loop.rs
+++ b/crates/autopilot/src/run_loop.rs
@@ -27,7 +27,7 @@ use {
         SolverCompetitionDB,
         SolverSettlement,
     },
-    num::{CheckedDiv, CheckedMul, CheckedSub},
+    num::{CheckedDiv, CheckedMul, CheckedSub, Zero},
     primitive_types::H256,
     rand::seq::SliceRandom,
     shared::token_list::AutoUpdatingTokenList,
@@ -427,6 +427,7 @@ impl RunLoop {
                         .unwrap_or(U256::max_value().into()),
                 )?
                 .checked_div(&right.sell)
+                .filter(|diff| !diff.is_zero())
         };
 
         // Find best execution per order
@@ -442,7 +443,7 @@ impl RunLoop {
 
         // Check if the winning solution contains an execution that is more than
         // `fairness_threshold` worse than the best execution
-        winner
+        let unfair = winner
             .solution
             .orders()
             .iter()
@@ -471,7 +472,8 @@ impl RunLoop {
                         }
                     })
                     .is_some()
-            })
+            });
+        !unfair
     }
 
     /// Computes a driver's solutions for the solver competition.

--- a/crates/e2e/src/setup/colocation.rs
+++ b/crates/e2e/src/setup/colocation.rs
@@ -5,11 +5,16 @@ use {
     tokio::task::JoinHandle,
 };
 
-pub async fn start_baseline_solver(weth: H160) -> Url {
+pub async fn start_baseline_solver(weth: H160, base_tokens: Vec<H160>) -> Url {
+    let base_tokens = base_tokens
+        .iter()
+        .map(|token| format!(r#"{:?}"#, token))
+        .collect::<Vec<_>>()
+        .join(", ");
     let config_file = config_tmp_file(format!(
         r#"
 weth = "{weth:?}"
-base-tokens = []
+base-tokens = [{base_tokens:?}]
 max-hops = 1
 max-partial-attempts = 5
 native-token-price-estimation-amount = "100000000000000000"
@@ -96,7 +101,7 @@ name = "{name}"
 endpoint = "{endpoint}"
 relative-slippage = "0.1"
 account = "{account}"
-
+merge-solutions = true
 "#
                 )
             },
@@ -139,7 +144,7 @@ weth = "{:?}"
 {solvers}
 
 [liquidity]
-base-tokens = []
+base-tokens = ["0x84ea74d481ee0a5332c457a4d796187f6ba67feb","0xc3e53f4d16ae77db1c982e75a937b9f60fe63690"]
 
 {liquidity}
 

--- a/crates/e2e/src/setup/services.rs
+++ b/crates/e2e/src/setup/services.rs
@@ -180,7 +180,7 @@ impl<'a> Services<'a> {
 
     pub async fn start_protocol_with_args(&self, args: ExtraServiceArgs, solver: TestAccount) {
         let solver_endpoint =
-            colocation::start_baseline_solver(self.contracts.weth.address()).await;
+            colocation::start_baseline_solver(self.contracts.weth.address(), vec![]).await;
         colocation::start_driver(
             self.contracts,
             vec![SolverEngine {
@@ -235,7 +235,7 @@ impl<'a> Services<'a> {
 
         let (autopilot_args, api_args) = if run_baseline {
             let baseline_solver_endpoint =
-                colocation::start_baseline_solver(self.contracts.weth.address()).await;
+                colocation::start_baseline_solver(self.contracts.weth.address(), vec![]).await;
 
             solvers.push(SolverEngine {
                 name: "baseline_solver".into(),

--- a/crates/e2e/src/setup/services.rs
+++ b/crates/e2e/src/setup/services.rs
@@ -179,15 +179,17 @@ impl<'a> Services<'a> {
     }
 
     pub async fn start_protocol_with_args(&self, args: ExtraServiceArgs, solver: TestAccount) {
-        let solver_endpoint =
-            colocation::start_baseline_solver(self.contracts.weth.address(), vec![]).await;
         colocation::start_driver(
             self.contracts,
-            vec![SolverEngine {
-                name: "test_solver".into(),
-                account: solver,
-                endpoint: solver_endpoint,
-            }],
+            vec![
+                colocation::start_baseline_solver(
+                    "test_solver".into(),
+                    solver,
+                    self.contracts.weth.address(),
+                    vec![],
+                )
+                .await,
+            ],
             colocation::LiquidityProvider::UniswapV2,
         );
         self.start_autopilot(
@@ -231,17 +233,19 @@ impl<'a> Services<'a> {
             name: "test_solver".into(),
             account: solver.clone(),
             endpoint: external_solver_endpoint,
+            base_tokens: vec![],
         }];
 
         let (autopilot_args, api_args) = if run_baseline {
-            let baseline_solver_endpoint =
-                colocation::start_baseline_solver(self.contracts.weth.address(), vec![]).await;
-
-            solvers.push(SolverEngine {
-                name: "baseline_solver".into(),
-                account: solver,
-                endpoint: baseline_solver_endpoint,
-            });
+            solvers.push(
+                colocation::start_baseline_solver(
+                    "baseline_solver".into(),
+                    solver,
+                    self.contracts.weth.address(),
+                    vec![],
+                )
+                .await,
+            );
 
             // Here we call the baseline_solver "test_quoter" to make the native price
             // estimation use the baseline_solver instead of the test_quoter

--- a/crates/e2e/tests/e2e/buffers.rs
+++ b/crates/e2e/tests/e2e/buffers.rs
@@ -44,7 +44,7 @@ async fn onchain_settlement_without_liquidity(web3: Web3) {
 
     // Start system
     let solver_endpoint =
-        colocation::start_baseline_solver(onchain.contracts().weth.address()).await;
+        colocation::start_baseline_solver(onchain.contracts().weth.address(), vec![]).await;
     colocation::start_driver(
         onchain.contracts(),
         vec![SolverEngine {

--- a/crates/e2e/tests/e2e/buffers.rs
+++ b/crates/e2e/tests/e2e/buffers.rs
@@ -1,8 +1,5 @@
 use {
-    e2e::{
-        setup::{colocation::SolverEngine, *},
-        tx,
-    },
+    e2e::{setup::*, tx},
     ethcontract::prelude::U256,
     model::{
         order::{OrderCreation, OrderKind},
@@ -43,15 +40,17 @@ async fn onchain_settlement_without_liquidity(web3: Web3) {
     );
 
     // Start system
-    let solver_endpoint =
-        colocation::start_baseline_solver(onchain.contracts().weth.address(), vec![]).await;
     colocation::start_driver(
         onchain.contracts(),
-        vec![SolverEngine {
-            name: "test_solver".into(),
-            account: solver,
-            endpoint: solver_endpoint,
-        }],
+        vec![
+            colocation::start_baseline_solver(
+                "test_solver".into(),
+                solver,
+                onchain.contracts().weth.address(),
+                vec![],
+            )
+            .await,
+        ],
         colocation::LiquidityProvider::UniswapV2,
     );
     let services = Services::new(onchain.contracts()).await;

--- a/crates/e2e/tests/e2e/cow_amm.rs
+++ b/crates/e2e/tests/e2e/cow_amm.rs
@@ -134,19 +134,18 @@ async fn cow_amm_jit(web3: Web3) {
     colocation::start_driver(
         onchain.contracts(),
         vec![
-            SolverEngine {
-                name: "test_solver".into(),
-                account: solver.clone(),
-                endpoint: colocation::start_baseline_solver(
-                    onchain.contracts().weth.address(),
-                    vec![],
-                )
-                .await,
-            },
+            colocation::start_baseline_solver(
+                "test_solver".into(),
+                solver.clone(),
+                onchain.contracts().weth.address(),
+                vec![],
+            )
+            .await,
             SolverEngine {
                 name: "mock_solver".into(),
                 account: solver.clone(),
                 endpoint: mock_solver.url.clone(),
+                base_tokens: vec![],
             },
         ],
         colocation::LiquidityProvider::UniswapV2,
@@ -453,19 +452,18 @@ async fn cow_amm_driver_support(web3: Web3) {
     colocation::start_driver(
         onchain.contracts(),
         vec![
-            SolverEngine {
-                name: "test_solver".into(),
-                account: solver.clone(),
-                endpoint: colocation::start_baseline_solver(
-                    onchain.contracts().weth.address(),
-                    vec![],
-                )
-                .await,
-            },
+            colocation::start_baseline_solver(
+                "test_solver".into(),
+                solver.clone(),
+                onchain.contracts().weth.address(),
+                vec![],
+            )
+            .await,
             SolverEngine {
                 name: "mock_solver".into(),
                 account: solver.clone(),
                 endpoint: mock_solver.url.clone(),
+                base_tokens: vec![],
             },
         ],
         colocation::LiquidityProvider::UniswapV2,

--- a/crates/e2e/tests/e2e/cow_amm.rs
+++ b/crates/e2e/tests/e2e/cow_amm.rs
@@ -137,8 +137,11 @@ async fn cow_amm_jit(web3: Web3) {
             SolverEngine {
                 name: "test_solver".into(),
                 account: solver.clone(),
-                endpoint: colocation::start_baseline_solver(onchain.contracts().weth.address())
-                    .await,
+                endpoint: colocation::start_baseline_solver(
+                    onchain.contracts().weth.address(),
+                    vec![],
+                )
+                .await,
             },
             SolverEngine {
                 name: "mock_solver".into(),
@@ -453,8 +456,11 @@ async fn cow_amm_driver_support(web3: Web3) {
             SolverEngine {
                 name: "test_solver".into(),
                 account: solver.clone(),
-                endpoint: colocation::start_baseline_solver(onchain.contracts().weth.address())
-                    .await,
+                endpoint: colocation::start_baseline_solver(
+                    onchain.contracts().weth.address(),
+                    vec![],
+                )
+                .await,
             },
             SolverEngine {
                 name: "mock_solver".into(),

--- a/crates/e2e/tests/e2e/jit_orders.rs
+++ b/crates/e2e/tests/e2e/jit_orders.rs
@@ -61,8 +61,11 @@ async fn single_limit_order_test(web3: Web3) {
             SolverEngine {
                 name: "test_solver".into(),
                 account: solver.clone(),
-                endpoint: colocation::start_baseline_solver(onchain.contracts().weth.address())
-                    .await,
+                endpoint: colocation::start_baseline_solver(
+                    onchain.contracts().weth.address(),
+                    vec![],
+                )
+                .await,
             },
             SolverEngine {
                 name: "mock_solver".into(),

--- a/crates/e2e/tests/e2e/jit_orders.rs
+++ b/crates/e2e/tests/e2e/jit_orders.rs
@@ -58,19 +58,18 @@ async fn single_limit_order_test(web3: Web3) {
     colocation::start_driver(
         onchain.contracts(),
         vec![
-            SolverEngine {
-                name: "test_solver".into(),
-                account: solver.clone(),
-                endpoint: colocation::start_baseline_solver(
-                    onchain.contracts().weth.address(),
-                    vec![],
-                )
-                .await,
-            },
+            colocation::start_baseline_solver(
+                "test_solver".into(),
+                solver.clone(),
+                onchain.contracts().weth.address(),
+                vec![],
+            )
+            .await,
             SolverEngine {
                 name: "mock_solver".into(),
                 account: solver.clone(),
                 endpoint: mock_solver.url.clone(),
+                base_tokens: vec![token.address()],
             },
         ],
         colocation::LiquidityProvider::UniswapV2,

--- a/crates/e2e/tests/e2e/limit_orders.rs
+++ b/crates/e2e/tests/e2e/limit_orders.rs
@@ -317,7 +317,7 @@ async fn too_many_limit_orders_test(web3: Web3) {
     // Place Orders
     let services = Services::new(onchain.contracts()).await;
     let solver_endpoint =
-        colocation::start_baseline_solver(onchain.contracts().weth.address()).await;
+        colocation::start_baseline_solver(onchain.contracts().weth.address(), vec![]).await;
     colocation::start_driver(
         onchain.contracts(),
         vec![colocation::SolverEngine {
@@ -391,7 +391,7 @@ async fn limit_does_not_apply_to_in_market_orders_test(web3: Web3) {
     // Place Orders
     let services = Services::new(onchain.contracts()).await;
     let solver_endpoint =
-        colocation::start_baseline_solver(onchain.contracts().weth.address()).await;
+        colocation::start_baseline_solver(onchain.contracts().weth.address(), vec![]).await;
     colocation::start_driver(
         onchain.contracts(),
         vec![colocation::SolverEngine {

--- a/crates/e2e/tests/e2e/limit_orders.rs
+++ b/crates/e2e/tests/e2e/limit_orders.rs
@@ -316,15 +316,17 @@ async fn too_many_limit_orders_test(web3: Web3) {
 
     // Place Orders
     let services = Services::new(onchain.contracts()).await;
-    let solver_endpoint =
-        colocation::start_baseline_solver(onchain.contracts().weth.address(), vec![]).await;
     colocation::start_driver(
         onchain.contracts(),
-        vec![colocation::SolverEngine {
-            name: "test_solver".into(),
-            account: solver,
-            endpoint: solver_endpoint,
-        }],
+        vec![
+            colocation::start_baseline_solver(
+                "test_solver".into(),
+                solver,
+                onchain.contracts().weth.address(),
+                vec![],
+            )
+            .await,
+        ],
         colocation::LiquidityProvider::UniswapV2,
     );
     services
@@ -390,15 +392,17 @@ async fn limit_does_not_apply_to_in_market_orders_test(web3: Web3) {
 
     // Place Orders
     let services = Services::new(onchain.contracts()).await;
-    let solver_endpoint =
-        colocation::start_baseline_solver(onchain.contracts().weth.address(), vec![]).await;
     colocation::start_driver(
         onchain.contracts(),
-        vec![colocation::SolverEngine {
-            name: "test_solver".into(),
-            account: solver,
-            endpoint: solver_endpoint,
-        }],
+        vec![
+            colocation::start_baseline_solver(
+                "test_solver".into(),
+                solver,
+                onchain.contracts().weth.address(),
+                vec![],
+            )
+            .await,
+        ],
         colocation::LiquidityProvider::UniswapV2,
     );
     services

--- a/crates/e2e/tests/e2e/liquidity.rs
+++ b/crates/e2e/tests/e2e/liquidity.rs
@@ -7,7 +7,7 @@ use {
         assert_approximately_eq,
         nodes::forked_node::ForkedNodeApi,
         setup::{
-            colocation::{self, SolverEngine},
+            colocation,
             run_forked_test_with_block_number,
             to_wei,
             to_wei_with_exp,
@@ -133,15 +133,17 @@ async fn zero_ex_liquidity(web3: Web3) {
 
     // Place Orders
     let services = Services::new(onchain.contracts()).await;
-    let solver_endpoint =
-        colocation::start_baseline_solver(onchain.contracts().weth.address(), vec![]).await;
     colocation::start_driver(
         onchain.contracts(),
-        vec![SolverEngine {
-            name: "test_solver".into(),
-            account: solver.clone(),
-            endpoint: solver_endpoint,
-        }],
+        vec![
+            colocation::start_baseline_solver(
+                "test_solver".into(),
+                solver.clone(),
+                onchain.contracts().weth.address(),
+                vec![],
+            )
+            .await,
+        ],
         colocation::LiquidityProvider::ZeroEx {
             api_port: zeroex_api_port,
         },

--- a/crates/e2e/tests/e2e/liquidity.rs
+++ b/crates/e2e/tests/e2e/liquidity.rs
@@ -134,7 +134,7 @@ async fn zero_ex_liquidity(web3: Web3) {
     // Place Orders
     let services = Services::new(onchain.contracts()).await;
     let solver_endpoint =
-        colocation::start_baseline_solver(onchain.contracts().weth.address()).await;
+        colocation::start_baseline_solver(onchain.contracts().weth.address(), vec![]).await;
     colocation::start_driver(
         onchain.contracts(),
         vec![SolverEngine {

--- a/crates/e2e/tests/e2e/order_cancellation.rs
+++ b/crates/e2e/tests/e2e/order_cancellation.rs
@@ -48,7 +48,7 @@ async fn order_cancellation(web3: Web3) {
 
     let services = Services::new(onchain.contracts()).await;
     let solver_endpoint =
-        colocation::start_baseline_solver(onchain.contracts().weth.address()).await;
+        colocation::start_baseline_solver(onchain.contracts().weth.address(), vec![]).await;
     colocation::start_driver(
         onchain.contracts(),
         vec![colocation::SolverEngine {

--- a/crates/e2e/tests/e2e/order_cancellation.rs
+++ b/crates/e2e/tests/e2e/order_cancellation.rs
@@ -47,15 +47,17 @@ async fn order_cancellation(web3: Web3) {
     );
 
     let services = Services::new(onchain.contracts()).await;
-    let solver_endpoint =
-        colocation::start_baseline_solver(onchain.contracts().weth.address(), vec![]).await;
     colocation::start_driver(
         onchain.contracts(),
-        vec![colocation::SolverEngine {
-            name: "test_solver".into(),
-            account: solver,
-            endpoint: solver_endpoint,
-        }],
+        vec![
+            colocation::start_baseline_solver(
+                "test_solver".into(),
+                solver,
+                onchain.contracts().weth.address(),
+                vec![],
+            )
+            .await,
+        ],
         colocation::LiquidityProvider::UniswapV2,
     );
     services

--- a/crates/e2e/tests/e2e/solver_competition.rs
+++ b/crates/e2e/tests/e2e/solver_competition.rs
@@ -19,6 +19,12 @@ async fn local_node_solver_competition() {
     run_test(solver_competition).await;
 }
 
+#[tokio::test]
+#[ignore]
+async fn local_node_fairness_check() {
+    run_test(fairness_check).await;
+}
+
 async fn solver_competition(web3: Web3) {
     let mut onchain = OnchainComponents::deploy(web3).await;
 
@@ -45,14 +51,20 @@ async fn solver_competition(web3: Web3) {
             SolverEngine {
                 name: "test_solver".into(),
                 account: solver.clone(),
-                endpoint: colocation::start_baseline_solver(onchain.contracts().weth.address())
-                    .await,
+                endpoint: colocation::start_baseline_solver(
+                    onchain.contracts().weth.address(),
+                    vec![],
+                )
+                .await,
             },
             SolverEngine {
                 name: "solver2".into(),
                 account: solver,
-                endpoint: colocation::start_baseline_solver(onchain.contracts().weth.address())
-                    .await,
+                endpoint: colocation::start_baseline_solver(
+                    onchain.contracts().weth.address(),
+                    vec![],
+                )
+                .await,
             },
         ],
         colocation::LiquidityProvider::UniswapV2,
@@ -120,4 +132,143 @@ async fn solver_competition(web3: Web3) {
     // Winning candidate
     assert!(competition.common.solutions[1].ranking == 1);
     assert!(competition.common.solutions[1].call_data.is_some());
+}
+
+async fn fairness_check(web3: Web3) {
+    let mut onchain = OnchainComponents::deploy(web3).await;
+
+    let [solver] = onchain.make_solvers(to_wei(1)).await;
+    let [trader_a, trader_b] = onchain.make_accounts(to_wei(1)).await;
+    let [token_a, token_b] = onchain
+        .deploy_tokens_with_weth_uni_v2_pools(to_wei(1_000), to_wei(1_000))
+        .await;
+
+    // Fund traders
+    token_a.mint(trader_a.address(), to_wei(10)).await;
+    token_b.mint(trader_b.address(), to_wei(10)).await;
+
+    // Create more liquid routes between token_a (token_b) and weth via base_a
+    // (base_b). base_a has more liquidity then base_b, leading to the solver that
+    // knows about base_a to win
+    let [base_a, base_b] = onchain
+        .deploy_tokens_with_weth_uni_v2_pools(to_wei(10_000), to_wei(10_000))
+        .await;
+    onchain
+        .seed_uni_v2_pool((&token_a, to_wei(100_000)), (&base_a, to_wei(100_000)))
+        .await;
+    onchain
+        .seed_uni_v2_pool((&token_b, to_wei(10_000)), (&base_b, to_wei(10_000)))
+        .await;
+
+    // Approve GPv2 for trading
+    tx!(
+        trader_a.account(),
+        token_a.approve(onchain.contracts().allowance, to_wei(100))
+    );
+    tx!(
+        trader_b.account(),
+        token_b.approve(onchain.contracts().allowance, to_wei(100))
+    );
+
+    // Start system, with two solvers, one that knows about base_a and one that
+    // knows about base_b
+    colocation::start_driver(
+        onchain.contracts(),
+        vec![
+            SolverEngine {
+                name: "test_solver".into(),
+                account: solver.clone(),
+                endpoint: colocation::start_baseline_solver(
+                    onchain.contracts().weth.address(),
+                    vec![base_a.address()],
+                )
+                .await,
+            },
+            SolverEngine {
+                name: "solver2".into(),
+                account: solver,
+                endpoint: colocation::start_baseline_solver(
+                    onchain.contracts().weth.address(),
+                    vec![base_b.address()],
+                )
+                .await,
+            },
+        ],
+        colocation::LiquidityProvider::UniswapV2,
+    );
+
+    let services = Services::new(onchain.contracts()).await;
+    services.start_autopilot(
+        None,
+        // fairness threshold of 0.01 ETH
+        vec![
+            "--drivers=test_solver|http://localhost:11088/test_solver|10000000000000000,solver2|http://localhost:11088/solver2"
+                .to_string(),
+            "--price-estimation-drivers=test_quoter|http://localhost:11088/test_solver".to_string(),
+        ],
+    ).await;
+    services
+        .start_api(vec![
+            "--price-estimation-drivers=test_quoter|http://localhost:11088/test_solver".to_string(),
+        ])
+        .await;
+
+    // Place Orders
+    let order_a = OrderCreation {
+        sell_token: token_a.address(),
+        sell_amount: to_wei(10),
+        buy_token: onchain.contracts().weth.address(),
+        buy_amount: to_wei(5),
+        valid_to: model::time::now_in_epoch_seconds() + 300,
+        kind: OrderKind::Sell,
+        ..Default::default()
+    }
+    .sign(
+        EcdsaSigningScheme::Eip712,
+        &onchain.contracts().domain_separator,
+        SecretKeyRef::from(&SecretKey::from_slice(trader_a.private_key()).unwrap()),
+    );
+    let uid_a = services.create_order(&order_a).await.unwrap();
+
+    let order_b = OrderCreation {
+        sell_token: token_b.address(),
+        sell_amount: to_wei(10),
+        buy_token: onchain.contracts().weth.address(),
+        buy_amount: to_wei(5),
+        valid_to: model::time::now_in_epoch_seconds() + 300,
+        kind: OrderKind::Sell,
+        ..Default::default()
+    }
+    .sign(
+        EcdsaSigningScheme::Eip712,
+        &onchain.contracts().domain_separator,
+        SecretKeyRef::from(&SecretKey::from_slice(trader_b.private_key()).unwrap()),
+    );
+    services.create_order(&order_b).await.unwrap();
+
+    // Wait for trade
+    let indexed_trades = || async {
+        onchain.mint_block().await;
+        match services.get_trades(&uid_a).await.unwrap().first() {
+            Some(trade) => services
+                .get_solver_competition(trade.tx_hash.unwrap())
+                .await
+                .is_ok(),
+            None => false,
+        }
+    };
+    wait_for_condition(TIMEOUT, indexed_trades).await.unwrap();
+
+    // Verify that test_solver was excluded due to fairness check
+    let trades = services.get_trades(&uid_a).await.unwrap();
+    let competition = services
+        .get_solver_competition(trades[0].tx_hash.unwrap())
+        .await
+        .unwrap();
+    tracing::info!(?competition, "competition");
+    assert_eq!(
+        competition.common.solutions.last().unwrap().solver,
+        "solver2"
+    );
+    assert_eq!(competition.common.solutions.len(), 1);
 }


### PR DESCRIPTION
# Description
This PR add an additional optional config value for solvers in the autopilot, which aims at preventing solvers that are highly specialised at certain token pairs to get picked as an auction winner with an order execution that is violating EBBO or other fairness constraints.

An example for this is this [recent settlement](https://explorer.cow.fi/tx/0x1a482783a9eb243a007196913ce2b2bb86a110d7e3d1e4807a4ff679007c3629?tab=orders), which triggered an EBBO violation. The winning solver was the only one bidding for the orders that sell _PYUSD_ and _crvCVXETH_ creating enough surplus on these two orders to win the overall auction.

However, due to outdated liquidity sources on their end, the execution for the last sDAI -> crvUSD order was terrible triggering a violation of the rules of the competition. Many other solvers were able to settle this order at the fair price (however since they didn't solver the other two orders their total surplus was still lower).

In this case, users are guaranteed to receive at least [EBBO](https://docs.cow.fi/cow-protocol/reference/core/definitions#ebbo) and the violating solver needs to refund the trader the difference between their execution and EBBO creating a loss for the solver.

In order to protect solvers from these cases going forward, this PR allows solvers to configure a "fairness threshold", which if set carries out a check for each executed order of the winning solution. Specifically, it looks at the best execution for each individual order in any of the submitted solutions from other solvers. If there exists an execution in which the order would exceed the surplus of the winning solution  by at least the threshold the solution is considered invalid.

Note, that this is an opt in feature so the majority of solvers that don't struggle with EBBO are likely not going to use this feature.

The main change is the 80 lines `check_fairness` method in `run_loop`, the rest is the e2e test (and changes to make is easier to configure multiple solver)

# Changes
- [x] Allow solvers to specify an optional fairness threshold
- [x] If set, carry out fairness check and prevent "unfair" solutions from winning. 
- [x] Refactor e2e test suite to make it possible to run different baseline solvers with different set of base tokens
- [x] New e2e demonstrating the feature (two baseline solvers with different base tokens each specialising on one order) 

## How to test
The new test

## Related Issues

This issue is related to using "combinatorial auctions" which are aimed to properly fix the fairness concerns of batching and replace the EBBO rule in the long run. The exact auction mechanism is still being researched, but basically solvers will submit a solution for each individual order as well as batched solutions. A batch will only be accepted if all orders are at least executed as well as their individually best execution. However, making this the protocol default requires much more work, so consider this is a temporary workaround for solvers that are unable to reliably solve for EBBO.