### PR TITLE
add missing `creation_timestamp`

### DIFF
--- a/database/sql/V089__add_inserted_timestamp_to_appdata_and_orderquotes.sql
+++ b/database/sql/V089__add_inserted_timestamp_to_appdata_and_orderquotes.sql
@@ -1,0 +1,6 @@
+
+ALTER TABLE app_data
+    ADD COLUMN creation_timestamp timestamptz DEFAULT NOW();
+
+ALTER TABLE order_quotes
+    ADD COLUMN creation_timestamp timestamptz DEFAULT NOW();


### PR DESCRIPTION
# Description
added to tables: `app_data` and `order_quotes`. This makes them aligned with the other table schemas and easier for our analytics to process incrementally instead of having to reindex entirely

