### PR TITLE
[PROPOSAL] Event indexer counters

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4450,6 +4450,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
+ "sqlx",
  "strum",
  "tempfile",
  "testlib",

--- a/crates/autopilot/src/boundary/events/settlement.rs
+++ b/crates/autopilot/src/boundary/events/settlement.rs
@@ -2,7 +2,11 @@ use {
     crate::{database::Postgres, on_settlement_event_updater::OnSettlementEventUpdater},
     anyhow::Result,
     ethrpc::block_stream::RangeInclusive,
-    shared::{event_handling::EventStoring, impl_event_retrieving},
+    shared::{
+        event_handling::{EventStoring, PgEventCounter},
+        impl_event_retrieving,
+    },
+    sqlx::PgPool,
 };
 
 impl_event_retrieving! {
@@ -25,11 +29,6 @@ impl Indexer {
 
 #[async_trait::async_trait]
 impl EventStoring<contracts::gpv2_settlement::Event> for Indexer {
-    async fn last_event_block(&self) -> Result<u64> {
-        let mut con = self.db.pool.acquire().await?;
-        crate::database::events::last_event_block(&mut con).await
-    }
-
     async fn replace_events(
         &mut self,
         events: Vec<ethcontract::Event<contracts::gpv2_settlement::Event>>,
@@ -55,5 +54,22 @@ impl EventStoring<contracts::gpv2_settlement::Event> for Indexer {
 
         self.settlement_updater.update().await;
         Ok(())
+    }
+
+    async fn last_event_block(&self) -> Result<u64> {
+        PgEventCounter::last_event_block(self).await
+    }
+
+    async fn update_counter(&mut self, new_value: u64) -> Result<()> {
+        PgEventCounter::update_counter(self, new_value).await
+    }
+}
+
+#[async_trait::async_trait]
+impl PgEventCounter<contracts::gpv2_settlement::Event> for Indexer {
+    const INDEXER_NAME: &'static str = "gpv2_settlement_indexer";
+
+    fn pg_pool(&self) -> &PgPool {
+        &self.db.pool
     }
 }

--- a/crates/cow-amm/src/cache.rs
+++ b/crates/cow-amm/src/cache.rs
@@ -118,4 +118,8 @@ impl EventStoring<CowAmmEvent> for Storage {
             .unwrap_or(self.0.start_of_index);
         Ok(last_block)
     }
+
+    async fn update_counter(&mut self, _new_value: u64) -> anyhow::Result<()> {
+        Ok(())
+    }
 }

--- a/crates/database/src/event_indexer_counters.rs
+++ b/crates/database/src/event_indexer_counters.rs
@@ -1,0 +1,52 @@
+use sqlx::{Executor, PgConnection};
+
+pub async fn insert_or_update_counter(
+    ex: &mut PgConnection,
+    name: &str,
+    value: i64,
+) -> Result<(), sqlx::Error> {
+    const QUERY: &str = r#"
+INSERT INTO event_indexer_counters (name, counter)
+VALUES ($1, $2)
+ON CONFLICT (name)
+DO UPDATE SET counter = EXCLUDED.counter;
+    "#;
+
+    ex.execute(sqlx::query(QUERY).bind(name).bind(value))
+        .await?;
+    Ok(())
+}
+
+pub async fn current_value(ex: &mut PgConnection, name: &str) -> Result<Option<i64>, sqlx::Error> {
+    const QUERY: &str = r#"
+SELECT counter
+FROM event_indexer_counters
+WHERE name = $1;
+    "#;
+
+    sqlx::query_scalar(QUERY)
+        .bind(name)
+        .fetch_optional(ex)
+        .await
+}
+
+#[cfg(test)]
+mod tests {
+    use {super::*, sqlx::Connection};
+
+    #[tokio::test]
+    #[ignore]
+    async fn postgres_event_indexer_counter_roundtrip() {
+        let mut db = PgConnection::connect("postgresql://").await.unwrap();
+        let mut db = db.begin().await.unwrap();
+        crate::clear_DANGER_(&mut db).await.unwrap();
+
+        assert_eq!(current_value(&mut db, "test").await.unwrap(), None);
+
+        insert_or_update_counter(&mut db, "test", 42).await.unwrap();
+        assert_eq!(current_value(&mut db, "test").await.unwrap(), Some(42));
+
+        insert_or_update_counter(&mut db, "test", 43).await.unwrap();
+        assert_eq!(current_value(&mut db, "test").await.unwrap(), Some(43));
+    }
+}

--- a/crates/database/src/lib.rs
+++ b/crates/database/src/lib.rs
@@ -5,6 +5,7 @@ pub mod auction_participants;
 pub mod auction_prices;
 pub mod byte_array;
 pub mod ethflow_orders;
+pub mod event_indexer_counters;
 pub mod events;
 pub mod fee_policies;
 pub mod jit_orders;

--- a/crates/shared/Cargo.toml
+++ b/crates/shared/Cargo.toml
@@ -51,6 +51,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 serde_with = { workspace = true }
 strum = { workspace = true }
+sqlx = { workspace = true }
 thiserror = { workspace = true }
 time = { workspace = true }
 tokio = { workspace = true, features = ["macros", "time"] }

--- a/crates/shared/src/event_handling.rs
+++ b/crates/shared/src/event_handling.rs
@@ -10,6 +10,8 @@ use {
     },
     ethrpc::block_stream::{BlockNumberHash, BlockRetrieving, RangeInclusive},
     futures::{future, Stream, StreamExt, TryStreamExt},
+    num::ToPrimitive,
+    sqlx::PgPool,
     std::sync::Arc,
     tokio::sync::Mutex,
 };
@@ -69,7 +71,6 @@ pub trait EventStoring<T>: Send + Sync {
         events: Vec<EthcontractEvent<T>>,
         range: RangeInclusive<u64>,
     ) -> Result<()>;
-
     /// Returns ok, on successful execution, otherwise an appropriate error
     ///
     /// # Arguments
@@ -77,6 +78,38 @@ pub trait EventStoring<T>: Send + Sync {
     async fn append_events(&mut self, events: Vec<EthcontractEvent<T>>) -> Result<()>;
 
     async fn last_event_block(&self) -> Result<u64>;
+
+    async fn update_counter(&mut self, new_value: u64) -> Result<()>;
+}
+
+#[async_trait::async_trait]
+pub trait PgEventCounter<T>: EventStoring<T> {
+    const INDEXER_NAME: &'static str;
+
+    fn pg_pool(&self) -> &PgPool;
+
+    async fn last_event_block(&self) -> Result<u64> {
+        let mut ex = self.pg_pool().acquire().await?;
+        Ok(
+            database::event_indexer_counters::current_value(&mut ex, Self::INDEXER_NAME)
+                .await?
+                .unwrap_or_default()
+                .to_u64()
+                .context("last event block is not u64")?,
+        )
+    }
+
+    async fn update_counter(&mut self, new_value: u64) -> Result<()> {
+        let mut ex = self.pg_pool().acquire().await?;
+        database::event_indexer_counters::insert_or_update_counter(
+            &mut ex,
+            Self::INDEXER_NAME,
+            i64::try_from(new_value).context("new value of counter is not i64")?,
+        )
+        .await?;
+
+        Ok(())
+    }
 }
 
 pub trait EventRetrieving {
@@ -331,6 +364,9 @@ where
         }
 
         self.update_last_handled_blocks(&blocks);
+        if let Some(last_block) = self.last_handled_blocks.last() {
+            self.store.update_counter(last_block.0).await?;
+        }
         Ok(())
     }
 
