### PR TITLE
[TRIVIAL] Native price cache logs

### DIFF
--- a/crates/autopilot/src/solvable_orders.rs
+++ b/crates/autopilot/src/solvable_orders.rs
@@ -633,8 +633,7 @@ async fn get_orders_with_native_prices(
 /// with very few fetch requests.
 fn prioritize_missing_prices(mut orders: Vec<Order>) -> IndexSet<H160> {
     /// How old an order can be at most to be considered a market order.
-    const MARKET_ORDER_AGE_MINUTES: i64 = 30;
-    let market_order_age = chrono::Duration::minutes(MARKET_ORDER_AGE_MINUTES);
+    const MARKET_ORDER_AGE: chrono::Duration = chrono::Duration::minutes(30);
     let now = chrono::Utc::now();
 
     // newer orders at the start
@@ -645,7 +644,7 @@ fn prioritize_missing_prices(mut orders: Vec<Order>) -> IndexSet<H160> {
     for order in orders {
         let sell_token = order.data.sell_token;
         let buy_token = order.data.buy_token;
-        let is_market = now.signed_duration_since(order.metadata.creation_date) <= market_order_age;
+        let is_market = now.signed_duration_since(order.metadata.creation_date) <= MARKET_ORDER_AGE;
 
         if is_market {
             // already correct priority because orders were sorted by creation_date

--- a/crates/shared/src/price_estimation/native_price_cache.rs
+++ b/crates/shared/src/price_estimation/native_price_cache.rs
@@ -279,11 +279,8 @@ impl UpdateTask {
             return;
         }
 
-        let mut stream = inner.estimate_prices_and_update_cache(
-            &outdated_entries,
-            max_age,
-            inner.quote_timeout,
-        );
+        let mut stream =
+            inner.estimate_prices_and_update_cache(&outdated_entries, max_age, inner.quote_timeout);
         while stream.next().await.is_some() {}
         metrics
             .native_price_cache_background_updates

--- a/crates/shared/src/price_estimation/native_price_cache.rs
+++ b/crates/shared/src/price_estimation/native_price_cache.rs
@@ -141,6 +141,7 @@ impl Inner {
                     // This should happen only for prices missing while building the auction.
                     // Otherwise malicious actors could easily cause the cache size to blow up.
                     let outdated_timestamp = now.checked_sub(*max_age).unwrap();
+                    tracing::trace!(?token, "create outdated price entry");
                     entry.insert(CachedResult::new(
                         Ok(0.),
                         outdated_timestamp,
@@ -266,23 +267,27 @@ impl UpdateTask {
         let max_age = inner.max_age.saturating_sub(self.prefetch_time);
         let mut outdated_entries = inner.sorted_tokens_to_update(max_age, Instant::now());
 
+        tracing::trace!(tokens = ?outdated_entries, first_n = ?self.update_size, "outdated prices to fetch");
+
         metrics
             .native_price_cache_outdated_entries
             .set(i64::try_from(outdated_entries.len()).unwrap_or(i64::MAX));
 
         outdated_entries.truncate(self.update_size.unwrap_or(usize::MAX));
 
-        if !outdated_entries.is_empty() {
-            let mut stream = inner.estimate_prices_and_update_cache(
-                &outdated_entries,
-                max_age,
-                inner.quote_timeout,
-            );
-            while stream.next().await.is_some() {}
-            metrics
-                .native_price_cache_background_updates
-                .inc_by(outdated_entries.len() as u64);
+        if outdated_entries.is_empty() {
+            return;
         }
+
+        let mut stream = inner.estimate_prices_and_update_cache(
+            &outdated_entries,
+            max_age,
+            inner.quote_timeout,
+        );
+        while stream.next().await.is_some() {}
+        metrics
+            .native_price_cache_background_updates
+            .inc_by(outdated_entries.len() as u64);
     }
 
     /// Runs background updates until inner is no longer alive.
@@ -396,6 +401,7 @@ impl CachingNativePriceEstimator {
     }
 
     pub fn replace_high_priority(&self, tokens: IndexSet<H160>) {
+        tracing::trace!(?tokens, "update high priority tokens");
         *self.0.high_priority.lock().unwrap() = tokens;
     }
 


### PR DESCRIPTION
# Changes
* adds logs that should help with debugging https://github.com/cowprotocol/services/issues/3562
    * I used `trace` level as we don't always want to have these logs enabled
* also replaces an if-block with an early return to reduce rightward drift
* uses `const` API to create a target duration

## How to test
no logic changes - compiler and existing tests should suffice