### PR TITLE
Bad token detection: only transfer as much as is available

### DIFF
--- a/crates/driver/src/domain/competition/bad_tokens/simulation.rs
+++ b/crates/driver/src/domain/competition/bad_tokens/simulation.rs
@@ -80,7 +80,10 @@ impl Detector {
                     })
                     .collect();
                 let trader = eth::Address::from(order.trader()).0;
-                let sell_amount = order.sell.amount.0;
+                let sell_amount = match order.partial {
+                    order::Partial::Yes { available } => available.0,
+                    order::Partial::No => order.sell.amount.0,
+                };
 
                 async move {
                     let result = inner


### PR DESCRIPTION
# Description
The new bad token detection in the driver identified some sell tokens as unsupported although they are perfectly fine 
([example order](https://barn.explorer.cow.fi/orders/0x2e8eccaad6313a1a2282bed349331a580319854ae9f448aa7290cf5c42ce4d6e9fa3c00a92ec5f96b1ad2527ab41b3932efeda5869442680?tab=overview))

The reason is probably that the test transfer the bad token detection currently always uses the order's full signed sell amount. This will fail if the user created a partially fillable order where the sell amount exceeds their current balance.

# Changes
Adjusted the test transfer to only transfer the `order.partial.available` amount (when applicable). This value takes partial fills of the given order and the user's current balance into account.