### PR TITLE
Remove Liquidity orders from Driver

### DIFF
--- a/crates/driver/src/domain/competition/auction.rs
+++ b/crates/driver/src/domain/competition/auction.rs
@@ -93,12 +93,7 @@ impl Auction {
     pub fn liquidity_pairs(&self) -> HashSet<liquidity::TokenPair> {
         self.orders
             .iter()
-            .filter_map(|order| match order.kind {
-                order::Kind::Market | order::Kind::Limit { .. } => {
-                    liquidity::TokenPair::new(order.sell.token, order.buy.token).ok()
-                }
-                order::Kind::Liquidity => None,
-            })
+            .filter_map(|order| liquidity::TokenPair::new(order.sell.token, order.buy.token).ok())
             .collect()
     }
 

--- a/crates/driver/src/domain/competition/order/mod.rs
+++ b/crates/driver/src/domain/competition/order/mod.rs
@@ -136,10 +136,6 @@ impl Order {
         self.receiver.unwrap_or(self.signature.signer)
     }
 
-    pub fn is_liquidity(&self) -> bool {
-        matches!(self.kind, Kind::Liquidity)
-    }
-
     /// Returns the order's available amounts to be passed to a solver engine.
     ///
     /// See [`Available`] for more details.
@@ -307,9 +303,6 @@ pub enum Kind {
     /// solve for, above what the user specified in the order. The exact amount
     /// of fees that are taken is determined by the solver.
     Limit,
-    /// An order submitted by a privileged user, which provides liquidity for
-    /// our settlement contract.
-    Liquidity,
 }
 
 /// [Balancer V2](https://docs.balancer.fi/) integration, used for settlement encoding.

--- a/crates/driver/src/infra/api/routes/solve/dto/auction.rs
+++ b/crates/driver/src/infra/api/routes/solve/dto/auction.rs
@@ -51,7 +51,6 @@ impl Auction {
                     kind: match order.class {
                         Class::Market => competition::order::Kind::Market,
                         Class::Limit => competition::order::Kind::Limit,
-                        Class::Liquidity => competition::order::Kind::Liquidity,
                     },
                     app_data: order.app_data.into(),
                     partial: if order.partially_fillable {
@@ -311,7 +310,6 @@ enum SigningScheme {
 enum Class {
     Market,
     Limit,
-    Liquidity,
 }
 
 #[derive(Debug, Deserialize)]

--- a/crates/driver/src/infra/solver/dto/auction.rs
+++ b/crates/driver/src/infra/solver/dto/auction.rs
@@ -135,7 +135,6 @@ impl Auction {
                         class: match order.kind {
                             order::Kind::Market => Class::Market,
                             order::Kind::Limit { .. } => Class::Limit,
-                            order::Kind::Liquidity => Class::Liquidity,
                         },
                         pre_interactions: order
                             .pre_interactions
@@ -390,7 +389,6 @@ enum Kind {
 enum Class {
     Market,
     Limit,
-    Liquidity,
 }
 
 #[serde_as]

--- a/crates/driver/src/tests/cases/settle.rs
+++ b/crates/driver/src/tests/cases/settle.rs
@@ -20,7 +20,6 @@ async fn matrix() {
             let solver_fee = match kind {
                 order::Kind::Market => None,
                 order::Kind::Limit { .. } => Some(DEFAULT_SOLVER_FEE.ether().into_wei()),
-                order::Kind::Liquidity => None,
             };
             let test = tests::setup()
                 .name(format!("{side:?} {kind:?}"))

--- a/crates/driver/src/tests/setup/driver.rs
+++ b/crates/driver/src/tests/setup/driver.rs
@@ -75,7 +75,6 @@ pub fn solve_req(test: &Test) -> serde_json::Value {
             "buyAmount": quote.buy_amount().to_string(),
             "protocolFees": match quote.order.kind {
                 order::Kind::Market => json!([]),
-                order::Kind::Liquidity => json!([]),
                         order::Kind::Limit { .. } => {
                             let fee_policies_json: Vec<serde_json::Value> = quote
                                 .order
@@ -102,7 +101,6 @@ pub fn solve_req(test: &Test) -> serde_json::Value {
             "postInteractions": [],
             "class": match quote.order.kind {
                 order::Kind::Market => "market",
-                order::Kind::Liquidity => "liquidity",
                 order::Kind::Limit { .. } => "limit",
             },
             "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",

--- a/crates/driver/src/tests/setup/solver.rs
+++ b/crates/driver/src/tests/setup/solver.rs
@@ -140,7 +140,6 @@ impl Solver {
                 "class": match quote.order.kind {
                     _ if config.quote => "market",
                     order::Kind::Market => "market",
-                    order::Kind::Liquidity => "liquidity",
                     order::Kind::Limit { .. } => "limit",
                 },
                 "appData": quote.order.app_data,
@@ -153,7 +152,6 @@ impl Solver {
                     match quote.order.kind {
                         _ if config.quote => json!([]),
                         order::Kind::Market => json!([]),
-                        order::Kind::Liquidity => json!([]),
                         order::Kind::Limit { .. } => {
                             let fee_policies_json: Vec<serde_json::Value> = quote
                                 .order


### PR DESCRIPTION
# Description
With https://github.com/cowprotocol/services/pull/2961, we made sure only Limit orders are sent to driver for solving. For quoting, driver still uses Market orders, and removing this is captured with https://github.com/cowprotocol/services/issues/2543, and resolving this would allow us to completely remove `class` type in driver.

But for now, I think we don't use Liquidity type for anything. Liquidity orders are not part of the Auction, so solvers also cant refer to them in their solutions, so I think removing them is not even a breaking change. 

Still checking if we want to remove them from the solvers API as well. edit: went down a rabit hole of removing from solvers API and since the code change is huge, will do it in a separate PR.

Would allow for cleaner implementation of https://github.com/cowprotocol/services/pull/3048

## How to test
Existing tests.