### PR TITLE
[Easy] Explicit Solver Notification for expired settlements

### DIFF
--- a/crates/driver/src/infra/notify/mod.rs
+++ b/crates/driver/src/infra/notify/mod.rs
@@ -107,7 +107,8 @@ pub fn executed(
         Ok(hash) => notification::Settlement::Success(hash.clone()),
         Err(Error::Revert(hash)) => notification::Settlement::Revert(hash.clone()),
         Err(Error::SimulationRevert) => notification::Settlement::SimulationRevert,
-        Err(Error::Other(_) | Error::Expired | Error::Disabled) => notification::Settlement::Fail,
+        Err(Error::Expired) => notification::Settlement::Expired,
+        Err(Error::Other(_) | Error::Disabled) => notification::Settlement::Fail,
     };
 
     solver.notify(

--- a/crates/driver/src/infra/notify/notification.rs
+++ b/crates/driver/src/infra/notify/notification.rs
@@ -66,7 +66,7 @@ pub enum Settlement {
     Revert(TransactionHash),
     /// Transaction started reverting during the submission.
     SimulationRevert,
-    /// Settlement was not confirmed in time
+    /// Transaction was not confirmed in time
     Expired,
     /// Winning solver failed to settle the transaction onchain for other
     /// reasons.

--- a/crates/driver/src/infra/notify/notification.rs
+++ b/crates/driver/src/infra/notify/notification.rs
@@ -66,6 +66,9 @@ pub enum Settlement {
     Revert(TransactionHash),
     /// Transaction started reverting during the submission.
     SimulationRevert,
-    /// Winning solver failed to settle the transaction onchain.
+    /// Settlement was not confirmed in time
+    Expired,
+    /// Winning solver failed to settle the transaction onchain for other
+    /// reasons.
     Fail,
 }

--- a/crates/driver/src/infra/solver/dto/notification.rs
+++ b/crates/driver/src/infra/solver/dto/notification.rs
@@ -57,7 +57,8 @@ impl Notification {
                         transaction: hash.0,
                     },
                     notify::Settlement::SimulationRevert => Kind::Cancelled,
-                    notify::Settlement::Fail | notify::Settlement::Expired => Kind::Fail,
+                    notify::Settlement::Fail => Kind::Fail,
+                    notify::Settlement::Expired => Kind::Expired,
                 },
                 notify::Kind::PostprocessingTimedOut => Kind::PostprocessingTimedOut,
             },
@@ -140,6 +141,7 @@ pub enum Kind {
         reason: String,
     },
     Cancelled,
+    Expired,
     Fail,
     PostprocessingTimedOut,
 }

--- a/crates/driver/src/infra/solver/dto/notification.rs
+++ b/crates/driver/src/infra/solver/dto/notification.rs
@@ -57,7 +57,7 @@ impl Notification {
                         transaction: hash.0,
                     },
                     notify::Settlement::SimulationRevert => Kind::Cancelled,
-                    notify::Settlement::Fail => Kind::Fail,
+                    notify::Settlement::Fail | notify::Settlement::Expired => Kind::Fail,
                 },
                 notify::Kind::PostprocessingTimedOut => Kind::PostprocessingTimedOut,
             },


### PR DESCRIPTION
# Description

One of the main source for confusion for solvers that aren't running their own driver are Settlement failures where they don't understand why the settlement failed. Recently a lot of teams asked us to investigate instances where it turned out that their settlement simply was included before the deadline.

This PR creates an explicit notification subtype for it so that solvers can self-diagnose this case. cc @bram-vdberg 

# Changes
- [x] Introduce new notification dto variant and map `Expired` errors to it.