### PR TITLE
Move JSON asserts into `testlib`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3110,6 +3110,7 @@ dependencies = [
  "serde_with",
  "shared",
  "strum",
+ "testlib",
  "web3",
 ]
 
@@ -5049,9 +5050,12 @@ checksum = "3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76"
 name = "testlib"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "ethcontract",
  "ethcontract-mock",
  "hex-literal",
+ "maplit",
+ "serde_json",
 ]
 
 [[package]]

--- a/crates/model/Cargo.toml
+++ b/crates/model/Cargo.toml
@@ -31,6 +31,7 @@ web3 = { workspace = true, features = ["signing"] }
 serde_json = { workspace = true }
 shared = { path = "../shared" }
 maplit = { workspace = true }
+testlib = { path = "../testlib" }
 
 [features]
 e2e = []

--- a/crates/model/src/auction.rs
+++ b/crates/model/src/auction.rs
@@ -58,7 +58,7 @@ mod tests {
         crate::order::{OrderMetadata, OrderUid},
         maplit::btreemap,
         serde_json::json,
-        shared::assert_json_matches,
+        testlib::assert_json_matches,
     };
 
     #[test]

--- a/crates/model/src/order.rs
+++ b/crates/model/src/order.rs
@@ -1034,7 +1034,7 @@ mod tests {
         primitive_types::H256,
         secp256k1::{PublicKey, Secp256k1, SecretKey},
         serde_json::json,
-        shared::assert_json_matches,
+        testlib::assert_json_matches,
         web3::signing::keccak256,
     };
 

