### PR TITLE
Use surplus token for total fee calculation

### DIFF
--- a/crates/autopilot/src/domain/settlement/mod.rs
+++ b/crates/autopilot/src/domain/settlement/mod.rs
@@ -340,9 +340,11 @@ mod tests {
             eth::U256::from(52937525819789126u128)
         );
         // fee read from "executedSurplusFee" https://api.cow.fi/mainnet/api/v1/orders/0x10dab31217bb6cc2ace0fe601c15d342f7626a1ee5ef0495449800e73156998740a50cf069e992aa4536211b23f286ef88752187ffffffff
+        // but not equal to 6890975030480504 anymore, since after this tx we switched to
+        // convert the fee from surplus token directly to ether
         assert_eq!(
             trade.fee_in_ether(&auction.prices).unwrap().0,
-            eth::U256::from(6890975030480504u128)
+            eth::U256::from(6752697350740628u128)
         );
     }
 

--- a/crates/autopilot/src/domain/settlement/trade/math.rs
+++ b/crates/autopilot/src/domain/settlement/trade/math.rs
@@ -111,11 +111,11 @@ impl Trade {
     /// Total fee (protocol fee + network fee). Equal to a surplus difference
     /// before and after applying the fees.
     pub fn fee_in_ether(&self, prices: &auction::Prices) -> Result<eth::Ether, Error> {
-        let total_fee = self.fee_in_sell_token()?;
+        let fee = self.fee()?;
         let price = prices
-            .get(&self.sell.token)
-            .ok_or(Error::MissingPrice(self.sell.token))?;
-        Ok(price.in_eth(total_fee.into()))
+            .get(&fee.token)
+            .ok_or(Error::MissingPrice(fee.token))?;
+        Ok(price.in_eth(fee.amount))
     }
 
     /// Converts given surplus fee into sell token fee.


### PR DESCRIPTION
# Description
`fee_in_ether` is practically only used to store result into `settlement_observations.fee` field, which is used by solver team.

We calculate the total fee in surplus token, as a first step always. Now, instead of using uniform clearing prices to convert that fee to sell token, and then into Ether using external prices, we go directly from surplus token -> Ether:

before: `surplus token -> sell token -> Ether`
after: `surplus token -> Ether`

This is just a small step of moving all fees to be expressed over surplus token and remove conversions to sell token.

@fhenneke please would like your approval first since you work with this result.

## How to test
Existing tests.