### PR TITLE
Bring back tracing spans for submission

### DIFF
--- a/crates/autopilot/src/run_loop.rs
+++ b/crates/autopilot/src/run_loop.rs
@@ -313,7 +313,8 @@ impl RunLoop {
                 }
             }
             Metrics::single_run_completed(single_run_start.elapsed());
-        };
+        }
+        .instrument(tracing::Span::current());
 
         let sender = self.get_settlement_queue_sender(&driver.name).await;
         if let Err(err) = sender.send(Box::pin(settle_fut)) {


### PR DESCRIPTION
# Description
When we started to submit solutions in a background task with https://github.com/cowprotocol/services/pull/2986 the logs emitted from the submission future lost all the tracing information of the run loop.
That means you can no longer easily grep for an auction id in the logs and see the submission logs.

# Changes
Instruments the submission future with the current tracing span to bring back the auction id and other data that is available while building the future.