### PR TITLE
New logic to compute scores of buy order trades

### DIFF
--- a/crates/driver/example.toml
+++ b/crates/driver/example.toml
@@ -1,3 +1,5 @@
+buy-order-scoring-change-cutover = "2025-12-01T12:00:00Z"
+
 [[solver]]
 name = "mysolver" # Arbitrary name given to this solver, must be unique
 endpoint = "http://0.0.0.0:7872"

--- a/crates/driver/example.toml
+++ b/crates/driver/example.toml
@@ -1,4 +1,4 @@
-buy-order-scoring-change-cutover = "2025-12-01T12:00:00Z"
+buy-order-scoring-change-cutover = "1970-12-01T12:00:00Z"
 
 [[solver]]
 name = "mysolver" # Arbitrary name given to this solver, must be unique

--- a/crates/driver/src/domain/competition/auction.rs
+++ b/crates/driver/src/domain/competition/auction.rs
@@ -116,7 +116,9 @@ impl Auction {
         self.deadline
     }
 
-    pub fn prices(&self) -> Prices {
+    /// Prices used to convert token amounts to an equivalent amount of the
+    /// native asset (e.g. ETH on ethereum, or xdai on gnosis chain).
+    pub fn native_prices(&self) -> Prices {
         self.tokens
             .0
             .iter()
@@ -620,7 +622,7 @@ pub struct Token {
 /// The price of a token in wei. This represents how much wei is needed to buy
 /// 10**18 of another token.
 #[derive(Debug, Clone, Copy)]
-pub struct Price(eth::Ether);
+pub struct Price(pub eth::Ether);
 
 impl Price {
     /// The base Ether amount for pricing.

--- a/crates/driver/src/domain/competition/mod.rs
+++ b/crates/driver/src/domain/competition/mod.rs
@@ -219,7 +219,7 @@ impl Competition {
                 observe::scoring(&settlement);
                 (
                     settlement.score(
-                        &auction.prices(),
+                        &auction.native_prices(),
                         auction.surplus_capturing_jit_order_owners(),
                     ),
                     settlement,
@@ -541,7 +541,7 @@ fn merge(
         Reverse(
             solution
                 .scoring(
-                    &auction.prices(),
+                    &auction.native_prices(),
                     auction.surplus_capturing_jit_order_owners(),
                 )
                 .map(|score| score.0)

--- a/crates/driver/src/domain/competition/mod.rs
+++ b/crates/driver/src/domain/competition/mod.rs
@@ -61,6 +61,10 @@ pub struct Competition {
     pub settlements: Mutex<VecDeque<Settlement>>,
     pub bad_tokens: Arc<bad_tokens::Detector>,
     settle_queue: mpsc::Sender<SettleRequest>,
+    /// If the auction deadline is later than this timestamp the score
+    /// for buy orders will be computed based on the latest rules.
+    // TODO: remove after the cutover happened
+    pub buy_order_scoring_change_cutover: chrono::DateTime<chrono::Utc>,
 }
 
 impl Competition {
@@ -71,6 +75,7 @@ impl Competition {
         simulator: Simulator,
         mempools: Mempools,
         bad_tokens: Arc<bad_tokens::Detector>,
+        cip_12123_cutover: chrono::DateTime<chrono::Utc>,
     ) -> Arc<Self> {
         let (settle_sender, settle_receiver) = mpsc::channel(solver.settle_queue_size());
 
@@ -83,6 +88,7 @@ impl Competition {
             settlements: Default::default(),
             settle_queue: settle_sender,
             bad_tokens,
+            buy_order_scoring_change_cutover: cip_12123_cutover,
         });
 
         let competition_clone = Arc::clone(&competition);
@@ -150,10 +156,17 @@ impl Competition {
             }
         });
 
+        let use_new_scoring_logic =
+            auction.deadline().auction() >= self.buy_order_scoring_change_cutover;
         let all_solutions = match self.solver.solution_merging() {
             SolutionMerging::Allowed {
                 max_orders_per_merged_solution,
-            } => merge(solutions, auction, max_orders_per_merged_solution),
+            } => merge(
+                solutions,
+                auction,
+                max_orders_per_merged_solution,
+                use_new_scoring_logic,
+            ),
             SolutionMerging::Forbidden => solutions.collect(),
         };
 
@@ -221,6 +234,7 @@ impl Competition {
                     settlement.score(
                         &auction.native_prices(),
                         auction.surplus_capturing_jit_order_owners(),
+                        use_new_scoring_logic,
                     ),
                     settlement,
                 )
@@ -513,6 +527,7 @@ fn merge(
     solutions: impl Iterator<Item = Solution>,
     auction: &Auction,
     max_orders_per_merged_solution: usize,
+    use_new_scoring_logic: bool,
 ) -> Vec<Solution> {
     let mut merged: Vec<Solution> = Vec::new();
     // Limit the number of solutions to merge to avoid combinatorial explosion
@@ -543,6 +558,7 @@ fn merge(
                 .scoring(
                     &auction.native_prices(),
                     auction.surplus_capturing_jit_order_owners(),
+                    use_new_scoring_logic,
                 )
                 .map(|score| score.0)
                 .unwrap_or_default(),

--- a/crates/driver/src/domain/competition/solution/encoding.rs
+++ b/crates/driver/src/domain/competition/solution/encoding.rs
@@ -176,7 +176,7 @@ pub fn tx(
         max: solution.solver().slippage().absolute.map(Ether::into),
         // TODO configure min slippage
         min: None,
-        prices: auction.prices().clone(),
+        prices: auction.native_prices().clone(),
     };
 
     // Add all interactions needed to move flash loaned tokens around

--- a/crates/driver/src/domain/competition/solution/fee.rs
+++ b/crates/driver/src/domain/competition/solution/fee.rs
@@ -127,7 +127,13 @@ impl Fulfillment {
             }
             FeePolicy::Volume { factor } => {
                 let fee_from_volume = self.fee_from_volume(prices, *factor)?;
-                tracing::debug!(uid=?self.order().uid, ?fee_from_volume, executed=?self.executed(), surplus_fee=?self.surplus_fee(), "calculated protocol fee");
+                tracing::debug!(
+                    uid = ?self.order().uid,
+                    ?fee_from_volume,
+                    executed = ?self.executed(),
+                    surplus_fee = ?self.surplus_fee(),
+                    "calculated protocol fee"
+                );
                 Ok(fee_from_volume)
             }
         }
@@ -149,7 +155,15 @@ impl Fulfillment {
         let fee_from_volume = self.fee_from_volume(prices, max_volume_factor)?;
         // take the smaller of the two
         let protocol_fee = std::cmp::min(fee_from_surplus, fee_from_volume);
-        tracing::debug!(uid=?self.order().uid, ?fee_from_surplus, ?fee_from_volume, ?protocol_fee, executed=?self.executed(), surplus_fee=?self.surplus_fee(), "calculated protocol fee");
+        tracing::debug!(
+            uid = ?self.order().uid,
+            ?fee_from_surplus,
+            ?fee_from_volume,
+            ?protocol_fee,
+            executed = ?self.executed(),
+            surplus_fee = ?self.surplus_fee(),
+            "calculated protocol fee"
+        );
         Ok(protocol_fee)
     }
 

--- a/crates/driver/src/domain/competition/solution/mod.rs
+++ b/crates/driver/src/domain/competition/solution/mod.rs
@@ -225,6 +225,7 @@ impl Solution {
         &self,
         native_prices: &auction::Prices,
         surplus_capturing_jit_order_owners: &HashSet<eth::Address>,
+        use_new_score_logic: bool,
     ) -> Result<eth::Ether, error::Scoring> {
         let mut trades = Vec::with_capacity(self.trades.len());
         for trade in self.trades().iter().filter(|trade| {
@@ -256,8 +257,8 @@ impl Solution {
             ))
         }
 
-        let scoring = scoring::Scoring::new(trades);
-        scoring.score(native_prices).map_err(error::Scoring::from)
+        scoring::compute_score(&trades, native_prices, use_new_score_logic)
+            .map_err(error::Scoring::from)
     }
 
     /// Approval interactions necessary for encoding the settlement.

--- a/crates/driver/src/domain/competition/solution/mod.rs
+++ b/crates/driver/src/domain/competition/solution/mod.rs
@@ -220,10 +220,10 @@ impl Solution {
         }
     }
 
-    /// JIT score calculation as per CIP38
+    /// JIT score calculation.
     pub fn scoring(
         &self,
-        prices: &auction::Prices,
+        native_prices: &auction::Prices,
         surplus_capturing_jit_order_owners: &HashSet<eth::Address>,
     ) -> Result<eth::Ether, error::Scoring> {
         let mut trades = Vec::with_capacity(self.trades.len());
@@ -257,7 +257,7 @@ impl Solution {
         }
 
         let scoring = scoring::Scoring::new(trades);
-        scoring.score(prices).map_err(error::Scoring::from)
+        scoring.score(native_prices).map_err(error::Scoring::from)
     }
 
     /// Approval interactions necessary for encoding the settlement.

--- a/crates/driver/src/domain/competition/solution/scoring.rs
+++ b/crates/driver/src/domain/competition/solution/scoring.rs
@@ -86,8 +86,8 @@ impl Trade {
     ///
     /// [CIP-38](https://forum.cow.fi/t/cip-38-solver-computed-fees-rank-by-surplus/2061>) as the
     /// base of the score computation.
-    /// [CIP-XX](TODO) as the latest revision to avoid edge cases for certain
-    /// buy orders.
+    /// [Draft CIP](https://forum.cow.fi/t/cip-draft-updating-score-definition-for-buy-orders/2930)
+    /// as the latest revision to avoid edge cases for certain buy orders./
     ///
     /// Denominated in NATIVE token
     fn score(&self, native_prices: &auction::Prices) -> Result<eth::Ether, Error> {
@@ -487,7 +487,6 @@ mod tests {
         assert_eq!(old_score.0, 19731899115084598u128.into());
 
         let new_score = trade.score(&native_prices).unwrap();
-        // TODO: double check, this seems super low...
         assert_eq!(new_score.0, 911.into());
     }
 }

--- a/crates/driver/src/domain/competition/solution/scoring.rs
+++ b/crates/driver/src/domain/competition/solution/scoring.rs
@@ -494,7 +494,5 @@ mod tests {
         let new_score = trade.score(&native_prices).unwrap();
         // TODO: double check, this seems super low...
         assert_eq!(new_score.0, 911.into());
-
-        panic!("miep");
     }
 }

--- a/crates/driver/src/domain/competition/solution/scoring.rs
+++ b/crates/driver/src/domain/competition/solution/scoring.rs
@@ -445,7 +445,7 @@ mod tests {
 
     /// Tests that the new score computation limits the score of certain
     /// buy orders to a reasonable amount.
-    /// Data based is on this
+    /// Data is based on this
     /// [auction](https://api.cow.fi/base/api/v1/solver_competition/by_tx_hash/0xe3ef02493255f17c0abd2ff88c34682d35f0de4f4875a4653104e3453473d8d9).
     #[test]
     fn score_problematic_buy_order() {

--- a/crates/driver/src/domain/competition/solution/scoring.rs
+++ b/crates/driver/src/domain/competition/solution/scoring.rs
@@ -163,8 +163,6 @@ impl Trade {
 
     /// Surplus based on custom clearing prices returns the surplus after all
     /// fees have been applied and calculated over the price limits.
-    ///
-    /// Denominated in SURPLUS token
     fn surplus_over(&self, price_limits: PriceLimits) -> Result<eth::SurplusTokenAmount, Math> {
         match self.side {
             Side::Buy => {
@@ -352,7 +350,7 @@ impl Trade {
         Ok(self.surplus_over(limit_price)?)
     }
 
-    /// Protocol fee as a cut of surplus, denominated in SURPLUS token
+    /// Protocol fee as a cut of surplus.
     fn fee(
         &self,
         surplus: eth::SurplusTokenAmount,
@@ -382,7 +380,7 @@ impl Trade {
         Ok(multiplied.into())
     }
 
-    /// Protocol fee as a cut of the trade volume, denominated in SURPLUS token
+    /// Protocol fee as a cut of the trade volume.
     fn volume_fee(&self, factor: f64) -> Result<eth::SurplusTokenAmount, Error> {
         // Volume fee is specified as a `factor` from raw volume (before fee). Since
         // this module works with trades that already have the protocol fee applied, we

--- a/crates/driver/src/domain/competition/solution/scoring.rs
+++ b/crates/driver/src/domain/competition/solution/scoring.rs
@@ -27,8 +27,6 @@ use {
         },
         util::conv::u256::U256Ext,
     },
-    bigdecimal::Zero,
-    num::{CheckedAdd, CheckedSub},
 };
 
 /// Scoring contains trades with values as they are expected by the settlement
@@ -55,8 +53,11 @@ impl Scoring {
     /// Settlement score is valid only if all trade scores are valid.
     ///
     /// Denominated in NATIVE token
-    pub fn score(&self, prices: &auction::Prices) -> Result<eth::Ether, Error> {
-        self.trades.iter().map(|trade| trade.score(prices)).sum()
+    pub fn score(&self, native_prices: &auction::Prices) -> Result<eth::Ether, Error> {
+        self.trades
+            .iter()
+            .map(|trade| trade.score_old(native_prices))
+            .sum()
     }
 }
 
@@ -67,26 +68,30 @@ impl Scoring {
 // fees). Also, executed amount contains the fees for sell order.
 #[derive(Debug, Clone)]
 pub struct Trade {
-    sell: eth::Asset,
-    buy: eth::Asset,
+    /// signed sell token parameters of the order (i.e. limit price)
+    signed_sell: eth::Asset,
+    /// signed buy token parameters of the order (i.e. limit price)
+    signed_buy: eth::Asset,
     side: Side,
     executed: order::TargetAmount,
+    /// Price at which the order gets filled. This is based on the solution's
+    /// price vector and the necessary adjustements to incorporate fees.
     custom_price: CustomClearingPrices,
     policies: Vec<FeePolicy>,
 }
 
 impl Trade {
     pub fn new(
-        sell: eth::Asset,
-        buy: eth::Asset,
+        signed_sell: eth::Asset,
+        signed_buy: eth::Asset,
         side: Side,
         executed: order::TargetAmount,
         custom_price: CustomClearingPrices,
         policies: Vec<FeePolicy>,
     ) -> Self {
         Self {
-            sell,
-            buy,
+            signed_sell,
+            signed_buy,
             side,
             executed,
             custom_price,
@@ -94,19 +99,91 @@ impl Trade {
         }
     }
 
-    /// CIP38 score defined as surplus + protocol fee
+    /// Score defined as (surplus + protocol fees) first converted to buy
+    /// amounts and then converted to the native token.
+    ///
+    /// [CIP-38](https://forum.cow.fi/t/cip-38-solver-computed-fees-rank-by-surplus/2061>) as the
+    /// base of the score computation.
+    /// [CIP-XX](TODO) as the latest revision to avoid edge cases for certain
+    /// buy orders.
     ///
     /// Denominated in NATIVE token
-    fn score(&self, prices: &auction::Prices) -> Result<eth::Ether, Error> {
+    fn score(&self, native_prices: &auction::Prices) -> Result<eth::Ether, Error> {
         tracing::debug!("Scoring trade {:?}", self);
-        Ok(self.native_surplus(prices)? + self.native_protocol_fee(prices)?)
+        let native_price_buy = native_prices
+            .get(&self.signed_buy.token)
+            .ok_or(Error::MissingPrice(self.signed_buy.token))?;
+
+        let surplus_in_surplus_token = self
+            .user_surplus()?
+            .0
+            .checked_add(self.fees()?.0)
+            .ok_or(Error::Math(Math::Overflow))?;
+
+        let score = match self.side {
+            // `surplus` of sell orders is already in buy tokens so we simply convert it to ETH
+            Side::Sell => native_price_buy.in_eth(eth::TokenAmount(surplus_in_surplus_token)),
+            Side::Buy => {
+                // `surplus` of buy orders is in sell tokens. We start with following formula:
+                // buy_amount / sell_amount == buy_price / sell_price
+                //
+                // since `surplus` of buy orders is in sell tokens we convert to buy amount via:
+                // buy_amount == (buy_price / sell_price) * surplus
+                //
+                // to avoid loss of precision because we work with integers we first multiply
+                // and then divide:
+                // buy_amount = surplus * buy_price / sell_price
+                let surplus_in_buy_tokens: eth::U256 = surplus_in_surplus_token
+                    .full_mul(self.signed_buy.amount.0)
+                    .checked_div(self.signed_sell.amount.0.into())
+                    .ok_or(Error::Math(Math::DivisionByZero))?
+                    .try_into()
+                    .map_err(|_| Error::Math(Math::Overflow))?;
+
+                // Afterwards we convert the buy token surplus to the native token.
+                native_price_buy.in_eth(surplus_in_buy_tokens.into())
+            }
+        };
+        Ok(score)
+    }
+
+    /// Score defined as (surplus + protocol fees) per CIP-38.
+    ///
+    /// [CIP-38](https://forum.cow.fi/t/cip-38-solver-computed-fees-rank-by-surplus/2061>) as the
+    ///
+    /// Denominated in NATIVE token
+    // TODO: replace once we completely switch to new method.
+    fn score_old(&self, native_prices: &auction::Prices) -> Result<eth::Ether, Error> {
+        tracing::debug!("Scoring trade {:?}", self);
+
+        let surplus_in_surplus_token = self
+            .user_surplus()?
+            .0
+            .checked_add(self.fees()?.0)
+            .ok_or(Error::Math(Math::Overflow))?;
+
+        let score = match self.side {
+            Side::Sell => {
+                let native_price_buy = native_prices
+                    .get(&self.signed_buy.token)
+                    .ok_or(Error::MissingPrice(self.signed_buy.token))?;
+                native_price_buy.in_eth(eth::TokenAmount(surplus_in_surplus_token))
+            }
+            Side::Buy => {
+                let native_price_sell = native_prices
+                    .get(&self.signed_sell.token)
+                    .ok_or(Error::MissingPrice(self.signed_sell.token))?;
+                native_price_sell.in_eth(eth::TokenAmount(surplus_in_surplus_token))
+            }
+        };
+        Ok(score)
     }
 
     /// Surplus based on custom clearing prices returns the surplus after all
     /// fees have been applied and calculated over the price limits.
     ///
     /// Denominated in SURPLUS token
-    fn surplus_over(&self, price_limits: PriceLimits) -> Result<eth::Asset, Math> {
+    fn surplus_over(&self, price_limits: PriceLimits) -> Result<eth::SurplusTokenAmount, Math> {
         match self.side {
             Side::Buy => {
                 // scale limit sell to support partially fillable orders
@@ -150,45 +227,22 @@ impl Trade {
                 bought.checked_sub(limit_buy).ok_or(Math::Negative)
             }
         }
-        .map(|surplus| eth::Asset {
-            token: self.surplus_token(),
-            amount: surplus.into(),
-        })
-    }
-
-    /// Surplus based on custom clearing prices returns the surplus after all
-    /// fees have been applied.
-    ///
-    /// Denominated in NATIVE token
-    fn native_surplus(&self, prices: &auction::Prices) -> Result<eth::Ether, Error> {
-        let surplus = self.surplus_over_limit_price()?;
-        let price = prices
-            .get(&surplus.token)
-            .ok_or(Error::MissingPrice(surplus.token))?;
-
-        Ok(price.in_eth(surplus.amount))
+        .map(eth::SurplusTokenAmount)
     }
 
     /// Protocol fees are defined by fee policies attached to the order.
-    ///
-    /// Denominated in SURPLUS token
-    fn protocol_fees(&self) -> Result<Vec<eth::Asset>, Error> {
+    fn fees(&self) -> Result<eth::SurplusTokenAmount, Error> {
         let mut current_trade = self.clone();
-        let mut total = eth::TokenAmount::default();
-        let mut fees = vec![];
-        for (i, protocol_fee) in self.policies.iter().enumerate().rev() {
-            let fee = current_trade.protocol_fee(protocol_fee)?;
-            // Do not need to calculate the last custom prices because in the last iteration
-            // the prices are not used anymore to calculate the protocol fee
-            fees.push(fee);
-            total += fee.amount;
-            if !i.is_zero() {
-                current_trade.custom_price = self.calculate_custom_prices(total)?;
-            }
+        let mut total = eth::SurplusTokenAmount::default();
+        for protocol_fee in self.policies.iter().rev() {
+            total = total
+                .0
+                .checked_add(current_trade.protocol_fee(protocol_fee)?.0)
+                .ok_or(Error::Math(Math::Overflow))?
+                .into();
+            current_trade.custom_price = self.calculate_custom_prices(total)?;
         }
-        // Reverse the fees to have them in the same order as the policies
-        fees.reverse();
-        Ok(fees)
+        Ok(total)
     }
 
     /// The effective amount that left the user's wallet including all fees.
@@ -233,41 +287,39 @@ impl Trade {
     /// Note how the custom prices are expressed over actual traded amounts.
     pub fn calculate_custom_prices(
         &self,
-        protocol_fee: eth::TokenAmount,
+        protocol_fee: eth::SurplusTokenAmount,
     ) -> Result<CustomClearingPrices, error::Math> {
         Ok(CustomClearingPrices {
             sell: match self.side {
                 Side::Sell => self
                     .buy_amount()?
-                    .checked_add(&protocol_fee)
+                    .0
+                    .checked_add(protocol_fee.0)
                     .ok_or(Math::Overflow)?,
-                Side::Buy => self.buy_amount()?,
-            }
-            .0,
+                Side::Buy => self.buy_amount()?.0,
+            },
             buy: match self.side {
-                Side::Sell => self.sell_amount()?,
+                Side::Sell => self.sell_amount()?.0,
                 Side::Buy => self
                     .sell_amount()?
-                    .checked_sub(&protocol_fee)
+                    .0
+                    .checked_sub(protocol_fee.0)
                     .ok_or(Math::Negative)?,
-            }
-            .0,
+            },
         })
     }
 
     /// Protocol fee is defined by a fee policy attached to the order.
-    ///
-    /// Denominated in SURPLUS token
-    fn protocol_fee(&self, fee_policy: &FeePolicy) -> Result<eth::Asset, Error> {
+    fn protocol_fee(&self, fee_policy: &FeePolicy) -> Result<eth::SurplusTokenAmount, Error> {
         let amount = match fee_policy {
             FeePolicy::Surplus {
                 factor,
                 max_volume_factor,
             } => {
-                let surplus = self.surplus_over_limit_price()?;
+                let surplus = self.user_surplus()?;
                 std::cmp::min(
-                    self.surplus_fee(surplus, *factor)?.amount,
-                    self.volume_fee(*max_volume_factor)?.amount,
+                    self.fee(surplus, *factor)?,
+                    self.volume_fee(*max_volume_factor)?,
                 )
             }
             FeePolicy::PriceImprovement {
@@ -277,23 +329,20 @@ impl Trade {
             } => {
                 let price_improvement = self.price_improvement(quote)?;
                 std::cmp::min(
-                    self.surplus_fee(price_improvement, *factor)?.amount,
-                    self.volume_fee(*max_volume_factor)?.amount,
+                    self.fee(price_improvement, *factor)?,
+                    self.volume_fee(*max_volume_factor)?,
                 )
             }
-            FeePolicy::Volume { factor } => self.volume_fee(*factor)?.amount,
+            FeePolicy::Volume { factor } => self.volume_fee(*factor)?,
         };
-        Ok(eth::Asset {
-            token: self.surplus_token(),
-            amount,
-        })
+        Ok(eth::SurplusTokenAmount(amount.0))
     }
 
-    fn price_improvement(&self, quote: &order::Quote) -> Result<eth::Asset, Error> {
+    fn price_improvement(&self, quote: &order::Quote) -> Result<eth::SurplusTokenAmount, Error> {
         let quote = adjust_quote_to_order_limits(
             fee::Order {
-                sell_amount: self.sell.amount.0,
-                buy_amount: self.buy.amount.0,
+                sell_amount: self.signed_sell.amount.0,
+                buy_amount: self.signed_buy.amount.0,
                 side: self.side,
             },
             fee::Quote {
@@ -306,24 +355,27 @@ impl Trade {
         // negative surplus is not error in this case, as solutions often have no
         // improvement over quote which results in negative surplus
         if let Err(Math::Negative) = surplus {
-            return Ok(eth::Asset {
-                token: self.surplus_token(),
-                amount: 0.into(),
-            });
+            return Ok(eth::SurplusTokenAmount(0.into()));
         }
         Ok(surplus?)
     }
 
-    fn surplus_over_limit_price(&self) -> Result<eth::Asset, Error> {
+    /// Amount of value the user got above the order's limit price
+    /// denominated in the surplus token.
+    fn user_surplus(&self) -> Result<eth::SurplusTokenAmount, Error> {
         let limit_price = PriceLimits {
-            sell: self.sell.amount,
-            buy: self.buy.amount,
+            sell: self.signed_sell.amount,
+            buy: self.signed_buy.amount,
         };
         Ok(self.surplus_over(limit_price)?)
     }
 
     /// Protocol fee as a cut of surplus, denominated in SURPLUS token
-    fn surplus_fee(&self, surplus: eth::Asset, factor: f64) -> Result<eth::Asset, Error> {
+    fn fee(
+        &self,
+        surplus: eth::SurplusTokenAmount,
+        factor: f64,
+    ) -> Result<eth::SurplusTokenAmount, Error> {
         // Surplus fee is specified as a `factor` from raw surplus (before fee). Since
         // this module works with trades that already have the protocol fee applied, we
         // need to calculate the protocol fee as an observation of the eventually traded
@@ -341,19 +393,15 @@ impl Trade {
         //
         // Finally:
         //     fee = surplus_after_fee * factor / (1 - factor)
-        let fee = surplus
-            .amount
-            .apply_factor(factor / (1.0 - factor))
-            .ok_or(Math::Overflow)?;
-
-        Ok(eth::Asset {
-            token: surplus.token,
-            amount: fee,
-        })
+        let multiplied = surplus
+            .0
+            .mul_f64(factor / (1.0 - factor))
+            .ok_or(Error::Math(Math::Overflow))?;
+        Ok(multiplied.into())
     }
 
     /// Protocol fee as a cut of the trade volume, denominated in SURPLUS token
-    fn volume_fee(&self, factor: f64) -> Result<eth::Asset, Error> {
+    fn volume_fee(&self, factor: f64) -> Result<eth::SurplusTokenAmount, Error> {
         // Volume fee is specified as a `factor` from raw volume (before fee). Since
         // this module works with trades that already have the protocol fee applied, we
         // need to calculate the protocol fee as an observation of a the eventually
@@ -383,44 +431,16 @@ impl Trade {
         // case Sell: fee = traded_buy_amount' * factor / (1 - factor)
         // case Buy: fee = traded_sell_amount' * factor / (1 + factor)
         let executed_in_surplus_token = match self.side {
-            order::Side::Buy => self.sell_amount()?,
-            order::Side::Sell => self.buy_amount()?,
+            order::Side::Buy => eth::SurplusTokenAmount(self.sell_amount()?.0),
+            order::Side::Sell => eth::SurplusTokenAmount(self.buy_amount()?.0),
         };
         let factor = match self.side {
             Side::Sell => factor / (1.0 - factor),
             Side::Buy => factor / (1.0 + factor),
         };
 
-        Ok(eth::Asset {
-            token: self.surplus_token(),
-            amount: {
-                executed_in_surplus_token
-                    .apply_factor(factor)
-                    .ok_or(Math::Overflow)?
-            },
-        })
-    }
-
-    /// Protocol fee is defined by fee policies attached to the order.
-    ///
-    /// Denominated in NATIVE token
-    fn native_protocol_fee(&self, prices: &auction::Prices) -> Result<eth::Ether, Error> {
-        self.protocol_fees()?
-            .into_iter()
-            .map(|fee| {
-                let price = prices
-                    .get(&fee.token)
-                    .ok_or(Error::MissingPrice(fee.token))?;
-                Ok(price.in_eth(fee.amount))
-            })
-            .sum()
-    }
-
-    fn surplus_token(&self) -> eth::TokenAddress {
-        match self.side {
-            Side::Buy => self.sell.token,
-            Side::Sell => self.buy.token,
-        }
+        let multiplied = executed_in_surplus_token.0.mul_f64(factor).ok_or(Error::Math(Math::Overflow))?;
+        Ok(multiplied.into())
     }
 }
 

--- a/crates/driver/src/domain/competition/solution/scoring.rs
+++ b/crates/driver/src/domain/competition/solution/scoring.rs
@@ -456,11 +456,11 @@ mod tests {
         // using the original scoring mechanism.
         let trade = Trade {
             signed_sell: eth::Asset {
-                token: weth.clone().into(),
+                token: weth.into(),
                 amount: 9865986634773384514560000000000000u128.into(),
             },
             signed_buy: eth::Asset {
-                token: bnkr.clone().into(),
+                token: bnkr.into(),
                 amount: 4025333872768468868566822740u128.into(),
             },
             side: Side::Buy,
@@ -474,13 +474,10 @@ mod tests {
 
         let native_prices: HashMap<_, _> = [
             (
-                weth.clone().into(),
+                weth.into(),
                 Price(eth::Ether(1000000000000000000u128.into())),
             ),
-            (
-                bnkr.clone().into(),
-                Price(eth::Ether(113181296327u128.into())),
-            ),
+            (bnkr.into(), Price(eth::Ether(113181296327u128.into()))),
         ]
         .into_iter()
         .collect();

--- a/crates/driver/src/domain/competition/solution/scoring.rs
+++ b/crates/driver/src/domain/competition/solution/scoring.rs
@@ -377,7 +377,7 @@ impl Trade {
         //     fee = surplus_after_fee * factor / (1 - factor)
         let multiplied = surplus
             .0
-            .mul_f64(factor / (1.0 - factor))
+            .checked_mul_f64(factor / (1.0 - factor))
             .ok_or(Error::Math(Math::Overflow))?;
         Ok(multiplied.into())
     }
@@ -423,7 +423,7 @@ impl Trade {
 
         let multiplied = executed_in_surplus_token
             .0
-            .mul_f64(factor)
+            .checked_mul_f64(factor)
             .ok_or(Error::Math(Math::Overflow))?;
         Ok(multiplied.into())
     }

--- a/crates/driver/src/domain/competition/solution/settlement.rs
+++ b/crates/driver/src/domain/competition/solution/settlement.rs
@@ -242,9 +242,13 @@ impl Settlement {
         &self,
         prices: &auction::Prices,
         surplus_capturing_jit_order_owners: &HashSet<eth::Address>,
+        use_new_scoring_logic: bool,
     ) -> Result<eth::Ether, solution::error::Scoring> {
-        self.solution
-            .scoring(prices, surplus_capturing_jit_order_owners)
+        self.solution.scoring(
+            prices,
+            surplus_capturing_jit_order_owners,
+            use_new_scoring_logic,
+        )
     }
 
     /// The solution encoded in this settlement.

--- a/crates/driver/src/domain/eth/mod.rs
+++ b/crates/driver/src/domain/eth/mod.rs
@@ -1,5 +1,5 @@
 use {
-    crate::util::Bytes,
+    crate::util::{Bytes, conv::u256::U256Ext},
     derive_more::{From, Into},
     itertools::Itertools,
     std::{
@@ -126,23 +126,15 @@ pub struct TokenAmount(pub U256);
 
 impl TokenAmount {
     /// Applies a factor to the token amount.
-    ///
-    /// The factor is first multiplied by 10^18 to convert it to integer, to
-    /// avoid rounding to 0. Then, the token amount is divided by 10^18 to
-    /// convert it back to the original scale.
-    ///
-    /// The higher the conversion factor (10^18) the precision is higher. E.g.
-    /// 0.123456789123456789 will be converted to 123456789123456789.
     pub fn apply_factor(&self, factor: f64) -> Option<Self> {
-        Some(
-            (self
-                .0
-                .checked_mul(U256::from_f64_lossy(factor * 1000000000000000000.))?
-                / 1000000000000000000u128)
-                .into(),
-        )
+        Some(self.0.mul_f64(factor)?.into())
     }
 }
+
+/// A value denominated in an order's surplus token (buy token for
+/// sell orders and sell token for buy orders).
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, From, Into)]
+pub struct SurplusTokenAmount(pub U256);
 
 impl Sub<Self> for TokenAmount {
     type Output = TokenAmount;

--- a/crates/driver/src/domain/eth/mod.rs
+++ b/crates/driver/src/domain/eth/mod.rs
@@ -127,7 +127,7 @@ pub struct TokenAmount(pub U256);
 impl TokenAmount {
     /// Applies a factor to the token amount.
     pub fn apply_factor(&self, factor: f64) -> Option<Self> {
-        Some(self.0.mul_f64(factor)?.into())
+        Some(self.0.checked_mul_f64(factor)?.into())
     }
 }
 

--- a/crates/driver/src/infra/api/mod.rs
+++ b/crates/driver/src/infra/api/mod.rs
@@ -34,6 +34,7 @@ pub struct Api {
     pub mempools: Mempools,
     pub addr: SocketAddr,
     pub bad_token_detector: bad_tokens::simulation::Detector,
+    pub buy_order_scoring_change_cutover: chrono::DateTime<chrono::Utc>,
     /// If this channel is specified, the bound address will be sent to it. This
     /// allows the driver to bind to 0.0.0.0:0 during testing.
     pub addr_sender: Option<oneshot::Sender<SocketAddr>>,
@@ -107,6 +108,7 @@ impl Api {
                     self.simulator.clone(),
                     self.mempools.clone(),
                     Arc::new(bad_tokens),
+                    self.buy_order_scoring_change_cutover,
                 ),
                 liquidity: self.liquidity.clone(),
                 tokens: tokens.clone(),

--- a/crates/driver/src/infra/config/file/load.rs
+++ b/crates/driver/src/infra/config/file/load.rs
@@ -404,5 +404,6 @@ pub async fn load(chain: Chain, path: &Path) -> infra::Config {
         archive_node_url: config.archive_node_url,
         simulation_bad_token_max_age: config.simulation_bad_token_max_age,
         app_data_fetching: config.app_data_fetching,
+        buy_order_scoring_change_cutover: config.buy_order_scoring_change_cutover,
     }
 }

--- a/crates/driver/src/infra/config/file/mod.rs
+++ b/crates/driver/src/infra/config/file/mod.rs
@@ -81,6 +81,10 @@ struct Config {
     /// Whether the flashloans feature is enabled.
     #[serde(default)]
     flashloans_enabled: bool,
+
+    /// Time at which the buy order scoring change should go into
+    /// effect (based on `deadline` in `/solve` request).
+    buy_order_scoring_change_cutover: chrono::DateTime<chrono::Utc>,
 }
 
 #[serde_as]

--- a/crates/driver/src/infra/config/file/mod.rs
+++ b/crates/driver/src/infra/config/file/mod.rs
@@ -84,6 +84,7 @@ struct Config {
 
     /// Time at which the buy order scoring change should go into
     /// effect (based on `deadline` in `/solve` request).
+    #[serde(default = "default_buy_order_scoring_change_cutover")]
     buy_order_scoring_change_cutover: chrono::DateTime<chrono::Utc>,
 }
 
@@ -888,4 +889,10 @@ fn default_metrics_bad_token_detector_freeze_time() -> Duration {
 /// With this default, the approximate size of the cache will be ~1.6 MB.
 fn default_app_data_cache_size() -> u64 {
     2000
+}
+
+/// Time when the solution score computation is supposed to change
+/// according to [CIP-65](https://snapshot.box/#/s:cow.eth/proposal/0xd172281444c48254398881c57a57a2acbf0802a385e6c94384fd358b943aa4f4).
+fn default_buy_order_scoring_change_cutover() -> chrono::DateTime<chrono::Utc> {
+    "2025-04-16T12:00:00Z".parse().unwrap()
 }

--- a/crates/driver/src/infra/config/mod.rs
+++ b/crates/driver/src/infra/config/mod.rs
@@ -31,4 +31,5 @@ pub struct Config {
     pub archive_node_url: Option<Url>,
     pub simulation_bad_token_max_age: Duration,
     pub app_data_fetching: AppDataFetching,
+    pub buy_order_scoring_change_cutover: chrono::DateTime<chrono::Utc>,
 }

--- a/crates/driver/src/run.rs
+++ b/crates/driver/src/run.rs
@@ -81,6 +81,7 @@ async fn run_with(args: cli::Args, addr_sender: Option<oneshot::Sender<SocketAdd
             &eth,
         ),
         eth,
+        buy_order_scoring_change_cutover: config.buy_order_scoring_change_cutover,
         addr: args.addr,
         addr_sender,
     }

--- a/crates/driver/src/tests/cases/jit_orders.rs
+++ b/crates/driver/src/tests/cases/jit_orders.rs
@@ -152,8 +152,8 @@ async fn surplus_protocol_fee_jit_order_from_surplus_capturing_owner_not_capped(
                     side: Side::Buy,
                 },
             },
-            // Score is 20 x 2 since there are two orders with score 20 (user order + JIT order)
-            expected_score: 40.ether().into_wei(),
+            // TODO explain how we arrive at a score of 32 now...
+            expected_score: 32.ether().into_wei(),
         },
     };
 
@@ -190,8 +190,8 @@ async fn surplus_protocol_fee_jit_order_not_capped() {
                     side: Side::Buy,
                 },
             },
-            // Score is 20 since the JIT order is not from a surplus capturing owner
-            expected_score: 20.ether().into_wei(),
+            // TODO explain how we arrive at a score of 16 now...
+            expected_score: 16.ether().into_wei(),
         },
     };
 

--- a/crates/driver/src/tests/cases/jit_orders.rs
+++ b/crates/driver/src/tests/cases/jit_orders.rs
@@ -152,7 +152,8 @@ async fn surplus_protocol_fee_jit_order_from_surplus_capturing_owner_not_capped(
                     side: Side::Buy,
                 },
             },
-            // TODO explain how we arrive at a score of 32 now...
+            // Surplus is 40 ETH worth of sell tokens, converted to buy tokens using the order's
+            // limit price (50 / 60 = 80%) this leaves us with a score of 32 ETH.
             expected_score: 32.ether().into_wei(),
         },
     };
@@ -190,7 +191,8 @@ async fn surplus_protocol_fee_jit_order_not_capped() {
                     side: Side::Buy,
                 },
             },
-            // TODO explain how we arrive at a score of 16 now...
+            // Surplus is 20 ETH worth of sell tokens, converted to buy tokens using the order's
+            // limit price (40 / 50 = 80%) this leaves us with a score of 16 ETH.
             expected_score: 16.ether().into_wei(),
         },
     };

--- a/crates/driver/src/tests/cases/protocol_fees.rs
+++ b/crates/driver/src/tests/cases/protocol_fees.rs
@@ -1394,7 +1394,7 @@ async fn price_improvement_fee_partial_buy_in_market_order_capped() {
         },
         // Surplus is 20 ETH worth of sell tokens, converted to buy tokens using the order's
         // limit price (50 / 75 = 66.6%) this leaves us with a score of 13.3 ETH.
-        expected_score: 13.3333333333333333.ether().into_wei(),
+        expected_score: 13.333333333333333.ether().into_wei(),
         fee_handler: FeeHandler::Driver,
     };
     protocol_fee_test_case(test_case).await;

--- a/crates/driver/src/tests/cases/protocol_fees.rs
+++ b/crates/driver/src/tests/cases/protocol_fees.rs
@@ -1394,7 +1394,7 @@ async fn price_improvement_fee_partial_buy_in_market_order_capped() {
         },
         // Surplus is 20 ETH worth of sell tokens, converted to buy tokens using the order's
         // limit price (50 / 75 = 66.6%) this leaves us with a score of 13.3 ETH.
-        expected_score: 13.33333333333333333.ether().into_wei(),
+        expected_score: 13.3333333333333333.ether().into_wei(),
         fee_handler: FeeHandler::Driver,
     };
     protocol_fee_test_case(test_case).await;

--- a/crates/driver/src/tests/cases/protocol_fees.rs
+++ b/crates/driver/src/tests/cases/protocol_fees.rs
@@ -143,7 +143,7 @@ async fn triple_surplus_protocol_fee_buy_order_not_capped() {
                 buy: 40.ether().into_wei(),
             },
         },
-        expected_score: 20.ether().into_wei(),
+        expected_score: 16.ether().into_wei(),
         fee_handler: FeeHandler::Driver,
     };
 
@@ -228,7 +228,7 @@ async fn surplus_and_volume_protocol_fee_buy_order_not_capped() {
                 buy: 40.ether().into_wei(),
             },
         },
-        expected_score: 20.ether().into_wei(),
+        expected_score: 13.3333333333333.ether().into_wei(),
         fee_handler: FeeHandler::Driver,
     };
     protocol_fee_test_case(test_case).await;
@@ -332,7 +332,7 @@ async fn surplus_and_price_improvement_fee_buy_in_market_order_not_capped() {
                 buy: 40.ether().into_wei(),
             },
         },
-        expected_score: 20.ether().into_wei(),
+        expected_score: 13.33333333333333.ether().into_wei(),
         fee_handler: FeeHandler::Driver,
     };
     protocol_fee_test_case(test_case).await;
@@ -365,7 +365,7 @@ async fn surplus_protocol_fee_buy_order_not_capped() {
                 buy: 40.ether().into_wei(),
             },
         },
-        expected_score: 20.ether().into_wei(),
+        expected_score: 16.ether().into_wei(),
         fee_handler: FeeHandler::Driver,
     };
 
@@ -396,7 +396,7 @@ async fn protocol_fee_calculated_on_the_solver_side() {
                 buy: 40.ether().into_wei(),
             },
         },
-        expected_score: 35.ether().into_wei(),
+        expected_score: 28.ether().into_wei(),
         fee_handler: FeeHandler::Solver,
     };
 
@@ -527,7 +527,7 @@ async fn surplus_protocol_fee_buy_order_capped() {
                 buy: 40.ether().into_wei(),
             },
         },
-        expected_score: 20.ether().into_wei(),
+        expected_score: 16.ether().into_wei(),
         fee_handler: FeeHandler::Driver,
     };
     protocol_fee_test_case(test_case).await;
@@ -651,7 +651,7 @@ async fn volume_protocol_fee_buy_order() {
                 buy: 40.ether().into_wei(),
             },
         },
-        expected_score: 20.ether().into_wei(),
+        expected_score: 16.ether().into_wei(),
         fee_handler: FeeHandler::Driver,
     };
     protocol_fee_test_case(test_case).await;
@@ -681,7 +681,7 @@ async fn volume_protocol_fee_buy_order_at_limit_price() {
                 buy: 40.ether().into_wei(),
             },
         },
-        expected_score: 10.ether().into_wei(),
+        expected_score: 8.ether().into_wei(),
         fee_handler: FeeHandler::Driver,
     };
     protocol_fee_test_case(test_case).await;
@@ -896,7 +896,7 @@ async fn price_improvement_fee_buy_in_market_order_not_capped() {
                 buy: 40.ether().into_wei(),
             },
         },
-        expected_score: 20.ether().into_wei(),
+        expected_score: 13.33333333333333.ether().into_wei(),
         fee_handler: FeeHandler::Driver,
     };
     protocol_fee_test_case(test_case).await;
@@ -974,7 +974,7 @@ async fn price_improvement_fee_buy_out_of_market_order_not_capped() {
                 buy: 40.ether().into_wei(),
             },
         },
-        expected_score: 10.ether().into_wei(),
+        expected_score: 8.ether().into_wei(),
         fee_handler: FeeHandler::Driver,
     };
     protocol_fee_test_case(test_case).await;
