### PR TITLE
Switch back to stable foundry

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -140,10 +140,6 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
       - run: rustup toolchain install stable --profile minimal
       - uses: foundry-rs/foundry-toolchain@v1
-        with:
-          # the latest version introduced a bug caused forked node tests to fail
-          # only switch back to latest stable version after it was fixed in anvil
-          version: v1.0.0
       - uses: Swatinem/rust-cache@v2
       # Start the build process in the background. The following cargo test command will automatically
       # wait for the build process to be done before proceeding.


### PR DESCRIPTION
# Description
Foundry introduced a change in `v1.1.0` which broke our forked node tests. Since then a new stable version was [release](https://github.com/foundry-rs/foundry/releases/tag/v1.2.1) which contains the [fix](https://github.com/foundry-rs/foundry/pull/10471) for that [issue](https://github.com/foundry-rs/foundry/issues/10452).

# Changes
CI uses the latest stable foundry version again

## How to test
run ci a couple of times to see that it still works (I already ran a couple of tests when the fix was introduced in nightly).