### PR TITLE
Stable results for traded orders in `/status` endpoint

### DIFF
--- a/crates/orderbook/src/orderbook.rs
+++ b/crates/orderbook/src/orderbook.rs
@@ -464,7 +464,7 @@ impl Orderbook {
                             id,
                             sell_amount,
                             buy_amount,
-                        } => (id.0 == uid.0).then_some(dto::order::ExecutedAmounts {
+                        } => (id == uid).then_some(dto::order::ExecutedAmounts {
                             sell: *sell_amount,
                             buy: *buy_amount,
                         }),


### PR DESCRIPTION
# Description
So far the order status endpoint had a pretty bad UX flaw:
If an order was traded we blindly return the latest competition data. This is correct when the endpoint gets called right after the settlement happened but wrong if it gets called a long time after the settlement.
Also discussed in this [slack thread](https://cowservices.slack.com/archives/C07BQJHK2E8/p1725912352749109).

# Changes
The simple solution is to first check the `trades` table for the given order and return the competition data of the auction an order was executed the first time.
For any other label we can do the same thing we always did (return latest competition data).

## How to test
I stumbled over this when I wanted to migrate the e2e tests to `--run-loop-mode=sync-to-blockchain` which triggered this exact error in an e2e test case.
With the new implementation this assertion no longer failed. But I didn't check in another test case since this is a pretty obvious solution to the problem.

This assertion was also the one I rewrote because it looked horrible. 🙈 