### PR TITLE
Ignore nonsensical native prices

### DIFF
--- a/crates/shared/src/price_estimation/native.rs
+++ b/crates/shared/src/price_estimation/native.rs
@@ -94,7 +94,7 @@ impl NativePriceEstimating for NativePriceEstimator {
             let query = Arc::new(self.query(&token));
             let estimate = self.inner.estimate(query.clone()).await?;
             let price = estimate.price_in_buy_token_f64(&query);
-            if !is_price_malformed(price) {
+            if is_price_malformed(price) {
                 let err = anyhow::anyhow!("estimator returned malformed price: {price}");
                 Err(PriceEstimationError::EstimatorInternal(err))
             } else {


### PR DESCRIPTION
# Description
Currently some solvers are reporting nonsensical results for native prices.

# Changes
Changes the native price competition to ignore subnormal values (e.g. infinities, and undefined byte patterns) and non-positive values. This still leaves plenty of room for incorrect values but at least the obviously wrong values get eliminated by that.

## How to test
added a unit test