### PR TITLE
Added `auction_id` field to `/settle` and `/reveal` driver requests.

### DIFF
--- a/crates/autopilot/src/infra/solvers/dto/reveal.rs
+++ b/crates/autopilot/src/infra/solvers/dto/reveal.rs
@@ -11,8 +11,8 @@ pub struct Request {
     /// Unique ID of the solution (per driver competition), to reveal.
     pub solution_id: u64,
     /// Auction ID in which the specified solution ID is competing.
-    #[serde_as(as = "Option<serde_with::DisplayFromStr>")]
-    pub auction_id: Option<i64>,
+    #[serde_as(as = "serde_with::DisplayFromStr")]
+    pub auction_id: i64,
 }
 
 #[serde_as]

--- a/crates/autopilot/src/infra/solvers/dto/settle.rs
+++ b/crates/autopilot/src/infra/solvers/dto/settle.rs
@@ -13,6 +13,6 @@ pub struct Request {
     /// The last block number in which the solution TX can be included
     pub submission_deadline_latest_block: u64,
     /// Auction ID in which the specified solution ID is competing.
-    #[serde_as(as = "Option<serde_with::DisplayFromStr>")]
-    pub auction_id: Option<i64>,
+    #[serde_as(as = "serde_with::DisplayFromStr")]
+    pub auction_id: i64,
 }

--- a/crates/autopilot/src/run_loop.rs
+++ b/crates/autopilot/src/run_loop.rs
@@ -765,7 +765,7 @@ impl RunLoop {
             let request = settle::Request {
                 solution_id,
                 submission_deadline_latest_block,
-                auction_id: None, // Requires 2-stage release for API-break change
+                auction_id,
             };
             driver
                 .settle(&request, self.config.max_settlement_transaction_wait)

--- a/crates/autopilot/src/shadow.rs
+++ b/crates/autopilot/src/shadow.rs
@@ -276,7 +276,7 @@ impl RunLoop {
         let revealed = driver
             .reveal(&reveal::Request {
                 solution_id,
-                auction_id: None, // Requires 2-stage release for API-break change
+                auction_id: request.id,
             })
             .await
             .map_err(Error::Reveal)?;

--- a/crates/driver/src/infra/api/routes/reveal/dto/reveal_request.rs
+++ b/crates/driver/src/infra/api/routes/reveal/dto/reveal_request.rs
@@ -7,6 +7,6 @@ pub struct RevealRequest {
     /// Unique ID of the solution (per driver competition), to reveal.
     pub solution_id: u64,
     /// Auction ID in which the specified solution ID is competing.
-    #[serde_as(as = "Option<serde_with::DisplayFromStr>")]
-    pub auction_id: Option<i64>,
+    #[serde_as(as = "serde_with::DisplayFromStr")]
+    pub auction_id: i64,
 }

--- a/crates/driver/src/infra/api/routes/reveal/mod.rs
+++ b/crates/driver/src/infra/api/routes/reveal/mod.rs
@@ -1,9 +1,12 @@
 mod dto;
 
 use {
-    crate::infra::{
-        api::{Error, State},
-        observe,
+    crate::{
+        domain::competition::auction,
+        infra::{
+            api::{self, Error, State},
+            observe,
+        },
     },
     tracing::Instrument,
 };
@@ -16,11 +19,13 @@ async fn route(
     state: axum::extract::State<State>,
     req: axum::Json<dto::RevealRequest>,
 ) -> Result<axum::Json<dto::RevealResponse>, (hyper::StatusCode, axum::Json<Error>)> {
+    let auction_id =
+        auction::Id::try_from(req.auction_id).map_err(Into::<api::routes::AuctionError>::into)?;
     let handle_request = async {
         observe::revealing();
         let result = state
             .competition()
-            .reveal(req.solution_id, req.auction_id)
+            .reveal(req.solution_id, auction_id)
             .await;
         observe::revealed(state.solver().name(), &result);
         let result = result?;
@@ -28,6 +33,6 @@ async fn route(
     };
 
     handle_request
-        .instrument(tracing::info_span!("/reveal", solver = %state.solver().name(), req.auction_id))
+        .instrument(tracing::info_span!("/reveal", solver = %state.solver().name(), %auction_id))
         .await
 }

--- a/crates/driver/src/infra/api/routes/reveal/mod.rs
+++ b/crates/driver/src/infra/api/routes/reveal/mod.rs
@@ -20,7 +20,7 @@ async fn route(
     req: axum::Json<dto::RevealRequest>,
 ) -> Result<axum::Json<dto::RevealResponse>, (hyper::StatusCode, axum::Json<Error>)> {
     let auction_id =
-        auction::Id::try_from(req.auction_id).map_err(Into::<api::routes::AuctionError>::into)?;
+        auction::Id::try_from(req.auction_id).map_err(api::routes::AuctionError::from)?;
     let handle_request = async {
         observe::revealing();
         let result = state

--- a/crates/driver/src/infra/api/routes/settle/dto/settle_request.rs
+++ b/crates/driver/src/infra/api/routes/settle/dto/settle_request.rs
@@ -9,6 +9,6 @@ pub struct SettleRequest {
     /// The last block number in which the solution TX can be included
     pub submission_deadline_latest_block: u64,
     /// Auction ID in which this solution is competing.
-    #[serde_as(as = "Option<serde_with::DisplayFromStr>")]
-    pub auction_id: Option<i64>,
+    #[serde_as(as = "serde_with::DisplayFromStr")]
+    pub auction_id: i64,
 }

--- a/crates/driver/src/infra/api/routes/settle/mod.rs
+++ b/crates/driver/src/infra/api/routes/settle/mod.rs
@@ -20,7 +20,7 @@ async fn route(
     req: axum::Json<dto::SettleRequest>,
 ) -> Result<(), (hyper::StatusCode, axum::Json<Error>)> {
     let auction_id =
-        auction::Id::try_from(req.auction_id).map_err(Into::<api::routes::AuctionError>::into)?;
+        auction::Id::try_from(req.auction_id).map_err(api::routes::AuctionError::from)?;
     let solver = state.solver().name().to_string();
 
     let handle_request = async move {


### PR DESCRIPTION
# Description
This is a continuation of the previous PR #3131 which added `auction_id` field as optional on the driver `/settle` and `/reveal` requests. Because this is API breaking change we had to wait for Solvers teams to updated their driver version, so they will support new `auction_id` field. 
Current PR changes `auction_id` field from optional to mandatory and starts sending it from the autopilot.

# Changes
This is mainly port of PR #3113 which introduced API break (and was reverted with PR #3131) on to the current main branch: updated driver and autopilot DTOs, added code to use these new fields and added additional condition on driver side to verify if provided `solution_id` is competing in provided `auction_id`.
OpenAPI definition is already up to date.

## How to test
Existing tests, esp. `driver_handles_solutions_based_on_id()`.