### PR TITLE
Add metrics for solve times in driver

### DIFF
--- a/crates/driver/src/infra/observe/metrics.rs
+++ b/crates/driver/src/infra/observe/metrics.rs
@@ -34,6 +34,25 @@ pub struct Metrics {
         )
     )]
     pub auction_preprocessing: prometheus::HistogramVec,
+
+    /// Remaining time the solver has to compute a solution.
+    #[metric(
+        labels("solver"),
+        buckets(
+            3., 3.5, 4., 4.5, 5., 5.5, 6., 6.5, 7., 7.5, 8., 8.5, 9., 9.5, 10, 10.5, 11.
+        )
+    )]
+    pub remaining_solve_time: prometheus::HistogramVec,
+
+    /// How much time it took to receive a response from the solver.
+    #[metric(
+        labels("solver"),
+        buckets(
+            0.5, 1, 1.5, 2, 2.5, 3., 3.5, 4., 4.5, 5., 5.5, 6., 6.5, 7., 7.5, 8., 8.5, 9., 9.5, 10,
+            10.5, 11.
+        )
+    )]
+    pub used_solve_time: prometheus::HistogramVec,
 }
 
 /// Setup the metrics registry.


### PR DESCRIPTION
# Description
Currently we don't have good data on how long solvers have to compute their solution. We do have a dashboard that shows the remaining time as observed by the solver engine. While this is the most accurate way to measure this we also only have data for very few solvers.

# Changes
- measure remaining solve time right before driver starts sending the request.
- measure how long the solver needed to report back a solution

# Test
- deployed on shadow mainnet and checked the presence of the data with grafana