### PR TITLE
Revert #3417 (switch foundry version)

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -140,6 +140,10 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
       - run: rustup toolchain install stable --profile minimal
       - uses: foundry-rs/foundry-toolchain@v1
+        with:
+          # the latest version introduced a bug caused forked node tests to fail
+          # only switch back to latest stable version after it was fixed in anvil
+          version: v1.0.0
       - uses: Swatinem/rust-cache@v2
       # Start the build process in the background. The following cargo test command will automatically
       # wait for the build process to be done before proceeding.


### PR DESCRIPTION
# Description
After switching to the latest foundry release the forked tests became flaky again. Seems like I didn't run the tests often enough to verify that the new version is indeed stable.
Will try to debug the foundry

# Changes
Switch back to foundry `v1.0.0` for forked tests.

## How to test
Use flaky test runner to verify fix