### PR TITLE
Save all auction prices

### DIFF
--- a/crates/autopilot/src/run_loop.rs
+++ b/crates/autopilot/src/run_loop.rs
@@ -31,7 +31,7 @@ use {
     rand::seq::SliceRandom,
     shared::token_list::AutoUpdatingTokenList,
     std::{
-        collections::{BTreeMap, HashMap, HashSet},
+        collections::{HashMap, HashSet},
         sync::Arc,
         time::{Duration, Instant, SystemTime},
     },
@@ -266,35 +266,18 @@ impl RunLoop {
             .map(|participant| participant.solution.solver().into())
             .collect::<HashSet<_>>();
 
-        let mut prices = BTreeMap::new();
         let mut fee_policies = Vec::new();
         let call_data = revealed.calldata.internalized.clone();
         let uninternalized_call_data = revealed.calldata.uninternalized.clone();
 
         for order_id in winning_solution.order_ids() {
-            let auction_order = auction
+            match auction
                 .orders
                 .iter()
-                .find(|auction_order| &auction_order.uid == order_id);
-            match auction_order {
+                .find(|auction_order| &auction_order.uid == order_id)
+            {
                 Some(auction_order) => {
                     fee_policies.push((auction_order.uid, auction_order.protocol_fees.clone()));
-                    if let Some(price) = auction.prices.get(&auction_order.sell.token) {
-                        prices.insert(auction_order.sell.token, *price);
-                    } else {
-                        tracing::error!(
-                            sell_token = ?auction_order.sell.token,
-                            "sell token price is missing in auction"
-                        );
-                    }
-                    if let Some(price) = auction.prices.get(&auction_order.buy.token) {
-                        prices.insert(auction_order.buy.token, *price);
-                    } else {
-                        tracing::error!(
-                            buy_token = ?auction_order.buy.token,
-                            "buy token price is missing in auction"
-                        );
-                    }
                 }
                 None => {
                     tracing::debug!(?order_id, "order not found in auction");
@@ -313,8 +296,8 @@ impl RunLoop {
                     .collect(),
                 prices: auction
                     .prices
-                    .into_iter()
-                    .map(|(key, value)| (key.into(), value.get().into()))
+                    .iter()
+                    .map(|(key, value)| ((*key).into(), value.get().into()))
                     .collect(),
             },
             solutions: solutions
@@ -361,7 +344,8 @@ impl RunLoop {
             winning_score,
             reference_score,
             participants,
-            prices: prices
+            prices: auction
+                .prices
                 .into_iter()
                 .map(|(key, value)| (key.into(), value.get().into()))
                 .collect(),


### PR DESCRIPTION
# Description

Historical context:

Initially we wanted to save all auction prices so we can reconstruct the whole auction object if needed.

Then, I implemented the optimization that we save prices only for orders that appear in the winning solution, with the assumption that this is all we will need. 

However, this assumption changed with cow amm implementation, where cow amm orders do not exist in the auction, therefore we are unable to determine their sell/buy tokens and save token prices for those cow amm orders.

Consequently, missing prices cause failure in score computing, where for all surplus capturing orders (cow amm orders) we need to have auction prices.

# Changes
<!-- List of detailed changes (how the change is accomplished) -->

- [ ] Save all auction prices to database