### PR TITLE
Optimize `/solve` request serialization

### DIFF
--- a/crates/autopilot/src/infra/solvers/mod.rs
+++ b/crates/autopilot/src/infra/solvers/mod.rs
@@ -103,6 +103,7 @@ impl Driver {
             request = request.header("X-REQUEST-ID", request_id);
         }
 
+        tracing::debug!(solver = self.name, "sending request");
         let mut response = request.send().await.context("send")?;
         let status = response.status().as_u16();
         let body = response_body_with_size_limit(&mut response, RESPONSE_SIZE_LIMIT)

--- a/crates/autopilot/src/infra/solvers/mod.rs
+++ b/crates/autopilot/src/infra/solvers/mod.rs
@@ -78,11 +78,11 @@ impl Driver {
     }
 
     pub async fn solve(&self, request: &solve::Request) -> Result<solve::Response> {
-        self.request_response("solve", request, None).await
+        self.request_response("solve", request).await
     }
 
     pub async fn reveal(&self, request: &reveal::Request) -> Result<reveal::Response> {
-        self.request_response("reveal", request, None).await
+        self.request_response("reveal", request).await
     }
 
     pub async fn settle(
@@ -118,14 +118,13 @@ impl Driver {
     }
 
     pub async fn notify(&self, request: &notify::Request) -> Result<()> {
-        self.request_response("notify", request, None).await
+        self.request_response("notify", request).await
     }
 
     async fn request_response<Response>(
         &self,
         path: &str,
         request: &impl serde::Serialize,
-        timeout: Option<std::time::Duration>,
     ) -> Result<Response>
     where
         Response: serde::de::DeserializeOwned,
@@ -138,9 +137,6 @@ impl Driver {
         );
         let mut request = self.client.post(url.clone()).json(request);
 
-        if let Some(timeout) = timeout {
-            request = request.timeout(timeout);
-        }
         if let Some(request_id) = observe::request_id::from_current_span() {
             request = request.header("X-REQUEST-ID", request_id);
         }

--- a/crates/autopilot/src/infra/solvers/mod.rs
+++ b/crates/autopilot/src/infra/solvers/mod.rs
@@ -91,8 +91,8 @@ impl Driver {
             // and would otherwise block the main task and delay requests to other
             // drivers.
             tokio::task::spawn_blocking(move || builder.json(&request))
-            .await
-            .context("failed to build request")?
+                .await
+                .context("failed to build request")?
         };
 
         if let Some(request_id) = observe::request_id::from_current_span() {

--- a/crates/autopilot/src/run_loop.rs
+++ b/crates/autopilot/src/run_loop.rs
@@ -547,12 +547,11 @@ impl RunLoop {
             &self.trusted_tokens.all(),
             self.config.solve_deadline,
         );
-        let request = &request;
 
         let mut solutions = futures::future::join_all(
             self.drivers
                 .iter()
-                .map(|driver| self.solve(driver.clone(), request)),
+                .map(|driver| self.solve(driver.clone(), request.clone())),
         )
         .await
         .into_iter()
@@ -592,10 +591,10 @@ impl RunLoop {
     async fn solve(
         &self,
         driver: Arc<infra::Driver>,
-        request: &solve::Request,
+        request: solve::Request,
     ) -> Vec<competition::Participant<Unranked>> {
         let start = Instant::now();
-        let result = self.try_solve(&driver, request).await;
+        let result = self.try_solve(Arc::clone(&driver), request).await;
         let solutions = match result {
             Ok(solutions) => {
                 Metrics::solve_ok(&driver, start.elapsed());
@@ -631,8 +630,8 @@ impl RunLoop {
     /// Sends `/solve` request to the driver and forwards errors to the caller.
     async fn try_solve(
         &self,
-        driver: &infra::Driver,
-        request: &solve::Request,
+        driver: Arc<infra::Driver>,
+        request: solve::Request,
     ) -> Result<Vec<Result<competition::Solution, domain::competition::SolutionError>>, SolveError>
     {
         let check_allowed = self

--- a/crates/autopilot/src/shadow.rs
+++ b/crates/autopilot/src/shadow.rs
@@ -277,7 +277,7 @@ impl RunLoop {
             .collect();
 
         let revealed = driver
-            .reveal(&reveal::Request {
+            .reveal(reveal::Request {
                 solution_id,
                 auction_id,
             })

--- a/crates/autopilot/src/shadow.rs
+++ b/crates/autopilot/src/shadow.rs
@@ -196,13 +196,14 @@ impl RunLoop {
     }
 
     /// Runs the solver competition, making all configured drivers participate.
-    async fn competition(&self, auction: &domain::Auction) -> Vec<Participant<'_>> {
+    async fn competition(&self, auction: &domain::Auction) -> Vec<Participant> {
         let request = solve::Request::new(auction, &self.trusted_tokens.all(), self.solve_deadline);
-        let request = &request;
 
         let mut participants =
-            futures::future::join_all(self.drivers.iter().map(|driver| async move {
-                let solution = self.participate(driver, request).await;
+            futures::future::join_all(self.drivers.iter().cloned().map(|driver| async {
+                let solution = self
+                    .participate(Arc::clone(&driver), request.clone(), auction.id)
+                    .await;
                 Participant { driver, solution }
             }))
             .await;
@@ -222,7 +223,7 @@ impl RunLoop {
     /// until `max_winners_per_auction` are selected. The solution is a winner
     /// if it swaps tokens that are not yet swapped by any other already
     /// selected winner.
-    fn select_winners<'a>(&self, participants: &'a [Participant<'a>]) -> Vec<&'a Participant<'a>> {
+    fn select_winners<'a>(&self, participants: &'a [Participant]) -> Vec<&'a Participant> {
         let mut winners = Vec::new();
         let mut already_swapped_tokens = HashSet::new();
         for participant in participants.iter() {
@@ -247,8 +248,9 @@ impl RunLoop {
     /// Computes a driver's solutions in the shadow competition.
     async fn participate(
         &self,
-        driver: &infra::Driver,
-        request: &solve::Request,
+        driver: Arc<infra::Driver>,
+        request: solve::Request,
+        auction_id: i64,
     ) -> Result<Solution, Error> {
         let proposed = tokio::time::timeout(self.solve_deadline, driver.solve(request))
             .await
@@ -277,14 +279,14 @@ impl RunLoop {
         let revealed = driver
             .reveal(&reveal::Request {
                 solution_id,
-                auction_id: request.id,
+                auction_id,
             })
             .await
             .map_err(Error::Reveal)?;
         if !revealed
             .calldata
             .internalized
-            .ends_with(&request.id.to_be_bytes())
+            .ends_with(&auction_id.to_be_bytes())
         {
             return Err(Error::Mismatch);
         }
@@ -298,12 +300,12 @@ impl RunLoop {
     }
 }
 
-struct Participant<'a> {
-    driver: &'a infra::Driver,
+struct Participant {
+    driver: Arc<infra::Driver>,
     solution: Result<Solution, Error>,
 }
 
-impl Participant<'_> {
+impl Participant {
     fn score(&self) -> U256 {
         self.solution
             .as_ref()


### PR DESCRIPTION
# Description
Follow up to https://github.com/cowprotocol/services/pull/3386 since that actually did not resolve the issue.
We still have the problem where the first driver can see an auction sometimes multiple seconds before the last driver.
It turns out the problem is how we send out the requests. There are 2 main problems with our current approach:
1. the request is huge and we re-serialize it for each driver (this can take ~200ms)
2. we serialize the request in our main task

Both issues combined lead to the autopilot getting blocked for 200ms per driver. In the grand scheme of things this effectively turns our request sending from concurrent to serial. So if we have 20 solvers the last one could see the auction ~4s later than the first driver.

# Changes
I tackled `1` by introducing a new type that serializes the `/solve` request once and allows cheap clones with `Arc`. Serializing this type then effectively turns into copying a `str` instead of recursively calling the serialize logic of each contained struct.
`2` gets addresses by simply using `tokio::task::spawn_blocking()` when calling `request.json(data)`. Using the helper struct that's already way faster but just copying the data around can already take up to 30ms. So without this the 20th driver would still see the auction ~600ms later than the first one.

## How to test
I deployed the change to the mainnet shadow environment which for these purposes is identical to prod (huge requests, many connected drivers). With some temporary logs (not contained in this PR) I was able to verify that the autopilot now sends all requests within `~10ms` and all drivers received the requests within `~200ms`.

[Logs](https://aws-es.cow.fi/_dashboards/app/data-explorer/discover#?_a=(discover:(columns:!(log,log_level),isDirty:!f,sort:!()),metadata:(indexPattern:'86e4a5a0-4e4b-11ef-85c5-3946a99ed1a7',view:discover))&_g=(filters:!(),refreshInterval:(pause:!t,value:0),time:(from:'2025-05-15T13:24:29.054Z',to:'2025-05-15T13:35:24.105Z'))&_q=(filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'86e4a5a0-4e4b-11ef-85c5-3946a99ed1a7',key:kubernetes.container_image,negate:!t,params:(query:nginx),type:phrase),query:(match_phrase:(kubernetes.container_image:nginx))),('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'86e4a5a0-4e4b-11ef-85c5-3946a99ed1a7',key:kubernetes.pod_labels.network,negate:!f,params:(query:mainnet),type:phrase),query:(match_phrase:(kubernetes.pod_labels.network:mainnet)))),query:(language:kuery,query:'log:%20%2210673186%22%20and%20(log:%20%22solving%22%20or%20log:%20%22sending%20request%22%20or%20log:%20%22received%20auction%22)'))) without the patch (only shows difference between cutting the auction and drivers receiving it)
[Logs](https://aws-es.cow.fi/_dashboards/app/data-explorer/discover#?_a=(discover:(columns:!(log,log_level),isDirty:!f,sort:!()),metadata:(indexPattern:'5ed837d0-4a67-11ef-8b11-a98c7c46873d',view:discover))&_g=(filters:!(),refreshInterval:(pause:!t,value:0),time:(from:'2025-05-15T13:24:29.054Z',to:'2025-05-15T13:35:24.105Z'))&_q=(filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'86e4a5a0-4e4b-11ef-85c5-3946a99ed1a7',key:kubernetes.container_image,negate:!t,params:(query:nginx),type:phrase),query:(match_phrase:(kubernetes.container_image:nginx))),('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'86e4a5a0-4e4b-11ef-85c5-3946a99ed1a7',key:kubernetes.pod_labels.network,negate:!f,params:(query:mainnet),type:phrase),query:(match_phrase:(kubernetes.pod_labels.network:mainnet)))),query:(language:kuery,query:'%22shadow%22%20and%20log:%20%2210673180%22%20and%20(log:%20%22sending%20request%22%20or%20log:%20%22received%20auction%22)'))) with the patch (shows timings of sending and receiving the requests)