### PR TITLE
[TRIVIAL] Remove enable_multiple_fees config

### DIFF
--- a/crates/autopilot/src/arguments.rs
+++ b/crates/autopilot/src/arguments.rs
@@ -181,10 +181,6 @@ pub struct Arguments {
     #[clap(long, env, use_value_delimiter = true)]
     pub fee_policies: Vec<FeePolicy>,
 
-    /// Enables multiple fees
-    #[clap(long, env, action = clap::ArgAction::Set, default_value = "false")]
-    pub enable_multiple_fees: bool,
-
     /// Maximum partner fee allow. If the partner fee specified is greater than
     /// this maximum, the partner fee will be capped
     #[clap(long, env, default_value = "0.01")]
@@ -269,7 +265,6 @@ impl std::fmt::Display for Arguments {
             shadow,
             solve_deadline,
             fee_policies,
-            enable_multiple_fees,
             fee_policy_max_partner_fee,
             order_events_cleanup_interval,
             order_events_cleanup_threshold,
@@ -326,7 +321,6 @@ impl std::fmt::Display for Arguments {
         display_option(f, "shadow", shadow)?;
         writeln!(f, "solve_deadline: {:?}", solve_deadline)?;
         writeln!(f, "fee_policies: {:?}", fee_policies)?;
-        writeln!(f, "enable_multiple_fees: {:?}", enable_multiple_fees)?;
         writeln!(
             f,
             "fee_policy_max_partner_fee: {:?}",

--- a/crates/autopilot/src/domain/fee/mod.rs
+++ b/crates/autopilot/src/domain/fee/mod.rs
@@ -14,7 +14,6 @@ use {
     },
     app_data::Validator,
     derive_more::Into,
-    itertools::Itertools,
     primitive_types::{H160, U256},
     prometheus::core::Number,
     std::{collections::HashSet, str::FromStr},
@@ -57,14 +56,12 @@ pub type ProtocolFeeExemptAddresses = HashSet<H160>;
 pub struct ProtocolFees {
     fee_policies: Vec<ProtocolFee>,
     max_partner_fee: FeeFactor,
-    enable_protocol_fees: bool,
 }
 
 impl ProtocolFees {
     pub fn new(
         fee_policies: &[arguments::FeePolicy],
         fee_policy_max_partner_fee: FeeFactor,
-        enable_protocol_fees: bool,
     ) -> Self {
         Self {
             fee_policies: fee_policies
@@ -73,7 +70,6 @@ impl ProtocolFees {
                 .map(ProtocolFee::from)
                 .collect(),
             max_partner_fee: fee_policy_max_partner_fee,
-            enable_protocol_fees,
         }
     }
 
@@ -132,37 +128,10 @@ impl ProtocolFees {
             fee: quote.fee.into(),
         };
 
-        if self.enable_protocol_fees {
-            self.apply_multiple_policies(order, quote, order_, quote_, partner_fee)
-        } else {
-            self.apply_single_policy(order, quote, order_, quote_, partner_fee)
-        }
+        self.apply_policies(order, quote, order_, quote_, partner_fee)
     }
 
-    fn apply_single_policy(
-        &self,
-        order: boundary::Order,
-        quote: domain::Quote,
-        order_: boundary::Amounts,
-        quote_: boundary::Amounts,
-        partner_fees: Vec<Policy>,
-    ) -> domain::Order {
-        if let Some(partner_fee) = partner_fees.first() {
-            return boundary::order::to_domain(order, vec![*partner_fee], Some(quote));
-        }
-        let protocol_fees = self
-            .fee_policies
-            .iter()
-            .find_map(|fee_policy| {
-                Self::protocol_fee_into_policy(&order, &order_, &quote_, fee_policy)
-            })
-            .and_then(|policy| Self::variant_fee_apply(&order, &quote, policy))
-            .into_iter()
-            .collect_vec();
-        boundary::order::to_domain(order, protocol_fees, Some(quote))
-    }
-
-    fn apply_multiple_policies(
+    fn apply_policies(
         &self,
         order: boundary::Order,
         quote: domain::Quote,

--- a/crates/autopilot/src/run.rs
+++ b/crates/autopilot/src/run.rs
@@ -439,11 +439,7 @@ pub async fn run(args: Arguments) {
         args.limit_order_price_factor
             .try_into()
             .expect("limit order price factor can't be converted to BigDecimal"),
-        domain::ProtocolFees::new(
-            &args.fee_policies,
-            args.fee_policy_max_partner_fee,
-            args.enable_multiple_fees,
-        ),
+        domain::ProtocolFees::new(&args.fee_policies, args.fee_policy_max_partner_fee),
         cow_amm_registry.clone(),
         args.run_loop_native_price_timeout,
     );

--- a/crates/e2e/tests/e2e/limit_orders.rs
+++ b/crates/e2e/tests/e2e/limit_orders.rs
@@ -901,7 +901,6 @@ async fn no_liquidity_limit_order(web3: Web3) {
             ExtraServiceArgs {
                 autopilot: vec![
                     protocol_fees_config,
-                    "--enable-multiple-fees=true".to_string(),
                     format!("--unsupported-tokens={:#x}", unsupported.address()),
                 ],
                 ..Default::default()

--- a/crates/e2e/tests/e2e/protocol_fee.rs
+++ b/crates/e2e/tests/e2e/protocol_fee.rs
@@ -120,7 +120,6 @@ async fn combined_protocol_fees(web3: Web3) {
     let autopilot_config = vec![
         ProtocolFeesConfig(vec![limit_surplus_policy, market_price_improvement_policy]).to_string(),
         "--fee-policy-max-partner-fee=0.02".to_string(),
-        "--enable-multiple-fees=true".to_string(),
     ];
     let services = Services::new(&onchain).await;
     services


### PR DESCRIPTION
# Description
This config was added for one purpose only - to coordinate with accounting team when and how to turn on the feature - reference https://github.com/cowprotocol/services/pull/2595#pullrequestreview-2001563041

Since battled tested, this can be removed now.

Will create the PR for infrastructure as well. Edit: https://github.com/cowprotocol/infrastructure/pull/2394

# Changes
<!-- List of detailed changes (how the change is accomplished) -->

- [ ] Remove `enable_multiple_fees`

## How to test
e2e tests

<!--
## Related Issues

Fixes #
-->