### PR TITLE
[EASY] Log order quote's solver

### DIFF
--- a/crates/orderbook/src/api/post_order.rs
+++ b/crates/orderbook/src/api/post_order.rs
@@ -312,7 +312,9 @@ pub fn post_order(
                 .add_order(order.clone())
                 .await
                 .map(|(order_uid, quote_metadata)| {
-                    tracing::debug!(%order_uid, ?quote_metadata, "order created");
+                    let quote_id = quote_metadata.as_ref().and_then(|q| q.id);
+                    let quote_solver = quote_metadata.as_ref().map(|q| q.solver);
+                    tracing::debug!(%order_uid, ?quote_id, ?quote_solver, "order created");
                     (order_uid, quote_metadata.and_then(|quote| quote.id))
                 })
                 .inspect_err(|err| {

--- a/crates/shared/src/order_validation.rs
+++ b/crates/shared/src/order_validation.rs
@@ -37,7 +37,7 @@ use {
             SellTokenSource,
             VerificationError,
         },
-        quote::{OrderQuoteSide, QuoteId, QuoteSigningScheme, SellAmount},
+        quote::{OrderQuoteSide, QuoteSigningScheme, SellAmount},
         signature::{self, Signature, SigningScheme, hashed_eip712_message},
         time,
     },
@@ -94,7 +94,7 @@ pub trait OrderValidating: Send + Sync {
         domain_separator: &DomainSeparator,
         settlement_contract: H160,
         full_app_data_override: Option<String>,
-    ) -> Result<(Order, Option<QuoteId>), ValidationError>;
+    ) -> Result<(Order, Option<Quote>), ValidationError>;
 }
 
 #[derive(Debug)]
@@ -547,7 +547,7 @@ impl OrderValidating for OrderValidator {
         domain_separator: &DomainSeparator,
         settlement_contract: H160,
         full_app_data_override: Option<String>,
-    ) -> Result<(Order, Option<QuoteId>), ValidationError> {
+    ) -> Result<(Order, Option<Quote>), ValidationError> {
         // Happens before signature verification because a miscalculated app data hash
         // by the API user would lead to being unable to validate the signature below.
         let app_data = self.validate_app_data(&order.app_data, &full_app_data_override)?;
@@ -759,7 +759,7 @@ impl OrderValidating for OrderValidator {
             interactions: app_data.interactions,
         };
 
-        Ok((order, quote.and_then(|q| q.id)))
+        Ok((order, quote))
     }
 }
 
@@ -2289,6 +2289,6 @@ mod tests {
             .await
             .unwrap();
 
-        assert_eq!(quote_id, returned_quote_id);
+        assert_eq!(quote_id, returned_quote_id.and_then(|quote| quote.id));
     }
 }


### PR DESCRIPTION
# Description
As a first step to improve the quote competition visualization for a specific order, this PR updates the order creation log by including the selected quote solver address, which eliminates the redundant step of searching for this data in either logs or db. If the initiative gets approved, this can be improved by logging the solver's name. However, this would require additional work to build a mapping between the solver's address and its name.

## How to test
Observe the logs.
