### PR TITLE
Fix replace order test flakiness

### DIFF
--- a/crates/e2e/src/nodes/local_node.rs
+++ b/crates/e2e/src/nodes/local_node.rs
@@ -49,17 +49,10 @@ impl<T: Transport> TestNodeApi<T> {
         CallFuture::new(self.transport.execute("evm_mine", vec![]))
     }
 
-    pub fn disable_automine(&self) -> CallFuture<(), T::Out> {
+    pub fn set_automine_enabled(&self, enabled: bool) -> CallFuture<(), T::Out> {
         CallFuture::new(
             self.transport
-                .execute("evm_setAutomine", vec![serde_json::json!(false)]),
-        )
-    }
-
-    pub fn enable_automine(&self) -> CallFuture<(), T::Out> {
-        CallFuture::new(
-            self.transport
-                .execute("evm_setAutomine", vec![serde_json::json!(true)]),
+                .execute("evm_setAutomine", vec![serde_json::json!(enabled)]),
         )
     }
 

--- a/crates/e2e/src/nodes/local_node.rs
+++ b/crates/e2e/src/nodes/local_node.rs
@@ -56,6 +56,13 @@ impl<T: Transport> TestNodeApi<T> {
         )
     }
 
+    pub fn enable_automine(&self) -> CallFuture<(), T::Out> {
+        CallFuture::new(
+            self.transport
+                .execute("evm_setAutomine", vec![serde_json::json!(true)]),
+        )
+    }
+
     pub fn set_mining_interval(&self, seconds: usize) -> CallFuture<(), T::Out> {
         CallFuture::new(
             self.transport

--- a/crates/e2e/tests/e2e/place_order_with_quote.rs
+++ b/crates/e2e/tests/e2e/place_order_with_quote.rs
@@ -47,7 +47,7 @@ async fn place_order_with_quote(web3: Web3) {
 
     // Disable auto-mine so we don't accidentally mine a settlement
     web3.api::<TestNodeApi<_>>()
-        .disable_automine()
+        .set_automine_enabled(false)
         .await
         .expect("Must be able to disable automine");
 

--- a/crates/e2e/tests/e2e/replace_order.rs
+++ b/crates/e2e/tests/e2e/replace_order.rs
@@ -94,7 +94,7 @@ async fn try_replace_unreplaceable_order_test(web3: Web3) {
     web3.api::<TestNodeApi<_>>()
         .set_automine_enabled(false)
         .await
-        .expect("Must be able to disable auto-mining");
+        .unwrap();
 
     // Place Orders
     let services = Services::new(&onchain).await;

--- a/crates/e2e/tests/e2e/replace_order.rs
+++ b/crates/e2e/tests/e2e/replace_order.rs
@@ -183,7 +183,7 @@ async fn try_replace_unreplaceable_order_test(web3: Web3) {
     wait_for_condition(TIMEOUT, || async {
         let balance_after = token_a.balance_of(trader.address()).call().await.unwrap();
         balance_before.saturating_sub(balance_after) == to_wei(10)
-            && services.get_trades(&order_id).await.unwrap().len() > 0
+            && !services.get_trades(&order_id).await.unwrap().is_empty()
     })
     .await
     .unwrap();

--- a/crates/e2e/tests/e2e/submission.rs
+++ b/crates/e2e/tests/e2e/submission.rs
@@ -47,7 +47,7 @@ async fn test_cancel_on_expiry(web3: Web3) {
 
     // Disable auto-mine so we don't accidentally mine a settlement
     web3.api::<TestNodeApi<_>>()
-        .disable_automine()
+        .set_automine_enabled(false)
         .await
         .expect("Must be able to disable automine");
 


### PR DESCRIPTION
# Description

The test was flaky, because the assertion needed to happen in a certain time window after the order was submitted and auction happened, but before the order was filled. 

There are 2 parts to the MR:
* first disable forging blocks after setup, then posting the order and initiating the auction by minting a single block, which takes us to the point where we can wait for the order to be bid on, but it will never get executed as that would require mining more blocks
* extending the test by allowing the order to be filled afterwards and making sure it can't be replaced 