### PR TITLE
[EASY] Fix `solver_competition_v2::load_by_tx_hash` SQL query

### DIFF
--- a/crates/database/src/solver_competition_v2.rs
+++ b/crates/database/src/solver_competition_v2.rs
@@ -73,16 +73,15 @@ pub async fn load_by_tx_hash(
     const FETCH_AUCTION_ID: &str = r#"
         SELECT s.auction_id
         FROM settlements s
-        LEFT OUTER JOIN settlement_observations so ON
+        JOIN settlement_observations so ON
              s.block_number = so.block_number
              AND s.log_index = so.log_index
-        WHERE s.tx_hash = $1;
+        WHERE s.tx_hash = $1 AND s.auction_id IS NOT NULL;
     "#;
-    let auction_id = sqlx::query_scalar::<_, Option<i64>>(FETCH_AUCTION_ID)
+    let auction_id = sqlx::query_scalar(FETCH_AUCTION_ID)
         .bind(tx_hash)
         .fetch_optional(ex.deref_mut())
-        .await?
-        .flatten();
+        .await?;
     let Some(auction_id) = auction_id else {
         return Ok(None);
     };

--- a/crates/orderbook/src/database/solver_competition_v2.rs
+++ b/crates/orderbook/src/database/solver_competition_v2.rs
@@ -25,7 +25,7 @@ impl Postgres {
         let mut ex = self.pool.acquire().await.map_err(anyhow::Error::from)?;
         database::solver_competition_v2::load_by_id(&mut ex, auction_id)
             .await
-            .context("solver_competition::load_by_id")?
+            .context("solver_competition_v2::load_by_id")?
             .map(try_into_dto)
             .ok_or(LoadSolverCompetitionError::NotFound)?
     }
@@ -42,7 +42,7 @@ impl Postgres {
         let mut ex = self.pool.acquire().await.map_err(anyhow::Error::from)?;
         database::solver_competition_v2::load_by_tx_hash(&mut ex, ByteArray(tx_hash.0))
             .await
-            .context("solver_competition::load_by_tx_hash")?
+            .context("solver_competition_v2::load_by_tx_hash")?
             .map(try_into_dto)
             .ok_or(LoadSolverCompetitionError::NotFound)?
     }
@@ -56,7 +56,7 @@ impl Postgres {
         let mut ex = self.pool.acquire().await.map_err(anyhow::Error::from)?;
         database::solver_competition_v2::load_latest(&mut ex)
             .await
-            .context("solver_competition::load_latest")?
+            .context("solver_competition_v2::load_latest")?
             .map(try_into_dto)
             .ok_or(LoadSolverCompetitionError::NotFound)?
     }


### PR DESCRIPTION
# Description
Fixes an SQL issue mentioned in #3481:

> The following error was noticed in the logs:
> ```
> 2025-07-11T11:38:02.553Z ERROR request{id="881fab40fb9666ccd88bc5e7abb8ef06"}: orderbook::api::get_solver_competition_v2: load solver competition err=solver_competition::load_by_tx_hash
> 
> Caused by:
>     0: error occurred while decoding column 0: unexpected null; try decoding as an `Option`
>     1: unexpected null; try decoding as an `Option`
> ```

# Changes
This change ensures that `load_by_tx_hash` handles cases where `settlements.auction_id` is NULL.

- Uses Option<i64> in the SQLx query to avoid runtime decoding errors when the column is null.
- Applies `.flatten()` to handle the Option<Option<_>> from fetch_optional. An alternative solution is to declare a wrapper struct, which contains an optional single value, but flattening is concise enough.
- Prevents panics when the `settlement_observations` row is missing or when `auction_id` is not yet set.


## How to test
Added a new test. It is quite involved to add a positive case scenario, where all the corresponding tables are also filled out, so I kept things simple for now. Will test it in staging first.


## Related Issues

Fixes #3481
Requires #3482 to fix the issue completely