### PR TITLE
Filter in-flight cow-amms

### DIFF
--- a/crates/autopilot/src/run_loop.rs
+++ b/crates/autopilot/src/run_loop.rs
@@ -865,7 +865,13 @@ impl RunLoop {
         };
 
         auction.orders.retain(|o| !in_flight.contains(&o.uid));
-        tracing::debug!(orders = ?in_flight, "filtered out in-flight orders");
+        auction
+            .surplus_capturing_jit_order_owners
+            .retain(|owner| !in_flight.iter().any(|i| i.owner() == *owner));
+        tracing::debug!(
+            orders = ?in_flight,
+            "filtered out in-flight orders and surplus_capturing_jit_order_owners"
+        );
 
         auction
     }


### PR DESCRIPTION
# Description
Fixes: #3264

# Changes
Not only filters out in-flight orders from the auction but also `surplus_capturing_jit_order_owners` (i.e. cow amms) to help solvers avoid reverts caused by multiple different solvers trying to rebalance the same pool right after each other.

Luckily the `OrderUid` already contains the order owner so we only need to adjust the filtering logic.