### PR TITLE
Alloy function selectors

### DIFF
--- a/crates/contracts/Cargo.toml
+++ b/crates/contracts/Cargo.toml
@@ -16,22 +16,21 @@ required-features = ["bin"]
 default = []
 bin = [
     "ethcontract-generate",
-    "serde_json",
     "tracing",
     "tracing-subscriber",
 ]
 
 [dependencies]
-alloy = { workspace = true, features = ["sol-types", "json", "contract"] }
+alloy = { workspace = true, features = ["sol-types", "json", "contract", "json-abi"] }
 paste = { workspace = true }
 maplit = { workspace = true }
 ethcontract = { workspace = true }
 serde = { workspace = true }
+serde_json = { workspace = true }
 
 # [bin-dependencies]
 anyhow = { workspace = true }
 ethcontract-generate = { workspace = true, optional = true, features = ["http"] }
-serde_json = { workspace = true, optional = true }
 tracing = { workspace = true, optional = true }
 tracing-subscriber = { workspace = true, features = ["env-filter", "fmt"], optional = true }
 

--- a/crates/contracts/src/alloy.rs
+++ b/crates/contracts/src/alloy.rs
@@ -131,12 +131,11 @@ macro_rules! bindings {
                 });
 
                 /// Return all overloads by *name* and their 4-byte selectors.
