### PR TITLE
Reduce Try/TryFrom implementations for general types

### DIFF
--- a/crates/autopilot/src/domain/fee/mod.rs
+++ b/crates/autopilot/src/domain/fee/mod.rs
@@ -288,8 +288,8 @@ pub struct Quote {
     pub solver: H160,
 }
 
-impl From<domain::Quote> for Quote {
-    fn from(value: domain::Quote) -> Self {
+impl Quote {
+    fn from_domain(value: &domain::Quote) -> Self {
         Self {
             sell_amount: value.sell_amount.into(),
             buy_amount: value.buy_amount.into(),

--- a/crates/autopilot/src/domain/fee/policy.rs
+++ b/crates/autopilot/src/domain/fee/policy.rs
@@ -1,7 +1,10 @@
 use crate::{
     arguments,
     boundary,
-    domain::{self, fee::FeeFactor},
+    domain::{
+        self,
+        fee::{FeeFactor, Quote},
+    },
 };
 
 pub enum Policy {
@@ -74,7 +77,7 @@ impl PriceImprovement {
             boundary::OrderClass::Limit => Some(domain::fee::Policy::PriceImprovement {
                 factor: self.factor,
                 max_volume_factor: self.max_volume_factor,
-                quote: quote.clone().into(),
+                quote: Quote::from_domain(quote),
             }),
         }
     }

--- a/crates/autopilot/src/infra/persistence/dto/order.rs
+++ b/crates/autopilot/src/infra/persistence/dto/order.rs
@@ -90,7 +90,7 @@ pub fn to_domain(order: Order) -> domain::Order {
         protocol_fees: order
             .protocol_fees
             .into_iter()
-            .map(|fee_policy| fee_policy.into_domain())
+            .map(FeePolicy::into_domain)
             .collect(),
         created: order.created,
         valid_to: order.valid_to,

--- a/crates/autopilot/src/infra/persistence/dto/order.rs
+++ b/crates/autopilot/src/infra/persistence/dto/order.rs
@@ -72,7 +72,7 @@ pub fn from_domain(order: domain::Order) -> Order {
         class: boundary::OrderClass::Limit,
         app_data: order.app_data.into(),
         signature: order.signature.into(),
-        quote: order.quote.map(Into::into),
+        quote: order.quote.map(Quote::from_domain),
     }
 }
 
@@ -344,6 +344,15 @@ pub struct Quote {
 }
 
 impl Quote {
+    fn from_domain(quote: domain::Quote) -> Self {
+        Quote {
+            sell_amount: quote.sell_amount.0,
+            buy_amount: quote.buy_amount.0,
+            fee: quote.fee.0,
+            solver: quote.solver.0,
+        }
+    }
+
     pub fn to_domain(&self, order_uid: OrderUid) -> domain::Quote {
         domain::Quote {
             order_uid,
@@ -351,17 +360,6 @@ impl Quote {
             buy_amount: self.buy_amount.into(),
             fee: self.fee.into(),
             solver: self.solver.into(),
-        }
-    }
-}
-
-impl From<domain::Quote> for Quote {
-    fn from(quote: domain::Quote) -> Self {
-        Quote {
-            sell_amount: quote.sell_amount.0,
-            buy_amount: quote.buy_amount.0,
-            fee: quote.fee.0,
-            solver: quote.solver.0,
         }
     }
 }

--- a/crates/autopilot/src/infra/shadow/orderbook/mod.rs
+++ b/crates/autopilot/src/infra/shadow/orderbook/mod.rs
@@ -25,7 +25,7 @@ impl Orderbook {
             .error_for_status()?
             .json::<dto::Auction>()
             .await
-            .map(TryInto::try_into)
+            .map(dto::Auction::try_into_domain)
             .map_err(Into::<anyhow::Error>::into)?
     }
 }

--- a/crates/driver/src/infra/solver/dto/auction.rs
+++ b/crates/driver/src/infra/solver/dto/auction.rs
@@ -155,7 +155,7 @@ impl Auction {
                                 .protocol_fees
                                 .iter()
                                 .cloned()
-                                .map(Into::into)
+                                .map(FeePolicy::from_domain)
                                 .collect(),
                         ),
                         app_data: AppDataHash(order.app_data.0.into()),
@@ -407,8 +407,8 @@ pub enum FeePolicy {
     Volume { factor: f64 },
 }
 
-impl From<fees::FeePolicy> for FeePolicy {
-    fn from(value: order::FeePolicy) -> Self {
+impl FeePolicy {
+    pub fn from_domain(value: fees::FeePolicy) -> FeePolicy {
         match value {
             order::FeePolicy::Surplus {
                 factor,


### PR DESCRIPTION
# Description
During some debugging sessions, it was noticed that having implicit conversions overcomplicate code navigations. The proposal is to use explicit `from/into_domain` functions for general types.

# Changes

The PR touches only Auction and FeePolicy structs at the moment. But once bumped into the same issue with any other struct, a follow-up should be opened.
