### PR TITLE
Univ3 support in baseline

### DIFF
--- a/crates/solvers/src/boundary/baseline.rs
+++ b/crates/solvers/src/boundary/baseline.rs
@@ -23,7 +23,7 @@ impl<'a> Solver<'a> {
         weth: &eth::WethAddress,
         base_tokens: &HashSet<eth::TokenAddress>,
         liquidity: &'a [liquidity::Liquidity],
-        web3: &Web3,
+        web3: Option<&Web3>,
     ) -> Self {
         Self {
             base_tokens: to_boundary_base_tokens(weth, base_tokens),
@@ -155,7 +155,7 @@ impl<'a> Solver<'a> {
 
 fn to_boundary_liquidity(
     liquidity: &[liquidity::Liquidity],
-    web3: &Web3,
+    web3: Option<&Web3>,
 ) -> HashMap<TokenPair, Vec<OnchainLiquidity>> {
     liquidity
         .iter()
@@ -228,6 +228,11 @@ fn to_boundary_liquidity(
                     }
                 }
                 liquidity::State::Concentrated(pool) => {
+                    let Some(web3) = web3 else {
+                        // liquidity sources that rely on an RPC are disabled
+                        return onchain_liquidity;
+                    };
+
                     let token_pair = to_boundary_token_pair(&pool.tokens);
                     onchain_liquidity
                         .entry(token_pair)

--- a/crates/solvers/src/boundary/liquidity/concentrated.rs
+++ b/crates/solvers/src/boundary/liquidity/concentrated.rs
@@ -1,0 +1,94 @@
+use {
+    contracts::{
+        ethcontract::{H160, I256, U256},
+        uniswap_v3_pool,
+    },
+    ethrpc::Web3,
+    model::TokenPair,
+    shared::baseline_solver::BaselineSolvable,
+};
+
+#[derive(Debug)]
+pub struct Pool {
+    pub web3: Web3,
+    pub address: H160,
+    pub tokens: TokenPair,
+}
+
+impl BaselineSolvable for Pool {
+    async fn get_amount_out(
+        &self,
+        out_token: H160,
+        (in_amount, in_token): (U256, H160),
+    ) -> Option<U256> {
+        let in_amount = I256::from_raw(in_amount);
+        if TokenPair::new(out_token, in_token) != Some(self.tokens) || in_amount.is_negative() {
+            // pool has wrong tokens or input amount would overflow
+            return None;
+        }
+
+        let contract = uniswap_v3_pool::Contract::at(&self.web3, self.address);
+        let zero_for_one = in_token == self.tokens.get().0;
+
+        let (amount0, amount1) = contract
+            .swap(
+                H160::random(), // use random address since we only care about the amounts and not
+                // the exact calldata here
+                zero_for_one, // indicates whether we swap token0 for token1 or the other way
+                in_amount,    // positive value indicates exact input
+                U256::zero(), // disable price impact protection
+                Default::default(), // don't pass additional data
+            )
+            .call()
+            .await
+            .ok()?;
+
+        match zero_for_one {
+            true => Some(abs(&amount1)),
+            false => Some(abs(&amount0)),
+        }
+    }
+
+    async fn get_amount_in(
+        &self,
+        in_token: H160,
+        (out_amount, out_token): (U256, H160),
+    ) -> Option<U256> {
+        let out_amount = I256::from_raw(out_amount);
+        if TokenPair::new(out_token, in_token) != Some(self.tokens) || out_amount.is_negative() {
+            // pool has wrong tokens or out amount would overflow
+            return None;
+        }
+
+        let contract = uniswap_v3_pool::Contract::at(&self.web3, self.address);
+        let zero_for_one = in_token == self.tokens.get().0;
+
+        let (amount0, amount1) = contract
+            .swap(
+                H160::random(), // use random address since we only care about the amounts and not
+                // the exact calldata here
+                zero_for_one, // indicates whether we swap token0 for token1 or the other way
+                -out_amount,  // negative indicates exact output
+                U256::zero(), // disable price impact protection
+                Default::default(), // don't pass additional data
+            )
+            .call()
+            .await
+            .ok()?;
+        match zero_for_one {
+            true => Some(abs(&amount0)),
+            false => Some(abs(&amount1)),
+        }
+    }
+
+    async fn gas_cost(&self) -> usize {
+        // TODO: research a reasonable approximation
+        100_000
+    }
+}
+
+fn abs(val: &I256) -> U256 {
+    let mut bytes = [0_u8; 32];
+    val.abs().to_big_endian(&mut bytes);
+    U256::from_big_endian(&bytes)
+}

--- a/crates/solvers/src/boundary/liquidity/concentrated.rs
+++ b/crates/solvers/src/boundary/liquidity/concentrated.rs
@@ -15,6 +15,8 @@ pub struct Pool {
     pub tokens: TokenPair,
 }
 
+// Computes input or output amounts via eth_calls. The implementation was based
+// on these [docs](https://docs.uniswap.org/contracts/v3/reference/core/UniswapV3Pool#swap).
 impl BaselineSolvable for Pool {
     async fn get_amount_out(
         &self,

--- a/crates/solvers/src/boundary/liquidity/mod.rs
+++ b/crates/solvers/src/boundary/liquidity/mod.rs
@@ -1,3 +1,4 @@
+pub mod concentrated;
 pub mod constant_product;
 mod limit_order;
 pub mod stable;

--- a/crates/solvers/src/domain/solver.rs
+++ b/crates/solvers/src/domain/solver.rs
@@ -68,12 +68,14 @@ struct Inner {
     /// token
     native_token_price_estimation_amount: eth::U256,
 
-    web3: Web3,
+    /// If a provider is configured the solver will use liquidity sources which
+    /// rely on eth_calls to compute the input or output amounts.
+    web3: Option<Web3>,
 }
 
 impl Solver {
     /// Creates a new baseline solver for the specified configuration.
-    pub fn new(config: Config, web3: Web3) -> Self {
+    pub fn new(config: Config, web3: Option<Web3>) -> Self {
         Self(Arc::new(Inner {
             weth: config.weth,
             base_tokens: config.base_tokens.into_iter().collect(),
@@ -135,7 +137,7 @@ impl Inner {
             &self.weth,
             &self.base_tokens,
             &auction.liquidity,
-            &self.web3,
+            self.web3.as_ref(),
         );
 
         for (i, order) in auction.orders.into_iter().enumerate() {

--- a/crates/solvers/src/infra/cli.rs
+++ b/crates/solvers/src/infra/cli.rs
@@ -41,6 +41,6 @@ pub enum Command {
         config: PathBuf,
 
         #[clap(long, env)]
-        node_url: Url,
+        node_url: Option<Url>,
     },
 }

--- a/crates/solvers/src/infra/cli.rs
+++ b/crates/solvers/src/infra/cli.rs
@@ -2,6 +2,7 @@
 
 use {
     clap::{Parser, Subcommand},
+    reqwest::Url,
     std::{net::SocketAddr, path::PathBuf},
 };
 
@@ -38,5 +39,8 @@ pub enum Command {
     Baseline {
         #[clap(long, env)]
         config: PathBuf,
+
+        #[clap(long, env)]
+        node_url: Url,
     },
 }

--- a/crates/solvers/src/run.rs
+++ b/crates/solvers/src/run.rs
@@ -29,9 +29,15 @@ async fn run_with(args: cli::Args, bind: Option<oneshot::Sender<SocketAddr>>) {
     tracing::info!("running solver engine with {args:#?}");
 
     let solver = match args.command {
-        cli::Command::Baseline { config } => {
+        cli::Command::Baseline { config, node_url } => {
             let config = config::load(&config).await;
-            solver::Solver::new(config)
+            let web3 = ethrpc::web3(
+                Default::default(),
+                Default::default(),
+                &node_url,
+                "baseline",
+            );
+            solver::Solver::new(config, web3)
         }
     };
 

--- a/crates/solvers/src/run.rs
+++ b/crates/solvers/src/run.rs
@@ -31,12 +31,8 @@ async fn run_with(args: cli::Args, bind: Option<oneshot::Sender<SocketAddr>>) {
     let solver = match args.command {
         cli::Command::Baseline { config, node_url } => {
             let config = config::load(&config).await;
-            let web3 = ethrpc::web3(
-                Default::default(),
-                Default::default(),
-                &node_url,
-                "baseline",
-            );
+            let web3 = node_url
+                .map(|url| ethrpc::web3(Default::default(), Default::default(), &url, "baseline"));
             solver::Solver::new(config, web3)
         }
     };


### PR DESCRIPTION
# Description
Adds support for uniswap v3 liquidity in the baseline solver. Instead of using the traditional approach of reimplementing the pool smart contract logic to a tea in Rust (which is complicated and error prone) we compute input and output amounts via `eth_call`s.
The downside of this approach is that it's slower than the pure Rust solution. To de-risk this change I made the RPC based liquidity usage optional. That way we can easily test this in staging / prod and quickly revert in case we see issues with this.

Since the baseline solver algorithm is very simple I hope it doesn't issue too many RPC calls but that needs to be tested for real.

# Changes
Implements `BaselineSolvable` for univ3 liquidity using `eth_calls`.

## How to test
I want to deploy this to staging first to see if the approach is actually viable and doesn't issue too many RPC calls and introduce too much latency.
Once this is confirmed I'll probably open another PR for a forked e2e test using only univ3 liquidity.