### PR TITLE
Add block number to mempool_executed logs

### DIFF
--- a/crates/driver/src/domain/mempools.rs
+++ b/crates/driver/src/domain/mempools.rs
@@ -240,12 +240,12 @@ pub enum RevertProtection {
 
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
-    #[error("Mined reverted transaction: {tx_id:?}")]
+    #[error("Mined reverted transaction: {tx_id:?}, block number: {block_number}")]
     Revert {
         tx_id: eth::TxId,
         block_number: BlockNo,
     },
-    #[error("Simulation started reverting during submission")]
+    #[error("Simulation started reverting during submission, block number: {0:?}")]
     SimulationRevert(Option<BlockNo>),
     #[error("Settlement did not get included in time")]
     Expired,

--- a/crates/driver/src/domain/mempools.rs
+++ b/crates/driver/src/domain/mempools.rs
@@ -145,7 +145,7 @@ impl Mempools {
                     TxStatus::Reverted => {
                         return Err(Error::Revert {
                             tx_id: hash.clone(),
-                            block_no: Some(block.number),
+                            block_number: block.number,
                         })
                     }
                     TxStatus::Pending => {
@@ -243,7 +243,7 @@ pub enum Error {
     #[error("Mined reverted transaction: {tx_id:?}")]
     Revert {
         tx_id: eth::TxId,
-        block_no: Option<BlockNo>,
+        block_number: BlockNo,
     },
     #[error("Simulation started reverting during submission")]
     SimulationRevert(Option<BlockNo>),
@@ -253,13 +253,4 @@ pub enum Error {
     Disabled,
     #[error("Failed to submit: {0:?}")]
     Other(#[from] anyhow::Error),
-}
-
-impl Error {
-    pub fn block_no(&self) -> Option<BlockNo> {
-        match &self {
-            Error::Revert { block_no, .. } | Error::SimulationRevert(block_no) => *block_no,
-            _ => None,
-        }
-    }
 }

--- a/crates/driver/src/infra/notify/mod.rs
+++ b/crates/driver/src/infra/notify/mod.rs
@@ -105,8 +105,8 @@ pub fn executed(
 ) {
     let kind = match res {
         Ok(hash) => notification::Settlement::Success(hash.clone()),
-        Err(Error::Revert(hash)) => notification::Settlement::Revert(hash.clone()),
-        Err(Error::SimulationRevert) => notification::Settlement::SimulationRevert,
+        Err(Error::Revert { tx_id: hash, .. }) => notification::Settlement::Revert(hash.clone()),
+        Err(Error::SimulationRevert { .. }) => notification::Settlement::SimulationRevert,
         Err(Error::Expired) => notification::Settlement::Expired,
         Err(Error::Other(_) | Error::Disabled) => notification::Settlement::Fail,
     };

--- a/crates/driver/src/infra/observe/mod.rs
+++ b/crates/driver/src/infra/observe/mod.rs
@@ -333,7 +333,6 @@ pub fn mempool_executed(
                 ?err,
                 %mempool,
                 ?settlement,
-                block_no=err.block_no(),
                 "sending transaction via mempool failed",
             );
         }

--- a/crates/driver/src/infra/observe/mod.rs
+++ b/crates/driver/src/infra/observe/mod.rs
@@ -333,13 +333,14 @@ pub fn mempool_executed(
                 ?err,
                 %mempool,
                 ?settlement,
+                block_no=err.block_no(),
                 "sending transaction via mempool failed",
             );
         }
     }
     let result = match res {
         Ok(_) => "Success",
-        Err(mempools::Error::Revert(_) | mempools::Error::SimulationRevert) => "Revert",
+        Err(mempools::Error::Revert { .. } | mempools::Error::SimulationRevert { .. }) => "Revert",
         Err(mempools::Error::Expired) => "Expired",
         Err(mempools::Error::Other(_)) => "Other",
         Err(mempools::Error::Disabled) => "Disabled",


### PR DESCRIPTION
# Description
Add block number to mempool_executed logs, so we can simulate failed submissions in order to debug the reason of the failure.