### PR TITLE
Fix flaky forked nodes tests

### DIFF
--- a/crates/e2e/src/setup/services.rs
+++ b/crates/e2e/src/setup/services.rs
@@ -145,6 +145,7 @@ impl<'a> Services<'a> {
         let args = [
             "autopilot".to_string(),
             "--auction-update-interval=1s".to_string(),
+            "--run-loop-native-price-timeout=500ms".to_string(),
             format!("--ethflow-contract={:?}", self.contracts.ethflow.address()),
             "--skip-event-sync=true".to_string(),
             format!("--solve-deadline={solve_deadline:?}"),


### PR DESCRIPTION
# Description
Recently we changed default values for the native price cache which led to some tests failing.
The problem seems to be that we can no longer reliably fetch native prices for some tokens.

# Changes
With https://github.com/cowprotocol/services/pull/2987 we now have an easy way to make sure that all the native prices that can be there will be there. So I just enabled the feature and at least one of the problematic tests passed right away.
Will check CI if other tests are still problematic.
Edit: Seems to fix the forked nodes tests but some driver tests are still [flaky](https://github.com/cowprotocol/services/actions/runs/11121979135/job/30902264434?pr=3029)

## How to test
This is the test