### PR TITLE
Move refund indexing back into background task

### DIFF
--- a/crates/autopilot/src/run.rs
+++ b/crates/autopilot/src/run.rs
@@ -41,6 +41,7 @@ use {
         baseline_solver::BaseTokens,
         code_fetching::CachedCodeFetcher,
         http_client::HttpClientFactory,
+        maintenance::ServiceMaintenance,
         metrics::LivenessChecking,
         order_quoting::{self, OrderQuoter},
         price_estimation::factory::{self, PriceEstimatorFactory},
@@ -510,7 +511,13 @@ pub async fn run(args: Arguments) {
         .await
         .expect("Should be able to initialize event updater. Database read issues?");
 
-        maintenance.with_ethflow(onchain_order_indexer, refund_event_handler);
+        maintenance.with_ethflow(onchain_order_indexer);
+        // refunds are not critical for correctness and can therefore be indexed
+        // sporadically in a background task
+        let service_maintainer = ServiceMaintenance::new(vec![Arc::new(refund_event_handler)]);
+        tokio::task::spawn(
+            service_maintainer.run_maintenance_on_new_block(eth.current_block().clone()),
+        );
     }
 
     let run = RunLoop {


### PR DESCRIPTION
# Description
Indexing refunds is not strictly necessary to have all relevant state for building the next auction. That's why it's okay to move that logic off of the critical path.
This should resolve the start up issues we've been seeing on arbitrum staging where we have to reindex lots of blocks because the blocktime is so fast and we don't do refunds regularly. However, we should still find a better way to store the blocks we already indexed to avoid these issues in general.

# Changes
Index refund events in a separate background task again.