@@ -1052,7 +1052,8 @@ async fn price_improvement_fee_buy_in_market_order_capped() {
                 buy: 40.ether().into_wei(),
             },
         },
-        expected_score: 20.ether().into_wei(),
+        // TODO explain how we get 13.3333 now...
+        expected_score: 13.33333333333333.ether().into_wei(),
         fee_handler: FeeHandler::Driver,
     };
     protocol_fee_test_case(test_case).await;
@@ -1130,7 +1131,7 @@ async fn price_improvement_fee_buy_out_of_market_order_capped() {
                 buy: 40.ether().into_wei(),
             },
         },
-        expected_score: 10.ether().into_wei(),
+        expected_score: 8.ether().into_wei(),
         fee_handler: FeeHandler::Driver,
     };
     protocol_fee_test_case(test_case).await;
@@ -1208,7 +1209,7 @@ async fn price_improvement_fee_partial_buy_in_market_order_not_capped() {
                 buy: 20.ether().into_wei(),
             },
         },
-        expected_score: 15.ether().into_wei(),
+        expected_score: 12.ether().into_wei(),
         fee_handler: FeeHandler::Driver,
     };
     protocol_fee_test_case(test_case).await;
@@ -1366,7 +1367,7 @@ async fn price_improvement_fee_partial_buy_in_market_order_capped() {
                 buy: 20.ether().into_wei(),
             },
         },
