### PR TITLE
Faster implementation of math for `x * q / d`

### DIFF
--- a/crates/driver/src/util/math.rs
+++ b/crates/driver/src/util/math.rs
@@ -11,8 +11,15 @@ pub fn mul_ratio(x: U256, q: U256, d: U256) -> Option<U256> {
 ///
 /// Returns `None` if `d` is `0` or if the result overflows a 256-bit integer.
 pub fn mul_ratio_ceil(x: U256, q: U256, d: U256) -> Option<U256> {
+    if d.is_zero() {
+        return None;
+    }
+
     let p = x.full_mul(q);
-    let result = U256::try_from(p.checked_div(d.into())?).ok()?;
-    let round_up = !p.checked_rem(d.into())?.is_zero();
-    result.checked_add(u8::from(round_up).into())
+    let (div, rem) = p.div_mod(d.into());
+    let mut result = U256::try_from(div).ok()?;
+    if !rem.is_zero() {
+        result = result.checked_add(U256::one())?;
+    }
+    Some(result)
 }

--- a/crates/driver/src/util/math.rs
+++ b/crates/driver/src/util/math.rs
@@ -4,6 +4,15 @@ use ethereum_types::U256;
 ///
 /// Returns `None` if `d` is `0` or if the result overflows a 256-bit integer.
 pub fn mul_ratio(x: U256, q: U256, d: U256) -> Option<U256> {
+    if d.is_zero() {
+        return None;
+    }
+
+    // fast path when math in U256 doesn't overflow
+    if let Some(res) = x.checked_mul(q) {
+        return Some(res / d);
+    }
+
     x.full_mul(q).checked_div(d.into())?.try_into().ok()
 }
 
@@ -15,11 +24,14 @@ pub fn mul_ratio_ceil(x: U256, q: U256, d: U256) -> Option<U256> {
         return None;
     }
 
+    // fast path when math in U256 doesn't overflow
+    if let Some(p) = x.checked_mul(q) {
+        let (div, rem) = p.div_mod(d);
+        return div.checked_add(u8::from(!rem.is_zero()).into());
+    }
+
     let p = x.full_mul(q);
     let (div, rem) = p.div_mod(d.into());
-    let mut result = U256::try_from(div).ok()?;
-    if !rem.is_zero() {
-        result = result.checked_add(U256::one())?;
-    }
-    Some(result)
+    let result = U256::try_from(div).ok()?;
+    result.checked_add(u8::from(!rem.is_zero()).into())
 }


### PR DESCRIPTION
# Description
This PR optimizes `driver::util::mul_ratio` and `driver::util::mul_ratio_ceil`.
These functions actually use up the majority of time inside `update_orders` which is a critical step in the auction pre-processing.

# Changes
- added a fast path that tries to do the computation with `U256` because `U512` is basically never needed
- replaced the individual `div()` and `mod()` operations with `div_mod()` that does both in one go

## How to test
ran an experiment in the shadow competition