### PR TITLE
Migrate GnosisSafe* contracts to alloy-rs

### DIFF
--- a/crates/contracts/Cargo.toml
+++ b/crates/contracts/Cargo.toml
@@ -19,6 +19,7 @@ bin = [
     "tracing",
     "tracing-subscriber",
 ]
+test-util = []
 
 [dependencies]
 alloy = { workspace = true, features = ["sol-types", "json", "contract", "json-abi"] }

--- a/crates/contracts/build.rs
+++ b/crates/contracts/build.rs
@@ -1297,12 +1297,6 @@ fn main() {
                 },
             )
     });
-    generate_contract("GnosisSafe");
-    generate_contract_with_config("GnosisSafeCompatibilityFallbackHandler", |builder| {
-        builder.add_method_alias("isValidSignature(bytes,bytes)", "is_valid_signature_legacy")
-    });
-    generate_contract("GnosisSafeProxy");
-    generate_contract("GnosisSafeProxyFactory");
     generate_contract_with_config("HoneyswapRouter", |builder| {
         builder.add_network_str(GNOSIS, "0x1C232F01118CB8B424793ae03F870aa7D0ac7f77")
     });

--- a/crates/contracts/src/alloy.rs
+++ b/crates/contracts/src/alloy.rs
@@ -1,3 +1,6 @@
+#[cfg(feature = "test-util")]
+pub use crate::{tx, tx_value};
+
 pub mod networks {
     pub const MAINNET: u64 = 1;
     pub const GNOSIS: u64 = 100;
@@ -38,6 +41,11 @@ crate::bindings!(
         // Not available on Lens
     }
 );
+
+crate::bindings!(GnosisSafe);
+crate::bindings!(GnosisSafeCompatibilityFallbackHandler);
+crate::bindings!(GnosisSafeProxy);
+crate::bindings!(GnosisSafeProxyFactory);
 
 pub use alloy::providers::DynProvider as Provider;
 
@@ -194,6 +202,41 @@ macro_rules! bindings {
     };
 }
 
+#[cfg(feature = "test-util")]
+#[macro_export]
+macro_rules! tx_value {
+    ($call:expr, $value:expr) => {{
+        const NAME: &str = stringify!($call);
+        $call
+            .value($value)
+            .send()
+            .await
+            .expect(&format!("failed to send: {}", NAME))
+            .watch()
+            .await
+            .expect(&format!("failed to get confirmations for: {}", NAME))
+    }};
+    ($call:expr, $value:expr, $acc:expr) => {{
+        const NAME: &str = stringify!($call);
+        $call
+            .from($acc)
+            .value($value)
+            .send()
+            .await
+            .expect(&format!("failed to send: {}", NAME))
+            .watch()
+            .await
+            .expect(&format!("failed to get confirmations for: {}", NAME))
+    }};
+}
+
+#[cfg(feature = "test-util")]
+#[macro_export]
+macro_rules! tx {
+    ($call:expr) => {{ $crate::tx_value!($call, ::alloy::primitives::U256::ZERO) }};
+    ($call:expr, $acc:expr) => {{ $crate::tx_value!($call, ::alloy::primitives::U256::ZERO, $acc) }};
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -251,46 +294,4 @@ mod tests {
         assert!(result2.is_err());
         assert!(result3.is_err());
     }
-}
-
-crate::bindings!(GnosisSafe);
-crate::bindings!(GnosisSafeCompatibilityFallbackHandler);
-crate::bindings!(GnosisSafeProxy);
-crate::bindings!(GnosisSafeProxyFactory);
-
-pub mod macros {
-    #[macro_export]
-    macro_rules! tx_value {
-        ($call:expr, $value:expr) => {{
-            const NAME: &str = stringify!($call);
-            $call
-                .value($value)
-                .send()
-                .await
-                .expect(&format!("failed to send: {}", NAME))
-                .watch()
-                .await
-                .expect(&format!("failed to get confirmations for: {}", NAME))
-        }};
-        ($call:expr, $value:expr, $acc:expr) => {{
-            const NAME: &str = stringify!($call);
-            $call
-                .from($acc)
-                .value($value)
-                .send()
-                .await
-                .expect(&format!("failed to send: {}", NAME))
-                .watch()
-                .await
-                .expect(&format!("failed to get confirmations for: {}", NAME))
-        }};
-    }
-
-    #[macro_export]
-    macro_rules! tx {
-        ($call:expr) => {{ $crate::alloy::macros::tx_value!($call, ::alloy::primitives::U256::ZERO) }};
-        ($call:expr, $acc:expr) => {{ $crate::alloy::macros::tx_value!($call, ::alloy::primitives::U256::ZERO, $acc) }};
-    }
-
-    pub use {tx, tx_value};
 }

--- a/crates/contracts/src/alloy.rs
+++ b/crates/contracts/src/alloy.rs
@@ -268,9 +268,9 @@ pub mod macros {
                 .send()
                 .await
                 .expect(&format!("failed to send: {}", NAME))
-                .get_receipt()
+                .watch()
                 .await
-                .expect(&format!("failed to get receipt: {}", NAME))
+                .expect(&format!("failed to get confirmations for: {}", NAME))
         }};
         ($call:expr, $value:expr, $acc:expr) => {{
             const NAME: &str = stringify!($call);
@@ -280,9 +280,9 @@ pub mod macros {
                 .send()
                 .await
                 .expect(&format!("failed to send: {}", NAME))
-                .get_receipt()
+                .watch()
                 .await
-                .expect(&format!("failed to get receipt: {}", NAME))
+                .expect(&format!("failed to get confirmations for: {}", NAME))
         }};
     }
 

--- a/crates/contracts/src/alloy.rs
+++ b/crates/contracts/src/alloy.rs
@@ -252,3 +252,45 @@ mod tests {
         assert!(result3.is_err());
     }
 }
