### PR TITLE
Remove concurrency limit on forked e2e tests

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -122,8 +122,6 @@ jobs:
   test-forked-node:
     timeout-minutes: 60
     runs-on: ubuntu-latest
-    concurrency:
-      group: archive_node
     env:
       # Shrink artifact size by not including debug info. Makes build faster and shrinks cache.
       CARGO_PROFILE_DEV_DEBUG: 0


### PR DESCRIPTION
# Description
The forked e2e tests are overall pretty useful but the public nodes we've used so far have been pretty flaky which leads to people not paying too much attention when a forked test fails for a good reason.

# Changes
- I changed the github secrets to use self hosted nodes which should be more reliable
- removed the concurrency limit on the tests as we don't have to adhere to any compute limits anymore

## How to test
forked tests should still work