### PR TITLE
[TRIVIAL] Fix API error message

### DIFF
--- a/crates/orderbook/src/api/get_trades.rs
+++ b/crates/orderbook/src/api/get_trades.rs
@@ -38,7 +38,7 @@ impl Query {
         match (self.order_uid.as_ref(), self.owner.as_ref()) {
             (Some(_), None) | (None, Some(_)) => Ok(self.trade_filter()),
             _ => Err(TradeFilterError::InvalidFilter(
-                "Must specify exactly one of owner and orderUid.".to_owned(),
+                "Must specify exactly one of owner or orderUid.".to_owned(),
             )),
         }
     }

--- a/crates/orderbook/src/api/get_trades.rs
+++ b/crates/orderbook/src/api/get_trades.rs
@@ -38,7 +38,7 @@ impl Query {
         match (self.order_uid.as_ref(), self.owner.as_ref()) {
             (Some(_), None) | (None, Some(_)) => Ok(self.trade_filter()),
             _ => Err(TradeFilterError::InvalidFilter(
-                "Must specify exactly one of owner and order_uid.".to_owned(),
+                "Must specify exactly one of owner and orderUid.".to_owned(),
             )),
         }
     }


### PR DESCRIPTION
# Description
The API expects camelCase query parameters and parses them into snake_case Rust identifiers. Therefor  the `API` actually expects the query parameter `orderUid` and not `order_uid` which should be reflected in the error message.

# Changes
Updated error message to be correct from the perspective of the API consumer not the backend internals.

The error message also now uses `or` instead of `and` to more strongly indicate that only 1 parameter is expected. This was not obvious when a user provided the arguments `order_uid` and `owner` and was surprised that the request returned results for different orders.