### PR TITLE
[TRIVIAL] Improve logs for created ethflow orders

### DIFF
--- a/crates/autopilot/src/database/onchain_order_events.rs
+++ b/crates/autopilot/src/database/onchain_order_events.rs
@@ -349,7 +349,7 @@ impl<T: Send + Sync + Clone, W: Send + Sync> OnchainOrderParser<T, W> {
             tracing::debug!(?order, "invalidated order");
         }
         for (order, quote) in orders.iter().zip(quotes.iter()) {
-            tracing::debug!(order =? order.uid, ?quote, "upserted order");
+            tracing::debug!(order =? order.uid, ?quote, "order created");
         }
 
         Ok(())


### PR DESCRIPTION
# Description
It annoys me to no end that you have to search different words for order creation depending on whether it was indexed by the autopilot or submitted by the user via the orderbook.
I don't know how much time I already wasted searching for ethflow orders because these logs are different!
**rant over**

# Changes
Makes the onchain order indexing log use the same words as the orderbook.