### PR TITLE
Hide quote execution plan

### DIFF
--- a/crates/e2e/tests/e2e/limit_orders.rs
+++ b/crates/e2e/tests/e2e/limit_orders.rs
@@ -165,7 +165,10 @@ async fn single_limit_order_test(web3: Web3) {
 
     // we hide the quote's execution plan while the order is still fillable
     let order = services.get_order(&order_id).await.unwrap();
-    assert_eq!(order.metadata.quote.unwrap().metadata, serde_json::Value::default());
+    assert_eq!(
+        order.metadata.quote.unwrap().metadata,
+        serde_json::Value::default()
+    );
 
     onchain.mint_block().await;
     let limit_order = services.get_order(&order_id).await.unwrap();

--- a/crates/e2e/tests/e2e/limit_orders.rs
+++ b/crates/e2e/tests/e2e/limit_orders.rs
@@ -162,6 +162,11 @@ async fn single_limit_order_test(web3: Web3) {
     );
     let balance_before = token_b.balance_of(trader_a.address()).call().await.unwrap();
     let order_id = services.create_order(&order).await.unwrap();
+
+    // we hide the quote's execution plan while the order is still fillable
+    let order = services.get_order(&order_id).await.unwrap();
+    assert_eq!(order.metadata.quote.unwrap().metadata, serde_json::Value::default());
+
     onchain.mint_block().await;
     let limit_order = services.get_order(&order_id).await.unwrap();
     assert_eq!(limit_order.metadata.class, OrderClass::Limit);
@@ -171,6 +176,15 @@ async fn single_limit_order_test(web3: Web3) {
     wait_for_condition(TIMEOUT, || async {
         let balance_after = token_b.balance_of(trader_a.address()).call().await.unwrap();
         balance_after.checked_sub(balance_before).unwrap() >= to_wei(5)
+    })
+    .await
+    .unwrap();
+
+    wait_for_condition(TIMEOUT, || async {
+        // after the order got filled we are able to see the quote's execution plan
+        let order = services.get_order(&order_id).await.unwrap();
+        tracing::error!(?order);
+        order.metadata.quote.unwrap().metadata != serde_json::Value::default()
     })
     .await
     .unwrap();

--- a/crates/orderbook/src/database/orders.rs
+++ b/crates/orderbook/src/database/orders.rs
@@ -1124,12 +1124,13 @@ mod tests {
         let uid = OrderUid([0x42; 56]);
         let order = Order {
             data: OrderData {
-                valid_to: u32::MAX,
+                valid_to: 0,
                 ..Default::default()
             },
             metadata: OrderMetadata {
                 uid,
                 quote: Some(quote.try_to_model_order_quote().unwrap()),
+                status: OrderStatus::Expired,
                 ..Default::default()
             },
             interactions: Interactions {
@@ -1190,12 +1191,13 @@ mod tests {
         let uid = OrderUid([0x42; 56]);
         let order = Order {
             data: OrderData {
-                valid_to: u32::MAX,
+                valid_to: 0,
                 ..Default::default()
             },
             metadata: OrderMetadata {
                 uid,
                 quote: Some(quote.try_to_model_order_quote().unwrap()),
+                status: OrderStatus::Expired,
                 ..Default::default()
             },
             ..Default::default()


### PR DESCRIPTION
# Description
Currently we always expose the metadata of an order's quote. This basically contains the execution plan used to generate the quote. If this is made public while an order is still fillable you could theoretically have a solver that just tries to copy the quote's execution plan. That could lead to quoters not providing their best solution because they are afraid that the copy solver would snipe their order.
If we only show the execution plan after an order is no longer fillable this strategy will no longer work and the incentives of the quote competition remain unchanged (compared to never showing the execution plan like we did before).

# Changes
We now hide a quote's `metadata` until an order is no longer fillable.

## How to test
Adjusted an existing e2e test