### PR TITLE
fix V089 migration

### DIFF
--- a/database/sql/V089__add_creation_timestamp_to_appdata_and_orderquotes.sql
+++ b/database/sql/V089__add_creation_timestamp_to_appdata_and_orderquotes.sql
@@ -2,10 +2,10 @@
 -- in order to help data ingestion for our analytics team
 
 ALTER TABLE app_data
-    ADD COLUMN creation_timestamp timestamptz NOT NULL SET DEFAULT '1970-01-01 00:00:00+00'::timestamptz;
+    ADD COLUMN creation_timestamp timestamptz NOT NULL DEFAULT '1970-01-01 00:00:00+00'::timestamptz;
 
 ALTER TABLE order_quotes
-    ADD COLUMN creation_timestamp timestamptz NOT NULL SET DEFAULT '1970-01-01 00:00:00+00'::timestamptz;
+    ADD COLUMN creation_timestamp timestamptz NOT NULL DEFAULT '1970-01-01 00:00:00+00'::timestamptz;
 
 -- Set default for future inserts
 ALTER TABLE app_data


### PR DESCRIPTION
fix SQL syntax expecting SET in `ALTER COLUMN` but not in `ADD COLUMN`

# Description
Invalid SQL migration syntax got merged because 'just' a failing migration does not trigger the CI to fail.

followup to https://github.com/cowprotocol/services/pull/3534

# Changes
do not use `SET DEFAULT` in `ADD COLUMN` but just `DEFAULT`

## How to test
observe migration log output actually successfully running migration
