### PR TITLE
Store filtered out solutions in the DB

### DIFF
--- a/crates/autopilot/src/database/competition.rs
+++ b/crates/autopilot/src/database/competition.rs
@@ -19,6 +19,8 @@ use {
 #[derive(Clone, Default, Debug)]
 pub struct Competition {
     pub auction_id: AuctionId,
+    // TODO: remove when `settlement_scores` table is no longer used
+    pub legacy: Option<LegacyScore>,
     pub reference_scores: HashMap<eth::Address, Score>,
     /// Addresses to which the CIP20 participation rewards will be payed out.
     /// Usually the same as the solver addresses.
@@ -30,6 +32,17 @@ pub struct Competition {
     pub block_deadline: u64,
     pub competition_simulation_block: u64,
     pub competition_table: SolverCompetitionDB,
+}
+
+/// Score containing the data relevant for the single winner auction algorithm
+#[derive(Clone, Default, Debug)]
+pub struct LegacyScore {
+    /// Single winner of the auction.
+    pub winner: H160,
+    /// Score of the winning solution.
+    pub winning_score: U256,
+    /// Score of the second best solution.
+    pub reference_score: U256,
 }
 
 impl super::Postgres {
@@ -50,6 +63,33 @@ impl super::Postgres {
         )
         .await
         .context("solver_competition::save_solver_competition")?;
+
+        // TODO: this is deprecated and needs to be removed once the solver team has
+        // switched to the reference_scores table.
+        // If we enable combinatorial auctions before that switch the solver rewards
+        // payout will be blocked until the switch happens since no data would be
+        // stored in the old format anymore.
+        if let Some(legacy) = &competition.legacy {
+            database::settlement_scores::insert(
+                &mut ex,
+                database::settlement_scores::Score {
+                    auction_id: competition.auction_id,
+                    winner: ByteArray(legacy.winner.0),
+                    winning_score: u256_to_big_decimal(&legacy.winning_score),
+                    reference_score: u256_to_big_decimal(&legacy.reference_score),
+                    block_deadline: competition
+                        .block_deadline
+                        .try_into()
+                        .context("convert block deadline")?,
+                    simulation_block: competition
+                        .competition_simulation_block
+                        .try_into()
+                        .context("convert simulation block")?,
+                },
+            )
+            .await
+            .context("settlement_scores::insert")?;
+        }
 
         let reference_scores: Vec<_> = competition
             .reference_scores

--- a/crates/autopilot/src/database/competition.rs
+++ b/crates/autopilot/src/database/competition.rs
@@ -19,8 +19,6 @@ use {
 #[derive(Clone, Default, Debug)]
 pub struct Competition {
     pub auction_id: AuctionId,
-    // TODO: remove when `settlement_scores` table is no longer used
-    pub legacy: Option<LegacyScore>,
     pub reference_scores: HashMap<eth::Address, Score>,
     /// Addresses to which the CIP20 participation rewards will be payed out.
     /// Usually the same as the solver addresses.
@@ -32,17 +30,6 @@ pub struct Competition {
     pub block_deadline: u64,
     pub competition_simulation_block: u64,
     pub competition_table: SolverCompetitionDB,
-}
-
-/// Score containing the data relevant for the single winner auction algorithm
-#[derive(Clone, Default, Debug)]
-pub struct LegacyScore {
-    /// Single winner of the auction.
-    pub winner: H160,
-    /// Score of the winning solution.
-    pub winning_score: U256,
-    /// Score of the second best solution.
-    pub reference_score: U256,
 }
 
 impl super::Postgres {
@@ -63,33 +50,6 @@ impl super::Postgres {
         )
         .await
         .context("solver_competition::save_solver_competition")?;
-
-        // TODO: this is deprecated and needs to be removed once the solver team has
-        // switched to the reference_scores table.
-        // If we enable combinatorial auctions before that switch the solver rewards
-        // payout will be blocked until the switch happens since no data would be
-        // stored in the old format anymore.
-        if let Some(legacy) = &competition.legacy {
-            database::settlement_scores::insert(
-                &mut ex,
-                database::settlement_scores::Score {
-                    auction_id: competition.auction_id,
-                    winner: ByteArray(legacy.winner.0),
-                    winning_score: u256_to_big_decimal(&legacy.winning_score),
-                    reference_score: u256_to_big_decimal(&legacy.reference_score),
-                    block_deadline: competition
-                        .block_deadline
-                        .try_into()
-                        .context("convert block deadline")?,
-                    simulation_block: competition
-                        .competition_simulation_block
-                        .try_into()
-                        .context("convert simulation block")?,
-                },
-            )
-            .await
-            .context("settlement_scores::insert")?;
-        }
 
         let reference_scores: Vec<_> = competition
             .reference_scores

--- a/crates/autopilot/src/domain/competition/participant.rs
+++ b/crates/autopilot/src/domain/competition/participant.rs
@@ -13,8 +13,10 @@ pub struct Participant<State = Ranked> {
 
 #[derive(Clone)]
 pub struct Unranked;
-pub struct Ranked {
-    is_winner: bool,
+pub enum Ranked {
+    Winner,
+    NonWinner,
+    Filtered,
 }
 
 impl<T> Participant<T> {
@@ -40,9 +42,9 @@ impl Participant<Unranked> {
         }
     }
 
-    pub fn rank(self, is_winner: bool) -> Participant<Ranked> {
+    pub fn rank(self, rank: Ranked) -> Participant<Ranked> {
         Participant::<Ranked> {
-            state: Ranked { is_winner },
+            state: rank,
             solution: self.solution,
             driver: self.driver,
         }
@@ -51,6 +53,10 @@ impl Participant<Unranked> {
 
 impl Participant<Ranked> {
     pub fn is_winner(&self) -> bool {
-        self.state.is_winner
+        matches!(self.state, Ranked::Winner)
+    }
+
+    pub fn was_filtered(&self) -> bool {
+        matches!(self.state, Ranked::Filtered)
     }
 }

--- a/crates/autopilot/src/domain/competition/participant.rs
+++ b/crates/autopilot/src/domain/competition/participant.rs
@@ -16,7 +16,7 @@ pub struct Unranked;
 pub enum Ranked {
     Winner,
     NonWinner,
-    Filtered,
+    FilteredOut,
 }
 
 impl<T> Participant<T> {
@@ -56,7 +56,7 @@ impl Participant<Ranked> {
         matches!(self.state, Ranked::Winner)
     }
 
-    pub fn was_filtered(&self) -> bool {
-        matches!(self.state, Ranked::Filtered)
+    pub fn filtered_out(&self) -> bool {
+        matches!(self.state, Ranked::FilteredOut)
     }
 }

--- a/crates/autopilot/src/domain/competition/winner_selection/combinatorial.rs
+++ b/crates/autopilot/src/domain/competition/winner_selection/combinatorial.rs
@@ -24,7 +24,7 @@
 //! That is effectively a measurement of how much better each order got executed
 //! because solver S participated in the competition.
 use {
-    super::{Arbitrator, FilteredSolutions, Ranking},
+    super::{Arbitrator, PartitionedSolutions, Ranking},
     crate::domain::{
         self,
         OrderUid,
@@ -53,7 +53,7 @@ impl Arbitrator for Config {
         &self,
         mut participants: Vec<Participant<Unranked>>,
         auction: &domain::Auction,
-    ) -> FilteredSolutions {
+    ) -> PartitionedSolutions {
         // Discard all solutions where we can't compute the aggregate scores
         // accurately because the fairness guarantees heavily rely on them.
         let scores_by_solution = compute_scores_by_solution(&mut participants, auction);
@@ -93,9 +93,9 @@ impl Arbitrator for Config {
                 Either::Right(p)
             }
         });
-        FilteredSolutions {
+        PartitionedSolutions {
             kept: fair,
-            filtered: unfair,
+            discarded: unfair,
         }
     }
 

--- a/crates/autopilot/src/domain/competition/winner_selection/max_score.rs
+++ b/crates/autopilot/src/domain/competition/winner_selection/max_score.rs
@@ -13,7 +13,7 @@
 //! The reference score is simply the second highest reported score of all
 //! solutions. If there is only 1 solution the reference score is 0.
 use {
-    super::{Arbitrator, FilteredSolutions, Ranking},
+    super::{Arbitrator, PartitionedSolutions, Ranking},
     crate::domain::{
         Auction,
         competition::{Participant, Ranked, Score, TradedOrder, Unranked},
@@ -31,7 +31,7 @@ impl Arbitrator for Config {
         &self,
         mut participants: Vec<Participant<Unranked>>,
         auction: &Auction,
-    ) -> FilteredSolutions {
+    ) -> PartitionedSolutions {
         // sort by score descending
         participants.sort_unstable_by_key(|participant| {
             std::cmp::Reverse(participant.solution().score().get().0)
@@ -51,8 +51,8 @@ impl Arbitrator for Config {
                         Either::Right(participant.clone())
                     }
                 });
-        FilteredSolutions {
-            filtered: unfair,
+        PartitionedSolutions {
+            discarded: unfair,
             kept: fair,
         }
     }

--- a/crates/autopilot/src/domain/competition/winner_selection/mod.rs
+++ b/crates/autopilot/src/domain/competition/winner_selection/mod.rs
@@ -1,7 +1,7 @@
 use {
     crate::domain::{
         Auction,
-        competition::{Participant, Score, Unranked},
+        competition::{Participant, Ranked, Score, Unranked},
         eth,
     },
     std::collections::HashMap,
@@ -9,6 +9,43 @@ use {
 
 pub mod combinatorial;
 pub mod max_score;
+
+pub struct Ranking {
+    /// Solutions that were discarded because they were malformed
+    /// in some way or deemed unfair by the selection mechanism.
+    filtered: Vec<Participant<Ranked>>,
+    /// Final ranking of the solutions that passed the fairness
+    /// check. Winners come before non-winners and higher total
+    /// scores come before lower scores.
+    ranked: Vec<Participant<Ranked>>,
+}
+
+impl Ranking {
+    /// All solutions including the ones that got filtered out.
+    pub fn all(&self) -> impl Iterator<Item = &Participant<Ranked>> {
+        self.ranked.iter().chain(&self.filtered)
+    }
+
+    /// All solutions that won the right to get executed.
+    pub fn winners(&self) -> impl Iterator<Item = &Participant<Ranked>> {
+        self.ranked.iter().filter(|p| p.is_winner())
+    }
+
+    /// All solutions that were not filtered out but also did not win.
+    pub fn non_winners(&self) -> impl Iterator<Item = &Participant<Ranked>> {
+        self.ranked.iter().filter(|p| !p.is_winner())
+    }
+
+    /// All solutions that passed the filtering step.
+    pub fn ranked(&self) -> impl Iterator<Item = &Participant<Ranked>> {
+        self.ranked.iter()
+    }
+}
+
+pub struct FilteredSolutions {
+    kept: Vec<Participant<Unranked>>,
+    filtered: Vec<Participant<Unranked>>,
+}
 
 /// Implements auction arbitration in 3 phases:
 /// 1. filter unfair solutions
@@ -18,21 +55,39 @@ pub mod max_score;
 /// The functions assume the `Arbitrator` is the only one
 /// changing the ordering or the `participants.
 pub trait Arbitrator: Send + Sync + 'static {
+    /// Runs the entire auction mechanism on the passed in solutions.
+    fn arbitrate(&self, participants: Vec<Participant<Unranked>>, auction: &Auction) -> Ranking {
+        let partitioned = self.partition_unfair_solutions(participants, auction);
+        let filtered = partitioned
+            .filtered
+            .into_iter()
+            .map(|participant| participant.rank(Ranked::Filtered))
+            .collect();
+
+        let mut ranked = self.mark_winners(partitioned.kept);
+        ranked.sort_by_key(|participant| {
+            (
+                // winners before non-winners
+                std::cmp::Reverse(participant.is_winner()),
+                // high score before low score
+                std::cmp::Reverse(participant.solution().computed_score().cloned()),
+            )
+        });
+        Ranking { filtered, ranked }
+    }
+
     /// Removes unfair solutions from the set of all solutions.
-    fn filter_unfair_solutions(
+    fn partition_unfair_solutions(
         &self,
         participants: Vec<Participant<Unranked>>,
         auction: &Auction,
-    ) -> Vec<Participant<Unranked>>;
+    ) -> FilteredSolutions;
 
     /// Picks winners and sorts all solutions where winners come before
     /// non-winners and higher scores come before lower scores.
-    fn mark_winners(&self, participants: Vec<Participant<Unranked>>) -> Vec<Participant>;
+    fn mark_winners(&self, participants: Vec<Participant<Unranked>>) -> Vec<Participant<Ranked>>;
 
     /// Computes the reference scores which are used to compute
     /// rewards for the winning solvers.
-    fn compute_reference_scores(
-        &self,
-        participants: &[Participant],
-    ) -> HashMap<eth::Address, Score>;
+    fn compute_reference_scores(&self, ranking: &Ranking) -> HashMap<eth::Address, Score>;
 }

--- a/crates/autopilot/src/domain/competition/winner_selection/mod.rs
+++ b/crates/autopilot/src/domain/competition/winner_selection/mod.rs
@@ -73,7 +73,10 @@ pub trait Arbitrator: Send + Sync + 'static {
                 std::cmp::Reverse(participant.solution().computed_score().cloned()),
             )
         });
-        Ranking { filtered_out, ranked }
+        Ranking {
+            filtered_out,
+            ranked,
+        }
     }
 
     /// Removes unfair solutions from the set of all solutions.

--- a/crates/autopilot/src/infra/persistence/mod.rs
+++ b/crates/autopilot/src/infra/persistence/mod.rs
@@ -153,7 +153,7 @@ impl Persistence {
                         id: u256_to_big_decimal(&participant.solution().id().into()),
                         solver: ByteArray(participant.solution().solver().0.0),
                         is_winner: participant.is_winner(),
-                        was_filtered: participant.was_filtered(),
+                        filtered_out: participant.filtered_out(),
                         score: u256_to_big_decimal(&participant.solution().score().get().0),
                         orders: participant
                             .solution()

--- a/crates/autopilot/src/infra/persistence/mod.rs
+++ b/crates/autopilot/src/infra/persistence/mod.rs
@@ -133,7 +133,7 @@ impl Persistence {
     pub async fn save_solutions(
         &self,
         auction_id: domain::auction::Id,
-        solutions: &[domain::competition::Participant],
+        solutions: impl Iterator<Item = &domain::competition::Participant>,
     ) -> Result<(), DatabaseError> {
         let _timer = Metrics::get()
             .database_queries
@@ -146,7 +146,6 @@ impl Persistence {
             &mut ex,
             auction_id,
             &solutions
-                .iter()
                 .enumerate()
                 .map(|(uid, participant)| {
                     let solution = Solution {
@@ -154,6 +153,7 @@ impl Persistence {
                         id: u256_to_big_decimal(&participant.solution().id().into()),
                         solver: ByteArray(participant.solution().solver().0.0),
                         is_winner: participant.is_winner(),
+                        was_filtered: participant.was_filtered(),
                         score: u256_to_big_decimal(&participant.solution().score().get().0),
                         orders: participant
                             .solution()

--- a/crates/autopilot/src/run_loop.rs
+++ b/crates/autopilot/src/run_loop.rs
@@ -11,7 +11,7 @@ use {
                 SolutionError,
                 SolverParticipationGuard,
                 Unranked,
-                winner_selection,
+                winner_selection::{self, Ranking},
             },
             eth::{self, TxId},
             settlement::{ExecutionEnded, ExecutionStarted},
@@ -280,11 +280,10 @@ impl RunLoop {
             })
         };
 
-        let solutions = winner_selection.filter_unfair_solutions(solutions, &auction);
-        let solutions = winner_selection.mark_winners(solutions);
+        let ranking = winner_selection.arbitrate(solutions, &auction);
 
         // Count and record the number of winners
-        let num_winners = solutions.iter().filter(|p| p.is_winner()).count();
+        let num_winners = ranking.winners().count();
         if let Some(num_winners_f64) = num_winners.to_f64() {
             Metrics::get().auction_winners.observe(num_winners_f64);
         }
@@ -298,7 +297,7 @@ impl RunLoop {
             .post_processing(
                 &auction,
                 competition_simulation_block,
-                &solutions,
+                &ranking,
                 block_deadline,
                 winner_selection,
             )
@@ -309,9 +308,8 @@ impl RunLoop {
         }
 
         // Mark all winning orders as `Executing`
-        let winning_orders = solutions
-            .iter()
-            .filter(|p| p.is_winner())
+        let winning_orders = ranking
+            .winners()
             .flat_map(|p| p.solution().order_ids().copied())
             .collect::<HashSet<_>>();
         self.persistence
@@ -319,17 +317,14 @@ impl RunLoop {
 
         // Mark the rest as `Considered` for execution
         self.persistence.store_order_events(
-            solutions
-                .iter()
+            ranking
+                .non_winners()
                 .flat_map(|p| p.solution().order_ids().copied())
                 .filter(|order_id| !winning_orders.contains(order_id)),
             OrderEventLabel::Considered,
         );
 
-        for winner in solutions
-            .iter()
-            .filter(|participant| participant.is_winner())
-        {
+        for winner in ranking.winners() {
             let (driver, solution) = (winner.driver(), winner.solution());
             tracing::info!(driver = %driver.name, solution = %solution.id(), "winner");
 
@@ -342,7 +337,7 @@ impl RunLoop {
             )
             .await;
         }
-        observe::unsettled(&solutions, &auction);
+        observe::unsettled(&ranking, &auction);
     }
 
     /// Starts settlement execution in a background task. The function is async
@@ -405,21 +400,20 @@ impl RunLoop {
         &self,
         auction: &domain::Auction,
         competition_simulation_block: u64,
-        solutions: &[competition::Participant],
+        ranking: &Ranking,
         block_deadline: u64,
         winner_selection: Box<dyn winner_selection::Arbitrator>,
     ) -> Result<()> {
         let start = Instant::now();
+        let reference_scores = winner_selection.compute_reference_scores(ranking);
 
-        let reference_scores = winner_selection.compute_reference_scores(solutions);
-
-        let participants = solutions
-            .iter()
+        let participants = ranking
+            .all()
             .map(|participant| participant.solution().solver().into())
             .collect::<HashSet<_>>();
         let mut fee_policies = Vec::new();
-        for order_id in solutions
-            .iter()
+        for order_id in ranking
+            .ranked()
             .flat_map(|participant| participant.solution().order_ids())
             .unique()
         {
@@ -437,6 +431,38 @@ impl RunLoop {
             }
         }
 
+        let mut solutions: Vec<_> = ranking
+            .all()
+            .enumerate()
+            .map(|(index, participant)| SolverSettlement {
+                solver: participant.driver().name.clone(),
+                solver_address: participant.solution().solver().0,
+                score: Some(Score::Solver(participant.solution().score().get().0)),
+                ranking: index + 1,
+                orders: participant
+                    .solution()
+                    .orders()
+                    .iter()
+                    .map(|(id, order)| Order::Colocated {
+                        id: (*id).into(),
+                        sell_amount: order.executed_sell.into(),
+                        buy_amount: order.executed_buy.into(),
+                    })
+                    .collect(),
+                clearing_prices: participant
+                    .solution()
+                    .prices()
+                    .iter()
+                    .map(|(token, price)| (token.0, price.get().into()))
+                    .collect(),
+                is_winner: participant.is_winner(),
+                was_filtered: participant.was_filtered(),
+            })
+            .collect();
+        // reverse as solver competition table is sorted from worst to best,
+        // so we need to keep the ordering for backwards compatibility
+        solutions.reverse();
+
         let competition_table = SolverCompetitionDB {
             auction_start_block: auction.block,
             competition_simulation_block,
@@ -452,35 +478,7 @@ impl RunLoop {
                     .map(|(key, value)| ((*key).into(), value.get().into()))
                     .collect(),
             },
-            solutions: solutions
-                .iter()
-                // reverse as solver competition table is sorted from worst to best, so we need to keep the ordering for backwards compatibility
-                .rev()
-                .enumerate()
-                .map(|(index, participant)| SolverSettlement {
-                    solver: participant.driver().name.clone(),
-                    solver_address: participant.solution().solver().0,
-                    score: Some(Score::Solver(participant.solution().score().get().0)),
-                    ranking: solutions.len() - index,
-                    orders: participant
-                        .solution()
-                        .orders()
-                        .iter()
-                        .map(|(id, order)| Order::Colocated {
-                            id: (*id).into(),
-                            sell_amount: order.executed_sell.into(),
-                            buy_amount: order.executed_buy.into(),
-                        })
-                        .collect(),
-                    clearing_prices: participant
-                        .solution()
-                        .prices()
-                        .iter()
-                        .map(|(token, price)| (token.0, price.get().into()))
-                        .collect(),
-                    is_winner: participant.is_winner(),
-                })
-                .collect(),
+            solutions,
         };
         let competition = Competition {
             auction_id: auction.id,
@@ -502,7 +500,7 @@ impl RunLoop {
                 .save_auction(auction, block_deadline)
                 .map_err(|e| e.0.context("failed to save auction")),
             self.persistence
-                .save_solutions(auction.id, solutions)
+                .save_solutions(auction.id, ranking.all())
                 .map_err(|e| e.0.context("failed to save solutions")),
         ) {
             Ok(_) => {
@@ -919,9 +917,8 @@ struct Metrics {
     settle: prometheus::HistogramVec,
 
     /// Tracks the number of orders that were part of some but not the winning
-    /// solution together with the winning driver that did't include it.
-    #[metric(labels("ignored_by"))]
-    matched_unsettled: prometheus::IntCounterVec,
+    /// solutions.
+    matched_unsettled: prometheus::IntCounter,
 
     /// Tracks the number of orders that were settled together with the
     /// settling driver.
@@ -1021,14 +1018,11 @@ impl Metrics {
             .observe(elapsed.as_secs_f64());
     }
 
-    fn matched_unsettled(winning: &infra::Driver, unsettled: HashSet<&domain::OrderUid>) {
+    fn matched_unsettled(unsettled: HashSet<&domain::OrderUid>) {
         if !unsettled.is_empty() {
             tracing::debug!(?unsettled, "some orders were matched but not settled");
         }
-        Self::get()
-            .matched_unsettled
-            .with_label_values(&[&winning.name])
-            .inc_by(unsettled.len() as u64);
+        Self::get().matched_unsettled.inc_by(unsettled.len() as u64);
     }
 
     fn post_processed(elapsed: Duration) {
@@ -1056,7 +1050,10 @@ impl Metrics {
 
 pub mod observe {
     use {
-        crate::domain::{self, competition::Unranked},
+        crate::domain::{
+            self,
+            competition::{Unranked, winner_selection::Ranking},
+        },
         std::collections::HashSet,
     };
 
@@ -1103,20 +1100,14 @@ pub mod observe {
     }
 
     /// Records metrics for the matched but unsettled orders.
-    pub fn unsettled(solutions: &[domain::competition::Participant], auction: &domain::Auction) {
-        let Some(winner) = solutions.first() else {
-            // no solutions means nothing to report
-            return;
-        };
-
+    pub fn unsettled(ranking: &Ranking, auction: &domain::Auction) {
         let mut non_winning_orders = {
-            let winning_orders = solutions
-                .iter()
-                .filter(|p| p.is_winner())
+            let winning_orders = ranking
+                .winners()
                 .flat_map(|p| p.solution().order_ids())
                 .collect::<HashSet<_>>();
-            solutions
-                .iter()
+            ranking
+                .ranked()
                 .flat_map(|p| p.solution().order_ids())
                 .filter(|uid| !winning_orders.contains(uid))
                 .collect::<HashSet<_>>()
@@ -1125,6 +1116,6 @@ pub mod observe {
         // but only if they were part of the auction (filter out jit orders)
         let auction_uids = auction.orders.iter().map(|o| o.uid).collect::<HashSet<_>>();
         non_winning_orders.retain(|uid| auction_uids.contains(uid));
-        super::Metrics::matched_unsettled(winner.driver(), non_winning_orders);
+        super::Metrics::matched_unsettled(non_winning_orders);
     }
 }

--- a/crates/autopilot/src/run_loop.rs
+++ b/crates/autopilot/src/run_loop.rs
@@ -421,7 +421,7 @@ impl RunLoop {
             let winner = winning_solution.solver().into();
             let winning_score = winning_solution.score().get().0;
             let reference_score = ranking
-                .all()
+                .ranked()
                 .nth(1)
                 .map(|participant| participant.solution().score().get().0)
                 .unwrap_or_default();

--- a/crates/autopilot/src/run_loop.rs
+++ b/crates/autopilot/src/run_loop.rs
@@ -481,7 +481,7 @@ impl RunLoop {
                     .map(|(token, price)| (token.0, price.get().into()))
                     .collect(),
                 is_winner: participant.is_winner(),
-                was_filtered: participant.was_filtered(),
+                filtered_out: participant.filtered_out(),
             })
             .collect();
         // reverse as solver competition table is sorted from worst to best,

--- a/crates/database/src/solver_competition.rs
+++ b/crates/database/src/solver_competition.rs
@@ -225,7 +225,7 @@ pub struct Solution {
     pub id: BigDecimal,
     pub solver: Address,
     pub is_winner: bool,
-    pub was_filtered: bool,
+    pub filtered_out: bool,
     pub score: BigDecimal,
     pub orders: Vec<Order>,
     // UCP prices
@@ -268,7 +268,7 @@ async fn save_solutions(
 ) -> Result<(), sqlx::Error> {
     let mut builder = QueryBuilder::new(
         r#"INSERT INTO proposed_solutions 
-        (auction_id, uid, id, solver, is_winner, was_filtered, score, price_tokens, price_values)"#,
+        (auction_id, uid, id, solver, is_winner, filtered_out, score, price_tokens, price_values)"#,
     );
 
     builder.push_values(solutions.iter(), |mut b, solution| {
@@ -277,7 +277,7 @@ async fn save_solutions(
             .push_bind(&solution.id)
             .push_bind(solution.solver)
             .push_bind(solution.is_winner)
-            .push_bind(solution.was_filtered)
+            .push_bind(solution.filtered_out)
             .push_bind(&solution.score)
             .push_bind(&solution.price_tokens)
             .push_bind(&solution.price_values);
@@ -358,7 +358,7 @@ struct SolutionRow {
     id: BigDecimal,
     solver: Address,
     is_winner: bool,
-    was_filtered: bool,
+    filtered_out: bool,
     score: BigDecimal,
     price_tokens: Vec<Address>,
     price_values: Vec<BigDecimal>,
@@ -374,7 +374,7 @@ struct SolutionRow {
 
 const BASE_SOLUTIONS_QUERY: &str = r#"
     SELECT
-        ps.uid, ps.id, ps.solver, ps.is_winner, ps.was_filtered,
+        ps.uid, ps.id, ps.solver, ps.is_winner, ps.filtered_out,
         ps.score, ps.price_tokens, ps.price_values,
         pse.order_uid, pse.executed_sell, pse.executed_buy,
         COALESCE(pjo.sell_token, o.sell_token) AS sell_token,
@@ -438,7 +438,7 @@ fn map_rows_to_solutions(rows: Vec<SolutionRow>) -> Result<Vec<Solution>, sqlx::
                 id: row.id,
                 solver: row.solver,
                 is_winner: row.is_winner,
-                was_filtered: row.was_filtered,
+                filtered_out: row.filtered_out,
                 score: row.score,
                 orders: Vec::new(),
                 price_tokens: row.price_tokens,
@@ -739,7 +739,7 @@ mod tests {
                 id: solution_uid.into(),
                 solver: non_settling_solver,
                 is_winner: true,
-                was_filtered: false,
+                filtered_out: false,
                 score: Default::default(),
                 orders: Default::default(),
                 price_tokens: Default::default(),
@@ -758,7 +758,7 @@ mod tests {
                 id: solution_uid.into(),
                 solver: ByteArray([2u8; 20]),
                 is_winner: auction_id != 2,
-                was_filtered: false,
+                filtered_out: false,
                 score: Default::default(),
                 orders: Default::default(),
                 price_tokens: Default::default(),
@@ -782,7 +782,7 @@ mod tests {
                 id: solution_uid.into(),
                 solver: ByteArray([3u8; 20]),
                 is_winner: true,
-                was_filtered: false,
+                filtered_out: false,
                 score: Default::default(),
                 orders: Default::default(),
                 price_tokens: Default::default(),
@@ -802,7 +802,7 @@ mod tests {
                 id: solution_uid.into(),
                 solver: ByteArray([4u8; 20]),
                 is_winner: true,
-                was_filtered: false,
+                filtered_out: false,
                 score: Default::default(),
                 orders: Default::default(),
                 price_tokens: Default::default(),
@@ -895,7 +895,7 @@ mod tests {
                 id: auction_id.into(),
                 solver: low_settling_solver,
                 is_winner: true,
-                was_filtered: false,
+                filtered_out: false,
                 score: Default::default(),
                 orders: Default::default(),
                 price_tokens: Default::default(),
@@ -929,7 +929,7 @@ mod tests {
                 id: auction_id.into(),
                 solver: non_settling_solver,
                 is_winner: true,
-                was_filtered: false,
+                filtered_out: false,
                 score: Default::default(),
                 orders: Default::default(),
                 price_tokens: Default::default(),
@@ -949,7 +949,7 @@ mod tests {
                 id: auction_id.into(),
                 solver: settling_solver,
                 is_winner: true,
-                was_filtered: false,
+                filtered_out: false,
                 score: Default::default(),
                 orders: Default::default(),
                 price_tokens: Default::default(),

--- a/crates/e2e/tests/e2e/solver_competition.rs
+++ b/crates/e2e/tests/e2e/solver_competition.rs
@@ -1,5 +1,8 @@
 use {
-    e2e::{setup::*, tx},
+    e2e::{
+        setup::{colocation::SolverEngine, mock::Mock, *},
+        tx,
+    },
     ethcontract::prelude::U256,
     model::{
         order::{OrderCreation, OrderKind},
@@ -7,6 +10,8 @@ use {
     },
     secp256k1::SecretKey,
     shared::ethrpc::Web3,
+    solvers_dto::solution::Solution,
+    std::collections::HashMap,
     web3::signing::SecretKeyRef,
 };
 
@@ -26,6 +31,12 @@ async fn local_node_fairness_check() {
 #[ignore]
 async fn local_node_wrong_solution_submission_address() {
     run_test(wrong_solution_submission_address).await;
+}
+
+#[tokio::test]
+#[ignore]
+async fn local_node_store_filtered_solutions() {
+    run_test(store_filtered_solutions).await;
 }
 
 async fn solver_competition(web3: Web3) {
@@ -418,4 +429,231 @@ async fn wrong_solution_submission_address(web3: Web3) {
         "solver2"
     );
     assert_eq!(competition.common.solutions.len(), 1);
+}
+
+async fn store_filtered_solutions(web3: Web3) {
+    let mut onchain = OnchainComponents::deploy(web3.clone()).await;
+
+    let [good_solver_account, bad_solver_account] = onchain.make_solvers(to_wei(100)).await;
+    let [trader] = onchain.make_accounts(to_wei(100)).await;
+    let [token_a, token_b, token_c] = onchain
+        .deploy_tokens_with_weth_uni_v2_pools(to_wei(300_000), to_wei(1_000))
+        .await;
+
+    // give the settlement contract a ton of the traded tokens so that the mocked
+    // solver solutions can simply give money away to make the trade execute
+    token_b
+        .mint(onchain.contracts().gp_settlement.address(), to_wei(50))
+        .await;
+    token_c
+        .mint(onchain.contracts().gp_settlement.address(), to_wei(50))
+        .await;
+
+    // set up trader for their order
+    token_a.mint(trader.address(), to_wei(2)).await;
+    tx!(
+        trader.account(),
+        token_a.approve(onchain.contracts().allowance, to_wei(2))
+    );
+
+    let services = Services::new(&onchain).await;
+
+    let good_solver = Mock::default();
+    let bad_solver = Mock::default();
+
+    // Start system
+    let base_tokens = vec![token_a.address(), token_b.address(), token_c.address()];
+    colocation::start_driver(
+        onchain.contracts(),
+        vec![
+            colocation::start_baseline_solver(
+                "test_solver".into(),
+                good_solver_account.clone(),
+                onchain.contracts().weth.address(),
+                base_tokens.clone(),
+                1,
+                true,
+            )
+            .await,
+            SolverEngine {
+                name: "good_solver".into(),
+                account: good_solver_account.clone(),
+                endpoint: good_solver.url.clone(),
+                base_tokens: base_tokens.clone(),
+                merge_solutions: true,
+            },
+            SolverEngine {
+                name: "bad_solver".into(),
+                account: bad_solver_account.clone(),
+                endpoint: bad_solver.url.clone(),
+                base_tokens,
+                merge_solutions: true,
+            },
+        ],
+        colocation::LiquidityProvider::UniswapV2,
+        false,
+    );
+
+    // We start the quoter as the baseline solver, and the mock solver as the one
+    // returning the solution
+    services
+        .start_autopilot(
+            None,
+            vec![
+                format!(
+                    "--drivers=good_solver|http://localhost:11088/good_solver|{},bad_solver|http://localhost:11088/bad_solver|{}",
+                    hex::encode(good_solver_account.address()),
+                    hex::encode(bad_solver_account.address()),
+                ),
+                "--price-estimation-drivers=test_solver|http://localhost:11088/test_solver"
+                    .to_string(),
+                "--max-winners-per-auction=10".to_string(),
+                "--combinatorial-auctions-cutover=1970-03-27T15:04:50.410Z".to_string()
+            ],
+        )
+        .await;
+    services
+        .start_api(vec![
+            "--price-estimation-drivers=test_solver|http://localhost:11088/test_solver".to_string(),
+        ])
+        .await;
+
+    // Place order
+    let order_ab = OrderCreation {
+        sell_token: token_a.address(),
+        sell_amount: to_wei(1),
+        buy_token: token_b.address(),
+        buy_amount: to_wei(1),
+        valid_to: model::time::now_in_epoch_seconds() + 300,
+        kind: OrderKind::Sell,
+        ..Default::default()
+    }
+    .sign(
+        EcdsaSigningScheme::Eip712,
+        &onchain.contracts().domain_separator,
+        SecretKeyRef::from(&SecretKey::from_slice(trader.private_key()).unwrap()),
+    );
+
+    let order_ac = OrderCreation {
+        sell_token: token_a.address(),
+        sell_amount: to_wei(1),
+        buy_token: token_c.address(),
+        buy_amount: to_wei(1),
+        valid_to: model::time::now_in_epoch_seconds() + 300,
+        kind: OrderKind::Sell,
+        ..Default::default()
+    }
+    .sign(
+        EcdsaSigningScheme::Eip712,
+        &onchain.contracts().domain_separator,
+        SecretKeyRef::from(&SecretKey::from_slice(trader.private_key()).unwrap()),
+    );
+
+    let order_ab_id = services.create_order(&order_ab).await.unwrap();
+    let order_ac_id = services.create_order(&order_ac).await.unwrap();
+    onchain.mint_block().await;
+
+    // good solver settles order_ab at a price 3:1
+    good_solver.configure_solution(Some(Solution {
+        id: 0,
+        prices: HashMap::from([
+            (token_a.address(), to_wei(3)),
+            (token_b.address(), to_wei(1)),
+        ]),
+        trades: vec![solvers_dto::solution::Trade::Fulfillment(
+            solvers_dto::solution::Fulfillment {
+                executed_amount: order_ab.sell_amount,
+                fee: Some(0.into()),
+                order: solvers_dto::solution::OrderUid(order_ab_id.0),
+            },
+        )],
+        pre_interactions: vec![],
+        interactions: vec![],
+        post_interactions: vec![],
+        gas: None,
+        flashloans: None,
+    }));
+
+    // bad solver settles both orders at 2:1. Because it can't beat the
+    // reference solution of order_a provided by the good solver this
+    // solution will get filtered during the combinatorial auction.
+    bad_solver.configure_solution(Some(Solution {
+        id: 0,
+        prices: HashMap::from([
+            (token_a.address(), to_wei(2)),
+            (token_b.address(), to_wei(1)),
+            (token_c.address(), to_wei(1)),
+        ]),
+        trades: vec![
+            solvers_dto::solution::Trade::Fulfillment(solvers_dto::solution::Fulfillment {
+                executed_amount: order_ab.sell_amount,
+                fee: Some(0.into()),
+                order: solvers_dto::solution::OrderUid(order_ab_id.0),
+            }),
+            solvers_dto::solution::Trade::Fulfillment(solvers_dto::solution::Fulfillment {
+                executed_amount: order_ac.sell_amount,
+                fee: Some(0.into()),
+                order: solvers_dto::solution::OrderUid(order_ac_id.0),
+            }),
+        ],
+        pre_interactions: vec![],
+        interactions: vec![],
+        post_interactions: vec![],
+        gas: None,
+        flashloans: None,
+    }));
+
+    // Drive solution
+    tracing::info!("Waiting for trade to get indexed");
+    onchain.mint_block().await;
+    wait_for_condition(TIMEOUT, || async {
+        let trade = services.get_trades(&order_ab_id).await.unwrap().pop()?;
+        Some(
+            services
+                .get_solver_competition(trade.tx_hash?)
+                .await
+                .is_ok(),
+        )
+    })
+    .await
+    .unwrap();
+
+    let trade = services
+        .get_trades(&order_ab_id)
+        .await
+        .unwrap()
+        .pop()
+        .unwrap();
+
+    let competition = services
+        .get_solver_competition(trade.tx_hash.unwrap())
+        .await
+        .unwrap();
+
+    // check that JSON endpoint contains the filtered solution
+    let bad_solution = &competition.common.solutions[0];
+    assert!(bad_solution.was_filtered);
+    assert!(!bad_solution.is_winner);
+    assert_eq!(bad_solution.solver_address, bad_solver_account.address());
+
+    let good_solution = &competition.common.solutions[1];
+    assert!(!good_solution.was_filtered);
+    assert!(good_solution.is_winner);
+    assert_eq!(good_solution.solver_address, good_solver_account.address());
+
+    // check that new DB tables contain the filtered solution
+    let mut db = services.db().acquire().await.unwrap();
+    let solutions = database::solver_competition::fetch(&mut db, competition.auction_id)
+        .await
+        .unwrap();
+    assert!(
+        solutions.iter().any(|s| s.was_filtered
+            && !s.is_winner
+            && s.solver.0 == bad_solver_account.address().0)
+    );
+    assert!(
+        solutions.iter().any(|s| !s.was_filtered
+            && s.is_winner
+            && s.solver.0 == good_solver_account.address().0)
+    );
 }

--- a/crates/e2e/tests/e2e/solver_competition.rs
+++ b/crates/e2e/tests/e2e/solver_competition.rs
@@ -287,12 +287,12 @@ async fn fairness_check(web3: Web3) {
     assert_eq!(competition.common.solutions.len(), 2);
     let unfair_solution = &competition.common.solutions[0];
     assert_eq!(unfair_solution.solver, "solver1");
-    assert!(unfair_solution.was_filtered);
+    assert!(unfair_solution.filtered_out);
     assert!(!unfair_solution.is_winner);
 
     let fair_solution = &competition.common.solutions[1];
     assert_eq!(fair_solution.solver, "solver2");
-    assert!(!fair_solution.was_filtered);
+    assert!(!fair_solution.filtered_out);
     assert!(fair_solution.is_winner);
 }
 
@@ -638,12 +638,12 @@ async fn store_filtered_solutions(web3: Web3) {
 
     // check that JSON endpoint contains the filtered solution
     let bad_solution = &competition.common.solutions[0];
-    assert!(bad_solution.was_filtered);
+    assert!(bad_solution.filtered_out);
     assert!(!bad_solution.is_winner);
     assert_eq!(bad_solution.solver_address, bad_solver_account.address());
 
     let good_solution = &competition.common.solutions[1];
-    assert!(!good_solution.was_filtered);
+    assert!(!good_solution.filtered_out);
     assert!(good_solution.is_winner);
     assert_eq!(good_solution.solver_address, good_solver_account.address());
 
@@ -653,12 +653,12 @@ async fn store_filtered_solutions(web3: Web3) {
         .await
         .unwrap();
     assert!(
-        solutions.iter().any(|s| s.was_filtered
+        solutions.iter().any(|s| s.filtered_out
             && !s.is_winner
             && s.solver.0 == bad_solver_account.address().0)
     );
     assert!(
-        solutions.iter().any(|s| !s.was_filtered
+        solutions.iter().any(|s| !s.filtered_out
             && s.is_winner
             && s.solver.0 == good_solver_account.address().0)
     );

--- a/crates/e2e/tests/e2e/solver_competition.rs
+++ b/crates/e2e/tests/e2e/solver_competition.rs
@@ -283,11 +283,17 @@ async fn fairness_check(web3: Web3) {
         .await
         .unwrap();
     tracing::info!(?competition, "competition");
-    assert_eq!(
-        competition.common.solutions.last().unwrap().solver,
-        "solver2"
-    );
-    assert_eq!(competition.common.solutions.len(), 1);
+
+    assert_eq!(competition.common.solutions.len(), 2);
+    let unfair_solution = &competition.common.solutions[0];
+    assert_eq!(unfair_solution.solver, "solver1");
+    assert!(unfair_solution.was_filtered);
+    assert!(!unfair_solution.is_winner);
+
+    let fair_solution = &competition.common.solutions[1];
+    assert_eq!(fair_solution.solver, "solver2");
+    assert!(!fair_solution.was_filtered);
+    assert!(fair_solution.is_winner);
 }
 
 async fn wrong_solution_submission_address(web3: Web3) {

--- a/crates/model/src/solver_competition.rs
+++ b/crates/model/src/solver_competition.rs
@@ -54,6 +54,8 @@ pub struct SolverSettlement {
     pub orders: Vec<Order>,
     #[serde(default)]
     pub is_winner: bool,
+    #[serde(default)]
+    pub was_filtered: bool,
 }
 
 #[serde_as]
@@ -168,6 +170,7 @@ mod tests {
                         }
                     ],
                     "isWinner": true,
+                    "wasFiltered": false,
                 },
             ],
         });
@@ -210,6 +213,7 @@ mod tests {
                         },
                     ],
                     is_winner: true,
+                    was_filtered: false,
                 }],
             },
         };

--- a/crates/model/src/solver_competition.rs
+++ b/crates/model/src/solver_competition.rs
@@ -55,7 +55,7 @@ pub struct SolverSettlement {
     #[serde(default)]
     pub is_winner: bool,
     #[serde(default)]
-    pub was_filtered: bool,
+    pub filtered_out: bool,
 }
 
 #[serde_as]
@@ -170,7 +170,7 @@ mod tests {
                         }
                     ],
                     "isWinner": true,
-                    "wasFiltered": false,
+                    "filteredOut": false,
                 },
             ],
         });
@@ -213,7 +213,7 @@ mod tests {
                         },
                     ],
                     is_winner: true,
-                    was_filtered: false,
+                    filtered_out: false,
                 }],
             },
         };

--- a/database/README.md
+++ b/database/README.md
@@ -359,6 +359,7 @@ All solutions reported by solvers, that were part of a solver competition. A sol
  id            | numeric   | not null | id of the proposed solution as reported by the solver
  solver        | bytea     | not null | solver submission address
  is\_winner    | boolean   | not null | specifies if a solver that proposed this solution is required to execute the solution
+ was\_filtered | boolean   | not null | specifies whether the solutions was filtered out during the initial fairness checks of the winner selection
  score         | numeric   | not null | score of a solution, based on a scoring criteria used at the time of competition
  price\_tokens | bytea[]   | not null | tokens used in a solution, for which uniform prices are provided
  price\_values | numeric[] | not null | uniform prices for all tokens in `price\_tokens` list

--- a/database/sql/V086__store_filtered_solutions.sql
+++ b/database/sql/V086__store_filtered_solutions.sql
@@ -1,10 +1,11 @@
 -- To sanity check the combinatorial auction winner selection
--- we also need to know which solutions got filetered out.
--- Since we only stored non-filtered solutions to begin with
--- we backfill the existing data with `was_filtered = false`.
+-- we also need to know which solutions got filtered out.
+-- Since we only stored solutions that passed the filter to
+-- begin with we backfill the existing data with
+-- `filtered_out = false`.
 ALTER TABLE proposed_solutions
-    ADD COLUMN was_filtered BOOLEAN NOT NULL DEFAULT FALSE;
+    ADD COLUMN filtered_out BOOLEAN NOT NULL DEFAULT FALSE;
 
 -- Drop default because we want to enforce this data to be set.
 ALTER TABLE proposed_solutions
-    ALTER COLUMN was_filtered DROP DEFAULT;
+    ALTER COLUMN filtered_out DROP DEFAULT;

--- a/database/sql/V086__store_filtered_solutions.sql
+++ b/database/sql/V086__store_filtered_solutions.sql
@@ -1,0 +1,10 @@
+-- To sanity check the combinatorial auction winner selection
+-- we also need to know which solutions got filetered out.
+-- Since we only stored non-filtered solutions to begin with
+-- we backfill the existing data with `was_filtered = false`.
+ALTER TABLE proposed_solutions
+    ADD COLUMN was_filtered BOOLEAN NOT NULL DEFAULT FALSE;
+
+-- Drop default because we want to enforce this data to be set.
+ALTER TABLE proposed_solutions
+    ALTER COLUMN was_filtered DROP DEFAULT;


### PR DESCRIPTION
# Description
Combinatorial auctions rely on a 2 step approach: (1) filter unfair solutions, (2) rank remaining solutions.
Currently we only store solutions that are left over after step `2` but for better observability and sanity checking individual auctions we should also store solutions that got filtered out in the first step.

# Changes
- refactor `Arbitrator` logic to make it a bit nicer to work with
- DB migration to add `was_filtered` column to `proposed_solutions` table (+ update for README)
- store discarded solutions in 2 places:
    - legacy JSON blob that stores the whole auction data
    - `proposed_solutions` table

## How to test
I added an e2e test that uses 2 solvers that return hand crafted solutions to ensure that one of them will be considered unfair and filtered out during the first phase of the combinatorial auction process. Asserts that the data shows up correctly in the `/solver_competition` endpoint and in the `proposed_solutions` table.