### PR TITLE
Detect bad tokens in parallel

### DIFF
--- a/crates/autopilot/src/solvable_orders.rs
+++ b/crates/autopilot/src/solvable_orders.rs
@@ -684,12 +684,12 @@ async fn filter_unsupported_tokens(
     .collect::<HashSet<_>>();
 
     orders.retain(|order| {
-        !order
+        order
             .data
             .token_pair()
-            .unwrap_or_default()
             .into_iter()
-            .any(|token| bad_tokens.contains(&token))
+            .flatten()
+            .all(|token| !bad_tokens.contains(&token))
     });
     orders
 }

--- a/crates/autopilot/src/solvable_orders.rs
+++ b/crates/autopilot/src/solvable_orders.rs
@@ -665,10 +665,10 @@ async fn filter_unsupported_tokens(
         async move {
             for token in order.data.token_pair().unwrap() {
                 if !bad_token.detect(token).await?.is_good() {
-                    return Ok(None);
+                    return Ok(None) as Result<Option<Order>>;
                 }
             }
-            Ok(Some(order))
+            Ok(Some(order)) as Result<Option<Order>>
         }
     }))
     .await

--- a/crates/autopilot/src/solvable_orders.rs
+++ b/crates/autopilot/src/solvable_orders.rs
@@ -7,6 +7,7 @@ use {
     bigdecimal::BigDecimal,
     database::order_events::OrderEventLabel,
     ethrpc::block_stream::CurrentBlockWatcher,
+    futures::future::try_join_all,
     indexmap::IndexSet,
     itertools::Itertools,
     model::{
@@ -195,8 +196,7 @@ impl SolvableOrdersCache {
 
         let orders = {
             let _timer = self.stage_timer("unsupported_token_filtering");
-            let orders =
-                filter_unsupported_tokens(orders, self.bad_token_detector.as_ref()).await?;
+            let orders = filter_unsupported_tokens(orders, self.bad_token_detector.clone()).await?;
             let removed = counter.checkpoint("unsupported_token", &orders);
             invalid_order_uids.extend(removed);
             orders
@@ -657,22 +657,22 @@ fn to_normalized_price(price: f64) -> Option<U256> {
 }
 
 async fn filter_unsupported_tokens(
-    mut orders: Vec<Order>,
-    bad_token: &dyn BadTokenDetecting,
+    orders: Vec<Order>,
+    bad_token: Arc<dyn BadTokenDetecting>,
 ) -> Result<Vec<Order>> {
-    // Can't use normal `retain` or `filter` because the bad token detection is
-    // async. So either this manual iteration or conversion to stream.
-    let mut index = 0;
-    'outer: while index < orders.len() {
-        for token in orders[index].data.token_pair().unwrap() {
-            if !bad_token.detect(token).await?.is_good() {
-                orders.swap_remove(index);
-                continue 'outer;
+    try_join_all(orders.into_iter().map(|order| {
+        let bad_token = bad_token.clone();
+        async move {
+            for token in order.data.token_pair().unwrap() {
+                if !bad_token.detect(token).await?.is_good() {
+                    return Ok(None) as Result<Option<Order>>;
+                }
             }
+            Ok(Some(order)) as Result<Option<Order>>
         }
-        index += 1;
-    }
-    Ok(orders)
+    }))
+    .await
+    .map(|orders| orders.into_iter().flatten().collect())
 }
 
 /// Filter out limit orders which are far enough outside the estimated native
@@ -1098,7 +1098,7 @@ mod tests {
         let token0 = H160::from_low_u64_le(0);
         let token1 = H160::from_low_u64_le(1);
         let token2 = H160::from_low_u64_le(2);
-        let bad_token = ListBasedDetector::deny_list(vec![token0]);
+        let bad_token = Arc::new(ListBasedDetector::deny_list(vec![token0]));
         let orders = vec![
             OrderBuilder::default()
                 .with_sell_token(token0)
@@ -1113,7 +1113,7 @@ mod tests {
                 .with_buy_token(token2)
                 .build(),
         ];
-        let result = filter_unsupported_tokens(orders.clone(), &bad_token)
+        let result = filter_unsupported_tokens(orders.clone(), bad_token)
             .now_or_never()
             .unwrap()
             .unwrap();

--- a/crates/autopilot/src/solvable_orders.rs
+++ b/crates/autopilot/src/solvable_orders.rs
@@ -665,10 +665,10 @@ async fn filter_unsupported_tokens(
         async move {
             for token in order.data.token_pair().unwrap() {
                 if !bad_token.detect(token).await?.is_good() {
-                    return Ok(None) as Result<Option<Order>>;
+                    return Ok(None);
                 }
             }
-            Ok(Some(order)) as Result<Option<Order>>
+            Ok(Some(order))
         }
     }))
     .await

--- a/crates/autopilot/src/solvable_orders.rs
+++ b/crates/autopilot/src/solvable_orders.rs
@@ -7,6 +7,7 @@ use {
     bigdecimal::BigDecimal,
     database::order_events::OrderEventLabel,
     ethrpc::block_stream::CurrentBlockWatcher,
+    futures::future::join_all,
     indexmap::IndexSet,
     itertools::Itertools,
     model::{
@@ -195,8 +196,7 @@ impl SolvableOrdersCache {
 
         let orders = {
             let _timer = self.stage_timer("unsupported_token_filtering");
-            let orders =
-                filter_unsupported_tokens(orders, self.bad_token_detector.as_ref()).await?;
+            let orders = filter_unsupported_tokens(orders, self.bad_token_detector.clone()).await?;
             let removed = counter.checkpoint("unsupported_token", &orders);
             invalid_order_uids.extend(removed);
             orders
@@ -658,14 +658,35 @@ fn to_normalized_price(price: f64) -> Option<U256> {
 
 async fn filter_unsupported_tokens(
     mut orders: Vec<Order>,
-    bad_token: &dyn BadTokenDetecting,
+    bad_token: Arc<dyn BadTokenDetecting>,
 ) -> Result<Vec<Order>> {
-    // Can't use normal `retain` or `filter` because the bad token detection is
-    // async. So either this manual iteration or conversion to stream.
+    let bad_tokens = join_all(
+        orders
+            .iter()
+            .flat_map(|o| o.data.token_pair().unwrap_or_default())
+            .unique()
+            .map(|token| {
+                let bad_token = bad_token.clone();
+                async move {
+                    match bad_token.detect(token).await {
+                        Ok(quality) => (!quality.is_good()).then_some(token),
+                        Err(err) => {
+                            tracing::warn!(?token, ?err, "unable to determine token quality");
+                            Some(token)
+                        }
+                    }
+                }
+            }),
+    )
+    .await
+    .into_iter()
+    .flatten()
+    .collect::<HashSet<_>>();
+
     let mut index = 0;
     'outer: while index < orders.len() {
         for token in orders[index].data.token_pair().unwrap() {
-            if !bad_token.detect(token).await?.is_good() {
+            if bad_tokens.contains(&token) {
                 orders.swap_remove(index);
                 continue 'outer;
             }
@@ -1098,7 +1119,7 @@ mod tests {
         let token0 = H160::from_low_u64_le(0);
         let token1 = H160::from_low_u64_le(1);
         let token2 = H160::from_low_u64_le(2);
-        let bad_token = ListBasedDetector::deny_list(vec![token0]);
+        let bad_token = Arc::new(ListBasedDetector::deny_list(vec![token0]));
         let orders = vec![
             OrderBuilder::default()
                 .with_sell_token(token0)
@@ -1113,7 +1134,7 @@ mod tests {
                 .with_buy_token(token2)
                 .build(),
         ];
-        let result = filter_unsupported_tokens(orders.clone(), &bad_token)
+        let result = filter_unsupported_tokens(orders.clone(), bad_token)
             .now_or_never()
             .unwrap()
             .unwrap();


### PR DESCRIPTION
# Description
Bad token detection sometimes takes an unreasonable amount of time. An attempt to speed up this a bit is to execute operations for each order in parallel.
<img width="461" alt="image" src="https://github.com/user-attachments/assets/b39687ce-c60b-4347-b9a7-72abf620621a">

## Further changes

The whole `filter_unsupported_tokens` could be executed in parallel together with other orders filtering functions. Subject of a separate PR.