### PR TITLE
[EASY] Improve config group for blockscout and ethplorer

### DIFF
--- a/crates/orderbook/src/arguments.rs
+++ b/crates/orderbook/src/arguments.rs
@@ -235,7 +235,7 @@ impl std::fmt::Display for Arguments {
             max_limit_orders_per_user
         )?;
         writeln!(f, "ipfs_gateway: {:?}", ipfs_gateway)?;
-        display_secret_option(f, "ipfs_pinata_auth", ipfs_pinata_auth)?;
+        display_secret_option(f, "ipfs_pinata_auth", ipfs_pinata_auth.as_ref())?;
         display_option(
             f,
             "hooks_contract_address",

--- a/crates/shared/src/arguments.rs
+++ b/crates/shared/src/arguments.rs
@@ -241,7 +241,7 @@ pub struct Arguments {
 pub fn display_secret_option<T>(
     f: &mut Formatter<'_>,
     name: &str,
-    option: &Option<T>,
+    option: Option<&T>,
 ) -> std::fmt::Result {
     display_option(f, name, &option.as_ref().map(|_| "SECRET"))
 }
@@ -346,7 +346,7 @@ impl Display for Arguments {
         display_option(f, "chain_id", chain_id)?;
         display_option(f, "simulation_node_url", simulation_node_url)?;
         writeln!(f, "gas_estimators: {:?}", gas_estimators)?;
-        display_secret_option(f, "blocknative_api_key", blocknative_api_key)?;
+        display_secret_option(f, "blocknative_api_key", blocknative_api_key.as_ref())?;
         writeln!(f, "base_tokens: {:?}", base_tokens)?;
         writeln!(f, "baseline_sources: {:?}", baseline_sources)?;
         writeln!(f, "pool_cache_blocks: {}", pool_cache_blocks)?;
@@ -368,7 +368,11 @@ impl Display for Arguments {
         writeln!(f, "use_internal_buffers: {}", use_internal_buffers)?;
         writeln!(f, "balancer_factories: {:?}", balancer_factories)?;
         writeln!(f, "balancer_pool_deny_list: {:?}", balancer_pool_deny_list)?;
-        display_secret_option(f, "solver_competition_auth", solver_competition_auth)?;
+        display_secret_option(
+            f,
+            "solver_competition_auth",
+            solver_competition_auth.as_ref(),
+        )?;
         display_option(
             f,
             "network_block_interval",

--- a/crates/shared/src/bad_token/token_owner_finder.rs
+++ b/crates/shared/src/bad_token/token_owner_finder.rs
@@ -223,30 +223,30 @@ impl Display for Arguments {
             "blockscout_api_url",
             &blockscout
                 .as_ref()
-                .map(|blockscout| blockscout.blockscout_api_url.clone())
-                .flatten(),
+                .and_then(|blockscout| blockscout.blockscout_api_url.clone()),
         )?;
         display_secret_option(
             f,
             "blockscout_api_key",
-            &blockscout
+            blockscout
                 .as_ref()
-                .map(|blockscout| blockscout.blockscout_api_key.clone()),
+                .and_then(|blockscout| blockscout.blockscout_api_key.clone())
+                .as_ref(),
         )?;
         display_option(
             f,
             "ethplorer_api_url",
             &ethplorer
                 .as_ref()
-                .map(|blockscout| blockscout.ethplorer_api_url.clone())
-                .flatten(),
+                .and_then(|blockscout| blockscout.ethplorer_api_url.clone()),
         )?;
         display_secret_option(
             f,
             "ethplorer_api_key",
-            &ethplorer
+            ethplorer
                 .as_ref()
-                .map(|blockscout| blockscout.ethplorer_api_key.clone()),
+                .and_then(|blockscout| blockscout.ethplorer_api_key.clone())
+                .as_ref(),
         )?;
         display_option(
             f,
@@ -330,8 +330,7 @@ pub async fn init(
             http_factory.create(),
             args.ethplorer
                 .as_ref()
-                .map(|ethplorer| ethplorer.ethplorer_api_key.clone())
-                .flatten(),
+                .and_then(|ethplorer| ethplorer.ethplorer_api_key.clone()),
             chain_id,
         )?;
         if let Some(ethplorer_config) = &args.ethplorer {

--- a/crates/shared/src/price_estimation.rs
+++ b/crates/shared/src/price_estimation.rs
@@ -329,12 +329,16 @@ impl Display for Arguments {
             amount_to_estimate_prices_with,
         )?;
         display_option(f, "balancer_sor_url", balancer_sor_url)?;
-        display_secret_option(f, "one_inch_spot_price_api_key: {:?}", one_inch_api_key)?;
+        display_secret_option(
+            f,
+            "one_inch_spot_price_api_key: {:?}",
+            one_inch_api_key.as_ref(),
+        )?;
         writeln!(f, "one_inch_spot_price_api_url: {}", one_inch_url)?;
         display_secret_option(
             f,
             "coin_gecko_api_key: {:?}",
-            &coin_gecko.coin_gecko_api_key,
+            coin_gecko.coin_gecko_api_key.as_ref(),
         )?;
         writeln!(f, "coin_gecko_api_url: {}", coin_gecko.coin_gecko_url)?;
         writeln!(f, "coin_gecko_api_url: {}", coin_gecko.coin_gecko_url)?;

--- a/crates/shared/src/tenderly_api.rs
+++ b/crates/shared/src/tenderly_api.rs
@@ -313,7 +313,7 @@ impl Display for Arguments {
 
         display_option(f, "tenderly_user", tenderly_user)?;
         display_option(f, "tenderly_project", tenderly_project)?;
-        display_secret_option(f, "tenderly_api_key", tenderly_api_key)?;
+        display_secret_option(f, "tenderly_api_key", tenderly_api_key.as_ref())?;
 
         Ok(())
     }


### PR DESCRIPTION
# Description
Improve the groups for `ethplorer` and `blockscout` inspired by the CoinGecko configuration done in: https://github.com/cowprotocol/services/pull/2909

## How to test
1.Unit test