### PR TITLE
Trivial: log liquidity sources consistently

### DIFF
--- a/crates/driver/src/infra/observe/mod.rs
+++ b/crates/driver/src/infra/observe/mod.rs
@@ -24,7 +24,7 @@ use {
         util::http,
     },
     ethrpc::block_stream::BlockInfo,
-    std::collections::{HashMap, HashSet},
+    std::collections::{BTreeMap, HashMap, HashSet},
     url::Url,
 };
 
@@ -49,7 +49,7 @@ pub fn fetching_liquidity() {
 
 /// Observe the fetched liquidity.
 pub fn fetched_liquidity(liquidity: &[Liquidity]) {
-    let mut grouped: HashMap<&'static str, usize> = Default::default();
+    let mut grouped: BTreeMap<&'static str, usize> = Default::default();
     for liquidity in liquidity {
         *grouped.entry((&liquidity.kind).into()).or_default() += 1;
     }

--- a/crates/driver/src/infra/observe/mod.rs
+++ b/crates/driver/src/infra/observe/mod.rs
@@ -24,7 +24,7 @@ use {
         util::http,
     },
     ethrpc::block_stream::BlockInfo,
-    std::collections::{BTreeMap, HashMap, HashSet},
+    std::collections::{BTreeMap, HashSet},
     url::Url,
 };
 


### PR DESCRIPTION
# Description
When logging the number of pools collected for each liquidity source we collect them into a map to print a small overview.
Currently the order in which these sources get printed is not stable because we use a `HashMap`.

# Changes
Replace `HashMap` with `BTreeMap` to have a consistent iteration and therefore logging.