### PR TITLE
Cleanup competition::Solution

### DIFF
--- a/crates/autopilot/src/domain/competition/mod.rs
+++ b/crates/autopilot/src/domain/competition/mod.rs
@@ -11,12 +11,15 @@ use {
 type SolutionId = u64;
 
 #[derive(Debug)]
-pub struct SolutionWithId {
+pub struct Solution {
     id: SolutionId,
-    solution: Solution,
+    solver: eth::Address,
+    score: Score,
+    orders: HashMap<domain::OrderUid, TradedOrder>,
+    prices: auction::Prices,
 }
 
-impl SolutionWithId {
+impl Solution {
     pub fn new(
         id: SolutionId,
         solver: eth::Address,
@@ -26,56 +29,15 @@ impl SolutionWithId {
     ) -> Self {
         Self {
             id,
-            solution: Solution::new(solver, score, orders, prices),
-        }
-    }
-
-    pub fn id(&self) -> SolutionId {
-        self.id
-    }
-
-    pub fn solver(&self) -> eth::Address {
-        self.solution.solver()
-    }
-
-    pub fn score(&self) -> Score {
-        self.solution.score()
-    }
-
-    pub fn order_ids(&self) -> impl Iterator<Item = &domain::OrderUid> + std::fmt::Debug {
-        self.solution.order_ids()
-    }
-
-    pub fn orders(&self) -> &HashMap<domain::OrderUid, TradedOrder> {
-        self.solution.orders()
-    }
-
-    pub fn prices(&self) -> &HashMap<eth::TokenAddress, auction::Price> {
-        self.solution.prices()
-    }
-}
-
-#[derive(Debug)]
-pub struct Solution {
-    solver: eth::Address,
-    score: Score,
-    orders: HashMap<domain::OrderUid, TradedOrder>,
-    prices: auction::Prices,
-}
-
-impl Solution {
-    pub fn new(
-        solver: eth::Address,
-        score: Score,
-        orders: HashMap<domain::OrderUid, TradedOrder>,
-        prices: auction::Prices,
-    ) -> Self {
-        Self {
             solver,
             score,
             orders,
             prices,
         }
+    }
+
+    pub fn id(&self) -> SolutionId {
+        self.id
     }
 
     pub fn solver(&self) -> eth::Address {

--- a/crates/autopilot/src/infra/solvers/dto/solve.rs
+++ b/crates/autopilot/src/infra/solvers/dto/solve.rs
@@ -59,7 +59,7 @@ impl Request {
 impl Response {
     pub fn into_domain(
         self,
-    ) -> Vec<Result<domain::competition::SolutionWithId, domain::competition::SolutionError>> {
+    ) -> Vec<Result<domain::competition::Solution, domain::competition::SolutionError>> {
         self.solutions
             .into_iter()
             .map(Solution::into_domain)
@@ -92,8 +92,8 @@ pub struct Token {
 impl Solution {
     pub fn into_domain(
         self,
-    ) -> Result<domain::competition::SolutionWithId, domain::competition::SolutionError> {
-        Ok(domain::competition::SolutionWithId::new(
+    ) -> Result<domain::competition::Solution, domain::competition::SolutionError> {
+        Ok(domain::competition::Solution::new(
             self.solution_id,
             self.submission_address.into(),
             domain::competition::Score::new(self.score.into())?,

--- a/crates/autopilot/src/run_loop.rs
+++ b/crates/autopilot/src/run_loop.rs
@@ -5,7 +5,7 @@ use {
         domain::{
             self,
             auction::Id,
-            competition::{self, SolutionError, SolutionWithId, TradedOrder},
+            competition::{self, Solution, SolutionError, TradedOrder},
             eth::{self, TxId},
             OrderUid,
         },
@@ -276,7 +276,7 @@ impl RunLoop {
         auction_id: Id,
         single_run_start: Instant,
         driver: &Arc<infra::Driver>,
-        solution: &SolutionWithId,
+        solution: &Solution,
         block_deadline: u64,
     ) {
         let solved_order_uids: HashSet<_> = solution.orders().keys().cloned().collect();
@@ -365,7 +365,7 @@ impl RunLoop {
         auction_id: domain::auction::Id,
         auction: domain::Auction,
         competition_simulation_block: u64,
-        winning_solution: &competition::SolutionWithId,
+        winning_solution: &competition::Solution,
         solutions: &[Participant],
         block_deadline: u64,
     ) -> Result<()> {
@@ -706,10 +706,8 @@ impl RunLoop {
         &self,
         driver: &infra::Driver,
         request: &solve::Request,
-    ) -> Result<
-        Vec<Result<competition::SolutionWithId, domain::competition::SolutionError>>,
-        SolveError,
-    > {
+    ) -> Result<Vec<Result<competition::Solution, domain::competition::SolutionError>>, SolveError>
+    {
         let response = tokio::time::timeout(self.config.solve_deadline, driver.solve(request))
             .await
             .map_err(|_| SolveError::Timeout)?
@@ -854,7 +852,7 @@ impl RunLoop {
 
 struct Participant {
     driver: Arc<infra::Driver>,
-    solution: competition::SolutionWithId,
+    solution: competition::Solution,
 }
 
 #[derive(Debug, thiserror::Error)]


### PR DESCRIPTION
# Description
Not sure what was the original reason to have two structs here (Solution and SolutionWithId), but anyway, it doesn't exist anymore and we should have a single struct for `Solution`.

This is a preliminary cleanup for implementing some basic validation rules on `competition::Solution` object, like uniqueness of <solution_id, solver> within Auction, existence of all clearing prices for all user order and surplus capturing JIT orders etc...

# Changes
<!-- List of detailed changes (how the change is accomplished) -->

- [ ] Remove SolutionWithId

## How to test
Existing e2e tests.