### PR TITLE
Optimize live orders query

### DIFF
--- a/crates/database/src/orders.rs
+++ b/crates/database/src/orders.rs
@@ -705,23 +705,104 @@ WHERE
 /// - pending pre-signature
 /// - ethflow specific invalidation conditions
 #[rustfmt::skip]
-const OPEN_ORDERS: &str = const_format::concatcp!(
-"SELECT * FROM ( ",
-    "SELECT ", SELECT,
-    " FROM ", FROM,
-    " LEFT OUTER JOIN ethflow_orders eth_o on eth_o.uid = o.uid ",
-    " WHERE o.valid_to >= $1",
-    " AND CASE WHEN eth_o.valid_to IS NULL THEN true ELSE eth_o.valid_to >= $1 END",
-r#") AS unfiltered
-WHERE
-    CASE kind
-        WHEN 'sell' THEN sum_sell < sell_amount
-        WHEN 'buy' THEN sum_buy < buy_amount
-    END AND
-    (NOT invalidated) AND
-    (onchain_placement_error IS NULL)
-"#
-);
+const OPEN_ORDERS: &str = r#"
+WITH live_orders AS (
+    SELECT o.*
+    FROM   orders o
+    LEFT   JOIN ethflow_orders e ON e.uid = o.uid
+    WHERE  o.cancellation_timestamp IS NULL
+      AND  o.valid_to >= $1
+      AND (e.valid_to IS NULL OR e.valid_to >= $1)
+      AND NOT EXISTS (SELECT 1 FROM invalidations               i  WHERE i.order_uid = o.uid)
+      AND NOT EXISTS (SELECT 1 FROM onchain_order_invalidations oi WHERE oi.uid      = o.uid)
+      AND NOT EXISTS (SELECT 1 FROM onchain_placed_orders       op WHERE op.uid      = o.uid
+                                                                     AND op.placement_error IS NOT NULL)
+),
+trades_agg AS (
+     SELECT t.order_uid,
+            SUM(t.buy_amount)  AS sum_buy,
+            SUM(t.sell_amount) AS sum_sell,
+            SUM(t.fee_amount) AS sum_fee
+     FROM trades t
+     JOIN live_orders lo ON lo.uid = t.order_uid
+     GROUP BY t.order_uid
+)
+SELECT
+    lo.uid,
+    lo.owner,
+    lo.creation_timestamp,
+    lo.sell_token,
+    lo.buy_token,
+    lo.sell_amount,
+    lo.buy_amount,
+    lo.valid_to,
+    lo.app_data,
+    lo.fee_amount,
+    lo.kind,
+    lo.partially_fillable,
+    lo.signature,
+    lo.receiver,
+    lo.signing_scheme,
+    lo.settlement_contract,
+    lo.sell_token_balance,
+    lo.buy_token_balance,
+    lo.class,
+
+    COALESCE(ta.sum_buy ,0) AS sum_buy,
+    COALESCE(ta.sum_sell,0) AS sum_sell,
+    COALESCE(ta.sum_fee ,0) AS sum_fee,
+    false AS invalidated,
+    (lo.signing_scheme = 'presign' AND COALESCE(pl.unsigned,TRUE)) AS presignature_pending,
+    ARRAY(
+            SELECT (p.target, p.value, p.data)
+            FROM   interactions p
+            WHERE  p.order_uid = lo.uid AND p.execution = 'pre'
+            ORDER  BY p.index
+    ) AS pre_interactions,
+    ARRAY(
+            SELECT (p.target, p.value, p.data)
+            FROM   interactions p
+            WHERE  p.order_uid = lo.uid AND p.execution = 'post'
+            ORDER  BY p.index
+    ) AS post_interactions,
+    ef.ethflow_data,
+    pf.onchain_user,
+    NULL AS onchain_placement_error,
+    COALESCE(ea.executed_fee,0)        AS executed_fee,
+    COALESCE(ea.executed_fee_token, lo.sell_token) AS executed_fee_token,
+    ad.full_app_data
+FROM live_orders lo
+LEFT JOIN LATERAL (
+    SELECT NOT signed AS unsigned
+    FROM   presignature_events
+    WHERE  order_uid = lo.uid
+    ORDER  BY block_number DESC, log_index DESC
+    LIMIT  1
+    ) pl ON TRUE
+LEFT JOIN LATERAL (
+    SELECT sender AS onchain_user
+    FROM   onchain_placed_orders
+    WHERE  uid = lo.uid
+    ORDER  BY block_number DESC
+    LIMIT  1
+    ) pf ON TRUE
+LEFT JOIN LATERAL (
+    SELECT ROW(tx_hash, eo.valid_to) AS ethflow_data
+    FROM   ethflow_orders  eo
+    LEFT   JOIN ethflow_refunds r ON r.order_uid = eo.uid
+    WHERE  eo.uid = lo.uid
+    ) ef ON TRUE
+LEFT JOIN LATERAL (
+    SELECT SUM(executed_fee) AS executed_fee,
+           (ARRAY_AGG(executed_fee_token))[1] AS executed_fee_token
+    FROM   order_execution
+    WHERE  order_uid = lo.uid
+) ea ON TRUE
+LEFT JOIN app_data ad ON ad.contract_app_data = lo.app_data
+LEFT JOIN trades_agg ta ON  ta.order_uid = lo.uid
+WHERE ((lo.kind = 'sell' AND COALESCE(ta.sum_sell,0) < lo.sell_amount) OR
+       (lo.kind = 'buy'  AND COALESCE(ta.sum_buy ,0) < lo.buy_amount))
+"#;
 
 /// Uses the conditions from OPEN_ORDERS and checks the fok limit orders have
 /// surplus fee.
