### PR TITLE
Add log for debugging tx submission

### DIFF
--- a/crates/driver/src/domain/mempools.rs
+++ b/crates/driver/src/domain/mempools.rs
@@ -103,6 +103,7 @@ impl Mempools {
         block_stream.next().await;
 
         let hash = mempool.submit(tx.clone(), settlement.gas, solver).await?;
+        tracing::debug!(?hash, "submitted tx to the mempool");
 
         // Wait for the transaction to be mined, expired or failing.
         let result = async {


### PR DESCRIPTION
# Description
We don't have a log emitted right after we submit a tx to the mempool. This makes it impossible to relate logs of that RPC with the respective settlement.

# Changes
Adds the necessary log
Additional tracing information we get by default are `request_id`, `solver` and `mempool` type