### PR TITLE
Save fee policies for all auction orders

### DIFF
--- a/crates/autopilot/src/infra/persistence/mod.rs
+++ b/crates/autopilot/src/infra/persistence/mod.rs
@@ -164,6 +164,11 @@ impl Persistence {
         auction_id: domain::auction::Id,
         fee_policies: Vec<(domain::OrderUid, Vec<domain::fee::Policy>)>,
     ) -> anyhow::Result<()> {
+        let _timer = Metrics::get()
+            .database_queries
+            .with_label_values(&["store_fee_policies"])
+            .start_timer();
+
         let mut ex = self.postgres.pool.begin().await.context("begin")?;
         for chunk in fee_policies.chunks(self.postgres.config.insert_batch_size.get()) {
             crate::database::fee_policies::insert_batch(&mut ex, auction_id, chunk.iter().cloned())

--- a/crates/autopilot/src/run_loop.rs
+++ b/crates/autopilot/src/run_loop.rs
@@ -251,22 +251,11 @@ impl RunLoop {
             .iter()
             .map(|participant| participant.solution.solver().into())
             .collect::<HashSet<_>>();
-
-        let mut fee_policies = Vec::new();
-        for order_id in winning_solution.order_ids() {
-            match auction
-                .orders
-                .iter()
-                .find(|auction_order| &auction_order.uid == order_id)
-            {
-                Some(auction_order) => {
-                    fee_policies.push((auction_order.uid, auction_order.protocol_fees.clone()));
-                }
-                None => {
-                    tracing::debug!(?order_id, "order not found in auction");
-                }
-            }
-        }
+        let fee_policies = auction
+            .orders
+            .iter()
+            .map(|order| (order.uid, order.protocol_fees.clone()))
+            .collect::<Vec<_>>();
 
         let competition_table = SolverCompetitionDB {
             auction_start_block: auction.block,


### PR DESCRIPTION
# Description
Currently fee policies are saved only for winning solution.

This PR saves fee policies for all auction orders. This is needed for at least two reasons:

1. As discussed [in the PR](https://github.com/cowprotocol/services/pull/2980#issuecomment-2354990062), fee policies will be needed for all proposed solutions during a competition so that the score could be reconstructed in circuit breaker.
2. [For historical get_auction](https://github.com/cowprotocol/services/issues/2844).