@@ -761,28 +842,6 @@ SELECT COALESCE(MAX(block_number), 0)
 FROM settlements
     "#;
     sqlx::query_scalar(QUERY).fetch_one(ex).await
-}
-
-/// Counts the number of limit orders with the conditions of OPEN_ORDERS. Used
-/// to enforce a maximum number of limit orders per user.
-#[instrument(skip_all)]
-pub async fn count_limit_orders_by_owner(
-    ex: &mut PgConnection,
-    min_valid_to: i64,
-    owner: &Address,
-) -> Result<i64, sqlx::Error> {
-    const QUERY: &str = const_format::concatcp!(
-        "SELECT COUNT (*) FROM (",
-        OPEN_ORDERS,
-        " AND class = 'limit'",
-        " AND owner = $2",
-        " ) AS subquery"
-    );
-    sqlx::query_scalar(QUERY)
-        .bind(min_valid_to)
-        .bind(owner)
-        .fetch_one(ex)
-        .await
 }
 
 #[derive(Debug, sqlx::FromRow)]
@@ -1614,6 +1673,17 @@ mod tests {
         // solvable once again because of new presignature event.
         pre_signature_event(&mut db, 2, order.owner, order.uid, true).await;
         assert!(!get_full_order(&mut db).await.unwrap().presignature_pending);
+    }
+
+    #[tokio::test]
+    async fn get_orders_with_quote() {
+        let mut db = PgConnection::connect("postgresql://").await.unwrap();
+        let mut db = db.begin().await.unwrap();
+        assert!(
+            user_orders_with_quote(&mut db, 0, &Default::default())
+                .await
+                .is_ok()
+        )
     }
 
     #[tokio::test]


### PR DESCRIPTION
# Description

When the autopilot starts it loads all orders and populates its in-memory cache with them. This query is slow and blocks the autopilot for the full duration of it, which, depending on the current DB conditions, can take somewhere between 45 seconds and 1 minute and ten second judging by my experiments with running the original query against prod. The optimized version takes up to 8-12 seconds depending on the conditions on cold runs.

The original query:

```sql
SELECT *
FROM (SELECT o.uid,
             o.owner,
             o.creation_timestamp,
             o.sell_token,
             o.buy_token,
             o.sell_amount,
             o.buy_amount,
             o.valid_to,
             o.app_data,
             o.fee_amount,
             o.kind,
             o.partially_fillable,
             o.signature,
             o.receiver,
             o.signing_scheme,
             o.settlement_contract,
             o.sell_token_balance,
             o.buy_token_balance,
             o.class,
             (SELECT COALESCE(SUM(t.buy_amount), 0) FROM trades t WHERE t.order_uid = o.uid)            AS sum_buy,
             (SELECT COALESCE(SUM(t.sell_amount), 0) FROM trades t WHERE t.order_uid = o.uid)           AS sum_sell,
             (SELECT COALESCE(SUM(t.fee_amount), 0) FROM trades t WHERE t.order_uid = o.uid)            AS sum_fee,
             (o.cancellation_timestamp IS NOT NULL OR
              (SELECT COUNT(*) FROM invalidations WHERE invalidations.order_uid = o.uid) > 0 OR
              (SELECT COUNT(*) FROM onchain_order_invalidations onchain_c where onchain_c.uid = o.uid limit 1) >
              0)                                                                                        AS invalidated,
             (o.signing_scheme = 'presign' AND COALESCE((SELECT (NOT p.signed) as unsigned
                                                         FROM presignature_events p
                                                         WHERE o.uid = p.order_uid
                                                         ORDER BY p.block_number DESC, p.log_index DESC
                                                         LIMIT 1),
                                                        true))                                          AS presignature_pending,
             array(Select (p.target, p.value, p.data)
                   from interactions p
                   where p.order_uid = o.uid
                     and p.execution = 'pre'
                   order by p.index)                                                                    as pre_interactions,
             array(Select (p.target, p.value, p.data)
                   from interactions p
                   where p.order_uid = o.uid
                     and p.execution = 'post'
                   order by p.index)                                                                    as post_interactions,
             (SELECT (tx_hash, eth_o.valid_to)
              from ethflow_orders eth_o
                       left join ethflow_refunds on ethflow_refunds.order_uid = eth_o.uid
              where eth_o.uid = o.uid
              limit 1)                                                                                  as ethflow_data,
             (SELECT onchain_o.sender
              from onchain_placed_orders onchain_o
              where onchain_o.uid = o.uid
              limit 1)                                                                                  as onchain_user,
             (SELECT onchain_o.placement_error
              from onchain_placed_orders onchain_o
              where onchain_o.uid = o.uid
              limit 1)                                                                                  as onchain_placement_error,
             COALESCE((SELECT SUM(executed_fee) FROM order_execution oe WHERE oe.order_uid = o.uid), 0) as executed_fee,
             COALESCE((SELECT executed_fee_token
                       FROM order_execution oe
                       WHERE oe.order_uid = o.uid
                       LIMIT 1),
                      o.sell_token)                                                                     as executed_fee_token,
             (SELECT full_app_data
              FROM app_data ad
              WHERE o.app_data = ad.contract_app_data
              LIMIT 1)                                                                                  as full_app_data
      FROM orders o
               LEFT OUTER JOIN ethflow_orders eth_o
                               on eth_o.uid = o.uid
      WHERE o.valid_to >= 1754238737
        AND CASE WHEN eth_o.valid_to IS NULL THEN true ELSE eth_o.valid_to >= 1754238737 END) AS unfiltered
WHERE CASE kind
          WHEN 'sell' THEN sum_sell
              < sell_amount
          WHEN 'buy' THEN sum_buy
              < buy_amount END
  AND (NOT invalidated)
  AND (onchain_placement_error IS NULL)
```

# Changes

There are the following issues with the old query that the new one fixes:
1. There is an outer select and an inner select and there is filtering on the outer select. This is slowing us down, because we are loading in orders that we don't have to work on at all. The new query is fronting that filtering. 
2. Trades is being traversed in three runs to compute aggregates. There is no need to hit the trade table three times, we can get all of these aggregates in one run.
3. Checking for existence via `COUNT(*) > 0` requires loading all the rows first. With `LIMIT 1` we can exit early when a matching row is found. 
4. Using nested subqueries is less planner friendly than using LATERAL joins. This one is the least important from all the above. 


## How to test

I was testing the equality of the queries by running both of them in a SERIALIZABLE READ transaction and comparing the outputs in SQL. When it returns no rows it means there are no differences in the outputs. As I was working on the queries I introduced some bugs which I was able to discover this way. 

