### PR TITLE
Prefetch tokens quality cache

### DIFF
--- a/crates/autopilot/src/arguments.rs
+++ b/crates/autopilot/src/arguments.rs
@@ -72,31 +72,6 @@ pub struct Arguments {
     #[clap(long, env, use_value_delimiter = true)]
     pub unsupported_tokens: Vec<H160>,
 
-    /// The amount of time a classification of a token into good or
-    /// bad is valid for.
-    #[clap(
-        long,
-        env,
-        default_value = "10m",
-        value_parser = humantime::parse_duration,
-    )]
-    pub token_quality_cache_expiry: Duration,
-
-    /// How long before expiry the token quality cache should try to update the
-    /// token quality in the background. This is useful to make sure that token
-    /// quality for every cached token is usable at all times. This value
-    /// has to be smaller than `token_quality_cache_expiry`
-    /// This configuration also affects the period of the token quality
-    /// maintenance job. Maintenance period =
-    /// `token_quality_cache_prefetch_time` / 2
-    #[clap(
-        long,
-        env,
-        default_value = "2m",
-        value_parser = humantime::parse_duration,
-    )]
-    pub token_quality_cache_prefetch_time: Duration,
-
     /// The number of pairs that are automatically updated in the pool cache.
     #[clap(long, env, default_value = "200")]
     pub pool_cache_lru_size: NonZeroUsize,
@@ -269,8 +244,6 @@ impl std::fmt::Display for Arguments {
             skip_event_sync,
             allowed_tokens,
             unsupported_tokens,
-            token_quality_cache_expiry,
-            token_quality_cache_prefetch_time,
             pool_cache_lru_size,
             native_price_estimators,
             min_order_validity_period,
@@ -314,16 +287,6 @@ impl std::fmt::Display for Arguments {
         writeln!(f, "skip_event_sync: {}", skip_event_sync)?;
         writeln!(f, "allowed_tokens: {:?}", allowed_tokens)?;
         writeln!(f, "unsupported_tokens: {:?}", unsupported_tokens)?;
-        writeln!(
-            f,
-            "token_quality_cache_expiry: {:?}",
-            token_quality_cache_expiry
-        )?;
-        writeln!(
-            f,
-            "token_quality_cache_prefetch_time: {:?}",
-            token_quality_cache_prefetch_time
-        )?;
         writeln!(f, "pool_cache_lru_size: {}", pool_cache_lru_size)?;
         writeln!(f, "native_price_estimators: {}", native_price_estimators)?;
         writeln!(

--- a/crates/autopilot/src/arguments.rs
+++ b/crates/autopilot/src/arguments.rs
@@ -82,6 +82,21 @@ pub struct Arguments {
     )]
     pub token_quality_cache_expiry: Duration,
 
+    /// How long before expiry the token quality cache should try to update the
+    /// token quality in the background. This is useful to make sure that token
+    /// quality for every cached token is usable at all times. This value
+    /// has to be smaller than `token_quality_cache_expiry`
+    /// This configuration also affects the period of the token quality
+    /// maintenance job. Maintenance period =
+    /// `token_quality_cache_prefetch_time` / 2
+    #[clap(
+        long,
+        env,
+        default_value = "2m",
+        value_parser = humantime::parse_duration,
+    )]
+    pub token_quality_cache_prefetch_time: Duration,
+
     /// The number of pairs that are automatically updated in the pool cache.
     #[clap(long, env, default_value = "200")]
     pub pool_cache_lru_size: NonZeroUsize,
