### PR TITLE
Use foundry stable version in the playground docker image

### DIFF
--- a/.github/workflows/playground-check.yaml
+++ b/.github/workflows/playground-check.yaml
@@ -2,6 +2,7 @@ name: Playground operation check
 
 on:
   workflow_dispatch:
+  pull_request:
   schedule:
     # Run this job once per day
     - cron: "0 0 * * *"

--- a/.github/workflows/playground-check.yaml
+++ b/.github/workflows/playground-check.yaml
@@ -2,7 +2,6 @@ name: Playground operation check
 
 on:
   workflow_dispatch:
-  pull_request:
   schedule:
     # Run this job once per day
     - cron: "0 0 * * *"

--- a/playground/docker-compose.fork.yml
+++ b/playground/docker-compose.fork.yml
@@ -110,7 +110,7 @@ services:
       - SOLVER_TIME_LIMIT=5
       - PRICE_ESTIMATION_DRIVERS=baseline|http://driver/baseline
       - NATIVE_PRICE_ESTIMATORS=baseline|http://driver/baseline
-      - DRIVERS=baseline|http://driver/baseline|0x2e6822f4Ab355E386d1A4fd34947ACE0F6f344a7
+      - DRIVERS=baseline|http://driver/baseline|0xa0Ee7A142d267C1f36714E4a8F75612F20a79720
       - SKIP_EVENT_SYNC=true
       - BASELINE_SOURCES=None
       - RUST_BACKTRACE=1

--- a/playground/docker-compose.fork.yml
+++ b/playground/docker-compose.fork.yml
@@ -110,7 +110,7 @@ services:
       - SOLVER_TIME_LIMIT=5
       - PRICE_ESTIMATION_DRIVERS=baseline|http://driver/baseline
       - NATIVE_PRICE_ESTIMATORS=baseline|http://driver/baseline
-      - DRIVERS=baseline|http://driver/baseline
+      - DRIVERS=baseline|http://driver/baseline|0x2e6822f4Ab355E386d1A4fd34947ACE0F6f344a7
       - SKIP_EVENT_SYNC=true
       - BASELINE_SOURCES=None
       - RUST_BACKTRACE=1

--- a/playground/docker-compose.fork.yml
+++ b/playground/docker-compose.fork.yml
@@ -1,7 +1,7 @@
 version: "3.9"
 services:
   chain:
-    image: ghcr.io/foundry-rs/foundry:latest
+    image: ghcr.io/foundry-rs/foundry:stable
     restart: always
     entrypoint: /usr/local/bin/anvil
     command: --fork-url ${ETH_RPC_URL} --block-time 12

--- a/playground/docker-compose.fork.yml
+++ b/playground/docker-compose.fork.yml
@@ -108,9 +108,9 @@ services:
       - NATIVE_PRICE_CACHE_MAX_UPDATE_SIZE=100
       - NATIVE_PRICE_CACHE_MAX_AGE=20m
       - SOLVER_TIME_LIMIT=5
-      - PRICE_ESTIMATION_DRIVERS=baseline|http://driver/baseline|0x2e6822f4Ab355E386d1A4fd34947ACE0F6f344a7
-      - NATIVE_PRICE_ESTIMATORS=baseline|http://driver/baseline|0x2e6822f4Ab355E386d1A4fd34947ACE0F6f344a7
-      - DRIVERS=baseline|http://driver/baseline|0x2e6822f4Ab355E386d1A4fd34947ACE0F6f344a7
+      - PRICE_ESTIMATION_DRIVERS=baseline|http://driver/baseline
+      - NATIVE_PRICE_ESTIMATORS=baseline|http://driver/baseline
+      - DRIVERS=baseline|http://driver/baseline
       - SKIP_EVENT_SYNC=true
       - BASELINE_SOURCES=None
       - RUST_BACKTRACE=1

--- a/playground/docker-compose.fork.yml
+++ b/playground/docker-compose.fork.yml
@@ -108,9 +108,9 @@ services:
       - NATIVE_PRICE_CACHE_MAX_UPDATE_SIZE=100
       - NATIVE_PRICE_CACHE_MAX_AGE=20m
       - SOLVER_TIME_LIMIT=5
-      - PRICE_ESTIMATION_DRIVERS=baseline|http://driver/baseline
-      - NATIVE_PRICE_ESTIMATORS=baseline|http://driver/baseline
-      - DRIVERS=baseline|http://driver/baseline
+      - PRICE_ESTIMATION_DRIVERS=baseline|http://driver/baseline|0x2e6822f4Ab355E386d1A4fd34947ACE0F6f344a7
+      - NATIVE_PRICE_ESTIMATORS=baseline|http://driver/baseline|0x2e6822f4Ab355E386d1A4fd34947ACE0F6f344a7
+      - DRIVERS=baseline|http://driver/baseline|0x2e6822f4Ab355E386d1A4fd34947ACE0F6f344a7
       - SKIP_EVENT_SYNC=true
       - BASELINE_SOURCES=None
       - RUST_BACKTRACE=1


### PR DESCRIPTION
# Description
It was noticed by @ahhda that the test playground CI job [started to fail constantly](https://github.com/cowprotocol/services/actions/runs/12898722916). Seems like one of the nightly [foundry-rs releases](https://github.com/foundry-rs/foundry/releases) was the main reason for this. Even though the [stable](https://github.com/foundry-rs/foundry/releases/tag/stable) release is marked as `latest`, according to the logs, a dev version of `anvil` was used.

# Changes

- [ ] Switch from the `latest` to `stable` version.
- [ ] Fix autopilot driver config updated due to https://github.com/cowprotocol/services/pull/3065

## How to test
https://github.com/cowprotocol/services/actions/runs/13018157686?pr=3254
