### PR TITLE
Fix clippy lints 1.88

### DIFF
--- a/crates/autopilot/src/arguments.rs
+++ b/crates/autopilot/src/arguments.rs
@@ -387,96 +387,78 @@ impl std::fmt::Display for Arguments {
             db_based_solver_participation_guard,
         } = self;
 
-        write!(f, "{}", shared)?;
-        write!(f, "{}", order_quoting)?;
-        write!(f, "{}", http_client)?;
-        write!(f, "{}", token_owner_finder)?;
-        write!(f, "{}", price_estimation)?;
+        write!(f, "{shared}")?;
+        write!(f, "{order_quoting}")?;
+        write!(f, "{http_client}")?;
+        write!(f, "{token_owner_finder}")?;
+        write!(f, "{price_estimation}")?;
         display_option(f, "tracing_node_url", tracing_node_url)?;
-        writeln!(f, "ethflow_contracts: {:?}", ethflow_contracts)?;
-        writeln!(f, "ethflow_indexing_start: {:?}", ethflow_indexing_start)?;
-        writeln!(f, "metrics_address: {}", metrics_address)?;
+        writeln!(f, "ethflow_contracts: {ethflow_contracts:?}")?;
+        writeln!(f, "ethflow_indexing_start: {ethflow_indexing_start:?}")?;
+        writeln!(f, "metrics_address: {metrics_address}")?;
         let _intentionally_ignored = db_url;
         writeln!(f, "db_url: SECRET")?;
-        writeln!(f, "skip_event_sync: {}", skip_event_sync)?;
-        writeln!(f, "allowed_tokens: {:?}", allowed_tokens)?;
-        writeln!(f, "unsupported_tokens: {:?}", unsupported_tokens)?;
-        writeln!(f, "pool_cache_lru_size: {}", pool_cache_lru_size)?;
-        writeln!(f, "native_price_estimators: {}", native_price_estimators)?;
+        writeln!(f, "skip_event_sync: {skip_event_sync}")?;
+        writeln!(f, "allowed_tokens: {allowed_tokens:?}")?;
+        writeln!(f, "unsupported_tokens: {unsupported_tokens:?}")?;
+        writeln!(f, "pool_cache_lru_size: {pool_cache_lru_size}")?;
+        writeln!(f, "native_price_estimators: {native_price_estimators}")?;
         writeln!(
             f,
-            "min_order_validity_period: {:?}",
-            min_order_validity_period
+            "min_order_validity_period: {min_order_validity_period:?}"
         )?;
-        writeln!(f, "banned_users: {:?}", banned_users)?;
-        writeln!(f, "max_auction_age: {:?}", max_auction_age)?;
-        writeln!(
-            f,
-            "limit_order_price_factor: {:?}",
-            limit_order_price_factor
-        )?;
+        writeln!(f, "banned_users: {banned_users:?}")?;
+        writeln!(f, "max_auction_age: {max_auction_age:?}")?;
+        writeln!(f, "limit_order_price_factor: {limit_order_price_factor:?}")?;
         display_option(f, "trusted_tokens_url", trusted_tokens_url)?;
-        writeln!(f, "trusted_tokens: {:?}", trusted_tokens)?;
+        writeln!(f, "trusted_tokens: {trusted_tokens:?}")?;
         writeln!(
             f,
-            "trusted_tokens_update_interval: {:?}",
-            trusted_tokens_update_interval
+            "trusted_tokens_update_interval: {trusted_tokens_update_interval:?}"
         )?;
         display_list(f, "drivers", drivers.iter())?;
-        writeln!(f, "submission_deadline: {}", submission_deadline)?;
+        writeln!(f, "submission_deadline: {submission_deadline}")?;
         display_option(f, "shadow", shadow)?;
-        writeln!(f, "solve_deadline: {:?}", solve_deadline)?;
-        writeln!(f, "fee_policies: {:?}", fee_policies)?;
+        writeln!(f, "solve_deadline: {solve_deadline:?}")?;
+        writeln!(f, "fee_policies: {fee_policies:?}")?;
         writeln!(
             f,
-            "fee_policy_max_partner_fee: {:?}",
-            fee_policy_max_partner_fee
+            "fee_policy_max_partner_fee: {fee_policy_max_partner_fee:?}"
         )?;
         writeln!(
             f,
-            "order_events_cleanup_interval: {:?}",
-            order_events_cleanup_interval
+            "order_events_cleanup_interval: {order_events_cleanup_interval:?}"
         )?;
         writeln!(
             f,
-            "order_events_cleanup_threshold: {:?}",
-            order_events_cleanup_threshold
+            "order_events_cleanup_threshold: {order_events_cleanup_threshold:?}"
         )?;
-        writeln!(f, "insert_batch_size: {}", insert_batch_size)?;
+        writeln!(f, "insert_batch_size: {insert_batch_size}")?;
         writeln!(
             f,
-            "native_price_estimation_results_required: {}",
-            native_price_estimation_results_required
+            "native_price_estimation_results_required: {native_price_estimation_results_required}"
         )?;
         writeln!(
             f,
-            "max_settlement_transaction_wait: {:?}",
-            max_settlement_transaction_wait
+            "max_settlement_transaction_wait: {max_settlement_transaction_wait:?}"
         )?;
