### PR TITLE
Fix driver gas estimator config reading

### DIFF
--- a/crates/driver/src/infra/config/file/mod.rs
+++ b/crates/driver/src/infra/config/file/mod.rs
@@ -646,16 +646,21 @@ fn default_number_of_orders_per_merged_solution() -> usize {
 
 #[derive(Clone, Debug, Deserialize)]
 #[serde(rename_all = "kebab-case", deny_unknown_fields)]
+#[serde(tag = "estimator")]
 pub enum GasEstimatorType {
+    #[serde(rename_all = "kebab-case")]
     Native {
         // Effective reward value to be selected from each individual block
         // Example: 20 means 20% of the transactions with the lowest gas price will be analyzed
+        #[serde(default = "default_max_reward_percentile")]
         max_reward_percentile: usize,
         // Economical priority fee to be selected from sorted individual block reward percentiles
         // This constitutes the part of priority fee that doesn't depend on the time_limit
+        #[serde(default = "default_min_block_percentile")]
         min_block_percentile: f64,
         // Urgent priority fee to be selected from sorted individual block reward percentiles
         // This constitutes the part of priority fee that depends on the time_limit
+        #[serde(default = "default_max_block_percentile")]
         max_block_percentile: f64,
     },
     Web3,
@@ -664,11 +669,23 @@ pub enum GasEstimatorType {
 impl Default for GasEstimatorType {
     fn default() -> Self {
         GasEstimatorType::Native {
-            max_reward_percentile: 20,
-            min_block_percentile: 30.,
-            max_block_percentile: 60.,
+            max_reward_percentile: default_max_reward_percentile(),
+            min_block_percentile: default_min_block_percentile(),
+            max_block_percentile: default_max_block_percentile(),
         }
     }
+}
+
+fn default_max_reward_percentile() -> usize {
+    20
+}
+
+fn default_min_block_percentile() -> f64 {
+    30.
+}
+
+fn default_max_block_percentile() -> f64 {
+    60.
 }
 
 /// Defines various strategies to prioritize orders.

--- a/crates/e2e/src/setup/colocation.rs
+++ b/crates/e2e/src/setup/colocation.rs
@@ -166,6 +166,9 @@ app-data-fetching-enabled = true
 orderbook-url = "http://localhost:8080"
 flashloans-enabled = true
 
+[gas-estimator]
+estimator = "web3"
+
 [contracts]
 gp-v2-settlement = "{:?}"
 weth = "{:?}"


### PR DESCRIPTION
# Description
Config indeed had to be changed to be properly parsed (As Ilya already pointed out in [previous PR](https://github.com/cowprotocol/services/pull/3316).

## How to test
Added gas estimator config into e2e setup, so you can try out with "native" as well.

<!--
## Related Issues

Fixes #
-->