### PR TITLE
Fix default lender - improvement

### DIFF
--- a/crates/driver/src/infra/blockchain/contracts.rs
+++ b/crates/driver/src/infra/blockchain/contracts.rs
@@ -121,7 +121,7 @@ impl Contracts {
                 };
                 (wrapper_config.lender.into(), wrapper_data)
             })
-            .collect::<HashMap<_, _>>();
+            .collect();
 
         // TODO: use `address_for()` once contracts are deployed
         let flashloan_router = addresses

--- a/crates/driver/src/infra/blockchain/contracts.rs
+++ b/crates/driver/src/infra/blockchain/contracts.rs
@@ -177,6 +177,10 @@ impl Contracts {
         self.flashloan_wrapper_by_lender.get(lender)
     }
 
+    pub fn default_flashloan_lender(&self) -> Option<eth::ContractAddress> {
+        self.flashloan_wrapper_by_lender.keys().next().copied()
+    }
+
     pub fn flashloan_router(&self) -> Option<&contracts::FlashLoanRouter> {
         self.flashloan_router.as_ref()
     }

--- a/crates/driver/src/infra/blockchain/contracts.rs
+++ b/crates/driver/src/infra/blockchain/contracts.rs
@@ -31,6 +31,9 @@ pub struct Contracts {
     // TODO: make this non-optional when contracts are deployed
     // everywhere
     flashloan_router: Option<FlashLoanRouter>,
+    /// Default lender to use for flashloans, if flashloan doesn't have a lender
+    /// specified.
+    flashloan_default_lender: Option<eth::ContractAddress>,
 }
 
 #[derive(Debug, Clone)]
@@ -46,6 +49,7 @@ pub struct Addresses {
     pub cow_amms: Vec<CowAmmConfig>,
     pub flashloan_wrappers: Vec<config::file::FlashloanWrapperConfig>,
     pub flashloan_router: Option<eth::ContractAddress>,
+    pub flashloan_default_lender: Option<eth::ContractAddress>,
 }
 
 impl Contracts {
@@ -117,7 +121,7 @@ impl Contracts {
                 };
                 (wrapper_config.lender.into(), wrapper_data)
             })
-            .collect();
+            .collect::<HashMap<_, _>>();
 
         // TODO: use `address_for()` once contracts are deployed
         let flashloan_router = addresses
@@ -139,6 +143,7 @@ impl Contracts {
             cow_amm_registry,
             flashloan_wrapper_by_lender,
             flashloan_router,
+            flashloan_default_lender: addresses.flashloan_default_lender,
         })
     }
 
@@ -177,8 +182,8 @@ impl Contracts {
         self.flashloan_wrapper_by_lender.get(lender)
     }
 
-    pub fn default_flashloan_lender(&self) -> Option<eth::ContractAddress> {
-        self.flashloan_wrapper_by_lender.keys().next().copied()
+    pub fn flashloan_default_lender(&self) -> Option<eth::ContractAddress> {
+        self.flashloan_default_lender
     }
 
     pub fn flashloan_router(&self) -> Option<&contracts::FlashLoanRouter> {

--- a/crates/driver/src/infra/config/file/load.rs
+++ b/crates/driver/src/infra/config/file/load.rs
@@ -377,6 +377,23 @@ pub async fn load(chain: Chain, path: &Path) -> infra::Config {
                     helper: cfg.helper,
                 })
                 .collect(),
+            flashloan_default_lender: {
+                // Make sure flashloan default lender exists in the flashloan wrappers
+                if let Some(default_lender) = config.contracts.flashloan_default_lender {
+                    if !config
+                        .contracts
+                        .flashloan_wrappers
+                        .iter()
+                        .any(|wrapper| wrapper.lender == default_lender)
+                    {
+                        panic!(
+                            "Flashloan default lender {:?} not found in flashloan wrappers",
+                            default_lender
+                        );
+                    }
+                }
+                config.contracts.flashloan_default_lender.map(Into::into)
+            },
             flashloan_wrappers: config.contracts.flashloan_wrappers,
             flashloan_router: config.contracts.flashloan_router.map(Into::into),
         },

--- a/crates/driver/src/infra/config/file/load.rs
+++ b/crates/driver/src/infra/config/file/load.rs
@@ -137,7 +137,6 @@ pub async fn load(chain: Chain, path: &Path) -> infra::Config {
                 },
                 settle_queue_size: solver_config.settle_queue_size,
                 flashloans_enabled: config.flashloans_enabled,
-                flashloan_default_lender: config.flashloans_default_lender.map(Into::into),
             }
         }))
         .await,

