### PR TITLE
Execute hooks of ethflow orders

### DIFF
--- a/crates/autopilot/src/database/onchain_order_events/mod.rs
+++ b/crates/autopilot/src/database/onchain_order_events/mod.rs
@@ -56,6 +56,7 @@ use {
             get_quote_and_check_fee,
         },
     },
+    sqlx::PgConnection,
     std::{collections::HashMap, sync::Arc},
     web3::types::U64,
 };
@@ -68,6 +69,7 @@ pub struct OnchainOrderParser<EventData: Send + Sync, EventRow: Send + Sync> {
     domain_separator: DomainSeparator,
     settlement_contract: H160,
     metrics: &'static Metrics,
+    trampoline: contracts::HooksTrampoline,
 }
 
 impl<EventData, EventRow> OnchainOrderParser<EventData, EventRow>
@@ -82,6 +84,7 @@ where
         custom_onchain_data_parser: Box<dyn OnchainOrderParsing<EventData, EventRow>>,
         domain_separator: DomainSeparator,
         settlement_contract: H160,
+        trampoline: contracts::HooksTrampoline,
     ) -> Self {
         OnchainOrderParser {
             db,
@@ -91,6 +94,7 @@ where
             domain_separator,
             settlement_contract,
             metrics: Metrics::get(),
+            trampoline,
         }
     }
 }
@@ -351,6 +355,10 @@ impl<T: Send + Sync + Clone, W: Send + Sync> OnchainOrderParser<T, W> {
         )
         .await
         .context("appending quotes for onchain orders failed")?;
+
+        insert_order_hooks(transaction, &orders, &self.trampoline)
+            .await
+            .context("failed to insert hooks")?;
 
         database::orders::insert_orders_and_ignore_conflicts(transaction, orders.as_slice())
             .await
@@ -678,6 +686,81 @@ fn extract_order_data_from_onchain_order_placement_event(
     };
     let order_uid = order_data.uid(&domain_separator, &owner);
     Ok((order_data, owner, signing_scheme, order_uid))
+}
+
+async fn insert_order_hooks(
+    db: &mut PgConnection,
+    orders: &[Order],
+    trampoline: &contracts::HooksTrampoline,
+) -> Result<()> {
+    let mut interactions_to_insert = vec![];
+
+    let execute_via_trampoline = |hooks: Vec<app_data::Hook>| {
+        trampoline
+            .execute(
+                hooks
+                    .into_iter()
+                    .map(|hook| {
+                        (
+                            hook.target,
+                            ethcontract::Bytes(hook.call_data.clone()),
+                            hook.gas_limit.into(),
+                        )
+                    })
+                    .collect(),
+            )
+            .tx
+            .data
+            .unwrap()
+            .0
+    };
+
+    for order in orders {
+        let appdata_json = database::app_data::fetch(db, &order.app_data)
+            .await
+            .context("failed to fetch appdata")?;
+        let Some(appdata_json) = appdata_json else {
+            tracing::debug!(order = ?order.uid, "appdata for order is unknown");
+            continue;
+        };
+        let Ok(parsed) = app_data::parse(&appdata_json) else {
+            tracing::debug!(appdata = %String::from_utf8_lossy(&appdata_json), "could not parse appdata");
+            continue;
+        };
+        if parsed.hooks.pre.is_empty() && parsed.hooks.post.is_empty() {
+            continue; // no additional interactions to index
+        }
+
+        let interactions_count = database::orders::interaction_count(db, order.uid)
+            .await
+            .context("failed to fetch interaction count")?;
+
+        if !parsed.hooks.pre.is_empty() {
+            let interaction = database::orders::Interaction {
+                target: ByteArray(trampoline.address().0),
+                value: 0.into(),
+                data: execute_via_trampoline(parsed.hooks.pre),
+                index: interactions_count.next_pre_interaction_index,
+                execution: database::orders::ExecutionTime::Pre,
+            };
+            interactions_to_insert.push((order.uid, interaction));
+        }
+
+        if !parsed.hooks.post.is_empty() {
+            let interaction = database::orders::Interaction {
+                target: ByteArray(trampoline.address().0),
+                value: 0.into(),
+                data: execute_via_trampoline(parsed.hooks.post),
+                index: interactions_count.next_post_interaction_index,
+                execution: database::orders::ExecutionTime::Post,
+            };
+            interactions_to_insert.push((order.uid, interaction));
+        }
+    }
+
+    database::orders::insert_or_overwrite_interactions(db, &interactions_to_insert)
+        .await
+        .context("could not insert interactions for orders")
 }
 
 #[derive(prometheus_metric_storage::MetricStorage, Clone, Debug)]
