### PR TITLE
Make access lists for tradable balance simulations configurable

### DIFF
--- a/crates/driver/src/infra/api/mod.rs
+++ b/crates/driver/src/infra/api/mod.rs
@@ -46,6 +46,7 @@ impl Api {
         shutdown: impl Future<Output = ()> + Send + 'static,
         order_priority_strategies: Vec<OrderPriorityStrategy>,
         app_data_retriever: Option<AppDataRetriever>,
+        disable_access_list_simulation: bool,
     ) -> Result<(), hyper::Error> {
         // Add middleware.
         let mut app = axum::Router::new().layer(tower::ServiceBuilder::new().layer(
@@ -57,6 +58,7 @@ impl Api {
             self.eth.clone(),
             app_data_retriever.clone(),
             self.liquidity.clone(),
+            disable_access_list_simulation,
         ));
 
         let order_sorting_strategies =

--- a/crates/driver/src/run.rs
+++ b/crates/driver/src/run.rs
@@ -96,6 +96,7 @@ async fn run_with(args: cli::Args, addr_sender: Option<oneshot::Sender<SocketAdd
         },
         config.order_priority_strategies,
         app_data_retriever,
+        config.disable_access_list_simulation,
     );
 
     futures::pin_mut!(serve);


### PR DESCRIPTION
# Description
[The current config](https://github.com/cowprotocol/services/blob/503a50b93a641d936df5767de0fb6dcf377414a7/crates/driver/src/infra/config/file/mod.rs#L23-L26) that controls access lists feature usage for simulations doesn't affect the tradable balance simulations. This is also important for chains that don't support access lists(e.g. ZKSync). This PR fixes it.

## How to test
Will be tested on Lens.
