### PR TITLE
Speed up order prioritization

### DIFF
--- a/crates/driver/src/domain/competition/order/mod.rs
+++ b/crates/driver/src/domain/competition/order/mod.rs
@@ -1,14 +1,11 @@
 use {
-    super::auction,
     crate::{
         domain::eth,
         infra::{Ethereum, blockchain},
-        util::{self, Bytes, conv::u256::U256Ext},
+        util::{self, Bytes},
     },
-    bigdecimal::Zero,
     derive_more::{From, Into},
     model::order::{BuyTokenDestination, SellTokenSource},
-    num::CheckedDiv,
 };
 pub use {fees::FeePolicy, signature::Signature};
 
@@ -168,26 +165,6 @@ impl Order {
     /// partial limit orders.
     pub fn solver_determines_fee(&self) -> bool {
         matches!(self.kind, Kind::Limit)
-    }
-
-    /// The likelihood that this order will be fulfilled, based on token prices.
-    /// A larger value means that the order is more likely to be fulfilled.
-    /// This is used to prioritize orders when solving.
-    pub fn likelihood(&self, tokens: &auction::Tokens) -> num::BigRational {
-        match (
-            tokens.get(self.buy.token).price,
-            tokens.get(self.sell.token).price,
-        ) {
-            (Some(buy_price), Some(sell_price)) => {
-                let buy = buy_price.in_eth(self.buy.amount);
-                let sell = sell_price.in_eth(self.sell.amount);
-                sell.0
-                    .to_big_rational()
-                    .checked_div(&buy.0.to_big_rational())
-                    .unwrap_or_else(num::BigRational::zero)
-            }
-            _ => num::BigRational::zero(),
-        }
     }
 }
 


### PR DESCRIPTION
# Description
The sorting of orders based on priority takes a non-trivial amount of time. I ran a few experiments and using `f64` instead of `BigRational` for the comparison speeds up the process visibly.

# Changes
Replace `BigRational` with `OrdFloat` - a helper type which allows us to use a simple `f64` for sorting purposes.
Also since the `likelihood` function was only used in the sorting logic I moved it there.

## How to test
Ran the experiment on shadow mainnet resulting in modest speed improvements.

This shows only the sorting step and indicates that it goes from 100-250 to the 50-100ms bucket.
<img width="1336" alt="Screenshot 2025-05-20 at 19 32 41" src="https://github.com/user-attachments/assets/a53be0f1-8b07-419d-b130-69a9d29a984c" />
