### PR TITLE
Only parse and not re-hash appdata

### DIFF
--- a/crates/driver/src/domain/competition/order/app_data.rs
+++ b/crates/driver/src/domain/competition/order/app_data.rs
@@ -74,16 +74,24 @@ impl AppDataRetriever {
                                 .context("invalid app data document")?;
                         match appdata.full_app_data == app_data::EMPTY {
                             true => None, // empty app data
-                            false => Some(
-                                self_
+                            false => {
+                                let mut validated = self_
                                     .0
                                     .app_data_validator
-                                    .validate(&appdata.full_app_data.into_bytes())?,
-                            ),
+                                    .validate(&appdata.full_app_data.into_bytes())?;
+                                // There is at least 1 widely used appdata JSON that apparently
+                                // was stored with the wrong hash in the DB. Since the backend
+                                // is now the source of truth we need to keep using the hash
+                                // the backend thinks is correct. If we use the rehashed value
+                                // returned by `validate()` the driver will run into encoding
+                                // errors when building settlement calldata.
+                                validated.hash = app_data::AppDataHash(app_data.0.0);
+
+                                Some(validated)
+                            },
                         }
                     }
                 };
-
                 self_
                     .0
                     .cache

--- a/crates/driver/src/domain/competition/order/app_data.rs
+++ b/crates/driver/src/domain/competition/order/app_data.rs
@@ -88,7 +88,7 @@ impl AppDataRetriever {
                                 validated.hash = app_data::AppDataHash(app_data.0.0);
 
                                 Some(validated)
-                            },
+                            }
                         }
                     }
                 };


### PR DESCRIPTION
# Description
To support flashloans in the reference driver we added the logic to lookup the full JSON that is associated with an appdata hash. The logic previously fetched the JSON from the orderbook and revalidated it.
Now one solver team reported that the appdata reported by the driver does not match the appdata shown in the explorer.
This is the case for <https://api.cow.fi/xdai/api/v1/app_data/0xf249b3db926aa5b5a1b18f3fec86b9cc99b9a8a99ad7e8034242d2838ae97422>. When we manually rehash the data stored in the backend we arrive at the hash `0x0fa8041819d62080e9d0ba2285696640270550336299729a441dfdceceac509d` instead of `0xf249b3db926aa5b5a1b18f3fec86b9cc99b9a8a99ad7e8034242d2838ae97422` which indicates the we somehow associated the hash incorrectly in the DB.

# Changes
While this is an issue and we would ideally figure out how this happened in the first place it's also important to work around this on the driver side. Ultimately the backend is the source of truth for these hashes so it doesn't really matter if the driver ends up with a different hash. To keep the data consistent with the backend's view we simply trust the appdata hash and don't recompute it.