-        expected_score: 20.ether().into_wei(),
+        expected_score: 13.33333333333333333.ether().into_wei(),
         fee_handler: FeeHandler::Driver,
     };
     protocol_fee_test_case(test_case).await;

--- a/crates/driver/src/tests/cases/protocol_fees.rs
+++ b/crates/driver/src/tests/cases/protocol_fees.rs
@@ -143,6 +143,8 @@ async fn triple_surplus_protocol_fee_buy_order_not_capped() {
                 buy: 40.ether().into_wei(),
             },
         },
+        // Surplus is 20 ETH worth of sell tokens, converted to buy tokens using the order's
+        // limit price (50 / 60 = 80%) this leaves us with a score of 16 ETH.
         expected_score: 16.ether().into_wei(),
         fee_handler: FeeHandler::Driver,
     };
@@ -228,6 +230,8 @@ async fn surplus_and_volume_protocol_fee_buy_order_not_capped() {
                 buy: 40.ether().into_wei(),
             },
         },
+        // Surplus is 20 ETH worth of sell tokens, converted to buy tokens using the order's
+        // limit price (40 / 60 = 66.6%) this leaves us with a score of 13.3 ETH.
         expected_score: 13.3333333333333.ether().into_wei(),
         fee_handler: FeeHandler::Driver,
     };
