### PR TITLE
Main Auction object has id

### DIFF
--- a/crates/autopilot/src/database/auction.rs
+++ b/crates/autopilot/src/database/auction.rs
@@ -97,7 +97,10 @@ impl Postgres {
         })
     }
 
-    pub async fn replace_current_auction(&self, auction: &dto::Auction) -> Result<dto::AuctionId> {
+    pub async fn replace_current_auction(
+        &self,
+        auction: &dto::AuctionWithoutId,
+    ) -> Result<dto::AuctionId> {
         let _timer = super::Metrics::get()
             .database_queries
             .with_label_values(&["replace_current_auction"])

--- a/crates/autopilot/src/database/auction.rs
+++ b/crates/autopilot/src/database/auction.rs
@@ -99,7 +99,7 @@ impl Postgres {
 
     pub async fn replace_current_auction(
         &self,
-        auction: &dto::AuctionWithoutId,
+        auction: &dto::RawAuctionData,
     ) -> Result<dto::AuctionId> {
         let _timer = super::Metrics::get()
             .database_queries

--- a/crates/autopilot/src/domain/auction/mod.rs
+++ b/crates/autopilot/src/domain/auction/mod.rs
@@ -6,8 +6,12 @@ use {
 pub mod order;
 
 /// Replicates [`crate::model::Auction`].
+///
+/// Doesn't have an `id` field which is a main difference between this struct
+/// and `domain::Auction` struct, which is by default the main auction object
+/// used in the autopilot.
 #[derive(Clone, Debug, PartialEq)]
-pub struct AuctionWithoutId {
+pub struct RawAuctionData {
     pub block: u64,
     pub latest_settlement_block: u64,
     pub orders: Vec<Order>,

--- a/crates/autopilot/src/domain/auction/mod.rs
+++ b/crates/autopilot/src/domain/auction/mod.rs
@@ -7,7 +7,7 @@ pub mod order;
 
 /// Replicates [`crate::model::Auction`].
 #[derive(Clone, Debug, PartialEq)]
-pub struct Auction {
+pub struct AuctionWithoutId {
     pub block: u64,
     pub latest_settlement_block: u64,
     pub orders: Vec<Order>,
@@ -18,9 +18,23 @@ pub struct Auction {
 pub type Id = i64;
 
 #[derive(Clone, Debug)]
-pub struct AuctionWithId {
+pub struct Auction {
     pub id: Id,
-    pub auction: Auction,
+    pub block: u64,
+    pub latest_settlement_block: u64,
+    pub orders: Vec<Order>,
+    pub prices: Prices,
+    pub surplus_capturing_jit_order_owners: Vec<eth::Address>,
+}
+
+impl PartialEq for Auction {
+    fn eq(&self, other: &Self) -> bool {
+        self.block == other.block
+            && self.latest_settlement_block == other.latest_settlement_block
+            && self.orders == other.orders
+            && self.prices == other.prices
+            && self.surplus_capturing_jit_order_owners == other.surplus_capturing_jit_order_owners
+    }
 }
 
 /// The price of a token in wei. This represents how much wei is needed to buy

--- a/crates/autopilot/src/domain/mod.rs
+++ b/crates/autopilot/src/domain/mod.rs
@@ -9,7 +9,7 @@ pub use {
     auction::{
         order::{Order, OrderUid},
         Auction,
-        AuctionWithoutId,
+        RawAuctionData,
     },
     fee::ProtocolFees,
     quote::Quote,

--- a/crates/autopilot/src/domain/mod.rs
+++ b/crates/autopilot/src/domain/mod.rs
@@ -9,7 +9,7 @@ pub use {
     auction::{
         order::{Order, OrderUid},
         Auction,
-        AuctionWithId,
+        AuctionWithoutId,
     },
     fee::ProtocolFees,
     quote::Quote,

--- a/crates/autopilot/src/infra/persistence/dto/auction.rs
+++ b/crates/autopilot/src/infra/persistence/dto/auction.rs
@@ -11,8 +11,8 @@ use {
     std::collections::BTreeMap,
 };
 
-pub fn from_domain(auction: domain::AuctionWithoutId) -> AuctionWithoutId {
-    AuctionWithoutId {
+pub fn from_domain(auction: domain::RawAuctionData) -> RawAuctionData {
+    RawAuctionData {
         block: auction.block,
         latest_settlement_block: auction.latest_settlement_block,
         orders: auction
@@ -37,7 +37,7 @@ pub fn from_domain(auction: domain::AuctionWithoutId) -> AuctionWithoutId {
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(rename = "Auction")]
 #[serde(rename_all = "camelCase")]
-pub struct AuctionWithoutId {
+pub struct RawAuctionData {
     pub block: u64,
     pub latest_settlement_block: u64,
     pub orders: Vec<Order>,
@@ -88,5 +88,5 @@ impl TryFrom<Auction> for domain::Auction {
 pub struct Auction {
     pub id: AuctionId,
     #[serde(flatten)]
-    pub auction: AuctionWithoutId,
+    pub auction: RawAuctionData,
 }

--- a/crates/autopilot/src/infra/persistence/dto/auction.rs
+++ b/crates/autopilot/src/infra/persistence/dto/auction.rs
@@ -35,7 +35,6 @@ pub fn from_domain(auction: domain::RawAuctionData) -> RawAuctionData {
 
 #[serde_as]
 #[derive(Clone, Debug, Serialize, Deserialize)]
-#[serde(rename = "Auction")]
 #[serde(rename_all = "camelCase")]
 pub struct RawAuctionData {
     pub block: u64,
@@ -83,7 +82,6 @@ impl TryFrom<Auction> for domain::Auction {
 
 #[serde_as]
 #[derive(Clone, Debug, Deserialize)]
-#[serde(rename = "AuctionWithId")]
 #[serde(rename_all = "camelCase")]
 pub struct Auction {
     pub id: AuctionId,

--- a/crates/autopilot/src/infra/persistence/dto/auction.rs
+++ b/crates/autopilot/src/infra/persistence/dto/auction.rs
@@ -11,8 +11,8 @@ use {
     std::collections::BTreeMap,
 };
 
-pub fn from_domain(auction: domain::Auction) -> Auction {
-    Auction {
+pub fn from_domain(auction: domain::AuctionWithoutId) -> AuctionWithoutId {
+    AuctionWithoutId {
         block: auction.block,
         latest_settlement_block: auction.latest_settlement_block,
         orders: auction
@@ -33,34 +33,11 @@ pub fn from_domain(auction: domain::Auction) -> Auction {
     }
 }
 
-pub fn try_to_domain(auction: Auction) -> anyhow::Result<domain::Auction> {
-    Ok(domain::Auction {
-        block: auction.block,
-        latest_settlement_block: auction.latest_settlement_block,
-        orders: auction
-            .orders
-            .into_iter()
-            .map(super::order::to_domain)
-            .collect(),
-        prices: auction
-            .prices
-            .into_iter()
-            .map(|(key, value)| {
-                Price::new(value.into()).map(|price| (eth::TokenAddress(key), price))
-            })
-            .collect::<Result<_, _>>()?,
-        surplus_capturing_jit_order_owners: auction
-            .surplus_capturing_jit_order_owners
-            .into_iter()
-            .map(Into::into)
-            .collect(),
-    })
-}
-
 #[serde_as]
 #[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename = "Auction")]
 #[serde(rename_all = "camelCase")]
-pub struct Auction {
+pub struct AuctionWithoutId {
     pub block: u64,
     pub latest_settlement_block: u64,
     pub orders: Vec<Order>,
@@ -72,22 +49,44 @@ pub struct Auction {
 
 pub type AuctionId = i64;
 
-impl TryFrom<AuctionWithId> for domain::AuctionWithId {
+impl TryFrom<Auction> for domain::Auction {
     type Error = anyhow::Error;
 
-    fn try_from(dto: AuctionWithId) -> anyhow::Result<Self> {
-        Ok(domain::AuctionWithId {
+    fn try_from(dto: Auction) -> anyhow::Result<Self> {
+        Ok(domain::Auction {
             id: dto.id,
-            auction: try_to_domain(dto.auction)?,
+            block: dto.auction.block,
+            latest_settlement_block: dto.auction.latest_settlement_block,
+            orders: dto
+                .auction
+                .orders
+                .into_iter()
+                .map(super::order::to_domain)
+                .collect(),
+            prices: dto
+                .auction
+                .prices
+                .into_iter()
+                .map(|(key, value)| {
+                    Price::new(value.into()).map(|price| (eth::TokenAddress(key), price))
+                })
+                .collect::<Result<_, _>>()?,
+            surplus_capturing_jit_order_owners: dto
+                .auction
+                .surplus_capturing_jit_order_owners
+                .into_iter()
+                .map(Into::into)
+                .collect(),
         })
     }
 }
 
 #[serde_as]
 #[derive(Clone, Debug, Deserialize)]
+#[serde(rename = "AuctionWithId")]
 #[serde(rename_all = "camelCase")]
-pub struct AuctionWithId {
+pub struct Auction {
     pub id: AuctionId,
     #[serde(flatten)]
-    pub auction: Auction,
+    pub auction: AuctionWithoutId,
 }

--- a/crates/autopilot/src/infra/persistence/dto/mod.rs
+++ b/crates/autopilot/src/infra/persistence/dto/mod.rs
@@ -3,4 +3,4 @@ pub mod fee_policy;
 pub mod order;
 pub mod quote;
 
-pub use auction::{Auction, AuctionId, AuctionWithId};
+pub use auction::{Auction, AuctionId, AuctionWithoutId};

--- a/crates/autopilot/src/infra/persistence/dto/mod.rs
+++ b/crates/autopilot/src/infra/persistence/dto/mod.rs
@@ -3,4 +3,4 @@ pub mod fee_policy;
 pub mod order;
 pub mod quote;
 
-pub use auction::{Auction, AuctionId, AuctionWithoutId};
+pub use auction::{Auction, AuctionId, RawAuctionData};

--- a/crates/autopilot/src/infra/persistence/mod.rs
+++ b/crates/autopilot/src/infra/persistence/mod.rs
@@ -63,14 +63,14 @@ impl Persistence {
     /// If the given auction is successfully saved, it is also archived.
     pub async fn replace_current_auction(
         &self,
-        auction: &domain::Auction,
+        auction: &domain::AuctionWithoutId,
     ) -> Result<domain::auction::Id, DatabaseError> {
         let auction = dto::auction::from_domain(auction.clone());
         self.postgres
             .replace_current_auction(&auction)
             .await
-            .inspect(|&auction_id| {
-                self.archive_auction(auction_id, auction);
+            .inspect(|&id| {
+                self.archive_auction(dto::auction::Auction { id, auction });
             })
             .map_err(DatabaseError)
     }
@@ -89,13 +89,16 @@ impl Persistence {
     /// Saves the given auction to storage for debugging purposes.
     ///
     /// There is no intention to retrieve this data programmatically.
-    fn archive_auction(&self, id: domain::auction::Id, instance: dto::auction::Auction) {
+    fn archive_auction(&self, instance: dto::auction::Auction) {
         let Some(uploader) = self.s3.clone() else {
             return;
         };
         tokio::spawn(
             async move {
-                match uploader.upload(id.to_string(), &instance).await {
+                match uploader
+                    .upload(instance.id.to_string(), &instance.auction)
+                    .await
+                {
                     Ok(key) => {
                         tracing::info!(?key, "uploaded auction to s3");
                     }

--- a/crates/autopilot/src/infra/persistence/mod.rs
+++ b/crates/autopilot/src/infra/persistence/mod.rs
@@ -63,7 +63,7 @@ impl Persistence {
     /// If the given auction is successfully saved, it is also archived.
     pub async fn replace_current_auction(
         &self,
-        auction: &domain::AuctionWithoutId,
+        auction: &domain::RawAuctionData,
     ) -> Result<domain::auction::Id, DatabaseError> {
         let auction = dto::auction::from_domain(auction.clone());
         self.postgres

--- a/crates/autopilot/src/infra/shadow/orderbook/mod.rs
+++ b/crates/autopilot/src/infra/shadow/orderbook/mod.rs
@@ -17,13 +17,13 @@ impl Orderbook {
     }
 
     /// Retrieves the current auction.
-    pub async fn auction(&self) -> anyhow::Result<domain::AuctionWithId> {
+    pub async fn auction(&self) -> anyhow::Result<domain::Auction> {
         self.client
             .get(shared::url::join(&self.url, "api/v1/auction"))
             .send()
             .await?
             .error_for_status()?
-            .json::<dto::AuctionWithId>()
+            .json::<dto::Auction>()
             .await
             .map(TryInto::try_into)
             .map_err(Into::<anyhow::Error>::into)?

--- a/crates/autopilot/src/infra/solvers/dto/solve.rs
+++ b/crates/autopilot/src/infra/solvers/dto/solve.rs
@@ -18,13 +18,12 @@ use {
 
 impl Request {
     pub fn new(
-        id: domain::auction::Id,
         auction: &domain::Auction,
         trusted_tokens: &HashSet<H160>,
         time_limit: Duration,
     ) -> Self {
         Self {
-            id,
+            id: auction.id,
             orders: auction
                 .orders
                 .clone()

--- a/crates/autopilot/src/run_loop.rs
+++ b/crates/autopilot/src/run_loop.rs
@@ -112,10 +112,11 @@ impl RunLoop {
             let auction = self_arc
                 .next_auction(&mut last_auction, &mut last_block)
                 .await;
-            if let Some(domain::AuctionWithId { id, auction }) = auction {
+            if let Some(auction) = auction {
+                let auction_id = auction.id;
                 self_arc
-                    .single_run(id, auction)
-                    .instrument(tracing::info_span!("auction", id))
+                    .single_run(auction)
+                    .instrument(tracing::info_span!("auction", auction_id))
                     .await;
             };
         }
@@ -127,7 +128,7 @@ impl RunLoop {
         &self,
         prev_auction: &mut Option<domain::Auction>,
         prev_block: &mut Option<H256>,
-    ) -> Option<domain::AuctionWithId> {
+    ) -> Option<domain::Auction> {
         // wait for appropriate time to start building the auction
         let start_block = match self.config.synchronization {
             RunLoopMode::Unsynchronized => {
@@ -166,8 +167,8 @@ impl RunLoop {
         let auction = self.cut_auction().await?;
 
         // Only run the solvers if the auction or block has changed.
-        let previous = prev_auction.replace(auction.auction.clone());
-        if previous.as_ref() == Some(&auction.auction)
+        let previous = prev_auction.replace(auction.clone());
+        if previous.as_ref() == Some(&auction)
             && prev_block.replace(start_block.hash) == Some(start_block.hash)
         {
             return None;
@@ -187,7 +188,7 @@ impl RunLoop {
         Metrics::ran_maintenance(start.elapsed());
     }
 
-    async fn cut_auction(&self) -> Option<domain::AuctionWithId> {
+    async fn cut_auction(&self) -> Option<domain::Auction> {
         let auction = match self.solvable_orders_cache.current_auction().await {
             Some(auction) => auction,
             None => {
@@ -214,20 +215,23 @@ impl RunLoop {
             return None;
         }
 
-        Some(domain::AuctionWithId { id, auction })
+        Some(domain::Auction {
+            id,
+            block: auction.block,
+            latest_settlement_block: auction.latest_settlement_block,
+            orders: auction.orders,
+            prices: auction.prices,
+            surplus_capturing_jit_order_owners: auction.surplus_capturing_jit_order_owners,
+        })
     }
 
-    async fn single_run(
-        self: &Arc<Self>,
-        auction_id: domain::auction::Id,
-        auction: domain::Auction,
-    ) {
+    async fn single_run(self: &Arc<Self>, auction: domain::Auction) {
         let single_run_start = Instant::now();
-        tracing::info!(?auction_id, "solving");
+        tracing::info!(auction_id = ?auction.id, "solving");
 
         let auction = self.remove_in_flight_orders(auction).await;
 
-        let solutions = self.competition(auction_id, &auction).await;
+        let solutions = self.competition(&auction).await;
         if solutions.is_empty() {
             tracing::info!("no solutions for auction");
             return;
@@ -245,8 +249,7 @@ impl RunLoop {
             // of storing all the competition/auction-related data to the DB.
             if let Err(err) = self
                 .post_processing(
-                    auction_id,
-                    auction,
+                    &auction,
                     competition_simulation_block,
                     solution,
                     &solutions,
@@ -259,7 +262,7 @@ impl RunLoop {
             }
 
             self.start_settlement_execution(
-                auction_id,
+                auction.id,
                 single_run_start,
                 driver,
                 solution,
@@ -362,8 +365,7 @@ impl RunLoop {
     #[allow(clippy::too_many_arguments)]
     async fn post_processing(
         &self,
-        auction_id: domain::auction::Id,
-        auction: domain::Auction,
+        auction: &domain::Auction,
         competition_simulation_block: u64,
         winning_solution: &competition::SolutionWithId,
         solutions: &[Participant],
@@ -444,13 +446,14 @@ impl RunLoop {
                 .collect(),
         };
         let competition = Competition {
-            auction_id,
+            auction_id: auction.id,
             winner,
             winning_score,
             reference_score,
             participants,
             prices: auction
                 .prices
+                .clone()
                 .into_iter()
                 .map(|(key, value)| (key.into(), value.get().into()))
                 .collect(),
@@ -466,12 +469,12 @@ impl RunLoop {
                 .map_err(|e| e.0.context("failed to save competition")),
             self.persistence
                 .save_surplus_capturing_jit_orders_orders(
-                    auction_id,
+                    auction.id,
                     &auction.surplus_capturing_jit_order_owners,
                 )
                 .map_err(|e| e.0.context("failed to save jit order owners")),
             self.persistence
-                .store_fee_policies(auction_id, fee_policies)
+                .store_fee_policies(auction.id, fee_policies)
                 .map_err(|e| e.context("failed to fee_policies")),
         )?;
 
@@ -481,13 +484,8 @@ impl RunLoop {
 
     /// Runs the solver competition, making all configured drivers participate.
     /// Returns all fair solutions sorted by their score (worst to best).
-    async fn competition(
-        &self,
-        id: domain::auction::Id,
-        auction: &domain::Auction,
-    ) -> Vec<Participant> {
+    async fn competition(&self, auction: &domain::Auction) -> Vec<Participant> {
         let request = solve::Request::new(
-            id,
             auction,
             &self.market_makable_token_list.all(),
             self.config.solve_deadline,
@@ -1031,7 +1029,7 @@ impl Metrics {
 pub mod observe {
     use {crate::domain, std::collections::HashSet};
 
-    pub fn log_auction_delta(previous: &Option<domain::Auction>, current: &domain::AuctionWithId) {
+    pub fn log_auction_delta(previous: &Option<domain::Auction>, current: &domain::Auction) {
         let previous_uids = match previous {
             Some(previous) => previous
                 .orders
@@ -1041,7 +1039,6 @@ pub mod observe {
             None => HashSet::new(),
         };
         let current_uids = current
-            .auction
             .orders
             .iter()
             .map(|order| order.uid)

--- a/crates/autopilot/src/solvable_orders.rs
+++ b/crates/autopilot/src/solvable_orders.rs
@@ -98,7 +98,7 @@ pub struct SolvableOrdersCache {
 type Balances = HashMap<Query, U256>;
 
 struct Inner {
-    auction: domain::Auction,
+    auction: domain::AuctionWithoutId,
     solvable_orders: boundary::SolvableOrders,
 }
 
@@ -150,7 +150,7 @@ impl SolvableOrdersCache {
         );
     }
 
-    pub async fn current_auction(&self) -> Option<domain::Auction> {
+    pub async fn current_auction(&self) -> Option<domain::AuctionWithoutId> {
         self.cache
             .lock()
             .await
@@ -272,7 +272,7 @@ impl SolvableOrdersCache {
             .cloned()
             .map(eth::Address::from)
             .collect::<Vec<_>>();
-        let auction = domain::Auction {
+        let auction = domain::AuctionWithoutId {
             block,
             latest_settlement_block: db_solvable_orders.latest_settlement_block,
             orders: orders

--- a/crates/autopilot/src/solvable_orders.rs
+++ b/crates/autopilot/src/solvable_orders.rs
@@ -98,7 +98,7 @@ pub struct SolvableOrdersCache {
 type Balances = HashMap<Query, U256>;
 
 struct Inner {
-    auction: domain::AuctionWithoutId,
+    auction: domain::RawAuctionData,
     solvable_orders: boundary::SolvableOrders,
 }
 
@@ -150,7 +150,7 @@ impl SolvableOrdersCache {
         );
     }
 
-    pub async fn current_auction(&self) -> Option<domain::AuctionWithoutId> {
+    pub async fn current_auction(&self) -> Option<domain::RawAuctionData> {
         self.cache
             .lock()
             .await
@@ -272,7 +272,7 @@ impl SolvableOrdersCache {
             .cloned()
             .map(eth::Address::from)
             .collect::<Vec<_>>();
-        let auction = domain::AuctionWithoutId {
+        let auction = domain::RawAuctionData {
             block,
             latest_settlement_block: db_solvable_orders.latest_settlement_block,
             orders: orders

--- a/crates/e2e/src/setup/services.rs
+++ b/crates/e2e/src/setup/services.rs
@@ -329,7 +329,7 @@ impl<'a> Services<'a> {
     /// Fetches the current auction. Don't use this as a synchronization
     /// mechanism in tests because that is prone to race conditions
     /// which would make tests flaky.
-    pub async fn get_auction(&self) -> dto::AuctionWithId {
+    pub async fn get_auction(&self) -> dto::Auction {
         let response = self
             .http
             .get(format!("{API_HOST}{AUCTION_ENDPOINT}"))


### PR DESCRIPTION
# Description
I got very frustrated by the fact that we have two versions of Auction object in autopilot domain:

1. `domain::Auction`
2. `domain::AuctionWithId`

and as a cherry on top, we almost never use `domain::AuctionWithId`, but instead use a pair of `<domain::auction::Id, domain::Auction>` throughout the whole runloop logic. Also, I never actually had an easy understanding why and where exactly auction has / doesn't have ID. This is my attempt to make thing cleaner (although not 100% clean).

# Changes
<!-- List of detailed changes (how the change is accomplished) -->

- [ ] Rename `domain::Auction` to `domain::RawAuctionData`
- [ ] Rename `domain::AuctionWithId` to `domain::Auction` and flatten all auction fields
- [ ] Use `domain::Auction` whenever possible

Now, let's agree that `domain::Auction` has become the main Auction object which has ID, and we want to use this object everywhere in the autopilot. The small, isolated part of the autopilot code (SolvableOrdersCache which actually builds the auction object but without ID) is now marked by using `domain::RawAuctionData` and since we interact with this small part much less then with the rest of the autopilot code, I believe it's better to have opposite logic to what we had so far, with regards to naming.

Final goal here is to remove `domain::RawAuctionData` completely, by moving ID generation to SolvableOrdersCache which would cache `domain::Auction` and not `domain::RawAuctionData`. @cowprotocol/backend do you think this is feasible now with sync-to-blockchain feature?

## How to test
Existing e2e tests