### PR TITLE
[PoC] Improve price estimation error

### DIFF
--- a/crates/orderbook/src/api/post_quote.rs
+++ b/crates/orderbook/src/api/post_quote.rs
@@ -9,6 +9,7 @@ use {
     reqwest::StatusCode,
     shared::order_quoting::CalculateQuoteError,
     std::{convert::Infallible, sync::Arc},
+    thiserror::Error,
     warp::{Filter, Rejection},
 };
 
@@ -29,14 +30,15 @@ pub fn post_quote(
                 .await
                 .map_err(OrderQuoteErrorWrapper);
             if let Err(err) = &result {
-                tracing::warn!(?err, ?request, "post_quote error");
+                tracing::warn!(%err, ?request, "post_quote error");
             }
             Result::<_, Infallible>::Ok(convert_json_response(result))
         }
     })
 }
 
-#[derive(Debug)]
+#[derive(Debug, Error)]
+#[error(transparent)]
 pub struct OrderQuoteErrorWrapper(pub OrderQuoteError);
 impl IntoWarpReply for OrderQuoteErrorWrapper {
     fn into_warp_reply(self) -> ApiReply {

--- a/crates/orderbook/src/api/post_quote.rs
+++ b/crates/orderbook/src/api/post_quote.rs
@@ -54,7 +54,7 @@ pub struct CalculateQuoteErrorWrapper(CalculateQuoteError);
 impl IntoWarpReply for CalculateQuoteErrorWrapper {
     fn into_warp_reply(self) -> ApiReply {
         match self.0 {
-            CalculateQuoteError::Price(err) => err.source.into_warp_reply(),
+            CalculateQuoteError::Price { source, .. } => source.into_warp_reply(),
             CalculateQuoteError::SellAmountDoesNotCoverFee { fee_amount } => {
                 warp::reply::with_status(
                     rich_error(

--- a/crates/orderbook/src/api/post_quote.rs
+++ b/crates/orderbook/src/api/post_quote.rs
@@ -54,7 +54,7 @@ pub struct CalculateQuoteErrorWrapper(CalculateQuoteError);
 impl IntoWarpReply for CalculateQuoteErrorWrapper {
     fn into_warp_reply(self) -> ApiReply {
         match self.0 {
-            CalculateQuoteError::Price(err) => err.into_warp_reply(),
+            CalculateQuoteError::Price(err) => err.source.into_warp_reply(),
             CalculateQuoteError::SellAmountDoesNotCoverFee { fee_amount } => {
                 warp::reply::with_status(
                     rich_error(

--- a/crates/shared/src/order_quoting.rs
+++ b/crates/shared/src/order_quoting.rs
@@ -246,7 +246,7 @@ pub enum CalculateQuoteError {
     #[error("sell amount does not cover fee")]
     SellAmountDoesNotCoverFee { fee_amount: U256 },
 
-    #[error("estimator {estimator_kind:?} failed: {source}")]
+    #[error("{estimator_kind:?} estimator failed: {source}")]
     Price {
         estimator_kind: EstimatorKind,
         source: PriceEstimationError,

--- a/crates/shared/src/order_quoting.rs
+++ b/crates/shared/src/order_quoting.rs
@@ -271,9 +271,13 @@ impl From<(EstimatorKind, PriceEstimationError)> for CalculateQuoteError {
 
 #[derive(Debug)]
 pub enum EstimatorKind {
+    /// The gas price estimator.
     Gas,
+    /// Estimator for calculating the token pair price of an order.
     Regular,
+    /// Estimator for calculating the native token price of order's sell token.
     NativeSell,
+    /// Estimator for calculating the native token price of order's buy token.
     NativeBuy,
 }
 

--- a/crates/shared/src/order_quoting.rs
+++ b/crates/shared/src/order_quoting.rs
@@ -268,15 +268,11 @@ impl From<(EstimatorKind, PriceEstimationError)> for CalculateQuoteError {
     }
 }
 
-#[derive(Debug, Error)]
+#[derive(Debug)]
 pub enum EstimatorKind {
-    #[error("Gas")]
     Gas,
-    #[error("Regular")]
     Regular,
-    #[error("Native (sell)")]
     NativeSell,
-    #[error("Native (buy)")]
     NativeBuy,
 }
 

--- a/crates/shared/src/order_quoting.rs
+++ b/crates/shared/src/order_quoting.rs
@@ -17,7 +17,6 @@ use {
     chrono::{DateTime, Duration, Utc},
     database::quotes::{Quote as QuoteRow, QuoteKind},
     ethcontract::{H160, U256},
-    futures::TryFutureExt as _,
     gas_estimation::GasPriceEstimating,
     model::{
         interaction::InteractionData,
@@ -248,13 +247,33 @@ pub enum CalculateQuoteError {
     SellAmountDoesNotCoverFee { fee_amount: U256 },
 
     #[error("failed to estimate price")]
-    Price(#[from] PriceEstimationError),
+    Price(#[from] PriceEstimationContextError),
 
     #[error("failed to verify quote")]
     QuoteNotVerified,
 
     #[error(transparent)]
     Other(#[from] anyhow::Error),
+}
+
+#[derive(Debug, Error)]
+#[error("estimator {kind:?} failed: {source}")]
+pub struct PriceEstimationContextError {
+    pub kind: EstimatorKind,
+    #[source]
+    pub source: PriceEstimationError,
+}
+
+#[derive(Debug, Error)]
+pub enum EstimatorKind {
+    #[error("Gas")]
+    Gas,
+    #[error("Regular")]
+    Regular,
+    #[error("Native (sell)")]
+    NativeSell,
+    #[error("Native (buy)")]
+    NativeBuy,
 }
 
 #[derive(Error, Debug)]
@@ -419,17 +438,53 @@ impl OrderQuoter {
 
         let trade_query = Arc::new(parameters.to_price_query());
         let (gas_estimate, trade_estimate, sell_token_price, _) = futures::try_join!(
-            self.gas_estimator
-                .estimate()
-                .map_err(PriceEstimationError::ProtocolInternal),
-            self.price_estimator.estimate(trade_query.clone()),
-            self.native_price_estimator
-                .estimate_native_price(parameters.sell_token),
+            async {
+                match self.gas_estimator.estimate().await {
+                    Ok(estimate) => Ok(estimate),
+                    Err(err) => Err(CalculateQuoteError::Price(PriceEstimationContextError {
+                        kind: EstimatorKind::Gas,
+                        source: PriceEstimationError::ProtocolInternal(err),
+                    })),
+                }
+            },
+            async {
+                match self.price_estimator.estimate(trade_query.clone()).await {
+                    Ok(estimate) => Ok(estimate),
+                    Err(err) => Err(CalculateQuoteError::Price(PriceEstimationContextError {
+                        kind: EstimatorKind::Regular,
+                        source: err,
+                    })),
+                }
+            },
+            async {
+                match self
+                    .native_price_estimator
+                    .estimate_native_price(parameters.sell_token)
+                    .await
+                {
+                    Ok(price) => Ok(price),
+                    Err(err) => Err(CalculateQuoteError::Price(PriceEstimationContextError {
+                        kind: EstimatorKind::NativeSell,
+                        source: err,
+                    })),
+                }
+            },
             // We don't care about the native price of the buy_token for the quote but we need it
             // when we build the auction. To prevent creating orders which we can't settle later on
             // we make the native buy_token price a requirement here as well.
-            self.native_price_estimator
-                .estimate_native_price(parameters.buy_token),
+            async {
+                match self
+                    .native_price_estimator
+                    .estimate_native_price(parameters.buy_token)
+                    .await
+                {
+                    Ok(price) => Ok(price),
+                    Err(err) => Err(CalculateQuoteError::Price(PriceEstimationContextError {
+                        kind: EstimatorKind::NativeBuy,
+                        source: err,
+                    })),
+                }
+            },
         )?;
 
         let (quoted_sell_amount, quoted_buy_amount) = match &parameters.side {
@@ -1316,7 +1371,10 @@ mod tests {
 
         assert!(matches!(
             quoter.calculate_quote(parameters).await.unwrap_err(),
-            CalculateQuoteError::Price(PriceEstimationError::NoLiquidity),
+            CalculateQuoteError::Price(PriceEstimationContextError {
+                kind: EstimatorKind::NativeBuy,
+                source: PriceEstimationError::NoLiquidity
+            }),
         ));
     }
 
@@ -1711,8 +1769,8 @@ mod tests {
          "preInteractions":[
          {"target":"0x0303030303030303030303030303030303030303","value":"3","callData":"0x03"},
          {"target":"0x0404040404040404040404040404040404040404","value":"4","callData":"0x04"}],
-         "jitOrders":[{"appData": "0x0000000000000000000000000000000000000000000000000000000000000000", 
-            "buyAmount": "20", "buyToken": "0x0404040404040404040404040404040404040404", "buyTokenDestination": "internal", 
+         "jitOrders":[{"appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
+            "buyAmount": "20", "buyToken": "0x0404040404040404040404040404040404040404", "buyTokenDestination": "internal",
             "executedAmount": "11", "partiallyFillable": false, "receiver": "0x0606060606060606060606060606060606060606",
             "sellAmount": "10", "sellToken": "0x0505050505050505050505050505050505050505", "sellTokenSource": "external",
             "side": "sell", "signature": "0x01010101010101010101010101010101", "signingScheme": "eip712", "validTo": 1734084318}]
@@ -1742,13 +1800,13 @@ mod tests {
         "preInteractions":[
         {"target":"0x0303030303030303030303030303030303030303","value":"3","callData":"0x03"},
         {"target":"0x0404040404040404040404040404040404040404","value":"4","callData":"0x04"}],
-        "jitOrders":[{"appData": "0x0000000000000000000000000000000000000000000000000000000000000000", 
-            "buyAmount": "20", "buyToken": "0x0404040404040404040404040404040404040404", "buyTokenDestination": "internal", 
+        "jitOrders":[{"appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
+            "buyAmount": "20", "buyToken": "0x0404040404040404040404040404040404040404", "buyTokenDestination": "internal",
             "executedAmount": "11", "partiallyFillable": false, "receiver": "0x0606060606060606060606060606060606060606",
             "sellAmount": "10", "sellToken": "0x0505050505050505050505050505050505050505", "sellTokenSource": "external",
             "side": "sell", "signature": "0x01010101010101010101010101010101", "signingScheme": "eip712", "validTo": 1734084318},
-            {"appData": "0x0ddeb6e4a814908832cc25d11311c514e7efe6af3c9bafeb0d241129cf7f4d83", 
-            "buyAmount": "100", "buyToken": "0x0606060606060606060606060606060606060606", "buyTokenDestination": "erc20", 
+            {"appData": "0x0ddeb6e4a814908832cc25d11311c514e7efe6af3c9bafeb0d241129cf7f4d83",
+            "buyAmount": "100", "buyToken": "0x0606060606060606060606060606060606060606", "buyTokenDestination": "erc20",
             "executedAmount": "99", "partiallyFillable": true, "receiver": "0x0303030303030303030303030303030303030303",
             "sellAmount": "10", "sellToken": "0x0101010101010101010101010101010101010101", "sellTokenSource": "erc20",
             "side": "buy", "signature": "0x01010101010101010101010101010101", "signingScheme": "eip1271", "validTo": 1734085109}]

--- a/crates/shared/src/order_quoting.rs
+++ b/crates/shared/src/order_quoting.rs
@@ -447,16 +447,16 @@ impl OrderQuoter {
                 ))),
             self.price_estimator
                 .estimate(trade_query.clone())
-                .map_err(|err| CalculateQuoteError::from((EstimatorKind::Regular, err))),
+                .map_err(|err| (EstimatorKind::Regular, err).into()),
             self.native_price_estimator
                 .estimate_native_price(parameters.sell_token)
-                .map_err(|err| CalculateQuoteError::from((EstimatorKind::NativeSell, err))),
+                .map_err(|err| (EstimatorKind::NativeSell, err).into()),
             // We don't care about the native price of the buy_token for the quote but we need it
             // when we build the auction. To prevent creating orders which we can't settle later on
             // we make the native buy_token price a requirement here as well.
             self.native_price_estimator
                 .estimate_native_price(parameters.buy_token)
-                .map_err(|err| CalculateQuoteError::from((EstimatorKind::NativeBuy, err))),
+                .map_err(|err| (EstimatorKind::NativeBuy, err).into()),
         )?;
 
         let (quoted_sell_amount, quoted_buy_amount) = match &parameters.side {

--- a/crates/shared/src/order_validation.rs
+++ b/crates/shared/src/order_validation.rs
@@ -6,7 +6,6 @@ use {
         order_quoting::{
             CalculateQuoteError,
             OrderQuoting,
-            PriceEstimationContextError,
             Quote,
             QuoteParameters,
             QuoteSearchParameters,
@@ -178,18 +177,18 @@ impl From<VerificationError> for ValidationError {
 impl From<CalculateQuoteError> for ValidationError {
     fn from(err: CalculateQuoteError) -> Self {
         match err {
-            CalculateQuoteError::Price(PriceEstimationContextError {
+            CalculateQuoteError::Price {
                 source: PriceEstimationError::UnsupportedToken { token, reason },
                 ..
-            }) => {
+            } => {
                 ValidationError::Partial(PartialValidationError::UnsupportedToken { token, reason })
             }
-            CalculateQuoteError::Price(PriceEstimationContextError {
+            CalculateQuoteError::Price {
                 source: PriceEstimationError::ProtocolInternal(err),
                 ..
-            })
+            }
             | CalculateQuoteError::Other(err) => ValidationError::Other(err),
-            CalculateQuoteError::Price(err) => ValidationError::PriceForQuote(err.source),
+            CalculateQuoteError::Price { source, .. } => ValidationError::PriceForQuote(source),
             CalculateQuoteError::QuoteNotVerified => ValidationError::QuoteNotVerified,
             // This should never happen because we only calculate quotes with
             // `SellAmount::AfterFee`, meaning that the sell amount does not

--- a/crates/shared/src/order_validation.rs
+++ b/crates/shared/src/order_validation.rs
@@ -201,6 +201,7 @@ impl From<CalculateQuoteError> for ValidationError {
         }
     }
 }
+
 #[mockall::automock]
 #[async_trait]
 pub trait LimitOrderCounting: Send + Sync {


### PR DESCRIPTION
# Description
Currently, it's quite difficult to understand why a quoting competition failed. All the estimators use the same error struct and much more time than anticipated needs to be spent to find the cause of the problem.

The issue that inspired me to open this PR was the unstable quoting results for a particular token pair. If I filter the logs by this pair, with this PR, I will easily see the list of all the errors and can decide what the majority of the causes are. With any extra step, this won't be possible(as right now). I would need to get the request ID each time. This is a very annoying problem in other backend components, which is much harder/impossible to address.

# Changes

- [ ] As a first step, the price estimation error is enriched with the estimator kind that caused the competition to fail.
- [ ] Using this, it should be much easier to understand at which step the competition has failed (e.g., whether a Native sell token estimator or a regular one failed, and then dive deeper into the exact problem if needed).
- [ ] It doesn't change the API, only the logging.

## How to test
Observe logs.

Sampled log:
```
2025-04-25T10:23:39.841Z  WARN request{id="1"}: orderbook::api::post_quote: post_quote error err=error calculating quote: NativeBuy estimator failed: No liquidity request=OrderQuoteRequest { from: 0x2b5ad5c4795c026514f8317c7a215e218dccd6cf, sell_token: 0x5fbdb2315678afecb367f032d93f642f64180aa3, buy_token: 0x68b1d87f95878fe05b998f19b66f4baba5de1aed, receiver: None, side: Sell { sell_amount: AfterFee { value: U256(1000000000000000000) } }, validity: For(1800), app_data: Hash { hash: 0x0000000000000000000000000000000000000000000000000000000000000000 }, sell_token_balance: Erc20, buy_token_balance: Erc20, signing_scheme: Eip712, price_quality: Optimal }
```
- `error calculating quote:`  is an API wrapper
- `NativeBuy estimator failed:`  is a new estimator wrapper
- `No liquidity` - the original error
