### PR TITLE
Native price fetching finishing touches

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4458,6 +4458,7 @@ dependencies = [
  "primitive-types",
  "prometheus",
  "prometheus-metric-storage",
+ "rand",
  "rate-limit",
  "regex",
  "reqwest",

--- a/crates/shared/Cargo.toml
+++ b/crates/shared/Cargo.toml
@@ -44,6 +44,7 @@ order-validation = { path = "../order-validation" }
 primitive-types = { workspace = true }
 prometheus = { workspace = true }
 prometheus-metric-storage = { workspace = true }
+rand = { workspace = true }
 rate-limit = { path = "../rate-limit" }
 reqwest = { workspace = true, features = ["cookies", "gzip", "json"] }
 rust_decimal = { version = "1.35.0", features = ["maths"] }

--- a/crates/shared/src/price_estimation/native_price_cache.rs
+++ b/crates/shared/src/price_estimation/native_price_cache.rs
@@ -235,8 +235,8 @@ impl CachingNativePriceEstimator {
             .filter_map(|(token, price)| {
                 // Generate random `updated_at` timestamp
                 // to avoid spikes of expired prices.
-                let percent_expired = rng.gen_range(10..=50);
-                let age = self.0.max_age.as_secs() * 100 / percent_expired;
+                let percent_expired = rng.gen_range(50..=90);
+                let age = self.0.max_age.as_secs() * 100 / (100 - percent_expired);
                 let updated_at = now - Duration::from_secs(age);
 
                 Some((

--- a/crates/shared/src/price_estimation/native_price_cache.rs
+++ b/crates/shared/src/price_estimation/native_price_cache.rs
@@ -408,11 +408,8 @@ mod tests {
         let min_age = Duration::from_secs(MAX_AGE_SECS * 49 / 100);
         let max_age = Duration::from_secs(MAX_AGE_SECS * 91 / 100);
 
-        let prices = HashMap::from_iter(
-            (0..10)
-                .into_iter()
-                .map(|t| (token(t), BigDecimal::try_from(1e18).unwrap())),
-        );
+        let prices =
+            HashMap::from_iter((0..10).map(|t| (token(t), BigDecimal::try_from(1e18).unwrap())));
         let estimator = CachingNativePriceEstimator::new(
             Box::new(inner),
             Duration::from_secs(MAX_AGE_SECS),

--- a/crates/shared/src/price_estimation/native_price_cache.rs
+++ b/crates/shared/src/price_estimation/native_price_cache.rs
@@ -236,7 +236,7 @@ impl CachingNativePriceEstimator {
                 // Generate random `updated_at` timestamp
                 // to avoid spikes of expired prices.
                 let percent_expired = rng.gen_range(50..=90);
-                let age = self.0.max_age.as_secs() * 100 / (100 - percent_expired);
+                let age = self.0.max_age.as_secs() * percent_expired / 100;
                 let updated_at = now - Duration::from_secs(age);
 
                 Some((


### PR DESCRIPTION
# Description
This PR addresses the last known issues with native price fetching: lock contention and spikes of expired orders.

# Changes
## Reduce Lock Contention
https://github.com/cowprotocol/services/pull/2987 made it such that we can now fetch missing prices while building the auction. However, the implementation resulted in too much lock contention. Previously we locked the cache once and returned all relevant prices and now we lock it at least once per fetched price.
To fix that we first use the optimized function which only takes one lock and then we use the generic implementation that locks on every token. Since we started initializing the native price cache by loading prices from the DB we should rarely have many prices expire together so this should be fine.
Already confirmed to be working with a hotfixed prod release.


## Reduce Spikes of Expired Prices
So far all prices we initialized the cache with expire together. This can lead to a few spikes of prices expiring together where the update logic can't refresh them in time which leads to expired orders.
To address that we generate random `updated_at` timestamps between 50% and 90% expired. That way the background task should never get overwhelmed by updating too many prices at once.

## How to test
Tested in prod