### PR TITLE
[EASY] Fix baseline buy amount calculation

### DIFF
--- a/crates/solvers/src/domain/solution.rs
+++ b/crates/solvers/src/domain/solution.rs
@@ -1,8 +1,5 @@
 use {
-    crate::{
-        domain::{auction, eth, liquidity, order},
-        util,
-    },
+    crate::domain::{auction, eth, liquidity, order},
     ethereum_types::{Address, U256},
     std::{collections::HashMap, slice},
 };
@@ -155,10 +152,10 @@ impl Single {
                     .amount
                     .checked_add(surplus_fee)?
                     .min(order.sell.amount);
-                let buy = util::math::div_ceil(
-                    sell.checked_sub(surplus_fee)?.checked_mul(output.amount)?,
-                    input.amount,
-                )?;
+                let buy = sell
+                    .checked_sub(surplus_fee)?
+                    .checked_mul(output.amount)?
+                    .checked_div(input.amount)?;
                 (sell, buy)
             }
         };

--- a/crates/solvers/src/tests/cases/limit_order_quoting.rs
+++ b/crates/solvers/src/tests/cases/limit_order_quoting.rs
@@ -116,7 +116,7 @@ async fn sell_order() {
                 "id": 0,
                 "prices": {
                     "0x177127622c4a00f3d409b75571e12cb3c8973d3c": "995857692278744911",
-                    "0x9c58bacc331c9aa871afd802db6379a98e80cedb": "1656483497858673768805"
+                    "0x9c58bacc331c9aa871afd802db6379a98e80cedb": "1656483497858673768804"
                 },
                 "trades": [
                     {


### PR DESCRIPTION
# Description
When testing on new networks where the settlement contract buffers are empty, baseline solver solutions couldn't be verified due to on-chain reverts that showed a 1 unit higher out amount calculated by the solver compared to the values returned by liquidity pools. After testing it with different liquidity pools separately(uniswap and balancer), it became apparent that there is an issue on the baseline's side.

# Changes
When calculating the buy amount for sell orders, `ceil_div` was used, probably because the settlement contract uses it. But from the solver's perspective, it should be a `floor` operation to avoid providing too good solutions. This PR addresses it.

## How to test
It is hard to validate on the existing networks, but pretty straightforward on new ones, such as Polygon. No more reverts with the baseline's solutions. Also, an updated unit test.