### PR TITLE
[EASY] Adjust driver's auction preprocessing metric

### DIFF
--- a/crates/driver/src/infra/api/routes/solve/mod.rs
+++ b/crates/driver/src/infra/api/routes/solve/mod.rs
@@ -34,7 +34,11 @@ async fn route(
         let competition = state.competition();
         let auction = state
             .pre_processor()
-            .prioritize(auction, &competition.solver.account().address())
+            .prioritize(
+                auction,
+                competition.solver.name(),
+                &competition.solver.account().address(),
+            )
             .await;
         let result = competition.solve(auction).await;
         // Solving takes some time, so there is a chance for the settlement queue to

--- a/crates/driver/src/infra/observe/metrics.rs
+++ b/crates/driver/src/infra/observe/metrics.rs
@@ -24,7 +24,7 @@ pub struct Metrics {
     pub bad_tokens_detected: prometheus::IntCounterVec,
     /// Time spent in the auction preprocessing stage.
     #[metric(
-        labels("stage"),
+        labels("solver", "auction_preprocessing_stage"),
         buckets(
             0.01, 0.05, 0.1, 0.25, 0.5, 0.75, 1.0, 1.25, 1.5, 1.75, 2.0, 2.5, 3.0, 3.5, 4.0, 5.0
         )


### PR DESCRIPTION
When creating a Grafana metric, I just realized that it is not possible to group the driver's auction preprocessing metric by the solver's name. This PR fixes it. Also, uses a more specific stage label name.