### PR TITLE
Add ansi to fmt layer

### DIFF
--- a/crates/observe/src/tracing.rs
+++ b/crates/observe/src/tracing.rs
@@ -98,6 +98,7 @@ fn set_tracing_subscriber(config: &Config) {
             } else {
                 tracing_subscriber::fmt::layer()
                     .with_timer(timer)
+                    .with_ansi(atty::is(atty::Stream::Stdout))
                     .map_event_format(|formatter| TraceIdFmt {
                         inner: formatter.with_ansi(atty::is(atty::Stream::Stdout)),
                     })


### PR DESCRIPTION
This field needs to be set on the layer as well as on the custom formatter as it's being propagated to other structs (not just the formatter). This was mistakenly removed in https://github.com/cowprotocol/services/pull/3491