### PR TITLE
Speed up `update_orders` pre-processing step

### DIFF
--- a/crates/driver/src/domain/competition/bad_tokens/mod.rs
+++ b/crates/driver/src/domain/competition/bad_tokens/mod.rs
@@ -66,7 +66,7 @@ impl Detector {
 
         let mut supported_orders = Vec::with_capacity(auction.orders.len());
         let mut token_quality_checks = FuturesUnordered::new();
-        let mut removed_uids = Vec::with_capacity(auction.orders.len());
+        let mut removed_uids = Vec::new();
 
         for order in auction.orders {
             let sell = self.get_token_quality(order.sell.token, now);

--- a/crates/driver/src/domain/competition/bad_tokens/mod.rs
+++ b/crates/driver/src/domain/competition/bad_tokens/mod.rs
@@ -104,7 +104,6 @@ impl Detector {
 
         while let Some((order, quality)) = token_quality_checks.next().await {
             if quality == Quality::Supported {
-                // if we use retain to reuse the allocation we have to clone orders...
                 supported_orders.push(order);
             } else {
                 removed_uids.push(order.uid);

--- a/crates/driver/src/domain/competition/bad_tokens/mod.rs
+++ b/crates/driver/src/domain/competition/bad_tokens/mod.rs
@@ -1,6 +1,6 @@
 use {
     crate::domain::{competition::Auction, eth},
-    futures::{StreamExt, future::join_all, stream::FuturesUnordered},
+    futures::{StreamExt, stream::FuturesUnordered},
     std::{collections::HashMap, fmt, time::Instant},
 };
 
@@ -65,7 +65,7 @@ impl Detector {
         let now = Instant::now();
 
         // reuse the original allocation
-        let supported_orders = std::mem::replace(&mut auction.orders, Vec::new());
+        let supported_orders = std::mem::take(&mut auction.orders);
         let mut token_quality_checks = FuturesUnordered::new();
         let mut removed_uids = Vec::new();
 


### PR DESCRIPTION
# Description
`update_orders` is on the critical path inside the auction pre-processing phase. The majority of runtime was dictated by running `join_all` and allocating memory. This PR optimizes both of these things.

# Changes
Instead of creating a future for all orders even when only 1 branch actually returns a future we now separate out only the futures that actually need to run.
Also instead of collecting results into different vectors we now reuse the original `orders` vector. First we discard the clearly unsupported and questionable orders (questionable orders are the ones that we run a future for) and later we put back the questionable orders that came back okay.

## How to test
ran experiment on shadow environment and compared flamegraphs. I highlighted the `get_token_quality` function show how much more time is now spent doing actual work instead of shuffling allocations around and polling futures needlessly.

Before
<img width="1920" height="911" alt="Screenshot 2025-09-01 at 07 44 46" src="https://github.com/user-attachments/assets/cc2ed60c-55d9-428f-9c6e-c738d879022e" />

After
<img width="1920" height="943" alt="Screenshot 2025-09-01 at 07 44 49" src="https://github.com/user-attachments/assets/2e11a1bf-5fde-46ad-947b-a8dedfec6f85" />
