### PR TITLE
Abstract winner selection

### DIFF
--- a/crates/autopilot/src/domain/competition/mod.rs
+++ b/crates/autopilot/src/domain/competition/mod.rs
@@ -7,6 +7,7 @@ use {
 
 mod participant;
 mod participation_guard;
+pub mod winner_selection;
 
 pub use {
     participant::{Participant, Ranked, Unranked},
@@ -79,7 +80,7 @@ pub struct TradedOrder {
     pub executed_buy: eth::TokenAmount,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, PartialOrd, Display)]
+#[derive(Debug, Clone, Copy, PartialEq, PartialOrd, Display, Default)]
 pub struct Score(eth::Ether);
 
 impl Score {

--- a/crates/autopilot/src/domain/competition/winner_selection/max_score.rs
+++ b/crates/autopilot/src/domain/competition/winner_selection/max_score.rs
@@ -1,0 +1,166 @@
+//! Winner Selection:
+//! Simply picks the 1 solution with the highest overall score.
+//!
+//! Fairness Guarantees:
+//! This winner selection does not have any inherent fairness guarantees for
+//! individual orders. However, each order's execution is basically "insured" by
+//! EBBO (ethereum best bid offer) - that is an order should get executed at
+//! least as good as possible using very popular onchain liquidity sources. Each
+//! solver can opt-in to have their solutions invalidated if the estimated total
+//! EBBO violations would exceed a configurable threshold.
+//!
+//! Reference Score:
+//! The reference score is simply the second highest reported score of all
+//! solutions. If there is only 1 solution the reference score is 0.
+use {
+    super::Arbitrator,
+    crate::domain::{
+        Auction,
+        competition::{Participant, Score, TradedOrder, Unranked},
+        eth,
+    },
+    ethcontract::U256,
+    std::collections::HashMap,
+};
+
+pub struct Config;
+
+impl Arbitrator for Config {
+    fn mark_winners(&self, mut solutions: Vec<Participant<Unranked>>) -> Vec<Participant> {
+        // The current system theoretically already supports multiple winners. However,
+        // it was never activated because the rewards mechanism was never
+        // decided. To make the migration easier we revert back to only allowing
+        // 1 winner. And that is simply the solution with the highest total
+        // score.
+        solutions.sort_unstable_by_key(|participant| {
+            std::cmp::Reverse(participant.solution().score().get().0)
+        });
+        solutions
+            .into_iter()
+            .enumerate()
+            .map(|(index, solution)| solution.rank(index == 0))
+            .collect()
+    }
+
+    fn compute_reference_scores(&self, solutions: &[Participant]) -> HashMap<eth::Address, Score> {
+        // this will hold at most 1 score but the interface needs to support multiple
+        // scores to fit the interface
+        let mut reference_scores = HashMap::default();
+        if let Some(winner) = solutions.first() {
+            let runner_up = solutions
+                .get(1)
+                .map(|s| s.solution().score())
+                .unwrap_or_default();
+            reference_scores.insert(winner.driver().submission_address, runner_up);
+        }
+        reference_scores
+    }
+
+    fn filter_solutions(
+        &self,
+        solutions: Vec<Participant<Unranked>>,
+        auction: &Auction,
+    ) -> Vec<Participant<Unranked>> {
+        solutions
+            .iter()
+            .enumerate()
+            .filter_map(|(index, participant)| {
+                if is_solution_fair(participant, &solutions[index..], auction) {
+                    Some(participant.clone())
+                } else {
+                    tracing::warn!(
+                        invalidated = participant.driver().name,
+                        "fairness check invalidated of solution"
+                    );
+                    None
+                }
+            })
+            .collect()
+    }
+}
+
+/// Returns true if solution is fair to other solutions.
+fn is_solution_fair(
+    solution: &Participant<Unranked>,
+    others: &[Participant<Unranked>],
+    auction: &Auction,
+) -> bool {
+    let Some(fairness_threshold) = solution.driver().fairness_threshold else {
+        return true;
+    };
+
+    // Returns the surplus difference in the buy token if `left`
+    // is better for the trader than `right`, or 0 otherwise.
+    // This takes differently partial fills into account.
+    let improvement_in_buy = |left: &TradedOrder, right: &TradedOrder| {
+        // If `left.sell / left.buy < right.sell / right.buy`, left is "better" as the
+        // trader either sells less or gets more. This can be reformulated as
+        // `right.sell * left.buy > left.sell * right.buy`.
+        let right_sell_left_buy = right.executed_sell.0.full_mul(left.executed_buy.0);
+        let left_sell_right_buy = left.executed_sell.0.full_mul(right.executed_buy.0);
+        let improvement = right_sell_left_buy
+            .checked_sub(left_sell_right_buy)
+            .unwrap_or_default();
+
+        // The difference divided by the original sell amount is the improvement in buy
+        // token. Casting to U256 is safe because the difference is smaller than the
+        // original product, which if re-divided by right.sell must fit in U256.
+        improvement
+            .checked_div(right.executed_sell.0.into())
+            .map(|v| U256::try_from(v).expect("improvement in buy fits in U256"))
+            .unwrap_or_default()
+    };
+
+    // Record best execution per order
+    let mut best_executions = HashMap::new();
+    for other in others {
+        for (uid, execution) in other.solution().orders() {
+            best_executions
+                .entry(uid)
+                .and_modify(|best_execution| {
+                    if !improvement_in_buy(execution, best_execution).is_zero() {
+                        *best_execution = *execution;
+                    }
+                })
+                .or_insert(*execution);
+        }
+    }
+
+    // Check if the solution contains an order whose execution in the
+    // solution is more than `fairness_threshold` worse than the
+    // order's best execution across all solutions
+    let unfair = solution
+        .solution()
+        .orders()
+        .iter()
+        .any(|(uid, current_execution)| {
+            let best_execution = best_executions.get(uid).expect("by construction above");
+            let improvement = improvement_in_buy(best_execution, current_execution);
+            if improvement.is_zero() {
+                return false;
+            };
+            tracing::debug!(
+                ?uid,
+                ?improvement,
+                ?best_execution,
+                ?current_execution,
+                "fairness check"
+            );
+            // Improvement is denominated in buy token, use buy price to normalize the
+            // difference into eth
+            let Some(order) = auction.orders.iter().find(|order| order.uid == *uid) else {
+                // This can happen for jit orders
+                tracing::debug!(?uid, "cannot ensure fairness, order not found in auction");
+                return false;
+            };
+            let Some(buy_price) = auction.prices.get(&order.buy.token) else {
+                tracing::warn!(
+                    ?order,
+                    "cannot ensure fairness, buy price not found in auction"
+                );
+                return false;
+            };
+            buy_price.in_eth(improvement.into()) > fairness_threshold
+        });
+    !unfair
+}

--- a/crates/autopilot/src/domain/competition/winner_selection/mod.rs
+++ b/crates/autopilot/src/domain/competition/winner_selection/mod.rs
@@ -1,0 +1,27 @@
+use {
+    crate::domain::{
+        Auction,
+        competition::{Participant, Score, Unranked},
+        eth,
+    },
+    std::collections::HashMap,
+};
+
+pub mod max_score;
+
+pub trait Arbitrator: Send + Sync + 'static {
+    /// Picks winners and sorts all solutions where winners come before losers
+    /// and higher scores come before lower scores.
+    fn mark_winners(&self, solutions: Vec<Participant<Unranked>>) -> Vec<Participant>;
+
+    /// Computes the reference scores which are used to compute
+    /// rewards for the winning solvers.
+    fn compute_reference_scores(&self, solutions: &[Participant]) -> HashMap<eth::Address, Score>;
+
+    /// Removes unfair solutions from the set of all solutions.
+    fn filter_solutions(
+        &self,
+        solutions: Vec<Participant<Unranked>>,
+        auction: &Auction,
+    ) -> Vec<Participant<Unranked>>;
+}

--- a/crates/autopilot/src/domain/competition/winner_selection/mod.rs
+++ b/crates/autopilot/src/domain/competition/winner_selection/mod.rs
@@ -9,19 +9,29 @@ use {
 
 pub mod max_score;
 
+/// Implements auction arbitration in 3 phases:
+/// 1. filter unfair solutions
+/// 2. mark winners
+/// 3. compute reference scores
+///
+/// The functions assume the `Arbitrator` is the only one
+/// changing the ordering or the `participants.
 pub trait Arbitrator: Send + Sync + 'static {
+    /// Removes unfair solutions from the set of all solutions.
+    fn filter_unfair_solutions(
+        &self,
+        participants: Vec<Participant<Unranked>>,
+        auction: &Auction,
+    ) -> Vec<Participant<Unranked>>;
+
     /// Picks winners and sorts all solutions where winners come before losers
     /// and higher scores come before lower scores.
-    fn mark_winners(&self, solutions: Vec<Participant<Unranked>>) -> Vec<Participant>;
+    fn mark_winners(&self, participants: Vec<Participant<Unranked>>) -> Vec<Participant>;
 
     /// Computes the reference scores which are used to compute
     /// rewards for the winning solvers.
-    fn compute_reference_scores(&self, solutions: &[Participant]) -> HashMap<eth::Address, Score>;
-
-    /// Removes unfair solutions from the set of all solutions.
-    fn filter_solutions(
+    fn compute_reference_scores(
         &self,
-        solutions: Vec<Participant<Unranked>>,
-        auction: &Auction,
-    ) -> Vec<Participant<Unranked>>;
+        participants: &[Participant],
+    ) -> HashMap<eth::Address, Score>;
 }

--- a/crates/autopilot/src/run_loop.rs
+++ b/crates/autopilot/src/run_loop.rs
@@ -248,7 +248,9 @@ impl RunLoop {
             return;
         }
 
-        let solutions = self.winner_selection.filter_solutions(solutions, &auction);
+        let solutions = self
+            .winner_selection
+            .filter_unfair_solutions(solutions, &auction);
         let solutions = self.winner_selection.mark_winners(solutions);
 
         let competition_simulation_block = self.eth.current_block().borrow().number;

--- a/crates/autopilot/src/run_loop.rs
+++ b/crates/autopilot/src/run_loop.rs
@@ -1,6 +1,6 @@
 use {
     crate::{
-        database::competition::Competition,
+        database::competition::{Competition, LegacyScore},
         domain::{
             self,
             OrderUid,
@@ -10,8 +10,8 @@ use {
                 Solution,
                 SolutionError,
                 SolverParticipationGuard,
-                TradedOrder,
                 Unranked,
+                winner_selection,
             },
             eth::{self, TxId},
             settlement::{ExecutionEnded, ExecutionStarted},
@@ -27,7 +27,6 @@ use {
     ::observe::metrics,
     anyhow::Result,
     database::order_events::OrderEventLabel,
-    ethcontract::U256,
     ethrpc::block_stream::BlockInfo,
     futures::{FutureExt, TryFutureExt},
     itertools::Itertools,
@@ -77,6 +76,7 @@ pub struct RunLoop {
     /// the most recent data available.
     maintenance: Arc<Maintenance>,
     competition_updates_sender: tokio::sync::mpsc::UnboundedSender<()>,
+    winner_selection: Box<dyn winner_selection::Arbitrator>,
 }
 
 impl RunLoop {
@@ -94,6 +94,7 @@ impl RunLoop {
         competition_updates_sender: tokio::sync::mpsc::UnboundedSender<()>,
     ) -> Self {
         Self {
+            winner_selection: Box::new(winner_selection::max_score::Config),
             config,
             eth,
             persistence,
@@ -241,11 +242,14 @@ impl RunLoop {
             .store_order_events(auction.orders.iter().map(|o| o.uid), OrderEventLabel::Ready);
 
         // Collect valid solutions from all drivers
-        let solutions = self.competition(&auction).await;
+        let solutions = self.fetch_solutions(&auction).await;
         observe::solutions(&solutions);
         if solutions.is_empty() {
             return;
         }
+
+        let solutions = self.winner_selection.filter_solutions(solutions, &auction);
+        let solutions = self.winner_selection.mark_winners(solutions);
 
         let competition_simulation_block = self.eth.current_block().borrow().number;
         let block_deadline = competition_simulation_block + self.config.submission_deadline;
@@ -368,19 +372,28 @@ impl RunLoop {
         let start = Instant::now();
         // TODO: Needs to be removed once other teams fully migrated to the
         // reference_scores table
-        let Some(winning_solution) = solutions
-            .iter()
-            .find(|participant| participant.is_winner())
-            .map(|participant| participant.solution())
-        else {
-            return Err(anyhow::anyhow!("no winners found"));
+        let legacy_score = {
+            let Some(winning_solution) = solutions
+                .iter()
+                .find(|participant| participant.is_winner())
+                .map(|participant| participant.solution())
+            else {
+                return Err(anyhow::anyhow!("no winners found"));
+            };
+            let winner = winning_solution.solver().into();
+            let winning_score = winning_solution.score().get().0;
+            let reference_score = solutions
+                .get(1)
+                .map(|participant| participant.solution().score().get().0)
+                .unwrap_or_default();
+            Some(LegacyScore {
+                winner,
+                winning_score,
+                reference_score,
+            })
         };
-        let winner = winning_solution.solver().into();
-        let winning_score = winning_solution.score().get().0;
-        let reference_score = solutions
-            .get(1)
-            .map(|participant| participant.solution().score().get().0)
-            .unwrap_or_default();
+
+        let reference_scores = self.winner_selection.compute_reference_scores(solutions);
 
         let participants = solutions
             .iter()
@@ -453,9 +466,8 @@ impl RunLoop {
         };
         let competition = Competition {
             auction_id: auction.id,
-            winner,
-            winning_score,
-            reference_score,
+            legacy: legacy_score,
+            reference_scores,
             participants,
             prices: auction
                 .prices
@@ -512,7 +524,10 @@ impl RunLoop {
 
     /// Runs the solver competition, making all configured drivers participate.
     /// Returns all fair solutions sorted by their score (best to worst).
-    async fn competition(&self, auction: &domain::Auction) -> Vec<competition::Participant> {
+    async fn fetch_solutions(
+        &self,
+        auction: &domain::Auction,
+    ) -> Vec<competition::Participant<Unranked>> {
         let request = solve::Request::new(
             auction,
             &self.trusted_tokens.all(),
@@ -530,175 +545,32 @@ impl RunLoop {
         .flatten()
         .collect::<Vec<_>>();
 
-        // Shuffle so that sorting randomly splits ties.
-        solutions.shuffle(&mut rand::thread_rng());
-        solutions.sort_unstable_by_key(|participant| {
-            std::cmp::Reverse(participant.solution().score().get().0)
-        });
-
-        // Filter out solutions that don't come from their corresponding submission
-        // address
-        let mut solutions = solutions
-            .into_iter()
-            .filter(|participant| {
-                let submission_address = participant.driver().submission_address;
-                let is_solution_from_driver = participant.solution().solver() == submission_address;
-                if !is_solution_from_driver {
-                    tracing::warn!(
-                        driver = participant.driver().name,
-                        ?submission_address,
-                        "the solution received is not from the driver submission address"
-                    );
-                }
-                is_solution_from_driver
-            })
-            .collect::<Vec<_>>();
-
-        // Limit the number of accepted solutions per solver. Do not alter the ordering
-        // of solutions
         let mut counter = HashMap::new();
         solutions.retain(|participant| {
+            let submission_address = participant.driver().submission_address;
+            let is_solution_from_driver = participant.solution().solver() == submission_address;
+
+            // Filter out solutions that don't come from their corresponding submission
+            // address
+            if !is_solution_from_driver {
+                tracing::warn!(
+                    driver = participant.driver().name,
+                    ?submission_address,
+                    "the solution received is not from the driver submission address"
+                );
+                return false;
+            }
+
+            // limit number of solutions per solver
             let driver = participant.driver().name.clone();
             let count = counter.entry(driver).or_insert(0);
             *count += 1;
             *count <= self.config.max_solutions_per_solver.get()
         });
 
-        // Filter out solutions that are not fair
-        let solutions = solutions
-            .iter()
-            .enumerate()
-            .filter_map(|(index, participant)| {
-                if Self::is_solution_fair(participant, &solutions[index..], auction) {
-                    Some(participant)
-                } else {
-                    tracing::warn!(
-                        invalidated = participant.driver().name,
-                        "fairness check invalidated of solution"
-                    );
-                    None
-                }
-            });
-
-        // Winners are selected one by one, starting from the best solution,
-        // until `max_winners_per_auction` are selected. The solution is a winner
-        // if it swaps tokens that are not yet swapped by any previously processed
-        // solution.
-        let wrapped_native_token = self.eth.contracts().wrapped_native_token();
-        let mut already_swapped_tokens = HashSet::new();
-        let mut winners = 0;
-        let solutions = solutions
-            .cloned()
-            .map(|participant| {
-                let swapped_tokens = participant
-                    .solution()
-                    .orders()
-                    .iter()
-                    .flat_map(|(_, order)| {
-                        [
-                            order.sell.token.as_erc20(wrapped_native_token),
-                            order.buy.token.as_erc20(wrapped_native_token),
-                        ]
-                    })
-                    .collect::<HashSet<_>>();
-
-                let is_winner = swapped_tokens.is_disjoint(&already_swapped_tokens)
-                    && winners < self.config.max_winners_per_auction.get();
-
-                already_swapped_tokens.extend(swapped_tokens);
-                winners += usize::from(is_winner);
-
-                participant.rank(is_winner)
-            })
-            .collect();
-
+        // Shuffle so that sorting randomly splits ties.
+        solutions.shuffle(&mut rand::thread_rng());
         solutions
-    }
-
-    /// Returns true if solution is fair to other solutions
-    fn is_solution_fair(
-        solution: &competition::Participant<Unranked>,
-        others: &[competition::Participant<Unranked>],
-        auction: &domain::Auction,
-    ) -> bool {
-        let Some(fairness_threshold) = solution.driver().fairness_threshold else {
-            return true;
-        };
-
-        // Returns the surplus difference in the buy token if `left`
-        // is better for the trader than `right`, or 0 otherwise.
-        // This takes differently partial fills into account.
-        let improvement_in_buy = |left: &TradedOrder, right: &TradedOrder| {
-            // If `left.sell / left.buy < right.sell / right.buy`, left is "better" as the
-            // trader either sells less or gets more. This can be reformulated as
-            // `right.sell * left.buy > left.sell * right.buy`.
-            let right_sell_left_buy = right.executed_sell.0.full_mul(left.executed_buy.0);
-            let left_sell_right_buy = left.executed_sell.0.full_mul(right.executed_buy.0);
-            let improvement = right_sell_left_buy
-                .checked_sub(left_sell_right_buy)
-                .unwrap_or_default();
-
-            // The difference divided by the original sell amount is the improvement in buy
-            // token. Casting to U256 is safe because the difference is smaller than the
-            // original product, which if re-divided by right.sell must fit in U256.
-            improvement
-                .checked_div(right.executed_sell.0.into())
-                .map(|v| U256::try_from(v).expect("improvement in buy fits in U256"))
-                .unwrap_or_default()
-        };
-
-        // Record best execution per order
-        let mut best_executions = HashMap::new();
-        for other in others {
-            for (uid, execution) in other.solution().orders() {
-                best_executions
-                    .entry(uid)
-                    .and_modify(|best_execution| {
-                        if !improvement_in_buy(execution, best_execution).is_zero() {
-                            *best_execution = *execution;
-                        }
-                    })
-                    .or_insert(*execution);
-            }
-        }
-
-        // Check if the solution contains an order whose execution in the
-        // solution is more than `fairness_threshold` worse than the
-        // order's best execution across all solutions
-        let unfair = solution
-            .solution()
-            .orders()
-            .iter()
-            .any(|(uid, current_execution)| {
-                let best_execution = best_executions.get(uid).expect("by construction above");
-                let improvement = improvement_in_buy(best_execution, current_execution);
-                if improvement.is_zero() {
-                    return false;
-                };
-                tracing::debug!(
-                    ?uid,
-                    ?improvement,
-                    ?best_execution,
-                    ?current_execution,
-                    "fairness check"
-                );
-                // Improvement is denominated in buy token, use buy price to normalize the
-                // difference into eth
-                let Some(order) = auction.orders.iter().find(|order| order.uid == *uid) else {
-                    // This can happen for jit orders
-                    tracing::debug!(?uid, "cannot ensure fairness, order not found in auction");
-                    return false;
-                };
-                let Some(buy_price) = auction.prices.get(&order.buy.token) else {
-                    tracing::warn!(
-                        ?order,
-                        "cannot ensure fairness, buy price not found in auction"
-                    );
-                    return false;
-                };
-                buy_price.in_eth(improvement.into()) > fairness_threshold
-            });
-        !unfair
     }
 
     /// Sends a `/solve` request to the driver and manages all error cases and
@@ -1148,7 +1020,10 @@ impl Metrics {
 }
 
 pub mod observe {
-    use {crate::domain, std::collections::HashSet};
+    use {
+        crate::domain::{self, competition::Unranked},
+        std::collections::HashSet,
+    };
 
     pub fn log_auction_delta(previous: &Option<domain::Auction>, current: &domain::Auction) {
         let previous_uids = match previous {
@@ -1178,7 +1053,7 @@ pub mod observe {
         );
     }
 
-    pub fn solutions(solutions: &[domain::competition::Participant]) {
+    pub fn solutions(solutions: &[domain::competition::Participant<Unranked>]) {
         if solutions.is_empty() {
             tracing::info!("no solutions for auction");
         }

--- a/crates/e2e/tests/e2e/limit_orders.rs
+++ b/crates/e2e/tests/e2e/limit_orders.rs
@@ -30,11 +30,11 @@ async fn local_node_two_limit_orders() {
     run_test(two_limit_orders_test).await;
 }
 
-#[tokio::test]
-#[ignore]
-async fn local_node_two_limit_orders_multiple_winners() {
-    run_test(two_limit_orders_multiple_winners_test).await;
-}
+// #[tokio::test]
+// #[ignore]
+// async fn local_node_two_limit_orders_multiple_winners() {
+//     run_test(two_limit_orders_multiple_winners_test).await;
+// }
 
 #[tokio::test]
 #[ignore]
@@ -318,6 +318,7 @@ async fn two_limit_orders_test(web3: Web3) {
     .unwrap();
 }
 
+#[allow(unused)]
 async fn two_limit_orders_multiple_winners_test(web3: Web3) {
     let mut onchain = OnchainComponents::deploy(web3).await;
 


### PR DESCRIPTION
# Description
Extracts the arbitration logic into a new trait which allows swapping out the core logic with combinatorial auctions using CLI arguments. This is an alternative to https://github.com/cowprotocol/services/pull/3359 which simplifies a few things.


# Changes
Reverts back current logic to always return just 1 winning solver. While the DB is able to handle multiple winners there is no reward mechanism in place for the current logic so we can't enable it in practice anyway.
This causes multi winner tests to fail. Since this is, again, still not used in production and a follow up PR brings back multi winners with combinatorial auctions I decided to simply comment out these tests.

I also turned `RunLoop::competition()` into `RunLoop::fetch_solutions()` which only fetches the solutions and applies the existing filtering options. This allows winner selection to be separated cleanly from fetching the solutions.
Note that the 2 steps, ensuring that solvers don't lie about their submission address, and limiting the number of solutions per solver have been moved into a single loop.

`RunLoop::is_solution_fair()` was moved into `winner_selection::max_surplus` since combinatorial auctions will apply a different filtering logic to ensure fairness.

Introduces very simple logic to switch from using the `settlement_scores` table to using `reference_scores`. Because we already populate `reference_scores` appropriately the simplest migration path is to wait for the solver team to stop using `settlement_scores` and kill the table and all logic related to that in one go.

## How to test
Besides the multi winners tests everything should still work as before.