### PR TITLE
Instrument drive solve fns

### DIFF
--- a/crates/driver/src/domain/competition/auction.rs
+++ b/crates/driver/src/domain/competition/auction.rs
@@ -28,6 +28,7 @@ use {
     },
     tap::TapFallible,
     thiserror::Error,
+    tracing::instrument,
 };
 
 /// An auction is a set of orders that can be solved. The solvers calculate
@@ -167,6 +168,7 @@ impl AuctionProcessor {
         }
     }
 
+    #[instrument(skip_all)]
     fn prioritize_orders(
         &self,
         auction: &Auction,

--- a/crates/driver/src/domain/competition/mod.rs
+++ b/crates/driver/src/domain/competition/mod.rs
@@ -515,6 +515,7 @@ impl Competition {
         Ok(())
     }
 
+    #[instrument]
     async fn without_unsupported_orders(&self, mut auction: Auction) -> Auction {
         if !self.solver.config().flashloans_enabled {
             auction.orders.retain(|o| o.app_data.flashloan().is_none());

--- a/crates/driver/src/domain/competition/mod.rs
+++ b/crates/driver/src/domain/competition/mod.rs
@@ -515,7 +515,7 @@ impl Competition {
         Ok(())
     }
 
-    #[instrument]
+    #[instrument(skip_all)]
     async fn without_unsupported_orders(&self, mut auction: Auction) -> Auction {
         if !self.solver.config().flashloans_enabled {
             auction.orders.retain(|o| o.app_data.flashloan().is_none());

--- a/crates/driver/src/domain/competition/mod.rs
+++ b/crates/driver/src/domain/competition/mod.rs
@@ -28,7 +28,7 @@ use {
     },
     tap::TapFallible,
     tokio::sync::{mpsc, oneshot},
-    tracing::Instrument,
+    tracing::{Instrument, instrument},
 };
 
 pub mod auction;
@@ -96,6 +96,7 @@ impl Competition {
     }
 
     /// Solve an auction as part of this competition.
+    #[instrument(skip_all)]
     pub async fn solve(&self, auction: Auction) -> Result<Option<Solved>, Error> {
         let pairs_to_fetch = match self.solver.liquidity() {
             solver::Liquidity::Fetch => auction.liquidity_pairs(),

--- a/crates/driver/src/domain/competition/solution/settlement.rs
+++ b/crates/driver/src/domain/competition/solution/settlement.rs
@@ -14,6 +14,7 @@ use {
     },
     futures::future::try_join_all,
     std::collections::{BTreeSet, HashMap, HashSet},
+    tracing::instrument,
 };
 
 /// A transaction calling into our settlement contract on the blockchain, ready
@@ -68,6 +69,7 @@ impl SettlementTx {
 
 impl Settlement {
     /// Encode a solution into an onchain settlement.
+    #[instrument(name = "encode_settlement", skip_all)]
     pub(super) async fn encode(
         solution: competition::Solution,
         auction: &competition::Auction,
@@ -202,6 +204,7 @@ impl Settlement {
     /// Simulate executing this settlement on the blockchain. This process
     /// ensures that the settlement does not revert, and calculates the
     /// access list and gas needed to settle the solution.
+    #[instrument(name = "simulate_settlement", skip_all)]
     async fn simulate(
         tx: eth::Tx,
         partial_access_list: &eth::AccessList,

--- a/crates/driver/src/infra/api/routes/solve/dto/solve_request.rs
+++ b/crates/driver/src/infra/api/routes/solve/dto/solve_request.rs
@@ -11,9 +11,11 @@ use {
     serde::Deserialize,
     serde_with::serde_as,
     std::collections::HashSet,
+    tracing::instrument,
 };
 
 impl SolveRequest {
+    #[instrument(skip_all)]
     pub async fn into_domain(
         self,
         eth: &Ethereum,

--- a/crates/driver/src/infra/solver/mod.rs
+++ b/crates/driver/src/infra/solver/mod.rs
@@ -28,7 +28,7 @@ use {
     std::{collections::HashMap, time::Duration},
     tap::TapFallible,
     thiserror::Error,
-    tracing::Instrument,
+    tracing::{Instrument, instrument},
 };
 
 pub mod dto;
@@ -227,6 +227,7 @@ impl Solver {
 
     /// Make a POST request instructing the solver to solve an auction.
     /// Allocates at most `timeout` time for the solving.
+    #[instrument(skip_all)]
     pub async fn solve(
         &self,
         auction: &Auction,

--- a/crates/driver/src/infra/solver/mod.rs
+++ b/crates/driver/src/infra/solver/mod.rs
@@ -227,7 +227,7 @@ impl Solver {
 
     /// Make a POST request instructing the solver to solve an auction.
     /// Allocates at most `timeout` time for the solving.
-    #[instrument(skip_all)]
+    #[instrument(name = "solver_engine", skip_all)]
     pub async fn solve(
         &self,
         auction: &Auction,

--- a/crates/driver/src/util/http.rs
+++ b/crates/driver/src/util/http.rs
@@ -1,7 +1,12 @@
-use thiserror::Error;
+use {
+    thiserror::Error,
+    tracing::{Span, field, instrument},
+};
 
+#[instrument(skip_all, fields(url = field::Empty))]
 pub async fn send(limit_bytes: usize, req: reqwest::RequestBuilder) -> Result<String, Error> {
     let mut res = req.send().await?;
+    Span::current().record("url", res.url().as_str());
     let mut data = Vec::new();
     while let Some(chunk) = res.chunk().await? {
         data.extend_from_slice(&chunk);

--- a/crates/solver/src/liquidity/balancer_v2.rs
+++ b/crates/solver/src/liquidity/balancer_v2.rs
@@ -27,6 +27,7 @@ use {
         sources::balancer_v2::pool_fetching::BalancerPoolFetching,
     },
     std::{collections::HashSet, sync::Arc},
+    tracing::instrument,
 };
 
 /// A liquidity provider for Balancer V2 weighted pools.
@@ -110,6 +111,7 @@ impl BalancerV2Liquidity {
 impl LiquidityCollecting for BalancerV2Liquidity {
     /// Returns relevant Balancer V2 weighted pools given a list of off-chain
     /// orders.
+    #[instrument(name = "balancer_v2_liquidity", skip_all)]
     async fn get_liquidity(
         &self,
         pairs: HashSet<TokenPair>,

--- a/crates/solver/src/liquidity/uniswap_v2.rs
+++ b/crates/solver/src/liquidity/uniswap_v2.rs
@@ -23,6 +23,7 @@ use {
         collections::HashSet,
         sync::{Arc, Mutex},
     },
+    tracing::instrument,
 };
 
 pub struct UniswapLikeLiquidity {
@@ -90,6 +91,7 @@ impl UniswapLikeLiquidity {
 impl LiquidityCollecting for UniswapLikeLiquidity {
     /// Given a list of offchain orders returns the list of AMM liquidity to be
     /// considered
+    #[instrument(name = "uniswap_like_liquidity", skip_all)]
     async fn get_liquidity(
         &self,
         pairs: HashSet<TokenPair>,

--- a/crates/solver/src/liquidity/uniswap_v3.rs
+++ b/crates/solver/src/liquidity/uniswap_v3.rs
@@ -25,6 +25,7 @@ use {
         collections::HashSet,
         sync::{Arc, Mutex},
     },
+    tracing::instrument,
 };
 
 // 1h timeout for Uniswap V3 interactions
@@ -121,6 +122,7 @@ impl UniswapV3Liquidity {
 impl LiquidityCollecting for UniswapV3Liquidity {
     /// Given a list of offchain orders returns the list of AMM liquidity to be
     /// considered
+    #[instrument(name = "uniswap_v3_liquidity", skip_all)]
     async fn get_liquidity(
         &self,
         pairs: HashSet<TokenPair>,

--- a/crates/solver/src/liquidity/zeroex.rs
+++ b/crates/solver/src/liquidity/zeroex.rs
@@ -27,6 +27,7 @@ use {
         collections::{HashMap, HashSet},
         sync::Arc,
     },
+    tracing::instrument,
 };
 
 type OrderBuckets = HashMap<(H160, H160), Vec<OrderRecord>>;
@@ -128,6 +129,7 @@ impl ZeroExLiquidity {
 
 #[async_trait::async_trait]
 impl LiquidityCollecting for ZeroExLiquidity {
+    #[instrument(name = "zeroex_liquidity", skip_all)]
     async fn get_liquidity(
         &self,
         pairs: HashSet<TokenPair>,

--- a/crates/solver/src/liquidity_collector.rs
+++ b/crates/solver/src/liquidity_collector.rs
@@ -5,7 +5,7 @@ use {
     shared::{baseline_solver::BaseTokens, recent_block_cache::Block},
     std::{collections::HashSet, future::Future, sync::Arc, time::Duration},
     tokio::sync::RwLock,
-    tracing::Instrument,
+    tracing::{Instrument, instrument},
 };
 
 #[async_trait::async_trait]
@@ -24,6 +24,7 @@ pub struct LiquidityCollector {
 
 #[async_trait::async_trait]
 impl LiquidityCollecting for LiquidityCollector {
+    #[instrument(skip_all, fields(pair_count = pairs.len()))]
     async fn get_liquidity(
         &self,
         pairs: HashSet<TokenPair>,


### PR DESCRIPTION
# Description

To get more visibility into where we spend time the /solve endpoint we can instrument the functions in that flow and look up Grafana.

- [x] Added instrument macros on function used in driver's /solve endpoint

## How to test

I deployed this branch to sepolia staging and looked up traces in Grafana. 


<img width="1149" height="981" alt="Screenshot 2025-07-23 at 15 02 37" src="https://github.com/user-attachments/assets/a519e644-3c0b-4f59-9608-1a23aa6a43c6" />

