### PR TITLE
Driver's auction preprocessing `total` metric fix

### DIFF
--- a/crates/driver/src/domain/competition/auction.rs
+++ b/crates/driver/src/domain/competition/auction.rs
@@ -155,11 +155,6 @@ impl AuctionProcessor {
     /// unfillable orders. Fetches full app data for each order and returns an
     /// auction with updated orders.
     pub async fn prioritize(&self, auction: Auction, solver: &eth::H160) -> Auction {
-        let _timer = metrics::get()
-            .auction_preprocessing
-            .with_label_values(&["total"])
-            .start_timer();
-
         Auction {
             orders: self.prioritize_orders(&auction, solver).await,
             ..auction
@@ -202,6 +197,10 @@ impl AuctionProcessor {
             let start = std::time::Instant::now();
             orders.extend(rt.block_on(Self::cow_amm_orders(&eth, &tokens, &cow_amms, signature_validator.as_ref())));
             sorting::sort_orders(&mut orders, &tokens, &solver, &order_comparators);
+            let _timer = metrics::get()
+                .auction_preprocessing
+                .with_label_values(&["total"])
+                .start_timer();
             let (mut balances, mut app_data_by_hash) =
                 rt.block_on(async {
                     tokio::join!(


### PR DESCRIPTION
The auction preprocessing job runs only once for each auction, which is achieved by using a mutex where other threads wait until the running job is completed. The `total` metric was placed incorrectly outside the lock, accumulating a lot of useless information where the preprocessing is already done, and other threads just read the value. This PR fixes it by only populating the metric when the async job is really executed.