### PR TITLE
Generate bindings for balancer v3 BatchRouter

### DIFF
--- a/crates/contracts/artifacts/BalancerV3BatchRouter.json
+++ b/crates/contracts/artifacts/BalancerV3BatchRouter.json
@@ -1,0 +1,998 @@
+{
+  "_format": "hh-sol-artifact-1",
+  "contractName": "BatchRouter",
+  "sourceName": "contracts/BatchRouter.sol",
+  "abi": [
+    {
+      "inputs": [
+        {
+          "internalType": "contract IVault",
+          "name": "vault",
+          "type": "address"
+        },
+        {
+          "internalType": "contract IWETH",
+          "name": "weth",
+          "type": "address"
+        },
+        {
+          "internalType": "contract IPermit2",
+          "name": "permit2",
+          "type": "address"
+        },
+        {
+          "internalType": "string",
+          "name": "routerVersion",
+          "type": "string"
+        }
+      ],
+      "stateMutability": "nonpayable",
+      "type": "constructor"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "target",
+          "type": "address"
+        }
+      ],
+      "name": "AddressEmptyCode",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "account",
+          "type": "address"
+        }
+      ],
+      "name": "AddressInsufficientBalance",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "ErrorSelectorNotFound",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "EthTransfer",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "FailedInnerCall",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "InputLengthMismatch",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "InsufficientEth",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "ReentrancyGuardReentrantCall",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint8",
+          "name": "bits",
+          "type": "uint8"
+        },
+        {
+          "internalType": "uint256",
+          "name": "value",
+          "type": "uint256"
+        }
+      ],
+      "name": "SafeCastOverflowedUintDowncast",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "token",
+          "type": "address"
+        }
+      ],
+      "name": "SafeERC20FailedOperation",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "sender",
+          "type": "address"
+        }
+      ],
+      "name": "SenderIsNotVault",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "SwapDeadline",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "TransientIndexOutOfBounds",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "getSender",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "bytes[]",
+          "name": "data",
+          "type": "bytes[]"
+        }
+      ],
+      "name": "multicall",
+      "outputs": [
+        {
+          "internalType": "bytes[]",
+          "name": "results",
+          "type": "bytes[]"
+        }
+      ],
+      "stateMutability": "payable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "components": [
+            {
+              "internalType": "address",
+              "name": "token",
+              "type": "address"
+            },
+            {
+              "internalType": "address",
+              "name": "owner",
+              "type": "address"
+            },
+            {
+              "internalType": "address",
+              "name": "spender",
+              "type": "address"
+            },
+            {
+              "internalType": "uint256",
+              "name": "amount",
+              "type": "uint256"
+            },
+            {
+              "internalType": "uint256",
+              "name": "nonce",
+              "type": "uint256"
+            },
+            {
+              "internalType": "uint256",
+              "name": "deadline",
+              "type": "uint256"
+            }
+          ],
+          "internalType": "struct IRouterCommon.PermitApproval[]",
+          "name": "permitBatch",
+          "type": "tuple[]"
+        },
+        {
+          "internalType": "bytes[]",
+          "name": "permitSignatures",
+          "type": "bytes[]"
+        },
+        {
+          "components": [
+            {
+              "components": [
+                {
+                  "internalType": "address",
+                  "name": "token",
+                  "type": "address"
+                },
+                {
+                  "internalType": "uint160",
+                  "name": "amount",
+                  "type": "uint160"
+                },
+                {
+                  "internalType": "uint48",
+                  "name": "expiration",
+                  "type": "uint48"
+                },
+                {
+                  "internalType": "uint48",
+                  "name": "nonce",
+                  "type": "uint48"
+                }
+              ],
+              "internalType": "struct IAllowanceTransfer.PermitDetails[]",
+              "name": "details",
+              "type": "tuple[]"
+            },
+            {
+              "internalType": "address",
+              "name": "spender",
+              "type": "address"
+            },
+            {
+              "internalType": "uint256",
+              "name": "sigDeadline",
+              "type": "uint256"
+            }
+          ],
+          "internalType": "struct IAllowanceTransfer.PermitBatch",
+          "name": "permit2Batch",
+          "type": "tuple"
+        },
+        {
+          "internalType": "bytes",
+          "name": "permit2Signature",
+          "type": "bytes"
+        },
+        {
+          "internalType": "bytes[]",
+          "name": "multicallData",
+          "type": "bytes[]"
+        }
+      ],
+      "name": "permitBatchAndCall",
+      "outputs": [
+        {
+          "internalType": "bytes[]",
+          "name": "results",
+          "type": "bytes[]"
+        }
+      ],
+      "stateMutability": "payable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "components": [
+            {
+              "internalType": "contract IERC20",
+              "name": "tokenIn",
+              "type": "address"
+            },
+            {
+              "components": [
+                {
+                  "internalType": "address",
+                  "name": "pool",
+                  "type": "address"
+                },
+                {
+                  "internalType": "contract IERC20",
+                  "name": "tokenOut",
+                  "type": "address"
+                },
+                {
+                  "internalType": "bool",
+                  "name": "isBuffer",
+                  "type": "bool"
+                }
+              ],
+              "internalType": "struct IBatchRouter.SwapPathStep[]",
+              "name": "steps",
+              "type": "tuple[]"
+            },
+            {
+              "internalType": "uint256",
+              "name": "exactAmountIn",
+              "type": "uint256"
+            },
+            {
+              "internalType": "uint256",
+              "name": "minAmountOut",
+              "type": "uint256"
+            }
+          ],
+          "internalType": "struct IBatchRouter.SwapPathExactAmountIn[]",
+          "name": "paths",
+          "type": "tuple[]"
+        },
+        {
+          "internalType": "address",
+          "name": "sender",
+          "type": "address"
+        },
+        {
+          "internalType": "bytes",
+          "name": "userData",
+          "type": "bytes"
+        }
+      ],
+      "name": "querySwapExactIn",
+      "outputs": [
+        {
+          "internalType": "uint256[]",
+          "name": "pathAmountsOut",
+          "type": "uint256[]"
+        },
+        {
+          "internalType": "address[]",
+          "name": "tokensOut",
+          "type": "address[]"
+        },
+        {
+          "internalType": "uint256[]",
+          "name": "amountsOut",
+          "type": "uint256[]"
+        }
+      ],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "components": [
+            {
+              "internalType": "address",
+              "name": "sender",
+              "type": "address"
+            },
+            {
+              "components": [
+                {
+                  "internalType": "contract IERC20",
+                  "name": "tokenIn",
+                  "type": "address"
+                },
+                {
+                  "components": [
+                    {
+                      "internalType": "address",
+                      "name": "pool",
+                      "type": "address"
+                    },
+                    {
+                      "internalType": "contract IERC20",
+                      "name": "tokenOut",
+                      "type": "address"
+                    },
+                    {
+                      "internalType": "bool",
+                      "name": "isBuffer",
+                      "type": "bool"
+                    }
+                  ],
+                  "internalType": "struct IBatchRouter.SwapPathStep[]",
+                  "name": "steps",
+                  "type": "tuple[]"
+                },
+                {
+                  "internalType": "uint256",
+                  "name": "exactAmountIn",
+                  "type": "uint256"
+                },
+                {
+                  "internalType": "uint256",
+                  "name": "minAmountOut",
+                  "type": "uint256"
+                }
+              ],
+              "internalType": "struct IBatchRouter.SwapPathExactAmountIn[]",
+              "name": "paths",
+              "type": "tuple[]"
+            },
+            {
+              "internalType": "uint256",
+              "name": "deadline",
+              "type": "uint256"
+            },
+            {
+              "internalType": "bool",
+              "name": "wethIsEth",
+              "type": "bool"
+            },
+            {
+              "internalType": "bytes",
+              "name": "userData",
+              "type": "bytes"
+            }
+          ],
+          "internalType": "struct IBatchRouter.SwapExactInHookParams",
+          "name": "params",
+          "type": "tuple"
+        }
+      ],
+      "name": "querySwapExactInHook",
+      "outputs": [
+        {
+          "internalType": "uint256[]",
+          "name": "pathAmountsOut",
+          "type": "uint256[]"
+        },
+        {
+          "internalType": "address[]",
+          "name": "tokensOut",
+          "type": "address[]"
+        },
+        {
+          "internalType": "uint256[]",
+          "name": "amountsOut",
+          "type": "uint256[]"
+        }
+      ],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "components": [
+            {
+              "internalType": "contract IERC20",
+              "name": "tokenIn",
+              "type": "address"
+            },
+            {
+              "components": [
+                {
+                  "internalType": "address",
+                  "name": "pool",
+                  "type": "address"
+                },
+                {
+                  "internalType": "contract IERC20",
+                  "name": "tokenOut",
+                  "type": "address"
+                },
+                {
+                  "internalType": "bool",
+                  "name": "isBuffer",
+                  "type": "bool"
+                }
+              ],
+              "internalType": "struct IBatchRouter.SwapPathStep[]",
+              "name": "steps",
+              "type": "tuple[]"
+            },
+            {
+              "internalType": "uint256",
+              "name": "maxAmountIn",
+              "type": "uint256"
+            },
+            {
+              "internalType": "uint256",
+              "name": "exactAmountOut",
+              "type": "uint256"
+            }
+          ],
+          "internalType": "struct IBatchRouter.SwapPathExactAmountOut[]",
+          "name": "paths",
+          "type": "tuple[]"
+        },
+        {
+          "internalType": "address",
+          "name": "sender",
+          "type": "address"
+        },
+        {
+          "internalType": "bytes",
+          "name": "userData",
+          "type": "bytes"
+        }
+      ],
+      "name": "querySwapExactOut",
+      "outputs": [
+        {
+          "internalType": "uint256[]",
+          "name": "pathAmountsIn",
+          "type": "uint256[]"
+        },
+        {
+          "internalType": "address[]",
+          "name": "tokensIn",
+          "type": "address[]"
+        },
+        {
+          "internalType": "uint256[]",
+          "name": "amountsIn",
+          "type": "uint256[]"
+        }
+      ],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "components": [
+            {
+              "internalType": "address",
+              "name": "sender",
+              "type": "address"
+            },
+            {
+              "components": [
+                {
+                  "internalType": "contract IERC20",
+                  "name": "tokenIn",
+                  "type": "address"
+                },
+                {
+                  "components": [
+                    {
+                      "internalType": "address",
+                      "name": "pool",
+                      "type": "address"
+                    },
+                    {
+                      "internalType": "contract IERC20",
+                      "name": "tokenOut",
+                      "type": "address"
+                    },
+                    {
+                      "internalType": "bool",
+                      "name": "isBuffer",
+                      "type": "bool"
+                    }
+                  ],
+                  "internalType": "struct IBatchRouter.SwapPathStep[]",
+                  "name": "steps",
+                  "type": "tuple[]"
+                },
+                {
+                  "internalType": "uint256",
+                  "name": "maxAmountIn",
+                  "type": "uint256"
+                },
+                {
+                  "internalType": "uint256",
+                  "name": "exactAmountOut",
+                  "type": "uint256"
+                }
+              ],
+              "internalType": "struct IBatchRouter.SwapPathExactAmountOut[]",
+              "name": "paths",
+              "type": "tuple[]"
+            },
+            {
+              "internalType": "uint256",
+              "name": "deadline",
+              "type": "uint256"
+            },
+            {
+              "internalType": "bool",
+              "name": "wethIsEth",
+              "type": "bool"
+            },
+            {
+              "internalType": "bytes",
+              "name": "userData",
+              "type": "bytes"
+            }
+          ],
+          "internalType": "struct IBatchRouter.SwapExactOutHookParams",
+          "name": "params",
+          "type": "tuple"
+        }
+      ],
+      "name": "querySwapExactOutHook",
+      "outputs": [
+        {
+          "internalType": "uint256[]",
+          "name": "pathAmountsIn",
+          "type": "uint256[]"
+        },
+        {
+          "internalType": "address[]",
+          "name": "tokensIn",
+          "type": "address[]"
+        },
+        {
+          "internalType": "uint256[]",
+          "name": "amountsIn",
+          "type": "uint256[]"
+        }
+      ],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "components": [
+            {
+              "internalType": "contract IERC20",
+              "name": "tokenIn",
+              "type": "address"
+            },
+            {
+              "components": [
+                {
+                  "internalType": "address",
+                  "name": "pool",
+                  "type": "address"
+                },
+                {
+                  "internalType": "contract IERC20",
+                  "name": "tokenOut",
+                  "type": "address"
+                },
+                {
+                  "internalType": "bool",
+                  "name": "isBuffer",
+                  "type": "bool"
+                }
+              ],
+              "internalType": "struct IBatchRouter.SwapPathStep[]",
+              "name": "steps",
+              "type": "tuple[]"
+            },
+            {
+              "internalType": "uint256",
+              "name": "exactAmountIn",
+              "type": "uint256"
+            },
+            {
+              "internalType": "uint256",
+              "name": "minAmountOut",
+              "type": "uint256"
+            }
+          ],
+          "internalType": "struct IBatchRouter.SwapPathExactAmountIn[]",
+          "name": "paths",
+          "type": "tuple[]"
+        },
+        {
+          "internalType": "uint256",
+          "name": "deadline",
+          "type": "uint256"
+        },
+        {
+          "internalType": "bool",
+          "name": "wethIsEth",
+          "type": "bool"
+        },
+        {
+          "internalType": "bytes",
+          "name": "userData",
+          "type": "bytes"
+        }
+      ],
+      "name": "swapExactIn",
+      "outputs": [
+        {
+          "internalType": "uint256[]",
+          "name": "pathAmountsOut",
+          "type": "uint256[]"
+        },
+        {
+          "internalType": "address[]",
+          "name": "tokensOut",
+          "type": "address[]"
+        },
+        {
+          "internalType": "uint256[]",
+          "name": "amountsOut",
+          "type": "uint256[]"
+        }
+      ],
+      "stateMutability": "payable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "components": [
+            {
+              "internalType": "address",
+              "name": "sender",
+              "type": "address"
+            },
+            {
+              "components": [
+                {
+                  "internalType": "contract IERC20",
+                  "name": "tokenIn",
+                  "type": "address"
+                },
+                {
+                  "components": [
+                    {
+                      "internalType": "address",
+                      "name": "pool",
+                      "type": "address"
+                    },
+                    {
+                      "internalType": "contract IERC20",
+                      "name": "tokenOut",
+                      "type": "address"
+                    },
+                    {
+                      "internalType": "bool",
+                      "name": "isBuffer",
+                      "type": "bool"
+                    }
+                  ],
+                  "internalType": "struct IBatchRouter.SwapPathStep[]",
+                  "name": "steps",
+                  "type": "tuple[]"
+                },
+                {
+                  "internalType": "uint256",
+                  "name": "exactAmountIn",
+                  "type": "uint256"
+                },
+                {
+                  "internalType": "uint256",
+                  "name": "minAmountOut",
+                  "type": "uint256"
+                }
+              ],
+              "internalType": "struct IBatchRouter.SwapPathExactAmountIn[]",
+              "name": "paths",
+              "type": "tuple[]"
+            },
+            {
+              "internalType": "uint256",
+              "name": "deadline",
+              "type": "uint256"
+            },
+            {
+              "internalType": "bool",
+              "name": "wethIsEth",
+              "type": "bool"
+            },
+            {
+              "internalType": "bytes",
+              "name": "userData",
+              "type": "bytes"
+            }
+          ],
+          "internalType": "struct IBatchRouter.SwapExactInHookParams",
+          "name": "params",
+          "type": "tuple"
+        }
+      ],
+      "name": "swapExactInHook",
+      "outputs": [
+        {
+          "internalType": "uint256[]",
+          "name": "pathAmountsOut",
+          "type": "uint256[]"
+        },
+        {
+          "internalType": "address[]",
+          "name": "tokensOut",
+          "type": "address[]"
+        },
+        {
+          "internalType": "uint256[]",
+          "name": "amountsOut",
+          "type": "uint256[]"
+        }
+      ],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "components": [
+            {
+              "internalType": "contract IERC20",
+              "name": "tokenIn",
+              "type": "address"
+            },
+            {
+              "components": [
+                {
+                  "internalType": "address",
+                  "name": "pool",
+                  "type": "address"
+                },
+                {
+                  "internalType": "contract IERC20",
+                  "name": "tokenOut",
+                  "type": "address"
+                },
+                {
+                  "internalType": "bool",
+                  "name": "isBuffer",
+                  "type": "bool"
+                }
+              ],
+              "internalType": "struct IBatchRouter.SwapPathStep[]",
+              "name": "steps",
+              "type": "tuple[]"
+            },
+            {
+              "internalType": "uint256",
+              "name": "maxAmountIn",
+              "type": "uint256"
+            },
+            {
+              "internalType": "uint256",
+              "name": "exactAmountOut",
+              "type": "uint256"
+            }
+          ],
+          "internalType": "struct IBatchRouter.SwapPathExactAmountOut[]",
+          "name": "paths",
+          "type": "tuple[]"
+        },
+        {
+          "internalType": "uint256",
+          "name": "deadline",
+          "type": "uint256"
+        },
+        {
+          "internalType": "bool",
+          "name": "wethIsEth",
+          "type": "bool"
+        },
+        {
+          "internalType": "bytes",
+          "name": "userData",
+          "type": "bytes"
+        }
+      ],
+      "name": "swapExactOut",
+      "outputs": [
+        {
+          "internalType": "uint256[]",
+          "name": "pathAmountsIn",
+          "type": "uint256[]"
+        },
+        {
+          "internalType": "address[]",
+          "name": "tokensIn",
+          "type": "address[]"
+        },
+        {
+          "internalType": "uint256[]",
+          "name": "amountsIn",
+          "type": "uint256[]"
+        }
+      ],
+      "stateMutability": "payable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "components": [
+            {
+              "internalType": "address",
+              "name": "sender",
+              "type": "address"
+            },
+            {
+              "components": [
+                {
+                  "internalType": "contract IERC20",
+                  "name": "tokenIn",
+                  "type": "address"
+                },
+                {
+                  "components": [
+                    {
+                      "internalType": "address",
+                      "name": "pool",
+                      "type": "address"
+                    },
+                    {
+                      "internalType": "contract IERC20",
+                      "name": "tokenOut",
+                      "type": "address"
+                    },
+                    {
+                      "internalType": "bool",
+                      "name": "isBuffer",
+                      "type": "bool"
+                    }
+                  ],
+                  "internalType": "struct IBatchRouter.SwapPathStep[]",
+                  "name": "steps",
+                  "type": "tuple[]"
+                },
+                {
+                  "internalType": "uint256",
+                  "name": "maxAmountIn",
+                  "type": "uint256"
+                },
+                {
+                  "internalType": "uint256",
+                  "name": "exactAmountOut",
+                  "type": "uint256"
+                }
+              ],
+              "internalType": "struct IBatchRouter.SwapPathExactAmountOut[]",
+              "name": "paths",
+              "type": "tuple[]"
+            },
+            {
+              "internalType": "uint256",
+              "name": "deadline",
+              "type": "uint256"
+            },
+            {
+              "internalType": "bool",
+              "name": "wethIsEth",
+              "type": "bool"
+            },
+            {
+              "internalType": "bytes",
+              "name": "userData",
+              "type": "bytes"
+            }
+          ],
+          "internalType": "struct IBatchRouter.SwapExactOutHookParams",
+          "name": "params",
+          "type": "tuple"
+        }
+      ],
+      "name": "swapExactOutHook",
+      "outputs": [
+        {
+          "internalType": "uint256[]",
+          "name": "pathAmountsIn",
+          "type": "uint256[]"
+        },
+        {
+          "internalType": "address[]",
+          "name": "tokensIn",
+          "type": "address[]"
+        },
+        {
+          "internalType": "uint256[]",
+          "name": "amountsIn",
+          "type": "uint256[]"
+        }
+      ],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "version",
+      "outputs": [
+        {
+          "internalType": "string",
+          "name": "",
+          "type": "string"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "stateMutability": "payable",
+      "type": "receive"
+    }
+  ],
+  "bytecode": "0x6101c0604090808252346105c957614bbd803803809161001f82856105e8565b83398101916080828403126105c95781516001600160a01b03939084811681036105c957602093848101519286841684036105c9578482015196871687036105c95760608201516001600160401b03928382116105c9570192601f908282860112156105c95784518481116105b557601f19958851946100a58b898786011601876105e8565b8286528a83830101116105c957815f928b8093018388015e8501015260805281519283116105b5575f54916001928381811c911680156105ab575b8982101461059757828111610554575b50879184116001146104f757839450908392915f946104ec575b50501b915f199060031b1c1916175f555b61014961012661060b565b835190610132826105cd565b600682526539b2b73232b960d11b86830152610669565b60a05261018561015761060b565b835190610163826105cd565b60118252701a5cd4995d1d5c9b915d1a131bd8dad959607a1b86830152610669565b60c05260e0526101009283526101cd815161019f816105cd565b601381527f63757272656e7453776170546f6b656e73496e0000000000000000000000000084820152610633565b9161012092835261021082516101e2816105cd565b601481527f63757272656e7453776170546f6b656e734f757400000000000000000000000083820152610633565b6101409081526102528351610224816105cd565b601981527f63757272656e7453776170546f6b656e496e416d6f756e74730000000000000084820152610633565b906101609182526102d8610298855161026a816105cd565b601a81527f63757272656e7453776170546f6b656e4f7574416d6f756e747300000000000086820152610633565b936101809485527f736574746c6564546f6b656e416d6f756e7473000000000000000000000000008651916102cc836105cd565b60138352820152610633565b936101a094855251946144a1968761071c88396080518781816102460152818161197c01528181611be001528181611e22015281816120790152818161221201528181612323015281816123b10152818161247301528181612aad01528181612c8c01528181612cd401528181612d5201528181612df901528181612f0701528181612f840152818161321901528181613348015281816133e5015281816134ab01528181613b6c01528181613c9101528181613ed0015281816140150152614271015260a0518781816102aa015281816105350152818161181f01526128be015260c0518781816117a901526136ba015260e051878181602201528181613afe01528181613de401528181613f5801526140af0152518681816109f001528181610b0401528181611f6e01528181611ff4015281816130790152613c6d015251858181612569015281816127500152818161295a01526135d8015251848181611c4301528181611e8f01528181612275015281816124d7015281816125ce0152818161272c01528181612b1201526135a8015251838181611d43015281816125950152818161277c0152818161328e01528181613509015261362b015251828181611c6c01528181611ec00152818161250101528181612621015281816127b401528181612b5101526132d001525181818161229f015281816125ff01528181612b8201528181612e5601526136090152f35b015192505f8061010a565b91938316915f805283885f20935f5b8a8883831061053d5750505010610525575b505050811b015f5561011b565b01515f1960f88460031b161c191690555f8080610518565b868601518855909601959485019487935001610506565b5f8052885f208380870160051c8201928b881061058e575b0160051c019084905b8281106105835750506100f0565b5f8155018490610575565b9250819261056c565b634e487b7160e01b5f52602260045260245ffd5b90607f16906100e0565b634e487b7160e01b5f52604160045260245ffd5b5f80fd5b604081019081106001600160401b038211176105b557604052565b601f909101601f19168101906001600160401b038211908210176105b557604052565b60405190610618826105cd565b600c82526b2937baba32b921b7b6b6b7b760a11b6020830152565b61066690604051610643816105cd565b60118152702130ba31b42937baba32b921b7b6b6b7b760791b6020820152610669565b90565b906106d6603a60209260405193849181808401977f62616c616e6365722d6c6162732e76332e73746f726167652e000000000000008952805191829101603986015e830190601760f91b60398301528051928391018583015e015f8382015203601a8101845201826105e8565b5190205f198101908111610707576040519060208201908152602082526106fc826105cd565b9051902060ff191690565b634e487b7160e01b5f52601160045260245ffdfe60806040526004361015610072575b3615610018575f80fd5b6001600160a01b037f000000000000000000000000000000000000000000000000000000000000000016330361004a57005b7f0540ddf6000000000000000000000000000000000000000000000000000000005f5260045ffd5b5f3560e01c806308a465f614610e9d57806319c6989f1461084e578063286f580d146107b75780632950286e146106cc57806354fd4d501461058f5780635a3c3987146105665780635e01eb5a146105215780638a12a08c146104c65780638eb1b65e146103bf578063945ed33f14610344578063ac9650d8146103005763e3b5dff40361000e57346102fc576060806003193601126102fc5767ffffffffffffffff6004358181116102fc5761012d9036906004016112c4565b6101356111a1565b6044359283116102fc57610150610158933690600401610fcd565b9390916128b9565b905f5b835181101561017c57805f8761017360019488611691565b5101520161015b565b506101f06101fe610239946101b65f94886040519361019a8561111a565b30855260208501525f1960408501528660608501523691611381565b60808201526040519283917f8a12a08c0000000000000000000000000000000000000000000000000000000060208401526024830161143e565b03601f198101835282611152565b604051809481927fedfa3568000000000000000000000000000000000000000000000000000000008352602060048401526024830190610ffb565b0381836001600160a01b037f0000000000000000000000000000000000000000000000000000000000000000165af19182156102f1576102a39261028e915f916102cf575b50602080825183010191016115d4565b909391926102a7575b60405193849384610f2f565b0390f35b5f7f00000000000000000000000000000000000000000000000000000000000000005d610297565b6102eb91503d805f833e6102e38183611152565b81019061154d565b8461027e565b6040513d5f823e3d90fd5b5f80fd5b60206003193601126102fc5760043567ffffffffffffffff81116102fc576103386103326102a3923690600401610f9c565b9061179b565b60405191829182611020565b346102fc5761035236610eca565b61035a611945565b610362611972565b6103906102a3610371836128fb565b9193909461038a606061038383611344565b9201611358565b90612729565b5f7f9b779b17422d0df92223018b32b4d1fa46e071723d6817e2486d003becc55f005d60405193849384610f2f565b60806003193601126102fc5767ffffffffffffffff6004358181116102fc576103ec9036906004016112c4565b906103f56111b7565b906064359081116102fc576101f061048b6102399461045161041c5f953690600401610fcd565b610425336128b9565b97604051946104338661111a565b33865260208601526024356040860152151560608501523691611381565b60808201526040519283917f945ed33f000000000000000000000000000000000000000000000000000000006020840152602483016116d2565b604051809481927f48c89491000000000000000000000000000000000000000000000000000000008352602060048401526024830190610ffb565b346102fc576102a36104ef6104da36610eca565b6104e2611945565b6104ea611972565b611a3b565b5f7f9b779b17422d0df92223018b32b4d1fa46e071723d6817e2486d003becc55f009492945d60405193849384610f2f565b346102fc575f6003193601126102fc5760207f00000000000000000000000000000000000000000000000000000000000000005c6001600160a01b0360405191168152f35b346102fc576102a36104ef61057a36610eca565b610582611945565b61058a611972565b6128fb565b346102fc575f6003193601126102fc576040515f80549060018260011c91600184169182156106c2575b60209485851084146106955785879486865291825f146106575750506001146105fe575b506105ea92500383611152565b6102a3604051928284938452830190610ffb565b5f808052859250907f290decd9548b62a8d60345a988386fc84ba6bc95484008f6362f93160ef3e5635b85831061063f5750506105ea9350820101856105dd565b80548389018501528794508693909201918101610628565b7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff0016858201526105ea95151560051b85010192508791506105dd9050565b7f4e487b71000000000000000000000000000000000000000000000000000000005f52602260045260245ffd5b92607f16926105b9565b346102fc5760606003193601126102fc5767ffffffffffffffff6004358181116102fc576106fe9036906004016112c4565b906107076111a1565b6044359182116102fc5761072261072a923690600401610fcd565b9290916128b9565b905f5b845181101561075f57806fffffffffffffffffffffffffffffffff604061075660019489611691565b5101520161072d565b506101f06101fe8561077d5f94610239976040519361019a8561111a565b60808201526040519283917f5a3c3987000000000000000000000000000000000000000000000000000000006020840152602483016116d2565b60806003193601126102fc5767ffffffffffffffff6004358181116102fc576107e49036906004016112c4565b906107ed6111b7565b906064359081116102fc576101f061048b6102399461081461041c5f953690600401610fcd565b60808201526040519283917f08a465f60000000000000000000000000000000000000000000000000000000060208401526024830161143e565b60a06003193601126102fc5767ffffffffffffffff600435116102fc573660236004350112156102fc5767ffffffffffffffff60043560040135116102fc5736602460c060043560040135026004350101116102fc5760243567ffffffffffffffff81116102fc576108c4903690600401610f9c565b67ffffffffffffffff604435116102fc576060600319604435360301126102fc5760643567ffffffffffffffff81116102fc57610905903690600401610fcd565b60843567ffffffffffffffff81116102fc57610925903690600401610f9c565b949093610930611945565b806004356004013503610e75575f5b600435600401358110610bd25750505060443560040135907fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffdd6044353603018212156102fc57816044350160048101359067ffffffffffffffff82116102fc5760248260071b36039101136102fc576109e3575b6102a361033886865f7f9b779b17422d0df92223018b32b4d1fa46e071723d6817e2486d003becc55f005d61179b565b6001600160a01b039492947f0000000000000000000000000000000000000000000000000000000000000000163b156102fc57604051947f2a2d80d10000000000000000000000000000000000000000000000000000000086523360048701526060602487015260c486019260443501602481019367ffffffffffffffff6004830135116102fc57600482013560071b360385136102fc5760606064890152600482013590529192869260e484019291905f905b60048101358210610b5457505050602091601f19601f865f9787956001600160a01b03610ac860246044350161118d565b16608488015260448035013560a48801526003198787030160448801528186528786013787868286010152011601030181836001600160a01b037f0000000000000000000000000000000000000000000000000000000000000000165af19182156102f1576102a39361033893610b45575b8294508193506109b3565b610b4e90611106565b84610b3a565b9195945091926001600160a01b03610b6b8761118d565b168152602080870135916001600160a01b0383168093036102fc57600492600192820152610b9b604089016128a6565b65ffffffffffff8091166040830152610bb660608a016128a6565b1660608201526080809101970193019050889495939291610a97565b610be7610be082848661192a565b3691611381565b604051610bf3816110a1565b5f81526020915f838301525f60408301528281015190606060408201519101515f1a91835283830152604082015260c07fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffdc81850260043501360301126102fc5760405190610c60826110ea565b610c73602460c08602600435010161118d565b808352610c89604460c08702600435010161118d565b908185850152610ca2606460c08802600435010161118d565b60408581019190915260043560c08802016084810135606087015260a4810135608087015260c4013560a086015283015183519386015160ff91909116926001600160a01b0383163b156102fc575f6001600160a01b03809460e4948b98849860c460c06040519c8d9b8c9a7fd505accf000000000000000000000000000000000000000000000000000000008c521660048b01523060248b0152608482820260043501013560448b0152026004350101356064880152608487015260a486015260c4850152165af19081610e66575b50610e5c57610d7f612877565b906001600160a01b0381511690836001600160a01b0381830151166044604051809581937fdd62ed3e00000000000000000000000000000000000000000000000000000000835260048301523060248301525afa9182156102f1575f92610e2c575b506060015103610df75750506001905b0161093f565b805115610e045780519101fd5b7fa7285689000000000000000000000000000000000000000000000000000000005f5260045ffd5b9091508381813d8311610e55575b610e448183611152565b810103126102fc5751906060610de1565b503d610e3a565b5050600190610df1565b610e6f90611106565b8a610d72565b7faaad13f7000000000000000000000000000000000000000000000000000000005f5260045ffd5b346102fc57610eab36610eca565b610eb3611945565b610ebb611972565b6103906102a361037183611a3b565b600319906020828201126102fc576004359167ffffffffffffffff83116102fc578260a0920301126102fc5760040190565b9081518082526020808093019301915f5b828110610f1b575050505090565b835185529381019392810192600101610f0d565b939290610f4490606086526060860190610efc565b936020948181036020830152602080855192838152019401905f5b818110610f7f57505050610f7c9394506040818403910152610efc565b90565b82516001600160a01b031686529487019491870191600101610f5f565b9181601f840112156102fc5782359167ffffffffffffffff83116102fc576020808501948460051b0101116102fc57565b9181601f840112156102fc5782359167ffffffffffffffff83116102fc57602083818601950101116102fc57565b90601f19601f602080948051918291828752018686015e5f8582860101520116010190565b6020808201906020835283518092526040830192602060408460051b8301019501935f915b8483106110555750505050505090565b9091929394958480611091837fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc086600196030187528a51610ffb565b9801930193019194939290611045565b6060810190811067ffffffffffffffff8211176110bd57604052565b7f4e487b71000000000000000000000000000000000000000000000000000000005f52604160045260245ffd5b60c0810190811067ffffffffffffffff8211176110bd57604052565b67ffffffffffffffff81116110bd57604052565b60a0810190811067ffffffffffffffff8211176110bd57604052565b60e0810190811067ffffffffffffffff8211176110bd57604052565b90601f601f19910116810190811067ffffffffffffffff8211176110bd57604052565b67ffffffffffffffff81116110bd5760051b60200190565b35906001600160a01b03821682036102fc57565b602435906001600160a01b03821682036102fc57565b6044359081151582036102fc57565b9190916080818403126102fc57604090815191608083019467ffffffffffffffff95848110878211176110bd57825283956112008461118d565b8552602090818501359081116102fc57840182601f820112156102fc5780359061122982611175565b9361123686519586611152565b82855283850190846060809502840101928184116102fc578501915b8383106112745750505050508401528181013590830152606090810135910152565b84838303126102fc57875190611289826110a1565b6112928461118d565b825261129f87850161118d565b87830152888401359081151582036102fc578288928b89950152815201920191611252565b81601f820112156102fc578035916020916112de84611175565b936112ec6040519586611152565b808552838086019160051b830101928084116102fc57848301915b8483106113175750505050505090565b823567ffffffffffffffff81116102fc578691611339848480948901016111c6565b815201920191611307565b356001600160a01b03811681036102fc5790565b3580151581036102fc5790565b67ffffffffffffffff81116110bd57601f01601f191660200190565b92919261138d82611365565b9161139b6040519384611152565b8294818452818301116102fc578281602093845f960137010152565b9060808101916001600160a01b03808251168352602093848301519460808186015285518092528060a086019601925f905b83821061140b5750505050506060816040829301516040850152015191015290565b845180518216895280840151821689850152604090810151151590890152606090970196938201936001909101906113e9565b91909160209081815260c08101916001600160a01b0385511681830152808501519260a06040840152835180915260e08301918060e08360051b8601019501925f905b8382106114bd5750505050506080846040610f7c959601516060840152606081015115158284015201519060a0601f1982850301910152610ffb565b909192939583806114f8837fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff208a600196030186528a516113b7565b98019201920190939291611481565b81601f820112156102fc5780519061151e82611365565b9261152c6040519485611152565b828452602083830101116102fc57815f9260208093018386015e8301015290565b906020828203126102fc57815167ffffffffffffffff81116102fc57610f7c9201611507565b9080601f830112156102fc5781519060209161158e81611175565b9361159c6040519586611152565b81855260208086019260051b8201019283116102fc57602001905b8282106115c5575050505090565b815181529083019083016115b7565b90916060828403126102fc5781519167ffffffffffffffff928381116102fc5784611600918301611573565b936020808301518581116102fc5783019082601f830112156102fc5781519161162883611175565b926116366040519485611152565b808452828085019160051b830101918583116102fc578301905b82821061167257505050509360408301519081116102fc57610f7c9201611573565b81516001600160a01b03811681036102fc578152908301908301611650565b80518210156116a55760209160051b010190565b7f4e487b71000000000000000000000000000000000000000000000000000000005f52603260045260245ffd5b91909160209081815260c08101916001600160a01b0385511681830152808501519260a06040840152835180915260e08301918060e08360051b8601019501925f905b8382106117515750505050506080846040610f7c959601516060840152606081015115158284015201519060a0601f1982850301910152610ffb565b9091929395838061178c837fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff208a600196030186528a516113b7565b98019201920190939291611715565b91906117a6336128b9565b907f000000000000000000000000000000000000000000000000000000000000000093845c6118b1576001906001865d6117df83611175565b926117ed6040519485611152565b808452601f196117fc82611175565b015f5b8181106118a05750505f5b8181106118575750505050905f61184c92945d7f0000000000000000000000000000000000000000000000000000000000000000805c9161184e575b506136b1565b565b5f905d5f611846565b806118845f8061186c610be08996888a61192a565b602081519101305af461187d612877565b903061415c565b61188e8288611691565b526118998187611691565b500161180a565b8060606020809389010152016117ff565b7f3ee5aeb5000000000000000000000000000000000000000000000000000000005f5260045ffd5b9035907fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe1813603018212156102fc570180359067ffffffffffffffff82116102fc576020019181360383136102fc57565b908210156116a5576119419160051b8101906118d9565b9091565b7f9b779b17422d0df92223018b32b4d1fa46e071723d6817e2486d003becc55f00805c6118b1576001905d565b6001600160a01b037f00000000000000000000000000000000000000000000000000000000000000001633036119a457565b7f089676d5000000000000000000000000000000000000000000000000000000005f523360045260245ffd5b906119da82611175565b6119e76040519182611152565b828152601f196119f78294611175565b0190602036910137565b91908201809211611a0e57565b7f4e487b71000000000000000000000000000000000000000000000000000000005f52601160045260245ffd5b604081013542116126c35790611a5e611a5760208401846136f4565b90506119d0565b915f5b611a6e60208301836136f4565b90508110156125c757611a9881611a93611a8b60208601866136f4565b369391613748565b6111c6565b936040850151936001600160a01b038651169060208701518051156116a55760200151604001511515806125be575b1561256357611aec611ad886611344565b8784611ae660608a01611358565b92613add565b5f5b60208801515181101561255357611b03613788565b6020890151515f198101908111611a0e578214806020830152821582525f1461254c576060890151905b611b3b8360208c0151611691565b51604081015190919015611cee57611bd36001600160a01b03835116936001600160a01b03881685145f14611ce7576001945b60405195611b7b8761111a565b5f8752611b87816137be565b6020870152604086015260609485918d838301526080820152604051809381927f43583be500000000000000000000000000000000000000000000000000000000835260048301613a22565b03815f6001600160a01b037f0000000000000000000000000000000000000000000000000000000000000000165af19384156102f1575f94611cb0575b50506020015115611c9657816001600160a01b036020611c909360019695611c388c8c611691565b5201611c67828251167f00000000000000000000000000000000000000000000000000000000000000006141c0565b5051167f000000000000000000000000000000000000000000000000000000000000000061420a565b01611aee565b602001519097506001600160a01b03169250600190611c90565b60209294509081611cd592903d10611ce0575b611ccd8183611152565b8101906137f5565b91505092905f611c10565b503d611cc3565b5f94611b6e565b888a6001600160a01b038495945116806001600160a01b038a16145f14612132575050815115905061206e57888a80151580612053575b611f4d575b6001600160a01b03939291611ddd82611e15978b5f95897f0000000000000000000000000000000000000000000000000000000000000000921680885282602052604088205c611f3c575b5050505b6001611d9c8983511660208401998b8b51169080158a14611f3657508391614223565b999092511694611db1608091828101906118d9565b93909460405197611dc1896110ea565b8852306020890152604088015260608701528501523691611381565b60a0820152604051809681927f21457897000000000000000000000000000000000000000000000000000000008352600483016139b1565b0381836001600160a01b037f0000000000000000000000000000000000000000000000000000000000000000165af19384156102f1575f94611f0c575b506020015115611ee95791611ebc826001600160a01b0360019695611e7a611ee49686611691565b51611e858d8d611691565b52611eb3828251167f00000000000000000000000000000000000000000000000000000000000000006141c0565b50511692611691565b51907f000000000000000000000000000000000000000000000000000000000000000061420a565b611c90565b98506001929450611f02906001600160a01b0392611691565b5197511692611c90565b6020919450611f2c903d805f833e611f248183611152565b810190613969565b5094919050611e52565b91614223565b611f4592614341565b5f8281611d75565b50611f5a90929192611344565b91611f648b6142fd565b6001600160a01b037f0000000000000000000000000000000000000000000000000000000000000000163b156102fc576040517f36c785160000000000000000000000000000000000000000000000000000000081526001600160a01b039485166004820152306024820152908416604482015292871660648401525f8380608481010381836001600160a01b037f0000000000000000000000000000000000000000000000000000000000000000165af180156102f1578a611ddd8d611e15976001600160a01b03975f95612044575b50975092505091929350611d2a565b61204d90611106565b5f612035565b5061205d82611344565b6001600160a01b0316301415611d25565b906001600160a01b037f000000000000000000000000000000000000000000000000000000000000000016916001600160a01b0384511692803b156102fc576040517fae6393290000000000000000000000000000000000000000000000000000000081526001600160a01b03949094166004850152306024850152604484018c90525f908490606490829084905af180156102f1578a611ddd8d611e15976001600160a01b03975f95612123575b50611d79565b61212c90611106565b5f61211d565b6001600160a01b0360208796949701511690898183145f146123d7576121cd925061220597915060016121735f96956001600160a01b0393848b5116614223565b509282895116956020890151151588146123ae5761219082611344565b945b6121a1608093848101906118d9565b959096604051996121b18b6110ea565b8a52166020890152604088015260608701528501523691611381565b60a0820152604051809581927f4af29ec4000000000000000000000000000000000000000000000000000000008352600483016138f8565b0381836001600160a01b037f0000000000000000000000000000000000000000000000000000000000000000165af19283156102f1575f93612384575b5060200151156122c357816001600160a01b036020611ee493600196956122698c8c611691565b526122998383830151167f00000000000000000000000000000000000000000000000000000000000000006141c0565b500151167f000000000000000000000000000000000000000000000000000000000000000061420a565b60208181015191516040517f15afd4090000000000000000000000000000000000000000000000000000000081526001600160a01b03918216600482015260248101859052939a50909116945081806044810103815f6001600160a01b037f0000000000000000000000000000000000000000000000000000000000000000165af180156102f157612359575b50600190611c90565b602090813d831161237d575b61236f8183611152565b810103126102fc575f612350565b503d612365565b60209193506123a4903d805f833e61239c8183611152565b81019061387c565b5093919050612242565b837f00000000000000000000000000000000000000000000000000000000000000001694612192565b6001600160a01b036124669561242e9394956123f860809b8c8101906118d9565b9390946040519761240889611136565b5f8952602089015216604087015260609a8b978888015286015260a08501523691611381565b60c0820152604051809381927f2bfb780c00000000000000000000000000000000000000000000000000000000835260048301613810565b03815f6001600160a01b037f0000000000000000000000000000000000000000000000000000000000000000165af19384156102f1575f94612525575b50506020015115611c9657816001600160a01b036020611ee493600196956124cb8c8c611691565b526124fb8383830151167f00000000000000000000000000000000000000000000000000000000000000006141c0565b500151167f000000000000000000000000000000000000000000000000000000000000000061420a565b6020929450908161254192903d10611ce057611ccd8183611152565b91505092905f6124a3565b5f90611b2d565b5091955090935050600101611a61565b61258d827f00000000000000000000000000000000000000000000000000000000000000006141c0565b506125b986837f000000000000000000000000000000000000000000000000000000000000000061420a565b611aec565b50321515611ac7565b50506125f27f0000000000000000000000000000000000000000000000000000000000000000613a71565b916125fd83516119d0565b7f0000000000000000000000000000000000000000000000000000000000000000917f000000000000000000000000000000000000000000000000000000000000000091905f5b86518110156126ba576001906001600160a01b0380612663838b611691565b51165f528560205261269160405f205c8261267e858d611691565b51165f528860205260405f205c90611a01565b61269b8387611691565b526126a6828a611691565b51165f52856020525f604081205d01612644565b50949391509150565b7fe08b8af0000000000000000000000000000000000000000000000000000000005f5260045ffd5b905f198201918213600116611a0e57565b7f80000000000000000000000000000000000000000000000000000000000000008114611a0e575f190190565b907f000000000000000000000000000000000000000000000000000000000000000090815c7f0000000000000000000000000000000000000000000000000000000000000000612779815c6126eb565b907f0000000000000000000000000000000000000000000000000000000000000000915b5f81121561283a575050506127b1906126eb565b917f0000000000000000000000000000000000000000000000000000000000000000925b5f8112156127ea575050505061184c906136b1565b61283590825f5261282f60205f83828220015c91828252888152886040916128228a8d8587205c906001600160a01b03891690613eb0565b8484525281205d84613e0d565b506126fc565b6127d5565b61287290825f5261282f60205f8a8785848420015c938484528181526128228c6040948587205c906001600160a01b03891690613add565b61279d565b3d156128a1573d9061288882611365565b916128966040519384611152565b82523d5f602084013e565b606090565b359065ffffffffffff821682036102fc57565b905f917f00000000000000000000000000000000000000000000000000000000000000006001600160a01b03815c16156128f1575050565b909192505d600190565b90604082013542116126c357612917611a5760208401846136f4565b915f5b61292760208301836136f4565b90508110156135d15761294481611a93611a8b60208601866136f4565b60608101519061297e6001600160a01b038251167f00000000000000000000000000000000000000000000000000000000000000006141c0565b506020810151515f198101908111611a0e575b5f8112156129a45750505060010161291a565b6129b2816020840151611691565b516129bb613788565b9082156020830152602084015151805f19810111611a0e575f1901831480835261358f575b6020820151156135545760408401516001600160a01b03855116915b604081015115612c1d5783916001600160a01b036060926020612aa0970151151580612c14575b612bed575b5116906001600160a01b0385168203612be6576001915b60405192612a4c8461111a565b60018452612a59816137be565b6020840152604083015288838301526080820152604051809581927f43583be500000000000000000000000000000000000000000000000000000000835260048301613a22565b03815f6001600160a01b037f0000000000000000000000000000000000000000000000000000000000000000165af19283156102f15787918b915f95612bbf575b506020015115612bb057612ba69284612b02612bab979694612b7594611691565b52612b366001600160a01b0382167f00000000000000000000000000000000000000000000000000000000000000006141c0565b506001600160a01b03612b4d8460408a01516137b1565b91167f000000000000000000000000000000000000000000000000000000000000000061420a565b6001600160a01b038551167f000000000000000000000000000000000000000000000000000000000000000061420a565b6126fc565b612991565b505050612bab919350926126fc565b6020919550612bdc9060603d606011611ce057611ccd8183611152565b5095919050612ae1565b5f91612a3f565b612c0f612bf98d611344565b8d8b611ae6886040888451169301519301611358565b612a28565b50321515612a23565b906001600160a01b03825116806001600160a01b038516145f14613137575060208401516130495750604051927f967870920000000000000000000000000000000000000000000000000000000084526001600160a01b03831660048501526020846024816001600160a01b037f0000000000000000000000000000000000000000000000000000000000000000165afa9384156102f1575f94613015575b5083916001600160a01b038151166001600160a01b037f0000000000000000000000000000000000000000000000000000000000000000163b156102fc576040517fae6393290000000000000000000000000000000000000000000000000000000081526001600160a01b03909116600482015230602482015260448101959095525f8580606481010381836001600160a01b037f0000000000000000000000000000000000000000000000000000000000000000165af19081156102f157612dec955f92613006575b505b611ddd6001600160a01b03612da88b828551168360208701511690614223565b50925116918c6002612dbf608092838101906118d9565b92909360405196612dcf886110ea565b875230602088015289604088015260608701528501523691611381565b0381836001600160a01b037f0000000000000000000000000000000000000000000000000000000000000000165af19384156102f1575f94612fe3575b506020015115612ecf57908291612bab9493612e45898d611691565b52612e7a836001600160a01b0384167f000000000000000000000000000000000000000000000000000000000000000061420a565b80831080612eb4575b612e90575b5050506126fc565b612ea6612eac93612ea08b611344565b926137b1565b91614356565b5f8080612e88565b50306001600160a01b03612ec78b611344565b161415612e83565b9450908094808210612ee8575b505050612bab906126fc565b91612ef8602092612f77946137b1565b90612f2d826001600160a01b037f00000000000000000000000000000000000000000000000000000000000000001683614356565b60405193849283927f15afd40900000000000000000000000000000000000000000000000000000000845260048401602090939291936001600160a01b0360408201951681520152565b03815f6001600160a01b037f0000000000000000000000000000000000000000000000000000000000000000165af180156102f157612fb8575b8080612edc565b602090813d8311612fdc575b612fce8183611152565b810103126102fc575f612fb1565b503d612fc4565b6020919450612ffb903d805f833e611f248183611152565b509094919050612e29565b61300f90611106565b5f612d86565b9093506020813d602011613041575b8161303160209383611152565b810103126102fc5751925f612cbc565b3d9150613024565b909261305489611344565b6001600160a01b033091160361306f575b5f612dec94612d88565b6001600160a01b037f000000000000000000000000000000000000000000000000000000000000000016936130a38a611344565b6130ac846142fd565b90863b156102fc576040517f36c785160000000000000000000000000000000000000000000000000000000081526001600160a01b039182166004820152306024820152918116604483015285166064820152945f908690608490829084905af19081156102f157612dec955f92613128575b50945050613065565b61313190611106565b5f61311f565b6001600160a01b036020849695940151168a8282145f1461340b5750505061320c61316e5f92846001600160a01b03885116614223565b92906131d48c6001600160a01b03808a5116938951151586146133df576131a361319784611344565b935b60808101906118d9565b929093604051966131b3886110ea565b875216602086015260408501528c6060850152600260808501523691611381565b60a0820152604051809381927f4af29ec4000000000000000000000000000000000000000000000000000000008352600483016138f8565b0381836001600160a01b037f0000000000000000000000000000000000000000000000000000000000000000165af19081156102f1575f916133c4575b5060208401518c908a90156133aa5783836001600160a01b03936132836132899461327c8f9c9b9a98996132b29a611691565b5192611691565b52611691565b5191167f000000000000000000000000000000000000000000000000000000000000000061420a565b51156132f457612bab92916001600160a01b036020612ba6930151167f0000000000000000000000000000000000000000000000000000000000000000614341565b516040517f15afd4090000000000000000000000000000000000000000000000000000000081526001600160a01b0390911660048201526024810191909152602081806044810103815f6001600160a01b037f0000000000000000000000000000000000000000000000000000000000000000165af180156102f15761337f575b50612bab906126fc565b602090813d83116133a3575b6133958183611152565b810103126102fc575f613375565b503d61338b565b50509091506133bb92939650611691565b519384916132b2565b6133d891503d805f833e61239c8183611152565b9050613249565b6131a3827f00000000000000000000000000000000000000000000000000000000000000001693613199565b61349e965090613466916060948b61342b608099989993848101906118d9565b9390946040519761343b89611136565b6001895260208901526001600160a01b038b1660408901528888015286015260a08501523691611381565b60c0820152604051809581927f2bfb780c00000000000000000000000000000000000000000000000000000000835260048301613810565b03815f6001600160a01b037f0000000000000000000000000000000000000000000000000000000000000000165af19283156102f15787918b915f9561352d575b506020015115612bb057612ba69284613505612bab9796946001600160a01b0394611691565b52167f000000000000000000000000000000000000000000000000000000000000000061420a565b602091955061354a9060603d606011611ce057611ccd8183611152565b50959190506134df565b6fffffffffffffffffffffffffffffffff6001600160a01b0360206135858188015161357f886126eb565b90611691565b51015116916129fc565b6135cc856001600160a01b0360208401611c67828251167f00000000000000000000000000000000000000000000000000000000000000006141c0565b6129e0565b50506135fc7f0000000000000000000000000000000000000000000000000000000000000000613a71565b9161360783516119d0565b7f0000000000000000000000000000000000000000000000000000000000000000917f000000000000000000000000000000000000000000000000000000000000000091905f5b86518110156126ba576001906001600160a01b038061366d838b611691565b51165f528560205261368860405f205c8261267e858d611691565b6136928387611691565b5261369d828a611691565b51165f52856020525f604081205d0161364e565b4780156136f0577f00000000000000000000000000000000000000000000000000000000000000005c6136f0576001600160a01b0361184c92166140e0565b5050565b9035907fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe1813603018212156102fc570180359067ffffffffffffffff82116102fc57602001918160051b360383136102fc57565b91908110156116a55760051b810135907fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff81813603018212156102fc570190565b604051906040820182811067ffffffffffffffff8211176110bd576040525f6020838281520152565b91908203918211611a0e57565b600211156137c857565b7f4e487b71000000000000000000000000000000000000000000000000000000005f52602160045260245ffd5b908160609103126102fc578051916040602083015192015190565b61010060c0610f7c93602084528051613828816137be565b602085015260208101516001600160a01b0380911660408601528060408301511660608601526060820151166080850152608081015160a085015260a08101518285015201519160e0808201520190610ffb565b90916060828403126102fc5781519167ffffffffffffffff928381116102fc57846138a8918301611573565b9360208201519360408301519081116102fc57610f7c9201611507565b9081518082526020808093019301915f5b8281106138e4575050505090565b8351855293810193928101926001016138d6565b602081526001600160a01b038083511660208301526020830151166040820152613931604083015160c0606084015260e08301906138c5565b9060608301516080820152608083015160058110156137c857610f7c9360a0918284015201519060c0601f1982850301910152610ffb565b916060838303126102fc5782519260208101519267ffffffffffffffff938481116102fc578161399a918401611573565b9360408301519081116102fc57610f7c9201611507565b602081526001600160a01b038083511660208301526020830151166040820152604082015160608201526139f4606083015160c0608084015260e08301906138c5565b90608083015160048110156137c857610f7c9360a0918284015201519060c0601f1982850301910152610ffb565b91909160808060a08301948051613a38816137be565b84526020810151613a48816137be565b60208501526001600160a01b036040820151166040850152606081015160608501520151910152565b90815c613a7d81611175565b613a8a6040519182611152565b818152613a9682611175565b601f196020910136602084013781945f5b848110613ab5575050505050565b600190825f5280845f20015c6001600160a01b03613ad38388611691565b9116905201613aa7565b919280613dd8575b15613c51575050804710613c29576001600160a01b03807f00000000000000000000000000000000000000000000000000000000000000001691823b156102fc57604051907fd0e30db00000000000000000000000000000000000000000000000000000000082525f915f8160048185895af180156102f157613c12575b506044602092937f00000000000000000000000000000000000000000000000000000000000000001694613b98838783614356565b8460405196879485937f15afd409000000000000000000000000000000000000000000000000000000008552600485015260248401525af1908115613c065750613bdf5750565b602090813d8311613bff575b613bf58183611152565b810103126102fc57565b503d613beb565b604051903d90823e3d90fd5b60209250613c1f90611106565b60445f9250613b63565b7fa01a9df6000000000000000000000000000000000000000000000000000000005f5260045ffd5b90915f9080613c61575b50505050565b6001600160a01b0393847f00000000000000000000000000000000000000000000000000000000000000001694807f00000000000000000000000000000000000000000000000000000000000000001691613cbb846142fd565b96803b156102fc576040517f36c785160000000000000000000000000000000000000000000000000000000081526001600160a01b039283166004820152848316602482015297821660448901529186161660648701525f908690608490829084905af19485156102f157613d8095613dc4575b5082936020936040518097819582947f15afd40900000000000000000000000000000000000000000000000000000000845260048401602090939291936001600160a01b0360408201951681520152565b03925af1908115613c065750613d99575b808080613c5b565b602090813d8311613dbd575b613daf8183611152565b810103126102fc575f613d91565b503d613da5565b60209350613dd190611106565b5f92613d2f565b506001600160a01b03807f00000000000000000000000000000000000000000000000000000000000000001690821614613ae5565b6001810191805f5260209183835260405f205c8015155f14613ea7575f1990818101835c8380820191828403613e6a575b5050505050815c81810192818411611a0e575f93815d835284832001015d5f52525f604081205d600190565b613e77613e87938861443a565b865f52885f2001015c918561443a565b835f52808383885f2001015d5f5285855260405f205d5f80808381613e3e565b50505050505f90565b5f949383156140d857806140a3575b15614007576001600160a01b0391827f000000000000000000000000000000000000000000000000000000000000000016803b156102fc576040517fae6393290000000000000000000000000000000000000000000000000000000081526001600160a01b03929092166004830152306024830152604482018590525f908290606490829084905af180156102f157613ff4575b5084827f000000000000000000000000000000000000000000000000000000000000000016803b15613ff05781906024604051809481937f2e1a7d4d0000000000000000000000000000000000000000000000000000000083528960048401525af18015613fe557613fcd575b5061184c939450166140e0565b613fd78691611106565b613fe15784613fc0565b8480fd5b6040513d88823e3d90fd5b5080fd5b613fff919550611106565b5f935f613f53565b929350906001600160a01b037f000000000000000000000000000000000000000000000000000000000000000016803b156102fc576040517fae6393290000000000000000000000000000000000000000000000000000000081526001600160a01b03938416600482015293909216602484015260448301525f908290606490829084905af180156102f15761409a5750565b61184c90611106565b506001600160a01b03807f00000000000000000000000000000000000000000000000000000000000000001690831614613ebf565b505050509050565b814710614130575f8080936001600160a01b038294165af1614100612877565b501561410857565b7f1425ea42000000000000000000000000000000000000000000000000000000005f5260045ffd5b7fcd786059000000000000000000000000000000000000000000000000000000005f523060045260245ffd5b90614171575080511561410857805190602001fd5b815115806141b7575b614182575090565b6001600160a01b03907f9996b315000000000000000000000000000000000000000000000000000000005f521660045260245ffd5b50803b1561417a565b6001810190825f528160205260405f205c155f1461420357805c815f52838160205f20015d60018101809111611a0e57815d5c915f5260205260405f205d600190565b5050505f90565b905f5260205261421f60405f2091825c611a01565b905d565b916044929391936001600160a01b03604094859282808551998a9586947fc9c1661b0000000000000000000000000000000000000000000000000000000086521660048501521660248301527f0000000000000000000000000000000000000000000000000000000000000000165afa9384156142f3575f935f956142bc575b50506142b96142b285946119d0565b9485611691565b52565b809295508194503d83116142ec575b6142d58183611152565b810103126102fc5760208251920151925f806142a3565b503d6142cb565b83513d5f823e3d90fd5b6001600160a01b0390818111614311571690565b7f6dfcc650000000000000000000000000000000000000000000000000000000005f5260a060045260245260445ffd5b905f5260205261421f60405f2091825c6137b1565b6040519260208401907fa9059cbb0000000000000000000000000000000000000000000000000000000082526001600160a01b038094166024860152604485015260448452608084019084821067ffffffffffffffff8311176110bd576143d5935f9384936040521694519082865af16143ce612877565b908361415c565b8051908115159182614416575b50506143eb5750565b7f5274afe7000000000000000000000000000000000000000000000000000000005f5260045260245ffd5b81925090602091810103126102fc57602001518015908115036102fc575f806143e2565b5c111561444357565b7f0f4ae0e4000000000000000000000000000000000000000000000000000000005f5260045ffdfea2646970667358221220229a5cf89aa7c2d0a4b4d5db20bba6c2b3a74b080303fc6ec00ba582a5dcf75164736f6c634300081a0033",
+  "deployedBytecode": "0x60806040526004361015610072575b3615610018575f80fd5b6001600160a01b037f000000000000000000000000000000000000000000000000000000000000000016330361004a57005b7f0540ddf6000000000000000000000000000000000000000000000000000000005f5260045ffd5b5f3560e01c806308a465f614610e9d57806319c6989f1461084e578063286f580d146107b75780632950286e146106cc57806354fd4d501461058f5780635a3c3987146105665780635e01eb5a146105215780638a12a08c146104c65780638eb1b65e146103bf578063945ed33f14610344578063ac9650d8146103005763e3b5dff40361000e57346102fc576060806003193601126102fc5767ffffffffffffffff6004358181116102fc5761012d9036906004016112c4565b6101356111a1565b6044359283116102fc57610150610158933690600401610fcd565b9390916128b9565b905f5b835181101561017c57805f8761017360019488611691565b5101520161015b565b506101f06101fe610239946101b65f94886040519361019a8561111a565b30855260208501525f1960408501528660608501523691611381565b60808201526040519283917f8a12a08c0000000000000000000000000000000000000000000000000000000060208401526024830161143e565b03601f198101835282611152565b604051809481927fedfa3568000000000000000000000000000000000000000000000000000000008352602060048401526024830190610ffb565b0381836001600160a01b037f0000000000000000000000000000000000000000000000000000000000000000165af19182156102f1576102a39261028e915f916102cf575b50602080825183010191016115d4565b909391926102a7575b60405193849384610f2f565b0390f35b5f7f00000000000000000000000000000000000000000000000000000000000000005d610297565b6102eb91503d805f833e6102e38183611152565b81019061154d565b8461027e565b6040513d5f823e3d90fd5b5f80fd5b60206003193601126102fc5760043567ffffffffffffffff81116102fc576103386103326102a3923690600401610f9c565b9061179b565b60405191829182611020565b346102fc5761035236610eca565b61035a611945565b610362611972565b6103906102a3610371836128fb565b9193909461038a606061038383611344565b9201611358565b90612729565b5f7f9b779b17422d0df92223018b32b4d1fa46e071723d6817e2486d003becc55f005d60405193849384610f2f565b60806003193601126102fc5767ffffffffffffffff6004358181116102fc576103ec9036906004016112c4565b906103f56111b7565b906064359081116102fc576101f061048b6102399461045161041c5f953690600401610fcd565b610425336128b9565b97604051946104338661111a565b33865260208601526024356040860152151560608501523691611381565b60808201526040519283917f945ed33f000000000000000000000000000000000000000000000000000000006020840152602483016116d2565b604051809481927f48c89491000000000000000000000000000000000000000000000000000000008352602060048401526024830190610ffb565b346102fc576102a36104ef6104da36610eca565b6104e2611945565b6104ea611972565b611a3b565b5f7f9b779b17422d0df92223018b32b4d1fa46e071723d6817e2486d003becc55f009492945d60405193849384610f2f565b346102fc575f6003193601126102fc5760207f00000000000000000000000000000000000000000000000000000000000000005c6001600160a01b0360405191168152f35b346102fc576102a36104ef61057a36610eca565b610582611945565b61058a611972565b6128fb565b346102fc575f6003193601126102fc576040515f80549060018260011c91600184169182156106c2575b60209485851084146106955785879486865291825f146106575750506001146105fe575b506105ea92500383611152565b6102a3604051928284938452830190610ffb565b5f808052859250907f290decd9548b62a8d60345a988386fc84ba6bc95484008f6362f93160ef3e5635b85831061063f5750506105ea9350820101856105dd565b80548389018501528794508693909201918101610628565b7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff0016858201526105ea95151560051b85010192508791506105dd9050565b7f4e487b71000000000000000000000000000000000000000000000000000000005f52602260045260245ffd5b92607f16926105b9565b346102fc5760606003193601126102fc5767ffffffffffffffff6004358181116102fc576106fe9036906004016112c4565b906107076111a1565b6044359182116102fc5761072261072a923690600401610fcd565b9290916128b9565b905f5b845181101561075f57806fffffffffffffffffffffffffffffffff604061075660019489611691565b5101520161072d565b506101f06101fe8561077d5f94610239976040519361019a8561111a565b60808201526040519283917f5a3c3987000000000000000000000000000000000000000000000000000000006020840152602483016116d2565b60806003193601126102fc5767ffffffffffffffff6004358181116102fc576107e49036906004016112c4565b906107ed6111b7565b906064359081116102fc576101f061048b6102399461081461041c5f953690600401610fcd565b60808201526040519283917f08a465f60000000000000000000000000000000000000000000000000000000060208401526024830161143e565b60a06003193601126102fc5767ffffffffffffffff600435116102fc573660236004350112156102fc5767ffffffffffffffff60043560040135116102fc5736602460c060043560040135026004350101116102fc5760243567ffffffffffffffff81116102fc576108c4903690600401610f9c565b67ffffffffffffffff604435116102fc576060600319604435360301126102fc5760643567ffffffffffffffff81116102fc57610905903690600401610fcd565b60843567ffffffffffffffff81116102fc57610925903690600401610f9c565b949093610930611945565b806004356004013503610e75575f5b600435600401358110610bd25750505060443560040135907fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffdd6044353603018212156102fc57816044350160048101359067ffffffffffffffff82116102fc5760248260071b36039101136102fc576109e3575b6102a361033886865f7f9b779b17422d0df92223018b32b4d1fa46e071723d6817e2486d003becc55f005d61179b565b6001600160a01b039492947f0000000000000000000000000000000000000000000000000000000000000000163b156102fc57604051947f2a2d80d10000000000000000000000000000000000000000000000000000000086523360048701526060602487015260c486019260443501602481019367ffffffffffffffff6004830135116102fc57600482013560071b360385136102fc5760606064890152600482013590529192869260e484019291905f905b60048101358210610b5457505050602091601f19601f865f9787956001600160a01b03610ac860246044350161118d565b16608488015260448035013560a48801526003198787030160448801528186528786013787868286010152011601030181836001600160a01b037f0000000000000000000000000000000000000000000000000000000000000000165af19182156102f1576102a39361033893610b45575b8294508193506109b3565b610b4e90611106565b84610b3a565b9195945091926001600160a01b03610b6b8761118d565b168152602080870135916001600160a01b0383168093036102fc57600492600192820152610b9b604089016128a6565b65ffffffffffff8091166040830152610bb660608a016128a6565b1660608201526080809101970193019050889495939291610a97565b610be7610be082848661192a565b3691611381565b604051610bf3816110a1565b5f81526020915f838301525f60408301528281015190606060408201519101515f1a91835283830152604082015260c07fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffdc81850260043501360301126102fc5760405190610c60826110ea565b610c73602460c08602600435010161118d565b808352610c89604460c08702600435010161118d565b908185850152610ca2606460c08802600435010161118d565b60408581019190915260043560c08802016084810135606087015260a4810135608087015260c4013560a086015283015183519386015160ff91909116926001600160a01b0383163b156102fc575f6001600160a01b03809460e4948b98849860c460c06040519c8d9b8c9a7fd505accf000000000000000000000000000000000000000000000000000000008c521660048b01523060248b0152608482820260043501013560448b0152026004350101356064880152608487015260a486015260c4850152165af19081610e66575b50610e5c57610d7f612877565b906001600160a01b0381511690836001600160a01b0381830151166044604051809581937fdd62ed3e00000000000000000000000000000000000000000000000000000000835260048301523060248301525afa9182156102f1575f92610e2c575b506060015103610df75750506001905b0161093f565b805115610e045780519101fd5b7fa7285689000000000000000000000000000000000000000000000000000000005f5260045ffd5b9091508381813d8311610e55575b610e448183611152565b810103126102fc5751906060610de1565b503d610e3a565b5050600190610df1565b610e6f90611106565b8a610d72565b7faaad13f7000000000000000000000000000000000000000000000000000000005f5260045ffd5b346102fc57610eab36610eca565b610eb3611945565b610ebb611972565b6103906102a361037183611a3b565b600319906020828201126102fc576004359167ffffffffffffffff83116102fc578260a0920301126102fc5760040190565b9081518082526020808093019301915f5b828110610f1b575050505090565b835185529381019392810192600101610f0d565b939290610f4490606086526060860190610efc565b936020948181036020830152602080855192838152019401905f5b818110610f7f57505050610f7c9394506040818403910152610efc565b90565b82516001600160a01b031686529487019491870191600101610f5f565b9181601f840112156102fc5782359167ffffffffffffffff83116102fc576020808501948460051b0101116102fc57565b9181601f840112156102fc5782359167ffffffffffffffff83116102fc57602083818601950101116102fc57565b90601f19601f602080948051918291828752018686015e5f8582860101520116010190565b6020808201906020835283518092526040830192602060408460051b8301019501935f915b8483106110555750505050505090565b9091929394958480611091837fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc086600196030187528a51610ffb565b9801930193019194939290611045565b6060810190811067ffffffffffffffff8211176110bd57604052565b7f4e487b71000000000000000000000000000000000000000000000000000000005f52604160045260245ffd5b60c0810190811067ffffffffffffffff8211176110bd57604052565b67ffffffffffffffff81116110bd57604052565b60a0810190811067ffffffffffffffff8211176110bd57604052565b60e0810190811067ffffffffffffffff8211176110bd57604052565b90601f601f19910116810190811067ffffffffffffffff8211176110bd57604052565b67ffffffffffffffff81116110bd5760051b60200190565b35906001600160a01b03821682036102fc57565b602435906001600160a01b03821682036102fc57565b6044359081151582036102fc57565b9190916080818403126102fc57604090815191608083019467ffffffffffffffff95848110878211176110bd57825283956112008461118d565b8552602090818501359081116102fc57840182601f820112156102fc5780359061122982611175565b9361123686519586611152565b82855283850190846060809502840101928184116102fc578501915b8383106112745750505050508401528181013590830152606090810135910152565b84838303126102fc57875190611289826110a1565b6112928461118d565b825261129f87850161118d565b87830152888401359081151582036102fc578288928b89950152815201920191611252565b81601f820112156102fc578035916020916112de84611175565b936112ec6040519586611152565b808552838086019160051b830101928084116102fc57848301915b8483106113175750505050505090565b823567ffffffffffffffff81116102fc578691611339848480948901016111c6565b815201920191611307565b356001600160a01b03811681036102fc5790565b3580151581036102fc5790565b67ffffffffffffffff81116110bd57601f01601f191660200190565b92919261138d82611365565b9161139b6040519384611152565b8294818452818301116102fc578281602093845f960137010152565b9060808101916001600160a01b03808251168352602093848301519460808186015285518092528060a086019601925f905b83821061140b5750505050506060816040829301516040850152015191015290565b845180518216895280840151821689850152604090810151151590890152606090970196938201936001909101906113e9565b91909160209081815260c08101916001600160a01b0385511681830152808501519260a06040840152835180915260e08301918060e08360051b8601019501925f905b8382106114bd5750505050506080846040610f7c959601516060840152606081015115158284015201519060a0601f1982850301910152610ffb565b909192939583806114f8837fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff208a600196030186528a516113b7565b98019201920190939291611481565b81601f820112156102fc5780519061151e82611365565b9261152c6040519485611152565b828452602083830101116102fc57815f9260208093018386015e8301015290565b906020828203126102fc57815167ffffffffffffffff81116102fc57610f7c9201611507565b9080601f830112156102fc5781519060209161158e81611175565b9361159c6040519586611152565b81855260208086019260051b8201019283116102fc57602001905b8282106115c5575050505090565b815181529083019083016115b7565b90916060828403126102fc5781519167ffffffffffffffff928381116102fc5784611600918301611573565b936020808301518581116102fc5783019082601f830112156102fc5781519161162883611175565b926116366040519485611152565b808452828085019160051b830101918583116102fc578301905b82821061167257505050509360408301519081116102fc57610f7c9201611573565b81516001600160a01b03811681036102fc578152908301908301611650565b80518210156116a55760209160051b010190565b7f4e487b71000000000000000000000000000000000000000000000000000000005f52603260045260245ffd5b91909160209081815260c08101916001600160a01b0385511681830152808501519260a06040840152835180915260e08301918060e08360051b8601019501925f905b8382106117515750505050506080846040610f7c959601516060840152606081015115158284015201519060a0601f1982850301910152610ffb565b9091929395838061178c837fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff208a600196030186528a516113b7565b98019201920190939291611715565b91906117a6336128b9565b907f000000000000000000000000000000000000000000000000000000000000000093845c6118b1576001906001865d6117df83611175565b926117ed6040519485611152565b808452601f196117fc82611175565b015f5b8181106118a05750505f5b8181106118575750505050905f61184c92945d7f0000000000000000000000000000000000000000000000000000000000000000805c9161184e575b506136b1565b565b5f905d5f611846565b806118845f8061186c610be08996888a61192a565b602081519101305af461187d612877565b903061415c565b61188e8288611691565b526118998187611691565b500161180a565b8060606020809389010152016117ff565b7f3ee5aeb5000000000000000000000000000000000000000000000000000000005f5260045ffd5b9035907fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe1813603018212156102fc570180359067ffffffffffffffff82116102fc576020019181360383136102fc57565b908210156116a5576119419160051b8101906118d9565b9091565b7f9b779b17422d0df92223018b32b4d1fa46e071723d6817e2486d003becc55f00805c6118b1576001905d565b6001600160a01b037f00000000000000000000000000000000000000000000000000000000000000001633036119a457565b7f089676d5000000000000000000000000000000000000000000000000000000005f523360045260245ffd5b906119da82611175565b6119e76040519182611152565b828152601f196119f78294611175565b0190602036910137565b91908201809211611a0e57565b7f4e487b71000000000000000000000000000000000000000000000000000000005f52601160045260245ffd5b604081013542116126c35790611a5e611a5760208401846136f4565b90506119d0565b915f5b611a6e60208301836136f4565b90508110156125c757611a9881611a93611a8b60208601866136f4565b369391613748565b6111c6565b936040850151936001600160a01b038651169060208701518051156116a55760200151604001511515806125be575b1561256357611aec611ad886611344565b8784611ae660608a01611358565b92613add565b5f5b60208801515181101561255357611b03613788565b6020890151515f198101908111611a0e578214806020830152821582525f1461254c576060890151905b611b3b8360208c0151611691565b51604081015190919015611cee57611bd36001600160a01b03835116936001600160a01b03881685145f14611ce7576001945b60405195611b7b8761111a565b5f8752611b87816137be565b6020870152604086015260609485918d838301526080820152604051809381927f43583be500000000000000000000000000000000000000000000000000000000835260048301613a22565b03815f6001600160a01b037f0000000000000000000000000000000000000000000000000000000000000000165af19384156102f1575f94611cb0575b50506020015115611c9657816001600160a01b036020611c909360019695611c388c8c611691565b5201611c67828251167f00000000000000000000000000000000000000000000000000000000000000006141c0565b5051167f000000000000000000000000000000000000000000000000000000000000000061420a565b01611aee565b602001519097506001600160a01b03169250600190611c90565b60209294509081611cd592903d10611ce0575b611ccd8183611152565b8101906137f5565b91505092905f611c10565b503d611cc3565b5f94611b6e565b888a6001600160a01b038495945116806001600160a01b038a16145f14612132575050815115905061206e57888a80151580612053575b611f4d575b6001600160a01b03939291611ddd82611e15978b5f95897f0000000000000000000000000000000000000000000000000000000000000000921680885282602052604088205c611f3c575b5050505b6001611d9c8983511660208401998b8b51169080158a14611f3657508391614223565b999092511694611db1608091828101906118d9565b93909460405197611dc1896110ea565b8852306020890152604088015260608701528501523691611381565b60a0820152604051809681927f21457897000000000000000000000000000000000000000000000000000000008352600483016139b1565b0381836001600160a01b037f0000000000000000000000000000000000000000000000000000000000000000165af19384156102f1575f94611f0c575b506020015115611ee95791611ebc826001600160a01b0360019695611e7a611ee49686611691565b51611e858d8d611691565b52611eb3828251167f00000000000000000000000000000000000000000000000000000000000000006141c0565b50511692611691565b51907f000000000000000000000000000000000000000000000000000000000000000061420a565b611c90565b98506001929450611f02906001600160a01b0392611691565b5197511692611c90565b6020919450611f2c903d805f833e611f248183611152565b810190613969565b5094919050611e52565b91614223565b611f4592614341565b5f8281611d75565b50611f5a90929192611344565b91611f648b6142fd565b6001600160a01b037f0000000000000000000000000000000000000000000000000000000000000000163b156102fc576040517f36c785160000000000000000000000000000000000000000000000000000000081526001600160a01b039485166004820152306024820152908416604482015292871660648401525f8380608481010381836001600160a01b037f0000000000000000000000000000000000000000000000000000000000000000165af180156102f1578a611ddd8d611e15976001600160a01b03975f95612044575b50975092505091929350611d2a565b61204d90611106565b5f612035565b5061205d82611344565b6001600160a01b0316301415611d25565b906001600160a01b037f000000000000000000000000000000000000000000000000000000000000000016916001600160a01b0384511692803b156102fc576040517fae6393290000000000000000000000000000000000000000000000000000000081526001600160a01b03949094166004850152306024850152604484018c90525f908490606490829084905af180156102f1578a611ddd8d611e15976001600160a01b03975f95612123575b50611d79565b61212c90611106565b5f61211d565b6001600160a01b0360208796949701511690898183145f146123d7576121cd925061220597915060016121735f96956001600160a01b0393848b5116614223565b509282895116956020890151151588146123ae5761219082611344565b945b6121a1608093848101906118d9565b959096604051996121b18b6110ea565b8a52166020890152604088015260608701528501523691611381565b60a0820152604051809581927f4af29ec4000000000000000000000000000000000000000000000000000000008352600483016138f8565b0381836001600160a01b037f0000000000000000000000000000000000000000000000000000000000000000165af19283156102f1575f93612384575b5060200151156122c357816001600160a01b036020611ee493600196956122698c8c611691565b526122998383830151167f00000000000000000000000000000000000000000000000000000000000000006141c0565b500151167f000000000000000000000000000000000000000000000000000000000000000061420a565b60208181015191516040517f15afd4090000000000000000000000000000000000000000000000000000000081526001600160a01b03918216600482015260248101859052939a50909116945081806044810103815f6001600160a01b037f0000000000000000000000000000000000000000000000000000000000000000165af180156102f157612359575b50600190611c90565b602090813d831161237d575b61236f8183611152565b810103126102fc575f612350565b503d612365565b60209193506123a4903d805f833e61239c8183611152565b81019061387c565b5093919050612242565b837f00000000000000000000000000000000000000000000000000000000000000001694612192565b6001600160a01b036124669561242e9394956123f860809b8c8101906118d9565b9390946040519761240889611136565b5f8952602089015216604087015260609a8b978888015286015260a08501523691611381565b60c0820152604051809381927f2bfb780c00000000000000000000000000000000000000000000000000000000835260048301613810565b03815f6001600160a01b037f0000000000000000000000000000000000000000000000000000000000000000165af19384156102f1575f94612525575b50506020015115611c9657816001600160a01b036020611ee493600196956124cb8c8c611691565b526124fb8383830151167f00000000000000000000000000000000000000000000000000000000000000006141c0565b500151167f000000000000000000000000000000000000000000000000000000000000000061420a565b6020929450908161254192903d10611ce057611ccd8183611152565b91505092905f6124a3565b5f90611b2d565b5091955090935050600101611a61565b61258d827f00000000000000000000000000000000000000000000000000000000000000006141c0565b506125b986837f000000000000000000000000000000000000000000000000000000000000000061420a565b611aec565b50321515611ac7565b50506125f27f0000000000000000000000000000000000000000000000000000000000000000613a71565b916125fd83516119d0565b7f0000000000000000000000000000000000000000000000000000000000000000917f000000000000000000000000000000000000000000000000000000000000000091905f5b86518110156126ba576001906001600160a01b0380612663838b611691565b51165f528560205261269160405f205c8261267e858d611691565b51165f528860205260405f205c90611a01565b61269b8387611691565b526126a6828a611691565b51165f52856020525f604081205d01612644565b50949391509150565b7fe08b8af0000000000000000000000000000000000000000000000000000000005f5260045ffd5b905f198201918213600116611a0e57565b7f80000000000000000000000000000000000000000000000000000000000000008114611a0e575f190190565b907f000000000000000000000000000000000000000000000000000000000000000090815c7f0000000000000000000000000000000000000000000000000000000000000000612779815c6126eb565b907f0000000000000000000000000000000000000000000000000000000000000000915b5f81121561283a575050506127b1906126eb565b917f0000000000000000000000000000000000000000000000000000000000000000925b5f8112156127ea575050505061184c906136b1565b61283590825f5261282f60205f83828220015c91828252888152886040916128228a8d8587205c906001600160a01b03891690613eb0565b8484525281205d84613e0d565b506126fc565b6127d5565b61287290825f5261282f60205f8a8785848420015c938484528181526128228c6040948587205c906001600160a01b03891690613add565b61279d565b3d156128a1573d9061288882611365565b916128966040519384611152565b82523d5f602084013e565b606090565b359065ffffffffffff821682036102fc57565b905f917f00000000000000000000000000000000000000000000000000000000000000006001600160a01b03815c16156128f1575050565b909192505d600190565b90604082013542116126c357612917611a5760208401846136f4565b915f5b61292760208301836136f4565b90508110156135d15761294481611a93611a8b60208601866136f4565b60608101519061297e6001600160a01b038251167f00000000000000000000000000000000000000000000000000000000000000006141c0565b506020810151515f198101908111611a0e575b5f8112156129a45750505060010161291a565b6129b2816020840151611691565b516129bb613788565b9082156020830152602084015151805f19810111611a0e575f1901831480835261358f575b6020820151156135545760408401516001600160a01b03855116915b604081015115612c1d5783916001600160a01b036060926020612aa0970151151580612c14575b612bed575b5116906001600160a01b0385168203612be6576001915b60405192612a4c8461111a565b60018452612a59816137be565b6020840152604083015288838301526080820152604051809581927f43583be500000000000000000000000000000000000000000000000000000000835260048301613a22565b03815f6001600160a01b037f0000000000000000000000000000000000000000000000000000000000000000165af19283156102f15787918b915f95612bbf575b506020015115612bb057612ba69284612b02612bab979694612b7594611691565b52612b366001600160a01b0382167f00000000000000000000000000000000000000000000000000000000000000006141c0565b506001600160a01b03612b4d8460408a01516137b1565b91167f000000000000000000000000000000000000000000000000000000000000000061420a565b6001600160a01b038551167f000000000000000000000000000000000000000000000000000000000000000061420a565b6126fc565b612991565b505050612bab919350926126fc565b6020919550612bdc9060603d606011611ce057611ccd8183611152565b5095919050612ae1565b5f91612a3f565b612c0f612bf98d611344565b8d8b611ae6886040888451169301519301611358565b612a28565b50321515612a23565b906001600160a01b03825116806001600160a01b038516145f14613137575060208401516130495750604051927f967870920000000000000000000000000000000000000000000000000000000084526001600160a01b03831660048501526020846024816001600160a01b037f0000000000000000000000000000000000000000000000000000000000000000165afa9384156102f1575f94613015575b5083916001600160a01b038151166001600160a01b037f0000000000000000000000000000000000000000000000000000000000000000163b156102fc576040517fae6393290000000000000000000000000000000000000000000000000000000081526001600160a01b03909116600482015230602482015260448101959095525f8580606481010381836001600160a01b037f0000000000000000000000000000000000000000000000000000000000000000165af19081156102f157612dec955f92613006575b505b611ddd6001600160a01b03612da88b828551168360208701511690614223565b50925116918c6002612dbf608092838101906118d9565b92909360405196612dcf886110ea565b875230602088015289604088015260608701528501523691611381565b0381836001600160a01b037f0000000000000000000000000000000000000000000000000000000000000000165af19384156102f1575f94612fe3575b506020015115612ecf57908291612bab9493612e45898d611691565b52612e7a836001600160a01b0384167f000000000000000000000000000000000000000000000000000000000000000061420a565b80831080612eb4575b612e90575b5050506126fc565b612ea6612eac93612ea08b611344565b926137b1565b91614356565b5f8080612e88565b50306001600160a01b03612ec78b611344565b161415612e83565b9450908094808210612ee8575b505050612bab906126fc565b91612ef8602092612f77946137b1565b90612f2d826001600160a01b037f00000000000000000000000000000000000000000000000000000000000000001683614356565b60405193849283927f15afd40900000000000000000000000000000000000000000000000000000000845260048401602090939291936001600160a01b0360408201951681520152565b03815f6001600160a01b037f0000000000000000000000000000000000000000000000000000000000000000165af180156102f157612fb8575b8080612edc565b602090813d8311612fdc575b612fce8183611152565b810103126102fc575f612fb1565b503d612fc4565b6020919450612ffb903d805f833e611f248183611152565b509094919050612e29565b61300f90611106565b5f612d86565b9093506020813d602011613041575b8161303160209383611152565b810103126102fc5751925f612cbc565b3d9150613024565b909261305489611344565b6001600160a01b033091160361306f575b5f612dec94612d88565b6001600160a01b037f000000000000000000000000000000000000000000000000000000000000000016936130a38a611344565b6130ac846142fd565b90863b156102fc576040517f36c785160000000000000000000000000000000000000000000000000000000081526001600160a01b039182166004820152306024820152918116604483015285166064820152945f908690608490829084905af19081156102f157612dec955f92613128575b50945050613065565b61313190611106565b5f61311f565b6001600160a01b036020849695940151168a8282145f1461340b5750505061320c61316e5f92846001600160a01b03885116614223565b92906131d48c6001600160a01b03808a5116938951151586146133df576131a361319784611344565b935b60808101906118d9565b929093604051966131b3886110ea565b875216602086015260408501528c6060850152600260808501523691611381565b60a0820152604051809381927f4af29ec4000000000000000000000000000000000000000000000000000000008352600483016138f8565b0381836001600160a01b037f0000000000000000000000000000000000000000000000000000000000000000165af19081156102f1575f916133c4575b5060208401518c908a90156133aa5783836001600160a01b03936132836132899461327c8f9c9b9a98996132b29a611691565b5192611691565b52611691565b5191167f000000000000000000000000000000000000000000000000000000000000000061420a565b51156132f457612bab92916001600160a01b036020612ba6930151167f0000000000000000000000000000000000000000000000000000000000000000614341565b516040517f15afd4090000000000000000000000000000000000000000000000000000000081526001600160a01b0390911660048201526024810191909152602081806044810103815f6001600160a01b037f0000000000000000000000000000000000000000000000000000000000000000165af180156102f15761337f575b50612bab906126fc565b602090813d83116133a3575b6133958183611152565b810103126102fc575f613375565b503d61338b565b50509091506133bb92939650611691565b519384916132b2565b6133d891503d805f833e61239c8183611152565b9050613249565b6131a3827f00000000000000000000000000000000000000000000000000000000000000001693613199565b61349e965090613466916060948b61342b608099989993848101906118d9565b9390946040519761343b89611136565b6001895260208901526001600160a01b038b1660408901528888015286015260a08501523691611381565b60c0820152604051809581927f2bfb780c00000000000000000000000000000000000000000000000000000000835260048301613810565b03815f6001600160a01b037f0000000000000000000000000000000000000000000000000000000000000000165af19283156102f15787918b915f9561352d575b506020015115612bb057612ba69284613505612bab9796946001600160a01b0394611691565b52167f000000000000000000000000000000000000000000000000000000000000000061420a565b602091955061354a9060603d606011611ce057611ccd8183611152565b50959190506134df565b6fffffffffffffffffffffffffffffffff6001600160a01b0360206135858188015161357f886126eb565b90611691565b51015116916129fc565b6135cc856001600160a01b0360208401611c67828251167f00000000000000000000000000000000000000000000000000000000000000006141c0565b6129e0565b50506135fc7f0000000000000000000000000000000000000000000000000000000000000000613a71565b9161360783516119d0565b7f0000000000000000000000000000000000000000000000000000000000000000917f000000000000000000000000000000000000000000000000000000000000000091905f5b86518110156126ba576001906001600160a01b038061366d838b611691565b51165f528560205261368860405f205c8261267e858d611691565b6136928387611691565b5261369d828a611691565b51165f52856020525f604081205d0161364e565b4780156136f0577f00000000000000000000000000000000000000000000000000000000000000005c6136f0576001600160a01b0361184c92166140e0565b5050565b9035907fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe1813603018212156102fc570180359067ffffffffffffffff82116102fc57602001918160051b360383136102fc57565b91908110156116a55760051b810135907fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff81813603018212156102fc570190565b604051906040820182811067ffffffffffffffff8211176110bd576040525f6020838281520152565b91908203918211611a0e57565b600211156137c857565b7f4e487b71000000000000000000000000000000000000000000000000000000005f52602160045260245ffd5b908160609103126102fc578051916040602083015192015190565b61010060c0610f7c93602084528051613828816137be565b602085015260208101516001600160a01b0380911660408601528060408301511660608601526060820151166080850152608081015160a085015260a08101518285015201519160e0808201520190610ffb565b90916060828403126102fc5781519167ffffffffffffffff928381116102fc57846138a8918301611573565b9360208201519360408301519081116102fc57610f7c9201611507565b9081518082526020808093019301915f5b8281106138e4575050505090565b8351855293810193928101926001016138d6565b602081526001600160a01b038083511660208301526020830151166040820152613931604083015160c0606084015260e08301906138c5565b9060608301516080820152608083015160058110156137c857610f7c9360a0918284015201519060c0601f1982850301910152610ffb565b916060838303126102fc5782519260208101519267ffffffffffffffff938481116102fc578161399a918401611573565b9360408301519081116102fc57610f7c9201611507565b602081526001600160a01b038083511660208301526020830151166040820152604082015160608201526139f4606083015160c0608084015260e08301906138c5565b90608083015160048110156137c857610f7c9360a0918284015201519060c0601f1982850301910152610ffb565b91909160808060a08301948051613a38816137be565b84526020810151613a48816137be565b60208501526001600160a01b036040820151166040850152606081015160608501520151910152565b90815c613a7d81611175565b613a8a6040519182611152565b818152613a9682611175565b601f196020910136602084013781945f5b848110613ab5575050505050565b600190825f5280845f20015c6001600160a01b03613ad38388611691565b9116905201613aa7565b919280613dd8575b15613c51575050804710613c29576001600160a01b03807f00000000000000000000000000000000000000000000000000000000000000001691823b156102fc57604051907fd0e30db00000000000000000000000000000000000000000000000000000000082525f915f8160048185895af180156102f157613c12575b506044602092937f00000000000000000000000000000000000000000000000000000000000000001694613b98838783614356565b8460405196879485937f15afd409000000000000000000000000000000000000000000000000000000008552600485015260248401525af1908115613c065750613bdf5750565b602090813d8311613bff575b613bf58183611152565b810103126102fc57565b503d613beb565b604051903d90823e3d90fd5b60209250613c1f90611106565b60445f9250613b63565b7fa01a9df6000000000000000000000000000000000000000000000000000000005f5260045ffd5b90915f9080613c61575b50505050565b6001600160a01b0393847f00000000000000000000000000000000000000000000000000000000000000001694807f00000000000000000000000000000000000000000000000000000000000000001691613cbb846142fd565b96803b156102fc576040517f36c785160000000000000000000000000000000000000000000000000000000081526001600160a01b039283166004820152848316602482015297821660448901529186161660648701525f908690608490829084905af19485156102f157613d8095613dc4575b5082936020936040518097819582947f15afd40900000000000000000000000000000000000000000000000000000000845260048401602090939291936001600160a01b0360408201951681520152565b03925af1908115613c065750613d99575b808080613c5b565b602090813d8311613dbd575b613daf8183611152565b810103126102fc575f613d91565b503d613da5565b60209350613dd190611106565b5f92613d2f565b506001600160a01b03807f00000000000000000000000000000000000000000000000000000000000000001690821614613ae5565b6001810191805f5260209183835260405f205c8015155f14613ea7575f1990818101835c8380820191828403613e6a575b5050505050815c81810192818411611a0e575f93815d835284832001015d5f52525f604081205d600190565b613e77613e87938861443a565b865f52885f2001015c918561443a565b835f52808383885f2001015d5f5285855260405f205d5f80808381613e3e565b50505050505f90565b5f949383156140d857806140a3575b15614007576001600160a01b0391827f000000000000000000000000000000000000000000000000000000000000000016803b156102fc576040517fae6393290000000000000000000000000000000000000000000000000000000081526001600160a01b03929092166004830152306024830152604482018590525f908290606490829084905af180156102f157613ff4575b5084827f000000000000000000000000000000000000000000000000000000000000000016803b15613ff05781906024604051809481937f2e1a7d4d0000000000000000000000000000000000000000000000000000000083528960048401525af18015613fe557613fcd575b5061184c939450166140e0565b613fd78691611106565b613fe15784613fc0565b8480fd5b6040513d88823e3d90fd5b5080fd5b613fff919550611106565b5f935f613f53565b929350906001600160a01b037f000000000000000000000000000000000000000000000000000000000000000016803b156102fc576040517fae6393290000000000000000000000000000000000000000000000000000000081526001600160a01b03938416600482015293909216602484015260448301525f908290606490829084905af180156102f15761409a5750565b61184c90611106565b506001600160a01b03807f00000000000000000000000000000000000000000000000000000000000000001690831614613ebf565b505050509050565b814710614130575f8080936001600160a01b038294165af1614100612877565b501561410857565b7f1425ea42000000000000000000000000000000000000000000000000000000005f5260045ffd5b7fcd786059000000000000000000000000000000000000000000000000000000005f523060045260245ffd5b90614171575080511561410857805190602001fd5b815115806141b7575b614182575090565b6001600160a01b03907f9996b315000000000000000000000000000000000000000000000000000000005f521660045260245ffd5b50803b1561417a565b6001810190825f528160205260405f205c155f1461420357805c815f52838160205f20015d60018101809111611a0e57815d5c915f5260205260405f205d600190565b5050505f90565b905f5260205261421f60405f2091825c611a01565b905d565b916044929391936001600160a01b03604094859282808551998a9586947fc9c1661b0000000000000000000000000000000000000000000000000000000086521660048501521660248301527f0000000000000000000000000000000000000000000000000000000000000000165afa9384156142f3575f935f956142bc575b50506142b96142b285946119d0565b9485611691565b52565b809295508194503d83116142ec575b6142d58183611152565b810103126102fc5760208251920151925f806142a3565b503d6142cb565b83513d5f823e3d90fd5b6001600160a01b0390818111614311571690565b7f6dfcc650000000000000000000000000000000000000000000000000000000005f5260a060045260245260445ffd5b905f5260205261421f60405f2091825c6137b1565b6040519260208401907fa9059cbb0000000000000000000000000000000000000000000000000000000082526001600160a01b038094166024860152604485015260448452608084019084821067ffffffffffffffff8311176110bd576143d5935f9384936040521694519082865af16143ce612877565b908361415c565b8051908115159182614416575b50506143eb5750565b7f5274afe7000000000000000000000000000000000000000000000000000000005f5260045260245ffd5b81925090602091810103126102fc57602001518015908115036102fc575f806143e2565b5c111561444357565b7f0f4ae0e4000000000000000000000000000000000000000000000000000000005f5260045ffdfea2646970667358221220229a5cf89aa7c2d0a4b4d5db20bba6c2b3a74b080303fc6ec00ba582a5dcf75164736f6c634300081a0033",
+  "linkReferences": {},
+  "deployedLinkReferences": {}
+}

