### PR TITLE
Fix the DB table rows metric

### DIFF
--- a/crates/autopilot/src/database/mod.rs
+++ b/crates/autopilot/src/database/mod.rs
@@ -41,22 +41,19 @@ impl Postgres {
         let metrics = Metrics::get();
 
         // update table row metrics
-        for &table in database::TABLES {
-            let mut ex = self.pool.acquire().await?;
-            let count = count_rows_in_table(&mut ex, table).await?;
-            metrics.table_rows.with_label_values(&[table]).set(count);
-        }
-
-        // update table row metrics
-        for &table in database::LARGE_TABLES {
-            let mut ex = self.pool.acquire().await?;
-            let count = estimate_rows_in_table(&mut ex, table).await?;
-            metrics.table_rows.with_label_values(&[table]).set(count);
+        let mut ex = self.pool.acquire().await?;
+        for table in database::all_tables(&mut ex).await? {
+            if database::LARGE_TABLES.iter().any(|t| *t == table) {
+                let count = estimate_rows_in_table(&mut ex, table).await?;
+                metrics.table_rows.with_label_values(&[table]).set(count);
+            } else {
+                let count = count_rows_in_table(&mut ex, table).await?;
+                metrics.table_rows.with_label_values(&[table]).set(count);
+            }
         }
 
         // update unused app data metric
         {
-            let mut ex = self.pool.acquire().await?;
             let count = count_unused_app_data(&mut ex).await?;
             metrics.unused_app_data.set(count);
         }

--- a/crates/database/Cargo.toml
+++ b/crates/database/Cargo.toml
@@ -14,6 +14,7 @@ hex = { workspace = true }
 sqlx = { workspace = true }
 strum = { workspace = true }
 serde_json = { workspace = true }
+tokio = { workspace = true, features = ["sync"] }
 
 [dev-dependencies]
 maplit = { workspace = true }

--- a/crates/database/src/lib.rs
+++ b/crates/database/src/lib.rs
@@ -66,7 +66,8 @@ pub async fn all_tables(ex: &mut PgConnection) -> sqlx::Result<&'static Vec<Stri
             struct TableName(String);
 
             const QUERY: &str = "SELECT tablename FROM pg_tables WHERE schemaname = 'public' AND \
-                                 tablename NOT LIKE '%flyway%' AND tablename NOT LIKE 'aws%'";
+                                 tablename NOT LIKE '%flyway%' AND tableowner NOT IN ('rdsadmin', \
+                                 'cow_protocol_admin')";
 
             let table_names: Vec<String> = sqlx::query_as(QUERY)
                 .fetch_all(ex)

--- a/crates/database/src/lib.rs
+++ b/crates/database/src/lib.rs
@@ -50,7 +50,12 @@ use {
 pub type PgTransaction<'a> = sqlx::Transaction<'a, sqlx::Postgres>;
 
 /// The names of potentially big volume tables we use in the db.
-pub const LARGE_TABLES: &[&str] = &["auction_prices", "order_events"];
+pub const LARGE_TABLES: &[&str] = &[
+    "auction_participants",
+    "auction_prices",
+    "order_events",
+    "proposed_trade_executions",
+];
 
 pub async fn all_tables(ex: &mut PgConnection) -> sqlx::Result<&'static Vec<String>> {
     static TABLES: OnceCell<Vec<String>> = OnceCell::const_new();
@@ -61,7 +66,7 @@ pub async fn all_tables(ex: &mut PgConnection) -> sqlx::Result<&'static Vec<Stri
             struct TableName(String);
 
             const QUERY: &str = "SELECT tablename FROM pg_tables WHERE schemaname = 'public' AND \
-                                 tablename NOT LIKE '%flyway%'";
+                                 tablename NOT LIKE '%flyway%' AND tablename NOT LIKE 'aws%'";
 
             let table_names: Vec<String> = sqlx::query_as(QUERY)
                 .fetch_all(ex)


### PR DESCRIPTION
Resurrects https://github.com/cowprotocol/services/pull/3266 with the following changes:

- ~~Exludes `aws`-related tables from the query that leads to the `insufficient rights` error.~~ Filters out tables with `rsadmin` and `cow_protocol_admin` owners. This should be a more robust approach since these roles can still add more tables, but adding more roles is controlled.
- Moves `auction_participants` and `proposed_trade_executions` to the `LARGE_TABLES` constant since their size is 4M+ and 8M+ already. That should slightly reduce the DB load since the count queries for these tables might take more than 5s.
- Slightly optimizes the estimate_rows_in_table query.