### PR TITLE
Replace auction using a single SQL query

### DIFF
--- a/crates/autopilot/src/database/auction.rs
+++ b/crates/autopilot/src/database/auction.rs
@@ -104,10 +104,8 @@ impl Postgres {
             .start_timer();
 
         let data = serde_json::to_value(auction)?;
-        let mut ex = self.pool.begin().await?;
-        database::auction::delete_all_auctions(&mut ex).await?;
-        let id = database::auction::save(&mut ex, &data).await?;
-        ex.commit().await?;
+        let mut ex = self.pool.acquire().await?;
+        let id = database::auction::replace_auction(&mut ex, &data).await?;
         Ok(id)
     }
 }

--- a/crates/database/src/auction.rs
+++ b/crates/database/src/auction.rs
@@ -2,16 +2,6 @@ use sqlx::{types::JsonValue, PgConnection};
 
 pub type AuctionId = i64;
 
-pub async fn save(ex: &mut PgConnection, data: &JsonValue) -> Result<AuctionId, sqlx::Error> {
-    const QUERY: &str = r#"
-INSERT INTO auctions (json)
-VALUES ($1)
-RETURNING id
-    "#;
-    let (id,) = sqlx::query_as(QUERY).bind(data).fetch_one(ex).await?;
-    Ok(id)
-}
-
 pub async fn load_most_recent(
     ex: &mut PgConnection,
 ) -> Result<Option<(AuctionId, JsonValue)>, sqlx::Error> {
@@ -24,9 +14,21 @@ LIMIT 1
     sqlx::query_as(QUERY).fetch_optional(ex).await
 }
 
-pub async fn delete_all_auctions(ex: &mut PgConnection) -> Result<(), sqlx::Error> {
-    const QUERY: &str = "TRUNCATE auctions;";
-    sqlx::query(QUERY).execute(ex).await.map(|_| ())
+pub async fn replace_auction(
+    ex: &mut PgConnection,
+    data: &JsonValue,
+) -> Result<AuctionId, sqlx::Error> {
+    const QUERY: &str = r#"
+WITH deleted AS (
+    DELETE FROM auctions
+)
+INSERT INTO auctions (json)
+VALUES ($1)
+RETURNING id;
+    "#;
+
+    let (id,) = sqlx::query_as(QUERY).bind(data).fetch_one(ex).await?;
+    Ok(id)
 }
 
 #[cfg(test)]
@@ -41,25 +43,13 @@ mod tests {
         crate::clear_DANGER_(&mut db).await.unwrap();
 
         let value = JsonValue::Number(1.into());
-        let id = save(&mut db, &value).await.unwrap();
+        let id = replace_auction(&mut db, &value).await.unwrap();
         let (id_, value_) = load_most_recent(&mut db).await.unwrap().unwrap();
         assert_eq!(id, id_);
         assert_eq!(value, value_);
 
         let value = JsonValue::Number(2.into());
-        let id_ = save(&mut db, &value).await.unwrap();
-        assert_eq!(id + 1, id_);
-        let (id, value_) = load_most_recent(&mut db).await.unwrap().unwrap();
-        assert_eq!(value, value_);
-        assert_eq!(id_, id);
-
-        delete_all_auctions(&mut db).await.unwrap();
-        let result = load_most_recent(&mut db).await.unwrap();
-        assert!(result.is_none());
-
-        // id still increases after deletion
-        let value = JsonValue::Number(3.into());
-        let id_ = save(&mut db, &value).await.unwrap();
+        let id_ = replace_auction(&mut db, &value).await.unwrap();
         assert_eq!(id + 1, id_);
         let (id, value_) = load_most_recent(&mut db).await.unwrap().unwrap();
         assert_eq!(value, value_);


### PR DESCRIPTION
Alternative to https://github.com/cowprotocol/services/pull/2972 to be tested in order to speed up the auction replacement process.

- Replaces `TRUNCATE` with `DELETE` which should be more performant for small tables
- Uses a single combined SQL query.

> [!IMPORTANT]
> Should not be merged until a positive impact is confirmed.