### PR TITLE
[TRIVIAL] Drop redundant maintenance metric

### DIFF
--- a/crates/autopilot/src/maintenance.rs
+++ b/crates/autopilot/src/maintenance.rs
@@ -81,9 +81,6 @@ impl Maintenance {
             "successfully ran maintenance task"
         );
 
-        metrics()
-            .update_duration
-            .observe(start.elapsed().as_secs_f64());
         metrics().updates.with_label_values(&["success"]).inc();
         metrics().last_updated_block.set(new_block.number);
         *last_block = *new_block;
@@ -191,10 +188,6 @@ struct Metrics {
     /// Autopilot maintenance error counter
     #[metric(labels("result"))]
     updates: IntCounterVec,
-
-    /// Execution time for updates
-    #[metric(buckets(0.01, 0.05, 0.1, 0.2, 0.5, 1, 1.5, 2, 2.5, 5))]
-    update_duration: Histogram,
 }
 
 fn metrics() -> &'static Metrics {

--- a/crates/autopilot/src/maintenance.rs
+++ b/crates/autopilot/src/maintenance.rs
@@ -18,7 +18,6 @@ use {
     futures::StreamExt,
     prometheus::{
         core::{AtomicU64, GenericGauge},
-        Histogram,
         IntCounterVec,
     },
     shared::maintenance::Maintaining,

--- a/crates/autopilot/src/run_loop.rs
+++ b/crates/autopilot/src/run_loop.rs
@@ -772,7 +772,7 @@ struct Metrics {
 
     /// Tracks the time spent running maintenance. This mostly consists of
     /// indexing new events.
-    #[metric(buckets(0, 0.01, 0.05, 0.1, 0.2, 0.5, 1., 2., 5.))]
+    #[metric(buckets(0.01, 0.05, 0.1, 0.2, 0.5, 1, 1.5, 2, 2.5, 5))]
     service_maintenance_time: prometheus::Histogram,
 
     /// Total time spent in a single run of the run loop.


### PR DESCRIPTION
The dropped metric actually duplicates the service maintenance time metric:
https://github.com/cowprotocol/services/blob/e84102090d6fecfbd4e967d09f2e0df5d2e951ac/crates/autopilot/src/run_loop.rs#L773-L776