### PR TITLE
Multiple winners e2e test

### DIFF
--- a/crates/autopilot/src/run_loop.rs
+++ b/crates/autopilot/src/run_loop.rs
@@ -82,13 +82,6 @@ impl RunLoop {
         liveness: Arc<Liveness>,
         maintenance: Arc<Maintenance>,
     ) -> Self {
-        // Added to make sure no more than one winner is activated by accident
-        // Should be removed once we decide to activate "multiple winners per auction"
-        // feature.
-        assert_eq!(
-            config.max_winners_per_auction, 1,
-            "only one winner is supported"
-        );
         Self {
             config,
             eth,

--- a/crates/autopilot/src/shadow.rs
+++ b/crates/autopilot/src/shadow.rs
@@ -54,10 +54,6 @@ impl RunLoop {
         current_block: CurrentBlockWatcher,
         max_winners_per_auction: usize,
     ) -> Self {
-        // Added to make sure no more than one winner is activated by accident
-        // Should be removed once we decide to activate "multiple winners per auction"
-        // feature.
-        assert_eq!(max_winners_per_auction, 1, "only one winner is supported");
         Self {
             orderbook,
             drivers,

--- a/crates/e2e/src/setup/colocation.rs
+++ b/crates/e2e/src/setup/colocation.rs
@@ -11,6 +11,7 @@ pub struct SolverEngine {
     pub endpoint: Url,
     pub account: TestAccount,
     pub base_tokens: Vec<H160>,
+    pub merge_solutions: bool,
 }
 
 pub async fn start_baseline_solver(
@@ -18,13 +19,15 @@ pub async fn start_baseline_solver(
     account: TestAccount,
     weth: H160,
     base_tokens: Vec<H160>,
+    max_hops: usize,
+    merge_solutions: bool,
 ) -> SolverEngine {
     let encoded_base_tokens = encode_base_tokens(base_tokens.clone());
     let config_file = config_tmp_file(format!(
         r#"
 weth = "{weth:?}"
 base-tokens = [{encoded_base_tokens}]
-max-hops = 1
+max-hops = {max_hops}
 max-partial-attempts = 5
 native-token-price-estimation-amount = "100000000000000000"
         "#,
@@ -36,6 +39,7 @@ native-token-price-estimation-amount = "100000000000000000"
         endpoint,
         account,
         base_tokens,
+        merge_solutions,
     }
 }
 
@@ -107,6 +111,7 @@ pub fn start_driver(
                  account,
                  endpoint,
                  base_tokens: _,
+                 merge_solutions,
              }| {
                 let account = hex::encode(account.private_key());
                 format!(
@@ -116,7 +121,7 @@ name = "{name}"
 endpoint = "{endpoint}"
 relative-slippage = "0.1"
 account = "{account}"
-merge-solutions = true
+merge-solutions = {merge_solutions}
 "#
                 )
             },

--- a/crates/e2e/src/setup/services.rs
+++ b/crates/e2e/src/setup/services.rs
@@ -204,6 +204,8 @@ impl<'a> Services<'a> {
                     solver,
                     self.contracts.weth.address(),
                     vec![],
+                    1,
+                    true,
                 )
                 .await,
             ],
@@ -251,6 +253,7 @@ impl<'a> Services<'a> {
             account: solver.clone(),
             endpoint: external_solver_endpoint,
             base_tokens: vec![],
+            merge_solutions: true,
         }];
 
         let (autopilot_args, api_args) = if run_baseline {
@@ -260,6 +263,8 @@ impl<'a> Services<'a> {
                     solver,
                     self.contracts.weth.address(),
                     vec![],
+                    1,
+                    true,
                 )
                 .await,
             );

--- a/crates/e2e/tests/e2e/buffers.rs
+++ b/crates/e2e/tests/e2e/buffers.rs
@@ -48,6 +48,8 @@ async fn onchain_settlement_without_liquidity(web3: Web3) {
                 solver,
                 onchain.contracts().weth.address(),
                 vec![],
+                1,
+                true,
             )
             .await,
         ],

--- a/crates/e2e/tests/e2e/cow_amm.rs
+++ b/crates/e2e/tests/e2e/cow_amm.rs
@@ -139,6 +139,8 @@ async fn cow_amm_jit(web3: Web3) {
                 solver.clone(),
                 onchain.contracts().weth.address(),
                 vec![],
+                1,
+                true,
             )
             .await,
             SolverEngine {
@@ -146,6 +148,7 @@ async fn cow_amm_jit(web3: Web3) {
                 account: solver.clone(),
                 endpoint: mock_solver.url.clone(),
                 base_tokens: vec![],
+                merge_solutions: true,
             },
         ],
         colocation::LiquidityProvider::UniswapV2,
@@ -458,6 +461,8 @@ async fn cow_amm_driver_support(web3: Web3) {
                 solver.clone(),
                 onchain.contracts().weth.address(),
                 vec![],
+                1,
+                true,
             )
             .await,
             SolverEngine {
@@ -465,6 +470,7 @@ async fn cow_amm_driver_support(web3: Web3) {
                 account: solver.clone(),
                 endpoint: mock_solver.url.clone(),
                 base_tokens: vec![],
+                merge_solutions: true,
             },
         ],
         colocation::LiquidityProvider::UniswapV2,

--- a/crates/e2e/tests/e2e/jit_orders.rs
+++ b/crates/e2e/tests/e2e/jit_orders.rs
@@ -63,6 +63,8 @@ async fn single_limit_order_test(web3: Web3) {
                 solver.clone(),
                 onchain.contracts().weth.address(),
                 vec![],
+                1,
+                true,
             )
             .await,
             SolverEngine {
@@ -70,6 +72,7 @@ async fn single_limit_order_test(web3: Web3) {
                 account: solver.clone(),
                 endpoint: mock_solver.url.clone(),
                 base_tokens: vec![token.address()],
+                merge_solutions: true,
             },
         ],
         colocation::LiquidityProvider::UniswapV2,

--- a/crates/e2e/tests/e2e/limit_orders.rs
+++ b/crates/e2e/tests/e2e/limit_orders.rs
@@ -416,17 +416,17 @@ async fn two_limit_orders_multiple_winners_test(web3: Web3) {
         let trade_b = services.get_trades(&uid_b).await.unwrap().first().cloned();
         match (trade_a, trade_b) {
             (Some(trade_a), Some(trade_b)) => {
-                match (
-                    services
-                        .get_solver_competition(trade_a.tx_hash.unwrap())
-                        .await,
-                    services
-                        .get_solver_competition(trade_b.tx_hash.unwrap())
-                        .await,
-                ) {
-                    (Ok(_), Ok(_)) => true,
-                    _ => false,
-                }
+                matches!(
+                    (
+                        services
+                            .get_solver_competition(trade_a.tx_hash.unwrap())
+                            .await,
+                        services
+                            .get_solver_competition(trade_b.tx_hash.unwrap())
+                            .await
+                    ),
+                    (Ok(_), Ok(_))
+                )
             }
             _ => false,
         }

--- a/crates/e2e/tests/e2e/limit_orders.rs
+++ b/crates/e2e/tests/e2e/limit_orders.rs
@@ -28,6 +28,12 @@ async fn local_node_two_limit_orders() {
 
 #[tokio::test]
 #[ignore]
+async fn local_node_two_limit_orders_multiple_winners() {
+    run_test(two_limit_orders_multiple_winners_test).await;
+}
+
+#[tokio::test]
+#[ignore]
 async fn local_node_too_many_limit_orders() {
     run_test(too_many_limit_orders_test).await;
 }
@@ -291,6 +297,147 @@ async fn two_limit_orders_test(web3: Web3) {
     .unwrap();
 }
 
+async fn two_limit_orders_multiple_winners_test(web3: Web3) {
+    let mut onchain = OnchainComponents::deploy(web3).await;
+
+    let [solver1, solver2] = onchain.make_solvers(to_wei(1)).await;
+    let [trader_a, trader_b] = onchain.make_accounts(to_wei(1)).await;
+    let [token_a, token_b, token_c, token_d] = onchain
+        .deploy_tokens_with_weth_uni_v2_pools(to_wei(1_000), to_wei(1_000))
+        .await;
+
+    // Fund traders
+    token_a.mint(trader_a.address(), to_wei(10)).await;
+    token_b.mint(trader_b.address(), to_wei(10)).await;
+
+    // Create more liquid routes between token_a (token_b) and weth via base_a
+    // (base_b). base_a has more liquidity then base_b, leading to the solver that
+    // knows about base_a to offer different solution.
+    let [base_a, base_b] = onchain
+        .deploy_tokens_with_weth_uni_v2_pools(to_wei(10_000), to_wei(10_000))
+        .await;
+    onchain
+        .seed_uni_v2_pool((&token_a, to_wei(100_000)), (&base_a, to_wei(100_000)))
+        .await;
+    onchain
+        .seed_uni_v2_pool((&token_b, to_wei(10_000)), (&base_b, to_wei(10_000)))
+        .await;
+
+    // Approve GPv2 for trading
+    tx!(
+        trader_a.account(),
+        token_a.approve(onchain.contracts().allowance, to_wei(100))
+    );
+    tx!(
+        trader_b.account(),
+        token_b.approve(onchain.contracts().allowance, to_wei(100))
+    );
+
+    // Start system, with two solvers, one that knows about base_a and one that
+    // knows about base_b
+    colocation::start_driver(
+        onchain.contracts(),
+        vec![
+            colocation::start_baseline_solver(
+                "test_solver".into(),
+                solver1.clone(),
+                onchain.contracts().weth.address(),
+                vec![base_a.address()],
+                2,
+                false,
+            )
+            .await,
+            colocation::start_baseline_solver(
+                "solver2".into(),
+                solver2,
+                onchain.contracts().weth.address(),
+                vec![base_b.address()],
+                2,
+                false,
+            )
+            .await,
+        ],
+        colocation::LiquidityProvider::UniswapV2,
+    );
+
+    let services = Services::new(&onchain).await;
+    services.start_autopilot(
+        None,
+        vec![
+            "--drivers=solver1|http://localhost:11088/test_solver|10000000000000000,solver2|http://localhost:11088/solver2"
+                .to_string(),
+            "--price-estimation-drivers=solver1|http://localhost:11088/test_solver".to_string(),
+            "--max-winners-per-auction=2".to_string(),
+        ],
+    ).await;
+    services
+        .start_api(vec![
+            "--price-estimation-drivers=solver1|http://localhost:11088/test_solver".to_string(),
+        ])
+        .await;
+
+    // Place Orders
+    let order_a = OrderCreation {
+        sell_token: token_a.address(),
+        sell_amount: to_wei(10),
+        buy_token: token_c.address(),
+        buy_amount: to_wei(5),
+        valid_to: model::time::now_in_epoch_seconds() + 300,
+        kind: OrderKind::Sell,
+        ..Default::default()
+    }
+    .sign(
+        EcdsaSigningScheme::Eip712,
+        &onchain.contracts().domain_separator,
+        SecretKeyRef::from(&SecretKey::from_slice(trader_a.private_key()).unwrap()),
+    );
+    let uid_a = services.create_order(&order_a).await.unwrap();
+
+    onchain.mint_block().await;
+
+    let order_b = OrderCreation {
+        sell_token: token_b.address(),
+        sell_amount: to_wei(10),
+        buy_token: token_d.address(),
+        buy_amount: to_wei(5),
+        valid_to: model::time::now_in_epoch_seconds() + 300,
+        kind: OrderKind::Sell,
+        ..Default::default()
+    }
+    .sign(
+        EcdsaSigningScheme::Eip712,
+        &onchain.contracts().domain_separator,
+        SecretKeyRef::from(&SecretKey::from_slice(trader_b.private_key()).unwrap()),
+    );
+    let uid_b = services.create_order(&order_b).await.unwrap();
+
+    // Wait for trade
+    let indexed_trades = || async {
+        onchain.mint_block().await;
+        match services.get_trades(&uid_a).await.unwrap().first() {
+            Some(trade) => services
+                .get_solver_competition(trade.tx_hash.unwrap())
+                .await
+                .is_ok(),
+            None => false,
+        }
+    };
+    wait_for_condition(TIMEOUT, indexed_trades).await.unwrap();
+
+    let trades = services.get_trades(&uid_a).await.unwrap();
+    let competition = services
+        .get_solver_competition(trades[0].tx_hash.unwrap())
+        .await
+        .unwrap();
+    // Verify that both transactions were properly indexed
+    assert_eq!(competition.transaction_hashes.len(), 2);
+    // Verify that settlement::Observed properly handled events
+    let order_a_settled = services.get_order(&uid_a).await.unwrap();
+    assert!(order_a_settled.metadata.executed_surplus_fee > 0.into());
+    let order_b_settled = services.get_order(&uid_b).await.unwrap();
+    assert!(order_b_settled.metadata.executed_surplus_fee > 0.into());
+}
+
 async fn too_many_limit_orders_test(web3: Web3) {
     let mut onchain = OnchainComponents::deploy(web3.clone()).await;
 
@@ -317,6 +464,8 @@ async fn too_many_limit_orders_test(web3: Web3) {
                 solver,
                 onchain.contracts().weth.address(),
                 vec![],
+                1,
+                true,
             )
             .await,
         ],
@@ -393,6 +542,8 @@ async fn limit_does_not_apply_to_in_market_orders_test(web3: Web3) {
                 solver,
                 onchain.contracts().weth.address(),
                 vec![],
+                1,
+                true,
             )
             .await,
         ],

--- a/crates/e2e/tests/e2e/liquidity.rs
+++ b/crates/e2e/tests/e2e/liquidity.rs
@@ -141,6 +141,8 @@ async fn zero_ex_liquidity(web3: Web3) {
                 solver.clone(),
                 onchain.contracts().weth.address(),
                 vec![],
+                1,
+                true,
             )
             .await,
         ],

--- a/crates/e2e/tests/e2e/order_cancellation.rs
+++ b/crates/e2e/tests/e2e/order_cancellation.rs
@@ -55,6 +55,8 @@ async fn order_cancellation(web3: Web3) {
                 solver,
                 onchain.contracts().weth.address(),
                 vec![],
+                1,
+                true,
             )
             .await,
         ],

--- a/crates/e2e/tests/e2e/solver_competition.rs
+++ b/crates/e2e/tests/e2e/solver_competition.rs
@@ -50,6 +50,8 @@ async fn solver_competition(web3: Web3) {
                 solver.clone(),
                 onchain.contracts().weth.address(),
                 vec![],
+                1,
+                true,
             )
             .await,
             colocation::start_baseline_solver(
@@ -57,6 +59,8 @@ async fn solver_competition(web3: Web3) {
                 solver,
                 onchain.contracts().weth.address(),
                 vec![],
+                1,
+                true,
             )
             .await,
         ],
@@ -171,6 +175,8 @@ async fn fairness_check(web3: Web3) {
                 solver.clone(),
                 onchain.contracts().weth.address(),
                 vec![base_a.address()],
+                1,
+                true,
             )
             .await,
             colocation::start_baseline_solver(
@@ -178,6 +184,8 @@ async fn fairness_check(web3: Web3) {
                 solver,
                 onchain.contracts().weth.address(),
                 vec![base_b.address()],
+                1,
+                true,
             )
             .await,
         ],

--- a/crates/e2e/tests/e2e/solver_competition.rs
+++ b/crates/e2e/tests/e2e/solver_competition.rs
@@ -143,7 +143,7 @@ async fn fairness_check(web3: Web3) {
     token_b.mint(trader_b.address(), to_wei(10)).await;
 
     // Create more liquid routes between token_a (token_b) and weth via base_a
-    // (base_b). base_a has more liquidity then base_b, leading to the solver that
+    // (base_b). base_a has more liquidity than base_b, leading to the solver that
     // knows about base_a to win
     let [base_a, base_b] = onchain
         .deploy_tokens_with_weth_uni_v2_pools(to_wei(10_000), to_wei(10_000))


### PR DESCRIPTION
# Description
Implements e2e test for multiple winners per auction feature.

Verifies that:
1. Two winners are selected
2. Winning solutions trade disjoint tokens
3. Two `/settle` calls are sent and two transactions are mined.
4. Two settlements are indexed and dependent data is properly saved to database.

## How to test
Added test.