### PR TITLE
Fix flashloan default lender

### DIFF
--- a/crates/driver/src/infra/blockchain/contracts.rs
+++ b/crates/driver/src/infra/blockchain/contracts.rs
@@ -31,6 +31,9 @@ pub struct Contracts {
     // TODO: make this non-optional when contracts are deployed
     // everywhere
     flashloan_router: Option<FlashLoanRouter>,
+    /// Default lender to use for flashloans, if flashloan doesn't have a lender
+    /// specified.
+    flashloan_default_lender: Option<eth::ContractAddress>,
 }
 
 #[derive(Debug, Clone)]
@@ -46,6 +49,7 @@ pub struct Addresses {
     pub cow_amms: Vec<CowAmmConfig>,
     pub flashloan_wrappers: Vec<config::file::FlashloanWrapperConfig>,
     pub flashloan_router: Option<eth::ContractAddress>,
+    pub flashloan_default_lender: Option<eth::ContractAddress>,
 }
 
 impl Contracts {
@@ -139,6 +143,7 @@ impl Contracts {
             cow_amm_registry,
             flashloan_wrapper_by_lender,
             flashloan_router,
+            flashloan_default_lender: addresses.flashloan_default_lender,
         })
     }
 
@@ -175,6 +180,10 @@ impl Contracts {
         lender: &eth::ContractAddress,
     ) -> Option<&FlashloanWrapperData> {
         self.flashloan_wrapper_by_lender.get(lender)
+    }
+
+    pub fn flashloan_default_lender(&self) -> Option<eth::ContractAddress> {
+        self.flashloan_default_lender
     }
 
     pub fn flashloan_router(&self) -> Option<&contracts::FlashLoanRouter> {

--- a/crates/driver/src/infra/config/file/load.rs
+++ b/crates/driver/src/infra/config/file/load.rs
@@ -137,7 +137,7 @@ pub async fn load(chain: Chain, path: &Path) -> infra::Config {
                 },
                 settle_queue_size: solver_config.settle_queue_size,
                 flashloans_enabled: config.flashloans_enabled,
-                flashloan_default_lender: eth::Address(config.flashloans_default_lender),
+                flashloan_default_lender: config.flashloans_default_lender.map(Into::into),
             }
         }))
         .await,

--- a/crates/driver/src/infra/config/file/load.rs
+++ b/crates/driver/src/infra/config/file/load.rs
@@ -137,7 +137,6 @@ pub async fn load(chain: Chain, path: &Path) -> infra::Config {
                 },
                 settle_queue_size: solver_config.settle_queue_size,
                 flashloans_enabled: config.flashloans_enabled,
-                flashloan_default_lender: config.flashloans_default_lender.map(Into::into),
             }
         }))
         .await,
@@ -378,6 +377,23 @@ pub async fn load(chain: Chain, path: &Path) -> infra::Config {
                     helper: cfg.helper,
                 })
                 .collect(),
+            flashloan_default_lender: {
+                // Make sure flashloan default lender exists in the flashloan wrappers
+                if let Some(default_lender) = config.contracts.flashloan_default_lender {
+                    if !config
+                        .contracts
+                        .flashloan_wrappers
+                        .iter()
+                        .any(|wrapper| wrapper.lender == default_lender)
+                    {
+                        panic!(
+                            "Flashloan default lender {:?} not found in flashloan wrappers",
+                            default_lender
+                        );
+                    }
+                }
+                config.contracts.flashloan_default_lender.map(Into::into)
+            },
             flashloan_wrappers: config.contracts.flashloan_wrappers,
             flashloan_router: config.contracts.flashloan_router.map(Into::into),
         },

--- a/crates/driver/src/infra/config/file/mod.rs
+++ b/crates/driver/src/infra/config/file/mod.rs
@@ -81,10 +81,6 @@ struct Config {
     /// Whether the flashloans feature is enabled.
     #[serde(default)]
     flashloans_enabled: bool,
-
-    /// If no lender is specified in flashloan hint, use this default lender.
-    #[serde(default)]
-    flashloans_default_lender: Option<eth::H160>,
 }
 
 #[serde_as]
@@ -382,6 +378,10 @@ struct ContractsConfig {
     /// Flashloan router to support taking out multiple flashloans
     /// in the same settlement.
     flashloan_router: Option<eth::H160>,
+
+    /// Address of the default flashloan lender that should be used as lender,
+    /// for all flashloans that don't have a specific lender set.
+    flashloan_default_lender: Option<eth::H160>,
 }
 
 #[derive(Debug, Clone, Deserialize)]

--- a/crates/driver/src/infra/config/file/mod.rs
+++ b/crates/driver/src/infra/config/file/mod.rs
@@ -5,7 +5,7 @@ use {
     serde::{Deserialize, Deserializer, Serialize},
     serde_with::serde_as,
     solver::solver::Arn,
-    std::{collections::HashMap, str::FromStr, time::Duration},
+    std::{collections::HashMap, time::Duration},
 };
 
 mod load;
@@ -83,8 +83,8 @@ struct Config {
     flashloans_enabled: bool,
 
     /// If no lender is specified in flashloan hint, use this default lender.
-    #[serde(default = "default_flashloans_lender")]
-    flashloans_default_lender: eth::H160,
+    #[serde(default)]
+    flashloans_default_lender: Option<eth::H160>,
 }
 
 #[serde_as]
