### PR TITLE
Use old live orders query for counting orders per user

### DIFF
--- a/crates/database/src/orders.rs
+++ b/crates/database/src/orders.rs
@@ -695,136 +695,6 @@ WHERE
     sqlx::query_as(QUERY).bind(tx_hash).fetch(ex)
 }
 
-/// The base solvable orders query used in specialized queries. Parametrized by valid_to.
-///
-/// Excludes orders for the following conditions:
-/// - valid_to is in the past
-/// - fully executed
-/// - cancelled on chain
-/// - cancelled through API
-/// - pending pre-signature
-/// - ethflow specific invalidation conditions
-#[rustfmt::skip]
-const OPEN_ORDERS: &str = r#"
-WITH live_orders AS (
-    SELECT o.*
-    FROM   orders o
-    LEFT   JOIN ethflow_orders e ON e.uid = o.uid
-    WHERE  o.cancellation_timestamp IS NULL
-      AND  o.valid_to >= $1
-      AND (e.valid_to IS NULL OR e.valid_to >= $1)
-      AND NOT EXISTS (SELECT 1 FROM invalidations               i  WHERE i.order_uid = o.uid)
-      AND NOT EXISTS (SELECT 1 FROM onchain_order_invalidations oi WHERE oi.uid      = o.uid)
-      AND NOT EXISTS (SELECT 1 FROM onchain_placed_orders       op WHERE op.uid      = o.uid
-                                                                     AND op.placement_error IS NOT NULL)
-),
-trades_agg AS (
-     SELECT t.order_uid,
-            SUM(t.buy_amount) AS sum_buy,
-            SUM(t.sell_amount) AS sum_sell,
-            SUM(t.fee_amount) AS sum_fee
-     FROM trades t
-     JOIN live_orders lo ON lo.uid = t.order_uid
-     GROUP BY t.order_uid
-)
-SELECT
-    lo.uid,
-    lo.owner,
-    lo.creation_timestamp,
-    lo.sell_token,
-    lo.buy_token,
-    lo.sell_amount,
-    lo.buy_amount,
-    lo.valid_to,
-    lo.app_data,
-    lo.fee_amount,
-    lo.kind,
-    lo.partially_fillable,
-    lo.signature,
-    lo.receiver,
-    lo.signing_scheme,
-    lo.settlement_contract,
-    lo.sell_token_balance,
-    lo.buy_token_balance,
-    lo.class,
-
-    COALESCE(ta.sum_buy, 0) AS sum_buy,
-    COALESCE(ta.sum_sell, 0) AS sum_sell,
-    COALESCE(ta.sum_fee, 0) AS sum_fee,
-    false AS invalidated,
-    (lo.signing_scheme = 'presign' AND COALESCE(pe.unsigned, TRUE)) AS presignature_pending,
-    ARRAY(
-            SELECT (p.target, p.value, p.data)
-            FROM   interactions p
-            WHERE  p.order_uid = lo.uid AND p.execution = 'pre'
-            ORDER  BY p.index
-    ) AS pre_interactions,
-    ARRAY(
-            SELECT (p.target, p.value, p.data)
-            FROM   interactions p
-            WHERE  p.order_uid = lo.uid AND p.execution = 'post'
-            ORDER  BY p.index
-    ) AS post_interactions,
-    ed.ethflow_data,
-    opo.onchain_user,
-    NULL AS onchain_placement_error,
-    COALESCE(fee_agg.executed_fee,0)        AS executed_fee,
-    COALESCE(fee_agg.executed_fee_token, lo.sell_token) AS executed_fee_token,
-    ad.full_app_data
-FROM live_orders lo
-LEFT JOIN LATERAL (
-    SELECT NOT signed AS unsigned
-    FROM   presignature_events
-    WHERE  order_uid = lo.uid
-    ORDER  BY block_number DESC, log_index DESC
-    LIMIT  1
-    ) pe ON TRUE
-LEFT JOIN LATERAL (
-    SELECT sender AS onchain_user
-    FROM   onchain_placed_orders
-    WHERE  uid = lo.uid
-    ORDER  BY block_number DESC
-    LIMIT  1
-    ) opo ON TRUE
-LEFT JOIN LATERAL (
-    SELECT ROW(tx_hash, eo.valid_to) AS ethflow_data
-    FROM   ethflow_orders  eo
-    LEFT JOIN ethflow_refunds r ON r.order_uid = eo.uid
-    WHERE  eo.uid = lo.uid
-    ) ed ON TRUE
-LEFT JOIN LATERAL (
-    SELECT SUM(executed_fee) AS executed_fee,
-           (ARRAY_AGG(executed_fee_token))[1] AS executed_fee_token
-    FROM   order_execution
-    WHERE  order_uid = lo.uid
-) fee_agg ON TRUE
-LEFT JOIN app_data ad ON ad.contract_app_data = lo.app_data
-LEFT JOIN trades_agg ta ON  ta.order_uid = lo.uid
-WHERE ((lo.kind = 'sell' AND COALESCE(ta.sum_sell,0) < lo.sell_amount) OR
-       (lo.kind = 'buy'  AND COALESCE(ta.sum_buy ,0) < lo.buy_amount))
-"#;
-
-// Same functionality as OPEN_ORDERS but not optimized to fetch all live orders
-// at once. Performs better when used with filtering by user.
-#[rustfmt::skip]
-const OPEN_ORDERS_EMBEDDABLE: &str = const_format::concatcp!(
-"SELECT * FROM ( ",
-    "SELECT ", SELECT,
-    " FROM ", FROM,
-    " LEFT OUTER JOIN ethflow_orders eth_o on eth_o.uid = o.uid ",
-    " WHERE o.valid_to >= $1",
-    " AND CASE WHEN eth_o.valid_to IS NULL THEN true ELSE eth_o.valid_to >= $1 END",
-r#") AS unfiltered
-WHERE
-    CASE kind
-        WHEN 'sell' THEN sum_sell < sell_amount
-        WHEN 'buy' THEN sum_buy < buy_amount
-    END AND
-    (NOT invalidated) AND
-    (onchain_placement_error IS NULL)
-"#
-);
-
 /// Uses the conditions from OPEN_ORDERS and checks the fok limit orders have
 /// surplus fee.
 /// cleanup: fok limit orders should be allowed to not have surplus fee
