### PR TITLE
Remove Liquidity order type from Solvers

### DIFF
--- a/crates/solvers-dto/src/auction.rs
+++ b/crates/solvers-dto/src/auction.rs
@@ -112,7 +112,6 @@ pub enum Kind {
 pub enum Class {
     Market,
     Limit,
-    Liquidity,
 }
 
 #[derive(Debug, Deserialize)]

--- a/crates/solvers/openapi.yml
+++ b/crates/solvers/openapi.yml
@@ -234,7 +234,7 @@ components:
       description: |
         How the CoW Protocol order was classified.
       type: string
-      enum: [ market, limit, liquidity ]
+      enum: [ market, limit ]
 
     AppData:
       description: |

--- a/crates/solvers/src/api/routes/solve/dto/auction.rs
+++ b/crates/solvers/src/api/routes/solve/dto/auction.rs
@@ -56,7 +56,6 @@ pub fn to_domain(auction: &Auction) -> Result<auction::Auction, Error> {
                 class: match order.class {
                     Class::Market => order::Class::Market,
                     Class::Limit => order::Class::Limit,
-                    Class::Liquidity => order::Class::Liquidity,
                 },
                 partially_fillable: order.partially_fillable,
             })

--- a/crates/solvers/src/boundary/naive.rs
+++ b/crates/solvers/src/boundary/naive.rs
@@ -22,7 +22,6 @@ use {
             LimitOrder,
             LimitOrderExecution,
             LimitOrderId,
-            LiquidityOrderId,
             SettlementHandling,
         },
         settlement::SettlementEncoder,
@@ -57,9 +56,6 @@ pub fn solve(
             id: match order.class {
                 order::Class::Market => LimitOrderId::Market(OrderUid(order.uid.0)),
                 order::Class::Limit => LimitOrderId::Limit(OrderUid(order.uid.0)),
-                order::Class::Liquidity => {
-                    LimitOrderId::Liquidity(LiquidityOrderId::Protocol(OrderUid(order.uid.0)))
-                }
             },
             sell_token: order.sell.token.0,
             buy_token: order.buy.token.0,
@@ -78,7 +74,6 @@ pub fn solve(
                         class: match order.class {
                             order::Class::Market => OrderClass::Market,
                             order::Class::Limit => OrderClass::Limit,
-                            order::Class::Liquidity => OrderClass::Liquidity,
                         },
                         solver_fee: 0.into(),
                         ..Default::default()

--- a/crates/solvers/src/domain/order.rs
+++ b/crates/solvers/src/domain/order.rs
@@ -63,48 +63,6 @@ pub enum Side {
 pub enum Class {
     Market,
     Limit,
-    Liquidity,
-}
-
-/// A user order, guaranteed to not be a liquidity order.
-///
-/// Note that the concept of a user order is important enough to merit its own
-/// type. The reason for this is that these orders and liquidity orders differ
-/// in fundamental ways and we do not want to confuse them and accidentally use
-/// a liquidity order where it shouldn't be used. Some of the notable
-/// differences between the order types are:
-///
-/// - Liquidity orders can't be settled directly against on-chain liquidity.
-///   They are meant to only be used in CoWs to facilitate the trading of other
-///   non-liquidity orders.
-/// - Liquidity orders do not provide any solver rewards.
-///
-/// As their name suggests, they are meant as a mechanism for providing
-/// liquidity on CoW Protocol to other non-liquidity orders: they provide a
-/// mechanism for turning one token into another. In this regard, a liquidity
-/// order is conceptually similar to `liquidity::Liquidity`. One notable
-/// difference between the two is in how they are executed. General liquidity
-/// requires tokens up-front in order to exchange them for something else. On
-/// the other hand, liquidity orders are CoW Protocol orders, meaning that they
-/// first provide the tokens being swapped to and only get paid at the end of
-/// the settlement.
-#[derive(Clone, Copy, Debug)]
-pub struct UserOrder<'a>(&'a Order);
-
-impl<'a> UserOrder<'a> {
-    /// Wraps an order as a user order, returns `None` if the specified order is
-    /// not a user order.
-    pub fn new(order: &'a Order) -> Option<Self> {
-        match order.class {
-            Class::Market | Class::Limit => Some(Self(order)),
-            Class::Liquidity => None,
-        }
-    }
-
-    /// Returns a reference to the underlying CoW Protocol order.
-    pub fn get(&self) -> &'a Order {
-        self.0
-    }
 }
 
 /// An order that can be used to provide just-in-time liquidity in form of a CoW

--- a/crates/solvers/src/domain/solver/baseline.rs
+++ b/crates/solvers/src/domain/solver/baseline.rs
@@ -12,10 +12,7 @@ use {
             auction,
             eth,
             liquidity,
-            order::{
-                Order,
-                {self},
-            },
+            order::{self, Order},
             solution,
         },
     },

