### PR TITLE
OpenAPI formatting linter

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -176,13 +176,13 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha }}
-      - run: npm install @apidevtools/swagger-cli @redocly/openapi-cli
+      - run: npm install @apidevtools/swagger-cli @stoplight/spectral-cli
       - run: node_modules/.bin/swagger-cli validate crates/orderbook/openapi.yml
       - run: node_modules/.bin/swagger-cli validate crates/driver/openapi.yml
       - run: node_modules/.bin/swagger-cli validate crates/solvers/openapi.yml
-      - run: node_modules/.bin/openapi validate crates/orderbook/openapi.yml
-      - run: node_modules/.bin/openapi validate crates/driver/openapi.yml
-      - run: node_modules/.bin/openapi validate crates/solvers/openapi.yml
+      - run: node_modules/.bin/spectral lint crates/orderbook/openapi.yml
+      - run: node_modules/.bin/spectral lint crates/driver/openapi.yml
+      - run: node_modules/.bin/spectral lint crates/solvers/openapi.yml
 
   run-flaky-test:
     # to debug a flaky test set `if` to true and configure the flaky test in the `run` step

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -176,10 +176,13 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha }}
-      - run: npm install @apidevtools/swagger-cli
+      - run: npm install @apidevtools/swagger-cli @redocly/openapi-cli
       - run: node_modules/.bin/swagger-cli validate crates/orderbook/openapi.yml
       - run: node_modules/.bin/swagger-cli validate crates/driver/openapi.yml
       - run: node_modules/.bin/swagger-cli validate crates/solvers/openapi.yml
+      - run: node_modules/.bin/openapi validate crates/orderbook/openapi.yml
+      - run: node_modules/.bin/openapi validate crates/driver/openapi.yml
+      - run: node_modules/.bin/openapi validate crates/solvers/openapi.yml
 
   run-flaky-test:
     # to debug a flaky test set `if` to true and configure the flaky test in the `run` step

--- a/.spectral.yaml
+++ b/.spectral.yaml
@@ -1,0 +1,2 @@
+extends: "spectral:oas"
+

--- a/.spectral.yaml
+++ b/.spectral.yaml
@@ -1,2 +1,1 @@
 extends: "spectral:oas"
-

--- a/crates/driver/openapi.yml
+++ b/crates/driver/openapi.yml
@@ -23,12 +23,14 @@ paths:
           required: true
         - in: query
           name: kind
-          description: |
-            - `buy`: amount is in buy_token, out_amount is in sell_token
-            - `sell`: amount is in sell_token, out_amount is in buy_token
+          description: >-
+            - `buy`: amount is in buy_token, out_amount is in sell_token -
+            `sell`: amount is in sell_token, out_amount is in buy_token
           schema:
             type: string
-            enum: ["buy", "sell"]
+            enum:
+              - buy
+              - sell
           required: true
         - in: query
           name: amount
@@ -43,34 +45,35 @@ paths:
             $ref: "#/components/schemas/DateTime"
           required: true
       responses:
-        200:
+        "200":
           description: Quote successfully created.
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/QuoteResponseKind"
-        400:
+        "400":
           $ref: "#/components/responses/BadRequest"
-        429:
+        "429":
           description: The solver cannot keep up. It is too busy to handle more requests.
-        500:
+        "500":
           $ref: "#/components/responses/InternalServerError"
   /solve:
     post:
-      description: |
+      description: |-
         Solve the passed in auction.
 
-        The response contains the objective value of the solution the Solver is able to find but not
-        the calldata. This facilitates solvers that work with an RFQ system. When Autopilot decides
-        the winner of the of the auction it prompts the corresponding solver to execute its solution
+        The response contains the objective value of the solution the Solver is
+        able to find but not the calldata. This facilitates solvers that work
+        with an RFQ system. When Autopilot decides the winner of the of the
+        auction it prompts the corresponding solver to execute its solution
         through the execute endpoint.
 
-        The Solver should respond quickly enough so that the caller of the endpoint receives the
-        response within the deadline indicated in the request. This includes taking into account
-        network delay.
+        The Solver should respond quickly enough so that the caller of the
+        endpoint receives the response within the deadline indicated in the
+        request. This includes taking into account network delay.
 
-        Autopilot will call this endpoint at most once for the same auction id and the following
-        call will have a larger id.
+        Autopilot will call this endpoint at most once for the same auction id
+        and the following call will have a larger id.
       requestBody:
         required: true
         content:
@@ -78,22 +81,23 @@ paths:
             schema:
               $ref: "#/components/schemas/SolveRequest"
       responses:
-        200:
+        "200":
           description: Auction successfully solved.
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/SolveResponse"
-        400:
+        "400":
           $ref: "#/components/responses/BadRequest"
-        500:
+        "500":
           $ref: "#/components/responses/InternalServerError"
   /reveal:
     post:
-      description: |
+      description: >
         Reveal the calldata of the previously solved auction.
 
-        This may be used by the autopilot for the shadow competition to verify the solution before requesting its execution it on chain.
+        This may be used by the autopilot for the shadow competition to verify
+        the solution before requesting its execution it on chain.
       requestBody:
         required: true
         content:
@@ -101,25 +105,26 @@ paths:
             schema:
               $ref: "#/components/schemas/Solution"
       responses:
-        200:
+        "200":
           description: Execution accepted.
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/RevealedResponse"
-        400:
+        "400":
           $ref: "#/components/responses/BadRequest"
-        500:
+        "500":
           $ref: "#/components/responses/InternalServerError"
   /settle:
     post:
-      description: |
+      description: |-
         Execute the previously solved auction on chain.
 
-        The auction that should be executed is identified through its id and was recently returned
-        by this Solver's solve endpoint.
+        The auction that should be executed is identified through its id and was
+        recently returned by this Solver's solve endpoint. 
 
-        By accepting the execute request the Solver promises to execute the solution on chain immediately.
+        By accepting the execute request the Solver promises to execute the
+        solution on chain immediately.
       requestBody:
         required: true
         content:
@@ -127,11 +132,11 @@ paths:
             schema:
               $ref: "#/components/schemas/Solution"
       responses:
-        200:
+        "200":
           description: Execution accepted.
-        400:
+        "400":
           $ref: "#/components/responses/BadRequest"
-        500:
+        "500":
           $ref: "#/components/responses/InternalServerError"
 components:
   schemas:
@@ -163,17 +168,24 @@ components:
           nullable: true
           allOf:
             - $ref: "#/components/schemas/TokenAmount"
-          description: |
-            The reference price denominated in native token (i.e. 1e18 represents a token that
-            trades one to one with the native token). These prices are used for solution competition
+          description: |-
+            The reference price denominated in native token (i.e. 1e18
+            represents a token that
+
+            trades one to one with the native token). These prices are used for
+            solution competition
+
             for computing surplus and converting fees to native token.
         trusted:
-          description: |
-            Whether the protocol trusts the token to be used for internalizing trades.
+          description: |-
+            Whether the protocol trusts the token to be used for internalizing
+            trades.
 
-            Solvers are allowed to internalize trades, ie. omit the interaction that executes the swap from token A to token B
-            and instead use the settlement contract balances, aka buffers, to fulfil the interaction as long as the token 
-            the contract receives (A in the example) is trusted.
+            Solvers are allowed to internalize trades, ie. omit the interaction
+            that executes the swap from token A to token B and instead use the
+            settlement contract balances, aka buffers, to fulfil the interaction
+            as long as the token the contract receives (A in the example) is
+            trusted.
           type: boolean
     Order:
       description: |
@@ -183,17 +195,21 @@ components:
         uid:
           $ref: "#/components/schemas/OrderUID"
         sellToken:
-          description: Token being sold
-          $ref: "#/components/schemas/Address"
+          allOf:
+            - description: Token being sold
+            - $ref: "#/components/schemas/Address"
         buyToken:
-          description: Token being bought
-          $ref: "#/components/schemas/Address"
+          allOf:
+            - description: Token being bought
+            - $ref: "#/components/schemas/Address"
         sellAmount:
-          description: Amount to be sold
-          $ref: "#/components/schemas/TokenAmount"
+          allOf:
+            - description: Amount to be sold
+            - $ref: "#/components/schemas/TokenAmount"
         buyAmount:
-          description: Amount to be bought
-          $ref: "#/components/schemas/TokenAmount"
+          allOf:
+            - description: Amount to be bought
+            - $ref: "#/components/schemas/TokenAmount"
         created:
           description: Creation time of the order. Denominated in epoch seconds.
           type: string
@@ -203,22 +219,28 @@ components:
           type: integer
         kind:
           type: string
-          enum: ["buy", "sell"]
+          enum:
+            - buy
+            - sell
         receiver:
-          description: The address that should receive the bought tokens.
-          $ref: "#/components/schemas/Address"
+          allOf:
+            - description: The address that should receive the bought tokens.
+            - $ref: "#/components/schemas/Address"
         owner:
-          description: The address that created the order.
-          $ref: "#/components/schemas/Address"
+          allOf:
+            - description: The address that created the order.
+            - $ref: "#/components/schemas/Address"
         partiallyFillable:
-          description: |
+          description: |-
             Whether the order can be partially filled.
 
-            If this is false then the solver must fill the entire order or not at all.
+            If this is false then the solver must fill the entire order or not
+            at all.
           type: boolean
         executed:
-          description: The amount that has already been filled.
-          $ref: "#/components/schemas/TokenAmount"
+          allOf:
+            - description: The amount that has already been filled.
+            - $ref: "#/components/schemas/TokenAmount"
         preInteractions:
           description: Interactions that must be executed before the order can be filled.
           type: array
@@ -231,34 +253,45 @@ components:
             $ref: "#/components/schemas/Interaction"
         sellTokenBalance:
           type: string
-          enum: ["erc20", "internal", "external"]
+          enum:
+            - erc20
+            - internal
+            - external
         buyTokenBalance:
           type: string
-          enum: ["erc20", "internal"]
+          enum:
+            - erc20
+            - internal
         class:
           type: string
-          enum: ["market", "limit"]
+          enum:
+            - market
+            - limit
         appData:
           description: 32 bytes encoded as hex with `0x` prefix.
           type: string
         signingScheme:
           type: string
-          enum: [ "eip712", "ethsign", "presign", "eip1271" ]
+          enum:
+            - eip712
+            - ethsign
+            - presign
+            - eip1271
         signature:
           description: Hex encoded bytes with `0x` prefix.
           type: string
         protocolFees:
-          description: |
+          description: |-
             Any protocol fee policies that apply to the order.
 
-            The solver should make sure the fee policy is applied when computing their solution.
+            The solver should make sure the fee policy is applied when computing
+            their solution.
           type: array
           items:
             $ref: "#/components/schemas/FeePolicy"
         quote:
-          description: |
-            A winning quote.
           allOf:
+            - description: A winning quote.
             - $ref: "#/components/schemas/Quote"
       required:
         - uid
@@ -286,26 +319,29 @@ components:
       type: string
       example: "1234567890"
     OrderUID:
