### PR TITLE
Sync start of auction with submission logic AND blockchain

### DIFF
--- a/crates/autopilot/src/run.rs
+++ b/crates/autopilot/src/run.rs
@@ -520,6 +520,7 @@ pub async fn run(args: Arguments) {
         persistence: persistence.clone(),
         liveness: liveness.clone(),
         synchronization: args.run_loop_mode,
+        run_loop_start_notifier: Default::default(),
     };
     run.run_forever(args.auction_update_interval).await;
     unreachable!("run loop exited");

--- a/crates/autopilot/src/run.rs
+++ b/crates/autopilot/src/run.rs
@@ -359,7 +359,7 @@ pub async fn run(args: Arguments) {
         boundary::events::settlement::GPv2SettlementContract::new(
             eth.contracts().settlement().clone(),
         ),
-        boundary::events::settlement::Indexer::new(db.clone(), on_settlement_event_updater),
+        boundary::events::settlement::Indexer::new(db.clone(), on_settlement_event_updater.clone()),
         block_retriever.clone(),
         skip_event_sync_start,
     ));
@@ -521,6 +521,7 @@ pub async fn run(args: Arguments) {
         liveness: liveness.clone(),
         synchronization: args.run_loop_mode,
         run_loop_start_notifier: Default::default(),
+        settlement_processed_receiver: on_settlement_event_updater.subscribe_to_updates(),
     };
     run.run_forever(args.auction_update_interval).await;
     unreachable!("run loop exited");

--- a/crates/autopilot/src/run_loop.rs
+++ b/crates/autopilot/src/run_loop.rs
@@ -70,7 +70,6 @@ impl RunLoop {
         let mut last_auction = None;
         let mut last_block = None;
         loop {
-            self.sleep_until_next_auction().await;
             if let Some(domain::AuctionWithId { id, auction }) = self.next_auction().await {
                 let current_block = self.eth.current_block().borrow().hash;
                 // Only run the solvers if the auction or block has changed.
@@ -131,6 +130,7 @@ impl RunLoop {
     }
 
     async fn next_auction(&self) -> Option<domain::AuctionWithId> {
+        self.sleep_until_next_auction().await;
         let auction = match self.solvable_orders_cache.current_auction() {
             Some(auction) => auction,
             None => {

--- a/crates/autopilot/src/run_loop.rs
+++ b/crates/autopilot/src/run_loop.rs
@@ -700,13 +700,7 @@ impl RunLoop {
                 }
                 Ok(None) => {}
             }
-            // TODO: fix bug in driver to make this `>=` instead of `>`
-            // Technically this should be `>=` to stop exactly on the deadline block.
-            // However, the current driver implementation has a bug where it does not try
-            // to cancel a transaction when the `autopilot` already terminated the
-            // connection to the driver since the cancellation does not get
-            // handled in a background task.
-            if block_number > deadline {
+            if block_number == deadline {
                 // The last allowed block did not contain the desired transaction.
                 // Stop waiting for the tx and signal to the run loop to **NOT** wait for the
                 // next block since that would mean 1 entire block interval of waiting.

--- a/crates/driver/src/domain/competition/mod.rs
+++ b/crates/driver/src/domain/competition/mod.rs
@@ -5,7 +5,7 @@ use {
         Mempools,
     },
     crate::{
-        domain::{competition::solution::Settlement, eth, mempools},
+        domain::{competition::solution::Settlement, eth},
         infra::{
             self,
             blockchain::Ethereum,
@@ -281,24 +281,10 @@ impl Competition {
             .take()
             .ok_or(Error::SolutionNotAvailable)?;
 
-        // Submit the transaction in a background task to bring the transaction
-        // (or cancellation) correctly on-chain even when the autopilot aborts
-        // the `/settle` request due to connection issues or reaching the
-        // submission deadline.
-        let mempools_cloned = self.mempools.clone();
-        let solver_cloned = self.solver.clone();
-        let settlement_cloned = settlement.clone();
-        let executed = tokio::task::spawn(async move {
-            mempools_cloned
-                .execute(&solver_cloned, &settlement_cloned, submission_deadline)
-                .await
-        })
-        .await
-        .unwrap_or_else(|err| {
-            Err(mempools::Error::Other(anyhow::anyhow!(
-                "failed to executed submission task: {err:?}"
-            )))
-        });
+        let executed = self
+            .mempools
+            .execute(&self.solver, &settlement, submission_deadline)
+            .await;
 
         notify::executed(
             &self.solver,


### PR DESCRIPTION
# Description
Last part for https://github.com/cowprotocol/services/issues/486

# Changes
Either await new block **OR** signal from submission logic to start right away.
Will not go into details here since I wrote extensive comments to explain the somewhat subtle issue.

One open question: Do you think we should always skip waiting for the next block for the very first auction? My reasoning is that a sub-optimal auction synchronization might be better UX than having up to 12s of no action after restarts.

## How to test
Will add an e2e test using the new runmode in a separate PR
Having this untested until then seems fine since that behavior is feature gated and the changes were pretty minor so far.