### PR TITLE
Add 1wei tolerance for bad token detection

### DIFF
--- a/crates/shared/src/bad_token/trace_call.rs
+++ b/crates/shared/src/bad_token/trace_call.rs
@@ -194,11 +194,7 @@ impl TraceCallDetector {
         // Allow for a small discrepancy (1 wei) in the balance after the transfer which
         // may come from rounding discrepancies in tokens that track balances
         // with "shares" (e.g. eUSD).
-        if balance_after_in
-            < computed_balance_after_in
-                .checked_sub(U256::one())
-                .unwrap_or_default()
-        {
+        if balance_after_in < computed_balance_after_in.saturating_sub(U256::one()) {
             return Ok(TokenQuality::bad(format!(
                 "Transferring {amount} into settlement contract was expected to result in a \
                  balance of {computed_balance_after_in} but actually resulted in \
@@ -225,11 +221,7 @@ impl TraceCallDetector {
         // Allow for a small discrepancy (1 wei) in the balance after the transfer
         // which may come from rounding discrepancies in tokens that track
         // balances with "shares" (e.g. eUSD).
-        if computed_balance_recipient_after
-            < balance_recipient_after
-                .checked_sub(U256::one())
-                .unwrap_or_default()
-        {
+        if computed_balance_recipient_after < balance_recipient_after.saturating_sub(U256::one()) {
             return Ok(TokenQuality::bad(format!(
                 "Transferring {amount} into arbitrary recipient {arbitrary:?} was expected to \
                  result in a balance of {computed_balance_recipient_after} but actually resulted \

--- a/crates/shared/src/bad_token/trace_call.rs
+++ b/crates/shared/src/bad_token/trace_call.rs
@@ -195,7 +195,7 @@ impl TraceCallDetector {
         // may come from rounding discrepancies in tokens that track balances
         // with "shares" (e.g. eUSD).
         if balance_after_in
-            <= computed_balance_after_in
+            < computed_balance_after_in
                 .checked_sub(U256::one())
                 .unwrap_or_default()
         {
@@ -226,7 +226,7 @@ impl TraceCallDetector {
         // which may come from rounding discrepancies in tokens that track
         // balances with "shares" (e.g. eUSD).
         if computed_balance_recipient_after
-            <= balance_recipient_after
+            < balance_recipient_after
                 .checked_sub(U256::one())
                 .unwrap_or_default()
         {


### PR DESCRIPTION
# Description
This is a pretty hacky PR, but given that we didn't manage to get rid of bad token detection in the last quarter and it's not clear when we will find the ressources for it, I feel the impact this change can have may be worth its ugliness.

There are a lot of tokens (e.g. stETH, eUSD, oETH, etc.) whose transfer logic is based on "shares" (cf. eUSD [transfer implementation](https://etherscan.io/token/0x97de57ec338ab5d51557da3434828c5dbfada371#code#F3#L355)). The logic to convert shares into token amounts requires a division which can lead to off by one error: 

<details>
<summary>Relevant solidity code</summary>

```solidity

function balanceOf(address _account) public view returns (uint256) {
        return getMintedEUSDByShares(_sharesOf(_account));
    }

function _transfer(
        address _sender,
        address _recipient,
        uint256 _amount
    ) internal {
        uint256 _sharesToTransfer = getSharesByMintedEUSD(_amount);
        _transferShares(_sender, _recipient, _sharesToTransfer);
        emit Transfer(_sender, _recipient, _amount);
        emit TransferShares(_sender, _recipient, _sharesToTransfer);
    }

function getMintedEUSDByShares(
        uint256 _sharesAmount
    ) public view returns (uint256) {
        uint256 totalSharesAmount = _getTotalShares();
        if (totalShares == 0) {
            return 0;
        } else {
            return
                _sharesAmount.mul(_getTotalMintedEUSD()).div(totalSharesAmount);
        }
    }

function getSharesByMintedEUSD(
        uint256 _EUSDAmount
    ) public view returns (uint256) {
        uint256 totalMintedEUSD = _getTotalMintedEUSD();
        if (totalMintedEUSD == 0) {
            return 0;
        } else {
            return _EUSDAmount.mul(_getTotalShares()).div(totalMintedEUSD);
        }
    }
```

</details>

Consider the following example:

- totalMintedEUSD: 100
- total shares: 50
- balanceOf(A) = 4 shares = 8 eUSD

Transferring 3 eUSD would lead to transferring 1 share (3 * 50 / 100). After the transfer the user therefore has 5 shares = 10 eUSD (5 * 100 / 50) which is not in line with our expectation (8 + 3 = 11). This 1 wei discrepency is causing the bad token detector to fire.

# Changes
- [x] Pass the balance check if the observed balance is not more than 1 wei less than expected (this also allows higher balances)

## How to test
Not sure if this warrants an e2e test in and of itself (I assume it will be quite involved to deploy the token as in the example)? For now I would rely on the existing unit tests. In particular

```
cargo test -p shared mainnet_tokens -- --nocapture --ignored
```

now shows `0x0aacfbec6a24756c20d41914f2caba817c0d8521` as supported 💪 