### PR TITLE
Harden foundry version in the driver-tests CI job

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -173,7 +173,7 @@ jobs:
         with:
           # the latest version introduced a bug caused driver tests to fail
           # only switch back to latest stable version after it was fixed in anvil
-          version: v1.3.0
+          version: v1.2.3
       - uses: Swatinem/rust-cache@v2
       - uses: taiki-e/install-action@nextest
       # Build the driver's tests.


### PR DESCRIPTION
Some driver tests fail on the latest stable foundry version, which is [v1.3.0](https://github.com/foundry-rs/foundry/releases/tag/v1.3.0), e.g. https://github.com/cowprotocol/services/actions/runs/17035464014

This PR set the previous 1.2.3 version which works fine.