### PR TITLE
Use correct pool digest for BNB

### DIFF
--- a/crates/driver/src/infra/liquidity/config.rs
+++ b/crates/driver/src/infra/liquidity/config.rs
@@ -91,10 +91,14 @@ impl UniswapV2 {
 
     /// Returns the liquidity configuration for PancakeSwap.
     pub fn pancake_swap(chain: Chain) -> Option<Self> {
+        let pool_code = match chain {
+            Chain::Bnb => hex!("00fb7f630766e6a796048ea87d01acd3068e8ff67d078148a3fa3f4a84f69bd5"),
+            _ => hex!("57224589c67f3f30a6b0d7a1b54cf3153ab84563bc609ef41dfb34f8b2974d2d"),
+        }
+        .into();
         Some(Self {
             router: deployment_address(contracts::PancakeRouter::raw_contract(), chain)?,
-            pool_code: hex!("57224589c67f3f30a6b0d7a1b54cf3153ab84563bc609ef41dfb34f8b2974d2d")
-                .into(),
+            pool_code,
             missing_pool_cache_time: Duration::from_secs(60 * 60),
         })
     }


### PR DESCRIPTION
# Description

Pancake v2 pool digest on BNB is different. I found the correct one by going to https://bscscan.com/address/0xca143ce32fe78f1f7019d7d551a6402fc5350c73#readContract and reading the `INIT_CODE_PAIR_HASH` constant.  I was able to get a quote with this hash. 