### PR TITLE
Use unbuffered transport for the Debug RPC API

### DIFF
--- a/crates/autopilot/src/infra/blockchain/mod.rs
+++ b/crates/autopilot/src/infra/blockchain/mod.rs
@@ -57,6 +57,7 @@ impl Rpc {
 #[derive(Clone)]
 pub struct Ethereum {
     web3: DynWeb3,
+    debug_api_web3: DynWeb3,
     chain: Chain,
     current_block: CurrentBlockWatcher,
     contracts: Contracts,
@@ -71,6 +72,7 @@ impl Ethereum {
     /// any initialization error.
     pub async fn new(
         web3: DynWeb3,
+        debug_api_web3: DynWeb3,
         chain: &Chain,
         url: Url,
         addresses: contracts::Addresses,
@@ -83,6 +85,7 @@ impl Ethereum {
                 .await
                 .expect("couldn't initialize current block stream"),
             web3,
+            debug_api_web3,
             chain: *chain,
             contracts,
         }
@@ -106,7 +109,7 @@ impl Ethereum {
         let (transaction, receipt, traces) = tokio::try_join!(
             self.web3.eth().transaction(hash.0.into()),
             self.web3.eth().transaction_receipt(hash.0),
-            self.web3.debug().transaction(hash.0),
+            self.debug_api_web3.debug().transaction(hash.0),
         )?;
         let transaction = transaction.ok_or(Error::TransactionNotFound)?;
         let receipt = receipt.ok_or(Error::TransactionNotFound)?;

--- a/crates/autopilot/src/run.rs
+++ b/crates/autopilot/src/run.rs
@@ -108,13 +108,13 @@ async fn unbuffered_ethrpc(url: &Url) -> infra::blockchain::Rpc {
 
 async fn ethereum(
     web3: DynWeb3,
-    debug_api_web3: DynWeb3,
+    unbuffered_web3: DynWeb3,
     chain: &Chain,
     url: Url,
     contracts: infra::blockchain::contracts::Addresses,
     poll_interval: Duration,
 ) -> infra::Ethereum {
-    infra::Ethereum::new(web3, debug_api_web3, chain, url, contracts, poll_interval).await
+    infra::Ethereum::new(web3, unbuffered_web3, chain, url, contracts, poll_interval).await
 }
 
 pub async fn start(args: impl Iterator<Item = String>) {
@@ -171,9 +171,7 @@ pub async fn run(args: Arguments) {
         );
     }
 
-    // Use unbuffered transport for the Debug API since not all providers support
-    // batched debug calls.
-    let debug_api_ethrpc = unbuffered_ethrpc(&args.shared.node_url).await;
+    let unbuffered_ethrpc = unbuffered_ethrpc(&args.shared.node_url).await;
     let ethrpc = ethrpc(&args.shared.node_url, &args.shared.ethrpc).await;
     let chain = ethrpc.chain();
     let web3 = ethrpc.web3().clone();
@@ -184,7 +182,7 @@ pub async fn run(args: Arguments) {
     };
     let eth = ethereum(
         web3.clone(),
-        debug_api_ethrpc.web3().clone(),
+        unbuffered_ethrpc.web3().clone(),
         &chain,
         url,
         contracts.clone(),


### PR DESCRIPTION
## Description

Since Alchemy is used as one of the failover providers and it doesn't support buffered debug RPC API, it is important to use unbuffered transport when sending `debug_traceTransaction` calls. Otherwise, this leads to failed RPC calls.

## Changes

The easiest workaround is to use 2 separate transports for different purposes. The current approach is not really flexible since it is not configurable, but in order to keep it simple, this should be acceptable.