### PR TITLE
Adjust coingecko prices based on token decimals

### DIFF
--- a/crates/shared/Cargo.toml
+++ b/crates/shared/Cargo.toml
@@ -45,7 +45,7 @@ prometheus = { workspace = true }
 prometheus-metric-storage = { workspace = true }
 rate-limit = { path = "../rate-limit" }
 reqwest = { workspace = true, features = ["cookies", "gzip", "json"] }
-rust_decimal = "1.35.0"
+rust_decimal = { version = "1.35.0", features = ["maths"] }
 secp256k1 = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/shared/src/price_estimation/factory.rs
+++ b/crates/shared/src/price_estimation/factory.rs
@@ -214,7 +214,8 @@ impl<'a> PriceEstimatorFactory<'a> {
                         self.args.coin_gecko_url.clone(),
                         self.args.coin_gecko_api_key.clone(),
                         self.network.chain_id,
-                        weth,
+                        weth.address(),
+                        self.components.tokens.clone(),
                     )
                     .await?,
                 ),

--- a/crates/shared/src/price_estimation/native/coingecko.rs
+++ b/crates/shared/src/price_estimation/native/coingecko.rs
@@ -195,8 +195,9 @@ impl CoinGecko {
 
         // When the quoted token and the denominator have different number of decimals
         // the computed price effectively needs to be shifted by the difference.
-        let adjustment =
-            Decimal::new(10, 0).powi(denominator.decimals as i64 - token_decimals as i64);
+        let adjustment = Decimal::new(10, 0)
+            .checked_powi(i64::from(denominator.decimals) - i64::from(token_decimals))
+            .context("price adjustment overflows Decimal")?;
 
         let price_denominated_in_token = token_price_eth
             .checked_div(denominator_price_eth)


### PR DESCRIPTION
# Description
Fixes: https://github.com/cowprotocol/services/issues/2887

# Changes
Adjust returned native token prices when the quoted token has a different amount of decimals than the native token to be inline with all other native price estimator implementations.

Additionally I also removed the option to quote without denominating in any token mainly to reduce complexity.

## How to test
Added an `ignored` unit test that checks that prices make sense.
Also compared prices returned for `wxdai` and `usdc` with prices logged in our infra.