### PR TITLE
Fixed playground check job

### DIFF
--- a/.github/workflows/playground-check.yaml
+++ b/.github/workflows/playground-check.yaml
@@ -37,6 +37,8 @@ jobs:
           cp playground/.env.example playground/.env
           sed -i -e 's/ETH_RPC_URL=.*/ETH_RPC_URL=$FORK_URL_MAINNET/g' playground/.env
           cat playground/.env
+          # check if RPC node is working on specified URL
+          curl $FORK_URL_MAINNET -X POST -H "Content-Type: application/json" --data '{"jsonrpc": "2.0", "method": "eth_blockNumber", "params": [],"id":1}'
 
       - name: Start docker containers
         id: containers

--- a/.github/workflows/playground-check.yaml
+++ b/.github/workflows/playground-check.yaml
@@ -60,6 +60,10 @@ jobs:
         with:
           dest: './logs'
 
+      - name: Collect chain container health logs on failure
+        if: failure()
+        run: docker inspect --format='{{json .State.Health}}' playground-chain-1 > ./logs/health-playground-chain-1.json
+
       - name: Tar logs
         if: failure()
         run: tar cvzf ./logs.tgz ./logs

--- a/.github/workflows/playground-check.yaml
+++ b/.github/workflows/playground-check.yaml
@@ -37,8 +37,6 @@ jobs:
           cp playground/.env.example playground/.env
           sed -i -e 's/ETH_RPC_URL=.*/ETH_RPC_URL=$FORK_URL_MAINNET/g' playground/.env
           cat playground/.env
-          # check if RPC node is working on specified URL
-          curl $FORK_URL_MAINNET -X POST -H "Content-Type: application/json" --data '{"jsonrpc": "2.0", "method": "eth_blockNumber", "params": [],"id":1}'
 
       - name: Start docker containers
         id: containers
@@ -60,9 +58,9 @@ jobs:
         with:
           dest: './logs'
 
-      - name: Collect chain container health logs on failure
+      - name: Collect playground-chain-1 container health logs on failure
         if: failure()
-        run: docker inspect --format='{{json .State.Health}}' playground-chain-1 > ./logs/health-playground-chain-1.json
+        run: docker inspect --format='{{json .State.Health}}' playground-chain-1 > ./logs/playground-chain-1-health-log.json
 
       - name: Tar logs
         if: failure()

--- a/playground/Dockerfile.chain
+++ b/playground/Dockerfile.chain
@@ -1,0 +1,3 @@
+FROM ghcr.io/foundry-rs/foundry:stable
+USER root
+RUN apt-get update && apt-get install -y wget

--- a/playground/Dockerfile.cowswap
+++ b/playground/Dockerfile.cowswap
@@ -35,8 +35,6 @@ ENV REACT_APP_NETWORK_URL_5=$REACT_APP_NETWORK_URL_5
 ENV REACT_APP_NETWORK_URL_100=$REACT_APP_NETWORK_URL_100
 ENV REACT_APP_ORDER_BOOK_URLS=$REACT_APP_ORDER_BOOK_URLS
 
-ENV NX_NO_CLOUD=true
-
 # Update environment variables based on "chain" and "ETH_RPC_URL" and build the frontend
 RUN if [ -n "$ETH_RPC_URL" ]; then \
         case "$CHAIN" in \
@@ -53,7 +51,7 @@ RUN if [ -n "$ETH_RPC_URL" ]; then \
                 REACT_APP_ORDER_BOOK_URLS=$(echo $REACT_APP_ORDER_BOOK_URLS | jq --arg chain "100" '.[$chain]="http://127.0.0.1:8080"') \
                 ;; \
         esac; \
-        yarn build --env REACT_APP_NETWORK_URL_1=$REACT_APP_NETWORK_URL_1 \
+        NODE_OPTIONS="--max-old-space-size=4096" NX_NO_CLOUD=true yarn build --env REACT_APP_NETWORK_URL_1=$REACT_APP_NETWORK_URL_1 \
                    --env REACT_APP_NETWORK_URL_5=$REACT_APP_NETWORK_URL_5 \
                    --env REACT_APP_NETWORK_URL_100=$REACT_APP_NETWORK_URL_100 \
                    --env REACT_APP_ORDER_BOOK_URLS="$REACT_APP_ORDER_BOOK_URLS"; \

--- a/playground/Dockerfile.cowswap
+++ b/playground/Dockerfile.cowswap
@@ -35,6 +35,8 @@ ENV REACT_APP_NETWORK_URL_5=$REACT_APP_NETWORK_URL_5
 ENV REACT_APP_NETWORK_URL_100=$REACT_APP_NETWORK_URL_100
 ENV REACT_APP_ORDER_BOOK_URLS=$REACT_APP_ORDER_BOOK_URLS
 
+ENV NX_NO_CLOUD=true
+
 # Update environment variables based on "chain" and "ETH_RPC_URL" and build the frontend
 RUN if [ -n "$ETH_RPC_URL" ]; then \
         case "$CHAIN" in \

--- a/playground/docker-compose.fork.yml
+++ b/playground/docker-compose.fork.yml
@@ -1,7 +1,8 @@
-version: "3.9"
 services:
   chain:
-    image: ghcr.io/foundry-rs/foundry:stable
+    build:
+      context: .
+      dockerfile: Dockerfile.chain
     restart: always
     entrypoint: /usr/local/bin/anvil
     command: --fork-url ${ETH_RPC_URL} --block-time 12


### PR DESCRIPTION
# Description
`playground-chain-1` container health check was failing due to lack of `wget` in Foundry image.
[Link](https://github.com/cowprotocol/services/actions/runs/13445138497) to the successful job with this PR fixes.

# Changes
- Added new `Dockerfile.chain` file which installs `wget` in the Foundry image. On 13.02.2025 Foundry changed `stable` tag on their image ([link](https://github.com/foundry-rs/foundry/pkgs/container/foundry/355379131?tag=stable)) to image without `wget` which is used in the healthcheck script. From that time our `playground-check` job started to fail.
- Added storing of healthcheck logs in artifacts in case of job failure for easier issue analysis.
- Disable use of NX Cloud cache for cowswap dockerfile build (`yarn build` command), as there are errors in the job log and local build fails: `Error when connecting to Nx Cloud. Code: ERR_BAD_REQUEST. Error: This Nx Cloud organization has been disabled due to exceeding the FREE plan.`, job [link](https://github.com/cowprotocol/services/actions/runs/13349782041/job/37284732426#step:7:4130).
- Increased javascript memory for cowswap dockerfile build (`yarn build` command), as there was na heap Out Of Memory error during local build.

## How to test
Run `playground-check` github workflow, or run playground locally.
