### PR TITLE
Return error on order replacement when it's not safe

### DIFF
--- a/crates/database/src/solver_competition.rs
+++ b/crates/database/src/solver_competition.rs
@@ -71,7 +71,8 @@ LIMIT $1
     ;"#;
     sqlx::query_as(QUERY)
         .bind(i64::from(latest_competitions_count))
-        .fetch_all(ex).await
+        .fetch_all(ex)
+        .await
 }
 
 pub async fn load_latest_competition(

--- a/crates/e2e/tests/e2e/replace_order.rs
+++ b/crates/e2e/tests/e2e/replace_order.rs
@@ -149,7 +149,7 @@ async fn try_replace_active_order_test(web3: Web3) {
     );
     let response = services.create_order(&new_order).await;
     let (error_code, _) = response.err().unwrap();
-    assert_eq!(error_code, StatusCode::UNAUTHORIZED);
+    assert_eq!(error_code, StatusCode::BAD_REQUEST);
 }
 
 async fn try_replace_someone_else_order_test(web3: Web3) {

--- a/crates/e2e/tests/e2e/replace_order.rs
+++ b/crates/e2e/tests/e2e/replace_order.rs
@@ -2,7 +2,7 @@ use {
     e2e::{setup::*, tx}, ethcontract::prelude::U256, model::{
         order::{OrderCreation, OrderCreationAppData, OrderKind, OrderStatus},
         signature::EcdsaSigningScheme,
-    }, orderbook::{api::IntoWarpReply, orderbook::{AddOrderError, OrderReplacementError}}, reqwest::StatusCode, secp256k1::SecretKey, shared::ethrpc::Web3, warp::reply::Reply, web3::signing::SecretKeyRef
+    }, orderbook::{api::IntoWarpReply, orderbook::OrderReplacementError}, reqwest::StatusCode, secp256k1::SecretKey, shared::ethrpc::Web3, warp::reply::Reply, web3::signing::SecretKeyRef
 };
 
 #[tokio::test]

--- a/crates/e2e/tests/e2e/replace_order.rs
+++ b/crates/e2e/tests/e2e/replace_order.rs
@@ -1,8 +1,16 @@
 use {
-    e2e::{setup::*, tx}, ethcontract::prelude::U256, model::{
+    e2e::{setup::*, tx},
+    ethcontract::prelude::U256,
+    model::{
         order::{OrderCreation, OrderCreationAppData, OrderKind, OrderStatus},
         signature::EcdsaSigningScheme,
-    }, orderbook::{api::IntoWarpReply, orderbook::OrderReplacementError}, reqwest::StatusCode, secp256k1::SecretKey, shared::ethrpc::Web3, warp::reply::Reply, web3::signing::SecretKeyRef
+    },
+    orderbook::{api::IntoWarpReply, orderbook::OrderReplacementError},
+    reqwest::StatusCode,
+    secp256k1::SecretKey,
+    shared::ethrpc::Web3,
+    warp::reply::Reply,
+    web3::signing::SecretKeyRef,
 };
 
 #[tokio::test]
@@ -133,19 +141,18 @@ async fn try_replace_active_order_test(web3: Web3) {
     );
     let response = services.create_order(&new_order).await;
     let (error_code, error_message) = response.err().unwrap();
-    
+
     assert_eq!(error_code, StatusCode::BAD_REQUEST);
 
-    let expected_response =  OrderReplacementError::OldOrderActivelyBidOn
+    let expected_response = OrderReplacementError::OldOrderActivelyBidOn
         .into_warp_reply()
         .into_response()
         .into_body();
-    let expected_body_bytes = warp::hyper::body::to_bytes(expected_response).await.unwrap();
+    let expected_body_bytes = warp::hyper::body::to_bytes(expected_response)
+        .await
+        .unwrap();
     let expected_body = String::from_utf8(expected_body_bytes.to_vec()).unwrap();
