### PR TITLE
[TRIVIAL] `requested-timeout-on-problems` config camel-case

### DIFF
--- a/crates/autopilot/src/arguments.rs
+++ b/crates/autopilot/src/arguments.rs
@@ -524,13 +524,13 @@ impl FromStr for Solver {
                 }
                 Err(_) => {
                     requested_timeout_on_problems =
-                        value.to_lowercase() == "requested_timeout_on_problems";
+                        value.to_lowercase() == "requested-timeout-on-problems";
                 }
             }
         };
 
         if let Some(value) = parts.get(4) {
-            requested_timeout_on_problems = value.to_lowercase() == "requested_timeout_on_problems";
+            requested_timeout_on_problems = value.to_lowercase() == "requested-timeout-on-problems";
         }
 
         Ok(Self {
@@ -780,7 +780,7 @@ mod test {
     #[test]
     fn parse_driver_with_accepts_unsettled_blocking_flag() {
         let argument =
-            "name1|http://localhost:8080|0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2|requested_timeout_on_problems";
+            "name1|http://localhost:8080|0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2|requested-timeout-on-problems";
         let driver = Solver::from_str(argument).unwrap();
         let expected = Solver {
             name: "name1".into(),
@@ -796,7 +796,7 @@ mod test {
 
     #[test]
     fn parse_driver_with_threshold_and_accepts_unsettled_blocking_flag() {
-        let argument = "name1|http://localhost:8080|0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2|1000000000000000000|requested_timeout_on_problems";
+        let argument = "name1|http://localhost:8080|0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2|1000000000000000000|requested-timeout-on-problems";
         let driver = Solver::from_str(argument).unwrap();
         let expected = Solver {
             name: "name1".into(),

--- a/crates/e2e/src/setup/services.rs
+++ b/crates/e2e/src/setup/services.rs
@@ -224,7 +224,7 @@ impl<'a> Services<'a> {
             [
                 vec![
                     format!(
-                        "--drivers=test_solver|http://localhost:11088/test_solver|{}|requested_timeout_on_problems",
+                        "--drivers=test_solver|http://localhost:11088/test_solver|{}|requested-timeout-on-problems",
                         hex::encode(solver.address())
                     ),
                     "--price-estimation-drivers=test_quoter|http://localhost:11088/test_solver"


### PR DESCRIPTION
Switches to camel-case since it is already used in most of the cases.