### PR TITLE
OpenAPI yaml files formatting

### DIFF
--- a/crates/driver/openapi.yml
+++ b/crates/driver/openapi.yml
@@ -63,7 +63,7 @@ paths:
           $ref: '#/components/responses/InternalServerError'
   /solve:
     post:
-      description: >
+      description: |-
         Solve the passed in auction.
 
         The response contains the objective value of the solution the Solver is
@@ -121,7 +121,7 @@ paths:
           $ref: '#/components/responses/InternalServerError'
   /settle:
     post:
-      description: >
+      description: |-
         Execute the previously solved auction on chain.
 
         The auction that should be executed is identified through its id and was
@@ -235,7 +235,7 @@ components:
             - description: The address that created the order.
             - $ref: '#/components/schemas/Address'
         partiallyFillable:
-          description: >
+          description: |-
             Whether the order can be partially filled.
 
             If this is false then the solver must fill the entire order or not
@@ -285,7 +285,7 @@ components:
           description: Hex encoded bytes with `0x` prefix.
           type: string
         protocolFees:
-          description: >
+          description: |-
             Any protocol fee policies that apply to the order.
 
             The solver should make sure the fee policy is applied when computing
@@ -323,7 +323,7 @@ components:
       type: string
       example: '1234567890'
     OrderUID:
-      description: >
+      description: |-
         Unique identifier for the order: 56 bytes encoded as hex with `0x`
         prefix.
 
@@ -338,7 +338,7 @@ components:
         - $ref: '#/components/schemas/QuoteResponse'
         - $ref: '#/components/schemas/Error'
     LegacyQuoteResponse:
-      description: >
+      description: |-
         Successful Quote.
 
         The Solver knows how to fill the request with these parameters.
@@ -422,7 +422,7 @@ components:
           type: string
           example: '0x1234567890'
         uninternalized:
-          description: >
+          description: |-
             The calldata with all internalized interactions encoded.
 
             This is the calldata that should be used for simulation/verification
@@ -666,7 +666,7 @@ components:
         appData:
           type: string
         signature:
-          description: >
+          description: >-
             Hex encoded bytes with `0x` prefix. The content depends on the
             `signingScheme`.
 

--- a/crates/driver/openapi.yml
+++ b/crates/driver/openapi.yml
@@ -4,10 +4,6 @@ info:
   description: |
     The API implemented by Solvers to be queried by Autopilot.
   version: 0.0.1
-  contact:
-    name: CoW DAO
-      url: "https://cow.fi"
-    email: dev@cow.fi
 paths:
   /quote:
     get:

--- a/crates/driver/openapi.yml
+++ b/crates/driver/openapi.yml
@@ -27,9 +27,9 @@ paths:
           required: true
         - in: query
           name: kind
-          description: |
-            - `buy`: amount is in buy_token, out_amount is in sell_token
-            - `sell`: amount is in sell_token, out_amount is in buy_token
+          description: >-
+            - `buy`: amount is in buy_token, out_amount is in sell_token -
+            `sell`: amount is in sell_token, out_amount is in buy_token
           schema:
             type: string
             enum:
@@ -66,32 +66,18 @@ paths:
       description: >
         Solve the passed in auction.
 
-
         The response contains the objective value of the solution the Solver is
-        able to find but not
-
-        the calldata. This facilitates solvers that work with an RFQ system.
-        When Autopilot decides
-
-        the winner of the of the auction it prompts the corresponding solver to
-        execute its solution
-
+        able to find but not the calldata. This facilitates solvers that work
+        with an RFQ system. When Autopilot decides the winner of the of the
+        auction it prompts the corresponding solver to execute its solution
         through the execute endpoint.
 
-
         The Solver should respond quickly enough so that the caller of the
-        endpoint receives the
-
-        response within the deadline indicated in the request. This includes
-        taking into account
-
-        network delay.
-
+        endpoint receives the response within the deadline indicated in the
+        request. This includes taking into account network delay.
 
         Autopilot will call this endpoint at most once for the same auction id
-        and the following
-
-        call will have a larger id.
+        and the following call will have a larger id.
       requestBody:
         required: true
         content:
@@ -113,7 +99,6 @@ paths:
     post:
       description: >
         Reveal the calldata of the previously solved auction.
-
 
         This may be used by the autopilot for the shadow competition to verify
         the solution before requesting its execution it on chain.
@@ -139,12 +124,8 @@ paths:
       description: >
         Execute the previously solved auction on chain.
 
-
         The auction that should be executed is identified through its id and was
-        recently returned
-
-        by this Solver's solve endpoint.
-
+        recently returned by this Solver's solve endpoint. 
 
         By accepting the execute request the Solver promises to execute the
         solution on chain immediately.
@@ -191,7 +172,7 @@ components:
           nullable: true
           allOf:
             - $ref: '#/components/schemas/TokenAmount'
