### PR TITLE
Rollback PR: Remove created_at column from app_data table

### DIFF
--- a/database/sql/V089__remove_app_data_timestamp.sql
+++ b/database/sql/V089__remove_app_data_timestamp.sql
@@ -1,0 +1,5 @@
+-- Remove the timestamp column from app_data table
+-- This is a rollback migration for testing purposes
+
+ALTER TABLE app_data 
+DROP COLUMN created_at; 


### PR DESCRIPTION
This PR removes the `created_at` timestamp column from the `app_data` table, rolling back the changes from the previous migration.

## Changes

- **Migration**: Added `V089__remove_app_data_timestamp.sql` which removes the `created_at` column

## Purpose

This rollback migration demonstrates:
1. How to reverse database schema changes
2. Testing flyway rollback scenarios
3. Ensuring migrations can be safely undone

## Migration Details

```sql
ALTER TABLE app_data 
DROP COLUMN created_at;
```

## Dependencies

This migration depends on the previous migration V088 that added the `created_at` column. It should be applied after V088 to properly remove the column.

## Testing

This rollback can be tested to ensure:
- Column is successfully removed
- No data loss occurs (other than the timestamp data)
- Application continues to function normally
- Database schema returns to previous state