### PR TITLE
Use only new format of solve response

### DIFF
--- a/crates/autopilot/src/domain/competition/mod.rs
+++ b/crates/autopilot/src/domain/competition/mod.rs
@@ -1,4 +1,5 @@
 use {
+    super::auction::order,
     crate::{
         domain,
         domain::{auction, eth},
@@ -20,7 +21,7 @@ impl SolutionWithId {
         id: SolutionId,
         solver: eth::Address,
         score: Score,
-        orders: HashMap<domain::OrderUid, TradedAmounts>,
+        orders: HashMap<domain::OrderUid, TradedOrder>,
         prices: auction::Prices,
     ) -> Self {
         Self {
@@ -45,7 +46,7 @@ impl SolutionWithId {
         self.solution.order_ids()
     }
 
-    pub fn orders(&self) -> &HashMap<domain::OrderUid, TradedAmounts> {
+    pub fn orders(&self) -> &HashMap<domain::OrderUid, TradedOrder> {
         self.solution.orders()
     }
 
@@ -58,7 +59,7 @@ impl SolutionWithId {
 pub struct Solution {
     solver: eth::Address,
     score: Score,
-    orders: HashMap<domain::OrderUid, TradedAmounts>,
+    orders: HashMap<domain::OrderUid, TradedOrder>,
     prices: auction::Prices,
 }
 
@@ -66,7 +67,7 @@ impl Solution {
     pub fn new(
         solver: eth::Address,
         score: Score,
-        orders: HashMap<domain::OrderUid, TradedAmounts>,
+        orders: HashMap<domain::OrderUid, TradedOrder>,
         prices: auction::Prices,
     ) -> Self {
         Self {
@@ -89,7 +90,7 @@ impl Solution {
         self.orders.keys()
     }
 
-    pub fn orders(&self) -> &HashMap<domain::OrderUid, TradedAmounts> {
+    pub fn orders(&self) -> &HashMap<domain::OrderUid, TradedOrder> {
         &self.orders
     }
 
@@ -99,11 +100,16 @@ impl Solution {
 }
 
 #[derive(Debug, Copy, Clone)]
-pub struct TradedAmounts {
+pub struct TradedOrder {
+    pub side: order::Side,
+    /// The sell token and limit sell amount of sell token.
+    pub sell: eth::Asset,
+    /// The buy token and limit buy amount of buy token.
+    pub buy: eth::Asset,
     /// The effective amount that left the user's wallet including all fees.
-    pub sell: eth::TokenAmount,
+    pub executed_sell: eth::TokenAmount,
     /// The effective amount the user received after all fees.
-    pub buy: eth::TokenAmount,
+    pub executed_buy: eth::TokenAmount,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, PartialOrd, Display)]

--- a/crates/autopilot/src/run_loop.rs
+++ b/crates/autopilot/src/run_loop.rs
@@ -4,7 +4,7 @@ use {
         database::competition::Competition,
         domain::{
             self,
-            competition::{self, SolutionError, TradedAmounts},
+            competition::{self, SolutionError, TradedOrder},
             eth,
             OrderUid,
         },
@@ -297,8 +297,8 @@ impl RunLoop {
                         .iter()
                         .map(|(id, order)| Order::Colocated {
                             id: (*id).into(),
-                            sell_amount: order.sell.into(),
-                            buy_amount: order.buy.into(),
+                            sell_amount: order.executed_sell.into(),
+                            buy_amount: order.executed_buy.into(),
                         })
                         .collect(),
                     clearing_prices: participant
@@ -458,12 +458,12 @@ impl RunLoop {
         // Returns the surplus difference in the buy token if `left`
         // is better for the trader than `right`, or 0 otherwise.
         // This takes differently partial fills into account.
-        let improvement_in_buy = |left: &TradedAmounts, right: &TradedAmounts| {
+        let improvement_in_buy = |left: &TradedOrder, right: &TradedOrder| {
             // If `left.sell / left.buy < right.sell / right.buy`, left is "better" as the
             // trader either sells less or gets more. This can be reformulated as
             // `right.sell * left.buy > left.sell * right.buy`.
-            let right_sell_left_buy = right.sell.0.full_mul(left.buy.0);
-            let left_sell_right_buy = left.sell.0.full_mul(right.buy.0);
+            let right_sell_left_buy = right.executed_sell.0.full_mul(left.executed_buy.0);
+            let left_sell_right_buy = left.executed_sell.0.full_mul(right.executed_buy.0);
             let improvement = right_sell_left_buy
                 .checked_sub(left_sell_right_buy)
                 .unwrap_or_default();
@@ -472,7 +472,7 @@ impl RunLoop {
             // token. Casting to U256 is safe because the difference is smaller than the
             // original product, which if re-divided by right.sell must fit in U256.
             improvement
-                .checked_div(right.sell.0.into())
+                .checked_div(right.executed_sell.0.into())
                 .map(|v| U256::try_from(v).expect("improvement in buy fits in U256"))
                 .unwrap_or_default()
         };


### PR DESCRIPTION
# Description
A follow up for https://github.com/cowprotocol/services/pull/2984 where we added a new format of /solve response, after which there were two ways to submit /solve response.

This PR deprecates the old way and uses only the new format and adjusts the autopilot domain code to use it (which is needed so we can finally merge https://github.com/cowprotocol/services/pull/2730

Will not merge it until all solvers switch to new format.