### PR TITLE
Reinit subgraph liquidity sources

### DIFF
--- a/crates/driver/src/boundary/liquidity/balancer/v2/mod.rs
+++ b/crates/driver/src/boundary/liquidity/balancer/v2/mod.rs
@@ -94,7 +94,7 @@ pub fn collector(
     Box::new(BackgroundInitLiquiditySource::new(
         "balancer-v2",
         init,
-        TEN_MINUTES, // retry interval
+        TEN_MINUTES,
         reinit_interval,
     )) as Box<_>
 }

--- a/crates/driver/src/boundary/liquidity/balancer/v2/mod.rs
+++ b/crates/driver/src/boundary/liquidity/balancer/v2/mod.rs
@@ -90,10 +90,12 @@ pub fn collector(
         async move { init_liquidity(&eth, &block_stream, block_retriever.clone(), &config).await }
     };
     const TEN_MINUTES: std::time::Duration = std::time::Duration::from_secs(10 * 60);
+    const ONE_HOUR: std::time::Duration = std::time::Duration::from_secs(60 * 60);
     Box::new(BackgroundInitLiquiditySource::new(
         "balancer-v2",
         init,
-        TEN_MINUTES,
+        TEN_MINUTES,    // retry interval
+        Some(ONE_HOUR), // reinit interval
     )) as Box<_>
 }
 

