### PR TITLE
[EASY] Bump response size limit

### DIFF
--- a/crates/driver/example.toml
+++ b/crates/driver/example.toml
@@ -5,6 +5,7 @@ absolute-slippage = "40000000000000000" # Denominated in wei, optional
 relative-slippage = "0.1" # Percentage in the [0, 1] range
 account = "0x0000000000000000000000000000000000000000000000000000000000000001" # The private key of the solver
 merge-solutions = true # Multiple solutions proposed by the solver may be combined into one by the driver
+response-size-limit-max-bytes = 30000000
 
 [solver.request-headers]
 fake-header-one = "FAKE-HEADER-VALUE" # For instance an authorization token which must be provided on each request

--- a/crates/driver/src/infra/config/file/load.rs
+++ b/crates/driver/src/infra/config/file/load.rs
@@ -93,6 +93,7 @@ pub async fn load(chain: eth::ChainId, path: &Path) -> infra::Config {
                 s3: config.s3.map(Into::into),
                 solver_native_token: config.manage_native_token.to_domain(),
                 quote_tx_origin: config.quote_tx_origin.map(eth::Address),
+                response_size_limit_max_bytes: config.response_size_limit_max_bytes,
             }
         }))
         .await,

--- a/crates/driver/src/infra/config/file/mod.rs
+++ b/crates/driver/src/infra/config/file/mod.rs
@@ -256,6 +256,10 @@ struct SolverConfig {
     /// Which `tx.origin` is required to make a quote simulation pass.
     #[serde(default)]
     quote_tx_origin: Option<eth::H160>,
+
+    /// Maximum HTTP response size the driver will accept in bytes.
+    #[serde(default = "default_response_size_limit_max_bytes")]
+    response_size_limit_max_bytes: usize,
 }
 
 #[derive(Clone, Copy, Debug, Default, Deserialize, PartialEq, Serialize)]
@@ -588,6 +592,10 @@ fn default_zeroex_base_url() -> String {
 
 fn default_http_timeout() -> Duration {
     Duration::from_secs(10)
+}
+
+fn default_response_size_limit_max_bytes() -> usize {
+    30_000_000
 }
 
 #[derive(Clone, Debug, Deserialize, Default)]


### PR DESCRIPTION
# Description
Since October 6th we see alerts like `Failed to buffer the request body: length limit exceeded` indicating that the response returned by multiple solvers (`oneinch`, `zeroex`, `paraswap`, `balancer`) is too big for the driver.
It's unclear why this suddenly started happening on a Sunday where nothing gets released or why it only seems to affect dex solvers but making the max response size configurable seems like a reasonable thing to do regardless.

# Changes
* Made drivers response size limit configurable and increased the default value by 3x.
* Added trace log to print responses that exceed the limit to easily debug this the next time this happens (disabled by default but be temporarily enabled without restarting the pod)

## How to test
e2e test covers parsing of the new config parameter