### PR TITLE
[TRIVIAL] Better signature check logging

### DIFF
--- a/crates/shared/src/signature_validator/mod.rs
+++ b/crates/shared/src/signature_validator/mod.rs
@@ -23,8 +23,11 @@ impl std::fmt::Debug for SignatureCheck {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("SignatureCheck")
             .field("signer", &self.signer)
-            .field("hash", &format!("0x{}", hex::encode(self.hash)))
-            .field("signature", &format!("0x{}", hex::encode(&self.signature)))
+            .field("hash", &format_args!("0x{}", hex::encode(self.hash)))
+            .field(
+                "signature",
+                &format_args!("0x{}", hex::encode(&self.signature)),
+            )
             .field("interactions", &self.interactions)
             .finish()
     }

--- a/crates/shared/src/signature_validator/mod.rs
+++ b/crates/shared/src/signature_validator/mod.rs
@@ -11,12 +11,23 @@ use {
 mod simulation;
 
 /// Structure used to represent a signature.
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Eq, PartialEq)]
 pub struct SignatureCheck {
     pub signer: H160,
     pub hash: [u8; 32],
     pub signature: Vec<u8>,
     pub interactions: Vec<InteractionData>,
+}
+
+impl std::fmt::Debug for SignatureCheck {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SignatureCheck")
+            .field("signer", &self.signer)
+            .field("hash", &format!("0x{}", hex::encode(self.hash)))
+            .field("signature", &format!("0x{}", hex::encode(&self.signature)))
+            .field("interactions", &self.interactions)
+            .finish()
+    }
 }
 
 #[derive(Debug, Error)]


### PR DESCRIPTION
# Description
Using the log emitted from the signature check is currently a bit annoying because the `hash` and `signature` do not get printed as a hex string but as a list of integers.

# Changes
- manually implement `Debug` for `SignatureCheck` to log the fields as hex strings