### PR TITLE
Add filename and line to logs

### DIFF
--- a/crates/observe/src/tracing.rs
+++ b/crates/observe/src/tracing.rs
@@ -100,7 +100,9 @@ fn set_tracing_subscriber(config: &Config) {
                     .with_timer(timer)
                     .with_ansi(atty::is(atty::Stream::Stdout))
                     .map_event_format(|formatter| TraceIdFmt {
-                        inner: formatter.with_ansi(atty::is(atty::Stream::Stdout)),
+                        inner: formatter
+                            .with_ansi(atty::is(atty::Stream::Stdout))
+                            .with_source_location(true),
                     })
                     .with_writer(writer)
                     .with_filter($env_filter)


### PR DESCRIPTION
# Description

Display from which file and line the log originated. The benefit is that this makes it clear where the log has come from without full text search over the whole repo, but there is a concern here is that this will increase our log size. 

# Changes

- [x] Switch on displaying event source file and line number in logs 


## How to test

Start up any service locally and observe logs:

`2025-07-31T15:29:15.613Z  INFO orderbook::run: crates/orderbook/src/run.rs:499: serving order book address=0.0.0.0:8080`

`2025-07-31T15:29:54.037Z  INFO http_request{request_id=0}: orderbook::api::request_summary: /Users/fafk/.cargo/git/checkouts/warp-ee983b87d3028bb6/586244e/src/filters/log.rs:37: - "POST /api/v1/orders HTTP/1.1" 400 "-" "curl/8.7.1" 148.906291ms     trace_id=5ab1a5f4a012c0710b355d7802ca33dd`