### PR TITLE
fix: Eliminate Arc ping-pong pattern in competition solving

### DIFF
--- a/crates/driver/src/domain/competition/mod.rs
+++ b/crates/driver/src/domain/competition/mod.rs
@@ -112,9 +112,9 @@ impl Competition {
     /// Solve an auction as part of this competition.
     #[instrument(skip_all)]
     pub async fn solve(&self, auction: Auction) -> Result<Option<Solved>, Error> {
-        let auction = Arc::new(auction);
-        let tasks = self.fetcher.start_or_get_tasks_for_auction(auction.clone());
-        let mut auction = Arc::unwrap_or_clone(auction);
+        // Start data fetching tasks for the auction
+        let tasks = self.fetcher.start_or_get_tasks_for_auction(&auction);
+        let mut auction = auction;
 
         let settlement_contract = self.eth.contracts().settlement().address();
         let solver_address = self.solver.account().address();


### PR DESCRIPTION
# Description

This PR would eliminate the Arc ping-pong anti-pattern in the competition solving hot path, which would reduce atomic operations and memory allocations during auction processing. 

## Changes Made

### 1. `crates/driver/src/domain/competition/mod.rs`

This is the Arc Ping-Pong Anti-Pattern, where the code is basically just wrapping data in Arc, immediately cloning it, and then unwrapping it back to owned data.
```rust
let auction = Arc::new(auction);                  
let tasks = self.fetcher.start_or_get_tasks_for_auction(auction.clone()); 
let mut auction = Arc::unwrap_or_clone(auction);   
```
Which would become
```rust
let tasks = self.fetcher.start_or_get_tasks_for_auction(&auction);
let mut auction = auction;
```

Instead of wrapping the auction immediately into an Arc, cloning it, and then unwrapping it back to an owned value, the code would pass a reference `&auction` directly to `start_or_get_tasks_for_auction`.

### 2. `crates/driver/src/domain/competition/pre_processing.rs` (excluding function signature update)

Here the function would accept a reference and create the Arc only when actually needed for async tasks. 
```rust
fn assemble_tasks(&self, auction: &Auction) -> DataFetchingTasks {
    // Create Arc only once for sharing across async tasks
    let auction_arc = Arc::new(auction.clone());
    let utilities = Arc::clone(&self.utilities);
    
    // Reuse Arc references instead of repeated Arc::clone() calls
    let balances = Self::spawn_shared(utilities.clone().fetch_balances(auction_arc.clone()));
    // ... other tasks use the same pattern
}
```


