### PR TITLE
[EASY] Improve mempool submission expired logs

### DIFF
--- a/crates/driver/src/domain/mempools.rs
+++ b/crates/driver/src/domain/mempools.rs
@@ -252,7 +252,10 @@ pub enum Error {
     },
     #[error("Simulation started reverting during submission, block number: {0:?}")]
     SimulationRevert(Option<BlockNo>),
-    #[error("Settlement did not get included in time")]
+    #[error(
+        "Settlement did not get included in time: submitted at block: {submitted_at_block}, \
+         submission deadline: {submission_deadline}, tx: {tx_id:?}"
+    )]
     Expired {
         tx_id: eth::TxId,
         submitted_at_block: BlockNo,

--- a/crates/driver/src/infra/notify/mod.rs
+++ b/crates/driver/src/infra/notify/mod.rs
@@ -107,7 +107,7 @@ pub fn executed(
         Ok(hash) => notification::Settlement::Success(hash.clone()),
         Err(Error::Revert { tx_id: hash, .. }) => notification::Settlement::Revert(hash.clone()),
         Err(Error::SimulationRevert { .. }) => notification::Settlement::SimulationRevert,
-        Err(Error::Expired) => notification::Settlement::Expired,
+        Err(Error::Expired { .. }) => notification::Settlement::Expired,
         Err(Error::Other(_) | Error::Disabled) => notification::Settlement::Fail,
     };
 

--- a/crates/driver/src/infra/observe/mod.rs
+++ b/crates/driver/src/infra/observe/mod.rs
@@ -340,7 +340,7 @@ pub fn mempool_executed(
     let result = match res {
         Ok(_) => "Success",
         Err(mempools::Error::Revert { .. } | mempools::Error::SimulationRevert { .. }) => "Revert",
-        Err(mempools::Error::Expired) => "Expired",
+        Err(mempools::Error::Expired { .. }) => "Expired",
         Err(mempools::Error::Other(_)) => "Other",
         Err(mempools::Error::Disabled) => "Disabled",
     };


### PR DESCRIPTION
Currently, it is not really convenient to debug mempool submission errors, especially when a tx has expired. This PR adds current block number info, when the submission started and the deadline. The expired tx hash would help search for the logs associated with it without looking into the code to find the required messages to filter in.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced error reporting for transactions that fail due to timing, now providing additional context such as transaction identifiers and associated timing details.
	- Improved logging during transaction submission and verification by including current block information, aiding in better traceability and monitoring.
- **Bug Fixes**
	- Updated error handling logic to accommodate additional data for the `Expired` error variant, allowing for more detailed future handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->