### PR TITLE
Log initial live order fetch duration

### DIFF
--- a/crates/autopilot/src/database/auction.rs
+++ b/crates/autopilot/src/database/auction.rs
@@ -85,7 +85,7 @@ impl Postgres {
                 })
                 .try_collect()
                 .await?;
-        info!("all solvable orders fetched in {}", Utc::now() - start);
+        info!(time = Utc::now() - start, "fetched all solvable orders");
         let latest_settlement_block = database::orders::latest_settlement_block(&mut ex)
             .await?
             .to_u64()

--- a/crates/autopilot/src/database/auction.rs
+++ b/crates/autopilot/src/database/auction.rs
@@ -12,6 +12,7 @@ use {
         order_quoting::{QuoteData, QuoteSearchParameters, QuoteStoring},
     },
     std::{collections::HashMap, ops::DerefMut},
+    tracing::log::info,
 };
 
 #[async_trait::async_trait]
@@ -84,6 +85,7 @@ impl Postgres {
                 })
                 .try_collect()
                 .await?;
+        info!("all solvable orders fetched in {}", Utc::now() - start);
         let latest_settlement_block = database::orders::latest_settlement_block(&mut ex)
             .await?
             .to_u64()

--- a/crates/autopilot/src/database/auction.rs
+++ b/crates/autopilot/src/database/auction.rs
@@ -12,7 +12,6 @@ use {
         order_quoting::{QuoteData, QuoteSearchParameters, QuoteStoring},
     },
     std::{collections::HashMap, ops::DerefMut},
-    tracing::log::info,
 };
 
 #[async_trait::async_trait]
@@ -85,7 +84,10 @@ impl Postgres {
                 })
                 .try_collect()
                 .await?;
-        info!(time = Utc::now() - start, "fetched all solvable orders");
+        tracing::info!(
+            time = (Utc::now() - start).to_string(),
+            "fetched all solvable orders"
+        );
         let latest_settlement_block = database::orders::latest_settlement_block(&mut ex)
             .await?
             .to_u64()


### PR DESCRIPTION
# Description

Recently we merged a PR that optimizes the initial fetch of live orders. To clearly see how long it takes to load these orders in prod I'd like to add this log. 

This code run once on autopilot start up, so one needs not worry about this log being spammy. 