@@ -332,6 +336,8 @@ async fn surplus_and_price_improvement_fee_buy_in_market_order_not_capped() {
                 buy: 40.ether().into_wei(),
             },
         },
+        // Surplus is 20 ETH worth of sell tokens, converted to buy tokens using the order's
+        // limit price (40 / 60 = 66.6%) this leaves us with a score of 13.3 ETH.
         expected_score: 13.33333333333333.ether().into_wei(),
         fee_handler: FeeHandler::Driver,
     };
@@ -365,6 +371,8 @@ async fn surplus_protocol_fee_buy_order_not_capped() {
                 buy: 40.ether().into_wei(),
             },
         },
+        // Surplus is 20 ETH worth of sell tokens, converted to buy tokens using the order's
+        // limit price (40 / 50 = 80%) this leaves us with a score of 16 ETH.
         expected_score: 16.ether().into_wei(),
         fee_handler: FeeHandler::Driver,
     };
@@ -396,6 +404,8 @@ async fn protocol_fee_calculated_on_the_solver_side() {
                 buy: 40.ether().into_wei(),
             },
         },
+        // Surplus is 35 ETH worth of sell tokens, converted to buy tokens using the order's
+        // limit price (40 / 50 = 80%) this leaves us with a score of 28 ETH.
         expected_score: 28.ether().into_wei(),
         fee_handler: FeeHandler::Solver,
     };
