### PR TITLE
Runloop trace logs

### DIFF
--- a/crates/autopilot/src/run_loop.rs
+++ b/crates/autopilot/src/run_loop.rs
@@ -179,6 +179,7 @@ impl RunLoop {
                 .await
             {
                 Ok(()) => {
+                    tracing::trace!("solvable orders cache updated");
                     self.solvable_orders_cache.track_auction_update("success");
                 }
                 Err(err) => {
@@ -190,6 +191,7 @@ impl RunLoop {
         };
 
         let auction = self.cut_auction().await?;
+        tracing::trace!(auction_id = ?auction.id, "auction cut");
 
         // Only run the solvers if the auction or block has changed.
         let previous = prev_auction.replace(auction.clone());
@@ -257,6 +259,7 @@ impl RunLoop {
         // Mark all auction orders as `Ready` for competition
         self.persistence
             .store_order_events(auction.orders.iter().map(|o| o.uid), OrderEventLabel::Ready);
+        tracing::trace!(auction_id = ?auction.id, "orders marked as ready");
 
         // Collect valid solutions from all drivers
         let solutions = self.fetch_solutions(&auction).await;
@@ -307,6 +310,7 @@ impl RunLoop {
             tracing::error!(?err, "failed to post-process competition");
             return;
         }
+        tracing::trace!(auction_id = ?auction.id, "post-processing completed");
 
         // Mark all winning orders as `Executing`
         let winning_orders = ranking
@@ -324,6 +328,7 @@ impl RunLoop {
                 .filter(|order_id| !winning_orders.contains(order_id)),
             OrderEventLabel::Considered,
         );
+        tracing::trace!(auction_id = ?auction.id, "orders marked as considered");
 
         for (solution_uid, winner) in ranking
             .enumerated()
@@ -342,6 +347,7 @@ impl RunLoop {
             )
             .await;
         }
+        tracing::trace!(auction_id = ?auction.id, "settlement execution started");
         observe::unsettled(&ranking, &auction);
     }
 
@@ -547,6 +553,7 @@ impl RunLoop {
                 tracing::warn!(?err, "failed to save new competition data");
             }
         }
+        tracing::trace!(auction_id = ?auction.id, "auction saved");
 
         tracing::trace!(?competition, "saving competition");
         futures::try_join!(
@@ -563,6 +570,7 @@ impl RunLoop {
                 .store_fee_policies(auction.id, fee_policies)
                 .map_err(|e| e.context("failed to fee_policies")),
         )?;
+        tracing::trace!(auction_id = ?auction.id, "competition saved");
 
         Metrics::post_processed(start.elapsed());
         Ok(())

--- a/crates/autopilot/src/solvable_orders.rs
+++ b/crates/autopilot/src/solvable_orders.rs
@@ -163,6 +163,7 @@ impl SolvableOrdersCache {
         let start = Instant::now();
 
         let db_solvable_orders = self.get_solvable_orders().await?;
+        tracing::trace!("fetched solvable orders from db");
 
         let orders = db_solvable_orders
             .orders
@@ -210,6 +211,7 @@ impl SolvableOrdersCache {
                 ),
             )
             .await;
+        tracing::trace!("fetched native prices for solvable orders");
         // Add WETH price if it's not already there to support ETH wrap when required.
         if let Entry::Vacant(entry) = prices.entry(self.weth) {
             let weth_price = self
@@ -309,6 +311,7 @@ impl SolvableOrdersCache {
                 self.balance_fetcher.get_balances(&queries),
             )
             .await;
+        tracing::trace!("fetched balances for solvable orders");
         queries
             .into_iter()
             .zip(fetched_balances)
@@ -384,6 +387,7 @@ impl SolvableOrdersCache {
                 find_unsupported_tokens(&orders, self.bad_token_detector.clone())
             ),
         );
+        tracing::trace!("filtered invalid orders");
 
         counter.checkpoint_by_invalid_orders("banned_user", &banned_user_orders);
         counter.checkpoint_by_invalid_orders("invalid_signature", &invalid_signature_orders);


### PR DESCRIPTION
# Description
This PR adds some tracing logs to the auction runloop to improve observability during debugging issues when autopilot crashloops. With that, we can probably understand if a specific operation precedes the crashloop.

## How to test
Dynamicly enable the following logs:
```
autopilot::run_loop=trace,autopilot::solvable_orders=trace
```