### PR TITLE
Downgrade tenderly simulation log to `trace`

### DIFF
--- a/crates/shared/src/tenderly_api.rs
+++ b/crates/shared/src/tenderly_api.rs
@@ -111,7 +111,7 @@ impl TenderlyApi for TenderlyHttpApi {
         let body = serde_json::to_string(&simulation)?;
 
         #[rustfmt::skip]
-        tracing::debug!(
+        tracing::trace!(
             "resimulate by setting TENDERLY_API_KEY environment variable and running: \
             curl -X POST -H \"X-ACCESS-KEY: $TENDERLY_API_KEY\" -H \"Content-Type: application/json\" --data '{body}' {request_url} \
             | jq -r \".simulation.id\" \


### PR DESCRIPTION
# Description
Over the last month we have been handling a lot more quote requests which is currently overwhelming the logging infra.
To combat that this PR demotes a very common and huge log to `trace`. That will prevent it from being emitted with our default log levels. If an investigation requires those logs they can be temporarily enabled again.

Ideally we'd at least get the simulation log for the winning solver but that would be more involved as the code that emits the log has no notion of which quote won.
To alleviate the log pressure ASAP we can merge this.