+
+crate::bindings!(GnosisSafe);
+crate::bindings!(GnosisSafeCompatibilityFallbackHandler);
+crate::bindings!(GnosisSafeProxy);
+crate::bindings!(GnosisSafeProxyFactory);
+
+pub mod macros {
+    #[macro_export]
+    macro_rules! tx_value {
+        ($call:expr, $value:expr) => {{
+            const NAME: &str = stringify!($call);
+            $call
+                .value($value)
+                .send()
+                .await
+                .expect(&format!("failed to send: {}", NAME))
+                .get_receipt()
+                .await
+                .expect(&format!("failed to get receipt: {}", NAME))
+        }};
+        ($call:expr, $value:expr, $acc:expr) => {{
+            const NAME: &str = stringify!($call);
+            $call
+                .from($acc)
+                .value($value)
+                .send()
+                .await
+                .expect(&format!("failed to send: {}", NAME))
+                .get_receipt()
+                .await
+                .expect(&format!("failed to get receipt: {}", NAME))
+        }};
+    }
+
+    #[macro_export]
+    macro_rules! tx {
+        ($call:expr) => {{ $crate::alloy::macros::tx_value!($call, ::alloy::primitives::U256::ZERO) }};
+        ($call:expr, $acc:expr) => {{ $crate::alloy::macros::tx_value!($call, ::alloy::primitives::U256::ZERO, $acc) }};
+    }
+
+    pub use {tx, tx_value};
+}

--- a/crates/contracts/src/lib.rs
+++ b/crates/contracts/src/lib.rs
@@ -86,10 +86,6 @@ include_contracts! {
     FlashLoanRouter;
     GPv2AllowListAuthentication;
     GPv2Settlement;
-    GnosisSafe;
-    GnosisSafeCompatibilityFallbackHandler;
-    GnosisSafeProxy;
-    GnosisSafeProxyFactory;
     HoneyswapRouter;
     HooksTrampoline;
     IAavePool;

--- a/crates/e2e/Cargo.toml
+++ b/crates/e2e/Cargo.toml
@@ -1,12 +1,23 @@
 [package]
 name = "e2e"
 version = "1.0.0"
-authors = ["Gnosis Developers <developers@gnosis.io>", "Cow Protocol Developers <dev@cow.fi>"]
+authors = [
+    "Gnosis Developers <developers@gnosis.io>",
+    "Cow Protocol Developers <dev@cow.fi>",
+]
 edition = "2024"
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-alloy = { workspace = true, default-features = false, features = ["json-rpc", "providers", "rpc-client", "transports", "reqwest", "signers", "signer-local"] }
+alloy = { workspace = true, default-features = false, features = [
+    "json-rpc",
+    "providers",
+    "rpc-client",
+    "transports",
+    "reqwest",
+    "signers",
+    "signer-local",
+] }
 app-data = { workspace = true }
 anyhow = { workspace = true }
 autopilot = { workspace = true }

--- a/crates/e2e/Cargo.toml
+++ b/crates/e2e/Cargo.toml
@@ -9,15 +9,7 @@ edition = "2024"
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-alloy = { workspace = true, default-features = false, features = [
-    "json-rpc",
-    "providers",
-    "rpc-client",
-    "transports",
-    "reqwest",
-    "signers",
-    "signer-local",
-] }
+alloy = { workspace = true, default-features = false, features = ["json-rpc", "providers", "rpc-client", "transports", "reqwest", "signers", "signer-local"] }
 app-data = { workspace = true }
 anyhow = { workspace = true }
 autopilot = { workspace = true }
@@ -25,7 +17,7 @@ axum = { workspace = true }
 bigdecimal = { workspace = true }
 chrono = { workspace = true }
 clap = { workspace = true }
-contracts = { workspace = true }
+contracts = { workspace = true, features = ["test-util"] }
 database = { workspace = true }
 driver = { workspace = true }
 ethcontract = { workspace = true }

--- a/crates/e2e/src/setup/mod.rs
+++ b/crates/e2e/src/setup/mod.rs
@@ -111,7 +111,7 @@ where
 /// of the chain. The saved state is restored at the end of the test.
 /// The database is cleaned at the end of the test.
 ///
-/// This function also intializes tracing and sets panic hook.
+/// This function also initializes tracing and sets panic hook.
 ///
 /// Note that tests calling with this function will not be run simultaneously.
 pub async fn run_test<F, Fut>(f: F)

--- a/crates/e2e/src/setup/onchain_components/alloy.rs
+++ b/crates/e2e/src/setup/onchain_components/alloy.rs
@@ -1,0 +1,29 @@
+use {
+    alloy::contract::{CallBuilder, CallDecoder},
+    app_data::Hook,
+    ethrpc::{AlloyProvider, alloy::conversions::IntoLegacy},
+};
+
+pub async fn hook_for_transaction<D>(tx: CallBuilder<&AlloyProvider, D>) -> Hook
+where
+    D: CallDecoder,
+{
+    let gas_limit = tx
+        .estimate_gas()
+        .await
+        .expect("transaction reverted when estimating gas");
+    let call_data = tx.calldata().to_vec();
+    let target = tx
+        .into_transaction_request()
+        .to
+        .unwrap()
+        .into_to()
+        .unwrap()
+        .into_legacy();
+
+    Hook {
+        target,
+        call_data,
+        gas_limit,
+    }
+}

--- a/crates/e2e/src/setup/onchain_components/alloy.rs
+++ b/crates/e2e/src/setup/onchain_components/alloy.rs
@@ -4,14 +4,11 @@ use {
     ethrpc::{AlloyProvider, alloy::conversions::IntoLegacy},
 };
 
-pub async fn hook_for_transaction<D>(tx: CallBuilder<&AlloyProvider, D>) -> Hook
+pub async fn hook_for_transaction<D>(tx: CallBuilder<&AlloyProvider, D>) -> anyhow::Result<Hook>
 where
     D: CallDecoder,
 {
-    let gas_limit = tx
-        .estimate_gas()
-        .await
-        .expect("transaction reverted when estimating gas");
+    let gas_limit = tx.estimate_gas().await?;
     let call_data = tx.calldata().to_vec();
     let target = tx
         .into_transaction_request()
@@ -21,9 +18,9 @@ where
         .unwrap()
         .into_legacy();
 
-    Hook {
+    Ok(Hook {
         target,
         call_data,
         gas_limit,
-    }
+    })
 }

--- a/crates/e2e/src/setup/onchain_components/mod.rs
+++ b/crates/e2e/src/setup/onchain_components/mod.rs
@@ -28,6 +28,7 @@ use {
     },
 };
 
