### PR TITLE
Adjust time limit for gas price estimation

### DIFF
--- a/crates/driver/src/domain/competition/auction.rs
+++ b/crates/driver/src/domain/competition/auction.rs
@@ -74,7 +74,7 @@ impl Auction {
             id,
             orders,
             tokens,
-            gas_price: eth.gas_price().await?,
+            gas_price: eth.gas_price(None).await?,
             deadline,
             surplus_capturing_jit_order_owners,
         })

--- a/crates/driver/src/domain/competition/solution/settlement.rs
+++ b/crates/driver/src/domain/competition/solution/settlement.rs
@@ -160,7 +160,7 @@ impl Settlement {
             simulator,
         )
         .await?;
-        let price = eth.gas_price().await?;
+        let price = eth.gas_price(None).await?;
         let gas = Gas::new(gas, eth.block_gas_limit(), price)?;
 
         // Ensure that the solver has sufficient balance for the settlement to be mined.

--- a/crates/driver/src/infra/blockchain/gas.rs
+++ b/crates/driver/src/infra/blockchain/gas.rs
@@ -4,11 +4,13 @@
 /// private submission networks are used.
 use {
     super::Error,
-    crate::infra::config::file::GasEstimatorType,
-    crate::{domain::eth, infra::mempool},
+    crate::{
+        domain::eth,
+        infra::{config::file::GasEstimatorType, mempool},
+    },
     ethcontract::dyns::DynWeb3,
     gas_estimation::{GasPriceEstimating, nativegasestimator::NativeGasEstimator},
-    std::sync::Arc,
+    std::{sync::Arc, time::Duration},
 };
 
 type MaxAdditionalTip = eth::U256;
@@ -77,9 +79,9 @@ impl GasPriceEstimator {
     /// If additional tip is configured, it will be added to the gas price. This
     /// is to increase the chance of a transaction being included in a block, in
     /// case private submission networks are used.
-    pub async fn estimate(&self) -> Result<eth::GasPrice, Error> {
+    pub async fn estimate(&self, time_limit: Option<Duration>) -> Result<eth::GasPrice, Error> {
         self.gas
-            .estimate()
+            .estimate_with_limits(21000., time_limit.unwrap_or(Duration::from_secs(30)))
             .await
             .map(|mut estimate| {
                 let estimate = match self.additional_tip {

--- a/crates/driver/src/infra/blockchain/gas.rs
+++ b/crates/driver/src/infra/blockchain/gas.rs
@@ -9,7 +9,12 @@ use {
         infra::{config::file::GasEstimatorType, mempool},
     },
     ethcontract::dyns::DynWeb3,
-    gas_estimation::{GasPriceEstimating, nativegasestimator::NativeGasEstimator},
+    gas_estimation::{
+        DEFAULT_GAS_LIMIT,
+        DEFAULT_TIME_LIMIT,
+        GasPriceEstimating,
+        nativegasestimator::NativeGasEstimator,
+    },
     std::{sync::Arc, time::Duration},
 };
 
@@ -81,7 +86,7 @@ impl GasPriceEstimator {
     /// case private submission networks are used.
     pub async fn estimate(&self, time_limit: Option<Duration>) -> Result<eth::GasPrice, Error> {
         self.gas
-            .estimate_with_limits(21000., time_limit.unwrap_or(Duration::from_secs(30)))
+            .estimate_with_limits(DEFAULT_GAS_LIMIT, time_limit.unwrap_or(DEFAULT_TIME_LIMIT))
             .await
             .map(|mut estimate| {
                 let estimate = match self.additional_tip {

--- a/crates/driver/src/infra/blockchain/mod.rs
+++ b/crates/driver/src/infra/blockchain/mod.rs
@@ -214,9 +214,9 @@ impl Ethereum {
             .map_err(Into::into)
     }
 
-    /// Gas price can be evaluated in the context of a deadline until which the
-    /// transaction is supposed to be included onchain. The shorter deadline,
-    /// the higher gas price is needed.
+    /// The gas price is determined based on the deadline by which the
+    /// transaction must be included on-chain. A shorter deadline requires a
+    /// higher gas price to increase the likelihood of timely inclusion.
     pub async fn gas_price(&self, time_limit: Option<Duration>) -> Result<eth::GasPrice, Error> {
         self.inner.gas.estimate(time_limit).await
     }

--- a/crates/driver/src/tests/setup/solver.rs
+++ b/crates/driver/src/tests/setup/solver.rs
@@ -466,7 +466,7 @@ impl Solver {
                 move |axum::extract::State(state): axum::extract::State<State>,
                  axum::extract::Json(req): axum::extract::Json<serde_json::Value>| async move {
                     let effective_gas_price = eth
-                        .gas_price()
+                        .gas_price(None)
                         .await
                         .unwrap()
                         .effective()


### PR DESCRIPTION
# Description
A follow up to https://github.com/cowprotocol/services/pull/3312

Currently, all gas prices in `driver` are determined by using the default time limit of 30s as targeted inclusion time - https://github.com/cowprotocol/gas-estimation/blob/main/src/lib.rs#L26

This is static and equal for all networks, always (even during volatility times, although one can argue that volatility is expected to be handled by gas estimators themselves, hopefully).

This PR implements defining this parameter based on the submission deadline, per each network.

In practice, solvers on different networks are given different number of blocks as submission deadline:
Mainnet - 3 blocks
Base - 20 blocks
Arbitrum - 40 blocks
Gnosis - 5 blocks
Sepolia - 5 blocks
Taken from https://aws-es.cow.fi/_dashboards/goto/ba5daa93d871ff3d7099d5e3462ddd28?security_tenant=global

This effectively means that this PR reduces the time limit from 30s to:
Mainnet - 3 * 12s / 2 = 18s
Base - 20 * 2s / 2 = 20s
Arbitrum - 40 * 0.25 / 2 = 5s
Gnosis - 5 * 5s / 2 = 12.5s
Sepolia - 5 * 12s / 2 = 30s

# Changes
<!-- List of detailed changes (how the change is accomplished) -->

- [ ] Make `time_limit` dynamic (effectively lower) so that the gas price is properly defined according to submission deadline

## How to test
This is a bit riskier change that could potentially increase the gas prices more than we expect. That said, all networks will be debugged/observed on staging first.

<!--
## Related Issues

Fixes #
-->