### PR TITLE
Revert "Use quote id just for debugging (#3054)"

### DIFF
--- a/crates/autopilot/src/database/auction.rs
+++ b/crates/autopilot/src/database/auction.rs
@@ -28,6 +28,17 @@ impl QuoteStoring for Postgres {
         Ok(id)
     }
 
+    async fn get(&self, id: QuoteId) -> Result<Option<QuoteData>> {
+        let _timer = super::Metrics::get()
+            .database_queries
+            .with_label_values(&["get_quote"])
+            .start_timer();
+
+        let mut ex = self.pool.acquire().await?;
+        let quote = database::quotes::get(&mut ex, id).await?;
+        quote.map(TryFrom::try_from).transpose()
+    }
+
     async fn find(
         &self,
         params: QuoteSearchParameters,

--- a/crates/autopilot/src/database/onchain_order_events.rs
+++ b/crates/autopilot/src/database/onchain_order_events.rs
@@ -1133,7 +1133,7 @@ mod test {
         let cloned_quote = quote.clone();
         order_quoter
             .expect_find_quote()
-            .returning(move |_| Ok(cloned_quote.clone()));
+            .returning(move |_, _| Ok(cloned_quote.clone()));
         let mut custom_onchain_order_parser = MockOnchainOrderParsing::<u8, u8>::new();
         custom_onchain_order_parser
             .expect_parse_custom_event_data()

--- a/crates/autopilot/src/database/onchain_order_events.rs
+++ b/crates/autopilot/src/database/onchain_order_events.rs
@@ -555,29 +555,15 @@ async fn get_quote(
         // verified quote here on purpose.
         verification: Default::default(),
     };
-    let mut result = get_quote_and_check_fee(
+
+    get_quote_and_check_fee(
         quoter,
         &parameters.clone(),
         Some(*quote_id),
         Some(order_data.fee_amount),
     )
-    .await;
-
-    // If we didn't find the quote, recompute a fresh one
-    if matches!(
-        result,
-        Err(ValidationError::QuoteNotFound | ValidationError::InvalidQuote)
-    ) {
-        result = get_quote_and_check_fee(
-            quoter,
-            &parameters.clone(),
-            None,
-            Some(order_data.fee_amount),
-        )
-        .await;
-    }
-
-    result.map_err(|err| match err {
+    .await
+    .map_err(|err| match err {
         ValidationError::Partial(_) => OnchainOrderPlacementError::PreValidationError,
         ValidationError::NonZeroFee => OnchainOrderPlacementError::NonZeroFee,
         _ => OnchainOrderPlacementError::Other,

--- a/crates/e2e/src/setup/onchain_components.rs
+++ b/crates/e2e/src/setup/onchain_components.rs
@@ -251,26 +251,15 @@ impl OnchainComponents {
         let solvers = self.make_accounts::<N>(with_wei).await;
 
         for solver in &solvers {
-            self.allow_solving(solver, true).await;
+            self.contracts
+                .gp_authenticator
+                .add_solver(solver.address())
+                .send()
+                .await
+                .expect("failed to add solver");
         }
 
         solvers
-    }
-
-    /// Adds or removes the passed `account` from the list of allowed solver
-    /// addresses. This can be useful to temporarily disable active solvers
-    /// until all the necessary pre-conditions for a test have been set up.
-    pub async fn allow_solving(&self, account: &TestAccount, is_allowed: bool) {
-        let tx = if is_allowed {
-            self.contracts
-                .gp_authenticator
-                .add_solver(account.address())
-        } else {
-            self.contracts
-                .gp_authenticator
-                .remove_solver(account.address())
-        };
-        tx.send().await.expect("failed to update authenticator");
     }
 
     /// Generate next `N` accounts with the given initial balance and

--- a/crates/e2e/tests/e2e/solver_competition.rs
+++ b/crates/e2e/tests/e2e/solver_competition.rs
@@ -181,7 +181,7 @@ async fn fairness_check(web3: Web3) {
             .await,
             colocation::start_baseline_solver(
                 "solver2".into(),
-                solver.clone(),
+                solver,
                 onchain.contracts().weth.address(),
                 vec![base_b.address()],
                 1,
@@ -208,9 +208,6 @@ async fn fairness_check(web3: Web3) {
         ])
         .await;
 
-    // Disable solving until all orders have been placed.
-    onchain.allow_solving(&solver, false).await;
-
     // Place Orders
     let order_a = OrderCreation {
         sell_token: token_a.address(),
@@ -228,6 +225,8 @@ async fn fairness_check(web3: Web3) {
     );
     let uid_a = services.create_order(&order_a).await.unwrap();
 
+    onchain.mint_block().await;
+
     let order_b = OrderCreation {
         sell_token: token_b.address(),
         sell_amount: to_wei(10),
@@ -243,9 +242,6 @@ async fn fairness_check(web3: Web3) {
         SecretKeyRef::from(&SecretKey::from_slice(trader_b.private_key()).unwrap()),
     );
     services.create_order(&order_b).await.unwrap();
-
-    // Enable solving again
-    onchain.allow_solving(&solver, true).await;
 
     // Wait for trade
     let indexed_trades = || async {

--- a/crates/orderbook/src/api/post_order.rs
+++ b/crates/orderbook/src/api/post_order.rs
@@ -122,20 +122,6 @@ impl IntoWarpReply for ValidationErrorWrapper {
         match self.0 {
             ValidationError::Partial(pre) => PartialValidationErrorWrapper(pre).into_warp_reply(),
             ValidationError::AppData(err) => AppDataValidationErrorWrapper(err).into_warp_reply(),
-            ValidationError::QuoteNotFound => with_status(
-                error(
-                    "QuoteNotFound",
-                    "could not find quote with the specified ID",
-                ),
-                StatusCode::BAD_REQUEST,
-            ),
-            ValidationError::InvalidQuote => with_status(
-                error(
-                    "InvalidQuote",
-                    "the quote with the specified ID does not match the order",
-                ),
-                StatusCode::BAD_REQUEST,
-            ),
             ValidationError::PriceForQuote(err) => err.into_warp_reply(),
             ValidationError::MissingFrom => with_status(
                 error(

--- a/crates/orderbook/src/database/quotes.rs
+++ b/crates/orderbook/src/database/quotes.rs
@@ -23,6 +23,17 @@ impl QuoteStoring for Postgres {
         Ok(id)
     }
 
+    async fn get(&self, id: QuoteId) -> Result<Option<QuoteData>> {
+        let _timer = super::Metrics::get()
+            .database_queries
+            .with_label_values(&["get_quote"])
+            .start_timer();
+
+        let mut ex = self.pool.acquire().await?;
+        let quote = database::quotes::get(&mut ex, id).await?;
+        quote.map(TryFrom::try_from).transpose()
+    }
+
     async fn find(
         &self,
         params: QuoteSearchParameters,

--- a/crates/shared/src/order_quoting.rs
+++ b/crates/shared/src/order_quoting.rs
@@ -213,7 +213,11 @@ pub trait OrderQuoting: Send + Sync {
     async fn store_quote(&self, quote: Quote) -> Result<Quote>;
 
     /// Finds an existing quote.
-    async fn find_quote(&self, parameters: QuoteSearchParameters) -> Result<Quote, FindQuoteError>;
+    async fn find_quote(
+        &self,
+        id: Option<QuoteId>,
+        parameters: QuoteSearchParameters,
+    ) -> Result<Quote, FindQuoteError>;
 }
 
 #[derive(Error, Debug)]
@@ -234,7 +238,13 @@ pub enum CalculateQuoteError {
 #[derive(Error, Debug)]
 pub enum FindQuoteError {
     #[error("quote not found")]
-    NotFound,
+    NotFound(Option<QuoteId>),
+
+    #[error("quote does not match parameters")]
+    ParameterMismatch(QuoteData),
+
+    #[error("quote expired")]
+    Expired(DateTime<Utc>),
 
     #[error(transparent)]
     Other(#[from] anyhow::Error),
@@ -255,6 +265,22 @@ pub struct QuoteSearchParameters {
 }
 
 impl QuoteSearchParameters {
+    /// Returns true if the search parameter instance matches the specified
+    /// quote data.
+    fn matches(&self, data: &QuoteData) -> bool {
+        let amounts_match = match self.kind {
+            OrderKind::Buy => self.buy_amount == data.quoted_buy_amount,
+            OrderKind::Sell => {
+                self.sell_amount == data.quoted_sell_amount
+                    || self.sell_amount + self.fee_amount == data.quoted_sell_amount
+            }
+        };
+
+        amounts_match
+            && (self.sell_token, self.buy_token, self.kind)
+                == (data.sell_token, data.buy_token, data.kind)
+    }
+
     /// Returns additional gas costs incurred by the quote.
     pub fn additional_cost(&self) -> u64 {
         self.signing_scheme
@@ -271,6 +297,9 @@ pub trait QuoteStoring: Send + Sync {
     /// This storage implementation should return `None` to indicate that it
     /// will not store the quote.
     async fn save(&self, data: QuoteData) -> Result<QuoteId>;
+
+    /// Retrieves an existing quote by ID.
+    async fn get(&self, id: QuoteId) -> Result<Option<QuoteData>>;
 
     /// Retrieves an existing quote by ID.
     async fn find(
@@ -518,7 +547,11 @@ impl OrderQuoting for OrderQuoter {
         })
     }
 
-    async fn find_quote(&self, parameters: QuoteSearchParameters) -> Result<Quote, FindQuoteError> {
+    async fn find_quote(
+        &self,
+        id: Option<QuoteId>,
+        parameters: QuoteSearchParameters,
+    ) -> Result<Quote, FindQuoteError> {
         let scaled_sell_amount = match parameters.kind {
             OrderKind::Sell => Some(parameters.sell_amount),
             OrderKind::Buy => None,
@@ -526,14 +559,34 @@ impl OrderQuoting for OrderQuoter {
 
         let now = self.now.now();
         let additional_cost = parameters.additional_cost();
+        let quote = async {
+            let (id, data) = match id {
+                Some(id) => {
+                    let data = self
+                        .storage
+                        .get(id)
+                        .await?
+                        .ok_or(FindQuoteError::NotFound(Some(id)))?;
 
-        let (id, data) = self
-            .storage
-            .find(parameters, now)
-            .await?
-            .ok_or(FindQuoteError::NotFound)?;
+                    if !parameters.matches(&data) {
+                        return Err(FindQuoteError::ParameterMismatch(data));
+                    }
+                    if data.expiration < now {
+                        return Err(FindQuoteError::Expired(data.expiration));
+                    }
 
-        let quote = Quote::new(Some(id), data).with_additional_cost(additional_cost);
+                    (id, data)
+                }
+                None => self
+                    .storage
+                    .find(parameters, now)
+                    .await?
+                    .ok_or(FindQuoteError::NotFound(None))?,
+            };
+            Ok(Quote::new(Some(id), data))
+        }
+        .await?
+        .with_additional_cost(additional_cost);
 
         let quote = match scaled_sell_amount {
             Some(sell_amount) => quote.with_scaled_sell_amount(sell_amount),
@@ -589,7 +642,7 @@ mod tests {
         ethcontract::H160,
         futures::FutureExt,
         gas_estimation::GasPrice1559,
-        mockall::predicate::eq,
+        mockall::{predicate::eq, Sequence},
         model::time,
         number::nonzero::U256 as NonZeroU256,
         std::sync::Mutex,
@@ -1167,8 +1220,89 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn finds_quote_by_id() {
+        let now = Utc::now();
+        let quote_id = 42;
+        let parameters = QuoteSearchParameters {
+            sell_token: H160([1; 20]),
+            buy_token: H160([2; 20]),
+            sell_amount: 85.into(),
+            buy_amount: 40.into(),
+            fee_amount: 15.into(),
+            kind: OrderKind::Sell,
+            signing_scheme: QuoteSigningScheme::Eip712,
+            additional_gas: 0,
+            verification: Verification {
+                from: H160([3; 20]),
+                ..Default::default()
+            },
+        };
+
+        let mut storage = MockQuoteStoring::new();
+        storage.expect_get().with(eq(42)).returning(move |_| {
+            Ok(Some(QuoteData {
+                sell_token: H160([1; 20]),
+                buy_token: H160([2; 20]),
+                quoted_sell_amount: 100.into(),
+                quoted_buy_amount: 42.into(),
+                fee_parameters: FeeParameters {
+                    gas_amount: 3.,
+                    gas_price: 2.,
+                    sell_token_price: 0.2,
+                },
+                kind: OrderKind::Sell,
+                expiration: now + chrono::Duration::seconds(10),
+                quote_kind: QuoteKind::Standard,
+                solver: H160([1; 20]),
+                verified: false,
+            }))
+        });
+
+        let quoter = OrderQuoter {
+            price_estimator: Arc::new(MockPriceEstimating::new()),
+            native_price_estimator: Arc::new(MockNativePriceEstimating::new()),
+            gas_estimator: Arc::new(FakeGasPriceEstimator::default()),
+            storage: Arc::new(storage),
+            now: Arc::new(now),
+            validity: Validity::default(),
+            quote_verification: QuoteVerificationMode::Unverified,
+            balance_fetcher: mock_balance_fetcher(),
+        };
+
+        assert_eq!(
+            quoter.find_quote(Some(quote_id), parameters).await.unwrap(),
+            Quote {
+                id: Some(42),
+                data: QuoteData {
+                    sell_token: H160([1; 20]),
+                    buy_token: H160([2; 20]),
+                    quoted_sell_amount: 100.into(),
+                    quoted_buy_amount: 42.into(),
+                    fee_parameters: FeeParameters {
+                        gas_amount: 3.,
+                        gas_price: 2.,
+                        sell_token_price: 0.2,
+                    },
+                    kind: OrderKind::Sell,
+                    expiration: now + chrono::Duration::seconds(10),
+                    quote_kind: QuoteKind::Standard,
+                    solver: H160([1; 20]),
+                    verified: false,
+                },
+                sell_amount: 85.into(),
+                // Allows for "out-of-price" buy amounts. This means that order
+                // be used for providing liquidity at a premium over current
+                // market price.
+                buy_amount: 35.into(),
+                fee_amount: 30.into(),
+            }
+        );
+    }
+
+    #[tokio::test]
     async fn finds_quote_with_sell_amount_after_fee() {
         let now = Utc::now();
+        let quote_id = 42;
         let parameters = QuoteSearchParameters {
             sell_token: H160([1; 20]),
             buy_token: H160([2; 20]),
@@ -1185,30 +1319,24 @@ mod tests {
         };
 
         let mut storage = MockQuoteStoring::new();
-        storage
-            .expect_find()
-            .with(eq(parameters.clone()), eq(now))
-            .returning(move |_, _| {
-                Ok(Some((
-                    42,
-                    QuoteData {
-                        sell_token: H160([1; 20]),
-                        buy_token: H160([2; 20]),
-                        quoted_sell_amount: 100.into(),
-                        quoted_buy_amount: 42.into(),
-                        fee_parameters: FeeParameters {
-                            gas_amount: 3.,
-                            gas_price: 2.,
-                            sell_token_price: 0.2,
-                        },
-                        kind: OrderKind::Sell,
-                        expiration: now + chrono::Duration::seconds(10),
-                        quote_kind: QuoteKind::Standard,
-                        solver: H160([1; 20]),
-                        verified: false,
-                    },
-                )))
-            });
+        storage.expect_get().with(eq(42)).returning(move |_| {
+            Ok(Some(QuoteData {
+                sell_token: H160([1; 20]),
+                buy_token: H160([2; 20]),
+                quoted_sell_amount: 100.into(),
+                quoted_buy_amount: 42.into(),
+                fee_parameters: FeeParameters {
+                    gas_amount: 3.,
+                    gas_price: 2.,
+                    sell_token_price: 0.2,
+                },
+                kind: OrderKind::Sell,
+                expiration: now + chrono::Duration::seconds(10),
+                quote_kind: QuoteKind::Standard,
+                solver: H160([1; 20]),
+                verified: false,
+            }))
+        });
 
         let quoter = OrderQuoter {
             price_estimator: Arc::new(MockPriceEstimating::new()),
@@ -1222,7 +1350,7 @@ mod tests {
         };
 
         assert_eq!(
-            quoter.find_quote(parameters).await.unwrap(),
+            quoter.find_quote(Some(quote_id), parameters).await.unwrap(),
             Quote {
                 id: Some(42),
                 data: QuoteData {
@@ -1304,7 +1432,7 @@ mod tests {
         };
 
         assert_eq!(
-            quoter.find_quote(parameters).await.unwrap(),
+            quoter.find_quote(None, parameters).await.unwrap(),
             Quote {
                 id: Some(42),
                 data: QuoteData {
@@ -1331,8 +1459,66 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn find_invalid_quote_error() {
+        let now = Utc::now();
+        let parameters = QuoteSearchParameters {
+            sell_token: H160([1; 20]),
+            ..Default::default()
+        };
+
+        let mut storage = MockQuoteStoring::new();
+        let mut sequence = Sequence::new();
+        storage
+            .expect_get()
+            .times(1)
+            .in_sequence(&mut sequence)
+            .returning(move |_| {
+                Ok(Some(QuoteData {
+                    sell_token: H160([2; 20]),
+                    expiration: now,
+                    ..Default::default()
+                }))
+            });
+        storage
+            .expect_get()
+            .times(1)
+            .in_sequence(&mut sequence)
+            .returning(move |_| {
+                Ok(Some(QuoteData {
+                    sell_token: H160([1; 20]),
+                    expiration: now - chrono::Duration::seconds(1),
+                    ..Default::default()
+                }))
+            });
+
+        let quoter = OrderQuoter {
+            price_estimator: Arc::new(MockPriceEstimating::new()),
+            native_price_estimator: Arc::new(MockNativePriceEstimating::new()),
+            gas_estimator: Arc::new(FakeGasPriceEstimator::default()),
+            storage: Arc::new(storage),
+            now: Arc::new(now),
+            validity: Validity::default(),
+            quote_verification: QuoteVerificationMode::Unverified,
+            balance_fetcher: mock_balance_fetcher(),
+        };
+
+        assert!(matches!(
+            quoter
+                .find_quote(Some(0), parameters.clone())
+                .await
+                .unwrap_err(),
+            FindQuoteError::ParameterMismatch(_),
+        ));
+        assert!(matches!(
+            quoter.find_quote(Some(0), parameters).await.unwrap_err(),
+            FindQuoteError::Expired(_),
+        ));
+    }
+
+    #[tokio::test]
     async fn find_quote_error_when_not_found() {
         let mut storage = MockQuoteStoring::new();
+        storage.expect_get().returning(move |_| Ok(None));
         storage.expect_find().returning(move |_, _| Ok(None));
 
         let quoter = OrderQuoter {
@@ -1347,8 +1533,18 @@ mod tests {
         };
 
         assert!(matches!(
-            quoter.find_quote(Default::default()).await.unwrap_err(),
-            FindQuoteError::NotFound,
+            quoter
+                .find_quote(Some(0), Default::default())
+                .await
+                .unwrap_err(),
+            FindQuoteError::NotFound(Some(0)),
+        ));
+        assert!(matches!(
+            quoter
+                .find_quote(None, Default::default())
+                .await
+                .unwrap_err(),
+            FindQuoteError::NotFound(None),
         ));
     }
 }

--- a/crates/shared/src/order_validation.rs
+++ b/crates/shared/src/order_validation.rs
@@ -183,7 +183,8 @@ impl From<VerificationError> for ValidationError {
 impl From<FindQuoteError> for ValidationError {
     fn from(err: FindQuoteError) -> Self {
         match err {
-            FindQuoteError::NotFound => Self::QuoteNotFound,
+            FindQuoteError::NotFound(_) => Self::QuoteNotFound,
+            FindQuoteError::ParameterMismatch(_) | FindQuoteError::Expired(_) => Self::InvalidQuote,
             FindQuoteError::Other(err) => Self::Other(err),
         }
     }
@@ -844,51 +845,53 @@ async fn get_or_create_quote(
     quote_search_parameters: &QuoteSearchParameters,
     quote_id: Option<i64>,
 ) -> Result<Quote, ValidationError> {
-    if let Ok(quote) = quoter.find_quote(quote_search_parameters.clone()).await {
-        tracing::debug!(
-            found_quote = ?quote.id,
-            user_provided_quote = ?quote_id,
-            "found quote for order creation"
-        );
-        return Ok(quote);
-    }
-
-    // Quote could not be found so let's compute a fresh one.
-    let parameters = QuoteParameters {
-        sell_token: quote_search_parameters.sell_token,
-        buy_token: quote_search_parameters.buy_token,
-        side: match quote_search_parameters.kind {
-            OrderKind::Buy => OrderQuoteSide::Buy {
-                buy_amount_after_fee: quote_search_parameters
-                    .buy_amount
-                    .try_into()
-                    .map_err(|_| ValidationError::ZeroAmount)?,
-            },
-            OrderKind::Sell => OrderQuoteSide::Sell {
-                sell_amount: SellAmount::AfterFee {
-                    value: quote_search_parameters
-                        .sell_amount
-                        .try_into()
-                        .map_err(|_| ValidationError::ZeroAmount)?,
+    let quote = match quoter
+        .find_quote(quote_id, quote_search_parameters.clone())
+        .await
+    {
+        Ok(quote) => {
+            tracing::debug!(quote_id =? quote.id, "found quote for order creation");
+            quote
+        }
+        // We couldn't find a quote, and no ID was specified. Try computing a
+        // fresh quote to use instead.
+        Err(FindQuoteError::NotFound(_)) if quote_id.is_none() => {
+            let parameters = QuoteParameters {
+                sell_token: quote_search_parameters.sell_token,
+                buy_token: quote_search_parameters.buy_token,
+                side: match quote_search_parameters.kind {
+                    OrderKind::Buy => OrderQuoteSide::Buy {
+                        buy_amount_after_fee: quote_search_parameters
+                            .buy_amount
+                            .try_into()
+                            .map_err(|_| ValidationError::ZeroAmount)?,
+                    },
+                    OrderKind::Sell => OrderQuoteSide::Sell {
+                        sell_amount: SellAmount::AfterFee {
+                            value: quote_search_parameters
+                                .sell_amount
+                                .try_into()
+                                .map_err(|_| ValidationError::ZeroAmount)?,
+                        },
+                    },
                 },
-            },
-        },
-        verification: quote_search_parameters.verification.clone(),
-        signing_scheme: quote_search_parameters.signing_scheme,
-        additional_gas: quote_search_parameters.additional_gas,
+                verification: quote_search_parameters.verification.clone(),
+                signing_scheme: quote_search_parameters.signing_scheme,
+                additional_gas: quote_search_parameters.additional_gas,
+            };
+
+            let quote = quoter.calculate_quote(parameters).await?;
+            let quote = quoter
+                .store_quote(quote)
+                .await
+                .map_err(ValidationError::Other)?;
+
+            tracing::debug!(quote_id =? quote.id, "computed fresh quote for order creation");
+            quote
+        }
+        Err(err) => return Err(err.into()),
     };
 
-    let quote = quoter.calculate_quote(parameters).await?;
-    let quote = quoter
-        .store_quote(quote)
-        .await
-        .map_err(ValidationError::Other)?;
-
-    tracing::debug!(
-        computed_quote = ?quote.id,
-        user_provided_quote = ?quote_id,
-        "computed fresh quote for order creation"
-    );
     Ok(quote)
 }
 
@@ -963,6 +966,7 @@ mod tests {
             signature_validator::MockSignatureValidating,
         },
         anyhow::anyhow,
+        chrono::Utc,
         contracts::dummy_contract,
         ethcontract::web3::signing::SecretKeyRef,
         futures::FutureExt,
@@ -1241,7 +1245,7 @@ mod tests {
         let mut balance_fetcher = MockBalanceFetching::new();
         order_quoter
             .expect_find_quote()
-            .returning(|_| Ok(Default::default()));
+            .returning(|_, _| Ok(Default::default()));
         bad_token_detector
             .expect_detect()
             .returning(|_| Ok(TokenQuality::Good));
@@ -1436,7 +1440,7 @@ mod tests {
         let mut order_quoter = MockOrderQuoting::new();
         let mut bad_token_detector = MockBadTokenDetecting::new();
         let mut balance_fetcher = MockBalanceFetching::new();
-        order_quoter.expect_find_quote().returning(|_| {
+        order_quoter.expect_find_quote().returning(|_, _| {
             Ok(Quote {
                 id: None,
                 data: Default::default(),
@@ -1519,7 +1523,7 @@ mod tests {
         let mut balance_fetcher = MockBalanceFetching::new();
         order_quoter
             .expect_find_quote()
-            .returning(|_| Ok(Default::default()));
+            .returning(|_, _| Ok(Default::default()));
         bad_token_detector
             .expect_detect()
             .returning(|_| Ok(TokenQuality::Good));
@@ -1587,7 +1591,7 @@ mod tests {
         let mut balance_fetcher = MockBalanceFetching::new();
         order_quoter
             .expect_find_quote()
-            .returning(|_| Ok(Default::default()));
+            .returning(|_, _| Ok(Default::default()));
         bad_token_detector
             .expect_detect()
             .returning(|_| Ok(TokenQuality::Good));
@@ -1638,7 +1642,7 @@ mod tests {
         let mut balance_fetcher = MockBalanceFetching::new();
         order_quoter
             .expect_find_quote()
-            .returning(|_| Ok(Default::default()));
+            .returning(|_, _| Ok(Default::default()));
         bad_token_detector
             .expect_detect()
             .returning(|_| Ok(TokenQuality::Good));
@@ -1690,10 +1694,7 @@ mod tests {
         let mut balance_fetcher = MockBalanceFetching::new();
         order_quoter
             .expect_find_quote()
-            .returning(|_| Err(FindQuoteError::Other(anyhow!("err"))));
-        order_quoter
-            .expect_calculate_quote()
-            .returning(|_| Err(CalculateQuoteError::Other(anyhow!("err"))));
+            .returning(|_, _| Err(FindQuoteError::Other(anyhow!("err"))));
         bad_token_detector
             .expect_detect()
             .returning(|_| Ok(TokenQuality::Good));
@@ -1745,7 +1746,7 @@ mod tests {
         let mut balance_fetcher = MockBalanceFetching::new();
         order_quoter
             .expect_find_quote()
-            .returning(|_| Ok(Default::default()));
+            .returning(|_, _| Ok(Default::default()));
         bad_token_detector.expect_detect().returning(|_| {
             Ok(TokenQuality::Bad {
                 reason: Default::default(),
@@ -1804,7 +1805,7 @@ mod tests {
         let mut balance_fetcher = MockBalanceFetching::new();
         order_quoter
             .expect_find_quote()
-            .returning(|_| Ok(Default::default()));
+            .returning(|_, _| Ok(Default::default()));
         bad_token_detector
             .expect_detect()
             .returning(|_| Ok(TokenQuality::Good));
@@ -1857,7 +1858,7 @@ mod tests {
         let mut signature_validator = MockSignatureValidating::new();
         order_quoter
             .expect_find_quote()
-            .returning(|_| Ok(Default::default()));
+            .returning(|_, _| Ok(Default::default()));
         bad_token_detector
             .expect_detect()
             .returning(|_| Ok(TokenQuality::Good));
@@ -1923,7 +1924,7 @@ mod tests {
             let mut balance_fetcher = MockBalanceFetching::new();
             order_quoter
                 .expect_find_quote()
-                .returning(|_| Ok(Default::default()));
+                .returning(|_, _| Ok(Default::default()));
             bad_token_detector
                 .expect_detect()
                 .returning(|_| Ok(TokenQuality::Good));
@@ -2002,7 +2003,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn get_quote_find_by_parameters() {
+    async fn get_quote_find_by_id() {
         let mut order_quoter = MockOrderQuoting::new();
         let quote_search_parameters = QuoteSearchParameters {
             sell_token: H160([1; 20]),
@@ -2029,8 +2030,8 @@ mod tests {
         let quote_id = Some(42);
         order_quoter
             .expect_find_quote()
-            .with(eq(quote_search_parameters.clone()))
-            .returning(move |_| Ok(quote_data.clone()));
+            .with(eq(quote_id), eq(quote_search_parameters.clone()))
+            .returning(move |_, _| Ok(quote_data.clone()));
 
         let quote = get_quote_and_check_fee(
             &order_quoter,
@@ -2060,8 +2061,8 @@ mod tests {
         let mut order_quoter = MockOrderQuoting::new();
         order_quoter
             .expect_find_quote()
-            .with(always())
-            .returning(|_| Err(FindQuoteError::NotFound));
+            .with(eq(None), always())
+            .returning(|_, _| Err(FindQuoteError::NotFound(None)));
         let quote_search_parameters = QuoteSearchParameters {
             sell_token: H160([1; 20]),
             buy_token: H160([2; 20]),
@@ -2123,13 +2124,68 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn get_quote_errors_when_not_found_by_id() {
+        let quote_search_parameters = QuoteSearchParameters {
+            ..Default::default()
+        };
+
+        let mut order_quoter = MockOrderQuoting::new();
+        order_quoter
+            .expect_find_quote()
+            .returning(|_, _| Err(FindQuoteError::NotFound(Some(0))));
+
+        let err = get_quote_and_check_fee(
+            &order_quoter,
+            &quote_search_parameters,
+            Some(0),
+            Some(U256::zero()),
+        )
+        .await
+        .unwrap_err();
+
+        assert!(matches!(err, ValidationError::QuoteNotFound));
+    }
+
+    #[tokio::test]
     async fn get_quote_bubbles_errors() {
+        macro_rules! assert_find_error_matches {
+            ($find_err:expr, $validation_err:pat) => {{
+                let mut order_quoter = MockOrderQuoting::new();
+                order_quoter
+                    .expect_find_quote()
+                    .returning(|_, _| Err($find_err));
+                let err = get_quote_and_check_fee(
+                    &order_quoter,
+                    &QuoteSearchParameters {
+                        sell_amount: 1.into(),
+                        kind: OrderKind::Sell,
+                        ..Default::default()
+                    },
+                    Default::default(),
+                    Default::default(),
+                )
+                .await
+                .unwrap_err();
+
+                assert!(matches!(err, $validation_err));
+            }};
+        }
+
+        assert_find_error_matches!(
+            FindQuoteError::Expired(Utc::now()),
+            ValidationError::InvalidQuote
+        );
+        assert_find_error_matches!(
+            FindQuoteError::ParameterMismatch(Default::default()),
+            ValidationError::InvalidQuote
+        );
+
         macro_rules! assert_calc_error_matches {
             ($calc_err:expr, $validation_err:pat) => {{
                 let mut order_quoter = MockOrderQuoting::new();
                 order_quoter
                     .expect_find_quote()
-                    .returning(|_| Err(FindQuoteError::NotFound));
+                    .returning(|_, _| Err(FindQuoteError::NotFound(None)));
                 order_quoter
                     .expect_calculate_quote()
                     .returning(|_| Err($calc_err));

--- a/crates/shared/src/order_validation.rs
+++ b/crates/shared/src/order_validation.rs
@@ -5,7 +5,6 @@ use {
         code_fetching::CodeFetching,
         order_quoting::{
             CalculateQuoteError,
-            FindQuoteError,
             OrderQuoting,
             Quote,
             QuoteParameters,
@@ -130,11 +129,6 @@ pub enum AppDataValidationError {
 pub enum ValidationError {
     Partial(PartialValidationError),
     AppData(AppDataValidationError),
-    /// The quote ID specified with the order could not be found.
-    QuoteNotFound,
-    /// The quote specified by ID is invalid. Either it doesn't match the order
-    /// or it has already expired.
-    InvalidQuote,
     /// Unable to compute quote because of a price estimation error.
     PriceForQuote(PriceEstimationError),
     /// Orders with positive signed fee amount are deprecated
@@ -176,16 +170,6 @@ impl From<VerificationError> for ValidationError {
             VerificationError::UnexpectedSigner(recovered) => Self::WrongOwner(recovered),
             VerificationError::MissingFrom => Self::MissingFrom,
             VerificationError::AppdataFromMismatch(mismatch) => Self::AppdataFromMismatch(mismatch),
-        }
-    }
-}
-
-impl From<FindQuoteError> for ValidationError {
-    fn from(err: FindQuoteError) -> Self {
-        match err {
-            FindQuoteError::NotFound(_) => Self::QuoteNotFound,
-            FindQuoteError::ParameterMismatch(_) | FindQuoteError::Expired(_) => Self::InvalidQuote,
-            FindQuoteError::Other(err) => Self::Other(err),
         }
     }
 }
@@ -838,8 +822,7 @@ pub async fn get_quote_and_check_fee(
 /// Retrieves the quote for an order that is being created
 ///
 /// This works by first trying to find an existing quote, and then falling back
-/// to calculating a brand new one if none can be found and a quote ID was not
-/// specified.
+/// to calculating a brand new one if none can be found.
 async fn get_or_create_quote(
     quoter: &dyn OrderQuoting,
     quote_search_parameters: &QuoteSearchParameters,
@@ -853,9 +836,9 @@ async fn get_or_create_quote(
             tracing::debug!(quote_id =? quote.id, "found quote for order creation");
             quote
         }
-        // We couldn't find a quote, and no ID was specified. Try computing a
-        // fresh quote to use instead.
-        Err(FindQuoteError::NotFound(_)) if quote_id.is_none() => {
+        // We couldn't find a quote, so try computing a fresh quote to use instead.
+        Err(err) => {
+            tracing::debug!(?err, "failed to find quote for order creation");
             let parameters = QuoteParameters {
                 sell_token: quote_search_parameters.sell_token,
                 buy_token: quote_search_parameters.buy_token,
@@ -889,7 +872,6 @@ async fn get_or_create_quote(
             tracing::debug!(quote_id =? quote.id, "computed fresh quote for order creation");
             quote
         }
-        Err(err) => return Err(err.into()),
     };
 
     Ok(quote)
@@ -962,11 +944,9 @@ mod tests {
             account_balances::MockBalanceFetching,
             bad_token::{MockBadTokenDetecting, TokenQuality},
             code_fetching::MockCodeFetching,
-            order_quoting::MockOrderQuoting,
+            order_quoting::{FindQuoteError, MockOrderQuoting},
             signature_validator::MockSignatureValidating,
         },
-        anyhow::anyhow,
-        chrono::Utc,
         contracts::dummy_contract,
         ethcontract::web3::signing::SecretKeyRef,
         futures::FutureExt,
@@ -1688,58 +1668,6 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn post_validate_err_getting_quote() {
-        let mut order_quoter = MockOrderQuoting::new();
-        let mut bad_token_detector = MockBadTokenDetecting::new();
-        let mut balance_fetcher = MockBalanceFetching::new();
-        order_quoter
-            .expect_find_quote()
-            .returning(|_, _| Err(FindQuoteError::Other(anyhow!("err"))));
-        bad_token_detector
-            .expect_detect()
-            .returning(|_| Ok(TokenQuality::Good));
-        balance_fetcher
-            .expect_can_transfer()
-            .returning(|_, _| Ok(()));
-        let mut limit_order_counter = MockLimitOrderCounting::new();
-        limit_order_counter.expect_count().returning(|_| Ok(0u64));
-        let validator = OrderValidator::new(
-            dummy_contract!(WETH9, [0xef; 20]),
-            Arc::new(order_validation::banned::Users::none()),
-            OrderValidPeriodConfiguration::any(),
-            false,
-            Arc::new(bad_token_detector),
-            dummy_contract!(HooksTrampoline, [0xcf; 20]),
-            Arc::new(order_quoter),
-            Arc::new(balance_fetcher),
-            Arc::new(MockSignatureValidating::new()),
-            Arc::new(limit_order_counter),
-            0,
-            Arc::new(MockCodeFetching::new()),
-            Default::default(),
-            u64::MAX,
-        );
-        let order = OrderCreation {
-            valid_to: time::now_in_epoch_seconds() + 2,
-            sell_token: H160::from_low_u64_be(1),
-            buy_token: H160::from_low_u64_be(2),
-            buy_amount: U256::from(1),
-            sell_amount: U256::from(1),
-            fee_amount: U256::from(1),
-            signature: Signature::Eip712(EcdsaSignature::non_zero()),
-            app_data: OrderCreationAppData::Full {
-                full: "{}".to_string(),
-            },
-            ..Default::default()
-        };
-        let result = validator
-            .validate_and_construct_order(order, &Default::default(), Default::default(), None)
-            .await;
-        dbg!(&result);
-        assert!(matches!(result, Err(ValidationError::Other(_))));
-    }
-
-    #[tokio::test]
     async fn post_validate_err_unsupported_token() {
         let mut order_quoter = MockOrderQuoting::new();
         let mut bad_token_detector = MockBadTokenDetecting::new();
@@ -2120,117 +2048,6 @@ mod tests {
                 fee_amount: 6.into(),
                 ..Default::default()
             }
-        );
-    }
-
-    #[tokio::test]
-    async fn get_quote_errors_when_not_found_by_id() {
-        let quote_search_parameters = QuoteSearchParameters {
-            ..Default::default()
-        };
-
-        let mut order_quoter = MockOrderQuoting::new();
-        order_quoter
-            .expect_find_quote()
-            .returning(|_, _| Err(FindQuoteError::NotFound(Some(0))));
-
-        let err = get_quote_and_check_fee(
-            &order_quoter,
-            &quote_search_parameters,
-            Some(0),
-            Some(U256::zero()),
-        )
-        .await
-        .unwrap_err();
-
-        assert!(matches!(err, ValidationError::QuoteNotFound));
-    }
-
-    #[tokio::test]
-    async fn get_quote_bubbles_errors() {
-        macro_rules! assert_find_error_matches {
-            ($find_err:expr, $validation_err:pat) => {{
-                let mut order_quoter = MockOrderQuoting::new();
-                order_quoter
-                    .expect_find_quote()
-                    .returning(|_, _| Err($find_err));
-                let err = get_quote_and_check_fee(
-                    &order_quoter,
-                    &QuoteSearchParameters {
-                        sell_amount: 1.into(),
-                        kind: OrderKind::Sell,
-                        ..Default::default()
-                    },
-                    Default::default(),
-                    Default::default(),
-                )
-                .await
-                .unwrap_err();
-
-                assert!(matches!(err, $validation_err));
-            }};
-        }
-
-        assert_find_error_matches!(
-            FindQuoteError::Expired(Utc::now()),
-            ValidationError::InvalidQuote
-        );
-        assert_find_error_matches!(
-            FindQuoteError::ParameterMismatch(Default::default()),
-            ValidationError::InvalidQuote
-        );
-
-        macro_rules! assert_calc_error_matches {
-            ($calc_err:expr, $validation_err:pat) => {{
-                let mut order_quoter = MockOrderQuoting::new();
-                order_quoter
-                    .expect_find_quote()
-                    .returning(|_, _| Err(FindQuoteError::NotFound(None)));
-                order_quoter
-                    .expect_calculate_quote()
-                    .returning(|_| Err($calc_err));
-
-                let err = get_quote_and_check_fee(
-                    &order_quoter,
-                    &QuoteSearchParameters {
-                        sell_amount: 1.into(),
-                        kind: OrderKind::Sell,
-                        ..Default::default()
-                    },
-                    Default::default(),
-                    Some(U256::zero()),
-                )
-                .await
-                .unwrap_err();
-
-                assert!(matches!(err, $validation_err));
-            }};
-        }
-
-        assert_calc_error_matches!(
-            CalculateQuoteError::SellAmountDoesNotCoverFee {
-                fee_amount: Default::default()
-            },
-            ValidationError::Other(_)
-        );
-        assert_calc_error_matches!(
-            CalculateQuoteError::Price(PriceEstimationError::UnsupportedToken {
-                token: Default::default(),
-                reason: Default::default()
-            }),
-            ValidationError::Partial(PartialValidationError::UnsupportedToken { .. })
-        );
-        assert_calc_error_matches!(
-            CalculateQuoteError::Price(PriceEstimationError::NoLiquidity),
-            ValidationError::PriceForQuote(_)
-        );
-        assert_calc_error_matches!(
-            CalculateQuoteError::Price(PriceEstimationError::UnsupportedOrderType("test".into())),
-            ValidationError::PriceForQuote(_)
-        );
-        assert_calc_error_matches!(
-            CalculateQuoteError::Price(PriceEstimationError::RateLimited),
-            ValidationError::PriceForQuote(_)
         );
     }
 


### PR DESCRIPTION
This reverts commit cea22f679c68eac1cfe8649bc3c8f2ea7c9aed98.
Then implements https://github.com/cowprotocol/services/pull/3100

# Description
Reverts the change introduced by the PR https://github.com/cowprotocol/services/pull/3054

Apparently the current implementation is not good at recovering the right quote as it sometimes finds the quote that is too old, while the order was intended to be created with the most recent quote.

A different fix is implemented to actually continue using quote_id, but compute the fresh quote if quote_id cant be found.