### PR TITLE
Move settlement updater

### DIFF
--- a/crates/autopilot/src/boundary/events/settlement.rs
+++ b/crates/autopilot/src/boundary/events/settlement.rs
@@ -11,14 +11,14 @@ impl_event_retrieving! {
 
 pub struct Indexer {
     db: Postgres,
-    settlement_updater: settlement::OnEvent,
+    settlement_observer: settlement::Observer,
 }
 
 impl Indexer {
-    pub fn new(db: Postgres, settlement_updater: settlement::OnEvent) -> Self {
+    pub fn new(db: Postgres, settlement_observer: settlement::Observer) -> Self {
         Self {
             db,
-            settlement_updater,
+            settlement_observer,
         }
     }
 }
@@ -41,7 +41,7 @@ impl EventStoring<contracts::gpv2_settlement::Event> for Indexer {
         database::settlements::delete(&mut transaction, from_block).await?;
         transaction.commit().await?;
 
-        self.settlement_updater.update().await;
+        self.settlement_observer.update().await;
         Ok(())
     }
 
@@ -53,7 +53,7 @@ impl EventStoring<contracts::gpv2_settlement::Event> for Indexer {
         crate::database::events::append_events(&mut transaction, events).await?;
         transaction.commit().await?;
 
-        self.settlement_updater.update().await;
+        self.settlement_observer.update().await;
         Ok(())
     }
 }

--- a/crates/autopilot/src/domain/settlement/mod.rs
+++ b/crates/autopilot/src/domain/settlement/mod.rs
@@ -9,10 +9,10 @@ use {
 };
 
 mod auction;
-mod on_event;
+mod observer;
 mod trade;
 mod transaction;
-pub use {auction::Auction, on_event::OnEvent, trade::Trade, transaction::Transaction};
+pub use {auction::Auction, observer::Observer, trade::Trade, transaction::Transaction};
 
 /// A settled transaction together with the `Auction`, for which it was executed
 /// on-chain.

--- a/crates/autopilot/src/domain/settlement/mod.rs
+++ b/crates/autopilot/src/domain/settlement/mod.rs
@@ -9,9 +9,10 @@ use {
 };
 
 mod auction;
+mod on_event;
 mod trade;
 mod transaction;
-pub use {auction::Auction, trade::Trade, transaction::Transaction};
+pub use {auction::Auction, on_event::OnEvent, trade::Trade, transaction::Transaction};
 
 /// A settled transaction together with the `Auction`, for which it was executed
 /// on-chain.

--- a/crates/autopilot/src/domain/settlement/observer.rs
+++ b/crates/autopilot/src/domain/settlement/observer.rs
@@ -22,7 +22,8 @@ pub struct Observer {
 }
 
 impl Observer {
-    /// Creates a new Observer and asynchronously schedules the first update run.
+    /// Creates a new Observer and asynchronously schedules the first update
+    /// run.
     pub fn new(eth: infra::Ethereum, persistence: infra::Persistence) -> Self {
         Self { eth, persistence }
     }

--- a/crates/autopilot/src/domain/settlement/observer.rs
+++ b/crates/autopilot/src/domain/settlement/observer.rs
@@ -16,13 +16,13 @@ use {
 };
 
 #[derive(Clone)]
-pub struct OnEvent {
+pub struct Observer {
     eth: infra::Ethereum,
     persistence: infra::Persistence,
 }
 
-impl OnEvent {
-    /// Creates a new OnEvent and asynchronously schedules the first update run.
+impl Observer {
+    /// Creates a new Observer and asynchronously schedules the first update run.
     pub fn new(eth: infra::Ethereum, persistence: infra::Persistence) -> Self {
         Self { eth, persistence }
     }
@@ -113,7 +113,7 @@ impl OnEvent {
     }
 }
 
-/// Whether OnEvent loop should retry on the given error.
+/// Whether Observer loop should retry on the given error.
 fn retryable(err: &settlement::Error) -> bool {
     match err {
         settlement::Error::Infra(_) => true,

--- a/crates/autopilot/src/domain/settlement/on_event.rs
+++ b/crates/autopilot/src/domain/settlement/on_event.rs
@@ -12,33 +12,20 @@
 
 use {
     crate::{domain::settlement, infra},
-    anyhow::{anyhow, Context, Result},
-    database::PgTransaction,
+    anyhow::{anyhow, Result},
 };
 
 #[derive(Clone)]
-pub struct OnSettlementEventUpdater {
+pub struct OnEvent {
     eth: infra::Ethereum,
     persistence: infra::Persistence,
 }
 
-impl OnSettlementEventUpdater {
+impl OnEvent {
     /// Creates a new OnSettlementEventUpdater and asynchronously schedules the
     /// first update run.
     pub fn new(eth: infra::Ethereum, persistence: infra::Persistence) -> Self {
         Self { eth, persistence }
-    }
-
-    /// Deletes settlement_observations and order executions for the given range
-    pub async fn delete_observations(
-        transaction: &mut PgTransaction<'_>,
-        from_block: u64,
-    ) -> Result<()> {
-        database::settlements::delete(transaction, from_block)
-            .await
-            .context("delete_settlement_observations")?;
-
-        Ok(())
     }
 
     /// Fetches all the available missing data needed for bookkeeping.
@@ -128,7 +115,7 @@ impl OnSettlementEventUpdater {
     }
 }
 
-/// Whether OnSettlementEventUpdater loop should retry on the given error.
+/// Whether OnEvent loop should retry on the given error.
 fn retryable(err: &settlement::Error) -> bool {
     match err {
         settlement::Error::Infra(_) => true,

--- a/crates/autopilot/src/domain/settlement/on_event.rs
+++ b/crates/autopilot/src/domain/settlement/on_event.rs
@@ -22,8 +22,7 @@ pub struct OnEvent {
 }
 
 impl OnEvent {
-    /// Creates a new OnSettlementEventUpdater and asynchronously schedules the
-    /// first update run.
+    /// Creates a new OnEvent and asynchronously schedules the first update run.
     pub fn new(eth: infra::Ethereum, persistence: infra::Persistence) -> Self {
         Self { eth, persistence }
     }
@@ -62,8 +61,7 @@ impl OnEvent {
 
         tracing::debug!(tx = ?event.transaction, "updating settlement details");
 
-        // Reconstruct the settlement transaction based on the blockchain transaction
-        // hash
+        // Reconstruct the settlement transaction based on the transaction hash
         let transaction = match self.eth.transaction(event.transaction).await {
             Ok(transaction) => {
                 let separator = self.eth.contracts().settlement_domain_separator();

--- a/crates/autopilot/src/lib.rs
+++ b/crates/autopilot/src/lib.rs
@@ -5,7 +5,6 @@ pub mod domain;
 pub mod event_updater;
 pub mod infra;
 mod maintenance;
-pub mod on_settlement_event_updater;
 pub mod periodic_db_cleanup;
 pub mod run;
 pub mod run_loop;

--- a/crates/autopilot/src/run.rs
+++ b/crates/autopilot/src/run.rs
@@ -362,13 +362,13 @@ pub async fn run(args: Arguments) {
 
     let persistence =
         infra::persistence::Persistence::new(args.s3.into().unwrap(), Arc::new(db.clone())).await;
-    let on_settlement_event_updater =
-        crate::domain::settlement::OnEvent::new(eth.clone(), persistence.clone());
+    let settlement_observer =
+        crate::domain::settlement::Observer::new(eth.clone(), persistence.clone());
     let settlement_event_indexer = EventUpdater::new(
         boundary::events::settlement::GPv2SettlementContract::new(
             eth.contracts().settlement().clone(),
         ),
-        boundary::events::settlement::Indexer::new(db.clone(), on_settlement_event_updater),
+        boundary::events::settlement::Indexer::new(db.clone(), settlement_observer),
         block_retriever.clone(),
         skip_event_sync_start,
     );

--- a/crates/autopilot/src/run.rs
+++ b/crates/autopilot/src/run.rs
@@ -363,10 +363,7 @@ pub async fn run(args: Arguments) {
     let persistence =
         infra::persistence::Persistence::new(args.s3.into().unwrap(), Arc::new(db.clone())).await;
     let on_settlement_event_updater =
-        crate::on_settlement_event_updater::OnSettlementEventUpdater::new(
-            eth.clone(),
-            persistence.clone(),
-        );
+        crate::domain::settlement::OnEvent::new(eth.clone(), persistence.clone());
     let settlement_event_indexer = EventUpdater::new(
         boundary::events::settlement::GPv2SettlementContract::new(
             eth.contracts().settlement().clone(),

--- a/crates/database/src/settlements.rs
+++ b/crates/database/src/settlements.rs
@@ -73,6 +73,7 @@ WHERE block_number = $2 AND log_index = $3
         .map(|_| ())
 }
 
+/// Deletes all database data that referenced the deleted settlement events.
 pub async fn delete(
     ex: &mut PgTransaction<'_>,
     delete_from_block_number: u64,


### PR DESCRIPTION
# Description
`OnSettlementEventUpdater` was previously refactored and ended up being dependent on `domain` and `infra` objects only. 

That means it is ready to be moved to a proper place inside `domain`.

# Changes
<!-- List of detailed changes (how the change is accomplished) -->

- [ ] Moved updater to domain::settlement::on_event module
- [ ] Updated EventIndexer to call deletion of settlement dependent data directly.

## How to test
Existing e2e tests.