### PR TITLE
Remove balancer weighted pools weights check

### DIFF
--- a/crates/driver/src/domain/liquidity/balancer/v2/weighted.rs
+++ b/crates/driver/src/domain/liquidity/balancer/v2/weighted.rs
@@ -62,13 +62,6 @@ impl Reserves {
             return Err(InvalidReserves::DuplicateToken);
         }
 
-        let total_weight = reserves.iter().fold(eth::U256::default(), |acc, r| {
-            acc.saturating_add(r.weight.0)
-        });
-        if total_weight != Weight::base() {
-            return Err(InvalidReserves::AbnormalWeights);
-        }
-
         Ok(Self(reserves))
     }
 
@@ -101,9 +94,6 @@ impl IntoIterator for Reserves {
 pub enum InvalidReserves {
     #[error("invalid Balancer V2 token reserves; duplicate token address")]
     DuplicateToken,
-
-    #[error("invalid Balancer V2 token reserves; token weights do not sum to 1.0")]
-    AbnormalWeights,
 }
 
 /// Balancer weighted pool reserve for a single token.


### PR DESCRIPTION
# Description
The metri team reported [[slack](https://cowservices.slack.com/archives/C036MD8ADMG/p1751385358082819)] that we couldn't compute a native price for `0x31b32b96049f8fd24969611252c4e44a1b4a07eb` on gnosis chain although there are 2 pools for that token:
* a uniswap v3 [pool](https://oku.trade/app/gnosis/pool/0x2cb844B91212a4a5a1C6c70F0304edED3e4E0b8A?isFlipped=false)
* a balancer v2 liquidity bootstrapping [pool](https://balancer.fi/pools/gnosis/v2/0x34414fd9af0d38a9f1cc69cd1abb8f1d4ddd9519000200000000000000000150) (LBP)

The subgraph we use for uniswap v3 doesn't index the first pool - we can't do anything about that. But the balancer subgraph has the second pool indexed.
The issue is that the weights of the balancer pool don't add up to 1 which causes us to discard that pool before we send the liquidity sources to the solver. I did some research [[github](https://github.com/balancer/balancer-subgraph-v2/issues/173), [slack](https://cowservices.slack.com/archives/C035TDPHQAJ/p1751549493660739)] and it turns out that this is somewhat expected and does not have to be enforced. When I removed this check the baseline solver was able to compute a native price for the token.

# Changes
- removed code to enforce that weights sum up to 1

## How to test
did a local test