### PR TITLE
Fill flashloan data in driver if solver didn't specify anything

### DIFF
--- a/crates/driver/src/domain/eth/mod.rs
+++ b/crates/driver/src/domain/eth/mod.rs
@@ -2,6 +2,7 @@ use {
     crate::util::{Bytes, conv::u256::U256Ext},
     derive_more::{From, Into},
     itertools::Itertools,
+    solvers_dto::auction::FlashloanHint,
     std::{
         collections::{HashMap, HashSet},
         ops::{Div, Mul, Sub},
@@ -428,4 +429,27 @@ pub struct Flashloan {
     pub borrower: Address,
     pub token: TokenAddress,
     pub amount: TokenAmount,
+}
+
+impl From<&solvers_dto::solution::Flashloan> for Flashloan {
+    fn from(value: &solvers_dto::solution::Flashloan) -> Self {
+        Self {
+            lender: value.lender.into(),
+            borrower: value.borrower.into(),
+            token: value.token.into(),
+            amount: value.amount.into(),
+        }
+    }
+}
+
+#[allow(clippy::from_over_into)]
+impl Into<FlashloanHint> for &Flashloan {
+    fn into(self) -> FlashloanHint {
+        FlashloanHint {
+            lender: self.lender.into(),
+            borrower: self.borrower.into(),
+            token: self.token.into(),
+            amount: self.amount.into(),
+        }
+    }
 }

--- a/crates/driver/src/infra/solver/dto/solution.rs
+++ b/crates/driver/src/infra/solver/dto/solution.rs
@@ -1,7 +1,7 @@
 use {
     crate::{
         domain::{competition, eth, liquidity},
-        infra::{Solver, solver::Config},
+        infra::Solver,
         util::Bytes,
     },
     app_data::AppDataHash,
@@ -10,7 +10,7 @@ use {
         DomainSeparator,
         order::{BuyTokenDestination, OrderData, OrderKind, SellTokenSource},
     },
-    std::str::FromStr,
+    std::{collections::HashMap, str::FromStr},
 };
 
 #[derive(derive_more::From)]
@@ -23,7 +23,7 @@ impl Solutions {
         liquidity: &[liquidity::Liquidity],
         weth: eth::WethAddress,
         solver: Solver,
-        solver_config: &Config,
+        flashloan_hints: &HashMap<competition::order::Uid, eth::Flashloan>,
     ) -> Result<Vec<competition::Solution>, super::Error> {
         self.0.solutions
             .into_iter()
@@ -32,7 +32,7 @@ impl Solutions {
                     competition::solution::Id::new(solution.id),
                     solution
                         .trades
-                        .into_iter()
+                        .iter()
                         .map(|trade| match trade {
                             solvers_dto::solution::Trade::Fulfillment(fulfillment) => {
                                 let order = auction
@@ -59,7 +59,7 @@ impl Solutions {
                                 .map_err(|err| super::Error(format!("invalid fulfillment: {err}")))
                             }
                             solvers_dto::solution::Trade::Jit(jit) => {
-                                let jit_order: JitOrder = jit.order.into();
+                                let jit_order: JitOrder = jit.order.clone().into();
                                 Ok(competition::solution::Trade::Jit(
                                 competition::solution::trade::Jit::new(
                                     competition::order::Jit {
@@ -206,18 +206,18 @@ impl Solutions {
                     solver.clone(),
                     weth,
                     solution.gas.map(|gas| eth::Gas(gas.into())),
-                    solver_config.fee_handler,
+                    solver.config().fee_handler,
                     auction.surplus_capturing_jit_order_owners(),
-                    solution
-                        .flashloans
-                        .into_iter()
-                        .map(|flashloan| eth::Flashloan {
-                            lender: flashloan.lender.into(),
-                            borrower: flashloan.borrower.into(),
-                            token: flashloan.token.into(),
-                            amount: flashloan.amount.into(),
-                        })
-                        .collect(),
+                    solution.flashloans
+                        .map(|f| f.iter().map(Into::into).collect())
+                        .unwrap_or_else(|| solution.trades.iter()
+                            .filter_map(|t| {
+                            let solvers_dto::solution::Trade::Fulfillment(trade) = &t else {
+                                // we don't have any flashloan data on JIT orders
+                                return None;
+                            };
+                            flashloan_hints.get(&trade.order.into()).cloned()
+                        }).collect()),
                 )
                 .map_err(|err| match err {
                     competition::solution::error::Solution::InvalidClearingPrices => {

--- a/crates/driver/src/infra/solver/mod.rs
+++ b/crates/driver/src/infra/solver/mod.rs
@@ -5,6 +5,7 @@ use {
             competition::{
                 auction::{self, Auction},
                 bad_tokens,
+                order,
                 solution::{self, Solution},
             },
             eth,
@@ -222,6 +223,7 @@ impl Solver {
         auction: &Auction,
         liquidity: &[liquidity::Liquidity],
     ) -> Result<Vec<Solution>, Error> {
+        let flashloan_hints = self.assemble_flashloan_hints(auction);
         // Fetch the solutions from the solver.
         let weth = self.eth.contracts().weth_address();
         let auction_dto = dto::auction::new(
@@ -230,8 +232,7 @@ impl Solver {
             weth,
             self.config.fee_handler,
             self.config.solver_native_token,
-            self.config.flashloans_enabled,
-            self.eth.contracts().flashloan_default_lender(),
+            &flashloan_hints,
         );
         // Only auctions with IDs are real auctions (/quote requests don't have an ID,
         // and it makes no sense to store them)
@@ -269,11 +270,34 @@ impl Solver {
             liquidity,
             weth,
             self.clone(),
-            &self.config,
+            &flashloan_hints,
         )?;
 
         super::observe::solutions(&solutions, auction.surplus_capturing_jit_order_owners());
         Ok(solutions)
+    }
+
+    fn assemble_flashloan_hints(&self, auction: &Auction) -> HashMap<order::Uid, eth::Flashloan> {
+        if !self.config.flashloans_enabled {
+            return Default::default();
+        }
+        let Some(lender) = self.eth.contracts().flashloan_default_lender() else {
+            return Default::default();
+        };
+
+        auction
+            .orders()
+            .iter()
+            .flat_map(|order| {
+                let flashloan = order.app_data.flashloan().map(|f| eth::Flashloan {
+                    lender,
+                    borrower: f.borrower.unwrap_or(order.uid.owner().0).into(),
+                    token: f.token.into(),
+                    amount: f.amount.into(),
+                });
+                Some((order.uid, flashloan?))
+            })
+            .collect()
     }
 
     /// Make a fire and forget POST request to notify the solver about an event.
@@ -298,6 +322,10 @@ impl Solver {
             }
         };
         tokio::task::spawn(future.in_current_span());
+    }
+
+    pub fn config(&self) -> &Config {
+        &self.config
     }
 }
 

--- a/crates/e2e/tests/e2e/cow_amm.rs
+++ b/crates/e2e/tests/e2e/cow_amm.rs
@@ -343,7 +343,7 @@ async fn cow_amm_jit(web3: Web3) {
         interactions: vec![],
         post_interactions: vec![],
         gas: None,
-        flashloans: vec![],
+        flashloans: None,
     }));
 
     // Drive solution
@@ -918,7 +918,7 @@ async fn cow_amm_opposite_direction(web3: Web3) {
             interactions: vec![],
             post_interactions: vec![],
             gas: None,
-            flashloans: vec![],
+            flashloans: None,
         }
     };
 

--- a/crates/e2e/tests/e2e/jit_orders.rs
+++ b/crates/e2e/tests/e2e/jit_orders.rs
@@ -167,7 +167,7 @@ async fn single_limit_order_test(web3: Web3) {
         interactions: vec![],
         post_interactions: vec![],
         gas: None,
-        flashloans: vec![],
+        flashloans: None,
     }));
 
     // Drive solution

--- a/crates/solvers-dto/src/solution.rs
+++ b/crates/solvers-dto/src/solution.rs
@@ -1,5 +1,6 @@
 use {
     super::serialize,
+    crate::auction::FlashloanHint,
     number::serialization::HexOrDecimalU256,
     serde::{Deserialize, Serialize},
     serde_with::serde_as,
@@ -28,8 +29,8 @@ pub struct Solution {
     pub post_interactions: Vec<Call>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub gas: Option<u64>,
-    #[serde(skip_serializing_if = "Vec::is_empty", default)]
-    pub flashloans: Vec<Flashloan>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub flashloans: Option<Vec<Flashloan>>,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -211,4 +212,15 @@ pub struct Flashloan {
     pub token: H160,
     #[serde_as(as = "HexOrDecimalU256")]
     pub amount: U256,
+}
+
+impl From<&FlashloanHint> for Flashloan {
+    fn from(value: &FlashloanHint) -> Self {
+        Self {
+            lender: value.lender,
+            borrower: value.borrower,
+            token: value.token,
+            amount: value.amount,
+        }
+    }
 }

--- a/crates/solvers/src/api/routes/solve/dto/solution.rs
+++ b/crates/solvers/src/api/routes/solve/dto/solution.rs
@@ -116,16 +116,17 @@ pub fn from_domain(solutions: &[solution::Solution]) -> super::Solutions {
                     })
                     .collect(),
                 gas: solution.gas.map(|gas| gas.0.as_u64()),
-                flashloans: solution
-                    .flashloans
-                    .iter()
-                    .map(|loan| Flashloan {
-                        lender: loan.lender.0,
-                        borrower: loan.borrower.0,
-                        token: loan.token.0,
-                        amount: loan.amount,
-                    })
-                    .collect(),
+                flashloans: solution.flashloans.as_ref().map(|loans| {
+                    loans
+                        .iter()
+                        .map(|loan| Flashloan {
+                            lender: loan.lender.0,
+                            borrower: loan.borrower.0,
+                            token: loan.token.0,
+                            amount: loan.amount,
+                        })
+                        .collect()
+                }),
             })
             .collect(),
     }

--- a/crates/solvers/src/domain/solution.rs
+++ b/crates/solvers/src/domain/solution.rs
@@ -17,7 +17,7 @@ pub struct Solution {
     pub interactions: Vec<Interaction>,
     pub post_interactions: Vec<eth::Interaction>,
     pub gas: Option<eth::Gas>,
-    pub flashloans: Vec<Flashloan>,
+    pub flashloans: Option<Vec<Flashloan>>,
 }
 
 impl Solution {
@@ -180,17 +180,8 @@ impl Single {
             interactions,
             post_interactions: Default::default(),
             gas: Some(gas),
-            flashloans: order
-                .flashloan_hint
-                .clone()
-                .map(|hint| Flashloan {
-                    lender: hint.lender,
-                    borrower: hint.borrower,
-                    token: hint.token,
-                    amount: hint.amount,
-                })
-                .into_iter()
-                .collect(),
+            // rely on driver to fill in the blanks
+            flashloans: None,
             trades: vec![Trade::Fulfillment(Fulfillment::new(order, executed, fee)?)],
         })
     }


### PR DESCRIPTION
# Description
Currently solvers would have to copy the flashloan hints provided in the auction into their solution to make the driver encode the flashloan solution correctly. To allow solvers to support flashloans without having to alter anything in their response the driver actually needs to copy over the data.

# Changes
With this PR the solvers have 3 options:
* return `flashloans: null` (or don't set the field at all) => driver will fill in the blanks
* return `flashloans: []` => indicates that the solver fronts the cache
* return `flashloans: [flashloan]` => tells solver exactly which flashloan to take out (could be the original hints just copied over, or something completely different)

## How to test
I removed the logic in the baseline solver to actively copy the flashloan hints into the solution so now it also relies on the driver doing the copying. The existing flashloan e2e should still pass.