@@ -833,6 +703,115 @@ pub fn solvable_orders(
     ex: &mut PgConnection,
     min_valid_to: i64,
 ) -> BoxStream<'_, Result<FullOrder, sqlx::Error>> {
+    /// The base solvable orders query used in specialized queries. Parametrized
+    /// by valid_to.
+    ///
+    /// Excludes orders for the following conditions:
+    /// - valid_to is in the past
+    /// - fully executed
+    /// - cancelled on chain
+    /// - cancelled through API
+    /// - pending pre-signature
+    /// - ethflow specific invalidation conditions
+    const OPEN_ORDERS: &str = r#"
+    WITH live_orders AS (
+        SELECT o.*
+        FROM   orders o
+        LEFT   JOIN ethflow_orders e ON e.uid = o.uid
+        WHERE  o.cancellation_timestamp IS NULL
+          AND  o.valid_to >= $1
+          AND (e.valid_to IS NULL OR e.valid_to >= $1)
+          AND NOT EXISTS (SELECT 1 FROM invalidations               i  WHERE i.order_uid = o.uid)
+          AND NOT EXISTS (SELECT 1 FROM onchain_order_invalidations oi WHERE oi.uid      = o.uid)
+          AND NOT EXISTS (SELECT 1 FROM onchain_placed_orders       op WHERE op.uid      = o.uid
+                                                                         AND op.placement_error IS NOT NULL)
+    ),
+    trades_agg AS (
+         SELECT t.order_uid,
+                SUM(t.buy_amount) AS sum_buy,
+                SUM(t.sell_amount) AS sum_sell,
+                SUM(t.fee_amount) AS sum_fee
+         FROM trades t
+         JOIN live_orders lo ON lo.uid = t.order_uid
+         GROUP BY t.order_uid
+    )
+    SELECT
+        lo.uid,
+        lo.owner,
+        lo.creation_timestamp,
+        lo.sell_token,
+        lo.buy_token,
+        lo.sell_amount,
+        lo.buy_amount,
+        lo.valid_to,
+        lo.app_data,
+        lo.fee_amount,
+        lo.kind,
+        lo.partially_fillable,
+        lo.signature,
+        lo.receiver,
+        lo.signing_scheme,
+        lo.settlement_contract,
+        lo.sell_token_balance,
+        lo.buy_token_balance,
+        lo.class,
+
+        COALESCE(ta.sum_buy, 0) AS sum_buy,
+        COALESCE(ta.sum_sell, 0) AS sum_sell,
+        COALESCE(ta.sum_fee, 0) AS sum_fee,
+        false AS invalidated,
+        (lo.signing_scheme = 'presign' AND COALESCE(pe.unsigned, TRUE)) AS presignature_pending,
+        ARRAY(
+                SELECT (p.target, p.value, p.data)
+                FROM   interactions p
+                WHERE  p.order_uid = lo.uid AND p.execution = 'pre'
+                ORDER  BY p.index
+        ) AS pre_interactions,
+        ARRAY(
+                SELECT (p.target, p.value, p.data)
+                FROM   interactions p
+                WHERE  p.order_uid = lo.uid AND p.execution = 'post'
+                ORDER  BY p.index
+        ) AS post_interactions,
+        ed.ethflow_data,
+        opo.onchain_user,
+        NULL AS onchain_placement_error,
+        COALESCE(fee_agg.executed_fee,0)        AS executed_fee,
+        COALESCE(fee_agg.executed_fee_token, lo.sell_token) AS executed_fee_token,
+        ad.full_app_data
+    FROM live_orders lo
+    LEFT JOIN LATERAL (
+        SELECT NOT signed AS unsigned
+        FROM   presignature_events
+        WHERE  order_uid = lo.uid
+        ORDER  BY block_number DESC, log_index DESC
+        LIMIT  1
+        ) pe ON TRUE
+    LEFT JOIN LATERAL (
+        SELECT sender AS onchain_user
+        FROM   onchain_placed_orders
+        WHERE  uid = lo.uid
+        ORDER  BY block_number DESC
+        LIMIT  1
+        ) opo ON TRUE
+    LEFT JOIN LATERAL (
+        SELECT ROW(tx_hash, eo.valid_to) AS ethflow_data
+        FROM   ethflow_orders  eo
+        LEFT JOIN ethflow_refunds r ON r.order_uid = eo.uid
+        WHERE  eo.uid = lo.uid
+        ) ed ON TRUE
+    LEFT JOIN LATERAL (
+        SELECT SUM(executed_fee) AS executed_fee,
+               (ARRAY_AGG(executed_fee_token))[1] AS executed_fee_token
+        FROM   order_execution
+        WHERE  order_uid = lo.uid
+    ) fee_agg ON TRUE
+    LEFT JOIN app_data ad ON ad.contract_app_data = lo.app_data
+    LEFT JOIN trades_agg ta ON  ta.order_uid = lo.uid
+    WHERE ((lo.kind = 'sell' AND COALESCE(ta.sum_sell,0) < lo.sell_amount) OR
+           (lo.kind = 'buy'  AND COALESCE(ta.sum_buy ,0) < lo.buy_amount))
+    "#;
+
     sqlx::query_as(OPEN_ORDERS).bind(min_valid_to).fetch(ex)
 }
 
