### PR TITLE
[TRIVIAL] Adjust message for breaking API changes

### DIFF
--- a/.github/nitpicks.yml
+++ b/.github/nitpicks.yml
@@ -7,7 +7,7 @@
     Reminder: Please consider backward compatibility when modifying the API specification. 
     If breaking changes are unavoidable, ensure:
     - You explicitly pointed out breaking changes.
-    - You communicate the changes to affected teams.
+    - You communicate the changes before merging to affected teams (at least Frontend team and SAFE team).
     - You provide proper versioning and migration mechanisms.
   pathFilter:
     - "**/openapi.yml"

--- a/.github/nitpicks.yml
+++ b/.github/nitpicks.yml
@@ -7,7 +7,7 @@
     Reminder: Please consider backward compatibility when modifying the API specification. 
     If breaking changes are unavoidable, ensure:
     - You explicitly pointed out breaking changes.
-    - You communicate the changes before merging to affected teams (at least Frontend team and SAFE team).
+    - You communicate the changes to affected teams (at least Frontend team and SAFE team).
     - You provide proper versioning and migration mechanisms.
   pathFilter:
     - "**/openapi.yml"


### PR DESCRIPTION
# Description
https://github.com/cowprotocol/services/pull/3223 caused breaking the SAFE client even though they did not actually use the field.

In the future, all API changes (without exception) need to be communicated with
1. Frontend team
2. Safe team

# Changes
<!-- List of detailed changes (how the change is accomplished) -->

- [ ] Adjusted the message