### PR TITLE
Update information about fee fields in openapi docs

### DIFF
--- a/crates/orderbook/openapi.yml
+++ b/crates/orderbook/openapi.yml
@@ -906,9 +906,9 @@ components:
           allOf:
             - $ref: "#/components/schemas/BigUint"
         executedFeeAmount:
-          description: The total amount of the user signed `fee` that have been
-          executed for this order. This value is only non-negative for very
-          old orders.
+          description: >
+            [DEPRECATED] The total amount of the user signed `fee` that have been
+            executed for this order. This value is only non-negative for very old orders.
           allOf:
             - $ref: "#/components/schemas/BigUint"
         invalidated:
@@ -950,8 +950,9 @@ components:
           allOf:
             - $ref: "#/components/schemas/OnchainOrderData"
         executedFee:
-          description: Total fee charged for execution of the order. Contains network fee and protocol fees.
-          This takes into account the historic static fee signed by the user and the new dynamic fee computed by solvers.
+          description: >
+            Total fee charged for execution of the order. Contains network fee and protocol fees.
+            This takes into account the historic static fee signed by the user and the new dynamic fee computed by solvers.
           allOf:
             - $ref: "#/components/schemas/BigUint"
           nullable: false

--- a/crates/orderbook/openapi.yml
+++ b/crates/orderbook/openapi.yml
@@ -885,14 +885,18 @@ components:
           deprecated: true
         executedSellAmount:
           description: >
-            The total amount of `sellToken` that has been executed for this
-            order including fees.
+            The total amount of `sellToken` that has been transferred from the
+            user for this order so far.
           allOf:
             - $ref: "#/components/schemas/BigUint"
         executedSellAmountBeforeFees:
           description: >
-            The total amount of `sellToken` that has been executed for this
-            order without fees.
+            The total amount of `sellToken` that has been transferred from the
+            user for this order so far minus tokens that were transferred
+            as part of the signed `fee` of the order.
+            This is only relevant for old orders because now all orders have
+            a signed `fee` of 0 and solvers compute an appropriate fee
+            dynamically at the time of the order execution.
           allOf:
             - $ref: "#/components/schemas/BigUint"
         executedBuyAmount:
@@ -902,7 +906,9 @@ components:
           allOf:
             - $ref: "#/components/schemas/BigUint"
         executedFeeAmount:
-          description: The total amount of fees that have been executed for this order.
+          description: The total amount of the user signed `fee` that have been
+          executed for this order. This value is only non-negative for very
+          old orders.
           allOf:
             - $ref: "#/components/schemas/BigUint"
         invalidated:
@@ -945,6 +951,7 @@ components:
             - $ref: "#/components/schemas/OnchainOrderData"
         executedFee:
           description: Total fee charged for execution of the order. Contains network fee and protocol fees.
+          This takes into account the historic static fee signed by the user and the new dynamic fee computed by solvers.
           allOf:
             - $ref: "#/components/schemas/BigUint"
           nullable: false


### PR DESCRIPTION
# Description
Since we switched to dynamically computed fees and enforcing a signed `fee` amount of 0 the order's fee fields got quite confusing.

# Changes
Updated openapi docs to explain the fields better.