### PR TITLE
Cancelled orders are not allowed to change status anymore

### DIFF
--- a/crates/database/src/order_events.rs
+++ b/crates/database/src/order_events.rs
@@ -64,7 +64,7 @@ pub async fn insert_order_event(
         WHERE NOT EXISTS (
             SELECT 1
             FROM cte
-            WHERE label = $3
+            WHERE label = $3 OR label = 'cancelled'
         )
     "#;
     sqlx::query(QUERY)


### PR DESCRIPTION
# Description
Once cancelled, orders are not allowed to change their status anymore (this actually makes sense).

OTOS, this fixes flaky `local_node_order_cancellation` test failing, but in a hacky way. So, the e2e test fails because:

1. Order gets created
2. Order becomes a part of Auction X
3. Order gets cancelled - this updates the db orders table and db event store table
4. Runloop does another iteration with Auction X overwriting db event store table with Ready order status, since Order is still in Auction X.
5. Auction Y is cut where the order is actually seen as cancelled so it's missing, this triggers the continuation of e2e test.
6. e2e asks for `get_order_status` where Ready status is read as the last event stored.

So this fix actually prevents step 4.