### PR TITLE
[EASY] Use autopilot ethrpc config from args

### DIFF
--- a/crates/autopilot/src/boundary/mod.rs
+++ b/crates/autopilot/src/boundary/mod.rs
@@ -26,9 +26,8 @@ use {crate::domain, ethrpc::Web3, std::collections::HashMap, url::Url};
 pub mod events;
 pub mod order;
 
-/// Builds a web3 client that bufferes requests and sends them in a
-/// batch call.
-pub fn buffered_web3_client(ethrpc: &Url, ethrpc_args: &shared::ethrpc::Arguments) -> Web3 {
+/// Builds a web3 client based on the ethrpc args config.
+pub fn web3_client(ethrpc: &Url, ethrpc_args: &shared::ethrpc::Arguments) -> Web3 {
     let http_factory =
         shared::http_client::HttpClientFactory::new(&shared::http_client::Arguments {
             http_timeout: std::time::Duration::from_secs(10),

--- a/crates/autopilot/src/boundary/mod.rs
+++ b/crates/autopilot/src/boundary/mod.rs
@@ -28,17 +28,12 @@ pub mod order;
 
 /// Builds a web3 client that bufferes requests and sends them in a
 /// batch call.
-pub fn buffered_web3_client(ethrpc: &Url) -> Web3 {
-    let ethrpc_args = shared::ethrpc::Arguments {
-        ethrpc_max_batch_size: 20,
-        ethrpc_max_concurrent_requests: 10,
-        ethrpc_batch_delay: Default::default(),
-    };
+pub fn buffered_web3_client(ethrpc: &Url, ethrpc_args: &shared::ethrpc::Arguments) -> Web3 {
     let http_factory =
         shared::http_client::HttpClientFactory::new(&shared::http_client::Arguments {
             http_timeout: std::time::Duration::from_secs(10),
         });
-    shared::ethrpc::web3(&ethrpc_args, &http_factory, ethrpc, "base")
+    shared::ethrpc::web3(ethrpc_args, &http_factory, ethrpc, "base")
 }
 
 pub struct SolvableOrders {

--- a/crates/autopilot/src/infra/blockchain/mod.rs
+++ b/crates/autopilot/src/infra/blockchain/mod.rs
@@ -44,7 +44,7 @@ impl Rpc {
         url: &url::Url,
         ethrpc_args: &shared::ethrpc::Arguments,
     ) -> Result<Self, Error> {
-        let web3 = boundary::buffered_web3_client(url, ethrpc_args);
+        let web3 = boundary::web3_client(url, ethrpc_args);
         let chain = web3.eth().chain_id().await?.into();
 
         Ok(Self {

--- a/crates/autopilot/src/infra/blockchain/mod.rs
+++ b/crates/autopilot/src/infra/blockchain/mod.rs
@@ -40,8 +40,11 @@ pub struct Rpc {
 impl Rpc {
     /// Instantiate an RPC client to an Ethereum (or Ethereum-compatible) node
     /// at the specifed URL.
-    pub async fn new(url: &url::Url) -> Result<Self, Error> {
-        let web3 = boundary::buffered_web3_client(url);
+    pub async fn new(
+        url: &url::Url,
+        ethrpc_args: &shared::ethrpc::Arguments,
+    ) -> Result<Self, Error> {
+        let web3 = boundary::buffered_web3_client(url, ethrpc_args);
         let chain = web3.eth().chain_id().await?.into();
 
         Ok(Self {

--- a/crates/autopilot/src/run.rs
+++ b/crates/autopilot/src/run.rs
@@ -80,8 +80,8 @@ impl Liveness {
     }
 }
 
-async fn ethrpc(url: &Url) -> infra::blockchain::Rpc {
-    infra::blockchain::Rpc::new(url)
+async fn ethrpc(url: &Url, ethrpc_args: &shared::ethrpc::Arguments) -> infra::blockchain::Rpc {
+    infra::blockchain::Rpc::new(url, ethrpc_args)
         .await
         .expect("connect ethereum RPC")
 }
@@ -150,7 +150,7 @@ pub async fn run(args: Arguments) {
         );
     }
 
-    let ethrpc = ethrpc(&args.shared.node_url).await;
+    let ethrpc = ethrpc(&args.shared.node_url, &args.shared.ethrpc).await;
     let chain = ethrpc.chain();
     let web3 = ethrpc.web3().clone();
     let url = ethrpc.url().clone();


### PR DESCRIPTION
# Description
Currently, ethrpc values are hardcoded. It makes sense to start using values from arguments to adjust them using infra. No config change is required since the same ones are used in the pulumi config.
