### PR TITLE
Return an error when we'd pass to many arguments in an SQL query

### DIFF
--- a/crates/orderbook/src/database/trades.rs
+++ b/crates/orderbook/src/database/trades.rs
@@ -45,6 +45,13 @@ impl TradeRetrieving for Postgres {
             .iter()
             .filter_map(|t| t.auction_id.map(|auction_id| (auction_id, t.order_uid)))
             .collect::<Vec<_>>();
+
+        if auction_order_uids.len() >= u16::MAX as usize {
+            // We use these ids as arguments for an SQL query and sqlx only allows
+            // u16::MAX arguments. To avoid a panic later on we return an error here.
+            anyhow::bail!("query response too large");
+        }
+
         let executed_protocol_fees = self
             .executed_protocol_fees(auction_order_uids.as_slice())
             .await?;


### PR DESCRIPTION
# Description
`sqlx` panics when you try to pass `> u16::MAX` arguments in your query. This currently happens when somebody requests the trade history of the ethflow contract which has ~230K trades.

example [logs](https://aws-es.cow.fi/_dashboards/app/data-explorer/discover#?_a=(discover:(columns:!(log,log_level),isDirty:!f,sort:!()),metadata:(indexPattern:'86e4a5a0-4e4b-11ef-85c5-3946a99ed1a7',view:discover))&_g=(filters:!(),refreshInterval:(pause:!t,value:0),time:(from:'2025-07-10T19:22:58.372Z',to:'2025-07-10T20:31:49.345Z'))&_q=(filters:!(),query:(language:kuery,query:'2bfd91b81a897c0e21e06210fdbdbe41'))) showing the panic

To find the most likely culprit I ran this query:
```sql
SELECT encode(o.owner, 'hex') as owner, COUNT(*) AS trade_count
FROM trades t
JOIN orders o ON t.order_uid = o.uid
GROUP BY o.owner
ORDER BY trade_count DESC
LIMIT 1;
```
This returned the ethflow contract which had exactly the same number of trades as were returned in one DB query executed during the user request making it very likely that this was the cause. 

# Changes
Detect the case when we'd exceed the argument limit and return an error instead of panicking later.