### PR TITLE
Cleanup gas estimators

### DIFF
--- a/crates/autopilot/src/run.rs
+++ b/crates/autopilot/src/run.rs
@@ -8,7 +8,8 @@ use {
             onchain_order_events::{
                 OnchainOrderParser,
                 ethflow_events::{
-                    EthFlowOnchainOrderParser, determine_ethflow_indexing_start,
+                    EthFlowOnchainOrderParser,
+                    determine_ethflow_indexing_start,
                     determine_ethflow_refund_indexing_start,
                 },
                 event_retriever::CoWSwapOnchainOrdersContract,
@@ -26,7 +27,11 @@ use {
     clap::Parser,
     contracts::{BalancerV2Vault, IUniswapV3Factory},
     ethcontract::{
-        BlockNumber, H160, common::DeploymentInformation, dyns::DynWeb3, errors::DeployError,
+        BlockNumber,
+        H160,
+        common::DeploymentInformation,
+        dyns::DynWeb3,
+        errors::DeployError,
     },
     ethrpc::block_stream::block_number_to_block_number_hash,
     futures::stream::StreamExt,

--- a/crates/autopilot/src/run.rs
+++ b/crates/autopilot/src/run.rs
@@ -8,8 +8,7 @@ use {
             onchain_order_events::{
                 OnchainOrderParser,
                 ethflow_events::{
-                    EthFlowOnchainOrderParser,
-                    determine_ethflow_indexing_start,
+                    EthFlowOnchainOrderParser, determine_ethflow_indexing_start,
                     determine_ethflow_refund_indexing_start,
                 },
                 event_retriever::CoWSwapOnchainOrdersContract,
@@ -27,11 +26,7 @@ use {
     clap::Parser,
     contracts::{BalancerV2Vault, IUniswapV3Factory},
     ethcontract::{
-        BlockNumber,
-        H160,
-        common::DeploymentInformation,
-        dyns::DynWeb3,
-        errors::DeployError,
+        BlockNumber, H160, common::DeploymentInformation, dyns::DynWeb3, errors::DeployError,
     },
     ethrpc::block_stream::block_number_to_block_number_hash,
     futures::stream::StreamExt,
@@ -272,8 +267,6 @@ pub async fn run(args: Arguments) {
             &http_factory,
             &web3,
             args.shared.gas_estimators.as_slice(),
-            args.shared.blocknative_api_key.clone(),
-            args.shared.gas_estimation_driver_url.clone(),
         )
         .await
         .expect("failed to create gas price estimator"),

--- a/crates/driver/src/infra/blockchain/gas.rs
+++ b/crates/driver/src/infra/blockchain/gas.rs
@@ -10,9 +10,7 @@ use {
     },
     ethcontract::dyns::DynWeb3,
     gas_estimation::{
-        DEFAULT_GAS_LIMIT,
-        DEFAULT_TIME_LIMIT,
-        GasPriceEstimating,
+        DEFAULT_GAS_LIMIT, DEFAULT_TIME_LIMIT, GasPriceEstimating,
         nativegasestimator::{NativeGasEstimator, Params},
     },
     std::{sync::Arc, time::Duration},
@@ -23,8 +21,7 @@ type AdditionalTipPercentage = f64;
 type AdditionalTip = (MaxAdditionalTip, AdditionalTipPercentage);
 
 pub struct GasPriceEstimator {
-    //TODO: remove visibility once boundary is removed
-    pub(super) gas: Arc<dyn GasPriceEstimating>,
+    gas: Arc<dyn GasPriceEstimating>,
     additional_tip: AdditionalTip,
     max_fee_per_gas: eth::U256,
     min_priority_fee: eth::U256,

--- a/crates/driver/src/infra/blockchain/gas.rs
+++ b/crates/driver/src/infra/blockchain/gas.rs
@@ -10,7 +10,9 @@ use {
     },
     ethcontract::dyns::DynWeb3,
     gas_estimation::{
-        DEFAULT_GAS_LIMIT, DEFAULT_TIME_LIMIT, GasPriceEstimating,
+        DEFAULT_GAS_LIMIT,
+        DEFAULT_TIME_LIMIT,
+        GasPriceEstimating,
         nativegasestimator::{NativeGasEstimator, Params},
     },
     std::{sync::Arc, time::Duration},

--- a/crates/e2e/src/setup/services.rs
+++ b/crates/e2e/src/setup/services.rs
@@ -245,8 +245,7 @@ impl<'a> Services<'a> {
                     ),
                     "--price-estimation-drivers=test_quoter|http://localhost:11088/test_solver"
                         .to_string(),
-                    "--gas-estimators=Driver".to_string(),
-                    "--gas-estimation-driver-url=http://localhost:11088/gasprice".to_string(),
+                    "--gas-estimators=http://localhost:11088/gasprice".to_string(),
                 ],
                 args.autopilot,
             ]
@@ -258,8 +257,7 @@ impl<'a> Services<'a> {
                 vec![
                     "--price-estimation-drivers=test_quoter|http://localhost:11088/test_solver"
                         .to_string(),
-                    "--gas-estimators=Driver".to_string(),
-                    "--gas-estimation-driver-url=http://localhost:11088/gasprice".to_string(),
+                    "--gas-estimators=http://localhost:11088/gasprice".to_string(),
                 ],
                 args.api,
             ]

--- a/crates/orderbook/src/run.rs
+++ b/crates/orderbook/src/run.rs
@@ -1,7 +1,12 @@
 use {
     crate::{
-        api, arguments::Arguments, database::Postgres, ipfs::Ipfs, ipfs_app_data::IpfsAppData,
-        orderbook::Orderbook, quoter::QuoteHandler,
+        api,
+        arguments::Arguments,
+        database::Postgres,
+        ipfs::Ipfs,
+        ipfs_app_data::IpfsAppData,
+        orderbook::Orderbook,
+        quoter::QuoteHandler,
     },
     anyhow::{Context, Result, anyhow},
     app_data::Validator,
@@ -30,7 +35,8 @@ use {
         order_quoting::{self, OrderQuoter},
         order_validation::{OrderValidPeriodConfiguration, OrderValidator},
         price_estimation::{
-            PriceEstimating, QuoteVerificationMode,
+            PriceEstimating,
+            QuoteVerificationMode,
             factory::{self, PriceEstimatorFactory},
             native::NativePriceEstimating,
         },

--- a/crates/orderbook/src/run.rs
+++ b/crates/orderbook/src/run.rs
@@ -1,12 +1,7 @@
 use {
     crate::{
-        api,
-        arguments::Arguments,
-        database::Postgres,
-        ipfs::Ipfs,
-        ipfs_app_data::IpfsAppData,
-        orderbook::Orderbook,
-        quoter::QuoteHandler,
+        api, arguments::Arguments, database::Postgres, ipfs::Ipfs, ipfs_app_data::IpfsAppData,
+        orderbook::Orderbook, quoter::QuoteHandler,
     },
     anyhow::{Context, Result, anyhow},
     app_data::Validator,
@@ -35,8 +30,7 @@ use {
         order_quoting::{self, OrderQuoter},
         order_validation::{OrderValidPeriodConfiguration, OrderValidator},
         price_estimation::{
-            PriceEstimating,
-            QuoteVerificationMode,
+            PriceEstimating, QuoteVerificationMode,
             factory::{self, PriceEstimatorFactory},
             native::NativePriceEstimating,
         },
@@ -173,8 +167,6 @@ pub async fn run(args: Arguments) {
             &http_factory,
             &web3,
             args.shared.gas_estimators.as_slice(),
-            args.shared.blocknative_api_key.clone(),
-            args.shared.gas_estimation_driver_url.clone(),
         )
         .await
         .expect("failed to create gas price estimator"),

--- a/crates/shared/src/arguments.rs
+++ b/crates/shared/src/arguments.rs
@@ -5,7 +5,8 @@ use {
     crate::{
         gas_price_estimation::GasEstimatorType,
         sources::{
-            BaselineSource, balancer_v2::BalancerFactoryKind,
+            BaselineSource,
+            balancer_v2::BalancerFactoryKind,
             uniswap_v2::UniV2BaselineSourceParameters,
         },
         tenderly_api,

--- a/crates/shared/src/arguments.rs
+++ b/crates/shared/src/arguments.rs
@@ -5,8 +5,7 @@ use {
     crate::{
         gas_price_estimation::GasEstimatorType,
         sources::{
-            BaselineSource,
-            balancer_v2::BalancerFactoryKind,
+            BaselineSource, balancer_v2::BalancerFactoryKind,
             uniswap_v2::UniV2BaselineSourceParameters,
         },
         tenderly_api,
@@ -173,20 +172,10 @@ pub struct Arguments {
         long,
         env,
         default_value = "Web3",
-        value_enum,
-        ignore_case = true,
-        use_value_delimiter = true
+        use_value_delimiter = true,
+        value_parser = clap::value_parser!(GasEstimatorType)
     )]
     pub gas_estimators: Vec<GasEstimatorType>,
-
-    /// BlockNative requires api key to work. Optional since BlockNative could
-    /// be skipped in gas estimators.
-    #[clap(long, env)]
-    pub blocknative_api_key: Option<String>,
-
-    /// Driver URL for gas price estimation when using the Driver estimator.
-    #[clap(long, env)]
-    pub gas_estimation_driver_url: Option<Url>,
 
     /// Base tokens used for finding multi-hop paths between multiple AMMs
     /// Should be the most liquid tokens of the given network.
@@ -385,8 +374,6 @@ impl Display for Arguments {
             chain_id,
             simulation_node_url,
             gas_estimators,
-            blocknative_api_key,
-            gas_estimation_driver_url,
             base_tokens,
             baseline_sources,
             pool_cache_blocks,
@@ -419,8 +406,6 @@ impl Display for Arguments {
         display_option(f, "chain_id", chain_id)?;
         display_option(f, "simulation_node_url", simulation_node_url)?;
         writeln!(f, "gas_estimators: {gas_estimators:?}")?;
-        display_secret_option(f, "blocknative_api_key", blocknative_api_key.as_ref())?;
-        display_option(f, "gas_estimation_driver_url", gas_estimation_driver_url)?;
         writeln!(f, "base_tokens: {base_tokens:?}")?;
         writeln!(f, "baseline_sources: {baseline_sources:?}")?;
         writeln!(f, "pool_cache_blocks: {pool_cache_blocks}")?;

--- a/crates/shared/src/gas_price_estimation/mod.rs
+++ b/crates/shared/src/gas_price_estimation/mod.rs
@@ -5,7 +5,9 @@ use {
     crate::{ethrpc::Web3, http_client::HttpClientFactory},
     anyhow::Result,
     gas_estimation::{
-        GasPriceEstimating, PriorityGasPriceEstimating, nativegasestimator::NativeGasEstimator,
+        GasPriceEstimating,
+        PriorityGasPriceEstimating,
+        nativegasestimator::NativeGasEstimator,
     },
     std::str::FromStr,
     tracing::instrument,

--- a/crates/shared/src/gas_price_estimation/mod.rs
+++ b/crates/shared/src/gas_price_estimation/mod.rs
@@ -3,51 +3,34 @@ pub mod fake;
 
 use {
     crate::{ethrpc::Web3, http_client::HttpClientFactory},
-    anyhow::{Context, Result, anyhow, ensure},
+    anyhow::Result,
     gas_estimation::{
-        EthGasStation,
-        GasNowGasStation,
-        GasPriceEstimating,
-        PriorityGasPriceEstimating,
-        Transport,
-        blocknative::BlockNative,
-        nativegasestimator::NativeGasEstimator,
+        GasPriceEstimating, PriorityGasPriceEstimating, nativegasestimator::NativeGasEstimator,
     },
-    reqwest::header::{self, HeaderMap, HeaderValue},
-    serde::de::DeserializeOwned,
+    std::str::FromStr,
     tracing::instrument,
     url::Url,
 };
 pub use {driver::DriverGasEstimator, fake::FakeGasPriceEstimator};
 
-#[derive(Copy, Clone, Debug, clap::ValueEnum)]
-#[clap(rename_all = "verbatim")]
+#[derive(Clone, Debug)]
 pub enum GasEstimatorType {
-    EthGasStation,
-    GasNow,
     Web3,
-    BlockNative,
     Native,
-    Driver,
+    Driver(Url),
 }
 
-#[derive(Clone)]
-pub struct Client(pub reqwest::Client);
+impl FromStr for GasEstimatorType {
+    type Err = String;
 
-#[async_trait::async_trait]
-impl Transport for Client {
-    async fn get_json<T: DeserializeOwned>(&self, url: &str, header: HeaderMap) -> Result<T> {
-        self.0
-            .get(url)
-            .headers(header)
-            .send()
-            .await
-            .context("failed to make request")?
-            .error_for_status()
-            .context("response status is not success")?
-            .json()
-            .await
-            .context("failed to decode response")
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.to_ascii_lowercase().as_str() {
+            "web3" => Ok(GasEstimatorType::Web3),
+            "native" => Ok(GasEstimatorType::Native),
+            _ => Url::parse(s).map(GasEstimatorType::Driver).map_err(|e| {
+                format!("expected 'web3', 'native', or a valid driver URL; got {s:?}: {e}")
+            }),
+        }
     }
 }
 
@@ -56,56 +39,18 @@ pub async fn create_priority_estimator(
     http_factory: &HttpClientFactory,
     web3: &Web3,
     estimator_types: &[GasEstimatorType],
-    blocknative_api_key: Option<String>,
-    driver_url: Option<Url>,
 ) -> Result<impl GasPriceEstimating + use<>> {
-    let client = || Client(http_factory.create());
     let network_id = web3.eth().chain_id().await?.to_string();
     let mut estimators = Vec::<Box<dyn GasPriceEstimating>>::new();
 
     for estimator_type in estimator_types {
         tracing::info!("estimator {estimator_type:?}, networkid {network_id}");
         match estimator_type {
-            GasEstimatorType::Driver => {
-                let url = driver_url.clone().ok_or_else(|| {
-                    anyhow!("Driver URL must be provided when using Driver gas estimator")
-                })?;
+            GasEstimatorType::Driver(url) => {
                 estimators.push(Box::new(DriverGasEstimator::new(
                     http_factory.create(),
-                    url,
+                    url.clone(),
                 )));
-            }
-            GasEstimatorType::BlockNative => {
-                ensure!(is_mainnet(&network_id), "BlockNative only supports mainnet");
-                ensure!(
-                    blocknative_api_key.is_some(),
-                    "BlockNative api key is empty"
-                );
-                let api_key = HeaderValue::from_str(&blocknative_api_key.clone().unwrap());
-                let headers = match api_key {
-                    Ok(mut api_key) => {
-                        let mut headers = HeaderMap::new();
-                        api_key.set_sensitive(true);
-                        headers.insert(header::AUTHORIZATION, api_key);
-                        headers
-                    }
-                    _ => HeaderMap::new(),
-                };
-                match BlockNative::new(client(), headers).await {
-                    Ok(estimator) => estimators.push(Box::new(estimator)),
-                    Err(err) => tracing::error!("blocknative failed: {}", err),
-                }
-            }
-            GasEstimatorType::EthGasStation => {
-                ensure!(
-                    is_mainnet(&network_id),
-                    "EthGasStation only supports mainnet"
-                );
-                estimators.push(Box::new(EthGasStation::new(client())))
-            }
-            GasEstimatorType::GasNow => {
-                ensure!(is_mainnet(&network_id), "GasNow only supports mainnet");
-                estimators.push(Box::new(GasNowGasStation::new(client())))
             }
             GasEstimatorType::Web3 => estimators.push(Box::new(web3.clone())),
             GasEstimatorType::Native => {
@@ -121,8 +66,4 @@ pub async fn create_priority_estimator(
         "all gas estimators failed to initialize"
     );
     Ok(PriorityGasPriceEstimating::new(estimators))
-}
-
-fn is_mainnet(network_id: &str) -> bool {
-    network_id == "1"
 }


### PR DESCRIPTION
# Description
Follow up PR from #3569.

> [!CAUTION]
> Given the parsing logic is changed this PR will need to be synchronized with an infrastructure change upon merge.

# Changes
- [x] reduces the number of choices we have to configure our gas estimators in the API and autopilot to reflect current reality (GasNot, Blocknative, etc don't really exist anymore and are not used in prodcution)
- [x] changes the configuration to not require two orthogonal parameters (gas_estimator & gas_estimator_driver_url) and clumsy logic to ensure consistency and collapses them into a single type that can be parsed
- [x] remove some otherwise unneeded code

## How to test
Existing tests