--- a/crates/driver/src/boundary/liquidity/balancer/v2/mod.rs
+++ b/crates/driver/src/boundary/liquidity/balancer/v2/mod.rs
@@ -81,6 +81,7 @@ pub fn collector(
     config: &infra::liquidity::config::BalancerV2,
 ) -> Box<dyn LiquidityCollecting> {
     let eth = Arc::new(eth.with_metric_label("balancerV2".into()));
+    let reinit_interval = config.reinit_interval;
     let config = Arc::new(config.clone());
     let init = move || {
         let eth = eth.clone();
@@ -90,12 +91,11 @@ pub fn collector(
         async move { init_liquidity(&eth, &block_stream, block_retriever.clone(), &config).await }
     };
     const TEN_MINUTES: std::time::Duration = std::time::Duration::from_secs(10 * 60);
-    const ONE_HOUR: std::time::Duration = std::time::Duration::from_secs(60 * 60);
     Box::new(BackgroundInitLiquiditySource::new(
         "balancer-v2",
         init,
-        TEN_MINUTES,    // retry interval
-        Some(ONE_HOUR), // reinit interval
+        TEN_MINUTES, // retry interval
+        reinit_interval,
     )) as Box<_>
 }
 

--- a/crates/driver/src/boundary/liquidity/uniswap/v3.rs
+++ b/crates/driver/src/boundary/liquidity/uniswap/v3.rs
@@ -107,6 +107,7 @@ pub fn collector(
 ) -> Box<dyn LiquidityCollecting> {
     let eth = Arc::new(eth.with_metric_label("uniswapV3".into()));
     let config = Arc::new(Clone::clone(config));
+    let reinit_interval = config.reinit_interval;
     let init = move || {
         let eth = eth.clone();
         let block_retriever = block_retriever.clone();
@@ -114,12 +115,11 @@ pub fn collector(
         async move { init_liquidity(&eth, block_retriever.clone(), &config).await }
     };
     const TEN_MINUTES: std::time::Duration = std::time::Duration::from_secs(10 * 60);
-    const ONE_HOUR: std::time::Duration = std::time::Duration::from_secs(60 * 60);
     Box::new(BackgroundInitLiquiditySource::new(
         "uniswap-v3",
         init,
-        TEN_MINUTES,    // retry interval
-        Some(ONE_HOUR), // reinit interval
+        TEN_MINUTES, // retry interval
+        reinit_interval,
     )) as Box<_>
 }
 

--- a/crates/driver/src/boundary/liquidity/uniswap/v3.rs
+++ b/crates/driver/src/boundary/liquidity/uniswap/v3.rs
@@ -118,7 +118,7 @@ pub fn collector(
     Box::new(BackgroundInitLiquiditySource::new(
         "uniswap-v3",
         init,
-        TEN_MINUTES, // retry interval
+        TEN_MINUTES,
         reinit_interval,
     )) as Box<_>
 }

--- a/crates/driver/src/boundary/liquidity/uniswap/v3.rs
+++ b/crates/driver/src/boundary/liquidity/uniswap/v3.rs
@@ -114,10 +114,12 @@ pub fn collector(
         async move { init_liquidity(&eth, block_retriever.clone(), &config).await }
     };
     const TEN_MINUTES: std::time::Duration = std::time::Duration::from_secs(10 * 60);
+    const ONE_HOUR: std::time::Duration = std::time::Duration::from_secs(60 * 60);
     Box::new(BackgroundInitLiquiditySource::new(
         "uniswap-v3",
         init,
-        TEN_MINUTES,
+        TEN_MINUTES,    // retry interval
+        Some(ONE_HOUR), // reinit interval
     )) as Box<_>
 }
 

--- a/crates/driver/src/infra/config/file/load.rs
+++ b/crates/driver/src/infra/config/file/load.rs
@@ -217,8 +217,10 @@ pub async fn load(chain: Chain, path: &Path) -> infra::Config {
                         preset,
                         max_pools_to_initialize,
                         graph_url,
+                        reinit_interval,
                     } => liquidity::config::UniswapV3 {
                         max_pools_to_initialize,
+                        reinit_interval,
                         ..match preset {
                             file::UniswapV3Preset::UniswapV3 => {
                                 liquidity::config::UniswapV3::uniswap_v3(&graph_url, chain)
@@ -230,10 +232,12 @@ pub async fn load(chain: Chain, path: &Path) -> infra::Config {
                         router,
                         max_pools_to_initialize,
                         graph_url,
+                        reinit_interval,
                     } => liquidity::config::UniswapV3 {
                         router: router.into(),
                         max_pools_to_initialize,
                         graph_url,
+                        reinit_interval,
                     },
                 })
                 .collect(),
@@ -247,8 +251,10 @@ pub async fn load(chain: Chain, path: &Path) -> infra::Config {
                         preset,
                         pool_deny_list,
                         graph_url,
+                        reinit_interval,
                     } => liquidity::config::BalancerV2 {
                         pool_deny_list: pool_deny_list.clone(),
+                        reinit_interval,
                         ..match preset {
                             file::BalancerV2Preset::BalancerV2 => {
                                 liquidity::config::BalancerV2::balancer_v2(&graph_url, chain)
@@ -265,6 +271,7 @@ pub async fn load(chain: Chain, path: &Path) -> infra::Config {
                         composable_stable,
                         pool_deny_list,
                         graph_url,
+                        reinit_interval,
                     } => liquidity::config::BalancerV2 {
                         vault: vault.into(),
                         weighted: weighted
@@ -286,6 +293,7 @@ pub async fn load(chain: Chain, path: &Path) -> infra::Config {
                             .collect(),
                         pool_deny_list: pool_deny_list.clone(),
                         graph_url,
+                        reinit_interval,
                     },
                 })
                 .collect(),

--- a/crates/driver/src/infra/config/file/mod.rs
+++ b/crates/driver/src/infra/config/file/mod.rs
@@ -544,6 +544,9 @@ enum UniswapV3Config {
         max_pools_to_initialize: usize,
 
         graph_url: Url,
+
+        #[serde(with = "humantime_serde", default = "default_reinit_interval")]
+        reinit_interval: Option<Duration>,
     },
 
     #[serde(rename_all = "kebab-case")]
@@ -557,6 +560,9 @@ enum UniswapV3Config {
 
         /// The URL used to connect to uniswap v3 subgraph client.
         graph_url: Url,
+
+        #[serde(with = "humantime_serde", default = "default_reinit_interval")]
+        reinit_interval: Option<Duration>,
     },
 }
 
@@ -585,6 +591,11 @@ enum BalancerV2Config {
 
         /// The URL used to connect to balancer v2 subgraph client.
         graph_url: Url,
+
+        /// How often the liquidity source should be reinitialized to get
+        /// access to new pools.
+        #[serde(with = "humantime_serde", default = "default_reinit_interval")]
+        reinit_interval: Option<Duration>,
     },
 
     #[serde(rename_all = "kebab-case")]
@@ -621,6 +632,11 @@ enum BalancerV2Config {
 
         /// The URL used to connect to balancer v2 subgraph client.
         graph_url: Url,
+
+        /// How often the liquidity source should be reinitialized to get
+        /// access to new pools.
+        #[serde(with = "humantime_serde", default = "default_reinit_interval")]
+        reinit_interval: Option<Duration>,
     },
 }
 
@@ -628,6 +644,10 @@ enum BalancerV2Config {
 #[serde(rename_all = "kebab-case", deny_unknown_fields)]
 enum BalancerV2Preset {
     BalancerV2,
+}
+
+fn default_reinit_interval() -> Option<Duration> {
+    Some(Duration::from_secs(12 * 60 * 60))
 }
 
 #[derive(Clone, Debug, Deserialize)]

--- a/crates/driver/src/infra/config/file/mod.rs
+++ b/crates/driver/src/infra/config/file/mod.rs
@@ -545,6 +545,8 @@ enum UniswapV3Config {
 
         graph_url: Url,
 
+        /// How often the liquidity source should be reinitialized to get
+        /// access to new pools.
         #[serde(with = "humantime_serde", default = "default_reinit_interval")]
         reinit_interval: Option<Duration>,
     },
@@ -561,6 +563,8 @@ enum UniswapV3Config {
         /// The URL used to connect to uniswap v3 subgraph client.
         graph_url: Url,
 
+        /// How often the liquidity source should be reinitialized to get
+        /// access to new pools.
         #[serde(with = "humantime_serde", default = "default_reinit_interval")]
         reinit_interval: Option<Duration>,
     },

--- a/crates/driver/src/infra/liquidity/config.rs
+++ b/crates/driver/src/infra/liquidity/config.rs
@@ -148,6 +148,10 @@ pub struct UniswapV3 {
 
     /// The URL used to connect to uniswap v3 subgraph client.
     pub graph_url: Url,
+
+    /// How often the liquidity source should be reinitialized to
+    /// become aware of new pools.
+    pub reinit_interval: Option<Duration>,
 }
 
 impl UniswapV3 {
@@ -158,6 +162,7 @@ impl UniswapV3 {
             router: deployment_address(contracts::UniswapV3SwapRouter::raw_contract(), chain)?,
             max_pools_to_initialize: 100,
             graph_url: graph_url.clone(),
+            reinit_interval: None,
         })
     }
 }
@@ -192,6 +197,10 @@ pub struct BalancerV2 {
 
     /// The base URL used to connect to balancer v2 subgraph client.
     pub graph_url: Url,
+
+    /// How often the liquidty source should be re-initialized to become
+    /// aware of new pools.
+    pub reinit_interval: Option<Duration>,
 }
 
 impl BalancerV2 {
@@ -231,6 +240,7 @@ impl BalancerV2 {
             ]),
             pool_deny_list: Vec::new(),
             graph_url: graph_url.clone(),
+            reinit_interval: None,
         })
     }
 }

