### PR TITLE
only mark tokens as unsupported based on metrics for a limited time

### DIFF
--- a/crates/driver/src/domain/competition/bad_tokens/metrics.rs
+++ b/crates/driver/src/domain/competition/bad_tokens/metrics.rs
@@ -139,7 +139,6 @@ mod tests {
         );
 
         // after the freeze period is over the token gets reported as good again
-        // after the token gets unfrozen it gets reported as good again
         tokio::time::sleep(FREEZE_DURATION).await;
         assert_eq!(detector.get_quality(&token_a, Instant::now()), None);
 

--- a/crates/driver/src/domain/competition/bad_tokens/metrics.rs
+++ b/crates/driver/src/domain/competition/bad_tokens/metrics.rs
@@ -15,27 +15,6 @@ struct TokenStatistics {
     flagged_unsupported_at: Option<Instant>,
 }
 
-#[derive(Default, Clone)]
-pub struct DetectorBuilder(Arc<DashMap<eth::TokenAddress, TokenStatistics>>);
-
-impl DetectorBuilder {
-    pub fn build(
-        self,
-        failure_ratio: f64,
-        required_measurements: u32,
-        log_only: bool,
-        token_freeze_time: Duration,
-    ) -> Detector {
-        Detector {
-            failure_ratio,
-            required_measurements,
-            counter: self.0,
-            log_only,
-            token_freeze_time,
-        }
-    }
-}
-
 /// Monitors tokens to determine whether they are considered "unsupported" based
 /// on the ratio of failing to total settlement encoding attempts. A token must
 /// have participated in at least `REQUIRED_MEASUREMENTS` attempts to be
