### PR TITLE
Append trace id instead of prepending

### DIFF
--- a/crates/observe/src/distributed_tracing/trace_id_format.rs
+++ b/crates/observe/src/distributed_tracing/trace_id_format.rs
@@ -139,7 +139,7 @@ where
                 line.pop();
             }
             // append trace id and a newline
-            line.push_str(&format!(" [trace_id {trace_id}]\n"));
+            line.push_str(&format!(" trace_id={trace_id}\n"));
         }
         writer.write_str(&line)?;
         format_res


### PR DESCRIPTION
# Description

Some of our log processing components expect every new line to start with a timestamp and a recent change where we introduced trace ID in the beginning of lines broke this. This PR changes it so trace IDs are appended instead. 

New output looks like this:
```
2025-07-09T14:59:19.707Z  INFO current_block_stream: ethrpc::block_stream: noticed a new block number=22882375 hash=0xdc06af00cce033449905a942d578e2dadfdca6e8f5fd33a65ba394d084cbe318 [trace_id 282c260b4c4be165971c9aad02caa644]
```

