### PR TITLE
Handle fatal errors when indexing cow amms

### DIFF
--- a/crates/cow-amm/src/amm.rs
+++ b/crates/cow-amm/src/amm.rs
@@ -2,7 +2,7 @@ use {
     anyhow::Result,
     app_data::AppDataHash,
     contracts::CowAmmLegacyHelper,
-    ethcontract::{Address, Bytes, U256},
+    ethcontract::{errors::MethodError, Address, Bytes, U256},
     model::{
         interaction::InteractionData,
         order::{BuyTokenDestination, OrderData, OrderKind, SellTokenSource},
@@ -18,7 +18,10 @@ pub struct Amm {
 }
 
 impl Amm {
-    pub(crate) async fn new(address: Address, helper: &CowAmmLegacyHelper) -> Result<Self> {
+    pub(crate) async fn new(
+        address: Address,
+        helper: &CowAmmLegacyHelper,
+    ) -> Result<Self, MethodError> {
         let tradeable_tokens = helper.tokens(address).call().await?;
 
         Ok(Self {

--- a/crates/cow-amm/src/cache.rs
+++ b/crates/cow-amm/src/cache.rs
@@ -92,7 +92,7 @@ impl EventStoring<CowAmmEvent> for Storage {
                     return Err(err.into());
                 }
                 Err(err) => {
-                    tracing::info!(?err, ?cow_amm, "helper contract does not support amm");
+                    tracing::info!(?cow_amm, ?err, "helper contract does not support amm");
                     continue;
                 }
             };

--- a/crates/shared/src/arguments.rs
+++ b/crates/shared/src/arguments.rs
@@ -99,7 +99,7 @@ pub struct OrderQuotingArguments {
 
 logging_args_with_default_filter!(
     LoggingArguments,
-    "warn,autopilot=debug,driver=debug,orderbook=debug,solver=debug,shared=debug"
+    "warn,autopilot=debug,driver=debug,orderbook=debug,solver=debug,shared=debug,cow_amm=debug"
 );
 
 #[derive(clap::Parser)]


### PR DESCRIPTION
# Description
Currently the `autopilot` maintenance loop can get stuck when the configured cow amm helper contract does not support a found contract with this error:
```
2024-09-03T06:13:17.420Z  WARN autopilot::maintenance: failed to run background task successfully err=method 'tokens(address):(address[])' failure: contract call reverted with message: None

Caused by:
    contract call reverted with message: None
```

So far we have been retrying this error over and over although the call to detect which tokens the pool is trading will never work if an amm is misconfigured or generally not supported by the helper contract.

# Changes
Differentiate between retryable and fatal errors while indexing the amms and retry or skip this pool respectively.

# Testplan
Set up sepolia configuration locally and checked that we don't get stuck on the unsupported pools:
```
2024-09-03T06:24:55.880Z  INFO cow_amm::cache: helper contract does not support amm cow_amm=0xe4abfda4e8c02fcafc34981dafaeb426aa4186e6 err=MethodError { signature: "tokens(address):(address[])", inner: Revert(None) }
2024-09-03T06:24:55.921Z  INFO cow_amm::cache: indexed new cow amm cow_amm=0xac140f325afd20a733e12580aeb22ff9bf46982f
2024-09-03T06:24:55.956Z  INFO cow_amm::cache: indexed new cow amm cow_amm=0xa54442606548bf1b627662a465a40b31b7e8e711
```