### PR TITLE
[EASY] Drop solvable orders cache update background task

### DIFF
--- a/crates/autopilot/src/run_loop.rs
+++ b/crates/autopilot/src/run_loop.rs
@@ -152,12 +152,18 @@ impl RunLoop {
                 };
 
                 self.run_maintenance(&auction_block).await;
-                if let Err(err) = self
+                match self
                     .solvable_orders_cache
                     .update(auction_block.number)
                     .await
                 {
-                    tracing::warn!(?err, "failed to update auction");
+                    Ok(()) => {
+                        self.solvable_orders_cache.track_auction_update("success");
+                    }
+                    Err(err) => {
+                        self.solvable_orders_cache.track_auction_update("failure");
+                        tracing::warn!(?err, "failed to update auction");
+                    }
                 }
                 auction_block
             }


### PR DESCRIPTION
The code is not used anymore since this is now a part of the maintenance task.