### PR TITLE
Verify quotes from zero address

### DIFF
--- a/crates/e2e/tests/e2e/quote_verification.rs
+++ b/crates/e2e/tests/e2e/quote_verification.rs
@@ -409,4 +409,22 @@ async fn verified_quote_with_simulated_balance(web3: Web3) {
         .await
         .unwrap();
     assert!(response.verified);
+
+    // with balance overrides we can even verify quotes for the 0 address
+    // which is used when no wallet is connected in the frontend
+    let response = services
+        .submit_quote(&OrderQuoteRequest {
+            from: H160::zero(),
+            sell_token: weth.address(),
+            buy_token: token.address(),
+            side: OrderQuoteSide::Sell {
+                sell_amount: SellAmount::BeforeFee {
+                    value: to_wei(1).try_into().unwrap(),
+                },
+            },
+            ..Default::default()
+        })
+        .await
+        .unwrap();
+    assert!(response.verified);
 }


### PR DESCRIPTION
# Description
@nlordell's recent PR stack enabled the use case where a real trader (wallet is connected in the frontend) does not have the required balances by faking balances.
But with the new ability to fake balances for many tokens we can even go one step further.

# Changes
If we know how to fake balances for the given sell token AND no wallet is connected (i.e. `verification.from.is_zero()`) we simply generate a random address and use that as the trader with fake balances.
Using a non-zero address is important because many token transfer functions don't like sending tokens to or from the zero address.

This should prevent the annoying UX where you sometime see a really good (unverified) price when your wallet is not connected and end up seeing worse (but verified) prices after you connect your wallet.

## How to test
added an e2e test which produces a verified quote with `from: H160::zero()`