### PR TITLE
Update docs for feeAmount for OrderCreation

### DIFF
--- a/crates/orderbook/openapi.yml
+++ b/crates/orderbook/openapi.yml
@@ -748,7 +748,7 @@ components:
           description: "see `OrderParameters::validTo`"
           type: integer
         feeAmount:
-          description: "see `OrderParameters::feeAmount`"
+          description: "Deprecated: must be zero"
           allOf:
             - $ref: "#/components/schemas/TokenAmount"
         kind:


### PR DESCRIPTION
# Description
Some integrators are confused how to set the `feeAmount` in `OrderCreation` struct.

This value should be set to 0. This PR updates the openapi schema which should reflect the docs here:
https://docs.cow.fi/cow-protocol/reference/apis/orderbook

<img width="561" alt="Screenshot 2025-03-20 at 10 14 27" src="https://github.com/user-attachments/assets/d1215c5d-4fab-41a1-b890-26c5aa724264" />