@@ -883,6 +862,26 @@ pub async fn user_orders_with_quote(
     min_valid_to: i64,
     owner: &Address,
 ) -> Result<Vec<OrderWithQuote>, sqlx::Error> {
+    // Same functionality as OPEN_ORDERS but not optimized to fetch all live orders
+    // at once. Performs better when used with filtering by user.
+    #[rustfmt::skip]
+    const OPEN_ORDERS_EMBEDDABLE: &str = const_format::concatcp!(
+    "SELECT * FROM ( ",
+        "SELECT ", SELECT,
+        " FROM ", FROM,
+        " LEFT OUTER JOIN ethflow_orders eth_o on eth_o.uid = o.uid ",
+        " WHERE o.valid_to >= $1",
+        " AND CASE WHEN eth_o.valid_to IS NULL THEN true ELSE eth_o.valid_to >= $1 END",
+    r#") AS unfiltered
+    WHERE
+        CASE kind
+            WHEN 'sell' THEN sum_sell < sell_amount
+            WHEN 'buy' THEN sum_buy < buy_amount
+        END AND
+        (NOT invalidated) AND
+        (onchain_placement_error IS NULL)
+    "#);
+
     #[rustfmt::skip]
     const QUERY: &str = const_format::concatcp!(
         "SELECT o_quotes.sell_amount as quote_sell_amount, o.sell_amount as order_sell_amount,",


### PR DESCRIPTION
# Description

In https://github.com/cowprotocol/services/pull/3542 we improved the performance of loading live orders on `autopilot` startup, but it turns out that this made the performance of counting orders per user worse: [grafana](https://g-0263500beb.grafana-workspace.eu-central-1.amazonaws.com/explore?schemaVersion=1&panes=%7B%22zj9%22:%7B%22datasource%22:%225An5Ejq4k%22,%22queries%22:%5B%7B%22refId%22:%22A%22,%22expr%22:%22rate%28gp_v2_api_orderbook_database_queries_sum%7Btype%3D%5C%22count_limit_orders_by_owner%5C%22,%20network%3D%5C%22mainnet%5C%22%7D%5B5m%5D%29%20%2F%20rate%28gp_v2_api_orderbook_database_queries_count%7Btype%3D%5C%22count_limit_orders_by_owner%5C%22,%20network%3D%5C%22mainnet%5C%22%7D%5B5m%5D%29%22,%22range%22:true,%22instant%22:true,%22datasource%22:%7B%22type%22:%22prometheus%22,%22uid%22:%225An5Ejq4k%22%7D,%22editorMode%22:%22builder%22,%22legendFormat%22:%22__auto%22,%22useBackend%22:false,%22disableTextWrap%22:false,%22fullMetaSearch%22:false,%22includeNullMetadata%22:true%7D%5D,%22range%22:%7B%22from%22:%22now-6h%22,%22to%22:%22now%22%7D%7D%7D&orgId=1)

This PR bring the old query back for limit order counting which se use [in the orderbook](https://github.com/cowprotocol/services/blob/main/crates/shared/src/order_validation.rs#L712)