### PR TITLE
[TRIVIAL] Run forked-node tests on main

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -121,7 +121,9 @@ jobs:
 
   test-forked-node:
     # Do not run this job on forks since some secrets are required for it.
-    if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
+    if: |
+      github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository ||
+      github.event_name == 'push' && github.ref == 'refs/heads/main'
     timeout-minutes: 60
     runs-on: ubuntu-latest
     env:

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -122,8 +122,8 @@ jobs:
   test-forked-node:
     # Do not run this job on forks since some secrets are required for it.
     if: |
-      github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository ||
-      github.event_name == 'push' && github.ref == 'refs/heads/main'
+      (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository) ||
+      (github.event_name == 'push' && github.ref == 'refs/heads/main')
     timeout-minutes: 60
     runs-on: ubuntu-latest
     env:


### PR DESCRIPTION
After https://github.com/cowprotocol/services/pull/3201, the forked-node tests are no longer triggered on the `main` branch since the filter is configured for pull requests only. This PR fixes this.