### PR TITLE
ETH-flow refunder: allow negative slippage orders

### DIFF
--- a/crates/database/src/ethflow_orders.rs
+++ b/crates/database/src/ethflow_orders.rs
@@ -114,7 +114,7 @@ pub async fn refundable_orders(
     ex: &mut PgConnection,
     since_valid_to: i64,
     min_validity_duration: i64,
-    min_slippage: f64,
+    min_price_deviation: f64,
 ) -> Result<Vec<EthOrderPlacement>, sqlx::Error> {
     // condition (1.0 - o.buy_amount / GREATEST(oq.buy_amount,1)) >= $3 is added to
     // skip refunding orders that have unrealistic slippage set. Those orders are
@@ -145,7 +145,7 @@ AND eo.valid_to - extract(epoch from creation_timestamp)::int > $2
     sqlx::query_as(QUERY)
         .bind(since_valid_to)
         .bind(min_validity_duration)
-        .bind(min_slippage)
+        .bind(min_price_deviation)
         .fetch_all(ex)
         .await
 }

--- a/crates/e2e/tests/e2e/refunder.rs
+++ b/crates/e2e/tests/e2e/refunder.rs
@@ -126,7 +126,7 @@ async fn refunder_tx(web3: Web3) {
         web3,
         vec![ethflow_contract.clone(), ethflow_contract_2.clone()],
         validity_duration as i64 / 2,
-        10u64,
+        10i64,
         refunder.account().clone(),
     );
 

--- a/crates/refunder/src/arguments.rs
+++ b/crates/refunder/src/arguments.rs
@@ -30,12 +30,15 @@ pub struct Arguments {
     )]
     pub min_validity_duration: Duration,
 
-    /// Minimum slippage an order must have, in order
-    /// to be eligble for refunding
-    /// Front-end will place orders with a default slippage of 2%
-    /// hence, we are requiring as a default 190 bps or 1.9 %
+    /// Minimum *required* price deviation from quote (in basis points),
+    /// for an order to be eligible for refunding.
+    /// Negative values mean the order was placed with a better-than-quote price (more executable).
+    /// For example:
+    ///   - A value of `-10` allows refunding orders up to 0.10% better than quote
+    ///   - A value of `0` requires the order to be at least equal to quote
+    ///   - A value of `190` (default) allows refunding only orders with ≥1.9% worse price
     #[clap(long, env, default_value = "190")]
-    pub min_slippage_bps: u64,
+    pub min_price_deviation_bps: i64,
 
     /// Url of the Postgres database. By default connects to locally running
     /// postgres.
