### PR TITLE
[TRIVIAL] Format hex encoding with derive_more

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1709,6 +1709,7 @@ dependencies = [
  "bigdecimal",
  "chrono",
  "const_format",
+ "derive_more 1.0.0",
  "futures",
  "hex",
  "maplit",

--- a/crates/database/Cargo.toml
+++ b/crates/database/Cargo.toml
@@ -9,6 +9,7 @@ license = "MIT OR Apache-2.0"
 bigdecimal = { workspace = true }
 chrono = { workspace = true, features = ["clock"] }
 const_format = "0.2.32"
+derive_more = { workspace = true }
 futures = { workspace = true }
 hex = { workspace = true }
 sqlx = { workspace = true }

--- a/crates/database/src/byte_array.rs
+++ b/crates/database/src/byte_array.rs
@@ -1,26 +1,19 @@
-use {
-    sqlx::{
-        encode::IsNull,
-        error::BoxDynError,
-        postgres::{PgArgumentBuffer, PgHasArrayType, PgTypeInfo, PgValueFormat, PgValueRef},
-        Decode,
-        Encode,
-        Postgres,
-        Type,
-    },
-    std::fmt::{self, Debug, Formatter},
+use sqlx::{
+    encode::IsNull,
+    error::BoxDynError,
+    postgres::{PgArgumentBuffer, PgHasArrayType, PgTypeInfo, PgValueFormat, PgValueRef},
+    Decode,
+    Encode,
+    Postgres,
+    Type,
 };
 
 /// Wrapper type for fixed size byte arrays compatible with sqlx's Postgres
 /// implementation.
-#[derive(Clone, Copy, Eq, PartialEq, Hash, sqlx::FromRow)]
-pub struct ByteArray<const N: usize>(pub [u8; N]);
-
-impl<const N: usize> Debug for ByteArray<N> {
-    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
-        write!(f, "0x{}", hex::encode(self.0))
-    }
-}
+#[derive(Clone, Copy, Eq, PartialEq, Hash, sqlx::FromRow, derive_more::Debug)]
+pub struct ByteArray<const N: usize>(
+    #[debug("0x{}", hex::encode::<&[u8]>(self.0.as_ref()))] pub [u8; N],
+);
 
 impl<const N: usize> Default for ByteArray<N> {
     fn default() -> Self {


### PR DESCRIPTION
# Description
Use the crate `derive_more` in order to avoid repeated `Debug` implementation for the hex encoding.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated project dependencies to enable enhanced internal functionality.
- **Refactor**
	- Improved how binary data is represented in debug outputs, making diagnostic information clearer for troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->