@@ -597,6 +633,16 @@ mod tests {
     /// Simple event storage for testing purposes of EventHandler
     struct EventStorage<T> {
         pub events: Vec<EthcontractEvent<T>>,
+        pub last_processed_block: u64,
+    }
+
+    impl<T> Default for EventStorage<T> {
+        fn default() -> Self {
+            Self {
+                events: vec![],
+                last_processed_block: 0,
+            }
+        }
     }
 
     #[async_trait::async_trait]
@@ -621,11 +667,12 @@ mod tests {
         }
 
         async fn last_event_block(&self) -> Result<u64> {
-            Ok(self
-                .events
-                .last()
-                .map(|event| event.meta.clone().unwrap().block_number)
-                .unwrap_or_default())
+            Ok(self.last_processed_block)
+        }
+
+        async fn update_counter(&mut self, counter: u64) -> Result<()> {
+            self.last_processed_block = counter;
+            Ok(())
         }
     }
 
@@ -739,7 +786,7 @@ mod tests {
         let transport = create_env_test_transport();
         let web3 = Web3::new(transport);
         let contract = GPv2Settlement::deployed(&web3).await.unwrap();
-        let storage = EventStorage { events: vec![] };
+        let storage = EventStorage::default();
         let blocks = vec![
             (
                 15575559,
@@ -786,7 +833,7 @@ mod tests {
         let transport = create_env_test_transport();
         let web3 = Web3::new(transport);
         let contract = GPv2Settlement::deployed(&web3).await.unwrap();
-        let storage = EventStorage { events: vec![] };
+        let storage = EventStorage::default();
         let current_block = web3.eth().block_number().await.unwrap();
 
         const NUMBER_OF_BLOCKS: u64 = 300;
@@ -836,7 +883,7 @@ mod tests {
         // settlement contract that are at least MAX_REORG_BLOCK_COUNT apart.
         const RANGE_SIZE: u64 = 24 * 3600 / 12;
 
-        let storage_empty = EventStorage { events: vec![] };
+        let storage_empty = EventStorage::default();
         let event_start =
             block_number_to_block_number_hash(&web3, (current_block - RANGE_SIZE).into())
                 .await
@@ -856,7 +903,7 @@ mod tests {
 
         // We collect events again with an event handler generated from the same start
         // date but using `new_skip_blocks_before` if there are no events
-        let storage_empty = EventStorage { events: vec![] };
+        let storage_empty = EventStorage::default();
         let event_start =
             block_number_to_block_number_hash(&web3, (current_block - RANGE_SIZE).into())
                 .await
@@ -898,6 +945,7 @@ mod tests {
         // Recreate the same event handler with the last event already in storage.
         let storage_nonempty = EventStorage {
             events: vec![last_event.clone()],
+            last_processed_block: last_event.meta.as_ref().unwrap().block_number,
         };
         let mut nonempty_event_handler = EventHandler::new_skip_blocks_before(
             Arc::new(web3.clone()),

--- a/crates/shared/src/sources/balancer_v2/pool_fetching/pool_storage.rs
+++ b/crates/shared/src/sources/balancer_v2/pool_fetching/pool_storage.rs
@@ -212,6 +212,10 @@ where
     async fn last_event_block(&self) -> Result<u64> {
         Ok(self.last_event_block())
     }
+
+    async fn update_counter(&mut self, _new_value: u64) -> Result<()> {
+        Ok(())
+    }
 }
 
 #[cfg(test)]

--- a/crates/shared/src/sources/uniswap_v3/event_fetching.rs
+++ b/crates/shared/src/sources/uniswap_v3/event_fetching.rs
@@ -145,6 +145,10 @@ impl EventStoring<UniswapV3Event> for RecentEventsCache {
             .cloned()
             .context("no events")
     }
+
+    async fn update_counter(&mut self, _new_value: u64) -> Result<()> {
+        Ok(())
+    }
 }
 
 #[cfg(test)]

--- a/database/sql/V071__create_event_indexer_counters.sql
+++ b/database/sql/V071__create_event_indexer_counters.sql
@@ -1,0 +1,20 @@
+CREATE TABLE event_indexer_counters
+(
+    name    VARCHAR(255) PRIMARY KEY,
+    counter BIGINT NOT NULL DEFAULT 0
+);
+
+INSERT INTO event_indexer_counters (name, counter)
+VALUES ('gpv2_settlement_indexer',
+        GREATEST(
+                (SELECT COALESCE(MAX(block_number), 0) FROM trades),
+                (SELECT COALESCE(MAX(block_number), 0) FROM settlements),
+                (SELECT COALESCE(MAX(block_number), 0) FROM invalidations),
+                (SELECT COALESCE(MAX(block_number), 0) FROM presignature_events)
+        ));
+
+INSERT INTO event_indexer_counters (name, counter)
+VALUES ('ethflow_refund_indexer', (SELECT COALESCE(MAX(block_number), 0) FROM ethflow_refunds));
+
+INSERT INTO event_indexer_counters (name, counter)
+VALUES ('onchain_order_indexer', (SELECT COALESCE(MAX(block_number), 0) FROM onchain_placed_orders));


### PR DESCRIPTION
# Description
During one of the bugfixes(https://github.com/cowprotocol/services/pull/2931) it was noticed that some of the event handlers might spend a lot of time and resources on each restart due to the absence of the corresponding items in the DB. In that case, preconfigured start block numbers are used that, in most cases, are too old. As a result, on each restart, a background task might fetch millions of blocks on networks with a short round time(such as arbitrum one).

# Changes
As a proposal, store indexer counters in a separate table each time a portion of new blocks are processed. It is currently impossible to use existing `append_events` function since it operates with pre-filtered events only that can never happen if we don't have a single event for the specified type on the chain.

Driver crate doesn't have access to the DB currently, which will be required in case this proposal is accepted.