### PR TITLE
Insert auction prices in batches

### DIFF
--- a/crates/database/src/auction_prices.rs
+++ b/crates/database/src/auction_prices.rs
@@ -18,10 +18,10 @@ pub async fn insert(
     prices: &[AuctionPrice],
 ) -> Result<(), sqlx::Error> {
     const BATCH_SIZE: usize = 5000;
+    const QUERY: &str = "INSERT INTO auction_prices (auction_id, token, price) ";
 
     for chunk in prices.chunks(BATCH_SIZE) {
-        let mut query_builder =
-            QueryBuilder::new("INSERT INTO auction_prices (auction_id, token, price) ");
+        let mut query_builder = QueryBuilder::new(QUERY);
 
         query_builder.push_values(chunk, |mut builder, price| {
             builder


### PR DESCRIPTION
# Description
Since all the native prices are stored instead of just the ones the winning solution won, this process takes much more time than before.
![image](https://github.com/user-attachments/assets/d09948e7-f37b-49d9-8a91-df03ab251e4c)


# Changes
Store prices in batches should speed up this.

## How to test
Existing tests.