### PR TITLE
Separate `solvable_orders_after` query

### DIFF
--- a/crates/autopilot/src/infra/persistence/mod.rs
+++ b/crates/autopilot/src/infra/persistence/mod.rs
@@ -420,16 +420,13 @@ impl Persistence {
             .await?;
 
         // Find order uids for orders that were updated after the given block.
-        let updated_order_uids: Vec<database::OrderUid> = {
+        let updated_order_uids = {
             let _timer = Metrics::get()
                 .database_queries
                 .with_label_values(&["updated_order_uids"])
                 .start_timer();
 
-            database::orders::updated_order_uids_after(&mut tx, after_block)
-                .map_ok(|uid| uid.0)
-                .try_collect()
-                .await?
+            database::orders::updated_order_uids_after(&mut tx, after_block).await?
         };
 
         // Fetch the orders that were updated after the given block and were created or

--- a/crates/autopilot/src/infra/persistence/mod.rs
+++ b/crates/autopilot/src/infra/persistence/mod.rs
@@ -437,7 +437,7 @@ impl Persistence {
                 .with_label_values(&["open_orders_after"])
                 .start_timer();
 
-            database::orders::open_orders_by_time_and_uids(
+            database::orders::open_orders_by_time_or_uids(
                 &mut tx,
                 &updated_order_uids,
                 after_timestamp,

--- a/crates/autopilot/src/infra/persistence/mod.rs
+++ b/crates/autopilot/src/infra/persistence/mod.rs
@@ -419,6 +419,19 @@ impl Persistence {
             .execute(tx.deref_mut())
             .await?;
 
+        // Find order uids for orders that were updated after the given block.
+        let updated_order_uids: Vec<database::OrderUid> = {
+            let _timer = Metrics::get()
+                .database_queries
+                .with_label_values(&["updated_order_uids"])
+                .start_timer();
+
+            database::orders::updated_order_uids_after(&mut tx, after_block)
+                .map_ok(|uid| uid.0)
+                .try_collect()
+                .await?
+        };
+
         // Fetch the orders that were updated after the given block and were created or
         // cancelled after the given timestamp.
         let next_orders: HashMap<domain::OrderUid, model::order::Order> = {
@@ -427,14 +440,18 @@ impl Persistence {
                 .with_label_values(&["open_orders_after"])
                 .start_timer();
 
-            database::orders::open_orders_after(&mut tx, after_block, after_timestamp)
-                .map(|result| match result {
-                    Ok(order) => full_order_into_model_order(order)
-                        .map(|order| (domain::OrderUid(order.metadata.uid.0), order)),
-                    Err(err) => Err(anyhow::Error::from(err)),
-                })
-                .try_collect()
-                .await?
+            database::orders::open_orders_by_time_and_uids(
+                &mut tx,
+                &updated_order_uids,
+                after_timestamp,
+            )
+            .map(|result| match result {
+                Ok(order) => full_order_into_model_order(order)
+                    .map(|order| (domain::OrderUid(order.metadata.uid.0), order)),
+                Err(err) => Err(anyhow::Error::from(err)),
+            })
+            .try_collect()
+            .await?
         };
 
         // Fetch quotes for new orders and also update them for the cached ones since

--- a/crates/database/src/byte_array.rs
+++ b/crates/database/src/byte_array.rs
@@ -13,7 +13,7 @@ use {
 
 /// Wrapper type for fixed size byte arrays compatible with sqlx's Postgres
 /// implementation.
-#[derive(Clone, Copy, Eq, PartialEq, Hash)]
+#[derive(Clone, Copy, Eq, PartialEq, Hash, sqlx::FromRow)]
 pub struct ByteArray<const N: usize>(pub [u8; N]);
 
 impl<const N: usize> Debug for ByteArray<N> {

--- a/crates/database/src/orders.rs
+++ b/crates/database/src/orders.rs
@@ -687,43 +687,22 @@ pub fn solvable_orders(
     sqlx::query_as(OPEN_ORDERS).bind(min_valid_to).fetch(ex)
 }
 
-pub fn open_orders_after(
-    ex: &mut PgConnection,
-    after_block: i64,
+pub fn open_orders_by_time_and_uids<'a>(
+    ex: &'a mut PgConnection,
+    uids: &'a [OrderUid],
     after_timestamp: DateTime<Utc>,
-) -> BoxStream<'_, Result<FullOrder, sqlx::Error>> {
-    const UPDATED_UIDS_QUERY: &str = r#"
-WITH updated_uids AS (
-    SELECT DISTINCT order_uid FROM (
-        SELECT order_uid FROM trades WHERE block_number > $1
-        UNION
-        SELECT order_uid FROM order_execution WHERE block_number > $1
-        UNION
-        SELECT order_uid FROM invalidations WHERE block_number > $1
-        UNION
-        SELECT uid AS order_uid FROM onchain_order_invalidations WHERE block_number > $1
-        UNION
-        SELECT uid AS order_uid FROM onchain_placed_orders WHERE block_number > $1
-        UNION
-        SELECT order_uid FROM ethflow_refunds WHERE block_number > $1
-        UNION
-        SELECT order_uid FROM presignature_events WHERE block_number > $1
-    )
-)
-    "#;
-
+) -> BoxStream<'a, Result<FullOrder, sqlx::Error>> {
     #[rustfmt::skip]
     const OPEN_ORDERS_AFTER: &str = const_format::concatcp!(
-        UPDATED_UIDS_QUERY,
-        " SELECT ", ORDERS_SELECT,
+        "SELECT ", ORDERS_SELECT,
         " FROM ", ORDERS_FROM,
         " LEFT OUTER JOIN ethflow_orders eth_o on eth_o.uid = o.uid ",
-        " WHERE (o.creation_timestamp > $2 OR o.cancellation_timestamp > $2 OR o.uid IN (SELECT order_uid FROM updated_uids))",
+        " WHERE (o.creation_timestamp > $1 OR o.cancellation_timestamp > $1 OR o.uid = ANY($2))",
     );
 
     sqlx::query_as(OPEN_ORDERS_AFTER)
-        .bind(after_block)
         .bind(after_timestamp)
+        .bind(uids)
         .fetch(ex)
 }
 
@@ -793,6 +772,34 @@ pub async fn user_orders_with_quote(
         .bind(owner)
         .fetch_all(ex)
         .await
+}
+
+#[derive(Debug, PartialEq, Eq, sqlx::FromRow)]
+pub struct DbOrderUid(pub OrderUid);
+
+pub fn updated_order_uids_after(
+    ex: &mut PgConnection,
+    after_block: i64,
+) -> BoxStream<'_, Result<DbOrderUid, sqlx::Error>> {
+    const QUERY: &str = r#"
+SELECT DISTINCT order_uid FROM (
+    SELECT order_uid FROM trades WHERE block_number > $1
+    UNION
+    SELECT order_uid FROM order_execution WHERE block_number > $1
+    UNION
+    SELECT order_uid FROM invalidations WHERE block_number > $1
+    UNION
+    SELECT uid AS order_uid FROM onchain_order_invalidations WHERE block_number > $1
+    UNION
+    SELECT uid AS order_uid FROM onchain_placed_orders WHERE block_number > $1
+    UNION
+    SELECT order_uid FROM ethflow_refunds WHERE block_number > $1
+    UNION
+    SELECT order_uid FROM presignature_events WHERE block_number > $1
+) AS updated_orders
+"#;
+
+    sqlx::query_as(QUERY).bind(after_block).fetch(ex)
 }
 
 #[cfg(test)]
@@ -1581,17 +1588,17 @@ mod tests {
 
     #[tokio::test]
     #[ignore]
-    async fn postgres_open_orders_after() {
+    async fn postgres_open_orders_by_time_and_uids() {
         let mut db = PgConnection::connect("postgresql://").await.unwrap();
         let mut db = db.begin().await.unwrap();
         crate::clear_DANGER_(&mut db).await.unwrap();
 
-        async fn get_open_orders_after(
+        async fn get_open_orders_by_time_and_uids(
             ex: &mut PgConnection,
-            after_block: i64,
             after_timestamp: DateTime<Utc>,
+            uids: &[OrderUid],
         ) -> HashSet<OrderUid> {
-            open_orders_after(ex, after_block, after_timestamp)
+            open_orders_by_time_and_uids(ex, uids, after_timestamp)
                 .map_ok(|o| o.uid)
                 .try_collect()
                 .await
@@ -1617,264 +1624,56 @@ mod tests {
             ..Default::default()
         };
         insert_order(&mut db, &order_c).await.unwrap();
-        let order_d = Order {
-            uid: ByteArray([4u8; 56]),
-            cancellation_timestamp: Some(now + Duration::seconds(25)),
-            ..Default::default()
-        };
-        insert_order(&mut db, &order_d).await.unwrap();
-        let order_e = Order {
-            uid: ByteArray([5u8; 56]),
-            cancellation_timestamp: Some(now + Duration::seconds(25)),
-            ..Default::default()
-        };
-        insert_order(&mut db, &order_e).await.unwrap();
 
         // Check fetching by timestamp only.
         // Early timestamp should cover all the orders.
         assert_eq!(
-            get_open_orders_after(&mut db, Default::default(), now - Duration::seconds(1)).await,
-            hashset![
-                ByteArray([1u8; 56]),
-                ByteArray([2u8; 56]),
-                ByteArray([3u8; 56]),
-                ByteArray([4u8; 56]),
-                ByteArray([5u8; 56]),
-            ]
-        );
-        // First order created at `now` timestamp.
-        assert_eq!(
-            get_open_orders_after(&mut db, Default::default(), now).await,
-            hashset![
-                ByteArray([2u8; 56]),
-                ByteArray([3u8; 56]),
-                ByteArray([4u8; 56]),
-                ByteArray([5u8; 56])
-            ]
-        );
-        // First to orders created before `now + 10s` timestamp.
-        assert_eq!(
-            get_open_orders_after(&mut db, Default::default(), now + Duration::seconds(10)).await,
-            hashset![
-                ByteArray([3u8; 56]),
-                ByteArray([4u8; 56]),
-                ByteArray([5u8; 56])
-            ]
-        );
-
-        // Check fetching by block number.
-        let future_timestamp = now + Duration::seconds(50000);
-        // trades table
-        let (index_a, event_a) = {
-            (
-                EventIndex {
-                    block_number: 1,
-                    ..Default::default()
-                },
-                Trade {
-                    order_uid: ByteArray([1u8; 56]),
-                    sell_amount_including_fee: BigDecimal::from(10),
-                    buy_amount: BigDecimal::from(100),
-                    fee_amount: BigDecimal::from(1),
-                },
+            get_open_orders_by_time_and_uids(
+                &mut db,
+                now - Duration::seconds(1),
+                Default::default()
             )
-        };
-        let (index_b, event_b) = {
-            (
-                EventIndex {
-                    block_number: 2,
-                    ..Default::default()
-                },
-                Trade {
-                    order_uid: ByteArray([1u8; 56]),
-                    sell_amount_including_fee: BigDecimal::from(20),
-                    buy_amount: BigDecimal::from(200),
-                    fee_amount: BigDecimal::from(2),
-                },
+            .await,
+            hashset![
+                ByteArray([1u8; 56]),
+                ByteArray([2u8; 56]),
+                ByteArray([3u8; 56]),
+            ]
+        );
+        // Only 2 orders created after `now`.
+        assert_eq!(
+            get_open_orders_by_time_and_uids(&mut db, now, Default::default()).await,
+            hashset![ByteArray([2u8; 56]), ByteArray([3u8; 56]),]
+        );
+        // Only 1 order created after `now + 10s`
+        assert_eq!(
+            get_open_orders_by_time_and_uids(
+                &mut db,
+                now + Duration::seconds(10),
+                Default::default()
             )
-        };
-        let (index_c, event_c) = {
-            (
-                EventIndex {
-                    block_number: 1,
-                    log_index: 1,
-                },
-                Trade {
-                    order_uid: ByteArray([2u8; 56]),
-                    sell_amount_including_fee: BigDecimal::from(40),
-                    buy_amount: BigDecimal::from(400),
-                    fee_amount: BigDecimal::from(4),
-                },
+            .await,
+            hashset![ByteArray([3u8; 56]),]
+        );
+        // Even though no orders should be returned after the provided timestamp,
+        // specified order UIDs list helps to return all the requested orders.
+        assert_eq!(
+            get_open_orders_by_time_and_uids(
+                &mut db,
+                now + Duration::seconds(20),
+                &[
+                    ByteArray([1u8; 56]),
+                    ByteArray([2u8; 56]),
+                    ByteArray([3u8; 56]),
+                ]
             )
-        };
-
-        crate::events::insert_trade(&mut db, &index_a, &event_a)
-            .await
-            .unwrap();
-        crate::events::insert_trade(&mut db, &index_b, &event_b)
-            .await
-            .unwrap();
-        crate::events::insert_trade(&mut db, &index_c, &event_c)
-            .await
-            .unwrap();
-
-        // No events after block 2.
-        assert!(get_open_orders_after(&mut db, 2, future_timestamp)
-            .await
-            .is_empty());
-        assert_eq!(
-            get_open_orders_after(&mut db, 0, future_timestamp).await,
-            hashset![ByteArray([1u8; 56]), ByteArray([2u8; 56])]
-        );
-
-        // order_execution table
-        crate::order_execution::save(
-            &mut db,
-            &ByteArray([1u8; 56]),
-            1,
-            1,
-            &BigDecimal::from(1),
-            &[],
-        )
-        .await
-        .unwrap();
-        crate::order_execution::save(
-            &mut db,
-            &ByteArray([1u8; 56]),
-            2,
-            2,
-            &BigDecimal::from(2),
-            &[],
-        )
-        .await
-        .unwrap();
-        crate::order_execution::save(
-            &mut db,
-            &ByteArray([1u8; 56]),
-            3,
-            0,
-            &BigDecimal::from(4),
-            &[],
-        )
-        .await
-        .unwrap();
-        crate::order_execution::save(
-            &mut db,
-            &ByteArray([3u8; 56]),
-            2,
-            3,
-            &BigDecimal::from(4),
-            &[],
-        )
-        .await
-        .unwrap();
-
-        assert_eq!(
-            get_open_orders_after(&mut db, 0, future_timestamp).await,
-            hashset![
-                ByteArray([1u8; 56]),
-                ByteArray([2u8; 56]),
-                ByteArray([3u8; 56])
-            ]
-        );
-
-        // invalidations table
-        let invalidation_events = vec![
-            (
-                EventIndex {
-                    block_number: 1,
-                    ..Default::default()
-                },
-                Event::Invalidation(Invalidation {
-                    order_uid: ByteArray([1u8; 56]),
-                }),
-            ),
-            (
-                EventIndex {
-                    block_number: 0,
-                    ..Default::default()
-                },
-                Event::Invalidation(Invalidation {
-                    order_uid: ByteArray([2u8; 56]),
-                }),
-            ),
-            (
-                EventIndex {
-                    block_number: 2,
-                    log_index: 1,
-                },
-                Event::Invalidation(Invalidation {
-                    order_uid: ByteArray([4u8; 56]),
-                }),
-            ),
-        ];
-        crate::events::append(&mut db, &invalidation_events)
-            .await
-            .unwrap();
-
-        assert_eq!(
-            get_open_orders_after(&mut db, 0, future_timestamp).await,
+            .await,
             hashset![
                 ByteArray([1u8; 56]),
                 ByteArray([2u8; 56]),
                 ByteArray([3u8; 56]),
-                ByteArray([4u8; 56])
             ]
-        );
-
-        // onchain_order_invalidations table
-        insert_onchain_invalidation(
-            &mut db,
-            &EventIndex {
-                block_number: 0,
-                ..Default::default()
-            },
-            &ByteArray([3u8; 56]),
         )
-        .await
-        .unwrap();
-        insert_onchain_invalidation(
-            &mut db,
-            &EventIndex {
-                block_number: 1,
-                ..Default::default()
-            },
-            &ByteArray([2u8; 56]),
-        )
-        .await
-        .unwrap();
-        insert_onchain_invalidation(
-            &mut db,
-            &EventIndex {
-                block_number: 1,
-                ..Default::default()
-            },
-            &ByteArray([5u8; 56]),
-        )
-        .await
-        .unwrap();
-
-        assert_eq!(
-            get_open_orders_after(&mut db, 0, future_timestamp).await,
-            hashset![
-                ByteArray([1u8; 56]),
-                ByteArray([2u8; 56]),
-                ByteArray([3u8; 56]),
-                ByteArray([4u8; 56]),
-                ByteArray([5u8; 56])
-            ]
-        );
-
-        // Combined query. Order 3 has event after block 2 and order 4, 5 have creation
-        // timestamp after `now + 20s`.
-        assert_eq!(
-            get_open_orders_after(&mut db, 2, now + Duration::seconds(20)).await,
-            hashset![
-                ByteArray([3u8; 56]),
-                ByteArray([4u8; 56]),
-                ByteArray([5u8; 56]),
-            ]
-        );
     }
 
     type Data = ([u8; 56], Address, DateTime<Utc>);
@@ -2233,5 +2032,222 @@ mod tests {
             .unwrap()
             .unwrap();
         assert_eq!(full_order.full_app_data, Some(full_app_data));
+    }
+
+    #[tokio::test]
+    #[ignore]
+    async fn postgres_updated_order_uids_after() {
+        let mut db = PgConnection::connect("postgresql://").await.unwrap();
+        let mut db = db.begin().await.unwrap();
+        crate::clear_DANGER_(&mut db).await.unwrap();
+
+        async fn get_updated_order_uids_after(
+            ex: &mut PgConnection,
+            after_block: i64,
+        ) -> HashSet<OrderUid> {
+            updated_order_uids_after(ex, after_block)
+                .map_ok(|o| o.0)
+                .try_collect()
+                .await
+                .unwrap()
+        }
+
+        // trades table
+        let (index_a, event_a) = {
+            (
+                EventIndex {
+                    block_number: 1,
+                    ..Default::default()
+                },
+                Trade {
+                    order_uid: ByteArray([1u8; 56]),
+                    sell_amount_including_fee: BigDecimal::from(10),
+                    buy_amount: BigDecimal::from(100),
+                    fee_amount: BigDecimal::from(1),
+                },
+            )
+        };
+        let (index_b, event_b) = {
+            (
+                EventIndex {
+                    block_number: 2,
+                    ..Default::default()
+                },
+                Trade {
+                    order_uid: ByteArray([1u8; 56]),
+                    sell_amount_including_fee: BigDecimal::from(20),
+                    buy_amount: BigDecimal::from(200),
+                    fee_amount: BigDecimal::from(2),
+                },
+            )
+        };
+        let (index_c, event_c) = {
+            (
+                EventIndex {
+                    block_number: 1,
+                    log_index: 1,
+                },
+                Trade {
+                    order_uid: ByteArray([2u8; 56]),
+                    sell_amount_including_fee: BigDecimal::from(40),
+                    buy_amount: BigDecimal::from(400),
+                    fee_amount: BigDecimal::from(4),
+                },
+            )
+        };
+
+        crate::events::insert_trade(&mut db, &index_a, &event_a)
+            .await
+            .unwrap();
+        crate::events::insert_trade(&mut db, &index_b, &event_b)
+            .await
+            .unwrap();
+        crate::events::insert_trade(&mut db, &index_c, &event_c)
+            .await
+            .unwrap();
+
+        assert!(get_updated_order_uids_after(&mut db, 2).await.is_empty());
+        assert_eq!(
+            get_updated_order_uids_after(&mut db, 0).await,
+            hashset![ByteArray([1u8; 56]), ByteArray([2u8; 56])]
+        );
+
+        // order_execution table
+        crate::order_execution::save(
+            &mut db,
+            &ByteArray([1u8; 56]),
+            1,
+            1,
+            &BigDecimal::from(1),
+            Default::default(),
+        )
+        .await
+        .unwrap();
+        crate::order_execution::save(
+            &mut db,
+            &ByteArray([1u8; 56]),
+            2,
+            2,
+            &BigDecimal::from(2),
+            Default::default(),
+        )
+        .await
+        .unwrap();
+        crate::order_execution::save(
+            &mut db,
+            &ByteArray([1u8; 56]),
+            3,
+            0,
+            &BigDecimal::from(4),
+            Default::default(),
+        )
+        .await
+        .unwrap();
+        crate::order_execution::save(
+            &mut db,
+            &ByteArray([3u8; 56]),
+            2,
+            3,
+            &BigDecimal::from(4),
+            Default::default(),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(
+            get_updated_order_uids_after(&mut db, 0).await,
+            hashset![
+                ByteArray([1u8; 56]),
+                ByteArray([2u8; 56]),
+                ByteArray([3u8; 56])
+            ]
+        );
+
+        // invalidations table
+        let invalidation_events = vec![
+            (
+                EventIndex {
+                    block_number: 1,
+                    ..Default::default()
+                },
+                Event::Invalidation(Invalidation {
+                    order_uid: ByteArray([1u8; 56]),
+                }),
+            ),
+            (
+                EventIndex {
+                    block_number: 0,
+                    ..Default::default()
+                },
+                Event::Invalidation(Invalidation {
+                    order_uid: ByteArray([2u8; 56]),
+                }),
+            ),
+            (
+                EventIndex {
+                    block_number: 1,
+                    log_index: 1,
+                },
+                Event::Invalidation(Invalidation {
+                    order_uid: ByteArray([4u8; 56]),
+                }),
+            ),
+        ];
+        crate::events::append(&mut db, &invalidation_events)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            get_updated_order_uids_after(&mut db, 0).await,
+            hashset![
+                ByteArray([1u8; 56]),
+                ByteArray([2u8; 56]),
+                ByteArray([3u8; 56]),
+                ByteArray([4u8; 56])
+            ]
+        );
+
+        // onchain_order_invalidations table
+        insert_onchain_invalidation(
+            &mut db,
+            &EventIndex {
+                block_number: 0,
+                ..Default::default()
+            },
+            &ByteArray([3u8; 56]),
+        )
+        .await
+        .unwrap();
+        insert_onchain_invalidation(
+            &mut db,
+            &EventIndex {
+                block_number: 1,
+                ..Default::default()
+            },
+            &ByteArray([2u8; 56]),
+        )
+        .await
+        .unwrap();
+        insert_onchain_invalidation(
+            &mut db,
+            &EventIndex {
+                block_number: 1,
+                ..Default::default()
+            },
+            &ByteArray([5u8; 56]),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(
+            get_updated_order_uids_after(&mut db, 0).await,
+            hashset![
+                ByteArray([1u8; 56]),
+                ByteArray([2u8; 56]),
+                ByteArray([3u8; 56]),
+                ByteArray([4u8; 56]),
+                ByteArray([5u8; 56])
+            ]
+        );
     }
 }


### PR DESCRIPTION
# Description
A suggestion to unify SQL queries mentioned in the https://github.com/cowprotocol/services/pull/2923 didn't work out. Postgres converts common table expressions into subqueries, which affects the performance. Also, with this approach, indexes cease to be utilized. As a result, it executes in 1.2-1.5s instead of ~200ms.

Tried so far(nothing helped):
- JOIN with CTE instead of using `WHERE IN (rowset)`
- Use `WITH cte AS NOT MATERIALIZED`
- Replace CTE with a subquery.
- Convert CTE result into ARRAY(has the best performance, but still 2-3 times slower than separated queries).

# Changes
Revert to the separated queries that execute in ~200ms total.

## How to test
Restored DB tests.