### PR TITLE
Fix nested spans driver

### DIFF
--- a/crates/driver/src/infra/api/mod.rs
+++ b/crates/driver/src/infra/api/mod.rs
@@ -111,17 +111,17 @@ impl Api {
             })));
             let path = format!("/{name}");
             infra::observe::mounting_solver(&name, &path);
-            app = app
-                .nest(&path, router)
-                // axum's default body limit needs to be disabled to not have the default limit on top of our custom limit
-                .layer(axum::extract::DefaultBodyLimit::disable());
+            app = app.nest(&path, router);
         }
 
-        app = app.layer(
-            tower::ServiceBuilder::new()
-                .layer(tower_http::trace::TraceLayer::new_for_http().make_span_with(make_span))
-                .map_request(record_trace_id),
-        );
+        app = app
+            // axum's default body limit needs to be disabled to not have the default limit on top of our custom limit
+            .layer(axum::extract::DefaultBodyLimit::disable())
+            .layer(
+                tower::ServiceBuilder::new()
+                    .layer(tower_http::trace::TraceLayer::new_for_http().make_span_with(make_span))
+                    .map_request(record_trace_id),
+            );
 
         // Start the server.
         let server = axum::Server::bind(&self.addr).serve(app.into_make_service());


### PR DESCRIPTION
# Description

We are getting nested http_request spans in logs right now. This PR removes the unnecessary nesting by removing adding the layer multiple times, which led to the make_span() creating as many spans as there were solvers configured. 

# Changes

- [x] Moved tracing layer outside of the loop that adds routes per solver 

## How to test

Tested locally running driver and hitting /metrics endpoint. For this to appear I had to add a second solver to the config. 

Before

`2025-07-22T11:29:46.056Z  INFO http_request{request_id="0" trace_id="102b7f7baa329060253ca65322cec493"}:http_request{request_id="1"}: observe::distributed_tracing::tracing_axum: HTTP request uri=/metrics method=GET trace_id=368e2d963b47f1041fc94b81458f3198`

After

`2025-07-22T11:32:19.355Z  INFO http_request{request_id="0"}: observe::distributed_tracing::tracing_axum: HTTP request uri=/metrics method=GET trace_id=9da06c12686e374b7d08fd4221d9b731`