--- a/crates/solvers/src/domain/solver/baseline.rs
+++ b/crates/solvers/src/domain/solver/baseline.rs
@@ -12,7 +12,10 @@ use {
             auction,
             eth,
             liquidity,
-            order::{self, UserOrder},
+            order::{
+                Order,
+                {self},
+            },
             solution,
         },
     },
@@ -126,11 +129,7 @@ impl Inner {
             boundary::baseline::Solver::new(&self.weth, &self.base_tokens, &auction.liquidity);
 
         for (i, order) in auction.orders.into_iter().enumerate() {
-            let Some(user_order) = UserOrder::new(&order) else {
-                continue;
-            };
-
-            let sell_token = user_order.get().sell.token;
+            let sell_token = order.sell.token;
             let sell_token_price = match auction.tokens.reference_price(&sell_token) {
                 Some(price) => price,
                 None if sell_token == self.weth.0.into() => {
@@ -139,7 +138,7 @@ impl Inner {
                 }
                 None => {
                     // Estimate the price of the sell token in the native token
-                    let native_price_request = self.native_price_request(user_order);
+                    let native_price_request = self.native_price_request(&order);
                     if let Some(route) = boundary_solver.route(native_price_request, self.max_hops)
                     {
                         // how many units of buy_token are bought for one unit of sell_token
@@ -159,7 +158,7 @@ impl Inner {
                 }
             };
 
-            let solution = self.requests_for_order(user_order).find_map(|request| {
+            let solution = self.requests_for_order(&order).find_map(|request| {
                 tracing::trace!(order =% order.uid, ?request, "finding route");
 
                 let route = boundary_solver.route(request, self.max_hops)?;
@@ -215,12 +214,12 @@ impl Inner {
         }
     }
 
-    fn requests_for_order(&self, order: UserOrder) -> impl Iterator<Item = Request> {
+    fn requests_for_order(&self, order: &Order) -> impl Iterator<Item = Request> {
         let order::Order {
             sell, buy, side, ..
-        } = order.get().clone();
+        } = order.clone();
 
-        let n = if order.get().partially_fillable {
+        let n = if order.partially_fillable {
             self.max_partial_attempts
         } else {
             1
@@ -244,9 +243,9 @@ impl Inner {
             .filter(|r| !r.sell.amount.is_zero() && !r.buy.amount.is_zero())
     }
 
-    fn native_price_request(&self, order: UserOrder) -> Request {
+    fn native_price_request(&self, order: &Order) -> Request {
         let sell = eth::Asset {
-            token: order.get().sell.token,
+            token: order.sell.token,
             // Note that we intentionally do not use [`eth::U256::max_value()`]
             // as an order with this would cause overflows with the smart
             // contract, so buy orders requiring excessively large sell amounts

--- a/crates/solvers/src/tests/naive/swap_less_than_reserves.rs
+++ b/crates/solvers/src/tests/naive/swap_less_than_reserves.rs
@@ -36,7 +36,7 @@ async fn test() {
                     "postInteractions": [],
                     "sellTokenSource": "erc20",
                     "buyTokenDestination": "erc20",
-                    "class": "liquidity",
+                    "class": "limit",
                     "appData": "0x6000000000000000000000000000000000000000000000000000000000000007",
                     "signingScheme": "presign",
                     "signature": "0x",


### PR DESCRIPTION
# Description
A follow up for https://github.com/cowprotocol/services/pull/3058

Removes Liquidity order type from solvers API.

Solvers PR: https://github.com/gnosis/solvers/pull/77

# Changes
<!-- List of detailed changes (how the change is accomplished) -->

- [ ] Removed Liquidity order type from interface and from the domain

## How to test
Existing tests.