### PR TITLE
Fix solvers compilation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6223,6 +6223,7 @@ dependencies = [
  "tower-http",
  "tracing",
  "tracing-opentelemetry",
+ "url",
  "vergen",
  "web3",
 ]

--- a/crates/solvers/Cargo.toml
+++ b/crates/solvers/Cargo.toml
@@ -40,6 +40,7 @@ tokio = { workspace = true, features = ["macros", "rt-multi-thread", "signal", "
 toml = { workspace = true }
 tower = { workspace = true }
 tower-http = { workspace = true, features = ["limit", "trace"] }
+url = { workspace = true, features = ["serde"] }
 web3 = { workspace = true }
 
 # TODO Once solvers are ported and E2E tests set up, slowly migrate code and

--- a/crates/solvers/src/infra/config.rs
+++ b/crates/solvers/src/infra/config.rs
@@ -6,12 +6,12 @@ use {
     },
     chain::Chain,
     ethereum_types::H160,
-    reqwest::Url,
     serde::Deserialize,
     serde_with::serde_as,
     shared::price_estimation::gas::SETTLEMENT_OVERHEAD,
     std::{fmt::Debug, path::Path},
     tokio::fs,
+    url::Url,
 };
 
 #[serde_as]


### PR DESCRIPTION
# Description
Still not sure what exactly has happened, but currently `cargo build -p solvers` fails both locally and in [CI release build](https://github.com/cowprotocol/services/actions/runs/17259402078/job/48980558342) on the latest rust version. The serde crate version is hardened, tho. This PR fixes the compilation.
