### PR TITLE
Solution_id is integer

### DIFF
--- a/crates/autopilot/src/shadow.rs
+++ b/crates/autopilot/src/shadow.rs
@@ -260,13 +260,13 @@ impl RunLoop {
         let (score, solution_id, submission_address, orders) = proposed
             .solutions
             .into_iter()
-            .max_by_key(|solution| solution.score())
+            .max_by_key(|solution| solution.score)
             .map(|solution| {
                 (
-                    solution.score(),
-                    solution.solution_id(),
-                    solution.submission_address(),
-                    solution.orders().clone(),
+                    solution.score,
+                    solution.solution_id,
+                    solution.submission_address,
+                    solution.orders,
                 )
             })
             .ok_or(Error::NoSolutions)?;

--- a/crates/autopilot/src/shadow.rs
+++ b/crates/autopilot/src/shadow.rs
@@ -260,13 +260,13 @@ impl RunLoop {
         let (score, solution_id, submission_address, orders) = proposed
             .solutions
             .into_iter()
-            .max_by_key(|solution| solution.score)
+            .max_by_key(|solution| solution.score())
             .map(|solution| {
                 (
-                    solution.score,
-                    solution.solution_id,
-                    solution.submission_address,
-                    solution.orders,
+                    solution.score(),
+                    solution.solution_id(),
+                    solution.submission_address(),
+                    solution.orders().clone(),
                 )
             })
             .ok_or(Error::NoSolutions)?;

--- a/crates/driver/openapi.yml
+++ b/crates/driver/openapi.yml
@@ -382,8 +382,8 @@ components:
                   The unique identifier of the solution.
                   
                   This id is used to identify the solution when executing it.
-                type: string
-                example: "1"
+                type: integer
+                example: 1
               score:
                 description: |
                   The objective value of the solution.

--- a/crates/driver/src/infra/api/routes/solve/dto/solved.rs
+++ b/crates/driver/src/infra/api/routes/solve/dto/solved.rs
@@ -70,7 +70,6 @@ type OrderId = [u8; order::UID_LEN];
 pub struct Solution {
     /// Unique ID of the solution (per driver competition), used to identify it
     /// in subsequent requests (reveal, settle).
-    #[serde_as(as = "serde_with::DisplayFromStr")]
     solution_id: u64,
     #[serde_as(as = "serialize::U256")]
     score: eth::U256,

--- a/crates/driver/src/tests/setup/mod.rs
+++ b/crates/driver/src/tests/setup/mod.rs
@@ -1193,7 +1193,8 @@ impl<'a> SolveOk<'a> {
         solution
             .get("solutionId")
             .unwrap()
-            .as_str()
+            .as_u64()
+            .map(|id| id.to_string())
             .unwrap()
             .to_owned()
     }


### PR DESCRIPTION
# Description
Related to https://github.com/cowprotocol/services/issues/3064

This PR enables driver to send either string or integer for `solution_id`. 

This PR marks the start of transition period. Once the PR is merged, external solvers will be asked to:
1. Start sending `solution_id` as integer in `/solve` response.
2. Implement receiving either string or integer for `solution_id` on `/reveal` and on `/settle`.

Once done, backend will have a [follow up](https://github.com/cowprotocol/services/issues/3072) where we will definitely switch to using integers in all three endpoints and https://github.com/cowprotocol/services/issues/3064 will be fixed.

## How to test
Manually checked that both versions are properly serialized/deserialized.

<!--
## Related Issues

Fixes #
-->