-      description: |
-        Unique identifier for the order: 56 bytes encoded as hex with `0x` prefix.
-        Bytes 0 to 32 are the order digest, bytes 30 to 52 the owner address
-        and bytes 52..56 valid to,
+      description: |-
+        Unique identifier for the order: 56 bytes encoded as hex with `0x`
+        prefix.
+
+        Bytes 0 to 32 are the order digest, bytes 30 to 52 the owner address and
+        bytes 52..56 valid to,
       type: string
-      example: "0x30cff40d9f60caa68a37f0ee73253ad6ad72b45580c945fe3ab67596476937197854163b1b0d24e77dca702b97b5cc33e0f83dcb626122a6"
+      example: >-
+        0x30cff40d9f60caa68a37f0ee73253ad6ad72b45580c945fe3ab67596476937197854163b1b0d24e77dca702b97b5cc33e0f83dcb626122a6
     QuoteResponseKind:
       oneOf:
         - $ref: "#/components/schemas/LegacyQuoteResponse"
         - $ref: "#/components/schemas/QuoteResponse"
         - $ref: "#/components/schemas/Error"
     LegacyQuoteResponse:
-      description: |
-        Successful Quote
+      description: |-
+        Successful Quote.
 
         The Solver knows how to fill the request with these parameters.
 
-        If the request was of type `buy` then the response's buy amount has the same value as the
-        request's amount and the sell amount was filled in by the server. Vice versa for type
-        `sell`.
+        If the request was of type `buy` then the response's buy amount has the
+        same value as the request's amount and the sell amount was filled in by
+        the server. Vice versa for type `sell`.
       type: object
       properties:
         amount:
@@ -315,8 +351,9 @@ components:
           items:
             $ref: "#/components/schemas/Interaction"
         solver:
-          description: The address of the solver that quoted this order.
-          $ref: "#/components/schemas/Address"
+          allOf:
+            - description: The address of the solver that quoted this order.
+            - $ref: "#/components/schemas/Address"
         gas:
           type: integer
           description: How many units of gas this trade is estimated to cost.
@@ -329,9 +366,8 @@ components:
         - interactions
         - solver
     QuoteResponse:
-      description: |
+      description: |-
         Successful Quote with JIT orders support.
-
         The Solver knows how to fill the request with these parameters.
       type: object
       properties:
@@ -376,17 +412,17 @@ components:
       type: object
       properties:
         internalized:
-          description: |
+          description: |-
             The calldata without any internalized interactions encoded.
-
             This is the calldata that can be found on chain.
           type: string
           example: "0x1234567890"
         uninternalized:
-          description: |
+          description: |-
             The calldata with all internalized interactions encoded.
 
-            This is the calldata that should be used for simulation/verification purposes.
+            This is the calldata that should be used for simulation/verification
+            purposes.
           type: string
           example: "0x1234567890"
     SolveRequest:
@@ -415,8 +451,10 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/Address"
-          description: |
-            List of addresses on whose surplus will count towards the objective value of their solution (unlike other orders that were created by the solver).
+          description: >
+            List of addresses on whose surplus will count towards the objective
+            value of their solution (unlike other orders that were created by
+            the solver).
     SolveResponse:
       description: |
         Response of the solve endpoint.
@@ -428,9 +466,8 @@ components:
             type: object
             properties:
               solutionId:
-                description: |
+                description: |-
                   The unique identifier of the solution.
-                  
                   This id is used to identify the solution when executing it.
                 type: integer
                 example: 1
@@ -440,24 +477,29 @@ components:
                 type: string
                 example: "100"
               submissionAddress:
-                description: |
-                  The address that will be used to submit the solution.
-                $ref: "#/components/schemas/Address"
+                allOf:
+                  - description: The address that will be used to submit the solution.
+                  - $ref: "#/components/schemas/Address"
               orders:
-                description: |
-                  Mapping of order uid to net executed amount (including all fees).
+                description: >
+                  Mapping of order uid to net executed amount (including all
+                  fees).
                 additionalProperties:
                   type: object
                   properties:
                     side:
                       type: string
-                      enum: ["buy", "sell"]
+                      enum:
+                        - buy
+                        - sell
                     sellToken:
-                      description: Token being sold
-                      $ref: "#/components/schemas/Address"
+                      allOf:
+                        - description: Token being sold
+                        - $ref: "#/components/schemas/Address"
                     buyToken:
-                      description: Token being bought
-                      $ref: "#/components/schemas/Address"
+                      allOf:
+                        - description: Token being bought
+                        - $ref: "#/components/schemas/Address"
                     limitSell:
                       type: string
                       description: Maximum amount to be sold.
@@ -466,19 +508,21 @@ components:
                       description: Minimum amount to be bought.
                     executedSell:
                       type: string
-                      description: The effective amount that left the user's wallet including all fees.
+                      description: >-
+                        The effective amount that left the user's wallet
+                        including all fees.
                     executedBuy:
                       type: string
                       description: The effective amount the user received after all fees.
               clearingPrices:
-                description: |
+                description: >
                   Mapping of hex token address to price.
-                  
-                  The prices of tokens for settled user orders as passed to the settlement contract.
+
+                  The prices of tokens for settled user orders as passed to the
+                  settlement contract.
                 type: object
                 additionalProperties:
                   $ref: "#/components/schemas/BigUint"
-
               gas:
                 type: integer
     Solution:
@@ -504,45 +548,54 @@ components:
         calldata:
           $ref: "#/components/schemas/Calldata"
     FeePolicy:
-      description: |
+      description: >
         A fee policy that applies to an order.
 
-        The solver should make sure the fee policy is applied when computing their solution.
+        The solver should make sure the fee policy is applied when computing
+        their solution.
       type: object
       oneOf:
         - $ref: "#/components/schemas/SurplusFee"
         - $ref: "#/components/schemas/PriceImprovement"
         - $ref: "#/components/schemas/VolumeFee"
     SurplusFee:
-      description: |
-        If the order receives more than limit price, pay the protocol a factor of the difference.
+      description: >
+        If the order receives more than limit price, pay the protocol a factor
+        of the difference.
       type: object
       properties:
         kind:
           type: string
-          enum: ["surplus"]
+          enum:
+            - surplus
         maxVolumeFactor:
           description: Never charge more than that percentage of the order volume.
           type: number
           example: 0.1
         factor:
-          description: The factor of the user surplus that the protocol will request from the solver after settling the order
+          description: >-
+            The factor of the user surplus that the protocol will request from
+            the solver after settling the order
           type: number
           example: 0.5
     PriceImprovement:
-      description: |
-        A cut from the price improvement over the best quote is taken as a protocol fee.
+      description: >
+        A cut from the price improvement over the best quote is taken as a
+        protocol fee.
       type: object
       properties:
         kind:
           type: string
-          enum: ["priceImprovement"]
+          enum:
+            - priceImprovement
         maxVolumeFactor:
           description: Never charge more than that percentage of the order volume.
           type: number
           example: 0.01
         factor:
-          description: The factor of the user surplus that the protocol will request from the solver after settling the order
+          description: >-
+            The factor of the user surplus that the protocol will request from
+            the solver after settling the order
           type: number
           example: 0.5
         quote:
@@ -552,9 +605,12 @@ components:
       properties:
         kind:
           type: string
-          enum: ["volume"]
+          enum:
+            - volume
         factor:
-          description: The fraction of the order's volume that the protocol will request from the solver after settling the order.
+          description: >-
+            The fraction of the order's volume that the protocol will request
+            from the solver after settling the order.
           type: number
           example: 0.5
     Quote:
@@ -587,26 +643,41 @@ components:
           type: integer
         side:
           type: string
-          enum: ["buy", "sell"]
+          enum:
+            - buy
+            - sell
         partiallyFillable:
           type: boolean
         sellTokenSource:
           type: string
-          enum: ["erc20", "internal", "external"]
+          enum:
+            - erc20
+            - internal
+            - external
         buyTokenSource:
           type: string
-          enum: ["erc20", "internal"]
+          enum:
+            - erc20
+            - internal
         appData:
           type: string
         signature:
-          description: | 
-            Hex encoded bytes with `0x` prefix. The content depends on the `signingScheme`.
-            For `presign`, this should contain the address of the owner. 
-            For `eip1271`, the signature should consist of `<owner_address><signature_bytes>`.
+          description: >-
+            Hex encoded bytes with `0x` prefix. The content depends on the
+            `signingScheme`.
+
+            For `presign`, this should contain the address of the owner.
+
+            For `eip1271`, the signature should consist of
+            `<owner_address><signature_bytes>`.
           type: string
         signingScheme:
           type: string
-          enum: ["eip712", "ethsign", "presign", "eip1271"]
+          enum:
+            - eip712
+            - ethsign
+            - presign
+            - eip1271
       required:
         - sellToken
         - buyToken
@@ -633,19 +704,19 @@ components:
           description: Text describing the error.
           type: string
   responses:
+    "200":
+      description: The request was successful.
     BadRequest:
-      description: |
+      description: |-
         There is something wrong with the request.
-
         Body potentially contains extra information.
       content:
         text/plain:
           schema:
             type: string
     InternalServerError:
-      description: |
+      description: |-
         Something went wrong when handling the request.
-
         Body potentially contains extra information.
       content:
         text/plain:

--- a/crates/orderbook/openapi.yml
+++ b/crates/orderbook/openapi.yml
@@ -4,52 +4,57 @@ info:
   title: Order Book API
 servers:
   - description: Mainnet (Prod)
-    url: https://api.cow.fi/mainnet
+    url: "https://api.cow.fi/mainnet"
   - description: Mainnet (Staging)
-    url: https://barn.api.cow.fi/mainnet
+    url: "https://barn.api.cow.fi/mainnet"
   - description: Gnosis Chain (Prod)
-    url: https://api.cow.fi/xdai
+    url: "https://api.cow.fi/xdai"
   - description: Gnosis Chain (Staging)
-    url: https://barn.api.cow.fi/xdai
+    url: "https://barn.api.cow.fi/xdai"
   - description: Arbitrum One (Prod)
-    url: https://api.cow.fi/arbitrum_one
+    url: "https://api.cow.fi/arbitrum_one"
   - description: Arbitrum One (Staging)
-    url: https://barn.api.cow.fi/arbitrum_one
+    url: "https://barn.api.cow.fi/arbitrum_one"
   - description: Sepolia (Prod)
-    url: https://api.cow.fi/sepolia
+    url: "https://api.cow.fi/sepolia"
   - description: Sepolia (Staging)
-    url: https://barn.api.cow.fi/sepolia
+    url: "https://barn.api.cow.fi/sepolia"
   - description: Local
-    url: http://localhost:8080
+    url: "http://localhost:8080"
 paths:
   /api/v1/orders:
     post:
