### PR TITLE
EventIndexing: add fast path for multiple new blocks without reorg

### DIFF
--- a/crates/shared/src/event_handling.rs
+++ b/crates/shared/src/event_handling.rs
@@ -207,7 +207,9 @@ where
         // Special case where multiple new blocks were added and no reorg happened.
         // Because we need to fetch the full block range we only do this if the number
         // of new blocks is sufficiently small.
-        if let Ok(block_range) = RangeInclusive::try_new(last_handled_block_number, current_block_number) {
+        if let Ok(block_range) =
+            RangeInclusive::try_new(last_handled_block_number, current_block_number)
+        {
             if block_range.end() - block_range.start() <= MAX_REORG_BLOCK_COUNT {
                 let mut new_blocks = self.block_retriever.blocks(block_range).await?;
                 if new_blocks.first().map(|b| b.1) == Some(last_handled_block_hash) {


### PR DESCRIPTION
# Description
Recently we moved some event indexing onto the hot path for auction building. This turned out to be surprisingly slow (500ms - 750ms) quite often [[1](https://g-0263500beb.grafana-workspace.eu-central-1.amazonaws.com/d/bdva97ea9wni8e/autopilot-runloop?orgId=1&from=now-12h&to=now&var-network=mainnet&var-datasource=5An5Ejq4k&var-driver=All&var-runloop_maintenance_stage=settlement_indexer&var-auction_update_stage=All&editPanel=14)]. Judging by the logs the prod mainnet autopilot entered the event indexing logic ~24K times [[2](https://aws-es.cow.fi/_dashboards/app/data-explorer/discover#?_a=(discover:(columns:!(log,log_level),isDirty:!f,sort:!()),metadata:(indexPattern:'86e4a5a0-4e4b-11ef-85c5-3946a99ed1a7',view:discover))&_g=(filters:!(),refreshInterval:(pause:!t,value:0),time:(from:now-24h,to:now))&_q=(filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'86e4a5a0-4e4b-11ef-85c5-3946a99ed1a7',key:kubernetes.container_name,negate:!f,params:(query:mainnet-autopilot-prod),type:phrase),query:(match_phrase:(kubernetes.container_name:mainnet-autopilot-prod)))),query:(language:kuery,query:'log:%20%22current%20block%22%20and%20log:%20%22handled_blocks%22%20and%20mainnet')))]. Around half the time we hit the code path were do not add 0 or 1 blocks to the index (those are the fast paths) [[3](https://aws-es.cow.fi/_dashboards/app/data-explorer/discover#?_a=(discover:(columns:!(log,log_level),isDirty:!f,sort:!()),metadata:(indexPattern:'86e4a5a0-4e4b-11ef-85c5-3946a99ed1a7',view:discover))&_g=(filters:!(),refreshInterval:(pause:!t,value:0),time:(from:now-24h,to:now))&_q=(filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'86e4a5a0-4e4b-11ef-85c5-3946a99ed1a7',key:kubernetes.container_name,negate:!f,params:(query:mainnet-autopilot-prod),type:phrase),query:(match_phrase:(kubernetes.container_name:mainnet-autopilot-prod))),('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'86e4a5a0-4e4b-11ef-85c5-3946a99ed1a7',key:log,negate:!f,params:(query:'shared::event_handling'),type:phrase),query:(match_phrase:(log:'shared::event_handling')))),query:(language:kuery,query:'log:%20%22history%20range%22%20and%20mainnet')))].

It looks like the indexing logic assumes that it runs on every block. And if the current block is not the last handled block or the next block after it suspects a reorg happened somewhere (this is the slow path). In that case it fetches the entire range of blocks we consider not finalized to check for the reorg. This effectively means on 50% of indexing runs we fetch the last 64 blocks which takes a lot of time and spams the RPC node.

# Changes
I handled the case where multiple new blocks got added without any reorg. For that I fetch the range `[last_handled_block_number, current_block_number]`. If the block hash returned for `last_handled_block_number` is equal to the hash of the last block we handled it means all those blocks are just new **but not reorged**.
This special handling should make it such that for the vast majority of cases we only fetch the number of blocks we missed (+1) instead of >64 blocks.

## How to test
I copied one existing ignored test and adjusted it slightly. By waiting for ~25s between 2 updates we know that we hit the problematic code path. While running the test I also added a log `"fetch block"` which prints how many blocks the code would try to fetch. With the original code we can see 3 fetches (127, 64, 66) where 66 is the problematic fetch.
With the new changes the same test logged 127, 64 and 3 fetches instead.

Given that the test is ignored (i.e. manual) anyway I'll remove it before merging this PR.

@sunce86 could you please take a close look at this PR? I believe you were very involved in this logic and I find it very hard to understand so I would appreciate a thorough review to not blow up the indexing logic by accident. I tried to make the change as side effect free as possible but TBH I still have only moderate confidence that this is actually correct.

<details>
<summary>run without change</summary>

```
2024-09-24T19:27:31.524969Z DEBUG shared::event_handling: current block: 20822542 - 0xc3a91f01c98573ae4e0c34905d4b3cf5876195f59254179d9170cd68f8419864, handled_blocks: (Some(20822242) - Some(20822242))
2024-09-24T19:27:31.525205Z DEBUG shared::event_handling: history range Some(RangeInclusive { start: 20822178, end: 20822414 }), latest_range RangeInclusive { start: 20822415, end: 20822542 }
2024-09-24T19:27:31.525313Z ERROR ethrpc::block_stream: fetch blocks len=127
2024-09-24T19:27:31.995576Z DEBUG shared::event_handling: latest blocks: Some((20822415, 0xf87e3f028de95770f95b230536d74452f7a78f2f0f583f3f4bd041e33989b98f)) - Some((20822542, 0xc3a91f01c98573ae4e0c34905d4b3cf5876195f59254179d9170cd68f8419864))
2024-09-24T19:27:31.995639Z DEBUG shared::event_handling: final latest blocks Some((20822415, 0xf87e3f028de95770f95b230536d74452f7a78f2f0f583f3f4bd041e33989b98f)) - Some((20822542, 0xc3a91f01c98573ae4e0c34905d4b3cf5876195f59254179d9170cd68f8419864)), is reorg: true
2024-09-24T19:27:31.995676Z ERROR ethrpc::block_stream: fetch blocks len=64
2024-09-24T19:27:32.310109Z DEBUG shared::event_handling: blocks to update into last_handled_blocks: Some((20822350, 0x01250c2b63749570fb0b87eaa222f303b90eda0fc0f449b74e8f188c87bbb69c)) - Some((20822414, 0x7d5fb4e7ca13fa6d4696664687fb4d7adcc5bb70cb757a2275ad5eeddfaa2e39)), last_handled_blocks: Some((20822242, 0xc3d81c74ac58b189f9eec07e3f58f83552624594ca4516a8774becb1ef6cddb7)) - Some((20822242, 0xc3d81c74ac58b189f9eec07e3f58f83552624594ca4516a8774becb1ef6cddb7))
2024-09-24T19:27:32.310225Z DEBUG shared::event_handling: last_handled_blocks after update: Some((20822351, 0x0866b6152b54d9454b7253346dafdff089fe544f774ca3553a5e230beb25c599)) - Some((20822414, 0x7d5fb4e7ca13fa6d4696664687fb4d7adcc5bb70cb757a2275ad5eeddfaa2e39))
2024-09-24T19:27:33.187629Z DEBUG shared::event_handling: events fetched for block: (20822415, 0xf87e3f028de95770f95b230536d74452f7a78f2f0f583f3f4bd041e33989b98f), events: 4
2024-09-24T19:27:33.187690Z DEBUG shared::event_handling: events fetched for block: (20822416, 0x7a6fc197323ee2e2274462c6fc05bd9b48d7d86a5cce366e75fb7f92ce3a6f1d), events: 4
2024-09-24T19:27:33.187701Z DEBUG shared::event_handling: events fetched for block: (20822419, 0x68c599c71080c5f018e41bba643548c1724d4877020d5291f4439bc2753f0f57), events: 4
2024-09-24T19:27:33.187710Z DEBUG shared::event_handling: events fetched for block: (20822421, 0xadde2cc33124316e3ba6c04b355f392946363993dad48a3b351ceef557a080dc), events: 7
2024-09-24T19:27:33.187721Z DEBUG shared::event_handling: events fetched for block: (20822424, 0xd69013ac25458d7e47474a9e47a92f438ce54d670f55f9c72802a9fcd11e7ba8), events: 4
2024-09-24T19:27:33.187768Z DEBUG shared::event_handling: events fetched for block: (20822426, 0x73ce9515341bc09ced0ef1e82627f7660fded7f37353fef4f1e1b04deb374c7c), events: 3
2024-09-24T19:27:33.187777Z DEBUG shared::event_handling: events fetched for block: (20822427, 0xdeedb9170d717961ebd4c956ec37f57f56bce49dd5ec59b3d35af0cf7f2f2cfc), events: 6
2024-09-24T19:27:33.187788Z DEBUG shared::event_handling: events fetched for block: (20822435, 0x65bea17e20bb4b684726bb1ee8c61c58c2c703d676a38676487d7f38fe9ed194), events: 4
2024-09-24T19:27:33.187796Z DEBUG shared::event_handling: events fetched for block: (20822437, 0xfce692afcf02389fae6dd992197d8a8a7f55306dd016ca4fba0a89f206f9351d), events: 4
2024-09-24T19:27:33.187805Z DEBUG shared::event_handling: events fetched for block: (20822439, 0x63bbca94f8a9fc7e14b03a9d50c00b14c9aeaa7c32a0a7e47765898aa0158beb), events: 10
2024-09-24T19:27:33.188025Z DEBUG shared::event_handling: events fetched for block: (20822441, 0xf53cedb6def926141c68641ffeca663c5d38c161a6564e935de0812596b0b33c), events: 4
2024-09-24T19:27:33.188034Z DEBUG shared::event_handling: events fetched for block: (20822443, 0x7f195d7e6378d3df459af3d2fcf28058abe0a5b389d8a5e3c53895aeec4ca5f9), events: 4
2024-09-24T19:27:33.188045Z DEBUG shared::event_handling: events fetched for block: (20822459, 0x5ff7cc9df1d5810ba91486db64fc83ebb8c8d52e7ced63e6e70bf79c9817019a), events: 3
2024-09-24T19:27:33.188054Z DEBUG shared::event_handling: events fetched for block: (20822462, 0x3f5edbfcf16053956b5d2951d2b9925fa20454c0c1c706ebb744c17a11106202), events: 5
2024-09-24T19:27:33.188065Z DEBUG shared::event_handling: events fetched for block: (20822464, 0x47f35050424a87cbd17b5e4a9947f81dc24cea4545c63df80d8eb65cb55e0cd2), events: 3
2024-09-24T19:27:33.188310Z DEBUG shared::event_handling: events fetched for block: (20822471, 0x1c8ae8413801fc0fdcba5f9a9124a43fe1beafeed4f92889cb39ba6ee013d188), events: 10
2024-09-24T19:27:33.188320Z DEBUG shared::event_handling: events fetched for block: (20822473, 0xc3624cad376e0864609a079593daed31d96cc9e6909ad096a5722b2406dbb203), events: 5
2024-09-24T19:27:33.188329Z DEBUG shared::event_handling: events fetched for block: (20822476, 0x2f3e75de1d200d224041219dc52620526e6037363ddf39782d09ecf0ec579f3d), events: 3
2024-09-24T19:27:33.188337Z DEBUG shared::event_handling: events fetched for block: (20822479, 0x650d4d339852673ad33b1943ac9fdc1569a1d73dbd8735dc365d88ae77763923), events: 4
2024-09-24T19:27:33.188348Z DEBUG shared::event_handling: events fetched for block: (20822489, 0xe0c8adf01e50a1eef83e2403963f0c7c50393dc83c9a08788c8657201d2b158b), events: 4
2024-09-24T19:27:33.188407Z DEBUG shared::event_handling: events fetched for block: (20822491, 0x91403b4f26aea37790e70e26ca9e2856671a21ccbeaac18914f6d3b736c5b873), events: 8
2024-09-24T19:27:33.188416Z DEBUG shared::event_handling: events fetched for block: (20822493, 0x2b9dd46846fb79d33e40d82a438f6274b404127a69f943cc006868873f913710), events: 9
2024-09-24T19:27:33.188425Z DEBUG shared::event_handling: events fetched for block: (20822496, 0x19a0824ec7bc114a2b14b47cce413f55f9526f104871b77ff19a85fa519b39d1), events: 8
2024-09-24T19:27:33.188434Z DEBUG shared::event_handling: events fetched for block: (20822499, 0x89fe1cfb496762d4a57ba9bb99a3cfc240f20399daf369acb639975f3c1da2bf), events: 4
2024-09-24T19:27:33.188441Z DEBUG shared::event_handling: events fetched for block: (20822500, 0x5dbd05a161c3aaa6d6f635469f0a621060835f9fc505a506c7c4bfbd55e879ae), events: 6
2024-09-24T19:27:33.188512Z DEBUG shared::event_handling: events fetched for block: (20822507, 0x8c7df34acd97df9cdef3d4677fb1460a30a29b8501e0d7b3ce19427e528f4efc), events: 4
2024-09-24T19:27:33.188524Z DEBUG shared::event_handling: events fetched for block: (20822522, 0xfbe100a8b1833b2137ff09275d2f84b15c594df19d95df3cb2bb2581540bd3a1), events: 10
2024-09-24T19:27:33.188533Z DEBUG shared::event_handling: events fetched for block: (20822528, 0xf28a0cf526cf99c0fc54c8ceab36cf85ef8951f8ba1f19e58a9cd959893ab13e), events: 4
2024-09-24T19:27:33.188541Z DEBUG shared::event_handling: events fetched for block: (20822530, 0x4729dd4a0708e1c90de09c49c8e8a0ff2bdac26da63d0b233ef5278fee8570d4), events: 8
2024-09-24T19:27:33.188549Z DEBUG shared::event_handling: events fetched for block: (20822532, 0x17f8ca6da636aae418a6a9583a686b757fd85cafae2b7d8ba1c3bedf792f6ab1), events: 3
2024-09-24T19:27:33.188644Z DEBUG shared::event_handling: events fetched for block: (20822536, 0x4e12278ec65cf89e49229aecfdfe723d0a176e9a4f3ef8f7c22603fd47e5a746), events: 7
2024-09-24T19:27:33.189177Z DEBUG shared::event_handling: blocks to update into last_handled_blocks: Some((20822415, 0xf87e3f028de95770f95b230536d74452f7a78f2f0f583f3f4bd041e33989b98f)) - Some((20822542, 0xc3a91f01c98573ae4e0c34905d4b3cf5876195f59254179d9170cd68f8419864)), last_handled_blocks: Some((20822351, 0x0866b6152b54d9454b7253346dafdff089fe544f774ca3553a5e230beb25c599)) - Some((20822414, 0x7d5fb4e7ca13fa6d4696664687fb4d7adcc5bb70cb757a2275ad5eeddfaa2e39))
2024-09-24T19:27:33.189210Z DEBUG shared::event_handling: last_handled_blocks after update: Some((20822479, 0x650d4d339852673ad33b1943ac9fdc1569a1d73dbd8735dc365d88ae77763923)) - Some((20822542, 0xc3a91f01c98573ae4e0c34905d4b3cf5876195f59254179d9170cd68f8419864))
2024-09-24T19:27:33.189278Z  INFO shared::event_handling::tests: wait for at least 2 blocks to see if we hit the new code path
2024-09-24T19:27:59.250673Z DEBUG shared::event_handling: current block: 20822544 - 0x7736a02e489fc851aa8be6f7bf1bde92899553ddfcfa50daedfcc0306e72cd24, handled_blocks: (Some(20822479) - Some(20822542))
2024-09-24T19:27:59.250797Z DEBUG shared::event_handling: history range None, latest_range RangeInclusive { start: 20822478, end: 20822544 }
2024-09-24T19:27:59.250822Z ERROR ethrpc::block_stream: fetch blocks len=66
2024-09-24T19:27:59.548357Z DEBUG shared::event_handling: latest blocks: Some((20822478, 0x04ea76707dd932a25be08dfcc782932e8e1b3aa2ec835065c1d9093dc97b37dc)) - Some((20822544, 0x7736a02e489fc851aa8be6f7bf1bde92899553ddfcfa50daedfcc0306e72cd24))
2024-09-24T19:27:59.548405Z DEBUG shared::event_handling: final latest blocks Some((20822543, 0x2285193595843415e4d290a8705771af543ee30ea73d0abaedba23ab3438e6b9)) - Some((20822544, 0x7736a02e489fc851aa8be6f7bf1bde92899553ddfcfa50daedfcc0306e72cd24)), is reorg: false
2024-09-24T19:27:59.583168Z DEBUG shared::event_handling: events fetched for block: (20822543, 0x2285193595843415e4d290a8705771af543ee30ea73d0abaedba23ab3438e6b9), events: 12
2024-09-24T19:27:59.583282Z DEBUG shared::event_handling: blocks to update into last_handled_blocks: Some((20822543, 0x2285193595843415e4d290a8705771af543ee30ea73d0abaedba23ab3438e6b9)) - Some((20822544, 0x7736a02e489fc851aa8be6f7bf1bde92899553ddfcfa50daedfcc0306e72cd24)), last_handled_blocks: Some((20822479, 0x650d4d339852673ad33b1943ac9fdc1569a1d73dbd8735dc365d88ae77763923)) - Some((20822542, 0xc3a91f01c98573ae4e0c34905d4b3cf5876195f59254179d9170cd68f8419864))
2024-09-24T19:27:59.583308Z DEBUG shared::event_handling: last_handled_blocks after update: Some((20822481, 0x818489551892288af5d8bbf4d7d31285b74946247a9274ea40b73a0b86211b0f)) - Some((20822544, 0x7736a02e489fc851aa8be6f7bf1bde92899553ddfcfa50daedfcc0306e72cd24))
```
</details>

<details>
<summary>run with change</summary>

```
2024-09-24T19:40:23.390315Z DEBUG shared::event_handling: current block: 20822605 - 0xab39d6aa6a558a0943fbdd068261e4c708f1b8c58d2f1f45da610005caf331c1, handled_blocks: (Some(20822305) - Some(20822305))
2024-09-24T19:40:23.390434Z DEBUG shared::event_handling: history range Some(RangeInclusive { start: 20822241, end: 20822477 }), latest_range RangeInclusive { start: 20822478, end: 20822605 }
2024-09-24T19:40:23.390447Z ERROR ethrpc::block_stream: fetch blocks len=127
2024-09-24T19:40:23.854637Z DEBUG shared::event_handling: latest blocks: Some((20822478, 0x04ea76707dd932a25be08dfcc782932e8e1b3aa2ec835065c1d9093dc97b37dc)) - Some((20822605, 0xab39d6aa6a558a0943fbdd068261e4c708f1b8c58d2f1f45da610005caf331c1))
2024-09-24T19:40:23.854686Z DEBUG shared::event_handling: final latest blocks Some((20822478, 0x04ea76707dd932a25be08dfcc782932e8e1b3aa2ec835065c1d9093dc97b37dc)) - Some((20822605, 0xab39d6aa6a558a0943fbdd068261e4c708f1b8c58d2f1f45da610005caf331c1)), is reorg: true
2024-09-24T19:40:23.854718Z ERROR ethrpc::block_stream: fetch blocks len=64
2024-09-24T19:40:24.168547Z DEBUG shared::event_handling: blocks to update into last_handled_blocks: Some((20822413, 0x6641194adc04f99d29557e66d3aae16b7508f7628bd537770b135231c79b008c)) - Some((20822477, 0xfc5730deb45f5f32e27895111277a389cd7578e296c17990ea4f4f40ae5808db)), last_handled_blocks: Some((20822305, 0xe97a80cedc525afa87da3f1edf60076eb5426b3f14bae811e3a5a6baff153bc9)) - Some((20822305, 0xe97a80cedc525afa87da3f1edf60076eb5426b3f14bae811e3a5a6baff153bc9))
2024-09-24T19:40:24.168614Z DEBUG shared::event_handling: last_handled_blocks after update: Some((20822414, 0x7d5fb4e7ca13fa6d4696664687fb4d7adcc5bb70cb757a2275ad5eeddfaa2e39)) - Some((20822477, 0xfc5730deb45f5f32e27895111277a389cd7578e296c17990ea4f4f40ae5808db))
2024-09-24T19:40:25.079068Z DEBUG shared::event_handling: events fetched for block: (20822479, 0x650d4d339852673ad33b1943ac9fdc1569a1d73dbd8735dc365d88ae77763923), events: 4
2024-09-24T19:40:25.079157Z DEBUG shared::event_handling: events fetched for block: (20822489, 0xe0c8adf01e50a1eef83e2403963f0c7c50393dc83c9a08788c8657201d2b158b), events: 4
2024-09-24T19:40:25.079185Z DEBUG shared::event_handling: events fetched for block: (20822491, 0x91403b4f26aea37790e70e26ca9e2856671a21ccbeaac18914f6d3b736c5b873), events: 8
2024-09-24T19:40:25.079212Z DEBUG shared::event_handling: events fetched for block: (20822493, 0x2b9dd46846fb79d33e40d82a438f6274b404127a69f943cc006868873f913710), events: 9
2024-09-24T19:40:25.079234Z DEBUG shared::event_handling: events fetched for block: (20822496, 0x19a0824ec7bc114a2b14b47cce413f55f9526f104871b77ff19a85fa519b39d1), events: 8
2024-09-24T19:40:25.079251Z DEBUG shared::event_handling: events fetched for block: (20822499, 0x89fe1cfb496762d4a57ba9bb99a3cfc240f20399daf369acb639975f3c1da2bf), events: 4
2024-09-24T19:40:25.079267Z DEBUG shared::event_handling: events fetched for block: (20822500, 0x5dbd05a161c3aaa6d6f635469f0a621060835f9fc505a506c7c4bfbd55e879ae), events: 6
2024-09-24T19:40:25.079284Z DEBUG shared::event_handling: events fetched for block: (20822507, 0x8c7df34acd97df9cdef3d4677fb1460a30a29b8501e0d7b3ce19427e528f4efc), events: 4
2024-09-24T19:40:25.079478Z DEBUG shared::event_handling: events fetched for block: (20822522, 0xfbe100a8b1833b2137ff09275d2f84b15c594df19d95df3cb2bb2581540bd3a1), events: 10
2024-09-24T19:40:25.079506Z DEBUG shared::event_handling: events fetched for block: (20822528, 0xf28a0cf526cf99c0fc54c8ceab36cf85ef8951f8ba1f19e58a9cd959893ab13e), events: 4
2024-09-24T19:40:25.079524Z DEBUG shared::event_handling: events fetched for block: (20822530, 0x4729dd4a0708e1c90de09c49c8e8a0ff2bdac26da63d0b233ef5278fee8570d4), events: 8
2024-09-24T19:40:25.079618Z DEBUG shared::event_handling: events fetched for block: (20822532, 0x17f8ca6da636aae418a6a9583a686b757fd85cafae2b7d8ba1c3bedf792f6ab1), events: 3
2024-09-24T19:40:25.079637Z DEBUG shared::event_handling: events fetched for block: (20822536, 0x4e12278ec65cf89e49229aecfdfe723d0a176e9a4f3ef8f7c22603fd47e5a746), events: 7
2024-09-24T19:40:25.080014Z DEBUG shared::event_handling: events fetched for block: (20822543, 0x2285193595843415e4d290a8705771af543ee30ea73d0abaedba23ab3438e6b9), events: 12
2024-09-24T19:40:25.080035Z DEBUG shared::event_handling: events fetched for block: (20822546, 0xd071b60457b3697c6f683ed0ee355aa50026e512b0bcfb6a322a313b6fca5889), events: 5
2024-09-24T19:40:25.080051Z DEBUG shared::event_handling: events fetched for block: (20822547, 0xa1370e125444e00c5a4be9d3575927c335f68727628365b5fea2bdc7eb416457), events: 5
2024-09-24T19:40:25.080075Z DEBUG shared::event_handling: events fetched for block: (20822552, 0x14bfbb13cff143999b7e607f636f44a739330b7dc7846a6547fe3f9ecf68aa9f), events: 4
2024-09-24T19:40:25.080092Z DEBUG shared::event_handling: events fetched for block: (20822554, 0x3059919e52677aad6e913e4e2789834e502ab15a39d814cf4dc7bb78005a02c5), events: 4
2024-09-24T19:40:25.080178Z DEBUG shared::event_handling: events fetched for block: (20822557, 0xe1b7e1fca719235f5842db492c39d83cca8d39a72e0fbb5d6aededbfbc1370d1), events: 7
2024-09-24T19:40:25.080205Z DEBUG shared::event_handling: events fetched for block: (20822560, 0x93f11c030485b851c7a612a98adc07635f7c004ad75d24b5bb6587d7bc7acd87), events: 13
2024-09-24T19:40:25.080226Z DEBUG shared::event_handling: events fetched for block: (20822565, 0x2126b57113ef00c4cbe5e4522d647c938624c3b4c781a725659e323a4d902c09), events: 10
2024-09-24T19:40:25.080242Z DEBUG shared::event_handling: events fetched for block: (20822567, 0xa6c201356d53a6e5a1ffdc5decf071a4180b7571c0012a32f1d9e8cb43d6d124), events: 5
2024-09-24T19:40:25.080265Z DEBUG shared::event_handling: events fetched for block: (20822569, 0xbdc8105794f1820baf24b1d1db9e643ad53d1b9c8277d0968136fb0b6a4c5ed8), events: 4
2024-09-24T19:40:25.080345Z DEBUG shared::event_handling: events fetched for block: (20822580, 0x983941b55933e58536822137679ba55499d34a78ce0ff2e949c9c5285020baf2), events: 4
2024-09-24T19:40:25.080365Z DEBUG shared::event_handling: events fetched for block: (20822582, 0xdf65b0d99d43ec1755f8085c4b349c37ccec6126b0fd7c16ebcebb841c636922), events: 4
2024-09-24T19:40:25.080382Z DEBUG shared::event_handling: events fetched for block: (20822589, 0xbabb91771080ddce645310fc2b52521337bfad7a90f11958be650d50bdb6a173), events: 4
2024-09-24T19:40:25.080399Z DEBUG shared::event_handling: events fetched for block: (20822592, 0xd9c9f0c7c5c8883847480ca551ee70a4cb88b2865caa9f9db956b1da83039d75), events: 4
2024-09-24T19:40:25.080414Z DEBUG shared::event_handling: events fetched for block: (20822593, 0x6351f327e36f1913a3f54f65fce5ee924f59fbc9b033a893c11313a7f984fa22), events: 3
2024-09-24T19:40:25.080512Z DEBUG shared::event_handling: events fetched for block: (20822595, 0xd173609960ce1e3404ba063b764b748bc67cd83f026de9234305b131133e47eb), events: 4
2024-09-24T19:40:25.080530Z DEBUG shared::event_handling: events fetched for block: (20822597, 0xd503ec489cfc7848c0520a5029d4207afa6eaf7dabe98c667fe80951b7c51332), events: 8
2024-09-24T19:40:25.081309Z DEBUG shared::event_handling: blocks to update into last_handled_blocks: Some((20822478, 0x04ea76707dd932a25be08dfcc782932e8e1b3aa2ec835065c1d9093dc97b37dc)) - Some((20822605, 0xab39d6aa6a558a0943fbdd068261e4c708f1b8c58d2f1f45da610005caf331c1)), last_handled_blocks: Some((20822414, 0x7d5fb4e7ca13fa6d4696664687fb4d7adcc5bb70cb757a2275ad5eeddfaa2e39)) - Some((20822477, 0xfc5730deb45f5f32e27895111277a389cd7578e296c17990ea4f4f40ae5808db))
2024-09-24T19:40:25.081359Z DEBUG shared::event_handling: last_handled_blocks after update: Some((20822542, 0xc3a91f01c98573ae4e0c34905d4b3cf5876195f59254179d9170cd68f8419864)) - Some((20822605, 0xab39d6aa6a558a0943fbdd068261e4c708f1b8c58d2f1f45da610005caf331c1))
2024-09-24T19:40:25.081458Z  INFO shared::event_handling::tests: wait for at least 2 blocks to see if we hit the new code path
2024-09-24T19:40:51.149252Z DEBUG shared::event_handling: current block: 20822608 - 0xb72f19def275ba8d46bb3f840627054cc065cf43cf257cff21072f30416b8cb2, handled_blocks: (Some(20822542) - Some(20822605))
2024-09-24T19:40:51.149354Z ERROR ethrpc::block_stream: fetch blocks len=3
2024-09-24T19:40:51.225757Z DEBUG shared::event_handling: multiple new blocks without reorg history=None first_new=Some((20822605, 0xab39d6aa6a558a0943fbdd068261e4c708f1b8c58d2f1f45da610005caf331c1)) last_new=Some((20822608, 0xb72f19def275ba8d46bb3f840627054cc065cf43cf257cff21072f30416b8cb2))
2024-09-24T19:40:51.261634Z DEBUG shared::event_handling: events fetched for block: (20822607, 0xd9a7b03cbf8e1844245dccfa7ea39143ed86838fee59b47603ea8ccc457e1f70), events: 7
2024-09-24T19:40:51.261830Z DEBUG shared::event_handling: blocks to update into last_handled_blocks: Some((20822605, 0xab39d6aa6a558a0943fbdd068261e4c708f1b8c58d2f1f45da610005caf331c1)) - Some((20822608, 0xb72f19def275ba8d46bb3f840627054cc065cf43cf257cff21072f30416b8cb2)), last_handled_blocks: Some((20822542, 0xc3a91f01c98573ae4e0c34905d4b3cf5876195f59254179d9170cd68f8419864)) - Some((20822605, 0xab39d6aa6a558a0943fbdd068261e4c708f1b8c58d2f1f45da610005caf331c1))
2024-09-24T19:40:51.261882Z DEBUG shared::event_handling: last_handled_blocks after update: Some((20822545, 0x845e28ecfae8010b1b3663b8dc6049f1ad7135d6d812eb40a07211d4e0315f88)) - Some((20822608, 0xb72f19def275ba8d46bb3f840627054cc065cf43cf257cff21072f30416b8cb2))
```
</details>