### PR TITLE
Replace system allocator with mimalloc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -68,6 +68,7 @@ dependencies = [
  "chrono",
  "clap",
  "humantime",
+ "mimalloc",
  "model",
  "number",
  "observe",
@@ -293,6 +294,7 @@ dependencies = [
  "indexmap 2.2.6",
  "itertools 0.12.1",
  "maplit",
+ "mimalloc",
  "mockall 0.12.1",
  "model",
  "num",
@@ -1785,6 +1787,7 @@ dependencies = [
  "itertools 0.12.1",
  "lazy_static",
  "maplit",
+ "mimalloc",
  "mockall 0.12.1",
  "model",
  "num",
@@ -2868,6 +2871,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058"
 
 [[package]]
+name = "libmimalloc-sys"
+version = "0.1.39"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23aa6811d3bd4deb8a84dde645f943476d13b248d818edcf8ce0b2f37f036b44"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
 name = "libsqlite3-sys"
 version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2963,6 +2976,15 @@ name = "memchr"
 version = "2.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c8640c5d730cb13ebd907d8d04b52f55ac9a2eec55b440c8892f40d56c76c1d"
+
+[[package]]
+name = "mimalloc"
+version = "0.1.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68914350ae34959d83f732418d51e2427a794055d0b9529f48259ac07af65633"
+dependencies = [
+ "libmimalloc-sys",
+]
 
 [[package]]
 name = "mime"
@@ -3379,6 +3401,7 @@ dependencies = [
  "humantime",
  "hyper",
  "maplit",
+ "mimalloc",
  "mockall 0.12.1",
  "model",
  "multibase",
@@ -3864,6 +3887,7 @@ dependencies = [
  "gas-estimation",
  "humantime",
  "lazy_static",
+ "mimalloc",
  "model",
  "number",
  "observe",
@@ -4601,6 +4625,7 @@ dependencies = [
  "hex-literal",
  "hyper",
  "itertools 0.12.1",
+ "mimalloc",
  "model",
  "num",
  "observe",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ clap = { version = "4.5.6", features = ["derive", "env"] }
 derivative = "2.2.0"
 derive_more = "0.99.17"
 ethcontract = { version = "0.25.7", default-features = false, features = ["aws-kms"] }
+mimalloc = "0.1.43"
 ethcontract-generate = { version = "0.25.7", default-features = false }
 ethcontract-mock = { version = "0.25.7", default-features = false }
 ethereum-types = "0.14.1"

--- a/crates/alerter/Cargo.toml
+++ b/crates/alerter/Cargo.toml
@@ -11,6 +11,7 @@ chrono = { workspace = true }
 clap = { workspace = true }
 humantime = { workspace = true }
 observe = { path = "../observe" }
+mimalloc = { workspace = true }
 model = { path = "../model" }
 number = { path = "../number" }
 primitive-types = { workspace = true }

--- a/crates/alerter/src/main.rs
+++ b/crates/alerter/src/main.rs
@@ -1,3 +1,6 @@
+#[global_allocator]
+static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
+
 #[tokio::main]
 async fn main() {
     alerter::start(std::env::args()).await;

--- a/crates/autopilot/Cargo.toml
+++ b/crates/autopilot/Cargo.toml
@@ -38,6 +38,7 @@ humantime = { workspace = true }
 indexmap = { workspace = true }
 itertools = { workspace = true }
 maplit = { workspace = true }
+mimalloc = { workspace = true }
 model = { path = "../model" }
 num = { workspace = true }
 number = { path = "../number" }

--- a/crates/autopilot/src/main.rs
+++ b/crates/autopilot/src/main.rs
@@ -1,3 +1,6 @@
+#[global_allocator]
+static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
+
 #[tokio::main]
 async fn main() {
     autopilot::start(std::env::args()).await;

--- a/crates/driver/Cargo.toml
+++ b/crates/driver/Cargo.toml
@@ -37,6 +37,7 @@ hyper = { workspace = true }
 lazy_static = { workspace = true }
 indexmap = { workspace = true, features = ["serde"] }
 itertools = { workspace = true }
+mimalloc = { workspace = true }
 num = { workspace = true }
 number = { path = "../number" }
 prometheus = { workspace = true }

--- a/crates/driver/src/main.rs
+++ b/crates/driver/src/main.rs
@@ -1,3 +1,6 @@
+#[global_allocator]
+static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
+
 #[tokio::main]
 async fn main() {
     driver::start(std::env::args()).await;

--- a/crates/orderbook/Cargo.toml
+++ b/crates/orderbook/Cargo.toml
@@ -34,6 +34,7 @@ hex-literal = { workspace = true }
 humantime = { workspace = true }
 hyper = { workspace = true }
 maplit = { workspace = true }
+mimalloc = { workspace = true }
 model = { path = "../model" }
 multibase = "0.9"
 num = { workspace = true }

--- a/crates/orderbook/src/main.rs
+++ b/crates/orderbook/src/main.rs
@@ -1,3 +1,6 @@
+#[global_allocator]
+static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
+
 #[tokio::main]
 async fn main() {
     orderbook::start(std::env::args()).await;

--- a/crates/refunder/Cargo.toml
+++ b/crates/refunder/Cargo.toml
@@ -18,6 +18,7 @@ futures = {workspace = true}
 gas-estimation = { workspace = true }
 humantime = { workspace = true }
 lazy_static = { workspace = true }
+mimalloc = "0.1.43"
 model = { path = "../model" }
 number = { path = "../number" }
 observe = { path = "../observe" }

--- a/crates/refunder/src/main.rs
+++ b/crates/refunder/src/main.rs
@@ -1,3 +1,6 @@
+#[global_allocator]
+static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
+
 #[tokio::main]
 async fn main() {
     refunder::start(std::env::args()).await

--- a/crates/solvers/Cargo.toml
+++ b/crates/solvers/Cargo.toml
@@ -24,6 +24,7 @@ futures = { workspace = true }
 hex = { workspace = true }
 hyper = { workspace = true }
 itertools = { workspace = true }
+mimalloc = { workspace = true }
 num = { workspace = true }
 prometheus = { workspace = true }
 prometheus-metric-storage = { workspace = true }

--- a/crates/solvers/src/main.rs
+++ b/crates/solvers/src/main.rs
@@ -1,3 +1,6 @@
+#[global_allocator]
+static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
+
 #[tokio::main]
 async fn main() {
     solvers::start(std::env::args()).await;


### PR DESCRIPTION
# Description
I looked more into the supposed memory leak and noticed that the system allocator requires unreasonable amounts of memory compared to [mimalloc](https://www.google.com/search?client=firefox-b-d&q=mimalloc+github) so I replaced it for all the binaries.

Here we can see the memory footprint of the api pod with `mimalloc` (green) and the system allocator (yellow). The served traffic is the same but the system allocator continues to require more and more memory - probably because it's worse at dealing with memory fragmentation than `mimalloc`.

<img width="1184" alt="Screenshot 2024-10-26 at 17 10 42" src="https://github.com/user-attachments/assets/479a464c-a4a9-4a50-8cf8-05e09d2a45a8">
