### PR TITLE
Run participation guard in background

### DIFF
--- a/crates/autopilot/src/run_loop.rs
+++ b/crates/autopilot/src/run_loop.rs
@@ -648,7 +648,7 @@ impl RunLoop {
                 _ = &mut timeout => return Err(SolveError::Timeout),
                 is_allowed = &mut check_allowed => match is_allowed {
                     Ok(false) => return Err(SolveError::SolverDenyListed),
-                    Ok(true) => (), // all good => continue with other tasks
+                    Ok(true) => continue, // all good => continue with other tasks
                     Err(err) => {
                         tracing::error!(
                             ?err,

--- a/crates/autopilot/src/run_loop.rs
+++ b/crates/autopilot/src/run_loop.rs
@@ -635,11 +635,12 @@ impl RunLoop {
         request: &solve::Request,
     ) -> Result<Vec<Result<competition::Solution, domain::competition::SolutionError>>, SolveError>
     {
-        let timeout = tokio::time::sleep(self.config.solve_deadline);
-        let send_request = driver.solve(request);
+        let timeout = tokio::time::sleep(self.config.solve_deadline).fuse();
+        let send_request = driver.solve(request).fuse();
         let check_allowed = self
             .solver_participation_guard
-            .can_participate(&driver.submission_address);
+            .can_participate(&driver.submission_address)
+            .fuse();
         tokio::pin!(timeout, send_request, check_allowed);
 
         let response = loop {


### PR DESCRIPTION
# Description
Recently we experienced some serious degradation when we needed to use a fallback node provider which had high latency. This resulted in up to 4s between the autopilot cutting an auction and the drivers receiving the request. The reason was that the participation guard (to check whether a solver is eligible to participate in the current auction) awaits an RPC request before we send out the `/solve` request to the driver.
Additionally it looked like these individual RPC requests were not batched together by our auto batching logic. The end result basically looked like what you would expect from this code:
```rust
for driver in &drivers {
    if !check_allowed().await {
        anyhow::bail!("solver deny listed");
    }
    tokio::task::spawn(driver.send_request())
}
```

# Changes
There are a few things which we need to handle:
1. send request
2. check if solver is eligible
3. abort request if we exceed the deadline
4. abort request if the solver is not allow listed
5. do everything concurrently
6. handle all the error cases

I tried to make this as readable as possible but I'm not super happy with the result. LMK if you have ideas how to make this code nicer.