### PR TITLE
Exclude orderbook orders from jit orders

### DIFF
--- a/crates/database/src/jit_orders.rs
+++ b/crates/database/src/jit_orders.rs
@@ -58,7 +58,11 @@ pub async fn get_by_tx(
         t.block_number = (SELECT block_number FROM settlement) AND
         -- BETWEEN is inclusive
         t.log_index BETWEEN (SELECT * from previous_settlement) AND (SELECT log_index FROM \
-         settlement) ",
+         settlement) 
+        AND NOT EXISTS (
+            SELECT 1 FROM orders ord
+            WHERE ord.uid = o.uid)
+        ",
     );
     sqlx::query_as::<_, JitOrderWithExecutions>(QUERY)
         .bind(tx_hash)


### PR DESCRIPTION
# Description
A follow up for https://github.com/cowprotocol/services/pull/2941 that handles an edge case:

`jit_orders` database table is potentially containing:
1. normal jit orders (orders that do not exist in orderbook)
2. orders that exist in the orderbook but do not exist in the auction (so called out-of-auction settled user trades).

This PR excludes (2) so that API function `get_orders_for_tx` doesn't return duplicated values for (2), since those exist in both `orders` and `jit_orders` tables.

## How to test
Existing e2e tests.