### PR TITLE
Remove `crates` vscode extension dependency from devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -41,8 +41,7 @@
                 ]
             },
             "extensions": [
-                "rust-lang.rust-analyzer",
-                "serayuzgur.crates"
+                "rust-lang.rust-analyzer"
             ]
         }
     },


### PR DESCRIPTION
# Description
Devcontainer json definition file contains vscode extension dependency: `crates` which is deprecated. As this extension is only an utility for checking `Cargo.toml` dependency creates versions and is not needed for devcontainer to work on our codebase, we decided to drop that extension from our devcontainer json definition file.
Anyone can still use `crates` or similar extension (like `dependi`) in devcontainer by installing it locally in vscode.
Reference discussion: [link](https://cowservices.slack.com/archives/C0375NV72SC/p1731961303020439)

# Changes
Updated `devcontainer.json` file.

## How to test
Open vscode from `services` folder and on popup window click option "Open in devcontainer" (docker daemon is required to operate). Wait for containers setup and validation by rust analyzer.
