### PR TITLE
Implement manual batching of balance queries

### DIFF
--- a/crates/shared/src/account_balances/simulation.rs
+++ b/crates/shared/src/account_balances/simulation.rs
@@ -63,9 +63,9 @@ impl Balances {
                 .collect(),
         );
         contracts::storage_accessible::call(
-            call_builder.tx.to.expect("call builder populates \"to\""),
+            call_builder.tx.to.expect("builder populates to"),
             contracts::bytecode!(contracts::support::Balances),
-            call_builder.tx.data.expect("call builder populates \"data\""),
+            call_builder.tx.data.expect("builder populates data"),
         )
     }
 


### PR DESCRIPTION
# Description
When we parallelized all auction building stages in https://github.com/cowprotocol/services/pull/2916 the total runtime of the stages actually increased slightly.
The current hypothesis is that the underlying RPC batching logic now batches very fast balance queries with slow signature validation queries which then causes the responses of the fast queries to be delayed significantly.

Overall this solution (manually implementing ugly batching logic) is not really scalable in terms of code complexity so I'm actually not super convinced anymore that it's really worth it (I thought it would be more straight forward to implement this).
Will think a bit more about how to best deal with these very specific optimizations.

# Changes
Manually batch balance fetch queries.

## How to test
Correctness should be validated by e2e tests and performance should be tested by running a hotfixed deployment in staging or prod to measure the real word improvements.