### PR TITLE
Fix order status endpoint

### DIFF
--- a/crates/e2e/tests/e2e/partial_fill.rs
+++ b/crates/e2e/tests/e2e/partial_fill.rs
@@ -113,5 +113,4 @@ async fn test(web3: Web3) {
     };
     assert_eq!(solutions.len(), 1);
     assert_eq!(solutions[0].solver, "test_solver");
-    assert!(solutions[0].executed_amounts.is_some());
 }

--- a/crates/orderbook/src/dto/order.rs
+++ b/crates/orderbook/src/dto/order.rs
@@ -93,7 +93,7 @@ pub struct SolutionInclusion {
     pub solver: String,
     /// The executed amounts for the order as proposed by the solver, included
     /// if the solution was for the desired order, or omitted otherwise.
-    pub executed_amounts: Option<ExecutedAmounts>,
+    pub executed_amounts: ExecutedAmounts,
 }
 
 #[derive(Serialize, PartialEq, Debug, Clone)]

--- a/crates/orderbook/src/orderbook.rs
+++ b/crates/orderbook/src/orderbook.rs
@@ -514,7 +514,7 @@ impl Orderbook {
                 .common
                 .solutions
                 .into_iter()
-                .map(|solution| {
+                .filter_map(|solution| {
                     let executed_amounts = solution.orders.iter().find_map(|o| match o {
                         solver_competition::Order::Legacy { .. } => None,
                         solver_competition::Order::Colocated {
@@ -525,11 +525,11 @@ impl Orderbook {
                             sell: *sell_amount,
                             buy: *buy_amount,
                         }),
-                    });
-                    dto::order::SolutionInclusion {
+                    })?;
+                    Some(dto::order::SolutionInclusion {
                         solver: solution.solver,
                         executed_amounts,
-                    }
+                    })
                 })
                 .collect::<Vec<_>>()
         };


### PR DESCRIPTION
# Description
Due to combinatorial auctions the order status endpoint can now return responses where the last solver bid is not for the respective order (as there can be multiple winners now).
This causes issues in the frontend's progress bar.

# Changes
Since the endpoint is supposed to return the status for a specific order it doesn't make much sense to return bids that don't contain the order at all.