### PR TITLE
[TRIVIAL] Do not log on the found misbehaving solvers empty collection

### DIFF
--- a/crates/autopilot/src/domain/competition/participation_guard/db.rs
+++ b/crates/autopilot/src/domain/competition/participation_guard/db.rs
@@ -183,6 +183,10 @@ impl SolverValidator {
             })
             .collect();
 
+        if non_settling_solver_names.is_empty() {
+            return;
+        }
+
         let log_message = match ban_reason {
             dto::notify::BanReason::UnsettledConsecutiveAuctions => "found non-settling solvers",
             dto::notify::BanReason::HighSettleFailureRate => {


### PR DESCRIPTION
Currently, the log produces a lot of noise and should not be printed on the empty collection.