### PR TITLE
Revert executing `eth_estimateGas` and `eth_createAccessList` on the latest block

### DIFF
--- a/crates/driver/src/infra/blockchain/mod.rs
+++ b/crates/driver/src/infra/blockchain/mod.rs
@@ -182,10 +182,7 @@ impl Ethereum {
             .transport()
             .execute(
                 "eth_createAccessList",
-                vec![
-                    serde_json::to_value(&tx).unwrap(),
-                    serde_json::Value::String("latest".into()),
-                ],
+                vec![serde_json::to_value(&tx).unwrap()],
             )
             .await?;
         if let Some(err) = json.get("error") {
@@ -210,7 +207,7 @@ impl Ethereum {
                     gas_price: self.simulation_gas_price().await,
                     ..Default::default()
                 },
-                Some(ethcontract::BlockNumber::Latest),
+                None,
             )
             .await
             .map(Into::into)


### PR DESCRIPTION
While this PR would give us revert detection reproducible with tenderly it also leads to an overly optimistic revert protection. Meaning on average future reverts get detected too late which would result in solvers losing a lot of money.

This was noticed by an external solver running the original PR in production and seeing their rewards vanish due to increased reverts.

See this [thread](https://cowservices.slack.com/archives/C0690QX4R5X/p1736368423899369?thread_ts=1736279159.869429&cid=C0690QX4R5X) for reference.