### PR TITLE
Simplify ethflow indexing start block search

### DIFF
--- a/crates/autopilot/src/boundary/events/settlement.rs
+++ b/crates/autopilot/src/boundary/events/settlement.rs
@@ -26,7 +26,7 @@ impl Indexer {
 }
 
 /// This name is used to store the latest indexed block in the db.
-const INDEX_NAME: &str = "settlements";
+pub const INDEX_NAME: &str = "settlements";
 
 #[async_trait::async_trait]
 impl EventStoring<contracts::gpv2_settlement::Event> for Indexer {

--- a/crates/autopilot/src/boundary/events/settlement.rs
+++ b/crates/autopilot/src/boundary/events/settlement.rs
@@ -26,7 +26,7 @@ impl Indexer {
 }
 
 /// This name is used to store the latest indexed block in the db.
-pub const INDEX_NAME: &str = "settlements";
+pub(crate) const INDEX_NAME: &str = "settlements";
 
 #[async_trait::async_trait]
 impl EventStoring<contracts::gpv2_settlement::Event> for Indexer {

--- a/crates/autopilot/src/database/ethflow_events/event_storing.rs
+++ b/crates/autopilot/src/database/ethflow_events/event_storing.rs
@@ -36,7 +36,7 @@ fn get_refunds(events: Vec<ethcontract::Event<EthFlowEvent>>) -> Result<Vec<Refu
 type EthFlowEvent = contracts::cowswap_eth_flow::Event;
 
 /// This name is used to store the latest indexed block in the db.
-const INDEX_NAME: &str = "ethflow_refunds";
+pub const INDEX_NAME: &str = "ethflow_refunds";
 
 #[async_trait::async_trait]
 impl EventStoring<EthFlowEvent> for Postgres {

--- a/crates/autopilot/src/database/ethflow_events/event_storing.rs
+++ b/crates/autopilot/src/database/ethflow_events/event_storing.rs
@@ -36,7 +36,7 @@ fn get_refunds(events: Vec<ethcontract::Event<EthFlowEvent>>) -> Result<Vec<Refu
 type EthFlowEvent = contracts::cowswap_eth_flow::Event;
 
 /// This name is used to store the latest indexed block in the db.
-pub const INDEX_NAME: &str = "ethflow_refunds";
+pub(crate) const INDEX_NAME: &str = "ethflow_refunds";
 
 #[async_trait::async_trait]
 impl EventStoring<EthFlowEvent> for Postgres {

--- a/crates/autopilot/src/database/onchain_order_events/ethflow_events.rs
+++ b/crates/autopilot/src/database/onchain_order_events/ethflow_events.rs
@@ -212,7 +212,7 @@ pub async fn determine_ethflow_refund_indexing_start(
         return *block_number_hash;
     }
 
-    let last_indexed_refund_block = find_indexing_start_block(
+    let ethflow_refund_indexing_start = find_indexing_start_block(
         &db.pool,
         web3,
         crate::database::ethflow_events::event_storing::INDEX_NAME,
@@ -221,7 +221,7 @@ pub async fn determine_ethflow_refund_indexing_start(
     )
     .await
     .expect("Should be able to find last indexed refund block");
-    let last_indexed_settlement_block = find_indexing_start_block(
+    let settlement_contract_indexing_start = find_indexing_start_block(
         &db.pool,
         web3,
         crate::boundary::events::settlement::INDEX_NAME,
@@ -231,11 +231,14 @@ pub async fn determine_ethflow_refund_indexing_start(
     .await
     .expect("Should be able to find last indexed settlement block");
 
-    vec![last_indexed_refund_block, last_indexed_settlement_block]
-        .into_iter()
-        .flatten()
-        .max_by_key(|(block_number, _)| *block_number)
-        .expect("Should be able to find a valid start block")
+    vec![
+        ethflow_refund_indexing_start,
+        settlement_contract_indexing_start,
+    ]
+    .into_iter()
+    .flatten()
+    .max_by_key(|(block_number, _)| *block_number)
+    .expect("Should be able to find a valid start block")
 }
 
 /// 1. Check the `last_indexed_blocks` table for the `index_name`. Use the next

--- a/crates/autopilot/src/database/onchain_order_events/ethflow_events.rs
+++ b/crates/autopilot/src/database/onchain_order_events/ethflow_events.rs
@@ -264,7 +264,7 @@ async fn find_indexing_start_block(
         return block_number_to_block_number_hash(web3, U64::from(last_indexed_block + 1).into())
             .await
             .map(Some)
-            .ok_or_else(|| anyhow::anyhow!("failed to fetch block"));
+            .context("failed to fetch block");
     }
     if let Some(start_block) = fallback_start_block {
         return block_number_to_block_number_hash(web3, start_block.into())

--- a/crates/autopilot/src/database/onchain_order_events/ethflow_events.rs
+++ b/crates/autopilot/src/database/onchain_order_events/ethflow_events.rs
@@ -165,7 +165,7 @@ pub async fn determine_ethflow_indexing_start(
     ethflow_indexing_start: Option<u64>,
     web3: &Web3,
     chain_id: u64,
-    db: crate::database::Postgres,
+    db: &crate::database::Postgres,
 ) -> BlockNumberHash {
     if let Some(block_number_hash) = skip_event_sync_start {
         return *block_number_hash;
@@ -180,7 +180,7 @@ pub async fn determine_ethflow_indexing_start(
     )
     .await
     .expect("Should be able to find last indexed onchain order block")
-    .unwrap_or_else(|| panic!("No last indexed block found for ethflow orders"))
+    .expect("No last indexed block found for ethflow orders")
 }
 
 /// Determines the starting block number and hash for indexing eth-flow refund

--- a/crates/autopilot/src/database/onchain_order_events/ethflow_events.rs
+++ b/crates/autopilot/src/database/onchain_order_events/ethflow_events.rs
@@ -261,23 +261,25 @@ async fn find_indexing_start_block(
         .context("failed to read last indexed block from db")?;
 
     if last_indexed_block > 0 {
-        block_number_to_block_number_hash(web3, U64::from(last_indexed_block + 1).into())
+        return block_number_to_block_number_hash(web3, U64::from(last_indexed_block + 1).into())
             .await
             .map(Some)
-            .ok_or_else(|| anyhow::anyhow!("failed to fetch block"))
-    } else if let Some(start_block) = fallback_start_block {
-        block_number_to_block_number_hash(web3, start_block.into())
-            .await
-            .map(Some)
-            .context("failed to fetch fallback indexing start block")
-    } else if let Some(chain_id) = settlement_fallback_chain_id {
-        settlement_deployment_block_number_hash(web3, chain_id)
-            .await
-            .map(Some)
-            .context("failed to fetch settlement deployment block")
-    } else {
-        Ok(None)
+            .ok_or_else(|| anyhow::anyhow!("failed to fetch block"));
     }
+    if let Some(start_block) = fallback_start_block {
+        return block_number_to_block_number_hash(web3, start_block.into())
+            .await
+            .map(Some)
+            .context("failed to fetch fallback indexing start block");
+    }
+    if let Some(chain_id) = settlement_fallback_chain_id {
+        return settlement_deployment_block_number_hash(web3, chain_id)
+            .await
+            .map(Some)
+            .context("failed to fetch settlement deployment block");
+    }
+
+    Ok(None)
 }
 
 #[cfg(test)]

--- a/crates/autopilot/src/database/onchain_order_events/mod.rs
+++ b/crates/autopilot/src/database/onchain_order_events/mod.rs
@@ -148,7 +148,7 @@ where
 }
 
 /// This name is used to store the latest indexed block in the db.
-pub const INDEX_NAME: &str = "onchain_orders";
+pub(crate) const INDEX_NAME: &str = "onchain_orders";
 
 #[async_trait::async_trait]
 impl<T: Sync + Send + Clone, W: Sync + Send + Clone> EventStoring<ContractEvent>

--- a/crates/autopilot/src/database/onchain_order_events/mod.rs
+++ b/crates/autopilot/src/database/onchain_order_events/mod.rs
@@ -148,7 +148,7 @@ where
 }
 
 /// This name is used to store the latest indexed block in the db.
-const INDEX_NAME: &str = "onchain_orders";
+pub const INDEX_NAME: &str = "onchain_orders";
 
 #[async_trait::async_trait]
 impl<T: Sync + Send + Clone, W: Sync + Send + Clone> EventStoring<ContractEvent>

--- a/crates/autopilot/src/run.rs
+++ b/crates/autopilot/src/run.rs
@@ -544,7 +544,7 @@ pub async fn run(args: Arguments) {
             args.ethflow_indexing_start,
             &web3,
             chain_id,
-            db.clone(),
+            &db,
         )
         .await;
 

--- a/crates/autopilot/src/run.rs
+++ b/crates/autopilot/src/run.rs
@@ -544,6 +544,7 @@ pub async fn run(args: Arguments) {
             args.ethflow_indexing_start,
             &web3,
             chain_id,
+            db.clone(),
         )
         .await;
 

--- a/crates/database/src/ethflow_orders.rs
+++ b/crates/database/src/ethflow_orders.rs
@@ -73,14 +73,6 @@ pub async fn delete_refunds(
     Ok(())
 }
 
-/// Returns the last block where an ethflow refund transaction has been indexed.
-pub async fn last_indexed_block(ex: &mut PgConnection) -> Result<Option<i64>, sqlx::Error> {
-    const QUERY: &str = r#"
-        SELECT block_number from ethflow_refunds ORDER BY block_number DESC LIMIT 1;
-    "#;
-    sqlx::query_scalar(QUERY).fetch_optional(ex).await
-}
-
 pub async fn insert_refund_tx_hashes(
     ex: &mut PgTransaction<'_>,
     refunds: &[Refund],


### PR DESCRIPTION
# Description
Currently, determining the start block of indexing ethflow events on fresh chains with no corresponding orders/refunds requires using an RPC node that has access to either the ethflow or settlement contract deployment blocks. 

When dealing with pruned full nodes as a primary transport, a solution for that could be to use an archive node for the initial start that will index all the old blocks, and then switch back to the pruned one. With the current implementation, that is not possible, which still requires access to either the ethflow db data or the contract deployment block. Another ethflow indexing start block or even "skip indexing" flag can be provided via the config to solve this, but the autopilot's logic remains outdated.

With #3075, this logic can be simplified by relying on the last indexed blocks stored in the corresponding DB table.

# Changes

1. Search for a corresponding record in the `last_indexed_blocks`. Use the next block as the starting index.
2. In case it doesn't exist yet or the index is 0, use the configured ethflow indexing start block value.
3. Fallback to the settlement contract deployment block number.
4. Use the determined number to fetch the block using the connected RPC node to ensure it is able to continue indexing.

With this logic, the pruned node can safely be used on networks with no ethflow orders yet, but with already indexed data.

## How to test
✅  Tested on Avalanche + pruned full node, which fails to start with the `main` services image but works with this PR.

## Related PRs

Simplifies #2931, utilized #3075