### PR TITLE
Limit number of accepted proposed solutions

### DIFF
--- a/crates/autopilot/src/arguments.rs
+++ b/crates/autopilot/src/arguments.rs
@@ -230,6 +230,11 @@ pub struct Arguments {
     /// to settle their winning orders at the same time.
     pub max_winners_per_auction: usize,
 
+    #[clap(long, env, default_value = "3")]
+    /// The maximum allowed number of solutions to be proposed from a single
+    /// solver, per auction.
+    pub max_solutions_per_solver: usize,
+
     /// Archive node URL used to index CoW AMM
     #[clap(long, env)]
     pub archive_node_url: Option<Url>,
@@ -278,6 +283,7 @@ impl std::fmt::Display for Arguments {
             run_loop_native_price_timeout,
             max_winners_per_auction,
             archive_node_url,
+            max_solutions_per_solver,
         } = self;
 
         write!(f, "{}", shared)?;
@@ -357,6 +363,11 @@ impl std::fmt::Display for Arguments {
         )?;
         writeln!(f, "max_winners_per_auction: {:?}", max_winners_per_auction)?;
         writeln!(f, "archive_node_url: {:?}", archive_node_url)?;
+        writeln!(
+            f,
+            "max_solutions_per_solver: {:?}",
+            max_solutions_per_solver
+        )?;
         Ok(())
     }
 }

--- a/crates/autopilot/src/run.rs
+++ b/crates/autopilot/src/run.rs
@@ -528,6 +528,7 @@ pub async fn run(args: Arguments) {
         solve_deadline: args.solve_deadline,
         max_run_loop_delay: args.max_run_loop_delay,
         max_winners_per_auction: args.max_winners_per_auction,
+        max_solutions_per_solver: args.max_solutions_per_solver,
     };
 
     let run = RunLoop::new(

--- a/crates/autopilot/src/run_loop.rs
+++ b/crates/autopilot/src/run_loop.rs
@@ -552,7 +552,7 @@ impl RunLoop {
         let mut counter = HashMap::new();
         solutions.retain(|participant| {
             let driver = participant.driver().name.clone();
-            let count = counter.entry(driver.clone()).or_insert(0);
+            let count = counter.entry(driver).or_insert(0);
             *count += 1;
             *count <= self.config.max_solutions_per_solver
         });


### PR DESCRIPTION
# Description
Fixes https://github.com/cowprotocol/services/issues/3063

With full colocation, we need to have a limit on the number of solutions a solver can propose per auction.

# Changes
<!-- List of detailed changes (how the change is accomplished) -->

- [ ] Added configuration parameter for limiting the number of proposed solutions per solver
- [ ] Filter out solutions that don't satisfy the new condition.

## How to test
Existing tests.