### PR TITLE
[TRIVIAL] More precise auction update total time metric buckets

### DIFF
--- a/crates/autopilot/src/solvable_orders.rs
+++ b/crates/autopilot/src/solvable_orders.rs
@@ -55,7 +55,7 @@ pub struct Metrics {
     auction_update: IntCounterVec,
 
     /// Time taken to update the solvable orders cache.
-    #[metric(buckets(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12))]
+    #[metric(buckets(0.1, 0.2, 0.5, 1, 1.5, 2, 2.5, 3, 4, 5, 6, 8, 10))]
     auction_update_total_time: Histogram,
 
     /// Time spent on auction update individual stage.


### PR DESCRIPTION
Currently, it is impossible to detect some of the changes due to the poorly detailed buckets.