### PR TITLE
DB-based solver participation guard query fix

### DIFF
--- a/crates/database/src/solver_competition.rs
+++ b/crates/database/src/solver_competition.rs
@@ -174,6 +174,7 @@ WITH
             SELECT DISTINCT ca.id AS auction_id
             FROM competition_auctions ca
             WHERE ca.deadline <= $1
+            ORDER BY ca.id DESC
             LIMIT $2
         ) latest_auctions
         JOIN proposed_solutions ps ON ps.auction_id = latest_auctions.auction_id


### PR DESCRIPTION
In one of the previous PRs, I removed the ordering which actually broke the logic.
https://github.com/cowprotocol/services/pull/3263#discussion_r1967467775
I actually can't remember why I decided to do so...