### PR TITLE
Surplus partner fee

### DIFF
--- a/crates/app-data/src/app_data.rs
+++ b/crates/app-data/src/app_data.rs
@@ -63,8 +63,106 @@ pub struct ReplacedOrder {
 #[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq)]
 #[cfg_attr(any(test, feature = "test_helpers"), derive(Serialize))]
 pub struct PartnerFee {
-    pub bps: u64,
+    #[serde(flatten)]
+    pub policy: FeePolicy,
     pub recipient: H160,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum FeePolicy {
+    /// Fees should be captured from an order's surplus (depending on the
+    /// order's type measured against the order's limit price or quote
+    /// associated with the order creation).
+    Surplus {
+        /// How many bps of surplus should be captured as fees.
+        bps: u64,
+        /// How many bps of the total volume may be captured at most. Under some
+        /// conditions there can be a lot of surplus so to not charge egrigious
+        /// amounts there is a cap. Note that there is also a cap enforced by
+        /// the protocol so effectively the partner can only lower the
+        /// limit here.
+        max_volume_bps: u64,
+    },
+    /// Fees should be captured from an order's entire volume.
+    /// In that case an order's execution must be so much better that
+    /// taking a cut from the volume will not end up violating the
+    /// order's limit price.
+    Volume { bps: u64 },
+}
+
+impl Default for FeePolicy {
+    fn default() -> Self {
+        Self::Volume { bps: 0 }
+    }
+}
+
+impl<'de> Deserialize<'de> for FeePolicy {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        #[serde(untagged)]
+        enum Helper {
+            #[serde(rename_all = "camelCase")]
+            Surplus {
+                surplus_bps: u64,
+                max_volume_bps: u64,
+            },
+            // Originally only volume fees were allowed and they used the field `bps`.
+            // To stay backwards compatible with old appdata we still support this old
+            // format.
+            #[serde(rename_all = "camelCase")]
+            VolumeOld { bps: u64 },
+            #[serde(rename_all = "camelCase")]
+            Volume { volume_bps: u64 },
+        }
+
+        match Helper::deserialize(deserializer)? {
+            Helper::Surplus {
+                surplus_bps,
+                max_volume_bps,
+            } => Ok(FeePolicy::Surplus {
+                bps: surplus_bps,
+                max_volume_bps,
+            }),
+            Helper::Volume { volume_bps } => Ok(FeePolicy::Volume { bps: volume_bps }),
+            Helper::VolumeOld { bps } => Ok(FeePolicy::Volume { bps }),
+        }
+    }
+}
+
+#[cfg(any(test, feature = "test_helpers"))]
+impl serde::Serialize for FeePolicy {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        #[derive(Serialize)]
+        #[serde(rename_all = "camelCase")]
+        enum Helper {
+            Surplus {
+                surplus_bps: u64,
+                max_volume_bps: u64,
+            },
+            Volume {
+                volume_bps: u64,
+            },
+        }
+
+        let helper = match self {
+            Self::Volume { bps } => Helper::Volume { volume_bps: *bps },
+            Self::Surplus {
+                bps,
+                max_volume_bps,
+            } => Helper::Surplus {
+                surplus_bps: *bps,
+                max_volume_bps: *max_volume_bps,
+            },
+        };
+
+        helper.serialize(serializer)
+    }
 }
 
 #[derive(Clone)]
