### PR TITLE
autopilot: Add solve deadline to the S3 auction

### DIFF
--- a/crates/autopilot/src/domain/auction/mod.rs
+++ b/crates/autopilot/src/domain/auction/mod.rs
@@ -1,5 +1,6 @@
 use {
     super::{Order, eth},
+    chrono::{DateTime, Utc},
     std::collections::HashMap,
 };
 
@@ -27,6 +28,7 @@ pub struct Auction {
     pub orders: Vec<Order>,
     pub prices: Prices,
     pub surplus_capturing_jit_order_owners: Vec<eth::Address>,
+    pub deadline: DateTime<Utc>,
 }
 
 impl PartialEq for Auction {

--- a/crates/autopilot/src/infra/persistence/dto/auction.rs
+++ b/crates/autopilot/src/infra/persistence/dto/auction.rs
@@ -4,6 +4,7 @@ use {
         domain,
         domain::{auction::Price, eth},
     },
+    chrono::{DateTime, Utc},
     number::serialization::HexOrDecimalU256,
     primitive_types::{H160, U256},
     serde::{Deserialize, Serialize},
@@ -11,7 +12,7 @@ use {
     std::collections::BTreeMap,
 };
 
-pub fn from_domain(auction: domain::RawAuctionData) -> RawAuctionData {
+pub fn from_domain(auction: domain::RawAuctionData, deadline: DateTime<Utc>) -> RawAuctionData {
     RawAuctionData {
         block: auction.block,
         orders: auction
@@ -29,6 +30,7 @@ pub fn from_domain(auction: domain::RawAuctionData) -> RawAuctionData {
             .into_iter()
             .map(Into::into)
             .collect(),
+        deadline,
     }
 }
 
@@ -42,6 +44,7 @@ pub struct RawAuctionData {
     pub prices: BTreeMap<H160, U256>,
     #[serde(default)]
     pub surplus_capturing_jit_order_owners: Vec<H160>,
+    pub deadline: DateTime<Utc>,
 }
 
 pub type AuctionId = i64;
@@ -80,6 +83,7 @@ impl Auction {
                 .into_iter()
                 .map(Into::into)
                 .collect(),
+            deadline: self.auction.deadline,
         })
     }
 }

--- a/crates/autopilot/src/infra/persistence/mod.rs
+++ b/crates/autopilot/src/infra/persistence/mod.rs
@@ -66,8 +66,9 @@ impl Persistence {
     pub async fn replace_current_auction(
         &self,
         auction: &domain::RawAuctionData,
+        deadline: DateTime<Utc>,
     ) -> Result<domain::auction::Id, DatabaseError> {
-        let auction = dto::auction::from_domain(auction.clone());
+        let auction = dto::auction::from_domain(auction.clone(), deadline);
         self.postgres
             .replace_current_auction(&auction)
             .await

--- a/crates/autopilot/src/infra/solvers/dto/solve.rs
+++ b/crates/autopilot/src/infra/solvers/dto/solve.rs
@@ -10,18 +10,11 @@ use {
     primitive_types::{H160, U256},
     serde::{Deserialize, Serialize},
     serde_with::{DisplayFromStr, serde_as},
-    std::{
-        collections::{HashMap, HashSet},
-        time::Duration,
-    },
+    std::collections::{HashMap, HashSet},
 };
 
 impl Request {
-    pub fn new(
-        auction: &domain::Auction,
-        trusted_tokens: &HashSet<H160>,
-        time_limit: Duration,
-    ) -> Self {
+    pub fn new(auction: &domain::Auction, trusted_tokens: &HashSet<H160>) -> Self {
         Self {
             id: auction.id,
             orders: auction
@@ -45,7 +38,7 @@ impl Request {
                 }))
                 .unique_by(|token| token.address)
                 .collect(),
-            deadline: Utc::now() + chrono::Duration::from_std(time_limit).unwrap(),
+            deadline: auction.deadline,
             surplus_capturing_jit_order_owners: auction
                 .surplus_capturing_jit_order_owners
                 .iter()

--- a/crates/autopilot/src/shadow.rs
+++ b/crates/autopilot/src/shadow.rs
@@ -196,7 +196,7 @@ impl RunLoop {
 
     /// Runs the solver competition, making all configured drivers participate.
     async fn competition(&self, auction: &domain::Auction) -> Vec<Participant<'_>> {
-        let request = solve::Request::new(auction, &self.trusted_tokens.all(), self.solve_deadline);
+        let request = solve::Request::new(auction, &self.trusted_tokens.all());
         let request = &request;
 
         let mut participants =

--- a/crates/e2e/src/setup/services.rs
+++ b/crates/e2e/src/setup/services.rs
@@ -8,7 +8,6 @@ use {
         wait_for_condition,
     },
     app_data::{AppDataDocument, AppDataHash},
-    autopilot::infra::persistence::dto,
     clap::Parser,
     ethcontract::{H160, H256},
     model::{
@@ -17,6 +16,7 @@ use {
         solver_competition::SolverCompetitionAPI,
         trade::Trade,
     },
+    orderbook::dto,
     reqwest::{Client, StatusCode, Url},
     shared::ethrpc::Web3,
     sqlx::Connection,
@@ -357,7 +357,7 @@ impl<'a> Services<'a> {
     /// Fetches the current auction. Don't use this as a synchronization
     /// mechanism in tests because that is prone to race conditions
     /// which would make tests flaky.
-    pub async fn get_auction(&self) -> dto::Auction {
+    pub async fn get_auction(&self) -> dto::AuctionWithId {
         let response = self
             .http
             .get(format!("{API_HOST}{AUCTION_ENDPOINT}"))
@@ -494,7 +494,7 @@ impl<'a> Services<'a> {
     pub async fn get_order_status(
         &self,
         uid: &OrderUid,
-    ) -> Result<orderbook::dto::order::Status, (StatusCode, String)> {
+    ) -> Result<dto::order::Status, (StatusCode, String)> {
         let response = self
             .http
             .get(format!("{API_HOST}{}", order_status_endpoint(uid)))
@@ -506,9 +506,7 @@ impl<'a> Services<'a> {
         let body = response.text().await.unwrap();
 
         match status {
-            StatusCode::OK => {
-                Ok(serde_json::from_str::<orderbook::dto::order::Status>(&body).unwrap())
-            }
+            StatusCode::OK => Ok(serde_json::from_str::<dto::order::Status>(&body).unwrap()),
             code => Err((code, body)),
         }
     }

--- a/crates/orderbook/src/dto/auction.rs
+++ b/crates/orderbook/src/dto/auction.rs
@@ -23,7 +23,7 @@ pub struct Auction {
 pub type AuctionId = i64;
 
 #[serde_as]
-#[derive(Clone, Debug, Serialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct AuctionWithId {
     /// Increments whenever the backend updates the auction.


### PR DESCRIPTION
# Description
Add solve deadline to the S3 auction as requested by the solver team.

# Changes
- Add solve deadline to the S3 auction
- Move the deadline calculation from the request code to the cut auction code

## How to test
1. Regression test