-        writeln!(f, "s3: {:?}", s3)?;
-        writeln!(f, "cow_amm_configs: {:?}", cow_amm_configs)?;
-        writeln!(f, "max_run_loop_delay: {:?}", max_run_loop_delay)?;
+        writeln!(f, "s3: {s3:?}")?;
+        writeln!(f, "cow_amm_configs: {cow_amm_configs:?}")?;
+        writeln!(f, "max_run_loop_delay: {max_run_loop_delay:?}")?;
         writeln!(
             f,
-            "run_loop_native_price_timeout: {:?}",
-            run_loop_native_price_timeout
+            "run_loop_native_price_timeout: {run_loop_native_price_timeout:?}"
         )?;
         writeln!(
             f,
-            "combinatorial_auctions_cutover: {:?}",
-            combinatorial_auctions_cutover
+            "combinatorial_auctions_cutover: {combinatorial_auctions_cutover:?}"
         )?;
-        writeln!(f, "max_winners_per_auction: {:?}", max_winners_per_auction)?;
-        writeln!(f, "archive_node_url: {:?}", archive_node_url)?;
+        writeln!(f, "max_winners_per_auction: {max_winners_per_auction:?}")?;
+        writeln!(f, "archive_node_url: {archive_node_url:?}")?;
+        writeln!(f, "max_solutions_per_solver: {max_solutions_per_solver:?}")?;
         writeln!(
             f,
-            "max_solutions_per_solver: {:?}",
-            max_solutions_per_solver
-        )?;
-        writeln!(
-            f,
-            "db_based_solver_participation_guard: {:?}",
-            db_based_solver_participation_guard
+            "db_based_solver_participation_guard: {db_based_solver_participation_guard:?}"
         )?;
         Ok(())
     }

--- a/crates/autopilot/src/boundary/order.rs
+++ b/crates/autopilot/src/boundary/order.rs
@@ -29,9 +29,11 @@ pub fn to_domain(
         owner: order.metadata.owner.into(),
         partially_fillable: order.data.partially_fillable,
         executed: remaining_order.executed_amount.into(),
-        pre_interactions: order_is_untouched
-            .then(|| order.interactions.pre.into_iter().map(Into::into).collect())
-            .unwrap_or_default(),
+        pre_interactions: if order_is_untouched {
+            order.interactions.pre.into_iter().map(Into::into).collect()
+        } else {
+            Default::default()
+        },
         post_interactions: order
             .interactions
             .post

--- a/crates/autopilot/src/domain/competition/winner_selection/combinatorial.rs
+++ b/crates/autopilot/src/domain/competition/winner_selection/combinatorial.rs
@@ -1367,7 +1367,7 @@ mod tests {
         match s.to_lowercase().as_str() {
             "buy" => Ok(order::Side::Buy),
             "sell" => Ok(order::Side::Sell),
-            _ => Err(serde::de::Error::custom(format!("Invalid side: {}", s))),
+            _ => Err(serde::de::Error::custom(format!("Invalid side: {s}"))),
         }
     }
 }

