### PR TITLE
[TRIVIAL] Hotfix GH job typo fix

### DIFF
--- a/.github/workflows/hotfix.yml
+++ b/.github/workflows/hotfix.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Check out
         uses: actions/checkout@v4
         with:
-          token: "${{ secrets.HOTFIX_ACTION_JOB }}"
+          token: "${{ secrets.HOTFIX_ACTION_TOKEN }}"
           fetch-depth: 0
 
       - name: Configure git


### PR DESCRIPTION
There was a typo in the GH token name.