### PR TITLE
Use order partial amount in the bad token detector

### DIFF
--- a/crates/driver/src/domain/competition/bad_tokens/simulation.rs
+++ b/crates/driver/src/domain/competition/bad_tokens/simulation.rs
@@ -3,7 +3,7 @@ use {
         domain::{
             competition::{
                 bad_tokens::{cache::Cache, Quality},
-                order,
+                order::{self, Partial},
                 Order,
             },
             eth,
@@ -80,7 +80,10 @@ impl Detector {
                     })
                     .collect();
                 let trader = eth::Address::from(order.trader()).0;
-                let sell_amount = order.sell.amount.0;
+                let sell_amount = match order.partial {
+                    Partial::Yes { available } => available.0,
+                    Partial::No => order.sell.amount.0,
+                };
 
                 async move {
                     let result = inner


### PR DESCRIPTION
# Description
The bad token detector uses `order.sell_amount` for simulations. This is problematic for partial fill orders where a trader might not have the whole amount at the time of the simulation. `order.partial.available` should be used instead with the `sell_amount` fallback.

## How to test
Staging logs.