### PR TITLE
Fix JIT orders saving

### DIFF
--- a/crates/autopilot/src/domain/eth/mod.rs
+++ b/crates/autopilot/src/domain/eth/mod.rs
@@ -1,5 +1,8 @@
-use derive_more::{Display, From, Into};
 pub use primitive_types::{H160, H256, U256};
+use {
+    crate::domain,
+    derive_more::{Display, From, Into},
+};
 
 /// An address. Can be an EOA or a smart contract address.
 #[derive(
@@ -254,12 +257,20 @@ pub struct DomainSeparator(pub [u8; 32]);
 /// Originated from the blockchain transaction input data.
 pub type Calldata = crate::util::Bytes<Vec<u8>>;
 
-/// An event emitted by a settlement smart contract.
+/// A settlement event emitted by a settlement smart contract.
 #[derive(Debug, Clone, Copy)]
-pub struct Event {
+pub struct SettlementEvent {
     pub block: BlockNo,
     pub log_index: u64,
     pub transaction: TxId,
+}
+
+/// A trade event emitted by a settlement smart contract.
+#[derive(Debug, Clone, Copy)]
+pub struct TradeEvent {
+    pub block: BlockNo,
+    pub log_index: u64,
+    pub order_uid: domain::OrderUid,
 }
 
 /// Any type of on-chain transaction.

--- a/crates/autopilot/src/infra/persistence/mod.rs
+++ b/crates/autopilot/src/infra/persistence/mod.rs
@@ -10,6 +10,7 @@ use {
     boundary::database::byte_array::ByteArray,
     chrono::{DateTime, Utc},
     database::{
+        events::EventIndex,
         order_events::OrderEventLabel,
         order_execution::Asset,
         orders::{
@@ -470,7 +471,7 @@ impl Persistence {
     /// not yet populated in the database.
     pub async fn get_settlement_without_auction(
         &self,
-    ) -> Result<Option<domain::eth::Event>, DatabaseError> {
+    ) -> Result<Option<domain::eth::SettlementEvent>, DatabaseError> {
         let _timer = Metrics::get()
             .database_queries
             .with_label_values(&["get_settlement_without_auction"])
@@ -480,7 +481,7 @@ impl Persistence {
         let event = database::settlements::get_settlement_without_auction(&mut ex)
             .await?
             .map(|event| {
-                let event = domain::eth::Event {
+                let event = domain::eth::SettlementEvent {
                     block: u64::try_from(event.block_number)
                         .context("negative block")?
                         .into(),
@@ -493,9 +494,42 @@ impl Persistence {
         Ok(event)
     }
 
+    /// Returns the trade events that are associated with the settlement event
+    pub async fn get_trades_for_settlement(
+        &self,
+        settlement: &domain::eth::SettlementEvent,
+    ) -> Result<Vec<domain::eth::TradeEvent>, DatabaseError> {
+        let _timer = Metrics::get()
+            .database_queries
+            .with_label_values(&["get_trades_for_settlement"])
+            .start_timer();
+
+        let mut ex = self.postgres.pool.acquire().await?;
+        database::trades::get_trades_for_settlement(
+            &mut ex,
+            EventIndex {
+                block_number: i64::try_from(settlement.block.0).context("block overflow")?,
+                log_index: i64::try_from(settlement.log_index).context("log index overflow")?,
+            },
+        )
+        .await?
+        .into_iter()
+        .map(|event| {
+            let event = domain::eth::TradeEvent {
+                block: u64::try_from(event.block_number)
+                    .context("negative block")?
+                    .into(),
+                log_index: u64::try_from(event.log_index).context("negative log index")?,
+                order_uid: domain::OrderUid(event.order_uid.0),
+            };
+            Ok::<_, DatabaseError>(event)
+        })
+        .collect()
+    }
+
     pub async fn save_settlement(
         &self,
-        event: domain::eth::Event,
+        event: domain::eth::SettlementEvent,
         auction_id: domain::auction::Id,
         settlement: Option<&domain::settlement::Settlement>,
     ) -> Result<(), DatabaseError> {
@@ -585,53 +619,83 @@ impl Persistence {
                 .await?;
             }
 
-            database::jit_orders::insert(
-                &mut ex,
-                &jit_orders
+            if !jit_orders.is_empty() {
+                // each jit order should have a corresponding trade event, try to find them
+                let trade_events = self
+                    .get_trades_for_settlement(&event)
+                    .await?
                     .into_iter()
-                    .map(|jit_order| database::jit_orders::JitOrder {
-                        block_number,
-                        log_index,
-                        uid: ByteArray(jit_order.uid.0),
-                        owner: ByteArray(jit_order.uid.owner().0 .0),
-                        creation_timestamp: chrono::DateTime::from_timestamp(
-                            i64::from(jit_order.created),
-                            0,
-                        )
-                        .unwrap_or_default(),
-                        sell_token: ByteArray(jit_order.sell.token.0 .0),
-                        buy_token: ByteArray(jit_order.buy.token.0 .0),
-                        sell_amount: u256_to_big_decimal(&jit_order.sell.amount.0),
-                        buy_amount: u256_to_big_decimal(&jit_order.buy.amount.0),
-                        valid_to: i64::from(jit_order.valid_to),
-                        app_data: ByteArray(jit_order.app_data.0),
-                        fee_amount: u256_to_big_decimal(&jit_order.fee_amount.0),
-                        kind: match jit_order.side {
-                            domain::auction::order::Side::Buy => database::orders::OrderKind::Buy,
-                            domain::auction::order::Side::Sell => database::orders::OrderKind::Sell,
-                        },
-                        partially_fillable: jit_order.partially_fillable,
-                        signature: jit_order.signature.to_bytes(),
-                        receiver: ByteArray(jit_order.receiver.0 .0),
-                        signing_scheme: match jit_order.signature.scheme() {
-                            DomainSigningScheme::Eip712 => DbSigningScheme::Eip712,
-                            DomainSigningScheme::EthSign => DbSigningScheme::EthSign,
-                            DomainSigningScheme::Eip1271 => DbSigningScheme::Eip1271,
-                            DomainSigningScheme::PreSign => DbSigningScheme::PreSign,
-                        },
-                        sell_token_balance: match jit_order.sell_token_balance {
-                            DomainSellTokenSource::Erc20 => DbSellTokenSource::Erc20,
-                            DomainSellTokenSource::External => DbSellTokenSource::External,
-                            DomainSellTokenSource::Internal => DbSellTokenSource::Internal,
-                        },
-                        buy_token_balance: match jit_order.buy_token_balance {
-                            DomainBuyTokenDestination::Erc20 => DbBuyTokenDestination::Erc20,
-                            DomainBuyTokenDestination::Internal => DbBuyTokenDestination::Internal,
-                        },
-                    })
-                    .collect::<Vec<_>>(),
-            )
-            .await?;
+                    .map(|event| (event.order_uid, (event.block, event.log_index)))
+                    .collect::<HashMap<_, (_, _)>>();
+
+                database::jit_orders::insert(
+                    &mut ex,
+                    &jit_orders
+                        .into_iter()
+                        .filter_map(|jit_order| match trade_events.get(&jit_order.uid) {
+                            Some((block_number, log_index)) => {
+                                Some(database::jit_orders::JitOrder {
+                                    block_number: i64::try_from(block_number.0).ok()?,
+                                    log_index: i64::try_from(*log_index).ok()?,
+                                    uid: ByteArray(jit_order.uid.0),
+                                    owner: ByteArray(jit_order.uid.owner().0 .0),
+                                    creation_timestamp: chrono::DateTime::from_timestamp(
+                                        i64::from(jit_order.created),
+                                        0,
+                                    )
+                                    .unwrap_or_default(),
+                                    sell_token: ByteArray(jit_order.sell.token.0 .0),
+                                    buy_token: ByteArray(jit_order.buy.token.0 .0),
+                                    sell_amount: u256_to_big_decimal(&jit_order.sell.amount.0),
+                                    buy_amount: u256_to_big_decimal(&jit_order.buy.amount.0),
+                                    valid_to: i64::from(jit_order.valid_to),
+                                    app_data: ByteArray(jit_order.app_data.0),
+                                    fee_amount: u256_to_big_decimal(&jit_order.fee_amount.0),
+                                    kind: match jit_order.side {
+                                        domain::auction::order::Side::Buy => {
+                                            database::orders::OrderKind::Buy
+                                        }
+                                        domain::auction::order::Side::Sell => {
+                                            database::orders::OrderKind::Sell
+                                        }
+                                    },
+                                    partially_fillable: jit_order.partially_fillable,
+                                    signature: jit_order.signature.to_bytes(),
+                                    receiver: ByteArray(jit_order.receiver.0 .0),
+                                    signing_scheme: match jit_order.signature.scheme() {
+                                        DomainSigningScheme::Eip712 => DbSigningScheme::Eip712,
+                                        DomainSigningScheme::EthSign => DbSigningScheme::EthSign,
+                                        DomainSigningScheme::Eip1271 => DbSigningScheme::Eip1271,
+                                        DomainSigningScheme::PreSign => DbSigningScheme::PreSign,
+                                    },
+                                    sell_token_balance: match jit_order.sell_token_balance {
+                                        DomainSellTokenSource::Erc20 => DbSellTokenSource::Erc20,
+                                        DomainSellTokenSource::External => {
+                                            DbSellTokenSource::External
+                                        }
+                                        DomainSellTokenSource::Internal => {
+                                            DbSellTokenSource::Internal
+                                        }
+                                    },
+                                    buy_token_balance: match jit_order.buy_token_balance {
+                                        DomainBuyTokenDestination::Erc20 => {
+                                            DbBuyTokenDestination::Erc20
+                                        }
+                                        DomainBuyTokenDestination::Internal => {
+                                            DbBuyTokenDestination::Internal
+                                        }
+                                    },
+                                })
+                            }
+                            None => {
+                                tracing::warn!(order_uid = ?jit_order.uid, "missing trade event for jit order");
+                                None
+                            }
+                        })
+                        .collect::<Vec<_>>(),
+                )
+                .await?;
+            }
         }
 
         ex.commit().await?;

--- a/crates/database/src/trades.rs
+++ b/crates/database/src/trades.rs
@@ -555,8 +555,7 @@ mod tests {
         .await;
         assert_trades(&mut db, None, None, &[trade_a.clone(), trade_b.clone()]).await;
 
-        // make sure that for a first settlement in the same block, only trade_a is
-        // returned
+        // make sure that for a settlement_a in the same block, only trade_a is returned
         assert_eq!(
             get_trades_for_settlement(&mut db, settlement_a_event)
                 .await
@@ -568,8 +567,7 @@ mod tests {
             }]
         );
 
-        // make sure that for a second settlement in the same block, only trade_b is
-        // returned
+        // make sure that for a settlement_b in the same block, only trade_b is returned
         assert_eq!(
             get_trades_for_settlement(&mut db, settlement_b_event)
                 .await

--- a/crates/database/src/trades.rs
+++ b/crates/database/src/trades.rs
@@ -87,7 +87,7 @@ pub async fn get_trades_for_settlement(
 WITH
     -- The log index in this query is the log index of the settlement event from the previous (lower log index) settlement in the same transaction or 0 if there is no previous settlement.
     previous_settlement AS (
-        SELECT COALESCE(MAX(log_index), 0) AS low
+        SELECT COALESCE(MAX(log_index), 0)
         FROM settlements
         WHERE block_number = $1 AND log_index < $2
     )

--- a/crates/orderbook/src/database/fee_policies.rs
+++ b/crates/orderbook/src/database/fee_policies.rs
@@ -80,7 +80,7 @@ impl super::Postgres {
                 tracing::warn!(
                     auction_id = ?key.0,
                     order = ?model::order::OrderUid(key.1.0),
-                    "missing fee policies for executed protocol fee",
+                    "missing fee policies for executed protocol fee, possibly a JIT order?",
                 );
             }
         }


### PR DESCRIPTION
# Description
JIT orders have a primary key `<block_number, log_index>` in `jit_orders` table. However, currently we use a single settlement event to save multiple JIT orders to database from `settlement::Observer`, which leads to only first JIT order being saved, while all others (if they exist) are skipped by an "[ON CONFLICT DO NOTHING](https://github.com/cowprotocol/services/blob/main/crates/database/src/jit_orders.rs#L158)" on insertion.

Instead of using a single settlement event, we now fetch all trade events that are associated with a settlement, match them to JIT orders, and then use trade events for PKs of JIT orders in database.

# Changes
<!-- List of detailed changes (how the change is accomplished) -->

- [ ] Added persistence function which, for a given settlement event, returns a list of trade events associated with it.
- [ ] Updated saving of settlement data from `settlement::Observer`, to use trade events for saving of JIT orders.

## How to test
Updated database unit test to prove that sql query is correct.
Existing e2e should prove no regression bugs were introduced.

<!--
## Related Issues

Fixes #
-->