### PR TITLE
Update cla.yaml

### DIFF
--- a/.github/workflows/cla.yaml
+++ b/.github/workflows/cla.yaml
@@ -12,10 +12,9 @@ jobs:
     steps:
       - name: "CLA Assistant"
         if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target'
-        uses: contributor-assistant/github-action@v2.2.1
+        uses: contributor-assistant/github-action@v2.6.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PERSONAL_ACCESS_TOKEN : ${{ secrets.ORG_TOKEN }}
         with:
           branch: 'cla-signatures'
           path-to-signatures: 'signatures/version1/cla.json'


### PR DESCRIPTION
Remove ORG_TOKEN from cla as it's deprecated and the new versions work with the default token.