### PR TITLE
Update node version to fix build

### DIFF
--- a/playground/Dockerfile.cowswap
+++ b/playground/Dockerfile.cowswap
@@ -1,5 +1,5 @@
 # Stage 1: Build the frontend
-FROM docker.io/node:18-bullseye-slim as node-build
+FROM docker.io/node:22-bullseye-slim as node-build
 WORKDIR /usr/src/app
 
 # RPC URL args


### PR DESCRIPTION
# Description

Use a newer node version to fix FE build. Some react packages were no longer compatible with node v18, but also not compatible with node v24. Works with node v22.