### PR TITLE
[Easy] Settled order count metric

### DIFF
--- a/crates/autopilot/src/run_loop.rs
+++ b/crates/autopilot/src/run_loop.rs
@@ -322,7 +322,7 @@ impl RunLoop {
                 .settle(
                     &driver_,
                     solution_id,
-                    solved_order_uids,
+                    solved_order_uids.clone(),
                     solver,
                     auction_id,
                     block_deadline,
@@ -1026,7 +1026,7 @@ impl Metrics {
         Self::get()
             .settled
             .with_label_values(&[&driver.name])
-            .inc_by(settled_order_count);
+            .inc_by(settled_order_count.try_into().unwrap_or(u64::MAX));
     }
 
     fn settle_err(driver: &infra::Driver, elapsed: Duration, err: &SettleError) {

--- a/crates/autopilot/src/run_loop.rs
+++ b/crates/autopilot/src/run_loop.rs
@@ -330,7 +330,11 @@ impl RunLoop {
                 .await
             {
                 Ok(tx_hash) => {
-                    Metrics::settle_ok(&driver_, submission_start.elapsed());
+                    Metrics::settle_ok(
+                        &driver_,
+                        solved_order_uids.len(),
+                        submission_start.elapsed(),
+                    );
                     tracing::debug!(?tx_hash, driver = %driver_.name, ?solver, "solution settled");
                 }
                 Err(err) => {
@@ -939,6 +943,11 @@ struct Metrics {
     #[metric(labels("ignored_by"))]
     matched_unsettled: prometheus::IntCounterVec,
 
+    /// Tracks the number of orders that were settled together with the
+    /// settling driver.
+    #[metric(labels("driver"))]
+    settled: prometheus::IntCounterVec,
+
     /// Tracks the number of database errors.
     #[metric(labels("error_type"))]
     db_metric_error: prometheus::IntCounterVec,
@@ -1009,11 +1018,15 @@ impl Metrics {
             .inc();
     }
 
-    fn settle_ok(driver: &infra::Driver, elapsed: Duration) {
+    fn settle_ok(driver: &infra::Driver, settled_order_count: usize, elapsed: Duration) {
         Self::get()
             .settle
             .with_label_values(&[&driver.name, "success"])
             .observe(elapsed.as_secs_f64());
+        Self::get()
+            .settled
+            .with_label_values(&[&driver.name])
+            .inc_by(settled_order_count);
     }
 
     fn settle_err(driver: &infra::Driver, elapsed: Duration, err: &SettleError) {


### PR DESCRIPTION
# Description
In order to improve our settlement throughput alerting I'd like to plot the number of orders we settle per minute over time (to be able to compare it with the "matched but unsettled" ones.

I don't think there is a way to get this information from the existing autopilot metrics so adding this counter to the `settle_ok` call.

# Changes
- [x] Expose new metric
- [x] Add settled order count to the `settle_ok` callback

## How to test
See new metrics exposed in prometheus logs

<!--
## Related Issues

Fixes #
-->