@@ -51,6 +30,21 @@ pub struct Detector {
 }
 
 impl Detector {
+    pub fn new(
+        failure_ratio: f64,
+        required_measurements: u32,
+        log_only: bool,
+        token_freeze_time: Duration,
+    ) -> Self {
+        Self {
+            failure_ratio,
+            required_measurements,
+            counter: Default::default(),
+            log_only,
+            token_freeze_time,
+        }
+    }
+
     pub fn get_quality(&self, token: &eth::TokenAddress, now: Instant) -> Option<Quality> {
         let stats = self.counter.get(token)?;
         if stats

--- a/crates/driver/src/domain/competition/bad_tokens/metrics.rs
+++ b/crates/driver/src/domain/competition/bad_tokens/metrics.rs
@@ -63,7 +63,7 @@ impl Detector {
     fn stats_indicate_unsupported(&self, stats: &TokenStatistics) -> bool {
         let token_failure_ratio = match stats.attempts {
             0 => return false,
-            attempts => f64::from(stats.fails) / f64::from(attempts)
+            attempts => f64::from(stats.fails) / f64::from(attempts),
         };
         stats.attempts >= self.required_measurements && token_failure_ratio >= self.failure_ratio
     }

--- a/crates/driver/src/domain/competition/bad_tokens/mod.rs
+++ b/crates/driver/src/domain/competition/bad_tokens/mod.rs
@@ -132,7 +132,7 @@ impl Detector {
         }
 
         if let Some(metrics) = &self.metrics {
-            return metrics.get_quality(&token);
+            return metrics.get_quality(&token, now);
         }
 
         None

--- a/crates/driver/src/infra/api/mod.rs
+++ b/crates/driver/src/infra/api/mod.rs
@@ -85,6 +85,7 @@ impl Api {
                     bad_token_config.metrics_strategy_failure_ratio,
                     bad_token_config.metrics_strategy_required_measurements,
                     bad_token_config.metrics_strategy_log_only,
+                    bad_token_config.metrics_strategy_token_freeze_time,
                 ));
             }
 

--- a/crates/driver/src/infra/api/mod.rs
+++ b/crates/driver/src/infra/api/mod.rs
@@ -58,8 +58,6 @@ impl Api {
         app = routes::metrics(app);
         app = routes::healthz(app);
 
-        let metrics_bad_token_detector_builder = bad_tokens::metrics::DetectorBuilder::default();
-
         // Multiplex each solver as part of the API. Multiple solvers are multiplexed
         // on the same driver so only one liquidity collector collects the liquidity
         // for all of them. This is important because liquidity collection is
@@ -81,7 +79,7 @@ impl Api {
             }
 
             if bad_token_config.enable_metrics_strategy {
-                bad_tokens.with_metrics_detector(metrics_bad_token_detector_builder.clone().build(
+                bad_tokens.with_metrics_detector(bad_tokens::metrics::Detector::new(
                     bad_token_config.metrics_strategy_failure_ratio,
                     bad_token_config.metrics_strategy_required_measurements,
                     bad_token_config.metrics_strategy_log_only,

--- a/crates/driver/src/infra/config/file/load.rs
+++ b/crates/driver/src/infra/config/file/load.rs
@@ -124,6 +124,9 @@ pub async fn load(chain: Chain, path: &Path) -> infra::Config {
                         .bad_token_detection
                         .metrics_strategy_required_measurements,
                     metrics_strategy_log_only: config.bad_token_detection.metrics_strategy_log_only,
+                    metrics_strategy_token_freeze_time: config
+                        .bad_token_detection
+                        .metrics_strategy_token_freeze_time,
                 },
                 settle_queue_size: config.settle_queue_size,
             }

--- a/crates/driver/src/infra/config/file/mod.rs
+++ b/crates/driver/src/infra/config/file/mod.rs
@@ -716,6 +716,15 @@ pub struct BadTokenDetectionConfig {
         rename = "metrics-bad-token-detection-log-only"
     )]
     pub metrics_strategy_log_only: bool,
+
+    /// How long the metrics based bad token detection should flag a token as
+    /// unsupported before it allows to solve for that token again.
+    #[serde(
+        default = "default_metrics_bad_token_detector_freeze_time",
+        rename = "metrics-bad-token-detection-token-freeze-time",
+        with = "humantime_serde"
+    )]
+    pub metrics_strategy_token_freeze_time: Duration,
 }
 
 impl Default for BadTokenDetectionConfig {
@@ -741,4 +750,8 @@ fn default_settle_queue_size() -> usize {
 
 fn default_metrics_bad_token_detector_log_only() -> bool {
     true
+}
+
+fn default_metrics_bad_token_detector_freeze_time() -> Duration {
+    Duration::from_secs(60 * 10)
 }

--- a/crates/driver/src/infra/solver/mod.rs
+++ b/crates/driver/src/infra/solver/mod.rs
@@ -22,7 +22,7 @@ use {
     derive_more::{From, Into},
     num::BigRational,
     reqwest::header::HeaderName,
-    std::collections::HashMap,
+    std::{collections::HashMap, time::Duration},
     tap::TapFallible,
     thiserror::Error,
     tracing::Instrument,
@@ -317,4 +317,5 @@ pub struct BadTokenDetection {
     pub metrics_strategy_failure_ratio: f64,
     pub metrics_strategy_required_measurements: u32,
     pub metrics_strategy_log_only: bool,
+    pub metrics_strategy_token_freeze_time: Duration,
 }


### PR DESCRIPTION
# Description
Currently the bad token detection based on metrics will mark tokens as unsupported forever. This is problematic for tokens which only have issues temporarily. For example this can happen when the most important pool for a token gets into a weird state or when a token gets paused or a while.

# Changes
Adjusts the logic to freeze tokens for a configurable period of time. Once the freeze period is over we give the token another chance (even if the stats indicate that it's currently unsupported). To not run into issues when a token is always bad the logic was built such that 1 more `bad` measurement is enough to freeze the token again.
That way we can safely configure a very high `min_measurements` without having periods where a token that was flagged as bad can issues again because we need to get a lot new measurements to mark it as unsupported again.

Additionally the PR simplifies how the metrics based bad token detector gets instantiated and gives each solver their completely separate instance (how it was originally communicated because each solver may support different tokens).

## How to test
added a unit test