### PR TITLE
Driver `/quote` response with JIT orders

### DIFF
--- a/crates/driver/openapi.yml
+++ b/crates/driver/openapi.yml
@@ -525,10 +525,6 @@ components:
     JitOrder:
       type: object
       properties:
-        uid:
-          $ref: "#/components/schemas/OrderUID"
-        owner:
-          $ref: "#/components/schemas/Address"
         sellToken:
           $ref: "#/components/schemas/Address"
         buyToken:

--- a/crates/driver/openapi.yml
+++ b/crates/driver/openapi.yml
@@ -533,6 +533,8 @@ components:
           $ref: "#/components/schemas/TokenAmount"
         buyAmount:
           $ref: "#/components/schemas/TokenAmount"
+        executedAmount:
+          $ref: "#/components/schemas/TokenAmount"
         receiver:
           $ref: "#/components/schemas/Address"
         validTo:

--- a/crates/driver/openapi.yml
+++ b/crates/driver/openapi.yml
@@ -549,6 +549,10 @@ components:
         appData:
           type: string
         signature:
+          description: | 
+            Hex encoded bytes with `0x` prefix. The content depends on the `signingScheme`.
+            For `presign`, this should contain the address of the owner. 
+            For `eip1271`, the signature should consist of `<owner_address><signature_bytes>`.
           type: string
         signingScheme:
           type: string

--- a/crates/driver/openapi.yml
+++ b/crates/driver/openapi.yml
@@ -306,6 +306,10 @@ components:
           properties:
             amount:
               $ref: "#/components/schemas/TokenAmount"
+            preInteractions:
+              type: array
+              items:
+                $ref: "#/components/schemas/Interaction"
             interactions:
               type: array
               items:
@@ -316,6 +320,10 @@ components:
             gas:
               type: integer
               description: How many units of gas this trade is estimated to cost.
+            jitOrders:
+              type: array
+              items:
+                $ref: "#/components/schemas/JitOrder"
         - $ref: "#/components/schemas/Error"
     DateTime:
       description: An ISO 8601 UTC date time string.
@@ -514,6 +522,41 @@ components:
           $ref: "#/components/schemas/TokenAmount"
         solver:
           $ref: "#/components/schemas/Address"
+    JitOrder:
+      type: object
+      properties:
+        uid:
+          $ref: "#/components/schemas/OrderUID"
+        owner:
+          $ref: "#/components/schemas/Address"
+        sellToken:
+          $ref: "#/components/schemas/Address"
+        buyToken:
+          $ref: "#/components/schemas/Address"
+        sellAmount:
+          $ref: "#/components/schemas/TokenAmount"
+        buyAmount:
+          $ref: "#/components/schemas/TokenAmount"
+        receiver:
+          $ref: "#/components/schemas/Address"
+        validTo:
+          type: integer
+        side:
+          type: string
+          enum: ["buy", "sell"]
+        sellTokenSource:
+          type: string
+          enum: ["erc20", "internal", "external"]
+        buyTokenSource:
+          type: string
+          enum: ["erc20", "internal"]
+        appData:
+          type: string
+        signature:
+          type: string
+        signingScheme:
+          type: string
+          enum: ["eip712", "ethsign", "presign", "eip1271"]
     Error:
       description: Response on API errors.
       type: object

--- a/crates/driver/src/domain/competition/order/signature.rs
+++ b/crates/driver/src/domain/competition/order/signature.rs
@@ -42,6 +42,17 @@ pub enum Scheme {
     PreSign,
 }
 
