### PR TITLE
stale bot should ignore issues marked as tech-dept

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -16,4 +16,4 @@ jobs:
           stale-issue-message: 'This issue has been marked as stale because it has been inactive a while. Please update this issue or it will be automatically closed.'
           stale-pr-label: stale
           exempt-pr-labels: 'blocked'
-          exempt-issue-labels: 'blocked, help wanted'
+          exempt-issue-labels: "blocked, help wanted, tech-dept"


### PR DESCRIPTION
# Description

After reviewing the backlog of issues quiet a few were marked as tech-dept to be planned for in an upcoming cycle so it makes no sense to close them by the stale bot

see https://github.com/cowprotocol/services/issues?q=is%3Aissue%20state%3Aopen%20label%3Atech-debt