### PR TITLE
[TRIVIAL] Fix Rust 1.82 warnings

### DIFF
--- a/crates/autopilot/src/run.rs
+++ b/crates/autopilot/src/run.rs
@@ -550,7 +550,6 @@ pub async fn run(args: Arguments) {
         Arc::new(maintenance),
     );
     run.run_forever().await;
-    unreachable!("run loop exited");
 }
 
 async fn shadow_mode(args: Arguments) -> ! {
@@ -624,6 +623,4 @@ async fn shadow_mode(args: Arguments) -> ! {
         args.max_winners_per_auction,
     );
     shadow.run_forever().await;
-
-    unreachable!("shadow run loop exited");
 }

--- a/crates/observe/src/panic_hook.rs
+++ b/crates/observe/src/panic_hook.rs
@@ -10,7 +10,7 @@
 /// alternatives.
 pub fn install() {
     let previous_hook = std::panic::take_hook();
-    let new_hook = move |info: &std::panic::PanicInfo| {
+    let new_hook = move |info: &std::panic::PanicHookInfo| {
         previous_hook(info);
         std::process::exit(1);
     };
@@ -21,9 +21,9 @@ pub fn install() {
 /// handler was already set up.
 /// This can be useful to make absolutely sure to clean up some resources like
 /// running processes on a panic.
-pub fn prepend_panic_handler(handler: Box<dyn Fn(&std::panic::PanicInfo) + Send + Sync>) {
+pub fn prepend_panic_handler(handler: Box<dyn Fn(&std::panic::PanicHookInfo) + Send + Sync>) {
     let previous_hook = std::panic::take_hook();
-    let new_hook = move |info: &std::panic::PanicInfo| {
+    let new_hook = move |info: &std::panic::PanicHookInfo| {
         handler(info);
         previous_hook(info);
     };

--- a/crates/observe/src/tracing.rs
+++ b/crates/observe/src/tracing.rs
@@ -1,6 +1,6 @@
 use {
     crate::tracing_reload_handler::spawn_reload_handler,
-    std::{panic::PanicInfo, sync::Once},
+    std::{panic::PanicHookInfo, sync::Once},
     time::macros::format_description,
     tracing::level_filters::LevelFilter,
     tracing_subscriber::{
@@ -110,7 +110,7 @@ fn set_tracing_subscriber(env_filter: &str, stderr_threshold: LevelFilter) {
 /// but uses tracing:error instead of stderr.
 ///
 /// Useful when we want panic messages to have the proper log format for Kibana.
-fn tracing_panic_hook(panic: &PanicInfo) {
+fn tracing_panic_hook(panic: &PanicHookInfo) {
     let thread = std::thread::current();
     let name = thread.name().unwrap_or("<unnamed>");
     let backtrace = std::backtrace::Backtrace::force_capture();


### PR DESCRIPTION
# Description
Rust 1.82 was released and caused 2 warnings:
* `PanicInfo` was deprecated in favour of `PanicHookInfo`
* code after function returning `!` is now marked as unreachable