### PR TITLE
Make `Considered` state more useful

### DIFF
--- a/crates/e2e/tests/e2e/univ2.rs
+++ b/crates/e2e/tests/e2e/univ2.rs
@@ -94,7 +94,6 @@ async fn test(web3: Web3) {
             &[
                 OrderEventLabel::Created,
                 OrderEventLabel::Ready,
-                OrderEventLabel::Considered,
                 OrderEventLabel::Executing,
                 OrderEventLabel::Traded,
             ],


### PR DESCRIPTION
# Description
Currently all orders that are part of any solution are marked as considered. This seems to be problematic for the progress bar feature because the winning solution can report `Considered` for a split second and then `Executing` because those state get stored in very quick succession.

Since this state is not used for anything backend related and it doesn't seem crazy useful to store `Considered` and `Executing` for the same order this PR makes it so that we only store `Considered` for **non-winning** solutions.

# Changes
- store `Considered` only for **non-winning** solutions
- store `Considered` states **after** filtering out "unfair" solutions

## How to test
e2e tests should still pass

@alfetopito let me know if you want to have this merged for the progress bar or not