+pub mod alloy;
 pub mod safe;
 
 #[macro_export]
@@ -46,7 +47,7 @@ macro_rules! tx_value {
 #[macro_export]
 macro_rules! tx {
     ($acc:expr_2021, $call:expr_2021) => {
-        $crate::tx_value!($acc, U256::zero(), $call)
+        $crate::tx_value!($acc, ethcontract::U256::zero(), $call)
     };
 }
 

--- a/crates/e2e/src/setup/onchain_components/safe.rs
+++ b/crates/e2e/src/setup/onchain_components/safe.rs
@@ -39,10 +39,7 @@ pub struct Infrastructure {
 }
 
 impl Infrastructure {
-    pub async fn new() -> Self {
-        // Using the NODE_HOST here kind of sucks but this is a workaround
-        // for the alloy provider signing issue
-        let provider = provider(NODE_HOST);
+    pub async fn new(provider: AlloyProvider) -> Self {
         let first_account = *provider.get_accounts().await.unwrap().first().unwrap();
 
         let singleton = {
@@ -141,8 +138,8 @@ impl Safe {
         // but it leads to boilerplate code that we don't need. Redeploying the
         // infrastructure contracts every time should have no appreciable impact in the
         // tests.
-        let infra = Infrastructure::new().await;
         let chain_id = U256::from(alloy.get_chain_id().await.unwrap());
+        let infra = Infrastructure::new(alloy).await;
         let contract = infra.deploy_safe(vec![owner.clone()], 1).await;
         Self {
             chain_id,

--- a/crates/e2e/src/setup/onchain_components/safe.rs
+++ b/crates/e2e/src/setup/onchain_components/safe.rs
@@ -1,6 +1,5 @@
 use {
     super::{OnchainComponents, TestAccount},
-    crate::nodes::NODE_HOST,
     alloy::{
         primitives::{Address, Bytes, U256},
         providers::Provider,
@@ -17,7 +16,6 @@ use {
         alloy::{
             ProviderSignerExt,
             conversions::{IntoAlloy, TryIntoAlloyAsync},
-            provider,
         },
     },
     hex_literal::hex,

--- a/crates/e2e/src/setup/onchain_components/safe.rs
+++ b/crates/e2e/src/setup/onchain_components/safe.rs
@@ -93,7 +93,7 @@ impl Infrastructure {
                 .unwrap();
         let safe = GnosisSafe::Instance::new(safe_proxy, provider.clone());
 
-        contracts::alloy::macros::tx!(
+        contracts::alloy::tx!(
             safe.setup(
                 owners
                     .into_iter()
@@ -155,7 +155,7 @@ impl Safe {
             data, value, to, ..
         } = tx.tx;
 
-        contracts::alloy::macros::tx!(
+        contracts::alloy::tx!(
             contract.execTransaction(
                 to.unwrap().into_alloy(),
                 value.unwrap_or_default().into_alloy(),

--- a/crates/e2e/src/setup/onchain_components/safe.rs
+++ b/crates/e2e/src/setup/onchain_components/safe.rs
@@ -1,91 +1,119 @@
 use {
     super::{OnchainComponents, TestAccount},
-    contracts::{
-        GnosisSafe,
+    crate::nodes::NODE_HOST,
+    alloy::{
+        primitives::{Address, Bytes, U256},
+        providers::Provider,
+    },
+    contracts::alloy::{
+        GnosisSafe::{self, GnosisSafe::execTransactionCall},
         GnosisSafeCompatibilityFallbackHandler,
         GnosisSafeProxy,
         GnosisSafeProxyFactory,
     },
-    ethcontract::{Bytes, H160, H256, U256},
+    ethcontract::transaction::TransactionBuilder,
+    ethrpc::{
+        AlloyProvider,
+        alloy::{
+            ProviderSignerExt,
+            conversions::{IntoAlloy, TryIntoAlloyAsync},
+            provider,
+        },
+    },
     hex_literal::hex,
     model::{
         DomainSeparator,
         order::OrderCreation,
         signature::{Signature, hashed_eip712_message},
     },
-    shared::ethrpc::Web3,
-    web3::{
-        signing,
-        signing::{Key, SecretKeyRef},
-    },
+    std::marker::PhantomData,
+    web3::signing::{self},
 };
 
-macro_rules! tx_safe {
-    ($acc:expr_2021, $safe:ident, $call:expr_2021) => {{
-        let call = $call;
-        $crate::tx!(
-            $acc,
-            $safe.exec_transaction(
-                call.tx.to.unwrap(),
-                call.tx.value.unwrap_or_default(),
-                ::ethcontract::Bytes(call.tx.data.unwrap_or_default().0),
-                Default::default(),
-                Default::default(),
-                Default::default(),
-                Default::default(),
-                Default::default(),
-                Default::default(),
-                $crate::setup::safe::gnosis_safe_prevalidated_signature($acc.address()),
-            )
-        );
-    }};
-}
-
 pub struct Infrastructure {
-    pub factory: GnosisSafeProxyFactory,
-    pub fallback: GnosisSafeCompatibilityFallbackHandler,
-    pub singleton: GnosisSafe,
-    web3: Web3,
+    pub factory: GnosisSafeProxyFactory::Instance,
+    pub fallback: GnosisSafeCompatibilityFallbackHandler::Instance,
+    pub singleton: GnosisSafe::Instance,
+
+    pub provider: AlloyProvider,
 }
 
 impl Infrastructure {
-    pub async fn new(web3: &Web3) -> Self {
-        let singleton = GnosisSafe::builder(web3).deploy().await.unwrap();
-        let fallback = GnosisSafeCompatibilityFallbackHandler::builder(web3)
-            .deploy()
-            .await
-            .unwrap();
-        let factory = GnosisSafeProxyFactory::builder(web3)
-            .deploy()
-            .await
-            .unwrap();
+    pub async fn new() -> Self {
+        // Using the NODE_HOST here kind of sucks but this is a workaround
+        // for the alloy provider signing issue
+        let provider = provider(NODE_HOST);
+        let first_account = *provider.get_accounts().await.unwrap().first().unwrap();
+
+        let singleton = {
+            let deployed_address = GnosisSafe::Instance::deploy_builder(provider.clone())
+                .from(first_account)
+                .deploy()
+                .await
+                .unwrap();
+            GnosisSafe::Instance::new(deployed_address, provider.clone())
+        };
+        let fallback = {
+            let deployed_address =
+                GnosisSafeCompatibilityFallbackHandler::Instance::deploy_builder(provider.clone())
+                    .from(first_account)
+                    .deploy()
+                    .await
+                    .unwrap();
+            GnosisSafeCompatibilityFallbackHandler::Instance::new(
+                deployed_address,
+                provider.clone(),
+            )
+        };
+        let factory = {
+            let deployed_address =
+                GnosisSafeProxyFactory::Instance::deploy_builder(provider.clone())
+                    .from(first_account)
+                    .deploy()
+                    .await
+                    .unwrap();
+            GnosisSafeProxyFactory::Instance::new(deployed_address, provider.clone())
+        };
+
         Self {
-            web3: web3.clone(),
             singleton,
             fallback,
             factory,
+            provider,
         }
     }
 
-    pub async fn deploy_safe(&self, owners: Vec<H160>, threshold: usize) -> GnosisSafe {
-        let safe_proxy = GnosisSafeProxy::builder(&self.web3, self.singleton.address())
-            .deploy()
-            .await
-            .unwrap();
-        let safe = GnosisSafe::at(&self.web3, safe_proxy.address());
-        safe.setup(
-            owners,
-            threshold.into(),
-            H160::default(),  // delegate call
-            Bytes::default(), // delegate call bytes
-            self.fallback.address(),
-            H160::default(), // relayer payment token
-            0.into(),        // relayer payment amount
-            H160::default(), // relayer address
-        )
-        .send()
-        .await
-        .unwrap();
+    pub async fn deploy_safe(
+        &self,
+        owners: Vec<TestAccount>,
+        threshold: usize,
+    ) -> GnosisSafe::Instance {
+        let provider = self
+            .provider
+            .with_signer(owners[0].account().clone().try_into_alloy().await.unwrap());
+        let safe_proxy =
+            GnosisSafeProxy::Instance::deploy_builder(provider.clone(), *self.singleton.address())
+                .deploy()
+                .await
+                .unwrap();
+        let safe = GnosisSafe::Instance::new(safe_proxy, provider.clone());
+
+        contracts::alloy::macros::tx!(
+            safe.setup(
+                owners
+                    .into_iter()
+                    .map(|owner| owner.address().into_alloy())
+                    .collect(),
+                U256::from(threshold),
+                Address::default(), // delegate call
+                Bytes::default(),   // delegate call bytes
+                *self.fallback.address(),
+                Address::default(), // relayer payment token
+                U256::ZERO,         // relayer payment amount
+                Address::default(), // relayer address
+            )
+        );
+
         safe
     }
 }
@@ -93,13 +121,13 @@ impl Infrastructure {
 /// Wrapper over a deployed Safe.
 pub struct Safe {
     chain_id: U256,
-    contract: GnosisSafe,
+    contract: GnosisSafe::Instance,
     owner: TestAccount,
 }
 
 impl Safe {
     /// Return a wrapper at the deployed address.
-    pub fn deployed(chain_id: U256, contract: GnosisSafe, owner: TestAccount) -> Self {
+    pub fn deployed(chain_id: U256, contract: GnosisSafe::Instance, owner: TestAccount) -> Self {
         Self {
             chain_id,
             contract,
@@ -108,14 +136,14 @@ impl Safe {
     }
 
     /// Deploy a Safe with a single owner.
-    pub async fn deploy(owner: TestAccount, web3: &Web3) -> Self {
+    pub async fn deploy(owner: TestAccount, alloy: AlloyProvider) -> Self {
         // Infrastructure contracts can in principle be reused for any new deployments,
         // but it leads to boilerplate code that we don't need. Redeploying the
         // infrastructure contracts every time should have no appreciable impact in the
         // tests.
-        let infra = Infrastructure::new(web3).await;
-        let chain_id = web3.eth().chain_id().await.unwrap();
-        let contract = infra.deploy_safe(vec![owner.address()], 1).await;
+        let infra = Infrastructure::new().await;
+        let chain_id = U256::from(alloy.get_chain_id().await.unwrap());
+        let contract = infra.deploy_safe(vec![owner.clone()], 1).await;
         Self {
             chain_id,
             contract,
@@ -128,26 +156,47 @@ impl Safe {
         tx: ethcontract::dyns::DynMethodBuilder<T>,
     ) {
         let contract = &self.contract;
-        tx_safe!(self.owner.account(), contract, tx);
+        let TransactionBuilder {
+            data, value, to, ..
+        } = tx.tx;
+
+        contracts::alloy::macros::tx!(
+            contract.execTransaction(
+                to.unwrap().into_alloy(),
+                value.unwrap_or_default().into_alloy(),
+                alloy::primitives::Bytes::from(data.unwrap_or_default().0),
+                Default::default(),
+                Default::default(),
+                Default::default(),
+                Default::default(),
+                Default::default(),
+                Default::default(),
+                crate::setup::safe::gnosis_safe_prevalidated_signature(
+                    self.owner.address().into_alloy(),
+                ),
+            ),
+            self.owner.address().into_alloy()
+        );
     }
 
     /// Returns the address of the Safe.
-    pub fn address(&self) -> H160 {
-        self.contract.address()
+    pub fn address(&self) -> alloy::primitives::Address {
+        *self.contract.address()
     }
 
     /// Returns the next nonce to be used.
-    pub async fn nonce(&self) -> U256 {
+    pub async fn nonce(&self) -> alloy::primitives::U256 {
         self.contract.nonce().call().await.unwrap()
     }
 
     /// Returns a signed transaction ready for execution.
     pub fn sign_transaction(
         &self,
-        to: H160,
+        to: alloy::primitives::Address,
         data: Vec<u8>,
-        nonce: U256,
-    ) -> ethcontract::dyns::DynMethodBuilder<bool> {
+        nonce: alloy::primitives::U256,
+    ) -> alloy::contract::CallBuilder<&contracts::alloy::Provider, PhantomData<execTransactionCall>>
+    {
         let signature = self.sign({
             // `SafeTx` struct hash computation ported from the Safe Solidity code:
             // <https://etherscan.io/address/0xd9Db270c1B5E3Bd161E8c8503c55cEABeE709552#code#F1#L377>
@@ -158,9 +207,9 @@ impl Safe {
                 // <https://etherscan.io/address/0xd9Db270c1B5E3Bd161E8c8503c55cEABeE709552#code#F1#L43>
                 "bb8310d486368db6bd6f849402fdd73ad53d316b5a4b2644ad6efe0f941286d8"
             ));
-            buffer[44..64].copy_from_slice(to.as_bytes());
+            buffer[44..64].copy_from_slice(to.as_slice());
             buffer[96..128].copy_from_slice(&signing::keccak256(&data));
-            nonce.to_big_endian(&mut buffer[320..352]);
+            nonce.copy_be_bytes_to(&mut buffer[320..352]);
 
             // Since the [`sign_transaction`] transaction method only accepts
             // a limited number of parameters and defaults to 0 for the others,
@@ -170,17 +219,17 @@ impl Safe {
             signing::keccak256(&buffer)
         });
 
-        self.contract.exec_transaction(
+        self.contract.execTransaction(
             to,
             Default::default(), // value
-            Bytes(data),
+            alloy::primitives::Bytes::from(data),
             Default::default(), // operation (= CALL)
             Default::default(), // safe tx gas
             Default::default(), // base gas
             Default::default(), // gas price
             Default::default(), // gas token
             Default::default(), // refund receiver
-            Bytes(signature),
+            alloy::primitives::Bytes::from(signature),
         )
     }
 
@@ -228,8 +277,8 @@ impl Safe {
             // <https://etherscan.io/address/0xd9Db270c1B5E3Bd161E8c8503c55cEABeE709552#code#F1#L38>
             "47e79534a245952e8b16893a336b85a3d9ea9fa8c573f3d803afb92a79469218"
         ));
-        self.chain_id.to_big_endian(&mut buffer[32..64]);
-        buffer[76..96].copy_from_slice(self.contract.address().as_bytes());
+        self.chain_id.copy_be_bytes_to(&mut buffer[32..64]);
+        buffer[76..96].copy_from_slice(self.contract.address().as_slice());
 
         DomainSeparator(signing::keccak256(&buffer))
     }
@@ -260,42 +309,11 @@ impl Safe {
 /// See:
 /// - Documentation: <https://docs.gnosis-safe.io/contracts/signatures#pre-validated-signatures>
 /// - Code: <https://github.com/safe-global/safe-contracts/blob/c36bcab46578a442862d043e12a83fec41143dec/contracts/GnosisSafe.sol#L287-L291>
-pub fn gnosis_safe_prevalidated_signature(owner: H160) -> Bytes<Vec<u8>> {
+pub fn gnosis_safe_prevalidated_signature(
+    owner: alloy::primitives::Address,
+) -> alloy::primitives::Bytes {
     let mut signature = vec![0; 65];
-    signature[12..32].copy_from_slice(owner.as_bytes());
+    signature[12..32].copy_from_slice(owner.as_slice());
     signature[64] = 1;
-    Bytes(signature)
-}
-
-/// Generate an owner signature for EIP-1271.
-///
-/// The Gnosis Safe uses off-chain ECDSA signatures from its owners as the
-/// signature bytes when validating EIP-1271 signatures. Specifically, it
-/// expects a signed EIP-712 `SafeMessage(bytes message)` (where `message` is
-/// the 32-byte hash of the data being verified).
-///
-/// See:
-/// - Code: <https://github.com/safe-global/safe-contracts/blob/c36bcab46578a442862d043e12a83fec41143dec/contracts/handler/CompatibilityFallbackHandler.sol#L66-L70>
-pub async fn gnosis_safe_eip1271_signature(
-    key: SecretKeyRef<'_>,
-    safe: &GnosisSafe,
-    message_hash: H256,
-) -> Vec<u8> {
-    let handler =
-        GnosisSafeCompatibilityFallbackHandler::at(&safe.raw_instance().web3(), safe.address());
-
-    let signing_hash = handler
-        .get_message_hash(Bytes(message_hash.as_bytes().to_vec()))
-        .call()
-        .await
-        .unwrap();
-
-    let signature = key.sign(&signing_hash.0, None).unwrap();
-
-    let mut bytes = vec![0u8; 65];
-    bytes[0..32].copy_from_slice(signature.r.as_bytes());
-    bytes[32..64].copy_from_slice(signature.s.as_bytes());
-    bytes[64] = signature.v as _;
-
-    bytes
+    alloy::primitives::Bytes::from(signature)
 }

--- a/crates/e2e/tests/e2e/app_data.rs
+++ b/crates/e2e/tests/e2e/app_data.rs
@@ -1,7 +1,6 @@
 use {
     app_data::{AppDataHash, hash_full_app_data},
     e2e::{setup::*, tx},
-    ethcontract::prelude::U256,
     model::{
         order::{OrderCreation, OrderCreationAppData, OrderKind},
         quote::{OrderQuoteRequest, OrderQuoteSide, SellAmount},

--- a/crates/e2e/tests/e2e/banned_users.rs
+++ b/crates/e2e/tests/e2e/banned_users.rs
@@ -11,7 +11,7 @@ use {
         },
         tx,
     },
-    ethcontract::{H160, prelude::U256},
+    ethcontract::H160,
     ethrpc::Web3,
     model::quote::{OrderQuoteRequest, OrderQuoteSide, SellAmount},
     reqwest::StatusCode,

--- a/crates/e2e/tests/e2e/buffers.rs
+++ b/crates/e2e/tests/e2e/buffers.rs
@@ -1,6 +1,5 @@
 use {
     e2e::{setup::*, tx},
-    ethcontract::prelude::U256,
     model::{
         order::{OrderCreation, OrderKind},
         signature::EcdsaSigningScheme,

--- a/crates/e2e/tests/e2e/eth_integration.rs
+++ b/crates/e2e/tests/e2e/eth_integration.rs
@@ -1,6 +1,6 @@
 use {
     e2e::{setup::*, tx},
-    ethcontract::prelude::{Address, U256},
+    ethcontract::prelude::Address,
     model::{
         order::{BUY_ETH_ADDRESS, OrderCreation, OrderKind},
         quote::{OrderQuoteRequest, OrderQuoteSide, SellAmount},

--- a/crates/e2e/tests/e2e/hooks.rs
+++ b/crates/e2e/tests/e2e/hooks.rs
@@ -1,12 +1,23 @@
 use {
+    alloy::providers::Provider,
     app_data::Hook,
-    contracts::GnosisSafe,
     e2e::{
-        setup::{safe::Safe, *},
+        setup::{
+            OnchainComponents,
+            Services,
+            TIMEOUT,
+            hook_for_transaction,
+            onchain_components,
+            run_test,
+            safe::Safe,
+            to_wei,
+            wait_for_condition,
+        },
         tx,
         tx_value,
     },
-    ethcontract::{Bytes, H160, U256},
+    ethcontract::U256,
+    ethrpc::alloy::conversions::{IntoAlloy, IntoLegacy},
     model::{
         order::{OrderCreation, OrderCreationAppData, OrderKind},
         quote::{OrderQuoteRequest, OrderQuoteSide, SellAmount},
@@ -239,67 +250,72 @@ async fn allowance(web3: Web3) {
 async fn signature(web3: Web3) {
     let mut onchain = OnchainComponents::deploy(web3.clone()).await;
 
-    let chain_id = web3.eth().chain_id().await.unwrap();
+    let chain_id = alloy::primitives::U256::from(web3.alloy.get_chain_id().await.unwrap());
 
     let [solver] = onchain.make_solvers(to_wei(1)).await;
     let [trader] = onchain.make_accounts(to_wei(1)).await;
 
-    let safe_infra = safe::Infrastructure::new(&web3).await;
+    let safe_infra = onchain_components::safe::Infrastructure::new().await;
 
     // Prepare the Safe creation transaction, but don't execute it! This will
     // be executed as a pre-hook.
-    let safe_creation_builder = safe_infra.factory.create_proxy(
-        safe_infra.singleton.address(),
-        ethcontract::Bytes(
-            safe_infra
-                .singleton
-                .setup(
-                    vec![trader.address()], // owners
-                    1.into(),               // threshold
-                    H160::default(),        // delegate call
-                    Bytes::default(),       // delegate call bytes
-                    safe_infra.fallback.address(),
-                    H160::default(), // relayer payment token
-                    0.into(),        // relayer payment amount
-                    H160::default(), // relayer address
-                )
-                .tx
-                .data
-                .unwrap()
-                .0,
-        ),
+    let safe_creation_builder = safe_infra.factory.createProxy(
+        *safe_infra.singleton.address(),
+        safe_infra
+            .singleton
+            .setup(
+                vec![trader.address().into_alloy()],   // owners
+                alloy::primitives::U256::ONE,          // threshold
+                alloy::primitives::Address::default(), // delegate call
+                alloy::primitives::Bytes::default(),   // delegate call bytes
+                *safe_infra.fallback.address(),
+                alloy::primitives::Address::default(), // relayer payment token
+                alloy::primitives::U256::ZERO,         // relayer payment amount
+                alloy::primitives::Address::default(), // relayer address
+            )
+            .calldata()
+            .clone(),
     );
-    let safe_creation = hook_for_transaction(safe_creation_builder.tx.clone()).await;
+    let safe_creation =
+        onchain_components::alloy::hook_for_transaction(safe_creation_builder.clone()).await;
 
     // Create a contract instance at the would-be address of the Safe we are
     // creating with the pre-hook.
-    let safe_address = safe_creation_builder.clone().view().call().await.unwrap();
+    let safe_address = safe_creation_builder.clone().call().await.unwrap();
     let safe = Safe::deployed(
         chain_id,
-        GnosisSafe::at(&web3, safe_address),
+        contracts::alloy::GnosisSafe::Instance::new(safe_address, web3.alloy.clone()),
         trader.clone(),
     );
 
     let [token] = onchain
         .deploy_tokens_with_weth_uni_v2_pools(to_wei(100_000), to_wei(100_000))
         .await;
-    token.mint(safe.address(), to_wei(5)).await;
+    token.mint(safe.address().into_legacy(), to_wei(5)).await;
 
     // Sign an approval transaction for trading. This will be at nonce 0 because
     // it is the first transaction evah!
     let approval_builder = safe.sign_transaction(
-        token.address(),
+        token.address().into_alloy(),
         token
             .approve(onchain.contracts().allowance, to_wei(5))
             .tx
             .data
             .unwrap()
             .0,
-        0.into(),
+        alloy::primitives::U256::ZERO,
     );
+    let call_data = approval_builder.calldata().to_vec();
+    let target = approval_builder
+        .into_transaction_request()
+        .to
+        .unwrap()
+        .into_to()
+        .unwrap()
+        .into_legacy();
     let approval = Hook {
-        target: approval_builder.tx.to.unwrap(),
-        call_data: approval_builder.tx.data.unwrap().0,
+        target,
+        call_data,
         // The contract isn't deployed, so we can't estimate this. Instead, we
         // just guess an amount that should be high enough.
         gas_limit: 100_000,
@@ -311,7 +327,7 @@ async fn signature(web3: Web3) {
 
     // Place Orders
     let mut order = OrderCreation {
-        from: Some(safe.address()),
+        from: Some(safe.address().into_legacy()),
         // Quotes for trades where the pre-interactions deploy a contract
         // at the `from` address currently can't be verified.
         // To not throw an error because we can't get a verifiable quote
@@ -344,17 +360,25 @@ async fn signature(web3: Web3) {
     services.create_order(&order).await.unwrap();
     onchain.mint_block().await;
 
-    let balance = token.balance_of(safe.address()).call().await.unwrap();
+    let balance = token
+        .balance_of(safe.address().into_legacy())
+        .call()
+        .await
+        .unwrap();
     assert_eq!(balance, to_wei(5));
 
     // Check that the Safe really hasn't been deployed yet.
-    let code = web3.eth().code(safe.address(), None).await.unwrap();
+    let code = web3
+        .eth()
+        .code(safe.address().into_legacy(), None)
+        .await
+        .unwrap();
     assert_eq!(code.0.len(), 0);
 
     tracing::info!("Waiting for trade.");
     let trade_happened = || async {
         token
-            .balance_of(safe.address())
+            .balance_of(safe.address().into_legacy())
             .call()
             .await
             .unwrap()
@@ -367,14 +391,18 @@ async fn signature(web3: Web3) {
     let balance = onchain
         .contracts()
         .weth
-        .balance_of(safe.address())
+        .balance_of(safe.address().into_legacy())
         .call()
         .await
         .unwrap();
     assert!(balance >= order.buy_amount);
 
     // Check Safe was deployed
-    let code = web3.eth().code(safe.address(), None).await.unwrap();
+    let code = web3
+        .eth()
+        .code(safe.address().into_legacy(), None)
+        .await
+        .unwrap();
     assert_ne!(code.0.len(), 0);
 
     tracing::info!("Waiting for auction to be cleared.");
@@ -489,69 +517,74 @@ async fn partial_fills(web3: Web3) {
 async fn quote_verification(web3: Web3) {
     let mut onchain = OnchainComponents::deploy(web3.clone()).await;
 
-    let chain_id = web3.eth().chain_id().await.unwrap();
+    let chain_id = alloy::primitives::U256::from(web3.alloy.get_chain_id().await.unwrap());
 
     let [trader] = onchain.make_accounts(to_wei(1)).await;
     let [solver] = onchain.make_solvers(to_wei(1)).await;
 
-    let safe_infra = safe::Infrastructure::new(&web3).await;
+    let safe_infra = onchain_components::safe::Infrastructure::new().await;
 
     // Prepare the Safe creation transaction, but don't execute it! This will
     // be executed as a pre-hook.
-    let safe_creation_builder = safe_infra.factory.create_proxy(
-        safe_infra.singleton.address(),
-        ethcontract::Bytes(
-            safe_infra
-                .singleton
-                .setup(
-                    vec![trader.address()], // owners
-                    1.into(),               // threshold
-                    H160::default(),        // delegate call
-                    Bytes::default(),       // delegate call bytes
-                    safe_infra.fallback.address(),
-                    H160::default(), // relayer payment token
-                    0.into(),        // relayer payment amount
-                    H160::default(), // relayer address
-                )
-                .tx
-                .data
-                .unwrap()
-                .0,
-        ),
+    let safe_creation_builder = safe_infra.factory.createProxy(
+        *safe_infra.singleton.address(),
+        safe_infra
+            .singleton
+            .setup(
+                vec![trader.address().into_alloy()],   // owners
+                alloy::primitives::U256::ONE,          // threshold
+                alloy::primitives::Address::default(), // delegate call
+                alloy::primitives::Bytes::default(),   // delegate call bytes
+                *safe_infra.fallback.address(),
+                alloy::primitives::Address::default(), // relayer payment token
+                alloy::primitives::U256::ZERO,         // relayer payment amount
+                alloy::primitives::Address::default(), // relayer address
+            )
+            .calldata()
+            .clone(),
     );
-    let safe_address = safe_creation_builder.clone().view().call().await.unwrap();
-    safe_creation_builder.clone().send().await.unwrap();
+    let safe_address = safe_creation_builder.clone().call().await.unwrap();
+    let first_account = *web3.alloy.get_accounts().await.unwrap().first().unwrap();
+    contracts::alloy::macros::tx!(safe_creation_builder, first_account);
 
     let safe = Safe::deployed(
         chain_id,
-        GnosisSafe::at(&web3, safe_address),
+        contracts::alloy::GnosisSafe::Instance::new(safe_address, web3.alloy.clone()),
         trader.clone(),
     );
 
     let [token] = onchain
         .deploy_tokens_with_weth_uni_v2_pools(to_wei(100_000), to_wei(100_000))
         .await;
-    token.mint(safe.address(), to_wei(5)).await;
+    token.mint(safe.address().into_legacy(), to_wei(5)).await;
     tx!(
         trader.account(),
         token.approve(onchain.contracts().allowance, to_wei(5))
     );
 
-    // Sign transaction transfering 5 token from the safe to the trader
+    // Sign transaction transferring 5 token from the safe to the trader
     // to fund the trade in a pre-hook.
     let transfer_builder = safe.sign_transaction(
-        token.address(),
+        token.address().into_alloy(),
         token
             .transfer(trader.address(), to_wei(5))
             .tx
             .data
             .unwrap()
             .0,
-        0.into(),
+        alloy::primitives::U256::ZERO,
     );
+    let call_data = transfer_builder.calldata().to_vec();
+    let target = transfer_builder
+        .into_transaction_request()
+        .to
+        .unwrap()
+        .into_to()
+        .unwrap()
+        .into_legacy();
     let transfer = Hook {
-        target: transfer_builder.tx.to.unwrap(),
-        call_data: transfer_builder.tx.data.unwrap().0,
+        target,
+        call_data,
         gas_limit: 100_000,
     };
 

--- a/crates/e2e/tests/e2e/hooks.rs
+++ b/crates/e2e/tests/e2e/hooks.rs
@@ -547,7 +547,7 @@ async fn quote_verification(web3: Web3) {
     );
     let safe_address = safe_creation_builder.clone().call().await.unwrap();
     let first_account = *web3.alloy.get_accounts().await.unwrap().first().unwrap();
-    contracts::alloy::macros::tx!(safe_creation_builder, first_account);
+    contracts::alloy::tx!(safe_creation_builder, first_account);
 
     let safe = Safe::deployed(
         chain_id,

--- a/crates/e2e/tests/e2e/hooks.rs
+++ b/crates/e2e/tests/e2e/hooks.rs
@@ -255,7 +255,7 @@ async fn signature(web3: Web3) {
     let [solver] = onchain.make_solvers(to_wei(1)).await;
     let [trader] = onchain.make_accounts(to_wei(1)).await;
 
-    let safe_infra = onchain_components::safe::Infrastructure::new().await;
+    let safe_infra = onchain_components::safe::Infrastructure::new(web3.alloy.clone()).await;
 
     // Prepare the Safe creation transaction, but don't execute it! This will
     // be executed as a pre-hook.
@@ -522,7 +522,7 @@ async fn quote_verification(web3: Web3) {
     let [trader] = onchain.make_accounts(to_wei(1)).await;
     let [solver] = onchain.make_solvers(to_wei(1)).await;
 
-    let safe_infra = onchain_components::safe::Infrastructure::new().await;
+    let safe_infra = onchain_components::safe::Infrastructure::new(web3.alloy.clone()).await;
 
     // Prepare the Safe creation transaction, but don't execute it! This will
     // be executed as a pre-hook.

--- a/crates/e2e/tests/e2e/hooks.rs
+++ b/crates/e2e/tests/e2e/hooks.rs
@@ -277,7 +277,9 @@ async fn signature(web3: Web3) {
             .clone(),
     );
     let safe_creation =
-        onchain_components::alloy::hook_for_transaction(safe_creation_builder.clone()).await;
+        onchain_components::alloy::hook_for_transaction(safe_creation_builder.clone())
+            .await
+            .unwrap();
 
     // Create a contract instance at the would-be address of the Safe we are
     // creating with the pre-hook.

--- a/crates/e2e/tests/e2e/order_cancellation.rs
+++ b/crates/e2e/tests/e2e/order_cancellation.rs
@@ -1,7 +1,6 @@
 use {
     database::order_events::OrderEventLabel,
     e2e::{setup::*, tx},
-    ethcontract::prelude::U256,
     model::{
         order::{
             CancellationPayload,

--- a/crates/e2e/tests/e2e/place_order_with_quote.rs
+++ b/crates/e2e/tests/e2e/place_order_with_quote.rs
@@ -1,7 +1,6 @@
 use {
     driver::domain::eth::NonZeroU256,
     e2e::{nodes::local_node::TestNodeApi, setup::*, tx, tx_value},
-    ethcontract::U256,
     model::{
         order::{OrderCreation, OrderKind},
         quote::{OrderQuoteRequest, OrderQuoteSide, SellAmount},

--- a/crates/e2e/tests/e2e/quoting.rs
+++ b/crates/e2e/tests/e2e/quoting.rs
@@ -4,7 +4,6 @@ use {
         tx,
         tx_value,
     },
-    ethcontract::prelude::U256,
     futures::FutureExt,
     model::{
         order::{OrderCreation, OrderCreationAppData, OrderKind},

--- a/crates/e2e/tests/e2e/submission.rs
+++ b/crates/e2e/tests/e2e/submission.rs
@@ -1,6 +1,6 @@
 use {
     e2e::{nodes::local_node::TestNodeApi, setup::*, tx, tx_value},
-    ethcontract::{BlockId, H160, H256, U256},
+    ethcontract::{BlockId, H160, H256},
     futures::{Stream, StreamExt},
     model::{
         order::{OrderCreation, OrderKind},

--- a/crates/e2e/tests/e2e/tracking_insufficient_funds.rs
+++ b/crates/e2e/tests/e2e/tracking_insufficient_funds.rs
@@ -1,7 +1,6 @@
 use {
     database::order_events::{OrderEvent, OrderEventLabel},
     e2e::{setup::*, tx, tx_value},
-    ethcontract::U256,
     model::{
         order::{OrderCreation, OrderKind},
         signature::EcdsaSigningScheme,

--- a/crates/e2e/tests/e2e/uncovered_order.rs
+++ b/crates/e2e/tests/e2e/uncovered_order.rs
@@ -1,6 +1,5 @@
 use {
     e2e::{setup::*, tx, tx_value},
-    ethcontract::U256,
     model::{
         order::{OrderCreation, OrderKind},
         signature::EcdsaSigningScheme,

--- a/crates/e2e/tests/e2e/vault_balances.rs
+++ b/crates/e2e/tests/e2e/vault_balances.rs
@@ -1,6 +1,5 @@
 use {
     e2e::{setup::*, tx},
-    ethcontract::prelude::U256,
     model::{
         order::{OrderCreation, OrderKind, SellTokenSource},
         signature::EcdsaSigningScheme,

--- a/crates/ethrpc/Cargo.toml
+++ b/crates/ethrpc/Cargo.toml
@@ -6,17 +6,20 @@ edition = "2024"
 license = "GPL-3.0-or-later"
 
 [lib]
+doctest = false
 name = "ethrpc"
 path = "src/lib.rs"
-doctest = false
 
 [dependencies]
 alloy = { workspace = true, default-features = false, features = ["json-rpc", "providers", "rpc-client", "transports", "reqwest", "signers", "signer-aws", "signer-local", "eips"] }
 anyhow = { workspace = true }
 async-trait = { workspace = true }
+contracts = { workspace = true }
+ethcontract = { workspace = true }
 futures = { workspace = true }
 hex = { workspace = true }
 hex-literal = { workspace = true }
+itertools = { workspace = true }
 mockall = { workspace = true }
 observe = { workspace = true }
 primitive-types = { workspace = true }
@@ -28,17 +31,17 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 tokio = { workspace = true, features = [] }
 tokio-stream = { workspace = true }
-web3 = { workspace = true }
-contracts = { workspace = true }
-ethcontract = { workspace = true }
+tower = { workspace = true }
 tracing = { workspace = true }
 url = { workspace = true }
-itertools = { workspace = true }
-tower = { workspace = true }
+web3 = { workspace = true }
 
 [dev-dependencies]
 maplit = { workspace = true }
 testlib = { workspace = true }
+
+[features]
+test-util = []
 
 [lints]
 workspace = true


### PR DESCRIPTION
# Description
Migrates the GnosisSafe* contracts to alloy-rs

# Changes
<!-- List of detailed changes (how the change is accomplished) -->

- [ ] Migrate `GnosisSafe`, `GnosisSafeProxy`, `GnosisSafeProxyFactory` and `GnosisSafeCompatibilityFallbackHandler`
- [ ] Removes the `web3` value from `safe::Infrastructure`, it was no longer needed due to the refactors needed to work around the lack of way to sign transactions with a different signer than the provider's one
- [ ] Removes `gnosis_safe_eip1271_signature` due to not being used anywhere

## How to test
Run all tests

