### PR TITLE
Limit pool ids in `where` clause when querying univ3 subgraph for Ticks

### DIFF
--- a/crates/driver/src/boundary/liquidity/uniswap/v3.rs
+++ b/crates/driver/src/boundary/liquidity/uniswap/v3.rs
@@ -138,6 +138,7 @@ async fn init_liquidity(
             boundary::liquidity::http_client(),
             block_retriever,
             config.max_pools_to_initialize,
+            config.max_pools_per_tick_query,
         )
         .await
         .context("failed to initialise UniswapV3 liquidity")?,

--- a/crates/driver/src/infra/config/file/load.rs
+++ b/crates/driver/src/infra/config/file/load.rs
@@ -222,12 +222,17 @@ pub async fn load(chain: Chain, path: &Path) -> infra::Config {
                         max_pools_to_initialize,
                         graph_url,
                         reinit_interval,
+                        max_pools_per_tick_query,
                     } => liquidity::config::UniswapV3 {
                         max_pools_to_initialize,
                         reinit_interval,
                         ..match preset {
                             file::UniswapV3Preset::UniswapV3 => {
-                                liquidity::config::UniswapV3::uniswap_v3(&graph_url, chain)
+                                liquidity::config::UniswapV3::uniswap_v3(
+                                    &graph_url,
+                                    chain,
+                                    max_pools_per_tick_query,
+                                )
                             }
                         }
                         .expect("no Uniswap V3 preset for current network")
@@ -237,11 +242,13 @@ pub async fn load(chain: Chain, path: &Path) -> infra::Config {
                         max_pools_to_initialize,
                         graph_url,
                         reinit_interval,
+                        max_pools_per_tick_query,
                     } => liquidity::config::UniswapV3 {
                         router: router.into(),
                         max_pools_to_initialize,
                         graph_url,
                         reinit_interval,
+                        max_pools_per_tick_query,
                     },
                 })
                 .collect(),

