### PR TITLE
Detect under funded flashloans

### DIFF
--- a/crates/driver/src/domain/competition/order/mod.rs
+++ b/crates/driver/src/domain/competition/order/mod.rs
@@ -201,6 +201,12 @@ pub const UID_LEN: usize = 56;
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct Uid(pub Bytes<[u8; UID_LEN]>);
 
+impl From<&solvers_dto::solution::OrderUid> for Uid {
+    fn from(value: &solvers_dto::solution::OrderUid) -> Self {
+        Self(value.0.into())
+    }
+}
+
 impl Uid {
     pub fn owner(&self) -> eth::Address {
         self.parts().1.into()

--- a/crates/driver/src/domain/competition/solution/encoding.rs
+++ b/crates/driver/src/domain/competition/solution/encoding.rs
@@ -13,9 +13,8 @@ use {
         util::{Bytes, conv::u256::U256Ext},
     },
     allowance::Allowance,
-    ethcontract::{H160, U256},
+    ethcontract::H160,
     itertools::Itertools,
-    std::collections::HashMap,
 };
 
 #[derive(Debug, thiserror::Error)]
@@ -33,8 +32,8 @@ pub enum Error {
     FlashloanSupportDisabled,
     #[error("no flashloan helper configured for lender: {0}")]
     UnsupportedFlashloanLender(eth::H160),
-    #[error("trades don't pay enough to cover flashloan repayments")]
-    FlashloanUnderFunded,
+    #[error("incorrect flashloan payment (order: {order:?}): {error}")]
+    FlashloanPayment { order: order::Uid, error: String },
 }
 
 pub fn tx(
@@ -183,20 +182,35 @@ pub fn tx(
         prices: auction.native_prices().clone(),
     };
 
-    let mut flashloan_payments = flashloan_payments(solution, contracts.settlement().address());
-
     // Add all interactions needed to move flash loaned tokens around
     // These interactions are executed before all other pre-interactions
     let flashloans = solution
         .flashloans
         .iter()
-        // Necessary pre-interactions get prepended to the settlement. So to initiate
-        // the loans in the desired order we need to add them in reverse order.
-        .rev()
-        .map(|flashloan| {
+        .map(|(order, flashloan)| {
             let flashloan_wrapper = contracts
                 .get_flashloan_wrapper(&flashloan.lender)
                 .ok_or(Error::UnsupportedFlashloanLender(flashloan.lender.0))?;
+
+            // Repayment amount needs to be increased by flash fee
+            let fee_amount =
+                (flashloan.amount.0 * flashloan_wrapper.fee_in_bps).ceil_div(&10_000.into());
+            let repayment_amount = flashloan.amount.0 + fee_amount;
+
+            ensure_flashloan_is_paid_for(
+                auction,
+                solution,
+                order,
+                contracts.settlement().address(),
+                eth::Asset {
+                    token: flashloan.token,
+                    amount: repayment_amount.into(),
+                },
+            )
+            .map_err(|error| Error::FlashloanPayment {
+                order: *order,
+                error,
+            })?;
 
             // Allow settlement contract to pull borrowed tokens from flashloan wrapper
             pre_interactions.insert(
@@ -230,15 +244,6 @@ pub fn tx(
                 },
             );
 
-            // Repayment amount needs to be increased by flash fee
-            let fee_amount =
-                (flashloan.amount.0 * flashloan_wrapper.fee_in_bps).ceil_div(&10_000.into());
-            let repayment_amount = flashloan.amount.0 + fee_amount;
-
-            // deduct the repayment amount from the flashloan payments to make sure we are covered
-            let available_tokens = flashloan_payments.get_mut(&flashloan.token).ok_or(Error::FlashloanUnderFunded)?;
-            *available_tokens = available_tokens.checked_sub(repayment_amount).ok_or(Error::FlashloanUnderFunded)?;
-
             // Since the order receiver is expected to be the setttlement contract, we need
             // to transfer tokens from the settlement contract to the flashloan wrapper
             let tx = contracts::ERC20::at(
@@ -270,7 +275,8 @@ pub fn tx(
                 flashloan.lender.0,
                 flashloan.token.0.0,
             ))
-        }).collect::<Result<Vec<(eth::U256, eth::H160, eth::H160, eth::H160)>, Error>>()?;
+        })
+        .collect::<Result<Vec<(eth::U256, eth::H160, eth::H160, eth::H160)>, Error>>()?;
 
     for interaction in solution.interactions() {
         if matches!(internalization, settlement::Internalization::Enable)
@@ -335,21 +341,41 @@ pub fn tx(
     })
 }
 
-/// Aggregates all payments directly to the settlement contract
-/// that can be used to repay flashloans.
-fn flashloan_payments(
+/// Makes sure that there is an order that intended to pay for a
+/// given flashloan and that the payment is sufficient.
+fn ensure_flashloan_is_paid_for(
+    auction: &competition::Auction,
     solution: &super::Solution,
+    uid: &order::Uid,
     settlement: H160,
-) -> HashMap<eth::TokenAddress, U256> {
-    let mut amounts = HashMap::<eth::TokenAddress, U256>::default();
-    for trade in solution.trades() {
-        if trade.receiver().0 == settlement {
-            let proceeds = trade.buy();
-            let amount = amounts.entry(proceeds.token).or_default();
-            *amount = *amount + proceeds.amount;
-        }
+    expected_payment: eth::Asset,
+) -> Result<(), String> {
+    let Some(trade) = solution.trades().iter().find(|t| t.uid() == *uid) else {
+        return Err("no trade execution to repay the flashloan".into());
+    };
+    if trade.receiver().0 != settlement {
+        return Err("order does not pay the settlement contract".into());
     }
-    amounts
+
+    let paid = trade.buy();
+    if paid.token != expected_payment.token {
+        return Err("order pays with the wrong token".into());
+    }
+    if paid.amount < expected_payment.amount {
+        return Err("order does not pay enough".into());
+    }
+
+    if auction
+        .orders
+        .iter()
+        .find(|o| o.uid == *uid)
+        .and_then(|o| o.app_data.flashloan())
+        .is_none()
+    {
+        return Err("order did not request a flashloan".into());
+    }
+
+    Ok(())
 }
 
 pub fn liquidity_interaction(

--- a/crates/driver/src/domain/competition/solution/mod.rs
+++ b/crates/driver/src/domain/competition/solution/mod.rs
@@ -54,7 +54,7 @@ pub struct Solution {
     solver: Solver,
     weth: eth::WethAddress,
     gas: Option<eth::Gas>,
-    flashloans: Vec<Flashloan>,
+    flashloans: HashMap<order::Uid, Flashloan>,
 }
 
 impl Solution {
@@ -71,7 +71,7 @@ impl Solution {
         gas: Option<eth::Gas>,
         fee_handler: FeeHandler,
         surplus_capturing_jit_order_owners: &HashSet<eth::Address>,
-        flashloans: Vec<Flashloan>,
+        flashloans: HashMap<order::Uid, Flashloan>,
     ) -> Result<Self, error::Solution> {
         // Surplus capturing JIT orders behave like Fulfillment orders. They capture
         // surplus, pay network fees and contribute to score of a solution.
@@ -343,6 +343,12 @@ impl Solution {
             }
         }
 
+        let flashloans = {
+            let mut merged = self.flashloans.clone();
+            merged.extend(other.flashloans.clone());
+            merged
+        };
+
         // Merge remaining fields
         Ok(Solution {
             id: Id::new_merged(&self.id, &other.id),
@@ -368,7 +374,7 @@ impl Solution {
                 (None, Some(gas)) => Some(gas),
                 (None, None) => None,
             },
-            flashloans: [self.flashloans.clone(), other.flashloans.clone()].concat(),
+            flashloans,
         })
     }
 

--- a/crates/driver/src/domain/competition/solution/trade.rs
+++ b/crates/driver/src/domain/competition/solution/trade.rs
@@ -117,6 +117,13 @@ impl Trade {
             buy: self.sell_amount(prices)?.into(),
         })
     }
+
+    pub fn receiver(&self) -> eth::Address {
+        match self {
+            Trade::Fulfillment(fulfillment) => fulfillment.order().receiver(),
+            Trade::Jit(jit) => jit.order().receiver,
+        }
+    }
 }
 
 /// A trade which fulfills an order from the auction.

--- a/crates/driver/src/tests/cases/flashloan_hints.rs
+++ b/crates/driver/src/tests/cases/flashloan_hints.rs
@@ -34,7 +34,9 @@ async fn solutions_with_flashloan() {
         .settlement_address(&settlement)
         .pool(ab_pool())
         .order(order.clone())
-        .solution(ab_solution().flashloan(flashloan_into_dto(flashloan)))
+        // This test is just about parsing the request JSON bodies so we don't care
+        // about the specific order uid here
+        .solution(ab_solution().flashloan(Default::default(), flashloan_into_dto(flashloan)))
         .done()
         .await;
 

--- a/crates/driver/src/tests/setup/blockchain.rs
+++ b/crates/driver/src/tests/setup/blockchain.rs
@@ -90,7 +90,7 @@ impl Pool {
 #[derive(Debug, Clone)]
 pub struct Solution {
     pub trades: Vec<Trade>,
-    pub flashloans: Vec<Flashloan>,
+    pub flashloans: HashMap<order::Uid, Flashloan>,
 }
 
 #[derive(Debug, Clone)]

--- a/crates/driver/src/tests/setup/mod.rs
+++ b/crates/driver/src/tests/setup/mod.rs
@@ -575,7 +575,7 @@ pub enum Calldata {
 pub struct Solution {
     pub calldata: Calldata,
     pub orders: Vec<&'static str>,
-    pub flashloans: Vec<Flashloan>,
+    pub flashloans: HashMap<order::Uid, Flashloan>,
 }
 
 impl Solution {
@@ -618,8 +618,8 @@ impl Solution {
         }
     }
 
-    pub fn flashloan(mut self, flashloan: Flashloan) -> Self {
-        self.flashloans.push(flashloan);
+    pub fn flashloan(mut self, order: order::Uid, flashloan: Flashloan) -> Self {
+        self.flashloans.insert(order, flashloan);
         self
     }
 }

--- a/crates/driver/src/tests/setup/solver.rs
+++ b/crates/driver/src/tests/setup/solver.rs
@@ -389,7 +389,18 @@ impl Solver {
                 "preInteractions": pre_interactions_json,
             });
             if !solution.flashloans.is_empty() {
-                solution_json["flashloans"] = json!(solution.flashloans);
+                solution_json["flashloans"] = serde_json::Value::Object(
+                    solution
+                        .flashloans
+                        .iter()
+                        .map(|(order, loan)| {
+                            (
+                                format!("{:?}", order.0),
+                                serde_json::to_value(loan).unwrap(),
+                            )
+                        })
+                        .collect(),
+                );
             }
             solutions_json.push(solution_json);
         }
@@ -461,7 +472,7 @@ impl Solver {
             .solutions
             .iter()
             .flat_map(|solution| solution.flashloans.clone())
-            .map(|flashloan| FlashloanWrapperConfig {
+            .map(|(_order, flashloan)| FlashloanWrapperConfig {
                 lender: flashloan.lender,
                 helper_contract: config.blockchain.flashloan_wrapper.address(),
                 fee_in_bps: Default::default(),

--- a/crates/e2e/tests/e2e/cow_amm.rs
+++ b/crates/e2e/tests/e2e/cow_amm.rs
@@ -334,7 +334,7 @@ async fn cow_amm_jit(web3: Web3) {
                 fee: Some(fee),
             }),
             solvers_dto::solution::Trade::Fulfillment(solvers_dto::solution::Fulfillment {
-                order: user_order_id.0,
+                order: solvers_dto::solution::OrderUid(user_order_id.0),
                 executed_amount: user_order.sell_amount - fee,
                 fee: Some(fee),
             }),
@@ -909,7 +909,7 @@ async fn cow_amm_opposite_direction(web3: Web3) {
                     fee: Some(fee_cow_amm),
                 }),
                 solvers_dto::solution::Trade::Fulfillment(solvers_dto::solution::Fulfillment {
-                    order: order_uid.0,
+                    order: solvers_dto::solution::OrderUid(order_uid.0),
                     executed_amount: executed_amount - fee_user,
                     fee: Some(fee_user),
                 }),

--- a/crates/e2e/tests/e2e/jit_orders.rs
+++ b/crates/e2e/tests/e2e/jit_orders.rs
@@ -160,7 +160,7 @@ async fn single_limit_order_test(web3: Web3) {
             solvers_dto::solution::Trade::Fulfillment(solvers_dto::solution::Fulfillment {
                 executed_amount: order.sell_amount,
                 fee: Some(0.into()),
-                order: order_id.0,
+                order: solvers_dto::solution::OrderUid(order_id.0),
             }),
         ],
         pre_interactions: vec![],

--- a/crates/solvers-dto/src/solution.rs
+++ b/crates/solvers-dto/src/solution.rs
@@ -29,8 +29,12 @@ pub struct Solution {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub gas: Option<u64>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
-    pub flashloans: Option<Vec<Flashloan>>,
+    pub flashloans: Option<HashMap<OrderUid, Flashloan>>,
 }
+
+#[serde_as]
+#[derive(Clone, Debug, Serialize, Deserialize, Hash, Eq, PartialEq)]
+pub struct OrderUid(#[serde_as(as = "serialize::Hex")] pub [u8; 56]);
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(tag = "kind", rename_all = "camelCase")]
@@ -43,8 +47,7 @@ pub enum Trade {
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Fulfillment {
-    #[serde_as(as = "serialize::Hex")]
-    pub order: [u8; 56],
+    pub order: OrderUid,
     #[serde_as(as = "HexOrDecimalU256")]
     pub executed_amount: U256,
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/crates/solvers/src/api/routes/solve/dto/solution.rs
+++ b/crates/solvers/src/api/routes/solve/dto/solution.rs
@@ -21,7 +21,7 @@ pub fn from_domain(solutions: &[solution::Solution]) -> super::Solutions {
                     .iter()
                     .map(|trade| match trade {
                         solution::Trade::Fulfillment(trade) => Trade::Fulfillment(Fulfillment {
-                            order: trade.order().uid.0,
+                            order: OrderUid(trade.order().uid.0),
                             executed_amount: trade.executed().amount,
                             fee: trade.surplus_fee().map(|fee| fee.amount),
                         }),
@@ -116,17 +116,8 @@ pub fn from_domain(solutions: &[solution::Solution]) -> super::Solutions {
                     })
                     .collect(),
                 gas: solution.gas.map(|gas| gas.0.as_u64()),
-                flashloans: solution.flashloans.as_ref().map(|loans| {
-                    loans
-                        .iter()
-                        .map(|loan| Flashloan {
-                            lender: loan.lender.0,
-                            borrower: loan.borrower.0,
-                            token: loan.token.0,
-                            amount: loan.amount,
-                        })
-                        .collect()
-                }),
+                // rely on driver to fill in the blanks
+                flashloans: None,
             })
             .collect(),
     }

--- a/crates/solvers/src/domain/solution.rs
+++ b/crates/solvers/src/domain/solution.rs
@@ -17,7 +17,6 @@ pub struct Solution {
     pub interactions: Vec<Interaction>,
     pub post_interactions: Vec<eth::Interaction>,
     pub gas: Option<eth::Gas>,
-    pub flashloans: Option<Vec<Flashloan>>,
 }
 
 impl Solution {
@@ -180,8 +179,6 @@ impl Single {
             interactions,
             post_interactions: Default::default(),
             gas: Some(gas),
-            // rely on driver to fill in the blanks
-            flashloans: None,
             trades: vec![Trade::Fulfillment(Fulfillment::new(order, executed, fee)?)],
         })
     }
@@ -368,12 +365,3 @@ pub const SETTLEMENT: u64 = 7365;
 /// Value was computed by taking 52 percentile median of `transfer()` costs
 /// of the 90% most traded tokens by volume in the month of Oct. 2021.
 pub const ERC20_TRANSFER: u64 = 27_513;
-
-/// A flashloan that is required to execute a solution.
-#[derive(Debug, Clone)]
-pub struct Flashloan {
-    pub lender: eth::Address,
-    pub borrower: eth::Address,
-    pub token: eth::TokenAddress,
-    pub amount: eth::U256,
-}


### PR DESCRIPTION
# Description
The driver aims to abstract flashloan handling for orders completely away from the solver (if they don't want to handle that themselves). That means the driver should also offer a reasonable amount of protection.

# Changes
Added a sanity check in the driver to verify that the funds paid by flashloan orders indeed cover the repayment cost of the flashloans.
It's admittedly a bit ugly to only detect this case when we encode the solution but that's currently the only place where we have all the necessary data.

## How to test
Initially adjusted the flashloan e2e test to trigger the issue where the driver allows executing flashloans for orders which don't cover the repayment cost.
After the fix was implemented the driver refused to submit these problematic solutions.