@@ -751,11 +751,6 @@ fn default_max_order_age() -> Option<Duration> {
 
 fn default_simulation_bad_token_max_age() -> Duration {
     Duration::from_secs(600)
-}
-
-// SKY lending DAI token
-fn default_flashloans_lender() -> eth::H160 {
-    eth::H160::from_str("0x60744434d6339a6B27d73d9Eda62b6F66a0a04FA").unwrap()
 }
 
 #[serde_as]

--- a/crates/driver/src/infra/solver/dto/auction.rs
+++ b/crates/driver/src/infra/solver/dto/auction.rs
@@ -24,7 +24,7 @@ pub fn new(
     fee_handler: FeeHandler,
     solver_native_token: ManageNativeToken,
     flashloans_enabled: bool,
-    flashloan_default_lender: eth::Address,
+    flashloan_default_lender: Option<eth::Address>,
 ) -> solvers_dto::auction::Auction {
     let mut tokens: HashMap<eth::H160, _> = auction
         .tokens()
@@ -155,13 +155,15 @@ pub fn new(
                     app_data: AppDataHash(order.app_data.hash().0.into()),
                     flashloan_hint: flashloans_enabled
                         .then(|| {
-                            order.app_data.flashloan().map(|flashloan| {
-                                solvers_dto::auction::FlashloanHint {
-                                    lender: flashloan.lender.unwrap_or(flashloan_default_lender.0),
+                            order.app_data.flashloan().and_then(|flashloan| {
+                                let lender =
+                                    flashloan.lender.or(flashloan_default_lender.map(|l| l.0));
+                                lender.map(|lender| solvers_dto::auction::FlashloanHint {
+                                    lender,
                                     borrower: flashloan.borrower.unwrap_or(order.uid.owner().0),
                                     token: flashloan.token,
                                     amount: flashloan.amount,
-                                }
+                                })
                             })
                         })
                         .flatten(),

--- a/crates/driver/src/infra/solver/dto/auction.rs
+++ b/crates/driver/src/infra/solver/dto/auction.rs
@@ -24,7 +24,7 @@ pub fn new(
     fee_handler: FeeHandler,
     solver_native_token: ManageNativeToken,
     flashloans_enabled: bool,
-    flashloan_default_lender: Option<eth::Address>,
+    flashloan_default_lender: Option<eth::ContractAddress>,
 ) -> solvers_dto::auction::Auction {
     let mut tokens: HashMap<eth::H160, _> = auction
         .tokens()

--- a/crates/driver/src/infra/solver/mod.rs
+++ b/crates/driver/src/infra/solver/mod.rs
@@ -129,9 +129,6 @@ pub struct Config {
     pub settle_queue_size: usize,
     /// Whether flashloan hints should be sent to the solver.
     pub flashloans_enabled: bool,
-    /// If no lender is specified in flashloan hint, use default one (if
-    /// specified)
-    pub flashloan_default_lender: Option<eth::Address>,
 }
 
 impl Solver {
@@ -234,7 +231,7 @@ impl Solver {
             self.config.fee_handler,
             self.config.solver_native_token,
             self.config.flashloans_enabled,
-            self.config.flashloan_default_lender,
+            self.eth.contracts().flashloan_default_lender(),
         );
         // Only auctions with IDs are real auctions (/quote requests don't have an ID,
         // and it makes no sense to store them)

--- a/crates/driver/src/infra/solver/mod.rs
+++ b/crates/driver/src/infra/solver/mod.rs
@@ -129,8 +129,9 @@ pub struct Config {
     pub settle_queue_size: usize,
     /// Whether flashloan hints should be sent to the solver.
     pub flashloans_enabled: bool,
-    /// If no lender is specified in flashloan hint, use default one
-    pub flashloan_default_lender: eth::Address,
+    /// If no lender is specified in flashloan hint, use default one (if
+    /// specified)
+    pub flashloan_default_lender: Option<eth::Address>,
 }
 
 impl Solver {

--- a/crates/driver/src/tests/setup/solver.rs
+++ b/crates/driver/src/tests/setup/solver.rs
@@ -460,13 +460,14 @@ impl Solver {
                 helper_contract: config.blockchain.flashloan_wrapper.address(),
                 fee_in_bps: Default::default(),
             })
-            .collect();
+            .collect::<Vec<_>>();
         let eth = Ethereum::new(
             rpc,
             Addresses {
                 settlement: Some(config.blockchain.settlement.address().into()),
                 weth: Some(config.blockchain.weth.address().into()),
                 cow_amms: vec![],
+                flashloan_default_lender: flashloan_wrappers.first().map(|w| w.lender.into()),
                 flashloan_wrappers,
                 flashloan_router: Some(config.blockchain.flashloan_wrapper.address().into()),
             },


### PR DESCRIPTION
# Description
This PR makes the driver configuration for flashloans more production-ready.

Using MAKER(SKY) address as hardcoded default lender doesn't make sense anymore, because SKY only lends DAI token. If, instead, we wanted to replace it with AAVE or some other lender that lends all sorts of tokens, then it means this lender has to be deployed on all networks we support.

With that, it makes most sense to not have a hardcoded default lender and just define it in the infra, which should avoid weird bugs.

# Changes
<!-- List of detailed changes (how the change is accomplished) -->

- [ ] Removed default lender config in the driver

## How to test
Existing tests.

<!--
## Related Issues

Fixes #
-->