### PR TITLE
Fix flashloan encoding

### DIFF
--- a/crates/driver/src/domain/competition/solution/encoding.rs
+++ b/crates/driver/src/domain/competition/solution/encoding.rs
@@ -235,8 +235,7 @@ pub fn tx(
                 &contracts.settlement().raw_instance().web3(),
                 flashloan.token.into(),
             )
-            .transfer_from(
-                contracts.settlement().address(),
+            .transfer(
                 flashloan_wrapper.helper_contract.address(),
                 repayment_amount,
             )


### PR DESCRIPTION
# Description
@mrnaveira did some manual testing of the flashloan feature on sepolia which showed a small bug in the flashloan related interactions injected into the settlement by the driver. This [simulation](https://dashboard.tenderly.co/shared/simulation/899885c7-0cb0-4cfa-ad19-1eb7208ecd61) showed that the transfer of the flashloan repayment amount from the settlement contract to the flashloan helper contract did not work because the correct approvals were set.
Instead of injecting another `approve()` transaction we can turn the `transferFrom()` into `transfer()` because the transfer happens in the context of the settlement contract and the spender is also the settlement contract.
This is more gas efficient and easier to understand.

# Changes
- convert `transferFrom()` into `transfer()`

## How to test
To test this change we deployed a custom image with this patch to the staging cluster and the test flashloan [order](https://explorer.cow.fi/sepolia/orders/0xe5e140e989a8ab8a66a8fe70d3dbd1095935d6a9355a21752c7f7a50d9e3e49b35ed9a9d1122a1544e031cc92fcc7ea599e28d9c67dc304c) finally went through. ([simulation](https://www.tdly.co/tx/0x753b65e09447f1fb783b5aabbb4c1e35cf4311fb08a1d9695130e587a4f6812d))
I did not investigate yet why the e2e test worked without this change, though.