### PR TITLE
Allow to specify rpc batching config in driver binary

### DIFF
--- a/crates/driver/src/boundary/mod.rs
+++ b/crates/driver/src/boundary/mod.rs
@@ -45,8 +45,12 @@ fn web3(eth: &Ethereum) -> Web3 {
 
 /// Builds a web3 client that buffers requests and sends them in a
 /// batch call.
-pub fn buffered_web3_client(ethrpc: &Url) -> Web3 {
-    web3_client(ethrpc, 20, 10)
+pub fn buffered_web3_client(
+    ethrpc: &Url,
+    max_batch_size: usize,
+    max_concurrent_requests: usize,
+) -> Web3 {
+    web3_client(ethrpc, max_batch_size, max_concurrent_requests)
 }
 
 /// Builds a web3 client that sends requests one by one.

--- a/crates/driver/src/infra/blockchain/contracts.rs
+++ b/crates/driver/src/infra/blockchain/contracts.rs
@@ -10,7 +10,6 @@ use {
     ethrpc::block_stream::CurrentBlockWatcher,
     std::collections::HashMap,
     thiserror::Error,
-    url::Url,
 };
 
 #[derive(Debug, Clone)]
@@ -59,7 +58,7 @@ impl Contracts {
         chain: Chain,
         addresses: Addresses,
         block_stream: CurrentBlockWatcher,
-        archive_node_url: Option<&Url>,
+        archive_node: Option<super::RpcArgs>,
     ) -> Result<Self, Error> {
         let address_for = |contract: &ethcontract::Contract,
                            address: Option<eth::ContractAddress>| {
@@ -95,9 +94,13 @@ impl Contracts {
                 .0,
         );
 
-        let archive_node_web3 = archive_node_url
-            .as_ref()
-            .map_or(web3.clone(), |url| boundary::buffered_web3_client(url));
+        let archive_node_web3 = archive_node.as_ref().map_or(web3.clone(), |args| {
+            boundary::buffered_web3_client(
+                &args.url,
+                args.max_batch_size,
+                args.max_concurrent_requests,
+            )
+        });
         let mut cow_amm_registry = cow_amm::Registry::new(archive_node_web3);
         for config in addresses.cow_amms {
             cow_amm_registry

--- a/crates/driver/src/infra/blockchain/mod.rs
+++ b/crates/driver/src/infra/blockchain/mod.rs
@@ -194,9 +194,10 @@ impl Ethereum {
         let json = self
             .web3
             .transport()
-            .execute("eth_createAccessList", vec![
-                serde_json::to_value(&tx).unwrap(),
-            ])
+            .execute(
+                "eth_createAccessList",
+                vec![serde_json::to_value(&tx).unwrap()],
+            )
             .await?;
         if let Some(err) = json.get("error") {
             return Err(Error::AccessList(err.to_owned()));

--- a/crates/driver/src/infra/blockchain/mod.rs
+++ b/crates/driver/src/infra/blockchain/mod.rs
@@ -20,21 +20,27 @@ pub use self::{contracts::Contracts, gas::GasPriceEstimator};
 pub struct Rpc {
     web3: DynWeb3,
     chain: Chain,
-    url: Url,
+    args: RpcArgs,
+}
+
+pub struct RpcArgs {
+    pub url: Url,
+    pub max_batch_size: usize,
+    pub max_concurrent_requests: usize,
 }
 
 impl Rpc {
     /// Instantiate an RPC client to an Ethereum (or Ethereum-compatible) node
     /// at the specifed URL.
-    pub async fn try_new(url: &url::Url) -> Result<Self, RpcError> {
-        let web3 = boundary::buffered_web3_client(url);
+    pub async fn try_new(args: RpcArgs) -> Result<Self, RpcError> {
+        let web3 = boundary::buffered_web3_client(
+            &args.url,
+            args.max_batch_size,
+            args.max_concurrent_requests,
+        );
         let chain = Chain::try_from(web3.eth().chain_id().await?)?;
 
-        Ok(Self {
-            web3,
-            chain,
-            url: url.clone(),
-        })
+        Ok(Self { web3, chain, args })
     }
 
     /// Returns the chain for the RPC connection.
@@ -83,19 +89,25 @@ impl Ethereum {
         gas: Arc<GasPriceEstimator>,
         archive_node_url: Option<&Url>,
     ) -> Self {
-        let Rpc { web3, chain, url } = rpc;
+        let Rpc { web3, chain, args } = rpc;
 
-        let current_block_stream =
-            ethrpc::block_stream::current_block_stream(url, std::time::Duration::from_millis(500))
-                .await
-                .expect("couldn't initialize current block stream");
+        let current_block_stream = ethrpc::block_stream::current_block_stream(
+            args.url.clone(),
+            std::time::Duration::from_millis(500),
+        )
+        .await
+        .expect("couldn't initialize current block stream");
 
         let contracts = Contracts::new(
             &web3,
             chain,
             addresses,
             current_block_stream.clone(),
-            archive_node_url,
+            archive_node_url.map(|url| RpcArgs {
+                url: url.clone(),
+                max_batch_size: args.max_batch_size,
+                max_concurrent_requests: args.max_concurrent_requests,
+            }),
         )
         .await
         .expect("could not initialize important smart contracts");
@@ -182,10 +194,9 @@ impl Ethereum {
         let json = self
             .web3
             .transport()
-            .execute(
-                "eth_createAccessList",
-                vec![serde_json::to_value(&tx).unwrap()],
-            )
+            .execute("eth_createAccessList", vec![
+                serde_json::to_value(&tx).unwrap(),
+            ])
             .await?;
         if let Some(err) = json.get("error") {
             return Err(Error::AccessList(err.to_owned()));

--- a/crates/driver/src/infra/cli.rs
+++ b/crates/driver/src/infra/cli.rs
@@ -25,6 +25,14 @@ pub struct Args {
     #[clap(long, env)]
     pub ethrpc: Url,
 
+    /// The amount of RPC calls to pack into a single RPC request.
+    #[clap(long, env, default_value = "20")]
+    pub ethrpc_max_batch_size: usize,
+
+    /// The maximum number of concurrent requests to the RPC node.
+    #[clap(long, env, default_value = "10")]
+    pub ethrpc_max_concurrent_requests: usize,
+
     /// Path to the driver configuration file. This file should be in TOML
     /// format. For an example see
     /// https://github.com/cowprotocol/services/blob/main/crates/driver/example.toml.

--- a/crates/driver/src/run.rs
+++ b/crates/driver/src/run.rs
@@ -139,7 +139,12 @@ fn simulator(config: &infra::Config, eth: &Ethereum) -> Simulator {
 }
 
 async fn ethrpc(args: &cli::Args) -> blockchain::Rpc {
-    blockchain::Rpc::try_new(&args.ethrpc)
+    let args = blockchain::RpcArgs {
+        url: args.ethrpc.clone(),
+        max_batch_size: args.ethrpc_max_batch_size,
+        max_concurrent_requests: args.ethrpc_max_concurrent_requests,
+    };
+    blockchain::Rpc::try_new(args)
         .await
         .expect("connect ethereum RPC")
 }

--- a/crates/driver/src/tests/setup/solver.rs
+++ b/crates/driver/src/tests/setup/solver.rs
@@ -439,8 +439,10 @@ impl Solver {
         .await
         .unwrap();
         let gas = Arc::new(
-            infra::blockchain::GasPriceEstimator::new(rpc.web3(), &Default::default(), &[
-                infra::mempool::Config {
+            infra::blockchain::GasPriceEstimator::new(
+                rpc.web3(),
+                &Default::default(),
+                &[infra::mempool::Config {
                     min_priority_fee: Default::default(),
                     gas_price_cap: eth::U256::MAX,
                     target_confirm_time: Default::default(),
@@ -450,8 +452,8 @@ impl Solver {
                         additional_tip_percentage: 0.,
                         revert_protection: infra::mempool::RevertProtection::Disabled,
                     },
-                },
-            ])
+                }],
+            )
             .await
             .unwrap(),
         );

--- a/crates/driver/src/tests/setup/solver.rs
+++ b/crates/driver/src/tests/setup/solver.rs
@@ -431,12 +431,16 @@ impl Solver {
             .collect::<HashMap<_, _>>();
 
         let url = config.blockchain.web3_url.parse().unwrap();
-        let rpc = infra::blockchain::Rpc::try_new(&url).await.unwrap();
+        let rpc = infra::blockchain::Rpc::try_new(infra::blockchain::RpcArgs {
+            url,
+            max_batch_size: 20,
+            max_concurrent_requests: 10,
+        })
+        .await
+        .unwrap();
         let gas = Arc::new(
-            infra::blockchain::GasPriceEstimator::new(
-                rpc.web3(),
-                &Default::default(),
-                &[infra::mempool::Config {
+            infra::blockchain::GasPriceEstimator::new(rpc.web3(), &Default::default(), &[
+                infra::mempool::Config {
                     min_priority_fee: Default::default(),
                     gas_price_cap: eth::U256::MAX,
                     target_confirm_time: Default::default(),
@@ -446,8 +450,8 @@ impl Solver {
                         additional_tip_percentage: 0.,
                         revert_protection: infra::mempool::RevertProtection::Disabled,
                     },
-                }],
-            )
+                },
+            ])
             .await
             .unwrap(),
         );


### PR DESCRIPTION
# Description
Currently the driver runs all rpc requests with a hardcoded 20, 10 for `max_requests_per_batch` and `max_concurrent_requests`. For other binaries, we override this value in infra to be 40, 20 (cf. [infra](https://github.com/cowprotocol/infrastructure/blob/43c42bae52e6c2b9d525e08b875321fdce8f7073/services/config/rpc.ts#L23))

At the same time we are seeing significant performance issues ([slack](https://cowservices.slack.com/archives/C0361CDD1FZ/p1747920216957199)) when not using RPC nodes that are inside our cluster. After inspecting the RPC performance itself our current assumption is that the added network latency from going over the internet is the root cause. This overhead should be controllable by batching more.

# Changes
- [x] Add additional optional parameters to the drivers run binary (cannot add it to config since we need the RPC instance before we can load the config file)
- [x] Use new config and initialise with default parameters on all call sites
- [x] Make optional archive node URL use the same config as default RPC

## How to test
CI

## Related Issues
#3409