### PR TITLE
Align with the updated Rust

### DIFF
--- a/crates/app-data/src/app_data.rs
+++ b/crates/app-data/src/app_data.rs
@@ -175,7 +175,7 @@ impl<'de> Deserialize<'de> for OrderUid {
         D: Deserializer<'de>,
     {
         struct Visitor {}
-        impl<'de> de::Visitor<'de> for Visitor {
+        impl de::Visitor<'_> for Visitor {
             type Value = OrderUid;
 
             fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {

--- a/crates/autopilot/src/infra/solvers/dto/solve.rs
+++ b/crates/autopilot/src/infra/solvers/dto/solve.rs
@@ -188,7 +188,7 @@ where
 {
     struct SolutionIdVisitor;
 
-    impl<'de> serde::de::Visitor<'de> for SolutionIdVisitor {
+    impl serde::de::Visitor<'_> for SolutionIdVisitor {
         type Value = u64;
 
         fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {

--- a/crates/chain/src/lib.rs
+++ b/crates/chain/src/lib.rs
@@ -129,7 +129,7 @@ impl<'de> Deserialize<'de> for Chain {
     {
         struct NetworkVisitor;
 
-        impl<'de> de::Visitor<'de> for NetworkVisitor {
+        impl de::Visitor<'_> for NetworkVisitor {
             type Value = Chain;
 
             fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {

--- a/crates/driver/src/tests/setup/mod.rs
+++ b/crates/driver/src/tests/setup/mod.rs
@@ -1194,7 +1194,7 @@ impl<'a> Solve<'a> {
     }
 }
 
-impl<'a> SolveOk<'a> {
+impl SolveOk<'_> {
     fn solutions(&self) -> Vec<serde_json::Value> {
         #[derive(serde::Deserialize)]
         struct Body {

--- a/crates/driver/src/util/serialize/hex.rs
+++ b/crates/driver/src/util/serialize/hex.rs
@@ -11,7 +11,7 @@ impl<'de> DeserializeAs<'de, Vec<u8>> for Hex {
     fn deserialize_as<D: Deserializer<'de>>(deserializer: D) -> Result<Vec<u8>, D::Error> {
         struct Visitor;
 
-        impl<'de> de::Visitor<'de> for Visitor {
+        impl de::Visitor<'_> for Visitor {
             type Value = Vec<u8>;
 
             fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
@@ -50,7 +50,7 @@ impl<'de, const N: usize> DeserializeAs<'de, [u8; N]> for Hex {
             result: [u8; N],
         }
 
-        impl<'de, const N: usize> de::Visitor<'de> for Visitor<N> {
+        impl<const N: usize> de::Visitor<'_> for Visitor<N> {
             type Value = [u8; N];
 
             fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {

--- a/crates/driver/src/util/serialize/u256.rs
+++ b/crates/driver/src/util/serialize/u256.rs
@@ -12,7 +12,7 @@ impl<'de> DeserializeAs<'de, eth::U256> for U256 {
     fn deserialize_as<D: Deserializer<'de>>(deserializer: D) -> Result<eth::U256, D::Error> {
         struct Visitor;
 
-        impl<'de> de::Visitor<'de> for Visitor {
+        impl de::Visitor<'_> for Visitor {
             type Value = eth::U256;
 
             fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {

--- a/crates/model/src/order.rs
+++ b/crates/model/src/order.rs
@@ -677,10 +677,8 @@ pub struct OnchainOrderData {
 }
 
 /// An order as provided to the orderbook by the frontend.
-#[allow(clippy::needless_lifetimes)]
 #[serde_as]
-#[derive(Eq, PartialEq, Clone, Default, Derivative, Deserialize, Serialize)]
-#[derivative(Debug)]
+#[derive(Eq, PartialEq, Clone, Default, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct OrderMetadata {
     pub creation_date: DateTime<Utc>,
@@ -689,10 +687,8 @@ pub struct OrderMetadata {
     /// deprecated, always set to null
     #[serde_as(as = "Option<HexOrDecimalU256>")]
     pub available_balance: Option<U256>,
-    #[derivative(Debug(format_with = "debug_biguint_to_string"))]
     #[serde_as(as = "DisplayFromStr")]
     pub executed_buy_amount: BigUint,
-    #[derivative(Debug(format_with = "debug_biguint_to_string"))]
     #[serde_as(as = "DisplayFromStr")]
     pub executed_sell_amount: BigUint,
     #[serde_as(as = "HexOrDecimalU256")]
@@ -737,6 +733,42 @@ pub struct OrderMetadata {
     /// Full app data that `OrderData::app_data` is a hash of. Can be None if
     /// the backend doesn't know about the full app data.
     pub full_app_data: Option<String>,
+}
+
+impl std::fmt::Debug for OrderMetadata {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("OrderMetadata")
+            .field("creation_date", &self.creation_date)
+            .field("owner", &self.owner)
+            .field("uid", &self.uid)
+            .field("available_balance", &self.available_balance)
+            .field(
+                "executed_buy_amount",
+                &format_args!("{}", self.executed_buy_amount),
+            )
+            .field(
+                "executed_sell_amount",
+                &format_args!("{}", self.executed_sell_amount),
+            )
+            .field(
+                "executed_sell_amount_before_fees",
+                &self.executed_sell_amount_before_fees,
+            )
+            .field("executed_fee_amount", &self.executed_fee_amount)
+            .field("executed_surplus_fee", &self.executed_surplus_fee)
+            .field("invalidated", &self.invalidated)
+            .field("status", &self.status)
+            .field("class", &self.class)
+            .field("settlement_contract", &self.settlement_contract)
+            .field("full_fee_amount", &self.full_fee_amount)
+            .field("solver_fee", &self.solver_fee)
+            .field("ethflow_data", &self.ethflow_data)
+            .field("onchain_order_data", &self.onchain_order_data)
+            .field("onchain_user", &self.onchain_user)
+            .field("is_liquidity_order", &self.is_liquidity_order)
+            .field("full_app_data", &self.full_app_data)
+            .finish()
+    }
 }
 
 // uid as 56 bytes: 32 for orderDigest, 20 for ownerAddress and 4 for validTo
@@ -1008,20 +1040,6 @@ impl BuyTokenDestination {
             Self::Internal => Self::INTERNAL,
         }
     }
-}
-
-pub fn debug_app_data(
-    app_data: &[u8; 32],
-    formatter: &mut std::fmt::Formatter,
-) -> Result<(), std::fmt::Error> {
-    formatter.write_fmt(format_args!("{:?}", H256(*app_data)))
-}
-
-pub fn debug_biguint_to_string(
-    value: &BigUint,
-    formatter: &mut std::fmt::Formatter,
-) -> Result<(), std::fmt::Error> {
-    formatter.write_fmt(format_args!("{value}"))
 }
 
 #[cfg(test)]

--- a/crates/model/src/order.rs
+++ b/crates/model/src/order.rs
@@ -677,6 +677,7 @@ pub struct OnchainOrderData {
 }
 
 /// An order as provided to the orderbook by the frontend.
+#[allow(clippy::needless_lifetimes)]
 #[serde_as]
 #[derive(Eq, PartialEq, Clone, Default, Derivative, Deserialize, Serialize)]
 #[derivative(Debug)]
@@ -819,7 +820,7 @@ impl<'de> Deserialize<'de> for OrderUid {
         D: Deserializer<'de>,
     {
         struct Visitor {}
-        impl<'de> de::Visitor<'de> for Visitor {
+        impl de::Visitor<'_> for Visitor {
             type Value = OrderUid;
 
             fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {

--- a/crates/model/src/order.rs
+++ b/crates/model/src/order.rs
@@ -1,5 +1,6 @@
 //! Contains the order type as described by the specification with serialization
 //! as described by the openapi documentation.
+#![allow(clippy::needless_lifetimes)] // todo: migrate from derivative to derive_more
 
 use {
     crate::{
@@ -677,8 +678,10 @@ pub struct OnchainOrderData {
 }
 
 /// An order as provided to the orderbook by the frontend.
+#[allow(clippy::needless_lifetimes)]
 #[serde_as]
-#[derive(Eq, PartialEq, Clone, Default, Deserialize, Serialize)]
+#[derive(Eq, PartialEq, Clone, Default, Derivative, Deserialize, Serialize)]
+#[derivative(Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct OrderMetadata {
     pub creation_date: DateTime<Utc>,
@@ -687,8 +690,10 @@ pub struct OrderMetadata {
     /// deprecated, always set to null
     #[serde_as(as = "Option<HexOrDecimalU256>")]
     pub available_balance: Option<U256>,
+    #[derivative(Debug(format_with = "debug_biguint_to_string"))]
     #[serde_as(as = "DisplayFromStr")]
     pub executed_buy_amount: BigUint,
+    #[derivative(Debug(format_with = "debug_biguint_to_string"))]
     #[serde_as(as = "DisplayFromStr")]
     pub executed_sell_amount: BigUint,
     #[serde_as(as = "HexOrDecimalU256")]
@@ -733,42 +738,6 @@ pub struct OrderMetadata {
     /// Full app data that `OrderData::app_data` is a hash of. Can be None if
     /// the backend doesn't know about the full app data.
     pub full_app_data: Option<String>,
-}
-
-impl std::fmt::Debug for OrderMetadata {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("OrderMetadata")
-            .field("creation_date", &self.creation_date)
-            .field("owner", &self.owner)
-            .field("uid", &self.uid)
-            .field("available_balance", &self.available_balance)
-            .field(
-                "executed_buy_amount",
-                &format_args!("{}", self.executed_buy_amount),
-            )
-            .field(
-                "executed_sell_amount",
-                &format_args!("{}", self.executed_sell_amount),
-            )
-            .field(
-                "executed_sell_amount_before_fees",
-                &self.executed_sell_amount_before_fees,
-            )
-            .field("executed_fee_amount", &self.executed_fee_amount)
-            .field("executed_surplus_fee", &self.executed_surplus_fee)
-            .field("invalidated", &self.invalidated)
-            .field("status", &self.status)
-            .field("class", &self.class)
-            .field("settlement_contract", &self.settlement_contract)
-            .field("full_fee_amount", &self.full_fee_amount)
-            .field("solver_fee", &self.solver_fee)
-            .field("ethflow_data", &self.ethflow_data)
-            .field("onchain_order_data", &self.onchain_order_data)
-            .field("onchain_user", &self.onchain_user)
-            .field("is_liquidity_order", &self.is_liquidity_order)
-            .field("full_app_data", &self.full_app_data)
-            .finish()
-    }
 }
 
 // uid as 56 bytes: 32 for orderDigest, 20 for ownerAddress and 4 for validTo
@@ -1040,6 +1009,13 @@ impl BuyTokenDestination {
             Self::Internal => Self::INTERNAL,
         }
     }
+}
+
+pub fn debug_biguint_to_string(
+    value: &BigUint,
+    formatter: &mut std::fmt::Formatter,
+) -> Result<(), std::fmt::Error> {
+    formatter.write_fmt(format_args!("{value}"))
 }
 
 #[cfg(test)]

--- a/crates/model/src/order.rs
+++ b/crates/model/src/order.rs
@@ -678,7 +678,6 @@ pub struct OnchainOrderData {
 }
 
 /// An order as provided to the orderbook by the frontend.
-#[allow(clippy::needless_lifetimes)]
 #[serde_as]
 #[derive(Eq, PartialEq, Clone, Default, Derivative, Deserialize, Serialize)]
 #[derivative(Debug)]

--- a/crates/model/src/quote.rs
+++ b/crates/model/src/quote.rs
@@ -184,7 +184,6 @@ impl Default for Validity {
 }
 
 /// Helper struct for `Validity` serialization.
-
 impl<'de> Deserialize<'de> for Validity {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where

--- a/crates/model/src/signature.rs
+++ b/crates/model/src/signature.rs
@@ -385,7 +385,7 @@ impl<'de> Deserialize<'de> for EcdsaSignature {
         D: serde::Deserializer<'de>,
     {
         struct Visitor {}
-        impl<'de> de::Visitor<'de> for Visitor {
+        impl de::Visitor<'_> for Visitor {
             type Value = EcdsaSignature;
 
             fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {

--- a/crates/number/src/serialization.rs
+++ b/crates/number/src/serialization.rs
@@ -37,7 +37,7 @@ where
     D: Deserializer<'de>,
 {
     struct Visitor {}
-    impl<'de> de::Visitor<'de> for Visitor {
+    impl de::Visitor<'_> for Visitor {
         type Value = U256;
 
         fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {

--- a/crates/shared/src/baseline_solver.rs
+++ b/crates/shared/src/baseline_solver.rs
@@ -39,7 +39,7 @@ pub struct Estimate<'a, V, L> {
     pub path: Vec<&'a L>,
 }
 
-impl<'a, V, L: BaselineSolvable> Estimate<'a, V, L> {
+impl<V, L: BaselineSolvable> Estimate<'_, V, L> {
     pub fn gas_cost(&self) -> usize {
         // This could be more accurate by actually simulating the settlement (since
         // different tokens might have more or less expensive transfer costs)

--- a/crates/shared/src/lib.rs
+++ b/crates/shared/src/lib.rs
@@ -54,6 +54,13 @@ pub async fn measure_time<T>(future: impl Future<Output = T>, timer: impl FnOnce
     result
 }
 
+pub fn debug_bytes(
+    bytes: impl AsRef<[u8]>,
+    formatter: &mut std::fmt::Formatter,
+) -> Result<(), std::fmt::Error> {
+    formatter.write_fmt(format_args!("0x{}", hex::encode(bytes.as_ref())))
+}
+
 /// anyhow errors are not clonable natively. This is a workaround that creates a
 /// new anyhow error based on formatting the error with its inner sources
 /// without backtrace.

--- a/crates/shared/src/lib.rs
+++ b/crates/shared/src/lib.rs
@@ -54,13 +54,6 @@ pub async fn measure_time<T>(future: impl Future<Output = T>, timer: impl FnOnce
     result
 }
 
-pub fn debug_bytes(
-    bytes: impl AsRef<[u8]>,
-    formatter: &mut std::fmt::Formatter,
-) -> Result<(), std::fmt::Error> {
-    formatter.write_fmt(format_args!("0x{}", hex::encode(bytes.as_ref())))
-}
-
 /// anyhow errors are not clonable natively. This is a workaround that creates a
 /// new anyhow error based on formatting the error with its inner sources
 /// without backtrace.

--- a/crates/shared/src/price_estimation/native_price_cache.rs
+++ b/crates/shared/src/price_estimation/native_price_cache.rs
@@ -115,7 +115,7 @@ impl Inner {
         &'a self,
         tokens: &'a [H160],
         max_age: Duration,
-    ) -> futures::stream::BoxStream<'_, (H160, NativePriceEstimateResult)> {
+    ) -> futures::stream::BoxStream<'a, (H160, NativePriceEstimateResult)> {
         let estimates = tokens.iter().map(move |token| async move {
             {
                 // check if price is cached by now

--- a/crates/shared/src/trade_finding/mod.rs
+++ b/crates/shared/src/trade_finding/mod.rs
@@ -6,10 +6,10 @@ pub mod external;
 use {
     crate::price_estimation::{PriceEstimationError, Query},
     anyhow::Result,
-    derivative::Derivative,
     ethcontract::{contract::MethodBuilder, tokens::Tokenize, web3::Transport, Bytes, H160, U256},
     model::interaction::InteractionData,
     serde::Serialize,
+    std::fmt,
     thiserror::Error,
 };
 
@@ -50,13 +50,21 @@ pub struct Trade {
 }
 
 /// Data for a raw GPv2 interaction.
-#[derive(Clone, PartialEq, Eq, Hash, Default, Serialize, Derivative)]
-#[derivative(Debug)]
+#[derive(Clone, PartialEq, Eq, Hash, Default, Serialize)]
 pub struct Interaction {
     pub target: H160,
     pub value: U256,
-    #[derivative(Debug(format_with = "crate::debug_bytes"))]
     pub data: Vec<u8>,
+}
+
+impl fmt::Debug for Interaction {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Interaction")
+            .field("target", &self.target)
+            .field("value", &self.value)
+            .field("data", &format_args!("0x{}", hex::encode(&self.data)))
+            .finish()
+    }
 }
 
 impl Interaction {

--- a/crates/shared/src/trade_finding/mod.rs
+++ b/crates/shared/src/trade_finding/mod.rs
@@ -1,15 +1,16 @@
 //! A module for abstracting a component that can produce a quote with calldata
 //! for a specified token pair and amount.
+#![allow(clippy::needless_lifetimes)] // todo: migrate from derivative to derive_more
 
 pub mod external;
 
 use {
     crate::price_estimation::{PriceEstimationError, Query},
     anyhow::Result,
+    derivative::Derivative,
     ethcontract::{contract::MethodBuilder, tokens::Tokenize, web3::Transport, Bytes, H160, U256},
     model::interaction::InteractionData,
     serde::Serialize,
-    std::fmt,
     thiserror::Error,
 };
 
@@ -50,21 +51,13 @@ pub struct Trade {
 }
 
 /// Data for a raw GPv2 interaction.
-#[derive(Clone, PartialEq, Eq, Hash, Default, Serialize)]
+#[derive(Clone, PartialEq, Eq, Hash, Default, Serialize, Derivative)]
+#[derivative(Debug)]
 pub struct Interaction {
     pub target: H160,
     pub value: U256,
+    #[derivative(Debug(format_with = "crate::debug_bytes"))]
     pub data: Vec<u8>,
-}
-
-impl fmt::Debug for Interaction {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("Interaction")
-            .field("target", &self.target)
-            .field("value", &self.value)
-            .field("data", &format_args!("0x{}", hex::encode(&self.data)))
-            .finish()
-    }
 }
 
 impl Interaction {

--- a/crates/solver/src/liquidity/slippage.rs
+++ b/crates/solver/src/liquidity/slippage.rs
@@ -22,7 +22,7 @@ pub struct SlippageContext<'a> {
     calculator: &'a SlippageCalculator,
 }
 
-impl<'a> SlippageContext<'a> {
+impl SlippageContext<'_> {
     /// Returns the external prices used for the slippage context.
     pub fn prices(&self) -> &ExternalPrices {
         self.prices

--- a/crates/solvers-dto/src/lib.rs
+++ b/crates/solvers-dto/src/lib.rs
@@ -19,7 +19,7 @@ mod serialize {
         fn deserialize_as<D: Deserializer<'de>>(deserializer: D) -> Result<Vec<u8>, D::Error> {
             struct Visitor;
 
-            impl<'de> de::Visitor<'de> for Visitor {
+            impl de::Visitor<'_> for Visitor {
                 type Value = Vec<u8>;
 
                 fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
@@ -58,7 +58,7 @@ mod serialize {
                 result: [u8; N],
             }
 
-            impl<'de, const N: usize> de::Visitor<'de> for Visitor<N> {
+            impl<const N: usize> de::Visitor<'_> for Visitor<N> {
                 type Value = [u8; N];
 
                 fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {


### PR DESCRIPTION
Fixes the code to satisfy `clippy`.

Some Derivative annotations were replaced with custom implementation due to the following weird error, which I couldn't mute even with `#[allow(clippy::needless_lifetimes)]`.
```
53 | #[derive(Clone, PartialEq, Eq, Hash, Default, Serialize, Derivative)]
   |                                                          ^^^^^^^^^^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_lifetimes
   = note: `-D clippy::needless-lifetimes` implied by `-D warnings`
   = help: to override `-D warnings` add `#[allow(clippy::needless_lifetimes)]`
   = note: this error originates in the derive macro `Derivative` (in Nightly builds, run with -Z macro-backtrace for more info)
```