### PR TITLE
chore: add build commit hash to logs(autopilot, driver, solvers)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -945,6 +945,7 @@ dependencies = [
  "tokio",
  "tracing",
  "url",
+ "vergen",
  "web3",
 ]
 
@@ -2629,6 +2630,7 @@ dependencies = [
  "tower-http",
  "tracing",
  "url",
+ "vergen",
  "warp",
  "web3",
 ]
@@ -6201,6 +6203,7 @@ dependencies = [
  "tower-http",
  "tracing",
  "tracing-opentelemetry",
+ "vergen",
  "web3",
 ]
 

--- a/crates/autopilot/Cargo.toml
+++ b/crates/autopilot/Cargo.toml
@@ -66,5 +66,9 @@ web3 = { workspace = true }
 mockall = { workspace = true }
 tokio = { workspace = true, features = ["test-util"] }
 
+[build-dependencies]
+anyhow = { workspace = true }
+vergen = { workspace = true, features = ["git", "gitcl"] }
+
 [lints]
 workspace = true

--- a/crates/autopilot/build.rs
+++ b/crates/autopilot/build.rs
@@ -1,0 +1,12 @@
+use {
+    anyhow::{Context, Result},
+    vergen::EmitBuilder,
+};
+
+fn main() -> Result<()> {
+    // Set environment variable VERGEN_GIT_DESCRIBE for use to log version at startup
+    EmitBuilder::builder()
+        .git_describe(true, true, None)
+        .emit()
+        .context("emit")
+}

--- a/crates/autopilot/src/main.rs
+++ b/crates/autopilot/src/main.rs
@@ -3,5 +3,9 @@ static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
 
 #[tokio::main]
 async fn main() {
+    let commit = env!("VERGEN_GIT_DESCRIBE");
+    //Log version at startup
+    tracing::info!(%commit, "starting autopilot");
+
     autopilot::start(std::env::args()).await;
 }

--- a/crates/driver/Cargo.toml
+++ b/crates/driver/Cargo.toml
@@ -85,5 +85,9 @@ mockall = { workspace = true }
 tokio = { workspace = true, features = ["test-util", "process"] }
 tempfile = { workspace = true }
 
+[build-dependencies]
+anyhow = { workspace = true }
+vergen = { workspace = true, features = ["git", "gitcl"] }
+
 [lints]
 workspace = true

--- a/crates/driver/build.rs
+++ b/crates/driver/build.rs
@@ -1,0 +1,12 @@
+use {
+    anyhow::{Context, Result},
+    vergen::EmitBuilder,
+};
+
+fn main() -> Result<()> {
+    // Set environment variable VERGEN_GIT_DESCRIBE for use to log version at startup
+    EmitBuilder::builder()
+        .git_describe(true, true, None)
+        .emit()
+        .context("emit")
+}

--- a/crates/driver/src/main.rs
+++ b/crates/driver/src/main.rs
@@ -3,5 +3,9 @@ static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
 
 #[tokio::main]
 async fn main() {
+    let commit = env!("VERGEN_GIT_DESCRIBE");
+    //Log version at startup
+    tracing::info!(%commit, "starting driver");
+
     driver::start(std::env::args()).await;
 }

--- a/crates/solvers/Cargo.toml
+++ b/crates/solvers/Cargo.toml
@@ -59,5 +59,9 @@ tempfile = { workspace = true }
 hex-literal = { workspace = true }
 ethcontract = { workspace = true }
 
+[build-dependencies]
+anyhow = { workspace = true }
+vergen = { workspace = true, features = ["git", "gitcl"] }
+
 [lints]
 workspace = true

--- a/crates/solvers/build.rs
+++ b/crates/solvers/build.rs
@@ -1,0 +1,12 @@
+use {
+    anyhow::{Context, Result},
+    vergen::EmitBuilder,
+};
+
+fn main() -> Result<()> {
+    // Set environment variable VERGEN_GIT_DESCRIBE for use to log version at startup
+    EmitBuilder::builder()
+        .git_describe(true, true, None)
+        .emit()
+        .context("emit")
+}

--- a/crates/solvers/src/main.rs
+++ b/crates/solvers/src/main.rs
@@ -3,5 +3,9 @@ static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
 
 #[tokio::main]
 async fn main() {
+    let commit = env!("VERGEN_GIT_DESCRIBE");
+    //Log version at startup
+    tracing::info!(%commit, "starting solver(solvers)");
+
     solvers::start(std::env::args()).await;
 }


### PR DESCRIPTION
# Description
<!--- Describe your changes to provide context for reviewers, including why it is needed -->
This PR adds the build commit hash to the logs of crates {`autopilot`, `orderbook`, `solvers` etc.}
  
Currently, it’s difficult to identify which commit a running deployment originates from.  
By logging the commit hash at startup, operators can quickly determine the deployed version.

# Changes
<!-- List of detailed changes (how the change is accomplished) -->

- Added build.rs with `vergen` to each crate to emit `VERGEN_GIT_DESCRIBE`.
- Updated `main.rs` in each crate (`autopilot`, `orderbook`, `solvers`) to log the commit hash once at startup.
- Added vergen, and anyhow as build-dependencies for each crate specified above.

## How to test
<!--- Include details of how to test your changes, including any pre-requisites. If no unit tests are included, please explain why and how to test manually
-->
 A log in the form: `INFO starting autopilot commit=xyz2` should be visible at startup of crates
<!--
## Related Issues
-->
Fixes #3572 