### PR TITLE
Bad token detector metrics

### DIFF
--- a/crates/driver/src/domain/competition/bad_tokens/metrics.rs
+++ b/crates/driver/src/domain/competition/bad_tokens/metrics.rs
@@ -127,7 +127,7 @@ impl Detector {
                 "mark tokens as unsupported"
             );
             metrics::get()
-                .bad_token_detection
+                .bad_tokens_detected
                 .with_label_values(&[&self.solver.0, "metrics"])
                 .inc_by(new_unsupported_tokens.len() as u64);
         }

--- a/crates/driver/src/domain/competition/bad_tokens/metrics.rs
+++ b/crates/driver/src/domain/competition/bad_tokens/metrics.rs
@@ -1,6 +1,9 @@
 use {
     super::Quality,
-    crate::domain::eth,
+    crate::{
+        domain::eth,
+        infra::{observe::metrics, solver},
+    },
     dashmap::DashMap,
     std::{
         sync::Arc,
@@ -27,6 +30,7 @@ pub struct Detector {
     counter: Arc<DashMap<eth::TokenAddress, TokenStatistics>>,
     log_only: bool,
     token_freeze_time: Duration,
+    solver: solver::Name,
 }
 
 impl Detector {
@@ -35,6 +39,7 @@ impl Detector {
         required_measurements: u32,
         log_only: bool,
         token_freeze_time: Duration,
+        solver: solver::Name,
     ) -> Self {
         Self {
             failure_ratio,
@@ -42,6 +47,7 @@ impl Detector {
             counter: Default::default(),
             log_only,
             token_freeze_time,
+            solver,
         }
     }
 
@@ -120,6 +126,10 @@ impl Detector {
                 tokens = ?new_unsupported_tokens,
                 "mark tokens as unsupported"
             );
+            metrics::get()
+                .bad_token_detection
+                .with_label_values(&[&self.solver.0, "metrics"])
+                .inc_by(new_unsupported_tokens.len() as u64);
         }
     }
 }
@@ -133,7 +143,13 @@ mod tests {
     #[tokio::test]
     async fn unfreeze_bad_tokens() {
         const FREEZE_DURATION: Duration = Duration::from_millis(50);
-        let detector = Detector::new(0.5, 2, false, FREEZE_DURATION);
+        let detector = Detector::new(
+            0.5,
+            2,
+            false,
+            FREEZE_DURATION,
+            solver::Name("mysolver".to_string()),
+        );
 
         let token_a = eth::TokenAddress(eth::ContractAddress(H160([1; 20])));
         let token_b = eth::TokenAddress(eth::ContractAddress(H160([2; 20])));

--- a/crates/driver/src/domain/competition/bad_tokens/simulation.rs
+++ b/crates/driver/src/domain/competition/bad_tokens/simulation.rs
@@ -116,7 +116,7 @@ impl Detector {
                         }
                         Ok(TokenQuality::Bad { reason }) => {
                             tracing::debug!(reason, token=?sell_token.0, "cache token as unsupported");
-                            metrics::get().bad_tokens_detected.with_label_values(&[&solver_name,"simulation"]).inc();
+                            metrics::get().bad_tokens_detected.with_label_values(&[&solver_name, "simulation"]).inc();
                             inner
                                 .cache
                                 .update_quality(sell_token, false, now);

--- a/crates/driver/src/domain/competition/bad_tokens/simulation.rs
+++ b/crates/driver/src/domain/competition/bad_tokens/simulation.rs
@@ -116,7 +116,7 @@ impl Detector {
                         }
                         Ok(TokenQuality::Bad { reason }) => {
                             tracing::debug!(reason, token=?sell_token.0, "cache token as unsupported");
-                            metrics::get().bad_token_detection.with_label_values(&[&solver_name,"simulation"]).inc();
+                            metrics::get().bad_tokens_detected.with_label_values(&[&solver_name,"simulation"]).inc();
                             inner
                                 .cache
                                 .update_quality(sell_token, false, now);

--- a/crates/driver/src/infra/api/mod.rs
+++ b/crates/driver/src/infra/api/mod.rs
@@ -29,7 +29,7 @@ pub struct Api {
     pub eth: Ethereum,
     pub mempools: Mempools,
     pub addr: SocketAddr,
-    pub bad_token_detector: bad_tokens::simulation::Detector,
+    pub bad_token_detector_builder: bad_tokens::simulation::DetectorBuilder,
     /// If this channel is specified, the bound address will be sent to it. This
     /// allows the driver to bind to 0.0.0.0:0 during testing.
     pub addr_sender: Option<oneshot::Sender<SocketAddr>>,
@@ -75,7 +75,9 @@ impl Api {
             let mut bad_tokens =
                 bad_tokens::Detector::new(bad_token_config.tokens_supported.clone());
             if bad_token_config.enable_simulation_strategy {
-                bad_tokens.with_simulation_detector(self.bad_token_detector.clone());
+                bad_tokens.with_simulation_detector(
+                    self.bad_token_detector_builder.clone().build(name.clone()),
+                );
             }
 
             if bad_token_config.enable_metrics_strategy {
@@ -84,6 +86,7 @@ impl Api {
                     bad_token_config.metrics_strategy_required_measurements,
                     bad_token_config.metrics_strategy_log_only,
                     bad_token_config.metrics_strategy_token_freeze_time,
+                    name.clone(),
                 ));
             }
 

--- a/crates/driver/src/infra/api/mod.rs
+++ b/crates/driver/src/infra/api/mod.rs
@@ -29,7 +29,7 @@ pub struct Api {
     pub eth: Ethereum,
     pub mempools: Mempools,
     pub addr: SocketAddr,
-    pub bad_token_detector_builder: bad_tokens::simulation::DetectorBuilder,
+    pub bad_token_detector: bad_tokens::simulation::Detector,
     /// If this channel is specified, the bound address will be sent to it. This
     /// allows the driver to bind to 0.0.0.0:0 during testing.
     pub addr_sender: Option<oneshot::Sender<SocketAddr>>,
@@ -75,9 +75,7 @@ impl Api {
             let mut bad_tokens =
                 bad_tokens::Detector::new(bad_token_config.tokens_supported.clone());
             if bad_token_config.enable_simulation_strategy {
-                bad_tokens.with_simulation_detector(
-                    self.bad_token_detector_builder.clone().build(name.clone()),
-                );
+                bad_tokens.with_simulation_detector(self.bad_token_detector.clone());
             }
 
             if bad_token_config.enable_metrics_strategy {

--- a/crates/driver/src/infra/observe/metrics.rs
+++ b/crates/driver/src/infra/observe/metrics.rs
@@ -21,7 +21,7 @@ pub struct Metrics {
     pub mempool_submission: prometheus::IntCounterVec,
     /// Bad token detection metrics by solver and detection strategy.
     #[metric(labels("solver", "strategy"))]
-    pub bad_token_detection: prometheus::IntCounterVec,
+    pub bad_tokens_detected: prometheus::IntCounterVec,
 }
 
 /// Setup the metrics registry.

--- a/crates/driver/src/infra/observe/metrics.rs
+++ b/crates/driver/src/infra/observe/metrics.rs
@@ -19,6 +19,9 @@ pub struct Metrics {
     /// The results of the mempool submission.
     #[metric(labels("mempool", "result"))]
     pub mempool_submission: prometheus::IntCounterVec,
+    /// Bad token detection metrics by solver and detection strategy.
+    #[metric(labels("solver", "strategy"))]
+    pub bad_token_detection: prometheus::IntCounterVec,
 }
 
 /// Setup the metrics registry.

--- a/crates/driver/src/infra/observe/metrics.rs
+++ b/crates/driver/src/infra/observe/metrics.rs
@@ -19,7 +19,7 @@ pub struct Metrics {
     /// The results of the mempool submission.
     #[metric(labels("mempool", "result"))]
     pub mempool_submission: prometheus::IntCounterVec,
-    /// Bad token detection metrics by solver and detection strategy.
+    /// How many tokens detected by specific solver and strategy.
     #[metric(labels("solver", "strategy"))]
     pub bad_tokens_detected: prometheus::IntCounterVec,
 }

--- a/crates/driver/src/infra/observe/mod.rs
+++ b/crates/driver/src/infra/observe/mod.rs
@@ -28,7 +28,7 @@ use {
     url::Url,
 };
 
-mod metrics;
+pub mod metrics;
 
 /// Setup the observability. The log argument configures the tokio tracing
 /// framework.

--- a/crates/driver/src/run.rs
+++ b/crates/driver/src/run.rs
@@ -66,7 +66,7 @@ async fn run_with(args: cli::Args, addr_sender: Option<oneshot::Sender<SocketAdd
             eth.clone(),
         )
         .unwrap(),
-        bad_token_detector_builder: bad_tokens::simulation::DetectorBuilder::new(
+        bad_token_detector: bad_tokens::simulation::Detector::new(
             config.simulation_bad_token_max_age,
             &eth,
         ),

--- a/crates/driver/src/run.rs
+++ b/crates/driver/src/run.rs
@@ -66,7 +66,7 @@ async fn run_with(args: cli::Args, addr_sender: Option<oneshot::Sender<SocketAdd
             eth.clone(),
         )
         .unwrap(),
-        bad_token_detector: bad_tokens::simulation::Detector::new(
+        bad_token_detector_builder: bad_tokens::simulation::DetectorBuilder::new(
             config.simulation_bad_token_max_age,
             &eth,
         ),


### PR DESCRIPTION
# Description
Adds Prometheus metrics for driver's bad token detector strategies, so it will be possible to show how many tokens were marked as `bad` by each solver and strategy. It would be helpful to identify solvers that perform as not expected and to analyze the work of each detection strategy individually.

## How to test
Create 2 grafana panels: the one that shows detected tokens by solver and another - by strategy.

Added `hotfix` label to deploy it asap.
