### PR TITLE
Demote some log statements from warn -> debug

### DIFF
--- a/crates/autopilot/src/run_loop.rs
+++ b/crates/autopilot/src/run_loop.rs
@@ -630,11 +630,7 @@ impl RunLoop {
             }
             Err(err) => {
                 Metrics::solve_err(&driver, start.elapsed(), &err);
-                if matches!(err, SolveError::NoSolutions) {
-                    tracing::debug!(driver = %driver.name, "solver found no solution");
-                } else {
-                    tracing::warn!(?err, driver = %driver.name, "solve error");
-                }
+                tracing::debug!(?err, driver = %driver.name, "solver didn't provide solutions");
                 vec![]
             }
         };

--- a/crates/shared/src/bad_token/instrumented.rs
+++ b/crates/shared/src/bad_token/instrumented.rs
@@ -56,7 +56,7 @@ impl BadTokenDetecting for InstrumentedBadTokenDetector {
                 "error"
             }
             Ok(quality @ TokenQuality::Bad { .. }) => {
-                tracing::warn!("bad token detection for {:?} returned {:?}", token, quality);
+                tracing::debug!("bad token detection for {:?} returned {:?}", token, quality);
                 "bad"
             }
         };

--- a/crates/shared/src/price_estimation/trade_finder.rs
+++ b/crates/shared/src/price_estimation/trade_finder.rs
@@ -81,8 +81,6 @@ impl Inner {
                 .map_err(PriceEstimationError::EstimatorInternal);
         }
 
-        tracing::warn!("verified quote requested but no verifier configured");
-
         let quote = self.finder.get_quote(&query).await?;
         Ok(Estimate {
             out_amount: quote.out_amount,


### PR DESCRIPTION
# Description
Some of these warn statements are polluting our logs without actually triggering anything bad. This PR demotes them to debug logs for better signal/noise ratio

# Changes
- [x] don't warn when there is no trade verifier configured (this is always the case for native price estimates)
- [x] don't warn on bad token detection, we do have bad tokens that are expected to be bad
- [x] don't warn when a solver engine errors. A lot of solvers return 400 when they don't provide a solution (which is very often) and we can't really force them to give us a more structured response. We should simply not warn in these cases 

## How to test
Once deployed, I hope the kibana logs are much more readable.