### PR TITLE
fix(database): Set replica identity for order_events

### DIFF
--- a/database/sql/V087__add_primary_key_to_order_events.sql
+++ b/database/sql/V087__add_primary_key_to_order_events.sql
@@ -1,5 +1,0 @@
--- The `order_events` table needs a `REPLICA IDENTITY` in order for `DELETE`
--- operations to be published to replicas.
--- This migration adds a new `id` column as the `PRIMARY KEY` to serve as the
--- `REPLICA IDENTITY`.
-ALTER TABLE order_events ADD COLUMN id BIGSERIAL PRIMARY KEY;

--- a/database/sql/V087__add_primary_key_to_order_events.sql
+++ b/database/sql/V087__add_primary_key_to_order_events.sql
@@ -1,0 +1,5 @@
+-- The `order_events` table needs a `REPLICA IDENTITY` in order for `DELETE`
+-- operations to be published to replicas.
+-- This migration adds a new `id` column as the `PRIMARY KEY` to serve as the
+-- `REPLICA IDENTITY`.
+ALTER TABLE order_events ADD COLUMN id BIGSERIAL PRIMARY KEY;

--- a/database/sql/V087__set_replica_identity_full_for_order_events.sql
+++ b/database/sql/V087__set_replica_identity_full_for_order_events.sql
@@ -1,0 +1,6 @@
+-- The `order_events` table needs a `REPLICA IDENTITY` in order for `DELETE`
+-- operations to be published to replicas.
+-- This migration sets the replica identity to FULL, which uses the entire row
+-- for identifying changes. This is a temporary solution until a proper primary key is added.
+
+ALTER TABLE public.order_events REPLICA IDENTITY FULL;


### PR DESCRIPTION
# Description

This PR addresses a recurring database error that prevents the successful cleanup of old records from the `order_events` table.

> 2025-07-01T09:04:00.609Z  WARN order_events_cleaner: autopilot::periodic_db_cleanup: failed to delete order events before 2025-06-01 09:04:00.604091056 UTC err=Database(PgDatabaseError { severity: Error, code: "55000", message: "cannot delete from table \"order_events\" because it does not have a replica identity and publishes deletes", detail: None, hint: Some("To enable deleting from the table, set REPLICA IDENTITY using ALTER TABLE."), position: None, where: None, schema: None, table: None, column: None, data_type: None, constraint: None, file: Some("execReplication.c"), line: Some(692), routine: Some("CheckCmdReplicaIdentity") })

This also enables us to use logical replication on this table without getting the following error:

> 2025-07-02 08:47:41 UTC:10.0.128.185(43404):USER@xdai:[10395]:ERROR:  cannot delete from table "order_events" because it does not have a replica identity and publishes deletes

## Solution

   - Created a new database migration `set_replica_identity_full_for_order_events.sql`.
   - This migration sets the replica identity to FULL for the `order_events` table using `ALTER TABLE public.order_events REPLICA IDENTITY FULL`.
   - With replica identity set to FULL, the entire row is used for identifying changes, which enables DELETE operations to be published to replicas.
   - This is a temporary solution until a proper primary key is added to the table.
   - No application code changes are needed as this only affects the database's replication behavior.

This change is non-breaking because:
   1. It only changes the replica identity setting, not the table structure.
   2. The table continues to function exactly as before for all application operations.
   3. The application code does not need any modifications.
   4. This change only affects how the database handles replication of DELETE operations.

**Note**: Setting replica identity to FULL is less efficient than having a proper primary key, as it requires the entire row to be logged for replication. A future migration will add a proper primary key to optimize this further. Since the rows do not contain a lot of data, this is okay.