### PR TITLE
Revert back to `foundry v1.0.0` for forked e2e tests

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -140,6 +140,10 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
       - run: rustup toolchain install stable --profile minimal
       - uses: foundry-rs/foundry-toolchain@v1
+        with:
+          # the latest version introduced a bug caused forked node tests to fail
+          # only switch back to latest stable version after it was fixed in anvil
+          version: v1.0.0
       - uses: Swatinem/rust-cache@v2
       # Start the build process in the background. The following cargo test command will automatically
       # wait for the build process to be done before proceeding.


### PR DESCRIPTION
# Description
Seems like the latest `foundry` release (v1.1.0) introduced a bug in anvil that causes our forked e2e tests to fail.

It looks like there is some sort of race condition that can cause `anvil` to get stuck (perhaps deadlock?) after an `evm_mine` call. This is based on observations from this [test run](https://github.com/cowprotocol/services/actions/runs/14878604711/job/41781127003?pr=3377).
Here we can see that at some point our calls to our price estimators are timing out after 5s. Exactly 5s before that we see that `anvil` started to process an `evm_mine` request but never finished (finished requests result in logs like `finished processing request` from the `tower` crate).

Screenshot to avoid logs from the job getting deleted in the future.
<img width="1526" alt="Screenshot 2025-05-07 at 08 54 22" src="https://github.com/user-attachments/assets/d39329f3-363e-4a97-8d15-31fe61f70874" />


# Changes
Reverts back to foundry 1.0.0 (only for forked tests)

# TODO
`git bisect` to find the problematic commit and open an issue in the `foundry` repo.

## How to test
all tests should pass again