--- a/crates/driver/src/infra/config/file/mod.rs
+++ b/crates/driver/src/infra/config/file/mod.rs
@@ -556,6 +556,12 @@ enum UniswapV3Config {
 
         graph_url: Url,
 
+        /// How many pool IDs can be present in a where clause of a Tick query
+        /// at once. Some subgraphs are overloaded and throw errors when
+        /// there are too many.
+        #[serde(default = "uniswap_v3::default_max_pools_per_tick_query")]
+        max_pools_per_tick_query: usize,
+
         /// How often the liquidity source should be reinitialized to get
         /// access to new pools.
         #[serde(with = "humantime_serde", default = "default_reinit_interval")]
@@ -570,6 +576,12 @@ enum UniswapV3Config {
         /// How many pools to initialize during start up.
         #[serde(default = "uniswap_v3::default_max_pools_to_initialize")]
         max_pools_to_initialize: usize,
+
+        /// How many pool IDs can be present in a where clause of a Tick query
+        /// at once. Some subgraphs are overloaded and throw errors when
+        /// there are too many.
+        #[serde(default = "uniswap_v3::default_max_pools_per_tick_query")]
+        max_pools_per_tick_query: usize,
 
         /// The URL used to connect to uniswap v3 subgraph client.
         graph_url: Url,
@@ -590,6 +602,9 @@ enum UniswapV3Preset {
 mod uniswap_v3 {
     pub fn default_max_pools_to_initialize() -> usize {
         100
+    }
+    pub fn default_max_pools_per_tick_query() -> usize {
+        usize::MAX
     }
 }
 

--- a/crates/driver/src/infra/config/file/mod.rs
+++ b/crates/driver/src/infra/config/file/mod.rs
@@ -603,6 +603,7 @@ mod uniswap_v3 {
     pub fn default_max_pools_to_initialize() -> usize {
         100
     }
+
     pub fn default_max_pools_per_tick_query() -> usize {
         usize::MAX
     }

--- a/crates/driver/src/infra/liquidity/config.rs
+++ b/crates/driver/src/infra/liquidity/config.rs
@@ -156,17 +156,29 @@ pub struct UniswapV3 {
     /// How often the liquidity source should be reinitialized to
     /// become aware of new pools.
     pub reinit_interval: Option<Duration>,
+
+    /// How many pool IDs can be present in a where clause of a Tick query at
+    /// once. Some subgraphs are overloaded and throw errors when there are
+    /// too many.
+    pub max_pools_per_tick_query: usize,
 }
 
 impl UniswapV3 {
     /// Returns the liquidity configuration for Uniswap V3.
     #[allow(clippy::self_named_constructors)]
-    pub fn uniswap_v3(graph_url: &Url, chain: Chain) -> Option<Self> {
+    pub fn uniswap_v3(
+        graph_url: &Url,
+        chain: Chain,
+        max_pools_per_tick_query: usize,
+    ) -> Option<Self> {
+        let addr = deployment_address(contracts::UniswapV3SwapRouterV2::raw_contract(), chain)?;
+        tracing::error!(addr = ?addr, "uniswap_v3");
         Some(Self {
-            router: deployment_address(contracts::UniswapV3SwapRouterV2::raw_contract(), chain)?,
+            router: addr,
             max_pools_to_initialize: 100,
             graph_url: graph_url.clone(),
             reinit_interval: None,
+            max_pools_per_tick_query,
         })
     }
 }

--- a/crates/driver/src/infra/liquidity/config.rs
+++ b/crates/driver/src/infra/liquidity/config.rs
@@ -171,10 +171,8 @@ impl UniswapV3 {
         chain: Chain,
         max_pools_per_tick_query: usize,
     ) -> Option<Self> {
-        let addr = deployment_address(contracts::UniswapV3SwapRouterV2::raw_contract(), chain)?;
-        tracing::error!(addr = ?addr, "uniswap_v3");
         Some(Self {
-            router: addr,
+            router: deployment_address(contracts::UniswapV3SwapRouterV2::raw_contract(), chain)?,
             max_pools_to_initialize: 100,
             graph_url: graph_url.clone(),
             reinit_interval: None,

--- a/crates/shared/src/sources/balancer_v2/graph_api.rs
+++ b/crates/shared/src/sources/balancer_v2/graph_api.rs
@@ -35,7 +35,11 @@ pub struct BalancerSubgraphClient(SubgraphClient);
 impl BalancerSubgraphClient {
     /// Creates a new Balancer subgraph client with full subgraph URL.
     pub fn from_subgraph_url(subgraph_url: &Url, client: Client) -> Result<Self> {
-        Ok(Self(SubgraphClient::try_new(subgraph_url.clone(), client)?))
+        Ok(Self(SubgraphClient::try_new(
+            subgraph_url.clone(),
+            client,
+            usize::MAX,
+        )?))
     }
 
     /// Retrieves the list of registered pools from the subgraph.

--- a/crates/shared/src/sources/uniswap_v3/graph_api.rs
+++ b/crates/shared/src/sources/uniswap_v3/graph_api.rs
@@ -107,8 +107,16 @@ pub struct UniV3SubgraphClient(SubgraphClient);
 
 impl UniV3SubgraphClient {
     /// Creates a new Uniswap V3 subgraph client from the specified URL.
-    pub fn from_subgraph_url(subgraph_url: &Url, client: Client) -> Result<Self> {
-        Ok(Self(SubgraphClient::try_new(subgraph_url.clone(), client)?))
+    pub fn from_subgraph_url(
+        subgraph_url: &Url,
+        client: Client,
+        max_pools_per_tick_query: usize,
+    ) -> Result<Self> {
+        Ok(Self(SubgraphClient::try_new(
+            subgraph_url.clone(),
+            client,
+            max_pools_per_tick_query,
+        )?))
     }
 
     async fn get_pools(&self, query: &str, variables: Map<String, Value>) -> Result<Vec<PoolData>> {
@@ -134,7 +142,6 @@ impl UniV3SubgraphClient {
         })
     }
 
-    /// Retrieves the pool data for pools with given pool ids
     async fn get_pools_by_pool_ids(
         &self,
         pool_ids: &[H160],
@@ -154,15 +161,23 @@ impl UniV3SubgraphClient {
         pool_ids: &[H160],
         block_number: u64,
     ) -> Result<Vec<TickData>> {
-        let variables = json_map! {
-            "block" => block_number,
-            "pool_ids" => json!(pool_ids)
-        };
-        let result = self
-            .0
-            .paginated_query(TICKS_BY_POOL_IDS_QUERY, variables)
-            .await?;
-        Ok(result)
+        let mut all = Vec::new();
+
+        // Default chunk size is usize::MAX - all pool ids in one `where`. We want to
+        // run reqeusts sequntially to avoid overwhelming the node.
+        for chunk in pool_ids.chunks(self.0.max_pools_per_tick_query()) {
+            let variables = json_map! {
+                "block" => block_number,
+                "pool_ids" => json!(chunk)
+            };
+            let mut batch = self
+                .0
+                .paginated_query(TICKS_BY_POOL_IDS_QUERY, variables)
+                .await?;
+            all.append(&mut batch);
+        }
+
+        Ok(all)
     }
 
     /// Retrieves the pool data and ticks data for pools with given pool ids

--- a/crates/shared/src/subgraph.rs
+++ b/crates/shared/src/subgraph.rs
@@ -15,6 +15,7 @@ const MAX_NUMBER_OF_RETRIES: usize = 10;
 pub struct SubgraphClient {
     client: Client,
     subgraph_url: Url,
+    max_pools_per_tick_query: usize,
 }
 
 pub trait ContainsId {
@@ -29,11 +30,21 @@ pub struct Data<T> {
 
 impl SubgraphClient {
     /// Creates a new subgraph client from the specified organization and name.
-    pub fn try_new(subgraph_url: Url, client: Client) -> Result<Self> {
+    pub fn try_new(
+        subgraph_url: Url,
+        client: Client,
+        max_pools_per_tick_query: usize,
+    ) -> Result<Self> {
         Ok(Self {
             client,
             subgraph_url,
+            max_pools_per_tick_query,
         })
+    }
+
+    pub fn with_max_pools_per_tick_query(mut self, max_pools_per_tick_query: usize) -> Self {
+        self.max_pools_per_tick_query = max_pools_per_tick_query;
+        self
     }
 
     /// Performs the specified GraphQL query on the current subgraph.
@@ -103,6 +114,10 @@ impl SubgraphClient {
         }
 
         Ok(result)
+    }
+
+    pub fn max_pools_per_tick_query(&self) -> usize {
+        self.max_pools_per_tick_query
     }
 }
 

--- a/crates/shared/src/subgraph.rs
+++ b/crates/shared/src/subgraph.rs
@@ -42,11 +42,6 @@ impl SubgraphClient {
         })
     }
 
-    pub fn with_max_pools_per_tick_query(mut self, max_pools_per_tick_query: usize) -> Self {
-        self.max_pools_per_tick_query = max_pools_per_tick_query;
-        self
-    }
-
     /// Performs the specified GraphQL query on the current subgraph.
     pub async fn query<T>(&self, query: &str, variables: Option<Map<String, Value>>) -> Result<T>
     where


### PR DESCRIPTION
# Description

Some slow nodes time out when there are too many pool IDs when we query the uniswap v3 subgraph for `Tick`s. This PR adds the option to limit the number of such items in the query which means running multiple queries with fewer pool IDs in `where` to achieve the same effect. This can't be done in parallel as it overloads these slow nodes. 

In the end I found a [fast graph](https://thegraph.com/explorer/subgraphs/FiJDXMFCBv88GP17g2TtPh8BcA8jZozn5WRW7hCN7cUT?view=About&chain=arbitrum-one) so this change is not needed, but if this one ever stops working we might be happy to have the option.

# Changes

- [x] Add a new driver param that limits how many pool ids are added to a single query

## How to test

Start driver with graph-url against a slow subgraph (e.g. `F85MNzUGYqgSHSHRGgeVMNsdnW1KtZSVgFULumXRZTw2`) and watch it fail. Then set max pool ids to 10 and see it succeed. 