--- a/crates/autopilot/src/run_loop.rs
+++ b/crates/autopilot/src/run_loop.rs
@@ -798,7 +798,7 @@ impl RunLoop {
         let outcome = match result {
             Ok(_) => "success".to_string(),
             Err(SettleError::Timeout) => "timeout".to_string(),
-            Err(SettleError::Other(err)) => format!("driver failed: {}", err),
+            Err(SettleError::Other(err)) => format!("driver failed: {err}"),
         };
 
         tokio::spawn(async move {

--- a/crates/driver/src/infra/config/file/load.rs
+++ b/crates/driver/src/infra/config/file/load.rs
@@ -60,7 +60,7 @@ pub async fn load(chain: Chain, path: &Path) -> infra::Config {
                     let account =
                         ethcontract::transaction::kms::Account::new((&config).into(), &key_id.0)
                             .await
-                            .unwrap_or_else(|_| panic!("Unable to load KMS account {:?}", key_id));
+                            .unwrap_or_else(|_| panic!("Unable to load KMS account {key_id:?}"));
                     ethcontract::Account::Kms(account, None)
                 }
                 file::Account::Address(address) => ethcontract::Account::Local(address, None),
@@ -399,8 +399,8 @@ pub async fn load(chain: Chain, path: &Path) -> infra::Config {
                         .any(|wrapper| wrapper.lender == default_lender)
                     {
                         panic!(
-                            "Flashloan default lender {:?} not found in flashloan wrappers",
-                            default_lender
+                            "Flashloan default lender {default_lender:?} not found in flashloan \
+                             wrappers"
                         );
                     }
                 }

--- a/crates/driver/src/tests/cases/jit_orders.rs
+++ b/crates/driver/src/tests/cases/jit_orders.rs
@@ -104,12 +104,11 @@ async fn protocol_fee_test_case(test_case: TestCase) {
         .jit_order(jit_order.clone())
         .order(order.clone())
         .solution(ab_solution())
-        .surplus_capturing_jit_order_owners(
-            test_case
-                .is_surplus_capturing_jit_order
-                .then(|| vec![solver.address()])
-                .unwrap_or_default(),
-        )
+        .surplus_capturing_jit_order_owners(if test_case.is_surplus_capturing_jit_order {
+            vec![solver.address()]
+        } else {
+            Vec::default()
+        })
         .solvers(vec![solver])
         .done()
         .await;

--- a/crates/driver/src/tests/setup/driver.rs
+++ b/crates/driver/src/tests/setup/driver.rs
@@ -279,29 +279,27 @@ async fn create_config_file(
             .unwrap(),
             OrderPriorityStrategy::CreationTimestamp { max_order_age } => {
                 let max_order_age = max_order_age
-                    .map(|age| format!("max-order-age = \"{:?}\"", age))
+                    .map(|age| format!("max-order-age = \"{age:?}\""))
                     .unwrap_or_else(|| "".to_string());
                 write!(
                     file,
                     r#"[[order-priority]]
                     strategy = "creation-timestamp"
-                    {}
+                    {max_order_age}
                     "#,
-                    max_order_age,
                 )
                 .unwrap()
             }
             OrderPriorityStrategy::OwnQuotes { max_order_age } => {
                 let max_order_age = max_order_age
-                    .map(|age| format!("max-order-age = \"{:?}\"", age))
+                    .map(|age| format!("max-order-age = \"{age:?}\""))
                     .unwrap_or_else(|| "".to_string());
                 write!(
                     file,
                     r#"[[order-priority]]
                     strategy = "own-quotes"
-                    {}
+                    {max_order_age}
                     "#,
-                    max_order_age,
                 )
                 .unwrap()
             }

--- a/crates/driver/src/tests/setup/mod.rs
+++ b/crates/driver/src/tests/setup/mod.rs
@@ -454,8 +454,7 @@ impl Pool {
                 / (eth::U256::from(1000) * quote_buy_amount);
         if reserve_a_min > reserve_a_max {
             panic!(
-                "Unexpected calculated reserves. min: {:?}, max: {:?}",
-                reserve_a_min, reserve_a_max
+                "Unexpected calculated reserves. min: {reserve_a_min:?}, max: {reserve_a_max:?}"
             );
         }
         Self {
@@ -485,8 +484,7 @@ impl Pool {
             / (eth::U256::from(997) * quote_sell_amount);
         if reserve_b_min > reserve_b_max {
             panic!(
-                "Unexpected calculated reserves. min: {:?}, max: {:?}",
-                reserve_b_min, reserve_b_max
+                "Unexpected calculated reserves. min: {reserve_b_min:?}, max: {reserve_b_max:?}"
             );
         }
         Self {

--- a/crates/e2e/src/setup/colocation.rs
+++ b/crates/e2e/src/setup/colocation.rs
@@ -221,7 +221,7 @@ mempool = "public"
 fn encode_base_tokens(tokens: impl IntoIterator<Item = H160>) -> String {
     tokens
         .into_iter()
-        .map(|token| format!(r#""{:x}""#, token))
+        .map(|token| format!(r#""{token:x}""#))
         .collect::<Vec<_>>()
         .join(",")
 }

--- a/crates/e2e/src/setup/deploy.rs
+++ b/crates/e2e/src/setup/deploy.rs
@@ -50,7 +50,7 @@ impl Contracts {
         let gp_settlement = GPv2Settlement::deployed(web3).await.unwrap();
         let cow_amm_helper = match contracts::CowAmmLegacyHelper::deployed(web3).await {
             Err(DeployError::NotFound(_)) => None,
-            Err(err) => panic!("failed to find deployed contract: {:?}", err),
+            Err(err) => panic!("failed to find deployed contract: {err:?}"),
             Ok(contract) => Some(contract),
         };
 

--- a/crates/e2e/src/setup/fee.rs
+++ b/crates/e2e/src/setup/fee.rs
@@ -42,21 +42,16 @@ impl std::fmt::Display for ProtocolFee {
             FeePolicyKind::Surplus {
                 factor,
                 max_volume_factor,
-            } => write!(
-                f,
-                "surplus:{}:{}:{}",
-                factor, max_volume_factor, order_class_str
-            ),
+            } => write!(f, "surplus:{factor}:{max_volume_factor}:{order_class_str}"),
             FeePolicyKind::Volume { factor } => {
-                write!(f, "volume:{}:{}", factor, order_class_str)
+                write!(f, "volume:{factor}:{order_class_str}")
             }
             FeePolicyKind::PriceImprovement {
                 factor,
                 max_volume_factor,
             } => write!(
                 f,
-                "priceImprovement:{}:{}:{}",
-                factor, max_volume_factor, order_class_str
+                "priceImprovement:{factor}:{max_volume_factor}:{order_class_str}"
             ),
         }
     }
@@ -70,6 +65,6 @@ impl std::fmt::Display for ProtocolFeesConfig {
             .map(|fee| fee.to_string())
             .collect::<Vec<_>>()
             .join(",");
-        write!(f, "--fee-policies={}", fees_str)
+        write!(f, "--fee-policies={fees_str}")
     }
 }

--- a/crates/e2e/tests/e2e/app_data_signer.rs
+++ b/crates/e2e/tests/e2e/app_data_signer.rs
@@ -112,7 +112,7 @@ async fn order_creation_checks_metadata_signer(web3: Web3) {
 }
 
 fn full_app_data_with_signer(signer: H160) -> OrderCreationAppData {
-    let app_data = format!("{{\"metadata\": {{\"signer\": \"{:?}\"}}}}", signer);
+    let app_data = format!("{{\"metadata\": {{\"signer\": \"{signer:?}\"}}}}");
     OrderCreationAppData::Full {
         full: app_data.to_string(),
     }

--- a/crates/e2e/tests/e2e/replace_order.rs
+++ b/crates/e2e/tests/e2e/replace_order.rs
@@ -141,8 +141,7 @@ async fn try_replace_unreplaceable_order_test(web3: Web3) {
         partially_fillable: false,
         app_data: OrderCreationAppData::Full {
             full: format!(
-                r#"{{"version":"1.1.0","metadata":{{"replacedOrder":{{"uid":"{}"}}}}}}"#,
-                order_id
+                r#"{{"version":"1.1.0","metadata":{{"replacedOrder":{{"uid":"{order_id}"}}}}}}"#
             ),
         },
         ..Default::default()
@@ -294,8 +293,7 @@ async fn try_replace_someone_else_order_test(web3: Web3) {
         partially_fillable: false,
         app_data: OrderCreationAppData::Full {
             full: format!(
-                r#"{{"version":"1.1.0","metadata":{{"replacedOrder":{{"uid":"{}"}}}}}}"#,
-                order_id
+                r#"{{"version":"1.1.0","metadata":{{"replacedOrder":{{"uid":"{order_id}"}}}}}}"#
             ),
         },
         ..Default::default()
@@ -402,12 +400,11 @@ async fn single_replace_order_test(web3: Web3) {
               "version":"1.1.0",
                   "metadata":{{
                       "replacedOrder":{{
-                          "uid":"{}"
+                          "uid":"{order_id}"
                       }},
                       "customStuff": 20
                   }}
-              }}"#,
-        order_id
+              }}"#
     );
 
     // Replace order

--- a/crates/e2e/tests/e2e/solver_participation_guard.rs
+++ b/crates/e2e/tests/e2e/solver_participation_guard.rs
@@ -104,8 +104,7 @@ async fn non_settling_solver(web3: Web3) {
     // possible delays.
     let sleep_timeout_secs = 40 - now.elapsed().as_secs() + 5;
     println!(
-        "Sleeping for {} seconds to reset the solver participation guard cache",
-        sleep_timeout_secs
+        "Sleeping for {sleep_timeout_secs} seconds to reset the solver participation guard cache"
     );
     tokio::time::sleep(tokio::time::Duration::from_secs(sleep_timeout_secs)).await;
     // The cache is reset, and the solver is allowed to participate again.
@@ -175,8 +174,7 @@ async fn low_settling_solver(web3: Web3) {
     // possible delays.
     let sleep_timeout_secs = 40 - now.elapsed().as_secs() + 5;
     println!(
-        "Sleeping for {} seconds to reset the solver participation guard cache",
-        sleep_timeout_secs
+        "Sleeping for {sleep_timeout_secs} seconds to reset the solver participation guard cache"
     );
     tokio::time::sleep(tokio::time::Duration::from_secs(sleep_timeout_secs)).await;
     // The cache is reset, and the solver is allowed to participate again.

--- a/crates/ethrpc/src/buffered.rs
+++ b/crates/ethrpc/src/buffered.rs
@@ -308,15 +308,15 @@ fn build_rpc_metadata(
     let mut grouped_metadata_iter = grouped_metadata.into_iter().peekable();
     while let Some((trace_id, methods)) = grouped_metadata_iter.next() {
         // New entry starts with the trace_id
-        write!(metadata_str, "{}:", trace_id)?;
+        write!(metadata_str, "{trace_id}:")?;
 
         // Followed by the method names and their indices
         let mut methods_iter = methods.into_iter().peekable();
         while let Some((method, indices)) = methods_iter.next() {
-            write!(metadata_str, "{}(", method)?;
+            write!(metadata_str, "{method}(")?;
 
             let indices_str = format_indices_as_ranges(indices)?;
-            write!(metadata_str, "{}", indices_str)?;
+            write!(metadata_str, "{indices_str}")?;
 
             write!(metadata_str, ")")?;
 
@@ -394,11 +394,11 @@ fn format_indices_as_ranges(indices: BTreeSet<usize>) -> anyhow::Result<String> 
 ///   represented as a range using two dots (e.g., "start..last").
 fn append_sequence(buffer: &mut String, start: usize, last: usize) -> core::fmt::Result {
     if start == last {
-        write!(buffer, "{}", start)
+        write!(buffer, "{start}")
     } else if start == last - 1 {
-        write!(buffer, "{},{}", start, last)
+        write!(buffer, "{start},{last}")
     } else {
-        write!(buffer, "{}..{}", start, last)
+        write!(buffer, "{start}..{last}")
     }
 }
 

--- a/crates/orderbook/src/api/post_order.rs
+++ b/crates/orderbook/src/api/post_order.rs
@@ -99,7 +99,7 @@ impl IntoWarpReply for AppDataValidationErrorWrapper {
     fn into_warp_reply(self) -> ApiReply {
         match self.0 {
             AppDataValidationError::Invalid(err) => with_status(
-                error("InvalidAppData", format!("{:?}", err)),
+                error("InvalidAppData", format!("{err:?}")),
                 StatusCode::BAD_REQUEST,
             ),
             AppDataValidationError::Mismatch { provided, actual } => with_status(

--- a/crates/orderbook/src/arguments.rs
+++ b/crates/orderbook/src/arguments.rs
@@ -168,63 +168,52 @@ impl std::fmt::Display for Arguments {
             active_order_competition_threshold,
         } = self;
 
-        write!(f, "{}", shared)?;
-        write!(f, "{}", order_quoting)?;
-        write!(f, "{}", http_client)?;
-        write!(f, "{}", token_owner_finder)?;
-        write!(f, "{}", price_estimation)?;
+        write!(f, "{shared}")?;
+        write!(f, "{order_quoting}")?;
+        write!(f, "{http_client}")?;
+        write!(f, "{token_owner_finder}")?;
+        write!(f, "{price_estimation}")?;
         display_option(f, "tracing_node_url", tracing_node_url)?;
-        writeln!(f, "bind_address: {}", bind_address)?;
+        writeln!(f, "bind_address: {bind_address}")?;
         let _intentionally_ignored = db_url;
         writeln!(f, "db_url: SECRET")?;
         writeln!(
             f,
-            "min_order_validity_period: {:?}",
-            min_order_validity_period
+            "min_order_validity_period: {min_order_validity_period:?}"
         )?;
         writeln!(
             f,
-            "max_order_validity_period: {:?}",
-            max_order_validity_period
+            "max_order_validity_period: {max_order_validity_period:?}"
         )?;
         writeln!(
             f,
-            "max_limit_order_validity_period: {:?}",
-            max_limit_order_validity_period
+            "max_limit_order_validity_period: {max_limit_order_validity_period:?}"
         )?;
-        writeln!(f, "unsupported_tokens: {:?}", unsupported_tokens)?;
-        writeln!(f, "banned_users: {:?}", banned_users)?;
-        writeln!(f, "allowed_tokens: {:?}", allowed_tokens)?;
-        writeln!(f, "pool_cache_lru_size: {}", pool_cache_lru_size)?;
+        writeln!(f, "unsupported_tokens: {unsupported_tokens:?}")?;
+        writeln!(f, "banned_users: {banned_users:?}")?;
+        writeln!(f, "allowed_tokens: {allowed_tokens:?}")?;
+        writeln!(f, "pool_cache_lru_size: {pool_cache_lru_size}")?;
         writeln!(
             f,
-            "eip1271_skip_creation_validation: {}",
-            eip1271_skip_creation_validation
-        )?;
-        writeln!(
-            f,
-            "solvable_orders_max_update_age_blocks: {}",
-            solvable_orders_max_update_age_blocks,
-        )?;
-        writeln!(f, "native_price_estimators: {}", native_price_estimators)?;
-        writeln!(
-            f,
-            "fast_price_estimation_results_required: {}",
-            fast_price_estimation_results_required
+            "eip1271_skip_creation_validation: {eip1271_skip_creation_validation}"
         )?;
         writeln!(
             f,
-            "max_limit_orders_per_user: {}",
-            max_limit_orders_per_user
+            "solvable_orders_max_update_age_blocks: {solvable_orders_max_update_age_blocks}",
         )?;
-        writeln!(f, "ipfs_gateway: {:?}", ipfs_gateway)?;
+        writeln!(f, "native_price_estimators: {native_price_estimators}")?;
+        writeln!(
+            f,
+            "fast_price_estimation_results_required: {fast_price_estimation_results_required}"
+        )?;
+        writeln!(f, "max_limit_orders_per_user: {max_limit_orders_per_user}")?;
+        writeln!(f, "ipfs_gateway: {ipfs_gateway:?}")?;
         display_secret_option(f, "ipfs_pinata_auth", ipfs_pinata_auth.as_ref())?;
-        writeln!(f, "app_data_size_limit: {}", app_data_size_limit)?;
-        writeln!(f, "max_gas_per_order: {}", max_gas_per_order)?;
+        writeln!(f, "app_data_size_limit: {app_data_size_limit}")?;
+        writeln!(f, "max_gas_per_order: {max_gas_per_order}")?;
         writeln!(
             f,
-            "active_order_competition_threshold: {}",
-            active_order_competition_threshold
+            "active_order_competition_threshold: {active_order_competition_threshold}"
         )?;
 
         Ok(())

--- a/crates/orderbook/src/database/fee_policies.rs
+++ b/crates/orderbook/src/database/fee_policies.rs
@@ -109,8 +109,7 @@ fn fee_policy_from(
         },
         database::fee_policies::FeePolicyKind::PriceImprovement => {
             let quote = quote.context(format!(
-                "missing price improvement quote for order '{:?}'",
-                order_uid
+                "missing price improvement quote for order '{order_uid:?}'"
             ))?;
             let gas_amount =
                 BigRational::from_f64(quote.gas_amount).context("invalid quote gas amount")?;

--- a/crates/refunder/src/arguments.rs
+++ b/crates/refunder/src/arguments.rs
@@ -85,19 +85,19 @@ impl std::fmt::Display for Arguments {
             refunder_pk,
         } = self;
 
-        write!(f, "{}", http_client)?;
-        write!(f, "{}", ethrpc)?;
-        write!(f, "{}", logging)?;
-        writeln!(f, "min_validity_duration: {:?}", min_validity_duration)?;
-        writeln!(f, "min_price_deviation_bps: {}", min_price_deviation_bps)?;
+        write!(f, "{http_client}")?;
+        write!(f, "{ethrpc}")?;
+        write!(f, "{logging}")?;
+        writeln!(f, "min_validity_duration: {min_validity_duration:?}")?;
+        writeln!(f, "min_price_deviation_bps: {min_price_deviation_bps}")?;
         let _intentionally_ignored = db_url;
         writeln!(f, "db_url: SECRET")?;
-        writeln!(f, "node_url: {}", node_url)?;
+        writeln!(f, "node_url: {node_url}")?;
         display_option(f, "chain_id", chain_id)?;
-        writeln!(f, "ethflow_contracts: {:?}", ethflow_contracts)?;
+        writeln!(f, "ethflow_contracts: {ethflow_contracts:?}")?;
         let _intentionally_ignored = refunder_pk;
         writeln!(f, "refunder_pk: SECRET")?;
-        writeln!(f, "metrics_port: {}", metrics_port)?;
+        writeln!(f, "metrics_port: {metrics_port}")?;
         Ok(())
     }
 }

--- a/crates/shared/src/arguments.rs
+++ b/crates/shared/src/arguments.rs
@@ -319,19 +319,16 @@ impl Display for OrderQuotingArguments {
 
         writeln!(
             f,
-            "eip1271_onchain_quote_validity_second: {:?}",
-            eip1271_onchain_quote_validity
+            "eip1271_onchain_quote_validity_second: {eip1271_onchain_quote_validity:?}"
         )?;
         writeln!(
             f,
-            "presign_onchain_quote_validity_second: {:?}",
-            presign_onchain_quote_validity
+            "presign_onchain_quote_validity_second: {presign_onchain_quote_validity:?}"
         )?;
         display_list(f, "price_estimation_drivers", price_estimation_drivers)?;
         writeln!(
             f,
-            "standard_offchain_quote_validity: {:?}",
-            standard_offchain_quote_validity
+            "standard_offchain_quote_validity: {standard_offchain_quote_validity:?}"
         )?;
         Ok(())
     }
@@ -371,35 +368,32 @@ impl Display for Arguments {
             token_quality_cache_prefetch_time,
         } = self;
 
-        write!(f, "{}", ethrpc)?;
-        write!(f, "{}", current_block)?;
-        write!(f, "{}", tenderly)?;
-        write!(f, "{}", logging)?;
-        writeln!(f, "node_url: {}", node_url)?;
+        write!(f, "{ethrpc}")?;
+        write!(f, "{current_block}")?;
+        write!(f, "{tenderly}")?;
+        write!(f, "{logging}")?;
+        writeln!(f, "node_url: {node_url}")?;
         display_option(f, "chain_id", chain_id)?;
         display_option(f, "simulation_node_url", simulation_node_url)?;
-        writeln!(f, "gas_estimators: {:?}", gas_estimators)?;
+        writeln!(f, "gas_estimators: {gas_estimators:?}")?;
         display_secret_option(f, "blocknative_api_key", blocknative_api_key.as_ref())?;
-        writeln!(f, "base_tokens: {:?}", base_tokens)?;
-        writeln!(f, "baseline_sources: {:?}", baseline_sources)?;
-        writeln!(f, "pool_cache_blocks: {}", pool_cache_blocks)?;
+        writeln!(f, "base_tokens: {base_tokens:?}")?;
+        writeln!(f, "baseline_sources: {baseline_sources:?}")?;
+        writeln!(f, "pool_cache_blocks: {pool_cache_blocks}")?;
         writeln!(
             f,
-            "pool_cache_maximum_recent_block_age: {}",
-            pool_cache_maximum_recent_block_age
+            "pool_cache_maximum_recent_block_age: {pool_cache_maximum_recent_block_age}"
         )?;
         writeln!(
             f,
-            "pool_cache_maximum_retries: {}",
-            pool_cache_maximum_retries
+            "pool_cache_maximum_retries: {pool_cache_maximum_retries}"
         )?;
         writeln!(
             f,
-            "pool_cache_delay_between_retries: {:?}",
-            pool_cache_delay_between_retries
+            "pool_cache_delay_between_retries: {pool_cache_delay_between_retries:?}"
         )?;
-        writeln!(f, "use_internal_buffers: {}", use_internal_buffers)?;
-        writeln!(f, "balancer_factories: {:?}", balancer_factories)?;
+        writeln!(f, "use_internal_buffers: {use_internal_buffers}")?;
+        writeln!(f, "balancer_factories: {balancer_factories:?}")?;
         display_secret_option(
             f,
             "solver_competition_auth",
@@ -437,23 +431,19 @@ impl Display for Arguments {
         )?;
         writeln!(
             f,
-            "liquidity_fetcher_max_age_update: {:?}",
-            liquidity_fetcher_max_age_update
+            "liquidity_fetcher_max_age_update: {liquidity_fetcher_max_age_update:?}"
         )?;
         writeln!(
             f,
-            "max_pools_to_initialize_cache: {}",
-            max_pools_to_initialize_cache
+            "max_pools_to_initialize_cache: {max_pools_to_initialize_cache}"
         )?;
         writeln!(
             f,
-            "token_quality_cache_expiry: {:?}",
-            token_quality_cache_expiry
+            "token_quality_cache_expiry: {token_quality_cache_expiry:?}"
         )?;
         writeln!(
             f,
-            "token_quality_cache_prefetch_time: {:?}",
-            token_quality_cache_prefetch_time
+            "token_quality_cache_prefetch_time: {token_quality_cache_prefetch_time:?}"
         )?;
 
         Ok(())

--- a/crates/shared/src/bad_token/token_owner_finder/mod.rs
+++ b/crates/shared/src/bad_token/token_owner_finder/mod.rs
@@ -220,11 +220,11 @@ impl Display for Arguments {
             solver_token_owners_cache_update_intervals,
         } = self;
 
-        writeln!(f, "token_owner_finders: {:?}", token_owner_finders)?;
+        writeln!(f, "token_owner_finders: {token_owner_finders:?}")?;
         writeln!(
             f,
-            "token_owner_finder_uniswap_v3_fee_values: {:?}",
-            token_owner_finder_uniswap_v3_fee_values
+            "token_owner_finder_uniswap_v3_fee_values: \
+             {token_owner_finder_uniswap_v3_fee_values:?}"
         )?;
         display_option(
             f,
@@ -262,12 +262,12 @@ impl Display for Arguments {
             "token_owner_finder_rate_limiter",
             token_owner_finder_rate_limiter,
         )?;
-        writeln!(f, "whitelisted_owners, {:?}", whitelisted_owners)?;
+        writeln!(f, "whitelisted_owners, {whitelisted_owners:?}")?;
         display_list(f, "solver_token_owners_urls", solver_token_owners_urls)?;
         writeln!(
             f,
-            "solver_token_owners_cache_update_intervals, {:?}",
-            solver_token_owners_cache_update_intervals
+            "solver_token_owners_cache_update_intervals, \
+             {solver_token_owners_cache_update_intervals:?}"
         )?;
         Ok(())
     }

--- a/crates/shared/src/current_block.rs
+++ b/crates/shared/src/current_block.rs
@@ -48,8 +48,7 @@ impl Display for Arguments {
 
         writeln!(
             f,
-            "block_stream_poll_interval: {:?}",
-            block_stream_poll_interval
+            "block_stream_poll_interval: {block_stream_poll_interval:?}"
         )?;
 
         Ok(())

--- a/crates/shared/src/ethrpc.rs
+++ b/crates/shared/src/ethrpc.rs
@@ -44,13 +44,12 @@ impl Display for Arguments {
             ethrpc_batch_delay,
         } = self;
 
-        writeln!(f, "ethrpc_max_batch_size: {}", ethrpc_max_batch_size)?;
+        writeln!(f, "ethrpc_max_batch_size: {ethrpc_max_batch_size}")?;
         writeln!(
             f,
-            "ethrpc_max_concurrent_requests: {}",
-            ethrpc_max_concurrent_requests
+            "ethrpc_max_concurrent_requests: {ethrpc_max_concurrent_requests}"
         )?;
-        writeln!(f, "ethrpc_batch_delay: {:?}", ethrpc_batch_delay)?;
+        writeln!(f, "ethrpc_batch_delay: {ethrpc_batch_delay:?}")?;
 
         Ok(())
     }

--- a/crates/shared/src/http_client.rs
+++ b/crates/shared/src/http_client.rs
@@ -70,6 +70,6 @@ impl Display for Arguments {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         let Self { http_timeout } = self;
 
-        writeln!(f, "http_timeout: {:?}", http_timeout)
+        writeln!(f, "http_timeout: {http_timeout:?}")
     }
 }

--- a/crates/shared/src/price_estimation/mod.rs
+++ b/crates/shared/src/price_estimation/mod.rs
@@ -86,7 +86,7 @@ impl Display for NativePriceEstimator {
             NativePriceEstimator::OneInchSpotPriceApi => "OneInchSpotPriceApi".into(),
             NativePriceEstimator::CoinGecko => "CoinGecko".into(),
         };
-        write!(f, "{}", formatter)
+        write!(f, "{formatter}")
     }
 }
 
@@ -107,7 +107,7 @@ impl Display for NativePriceEstimators {
                     .format_with(",", |estimator, f| f(&format_args!("{estimator}")))
             })
             .format(";");
-        write!(f, "{}", formatter)
+        write!(f, "{formatter}")
     }
 }
 
@@ -363,28 +363,23 @@ impl Display for Arguments {
         )?;
         writeln!(
             f,
-            "native_price_cache_refresh: {:?}",
-            native_price_cache_refresh
+            "native_price_cache_refresh: {native_price_cache_refresh:?}"
         )?;
         writeln!(
             f,
-            "native_price_cache_max_age: {:?}",
-            native_price_cache_max_age
+            "native_price_cache_max_age: {native_price_cache_max_age:?}"
         )?;
         writeln!(
             f,
-            "native_price_prefetch_time: {:?}",
-            native_price_prefetch_time
+            "native_price_prefetch_time: {native_price_prefetch_time:?}"
         )?;
         writeln!(
             f,
-            "native_price_cache_max_update_size: {}",
-            native_price_cache_max_update_size
+            "native_price_cache_max_update_size: {native_price_cache_max_update_size}"
         )?;
         writeln!(
             f,
-            "native_price_cache_concurrent_requests: {}",
-            native_price_cache_concurrent_requests
+            "native_price_cache_concurrent_requests: {native_price_cache_concurrent_requests}"
         )?;
         display_option(
             f,
@@ -397,7 +392,7 @@ impl Display for Arguments {
             "one_inch_spot_price_api_key: {:?}",
             one_inch_api_key.as_ref(),
         )?;
-        writeln!(f, "one_inch_spot_price_api_url: {}", one_inch_url)?;
+        writeln!(f, "one_inch_spot_price_api_url: {one_inch_url}")?;
         display_secret_option(
             f,
             "coin_gecko_api_key: {:?}",
@@ -420,14 +415,13 @@ impl Display for Arguments {
                 |coin_gecko_buffered| coin_gecko_buffered.coin_gecko_broadcast_channel_capacity
             ),
         )?;
-        writeln!(f, "quote_inaccuracy_limit: {}", quote_inaccuracy_limit)?;
-        writeln!(f, "quote_verification: {:?}", quote_verification)?;
-        writeln!(f, "quote_timeout: {:?}", quote_timeout)?;
-        write!(f, "{}", balance_overrides)?;
+        writeln!(f, "quote_inaccuracy_limit: {quote_inaccuracy_limit}")?;
+        writeln!(f, "quote_verification: {quote_verification:?}")?;
+        writeln!(f, "quote_timeout: {quote_timeout:?}")?;
+        write!(f, "{balance_overrides}")?;
         writeln!(
             f,
-            "native_price_approximation_tokens: {:?}",
-            native_price_approximation_tokens
+            "native_price_approximation_tokens: {native_price_approximation_tokens:?}"
         )?;
 
         Ok(())

--- a/crates/shared/src/price_estimation/native/coingecko.rs
+++ b/crates/shared/src/price_estimation/native/coingecko.rs
@@ -105,7 +105,7 @@ impl CoinGecko {
                 "contract_addresses",
                 &tokens
                     .iter()
-                    .map(|token| format!("{:#x}", token))
+                    .map(|token| format!("{token:#x}"))
                     .collect::<Vec<_>>()
                     .join(","),
             )

--- a/crates/shared/src/price_estimation/native/oneinch.rs
+++ b/crates/shared/src/price_estimation/native/oneinch.rs
@@ -112,7 +112,7 @@ async fn get_current_prices(
     chain: u64,
     token_info: &dyn TokenInfoFetching,
 ) -> Result<HashMap<Token, f64>> {
-    let url = crate::url::join(&base_url, &format!("/price/v1.1/{}", chain));
+    let url = crate::url::join(&base_url, &format!("/price/v1.1/{chain}"));
     let mut builder = client.get(url);
     if let Some(api_key) = api_key {
         builder = builder.header(AUTHORIZATION, api_key)

--- a/crates/shared/src/price_estimation/trade_verifier/balance_overrides.rs
+++ b/crates/shared/src/price_estimation/trade_verifier/balance_overrides.rs
@@ -80,23 +80,22 @@ impl Display for Arguments {
 
         writeln!(
             f,
-            "quote_token_balance_overrides: {:?}",
-            quote_token_balance_overrides
+            "quote_token_balance_overrides: {quote_token_balance_overrides:?}"
         )?;
         writeln!(
             f,
-            "quote_autodetect_token_balance_overrides: {:?}",
-            quote_autodetect_token_balance_overrides
+            "quote_autodetect_token_balance_overrides: \
+             {quote_autodetect_token_balance_overrides:?}"
         )?;
         writeln!(
             f,
-            "quote_autodetect_token_balance_overrides_probing_depth: {:?}",
-            quote_autodetect_token_balance_overrides_probing_depth
+            "quote_autodetect_token_balance_overrides_probing_depth: \
+             {quote_autodetect_token_balance_overrides_probing_depth:?}"
         )?;
         writeln!(
             f,
-            "quote_autodetect_token_balance_overrides_cache_size: {:?}",
-            quote_autodetect_token_balance_overrides_cache_size
+            "quote_autodetect_token_balance_overrides_cache_size: \
+             {quote_autodetect_token_balance_overrides_cache_size:?}"
         )?;
 
         Ok(())

--- a/crates/shared/src/sources/balancer_v2/swap/stable_math.rs
+++ b/crates/shared/src/sources/balancer_v2/swap/stable_math.rs
@@ -290,13 +290,13 @@ mod tests {
             }
         }
         let b = (invariant / (amplification_parameter * num_tokens)) + sum - invariant;
-        let c = (invariant.powi(i32::try_from(num_tokens_usize).unwrap_or(i32::MAX) + 1) * -1.)
+        let c = -invariant.powi(i32::try_from(num_tokens_usize).unwrap_or(i32::MAX) + 1)
             / (amplification_parameter
                 * num_tokens.powi(i32::try_from(num_tokens_usize).unwrap_or(i32::MAX) + 1)
                 * prod);
         let x = b.powi(2) - (c * 4.);
         let root_x = x.powf(0.5);
-        let neg_b = b * -1.;
+        let neg_b = -b;
         (neg_b + root_x) / 2.
     }
 

--- a/crates/shared/src/trade_finding/external.rs
+++ b/crates/shared/src/trade_finding/external.rs
@@ -43,7 +43,7 @@ impl ExternalTradeFinder {
     pub fn new(driver: Url, client: Client, block_stream: CurrentBlockWatcher) -> Self {
         Self {
             quote_endpoint: crate::url::join(&driver, "quote"),
-            sharing: RequestSharing::labelled(format!("tradefinder_{}", driver)),
+            sharing: RequestSharing::labelled(format!("tradefinder_{driver}")),
             client,
             block_stream,
         }

--- a/crates/shared/src/trade_finding/mod.rs
+++ b/crates/shared/src/trade_finding/mod.rs
@@ -298,7 +298,7 @@ mod tests {
             data: vec![0x01, 0x02, 0x03, 0x04, 0x05, 0x06],
         };
 
-        let interaction_debug = format!("{:?}", interaction);
+        let interaction_debug = format!("{interaction:?}");
 
         assert_eq!(
             interaction_debug,


### PR DESCRIPTION
# Description
New rust - new clippy lints

# Changes
- use variables directly in some macros
- rewrite an "obfuscated if else" (not a huge fan of this one)
- replace `(f64 * -1)` with `-f64`

## How to test
`cargo clippy`