### PR TITLE
[2] Convert executed_fee_amount to surplus token

### DIFF
--- a/crates/model/src/order.rs
+++ b/crates/model/src/order.rs
@@ -673,6 +673,7 @@ pub struct OrderMetadata {
     pub executed_sell_amount: BigUint,
     #[serde_as(as = "HexOrDecimalU256")]
     pub executed_sell_amount_before_fees: U256,
+    // The fee amount is expressed in the surplus token
     #[serde_as(as = "HexOrDecimalU256")]
     pub executed_fee_amount: U256,
     #[serde_as(as = "HexOrDecimalU256")]

--- a/crates/orderbook/openapi.yml
+++ b/crates/orderbook/openapi.yml
@@ -903,8 +903,8 @@ components:
             - $ref: "#/components/schemas/BigUint"
         executedFeeAmount:
           description: The total amount of signed order fees that have been executed
-            for this order. The value is expressed in surplus token - sell token for 
-            buy orders, and in buy token for sell orders.
+            for this order. The value is expressed in surplus token (sell token for 
+            buy orders, and in buy token for sell orders).
           allOf:
             - $ref: "#/components/schemas/BigUint"
         invalidated:

--- a/crates/orderbook/openapi.yml
+++ b/crates/orderbook/openapi.yml
@@ -902,7 +902,9 @@ components:
           allOf:
             - $ref: "#/components/schemas/BigUint"
         executedFeeAmount:
-          description: The total amount of fees that have been executed for this order.
+          description: The total amount of signed order fees that have been executed
+            for this order. The value is expressed in surplus token - sell token for 
+            buy orders, and in buy token for sell orders.
           allOf:
             - $ref: "#/components/schemas/BigUint"
         invalidated:

--- a/crates/orderbook/src/database/orders.rs
+++ b/crates/orderbook/src/database/orders.rs
@@ -618,7 +618,9 @@ fn full_order_into_model_order(order: FullOrder) -> Result<Order> {
         // - as it is limited by the order format.
         executed_sell_amount_before_fees: big_decimal_to_u256(&(&order.sum_sell - &order.sum_fee))
             .context("executed sell amount before fees does not fit in a u256")?,
-        executed_fee_amount: {
+        executed_fee_amount: if order.sum_fee.is_zero() {
+            0.into()
+        } else {
             let fee_in_sell_token = big_decimal_to_u256(&order.sum_fee)
                 .context("executed fee amount is not a valid u256")?;
             match order.kind {

--- a/crates/shared/src/db_order_conversions.rs
+++ b/crates/shared/src/db_order_conversions.rs
@@ -1,6 +1,7 @@
 use {
     anyhow::{Context, Result},
     app_data::AppDataHash,
+    bigdecimal::Zero,
     database::{
         onchain_broadcasted_orders::OnchainOrderPlacementError as DbOnchainOrderPlacementError,
         orders::{
@@ -86,7 +87,9 @@ pub fn full_order_into_model_order(order: database::orders::FullOrder) -> Result
         // - as it is limited by the order format.
         executed_sell_amount_before_fees: big_decimal_to_u256(&(&order.sum_sell - &order.sum_fee))
             .context("executed sell amount before fees does not fit in a u256")?,
-        executed_fee_amount: {
+        executed_fee_amount: if order.sum_fee.is_zero() {
+            0.into()
+        } else {
             let fee_in_sell_token = big_decimal_to_u256(&order.sum_fee)
                 .context("executed fee amount is not a valid u256")?;
             match order.kind {

--- a/crates/shared/src/db_order_conversions.rs
+++ b/crates/shared/src/db_order_conversions.rs
@@ -84,12 +84,31 @@ pub fn full_order_into_model_order(order: database::orders::FullOrder) -> Result
         // Executed fee amounts and sell amounts before fees are capped by
         // order's fee and sell amounts, and thus can always fit in a `U256`
         // - as it is limited by the order format.
-        executed_sell_amount_before_fees: big_decimal_to_u256(&(order.sum_sell - &order.sum_fee))
-            .context(
-            "executed sell amount before fees does not fit in a u256",
-        )?,
-        executed_fee_amount: big_decimal_to_u256(&order.sum_fee)
-            .context("executed fee amount is not a valid u256")?,
+        executed_sell_amount_before_fees: big_decimal_to_u256(&(&order.sum_sell - &order.sum_fee))
+            .context("executed sell amount before fees does not fit in a u256")?,
+        executed_fee_amount: {
+            let fee_in_sell_token = big_decimal_to_u256(&order.sum_fee)
+                .context("executed fee amount is not a valid u256")?;
+            match order.kind {
+                DbOrderKind::Buy => fee_in_sell_token,
+                DbOrderKind::Sell => {
+                    // convert to buy token using executed amounts which are a very good
+                    // approximation of UCP prices conversion rate
+                    fee_in_sell_token
+                        .checked_mul(
+                            big_decimal_to_u256(&order.sum_buy)
+                                .context("executed buy amount is not an unsigned integer")?,
+                        )
+                        .context("fee_in_sell_token overflow")?
+                        .checked_div(
+                            big_decimal_to_u256(&(&order.sum_sell - &order.sum_fee)).context(
+                                "executed sell amount before fees does not fit in a u256",
+                            )?,
+                        )
+                        .context("fee_in_sell_token division by zero")?
+                }
+            }
+        },
         executed_surplus_fee: big_decimal_to_u256(&order.executed_fee)
             .context("executed fee is not a valid u256")?,
         executed_fee: big_decimal_to_u256(&order.executed_fee)


### PR DESCRIPTION
# Description
As part of the initiative to show all executed order fees in surplus tokens, we have to convert the `executed_fee_amount` from sell token to surplus token. This is needed by frontend and other integrators, so that ALL fees are in surplus token and easily summarized.

As a reminder, `executed_fee_amount` represents executed version of a fixed `fee_amount` fee that is part of the signed order and it's always assumed that it is expressed in sell token. But we can easily convert the EXECUTED REPRESENTATION of this fee into surplus token by following this math:

```
let executedFeeAmountInSurplusToken = match order.kind {
    Buy => executedFeeAmount,
    Sell => executedFeeAmount * executedBuyAmount / executedSellAmountBeforeFees,
};
```

This math is 100% equal to using uniform clearing prices to convert between fee in sell and buy tokens, as already used in the existing code:

https://github.com/cowprotocol/services/blob/main/crates/autopilot/src/domain/settlement/trade/math.rs#L126-L129 :
```
/// Converts given surplus fee into sell token fee.
    fn fee_into_sell_token(&self, fee: eth::TokenAmount) -> Result<eth::SellTokenAmount, Error> {
        let fee_in_sell_token = match self.side {
            order::Side::Buy => fee,
            order::Side::Sell => fee
                .checked_mul(&self.prices.uniform.buy.into())
                .ok_or(error::Math::Overflow)?
                .checked_div(&self.prices.uniform.sell.into())
                .ok_or(error::Math::DivisionByZero)?,
        }
        .into();
        Ok(fee_in_sell_token)
    }
```

Note 1: This PR only changes how the executed version of this fee is represented over the API. It does not change anything in the database, so it also does not change our assumption of how the `fee_amount` is saved internally.

Note 2: Only  > ~2 year old orders are affected by this. All newer orders have `executed_fee_amount = 0`.

Note 3: These old orders will have a bad total fee shown when this PR is merged. We need https://github.com/cowprotocol/services/pull/3184 merged as well (and all consequent data migrations) so that all fees are finally shown in surplus tokens.

# Changes
<!-- List of detailed changes (how the change is accomplished) -->

- [ ] Executed version of `fee_amount` is now shown in surplus token

## How to test
Confirmed on several examples of orders that have fee_amount > 0.

<!--
## Related Issues

Fixes #
-->