### PR TITLE
Reveal and settle to receive integer solution id

### DIFF
--- a/crates/driver/src/infra/api/routes/mod.rs
+++ b/crates/driver/src/infra/api/routes/mod.rs
@@ -15,3 +15,34 @@ pub(super) use {
     settle::settle,
     solve::{solve, AuctionError},
 };
+
+pub fn deserialize_solution_id<'de, D>(deserializer: D) -> Result<u64, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    struct SolutionIdVisitor;
+
+    impl serde::de::Visitor<'_> for SolutionIdVisitor {
+        type Value = u64;
+
+        fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+            formatter.write_str("a string or integer representing a solution ID")
+        }
+
+        fn visit_u64<E>(self, value: u64) -> Result<u64, E>
+        where
+            E: serde::de::Error,
+        {
+            Ok(value)
+        }
+
+        fn visit_str<E>(self, value: &str) -> Result<u64, E>
+        where
+            E: serde::de::Error,
+        {
+            value.parse::<u64>().map_err(serde::de::Error::custom)
+        }
+    }
+
+    deserializer.deserialize_any(SolutionIdVisitor)
+}

--- a/crates/driver/src/infra/api/routes/mod.rs
+++ b/crates/driver/src/infra/api/routes/mod.rs
@@ -16,7 +16,7 @@ pub(super) use {
     solve::{solve, AuctionError},
 };
 
-pub fn deserialize_solution_id<'de, D>(deserializer: D) -> Result<u64, D::Error>
+pub(crate) fn deserialize_solution_id<'de, D>(deserializer: D) -> Result<u64, D::Error>
 where
     D: serde::Deserializer<'de>,
 {

--- a/crates/driver/src/infra/api/routes/reveal/dto/solution.rs
+++ b/crates/driver/src/infra/api/routes/reveal/dto/solution.rs
@@ -1,11 +1,11 @@
-use {serde::Deserialize, serde_with::serde_as};
+use {super::super::super::deserialize_solution_id, serde::Deserialize, serde_with::serde_as};
 
 #[serde_as]
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Solution {
     /// Unique ID of the solution (per driver competition), to reveal.
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde(deserialize_with = "deserialize_solution_id")]
     pub solution_id: u64,
     /// Auction ID in which the specified solution ID is competing.
     #[serde_as(as = "Option<serde_with::DisplayFromStr>")]

--- a/crates/driver/src/infra/api/routes/settle/dto/solution.rs
+++ b/crates/driver/src/infra/api/routes/settle/dto/solution.rs
@@ -1,11 +1,11 @@
-use {serde::Deserialize, serde_with::serde_as};
+use {super::super::super::deserialize_solution_id, serde::Deserialize, serde_with::serde_as};
 
 #[serde_as]
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Solution {
     /// Unique ID of the solution (per driver competition), to settle.
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde(deserialize_with = "deserialize_solution_id")]
     pub solution_id: u64,
     /// The last block number in which the solution TX can be included
     pub submission_deadline_latest_block: u64,


### PR DESCRIPTION
# Description
A follow up for https://github.com/cowprotocol/services/pull/3071

This PR allows reference driver to receive both integer and strings for solution id, on `/reveal` and `/settle` endpoints. Note how this PR implements task 2 from the [linked pull request](https://github.com/cowprotocol/services/pull/3071). This is done in this PR as a separate step to give time to colocated solvers using reference driver to update on time.

If we were to just switch to using integer, colocated drivers would incur downtime.

Next step is final step to use integer ONLY in both autopilot and driver, once we made sure all colocated solvers updated their driver.

# Changes
<!-- List of detailed changes (how the change is accomplished) -->

- [ ] Driver able to receive both integer and string on `/reveal` and `/settle`
- [ ] ...

## How to test
The code is copy paste of already tested code.