### PR TITLE
Fix logs not being colored

### DIFF
--- a/crates/observe/src/tracing.rs
+++ b/crates/observe/src/tracing.rs
@@ -96,7 +96,7 @@ fn set_tracing_subscriber(config: &Config) {
                 tracing_subscriber::fmt::layer()
                     .with_timer(timer)
                     .map_event_format(|formatter| TraceIdFmt {
-                        inner: formatter.with_ansi(true),
+                        inner: formatter.with_ansi(atty::is(atty::Stream::Stdout)),
                     })
                     .with_writer(writer)
                     .with_filter($env_filter)


### PR DESCRIPTION
# Description

We're wrapping the default formatter and the ansi flag was not being propagated from Layer to Formatter which then sets the flag on Writer. This led to log output not using colors. By setting the flag on the Format struct the event formatting code will set it on the writer as well: https://github.com/tokio-rs/tracing/blob/main/tracing-subscriber/src/fmt/format/mod.rs#L922. 
