### PR TITLE
Store creds to be able to push a tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,6 @@ jobs:
           fetch-depth: 0 # Fetch all history for all branches and tags
           # Requires "Read and Write access to code" permission
           token: ${{ secrets.RELEASE_ACTION_ACCESS_TOKEN }}
-          persist-credentials: false
 
       - name: Fetch latest release version tag
         id: fetch_tag


### PR DESCRIPTION
# Description

https://github.com/cowprotocol/services/pull/3532 set persist-credentials to false leading the to the tag not being pushed as there is no github creds stored to do so.
