### PR TITLE
Separate the DB configuration

### DIFF
--- a/crates/autopilot/src/arguments.rs
+++ b/crates/autopilot/src/arguments.rs
@@ -4,7 +4,7 @@ use {
     clap::ValueEnum,
     primitive_types::H160,
     shared::{
-        arguments::{display_list, display_option, ExternalSolver},
+        arguments::{display_list, display_option, Db, ExternalSolver},
         bad_token::token_owner_finder,
         http_client,
         price_estimation::{self, NativePriceEstimators},
@@ -53,6 +53,10 @@ pub struct Arguments {
     /// postgres.
     #[clap(long, env, default_value = "postgresql://")]
     pub db_url: Url,
+
+    /// Url of the Postgres database.
+    #[clap(flatten)]
+    pub db: Db,
 
     /// The number of order events to insert in a single batch.
     #[clap(long, env, default_value = "500")]
@@ -269,6 +273,7 @@ impl std::fmt::Display for Arguments {
             order_events_cleanup_interval,
             order_events_cleanup_threshold,
             db_url,
+            db,
             insert_batch_size,
             native_price_estimation_results_required,
             max_settlement_transaction_wait,
@@ -292,6 +297,8 @@ impl std::fmt::Display for Arguments {
         writeln!(f, "metrics_address: {}", metrics_address)?;
         let _intentionally_ignored = db_url;
         writeln!(f, "db_url: SECRET")?;
+        let _intentionally_ignored = db;
+        writeln!(f, "db: SECRET")?;
         writeln!(f, "skip_event_sync: {}", skip_event_sync)?;
         writeln!(f, "allowed_tokens: {:?}", allowed_tokens)?;
         writeln!(f, "unsupported_tokens: {:?}", unsupported_tokens)?;

--- a/crates/autopilot/src/run.rs
+++ b/crates/autopilot/src/run.rs
@@ -127,7 +127,9 @@ pub async fn start(args: impl Iterator<Item = String>) {
 pub async fn run(args: Arguments) {
     assert!(args.shadow.is_none(), "cannot run in shadow mode");
 
-    let db = Postgres::new(args.db_url.as_str(), args.insert_batch_size)
+    let db_url = args.db.to_url().unwrap_or(args.db_url);
+
+    let db = Postgres::new(db_url.as_str(), args.insert_batch_size)
         .await
         .unwrap();
     crate::database::run_database_metrics_work(db.clone());

--- a/crates/orderbook/src/arguments.rs
+++ b/crates/orderbook/src/arguments.rs
@@ -2,7 +2,7 @@ use {
     primitive_types::H160,
     reqwest::Url,
     shared::{
-        arguments::{display_option, display_secret_option},
+        arguments::{display_option, display_secret_option, Db},
         bad_token::token_owner_finder,
         http_client,
         price_estimation::{self, NativePriceEstimators},
@@ -39,6 +39,10 @@ pub struct Arguments {
     /// postgres.
     #[clap(long, env, default_value = "postgresql://")]
     pub db_url: Url,
+
+    /// Url of the Postgres database.
+    #[clap(flatten)]
+    pub db: Db,
 
     /// The minimum amount of time in seconds an order has to be valid for.
     #[clap(
@@ -166,6 +170,7 @@ impl std::fmt::Display for Arguments {
             hooks_contract_address,
             app_data_size_limit,
             db_url,
+            db,
             max_gas_per_order,
         } = self;
 
@@ -178,6 +183,8 @@ impl std::fmt::Display for Arguments {
         writeln!(f, "bind_address: {}", bind_address)?;
         let _intentionally_ignored = db_url;
         writeln!(f, "db_url: SECRET")?;
+        let _intentionally_ignored = db;
+        writeln!(f, "db: SECRET")?;
         writeln!(
             f,
             "min_order_validity_period: {:?}",


### PR DESCRIPTION
# Description
Separate the DB configuration into base URL, user and password.

The reason of doing this is to add an extra layer of safety handing the DB credentials.

## How to test
1. Unit test