@@ -255,6 +270,7 @@ impl std::fmt::Display for Arguments {
             allowed_tokens,
             unsupported_tokens,
             token_quality_cache_expiry,
+            token_quality_cache_prefetch_time,
             pool_cache_lru_size,
             native_price_estimators,
             min_order_validity_period,
@@ -302,6 +318,11 @@ impl std::fmt::Display for Arguments {
             f,
             "token_quality_cache_expiry: {:?}",
             token_quality_cache_expiry
+        )?;
+        writeln!(
+            f,
+            "token_quality_cache_prefetch_time: {:?}",
+            token_quality_cache_prefetch_time
         )?;
         writeln!(f, "pool_cache_lru_size: {}", pool_cache_lru_size)?;
         writeln!(f, "native_price_estimators: {}", native_price_estimators)?;

--- a/crates/autopilot/src/run.rs
+++ b/crates/autopilot/src/run.rs
@@ -272,6 +272,10 @@ pub async fn run(args: Arguments) {
     .expect("failed to initialize token owner finders");
 
     let trace_call_detector = args.tracing_node_url.as_ref().map(|tracing_node_url| {
+        assert!(
+            args.token_quality_cache_expiry > args.token_quality_cache_prefetch_time,
+            "token quality cache prefetch time needs to be less than token quality cache expiry"
+        );
         CachingDetector::new(
             Box::new(TraceCallDetector {
                 web3: shared::ethrpc::web3(
@@ -284,6 +288,7 @@ pub async fn run(args: Arguments) {
                 settlement_contract: eth.contracts().settlement().address(),
             }),
             args.token_quality_cache_expiry,
+            args.token_quality_cache_prefetch_time,
         )
     });
     let bad_token_detector = Arc::new(

--- a/crates/autopilot/src/run.rs
+++ b/crates/autopilot/src/run.rs
@@ -272,10 +272,6 @@ pub async fn run(args: Arguments) {
     .expect("failed to initialize token owner finders");
 
     let trace_call_detector = args.tracing_node_url.as_ref().map(|tracing_node_url| {
-        assert!(
-            args.token_quality_cache_expiry > args.token_quality_cache_prefetch_time,
-            "token quality cache prefetch time needs to be less than token quality cache expiry"
-        );
         CachingDetector::new(
             Box::new(TraceCallDetector {
                 web3: shared::ethrpc::web3(
@@ -287,8 +283,8 @@ pub async fn run(args: Arguments) {
                 finder,
                 settlement_contract: eth.contracts().settlement().address(),
             }),
-            args.token_quality_cache_expiry,
-            args.token_quality_cache_prefetch_time,
+            args.shared.token_quality_cache_expiry,
+            args.shared.token_quality_cache_prefetch_time,
         )
     });
     let bad_token_detector = Arc::new(

--- a/crates/orderbook/src/arguments.rs
+++ b/crates/orderbook/src/arguments.rs
@@ -70,31 +70,6 @@ pub struct Arguments {
     )]
     pub max_limit_order_validity_period: Duration,
 
-    /// The amount of time in seconds a classification of a token into good or
-    /// bad is valid for.
-    #[clap(
-        long,
-        env,
-        default_value = "10m",
-        value_parser = humantime::parse_duration,
-    )]
-    pub token_quality_cache_expiry: Duration,
-
-    /// How long before expiry the token quality cache should try to update the
-    /// token quality in the background. This is useful to make sure that token
-    /// quality for every cached token is usable at all times. This value
-    /// has to be smaller than `token_quality_cache_expiry`
-    /// This configuration also affects the period of the token quality
-    /// maintenance job. Maintenance period =
-    /// `token_quality_cache_prefetch_time` / 2
-    #[clap(
-        long,
-        env,
-        default_value = "2m",
-        value_parser = humantime::parse_duration,
-    )]
-    pub token_quality_cache_prefetch_time: Duration,
-
     /// List of token addresses to be ignored throughout service
     #[clap(long, env, use_value_delimiter = true)]
     pub unsupported_tokens: Vec<H160>,
@@ -177,8 +152,6 @@ impl std::fmt::Display for Arguments {
             min_order_validity_period,
             max_order_validity_period,
             max_limit_order_validity_period,
-            token_quality_cache_expiry,
-            token_quality_cache_prefetch_time,
             unsupported_tokens,
             banned_users,
             allowed_tokens,
@@ -219,16 +192,6 @@ impl std::fmt::Display for Arguments {
             f,
             "max_limit_order_validity_period: {:?}",
             max_limit_order_validity_period
-        )?;
-        writeln!(
-            f,
-            "token_quality_cache_expiry: {:?}",
-            token_quality_cache_expiry
-        )?;
-        writeln!(
-            f,
-            "token_quality_cache_prefetch_time: {:?}",
-            token_quality_cache_prefetch_time
         )?;
         writeln!(f, "unsupported_tokens: {:?}", unsupported_tokens)?;
         writeln!(f, "banned_users: {:?}", banned_users)?;

--- a/crates/orderbook/src/arguments.rs
+++ b/crates/orderbook/src/arguments.rs
@@ -80,6 +80,21 @@ pub struct Arguments {
     )]
     pub token_quality_cache_expiry: Duration,
 
+    /// How long before expiry the token quality cache should try to update the
+    /// token quality in the background. This is useful to make sure that token
+    /// quality for every cached token is usable at all times. This value
+    /// has to be smaller than `token_quality_cache_expiry`
+    /// This configuration also affects the period of the token quality
+    /// maintenance job. Maintenance period =
+    /// `token_quality_cache_prefetch_time` / 2
+    #[clap(
+        long,
+        env,
+        default_value = "2m",
+        value_parser = humantime::parse_duration,
+    )]
+    pub token_quality_cache_prefetch_time: Duration,
+
     /// List of token addresses to be ignored throughout service
     #[clap(long, env, use_value_delimiter = true)]
     pub unsupported_tokens: Vec<H160>,
@@ -163,6 +178,7 @@ impl std::fmt::Display for Arguments {
             max_order_validity_period,
             max_limit_order_validity_period,
             token_quality_cache_expiry,
+            token_quality_cache_prefetch_time,
             unsupported_tokens,
             banned_users,
             allowed_tokens,
@@ -208,6 +224,11 @@ impl std::fmt::Display for Arguments {
             f,
             "token_quality_cache_expiry: {:?}",
             token_quality_cache_expiry
+        )?;
+        writeln!(
+            f,
+            "token_quality_cache_prefetch_time: {:?}",
+            token_quality_cache_prefetch_time
         )?;
         writeln!(f, "unsupported_tokens: {:?}", unsupported_tokens)?;
         writeln!(f, "banned_users: {:?}", banned_users)?;

--- a/crates/orderbook/src/run.rs
+++ b/crates/orderbook/src/run.rs
@@ -210,10 +210,6 @@ pub async fn run(args: Arguments) {
     .expect("failed to initialize token owner finders");
 
     let trace_call_detector = args.tracing_node_url.as_ref().map(|tracing_node_url| {
-        assert!(
-            args.token_quality_cache_expiry > args.token_quality_cache_prefetch_time,
-            "token quality cache prefetch time needs to be less than token quality cache expiry"
-        );
         CachingDetector::new(
             Box::new(TraceCallDetector {
                 web3: shared::ethrpc::web3(
@@ -225,8 +221,8 @@ pub async fn run(args: Arguments) {
                 finder,
                 settlement_contract: settlement_contract.address(),
             }),
-            args.token_quality_cache_expiry,
-            args.token_quality_cache_prefetch_time,
+            args.shared.token_quality_cache_expiry,
+            args.shared.token_quality_cache_prefetch_time,
         )
     });
     let bad_token_detector = Arc::new(

--- a/crates/orderbook/src/run.rs
+++ b/crates/orderbook/src/run.rs
@@ -210,6 +210,10 @@ pub async fn run(args: Arguments) {
     .expect("failed to initialize token owner finders");
 
     let trace_call_detector = args.tracing_node_url.as_ref().map(|tracing_node_url| {
+        assert!(
+            args.token_quality_cache_expiry > args.token_quality_cache_prefetch_time,
+            "token quality cache prefetch time needs to be less than token quality cache expiry"
+        );
         CachingDetector::new(
             Box::new(TraceCallDetector {
                 web3: shared::ethrpc::web3(
@@ -222,6 +226,7 @@ pub async fn run(args: Arguments) {
                 settlement_contract: settlement_contract.address(),
             }),
             args.token_quality_cache_expiry,
+            args.token_quality_cache_prefetch_time,
         )
     });
     let bad_token_detector = Arc::new(

--- a/crates/shared/src/arguments.rs
+++ b/crates/shared/src/arguments.rs
@@ -237,7 +237,7 @@ pub struct Arguments {
     #[clap(long, env)]
     pub balancer_v2_vault_address: Option<H160>,
 
-    /// The amount of time in seconds a classification of a token into good or
+    /// The amount of time a classification of a token into good or
     /// bad is valid for.
     #[clap(
         long,

--- a/crates/shared/src/arguments.rs
+++ b/crates/shared/src/arguments.rs
@@ -236,6 +236,31 @@ pub struct Arguments {
     /// Override address of the balancer vault contract.
     #[clap(long, env)]
     pub balancer_v2_vault_address: Option<H160>,
+
+    /// The amount of time in seconds a classification of a token into good or
+    /// bad is valid for.
+    #[clap(
+        long,
+        env,
+        default_value = "10m",
+        value_parser = humantime::parse_duration,
+    )]
+    pub token_quality_cache_expiry: Duration,
+
+    /// How long before expiry the token quality cache should try to update the
+    /// token quality in the background. This is useful to make sure that token
+    /// quality for every cached token is usable at all times. This value
+    /// has to be smaller than `token_quality_cache_expiry`
+    /// This configuration also affects the period of the token quality
+    /// maintenance job. Maintenance period =
+    /// `token_quality_cache_prefetch_time` / 2
+    #[clap(
+        long,
+        env,
+        default_value = "2m",
+        value_parser = humantime::parse_duration,
+    )]
+    pub token_quality_cache_prefetch_time: Duration,
 }
 
 pub fn display_secret_option<T>(
@@ -336,6 +361,8 @@ impl Display for Arguments {
             custom_univ2_baseline_sources,
             liquidity_fetcher_max_age_update,
             max_pools_to_initialize_cache,
+            token_quality_cache_expiry,
+            token_quality_cache_prefetch_time,
         } = self;
 
         write!(f, "{}", ethrpc)?;
@@ -403,6 +430,16 @@ impl Display for Arguments {
             f,
             "max_pools_to_initialize_cache: {}",
             max_pools_to_initialize_cache
+        )?;
+        writeln!(
+            f,
+            "token_quality_cache_expiry: {:?}",
+            token_quality_cache_expiry
+        )?;
+        writeln!(
+            f,
+            "token_quality_cache_prefetch_time: {:?}",
+            token_quality_cache_prefetch_time
         )?;
 
         Ok(())

--- a/crates/shared/src/bad_token/cache.rs
+++ b/crates/shared/src/bad_token/cache.rs
@@ -6,44 +6,50 @@ use {
     std::{
         collections::HashMap,
         ops::Div,
-        sync::{Arc, Mutex},
+        sync::Arc,
         time::{Duration, Instant},
     },
+    tokio::sync::RwLock,
 };
 
 pub struct CachingDetector {
     inner: Box<dyn BadTokenDetecting>,
-    // std mutex is fine because we don't hold lock across await.
-    cache: Mutex<HashMap<H160, (Instant, TokenQuality)>>,
+    cache: RwLock<HashMap<H160, (Instant, TokenQuality)>>,
     cache_expiry: Duration,
+    prefetch_time: Duration,
 }
 
 #[async_trait::async_trait]
 impl BadTokenDetecting for CachingDetector {
     async fn detect(&self, token: H160) -> Result<TokenQuality> {
-        if let Some(quality) = self.get_from_cache(&token, Instant::now()) {
+        if let Some(quality) = self.get_from_cache(&token, Instant::now()).await {
             return Ok(quality);
         }
 
         let result = self.inner.detect(token).await?;
-        self.insert_into_cache(token, result.clone());
+        self.insert_into_cache(token, result.clone()).await;
         Ok(result)
     }
 }
 
 impl CachingDetector {
-    pub fn new(inner: Box<dyn BadTokenDetecting>, cache_expiry: Duration) -> Arc<Self> {
+    pub fn new(
+        inner: Box<dyn BadTokenDetecting>,
+        cache_expiry: Duration,
+        prefetch_time: Duration,
+    ) -> Arc<Self> {
         let detector = Arc::new(Self {
             inner,
             cache: Default::default(),
             cache_expiry,
+            prefetch_time,
         });
         detector.clone().spawn_maintenance_task();
         detector
     }
 
-    fn get_from_cache(&self, token: &H160, now: Instant) -> Option<TokenQuality> {
-        match self.cache.lock().unwrap().get(token) {
+    async fn get_from_cache(&self, token: &H160, now: Instant) -> Option<TokenQuality> {
+        match self.cache.read().await.get(token) {
             Some((instant, quality))
                 if now.checked_duration_since(*instant).unwrap_or_default() < self.cache_expiry =>
             {
@@ -53,24 +59,29 @@ impl CachingDetector {
         }
     }
 
-    fn insert_into_cache(&self, token: H160, quality: TokenQuality) {
+    async fn insert_into_cache(&self, token: H160, quality: TokenQuality) {
         self.cache
-            .lock()
-            .unwrap()
+            .write()
+            .await
             .insert(token, (Instant::now(), quality));
     }
 
-    fn insert_many_into_cache(&self, tokens: impl Iterator<Item = (H160, TokenQuality)>) {
-        let mut cache = self.cache.lock().unwrap();
+    async fn insert_many_into_cache(&self, tokens: impl Iterator<Item = (H160, TokenQuality)>) {
+        let mut cache = self.cache.write().await;
         let now = Instant::now();
-        for (token, quality) in tokens {
+        tokens.into_iter().for_each(|(token, quality)| {
             cache.insert(token, (now, quality));
-        }
+        });
     }
 
     fn spawn_maintenance_task(self: Arc<Self>) {
-        let cache_expiry = self.cache_expiry;
-        let maintenance_timeout = cache_expiry.div(10).max(Duration::from_secs(60));
+        // We need to prefetch the token quality the `prefetch_time` before the cache
+        // expires
+        let prefetch_time_to_expire = self.cache_expiry - self.prefetch_time;
+        // The maintenance period has to be at least double of the prefetch time in
+        // order to guarantee that the prefetch time is executed before the token
+        // quality expires. This is because of the Nyquist–Shannon sampling theorem.
+        let maintenance_timeout = self.prefetch_time.div(2);
         let detector = Arc::clone(&self);
 
         tokio::task::spawn(async move {
@@ -78,13 +89,13 @@ impl CachingDetector {
                 let start = Instant::now();
 
                 let expired_tokens: Vec<H160> = {
-                    let cache = detector.cache.lock().unwrap();
+                    let cache = detector.cache.read().await;
                     let now = Instant::now();
                     cache
                         .iter()
                         .filter_map(|(token, (instant, _))| {
                             (now.checked_duration_since(*instant).unwrap_or_default()
-                                >= cache_expiry)
+                                >= prefetch_time_to_expire)
                                 .then_some(*token)
                         })
                         .collect()
@@ -110,7 +121,7 @@ impl CachingDetector {
                 .into_iter()
                 .flatten();
 
-                detector.insert_many_into_cache(results);
+                detector.insert_many_into_cache(results).await;
 
                 let remaining_sleep = maintenance_timeout
                     .checked_sub(start.elapsed())
@@ -134,7 +145,11 @@ mod tests {
             .times(1)
             .returning(|_| Ok(TokenQuality::Good));
 
-        let detector = CachingDetector::new(Box::new(inner), Duration::from_secs(1));
+        let detector = CachingDetector::new(
+            Box::new(inner),
+            Duration::from_secs(1),
+            Duration::from_millis(200),
+        );
 
         for _ in 0..2 {
             let result = detector
@@ -149,18 +164,74 @@ mod tests {
     async fn cache_expires() {
         let inner = MockBadTokenDetecting::new();
         let token = H160::from_low_u64_le(0);
-        let detector = CachingDetector::new(Box::new(inner), Duration::from_secs(2));
+        let detector = CachingDetector::new(
+            Box::new(inner),
+            Duration::from_secs(2),
+            Duration::from_millis(200),
+        );
         let now = Instant::now();
         detector
             .cache
-            .lock()
-            .unwrap()
+            .write()
+            .await
             .insert(token, (now, TokenQuality::Good));
         assert!(detector
             .get_from_cache(&token, now + Duration::from_secs(1))
+            .await
             .is_some());
         assert!(detector
             .get_from_cache(&token, now + Duration::from_secs(3))
+            .await
             .is_none());
+    }
+
+    #[tokio::test]
+    async fn cache_prefetch_works() {
+        let mut inner = MockBadTokenDetecting::new();
+        // we expect it to be called twice: first time + prefetch time
+        let mut seq = mockall::Sequence::new();
+        // First call returns Ok(TokenQuality::Good)
+        inner
+            .expect_detect()
+            .times(1)
+            .in_sequence(&mut seq)
+            .returning(|_| Ok(TokenQuality::Good));
+        // Second call returns Ok(TokenQuality::Bad)
+        inner
+            .expect_detect()
+            .times(1)
+            .in_sequence(&mut seq)
+            .returning(|_| {
+                Ok(TokenQuality::Bad {
+                    reason: "bad token".to_string(),
+                })
+            });
+
+        let detector = CachingDetector::new(
+            Box::new(inner),
+            Duration::from_millis(200),
+            Duration::from_millis(50),
+        );
+
+        let result = detector
+            .detect(H160::from_low_u64_le(0))
+            .now_or_never()
+            .unwrap();
+        assert!(result.unwrap().is_good());
+        // Check that the result is the same because we haven't reached the prefetch
+        // time yet
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        let result = detector
+            .detect(H160::from_low_u64_le(0))
+            .now_or_never()
+            .unwrap();
+        assert!(result.unwrap().is_good());
+        // We wait so the prefetch fetches the data
+        tokio::time::sleep(Duration::from_millis(70)).await;
+        let result = detector
+            .detect(H160::from_low_u64_le(0))
+            .now_or_never()
+            .unwrap();
+        assert!(!result.unwrap().is_good());
     }
 }

--- a/crates/shared/src/bad_token/cache.rs
+++ b/crates/shared/src/bad_token/cache.rs
@@ -38,6 +38,10 @@ impl CachingDetector {
         cache_expiry: Duration,
         prefetch_time: Duration,
     ) -> Arc<Self> {
+        assert!(
+            cache_expiry > prefetch_time,
+            "token quality cache prefetch time needs to be less than token quality cache expiry"
+        );
         let detector = Arc::new(Self {
             inner,
             cache: Default::default(),
@@ -78,9 +82,10 @@ impl CachingDetector {
         // We need to prefetch the token quality the `prefetch_time` before the cache
         // expires
         let prefetch_time_to_expire = self.cache_expiry - self.prefetch_time;
-        // The maintenance period has to be at least double of the prefetch time in
-        // order to guarantee that the prefetch time is executed before the token
-        // quality expires. This is because of the Nyquist–Shannon sampling theorem.
+        // The maintenance frequency has to be at least double of the prefetch time
+        // frequency in order to guarantee that the prefetch time is executed
+        // before the token quality expires. This is because of the
+        // Nyquist–Shannon sampling theorem.
         let maintenance_timeout = self.prefetch_time.div(2);
         let detector = Arc::clone(&self);
 


### PR DESCRIPTION
# Description
Implement a prefetch for the token quality cache (similar to what we do in the native prices cache). This ensures that we always keep the cache updated.

# Changes
- Change the `std::sync::Mutex` for a `tokio::sync::RwLock`, improving the performance
- Add to the orderbook and autopilot configuration the field `token_quality_cache_prefetch_time` in order to configure the prefetch time for token quality cache
- Change the `maintenance_timeout` in order to ensure its sampling time against `token_quality_cache_prefetch_time`


## How to test
1. Unit test