@@ -527,6 +537,8 @@ async fn surplus_protocol_fee_buy_order_capped() {
                 buy: 40.ether().into_wei(),
             },
         },
+        // Surplus is 20 ETH worth of sell tokens, converted to buy tokens using the order's
+        // limit price (40 / 50 = 80%) this leaves us with a score of 16 ETH.
         expected_score: 16.ether().into_wei(),
         fee_handler: FeeHandler::Driver,
     };
@@ -651,6 +663,8 @@ async fn volume_protocol_fee_buy_order() {
                 buy: 40.ether().into_wei(),
             },
         },
+        // Surplus is 20 ETH worth of sell tokens, converted to buy tokens using the order's
+        // limit price (40 / 50 = 80%) this leaves us with a score of 16 ETH.
         expected_score: 16.ether().into_wei(),
         fee_handler: FeeHandler::Driver,
     };
@@ -681,6 +695,8 @@ async fn volume_protocol_fee_buy_order_at_limit_price() {
                 buy: 40.ether().into_wei(),
             },
         },
+        // Surplus is 10 ETH worth of sell tokens, converted to buy tokens using the order's
+        // limit price (40 / 50 = 80%) this leaves us with a score of 8 ETH.
         expected_score: 8.ether().into_wei(),
         fee_handler: FeeHandler::Driver,
     };
