### PR TITLE
Add deployment addresses for flashloan contracts

### DIFF
--- a/crates/contracts/build.rs
+++ b/crates/contracts/build.rs
@@ -31,7 +31,27 @@ fn main() {
     // - https://doc.rust-lang.org/cargo/reference/build-scripts.html#cargorerun-if-changedpath
     println!("cargo:rerun-if-changed=build.rs");
 
-    generate_contract("AaveFlashLoanSolverWrapper");
+    generate_contract_with_config("AaveFlashLoanSolverWrapper", |builder| {
+        let mut builder = builder;
+        for network in [
+            MAINNET,
+            GNOSIS,
+            SEPOLIA,
+            ARBITRUM_ONE,
+            BASE,
+            POLYGON,
+            AVALANCHE,
+        ] {
+            builder = builder.add_network(
+                network,
+                Network {
+                    address: addr("0x7d9c4dee56933151bc5c909cfe09def0d315cb4a"),
+                    deployment_information: None,
+                },
+            );
+        }
+        builder
+    });
     generate_contract_with_config("CoWSwapEthFlow", |builder| {
         builder
             .contract_mod_override("cowswap_eth_flow")
@@ -1056,7 +1076,27 @@ fn main() {
     generate_contract("ERC20");
     generate_contract("ERC20Mintable");
     generate_contract("ERC3156FlashLoanSolverWrapper");
-    generate_contract("FlashLoanRouter");
+    generate_contract_with_config("FlashLoanRouter", |builder| {
+        let mut builder = builder;
+        for network in [
+            MAINNET,
+            GNOSIS,
+            SEPOLIA,
+            ARBITRUM_ONE,
+            BASE,
+            POLYGON,
+            AVALANCHE,
+        ] {
+            builder = builder.add_network(
+                network,
+                Network {
+                    address: addr("0x9da8b48441583a2b93e2ef8213aad0ec0b392c69"),
+                    deployment_information: None,
+                },
+            );
+        }
+        builder
+    });
     generate_contract_with_config("GPv2AllowListAuthentication", |builder| {
         builder
             .contract_mod_override("gpv2_allow_list_authentication")

--- a/crates/e2e/src/setup/onchain_components/mod.rs
+++ b/crates/e2e/src/setup/onchain_components/mod.rs
@@ -303,15 +303,15 @@ impl OnchainComponents {
                 .expect("failed to add solver");
         }
 
-        // TODO: remove when contract is actually deployed
-        // flashloan wrapper also needs to be authorized
-        self.contracts
-            .gp_authenticator
-            .add_solver(self.contracts.flashloan_router.address())
-            .from(auth_manager.clone())
-            .send()
-            .await
-            .expect("failed to add flashloan wrapper");
+        if let Some(router) = &self.contracts.flashloan_router {
+            self.contracts
+                .gp_authenticator
+                .add_solver(router.address())
+                .from(auth_manager.clone())
+                .send()
+                .await
+                .expect("failed to add flashloan wrapper");
+        }
 
         solvers
     }


### PR DESCRIPTION
# Description
So far we freshly deployed the 2 helper contracts related to flashloans even in forked tests because they haven't been audited and deployed when the test code was written.
Now they are deployed on all our networks so we can update the test setup code where we "look up" contracts that were deployed.

Unfortunately we have a couple of forked e2e tests which rely on state before these contracts were deployed so for now I made the contracts optional to handle that case too.

# Changes
- added deployment addresses for the deployed contracts. This did not happen for the maker contracts as that was not widely deployed. Luckily it's currently irrelevant for our testing.
- adjusted our e2e setup code to deal with these optional contracts

## How to test
e2e tests should continue to pass