### PR TITLE
Add new networks to openapi spec

### DIFF
--- a/crates/orderbook/openapi.yml
+++ b/crates/orderbook/openapi.yml
@@ -19,6 +19,14 @@ servers:
     url: "https://api.cow.fi/base"
   - description: Base (Staging)
     url: "https://barn.api.cow.fi/base"
+  - description: Avalanche (Prod)
+    url: "https://api.cow.fi/avalanche"
+  - description: Avalanche (Staging)
+    url: "https://barn.api.cow.fi/avalanche"
+  - description: Polygon (Prod)
+    url: "https://api.cow.fi/polygon"
+  - description: Polygon (Staging)
+    url: "https://barn.api.cow.fi/polygon"
   - description: Sepolia (Prod)
     url: "https://api.cow.fi/sepolia"
   - description: Sepolia (Staging)


### PR DESCRIPTION
# Description
Adds the endpoints for avalanche and polygon to the openapi spec so that they show up in the drop down menu.

Fixes: https://github.com/cowprotocol/services/issues/3487