### PR TITLE
orderbook: Return 404 for get order status when competition was not found

### DIFF
--- a/crates/orderbook/src/api/get_order_status.rs
+++ b/crates/orderbook/src/api/get_order_status.rs
@@ -1,7 +1,7 @@
 use {
     crate::{
         api::ApiReply,
-        orderbook::{self, Orderbook},
+        orderbook::{OrderStatusError, Orderbook},
     },
     anyhow::Result,
     model::order::OrderUid,
@@ -22,7 +22,7 @@ pub fn get_status(
             let status = orderbook.get_order_status(&uid).await;
             Result::<_, Infallible>::Ok(match status {
                 Ok(status) => warp::reply::with_status(warp::reply::json(&status), StatusCode::OK),
-                Err(orderbook::Error::NotFound) => reply::with_status(
+                Err(OrderStatusError::NotFound) => reply::with_status(
                     super::error("NotFound", "Order status was not found"),
                     StatusCode::NOT_FOUND,
                 ),

--- a/crates/orderbook/src/api/get_order_status.rs
+++ b/crates/orderbook/src/api/get_order_status.rs
@@ -29,7 +29,7 @@ pub fn get_status(
                     StatusCode::NOT_FOUND,
                 ),
                 Err(orderbook::Error::NotFound) => reply::with_status(
-                    super::error("NotFound", "Competition was not found"),
+                    super::error("NotFound", "Order status was not found"),
                     StatusCode::NOT_FOUND,
                 ),
                 Err(err) => {

--- a/crates/orderbook/src/api/get_order_status.rs
+++ b/crates/orderbook/src/api/get_order_status.rs
@@ -21,13 +21,7 @@ pub fn get_status(
         async move {
             let status = orderbook.get_order_status(&uid).await;
             Result::<_, Infallible>::Ok(match status {
-                Ok(Some(status)) => {
-                    warp::reply::with_status(warp::reply::json(&status), StatusCode::OK)
-                }
-                Ok(None) => warp::reply::with_status(
-                    super::error("OrderNotFound", "Order not located in database"),
-                    StatusCode::NOT_FOUND,
-                ),
+                Ok(status) => warp::reply::with_status(warp::reply::json(&status), StatusCode::OK),
                 Err(orderbook::Error::NotFound) => reply::with_status(
                     super::error("NotFound", "Order status was not found"),
                     StatusCode::NOT_FOUND,

--- a/crates/orderbook/src/api/get_order_status.rs
+++ b/crates/orderbook/src/api/get_order_status.rs
@@ -28,13 +28,10 @@ pub fn get_status(
                     super::error("OrderNotFound", "Order not located in database"),
                     StatusCode::NOT_FOUND,
                 ),
-                Err(err @ orderbook::Error::NotFound) => {
-                    tracing::error!(?err, "get_order_status");
-                    reply::with_status(
-                        super::error("NotFound", "Competition was not found"),
-                        StatusCode::NOT_FOUND,
-                    )
-                }
+                Err(orderbook::Error::NotFound) => reply::with_status(
+                    super::error("NotFound", "Competition was not found"),
+                    StatusCode::NOT_FOUND,
+                ),
                 Err(err) => {
                     tracing::error!(?err, "get_order_status");
                     *Box::new(crate::api::internal_error_reply())

--- a/crates/orderbook/src/orderbook.rs
+++ b/crates/orderbook/src/orderbook.rs
@@ -523,7 +523,7 @@ impl Orderbook {
                 .database
                 .load_latest_competition()
                 .await
-                .map_err(Into::into)?;
+                .map_err(Into::<Error>::into)?;
             Ok::<_, Error>(solutions(competition))
         };
 
@@ -572,7 +572,7 @@ impl Orderbook {
 }
 
 #[derive(Error, Debug)]
-pub(crate) enum Error {
+pub enum Error {
     #[error("solver competition not found")]
     NotFound,
     #[error(transparent)]


### PR DESCRIPTION
# Description
Right now we return internal error when the solver competition was not found.

Return `NOT_FOUND` (404) error instead of internal error (500) when there solver competition was not found for the given order.

## How to test
1. Regression test

The change is fairly simple, I assume adding an e2e test for this is a little bit of an overkill, but I am open to the idea too.