### PR TITLE
Update winners picking logic

### DIFF
--- a/crates/autopilot/src/run_loop.rs
+++ b/crates/autopilot/src/run_loop.rs
@@ -588,8 +588,9 @@ impl RunLoop {
                 let is_winner = swapped_tokens.is_disjoint(&already_swapped_tokens)
                     && winners < self.config.max_winners_per_auction;
 
+                already_swapped_tokens.extend(swapped_tokens);
+
                 if is_winner {
-                    already_swapped_tokens.extend(swapped_tokens);
                     winners += 1;
                 }
 

--- a/crates/autopilot/src/run_loop.rs
+++ b/crates/autopilot/src/run_loop.rs
@@ -589,10 +589,7 @@ impl RunLoop {
                     && winners < self.config.max_winners_per_auction;
 
                 already_swapped_tokens.extend(swapped_tokens);
-
-                if is_winner {
-                    winners += 1;
-                }
+                winners += usize::from(is_winner);
 
                 participant.rank(is_winner)
             })

--- a/crates/autopilot/src/run_loop.rs
+++ b/crates/autopilot/src/run_loop.rs
@@ -571,8 +571,8 @@ impl RunLoop {
 
         // Winners are selected one by one, starting from the best solution,
         // until `max_winners_per_auction` are selected. The solution is a winner
-        // if it swaps tokens that are not yet swapped by any other already
-        // selected winner.
+        // if it swaps tokens that are not yet swapped by any previously processed
+        // solution.
         let mut already_swapped_tokens = HashSet::new();
         let mut winners = 0;
         let solutions = solutions


### PR DESCRIPTION
# Description
In a discussion with the solver team, several different algorithms were proposed to pick winners.
https://www.notion.so/cownation/Rewards-for-multiple-winners-1218da5f04ca80f2a59ed8f0174b3a69?pvs=4#1228da5f04ca8050ac31e965b120709d

> We choose winners iteratively:
> 
> 1. Choose solutions with largest score from remaining solutions as next winner.
> 2. Choose largest score of solutions with overlap to winner as reference score. The reward is winning score - reference score, the penalty is reference score.
> 3. Remove all remaining solutions which have token pairs in common with the winner. Whenever a solution is filtered in this procedure, additionally use all token pairs of that filtered solution for filtering remaining solutions. 
> 4. Repeat.

Currently, the best option is "second price with aggressive filtering". This PR implements this logic.

# Changes
<!-- List of detailed changes (how the change is accomplished) -->

- [ ] Instead of adding only winner's swapped tokens to already swapped tokens list, add every solution's swapped tokens, regardless if they are a winner or not.