### PR TITLE
Do not settle after the deadline

### DIFF
--- a/crates/autopilot/src/run_loop.rs
+++ b/crates/autopilot/src/run_loop.rs
@@ -796,7 +796,7 @@ impl RunLoop {
         let settle = async move {
             let current_block = self.eth.current_block().borrow().number;
             anyhow::ensure!(
-                current_block >= submission_deadline_latest_block,
+                current_block < submission_deadline_latest_block,
                 "submission deadline was missed while waiting for the settlement queue"
             );
 

--- a/crates/autopilot/src/run_loop.rs
+++ b/crates/autopilot/src/run_loop.rs
@@ -314,7 +314,6 @@ impl RunLoop {
         let self_ = self.clone();
         let driver_ = driver.clone();
 
-        let solved_order_uids_ = solved_order_uids.clone();
         let settle_fut = async move {
             tracing::info!(driver = %driver_.name, solution = %solution_id, "settling");
             let submission_start = Instant::now();
@@ -323,7 +322,7 @@ impl RunLoop {
                 .settle(
                     &driver_,
                     solution_id,
-                    solved_order_uids_,
+                    solved_order_uids,
                     solver,
                     auction_id,
                     block_deadline,

--- a/crates/autopilot/src/run_loop.rs
+++ b/crates/autopilot/src/run_loop.rs
@@ -239,7 +239,7 @@ impl RunLoop {
         }
 
         let competition_simulation_block = self.eth.current_block().borrow().number;
-        let block_deadline = competition_simulation_block + self.config.submission_deadline;
+        let block_deadline = auction.block + self.config.submission_deadline;
 
         // Post-processing should not be executed asynchronously since it includes steps
         // of storing all the competition/auction-related data to the DB.


### PR DESCRIPTION
# Description
2 colocated solvers reported that `/settle` requests were sent after the deadline. The expected behaviour is that on each new block a new auction is cut. So for each new settlement the deadline should be the `auction.block + settlement_deadline`. It turned out that this is not the case and after the auction cut, the deadline is calculated as `current_block + settlement_deadline`. E.g(deadline config is `3`):
- Auction cut at block 10 in the end of the round.
- New block 11 is mined.
- Only then the deadline is calculated as 11+3=14.
- The next auction is being cut at block 11 and the deadline for the next settlement is also 11+3=14.
- The first settlement gets executed in the end of the block 13 round.
- A new block 14 gets mined and the next settle call is sent after the deadline.

This should probably explain how the settle call could be sent after the deadline.

# Changes

- Calculate the deadline based on the auction block, not the current.
- To properly validate the approach and make sure this never happens again, the proposal is to not send the `/settle` request once the deadline is reached.
- Another observation is that a log in the `wait_for_settlement_transaction` function uses a newly calculated deadline block number for some reason. The PR fixes that and uses the same value as was used in the `/settle` request. That should help better understand the root cause.

So in the end the expected behaviour should be observed, where each subsequent settle request has a deadline for at least 1 block ahead the previous deadline. So if a settlement gets executed in the end of the round 13 or gets discarded at block 14, the next settlement still have the deadline for block 15 which should be sufficient.

## How to test
Existing tests. This might require increasing the settlement deadline by 1.
