### PR TITLE
Update Fee Amount docs

### DIFF
--- a/crates/orderbook/openapi.yml
+++ b/crates/orderbook/openapi.yml
@@ -687,7 +687,7 @@ components:
         appData:
           $ref: "#/components/schemas/AppDataHash"
         feeAmount:
-          description: feeRatio * sellAmount + minimal_fee in atoms.
+          description: sellAmount in atoms to cover network fees. Needs to be zero (and incorporated into the limit price) when placing the order
           allOf:
             - $ref: "#/components/schemas/TokenAmount"
         kind:


### PR DESCRIPTION
The current description for the fee amount is misleading and outdated. It's the raw sell token amount. The field is referenced both in the quote response as well as in the order placement payload.

In the latter it has to be zero as otherwise the order will be rejected (wo no longer allow for upfront fixed fees).

cc @anxolin 