### PR TITLE
Get JIT orders by tx

### DIFF
--- a/crates/database/src/orders.rs
+++ b/crates/database/src/orders.rs
@@ -574,7 +574,7 @@ pub async fn single_full_order(
 // this, a tx hash is no longer enough to uniquely identify a settlement so the
 // "orders for tx hash" route needs to change in some way like taking block
 // number and log index directly.
-const SETTLEMENT_LOG_INDICES: &str = r#"
+pub const SETTLEMENT_LOG_INDICES: &str = r#"
 WITH
     -- The log index in this query is the log index from the settlement event, which comes after the trade events.
     settlement AS (

--- a/crates/e2e/tests/e2e/jit_orders.rs
+++ b/crates/e2e/tests/e2e/jit_orders.rs
@@ -202,8 +202,5 @@ async fn single_limit_order_test(web3: Web3) {
         .get_orders_for_tx(&orders[0].tx_hash.unwrap())
         .await
         .unwrap();
-    assert!(orders_by_tx
-        .iter()
-        .find(|o| o.metadata.uid == jit_order_uid)
-        .is_some());
+    assert!(orders_by_tx.iter().any(|o| o.metadata.uid == jit_order_uid));
 }

--- a/crates/e2e/tests/e2e/jit_orders.rs
+++ b/crates/e2e/tests/e2e/jit_orders.rs
@@ -204,6 +204,6 @@ async fn single_limit_order_test(web3: Web3) {
         .unwrap();
     assert!(orders_by_tx
         .iter()
-        .map(|o| o.metadata.uid)
-        .any(|uid| uid == jit_order_uid));
+        .find(|o| o.metadata.uid == jit_order_uid)
+        .is_some());
 }

--- a/crates/e2e/tests/e2e/jit_orders.rs
+++ b/crates/e2e/tests/e2e/jit_orders.rs
@@ -193,9 +193,17 @@ async fn single_limit_order_test(web3: Web3) {
     .await
     .unwrap();
 
-    // jit order can be found on /get_order
+    // jit order can be found on /api/v1/orders
     services.get_order(&jit_order_uid).await.unwrap();
-    // jit order can be found on /get_trades
+    // jit order can be found on /api/v1/trades
     let orders = services.get_trades(&jit_order_uid).await.unwrap();
-    assert_eq!(orders.len(), 1);
+    // jit order can be found on /api/v1/transactions/{tx_hash}/orders
+    let orders_by_tx = services
+        .get_orders_for_tx(&orders[0].tx_hash.unwrap())
+        .await
+        .unwrap();
+    assert!(orders_by_tx
+        .iter()
+        .map(|o| o.metadata.uid)
+        .any(|uid| uid == jit_order_uid));
 }

--- a/crates/orderbook/src/database/orders.rs
+++ b/crates/orderbook/src/database/orders.rs
@@ -324,7 +324,7 @@ impl OrderStoring for Postgres {
 
     async fn orders_for_tx(&self, tx_hash: &H256) -> Result<Vec<Order>> {
         tokio::try_join!(
-            self.regular_orders_for_tx(tx_hash),
+            self.user_order_for_tx(tx_hash),
             self.jit_orders_for_tx(tx_hash)
         )
         .map(|(mut user_orders, jit_orders)| {
@@ -374,10 +374,10 @@ impl OrderStoring for Postgres {
 
 impl Postgres {
     /// Retrieve all user posted orders for a given transaction.
-    pub async fn regular_orders_for_tx(&self, tx_hash: &H256) -> Result<Vec<Order>> {
+    pub async fn user_order_for_tx(&self, tx_hash: &H256) -> Result<Vec<Order>> {
         let _timer = super::Metrics::get()
             .database_queries
-            .with_label_values(&["regular_orders_for_tx"])
+            .with_label_values(&["user_order_for_tx"])
             .start_timer();
 
         let mut ex = self.pool.acquire().await?;

--- a/crates/orderbook/src/database/orders.rs
+++ b/crates/orderbook/src/database/orders.rs
@@ -323,28 +323,14 @@ impl OrderStoring for Postgres {
     }
 
     async fn orders_for_tx(&self, tx_hash: &H256) -> Result<Vec<Order>> {
-        let _timer = super::Metrics::get()
-            .database_queries
-            .with_label_values(&["orders_for_tx"])
-            .start_timer();
-
-        let mut ex = self.pool.acquire().await?;
-        let jit_orders = database::jit_orders::get_by_tx(&mut ex, &ByteArray(tx_hash.0))
-            .await?
-            .into_iter()
-            .map(full_order_into_model_order)
-            .collect::<Result<Vec<_>>>()?;
-        database::orders::full_orders_in_tx(&mut ex, &ByteArray(tx_hash.0))
-            .map(|result| match result {
-                Ok(order) => full_order_into_model_order(order),
-                Err(err) => Err(anyhow::Error::from(err)),
-            })
-            .try_collect()
-            .await
-            .map(|mut orders: Vec<Order>| {
-                orders.extend(jit_orders);
-                orders
-            })
+        tokio::try_join!(
+            self.regular_orders_for_tx(tx_hash),
+            self.jit_orders_for_tx(tx_hash)
+        )
+        .map(|(mut user_orders, jit_orders)| {
+            user_orders.extend(jit_orders);
+            user_orders
+        })
     }
 
     async fn user_orders(
@@ -383,6 +369,40 @@ impl OrderStoring for Postgres {
         database::order_events::get_latest(&mut ex, &ByteArray(order_uid.0))
             .await
             .context("order_events::get_latest")
+    }
+}
+
+impl Postgres {
+    /// Retrieve all user posted orders for a given transaction.
+    pub async fn regular_orders_for_tx(&self, tx_hash: &H256) -> Result<Vec<Order>> {
+        let _timer = super::Metrics::get()
+            .database_queries
+            .with_label_values(&["regular_orders_for_tx"])
+            .start_timer();
+
+        let mut ex = self.pool.acquire().await?;
+        database::orders::full_orders_in_tx(&mut ex, &ByteArray(tx_hash.0))
+            .map(|result| match result {
+                Ok(order) => full_order_into_model_order(order),
+                Err(err) => Err(anyhow::Error::from(err)),
+            })
+            .try_collect()
+            .await
+    }
+
+    /// Retrieve all JIT orders for a given transaction.
+    pub async fn jit_orders_for_tx(&self, tx_hash: &H256) -> Result<Vec<Order>> {
+        let _timer = super::Metrics::get()
+            .database_queries
+            .with_label_values(&["jit_orders_for_tx"])
+            .start_timer();
+
+        let mut ex = self.pool.acquire().await?;
+        database::jit_orders::get_by_tx(&mut ex, &ByteArray(tx_hash.0))
+            .await?
+            .into_iter()
+            .map(full_order_into_model_order)
+            .collect::<Result<Vec<_>>>()
     }
 }
 


### PR DESCRIPTION
# Description
A follow up for https://github.com/cowprotocol/services/pull/2920

Implements [https://api.cow.fi/mainnet/api/v1/transactions/{tx_hash}/orders](https://api.cow.fi/docs/#/default/get_api_v1_transactions__txHash__orders) for JIT orders.

# Changes
<!-- List of detailed changes (how the change is accomplished) -->

- [ ] implemented `get_by_tx` database function to retrieve all jit orders in a transaction
- [ ] expanded orderbook api function `orders_for_tx` to return jit orders as well

## How to test
updated e2e test

<!--
## Related Issues

Fixes #
-->