### PR TITLE
Cut auctions in parallel

### DIFF
--- a/crates/autopilot/src/run.rs
+++ b/crates/autopilot/src/run.rs
@@ -19,7 +19,7 @@ use {
         event_updater::EventUpdater,
         infra::{self, blockchain::ChainId},
         maintenance::Maintenance,
-        run_loop::RunLoop,
+        run_loop::{self, RunLoop},
         shadow,
         solvable_orders::SolvableOrdersCache,
     },
@@ -521,7 +521,16 @@ pub async fn run(args: Arguments) {
         );
     }
 
+    let run_loop_config = run_loop::Config {
+        submission_deadline: args.submission_deadline as u64,
+        max_settlement_transaction_wait: args.max_settlement_transaction_wait,
+        solve_deadline: args.solve_deadline,
+        synchronization: args.run_loop_mode,
+        max_run_loop_delay: args.max_run_loop_delay,
+    };
+
     let run = RunLoop::new(
+        run_loop_config,
         eth,
         persistence.clone(),
         args.drivers
@@ -536,12 +545,7 @@ pub async fn run(args: Arguments) {
             .collect(),
         solvable_orders_cache,
         market_makable_token_list,
-        args.submission_deadline as u64,
-        args.max_settlement_transaction_wait,
-        args.solve_deadline,
         liveness.clone(),
-        args.run_loop_mode,
-        args.max_run_loop_delay,
         Arc::new(maintenance),
     );
     run.run_forever(args.auction_update_interval).await;

--- a/crates/autopilot/src/run.rs
+++ b/crates/autopilot/src/run.rs
@@ -539,6 +539,7 @@ pub async fn run(args: Arguments) {
         submission_deadline: args.submission_deadline as u64,
         max_settlement_transaction_wait: args.max_settlement_transaction_wait,
         solve_deadline: args.solve_deadline,
+        in_flight_orders: Default::default(),
         persistence: persistence.clone(),
         liveness: liveness.clone(),
         synchronization: args.run_loop_mode,

--- a/crates/autopilot/src/run.rs
+++ b/crates/autopilot/src/run.rs
@@ -521,11 +521,10 @@ pub async fn run(args: Arguments) {
         );
     }
 
-    let run = RunLoop {
+    let run = RunLoop::new(
         eth,
-        solvable_orders_cache,
-        drivers: args
-            .drivers
+        persistence.clone(),
+        args.drivers
             .into_iter()
             .map(|driver| {
                 Arc::new(infra::Driver::new(
@@ -535,17 +534,16 @@ pub async fn run(args: Arguments) {
                 ))
             })
             .collect(),
+        solvable_orders_cache,
         market_makable_token_list,
-        submission_deadline: args.submission_deadline as u64,
-        max_settlement_transaction_wait: args.max_settlement_transaction_wait,
-        solve_deadline: args.solve_deadline,
-        in_flight_orders: Default::default(),
-        persistence: persistence.clone(),
-        liveness: liveness.clone(),
-        synchronization: args.run_loop_mode,
-        max_run_loop_delay: args.max_run_loop_delay,
-        maintenance: Arc::new(maintenance),
-    };
+        args.submission_deadline as u64,
+        args.max_settlement_transaction_wait,
+        args.solve_deadline,
+        liveness.clone(),
+        args.run_loop_mode,
+        args.max_run_loop_delay,
+        Arc::new(maintenance),
+    );
     run.run_forever(args.auction_update_interval).await;
     unreachable!("run loop exited");
 }

--- a/crates/autopilot/src/run.rs
+++ b/crates/autopilot/src/run.rs
@@ -528,11 +528,11 @@ pub async fn run(args: Arguments) {
             .drivers
             .into_iter()
             .map(|driver| {
-                infra::Driver::new(
+                Arc::new(infra::Driver::new(
                     driver.url,
                     driver.name,
                     driver.fairness_threshold.map(Into::into),
-                )
+                ))
             })
             .collect(),
         market_makable_token_list,

--- a/crates/autopilot/src/run_loop.rs
+++ b/crates/autopilot/src/run_loop.rs
@@ -12,7 +12,6 @@ use {
         infra::{
             self,
             solvers::dto::{settle, solve},
-            Driver,
         },
         maintenance::Maintenance,
         run::Liveness,
@@ -280,7 +279,7 @@ impl RunLoop {
         self: &Arc<Self>,
         auction_id: Id,
         single_run_start: Instant,
-        driver: &Arc<Driver>,
+        driver: &Arc<infra::Driver>,
         solution: &SolutionWithId,
         block_deadline: u64,
     ) {

--- a/crates/autopilot/src/run_loop.rs
+++ b/crates/autopilot/src/run_loop.rs
@@ -44,25 +44,25 @@ use {
 };
 
 pub struct RunLoop {
-    pub eth: infra::Ethereum,
-    pub persistence: infra::Persistence,
-    pub drivers: Vec<Arc<infra::Driver>>,
+    eth: infra::Ethereum,
+    persistence: infra::Persistence,
+    drivers: Vec<Arc<infra::Driver>>,
 
-    pub solvable_orders_cache: Arc<SolvableOrdersCache>,
-    pub market_makable_token_list: AutoUpdatingTokenList,
-    pub submission_deadline: u64,
-    pub max_settlement_transaction_wait: Duration,
-    pub solve_deadline: Duration,
-    pub in_flight_orders: Arc<Mutex<HashSet<OrderUid>>>,
-    pub liveness: Arc<Liveness>,
-    pub synchronization: RunLoopMode,
+    solvable_orders_cache: Arc<SolvableOrdersCache>,
+    market_makable_token_list: AutoUpdatingTokenList,
+    submission_deadline: u64,
+    max_settlement_transaction_wait: Duration,
+    solve_deadline: Duration,
+    in_flight_orders: Arc<Mutex<HashSet<OrderUid>>>,
+    liveness: Arc<Liveness>,
+    synchronization: RunLoopMode,
     /// How much time past observing the current block the runloop is
     /// allowed to start before it has to re-synchronize to the blockchain
     /// by waiting for the next block to appear.
-    pub max_run_loop_delay: Duration,
+    max_run_loop_delay: Duration,
     /// Maintenance tasks that should run before every runloop to have
     /// the most recent data available.
-    pub maintenance: Arc<Maintenance>,
+    maintenance: Arc<Maintenance>,
     /// Queues by solver for executing settle futures one by one guaranteeing
     /// FIFO execution order.
     settlement_queues: Arc<Mutex<HashMap<String, mpsc::UnboundedSender<BoxFuture<'static, ()>>>>>,

--- a/crates/autopilot/src/run_loop.rs
+++ b/crates/autopilot/src/run_loop.rs
@@ -690,14 +690,14 @@ impl RunLoop {
             .into_iter()
             .filter_map(|solution| match solution {
                 Ok(solution) => {
-                    Metrics::solution_ok(&driver.clone());
+                    Metrics::solution_ok(&driver);
                     Some(Participant {
                         driver: driver.clone(),
                         solution,
                     })
                 }
                 Err(err) => {
-                    Metrics::solution_err(&driver.clone(), &err);
+                    Metrics::solution_err(&driver, &err);
                     tracing::debug!(?err, driver = %driver.name, "invalid proposed solution");
                     None
                 }

--- a/crates/autopilot/src/run_loop.rs
+++ b/crates/autopilot/src/run_loop.rs
@@ -291,8 +291,8 @@ impl RunLoop {
             .extend(solved_order_uids.clone());
 
         let solution_id = solution.id();
-        let driver_ = driver.clone();
         let self_ = self.clone();
+        let driver_ = driver.clone();
 
         let settle_fut = async move {
             tracing::info!(driver = %driver_.name, "settling");
@@ -300,7 +300,7 @@ impl RunLoop {
 
             match self_
                 .settle(
-                    driver_.clone(),
+                    &driver_,
                     solution_id,
                     solved_order_uids,
                     auction_id,
@@ -755,7 +755,7 @@ impl RunLoop {
     /// transaction has been mined.
     async fn settle(
         &self,
-        driver: Arc<infra::Driver>,
+        driver: &infra::Driver,
         solution_id: u64,
         solved_order_uids: HashSet<OrderUid>,
         auction_id: i64,
@@ -766,7 +766,7 @@ impl RunLoop {
             submission_deadline_latest_block,
         };
         let tx_hash = self
-            .wait_for_settlement(driver.clone(), auction_id, request)
+            .wait_for_settlement(driver, auction_id, request)
             .await?;
         tracing::debug!(?tx_hash, "solution settled");
 
@@ -782,7 +782,7 @@ impl RunLoop {
     /// returned a result.
     async fn wait_for_settlement(
         &self,
-        driver: Arc<infra::Driver>,
+        driver: &infra::Driver,
         auction_id: i64,
         request: settle::Request,
     ) -> Result<eth::TxId, SettleError> {

--- a/crates/autopilot/src/run_loop.rs
+++ b/crates/autopilot/src/run_loop.rs
@@ -237,7 +237,6 @@ impl RunLoop {
         tracing::info!(?auction_id, "solving");
 
         let auction = self.remove_in_flight_orders(auction).await;
-        Metrics::pre_processed(single_run_start.elapsed());
 
         let solutions = self.competition(auction_id, &auction).await;
         if solutions.is_empty() {
@@ -872,10 +871,6 @@ struct Metrics {
     /// solved and before sending a `settle` request.
     auction_postprocessing_time: prometheus::Histogram,
 
-    /// Tracks the time spent in pre-processing before sending a `solve`
-    /// request.
-    auction_preprocessing_time: prometheus::Histogram,
-
     /// Tracks the time spent running maintenance. This mostly consists of
     /// indexing new events.
     #[metric(buckets(0, 0.01, 0.05, 0.1, 0.2, 0.5, 1., 2., 5.))]
@@ -975,12 +970,6 @@ impl Metrics {
     fn post_processed(elapsed: Duration) {
         Self::get()
             .auction_postprocessing_time
-            .observe(elapsed.as_secs_f64());
-    }
-
-    fn pre_processed(elapsed: Duration) {
-        Self::get()
-            .auction_preprocessing_time
             .observe(elapsed.as_secs_f64());
     }
 

--- a/crates/autopilot/src/run_loop.rs
+++ b/crates/autopilot/src/run_loop.rs
@@ -35,6 +35,7 @@ use {
         sync::Arc,
         time::{Duration, Instant},
     },
+    tokio::sync::Mutex,
     tracing::{warn, Instrument},
 };
 
@@ -48,6 +49,7 @@ pub struct RunLoop {
     pub submission_deadline: u64,
     pub max_settlement_transaction_wait: Duration,
     pub solve_deadline: Duration,
+    pub in_flight_orders: Arc<Mutex<Option<InFlightOrders>>>,
     pub liveness: Arc<Liveness>,
     pub synchronization: RunLoopMode,
     /// How much time past observing the current block the runloop is
@@ -180,6 +182,7 @@ impl RunLoop {
         let single_run_start = Instant::now();
         tracing::info!(?auction_id, "solving");
 
+        let auction = self.remove_in_flight_orders(auction.clone()).await;
         Metrics::pre_processed(single_run_start.elapsed());
 
         let solutions = self.competition(auction_id, auction).await;
@@ -201,7 +204,7 @@ impl RunLoop {
             if let Err(err) = self
                 .post_processing(
                     auction_id,
-                    auction.clone(),
+                    auction,
                     competition_simulation_block,
                     solution,
                     &solutions,
@@ -634,6 +637,10 @@ impl RunLoop {
         let tx_hash = self
             .wait_for_settlement(driver, auction_id, request)
             .await?;
+        *self.in_flight_orders.lock().await = Some(InFlightOrders {
+            tx_hash,
+            orders: solved.order_ids().copied().collect(),
+        });
         tracing::debug!(?tx_hash, "solution settled");
 
         Ok(())
@@ -701,6 +708,41 @@ impl RunLoop {
             "settlement transaction await reached deadline"
         )))
     }
+
+    /// Removes orders that are currently being settled to avoid solvers trying
+    /// to fill an order a second time.
+    async fn remove_in_flight_orders(&self, mut auction: domain::Auction) -> domain::Auction {
+        let Some(in_flight) = &*self.in_flight_orders.lock().await else {
+            return auction;
+        };
+
+        let transaction = self.eth.transaction(in_flight.tx_hash.into()).await;
+
+        let prev_settlement_block = match transaction {
+            Ok(transaction) => transaction.block,
+            // Could not find the block of the previous settlement, let's be
+            // conservative and assume all orders are still in-flight.
+            _ => u64::MAX.into(),
+        };
+
+        if auction.latest_settlement_block < prev_settlement_block.0 {
+            // Auction was built before the in-flight orders were processed.
+            auction
+                .orders
+                .retain(|o| !in_flight.orders.contains(&o.uid));
+            tracing::debug!(orders = ?in_flight.orders, "filtered out in-flight orders");
+        }
+
+        auction
+    }
+}
+
+/// Orders settled in the previous auction that might still be in-flight.
+#[derive(Default)]
+pub struct InFlightOrders {
+    /// The transaction that these orders where settled in.
+    tx_hash: H256,
+    orders: HashSet<domain::OrderUid>,
 }
 
 struct Participant<'a> {

--- a/crates/autopilot/src/run_loop.rs
+++ b/crates/autopilot/src/run_loop.rs
@@ -180,6 +180,8 @@ impl RunLoop {
         let single_run_start = Instant::now();
         tracing::info!(?auction_id, "solving");
 
+        Metrics::pre_processed(single_run_start.elapsed());
+
         let solutions = self.competition(auction_id, auction).await;
         if solutions.is_empty() {
             tracing::info!("no solutions for auction");
@@ -765,6 +767,10 @@ struct Metrics {
     /// solved and before sending a `settle` request.
     auction_postprocessing_time: prometheus::Histogram,
 
+    /// Tracks the time spent in pre-processing before sending a `solve`
+    /// request.
+    auction_preprocessing_time: prometheus::Histogram,
+
     /// Tracks the time spent running maintenance. This mostly consists of
     /// indexing new events.
     #[metric(buckets(0, 0.01, 0.05, 0.1, 0.2, 0.5, 1., 2., 5.))]
@@ -864,6 +870,12 @@ impl Metrics {
     fn post_processed(elapsed: Duration) {
         Self::get()
             .auction_postprocessing_time
+            .observe(elapsed.as_secs_f64());
+    }
+
+    fn pre_processed(elapsed: Duration) {
+        Self::get()
+            .auction_preprocessing_time
             .observe(elapsed.as_secs_f64());
     }
 

--- a/crates/autopilot/src/run_loop.rs
+++ b/crates/autopilot/src/run_loop.rs
@@ -276,15 +276,15 @@ impl RunLoop {
                 .extend(solved_order_uids.clone());
 
             let solution_id = solution.id();
-            let self_clone = self.clone();
-            let driver_clone = driver.clone();
+            let driver_ = driver.clone();
+            let self_ = self.clone();
             let settle_fut = async move {
-                tracing::info!(driver = %driver_clone.name, "settling");
+                tracing::info!(driver = %driver_.name, "settling");
                 let submission_start = Instant::now();
 
-                match self_clone
+                match self_
                     .settle(
-                        driver_clone.clone(),
+                        driver_.clone(),
                         solution_id,
                         solved_order_uids,
                         auction_id,
@@ -292,10 +292,10 @@ impl RunLoop {
                     )
                     .await
                 {
-                    Ok(()) => Metrics::settle_ok(&driver_clone, submission_start.elapsed()),
+                    Ok(()) => Metrics::settle_ok(&driver_, submission_start.elapsed()),
                     Err(err) => {
-                        Metrics::settle_err(&driver_clone, submission_start.elapsed(), &err);
-                        tracing::warn!(?err, driver = %driver_clone.name, "settlement failed");
+                        Metrics::settle_err(&driver_, submission_start.elapsed(), &err);
+                        tracing::warn!(?err, driver = %driver_.name, "settlement failed");
                     }
                 }
                 Metrics::single_run_completed(single_run_start.elapsed());

--- a/crates/autopilot/src/run_loop.rs
+++ b/crates/autopilot/src/run_loop.rs
@@ -39,7 +39,7 @@ use {
         sync::Arc,
         time::{Duration, Instant},
     },
-    tokio::sync::{mpsc, mpsc::UnboundedSender, Mutex},
+    tokio::sync::{mpsc, Mutex},
     tracing::Instrument,
 };
 
@@ -336,7 +336,7 @@ impl RunLoop {
     async fn get_settlement_queue_sender(
         self: &Arc<Self>,
         driver_name: &str,
-    ) -> UnboundedSender<BoxFuture<'static, ()>> {
+    ) -> mpsc::UnboundedSender<BoxFuture<'static, ()>> {
         let mut settlement_queues = self.settlement_queues.lock().await;
         match settlement_queues.get(driver_name) {
             Some(sender) => sender.clone(),

--- a/crates/autopilot/src/run_loop.rs
+++ b/crates/autopilot/src/run_loop.rs
@@ -670,7 +670,7 @@ impl RunLoop {
         request: &solve::Request,
     ) -> Vec<Participant> {
         let start = Instant::now();
-        let result = self.try_solve(driver.clone(), request).await;
+        let result = self.try_solve(&driver, request).await;
         let solutions = match result {
             Ok(solutions) => {
                 Metrics::solve_ok(&driver, start.elapsed());
@@ -709,7 +709,7 @@ impl RunLoop {
     /// Sends `/solve` request to the driver and forwards errors to the caller.
     async fn try_solve(
         &self,
-        driver: Arc<infra::Driver>,
+        driver: &infra::Driver,
         request: &solve::Request,
     ) -> Result<
         Vec<Result<competition::SolutionWithId, domain::competition::SolutionError>>,

--- a/crates/autopilot/src/run_loop.rs
+++ b/crates/autopilot/src/run_loop.rs
@@ -303,6 +303,19 @@ impl RunLoop {
         }
     }
 
+    /// Retrieves or creates the settlement queue sender for a given driver.
+    ///
+    /// This function ensures that there is a settlement execution queue
+    /// associated with the specified `driver_name`. If a queue already
+    /// exists, it returns the existing sender. If not, it creates a new
+    /// queue, starts a background task to process settlement futures
+    /// sequentially, and returns the new sender.
+    ///
+    /// The background task processes futures from the queue one by one,
+    /// guaranteeing FIFO execution order for settlements per driver. It
+    /// also implements an idle timeout: if no new futures are received within
+    /// `IDLE_TIMEOUT`, the background task terminates, and the queue is
+    /// removed.
     async fn get_settlement_queue_sender(
         self: &Arc<Self>,
         driver_name: &str,

--- a/crates/autopilot/src/run_loop.rs
+++ b/crates/autopilot/src/run_loop.rs
@@ -729,6 +729,8 @@ impl RunLoop {
             .await
             .retain(|order| !solved_order_uids.contains(order));
 
+        self.settlement_tasks.lock().await.remove(&driver.name);
+
         Ok(())
     }
 

--- a/crates/autopilot/src/run_loop.rs
+++ b/crates/autopilot/src/run_loop.rs
@@ -308,14 +308,9 @@ impl RunLoop {
     /// This function ensures that there is a settlement execution queue
     /// associated with the specified `driver_name`. If a queue already
     /// exists, it returns the existing sender. If not, it creates a new
-    /// queue, starts a background task to process settlement futures
-    /// sequentially, and returns the new sender.
-    ///
-    /// The background task processes futures from the queue one by one,
-    /// guaranteeing FIFO execution order for settlements per driver. It
-    /// also implements an idle timeout: if no new futures are received within
-    /// `IDLE_TIMEOUT`, the background task terminates, and the queue is
-    /// removed.
+    /// queue, starts a background task to process settlement futures,
+    /// guaranteeing FIFO execution order for settlements per driver, and
+    /// returns the new sender.
     async fn get_settlement_queue_sender(
         self: &Arc<Self>,
         driver_name: &str,

--- a/crates/autopilot/src/run_loop.rs
+++ b/crates/autopilot/src/run_loop.rs
@@ -61,7 +61,7 @@ pub struct RunLoop {
     /// Maintenance tasks that should run before every runloop to have
     /// the most recent data available.
     pub maintenance: Arc<Maintenance>,
-    /// Queues by solver for executing settle futures one by one guarantying
+    /// Queues by solver for executing settle futures one by one guaranteeing
     /// FIFO execution order.
     settlement_queues: Arc<Mutex<HashMap<String, mpsc::UnboundedSender<BoxFuture<'static, ()>>>>>,
 }
@@ -775,8 +775,6 @@ impl RunLoop {
             .lock()
             .await
             .retain(|order| !solved_order_uids.contains(order));
-
-        self.settlement_queues.lock().await.remove(&driver.name);
 
         Ok(())
     }


### PR DESCRIPTION
# Description
If an order is placed right after the auction cut, the user will wait for the whole runloop until their order gets picked up.

# Changes
- Start preparing a new auction once a winning solution is found.
- For this, the in-flight orders cache had to be restored.
- `settlement_queues` controls FIFO ordered settlement executions for each driver separately. The maximum length of the queue is naturally defined by the settlement block deadline.
- Store drivers as `Vec<Arc<infra::Driver>>` to have access to them from the background task.

The `/solve` request for the next auction is now sent while waiting for the current auction settlement.

## How to test
Existing tests.