--- a/crates/driver/src/infra/config/file/mod.rs
+++ b/crates/driver/src/infra/config/file/mod.rs
@@ -378,6 +378,10 @@ struct ContractsConfig {
     /// Flashloan router to support taking out multiple flashloans
     /// in the same settlement.
     flashloan_router: Option<eth::H160>,
+
+    /// Address of the default flashloan lender that should be used as lender,
+    /// for all flashloans that don't have a specific lender set.
+    flashloan_default_lender: Option<eth::H160>,
 }
 
 #[derive(Debug, Clone, Deserialize)]

--- a/crates/driver/src/infra/config/file/mod.rs
+++ b/crates/driver/src/infra/config/file/mod.rs
@@ -81,10 +81,6 @@ struct Config {
     /// Whether the flashloans feature is enabled.
     #[serde(default)]
     flashloans_enabled: bool,
-
-    /// If no lender is specified in flashloan hint, use this default lender.
-    #[serde(default)]
-    flashloans_default_lender: Option<eth::H160>,
 }
 
 #[serde_as]

--- a/crates/driver/src/infra/solver/dto/auction.rs
+++ b/crates/driver/src/infra/solver/dto/auction.rs
@@ -24,7 +24,7 @@ pub fn new(
     fee_handler: FeeHandler,
     solver_native_token: ManageNativeToken,
     flashloans_enabled: bool,
-    flashloan_default_lender: Option<eth::Address>,
+    flashloan_default_lender: Option<eth::ContractAddress>,
 ) -> solvers_dto::auction::Auction {
     let mut tokens: HashMap<eth::H160, _> = auction
         .tokens()

--- a/crates/driver/src/infra/solver/mod.rs
+++ b/crates/driver/src/infra/solver/mod.rs
@@ -231,7 +231,7 @@ impl Solver {
             self.config.fee_handler,
             self.config.solver_native_token,
             self.config.flashloans_enabled,
-            self.eth.contracts().default_flashloan_lender(),
+            self.eth.contracts().flashloan_default_lender(),
         );
         // Only auctions with IDs are real auctions (/quote requests don't have an ID,
         // and it makes no sense to store them)

--- a/crates/driver/src/infra/solver/mod.rs
+++ b/crates/driver/src/infra/solver/mod.rs
@@ -129,9 +129,6 @@ pub struct Config {
     pub settle_queue_size: usize,
     /// Whether flashloan hints should be sent to the solver.
     pub flashloans_enabled: bool,
-    /// If no lender is specified in flashloan hint, use default one (if
-    /// specified)
-    pub flashloan_default_lender: Option<eth::Address>,
 }
 
 impl Solver {
@@ -234,7 +231,7 @@ impl Solver {
             self.config.fee_handler,
             self.config.solver_native_token,
             self.config.flashloans_enabled,
-            self.config.flashloan_default_lender,
+            self.eth.contracts().default_flashloan_lender(),
         );
         // Only auctions with IDs are real auctions (/quote requests don't have an ID,
         // and it makes no sense to store them)

--- a/crates/driver/src/tests/setup/solver.rs
+++ b/crates/driver/src/tests/setup/solver.rs
@@ -467,6 +467,7 @@ impl Solver {
                 settlement: Some(config.blockchain.settlement.address().into()),
                 weth: Some(config.blockchain.weth.address().into()),
                 cow_amms: vec![],
+                flashloan_default_lender: flashloan_wrappers.first().map(|w| w.lender.into()),
                 flashloan_wrappers,
                 flashloan_router: Some(config.blockchain.flashloan_wrapper.address().into()),
             },

--- a/crates/driver/src/tests/setup/solver.rs
+++ b/crates/driver/src/tests/setup/solver.rs
@@ -460,7 +460,7 @@ impl Solver {
                 helper_contract: config.blockchain.flashloan_wrapper.address(),
                 fee_in_bps: Default::default(),
             })
-            .collect();
+            .collect::<Vec<_>>();
         let eth = Ethereum::new(
             rpc,
             Addresses {


### PR DESCRIPTION
# Description
Addresses https://github.com/cowprotocol/services/pull/3330#pullrequestreview-2697722134 by fetching the default lender from `contracts` driver config.

@squadgazzz would you prefer it this way, so that the default lender is always implicit -> first lender in the list of <lender, wrapper> pairs.

# Changes
<!-- List of detailed changes (how the change is accomplished) -->

- [ ] ...
- [ ] ...

## How to test
<!--- Include details of how to test your changes, including any pre-requisites. If no unit tests are included, please explain why and how to test manually
1.
2.
3.
-->

<!--
## Related Issues

Fixes #
-->