-                /// Example: `selector_by_name("swap")` -> `[("swap(address,uint256,...)", 0x....), ...]`
-                pub fn selector_by_name(name: &str) -> Result<Vec<(String, Selector)>> {
+                pub fn selector_by_name(name: &str) -> Result<Vec<Selector>> {
                     let Some(funcs) = ABI.functions.get(name) else {
                         return Err(anyhow!("no function named `{name}` in ABI"));
                     };
-                    Ok(funcs.iter().map(|f| (f.signature(), f.selector())).collect())
+                    Ok(funcs.iter().map(|f| f.selector()).collect())
                 }
 
                 $(
@@ -206,9 +205,7 @@ mod tests {
         let selectors = result.unwrap();
         assert_eq!(selectors.len(), 1);
 
-        let (signature, selector) = &selectors[0];
-        assert_eq!(signature, "isSanctioned(address)");
-        // The selector for isSanctioned(address) - using the actual computed value
+        let selector = &selectors[0];
         assert_eq!(selector, &Selector::from([0xdf, 0x59, 0x2f, 0x7d]));
     }
 
@@ -219,14 +216,10 @@ mod tests {
         let result = IZeroex::selector_by_name("transformERC20");
 
         let selectors = result.unwrap();
-        // Should have at least one overload
+
         assert!(!selectors.is_empty());
 
-        // Each entry should have a signature and selector
-        for (signature, selector) in &selectors {
-            assert!(signature.starts_with("transformERC20("));
-            assert!(signature.ends_with(')'));
-            // Selector should be 4 bytes
+        for selector in &selectors {
             assert_eq!(selector.as_slice().len(), 4);
         }
     }

--- a/crates/contracts/src/alloy.rs
+++ b/crates/contracts/src/alloy.rs
@@ -95,9 +95,7 @@ macro_rules! deployments {
 macro_rules! bindings {
     ($contract:ident $(, $deployment_info:expr)?) => {
         paste::paste! {
-            // Generate the main bindings in a private module. That allows
-            // us to re-export all items in our own module while also adding
-            // some items ourselves.
+            // Private module with the generated Alloy types from the JSON artifact.
             #[allow(non_snake_case)]
             mod [<$contract Private>] {
                 alloy::sol!(
@@ -110,19 +108,45 @@ macro_rules! bindings {
 
             #[allow(non_snake_case)]
             pub mod $contract {
-                use alloy::providers::DynProvider;
+                use {
+                    std::sync::LazyLock,
+                    anyhow::{anyhow, Result},
+                    alloy::{
+                        json_abi::{ContractObject, JsonAbi},
+                        primitives::Selector,
+                        providers::DynProvider,
+                    },
+                };
 
                 pub use super::[<$contract Private>]::*;
                 pub type Instance = $contract::[<$contract Instance>]<DynProvider>;
 
+                /// The contract's ABI parsed from the bundled artifact.
+                pub static ABI: LazyLock<JsonAbi> = LazyLock::new(|| {
+                    let obj: ContractObject = serde_json::from_str(include_str!(concat!(
+                        "../artifacts/", stringify!($contract), ".json"
+                    )))
+                    .expect(concat!("failed to parse artifact JSON for ", stringify!($contract)));
+                    obj.abi.expect("artifact missing `abi` field")
+                });
+
+                /// Return all overloads by *name* and their 4-byte selectors.
+                /// Example: `selector_by_name("swap")` -> `[("swap(address,uint256,...)", 0x....), ...]`
+                pub fn selector_by_name(name: &str) -> Result<Vec<(String, Selector)>> {
+                    let Some(funcs) = ABI.functions.get(name) else {
+                        return Err(anyhow!("no function named `{name}` in ABI"));
+                    };
+                    Ok(funcs.iter().map(|f| (f.signature(), f.selector())).collect())
+                }
+
                 $(
                 use {
-                    std::{sync::LazyLock, collections::HashMap},
+                    std::collections::HashMap,
                     alloy::{
                         providers::Provider,
                         primitives::{address, Address},
                     },
-                    anyhow::{Context, Result},
+                    anyhow::Context,
                     $crate::alloy::networks::*,
                 };
 
@@ -167,4 +191,69 @@ macro_rules! bindings {
             }
         }
     };
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy::primitives::Selector;
+
+    #[test]
+    fn test_selector_by_name_valid_function() {
+        let result = ChainalysisOracle::selector_by_name("isSanctioned");
+        assert!(result.is_ok());
+
+        let selectors = result.unwrap();
+        assert_eq!(selectors.len(), 1);
+
+        let (signature, selector) = &selectors[0];
+        assert_eq!(signature, "isSanctioned(address)");
+        // The selector for isSanctioned(address) - using the actual computed value
+        assert_eq!(selector, &Selector::from([0xdf, 0x59, 0x2f, 0x7d]));
+    }
+
+    #[test]
+    fn test_selector_by_name_multiple_overloads() {
+        // Test with a contract that might have function overloads
+        // Using IZeroex which likely has multiple swap functions
+        let result = IZeroex::selector_by_name("transformERC20");
+
+        let selectors = result.unwrap();
+        // Should have at least one overload
+        assert!(!selectors.is_empty());
+
+        // Each entry should have a signature and selector
+        for (signature, selector) in &selectors {
+            assert!(signature.starts_with("transformERC20("));
+            assert!(signature.ends_with(')'));
+            // Selector should be 4 bytes
+            assert_eq!(selector.as_slice().len(), 4);
+        }
+    }
+
+    #[test]
+    fn test_selector_by_name_invalid_function() {
+        let result = ChainalysisOracle::selector_by_name("nonExistentFunction");
+        assert!(result.is_err());
+
+        let error_msg = result.unwrap_err().to_string();
+        assert!(error_msg.contains("no function named `nonExistentFunction` in ABI"));
+    }
+
+    #[test]
+    fn test_selector_by_name_empty_string() {
+        let result = ChainalysisOracle::selector_by_name("");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_selector_by_name_case_sensitive() {
+        let result1 = ChainalysisOracle::selector_by_name("isSanctioned");
+        let result2 = ChainalysisOracle::selector_by_name("IsSanctioned");
+        let result3 = ChainalysisOracle::selector_by_name("ISSANCTIONED");
+
+        assert!(result1.is_ok());
+        assert!(result2.is_err());
+        assert!(result3.is_err());
+    }
 }


### PR DESCRIPTION
# Description
Adds an ability to retrieve SC function selectors required across the code base: https://github.com/cowprotocol/services/blob/e8fc0ac7e32d9046523c7d051f430e8d9cf2d5be/crates/autopilot/src/domain/settlement/transaction/mod.rs#L202
https://github.com/cowprotocol/services/blob/97ddf0c55b1ab7a41bd026ed5bfe7a95fd86f9ed/crates/contracts/src/vault.rs#L21

# Changes
Parse the same ABI JSON used for the SC bindings and get function selectors by its name.
