### PR TITLE
Request tracing without task local storage

### DIFF
--- a/crates/autopilot/src/infra/solvers/mod.rs
+++ b/crates/autopilot/src/infra/solvers/mod.rs
@@ -95,7 +95,7 @@ impl Driver {
         if let Some(timeout) = timeout {
             request = request.timeout(timeout);
         }
-        if let Some(request_id) = observe::request_id::get_task_local_storage() {
+        if let Some(request_id) = observe::request_id::from_current_span() {
             request = request.header("X-REQUEST-ID", request_id);
         }
 

--- a/crates/autopilot/src/infra/solvers/mod.rs
+++ b/crates/autopilot/src/infra/solvers/mod.rs
@@ -60,6 +60,7 @@ impl Driver {
             .post(url)
             .json(request)
             .timeout(timeout)
+            .header("X-REQUEST-ID", request.auction_id.to_string())
             .send()
             .await
             .context("send")?;

--- a/crates/autopilot/src/run_loop.rs
+++ b/crates/autopilot/src/run_loop.rs
@@ -107,12 +107,10 @@ impl RunLoop {
                 .await;
             if let Some(auction) = auction {
                 let auction_id = auction.id;
-                let auction_task = self_arc
+                self_arc
                     .single_run(auction)
-                    .instrument(tracing::info_span!("auction", auction_id));
-
-                ::observe::request_id::set_task_local_storage(auction_id.to_string(), auction_task)
-                    .await;
+                    .instrument(tracing::info_span!("auction", auction_id))
+                    .await
             };
         }
     }

--- a/crates/driver/src/domain/competition/mod.rs
+++ b/crates/driver/src/domain/competition/mod.rs
@@ -355,8 +355,7 @@ impl Competition {
             solution_id,
             submission_deadline,
             response_sender,
-            request_id: ::observe::request_id::get_task_local_storage()
-                .unwrap_or_else(|| auction_id.to_string()),
+            tracing_span: tracing::Span::current(),
         };
 
         self.settle_queue.try_send(request).map_err(|err| {
@@ -389,10 +388,9 @@ impl Competition {
                 solution_id,
                 submission_deadline,
                 response_sender,
-                request_id,
+                tracing_span,
             } = request;
-            let solver = self.solver.name().as_str();
-            let submission_task = async {
+            async {
                 if self.eth.current_block().borrow().number >= submission_deadline {
                     if let Err(err) = response_sender.send(Err(DeadlineExceeded.into())) {
                         tracing::error!(
@@ -413,9 +411,8 @@ impl Competition {
                     tracing::error!(?err, "Failed to send /settle response");
                 }
             }
-            .instrument(tracing::info_span!("/settle", solver, %auction_id));
-
-            ::observe::request_id::set_task_local_storage(request_id, submission_task).await;
+            .instrument(tracing_span)
+            .await
         }
     }
 
@@ -537,7 +534,7 @@ struct SettleRequest {
     solution_id: u64,
     submission_deadline: BlockNo,
     response_sender: oneshot::Sender<Result<Settled, Error>>,
-    request_id: String,
+    tracing_span: tracing::Span,
 }
 
 /// Solution information sent to the protocol by the driver before the solution

--- a/crates/driver/src/infra/api/mod.rs
+++ b/crates/driver/src/infra/api/mod.rs
@@ -111,7 +111,7 @@ impl Api {
                 .layer(axum::extract::DefaultBodyLimit::disable());
         }
 
-        let make_svc = observe::make_service_with_task_local_storage!(app);
+        let make_svc = observe::make_service_with_request_tracing!(app);
 
         // Start the server.
         let server = axum::Server::bind(&self.addr).serve(make_svc);

--- a/crates/driver/src/infra/solver/mod.rs
+++ b/crates/driver/src/infra/solver/mod.rs
@@ -242,7 +242,7 @@ impl Solver {
             .post(url.clone())
             .body(body)
             .timeout(auction.deadline().solvers().remaining().unwrap_or_default());
-        if let Some(id) = observe::request_id::get_task_local_storage() {
+        if let Some(id) = observe::request_id::from_current_span() {
             req = req.header("X-REQUEST-ID", id);
         }
         let res = util::http::send(self.config.response_size_limit_max_bytes, req).await;
@@ -268,7 +268,7 @@ impl Solver {
         let url = shared::url::join(&self.config.endpoint, "notify");
         super::observe::solver_request(&url, &body);
         let mut req = self.client.post(url).body(body);
-        if let Some(id) = observe::request_id::get_task_local_storage() {
+        if let Some(id) = observe::request_id::from_current_span() {
             req = req.header("X-REQUEST-ID", id);
         }
         let response_size = self.config.response_size_limit_max_bytes;

--- a/crates/e2e/src/setup/solver/mock.rs
+++ b/crates/e2e/src/setup/solver/mock.rs
@@ -52,7 +52,7 @@ impl Default for Mock {
             .route("/solve", axum::routing::post(solve))
             .with_state(state.clone());
 
-        let make_svc = observe::make_service_with_task_local_storage!(app);
+        let make_svc = observe::make_service_with_request_tracing!(app);
         let server = axum::Server::bind(&"0.0.0.0:0".parse().unwrap()).serve(make_svc);
 
         let mock = Mock {

--- a/crates/ethrpc/src/buffered.rs
+++ b/crates/ethrpc/src/buffered.rs
@@ -143,7 +143,6 @@ where
     fn queue_call(&self, id: RequestId, request: Call) -> oneshot::Receiver<RpcResult> {
         let (sender, receiver) = oneshot::channel();
         let trace_id = observe::request_id::from_current_span();
-        // tracing::error!(trace_id, "enqueue call");
         let context = (id, request, trace_id, sender);
         self.calls
             .unbounded_send(context)

--- a/crates/ethrpc/src/http.rs
+++ b/crates/ethrpc/src/http.rs
@@ -79,13 +79,13 @@ async fn execute_rpc<T: DeserializeOwned>(
         .body(body);
     match request {
         Request::Single(Call::MethodCall(call)) => {
-            if let Some(metadata) = observe::request_id::get_task_local_storage() {
+            if let Some(metadata) = observe::request_id::from_current_span() {
                 request_builder = request_builder.header("X-REQUEST-ID", metadata);
             }
             request_builder = request_builder.header("X-RPC-METHOD", call.method.clone());
         }
         Request::Batch(_) => {
-            if let Some(metadata) = observe::request_id::get_task_local_storage() {
+            if let Some(metadata) = observe::request_id::from_current_span() {
                 request_builder = request_builder.header("X-RPC-BATCH-METADATA", metadata);
             }
         }

--- a/crates/observe/src/request_id.rs
+++ b/crates/observe/src/request_id.rs
@@ -139,7 +139,7 @@ mod test {
 
     #[tokio::test]
     async fn request_id_from_current_span() {
-        crate::tracing::initialize_reentrant("debug");
+        crate::tracing::initialize_reentrant("error");
         async {
             assert_eq!(
                 Some("test".to_string()),
@@ -161,7 +161,7 @@ mod test {
 
     #[tokio::test]
     async fn request_id_from_ancestor_span() {
-        crate::tracing::initialize_reentrant("debug");
+        crate::tracing::initialize_reentrant("error");
         async {
             async {
                 async {
@@ -183,7 +183,7 @@ mod test {
 
     #[tokio::test]
     async fn request_id_from_first_ancestor_span() {
-        crate::tracing::initialize_reentrant("debug");
+        crate::tracing::initialize_reentrant("error");
         async {
             async {
                 async {
@@ -205,7 +205,7 @@ mod test {
 
     #[tokio::test]
     async fn request_id_within_spawned_task() {
-        crate::tracing::initialize_reentrant("debug");
+        crate::tracing::initialize_reentrant("error");
         async {
             tokio::spawn(
                 async {

--- a/crates/observe/src/request_id.rs
+++ b/crates/observe/src/request_id.rs
@@ -79,7 +79,13 @@ pub fn from_current_span() -> Option<String> {
     let mut result = None;
 
     Span::current().with_subscriber(|(id, sub)| {
-        let registry = sub.downcast_ref::<Registry>().unwrap();
+        let Some(registry) = sub.downcast_ref::<Registry>() else {
+            tracing::error!(
+                "looking up request_ids using the `RequestIdLayer` requires the global tracing \
+                 subscriber to be `tracing_subscriber::Registry`"
+            );
+            return;
+        };
         let mut current_span = registry.span(id);
         while let Some(span) = current_span {
             if let Some(request_id) = span.extensions().get::<RequestId>() {

--- a/crates/observe/src/request_id.rs
+++ b/crates/observe/src/request_id.rs
@@ -98,9 +98,9 @@ struct RequestId(String);
 
 /// Tracing layer that allows us to recover the request id
 /// from the current tracing span.
-pub struct ValuesLayer;
+pub struct RequestIdLayer;
 
-impl<S: Subscriber + for<'lookup> LookupSpan<'lookup>> Layer<S> for ValuesLayer {
+impl<S: Subscriber + for<'lookup> LookupSpan<'lookup>> Layer<S> for RequestIdLayer {
     /// When creating a new span check if it contains the request_id and store
     /// it in the trace's extension storage to make it available for lookup
     /// later on.
@@ -112,8 +112,8 @@ impl<S: Subscriber + for<'lookup> LookupSpan<'lookup>> Layer<S> for ValuesLayer 
             return;
         }
 
-        struct ValueVisitor(Option<RequestId>);
-        impl Visit for ValueVisitor {
+        struct RequestIdVisitor(Option<RequestId>);
+        impl Visit for RequestIdVisitor {
             // empty body because we want to use `record_str()` anyway
             fn record_debug(&mut self, _field: &Field, _value: &dyn fmt::Debug) {}
 
@@ -124,7 +124,7 @@ impl<S: Subscriber + for<'lookup> LookupSpan<'lookup>> Layer<S> for ValuesLayer 
             }
         }
 
-        let mut visitor = ValueVisitor(None);
+        let mut visitor = RequestIdVisitor(None);
         attrs.values().record(&mut visitor);
 
         if let Some(request_id) = visitor.0 {

--- a/crates/observe/src/request_id.rs
+++ b/crates/observe/src/request_id.rs
@@ -43,7 +43,7 @@ pub fn info_span(request_id: String) -> Span {
 /// Either that gets taken from the requests `X-REQUEST-ID` header of if that's
 /// missing a globally unique request number will be generated.
 #[macro_export]
-macro_rules! make_service_with_task_local_storage {
+macro_rules! make_service_with_request_tracing {
     ($service:expr) => {{
         {
             let internal_request_id = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));

--- a/crates/observe/src/request_id.rs
+++ b/crates/observe/src/request_id.rs
@@ -16,42 +16,24 @@
 //! And when we issue requests to another process we can simply fetch the
 //! current identifier specific to our task and send that along with the
 //! request.
-use {std::future::Future, tokio::task::JoinHandle};
+use {
+    std::fmt,
+    tracing::{
+        field::{Field, Visit},
+        span::Attributes,
+        Id,
+        Span,
+        Subscriber,
+    },
+    tracing_subscriber::{layer::Context, registry::LookupSpan, Layer, Registry},
+};
 
-tokio::task_local! {
-    pub static REQUEST_ID: String;
-}
+/// Name of the span that stores the id used to associated logs
+/// across processes.
+pub const SPAN_NAME: &str = "request";
 
-/// Tries to read the `request_id` from this task's storage.
-/// Returns `None` if task local storage was not initialized or is empty.
-pub fn get_task_local_storage() -> Option<String> {
-    let mut id = None;
-    let _ = REQUEST_ID.try_with(|cell| {
-        id = Some(cell.clone());
-    });
-    id
-}
-
-/// Sets the tasks's local id to the passed in value for the given scope.
-pub async fn set_task_local_storage<F, R>(id: String, scope: F) -> R
-where
-    F: Future<Output = R>,
-{
-    REQUEST_ID.scope(id, scope).await
-}
-
-/// Spawns a new task and ensures it uses the same request id as the current
-/// task (if present). This allows for tracing requests across task boundaries.
-pub fn spawn_task_with_current_request_id<F>(future: F) -> JoinHandle<F::Output>
-where
-    F: Future + Send + 'static,
-    F::Output: Send + 'static,
-{
-    if let Some(id) = get_task_local_storage() {
-        tokio::task::spawn(set_task_local_storage(id, future))
-    } else {
-        tokio::task::spawn(future)
-    }
+pub fn info_span(request_id: String) -> Span {
+    tracing::info_span!(SPAN_NAME, id = request_id)
 }
 
 /// Takes a `tower::Service` and embeds it in a `make_service` function that
@@ -81,12 +63,9 @@ macro_rules! make_service_with_task_local_storage {
                                         .fetch_add(1, std::sync::atomic::Ordering::SeqCst)
                                 )
                             };
-                            let span = tracing::info_span!("request", id);
-                            let handle_request = observe::request_id::set_task_local_storage(
-                                id,
-                                hyper::service::Service::call(&mut warp_svc, req),
-                            );
-                            tracing::Instrument::instrument(handle_request, span)
+                            let span = tracing::info_span!(observe::request_id::SPAN_NAME, id);
+                            let task = hyper::service::Service::call(&mut warp_svc, req);
+                            tracing::Instrument::instrument(task, span)
                         });
                     Ok::<_, std::convert::Infallible>(svc)
                 }
@@ -95,43 +74,72 @@ macro_rules! make_service_with_task_local_storage {
     }};
 }
 
+/// Looks up the request id from the current tracing span.
+pub fn from_current_span() -> Option<String> {
+    let mut result = None;
+
+    Span::current().with_subscriber(|(id, sub)| {
+        let registry = sub.downcast_ref::<Registry>().unwrap();
+        let mut current_span = registry.span(id);
+        while let Some(span) = current_span {
+            if let Some(request_id) = span.extensions().get::<RequestId>() {
+                result = Some(request_id.0.clone());
+                return;
+            }
+            current_span = span.parent();
+        }
+    });
+
+    result
+}
+
+/// Request id recovered from a tracing span.
+struct RequestId(String);
+
+/// Tracing layer that allows us to recover the request id
+/// from the current tracing span.
+pub struct ValuesLayer;
+
+impl<S: Subscriber + for<'lookup> LookupSpan<'lookup>> Layer<S> for ValuesLayer {
+    /// When creating a new span check if it contains the request_id and store
+    /// it in the trace's extension storage to make it available for lookup
+    /// later on.
+    fn on_new_span(&self, attrs: &Attributes<'_>, id: &Id, ctx: Context<'_, S>) {
+        let Some(span) = ctx.span(id) else {
+            return;
+        };
+        if span.name() != crate::request_id::SPAN_NAME {
+            return;
+        }
+
+        struct ValueVisitor(Option<RequestId>);
+        impl Visit for ValueVisitor {
+            // empty body because we want to use `record_str()` anyway
+            fn record_debug(&mut self, _field: &Field, _value: &dyn fmt::Debug) {}
+
+            fn record_str(&mut self, field: &Field, value: &str) {
+                if field.name() == "id" {
+                    self.0 = Some(RequestId(value.to_string()));
+                }
+            }
+        }
+
+        let mut visitor = ValueVisitor(None);
+        attrs.values().record(&mut visitor);
+
+        if let Some(request_id) = visitor.0 {
+            span.extensions_mut().insert(request_id);
+        }
+    }
+}
+
 #[cfg(test)]
 mod test {
     use super::*;
 
     #[tokio::test]
-    async fn request_id_copied_to_new_task() {
-        // use channels to enforce that assertions happen in the desired order.
-        // First we assert that the parent task's storage is empty after we
-        // spawned the child task.
-        // Afterwards we assert that the child task still has the parent task's
-        // value at the time of spawning.
-        let (sender1, receiver1) = tokio::sync::oneshot::channel();
-        let (sender2, receiver2) = tokio::sync::oneshot::channel();
+    async fn request_id_from_current_span() {}
 
-        spawn_task_with_current_request_id(async {
-            assert_eq!(None, get_task_local_storage());
-        })
-        .await
-        .unwrap();
-
-        // create a task with some task local value
-        let _ = set_task_local_storage("1234".into(), async {
-            // spawn a new task that copies the parent's task local value
-            assert_eq!(Some("1234".into()), get_task_local_storage());
-            spawn_task_with_current_request_id(async {
-                receiver1.await.unwrap();
-                assert_eq!(Some("1234".into()), get_task_local_storage());
-                sender2.send(()).unwrap();
-            });
-        })
-        .await;
-
-        // task local value is not populated outside of the previous scope
-        assert_eq!(None, get_task_local_storage());
-        sender1.send(()).unwrap();
-
-        // block test until the important assertion happened
-        receiver2.await.unwrap();
-    }
+    #[tokio::test]
+    async fn request_id_from_parent_span() {}
 }

--- a/crates/observe/src/tracing.rs
+++ b/crates/observe/src/tracing.rs
@@ -1,5 +1,5 @@
 use {
-    crate::{request_id::ValuesLayer, tracing_reload_handler::spawn_reload_handler},
+    crate::{request_id::RequestIdLayer, tracing_reload_handler::spawn_reload_handler},
     std::{panic::PanicHookInfo, sync::Once},
     time::macros::format_description,
     tracing::level_filters::LevelFilter,
@@ -82,7 +82,7 @@ fn set_tracing_subscriber(env_filter: &str, stderr_threshold: LevelFilter) {
         tracing_subscriber::registry()
             .with(console_subscriber::spawn())
             .with(fmt_layer!(env_filter, stderr_threshold))
-            .with(ValuesLayer)
+            .with(RequestIdLayer)
             .init();
         tracing::info!("started programm with support for tokio-console");
 
@@ -98,7 +98,7 @@ fn set_tracing_subscriber(env_filter: &str, stderr_threshold: LevelFilter) {
             // `sqlx` uses under the hood.
             .with(tracing::level_filters::LevelFilter::TRACE)
             .with(fmt_layer!(env_filter, stderr_threshold))
-            .with(ValuesLayer)
+            .with(RequestIdLayer)
             .init();
         tracing::info!("started programm without support for tokio-console");
 

--- a/crates/observe/src/tracing.rs
+++ b/crates/observe/src/tracing.rs
@@ -1,5 +1,5 @@
 use {
-    crate::tracing_reload_handler::spawn_reload_handler,
+    crate::{request_id::ValuesLayer, tracing_reload_handler::spawn_reload_handler},
     std::{panic::PanicHookInfo, sync::Once},
     time::macros::format_description,
     tracing::level_filters::LevelFilter,
@@ -82,6 +82,7 @@ fn set_tracing_subscriber(env_filter: &str, stderr_threshold: LevelFilter) {
         tracing_subscriber::registry()
             .with(console_subscriber::spawn())
             .with(fmt_layer!(env_filter, stderr_threshold))
+            .with(ValuesLayer)
             .init();
         tracing::info!("started programm with support for tokio-console");
 
@@ -97,6 +98,7 @@ fn set_tracing_subscriber(env_filter: &str, stderr_threshold: LevelFilter) {
             // `sqlx` uses under the hood.
             .with(tracing::level_filters::LevelFilter::TRACE)
             .with(fmt_layer!(env_filter, stderr_threshold))
+            .with(ValuesLayer)
             .init();
         tracing::info!("started programm without support for tokio-console");
 

--- a/crates/orderbook/src/run.rs
+++ b/crates/orderbook/src/run.rs
@@ -479,7 +479,7 @@ fn serve_api(
     .boxed();
     tracing::info!(%address, "serving order book");
     let warp_svc = warp::service(filter);
-    let warp_svc = observe::make_service_with_task_local_storage!(warp_svc);
+    let warp_svc = observe::make_service_with_request_tracing!(warp_svc);
     let server = hyper::Server::bind(&address)
         .serve(warp_svc)
         .with_graceful_shutdown(shutdown_receiver)

--- a/crates/shared/src/trade_finding/external.rs
+++ b/crates/shared/src/trade_finding/external.rs
@@ -70,7 +70,7 @@ impl ExternalTradeFinder {
                 deadline: chrono::Utc::now() + self.timeout,
             };
             let block_dependent = query.block_dependent;
-            let id = observe::request_id::get_task_local_storage();
+            let id = observe::request_id::from_current_span();
             let timeout = self.timeout;
             let client = self.client.clone();
             let quote_endpoint = self.quote_endpoint.clone();

--- a/crates/shared/src/zeroex_api.rs
+++ b/crates/shared/src/zeroex_api.rs
@@ -392,7 +392,7 @@ impl DefaultZeroExApi {
                     self.block_stream.borrow().hash.to_string(),
                 );
             };
-            if let Some(id) = observe::request_id::get_task_local_storage() {
+            if let Some(id) = observe::request_id::from_current_span() {
                 request = request.header("X-REQUEST-ID", id);
             }
 

--- a/crates/solvers/src/api/mod.rs
+++ b/crates/solvers/src/api/mod.rs
@@ -35,7 +35,7 @@ impl Api {
             // axum's default body limit needs to be disabled to not have the default limit on top of our custom limit
             .layer(axum::extract::DefaultBodyLimit::disable());
 
-        let make_svc = observe::make_service_with_task_local_storage!(app);
+        let make_svc = observe::make_service_with_request_tracing!(app);
 
         let server = axum::Server::bind(&self.addr).serve(make_svc);
         if let Some(bind) = bind {


### PR DESCRIPTION
# Description
Alternative to https://github.com/cowprotocol/services/pull/3247

All of the context still applies to this PR.
But instead of looking up the request id from the task local storage we are now able to look it up from the tracing span.
When I introduced the request id feature I already wanted to have it work this way but I was not able to get it working.

Finally after some more research I figured out that this can be accomplished by implementing a custom tracing layer which makes the request id available for lookup later on.

Now the request id is easily available wherever a the current span or any of it's parents contains the request id.
This means we no longer have to worry about 2 different ways of making important data available when spawning a new task.

# Changes
* reworked request_id handling to use a tracing layer instead of task local storage
* piped the auction id as a request id into the ethrpc http transport layer on `/settle` calls so we can associate rpc proxy logs with the solution we tried so submit
* since the driver now has an internal settle queue the additional indirection of spawning a new task in the `/settle` handler is no longer needed => I removed it to make the code simpler

## How to test
Ran local_node test with extra logging to make sure the request ids arrive in the http transport layer with and without request buffering. Since I used the e2e test for multiple winners again we try to submit 2 solutions.
without buffering (applies to mevblocker):
```
2025-01-22T10:07:46.274Z ERROR request{id="554"}:/settle{solver="test_solver" auction_id=554}:mempool{kind="Mempool(MEVBlocker)"}: ethrpc::http: metadata="554" call="eth_sendRawTransaction"
...
2025-01-22T10:07:46.277Z ERROR request{id="554"}:/settle{solver="solver2" auction_id=554}:mempool{kind="Mempool(MEVBlocker)"}: ethrpc::http: metadata="554" call="eth_sendRawTransaction"
```
with buffering (applies to public mempool submissions):
```
2025-01-22T10:02:10.347Z ERROR ethrpc::http::metadata="548:eth_sendRawTransaction(0,1)"
```

Also added unit tests to show that we can correctly get the request_id from the tracing span under various conditions.