### PR TITLE
[EASY] Recover solvable orders cache update metric

### DIFF
--- a/crates/autopilot/src/run_loop.rs
+++ b/crates/autopilot/src/run_loop.rs
@@ -152,12 +152,18 @@ impl RunLoop {
                 };
 
                 self.run_maintenance(&auction_block).await;
-                if let Err(err) = self
+                match self
                     .solvable_orders_cache
                     .update(auction_block.number)
                     .await
                 {
-                    tracing::warn!(?err, "failed to update auction");
+                    Ok(()) => {
+                        self.solvable_orders_cache.track_auction_update("success");
+                    }
+                    Err(err) => {
+                        self.solvable_orders_cache.track_auction_update("failure");
+                        tracing::warn!(?err, "failed to update auction");
+                    }
                 }
                 auction_block
             }


### PR DESCRIPTION
# Description
After switching to the sync-to-blockchain run loop mode, this metric is no longer populated, while a prod alert is still configured for it.

# Changes
Populate the metric, making the alert work again.

## How to test
Observe Grafana.