@@ -446,7 +544,7 @@ mod tests {
             "#,
             ProtocolAppData {
                 partner_fee: PartnerFees(vec![PartnerFee {
-                    bps: 100,
+                    policy: FeePolicy::Volume { bps: 100 },
                     recipient: H160([2; 20]),
                 }]),
                 ..Default::default()
@@ -471,7 +569,12 @@ mod tests {
                                 "recipient": "0x0202020202020202020202020202020202020202"
                             },
                             {
-                                "bps": 1000,
+                                "volumeBps": 1000,
+                                "recipient": "0x0101010101010101010101010101010101010101"
+                            },
+                            {
+                                "surplusBps": 100,
+                                "maxVolumeBps": 100,
                                 "recipient": "0x0101010101010101010101010101010101010101"
                             }
                         ]
@@ -481,12 +584,21 @@ mod tests {
             "#,
             ProtocolAppData {
                 partner_fee: PartnerFees(vec![
+                    // this one was parsed from the old format for volume fees
                     PartnerFee {
-                        bps: 100,
+                        policy: FeePolicy::Volume { bps: 100 },
                         recipient: H160([2; 20]),
                     },
+                    // this one is using the new format
                     PartnerFee {
-                        bps: 1000,
+                        policy: FeePolicy::Volume { bps: 1000 },
+                        recipient: H160([1; 20]),
+                    },
+                    PartnerFee {
+                        policy: FeePolicy::Surplus {
+                            bps: 100,
+                            max_volume_bps: 100
+                        },
                         recipient: H160([1; 20]),
                     },
                 ]),

--- a/crates/autopilot/src/domain/fee/mod.rs
+++ b/crates/autopilot/src/domain/fee/mod.rs
@@ -74,7 +74,11 @@ impl ProtocolFees {
     }
 
     /// Returns the capped aggregated partner fee
-    fn get_partner_fee(order: &boundary::Order, max_partner_fee: f64) -> Vec<Policy> {
+    fn get_partner_fee(
+        order: &boundary::Order,
+        quote: &domain::Quote,
+        max_partner_fee: f64,
+    ) -> Vec<Policy> {
         /// Convert a fee into a `FeeFactor` capping its value
         fn fee_factor_from_capped(value: Decimal, cap: Decimal, accumulated: Decimal) -> FeeFactor {
             // Calculate how much more we can compound before hitting the cap.
@@ -111,21 +115,63 @@ impl ProtocolFees {
 
         let mut accumulated = Decimal::ZERO;
 
+        let outside_market_price =
+            boundary::is_order_outside_market_price(&order.into(), &quote.into(), order.data.kind);
+
         validated
             .protocol
             .partner_fee
             .iter()
             .map(move |partner_fee| {
-                // Convert bps to decimal percentage
-                let fee_decimal = Decimal::from(partner_fee.bps) / Decimal::from(10_000);
+                /// Number of basis points that make up 100%.
+                const MAX_BPS: u32 = 10_000;
 
-                // Create policy and update accumulator
-                let factor = fee_factor_from_capped(fee_decimal, max_partner_fee, accumulated);
+                match partner_fee.policy {
+                    app_data::FeePolicy::Volume { bps } => {
+                        // Convert bps to decimal percentage
+                        let fee_decimal = Decimal::from(bps) / Decimal::from(MAX_BPS);
+                        // Create policy and update accumulator
+                        let factor =
+                            fee_factor_from_capped(fee_decimal, max_partner_fee, accumulated);
+                        // Update the accumulated value for the next iteration
+                        accumulated += fee_decimal.min(max_partner_fee - accumulated);
+                        Policy::Volume { factor }
+                    }
+                    app_data::FeePolicy::Surplus {
+                        bps,
+                        max_volume_bps,
+                    } => {
+                        // Convert bps to decimal percentage
+                        let fee_decimal = Decimal::from(max_volume_bps) / Decimal::from(MAX_BPS);
 
-                // Update the accumulated value for the next iteration
-                accumulated += fee_decimal.min(max_partner_fee - accumulated);
+                        // Compute max_volume_factor limited by the global volume cap.
+                        let max_volume_factor =
+                            fee_factor_from_capped(fee_decimal, max_partner_fee, accumulated);
 
-                Policy::Volume { factor }
+                        // clamp `bps` to a reasonable value
+                        let bps = u32::try_from(bps.min(u64::from(MAX_BPS) - 1)).unwrap();
+                        let factor = f64::from(bps) / f64::from(MAX_BPS);
+                        let factor = FeeFactor::try_from(factor)
+                            .expect("value was clamped to the required range");
+
+                        match outside_market_price {
+                            true => Policy::Surplus {
+                                factor,
+                                max_volume_factor,
+                            },
+                            false => Policy::PriceImprovement {
+                                factor,
+                                max_volume_factor,
+                                quote: Quote {
+                                    buy_amount: quote.buy_amount.into(),
+                                    sell_amount: quote.sell_amount.into(),
+                                    solver: quote.solver.into(),
+                                    fee: quote.fee.into(),
+                                },
+                            },
+                        }
+                    }
+                }
             })
             .collect::<Vec<_>>()
     }
@@ -138,21 +184,9 @@ impl ProtocolFees {
         quote: Option<domain::Quote>,
         surplus_capturing_jit_order_owners: &[eth::Address],
     ) -> domain::Order {
-        let partner_fee = Self::get_partner_fee(&order, self.max_partner_fee.into());
-
-        if surplus_capturing_jit_order_owners.contains(&order.metadata.owner.into()) {
-            return boundary::order::to_domain(order, partner_fee, quote);
-        }
-
-        let order_ = boundary::Amounts {
-            sell: order.data.sell_amount,
-            buy: order.data.buy_amount,
-            fee: order.data.fee_amount,
-        };
-
         // In case there is no quote, we assume 0 buy amount so that the order ends up
         // being considered out of market price.
-        let quote = quote.unwrap_or(domain::Quote {
+        let reference_quote = quote.clone().unwrap_or(domain::Quote {
             order_uid: order.metadata.uid.into(),
             sell_amount: order.data.sell_amount.into(),
             buy_amount: U256::zero().into(),
@@ -160,29 +194,29 @@ impl ProtocolFees {
             solver: H160::zero().into(),
         });
 
-        let quote_ = boundary::Amounts {
-            sell: quote.sell_amount.into(),
-            buy: quote.buy_amount.into(),
-            fee: quote.fee.into(),
-        };
+        let partner_fee =
+            Self::get_partner_fee(&order, &reference_quote, self.max_partner_fee.into());
+        if !partner_fee.is_empty() {
+            tracing::error!(?partner_fee);
+        }
 
-        self.apply_policies(order, quote, order_, quote_, partner_fee)
+        if surplus_capturing_jit_order_owners.contains(&order.metadata.owner.into()) {
+            return boundary::order::to_domain(order, partner_fee, quote);
+        }
+
+        self.apply_policies(order, reference_quote, partner_fee)
     }
 
     fn apply_policies(
         &self,
         order: boundary::Order,
         quote: domain::Quote,
-        order_: boundary::Amounts,
-        quote_: boundary::Amounts,
         partner_fees: Vec<Policy>,
     ) -> domain::Order {
         let protocol_fees = self
             .fee_policies
             .iter()
-            .filter_map(|fee_policy| {
-                Self::protocol_fee_into_policy(&order, &order_, &quote_, fee_policy)
-            })
+            .filter_map(|fee_policy| Self::protocol_fee_into_policy(&order, &quote, fee_policy))
             .flat_map(|policy| Self::variant_fee_apply(&order, &quote, policy))
             .chain(partner_fees)
             .collect::<Vec<_>>();
@@ -203,12 +237,11 @@ impl ProtocolFees {
 
     fn protocol_fee_into_policy<'a>(
         order: &boundary::Order,
-        order_: &boundary::Amounts,
-        quote_: &boundary::Amounts,
+        quote: &domain::Quote,
         protocol_fee: &'a ProtocolFee,
     ) -> Option<&'a policy::Policy> {
         let outside_market_price =
-            boundary::is_order_outside_market_price(order_, quote_, order.data.kind);
+            boundary::is_order_outside_market_price(&order.into(), &quote.into(), order.data.kind);
         match (outside_market_price, &protocol_fee.order_class) {
             (_, OrderClass::Any) => Some(&protocol_fee.policy),
             (true, OrderClass::Limit) => Some(&protocol_fee.policy),
@@ -336,7 +369,7 @@ mod test {
         };
 
         let max_partner_fee = 0.3; // 30%
-        let result = ProtocolFees::get_partner_fee(&order, max_partner_fee);
+        let result = ProtocolFees::get_partner_fee(&order, &Default::default(), max_partner_fee);
 
         // Expected: The compounded percentage (1 + 0.05) * (1 + 0.20) - 1 = 0.26 < 0.3
         // (not capped)
@@ -377,7 +410,7 @@ mod test {
         };
 
         let max_partner_fee = 0.3; // 30%
-        let result = ProtocolFees::get_partner_fee(&order, max_partner_fee);
+        let result = ProtocolFees::get_partner_fee(&order, &Default::default(), max_partner_fee);
 
         // Expected: Empty vector since there are no partner fees
         assert_eq!(result, vec![]);
@@ -412,7 +445,7 @@ mod test {
         };
 
         let max_partner_fee = 0.3; // 30%
-        let result = ProtocolFees::get_partner_fee(&order, max_partner_fee);
+        let result = ProtocolFees::get_partner_fee(&order, &Default::default(), max_partner_fee);
 
         // Expected: Empty vector since the only fee has 0 bps
         assert_eq!(
@@ -456,7 +489,7 @@ mod test {
         };
 
         let max_partner_fee = 0.0; // 0%
-        let result = ProtocolFees::get_partner_fee(&order, max_partner_fee);
+        let result = ProtocolFees::get_partner_fee(&order, &Default::default(), max_partner_fee);
 
         // Expected: All fees are capped to zero but still appear
         assert_eq!(
@@ -501,7 +534,7 @@ mod test {
         };
 
         let max_partner_fee = 0.3; // 30%
-        let result = ProtocolFees::get_partner_fee(&order, max_partner_fee);
+        let result = ProtocolFees::get_partner_fee(&order, &Default::default(), max_partner_fee);
 
         // Expected: Single fee capped at 0.3 (instead of 0.5)
         assert_eq!(
@@ -545,7 +578,7 @@ mod test {
         };
 
         let max_partner_fee = 0.3; // 30%
-        let result = ProtocolFees::get_partner_fee(&order, max_partner_fee);
+        let result = ProtocolFees::get_partner_fee(&order, &Default::default(), max_partner_fee);
 
         // Expected: With compounding:
         // First fee: 0.1
@@ -601,7 +634,7 @@ mod test {
         };
 
         let max_partner_fee = 0.3; // 30%
-        let result = ProtocolFees::get_partner_fee(&order, max_partner_fee);
+        let result = ProtocolFees::get_partner_fee(&order, &Default::default(), max_partner_fee);
 
         // Expected: With compounding, fees accumulate as follows:
         // First fee: 0.1

--- a/crates/autopilot/src/domain/fee/mod.rs
+++ b/crates/autopilot/src/domain/fee/mod.rs
@@ -144,6 +144,8 @@ impl ProtocolFees {
                         // Compute max_volume_factor limited by the global volume cap.
                         let max_volume_factor =
                             fee_factor_from_capped(fee_decimal, max_partner_fee, accumulated);
+                        // Update the accumulated value for the next iteration
+                        accumulated += fee_decimal.min(max_partner_fee - accumulated);
 
                         // clamp `bps` to a reasonable value
                         let bps = u32::try_from(bps.min(u64::from(MAX_BPS) - 1)).unwrap();
@@ -166,6 +168,8 @@ impl ProtocolFees {
                         // Compute max_volume_factor limited by the global volume cap.
                         let max_volume_factor =
                             fee_factor_from_capped(fee_decimal, max_partner_fee, accumulated);
+                        // Update the accumulated value for the next iteration
+                        accumulated += fee_decimal.min(max_partner_fee - accumulated);
 
                         // clamp `bps` to a reasonable value
                         let bps = u32::try_from(bps.min(u64::from(MAX_BPS) - 1)).unwrap();

--- a/crates/autopilot/src/domain/quote/mod.rs
+++ b/crates/autopilot/src/domain/quote/mod.rs
@@ -1,4 +1,7 @@
-use {super::OrderUid, crate::domain::eth};
+use {
+    super::OrderUid,
+    crate::{boundary::Amounts, domain::eth},
+};
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct Quote {
@@ -7,4 +10,27 @@ pub struct Quote {
     pub buy_amount: eth::TokenAmount,
     pub fee: eth::SellTokenAmount,
     pub solver: eth::Address,
+}
+
+impl From<&Quote> for Amounts {
+    fn from(quote: &Quote) -> Self {
+        Self {
+            sell: quote.sell_amount.into(),
+            buy: quote.buy_amount.into(),
+            fee: quote.fee.into(),
+        }
+    }
+}
+
+#[cfg(test)]
+impl Default for Quote {
+    fn default() -> Self {
+        Self {
+            order_uid: OrderUid([0; 56]),
+            sell_amount: Default::default(),
+            buy_amount: Default::default(),
+            fee: Default::default(),
+            solver: Default::default(),
+        }
+    }
 }

--- a/crates/e2e/tests/e2e/protocol_fee.rs
+++ b/crates/e2e/tests/e2e/protocol_fee.rs
@@ -430,9 +430,7 @@ async fn surplus_partner_fee(web3: Web3) {
     services
         .start_protocol_with_args(
             ExtraServiceArgs {
-                autopilot: vec![
-                    "--fee-policy-max-partner-fee=0.02".to_string(),
-                ],
+                autopilot: vec!["--fee-policy-max-partner-fee=0.02".to_string()],
                 ..Default::default()
             },
             solver,
@@ -443,15 +441,15 @@ async fn surplus_partner_fee(web3: Web3) {
     let quote_valid_to = model::time::now_in_epoch_seconds() + 300;
     let sell_amount = to_wei(10);
     let quote_before = get_quote(
-            &services,
-            onchain.contracts().weth.address(),
-            token.address(),
-            OrderKind::Sell,
-            sell_amount,
-            quote_valid_to,
-        )
-        .await
-        .unwrap();
+        &services,
+        onchain.contracts().weth.address(),
+        token.address(),
+        OrderKind::Sell,
+        sell_amount,
+        quote_valid_to,
+    )
+    .await
+    .unwrap();
 
     let order = OrderCreation {
         sell_amount,
@@ -494,15 +492,15 @@ async fn surplus_partner_fee(web3: Web3) {
     .expect("Timeout waiting for eviction of the cached liquidity");
 
     let quote_after = get_quote(
-            &services,
-            onchain.contracts().weth.address(),
-            token.address(),
-            OrderKind::Sell,
-            sell_amount,
-            quote_valid_to,
-        )
-        .await
-        .unwrap();
+        &services,
+        onchain.contracts().weth.address(),
+        token.address(),
+        OrderKind::Sell,
+        sell_amount,
+        quote_valid_to,
+    )
+    .await
+    .unwrap();
 
     let order_uid = services.create_order(&order).await.unwrap();
 
@@ -511,42 +509,45 @@ async fn surplus_partner_fee(web3: Web3) {
     tracing::info!("Waiting for orders to trade.");
     let metadata_updated = || async {
         onchain.mint_block().await;
-        services.get_order(&order_uid).await.is_ok_and(|order| !order.metadata.executed_fee.is_zero())
+        services
+            .get_order(&order_uid)
+            .await
+            .is_ok_and(|order| !order.metadata.executed_fee.is_zero())
     };
     wait_for_condition(TIMEOUT, metadata_updated)
         .await
         .expect("Timeout waiting for the orders to trade");
 
     tracing::info!("Checking executions...");
-    let order = services
-        .get_order(&order_uid)
-        .await
-        .unwrap();
+    let order = services.get_order(&order_uid).await.unwrap();
     tracing::error!(?order);
     // let market_executed_fee_in_buy_token =
-    //     fee_in_buy_token(&market_price_improvement_order, &market_quote_after.quote);
-    // let market_quote_diff = market_quote_after
-    //     .quote
+    //     fee_in_buy_token(&market_price_improvement_order,
+    // &market_quote_after.quote); let market_quote_diff =
+    // market_quote_after     .quote
     //     .buy_amount
     //     .saturating_sub(market_quote_before.quote.buy_amount);
     // // see `market_price_improvement_policy.factor`, which is 0.3
     // assert!(market_executed_fee_in_buy_token >= market_quote_diff * 3 / 10);
 
-    // let partner_fee_order = services.get_order(&partner_fee_order_uid).await.unwrap();
+    // let partner_fee_order =
+    // services.get_order(&partner_fee_order_uid).await.unwrap();
     // let partner_fee_executed_fee_in_buy_token =
     //     fee_in_buy_token(&partner_fee_order, &partner_fee_quote_after.quote);
     // assert!(
-    //     // see `--fee-policy-max-partner-fee` autopilot config argument, which is 0.02
-    //     partner_fee_executed_fee_in_buy_token >= partner_fee_quote.quote.buy_amount * 2 / 100
-    // );
+    //     // see `--fee-policy-max-partner-fee` autopilot config argument,
+    // which is 0.02     partner_fee_executed_fee_in_buy_token >=
+    // partner_fee_quote.quote.buy_amount * 2 / 100 );
     // let limit_quote_diff = partner_fee_quote_after
     //     .quote
     //     .buy_amount
     //     .saturating_sub(partner_fee_order.data.buy_amount);
     // // see `limit_surplus_policy.factor`, which is 0.3
-    // assert!(partner_fee_executed_fee_in_buy_token >= limit_quote_diff * 3 / 10);
+    // assert!(partner_fee_executed_fee_in_buy_token >= limit_quote_diff * 3 /
+    // 10);
 
-    // let limit_surplus_order = services.get_order(&limit_surplus_order_uid).await.unwrap();
+    // let limit_surplus_order =
+    // services.get_order(&limit_surplus_order_uid).await.unwrap();
     // let limit_executed_fee_in_buy_token =
     //     fee_in_buy_token(&limit_surplus_order, &limit_quote_after.quote);
     // let limit_quote_diff = limit_quote_after
@@ -576,8 +577,9 @@ async fn surplus_partner_fee(web3: Web3) {
     // .unwrap()
     // .try_into()
     // .expect("Expected exactly four elements");
-    // assert_approximately_eq!(market_executed_fee_in_buy_token, market_order_token_balance);
-    // assert_approximately_eq!(limit_executed_fee_in_buy_token, limit_order_token_balance);
+    // assert_approximately_eq!(market_executed_fee_in_buy_token,
+    // market_order_token_balance); assert_approximately_eq!
+    // (limit_executed_fee_in_buy_token, limit_order_token_balance);
     // assert_approximately_eq!(
     //     partner_fee_executed_fee_in_buy_token,
     //     partner_fee_order_token_balance

--- a/crates/e2e/tests/e2e/protocol_fee.rs
+++ b/crates/e2e/tests/e2e/protocol_fee.rs
@@ -373,9 +373,9 @@ async fn combined_protocol_fees(web3: Web3) {
 
 /// Tests that a partner can provide multiple partner fees and also use
 /// the `Surplus` and `PriceImprovement` fee policies. Also checks that
-/// the partner fees can not exceed the globally defined `--fee-policy-max-partner-fee`
-/// which defines how much of an order's volume may be captured in total
-/// by partner fees.
+/// the partner fees can not exceed the globally defined
+/// `--fee-policy-max-partner-fee` which defines how much of an order's volume
+/// may be captured in total by partner fees.
 async fn surplus_partner_fee(web3: Web3) {
     // All these values are unreasonably high but result in easier math
     // when it comes to limiting partner fees to the global volume cap.

--- a/crates/model/src/fee_policy.rs
+++ b/crates/model/src/fee_policy.rs
@@ -22,6 +22,20 @@ pub enum FeePolicy {
     },
 }
 
+impl FeePolicy {
+    pub fn max_volume_factor(&self) -> f64 {
+        match self {
+            FeePolicy::Surplus {
+                max_volume_factor, ..
+            } => *max_volume_factor,
+            FeePolicy::PriceImprovement {
+                max_volume_factor, ..
+            } => *max_volume_factor,
+            FeePolicy::Volume { factor, .. } => *factor,
+        }
+    }
+}
+
 #[serde_as]
 #[derive(PartialEq, Clone, Debug, Serialize)]
 #[cfg_attr(any(test, feature = "e2e"), derive(serde::Deserialize))]

--- a/crates/shared/src/order_validation.rs
+++ b/crates/shared/src/order_validation.rs
@@ -910,6 +910,16 @@ pub struct Amounts {
     pub fee: U256,
 }
 
+impl From<&model::order::Order> for Amounts {
+    fn from(order: &model::order::Order) -> Self {
+        Self {
+            sell: order.data.sell_amount,
+            buy: order.data.buy_amount,
+            fee: order.data.fee_amount,
+        }
+    }
+}
+
 /// Checks whether or not an order's limit price is outside the market price
 /// specified by the quote.
 pub fn is_order_outside_market_price(


### PR DESCRIPTION
# Description
Implements the ability for partners to specify the `Surplus` and `PriceImprovement` fee policy (in addition to the already available `Volume` policy).
The protocol enforces a maximum ratio of the order's total volume that can be captured via partner fees. Because `Surplus` and `PriceImpact` fee policies also configure a `max_volume_factor` we are able to cap these fees as well using the global volume limit.

# Changes
- slight refactor of the autopilot logic that computes the final partner fee policies (the `PriveImprovement` fee requires a reference quote)
- added logic to apply the new partner fee policies in the autopilot
- added backwards compatible (de)serialization logic for the new partner fee variants in the `appdata` crate

## How to test
- extended unit tests for new partner fee policy (de)serialization logic
- added new e2e test that verifies that the autopilot attached the correct fee policies to the order
    - also tests the logic to limit the new partner fees to the global volume cap