### PR TITLE
Combinatorial auctions e2e test

### DIFF
--- a/crates/e2e/tests/e2e/limit_orders.rs
+++ b/crates/e2e/tests/e2e/limit_orders.rs
@@ -1,5 +1,6 @@
 use {
     crate::database::AuctionTransaction,
+    bigdecimal::BigDecimal,
     contracts::ERC20,
     database::byte_array::ByteArray,
     driver::domain::eth::NonZeroU256,
@@ -14,7 +15,7 @@ use {
     number::conversions::big_decimal_to_big_uint,
     secp256k1::SecretKey,
     shared::ethrpc::Web3,
-    std::ops::DerefMut,
+    std::{collections::HashMap, ops::DerefMut},
     web3::signing::SecretKeyRef,
 };
 
@@ -30,11 +31,11 @@ async fn local_node_two_limit_orders() {
     run_test(two_limit_orders_test).await;
 }
 
-// #[tokio::test]
-// #[ignore]
-// async fn local_node_two_limit_orders_multiple_winners() {
-//     run_test(two_limit_orders_multiple_winners_test).await;
-// }
+#[tokio::test]
+#[ignore]
+async fn local_node_two_limit_orders_multiple_winners() {
+    run_test(two_limit_orders_multiple_winners_test).await;
+}
 
 #[tokio::test]
 #[ignore]
@@ -526,10 +527,31 @@ async fn two_limit_orders_multiple_winners_test(web3: Web3) {
         && settlement.solution_uid == solver_b_winning_solutions[0].uid));
 
     // Ensure all the reference scores are indexed
-    let reference_scores = database::reference_scores::fetch(&mut ex, competition.auction_id)
-        .await
-        .unwrap();
+    let reference_scores: HashMap<database::Address, BigDecimal> =
+        database::reference_scores::fetch(&mut ex, competition.auction_id)
+            .await
+            .unwrap()
+            .into_iter()
+            .map(|score| (score.solver, score.reference_score))
+            .collect();
     assert_eq!(reference_scores.len(), 2);
+
+    // fetch the reference scores of both winners
+    let solver_a_reference_score = reference_scores
+        .get(&ByteArray(solver_a.address().0))
+        .unwrap()
+        .clone();
+    let solver_b_reference_score = reference_scores
+        .get(&ByteArray(solver_b.address().0))
+        .unwrap()
+        .clone();
+
+    // The expected reference score for each winner is the solution score of the
+    // other winner
+    let solver_a_solution_score = solver_a_winning_solutions[0].score.clone();
+    let solver_b_solution_score = solver_b_winning_solutions[0].score.clone();
+    assert_eq!(solver_a_reference_score, solver_b_solution_score);
+    assert_eq!(solver_b_reference_score, solver_a_solution_score);
 }
 
 async fn too_many_limit_orders_test(web3: Web3) {


### PR DESCRIPTION
# Description

After the combinatorial auction fixes of https://github.com/cowprotocol/services/pull/3397 we can now uncomment the disabled e2e test related to multiple winners (https://github.com/cowprotocol/services/pull/3385) which already fetches data from the new `reference_scores` table (https://github.com/cowprotocol/services/pull/3365).

This PR also adds asserts for the expected reference scores of both winners of the test case.


# Changes
<!-- List of detailed changes (how the change is accomplished) -->

- [ ] Uncomment the existing `local_node_two_limit_orders_multiple_winners` e2e test
- [ ] Add asserts for the expected reference scores of both winners

## How to test
The test passes