### PR TITLE
[TRIVIAL] Fix signature verification log

### DIFF
--- a/crates/shared/src/signature_validator/simulation.rs
+++ b/crates/shared/src/signature_validator/simulation.rs
@@ -73,7 +73,7 @@ impl Validator {
         // 1. How the pre-interactions would behave as part of the settlement
         // 2. Simulate the actual `isValidSignature` calls that would happen as part of
         //    a settlement
-        let gas_used = contracts::storage_accessible::simulate(
+        let result = contracts::storage_accessible::simulate(
             BYTECODE.clone(),
             self.signatures.methods().validate(
                 (self.settlement, self.vault_relayer),
@@ -87,12 +87,10 @@ impl Validator {
                     .collect(),
             ),
         )
-        .await?;
+        .await;
 
-        let simulation = Simulation { gas_used };
-
-        tracing::trace!(?check, ?simulation, "simulated signature");
-        Ok(simulation)
+        tracing::trace!(?check, ?result, "simulated signature");
+        Ok(Simulation { gas_used: result? })
     }
 }
 


### PR DESCRIPTION
# Description
Recently I wanted to debug why a signature verification failed only to realize that the inputs only get printed after a successful simulation which defeats the purpose.

# Changes
Emit log before unpacking the error.

## How to test
compiler