### PR TITLE
Fix flaky e2e test

### DIFF
--- a/crates/e2e/tests/e2e/limit_orders.rs
+++ b/crates/e2e/tests/e2e/limit_orders.rs
@@ -361,15 +361,6 @@ async fn two_limit_orders_multiple_winners_test(web3: Web3) {
     );
 
     let services = Services::new(&onchain).await;
-    services.start_autopilot(
-        None,
-        vec![
-            "--drivers=solver1|http://localhost:11088/test_solver|10000000000000000,solver2|http://localhost:11088/solver2"
-                .to_string(),
-            "--price-estimation-drivers=solver1|http://localhost:11088/test_solver".to_string(),
-            "--max-winners-per-auction=2".to_string(),
-        ],
-    ).await;
     services
         .start_api(vec![
             "--price-estimation-drivers=solver1|http://localhost:11088/test_solver".to_string(),
@@ -408,6 +399,17 @@ async fn two_limit_orders_multiple_winners_test(web3: Web3) {
         SecretKeyRef::from(&SecretKey::from_slice(trader_b.private_key()).unwrap()),
     );
     let uid_b = services.create_order(&order_b).await.unwrap();
+
+    // Start autopilot only once all the orders are created.
+    services.start_autopilot(
+        None,
+        vec![
+            "--drivers=solver1|http://localhost:11088/test_solver|10000000000000000,solver2|http://localhost:11088/solver2"
+                .to_string(),
+            "--price-estimation-drivers=solver1|http://localhost:11088/test_solver".to_string(),
+            "--max-winners-per-auction=2".to_string(),
+        ],
+    ).await;
 
     // Wait for trade
     let indexed_trades = || async {

--- a/crates/e2e/tests/e2e/replace_order.rs
+++ b/crates/e2e/tests/e2e/replace_order.rs
@@ -202,22 +202,7 @@ async fn single_replace_order_test(web3: Web3) {
 
     // Place Orders
     let services = Services::new(&onchain).await;
-    services.start_api(Default::default()).await;
-    colocation::start_driver(
-        onchain.contracts(),
-        vec![
-            colocation::start_baseline_solver(
-                "test_solver".into(),
-                solver,
-                onchain.contracts().weth.address(),
-                vec![],
-                1,
-                true,
-            )
-            .await,
-        ],
-        colocation::LiquidityProvider::UniswapV2,
-    );
+    services.start_protocol(solver).await;
 
     let order = OrderCreation {
         sell_token: token_a.address(),
@@ -270,18 +255,6 @@ async fn single_replace_order_test(web3: Web3) {
     );
     let balance_before = token_a.balance_of(trader.address()).call().await.unwrap();
     let new_order_uid = services.create_order(&new_order).await.unwrap();
-
-    // Start autopilot once all the orders are created.
-    services
-        .start_autopilot(
-            None,
-            vec![
-                "--drivers=test_solver|http://localhost:11088/test_solver".to_string(),
-                "--price-estimation-drivers=test_quoter|http://localhost:11088/test_solver"
-                    .to_string(),
-            ],
-        )
-        .await;
 
     onchain.mint_block().await;
 


### PR DESCRIPTION
Fixes flaky e2e test by starting autopilot only once all the orders are created. Locally, these failures are almost impossible to reproduce since all the orders, in most cases, belong to a single auction, while this is not the case on CI.