### PR TITLE
[EASY] Runloop metrics buckets adjustments

### DIFF
--- a/crates/autopilot/src/run_loop.rs
+++ b/crates/autopilot/src/run_loop.rs
@@ -808,12 +808,10 @@ struct Metrics {
 
     /// Tracks the time spent in post-processing after the auction has been
     /// solved and before sending a `settle` request.
-    #[metric(buckets(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12))]
     auction_postprocessing_time: prometheus::Histogram,
 
     /// Tracks the time spent in pre-processing before sending a `solve`
     /// request.
-    #[metric(buckets(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12))]
     auction_preprocessing_time: prometheus::Histogram,
 
     /// Total time spent in a single run of the run loop.
@@ -822,7 +820,7 @@ struct Metrics {
 
     /// Time difference between the current block and when the single run
     /// function is started.
-    #[metric(buckets(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12))]
+    #[metric(buckets(0, 2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22, 25, 30, 40))]
     current_block_delay: prometheus::Histogram,
 }
 

--- a/crates/autopilot/src/solvable_orders.rs
+++ b/crates/autopilot/src/solvable_orders.rs
@@ -56,7 +56,7 @@ pub struct Metrics {
     auction_update_total_time: Histogram,
 
     /// Time spent on auction update individual stage.
-    #[metric(labels("stage"), buckets(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12))]
+    #[metric(labels("stage"))]
     auction_update_stage_time: HistogramVec,
 
     /// Auction creations.


### PR DESCRIPTION
# Description
New run loop metrics were introduced in #2888. Currently, we have them on staging only(GPv2 -> Autopilot Co-location Runloop section), and some of them are not really useful because the size of some buckets is too large.

# Changes
Use default buckets for metrics that spend less than 2s in general for all the operations.
Use larger buckets for the `current_block_delay` metric since most of the time it gets above the current 12s limit.

# Next steps
Prod deployment would probably require more bucket adjustments. Some of the metric might be merged in a single one with different labels.
