### PR TITLE
Speed up auction replacement query

### DIFF
--- a/crates/database/src/auction.rs
+++ b/crates/database/src/auction.rs
@@ -25,7 +25,7 @@ LIMIT 1
 }
 
 pub async fn delete_all_auctions(ex: &mut PgConnection) -> Result<(), sqlx::Error> {
-    const QUERY: &str = "TRUNCATE auctions;";
+    const QUERY: &str = "DELETE FROM auctions;";
     sqlx::query(QUERY).execute(ex).await.map(|_| ())
 }
 


### PR DESCRIPTION
# Description

Current auction replacement sometimes doesn't perform well. As an option, use DELETE instead of TRUNCATE.
![image](https://github.com/user-attachments/assets/0f6d4ba9-af80-4a6c-b6e8-4077d38e4d0e)

# How to test

Prod deployments.

> [!IMPORTANT]
> Should not be merged until a positive impact is confirmed.