--- a/crates/model/src/quote.rs
+++ b/crates/model/src/quote.rs
@@ -318,7 +318,7 @@ impl OrderQuoteRequest {
 
 #[cfg(test)]
 mod tests {
-    use {super::*, serde_json::json, shared::assert_json_matches};
+    use {super::*, serde_json::json, testlib::assert_json_matches};
 
     #[test]
     fn serialize_defaults() {

--- a/crates/model/src/ratio_as_decimal.rs
+++ b/crates/model/src/ratio_as_decimal.rs
@@ -63,7 +63,7 @@ mod tests {
         super::*,
         num::{BigRational, Zero},
         serde_json::{json, value::Serializer},
-        shared::assert_json_matches,
+        testlib::assert_json_matches,
     };
 
     #[test]

--- a/crates/model/src/signature.rs
+++ b/crates/model/src/signature.rs
@@ -422,7 +422,7 @@ impl<'de> Deserialize<'de> for EcdsaSignature {
 
 #[cfg(test)]
 mod tests {
-    use {super::*, serde_json::json, shared::assert_json_matches};
+    use {super::*, serde_json::json, testlib::assert_json_matches};
 
     #[test]
     fn onchain_signatures_cannot_recover_owners() {

--- a/crates/model/src/solver_competition.rs
+++ b/crates/model/src/solver_competition.rs
@@ -118,7 +118,7 @@ pub enum Order {
 
 #[cfg(test)]
 mod tests {
-    use {super::*, maplit::btreemap, shared::assert_json_matches};
+    use {super::*, maplit::btreemap, testlib::assert_json_matches};
 
     #[test]
     fn serialize() {

--- a/crates/model/src/trade.rs
+++ b/crates/model/src/trade.rs
@@ -39,7 +39,7 @@ mod tests {
         crate::fee_policy::{FeePolicy, Quote},
         primitive_types::U256,
         serde_json::json,
-        shared::assert_json_matches,
+        testlib::assert_json_matches,
     };
 
     #[test]

--- a/crates/shared/src/lib.rs
+++ b/crates/shared/src/lib.rs
@@ -36,7 +36,6 @@ pub mod sources;
 pub mod subgraph;
 pub mod submitter_constants;
 pub mod tenderly_api;
-pub mod test_utils;
 pub mod token_info;
 pub mod token_list;
 pub mod trace_many;

--- a/crates/shared/src/sources/uniswap_v3/pool_fetching.rs
+++ b/crates/shared/src/sources/uniswap_v3/pool_fetching.rs
@@ -496,7 +496,7 @@ impl Maintaining for UniswapV3PoolFetcher {
 mod tests {
     use {
         super::*,
-        crate::assert_json_matches,
+        testlib::assert_json_matches,
         contracts::uniswap_v3_pool::event_data::{Burn, Mint, Swap},
         ethcontract::EventMetadata,
         serde_json::json,

--- a/crates/shared/src/sources/uniswap_v3/pool_fetching.rs
+++ b/crates/shared/src/sources/uniswap_v3/pool_fetching.rs
@@ -496,11 +496,11 @@ impl Maintaining for UniswapV3PoolFetcher {
 mod tests {
     use {
         super::*,
-        testlib::assert_json_matches,
         contracts::uniswap_v3_pool::event_data::{Burn, Mint, Swap},
         ethcontract::EventMetadata,
         serde_json::json,
         std::str::FromStr,
+        testlib::assert_json_matches,
     };
 
     #[test]

--- a/crates/shared/src/tenderly_api.rs
+++ b/crates/shared/src/tenderly_api.rs
@@ -334,7 +334,7 @@ impl Metrics {
 
 #[cfg(test)]
 mod tests {
-    use {super::*, crate::assert_json_matches, hex_literal::hex, serde_json::json};
+    use {super::*, testlib::assert_json_matches, hex_literal::hex, serde_json::json};
 
     #[test]
     fn serialize_deserialize_simulation_request() {

--- a/crates/shared/src/tenderly_api.rs
+++ b/crates/shared/src/tenderly_api.rs
@@ -334,7 +334,7 @@ impl Metrics {
 
 #[cfg(test)]
 mod tests {
-    use {super::*, testlib::assert_json_matches, hex_literal::hex, serde_json::json};
+    use {super::*, hex_literal::hex, serde_json::json, testlib::assert_json_matches};
 
     #[test]
     fn serialize_deserialize_simulation_request() {

--- a/crates/testlib/Cargo.toml
+++ b/crates/testlib/Cargo.toml
@@ -9,6 +9,9 @@ license = "MIT OR Apache-2.0"
 ethcontract = { workspace = true }
 ethcontract-mock = { workspace = true }
 hex-literal = { workspace = true }
+anyhow = { workspace = true }
+maplit = { workspace = true }
+serde_json = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/testlib/src/json_matching.rs
+++ b/crates/testlib/src/json_matching.rs
@@ -29,9 +29,9 @@ use {anyhow::anyhow, std::collections::HashSet};
 #[macro_export]
 macro_rules! assert_json_matches_excluding {
     ($actual:expr, $expected:expr, $exclude_paths:expr) => {{
-        let exclude_paths = $crate::test_utils::parse_field_paths(&$exclude_paths);
+        let exclude_paths = $crate::json_matching::parse_field_paths(&$exclude_paths);
         let result =
-            $crate::test_utils::json_matches_excluding(&$actual, &$expected, &exclude_paths);
+            $crate::json_matching::json_matches_excluding(&$actual, &$expected, &exclude_paths);
         if let Err(e) = result {
             panic!(
                 "JSON did not match with the exclusion of specified paths. Error: {}\nActual \
@@ -78,7 +78,7 @@ macro_rules! assert_json_matches_excluding {
 #[macro_export]
 macro_rules! assert_json_matches {
     ($actual:expr, $expected:expr) => {{
-        let result = $crate::test_utils::json_matches_excluding(
+        let result = $crate::json_matching::json_matches_excluding(
             &$actual,
             &$expected,
             &std::collections::HashSet::new(),

--- a/crates/testlib/src/json_matching.rs
+++ b/crates/testlib/src/json_matching.rs
@@ -24,7 +24,7 @@ use {anyhow::anyhow, std::collections::HashSet};
 /// ```
 /// let actual = serde_json::json!({"user": {"id": 1, "name": "Alice", "email": "alice@example.com"}});
 /// let expected = serde_json::json!({"user": {"id": 1, "name": "Alice", "email": "bob@example.com"}});
-/// shared::assert_json_matches_excluding!(actual, expected, ["user.email"]);
+/// testlib::assert_json_matches_excluding!(actual, expected, ["user.email"]);
 /// ```
 #[macro_export]
 macro_rules! assert_json_matches_excluding {
@@ -65,7 +65,7 @@ macro_rules! assert_json_matches_excluding {
 /// # Examples
 ///
 /// ```
-/// use shared::assert_json_matches;
+/// use testlib::assert_json_matches;
 ///
 /// let actual = serde_json::json!({"user": {"id": 1, "name": "Alice"}});
 /// let expected = serde_json::json!({"user": {"id": 1, "name": "Alice"}});

--- a/crates/testlib/src/lib.rs
+++ b/crates/testlib/src/lib.rs
@@ -2,6 +2,6 @@
 
 pub use ethcontract_mock::utils::*;
 
+pub mod json_matching;
 pub mod protocol;
 pub mod tokens;
-pub mod json_matching;

--- a/crates/testlib/src/lib.rs
+++ b/crates/testlib/src/lib.rs
@@ -4,3 +4,4 @@ pub use ethcontract_mock::utils::*;
 
 pub mod protocol;
 pub mod tokens;
+pub mod json_matching;


### PR DESCRIPTION
# Description
Moves `shared::test_utils` into `testlib::json_matching` to reduce the scope of the `shared` crate.