### PR TITLE
[EASY] Info log when exit the current block stream loop

### DIFF
--- a/crates/ethrpc/src/block_stream/mod.rs
+++ b/crates/ethrpc/src/block_stream/mod.rs
@@ -161,7 +161,7 @@ pub async fn current_block_stream(
 
             tracing::info!(number=%block.number, hash=?block.hash, "noticed a new block");
             if sender.send(block).is_err() {
-                tracing::debug!("exiting polling loop");
+                tracing::info!("exiting polling loop");
                 break;
             }
 
@@ -201,7 +201,7 @@ pub fn throttle(blocks: CurrentBlockWatcher, updates_to_skip: NonZeroU64) -> Cur
             }
 
             if sender.send(block).is_err() {
-                tracing::debug!("exiting polling loop");
+                tracing::info!("exiting polling loop");
                 break;
             }
         }

--- a/crates/ethrpc/src/block_stream/mod.rs
+++ b/crates/ethrpc/src/block_stream/mod.rs
@@ -160,9 +160,12 @@ pub async fn current_block_stream(
             }
 
             tracing::info!(number=%block.number, hash=?block.hash, "noticed a new block");
-            if sender.send(block).is_err() {
-                tracing::info!("exiting polling loop");
-                break;
+            if let Err(err) = sender.send(block) {
+                tracing::error!(
+                    ?err,
+                    "failed to send block to stream, aborting polling loop"
+                );
+                panic!("polling loop terminated due to sender failure");
             }
 
             previous_block = block;
@@ -200,9 +203,12 @@ pub fn throttle(blocks: CurrentBlockWatcher, updates_to_skip: NonZeroU64) -> Cur
                 continue;
             }
 
-            if sender.send(block).is_err() {
-                tracing::info!("exiting polling loop");
-                break;
+            if let Err(err) = sender.send(block) {
+                tracing::error!(
+                    ?err,
+                    "failed to send block to stream, aborting polling loop"
+                );
+                panic!("polling loop terminated due to sender failure");
             }
         }
     };


### PR DESCRIPTION
# Description
Sometimes we have an issue with the stuck current block stream. The idea is to allow info-level logs. This PR raises the loop break log to the corresponding level to observe the error and to understand the cause of the problem better.
