### PR TITLE
Avoid clones for unchanging appdatas

### DIFF
--- a/crates/driver/src/domain/competition/mod.rs
+++ b/crates/driver/src/domain/competition/mod.rs
@@ -395,7 +395,7 @@ impl Competition {
     fn update_orders(
         mut auction: Auction,
         balances: Arc<Balances>,
-        app_data: Arc<HashMap<order::app_data::AppDataHash, app_data::ValidatedAppData>>,
+        app_data: Arc<HashMap<order::app_data::AppDataHash, Arc<app_data::ValidatedAppData>>>,
         cow_amm_orders: Arc<Vec<Order>>,
         settlement_contract: &eth::Address,
     ) -> Auction {

--- a/crates/driver/src/domain/competition/pre_processing.rs
+++ b/crates/driver/src/domain/competition/pre_processing.rs
@@ -35,7 +35,8 @@ type Balances = HashMap<BalanceGroup, order::SellAmount>;
 #[derive(Clone, Debug)]
 pub struct DataFetchingTasks {
     pub balances: Shared<Arc<Balances>>,
-    pub app_data: Shared<Arc<HashMap<order::app_data::AppDataHash, app_data::ValidatedAppData>>>,
+    pub app_data:
+        Shared<Arc<HashMap<order::app_data::AppDataHash, Arc<app_data::ValidatedAppData>>>>,
     pub cow_amm_orders: Shared<Arc<Vec<Order>>>,
     pub liquidity: Shared<Arc<Vec<liquidity::Liquidity>>>,
 }
@@ -237,7 +238,7 @@ impl Utilities {
     async fn collect_orders_app_data(
         self: Arc<Self>,
         auction: Arc<Auction>,
-    ) -> Arc<HashMap<order::app_data::AppDataHash, app_data::ValidatedAppData>> {
+    ) -> Arc<HashMap<order::app_data::AppDataHash, Arc<app_data::ValidatedAppData>>> {
         let Some(app_data_retriever) = &self.app_data_retriever else {
             return Default::default();
         };

--- a/crates/driver/src/tests/cases/flashloan_hints.rs
+++ b/crates/driver/src/tests/cases/flashloan_hints.rs
@@ -8,6 +8,7 @@ use {
     },
     app_data::{Flashloan, ProtocolAppData, hash_full_app_data},
     primitive_types::H160,
+    std::sync::Arc,
 };
 
 #[tokio::test]
@@ -23,7 +24,7 @@ async fn solutions_with_flashloan() {
         flashloan: Some(flashloan.clone()),
         ..Default::default()
     };
-    let app_data = AppData::Full(Box::new(protocol_app_data_into_validated(
+    let app_data = AppData::Full(Arc::new(protocol_app_data_into_validated(
         protocol_app_data,
     )));
 
@@ -59,7 +60,7 @@ async fn solutions_without_flashloan() {
         flashloan: Some(flashloan.clone()),
         ..Default::default()
     };
-    let app_data = AppData::Full(Box::new(protocol_app_data_into_validated(
+    let app_data = AppData::Full(Arc::new(protocol_app_data_into_validated(
         protocol_app_data,
     )));
     let settlement = H160([5; 20]);


### PR DESCRIPTION
# Description
The data behind appdata structs never changes so we can easily avoid expensive clones by storing them in `Arc`s and cheaply cloning those.

# Changes
- store appdata inside `Arc`s

## How to test
ran an experiment on shadow mainnet and compared flamegraphs. The screenshots show the optimization specifically inside `update_orders` but that's not the only place where this optimization comes into play.

Before
<img width="1918" height="818" alt="Screenshot 2025-09-01 at 07 25 20" src="https://github.com/user-attachments/assets/c9b3586c-3642-492f-aae5-589cf1376894" />

After
<img width="1913" height="388" alt="Screenshot 2025-09-01 at 07 25 56" src="https://github.com/user-attachments/assets/7c802aa7-12d1-4a9e-8e41-179700dd11c5" />
