### PR TITLE
Fix solver_competition::load_by_id SQL query

### DIFF
--- a/crates/database/src/solver_competition_v2.rs
+++ b/crates/database/src/solver_competition_v2.rs
@@ -19,7 +19,7 @@ use {
 
 #[derive(sqlx::FromRow)]
 pub struct Settlement {
-    pub solution_uid: i64,
+    pub solution_uid: Option<i64>,
     pub tx_hash: TransactionHash,
 }
 
@@ -124,7 +124,7 @@ pub async fn load_by_id(
     };
 
     const FETCH_SETTLEMENTS: &str = r#"
-        SELECT solution_uid, tx_hash
+        SELECT s.solution_uid, s.tx_hash
         FROM settlements s
         LEFT OUTER JOIN settlement_observations so ON
              s.block_number = so.block_number

--- a/crates/orderbook/src/database/solver_competition_v2.rs
+++ b/crates/orderbook/src/database/solver_competition_v2.rs
@@ -79,7 +79,7 @@ fn try_into_dto(value: DbResponse) -> Result<ApiResponse, LoadSolverCompetitionE
     let settlements: HashMap<_, _> = value
         .settlements
         .into_iter()
-        .map(|row| (row.solution_uid, H256(row.tx_hash.0)))
+        .filter_map(|row| row.solution_uid.map(|uid| (uid, H256(row.tx_hash.0))))
         .collect();
 
     let reference_scores: BTreeMap<_, _> = value


### PR DESCRIPTION
# Description
The following log was observed when the settlement's `solution_uid` is not yet updated:
```
2025-07-12T09:06:24.160Z ERROR request{id="3b3dca946e4113162fefcd6c1563e6b1"}: orderbook::api::get_solver_competition_v2: load solver competition err=solver_competition::load_by_id

Caused by:
    0: error occurred while decoding column "solution_uid": unexpected null; try decoding as an `Option`
    1: unexpected null; try decoding as an `Option`
```
This PR fixes that by handling this column as optional.

# Changes

- [ ] Make `solution_uid` optional
- [ ] Solution's tx hash is not returned in the API response until the uid is updated in the DB.

## How to test
Existing tests. It makes sense to create a huge after all.
