### PR TITLE
[Driver] expose endpoint to get current effective gas price (1/3)

### DIFF
--- a/crates/driver/src/domain/eth/gas.rs
+++ b/crates/driver/src/domain/eth/gas.rs
@@ -56,6 +56,10 @@ impl GasPrice {
         self.tip
     }
 
+    pub fn base(&self) -> FeePerGas {
+        self.base
+    }
+
     /// Creates a new instance limiting maxFeePerGas to a reasonable multiple of
     /// the current base fee.
     pub fn new(max: FeePerGas, tip: FeePerGas, base: FeePerGas) -> Self {

--- a/crates/driver/src/infra/api/error.rs
+++ b/crates/driver/src/infra/api/error.rs
@@ -1,7 +1,7 @@
 use {
     crate::{
         domain::{competition, quote},
-        infra::api,
+        infra::{api, blockchain},
     },
     serde::Serialize,
 };
@@ -91,6 +91,12 @@ impl From<competition::Error> for (hyper::StatusCode, axum::Json<Error>) {
             competition::Error::NoValidOrdersFound => Kind::NoValidOrders,
         };
         error.into()
+    }
+}
+
+impl From<blockchain::Error> for (hyper::StatusCode, axum::Json<Error>) {
+    fn from(_: blockchain::Error) -> Self {
+        Kind::Unknown.into()
     }
 }
 

--- a/crates/driver/src/infra/api/mod.rs
+++ b/crates/driver/src/infra/api/mod.rs
@@ -61,9 +61,12 @@ impl Api {
             disable_access_list_simulation,
         );
 
-        // Add the metrics and healthz endpoints.
+        // Add the metrics, healthz, and gasprice endpoints.
         app = routes::metrics(app);
         app = routes::healthz(app);
+
+        let eth = axum::Router::new();
+        app = app.merge(routes::gasprice(eth).with_state(self.eth.clone()));
 
         // Multiplex each solver as part of the API. Multiple solvers are multiplexed
         // on the same driver so only one liquidity collector collects the liquidity

--- a/crates/driver/src/infra/api/routes/gasprice.rs
+++ b/crates/driver/src/infra/api/routes/gasprice.rs
@@ -22,24 +22,28 @@ pub(in crate::infra::api) fn gasprice(
 #[serde_as]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
+/// Gas price components in EIP-1559 format.
 pub struct GasPriceResponse {
-    /// The estimated effective gas price that will be paid for a transaction.
     #[serde_as(as = "serialize::U256")]
-    pub effective_gas_price: eth::U256,
+    pub max_fee_per_gas: eth::U256,
+    #[serde_as(as = "serialize::U256")]
+    pub max_priority_fee_per_gas: eth::U256,
+    #[serde_as(as = "serialize::U256")]
+    pub base_fee_per_gas: eth::U256,
 }
 
 #[instrument(skip(eth))]
 async fn route(
     eth: axum::extract::State<Ethereum>,
 ) -> Result<Json<GasPriceResponse>, (hyper::StatusCode, axum::Json<Error>)> {
-    // Get gas price estimation with default time limit (None uses default from config)
+    // For simplicity we use the default time limit (None)
     let gas_price = eth
         .gas_price(None)
         .await?;
 
-    let effective = gas_price.effective();
-    
     Ok(Json(GasPriceResponse {
-        effective_gas_price: effective.0.0,
+        max_fee_per_gas: gas_price.max().0.0,
+        max_priority_fee_per_gas: gas_price.tip().0.0,
+        base_fee_per_gas: gas_price.base().0.0,
     }))
 }

--- a/crates/driver/src/infra/api/routes/gasprice.rs
+++ b/crates/driver/src/infra/api/routes/gasprice.rs
@@ -1,0 +1,45 @@
+use {
+    crate::{
+        domain::eth,
+        infra::{Ethereum, api::error::Error},
+        util::serialize,
+    },
+    axum::Json,
+    serde::{Deserialize, Serialize},
+    serde_with::serde_as,
+    tracing::instrument,
+};
+
+pub(in crate::infra::api) fn gasprice(
+    app: axum::Router<Ethereum>,
+) -> axum::Router<Ethereum> {
+    app.route(
+        "/gasprice",
+        axum::routing::get(route),
+    )
+}
+
+#[serde_as]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GasPriceResponse {
+    /// The estimated effective gas price that will be paid for a transaction.
+    #[serde_as(as = "serialize::U256")]
+    pub effective_gas_price: eth::U256,
+}
+
+#[instrument(skip(eth))]
+async fn route(
+    eth: axum::extract::State<Ethereum>,
+) -> Result<Json<GasPriceResponse>, (hyper::StatusCode, axum::Json<Error>)> {
+    // Get gas price estimation with default time limit (None uses default from config)
+    let gas_price = eth
+        .gas_price(None)
+        .await?;
+
+    let effective = gas_price.effective();
+    
+    Ok(Json(GasPriceResponse {
+        effective_gas_price: effective.0.0,
+    }))
+}

--- a/crates/driver/src/infra/api/routes/gasprice.rs
+++ b/crates/driver/src/infra/api/routes/gasprice.rs
@@ -10,13 +10,8 @@ use {
     tracing::instrument,
 };
 
-pub(in crate::infra::api) fn gasprice(
-    app: axum::Router<Ethereum>,
-) -> axum::Router<Ethereum> {
-    app.route(
-        "/gasprice",
-        axum::routing::get(route),
-    )
+pub(in crate::infra::api) fn gasprice(app: axum::Router<Ethereum>) -> axum::Router<Ethereum> {
+    app.route("/gasprice", axum::routing::get(route))
 }
 
 #[serde_as]
@@ -37,9 +32,7 @@ async fn route(
     eth: axum::extract::State<Ethereum>,
 ) -> Result<Json<GasPriceResponse>, (hyper::StatusCode, axum::Json<Error>)> {
     // For simplicity we use the default time limit (None)
-    let gas_price = eth
-        .gas_price(None)
-        .await?;
+    let gas_price = eth.gas_price(None).await?;
 
     Ok(Json(GasPriceResponse {
         max_fee_per_gas: gas_price.max().0.0,

--- a/crates/driver/src/infra/api/routes/mod.rs
+++ b/crates/driver/src/infra/api/routes/mod.rs
@@ -1,3 +1,4 @@
+mod gasprice;
 mod healthz;
 mod info;
 mod metrics;
@@ -8,6 +9,7 @@ mod settle;
 mod solve;
 
 pub(super) use {
+    gasprice::gasprice,
     healthz::healthz,
     info::info,
     metrics::metrics,


### PR DESCRIPTION
# Description
We are currently using different logic when estimating the gas price in the API (for network cost estimation purposes) compared to when estimating it in the driver (for actual submission purposes).

The difference in resulting gas price can be significant (up to 3-5x on mainnet). This may lead to us underreporting the network cost during quoting. Especially for small orders, where the network cost is a large relative fraction of the total volume, the error can easily be larger than the user's slippage tolerance leading to the order not being matched.

As a solution I suggest exposing the gas price computation that the driver performs via an API and calling this API from within the api (and autopilot) during quoting.

# Changes
This PR is the first of 3, it exposes a new `/gasprice` endpoint on the top level driver API (not on each solver's sub-api given that the gas price computation isn't solver specific).

## How to test
On a locally running driver:

```
curl http://localhost:11088/gasprice 
```