--- a/crates/contracts/build.rs
+++ b/crates/contracts/build.rs
@@ -635,6 +635,49 @@ fn main() {
     });
     generate_contract("BalancerV2LiquidityBootstrappingPool");
     generate_contract("BalancerV2ComposableStablePool");
+    generate_contract_with_config("BalancerV3BatchRouter", |builder| {
+        builder
+            .add_network(
+                MAINNET,
+                Network {
+                    address: addr("0x136f1EFcC3f8f88516B9E94110D56FDBfB1778d1"),
+                    // <https://etherscan.io/tx/0x41cb8619fb92dd532eb09b0e81fd4ce1c6006a10924893f02909e36a317777f3>
+                    deployment_information: Some(DeploymentInformation::BlockNumber(21339510)),
+                },
+            )
+            .add_network(
+                GNOSIS,
+                Network {
+                    address: addr("0xe2fa4e1d17725e72dcdAfe943Ecf45dF4B9E285b"),
+                    // <https://gnosisscan.io/tx/0xeafddbace9f445266f851ef1d92928e3d01a4622a1a6780b41ac52d5872f12ab>
+                    deployment_information: Some(DeploymentInformation::BlockNumber(37377506)),
+                },
+            )
+            .add_network(
+                SEPOLIA,
+                Network {
+                    address: addr("0xC85b652685567C1B074e8c0D4389f83a2E458b1C"),
+                    // <https://sepolia.etherscan.io/tx/0x95ed8e1aaaa7bdc5881f3c8fc5a4914a66639bee52987c3a1ea88545083b0681>
+                    deployment_information: Some(DeploymentInformation::BlockNumber(7219301)),
+                },
+            )
+            .add_network(
+                ARBITRUM_ONE,
+                Network {
+                    address: addr("0xaD89051bEd8d96f045E8912aE1672c6C0bF8a85E"),
+                    // <https://arbiscan.io/tx/0xa7968c6bc0775208ffece789c6e5d09b0eea5f2c3ed2806e9bd94fb0b978ff0f>
+                    deployment_information: Some(DeploymentInformation::BlockNumber(297828544)),
+                },
+            )
+            .add_network(
+                BASE,
+                Network {
+                    address: addr("0x85a80afee867aDf27B50BdB7b76DA70f1E853062"),
+                    // <https://basescan.org/tx/0x47b81146714630ce50445bfa28872a36973acedf785317ca423498810ec8e76c>
+                    deployment_information: Some(DeploymentInformation::BlockNumber(25347205)),
+                },
+            )
+    });
     generate_contract_with_config("BaoswapRouter", |builder| {
         builder.add_network_str(GNOSIS, "0x6093AeBAC87d62b1A5a4cEec91204e35020E38bE")
     });

--- a/crates/contracts/src/lib.rs
+++ b/crates/contracts/src/lib.rs
@@ -70,6 +70,7 @@ include_contracts! {
     BalancerV2WeightedPoolFactory;
     BalancerV2WeightedPoolFactoryV3;
     BalancerV2WeightedPoolFactoryV4;
+    BalancerV3BatchRouter;
     BaoswapRouter;
     CowAmm;
     CowAmmConstantProductFactory;


### PR DESCRIPTION
# Description
In order to support balancer v3 routes in the balancer solver we need to have the rust bindings for the balancer v3 BatchRouter contract (ABI taken from [here](https://github.com/balancer/balancer-deployments/blob/e94346b727530591252e2e9924068f1e4e0a6780/v3/tasks/20241205-v3-batch-router/artifact/BatchRouter.json)). This PR adds this in the services so the `solvers` repo can import the contract via the services dependency.

# Changes
- just adds the ABI file and the boiler plate code to generate the bindings