+impl Scheme {
+    pub fn to_boundary_scheme(&self) -> model::signature::SigningScheme {
+        match self {
+            Scheme::Eip712 => model::signature::SigningScheme::Eip712,
+            Scheme::EthSign => model::signature::SigningScheme::EthSign,
+            Scheme::Eip1271 => model::signature::SigningScheme::Eip1271,
+            Scheme::PreSign => model::signature::SigningScheme::PreSign,
+        }
+    }
+}
+
 pub fn domain_separator(
     chain_id: eth::ChainId,
     verifying_contract: eth::ContractAddress,

--- a/crates/driver/src/domain/competition/solution/mod.rs
+++ b/crates/driver/src/domain/competition/solution/mod.rs
@@ -179,6 +179,10 @@ impl Solution {
         &self.interactions
     }
 
+    pub fn pre_interactions(&self) -> &[eth::Interaction] {
+        &self.pre_interactions
+    }
+
     /// The solver which generated this solution.
     pub fn solver(&self) -> &Solver {
         &self.solver

--- a/crates/driver/src/domain/quote.rs
+++ b/crates/driver/src/domain/quote.rs
@@ -33,7 +33,7 @@ pub struct Quote {
     pub gas: Option<eth::Gas>,
     /// Which `tx.origin` is required to make the quote simulation pass.
     pub tx_origin: Option<eth::Address>,
-    pub jit_orders: Vec<order::Jit>,
+    pub jit_orders: Vec<solution::trade::Jit>,
 }
 
 impl Quote {
@@ -77,7 +77,7 @@ impl Quote {
                 .trades()
                 .iter()
                 .filter_map(|trade| match trade {
-                    solution::Trade::Jit(jit) => Some(jit.order().clone()),
+                    solution::Trade::Jit(jit) => Some(jit.clone()),
                     _ => None,
                 })
                 .collect(),

--- a/crates/driver/src/infra/api/routes/quote/dto/quote.rs
+++ b/crates/driver/src/infra/api/routes/quote/dto/quote.rs
@@ -95,8 +95,8 @@ struct JitOrder {
 impl From<domain::competition::order::Jit> for JitOrder {
     fn from(jit: domain::competition::order::Jit) -> Self {
         Self {
-            buy_token: jit.buy.token.into(),
             sell_token: jit.sell.token.into(),
+            buy_token: jit.buy.token.into(),
             sell_amount: jit.sell.amount.into(),
             buy_amount: jit.buy.amount.into(),
             receiver: jit.receiver.into(),

--- a/crates/driver/src/infra/api/routes/quote/dto/quote.rs
+++ b/crates/driver/src/infra/api/routes/quote/dto/quote.rs
@@ -78,6 +78,8 @@ struct JitOrder {
     sell_amount: eth::U256,
     #[serde_as(as = "serialize::U256")]
     buy_amount: eth::U256,
+    #[serde_as(as = "serialize::U256")]
+    executed_amount: eth::U256,
     receiver: eth::H160,
     valid_to: u32,
     #[serde_as(as = "serialize::Hex")]
@@ -90,21 +92,22 @@ struct JitOrder {
     signing_scheme: SigningScheme,
 }
 
-impl From<domain::competition::order::Jit> for JitOrder {
-    fn from(jit: domain::competition::order::Jit) -> Self {
+impl From<domain::competition::solution::trade::Jit> for JitOrder {
+    fn from(jit: domain::competition::solution::trade::Jit) -> Self {
         Self {
-            sell_token: jit.sell.token.into(),
-            buy_token: jit.buy.token.into(),
-            sell_amount: jit.sell.amount.into(),
-            buy_amount: jit.buy.amount.into(),
-            receiver: jit.receiver.into(),
-            valid_to: jit.valid_to.into(),
-            app_data: jit.app_data.into(),
-            side: jit.side.into(),
-            sell_token_source: jit.sell_token_balance.into(),
-            buy_token_destination: jit.buy_token_balance.into(),
-            signature: jit.signature.data.into(),
-            signing_scheme: jit.signature.scheme.to_boundary_scheme(),
+            sell_token: jit.order().sell.token.into(),
+            buy_token: jit.order().buy.token.into(),
+            sell_amount: jit.order().sell.amount.into(),
+            buy_amount: jit.order().buy.amount.into(),
+            executed_amount: jit.executed().into(),
+            receiver: jit.order().receiver.into(),
+            valid_to: jit.order().valid_to.into(),
+            app_data: jit.order().app_data.into(),
+            side: jit.order().side.into(),
+            sell_token_source: jit.order().sell_token_balance.into(),
+            buy_token_destination: jit.order().buy_token_balance.into(),
+            signature: jit.order().signature.data.clone().into(),
+            signing_scheme: jit.order().signature.scheme.to_boundary_scheme(),
         }
     }
 }

--- a/crates/driver/src/infra/api/routes/quote/dto/quote.rs
+++ b/crates/driver/src/infra/api/routes/quote/dto/quote.rs
@@ -1,16 +1,26 @@
 use {
     crate::{
-        domain::{eth, quote},
+        domain::{self, eth, quote},
         util::serialize,
     },
+    model::order::{BuyTokenDestination, SellTokenSource},
     serde::Serialize,
     serde_with::serde_as,
 };
 
 impl Quote {
-    pub fn new(quote: &quote::Quote) -> Self {
+    pub fn new(quote: quote::Quote) -> Self {
         Self {
             amount: quote.amount,
+            pre_interactions: quote
+                .pre_interactions
+                .iter()
+                .map(|interaction| Interaction {
+                    target: interaction.target.into(),
+                    value: interaction.value.into(),
+                    call_data: interaction.call_data.clone().into(),
+                })
+                .collect(),
             interactions: quote
                 .interactions
                 .iter()
@@ -23,6 +33,11 @@ impl Quote {
             solver: quote.solver.0,
             gas: quote.gas.map(|gas| gas.0.as_u64()),
             tx_origin: quote.tx_origin.map(|addr| addr.0),
+            jit_orders: quote
+                .jit_orders
+                .into_iter()
+                .map(|order| order.into())
+                .collect(),
         }
     }
 }
@@ -33,12 +48,14 @@ impl Quote {
 pub struct Quote {
     #[serde_as(as = "serialize::U256")]
     amount: eth::U256,
+    pre_interactions: Vec<Interaction>,
     interactions: Vec<Interaction>,
     solver: eth::H160,
     #[serde(skip_serializing_if = "Option::is_none")]
     gas: Option<u64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     tx_origin: Option<eth::H160>,
+    jit_orders: Vec<JitOrder>,
 }
 
 #[serde_as]
@@ -50,4 +67,84 @@ struct Interaction {
     value: eth::U256,
     #[serde_as(as = "serialize::Hex")]
     call_data: Vec<u8>,
+}
+
+#[serde_as]
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct JitOrder {
+    buy_token: eth::H160,
+    sell_token: eth::H160,
+    sell_amount: eth::U256,
+    buy_amount: eth::U256,
+    receiver: eth::H160,
+    valid_to: u32,
+    #[serde_as(as = "serialize::Hex")]
+    app_data: [u8; 32],
+    side: Side,
+    sell_token_source: SellTokenSource,
+    buy_token_destination: BuyTokenDestination,
+    #[serde_as(as = "serialize::Hex")]
+    signature: Vec<u8>,
+    signing_scheme: SigningScheme,
+    owner: eth::H160,
+    #[serde_as(as = "serialize::Hex")]
+    uid: [u8; 56],
+}
+
+impl From<domain::competition::order::Jit> for JitOrder {
+    fn from(jit: domain::competition::order::Jit) -> Self {
+        Self {
+            buy_token: jit.buy.token.into(),
+            sell_token: jit.sell.token.into(),
+            sell_amount: jit.sell.amount.into(),
+            buy_amount: jit.buy.amount.into(),
+            receiver: jit.receiver.into(),
+            valid_to: jit.valid_to.into(),
+            app_data: jit.app_data.into(),
+            side: jit.side.into(),
+            sell_token_source: jit.sell_token_balance.into(),
+            buy_token_destination: jit.buy_token_balance.into(),
+            signature: jit.signature.data.into(),
+            signing_scheme: jit.signature.scheme.into(),
+            owner: jit.signature.signer.into(),
+            uid: jit.uid.into(),
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+enum Side {
+    Sell,
+    Buy,
+}
+
+impl From<domain::competition::order::Side> for Side {
+    fn from(side: domain::competition::order::Side) -> Self {
+        match side {
+            domain::competition::order::Side::Sell => Side::Sell,
+            domain::competition::order::Side::Buy => Side::Buy,
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum SigningScheme {
+    Eip712,
+    EthSign,
+    Eip1271,
+    PreSign,
+}
+
+impl From<domain::competition::order::signature::Scheme> for SigningScheme {
+    fn from(scheme: domain::competition::order::signature::Scheme) -> Self {
+        match scheme {
+            domain::competition::order::signature::Scheme::Eip712 => SigningScheme::Eip712,
+            domain::competition::order::signature::Scheme::EthSign => SigningScheme::EthSign,
+            domain::competition::order::signature::Scheme::Eip1271 => SigningScheme::Eip1271,
+            domain::competition::order::signature::Scheme::PreSign => SigningScheme::PreSign,
+        }
+    }
 }

--- a/crates/driver/src/infra/api/routes/quote/dto/quote.rs
+++ b/crates/driver/src/infra/api/routes/quote/dto/quote.rs
@@ -74,7 +74,9 @@ struct Interaction {
 struct JitOrder {
     buy_token: eth::H160,
     sell_token: eth::H160,
+    #[serde_as(as = "serialize::U256")]
     sell_amount: eth::U256,
+    #[serde_as(as = "serialize::U256")]
     buy_amount: eth::U256,
     receiver: eth::H160,
     valid_to: u32,

--- a/crates/driver/src/infra/api/routes/quote/dto/quote.rs
+++ b/crates/driver/src/infra/api/routes/quote/dto/quote.rs
@@ -90,9 +90,6 @@ struct JitOrder {
     #[serde_as(as = "serialize::Hex")]
     signature: Vec<u8>,
     signing_scheme: SigningScheme,
-    owner: eth::H160,
-    #[serde_as(as = "serialize::Hex")]
-    uid: [u8; 56],
 }
 
 impl From<domain::competition::order::Jit> for JitOrder {
@@ -110,8 +107,6 @@ impl From<domain::competition::order::Jit> for JitOrder {
             buy_token_destination: jit.buy_token_balance.into(),
             signature: jit.signature.data.into(),
             signing_scheme: jit.signature.scheme.to_boundary_scheme(),
-            owner: jit.signature.signer.into(),
-            uid: jit.uid.into(),
         }
     }
 }

--- a/crates/driver/src/infra/api/routes/quote/dto/quote.rs
+++ b/crates/driver/src/infra/api/routes/quote/dto/quote.rs
@@ -3,7 +3,10 @@ use {
         domain::{self, eth, quote},
         util::serialize,
     },
-    model::order::{BuyTokenDestination, SellTokenSource},
+    model::{
+        order::{BuyTokenDestination, SellTokenSource},
+        signature::SigningScheme,
+    },
     serde::Serialize,
     serde_with::serde_as,
 };
@@ -106,7 +109,7 @@ impl From<domain::competition::order::Jit> for JitOrder {
             sell_token_source: jit.sell_token_balance.into(),
             buy_token_destination: jit.buy_token_balance.into(),
             signature: jit.signature.data.into(),
-            signing_scheme: jit.signature.scheme.into(),
+            signing_scheme: jit.signature.scheme.to_boundary_scheme(),
             owner: jit.signature.signer.into(),
             uid: jit.uid.into(),
         }
@@ -125,26 +128,6 @@ impl From<domain::competition::order::Side> for Side {
         match side {
             domain::competition::order::Side::Sell => Side::Sell,
             domain::competition::order::Side::Buy => Side::Buy,
-        }
-    }
-}
-
-#[derive(Debug, Serialize)]
-#[serde(rename_all = "lowercase")]
-pub enum SigningScheme {
-    Eip712,
-    EthSign,
-    Eip1271,
-    PreSign,
-}
-
-impl From<domain::competition::order::signature::Scheme> for SigningScheme {
-    fn from(scheme: domain::competition::order::signature::Scheme) -> Self {
-        match scheme {
-            domain::competition::order::signature::Scheme::Eip712 => SigningScheme::Eip712,
-            domain::competition::order::signature::Scheme::EthSign => SigningScheme::EthSign,
-            domain::competition::order::signature::Scheme::Eip1271 => SigningScheme::Eip1271,
-            domain::competition::order::signature::Scheme::PreSign => SigningScheme::PreSign,
         }
     }
 }

--- a/crates/driver/src/infra/api/routes/quote/dto/quote.rs
+++ b/crates/driver/src/infra/api/routes/quote/dto/quote.rs
@@ -36,11 +36,7 @@ impl Quote {
             solver: quote.solver.0,
             gas: quote.gas.map(|gas| gas.0.as_u64()),
             tx_origin: quote.tx_origin.map(|addr| addr.0),
-            jit_orders: quote
-                .jit_orders
-                .into_iter()
-                .map(|order| order.into())
-                .collect(),
+            jit_orders: quote.jit_orders.into_iter().map(Into::into).collect(),
         }
     }
 }

--- a/crates/driver/src/infra/api/routes/quote/mod.rs
+++ b/crates/driver/src/infra/api/routes/quote/mod.rs
@@ -33,7 +33,7 @@ async fn route(
             )
             .await;
         observe::quoted(state.solver().name(), &order, &quote);
-        Ok(axum::response::Json(dto::Quote::new(&quote?)))
+        Ok(axum::response::Json(dto::Quote::new(quote?)))
     };
 
     handle_request

--- a/crates/driver/src/tests/cases/quote.rs
+++ b/crates/driver/src/tests/cases/quote.rs
@@ -2,7 +2,7 @@ use crate::{
     domain::competition::order,
     tests::{
         self,
-        setup::{ab_order, ab_pool, ab_solution},
+        setup::{self, ab_order, ab_pool, ab_solution},
     },
 };
 
@@ -27,4 +27,39 @@ async fn matrix() {
             quote.ok().amount().interactions();
         }
     }
+}
+
+#[tokio::test]
+#[ignore]
+async fn with_jit_order() {
+    let side = order::Side::Sell;
+    let kind = order::Kind::Limit;
+    let jit_order = setup::JitOrder {
+        order: ab_order()
+            .kind(order::Kind::Limit)
+            .side(side)
+            .kind(kind)
+            .pre_interaction(setup::blockchain::Interaction {
+                address: ab_order().owner,
+                calldata: std::iter::repeat(0xab).take(32).collect(),
+                inputs: Default::default(),
+                outputs: Default::default(),
+                internalize: false,
+            })
+            .no_surplus(),
+    };
+
+    let test = tests::setup()
+        .name(format!("{side:?} {kind:?}"))
+        .pool(ab_pool())
+        .jit_order(jit_order)
+        .order(ab_order().side(side).kind(kind).no_surplus())
+        .solution(ab_solution())
+        .quote()
+        .done()
+        .await;
+
+    let quote = test.quote().await;
+
+    quote.ok().amount().interactions().jit_order();
 }

--- a/crates/driver/src/tests/setup/blockchain.rs
+++ b/crates/driver/src/tests/setup/blockchain.rs
@@ -41,7 +41,7 @@ pub struct Blockchain {
     pub pairs: Vec<Pair>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct Interaction {
     pub address: ethcontract::H160,
     pub calldata: Vec<u8>,
@@ -112,6 +112,7 @@ impl Trade {
 pub struct Fulfillment {
     pub quoted_order: QuotedOrder,
     pub execution: Execution,
+    pub pre_interactions: Vec<Interaction>,
     pub interactions: Vec<Interaction>,
 }
 
@@ -801,6 +802,7 @@ impl Blockchain {
             fulfillments.push(Fulfillment {
                 quoted_order: self.quote(order),
                 execution: execution.clone(),
+                pre_interactions: order.pre_interactions.clone(),
                 interactions: vec![
                     Interaction {
                         address: sell_token.address(),

--- a/crates/driver/src/tests/setup/solver.rs
+++ b/crates/driver/src/tests/setup/solver.rs
@@ -169,6 +169,7 @@ impl Solver {
             orders_json.push(order);
         }
         for (i, solution) in config.solutions.iter().enumerate() {
+            let mut pre_interactions_json = Vec::new();
             let mut interactions_json = Vec::new();
             let mut prices_json = HashMap::new();
             let mut trades_json = Vec::new();
@@ -250,6 +251,30 @@ impl Solver {
                         }
                     }
                     Trade::Jit(jit) => {
+                        pre_interactions_json.extend(jit.pre_interactions.iter().map(
+                            |interaction| {
+                                json!({
+                                    "kind": "custom",
+                                    "internalize": interaction.internalize,
+                                    "target": hex_address(interaction.address),
+                                    "value": "0",
+                                    "callData": format!("0x{}", hex::encode(&interaction.calldata)),
+                                    "allowances": [],
+                                    "inputs": interaction.inputs.iter().map(|input| {
+                                        json!({
+                                            "token": hex_address(input.token.into()),
+                                            "amount": input.amount.to_string(),
+                                        })
+                                    }).collect_vec(),
+                                    "outputs": interaction.outputs.iter().map(|output| {
+                                        json!({
+                                            "token": hex_address(output.token.into()),
+                                            "amount": output.amount.to_string(),
+                                        })
+                                    }).collect_vec(),
+                                })
+                            },
+                        ));
                         interactions_json.extend(jit.interactions.iter().map(|interaction| {
                             json!({
                                 "kind": "custom",
@@ -314,7 +339,7 @@ impl Solver {
                                 },
                                 "sellTokenBalance": jit.quoted_order.order.sell_token_source,
                                 "buyTokenBalance": jit.quoted_order.order.buy_token_destination,
-                                "signature": if config.quote { "0x".to_string() } else { format!("0x{}", hex::encode(jit.quoted_order.order_signature_with_private_key(config.blockchain, &config.private_key))) },
+                                "signature": format!("0x{}", hex::encode(jit.quoted_order.order_signature_with_private_key(config.blockchain, &config.private_key))),
                                 "signingScheme": if config.quote { "eip1271" } else { "eip712" },
                             });
                             trades_json.push(json!({
@@ -331,6 +356,7 @@ impl Solver {
                 "id": i,
                 "prices": prices_json,
                 "trades": trades_json,
+                "preInteractions": pre_interactions_json,
                 "interactions": interactions_json,
             }));
         }

--- a/crates/shared/src/trade_finding/external.rs
+++ b/crates/shared/src/trade_finding/external.rs
@@ -168,7 +168,10 @@ mod dto {
     use {
         bytes_hex::BytesHex,
         ethcontract::{H160, U256},
-        model::order::OrderKind,
+        model::{
+            order::{BuyTokenDestination, OrderKind, SellTokenSource},
+            signature::SigningScheme,
+        },
         number::serialization::HexOrDecimalU256,
         serde::{Deserialize, Serialize},
         serde_with::serde_as,
@@ -192,11 +195,15 @@ mod dto {
     pub struct Quote {
         #[serde_as(as = "HexOrDecimalU256")]
         pub amount: U256,
+        #[serde(default)]
+        pub pre_interactions: Vec<Interaction>,
         pub interactions: Vec<Interaction>,
         pub solver: H160,
         pub gas: Option<u64>,
         #[serde(default)]
         pub tx_origin: Option<H160>,
+        #[serde(default)]
+        pub jit_orders: Vec<JitOrder>,
     }
 
     #[serde_as]
@@ -213,8 +220,42 @@ mod dto {
     #[serde_as]
     #[derive(Clone, Debug, Deserialize)]
     #[serde(rename_all = "camelCase")]
+    #[allow(unused)]
+    pub struct JitOrder {
+        pub buy_token: H160,
+        pub sell_token: H160,
+        #[serde_as(as = "HexOrDecimalU256")]
+        pub sell_amount: U256,
+        #[serde_as(as = "HexOrDecimalU256")]
+        pub buy_amount: U256,
+        pub receiver: H160,
+        pub valid_to: u32,
+        #[serde_as(as = "BytesHex")]
+        pub app_data: Vec<u8>,
+        pub side: Side,
+        pub sell_token_source: SellTokenSource,
+        pub buy_token_destination: BuyTokenDestination,
+        #[serde_as(as = "BytesHex")]
+        pub signature: Vec<u8>,
+        pub signing_scheme: SigningScheme,
+        pub owner: H160,
+        #[serde_as(as = "BytesHex")]
+        pub uid: Vec<u8>,
+    }
+
+    #[serde_as]
+    #[derive(Clone, Debug, Deserialize)]
+    #[serde(rename_all = "camelCase")]
     pub struct Error {
         pub kind: String,
         pub description: String,
+    }
+
+    #[serde_as]
+    #[derive(Clone, Debug, Deserialize)]
+    #[serde(rename_all = "camelCase")]
+    pub enum Side {
+        Buy,
+        Sell,
     }
 }

--- a/crates/shared/src/trade_finding/external.rs
+++ b/crates/shared/src/trade_finding/external.rs
@@ -228,6 +228,8 @@ mod dto {
         pub sell_amount: U256,
         #[serde_as(as = "HexOrDecimalU256")]
         pub buy_amount: U256,
+        #[serde_as(as = "HexOrDecimalU256")]
+        pub executed_amount: U256,
         pub receiver: H160,
         pub valid_to: u32,
         #[serde_as(as = "BytesHex")]

--- a/crates/shared/src/trade_finding/external.rs
+++ b/crates/shared/src/trade_finding/external.rs
@@ -238,9 +238,6 @@ mod dto {
         #[serde_as(as = "BytesHex")]
         pub signature: Vec<u8>,
         pub signing_scheme: SigningScheme,
-        pub owner: H160,
-        #[serde_as(as = "BytesHex")]
-        pub uid: Vec<u8>,
     }
 
     #[serde_as]


### PR DESCRIPTION
# Description
> Allows solvers to return pre-interactions and JIT orders with their quote. That way solvers could quote with CoW AMMs (require JIT orders and pre-interactions). They could also index the orderbook and return resting limit orders as JIT orders.

# Changes

- [ ] update `driver -> autopilot/orderbook` `/quote` reponse to pass a list of pre-interactions and a list of JIT orders
- [ ] updated the openapi spec

## How to test
New driver tests(I can't express more how I want the driver's test framework to become more friendly).

Fixes #3027