### PR TITLE
cherry-pick: Fix eth call and trades() instrumentation (#3524)

### DIFF
--- a/crates/database/src/trades.rs
+++ b/crates/database/src/trades.rs
@@ -3,7 +3,7 @@ use {
     bigdecimal::BigDecimal,
     futures::stream::BoxStream,
     sqlx::PgConnection,
-    tracing::instrument,
+    tracing::{Instrument, info_span, instrument},
 };
 
 #[derive(Clone, Debug, Default, Eq, PartialEq, sqlx::FromRow)]
@@ -21,12 +21,11 @@ pub struct TradesQueryRow {
     pub auction_id: Option<AuctionId>,
 }
 
-#[instrument(skip_all)]
 pub fn trades<'a>(
     ex: &'a mut PgConnection,
     owner_filter: Option<&'a Address>,
     order_uid_filter: Option<&'a OrderUid>,
-) -> BoxStream<'a, Result<TradesQueryRow, sqlx::Error>> {
+) -> instrument::Instrumented<BoxStream<'a, Result<TradesQueryRow, sqlx::Error>>> {
     const COMMON_QUERY: &str = r#"
 SELECT
     t.block_number,
@@ -72,6 +71,7 @@ LEFT OUTER JOIN LATERAL (
         .bind(owner_filter)
         .bind(order_uid_filter)
         .fetch(ex)
+        .instrument(info_span!("trades"))
 }
 
 #[derive(Clone, Debug, Default, Eq, PartialEq, sqlx::FromRow)]
@@ -214,6 +214,7 @@ mod tests {
         expected: &[TradesQueryRow],
     ) {
         let mut filtered = trades(db, owner_filter, order_uid_filter)
+            .into_inner()
             .try_collect::<Vec<_>>()
             .await
             .unwrap();
@@ -287,6 +288,7 @@ mod tests {
 
         let now = std::time::Instant::now();
         trades(&mut db, Some(&ByteArray([2u8; 20])), None)
+            .into_inner()
             .try_collect::<Vec<_>>()
             .await
             .unwrap();

--- a/crates/orderbook/src/database/trades.rs
+++ b/crates/orderbook/src/database/trades.rs
@@ -36,6 +36,7 @@ impl TradeRetrieving for Postgres {
             filter.owner.map(|owner| ByteArray(owner.0)).as_ref(),
             filter.order_uid.map(|uid| ByteArray(uid.0)).as_ref(),
         )
+        .into_inner()
         .map_err(anyhow::Error::from)
         .try_collect::<Vec<TradesQueryRow>>()
         .await?;


### PR DESCRIPTION
# Description

We [reverted](https://github.com/cowprotocol/services/pull/3557) this MR because we were experiencing seg faults in the driver and this one was one of the 3 candidates that may have caused it. Let's bring it back and observe whether we get seg faults again in staging.