### PR TITLE
Deduplicate full_order to model::Order conversion

### DIFF
--- a/crates/autopilot/src/database/auction.rs
+++ b/crates/autopilot/src/database/auction.rs
@@ -7,7 +7,6 @@ use {
     model::{order::Order, quote::QuoteId},
     num::ToPrimitive,
     shared::{
-        db_order_conversions::full_order_into_model_order,
         event_storing_helpers::{create_db_search_parameters, create_quote_row},
         order_quoting::{QuoteData, QuoteSearchParameters, QuoteStoring},
     },
@@ -78,8 +77,10 @@ impl Postgres {
         let orders: HashMap<domain::OrderUid, Order> =
             database::orders::solvable_orders(&mut ex, i64::from(min_valid_to))
                 .map(|result| match result {
-                    Ok(order) => full_order_into_model_order(order)
-                        .map(|order| (domain::OrderUid(order.metadata.uid.0), order)),
+                    Ok(order) => {
+                        shared::db_order_conversions::full_order_into_model_order(order, None)
+                            .map(|order| (domain::OrderUid(order.metadata.uid.0), order))
+                    }
                     Err(err) => Err(anyhow::Error::from(err)),
                 })
                 .try_collect()

--- a/crates/autopilot/src/database/auction.rs
+++ b/crates/autopilot/src/database/auction.rs
@@ -7,6 +7,7 @@ use {
     model::{order::Order, quote::QuoteId},
     num::ToPrimitive,
     shared::{
+        db_order_conversions::full_order_into_model_order,
         event_storing_helpers::{create_db_search_parameters, create_quote_row},
         order_quoting::{QuoteData, QuoteSearchParameters, QuoteStoring},
     },
@@ -77,10 +78,8 @@ impl Postgres {
         let orders: HashMap<domain::OrderUid, Order> =
             database::orders::solvable_orders(&mut ex, i64::from(min_valid_to))
                 .map(|result| match result {
-                    Ok(order) => {
-                        shared::db_order_conversions::full_order_into_model_order(order, None)
-                            .map(|order| (domain::OrderUid(order.metadata.uid.0), order))
-                    }
+                    Ok(order) => full_order_into_model_order(order, None)
+                        .map(|order| (domain::OrderUid(order.metadata.uid.0), order)),
                     Err(err) => Err(anyhow::Error::from(err)),
                 })
                 .try_collect()

--- a/crates/autopilot/src/infra/persistence/mod.rs
+++ b/crates/autopilot/src/infra/persistence/mod.rs
@@ -29,7 +29,6 @@ use {
     futures::{StreamExt, TryStreamExt},
     number::conversions::{big_decimal_to_u256, u256_to_big_decimal, u256_to_big_uint},
     primitive_types::H256,
-    shared::db_order_conversions::full_order_into_model_order,
     std::{
         collections::{HashMap, HashSet},
         ops::DerefMut,
@@ -485,7 +484,7 @@ impl Persistence {
                 after_timestamp,
             )
             .map(|result| match result {
-                Ok(order) => full_order_into_model_order(order)
+                Ok(order) => shared::db_order_conversions::full_order_into_model_order(order, None)
                     .map(|order| (domain::OrderUid(order.metadata.uid.0), order)),
                 Err(err) => Err(anyhow::Error::from(err)),
             })

--- a/crates/autopilot/src/infra/persistence/mod.rs
+++ b/crates/autopilot/src/infra/persistence/mod.rs
@@ -29,6 +29,7 @@ use {
     futures::{StreamExt, TryStreamExt},
     number::conversions::{big_decimal_to_u256, u256_to_big_decimal, u256_to_big_uint},
     primitive_types::H256,
+    shared::db_order_conversions::full_order_into_model_order,
     std::{
         collections::{HashMap, HashSet},
         ops::DerefMut,
@@ -484,7 +485,7 @@ impl Persistence {
                 after_timestamp,
             )
             .map(|result| match result {
-                Ok(order) => shared::db_order_conversions::full_order_into_model_order(order, None)
+                Ok(order) => full_order_into_model_order(order, None)
                     .map(|order| (domain::OrderUid(order.metadata.uid.0), order)),
                 Err(err) => Err(anyhow::Error::from(err)),
             })

--- a/crates/database/src/orders.rs
+++ b/crates/database/src/orders.rs
@@ -7,6 +7,7 @@ use {
         onchain_broadcasted_orders::OnchainOrderPlacementError,
         order_events::{OrderEvent, OrderEventLabel, insert_order_event},
     },
+    bigdecimal::Zero,
     futures::stream::BoxStream,
     sqlx::{
         PgConnection,
@@ -502,6 +503,18 @@ impl FullOrder {
             return valid_to;
         }
         self.valid_to
+    }
+
+    pub fn is_buy_order_filled(&self) -> bool {
+        !self.sum_buy.is_zero() && self.buy_amount == self.sum_buy
+    }
+
+    pub fn is_sell_order_filled(&self) -> bool {
+        if self.sum_sell.is_zero() {
+            return false;
+        }
+        let total_amount = &self.sum_sell - &self.sum_fee;
+        total_amount == self.sell_amount
     }
 }
 

--- a/crates/orderbook/src/database/orders.rs
+++ b/crates/orderbook/src/database/orders.rs
@@ -2,7 +2,6 @@ use {
     super::Postgres,
     crate::dto::TokenMetadata,
     anyhow::{Context as _, Result},
-    app_data::AppDataHash,
     async_trait::async_trait,
     bigdecimal::ToPrimitive,
     chrono::{DateTime, Utc},
@@ -14,43 +13,23 @@ use {
     ethcontract::H256,
     futures::{FutureExt, StreamExt, stream::TryStreamExt},
     model::{
-        order::{
-            EthflowData,
-            Interactions,
-            OnchainOrderData,
-            Order,
-            OrderClass,
-            OrderData,
-            OrderMetadata,
-            OrderStatus,
-            OrderUid,
-        },
-        signature::Signature,
+        order::{Order, OrderUid},
         time::now_in_epoch_seconds,
     },
-    num::Zero,
-    number::conversions::{big_decimal_to_big_uint, big_decimal_to_u256, u256_to_big_decimal},
+    number::conversions::{big_decimal_to_u256, u256_to_big_decimal},
     primitive_types::{H160, U256},
     shared::{
         db_order_conversions::{
-            buy_token_destination_from,
             buy_token_destination_into,
-            extract_interactions,
-            onchain_order_placement_error_from,
-            order_class_from,
             order_class_into,
-            order_kind_from,
             order_kind_into,
-            order_quote_into_model,
-            sell_token_source_from,
             sell_token_source_into,
-            signing_scheme_from,
             signing_scheme_into,
         },
         fee::FeeParameters,
         order_validation::{Amounts, LimitOrderCounting, is_order_outside_market_price},
     },
-    sqlx::{Connection, PgConnection, types::BigDecimal},
+    sqlx::{Connection, PgConnection},
     std::convert::TryInto,
 };
 
@@ -299,7 +278,7 @@ impl OrderStoring for Postgres {
         match orders::single_full_order_with_quote(&mut ex, &ByteArray(uid.0)).await? {
             Some(order_with_quote) => {
                 let (order, quote) = order_with_quote.into_order_and_quote();
-                Some(full_order_with_quote_into_model_order(
+                Some(shared::db_order_conversions::full_order_into_model_order(
                     order,
                     quote.as_ref(),
                 ))
@@ -487,375 +466,23 @@ impl LimitOrderCounting for Postgres {
     }
 }
 
-fn calculate_status(order: &FullOrder) -> OrderStatus {
-    match order.kind {
-        DbOrderKind::Buy => {
-            if is_buy_order_filled(&order.buy_amount, &order.sum_buy) {
-                return OrderStatus::Fulfilled;
-            }
-        }
-        DbOrderKind::Sell => {
-            if is_sell_order_filled(&order.sell_amount, &order.sum_sell, &order.sum_fee) {
-                return OrderStatus::Fulfilled;
-            }
-        }
-    }
-    if order.invalidated {
-        return OrderStatus::Cancelled;
-    }
-    if order.valid_to() < Utc::now().timestamp() {
-        return OrderStatus::Expired;
-    }
-    if order.presignature_pending {
-        return OrderStatus::PresignaturePending;
-    }
-    OrderStatus::Open
-}
-
 fn full_order_into_model_order(order: FullOrder) -> Result<Order> {
-    full_order_with_quote_into_model_order(order, None)
-}
-
-/// If quote is provided, then it is used to extract quote metadata field value.
-fn full_order_with_quote_into_model_order(
-    order: FullOrder,
-    quote: Option<&orders::Quote>,
-) -> Result<Order> {
-    let status = calculate_status(&order);
-    let pre_interactions = extract_interactions(&order, database::orders::ExecutionTime::Pre)?;
-    let post_interactions = extract_interactions(&order, database::orders::ExecutionTime::Post)?;
-    let ethflow_data = if let Some((refund_tx, user_valid_to)) = order.ethflow_data {
-        Some(EthflowData {
-            user_valid_to,
-            refund_tx_hash: refund_tx.map(|hash| H256(hash.0)),
-        })
-    } else {
-        None
-    };
-    let onchain_user = order.onchain_user.map(|onchain_user| H160(onchain_user.0));
-    let class = order_class_from(&order);
-    let onchain_placement_error = onchain_order_placement_error_from(&order);
-    let onchain_order_data = onchain_user.map(|onchain_user| OnchainOrderData {
-        sender: onchain_user,
-        placement_error: onchain_placement_error,
-    });
-    let metadata = OrderMetadata {
-        creation_date: order.creation_timestamp,
-        owner: H160(order.owner.0),
-        uid: OrderUid(order.uid.0),
-        available_balance: Default::default(),
-        executed_buy_amount: big_decimal_to_big_uint(&order.sum_buy)
-            .context("executed buy amount is not an unsigned integer")?,
-        executed_sell_amount: big_decimal_to_big_uint(&order.sum_sell)
-            .context("executed sell amount is not an unsigned integer")?,
-        // Executed fee amounts and sell amounts before fees are capped by
-        // order's fee and sell amounts, and thus can always fit in a `U256`
-        // - as it is limited by the order format.
-        executed_sell_amount_before_fees: big_decimal_to_u256(&(order.sum_sell - &order.sum_fee))
-            .context(
-            "executed sell amount before fees does not fit in a u256",
-        )?,
-        executed_fee_amount: big_decimal_to_u256(&order.sum_fee)
-            .context("executed fee amount is not a valid u256")?,
-        executed_fee: big_decimal_to_u256(&order.executed_fee)
-            .context("executed fee is not a valid u256")?,
-        executed_fee_token: H160(order.executed_fee_token.0),
-        invalidated: order.invalidated,
-        status,
-        is_liquidity_order: class == OrderClass::Liquidity,
-        class,
-        settlement_contract: H160(order.settlement_contract.0),
-        ethflow_data,
-        onchain_user,
-        onchain_order_data,
-        full_app_data: order
-            .full_app_data
-            .map(String::from_utf8)
-            .transpose()
-            .context("full app data isn't utf-8")?,
-        quote: quote.map(order_quote_into_model).transpose()?,
-    };
-    let data = OrderData {
-        sell_token: H160(order.sell_token.0),
-        buy_token: H160(order.buy_token.0),
-        receiver: order.receiver.map(|address| H160(address.0)),
-        sell_amount: big_decimal_to_u256(&order.sell_amount).context("sell_amount is not U256")?,
-        buy_amount: big_decimal_to_u256(&order.buy_amount).context("buy_amount is not U256")?,
-        valid_to: order.valid_to.try_into().context("valid_to is not u32")?,
-        app_data: AppDataHash(order.app_data.0),
-        fee_amount: big_decimal_to_u256(&order.fee_amount).context("fee_amount is not U256")?,
-        kind: order_kind_from(order.kind),
-        partially_fillable: order.partially_fillable,
-        sell_token_balance: sell_token_source_from(order.sell_token_balance),
-        buy_token_balance: buy_token_destination_from(order.buy_token_balance),
-    };
-    let signing_scheme = signing_scheme_from(order.signing_scheme);
-    let signature = Signature::from_bytes(signing_scheme, &order.signature)?;
-    Ok(Order {
-        metadata,
-        data,
-        signature,
-        interactions: Interactions {
-            pre: pre_interactions,
-            post: post_interactions,
-        },
-    })
-}
-
-fn is_sell_order_filled(
-    amount: &BigDecimal,
-    executed_amount: &BigDecimal,
-    executed_fee: &BigDecimal,
-) -> bool {
-    if executed_amount.is_zero() {
-        return false;
-    }
-    let total_amount = executed_amount - executed_fee;
-    total_amount == *amount
-}
-
-fn is_buy_order_filled(amount: &BigDecimal, executed_amount: &BigDecimal) -> bool {
-    !executed_amount.is_zero() && *amount == *executed_amount
+    shared::db_order_conversions::full_order_into_model_order(order, None)
 }
 
 #[cfg(test)]
 mod tests {
     use {
         super::*,
-        chrono::Duration,
-        database::{
-            byte_array::ByteArray,
-            orders::{
-                BuyTokenDestination as DbBuyTokenDestination,
-                FullOrder,
-                OrderClass as DbOrderClass,
-                OrderKind as DbOrderKind,
-                SellTokenSource as DbSellTokenSource,
-                SigningScheme as DbSigningScheme,
-            },
-        },
         model::{
             interaction::InteractionData,
-            order::{Order, OrderData, OrderMetadata, OrderStatus, OrderUid},
+            order::{Interactions, Order, OrderData, OrderMetadata, OrderStatus, OrderUid},
             signature::{Signature, SigningScheme},
         },
         primitive_types::U256,
         shared::order_quoting::{Quote, QuoteData, QuoteMetadataV1},
         std::sync::atomic::{AtomicI64, Ordering},
     };
-
-    #[test]
-    fn order_status() {
-        let valid_to_timestamp = Utc::now() + Duration::days(1);
-
-        let order_row = || FullOrder {
-            uid: ByteArray([0; 56]),
-            owner: ByteArray([0; 20]),
-            creation_timestamp: Utc::now(),
-            sell_token: ByteArray([1; 20]),
-            buy_token: ByteArray([2; 20]),
-            sell_amount: BigDecimal::from(1),
-            buy_amount: BigDecimal::from(1),
-            valid_to: valid_to_timestamp.timestamp(),
-            app_data: ByteArray([0; 32]),
-            fee_amount: BigDecimal::default(),
-            kind: DbOrderKind::Sell,
-            class: DbOrderClass::Liquidity,
-            partially_fillable: true,
-            signature: vec![0; 65],
-            receiver: None,
-            sum_sell: BigDecimal::default(),
-            sum_buy: BigDecimal::default(),
-            sum_fee: BigDecimal::default(),
-            invalidated: false,
-            signing_scheme: DbSigningScheme::Eip712,
-            settlement_contract: ByteArray([0; 20]),
-            sell_token_balance: DbSellTokenSource::External,
-            buy_token_balance: DbBuyTokenDestination::Internal,
-            presignature_pending: false,
-            pre_interactions: Vec::new(),
-            post_interactions: Vec::new(),
-            ethflow_data: None,
-            onchain_user: None,
-            onchain_placement_error: None,
-            executed_fee: Default::default(),
-            executed_fee_token: ByteArray([1; 20]), // TODO surplus token
-            full_app_data: Default::default(),
-        };
-
-        // Open - sell (filled - 0%)
-        assert_eq!(calculate_status(&order_row()), OrderStatus::Open);
-
-        // Open - sell (almost filled - 99.99%)
-        assert_eq!(
-            calculate_status(&FullOrder {
-                kind: DbOrderKind::Sell,
-                sell_amount: BigDecimal::from(10_000),
-                sum_sell: BigDecimal::from(9_999),
-                ..order_row()
-            }),
-            OrderStatus::Open
-        );
-
-        // Open - with presignature
-        assert_eq!(
-            calculate_status(&FullOrder {
-                signing_scheme: DbSigningScheme::PreSign,
-                presignature_pending: false,
-                ..order_row()
-            }),
-            OrderStatus::Open
-        );
-
-        // PresignaturePending - without presignature
-        assert_eq!(
-            calculate_status(&FullOrder {
-                signing_scheme: DbSigningScheme::PreSign,
-                presignature_pending: true,
-                ..order_row()
-            }),
-            OrderStatus::PresignaturePending
-        );
-
-        // Filled - sell (filled - 100%)
-        assert_eq!(
-            calculate_status(&FullOrder {
-                kind: DbOrderKind::Sell,
-                sell_amount: BigDecimal::from(2),
-                sum_sell: BigDecimal::from(3),
-                sum_fee: BigDecimal::from(1),
-                ..order_row()
-            }),
-            OrderStatus::Fulfilled
-        );
-
-        // Open - buy (filled - 0%)
-        assert_eq!(
-            calculate_status(&FullOrder {
-                kind: DbOrderKind::Buy,
-                buy_amount: BigDecimal::from(1),
-                sum_buy: BigDecimal::from(0),
-                ..order_row()
-            }),
-            OrderStatus::Open
-        );
-
-        // Open - buy (almost filled - 99.99%)
-        assert_eq!(
-            calculate_status(&FullOrder {
-                kind: DbOrderKind::Buy,
-                buy_amount: BigDecimal::from(10_000),
-                sum_buy: BigDecimal::from(9_999),
-                ..order_row()
-            }),
-            OrderStatus::Open
-        );
-
-        // Filled - buy (filled - 100%)
-        assert_eq!(
-            calculate_status(&FullOrder {
-                kind: DbOrderKind::Buy,
-                buy_amount: BigDecimal::from(1),
-                sum_buy: BigDecimal::from(1),
-                ..order_row()
-            }),
-            OrderStatus::Fulfilled
-        );
-
-        // Cancelled - no fills - sell
-        assert_eq!(
-            calculate_status(&FullOrder {
-                invalidated: true,
-                ..order_row()
-            }),
-            OrderStatus::Cancelled
-        );
-
-        // Cancelled - partial fill - sell
-        assert_eq!(
-            calculate_status(&FullOrder {
-                kind: DbOrderKind::Sell,
-                sell_amount: BigDecimal::from(2),
-                sum_sell: BigDecimal::from(1),
-                sum_fee: BigDecimal::default(),
-                invalidated: true,
-                ..order_row()
-            }),
-            OrderStatus::Cancelled
-        );
-
-        // Cancelled - partial fill - buy
-        assert_eq!(
-            calculate_status(&FullOrder {
-                kind: DbOrderKind::Buy,
-                buy_amount: BigDecimal::from(2),
-                sum_buy: BigDecimal::from(1),
-                invalidated: true,
-                ..order_row()
-            }),
-            OrderStatus::Cancelled
-        );
-
-        // Expired - no fills
-        let valid_to_yesterday = Utc::now() - Duration::days(1);
-
-        assert_eq!(
-            calculate_status(&FullOrder {
-                invalidated: false,
-                valid_to: valid_to_yesterday.timestamp(),
-                ..order_row()
-            }),
-            OrderStatus::Expired
-        );
-
-        // Expired - partial fill - sell
-        assert_eq!(
-            calculate_status(&FullOrder {
-                kind: DbOrderKind::Sell,
-                sell_amount: BigDecimal::from(2),
-                sum_sell: BigDecimal::from(1),
-                invalidated: false,
-                valid_to: valid_to_yesterday.timestamp(),
-                ..order_row()
-            }),
-            OrderStatus::Expired
-        );
-
-        // Expired - partial fill - buy
-        assert_eq!(
-            calculate_status(&FullOrder {
-                kind: DbOrderKind::Buy,
-                buy_amount: BigDecimal::from(2),
-                sum_buy: BigDecimal::from(1),
-                invalidated: false,
-                valid_to: valid_to_yesterday.timestamp(),
-                ..order_row()
-            }),
-            OrderStatus::Expired
-        );
-
-        // Expired - with pending presignature
-        assert_eq!(
-            calculate_status(&FullOrder {
-                signing_scheme: DbSigningScheme::PreSign,
-                invalidated: false,
-                valid_to: valid_to_yesterday.timestamp(),
-                presignature_pending: true,
-                ..order_row()
-            }),
-            OrderStatus::Expired
-        );
-
-        // Expired - for ethflow orders
-        assert_eq!(
-            calculate_status(&FullOrder {
-                invalidated: false,
-                ethflow_data: Some((None, valid_to_yesterday.timestamp())),
-                ..order_row()
-            }),
-            OrderStatus::Expired
-        );
-    }
 
     #[tokio::test]
     #[ignore]

--- a/crates/shared/src/lib.rs
+++ b/crates/shared/src/lib.rs
@@ -23,6 +23,7 @@ pub mod http_solver;
 pub mod interaction;
 pub mod maintenance;
 pub mod order_quoting;
+pub mod order_status;
 pub mod order_validation;
 pub mod price_estimation;
 pub mod recent_block_cache;

--- a/crates/shared/src/order_status.rs
+++ b/crates/shared/src/order_status.rs
@@ -1,17 +1,6 @@
 use {
-    bigdecimal::BigDecimal,
-    chrono::{Duration, Utc},
-    database::{
-        byte_array::ByteArray,
-        orders::{
-            BuyTokenDestination,
-            FullOrder,
-            OrderClass,
-            OrderKind,
-            SellTokenSource,
-            SigningScheme,
-        },
-    },
+    chrono::Utc,
+    database::orders::{FullOrder, OrderKind},
     model::order::OrderStatus,
 };
 
@@ -40,215 +29,236 @@ pub fn calculate_status(order: &FullOrder) -> OrderStatus {
     OrderStatus::Open
 }
 
-#[test]
-fn order_status() {
-    let valid_to_timestamp = Utc::now() + Duration::days(1);
-
-    let order_row = || FullOrder {
-        uid: ByteArray([0; 56]),
-        owner: ByteArray([0; 20]),
-        creation_timestamp: Utc::now(),
-        sell_token: ByteArray([1; 20]),
-        buy_token: ByteArray([2; 20]),
-        sell_amount: BigDecimal::from(1),
-        buy_amount: BigDecimal::from(1),
-        valid_to: valid_to_timestamp.timestamp(),
-        app_data: ByteArray([0; 32]),
-        fee_amount: BigDecimal::default(),
-        kind: OrderKind::Sell,
-        class: OrderClass::Liquidity,
-        partially_fillable: true,
-        signature: vec![0; 65],
-        receiver: None,
-        sum_sell: BigDecimal::default(),
-        sum_buy: BigDecimal::default(),
-        sum_fee: BigDecimal::default(),
-        invalidated: false,
-        signing_scheme: SigningScheme::Eip712,
-        settlement_contract: ByteArray([0; 20]),
-        sell_token_balance: SellTokenSource::External,
-        buy_token_balance: BuyTokenDestination::Internal,
-        presignature_pending: false,
-        pre_interactions: Vec::new(),
-        post_interactions: Vec::new(),
-        ethflow_data: None,
-        onchain_user: None,
-        onchain_placement_error: None,
-        executed_fee: Default::default(),
-        executed_fee_token: ByteArray([1; 20]), // TODO surplus token
-        full_app_data: Default::default(),
+#[cfg(test)]
+mod test {
+    use {
+        crate::order_status::calculate_status,
+        bigdecimal::BigDecimal,
+        chrono::{Duration, Utc},
+        database::{
+            byte_array::ByteArray,
+            orders::{
+                BuyTokenDestination,
+                FullOrder,
+                OrderClass,
+                OrderKind,
+                SellTokenSource,
+                SigningScheme,
+            },
+        },
+        model::order::OrderStatus,
     };
 
-    // Open - sell (filled - 0%)
-    assert_eq!(calculate_status(&order_row()), OrderStatus::Open);
+    #[test]
+    fn order_status() {
+        let valid_to_timestamp = Utc::now() + Duration::days(1);
 
-    // Open - sell (almost filled - 99.99%)
-    assert_eq!(
-        calculate_status(&FullOrder {
-            kind: OrderKind::Sell,
-            sell_amount: BigDecimal::from(10_000),
-            sum_sell: BigDecimal::from(9_999),
-            ..order_row()
-        }),
-        OrderStatus::Open
-    );
-
-    // Open - with presignature
-    assert_eq!(
-        calculate_status(&FullOrder {
-            signing_scheme: SigningScheme::PreSign,
-            presignature_pending: false,
-            ..order_row()
-        }),
-        OrderStatus::Open
-    );
-
-    // PresignaturePending - without presignature
-    assert_eq!(
-        calculate_status(&FullOrder {
-            signing_scheme: SigningScheme::PreSign,
-            presignature_pending: true,
-            ..order_row()
-        }),
-        OrderStatus::PresignaturePending
-    );
-
-    // Filled - sell (filled - 100%)
-    assert_eq!(
-        calculate_status(&FullOrder {
-            kind: OrderKind::Sell,
-            sell_amount: BigDecimal::from(2),
-            sum_sell: BigDecimal::from(3),
-            sum_fee: BigDecimal::from(1),
-            ..order_row()
-        }),
-        OrderStatus::Fulfilled
-    );
-
-    // Open - buy (filled - 0%)
-    assert_eq!(
-        calculate_status(&FullOrder {
-            kind: OrderKind::Buy,
+        let order_row = || FullOrder {
+            uid: ByteArray([0; 56]),
+            owner: ByteArray([0; 20]),
+            creation_timestamp: Utc::now(),
+            sell_token: ByteArray([1; 20]),
+            buy_token: ByteArray([2; 20]),
+            sell_amount: BigDecimal::from(1),
             buy_amount: BigDecimal::from(1),
-            sum_buy: BigDecimal::from(0),
-            ..order_row()
-        }),
-        OrderStatus::Open
-    );
-
-    // Open - buy (almost filled - 99.99%)
-    assert_eq!(
-        calculate_status(&FullOrder {
-            kind: OrderKind::Buy,
-            buy_amount: BigDecimal::from(10_000),
-            sum_buy: BigDecimal::from(9_999),
-            ..order_row()
-        }),
-        OrderStatus::Open
-    );
-
-    // Filled - buy (filled - 100%)
-    assert_eq!(
-        calculate_status(&FullOrder {
-            kind: OrderKind::Buy,
-            buy_amount: BigDecimal::from(1),
-            sum_buy: BigDecimal::from(1),
-            ..order_row()
-        }),
-        OrderStatus::Fulfilled
-    );
-
-    // Cancelled - no fills - sell
-    assert_eq!(
-        calculate_status(&FullOrder {
-            invalidated: true,
-            ..order_row()
-        }),
-        OrderStatus::Cancelled
-    );
-
-    // Cancelled - partial fill - sell
-    assert_eq!(
-        calculate_status(&FullOrder {
+            valid_to: valid_to_timestamp.timestamp(),
+            app_data: ByteArray([0; 32]),
+            fee_amount: BigDecimal::default(),
             kind: OrderKind::Sell,
-            sell_amount: BigDecimal::from(2),
-            sum_sell: BigDecimal::from(1),
+            class: OrderClass::Liquidity,
+            partially_fillable: true,
+            signature: vec![0; 65],
+            receiver: None,
+            sum_sell: BigDecimal::default(),
+            sum_buy: BigDecimal::default(),
             sum_fee: BigDecimal::default(),
-            invalidated: true,
-            ..order_row()
-        }),
-        OrderStatus::Cancelled
-    );
-
-    // Cancelled - partial fill - buy
-    assert_eq!(
-        calculate_status(&FullOrder {
-            kind: OrderKind::Buy,
-            buy_amount: BigDecimal::from(2),
-            sum_buy: BigDecimal::from(1),
-            invalidated: true,
-            ..order_row()
-        }),
-        OrderStatus::Cancelled
-    );
-
-    // Expired - no fills
-    let valid_to_yesterday = Utc::now() - Duration::days(1);
-
-    assert_eq!(
-        calculate_status(&FullOrder {
             invalidated: false,
-            valid_to: valid_to_yesterday.timestamp(),
-            ..order_row()
-        }),
-        OrderStatus::Expired
-    );
+            signing_scheme: SigningScheme::Eip712,
+            settlement_contract: ByteArray([0; 20]),
+            sell_token_balance: SellTokenSource::External,
+            buy_token_balance: BuyTokenDestination::Internal,
+            presignature_pending: false,
+            pre_interactions: Vec::new(),
+            post_interactions: Vec::new(),
+            ethflow_data: None,
+            onchain_user: None,
+            onchain_placement_error: None,
+            executed_fee: Default::default(),
+            executed_fee_token: ByteArray([1; 20]), // TODO surplus token
+            full_app_data: Default::default(),
+        };
 
-    // Expired - partial fill - sell
-    assert_eq!(
-        calculate_status(&FullOrder {
-            kind: OrderKind::Sell,
-            sell_amount: BigDecimal::from(2),
-            sum_sell: BigDecimal::from(1),
-            invalidated: false,
-            valid_to: valid_to_yesterday.timestamp(),
-            ..order_row()
-        }),
-        OrderStatus::Expired
-    );
+        // Open - sell (filled - 0%)
+        assert_eq!(calculate_status(&order_row()), OrderStatus::Open);
 
-    // Expired - partial fill - buy
-    assert_eq!(
-        calculate_status(&FullOrder {
-            kind: OrderKind::Buy,
-            buy_amount: BigDecimal::from(2),
-            sum_buy: BigDecimal::from(1),
-            invalidated: false,
-            valid_to: valid_to_yesterday.timestamp(),
-            ..order_row()
-        }),
-        OrderStatus::Expired
-    );
+        // Open - sell (almost filled - 99.99%)
+        assert_eq!(
+            calculate_status(&FullOrder {
+                kind: OrderKind::Sell,
+                sell_amount: BigDecimal::from(10_000),
+                sum_sell: BigDecimal::from(9_999),
+                ..order_row()
+            }),
+            OrderStatus::Open
+        );
 
-    // Expired - with pending presignature
-    assert_eq!(
-        calculate_status(&FullOrder {
-            signing_scheme: SigningScheme::PreSign,
-            invalidated: false,
-            valid_to: valid_to_yesterday.timestamp(),
-            presignature_pending: true,
-            ..order_row()
-        }),
-        OrderStatus::Expired
-    );
+        // Open - with presignature
+        assert_eq!(
+            calculate_status(&FullOrder {
+                signing_scheme: SigningScheme::PreSign,
+                presignature_pending: false,
+                ..order_row()
+            }),
+            OrderStatus::Open
+        );
 
-    // Expired - for ethflow orders
-    assert_eq!(
-        calculate_status(&FullOrder {
-            invalidated: false,
-            ethflow_data: Some((None, valid_to_yesterday.timestamp())),
-            ..order_row()
-        }),
-        OrderStatus::Expired
-    );
+        // PresignaturePending - without presignature
+        assert_eq!(
+            calculate_status(&FullOrder {
+                signing_scheme: SigningScheme::PreSign,
+                presignature_pending: true,
+                ..order_row()
+            }),
+            OrderStatus::PresignaturePending
+        );
+
+        // Filled - sell (filled - 100%)
+        assert_eq!(
+            calculate_status(&FullOrder {
+                kind: OrderKind::Sell,
+                sell_amount: BigDecimal::from(2),
+                sum_sell: BigDecimal::from(3),
+                sum_fee: BigDecimal::from(1),
+                ..order_row()
+            }),
+            OrderStatus::Fulfilled
+        );
+
+        // Open - buy (filled - 0%)
+        assert_eq!(
+            calculate_status(&FullOrder {
+                kind: OrderKind::Buy,
+                buy_amount: BigDecimal::from(1),
+                sum_buy: BigDecimal::from(0),
+                ..order_row()
+            }),
+            OrderStatus::Open
+        );
+
+        // Open - buy (almost filled - 99.99%)
+        assert_eq!(
+            calculate_status(&FullOrder {
+                kind: OrderKind::Buy,
+                buy_amount: BigDecimal::from(10_000),
+                sum_buy: BigDecimal::from(9_999),
+                ..order_row()
+            }),
+            OrderStatus::Open
+        );
+
+        // Filled - buy (filled - 100%)
+        assert_eq!(
+            calculate_status(&FullOrder {
+                kind: OrderKind::Buy,
+                buy_amount: BigDecimal::from(1),
+                sum_buy: BigDecimal::from(1),
+                ..order_row()
+            }),
+            OrderStatus::Fulfilled
+        );
+
+        // Cancelled - no fills - sell
+        assert_eq!(
+            calculate_status(&FullOrder {
+                invalidated: true,
+                ..order_row()
+            }),
+            OrderStatus::Cancelled
+        );
+
+        // Cancelled - partial fill - sell
+        assert_eq!(
+            calculate_status(&FullOrder {
+                kind: OrderKind::Sell,
+                sell_amount: BigDecimal::from(2),
+                sum_sell: BigDecimal::from(1),
+                sum_fee: BigDecimal::default(),
+                invalidated: true,
+                ..order_row()
+            }),
+            OrderStatus::Cancelled
+        );
+
+        // Cancelled - partial fill - buy
+        assert_eq!(
+            calculate_status(&FullOrder {
+                kind: OrderKind::Buy,
+                buy_amount: BigDecimal::from(2),
+                sum_buy: BigDecimal::from(1),
+                invalidated: true,
+                ..order_row()
+            }),
+            OrderStatus::Cancelled
+        );
+
+        // Expired - no fills
+        let valid_to_yesterday = Utc::now() - Duration::days(1);
+
+        assert_eq!(
+            calculate_status(&FullOrder {
+                invalidated: false,
+                valid_to: valid_to_yesterday.timestamp(),
+                ..order_row()
+            }),
+            OrderStatus::Expired
+        );
+
+        // Expired - partial fill - sell
+        assert_eq!(
+            calculate_status(&FullOrder {
+                kind: OrderKind::Sell,
+                sell_amount: BigDecimal::from(2),
+                sum_sell: BigDecimal::from(1),
+                invalidated: false,
+                valid_to: valid_to_yesterday.timestamp(),
+                ..order_row()
+            }),
+            OrderStatus::Expired
+        );
+
+        // Expired - partial fill - buy
+        assert_eq!(
+            calculate_status(&FullOrder {
+                kind: OrderKind::Buy,
+                buy_amount: BigDecimal::from(2),
+                sum_buy: BigDecimal::from(1),
+                invalidated: false,
+                valid_to: valid_to_yesterday.timestamp(),
+                ..order_row()
+            }),
+            OrderStatus::Expired
+        );
+
+        // Expired - with pending presignature
+        assert_eq!(
+            calculate_status(&FullOrder {
+                signing_scheme: SigningScheme::PreSign,
+                invalidated: false,
+                valid_to: valid_to_yesterday.timestamp(),
+                presignature_pending: true,
+                ..order_row()
+            }),
+            OrderStatus::Expired
+        );
+
+        // Expired - for ethflow orders
+        assert_eq!(
+            calculate_status(&FullOrder {
+                invalidated: false,
+                ethflow_data: Some((None, valid_to_yesterday.timestamp())),
+                ..order_row()
+            }),
+            OrderStatus::Expired
+        );
+    }
 }

--- a/crates/shared/src/order_status.rs
+++ b/crates/shared/src/order_status.rs
@@ -1,0 +1,254 @@
+use {
+    bigdecimal::BigDecimal,
+    chrono::{Duration, Utc},
+    database::{
+        byte_array::ByteArray,
+        orders::{
+            BuyTokenDestination,
+            FullOrder,
+            OrderClass,
+            OrderKind,
+            SellTokenSource,
+            SigningScheme,
+        },
+    },
+    model::order::OrderStatus,
+};
+
+pub fn calculate_status(order: &FullOrder) -> OrderStatus {
+    match order.kind {
+        OrderKind::Buy => {
+            if order.is_buy_order_filled() {
+                return OrderStatus::Fulfilled;
+            }
+        }
+        OrderKind::Sell => {
+            if order.is_sell_order_filled() {
+                return OrderStatus::Fulfilled;
+            }
+        }
+    }
+    if order.invalidated {
+        return OrderStatus::Cancelled;
+    }
+    if order.valid_to() < Utc::now().timestamp() {
+        return OrderStatus::Expired;
+    }
+    if order.presignature_pending {
+        return OrderStatus::PresignaturePending;
+    }
+    OrderStatus::Open
+}
+
+#[test]
+fn order_status() {
+    let valid_to_timestamp = Utc::now() + Duration::days(1);
+
+    let order_row = || FullOrder {
+        uid: ByteArray([0; 56]),
+        owner: ByteArray([0; 20]),
+        creation_timestamp: Utc::now(),
+        sell_token: ByteArray([1; 20]),
+        buy_token: ByteArray([2; 20]),
+        sell_amount: BigDecimal::from(1),
+        buy_amount: BigDecimal::from(1),
+        valid_to: valid_to_timestamp.timestamp(),
+        app_data: ByteArray([0; 32]),
+        fee_amount: BigDecimal::default(),
+        kind: OrderKind::Sell,
+        class: OrderClass::Liquidity,
+        partially_fillable: true,
+        signature: vec![0; 65],
+        receiver: None,
+        sum_sell: BigDecimal::default(),
+        sum_buy: BigDecimal::default(),
+        sum_fee: BigDecimal::default(),
+        invalidated: false,
+        signing_scheme: SigningScheme::Eip712,
+        settlement_contract: ByteArray([0; 20]),
+        sell_token_balance: SellTokenSource::External,
+        buy_token_balance: BuyTokenDestination::Internal,
+        presignature_pending: false,
+        pre_interactions: Vec::new(),
+        post_interactions: Vec::new(),
+        ethflow_data: None,
+        onchain_user: None,
+        onchain_placement_error: None,
+        executed_fee: Default::default(),
+        executed_fee_token: ByteArray([1; 20]), // TODO surplus token
+        full_app_data: Default::default(),
+    };
+
+    // Open - sell (filled - 0%)
+    assert_eq!(calculate_status(&order_row()), OrderStatus::Open);
+
+    // Open - sell (almost filled - 99.99%)
+    assert_eq!(
+        calculate_status(&FullOrder {
+            kind: OrderKind::Sell,
+            sell_amount: BigDecimal::from(10_000),
+            sum_sell: BigDecimal::from(9_999),
+            ..order_row()
+        }),
+        OrderStatus::Open
+    );
+
+    // Open - with presignature
+    assert_eq!(
+        calculate_status(&FullOrder {
+            signing_scheme: SigningScheme::PreSign,
+            presignature_pending: false,
+            ..order_row()
+        }),
+        OrderStatus::Open
+    );
+
+    // PresignaturePending - without presignature
+    assert_eq!(
+        calculate_status(&FullOrder {
+            signing_scheme: SigningScheme::PreSign,
+            presignature_pending: true,
+            ..order_row()
+        }),
+        OrderStatus::PresignaturePending
+    );
+
+    // Filled - sell (filled - 100%)
+    assert_eq!(
+        calculate_status(&FullOrder {
+            kind: OrderKind::Sell,
+            sell_amount: BigDecimal::from(2),
+            sum_sell: BigDecimal::from(3),
+            sum_fee: BigDecimal::from(1),
+            ..order_row()
+        }),
+        OrderStatus::Fulfilled
+    );
+
+    // Open - buy (filled - 0%)
+    assert_eq!(
+        calculate_status(&FullOrder {
+            kind: OrderKind::Buy,
+            buy_amount: BigDecimal::from(1),
+            sum_buy: BigDecimal::from(0),
+            ..order_row()
+        }),
+        OrderStatus::Open
+    );
+
+    // Open - buy (almost filled - 99.99%)
+    assert_eq!(
+        calculate_status(&FullOrder {
+            kind: OrderKind::Buy,
+            buy_amount: BigDecimal::from(10_000),
+            sum_buy: BigDecimal::from(9_999),
+            ..order_row()
+        }),
+        OrderStatus::Open
+    );
+
+    // Filled - buy (filled - 100%)
+    assert_eq!(
+        calculate_status(&FullOrder {
+            kind: OrderKind::Buy,
+            buy_amount: BigDecimal::from(1),
+            sum_buy: BigDecimal::from(1),
+            ..order_row()
+        }),
+        OrderStatus::Fulfilled
+    );
+
+    // Cancelled - no fills - sell
+    assert_eq!(
+        calculate_status(&FullOrder {
+            invalidated: true,
+            ..order_row()
+        }),
+        OrderStatus::Cancelled
+    );
+
+    // Cancelled - partial fill - sell
+    assert_eq!(
+        calculate_status(&FullOrder {
+            kind: OrderKind::Sell,
+            sell_amount: BigDecimal::from(2),
+            sum_sell: BigDecimal::from(1),
+            sum_fee: BigDecimal::default(),
+            invalidated: true,
+            ..order_row()
+        }),
+        OrderStatus::Cancelled
+    );
+
+    // Cancelled - partial fill - buy
+    assert_eq!(
+        calculate_status(&FullOrder {
+            kind: OrderKind::Buy,
+            buy_amount: BigDecimal::from(2),
+            sum_buy: BigDecimal::from(1),
+            invalidated: true,
+            ..order_row()
+        }),
+        OrderStatus::Cancelled
+    );
+
+    // Expired - no fills
+    let valid_to_yesterday = Utc::now() - Duration::days(1);
+
+    assert_eq!(
+        calculate_status(&FullOrder {
+            invalidated: false,
+            valid_to: valid_to_yesterday.timestamp(),
+            ..order_row()
+        }),
+        OrderStatus::Expired
+    );
+
+    // Expired - partial fill - sell
+    assert_eq!(
+        calculate_status(&FullOrder {
+            kind: OrderKind::Sell,
+            sell_amount: BigDecimal::from(2),
+            sum_sell: BigDecimal::from(1),
+            invalidated: false,
+            valid_to: valid_to_yesterday.timestamp(),
+            ..order_row()
+        }),
+        OrderStatus::Expired
+    );
+
+    // Expired - partial fill - buy
+    assert_eq!(
+        calculate_status(&FullOrder {
+            kind: OrderKind::Buy,
+            buy_amount: BigDecimal::from(2),
+            sum_buy: BigDecimal::from(1),
+            invalidated: false,
+            valid_to: valid_to_yesterday.timestamp(),
+            ..order_row()
+        }),
+        OrderStatus::Expired
+    );
+
+    // Expired - with pending presignature
+    assert_eq!(
+        calculate_status(&FullOrder {
+            signing_scheme: SigningScheme::PreSign,
+            invalidated: false,
+            valid_to: valid_to_yesterday.timestamp(),
+            presignature_pending: true,
+            ..order_row()
+        }),
+        OrderStatus::Expired
+    );
+
+    // Expired - for ethflow orders
+    assert_eq!(
+        calculate_status(&FullOrder {
+            invalidated: false,
+            ethflow_data: Some((None, valid_to_yesterday.timestamp())),
+            ..order_row()
+        }),
+        OrderStatus::Expired
+    );
+}


### PR DESCRIPTION
# Description
Removed duplication of full_order_into_model_order function.
Moved calculate_status into a separate module under shared crate

Related to https://github.com/cowprotocol/services/issues/2110


## How to test
Existing tests