@@ -896,6 +912,8 @@ async fn price_improvement_fee_buy_in_market_order_not_capped() {
                 buy: 40.ether().into_wei(),
             },
         },
+        // Surplus is 20 ETH worth of sell tokens, converted to buy tokens using the order's
+        // limit price (40 / 60 = 66.6%) this leaves us with a score of 13.3 ETH.
         expected_score: 13.33333333333333.ether().into_wei(),
         fee_handler: FeeHandler::Driver,
     };
@@ -974,6 +992,8 @@ async fn price_improvement_fee_buy_out_of_market_order_not_capped() {
                 buy: 40.ether().into_wei(),
             },
         },
+        // Surplus is 10 ETH worth of sell tokens, converted to buy tokens using the order's
+        // limit price (40 / 50 = 80%) this leaves us with a score of 8 ETH.
         expected_score: 8.ether().into_wei(),
         fee_handler: FeeHandler::Driver,
     };
@@ -1052,7 +1072,8 @@ async fn price_improvement_fee_buy_in_market_order_capped() {
                 buy: 40.ether().into_wei(),
             },
         },
-        // TODO explain how we get 13.3333 now...
+        // Surplus is 20 ETH worth of sell tokens, converted to buy tokens using the order's
+        // limit price (40 / 60 = 66.6%) this leaves us with a score of 13.3 ETH.
         expected_score: 13.33333333333333.ether().into_wei(),
         fee_handler: FeeHandler::Driver,
     };
