### PR TITLE
Only allow order placements without quotes if there is NoLiquidity

### DIFF
--- a/crates/shared/src/order_validation.rs
+++ b/crates/shared/src/order_validation.rs
@@ -692,10 +692,10 @@ impl OrderValidating for OrderValidator {
                         }
                         (class, Some(quote))
                     }
-                    // If the quote cannot be computed, it's still possible to place this order (as
+                    // If there is not enoguh liquidity, it's still possible to place this order (as
                     // an implicit out of market order)
-                    Err(ValidationError::PriceForQuote(err)) => {
-                        tracing::debug!(?err, "placing order without quote");
+                    Err(ValidationError::PriceForQuote(PriceEstimationError::NoLiquidity)) => {
+                        tracing::debug!("placing order without quote");
                         (class, None)
                     }
                     Err(other) => return Err(other),

--- a/crates/shared/src/order_validation.rs
+++ b/crates/shared/src/order_validation.rs
@@ -692,7 +692,7 @@ impl OrderValidating for OrderValidator {
                         }
                         (class, Some(quote))
                     }
-                    // If there is not enoguh liquidity, it's still possible to place this order (as
+                    // If there is not enough liquidity, it's still possible to place this order (as
                     // an implicit out of market order)
                     Err(ValidationError::PriceForQuote(PriceEstimationError::NoLiquidity)) => {
                         tracing::debug!("placing order without quote");


### PR DESCRIPTION
# Description
#2854 added the ability to place orders without having a valid quote. The goal was to support limit orders for sizes that aren't covered by any on chain liquidity (and thus yield NoLiquidity as an error).

When looking at the logs however, we can see that the majority of orders that are placed are placed due to other (non liquidity related) quoting errors such as internal server errors etc.

We shouldn't allow order placement in those cases

# Changes
- [x] Specialise the quote error only pass in case there is no Liquidity

Technically, we might even want to differentiate between native price estimates (which are required for the order to land in the auction) and missing liquidity on the route, but that's a larger change.

## How to test
Adjusted the e2e test