--- a/crates/solver/src/liquidity_collector.rs
+++ b/crates/solver/src/liquidity_collector.rs
@@ -62,7 +62,7 @@ impl<L> BackgroundInitLiquiditySource<L> {
         label: &str,
         init: I,
         retry_init_timeout: Duration,
-        reinit_timeout: Option<Duration>,
+        reinit_interval: Option<Duration>,
     ) -> Self
     where
         I: Fn() -> F + Send + Sync + 'static,
@@ -95,7 +95,7 @@ impl<L> BackgroundInitLiquiditySource<L> {
                                 .with_label_values(&[&inner_label])
                                 .inc();
 
-                            match reinit_timeout {
+                            match reinit_interval {
                                 Some(timeout) => tokio::time::sleep(timeout).await,
                                 None => break,
                             }

--- a/crates/solver/src/liquidity_collector.rs
+++ b/crates/solver/src/liquidity_collector.rs
@@ -232,10 +232,11 @@ mod test {
         );
 
         // wait for 5 full re-init cycles
-        tokio::time::sleep(tokio::time::Duration::from_millis(55)).await;
+        tokio::time::sleep(tokio::time::Duration::from_millis(50)).await;
 
-        // init loop ran expected number of times
-        assert_eq!(counter.load(Ordering::SeqCst), 5);
+        // init loop ran expected number of times (note that we allow for slight
+        // variance due to our very short timeouts here).
+        assert!((5..=6).contains(&counter.load(Ordering::SeqCst)));
         let liquidity = source
             .get_liquidity(Default::default(), Block::Recent)
             .await;
@@ -244,6 +245,6 @@ mod test {
         let gauge = Metrics::get()
             .liquidity_enabled
             .with_label_values(&["fake"]);
-        assert_eq!(gauge.get(), 5);
+        assert!((5..=6).contains(&gauge.get()));
     }
 }


### PR DESCRIPTION
# Description
Currently our subgraph based liquidity sources (balancer v2, uniswap v3) fetch the list of known pools only on startup. This currently leads to frequent requests why some pool does not get indexed (e.g. baseline router is not returning quotes although there is a pool it could use).

# Changes
The optimal solution would be to build our indexing logic such that it only queries pools that were created since we last checked. However, that would be pretty involved and overall it doesn't make much sense to spend much effort on liquidity indexing since none of the competitive solvers use our indexed liquidity anyway.
To keep the effort to a minimum I adjusted the `BackgroundInitLiquiditySource` logic such that it can be configured to periodically rerun the initialization logic. This is effectively equivalent to restarting the driver manually (in terms of discovering new pools).

Since using the subgraph costs credits the default `reinit_interval` is a conservative `12h` but can be overwritten in the driver config file.

## How to test
Added a unit test to verify that the init logic runs multiple times if a `reinit_interval` was provided.