### PR TITLE
Fix `stderr_threshold` setting

### DIFF
--- a/crates/e2e/src/setup/mod.rs
+++ b/crates/e2e/src/setup/mod.rs
@@ -185,7 +185,7 @@ async fn run<F, Fut, T>(
 {
     let obs_config = observe::Config::new(
         &with_default_filters(filters).join(","),
-        tracing::Level::ERROR.into(),
+        Some(tracing::Level::ERROR),
         false,
         None,
     );

--- a/crates/observe/src/config.rs
+++ b/crates/observe/src/config.rs
@@ -1,4 +1,4 @@
-use {core::time::Duration, tracing::level_filters::LevelFilter};
+use {core::time::Duration, tracing::Level};
 
 #[derive(Debug, Clone)]
 pub struct Config {
@@ -6,7 +6,7 @@ pub struct Config {
     /// https://docs.rs/tracing-subscriber/latest/tracing_subscriber/filter/struct.EnvFilter.html
     pub(crate) env_filter: String,
     /// Minimum level threshold for stderr output
-    pub(crate) stderr_threshold: LevelFilter,
+    pub(crate) stderr_threshold: Option<Level>,
     /// Output log events as JSON
     pub(crate) use_json_format: bool,
     /// Tracing config
@@ -16,7 +16,7 @@ pub struct Config {
 impl Config {
     pub fn new(
         env_filter: &str,
-        stderr_threshold: LevelFilter,
+        stderr_threshold: Option<Level>,
         use_json_format: bool,
         tracing_config: Option<TracingConfig>,
     ) -> Self {
@@ -39,8 +39,8 @@ impl Config {
         self
     }
 
-    pub fn with_stderr_threshold(mut self, stderr_threshold: LevelFilter) -> Self {
-        self.stderr_threshold = stderr_threshold;
+    pub fn with_stderr_threshold(mut self, stderr_threshold: Level) -> Self {
+        self.stderr_threshold = Some(stderr_threshold);
         self
     }
 
@@ -54,7 +54,7 @@ impl Default for Config {
     fn default() -> Self {
         Self {
             env_filter: "info".to_string(),
-            stderr_threshold: LevelFilter::ERROR,
+            stderr_threshold: None,
             use_json_format: false,
             tracing: None,
         }
@@ -70,7 +70,7 @@ pub struct TracingConfig {
     /// Timeout for exporting spans to collector
     pub(crate) export_timeout: Duration,
     /// Level of traces that should be collected
-    pub(crate) level: LevelFilter,
+    pub(crate) level: Level,
 }
 
 impl TracingConfig {
@@ -78,7 +78,7 @@ impl TracingConfig {
         collector_endpoint: String,
         service_name: String,
         export_timeout: Duration,
-        level: LevelFilter,
+        level: Level,
     ) -> Self {
         Self {
             collector_endpoint,

--- a/crates/observe/src/panic_hook.rs
+++ b/crates/observe/src/panic_hook.rs
@@ -37,12 +37,7 @@ mod tests {
     #[test]
     #[ignore]
     fn manual_thread() {
-        let obs_config = Config::new(
-            "info",
-            tracing::level_filters::LevelFilter::OFF,
-            false,
-            None,
-        );
+        let obs_config = Config::new("info", None, false, None);
         crate::tracing::initialize(&obs_config);
 
         // Should print panic trace log but not kill the process.
@@ -61,12 +56,7 @@ mod tests {
     #[tokio::test(flavor = "multi_thread")]
     #[ignore]
     async fn manual_tokio() {
-        let obs_config = Config::new(
-            "info",
-            tracing::level_filters::LevelFilter::OFF,
-            false,
-            None,
-        );
+        let obs_config = Config::new("info", None, false, None);
         crate::tracing::initialize(&obs_config);
 
         let handle = tokio::task::spawn(async { panic!("you should see this message") });

--- a/crates/refunder/src/arguments.rs
+++ b/crates/refunder/src/arguments.rs
@@ -3,7 +3,6 @@ use {
     ethcontract::H160,
     shared::{arguments::display_option, ethrpc, http_client, logging_args_with_default_filter},
     std::time::Duration,
-    tracing::level_filters::LevelFilter,
     url::Url,
 };
 

--- a/crates/shared/src/arguments.rs
+++ b/crates/shared/src/arguments.rs
@@ -21,7 +21,6 @@ use {
         str::FromStr,
         time::Duration,
     },
-    tracing::level_filters::LevelFilter,
     url::Url,
 };
 
@@ -33,8 +32,8 @@ macro_rules! logging_args_with_default_filter {
             #[clap(long, env, default_value = $default_filter)]
             pub log_filter: String,
 
-            #[clap(long, env, default_value = "error")]
-            pub log_stderr_threshold: LevelFilter,
+            #[clap(long, env)]
+            pub log_stderr_threshold: Option<tracing::Level>,
 
             #[clap(long, env, default_value = "false")]
             pub use_json_logs: bool,
@@ -49,7 +48,7 @@ macro_rules! logging_args_with_default_filter {
                 } = self;
 
                 writeln!(f, "log_filter: {}", log_filter)?;
-                writeln!(f, "log_stderr_threshold: {}", log_stderr_threshold)?;
+                writeln!(f, "log_stderr_threshold: {:?}", log_stderr_threshold)?;
                 writeln!(f, "use_json_logs: {}", use_json_logs)?;
                 Ok(())
             }
@@ -111,8 +110,8 @@ logging_args_with_default_filter!(
 pub struct TracingArguments {
     #[clap(long, env)]
     pub tracing_collector_endpoint: Option<String>,
-    #[clap(long, env, default_value_t = LevelFilter::INFO)]
-    pub tracing_level: LevelFilter,
+    #[clap(long, env, default_value_t = tracing::Level::INFO)]
+    pub tracing_level: tracing::Level,
     #[clap(long, env, value_parser = humantime::parse_duration, default_value = "10s")]
     pub tracing_exporter_timeout: Duration,
 }


### PR DESCRIPTION
# Description
Follow up item of a post mortem.
During the post mortem it was discussed that we did not get any slack alerts despite emitting logs with the `error` log level. It was stated that it was a deliberate decision to stop emitting these errors as slack alerts due to noisy. However, my investigation suggests that this was not deliberate and the functionality simply broke in #2868.

The infra repo still configures `stderr_threshold` as `error` and the `stderr_threshold` config was never optional so some number of logs was always expected to go to stderr.

# Changes
- fixed the bug that caused us to stop writing to stderr for logs that had the correct level
- made `stderr_threshold` optional and disabled by default
- converted `LevelFilter` config member arguments to `Level` as that can better express optionality of arguments. You can't use `LevelFilter` to express that you want to always want logging to happen because you can populate it with `LevelFilter::Off` which disables logging, that's not possible with `Level` because that does not have the `OFF` variant. To express optionality with `Level` you have to use `Option<Level>` which communicates intent very clearly.

## How to test
Ran e2e tests with test logs with different levels and `stderr_threshold` settings, piped `stderr` to a file and verified that it only contains logs that were supposed to show up.