### PR TITLE
[TRIVIAL] Autopilot: Add last seen block metrics to Maintenance::update

### DIFF
--- a/crates/autopilot/src/maintenance.rs
+++ b/crates/autopilot/src/maintenance.rs
@@ -57,6 +57,7 @@ impl Maintenance {
     /// has a consistent state.
     pub async fn update(&self, new_block: &BlockInfo) {
         let mut last_block = self.last_processed.lock().await;
+        metrics().last_seen_block.set(new_block.number);
         if last_block.number > new_block.number || last_block.hash == new_block.hash {
             // `new_block` is neither newer than `last_block` nor a reorg
             return;


### PR DESCRIPTION
# Description
Add last seen block metrics to Maintenance::update, since it was removed in https://github.com/cowprotocol/services/pull/3050