### PR TITLE
Fix eth_createAccessList call

### DIFF
--- a/crates/driver/src/infra/blockchain/token.rs
+++ b/crates/driver/src/infra/blockchain/token.rs
@@ -141,7 +141,11 @@ impl Erc20 {
                         let access_list_call = CallRequest {
                             data: delegate_call.tx.data.clone(),
                             to: delegate_call.tx.to,
-                            from: delegate_call.tx.from.as_ref().map(|account| account.address()),
+                            from: delegate_call
+                                .tx
+                                .from
+                                .as_ref()
+                                .map(|account| account.address()),
                             ..Default::default()
                         };
                         let access_list = ethereum

--- a/crates/driver/src/infra/blockchain/token.rs
+++ b/crates/driver/src/infra/blockchain/token.rs
@@ -140,9 +140,8 @@ impl Erc20 {
 
                         let access_list_call = CallRequest {
                             data: delegate_call.tx.data.clone(),
-                            // `from` field is not populated, since it is only required for ZkSync
-                            // chains, that currently don't support access lists. On other chains,
-                            // access lists creation fails when an arbitrary `from` is used.
+                            to: delegate_call.tx.to,
+                            from: delegate_call.tx.from.as_ref().map(|account| account.address()),
                             ..Default::default()
                         };
                         let access_list = ethereum


### PR DESCRIPTION
# Description
We currently get [logs](https://aws-es.cow.fi/_dashboards/app/data-explorer/discover#?_a=(discover:(columns:!(log,kubernetes.pod_labels.appClass,log_level,kubernetes.pod_labels.app),isDirty:!t,sort:!(!(timestamp,asc))),metadata:(indexPattern:'86e4a5a0-4e4b-11ef-85c5-3946a99ed1a7',view:discover))&_g=(filters:!(),refreshInterval:(pause:!t,value:0),time:(from:'2025-09-04T04:36:24.915Z',to:'2025-09-04T05:54:01.909Z'))&_q=(filters:!(),query:(language:kuery,query:'%22access%20list%22'))) of the node's `eth_createAccessList` method handler crashing. This is most likely due to the driver's request not specifying all the relevant data. At the very least we need `to` and `calldata`. Additionally `erigon` for gnosis chain expects `from` to be populated as well.

# Changes
- specify the required pieces of data for `eth_createAccessList`