### PR TITLE
Fix clippy lints of 1.87

### DIFF
--- a/crates/autopilot/src/solvable_orders.rs
+++ b/crates/autopilot/src/solvable_orders.rs
@@ -126,7 +126,7 @@ impl SolvableOrdersCache {
         native_price_timeout: Duration,
         settlement_contract: H160,
     ) -> Arc<Self> {
-        let self_ = Arc::new(Self {
+        Arc::new(Self {
             min_order_validity_period,
             persistence,
             banned_users,
@@ -142,8 +142,7 @@ impl SolvableOrdersCache {
             cow_amm_registry,
             native_price_timeout,
             settlement_contract,
-        });
-        self_
+        })
     }
 
     pub async fn current_auction(&self) -> Option<domain::RawAuctionData> {

--- a/crates/driver/src/domain/competition/solution/encoding.rs
+++ b/crates/driver/src/domain/competition/solution/encoding.rs
@@ -19,7 +19,7 @@ use {
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
     #[error("invalid interaction: {0:?}")]
-    InvalidInteractionExecution(competition::solution::interaction::Liquidity),
+    InvalidInteractionExecution(Box<competition::solution::interaction::Liquidity>),
     #[error("missing auction id")]
     MissingAuctionId,
     #[error("invalid clearing price: {0:?}")]
@@ -353,7 +353,9 @@ pub fn liquidity_interaction(
             .ok(),
         liquidity::Kind::ZeroEx(limit_order) => limit_order.to_interaction(&input).ok(),
     }
-    .ok_or(Error::InvalidInteractionExecution(liquidity.clone()))
+    .ok_or(Error::InvalidInteractionExecution(Box::new(
+        liquidity.clone(),
+    )))
 }
 
 pub fn approve(allowance: &Allowance) -> eth::Interaction {

--- a/crates/driver/src/domain/competition/solution/mod.rs
+++ b/crates/driver/src/domain/competition/solution/mod.rs
@@ -611,7 +611,7 @@ pub mod error {
         #[error("boundary error: {0:?}")]
         Boundary(#[from] boundary::Error),
         #[error("simulation error: {0:?}")]
-        Simulation(#[from] simulator::Error),
+        Simulation(Box<simulator::Error>),
         #[error(
             "non bufferable tokens used: solution attempts to internalize tokens which are not \
              trusted"
@@ -627,6 +627,14 @@ pub mod error {
         DifferentSolvers,
         #[error("encoding error: {0:?}")]
         Encoding(#[from] encoding::Error),
+    }
+
+    // Custom conversion function because clippy wants us to box this
+    // particular error variant because it's so big.
+    impl From<simulator::Error> for Error {
+        fn from(value: simulator::Error) -> Self {
+            Self::Simulation(Box::new(value))
+        }
     }
 
     #[derive(Debug, thiserror::Error)]

--- a/crates/solvers/src/domain/solution.rs
+++ b/crates/solvers/src/domain/solution.rs
@@ -327,7 +327,7 @@ pub struct JitTrade {
 /// or running some custom logic.
 #[derive(Debug)]
 pub enum Interaction {
-    Liquidity(LiquidityInteraction),
+    Liquidity(Box<LiquidityInteraction>),
     Custom(CustomInteraction),
 }
 

--- a/crates/solvers/src/domain/solver.rs
+++ b/crates/solvers/src/domain/solver.rs
@@ -169,13 +169,13 @@ impl Inner {
                     .segments
                     .iter()
                     .map(|segment| {
-                        solution::Interaction::Liquidity(solution::LiquidityInteraction {
+                        solution::Interaction::Liquidity(Box::new(solution::LiquidityInteraction {
                             liquidity: segment.liquidity.clone(),
                             input: segment.input,
                             output: segment.output,
                             // TODO does the baseline solver know about this optimization?
                             internalize: false,
-                        })
+                        }))
                     })
                     .collect();
 


### PR DESCRIPTION
# Description
The new [Rust version](https://blog.rust-lang.org/2025/05/15/Rust-1.87.0/) brings new clippy lints. Mostly about individual enum variants being very big.

# Changes
Box enum variants clippy complains about