### PR TITLE
chore(OpenAPI): SolverCompetition transactionHash should be an array

### DIFF
--- a/crates/orderbook/openapi.yml
+++ b/crates/orderbook/openapi.yml
@@ -1600,14 +1600,12 @@ components:
         auctionId:
           type: integer
           description: The ID of the auction the competition info is for.
-        transactionHash:
-          type: string
-          nullable: true
-          allOf:
-            - $ref: "#/components/schemas/TransactionHash"
-          description: >-
-            The hash of the transaction that the winning solution of this info
-            was submitted in.
+        transactionHashes:
+          type: array
+          description: |
+            The hashes of the transactions for the winning solutions of this competition.
+          items:
+            $ref: "#/components/schemas/TransactionHash"
         gasPrice:
           type: number
           description: Gas price used for ranking solutions.


### PR DESCRIPTION
# Description
The OpenAPI spec is not up to date with the data returned in the corresponding endpoint, as the endpoint returns multiple transaction hashes to support multiple winners (ref #3049) but the OpenAPI still defines it as a single value.

This PR updates the field to be an array and updated the name to match the field.

<!--
## Related Issues

Fixes #
-->