### PR TITLE
Enable spans from observe crate

### DIFF
--- a/crates/shared/src/arguments.rs
+++ b/crates/shared/src/arguments.rs
@@ -104,7 +104,7 @@ pub struct OrderQuotingArguments {
 
 logging_args_with_default_filter!(
     LoggingArguments,
-    "info,autopilot=debug,driver=debug,orderbook=debug,solver=debug,shared=debug,cow_amm=debug"
+    "info,autopilot=debug,driver=debug,observe=info,orderbook=debug,solver=debug,shared=debug,cow_amm=debug"
 );
 
 #[derive(Debug, clap::Parser)]

--- a/crates/shared/src/arguments.rs
+++ b/crates/shared/src/arguments.rs
@@ -104,7 +104,8 @@ pub struct OrderQuotingArguments {
 
 logging_args_with_default_filter!(
     LoggingArguments,
-    "info,autopilot=debug,driver=debug,observe=info,orderbook=debug,solver=debug,shared=debug,cow_amm=debug"
+    "info,autopilot=debug,driver=debug,observe=info,orderbook=debug,solver=debug,shared=debug,\
+     cow_amm=debug"
 );
 
 #[derive(Debug, clap::Parser)]


### PR DESCRIPTION
# Description

The span we start in make_span() for warp was not being displayed in logs, because we had `warn` set for the `observe` module in which the span originates. We want to display this span, because it contains a request ID, which makes it easy to correlate logs. 