### PR TITLE
Abort stuck tests

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,0 +1,2 @@
+[profile.default]
+slow-timeout = { period = "10ms", terminate-after = 4 }

--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,2 +1,2 @@
 [profile.default]
-slow-timeout = { period = "10ms", terminate-after = 4 }
+slow-timeout = { period = "60s", terminate-after = 4 }


### PR DESCRIPTION
# Description
Some [test](https://github.com/cowprotocol/services/actions/runs/10935547840/job/30357491587?pr=3000) in the CI got stuck when testing a completely harmless PR.
To keep the logs of the CI relatively clean we only log the actual output of a test if it fails.
At the moment stuck tests run forever and don't get terminated by `nextest` which means we can't recover how far into the test we got before it got stuck which could help to figure out what the issue is.

# Changes
configures `nextest` to warn about a test being slow for every minute of runtime and aborts it after 4 minutes.
This will then result in logs being printed.

## How to test
Ran some tests locally with a very low `period` which produced the desired behavior.