### PR TITLE
Fix flaky e2e test

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -199,6 +199,8 @@ jobs:
       CARGO_PROFILE_TEST_DEBUG: 0
       CARGO_TERM_COLOR: always
       TOML_TRACE_ERROR: 1
+      FORK_URL_MAINNET: ${{ secrets.FORK_URL_MAINNET }}
+      FORK_URL_GNOSIS: ${{ secrets.FORK_URL_GNOSIS }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -219,7 +221,7 @@ jobs:
           attempt=1
           while true; do
             echo "Running test attempt #$attempt"
-            if ! cargo nextest run -p e2e local_node --test-threads 1 --failure-output final --run-ignored ignored-only; then
+            if ! cargo nextest run -p e2e forked_node_mainnet_repay_debt_with_collateral_of_safe --test-threads 1 --failure-output final --run-ignored ignored-only; then
               exit 1
             fi
             attempt=$((attempt+1))

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -190,7 +190,7 @@ jobs:
 
   run-flaky-test:
     # to debug a flaky test set `if` to true and configure the flaky test in the `run` step
-    if: ${{ false }}
+    if: ${{ true }}
     timeout-minutes: 60
     runs-on: ubuntu-latest
     env:

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -190,7 +190,7 @@ jobs:
 
   run-flaky-test:
     # to debug a flaky test set `if` to true and configure the flaky test in the `run` step
-    if: ${{ true }}
+    if: ${{ false }}
     timeout-minutes: 60
     runs-on: ubuntu-latest
     env:

--- a/crates/autopilot/src/domain/settlement/transaction/mod.rs
+++ b/crates/autopilot/src/domain/settlement/transaction/mod.rs
@@ -210,22 +210,12 @@ async fn find_solver_address(
     callers: Vec<eth::Address>,
     block: BlockId,
 ) -> Result<Option<eth::Address>, Error> {
-    let valid_solvers: Vec<Option<eth::Address>> =
-        // The RPC calls to check each address can be done in parallel as they are cheap
-        futures::future::join_all(callers.into_iter().map(|caller| async move {
-            match authenticator.is_valid_solver(caller, block).await {
-                Ok(true) => Ok(Some(caller)),
-                Ok(false) => Ok(None),
-                Err(e) => Err(e),
-            }
-        }))
-        .await
-        .into_iter()
-        .collect::<Result<_, _>>()?;
-
-    // The actual solver that triggered the transaction will be the first
-    // authenticated address in the call stack
-    Ok(valid_solvers.into_iter().flatten().next())
+    for caller in &callers {
+        if authenticator.is_valid_solver(caller.0.into(), block).await? {
+            return Ok(Some(*caller));
+        }
+    }
+    Ok(None)
 }
 
 /// Trade containing onchain observable data specific to a settlement

--- a/crates/e2e/tests/e2e/flashloans.rs
+++ b/crates/e2e/tests/e2e/flashloans.rs
@@ -251,12 +251,10 @@ async fn forked_mainnet_repay_debt_with_collateral_of_safe(web3: Web3) {
     let uid = services.create_order(&order).await.unwrap();
     tracing::info!(?uid, "placed order");
 
-    // mine a block to kick off an auction
-    onchain.mint_block().await;
-
     // Drive solution
     tracing::info!("Waiting for trade to get indexed.");
     wait_for_condition(TIMEOUT, || async {
+        onchain.mint_block().await;
         let executed_fee = services
             .get_order(&uid)
             .await

--- a/crates/e2e/tests/e2e/flashloans.rs
+++ b/crates/e2e/tests/e2e/flashloans.rs
@@ -251,10 +251,12 @@ async fn forked_mainnet_repay_debt_with_collateral_of_safe(web3: Web3) {
     let uid = services.create_order(&order).await.unwrap();
     tracing::info!(?uid, "placed order");
 
+    // mine a block to kick off an auction
+    onchain.mint_block().await;
+
     // Drive solution
     tracing::info!("Waiting for trade to get indexed.");
     wait_for_condition(TIMEOUT, || async {
-        onchain.mint_block().await;
         let executed_fee = services
             .get_order(&uid)
             .await


### PR DESCRIPTION
# Description
https://github.com/cowprotocol/services/pull/3342 seems to have made the flashloan test flaky. After some investigation it seems to me that the test might trigger a bug in anvil. I enabled anvils logs together with our e2e logs and it seems like anvil stops doing anything if a new block gets mined while it's handing a batch call.
```
2025-04-02T13:58:02.102Z ERROR address{address=[0x9008d19f58aabd9ed0d60971565aa8510560ab41]}: autopilot::domain::settlement::transaction: before indexing solver callers=[Address(0x7e5f4552091a69125d5dfcb7b8c2659029395bdf), Address(0xef66010868ff77119171628b7efa0f6179779375), Address(0xd544d7a5ef50c510f3e90863828eaba7e392907a), Address(0x87870bca3f3fd6335c3f4ce8392d69350b4fa4e2), Address(0x87870bca3f3fd6335c3f4ce8392d69350b4fa4e2), Address(0x87870bca3f3fd6335c3f4ce8392d69350b4fa4e2), Address(0xd544d7a5ef50c510f3e90863828eaba7e392907a), Address(0xef66010868ff77119171628b7efa0f6179779375)] len=8 unique=4
2025-04-02T13:58:02.104Z ERROR ethrpc::buffered: start batch call
2025-04-02T13:58:02.105Z  WARN e2e::nodes: line="2025-04-02T13:58:02.104594Z TRACE backend: get block by number 0x14dc5ef"
2025-04-02T13:58:02.105Z  WARN e2e::nodes: line="2025-04-02T13:58:02.104660Z TRACE backend: get block by number 0x14dc5ef"
2025-04-02T13:58:02.105Z  WARN e2e::nodes: line="2025-04-02T13:58:02.104660Z TRACE backend: get block by number 0x14dc5ef"
2025-04-02T13:58:02.105Z  WARN e2e::nodes: line="2025-04-02T13:58:02.104728Z TRACE backend: get block by number 0x14dc5ef"
2025-04-02T13:58:02.106Z  WARN e2e::nodes: line="2025-04-02T13:58:02.104760Z TRACE backend: get block by number 0x14dc5ef"
2025-04-02T13:58:02.106Z  WARN e2e::nodes: line="2025-04-02T13:58:02.104810Z TRACE backend: get block by number 0x14dc5ef"
2025-04-02T13:58:02.106Z  WARN e2e::nodes: line="2025-04-02T13:58:02.104959Z TRACE backend: get block by number 0x14dc5ef"
2025-04-02T13:58:02.106Z  WARN e2e::nodes: line="2025-04-02T13:58:02.104967Z TRACE backend: call return Return out: Some(Call(0x0000000000000000000000000000000000000000000000000000000000000001)) gas 28797 on block 21874159"
2025-04-02T13:58:02.106Z  WARN e2e::nodes: line="2025-04-02T13:58:02.104976Z TRACE backend: get block by number 0x14dc5ef"
2025-04-02T13:58:02.107Z  WARN e2e::nodes: line="2025-04-02T13:58:02.105065Z TRACE backendhandler: preparing storage request address=0x2c4c28DDBdAc9C5E7055b4C863b72eA0149D8aFE idx=18327229692755639534247341830219189238677050021245597243246588273308044878206"
2025-04-02T13:58:02.207Z  INFO e2e::setup::onchain_components: mining block
2025-04-02T13:58:02.208Z  WARN e2e::nodes: line="2025-04-02T13:58:02.207674Z TRACE backend: creating new block with 0 transactions"
... no further logs from anvil
```

# Changes
I changed the code back to serially checking the callers which resulted in a stable test.
Ideally we'd still check in parallel but atleast for the foreseeable future we'll always find an authenticated address in the first 2 callers.

## How to test
Used the flaky test runner GH action which resulted in tons of [runs](here](https://github.com/cowprotocol/services/actions/runs/14222811497/job/39854866509)) without any issues.