### PR TITLE
Settlement executions API

### DIFF
--- a/crates/database/src/settlement_executions.rs
+++ b/crates/database/src/settlement_executions.rs
@@ -4,6 +4,18 @@ use {
     sqlx::PgConnection,
 };
 
+#[derive(Debug, Clone, Eq, PartialEq, sqlx::FromRow)]
+pub struct ExecutionRow {
+    pub auction_id: AuctionId,
+    pub solver: Address,
+    pub start_timestamp: DateTime<Utc>,
+    pub end_timestamp: Option<DateTime<Utc>>,
+    pub start_block: i64,
+    pub end_block: Option<i64>,
+    pub deadline_block: i64,
+    pub outcome: Option<String>,
+}
+
 pub async fn insert(
     ex: &mut PgConnection,
     auction_id: AuctionId,
@@ -55,6 +67,25 @@ WHERE auction_id = $1 AND solver = $2
     Ok(())
 }
 
+pub async fn find(
+    ex: &mut PgConnection,
+    from_auction_id: AuctionId,
+    to_auction_id: AuctionId,
+) -> Result<Vec<ExecutionRow>, sqlx::Error> {
+    const QUERY: &str = r#"
+SELECT * FROM settlement_executions
+WHERE auction_id >= $1 AND auction_id <= $2
+    ;"#;
+
+    let rows = sqlx::query_as::<_, ExecutionRow>(QUERY)
+        .bind(from_auction_id)
+        .bind(to_auction_id)
+        .fetch_all(ex)
+        .await?;
+
+    Ok(rows)
+}
+
 #[cfg(test)]
 mod tests {
     use {
@@ -71,7 +102,8 @@ mod tests {
         let mut db = db.begin().await.unwrap();
         crate::clear_DANGER_(&mut db).await.unwrap();
 
-        let auction_id = 1;
+        let auction_id_a = 1;
+        let auction_id_b = 2;
         let solver_a = ByteArray([1u8; 20]);
         let solver_b = ByteArray([2u8; 20]);
         let start_timestamp = now_truncated_to_microseconds();
@@ -80,7 +112,7 @@ mod tests {
 
         insert(
             &mut db,
-            auction_id,
+            auction_id_a,
             solver_a,
             start_timestamp,
             start_block,
@@ -90,7 +122,7 @@ mod tests {
         .unwrap();
         insert(
             &mut db,
-            auction_id,
+            auction_id_a,
             solver_b,
             start_timestamp,
             start_block,
@@ -98,11 +130,21 @@ mod tests {
         )
         .await
         .unwrap();
+        insert(
+            &mut db,
+            auction_id_b,
+            solver_a,
+            start_timestamp,
+            start_block,
+            deadline_block,
+        )
+        .await
+        .unwrap();
 
-        let output = fetch(&mut db, auction_id).await.unwrap();
-        assert_eq!(output.len(), 2);
+        let output = find(&mut db, auction_id_a, auction_id_b).await.unwrap();
+        assert_eq!(output.len(), 3);
         let expected_a = ExecutionRow {
-            auction_id,
+            auction_id: auction_id_a,
             solver: solver_a,
             start_timestamp,
             end_timestamp: None,
@@ -112,8 +154,18 @@ mod tests {
             outcome: None,
         };
         let expected_b = ExecutionRow {
-            auction_id,
+            auction_id: auction_id_a,
             solver: solver_b,
+            start_timestamp,
+            end_timestamp: None,
+            start_block,
+            end_block: None,
+            deadline_block,
+            outcome: None,
+        };
+        let expected_c = ExecutionRow {
+            auction_id: auction_id_b,
+            solver: solver_a,
             start_timestamp,
             end_timestamp: None,
             start_block,
@@ -123,13 +175,14 @@ mod tests {
         };
         assert!(output.contains(&expected_a));
         assert!(output.contains(&expected_b));
+        assert!(output.contains(&expected_c));
 
         let end_timestamp_a = now_truncated_to_microseconds();
         let end_block_a = 8;
         let outcome_a = "success".to_string();
         update(
             &mut db,
-            auction_id,
+            auction_id_a,
             solver_a,
             end_timestamp_a,
             end_block_a,
@@ -143,7 +196,7 @@ mod tests {
         let outcome_b = "failure".to_string();
         update(
             &mut db,
-            auction_id,
+            auction_id_a,
             solver_b,
             end_timestamp_b,
             end_block_b,
@@ -152,10 +205,10 @@ mod tests {
         .await
         .unwrap();
 
-        let output = fetch(&mut db, auction_id).await.unwrap();
+        let output = find(&mut db, auction_id_a, auction_id_a).await.unwrap();
         assert_eq!(output.len(), 2);
         let expected_a = ExecutionRow {
-            auction_id,
+            auction_id: auction_id_a,
             solver: solver_a,
             start_timestamp,
             end_timestamp: Some(end_timestamp_a),
@@ -165,7 +218,7 @@ mod tests {
             outcome: Some(outcome_a),
         };
         let expected_b = ExecutionRow {
-            auction_id,
+            auction_id: auction_id_a,
             solver: solver_b,
             start_timestamp,
             end_timestamp: Some(end_timestamp_b),
@@ -176,27 +229,6 @@ mod tests {
         };
         assert!(output.contains(&expected_a));
         assert!(output.contains(&expected_b));
-    }
-
-    #[derive(Debug, Clone, Eq, PartialEq, sqlx::FromRow)]
-    struct ExecutionRow {
-        pub auction_id: AuctionId,
-        pub solver: Address,
-        pub start_timestamp: DateTime<Utc>,
-        pub end_timestamp: Option<DateTime<Utc>>,
-        pub start_block: i64,
-        pub end_block: Option<i64>,
-        pub deadline_block: i64,
-        pub outcome: Option<String>,
-    }
-
-    async fn fetch(
-        ex: &mut PgConnection,
-        auction_id: AuctionId,
-    ) -> Result<Vec<ExecutionRow>, sqlx::Error> {
-        const QUERY: &str = r#"SELECT * FROM settlement_executions WHERE auction_id = $1;"#;
-
-        sqlx::query_as(QUERY).bind(auction_id).fetch_all(ex).await
     }
 
     /// In the DB we use `timestampz` which doesn't store nanoseconds, so we

--- a/crates/orderbook/src/api.rs
+++ b/crates/orderbook/src/api.rs
@@ -22,6 +22,7 @@ mod get_native_price;
 mod get_order_by_uid;
 mod get_order_status;
 mod get_orders_by_tx;
+mod get_settlement_executions;
 mod get_solver_competition;
 mod get_token_metadata;
 mod get_total_surplus;
@@ -110,7 +111,11 @@ pub fn handle_all_routes(
         ),
         (
             "v1/get_token_metadata",
-            box_filter(get_token_metadata::get_token_metadata(database)),
+            box_filter(get_token_metadata::get_token_metadata(database.clone())),
+        ),
+        (
+            "v1/get_settlement_executions",
+            box_filter(get_settlement_executions::get(database)),
         ),
     ];
 

--- a/crates/orderbook/src/api/get_settlement_executions.rs
+++ b/crates/orderbook/src/api/get_settlement_executions.rs
@@ -1,0 +1,41 @@
+use {
+    crate::{database::Postgres, dto::AuctionId},
+    hyper::StatusCode,
+    serde::Deserialize,
+    std::convert::Infallible,
+    warp::{reply, Filter, Rejection},
+};
+
+pub fn get_settlement_executions_request(
+) -> impl Filter<Extract = ((AuctionId, AuctionId),), Error = Rejection> + Clone {
+    warp::path!("v1" / "settlement_executions")
+        .and(warp::query::<SettlementQuery>())
+        .and_then(|query: SettlementQuery| async move {
+            Result::<_, Infallible>::Ok((query.from_auction, query.to_auction))
+        })
+}
+
+#[derive(Debug, Deserialize)]
+pub struct SettlementQuery {
+    pub from_auction: AuctionId,
+    pub to_auction: AuctionId,
+}
+
+pub fn get(db: Postgres) -> impl Filter<Extract = (super::ApiReply,), Error = Rejection> + Clone {
+    get_settlement_executions_request().and_then(move |(from_auction, to_auction)| {
+        let db = db.clone();
+        async move {
+            let result = db
+                .find_settlement_executions(from_auction, to_auction)
+                .await;
+
+            Result::<_, Infallible>::Ok(match result {
+                Ok(executions) => reply::with_status(reply::json(&executions), StatusCode::OK),
+                Err(err) => {
+                    tracing::error!(?err, "get_settlement_executions");
+                    crate::api::internal_error_reply()
+                }
+            })
+        }
+    })
+}

--- a/crates/orderbook/src/api/get_settlement_executions.rs
+++ b/crates/orderbook/src/api/get_settlement_executions.rs
@@ -28,14 +28,20 @@ pub fn get(db: Postgres) -> impl Filter<Extract = (super::ApiReply,), Error = Re
             let result = db
                 .find_settlement_executions(from_auction, to_auction)
                 .await;
-
-            Result::<_, Infallible>::Ok(match result {
+            let response = match result {
                 Ok(executions) => reply::with_status(reply::json(&executions), StatusCode::OK),
                 Err(err) => {
-                    tracing::error!(?err, "get_settlement_executions");
+                    tracing::error!(
+                        ?err,
+                        ?from_auction,
+                        ?to_auction,
+                        "Failed to fetch settlement executions"
+                    );
                     crate::api::internal_error_reply()
                 }
-            })
+            };
+
+            Result::<_, Infallible>::Ok(response)
         }
     })
 }

--- a/crates/orderbook/src/database/orders.rs
+++ b/crates/orderbook/src/database/orders.rs
@@ -523,6 +523,7 @@ impl Postgres {
         })
     }
 
+    /// Retrieve all settlements executions for the given auction IDs range.
     pub async fn find_settlement_executions(
         &self,
         from_auction: AuctionId,

--- a/crates/orderbook/src/dto/mod.rs
+++ b/crates/orderbook/src/dto/mod.rs
@@ -6,8 +6,9 @@ pub use {
     order::Order,
 };
 use {
+    chrono::{DateTime, Utc},
     number::serialization::HexOrDecimalU256,
-    primitive_types::U256,
+    primitive_types::{H160, U256},
     serde::Serialize,
     serde_with::serde_as,
 };
@@ -19,4 +20,18 @@ pub struct TokenMetadata {
     pub first_trade_block: Option<u32>,
     #[serde_as(as = "Option<HexOrDecimalU256>")]
     pub native_price: Option<U256>,
+}
+
+#[serde_as]
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SettlementExecution {
+    pub auction_id: AuctionId,
+    pub solver: H160,
+    pub start_timestamp: DateTime<Utc>,
+    pub end_timestamp: Option<DateTime<Utc>>,
+    pub start_block: u32,
+    pub end_block: Option<u32>,
+    pub deadline_block: u32,
+    pub outcome: Option<String>,
 }


### PR DESCRIPTION
# Description
This is a follow-up to #3289, which adds a way to retrieve the settlement executions based on the auction ids range via the orderbook API. The API remains private to avoid unexpected usage.

## How to test
New DB tests. Staging manual test.