### PR TITLE
Fix sorting of ranked solutions

### DIFF
--- a/crates/autopilot/src/domain/competition/mod.rs
+++ b/crates/autopilot/src/domain/competition/mod.rs
@@ -101,6 +101,8 @@ pub struct TradedOrder {
     derive_more::AddAssign,
     derive_more::Add,
     derive_more::Sub,
+    Eq,
+    Ord,
 )]
 pub struct Score(eth::Ether);
 

--- a/crates/autopilot/src/domain/competition/winner_selection/combinatorial.rs
+++ b/crates/autopilot/src/domain/competition/winner_selection/combinatorial.rs
@@ -99,7 +99,7 @@ impl Arbitrator for Config {
             .map(|(index, participant)| participant.rank(winner_indexes.contains(&index)))
             .sorted_by_key(|p| {
                 (
-                    // winners before losers
+                    // winners before non-winners
                     std::cmp::Reverse(p.is_winner()),
                     // high score before low score
                     std::cmp::Reverse(p.solution().computed_score().cloned()),
@@ -1130,7 +1130,7 @@ mod tests {
             let solutions = arbitrator.mark_winners(solutions);
             let winners = filter_winners(&solutions);
             assert!(winners.iter().is_sorted_by_key(|a| (
-                // winners before losers
+                // winners before non-winners
                 std::cmp::Reverse(a.is_winner()),
                 // high score before low score
                 std::cmp::Reverse(a.solution().computed_score().unwrap())

--- a/crates/autopilot/src/domain/competition/winner_selection/combinatorial.rs
+++ b/crates/autopilot/src/domain/competition/winner_selection/combinatorial.rs
@@ -57,7 +57,7 @@ impl Arbitrator for Config {
         // Discard all solutions where we can't compute the aggregate scores
         // accurately because the fairness guarantees heavily rely on them.
         let scores_by_solution = compute_scores_by_solution(&mut participants, auction);
-        participants.sort_unstable_by_key(|participant| {
+        participants.sort_by_key(|participant| {
             std::cmp::Reverse(
                 // we use the computed score to not trust the score provided by solvers
                 participant
@@ -97,6 +97,14 @@ impl Arbitrator for Config {
             .into_iter()
             .enumerate()
             .map(|(index, participant)| participant.rank(winner_indexes.contains(&index)))
+            .sorted_by_key(|p| {
+                (
+                    // winners before losers
+                    std::cmp::Reverse(p.is_winner()),
+                    // high score before low score
+                    std::cmp::Reverse(p.solution().computed_score().cloned()),
+                )
+            })
             .collect()
     }
 
@@ -1121,10 +1129,16 @@ mod tests {
             // select the winners
             let solutions = arbitrator.mark_winners(solutions);
             let winners = filter_winners(&solutions);
+            assert!(winners.iter().is_sorted_by_key(|a| (
+                // winners before losers
+                std::cmp::Reverse(a.is_winner()),
+                // high score before low score
+                std::cmp::Reverse(a.solution().computed_score().unwrap())
+            )));
             assert_eq!(winners.len(), self.expected_winners.len());
-            for solution_id in &self.expected_winners {
-                let solution_uid = solution_map.get(&solution_id).unwrap().solution().id;
-                assert!(winners.iter().any(|s| s.solution().id == solution_uid));
+            for (actual, expected) in winners.iter().zip(&self.expected_winners) {
+                let solution_uid = solution_map.get(&expected).unwrap().solution().id;
+                assert_eq!(actual.solution().id, solution_uid);
             }
 
             // compute reference score

--- a/crates/autopilot/src/domain/competition/winner_selection/mod.rs
+++ b/crates/autopilot/src/domain/competition/winner_selection/mod.rs
@@ -25,8 +25,8 @@ pub trait Arbitrator: Send + Sync + 'static {
         auction: &Auction,
     ) -> Vec<Participant<Unranked>>;
 
-    /// Picks winners and sorts all solutions where winners come before non-winners
-    /// and higher scores come before lower scores.
+    /// Picks winners and sorts all solutions where winners come before
+    /// non-winners and higher scores come before lower scores.
     fn mark_winners(&self, participants: Vec<Participant<Unranked>>) -> Vec<Participant>;
 
     /// Computes the reference scores which are used to compute

--- a/crates/autopilot/src/domain/competition/winner_selection/mod.rs
+++ b/crates/autopilot/src/domain/competition/winner_selection/mod.rs
@@ -25,7 +25,7 @@ pub trait Arbitrator: Send + Sync + 'static {
         auction: &Auction,
     ) -> Vec<Participant<Unranked>>;
 
-    /// Picks winners and sorts all solutions where winners come before losers
+    /// Picks winners and sorts all solutions where winners come before non-winners
     /// and higher scores come before lower scores.
     fn mark_winners(&self, participants: Vec<Participant<Unranked>>) -> Vec<Participant>;
 


### PR DESCRIPTION
# Description
The `Arbitrator` trait expects the solutions to be sorted in a particular way: winners before losers, high scores before low scores.
This is currently not enforced. A wrong ordering will result down the line with solutions being stored in the wrong order in the solver competitions table. This results in the possibly wrong ordering in the solver competitions and order status API endpoints.

Effectively this now also ensures that the order status endpoint will do the right thing when we switch to combinatorial auctions.

# Changes
Implement correct sorting in the combinatorial auctions implementation.
Assert ordering in unit tests.
Also adjusted unit tests to enforce winners to be specified in that same order as well. This was not needed but seems nicer for consistency. No such ordering was enforced for `expected_fair_solutions` since the trait does not expect any particular ordering for that.
Lastly I switched from unstable to stable sorting algorithms just to make things more reproducible.

## How to test
The test changes in the PR are very circular (same code that sorts is also used to check order) but I felt it was not worth it to make the asserting code more verbose to make the correctness explicit.
Instead I wrote a small rust [playground test](https://play.rust-lang.org/?version=stable&mode=debug&edition=2024&gist=67cbf46bcc14232f031e8acafa35a78a) to show that the sorting is indeed correct.