### PR TITLE
Always compute fresh quote when not found

### DIFF
--- a/crates/autopilot/src/database/onchain_order_events.rs
+++ b/crates/autopilot/src/database/onchain_order_events.rs
@@ -555,27 +555,13 @@ async fn get_quote(
         // verified quote here on purpose.
         verification: Default::default(),
     };
-    let mut result = get_quote_and_check_fee(
+    let result = get_quote_and_check_fee(
         quoter,
         &parameters.clone(),
         Some(*quote_id),
         Some(order_data.fee_amount),
     )
     .await;
-
-    // If we didn't find the quote, recompute a fresh one
-    if matches!(
-        result,
-        Err(ValidationError::QuoteNotFound | ValidationError::InvalidQuote)
-    ) {
-        result = get_quote_and_check_fee(
-            quoter,
-            &parameters.clone(),
-            None,
-            Some(order_data.fee_amount),
-        )
-        .await;
-    }
 
     result.map_err(|err| match err {
         ValidationError::Partial(_) => OnchainOrderPlacementError::PreValidationError,

--- a/crates/autopilot/src/database/onchain_order_events.rs
+++ b/crates/autopilot/src/database/onchain_order_events.rs
@@ -555,15 +555,15 @@ async fn get_quote(
         // verified quote here on purpose.
         verification: Default::default(),
     };
-    let result = get_quote_and_check_fee(
+
+    get_quote_and_check_fee(
         quoter,
         &parameters.clone(),
         Some(*quote_id),
         Some(order_data.fee_amount),
     )
-    .await;
-
-    result.map_err(|err| match err {
+    .await
+    .map_err(|err| match err {
         ValidationError::Partial(_) => OnchainOrderPlacementError::PreValidationError,
         ValidationError::NonZeroFee => OnchainOrderPlacementError::NonZeroFee,
         _ => OnchainOrderPlacementError::Other,

--- a/crates/orderbook/src/api/post_order.rs
+++ b/crates/orderbook/src/api/post_order.rs
@@ -122,20 +122,6 @@ impl IntoWarpReply for ValidationErrorWrapper {
         match self.0 {
             ValidationError::Partial(pre) => PartialValidationErrorWrapper(pre).into_warp_reply(),
             ValidationError::AppData(err) => AppDataValidationErrorWrapper(err).into_warp_reply(),
-            ValidationError::QuoteNotFound => with_status(
-                error(
-                    "QuoteNotFound",
-                    "could not find quote with the specified ID",
-                ),
-                StatusCode::BAD_REQUEST,
-            ),
-            ValidationError::InvalidQuote => with_status(
-                error(
-                    "InvalidQuote",
-                    "the quote with the specified ID does not match the order",
-                ),
-                StatusCode::BAD_REQUEST,
-            ),
             ValidationError::PriceForQuote(err) => err.into_warp_reply(),
             ValidationError::MissingFrom => with_status(
                 error(

--- a/crates/shared/src/order_validation.rs
+++ b/crates/shared/src/order_validation.rs
@@ -838,8 +838,7 @@ pub async fn get_quote_and_check_fee(
 /// Retrieves the quote for an order that is being created
 ///
 /// This works by first trying to find an existing quote, and then falling back
-/// to calculating a brand new one if none can be found and a quote ID was not
-/// specified.
+/// to calculating a brand new one if none can be found.
 async fn get_or_create_quote(
     quoter: &dyn OrderQuoting,
     quote_search_parameters: &QuoteSearchParameters,
@@ -853,9 +852,8 @@ async fn get_or_create_quote(
             tracing::debug!(quote_id =? quote.id, "found quote for order creation");
             quote
         }
-        // We couldn't find a quote, and no ID was specified. Try computing a
-        // fresh quote to use instead.
-        Err(FindQuoteError::NotFound(_)) if quote_id.is_none() => {
+        // We couldn't find a quote, so try computing a fresh quote to use instead.
+        Err(FindQuoteError::NotFound(_)) => {
             let parameters = QuoteParameters {
                 sell_token: quote_search_parameters.sell_token,
                 buy_token: quote_search_parameters.buy_token,

--- a/crates/shared/src/order_validation.rs
+++ b/crates/shared/src/order_validation.rs
@@ -874,17 +874,6 @@ async fn get_or_create_quote(
         }
     };
 
-    let quote = quoter.calculate_quote(parameters).await?;
-    let quote = quoter
-        .store_quote(quote)
-        .await
-        .map_err(ValidationError::Other)?;
-
-    tracing::debug!(
-        computed_quote = ?quote.id,
-        user_provided_quote = ?quote_id,
-        "computed fresh quote for order creation"
-    );
     Ok(quote)
 }
 


### PR DESCRIPTION
# Description
A fix on top of the https://github.com/cowprotocol/services/pull/3096 for easier reviewing.

We want to always compute the fresh quote when provided quote_id is not found in database. This is now enabled for all orders, not just for ETHFlow orders.

A bit more context can be found https://github.com/cowprotocol/services/pull/3096#issuecomment-2446885623

# Changes
<!-- List of detailed changes (how the change is accomplished) -->

- [ ] Changed behavior of the function `get_or_create_quote`

## How to test
Existing tests updated.