### PR TITLE
Trivial: Use NonZeroUsize for CLI args

### DIFF
--- a/crates/autopilot/src/arguments.rs
+++ b/crates/autopilot/src/arguments.rs
@@ -235,12 +235,12 @@ pub struct Arguments {
     #[clap(long, env, default_value = "1")]
     /// The maximum number of winners per auction. Each winner will be allowed
     /// to settle their winning orders at the same time.
-    pub max_winners_per_auction: usize,
+    pub max_winners_per_auction: NonZeroUsize,
 
     #[clap(long, env, default_value = "3")]
     /// The maximum allowed number of solutions to be proposed from a single
     /// solver, per auction.
-    pub max_solutions_per_solver: usize,
+    pub max_solutions_per_solver: NonZeroUsize,
 
     /// Archive node URL used to index CoW AMM
     #[clap(long, env)]

--- a/crates/autopilot/src/run_loop.rs
+++ b/crates/autopilot/src/run_loop.rs
@@ -43,6 +43,7 @@ use {
     shared::token_list::AutoUpdatingTokenList,
     std::{
         collections::{HashMap, HashSet},
+        num::NonZeroUsize,
         sync::Arc,
         time::{Duration, Instant},
     },
@@ -58,8 +59,8 @@ pub struct Config {
     /// allowed to start before it has to re-synchronize to the blockchain
     /// by waiting for the next block to appear.
     pub max_run_loop_delay: Duration,
-    pub max_winners_per_auction: usize,
-    pub max_solutions_per_solver: usize,
+    pub max_winners_per_auction: NonZeroUsize,
+    pub max_solutions_per_solver: NonZeroUsize,
 }
 
 pub struct RunLoop {
@@ -560,7 +561,7 @@ impl RunLoop {
             let driver = participant.driver().name.clone();
             let count = counter.entry(driver).or_insert(0);
             *count += 1;
-            *count <= self.config.max_solutions_per_solver
+            *count <= self.config.max_solutions_per_solver.get()
         });
 
         // Filter out solutions that are not fair
@@ -602,7 +603,7 @@ impl RunLoop {
                     .collect::<HashSet<_>>();
 
                 let is_winner = swapped_tokens.is_disjoint(&already_swapped_tokens)
-                    && winners < self.config.max_winners_per_auction;
+                    && winners < self.config.max_winners_per_auction.get();
 
                 already_swapped_tokens.extend(swapped_tokens);
                 winners += usize::from(is_winner);

--- a/crates/autopilot/src/shadow.rs
+++ b/crates/autopilot/src/shadow.rs
@@ -26,6 +26,7 @@ use {
     std::{
         cmp,
         collections::{HashMap, HashSet},
+        num::NonZeroUsize,
         sync::Arc,
         time::Duration,
     },
@@ -41,7 +42,7 @@ pub struct RunLoop {
     solve_deadline: Duration,
     liveness: Arc<Liveness>,
     current_block: CurrentBlockWatcher,
-    max_winners_per_auction: usize,
+    max_winners_per_auction: NonZeroUsize,
 }
 
 impl RunLoop {
@@ -52,7 +53,7 @@ impl RunLoop {
         solve_deadline: Duration,
         liveness: Arc<Liveness>,
         current_block: CurrentBlockWatcher,
-        max_winners_per_auction: usize,
+        max_winners_per_auction: NonZeroUsize,
     ) -> Self {
         Self {
             orderbook,
@@ -234,7 +235,7 @@ impl RunLoop {
                 if swapped_tokens.is_disjoint(&already_swapped_tokens) {
                     winners.push(participant);
                     already_swapped_tokens.extend(swapped_tokens);
-                    if winners.len() >= self.max_winners_per_auction {
+                    if winners.len() >= self.max_winners_per_auction.get() {
                         break;
                     }
                 }


### PR DESCRIPTION
# Description
It doesn't make sense to allow the value `0` for `--max-winners-per-auction` and `--max-solutions-per-solver` so we switched from `usize` to `NonZeroUsize`.