@@ -1131,6 +1152,8 @@ async fn price_improvement_fee_buy_out_of_market_order_capped() {
                 buy: 40.ether().into_wei(),
             },
         },
+        // Surplus is 10 ETH worth of sell tokens, converted to buy tokens using the order's
+        // limit price (40 / 50 = 80%) this leaves us with a score of 8 ETH.
         expected_score: 8.ether().into_wei(),
         fee_handler: FeeHandler::Driver,
     };
@@ -1209,6 +1232,8 @@ async fn price_improvement_fee_partial_buy_in_market_order_not_capped() {
                 buy: 20.ether().into_wei(),
             },
         },
+        // Surplus is 15 ETH worth of sell tokens, converted to buy tokens using the order's
+        // limit price (40 / 50 = 80%) this leaves us with a score of 12 ETH.
         expected_score: 12.ether().into_wei(),
         fee_handler: FeeHandler::Driver,
     };
@@ -1367,6 +1392,8 @@ async fn price_improvement_fee_partial_buy_in_market_order_capped() {
                 buy: 20.ether().into_wei(),
             },
         },
+        // Surplus is 20 ETH worth of sell tokens, converted to buy tokens using the order's
+        // limit price (50 / 75 = 66.6%) this leaves us with a score of 13.3 ETH.
         expected_score: 13.33333333333333333.ether().into_wei(),
         fee_handler: FeeHandler::Driver,
     };

