### PR TITLE
[PROPOSAL] Enforce CoinGecko batching

### DIFF
--- a/crates/shared/src/price_estimation/buffered.rs
+++ b/crates/shared/src/price_estimation/buffered.rs
@@ -45,7 +45,7 @@ pub struct Configuration {
 /// Trait for fetching a batch of native price estimates.
 #[allow(dead_code)]
 #[cfg_attr(test, mockall::automock)]
-pub trait NativePriceBatchFetching: Sync + Send + NativePriceEstimating {
+pub trait NativePriceBatchFetching: Sync + Send {
     /// Fetches a batch of native price estimates.
     ///
     /// It returns a HashMap which maps the token with its native price
@@ -83,7 +83,7 @@ struct NativePriceResult {
 
 impl<Inner> NativePriceEstimating for BufferedRequest<Inner>
 where
-    Inner: NativePriceBatchFetching + NativePriceEstimating + 'static,
+    Inner: NativePriceBatchFetching + 'static,
 {
     /// Request to get estimate prices in a batch
     fn estimate_native_price(
@@ -132,7 +132,7 @@ where
 #[allow(dead_code)]
 impl<Inner> BufferedRequest<Inner>
 where
-    Inner: NativePriceBatchFetching + Send + Sync + NativePriceEstimating + 'static,
+    Inner: NativePriceBatchFetching + Send + Sync + 'static,
 {
     /// Creates a new buffered transport with the specified configuration.
     pub fn with_config(inner: Inner, config: Configuration) -> Self {

--- a/crates/shared/src/price_estimation/factory.rs
+++ b/crates/shared/src/price_estimation/factory.rs
@@ -218,32 +218,24 @@ impl<'a> PriceEstimatorFactory<'a> {
                 )
                 .await?;
 
-                let coin_gecko: Arc<dyn NativePriceEstimating> =
-                    if let Some(coin_gecko_buffered_configuration) =
-                        &self.args.coin_gecko.coin_gecko_buffered
-                    {
-                        let configuration = buffered::Configuration {
-                            max_concurrent_requests: Some(
-                                coin_gecko
-                                    .max_batch_size()
-                                    .try_into()
-                                    .context("invalid CoinGecko max batch size")?,
-                            ),
-                            debouncing_time: coin_gecko_buffered_configuration
-                                .coin_gecko_debouncing_time
-                                .unwrap(),
-                            result_ready_timeout: coin_gecko_buffered_configuration
-                                .coin_gecko_result_ready_timeout
-                                .unwrap(),
-                            broadcast_channel_capacity: coin_gecko_buffered_configuration
-                                .coin_gecko_broadcast_channel_capacity
-                                .unwrap(),
-                        };
-
-                        Arc::new(BufferedRequest::with_config(coin_gecko, configuration))
-                    } else {
-                        Arc::new(coin_gecko)
+                let coin_gecko: Arc<dyn NativePriceEstimating> = {
+                    let configuration = buffered::Configuration {
+                        max_concurrent_requests: Some(
+                            coin_gecko
+                                .max_batch_size()
+                                .try_into()
+                                .context("invalid CoinGecko max batch size")?,
+                        ),
+                        debouncing_time: self.args.coin_gecko.coin_gecko_debouncing_time,
+                        result_ready_timeout: self.args.coin_gecko.coin_gecko_result_ready_timeout,
+                        broadcast_channel_capacity: self
+                            .args
+                            .coin_gecko
+                            .coin_gecko_broadcast_channel_capacity,
                     };
+
+                    Arc::new(BufferedRequest::with_config(coin_gecko, configuration))
+                };
 
                 Ok(("CoinGecko".into(), coin_gecko))
             }


### PR DESCRIPTION
# Description
Now that we know that the batching works (even tho we don't batch that much yet :sweat: ). I believe we shouldn't implement the trait `NativePriceEstimating` for CoinGecko. We should use the implementation of `NativePriceEstimating` given by its buffering implementation.

Having CoinGecko implementing directly `NativePriceEstimating` may lead to errors, confusions and misuse.

On the other hand, this is not a hill I am willing to die on, and I also see the benefits of potentially having CoinGecko as a fetcher without the buffering, but I don't think we'll ever use it in that way.

# Changes
- Remove `NativePriceEstimating` trait implementation from CoinGecko
- Make the CoinGecko buffering configuration not optional (with default values)

## How to test
1. Regression tests