### PR TITLE
[EASY] Add base url to open api

### DIFF
--- a/crates/orderbook/openapi.yml
+++ b/crates/orderbook/openapi.yml
@@ -15,6 +15,10 @@ servers:
     url: "https://api.cow.fi/arbitrum_one"
   - description: Arbitrum One (Staging)
     url: "https://barn.api.cow.fi/arbitrum_one"
+  - description: Base (Prod)
+    url: "https://api.cow.fi/base"
+  - description: Base (Staging)
+    url: "https://barn.api.cow.fi/base"
   - description: Sepolia (Prod)
     url: "https://api.cow.fi/sepolia"
   - description: Sepolia (Staging)


### PR DESCRIPTION
# Description
We forgot to add `base` to the openapi spec so it doesn't show up in the network selection tab as reported by a user.

# Changes
adds the 2 new URLs to the openapi spec