### PR TITLE
Don't fetch future block on autopilot restarts

### DIFF
--- a/crates/autopilot/src/database/onchain_order_events/ethflow_events.rs
+++ b/crates/autopilot/src/database/onchain_order_events/ethflow_events.rs
@@ -240,17 +240,13 @@ pub async fn determine_ethflow_refund_indexing_start(
     .expect("Should be able to find a valid start block")
 }
 
-/// 1. Check the `last_indexed_blocks` table for the `index_name`. Use the next
-///    block as the starting point.
+/// 1. Check the `last_indexed_blocks` table for the `index_name`.
 /// 2. If no value found or the index is 0, use `fallback_start_block`, if
 ///    provided.
 /// 3. Fallback to the settlement deployment block number, if the `chain_id` is
 ///    provided.
 /// 4. Try to fetch the block number to ensure the node is able to continue
 ///    indexing.
-///
-/// Each option except the DB read is retried up to 3 times with a delay of
-/// 500ms.
 async fn find_indexing_start_block(
     db: &PgPool,
     web3: &Web3,

--- a/crates/autopilot/src/run.rs
+++ b/crates/autopilot/src/run.rs
@@ -8,8 +8,7 @@ use {
             onchain_order_events::{
                 OnchainOrderParser,
                 ethflow_events::{
-                    EthFlowOnchainOrderParser,
-                    determine_ethflow_indexing_start,
+                    EthFlowOnchainOrderParser, determine_ethflow_indexing_start,
                     determine_ethflow_refund_indexing_start,
                 },
                 event_retriever::CoWSwapOnchainOrdersContract,
@@ -27,11 +26,7 @@ use {
     clap::Parser,
     contracts::{BalancerV2Vault, IUniswapV3Factory},
     ethcontract::{
-        BlockNumber,
-        H160,
-        common::DeploymentInformation,
-        dyns::DynWeb3,
-        errors::DeployError,
+        BlockNumber, H160, common::DeploymentInformation, dyns::DynWeb3, errors::DeployError,
     },
     ethrpc::block_stream::block_number_to_block_number_hash,
     futures::stream::StreamExt,
@@ -388,7 +383,11 @@ pub async fn run(args: Arguments) {
         .unwrap();
 
     let skip_event_sync_start = if args.skip_event_sync {
-        block_number_to_block_number_hash(&web3, BlockNumber::Latest).await
+        Some(
+            block_number_to_block_number_hash(&web3, BlockNumber::Latest)
+                .await
+                .expect("Failed to fetch latest block"),
+        )
     } else {
         None
     };

--- a/crates/ethrpc/src/block_stream/mod.rs
+++ b/crates/ethrpc/src/block_stream/mod.rs
@@ -13,9 +13,7 @@ use {
     tracing::Instrument,
     url::Url,
     web3::{
-        BatchTransport,
-        Transport,
-        helpers,
+        BatchTransport, Transport, helpers,
         types::{Block, BlockId, BlockNumber, U64},
     },
 };
@@ -323,18 +321,16 @@ pub async fn timestamp_of_current_block_in_seconds(web3: &Web3) -> Result<u32> {
 pub async fn block_number_to_block_number_hash(
     web3: &Web3,
     block_number: BlockNumber,
-) -> Option<BlockNumberHash> {
-    web3.eth()
+) -> Result<BlockNumberHash> {
+    let block = web3
+        .eth()
         .block(BlockId::Number(block_number))
-        .await
-        .ok()
-        .flatten()
-        .map(|block| {
-            (
-                block.number.expect("number must exist").as_u64(),
-                block.hash.expect("hash must exist"),
-            )
-        })
+        .await?
+        .context("block should exists")?;
+    Ok((
+        block.number.expect("number must exist").as_u64(),
+        block.hash.expect("hash must exist"),
+    ))
 }
 
 pub async fn block_by_number(web3: &Web3, block_number: BlockNumber) -> Option<Block<H256>> {


### PR DESCRIPTION
# Description
We are currently seeing sporadic panics (around 50% of the time) when the mainnet autopilot restarts in production. I believe this is due to us trying to fetch "last seen block + 1" to initialize the eth flow refund (and settlement) event indexing flow. In particular what happens is:

1. The old autopilot instance sees a new block _t_ with a relevant event (~every other block for mainnet production)
2. Autopilot restarts and now tries to fetch block _t+1_ from the RPC, which doesn't yet exist (12s block production time) and thus panics
3. After the next restart it finds the block t+1 and starts correctly

This is causing sporadic micro outages (~30s) on mainnet production

https://github.com/cowprotocol/services/pull/3480 attempted to fix the same issue by introducing a retry mechanism. However, given the chosen parameters (3 retries with 500ms delay) this likely has only little effect on mainnet, where we would have to retry for 10+ seconds in order to see the next block

# Changes

- [x] remove retry logic to keep code simple
- [x] remove the +1 from the block fetching logic (I checked that potential reorgs are handled in the core event updater logic)
- [x] bubble up error message from `block_number_to_block_number_hash` to better debug what the node is responding in the error case

## How to test
This is hard to test since on staging we are barely having settlements (and thus last seen block is usually late in the past). Any suggestion on how to get more confidence in the change is appreciated.