-          description: >
+          description: |-
             The reference price denominated in native token (i.e. 1e18
             represents a token that
 
@@ -200,18 +181,15 @@ components:
 
             for computing surplus and converting fees to native token.
         trusted:
-          description: >
+          description: |-
             Whether the protocol trusts the token to be used for internalizing
             trades.
 
-
             Solvers are allowed to internalize trades, ie. omit the interaction
-            that executes the swap from token A to token B
-
-            and instead use the settlement contract balances, aka buffers, to
-            fulfil the interaction as long as the token 
-
-            the contract receives (A in the example) is trusted.
+            that executes the swap from token A to token B and instead use the
+            settlement contract balances, aka buffers, to fulfil the interaction
+            as long as the token the contract receives (A in the example) is
+            trusted.
           type: boolean
     Order:
       description: |
@@ -259,7 +237,6 @@ components:
         partiallyFillable:
           description: >
             Whether the order can be partially filled.
-
 
             If this is false then the solver must fill the entire order or not
             at all.
@@ -311,7 +288,6 @@ components:
           description: >
             Any protocol fee policies that apply to the order.
 
-
             The solver should make sure the fee policy is applied when computing
             their solution.
           type: array
@@ -351,9 +327,8 @@ components:
         Unique identifier for the order: 56 bytes encoded as hex with `0x`
         prefix.
 
-        Bytes 0 to 32 are the order digest, bytes 30 to 52 the owner address
-
-        and bytes 52..56 valid to,
+        Bytes 0 to 32 are the order digest, bytes 30 to 52 the owner address and
+        bytes 52..56 valid to,
       type: string
       example: >-
         0x30cff40d9f60caa68a37f0ee73253ad6ad72b45580c945fe3ab67596476937197854163b1b0d24e77dca702b97b5cc33e0f83dcb626122a6
@@ -364,19 +339,13 @@ components:
         - $ref: '#/components/schemas/Error'
     LegacyQuoteResponse:
       description: >
-        Successful Quote
-
+        Successful Quote.
 
         The Solver knows how to fill the request with these parameters.
 
-
         If the request was of type `buy` then the response's buy amount has the
-        same value as the
-
-        request's amount and the sell amount was filled in by the server. Vice
-        versa for type
-
-        `sell`.
+        same value as the request's amount and the sell amount was filled in by
+        the server. Vice versa for type `sell`.
       type: object
       properties:
         amount:
@@ -401,9 +370,8 @@ components:
         - interactions
         - solver
     QuoteResponse:
-      description: |
+      description: |-
         Successful Quote with JIT orders support.
-
         The Solver knows how to fill the request with these parameters.
       type: object
       properties:
@@ -448,16 +416,14 @@ components:
       type: object
       properties:
         internalized:
-          description: |
+          description: |-
             The calldata without any internalized interactions encoded.
-
             This is the calldata that can be found on chain.
           type: string
           example: '0x1234567890'
         uninternalized:
           description: >
             The calldata with all internalized interactions encoded.
-
 
             This is the calldata that should be used for simulation/verification
             purposes.
@@ -504,9 +470,8 @@ components:
             type: object
             properties:
               solutionId:
-                description: |
+                description: |-
                   The unique identifier of the solution.
-
                   This id is used to identify the solution when executing it.
                 type: integer
                 example: 1
@@ -557,7 +522,6 @@ components:
                 description: >
                   Mapping of hex token address to price.
 
-
                   The prices of tokens for settled user orders as passed to the
                   settlement contract.
                 type: object
@@ -590,7 +554,6 @@ components:
     FeePolicy:
       description: >
         A fee policy that applies to an order.
-
 
         The solver should make sure the fee policy is applied when computing
         their solution.
@@ -707,7 +670,7 @@ components:
             Hex encoded bytes with `0x` prefix. The content depends on the
             `signingScheme`.
 
-            For `presign`, this should contain the address of the owner. 
+            For `presign`, this should contain the address of the owner.
 
             For `eip1271`, the signature should consist of
             `<owner_address><signature_bytes>`.
@@ -745,21 +708,19 @@ components:
           description: Text describing the error.
           type: string
   responses:
-    200:
+    '200':
       description: The request was successful.
     BadRequest:
-      description: |
+      description: |-
         There is something wrong with the request.
-
         Body potentially contains extra information.
       content:
         text/plain:
           schema:
             type: string
     InternalServerError:
-      description: |
+      description: |-
         Something went wrong when handling the request.
-
         Body potentially contains extra information.
       content:
         text/plain:

--- a/crates/driver/openapi.yml
+++ b/crates/driver/openapi.yml
@@ -4,6 +4,10 @@ info:
   description: |
     The API implemented by Solvers to be queried by Autopilot.
   version: 0.0.1
+  contact:
+    name: CoW DAO
+    url: 'https://cow.fi'
+    email: dev@cow.fi
 paths:
   /quote:
     get:
@@ -13,13 +17,13 @@ paths:
           name: sellToken
           description: The token to sell.
           schema:
-            $ref: "#/components/schemas/Address"
+            $ref: '#/components/schemas/Address'
           required: true
         - in: query
           name: buyToken
           description: The token to buy.
           schema:
-            $ref: "#/components/schemas/Address"
+            $ref: '#/components/schemas/Address'
           required: true
         - in: query
           name: kind
@@ -28,128 +32,152 @@ paths:
             - `sell`: amount is in sell_token, out_amount is in buy_token
           schema:
             type: string
-            enum: ["buy", "sell"]
+            enum:
+              - buy
+              - sell
           required: true
         - in: query
           name: amount
           description: The amount to buy or sell.
           schema:
-            $ref: "#/components/schemas/TokenAmount"
+            $ref: '#/components/schemas/TokenAmount'
           required: true
         - in: query
           name: deadline
           description: The time until which the caller expects a response.
           schema:
-            $ref: "#/components/schemas/DateTime"
+            $ref: '#/components/schemas/DateTime'
           required: true
       responses:
-        200:
+        '200':
           description: Quote successfully created.
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/QuoteResponseKind"
-        400:
-          $ref: "#/components/responses/BadRequest"
-        429:
+                $ref: '#/components/schemas/QuoteResponseKind'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '429':
           description: The solver cannot keep up. It is too busy to handle more requests.
-        500:
-          $ref: "#/components/responses/InternalServerError"
+        '500':
+          $ref: '#/components/responses/InternalServerError'
   /solve:
     post:
-      description: |
+      description: >
         Solve the passed in auction.
 
-        The response contains the objective value of the solution the Solver is able to find but not
-        the calldata. This facilitates solvers that work with an RFQ system. When Autopilot decides
-        the winner of the of the auction it prompts the corresponding solver to execute its solution
+
+        The response contains the objective value of the solution the Solver is
+        able to find but not
+
+        the calldata. This facilitates solvers that work with an RFQ system.
+        When Autopilot decides
+
+        the winner of the of the auction it prompts the corresponding solver to
+        execute its solution
+
         through the execute endpoint.
 
-        The Solver should respond quickly enough so that the caller of the endpoint receives the
-        response within the deadline indicated in the request. This includes taking into account
+
+        The Solver should respond quickly enough so that the caller of the
+        endpoint receives the
+
+        response within the deadline indicated in the request. This includes
+        taking into account
+
         network delay.
 
-        Autopilot will call this endpoint at most once for the same auction id and the following
+
+        Autopilot will call this endpoint at most once for the same auction id
+        and the following
+
         call will have a larger id.
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/SolveRequest"
+              $ref: '#/components/schemas/SolveRequest'
       responses:
-        200:
+        '200':
           description: Auction successfully solved.
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/SolveResponse"
-        400:
-          $ref: "#/components/responses/BadRequest"
-        500:
-          $ref: "#/components/responses/InternalServerError"
+                $ref: '#/components/schemas/SolveResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
   /reveal:
     post:
-      description: |
+      description: >
         Reveal the calldata of the previously solved auction.
 
-        This may be used by the autopilot for the shadow competition to verify the solution before requesting its execution it on chain.
+
+        This may be used by the autopilot for the shadow competition to verify
+        the solution before requesting its execution it on chain.
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/Solution"
+              $ref: '#/components/schemas/Solution'
       responses:
-        200:
+        '200':
           description: Execution accepted.
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/RevealedResponse"
-        400:
-          $ref: "#/components/responses/BadRequest"
-        500:
-          $ref: "#/components/responses/InternalServerError"
+                $ref: '#/components/schemas/RevealedResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
   /settle:
     post:
-      description: |
+      description: >
         Execute the previously solved auction on chain.
 
-        The auction that should be executed is identified through its id and was recently returned
+
+        The auction that should be executed is identified through its id and was
+        recently returned
+
         by this Solver's solve endpoint.
 
-        By accepting the execute request the Solver promises to execute the solution on chain immediately.
+
+        By accepting the execute request the Solver promises to execute the
+        solution on chain immediately.
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/Solution"
+              $ref: '#/components/schemas/Solution'
       responses:
-        200:
+        '200':
           description: Execution accepted.
-        400:
-          $ref: "#/components/responses/BadRequest"
-        500:
-          $ref: "#/components/responses/InternalServerError"
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
 components:
   schemas:
     Address:
       description: 20 byte Ethereum address encoded as a hex with `0x` prefix.
       type: string
-      example: "0x6810e776880c02933d47db1b9fc05908e5386b96"
+      example: '0x6810e776880c02933d47db1b9fc05908e5386b96'
     TokenAmount:
       description: Amount of an ERC20 token. 256 bit unsigned integer in decimal notation.
       type: string
-      example: "1234567890"
+      example: '1234567890'
     Interaction:
       type: object
       properties:
         target:
-          $ref: "#/components/schemas/Address"
+          $ref: '#/components/schemas/Address'
         value:
-          $ref: "#/components/schemas/TokenAmount"
+          $ref: '#/components/schemas/TokenAmount'
         callData:
           description: Hex encoded bytes with `0x` prefix.
           type: string
@@ -158,21 +186,31 @@ components:
       type: object
       properties:
         address:
-          $ref: "#/components/schemas/Address"
+          $ref: '#/components/schemas/Address'
         price:
           nullable: true
           allOf:
-            - $ref: "#/components/schemas/TokenAmount"
-          description: |
-            The reference price denominated in native token (i.e. 1e18 represents a token that
-            trades one to one with the native token). These prices are used for solution competition
+            - $ref: '#/components/schemas/TokenAmount'
+          description: >
+            The reference price denominated in native token (i.e. 1e18
+            represents a token that
+
+            trades one to one with the native token). These prices are used for
+            solution competition
+
             for computing surplus and converting fees to native token.
         trusted:
-          description: |
-            Whether the protocol trusts the token to be used for internalizing trades.
+          description: >
+            Whether the protocol trusts the token to be used for internalizing
+            trades.
 
-            Solvers are allowed to internalize trades, ie. omit the interaction that executes the swap from token A to token B
-            and instead use the settlement contract balances, aka buffers, to fulfil the interaction as long as the token 
+
+            Solvers are allowed to internalize trades, ie. omit the interaction
+            that executes the swap from token A to token B
+
+            and instead use the settlement contract balances, aka buffers, to
+            fulfil the interaction as long as the token 
+
             the contract receives (A in the example) is trusted.
           type: boolean
     Order:
@@ -181,85 +219,108 @@ components:
       type: object
       properties:
         uid:
-          $ref: "#/components/schemas/OrderUID"
+          $ref: '#/components/schemas/OrderUID'
         sellToken:
-          description: Token being sold
-          $ref: "#/components/schemas/Address"
+          allOf:
+            - description: Token being sold
+            - $ref: '#/components/schemas/Address'
         buyToken:
-          description: Token being bought
-          $ref: "#/components/schemas/Address"
+          allOf:
+            - description: Token being bought
+            - $ref: '#/components/schemas/Address'
         sellAmount:
-          description: Amount to be sold
-          $ref: "#/components/schemas/TokenAmount"
+          allOf:
+            - description: Amount to be sold
+            - $ref: '#/components/schemas/TokenAmount'
         buyAmount:
-          description: Amount to be bought
-          $ref: "#/components/schemas/TokenAmount"
+          allOf:
+            - description: Amount to be bought
+            - $ref: '#/components/schemas/TokenAmount'
         created:
           description: Creation time of the order. Denominated in epoch seconds.
           type: string
-          example: "123456"
+          example: '123456'
         validTo:
           description: The time until which the order is valid.
           type: integer
         kind:
           type: string
-          enum: ["buy", "sell"]
+          enum:
+            - buy
+            - sell
         receiver:
-          description: The address that should receive the bought tokens.
-          $ref: "#/components/schemas/Address"
+          allOf:
+            - description: The address that should receive the bought tokens.
+            - $ref: '#/components/schemas/Address'
         owner:
-          description: The address that created the order.
-          $ref: "#/components/schemas/Address"
+          allOf:
+            - description: The address that created the order.
+            - $ref: '#/components/schemas/Address'
         partiallyFillable:
-          description: |
+          description: >
             Whether the order can be partially filled.
 
-            If this is false then the solver must fill the entire order or not at all.
+
+            If this is false then the solver must fill the entire order or not
+            at all.
           type: boolean
         executed:
-          description: The amount that has already been filled.
-          $ref: "#/components/schemas/TokenAmount"
+          allOf:
+            - description: The amount that has already been filled.
+            - $ref: '#/components/schemas/TokenAmount'
         preInteractions:
           description: Interactions that must be executed before the order can be filled.
           type: array
           items:
-            $ref: "#/components/schemas/Interaction"
+            $ref: '#/components/schemas/Interaction'
         postInteractions:
           description: Interactions that must be executed after the order has been filled.
           type: array
           items:
-            $ref: "#/components/schemas/Interaction"
+            $ref: '#/components/schemas/Interaction'
         sellTokenBalance:
           type: string
-          enum: ["erc20", "internal", "external"]
+          enum:
+            - erc20
+            - internal
+            - external
         buyTokenBalance:
           type: string
-          enum: ["erc20", "internal"]
+          enum:
+            - erc20
+            - internal
         class:
           type: string
-          enum: ["market", "limit"]
+          enum:
+            - market
+            - limit
         appData:
           description: 32 bytes encoded as hex with `0x` prefix.
           type: string
         signingScheme:
           type: string
-          enum: [ "eip712", "ethsign", "presign", "eip1271" ]
+          enum:
+            - eip712
+            - ethsign
+            - presign
+            - eip1271
         signature:
           description: Hex encoded bytes with `0x` prefix.
           type: string
         protocolFees:
-          description: |
+          description: >
             Any protocol fee policies that apply to the order.
 
-            The solver should make sure the fee policy is applied when computing their solution.
+
+            The solver should make sure the fee policy is applied when computing
+            their solution.
           type: array
           items:
-            $ref: "#/components/schemas/FeePolicy"
+            $ref: '#/components/schemas/FeePolicy'
         quote:
-          description: |
-            A winning quote.
           allOf:
-            - $ref: "#/components/schemas/Quote"
+            - description: A winning quote.
+            - $ref: '#/components/schemas/Quote'
       required:
         - uid
         - sellToken
@@ -284,45 +345,56 @@ components:
     BigUint:
       description: A big unsigned integer encoded in decimal.
       type: string
-      example: "1234567890"
+      example: '1234567890'
     OrderUID:
-      description: |
-        Unique identifier for the order: 56 bytes encoded as hex with `0x` prefix.
+      description: >
+        Unique identifier for the order: 56 bytes encoded as hex with `0x`
+        prefix.
+
         Bytes 0 to 32 are the order digest, bytes 30 to 52 the owner address
+
         and bytes 52..56 valid to,
       type: string
-      example: "0x30cff40d9f60caa68a37f0ee73253ad6ad72b45580c945fe3ab67596476937197854163b1b0d24e77dca702b97b5cc33e0f83dcb626122a6"
+      example: >-
+        0x30cff40d9f60caa68a37f0ee73253ad6ad72b45580c945fe3ab67596476937197854163b1b0d24e77dca702b97b5cc33e0f83dcb626122a6
     QuoteResponseKind:
       oneOf:
-        - $ref: "#/components/schemas/LegacyQuoteResponse"
-        - $ref: "#/components/schemas/QuoteResponse"
-        - $ref: "#/components/schemas/Error"
+        - $ref: '#/components/schemas/LegacyQuoteResponse'
+        - $ref: '#/components/schemas/QuoteResponse'
+        - $ref: '#/components/schemas/Error'
     LegacyQuoteResponse:
-      description: |
+      description: >
         Successful Quote
+
 
         The Solver knows how to fill the request with these parameters.
 
-        If the request was of type `buy` then the response's buy amount has the same value as the
-        request's amount and the sell amount was filled in by the server. Vice versa for type
+
+        If the request was of type `buy` then the response's buy amount has the
+        same value as the
+
+        request's amount and the sell amount was filled in by the server. Vice
+        versa for type
+
         `sell`.
       type: object
       properties:
         amount:
-          $ref: "#/components/schemas/TokenAmount"
+          $ref: '#/components/schemas/TokenAmount'
         interactions:
           type: array
           items:
-            $ref: "#/components/schemas/Interaction"
+            $ref: '#/components/schemas/Interaction'
         solver:
-          description: The address of the solver that quoted this order.
-          $ref: "#/components/schemas/Address"
+          allOf:
+            - description: The address of the solver that quoted this order.
+            - $ref: '#/components/schemas/Address'
         gas:
           type: integer
           description: How many units of gas this trade is estimated to cost.
         txOrigin:
           allOf:
-            - $ref: "#/components/schemas/Address"
+            - $ref: '#/components/schemas/Address'
           description: Which `tx.origin` is required to make a quote simulation pass.
       required:
         - amount
@@ -340,37 +412,37 @@ components:
             Mapping of hex token address to the uniform clearing price.
           type: object
           additionalProperties:
-            $ref: "#/components/schemas/BigUint"
+            $ref: '#/components/schemas/BigUint'
         preInteractions:
           type: array
           items:
-            $ref: "#/components/schemas/Interaction"
+            $ref: '#/components/schemas/Interaction'
         interactions:
           type: array
           items:
-            $ref: "#/components/schemas/Interaction"
+            $ref: '#/components/schemas/Interaction'
         solver:
           allOf:
-            - $ref: "#/components/schemas/Address"
+            - $ref: '#/components/schemas/Address'
           description: The address of the solver that quoted this order.
         gas:
           type: integer
           description: How many units of gas this trade is estimated to cost.
         txOrigin:
           allOf:
-            - $ref: "#/components/schemas/Address"
+            - $ref: '#/components/schemas/Address'
           description: Which `tx.origin` is required to make a quote simulation pass.
         jitOrders:
           type: array
           items:
-            $ref: "#/components/schemas/JitOrder"
+            $ref: '#/components/schemas/JitOrder'
       required:
         - clearingPrices
         - solver
     DateTime:
       description: An ISO 8601 UTC date time string.
       type: string
-      example: "2020-12-03T18:35:18.814523Z"
+      example: '2020-12-03T18:35:18.814523Z'
     Calldata:
       description: hex encoded calldata with `0x` prefix.
       type: object
@@ -381,14 +453,16 @@ components:
 
             This is the calldata that can be found on chain.
           type: string
-          example: "0x1234567890"
+          example: '0x1234567890'
         uninternalized:
-          description: |
+          description: >
             The calldata with all internalized interactions encoded.
 
-            This is the calldata that should be used for simulation/verification purposes.
+
+            This is the calldata that should be used for simulation/verification
+            purposes.
           type: string
-          example: "0x1234567890"
+          example: '0x1234567890'
     SolveRequest:
       description: Request to the solve endpoint.
       type: object
@@ -400,23 +474,25 @@ components:
         orders:
           type: array
           items:
-            $ref: "#/components/schemas/Order"
+            $ref: '#/components/schemas/Order'
           description: |
             The solvable orders included in the auction.
         tokens:
           type: array
           items:
-            $ref: "#/components/schemas/Token"
+            $ref: '#/components/schemas/Token'
           description: |
             Information about tokens used in the auction.
         deadline:
-          $ref: "#/components/schemas/DateTime"
+          $ref: '#/components/schemas/DateTime'
         surplusCapturingJitOrderOwners:
           type: array
           items:
-            $ref: "#/components/schemas/Address"
-          description: |
-            List of addresses on whose surplus will count towards the objective value of their solution (unlike other orders that were created by the solver).
+            $ref: '#/components/schemas/Address'
+          description: >
+            List of addresses on whose surplus will count towards the objective
+            value of their solution (unlike other orders that were created by
+            the solver).
     SolveResponse:
       description: |
         Response of the solve endpoint.
@@ -430,7 +506,7 @@ components:
               solutionId:
                 description: |
                   The unique identifier of the solution.
-                  
+
                   This id is used to identify the solution when executing it.
                 type: integer
                 example: 1
@@ -438,26 +514,31 @@ components:
                 description: |
                   The objective value of the solution.
                 type: string
-                example: "100"
+                example: '100'
               submissionAddress:
-                description: |
-                  The address that will be used to submit the solution.
-                $ref: "#/components/schemas/Address"
+                allOf:
+                  - description: The address that will be used to submit the solution.
+                  - $ref: '#/components/schemas/Address'
               orders:
-                description: |
-                  Mapping of order uid to net executed amount (including all fees).
+                description: >
+                  Mapping of order uid to net executed amount (including all
+                  fees).
                 additionalProperties:
                   type: object
                   properties:
                     side:
                       type: string
-                      enum: ["buy", "sell"]
+                      enum:
+                        - buy
+                        - sell
                     sellToken:
-                      description: Token being sold
-                      $ref: "#/components/schemas/Address"
+                      allOf:
+                        - description: Token being sold
+                        - $ref: '#/components/schemas/Address'
                     buyToken:
-                      description: Token being bought
-                      $ref: "#/components/schemas/Address"
+                      allOf:
+                        - description: Token being bought
+                        - $ref: '#/components/schemas/Address'
                     limitSell:
                       type: string
                       description: Maximum amount to be sold.
@@ -466,19 +547,22 @@ components:
                       description: Minimum amount to be bought.
                     executedSell:
                       type: string
-                      description: The effective amount that left the user's wallet including all fees.
+                      description: >-
+                        The effective amount that left the user's wallet
+                        including all fees.
                     executedBuy:
                       type: string
                       description: The effective amount the user received after all fees.
               clearingPrices:
-                description: |
+                description: >
                   Mapping of hex token address to price.
-                  
-                  The prices of tokens for settled user orders as passed to the settlement contract.
+
+
+                  The prices of tokens for settled user orders as passed to the
+                  settlement contract.
                 type: object
                 additionalProperties:
-                  $ref: "#/components/schemas/BigUint"
-
+                  $ref: '#/components/schemas/BigUint'
               gas:
                 type: integer
     Solution:
@@ -502,111 +586,139 @@ components:
       type: object
       properties:
         calldata:
-          $ref: "#/components/schemas/Calldata"
+          $ref: '#/components/schemas/Calldata'
     FeePolicy:
-      description: |
+      description: >
         A fee policy that applies to an order.
 
-        The solver should make sure the fee policy is applied when computing their solution.
+
+        The solver should make sure the fee policy is applied when computing
+        their solution.
       type: object
       oneOf:
-        - $ref: "#/components/schemas/SurplusFee"
-        - $ref: "#/components/schemas/PriceImprovement"
-        - $ref: "#/components/schemas/VolumeFee"
+        - $ref: '#/components/schemas/SurplusFee'
+        - $ref: '#/components/schemas/PriceImprovement'
+        - $ref: '#/components/schemas/VolumeFee'
     SurplusFee:
-      description: |
-        If the order receives more than limit price, pay the protocol a factor of the difference.
+      description: >
+        If the order receives more than limit price, pay the protocol a factor
+        of the difference.
       type: object
       properties:
         kind:
           type: string
-          enum: ["surplus"]
+          enum:
+            - surplus
         maxVolumeFactor:
           description: Never charge more than that percentage of the order volume.
           type: number
           example: 0.1
         factor:
-          description: The factor of the user surplus that the protocol will request from the solver after settling the order
+          description: >-
+            The factor of the user surplus that the protocol will request from
+            the solver after settling the order
           type: number
           example: 0.5
     PriceImprovement:
-      description: |
-        A cut from the price improvement over the best quote is taken as a protocol fee.
+      description: >
+        A cut from the price improvement over the best quote is taken as a
+        protocol fee.
       type: object
       properties:
         kind:
           type: string
-          enum: ["priceImprovement"]
+          enum:
+            - priceImprovement
         maxVolumeFactor:
           description: Never charge more than that percentage of the order volume.
           type: number
           example: 0.01
         factor:
-          description: The factor of the user surplus that the protocol will request from the solver after settling the order
+          description: >-
+            The factor of the user surplus that the protocol will request from
+            the solver after settling the order
           type: number
           example: 0.5
         quote:
-          $ref: "#/components/schemas/Quote"
+          $ref: '#/components/schemas/Quote'
     VolumeFee:
       type: object
       properties:
         kind:
           type: string
-          enum: ["volume"]
+          enum:
+            - volume
         factor:
-          description: The fraction of the order's volume that the protocol will request from the solver after settling the order.
+          description: >-
+            The fraction of the order's volume that the protocol will request
+            from the solver after settling the order.
           type: number
           example: 0.5
     Quote:
       type: object
       properties:
         sellAmount:
-          $ref: "#/components/schemas/TokenAmount"
+          $ref: '#/components/schemas/TokenAmount'
         buyAmount:
-          $ref: "#/components/schemas/TokenAmount"
+          $ref: '#/components/schemas/TokenAmount'
         fee:
-          $ref: "#/components/schemas/TokenAmount"
+          $ref: '#/components/schemas/TokenAmount'
         solver:
-          $ref: "#/components/schemas/Address"
+          $ref: '#/components/schemas/Address'
     JitOrder:
       type: object
       properties:
         sellToken:
-          $ref: "#/components/schemas/Address"
+          $ref: '#/components/schemas/Address'
         buyToken:
-          $ref: "#/components/schemas/Address"
+          $ref: '#/components/schemas/Address'
         sellAmount:
-          $ref: "#/components/schemas/TokenAmount"
+          $ref: '#/components/schemas/TokenAmount'
         buyAmount:
-          $ref: "#/components/schemas/TokenAmount"
+          $ref: '#/components/schemas/TokenAmount'
         executedAmount:
-          $ref: "#/components/schemas/TokenAmount"
+          $ref: '#/components/schemas/TokenAmount'
         receiver:
-          $ref: "#/components/schemas/Address"
+          $ref: '#/components/schemas/Address'
         validTo:
           type: integer
         side:
           type: string
-          enum: ["buy", "sell"]
+          enum:
+            - buy
+            - sell
         partiallyFillable:
           type: boolean
         sellTokenSource:
           type: string
-          enum: ["erc20", "internal", "external"]
+          enum:
+            - erc20
+            - internal
+            - external
         buyTokenSource:
           type: string
-          enum: ["erc20", "internal"]
+          enum:
+            - erc20
+            - internal
         appData:
           type: string
         signature:
-          description: | 
-            Hex encoded bytes with `0x` prefix. The content depends on the `signingScheme`.
+          description: >
+            Hex encoded bytes with `0x` prefix. The content depends on the
+            `signingScheme`.
+
             For `presign`, this should contain the address of the owner. 
-            For `eip1271`, the signature should consist of `<owner_address><signature_bytes>`.
+
+            For `eip1271`, the signature should consist of
+            `<owner_address><signature_bytes>`.
           type: string
         signingScheme:
           type: string
-          enum: ["eip712", "ethsign", "presign", "eip1271"]
+          enum:
+            - eip712
+            - ethsign
+            - presign
+            - eip1271
       required:
         - sellToken
         - buyToken
@@ -633,6 +745,8 @@ components:
           description: Text describing the error.
           type: string
   responses:
+    200:
+      description: The request was successful.
     BadRequest:
       description: |
         There is something wrong with the request.

--- a/crates/driver/openapi.yml
+++ b/crates/driver/openapi.yml
@@ -6,7 +6,7 @@ info:
   version: 0.0.1
   contact:
     name: CoW DAO
-    url: 'https://cow.fi'
+      url: "https://cow.fi"
     email: dev@cow.fi
 paths:
   /quote:
@@ -17,13 +17,13 @@ paths:
           name: sellToken
           description: The token to sell.
           schema:
-            $ref: '#/components/schemas/Address'
+            $ref: "#/components/schemas/Address"
           required: true
         - in: query
           name: buyToken
           description: The token to buy.
           schema:
-            $ref: '#/components/schemas/Address'
+            $ref: "#/components/schemas/Address"
           required: true
         - in: query
           name: kind
@@ -40,27 +40,27 @@ paths:
           name: amount
           description: The amount to buy or sell.
           schema:
-            $ref: '#/components/schemas/TokenAmount'
+            $ref: "#/components/schemas/TokenAmount"
           required: true
         - in: query
           name: deadline
           description: The time until which the caller expects a response.
           schema:
-            $ref: '#/components/schemas/DateTime'
+            $ref: "#/components/schemas/DateTime"
           required: true
       responses:
-        '200':
+        "200":
           description: Quote successfully created.
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/QuoteResponseKind'
-        '400':
-          $ref: '#/components/responses/BadRequest'
-        '429':
+                $ref: "#/components/schemas/QuoteResponseKind"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "429":
           description: The solver cannot keep up. It is too busy to handle more requests.
-        '500':
-          $ref: '#/components/responses/InternalServerError'
+        "500":
+          $ref: "#/components/responses/InternalServerError"
   /solve:
     post:
       description: |-
@@ -83,18 +83,18 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/SolveRequest'
+              $ref: "#/components/schemas/SolveRequest"
       responses:
-        '200':
+        "200":
           description: Auction successfully solved.
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/SolveResponse'
-        '400':
-          $ref: '#/components/responses/BadRequest'
-        '500':
-          $ref: '#/components/responses/InternalServerError'
+                $ref: "#/components/schemas/SolveResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
   /reveal:
     post:
       description: >
@@ -107,18 +107,18 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/Solution'
+              $ref: "#/components/schemas/Solution"
       responses:
-        '200':
+        "200":
           description: Execution accepted.
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/RevealedResponse'
-        '400':
-          $ref: '#/components/responses/BadRequest'
-        '500':
-          $ref: '#/components/responses/InternalServerError'
+                $ref: "#/components/schemas/RevealedResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
   /settle:
     post:
       description: |-
@@ -134,31 +134,31 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/Solution'
+              $ref: "#/components/schemas/Solution"
       responses:
-        '200':
+        "200":
           description: Execution accepted.
-        '400':
-          $ref: '#/components/responses/BadRequest'
-        '500':
-          $ref: '#/components/responses/InternalServerError'
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
 components:
   schemas:
     Address:
       description: 20 byte Ethereum address encoded as a hex with `0x` prefix.
       type: string
-      example: '0x6810e776880c02933d47db1b9fc05908e5386b96'
+      example: "0x6810e776880c02933d47db1b9fc05908e5386b96"
     TokenAmount:
       description: Amount of an ERC20 token. 256 bit unsigned integer in decimal notation.
       type: string
-      example: '1234567890'
+      example: "1234567890"
     Interaction:
       type: object
       properties:
         target:
-          $ref: '#/components/schemas/Address'
+          $ref: "#/components/schemas/Address"
         value:
-          $ref: '#/components/schemas/TokenAmount'
+          $ref: "#/components/schemas/TokenAmount"
         callData:
           description: Hex encoded bytes with `0x` prefix.
           type: string
@@ -167,11 +167,11 @@ components:
       type: object
       properties:
         address:
-          $ref: '#/components/schemas/Address'
+          $ref: "#/components/schemas/Address"
         price:
           nullable: true
           allOf:
-            - $ref: '#/components/schemas/TokenAmount'
+            - $ref: "#/components/schemas/TokenAmount"
           description: |-
             The reference price denominated in native token (i.e. 1e18
             represents a token that
@@ -197,27 +197,27 @@ components:
       type: object
       properties:
         uid:
-          $ref: '#/components/schemas/OrderUID'
+          $ref: "#/components/schemas/OrderUID"
         sellToken:
           allOf:
             - description: Token being sold
-            - $ref: '#/components/schemas/Address'
+            - $ref: "#/components/schemas/Address"
         buyToken:
           allOf:
             - description: Token being bought
-            - $ref: '#/components/schemas/Address'
+            - $ref: "#/components/schemas/Address"
         sellAmount:
           allOf:
             - description: Amount to be sold
-            - $ref: '#/components/schemas/TokenAmount'
+            - $ref: "#/components/schemas/TokenAmount"
         buyAmount:
           allOf:
             - description: Amount to be bought
-            - $ref: '#/components/schemas/TokenAmount'
+            - $ref: "#/components/schemas/TokenAmount"
         created:
           description: Creation time of the order. Denominated in epoch seconds.
           type: string
-          example: '123456'
+          example: "123456"
         validTo:
           description: The time until which the order is valid.
           type: integer
@@ -229,11 +229,11 @@ components:
         receiver:
           allOf:
             - description: The address that should receive the bought tokens.
-            - $ref: '#/components/schemas/Address'
+            - $ref: "#/components/schemas/Address"
         owner:
           allOf:
             - description: The address that created the order.
-            - $ref: '#/components/schemas/Address'
+            - $ref: "#/components/schemas/Address"
         partiallyFillable:
           description: |-
             Whether the order can be partially filled.
@@ -244,17 +244,17 @@ components:
         executed:
           allOf:
             - description: The amount that has already been filled.
-            - $ref: '#/components/schemas/TokenAmount'
+            - $ref: "#/components/schemas/TokenAmount"
         preInteractions:
           description: Interactions that must be executed before the order can be filled.
           type: array
           items:
-            $ref: '#/components/schemas/Interaction'
+            $ref: "#/components/schemas/Interaction"
         postInteractions:
           description: Interactions that must be executed after the order has been filled.
           type: array
           items:
-            $ref: '#/components/schemas/Interaction'
+            $ref: "#/components/schemas/Interaction"
         sellTokenBalance:
           type: string
           enum:
@@ -292,11 +292,11 @@ components:
             their solution.
           type: array
           items:
-            $ref: '#/components/schemas/FeePolicy'
+            $ref: "#/components/schemas/FeePolicy"
         quote:
           allOf:
             - description: A winning quote.
-            - $ref: '#/components/schemas/Quote'
+            - $ref: "#/components/schemas/Quote"
       required:
         - uid
         - sellToken
@@ -321,7 +321,7 @@ components:
     BigUint:
       description: A big unsigned integer encoded in decimal.
       type: string
-      example: '1234567890'
+      example: "1234567890"
     OrderUID:
       description: |-
         Unique identifier for the order: 56 bytes encoded as hex with `0x`
@@ -334,9 +334,9 @@ components:
         0x30cff40d9f60caa68a37f0ee73253ad6ad72b45580c945fe3ab67596476937197854163b1b0d24e77dca702b97b5cc33e0f83dcb626122a6
     QuoteResponseKind:
       oneOf:
-        - $ref: '#/components/schemas/LegacyQuoteResponse'
-        - $ref: '#/components/schemas/QuoteResponse'
-        - $ref: '#/components/schemas/Error'
+        - $ref: "#/components/schemas/LegacyQuoteResponse"
+        - $ref: "#/components/schemas/QuoteResponse"
+        - $ref: "#/components/schemas/Error"
     LegacyQuoteResponse:
       description: |-
         Successful Quote.
@@ -349,21 +349,21 @@ components:
       type: object
       properties:
         amount:
-          $ref: '#/components/schemas/TokenAmount'
+          $ref: "#/components/schemas/TokenAmount"
         interactions:
           type: array
           items:
-            $ref: '#/components/schemas/Interaction'
+            $ref: "#/components/schemas/Interaction"
         solver:
           allOf:
             - description: The address of the solver that quoted this order.
-            - $ref: '#/components/schemas/Address'
+            - $ref: "#/components/schemas/Address"
         gas:
           type: integer
           description: How many units of gas this trade is estimated to cost.
         txOrigin:
           allOf:
-            - $ref: '#/components/schemas/Address'
+            - $ref: "#/components/schemas/Address"
           description: Which `tx.origin` is required to make a quote simulation pass.
       required:
         - amount
@@ -380,37 +380,37 @@ components:
             Mapping of hex token address to the uniform clearing price.
           type: object
           additionalProperties:
-            $ref: '#/components/schemas/BigUint'
+            $ref: "#/components/schemas/BigUint"
         preInteractions:
           type: array
           items:
-            $ref: '#/components/schemas/Interaction'
+            $ref: "#/components/schemas/Interaction"
         interactions:
           type: array
           items:
-            $ref: '#/components/schemas/Interaction'
+            $ref: "#/components/schemas/Interaction"
         solver:
           allOf:
-            - $ref: '#/components/schemas/Address'
+            - $ref: "#/components/schemas/Address"
           description: The address of the solver that quoted this order.
         gas:
           type: integer
           description: How many units of gas this trade is estimated to cost.
         txOrigin:
           allOf:
-            - $ref: '#/components/schemas/Address'
+            - $ref: "#/components/schemas/Address"
           description: Which `tx.origin` is required to make a quote simulation pass.
         jitOrders:
           type: array
           items:
-            $ref: '#/components/schemas/JitOrder'
+            $ref: "#/components/schemas/JitOrder"
       required:
         - clearingPrices
         - solver
     DateTime:
       description: An ISO 8601 UTC date time string.
       type: string
-      example: '2020-12-03T18:35:18.814523Z'
+      example: "2020-12-03T18:35:18.814523Z"
     Calldata:
       description: hex encoded calldata with `0x` prefix.
       type: object
@@ -420,7 +420,7 @@ components:
             The calldata without any internalized interactions encoded.
             This is the calldata that can be found on chain.
           type: string
-          example: '0x1234567890'
+          example: "0x1234567890"
         uninternalized:
           description: |-
             The calldata with all internalized interactions encoded.
@@ -428,7 +428,7 @@ components:
             This is the calldata that should be used for simulation/verification
             purposes.
           type: string
-          example: '0x1234567890'
+          example: "0x1234567890"
     SolveRequest:
       description: Request to the solve endpoint.
       type: object
@@ -440,21 +440,21 @@ components:
         orders:
           type: array
           items:
-            $ref: '#/components/schemas/Order'
+            $ref: "#/components/schemas/Order"
           description: |
             The solvable orders included in the auction.
         tokens:
           type: array
           items:
-            $ref: '#/components/schemas/Token'
+            $ref: "#/components/schemas/Token"
           description: |
             Information about tokens used in the auction.
         deadline:
-          $ref: '#/components/schemas/DateTime'
+          $ref: "#/components/schemas/DateTime"
         surplusCapturingJitOrderOwners:
           type: array
           items:
-            $ref: '#/components/schemas/Address'
+            $ref: "#/components/schemas/Address"
           description: >
             List of addresses on whose surplus will count towards the objective
             value of their solution (unlike other orders that were created by
@@ -479,11 +479,11 @@ components:
                 description: |
                   The objective value of the solution.
                 type: string
-                example: '100'
+                example: "100"
               submissionAddress:
                 allOf:
                   - description: The address that will be used to submit the solution.
-                  - $ref: '#/components/schemas/Address'
+                  - $ref: "#/components/schemas/Address"
               orders:
                 description: >
                   Mapping of order uid to net executed amount (including all
@@ -499,11 +499,11 @@ components:
                     sellToken:
                       allOf:
                         - description: Token being sold
-                        - $ref: '#/components/schemas/Address'
+                        - $ref: "#/components/schemas/Address"
                     buyToken:
                       allOf:
                         - description: Token being bought
-                        - $ref: '#/components/schemas/Address'
+                        - $ref: "#/components/schemas/Address"
                     limitSell:
                       type: string
                       description: Maximum amount to be sold.
@@ -526,7 +526,7 @@ components:
                   settlement contract.
                 type: object
                 additionalProperties:
-                  $ref: '#/components/schemas/BigUint'
+                  $ref: "#/components/schemas/BigUint"
               gas:
                 type: integer
     Solution:
@@ -550,7 +550,7 @@ components:
       type: object
       properties:
         calldata:
-          $ref: '#/components/schemas/Calldata'
+          $ref: "#/components/schemas/Calldata"
     FeePolicy:
       description: >
         A fee policy that applies to an order.
@@ -559,9 +559,9 @@ components:
         their solution.
       type: object
       oneOf:
-        - $ref: '#/components/schemas/SurplusFee'
-        - $ref: '#/components/schemas/PriceImprovement'
-        - $ref: '#/components/schemas/VolumeFee'
+        - $ref: "#/components/schemas/SurplusFee"
+        - $ref: "#/components/schemas/PriceImprovement"
+        - $ref: "#/components/schemas/VolumeFee"
     SurplusFee:
       description: >
         If the order receives more than limit price, pay the protocol a factor
@@ -603,7 +603,7 @@ components:
           type: number
           example: 0.5
         quote:
-          $ref: '#/components/schemas/Quote'
+          $ref: "#/components/schemas/Quote"
     VolumeFee:
       type: object
       properties:
@@ -621,28 +621,28 @@ components:
       type: object
       properties:
         sellAmount:
-          $ref: '#/components/schemas/TokenAmount'
+          $ref: "#/components/schemas/TokenAmount"
         buyAmount:
-          $ref: '#/components/schemas/TokenAmount'
+          $ref: "#/components/schemas/TokenAmount"
         fee:
-          $ref: '#/components/schemas/TokenAmount'
+          $ref: "#/components/schemas/TokenAmount"
         solver:
-          $ref: '#/components/schemas/Address'
+          $ref: "#/components/schemas/Address"
     JitOrder:
       type: object
       properties:
         sellToken:
-          $ref: '#/components/schemas/Address'
+          $ref: "#/components/schemas/Address"
         buyToken:
-          $ref: '#/components/schemas/Address'
+          $ref: "#/components/schemas/Address"
         sellAmount:
-          $ref: '#/components/schemas/TokenAmount'
+          $ref: "#/components/schemas/TokenAmount"
         buyAmount:
-          $ref: '#/components/schemas/TokenAmount'
+          $ref: "#/components/schemas/TokenAmount"
         executedAmount:
-          $ref: '#/components/schemas/TokenAmount'
+          $ref: "#/components/schemas/TokenAmount"
         receiver:
-          $ref: '#/components/schemas/Address'
+          $ref: "#/components/schemas/Address"
         validTo:
           type: integer
         side:
@@ -708,7 +708,7 @@ components:
           description: Text describing the error.
           type: string
   responses:
-    '200':
+    "200":
       description: The request was successful.
     BadRequest:
       description: |-

--- a/crates/orderbook/openapi.yml
+++ b/crates/orderbook/openapi.yml
@@ -4,27 +4,27 @@ info:
   title: Order Book API
   contact:
     name: CoW DAO
-    url: 'https://cow.fi'
+    url: "https://cow.fi"
     email: dev@cow.fi
 servers:
   - description: Mainnet (Prod)
-    url: 'https://api.cow.fi/mainnet'
+    url: "https://api.cow.fi/mainnet"
   - description: Mainnet (Staging)
-    url: 'https://barn.api.cow.fi/mainnet'
+    url: "https://barn.api.cow.fi/mainnet"
   - description: Gnosis Chain (Prod)
-    url: 'https://api.cow.fi/xdai'
+    url: "https://api.cow.fi/xdai"
   - description: Gnosis Chain (Staging)
-    url: 'https://barn.api.cow.fi/xdai'
+    url: "https://barn.api.cow.fi/xdai"
   - description: Arbitrum One (Prod)
-    url: 'https://api.cow.fi/arbitrum_one'
+    url: "https://api.cow.fi/arbitrum_one"
   - description: Arbitrum One (Staging)
-    url: 'https://barn.api.cow.fi/arbitrum_one'
+    url: "https://barn.api.cow.fi/arbitrum_one"
   - description: Sepolia (Prod)
-    url: 'https://api.cow.fi/sepolia'
+    url: "https://api.cow.fi/sepolia"
   - description: Sepolia (Staging)
-    url: 'https://barn.api.cow.fi/sepolia'
+    url: "https://barn.api.cow.fi/sepolia"
   - description: Local
-    url: 'http://localhost:8080'
+    url: "http://localhost:8080"
 paths:
   /api/v1/orders:
     post:
@@ -40,25 +40,25 @@ paths:
         This may be useful for replacing orders when on-chain prices move
         outside of the original order's limit price.
       responses:
-        '201':
+        "201":
           description: Order has been accepted.
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/UID'
-        '400':
+                $ref: "#/components/schemas/UID"
+        "400":
           description: Error during order validation.
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/OrderPostError'
-        '403':
-          description: 'Forbidden, your account is deny-listed.'
-        '404':
+                $ref: "#/components/schemas/OrderPostError"
+        "403":
+          description: "Forbidden, your account is deny-listed."
+        "404":
           description: No route was found quoting the order.
-        '429':
+        "429":
           description: Too many order placements.
-        '500':
+        "500":
           description: Error adding an order.
       requestBody:
         description: The order to create.
@@ -66,7 +66,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/OrderCreation'
+              $ref: "#/components/schemas/OrderCreation"
     delete:
       summary: Cancel multiple orders by marking them invalid with a timestamp.
       description: >
@@ -81,37 +81,37 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/OrderCancellations'
+              $ref: "#/components/schemas/OrderCancellations"
       responses:
-        '200':
+        "200":
           description: Order(s) are cancelled.
-        '400':
+        "400":
           description: Malformed signature.
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/OrderCancellationError'
-        '401':
+                $ref: "#/components/schemas/OrderCancellationError"
+        "401":
           description: Invalid signature.
-        '404':
+        "404":
           description: One or more orders were not found and no orders were cancelled.
-  '/api/v1/orders/{UID}':
+  "/api/v1/orders/{UID}":
     get:
       summary: Get existing order from UID.
       parameters:
         - in: path
           name: UID
           schema:
-            $ref: '#/components/schemas/UID'
+            $ref: "#/components/schemas/UID"
           required: true
       responses:
-        '200':
+        "200":
           description: Order
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Order'
-        '404':
+                $ref: "#/components/schemas/Order"
+        "404":
           description: Order was not found.
     delete:
       deprecated: true
@@ -127,7 +127,7 @@ paths:
         - in: path
           name: UID
           schema:
-            $ref: '#/components/schemas/UID'
+            $ref: "#/components/schemas/UID"
           required: true
       requestBody:
         description: Signed `OrderCancellation`
@@ -135,56 +135,56 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/OrderCancellation'
+              $ref: "#/components/schemas/OrderCancellation"
       responses:
-        '200':
+        "200":
           description: Order cancelled.
-        '400':
+        "400":
           description: Malformed signature.
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/OrderCancellationError'
-        '401':
+                $ref: "#/components/schemas/OrderCancellationError"
+        "401":
           description: Invalid signature.
-        '404':
+        "404":
           description: Order was not found.
-  '/api/v1/orders/{UID}/status':
+  "/api/v1/orders/{UID}/status":
     get:
       summary: Get the status of an order.
       parameters:
         - in: path
           name: UID
           schema:
-            $ref: '#/components/schemas/UID'
+            $ref: "#/components/schemas/UID"
           required: true
       responses:
-        '200':
+        "200":
           description: >-
             The order status with a list of solvers that proposed solutions (if
             applicable).
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/CompetitionOrderStatus'
-  '/api/v1/transactions/{txHash}/orders':
+                $ref: "#/components/schemas/CompetitionOrderStatus"
+  "/api/v1/transactions/{txHash}/orders":
     get:
       summary: Get orders by settlement transaction hash.
       parameters:
         - in: path
           name: txHash
           schema:
-            $ref: '#/components/schemas/TransactionHash'
+            $ref: "#/components/schemas/TransactionHash"
           required: true
       responses:
-        '200':
+        "200":
           description: Order(s).
           content:
             application/json:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/Order'
+                  $ref: "#/components/schemas/Order"
   /api/v1/trades:
     get:
       summary: Get existing trades.
@@ -194,15 +194,15 @@ paths:
         - name: owner
           in: query
           schema:
-            $ref: '#/components/schemas/Address'
+            $ref: "#/components/schemas/Address"
           required: false
         - name: orderUid
           in: query
           schema:
-            $ref: '#/components/schemas/UID'
+            $ref: "#/components/schemas/UID"
           required: false
       responses:
-        '200':
+        "200":
           description: |-
             ### If `owner` is specified:
 
@@ -218,7 +218,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/Trade'
+                  $ref: "#/components/schemas/Trade"
   /api/v1/auction:
     get:
       summary: Get the current batch auction.
@@ -233,13 +233,13 @@ paths:
         **Note: This endpoint is currently permissioned. Reach out in discord if
         you need access.**
       responses:
-        '200':
+        "200":
           description: Batch auction.
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Auction'
-  '/api/v1/account/{owner}/orders':
+                $ref: "#/components/schemas/Auction"
+  "/api/v1/account/{owner}/orders":
     get:
       summary: Get orders of one user paginated.
       description: |-
@@ -254,7 +254,7 @@ paths:
           in: path
           required: true
           schema:
-            $ref: '#/components/schemas/Address'
+            $ref: "#/components/schemas/Address"
         - name: offset
           in: query
           description: |
@@ -270,17 +270,17 @@ paths:
             type: integer
           required: false
       responses:
-        '200':
+        "200":
           description: The orders.
           content:
             application/json:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/Order'
-        '400':
+                  $ref: "#/components/schemas/Order"
+        "400":
           description: Problem with parameters like limit being too large.
-  '/api/v1/token/{token}/native_price':
+  "/api/v1/token/{token}/native_price":
     get:
       summary: Get native price for the given token.
       description: |-
@@ -294,19 +294,19 @@ paths:
           in: path
           required: true
           schema:
-            $ref: '#/components/schemas/Address'
+            $ref: "#/components/schemas/Address"
       responses:
-        '200':
+        "200":
           description: The estimated native price.
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/NativePriceResponse'
-        '400':
+                $ref: "#/components/schemas/NativePriceResponse"
+        "400":
           description: Error finding the price.
-        '404':
+        "404":
           description: No liquidity was found.
-        '500':
+        "500":
           description: Unexpected error.
   /api/v1/quote:
     post:
@@ -322,27 +322,27 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/OrderQuoteRequest'
+              $ref: "#/components/schemas/OrderQuoteRequest"
       responses:
-        '200':
+        "200":
           description: Quoted order.
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/OrderQuoteResponse'
-        '400':
+                $ref: "#/components/schemas/OrderQuoteResponse"
+        "400":
           description: Error quoting order.
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/PriceEstimationError'
-        '404':
+                $ref: "#/components/schemas/PriceEstimationError"
+        "404":
           description: No route was found for the specified order.
-        '429':
+        "429":
           description: Too many order quotes.
-        '500':
+        "500":
           description: Unexpected error quoting an order.
-  '/api/v1/solver_competition/{auction_id}':
+  "/api/v1/solver_competition/{auction_id}":
     get:
       summary: Get information about a solver competition.
       description: |
@@ -354,15 +354,15 @@ paths:
           schema:
             type: integer
       responses:
-        '200':
+        "200":
           description: Competition
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/SolverCompetitionResponse'
-        '404':
+                $ref: "#/components/schemas/SolverCompetitionResponse"
+        "404":
           description: No competition information available for this auction id.
-  '/api/v1/solver_competition/by_tx_hash/{tx_hash}':
+  "/api/v1/solver_competition/by_tx_hash/{tx_hash}":
     get:
       summary: Get information about solver competition.
       description: |
@@ -373,15 +373,15 @@ paths:
           in: path
           required: true
           schema:
-            $ref: '#/components/schemas/TransactionHash'
+            $ref: "#/components/schemas/TransactionHash"
       responses:
-        '200':
+        "200":
           description: Competition
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/SolverCompetitionResponse'
-        '404':
+                $ref: "#/components/schemas/SolverCompetitionResponse"
+        "404":
           description: No competition information available for this `tx_hash`.
   /api/v1/solver_competition/latest:
     get:
@@ -389,13 +389,13 @@ paths:
       description: |
         Returns the competition information for the last seen auction_id.
       responses:
-        '200':
+        "200":
           description: Competition
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/SolverCompetitionResponse'
-        '404':
+                $ref: "#/components/schemas/SolverCompetitionResponse"
+        "404":
           description: No competition information available.
   /api/v1/version:
     get:
@@ -404,27 +404,27 @@ paths:
         Returns the git commit hash, branch name and release tag (code:
         https://github.com/cowprotocol/services).
       responses:
-        '200':
+        "200":
           description: Version
           content:
             text/plain: {}
-  '/api/v1/app_data/{app_data_hash}':
+  "/api/v1/app_data/{app_data_hash}":
     get:
       summary: Get the full `appData` from contract `appDataHash`.
       parameters:
         - in: path
           name: app_data_hash
           schema:
-            $ref: '#/components/schemas/AppDataHash'
+            $ref: "#/components/schemas/AppDataHash"
           required: true
       responses:
-        '200':
+        "200":
           description: Full `appData`.
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/AppDataObject'
-        '404':
+                $ref: "#/components/schemas/AppDataObject"
+        "404":
           description: No full `appData` stored for this hash.
     put:
       summary: Registers a full `appData` so it can be referenced by `appDataHash`.
@@ -436,7 +436,7 @@ paths:
         - in: path
           name: app_data_hash
           schema:
-            $ref: '#/components/schemas/AppDataHash'
+            $ref: "#/components/schemas/AppDataHash"
           required: true
       requestBody:
         description: The `appData` document to upload.
@@ -444,23 +444,23 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/AppDataObject'
+              $ref: "#/components/schemas/AppDataObject"
       responses:
-        '200':
+        "200":
           description: The full `appData` already exists.
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/AppDataHash'
-        '201':
+                $ref: "#/components/schemas/AppDataHash"
+        "201":
           description: The full `appData` was successfully registered.
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/AppDataHash'
-        '400':
+                $ref: "#/components/schemas/AppDataHash"
+        "400":
           description: Error validating full `appData`
-        '500':
+        "500":
           description: Error storing the full `appData`
   /api/v1/app_data:
     put:
@@ -474,27 +474,27 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/AppDataObject'
+              $ref: "#/components/schemas/AppDataObject"
       responses:
-        '200':
+        "200":
           description: The full `appData` already exists.
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/AppDataHash'
-        '201':
+                $ref: "#/components/schemas/AppDataHash"
+        "201":
           description: The full `appData` was successfully registered.
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/AppDataHash'
-        '400':
+                $ref: "#/components/schemas/AppDataHash"
+        "400":
           description: Error validating full `appData`
-        '500':
+        "500":
           description: Error storing the full `appData`
-  '/api/v1/users/{address}/total_surplus':
+  "/api/v1/users/{address}/total_surplus":
     get:
-      summary: 'Get the total surplus earned by the user. [UNSTABLE]'
+      summary: "Get the total surplus earned by the user. [UNSTABLE]"
       description: |-
         ### Caution
 
@@ -504,25 +504,25 @@ paths:
         - in: path
           name: address
           schema:
-            $ref: '#/components/schemas/Address'
+            $ref: "#/components/schemas/Address"
           required: true
       responses:
-        '200':
+        "200":
           description: The total surplus.
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/TotalSurplus'
+                $ref: "#/components/schemas/TotalSurplus"
 components:
   schemas:
     TransactionHash:
       description: 32 byte digest encoded as a hex with `0x` prefix.
       type: string
-      example: '0xd51f28edffcaaa76be4a22f6375ad289272c037f3cc072345676e88d92ced8b5'
+      example: "0xd51f28edffcaaa76be4a22f6375ad289272c037f3cc072345676e88d92ced8b5"
     Address:
       description: 20 byte Ethereum address encoded as a hex with `0x` prefix.
       type: string
-      example: '0x6810e776880c02933d47db1b9fc05908e5386b96'
+      example: "0x6810e776880c02933d47db1b9fc05908e5386b96"
     AppData:
       description: |
         The string encoding of a JSON object representing some `appData`. The
@@ -537,29 +537,29 @@ components:
         It's expected to be the hash of the stringified JSON object representing
         the `appData`.
       type: string
-      example: '0x0000000000000000000000000000000000000000000000000000000000000000'
+      example: "0x0000000000000000000000000000000000000000000000000000000000000000"
     AppDataObject:
       description: An `appData` document that is registered with the API.
       type: object
       properties:
         fullAppData:
-          $ref: '#/components/schemas/AppData'
+          $ref: "#/components/schemas/AppData"
       required:
         - appData
     BigUint:
       description: A big unsigned integer encoded in decimal.
       type: string
-      example: '1234567890'
+      example: "1234567890"
     CallData:
       description: >-
         Some `calldata` sent to a contract in a transaction encoded as a hex
         with `0x` prefix.
       type: string
-      example: '0xca11da7a'
+      example: "0xca11da7a"
     TokenAmount:
       description: Amount of a token. `uint256` encoded in decimal.
       type: string
-      example: '1234567890'
+      example: "1234567890"
     OnchainOrderData:
       type: object
       properties:
@@ -569,7 +569,7 @@ components:
             might be a smart contract, but not the user placing the order. The
             actual user will be provided in this field.
           allOf:
-            - $ref: '#/components/schemas/Address'
+            - $ref: "#/components/schemas/Address"
         placementError:
           description: >
             Describes the error, if the order placement was not successful. This
@@ -591,7 +591,7 @@ components:
             Specifies in which transaction the order was refunded. If
             this field is null the order was not yet refunded.
           allOf:
-            - $ref: '#/components/schemas/TransactionHash'
+            - $ref: "#/components/schemas/TransactionHash"
           nullable: true
         userValidTo:
           description: |
@@ -661,53 +661,53 @@ components:
         sellToken:
           description: ERC-20 token to be sold.
           allOf:
-            - $ref: '#/components/schemas/Address'
+            - $ref: "#/components/schemas/Address"
         buyToken:
           description: ERC-20 token to be bought.
           allOf:
-            - $ref: '#/components/schemas/Address'
+            - $ref: "#/components/schemas/Address"
         receiver:
           description: >
             An optional Ethereum address to receive the proceeds of the trade
             instead of the owner (i.e. the order signer).
           allOf:
-            - $ref: '#/components/schemas/Address'
+            - $ref: "#/components/schemas/Address"
           nullable: true
         sellAmount:
           description: Amount of `sellToken` to be sold in atoms.
           allOf:
-            - $ref: '#/components/schemas/TokenAmount'
+            - $ref: "#/components/schemas/TokenAmount"
         buyAmount:
           description: Amount of `buyToken` to be bought in atoms.
           allOf:
-            - $ref: '#/components/schemas/TokenAmount'
+            - $ref: "#/components/schemas/TokenAmount"
         validTo:
           description: Unix timestamp (`uint32`) until which the order is valid.
           type: integer
         appData:
-          $ref: '#/components/schemas/AppDataHash'
+          $ref: "#/components/schemas/AppDataHash"
         feeAmount:
           description: feeRatio * sellAmount + minimal_fee in atoms.
           allOf:
-            - $ref: '#/components/schemas/TokenAmount'
+            - $ref: "#/components/schemas/TokenAmount"
         kind:
           description: The kind is either a buy or sell order.
           allOf:
-            - $ref: '#/components/schemas/OrderKind'
+            - $ref: "#/components/schemas/OrderKind"
         partiallyFillable:
           description: Is the order fill-or-kill or partially fillable?
           type: boolean
         sellTokenBalance:
           allOf:
-            - $ref: '#/components/schemas/SellTokenSource'
+            - $ref: "#/components/schemas/SellTokenSource"
           default: erc20
         buyTokenBalance:
           allOf:
-            - $ref: '#/components/schemas/BuyTokenDestination'
+            - $ref: "#/components/schemas/BuyTokenDestination"
           default: erc20
         signingScheme:
           allOf:
-            - $ref: '#/components/schemas/SigningScheme'
+            - $ref: "#/components/schemas/SigningScheme"
           default: eip712
       required:
         - sellToken
@@ -724,54 +724,54 @@ components:
       type: object
       properties:
         sellToken:
-          description: 'see `OrderParameters::sellToken`'
+          description: "see `OrderParameters::sellToken`"
           allOf:
-            - $ref: '#/components/schemas/Address'
+            - $ref: "#/components/schemas/Address"
         buyToken:
-          description: 'see `OrderParameters::buyToken`'
+          description: "see `OrderParameters::buyToken`"
           allOf:
-            - $ref: '#/components/schemas/Address'
+            - $ref: "#/components/schemas/Address"
         receiver:
-          description: 'see `OrderParameters::receiver`'
+          description: "see `OrderParameters::receiver`"
           allOf:
-            - $ref: '#/components/schemas/Address'
+            - $ref: "#/components/schemas/Address"
           nullable: true
         sellAmount:
-          description: 'see `OrderParameters::sellAmount`'
+          description: "see `OrderParameters::sellAmount`"
           allOf:
-            - $ref: '#/components/schemas/TokenAmount'
+            - $ref: "#/components/schemas/TokenAmount"
         buyAmount:
-          description: 'see `OrderParameters::buyAmount`'
+          description: "see `OrderParameters::buyAmount`"
           allOf:
-            - $ref: '#/components/schemas/TokenAmount'
+            - $ref: "#/components/schemas/TokenAmount"
         validTo:
-          description: 'see `OrderParameters::validTo`'
+          description: "see `OrderParameters::validTo`"
           type: integer
         feeAmount:
-          description: 'see `OrderParameters::feeAmount`'
+          description: "see `OrderParameters::feeAmount`"
           allOf:
-            - $ref: '#/components/schemas/TokenAmount'
+            - $ref: "#/components/schemas/TokenAmount"
         kind:
-          description: 'see `OrderParameters::kind`'
+          description: "see `OrderParameters::kind`"
           allOf:
-            - $ref: '#/components/schemas/OrderKind'
+            - $ref: "#/components/schemas/OrderKind"
         partiallyFillable:
-          description: 'see `OrderParameters::partiallyFillable`'
+          description: "see `OrderParameters::partiallyFillable`"
           type: boolean
         sellTokenBalance:
-          description: 'see `OrderParameters::sellTokenBalance`'
+          description: "see `OrderParameters::sellTokenBalance`"
           allOf:
-            - $ref: '#/components/schemas/SellTokenSource'
+            - $ref: "#/components/schemas/SellTokenSource"
           default: erc20
         buyTokenBalance:
-          description: 'see `OrderParameters::buyTokenBalance`'
+          description: "see `OrderParameters::buyTokenBalance`"
           allOf:
-            - $ref: '#/components/schemas/BuyTokenDestination'
+            - $ref: "#/components/schemas/BuyTokenDestination"
           default: erc20
         signingScheme:
-          $ref: '#/components/schemas/SigningScheme'
+          $ref: "#/components/schemas/SigningScheme"
         signature:
-          $ref: '#/components/schemas/Signature'
+          $ref: "#/components/schemas/Signature"
         from:
           description: >
             If set, the backend enforces that this address matches what is
@@ -780,7 +780,7 @@ components:
             silently work with an unexpected address that for example does not
             have any balance.
           allOf:
-            - $ref: '#/components/schemas/Address'
+            - $ref: "#/components/schemas/Address"
           nullable: true
         quoteId:
           description: >
@@ -796,7 +796,7 @@ components:
           anyOf:
             - title: Full App Data
               allOf:
-                - $ref: '#/components/schemas/AppData'
+                - $ref: "#/components/schemas/AppData"
               description: >-
                 **Short**:
 
@@ -836,7 +836,7 @@ components:
                 The total byte size of this field's UTF-8 encoded bytes is
                 limited to 1000.
               type: string
-            - $ref: '#/components/schemas/AppDataHash'
+            - $ref: "#/components/schemas/AppDataHash"
         appDataHash:
           description: >
             May be set for debugging purposes. If set, this field is compared to
@@ -845,7 +845,7 @@ components:
             returned. If this field is set, then `appData` **MUST** be a string
             encoding of a JSON object.
           allOf:
-            - $ref: '#/components/schemas/AppDataHash'
+            - $ref: "#/components/schemas/AppDataHash"
           nullable: true
       required:
         - sellToken
@@ -868,19 +868,19 @@ components:
         creationDate:
           description: Creation time of the order. Encoded as ISO 8601 UTC.
           type: string
-          example: '2020-12-03T18:35:18.814523Z'
+          example: "2020-12-03T18:35:18.814523Z"
         class:
-          $ref: '#/components/schemas/OrderClass'
+          $ref: "#/components/schemas/OrderClass"
         owner:
-          $ref: '#/components/schemas/Address'
+          $ref: "#/components/schemas/Address"
         uid:
-          $ref: '#/components/schemas/UID'
+          $ref: "#/components/schemas/UID"
         availableBalance:
           description: >
             Unused field that is currently always set to `null` and will be
             removed in the future.
           allOf:
-            - $ref: '#/components/schemas/TokenAmount'
+            - $ref: "#/components/schemas/TokenAmount"
           nullable: true
           deprecated: true
         executedSellAmount:
@@ -888,34 +888,34 @@ components:
             The total amount of `sellToken` that has been executed for this
             order including fees.
           allOf:
-            - $ref: '#/components/schemas/BigUint'
+            - $ref: "#/components/schemas/BigUint"
         executedSellAmountBeforeFees:
           description: >
             The total amount of `sellToken` that has been executed for this
             order without fees.
           allOf:
-            - $ref: '#/components/schemas/BigUint'
+            - $ref: "#/components/schemas/BigUint"
         executedBuyAmount:
           description: >
             The total amount of `buyToken` that has been executed for this
             order.
           allOf:
-            - $ref: '#/components/schemas/BigUint'
+            - $ref: "#/components/schemas/BigUint"
         executedFeeAmount:
           description: The total amount of fees that have been executed for this order.
           allOf:
-            - $ref: '#/components/schemas/BigUint'
+            - $ref: "#/components/schemas/BigUint"
         invalidated:
           description: Has this order been invalidated?
           type: boolean
         status:
           description: Order status.
           allOf:
-            - $ref: '#/components/schemas/OrderStatus'
+            - $ref: "#/components/schemas/OrderStatus"
         fullFeeAmount:
           description: Amount that the signed fee would be without subsidies.
           allOf:
-            - $ref: '#/components/schemas/TokenAmount'
+            - $ref: "#/components/schemas/TokenAmount"
         isLiquidityOrder:
           description: |-
             Liquidity orders are functionally the same as normal smart contract
@@ -930,7 +930,7 @@ components:
           type: boolean
         ethflowData:
           allOf:
-            - $ref: '#/components/schemas/EthflowData'
+            - $ref: "#/components/schemas/EthflowData"
         onchainUser:
           description: >
             This represents the actual trader of an on-chain order.
@@ -940,17 +940,17 @@ components:
             In this case, the `owner` would be the `EthFlow` contract and *not*
             the actual trader.
           allOf:
-            - $ref: '#/components/schemas/Address'
+            - $ref: "#/components/schemas/Address"
         onchainOrderData:
           description: >
             There is some data only available for orders that are placed
             on-chain. This data can be found in this object.
           allOf:
-            - $ref: '#/components/schemas/OnchainOrderData'
+            - $ref: "#/components/schemas/OnchainOrderData"
         executedSurplusFee:
           description: Surplus fee that the limit order was executed with.
           allOf:
-            - $ref: '#/components/schemas/BigUint'
+            - $ref: "#/components/schemas/BigUint"
           nullable: true
         fullAppData:
           description: >
@@ -971,8 +971,8 @@ components:
         - status
     Order:
       allOf:
-        - $ref: '#/components/schemas/OrderCreation'
-        - $ref: '#/components/schemas/OrderMetaData'
+        - $ref: "#/components/schemas/OrderCreation"
+        - $ref: "#/components/schemas/OrderMetaData"
     AuctionOrder:
       description: >
         A solvable order included in the current batch auction. Contains the
@@ -980,92 +980,92 @@ components:
       type: object
       properties:
         uid:
-          $ref: '#/components/schemas/UID'
+          $ref: "#/components/schemas/UID"
         sellToken:
-          description: 'see `OrderParameters::sellToken`'
+          description: "see `OrderParameters::sellToken`"
           allOf:
-            - $ref: '#/components/schemas/Address'
+            - $ref: "#/components/schemas/Address"
         buyToken:
-          description: 'see `OrderParameters::buyToken`'
+          description: "see `OrderParameters::buyToken`"
           allOf:
-            - $ref: '#/components/schemas/Address'
+            - $ref: "#/components/schemas/Address"
         sellAmount:
-          description: 'see `OrderParameters::sellAmount`'
+          description: "see `OrderParameters::sellAmount`"
           allOf:
-            - $ref: '#/components/schemas/TokenAmount'
+            - $ref: "#/components/schemas/TokenAmount"
         buyAmount:
-          description: 'see `OrderParameters::buyAmount`'
+          description: "see `OrderParameters::buyAmount`"
           allOf:
-            - $ref: '#/components/schemas/TokenAmount'
+            - $ref: "#/components/schemas/TokenAmount"
         created:
           description: Creation time of the order. Denominated in epoch seconds.
           type: string
-          example: '123456'
+          example: "123456"
         validTo:
-          description: 'see `OrderParameters::validTo`'
+          description: "see `OrderParameters::validTo`"
           type: integer
         kind:
-          description: 'see `OrderParameters::kind`'
+          description: "see `OrderParameters::kind`"
           allOf:
-            - $ref: '#/components/schemas/OrderKind'
+            - $ref: "#/components/schemas/OrderKind"
         receiver:
-          description: 'see `OrderParameters::receiver`'
+          description: "see `OrderParameters::receiver`"
           allOf:
-            - $ref: '#/components/schemas/Address'
+            - $ref: "#/components/schemas/Address"
           nullable: true
         owner:
-          $ref: '#/components/schemas/Address'
+          $ref: "#/components/schemas/Address"
         partiallyFillable:
-          description: 'see `OrderParameters::partiallyFillable`'
+          description: "see `OrderParameters::partiallyFillable`"
           type: boolean
         executed:
           description: >
             Currently executed amount of sell/buy token, depending on the order
             kind.
           allOf:
-            - $ref: '#/components/schemas/TokenAmount'
+            - $ref: "#/components/schemas/TokenAmount"
         preInteractions:
           description: >
             The pre-interactions that need to be executed before the first
             execution of the order.
           type: array
           items:
-            $ref: '#/components/schemas/InteractionData'
+            $ref: "#/components/schemas/InteractionData"
         postInteractions:
           description: >
             The post-interactions that need to be executed after the execution
             of the order.
           type: array
           items:
-            $ref: '#/components/schemas/InteractionData'
+            $ref: "#/components/schemas/InteractionData"
         sellTokenBalance:
-          description: 'see `OrderParameters::sellTokenBalance`'
+          description: "see `OrderParameters::sellTokenBalance`"
           allOf:
-            - $ref: '#/components/schemas/SellTokenSource'
+            - $ref: "#/components/schemas/SellTokenSource"
           default: erc20
         buyTokenBalance:
-          description: 'see `OrderParameters::buyTokenBalance`'
+          description: "see `OrderParameters::buyTokenBalance`"
           allOf:
-            - $ref: '#/components/schemas/BuyTokenDestination'
+            - $ref: "#/components/schemas/BuyTokenDestination"
           default: erc20
         class:
-          $ref: '#/components/schemas/OrderClass'
+          $ref: "#/components/schemas/OrderClass"
         appData:
-          $ref: '#/components/schemas/AppDataHash'
+          $ref: "#/components/schemas/AppDataHash"
         signature:
-          $ref: '#/components/schemas/Signature'
+          $ref: "#/components/schemas/Signature"
         protocolFees:
           description: >
             The fee policies that are used to compute the protocol fees for this
             order.
           type: array
           items:
-            $ref: '#/components/schemas/FeePolicy'
+            $ref: "#/components/schemas/FeePolicy"
         quote:
           description: |
             A winning quote.
           allOf:
-            - $ref: '#/components/schemas/Quote'
+            - $ref: "#/components/schemas/Quote"
       required:
         - uid
         - sellToken
@@ -1114,15 +1114,15 @@ components:
         orders:
           type: array
           items:
-            $ref: '#/components/schemas/AuctionOrder'
+            $ref: "#/components/schemas/AuctionOrder"
           description: |
             The solvable orders included in the auction.
         prices:
-          $ref: '#/components/schemas/AuctionPrices'
+          $ref: "#/components/schemas/AuctionPrices"
         surplusCapturingJitOrderOwners:
           type: array
           items:
-            $ref: '#/components/schemas/Address'
+            $ref: "#/components/schemas/Address"
           description: >
             List of addresses on whose surplus will count towards the objective
             value of their solution (unlike other orders that were created by
@@ -1135,18 +1135,18 @@ components:
         orders:
           type: array
           items:
-            $ref: '#/components/schemas/UID'
+            $ref: "#/components/schemas/UID"
           description: |
             The UIDs of the orders included in the auction.
         prices:
-          $ref: '#/components/schemas/AuctionPrices'
+          $ref: "#/components/schemas/AuctionPrices"
     ExecutedAmounts:
       type: object
       properties:
         sell:
-          $ref: '#/components/schemas/BigUint'
+          $ref: "#/components/schemas/BigUint"
         buy:
-          $ref: '#/components/schemas/BigUint'
+          $ref: "#/components/schemas/BigUint"
       required:
         - sell
         - buy
@@ -1178,7 +1178,7 @@ components:
                 type: string
                 description: Name of the solver.
               executedAmounts:
-                $ref: '#/components/schemas/ExecutedAmounts'
+                $ref: "#/components/schemas/ExecutedAmounts"
             required:
               - solver
       required:
@@ -1192,7 +1192,7 @@ components:
         converting fees to native token.
       type: object
       additionalProperties:
-        $ref: '#/components/schemas/BigUint'
+        $ref: "#/components/schemas/BigUint"
     OrderCancellations:
       description: >
         EIP-712 signature of struct OrderCancellations { orderUid: bytes[] }
@@ -1203,14 +1203,14 @@ components:
           type: array
           description: UIDs of orders to cancel.
           items:
-            $ref: '#/components/schemas/UID'
+            $ref: "#/components/schemas/UID"
         signature:
-          description: '`OrderCancellation` signed by the owner.'
+          description: "`OrderCancellation` signed by the owner."
           allOf:
-            - $ref: '#/components/schemas/EcdsaSignature'
+            - $ref: "#/components/schemas/EcdsaSignature"
         signingScheme:
           allOf:
-            - $ref: '#/components/schemas/EcdsaSigningScheme'
+            - $ref: "#/components/schemas/EcdsaSigningScheme"
       required:
         - signature
         - signingScheme
@@ -1223,9 +1223,9 @@ components:
         signature:
           description: OrderCancellation signed by owner
           allOf:
-            - $ref: '#/components/schemas/EcdsaSignature'
+            - $ref: "#/components/schemas/EcdsaSignature"
         signingScheme:
-          $ref: '#/components/schemas/EcdsaSigningScheme'
+          $ref: "#/components/schemas/EcdsaSigningScheme"
       required:
         - signature
         - signingScheme
@@ -1244,41 +1244,41 @@ components:
         orderUid:
           description: UID of the order matched by this trade.
           allOf:
-            - $ref: '#/components/schemas/UID'
+            - $ref: "#/components/schemas/UID"
         owner:
           description: Address of trader.
           allOf:
-            - $ref: '#/components/schemas/Address'
+            - $ref: "#/components/schemas/Address"
         sellToken:
           description: Address of token sold.
           allOf:
-            - $ref: '#/components/schemas/Address'
+            - $ref: "#/components/schemas/Address"
         buyToken:
           description: Address of token bought.
           allOf:
-            - $ref: '#/components/schemas/Address'
+            - $ref: "#/components/schemas/Address"
         sellAmount:
           description: >-
             Total amount of `sellToken` that has been executed for this trade
             (including fees).
           allOf:
-            - $ref: '#/components/schemas/TokenAmount'
+            - $ref: "#/components/schemas/TokenAmount"
         sellAmountBeforeFees:
           description: >-
             The total amount of `sellToken` that has been executed for this
             order without fees.
           allOf:
-            - $ref: '#/components/schemas/BigUint'
+            - $ref: "#/components/schemas/BigUint"
         buyAmount:
           description: Total amount of `buyToken` received in this trade.
           allOf:
-            - $ref: '#/components/schemas/TokenAmount'
+            - $ref: "#/components/schemas/TokenAmount"
         txHash:
           description: >-
             Transaction hash of the corresponding settlement transaction
             containing the trade (if available).
           allOf:
-            - $ref: '#/components/schemas/TransactionHash'
+            - $ref: "#/components/schemas/TransactionHash"
           nullable: true
         executedProtocolFees:
           description: >
@@ -1286,7 +1286,7 @@ components:
             policies used. Listed in the order they got applied.
           type: array
           items:
-            $ref: '#/components/schemas/ExecutedProtocolFee'
+            $ref: "#/components/schemas/ExecutedProtocolFee"
       required:
         - blockNumber
         - logIndex
@@ -1325,8 +1325,8 @@ components:
     Signature:
       description: A signature.
       oneOf:
-        - $ref: '#/components/schemas/EcdsaSignature'
-        - $ref: '#/components/schemas/PreSignature'
+        - $ref: "#/components/schemas/EcdsaSignature"
+        - $ref: "#/components/schemas/PreSignature"
     EcdsaSignature:
       description: 65 bytes encoded as hex with `0x` prefix. `r || s || v` from the spec.
       type: string
@@ -1417,13 +1417,13 @@ components:
           properties:
             kind:
               allOf:
-                - $ref: '#/components/schemas/OrderQuoteSideKindSell'
+                - $ref: "#/components/schemas/OrderQuoteSideKindSell"
             sellAmountBeforeFee:
               description: >
                 The total amount that is available for the order. From this
                 value, the fee is deducted and the buy amount is calculated.
               allOf:
-                - $ref: '#/components/schemas/TokenAmount'
+                - $ref: "#/components/schemas/TokenAmount"
           required:
             - kind
             - sellAmountBeforeFee
@@ -1432,11 +1432,11 @@ components:
           properties:
             kind:
               allOf:
-                - $ref: '#/components/schemas/OrderQuoteSideKindSell'
+                - $ref: "#/components/schemas/OrderQuoteSideKindSell"
             sellAmountAfterFee:
               description: The `sellAmount` for the order.
               allOf:
-                - $ref: '#/components/schemas/TokenAmount'
+                - $ref: "#/components/schemas/TokenAmount"
           required:
             - kind
             - sellAmountAfterFee
@@ -1445,11 +1445,11 @@ components:
           properties:
             kind:
               allOf:
-                - $ref: '#/components/schemas/OrderQuoteSideKindBuy'
+                - $ref: "#/components/schemas/OrderQuoteSideKindBuy"
             buyAmountAfterFee:
               description: The `buyAmount` for the order.
               allOf:
-                - $ref: '#/components/schemas/TokenAmount'
+                - $ref: "#/components/schemas/TokenAmount"
           required:
             - kind
             - buyAmountAfterFee
@@ -1479,18 +1479,18 @@ components:
     OrderQuoteRequest:
       description: Request fee and price quote.
       allOf:
-        - $ref: '#/components/schemas/OrderQuoteSide'
-        - $ref: '#/components/schemas/OrderQuoteValidity'
+        - $ref: "#/components/schemas/OrderQuoteSide"
+        - $ref: "#/components/schemas/OrderQuoteValidity"
         - type: object
           properties:
             sellToken:
               description: ERC-20 token to be sold
               allOf:
-                - $ref: '#/components/schemas/Address'
+                - $ref: "#/components/schemas/Address"
             buyToken:
               description: ERC-20 token to be bought
               allOf:
-                - $ref: '#/components/schemas/Address'
+                - $ref: "#/components/schemas/Address"
             receiver:
               description: >
                 An optional address to receive the proceeds of the trade instead
@@ -1498,7 +1498,7 @@ components:
 
                 `owner` (i.e. the order signer).
               allOf:
-                - $ref: '#/components/schemas/Address'
+                - $ref: "#/components/schemas/Address"
               nullable: true
             appData:
               description: |-
@@ -1511,8 +1511,8 @@ components:
                 When the first format is used, it's possible to provide the
                 derived appDataHash field.
               oneOf:
-                - $ref: '#/components/schemas/AppData'
-                - $ref: '#/components/schemas/AppDataHash'
+                - $ref: "#/components/schemas/AppData"
+                - $ref: "#/components/schemas/AppDataHash"
             appDataHash:
               description: |-
                 The hash of the stringified JSON appData doc.
@@ -1522,24 +1522,24 @@ components:
 
                 In case they differ, the call will fail.
               anyOf:
-                - $ref: '#/components/schemas/AppDataHash'
+                - $ref: "#/components/schemas/AppDataHash"
             sellTokenBalance:
               allOf:
-                - $ref: '#/components/schemas/SellTokenSource'
+                - $ref: "#/components/schemas/SellTokenSource"
               default: erc20
             buyTokenBalance:
               allOf:
-                - $ref: '#/components/schemas/BuyTokenDestination'
+                - $ref: "#/components/schemas/BuyTokenDestination"
               default: erc20
             from:
-              $ref: '#/components/schemas/Address'
+              $ref: "#/components/schemas/Address"
             priceQuality:
               allOf:
-                - $ref: '#/components/schemas/PriceQuality'
+                - $ref: "#/components/schemas/PriceQuality"
               default: verified
             signingScheme:
               allOf:
-                - $ref: '#/components/schemas/SigningScheme'
+                - $ref: "#/components/schemas/SigningScheme"
               default: eip712
             onchainOrder:
               description: >
@@ -1557,15 +1557,15 @@ components:
       type: object
       properties:
         quote:
-          $ref: '#/components/schemas/OrderParameters'
+          $ref: "#/components/schemas/OrderParameters"
         from:
-          $ref: '#/components/schemas/Address'
+          $ref: "#/components/schemas/Address"
         expiration:
           description: |
             Expiration date of the offered fee. Order service might not accept
             the fee after this expiration date. Encoded as ISO 8601 UTC.
           type: string
-          example: '1985-03-10T18:35:18.814523Z'
+          example: "1985-03-10T18:35:18.814523Z"
         id:
           description: >
             Quote ID linked to a quote to enable providing more metadata when
@@ -1594,7 +1594,7 @@ components:
           type: string
           nullable: true
           allOf:
-            - $ref: '#/components/schemas/TransactionHash'
+            - $ref: "#/components/schemas/TransactionHash"
           description: >-
             The hash of the transaction that the winning solution of this info
             was submitted in.
@@ -1606,12 +1606,12 @@ components:
         competitionSimulationBlock:
           type: integer
         auction:
-          $ref: '#/components/schemas/CompetitionAuction'
+          $ref: "#/components/schemas/CompetitionAuction"
         solutions:
           type: array
           description: Maps from solver name to object describing that solver's settlement.
           items:
-            $ref: '#/components/schemas/SolverSettlement'
+            $ref: "#/components/schemas/SolverSettlement"
     SolverSettlement:
       type: object
       properties:
@@ -1641,7 +1641,7 @@ components:
               type: integer
         score:
           allOf:
-            - $ref: '#/components/schemas/BigUint'
+            - $ref: "#/components/schemas/BigUint"
           description: >
             The score of the current auction as defined in
             [CIP-20](https://snapshot.org/#/cow.eth/proposal/0x2d3f9bd1ea72dca84b03e97dda3efc1f4a42a772c54bd2037e8b62e7d09a491f).
@@ -1651,7 +1651,7 @@ components:
         clearingPrices:
           type: object
           additionalProperties:
-            $ref: '#/components/schemas/BigUint'
+            $ref: "#/components/schemas/BigUint"
           description: >
             The prices of tokens for settled user orders as passed to the
             settlement contract.
@@ -1662,9 +1662,9 @@ components:
             type: object
             properties:
               id:
-                $ref: '#/components/schemas/UID'
+                $ref: "#/components/schemas/UID"
               executedAmount:
-                $ref: '#/components/schemas/BigUint'
+                $ref: "#/components/schemas/BigUint"
     NativePriceResponse:
       description: |
         The estimated native price for the token
@@ -1685,13 +1685,13 @@ components:
       type: object
       properties:
         target:
-          $ref: '#/components/schemas/Address'
+          $ref: "#/components/schemas/Address"
         value:
-          $ref: '#/components/schemas/TokenAmount'
+          $ref: "#/components/schemas/TokenAmount"
         call_data:
           type: array
           items:
-            $ref: '#/components/schemas/CallData'
+            $ref: "#/components/schemas/CallData"
           description: The call data to be used for the interaction.
     Quote:
       description: |
@@ -1701,15 +1701,15 @@ components:
         sellAmount:
           description: The amount of the sell token.
           allOf:
-            - $ref: '#/components/schemas/TokenAmount'
+            - $ref: "#/components/schemas/TokenAmount"
         buyAmount:
           description: The amount of the buy token.
           allOf:
-            - $ref: '#/components/schemas/TokenAmount'
+            - $ref: "#/components/schemas/TokenAmount"
         fee:
-          description: 'The amount that needs to be paid, denominated in the sell token.'
+          description: "The amount that needs to be paid, denominated in the sell token."
           allOf:
-            - $ref: '#/components/schemas/TokenAmount'
+            - $ref: "#/components/schemas/TokenAmount"
     Surplus:
       description: The protocol fee is taken as a percent of the surplus.
       type: object
@@ -1757,7 +1757,7 @@ components:
         quote:
           description: The best quote received.
           allOf:
-            - $ref: '#/components/schemas/Quote'
+            - $ref: "#/components/schemas/Quote"
       required:
         - factor
         - maxVolumeFactor
@@ -1765,19 +1765,19 @@ components:
     FeePolicy:
       description: Defines the ways to calculate the protocol fee.
       oneOf:
-        - $ref: '#/components/schemas/Surplus'
-        - $ref: '#/components/schemas/Volume'
-        - $ref: '#/components/schemas/PriceImprovement'
+        - $ref: "#/components/schemas/Surplus"
+        - $ref: "#/components/schemas/Volume"
+        - $ref: "#/components/schemas/PriceImprovement"
     ExecutedProtocolFee:
       type: object
       properties:
         policy:
-          $ref: '#/components/schemas/FeePolicy'
+          $ref: "#/components/schemas/FeePolicy"
         amount:
           allOf:
             - description: Fee amount taken
-            - $ref: '#/components/schemas/TokenAmount'
+            - $ref: "#/components/schemas/TokenAmount"
         token:
           allOf:
             - description: The token in which the fee is taken
-            - $ref: '#/components/schemas/Address'
+            - $ref: "#/components/schemas/Address"

--- a/crates/orderbook/openapi.yml
+++ b/crates/orderbook/openapi.yml
@@ -2,10 +2,6 @@ openapi: 3.0.3
 info:
   version: 0.0.1
   title: Order Book API
-  contact:
-    name: CoW DAO
-    url: "https://cow.fi"
-    email: dev@cow.fi
 servers:
   - description: Mainnet (Prod)
     url: "https://api.cow.fi/mainnet"

--- a/crates/orderbook/openapi.yml
+++ b/crates/orderbook/openapi.yml
@@ -32,11 +32,13 @@ paths:
         Create a new order. In order to replace an existing order with a new
         one, the appData must contain a [valid replacement order
         UID](https://github.com/cowprotocol/app-data/blob/main/src/schemas/v1.1.0.json#L62),
-        then the indicated order is cancelled, and a new one placed. This allows
-        an old order to be cancelled AND a new order to be created in an atomic
-        operation with a single signature. This may be useful for replacing
-        orders when on-chain prices move outside of the original order's limit
-        price.
+        then the indicated order is cancelled, and a new one placed.
+
+        This allows an old order to be cancelled AND a new order to be created
+        in an atomic operation with a single signature.
+
+        This may be useful for replacing orders when on-chain prices move
+        outside of the original order's limit price.
       responses:
         '201':
           description: Order has been accepted.
@@ -67,12 +69,12 @@ paths:
               $ref: '#/components/schemas/OrderCreation'
     delete:
       summary: Cancel multiple orders by marking them invalid with a timestamp.
-      description: |
+      description: >
         This is a *best effort* cancellation, and might not prevent solvers from
         settling the orders (if the order is part of an in-flight settlement
         transaction for example). Authentication must be provided by an
-        [EIP-712](https://eips.ethereum.org/EIPS/eip-712)
-        signature of an `OrderCancellations(bytes[] orderUids)` message.
+        [EIP-712](https://eips.ethereum.org/EIPS/eip-712) signature of an
+        `OrderCancellations(bytes[] orderUids)` message.
       requestBody:
         description: Signed `OrderCancellations`.
         required: true
@@ -114,14 +116,12 @@ paths:
     delete:
       deprecated: true
       summary: Cancel an order by marking it invalid with a timestamp.
-      description: >
+      description: >-
         The successful deletion might not prevent solvers from settling the
         order.
 
         Authentication must be provided by providing an
-
         [EIP-712](https://eips.ethereum.org/EIPS/eip-712) signature of an
-
         `OrderCancellation(bytes orderUid)` message.
       parameters:
         - in: path
@@ -203,21 +203,16 @@ paths:
           required: false
       responses:
         '200':
-          description: >
+          description: >-
             ### If `owner` is specified:
-
 
             Return all trades related to that `owner`.
 
-
             ### If `orderUid` is specified:
 
-
             Return all trades related to that `orderUid`. Given that an order
-            may be partially
-
-            fillable, it is possible that an individual order may have
-            *multiple* trades.
+            may be partially fillable, it is possible that an individual order
+            may have *multiple* trades.
           content:
             application/json:
               schema:
@@ -227,18 +222,13 @@ paths:
   /api/v1/auction:
     get:
       summary: Get the current batch auction.
-      description: >
+      description: >-
         The current batch auction that solvers should be solving right now. This
         includes:
 
-
-        * A list of solvable orders.
-
-        * The block on which the batch was created.
-
+        * A list of solvable orders. * The block on which the batch was created.
         * Prices for all tokens being traded (used for objective value
         computation).
-
 
         **Note: This endpoint is currently permissioned. Reach out in discord if
         you need access.**
@@ -257,12 +247,8 @@ paths:
         first).
 
         To enumerate all orders start with `offset` 0 and keep increasing the
-        `offset` by the total
-
-        number of returned results. When a response contains less than `limit`
-        the last page has
-
-        been reached.
+        `offset` by the total number of returned results. When a response
+        contains less than `limit` the last page has been reached.
       parameters:
         - name: owner
           in: path
@@ -297,7 +283,7 @@ paths:
   '/api/v1/token/{token}/native_price':
     get:
       summary: Get native price for the given token.
-      description: >
+      description: >-
         Price is the exchange rate between the specified token and the network's
         native currency.
 
@@ -327,12 +313,9 @@ paths:
       summary: Quote a price and fee for the specified order parameters.
       description: >
         Given a partial order compute the minimum fee and a price estimate for
-        the order. Return a
-
-        full order that can be used directly for signing, and with an included
-        signature, passed
-
-        directly to the order creation endpoint.
+        the order. Return a full order that can be used directly for signing,
+        and with an included signature, passed directly to the order creation
+        endpoint.
       requestBody:
         description: The order parameters to compute a quote for.
         required: true
@@ -447,7 +430,6 @@ paths:
       summary: Registers a full `appData` so it can be referenced by `appDataHash`.
       description: >
         Uploads a full `appData` to orderbook so that orders created with the
-
         corresponding `appDataHash` can be linked to the original full
         `appData`.
       parameters:
@@ -515,7 +497,6 @@ paths:
       summary: 'Get the total surplus earned by the user. [UNSTABLE]'
       description: >
         ### Caution
-
 
         This endpoint is under active development and should NOT be considered
         stable.
@@ -585,22 +566,15 @@ components:
         sender:
           description: >
             If orders are placed as on-chain orders, the owner of the order
-            might
-
-            be a smart contract, but not the user placing the order. The
-
+            might be a smart contract, but not the user placing the order. The
             actual user will be provided in this field.
           allOf:
             - $ref: '#/components/schemas/Address'
         placementError:
           description: >
             Describes the error, if the order placement was not successful. This
-            could
-
-            happen, for example, if the `validTo` is too high, or no valid quote
-            was
-
-            found or generated.
+            could happen, for example, if the `validTo` is too high, or no valid
+            quote was found or generated.
           type: string
           enum:
             - QuoteNotFound
@@ -659,14 +633,10 @@ components:
       description: >
         How good should the price estimate be?
 
-
         Fast: The price estimate is chosen among the fastest N price estimates.
-
         Optimal: The price estimate is chosen among all price estimates.
-
         Verified: The price estimate is chosen among all verified/simulated
         price estimates.
-
 
         **NOTE**: Orders are supposed to be created from `verified` or `optimal`
         price estimates.
@@ -699,9 +669,7 @@ components:
         receiver:
           description: >
             An optional Ethereum address to receive the proceeds of the trade
-            instead
-
-            of the owner (i.e. the order signer).
+            instead of the owner (i.e. the order signer).
           allOf:
             - $ref: '#/components/schemas/Address'
           nullable: true
@@ -807,99 +775,63 @@ components:
         from:
           description: >
             If set, the backend enforces that this address matches what is
-            decoded as the *signer* of
-
-            the signature. This helps catch errors with invalid signature
-            encodings as the backend
-
-            might otherwise silently work with an unexpected address that for
-            example does not have
-
-            any balance.
+            decoded as the *signer* of the signature. This helps catch errors
+            with invalid signature encodings as the backend might otherwise
+            silently work with an unexpected address that for example does not
+            have any balance.
           allOf:
             - $ref: '#/components/schemas/Address'
           nullable: true
         quoteId:
           description: >
             Orders can optionally include a quote ID. This way the order can be
-            linked to a quote
-
-            and enable providing more metadata when analysing order slippage.
+            linked to a quote and enable providing more metadata when analysing
+            order slippage.
           type: integer
           nullable: true
         appData:
           description: >
             This field comes in two forms for backward compatibility. The hash
-            form will eventually 
-
-            stop being accepted.
+            form will eventually stop being accepted.
           anyOf:
             - title: Full App Data
               allOf:
                 - $ref: '#/components/schemas/AppData'
-              description: >
+              description: >-
                 **Short**:
 
-
                 If you do not care about `appData`, set this field to `"{}"` and
-                make sure that the
-
-                order you signed for this request had its `appData` field set to
-
+                make sure that the order you signed for this request had its
+                `appData` field set to
                 `0xb48d38f93eaa084033fc5970bf96e559c33c4cdc07d889ab00b4d63f9590739d`.
-
 
                 **Long**:
 
-
                 A string encoding a JSON object like `"{"hello":"world"}"`.
 
-
                 This field determines the smart contract order's `appData`
-                field, which is assumed to
-
-                be set to the `keccak256` hash of the UTF-8 encoded bytes of
-                this string. You must
-
-                ensure that the signature that is part of this request indeed
-                signed a smart contract
-
-                order with the `appData` field set appropriately. If this isn't
-                the case, signature
-
-                verification will fail. For easier debugging it is recommended
-                to additionally set the
-
+                field, which is assumed to be set to the `keccak256` hash of the
+                UTF-8 encoded bytes of this string. You must ensure that the
+                signature that is part of this request indeed signed a smart
+                contract order with the `appData` field set appropriately. If
+                this isn't the case, signature verification will fail. For
+                easier debugging it is recommended to additionally set the
                 `appDataHash` field.
 
-
                 The field must be the encoding of a valid JSON object. The JSON
-                object can contain
-
-                arbitrary application specific data (JSON key values). The
-                optional key `backend` is
-
-                special. It **MUST** conform to the schema documented in
-                `ProtocolAppData`.
-
+                object can contain arbitrary application specific data (JSON key
+                values). The optional key `backend` is special. It **MUST**
+                conform to the schema documented in `ProtocolAppData`.
 
                 The intended use of the other keys of the object is follow the
-                standardized format
+                standardized format defined
+                [here](https://github.com/cowprotocol/app-data). Example:
 
-                defined [here](https://github.com/cowprotocol/app-data).
-                Example:
-
-
-                ```json
-
-                {
+                ```json {
                   "version": "0.7.0",
                   "appCode": "YOUR_APP_CODE",
                   "metadata": {}
-                }
-
-                ```
-
+                } ```
 
                 The total byte size of this field's UTF-8 encoded bytes is
                 limited to 1000.
@@ -908,15 +840,10 @@ components:
         appDataHash:
           description: >
             May be set for debugging purposes. If set, this field is compared to
-            what the backend
-
-            internally calculates as the app data hash based on the contents of
-            `appData`. If the
-
-            hash does not match, an error is returned. If this field is set,
-            then `appData` **MUST** be
-
-            a string encoding of a JSON object.
+            what the backend internally calculates as the app data hash based on
+            the contents of `appData`. If the hash does not match, an error is
+            returned. If this field is set, then `appData` **MUST** be a string
+            encoding of a JSON object.
           allOf:
             - $ref: '#/components/schemas/AppDataHash'
           nullable: true
@@ -935,9 +862,7 @@ components:
     OrderMetaData:
       description: >
         Extra order data that is returned to users when querying orders but not
-        provided by users
-
-        when creating orders.
+        provided by users when creating orders.
       type: object
       properties:
         creationDate:
@@ -994,24 +919,14 @@ components:
         isLiquidityOrder:
           description: >
             Liquidity orders are functionally the same as normal smart contract
-            orders but are not
-
-            placed with the intent of actively getting traded. Instead they
-            facilitate the
-
-            trade of normal orders by allowing them to be matched against
-            liquidity orders which
-
-            uses less gas and can have better prices than external liquidity.
-
+            orders but are not placed with the intent of actively getting
+            traded. Instead they facilitate the trade of normal orders by
+            allowing them to be matched against liquidity orders which uses less
+            gas and can have better prices than external liquidity.
 
             As such liquidity orders will only be used in order to improve
-            settlement of normal
-
-            orders. They should not be expected to be traded otherwise and
-            should not expect to get
-
-            surplus.
+            settlement of normal orders. They should not be expected to be
+            traded otherwise and should not expect to get surplus.
           type: boolean
         ethflowData:
           allOf:
@@ -1020,9 +935,7 @@ components:
           description: >
             This represents the actual trader of an on-chain order.
 
-
             ### ethflow orders
-
 
             In this case, the `owner` would be the `EthFlow` contract and *not*
             the actual trader.
@@ -1031,9 +944,7 @@ components:
         onchainOrderData:
           description: >
             There is some data only available for orders that are placed
-            on-chain. This data
-
-            can be found in this object.
+            on-chain. This data can be found in this object.
           allOf:
             - $ref: '#/components/schemas/OnchainOrderData'
         executedSurplusFee:
@@ -1044,9 +955,7 @@ components:
         fullAppData:
           description: >
             Full `appData`, which the contract-level `appData` is a hash of. See
-            `OrderCreation`
-
-            for more information.
+            `OrderCreation` for more information.
           type: string
           nullable: true
       required:
@@ -1192,19 +1101,16 @@ components:
           type: integer
           description: >
             The block number for the auction. Orders and prices are guaranteed
-            to be valid on this
-
-            block. Proposed settlements should be valid for this block as well.
+            to be valid on this block. Proposed settlements should be valid for
+            this block as well.
         latestSettlementBlock:
           type: integer
           description: >
             The latest block on which a settlement has been processed.
 
-
             **NOTE**: Under certain conditions it is possible for a settlement
-            to have been mined as
-
-            part of `block` but not have yet been processed.
+            to have been mined as part of `block` but not have yet been
+            processed.
         orders:
           type: array
           items:
@@ -1280,15 +1186,10 @@ components:
     AuctionPrices:
       description: >
         The reference prices for all traded tokens in the auction as a mapping
-        from token
-
-        addresses to a price denominated in native token (i.e. 1e18 represents a
-        token that
-
-        trades one to one with the native token). These prices are used for
-        solution competition
-
-        for computing surplus and converting fees to native token.
+        from token addresses to a price denominated in native token (i.e. 1e18
+        represents a token that trades one to one with the native token). These
+        prices are used for solution competition for computing surplus and
+        converting fees to native token.
       type: object
       additionalProperties:
         $ref: '#/components/schemas/BigUint'
@@ -1403,9 +1304,7 @@ components:
         prefix.
 
         Bytes 0..32 are the order digest, bytes 30..52 the owner address and
-        bytes
-
-        52..56 the expiry (`validTo`) as a `uint32` unix epoch timestamp.
+        bytes 52..56 the expiry (`validTo`) as a `uint32` unix epoch timestamp.
       type: string
       example: >-
         0xff2e2e54d178997f173266817c1e9ed6fee1a1aae4b43971c53b543cffcc2969845c6f5599fbb25dbdd1b9b013daf85c03f3c63763e4bc4a
@@ -1522,9 +1421,7 @@ components:
             sellAmountBeforeFee:
               description: >
                 The total amount that is available for the order. From this
-                value, the fee
-
-                is deducted and the buy amount is calculated.
+                value, the fee is deducted and the buy amount is calculated.
               allOf:
                 - $ref: '#/components/schemas/TokenAmount'
           required:
@@ -1608,9 +1505,8 @@ components:
                 AppData which will be assigned to the order.
 
                 Expects either a string JSON doc as defined on
-                [AppData](https://github.com/cowprotocol/app-data) or a
-
-                hex encoded string for backwards compatibility.
+                [AppData](https://github.com/cowprotocol/app-data) or a hex
+                encoded string for backwards compatibility.
 
                 When the first format is used, it's possible to provide the
                 derived appDataHash field.
@@ -1648,9 +1544,7 @@ components:
             onchainOrder:
               description: >
                 Flag to signal whether the order is intended for on-chain order
-                placement. Only valid
-
-                for non ECDSA-signed orders."
+                placement. Only valid for non ECDSA-signed orders."
               default: false
           required:
             - sellToken
@@ -1675,9 +1569,7 @@ components:
         id:
           description: >
             Quote ID linked to a quote to enable providing more metadata when
-            analysing
-
-            order slippage.
+            analysing order slippage.
           type: integer
         verified:
           description: >

--- a/crates/orderbook/openapi.yml
+++ b/crates/orderbook/openapi.yml
@@ -2,54 +2,61 @@ openapi: 3.0.3
 info:
   version: 0.0.1
   title: Order Book API
+  contact:
+    name: CoW DAO
+    url: 'https://cow.fi'
+    email: dev@cow.fi
 servers:
   - description: Mainnet (Prod)
-    url: https://api.cow.fi/mainnet
+    url: 'https://api.cow.fi/mainnet'
   - description: Mainnet (Staging)
-    url: https://barn.api.cow.fi/mainnet
+    url: 'https://barn.api.cow.fi/mainnet'
   - description: Gnosis Chain (Prod)
-    url: https://api.cow.fi/xdai
+    url: 'https://api.cow.fi/xdai'
   - description: Gnosis Chain (Staging)
-    url: https://barn.api.cow.fi/xdai
+    url: 'https://barn.api.cow.fi/xdai'
   - description: Arbitrum One (Prod)
-    url: https://api.cow.fi/arbitrum_one
+    url: 'https://api.cow.fi/arbitrum_one'
   - description: Arbitrum One (Staging)
-    url: https://barn.api.cow.fi/arbitrum_one
+    url: 'https://barn.api.cow.fi/arbitrum_one'
   - description: Sepolia (Prod)
-    url: https://api.cow.fi/sepolia
+    url: 'https://api.cow.fi/sepolia'
   - description: Sepolia (Staging)
-    url: https://barn.api.cow.fi/sepolia
+    url: 'https://barn.api.cow.fi/sepolia'
   - description: Local
-    url: http://localhost:8080
+    url: 'http://localhost:8080'
 paths:
   /api/v1/orders:
     post:
-      summary: Create a new order.
-        In order to replace an existing order with a new one, the appData must contain a
-        [valid replacement order UID](https://github.com/cowprotocol/app-data/blob/main/src/schemas/v1.1.0.json#L62),
-        then the indicated order is cancelled, and a new one placed.
-        This allows an old order to be cancelled AND a new order to be created in an atomic operation with a single signature.
-        This may be useful for replacing orders when on-chain prices move outside of the original order's limit price.
+      summary: >-
+        Create a new order. In order to replace an existing order with a new
+        one, the appData must contain a [valid replacement order
+        UID](https://github.com/cowprotocol/app-data/blob/main/src/schemas/v1.1.0.json#L62),
+        then the indicated order is cancelled, and a new one placed. This allows
+        an old order to be cancelled AND a new order to be created in an atomic
+        operation with a single signature. This may be useful for replacing
+        orders when on-chain prices move outside of the original order's limit
+        price.
       responses:
-        201:
+        '201':
           description: Order has been accepted.
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/UID"
-        400:
+                $ref: '#/components/schemas/UID'
+        '400':
           description: Error during order validation.
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/OrderPostError"
-        403:
-          description: Forbidden, your account is deny-listed.
-        404:
+                $ref: '#/components/schemas/OrderPostError'
+        '403':
+          description: 'Forbidden, your account is deny-listed.'
+        '404':
           description: No route was found quoting the order.
-        429:
+        '429':
           description: Too many order placements.
-        500:
+        '500':
           description: Error adding an order.
       requestBody:
         description: The order to create.
@@ -57,7 +64,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/OrderCreation"
+              $ref: '#/components/schemas/OrderCreation'
     delete:
       summary: Cancel multiple orders by marking them invalid with a timestamp.
       description: |
@@ -72,51 +79,55 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/OrderCancellations"
+              $ref: '#/components/schemas/OrderCancellations'
       responses:
-        200:
+        '200':
           description: Order(s) are cancelled.
-        400:
+        '400':
           description: Malformed signature.
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/OrderCancellationError"
-        401:
+                $ref: '#/components/schemas/OrderCancellationError'
+        '401':
           description: Invalid signature.
-        404:
+        '404':
           description: One or more orders were not found and no orders were cancelled.
-  /api/v1/orders/{UID}:
+  '/api/v1/orders/{UID}':
     get:
       summary: Get existing order from UID.
       parameters:
         - in: path
           name: UID
           schema:
-            $ref: "#/components/schemas/UID"
+            $ref: '#/components/schemas/UID'
           required: true
       responses:
-        200:
+        '200':
           description: Order
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Order"
-        404:
+                $ref: '#/components/schemas/Order'
+        '404':
           description: Order was not found.
     delete:
       deprecated: true
       summary: Cancel an order by marking it invalid with a timestamp.
-      description: |
-        The successful deletion might not prevent solvers from settling the order.
+      description: >
+        The successful deletion might not prevent solvers from settling the
+        order.
+
         Authentication must be provided by providing an
+
         [EIP-712](https://eips.ethereum.org/EIPS/eip-712) signature of an
+
         `OrderCancellation(bytes orderUid)` message.
       parameters:
         - in: path
           name: UID
           schema:
-            $ref: "#/components/schemas/UID"
+            $ref: '#/components/schemas/UID'
           required: true
       requestBody:
         description: Signed `OrderCancellation`
@@ -124,54 +135,56 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/OrderCancellation"
+              $ref: '#/components/schemas/OrderCancellation'
       responses:
-        200:
+        '200':
           description: Order cancelled.
-        400:
+        '400':
           description: Malformed signature.
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/OrderCancellationError"
-        401:
+                $ref: '#/components/schemas/OrderCancellationError'
+        '401':
           description: Invalid signature.
-        404:
+        '404':
           description: Order was not found.
-  /api/v1/orders/{UID}/status:
+  '/api/v1/orders/{UID}/status':
     get:
       summary: Get the status of an order.
       parameters:
         - in: path
           name: UID
           schema:
-              $ref: "#/components/schemas/UID"
+            $ref: '#/components/schemas/UID'
           required: true
       responses:
-        200:
-          description: The order status with a list of solvers that proposed solutions (if applicable).
+        '200':
+          description: >-
+            The order status with a list of solvers that proposed solutions (if
+            applicable).
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/CompetitionOrderStatus"
-  /api/v1/transactions/{txHash}/orders:
+                $ref: '#/components/schemas/CompetitionOrderStatus'
+  '/api/v1/transactions/{txHash}/orders':
     get:
       summary: Get orders by settlement transaction hash.
       parameters:
         - in: path
           name: txHash
           schema:
-            $ref: "#/components/schemas/TransactionHash"
+            $ref: '#/components/schemas/TransactionHash'
           required: true
       responses:
-        200:
+        '200':
           description: Order(s).
           content:
             application/json:
               schema:
                 type: array
                 items:
-                  $ref: "#/components/schemas/Order"
+                  $ref: '#/components/schemas/Order'
   /api/v1/trades:
     get:
       summary: Get existing trades.
@@ -181,62 +194,81 @@ paths:
         - name: owner
           in: query
           schema:
-            $ref: "#/components/schemas/Address"
+            $ref: '#/components/schemas/Address'
           required: false
         - name: orderUid
           in: query
           schema:
-            $ref: "#/components/schemas/UID"
+            $ref: '#/components/schemas/UID'
           required: false
       responses:
-        200:
-          description: |
+        '200':
+          description: >
             ### If `owner` is specified:
+
 
             Return all trades related to that `owner`.
 
+
             ### If `orderUid` is specified:
 
-            Return all trades related to that `orderUid`. Given that an order may be partially
-            fillable, it is possible that an individual order may have *multiple* trades.
+
+            Return all trades related to that `orderUid`. Given that an order
+            may be partially
+
+            fillable, it is possible that an individual order may have
+            *multiple* trades.
           content:
             application/json:
               schema:
                 type: array
                 items:
-                  $ref: "#/components/schemas/Trade"
+                  $ref: '#/components/schemas/Trade'
   /api/v1/auction:
     get:
       summary: Get the current batch auction.
-      description: |
-        The current batch auction that solvers should be solving right now. This includes:
+      description: >
+        The current batch auction that solvers should be solving right now. This
+        includes:
+
 
         * A list of solvable orders.
-        * The block on which the batch was created.
-        * Prices for all tokens being traded (used for objective value computation).
 
-        **Note: This endpoint is currently permissioned. Reach out in discord if you need access.**
+        * The block on which the batch was created.
+
+        * Prices for all tokens being traded (used for objective value
+        computation).
+
+
+        **Note: This endpoint is currently permissioned. Reach out in discord if
+        you need access.**
       responses:
-        200:
+        '200':
           description: Batch auction.
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Auction"
-  /api/v1/account/{owner}/orders:
+                $ref: '#/components/schemas/Auction'
+  '/api/v1/account/{owner}/orders':
     get:
       summary: Get orders of one user paginated.
-      description: |
-        The orders are sorted by their creation date descending (newest orders first).
-        To enumerate all orders start with `offset` 0 and keep increasing the `offset` by the total
-        number of returned results. When a response contains less than `limit` the last page has
+      description: >
+        The orders are sorted by their creation date descending (newest orders
+        first).
+
+        To enumerate all orders start with `offset` 0 and keep increasing the
+        `offset` by the total
+
+        number of returned results. When a response contains less than `limit`
+        the last page has
+
         been reached.
       parameters:
         - name: owner
           in: path
           required: true
           schema:
-            $ref: "#/components/schemas/Address"
+            $ref: '#/components/schemas/Address'
         - name: offset
           in: query
           description: |
@@ -252,47 +284,54 @@ paths:
             type: integer
           required: false
       responses:
-        200:
+        '200':
           description: The orders.
           content:
             application/json:
               schema:
                 type: array
                 items:
-                  $ref: "#/components/schemas/Order"
-        400:
+                  $ref: '#/components/schemas/Order'
+        '400':
           description: Problem with parameters like limit being too large.
-  /api/v1/token/{token}/native_price:
+  '/api/v1/token/{token}/native_price':
     get:
       summary: Get native price for the given token.
-      description: |
-        Price is the exchange rate between the specified token and the network's native currency.
-        It represents the amount of native token atoms needed to buy 1 atom of the specified token.
+      description: >
+        Price is the exchange rate between the specified token and the network's
+        native currency.
+
+        It represents the amount of native token atoms needed to buy 1 atom of
+        the specified token.
       parameters:
         - name: token
           in: path
           required: true
           schema:
-            $ref: "#/components/schemas/Address"
+            $ref: '#/components/schemas/Address'
       responses:
-        200:
+        '200':
           description: The estimated native price.
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/NativePriceResponse"
-        400:
+                $ref: '#/components/schemas/NativePriceResponse'
+        '400':
           description: Error finding the price.
-        404:
+        '404':
           description: No liquidity was found.
-        500:
+        '500':
           description: Unexpected error.
   /api/v1/quote:
     post:
       summary: Quote a price and fee for the specified order parameters.
-      description: |
-        Given a partial order compute the minimum fee and a price estimate for the order. Return a
-        full order that can be used directly for signing, and with an included signature, passed
+      description: >
+        Given a partial order compute the minimum fee and a price estimate for
+        the order. Return a
+
+        full order that can be used directly for signing, and with an included
+        signature, passed
+
         directly to the order creation endpoint.
       requestBody:
         description: The order parameters to compute a quote for.
@@ -300,27 +339,27 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/OrderQuoteRequest"
+              $ref: '#/components/schemas/OrderQuoteRequest'
       responses:
-        200:
+        '200':
           description: Quoted order.
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/OrderQuoteResponse"
-        400:
+                $ref: '#/components/schemas/OrderQuoteResponse'
+        '400':
           description: Error quoting order.
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/PriceEstimationError"
-        404:
+                $ref: '#/components/schemas/PriceEstimationError'
+        '404':
           description: No route was found for the specified order.
-        429:
+        '429':
           description: Too many order quotes.
-        500:
+        '500':
           description: Unexpected error quoting an order.
-  /api/v1/solver_competition/{auction_id}:
+  '/api/v1/solver_competition/{auction_id}':
     get:
       summary: Get information about a solver competition.
       description: |
@@ -332,15 +371,15 @@ paths:
           schema:
             type: integer
       responses:
-        200:
+        '200':
           description: Competition
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/SolverCompetitionResponse"
-        404:
+                $ref: '#/components/schemas/SolverCompetitionResponse'
+        '404':
           description: No competition information available for this auction id.
-  /api/v1/solver_competition/by_tx_hash/{tx_hash}:
+  '/api/v1/solver_competition/by_tx_hash/{tx_hash}':
     get:
       summary: Get information about solver competition.
       description: |
@@ -351,15 +390,15 @@ paths:
           in: path
           required: true
           schema:
-            $ref: "#/components/schemas/TransactionHash"
+            $ref: '#/components/schemas/TransactionHash'
       responses:
-        200:
+        '200':
           description: Competition
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/SolverCompetitionResponse"
-        404:
+                $ref: '#/components/schemas/SolverCompetitionResponse'
+        '404':
           description: No competition information available for this `tx_hash`.
   /api/v1/solver_competition/latest:
     get:
@@ -367,52 +406,55 @@ paths:
       description: |
         Returns the competition information for the last seen auction_id.
       responses:
-        200:
+        '200':
           description: Competition
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/SolverCompetitionResponse"
-        404:
+                $ref: '#/components/schemas/SolverCompetitionResponse'
+        '404':
           description: No competition information available.
   /api/v1/version:
     get:
       summary: Get the API's current deployed version.
-      description: |
-        Returns the git commit hash, branch name and release tag (code: https://github.com/cowprotocol/services).
+      description: >
+        Returns the git commit hash, branch name and release tag (code:
+        https://github.com/cowprotocol/services).
       responses:
-        200:
+        '200':
           description: Version
           content:
-            text/plain: { }
-  /api/v1/app_data/{app_data_hash}:
+            text/plain: {}
+  '/api/v1/app_data/{app_data_hash}':
     get:
       summary: Get the full `appData` from contract `appDataHash`.
       parameters:
         - in: path
           name: app_data_hash
           schema:
-            $ref: "#/components/schemas/AppDataHash"
+            $ref: '#/components/schemas/AppDataHash'
           required: true
       responses:
-        200:
+        '200':
           description: Full `appData`.
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/AppDataObject"
-        404:
+                $ref: '#/components/schemas/AppDataObject'
+        '404':
           description: No full `appData` stored for this hash.
     put:
       summary: Registers a full `appData` so it can be referenced by `appDataHash`.
-      description: |
+      description: >
         Uploads a full `appData` to orderbook so that orders created with the
-        corresponding `appDataHash` can be linked to the original full `appData`.
+
+        corresponding `appDataHash` can be linked to the original full
+        `appData`.
       parameters:
         - in: path
           name: app_data_hash
           schema:
-            $ref: "#/components/schemas/AppDataHash"
+            $ref: '#/components/schemas/AppDataHash'
           required: true
       requestBody:
         description: The `appData` document to upload.
@@ -420,83 +462,86 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/AppDataObject"
+              $ref: '#/components/schemas/AppDataObject'
       responses:
-        200:
+        '200':
           description: The full `appData` already exists.
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/AppDataHash"
-        201:
+                $ref: '#/components/schemas/AppDataHash'
+        '201':
           description: The full `appData` was successfully registered.
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/AppDataHash"
-        400:
+                $ref: '#/components/schemas/AppDataHash'
+        '400':
           description: Error validating full `appData`
-        500:
+        '500':
           description: Error storing the full `appData`
   /api/v1/app_data:
     put:
       summary: Registers a full `appData` and returns `appDataHash`.
-      description: |
-        Uploads a full `appData` to orderbook and returns the corresponding `appDataHash`.
+      description: >
+        Uploads a full `appData` to orderbook and returns the corresponding
+        `appDataHash`.
       requestBody:
         description: The `appData` document to upload.
         required: true
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/AppDataObject"
+              $ref: '#/components/schemas/AppDataObject'
       responses:
-        200:
+        '200':
           description: The full `appData` already exists.
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/AppDataHash"
-        201:
+                $ref: '#/components/schemas/AppDataHash'
+        '201':
           description: The full `appData` was successfully registered.
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/AppDataHash"
-        400:
+                $ref: '#/components/schemas/AppDataHash'
+        '400':
           description: Error validating full `appData`
-        500:
+        '500':
           description: Error storing the full `appData`
-  /api/v1/users/{address}/total_surplus:
+  '/api/v1/users/{address}/total_surplus':
     get:
-      summary: Get the total surplus earned by the user. [UNSTABLE]
-      description: |
+      summary: 'Get the total surplus earned by the user. [UNSTABLE]'
+      description: >
         ### Caution
 
-        This endpoint is under active development and should NOT be considered stable.
+
+        This endpoint is under active development and should NOT be considered
+        stable.
       parameters:
         - in: path
           name: address
           schema:
-            $ref: "#/components/schemas/Address"
+            $ref: '#/components/schemas/Address'
           required: true
       responses:
-        200:
+        '200':
           description: The total surplus.
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/TotalSurplus"
+                $ref: '#/components/schemas/TotalSurplus'
 components:
   schemas:
     TransactionHash:
       description: 32 byte digest encoded as a hex with `0x` prefix.
       type: string
-      example: "0xd51f28edffcaaa76be4a22f6375ad289272c037f3cc072345676e88d92ced8b5"
+      example: '0xd51f28edffcaaa76be4a22f6375ad289272c037f3cc072345676e88d92ced8b5'
     Address:
       description: 20 byte Ethereum address encoded as a hex with `0x` prefix.
       type: string
-      example: "0x6810e776880c02933d47db1b9fc05908e5386b96"
+      example: '0x6810e776880c02933d47db1b9fc05908e5386b96'
     AppData:
       description: |
         The string encoding of a JSON object representing some `appData`. The
@@ -505,48 +550,62 @@ components:
       type: string
       example: '{"version":"0.9.0","metadata":{}}'
     AppDataHash:
-      description: |
+      description: >
         32 bytes encoded as hex with `0x` prefix.
-        It's expected to be the hash of the stringified JSON object representing the `appData`.
+
+        It's expected to be the hash of the stringified JSON object representing
+        the `appData`.
       type: string
-      example: "0x0000000000000000000000000000000000000000000000000000000000000000"
+      example: '0x0000000000000000000000000000000000000000000000000000000000000000'
     AppDataObject:
       description: An `appData` document that is registered with the API.
       type: object
       properties:
         fullAppData:
-          $ref: "#/components/schemas/AppData"
+          $ref: '#/components/schemas/AppData'
       required:
         - appData
     BigUint:
       description: A big unsigned integer encoded in decimal.
       type: string
-      example: "1234567890"
+      example: '1234567890'
     CallData:
-      description: Some `calldata` sent to a contract in a transaction encoded as a hex with `0x` prefix.
+      description: >-
+        Some `calldata` sent to a contract in a transaction encoded as a hex
+        with `0x` prefix.
       type: string
-      example: "0xca11da7a"
+      example: '0xca11da7a'
     TokenAmount:
       description: Amount of a token. `uint256` encoded in decimal.
       type: string
-      example: "1234567890"
+      example: '1234567890'
     OnchainOrderData:
       type: object
       properties:
         sender:
-          description: |
-            If orders are placed as on-chain orders, the owner of the order might
+          description: >
+            If orders are placed as on-chain orders, the owner of the order
+            might
+
             be a smart contract, but not the user placing the order. The
+
             actual user will be provided in this field.
           allOf:
-            - $ref: "#/components/schemas/Address"
+            - $ref: '#/components/schemas/Address'
         placementError:
-          description: |
-            Describes the error, if the order placement was not successful. This could
-            happen, for example, if the `validTo` is too high, or no valid quote was
+          description: >
+            Describes the error, if the order placement was not successful. This
+            could
+
+            happen, for example, if the `validTo` is too high, or no valid quote
+            was
+
             found or generated.
           type: string
-          enum: [ QuoteNotFound, ValidToTooFarInFuture, PreValidationError ]
+          enum:
+            - QuoteNotFound
+            - ValidToTooFarInFuture
+            - PreValidationError
       required:
         - sender
     EthflowData:
@@ -558,7 +617,7 @@ components:
             Specifies in which transaction the order was refunded. If
             this field is null the order was not yet refunded.
           allOf:
-            - $ref: "#/components/schemas/TransactionHash"
+            - $ref: '#/components/schemas/TransactionHash'
           nullable: true
         userValidTo:
           description: |
@@ -573,34 +632,58 @@ components:
     OrderKind:
       description: Is this order a buy or sell?
       type: string
-      enum: [ buy, sell ]
+      enum:
+        - buy
+        - sell
     OrderClass:
       description: Order class.
       type: string
-      enum: [ market, limit, liquidity ]
+      enum:
+        - market
+        - limit
+        - liquidity
     SellTokenSource:
       description: Where should the `sellToken` be drawn from?
       type: string
-      enum: [ erc20, internal, external ]
+      enum:
+        - erc20
+        - internal
+        - external
     BuyTokenDestination:
       description: Where should the `buyToken` be transferred to?
       type: string
-      enum: [ erc20, internal ]
+      enum:
+        - erc20
+        - internal
     PriceQuality:
-      description: |
+      description: >
         How good should the price estimate be?
 
-        Fast: The price estimate is chosen among the fastest N price estimates.
-        Optimal: The price estimate is chosen among all price estimates.
-        Verified: The price estimate is chosen among all verified/simulated price estimates.
 
-        **NOTE**: Orders are supposed to be created from `verified` or `optimal` price estimates.
+        Fast: The price estimate is chosen among the fastest N price estimates.
+
+        Optimal: The price estimate is chosen among all price estimates.
+
+        Verified: The price estimate is chosen among all verified/simulated
+        price estimates.
+
+
+        **NOTE**: Orders are supposed to be created from `verified` or `optimal`
+        price estimates.
       type: string
-      enum: [ fast, optimal, verified ]
+      enum:
+        - fast
+        - optimal
+        - verified
     OrderStatus:
       description: The current order status.
       type: string
-      enum: [ presignaturePending, open, fulfilled, cancelled, expired ]
+      enum:
+        - presignaturePending
+        - open
+        - fulfilled
+        - cancelled
+        - expired
     OrderParameters:
       description: Order parameters.
       type: object
@@ -608,54 +691,56 @@ components:
         sellToken:
           description: ERC-20 token to be sold.
           allOf:
-            - $ref: "#/components/schemas/Address"
+            - $ref: '#/components/schemas/Address'
         buyToken:
           description: ERC-20 token to be bought.
           allOf:
-            - $ref: "#/components/schemas/Address"
+            - $ref: '#/components/schemas/Address'
         receiver:
-          description: |
-            An optional Ethereum address to receive the proceeds of the trade instead
+          description: >
+            An optional Ethereum address to receive the proceeds of the trade
+            instead
+
             of the owner (i.e. the order signer).
           allOf:
-            - $ref: "#/components/schemas/Address"
+            - $ref: '#/components/schemas/Address'
           nullable: true
         sellAmount:
           description: Amount of `sellToken` to be sold in atoms.
           allOf:
-            - $ref: "#/components/schemas/TokenAmount"
+            - $ref: '#/components/schemas/TokenAmount'
         buyAmount:
           description: Amount of `buyToken` to be bought in atoms.
           allOf:
-            - $ref: "#/components/schemas/TokenAmount"
+            - $ref: '#/components/schemas/TokenAmount'
         validTo:
           description: Unix timestamp (`uint32`) until which the order is valid.
           type: integer
         appData:
-          $ref: "#/components/schemas/AppDataHash"
+          $ref: '#/components/schemas/AppDataHash'
         feeAmount:
           description: feeRatio * sellAmount + minimal_fee in atoms.
           allOf:
-            - $ref: "#/components/schemas/TokenAmount"
+            - $ref: '#/components/schemas/TokenAmount'
         kind:
           description: The kind is either a buy or sell order.
           allOf:
-            - $ref: "#/components/schemas/OrderKind"
+            - $ref: '#/components/schemas/OrderKind'
         partiallyFillable:
           description: Is the order fill-or-kill or partially fillable?
           type: boolean
         sellTokenBalance:
           allOf:
-            - $ref: "#/components/schemas/SellTokenSource"
-          default: "erc20"
+            - $ref: '#/components/schemas/SellTokenSource'
+          default: erc20
         buyTokenBalance:
           allOf:
-            - $ref: "#/components/schemas/BuyTokenDestination"
-          default: "erc20"
+            - $ref: '#/components/schemas/BuyTokenDestination'
+          default: erc20
         signingScheme:
           allOf:
-            - $ref: "#/components/schemas/SigningScheme"
-          default: "eip712"
+            - $ref: '#/components/schemas/SigningScheme'
+          default: eip712
       required:
         - sellToken
         - buyToken
@@ -671,121 +756,169 @@ components:
       type: object
       properties:
         sellToken:
-          description: see `OrderParameters::sellToken`
+          description: 'see `OrderParameters::sellToken`'
           allOf:
-            - $ref: "#/components/schemas/Address"
+            - $ref: '#/components/schemas/Address'
         buyToken:
-          description: see `OrderParameters::buyToken`
+          description: 'see `OrderParameters::buyToken`'
           allOf:
-            - $ref: "#/components/schemas/Address"
+            - $ref: '#/components/schemas/Address'
         receiver:
-          description: see `OrderParameters::receiver`
+          description: 'see `OrderParameters::receiver`'
           allOf:
-            - $ref: "#/components/schemas/Address"
+            - $ref: '#/components/schemas/Address'
           nullable: true
         sellAmount:
-          description: see `OrderParameters::sellAmount`
+          description: 'see `OrderParameters::sellAmount`'
           allOf:
-            - $ref: "#/components/schemas/TokenAmount"
+            - $ref: '#/components/schemas/TokenAmount'
         buyAmount:
-          description: see `OrderParameters::buyAmount`
+          description: 'see `OrderParameters::buyAmount`'
           allOf:
-            - $ref: "#/components/schemas/TokenAmount"
+            - $ref: '#/components/schemas/TokenAmount'
         validTo:
-          description: see `OrderParameters::validTo`
+          description: 'see `OrderParameters::validTo`'
           type: integer
         feeAmount:
-          description: see `OrderParameters::feeAmount`
+          description: 'see `OrderParameters::feeAmount`'
           allOf:
-            - $ref: "#/components/schemas/TokenAmount"
+            - $ref: '#/components/schemas/TokenAmount'
         kind:
-          description: see `OrderParameters::kind`
+          description: 'see `OrderParameters::kind`'
           allOf:
-            - $ref: "#/components/schemas/OrderKind"
+            - $ref: '#/components/schemas/OrderKind'
         partiallyFillable:
-          description: see `OrderParameters::partiallyFillable`
+          description: 'see `OrderParameters::partiallyFillable`'
           type: boolean
         sellTokenBalance:
-          description: see `OrderParameters::sellTokenBalance`
+          description: 'see `OrderParameters::sellTokenBalance`'
           allOf:
-            - $ref: "#/components/schemas/SellTokenSource"
-          default: "erc20"
+            - $ref: '#/components/schemas/SellTokenSource'
+          default: erc20
         buyTokenBalance:
-          description: see `OrderParameters::buyTokenBalance`
+          description: 'see `OrderParameters::buyTokenBalance`'
           allOf:
-            - $ref: "#/components/schemas/BuyTokenDestination"
-          default: "erc20"
+            - $ref: '#/components/schemas/BuyTokenDestination'
+          default: erc20
         signingScheme:
-          $ref: "#/components/schemas/SigningScheme"
+          $ref: '#/components/schemas/SigningScheme'
         signature:
-          $ref: "#/components/schemas/Signature"
+          $ref: '#/components/schemas/Signature'
         from:
-          description: |
-            If set, the backend enforces that this address matches what is decoded as the *signer* of
-            the signature. This helps catch errors with invalid signature encodings as the backend
-            might otherwise silently work with an unexpected address that for example does not have
+          description: >
+            If set, the backend enforces that this address matches what is
+            decoded as the *signer* of
+
+            the signature. This helps catch errors with invalid signature
+            encodings as the backend
+
+            might otherwise silently work with an unexpected address that for
+            example does not have
+
             any balance.
           allOf:
-            - $ref: "#/components/schemas/Address"
+            - $ref: '#/components/schemas/Address'
           nullable: true
         quoteId:
-          description: |
-            Orders can optionally include a quote ID. This way the order can be linked to a quote
+          description: >
+            Orders can optionally include a quote ID. This way the order can be
+            linked to a quote
+
             and enable providing more metadata when analysing order slippage.
           type: integer
           nullable: true
         appData:
-          description: |
-            This field comes in two forms for backward compatibility. The hash form will eventually 
+          description: >
+            This field comes in two forms for backward compatibility. The hash
+            form will eventually 
+
             stop being accepted.
           anyOf:
             - title: Full App Data
               allOf:
-                - $ref: "#/components/schemas/AppData"
-              description: |
+                - $ref: '#/components/schemas/AppData'
+              description: >
                 **Short**:
 
-                If you do not care about `appData`, set this field to `"{}"` and make sure that the
+
+                If you do not care about `appData`, set this field to `"{}"` and
+                make sure that the
+
                 order you signed for this request had its `appData` field set to
+
                 `0xb48d38f93eaa084033fc5970bf96e559c33c4cdc07d889ab00b4d63f9590739d`.
+
 
                 **Long**:
 
+
                 A string encoding a JSON object like `"{"hello":"world"}"`.
 
-                This field determines the smart contract order's `appData` field, which is assumed to
-                be set to the `keccak256` hash of the UTF-8 encoded bytes of this string. You must
-                ensure that the signature that is part of this request indeed signed a smart contract
-                order with the `appData` field set appropriately. If this isn't the case, signature
-                verification will fail. For easier debugging it is recommended to additionally set the
+
+                This field determines the smart contract order's `appData`
+                field, which is assumed to
+
+                be set to the `keccak256` hash of the UTF-8 encoded bytes of
+                this string. You must
+
+                ensure that the signature that is part of this request indeed
+                signed a smart contract
+
+                order with the `appData` field set appropriately. If this isn't
+                the case, signature
+
+                verification will fail. For easier debugging it is recommended
+                to additionally set the
+
                 `appDataHash` field.
 
-                The field must be the encoding of a valid JSON object. The JSON object can contain
-                arbitrary application specific data (JSON key values). The optional key `backend` is
-                special. It **MUST** conform to the schema documented in `ProtocolAppData`.
 
-                The intended use of the other keys of the object is follow the standardized format
-                defined [here](https://github.com/cowprotocol/app-data). Example:
+                The field must be the encoding of a valid JSON object. The JSON
+                object can contain
+
+                arbitrary application specific data (JSON key values). The
+                optional key `backend` is
+
+                special. It **MUST** conform to the schema documented in
+                `ProtocolAppData`.
+
+
+                The intended use of the other keys of the object is follow the
+                standardized format
+
+                defined [here](https://github.com/cowprotocol/app-data).
+                Example:
+
 
                 ```json
+
                 {
                   "version": "0.7.0",
                   "appCode": "YOUR_APP_CODE",
                   "metadata": {}
                 }
+
                 ```
 
-                The total byte size of this field's UTF-8 encoded bytes is limited to 1000.
+
+                The total byte size of this field's UTF-8 encoded bytes is
+                limited to 1000.
               type: string
-            - $ref: "#/components/schemas/AppDataHash"
+            - $ref: '#/components/schemas/AppDataHash'
         appDataHash:
-          description: |
-            May be set for debugging purposes. If set, this field is compared to what the backend
-            internally calculates as the app data hash based on the contents of `appData`. If the
-            hash does not match, an error is returned. If this field is set, then `appData` **MUST** be
+          description: >
+            May be set for debugging purposes. If set, this field is compared to
+            what the backend
+
+            internally calculates as the app data hash based on the contents of
+            `appData`. If the
+
+            hash does not match, an error is returned. If this field is set,
+            then `appData` **MUST** be
+
             a string encoding of a JSON object.
           allOf:
-            - $ref: "#/components/schemas/AppDataHash"
+            - $ref: '#/components/schemas/AppDataHash'
           nullable: true
       required:
         - sellToken
@@ -799,98 +932,120 @@ components:
         - partiallyFillable
         - signingScheme
         - signature
-    ProtocolAppData:
-      type: object
     OrderMetaData:
-      description: |
-        Extra order data that is returned to users when querying orders but not provided by users
+      description: >
+        Extra order data that is returned to users when querying orders but not
+        provided by users
+
         when creating orders.
       type: object
       properties:
         creationDate:
           description: Creation time of the order. Encoded as ISO 8601 UTC.
           type: string
-          example: "2020-12-03T18:35:18.814523Z"
+          example: '2020-12-03T18:35:18.814523Z'
         class:
-          $ref: "#/components/schemas/OrderClass"
+          $ref: '#/components/schemas/OrderClass'
         owner:
-          $ref: "#/components/schemas/Address"
+          $ref: '#/components/schemas/Address'
         uid:
-          $ref: "#/components/schemas/UID"
+          $ref: '#/components/schemas/UID'
         availableBalance:
-          description: |
-            Unused field that is currently always set to `null` and will be removed in the future.
+          description: >
+            Unused field that is currently always set to `null` and will be
+            removed in the future.
           allOf:
-            - $ref: "#/components/schemas/TokenAmount"
+            - $ref: '#/components/schemas/TokenAmount'
           nullable: true
           deprecated: true
         executedSellAmount:
-          description: |
-            The total amount of `sellToken` that has been executed for this order including fees.
+          description: >
+            The total amount of `sellToken` that has been executed for this
+            order including fees.
           allOf:
-            - $ref: "#/components/schemas/BigUint"
+            - $ref: '#/components/schemas/BigUint'
         executedSellAmountBeforeFees:
-          description: |
-            The total amount of `sellToken` that has been executed for this order without fees.
+          description: >
+            The total amount of `sellToken` that has been executed for this
+            order without fees.
           allOf:
-            - $ref: "#/components/schemas/BigUint"
+            - $ref: '#/components/schemas/BigUint'
         executedBuyAmount:
-          description: |
-            The total amount of `buyToken` that has been executed for this order.
+          description: >
+            The total amount of `buyToken` that has been executed for this
+            order.
           allOf:
-            - $ref: "#/components/schemas/BigUint"
+            - $ref: '#/components/schemas/BigUint'
         executedFeeAmount:
           description: The total amount of fees that have been executed for this order.
           allOf:
-            - $ref: "#/components/schemas/BigUint"
+            - $ref: '#/components/schemas/BigUint'
         invalidated:
           description: Has this order been invalidated?
           type: boolean
         status:
           description: Order status.
           allOf:
-            - $ref: "#/components/schemas/OrderStatus"
+            - $ref: '#/components/schemas/OrderStatus'
         fullFeeAmount:
           description: Amount that the signed fee would be without subsidies.
           allOf:
-            - $ref: "#/components/schemas/TokenAmount"
+            - $ref: '#/components/schemas/TokenAmount'
         isLiquidityOrder:
-          description: |
-            Liquidity orders are functionally the same as normal smart contract orders but are not
-            placed with the intent of actively getting traded. Instead they facilitate the
-            trade of normal orders by allowing them to be matched against liquidity orders which
+          description: >
+            Liquidity orders are functionally the same as normal smart contract
+            orders but are not
+
+            placed with the intent of actively getting traded. Instead they
+            facilitate the
+
+            trade of normal orders by allowing them to be matched against
+            liquidity orders which
+
             uses less gas and can have better prices than external liquidity.
 
-            As such liquidity orders will only be used in order to improve settlement of normal
-            orders. They should not be expected to be traded otherwise and should not expect to get
+
+            As such liquidity orders will only be used in order to improve
+            settlement of normal
+
+            orders. They should not be expected to be traded otherwise and
+            should not expect to get
+
             surplus.
           type: boolean
         ethflowData:
           allOf:
-            - $ref: "#/components/schemas/EthflowData"
+            - $ref: '#/components/schemas/EthflowData'
         onchainUser:
-          description: |
+          description: >
             This represents the actual trader of an on-chain order.
+
 
             ### ethflow orders
 
-            In this case, the `owner` would be the `EthFlow` contract and *not* the actual trader.
+
+            In this case, the `owner` would be the `EthFlow` contract and *not*
+            the actual trader.
           allOf:
-            - $ref: "#/components/schemas/Address"
+            - $ref: '#/components/schemas/Address'
         onchainOrderData:
-          description: |
-            There is some data only available for orders that are placed on-chain. This data
+          description: >
+            There is some data only available for orders that are placed
+            on-chain. This data
+
             can be found in this object.
           allOf:
-            - $ref: "#/components/schemas/OnchainOrderData"
+            - $ref: '#/components/schemas/OnchainOrderData'
         executedSurplusFee:
           description: Surplus fee that the limit order was executed with.
           allOf:
-            - $ref: "#/components/schemas/BigUint"
+            - $ref: '#/components/schemas/BigUint'
           nullable: true
         fullAppData:
-          description: |
-            Full `appData`, which the contract-level `appData` is a hash of. See `OrderCreation`
+          description: >
+            Full `appData`, which the contract-level `appData` is a hash of. See
+            `OrderCreation`
+
             for more information.
           type: string
           nullable: true
@@ -907,96 +1062,101 @@ components:
         - status
     Order:
       allOf:
-        - $ref: "#/components/schemas/OrderCreation"
-        - $ref: "#/components/schemas/OrderMetaData"
+        - $ref: '#/components/schemas/OrderCreation'
+        - $ref: '#/components/schemas/OrderMetaData'
     AuctionOrder:
-      description: |
-        A solvable order included in the current batch auction. Contains the data forwarded to solvers for solving.
+      description: >
+        A solvable order included in the current batch auction. Contains the
+        data forwarded to solvers for solving.
       type: object
       properties:
         uid:
-          $ref: "#/components/schemas/UID"
+          $ref: '#/components/schemas/UID'
         sellToken:
-          description: see `OrderParameters::sellToken`
+          description: 'see `OrderParameters::sellToken`'
           allOf:
-            - $ref: "#/components/schemas/Address"
+            - $ref: '#/components/schemas/Address'
         buyToken:
-          description: see `OrderParameters::buyToken`
+          description: 'see `OrderParameters::buyToken`'
           allOf:
-            - $ref: "#/components/schemas/Address"
+            - $ref: '#/components/schemas/Address'
         sellAmount:
-          description: see `OrderParameters::sellAmount`
+          description: 'see `OrderParameters::sellAmount`'
           allOf:
-            - $ref: "#/components/schemas/TokenAmount"
+            - $ref: '#/components/schemas/TokenAmount'
         buyAmount:
-          description: see `OrderParameters::buyAmount`
+          description: 'see `OrderParameters::buyAmount`'
           allOf:
-            - $ref: "#/components/schemas/TokenAmount"
+            - $ref: '#/components/schemas/TokenAmount'
         created:
           description: Creation time of the order. Denominated in epoch seconds.
           type: string
-          example: "123456"
+          example: '123456'
         validTo:
-          description: see `OrderParameters::validTo`
+          description: 'see `OrderParameters::validTo`'
           type: integer
         kind:
-          description: see `OrderParameters::kind`
+          description: 'see `OrderParameters::kind`'
           allOf:
-            - $ref: "#/components/schemas/OrderKind"
+            - $ref: '#/components/schemas/OrderKind'
         receiver:
-          description: see `OrderParameters::receiver`
+          description: 'see `OrderParameters::receiver`'
           allOf:
-            - $ref: "#/components/schemas/Address"
+            - $ref: '#/components/schemas/Address'
           nullable: true
         owner:
-          $ref: "#/components/schemas/Address"
+          $ref: '#/components/schemas/Address'
         partiallyFillable:
-          description: see `OrderParameters::partiallyFillable`
+          description: 'see `OrderParameters::partiallyFillable`'
           type: boolean
         executed:
-          description: |
-            Currently executed amount of sell/buy token, depending on the order kind.
+          description: >
+            Currently executed amount of sell/buy token, depending on the order
+            kind.
           allOf:
-            - $ref: "#/components/schemas/TokenAmount"
+            - $ref: '#/components/schemas/TokenAmount'
         preInteractions:
-          description: |
-            The pre-interactions that need to be executed before the first execution of the order.
+          description: >
+            The pre-interactions that need to be executed before the first
+            execution of the order.
           type: array
           items:
-            $ref: "#/components/schemas/InteractionData"
+            $ref: '#/components/schemas/InteractionData'
         postInteractions:
-          description: |
-            The post-interactions that need to be executed after the execution of the order.
+          description: >
+            The post-interactions that need to be executed after the execution
+            of the order.
           type: array
           items:
-            $ref: "#/components/schemas/InteractionData"
+            $ref: '#/components/schemas/InteractionData'
         sellTokenBalance:
-          description: see `OrderParameters::sellTokenBalance`
+          description: 'see `OrderParameters::sellTokenBalance`'
           allOf:
-            - $ref: "#/components/schemas/SellTokenSource"
-          default: "erc20"
+            - $ref: '#/components/schemas/SellTokenSource'
+          default: erc20
         buyTokenBalance:
-          description: see `OrderParameters::buyTokenBalance`
+          description: 'see `OrderParameters::buyTokenBalance`'
           allOf:
-            - $ref: "#/components/schemas/BuyTokenDestination"
-          default: "erc20"
+            - $ref: '#/components/schemas/BuyTokenDestination'
+          default: erc20
         class:
-          $ref: "#/components/schemas/OrderClass"
+          $ref: '#/components/schemas/OrderClass'
         appData:
-          $ref: "#/components/schemas/AppDataHash"
+          $ref: '#/components/schemas/AppDataHash'
         signature:
-          $ref: "#/components/schemas/Signature"
+          $ref: '#/components/schemas/Signature'
         protocolFees:
-          description: |
-            The fee policies that are used to compute the protocol fees for this order.
+          description: >
+            The fee policies that are used to compute the protocol fees for this
+            order.
           type: array
           items:
-            $ref: "#/components/schemas/FeePolicy"
+            $ref: '#/components/schemas/FeePolicy'
         quote:
           description: |
             A winning quote.
           allOf:
-            - $ref: "#/components/schemas/Quote"
+            - $ref: '#/components/schemas/Quote'
       required:
         - uid
         - sellToken
@@ -1025,34 +1185,42 @@ components:
       properties:
         id:
           type: integer
-          description: |
-            The unique identifier of the auction. Increment whenever the backend creates a new auction.
+          description: >
+            The unique identifier of the auction. Increment whenever the backend
+            creates a new auction.
         block:
           type: integer
-          description: |
-            The block number for the auction. Orders and prices are guaranteed to be valid on this
+          description: >
+            The block number for the auction. Orders and prices are guaranteed
+            to be valid on this
+
             block. Proposed settlements should be valid for this block as well.
         latestSettlementBlock:
           type: integer
-          description: |
+          description: >
             The latest block on which a settlement has been processed.
 
-            **NOTE**: Under certain conditions it is possible for a settlement to have been mined as
+
+            **NOTE**: Under certain conditions it is possible for a settlement
+            to have been mined as
+
             part of `block` but not have yet been processed.
         orders:
           type: array
           items:
-            $ref: "#/components/schemas/AuctionOrder"
+            $ref: '#/components/schemas/AuctionOrder'
           description: |
             The solvable orders included in the auction.
         prices:
-          $ref: "#/components/schemas/AuctionPrices"
+          $ref: '#/components/schemas/AuctionPrices'
         surplusCapturingJitOrderOwners:
           type: array
           items:
-            $ref: "#/components/schemas/Address"
-          description: |
-            List of addresses on whose surplus will count towards the objective value of their solution (unlike other orders that were created by the solver).
+            $ref: '#/components/schemas/Address'
+          description: >
+            List of addresses on whose surplus will count towards the objective
+            value of their solution (unlike other orders that were created by
+            the solver).
     CompetitionAuction:
       description: |
         The components that describe a batch auction for the solver competition.
@@ -1061,18 +1229,18 @@ components:
         orders:
           type: array
           items:
-            $ref: "#/components/schemas/UID"
+            $ref: '#/components/schemas/UID'
           description: |
             The UIDs of the orders included in the auction.
         prices:
-          $ref: "#/components/schemas/AuctionPrices"
+          $ref: '#/components/schemas/AuctionPrices'
     ExecutedAmounts:
       type: object
       properties:
         sell:
-          $ref: "#/components/schemas/BigUint"
+          $ref: '#/components/schemas/BigUint'
         buy:
-          $ref: "#/components/schemas/BigUint"
+          $ref: '#/components/schemas/BigUint'
       required:
         - sell
         - buy
@@ -1090,9 +1258,12 @@ components:
             - traded
             - cancelled
         value:
-          description: |
-            A list of solvers who participated in the latest competition, sorted by score in ascending order, where the last element is the winner.
-            The presence of executed amounts defines whether the solver provided a solution for the desired order.
+          description: >
+            A list of solvers who participated in the latest competition, sorted
+            by score in ascending order, where the last element is the winner.
+
+            The presence of executed amounts defines whether the solver provided
+            a solution for the desired order.
           type: array
           items:
             type: object
@@ -1101,37 +1272,44 @@ components:
                 type: string
                 description: Name of the solver.
               executedAmounts:
-                $ref: "#/components/schemas/ExecutedAmounts"
+                $ref: '#/components/schemas/ExecutedAmounts'
             required:
               - solver
       required:
         - type
     AuctionPrices:
-      description: |
-        The reference prices for all traded tokens in the auction as a mapping from token
-        addresses to a price denominated in native token (i.e. 1e18 represents a token that
-        trades one to one with the native token). These prices are used for solution competition
+      description: >
+        The reference prices for all traded tokens in the auction as a mapping
+        from token
+
+        addresses to a price denominated in native token (i.e. 1e18 represents a
+        token that
+
+        trades one to one with the native token). These prices are used for
+        solution competition
+
         for computing surplus and converting fees to native token.
       type: object
       additionalProperties:
-        $ref: "#/components/schemas/BigUint"
+        $ref: '#/components/schemas/BigUint'
     OrderCancellations:
-      description: |
-        EIP-712 signature of struct OrderCancellations { orderUid: bytes[] } from the order's owner.
+      description: >
+        EIP-712 signature of struct OrderCancellations { orderUid: bytes[] }
+        from the order's owner.
       type: object
       properties:
         orderUids:
           type: array
           description: UIDs of orders to cancel.
           items:
-            $ref: "#/components/schemas/UID"
+            $ref: '#/components/schemas/UID'
         signature:
-          description: "`OrderCancellation` signed by the owner."
+          description: '`OrderCancellation` signed by the owner.'
           allOf:
-            - $ref: "#/components/schemas/EcdsaSignature"
+            - $ref: '#/components/schemas/EcdsaSignature'
         signingScheme:
           allOf:
-            - $ref: "#/components/schemas/EcdsaSigningScheme"
+            - $ref: '#/components/schemas/EcdsaSigningScheme'
       required:
         - signature
         - signingScheme
@@ -1142,17 +1320,18 @@ components:
       type: object
       properties:
         signature:
-          description: "OrderCancellation signed by owner"
+          description: OrderCancellation signed by owner
           allOf:
-            - $ref: "#/components/schemas/EcdsaSignature"
+            - $ref: '#/components/schemas/EcdsaSignature'
         signingScheme:
-          $ref: "#/components/schemas/EcdsaSigningScheme"
+          $ref: '#/components/schemas/EcdsaSigningScheme'
       required:
         - signature
         - signingScheme
     Trade:
-      description: |
-        Trade data such as executed amounts, fees, `orderUid` and `block` number.
+      description: >
+        Trade data such as executed amounts, fees, `orderUid` and `block`
+        number.
       type: object
       properties:
         blockNumber:
@@ -1164,42 +1343,49 @@ components:
         orderUid:
           description: UID of the order matched by this trade.
           allOf:
-            - $ref: "#/components/schemas/UID"
+            - $ref: '#/components/schemas/UID'
         owner:
           description: Address of trader.
           allOf:
-            - $ref: "#/components/schemas/Address"
+            - $ref: '#/components/schemas/Address'
         sellToken:
           description: Address of token sold.
           allOf:
-            - $ref: "#/components/schemas/Address"
+            - $ref: '#/components/schemas/Address'
         buyToken:
           description: Address of token bought.
           allOf:
-            - $ref: "#/components/schemas/Address"
+            - $ref: '#/components/schemas/Address'
         sellAmount:
-          description: Total amount of `sellToken` that has been executed for this trade (including fees).
+          description: >-
+            Total amount of `sellToken` that has been executed for this trade
+            (including fees).
           allOf:
-            - $ref: "#/components/schemas/TokenAmount"
+            - $ref: '#/components/schemas/TokenAmount'
         sellAmountBeforeFees:
-          description: The total amount of `sellToken` that has been executed for this order without fees.
+          description: >-
+            The total amount of `sellToken` that has been executed for this
+            order without fees.
           allOf:
-            - $ref: "#/components/schemas/BigUint"
+            - $ref: '#/components/schemas/BigUint'
         buyAmount:
           description: Total amount of `buyToken` received in this trade.
           allOf:
-            - $ref: "#/components/schemas/TokenAmount"
+            - $ref: '#/components/schemas/TokenAmount'
         txHash:
-          description: "Transaction hash of the corresponding settlement transaction containing the trade (if available)."
+          description: >-
+            Transaction hash of the corresponding settlement transaction
+            containing the trade (if available).
           allOf:
-            - $ref: "#/components/schemas/TransactionHash"
+            - $ref: '#/components/schemas/TransactionHash'
           nullable: true
         executedProtocolFees:
-          description: | 
-           Executed protocol fees for this trade, together with the fee policies used. Listed in the order they got applied.
+          description: >
+            Executed protocol fees for this trade, together with the fee
+            policies used. Listed in the order they got applied.
           type: array
           items:
-            $ref: "#/components/schemas/ExecutedProtocolFee"
+            $ref: '#/components/schemas/ExecutedProtocolFee'
       required:
         - blockNumber
         - logIndex
@@ -1212,69 +1398,78 @@ components:
         - buyAmount
         - txHash
     UID:
-      description: |
-        Unique identifier for the order: 56 bytes encoded as hex with `0x` prefix.
-        Bytes 0..32 are the order digest, bytes 30..52 the owner address and bytes
+      description: >
+        Unique identifier for the order: 56 bytes encoded as hex with `0x`
+        prefix.
+
+        Bytes 0..32 are the order digest, bytes 30..52 the owner address and
+        bytes
+
         52..56 the expiry (`validTo`) as a `uint32` unix epoch timestamp.
       type: string
-      # ENS order
-      example: "0xff2e2e54d178997f173266817c1e9ed6fee1a1aae4b43971c53b543cffcc2969845c6f5599fbb25dbdd1b9b013daf85c03f3c63763e4bc4a"
+      example: >-
+        0xff2e2e54d178997f173266817c1e9ed6fee1a1aae4b43971c53b543cffcc2969845c6f5599fbb25dbdd1b9b013daf85c03f3c63763e4bc4a
     SigningScheme:
       description: How was the order signed?
       type: string
-      enum: [ eip712, ethsign, presign, eip1271 ]
+      enum:
+        - eip712
+        - ethsign
+        - presign
+        - eip1271
     EcdsaSigningScheme:
       description: How was the order signed?
       type: string
-      enum: [ eip712, ethsign ]
+      enum:
+        - eip712
+        - ethsign
     Signature:
       description: A signature.
       oneOf:
-        - $ref: "#/components/schemas/EcdsaSignature"
-        - $ref: "#/components/schemas/PreSignature"
+        - $ref: '#/components/schemas/EcdsaSignature'
+        - $ref: '#/components/schemas/PreSignature'
     EcdsaSignature:
       description: 65 bytes encoded as hex with `0x` prefix. `r || s || v` from the spec.
       type: string
-      example: "0x0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
+      example: >-
+        0x0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000
     PreSignature:
       description: Empty signature bytes. Used for "presign" signatures.
       type: string
-      example: "0x"
+      example: 0x
     OrderPostError:
       type: object
       properties:
         errorType:
           type: string
           enum:
-            [
-              DuplicatedOrder,
-              QuoteNotFound,
-              QuoteNotVerified,
-              InvalidQuote,
-              MissingFrom,
-              WrongOwner,
-              InvalidEip1271Signature,
-              InsufficientBalance,
-              InsufficientAllowance,
-              InvalidSignature,
-              SellAmountOverflow,
-              TransferSimulationFailed,
-              ZeroAmount,
-              IncompatibleSigningScheme,
-              TooManyLimitOrders,
-              TooMuchGas,
-              UnsupportedBuyTokenDestination,
-              UnsupportedSellTokenSource,
-              UnsupportedOrderType,
-              InsufficientValidTo,
-              ExcessiveValidTo,
-              InvalidNativeSellToken,
-              SameBuyAndSellToken,
-              UnsupportedToken,
-              InvalidAppData,
-              AppDataHashMismatch,
-              AppdataFromMismatch,
-            ]
+            - DuplicatedOrder
+            - QuoteNotFound
+            - QuoteNotVerified
+            - InvalidQuote
+            - MissingFrom
+            - WrongOwner
+            - InvalidEip1271Signature
+            - InsufficientBalance
+            - InsufficientAllowance
+            - InvalidSignature
+            - SellAmountOverflow
+            - TransferSimulationFailed
+            - ZeroAmount
+            - IncompatibleSigningScheme
+            - TooManyLimitOrders
+            - TooMuchGas
+            - UnsupportedBuyTokenDestination
+            - UnsupportedSellTokenSource
+            - UnsupportedOrderType
+            - InsufficientValidTo
+            - ExcessiveValidTo
+            - InvalidNativeSellToken
+            - SameBuyAndSellToken
+            - UnsupportedToken
+            - InvalidAppData
+            - AppDataHashMismatch
+            - AppdataFromMismatch
         description:
           type: string
       required:
@@ -1286,15 +1481,13 @@ components:
         errorType:
           type: string
           enum:
-            [
-              InvalidSignature,
-              WrongOwner,
-              OrderNotFound,
-              AlreadyCancelled,
-              OrderFullyExecuted,
-              OrderExpired,
-              OnChainOrder,
-            ]
+            - InvalidSignature
+            - WrongOwner
+            - OrderNotFound
+            - AlreadyCancelled
+            - OrderFullyExecuted
+            - OrderExpired
+            - OnChainOrder
         description:
           type: string
       required:
@@ -1306,12 +1499,10 @@ components:
         errorType:
           type: string
           enum:
-            [
-              "QuoteNotVerified",
-              "UnsupportedToken",
-              "ZeroAmount",
-              "UnsupportedOrderType",
-            ]
+            - QuoteNotVerified
+            - UnsupportedToken
+            - ZeroAmount
+            - UnsupportedOrderType
         description:
           type: string
       required:
@@ -1321,17 +1512,21 @@ components:
       description: The buy or sell side when quoting an order.
       oneOf:
         - type: object
-          description: Quote a sell order given the final total `sellAmount` including fees.
+          description: >-
+            Quote a sell order given the final total `sellAmount` including
+            fees.
           properties:
             kind:
               allOf:
-                - $ref: "#/components/schemas/OrderQuoteSideKindSell"
+                - $ref: '#/components/schemas/OrderQuoteSideKindSell'
             sellAmountBeforeFee:
-              description: |
-                The total amount that is available for the order. From this value, the fee
+              description: >
+                The total amount that is available for the order. From this
+                value, the fee
+
                 is deducted and the buy amount is calculated.
               allOf:
-                - $ref: "#/components/schemas/TokenAmount"
+                - $ref: '#/components/schemas/TokenAmount'
           required:
             - kind
             - sellAmountBeforeFee
@@ -1340,11 +1535,11 @@ components:
           properties:
             kind:
               allOf:
-                - $ref: "#/components/schemas/OrderQuoteSideKindSell"
+                - $ref: '#/components/schemas/OrderQuoteSideKindSell'
             sellAmountAfterFee:
               description: The `sellAmount` for the order.
               allOf:
-                - $ref: "#/components/schemas/TokenAmount"
+                - $ref: '#/components/schemas/TokenAmount'
           required:
             - kind
             - sellAmountAfterFee
@@ -1353,20 +1548,22 @@ components:
           properties:
             kind:
               allOf:
-                - $ref: "#/components/schemas/OrderQuoteSideKindBuy"
+                - $ref: '#/components/schemas/OrderQuoteSideKindBuy'
             buyAmountAfterFee:
               description: The `buyAmount` for the order.
               allOf:
-                - $ref: "#/components/schemas/TokenAmount"
+                - $ref: '#/components/schemas/TokenAmount'
           required:
             - kind
             - buyAmountAfterFee
     OrderQuoteSideKindSell:
       type: string
-      enum: [ sell ]
+      enum:
+        - sell
     OrderQuoteSideKindBuy:
       type: string
-      enum: [ buy ]
+      enum:
+        - buy
     OrderQuoteValidity:
       description: The validity for the order.
       oneOf:
@@ -1385,62 +1582,74 @@ components:
     OrderQuoteRequest:
       description: Request fee and price quote.
       allOf:
-        - $ref: "#/components/schemas/OrderQuoteSide"
-        - $ref: "#/components/schemas/OrderQuoteValidity"
+        - $ref: '#/components/schemas/OrderQuoteSide'
+        - $ref: '#/components/schemas/OrderQuoteValidity'
         - type: object
           properties:
             sellToken:
               description: ERC-20 token to be sold
               allOf:
-                - $ref: "#/components/schemas/Address"
+                - $ref: '#/components/schemas/Address'
             buyToken:
               description: ERC-20 token to be bought
               allOf:
-                - $ref: "#/components/schemas/Address"
+                - $ref: '#/components/schemas/Address'
             receiver:
-              description: |
-                An optional address to receive the proceeds of the trade instead of the
+              description: >
+                An optional address to receive the proceeds of the trade instead
+                of the
+
                 `owner` (i.e. the order signer).
               allOf:
-                - $ref: "#/components/schemas/Address"
+                - $ref: '#/components/schemas/Address'
               nullable: true
             appData:
-              description: |
+              description: >
                 AppData which will be assigned to the order.
-                Expects either a string JSON doc as defined on [AppData](https://github.com/cowprotocol/app-data) or a
+
+                Expects either a string JSON doc as defined on
+                [AppData](https://github.com/cowprotocol/app-data) or a
+
                 hex encoded string for backwards compatibility.
-                When the first format is used, it's possible to provide the derived appDataHash field.
+
+                When the first format is used, it's possible to provide the
+                derived appDataHash field.
               oneOf:
-                - $ref: "#/components/schemas/AppData"
-                - $ref: "#/components/schemas/AppDataHash"
+                - $ref: '#/components/schemas/AppData'
+                - $ref: '#/components/schemas/AppDataHash'
             appDataHash:
-              description: |
+              description: >
                 The hash of the stringified JSON appData doc.
-                If present, `appData` field must be set with the aforementioned data where this hash is derived from.
+
+                If present, `appData` field must be set with the aforementioned
+                data where this hash is derived from.
+
                 In case they differ, the call will fail.
               anyOf:
-                - $ref: "#/components/schemas/AppDataHash"
+                - $ref: '#/components/schemas/AppDataHash'
             sellTokenBalance:
               allOf:
-                - $ref: "#/components/schemas/SellTokenSource"
-              default: "erc20"
+                - $ref: '#/components/schemas/SellTokenSource'
+              default: erc20
             buyTokenBalance:
               allOf:
-                - $ref: "#/components/schemas/BuyTokenDestination"
-              default: "erc20"
+                - $ref: '#/components/schemas/BuyTokenDestination'
+              default: erc20
             from:
-              $ref: "#/components/schemas/Address"
+              $ref: '#/components/schemas/Address'
             priceQuality:
               allOf:
-                - $ref: "#/components/schemas/PriceQuality"
-              default: "verified"
+                - $ref: '#/components/schemas/PriceQuality'
+              default: verified
             signingScheme:
               allOf:
-                - $ref: "#/components/schemas/SigningScheme"
-              default: "eip712"
+                - $ref: '#/components/schemas/SigningScheme'
+              default: eip712
             onchainOrder:
-              description: |
-                Flag to signal whether the order is intended for on-chain order placement. Only valid
+              description: >
+                Flag to signal whether the order is intended for on-chain order
+                placement. Only valid
+
                 for non ECDSA-signed orders."
               default: false
           required:
@@ -1454,23 +1663,26 @@ components:
       type: object
       properties:
         quote:
-          $ref: "#/components/schemas/OrderParameters"
+          $ref: '#/components/schemas/OrderParameters'
         from:
-          $ref: "#/components/schemas/Address"
+          $ref: '#/components/schemas/Address'
         expiration:
           description: |
             Expiration date of the offered fee. Order service might not accept
             the fee after this expiration date. Encoded as ISO 8601 UTC.
           type: string
-          example: "1985-03-10T18:35:18.814523Z"
+          example: '1985-03-10T18:35:18.814523Z'
         id:
-          description: |
-            Quote ID linked to a quote to enable providing more metadata when analysing
+          description: >
+            Quote ID linked to a quote to enable providing more metadata when
+            analysing
+
             order slippage.
           type: integer
         verified:
-          description: |
-            Whether it was possible to verify that the quoted amounts are accurate using a simulation.
+          description: >
+            Whether it was possible to verify that the quoted amounts are
+            accurate using a simulation.
           type: boolean
       required:
         - quote
@@ -1490,8 +1702,10 @@ components:
           type: string
           nullable: true
           allOf:
-            - $ref: "#/components/schemas/TransactionHash"
-          description: The hash of the transaction that the winning solution of this info was submitted in.
+            - $ref: '#/components/schemas/TransactionHash'
+          description: >-
+            The hash of the transaction that the winning solution of this info
+            was submitted in.
         gasPrice:
           type: number
           description: Gas price used for ranking solutions.
@@ -1500,12 +1714,12 @@ components:
         competitionSimulationBlock:
           type: integer
         auction:
-          $ref: "#/components/schemas/CompetitionAuction"
+          $ref: '#/components/schemas/CompetitionAuction'
         solutions:
           type: array
           description: Maps from solver name to object describing that solver's settlement.
           items:
-            $ref: "#/components/schemas/SolverSettlement"
+            $ref: '#/components/schemas/SolverSettlement'
     SolverSettlement:
       type: object
       properties:
@@ -1514,9 +1728,11 @@ components:
           description: Name of the solver.
         solverAddress:
           type: string
-          description: |
+          description: >
             The address used by the solver to execute the settlement on-chain.
-            This field is missing for old settlements, the zero address has been used instead.
+
+            This field is missing for old settlements, the zero address has been
+            used instead.
         objective:
           type: object
           properties:
@@ -1533,17 +1749,20 @@ components:
               type: integer
         score:
           allOf:
-            - $ref: "#/components/schemas/BigUint"
-          description: |
-            The score of the current auction as defined in [CIP-20](https://snapshot.org/#/cow.eth/proposal/0x2d3f9bd1ea72dca84b03e97dda3efc1f4a42a772c54bd2037e8b62e7d09a491f).
+            - $ref: '#/components/schemas/BigUint'
+          description: >
+            The score of the current auction as defined in
+            [CIP-20](https://snapshot.org/#/cow.eth/proposal/0x2d3f9bd1ea72dca84b03e97dda3efc1f4a42a772c54bd2037e8b62e7d09a491f).
+
             It is `null` for old auctions.
           nullable: true
         clearingPrices:
           type: object
           additionalProperties:
-            $ref: "#/components/schemas/BigUint"
-          description: |
-            The prices of tokens for settled user orders as passed to the settlement contract.
+            $ref: '#/components/schemas/BigUint'
+          description: >
+            The prices of tokens for settled user orders as passed to the
+            settlement contract.
         orders:
           type: array
           description: Touched orders.
@@ -1551,9 +1770,9 @@ components:
             type: object
             properties:
               id:
-                $ref: "#/components/schemas/UID"
+                $ref: '#/components/schemas/UID'
               executedAmount:
-                $ref: "#/components/schemas/BigUint"
+                $ref: '#/components/schemas/BigUint'
     NativePriceResponse:
       description: |
         The estimated native price for the token
@@ -1574,13 +1793,13 @@ components:
       type: object
       properties:
         target:
-          $ref: "#/components/schemas/Address"
+          $ref: '#/components/schemas/Address'
         value:
-          $ref: "#/components/schemas/TokenAmount"
+          $ref: '#/components/schemas/TokenAmount'
         call_data:
           type: array
           items:
-            $ref: "#/components/schemas/CallData"
+            $ref: '#/components/schemas/CallData'
           description: The call data to be used for the interaction.
     Quote:
       description: |
@@ -1590,28 +1809,28 @@ components:
         sellAmount:
           description: The amount of the sell token.
           allOf:
-            - $ref: "#/components/schemas/TokenAmount"
+            - $ref: '#/components/schemas/TokenAmount'
         buyAmount:
           description: The amount of the buy token.
           allOf:
-            - $ref: "#/components/schemas/TokenAmount"
+            - $ref: '#/components/schemas/TokenAmount'
         fee:
-          description: The amount that needs to be paid, denominated in the sell token.
+          description: 'The amount that needs to be paid, denominated in the sell token.'
           allOf:
-            - $ref: "#/components/schemas/TokenAmount"
+            - $ref: '#/components/schemas/TokenAmount'
     Surplus:
       description: The protocol fee is taken as a percent of the surplus.
       type: object
       properties:
         factor:
           type: number
-          minimum: 0.0
-          maximum: 1.0
+          minimum: 0
+          maximum: 1
           exclusiveMaximum: true
         maxVolumeFactor:
           type: number
-          minimum: 0.0
-          maximum: 1.0
+          minimum: 0
+          maximum: 1
           exclusiveMaximum: true
       required:
         - factor
@@ -1622,29 +1841,31 @@ components:
       properties:
         factor:
           type: number
-          minimum: 0.0
-          maximum: 1.0
+          minimum: 0
+          maximum: 1
           exclusiveMaximum: true
       required:
         - factor
     PriceImprovement:
-      description: The protocol fee is taken as a percent of the order price improvement which is a difference between the executed price and the best quote.
+      description: >-
+        The protocol fee is taken as a percent of the order price improvement
+        which is a difference between the executed price and the best quote.
       type: object
       properties:
         factor:
           type: number
-          minimum: 0.0
-          maximum: 1.0
+          minimum: 0
+          maximum: 1
           exclusiveMaximum: true
         maxVolumeFactor:
           type: number
-          minimum: 0.0
-          maximum: 1.0
+          minimum: 0
+          maximum: 1
           exclusiveMaximum: true
         quote:
           description: The best quote received.
           allOf:
-            - $ref: "#/components/schemas/Quote"
+            - $ref: '#/components/schemas/Quote'
       required:
         - factor
         - maxVolumeFactor
@@ -1652,17 +1873,19 @@ components:
     FeePolicy:
       description: Defines the ways to calculate the protocol fee.
       oneOf:
-        - $ref: "#/components/schemas/Surplus"
-        - $ref: "#/components/schemas/Volume"
-        - $ref: "#/components/schemas/PriceImprovement"
+        - $ref: '#/components/schemas/Surplus'
+        - $ref: '#/components/schemas/Volume'
+        - $ref: '#/components/schemas/PriceImprovement'
     ExecutedProtocolFee:
       type: object
       properties:
         policy:
           $ref: '#/components/schemas/FeePolicy'
         amount:
-          description: "Fee amount taken"
-          $ref: "#/components/schemas/TokenAmount"
+          allOf:
+            - description: Fee amount taken
+            - $ref: '#/components/schemas/TokenAmount'
         token:
-          description: "The token in which the fee is taken"
-          $ref: "#/components/schemas/Address"
+          allOf:
+            - description: The token in which the fee is taken
+            - $ref: '#/components/schemas/Address'

--- a/crates/orderbook/openapi.yml
+++ b/crates/orderbook/openapi.yml
@@ -116,7 +116,7 @@ paths:
     delete:
       deprecated: true
       summary: Cancel an order by marking it invalid with a timestamp.
-      description: >-
+      description: |-
         The successful deletion might not prevent solvers from settling the
         order.
 
@@ -203,7 +203,7 @@ paths:
           required: false
       responses:
         '200':
-          description: >-
+          description: |-
             ### If `owner` is specified:
 
             Return all trades related to that `owner`.
@@ -222,7 +222,7 @@ paths:
   /api/v1/auction:
     get:
       summary: Get the current batch auction.
-      description: >-
+      description: |-
         The current batch auction that solvers should be solving right now. This
         includes:
 
@@ -242,7 +242,7 @@ paths:
   '/api/v1/account/{owner}/orders':
     get:
       summary: Get orders of one user paginated.
-      description: >
+      description: |-
         The orders are sorted by their creation date descending (newest orders
         first).
 
@@ -283,7 +283,7 @@ paths:
   '/api/v1/token/{token}/native_price':
     get:
       summary: Get native price for the given token.
-      description: >-
+      description: |-
         Price is the exchange rate between the specified token and the network's
         native currency.
 
@@ -495,7 +495,7 @@ paths:
   '/api/v1/users/{address}/total_surplus':
     get:
       summary: 'Get the total surplus earned by the user. [UNSTABLE]'
-      description: >
+      description: |-
         ### Caution
 
         This endpoint is under active development and should NOT be considered
@@ -630,7 +630,7 @@ components:
         - erc20
         - internal
     PriceQuality:
-      description: >
+      description: |-
         How good should the price estimate be?
 
         Fast: The price estimate is chosen among the fastest N price estimates.
@@ -917,7 +917,7 @@ components:
           allOf:
             - $ref: '#/components/schemas/TokenAmount'
         isLiquidityOrder:
-          description: >
+          description: |-
             Liquidity orders are functionally the same as normal smart contract
             orders but are not placed with the intent of actively getting
             traded. Instead they facilitate the trade of normal orders by
@@ -1164,7 +1164,7 @@ components:
             - traded
             - cancelled
         value:
-          description: >
+          description: |-
             A list of solvers who participated in the latest competition, sorted
             by score in ascending order, where the last element is the winner.
 
@@ -1299,7 +1299,7 @@ components:
         - buyAmount
         - txHash
     UID:
-      description: >
+      description: |-
         Unique identifier for the order: 56 bytes encoded as hex with `0x`
         prefix.
 
@@ -1501,7 +1501,7 @@ components:
                 - $ref: '#/components/schemas/Address'
               nullable: true
             appData:
-              description: >
+              description: |-
                 AppData which will be assigned to the order.
 
                 Expects either a string JSON doc as defined on
@@ -1514,7 +1514,7 @@ components:
                 - $ref: '#/components/schemas/AppData'
                 - $ref: '#/components/schemas/AppDataHash'
             appDataHash:
-              description: >
+              description: |-
                 The hash of the stringified JSON appData doc.
 
                 If present, `appData` field must be set with the aforementioned
@@ -1620,7 +1620,7 @@ components:
           description: Name of the solver.
         solverAddress:
           type: string
-          description: >
+          description: |-
             The address used by the solver to execute the settlement on-chain.
 
             This field is missing for old settlements, the zero address has been

--- a/crates/solvers/openapi.yml
+++ b/crates/solvers/openapi.yml
@@ -5,10 +5,6 @@ info:
     The API implemented by solver engines interacting with the reference driver
     implementation.
   version: 0.0.1
-  contact:
-    name: CoW DAO
-    url: "https://cow.fi"
-    email: dev@cow.fi
 paths:
   /solve:
     post:

--- a/crates/solvers/openapi.yml
+++ b/crates/solvers/openapi.yml
@@ -54,7 +54,7 @@ paths:
             schema:
               type: object
               additionalProperties: true
-              description: >
+              description: |-
                 A notification that informs the solver how its solution
                 performed in the auction.
 

--- a/crates/solvers/openapi.yml
+++ b/crates/solvers/openapi.yml
@@ -364,7 +364,7 @@ components:
           maximum: 0.99999
           example: 0.05
         factor:
-          description: >-
+          description: >
             The factor of the user surplus that the protocol will request from
             the solver after settling the order
           type: number
@@ -384,7 +384,7 @@ components:
           type: number
           example: 0.01
         factor:
-          description: >-
+          description: >
             The factor of the user surplus that the protocol will request from
             the solver after settling the order
           type: number
@@ -399,7 +399,7 @@ components:
           enum:
             - volume
         factor:
-          description: >-
+          description: >
             The fraction of the order's volume that the protocol will request
             from the solver after settling the order.
           type: number
@@ -909,7 +909,7 @@ components:
         - interactions
       properties:
         id:
-          description: >-
+          description: >
             An opaque identifier for the solution. This is a solver generated
             number that is unique across multiple solutions within the auction.
           type: number
@@ -960,7 +960,7 @@ components:
             $ref: '#/components/schemas/CallData'
           description: The call data to be used for the interaction.
     CallData:
-      description: >-
+      description: >
         Some `calldata` sent to a contract in a transaction encoded as a hex
         with `0x` prefix.
       type: string

--- a/crates/solvers/openapi.yml
+++ b/crates/solvers/openapi.yml
@@ -5,7 +5,10 @@ info:
     The API implemented by solver engines interacting with the reference driver
     implementation.
   version: 0.0.1
-
+  contact:
+    name: CoW DAO
+    url: 'https://cow.fi'
+    email: dev@cow.fi
 paths:
   /solve:
     post:
@@ -16,9 +19,9 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/Auction"
+              $ref: '#/components/schemas/Auction'
       responses:
-        200:
+        '200':
           description: Auction successfully solved.
           content:
             application/json:
@@ -28,16 +31,17 @@ paths:
                   - solutions
                 properties:
                   solutions:
-                    description: |
-                      Proposed solutions to settle some of the orders in the auction.
+                    description: >
+                      Proposed solutions to settle some of the orders in the
+                      auction.
                     type: array
                     items:
-                      $ref: "#/components/schemas/Solution"
-        400:
+                      $ref: '#/components/schemas/Solution'
+        '400':
           description: There is something wrong with the request.
-        429:
+        '429':
           description: The solver cannot keep up. It is too busy to handle more requests.
-        500:
+        '500':
           description: Something went wrong when handling the request.
   /notify:
     post:
@@ -50,9 +54,13 @@ paths:
             schema:
               type: object
               additionalProperties: true
-              description: |
-                A notification that informs the solver how its solution performed in the auction.
-                Depending on the notification type additional meta data may be attached but this
+              description: >
+                A notification that informs the solver how its solution
+                performed in the auction.
+
+                Depending on the notification type additional meta data may be
+                attached but this
+
                 is not guaranteed to be stable.
               properties:
                 auctionId:
@@ -61,109 +69,96 @@ paths:
                     for.
                   type: string
                 solutionId:
-                  description: |
-                    The solution ID within the auction for which the notification applies
+                  description: >
+                    The solution ID within the auction for which the
+                    notification applies
                   type: number
                 kind:
                   description: |
                     The kind of notification.
                   type: string
                   enum:
-                    [
-                      timeout,
-                      emptySolution,
-                      duplicatedSolutionId,
-                      simulationFailed,
-                      invalidClearingPrices,
-                      missingPrice,
-                      invalidExecutedAmount,
-                      nonBufferableTokensUsed,
-                      solverAccountInsufficientBalance,
-                      success,
-                      revert,
-                      driverError,
-                      cancelled,
-                      fail,
-                      postprocessingTimedOut,
-                    ]
+                    - timeout
+                    - emptySolution
+                    - duplicatedSolutionId
+                    - simulationFailed
+                    - invalidClearingPrices
+                    - missingPrice
+                    - invalidExecutedAmount
+                    - nonBufferableTokensUsed
+                    - solverAccountInsufficientBalance
+                    - success
+                    - revert
+                    - driverError
+                    - cancelled
+                    - fail
+                    - postprocessingTimedOut
       responses:
-        200:
+        '200':
           description: notification successfully received.
-
 components:
   schemas:
     Address:
       description: |
         An Ethereum public address.
       type: string
-      example: "0x0000000000000000000000000000000000000000"
-
+      example: '0x0000000000000000000000000000000000000000'
     Token:
       description: |
         An ERC20 token address.
       type: string
-      example: "0xDEf1CA1fb7FBcDC777520aa7f396b4E015F497aB"
-
+      example: '0xDEf1CA1fb7FBcDC777520aa7f396b4E015F497aB'
     TokenAmount:
       description: |
         Amount of an ERC20 token. 256 bit unsigned integer in decimal notation.
       type: string
-      example: "1234567890"
-
+      example: '1234567890'
     U256:
       description: |
         256 bit unsigned integer in decimal notation.
       type: string
-      example: "1234567890"
-
+      example: '1234567890'
     U128:
       description: |
         128 bit unsigned integer in decimal notation.
       type: string
-      example: "1234567890"
-
+      example: '1234567890'
     I128:
       description: |
         128 bit signed integer in decimal notation.
       type: string
-      example: "-1234567890"
-
+      example: '-1234567890'
     I32:
       description: |
         32 bit signed integer in decimal notation.
       type: number
       example: -12345
-
     BalancerPoolId:
-      description: |
-        A hex-encoded 32 byte string containing the pool address (0..20), the pool specialization (20..22) and the poolnonce (22..32).
+      description: >
+        A hex-encoded 32 byte string containing the pool address (0..20), the
+        pool specialization (20..22) and the poolnonce (22..32).
       type: string
-      example: "0xc88c76dd8b92408fe9bea1a54922a31e232d873c0002000000000000000005b2"
-
+      example: '0xc88c76dd8b92408fe9bea1a54922a31e232d873c0002000000000000000005b2'
     BigInt:
       description: |
         An arbitrary-precision integer value.
       type: string
-      example: "1234567890"
-
+      example: '1234567890'
     Decimal:
       description: |
         An arbitrary-precision decimal value.
       type: string
-      example: "13.37"
-
+      example: '13.37'
     NativePrice:
       description: |
         The price in wei of the native token (Ether on Mainnet for example) to
         buy 10**18 of a token.
       type: string
-      example: "1234567890"
-
+      example: '1234567890'
     DateTime:
       description: An ISO-8601 formatted date-time.
       type: string
-      example: "1970-01-01T00:00:00.000Z"
-
+      example: '1970-01-01T00:00:00.000Z'
     TokenInfo:
       description: |
         Information about a token relevant to the auction.
@@ -188,20 +183,19 @@ components:
             This price is only included for tokens for which there are CoW
             Protocol orders.
           allOf:
-            - $ref: "#/components/schemas/NativePrice"
+            - $ref: '#/components/schemas/NativePrice'
         availableBalance:
           description: |
             The balance held by the Settlement contract that is available
             during a settlement.
           allOf:
-            - $ref: "#/components/schemas/TokenAmount"
+            - $ref: '#/components/schemas/TokenAmount'
         trusted:
           description: |
             A flag which indicates that solvers are allowed to perform gas cost
             optimizations for this token by not routing the trades via an AMM,
             and instead use its available balances, as specified by CIP-2.
           type: boolean
-
     Asset:
       description: |
         A token address with an amount.
@@ -211,10 +205,9 @@ components:
         - amount
       properties:
         token:
-          $ref: "#/components/schemas/Token"
+          $ref: '#/components/schemas/Token'
         amount:
-          $ref: "#/components/schemas/TokenAmount"
-
+          $ref: '#/components/schemas/TokenAmount'
     OrderUid:
       description: |
         Unique identifier for the order. Order UIDs are 56 bytes long, where
@@ -222,51 +215,58 @@ components:
         [32, 52) represent the owner address and bytes [52, 56) represent the
         order's `validTo` field.
       type: string
-      example: "0x30cff40d9f60caa68a37f0ee73253ad6ad72b45580c945fe3ab67596476937197854163b1b0d24e77dca702b97b5cc33e0f83dcb626122a6"
-
+      example: >-
+        0x30cff40d9f60caa68a37f0ee73253ad6ad72b45580c945fe3ab67596476937197854163b1b0d24e77dca702b97b5cc33e0f83dcb626122a6
     OrderKind:
       description: |
         The trading side of the order.
       type: string
-      enum: [ sell, buy ]
-
+      enum:
+        - sell
+        - buy
     OrderClass:
       description: |
         How the CoW Protocol order was classified.
       type: string
-      enum: [ market, limit ]
-
+      enum:
+        - market
+        - limit
     AppData:
       description: |
         32 bytes of arbitrary application specific data that can be added to an
         order. This can also be used to ensure uniqueness between two orders
         with otherwise the exact same parameters.
-      example: "0x0000000000000000000000000000000000000000000000000000000000000000"
-
+      example: '0x0000000000000000000000000000000000000000000000000000000000000000'
     SellTokenBalance:
       description: |
         Where should the sell token be drawn from?
       type: string
-      enum: [ erc20, internal, external ]
-
+      enum:
+        - erc20
+        - internal
+        - external
     BuyTokenBalance:
       description: |
         Where should the buy token be transferred to?
       type: string
-      enum: [ erc20, internal ]
-
+      enum:
+        - erc20
+        - internal
     SigningScheme:
       description: |
         How was the order signed?
       type: string
-      enum: [ eip712, ethSign, preSign, eip1271 ]
-
+      enum:
+        - eip712
+        - ethSign
+        - preSign
+        - eip1271
     Signature:
       description: |
         Signature bytes.
       type: string
-      example: "0x0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
-
+      example: >-
+        0x0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000
     Order:
       description: |
         CoW Protocol order information relevant to execution.
@@ -282,33 +282,33 @@ components:
         - class
       properties:
         uid:
-          $ref: "#/components/schemas/OrderUid"
+          $ref: '#/components/schemas/OrderUid'
         sellToken:
-          $ref: "#/components/schemas/Token"
+          $ref: '#/components/schemas/Token'
         buyToken:
-          $ref: "#/components/schemas/Token"
+          $ref: '#/components/schemas/Token'
         sellAmount:
-          $ref: "#/components/schemas/TokenAmount"
+          $ref: '#/components/schemas/TokenAmount'
         fullSellAmount:
-          $ref: "#/components/schemas/TokenAmount"
+          $ref: '#/components/schemas/TokenAmount'
         buyAmount:
-          $ref: "#/components/schemas/TokenAmount"
+          $ref: '#/components/schemas/TokenAmount'
         fullBuyAmount:
-          $ref: "#/components/schemas/TokenAmount"
+          $ref: '#/components/schemas/TokenAmount'
         feePolicies:
           description: |
             Any protocol fee policies that apply to the order.
           type: array
           items:
-            $ref: "#/components/schemas/FeePolicy"
+            $ref: '#/components/schemas/FeePolicy'
         validTo:
           type: integer
         kind:
-          $ref: "#/components/schemas/OrderKind"
+          $ref: '#/components/schemas/OrderKind'
         receiver:
-          $ref: "#/components/schemas/Address"
+          $ref: '#/components/schemas/Address'
         owner:
-          $ref: "#/components/schemas/Address"
+          $ref: '#/components/schemas/Address'
         partiallyFillable:
           description: |
             Whether or not this order can be partially filled. If this is false,
@@ -318,90 +318,101 @@ components:
         preInteractions:
           type: array
           items:
-            $ref: "#/components/schemas/Interaction"
+            $ref: '#/components/schemas/Interaction'
         postInteractions:
           type: array
           items:
-            $ref: "#/components/schemas/InteractionData"
+            $ref: '#/components/schemas/InteractionData'
         sellTokenSource:
           allOf:
-            - $ref: "#/components/schemas/SellTokenBalance"
-          default: "erc20"
+            - $ref: '#/components/schemas/SellTokenBalance'
+          default: erc20
         buyTokenDestination:
           allOf:
-            - $ref: "#/components/schemas/BuyTokenBalance"
-          default: "erc20"
+            - $ref: '#/components/schemas/BuyTokenBalance'
+          default: erc20
         class:
-          $ref: "#/components/schemas/OrderClass"
+          $ref: '#/components/schemas/OrderClass'
         appData:
-          $ref: "#/components/schemas/AppData"
+          $ref: '#/components/schemas/AppData'
         signingScheme:
-          $ref: "#/components/schemas/SigningScheme"
+          $ref: '#/components/schemas/SigningScheme'
         signature:
-          $ref: "#/components/schemas/Signature"
+          $ref: '#/components/schemas/Signature'
     FeePolicy:
       description: |
         A fee policy that applies to an order.
       type: object
       oneOf:
-        - $ref: "#/components/schemas/SurplusFee"
-        - $ref: "#/components/schemas/PriceImprovement"
-        - $ref: "#/components/schemas/VolumeFee"
+        - $ref: '#/components/schemas/SurplusFee'
+        - $ref: '#/components/schemas/PriceImprovement'
+        - $ref: '#/components/schemas/VolumeFee'
     SurplusFee:
-      description: |
-        If the order receives more than limit price, pay the protocol a factor of the difference.
+      description: >
+        If the order receives more than limit price, pay the protocol a factor
+        of the difference.
       type: object
       properties:
         kind:
           type: string
-          enum: [ "surplus" ]
+          enum:
+            - surplus
         maxVolumeFactor:
           description: Never charge more than that percentage of the order volume.
           type: number
-          minimum: 0.0
+          minimum: 0
           maximum: 0.99999
           example: 0.05
         factor:
-          description: The factor of the user surplus that the protocol will request from the solver after settling the order
+          description: >-
+            The factor of the user surplus that the protocol will request from
+            the solver after settling the order
           type: number
           example: 0.5
     PriceImprovement:
-      description: |
-        A cut from the price improvement over the best quote is taken as a protocol fee.
+      description: >
+        A cut from the price improvement over the best quote is taken as a
+        protocol fee.
       type: object
       properties:
         kind:
           type: string
-          enum: [ "priceImprovement" ]
+          enum:
+            - priceImprovement
         maxVolumeFactor:
           description: Never charge more than that percentage of the order volume.
           type: number
           example: 0.01
         factor:
-          description: The factor of the user surplus that the protocol will request from the solver after settling the order
+          description: >-
+            The factor of the user surplus that the protocol will request from
+            the solver after settling the order
           type: number
           example: 0.5
         quote:
-          $ref: "#/components/schemas/Quote"
+          $ref: '#/components/schemas/Quote'
     VolumeFee:
       type: object
       properties:
         kind:
           type: string
-          enum: [ "volume" ]
+          enum:
+            - volume
         factor:
-          description: The fraction of the order's volume that the protocol will request from the solver after settling the order.
+          description: >-
+            The fraction of the order's volume that the protocol will request
+            from the solver after settling the order.
           type: number
           example: 0.5
     Quote:
       type: object
       properties:
         sell_amount:
-          $ref: "#/components/schemas/TokenAmount"
+          $ref: '#/components/schemas/TokenAmount'
         buy_amount:
-          $ref: "#/components/schemas/TokenAmount"
+          $ref: '#/components/schemas/TokenAmount'
         fee:
-          $ref: "#/components/schemas/TokenAmount"
+          $ref: '#/components/schemas/TokenAmount'
     TokenReserve:
       description: |
         A reserve of tokens in an on-chain liquidity pool.
@@ -410,8 +421,7 @@ components:
         - balance
       properties:
         balance:
-          $ref: "#/components/schemas/TokenAmount"
-
+          $ref: '#/components/schemas/TokenAmount'
     ConstantProductPool:
       description: |
         A UniswapV2-like constant product liquidity pool for a token pair.
@@ -424,18 +434,18 @@ components:
       properties:
         kind:
           type: string
-          enum: [ constantProduct ]
+          enum:
+            - constantProduct
         tokens:
           description: |
             A mapping of token address to its reserve amounts.
           type: object
           additionalProperties:
-            $ref: "#/components/schemas/TokenReserve"
+            $ref: '#/components/schemas/TokenReserve'
         fee:
-          $ref: "#/components/schemas/Decimal"
+          $ref: '#/components/schemas/Decimal'
         router:
-          $ref: "#/components/schemas/Address"
-
+          $ref: '#/components/schemas/Address'
     WeightedProductPool:
       description: |
         A Balancer-like weighted product liquidity pool of N tokens.
@@ -448,30 +458,32 @@ components:
       properties:
         kind:
           type: string
-          enum: [ weightedProduct ]
+          enum:
+            - weightedProduct
         tokens:
           description: |
             A mapping of token address to its reserve amounts with weights.
           type: object
           additionalProperties:
             allOf:
-              - $ref: "#/components/schemas/TokenReserve"
+              - $ref: '#/components/schemas/TokenReserve'
               - type: object
                 required:
                   - weight
                 properties:
                   scalingFactor:
-                    $ref: "#/components/schemas/Decimal"
+                    $ref: '#/components/schemas/Decimal'
                   weight:
-                    $ref: "#/components/schemas/Decimal"
+                    $ref: '#/components/schemas/Decimal'
         fee:
-          $ref: "#/components/schemas/Decimal"
+          $ref: '#/components/schemas/Decimal'
         version:
           type: string
-          enum: [ "v0", "v3Plus" ]
+          enum:
+            - v0
+            - v3Plus
         balancer_pool_id:
-          $ref: "#/components/schemas/BalancerPoolId"
-
+          $ref: '#/components/schemas/BalancerPoolId'
     StablePool:
       description: |
         A Curve-like stable pool of N tokens.
@@ -485,27 +497,27 @@ components:
       properties:
         kind:
           type: string
-          enum: [ stable ]
+          enum:
+            - stable
         tokens:
           description: |
             A mapping of token address to token balance and scaling rate.
           type: object
           additionalProperties:
             allOf:
-              - $ref: "#/components/schemas/TokenReserve"
+              - $ref: '#/components/schemas/TokenReserve'
               - type: object
                 required:
                   - scalingFactor
                 properties:
                   scalingFactor:
-                    $ref: "#/components/schemas/Decimal"
+                    $ref: '#/components/schemas/Decimal'
         amplificationParameter:
-          $ref: "#/components/schemas/Decimal"
+          $ref: '#/components/schemas/Decimal'
         fee:
-          $ref: "#/components/schemas/Decimal"
+          $ref: '#/components/schemas/Decimal'
         balancer_pool_id:
-          $ref: "#/components/schemas/BalancerPoolId"
-
+          $ref: '#/components/schemas/BalancerPoolId'
     ConcentratedLiquidityPool:
       description: |
         A UniswapV3-like concentrated liquidity pool of 2 tokens.
@@ -522,28 +534,28 @@ components:
       properties:
         kind:
           type: string
-          enum: [ concentratedLiquidity ]
+          enum:
+            - concentratedLiquidity
         tokens:
           type: array
           items:
-            $ref: "#/components/schemas/Token"
+            $ref: '#/components/schemas/Token'
         sqrtPrice:
-          $ref: "#/components/schemas/U256"
+          $ref: '#/components/schemas/U256'
         liquidity:
-          $ref: "#/components/schemas/U128"
+          $ref: '#/components/schemas/U128'
         tick:
-          $ref: "#/components/schemas/I32"
+          $ref: '#/components/schemas/I32'
         liquidityNet:
           description: |
             A map of tick indices to their liquidity values.
           type: object
           additionalProperties:
-            $ref: "#/components/schemas/I128"
+            $ref: '#/components/schemas/I128'
         fee:
-          $ref: "#/components/schemas/Decimal"
+          $ref: '#/components/schemas/Decimal'
         router:
-          $ref: "#/components/schemas/Address"
-
+          $ref: '#/components/schemas/Address'
     ForeignLimitOrder:
       description: |
         A 0x-like limit order external to CoW Protocol.
@@ -558,33 +570,32 @@ components:
       properties:
         kind:
           type: string
-          enum: [ limitOrder ]
+          enum:
+            - limitOrder
         makerToken:
-          $ref: "#/components/schemas/Token"
+          $ref: '#/components/schemas/Token'
         takerToken:
-          $ref: "#/components/schemas/Token"
+          $ref: '#/components/schemas/Token'
         makerAmount:
-          $ref: "#/components/schemas/TokenAmount"
+          $ref: '#/components/schemas/TokenAmount'
         takerAmount:
-          $ref: "#/components/schemas/TokenAmount"
+          $ref: '#/components/schemas/TokenAmount'
         takerTokenFeeAmount:
-          $ref: "#/components/schemas/TokenAmount"
-
+          $ref: '#/components/schemas/TokenAmount'
     LiquidityParameters:
       oneOf:
-        - $ref: "#/components/schemas/ConstantProductPool"
-        - $ref: "#/components/schemas/WeightedProductPool"
-        - $ref: "#/components/schemas/StablePool"
-        - $ref: "#/components/schemas/ConcentratedLiquidityPool"
-        - $ref: "#/components/schemas/ForeignLimitOrder"
-
+        - $ref: '#/components/schemas/ConstantProductPool'
+        - $ref: '#/components/schemas/WeightedProductPool'
+        - $ref: '#/components/schemas/StablePool'
+        - $ref: '#/components/schemas/ConcentratedLiquidityPool'
+        - $ref: '#/components/schemas/ForeignLimitOrder'
     Liquidity:
       description: |
         On-chain liquidity that can be used in a solution. This liquidity is
         provided to facilitate onboarding new solvers. Additional liquidity that
         is not included in this set may still be used in solutions.
       allOf:
-        - $ref: "#/components/schemas/LiquidityParameters"
+        - $ref: '#/components/schemas/LiquidityParameters'
         - type: object
           required:
             - id
@@ -603,14 +614,13 @@ components:
                 The Ethereum public address of the liquidity. The actual address
                 that is specified is dependent on the kind of liquidity.
               allOf:
-                - $ref: "#/components/schemas/Address"
+                - $ref: '#/components/schemas/Address'
             gasEstimate:
               description: |
                 A rough approximation of gas units required to use this
                 liquidity on-chain.
               allOf:
-                - $ref: "#/components/schemas/BigInt"
-
+                - $ref: '#/components/schemas/BigInt'
     Auction:
       description: |
         The abstract auction to be solved by the searcher.
@@ -634,40 +644,41 @@ components:
             A map of token addresses to token information.
           type: object
           additionalProperties:
-            $ref: "#/components/schemas/TokenInfo"
+            $ref: '#/components/schemas/TokenInfo'
         orders:
           description: |
             The solvable orders included in the auction.
           type: array
           items:
-            $ref: "#/components/schemas/Order"
+            $ref: '#/components/schemas/Order'
         liquidity:
           description: |
             On-chain liquidity that can be used by the solution.
           type: array
           items:
-            $ref: "#/components/schemas/Liquidity"
+            $ref: '#/components/schemas/Liquidity'
         effectiveGasPrice:
           description: |
             The current estimated gas price that will be paid when executing a
             settlement. Additionally, this is the gas price that is multiplied
             with a settlement's gas estimate for solution scoring.
           allOf:
-            - $ref: "#/components/schemas/TokenAmount"
+            - $ref: '#/components/schemas/TokenAmount'
         deadline:
           description: |
             The deadline by which a solution to the auction is required.
             Requests that go beyond this deadline are expected to be cancelled
             by the caller.
           allOf:
-            - $ref: "#/components/schemas/DateTime"
+            - $ref: '#/components/schemas/DateTime'
         surplusCapturingJitOrderOwners:
           type: array
           items:
-            $ref: "#/components/schemas/Address"
-          description: |
-            List of addresses on whose surplus will count towards the objective value of their solution (unlike other orders that were created by the solver).
-
+            $ref: '#/components/schemas/Address'
+          description: >
+            List of addresses on whose surplus will count towards the objective
+            value of their solution (unlike other orders that were created by
+            the solver).
     JitOrder:
       description: |
         A just-in-time liquidity order included in a settlement. These will
@@ -688,30 +699,29 @@ components:
         - signature
       properties:
         sellToken:
-          $ref: "#/components/schemas/Token"
+          $ref: '#/components/schemas/Token'
         buyToken:
-          $ref: "#/components/schemas/Token"
+          $ref: '#/components/schemas/Token'
         receiver:
-          $ref: "#/components/schemas/Address"
+          $ref: '#/components/schemas/Address'
         sellAmount:
-          $ref: "#/components/schemas/TokenAmount"
+          $ref: '#/components/schemas/TokenAmount'
         buyAmount:
-          $ref: "#/components/schemas/TokenAmount"
+          $ref: '#/components/schemas/TokenAmount'
         validTo:
           type: integer
         appData:
-          $ref: "#/components/schemas/AppData"
+          $ref: '#/components/schemas/AppData'
         kind:
-          $ref: "#/components/schemas/OrderKind"
+          $ref: '#/components/schemas/OrderKind'
         sellTokenBalance:
-          $ref: "#/components/schemas/SellTokenBalance"
+          $ref: '#/components/schemas/SellTokenBalance'
         buyTokenBalance:
-          $ref: "#/components/schemas/BuyTokenBalance"
+          $ref: '#/components/schemas/BuyTokenBalance'
         signingScheme:
-          $ref: "#/components/schemas/SigningScheme"
+          $ref: '#/components/schemas/SigningScheme'
         signature:
-          $ref: "#/components/schemas/Signature"
-
+          $ref: '#/components/schemas/Signature'
     Fulfillment:
       description: |
         A trade which fulfills an order from the auction.
@@ -722,13 +732,14 @@ components:
       properties:
         kind:
           type: string
-          enum: [ fulfillment ]
+          enum:
+            - fulfillment
         order:
           description: |
             A reference by UID of the order to execute in a solution. The order
             must be included in the auction input.
           allOf:
-            - $ref: "#/components/schemas/OrderUid"
+            - $ref: '#/components/schemas/OrderUid'
         fee:
           description: |
             The sell token amount that should be taken as a fee for this
@@ -739,8 +750,7 @@ components:
             The amount of the order that was executed. This is denoted in
             "sellToken" for sell orders, and "buyToken" for buy orders.
           allOf:
-            - $ref: "#/components/schemas/TokenAmount"
-
+            - $ref: '#/components/schemas/TokenAmount'
     JitTrade:
       description: |
         A trade with a JIT order.
@@ -752,13 +762,14 @@ components:
       properties:
         kind:
           type: string
-          enum: [ jit ]
+          enum:
+            - jit
         executedAmount:
           description: |
             The amount of the order that was executed. This is denoted in
             "sellToken" for sell orders, and "buyToken" for buy orders.
           allOf:
-            - $ref: "#/components/schemas/TokenAmount"
+            - $ref: '#/components/schemas/TokenAmount'
         fee:
           description: |
             The amount of sell token which should be kept to cover the gas
@@ -766,19 +777,18 @@ components:
             "executedAmount" needs to be reduced accordingly to not "overfill"
             the order.
           allOf:
-            - $ref: "#/components/schemas/TokenAmount"
+            - $ref: '#/components/schemas/TokenAmount'
         order:
           description: |
             The just-in-time liquidity order to execute in a solution.
           allOf:
-            - $ref: "#/components/schemas/JitOrder"
+            - $ref: '#/components/schemas/JitOrder'
     Trade:
       description: |
         A trade for a CoW Protocol order included in a solution.
       oneOf:
-        - $ref: "#/components/schemas/Fulfillment"
-        - $ref: "#/components/schemas/JitTrade"
-
+        - $ref: '#/components/schemas/Fulfillment'
+        - $ref: '#/components/schemas/JitTrade'
     LiquidityInteraction:
       description: |
         Interaction representing the execution of liquidity that was passed in
@@ -794,20 +804,20 @@ components:
       properties:
         kind:
           type: string
-          enum: [ liquidity ]
+          enum:
+            - liquidity
         id:
           description: |
             The ID of executed liquidity provided in the auction input.
           type: number
         inputToken:
-          $ref: "#/components/schemas/Token"
+          $ref: '#/components/schemas/Token'
         outputToken:
-          $ref: "#/components/schemas/Token"
+          $ref: '#/components/schemas/Token'
         inputAmount:
-          $ref: "#/components/schemas/TokenAmount"
+          $ref: '#/components/schemas/TokenAmount'
         outputAmount:
-          $ref: "#/components/schemas/TokenAmount"
-
+          $ref: '#/components/schemas/TokenAmount'
     Allowance:
       description: |
         An ERC20 allowance from the settlement contract to some spender that is
@@ -819,12 +829,11 @@ components:
         - minAmount
       properties:
         token:
-          $ref: "#/components/schemas/Token"
+          $ref: '#/components/schemas/Token'
         spender:
-          $ref: "#/components/schemas/Address"
+          $ref: '#/components/schemas/Address'
         amount:
-          $ref: "#/components/schemas/TokenAmount"
-
+          $ref: '#/components/schemas/TokenAmount'
     CustomInteraction:
       description: |
         A searcher-specified custom interaction to be included in the final
@@ -840,31 +849,31 @@ components:
       properties:
         kind:
           type: string
-          enum: [ custom ]
+          enum:
+            - custom
         target:
-          $ref: "#/components/schemas/Address"
+          $ref: '#/components/schemas/Address'
         value:
-          $ref: "#/components/schemas/TokenAmount"
+          $ref: '#/components/schemas/TokenAmount'
         callData:
           description: |
             The EVM calldata bytes.
           type: string
-          example: "0x01020304"
+          example: '0x01020304'
         allowances:
           description: |
             ERC20 allowances that are required for this custom interaction.
           type: array
           items:
-            $ref: "#/components/schemas/Allowance"
+            $ref: '#/components/schemas/Allowance'
         inputs:
           type: array
           items:
-            $ref: "#/components/schemas/Asset"
+            $ref: '#/components/schemas/Asset'
         outputs:
           type: array
           items:
-            $ref: "#/components/schemas/Asset"
-
+            $ref: '#/components/schemas/Asset'
     Interaction:
       description: |
         An interaction to execute as part of a settlement.
@@ -877,20 +886,18 @@ components:
                 as specified by CIP-2.
               type: boolean
         - oneOf:
-            - $ref: "#/components/schemas/LiquidityInteraction"
-            - $ref: "#/components/schemas/CustomInteraction"
-
+            - $ref: '#/components/schemas/LiquidityInteraction'
+            - $ref: '#/components/schemas/CustomInteraction'
     InteractionData:
       type: object
       properties:
         target:
-          $ref: "#/components/schemas/Address"
+          $ref: '#/components/schemas/Address'
         value:
-          $ref: "#/components/schemas/TokenAmount"
+          $ref: '#/components/schemas/TokenAmount'
         callData:
           description: Hex encoded bytes with `0x` prefix.
           type: string
-
     Solution:
       description: |
         A computed solution for a given auction.
@@ -902,7 +909,9 @@ components:
         - interactions
       properties:
         id:
-          description: An opaque identifier for the solution. This is a solver generated number that is unique across multiple solutions within the auction.
+          description: >-
+            An opaque identifier for the solution. This is a solver generated
+            number that is unique across multiple solutions within the auction.
           type: number
         prices:
           description: |
@@ -910,31 +919,31 @@ components:
             arbitrary denomination.
           type: object
           additionalProperties:
-            $ref: "#/components/schemas/U256"
+            $ref: '#/components/schemas/U256'
         trades:
           description: |
             CoW Protocol order trades included in the solution.
           type: array
           items:
-            $ref: "#/components/schemas/Trade"
+            $ref: '#/components/schemas/Trade'
         preInteractions:
           description: |
             Interactions to encode before a settlement.
           type: array
           items:
-            $ref: "#/components/schemas/Call"
+            $ref: '#/components/schemas/Call'
         interactions:
           description: |
             Interactions to encode within a settlement.
           type: array
           items:
-            $ref: "#/components/schemas/Interaction"
+            $ref: '#/components/schemas/Interaction'
         postInteractions:
           description: |
             Interactions to encode after a settlement.
           type: array
           items:
-            $ref: "#/components/schemas/Call"
+            $ref: '#/components/schemas/Call'
         gas:
           type: integer
           description: How many units of gas this solution is estimated to cost.
@@ -942,15 +951,17 @@ components:
       type: object
       properties:
         target:
-          $ref: "#/components/schemas/Address"
+          $ref: '#/components/schemas/Address'
         value:
-          $ref: "#/components/schemas/TokenAmount"
+          $ref: '#/components/schemas/TokenAmount'
         callData:
           type: array
           items:
-            $ref: "#/components/schemas/CallData"
+            $ref: '#/components/schemas/CallData'
           description: The call data to be used for the interaction.
     CallData:
-      description: Some `calldata` sent to a contract in a transaction encoded as a hex with `0x` prefix.
+      description: >-
+        Some `calldata` sent to a contract in a transaction encoded as a hex
+        with `0x` prefix.
       type: string
-      example: "0xca11da7a"
+      example: '0xca11da7a'

--- a/crates/solvers/openapi.yml
+++ b/crates/solvers/openapi.yml
@@ -7,7 +7,7 @@ info:
   version: 0.0.1
   contact:
     name: CoW DAO
-    url: 'https://cow.fi'
+    url: "https://cow.fi"
     email: dev@cow.fi
 paths:
   /solve:
@@ -19,9 +19,9 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/Auction'
+              $ref: "#/components/schemas/Auction"
       responses:
-        '200':
+        "200":
           description: Auction successfully solved.
           content:
             application/json:
@@ -36,12 +36,12 @@ paths:
                       auction.
                     type: array
                     items:
-                      $ref: '#/components/schemas/Solution'
-        '400':
+                      $ref: "#/components/schemas/Solution"
+        "400":
           description: There is something wrong with the request.
-        '429':
+        "429":
           description: The solver cannot keep up. It is too busy to handle more requests.
-        '500':
+        "500":
           description: Something went wrong when handling the request.
   /notify:
     post:
@@ -94,7 +94,7 @@ paths:
                     - fail
                     - postprocessingTimedOut
       responses:
-        '200':
+        "200":
           description: notification successfully received.
 components:
   schemas:
@@ -102,32 +102,32 @@ components:
       description: |
         An Ethereum public address.
       type: string
-      example: '0x0000000000000000000000000000000000000000'
+      example: "0x0000000000000000000000000000000000000000"
     Token:
       description: |
         An ERC20 token address.
       type: string
-      example: '0xDEf1CA1fb7FBcDC777520aa7f396b4E015F497aB'
+      example: "0xDEf1CA1fb7FBcDC777520aa7f396b4E015F497aB"
     TokenAmount:
       description: |
         Amount of an ERC20 token. 256 bit unsigned integer in decimal notation.
       type: string
-      example: '1234567890'
+      example: "1234567890"
     U256:
       description: |
         256 bit unsigned integer in decimal notation.
       type: string
-      example: '1234567890'
+      example: "1234567890"
     U128:
       description: |
         128 bit unsigned integer in decimal notation.
       type: string
-      example: '1234567890'
+      example: "1234567890"
     I128:
       description: |
         128 bit signed integer in decimal notation.
       type: string
-      example: '-1234567890'
+      example: "-1234567890"
     I32:
       description: |
         32 bit signed integer in decimal notation.
@@ -138,27 +138,27 @@ components:
         A hex-encoded 32 byte string containing the pool address (0..20), the
         pool specialization (20..22) and the poolnonce (22..32).
       type: string
-      example: '0xc88c76dd8b92408fe9bea1a54922a31e232d873c0002000000000000000005b2'
+      example: "0xc88c76dd8b92408fe9bea1a54922a31e232d873c0002000000000000000005b2"
     BigInt:
       description: |
         An arbitrary-precision integer value.
       type: string
-      example: '1234567890'
+      example: "1234567890"
     Decimal:
       description: |
         An arbitrary-precision decimal value.
       type: string
-      example: '13.37'
+      example: "13.37"
     NativePrice:
       description: |
         The price in wei of the native token (Ether on Mainnet for example) to
         buy 10**18 of a token.
       type: string
-      example: '1234567890'
+      example: "1234567890"
     DateTime:
       description: An ISO-8601 formatted date-time.
       type: string
-      example: '1970-01-01T00:00:00.000Z'
+      example: "1970-01-01T00:00:00.000Z"
     TokenInfo:
       description: |
         Information about a token relevant to the auction.
@@ -183,13 +183,13 @@ components:
             This price is only included for tokens for which there are CoW
             Protocol orders.
           allOf:
-            - $ref: '#/components/schemas/NativePrice'
+            - $ref: "#/components/schemas/NativePrice"
         availableBalance:
           description: |
             The balance held by the Settlement contract that is available
             during a settlement.
           allOf:
-            - $ref: '#/components/schemas/TokenAmount'
+            - $ref: "#/components/schemas/TokenAmount"
         trusted:
           description: |
             A flag which indicates that solvers are allowed to perform gas cost
@@ -205,9 +205,9 @@ components:
         - amount
       properties:
         token:
-          $ref: '#/components/schemas/Token'
+          $ref: "#/components/schemas/Token"
         amount:
-          $ref: '#/components/schemas/TokenAmount'
+          $ref: "#/components/schemas/TokenAmount"
     OrderUid:
       description: |
         Unique identifier for the order. Order UIDs are 56 bytes long, where
@@ -236,7 +236,7 @@ components:
         32 bytes of arbitrary application specific data that can be added to an
         order. This can also be used to ensure uniqueness between two orders
         with otherwise the exact same parameters.
-      example: '0x0000000000000000000000000000000000000000000000000000000000000000'
+      example: "0x0000000000000000000000000000000000000000000000000000000000000000"
     SellTokenBalance:
       description: |
         Where should the sell token be drawn from?
@@ -282,33 +282,33 @@ components:
         - class
       properties:
         uid:
-          $ref: '#/components/schemas/OrderUid'
+          $ref: "#/components/schemas/OrderUid"
         sellToken:
-          $ref: '#/components/schemas/Token'
+          $ref: "#/components/schemas/Token"
         buyToken:
-          $ref: '#/components/schemas/Token'
+          $ref: "#/components/schemas/Token"
         sellAmount:
-          $ref: '#/components/schemas/TokenAmount'
+          $ref: "#/components/schemas/TokenAmount"
         fullSellAmount:
-          $ref: '#/components/schemas/TokenAmount'
+          $ref: "#/components/schemas/TokenAmount"
         buyAmount:
-          $ref: '#/components/schemas/TokenAmount'
+          $ref: "#/components/schemas/TokenAmount"
         fullBuyAmount:
-          $ref: '#/components/schemas/TokenAmount'
+          $ref: "#/components/schemas/TokenAmount"
         feePolicies:
           description: |
             Any protocol fee policies that apply to the order.
           type: array
           items:
-            $ref: '#/components/schemas/FeePolicy'
+            $ref: "#/components/schemas/FeePolicy"
         validTo:
           type: integer
         kind:
-          $ref: '#/components/schemas/OrderKind'
+          $ref: "#/components/schemas/OrderKind"
         receiver:
-          $ref: '#/components/schemas/Address'
+          $ref: "#/components/schemas/Address"
         owner:
-          $ref: '#/components/schemas/Address'
+          $ref: "#/components/schemas/Address"
         partiallyFillable:
           description: |
             Whether or not this order can be partially filled. If this is false,
@@ -318,35 +318,35 @@ components:
         preInteractions:
           type: array
           items:
-            $ref: '#/components/schemas/Interaction'
+            $ref: "#/components/schemas/Interaction"
         postInteractions:
           type: array
           items:
-            $ref: '#/components/schemas/InteractionData'
+            $ref: "#/components/schemas/InteractionData"
         sellTokenSource:
           allOf:
-            - $ref: '#/components/schemas/SellTokenBalance'
+            - $ref: "#/components/schemas/SellTokenBalance"
           default: erc20
         buyTokenDestination:
           allOf:
-            - $ref: '#/components/schemas/BuyTokenBalance'
+            - $ref: "#/components/schemas/BuyTokenBalance"
           default: erc20
         class:
-          $ref: '#/components/schemas/OrderClass'
+          $ref: "#/components/schemas/OrderClass"
         appData:
-          $ref: '#/components/schemas/AppData'
+          $ref: "#/components/schemas/AppData"
         signingScheme:
-          $ref: '#/components/schemas/SigningScheme'
+          $ref: "#/components/schemas/SigningScheme"
         signature:
-          $ref: '#/components/schemas/Signature'
+          $ref: "#/components/schemas/Signature"
     FeePolicy:
       description: |
         A fee policy that applies to an order.
       type: object
       oneOf:
-        - $ref: '#/components/schemas/SurplusFee'
-        - $ref: '#/components/schemas/PriceImprovement'
-        - $ref: '#/components/schemas/VolumeFee'
+        - $ref: "#/components/schemas/SurplusFee"
+        - $ref: "#/components/schemas/PriceImprovement"
+        - $ref: "#/components/schemas/VolumeFee"
     SurplusFee:
       description: >
         If the order receives more than limit price, pay the protocol a factor
@@ -390,7 +390,7 @@ components:
           type: number
           example: 0.5
         quote:
-          $ref: '#/components/schemas/Quote'
+          $ref: "#/components/schemas/Quote"
     VolumeFee:
       type: object
       properties:
@@ -408,11 +408,11 @@ components:
       type: object
       properties:
         sell_amount:
-          $ref: '#/components/schemas/TokenAmount'
+          $ref: "#/components/schemas/TokenAmount"
         buy_amount:
-          $ref: '#/components/schemas/TokenAmount'
+          $ref: "#/components/schemas/TokenAmount"
         fee:
-          $ref: '#/components/schemas/TokenAmount'
+          $ref: "#/components/schemas/TokenAmount"
     TokenReserve:
       description: |
         A reserve of tokens in an on-chain liquidity pool.
@@ -421,7 +421,7 @@ components:
         - balance
       properties:
         balance:
-          $ref: '#/components/schemas/TokenAmount'
+          $ref: "#/components/schemas/TokenAmount"
     ConstantProductPool:
       description: |
         A UniswapV2-like constant product liquidity pool for a token pair.
@@ -441,11 +441,11 @@ components:
             A mapping of token address to its reserve amounts.
           type: object
           additionalProperties:
-            $ref: '#/components/schemas/TokenReserve'
+            $ref: "#/components/schemas/TokenReserve"
         fee:
-          $ref: '#/components/schemas/Decimal'
+          $ref: "#/components/schemas/Decimal"
         router:
-          $ref: '#/components/schemas/Address'
+          $ref: "#/components/schemas/Address"
     WeightedProductPool:
       description: |
         A Balancer-like weighted product liquidity pool of N tokens.
@@ -466,24 +466,24 @@ components:
           type: object
           additionalProperties:
             allOf:
-              - $ref: '#/components/schemas/TokenReserve'
+              - $ref: "#/components/schemas/TokenReserve"
               - type: object
                 required:
                   - weight
                 properties:
                   scalingFactor:
-                    $ref: '#/components/schemas/Decimal'
+                    $ref: "#/components/schemas/Decimal"
                   weight:
-                    $ref: '#/components/schemas/Decimal'
+                    $ref: "#/components/schemas/Decimal"
         fee:
-          $ref: '#/components/schemas/Decimal'
+          $ref: "#/components/schemas/Decimal"
         version:
           type: string
           enum:
             - v0
             - v3Plus
         balancer_pool_id:
-          $ref: '#/components/schemas/BalancerPoolId'
+          $ref: "#/components/schemas/BalancerPoolId"
     StablePool:
       description: |
         A Curve-like stable pool of N tokens.
@@ -505,19 +505,19 @@ components:
           type: object
           additionalProperties:
             allOf:
-              - $ref: '#/components/schemas/TokenReserve'
+              - $ref: "#/components/schemas/TokenReserve"
               - type: object
                 required:
                   - scalingFactor
                 properties:
                   scalingFactor:
-                    $ref: '#/components/schemas/Decimal'
+                    $ref: "#/components/schemas/Decimal"
         amplificationParameter:
-          $ref: '#/components/schemas/Decimal'
+          $ref: "#/components/schemas/Decimal"
         fee:
-          $ref: '#/components/schemas/Decimal'
+          $ref: "#/components/schemas/Decimal"
         balancer_pool_id:
-          $ref: '#/components/schemas/BalancerPoolId'
+          $ref: "#/components/schemas/BalancerPoolId"
     ConcentratedLiquidityPool:
       description: |
         A UniswapV3-like concentrated liquidity pool of 2 tokens.
@@ -539,23 +539,23 @@ components:
         tokens:
           type: array
           items:
-            $ref: '#/components/schemas/Token'
+            $ref: "#/components/schemas/Token"
         sqrtPrice:
-          $ref: '#/components/schemas/U256'
+          $ref: "#/components/schemas/U256"
         liquidity:
-          $ref: '#/components/schemas/U128'
+          $ref: "#/components/schemas/U128"
         tick:
-          $ref: '#/components/schemas/I32'
+          $ref: "#/components/schemas/I32"
         liquidityNet:
           description: |
             A map of tick indices to their liquidity values.
           type: object
           additionalProperties:
-            $ref: '#/components/schemas/I128'
+            $ref: "#/components/schemas/I128"
         fee:
-          $ref: '#/components/schemas/Decimal'
+          $ref: "#/components/schemas/Decimal"
         router:
-          $ref: '#/components/schemas/Address'
+          $ref: "#/components/schemas/Address"
     ForeignLimitOrder:
       description: |
         A 0x-like limit order external to CoW Protocol.
@@ -573,29 +573,29 @@ components:
           enum:
             - limitOrder
         makerToken:
-          $ref: '#/components/schemas/Token'
+          $ref: "#/components/schemas/Token"
         takerToken:
-          $ref: '#/components/schemas/Token'
+          $ref: "#/components/schemas/Token"
         makerAmount:
-          $ref: '#/components/schemas/TokenAmount'
+          $ref: "#/components/schemas/TokenAmount"
         takerAmount:
-          $ref: '#/components/schemas/TokenAmount'
+          $ref: "#/components/schemas/TokenAmount"
         takerTokenFeeAmount:
-          $ref: '#/components/schemas/TokenAmount'
+          $ref: "#/components/schemas/TokenAmount"
     LiquidityParameters:
       oneOf:
-        - $ref: '#/components/schemas/ConstantProductPool'
-        - $ref: '#/components/schemas/WeightedProductPool'
-        - $ref: '#/components/schemas/StablePool'
-        - $ref: '#/components/schemas/ConcentratedLiquidityPool'
-        - $ref: '#/components/schemas/ForeignLimitOrder'
+        - $ref: "#/components/schemas/ConstantProductPool"
+        - $ref: "#/components/schemas/WeightedProductPool"
+        - $ref: "#/components/schemas/StablePool"
+        - $ref: "#/components/schemas/ConcentratedLiquidityPool"
+        - $ref: "#/components/schemas/ForeignLimitOrder"
     Liquidity:
       description: |
         On-chain liquidity that can be used in a solution. This liquidity is
         provided to facilitate onboarding new solvers. Additional liquidity that
         is not included in this set may still be used in solutions.
       allOf:
-        - $ref: '#/components/schemas/LiquidityParameters'
+        - $ref: "#/components/schemas/LiquidityParameters"
         - type: object
           required:
             - id
@@ -614,13 +614,13 @@ components:
                 The Ethereum public address of the liquidity. The actual address
                 that is specified is dependent on the kind of liquidity.
               allOf:
-                - $ref: '#/components/schemas/Address'
+                - $ref: "#/components/schemas/Address"
             gasEstimate:
               description: |
                 A rough approximation of gas units required to use this
                 liquidity on-chain.
               allOf:
-                - $ref: '#/components/schemas/BigInt'
+                - $ref: "#/components/schemas/BigInt"
     Auction:
       description: |
         The abstract auction to be solved by the searcher.
@@ -644,37 +644,37 @@ components:
             A map of token addresses to token information.
           type: object
           additionalProperties:
-            $ref: '#/components/schemas/TokenInfo'
+            $ref: "#/components/schemas/TokenInfo"
         orders:
           description: |
             The solvable orders included in the auction.
           type: array
           items:
-            $ref: '#/components/schemas/Order'
+            $ref: "#/components/schemas/Order"
         liquidity:
           description: |
             On-chain liquidity that can be used by the solution.
           type: array
           items:
-            $ref: '#/components/schemas/Liquidity'
+            $ref: "#/components/schemas/Liquidity"
         effectiveGasPrice:
           description: |
             The current estimated gas price that will be paid when executing a
             settlement. Additionally, this is the gas price that is multiplied
             with a settlement's gas estimate for solution scoring.
           allOf:
-            - $ref: '#/components/schemas/TokenAmount'
+            - $ref: "#/components/schemas/TokenAmount"
         deadline:
           description: |
             The deadline by which a solution to the auction is required.
             Requests that go beyond this deadline are expected to be cancelled
             by the caller.
           allOf:
-            - $ref: '#/components/schemas/DateTime'
+            - $ref: "#/components/schemas/DateTime"
         surplusCapturingJitOrderOwners:
           type: array
           items:
-            $ref: '#/components/schemas/Address'
+            $ref: "#/components/schemas/Address"
           description: >
             List of addresses on whose surplus will count towards the objective
             value of their solution (unlike other orders that were created by
@@ -699,29 +699,29 @@ components:
         - signature
       properties:
         sellToken:
-          $ref: '#/components/schemas/Token'
+          $ref: "#/components/schemas/Token"
         buyToken:
-          $ref: '#/components/schemas/Token'
+          $ref: "#/components/schemas/Token"
         receiver:
-          $ref: '#/components/schemas/Address'
+          $ref: "#/components/schemas/Address"
         sellAmount:
-          $ref: '#/components/schemas/TokenAmount'
+          $ref: "#/components/schemas/TokenAmount"
         buyAmount:
-          $ref: '#/components/schemas/TokenAmount'
+          $ref: "#/components/schemas/TokenAmount"
         validTo:
           type: integer
         appData:
-          $ref: '#/components/schemas/AppData'
+          $ref: "#/components/schemas/AppData"
         kind:
-          $ref: '#/components/schemas/OrderKind'
+          $ref: "#/components/schemas/OrderKind"
         sellTokenBalance:
-          $ref: '#/components/schemas/SellTokenBalance'
+          $ref: "#/components/schemas/SellTokenBalance"
         buyTokenBalance:
-          $ref: '#/components/schemas/BuyTokenBalance'
+          $ref: "#/components/schemas/BuyTokenBalance"
         signingScheme:
-          $ref: '#/components/schemas/SigningScheme'
+          $ref: "#/components/schemas/SigningScheme"
         signature:
-          $ref: '#/components/schemas/Signature'
+          $ref: "#/components/schemas/Signature"
     Fulfillment:
       description: |
         A trade which fulfills an order from the auction.
@@ -739,7 +739,7 @@ components:
             A reference by UID of the order to execute in a solution. The order
             must be included in the auction input.
           allOf:
-            - $ref: '#/components/schemas/OrderUid'
+            - $ref: "#/components/schemas/OrderUid"
         fee:
           description: |
             The sell token amount that should be taken as a fee for this
@@ -750,7 +750,7 @@ components:
             The amount of the order that was executed. This is denoted in
             "sellToken" for sell orders, and "buyToken" for buy orders.
           allOf:
-            - $ref: '#/components/schemas/TokenAmount'
+            - $ref: "#/components/schemas/TokenAmount"
     JitTrade:
       description: |
         A trade with a JIT order.
@@ -769,7 +769,7 @@ components:
             The amount of the order that was executed. This is denoted in
             "sellToken" for sell orders, and "buyToken" for buy orders.
           allOf:
-            - $ref: '#/components/schemas/TokenAmount'
+            - $ref: "#/components/schemas/TokenAmount"
         fee:
           description: |
             The amount of sell token which should be kept to cover the gas
@@ -777,18 +777,18 @@ components:
             "executedAmount" needs to be reduced accordingly to not "overfill"
             the order.
           allOf:
-            - $ref: '#/components/schemas/TokenAmount'
+            - $ref: "#/components/schemas/TokenAmount"
         order:
           description: |
             The just-in-time liquidity order to execute in a solution.
           allOf:
-            - $ref: '#/components/schemas/JitOrder'
+            - $ref: "#/components/schemas/JitOrder"
     Trade:
       description: |
         A trade for a CoW Protocol order included in a solution.
       oneOf:
-        - $ref: '#/components/schemas/Fulfillment'
-        - $ref: '#/components/schemas/JitTrade'
+        - $ref: "#/components/schemas/Fulfillment"
+        - $ref: "#/components/schemas/JitTrade"
     LiquidityInteraction:
       description: |
         Interaction representing the execution of liquidity that was passed in
@@ -811,13 +811,13 @@ components:
             The ID of executed liquidity provided in the auction input.
           type: number
         inputToken:
-          $ref: '#/components/schemas/Token'
+          $ref: "#/components/schemas/Token"
         outputToken:
-          $ref: '#/components/schemas/Token'
+          $ref: "#/components/schemas/Token"
         inputAmount:
-          $ref: '#/components/schemas/TokenAmount'
+          $ref: "#/components/schemas/TokenAmount"
         outputAmount:
-          $ref: '#/components/schemas/TokenAmount'
+          $ref: "#/components/schemas/TokenAmount"
     Allowance:
       description: |
         An ERC20 allowance from the settlement contract to some spender that is
@@ -829,11 +829,11 @@ components:
         - minAmount
       properties:
         token:
-          $ref: '#/components/schemas/Token'
+          $ref: "#/components/schemas/Token"
         spender:
-          $ref: '#/components/schemas/Address'
+          $ref: "#/components/schemas/Address"
         amount:
-          $ref: '#/components/schemas/TokenAmount'
+          $ref: "#/components/schemas/TokenAmount"
     CustomInteraction:
       description: |
         A searcher-specified custom interaction to be included in the final
@@ -852,28 +852,28 @@ components:
           enum:
             - custom
         target:
-          $ref: '#/components/schemas/Address'
+          $ref: "#/components/schemas/Address"
         value:
-          $ref: '#/components/schemas/TokenAmount'
+          $ref: "#/components/schemas/TokenAmount"
         callData:
           description: |
             The EVM calldata bytes.
           type: string
-          example: '0x01020304'
+          example: "0x01020304"
         allowances:
           description: |
             ERC20 allowances that are required for this custom interaction.
           type: array
           items:
-            $ref: '#/components/schemas/Allowance'
+            $ref: "#/components/schemas/Allowance"
         inputs:
           type: array
           items:
-            $ref: '#/components/schemas/Asset'
+            $ref: "#/components/schemas/Asset"
         outputs:
           type: array
           items:
-            $ref: '#/components/schemas/Asset'
+            $ref: "#/components/schemas/Asset"
     Interaction:
       description: |
         An interaction to execute as part of a settlement.
@@ -886,15 +886,15 @@ components:
                 as specified by CIP-2.
               type: boolean
         - oneOf:
-            - $ref: '#/components/schemas/LiquidityInteraction'
-            - $ref: '#/components/schemas/CustomInteraction'
+            - $ref: "#/components/schemas/LiquidityInteraction"
+            - $ref: "#/components/schemas/CustomInteraction"
     InteractionData:
       type: object
       properties:
         target:
-          $ref: '#/components/schemas/Address'
+          $ref: "#/components/schemas/Address"
         value:
-          $ref: '#/components/schemas/TokenAmount'
+          $ref: "#/components/schemas/TokenAmount"
         callData:
           description: Hex encoded bytes with `0x` prefix.
           type: string
@@ -919,31 +919,31 @@ components:
             arbitrary denomination.
           type: object
           additionalProperties:
-            $ref: '#/components/schemas/U256'
+            $ref: "#/components/schemas/U256"
         trades:
           description: |
             CoW Protocol order trades included in the solution.
           type: array
           items:
-            $ref: '#/components/schemas/Trade'
+            $ref: "#/components/schemas/Trade"
         preInteractions:
           description: |
             Interactions to encode before a settlement.
           type: array
           items:
-            $ref: '#/components/schemas/Call'
+            $ref: "#/components/schemas/Call"
         interactions:
           description: |
             Interactions to encode within a settlement.
           type: array
           items:
-            $ref: '#/components/schemas/Interaction'
+            $ref: "#/components/schemas/Interaction"
         postInteractions:
           description: |
             Interactions to encode after a settlement.
           type: array
           items:
-            $ref: '#/components/schemas/Call'
+            $ref: "#/components/schemas/Call"
         gas:
           type: integer
           description: How many units of gas this solution is estimated to cost.
@@ -951,17 +951,17 @@ components:
       type: object
       properties:
         target:
-          $ref: '#/components/schemas/Address'
+          $ref: "#/components/schemas/Address"
         value:
-          $ref: '#/components/schemas/TokenAmount'
+          $ref: "#/components/schemas/TokenAmount"
         callData:
           type: array
           items:
-            $ref: '#/components/schemas/CallData'
+            $ref: "#/components/schemas/CallData"
           description: The call data to be used for the interaction.
     CallData:
       description: >
         Some `calldata` sent to a contract in a transaction encoded as a hex
         with `0x` prefix.
       type: string
-      example: '0xca11da7a'
+      example: "0xca11da7a"


### PR DESCRIPTION
Formats all the OpenAPI yaml.
 `openapi-cli` was used at first to automatically address most of the critical issue. Then `prettier`, just to format the yaml. In the future, `prettier` should be enough. 