### PR TITLE
[EASY] Use optional values in autopilot only

### DIFF
--- a/crates/autopilot/src/boundary/order.rs
+++ b/crates/autopilot/src/boundary/order.rs
@@ -22,7 +22,7 @@ pub fn to_domain(
             amount: order.data.buy_amount.into(),
         },
         protocol_fees,
-        created: Some(u32::try_from(order.metadata.creation_date.timestamp()).unwrap_or(u32::MIN)),
+        created: u32::try_from(order.metadata.creation_date.timestamp()).unwrap_or(u32::MIN),
         valid_to: order.data.valid_to,
         side: order.data.kind.into(),
         receiver: order.data.receiver.map(Into::into),

--- a/crates/autopilot/src/domain/auction/order.rs
+++ b/crates/autopilot/src/domain/auction/order.rs
@@ -15,7 +15,7 @@ pub struct Order {
     pub protocol_fees: Vec<fee::Policy>,
     pub side: Side,
     pub class: Class,
-    pub created: Option<u32>,
+    pub created: u32,
     pub valid_to: u32,
     pub receiver: Option<eth::Address>,
     pub owner: eth::Address,

--- a/crates/autopilot/src/domain/fee/mod.rs
+++ b/crates/autopilot/src/domain/fee/mod.rs
@@ -285,7 +285,7 @@ pub struct Quote {
     pub buy_amount: U256,
     /// The amount that needs to be paid, denominated in the sell token.
     pub fee: U256,
-    pub solver: Option<H160>,
+    pub solver: H160,
 }
 
 impl From<domain::Quote> for Quote {
@@ -294,7 +294,7 @@ impl From<domain::Quote> for Quote {
             sell_amount: value.sell_amount.into(),
             buy_amount: value.buy_amount.into(),
             fee: value.fee.into(),
-            solver: Some(value.solver.into()),
+            solver: value.solver.into(),
         }
     }
 }

--- a/crates/autopilot/src/infra/persistence/dto/fee_policy.rs
+++ b/crates/autopilot/src/infra/persistence/dto/fee_policy.rs
@@ -86,7 +86,7 @@ pub fn try_into_domain(
                     sell_amount: quote.sell_amount.into(),
                     buy_amount: quote.buy_amount.into(),
                     fee: quote.fee.into(),
-                    solver: Some(quote.solver.into()),
+                    solver: quote.solver.into(),
                 }
             },
         },

--- a/crates/autopilot/src/infra/persistence/dto/order.rs
+++ b/crates/autopilot/src/infra/persistence/dto/order.rs
@@ -22,7 +22,7 @@ pub struct Order {
     #[serde_as(as = "HexOrDecimalU256")]
     pub buy_amount: U256,
     pub protocol_fees: Vec<FeePolicy>,
-    pub created: u32,
+    pub created: Option<u32>,
     pub valid_to: u32,
     pub kind: boundary::OrderKind,
     pub receiver: Option<H160>,
@@ -50,7 +50,7 @@ pub fn from_domain(order: domain::Order) -> Order {
         sell_amount: order.sell.amount.into(),
         buy_amount: order.buy.amount.into(),
         protocol_fees: order.protocol_fees.into_iter().map(Into::into).collect(),
-        created: order.created.unwrap_or(u32::MIN),
+        created: Some(order.created),
         valid_to: order.valid_to,
         kind: order.side.into(),
         receiver: order.receiver.map(Into::into),
@@ -84,7 +84,7 @@ pub fn to_domain(order: Order) -> domain::Order {
             amount: order.buy_amount.into(),
         },
         protocol_fees: order.protocol_fees.into_iter().map(Into::into).collect(),
-        created: Some(order.created),
+        created: order.created.unwrap_or(u32::MIN),
         valid_to: order.valid_to,
         side: order.kind.into(),
         receiver: order.receiver.map(Into::into),
@@ -293,7 +293,7 @@ pub struct Quote {
     pub buy_amount: U256,
     #[serde_as(as = "HexOrDecimalU256")]
     pub fee: U256,
-    pub solver: H160,
+    pub solver: Option<H160>,
 }
 
 impl Quote {
@@ -303,7 +303,7 @@ impl Quote {
             sell_amount: self.sell_amount.into(),
             buy_amount: self.buy_amount.into(),
             fee: self.fee.into(),
-            solver: self.solver.into(),
+            solver: self.solver.unwrap_or_default().into(),
         }
     }
 }
@@ -314,7 +314,7 @@ impl From<domain::Quote> for Quote {
             sell_amount: quote.sell_amount.0,
             buy_amount: quote.buy_amount.0,
             fee: quote.fee.0,
-            solver: quote.solver.0,
+            solver: Some(quote.solver.0),
         }
     }
 }
@@ -340,7 +340,7 @@ impl From<domain::fee::Policy> for FeePolicy {
                     sell_amount: quote.sell_amount,
                     buy_amount: quote.buy_amount,
                     fee: quote.fee,
-                    solver: quote.solver.unwrap_or_default(),
+                    solver: Some(quote.solver),
                 },
             },
             domain::fee::Policy::Volume { factor } => Self::Volume {
@@ -371,7 +371,7 @@ impl From<FeePolicy> for domain::fee::Policy {
                     sell_amount: quote.sell_amount,
                     buy_amount: quote.buy_amount,
                     fee: quote.fee,
-                    solver: Some(quote.solver),
+                    solver: quote.solver.unwrap_or_default(),
                 },
             },
             FeePolicy::Volume { factor } => Self::Volume {

--- a/crates/driver/src/infra/api/routes/solve/dto/auction.rs
+++ b/crates/driver/src/infra/api/routes/solve/dto/auction.rs
@@ -34,7 +34,7 @@ impl Auction {
                 .map(|order| competition::Order {
                     uid: order.uid.into(),
                     receiver: order.receiver.map(Into::into),
-                    created: order.created.unwrap_or(u32::MIN).into(),
+                    created: order.created.into(),
                     valid_to: order.valid_to.into(),
                     buy: eth::Asset {
                         amount: order.buy_amount.into(),
@@ -238,7 +238,7 @@ struct Order {
     #[serde_as(as = "serialize::U256")]
     buy_amount: eth::U256,
     protocol_fees: Vec<FeePolicy>,
-    created: Option<u32>,
+    created: u32,
     valid_to: u32,
     kind: Kind,
     receiver: Option<eth::H160>,
@@ -339,7 +339,7 @@ pub struct Quote {
     pub buy_amount: eth::U256,
     #[serde_as(as = "serialize::U256")]
     pub fee: eth::U256,
-    pub solver: Option<eth::H160>,
+    pub solver: eth::H160,
 }
 
 impl Quote {
@@ -357,7 +357,7 @@ impl Quote {
                 amount: self.fee.into(),
                 token: sell_token.into(),
             },
-            solver: self.solver.unwrap_or_default().into(),
+            solver: self.solver.into(),
         }
     }
 }


### PR DESCRIPTION
Fixes DTOs after https://github.com/cowprotocol/services/pull/2897.
Also, uses optional values in `autopilot` only and sends default values to the driver.


> [!IMPORTANT]
> This PR should be reverted together with https://github.com/cowprotocol/services/pull/2897 after the next weekly release.