@@ -1159,6 +1242,7 @@ mod test {
                     insert_batch_size: NonZeroUsize::new(500).unwrap(),
                 },
             },
+            trampoline: contracts::HooksTrampoline::deployed(&web3).await.unwrap(),
             web3,
             quoter: Arc::new(order_quoter),
             custom_onchain_data_parser: Box::new(custom_onchain_order_parser),

--- a/crates/autopilot/src/database/onchain_order_events/mod.rs
+++ b/crates/autopilot/src/database/onchain_order_events/mod.rs
@@ -731,7 +731,7 @@ async fn insert_order_hooks(
             continue; // no additional interactions to index
         }
 
-        let interactions_count = database::orders::interaction_count(db, order.uid)
+        let interactions_count = database::orders::next_free_interaction_indices(db, order.uid)
             .await
             .context("failed to fetch interaction count")?;
 

--- a/crates/autopilot/src/infra/blockchain/contracts.rs
+++ b/crates/autopilot/src/infra/blockchain/contracts.rs
@@ -5,6 +5,7 @@ pub struct Contracts {
     settlement: contracts::GPv2Settlement,
     weth: contracts::WETH9,
     chainalysis_oracle: Option<contracts::ChainalysisOracle>,
+    trampoline: contracts::HooksTrampoline,
 
     /// The authenticator contract that decides which solver is allowed to
     /// submit settlements.
@@ -17,6 +18,7 @@ pub struct Contracts {
 pub struct Addresses {
     pub settlement: Option<H160>,
     pub weth: Option<H160>,
+    pub trampoline: Option<H160>,
 }
 
 impl Contracts {
@@ -38,6 +40,14 @@ impl Contracts {
         let weth = contracts::WETH9::at(
             web3,
             address_for(contracts::WETH9::raw_contract(), addresses.weth),
+        );
+
+        let trampoline = contracts::HooksTrampoline::at(
+            web3,
+            address_for(
+                contracts::HooksTrampoline::raw_contract(),
+                addresses.trampoline,
+            ),
         );
 
         let chainalysis_oracle = contracts::ChainalysisOracle::deployed(web3).await.ok();
@@ -66,11 +76,16 @@ impl Contracts {
             chainalysis_oracle,
             settlement_domain_separator,
             authenticator,
+            trampoline,
         }
     }
 
     pub fn settlement(&self) -> &contracts::GPv2Settlement {
         &self.settlement
+    }
+
+    pub fn trampoline(&self) -> &contracts::HooksTrampoline {
+        &self.trampoline
     }
 
     pub fn settlement_domain_separator(&self) -> &domain::eth::DomainSeparator {

--- a/crates/autopilot/src/run.rs
+++ b/crates/autopilot/src/run.rs
@@ -186,6 +186,7 @@ pub async fn run(args: Arguments) {
     let contracts = infra::blockchain::contracts::Addresses {
         settlement: args.shared.settlement_contract_address,
         weth: args.shared.native_token_address,
+        trampoline: args.shared.hooks_contract_address,
     };
     let eth = ethereum(
         web3.clone(),

--- a/crates/autopilot/src/run.rs
+++ b/crates/autopilot/src/run.rs
@@ -545,6 +545,7 @@ pub async fn run(args: Arguments) {
             Box::new(custom_ethflow_order_parser),
             DomainSeparator::new(chain_id, eth.contracts().settlement().address()),
             eth.contracts().settlement().address(),
+            eth.contracts().trampoline().clone(),
         );
 
         let ethflow_start_block = determine_ethflow_indexing_start(

--- a/crates/database/src/orders.rs
+++ b/crates/database/src/orders.rs
@@ -829,15 +829,15 @@ SELECT DISTINCT order_uid FROM (
 }
 
 #[derive(Debug, sqlx::FromRow)]
-pub struct InteractionCount {
+pub struct InteractionIndices {
     pub next_pre_interaction_index: i32,
     pub next_post_interaction_index: i32,
 }
 
-pub async fn interaction_count(
+pub async fn next_free_interaction_indices(
     db: &mut PgConnection,
     order: OrderUid,
-) -> sqlx::Result<InteractionCount> {
+) -> sqlx::Result<InteractionIndices> {
     const QUERY: &str = r#"
 SELECT
   COALESCE(MAX(index) FILTER (WHERE execution = 'pre'), -1) + 1 AS next_pre_interaction_index,

--- a/crates/e2e/src/setup/services.rs
+++ b/crates/e2e/src/setup/services.rs
@@ -114,7 +114,7 @@ impl<'a> Services<'a> {
         ServicesBuilder::new()
     }
 
-    fn api_autopilot_arguments() -> impl Iterator<Item = String> + use<> {
+    fn api_autopilot_arguments(&self) -> impl Iterator<Item = String> + use<> {
         [
             "--native-price-estimators=test_quoter|http://localhost:11088/test_solver".to_string(),
             "--amount-to-estimate-prices-with=1000000000000000000".to_string(),
@@ -122,6 +122,10 @@ impl<'a> Services<'a> {
             "--simulation-node-url=http://localhost:8545".to_string(),
             "--native-price-cache-max-age=2s".to_string(),
             "--native-price-prefetch-time=500ms".to_string(),
+            format!(
+                "--hooks-contract-address={:?}",
+                self.contracts.hooks.address()
+            ),
         ]
         .into_iter()
     }
@@ -169,7 +173,7 @@ impl<'a> Services<'a> {
         ]
         .into_iter()
         .chain(self.api_autopilot_solver_arguments())
-        .chain(Self::api_autopilot_arguments())
+        .chain(self.api_autopilot_arguments())
         .chain(extra_args)
         .collect();
         let args = ignore_overwritten_cli_params(args);
@@ -184,16 +188,12 @@ impl<'a> Services<'a> {
     pub async fn start_api(&self, extra_args: Vec<String>) {
         let args: Vec<_> = [
             "orderbook".to_string(),
-            format!(
-                "--hooks-contract-address={:?}",
-                self.contracts.hooks.address()
-            ),
             "--quote-timeout=10s".to_string(),
             "--quote-verification=enforce-when-possible".to_string(),
         ]
         .into_iter()
         .chain(self.api_autopilot_solver_arguments())
-        .chain(Self::api_autopilot_arguments())
+        .chain(self.api_autopilot_arguments())
         .chain(extra_args)
         .collect();
         let args = ignore_overwritten_cli_params(args);

--- a/crates/e2e/tests/e2e/ethflow.rs
+++ b/crates/e2e/tests/e2e/ethflow.rs
@@ -203,6 +203,25 @@ async fn eth_flow_tx(web3: Web3) {
         .await
         .unwrap();
     assert_eq!(allowance, to_wei(10));
+
+    // Just to be super sure we assert that we indeed were not
+    // able to set an allowance on behalf of the settlement contract.
+    let settlement = onchain.contracts().gp_settlement.address();
+    let allowance = dai
+        .allowance(settlement, trader.address())
+        .call()
+        .await
+        .unwrap();
+    assert_eq!(allowance, 0.into());
+
+    let allowance = onchain
+        .contracts()
+        .weth
+        .allowance(settlement, trader.address())
+        .call()
+        .await
+        .unwrap();
+    assert_eq!(allowance, 0.into());
 }
 
 async fn eth_flow_without_quote(web3: Web3) {

--- a/crates/e2e/tests/e2e/ethflow.rs
+++ b/crates/e2e/tests/e2e/ethflow.rs
@@ -85,11 +85,52 @@ async fn eth_flow_tx(web3: Web3) {
     let services = Services::new(&onchain).await;
     services.start_protocol(solver).await;
 
-    let quote: OrderQuoteResponse = test_submit_quote(
-        &services,
-        &intent.to_quote_request(trader.account().address(), &onchain.contracts().weth),
-    )
-    .await;
+    let approve_call_data = {
+        let bytes = dai.approve(trader.address(), to_wei(10)).tx.data.unwrap();
+        format!("0x{}", hex::encode(&bytes.0))
+    };
+
+    let hash = services
+        .put_app_data(
+            None,
+            &format!(
+                r#"{{
+    "metadata": {{
+         "hooks": {{
+             "pre": [
+                 {{
+                     "target": "{:?}",
+                     "callData": "{}",
+                     "gasLimit": "100000"
+                 }}
+             ],
+             "post": [
+                 {{
+                     "target": "{:?}",
+                     "callData": "{}",
+                     "gasLimit": "100000"
+                 }}
+             ]
+         }}
+    }}
+}}"#,
+                dai.address(),
+                approve_call_data,
+                onchain.contracts().weth.address(),
+                approve_call_data,
+            ),
+        )
+        .await
+        .unwrap();
+
+    let quote_request = OrderQuoteRequest {
+        app_data: OrderCreationAppData::Hash {
+            hash: app_data::AppDataHash(hex::decode(&hash[2..]).unwrap().try_into().unwrap()),
+        },
+        ..intent.to_quote_request(trader.account().address(), &onchain.contracts().weth)
+    };
+
+    let quote: OrderQuoteResponse = test_submit_quote(&services, &quote_request).await;
 
     let valid_to = chrono::offset::Utc::now().timestamp() as u32
         + timestamp_of_current_block_in_seconds(&web3).await.unwrap()
@@ -142,6 +183,26 @@ async fn eth_flow_tx(web3: Web3) {
         ethflow_contract,
     )
     .await;
+
+    // Pre and post interactions provided in the appdata got executed.
+    // Note that the allowance was set for the trampoline contract
+    // which proofs that the interactions were correctly sandboxed.
+    let trampoline = onchain.contracts().hooks.address();
+    let allowance = dai
+        .allowance(trampoline, trader.address())
+        .call()
+        .await
+        .unwrap();
+    assert_eq!(allowance, to_wei(10));
+
+    let allowance = onchain
+        .contracts()
+        .weth
+        .allowance(trampoline, trader.address())
+        .call()
+        .await
+        .unwrap();
+    assert_eq!(allowance, to_wei(10));
 }
 
 async fn eth_flow_without_quote(web3: Web3) {
@@ -503,7 +564,7 @@ async fn test_order_parameters(
     );
 
     // Requires wrapping first
-    assert_eq!(response.interactions.pre.len(), 1);
+    assert!(!response.interactions.pre.is_empty());
     assert_eq!(
         response.interactions.pre[0].target,
         ethflow_contract.address()

--- a/crates/orderbook/src/arguments.rs
+++ b/crates/orderbook/src/arguments.rs
@@ -124,12 +124,6 @@ pub struct Arguments {
     #[clap(long, env)]
     pub ipfs_pinata_auth: Option<String>,
 
-    /// Override the address of the `HooksTrampoline` contract used for
-    /// trampolining custom order interactions. If not specified, the default
-    /// contract deployment for the current network will be used.
-    #[clap(long, env)]
-    pub hooks_contract_address: Option<H160>,
-
     /// Set the maximum size in bytes of order app data.
     #[clap(long, env, default_value = "8192")]
     pub app_data_size_limit: usize,
@@ -168,7 +162,6 @@ impl std::fmt::Display for Arguments {
             max_limit_orders_per_user,
             ipfs_gateway,
             ipfs_pinata_auth,
-            hooks_contract_address,
             app_data_size_limit,
             db_url,
             max_gas_per_order,
@@ -226,11 +219,6 @@ impl std::fmt::Display for Arguments {
         )?;
         writeln!(f, "ipfs_gateway: {:?}", ipfs_gateway)?;
         display_secret_option(f, "ipfs_pinata_auth", ipfs_pinata_auth.as_ref())?;
-        display_option(
-            f,
-            "hooks_contract_address",
-            &hooks_contract_address.map(|a| format!("{a:?}")),
-        )?;
         writeln!(f, "app_data_size_limit: {}", app_data_size_limit)?;
         writeln!(f, "max_gas_per_order: {}", max_gas_per_order)?;
         writeln!(

--- a/crates/orderbook/src/run.rs
+++ b/crates/orderbook/src/run.rs
@@ -129,7 +129,7 @@ pub async fn run(args: Arguments) {
         },
     };
 
-    let hooks_contract = match args.hooks_contract_address {
+    let hooks_contract = match args.shared.hooks_contract_address {
         Some(address) => HooksTrampoline::at(&web3, address),
         None => HooksTrampoline::deployed(&web3)
             .await

--- a/crates/shared/src/arguments.rs
+++ b/crates/shared/src/arguments.rs
@@ -233,6 +233,12 @@ pub struct Arguments {
     #[clap(long, env)]
     pub native_token_address: Option<H160>,
 
+    /// Override the address of the `HooksTrampoline` contract used for
+    /// trampolining custom order interactions. If not specified, the default
+    /// contract deployment for the current network will be used.
+    #[clap(long, env)]
+    pub hooks_contract_address: Option<H160>,
+
     /// Override address of the balancer vault contract.
     #[clap(long, env)]
     pub balancer_v2_vault_address: Option<H160>,
@@ -356,6 +362,7 @@ impl Display for Arguments {
             network_block_interval,
             settlement_contract_address,
             native_token_address,
+            hooks_contract_address,
             balancer_v2_vault_address,
             custom_univ2_baseline_sources,
             liquidity_fetcher_max_age_update,
@@ -412,6 +419,11 @@ impl Display for Arguments {
             f,
             "native_token_address",
             &native_token_address.map(|a| format!("{a:?}")),
+        )?;
+        display_option(
+            f,
+            "hooks_contract_address",
+            &hooks_contract_address.map(|a| format!("{a:?}")),
         )?;
         display_option(
             f,

--- a/database/README.md
+++ b/database/README.md
@@ -120,7 +120,7 @@ The settlement contract allows associating user provided interactions to be exec
  execution  | [enum](#executiontime) | not null | in which phase the interaction should be executed
 
 Indexes:
-- PRIMARY KEY: btree(`order_uid`)
+- PRIMARY KEY: btree(`order_uid`, `index`, `execution`)
 
 
 ### invalidations

--- a/database/sql/V085__interactions_unique_constraint.sql
+++ b/database/sql/V085__interactions_unique_constraint.sql
@@ -1,0 +1,7 @@
+-- Include the execution phase into the primary key because there
+-- can be multiple interactions with the same index for the same
+-- order if they get executed in different phases.
+-- Because we are making the primary key stricter than before this
+-- modification can not fail.
+ALTER TABLE interactions DROP CONSTRAINT interactions_pkey;
+ALTER TABLE interactions ADD PRIMARY KEY (order_uid, index, execution);


### PR DESCRIPTION
Fixes: https://github.com/cowprotocol/services/issues/3388

# Description
Currently ethflow orders don't have their hooks executed. The reason is that ethflow orders don't get added to the order book via a REST API call which would execute the usual code paths. Instead the autopilot indexes events emitted from certain contracts and adds it to the orderbook that way. This executes a bunch of different code paths that actually didn't check the hooks at all.

# Changes
- moved `--hooks-contract-address` into shared args because the `autopilot` now needs it too
- during ethflow event indexing we now fetch the associated appdata, parse it, and insert the trampolined hook interactions if there are any. This code is a bit awkward due to the existing abstractions. Ethflow orders are a special variant of the more generic "onchain" orders. The ethflow specific handler already inserts the necessary unwrap pre-interaction. Because the general appdata handling needs to happen in the general handler and not the ethflow handler we first need to check how many interactions were already inserted for a given order so we don't overwrite any interactions by accident. Because the majority of times there is only 1 ethflow order per tx and to keep the code simple I decided to fetch the appdata sequentially instead of in parallel.
- because ethflow orders can be reorged (as they originate from onchain transactions) we need to be able to overwrite interactions in the DB. To do that I needed to adjust the primary key of the `interactions` table to include the `execution` flag. The readme was updated accordingly.

## How to test
I updated an existing ethflow e2e test to pass 1 pre and post hook in the appdata. The hooks set an allowance for the trader address. Because we use approval interactions we can easily see in which context the user passed interaction got executed.
If we didn't sandbox the interaction correctly the approval would be set by the settlement contract. But in our test we can see that the approval was given by the trampoline contract. This shows that we didn't introduce a security risk by accident with this fix.