### PR TITLE
Introduce Quality::Unknown variant

### DIFF
--- a/crates/driver/src/domain/competition/bad_tokens/cache.rs
+++ b/crates/driver/src/domain/competition/bad_tokens/cache.rs
@@ -43,14 +43,14 @@ impl Cache {
         self.0
             .cache
             .entry(token)
-            .and_modify(|value| {
-                if !is_supported || now.duration_since(value.last_updated) > self.0.max_age {
+            .and_modify(|token| {
+                if !is_supported || now.duration_since(token.last_updated) > self.0.max_age {
                     // Only update the value if the cached value is outdated by now or
                     // if the new value is "Unsupported". This means on conflicting updates
                     // we err on the conservative side and assume a token is unsupported.
-                    value.is_supported = is_supported;
+                    token.is_supported = is_supported;
                 }
-                value.last_updated = now;
+                token.last_updated = now;
             })
             .or_insert_with(|| CacheEntry {
                 is_supported,

--- a/crates/driver/src/domain/competition/bad_tokens/mod.rs
+++ b/crates/driver/src/domain/competition/bad_tokens/mod.rs
@@ -23,6 +23,9 @@ pub enum Quality {
     ///   contract - see <https://github.com/cowprotocol/services/pull/781>
     /// * probably tons of other reasons
     Unsupported,
+    /// The detection strategy does not have enough data to make an informed
+    /// decision.
+    Unknown,
 }
 
 #[derive(Default)]
@@ -67,26 +70,23 @@ impl Detector {
             let buy = self.get_token_quality(order.buy.token, now);
             match (sell, buy) {
                 // both tokens supported => keep order
-                (Some(Quality::Supported), Some(Quality::Supported)) => Either::Left(order),
+                (Quality::Supported, Quality::Supported) => Either::Left(order),
                 // at least 1 token unsupported => drop order
-                (Some(Quality::Unsupported), _) | (_, Some(Quality::Unsupported)) => {
-                    Either::Right(order.uid)
-                }
+                (Quality::Unsupported, _) | (_, Quality::Unsupported) => Either::Right(order.uid),
                 // sell token quality is unknown => keep order if token is supported
-                (None, _) => {
+                (Quality::Unknown, _) => {
                     let Some(detector) = &self.simulation_detector else {
                         // we can't determine quality => assume order is good
                         return Either::Left(order);
                     };
-                    let quality = detector.determine_sell_token_quality(&order, now).await;
-                    match quality {
-                        Some(Quality::Supported) => Either::Left(order),
+                    match detector.determine_sell_token_quality(&order, now).await {
+                        Quality::Supported => Either::Left(order),
                         _ => Either::Right(order.uid),
                     }
                 }
                 // buy token quality is unknown => keep order (because we can't
                 // determine quality and assume it's good)
-                (_, None) => Either::Left(order),
+                (_, Quality::Unknown) => Either::Left(order),
             }
         });
         let (supported_orders, removed_uids): (Vec<_>, Vec<_>) = join_all(token_quality_checks)
@@ -120,22 +120,27 @@ impl Detector {
         }
     }
 
-    fn get_token_quality(&self, token: eth::TokenAddress, now: Instant) -> Option<Quality> {
-        if let Some(quality) = self.hardcoded.get(&token) {
-            return Some(*quality);
+    fn get_token_quality(&self, token: eth::TokenAddress, now: Instant) -> Quality {
+        match self.hardcoded.get(&token) {
+            None | Some(Quality::Unknown) => (),
+            Some(quality) => return *quality,
         }
 
-        if let Some(detector) = &self.simulation_detector {
-            if let Some(quality) = detector.get_quality(&token, now) {
-                return Some(quality);
-            }
+        if let Some(Quality::Unsupported) = self
+            .simulation_detector
+            .as_ref()
+            .map(|d| d.get_quality(&token, now))
+        {
+            return Quality::Unsupported;
         }
 
-        if let Some(metrics) = &self.metrics {
-            return metrics.get_quality(&token, now);
+        if let Some(Quality::Unsupported) =
+            self.metrics.as_ref().map(|m| m.get_quality(&token, now))
+        {
+            return Quality::Unsupported;
         }
 
-        None
+        Quality::Unknown
     }
 }
 

--- a/crates/driver/src/domain/competition/bad_tokens/simulation.rs
+++ b/crates/driver/src/domain/competition/bad_tokens/simulation.rs
@@ -32,7 +32,7 @@ pub struct Detector(Arc<Inner>);
 struct Inner {
     cache: Cache,
     detector: TraceCallDetectorRaw,
-    sharing: BoxRequestSharing<order::Uid, Option<Quality>>,
+    sharing: BoxRequestSharing<order::Uid, Quality>,
 }
 
 impl Detector {
@@ -49,14 +49,11 @@ impl Detector {
     /// Simulates how the sell token behaves during transfers. Assumes that
     /// the order owner has the required sell token balance and approvals
     /// set.
-    pub async fn determine_sell_token_quality(
-        &self,
-        order: &Order,
-        now: Instant,
-    ) -> Option<Quality> {
+    pub async fn determine_sell_token_quality(&self, order: &Order, now: Instant) -> Quality {
         let cache = &self.0.cache;
-        if let Some(quality) = cache.get_quality(&order.sell.token, now) {
-            return Some(quality);
+        let quality = cache.get_quality(&order.sell.token, now);
+        if quality != Quality::Unknown {
+            return quality;
         }
 
         // The simulation detector gets used by multiple solvers at the same time
@@ -93,20 +90,20 @@ impl Detector {
                     match result {
                         Err(err) => {
                             tracing::debug!(?err, token=?sell_token.0, "failed to determine token quality");
-                            None
+                            Quality::Unknown
                         }
                         Ok(TokenQuality::Good) => {
                             inner
                                 .cache
-                                .update_quality(sell_token, Quality::Supported, now);
-                            Some(Quality::Supported)
+                                .update_quality(sell_token, true, now);
+                            Quality::Supported
                         }
                         Ok(TokenQuality::Bad { reason }) => {
                             tracing::debug!(reason, token=?sell_token.0, "cache token as unsupported");
                             inner
                                 .cache
-                                .update_quality(sell_token, Quality::Unsupported, now);
-                            Some(Quality::Unsupported)
+                                .update_quality(sell_token, false, now);
+                            Quality::Unsupported
                         }
                     }
                 }


### PR DESCRIPTION
# Description
Sparked by this [discussion](https://github.com/cowprotocol/services/pull/3205#discussion_r1901647654) I think that using `Option<Quality>` is a bit implicit.

# Changes
I adjusted the bad token detection code to use `Quality::Unknown` where possible to make it more explicit what the strategy thinks about a token.

This makes some of the code more verbose so I'm not super sold on this change yet. Let me know if you think this improves things.