### PR TITLE
Drop `from` field from the access lists simulation call

### DIFF
--- a/crates/driver/src/infra/blockchain/token.rs
+++ b/crates/driver/src/infra/blockchain/token.rs
@@ -140,7 +140,6 @@ impl Erc20 {
 
                         let access_list_call = CallRequest {
                             data: delegate_call.tx.data.clone(),
-                            from: delegate_call.tx.from.clone().map(|acc| acc.address()),
                             ..Default::default()
                         };
                         let access_list = ethereum

--- a/crates/driver/src/infra/blockchain/token.rs
+++ b/crates/driver/src/infra/blockchain/token.rs
@@ -140,6 +140,9 @@ impl Erc20 {
 
                         let access_list_call = CallRequest {
                             data: delegate_call.tx.data.clone(),
+                            // `from` field is not populated, since it is only required for ZkSync
+                            // chains, that currently don't support access lists. On other chains,
+                            // access lists creation fails when an arbitrary `from` is used.
                             ..Default::default()
                         };
                         let access_list = ethereum


### PR DESCRIPTION
# Description
Drops the `from` field from the access lists call since it currently fails on every chain. This logic was initially added when adapting services for the Lens chain, where `from` is required, but since access lists are not supported on ZKSync, we can simply remove it.