--- a/crates/driver/src/tests/setup/driver.rs
+++ b/crates/driver/src/tests/setup/driver.rs
@@ -204,6 +204,11 @@ async fn create_config_file(
     blockchain: &Blockchain,
 ) -> tempfile::TempPath {
     let mut file = tempfile::NamedTempFile::new().unwrap();
+    writeln!(
+        file,
+        "buy-order-scoring-change-cutover = \"2026-03-27T15:04:50.410Z\""
+    )
+    .unwrap();
     let simulation = if config.enable_simulation {
         ""
     } else {

--- a/crates/driver/src/tests/setup/driver.rs
+++ b/crates/driver/src/tests/setup/driver.rs
@@ -206,7 +206,7 @@ async fn create_config_file(
     let mut file = tempfile::NamedTempFile::new().unwrap();
     writeln!(
         file,
-        "buy-order-scoring-change-cutover = \"2026-03-27T15:04:50.410Z\""
+        "buy-order-scoring-change-cutover = \"1970-03-27T15:04:50.410Z\""
     )
     .unwrap();
     let simulation = if config.enable_simulation {

--- a/crates/driver/src/util/conv/u256.rs
+++ b/crates/driver/src/util/conv/u256.rs
@@ -7,7 +7,7 @@ pub trait U256Ext: Sized {
 
     fn checked_ceil_div(&self, other: &Self) -> Option<Self>;
     fn ceil_div(&self, other: &Self) -> Self;
-    fn mul_f64(&self, factor: f64) -> Option<Self>;
+    fn checked_mul_f64(&self, factor: f64) -> Option<Self>;
 
     fn from_big_int(input: &num::BigInt) -> Result<Self>;
     fn from_big_uint(input: &num::BigUint) -> Result<Self>;
@@ -39,7 +39,7 @@ impl U256Ext for eth::U256 {
             .expect("ceiling division arithmetic error")
     }
 
-    fn mul_f64(&self, factor: f64) -> Option<Self> {
+    fn checked_mul_f64(&self, factor: f64) -> Option<Self> {
         // `factor` is first multiplied by the conversion factor to convert
         // it to integer, to avoid rounding to 0. Then, the result is divided
         // by the conversion factor to convert it back to the original scale.

--- a/crates/driver/src/util/conv/u256.rs
+++ b/crates/driver/src/util/conv/u256.rs
@@ -1,4 +1,9 @@
-use {crate::domain::eth, anyhow::Result, bigdecimal::Zero};
+use {
+    crate::domain::eth,
+    anyhow::Result,
+    bigdecimal::Zero,
+    num::{CheckedMul, FromPrimitive},
+};
 
 pub trait U256Ext: Sized {
     fn to_big_int(&self) -> num::BigInt;
@@ -7,6 +12,7 @@ pub trait U256Ext: Sized {
 
     fn checked_ceil_div(&self, other: &Self) -> Option<Self>;
     fn ceil_div(&self, other: &Self) -> Self;
+    fn mul_f64(&self, factor: f64) -> Option<Self>;
 
     fn from_big_int(input: &num::BigInt) -> Result<Self>;
     fn from_big_uint(input: &num::BigUint) -> Result<Self>;
@@ -36,6 +42,13 @@ impl U256Ext for eth::U256 {
     fn ceil_div(&self, other: &Self) -> Self {
         self.checked_ceil_div(other)
             .expect("ceiling division arithmetic error")
+    }
+
+    fn mul_f64(&self, factor: f64) -> Option<Self> {
+        let result = self
+            .to_big_rational()
+            .checked_mul(&num::BigRational::from_f64(factor)?)?;
+        Self::from_big_rational(&result).ok()
     }
 
     fn from_big_int(input: &num::BigInt) -> Result<eth::U256> {

--- a/crates/e2e/src/setup/colocation.rs
+++ b/crates/e2e/src/setup/colocation.rs
@@ -162,6 +162,7 @@ factory = "{:?}"
 
     let config_file = config_tmp_file(format!(
         r#"
+buy-order-scoring-change-cutover = "2026-03-27T15:04:50.410Z"
 app-data-fetching-enabled = true
 orderbook-url = "http://localhost:8080"
 flashloans-enabled = true

--- a/crates/e2e/src/setup/colocation.rs
+++ b/crates/e2e/src/setup/colocation.rs
@@ -162,7 +162,7 @@ factory = "{:?}"
 
     let config_file = config_tmp_file(format!(
         r#"
-buy-order-scoring-change-cutover = "2026-03-27T15:04:50.410Z"
+buy-order-scoring-change-cutover = "1970-03-27T15:04:50.410Z"
 app-data-fetching-enabled = true
 orderbook-url = "http://localhost:8080"
 flashloans-enabled = true


### PR DESCRIPTION
# Description
Implements the necessary changes for this upcoming [CIP](https://forum.cow.fi/t/cip-draft-updating-score-definition-for-buy-orders/2930).
I also created https://github.com/cowprotocol/services/pull/3343 as a follow up PR for the same logic but on the autopilot side (eventually we should have 1 code shared across autopilot and driver).

# Changes
- refactor (hopefully simplify) logic to compute scores for trades
- moved logic to multiple `U256` with a fractional `f64` into `U256Ext`
- added boilerplate to switch to the new scoring logic when the `deadline` of a `/solve` requests is past the cutover date

## How to test
Added a unit test based on the order that sparked the CIP. (@harisang confirmed that the new values are correct)
Updated our e2e tests to use the new scores everywhere and verified that the new values are reasonable