### PR TITLE
Most recent native price token metadata

### DIFF
--- a/crates/orderbook/src/dto/mod.rs
+++ b/crates/orderbook/src/dto/mod.rs
@@ -5,11 +5,12 @@ pub use {
     auction::{Auction, AuctionId, AuctionWithId},
     order::Order,
 };
-use {serde::Serialize, serde_with::serde_as};
+use {bigdecimal::BigDecimal, serde::Serialize, serde_with::serde_as};
 
 #[serde_as]
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct TokenMetadata {
     pub first_trade_block: Option<u32>,
+    pub most_recent_native_price: Option<BigDecimal>,
 }


### PR DESCRIPTION
# Description
Currently, the Tenderly alert action sends emergency alerts on non-recent tokens even when just a few cents were transferred. This PR extends the token metadata API by providing the most recent token native price so the Tenderly action can decide whether an emergency must be sent.

# Changes
Since the response must be as quick as possible and the price accuracy is not important, the most recent native price from the DB is returned.

## How to test
A new DB test. Then, manual tests using the updated API.