### PR TITLE
Debugging improvements

### DIFF
--- a/crates/autopilot/src/infra/persistence/mod.rs
+++ b/crates/autopilot/src/infra/persistence/mod.rs
@@ -96,7 +96,7 @@ impl Persistence {
             return;
         };
         if instance.auction.orders.is_empty() {
-            tracing::info!("skip upload of empty auction");
+            tracing::debug!("skip upload of empty auction");
             return;
         }
         tokio::spawn(
@@ -106,7 +106,7 @@ impl Persistence {
                     .await
                 {
                     Ok(key) => {
-                        tracing::info!(?key, "uploaded auction to s3");
+                        tracing::debug!(?key, "uploaded auction to s3");
                     }
                     Err(err) => {
                         tracing::warn!(?err, "failed to upload auction to s3");

--- a/crates/autopilot/src/run_loop.rs
+++ b/crates/autopilot/src/run_loop.rs
@@ -930,7 +930,10 @@ impl RunLoop {
                 .find_settlement_transaction(auction_id, solver)
                 .await
             {
-                Ok(Some(transaction)) => return Ok(transaction),
+                Ok(Some(transaction)) => {
+                    tracing::info!(?solver, tx_hash = ?transaction, "found settlement onchain");
+                    return Ok(transaction);
+                }
                 Ok(None) => {}
                 Err(err) => {
                     tracing::warn!(

--- a/crates/autopilot/src/run_loop.rs
+++ b/crates/autopilot/src/run_loop.rs
@@ -576,7 +576,7 @@ impl RunLoop {
                 if Self::is_solution_fair(participant, &solutions[index..], auction) {
                     Some(participant)
                 } else {
-                    tracing::warn!(
+                    tracing::info!(
                         invalidated = participant.driver().name,
                         "fairness check invalidated of solution"
                     );
@@ -724,7 +724,7 @@ impl RunLoop {
                 if matches!(err, SolveError::NoSolutions) {
                     tracing::debug!(driver = %driver.name, "solver found no solution");
                 } else {
-                    tracing::warn!(?err, driver = %driver.name, "solve error");
+                    tracing::debug!(?err, driver = %driver.name, "solve error");
                 }
                 vec![]
             }

--- a/crates/autopilot/src/run_loop.rs
+++ b/crates/autopilot/src/run_loop.rs
@@ -287,7 +287,12 @@ impl RunLoop {
             .filter(|participant| participant.is_winner())
         {
             let (driver, solution) = (winner.driver(), winner.solution());
-            tracing::info!(driver = %driver.name, solution = %solution.id(), "winner");
+            tracing::info!(
+                driver = %driver.name,
+                solution = %solution.id(),
+                orders = ?solution.order_ids(),
+                "winner"
+            );
 
             self.start_settlement_execution(
                 auction.id,

--- a/crates/autopilot/src/solvable_orders.rs
+++ b/crates/autopilot/src/solvable_orders.rs
@@ -494,7 +494,7 @@ async fn find_invalid_signature_orders(
             continue;
         }
         if let Err(err) = validations.next().unwrap() {
-            tracing::warn!(
+            tracing::debug!(
                 order =% order.metadata.uid, ?err,
                 "invalid EIP-1271 signature"
             );
@@ -662,7 +662,7 @@ async fn find_unsupported_tokens(
                     match bad_token.detect(token).await {
                         Ok(quality) => (!quality.is_good()).then_some(token),
                         Err(err) => {
-                            tracing::warn!(
+                            tracing::debug!(
                                 ?token,
                                 ?err,
                                 "unable to determine token quality, assume good"

--- a/crates/driver/src/infra/api/routes/settle/mod.rs
+++ b/crates/driver/src/infra/api/routes/settle/mod.rs
@@ -3,10 +3,7 @@ mod dto;
 use {
     crate::{
         domain::competition::auction,
-        infra::{
-            api::{self, Error, State},
-            observe,
-        },
+        infra::api::{self, Error, State},
     },
     tracing::Instrument,
 };
@@ -24,7 +21,6 @@ async fn route(
     let solver = state.solver().name().to_string();
 
     async move {
-        observe::settling();
         let result = state
             .competition()
             .settle(
@@ -33,7 +29,6 @@ async fn route(
                 req.submission_deadline_latest_block,
             )
             .await;
-        observe::settled(state.solver().name(), &result);
         result.map(|_| ()).map_err(Into::into)
     }
     .instrument(tracing::info_span!("/settle", solver, %auction_id))

--- a/crates/driver/src/infra/observe/mod.rs
+++ b/crates/driver/src/infra/observe/mod.rs
@@ -78,7 +78,7 @@ pub fn solutions(
         .iter()
         .any(|s| !s.is_empty(surplus_capturing_jit_order_owners))
     {
-        tracing::info!(?solutions, "computed solutions");
+        tracing::debug!(?solutions, "computed solutions");
     } else {
         tracing::debug!("no solutions");
     }
@@ -155,7 +155,7 @@ pub fn scoring_failed(solver: &solver::Name, err: &solution::error::Scoring) {
 
 /// Observe the settlement score.
 pub fn score(settlement: &Settlement, score: &eth::Ether) {
-    tracing::info!(
+    tracing::debug!(
         solution = ?settlement.solution(),
         score = ?score,
         "scored settlement"
@@ -165,7 +165,7 @@ pub fn score(settlement: &Settlement, score: &eth::Ether) {
 // Observe that the winning settlement started failing upon arrival of a new
 // block
 pub fn winner_voided(block: BlockInfo, err: &simulator::RevertError) {
-    tracing::warn!(block = block.number, ?err, "solution reverts on new block");
+    tracing::debug!(block = block.number, ?err, "solution reverts on new block");
 }
 
 pub fn revealing() {
@@ -220,7 +220,7 @@ pub fn settled(solver: &solver::Name, result: &Result<competition::Settled, comp
 pub fn solved(solver: &solver::Name, result: &Result<Option<Solved>, competition::Error>) {
     match result {
         Ok(Some(solved)) => {
-            tracing::info!(?solved, "solved auction");
+            tracing::debug!(?solved, "solved auction");
             metrics::get()
                 .solutions
                 .with_label_values(&[solver.as_str(), "Success"])
@@ -234,7 +234,7 @@ pub fn solved(solver: &solver::Name, result: &Result<Option<Solved>, competition
                 .inc();
         }
         Err(err) => {
-            tracing::warn!(?err, "failed to solve auction");
+            tracing::debug!(?err, "failed to solve auction");
             metrics::get()
                 .solutions
                 .with_label_values(&[solver.as_str(), competition_error(err)])
@@ -247,14 +247,14 @@ pub fn solved(solver: &solver::Name, result: &Result<Option<Solved>, competition
 pub fn quoted(solver: &solver::Name, order: &quote::Order, result: &Result<Quote, quote::Error>) {
     match result {
         Ok(quote) => {
-            tracing::info!(?order, ?quote, "quoted order");
+            tracing::debug!(?order, ?quote, "quoted order");
             metrics::get()
                 .quotes
                 .with_label_values(&[solver.as_str(), "Success"])
                 .inc();
         }
         Err(err) => {
-            tracing::warn!(?order, ?err, "failed to quote order");
+            tracing::debug!(?order, ?err, "failed to quote order");
             metrics::get()
                 .quotes
                 .with_label_values(&[

--- a/crates/orderbook/src/api/post_quote.rs
+++ b/crates/orderbook/src/api/post_quote.rs
@@ -29,7 +29,7 @@ pub fn post_quote(
                 .await
                 .map_err(OrderQuoteErrorWrapper);
             if let Err(err) = &result {
-                tracing::warn!(?err, ?request, "post_quote error");
+                tracing::debug!(?err, ?request, "post_quote error");
             }
             Result::<_, Infallible>::Ok(convert_json_response(result))
         }

--- a/crates/rate-limit/src/lib.rs
+++ b/crates/rate-limit/src/lib.rs
@@ -221,7 +221,7 @@ impl RateLimiter {
             .times_rate_limited(Instant::now(), &self.name);
         let times_rate_limited = match times_rate_limited {
             None => {
-                tracing::warn!(?self.name, "dropping task because API is currently rate limited");
+                tracing::debug!(?self.name, "dropping task because API is currently rate limited");
                 return Err(Error::RateLimited);
             }
             Some(times_rate_limited) => times_rate_limited,
@@ -234,7 +234,7 @@ impl RateLimiter {
                 .strategy()
                 .response_rate_limited(times_rate_limited, &self.name);
             if let Some(new_back_off) = new_back_off {
-                tracing::warn!(?self.name, ?new_back_off, "extended rate limiting");
+                tracing::debug!(?self.name, ?new_back_off, "extended rate limiting");
             }
         } else {
             self.strategy().response_ok(&self.name);

--- a/crates/refunder/src/lib.rs
+++ b/crates/refunder/src/lib.rs
@@ -72,7 +72,7 @@ pub async fn run(args: arguments::Arguments) {
         refunder_account,
     );
     loop {
-        tracing::info!("Staring a new refunding loop");
+        tracing::debug!("Starting a new refunding loop");
         match refunder.try_to_refund_all_eligble_orders().await {
             Ok(_) => {
                 track_refunding_loop_result("success");

--- a/crates/shared/src/bad_token/instrumented.rs
+++ b/crates/shared/src/bad_token/instrumented.rs
@@ -48,15 +48,11 @@ impl BadTokenDetecting for InstrumentedBadTokenDetector {
             // prometheus isn't very good for string based data so we simply log the bad
             // tokens/errors and get the information from Kibana when we need it.
             Err(err) => {
-                tracing::warn!(
-                    "bad token detection for {:?} returned error:\n{:?}",
-                    token,
-                    err
-                );
+                tracing::warn!(?token, ?err, "bad token detection failed");
                 "error"
             }
             Ok(quality @ TokenQuality::Bad { .. }) => {
-                tracing::warn!("bad token detection for {:?} returned {:?}", token, quality);
+                tracing::debug!(?token, ?quality, "bad token detected");
                 "bad"
             }
         };

--- a/crates/shared/src/price_estimation/trade_verifier.rs
+++ b/crates/shared/src/price_estimation/trade_verifier.rs
@@ -210,7 +210,7 @@ impl TradeVerifier {
                         jit_orders: trade.jit_orders(),
                     },
                 };
-                tracing::warn!(
+                tracing::debug!(
                     ?estimate,
                     ?err,
                     "quote used invalid zeroex RFQ order; pass verification anyway"
@@ -428,7 +428,7 @@ impl TradeVerifying for TradeVerifier {
                             jit_orders: trade.jit_orders(),
                         },
                     };
-                    tracing::warn!(
+                    tracing::debug!(
                         ?err,
                         estimate = ?trade,
                         "failed verification; returning unverified estimate"
@@ -436,7 +436,7 @@ impl TradeVerifying for TradeVerifier {
                     Ok(estimate)
                 }
                 None => {
-                    tracing::warn!(
+                    tracing::debug!(
                         ?err,
                         estimate = ?trade,
                         "failed verification and no gas estimate provided; discarding estimate"
@@ -445,7 +445,7 @@ impl TradeVerifying for TradeVerifier {
                 }
             },
             Err(err @ Error::TooInaccurate) => {
-                tracing::warn!("discarding quote because it's too inaccurate");
+                tracing::debug!("discarding quote because it's too inaccurate");
                 Err(err.into())
             }
         }

--- a/crates/solver/src/liquidity/slippage.rs
+++ b/crates/solver/src/liquidity/slippage.rs
@@ -58,7 +58,7 @@ impl SlippageContext<'_> {
                     relative
                 }
                 _ => {
-                    tracing::warn!(
+                    tracing::debug!(
                         input_token = ?execution.input_max.token,
                         output_token = ?execution.output.token,
                         "unable to compute capped slippage; falling back to relative slippage",


### PR DESCRIPTION
# Description
This PR tries to improve the usefulness of our logs a bit.

# Changes
- turned some `warn` into `debug` logs since they usually don't indicate a real problem
- turned some `debug` into `info` logs to starting making the query `log: "info"` return a good high level overview of each component
- slightly altered existing log messages
- added some new logs

## How to test
mostly check logs when running the e2e tests