### PR TITLE
Save blocks passed since first submission attempt

### DIFF
--- a/crates/driver/src/domain/eth/mod.rs
+++ b/crates/driver/src/domain/eth/mod.rs
@@ -344,9 +344,9 @@ pub struct TxId(pub H256);
 
 pub enum TxStatus {
     /// The transaction has been included and executed successfully.
-    Executed,
+    Executed { block: BlockNo },
     /// The transaction has been included but execution failed.
-    Reverted,
+    Reverted { block: BlockNo },
     /// The transaction has not been included yet.
     Pending,
 }

--- a/crates/driver/src/domain/eth/mod.rs
+++ b/crates/driver/src/domain/eth/mod.rs
@@ -344,9 +344,9 @@ pub struct TxId(pub H256);
 
 pub enum TxStatus {
     /// The transaction has been included and executed successfully.
-    Executed { block: BlockNo },
+    Executed { block_number: BlockNo },
     /// The transaction has been included but execution failed.
-    Reverted { block: BlockNo },
+    Reverted { block_number: BlockNo },
     /// The transaction has not been included yet.
     Pending,
 }

--- a/crates/driver/src/domain/mempools.rs
+++ b/crates/driver/src/domain/mempools.rs
@@ -120,7 +120,7 @@ impl Mempools {
                 let block = self.ethereum.current_block().borrow().number;
                 return Err(Error::SimulationRevert {
                     submitted_at_block: block,
-                    block_number: block,
+                    reverted_at_block: block,
                 });
             } else {
                 tracing::warn!(
@@ -152,7 +152,7 @@ impl Mempools {
                         return Err(Error::Revert {
                             tx_id: hash.clone(),
                             submitted_at_block,
-                            block_number: block.number,
+                            reverted_at_block: block.number,
                         })
                     }
                     TxStatus::Pending => {
@@ -192,7 +192,7 @@ impl Mempools {
                                 );
                                 return Err(Error::SimulationRevert {
                                     submitted_at_block,
-                                    block_number: block.number,
+                                    reverted_at_block: block.number,
                                 });
                             } else {
                                 tracing::warn!(?hash, ?err, "couldn't re-simulate tx");
@@ -267,16 +267,16 @@ pub enum RevertProtection {
 
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
-    #[error("Mined reverted transaction: {tx_id:?}, block number: {block_number}")]
+    #[error("Mined reverted transaction: {tx_id:?}, block number: {reverted_at_block}")]
     Revert {
         tx_id: eth::TxId,
         submitted_at_block: BlockNo,
-        block_number: BlockNo,
+        reverted_at_block: BlockNo,
     },
-    #[error("Simulation started reverting during submission, block number: {block_number}")]
+    #[error("Simulation started reverting during submission, block number: {reverted_at_block}")]
     SimulationRevert {
         submitted_at_block: BlockNo,
-        block_number: BlockNo,
+        reverted_at_block: BlockNo,
     },
     #[error(
         "Settlement did not get included in time: submitted at block: {submitted_at_block}, \

--- a/crates/driver/src/domain/mempools.rs
+++ b/crates/driver/src/domain/mempools.rs
@@ -117,9 +117,10 @@ impl Mempools {
                     ?err,
                     "settlement tx simulation reverted before submitting to the mempool"
                 );
+                let block = self.ethereum.current_block().borrow().number;
                 return Err(Error::SimulationRevert {
-                    submitted_at_block: self.ethereum.current_block().borrow().number,
-                    block_number: self.ethereum.current_block().borrow().number,
+                    submitted_at_block: block,
+                    block_number: block,
                 });
             } else {
                 tracing::warn!(

--- a/crates/driver/src/domain/mempools.rs
+++ b/crates/driver/src/domain/mempools.rs
@@ -118,6 +118,7 @@ impl Mempools {
                     "settlement tx simulation reverted before submitting to the mempool"
                 );
                 return Err(Error::SimulationRevert {
+                    submitted_at_block: self.ethereum.current_block().borrow().number,
                     block_number: self.ethereum.current_block().borrow().number,
                 });
             } else {
@@ -149,6 +150,7 @@ impl Mempools {
                     TxStatus::Reverted => {
                         return Err(Error::Revert {
                             tx_id: hash.clone(),
+                            submitted_at_block,
                             block_number: block.number,
                         })
                     }
@@ -188,6 +190,7 @@ impl Mempools {
                                     "tx started failing in mempool, cancelling"
                                 );
                                 return Err(Error::SimulationRevert {
+                                    submitted_at_block,
                                     block_number: block.number,
                                 });
                             } else {
@@ -266,10 +269,14 @@ pub enum Error {
     #[error("Mined reverted transaction: {tx_id:?}, block number: {block_number}")]
     Revert {
         tx_id: eth::TxId,
+        submitted_at_block: BlockNo,
         block_number: BlockNo,
     },
     #[error("Simulation started reverting during submission, block number: {block_number}")]
-    SimulationRevert { block_number: BlockNo },
+    SimulationRevert {
+        submitted_at_block: BlockNo,
+        block_number: BlockNo,
+    },
     #[error(
         "Settlement did not get included in time: submitted at block: {submitted_at_block}, \
          submission deadline: {submission_deadline}, tx: {tx_id:?}"

--- a/crates/driver/src/infra/blockchain/mod.rs
+++ b/crates/driver/src/infra/blockchain/mod.rs
@@ -249,11 +249,11 @@ impl Ethereum {
                 }) => {
                     if status.is_zero() {
                         eth::TxStatus::Reverted {
-                            block: eth::BlockNo(block.as_u64()),
+                            block_number: eth::BlockNo(block.as_u64()),
                         }
                     } else {
                         eth::TxStatus::Executed {
-                            block: eth::BlockNo(block.as_u64()),
+                            block_number: eth::BlockNo(block.as_u64()),
                         }
                     }
                 }

--- a/crates/driver/src/infra/blockchain/mod.rs
+++ b/crates/driver/src/infra/blockchain/mod.rs
@@ -244,12 +244,17 @@ impl Ethereum {
             .map(|result| match result {
                 Some(web3::types::TransactionReceipt {
                     status: Some(status),
+                    block_number: Some(block),
                     ..
                 }) => {
                     if status.is_zero() {
-                        eth::TxStatus::Reverted
+                        eth::TxStatus::Reverted {
+                            block: eth::BlockNo(block.as_u64()),
+                        }
                     } else {
-                        eth::TxStatus::Executed
+                        eth::TxStatus::Executed {
+                            block: eth::BlockNo(block.as_u64()),
+                        }
                     }
                 }
                 _ => eth::TxStatus::Pending,

--- a/crates/driver/src/infra/observe/metrics.rs
+++ b/crates/driver/src/infra/observe/metrics.rs
@@ -19,8 +19,8 @@ pub struct Metrics {
     /// The results of the mempool submission.
     #[metric(labels("mempool", "result"))]
     pub mempool_submission: prometheus::IntCounterVec,
-    /// The number of blocks passed between the first time submission was atempted and the error
-    /// detection.
+    /// The number of blocks passed between the first time submission was
+    /// atempted and the error detection.
     #[metric(labels("mempool", "error"))]
     pub mempool_submission_error_blocks_passed: prometheus::HistogramVec,
     /// How many tokens detected by specific solver and strategy.

--- a/crates/driver/src/infra/observe/metrics.rs
+++ b/crates/driver/src/infra/observe/metrics.rs
@@ -19,6 +19,10 @@ pub struct Metrics {
     /// The results of the mempool submission.
     #[metric(labels("mempool", "result"))]
     pub mempool_submission: prometheus::IntCounterVec,
+    /// The number of blocks passed between the first time submission was atempted and the error
+    /// detection.
+    #[metric(labels("mempool", "error"))]
+    pub mempool_submission_error_blocks_passed: prometheus::HistogramVec,
     /// How many tokens detected by specific solver and strategy.
     #[metric(labels("solver", "strategy"))]
     pub bad_tokens_detected: prometheus::IntCounterVec,

--- a/crates/driver/src/infra/observe/metrics.rs
+++ b/crates/driver/src/infra/observe/metrics.rs
@@ -21,8 +21,8 @@ pub struct Metrics {
     pub mempool_submission: prometheus::IntCounterVec,
     /// The number of blocks passed between the first time submission was
     /// atempted and the error detection.
-    #[metric(labels("mempool", "error"))]
-    pub mempool_submission_error_blocks_passed: prometheus::HistogramVec,
+    #[metric(labels("mempool", "result"))]
+    pub mempool_submission_results_blocks_passed: prometheus::IntCounterVec,
     /// How many tokens detected by specific solver and strategy.
     #[metric(labels("solver", "strategy"))]
     pub bad_tokens_detected: prometheus::IntCounterVec,

--- a/crates/driver/src/infra/observe/mod.rs
+++ b/crates/driver/src/infra/observe/mod.rs
@@ -356,21 +356,21 @@ pub fn mempool_executed(
             submitted_at_block,
             included_in_block,
             ..
-        }) => Some(("success", &submitted_at_block.0, &included_in_block.0)),
+        }) => Some(("Success", &submitted_at_block.0, &included_in_block.0)),
         Err(mempools::Error::Revert {
             tx_id: _,
             submitted_at_block,
             reverted_at_block,
-        }) => Some(("revert", submitted_at_block, reverted_at_block)),
+        }) => Some(("Revert", submitted_at_block, reverted_at_block)),
         Err(mempools::Error::SimulationRevert {
             submitted_at_block,
             reverted_at_block,
-        }) => Some(("revert", submitted_at_block, reverted_at_block)),
+        }) => Some(("Revert", submitted_at_block, reverted_at_block)),
         Err(mempools::Error::Expired {
             tx_id: _,
             submitted_at_block,
             submission_deadline,
-        }) => Some(("timeout", submitted_at_block, submission_deadline)),
+        }) => Some(("Expired", submitted_at_block, submission_deadline)),
         Err(mempools::Error::Other(_)) => None,
         Err(mempools::Error::Disabled) => None,
     };

--- a/crates/driver/src/infra/observe/mod.rs
+++ b/crates/driver/src/infra/observe/mod.rs
@@ -356,12 +356,12 @@ pub fn mempool_executed(
         Err(mempools::Error::Revert {
             tx_id: _,
             submitted_at_block,
-            block_number,
-        }) => Some(block_number.saturating_sub(*submitted_at_block)),
+            reverted_at_block,
+        }) => Some(reverted_at_block.saturating_sub(*submitted_at_block)),
         Err(mempools::Error::SimulationRevert {
             submitted_at_block,
-            block_number,
-        }) => Some(block_number.saturating_sub(*submitted_at_block)),
+            reverted_at_block,
+        }) => Some(reverted_at_block.saturating_sub(*submitted_at_block)),
         Err(mempools::Error::Expired {
             tx_id: _,
             submitted_at_block,


### PR DESCRIPTION
# Description
New metric that saves the number of blocks passed between the first submission attempt and the block at which the error is detected.

This metric should tell us more whether the error is caused by MEVBlocker being down and not processing transactions (in this case we would expect high value for blocks passed) or it's caused by high price volatility which should result in revert in one or two blocks just after the submission started (in most cases).