### PR TITLE
Runloop maintenance stage metrics

### DIFF
--- a/crates/autopilot/src/maintenance.rs
+++ b/crates/autopilot/src/maintenance.rs
@@ -220,7 +220,10 @@ struct Metrics {
     updates: IntCounterVec,
 
     /// Autopilot maintenance stage time
-    #[metric(labels("stage"))]
+    #[metric(
+        labels("stage"),
+        buckets(0.01, 0.05, 0.1, 0.25, 0.5, 0.75, 1, 1.5, 2.0, 2.5, 3, 3.5, 4)
+    )]
     maintenance_stage_time: HistogramVec,
 }
 


### PR DESCRIPTION
# Description
Since the syncronized runloop mode was enabled, the maintenance task is on the critical auction preparation path now, which takes some time. New metrics should help finding the most expensive operations in order to find a way to optimize them.
<img width="476" alt="image" src="https://github.com/user-attachments/assets/921c7059-f5a9-493e-a71b-7af63cb479fd">

# Changes
A new HistogramVec metric with the `stage` label.

## How to test
Grafana.