@@ -70,7 +73,7 @@ impl std::fmt::Display for Arguments {
             http_client,
             ethrpc,
             min_validity_duration,
-            min_slippage_bps,
+            min_price_deviation_bps: min_slippage_bps,
             node_url,
             chain_id,
             ethflow_contracts,

--- a/crates/refunder/src/arguments.rs
+++ b/crates/refunder/src/arguments.rs
@@ -75,7 +75,7 @@ impl std::fmt::Display for Arguments {
             http_client,
             ethrpc,
             min_validity_duration,
-            min_price_deviation_bps: min_slippage_bps,
+            min_price_deviation_bps,
             node_url,
             chain_id,
             ethflow_contracts,
@@ -89,7 +89,7 @@ impl std::fmt::Display for Arguments {
         write!(f, "{}", ethrpc)?;
         write!(f, "{}", logging)?;
         writeln!(f, "min_validity_duration: {:?}", min_validity_duration)?;
-        writeln!(f, "min_slippage_bps: {}", min_slippage_bps)?;
+        writeln!(f, "min_price_deviation_bps: {}", min_price_deviation_bps)?;
         let _intentionally_ignored = db_url;
         writeln!(f, "db_url: SECRET")?;
         writeln!(f, "node_url: {}", node_url)?;

--- a/crates/refunder/src/arguments.rs
+++ b/crates/refunder/src/arguments.rs
@@ -33,12 +33,12 @@ pub struct Arguments {
     /// Minimum *required* price deviation from quote (in basis points),
     /// for an order to be eligible for refunding.
     /// Negative values mean the order was placed with a better-than-quote price
-    /// (more executable). For example:
+    /// (less executable). For example:
     ///   - A value of `-10` allows refunding orders up to 0.10% better than
-    ///     quote
+    ///     quote(price improvement)
     ///   - A value of `0` requires the order to be at least equal to quote
     ///   - A value of `190` (default) allows refunding only orders with ≥1.9%
-    ///     worse price
+    ///     slippage
     #[clap(long, env, default_value = "190")]
     pub min_price_deviation_bps: i64,
 

--- a/crates/refunder/src/arguments.rs
+++ b/crates/refunder/src/arguments.rs
@@ -32,11 +32,13 @@ pub struct Arguments {
 
     /// Minimum *required* price deviation from quote (in basis points),
     /// for an order to be eligible for refunding.
-    /// Negative values mean the order was placed with a better-than-quote price (more executable).
-    /// For example:
-    ///   - A value of `-10` allows refunding orders up to 0.10% better than quote
+    /// Negative values mean the order was placed with a better-than-quote price
+    /// (more executable). For example:
+    ///   - A value of `-10` allows refunding orders up to 0.10% better than
+    ///     quote
     ///   - A value of `0` requires the order to be at least equal to quote
-    ///   - A value of `190` (default) allows refunding only orders with ≥1.9% worse price
+    ///   - A value of `190` (default) allows refunding only orders with ≥1.9%
+    ///     worse price
     #[clap(long, env, default_value = "190")]
     pub min_price_deviation_bps: i64,
 

--- a/crates/refunder/src/lib.rs
+++ b/crates/refunder/src/lib.rs
@@ -68,7 +68,7 @@ pub async fn run(args: arguments::Arguments) {
         web3,
         ethflow_contracts,
         i64::try_from(args.min_validity_duration.as_secs()).unwrap_or(i64::MAX),
-        args.min_slippage_bps,
+        args.min_price_deviation_bps,
         refunder_account,
     );
     loop {

--- a/crates/refunder/src/refund_service.rs
+++ b/crates/refunder/src/refund_service.rs
@@ -26,7 +26,7 @@ pub struct RefundService {
     pub web3: Web3,
     pub ethflow_contracts: Vec<CoWSwapEthFlow>,
     pub min_validity_duration: i64,
-    pub min_slippage: f64,
+    pub min_price_deviation: f64,
     pub submitter: Submitter,
 }
 
@@ -43,7 +43,7 @@ impl RefundService {
         web3: Web3,
         ethflow_contracts: Vec<CoWSwapEthFlow>,
         min_validity_duration: i64,
-        min_slippage_bps: u64,
+        min_price_deviation_bps: i64,
         account: Account,
     ) -> Self {
         RefundService {
@@ -51,7 +51,7 @@ impl RefundService {
             web3: web3.clone(),
             ethflow_contracts,
             min_validity_duration,
-            min_slippage: min_slippage_bps as f64 / 10000f64,
+            min_price_deviation: min_price_deviation_bps as f64 / 10000f64,
             submitter: Submitter {
                 web3: web3.clone(),
                 account,
@@ -81,7 +81,7 @@ impl RefundService {
             &mut ex,
             block_time,
             self.min_validity_duration,
-            self.min_slippage,
+            self.min_price_deviation,
         )
         .await
         .map_err(|err| {


### PR DESCRIPTION
# Description
A few similar eth-flow orders were not automatically refunded([example](https://explorer.cow.fi/arb1/orders/0x36a494c38ad0bab7c6f73187ba39df9293d4b9342fe7fa2830d56bf54436de8c552fcecc218158fff20e505c8f3ad24f8e1dd33cffffffff)) since the price specified in the order was a bit better than the quote's, as a result, the computed slippage was negative. The config currently supports the positive values only. This PR address this by allowing specifying the negative price deviations. This PR needs to be merged together with a corresponding infra PR since the config param was renamed.

## How to test
Observe logs.
