### PR TITLE
Fix driver tests flakiness

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -186,7 +186,7 @@ jobs:
 
   run-flaky-test:
     # to debug a flaky test set `if` to true and configure the flaky test in the `run` step
-    if: ${{ false }}
+    if: ${{ true }}
     timeout-minutes: 60
     runs-on: ubuntu-latest
     env:
@@ -215,7 +215,7 @@ jobs:
           attempt=1
           while true; do
             echo "Running test attempt #$attempt"
-            if ! cargo nextest run -p e2e local_node --test-threads 1 --failure-output final --run-ignored ignored-only; then
+            if ! cargo nextest run -p driver --no-capture --run-ignored ignored-only; then
               exit 1
             fi
             attempt=$((attempt+1))

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -215,7 +215,7 @@ jobs:
           attempt=1
           while true; do
             echo "Running test attempt #$attempt"
-            if ! cargo nextest run -p driver --no-capture --run-ignored ignored-only; then
+            if ! cargo nextest run -p driver --test-threads 1 --failure-output final --run-ignored ignored-only; then
               exit 1
             fi
             attempt=$((attempt+1))

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -186,7 +186,7 @@ jobs:
 
   run-flaky-test:
     # to debug a flaky test set `if` to true and configure the flaky test in the `run` step
-    if: ${{ false }}
+    if: ${{ true }}
     timeout-minutes: 60
     runs-on: ubuntu-latest
     env:
@@ -215,7 +215,7 @@ jobs:
           attempt=1
           while true; do
             echo "Running test attempt #$attempt"
-            if ! cargo nextest run -p e2e local_node --test-threads 1 --failure-output final --run-ignored ignored-only; then
+            if ! cargo nextest run -p driver accepts_new_settle_requests_after_timeout --no-capture --run-ignored ignored-only; then
               exit 1
             fi
             attempt=$((attempt+1))

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -186,7 +186,7 @@ jobs:
 
   run-flaky-test:
     # to debug a flaky test set `if` to true and configure the flaky test in the `run` step
-    if: ${{ true }}
+    if: ${{ false }}
     timeout-minutes: 60
     runs-on: ubuntu-latest
     env:
@@ -215,7 +215,7 @@ jobs:
           attempt=1
           while true; do
             echo "Running test attempt #$attempt"
-            if ! cargo nextest run -p driver accepts_new_settle_requests_after_timeout --no-capture --run-ignored ignored-only; then
+            if ! cargo nextest run -p e2e local_node --test-threads 1 --failure-output final --run-ignored ignored-only; then
               exit 1
             fi
             attempt=$((attempt+1))

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -167,7 +167,7 @@ jobs:
       # Build the driver's tests.
       - run: cargo build -p driver --tests
       # Don't spawn any docker containers. The driver's tests will spawn anvil itself.
-      - run: cargo nextest run -p driver --run-ignored ignored-only
+      - run: cargo nextest run -p driver --test-threads 1 --run-ignored ignored-only
 
   openapi:
     timeout-minutes: 60
@@ -186,7 +186,7 @@ jobs:
 
   run-flaky-test:
     # to debug a flaky test set `if` to true and configure the flaky test in the `run` step
-    if: ${{ true }}
+    if: ${{ false }}
     timeout-minutes: 60
     runs-on: ubuntu-latest
     env:
@@ -215,7 +215,7 @@ jobs:
           attempt=1
           while true; do
             echo "Running test attempt #$attempt"
-            if ! cargo nextest run -p driver --run-ignored ignored-only; then
+            if ! cargo nextest run -p e2e local_node --test-threads 1 --failure-output final --run-ignored ignored-only; then
               exit 1
             fi
             attempt=$((attempt+1))

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -215,7 +215,7 @@ jobs:
           attempt=1
           while true; do
             echo "Running test attempt #$attempt"
-            if ! cargo nextest run -p driver --test-threads 1 --failure-output final --run-ignored ignored-only; then
+            if ! cargo nextest run -p driver --run-ignored ignored-only; then
               exit 1
             fi
             attempt=$((attempt+1))


### PR DESCRIPTION
# Description
It seems like running the driver tests in a single-thread mode fixes the issue with accidentally stuck tests(https://github.com/cowprotocol/services/actions/runs/11141574437/job/30962723813). During a couple of runs using the flaky runner job, not a single driver test failed. The only disadvantage is that these tests execute now 5m instead of 2m.