### PR TITLE
[TRIVIAL] Updated `driver` OpenApi after PR #3113 

### DIFF
--- a/crates/driver/openapi.yml
+++ b/crates/driver/openapi.yml
@@ -493,6 +493,10 @@ components:
           description: The last block number in which the solution TX can be included.
           type: integer
           example: 12345
+        auctionId:
+          description: Auction ID in which the specified solution ID is competing.
+          type: string
+          example: "123"
     RevealedResponse:
       description: Response of the reveal endpoint.
       type: object


### PR DESCRIPTION
# Description
PR #3113 added new field to /reveal and /settle requests but `openapi.yml` file wasn't updated. This PR adds missing field definition to `openapi.yml` file.