### PR TITLE
Use Jemalloc allocator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -68,7 +68,6 @@ dependencies = [
  "chrono",
  "clap",
  "humantime",
- "mimalloc",
  "model",
  "number",
  "observe",
@@ -288,7 +287,6 @@ dependencies = [
  "indexmap 2.2.6",
  "itertools 0.12.1",
  "maplit",
- "mimalloc",
  "mockall 0.12.1",
  "model",
  "num",
@@ -1793,7 +1791,6 @@ dependencies = [
  "itertools 0.12.1",
  "lazy_static",
  "maplit",
- "mimalloc",
  "mockall 0.12.1",
  "model",
  "num",
@@ -2876,16 +2873,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058"
 
 [[package]]
-name = "libmimalloc-sys"
-version = "0.1.39"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23aa6811d3bd4deb8a84dde645f943476d13b248d818edcf8ce0b2f37f036b44"
-dependencies = [
- "cc",
- "libc",
-]
-
-[[package]]
 name = "libsqlite3-sys"
 version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2981,15 +2968,6 @@ name = "memchr"
 version = "2.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c8640c5d730cb13ebd907d8d04b52f55ac9a2eec55b440c8892f40d56c76c1d"
-
-[[package]]
-name = "mimalloc"
-version = "0.1.43"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68914350ae34959d83f732418d51e2427a794055d0b9529f48259ac07af65633"
-dependencies = [
- "libmimalloc-sys",
-]
 
 [[package]]
 name = "mime"
@@ -3408,7 +3386,6 @@ dependencies = [
  "humantime",
  "hyper",
  "maplit",
- "mimalloc",
  "mockall 0.12.1",
  "model",
  "multibase",
@@ -3894,7 +3871,6 @@ dependencies = [
  "gas-estimation",
  "humantime",
  "lazy_static",
- "mimalloc",
  "model",
  "number",
  "observe",
@@ -4502,6 +4478,7 @@ dependencies = [
  "tempfile",
  "testlib",
  "thiserror",
+ "tikv-jemallocator",
  "time",
  "tokio",
  "tokio-stream",
@@ -4633,7 +4610,6 @@ dependencies = [
  "hex-literal",
  "hyper",
  "itertools 0.12.1",
- "mimalloc",
  "model",
  "num",
  "observe",
@@ -5088,6 +5064,26 @@ checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
 dependencies = [
  "cfg-if",
  "once_cell",
+]
+
+[[package]]
+name = "tikv-jemalloc-sys"
+version = "0.6.0+5.3.0-1-ge13ca993e8ccb9ba9847cc330696e02839f328f7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd3c60906412afa9c2b5b5a48ca6a5abe5736aec9eb48ad05037a677e52e4e2d"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
+name = "tikv-jemallocator"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cec5ff18518d81584f477e9bfdf957f5bb0979b0bac3af4ca30b5b3ae2d2865"
+dependencies = [
+ "libc",
+ "tikv-jemalloc-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ clap = { version = "4.5.6", features = ["derive", "env"] }
 derivative = "2.2.0"
 derive_more = "0.99.17"
 ethcontract = { version = "0.25.7", default-features = false, features = ["aws-kms"] }
-mimalloc = "0.1.43"
+tikv-jemallocator = "0.6"
 ethcontract-generate = { version = "0.25.7", default-features = false }
 ethcontract-mock = { version = "0.25.7", default-features = false }
 ethereum-types = "0.14.1"

--- a/crates/alerter/Cargo.toml
+++ b/crates/alerter/Cargo.toml
@@ -11,7 +11,6 @@ chrono = { workspace = true }
 clap = { workspace = true }
 humantime = { workspace = true }
 observe = { path = "../observe" }
-mimalloc = { workspace = true }
 model = { path = "../model" }
 number = { path = "../number" }
 primitive-types = { workspace = true }

--- a/crates/alerter/src/main.rs
+++ b/crates/alerter/src/main.rs
@@ -1,5 +1,4 @@
-#[global_allocator]
-static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
+shared::use_custom_global_allocator!();
 
 #[tokio::main]
 async fn main() {

--- a/crates/autopilot/Cargo.toml
+++ b/crates/autopilot/Cargo.toml
@@ -39,7 +39,6 @@ humantime = { workspace = true }
 indexmap = { workspace = true }
 itertools = { workspace = true }
 maplit = { workspace = true }
-mimalloc = { workspace = true }
 model = { path = "../model" }
 num = { workspace = true }
 number = { path = "../number" }

--- a/crates/autopilot/src/main.rs
+++ b/crates/autopilot/src/main.rs
@@ -1,5 +1,4 @@
-#[global_allocator]
-static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
+shared::use_custom_global_allocator!();
 
 #[tokio::main]
 async fn main() {

--- a/crates/driver/Cargo.toml
+++ b/crates/driver/Cargo.toml
@@ -38,7 +38,6 @@ hyper = { workspace = true }
 lazy_static = { workspace = true }
 indexmap = { workspace = true, features = ["serde"] }
 itertools = { workspace = true }
-mimalloc = { workspace = true }
 num = { workspace = true }
 number = { path = "../number" }
 prometheus = { workspace = true }

--- a/crates/driver/src/main.rs
+++ b/crates/driver/src/main.rs
@@ -1,5 +1,4 @@
-#[global_allocator]
-static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
+shared::use_custom_global_allocator!();
 
 #[tokio::main]
 async fn main() {

--- a/crates/orderbook/Cargo.toml
+++ b/crates/orderbook/Cargo.toml
@@ -34,7 +34,6 @@ hex-literal = { workspace = true }
 humantime = { workspace = true }
 hyper = { workspace = true }
 maplit = { workspace = true }
-mimalloc = { workspace = true }
 model = { path = "../model" }
 multibase = "0.9"
 num = { workspace = true }

--- a/crates/orderbook/src/main.rs
+++ b/crates/orderbook/src/main.rs
@@ -1,5 +1,4 @@
-#[global_allocator]
-static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
+shared::use_custom_global_allocator!();
 
 #[tokio::main]
 async fn main() {

--- a/crates/refunder/Cargo.toml
+++ b/crates/refunder/Cargo.toml
@@ -18,7 +18,6 @@ futures = {workspace = true}
 gas-estimation = { workspace = true }
 humantime = { workspace = true }
 lazy_static = { workspace = true }
-mimalloc = "0.1.43"
 model = { path = "../model" }
 number = { path = "../number" }
 observe = { path = "../observe" }

--- a/crates/refunder/src/main.rs
+++ b/crates/refunder/src/main.rs
@@ -1,5 +1,4 @@
-#[global_allocator]
-static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
+shared::use_custom_global_allocator!();
 
 #[tokio::main]
 async fn main() {

--- a/crates/shared/Cargo.toml
+++ b/crates/shared/Cargo.toml
@@ -62,6 +62,7 @@ tracing-subscriber = { workspace = true, features = ["env-filter", "fmt", "time"
 url = { workspace = true }
 warp = { workspace = true }
 web3 = { workspace = true }
+tikv-jemallocator = { workspace = true }
 
 [dev-dependencies]
 async-stream = "0.3.5"

--- a/crates/shared/src/alloc.rs
+++ b/crates/shared/src/alloc.rs
@@ -1,0 +1,11 @@
+pub use tikv_jemallocator;
+
+#[macro_export]
+macro_rules! use_custom_global_allocator {
+    () => {
+        use shared::alloc::tikv_jemallocator;
+
+        #[global_allocator]
+        static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
+    };
+}

--- a/crates/shared/src/lib.rs
+++ b/crates/shared/src/lib.rs
@@ -2,6 +2,7 @@
 pub mod macros;
 
 pub mod account_balances;
+pub mod alloc;
 pub mod arguments;
 pub mod bad_token;
 pub mod baseline_solver;
@@ -39,7 +40,6 @@ pub mod trace_many;
 pub mod trade_finding;
 pub mod url;
 pub mod zeroex_api;
-pub mod alloc;
 
 use std::{
     future::Future,

--- a/crates/shared/src/lib.rs
+++ b/crates/shared/src/lib.rs
@@ -39,6 +39,7 @@ pub mod trace_many;
 pub mod trade_finding;
 pub mod url;
 pub mod zeroex_api;
+pub mod alloc;
 
 use std::{
     future::Future,

--- a/crates/solvers/Cargo.toml
+++ b/crates/solvers/Cargo.toml
@@ -25,7 +25,6 @@ futures = { workspace = true }
 hex = { workspace = true }
 hyper = { workspace = true }
 itertools = { workspace = true }
-mimalloc = { workspace = true }
 num = { workspace = true }
 prometheus = { workspace = true }
 prometheus-metric-storage = { workspace = true }

--- a/crates/solvers/src/main.rs
+++ b/crates/solvers/src/main.rs
@@ -1,5 +1,4 @@
-#[global_allocator]
-static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
+shared::use_custom_global_allocator!();
 
 #[tokio::main]
 async fn main() {


### PR DESCRIPTION
# Description
Basing on test results ([link](https://www.notion.so/cownation/Custom-memory-allocators-1368da5f04ca800abf74db9b1202cc06)) of using custom allocators on Staging environment, applied `jemalloc` allocator as it uses the least memory.

# Changes
Removed `mimalloc` dependency. Added dedicated macro `use_custom_global_allocator!()` in `shared` crate, which declares `Jemalloc` as Rust global allocator. This macro is used all executables.

## How to test
Verify Grafana metrics after longer usage of `jemalloc` to verify if there is no regression comparing to `mimalloc`.