### PR TITLE
Enrich Solve response

### DIFF
--- a/crates/autopilot/src/infra/solvers/dto/solve.rs
+++ b/crates/autopilot/src/infra/solvers/dto/solve.rs
@@ -115,8 +115,8 @@ impl Solution {
                     (
                         o.into(),
                         domain::competition::TradedAmounts {
-                            sell: amounts.traded_sell().into(),
-                            buy: amounts.traded_buy().into(),
+                            sell: amounts.executed_sell().into(),
+                            buy: amounts.executed_buy().into(),
                         },
                     )
                 })
@@ -152,31 +152,31 @@ pub enum TradedOrder {
         buy_token: H160,
         #[serde_as(as = "HexOrDecimalU256")]
         /// Sell limit order amount.
-        sell_amount: U256,
+        limit_sell: U256,
         #[serde_as(as = "HexOrDecimalU256")]
         /// Buy limit order amount.
-        buy_amount: U256,
+        limit_buy: U256,
         /// The effective amount that left the user's wallet including all fees.
         #[serde_as(as = "HexOrDecimalU256")]
-        traded_sell: U256,
+        executed_sell: U256,
         /// The effective amount the user received after all fees.
         #[serde_as(as = "HexOrDecimalU256")]
-        traded_buy: U256,
+        executed_buy: U256,
     },
 }
 
 impl TradedOrder {
-    pub fn traded_sell(&self) -> U256 {
+    pub fn executed_sell(&self) -> U256 {
         match self {
             Self::TradedAmount { sell_amount, .. } => *sell_amount,
-            Self::TradedOrder { traded_sell, .. } => *traded_sell,
+            Self::TradedOrder { executed_sell, .. } => *executed_sell,
         }
     }
 
-    pub fn traded_buy(&self) -> U256 {
+    pub fn executed_buy(&self) -> U256 {
         match self {
             Self::TradedAmount { buy_amount, .. } => *buy_amount,
-            Self::TradedOrder { traded_buy, .. } => *traded_buy,
+            Self::TradedOrder { executed_buy, .. } => *executed_buy,
         }
     }
 }

--- a/crates/autopilot/src/infra/solvers/dto/solve.rs
+++ b/crates/autopilot/src/infra/solvers/dto/solve.rs
@@ -137,6 +137,7 @@ impl Solution {
 #[serde(untagged)]
 pub enum TradedOrder {
     #[serde(rename_all = "camelCase")]
+    /// An old format that only includes the executed amounts for an order.
     TradedAmount {
         /// The effective amount that left the user's wallet including all fees.
         #[serde_as(as = "HexOrDecimalU256")]
@@ -146,6 +147,10 @@ pub enum TradedOrder {
         buy_amount: U256,
     },
     #[serde(rename_all = "camelCase")]
+    /// Contains basic order information and the executed amounts. Basic order
+    /// information are required because of JIT orders which are not part of an
+    /// auction, so autopilot can be aware of them before the solution is
+    /// settled on-chain.
     TradedOrder {
         side: Side,
         sell_token: H160,

--- a/crates/driver/openapi.yml
+++ b/crates/driver/openapi.yml
@@ -406,7 +406,7 @@ components:
                       description: Token being sold
                       $ref: "#/components/schemas/Address"
                     buyToken:
-                      description: Token being sold
+                      description: Token being bought
                       $ref: "#/components/schemas/Address"
                     limitSell:
                       type: string

--- a/crates/driver/openapi.yml
+++ b/crates/driver/openapi.yml
@@ -399,10 +399,25 @@ components:
                 additionalProperties:
                   type: object
                   properties:
-                    sellAmount:
+                    side:
+                      type: string
+                      enum: ["buy", "sell"]
+                    sellToken:
+                      description: Token being sold
+                      $ref: "#/components/schemas/Address"
+                    buyToken:
+                      description: Token being sold
+                      $ref: "#/components/schemas/Address"
+                    limitSell:
+                      type: string
+                      description: Amount to be sold.
+                    limitBuy:
+                      type: string
+                      description: Amount to be bought.
+                    executedSell:
                       type: string
                       description: The effective amount that left the user's wallet including all fees.
-                    buyAmount:
+                    executedBuy:
                       type: string
                       description: The effective amount the user received after all fees.
               clearingPrices:

--- a/crates/driver/openapi.yml
+++ b/crates/driver/openapi.yml
@@ -410,10 +410,10 @@ components:
                       $ref: "#/components/schemas/Address"
                     limitSell:
                       type: string
-                      description: Amount to be sold.
+                      description: Maximum amount to be sold.
                     limitBuy:
                       type: string
-                      description: Amount to be bought.
+                      description: Minimum amount to be bought.
                     executedSell:
                       type: string
                       description: The effective amount that left the user's wallet including all fees.

--- a/crates/driver/src/domain/competition/mod.rs
+++ b/crates/driver/src/domain/competition/mod.rs
@@ -391,8 +391,8 @@ pub struct Amounts {
     pub side: order::Side,
     pub sell: eth::Asset,
     pub buy: eth::Asset,
-    pub traded_sell: eth::TokenAmount,
-    pub traded_buy: eth::TokenAmount,
+    pub executed_sell: eth::TokenAmount,
+    pub executed_buy: eth::TokenAmount,
 }
 
 #[derive(Clone, Debug)]

--- a/crates/driver/src/domain/competition/mod.rs
+++ b/crates/driver/src/domain/competition/mod.rs
@@ -389,9 +389,13 @@ pub struct Solved {
 #[derive(Debug)]
 pub struct Amounts {
     pub side: order::Side,
+    /// The sell token and it's limit amount.
     pub sell: eth::Asset,
+    /// The buy token and it's limit amount.
     pub buy: eth::Asset,
+    /// The effective amount that left the user's wallet including all fees.
     pub executed_sell: eth::TokenAmount,
+    /// The effective amount the user received after all fees.
     pub executed_buy: eth::TokenAmount,
 }
 

--- a/crates/driver/src/domain/competition/mod.rs
+++ b/crates/driver/src/domain/competition/mod.rs
@@ -395,24 +395,6 @@ pub struct Amounts {
     pub traded_buy: eth::TokenAmount,
 }
 
-impl Default for Amounts {
-    fn default() -> Self {
-        Self {
-            side: order::Side::Buy,
-            sell: eth::Asset {
-                token: eth::TokenAddress(eth::ContractAddress(Default::default())),
-                amount: Default::default(),
-            },
-            buy: eth::Asset {
-                token: eth::TokenAddress(eth::ContractAddress(Default::default())),
-                amount: Default::default(),
-            },
-            traded_sell: Default::default(),
-            traded_buy: Default::default(),
-        }
-    }
-}
-
 #[derive(Clone, Debug)]
 pub struct PriceLimits {
     pub sell: eth::TokenAmount,

--- a/crates/driver/src/domain/competition/mod.rs
+++ b/crates/driver/src/domain/competition/mod.rs
@@ -386,10 +386,31 @@ pub struct Solved {
     pub gas: Option<eth::Gas>,
 }
 
-#[derive(Debug, Default)]
+#[derive(Debug)]
 pub struct Amounts {
-    pub sell: eth::TokenAmount,
-    pub buy: eth::TokenAmount,
+    pub side: order::Side,
+    pub sell: eth::Asset,
+    pub buy: eth::Asset,
+    pub traded_sell: eth::TokenAmount,
+    pub traded_buy: eth::TokenAmount,
+}
+
+impl Default for Amounts {
+    fn default() -> Self {
+        Self {
+            side: order::Side::Buy,
+            sell: eth::Asset {
+                token: eth::TokenAddress(eth::ContractAddress(Default::default())),
+                amount: Default::default(),
+            },
+            buy: eth::Asset {
+                token: eth::TokenAddress(eth::ContractAddress(Default::default())),
+                amount: Default::default(),
+            },
+            traded_sell: Default::default(),
+            traded_buy: Default::default(),
+        }
+    }
 }
 
 #[derive(Clone, Debug)]

--- a/crates/driver/src/domain/competition/mod.rs
+++ b/crates/driver/src/domain/competition/mod.rs
@@ -389,9 +389,9 @@ pub struct Solved {
 #[derive(Debug)]
 pub struct Amounts {
     pub side: order::Side,
-    /// The sell token and it's limit amount.
+    /// The sell token and limit sell amount of sell token.
     pub sell: eth::Asset,
-    /// The buy token and it's limit amount.
+    /// The buy token and limit buy amount of buy token.
     pub buy: eth::Asset,
     /// The effective amount that left the user's wallet including all fees.
     pub executed_sell: eth::TokenAmount,

--- a/crates/driver/src/domain/competition/solution/settlement.rs
+++ b/crates/driver/src/domain/competition/solution/settlement.rs
@@ -256,26 +256,28 @@ impl Settlement {
     pub fn orders(&self) -> HashMap<order::Uid, competition::Amounts> {
         let mut acc: HashMap<order::Uid, competition::Amounts> = HashMap::new();
         for trade in self.solution.user_trades() {
-            let order = acc.entry(trade.order().uid).or_default();
             let prices = ClearingPrices {
                 sell: self.solution.prices[&trade.order().sell.token.wrap(self.solution.weth)],
                 buy: self.solution.prices[&trade.order().buy.token.wrap(self.solution.weth)],
             };
-            order.side = trade.order().side;
-            order.sell = trade.order().sell;
-            order.buy = trade.order().buy;
-            order.traded_sell = trade.sell_amount(&prices).unwrap_or_else(|err| {
-                        // This should never happen, returning 0 is better than panicking, but we
-                        // should still alert.
-                        tracing::error!(?trade, prices=?self.solution.prices, ?err, "could not compute sell_amount");
-                        0.into()
-                    });
-            order.traded_buy = trade.buy_amount(&prices).unwrap_or_else(|err| {
-                        // This should never happen, returning 0 is better than panicking, but we
-                        // should still alert.
-                        tracing::error!(?trade, prices=?self.solution.prices, ?err, "could not compute buy_amount");
-                        0.into()
-                    });
+            let order = competition::Amounts {
+                side: trade.order().side,
+                sell: trade.order().sell,
+                buy: trade.order().buy,
+                traded_sell: trade.sell_amount(&prices).unwrap_or_else(|err| {
+                    // This should never happen, returning 0 is better than panicking, but we
+                    // should still alert.
+                    tracing::error!(?trade, prices=?self.solution.prices, ?err, "could not compute sell_amount");
+                    0.into()
+                }),
+                traded_buy: trade.buy_amount(&prices).unwrap_or_else(|err| {
+                    // This should never happen, returning 0 is better than panicking, but we
+                    // should still alert.
+                    tracing::error!(?trade, prices=?self.solution.prices, ?err, "could not compute buy_amount");
+                    0.into()
+                }),
+            };
+            acc.insert(trade.order().uid, order);
         }
         acc
     }

--- a/crates/driver/src/domain/competition/solution/settlement.rs
+++ b/crates/driver/src/domain/competition/solution/settlement.rs
@@ -261,13 +261,16 @@ impl Settlement {
                 sell: self.solution.prices[&trade.order().sell.token.wrap(self.solution.weth)],
                 buy: self.solution.prices[&trade.order().buy.token.wrap(self.solution.weth)],
             };
-            order.sell = trade.sell_amount(&prices).unwrap_or_else(|err| {
+            order.side = trade.order().side;
+            order.sell = trade.order().sell;
+            order.buy = trade.order().buy;
+            order.traded_sell = trade.sell_amount(&prices).unwrap_or_else(|err| {
                         // This should never happen, returning 0 is better than panicking, but we
                         // should still alert.
                         tracing::error!(?trade, prices=?self.solution.prices, ?err, "could not compute sell_amount");
                         0.into()
                     });
-            order.buy = trade.buy_amount(&prices).unwrap_or_else(|err| {
+            order.traded_buy = trade.buy_amount(&prices).unwrap_or_else(|err| {
                         // This should never happen, returning 0 is better than panicking, but we
                         // should still alert.
                         tracing::error!(?trade, prices=?self.solution.prices, ?err, "could not compute buy_amount");

--- a/crates/driver/src/domain/competition/solution/settlement.rs
+++ b/crates/driver/src/domain/competition/solution/settlement.rs
@@ -264,13 +264,13 @@ impl Settlement {
                 side: trade.order().side,
                 sell: trade.order().sell,
                 buy: trade.order().buy,
-                traded_sell: trade.sell_amount(&prices).unwrap_or_else(|err| {
+                executed_sell: trade.sell_amount(&prices).unwrap_or_else(|err| {
                     // This should never happen, returning 0 is better than panicking, but we
                     // should still alert.
                     tracing::error!(?trade, prices=?self.solution.prices, ?err, "could not compute sell_amount");
                     0.into()
                 }),
-                traded_buy: trade.buy_amount(&prices).unwrap_or_else(|err| {
+                executed_buy: trade.buy_amount(&prices).unwrap_or_else(|err| {
                     // This should never happen, returning 0 is better than panicking, but we
                     // should still alert.
                     tracing::error!(?trade, prices=?self.solution.prices, ?err, "could not compute buy_amount");

--- a/crates/driver/src/infra/api/routes/solve/dto/solved.rs
+++ b/crates/driver/src/infra/api/routes/solve/dto/solved.rs
@@ -44,11 +44,11 @@ impl Solution {
                                 order::Side::Sell => Side::Sell,
                             },
                             sell_token: amounts.sell.token.into(),
-                            sell_amount: amounts.sell.amount.into(),
+                            limit_sell: amounts.sell.amount.into(),
                             buy_token: amounts.buy.token.into(),
-                            buy_amount: amounts.buy.amount.into(),
-                            traded_sell: amounts.traded_sell.into(),
-                            traded_buy: amounts.traded_buy.into(),
+                            limit_buy: amounts.buy.amount.into(),
+                            executed_sell: amounts.executed_sell.into(),
+                            executed_buy: amounts.executed_buy.into(),
                         },
                     )
                 })
@@ -90,16 +90,16 @@ pub struct TradedOrder {
     pub buy_token: eth::H160,
     #[serde_as(as = "serialize::U256")]
     /// Sell limit order amount.
-    pub sell_amount: eth::U256,
+    pub limit_sell: eth::U256,
     #[serde_as(as = "serialize::U256")]
     /// Buy limit order amount.
-    pub buy_amount: eth::U256,
+    pub limit_buy: eth::U256,
     /// The effective amount that left the user's wallet including all fees.
     #[serde_as(as = "serialize::U256")]
-    pub traded_sell: eth::U256,
+    pub executed_sell: eth::U256,
     /// The effective amount the user received after all fees.
     #[serde_as(as = "serialize::U256")]
-    pub traded_buy: eth::U256,
+    pub executed_buy: eth::U256,
 }
 
 #[serde_as]

--- a/crates/driver/src/infra/api/routes/solve/dto/solved.rs
+++ b/crates/driver/src/infra/api/routes/solve/dto/solved.rs
@@ -38,9 +38,17 @@ impl Solution {
                 .map(|(order_id, amounts)| {
                     (
                         order_id.into(),
-                        TradedAmounts {
-                            sell_amount: amounts.sell.into(),
-                            buy_amount: amounts.buy.into(),
+                        TradedOrder {
+                            side: match amounts.side {
+                                order::Side::Buy => Side::Buy,
+                                order::Side::Sell => Side::Sell,
+                            },
+                            sell_token: amounts.sell.token.into(),
+                            sell_amount: amounts.sell.amount.into(),
+                            buy_token: amounts.buy.token.into(),
+                            buy_amount: amounts.buy.amount.into(),
+                            traded_sell: amounts.traded_sell.into(),
+                            traded_buy: amounts.traded_buy.into(),
                         },
                     )
                 })
@@ -52,18 +60,6 @@ impl Solution {
                 .collect(),
         }
     }
-}
-
-#[serde_as]
-#[derive(Debug, Serialize)]
-#[serde(rename_all = "camelCase")]
-pub struct TradedAmounts {
-    /// The effective amount that left the user's wallet including all fees.
-    #[serde_as(as = "serialize::U256")]
-    pub sell_amount: eth::U256,
-    /// The effective amount the user received after all fees.
-    #[serde_as(as = "serialize::U256")]
-    pub buy_amount: eth::U256,
 }
 
 type OrderId = [u8; order::UID_LEN];
@@ -80,7 +76,36 @@ pub struct Solution {
     score: eth::U256,
     submission_address: eth::H160,
     #[serde_as(as = "HashMap<serialize::Hex, _>")]
-    orders: HashMap<OrderId, TradedAmounts>,
+    orders: HashMap<OrderId, TradedOrder>,
     #[serde_as(as = "HashMap<_, serialize::U256>")]
     clearing_prices: HashMap<eth::H160, eth::U256>,
+}
+
+#[serde_as]
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TradedOrder {
+    pub side: Side,
+    pub sell_token: eth::H160,
+    pub buy_token: eth::H160,
+    #[serde_as(as = "serialize::U256")]
+    /// Sell limit order amount.
+    pub sell_amount: eth::U256,
+    #[serde_as(as = "serialize::U256")]
+    /// Buy limit order amount.
+    pub buy_amount: eth::U256,
+    /// The effective amount that left the user's wallet including all fees.
+    #[serde_as(as = "serialize::U256")]
+    pub traded_sell: eth::U256,
+    /// The effective amount the user received after all fees.
+    #[serde_as(as = "serialize::U256")]
+    pub traded_buy: eth::U256,
+}
+
+#[serde_as]
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub enum Side {
+    Buy,
+    Sell,
 }

--- a/crates/driver/src/tests/setup/mod.rs
+++ b/crates/driver/src/tests/setup/mod.rs
@@ -1239,11 +1239,11 @@ impl<'a> SolveOk<'a> {
                 None => (quoted_order.sell, quoted_order.buy),
             };
             assert!(is_approximately_equal(
-                u256(trade.get("sellAmount").unwrap()),
+                u256(trade.get("tradedSell").unwrap()),
                 expected_sell
             ));
             assert!(is_approximately_equal(
-                u256(trade.get("buyAmount").unwrap()),
+                u256(trade.get("tradedBuy").unwrap()),
                 expected_buy
             ));
         }

--- a/crates/driver/src/tests/setup/mod.rs
+++ b/crates/driver/src/tests/setup/mod.rs
@@ -1239,11 +1239,11 @@ impl<'a> SolveOk<'a> {
                 None => (quoted_order.sell, quoted_order.buy),
             };
             assert!(is_approximately_equal(
-                u256(trade.get("tradedSell").unwrap()),
+                u256(trade.get("executedSell").unwrap()),
                 expected_sell
             ));
             assert!(is_approximately_equal(
-                u256(trade.get("tradedBuy").unwrap()),
+                u256(trade.get("executedBuy").unwrap()),
                 expected_buy
             ));
         }


### PR DESCRIPTION
# Description
Fixes https://github.com/cowprotocol/services/issues/2839

Adds additional order data to each `Solve` response. This includes order's sell token, sell amount, buy token, buy amount and side. This is needed for two reasons:

1. Cow amm orders do not exist in the Auction, so we need this data to calculate the score of a solution at a competition time. This is to unblock https://github.com/cowprotocol/services/pull/2730/files
2. To allow selecting multiple winners for combinatorial auctions. To be more specific, for each winner, next winner has to have tokens that are not used in first winner, and to know which tokens are those, we need to provide sell token and buy token for cow amm orders.

# Changes
<!-- List of detailed changes (how the change is accomplished) -->

- [ ] Update Solve response on both driver and autopilot side to include additional order data.

## How to test
Existing tests. Locally, I made sure that both old and new versions are properly deserialized on autopilot side.