### PR TITLE
Limit subquery results to 1

### DIFF
--- a/crates/database/src/jit_orders.rs
+++ b/crates/database/src/jit_orders.rs
@@ -32,7 +32,7 @@ NULL AS ethflow_data,
 NULL AS onchain_user,
 NULL AS onchain_placement_error,
 COALESCE((SELECT SUM(executed_fee) FROM order_execution oe WHERE oe.order_uid = o.uid), 0) as executed_fee,
-COALESCE((SELECT executed_fee_token FROM order_execution oe WHERE oe.order_uid = o.uid), o.sell_token) as executed_fee_token, -- TODO surplus token
+COALESCE((SELECT executed_fee_token FROM order_execution oe WHERE oe.order_uid = o.uid LIMIT 1), o.sell_token) as executed_fee_token, -- TODO surplus token
 NULL AS full_app_data
 "#;
 

--- a/crates/database/src/orders.rs
+++ b/crates/database/src/orders.rs
@@ -572,7 +572,7 @@ array(Select (p.target, p.value, p.data) from interactions p where p.order_uid =
 (SELECT onchain_o.sender from onchain_placed_orders onchain_o where onchain_o.uid = o.uid limit 1) as onchain_user,
 (SELECT onchain_o.placement_error from onchain_placed_orders onchain_o where onchain_o.uid = o.uid limit 1) as onchain_placement_error,
 COALESCE((SELECT SUM(executed_fee) FROM order_execution oe WHERE oe.order_uid = o.uid), 0) as executed_fee,
-COALESCE((SELECT executed_fee_token FROM order_execution oe WHERE oe.order_uid = o.uid), o.sell_token) as executed_fee_token, -- TODO surplus token
+COALESCE((SELECT executed_fee_token FROM order_execution oe WHERE oe.order_uid = o.uid LIMIT 1), o.sell_token) as executed_fee_token, -- TODO surplus token
 (SELECT full_app_data FROM app_data ad WHERE o.app_data = ad.contract_app_data LIMIT 1) as full_app_data
 "#;
 


### PR DESCRIPTION
# Description
Fixes failing of queries when orders with multiple order executions are queried from database.

Introduced in https://github.com/cowprotocol/services/pull/2966

# Changes
<!-- List of detailed changes (how the change is accomplished) -->

- [ ] In case mutliple rows exist, return only one. Right now it's guaranteed that all of them are the same.

## How to test
trust me bro
will be tested on staging since all staging pods are down

<!--
## Related Issues

Fixes #
-->