### PR TITLE
Fix eth call and trades() instrumentation

### DIFF
--- a/crates/database/src/trades.rs
+++ b/crates/database/src/trades.rs
@@ -3,7 +3,7 @@ use {
     bigdecimal::BigDecimal,
     futures::stream::BoxStream,
     sqlx::PgConnection,
-    tracing::instrument,
+    tracing::{Instrument, info_span, instrument},
 };
 
 #[derive(Clone, Debug, Default, Eq, PartialEq, sqlx::FromRow)]
@@ -21,12 +21,11 @@ pub struct TradesQueryRow {
     pub auction_id: Option<AuctionId>,
 }
 
-#[instrument(skip_all)]
 pub fn trades<'a>(
     ex: &'a mut PgConnection,
     owner_filter: Option<&'a Address>,
     order_uid_filter: Option<&'a OrderUid>,
-) -> BoxStream<'a, Result<TradesQueryRow, sqlx::Error>> {
+) -> instrument::Instrumented<BoxStream<'a, Result<TradesQueryRow, sqlx::Error>>> {
     const COMMON_QUERY: &str = r#"
 SELECT
     t.block_number,
@@ -72,6 +71,7 @@ LEFT OUTER JOIN LATERAL (
         .bind(owner_filter)
         .bind(order_uid_filter)
         .fetch(ex)
+        .instrument(info_span!("trades"))
 }
 
 #[derive(Clone, Debug, Default, Eq, PartialEq, sqlx::FromRow)]

--- a/crates/database/src/trades.rs
+++ b/crates/database/src/trades.rs
@@ -214,6 +214,7 @@ mod tests {
         expected: &[TradesQueryRow],
     ) {
         let mut filtered = trades(db, owner_filter, order_uid_filter)
+            .into_inner()
             .try_collect::<Vec<_>>()
             .await
             .unwrap();
@@ -287,6 +288,7 @@ mod tests {
 
         let now = std::time::Instant::now();
         trades(&mut db, Some(&ByteArray([2u8; 20])), None)
+            .into_inner()
             .try_collect::<Vec<_>>()
             .await
             .unwrap();

--- a/crates/ethrpc/src/extensions.rs
+++ b/crates/ethrpc/src/extensions.rs
@@ -3,7 +3,10 @@
 use {
     serde::{Deserialize, Serialize},
     std::collections::HashMap,
-    tracing::instrument,
+    tracing::{
+        Instrument,
+        instrument::{self, Instrumented},
+    },
     web3::{
         self,
         Transport,
@@ -23,20 +26,19 @@ where
         call: CallRequest,
         block: BlockId,
         overrides: HashMap<H160, StateOverride>,
-    ) -> CallFuture<Bytes, T::Out>;
+    ) -> Instrumented<CallFuture<Bytes, T::Out>>;
 }
 
 impl<T> EthExt<T> for web3::api::Eth<T>
 where
     T: Transport,
 {
-    #[instrument(skip_all)]
     fn call_with_state_overrides(
         &self,
         call: CallRequest,
         block: BlockId,
         overrides: StateOverrides,
-    ) -> CallFuture<Bytes, T::Out> {
+    ) -> Instrumented<CallFuture<Bytes, T::Out>> {
         let call = helpers::serialize(&call);
         let block = helpers::serialize(&block);
         let overrides = helpers::serialize(&overrides);
@@ -45,6 +47,7 @@ where
             self.transport()
                 .execute("eth_call", vec![call, block, overrides]),
         )
+        .instrument(tracing::info_span!("eth_call"))
     }
 }
 

--- a/crates/ethrpc/src/extensions.rs
+++ b/crates/ethrpc/src/extensions.rs
@@ -3,10 +3,7 @@
 use {
     serde::{Deserialize, Serialize},
     std::collections::HashMap,
-    tracing::{
-        Instrument,
-        instrument::{self, Instrumented},
-    },
+    tracing::{Instrument, instrument::Instrumented},
     web3::{
         self,
         Transport,

--- a/crates/orderbook/src/database/trades.rs
+++ b/crates/orderbook/src/database/trades.rs
@@ -36,6 +36,7 @@ impl TradeRetrieving for Postgres {
             filter.owner.map(|owner| ByteArray(owner.0)).as_ref(),
             filter.order_uid.map(|uid| ByteArray(uid.0)).as_ref(),
         )
+        .into_inner()
         .map_err(anyhow::Error::from)
         .try_collect::<Vec<TradesQueryRow>>()
         .await?;


### PR DESCRIPTION
# Description

The instrument macro doesn't instrument a sync function that returns a future properly, we need to wrap that future in Instrument instead. This came up after looking at the values in Grafana where this span length was in microseconds. 