### PR TITLE
Pre allocate request buffer

### DIFF
--- a/crates/solvers-dto/src/lib.rs
+++ b/crates/solvers-dto/src/lib.rs
@@ -47,8 +47,7 @@ mod serialize {
 
     impl SerializeAs<Vec<u8>> for Hex {
         fn serialize_as<S: Serializer>(source: &Vec<u8>, serializer: S) -> Result<S::Ok, S::Error> {
-            let hex = hex::encode(source);
-            serializer.serialize_str(&format!("0x{hex}"))
+            serializer.serialize_str(&bytes_to_hex_string(source.as_ref()))
         }
     }
 
@@ -97,8 +96,17 @@ mod serialize {
 
     impl<const N: usize> SerializeAs<[u8; N]> for Hex {
         fn serialize_as<S: Serializer>(source: &[u8; N], serializer: S) -> Result<S::Ok, S::Error> {
-            let hex = hex::encode(source);
-            serializer.serialize_str(&format!("0x{hex}"))
+            serializer.serialize_str(&bytes_to_hex_string(source))
         }
+    }
+
+    fn bytes_to_hex_string(bytes: &[u8]) -> String {
+        let mut v = vec![0u8; 2 + bytes.len() * 2];
+        v[0] = b'0';
+        v[1] = b'x';
+        // Unwrap because only possible error is vector wrong size which cannot happen.
+        hex::encode_to_slice(bytes, &mut v[2..]).unwrap();
+        // Unwrap because encoded data is always valid utf8.
+        String::from_utf8(v).unwrap()
     }
 }


### PR DESCRIPTION
# Description
Serialization is still a huge part of the CPU time used by the driver. Unfortunately the biggest chunk of time is spent serializing orders and due to a subtle detail it's not straight forward to serialize each order once and reuse the serialized representation.
That's why for now the best bet is to actually make serializing each /solve request faster in general.

# Changes
- pre-allocate buffer that is big enough to avoid re-allocating during the serialization. I approximated the size of the request by dividing the size of a `/solve` request coming from the autopilot (e.g. [here](https://solver-instances.s3.eu-central-1.amazonaws.com/prod/mainnet/autopilot/11320821.json)) by the number of orders included (as those contribute the most to the size). Note that the autoilot /solve request is not completely identical to the driver /solve request but it seems like we currently don't store that data and the approximation should be pretty good.
- faster implementation of serializing hex strings (taken from our `bytes-hex` crate)

## How to test
ran in shadow and generated flamegraphs

BEFORE (re-allocations)
<img width="1899" height="740" alt="Screenshot 2025-09-03 at 08 50 19" src="https://github.com/user-attachments/assets/822f5e80-a39e-4f5b-b92c-7f932033f061" />
AFTER (re-allocations)
<img width="1904" height="777" alt="Screenshot 2025-09-03 at 08 50 35" src="https://github.com/user-attachments/assets/8f205ddd-ab1f-4c5a-b252-b37496dae0f0" />

BEFORE (hex serialization)
<img width="1919" height="532" alt="Screenshot 2025-09-03 at 08 54 25" src="https://github.com/user-attachments/assets/dd8933df-0a46-4704-a506-74a8bfa61a3f" />
AFTER (hex serialization)
<img width="1920" height="633" alt="Screenshot 2025-09-03 at 08 54 30" src="https://github.com/user-attachments/assets/221bbc02-3f2f-465d-b642-ee52f43e703a" />

