### PR TITLE
Remove test-specific commands from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,8 @@ docker-compose up
 In order to run the `e2e forked_network` tests you have to have [anvil](https://github.com/foundry-rs/foundry) installed,
 if you haven't installed `anvil` yet, refer to `foundry`'s [installation guide](https://book.getfoundry.sh/getting-started/installation) to get started.
 
-Some tests will require a `FORK_GNOSIS_URL`, refer to the list of [Gnosis RPC Providers](https://docs.gnosischain.com/tools/RPC%20Providers/) for publicly available nodes.
+All `forked_node` tests will require a `FORK_MAINNET_URL`, you can refer to [Chainlist](https://chainlist.org/chain/1) to find some publicly available RPCs (terms and conditions may apply).
+A subset of the `forked_node` tests will require a `FORK_GNOSIS_URL`, refer to the list of [Gnosis RPC Providers](https://docs.gnosischain.com/tools/RPC%20Providers/) for publicly available nodes.
 
 ## Profiling
 

--- a/README.md
+++ b/README.md
@@ -89,18 +89,10 @@ docker-compose up
 
 ### Forked Test Network
 
-In order to run the `e2e forked_network` tests you have to have an EVM compatible network fork running locally.
-We make use of [anvil](https://github.com/foundry-rs/foundry) from the Foundry project to run the fork.
+In order to run the `e2e forked_network` tests you have to have [anvil](https://github.com/foundry-rs/foundry) installed,
+if you haven't installed `anvil` yet, refer to `foundry`'s [installation guide](https://book.getfoundry.sh/getting-started/installation) to get started.
 
-> If you haven't installed `anvil` yet, refer to the `foundry` [installation guide](https://book.getfoundry.sh/getting-started/installation) to get started.
-
-```bash
-anvil \
-  --fork-url <FORK_URL> \
-  --port <PORT>
-```
-
-> Some tests will require a `FORK_GNOSIS_URL`, to fork a Gnosis node you can refer to the list of [Gnosis RPC Providers](https://docs.gnosischain.com/tools/RPC%20Providers/).
+Some tests will require a `FORK_GNOSIS_URL`, refer to the list of [Gnosis RPC Providers](https://docs.gnosischain.com/tools/RPC%20Providers/) for publicly available nodes.
 
 ## Profiling
 

--- a/README.md
+++ b/README.md
@@ -54,6 +54,12 @@ docker compose up -f playground/docker-compose.fork.yml up -d
 
 You can read more about the services available and their respective ports in the [playground's README](./playground/README.md).
 
+> Binaries like `autopilot`, `orderbook`, `driver` and `solvers` have `-h` and `--help` for, respectively, short and long descriptions over available commands and options.
+> Furthermore, there's OpenAPI pages for the [`orderbook`](https://docs.cow.fi/cow-protocol/reference/apis/orderbook),
+> [`driver`](https://docs.cow.fi/cow-protocol/reference/apis/driver) and [`solver`](https://docs.cow.fi/cow-protocol/reference/apis/solver) APIs,
+> you can find more information about the services and the CoW Protocol at <docs.cow.fi>.
+
+
 ## Testing
 
 The CI (check [`.github/workflows/pull-request.yaml`](.github/workflows/pull-request.yaml)) runs
@@ -67,10 +73,6 @@ The CI system uses [cargo-nextest](https://nexte.st/) and therefor all tests are
 `cargo-nextest` and `cargo test` handle global state slightly differently which can cause some tests to fail with `cargo test`.
 That's why it's recommended to run tests with `cargo nextest run`.
 
-### DB & E2E Tests
-
-Database and E2E tests require some infrastructure, following is their setup process.
-
 ### Postgres
 
 The tests that require postgres connect to the default database of a locally running postgres instance on the default port.
@@ -81,26 +83,20 @@ Note: The migrations will be applied as well.
 docker-compose up
 ```
 
-### Local Test Network
+### Forked Test Network
 
-In order to run the `e2e` tests you have to have an EVM compatible testnet running locally.
-We make use of [anvil](https://github.com/foundry-rs/foundry) from the Foundry project to spin up a local testnet.
+In order to run the `e2e forked_network` tests you have to have an EVM compatible network fork running locally.
+We make use of [anvil](https://github.com/foundry-rs/foundry) from the Foundry project to run the fork.
 
-`anvil` supports all the RPC methods we need to run the services and tests.
-
-1. Install [foundryup](https://book.getfoundry.sh/getting-started/installation).
-2. Install foundry with `foundryup`.
-3. Run `anvil` with the following configuration:
+> If you haven't installed `anvil` yet, refer to the `foundry` [installation guide](https://book.getfoundry.sh/getting-started/installation) to get started.
 
 ```bash
-ANVIL_IP_ADDR=0.0.0.0 anvil \
-  --gas-price 1 \
-  --gas-limit 10000000 \
-  --base-fee 0 \
-  --balance 1000000 \
-  --chain-id 1 \
-  --timestamp 1577836800
+anvil \
+  --fork-url <FORK_URL> \
+  --port <PORT>
 ```
+
+> Some tests will require a `FORK_GNOSIS_URL`, to fork a Gnosis node you can refer to the list of [Gnosis RPC Providers](https://docs.gnosischain.com/tools/RPC%20Providers/).
 
 ## Profiling
 

--- a/README.md
+++ b/README.md
@@ -73,6 +73,10 @@ The CI system uses [cargo-nextest](https://nexte.st/) and therefor all tests are
 `cargo-nextest` and `cargo test` handle global state slightly differently which can cause some tests to fail with `cargo test`.
 That's why it's recommended to run tests with `cargo nextest run`.
 
+### Flaky Tests
+
+In case a test is flaky and only fails **sometimes** in CI you can use the [`run-flaky-test`](.github/workflows/pull-request.yaml) github action to test your fix with the CI to get confidence that the fix that works locally also works in CI.
+
 ### Postgres
 
 The tests that require postgres connect to the default database of a locally running postgres instance on the default port.

--- a/README.md
+++ b/README.md
@@ -43,46 +43,33 @@ There are additional crates that live in the cargo workspace.
 - `shared` provides other shared functionality between the solver and order book
 - `testlib` shared helpers for writing unit and end-to-end tests
 
+## Running the Services Locally
+
+To run the services locally you should use the [`playground`](./playground/README.md).
+You can launch it with the following command:
+
+```
+docker compose up -f playground/docker-compose.fork.yml up -d
+```
+
+You can read more about the services available and their respective ports in the [playground's README](./playground/README.md).
+
 ## Testing
 
-The CI (check .github/workflows/pull-request.yaml) runs unit tests, e2e tests, `clippy` and `cargo fmt`. The CI system uses [cargo-nextest](https://nexte.st/) and therefor all tests are getting verified by it. `cargo-nextest` and `cargo test` handle global state slightly differently which can cause some tests to fail with `cargo test`. That's why it's recommended to run tests with `cargo nextest run`.
+The CI (check [`.github/workflows/pull-request.yaml`](.github/workflows/pull-request.yaml)) runs
+[doc-tests](https://github.com/cowprotocol/services/tree/main/.github/workflows/pull-request.yaml#L71),
+[unit tests](https://github.com/cowprotocol/services/tree/main/.github/workflows/pull-request.yaml#L88-L89),
+[DB tests](https://github.com/cowprotocol/services/tree/main/.github/workflows/pull-request.yaml#L117),
+[E2E tests with a local node](https://github.com/cowprotocol/services/tree/main/.github/workflows/pull-request.yaml#L147),
+[E2E tests with a forked node](https://github.com/cowprotocol/services/tree/main/.github/workflows/pull-request.yaml#L187) and
+[driver tests](https://github.com/cowprotocol/services/tree/main/.github/workflows/pull-request.yaml#L206-L209) (and more).
+The CI system uses [cargo-nextest](https://nexte.st/) and therefor all tests are getting verified by it.
+`cargo-nextest` and `cargo test` handle global state slightly differently which can cause some tests to fail with `cargo test`.
+That's why it's recommended to run tests with `cargo nextest run`.
 
-### Unit Tests:
+### DB & E2E Tests
 
-`cargo nextest run`
-
-### DB Tests:
-
-`cargo nextest run postgres --test-threads 1 --run-ignored ignored-only`
-
-**Note:** Requires postgres database running (see below).
-
-### E2E Tests - Local Node:
-
-`cargo nextest run -p e2e local_node --test-threads 1 --failure-output final --run-ignored ignored-only`.
-
-**Note:** Requires postgres database and local test network with smart contracts deployed (see below).
-
-### E2E Tests - Forked Node:
-
-`FORK_URL=<mainnet archive node RPC URL> cargo nextest run -p e2e forked_node --test-threads 1 --run-ignored ignored-only --failure-output final`.
-
-**Note:** Requires postgres database (see below).
-
-### Clippy
-
-`cargo clippy --all-features --all-targets -- -D warnings`
-
-### Formatting
-
-We rely on custom formatting rules which currently can only be used with a nightly toolchain which is why we need to override the default toolchain with `+nightly`.
-
-`cargo +nightly fmt --all`
-
-### Flaky Tests
-In case a test is flaky and only fails **sometimes** in CI you can use the [`run-flaky-test`](.github/workflows/pull-request.yaml) github action to test your fix with the CI to get confidence that the fix that works locally also works in CI.
-
-## Development Setup
+Database and E2E tests require some infrastructure, following is their setup process.
 
 ### Postgres
 
@@ -115,7 +102,7 @@ ANVIL_IP_ADDR=0.0.0.0 anvil \
   --timestamp 1577836800
 ```
 
-### Profiling
+## Profiling
 
 All binaries are compiled with support for [tokio-console](https://github.com/tokio-rs/console) by default to allow you to look inside the tokio runtime.
 However, this feature is not enabled at runtime by default because it comes with a pretty significant memory overhead. To enable it you just have to set the environment variable `TOKIO_CONSOLE=true` and run the binary you want to instrument.
@@ -126,8 +113,7 @@ cargo install --locked tokio-console
 tokio-console
 ```
 
-
-### Changing Log Filters
+## Changing Log Filters
 
 It's possible to change the tracing log filter while the process is running. This can be useful to debug an error that requires more verbose logs but which might no longer appear after restarting the system.
 
@@ -136,71 +122,3 @@ You can also reset the log filter to the filter the program was initially starte
 
 See [here](https://docs.rs/tracing-subscriber/latest/tracing_subscriber/filter/struct.EnvFilter.html#directives) for documentation on the supported log filter format.
 
-## Running the Services Locally
-
-### Prerequisites
-
-Reading the state of the blockchain requires issuing RPC calls to an ethereum node. This can be a testnet you are running locally, some "real" node you have access to or the most convenient thing is to use a third-party service like [infura](https://infura.io/) to get access to an ethereum node which we recommend.
-After you made a free infura account they offer you "endpoints" for the mainnet and different testnets. We will refer those as `node-urls`.
-Because services are only run on Mainnet, Gnosis Chain, Arbitrum One and Sepolia you need to select one of those.
-
-Note that the `node-url` is sensitive data. The `orderbook` and `solver` executables allow you to pass it with the `--node-url` parameter. This is very convenient for our examples but to minimize the possibility of sharing this information by accident you should consider setting the `NODE_URL` environment variable so you don't have to pass the `--node-url` argument to the executables.
-
-To avoid confusion during your tests, always double-check that the token and account addresses you use actually correspond to the network of the `node-url` you are running the executables with.
-
-### Autopilot
-
-To see all supported command line arguments run `cargo run --bin autopilot -- --help`.
-
-Run an `autopilot` with:
-
-```sh
-cargo run --bin autopilot -- \
-  --skip-event-sync true \
-  --node-url <YOUR_NODE_URL>
-```
-
-`--skip-event-sync` will skip some work to speed up the initialization process.
-
-### Orderbook
-
-To see all supported command line arguments run `cargo run --bin orderbook -- --help`.
-
-Run an `orderbook` on `localhost:8080` with:
-
-```sh
-cargo run --bin orderbook -- \
-  --node-url <YOUR_NODE_URL>
-```
-
-If your node supports `trace_callMany`, or you have an additional node with tracing support, consider also specifying `--tracing-node-url <YOUR_NODE_URL>`.
-This will enable the tracing-based bad token detection.
-
-Note: Current version of the code does not compile under Windows OS. Context and workaround are [here](https://github.com/cowprotocol/services/issues/226).
-
-### Solvers
-
-To see all supported command line arguments run `cargo run --bin solver -- --help`.
-
-Run a solver which is connected to an `orderbook` at `localhost:8080` with:
-
-```sh
-cargo run -p solver -- \
-  --solver-account 0xa6DDBD0dE6B310819b49f680F65871beE85f517e \
-  --transaction-strategy DryRun \
-  --node-url <YOUR_NODE_URL>
-```
-
-`--transaction-strategy DryRun` will make the solver only print the solution but not submit it on-chain. This command is absolutely safe and will not use any funds.
-
-The `solver-account` is responsible for signing transactions. Solutions for settlements need to come from an address the settlement contract trusts in order to make the contract actually consider the solution. If we pass a public address, like we do here, the solver only pretends to be used for testing purposes. To actually submit transactions on behalf of a solver account you would have to pass a private key of an account the settlement contract trusts instead. Adding your personal solver account is quite involved and requires you to get in touch with the team, so we are using this public solver address for now.
-
-To make things more interesting and see some real orders you can connect the `solver` to our real `orderbook` service. There are several orderbooks for production and staging environments on different networks. Find the `orderbook-url` corresponding to your `node-url` which suits your purposes and connect your solver to it with `--orderbook-url <URL>`.
-
-The publicly available orderbook URLs can be found [here](https://api.cow.fi/docs/).
-
-Always make sure that the `solver` and the `orderbook` it connects to are configured to use the same network.
-
-### Frontend
-
-To conveniently submit orders checkout the [CowSwap](https://github.com/cowprotocol/cowswap) frontend and point it to your local instance.


### PR DESCRIPTION
# Description
Removes test-specific commands to avoid documentation rot

# Changes
- [ ] Added basic playground setup instructions
- [ ] Removed test-specific commands
- [ ] Added pointers to the respective tests in the CI file (not perfect but any dev should be able to navigate the file even if it gets out of sync)

## How to test
Read the README 😄 
