### PR TITLE
Use old HooksTrampoline on Gnosis chain

### DIFF
--- a/crates/contracts/build.rs
+++ b/crates/contracts/build.rs
@@ -1278,7 +1278,7 @@ fn main() {
         builder
             .add_network_str(MAINNET, "0x60Bf78233f48eC42eE3F101b9a05eC7878728006")
             .add_network_str(GOERLI, "0x60Bf78233f48eC42eE3F101b9a05eC7878728006")
-            .add_network_str(GNOSIS, "0x60Bf78233f48eC42eE3F101b9a05eC7878728006")
+            .add_network_str(GNOSIS, "0x01DcB88678aedD0C4cC9552B20F4718550250574")
             .add_network_str(SEPOLIA, "0x60Bf78233f48eC42eE3F101b9a05eC7878728006")
             .add_network_str(ARBITRUM_ONE, "0x60Bf78233f48eC42eE3F101b9a05eC7878728006")
             .add_network_str(BASE, "0x60Bf78233f48eC42eE3F101b9a05eC7878728006")


### PR DESCRIPTION
# Description
Gnosis pay hardcodes the HooksTrampoline SC address, so we should continue using the old one in services.

To double-check the old address: https://github.com/cowprotocol/services/pull/3528/files
