### PR TITLE
Fix metrics and observations in autopilot runloop

### DIFF
--- a/crates/autopilot/src/run.rs
+++ b/crates/autopilot/src/run.rs
@@ -453,7 +453,7 @@ pub async fn run(args: Arguments) {
         hardcoded: args.trusted_tokens.unwrap_or_default(),
     };
     // updated in background task
-    let market_makable_token_list =
+    let trusted_tokens =
         AutoUpdatingTokenList::from_configuration(market_makable_token_list_configuration).await;
 
     let mut maintenance = Maintenance::new(
@@ -546,7 +546,7 @@ pub async fn run(args: Arguments) {
             })
             .collect(),
         solvable_orders_cache,
-        market_makable_token_list,
+        trusted_tokens,
         liveness.clone(),
         Arc::new(maintenance),
     );
@@ -566,11 +566,11 @@ async fn shadow_mode(args: Arguments) -> ! {
         .drivers
         .into_iter()
         .map(|driver| {
-            infra::Driver::new(
+            Arc::new(infra::Driver::new(
                 driver.url,
                 driver.name,
                 driver.fairness_threshold.map(Into::into),
-            )
+            ))
         })
         .collect();
 

--- a/crates/autopilot/src/run_loop.rs
+++ b/crates/autopilot/src/run_loop.rs
@@ -253,10 +253,7 @@ impl RunLoop {
 
         // Collect valid solutions from all drivers
         let solutions = self.competition(&auction).await;
-        if solutions.is_empty() {
-            tracing::info!("no solutions for auction");
-            return;
-        }
+        observe::solutions(&solutions);
 
         // Mark all solved orders as `Considered` for execution
         self.persistence.store_order_events(
@@ -550,8 +547,6 @@ impl RunLoop {
         solutions.sort_unstable_by_key(|participant| {
             std::cmp::Reverse(participant.solution.score().get().0)
         });
-
-        observe::solutions(&solutions);
         solutions
     }
 
@@ -1083,6 +1078,9 @@ pub mod observe {
     }
 
     pub fn solutions(solutions: &[super::Participant]) {
+        if solutions.is_empty() {
+            tracing::info!("no solutions for auction");
+        }
         for participant in solutions {
             tracing::debug!(
                 driver = %participant.driver.name,

--- a/crates/autopilot/src/shadow.rs
+++ b/crates/autopilot/src/shadow.rs
@@ -35,7 +35,7 @@ use {
 
 pub struct RunLoop {
     orderbook: infra::shadow::Orderbook,
-    drivers: Vec<infra::Driver>,
+    drivers: Vec<Arc<infra::Driver>>,
     trusted_tokens: AutoUpdatingTokenList,
     auction: domain::auction::Id,
     block: u64,
@@ -50,7 +50,7 @@ impl RunLoop {
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         orderbook: infra::shadow::Orderbook,
-        drivers: Vec<infra::Driver>,
+        drivers: Vec<Arc<infra::Driver>>,
         trusted_tokens: AutoUpdatingTokenList,
         solve_deadline: Duration,
         liveness: Arc<Liveness>,


### PR DESCRIPTION
# Description
This PR addresses several smaller issues related to metrics in the autopilot run loop and refactors functions in preparation for https://github.com/cowprotocol/services/pull/2996#discussion_r1786395658.

# Changes
<!-- List of detailed changes (how the change is accomplished) -->

- [ ] Refactored `Self::is_solution_fair` out of the runloop competition function:
- Now checks fairness for every winner, not just the global winner (fixing an oversight in [PR #2996](https://github.com/cowprotocol/services/pull/2996)).
- Unfair solutions are still considered valid and rewarded as participants, as solvers should be credited for any valid solution they propose, regardless of what other solvers submit.
- [ ] Updated the "matched but unsettled" metric to include all winners, not just the global winner (fixing another oversight from [PR #2996](https://github.com/cowprotocol/services/pull/2996)).
- [ ] Reorganized logs and order status updates to facilitate extracting common functionality between shadow and main competitions (to be addressed in follow-up work).

Next step: refactor `competition` function from shadow and main runloop to be exactly the same and unify the `Participant` struct (currently both modes have their own version).

## How to test
Existing e2e tests