### PR TITLE
fix: enable `alloc` feature on `hex` crate

### DIFF
--- a/crates/bytes-hex/Cargo.toml
+++ b/crates/bytes-hex/Cargo.toml
@@ -11,7 +11,7 @@ license = "MIT OR Apache-2.0"
 serde = { workspace = true }
 serde_json = { workspace = true }
 serde_with = { workspace = true }
-hex = { workspace = true }
+hex = { workspace = true, features = ["alloc"] }
 
 [lints]
 workspace = true


### PR DESCRIPTION
# Description
I detected this issue while i was trying to run `unit test` under an individual crate `bytes-hex`. 
I mean to execute `cargo build` or `cargo test` right under `./crates/bytes-hex`. well, as `bytes-hex` is a crate, it's supposed to compile sucessfully & do unit tests independently.  but it cannot even compile.
with an error like:
```
296:8
    |
296 | pub fn decode<T: AsRef<[u8]>>(data: T) -> Result<Vec<u8>, FromHexError> {
    |        ^^^^^^
note: the item is gated behind the `alloc` feature
```
but I also realized the unit tests working well in github Actions. then i forked the code and test a few more scenarios, for examples, if you modify the `Cargo.toml` in the root directory, changing 
`members = ["crates/*"]`
into 
`members = ["crates/bytes-hex"]`
then the github actions will fail with the exact same error, here is the  [github action log ](https://github.com/yanCode/services/actions/runs/10898657291/job/30242328359#step:6:23) from my forked repo FYI.
however, as long as i include some crates which including `bytes-hex`  as dependency, like 
`members = ["crates/model", "crates/bytes-hex"]`
It works successfully as the default which including all crates. I mean `members = ["crates/*"]`

To this point, i realised that these crates like `model` much have smuggled the feature into `bytes-hex` somehow.
I did a lot of research, in the official doc of rust, i learned that is a concept [Feature unification](https://doc.rust-lang.org/cargo/reference/features.html#feature-unification). In short, in a workplace if multi crates/dependencies refer to the same crate, as long as these refers can be resolved to the same version, it will make an union of features from each reference. and the union of features will be available globally among the whole workplace.

for example, `web3` crate is commonly refered as a dependency in many crates, including `model`. if you step into the [dependency of `web3` crate ](https://github.com/tomusdrw/rust-web3/blob/master/Cargo.toml#L21). you can see `hex` is included with default features, that is it comes with `alloc` feature. because of this the feature `alloc` is propogating to `bytes-hex`. that's why it works if putting `bytes-hex` with other crates, it works fine. 
(N.B: `hex` is a commonly used crate with default feature in many dependencies from the crates in the workplace, you can using `cargo tree --all-features` to check.)

# Changes
As long as i can confirm the feature `alloc` of `hex` crate will be introduced by other dependencies into the workplace. so just update `Cargo.toml` inside `bytes-hex`. this can ensure tasks like `build`, `unit test` work inside `bytes-hex` and in the workplace level. while introducing very less (or even no) impacts to the whole workplace.


#How to test
now it can be tested freely either inside `bytes-hex` or in the workplace. in `.devcontainer` or in `github actions`.

# Why open this PR
 I open this PR because this is the first time I learnt how `feature unification` in rust exactly works although it claimed a few hours of mine with which I planed to learn some CoW knowledge.
