### PR TITLE
Spawn a task per solve request

### DIFF
--- a/crates/autopilot/src/run_loop.rs
+++ b/crates/autopilot/src/run_loop.rs
@@ -25,7 +25,7 @@ use {
         solvable_orders::SolvableOrdersCache,
     },
     ::observe::metrics,
-    anyhow::Result,
+    anyhow::{Context, Result},
     database::order_events::OrderEventLabel,
     ethrpc::block_stream::BlockInfo,
     futures::{FutureExt, TryFutureExt},
@@ -645,7 +645,8 @@ impl RunLoop {
             tokio::time::timeout(self.config.solve_deadline, both)
                 .await
                 .map_err(|_| SolveError::Timeout)?
-                .map_err(|_| SolveError::Failure(anyhow::anyhow!("could not finish task")))?
+                .context("could not finish the task")
+                .map_err(SolveError::Failure)?
         };
 
         let response = match (can_participate, response) {


### PR DESCRIPTION
# Description
After experimenting a bit more with the autopilot submission logic I settled on spawning a task per solve request in the autopilot. The impact can be seen somewhat in the baseline solver solving time (left before, right after the change) where data points higher up are better (more time to compute solutions).

<img width="544" alt="Screenshot 2025-05-16 at 17 57 48" src="https://github.com/user-attachments/assets/17bf2673-526a-445a-abbc-b1c344dcfb42" />

# Changes
Spawn a separate task per solve request.

## How to test
Tested in shadow mainnet and measured using metrics