### PR TITLE
Skip empty upload

### DIFF
--- a/crates/autopilot/src/infra/persistence/mod.rs
+++ b/crates/autopilot/src/infra/persistence/mod.rs
@@ -94,6 +94,10 @@ impl Persistence {
         let Some(uploader) = self.s3.clone() else {
             return;
         };
+        if instance.auction.orders.is_empty() {
+            tracing::info!("skip upload of empty auction");
+            return;
+        }
         tokio::spawn(
             async move {
                 match uploader


### PR DESCRIPTION
# Description
We are currently uploading tons of empty instance files to S3. Noticed by checking logs in the arbitrum staging environment.

# Changes
Skipping empty uploads.