### PR TITLE
Calculate reference scores

### DIFF
--- a/crates/autopilot/src/database/competition.rs
+++ b/crates/autopilot/src/database/competition.rs
@@ -1,5 +1,5 @@
 use {
-    crate::domain::competition::ReferenceScores,
+    crate::domain::competition::{LegacyScores, ReferenceScores},
     anyhow::Context,
     database::{
         Address,
@@ -19,9 +19,7 @@ use {
 #[derive(Clone, Default, Debug)]
 pub struct Competition {
     pub auction_id: AuctionId,
-    pub winner: H160,
-    pub winning_score: U256,
-    pub reference_score: U256,
+    pub legacy_scores: LegacyScores,
     pub reference_scores: ReferenceScores,
     /// Addresses to which the CIP20 participation rewards will be payed out.
     /// Usually the same as the solver addresses.
@@ -60,9 +58,9 @@ impl super::Postgres {
             &mut ex,
             database::settlement_scores::Score {
                 auction_id: competition.auction_id,
-                winner: ByteArray(competition.winner.0),
-                winning_score: u256_to_big_decimal(&competition.winning_score),
-                reference_score: u256_to_big_decimal(&competition.reference_score),
+                winner: ByteArray(competition.legacy_scores.winner.0),
+                winning_score: u256_to_big_decimal(&competition.legacy_scores.winning_score),
+                reference_score: u256_to_big_decimal(&competition.legacy_scores.reference_score),
                 block_deadline: competition
                     .block_deadline
                     .try_into()

--- a/crates/autopilot/src/database/competition.rs
+++ b/crates/autopilot/src/database/competition.rs
@@ -1,5 +1,5 @@
 use {
-    crate::domain::competition::ReferenceScore,
+    crate::domain::competition::ReferenceScores,
     anyhow::Context,
     database::{
         Address,
@@ -22,7 +22,7 @@ pub struct Competition {
     pub winner: H160,
     pub winning_score: U256,
     pub reference_score: U256,
-    pub reference_scores: Vec<ReferenceScore>,
+    pub reference_scores: ReferenceScores,
     /// Addresses to which the CIP20 participation rewards will be payed out.
     /// Usually the same as the solver addresses.
     pub participants: HashSet<H160>,
@@ -79,11 +79,13 @@ impl super::Postgres {
         let reference_scores = competition
             .reference_scores
             .iter()
-            .map(|score| database::reference_scores::Score {
-                auction_id: competition.auction_id,
-                solver: ByteArray(score.solver.0),
-                reference_score: u256_to_big_decimal(&score.reference_score),
-            })
+            .map(
+                |(solver, reference_score)| database::reference_scores::Score {
+                    auction_id: competition.auction_id,
+                    solver: ByteArray(solver.0),
+                    reference_score: u256_to_big_decimal(reference_score),
+                },
+            )
             .collect::<Vec<_>>();
 
         database::reference_scores::insert(&mut ex, &reference_scores)

--- a/crates/autopilot/src/domain/competition/auction_mechanism/mod.rs
+++ b/crates/autopilot/src/domain/competition/auction_mechanism/mod.rs
@@ -12,7 +12,6 @@ use {
 #[error("no winners found")]
 pub struct NoWinners;
 
-#[derive(Default)]
 pub struct CompetitionData {
     // TODO: for now we specify a single winner as the database still expects it
     // After https://github.com/cowprotocol/services/issues/3350, it will no longer be necessary and we will be able to return only the vec of ReferenceScore

--- a/crates/autopilot/src/domain/competition/auction_mechanism/mod.rs
+++ b/crates/autopilot/src/domain/competition/auction_mechanism/mod.rs
@@ -27,7 +27,9 @@ impl CompetitionData {
     }
 }
 
-#[derive(Default)]
+/// Legacy scores support only a single winner. This structure remains to avoid
+/// breaking changes in the database schema. Will be removed in the future.
+#[derive(Clone, Default, Debug)]
 pub struct LegacyScores {
     pub winner: H160,
     pub winning_score: U256,

--- a/crates/autopilot/src/domain/competition/auction_mechanism/mod.rs
+++ b/crates/autopilot/src/domain/competition/auction_mechanism/mod.rs
@@ -5,6 +5,7 @@ use {
     super::{Participant, Unranked},
     crate::domain::Auction,
     primitive_types::{H160, U256},
+    std::collections::{HashMap, hash_map::Iter},
 };
 
 #[derive(Debug, thiserror::Error)]
@@ -17,7 +18,7 @@ pub struct CompetitionData {
     // After https://github.com/cowprotocol/services/issues/3350, it will no longer be necessary and we will be able to return only the vec of ReferenceScore
     pub legacy_scores: LegacyScores,
     pub solutions: Vec<Participant>,
-    pub reference_scores: Vec<ReferenceScore>,
+    pub reference_scores: ReferenceScores,
 }
 
 impl CompetitionData {
@@ -33,10 +34,14 @@ pub struct LegacyScores {
     pub reference_score: U256,
 }
 
+/// Contains reference scores per solver address.
 #[derive(Clone, Default, Debug)]
-pub struct ReferenceScore {
-    pub solver: H160,
-    pub reference_score: U256,
+pub struct ReferenceScores(HashMap<H160, U256>);
+
+impl ReferenceScores {
+    pub fn iter(&self) -> Iter<'_, H160, U256> {
+        self.0.iter()
+    }
 }
 
 /// The following trait allows to implement custom auction mechanism logic

--- a/crates/autopilot/src/domain/competition/auction_mechanism/single_winner.rs
+++ b/crates/autopilot/src/domain/competition/auction_mechanism/single_winner.rs
@@ -1,11 +1,11 @@
 use {
-    super::{AuctionMechanism, NoWinners, Participant, ReferenceScore, Unranked},
+    super::{AuctionMechanism, NoWinners, Participant, Unranked},
     crate::{
         domain::{
             Auction,
             competition::{
                 TradedOrder,
-                auction_mechanism::{CompetitionData, LegacyScores},
+                auction_mechanism::{CompetitionData, LegacyScores, ReferenceScores},
             },
         },
         infra,
@@ -233,17 +233,14 @@ impl AuctionMechanism for SingleSurplusAuctionMechanism {
                     .ok()
                     .map(|scores| scores.winning_score)
                     .unwrap_or_default();
-                ReferenceScore {
-                    solver: solver.0,
-                    reference_score: winning_score,
-                }
+                (solver.0, winning_score)
             })
-            .collect::<Vec<_>>();
+            .collect::<HashMap<_, _>>();
 
         CompetitionData {
             legacy_scores,
             solutions: ranked_solutions,
-            reference_scores,
+            reference_scores: ReferenceScores(reference_scores),
         }
     }
 }

--- a/crates/autopilot/src/domain/competition/auction_mechanism/single_winner.rs
+++ b/crates/autopilot/src/domain/competition/auction_mechanism/single_winner.rs
@@ -222,13 +222,12 @@ impl AuctionMechanism for SingleSurplusAuctionMechanism {
             .map(|participant| participant.driver().submission_address)
             .unique()
             .map(|solver| {
-                let solutions_without_solver = solutions
+                let solutions_without_solver = filtered_solutions
                     .iter()
                     .filter(|participant| participant.driver().submission_address != solver)
                     .cloned()
                     .collect::<Vec<_>>();
-                let filtered_solutions = self.filter_solutions(auction, &solutions_without_solver);
-                let winning_solutions = self.rank_solutions(&filtered_solutions);
+                let winning_solutions = self.rank_solutions(&solutions_without_solver);
                 let winning_score = self
                     .compute_legacy_scores(&winning_solutions)
                     .ok()

--- a/crates/autopilot/src/domain/competition/auction_mechanism/single_winner.rs
+++ b/crates/autopilot/src/domain/competition/auction_mechanism/single_winner.rs
@@ -217,6 +217,7 @@ impl AuctionMechanism for SingleSurplusAuctionMechanism {
 
         let reference_scores = ranked_solutions
             .iter()
+            // Reference scores need to be collected only for winning solvers
             .filter(|participant| participant.is_winner())
             .map(|participant| participant.driver().submission_address)
             .unique()

--- a/crates/autopilot/src/domain/competition/mod.rs
+++ b/crates/autopilot/src/domain/competition/mod.rs
@@ -12,7 +12,7 @@ mod participation_guard;
 pub use {
     auction_mechanism::{
         AuctionMechanism,
-        ComputedScores,
+        CompetitionData,
         ReferenceScore,
         SingleSurplusAuctionMechanism,
     },

--- a/crates/autopilot/src/domain/competition/mod.rs
+++ b/crates/autopilot/src/domain/competition/mod.rs
@@ -13,7 +13,7 @@ pub use {
     auction_mechanism::{
         AuctionMechanism,
         CompetitionData,
-        ReferenceScore,
+        ReferenceScores,
         SingleSurplusAuctionMechanism,
     },
     participant::{Participant, Ranked, Unranked},

--- a/crates/autopilot/src/domain/competition/mod.rs
+++ b/crates/autopilot/src/domain/competition/mod.rs
@@ -13,6 +13,7 @@ pub use {
     auction_mechanism::{
         AuctionMechanism,
         CompetitionData,
+        LegacyScores,
         ReferenceScores,
         SingleSurplusAuctionMechanism,
     },

--- a/crates/autopilot/src/run_loop.rs
+++ b/crates/autopilot/src/run_loop.rs
@@ -445,9 +445,7 @@ impl RunLoop {
         };
         let competition = Competition {
             auction_id: auction.id,
-            winner: competition_data.legacy_scores.winner,
-            winning_score: competition_data.legacy_scores.winning_score,
-            reference_score: competition_data.legacy_scores.reference_score,
+            legacy_scores: competition_data.legacy_scores.clone(),
             reference_scores: competition_data.reference_scores.clone(),
             participants,
             prices: auction

--- a/crates/database/src/reference_scores.rs
+++ b/crates/database/src/reference_scores.rs
@@ -51,7 +51,7 @@ mod tests {
         let mut db = db.begin().await.unwrap();
         crate::clear_DANGER_(&mut db).await.unwrap();
 
-        let input = vec![];
+        let input: Vec<Score> = vec![];
         insert(&mut db, &input).await.unwrap();
         let output = fetch(&mut db, 1).await.unwrap();
         assert!(output.is_empty());

--- a/crates/e2e/tests/e2e/limit_orders.rs
+++ b/crates/e2e/tests/e2e/limit_orders.rs
@@ -548,6 +548,21 @@ async fn two_limit_orders_multiple_winners_test(web3: Web3) {
         solver_b_reference_score.reference_score,
         solver_a_winning_solutions[0].score
     );
+
+    // Ensure the new scores are computed the same way
+    let settlement_scores = database::settlement_scores::fetch(&mut ex, competition.auction_id)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(H160(settlement_scores.winner.0), solver_a.address());
+    assert_eq!(
+        settlement_scores.reference_score,
+        solver_b_winning_solutions[0].score
+    );
+    assert_eq!(
+        settlement_scores.winning_score,
+        solver_a_winning_solutions[0].score
+    );
 }
 
 async fn too_many_limit_orders_test(web3: Web3) {

--- a/crates/e2e/tests/e2e/limit_orders.rs
+++ b/crates/e2e/tests/e2e/limit_orders.rs
@@ -528,8 +528,26 @@ async fn two_limit_orders_multiple_winners_test(web3: Web3) {
     let reference_scores = database::reference_scores::fetch(&mut ex, competition.auction_id)
         .await
         .unwrap();
-    // TODO: support multiple winners
-    assert_eq!(reference_scores.len(), 1);
+    assert_eq!(reference_scores.len(), 2);
+
+    let solver_a_reference_score = reference_scores
+        .iter()
+        .find(|score| H160(score.solver.0) == solver_a.address())
+        .unwrap();
+    // The reference score for solver_a is the score of solver_b's winning solution
+    assert_eq!(
+        solver_a_reference_score.reference_score,
+        solver_b_winning_solutions[0].score
+    );
+    let solver_b_reference_score = reference_scores
+        .iter()
+        .find(|score| H160(score.solver.0) == solver_b.address())
+        .unwrap();
+    // and vice versa
+    assert_eq!(
+        solver_b_reference_score.reference_score,
+        solver_a_winning_solutions[0].score
+    );
 }
 
 async fn too_many_limit_orders_test(web3: Web3) {


### PR DESCRIPTION
# Description
This PR introduces the reference scores calculation, which now supports multiple winners for a single competition. The logic is the following:

- Filter solutions and find winners for the current competition
- For each winner:
	- Remove their solutions from the set of solutions that survived the filtering
	- Find winners for the updated set of solutions
	- The reference score for this solver would be the sum of all the new winning solution scores
- Store the calculated reference scores in the DB

Basically, the sum of all winning solution scores if the reference solver had not participated.

# Changes

- [ ] Refactored the auction mechanism interface a bit
- [ ] The new reference scores computation

## How to test
Updated e2e tests

## Related Issues

Task 3 from #3350