### PR TITLE
Fetch liquidity at block driver config

### DIFF
--- a/crates/driver/src/boundary/liquidity/mod.rs
+++ b/crates/driver/src/boundary/liquidity/mod.rs
@@ -147,6 +147,7 @@ impl Fetcher {
 
         let block = match block {
             infra::liquidity::AtBlock::Recent => recent_block_cache::Block::Recent,
+            infra::liquidity::AtBlock::Finalized => recent_block_cache::Block::Finalized,
             infra::liquidity::AtBlock::Latest => {
                 let block_number = self.blocks.borrow().number;
                 recent_block_cache::Block::Number(block_number)

--- a/crates/driver/src/domain/competition/mod.rs
+++ b/crates/driver/src/domain/competition/mod.rs
@@ -107,7 +107,9 @@ impl Competition {
                 self.liquidity
                     .fetch(
                         &auction.liquidity_pairs(),
-                        infra::liquidity::AtBlock::Latest,
+                        self.solver
+                            .fetch_liquidity_at_block()
+                            .unwrap_or(infra::liquidity::AtBlock::Latest),
                     )
                     .await
             }

--- a/crates/driver/src/domain/quote.rs
+++ b/crates/driver/src/domain/quote.rs
@@ -91,7 +91,12 @@ impl Order {
         let liquidity = match solver.liquidity() {
             solver::Liquidity::Fetch => {
                 liquidity
-                    .fetch(&self.liquidity_pairs(), infra::liquidity::AtBlock::Recent)
+                    .fetch(
+                        &self.liquidity_pairs(),
+                        solver
+                            .fetch_liquidity_at_block()
+                            .unwrap_or(infra::liquidity::AtBlock::Recent),
+                    )
                     .await
             }
             solver::Liquidity::Skip => Default::default(),

--- a/crates/driver/src/infra/config/file/load.rs
+++ b/crates/driver/src/infra/config/file/load.rs
@@ -137,6 +137,13 @@ pub async fn load(chain: Chain, path: &Path) -> infra::Config {
                 },
                 settle_queue_size: solver_config.settle_queue_size,
                 flashloans_enabled: config.flashloans_enabled,
+                fetch_liquidity_at_block: config.fetch_liquidity_at_block.map(|at_block| {
+                    match at_block {
+                        file::AtBlock::Latest => liquidity::AtBlock::Latest,
+                        file::AtBlock::Recent => liquidity::AtBlock::Recent,
+                        file::AtBlock::Finalized => liquidity::AtBlock::Finalized,
+                    }
+                }),
             }
         }))
         .await,

--- a/crates/driver/src/infra/config/file/mod.rs
+++ b/crates/driver/src/infra/config/file/mod.rs
@@ -81,6 +81,10 @@ struct Config {
     /// Whether the flashloans feature is enabled.
     #[serde(default)]
     flashloans_enabled: bool,
+
+    /// Defines if the liquidity needs to be fetched at a specific block.
+    #[serde(default)]
+    fetch_liquidity_at_block: Option<AtBlock>,
 }
 
 #[serde_as]
@@ -908,4 +912,12 @@ fn default_metrics_bad_token_detector_freeze_time() -> Duration {
 /// With this default, the approximate size of the cache will be ~1.6 MB.
 fn default_app_data_cache_size() -> u64 {
     2000
+}
+
+#[derive(Clone, Copy, Debug, Deserialize)]
+#[serde(untagged, deny_unknown_fields)]
+enum AtBlock {
+    Recent,
+    Latest,
+    Finalized,
 }

--- a/crates/driver/src/infra/config/file/mod.rs
+++ b/crates/driver/src/infra/config/file/mod.rs
@@ -914,10 +914,14 @@ fn default_app_data_cache_size() -> u64 {
     2000
 }
 
+/// Which block should be used to fetch the liquidity.
 #[derive(Clone, Copy, Debug, Deserialize)]
 #[serde(untagged, deny_unknown_fields)]
 enum AtBlock {
+    /// The Web3 client decides on its own which block is the latests. 
     Recent,
+    /// Use the latest block received by the `CurrentBlockWatcher`.
     Latest,
+    /// Use the latest finalized block.
     Finalized,
 }

--- a/crates/driver/src/infra/liquidity/fetcher.rs
+++ b/crates/driver/src/infra/liquidity/fetcher.rs
@@ -14,6 +14,7 @@ pub struct Fetcher {
 }
 
 /// Specifies at which block liquidity should be fetched.
+#[derive(Debug, Clone)]
 pub enum AtBlock {
     /// Fetches liquidity at a recent block. This will prefer reusing cached
     /// liquidity even if it is stale by a few blocks instead of fetching the
@@ -27,6 +28,9 @@ pub enum AtBlock {
     Recent,
     /// Fetches liquidity liquidity for the latest state of the blockchain.
     Latest,
+    /// Useful for chains that can't fetch liquidity on non-finalized
+    /// blocks(e.g. Avalanche).
+    Finalized,
 }
 
 impl Fetcher {

--- a/crates/driver/src/infra/solver/mod.rs
+++ b/crates/driver/src/infra/solver/mod.rs
@@ -129,6 +129,8 @@ pub struct Config {
     pub settle_queue_size: usize,
     /// Whether flashloan hints should be sent to the solver.
     pub flashloans_enabled: bool,
+    /// Defines if the liquidity needs to be fetched at a specific block.
+    pub fetch_liquidity_at_block: Option<crate::infra::liquidity::AtBlock>,
 }
 
 impl Solver {
@@ -213,6 +215,10 @@ impl Solver {
 
     pub fn settle_queue_size(&self) -> usize {
         self.config.settle_queue_size
+    }
+
+    pub fn fetch_liquidity_at_block(&self) -> Option<crate::infra::liquidity::AtBlock> {
+        self.config.fetch_liquidity_at_block.clone()
     }
 
     /// Make a POST request instructing the solver to solve an auction.

--- a/crates/shared/src/recent_block_cache.rs
+++ b/crates/shared/src/recent_block_cache.rs
@@ -71,6 +71,7 @@ pub enum Block {
     /// date.
     Recent,
     Number(u64),
+    Finalized,
 }
 
 impl From<Block> for BlockNumber {
@@ -78,6 +79,7 @@ impl From<Block> for BlockNumber {
         match val {
             Block::Recent => BlockNumber::Latest,
             Block::Number(number) => BlockNumber::Number(number.into()),
+            Block::Finalized => BlockNumber::Finalized,
         }
     }
 }
@@ -283,7 +285,7 @@ where
 
     async fn fetch(&self, keys: impl IntoIterator<Item = K>, block: Block) -> Result<Vec<V>> {
         let block = match block {
-            Block::Recent => None,
+            Block::Recent | Block::Finalized => None,
             Block::Number(number) => Some(number),
         };
 

--- a/crates/shared/src/sources/uniswap_v3/pool_fetching.rs
+++ b/crates/shared/src/sources/uniswap_v3/pool_fetching.rs
@@ -338,7 +338,7 @@ impl PoolFetching for UniswapV3PoolFetcher {
         at_block: Block,
     ) -> Result<Vec<PoolInfo>> {
         let block_number = match at_block {
-            Block::Recent => self
+            Block::Recent | Block::Finalized => self
                 .events
                 .lock()
                 .await


### PR DESCRIPTION
# Description
An issue was discovered recently on Avalanche where calling `getReserves()` for non-finalized blocks on UniV2 LP leads to failures with the `cannot query unfinalized data` error. Avalanche achieves sub-second finalization, which means it should be safe to use finalized blocks for fetching liquidity.

# Changes

- [ ] A new driver configuration allowing to specify which block will be used for liquidity fetching across all the solvers: Finalized, Recent, or Latest. The difference between Recent and Latest is that when using the former, CurrentBlockWatcher is used to get the latest block, and for the latter, the web3 client decides which block is the latest.
- [ ] A single config across all the solvers.

## How to test
Avalanche deployment.
