### PR TITLE
Fix wrong solver address saved to database on flash loans

### DIFF
--- a/crates/autopilot/src/domain/eth/mod.rs
+++ b/crates/autopilot/src/domain/eth/mod.rs
@@ -315,6 +315,8 @@ pub struct TradeEvent {
 /// Call frames of a transaction.
 #[derive(Clone, Debug, Default)]
 pub struct CallFrame {
+    /// The address of the call initiator.
+    pub from: Address,
     /// The address of the contract that was called.
     pub to: Option<Address>,
     /// Calldata input.

--- a/crates/autopilot/src/domain/settlement/mod.rs
+++ b/crates/autopilot/src/domain/settlement/mod.rs
@@ -45,7 +45,7 @@ impl Settlement {
     pub fn solver(&self) -> eth::Address {
         self.solver
     }
-    
+
     /// The gas used by the settlement.
     pub fn gas(&self) -> eth::Gas {
         self.gas
@@ -240,18 +240,21 @@ pub struct ExecutionEnded {
 #[cfg(test)]
 mod tests {
     use {
-        super::transaction::TransactionAuthenticator, crate::domain::{self, auction, eth}, hex_literal::hex, std::collections::{HashMap, HashSet}
+        super::transaction::TransactionAuthenticator,
+        crate::domain::{self, auction, eth},
+        hex_literal::hex,
+        std::collections::{HashMap, HashSet},
     };
 
     #[derive(Clone)]
     struct MockAuthenticator;
-    
+
     #[async_trait::async_trait]
     impl TransactionAuthenticator for MockAuthenticator {
         async fn is_solver(
             &self,
             _prospective_solver: ethcontract::Address,
-        ) -> Result<bool, super::transaction::Error>  {
+        ) -> Result<bool, super::transaction::Error> {
             return Ok(true);
         }
     }
@@ -484,7 +487,8 @@ mod tests {
             settlement_contract,
             &MockAuthenticator {},
         )
-        .await.unwrap_err();
+        .await
+        .unwrap_err();
 
         // These transfer transactions don't have the auction_id attached so overall bad
         // calldata is expected

--- a/crates/autopilot/src/domain/settlement/mod.rs
+++ b/crates/autopilot/src/domain/settlement/mod.rs
@@ -32,7 +32,7 @@ pub struct Settlement {
     gas_price: eth::EffectiveGasPrice,
     /// The block number of the block that contains the settlement transaction.
     block: eth::BlockNo,
-    /// The solver (submission address)
+    /// The solver (is different from `tx.from` for smart contract solvers)
     solver: eth::Address,
     /// The associated auction.
     auction: Auction,
@@ -41,7 +41,6 @@ pub struct Settlement {
 }
 
 impl Settlement {
-    /// The solver (submission address)
     pub fn solver(&self) -> eth::Address {
         self.solver
     }
@@ -240,7 +239,6 @@ pub struct ExecutionEnded {
 #[cfg(test)]
 mod tests {
     use {
-        super::transaction::TransactionAuthenticator,
         crate::domain::{self, auction, eth},
         hex_literal::hex,
         std::collections::{HashMap, HashSet},
@@ -250,10 +248,10 @@ mod tests {
     struct MockAuthenticator;
 
     #[async_trait::async_trait]
-    impl TransactionAuthenticator for MockAuthenticator {
+    impl super::transaction::Authenticator for MockAuthenticator {
         async fn is_solver(
             &self,
-            _prospective_solver: ethcontract::Address,
+            _prospective_solver: eth::Address,
         ) -> Result<bool, super::transaction::Error> {
             return Ok(true);
         }
@@ -485,7 +483,7 @@ mod tests {
             },
             &domain_separator,
             settlement_contract,
-            &MockAuthenticator {},
+            &MockAuthenticator,
         )
         .await
         .unwrap_err();
@@ -594,7 +592,7 @@ mod tests {
             },
             &domain_separator,
             settlement_contract,
-            &MockAuthenticator {},
+            &MockAuthenticator,
         )
         .await
         .unwrap();
@@ -740,7 +738,7 @@ mod tests {
             },
             &domain_separator,
             settlement_contract,
-            &MockAuthenticator {},
+            &MockAuthenticator,
         )
         .await
         .unwrap();
@@ -918,7 +916,7 @@ mod tests {
             },
             &domain_separator,
             settlement_contract,
-            &MockAuthenticator {},
+            &MockAuthenticator,
         )
         .await
         .unwrap();
@@ -1102,7 +1100,7 @@ mod tests {
             },
             &domain_separator,
             settlement_contract,
-            &MockAuthenticator {},
+            &MockAuthenticator,
         )
         .await
         .unwrap();

--- a/crates/autopilot/src/domain/settlement/mod.rs
+++ b/crates/autopilot/src/domain/settlement/mod.rs
@@ -249,7 +249,7 @@ mod tests {
 
     #[async_trait::async_trait]
     impl super::transaction::Authenticator for MockAuthenticator {
-        async fn is_solver(
+        async fn is_valid_solver(
             &self,
             _prospective_solver: eth::Address,
         ) -> Result<bool, super::transaction::Error> {

--- a/crates/autopilot/src/domain/settlement/mod.rs
+++ b/crates/autopilot/src/domain/settlement/mod.rs
@@ -240,6 +240,7 @@ pub struct ExecutionEnded {
 mod tests {
     use {
         crate::domain::{self, auction, eth},
+        ethcontract::BlockId,
         hex_literal::hex,
         std::collections::{HashMap, HashSet},
     };
@@ -252,6 +253,7 @@ mod tests {
         async fn is_valid_solver(
             &self,
             _prospective_solver: eth::Address,
+            _block: BlockId,
         ) -> Result<bool, super::transaction::Error> {
             return Ok(true);
         }

--- a/crates/autopilot/src/domain/settlement/mod.rs
+++ b/crates/autopilot/src/domain/settlement/mod.rs
@@ -240,7 +240,7 @@ pub struct ExecutionEnded {
 #[cfg(test)]
 mod tests {
     use {
-        super::transaction::TransactionAuthenticator, crate::domain::{self, auction, eth}, contracts::GPv2AllowListAuthentication, ethcontract::{contract::Deploy, Account, BlockNumber, TransactionCondition}, ethrpc::mock::{self, MockTransport}, hex_literal::hex, itertools::any, mockall::predicate::{always, eq}, serde_json::json, std::collections::{HashMap, HashSet}, web3::types::{CallRequest, U64}
+        super::transaction::TransactionAuthenticator, crate::domain::{self, auction, eth}, hex_literal::hex, std::collections::{HashMap, HashSet}
     };
 
     #[derive(Clone)]

--- a/crates/autopilot/src/domain/settlement/observer.rs
+++ b/crates/autopilot/src/domain/settlement/observer.rs
@@ -12,7 +12,7 @@
 
 use {
     crate::{
-        domain::settlement::{self, transaction::ContractAuthenticator},
+        domain::settlement::{self},
         infra,
     },
     anyhow::{Result, anyhow},
@@ -22,19 +22,13 @@ use {
 pub struct Observer {
     eth: infra::Ethereum,
     persistence: infra::Persistence,
-    authenticator: ContractAuthenticator,
 }
 
 impl Observer {
     /// Creates a new Observer and asynchronously schedules the first update
     /// run.
     pub fn new(eth: infra::Ethereum, persistence: infra::Persistence) -> Self {
-        let authenticator = ContractAuthenticator(eth.contracts().authenticator().clone());
-        Self {
-            eth,
-            persistence,
-            authenticator,
-        }
+        Self { eth, persistence }
     }
 
     /// Fetches all the available missing data needed for bookkeeping.
@@ -80,7 +74,7 @@ impl Observer {
                     &transaction,
                     separator,
                     settlement_contract,
-                    &self.authenticator,
+                    self.eth.contracts().authenticator(),
                 )
                 .await
             }

--- a/crates/autopilot/src/domain/settlement/observer.rs
+++ b/crates/autopilot/src/domain/settlement/observer.rs
@@ -11,8 +11,11 @@
 // used etc.
 
 use {
-    crate::{domain::settlement::{self, transaction::ContractTransactionAuthenticator}, infra},
-    anyhow::{anyhow, Result},
+    crate::{
+        domain::settlement::{self, transaction::ContractTransactionAuthenticator},
+        infra,
+    },
+    anyhow::{Result, anyhow},
 };
 
 #[derive(Clone)]
@@ -67,8 +70,15 @@ impl Observer {
             Ok(transaction) => {
                 let separator = self.eth.contracts().settlement_domain_separator();
                 let settlement_contract = self.eth.contracts().settlement().address().into();
-                let authenticator = ContractTransactionAuthenticator(self.eth.contracts().authenticator().clone());
-                settlement::Transaction::try_new(&transaction, separator, settlement_contract, &authenticator).await
+                let authenticator =
+                    ContractTransactionAuthenticator(self.eth.contracts().authenticator().clone());
+                settlement::Transaction::try_new(
+                    &transaction,
+                    separator,
+                    settlement_contract,
+                    &authenticator,
+                )
+                .await
             }
             Err(err) => {
                 tracing::warn!(hash = ?event.transaction, ?err, "no tx found");

--- a/crates/autopilot/src/domain/settlement/observer.rs
+++ b/crates/autopilot/src/domain/settlement/observer.rs
@@ -12,7 +12,7 @@
 
 use {
     crate::{
-        domain::settlement::{self, transaction::ContractTransactionAuthenticator},
+        domain::settlement::{self, transaction::ContractAuthenticator},
         infra,
     },
     anyhow::{Result, anyhow},
@@ -22,15 +22,14 @@ use {
 pub struct Observer {
     eth: infra::Ethereum,
     persistence: infra::Persistence,
-    authenticator: ContractTransactionAuthenticator,
+    authenticator: ContractAuthenticator,
 }
 
 impl Observer {
     /// Creates a new Observer and asynchronously schedules the first update
     /// run.
     pub fn new(eth: infra::Ethereum, persistence: infra::Persistence) -> Self {
-        let authenticator =
-            ContractTransactionAuthenticator(eth.contracts().authenticator().clone());
+        let authenticator = ContractAuthenticator(eth.contracts().authenticator().clone());
         Self {
             eth,
             persistence,

--- a/crates/autopilot/src/domain/settlement/observer.rs
+++ b/crates/autopilot/src/domain/settlement/observer.rs
@@ -11,8 +11,8 @@
 // used etc.
 
 use {
-    crate::{domain::settlement, infra},
-    anyhow::{Result, anyhow},
+    crate::{domain::settlement::{self, transaction::ContractTransactionAuthenticator}, infra},
+    anyhow::{anyhow, Result},
 };
 
 #[derive(Clone)]
@@ -67,8 +67,8 @@ impl Observer {
             Ok(transaction) => {
                 let separator = self.eth.contracts().settlement_domain_separator();
                 let settlement_contract = self.eth.contracts().settlement().address().into();
-                let authenticator = self.eth.contracts().authenticator();
-                settlement::Transaction::try_new(&transaction, separator, settlement_contract, authenticator).await
+                let authenticator = ContractTransactionAuthenticator(self.eth.contracts().authenticator().clone());
+                settlement::Transaction::try_new(&transaction, separator, settlement_contract, &authenticator).await
             }
             Err(err) => {
                 tracing::warn!(hash = ?event.transaction, ?err, "no tx found");

--- a/crates/autopilot/src/domain/settlement/transaction/mod.rs
+++ b/crates/autopilot/src/domain/settlement/transaction/mod.rs
@@ -14,18 +14,13 @@ mod tokenized;
 #[async_trait::async_trait]
 pub trait Authenticator {
     /// Determines whether the provided address is an authenticated solver.
-    async fn is_solver(&self, prospective_solver: eth::Address) -> Result<bool, Error>;
+    async fn is_valid_solver(&self, prospective_solver: eth::Address) -> Result<bool, Error>;
 }
 
-/// Solver authentication using a `GPv2AllowListAuthentication` smart contract
-#[derive(Clone)]
-pub struct ContractAuthenticator(pub contracts::GPv2AllowListAuthentication);
-
 #[async_trait::async_trait]
-impl Authenticator for ContractAuthenticator {
-    async fn is_solver(&self, prospective_solver: eth::Address) -> Result<bool, Error> {
+impl Authenticator for contracts::GPv2AllowListAuthentication {
+    async fn is_valid_solver(&self, prospective_solver: eth::Address) -> Result<bool, Error> {
         Ok(self
-            .0
             .is_solver(prospective_solver.into())
             .call()
             .await
@@ -74,7 +69,7 @@ impl Transaction {
         // submit solutions, the address is deducted from the calldata.
         let mut solver = None;
         for call in path {
-            if authenticator.is_solver(call.from).await? {
+            if authenticator.is_valid_solver(call.from).await? {
                 solver = Some(call.from);
                 break;
             }

--- a/crates/autopilot/src/domain/settlement/transaction/mod.rs
+++ b/crates/autopilot/src/domain/settlement/transaction/mod.rs
@@ -12,21 +12,21 @@ mod tokenized;
 /// The following trait allows to implement custom solver authentication logic
 /// for transactions.
 #[async_trait::async_trait]
-pub trait TransactionAuthenticator {
+pub trait Authenticator {
     /// Determines whether the provided address is an authenticated solver.
-    async fn is_solver(&self, prospective_solver: ethcontract::Address) -> Result<bool, Error>;
+    async fn is_solver(&self, prospective_solver: eth::Address) -> Result<bool, Error>;
 }
 
 /// Solver authentication using a `GPv2AllowListAuthentication` smart contract
 #[derive(Clone)]
-pub struct ContractTransactionAuthenticator(pub contracts::GPv2AllowListAuthentication);
+pub struct ContractAuthenticator(pub contracts::GPv2AllowListAuthentication);
 
 #[async_trait::async_trait]
-impl TransactionAuthenticator for ContractTransactionAuthenticator {
-    async fn is_solver(&self, prospective_solver: ethcontract::Address) -> Result<bool, Error> {
+impl Authenticator for ContractAuthenticator {
+    async fn is_solver(&self, prospective_solver: eth::Address) -> Result<bool, Error> {
         Ok(self
             .0
-            .is_solver(prospective_solver)
+            .is_solver(prospective_solver.into())
             .call()
             .await
             .map_err(Error::Authentication)?)
@@ -55,7 +55,7 @@ pub struct Transaction {
 }
 
 impl Transaction {
-    pub async fn try_new<T: TransactionAuthenticator + Clone>(
+    pub async fn try_new<T: Authenticator + Clone>(
         transaction: &eth::Transaction,
         domain_separator: &eth::DomainSeparator,
         settlement_contract: eth::Address,
@@ -74,7 +74,7 @@ impl Transaction {
         // submit solutions, the address is deducted from the calldata.
         let mut solver = None;
         for call in path {
-            if authenticator.is_solver(call.from.into()).await? {
+            if authenticator.is_solver(call.from).await? {
                 solver = Some(call.from);
                 break;
             }

--- a/crates/autopilot/src/domain/settlement/transaction/mod.rs
+++ b/crates/autopilot/src/domain/settlement/transaction/mod.rs
@@ -9,27 +9,23 @@ use {
 
 mod tokenized;
 
-/// The following trait allows to implement custom solver authentication logic for transactions.
+/// The following trait allows to implement custom solver authentication logic
+/// for transactions.
 #[async_trait::async_trait]
 pub trait TransactionAuthenticator {
     /// Determines whether the provided address is an authenticated solver.
-    async fn is_solver(
-        &self,
-        prospective_solver: ethcontract::Address,
-    ) -> Result<bool, Error>;
+    async fn is_solver(&self, prospective_solver: ethcontract::Address) -> Result<bool, Error>;
 }
 
-/// Solver authentication using a `GPv2AllowListAuthentication` smart contract 
+/// Solver authentication using a `GPv2AllowListAuthentication` smart contract
 #[derive(Clone)]
 pub struct ContractTransactionAuthenticator(pub contracts::GPv2AllowListAuthentication);
 
 #[async_trait::async_trait]
 impl TransactionAuthenticator for ContractTransactionAuthenticator {
-    async fn is_solver(
-        &self,
-        prospective_solver: ethcontract::Address,
-    ) -> Result<bool, Error> {
-        Ok(self.0
+    async fn is_solver(&self, prospective_solver: ethcontract::Address) -> Result<bool, Error> {
+        Ok(self
+            .0
             .is_solver(prospective_solver)
             .call()
             .await
@@ -78,10 +74,7 @@ impl Transaction {
         // submit solutions, the address is deducted from the calldata.
         let mut solver = None;
         for call in path {
-            if authenticator
-                .is_solver(call.from.into())
-                .await?
-            {
+            if authenticator.is_solver(call.from.into()).await? {
                 solver = Some(call.from);
                 break;
             }

--- a/crates/autopilot/src/domain/settlement/transaction/mod.rs
+++ b/crates/autopilot/src/domain/settlement/transaction/mod.rs
@@ -24,21 +24,42 @@ pub struct Transaction {
     pub gas: eth::Gas,
     /// The effective gas price of the transaction.
     pub gas_price: eth::EffectiveGasPrice,
+    /// The solver (submission address)
+    pub solver: eth::Address,
     /// Encoded trades that were settled by the transaction.
     pub trades: Vec<EncodedTrade>,
 }
 
 impl Transaction {
-    pub fn try_new(
+    pub async fn try_new(
         transaction: &eth::Transaction,
         domain_separator: &eth::DomainSeparator,
         settlement_contract: eth::Address,
+        authenticator: &contracts::GPv2AllowListAuthentication,
     ) -> Result<Self, Error> {
-        // find trace call to settlement contract
-        let calldata = find_settlement_trace(&transaction.trace_calls, settlement_contract).map(|trace| trace.input.clone())
-            // all transactions emitting settlement events should have a /settle call, 
+        // Find trace call to settlement contract
+        let (calldata, path) = find_settlement_trace_and_path(&transaction.trace_calls, settlement_contract)
+            .map(|(trace, path)| (trace.input.clone(), path.clone()))
+            // All transactions emitting settlement events should have a /settle call, 
             // otherwise it's an execution client bug
             .ok_or(Error::MissingCalldata)?;
+
+        // Find solver (submission address)
+        // In cases of solvers using EOA to submit solutions, the address is the sender
+        // of the transaction. In cases of solvers using a smart contract to
+        // submit solutions, the address is deducted from the calldata.
+        let mut solver = None;
+        for call in path {
+            if authenticator
+                .is_solver(call.from.into())
+                .call()
+                .await
+                .map_err(Error::Authentication)?
+            {
+                solver = Some(call.from);
+                break;
+            }
+        }
 
         /// Number of bytes that may be appended to the calldata to store an
         /// auction id.
@@ -63,6 +84,7 @@ impl Transaction {
             timestamp: transaction.timestamp,
             gas: transaction.gas,
             gas_price: transaction.gas_price,
+            solver: solver.ok_or(Error::MissingSolver)?,
             trades: {
                 let tokenized::Tokenized {
                     tokens,
@@ -128,20 +150,24 @@ impl Transaction {
     }
 }
 
-fn find_settlement_trace(
+fn find_settlement_trace_and_path(
     call_frame: &eth::CallFrame,
     settlement_contract: eth::Address,
-) -> Option<&eth::CallFrame> {
+) -> Option<(&eth::CallFrame, Vec<&eth::CallFrame>)> {
     // Use a queue (VecDeque) to keep track of frames to process
     let mut queue = std::collections::VecDeque::new();
-    queue.push_back(call_frame);
+    queue.push_back((call_frame, vec![call_frame]));
 
-    while let Some(call_frame) = queue.pop_front() {
+    while let Some((call_frame, path_so_far)) = queue.pop_front() {
         if is_settlement_trace(call_frame, settlement_contract) {
-            return Some(call_frame);
+            return Some((call_frame, path_so_far));
         }
-        // Add all nested calls to the queue
-        queue.extend(&call_frame.calls);
+        // Add all nested calls to the queue with the updated path
+        for sub_call in &call_frame.calls {
+            let mut new_path = path_so_far.clone();
+            new_path.push(sub_call);
+            queue.push_back((sub_call, new_path));
+        }
     }
 
     None
@@ -194,6 +220,8 @@ pub struct ClearingPrices {
 pub enum Error {
     #[error("settle calldata must exist for all transactions emitting settlement event")]
     MissingCalldata,
+    #[error("solver address must be deductible from calldata")]
+    MissingSolver,
     #[error("missing auction id")]
     MissingAuctionId,
     #[error(transparent)]
@@ -202,4 +230,6 @@ pub enum Error {
     OrderUidRecover(tokenized::error::Uid),
     #[error("failed to recover signature {0}")]
     SignatureRecover(#[source] anyhow::Error),
+    #[error("failed to check authentication {0}")]
+    Authentication(#[source] ethcontract::errors::MethodError),
 }

--- a/crates/autopilot/src/infra/blockchain/mod.rs
+++ b/crates/autopilot/src/infra/blockchain/mod.rs
@@ -165,6 +165,7 @@ fn into_domain(
 impl From<ethrpc::extensions::CallFrame> for eth::CallFrame {
     fn from(frame: ethrpc::extensions::CallFrame) -> Self {
         eth::CallFrame {
+            from: frame.from.into(),
             to: frame.to.map(Into::into),
             input: frame.input.0.into(),
             calls: frame.calls.into_iter().map(Into::into).collect(),

--- a/crates/autopilot/src/infra/persistence/mod.rs
+++ b/crates/autopilot/src/infra/persistence/mod.rs
@@ -666,10 +666,12 @@ impl Persistence {
             let fee = settlement.fee_in_ether();
             let fee_breakdown = settlement.fee_breakdown();
             let jit_orders = settlement.jit_orders();
+            let solver: database::Address = ByteArray(settlement.solver().0.0);
 
             tracing::debug!(
                 ?auction_id,
                 hash = ?event.transaction,
+                ?solver,
                 ?gas,
                 ?gas_price,
                 ?surplus,
@@ -678,6 +680,14 @@ impl Persistence {
                 ?jit_orders,
                 "settlement update",
             );
+
+            database::settlements::update_settlement_solver(
+                &mut ex,
+                block_number,
+                log_index,
+                solver,
+            )
+            .await?;
 
             database::settlement_observations::upsert(
                 &mut ex,

--- a/crates/database/src/settlements.rs
+++ b/crates/database/src/settlements.rs
@@ -61,6 +61,26 @@ WHERE block_number = $2 AND log_index = $3
         .map(|_| ())
 }
 
+pub async fn update_settlement_solver(
+    ex: &mut PgConnection,
+    block_number: i64,
+    log_index: i64,
+    solver: Address,
+) -> Result<(), sqlx::Error> {
+    const QUERY: &str = r#"
+UPDATE settlements
+SET solver = $1
+WHERE block_number = $2 AND log_index = $3
+    ;"#;
+    sqlx::query(QUERY)
+        .bind(solver)
+        .bind(block_number)
+        .bind(log_index)
+        .execute(ex)
+        .await
+        .map(|_| ())
+}
+
 /// Deletes all database data that referenced the deleted settlement events.
 pub async fn delete(
     ex: &mut PgTransaction<'_>,

--- a/crates/e2e/tests/e2e/flashloans.rs
+++ b/crates/e2e/tests/e2e/flashloans.rs
@@ -1,14 +1,30 @@
 use {
-    contracts::{IAavePool, ERC20}, database::Address, e2e::{
+    contracts::{ERC20, IAavePool},
+    database::Address,
+    e2e::{
         nodes::forked_node::ForkedNodeApi,
         setup::{
-            run_forked_test_with_block_number, safe::Safe, to_wei, to_wei_with_exp, wait_for_condition, Db, OnchainComponents, Services, TIMEOUT
+            Db,
+            OnchainComponents,
+            Services,
+            TIMEOUT,
+            run_forked_test_with_block_number,
+            safe::Safe,
+            to_wei,
+            to_wei_with_exp,
+            wait_for_condition,
         },
         tx,
-    }, ethcontract::{H160, U256}, ethrpc::Web3, model::{
+    },
+    ethcontract::{H160, U256},
+    ethrpc::Web3,
+    model::{
         order::{OrderCreation, OrderCreationAppData, OrderKind},
-        signature::{hashed_eip712_message, Signature},
-    }, shared::{addr, conversions::U256Ext}, sqlx::Row, std::time::Duration
+        signature::{Signature, hashed_eip712_message},
+    },
+    shared::{addr, conversions::U256Ext},
+    sqlx::Row,
+    std::time::Duration,
 };
 
 #[tokio::test]
@@ -271,7 +287,8 @@ async fn forked_mainnet_repay_debt_with_collateral_of_safe(web3: Web3) {
         onchain.mint_block().await;
         let last_solver = fetch_last_settled_auction_solver(pool).await;
         if let Some(last_solver_address) = last_solver {
-            let last_solver_eth_address = autopilot::domain::eth::Address(last_solver_address.0.into());
+            let last_solver_eth_address =
+                autopilot::domain::eth::Address(last_solver_address.0.into());
             return last_solver_eth_address == solver_address;
         }
 

--- a/crates/e2e/tests/e2e/flashloans.rs
+++ b/crates/e2e/tests/e2e/flashloans.rs
@@ -282,17 +282,9 @@ async fn forked_mainnet_repay_debt_with_collateral_of_safe(web3: Web3) {
 
     // Check that the solver address is stored in the settlement table
     let pool = services.db();
-    let solver_address = autopilot::domain::eth::Address(solver.address());
     let settler_is_solver = || async {
-        onchain.mint_block().await;
         let last_solver = fetch_last_settled_auction_solver(pool).await;
-        if let Some(last_solver_address) = last_solver {
-            let last_solver_eth_address =
-                autopilot::domain::eth::Address(last_solver_address.0.into());
-            return last_solver_eth_address == solver_address;
-        }
-
-        false
+        last_solver.is_some_and(|address| address.0 == solver.address().0)
     };
     wait_for_condition(TIMEOUT, settler_is_solver)
         .await

--- a/crates/e2e/tests/e2e/flashloans.rs
+++ b/crates/e2e/tests/e2e/flashloans.rs
@@ -1,5 +1,5 @@
 use {
-    autopilot::domain::eth, contracts::{IAavePool, ERC20}, database::{byte_array::ByteArray, Address}, e2e::{
+    contracts::{IAavePool, ERC20}, database::Address, e2e::{
         nodes::forked_node::ForkedNodeApi,
         setup::{
             run_forked_test_with_block_number, safe::Safe, to_wei, to_wei_with_exp, wait_for_condition, Db, OnchainComponents, Services, TIMEOUT

--- a/crates/e2e/tests/e2e/flashloans.rs
+++ b/crates/e2e/tests/e2e/flashloans.rs
@@ -302,8 +302,5 @@ async fn fetch_last_settled_auction_solver(pool: &Db) -> Option<Address> {
         .await
         .unwrap()
         .first()
-        .map(|row| {
-            let solver: Address = row.try_get(0).unwrap();
-            solver
-        })
+        .map(|row| row.try_get(0).unwrap())
 }

--- a/crates/ethrpc/src/extensions.rs
+++ b/crates/ethrpc/src/extensions.rs
@@ -124,6 +124,8 @@ impl<T: Transport> Debug<T> {
 /// Taken from alloy::rpc::types::trace::geth::CallFrame
 #[derive(Clone, Debug, Default, PartialEq, Eq, Deserialize)]
 pub struct CallFrame {
+    /// The address of that initiated the call.
+    pub from: primitive_types::H160,
     /// The address of the contract that was called.
     #[serde(default)]
     pub to: Option<primitive_types::H160>,


### PR DESCRIPTION
# Description
After a flash loan is settled, the solver address stored in database (`settlements` table) is actually the flash loan router address instead of the solver submission address.

This PR fixes it by analyzing the callstack to determine which address is actually a solver:
- We start from `tx.from` and go down to the `settle()` call.
- For each caller address we check if it corresponds to a solver (by calling `GPv2AllowListAuthentication.is_solver`).
- The actual solver that triggered the transaction will be the first authenticated address in that chain.

Then, when the Observer indexes a settlement transaction, the found address is used to overwrite the `settlement::solver` column.

# Changes
Changes affect the `autopilot` crate:
- Created a `TransactionAuthenticator` trait to decouple the solver authentication logic (and allow easier mocking in existing unit tests).
- On settlement transactions, we now fetch the `path` and find the first solver for each `call.from`. This is performed when the settlement observer updates.
- Updated `CallFrame` and `Settlement` definitions so they include the solver address.
- Added new error variants related to solver authentication.
- New database method `update_settlement_solver` called when saving a settlement.

## How to test
Updated the existing `forked_node_mainnet_repay_debt_with_collateral_of_safe` e2e test, to verify that the solver address is the expected one after settlement.

## Related Issues

Fixes https://github.com/cowprotocol/services/issues/3335