```sql
WITH q1 AS (

    WITH live_orders AS (
        SELECT o.*
        FROM   orders o
                   LEFT   JOIN ethflow_orders e ON e.uid = o.uid
        WHERE  o.cancellation_timestamp IS NULL
          AND  o.valid_to >= 1754238737
          AND (e.valid_to IS NULL OR e.valid_to >= 1754238737)
          AND NOT EXISTS (SELECT 1 FROM invalidations               i  WHERE i.order_uid = o.uid)
          AND NOT EXISTS (SELECT 1 FROM onchain_order_invalidations oi WHERE oi.uid      = o.uid)
          AND NOT EXISTS (SELECT 1 FROM onchain_placed_orders       op WHERE op.uid      = o.uid
                                                                         AND op.placement_error IS NOT NULL)
    ),
         trades_agg AS (
             SELECT t.order_uid,
                    SUM(t.buy_amount)  AS sum_buy,
                    SUM(t.sell_amount) AS sum_sell,
                    SUM(t.fee_amount) AS sum_fee
             FROM trades t
                      JOIN live_orders lo ON lo.uid = t.order_uid
             GROUP BY t.order_uid
         )
    SELECT
        lo.uid,
        lo.owner,
        lo.creation_timestamp,
        lo.sell_token,
        lo.buy_token,
        lo.sell_amount,
        lo.buy_amount,
        lo.valid_to,
        lo.app_data,
        lo.fee_amount,
        lo.kind,
        lo.partially_fillable,
        lo.signature,
        lo.receiver,
        lo.signing_scheme,
        lo.settlement_contract,
        lo.sell_token_balance,
        lo.buy_token_balance,
        lo.class,

        COALESCE(ta.sum_buy ,0) AS sum_buy,
        COALESCE(ta.sum_sell,0) AS sum_sell,
        COALESCE(ta.sum_fee ,0) AS sum_fee,
        false AS invalidated,
        (lo.signing_scheme = 'presign' AND COALESCE(pl.unsigned,TRUE)) AS presignature_pending,
        ARRAY(
                SELECT (p.target, p.value, p.data)
                FROM   interactions p
                WHERE  p.order_uid = lo.uid AND p.execution = 'pre'
                ORDER  BY p.index
        ) AS pre_interactions,
        ARRAY(
                SELECT (p.target, p.value, p.data)
                FROM   interactions p
                WHERE  p.order_uid = lo.uid AND p.execution = 'post'
                ORDER  BY p.index
        ) AS post_interactions,
        ef.ethflow_data,
        pf.onchain_user,
        NULL AS onchain_placement_error,
        COALESCE(ea.executed_fee,0)        AS executed_fee,
        COALESCE(ea.executed_fee_token, lo.sell_token) AS executed_fee_token,
        ad.full_app_data
    FROM live_orders lo
             LEFT JOIN LATERAL (
        SELECT NOT signed AS unsigned
        FROM   presignature_events
        WHERE  order_uid = lo.uid
        ORDER  BY block_number DESC, log_index DESC
        LIMIT  1
        ) pl ON TRUE
             LEFT JOIN LATERAL (
        SELECT sender AS onchain_user
        FROM   onchain_placed_orders
        WHERE  uid = lo.uid
        ORDER  BY block_number DESC
        LIMIT  1
        ) pf ON TRUE
             LEFT JOIN LATERAL (
        SELECT ROW(tx_hash, eo.valid_to) AS ethflow_data
        FROM   ethflow_orders  eo
                   LEFT   JOIN ethflow_refunds r ON r.order_uid = eo.uid
        WHERE  eo.uid = lo.uid
        ) ef ON TRUE
             LEFT JOIN LATERAL (
        SELECT SUM(executed_fee) AS executed_fee,
               (ARRAY_AGG(executed_fee_token))[1] AS executed_fee_token
        FROM   order_execution
        WHERE  order_uid = lo.uid
        ) ea ON TRUE
             LEFT JOIN app_data ad ON ad.contract_app_data = lo.app_data
             LEFT JOIN trades_agg ta ON  ta.order_uid = lo.uid
    WHERE (
              (lo.kind = 'sell' AND COALESCE(ta.sum_sell,0) < lo.sell_amount) OR
              (lo.kind = 'buy'  AND COALESCE(ta.sum_buy ,0) < lo.buy_amount)
              )

),

q2 AS (

    SELECT *
    FROM (SELECT o.uid,
                 o.owner,
                 o.creation_timestamp,
                 o.sell_token,
                 o.buy_token,
                 o.sell_amount,
                 o.buy_amount,
                 o.valid_to,
                 o.app_data,
                 o.fee_amount,
                 o.kind,
                 o.partially_fillable,
                 o.signature,
                 o.receiver,
                 o.signing_scheme,
                 o.settlement_contract,
                 o.sell_token_balance,
                 o.buy_token_balance,
                 o.class,
                 (SELECT COALESCE(SUM(t.buy_amount), 0) FROM trades t WHERE t.order_uid = o.uid)            AS sum_buy,
                 (SELECT COALESCE(SUM(t.sell_amount), 0) FROM trades t WHERE t.order_uid = o.uid)           AS sum_sell,
                 (SELECT COALESCE(SUM(t.fee_amount), 0) FROM trades t WHERE t.order_uid = o.uid)            AS sum_fee,
                 (o.cancellation_timestamp IS NOT NULL OR
                  (SELECT COUNT(*) FROM invalidations WHERE invalidations.order_uid = o.uid) > 0 OR
                  (SELECT COUNT(*) FROM onchain_order_invalidations onchain_c where onchain_c.uid = o.uid limit 1) >
                  0)                                                                                        AS invalidated,
                 (o.signing_scheme = 'presign' AND COALESCE((SELECT (NOT p.signed) as unsigned
                                                             FROM presignature_events p
                                                             WHERE o.uid = p.order_uid
                                                             ORDER BY p.block_number DESC, p.log_index DESC
                                                             LIMIT 1),
                                                            true))                                          AS presignature_pending,
                 array(Select (p.target, p.value, p.data)
                       from interactions p
                       where p.order_uid = o.uid
                         and p.execution = 'pre'
                       order by p.index)                                                                    as pre_interactions,
                 array(Select (p.target, p.value, p.data)
                       from interactions p
                       where p.order_uid = o.uid
                         and p.execution = 'post'
                       order by p.index)                                                                    as post_interactions,
                 (SELECT (tx_hash, eth_o.valid_to)
                  from ethflow_orders eth_o
                           left join ethflow_refunds on ethflow_refunds.order_uid = eth_o.uid
                  where eth_o.uid = o.uid
                  limit 1)                                                                                  as ethflow_data,
                 (SELECT onchain_o.sender
                  from onchain_placed_orders onchain_o
                  where onchain_o.uid = o.uid
                  limit 1)                                                                                  as onchain_user,
                 (SELECT onchain_o.placement_error::text
                  from onchain_placed_orders onchain_o
                  where onchain_o.uid = o.uid
                  limit 1)                                                                                  as onchain_placement_error,
                 COALESCE((SELECT SUM(executed_fee) FROM order_execution oe WHERE oe.order_uid = o.uid), 0) as executed_fee,
                 COALESCE((SELECT executed_fee_token
                           FROM order_execution oe
                           WHERE oe.order_uid = o.uid
                           LIMIT 1),
                          o.sell_token)                                                                     as executed_fee_token,
                 (SELECT full_app_data
                  FROM app_data ad
                  WHERE o.app_data = ad.contract_app_data
                  LIMIT 1)                                                                                  as full_app_data
          FROM orders o
                   LEFT OUTER JOIN ethflow_orders eth_o
                                   on eth_o.uid = o.uid
          WHERE o.valid_to >= 1754238737
            AND CASE WHEN eth_o.valid_to IS NULL THEN true ELSE eth_o.valid_to >= 1754238737 END) AS unfiltered
    WHERE CASE kind
              WHEN 'sell' THEN sum_sell
                  < sell_amount
              WHEN 'buy' THEN sum_buy
                  < buy_amount END
      AND (NOT invalidated)
      AND (onchain_placement_error IS NULL)




) SELECT *
FROM (
         (SELECT * FROM q1
          EXCEPT ALL              -- rows in q1 but not q2
          SELECT * FROM q2)

         UNION ALL

         (SELECT * FROM q2
          EXCEPT ALL              -- rows in q2 but not q1
          SELECT * FROM q1)
     ) AS deltas;
```

To compare performance I was running the queries again mainnet prod DB on different days (times of day) to not have warmed up cache. The new, optimized query reduces the runtime by ~75%. 