-    assert_eq!(
-        error_message,
-        expected_body
-    );
+    assert_eq!(error_message, expected_body);
 }
 
 async fn try_replace_someone_else_order_test(web3: Web3) {

--- a/crates/e2e/tests/e2e/replace_order.rs
+++ b/crates/e2e/tests/e2e/replace_order.rs
@@ -25,13 +25,16 @@ async fn local_node_try_replace_someone_else_order() {
     run_test(try_replace_someone_else_order_test).await;
 }
 
+// TODO: The test is not ideal, as we actually want to test the replacement of
+// active orders as soon as they are being bid on, even before they are
+// executed. For that we would need the ability to mock the driver in e2e tests.
 #[tokio::test]
 #[ignore]
-async fn local_node_try_replace_active_order() {
-    run_test(try_replace_active_order_test).await;
+async fn local_node_try_replace_executed_order() {
+    run_test(try_replace_executed_order_test).await;
 }
 
-async fn try_replace_active_order_test(web3: Web3) {
+async fn try_replace_executed_order_test(web3: Web3) {
     let mut onchain = OnchainComponents::deploy(web3.clone()).await;
 
     let [solver] = onchain.make_solvers(to_wei(1)).await;

--- a/crates/orderbook/openapi.yml
+++ b/crates/orderbook/openapi.yml
@@ -1362,6 +1362,7 @@ components:
             - InvalidAppData
             - AppDataHashMismatch
             - AppdataFromMismatch
+            - OldOrderActivelyBidOn
         description:
           type: string
       required:

--- a/crates/orderbook/src/api/post_order.rs
+++ b/crates/orderbook/src/api/post_order.rs
@@ -281,7 +281,7 @@ impl IntoWarpReply for OrderReplacementError {
             OrderReplacementError::OldOrderActivelyBidOn => with_status(
                 super::error(
                     "OldOrderActivelyBidOn",
-                    "The old order is being actively bid on in recent auctions",
+                    "The old order is actively beign bid on in recent auctions",
                 ),
                 StatusCode::BAD_REQUEST,
             ),

--- a/crates/orderbook/src/api/post_order.rs
+++ b/crates/orderbook/src/api/post_order.rs
@@ -1,6 +1,6 @@
 use {
     crate::{
-        api::{error, extract_payload, ApiReply, IntoWarpReply},
+        api::{ApiReply, IntoWarpReply, error, extract_payload},
         orderbook::{AddOrderError, OrderReplacementError, Orderbook},
     },
     anyhow::Result,
@@ -17,7 +17,10 @@ use {
     },
     std::{convert::Infallible, sync::Arc},
     warp::{
-        hyper::StatusCode, reply::{self, with_status}, Filter, Rejection
+        Filter,
+        Rejection,
+        hyper::StatusCode,
+        reply::{self, with_status},
     },
 };
 
@@ -272,10 +275,7 @@ impl IntoWarpReply for OrderReplacementError {
                 StatusCode::BAD_REQUEST,
             ),
             OrderReplacementError::WrongOwner => with_status(
-                super::error(
-                    "WrongOwner",
-                    "Old and new orders have different signers",
-                ),
+                super::error("WrongOwner", "Old and new orders have different signers"),
                 StatusCode::UNAUTHORIZED,
             ),
             OrderReplacementError::OldOrderActivelyBidOn => with_status(
@@ -288,7 +288,7 @@ impl IntoWarpReply for OrderReplacementError {
             OrderReplacementError::Other(err) => {
                 tracing::error!(?err, "replace_order");
                 crate::api::internal_error_reply()
-            },
+            }
         }
     }
 }

--- a/crates/orderbook/src/api/post_order.rs
+++ b/crates/orderbook/src/api/post_order.rs
@@ -283,7 +283,7 @@ impl IntoWarpReply for OrderReplacementError {
                     "OldOrderActivelyBidOn",
                     "The old order is being actively bid on in recent auctions",
                 ),
-                StatusCode::UNAUTHORIZED,
+                StatusCode::BAD_REQUEST,
             ),
             OrderReplacementError::Other(err) => {
                 tracing::error!(?err, "replace_order");

--- a/crates/orderbook/src/api/post_order.rs
+++ b/crates/orderbook/src/api/post_order.rs
@@ -258,7 +258,7 @@ impl IntoWarpReply for AddOrderError {
                 super::error("InvalidAppData", err.to_string()),
                 StatusCode::BAD_REQUEST,
             ),
-            err @ AddOrderError::InvalidReplacement => reply::with_status(
+            AddOrderError::InvalidReplacement(err) => reply::with_status(
                 super::error("InvalidReplacement", err.to_string()),
                 StatusCode::UNAUTHORIZED,
             ),

--- a/crates/orderbook/src/arguments.rs
+++ b/crates/orderbook/src/arguments.rs
@@ -233,7 +233,11 @@ impl std::fmt::Display for Arguments {
         )?;
         writeln!(f, "app_data_size_limit: {}", app_data_size_limit)?;
         writeln!(f, "max_gas_per_order: {}", max_gas_per_order)?;
-        writeln!(f, "active_order_competition_threshold: {}", active_order_competition_threshold)?;
+        writeln!(
+            f,
+            "active_order_competition_threshold: {}",
+            active_order_competition_threshold
+        )?;
 
         Ok(())
     }

--- a/crates/orderbook/src/arguments.rs
+++ b/crates/orderbook/src/arguments.rs
@@ -137,6 +137,11 @@ pub struct Arguments {
     /// The maximum gas amount a single order can use for getting settled.
     #[clap(long, env, default_value = "8000000")]
     pub max_gas_per_order: u64,
+
+    /// The number of past solver competitions to look back at to determine
+    /// whether an order is actively being bid on.
+    #[clap(long, env, default_value = "2")]
+    pub active_order_competition_threshold: u32,
 }
 
 impl std::fmt::Display for Arguments {
@@ -167,6 +172,7 @@ impl std::fmt::Display for Arguments {
             app_data_size_limit,
             db_url,
             max_gas_per_order,
+            active_order_competition_threshold,
         } = self;
 
         write!(f, "{}", shared)?;
@@ -227,6 +233,7 @@ impl std::fmt::Display for Arguments {
         )?;
         writeln!(f, "app_data_size_limit: {}", app_data_size_limit)?;
         writeln!(f, "max_gas_per_order: {}", max_gas_per_order)?;
+        writeln!(f, "active_order_competition_threshold: {}", active_order_competition_threshold)?;
 
         Ok(())
     }

--- a/crates/orderbook/src/arguments.rs
+++ b/crates/orderbook/src/arguments.rs
@@ -140,7 +140,7 @@ pub struct Arguments {
 
     /// The number of past solver competitions to look back at to determine
     /// whether an order is actively being bid on.
-    #[clap(long, env, default_value = "2")]
+    #[clap(long, env, default_value = "5")]
     pub active_order_competition_threshold: u32,
 }
 

--- a/crates/orderbook/src/database/solver_competition.rs
+++ b/crates/orderbook/src/database/solver_competition.rs
@@ -97,18 +97,21 @@ impl SolverCompetitionStoring for Postgres {
 
         let mut ex = self.pool.acquire().await.map_err(anyhow::Error::from)?;
 
-        let latest_competitions = database::solver_competition::load_latest_competitions(&mut ex, latest_competitions_count)
-            .await
-            .context("solver_competition::load_latest_competitions")?
-            .into_iter()
-            .map(|row| {
-                deserialize_solver_competition(
-                    row.json,
-                    row.id,
-                    row.tx_hashes.iter().map(|hash| H256(hash.0)).collect(),
-                )
-            })
-            .collect::<Result<Vec<_>, _>>()?;
+        let latest_competitions = database::solver_competition::load_latest_competitions(
+            &mut ex,
+            latest_competitions_count,
+        )
+        .await
+        .context("solver_competition::load_latest_competitions")?
+        .into_iter()
+        .map(|row| {
+            deserialize_solver_competition(
+                row.json,
+                row.id,
+                row.tx_hashes.iter().map(|hash| H256(hash.0)).collect(),
+            )
+        })
+        .collect::<Result<Vec<_>, _>>()?;
 
         Ok(latest_competitions)
     }

--- a/crates/orderbook/src/database/solver_competition.rs
+++ b/crates/orderbook/src/database/solver_competition.rs
@@ -75,7 +75,7 @@ impl SolverCompetitionStoring for Postgres {
         let mut ex = self.pool.acquire().await.map_err(anyhow::Error::from)?;
         database::solver_competition::load_latest_competition(&mut ex)
             .await
-            .context("solver_competition::load_latest")?
+            .context("solver_competition::load_latest_competition")?
             .map(|row| {
                 deserialize_solver_competition(
                     row.json,
@@ -84,6 +84,33 @@ impl SolverCompetitionStoring for Postgres {
                 )
             })
             .ok_or(LoadSolverCompetitionError::NotFound)?
+    }
+
+    async fn load_latest_competitions(
+        &self,
+        latest_competitions_count: u32,
+    ) -> Result<Vec<SolverCompetitionAPI>, LoadSolverCompetitionError> {
+        let _timer = super::Metrics::get()
+            .database_queries
+            .with_label_values(&["load_latest_competitions"])
+            .start_timer();
+
+        let mut ex = self.pool.acquire().await.map_err(anyhow::Error::from)?;
+
+        let latest_competitions = database::solver_competition::load_latest_competitions(&mut ex, latest_competitions_count)
+            .await
+            .context("solver_competition::load_latest_competitions")?
+            .into_iter()
+            .map(|row| {
+                deserialize_solver_competition(
+                    row.json,
+                    row.id,
+                    row.tx_hashes.iter().map(|hash| H256(hash.0)).collect(),
+                )
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+
+        Ok(latest_competitions)
     }
 }
 

--- a/crates/orderbook/src/orderbook.rs
+++ b/crates/orderbook/src/orderbook.rs
@@ -205,7 +205,7 @@ pub enum OrderReplacementError {
     InvalidSignature,
     #[error("signer does not match older order owner")]
     WrongOwner,
-    #[error("old order is being actively bid on")]
+    #[error("old order is actively being bid on")]
     OldOrderActivelyBidOn,
     #[error(transparent)]
     Other(#[from] anyhow::Error),

--- a/crates/orderbook/src/orderbook.rs
+++ b/crates/orderbook/src/orderbook.rs
@@ -404,22 +404,25 @@ impl Orderbook {
             .scheme()
             .try_to_ecdsa_scheme()
             .ok_or(AddOrderError::InvalidReplacement(
-                OrderReplacementError::InvalidSignature
+                OrderReplacementError::InvalidSignature,
             ))?;
 
         // Verify that the new order is a valid replacement order by checking
         // that both the old and new orders have the same signer.
         if validated_new_order.metadata.owner != old_order.metadata.owner {
             return Err(AddOrderError::InvalidReplacement(
-                OrderReplacementError::WrongOwner
+                OrderReplacementError::WrongOwner,
             ));
         }
 
         // Verify that the old order is not being actively bid on by solvers,
         // to prevent the possible double spending of both orders.
-        if self.order_is_actively_bid_on(old_order.metadata.uid).await? {
+        if self
+            .order_is_actively_bid_on(old_order.metadata.uid)
+            .await?
+        {
             return Err(AddOrderError::InvalidReplacement(
-                OrderReplacementError::OldOrderActivelyBidOn
+                OrderReplacementError::OldOrderActivelyBidOn,
             ));
         }
 
@@ -436,7 +439,10 @@ impl Orderbook {
     async fn order_is_actively_bid_on(&self, order_uid: OrderUid) -> Result<bool> {
         // The number of past solver competitions we want to look back at
         const COMPETITIONS_COUNT: u32 = 2;
-        let latest_competitions = self.database.load_latest_competitions(COMPETITIONS_COUNT).await?;
+        let latest_competitions = self
+            .database
+            .load_latest_competitions(COMPETITIONS_COUNT)
+            .await?;
 
         let order_is_bid_on = latest_competitions
             .into_iter()

--- a/crates/orderbook/src/orderbook.rs
+++ b/crates/orderbook/src/orderbook.rs
@@ -446,7 +446,14 @@ impl Orderbook {
 
         let order_is_bid_on = latest_competitions
             .into_iter()
-            .flat_map(|competition| competition.common.auction.orders)
+            .flat_map(|competition| competition.common.solutions)
+            .flat_map(|solution| solution.orders)
+            .map(|order|
+                match order {
+                    solver_competition::Order::Colocated { id, .. } => id,
+                    solver_competition::Order::Legacy { id, ..} => id,
+                }
+            )
             .any(|uid| uid == order_uid);
 
         Ok(order_is_bid_on)

--- a/crates/orderbook/src/orderbook.rs
+++ b/crates/orderbook/src/orderbook.rs
@@ -449,12 +449,10 @@ impl Orderbook {
             .into_iter()
             .flat_map(|competition| competition.common.solutions)
             .flat_map(|solution| solution.orders)
-            .map(|order|
-                match order {
-                    solver_competition::Order::Colocated { id, .. } => id,
-                    solver_competition::Order::Legacy { id, ..} => id,
-                }
-            )
+            .map(|order| match order {
+                solver_competition::Order::Colocated { id, .. } => id,
+                solver_competition::Order::Legacy { id, .. } => id,
+            })
             .any(|uid| uid == order_uid);
 
         Ok(order_is_bid_on)
@@ -647,7 +645,7 @@ mod tests {
             domain_separator: Default::default(),
             settlement_contract: H160([0xba; 20]),
             app_data,
-            active_order_competition_threshold: Default::default()
+            active_order_competition_threshold: Default::default(),
         };
 
         // Different owner

--- a/crates/orderbook/src/run.rs
+++ b/crates/orderbook/src/run.rs
@@ -394,6 +394,7 @@ pub async fn run(args: Arguments) {
         postgres.clone(),
         order_validator.clone(),
         app_data.clone(),
+        args.active_order_competition_threshold,
     ));
 
     check_database_connection(orderbook.as_ref()).await;

--- a/crates/orderbook/src/solver_competition.rs
+++ b/crates/orderbook/src/solver_competition.rs
@@ -32,6 +32,16 @@ pub trait SolverCompetitionStoring: Send + Sync {
     async fn load_latest_competition(
         &self,
     ) -> Result<SolverCompetitionAPI, crate::solver_competition::LoadSolverCompetitionError>;
+
+    /// Retrieves the solver competitions for the most recent auctions.
+    ///
+    /// Returns the latest solver competitions. 
+    /// It may return fewer results than specified by `latest_competitions_count` 
+    /// if not enough solver competitions are found.
+    async fn load_latest_competitions(
+        &self,
+        latest_competitions_count: u32,
+    ) -> Result<Vec<SolverCompetitionAPI>, crate::solver_competition::LoadSolverCompetitionError>;
 }
 
 /// Possible errors when loading a solver competition by ID.

--- a/crates/orderbook/src/solver_competition.rs
+++ b/crates/orderbook/src/solver_competition.rs
@@ -35,9 +35,10 @@ pub trait SolverCompetitionStoring: Send + Sync {
 
     /// Retrieves the solver competitions for the most recent auctions.
     ///
-    /// Returns the latest solver competitions. 
-    /// It may return fewer results than specified by `latest_competitions_count` 
-    /// if not enough solver competitions are found.
+    /// Returns the latest solver competitions.
+    /// It may return fewer results than specified by
+    /// `latest_competitions_count` if not enough solver competitions are
+    /// found.
     async fn load_latest_competitions(
         &self,
         latest_competitions_count: u32,


### PR DESCRIPTION
# Description
We want to allow users to "edit" orders, implemented by canceling a previous order when creating a new one. We have a `replacedOrder` property for this.

One concern is that this could lead to double spending when the old order is part of the current auction and the winning solver intends to settle it.

The goal of this PR is to mitigate this issue as much as possible by checking whether any solver has bid on the original order in the last few auctions. The POST `/orders` method now returns a `400 Bad Request` in that case.

A follow-up PR can extend this logic to the cancellation endpoint. In this case, instead of rejecting the cancellation outright, we may prefer to return a warning message instead.

# Changes
- Added a new database operation `load_latest_competitions` to fetch all the competitions from the last N auctions.
- Updated order replacement logic in the orderbook to verify that the order is not included in any recent competitions (using the new `order_is_actively_bid_on` function).
- Introduced a more granular order replacement error specification via the new `OrderReplacementError` enum.
- Updated `openapi.yml` specification with a new error variant in `OrderPostError`.
- New orderbook argument `active_order_competition_threshold`.

## How to test
Created a new e2e scenario, `try_replace_active_order_test`, under the `replace_order` e2e module, which triggers the new error.

However, the ideal scenario would be to test this when the old order is included in any solution by using a mock solver that always returns a bad solution containing the old order. However, achieving this would require the ability to mock the driver in e2e tests, which we currently lack. A follow-up PR can address this.

## Related Issues

Fixes https://github.com/cowprotocol/services/issues/3315