### PR TITLE
[TRIVIAL] Maintaining quote verified flag when creating an order

### DIFF
--- a/crates/e2e/tests/e2e/place_order_with_quote.rs
+++ b/crates/e2e/tests/e2e/place_order_with_quote.rs
@@ -67,6 +67,7 @@ async fn place_order_with_quote(web3: Web3) {
     let quote_response = services.submit_quote(&quote_request).await.unwrap();
     tracing::debug!(?quote_response);
     assert!(quote_response.id.is_some());
+    assert!(quote_response.verified);
 
     let quote_metadata =
         crate::database::quote_metadata(services.db(), quote_response.id.unwrap()).await;
@@ -99,9 +100,8 @@ async fn place_order_with_quote(web3: Web3) {
         &database::byte_array::ByteArray(order_uid.0),
     )
     .await
+    .unwrap()
     .unwrap();
-    assert!(order_quote.is_some());
-    // compare quote metadata and order quote metadata
-    let order_quote_metadata = order_quote.unwrap().metadata;
-    assert_eq!(quote_metadata.unwrap().0, order_quote_metadata);
+    assert_eq!(quote_response.verified, order_quote.verified);
+    assert_eq!(quote_metadata.unwrap().0, order_quote.metadata);
 }

--- a/crates/shared/src/order_quoting.rs
+++ b/crates/shared/src/order_quoting.rs
@@ -195,9 +195,7 @@ impl TryFrom<QuoteRow> for QuoteData {
             expiration: row.expiration_timestamp,
             quote_kind: row.quote_kind,
             solver: H160(row.solver.0),
-            // Even if the quote was verified at the time of creation
-            // it might no longer be accurate.
-            verified: false,
+            verified: row.verified,
             metadata: row.metadata.try_into()?,
         })
     }


### PR DESCRIPTION
# Description
Changed order `verified` flag to be used from quote original value when order is crated from that quote.
The need for this change is that ~98% of quotes are verified successfully but most of the created `order_quotes` from that orders are not verified.

## How to test
Updated e2e test to verify this particular case (it fails before applying this PR).