### PR TITLE
[PoC] Single run blocks count metric

### DIFF
--- a/crates/autopilot/src/run_loop.rs
+++ b/crates/autopilot/src/run_loop.rs
@@ -305,7 +305,7 @@ impl RunLoop {
                                 .eth
                                 .transaction(tx_id)
                                 .await
-                                .map(|tx| tx.block.0 - start_block + 1)
+                                .map(|tx| tx.block.0 - start_block)
                                 .ok();
                             Metrics::single_run_completed(elapsed, blocks_mined);
                         });

--- a/crates/autopilot/src/run_loop.rs
+++ b/crates/autopilot/src/run_loop.rs
@@ -791,7 +791,7 @@ struct Metrics {
     single_run_time: prometheus::Histogram,
 
     /// Total number of blocks mined during the single run loop.
-    #[metric(buckets(0, 1, 2, 3, 4, 5, 6, 10, 20, 30, 40))]
+    #[metric(buckets(0, 1, 2, 3, 4, 5, 6, 10, 20, 30, 40, 60, 80, 100, 120))]
     single_run_blocks_count: prometheus::Histogram,
 
     /// Time difference between the current block and when the single run


### PR DESCRIPTION
# Description
To increase the visibility of moving towards the one auction per block, a new metric is added, which simply shows how many blocks were mined during the single runloop.

Buckets with high values should be useful for the arb1 chain.

I was also thinking about similar metrics for the `/settle`, but not sure it will be useful. Open to other ideas.

## How to test
Grafana.