### PR TITLE
Index cow amms in background task

### DIFF
--- a/crates/autopilot/src/run_loop.rs
+++ b/crates/autopilot/src/run_loop.rs
@@ -97,6 +97,10 @@ impl RunLoop {
     }
 
     pub async fn run_forever(self) -> ! {
+        Maintenance::spawn_cow_amm_indexing_task(
+            self.maintenance.clone(),
+            self.eth.current_block().clone(),
+        );
         let mut last_auction = None;
         let mut last_block = None;
         let self_arc = Arc::new(self);


### PR DESCRIPTION
# Description
Currently restarts on arbitrum are slow enough to cause emergency alerts. The reason is that we still don't persist indexed cow amms so we re-index everything from scratch. As a workaround until we store cow amms in the DB which makes syncing to the tip very fast after a restart I moved the cow amm indexing into a background task that will not block starting new auctions.

The effect is that as we continue to index cow amms after a restart more and more cow amms will show up in the auction.

## How to test
CI and test on staging to see that restarts are fast again and cow amms eventually show up