-      summary: Create a new order.
-        In order to replace an existing order with a new one, the appData must contain a
-        [valid replacement order UID](https://github.com/cowprotocol/app-data/blob/main/src/schemas/v1.1.0.json#L62),
+      summary: >-
+        Create a new order. In order to replace an existing order with a new
+        one, the appData must contain a [valid replacement order
+        UID](https://github.com/cowprotocol/app-data/blob/main/src/schemas/v1.1.0.json#L62),
         then the indicated order is cancelled, and a new one placed.
-        This allows an old order to be cancelled AND a new order to be created in an atomic operation with a single signature.
-        This may be useful for replacing orders when on-chain prices move outside of the original order's limit price.
+
+        This allows an old order to be cancelled AND a new order to be created
+        in an atomic operation with a single signature.
+
+        This may be useful for replacing orders when on-chain prices move
+        outside of the original order's limit price.
       responses:
-        201:
+        "201":
           description: Order has been accepted.
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/UID"
-        400:
+        "400":
           description: Error during order validation.
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/OrderPostError"
-        403:
-          description: Forbidden, your account is deny-listed.
-        404:
+        "403":
+          description: "Forbidden, your account is deny-listed."
+        "404":
           description: No route was found quoting the order.
-        429:
+        "429":
           description: Too many order placements.
-        500:
+        "500":
           description: Error adding an order.
       requestBody:
         description: The order to create.
@@ -60,12 +65,12 @@ paths:
               $ref: "#/components/schemas/OrderCreation"
     delete:
       summary: Cancel multiple orders by marking them invalid with a timestamp.
-      description: |
+      description: >
         This is a *best effort* cancellation, and might not prevent solvers from
         settling the orders (if the order is part of an in-flight settlement
         transaction for example). Authentication must be provided by an
-        [EIP-712](https://eips.ethereum.org/EIPS/eip-712)
-        signature of an `OrderCancellations(bytes[] orderUids)` message.
+        [EIP-712](https://eips.ethereum.org/EIPS/eip-712) signature of an
+        `OrderCancellations(bytes[] orderUids)` message.
       requestBody:
         description: Signed `OrderCancellations`.
         required: true
@@ -74,19 +79,19 @@ paths:
             schema:
               $ref: "#/components/schemas/OrderCancellations"
       responses:
-        200:
+        "200":
           description: Order(s) are cancelled.
-        400:
+        "400":
           description: Malformed signature.
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/OrderCancellationError"
-        401:
+        "401":
           description: Invalid signature.
-        404:
+        "404":
           description: One or more orders were not found and no orders were cancelled.
-  /api/v1/orders/{UID}:
+  "/api/v1/orders/{UID}":
     get:
       summary: Get existing order from UID.
       parameters:
@@ -96,19 +101,21 @@ paths:
             $ref: "#/components/schemas/UID"
           required: true
       responses:
-        200:
+        "200":
           description: Order
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/Order"
-        404:
+        "404":
           description: Order was not found.
     delete:
       deprecated: true
       summary: Cancel an order by marking it invalid with a timestamp.
-      description: |
-        The successful deletion might not prevent solvers from settling the order.
+      description: |-
+        The successful deletion might not prevent solvers from settling the
+        order.
+
         Authentication must be provided by providing an
         [EIP-712](https://eips.ethereum.org/EIPS/eip-712) signature of an
         `OrderCancellation(bytes orderUid)` message.
@@ -126,35 +133,37 @@ paths:
             schema:
               $ref: "#/components/schemas/OrderCancellation"
       responses:
-        200:
+        "200":
           description: Order cancelled.
-        400:
+        "400":
           description: Malformed signature.
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/OrderCancellationError"
-        401:
+        "401":
           description: Invalid signature.
-        404:
+        "404":
           description: Order was not found.
-  /api/v1/orders/{UID}/status:
+  "/api/v1/orders/{UID}/status":
     get:
       summary: Get the status of an order.
       parameters:
         - in: path
           name: UID
           schema:
-              $ref: "#/components/schemas/UID"
+            $ref: "#/components/schemas/UID"
           required: true
       responses:
-        200:
-          description: The order status with a list of solvers that proposed solutions (if applicable).
+        "200":
+          description: >-
+            The order status with a list of solvers that proposed solutions (if
+            applicable).
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/CompetitionOrderStatus"
-  /api/v1/transactions/{txHash}/orders:
+  "/api/v1/transactions/{txHash}/orders":
     get:
       summary: Get orders by settlement transaction hash.
       parameters:
@@ -164,7 +173,7 @@ paths:
             $ref: "#/components/schemas/TransactionHash"
           required: true
       responses:
-        200:
+        "200":
           description: Order(s).
           content:
             application/json:
@@ -189,16 +198,17 @@ paths:
             $ref: "#/components/schemas/UID"
           required: false
       responses:
-        200:
-          description: |
+        "200":
+          description: |-
             ### If `owner` is specified:
 
             Return all trades related to that `owner`.
 
             ### If `orderUid` is specified:
 
-            Return all trades related to that `orderUid`. Given that an order may be partially
-            fillable, it is possible that an individual order may have *multiple* trades.
+            Return all trades related to that `orderUid`. Given that an order
+            may be partially fillable, it is possible that an individual order
+            may have *multiple* trades.
           content:
             application/json:
               schema:
@@ -208,29 +218,33 @@ paths:
   /api/v1/auction:
     get:
       summary: Get the current batch auction.
-      description: |
-        The current batch auction that solvers should be solving right now. This includes:
+      description: |-
+        The current batch auction that solvers should be solving right now. This
+        includes:
 
-        * A list of solvable orders.
-        * The block on which the batch was created.
-        * Prices for all tokens being traded (used for objective value computation).
+        * A list of solvable orders. * The block on which the batch was created.
+        * Prices for all tokens being traded (used for objective value
+        computation).
 
-        **Note: This endpoint is currently permissioned. Reach out in discord if you need access.**
+        **Note: This endpoint is currently permissioned. Reach out in discord if
+        you need access.**
       responses:
-        200:
+        "200":
           description: Batch auction.
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/Auction"
-  /api/v1/account/{owner}/orders:
+  "/api/v1/account/{owner}/orders":
     get:
       summary: Get orders of one user paginated.
-      description: |
-        The orders are sorted by their creation date descending (newest orders first).
-        To enumerate all orders start with `offset` 0 and keep increasing the `offset` by the total
-        number of returned results. When a response contains less than `limit` the last page has
-        been reached.
+      description: |-
+        The orders are sorted by their creation date descending (newest orders
+        first).
+
+        To enumerate all orders start with `offset` 0 and keep increasing the
+        `offset` by the total number of returned results. When a response
+        contains less than `limit` the last page has been reached.
       parameters:
         - name: owner
           in: path
@@ -252,7 +266,7 @@ paths:
             type: integer
           required: false
       responses:
-        200:
+        "200":
           description: The orders.
           content:
             application/json:
@@ -260,14 +274,17 @@ paths:
                 type: array
                 items:
                   $ref: "#/components/schemas/Order"
-        400:
+        "400":
           description: Problem with parameters like limit being too large.
-  /api/v1/token/{token}/native_price:
+  "/api/v1/token/{token}/native_price":
     get:
       summary: Get native price for the given token.
-      description: |
-        Price is the exchange rate between the specified token and the network's native currency.
-        It represents the amount of native token atoms needed to buy 1 atom of the specified token.
+      description: |-
+        Price is the exchange rate between the specified token and the network's
+        native currency.
+
+        It represents the amount of native token atoms needed to buy 1 atom of
+        the specified token.
       parameters:
         - name: token
           in: path
@@ -275,25 +292,26 @@ paths:
           schema:
             $ref: "#/components/schemas/Address"
       responses:
-        200:
+        "200":
           description: The estimated native price.
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/NativePriceResponse"
-        400:
+        "400":
           description: Error finding the price.
-        404:
+        "404":
           description: No liquidity was found.
-        500:
+        "500":
           description: Unexpected error.
   /api/v1/quote:
     post:
       summary: Quote a price and fee for the specified order parameters.
-      description: |
-        Given a partial order compute the minimum fee and a price estimate for the order. Return a
-        full order that can be used directly for signing, and with an included signature, passed
-        directly to the order creation endpoint.
+      description: >
+        Given a partial order compute the minimum fee and a price estimate for
+        the order. Return a full order that can be used directly for signing,
+        and with an included signature, passed directly to the order creation
+        endpoint.
       requestBody:
         description: The order parameters to compute a quote for.
         required: true
@@ -302,25 +320,25 @@ paths:
             schema:
               $ref: "#/components/schemas/OrderQuoteRequest"
       responses:
-        200:
+        "200":
           description: Quoted order.
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/OrderQuoteResponse"
-        400:
+        "400":
           description: Error quoting order.
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/PriceEstimationError"
-        404:
+        "404":
           description: No route was found for the specified order.
-        429:
+        "429":
           description: Too many order quotes.
-        500:
+        "500":
           description: Unexpected error quoting an order.
-  /api/v1/solver_competition/{auction_id}:
+  "/api/v1/solver_competition/{auction_id}":
     get:
       summary: Get information about a solver competition.
       description: |
@@ -332,15 +350,15 @@ paths:
           schema:
             type: integer
       responses:
-        200:
+        "200":
           description: Competition
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/SolverCompetitionResponse"
-        404:
+        "404":
           description: No competition information available for this auction id.
-  /api/v1/solver_competition/by_tx_hash/{tx_hash}:
+  "/api/v1/solver_competition/by_tx_hash/{tx_hash}":
     get:
       summary: Get information about solver competition.
       description: |
@@ -353,13 +371,13 @@ paths:
           schema:
             $ref: "#/components/schemas/TransactionHash"
       responses:
-        200:
+        "200":
           description: Competition
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/SolverCompetitionResponse"
-        404:
+        "404":
           description: No competition information available for this `tx_hash`.
   /api/v1/solver_competition/latest:
     get:
@@ -367,25 +385,26 @@ paths:
       description: |
         Returns the competition information for the last seen auction_id.
       responses:
-        200:
+        "200":
           description: Competition
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/SolverCompetitionResponse"
-        404:
+        "404":
           description: No competition information available.
   /api/v1/version:
     get:
       summary: Get the API's current deployed version.
-      description: |
-        Returns the git commit hash, branch name and release tag (code: https://github.com/cowprotocol/services).
+      description: >
+        Returns the git commit hash, branch name and release tag (code:
+        https://github.com/cowprotocol/services).
       responses:
-        200:
+        "200":
           description: Version
           content:
-            text/plain: { }
-  /api/v1/app_data/{app_data_hash}:
+            text/plain: {}
+  "/api/v1/app_data/{app_data_hash}":
     get:
       summary: Get the full `appData` from contract `appDataHash`.
       parameters:
@@ -395,19 +414,20 @@ paths:
             $ref: "#/components/schemas/AppDataHash"
           required: true
       responses:
-        200:
+        "200":
           description: Full `appData`.
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/AppDataObject"
-        404:
+        "404":
           description: No full `appData` stored for this hash.
     put:
       summary: Registers a full `appData` so it can be referenced by `appDataHash`.
-      description: |
+      description: >
         Uploads a full `appData` to orderbook so that orders created with the
-        corresponding `appDataHash` can be linked to the original full `appData`.
+        corresponding `appDataHash` can be linked to the original full
+        `appData`.
       parameters:
         - in: path
           name: app_data_hash
@@ -422,27 +442,28 @@ paths:
             schema:
               $ref: "#/components/schemas/AppDataObject"
       responses:
-        200:
+        "200":
           description: The full `appData` already exists.
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/AppDataHash"
-        201:
+        "201":
           description: The full `appData` was successfully registered.
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/AppDataHash"
-        400:
+        "400":
           description: Error validating full `appData`
-        500:
+        "500":
           description: Error storing the full `appData`
   /api/v1/app_data:
     put:
       summary: Registers a full `appData` and returns `appDataHash`.
-      description: |
-        Uploads a full `appData` to orderbook and returns the corresponding `appDataHash`.
+      description: >
+        Uploads a full `appData` to orderbook and returns the corresponding
+        `appDataHash`.
       requestBody:
         description: The `appData` document to upload.
         required: true
@@ -451,29 +472,30 @@ paths:
             schema:
               $ref: "#/components/schemas/AppDataObject"
       responses:
-        200:
+        "200":
           description: The full `appData` already exists.
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/AppDataHash"
-        201:
+        "201":
           description: The full `appData` was successfully registered.
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/AppDataHash"
-        400:
+        "400":
           description: Error validating full `appData`
-        500:
+        "500":
           description: Error storing the full `appData`
-  /api/v1/users/{address}/total_surplus:
+  "/api/v1/users/{address}/total_surplus":
     get:
-      summary: Get the total surplus earned by the user. [UNSTABLE]
-      description: |
+      summary: "Get the total surplus earned by the user. [UNSTABLE]"
+      description: |-
         ### Caution
 
-        This endpoint is under active development and should NOT be considered stable.
+        This endpoint is under active development and should NOT be considered
+        stable.
       parameters:
         - in: path
           name: address
@@ -481,7 +503,7 @@ paths:
             $ref: "#/components/schemas/Address"
           required: true
       responses:
-        200:
+        "200":
           description: The total surplus.
           content:
             application/json:
@@ -505,9 +527,11 @@ components:
       type: string
       example: '{"version":"0.9.0","metadata":{}}'
     AppDataHash:
-      description: |
+      description: >
         32 bytes encoded as hex with `0x` prefix.
-        It's expected to be the hash of the stringified JSON object representing the `appData`.
+
+        It's expected to be the hash of the stringified JSON object representing
+        the `appData`.
       type: string
       example: "0x0000000000000000000000000000000000000000000000000000000000000000"
     AppDataObject:
@@ -523,7 +547,9 @@ components:
       type: string
       example: "1234567890"
     CallData:
-      description: Some `calldata` sent to a contract in a transaction encoded as a hex with `0x` prefix.
+      description: >-
+        Some `calldata` sent to a contract in a transaction encoded as a hex
+        with `0x` prefix.
       type: string
       example: "0xca11da7a"
     TokenAmount:
@@ -534,19 +560,22 @@ components:
       type: object
       properties:
         sender:
-          description: |
-            If orders are placed as on-chain orders, the owner of the order might
-            be a smart contract, but not the user placing the order. The
+          description: >
+            If orders are placed as on-chain orders, the owner of the order
+            might be a smart contract, but not the user placing the order. The
             actual user will be provided in this field.
           allOf:
             - $ref: "#/components/schemas/Address"
         placementError:
-          description: |
-            Describes the error, if the order placement was not successful. This could
-            happen, for example, if the `validTo` is too high, or no valid quote was
-            found or generated.
+          description: >
+            Describes the error, if the order placement was not successful. This
+            could happen, for example, if the `validTo` is too high, or no valid
+            quote was found or generated.
           type: string
-          enum: [ QuoteNotFound, ValidToTooFarInFuture, PreValidationError ]
+          enum:
+            - QuoteNotFound
+            - ValidToTooFarInFuture
+            - PreValidationError
       required:
         - sender
     EthflowData:
@@ -573,34 +602,54 @@ components:
     OrderKind:
       description: Is this order a buy or sell?
       type: string
-      enum: [ buy, sell ]
+      enum:
+        - buy
+        - sell
     OrderClass:
       description: Order class.
       type: string
-      enum: [ market, limit, liquidity ]
+      enum:
+        - market
+        - limit
+        - liquidity
     SellTokenSource:
       description: Where should the `sellToken` be drawn from?
       type: string
-      enum: [ erc20, internal, external ]
+      enum:
+        - erc20
+        - internal
+        - external
     BuyTokenDestination:
       description: Where should the `buyToken` be transferred to?
       type: string
-      enum: [ erc20, internal ]
+      enum:
+        - erc20
+        - internal
     PriceQuality:
-      description: |
+      description: |-
         How good should the price estimate be?
 
         Fast: The price estimate is chosen among the fastest N price estimates.
         Optimal: The price estimate is chosen among all price estimates.
-        Verified: The price estimate is chosen among all verified/simulated price estimates.
+        Verified: The price estimate is chosen among all verified/simulated
+        price estimates.
 
-        **NOTE**: Orders are supposed to be created from `verified` or `optimal` price estimates.
+        **NOTE**: Orders are supposed to be created from `verified` or `optimal`
+        price estimates.
       type: string
-      enum: [ fast, optimal, verified ]
+      enum:
+        - fast
+        - optimal
+        - verified
     OrderStatus:
       description: The current order status.
       type: string
-      enum: [ presignaturePending, open, fulfilled, cancelled, expired ]
+      enum:
+        - presignaturePending
+        - open
+        - fulfilled
+        - cancelled
+        - expired
     OrderParameters:
       description: Order parameters.
       type: object
@@ -614,9 +663,9 @@ components:
           allOf:
             - $ref: "#/components/schemas/Address"
         receiver:
-          description: |
-            An optional Ethereum address to receive the proceeds of the trade instead
-            of the owner (i.e. the order signer).
+          description: >
+            An optional Ethereum address to receive the proceeds of the trade
+            instead of the owner (i.e. the order signer).
           allOf:
             - $ref: "#/components/schemas/Address"
           nullable: true
@@ -647,15 +696,15 @@ components:
         sellTokenBalance:
           allOf:
             - $ref: "#/components/schemas/SellTokenSource"
-          default: "erc20"
+          default: erc20
         buyTokenBalance:
           allOf:
             - $ref: "#/components/schemas/BuyTokenDestination"
-          default: "erc20"
+          default: erc20
         signingScheme:
           allOf:
             - $ref: "#/components/schemas/SigningScheme"
-          default: "eip712"
+          default: eip712
       required:
         - sellToken
         - buyToken
@@ -671,119 +720,126 @@ components:
       type: object
       properties:
         sellToken:
-          description: see `OrderParameters::sellToken`
+          description: "see `OrderParameters::sellToken`"
           allOf:
             - $ref: "#/components/schemas/Address"
         buyToken:
-          description: see `OrderParameters::buyToken`
+          description: "see `OrderParameters::buyToken`"
           allOf:
             - $ref: "#/components/schemas/Address"
         receiver:
-          description: see `OrderParameters::receiver`
+          description: "see `OrderParameters::receiver`"
           allOf:
             - $ref: "#/components/schemas/Address"
           nullable: true
         sellAmount:
-          description: see `OrderParameters::sellAmount`
+          description: "see `OrderParameters::sellAmount`"
           allOf:
             - $ref: "#/components/schemas/TokenAmount"
         buyAmount:
-          description: see `OrderParameters::buyAmount`
+          description: "see `OrderParameters::buyAmount`"
           allOf:
             - $ref: "#/components/schemas/TokenAmount"
         validTo:
-          description: see `OrderParameters::validTo`
+          description: "see `OrderParameters::validTo`"
           type: integer
         feeAmount:
-          description: see `OrderParameters::feeAmount`
+          description: "see `OrderParameters::feeAmount`"
           allOf:
             - $ref: "#/components/schemas/TokenAmount"
         kind:
-          description: see `OrderParameters::kind`
+          description: "see `OrderParameters::kind`"
           allOf:
             - $ref: "#/components/schemas/OrderKind"
         partiallyFillable:
-          description: see `OrderParameters::partiallyFillable`
+          description: "see `OrderParameters::partiallyFillable`"
           type: boolean
         sellTokenBalance:
-          description: see `OrderParameters::sellTokenBalance`
+          description: "see `OrderParameters::sellTokenBalance`"
           allOf:
             - $ref: "#/components/schemas/SellTokenSource"
-          default: "erc20"
+          default: erc20
         buyTokenBalance:
-          description: see `OrderParameters::buyTokenBalance`
+          description: "see `OrderParameters::buyTokenBalance`"
           allOf:
             - $ref: "#/components/schemas/BuyTokenDestination"
-          default: "erc20"
+          default: erc20
         signingScheme:
           $ref: "#/components/schemas/SigningScheme"
         signature:
           $ref: "#/components/schemas/Signature"
         from:
-          description: |
-            If set, the backend enforces that this address matches what is decoded as the *signer* of
-            the signature. This helps catch errors with invalid signature encodings as the backend
-            might otherwise silently work with an unexpected address that for example does not have
-            any balance.
+          description: >
+            If set, the backend enforces that this address matches what is
+            decoded as the *signer* of the signature. This helps catch errors
+            with invalid signature encodings as the backend might otherwise
+            silently work with an unexpected address that for example does not
+            have any balance.
           allOf:
             - $ref: "#/components/schemas/Address"
           nullable: true
         quoteId:
-          description: |
-            Orders can optionally include a quote ID. This way the order can be linked to a quote
-            and enable providing more metadata when analysing order slippage.
+          description: >
+            Orders can optionally include a quote ID. This way the order can be
+            linked to a quote and enable providing more metadata when analysing
+            order slippage.
           type: integer
           nullable: true
         appData:
-          description: |
-            This field comes in two forms for backward compatibility. The hash form will eventually 
-            stop being accepted.
+          description: >
+            This field comes in two forms for backward compatibility. The hash
+            form will eventually stop being accepted.
           anyOf:
             - title: Full App Data
               allOf:
                 - $ref: "#/components/schemas/AppData"
-              description: |
+              description: >-
                 **Short**:
 
-                If you do not care about `appData`, set this field to `"{}"` and make sure that the
-                order you signed for this request had its `appData` field set to
+                If you do not care about `appData`, set this field to `"{}"` and
+                make sure that the order you signed for this request had its
+                `appData` field set to
                 `0xb48d38f93eaa084033fc5970bf96e559c33c4cdc07d889ab00b4d63f9590739d`.
 
                 **Long**:
 
                 A string encoding a JSON object like `"{"hello":"world"}"`.
 
-                This field determines the smart contract order's `appData` field, which is assumed to
-                be set to the `keccak256` hash of the UTF-8 encoded bytes of this string. You must
-                ensure that the signature that is part of this request indeed signed a smart contract
-                order with the `appData` field set appropriately. If this isn't the case, signature
-                verification will fail. For easier debugging it is recommended to additionally set the
+                This field determines the smart contract order's `appData`
+                field, which is assumed to be set to the `keccak256` hash of the
+                UTF-8 encoded bytes of this string. You must ensure that the
+                signature that is part of this request indeed signed a smart
+                contract order with the `appData` field set appropriately. If
+                this isn't the case, signature verification will fail. For
+                easier debugging it is recommended to additionally set the
                 `appDataHash` field.
 
-                The field must be the encoding of a valid JSON object. The JSON object can contain
-                arbitrary application specific data (JSON key values). The optional key `backend` is
-                special. It **MUST** conform to the schema documented in `ProtocolAppData`.
+                The field must be the encoding of a valid JSON object. The JSON
+                object can contain arbitrary application specific data (JSON key
+                values). The optional key `backend` is special. It **MUST**
+                conform to the schema documented in `ProtocolAppData`.
 
-                The intended use of the other keys of the object is follow the standardized format
-                defined [here](https://github.com/cowprotocol/app-data). Example:
+                The intended use of the other keys of the object is follow the
+                standardized format defined
+                [here](https://github.com/cowprotocol/app-data). Example:
 
-                ```json
-                {
+                ```json {
                   "version": "0.7.0",
                   "appCode": "YOUR_APP_CODE",
                   "metadata": {}
-                }
-                ```
+                } ```
 
-                The total byte size of this field's UTF-8 encoded bytes is limited to 1000.
+                The total byte size of this field's UTF-8 encoded bytes is
+                limited to 1000.
               type: string
             - $ref: "#/components/schemas/AppDataHash"
         appDataHash:
-          description: |
-            May be set for debugging purposes. If set, this field is compared to what the backend
-            internally calculates as the app data hash based on the contents of `appData`. If the
-            hash does not match, an error is returned. If this field is set, then `appData` **MUST** be
-            a string encoding of a JSON object.
+          description: >
+            May be set for debugging purposes. If set, this field is compared to
+            what the backend internally calculates as the app data hash based on
+            the contents of `appData`. If the hash does not match, an error is
+            returned. If this field is set, then `appData` **MUST** be a string
+            encoding of a JSON object.
           allOf:
             - $ref: "#/components/schemas/AppDataHash"
           nullable: true
@@ -799,12 +855,10 @@ components:
         - partiallyFillable
         - signingScheme
         - signature
-    ProtocolAppData:
-      type: object
     OrderMetaData:
-      description: |
-        Extra order data that is returned to users when querying orders but not provided by users
-        when creating orders.
+      description: >
+        Extra order data that is returned to users when querying orders but not
+        provided by users when creating orders.
       type: object
       properties:
         creationDate:
@@ -818,25 +872,29 @@ components:
         uid:
           $ref: "#/components/schemas/UID"
         availableBalance:
-          description: |
-            Unused field that is currently always set to `null` and will be removed in the future.
+          description: >
+            Unused field that is currently always set to `null` and will be
+            removed in the future.
           allOf:
             - $ref: "#/components/schemas/TokenAmount"
           nullable: true
           deprecated: true
         executedSellAmount:
-          description: |
-            The total amount of `sellToken` that has been executed for this order including fees.
+          description: >
+            The total amount of `sellToken` that has been executed for this
+            order including fees.
           allOf:
             - $ref: "#/components/schemas/BigUint"
         executedSellAmountBeforeFees:
-          description: |
-            The total amount of `sellToken` that has been executed for this order without fees.
+          description: >
+            The total amount of `sellToken` that has been executed for this
+            order without fees.
           allOf:
             - $ref: "#/components/schemas/BigUint"
         executedBuyAmount:
-          description: |
-            The total amount of `buyToken` that has been executed for this order.
+          description: >
+            The total amount of `buyToken` that has been executed for this
+            order.
           allOf:
             - $ref: "#/components/schemas/BigUint"
         executedFeeAmount:
@@ -855,32 +913,34 @@ components:
           allOf:
             - $ref: "#/components/schemas/TokenAmount"
         isLiquidityOrder:
-          description: |
-            Liquidity orders are functionally the same as normal smart contract orders but are not
-            placed with the intent of actively getting traded. Instead they facilitate the
-            trade of normal orders by allowing them to be matched against liquidity orders which
-            uses less gas and can have better prices than external liquidity.
+          description: |-
+            Liquidity orders are functionally the same as normal smart contract
+            orders but are not placed with the intent of actively getting
+            traded. Instead they facilitate the trade of normal orders by
+            allowing them to be matched against liquidity orders which uses less
+            gas and can have better prices than external liquidity.
 
-            As such liquidity orders will only be used in order to improve settlement of normal
-            orders. They should not be expected to be traded otherwise and should not expect to get
-            surplus.
+            As such liquidity orders will only be used in order to improve
+            settlement of normal orders. They should not be expected to be
+            traded otherwise and should not expect to get surplus.
           type: boolean
         ethflowData:
           allOf:
             - $ref: "#/components/schemas/EthflowData"
         onchainUser:
-          description: |
+          description: >
             This represents the actual trader of an on-chain order.
 
             ### ethflow orders
 
-            In this case, the `owner` would be the `EthFlow` contract and *not* the actual trader.
+            In this case, the `owner` would be the `EthFlow` contract and *not*
+            the actual trader.
           allOf:
             - $ref: "#/components/schemas/Address"
         onchainOrderData:
-          description: |
-            There is some data only available for orders that are placed on-chain. This data
-            can be found in this object.
+          description: >
+            There is some data only available for orders that are placed
+            on-chain. This data can be found in this object.
           allOf:
             - $ref: "#/components/schemas/OnchainOrderData"
         executedSurplusFee:
@@ -889,9 +949,9 @@ components:
             - $ref: "#/components/schemas/BigUint"
           nullable: true
         fullAppData:
-          description: |
-            Full `appData`, which the contract-level `appData` is a hash of. See `OrderCreation`
-            for more information.
+          description: >
+            Full `appData`, which the contract-level `appData` is a hash of. See
+            `OrderCreation` for more information.
           type: string
           nullable: true
       required:
@@ -910,26 +970,27 @@ components:
         - $ref: "#/components/schemas/OrderCreation"
         - $ref: "#/components/schemas/OrderMetaData"
     AuctionOrder:
-      description: |
-        A solvable order included in the current batch auction. Contains the data forwarded to solvers for solving.
+      description: >
+        A solvable order included in the current batch auction. Contains the
+        data forwarded to solvers for solving.
       type: object
       properties:
         uid:
           $ref: "#/components/schemas/UID"
         sellToken:
-          description: see `OrderParameters::sellToken`
+          description: "see `OrderParameters::sellToken`"
           allOf:
             - $ref: "#/components/schemas/Address"
         buyToken:
-          description: see `OrderParameters::buyToken`
+          description: "see `OrderParameters::buyToken`"
           allOf:
             - $ref: "#/components/schemas/Address"
         sellAmount:
-          description: see `OrderParameters::sellAmount`
+          description: "see `OrderParameters::sellAmount`"
           allOf:
             - $ref: "#/components/schemas/TokenAmount"
         buyAmount:
-          description: see `OrderParameters::buyAmount`
+          description: "see `OrderParameters::buyAmount`"
           allOf:
             - $ref: "#/components/schemas/TokenAmount"
         created:
@@ -937,49 +998,52 @@ components:
           type: string
           example: "123456"
         validTo:
-          description: see `OrderParameters::validTo`
+          description: "see `OrderParameters::validTo`"
           type: integer
         kind:
-          description: see `OrderParameters::kind`
+          description: "see `OrderParameters::kind`"
           allOf:
             - $ref: "#/components/schemas/OrderKind"
         receiver:
-          description: see `OrderParameters::receiver`
+          description: "see `OrderParameters::receiver`"
           allOf:
             - $ref: "#/components/schemas/Address"
           nullable: true
         owner:
           $ref: "#/components/schemas/Address"
         partiallyFillable:
-          description: see `OrderParameters::partiallyFillable`
+          description: "see `OrderParameters::partiallyFillable`"
           type: boolean
         executed:
-          description: |
-            Currently executed amount of sell/buy token, depending on the order kind.
+          description: >
+            Currently executed amount of sell/buy token, depending on the order
+            kind.
           allOf:
             - $ref: "#/components/schemas/TokenAmount"
         preInteractions:
-          description: |
-            The pre-interactions that need to be executed before the first execution of the order.
+          description: >
+            The pre-interactions that need to be executed before the first
+            execution of the order.
           type: array
           items:
             $ref: "#/components/schemas/InteractionData"
         postInteractions:
-          description: |
-            The post-interactions that need to be executed after the execution of the order.
+          description: >
+            The post-interactions that need to be executed after the execution
+            of the order.
           type: array
           items:
             $ref: "#/components/schemas/InteractionData"
         sellTokenBalance:
-          description: see `OrderParameters::sellTokenBalance`
+          description: "see `OrderParameters::sellTokenBalance`"
           allOf:
             - $ref: "#/components/schemas/SellTokenSource"
-          default: "erc20"
+          default: erc20
         buyTokenBalance:
-          description: see `OrderParameters::buyTokenBalance`
+          description: "see `OrderParameters::buyTokenBalance`"
           allOf:
             - $ref: "#/components/schemas/BuyTokenDestination"
-          default: "erc20"
+          default: erc20
         class:
           $ref: "#/components/schemas/OrderClass"
         appData:
@@ -987,8 +1051,9 @@ components:
         signature:
           $ref: "#/components/schemas/Signature"
         protocolFees:
-          description: |
-            The fee policies that are used to compute the protocol fees for this order.
+          description: >
+            The fee policies that are used to compute the protocol fees for this
+            order.
           type: array
           items:
             $ref: "#/components/schemas/FeePolicy"
@@ -1025,20 +1090,23 @@ components:
       properties:
         id:
           type: integer
-          description: |
-            The unique identifier of the auction. Increment whenever the backend creates a new auction.
+          description: >
+            The unique identifier of the auction. Increment whenever the backend
+            creates a new auction.
         block:
           type: integer
-          description: |
-            The block number for the auction. Orders and prices are guaranteed to be valid on this
-            block. Proposed settlements should be valid for this block as well.
+          description: >
+            The block number for the auction. Orders and prices are guaranteed
+            to be valid on this block. Proposed settlements should be valid for
+            this block as well.
         latestSettlementBlock:
           type: integer
-          description: |
+          description: >
             The latest block on which a settlement has been processed.
 
-            **NOTE**: Under certain conditions it is possible for a settlement to have been mined as
-            part of `block` but not have yet been processed.
+            **NOTE**: Under certain conditions it is possible for a settlement
+            to have been mined as part of `block` but not have yet been
+            processed.
         orders:
           type: array
           items:
@@ -1051,8 +1119,10 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/Address"
-          description: |
-            List of addresses on whose surplus will count towards the objective value of their solution (unlike other orders that were created by the solver).
+          description: >
+            List of addresses on whose surplus will count towards the objective
+            value of their solution (unlike other orders that were created by
+            the solver).
     CompetitionAuction:
       description: |
         The components that describe a batch auction for the solver competition.
@@ -1090,9 +1160,12 @@ components:
             - traded
             - cancelled
         value:
-          description: |
-            A list of solvers who participated in the latest competition, sorted by score in ascending order, where the last element is the winner.
-            The presence of executed amounts defines whether the solver provided a solution for the desired order.
+          description: |-
+            A list of solvers who participated in the latest competition, sorted
+            by score in ascending order, where the last element is the winner.
+
+            The presence of executed amounts defines whether the solver provided
+            a solution for the desired order.
           type: array
           items:
             type: object
@@ -1107,17 +1180,19 @@ components:
       required:
         - type
     AuctionPrices:
-      description: |
-        The reference prices for all traded tokens in the auction as a mapping from token
-        addresses to a price denominated in native token (i.e. 1e18 represents a token that
-        trades one to one with the native token). These prices are used for solution competition
-        for computing surplus and converting fees to native token.
+      description: >
+        The reference prices for all traded tokens in the auction as a mapping
+        from token addresses to a price denominated in native token (i.e. 1e18
+        represents a token that trades one to one with the native token). These
+        prices are used for solution competition for computing surplus and
+        converting fees to native token.
       type: object
       additionalProperties:
         $ref: "#/components/schemas/BigUint"
     OrderCancellations:
-      description: |
-        EIP-712 signature of struct OrderCancellations { orderUid: bytes[] } from the order's owner.
+      description: >
+        EIP-712 signature of struct OrderCancellations { orderUid: bytes[] }
+        from the order's owner.
       type: object
       properties:
         orderUids:
@@ -1142,7 +1217,7 @@ components:
       type: object
       properties:
         signature:
-          description: "OrderCancellation signed by owner"
+          description: OrderCancellation signed by owner
           allOf:
             - $ref: "#/components/schemas/EcdsaSignature"
         signingScheme:
@@ -1151,8 +1226,9 @@ components:
         - signature
         - signingScheme
     Trade:
-      description: |
-        Trade data such as executed amounts, fees, `orderUid` and `block` number.
+      description: >
+        Trade data such as executed amounts, fees, `orderUid` and `block`
+        number.
       type: object
       properties:
         blockNumber:
@@ -1178,11 +1254,15 @@ components:
           allOf:
             - $ref: "#/components/schemas/Address"
         sellAmount:
-          description: Total amount of `sellToken` that has been executed for this trade (including fees).
+          description: >-
+            Total amount of `sellToken` that has been executed for this trade
+            (including fees).
           allOf:
             - $ref: "#/components/schemas/TokenAmount"
         sellAmountBeforeFees:
-          description: The total amount of `sellToken` that has been executed for this order without fees.
+          description: >-
+            The total amount of `sellToken` that has been executed for this
+            order without fees.
           allOf:
             - $ref: "#/components/schemas/BigUint"
         buyAmount:
@@ -1190,13 +1270,16 @@ components:
           allOf:
             - $ref: "#/components/schemas/TokenAmount"
         txHash:
-          description: "Transaction hash of the corresponding settlement transaction containing the trade (if available)."
+          description: >-
+            Transaction hash of the corresponding settlement transaction
+            containing the trade (if available).
           allOf:
             - $ref: "#/components/schemas/TransactionHash"
           nullable: true
         executedProtocolFees:
-          description: | 
-           Executed protocol fees for this trade, together with the fee policies used. Listed in the order they got applied.
+          description: >
+            Executed protocol fees for this trade, together with the fee
+            policies used. Listed in the order they got applied.
           type: array
           items:
             $ref: "#/components/schemas/ExecutedProtocolFee"
@@ -1212,21 +1295,29 @@ components:
         - buyAmount
         - txHash
     UID:
-      description: |
-        Unique identifier for the order: 56 bytes encoded as hex with `0x` prefix.
-        Bytes 0..32 are the order digest, bytes 30..52 the owner address and bytes
-        52..56 the expiry (`validTo`) as a `uint32` unix epoch timestamp.
+      description: |-
+        Unique identifier for the order: 56 bytes encoded as hex with `0x`
+        prefix.
+
+        Bytes 0..32 are the order digest, bytes 30..52 the owner address and
+        bytes 52..56 the expiry (`validTo`) as a `uint32` unix epoch timestamp.
       type: string
-      # ENS order
-      example: "0xff2e2e54d178997f173266817c1e9ed6fee1a1aae4b43971c53b543cffcc2969845c6f5599fbb25dbdd1b9b013daf85c03f3c63763e4bc4a"
+      example: >-
+        0xff2e2e54d178997f173266817c1e9ed6fee1a1aae4b43971c53b543cffcc2969845c6f5599fbb25dbdd1b9b013daf85c03f3c63763e4bc4a
     SigningScheme:
       description: How was the order signed?
       type: string
-      enum: [ eip712, ethsign, presign, eip1271 ]
+      enum:
+        - eip712
+        - ethsign
+        - presign
+        - eip1271
     EcdsaSigningScheme:
       description: How was the order signed?
       type: string
-      enum: [ eip712, ethsign ]
+      enum:
+        - eip712
+        - ethsign
     Signature:
       description: A signature.
       oneOf:
@@ -1235,46 +1326,45 @@ components:
     EcdsaSignature:
       description: 65 bytes encoded as hex with `0x` prefix. `r || s || v` from the spec.
       type: string
-      example: "0x0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
+      example: >-
+        0x0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000
     PreSignature:
       description: Empty signature bytes. Used for "presign" signatures.
       type: string
-      example: "0x"
+      example: 0x
     OrderPostError:
       type: object
       properties:
         errorType:
           type: string
           enum:
-            [
-              DuplicatedOrder,
-              QuoteNotFound,
-              QuoteNotVerified,
-              InvalidQuote,
-              MissingFrom,
-              WrongOwner,
-              InvalidEip1271Signature,
-              InsufficientBalance,
-              InsufficientAllowance,
-              InvalidSignature,
-              SellAmountOverflow,
-              TransferSimulationFailed,
-              ZeroAmount,
-              IncompatibleSigningScheme,
-              TooManyLimitOrders,
-              TooMuchGas,
-              UnsupportedBuyTokenDestination,
-              UnsupportedSellTokenSource,
-              UnsupportedOrderType,
-              InsufficientValidTo,
-              ExcessiveValidTo,
-              InvalidNativeSellToken,
-              SameBuyAndSellToken,
-              UnsupportedToken,
-              InvalidAppData,
-              AppDataHashMismatch,
-              AppdataFromMismatch,
-            ]
+            - DuplicatedOrder
+            - QuoteNotFound
+            - QuoteNotVerified
+            - InvalidQuote
+            - MissingFrom
+            - WrongOwner
+            - InvalidEip1271Signature
+            - InsufficientBalance
+            - InsufficientAllowance
+            - InvalidSignature
+            - SellAmountOverflow
+            - TransferSimulationFailed
+            - ZeroAmount
+            - IncompatibleSigningScheme
+            - TooManyLimitOrders
+            - TooMuchGas
+            - UnsupportedBuyTokenDestination
+            - UnsupportedSellTokenSource
+            - UnsupportedOrderType
+            - InsufficientValidTo
+            - ExcessiveValidTo
+            - InvalidNativeSellToken
+            - SameBuyAndSellToken
+            - UnsupportedToken
+            - InvalidAppData
+            - AppDataHashMismatch
+            - AppdataFromMismatch
         description:
           type: string
       required:
@@ -1286,15 +1376,13 @@ components:
         errorType:
           type: string
           enum:
-            [
-              InvalidSignature,
-              WrongOwner,
-              OrderNotFound,
-              AlreadyCancelled,
-              OrderFullyExecuted,
-              OrderExpired,
-              OnChainOrder,
-            ]
+            - InvalidSignature
+            - WrongOwner
+            - OrderNotFound
+            - AlreadyCancelled
+            - OrderFullyExecuted
+            - OrderExpired
+            - OnChainOrder
         description:
           type: string
       required:
@@ -1306,12 +1394,10 @@ components:
         errorType:
           type: string
           enum:
-            [
-              "QuoteNotVerified",
-              "UnsupportedToken",
-              "ZeroAmount",
-              "UnsupportedOrderType",
-            ]
+            - QuoteNotVerified
+            - UnsupportedToken
+            - ZeroAmount
+            - UnsupportedOrderType
         description:
           type: string
       required:
@@ -1321,15 +1407,17 @@ components:
       description: The buy or sell side when quoting an order.
       oneOf:
         - type: object
-          description: Quote a sell order given the final total `sellAmount` including fees.
+          description: >-
+            Quote a sell order given the final total `sellAmount` including
+            fees.
           properties:
             kind:
               allOf:
                 - $ref: "#/components/schemas/OrderQuoteSideKindSell"
             sellAmountBeforeFee:
-              description: |
-                The total amount that is available for the order. From this value, the fee
-                is deducted and the buy amount is calculated.
+              description: >
+                The total amount that is available for the order. From this
+                value, the fee is deducted and the buy amount is calculated.
               allOf:
                 - $ref: "#/components/schemas/TokenAmount"
           required:
@@ -1363,10 +1451,12 @@ components:
             - buyAmountAfterFee
     OrderQuoteSideKindSell:
       type: string
-      enum: [ sell ]
+      enum:
+        - sell
     OrderQuoteSideKindBuy:
       type: string
-      enum: [ buy ]
+      enum:
+        - buy
     OrderQuoteValidity:
       description: The validity for the order.
       oneOf:
@@ -1398,50 +1488,59 @@ components:
               allOf:
                 - $ref: "#/components/schemas/Address"
             receiver:
-              description: |
-                An optional address to receive the proceeds of the trade instead of the
+              description: >
+                An optional address to receive the proceeds of the trade instead
+                of the
+
                 `owner` (i.e. the order signer).
               allOf:
                 - $ref: "#/components/schemas/Address"
               nullable: true
             appData:
-              description: |
+              description: |-
                 AppData which will be assigned to the order.
-                Expects either a string JSON doc as defined on [AppData](https://github.com/cowprotocol/app-data) or a
-                hex encoded string for backwards compatibility.
-                When the first format is used, it's possible to provide the derived appDataHash field.
+
+                Expects either a string JSON doc as defined on
+                [AppData](https://github.com/cowprotocol/app-data) or a hex
+                encoded string for backwards compatibility.
+
+                When the first format is used, it's possible to provide the
+                derived appDataHash field.
               oneOf:
                 - $ref: "#/components/schemas/AppData"
                 - $ref: "#/components/schemas/AppDataHash"
             appDataHash:
-              description: |
+              description: |-
                 The hash of the stringified JSON appData doc.
-                If present, `appData` field must be set with the aforementioned data where this hash is derived from.
+
+                If present, `appData` field must be set with the aforementioned
+                data where this hash is derived from.
+
                 In case they differ, the call will fail.
               anyOf:
                 - $ref: "#/components/schemas/AppDataHash"
             sellTokenBalance:
               allOf:
                 - $ref: "#/components/schemas/SellTokenSource"
-              default: "erc20"
+              default: erc20
             buyTokenBalance:
               allOf:
                 - $ref: "#/components/schemas/BuyTokenDestination"
-              default: "erc20"
+              default: erc20
             from:
               $ref: "#/components/schemas/Address"
             priceQuality:
               allOf:
                 - $ref: "#/components/schemas/PriceQuality"
-              default: "verified"
+              default: verified
             signingScheme:
               allOf:
                 - $ref: "#/components/schemas/SigningScheme"
-              default: "eip712"
+              default: eip712
             onchainOrder:
-              description: |
-                Flag to signal whether the order is intended for on-chain order placement. Only valid
-                for non ECDSA-signed orders."
+              description: >
+                Flag to signal whether the order is intended for on-chain order
+                placement. Only valid for non ECDSA-signed orders."
               default: false
           required:
             - sellToken
@@ -1464,13 +1563,14 @@ components:
           type: string
           example: "1985-03-10T18:35:18.814523Z"
         id:
-          description: |
-            Quote ID linked to a quote to enable providing more metadata when analysing
-            order slippage.
+          description: >
+            Quote ID linked to a quote to enable providing more metadata when
+            analysing order slippage.
           type: integer
         verified:
-          description: |
-            Whether it was possible to verify that the quoted amounts are accurate using a simulation.
+          description: >
+            Whether it was possible to verify that the quoted amounts are
+            accurate using a simulation.
           type: boolean
       required:
         - quote
@@ -1491,7 +1591,9 @@ components:
           nullable: true
           allOf:
             - $ref: "#/components/schemas/TransactionHash"
-          description: The hash of the transaction that the winning solution of this info was submitted in.
+          description: >-
+            The hash of the transaction that the winning solution of this info
+            was submitted in.
         gasPrice:
           type: number
           description: Gas price used for ranking solutions.
@@ -1514,9 +1616,11 @@ components:
           description: Name of the solver.
         solverAddress:
           type: string
-          description: |
+          description: |-
             The address used by the solver to execute the settlement on-chain.
-            This field is missing for old settlements, the zero address has been used instead.
+
+            This field is missing for old settlements, the zero address has been
+            used instead.
         objective:
           type: object
           properties:
@@ -1534,16 +1638,19 @@ components:
         score:
           allOf:
             - $ref: "#/components/schemas/BigUint"
-          description: |
-            The score of the current auction as defined in [CIP-20](https://snapshot.org/#/cow.eth/proposal/0x2d3f9bd1ea72dca84b03e97dda3efc1f4a42a772c54bd2037e8b62e7d09a491f).
+          description: >
+            The score of the current auction as defined in
+            [CIP-20](https://snapshot.org/#/cow.eth/proposal/0x2d3f9bd1ea72dca84b03e97dda3efc1f4a42a772c54bd2037e8b62e7d09a491f).
+
             It is `null` for old auctions.
           nullable: true
         clearingPrices:
           type: object
           additionalProperties:
             $ref: "#/components/schemas/BigUint"
-          description: |
-            The prices of tokens for settled user orders as passed to the settlement contract.
+          description: >
+            The prices of tokens for settled user orders as passed to the
+            settlement contract.
         orders:
           type: array
           description: Touched orders.
@@ -1596,7 +1703,7 @@ components:
           allOf:
             - $ref: "#/components/schemas/TokenAmount"
         fee:
-          description: The amount that needs to be paid, denominated in the sell token.
+          description: "The amount that needs to be paid, denominated in the sell token."
           allOf:
             - $ref: "#/components/schemas/TokenAmount"
     Surplus:
@@ -1605,13 +1712,13 @@ components:
       properties:
         factor:
           type: number
-          minimum: 0.0
-          maximum: 1.0
+          minimum: 0
+          maximum: 1
           exclusiveMaximum: true
         maxVolumeFactor:
           type: number
-          minimum: 0.0
-          maximum: 1.0
+          minimum: 0
+          maximum: 1
           exclusiveMaximum: true
       required:
         - factor
@@ -1622,24 +1729,26 @@ components:
       properties:
         factor:
           type: number
-          minimum: 0.0
-          maximum: 1.0
+          minimum: 0
+          maximum: 1
           exclusiveMaximum: true
       required:
         - factor
     PriceImprovement:
-      description: The protocol fee is taken as a percent of the order price improvement which is a difference between the executed price and the best quote.
+      description: >-
+        The protocol fee is taken as a percent of the order price improvement
+        which is a difference between the executed price and the best quote.
       type: object
       properties:
         factor:
           type: number
-          minimum: 0.0
-          maximum: 1.0
+          minimum: 0
+          maximum: 1
           exclusiveMaximum: true
         maxVolumeFactor:
           type: number
-          minimum: 0.0
-          maximum: 1.0
+          minimum: 0
+          maximum: 1
           exclusiveMaximum: true
         quote:
           description: The best quote received.
@@ -1659,10 +1768,12 @@ components:
       type: object
       properties:
         policy:
-          $ref: '#/components/schemas/FeePolicy'
+          $ref: "#/components/schemas/FeePolicy"
         amount:
-          description: "Fee amount taken"
-          $ref: "#/components/schemas/TokenAmount"
+          allOf:
+            - description: Fee amount taken
+            - $ref: "#/components/schemas/TokenAmount"
         token:
-          description: "The token in which the fee is taken"
-          $ref: "#/components/schemas/Address"
+          allOf:
+            - description: The token in which the fee is taken
+            - $ref: "#/components/schemas/Address"

--- a/crates/solvers/openapi.yml
+++ b/crates/solvers/openapi.yml
@@ -5,7 +5,6 @@ info:
     The API implemented by solver engines interacting with the reference driver
     implementation.
   version: 0.0.1
-
 paths:
   /solve:
     post:
@@ -18,7 +17,7 @@ paths:
             schema:
               $ref: "#/components/schemas/Auction"
       responses:
-        200:
+        "200":
           description: Auction successfully solved.
           content:
             application/json:
@@ -28,16 +27,17 @@ paths:
                   - solutions
                 properties:
                   solutions:
-                    description: |
-                      Proposed solutions to settle some of the orders in the auction.
+                    description: >
+                      Proposed solutions to settle some of the orders in the
+                      auction.
                     type: array
                     items:
                       $ref: "#/components/schemas/Solution"
-        400:
+        "400":
           description: There is something wrong with the request.
-        429:
+        "429":
           description: The solver cannot keep up. It is too busy to handle more requests.
-        500:
+        "500":
           description: Something went wrong when handling the request.
   /notify:
     post:
@@ -50,9 +50,13 @@ paths:
             schema:
               type: object
               additionalProperties: true
-              description: |
-                A notification that informs the solver how its solution performed in the auction.
-                Depending on the notification type additional meta data may be attached but this
+              description: |-
+                A notification that informs the solver how its solution
+                performed in the auction.
+
+                Depending on the notification type additional meta data may be
+                attached but this
+
                 is not guaranteed to be stable.
               properties:
                 auctionId:
@@ -61,35 +65,33 @@ paths:
                     for.
                   type: string
                 solutionId:
-                  description: |
-                    The solution ID within the auction for which the notification applies
+                  description: >
+                    The solution ID within the auction for which the
+                    notification applies
                   type: number
                 kind:
                   description: |
                     The kind of notification.
                   type: string
                   enum:
-                    [
-                      timeout,
-                      emptySolution,
-                      duplicatedSolutionId,
-                      simulationFailed,
-                      invalidClearingPrices,
-                      missingPrice,
-                      invalidExecutedAmount,
-                      nonBufferableTokensUsed,
-                      solverAccountInsufficientBalance,
-                      success,
-                      revert,
-                      driverError,
-                      cancelled,
-                      fail,
-                      postprocessingTimedOut,
-                    ]
+                    - timeout
+                    - emptySolution
+                    - duplicatedSolutionId
+                    - simulationFailed
+                    - invalidClearingPrices
+                    - missingPrice
+                    - invalidExecutedAmount
+                    - nonBufferableTokensUsed
+                    - solverAccountInsufficientBalance
+                    - success
+                    - revert
+                    - driverError
+                    - cancelled
+                    - fail
+                    - postprocessingTimedOut
       responses:
-        200:
+        "200":
           description: notification successfully received.
-
 components:
   schemas:
     Address:
@@ -97,73 +99,62 @@ components:
         An Ethereum public address.
       type: string
       example: "0x0000000000000000000000000000000000000000"
-
     Token:
       description: |
         An ERC20 token address.
       type: string
       example: "0xDEf1CA1fb7FBcDC777520aa7f396b4E015F497aB"
-
     TokenAmount:
       description: |
         Amount of an ERC20 token. 256 bit unsigned integer in decimal notation.
       type: string
       example: "1234567890"
-
     U256:
       description: |
         256 bit unsigned integer in decimal notation.
       type: string
       example: "1234567890"
-
     U128:
       description: |
         128 bit unsigned integer in decimal notation.
       type: string
       example: "1234567890"
-
     I128:
       description: |
         128 bit signed integer in decimal notation.
       type: string
       example: "-1234567890"
-
     I32:
       description: |
         32 bit signed integer in decimal notation.
       type: number
       example: -12345
-
     BalancerPoolId:
-      description: |
-        A hex-encoded 32 byte string containing the pool address (0..20), the pool specialization (20..22) and the poolnonce (22..32).
+      description: >
+        A hex-encoded 32 byte string containing the pool address (0..20), the
+        pool specialization (20..22) and the poolnonce (22..32).
       type: string
       example: "0xc88c76dd8b92408fe9bea1a54922a31e232d873c0002000000000000000005b2"
-
     BigInt:
       description: |
         An arbitrary-precision integer value.
       type: string
       example: "1234567890"
-
     Decimal:
       description: |
         An arbitrary-precision decimal value.
       type: string
       example: "13.37"
-
     NativePrice:
       description: |
         The price in wei of the native token (Ether on Mainnet for example) to
         buy 10**18 of a token.
       type: string
       example: "1234567890"
-
     DateTime:
       description: An ISO-8601 formatted date-time.
       type: string
       example: "1970-01-01T00:00:00.000Z"
-
     TokenInfo:
       description: |
         Information about a token relevant to the auction.
@@ -201,7 +192,6 @@ components:
             optimizations for this token by not routing the trades via an AMM,
             and instead use its available balances, as specified by CIP-2.
           type: boolean
-
     Asset:
       description: |
         A token address with an amount.
@@ -214,7 +204,6 @@ components:
           $ref: "#/components/schemas/Token"
         amount:
           $ref: "#/components/schemas/TokenAmount"
-
     OrderUid:
       description: |
         Unique identifier for the order. Order UIDs are 56 bytes long, where
@@ -222,51 +211,58 @@ components:
         [32, 52) represent the owner address and bytes [52, 56) represent the
         order's `validTo` field.
       type: string
-      example: "0x30cff40d9f60caa68a37f0ee73253ad6ad72b45580c945fe3ab67596476937197854163b1b0d24e77dca702b97b5cc33e0f83dcb626122a6"
-
+      example: >-
+        0x30cff40d9f60caa68a37f0ee73253ad6ad72b45580c945fe3ab67596476937197854163b1b0d24e77dca702b97b5cc33e0f83dcb626122a6
     OrderKind:
       description: |
         The trading side of the order.
       type: string
-      enum: [ sell, buy ]
-
+      enum:
+        - sell
+        - buy
     OrderClass:
       description: |
         How the CoW Protocol order was classified.
       type: string
-      enum: [ market, limit ]
-
+      enum:
+        - market
+        - limit
     AppData:
       description: |
         32 bytes of arbitrary application specific data that can be added to an
         order. This can also be used to ensure uniqueness between two orders
         with otherwise the exact same parameters.
       example: "0x0000000000000000000000000000000000000000000000000000000000000000"
-
     SellTokenBalance:
       description: |
         Where should the sell token be drawn from?
       type: string
-      enum: [ erc20, internal, external ]
-
+      enum:
+        - erc20
+        - internal
+        - external
     BuyTokenBalance:
       description: |
         Where should the buy token be transferred to?
       type: string
-      enum: [ erc20, internal ]
-
+      enum:
+        - erc20
+        - internal
     SigningScheme:
       description: |
         How was the order signed?
       type: string
-      enum: [ eip712, ethSign, preSign, eip1271 ]
-
+      enum:
+        - eip712
+        - ethSign
+        - preSign
+        - eip1271
     Signature:
       description: |
         Signature bytes.
       type: string
-      example: "0x0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
-
+      example: >-
+        0x0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000
     Order:
       description: |
         CoW Protocol order information relevant to execution.
@@ -326,11 +322,11 @@ components:
         sellTokenSource:
           allOf:
             - $ref: "#/components/schemas/SellTokenBalance"
-          default: "erc20"
+          default: erc20
         buyTokenDestination:
           allOf:
             - $ref: "#/components/schemas/BuyTokenBalance"
-          default: "erc20"
+          default: erc20
         class:
           $ref: "#/components/schemas/OrderClass"
         appData:
@@ -348,37 +344,45 @@ components:
         - $ref: "#/components/schemas/PriceImprovement"
         - $ref: "#/components/schemas/VolumeFee"
     SurplusFee:
-      description: |
-        If the order receives more than limit price, pay the protocol a factor of the difference.
+      description: >
+        If the order receives more than limit price, pay the protocol a factor
+        of the difference.
       type: object
       properties:
         kind:
           type: string
-          enum: [ "surplus" ]
+          enum:
+            - surplus
         maxVolumeFactor:
           description: Never charge more than that percentage of the order volume.
           type: number
-          minimum: 0.0
+          minimum: 0
           maximum: 0.99999
           example: 0.05
         factor:
-          description: The factor of the user surplus that the protocol will request from the solver after settling the order
+          description: >
+            The factor of the user surplus that the protocol will request from
+            the solver after settling the order
           type: number
           example: 0.5
     PriceImprovement:
-      description: |
-        A cut from the price improvement over the best quote is taken as a protocol fee.
+      description: >
+        A cut from the price improvement over the best quote is taken as a
+        protocol fee.
       type: object
       properties:
         kind:
           type: string
-          enum: [ "priceImprovement" ]
+          enum:
+            - priceImprovement
         maxVolumeFactor:
           description: Never charge more than that percentage of the order volume.
           type: number
           example: 0.01
         factor:
-          description: The factor of the user surplus that the protocol will request from the solver after settling the order
+          description: >
+            The factor of the user surplus that the protocol will request from
+            the solver after settling the order
           type: number
           example: 0.5
         quote:
@@ -388,9 +392,12 @@ components:
       properties:
         kind:
           type: string
-          enum: [ "volume" ]
+          enum:
+            - volume
         factor:
-          description: The fraction of the order's volume that the protocol will request from the solver after settling the order.
+          description: >
+            The fraction of the order's volume that the protocol will request
+            from the solver after settling the order.
           type: number
           example: 0.5
     Quote:
@@ -411,7 +418,6 @@ components:
       properties:
         balance:
           $ref: "#/components/schemas/TokenAmount"
-
     ConstantProductPool:
       description: |
         A UniswapV2-like constant product liquidity pool for a token pair.
@@ -424,7 +430,8 @@ components:
       properties:
         kind:
           type: string
-          enum: [ constantProduct ]
+          enum:
+            - constantProduct
         tokens:
           description: |
             A mapping of token address to its reserve amounts.
@@ -435,7 +442,6 @@ components:
           $ref: "#/components/schemas/Decimal"
         router:
           $ref: "#/components/schemas/Address"
-
     WeightedProductPool:
       description: |
         A Balancer-like weighted product liquidity pool of N tokens.
@@ -448,7 +454,8 @@ components:
       properties:
         kind:
           type: string
-          enum: [ weightedProduct ]
+          enum:
+            - weightedProduct
         tokens:
           description: |
             A mapping of token address to its reserve amounts with weights.
@@ -468,10 +475,11 @@ components:
           $ref: "#/components/schemas/Decimal"
         version:
           type: string
-          enum: [ "v0", "v3Plus" ]
+          enum:
+            - v0
+            - v3Plus
         balancer_pool_id:
           $ref: "#/components/schemas/BalancerPoolId"
-
     StablePool:
       description: |
         A Curve-like stable pool of N tokens.
@@ -485,7 +493,8 @@ components:
       properties:
         kind:
           type: string
-          enum: [ stable ]
+          enum:
+            - stable
         tokens:
           description: |
             A mapping of token address to token balance and scaling rate.
@@ -505,7 +514,6 @@ components:
           $ref: "#/components/schemas/Decimal"
         balancer_pool_id:
           $ref: "#/components/schemas/BalancerPoolId"
-
     ConcentratedLiquidityPool:
       description: |
         A UniswapV3-like concentrated liquidity pool of 2 tokens.
@@ -522,7 +530,8 @@ components:
       properties:
         kind:
           type: string
-          enum: [ concentratedLiquidity ]
+          enum:
+            - concentratedLiquidity
         tokens:
           type: array
           items:
@@ -543,7 +552,6 @@ components:
           $ref: "#/components/schemas/Decimal"
         router:
           $ref: "#/components/schemas/Address"
-
     ForeignLimitOrder:
       description: |
         A 0x-like limit order external to CoW Protocol.
@@ -558,7 +566,8 @@ components:
       properties:
         kind:
           type: string
-          enum: [ limitOrder ]
+          enum:
+            - limitOrder
         makerToken:
           $ref: "#/components/schemas/Token"
         takerToken:
@@ -569,7 +578,6 @@ components:
           $ref: "#/components/schemas/TokenAmount"
         takerTokenFeeAmount:
           $ref: "#/components/schemas/TokenAmount"
-
     LiquidityParameters:
       oneOf:
         - $ref: "#/components/schemas/ConstantProductPool"
@@ -577,7 +585,6 @@ components:
         - $ref: "#/components/schemas/StablePool"
         - $ref: "#/components/schemas/ConcentratedLiquidityPool"
         - $ref: "#/components/schemas/ForeignLimitOrder"
-
     Liquidity:
       description: |
         On-chain liquidity that can be used in a solution. This liquidity is
@@ -610,7 +617,6 @@ components:
                 liquidity on-chain.
               allOf:
                 - $ref: "#/components/schemas/BigInt"
-
     Auction:
       description: |
         The abstract auction to be solved by the searcher.
@@ -665,9 +671,10 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/Address"
-          description: |
-            List of addresses on whose surplus will count towards the objective value of their solution (unlike other orders that were created by the solver).
-
+          description: >
+            List of addresses on whose surplus will count towards the objective
+            value of their solution (unlike other orders that were created by
+            the solver).
     JitOrder:
       description: |
         A just-in-time liquidity order included in a settlement. These will
@@ -711,7 +718,6 @@ components:
           $ref: "#/components/schemas/SigningScheme"
         signature:
           $ref: "#/components/schemas/Signature"
-
     Fulfillment:
       description: |
         A trade which fulfills an order from the auction.
@@ -722,7 +728,8 @@ components:
       properties:
         kind:
           type: string
-          enum: [ fulfillment ]
+          enum:
+            - fulfillment
         order:
           description: |
             A reference by UID of the order to execute in a solution. The order
@@ -740,7 +747,6 @@ components:
             "sellToken" for sell orders, and "buyToken" for buy orders.
           allOf:
             - $ref: "#/components/schemas/TokenAmount"
-
     JitTrade:
       description: |
         A trade with a JIT order.
@@ -752,7 +758,8 @@ components:
       properties:
         kind:
           type: string
-          enum: [ jit ]
+          enum:
+            - jit
         executedAmount:
           description: |
             The amount of the order that was executed. This is denoted in
@@ -778,7 +785,6 @@ components:
       oneOf:
         - $ref: "#/components/schemas/Fulfillment"
         - $ref: "#/components/schemas/JitTrade"
-
     LiquidityInteraction:
       description: |
         Interaction representing the execution of liquidity that was passed in
@@ -794,7 +800,8 @@ components:
       properties:
         kind:
           type: string
-          enum: [ liquidity ]
+          enum:
+            - liquidity
         id:
           description: |
             The ID of executed liquidity provided in the auction input.
@@ -807,7 +814,6 @@ components:
           $ref: "#/components/schemas/TokenAmount"
         outputAmount:
           $ref: "#/components/schemas/TokenAmount"
-
     Allowance:
       description: |
         An ERC20 allowance from the settlement contract to some spender that is
@@ -824,7 +830,6 @@ components:
           $ref: "#/components/schemas/Address"
         amount:
           $ref: "#/components/schemas/TokenAmount"
-
     CustomInteraction:
       description: |
         A searcher-specified custom interaction to be included in the final
@@ -840,7 +845,8 @@ components:
       properties:
         kind:
           type: string
-          enum: [ custom ]
+          enum:
+            - custom
         target:
           $ref: "#/components/schemas/Address"
         value:
@@ -864,7 +870,6 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/Asset"
-
     Interaction:
       description: |
         An interaction to execute as part of a settlement.
@@ -879,7 +884,6 @@ components:
         - oneOf:
             - $ref: "#/components/schemas/LiquidityInteraction"
             - $ref: "#/components/schemas/CustomInteraction"
-
     InteractionData:
       type: object
       properties:
@@ -890,7 +894,6 @@ components:
         callData:
           description: Hex encoded bytes with `0x` prefix.
           type: string
-
     Solution:
       description: |
         A computed solution for a given auction.
@@ -902,7 +905,9 @@ components:
         - interactions
       properties:
         id:
-          description: An opaque identifier for the solution. This is a solver generated number that is unique across multiple solutions within the auction.
+          description: >
+            An opaque identifier for the solution. This is a solver generated
+            number that is unique across multiple solutions within the auction.
           type: number
         prices:
           description: |
@@ -951,6 +956,8 @@ components:
             $ref: "#/components/schemas/CallData"
           description: The call data to be used for the interaction.
     CallData:
-      description: Some `calldata` sent to a contract in a transaction encoded as a hex with `0x` prefix.
+      description: >
+        Some `calldata` sent to a contract in a transaction encoded as a hex
+        with `0x` prefix.
       type: string
       example: "0xca11da7a"


### PR DESCRIPTION
## Description

Adds the `spectral` linter. `prettier` should be used as formatter.

The formatter is applied in https://github.com/cowprotocol/services/pull/3144.

~~`@redocly/openapi-cli` is chosen because it provides both a linter and a built-in formatter while other linters suggest using `prettier`, which provides less robust option compared to the `openapi-cli`.~~ Since the tool is depricated, switched to `spectral` + `prettier`.

## Related Issues

Fixes #2971