### PR TITLE
[EASY] Min won auctions participation guard threshold

### DIFF
--- a/crates/autopilot/src/arguments.rs
+++ b/crates/autopilot/src/arguments.rs
@@ -316,6 +316,15 @@ pub struct LowSettlingSolversFinderConfig {
     )]
     pub last_auctions_participation_count: u32,
 
+    /// The minimum number of winning solutions to start considering the solver.
+    #[clap(
+        id = "low_settling_min_wins_threshold",
+        long = "low-settling-min-wins-threshold",
+        env = "LOW_SETTLING_MIN_WINS_THRESHOLD",
+        default_value = "3"
+    )]
+    pub min_wins_threshold: u32,
+
     /// A max failure rate for a solver to remain eligible for
     /// participation in the competition. Otherwise, the solver will be
     /// banned.

--- a/crates/autopilot/src/domain/competition/participation_guard/db.rs
+++ b/crates/autopilot/src/domain/competition/participation_guard/db.rs
@@ -134,6 +134,7 @@ impl SolverValidator {
                 self.0
                     .low_settling_config
                     .solver_max_settlement_failure_rate,
+                self.0.low_settling_config.min_wins_threshold,
             )
             .await
         {

--- a/crates/autopilot/src/infra/persistence/mod.rs
+++ b/crates/autopilot/src/infra/persistence/mod.rs
@@ -885,6 +885,7 @@ impl Persistence {
         last_auctions_count: u32,
         current_block: u64,
         max_failure_rate: f64,
+        min_wins_threshold: u32,
     ) -> anyhow::Result<Vec<eth::Address>> {
         let mut ex = self.postgres.pool.acquire().await.context("acquire")?;
         let _timer = Metrics::get()
@@ -897,6 +898,7 @@ impl Persistence {
             last_auctions_count,
             current_block,
             max_failure_rate,
+            min_wins_threshold,
         )
         .await
         .context("solver_competition::find_low_settling_solvers")?

--- a/crates/database/src/solver_competition.rs
+++ b/crates/database/src/solver_competition.rs
@@ -165,6 +165,7 @@ pub async fn find_low_settling_solvers(
     last_auctions_count: u32,
     current_block: u64,
     max_failure_rate: f64,
+    min_wins_threshold: u32,
 ) -> Result<Vec<Address>, sqlx::Error> {
     const QUERY: &str = r#"
 WITH
@@ -191,12 +192,13 @@ WITH
     )
 SELECT solver
 FROM solver_settlement_counts
-WHERE (1 - (total_settlements::decimal / NULLIF(total_wins, 0))) > $3;
+WHERE total_wins >= $3 AND (1 - (total_settlements::decimal / NULLIF(total_wins, 0))) > $4;
     "#;
 
     sqlx::query_scalar(QUERY)
         .bind(sqlx::types::BigDecimal::from(current_block))
         .bind(i64::from(last_auctions_count))
+        .bind(i64::from(min_wins_threshold))
         .bind(max_failure_rate)
         .fetch_all(ex)
         .await
@@ -820,6 +822,7 @@ mod tests {
         let deadline_block = 2u64;
         let last_auctions_count = 100i64;
         let max_failure_ratio = 0.6;
+        let min_wins_threshold = 2;
         let mut solution_uid = 0;
 
         for auction_id in 1..=10 {
@@ -927,6 +930,7 @@ mod tests {
             u32::try_from(last_auctions_count).unwrap(),
             deadline_block,
             max_failure_ratio,
+            min_wins_threshold,
         )
         .await
         .unwrap();
@@ -934,6 +938,20 @@ mod tests {
         assert_eq!(result.len(), 2);
         assert!(result.contains(&low_settling_solver));
         assert!(result.contains(&non_settling_solver));
+
+        // Both won only 5 auctions. With threshold 6, no solver should be returned.
+        assert!(
+            find_low_settling_solvers(
+                &mut db,
+                u32::try_from(last_auctions_count).unwrap(),
+                deadline_block,
+                max_failure_ratio,
+                6,
+            )
+            .await
+            .unwrap()
+            .is_empty()
+        );
 
         // Low settling solver settles another auction
         let event = EventIndex {
@@ -956,6 +974,7 @@ mod tests {
             u32::try_from(last_auctions_count).unwrap(),
             deadline_block,
             max_failure_ratio,
+            min_wins_threshold,
         )
         .await
         .unwrap();


### PR DESCRIPTION
Currently, the db-statistics-based solver participation guard might ban a solver that won only 1 or 2 times in the last 100 auctions and failed to settle them. This is a very sensitive threshold, where the suggestion is to start considering the solver as low-settling that won at least 3 auctions among 100 latest. The value is configurable and currently equals the non-settling guard default config.