### PR TITLE
Remove redundant data from `Erc20` type

### DIFF
--- a/crates/driver/src/infra/blockchain/contracts.rs
+++ b/crates/driver/src/infra/blockchain/contracts.rs
@@ -34,6 +34,7 @@ pub struct Contracts {
     /// Default lender to use for flashloans, if flashloan doesn't have a lender
     /// specified.
     flashloan_default_lender: Option<eth::ContractAddress>,
+    balance_helper: contracts::support::Balances,
 }
 
 #[derive(Debug, Clone)]
@@ -78,6 +79,7 @@ impl Contracts {
         let vault_relayer = settlement.methods().vault_relayer().call().await?.into();
         let vault =
             contracts::BalancerV2Vault::at(web3, settlement.methods().vault().call().await?);
+        let balance_helper = contracts::support::Balances::at(web3, settlement.address());
 
         let weth = contracts::WETH9::at(
             web3,
@@ -144,6 +146,7 @@ impl Contracts {
             flashloan_wrapper_by_lender,
             flashloan_router,
             flashloan_default_lender: addresses.flashloan_default_lender,
+            balance_helper,
         })
     }
 
@@ -188,6 +191,10 @@ impl Contracts {
 
     pub fn flashloan_router(&self) -> Option<&contracts::FlashLoanRouter> {
         self.flashloan_router.as_ref()
+    }
+
+    pub fn balance_helper(&self) -> &contracts::support::Balances {
+        &self.balance_helper
     }
 }
 

--- a/crates/driver/src/infra/blockchain/token.rs
+++ b/crates/driver/src/infra/blockchain/token.rs
@@ -176,7 +176,7 @@ impl Erc20 {
                     .has_approved_relayer(trader.0, relayer.into())
                     .call()
                     .map_err(Error::from);
-                let allowance = self.allowance(trader, relayer.into());
+                let allowance = self.allowance(trader, vault.address().into());
                 let (balance, approved, allowance) =
                     futures::try_join!(balance, approved, allowance)?;
                 match approved {


### PR DESCRIPTION
# Description
Currently we store a few redundant pieces of information in the `Erc20` type. We create many instances of this type and these redundant fields bloat the memory usage. Since the type already contains the `Ethereum` type which holds all the necessary contract instances we can just look them up there instead.

# Changes
- moved `Balances` helper contract into `Ethereum`
- dropped `balances`, `vault_relayer` and `vault` fields from `Erc20`

## How to test
no logic changes -> e2e tests should be sufficient