### PR TITLE
Fix Dockerfile build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,9 @@ WORKDIR /src/
 
 # Install dependencies
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked apt-get update && \
-    apt-get install -y git libssl-dev pkg-config git
+    apt-get install -y git libssl-dev pkg-config
+# Install Rust toolchain
+RUN rustup install stable && rustup default stable
 
 # Copy and Build Code
 COPY . .


### PR DESCRIPTION
The Dockerfile build [has started failing](https://github.com/cowprotocol/services/actions/runs/13651510912/job/38164095331). While I don't see any changes in the [base image](https://github.com/rust-lang/docker-rust/blob/760aa127cc3da4d27851b67a08fed9e64df3e315/stable/bookworm/slim/Dockerfile), the following PR fixes the build.

Reproduced locally.