### PR TITLE
Autopilot: fetch only relevant quotes

### DIFF
--- a/crates/autopilot/src/infra/persistence/mod.rs
+++ b/crates/autopilot/src/infra/persistence/mod.rs
@@ -501,12 +501,12 @@ impl Persistence {
                 .with_label_values(&["read_quotes"])
                 .start_timer();
 
-            let all_order_uids = current_orders
+            let order_uids = current_orders
                 .keys()
                 .map(|uid| ByteArray(uid.0))
                 .collect::<Vec<_>>();
 
-            database::orders::read_quotes(&mut tx, &all_order_uids)
+            database::orders::read_quotes(&mut tx, &order_uids)
                 .await?
                 .into_iter()
                 .filter_map(|quote| {

--- a/crates/autopilot/src/solvable_orders.rs
+++ b/crates/autopilot/src/solvable_orders.rs
@@ -353,6 +353,7 @@ impl SolvableOrdersCache {
                 .persistence
                 .solvable_orders_after(
                     cache.solvable_orders.orders.clone(),
+                    cache.solvable_orders.quotes.clone(),
                     cache.solvable_orders.fetched_from_db,
                     cache.solvable_orders.latest_settlement_block,
                     min_valid_to,


### PR DESCRIPTION
# Description
The latest prod release showed that quotes fetching is one of the most expensive operations in the incremental solvable orders cache update.

# Changes
This can be slightly improved by fetching quotes for only newly created and placed onchain orders

## How to test
Existing tests.
