### PR TITLE
[EASY] Add metric for multiple winners

### DIFF
--- a/crates/autopilot/src/run_loop.rs
+++ b/crates/autopilot/src/run_loop.rs
@@ -287,11 +287,6 @@ impl RunLoop {
         let num_winners = solutions.iter().filter(|p| p.is_winner()).count();
         if let Some(num_winners_f64) = num_winners.to_f64() {
             Metrics::get().auction_winners.observe(num_winners_f64);
-        } else {
-            tracing::error!(
-                "Failed to convert auction winner count ({}) to f64",
-                num_winners
-            );
         }
 
         let competition_simulation_block = self.eth.current_block().borrow().number;


### PR DESCRIPTION
# Description
To better track the behavior and impact of combinatorial auctions, we want a new metric that allows us to visualize the amount of auction winners.

We want to plot a dashboard panel to group auctions by number of winners and compare the amount of auctions in each group.

# Changes
A new `Histogram` metric `gp_v2_autopilot_runloop_auction_winners` that records how many winners did an auction have

## How to test
Tested on staging 

<!--
## Related Issues

Fixes #
-->