### PR TITLE
Detect reorgs in block range

### DIFF
--- a/crates/ethrpc/src/block_stream/mod.rs
+++ b/crates/ethrpc/src/block_stream/mod.rs
@@ -260,7 +260,7 @@ impl BlockRetrieving for Web3 {
     }
 
     /// Gets all blocks requested in the range. For successful results it's
-    /// enforced that all the blocks a present, in the correct order and that
+    /// enforced that all the blocks are present, in the correct order and that
     /// there are not reorgs in the block range.
     async fn blocks(&self, range: RangeInclusive<u64>) -> Result<Vec<BlockNumberHash>> {
         let include_txs = helpers::serialize(&false);

--- a/crates/ethrpc/src/block_stream/mod.rs
+++ b/crates/ethrpc/src/block_stream/mod.rs
@@ -294,7 +294,7 @@ impl BlockRetrieving for Web3 {
                                     ?range,
                                     ?prev_hash,
                                     parent_hash = ?response.parent_hash,
-                                    "detected reorg in block range"
+                                    "inconsistent parent in block range"
                                 );
                                 return Err(anyhow!("block range contains a reorg"));
                             }

--- a/crates/ethrpc/src/block_stream/mod.rs
+++ b/crates/ethrpc/src/block_stream/mod.rs
@@ -296,7 +296,7 @@ impl BlockRetrieving for Web3 {
                                     parent_hash = ?response.parent_hash,
                                     "inconsistent parent in block range"
                                 );
-                                return Err(anyhow!("block range contains a reorg"));
+                                return Err(anyhow!("inconsistent block range"));
                             }
                             prev_hash = Some(current_hash);
 


### PR DESCRIPTION
# Description
We investigated an issue where our event handling logic did not correctly handle a reorg on polygon. One idea was that we might be getting inconsistent block ranges from our node. This initially did not have much credibility because we assumed we use a specific `eth_` call for fetching a whole block range where inconsistencies would be very surprising.
However, we are actually just sending a batch RPC call with many `eth_getBlockByNumber n`, `eth_getBlockByNumber n+1`, ... With that logic the possibility of receiving inconsistent results from the node seems more likely.

In the specific case we debugged there were actually multiple reorgs happening on top of each other so perhaps the node processed some blocks between the eth calls leading to an inconsistent block range.

# Changes
Updated `blocks()` to check for reorgs in the requested block range.