### PR TITLE
Refactor scores autopilot

### DIFF
--- a/crates/autopilot/src/domain/eth/mod.rs
+++ b/crates/autopilot/src/domain/eth/mod.rs
@@ -1,6 +1,6 @@
 pub use primitive_types::{H160, H256, U256};
 use {
-    crate::domain,
+    crate::{domain, util::conv::U256Ext},
     derive_more::{Display, From, Into},
 };
 
@@ -71,23 +71,15 @@ pub struct TokenAmount(pub U256);
 
 impl TokenAmount {
     /// Applies a factor to the token amount.
-    ///
-    /// The factor is first multiplied by 10^18 to convert it to integer, to
-    /// avoid rounding to 0. Then, the token amount is divided by 10^18 to
-    /// convert it back to the original scale.
-    ///
-    /// The higher the conversion factor (10^18) the precision is higher. E.g.
-    /// 0.123456789123456789 will be converted to 123456789123456789.
     pub fn apply_factor(&self, factor: f64) -> Option<Self> {
-        Some(
-            (self
-                .0
-                .checked_mul(U256::from_f64_lossy(factor * 1000000000000000000.))?
-                / 1000000000000000000u128)
-                .into(),
-        )
+        Some(self.0.checked_mul_f64(factor)?.into())
     }
 }
+
+/// A value denominated in an order's surplus token (buy token for
+/// sell orders and sell token for buy orders).
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, From, Into)]
+pub struct SurplusTokenAmount(pub U256);
 
 /// An ERC20 sell token amount.
 ///

--- a/crates/autopilot/src/domain/settlement/mod.rs
+++ b/crates/autopilot/src/domain/settlement/mod.rs
@@ -787,7 +787,7 @@ mod tests {
 
         assert_eq!(
             trade.score(&auction).unwrap().0,
-            eth::U256::from(769018961144624u128) // 2 x surplus
+            eth::U256::from(769018961144625u128) // 2 x surplus
         );
     }
 

--- a/crates/autopilot/src/domain/settlement/trade/math.rs
+++ b/crates/autopilot/src/domain/settlement/trade/math.rs
@@ -39,8 +39,8 @@ impl Trade {
     ///
     /// [CIP-38](https://forum.cow.fi/t/cip-38-solver-computed-fees-rank-by-surplus/2061>) as the
     /// base of the score computation.
-    /// [CIP-XX](TODO) as the latest revision to avoid edge cases for certain
-    /// buy orders.
+    /// [Draft CIP](https://forum.cow.fi/t/cip-draft-updating-score-definition-for-buy-orders/2930)
+    /// as the latest revision to avoid edge cases for certain buy orders.
     ///
     /// Denominated in NATIVE token
     pub fn score(&self, auction: &settlement::Auction) -> Result<eth::Ether, Error> {

--- a/crates/autopilot/src/domain/settlement/trade/mod.rs
+++ b/crates/autopilot/src/domain/settlement/trade/mod.rs
@@ -72,7 +72,13 @@ impl Trade {
         let trade = math::Trade::from(self);
         let total = trade.fee_in_sell_token()?;
         let protocol = trade.protocol_fees(auction)?;
-        Ok(FeeBreakdown { total, protocol })
+        Ok(FeeBreakdown {
+            total: eth::Asset {
+                token: self.sell_token(),
+                amount: total.into(),
+            },
+            protocol,
+        })
     }
 
     pub fn sell_token(&self) -> eth::TokenAddress {

--- a/crates/autopilot/src/util/conv.rs
+++ b/crates/autopilot/src/util/conv.rs
@@ -2,11 +2,28 @@ use crate::domain::eth;
 
 pub trait U256Ext: Sized {
     fn checked_ceil_div(&self, other: &Self) -> Option<Self>;
+    fn checked_mul_f64(&self, factor: f64) -> Option<Self>;
 }
 
 impl U256Ext for eth::U256 {
     fn checked_ceil_div(&self, other: &Self) -> Option<Self> {
         self.checked_add(other.checked_sub(1.into())?)?
             .checked_div(*other)
+    }
+
+    fn checked_mul_f64(&self, factor: f64) -> Option<Self> {
+        // `factor` is first multiplied by the conversion factor to convert
+        // it to integer, to avoid rounding to 0. Then, the result is divided
+        // by the conversion factor to convert it back to the original scale.
+        //
+        // The higher the conversion factor (10^18) the precision is higher. E.g.
+        // 0.123456789123456789 will be converted to 123456789123456789.
+        // TODO: consider doing the computation with `BigRational` instead but
+        // that requires to double check and adjust a few tests due to tiny
+        // changes in rounding.
+        const CONVERSION_FACTOR: f64 = 1_000_000_000_000_000_000.;
+        let multiplied = self.checked_mul(Self::from_f64_lossy(factor * CONVERSION_FACTOR))?
+            / Self::from_f64_lossy(CONVERSION_FACTOR);
+        Some(multiplied)
     }
 }


### PR DESCRIPTION
# Description
Follow up to #3340
Implements the same refactor to the fee and score computation but in the autopilot. Note that we currently don't make use of the `score()` function in the autopilot (except in tests) so we can immediately switch to the new scores for buy orders without worrying about breaking compatibility.

# Changes
- implements new buy order score login in the autopilot
- refactors fee and score computation in autopilot to use `eth::SurplusTokenAmount` instead of `eth::Asset` wherever possible

## How to test
existing tests based on actual historic auctions still pass
I just needed to adjust 1 test case since the new logic is slightly more accurate. Instead of `to_eth(user_surplus) + to_eth(fees)` we now do `to_eth(user_surplus + fees)` which does one fewer conversions, avoiding the loss of precision of the associated divisions.