### PR TITLE
Fix amount formatting

### DIFF
--- a/crates/model/src/solver_competition_v2.rs
+++ b/crates/model/src/solver_competition_v2.rs
@@ -59,3 +59,91 @@ pub struct Order {
     #[serde_as(as = "HexOrDecimalU256")]
     pub buy_amount: U256,
 }
+
+#[cfg(test)]
+mod tests {
+    use {super::*, maplit::btreemap, testlib::assert_json_matches};
+
+    #[test]
+    fn serialize() {
+        let correct = serde_json::json!({
+            "auctionId": 0,
+            "auctionStartBlock": 13u64,
+            "transactionHashes": ["0x3333333333333333333333333333333333333333333333333333333333333333"],
+            "referenceScores": {
+                "0x2222222222222222222222222222222222222222": "0",
+            },
+            "auction": {
+                "orders": [
+                    "0x1111111111111111111111111111111111111111111111111111111111111111\
+                       111111111111111111111111111111111111111111111111",
+                ],
+                "prices": {
+                    "0x2222222222222222222222222222222222222222": "2000",
+                },
+            },
+            "solutions": [
+                {
+                    "solverAddress": "0x2222222222222222222222222222222222222222",
+                    "score": "123",
+                    "ranking": 1,
+                    "clearingPrices": {
+                        "0x2222222222222222222222222222222222222222": "8",
+                    },
+                    "orders": [
+                        {
+                            "id": "0x1111111111111111111111111111111111111111111111111111111111111111\
+                                     111111111111111111111111111111111111111111111111",
+                            "sellAmount": "12",
+                            "buyAmount": "13",
+                        },
+                    ],
+                    "referenceScore": "10",
+                    "txHash": "0x3333333333333333333333333333333333333333333333333333333333333333",
+                    "isWinner": true,
+                    "filteredOut": false,
+                },
+            ],
+        });
+
+        let solver = H160([0x22; 20]);
+        let tx = H256([0x33; 32]);
+
+        let orig = Response {
+            auction_id: 0,
+            auction_start_block: 13,
+            transaction_hashes: vec![tx],
+            reference_scores: btreemap! {
+                solver => 0.into()
+            },
+            auction: Auction {
+                orders: vec![OrderUid([0x11; 56])],
+                prices: btreemap! {
+                    H160([0x22; 20]) => 2000.into(),
+                },
+            },
+            solutions: vec![Solution {
+                solver_address: solver,
+                score: 123.into(),
+                ranking: 1,
+                clearing_prices: btreemap! {
+                    H160([0x22; 20]) => 8.into(),
+                },
+                orders: vec![Order {
+                    id: OrderUid([0x11; 56]),
+                    sell_amount: 12.into(),
+                    buy_amount: 13.into(),
+                }],
+                is_winner: true,
+                filtered_out: false,
+                tx_hash: Some(tx),
+                reference_score: Some(10.into()),
+            }],
+        };
+
+        let serialized = serde_json::to_value(&orig).unwrap();
+        assert_json_matches!(correct, serialized);
+        let deserialized: Response = serde_json::from_value(correct).unwrap();
+        assert_eq!(orig, deserialized);
+    }
+}

--- a/crates/model/src/solver_competition_v2.rs
+++ b/crates/model/src/solver_competition_v2.rs
@@ -7,8 +7,8 @@ use {
     std::collections::BTreeMap,
 };
 
-#[derive(Clone, Debug, Default, Deserialize, Serialize, PartialEq)]
 #[serde_as]
+#[derive(Clone, Debug, Default, Deserialize, Serialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct Response {
     pub auction_id: AuctionId,
@@ -47,8 +47,8 @@ pub struct Solution {
     pub reference_score: Option<U256>,
 }
 
-#[derive(Clone, Debug, Deserialize, Serialize, Eq, PartialEq)]
 #[serde_as]
+#[derive(Clone, Debug, Deserialize, Serialize, Eq, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct Order {
     pub id: OrderUid,


### PR DESCRIPTION
# Description
The new endpoint displays order's sell and buy amounts as well as reference scores in hexadecimal instead of decimal. This can be seen [here](https://barn.api.cow.fi/mainnet/api/v2/solver_competition/13163216).

# Changes
Fixes the order of the `#[serde_as]` macro to make the `serde_as` annotations actually work.

## How to test
added a unit test that checks the serialized version looks like we want and that the `Serialize` and `Deserialize` implementations "agree" (i.e. we can serialize -> deserialize -> serialize` without changing values).