### PR TITLE
Migrate ERC20Mintable to alloy-rs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -101,13 +101,17 @@ dependencies = [
  "alloy-eips",
  "alloy-json-rpc",
  "alloy-network",
+ "alloy-node-bindings",
  "alloy-provider",
  "alloy-rpc-client",
+ "alloy-rpc-types",
+ "alloy-serde",
  "alloy-signer",
  "alloy-signer-aws",
  "alloy-signer-local",
  "alloy-transport",
  "alloy-transport-http",
+ "alloy-trie",
 ]
 
 [[package]]
@@ -269,6 +273,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloy-genesis"
+version = "1.0.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ba1cbc25a07e0142e8875fcbe80e1fdb02be8160ae186b90f4b9a69a72ed2b"
+dependencies = [
+ "alloy-eips",
+ "alloy-primitives",
+ "alloy-serde",
+ "alloy-trie",
+ "serde",
+]
+
+[[package]]
+name = "alloy-hardforks"
+version = "0.2.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3165210652f71dfc094b051602bafd691f506c54050a174b1cba18fb5ef706a3"
+dependencies = [
+ "alloy-chains",
+ "alloy-eip2124",
+ "alloy-primitives",
+ "auto_impl",
+ "dyn-clone",
+]
+
+[[package]]
 name = "alloy-json-abi"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -335,6 +365,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloy-node-bindings"
+version = "1.0.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d82efad69266f38e1ef3c6fbfe2f86fa7aec3cf4726368a64914ff5f7a37a0d"
+dependencies = [
+ "alloy-genesis",
+ "alloy-hardforks",
+ "alloy-network",
+ "alloy-primitives",
+ "alloy-signer",
+ "alloy-signer-local",
+ "k256",
+ "rand 0.8.5",
+ "serde_json",
+ "tempfile",
+ "thiserror 2.0.12",
+ "tracing",
+ "url",
+]
+
+[[package]]
 name = "alloy-primitives"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -373,8 +424,10 @@ dependencies = [
  "alloy-json-rpc",
  "alloy-network",
  "alloy-network-primitives",
+ "alloy-node-bindings",
  "alloy-primitives",
  "alloy-rpc-client",
+ "alloy-rpc-types-anvil",
  "alloy-rpc-types-eth",
  "alloy-signer",
  "alloy-sol-types",
@@ -443,6 +496,31 @@ dependencies = [
  "tracing",
  "url",
  "wasmtimer",
+]
+
+[[package]]
+name = "alloy-rpc-types"
+version = "1.0.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39676beaa50db545cf15447fc94ec5513b64e85a48357a0625b9a04aef08a910"
+dependencies = [
+ "alloy-primitives",
+ "alloy-rpc-types-anvil",
+ "alloy-rpc-types-eth",
+ "alloy-serde",
+ "serde",
+]
+
+[[package]]
+name = "alloy-rpc-types-anvil"
+version = "1.0.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9c8cad42fa936000be72ab80fcd97386a6a226c35c2989212756da9e76c1521"
+dependencies = [
+ "alloy-primitives",
+ "alloy-rpc-types-eth",
+ "alloy-serde",
+ "serde",
 ]
 
 [[package]]
@@ -2497,6 +2575,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
+name = "dyn-clone"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
+
+[[package]]
 name = "e2e"
 version = "1.0.0"
 dependencies = [
@@ -2598,12 +2682,12 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "errno"
-version = "0.3.9"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "534c5cf6194dfab3db3242765c03bbe257cf92f22b38f6bc0c58d59108a820ba"
+checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2803,9 +2887,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.1.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fc0510504f03c51ada170672ac806f1f105a88aa97a5281117e1ddc3368e51a"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "fastrlp"
@@ -3848,9 +3932,9 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.14"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
+checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
 
 [[package]]
 name = "lock_api"
@@ -4929,7 +5013,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.12.1",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.104",
@@ -5460,15 +5544,15 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.34"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70dc5ec042f7a43c4a73241207cecc9873a06d45debb38b329f8541d85c2730f"
+checksum = "11181fbabf243db407ef8df94a6ce0b2f9a733bd8be4ad02b4eda9602296cac8"
 dependencies = [
  "bitflags 2.9.1",
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6491,14 +6575,15 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tempfile"
-version = "3.10.1"
+version = "3.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85b77fafb263dd9d05cbeac119526425676db3784113aa9295c88498cbf8bff1"
+checksum = "15b61f8f20e3a6f7e0649d825294eaf317edce30f82cf6026e7e4cb9222a7d1e"
 dependencies = [
- "cfg-if",
  "fastrand",
+ "getrandom 0.3.3",
+ "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,14 +14,19 @@ clap = { version = "4.5.6", features = ["derive", "env"] }
 dashmap = "6.1.0"
 derivative = "2.2.0"
 derive_more = { version = "1.0.0", features = ["full"] }
-ethcontract = { git = "https://github.com/cowprotocol/ethcontract-rs", rev = "8817f4ba868e686f21cda886d6c8b75834eb51f2", default-features = false, features = ["aws-kms"] }
+ethcontract = { git = "https://github.com/cowprotocol/ethcontract-rs", rev = "8817f4ba868e686f21cda886d6c8b75834eb51f2", default-features = false, features = [
+    "aws-kms",
+] }
 mimalloc = "0.1.43"
 ethcontract-generate = { git = "https://github.com/cowprotocol/ethcontract-rs", rev = "8817f4ba868e686f21cda886d6c8b75834eb51f2", default-features = false }
 ethcontract-mock = { git = "https://github.com/cowprotocol/ethcontract-rs", rev = "8817f4ba868e686f21cda886d6c8b75834eb51f2", default-features = false }
 ethereum-types = "0.14.1"
 flate2 = "1.0.30"
 futures = "0.3.30"
-gas-estimation = { git = "https://github.com/cowprotocol/gas-estimation", tag = "v0.7.3", features = ["web3_", "tokio_"] }
+gas-estimation = { git = "https://github.com/cowprotocol/gas-estimation", tag = "v0.7.3", features = [
+    "web3_",
+    "tokio_",
+] }
 hex = { version = "0.4.3", default-features = false }
 hex-literal = "0.4.1"
 humantime = "2.1.0"
@@ -42,9 +47,16 @@ secp256k1 = "0.27.0"
 serde = { version = "1.0.203", features = ["derive"] }
 serde_json = "1.0.117"
 serde_with = "3.8.1"
-sqlx = { version = "0.7", default-features = false, features = ["runtime-tokio", "tls-native-tls", "bigdecimal", "chrono", "postgres", "macros"] }
+sqlx = { version = "0.7", default-features = false, features = [
+    "runtime-tokio",
+    "tls-native-tls",
+    "bigdecimal",
+    "chrono",
+    "postgres",
+    "macros",
+] }
 strum = { version = "0.26.2", features = ["derive"] }
-tempfile = "3.10.1"
+tempfile = "3.20.0"
 thiserror = "1.0.61"
 toml = "0.8.14"
 tokio = { version = "1.38.0", features = ["tracing"] }

--- a/crates/contracts/build.rs
+++ b/crates/contracts/build.rs
@@ -1297,12 +1297,6 @@ fn main() {
                 },
             )
     });
-    generate_contract("GnosisSafe");
-    generate_contract_with_config("GnosisSafeCompatibilityFallbackHandler", |builder| {
-        builder.add_method_alias("isValidSignature(bytes,bytes)", "is_valid_signature_legacy")
-    });
-    generate_contract("GnosisSafeProxy");
-    generate_contract("GnosisSafeProxyFactory");
     generate_contract_with_config("HoneyswapRouter", |builder| {
         builder.add_network_str(GNOSIS, "0x1C232F01118CB8B424793ae03F870aa7D0ac7f77")
     });

--- a/crates/contracts/build.rs
+++ b/crates/contracts/build.rs
@@ -1091,7 +1091,6 @@ fn main() {
         builder.add_network_str(GNOSIS, "0x6093AeBAC87d62b1A5a4cEec91204e35020E38bE")
     });
     generate_contract("ERC20");
-    generate_contract("ERC20Mintable");
     generate_contract("ERC3156FlashLoanSolverWrapper");
     generate_contract_with_config("FlashLoanRouter", |builder| {
         let mut builder = builder;

--- a/crates/contracts/src/alloy.rs
+++ b/crates/contracts/src/alloy.rs
@@ -128,9 +128,9 @@ pub mod macros {
                 .send()
                 .await
                 .expect(&format!("failed to send: {}", NAME))
-                .get_receipt()
+                .watch()
                 .await
-                .expect(&format!("failed to get receipt: {}", NAME))
+                .expect(&format!("failed to get confirmations for: {}", NAME))
         }};
         ($call:expr, $value:expr, $acc:expr) => {{
             const NAME: &str = stringify!($call);
@@ -140,9 +140,9 @@ pub mod macros {
                 .send()
                 .await
                 .expect(&format!("failed to send: {}", NAME))
-                .get_receipt()
+                .watch()
                 .await
-                .expect(&format!("failed to get receipt: {}", NAME))
+                .expect(&format!("failed to get confirmations for: {}", NAME))
         }};
     }
 

--- a/crates/contracts/src/alloy.rs
+++ b/crates/contracts/src/alloy.rs
@@ -52,7 +52,7 @@ pub trait InstanceExt: Sized {
 
 #[macro_export]
 macro_rules! bindings {
-    ($contract:ident, $($deployment_info:expr)?) => {
+    ($contract:ident $(, $deployment_info:expr)?) => {
         paste::paste! {
             // Generate the main bindings in a private module. That allows
             // us to re-export all items in our own module while also adding
@@ -111,4 +111,46 @@ macro_rules! bindings {
             }
         }
     };
+}
+
+crate::bindings!(GnosisSafe);
+crate::bindings!(GnosisSafeCompatibilityFallbackHandler);
+crate::bindings!(GnosisSafeProxy);
+crate::bindings!(GnosisSafeProxyFactory);
+
+pub mod macros {
+    #[macro_export]
+    macro_rules! tx_value {
+        ($call:expr, $value:expr) => {{
+            const NAME: &str = stringify!($call);
+            $call
+                .value($value)
+                .send()
+                .await
+                .expect(&format!("failed to send: {}", NAME))
+                .get_receipt()
+                .await
+                .expect(&format!("failed to get receipt: {}", NAME))
+        }};
+        ($call:expr, $value:expr, $acc:expr) => {{
+            const NAME: &str = stringify!($call);
+            $call
+                .from($acc)
+                .value($value)
+                .send()
+                .await
+                .expect(&format!("failed to send: {}", NAME))
+                .get_receipt()
+                .await
+                .expect(&format!("failed to get receipt: {}", NAME))
+        }};
+    }
+
+    #[macro_export]
+    macro_rules! tx {
+        ($call:expr) => {{ $crate::alloy::macros::tx_value!($call, ::alloy::primitives::U256::ZERO) }};
+        ($call:expr, $acc:expr) => {{ $crate::alloy::macros::tx_value!($call, ::alloy::primitives::U256::ZERO, $acc) }};
+    }
+
+    pub use {tx, tx_value};
 }

--- a/crates/contracts/src/alloy.rs
+++ b/crates/contracts/src/alloy.rs
@@ -39,6 +39,12 @@ crate::bindings!(
     }
 );
 
+crate::bindings!(GnosisSafe);
+crate::bindings!(GnosisSafeCompatibilityFallbackHandler);
+crate::bindings!(GnosisSafeProxy);
+crate::bindings!(GnosisSafeProxyFactory);
+crate::bindings!(ERC20Mintable);
+
 pub use alloy::providers::DynProvider as Provider;
 
 /// Extension trait to attach some useful functions to the contract instance.
@@ -112,11 +118,6 @@ macro_rules! bindings {
         }
     };
 }
-
-crate::bindings!(GnosisSafe);
-crate::bindings!(GnosisSafeCompatibilityFallbackHandler);
-crate::bindings!(GnosisSafeProxy);
-crate::bindings!(GnosisSafeProxyFactory);
 
 pub mod macros {
     #[macro_export]

--- a/crates/contracts/src/lib.rs
+++ b/crates/contracts/src/lib.rs
@@ -86,10 +86,6 @@ include_contracts! {
     FlashLoanRouter;
     GPv2AllowListAuthentication;
     GPv2Settlement;
-    GnosisSafe;
-    GnosisSafeCompatibilityFallbackHandler;
-    GnosisSafeProxy;
-    GnosisSafeProxyFactory;
     HoneyswapRouter;
     HooksTrampoline;
     IAavePool;

--- a/crates/contracts/src/lib.rs
+++ b/crates/contracts/src/lib.rs
@@ -81,7 +81,6 @@ include_contracts! {
     CowProtocolToken;
     ERC1271SignatureValidator;
     ERC20;
-    ERC20Mintable;
     ERC3156FlashLoanSolverWrapper;
     FlashLoanRouter;
     GPv2AllowListAuthentication;

--- a/crates/driver/src/tests/setup/blockchain.rs
+++ b/crates/driver/src/tests/setup/blockchain.rs
@@ -7,9 +7,16 @@ use {
         },
         tests::{self, boundary, cases::EtherExt},
     },
+    alloy::primitives::U256,
     ethcontract::PrivateKey,
-    ethrpc::Web3,
-    futures::Future,
+    ethrpc::{
+        Web3,
+        alloy::{
+            CallBuilderExt,
+            conversions::{IntoAlloy, IntoLegacy},
+        },
+    },
+    futures::{Future, FutureExt},
     secp256k1::SecretKey,
     serde_json::json,
     solvers_dto::solution::Flashloan,
@@ -33,7 +40,7 @@ pub struct Blockchain {
     pub trader_secret_key: SecretKey,
     pub web3: Web3,
     pub web3_url: String,
-    pub tokens: HashMap<&'static str, contracts::ERC20Mintable>,
+    pub tokens: HashMap<&'static str, contracts::alloy::ERC20Mintable::Instance>,
     pub weth: contracts::WETH9,
     pub settlement: contracts::GPv2Settlement,
     pub balances: contracts::support::Balances,
@@ -408,29 +415,35 @@ impl Blockchain {
         let domain_separator =
             boundary::DomainSeparator(settlement.domain_separator().call().await.unwrap().0);
 
+        async fn deploy_token(
+            web3: &Web3,
+            from_account: alloy::primitives::Address,
+        ) -> Result<contracts::alloy::ERC20Mintable::Instance, alloy::contract::Error> {
+            wait_for(&web3, async {
+                let contract_address =
+                    contracts::alloy::ERC20Mintable::Instance::deploy_builder(web3.alloy.clone())
+                        .from(from_account)
+                        .deploy()
+                        .await
+                        .unwrap();
+                contracts::alloy::ERC20Mintable::Instance::new(contract_address, web3.alloy.clone())
+            })
+            .await
+        }
+
         // Create (deploy) the tokens needed by the pools.
         let mut tokens = HashMap::new();
         for pool in config.pools.iter() {
             if pool.reserve_a.token != "WETH" && !tokens.contains_key(pool.reserve_a.token) {
-                let token = wait_for(
-                    &web3,
-                    contracts::ERC20Mintable::builder(&web3)
-                        .from(main_trader_account.clone())
-                        .deploy(),
-                )
-                .await
-                .unwrap();
+                let token = deploy_token(&web3, main_trader_account.address().into_alloy())
+                    .await
+                    .unwrap();
                 tokens.insert(pool.reserve_a.token, token);
             }
             if pool.reserve_b.token != "WETH" && !tokens.contains_key(pool.reserve_b.token) {
-                let token = wait_for(
-                    &web3,
-                    contracts::ERC20Mintable::builder(&web3)
-                        .from(main_trader_account.clone())
-                        .deploy(),
-                )
-                .await
-                .unwrap();
+                let token = deploy_token(&web3, main_trader_account.address().into_alloy())
+                    .await
+                    .unwrap();
                 tokens.insert(pool.reserve_b.token, token);
             }
         }
@@ -452,12 +465,20 @@ impl Blockchain {
             let token_a = if pool.reserve_a.token == "WETH" {
                 weth.address()
             } else {
-                tokens.get(pool.reserve_a.token).unwrap().address()
+                tokens
+                    .get(pool.reserve_a.token)
+                    .unwrap()
+                    .address()
+                    .into_legacy()
             };
             let token_b = if pool.reserve_b.token == "WETH" {
                 weth.address()
             } else {
-                tokens.get(pool.reserve_b.token).unwrap().address()
+                tokens
+                    .get(pool.reserve_b.token)
+                    .unwrap()
+                    .address()
+                    .into_legacy()
             };
             // Create the pair.
             wait_for(
@@ -519,9 +540,9 @@ impl Blockchain {
                         tokens
                             .get(pool.reserve_a.token)
                             .unwrap()
-                            .approve(vault_relayer, ethcontract::U256::max_value())
-                            .from(trader_account.clone())
-                            .send(),
+                            .approve(vault_relayer.into_alloy(), U256::MAX)
+                            .from(trader_account.address().into_alloy())
+                            .send_and_watch(),
                     )
                     .await
                     .unwrap();
@@ -532,9 +553,12 @@ impl Blockchain {
                     tokens
                         .get(pool.reserve_a.token)
                         .unwrap()
-                        .mint(pair.address(), pool.reserve_a.amount)
-                        .from(main_trader_account.clone())
-                        .send(),
+                        .mint(
+                            pair.address().into_alloy(),
+                            pool.reserve_a.amount.into_alloy(),
+                        )
+                        .from(main_trader_account.address().into_alloy())
+                        .send_and_watch(),
                 )
                 .await
                 .unwrap();
@@ -543,9 +567,12 @@ impl Blockchain {
                     tokens
                         .get(pool.reserve_a.token)
                         .unwrap()
-                        .mint(settlement.address(), pool.reserve_a.amount)
-                        .from(main_trader_account.clone())
-                        .send(),
+                        .mint(
+                            settlement.address().into_alloy(),
+                            pool.reserve_a.amount.into_alloy(),
+                        )
+                        .from(main_trader_account.address().into_alloy())
+                        .send_and_watch(),
                 )
                 .await
                 .unwrap();
@@ -556,9 +583,12 @@ impl Blockchain {
                         tokens
                             .get(pool.reserve_a.token)
                             .unwrap()
-                            .mint(trader_account.address(), pool.reserve_a.amount)
-                            .from(main_trader_account.clone())
-                            .send(),
+                            .mint(
+                                trader_account.address().into_alloy(),
+                                pool.reserve_a.amount.into_alloy(),
+                            )
+                            .from(main_trader_account.address().into_alloy())
+                            .send_and_watch(),
                     )
                     .await
                     .unwrap();
@@ -599,12 +629,10 @@ impl Blockchain {
                         tokens
                             .get(pool.reserve_b.token)
                             .unwrap()
-                            .approve(vault_relayer, ethcontract::U256::max_value())
-                            .from(trader_account.clone())
-                            .send(),
+                            .approve(vault_relayer.into_alloy(), U256::MAX)
+                            .from(trader_account.address().into_alloy())
+                            .send_and_watch(),
                     )
-                    .await
-                    .unwrap();
                 }
 
                 wait_for(
@@ -612,9 +640,12 @@ impl Blockchain {
                     tokens
                         .get(pool.reserve_b.token)
                         .unwrap()
-                        .mint(pair.address(), pool.reserve_b.amount)
-                        .from(main_trader_account.clone())
-                        .send(),
+                        .mint(
+                            pair.address().into_alloy(),
+                            pool.reserve_b.amount.into_alloy(),
+                        )
+                        .from(main_trader_account.address().into_alloy())
+                        .send_and_watch(),
                 )
                 .await
                 .unwrap();
@@ -623,9 +654,12 @@ impl Blockchain {
                     tokens
                         .get(pool.reserve_b.token)
                         .unwrap()
-                        .mint(settlement.address(), pool.reserve_b.amount)
-                        .from(main_trader_account.clone())
-                        .send(),
+                        .mint(
+                            settlement.address().into_alloy(),
+                            pool.reserve_b.amount.into_alloy(),
+                        )
+                        .from(main_trader_account.address().into_alloy())
+                        .send_and_watch(),
                 )
                 .await
                 .unwrap();
@@ -635,9 +669,12 @@ impl Blockchain {
                         tokens
                             .get(pool.reserve_b.token)
                             .unwrap()
-                            .mint(trader_account.address(), pool.reserve_b.amount)
-                            .from(main_trader_account.clone())
-                            .send(),
+                            .mint(
+                                trader_account.address().into_alloy(),
+                                pool.reserve_b.amount.into_alloy(),
+                            )
+                            .from(main_trader_account.address().into_alloy())
+                            .send_and_watch(),
                     )
                     .await
                     .unwrap();
@@ -797,11 +834,11 @@ impl Blockchain {
                         .get(order.sell_token)
                         .unwrap()
                         .mint(
-                            trader_account.address(),
-                            "1e-7".ether().into_wei() * execution.sell,
+                            trader_account.address().into_alloy(),
+                            ("1e-7".ether().into_wei() * execution.sell).into_alloy(),
                         )
-                        .from(trader_account.clone())
-                        .send(),
+                        .from(trader_account.address().into_alloy())
+                        .send_and_watch(),
                 )
                 .await
                 .unwrap();
@@ -814,9 +851,9 @@ impl Blockchain {
                 self.tokens
                     .get(order.sell_token)
                     .unwrap()
-                    .approve(vault_relayer, ethcontract::U256::max_value())
-                    .from(trader_account.clone())
-                    .send(),
+                    .approve(vault_relayer.into_alloy(), U256::MAX)
+                    .from(trader_account.address().into_alloy())
+                    .send_and_watch(),
             )
             .await
             .unwrap();
@@ -899,7 +936,7 @@ impl Blockchain {
         match token {
             "WETH" => self.weth.address(),
             "ETH" => eth::ETH_TOKEN.into(),
-            _ => self.tokens.get(token).unwrap().address(),
+            _ => self.tokens.get(token).unwrap().address().into_legacy(),
         }
     }
 
@@ -908,7 +945,7 @@ impl Blockchain {
     pub fn get_token_wrapped(&self, token: &str) -> eth::H160 {
         match token {
             "WETH" | "ETH" => self.weth.address(),
-            _ => self.tokens.get(token).unwrap().address(),
+            _ => self.tokens.get(token).unwrap().address().into_legacy(),
         }
     }
 

--- a/crates/driver/src/tests/setup/mod.rs
+++ b/crates/driver/src/tests/setup/mod.rs
@@ -4,7 +4,7 @@ use {
     self::{driver::Driver, solver::Solver as SolverInstance},
     crate::{
         domain::{
-            competition::{order, order::app_data::AppData},
+            competition::order::{self, app_data::AppData},
             eth,
             time,
         },
@@ -40,6 +40,7 @@ use {
     },
     bigdecimal::{BigDecimal, FromPrimitive},
     ethcontract::dyns::DynTransport,
+    ethrpc::alloy::conversions::{IntoAlloy, IntoLegacy},
     futures::future::join_all,
     hyper::StatusCode,
     model::order::{BuyTokenDestination, SellTokenSource},
@@ -1187,10 +1188,11 @@ impl Test {
         let mut balances = HashMap::new();
         for (token, contract) in self.blockchain.tokens.iter() {
             let balance = contract
-                .balance_of(self.trader_address)
+                .balanceOf(self.trader_address.into_alloy())
                 .call()
                 .await
-                .unwrap();
+                .unwrap()
+                .into_legacy();
             balances.insert(*token, balance);
         }
         balances.insert(

--- a/crates/e2e/Cargo.toml
+++ b/crates/e2e/Cargo.toml
@@ -1,12 +1,23 @@
 [package]
 name = "e2e"
 version = "1.0.0"
-authors = ["Gnosis Developers <developers@gnosis.io>", "Cow Protocol Developers <dev@cow.fi>"]
+authors = [
+    "Gnosis Developers <developers@gnosis.io>",
+    "Cow Protocol Developers <dev@cow.fi>",
+]
 edition = "2024"
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-alloy = { workspace = true, default-features = false, features = ["json-rpc", "providers", "rpc-client", "transports", "reqwest", "signers", "signer-local"] }
+alloy = { workspace = true, default-features = false, features = [
+    "json-rpc",
+    "providers",
+    "rpc-client",
+    "transports",
+    "reqwest",
+    "signers",
+    "signer-local",
+] }
 app-data = { workspace = true }
 anyhow = { workspace = true }
 autopilot = { workspace = true }

--- a/crates/e2e/Cargo.toml
+++ b/crates/e2e/Cargo.toml
@@ -17,6 +17,9 @@ alloy = { workspace = true, default-features = false, features = [
     "reqwest",
     "signers",
     "signer-local",
+    "rpc",
+    "rpc-types",
+    "provider-anvil-node",
 ] }
 app-data = { workspace = true }
 anyhow = { workspace = true }

--- a/crates/e2e/src/setup/mod.rs
+++ b/crates/e2e/src/setup/mod.rs
@@ -111,7 +111,7 @@ where
 /// of the chain. The saved state is restored at the end of the test.
 /// The database is cleaned at the end of the test.
 ///
-/// This function also intializes tracing and sets panic hook.
+/// This function also initializes tracing and sets panic hook.
 ///
 /// Note that tests calling with this function will not be run simultaneously.
 pub async fn run_test<F, Fut>(f: F)

--- a/crates/e2e/src/setup/mod.rs
+++ b/crates/e2e/src/setup/mod.rs
@@ -111,7 +111,7 @@ where
 /// of the chain. The saved state is restored at the end of the test.
 /// The database is cleaned at the end of the test.
 ///
-/// This function also initializes tracing and sets panic hook.
+/// This function also intializes tracing and sets panic hook.
 ///
 /// Note that tests calling with this function will not be run simultaneously.
 pub async fn run_test<F, Fut>(f: F)

--- a/crates/e2e/src/setup/onchain_components/alloy.rs
+++ b/crates/e2e/src/setup/onchain_components/alloy.rs
@@ -1,0 +1,29 @@
+use {
+    alloy::contract::{CallBuilder, CallDecoder},
+    app_data::Hook,
+    ethrpc::{AlloyProvider, alloy::conversions::IntoLegacy},
+};
+
+pub async fn hook_for_transaction<D>(tx: CallBuilder<&AlloyProvider, D>) -> Hook
+where
+    D: CallDecoder,
+{
+    let gas_limit = tx
+        .estimate_gas()
+        .await
+        .expect("transaction reverted when estimating gas");
+    let call_data = tx.calldata().to_vec();
+    let target = tx
+        .into_transaction_request()
+        .to
+        .unwrap()
+        .into_to()
+        .unwrap()
+        .into_legacy();
+
+    Hook {
+        target,
+        call_data,
+        gas_limit,
+    }
+}

--- a/crates/e2e/src/setup/onchain_components/alloy.rs
+++ b/crates/e2e/src/setup/onchain_components/alloy.rs
@@ -4,14 +4,11 @@ use {
     ethrpc::{AlloyProvider, alloy::conversions::IntoLegacy},
 };
 
-pub async fn hook_for_transaction<D>(tx: CallBuilder<&AlloyProvider, D>) -> Hook
+pub async fn hook_for_transaction<D>(tx: CallBuilder<&AlloyProvider, D>) -> anyhow::Result<Hook>
 where
     D: CallDecoder,
 {
-    let gas_limit = tx
-        .estimate_gas()
-        .await
-        .expect("transaction reverted when estimating gas");
+    let gas_limit = tx.estimate_gas().await?;
     let call_data = tx.calldata().to_vec();
     let target = tx
         .into_transaction_request()
@@ -21,9 +18,9 @@ where
         .unwrap()
         .into_legacy();
 
-    Hook {
+    Ok(Hook {
         target,
         call_data,
         gas_limit,
-    }
+    })
 }

--- a/crates/e2e/src/setup/onchain_components/mod.rs
+++ b/crates/e2e/src/setup/onchain_components/mod.rs
@@ -28,6 +28,7 @@ use {
     },
 };
 
+pub mod alloy;
 pub mod safe;
 
 #[macro_export]
@@ -46,7 +47,7 @@ macro_rules! tx_value {
 #[macro_export]
 macro_rules! tx {
     ($acc:expr_2021, $call:expr_2021) => {
-        $crate::tx_value!($acc, U256::zero(), $call)
+        $crate::tx_value!($acc, ethcontract::U256::zero(), $call)
     };
 }
 

--- a/crates/e2e/src/setup/onchain_components/mod.rs
+++ b/crates/e2e/src/setup/onchain_components/mod.rs
@@ -3,8 +3,9 @@ use {
         nodes::forked_node::ForkedNodeApi,
         setup::{DeployedContracts, deploy::Contracts},
     },
+    ::alloy::providers::Provider,
     app_data::Hook,
-    contracts::{CowProtocolToken, ERC20Mintable},
+    contracts::CowProtocolToken,
     ethcontract::{
         Account,
         Bytes,
@@ -12,6 +13,12 @@ use {
         PrivateKey,
         U256,
         transaction::{TransactionBuilder, TransactionResult},
+    },
+    ethrpc::alloy::{
+        CallBuilderExt,
+        ProviderExt,
+        ProviderSignerExt,
+        conversions::{IntoAlloy, IntoLegacy, TryIntoAlloyAsync},
     },
     hex_literal::hex,
     model::{
@@ -168,18 +175,40 @@ impl Iterator for AccountGenerator {
 
 #[derive(Debug)]
 pub struct MintableToken {
-    contract: ERC20Mintable,
+    contract: contracts::alloy::ERC20Mintable::Instance,
     minter: Account,
 }
 
 impl MintableToken {
     pub async fn mint(&self, to: H160, amount: U256) {
-        tx!(self.minter, self.contract.mint(to, amount));
+        // Due to interleaving of providers, this is the only way to ensure we have the
+        // right nonce once we fully (or at the very least, these paths) migrate
+        // to alloy we can remove this
+        let nonce = self
+            .contract
+            .provider()
+            .get_transaction_count(self.minter.address().into_alloy())
+            .await
+            .unwrap();
+        let signing_provider = self
+            .contract
+            .provider()
+            .with_signer(self.minter.clone().try_into_alloy().await.unwrap());
+        signing_provider
+            .send_and_watch(
+                self.contract
+                    .mint(to.into_alloy(), amount.into_alloy())
+                    .nonce(nonce)
+                    .from(self.minter.address().into_alloy())
+                    .into_transaction_request(),
+            )
+            .await
+            .unwrap();
     }
 }
 
 impl Deref for MintableToken {
-    type Target = ERC20Mintable;
+    type Target = contracts::alloy::ERC20Mintable::Instance;
 
     fn deref(&self) -> &Self::Target {
         &self.contract
@@ -381,12 +410,31 @@ impl OnchainComponents {
     /// Deploy `N` tokens without any onchain liquidity
     pub async fn deploy_tokens<const N: usize>(&self, minter: &Account) -> [MintableToken; N] {
         let mut res = Vec::with_capacity(N);
-        for _ in 0..N {
-            let contract = ERC20Mintable::builder(&self.web3)
-                .from(minter.clone())
-                .deploy()
-                .await
-                .expect("MintableERC20 deployment failed");
+        let signing_provider = self
+            .web3()
+            .alloy
+            .with_signer(minter.clone().try_into_alloy().await.unwrap());
+
+        let nonce = self
+            .web3
+            .alloy
+            .get_transaction_count(minter.address().into_alloy())
+            .await
+            .unwrap();
+
+        for n in 0..N {
+            let contract_address =
+                contracts::alloy::ERC20Mintable::Instance::deploy_builder(signing_provider.clone())
+                    .from(minter.address().into_alloy())
+                    .nonce(nonce + (n as u64))
+                    .deploy()
+                    .await
+                    .expect("MintableERC20 deployment failed");
+            let contract = contracts::alloy::ERC20Mintable::Instance::new(
+                contract_address,
+                self.web3.alloy.clone(),
+            );
+
             res.push(MintableToken {
                 contract,
                 minter: minter.clone(),
@@ -423,19 +471,58 @@ impl OnchainComponents {
         weth_amount: U256,
     ) {
         for MintableToken { contract, minter } in tokens {
-            tx!(minter, contract.mint(minter.address(), token_amount));
+            let signing_provider = self
+                .web3()
+                .alloy
+                .with_signer(minter.clone().try_into_alloy().await.unwrap());
+
+            let nonce = self
+                .web3()
+                .alloy
+                .get_transaction_count(minter.address().into_alloy())
+                .await
+                .unwrap();
+
+            signing_provider
+                .send_and_watch(
+                    contract
+                        .mint(minter.address().into_alloy(), token_amount.into_alloy())
+                        .from(minter.address().into_alloy())
+                        .nonce(nonce)
+                        .into_transaction_request(),
+                )
+                .await
+                .unwrap();
             tx_value!(minter, weth_amount, self.contracts.weth.deposit());
 
             tx!(
                 minter,
-                self.contracts
-                    .uniswap_v2_factory
-                    .create_pair(contract.address(), self.contracts.weth.address())
+                self.contracts.uniswap_v2_factory.create_pair(
+                    contract.address().into_legacy(),
+                    self.contracts.weth.address()
+                )
             );
-            tx!(
-                minter,
-                contract.approve(self.contracts.uniswap_v2_router.address(), token_amount)
-            );
+
+            let nonce = self
+                .web3
+                .alloy
+                .get_transaction_count(minter.address().into_alloy())
+                .await
+                .unwrap();
+            signing_provider
+                .send_and_watch(
+                    contract
+                        .approve(
+                            self.contracts.uniswap_v2_router.address().into_alloy(),
+                            token_amount.into_alloy(),
+                        )
+                        .from(minter.address().into_alloy())
+                        .nonce(nonce)
+                        .into_transaction_request(),
+                )
+                .await
+                .unwrap();
+
             tx!(
                 minter,
                 self.contracts
@@ -445,7 +532,7 @@ impl OnchainComponents {
             tx!(
                 minter,
                 self.contracts.uniswap_v2_router.add_liquidity(
-                    contract.address(),
+                    contract.address().into_legacy(),
                     self.contracts.weth.address(),
                     token_amount,
                     weth_amount,
@@ -469,27 +556,44 @@ impl OnchainComponents {
 
         tx!(
             lp,
-            self.contracts
-                .uniswap_v2_factory
-                .create_pair(asset_a.0.address(), asset_b.0.address())
+            self.contracts.uniswap_v2_factory.create_pair(
+                asset_a.0.address().into_legacy(),
+                asset_b.0.address().into_legacy()
+            )
         );
-        tx!(
-            lp,
-            asset_a
-                .0
-                .approve(self.contracts.uniswap_v2_router.address(), asset_a.1)
-        );
-        tx!(
-            lp,
-            asset_b
-                .0
-                .approve(self.contracts.uniswap_v2_router.address(), asset_b.1)
-        );
+        let lp_nonce = self
+            .web3
+            .alloy
+            .get_transaction_count(lp.address().into_alloy())
+            .await
+            .unwrap();
+        asset_a
+            .0
+            .approve(
+                self.contracts.uniswap_v2_router.address().into_alloy(),
+                asset_a.1.into_alloy(),
+            )
+            .from(lp.address().into_alloy())
+            .nonce(lp_nonce)
+            .send_and_watch()
+            .await
+            .unwrap();
+        asset_b
+            .0
+            .approve(
+                self.contracts.uniswap_v2_router.address().into_alloy(),
+                asset_b.1.into_alloy(),
+            )
+            .from(lp.address().into_alloy())
+            .nonce(lp_nonce + 1)
+            .send_and_watch()
+            .await
+            .unwrap();
         tx!(
             lp,
             self.contracts.uniswap_v2_router.add_liquidity(
-                asset_a.0.address(),
-                asset_b.0.address(),
+                asset_a.0.address().into_legacy(),
+                asset_b.0.address().into_legacy(),
                 asset_a.1,
                 asset_b.1,
                 0_u64.into(),
@@ -508,7 +612,7 @@ impl OnchainComponents {
             &self.web3,
             self.contracts
                 .uniswap_v2_factory
-                .get_pair(self.contracts.weth.address(), token.address())
+                .get_pair(self.contracts.weth.address(), token.address().into_legacy())
                 .call()
                 .await
                 .expect("failed to get Uniswap V2 pair"),
@@ -518,16 +622,17 @@ impl OnchainComponents {
         // Mint amount + 1 to the pool, and then swap out 1 of the minted token
         // in order to force it to update its K-value.
         token.mint(pair.address(), amount + 1).await;
-        let (out0, out1) = if TokenPair::new(self.contracts.weth.address(), token.address())
-            .unwrap()
-            .get()
-            .0
-            == token.address()
-        {
-            (1, 0)
-        } else {
-            (0, 1)
-        };
+        let (out0, out1) =
+            if TokenPair::new(self.contracts.weth.address(), token.address().into_legacy())
+                .unwrap()
+                .get()
+                .0
+                == token.address().into_legacy()
+            {
+                (1, 0)
+            } else {
+                (0, 1)
+            };
         pair.swap(
             out0.into(),
             out1.into(),

--- a/crates/e2e/src/setup/onchain_components/safe.rs
+++ b/crates/e2e/src/setup/onchain_components/safe.rs
@@ -39,10 +39,7 @@ pub struct Infrastructure {
 }
 
 impl Infrastructure {
-    pub async fn new() -> Self {
-        // Using the NODE_HOST here kind of sucks but this is a workaround
-        // for the alloy provider signing issue
-        let provider = provider(NODE_HOST);
+    pub async fn new(provider: AlloyProvider) -> Self {
         let first_account = *provider.get_accounts().await.unwrap().first().unwrap();
 
         let singleton = {
@@ -141,8 +138,8 @@ impl Safe {
         // but it leads to boilerplate code that we don't need. Redeploying the
         // infrastructure contracts every time should have no appreciable impact in the
         // tests.
-        let infra = Infrastructure::new().await;
         let chain_id = U256::from(alloy.get_chain_id().await.unwrap());
+        let infra = Infrastructure::new(alloy).await;
         let contract = infra.deploy_safe(vec![owner.clone()], 1).await;
         Self {
             chain_id,

--- a/crates/e2e/src/setup/onchain_components/safe.rs
+++ b/crates/e2e/src/setup/onchain_components/safe.rs
@@ -1,6 +1,5 @@
 use {
     super::{OnchainComponents, TestAccount},
-    crate::nodes::NODE_HOST,
     alloy::{
         primitives::{Address, Bytes, U256},
         providers::Provider,
@@ -17,7 +16,6 @@ use {
         alloy::{
             ProviderSignerExt,
             conversions::{IntoAlloy, TryIntoAlloyAsync},
-            provider,
         },
     },
     hex_literal::hex,

--- a/crates/e2e/src/setup/onchain_components/safe.rs
+++ b/crates/e2e/src/setup/onchain_components/safe.rs
@@ -1,91 +1,119 @@
 use {
     super::{OnchainComponents, TestAccount},
-    contracts::{
-        GnosisSafe,
+    crate::nodes::NODE_HOST,
+    alloy::{
+        primitives::{Address, Bytes, U256},
+        providers::Provider,
+    },
+    contracts::alloy::{
+        GnosisSafe::{self, GnosisSafe::execTransactionCall},
         GnosisSafeCompatibilityFallbackHandler,
         GnosisSafeProxy,
         GnosisSafeProxyFactory,
     },
-    ethcontract::{Bytes, H160, H256, U256},
+    ethcontract::transaction::TransactionBuilder,
+    ethrpc::{
+        AlloyProvider,
+        alloy::{
+            ProviderSignerExt,
+            conversions::{IntoAlloy, TryIntoAlloyAsync},
+            provider,
+        },
+    },
     hex_literal::hex,
     model::{
         DomainSeparator,
         order::OrderCreation,
         signature::{Signature, hashed_eip712_message},
     },
-    shared::ethrpc::Web3,
-    web3::{
-        signing,
-        signing::{Key, SecretKeyRef},
-    },
+    std::marker::PhantomData,
+    web3::signing::{self},
 };
 
-macro_rules! tx_safe {
-    ($acc:expr_2021, $safe:ident, $call:expr_2021) => {{
-        let call = $call;
-        $crate::tx!(
-            $acc,
-            $safe.exec_transaction(
-                call.tx.to.unwrap(),
-                call.tx.value.unwrap_or_default(),
-                ::ethcontract::Bytes(call.tx.data.unwrap_or_default().0),
-                Default::default(),
-                Default::default(),
-                Default::default(),
-                Default::default(),
-                Default::default(),
-                Default::default(),
-                $crate::setup::safe::gnosis_safe_prevalidated_signature($acc.address()),
-            )
-        );
-    }};
-}
-
 pub struct Infrastructure {
-    pub factory: GnosisSafeProxyFactory,
-    pub fallback: GnosisSafeCompatibilityFallbackHandler,
-    pub singleton: GnosisSafe,
-    web3: Web3,
+    pub factory: GnosisSafeProxyFactory::Instance,
+    pub fallback: GnosisSafeCompatibilityFallbackHandler::Instance,
+    pub singleton: GnosisSafe::Instance,
+
+    pub provider: AlloyProvider,
 }
 
 impl Infrastructure {
-    pub async fn new(web3: &Web3) -> Self {
-        let singleton = GnosisSafe::builder(web3).deploy().await.unwrap();
-        let fallback = GnosisSafeCompatibilityFallbackHandler::builder(web3)
-            .deploy()
-            .await
-            .unwrap();
-        let factory = GnosisSafeProxyFactory::builder(web3)
-            .deploy()
-            .await
-            .unwrap();
+    pub async fn new() -> Self {
+        // Using the NODE_HOST here kind of sucks but this is a workaround
+        // for the alloy provider signing issue
+        let provider = provider(NODE_HOST);
+        let first_account = *provider.get_accounts().await.unwrap().first().unwrap();
+
+        let singleton = {
+            let deployed_address = GnosisSafe::Instance::deploy_builder(provider.clone())
+                .from(first_account)
+                .deploy()
+                .await
+                .unwrap();
+            GnosisSafe::Instance::new(deployed_address, provider.clone())
+        };
+        let fallback = {
+            let deployed_address =
+                GnosisSafeCompatibilityFallbackHandler::Instance::deploy_builder(provider.clone())
+                    .from(first_account)
+                    .deploy()
+                    .await
+                    .unwrap();
+            GnosisSafeCompatibilityFallbackHandler::Instance::new(
+                deployed_address,
+                provider.clone(),
+            )
+        };
+        let factory = {
+            let deployed_address =
+                GnosisSafeProxyFactory::Instance::deploy_builder(provider.clone())
+                    .from(first_account)
+                    .deploy()
+                    .await
+                    .unwrap();
+            GnosisSafeProxyFactory::Instance::new(deployed_address, provider.clone())
+        };
+
         Self {
-            web3: web3.clone(),
             singleton,
             fallback,
             factory,
+            provider,
         }
     }
 
-    pub async fn deploy_safe(&self, owners: Vec<H160>, threshold: usize) -> GnosisSafe {
-        let safe_proxy = GnosisSafeProxy::builder(&self.web3, self.singleton.address())
-            .deploy()
-            .await
-            .unwrap();
-        let safe = GnosisSafe::at(&self.web3, safe_proxy.address());
-        safe.setup(
-            owners,
-            threshold.into(),
-            H160::default(),  // delegate call
-            Bytes::default(), // delegate call bytes
-            self.fallback.address(),
-            H160::default(), // relayer payment token
-            0.into(),        // relayer payment amount
-            H160::default(), // relayer address
-        )
-        .send()
-        .await
-        .unwrap();
+    pub async fn deploy_safe(
+        &self,
+        owners: Vec<TestAccount>,
+        threshold: usize,
+    ) -> GnosisSafe::Instance {
+        let provider = self
+            .provider
+            .with_signer(owners[0].account().clone().try_into_alloy().await.unwrap());
+        let safe_proxy =
+            GnosisSafeProxy::Instance::deploy_builder(provider.clone(), *self.singleton.address())
+                .deploy()
+                .await
+                .unwrap();
+        let safe = GnosisSafe::Instance::new(safe_proxy, provider.clone());
+
+        contracts::alloy::macros::tx!(
+            safe.setup(
+                owners
+                    .into_iter()
+                    .map(|owner| owner.address().into_alloy())
+                    .collect(),
+                U256::from(threshold),
+                Address::default(), // delegate call
+                Bytes::default(),   // delegate call bytes
+                *self.fallback.address(),
+                Address::default(), // relayer payment token
+                U256::ZERO,         // relayer payment amount
+                Address::default(), // relayer address
+            )
+        );
+
         safe
     }
 }
@@ -93,13 +121,13 @@ impl Infrastructure {
 /// Wrapper over a deployed Safe.
 pub struct Safe {
     chain_id: U256,
-    contract: GnosisSafe,
+    contract: GnosisSafe::Instance,
     owner: TestAccount,
 }
 
 impl Safe {
     /// Return a wrapper at the deployed address.
-    pub fn deployed(chain_id: U256, contract: GnosisSafe, owner: TestAccount) -> Self {
+    pub fn deployed(chain_id: U256, contract: GnosisSafe::Instance, owner: TestAccount) -> Self {
         Self {
             chain_id,
             contract,
@@ -108,14 +136,14 @@ impl Safe {
     }
 
     /// Deploy a Safe with a single owner.
-    pub async fn deploy(owner: TestAccount, web3: &Web3) -> Self {
+    pub async fn deploy(owner: TestAccount, alloy: AlloyProvider) -> Self {
         // Infrastructure contracts can in principle be reused for any new deployments,
         // but it leads to boilerplate code that we don't need. Redeploying the
         // infrastructure contracts every time should have no appreciable impact in the
         // tests.
-        let infra = Infrastructure::new(web3).await;
-        let chain_id = web3.eth().chain_id().await.unwrap();
-        let contract = infra.deploy_safe(vec![owner.address()], 1).await;
+        let infra = Infrastructure::new().await;
+        let chain_id = U256::from(alloy.get_chain_id().await.unwrap());
+        let contract = infra.deploy_safe(vec![owner.clone()], 1).await;
         Self {
             chain_id,
             contract,
@@ -128,26 +156,47 @@ impl Safe {
         tx: ethcontract::dyns::DynMethodBuilder<T>,
     ) {
         let contract = &self.contract;
-        tx_safe!(self.owner.account(), contract, tx);
+        let TransactionBuilder {
+            data, value, to, ..
+        } = tx.tx;
+
+        contracts::alloy::macros::tx!(
+            contract.execTransaction(
+                to.unwrap().into_alloy(),
+                value.unwrap_or_default().into_alloy(),
+                alloy::primitives::Bytes::from(data.unwrap_or_default().0),
+                Default::default(),
+                Default::default(),
+                Default::default(),
+                Default::default(),
+                Default::default(),
+                Default::default(),
+                crate::setup::safe::gnosis_safe_prevalidated_signature(
+                    self.owner.address().into_alloy(),
+                ),
+            ),
+            self.owner.address().into_alloy()
+        );
     }
 
     /// Returns the address of the Safe.
-    pub fn address(&self) -> H160 {
-        self.contract.address()
+    pub fn address(&self) -> alloy::primitives::Address {
+        *self.contract.address()
     }
 
     /// Returns the next nonce to be used.
-    pub async fn nonce(&self) -> U256 {
+    pub async fn nonce(&self) -> alloy::primitives::U256 {
         self.contract.nonce().call().await.unwrap()
     }
 
     /// Returns a signed transaction ready for execution.
     pub fn sign_transaction(
         &self,
-        to: H160,
+        to: alloy::primitives::Address,
         data: Vec<u8>,
-        nonce: U256,
-    ) -> ethcontract::dyns::DynMethodBuilder<bool> {
+        nonce: alloy::primitives::U256,
+    ) -> alloy::contract::CallBuilder<&contracts::alloy::Provider, PhantomData<execTransactionCall>>
+    {
         let signature = self.sign({
             // `SafeTx` struct hash computation ported from the Safe Solidity code:
             // <https://etherscan.io/address/0xd9Db270c1B5E3Bd161E8c8503c55cEABeE709552#code#F1#L377>
@@ -158,9 +207,9 @@ impl Safe {
                 // <https://etherscan.io/address/0xd9Db270c1B5E3Bd161E8c8503c55cEABeE709552#code#F1#L43>
                 "bb8310d486368db6bd6f849402fdd73ad53d316b5a4b2644ad6efe0f941286d8"
             ));
-            buffer[44..64].copy_from_slice(to.as_bytes());
+            buffer[44..64].copy_from_slice(to.as_slice());
             buffer[96..128].copy_from_slice(&signing::keccak256(&data));
-            nonce.to_big_endian(&mut buffer[320..352]);
+            nonce.copy_be_bytes_to(&mut buffer[320..352]);
 
             // Since the [`sign_transaction`] transaction method only accepts
             // a limited number of parameters and defaults to 0 for the others,
@@ -170,17 +219,17 @@ impl Safe {
             signing::keccak256(&buffer)
         });
 
-        self.contract.exec_transaction(
+        self.contract.execTransaction(
             to,
             Default::default(), // value
-            Bytes(data),
+            alloy::primitives::Bytes::from(data),
             Default::default(), // operation (= CALL)
             Default::default(), // safe tx gas
             Default::default(), // base gas
             Default::default(), // gas price
             Default::default(), // gas token
             Default::default(), // refund receiver
-            Bytes(signature),
+            alloy::primitives::Bytes::from(signature),
         )
     }
 
@@ -228,8 +277,8 @@ impl Safe {
             // <https://etherscan.io/address/0xd9Db270c1B5E3Bd161E8c8503c55cEABeE709552#code#F1#L38>
             "47e79534a245952e8b16893a336b85a3d9ea9fa8c573f3d803afb92a79469218"
         ));
-        self.chain_id.to_big_endian(&mut buffer[32..64]);
-        buffer[76..96].copy_from_slice(self.contract.address().as_bytes());
+        self.chain_id.copy_be_bytes_to(&mut buffer[32..64]);
+        buffer[76..96].copy_from_slice(self.contract.address().as_slice());
 
         DomainSeparator(signing::keccak256(&buffer))
     }
@@ -260,42 +309,11 @@ impl Safe {
 /// See:
 /// - Documentation: <https://docs.gnosis-safe.io/contracts/signatures#pre-validated-signatures>
 /// - Code: <https://github.com/safe-global/safe-contracts/blob/c36bcab46578a442862d043e12a83fec41143dec/contracts/GnosisSafe.sol#L287-L291>
-pub fn gnosis_safe_prevalidated_signature(owner: H160) -> Bytes<Vec<u8>> {
+pub fn gnosis_safe_prevalidated_signature(
+    owner: alloy::primitives::Address,
+) -> alloy::primitives::Bytes {
     let mut signature = vec![0; 65];
-    signature[12..32].copy_from_slice(owner.as_bytes());
+    signature[12..32].copy_from_slice(owner.as_slice());
     signature[64] = 1;
-    Bytes(signature)
-}
-
-/// Generate an owner signature for EIP-1271.
-///
-/// The Gnosis Safe uses off-chain ECDSA signatures from its owners as the
-/// signature bytes when validating EIP-1271 signatures. Specifically, it
-/// expects a signed EIP-712 `SafeMessage(bytes message)` (where `message` is
-/// the 32-byte hash of the data being verified).
-///
-/// See:
-/// - Code: <https://github.com/safe-global/safe-contracts/blob/c36bcab46578a442862d043e12a83fec41143dec/contracts/handler/CompatibilityFallbackHandler.sol#L66-L70>
-pub async fn gnosis_safe_eip1271_signature(
-    key: SecretKeyRef<'_>,
-    safe: &GnosisSafe,
-    message_hash: H256,
-) -> Vec<u8> {
-    let handler =
-        GnosisSafeCompatibilityFallbackHandler::at(&safe.raw_instance().web3(), safe.address());
-
-    let signing_hash = handler
-        .get_message_hash(Bytes(message_hash.as_bytes().to_vec()))
-        .call()
-        .await
-        .unwrap();
-
-    let signature = key.sign(&signing_hash.0, None).unwrap();
-
-    let mut bytes = vec![0u8; 65];
-    bytes[0..32].copy_from_slice(signature.r.as_bytes());
-    bytes[32..64].copy_from_slice(signature.s.as_bytes());
-    bytes[64] = signature.v as _;
-
-    bytes
+    alloy::primitives::Bytes::from(signature)
 }

--- a/crates/e2e/src/setup/onchain_components/safe.rs
+++ b/crates/e2e/src/setup/onchain_components/safe.rs
@@ -3,6 +3,7 @@ use {
     alloy::{
         primitives::{Address, Bytes, U256},
         providers::Provider,
+        rpc::types::TransactionRequest,
     },
     contracts::alloy::{
         GnosisSafe::{self, GnosisSafe::execTransactionCall},
@@ -39,10 +40,12 @@ pub struct Infrastructure {
 impl Infrastructure {
     pub async fn new(provider: AlloyProvider) -> Self {
         let first_account = *provider.get_accounts().await.unwrap().first().unwrap();
+        let nonce = provider.get_transaction_count(first_account).await.unwrap();
 
         let singleton = {
             let deployed_address = GnosisSafe::Instance::deploy_builder(provider.clone())
                 .from(first_account)
+                .nonce(nonce)
                 .deploy()
                 .await
                 .unwrap();
@@ -52,6 +55,7 @@ impl Infrastructure {
             let deployed_address =
                 GnosisSafeCompatibilityFallbackHandler::Instance::deploy_builder(provider.clone())
                     .from(first_account)
+                    .nonce(nonce + 1)
                     .deploy()
                     .await
                     .unwrap();
@@ -64,6 +68,7 @@ impl Infrastructure {
             let deployed_address =
                 GnosisSafeProxyFactory::Instance::deploy_builder(provider.clone())
                     .from(first_account)
+                    .nonce(nonce + 2)
                     .deploy()
                     .await
                     .unwrap();
@@ -160,6 +165,33 @@ impl Safe {
                 to.unwrap().into_alloy(),
                 value.unwrap_or_default().into_alloy(),
                 alloy::primitives::Bytes::from(data.unwrap_or_default().0),
+                Default::default(),
+                Default::default(),
+                Default::default(),
+                Default::default(),
+                Default::default(),
+                Default::default(),
+                crate::setup::safe::gnosis_safe_prevalidated_signature(
+                    self.owner.address().into_alloy(),
+                )
+            ),
+            self.owner.address().into_alloy()
+        );
+    }
+
+    pub async fn exec_alloy_call(&self, tx: TransactionRequest) {
+        // let tx = tx.with_input_and_data();
+        let to = tx.to.unwrap().into_to().unwrap();
+        let value = tx.value.unwrap_or_default();
+        let data = tx.input.input().unwrap_or_default().to_owned();
+
+        tracing::error!("{:?}, {:?}, {:?}", to, data, value);
+
+        contracts::alloy::macros::tx!(
+            self.contract.execTransaction(
+                to,
+                value,
+                data,
                 Default::default(),
                 Default::default(),
                 Default::default(),

--- a/crates/e2e/tests/e2e/app_data.rs
+++ b/crates/e2e/tests/e2e/app_data.rs
@@ -1,7 +1,6 @@
 use {
     app_data::{AppDataHash, hash_full_app_data},
     e2e::{setup::*, tx},
-    ethcontract::prelude::U256,
     model::{
         order::{OrderCreation, OrderCreationAppData, OrderKind},
         quote::{OrderQuoteRequest, OrderQuoteSide, SellAmount},

--- a/crates/e2e/tests/e2e/app_data.rs
+++ b/crates/e2e/tests/e2e/app_data.rs
@@ -1,6 +1,11 @@
 use {
+    ::alloy::providers::Provider,
     app_data::{AppDataHash, hash_full_app_data},
-    e2e::{setup::*, tx},
+    e2e::setup::*,
+    ethrpc::alloy::{
+        ProviderSignerExt,
+        conversions::{IntoAlloy, IntoLegacy, TryIntoAlloyAsync},
+    },
     model::{
         order::{OrderCreation, OrderCreationAppData, OrderKind},
         quote::{OrderQuoteRequest, OrderQuoteSide, SellAmount},
@@ -35,18 +40,32 @@ async fn app_data(web3: Web3) {
         .await;
 
     token_a.mint(trader.address(), to_wei(10)).await;
-    tx!(
-        trader.account(),
-        token_a.approve(onchain.contracts().allowance, to_wei(10))
-    );
+    let tx = token_a
+        .approve(
+            onchain.contracts().allowance.into_alloy(),
+            to_wei(10).into_alloy(),
+        )
+        .from(trader.address().into_alloy())
+        .into_transaction_request();
+
+    onchain
+        .web3()
+        .alloy
+        .with_signer(trader.account().clone().try_into_alloy().await.unwrap())
+        .send_transaction(tx)
+        .await
+        .unwrap()
+        .watch()
+        .await
+        .unwrap();
 
     let mut valid_to: u32 = model::time::now_in_epoch_seconds() + 300;
     let mut create_order = |app_data| {
         let order = OrderCreation {
             app_data,
-            sell_token: token_a.address(),
+            sell_token: token_a.address().into_legacy(),
             sell_amount: to_wei(2),
-            buy_token: token_b.address(),
+            buy_token: token_b.address().into_legacy(),
             buy_amount: to_wei(1),
             valid_to,
             kind: OrderKind::Sell,
@@ -194,18 +213,31 @@ async fn app_data_full_format(web3: Web3) {
         .await;
 
     token_a.mint(trader.address(), to_wei(10)).await;
-    tx!(
-        trader.account(),
-        token_a.approve(onchain.contracts().allowance, to_wei(10))
-    );
+    let tx_req = token_a
+        .approve(
+            onchain.contracts().allowance.into_alloy(),
+            to_wei(10).into_alloy(),
+        )
+        .from(trader.address().into_alloy())
+        .into_transaction_request();
+    onchain
+        .web3()
+        .alloy
+        .with_signer(trader.account().to_owned().try_into_alloy().await.unwrap())
+        .send_transaction(tx_req)
+        .await
+        .unwrap()
+        .watch()
+        .await
+        .unwrap();
 
     let mut valid_to: u32 = model::time::now_in_epoch_seconds() + 300;
     let mut create_order = |app_data| {
         let order = OrderCreation {
             app_data,
-            sell_token: token_a.address(),
+            sell_token: token_a.address().into_legacy(),
             sell_amount: to_wei(2),
-            buy_token: token_b.address(),
+            buy_token: token_b.address().into_legacy(),
             buy_amount: to_wei(1),
             valid_to,
             kind: OrderKind::Sell,

--- a/crates/e2e/tests/e2e/app_data_signer.rs
+++ b/crates/e2e/tests/e2e/app_data_signer.rs
@@ -1,9 +1,10 @@
 use {
-    e2e::{
-        setup::{OnchainComponents, Services, TestAccount, run_test, safe::Safe, to_wei},
-        tx,
+    alloy::{primitives::Address, providers::Provider},
+    e2e::setup::{OnchainComponents, Services, TestAccount, run_test, safe::Safe, to_wei},
+    ethrpc::alloy::{
+        ProviderSignerExt,
+        conversions::{IntoAlloy, IntoLegacy, TryIntoAlloyAsync},
     },
-    ethrpc::alloy::conversions::{IntoAlloy, IntoLegacy},
     model::{
         order::{OrderCreation, OrderCreationAppData, OrderKind},
         signature::EcdsaSigningScheme,
@@ -28,23 +29,58 @@ async fn order_creation_checks_metadata_signer(web3: Web3) {
         .await;
 
     token_a.mint(trader.address(), to_wei(10)).await;
-    tx!(
-        trader.account(),
-        token_a.approve(onchain.contracts().allowance, to_wei(10))
-    );
+    onchain
+        .web3()
+        .alloy
+        .with_signer(trader.account().to_owned().try_into_alloy().await.unwrap())
+        .send_transaction(
+            token_a
+                .approve(
+                    onchain.contracts().allowance.into_alloy(),
+                    to_wei(10).into_alloy(),
+                )
+                .from(trader.address().into_alloy())
+                .into_transaction_request(),
+        )
+        .await
+        .unwrap()
+        .watch()
+        .await
+        .unwrap();
     token_a.mint(adversary.address(), to_wei(10)).await;
-    tx!(
-        adversary.account(),
-        token_a.approve(onchain.contracts().allowance, to_wei(10))
-    );
+    onchain
+        .web3()
+        .alloy
+        .with_signer(
+            adversary
+                .account()
+                .to_owned()
+                .try_into_alloy()
+                .await
+                .unwrap(),
+        )
+        .send_transaction(
+            token_a
+                .approve(
+                    onchain.contracts().allowance.into_alloy(),
+                    to_wei(10).into_alloy(),
+                )
+                .from(adversary.address().into_alloy())
+                .into_transaction_request(),
+        )
+        .await
+        .unwrap()
+        .watch()
+        .await
+        .unwrap();
 
     let mut valid_to: u32 = model::time::now_in_epoch_seconds() + 300;
     let mut create_order = |app_data| {
         let order = OrderCreation {
             app_data,
-            sell_token: token_a.address(),
+            sell_token: token_a.address().into_legacy(),
             sell_amount: to_wei(2),
-            buy_token: token_b.address(),
+            buy_token: token_b.address().into_legacy(),
             buy_amount: to_wei(1),
             valid_to,
             kind: OrderKind::Sell,
@@ -93,8 +129,26 @@ async fn order_creation_checks_metadata_signer(web3: Web3) {
 
     let safe = Safe::deploy(safe_owner.clone(), web3.alloy.clone()).await;
     token_a.mint(safe.address().into_legacy(), to_wei(10)).await;
-    safe.exec_call(token_a.approve(onchain.contracts().allowance, to_wei(10)))
-        .await;
+    tracing::error!(
+        "{}",
+        hex::encode(
+            token_a
+                .approve(
+                    onchain.contracts().allowance.into_alloy(),
+                    to_wei(10).into_alloy(),
+                )
+                .calldata()
+        )
+    );
+    safe.exec_alloy_call(
+        token_a
+            .approve(
+                onchain.contracts().allowance.into_alloy(),
+                to_wei(10).into_alloy(),
+            )
+            .into_transaction_request(),
+    )
+    .await;
 
     // Accepted: owner retrieved from app data.
     let full_app_data = full_app_data_with_signer(safe.address());
@@ -111,7 +165,7 @@ async fn order_creation_checks_metadata_signer(web3: Web3) {
     assert!(err.1.contains("AppdataFromMismatch"));
 }
 
-fn full_app_data_with_signer(signer: alloy::primitives::Address) -> OrderCreationAppData {
+fn full_app_data_with_signer(signer: Address) -> OrderCreationAppData {
     let app_data = format!("{{\"metadata\": {{\"signer\": \"{signer:?}\"}}}}");
     OrderCreationAppData::Full {
         full: app_data.to_string(),

--- a/crates/e2e/tests/e2e/banned_users.rs
+++ b/crates/e2e/tests/e2e/banned_users.rs
@@ -11,7 +11,7 @@ use {
         },
         tx,
     },
-    ethcontract::{H160, prelude::U256},
+    ethcontract::H160,
     ethrpc::Web3,
     model::quote::{OrderQuoteRequest, OrderQuoteSide, SellAmount},
     reqwest::StatusCode,

--- a/crates/e2e/tests/e2e/buffers.rs
+++ b/crates/e2e/tests/e2e/buffers.rs
@@ -1,6 +1,5 @@
 use {
     e2e::{setup::*, tx},
-    ethcontract::prelude::U256,
     model::{
         order::{OrderCreation, OrderKind},
         signature::EcdsaSigningScheme,

--- a/crates/e2e/tests/e2e/buffers.rs
+++ b/crates/e2e/tests/e2e/buffers.rs
@@ -1,5 +1,10 @@
 use {
-    e2e::{setup::*, tx},
+    ::alloy::{primitives::U256, providers::Provider},
+    e2e::setup::*,
+    ethrpc::alloy::{
+        ProviderSignerExt,
+        conversions::{IntoAlloy, IntoLegacy, TryIntoAlloyAsync},
+    },
     model::{
         order::{OrderCreation, OrderKind},
         signature::EcdsaSigningScheme,
@@ -33,10 +38,23 @@ async fn onchain_settlement_without_liquidity(web3: Web3) {
     token_b.mint(solver.address(), to_wei(1000)).await;
 
     // Approve GPv2 for trading
-    tx!(
-        trader.account(),
-        token_a.approve(onchain.contracts().allowance, to_wei(100))
-    );
+    let tx = token_a
+        .approve(
+            onchain.contracts().allowance.into_alloy(),
+            to_wei(100).into_alloy(),
+        )
+        .from(trader.address().into_alloy())
+        .into_transaction_request();
+    onchain
+        .web3()
+        .alloy
+        .with_signer(trader.account().clone().try_into_alloy().await.unwrap())
+        .send_transaction(tx)
+        .await
+        .unwrap()
+        .watch()
+        .await
+        .unwrap();
 
     // Start system
     colocation::start_driver(
@@ -83,9 +101,9 @@ async fn onchain_settlement_without_liquidity(web3: Web3) {
 
     // Place Order
     let order = OrderCreation {
-        sell_token: token_a.address(),
+        sell_token: token_a.address().into_legacy(),
         sell_amount: to_wei(9),
-        buy_token: token_b.address(),
+        buy_token: token_b.address().into_legacy(),
         buy_amount: to_wei(5),
         valid_to: model::time::now_in_epoch_seconds() + 300,
         kind: OrderKind::Buy,
@@ -100,18 +118,24 @@ async fn onchain_settlement_without_liquidity(web3: Web3) {
 
     tracing::info!("waiting for first trade");
     onchain.mint_block().await;
-    let trade_happened =
-        || async { token_b.balance_of(trader.address()).call().await.unwrap() == order.buy_amount };
+    let trade_happened = || async {
+        token_b
+            .balanceOf(trader.address().into_alloy())
+            .call()
+            .await
+            .unwrap()
+            == order.buy_amount.into_alloy()
+    };
     wait_for_condition(TIMEOUT, trade_happened).await.unwrap();
 
     // Check that settlement buffers were traded.
     let settlement_contract_balance = token_b
-        .balance_of(onchain.contracts().gp_settlement.address())
+        .balanceOf(onchain.contracts().gp_settlement.address().into_alloy())
         .call()
         .await
         .unwrap();
     // Check that internal buffers were used
-    assert!(settlement_contract_balance == 0.into());
+    assert!(settlement_contract_balance == U256::ZERO);
 
     // Same order can trade again with external liquidity
     let order = OrderCreation {
@@ -127,7 +151,12 @@ async fn onchain_settlement_without_liquidity(web3: Web3) {
 
     tracing::info!("waiting for second trade");
     let trade_happened = || async {
-        token_b.balance_of(trader.address()).call().await.unwrap() == order.buy_amount * 2
+        token_b
+            .balanceOf(trader.address().into_alloy())
+            .call()
+            .await
+            .unwrap()
+            == (order.buy_amount.into_alloy() * U256::from(2))
     };
     wait_for_condition(TIMEOUT, trade_happened).await.unwrap();
 }

--- a/crates/e2e/tests/e2e/cow_amm.rs
+++ b/crates/e2e/tests/e2e/cow_amm.rs
@@ -1,4 +1,5 @@
 use {
+    alloy::providers::Provider,
     app_data::AppDataHash,
     contracts::{
         ERC20,
@@ -8,11 +9,28 @@ use {
     e2e::{
         deploy,
         nodes::forked_node::ForkedNodeApi,
-        setup::{colocation::SolverEngine, mock::Mock, *},
+        setup::{
+            DeployedContracts,
+            OnchainComponents,
+            Services,
+            TIMEOUT,
+            colocation::{self, SolverEngine},
+            mock::Mock,
+            run_forked_test_with_block_number,
+            run_test,
+            to_wei,
+            to_wei_with_exp,
+            wait_for_condition,
+        },
         tx,
         tx_value,
     },
     ethcontract::{BlockId, BlockNumber, H160, U256, web3::ethabi::Token},
+    ethrpc::alloy::{
+        ProviderExt,
+        ProviderSignerExt,
+        conversions::{IntoAlloy, IntoLegacy, TryIntoAlloyAsync},
+    },
     model::{
         order::{OrderClass, OrderCreation, OrderData, OrderKind, OrderUid},
         quote::{OrderQuoteRequest, OrderQuoteSide, SellAmount},
@@ -72,10 +90,28 @@ async fn cow_amm_jit(web3: Web3) {
 
     // Fund cow amm owner with 2_000 dai and allow factory take them
     dai.mint(cow_amm_owner.address(), to_wei(2_000)).await;
-    tx!(
-        cow_amm_owner.account(),
-        dai.approve(cow_amm_factory.address(), to_wei(2_000))
+    let signing_provider = onchain.web3().alloy.with_signer(
+        cow_amm_owner
+            .account()
+            .clone()
+            .try_into_alloy()
+            .await
+            .unwrap(),
     );
+    let tx = dai
+        .approve(
+            cow_amm_factory.address().into_alloy(),
+            to_wei(2_000).into_alloy(),
+        )
+        .from(cow_amm_owner.address().into_alloy())
+        .into_transaction_request();
+    signing_provider
+        .send_transaction(tx)
+        .await
+        .unwrap()
+        .watch()
+        .await
+        .unwrap();
     // Fund cow amm owner with 1 WETH and allow factory take them
     tx_value!(
         cow_amm_owner.account(),
@@ -93,7 +129,10 @@ async fn cow_amm_jit(web3: Web3) {
     let pair = onchain
         .contracts()
         .uniswap_v2_factory
-        .get_pair(onchain.contracts().weth.address(), dai.address())
+        .get_pair(
+            onchain.contracts().weth.address(),
+            dai.address().into_legacy(),
+        )
         .call()
         .await
         .expect("failed to get Uniswap V2 pair");
@@ -101,7 +140,7 @@ async fn cow_amm_jit(web3: Web3) {
     let cow_amm = cow_amm_factory
         .amm_deterministic_address(
             cow_amm_owner.address(),
-            dai.address(),
+            dai.address().into_legacy(),
             onchain.contracts().weth.address(),
         )
         .call()
@@ -116,7 +155,7 @@ async fn cow_amm_jit(web3: Web3) {
 
     cow_amm_factory
         .create(
-            dai.address(),
+            dai.address().into_legacy(),
             to_wei(2_000),
             onchain.contracts().weth.address(),
             to_wei(1),
@@ -198,7 +237,7 @@ async fn cow_amm_jit(web3: Web3) {
     // surplus.
     let cow_amm_order = OrderData {
         sell_token: onchain.contracts().weth.address(),
-        buy_token: dai.address(),
+        buy_token: dai.address().into_legacy(),
         receiver: None,
         sell_amount: U256::exp10(17),
         buy_amount: to_wei(230),
@@ -292,7 +331,7 @@ async fn cow_amm_jit(web3: Web3) {
     let user_order = OrderCreation {
         sell_token: onchain.contracts().weth.address(),
         sell_amount: U256::exp10(17), // 0.1 WETH
-        buy_token: dai.address(),
+        buy_token: dai.address().into_legacy(),
         buy_amount: to_wei(230), // 230 DAI
         valid_to: model::time::now_in_epoch_seconds() + 300,
         kind: OrderKind::Sell,
@@ -305,8 +344,16 @@ async fn cow_amm_jit(web3: Web3) {
     );
     let user_order_id = services.create_order(&user_order).await.unwrap();
 
-    let amm_balance_before = dai.balance_of(cow_amm.address()).call().await.unwrap();
-    let bob_balance_before = dai.balance_of(bob.address()).call().await.unwrap();
+    let amm_balance_before = dai
+        .balanceOf(cow_amm.address().into_alloy())
+        .call()
+        .await
+        .unwrap();
+    let bob_balance_before = dai
+        .balanceOf(bob.address().into_alloy())
+        .call()
+        .await
+        .unwrap();
 
     let fee = U256::exp10(16); // 0.01 WETH
 
@@ -314,7 +361,7 @@ async fn cow_amm_jit(web3: Web3) {
         id: 1,
         // assume price of the univ2 pool
         prices: HashMap::from([
-            (dai.address(), to_wei(100)),
+            (dai.address().into_legacy(), to_wei(100)),
             (onchain.contracts().weth.address(), to_wei(300_000)),
         ]),
         trades: vec![
@@ -354,14 +401,23 @@ async fn cow_amm_jit(web3: Web3) {
     tracing::info!("Waiting for trade.");
     onchain.mint_block().await;
     wait_for_condition(TIMEOUT, || async {
-        let amm_balance = dai.balance_of(cow_amm.address()).call().await.unwrap();
-        let bob_balance = dai.balance_of(bob.address()).call().await.unwrap();
+        let amm_balance = dai
+            .balanceOf(cow_amm.address().into_alloy())
+            .call()
+            .await
+            .unwrap();
+        let bob_balance = dai
+            .balanceOf(bob.address().into_alloy())
+            .call()
+            .await
+            .unwrap();
 
         let amm_received = amm_balance - amm_balance_before;
         let bob_received = bob_balance - bob_balance_before;
 
         // bob and CoW AMM both got surplus and an equal amount
-        amm_received >= cow_amm_order.buy_amount && bob_received > user_order.buy_amount
+        amm_received >= cow_amm_order.buy_amount.into_alloy()
+            && bob_received > user_order.buy_amount.into_alloy()
     })
     .await
     .unwrap();
@@ -670,10 +726,28 @@ async fn cow_amm_opposite_direction(web3: Web3) {
     // Fund the CoW AMM owner with DAI and WETH and approve the factory to transfer
     // them
     dai.mint(cow_amm_owner.address(), to_wei(2_000)).await;
-    tx!(
-        cow_amm_owner.account(),
-        dai.approve(cow_amm_factory.address(), to_wei(2_000))
+    let signing_provider = onchain.web3().alloy.with_signer(
+        cow_amm_owner
+            .account()
+            .clone()
+            .try_into_alloy()
+            .await
+            .unwrap(),
     );
+    let tx = dai
+        .approve(
+            cow_amm_factory.address().into_alloy(),
+            to_wei(2_000).into_alloy(),
+        )
+        .from(cow_amm_owner.address().into_alloy())
+        .into_transaction_request();
+    signing_provider
+        .send_transaction(tx)
+        .await
+        .unwrap()
+        .watch()
+        .await
+        .unwrap();
 
     tx_value!(
         cow_amm_owner.account(),
@@ -697,7 +771,10 @@ async fn cow_amm_opposite_direction(web3: Web3) {
     let pair = onchain
         .contracts()
         .uniswap_v2_factory
-        .get_pair(onchain.contracts().weth.address(), dai.address())
+        .get_pair(
+            onchain.contracts().weth.address(),
+            dai.address().into_legacy(),
+        )
         .call()
         .await
         .expect("failed to get Uniswap V2 pair");
@@ -705,7 +782,7 @@ async fn cow_amm_opposite_direction(web3: Web3) {
     let cow_amm_address = cow_amm_factory
         .amm_deterministic_address(
             cow_amm_owner.address(),
-            dai.address(),
+            dai.address().into_legacy(),
             onchain.contracts().weth.address(),
         )
         .call()
@@ -721,7 +798,7 @@ async fn cow_amm_opposite_direction(web3: Web3) {
     // Create the CoW AMM
     cow_amm_factory
         .create(
-            dai.address(),
+            dai.address().into_legacy(),
             to_wei(2_000),
             onchain.contracts().weth.address(),
             to_wei(1),
@@ -795,7 +872,7 @@ async fn cow_amm_opposite_direction(web3: Web3) {
     // CoW AMM order remains the same (selling WETH for DAI)
     let cow_amm_order = OrderData {
         sell_token: onchain.contracts().weth.address(),
-        buy_token: dai.address(),
+        buy_token: dai.address().into_legacy(),
         receiver: None,
         sell_amount: U256::exp10(17), // 0.1 WETH
         buy_amount: executed_amount,  // 230 DAI
@@ -869,10 +946,18 @@ async fn cow_amm_opposite_direction(web3: Web3) {
 
     // Fund trader "bob" with DAI and approve allowance
     dai.mint(bob.address(), to_wei(250)).await;
-    tx!(
-        bob.account(),
-        dai.approve(onchain.contracts().allowance, U256::MAX)
-    );
+    let signing_provider = onchain
+        .web3()
+        .alloy
+        .with_signer(bob.account().clone().try_into_alloy().await.unwrap());
+    let tx = dai
+        .approve(
+            onchain.contracts().allowance.into_alloy(),
+            alloy::primitives::U256::MAX,
+        )
+        .from(bob.address().into_alloy())
+        .into_transaction_request();
+    signing_provider.send_and_watch(tx).await.unwrap();
 
     // Get balances before the trade
     let amm_weth_balance_before = onchain
@@ -902,7 +987,7 @@ async fn cow_amm_opposite_direction(web3: Web3) {
         Solution {
             id: 1,
             prices: HashMap::from([
-                (dai.address(), to_wei(1)),                         // 1 DAI = $1
+                (dai.address().into_legacy(), to_wei(1)), // 1 DAI = $1
                 (onchain.contracts().weth.address(), to_wei(2300)), // 1 WETH = $2300
             ]),
             trades: vec![
@@ -945,7 +1030,7 @@ async fn cow_amm_opposite_direction(web3: Web3) {
 
     let quote_request = OrderQuoteRequest {
         from: bob.address(),
-        sell_token: dai.address(),
+        sell_token: dai.address().into_legacy(),
         buy_token: onchain.contracts().weth.address(),
         side: OrderQuoteSide::Sell {
             sell_amount: SellAmount::AfterFee {
@@ -958,7 +1043,7 @@ async fn cow_amm_opposite_direction(web3: Web3) {
     // Must align with the mocked_solutions.
     let quote_response = services.submit_quote(&quote_request).await.unwrap();
     assert!(quote_response.verified);
-    assert_eq!(quote_response.quote.sell_token, dai.address());
+    assert_eq!(quote_response.quote.sell_token, dai.address().into_legacy());
     assert_eq!(
         quote_response.quote.buy_token,
         onchain.contracts().weth.address()
@@ -969,7 +1054,7 @@ async fn cow_amm_opposite_direction(web3: Web3) {
 
     // Place user order where bob sells DAI to buy WETH (opposite direction)
     let user_order = OrderCreation {
-        sell_token: dai.address(),
+        sell_token: dai.address().into_legacy(),
         sell_amount: executed_amount, // 230 DAI
         buy_token: onchain.contracts().weth.address(),
         buy_amount: U256::from(90000000000000000u64), // 0.09 WETH to generate some surplus

--- a/crates/e2e/tests/e2e/eth_integration.rs
+++ b/crates/e2e/tests/e2e/eth_integration.rs
@@ -1,6 +1,6 @@
 use {
     e2e::{setup::*, tx},
-    ethcontract::prelude::{Address, U256},
+    ethcontract::prelude::Address,
     model::{
         order::{BUY_ETH_ADDRESS, OrderCreation, OrderKind},
         quote::{OrderQuoteRequest, OrderQuoteSide, SellAmount},

--- a/crates/e2e/tests/e2e/eth_integration.rs
+++ b/crates/e2e/tests/e2e/eth_integration.rs
@@ -1,6 +1,11 @@
 use {
-    e2e::{setup::*, tx},
+    e2e::setup::*,
     ethcontract::prelude::Address,
+    ethrpc::alloy::{
+        ProviderExt,
+        ProviderSignerExt,
+        conversions::{IntoAlloy, IntoLegacy, TryIntoAlloyAsync},
+    },
     model::{
         order::{BUY_ETH_ADDRESS, OrderCreation, OrderKind},
         quote::{OrderQuoteRequest, OrderQuoteSide, SellAmount},
@@ -32,14 +37,34 @@ async fn eth_integration(web3: Web3) {
     token.mint(trader_b.address(), to_wei(51)).await;
 
     // Approve GPv2 for trading
-    tx!(
-        trader_a.account(),
-        token.approve(onchain.contracts().allowance, to_wei(51))
-    );
-    tx!(
-        trader_b.account(),
-        token.approve(onchain.contracts().allowance, to_wei(51))
-    );
+    let tx = token
+        .approve(
+            onchain.contracts().allowance.into_alloy(),
+            to_wei(51).into_alloy(),
+        )
+        .from(trader_a.address().into_alloy())
+        .into_transaction_request();
+    onchain
+        .web3()
+        .alloy
+        .with_signer(trader_a.account().clone().try_into_alloy().await.unwrap())
+        .send_and_watch(tx)
+        .await
+        .unwrap();
+    let tx = token
+        .approve(
+            onchain.contracts().allowance.into_alloy(),
+            to_wei(51).into_alloy(),
+        )
+        .from(trader_b.address().into_alloy())
+        .into_transaction_request();
+    onchain
+        .web3()
+        .alloy
+        .with_signer(trader_b.account().clone().try_into_alloy().await.unwrap())
+        .send_and_watch(tx)
+        .await
+        .unwrap();
 
     let trader_a_eth_balance_before = web3.eth().balance(trader_a.address(), None).await.unwrap();
 
@@ -63,16 +88,20 @@ async fn eth_integration(web3: Web3) {
             services.submit_quote(&request).await
         }
     };
-    quote(token.address(), BUY_ETH_ADDRESS).await.unwrap();
+    quote(token.address().into_legacy(), BUY_ETH_ADDRESS)
+        .await
+        .unwrap();
     // Eth is only supported as the buy token
-    let (status, body) = quote(BUY_ETH_ADDRESS, token.address()).await.unwrap_err();
+    let (status, body) = quote(BUY_ETH_ADDRESS, token.address().into_legacy())
+        .await
+        .unwrap_err();
     assert_eq!(status, 400, "{body}");
 
     // Place Orders
     assert_ne!(onchain.contracts().weth.address(), BUY_ETH_ADDRESS);
     let order_buy_eth_a = OrderCreation {
         kind: OrderKind::Buy,
-        sell_token: token.address(),
+        sell_token: token.address().into_legacy(),
         sell_amount: to_wei(50),
         buy_token: BUY_ETH_ADDRESS,
         buy_amount: to_wei(49),
@@ -87,7 +116,7 @@ async fn eth_integration(web3: Web3) {
     services.create_order(&order_buy_eth_a).await.unwrap();
     let order_buy_eth_b = OrderCreation {
         kind: OrderKind::Sell,
-        sell_token: token.address(),
+        sell_token: token.address().into_legacy(),
         sell_amount: to_wei(50),
         buy_token: BUY_ETH_ADDRESS,
         buy_amount: to_wei(49),

--- a/crates/e2e/tests/e2e/eth_safe.rs
+++ b/crates/e2e/tests/e2e/eth_safe.rs
@@ -1,18 +1,19 @@
 use {
     ::alloy::{primitives::U256, providers::Provider},
-    e2e::{
-        setup::{
-            OnchainComponents,
-            Services,
-            TIMEOUT,
-            run_test,
-            safe::Safe,
-            to_wei,
-            wait_for_condition,
-        },
-        tx,
+    e2e::setup::{
+        OnchainComponents,
+        Services,
+        TIMEOUT,
+        run_test,
+        safe::Safe,
+        to_wei,
+        wait_for_condition,
     },
-    ethrpc::alloy::conversions::IntoLegacy,
+    ethrpc::alloy::{
+        ProviderExt,
+        ProviderSignerExt,
+        conversions::{IntoAlloy, IntoLegacy, TryIntoAlloyAsync},
+    },
     model::{
         order::{BUY_ETH_ADDRESS, OrderCreation, OrderKind},
         signature::{Signature, hashed_eip712_message},
@@ -38,13 +39,30 @@ async fn test(web3: Web3) {
         .await;
 
     token.mint(trader.address(), to_wei(4)).await;
-    safe.exec_call(token.approve(onchain.contracts().allowance, to_wei(4)))
-        .await;
+    safe.exec_alloy_call(
+        token
+            .approve(
+                onchain.contracts().allowance.into_alloy(),
+                to_wei(4).into_alloy(),
+            )
+            .into_transaction_request(),
+    )
+    .await;
     token.mint(safe.address().into_legacy(), to_wei(4)).await;
-    tx!(
-        trader.account(),
-        token.approve(onchain.contracts().allowance, to_wei(4))
-    );
+    let tx = token
+        .approve(
+            onchain.contracts().allowance.into_alloy(),
+            to_wei(4).into_alloy(),
+        )
+        .from(trader.address().into_alloy())
+        .into_transaction_request();
+    onchain
+        .web3()
+        .alloy
+        .with_signer(trader.account().clone().try_into_alloy().await.unwrap())
+        .send_and_watch(tx)
+        .await
+        .unwrap();
 
     tracing::info!("Starting services.");
     let services = Services::new(&onchain).await;
@@ -61,7 +79,7 @@ async fn test(web3: Web3) {
     assert_eq!(balance, 0.into());
     let mut order = OrderCreation {
         from: Some(safe.address().into_legacy()),
-        sell_token: token.address(),
+        sell_token: token.address().into_legacy(),
         sell_amount: to_wei(4),
         buy_token: BUY_ETH_ADDRESS,
         buy_amount: to_wei(3),

--- a/crates/e2e/tests/e2e/ethflow.rs
+++ b/crates/e2e/tests/e2e/ethflow.rs
@@ -1,11 +1,32 @@
 use {
     anyhow::bail,
     autopilot::database::onchain_order_events::ethflow_events::WRAP_ALL_SELECTOR,
-    contracts::{CoWSwapEthFlow, ERC20Mintable, WETH9},
+    contracts::{CoWSwapEthFlow, WETH9, alloy::ERC20Mintable},
     database::order_events::OrderEventLabel,
-    e2e::{nodes::local_node::TestNodeApi, setup::*, tx, tx_value},
+    e2e::{
+        nodes::local_node::TestNodeApi,
+        setup::{
+            ACCOUNT_ENDPOINT,
+            API_HOST,
+            Contracts,
+            OnchainComponents,
+            Services,
+            TIMEOUT,
+            TRADES_ENDPOINT,
+            TestAccount,
+            run_test,
+            to_wei,
+            wait_for_condition,
+        },
+        tx,
+        tx_value,
+    },
     ethcontract::{Account, Bytes, H160, H256, U256, transaction::TransactionResult},
-    ethrpc::{Web3, block_stream::timestamp_of_current_block_in_seconds},
+    ethrpc::{
+        Web3,
+        alloy::conversions::{IntoAlloy, IntoLegacy},
+        block_stream::timestamp_of_current_block_in_seconds,
+    },
     hex_literal::hex,
     model::{
         DomainSeparator,
@@ -81,7 +102,7 @@ async fn eth_flow_tx(web3: Web3) {
         .await;
 
     // Get a quote from the services
-    let buy_token = dai.address();
+    let buy_token = dai.address().into_legacy();
     let receiver = H160([0x42; 20]);
     let sell_amount = to_wei(1);
     let intent = EthFlowTradeIntent {
@@ -94,8 +115,9 @@ async fn eth_flow_tx(web3: Web3) {
     services.start_protocol(solver).await;
 
     let approve_call_data = {
-        let bytes = dai.approve(trader.address(), to_wei(10)).tx.data.unwrap();
-        format!("0x{}", hex::encode(&bytes.0))
+        let call_builder = dai.approve(trader.address().into_alloy(), to_wei(10).into_alloy());
+        let calldata = call_builder.calldata();
+        format!("0x{}", hex::encode(&calldata))
     };
 
     let hash = services
@@ -122,7 +144,7 @@ async fn eth_flow_tx(web3: Web3) {
          }}
     }}
 }}"#,
-                dai.address(),
+                dai.address().into_legacy(),
                 approve_call_data,
                 onchain.contracts().weth.address(),
                 approve_call_data,
@@ -197,11 +219,11 @@ async fn eth_flow_tx(web3: Web3) {
     // which proofs that the interactions were correctly sandboxed.
     let trampoline = onchain.contracts().hooks.address();
     let allowance = dai
-        .allowance(trampoline, trader.address())
+        .allowance(trampoline.into_alloy(), trader.address().into_alloy())
         .call()
         .await
         .unwrap();
-    assert_eq!(allowance, to_wei(10));
+    assert_eq!(allowance, to_wei(10).into_alloy());
 
     let allowance = onchain
         .contracts()
@@ -216,11 +238,11 @@ async fn eth_flow_tx(web3: Web3) {
     // able to set an allowance on behalf of the settlement contract.
     let settlement = onchain.contracts().gp_settlement.address();
     let allowance = dai
-        .allowance(settlement, trader.address())
+        .allowance(settlement.into_alloy(), trader.address().into_alloy())
         .call()
         .await
         .unwrap();
-    assert_eq!(allowance, 0.into());
+    assert_eq!(allowance, alloy::primitives::U256::ZERO);
 
     let allowance = onchain
         .contracts()
@@ -250,7 +272,7 @@ async fn eth_flow_without_quote(web3: Web3) {
         + timestamp_of_current_block_in_seconds(&web3).await.unwrap()
         + 3600;
     let ethflow_order = ExtendedEthFlowOrder(EthflowOrder {
-        buy_token: dai.address(),
+        buy_token: dai.address().into_legacy(),
         sell_amount: to_wei(1),
         buy_amount: 1.into(),
         valid_to,
@@ -302,7 +324,7 @@ async fn eth_flow_indexing_after_refund(web3: Web3) {
             &services,
             &(EthFlowTradeIntent {
                 sell_amount: 42.into(),
-                buy_token: dai.address(),
+                buy_token: dai.address().into_legacy(),
                 receiver: H160([42; 20]),
             })
             .to_quote_request(dummy_trader.account().address(), &onchain.contracts().weth),
@@ -328,7 +350,7 @@ async fn eth_flow_indexing_after_refund(web3: Web3) {
         .await;
 
     // Create the actual order that should be picked up by the services and matched.
-    let buy_token = dai.address();
+    let buy_token = dai.address().into_legacy();
     let receiver = H160([0x42; 20]);
     let sell_amount = to_wei(1);
     let valid_to = chrono::offset::Utc::now().timestamp() as u32
@@ -478,14 +500,17 @@ async fn test_trade_availability_in_api(
 
 async fn test_order_was_settled(ethflow_order: &ExtendedEthFlowOrder, web3: &Web3) {
     wait_for_condition(TIMEOUT, || async {
-        let buy_token = ERC20Mintable::at(web3, ethflow_order.0.buy_token);
+        let buy_token = ERC20Mintable::Instance::new(
+            ethflow_order.0.buy_token.into_alloy(),
+            web3.alloy.clone(),
+        );
         let receiver_buy_token_balance = buy_token
-            .balance_of(ethflow_order.0.receiver)
+            .balanceOf(ethflow_order.0.receiver.into_alloy())
             .call()
             .await
             .expect("Unable to get token balance");
 
-        receiver_buy_token_balance >= ethflow_order.0.buy_amount
+        receiver_buy_token_balance >= ethflow_order.0.buy_amount.into_alloy()
     })
     .await
     .unwrap();
@@ -817,7 +842,7 @@ async fn eth_flow_zero_buy_amount(web3: Web3) {
             + timestamp_of_current_block_in_seconds(&web3).await.unwrap()
             + 3600;
         let ethflow_order = ExtendedEthFlowOrder(EthflowOrder {
-            buy_token: dai.address(),
+            buy_token: dai.address().into_legacy(),
             sell_amount: to_wei(1),
             buy_amount: buy_amount.into(),
             valid_to,

--- a/crates/e2e/tests/e2e/hooks.rs
+++ b/crates/e2e/tests/e2e/hooks.rs
@@ -1,12 +1,23 @@
 use {
+    alloy::providers::Provider,
     app_data::Hook,
-    contracts::GnosisSafe,
     e2e::{
-        setup::{safe::Safe, *},
+        setup::{
+            OnchainComponents,
+            Services,
+            TIMEOUT,
+            hook_for_transaction,
+            onchain_components,
+            run_test,
+            safe::Safe,
+            to_wei,
+            wait_for_condition,
+        },
         tx,
         tx_value,
     },
-    ethcontract::{Bytes, H160, U256},
+    ethcontract::U256,
+    ethrpc::alloy::conversions::{IntoAlloy, IntoLegacy},
     model::{
         order::{OrderCreation, OrderCreationAppData, OrderKind},
         quote::{OrderQuoteRequest, OrderQuoteSide, SellAmount},
@@ -239,67 +250,72 @@ async fn allowance(web3: Web3) {
 async fn signature(web3: Web3) {
     let mut onchain = OnchainComponents::deploy(web3.clone()).await;
 
-    let chain_id = web3.eth().chain_id().await.unwrap();
+    let chain_id = alloy::primitives::U256::from(web3.alloy.get_chain_id().await.unwrap());
 
     let [solver] = onchain.make_solvers(to_wei(1)).await;
     let [trader] = onchain.make_accounts(to_wei(1)).await;
 
-    let safe_infra = safe::Infrastructure::new(&web3).await;
+    let safe_infra = onchain_components::safe::Infrastructure::new().await;
 
     // Prepare the Safe creation transaction, but don't execute it! This will
     // be executed as a pre-hook.
-    let safe_creation_builder = safe_infra.factory.create_proxy(
-        safe_infra.singleton.address(),
-        ethcontract::Bytes(
-            safe_infra
-                .singleton
-                .setup(
-                    vec![trader.address()], // owners
-                    1.into(),               // threshold
-                    H160::default(),        // delegate call
-                    Bytes::default(),       // delegate call bytes
-                    safe_infra.fallback.address(),
-                    H160::default(), // relayer payment token
-                    0.into(),        // relayer payment amount
-                    H160::default(), // relayer address
-                )
-                .tx
-                .data
-                .unwrap()
-                .0,
-        ),
+    let safe_creation_builder = safe_infra.factory.createProxy(
+        *safe_infra.singleton.address(),
+        safe_infra
+            .singleton
+            .setup(
+                vec![trader.address().into_alloy()],   // owners
+                alloy::primitives::U256::ONE,          // threshold
+                alloy::primitives::Address::default(), // delegate call
+                alloy::primitives::Bytes::default(),   // delegate call bytes
+                *safe_infra.fallback.address(),
+                alloy::primitives::Address::default(), // relayer payment token
+                alloy::primitives::U256::ZERO,         // relayer payment amount
+                alloy::primitives::Address::default(), // relayer address
+            )
+            .calldata()
+            .clone(),
     );
-    let safe_creation = hook_for_transaction(safe_creation_builder.tx.clone()).await;
+    let safe_creation =
+        onchain_components::alloy::hook_for_transaction(safe_creation_builder.clone()).await;
 
     // Create a contract instance at the would-be address of the Safe we are
     // creating with the pre-hook.
-    let safe_address = safe_creation_builder.clone().view().call().await.unwrap();
+    let safe_address = safe_creation_builder.clone().call().await.unwrap();
     let safe = Safe::deployed(
         chain_id,
-        GnosisSafe::at(&web3, safe_address),
+        contracts::alloy::GnosisSafe::Instance::new(safe_address, web3.alloy.clone()),
         trader.clone(),
     );
 
     let [token] = onchain
         .deploy_tokens_with_weth_uni_v2_pools(to_wei(100_000), to_wei(100_000))
         .await;
-    token.mint(safe.address(), to_wei(5)).await;
+    token.mint(safe.address().into_legacy(), to_wei(5)).await;
 
     // Sign an approval transaction for trading. This will be at nonce 0 because
     // it is the first transaction evah!
     let approval_builder = safe.sign_transaction(
-        token.address(),
+        token.address().into_alloy(),
         token
             .approve(onchain.contracts().allowance, to_wei(5))
             .tx
             .data
             .unwrap()
             .0,
-        0.into(),
+        alloy::primitives::U256::ZERO,
     );
+    let call_data = approval_builder.calldata().to_vec();
+    let target = approval_builder
+        .into_transaction_request()
+        .to
+        .unwrap()
+        .into_to()
+        .unwrap()
+        .into_legacy();
     let approval = Hook {
-        target: approval_builder.tx.to.unwrap(),
-        call_data: approval_builder.tx.data.unwrap().0,
+        target,
+        call_data,
         // The contract isn't deployed, so we can't estimate this. Instead, we
         // just guess an amount that should be high enough.
         gas_limit: 100_000,
@@ -311,7 +327,7 @@ async fn signature(web3: Web3) {
 
     // Place Orders
     let mut order = OrderCreation {
-        from: Some(safe.address()),
+        from: Some(safe.address().into_legacy()),
         // Quotes for trades where the pre-interactions deploy a contract
         // at the `from` address currently can't be verified.
         // To not throw an error because we can't get a verifiable quote
@@ -344,17 +360,25 @@ async fn signature(web3: Web3) {
     services.create_order(&order).await.unwrap();
     onchain.mint_block().await;
 
-    let balance = token.balance_of(safe.address()).call().await.unwrap();
+    let balance = token
+        .balance_of(safe.address().into_legacy())
+        .call()
+        .await
+        .unwrap();
     assert_eq!(balance, to_wei(5));
 
     // Check that the Safe really hasn't been deployed yet.
-    let code = web3.eth().code(safe.address(), None).await.unwrap();
+    let code = web3
+        .eth()
+        .code(safe.address().into_legacy(), None)
+        .await
+        .unwrap();
     assert_eq!(code.0.len(), 0);
 
     tracing::info!("Waiting for trade.");
     let trade_happened = || async {
         token
-            .balance_of(safe.address())
+            .balance_of(safe.address().into_legacy())
             .call()
             .await
             .unwrap()
@@ -367,14 +391,18 @@ async fn signature(web3: Web3) {
     let balance = onchain
         .contracts()
         .weth
-        .balance_of(safe.address())
+        .balance_of(safe.address().into_legacy())
         .call()
         .await
         .unwrap();
     assert!(balance >= order.buy_amount);
 
     // Check Safe was deployed
-    let code = web3.eth().code(safe.address(), None).await.unwrap();
+    let code = web3
+        .eth()
+        .code(safe.address().into_legacy(), None)
+        .await
+        .unwrap();
     assert_ne!(code.0.len(), 0);
 
     tracing::info!("Waiting for auction to be cleared.");
@@ -489,69 +517,74 @@ async fn partial_fills(web3: Web3) {
 async fn quote_verification(web3: Web3) {
     let mut onchain = OnchainComponents::deploy(web3.clone()).await;
 
-    let chain_id = web3.eth().chain_id().await.unwrap();
+    let chain_id = alloy::primitives::U256::from(web3.alloy.get_chain_id().await.unwrap());
 
     let [trader] = onchain.make_accounts(to_wei(1)).await;
     let [solver] = onchain.make_solvers(to_wei(1)).await;
 
-    let safe_infra = safe::Infrastructure::new(&web3).await;
+    let safe_infra = onchain_components::safe::Infrastructure::new().await;
 
     // Prepare the Safe creation transaction, but don't execute it! This will
     // be executed as a pre-hook.
-    let safe_creation_builder = safe_infra.factory.create_proxy(
-        safe_infra.singleton.address(),
-        ethcontract::Bytes(
-            safe_infra
-                .singleton
-                .setup(
-                    vec![trader.address()], // owners
-                    1.into(),               // threshold
-                    H160::default(),        // delegate call
-                    Bytes::default(),       // delegate call bytes
-                    safe_infra.fallback.address(),
-                    H160::default(), // relayer payment token
-                    0.into(),        // relayer payment amount
-                    H160::default(), // relayer address
-                )
-                .tx
-                .data
-                .unwrap()
-                .0,
-        ),
+    let safe_creation_builder = safe_infra.factory.createProxy(
+        *safe_infra.singleton.address(),
+        safe_infra
+            .singleton
+            .setup(
+                vec![trader.address().into_alloy()],   // owners
+                alloy::primitives::U256::ONE,          // threshold
+                alloy::primitives::Address::default(), // delegate call
+                alloy::primitives::Bytes::default(),   // delegate call bytes
+                *safe_infra.fallback.address(),
+                alloy::primitives::Address::default(), // relayer payment token
+                alloy::primitives::U256::ZERO,         // relayer payment amount
+                alloy::primitives::Address::default(), // relayer address
+            )
+            .calldata()
+            .clone(),
     );
-    let safe_address = safe_creation_builder.clone().view().call().await.unwrap();
-    safe_creation_builder.clone().send().await.unwrap();
+    let safe_address = safe_creation_builder.clone().call().await.unwrap();
+    let first_account = *web3.alloy.get_accounts().await.unwrap().first().unwrap();
+    contracts::alloy::macros::tx!(safe_creation_builder, first_account);
 
     let safe = Safe::deployed(
         chain_id,
-        GnosisSafe::at(&web3, safe_address),
+        contracts::alloy::GnosisSafe::Instance::new(safe_address, web3.alloy.clone()),
         trader.clone(),
     );
 
     let [token] = onchain
         .deploy_tokens_with_weth_uni_v2_pools(to_wei(100_000), to_wei(100_000))
         .await;
-    token.mint(safe.address(), to_wei(5)).await;
+    token.mint(safe.address().into_legacy(), to_wei(5)).await;
     tx!(
         trader.account(),
         token.approve(onchain.contracts().allowance, to_wei(5))
     );
 
-    // Sign transaction transfering 5 token from the safe to the trader
+    // Sign transaction transferring 5 token from the safe to the trader
     // to fund the trade in a pre-hook.
     let transfer_builder = safe.sign_transaction(
-        token.address(),
+        token.address().into_alloy(),
         token
             .transfer(trader.address(), to_wei(5))
             .tx
             .data
             .unwrap()
             .0,
-        0.into(),
+        alloy::primitives::U256::ZERO,
     );
+    let call_data = transfer_builder.calldata().to_vec();
+    let target = transfer_builder
+        .into_transaction_request()
+        .to
+        .unwrap()
+        .into_to()
+        .unwrap()
+        .into_legacy();
     let transfer = Hook {
-        target: transfer_builder.tx.to.unwrap(),
-        call_data: transfer_builder.tx.data.unwrap().0,
+        target,
+        call_data,
         gas_limit: 100_000,
     };
 

--- a/crates/e2e/tests/e2e/hooks.rs
+++ b/crates/e2e/tests/e2e/hooks.rs
@@ -255,7 +255,7 @@ async fn signature(web3: Web3) {
     let [solver] = onchain.make_solvers(to_wei(1)).await;
     let [trader] = onchain.make_accounts(to_wei(1)).await;
 
-    let safe_infra = onchain_components::safe::Infrastructure::new().await;
+    let safe_infra = onchain_components::safe::Infrastructure::new(web3.alloy.clone()).await;
 
     // Prepare the Safe creation transaction, but don't execute it! This will
     // be executed as a pre-hook.
@@ -522,7 +522,7 @@ async fn quote_verification(web3: Web3) {
     let [trader] = onchain.make_accounts(to_wei(1)).await;
     let [solver] = onchain.make_solvers(to_wei(1)).await;
 
-    let safe_infra = onchain_components::safe::Infrastructure::new().await;
+    let safe_infra = onchain_components::safe::Infrastructure::new(web3.alloy.clone()).await;
 
     // Prepare the Safe creation transaction, but don't execute it! This will
     // be executed as a pre-hook.

--- a/crates/e2e/tests/e2e/hooks.rs
+++ b/crates/e2e/tests/e2e/hooks.rs
@@ -277,7 +277,9 @@ async fn signature(web3: Web3) {
             .clone(),
     );
     let safe_creation =
-        onchain_components::alloy::hook_for_transaction(safe_creation_builder.clone()).await;
+        onchain_components::alloy::hook_for_transaction(safe_creation_builder.clone())
+            .await
+            .unwrap();
 
     // Create a contract instance at the would-be address of the Safe we are
     // creating with the pre-hook.

--- a/crates/e2e/tests/e2e/hooks.rs
+++ b/crates/e2e/tests/e2e/hooks.rs
@@ -17,7 +17,11 @@ use {
         tx_value,
     },
     ethcontract::U256,
-    ethrpc::alloy::conversions::{IntoAlloy, IntoLegacy},
+    ethrpc::alloy::{
+        ProviderExt,
+        ProviderSignerExt,
+        conversions::{IntoAlloy, IntoLegacy, TryIntoAlloyAsync},
+    },
     model::{
         order::{OrderCreation, OrderCreationAppData, OrderKind},
         quote::{OrderQuoteRequest, OrderQuoteSide, SellAmount},
@@ -297,14 +301,16 @@ async fn signature(web3: Web3) {
 
     // Sign an approval transaction for trading. This will be at nonce 0 because
     // it is the first transaction evah!
+    let approval_call_data = token
+        .approve(
+            onchain.contracts().allowance.into_alloy(),
+            to_wei(5).into_alloy(),
+        )
+        .calldata()
+        .to_vec(); // hmm
     let approval_builder = safe.sign_transaction(
-        token.address().into_alloy(),
-        token
-            .approve(onchain.contracts().allowance, to_wei(5))
-            .tx
-            .data
-            .unwrap()
-            .0,
+        *token.address(),
+        approval_call_data,
         alloy::primitives::U256::ZERO,
     );
     let call_data = approval_builder.calldata().to_vec();
@@ -337,7 +343,7 @@ async fn signature(web3: Web3) {
         // `from` currently has.
         sell_amount: to_wei(6),
         partially_fillable: true,
-        sell_token: token.address(),
+        sell_token: token.address().into_legacy(),
         buy_token: onchain.contracts().weth.address(),
         buy_amount: to_wei(3),
         valid_to: model::time::now_in_epoch_seconds() + 300,
@@ -363,10 +369,11 @@ async fn signature(web3: Web3) {
     onchain.mint_block().await;
 
     let balance = token
-        .balance_of(safe.address().into_legacy())
+        .balanceOf(safe.address())
         .call()
         .await
-        .unwrap();
+        .unwrap()
+        .into_legacy();
     assert_eq!(balance, to_wei(5));
 
     // Check that the Safe really hasn't been deployed yet.
@@ -380,7 +387,7 @@ async fn signature(web3: Web3) {
     tracing::info!("Waiting for trade.");
     let trade_happened = || async {
         token
-            .balance_of(safe.address().into_legacy())
+            .balanceOf(safe.address())
             .call()
             .await
             .unwrap()
@@ -448,7 +455,7 @@ async fn partial_fills(web3: Web3) {
     let order = OrderCreation {
         sell_token: onchain.contracts().weth.address(),
         sell_amount: to_wei(2),
-        buy_token: token.address(),
+        buy_token: token.address().into_legacy(),
         buy_amount: to_wei(1),
         valid_to: model::time::now_in_epoch_seconds() + 300,
         kind: OrderKind::Sell,
@@ -559,21 +566,29 @@ async fn quote_verification(web3: Web3) {
         .deploy_tokens_with_weth_uni_v2_pools(to_wei(100_000), to_wei(100_000))
         .await;
     token.mint(safe.address().into_legacy(), to_wei(5)).await;
-    tx!(
-        trader.account(),
-        token.approve(onchain.contracts().allowance, to_wei(5))
-    );
+    let tx = token
+        .approve(
+            onchain.contracts().allowance.into_alloy(),
+            to_wei(5).into_alloy(),
+        )
+        .from(trader.address().into_alloy())
+        .into_transaction_request();
+    onchain
+        .web3()
+        .alloy
+        .with_signer(trader.account().clone().try_into_alloy().await.unwrap())
+        .send_and_watch(tx)
+        .await
+        .unwrap();
 
     // Sign transaction transferring 5 token from the safe to the trader
     // to fund the trade in a pre-hook.
     let transfer_builder = safe.sign_transaction(
-        token.address().into_alloy(),
+        *token.address(),
         token
-            .transfer(trader.address(), to_wei(5))
-            .tx
-            .data
-            .unwrap()
-            .0,
+            .transfer(trader.address().into_alloy(), to_wei(5).into_alloy())
+            .calldata()
+            .to_vec(),
         alloy::primitives::U256::ZERO,
     );
     let call_data = transfer_builder.calldata().to_vec();
@@ -597,7 +612,7 @@ async fn quote_verification(web3: Web3) {
     let quote = services
         .submit_quote(&OrderQuoteRequest {
             from: trader.address(),
-            sell_token: token.address(),
+            sell_token: token.address().into_legacy(),
             buy_token: onchain.contracts().weth.address(),
             side: OrderQuoteSide::Sell {
                 sell_amount: SellAmount::BeforeFee {

--- a/crates/e2e/tests/e2e/jit_orders.rs
+++ b/crates/e2e/tests/e2e/jit_orders.rs
@@ -5,6 +5,11 @@ use {
         tx_value,
     },
     ethcontract::prelude::U256,
+    ethrpc::alloy::{
+        ProviderExt,
+        ProviderSignerExt,
+        conversions::{IntoAlloy, IntoLegacy, TryIntoAlloyAsync},
+    },
     model::{
         order::{OrderClass, OrderCreation, OrderKind},
         signature::EcdsaSigningScheme,
@@ -45,10 +50,20 @@ async fn single_limit_order_test(web3: Web3) {
             .weth
             .approve(onchain.contracts().allowance, U256::MAX)
     );
-    tx!(
-        solver.account(),
-        token.approve(onchain.contracts().allowance, U256::MAX)
-    );
+    let tx = token
+        .approve(
+            onchain.contracts().allowance.into_alloy(),
+            U256::MAX.into_alloy(),
+        )
+        .from(solver.address().into_alloy())
+        .into_transaction_request();
+    onchain
+        .web3()
+        .alloy
+        .with_signer(solver.account().clone().try_into_alloy().await.unwrap())
+        .send_and_watch(tx)
+        .await
+        .unwrap();
 
     let services = Services::new(&onchain).await;
 
@@ -71,7 +86,7 @@ async fn single_limit_order_test(web3: Web3) {
                 name: "mock_solver".into(),
                 account: solver.clone(),
                 endpoint: mock_solver.url.clone(),
-                base_tokens: vec![token.address()],
+                base_tokens: vec![token.address().into_legacy()],
                 merge_solutions: true,
             },
         ],
@@ -104,7 +119,7 @@ async fn single_limit_order_test(web3: Web3) {
     let order = OrderCreation {
         sell_token: onchain.contracts().weth.address(),
         sell_amount: to_wei(10),
-        buy_token: token.address(),
+        buy_token: token.address().into_legacy(),
         buy_amount: to_wei(5),
         valid_to: model::time::now_in_epoch_seconds() + 300,
         kind: OrderKind::Sell,
@@ -116,8 +131,16 @@ async fn single_limit_order_test(web3: Web3) {
         SecretKeyRef::from(&SecretKey::from_slice(trader.private_key()).unwrap()),
     );
 
-    let trader_balance_before = token.balance_of(trader.address()).call().await.unwrap();
-    let solver_balance_before = token.balance_of(solver.address()).call().await.unwrap();
+    let trader_balance_before = token
+        .balanceOf(trader.address().into_alloy())
+        .call()
+        .await
+        .unwrap();
+    let solver_balance_before = token
+        .balanceOf(solver.address().into_alloy())
+        .call()
+        .await
+        .unwrap();
     let order_id = services.create_order(&order).await.unwrap();
     let limit_order = services.get_order(&order_id).await.unwrap();
     onchain.mint_block().await;
@@ -127,7 +150,7 @@ async fn single_limit_order_test(web3: Web3) {
         owner: trader.address(),
         sell: Asset {
             amount: to_wei(10),
-            token: token.address(),
+            token: token.address().into_legacy(),
         },
         buy: Asset {
             amount: to_wei(1),
@@ -148,7 +171,7 @@ async fn single_limit_order_test(web3: Web3) {
     mock_solver.configure_solution(Some(Solution {
         id: 0,
         prices: HashMap::from([
-            (token.address(), to_wei(1)),
+            (token.address().into_legacy(), to_wei(1)),
             (onchain.contracts().weth.address(), to_wei(1)),
         ]),
         trades: vec![
@@ -176,15 +199,23 @@ async fn single_limit_order_test(web3: Web3) {
     tracing::info!("Waiting for trade.");
     onchain.mint_block().await;
     wait_for_condition(TIMEOUT, || async {
-        let trader_balance_after = token.balance_of(trader.address()).call().await.unwrap();
-        let solver_balance_after = token.balance_of(solver.address()).call().await.unwrap();
+        let trader_balance_after = token
+            .balanceOf(trader.address().into_alloy())
+            .call()
+            .await
+            .unwrap();
+        let solver_balance_after = token
+            .balanceOf(solver.address().into_alloy())
+            .call()
+            .await
+            .unwrap();
 
         let trader_balance_increased =
-            trader_balance_after.saturating_sub(trader_balance_before) >= to_wei(5);
+            trader_balance_after.saturating_sub(trader_balance_before) >= to_wei(5).into_alloy();
         // Since the fee is 0 in the custom solution, the balance difference has to be
         // exactly 10 wei
         let solver_balance_decreased =
-            solver_balance_before.saturating_sub(solver_balance_after) == to_wei(10);
+            solver_balance_before.saturating_sub(solver_balance_after) == to_wei(10).into_alloy();
         trader_balance_increased && solver_balance_decreased
     })
     .await

--- a/crates/e2e/tests/e2e/limit_orders.rs
+++ b/crates/e2e/tests/e2e/limit_orders.rs
@@ -6,6 +6,11 @@ use {
     driver::domain::eth::NonZeroU256,
     e2e::{nodes::forked_node::ForkedNodeApi, setup::*, tx},
     ethcontract::{H160, prelude::U256},
+    ethrpc::alloy::{
+        ProviderExt,
+        ProviderSignerExt,
+        conversions::{IntoAlloy, IntoLegacy, TryIntoAlloyAsync},
+    },
     fee::{FeePolicyOrderClass, ProtocolFee, ProtocolFeesConfig},
     model::{
         order::{OrderClass, OrderCreation, OrderKind},
@@ -108,30 +113,44 @@ async fn single_limit_order_test(web3: Web3) {
     token_b.mint(solver.address(), to_wei(1000)).await;
     tx!(
         solver.account(),
-        onchain
-            .contracts()
-            .uniswap_v2_factory
-            .create_pair(token_a.address(), token_b.address())
-    );
-    tx!(
-        solver.account(),
-        token_a.approve(
-            onchain.contracts().uniswap_v2_router.address(),
-            to_wei(1000)
+        onchain.contracts().uniswap_v2_factory.create_pair(
+            token_a.address().into_legacy(),
+            token_b.address().into_legacy()
         )
     );
-    tx!(
-        solver.account(),
-        token_b.approve(
-            onchain.contracts().uniswap_v2_router.address(),
-            to_wei(1000)
+    let tx = token_a
+        .approve(
+            onchain.contracts().uniswap_v2_router.address().into_alloy(),
+            to_wei(1000).into_alloy(),
         )
-    );
+        .from(solver.address().into_alloy())
+        .into_transaction_request();
+    onchain
+        .web3()
+        .alloy
+        .with_signer(solver.account().clone().try_into_alloy().await.unwrap())
+        .send_and_watch(tx)
+        .await
+        .unwrap();
+    let tx = token_b
+        .approve(
+            onchain.contracts().uniswap_v2_router.address().into_alloy(),
+            to_wei(1000).into_alloy(),
+        )
+        .from(solver.address().into_alloy())
+        .into_transaction_request();
+    onchain
+        .web3()
+        .alloy
+        .with_signer(solver.account().clone().try_into_alloy().await.unwrap())
+        .send_and_watch(tx)
+        .await
+        .unwrap();
     tx!(
         solver.account(),
         onchain.contracts().uniswap_v2_router.add_liquidity(
-            token_a.address(),
-            token_b.address(),
+            token_a.address().into_legacy(),
+            token_b.address().into_legacy(),
             to_wei(1000),
             to_wei(1000),
             0_u64.into(),
@@ -142,19 +161,29 @@ async fn single_limit_order_test(web3: Web3) {
     );
 
     // Approve GPv2 for trading
-    tx!(
-        trader_a.account(),
-        token_a.approve(onchain.contracts().allowance, to_wei(10))
-    );
+    let tx = token_a
+        .approve(
+            onchain.contracts().allowance.into_alloy(),
+            to_wei(10).into_alloy(),
+        )
+        .from(trader_a.address().into_alloy())
+        .into_transaction_request();
+    onchain
+        .web3()
+        .alloy
+        .with_signer(trader_a.account().clone().try_into_alloy().await.unwrap())
+        .send_and_watch(tx)
+        .await
+        .unwrap();
 
     // Place Orders
     let services = Services::new(&onchain).await;
     services.start_protocol(solver).await;
 
     let order = OrderCreation {
-        sell_token: token_a.address(),
+        sell_token: token_a.address().into_legacy(),
         sell_amount: to_wei(10),
-        buy_token: token_b.address(),
+        buy_token: token_b.address().into_legacy(),
         buy_amount: to_wei(5),
         valid_to: model::time::now_in_epoch_seconds() + 300,
         kind: OrderKind::Sell,
@@ -165,7 +194,11 @@ async fn single_limit_order_test(web3: Web3) {
         &onchain.contracts().domain_separator,
         SecretKeyRef::from(&SecretKey::from_slice(trader_a.private_key()).unwrap()),
     );
-    let balance_before = token_b.balance_of(trader_a.address()).call().await.unwrap();
+    let balance_before = token_b
+        .balanceOf(trader_a.address().into_alloy())
+        .call()
+        .await
+        .unwrap();
     let order_id = services.create_order(&order).await.unwrap();
 
     // we hide the quote's execution plan while the order is still fillable
@@ -182,8 +215,12 @@ async fn single_limit_order_test(web3: Web3) {
     // Drive solution
     tracing::info!("Waiting for trade.");
     wait_for_condition(TIMEOUT, || async {
-        let balance_after = token_b.balance_of(trader_a.address()).call().await.unwrap();
-        balance_after.checked_sub(balance_before).unwrap() >= to_wei(5)
+        let balance_after = token_b
+            .balanceOf(trader_a.address().into_alloy())
+            .call()
+            .await
+            .unwrap();
+        balance_after.checked_sub(balance_before).unwrap() >= to_wei(5).into_alloy()
     })
     .await
     .unwrap();
@@ -216,30 +253,44 @@ async fn two_limit_orders_test(web3: Web3) {
     // Create and fund Uniswap pool
     tx!(
         solver.account(),
-        onchain
-            .contracts()
-            .uniswap_v2_factory
-            .create_pair(token_a.address(), token_b.address())
-    );
-    tx!(
-        solver.account(),
-        token_a.approve(
-            onchain.contracts().uniswap_v2_router.address(),
-            to_wei(1000)
+        onchain.contracts().uniswap_v2_factory.create_pair(
+            token_a.address().into_legacy(),
+            token_b.address().into_legacy()
         )
     );
-    tx!(
-        solver.account(),
-        token_b.approve(
-            onchain.contracts().uniswap_v2_router.address(),
-            to_wei(1000)
+    let tx = token_a
+        .approve(
+            onchain.contracts().uniswap_v2_router.address().into_alloy(),
+            to_wei(1000).into_alloy(),
         )
-    );
+        .from(solver.address().into_alloy())
+        .into_transaction_request();
+    onchain
+        .web3()
+        .alloy
+        .with_signer(solver.account().clone().try_into_alloy().await.unwrap())
+        .send_and_watch(tx)
+        .await
+        .unwrap();
+    let tx = token_b
+        .approve(
+            onchain.contracts().uniswap_v2_router.address().into_alloy(),
+            to_wei(1000).into_alloy(),
+        )
+        .from(solver.address().into_alloy())
+        .into_transaction_request();
+    onchain
+        .web3()
+        .alloy
+        .with_signer(solver.account().clone().try_into_alloy().await.unwrap())
+        .send_and_watch(tx)
+        .await
+        .unwrap();
     tx!(
         solver.account(),
         onchain.contracts().uniswap_v2_router.add_liquidity(
-            token_a.address(),
-            token_b.address(),
+            token_a.address().into_legacy(),
+            token_b.address().into_legacy(),
             to_wei(1000),
             to_wei(1000),
             0_u64.into(),
@@ -250,23 +301,43 @@ async fn two_limit_orders_test(web3: Web3) {
     );
 
     // Approve GPv2 for trading
-    tx!(
-        trader_a.account(),
-        token_a.approve(onchain.contracts().allowance, to_wei(10))
-    );
-    tx!(
-        trader_b.account(),
-        token_b.approve(onchain.contracts().allowance, to_wei(10))
-    );
+    let tx = token_a
+        .approve(
+            onchain.contracts().allowance.into_alloy(),
+            to_wei(10).into_alloy(),
+        )
+        .from(trader_a.address().into_alloy())
+        .into_transaction_request();
+    onchain
+        .web3()
+        .alloy
+        .with_signer(trader_a.account().clone().try_into_alloy().await.unwrap())
+        .send_and_watch(tx)
+        .await
+        .unwrap();
+    let tx = token_b
+        .approve(
+            onchain.contracts().allowance.into_alloy(),
+            to_wei(10).into_alloy(),
+        )
+        .from(trader_b.address().into_alloy())
+        .into_transaction_request();
+    onchain
+        .web3()
+        .alloy
+        .with_signer(trader_b.account().clone().try_into_alloy().await.unwrap())
+        .send_and_watch(tx)
+        .await
+        .unwrap();
 
     // Place Orders
     let services = Services::new(&onchain).await;
     services.start_protocol(solver).await;
 
     let order_a = OrderCreation {
-        sell_token: token_a.address(),
+        sell_token: token_a.address().into_legacy(),
         sell_amount: to_wei(10),
-        buy_token: token_b.address(),
+        buy_token: token_b.address().into_legacy(),
         buy_amount: to_wei(5),
         valid_to: model::time::now_in_epoch_seconds() + 300,
         kind: OrderKind::Sell,
@@ -278,8 +349,16 @@ async fn two_limit_orders_test(web3: Web3) {
         SecretKeyRef::from(&SecretKey::from_slice(trader_a.private_key()).unwrap()),
     );
 
-    let balance_before_a = token_b.balance_of(trader_a.address()).call().await.unwrap();
-    let balance_before_b = token_a.balance_of(trader_b.address()).call().await.unwrap();
+    let balance_before_a = token_b
+        .balanceOf(trader_a.address().into_alloy())
+        .call()
+        .await
+        .unwrap();
+    let balance_before_b = token_a
+        .balanceOf(trader_b.address().into_alloy())
+        .call()
+        .await
+        .unwrap();
 
     let order_id = services.create_order(&order_a).await.unwrap();
     onchain.mint_block().await;
@@ -288,9 +367,9 @@ async fn two_limit_orders_test(web3: Web3) {
     assert!(limit_order.metadata.class.is_limit());
 
     let order_b = OrderCreation {
-        sell_token: token_b.address(),
+        sell_token: token_b.address().into_legacy(),
         sell_amount: to_wei(5),
-        buy_token: token_a.address(),
+        buy_token: token_a.address().into_legacy(),
         buy_amount: to_wei(2),
         valid_to: model::time::now_in_epoch_seconds() + 300,
         kind: OrderKind::Sell,
@@ -309,10 +388,20 @@ async fn two_limit_orders_test(web3: Web3) {
     // Drive solution
     tracing::info!("Waiting for trade.");
     wait_for_condition(TIMEOUT, || async {
-        let balance_after_a = token_b.balance_of(trader_a.address()).call().await.unwrap();
-        let balance_after_b = token_a.balance_of(trader_b.address()).call().await.unwrap();
-        let order_a_settled = balance_after_a.saturating_sub(balance_before_a) >= to_wei(5);
-        let order_b_settled = balance_after_b.saturating_sub(balance_before_b) >= to_wei(2);
+        let balance_after_a = token_b
+            .balanceOf(trader_a.address().into_alloy())
+            .call()
+            .await
+            .unwrap();
+        let balance_after_b = token_a
+            .balanceOf(trader_b.address().into_alloy())
+            .call()
+            .await
+            .unwrap();
+        let order_a_settled =
+            balance_after_a.saturating_sub(balance_before_a) >= to_wei(5).into_alloy();
+        let order_b_settled =
+            balance_after_b.saturating_sub(balance_before_b) >= to_wei(2).into_alloy();
         order_a_settled && order_b_settled
     })
     .await
@@ -347,14 +436,34 @@ async fn two_limit_orders_multiple_winners_test(web3: Web3) {
         .await;
 
     // Approve GPv2 for trading
-    tx!(
-        trader_a.account(),
-        token_a.approve(onchain.contracts().allowance, to_wei(100))
-    );
-    tx!(
-        trader_b.account(),
-        token_b.approve(onchain.contracts().allowance, to_wei(100))
-    );
+    let tx = token_a
+        .approve(
+            onchain.contracts().allowance.into_alloy(),
+            to_wei(100).into_alloy(),
+        )
+        .from(trader_a.address().into_alloy())
+        .into_transaction_request();
+    onchain
+        .web3()
+        .alloy
+        .with_signer(trader_a.account().clone().try_into_alloy().await.unwrap())
+        .send_and_watch(tx)
+        .await
+        .unwrap();
+    let tx = token_b
+        .approve(
+            onchain.contracts().allowance.into_alloy(),
+            to_wei(100).into_alloy(),
+        )
+        .from(trader_b.address().into_alloy())
+        .into_transaction_request();
+    onchain
+        .web3()
+        .alloy
+        .with_signer(trader_b.account().clone().try_into_alloy().await.unwrap())
+        .send_and_watch(tx)
+        .await
+        .unwrap();
 
     // Start system, with two solvers, one that knows about base_a and one that
     // knows about base_b
@@ -365,7 +474,7 @@ async fn two_limit_orders_multiple_winners_test(web3: Web3) {
                 "test_solver".into(),
                 solver_a.clone(),
                 onchain.contracts().weth.address(),
-                vec![base_a.address()],
+                vec![base_a.address().into_legacy()],
                 2,
                 false,
             )
@@ -374,7 +483,7 @@ async fn two_limit_orders_multiple_winners_test(web3: Web3) {
                 "solver2".into(),
                 solver_b.clone(),
                 onchain.contracts().weth.address(),
-                vec![base_b.address()],
+                vec![base_b.address().into_legacy()],
                 2,
                 false,
             )
@@ -393,9 +502,9 @@ async fn two_limit_orders_multiple_winners_test(web3: Web3) {
 
     // Place Orders
     let order_a = OrderCreation {
-        sell_token: token_a.address(),
+        sell_token: token_a.address().into_legacy(),
         sell_amount: to_wei(10),
-        buy_token: token_c.address(),
+        buy_token: token_c.address().into_legacy(),
         buy_amount: to_wei(5),
         valid_to: model::time::now_in_epoch_seconds() + 300,
         kind: OrderKind::Sell,
@@ -409,9 +518,9 @@ async fn two_limit_orders_multiple_winners_test(web3: Web3) {
     let uid_a = services.create_order(&order_a).await.unwrap();
 
     let order_b = OrderCreation {
-        sell_token: token_b.address(),
+        sell_token: token_b.address().into_legacy(),
         sell_amount: to_wei(10),
-        buy_token: token_d.address(),
+        buy_token: token_d.address().into_legacy(),
         buy_amount: to_wei(5),
         valid_to: model::time::now_in_epoch_seconds() + 300,
         kind: OrderKind::Sell,
@@ -567,10 +676,20 @@ async fn too_many_limit_orders_test(web3: Web3) {
     token_a.mint(trader.address(), to_wei(1)).await;
 
     // Approve GPv2 for trading
-    tx!(
-        trader.account(),
-        token_a.approve(onchain.contracts().allowance, to_wei(101))
-    );
+    let tx = token_a
+        .approve(
+            onchain.contracts().allowance.into_alloy(),
+            to_wei(101).into_alloy(),
+        )
+        .from(trader.address().into_alloy())
+        .into_transaction_request();
+    onchain
+        .web3()
+        .alloy
+        .with_signer(trader.account().clone().try_into_alloy().await.unwrap())
+        .send_and_watch(tx)
+        .await
+        .unwrap();
 
     // Place Orders
     let services = Services::new(&onchain).await;
@@ -598,7 +717,7 @@ async fn too_many_limit_orders_test(web3: Web3) {
         .await;
 
     let order = OrderCreation {
-        sell_token: token_a.address(),
+        sell_token: token_a.address().into_legacy(),
         sell_amount: to_wei(1),
         buy_token: onchain.contracts().weth.address(),
         buy_amount: to_wei(1),
@@ -616,7 +735,7 @@ async fn too_many_limit_orders_test(web3: Web3) {
     // Attempt to place another order, but the orderbook is configured to allow only
     // one limit order per user.
     let order = OrderCreation {
-        sell_token: token_a.address(),
+        sell_token: token_a.address().into_legacy(),
         sell_amount: to_wei(1),
         buy_token: onchain.contracts().weth.address(),
         buy_amount: to_wei(2),
@@ -646,10 +765,20 @@ async fn limit_does_not_apply_to_in_market_orders_test(web3: Web3) {
     token.mint(trader.address(), to_wei(100)).await;
 
     // Approve GPv2 for trading
-    tx!(
-        trader.account(),
-        token.approve(onchain.contracts().allowance, to_wei(101))
-    );
+    let tx = token
+        .approve(
+            onchain.contracts().allowance.into_alloy(),
+            to_wei(101).into_alloy(),
+        )
+        .from(trader.address().into_alloy())
+        .into_transaction_request();
+    onchain
+        .web3()
+        .alloy
+        .with_signer(trader.account().clone().try_into_alloy().await.unwrap())
+        .send_and_watch(tx)
+        .await
+        .unwrap();
 
     // Place Orders
     let services = Services::new(&onchain).await;
@@ -678,7 +807,7 @@ async fn limit_does_not_apply_to_in_market_orders_test(web3: Web3) {
 
     let quote_request = OrderQuoteRequest {
         from: trader.address(),
-        sell_token: token.address(),
+        sell_token: token.address().into_legacy(),
         buy_token: onchain.contracts().weth.address(),
         side: OrderQuoteSide::Sell {
             sell_amount: SellAmount::BeforeFee {
@@ -691,7 +820,7 @@ async fn limit_does_not_apply_to_in_market_orders_test(web3: Web3) {
 
     // Place "in-market" order
     let order = OrderCreation {
-        sell_token: token.address(),
+        sell_token: token.address().into_legacy(),
         sell_amount: quote.quote.sell_amount,
         buy_token: onchain.contracts().weth.address(),
         buy_amount: quote.quote.buy_amount.saturating_sub(to_wei(4)),
@@ -708,7 +837,7 @@ async fn limit_does_not_apply_to_in_market_orders_test(web3: Web3) {
 
     // Place a "limit" order
     let order = OrderCreation {
-        sell_token: token.address(),
+        sell_token: token.address().into_legacy(),
         sell_amount: to_wei(1),
         buy_token: onchain.contracts().weth.address(),
         buy_amount: to_wei(3),
@@ -727,7 +856,7 @@ async fn limit_does_not_apply_to_in_market_orders_test(web3: Web3) {
 
     // Place another "in-market" order in order to check it is not limited
     let order = OrderCreation {
-        sell_token: token.address(),
+        sell_token: token.address().into_legacy(),
         sell_amount: quote.quote.sell_amount,
         buy_token: onchain.contracts().weth.address(),
         buy_amount: quote.quote.buy_amount.saturating_sub(to_wei(2)),
@@ -744,7 +873,7 @@ async fn limit_does_not_apply_to_in_market_orders_test(web3: Web3) {
 
     // Place a "limit" order in order to see if fails
     let order = OrderCreation {
-        sell_token: token.address(),
+        sell_token: token.address().into_legacy(),
         sell_amount: to_wei(1),
         buy_token: onchain.contracts().weth.address(),
         buy_amount: to_wei(2),
@@ -977,10 +1106,20 @@ async fn no_liquidity_limit_order(web3: Web3) {
     token_a.mint(trader_a.address(), to_wei(10)).await;
 
     // Approve GPv2 for trading
-    tx!(
-        trader_a.account(),
-        token_a.approve(onchain.contracts().allowance, to_wei(10))
-    );
+    let tx = token_a
+        .approve(
+            onchain.contracts().allowance.into_alloy(),
+            to_wei(10).into_alloy(),
+        )
+        .from(trader_a.address().into_alloy())
+        .into_transaction_request();
+    onchain
+        .web3()
+        .alloy
+        .with_signer(trader_a.account().clone().try_into_alloy().await.unwrap())
+        .send_and_watch(tx)
+        .await
+        .unwrap();
 
     // Setup services
     let protocol_fees_config = ProtocolFeesConfig(vec![
@@ -1017,7 +1156,7 @@ async fn no_liquidity_limit_order(web3: Web3) {
 
     // Place order
     let mut order = OrderCreation {
-        sell_token: token_a.address(),
+        sell_token: token_a.address().into_legacy(),
         sell_amount: to_wei(10),
         buy_token: onchain.contracts().weth.address(),
         buy_amount: to_wei(1),
@@ -1036,7 +1175,7 @@ async fn no_liquidity_limit_order(web3: Web3) {
     assert_eq!(limit_order.metadata.class, OrderClass::Limit);
 
     // Cannot place orders with unsupported tokens
-    order.sell_token = unsupported.address();
+    order.sell_token = unsupported.address().into_legacy();
     services
         .create_order(&order.sign(
             EcdsaSigningScheme::Eip712,

--- a/crates/e2e/tests/e2e/order_cancellation.rs
+++ b/crates/e2e/tests/e2e/order_cancellation.rs
@@ -1,7 +1,6 @@
 use {
     database::order_events::OrderEventLabel,
     e2e::{setup::*, tx},
-    ethcontract::prelude::U256,
     model::{
         order::{
             CancellationPayload,

--- a/crates/e2e/tests/e2e/order_cancellation.rs
+++ b/crates/e2e/tests/e2e/order_cancellation.rs
@@ -1,6 +1,11 @@
 use {
     database::order_events::OrderEventLabel,
-    e2e::{setup::*, tx},
+    e2e::setup::*,
+    ethrpc::alloy::{
+        ProviderExt,
+        ProviderSignerExt,
+        conversions::{IntoAlloy, IntoLegacy, TryIntoAlloyAsync},
+    },
     model::{
         order::{
             CancellationPayload,
@@ -40,10 +45,20 @@ async fn order_cancellation(web3: Web3) {
     token.mint(trader.address(), to_wei(10)).await;
 
     // Approve GPv2 for trading
-    tx!(
-        trader.account(),
-        token.approve(onchain.contracts().allowance, to_wei(10))
-    );
+    let tx = token
+        .approve(
+            onchain.contracts().allowance.into_alloy(),
+            to_wei(10).into_alloy(),
+        )
+        .from(trader.address().into_alloy())
+        .into_transaction_request();
+    onchain
+        .web3()
+        .alloy
+        .with_signer(trader.account().clone().try_into_alloy().await.unwrap())
+        .send_and_watch(tx)
+        .await
+        .unwrap();
 
     let services = Services::new(&onchain).await;
     colocation::start_driver(
@@ -86,7 +101,7 @@ async fn order_cancellation(web3: Web3) {
 
         let request = OrderQuoteRequest {
             from: trader.address(),
-            sell_token: token.address(),
+            sell_token: token.address().into_legacy(),
             buy_token: onchain.contracts().weth.address(),
             side: OrderQuoteSide::Sell {
                 sell_amount: SellAmount::AfterFee {

--- a/crates/e2e/tests/e2e/partially_fillable_balance.rs
+++ b/crates/e2e/tests/e2e/partially_fillable_balance.rs
@@ -1,6 +1,11 @@
 use {
+    ::alloy::primitives::U256,
     e2e::{setup::*, tx},
-    ethcontract::prelude::U256,
+    ethrpc::alloy::{
+        ProviderExt,
+        ProviderSignerExt,
+        conversions::{IntoAlloy, IntoLegacy, TryIntoAlloyAsync},
+    },
     model::{
         order::{OrderCreation, OrderKind},
         signature::EcdsaSigningScheme,
@@ -31,51 +36,75 @@ async fn test(web3: Web3) {
 
     tx!(
         solver.account(),
-        onchain
-            .contracts()
-            .uniswap_v2_factory
-            .create_pair(token_a.address(), token_b.address())
-    );
-    tx!(
-        solver.account(),
-        token_a.approve(
-            onchain.contracts().uniswap_v2_router.address(),
-            to_wei(1000)
+        onchain.contracts().uniswap_v2_factory.create_pair(
+            token_a.address().into_legacy(),
+            token_b.address().into_legacy()
         )
     );
-    tx!(
-        solver.account(),
-        token_b.approve(
-            onchain.contracts().uniswap_v2_router.address(),
-            to_wei(1000)
+    let tx = token_a
+        .approve(
+            onchain.contracts().uniswap_v2_router.address().into_alloy(),
+            to_wei(1000).into_alloy(),
         )
-    );
+        .from(solver.address().into_alloy())
+        .into_transaction_request();
+    onchain
+        .web3()
+        .alloy
+        .with_signer(solver.account().clone().try_into_alloy().await.unwrap())
+        .send_and_watch(tx)
+        .await
+        .unwrap();
+    let tx = token_b
+        .approve(
+            onchain.contracts().uniswap_v2_router.address().into_alloy(),
+            to_wei(1000).into_alloy(),
+        )
+        .from(solver.address().into_alloy())
+        .into_transaction_request();
+    onchain
+        .web3()
+        .alloy
+        .with_signer(solver.account().clone().try_into_alloy().await.unwrap())
+        .send_and_watch(tx)
+        .await
+        .unwrap();
     tx!(
         solver.account(),
         onchain.contracts().uniswap_v2_router.add_liquidity(
-            token_a.address(),
-            token_b.address(),
+            token_a.address().into_legacy(),
+            token_b.address().into_legacy(),
             to_wei(1000),
             to_wei(1000),
             0_u64.into(),
             0_u64.into(),
             solver.address(),
-            U256::max_value(),
+            U256::MAX.into_legacy(),
         )
     );
 
-    tx!(
-        trader_a.account(),
-        token_a.approve(onchain.contracts().allowance, to_wei(500))
-    );
+    let tx = token_a
+        .approve(
+            onchain.contracts().allowance.into_alloy(),
+            to_wei(500).into_alloy(),
+        )
+        .from(trader_a.address().into_alloy())
+        .into_transaction_request();
+    onchain
+        .web3()
+        .alloy
+        .with_signer(trader_a.account().clone().try_into_alloy().await.unwrap())
+        .send_and_watch(tx)
+        .await
+        .unwrap();
 
     let services = Services::new(&onchain).await;
     services.start_protocol(solver).await;
 
     let order_a = OrderCreation {
-        sell_token: token_a.address(),
+        sell_token: token_a.address().into_legacy(),
         sell_amount: to_wei(100),
-        buy_token: token_b.address(),
+        buy_token: token_b.address().into_legacy(),
         buy_amount: to_wei(50),
         valid_to: model::time::now_in_epoch_seconds() + 300,
         kind: OrderKind::Sell,
@@ -95,7 +124,11 @@ async fn test(web3: Web3) {
 
     tracing::info!("Waiting for trade.");
     wait_for_condition(TIMEOUT, || async {
-        let balance = token_b.balance_of(trader_a.address()).call().await.unwrap();
+        let balance = token_b
+            .balanceOf(trader_a.address().into_alloy())
+            .call()
+            .await
+            .unwrap();
         !balance.is_zero()
     })
     .await
@@ -104,19 +137,20 @@ async fn test(web3: Web3) {
     // Expecting a partial fill because order sells 100 but user only has balance of
     // 50.
     let sell_balance = token_a
-        .balance_of(trader_a.address())
+        .balanceOf(trader_a.address().into_alloy())
         .call()
         .await
-        .unwrap()
-        .to_f64_lossy();
+        .unwrap();
     // Depending on how the solver works might not have sold all balance.
-    assert!((0e18..=1e18).contains(&sell_balance));
+    assert!(U256::ZERO <= sell_balance && sell_balance < U256::from(10u64.pow(18)));
     let buy_balance = token_b
-        .balance_of(trader_a.address())
+        .balanceOf(trader_a.address().into_alloy())
         .call()
         .await
-        .unwrap()
-        .to_f64_lossy();
+        .unwrap();
     // We don't know exact buy balance because of the fee.
-    assert!((45e18..=55e18).contains(&buy_balance));
+    assert!(
+        U256::from(45) * U256::from(10u64.pow(18)) <= buy_balance
+            && buy_balance <= U256::from(55) * U256::from(10u64.pow(18))
+    );
 }

--- a/crates/e2e/tests/e2e/partially_fillable_pool.rs
+++ b/crates/e2e/tests/e2e/partially_fillable_pool.rs
@@ -1,6 +1,11 @@
 use {
     e2e::{setup::*, tx},
     ethcontract::prelude::U256,
+    ethrpc::alloy::{
+        ProviderExt,
+        ProviderSignerExt,
+        conversions::{IntoAlloy, IntoLegacy, TryIntoAlloyAsync},
+    },
     model::{
         order::{OrderCreation, OrderKind},
         signature::EcdsaSigningScheme,
@@ -9,7 +14,6 @@ use {
     shared::ethrpc::Web3,
     web3::signing::SecretKeyRef,
 };
-
 #[tokio::test]
 #[ignore]
 async fn local_node_partially_fillable_pool() {
@@ -31,30 +35,44 @@ async fn test(web3: Web3) {
 
     tx!(
         solver.account(),
-        onchain
-            .contracts()
-            .uniswap_v2_factory
-            .create_pair(token_a.address(), token_b.address())
-    );
-    tx!(
-        solver.account(),
-        token_a.approve(
-            onchain.contracts().uniswap_v2_router.address(),
-            to_wei(1000)
+        onchain.contracts().uniswap_v2_factory.create_pair(
+            token_a.address().into_legacy(),
+            token_b.address().into_legacy()
         )
     );
-    tx!(
-        solver.account(),
-        token_b.approve(
-            onchain.contracts().uniswap_v2_router.address(),
-            to_wei(1000)
+    let tx = token_a
+        .approve(
+            onchain.contracts().uniswap_v2_router.address().into_alloy(),
+            to_wei(1000).into_alloy(),
         )
-    );
+        .from(solver.address().into_alloy())
+        .into_transaction_request();
+    onchain
+        .web3()
+        .alloy
+        .with_signer(solver.account().clone().try_into_alloy().await.unwrap())
+        .send_and_watch(tx)
+        .await
+        .unwrap();
+    let tx = token_b
+        .approve(
+            onchain.contracts().uniswap_v2_router.address().into_alloy(),
+            to_wei(1000).into_alloy(),
+        )
+        .from(solver.address().into_alloy())
+        .into_transaction_request();
+    onchain
+        .web3()
+        .alloy
+        .with_signer(solver.account().clone().try_into_alloy().await.unwrap())
+        .send_and_watch(tx)
+        .await
+        .unwrap();
     tx!(
         solver.account(),
         onchain.contracts().uniswap_v2_router.add_liquidity(
-            token_a.address(),
-            token_b.address(),
+            token_a.address().into_legacy(),
+            token_b.address().into_legacy(),
             to_wei(1000),
             to_wei(1000),
             0_u64.into(),
@@ -64,19 +82,29 @@ async fn test(web3: Web3) {
         )
     );
 
-    tx!(
-        trader_a.account(),
-        token_a.approve(onchain.contracts().allowance, to_wei(500))
-    );
+    let tx = token_a
+        .approve(
+            onchain.contracts().allowance.into_alloy(),
+            to_wei(500).into_alloy(),
+        )
+        .from(trader_a.address().into_alloy())
+        .into_transaction_request();
+    onchain
+        .web3()
+        .alloy
+        .with_signer(trader_a.account().clone().try_into_alloy().await.unwrap())
+        .send_and_watch(tx)
+        .await
+        .unwrap();
 
     let services = Services::new(&onchain).await;
     services.start_protocol(solver).await;
     onchain.mint_block().await;
 
     let order_a = OrderCreation {
-        sell_token: token_a.address(),
+        sell_token: token_a.address().into_legacy(),
         sell_amount: to_wei(500),
-        buy_token: token_b.address(),
+        buy_token: token_b.address().into_legacy(),
         buy_amount: to_wei(390),
         valid_to: model::time::now_in_epoch_seconds() + 300,
         kind: OrderKind::Sell,
@@ -95,7 +123,11 @@ async fn test(web3: Web3) {
 
     tracing::info!("Waiting for trade.");
     wait_for_condition(TIMEOUT, || async {
-        let balance = token_b.balance_of(trader_a.address()).call().await.unwrap();
+        let balance = token_b
+            .balanceOf(trader_a.address().into_alloy())
+            .call()
+            .await
+            .unwrap();
         onchain.mint_block().await;
         !balance.is_zero()
     })
@@ -103,16 +135,24 @@ async fn test(web3: Web3) {
     .unwrap();
 
     // Expecting a partial fill because the pool cannot trade the full amount.
-    let sell_balance = token_a.balance_of(trader_a.address()).call().await.unwrap();
+    let sell_balance = token_a
+        .balanceOf(trader_a.address().into_alloy())
+        .call()
+        .await
+        .unwrap();
     assert!(
         // Sell balance is strictly less than 250.0 because of the fee.
         (249_999_000_000_000_000_000_u128..250_000_000_000_000_000_000_u128)
-            .contains(&sell_balance.as_u128())
+            .contains(&u128::try_from(sell_balance).unwrap())
     );
-    let buy_balance = token_b.balance_of(trader_a.address()).call().await.unwrap();
+    let buy_balance = token_b
+        .balanceOf(trader_a.address().into_alloy())
+        .call()
+        .await
+        .unwrap();
     assert!(
         (199_000_000_000_000_000_000_u128..201_000_000_000_000_000_000_u128)
-            .contains(&buy_balance.as_u128())
+            .contains(&u128::try_from(buy_balance).unwrap())
     );
 
     let metadata_updated = || async {

--- a/crates/e2e/tests/e2e/place_order_with_quote.rs
+++ b/crates/e2e/tests/e2e/place_order_with_quote.rs
@@ -1,7 +1,6 @@
 use {
     driver::domain::eth::NonZeroU256,
     e2e::{nodes::local_node::TestNodeApi, setup::*, tx, tx_value},
-    ethcontract::U256,
     model::{
         order::{OrderCreation, OrderKind},
         quote::{OrderQuoteRequest, OrderQuoteSide, SellAmount},

--- a/crates/e2e/tests/e2e/protocol_fee.rs
+++ b/crates/e2e/tests/e2e/protocol_fee.rs
@@ -7,6 +7,11 @@ use {
         tx_value,
     },
     ethcontract::{Address, prelude::U256},
+    ethrpc::alloy::{
+        ProviderExt,
+        ProviderSignerExt,
+        conversions::{IntoAlloy, IntoLegacy, TryIntoAlloyAsync},
+    },
     model::{
         order::{Order, OrderCreation, OrderCreationAppData, OrderKind},
         quote::{
@@ -90,18 +95,35 @@ async fn combined_protocol_fees(web3: Web3) {
         &partner_fee_order_token,
     ] {
         token.mint(solver.address(), to_wei(1000)).await;
-        tx!(
-            solver.account(),
-            token.approve(
-                onchain.contracts().uniswap_v2_router.address(),
-                to_wei(1000)
+        let tx = token
+            .approve(
+                onchain.contracts().uniswap_v2_router.address().into_alloy(),
+                to_wei(1000).into_alloy(),
             )
-        );
+            .from(solver.address().into_alloy())
+            .into_transaction_request();
+        onchain
+            .web3()
+            .alloy
+            .with_signer(solver.account().clone().try_into_alloy().await.unwrap())
+            .send_and_watch(tx)
+            .await
+            .unwrap();
         for trader in &[&trader] {
-            tx!(
-                trader.account(),
-                token.approve(onchain.contracts().uniswap_v2_router.address(), to_wei(100))
-            );
+            let tx = token
+                .approve(
+                    onchain.contracts().uniswap_v2_router.address().into_alloy(),
+                    to_wei(100).into_alloy(),
+                )
+                .from(trader.address().into_alloy())
+                .into_transaction_request();
+            onchain
+                .web3()
+                .alloy
+                .with_signer(trader.account().clone().try_into_alloy().await.unwrap())
+                .send_and_watch(tx)
+                .await
+                .unwrap();
         }
     }
 
@@ -156,7 +178,7 @@ async fn combined_protocol_fees(web3: Web3) {
                 get_quote(
                     &services,
                     onchain.contracts().weth.address(),
-                    token.address(),
+                    token.address().into_legacy(),
                     OrderKind::Sell,
                     sell_amount,
                     quote_valid_to,
@@ -221,7 +243,7 @@ async fn combined_protocol_fees(web3: Web3) {
         let new_market_order_quote = get_quote(
             &services,
             onchain.contracts().weth.address(),
-            market_order_token.address(),
+            market_order_token.address().into_legacy(),
             OrderKind::Sell,
             sell_amount,
             model::time::now_in_epoch_seconds() + 300,
@@ -250,7 +272,7 @@ async fn combined_protocol_fees(web3: Web3) {
             get_quote(
                 &services,
                 onchain.contracts().weth.address(),
-                token.address(),
+                token.address().into_legacy(),
                 OrderKind::Sell,
                 sell_amount,
                 quote_valid_to,
@@ -353,10 +375,12 @@ async fn combined_protocol_fees(web3: Web3) {
             &limit_order_token,
             &partner_fee_order_token,
         ]
-        .map(|token| {
+        .map(|token| async {
             token
-                .balance_of(onchain.contracts().gp_settlement.address())
+                .balanceOf(onchain.contracts().gp_settlement.address().into_alloy())
                 .call()
+                .await
+                .map(|balance| balance.into_legacy())
         }),
     )
     .await
@@ -419,17 +443,34 @@ async fn surplus_partner_fee(web3: Web3) {
         .await;
 
     token.mint(solver.address(), to_wei(1000)).await;
-    tx!(
-        solver.account(),
-        token.approve(
-            onchain.contracts().uniswap_v2_router.address(),
-            to_wei(1000)
+    let tx = token
+        .approve(
+            onchain.contracts().uniswap_v2_router.address().into_alloy(),
+            to_wei(1000).into_alloy(),
         )
-    );
-    tx!(
-        trader.account(),
-        token.approve(onchain.contracts().uniswap_v2_router.address(), to_wei(100))
-    );
+        .from(solver.address().into_alloy())
+        .into_transaction_request();
+    onchain
+        .web3()
+        .alloy
+        .with_signer(solver.account().clone().try_into_alloy().await.unwrap())
+        .send_and_watch(tx)
+        .await
+        .unwrap();
+    let tx = token
+        .approve(
+            onchain.contracts().uniswap_v2_router.address().into_alloy(),
+            to_wei(100).into_alloy(),
+        )
+        .from(trader.address().into_alloy())
+        .into_transaction_request();
+    onchain
+        .web3()
+        .alloy
+        .with_signer(trader.account().clone().try_into_alloy().await.unwrap())
+        .send_and_watch(tx)
+        .await
+        .unwrap();
     tx!(
         trader.account(),
         onchain
@@ -468,7 +509,7 @@ async fn surplus_partner_fee(web3: Web3) {
         sell_token: onchain.contracts().weth.address(),
         // just set any low amount since it doesn't matter for this test
         buy_amount: to_wei(1),
-        buy_token: token.address(),
+        buy_token: token.address().into_legacy(),
         app_data: partner_fee_app_data.clone(),
         valid_to: model::time::now_in_epoch_seconds() + 300,
         ..Default::default()
@@ -626,30 +667,44 @@ async fn volume_fee_buy_order_test(web3: Web3) {
     token_dai.mint(solver.address(), to_wei(1000)).await;
     tx!(
         solver.account(),
-        onchain
-            .contracts()
-            .uniswap_v2_factory
-            .create_pair(token_gno.address(), token_dai.address())
-    );
-    tx!(
-        solver.account(),
-        token_gno.approve(
-            onchain.contracts().uniswap_v2_router.address(),
-            to_wei(1000)
+        onchain.contracts().uniswap_v2_factory.create_pair(
+            token_gno.address().into_legacy(),
+            token_dai.address().into_legacy()
         )
     );
-    tx!(
-        solver.account(),
-        token_dai.approve(
-            onchain.contracts().uniswap_v2_router.address(),
-            to_wei(1000)
+    let tx = token_gno
+        .approve(
+            onchain.contracts().uniswap_v2_router.address().into_alloy(),
+            to_wei(1000).into_alloy(),
         )
-    );
+        .from(solver.address().into_alloy())
+        .into_transaction_request();
+    onchain
+        .web3()
+        .alloy
+        .with_signer(solver.account().clone().try_into_alloy().await.unwrap())
+        .send_and_watch(tx)
+        .await
+        .unwrap();
+    let tx = token_dai
+        .approve(
+            onchain.contracts().uniswap_v2_router.address().into_alloy(),
+            to_wei(1000).into_alloy(),
+        )
+        .from(solver.address().into_alloy())
+        .into_transaction_request();
+    onchain
+        .web3()
+        .alloy
+        .with_signer(solver.account().clone().try_into_alloy().await.unwrap())
+        .send_and_watch(tx)
+        .await
+        .unwrap();
     tx!(
         solver.account(),
         onchain.contracts().uniswap_v2_router.add_liquidity(
-            token_gno.address(),
-            token_dai.address(),
+            token_gno.address().into_legacy(),
+            token_dai.address().into_legacy(),
             to_wei(1000),
             to_wei(1000),
             0_u64.into(),
@@ -660,10 +715,20 @@ async fn volume_fee_buy_order_test(web3: Web3) {
     );
 
     // Approve GPv2 for trading
-    tx!(
-        trader.account(),
-        token_gno.approve(onchain.contracts().allowance, to_wei(100))
-    );
+    let tx = token_gno
+        .approve(
+            onchain.contracts().allowance.into_alloy(),
+            to_wei(100).into_alloy(),
+        )
+        .from(trader.address().into_alloy())
+        .into_transaction_request();
+    onchain
+        .web3()
+        .alloy
+        .with_signer(trader.account().clone().try_into_alloy().await.unwrap())
+        .send_and_watch(tx)
+        .await
+        .unwrap();
 
     // Place Orders
     let services = Services::new(&onchain).await;
@@ -679,8 +744,8 @@ async fn volume_fee_buy_order_test(web3: Web3) {
 
     let quote = get_quote(
         &services,
-        token_gno.address(),
-        token_dai.address(),
+        token_gno.address().into_legacy(),
+        token_dai.address().into_legacy(),
         OrderKind::Buy,
         to_wei(5),
         model::time::now_in_epoch_seconds() + 300,
@@ -690,9 +755,9 @@ async fn volume_fee_buy_order_test(web3: Web3) {
     .quote;
 
     let order = OrderCreation {
-        sell_token: token_gno.address(),
+        sell_token: token_gno.address().into_legacy(),
         sell_amount: quote.sell_amount * 3 / 2,
-        buy_token: token_dai.address(),
+        buy_token: token_dai.address().into_legacy(),
         buy_amount: to_wei(5),
         valid_to: model::time::now_in_epoch_seconds() + 300,
         kind: OrderKind::Buy,
@@ -720,9 +785,10 @@ async fn volume_fee_buy_order_test(web3: Web3) {
 
     // Check settlement contract balance
     let balance_after = token_gno
-        .balance_of(onchain.contracts().gp_settlement.address())
+        .balanceOf(onchain.contracts().gp_settlement.address().into_alloy())
         .call()
         .await
-        .unwrap();
+        .unwrap()
+        .into_legacy();
     assert_eq!(order.metadata.executed_fee, balance_after);
 }

--- a/crates/e2e/tests/e2e/quote_verification.rs
+++ b/crates/e2e/tests/e2e/quote_verification.rs
@@ -1,8 +1,15 @@
 use {
     bigdecimal::{BigDecimal, Zero},
-    e2e::{setup::*, tx},
+    e2e::setup::*,
     ethcontract::{H160, U256},
-    ethrpc::Web3,
+    ethrpc::{
+        Web3,
+        alloy::{
+            ProviderExt,
+            ProviderSignerExt,
+            conversions::{IntoAlloy, IntoLegacy, TryIntoAlloyAsync},
+        },
+    },
     model::{
         interaction::InteractionData,
         order::{BuyTokenDestination, OrderKind, SellTokenSource},
@@ -87,10 +94,20 @@ async fn standard_verified_quote(web3: Web3) {
         .await;
 
     token.mint(trader.address(), to_wei(1)).await;
-    tx!(
-        trader.account(),
-        token.approve(onchain.contracts().allowance, to_wei(1))
-    );
+    let tx = token
+        .approve(
+            onchain.contracts().allowance.into_alloy(),
+            to_wei(1).into_alloy(),
+        )
+        .from(trader.address().into_alloy())
+        .into_transaction_request();
+    onchain
+        .web3()
+        .alloy
+        .with_signer(trader.account().clone().try_into_alloy().await.unwrap())
+        .send_and_watch(tx)
+        .await
+        .unwrap();
 
     tracing::info!("Starting services.");
     let services = Services::new(&onchain).await;
@@ -100,7 +117,7 @@ async fn standard_verified_quote(web3: Web3) {
     let response = services
         .submit_quote(&OrderQuoteRequest {
             from: trader.address(),
-            sell_token: token.address(),
+            sell_token: token.address().into_legacy(),
             buy_token: onchain.contracts().weth.address(),
             side: OrderQuoteSide::Sell {
                 sell_amount: SellAmount::BeforeFee {
@@ -192,9 +209,9 @@ async fn test_bypass_verification_for_rfq_quotes(web3: Web3) {
         verified: true,
         execution: QuoteExecution {
             interactions: vec![InteractionData {
-                target: H160::from_str("0xdef1c0ded9bec7f1a1670819833240f027b25eff").unwrap(), 
+                target: H160::from_str("0xdef1c0ded9bec7f1a1670819833240f027b25eff").unwrap(),
                 value: 0.into(),
-                call_data: hex::decode("aa77476c000000000000000000000000c02aaa39b223fe8d0a0e5c4f27ead9083c756cc20000000000000000000000002260fac5e5542a773aa44fbcfedf7c193bc2c599000000000000000000000000000000000000000000000000e357b42c3a9d8ccf0000000000000000000000000000000000000000000000000000000004d0e79e000000000000000000000000a69babef1ca67a37ffaf7a485dfff3382056e78c0000000000000000000000009008d19f58aabd9ed0d60971565aa8510560ab41000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000066360af101ffffffffffffffffffffffffffffffffffffff0f3f47f166360a8d0000003f0000000000000000000000000000000000000000000000000000000000000003000000000000000000000000000000000000000000000000000000000000001c66b3383f287dd9c85ad90e7c5a576ea4ba1bdf5a001d794a9afa379e6b2517b47e487a1aef32e75af432cbdbd301ada42754eaeac21ec4ca744afd92732f47540000000000000000000000000000000000000000000000000000000004d0c80f").unwrap() 
+                call_data: hex::decode("aa77476c000000000000000000000000c02aaa39b223fe8d0a0e5c4f27ead9083c756cc20000000000000000000000002260fac5e5542a773aa44fbcfedf7c193bc2c599000000000000000000000000000000000000000000000000e357b42c3a9d8ccf0000000000000000000000000000000000000000000000000000000004d0e79e000000000000000000000000a69babef1ca67a37ffaf7a485dfff3382056e78c0000000000000000000000009008d19f58aabd9ed0d60971565aa8510560ab41000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000066360af101ffffffffffffffffffffffffffffffffffffff0f3f47f166360a8d0000003f0000000000000000000000000000000000000000000000000000000000000003000000000000000000000000000000000000000000000000000000000000001c66b3383f287dd9c85ad90e7c5a576ea4ba1bdf5a001d794a9afa379e6b2517b47e487a1aef32e75af432cbdbd301ada42754eaeac21ec4ca744afd92732f47540000000000000000000000000000000000000000000000000000000004d0c80f").unwrap()
             }],
             pre_interactions: vec![],
             jit_orders: vec![],
@@ -250,7 +267,7 @@ async fn verified_quote_eth_balance(web3: Web3) {
         .submit_quote(&OrderQuoteRequest {
             from: trader.address(),
             sell_token: weth.address(),
-            buy_token: token.address(),
+            buy_token: token.address().into_legacy(),
             side: OrderQuoteSide::Sell {
                 sell_amount: SellAmount::BeforeFee {
                     value: to_wei(1).try_into().unwrap(),
@@ -287,7 +304,7 @@ async fn verified_quote_for_settlement_contract(web3: Web3) {
 
     let request = OrderQuoteRequest {
         sell_token: onchain.contracts().weth.address(),
-        buy_token: token.address(),
+        buy_token: token.address().into_legacy(),
         side: OrderQuoteSide::Sell {
             sell_amount: SellAmount::BeforeFee {
                 value: to_wei(3).try_into().unwrap(),
@@ -376,19 +393,29 @@ async fn verified_quote_with_simulated_balance(web3: Web3) {
     // quote where the trader has no balances or approval set from TOKEN->WETH
     assert_eq!(
         (
-            token.balance_of(trader.address()).call().await.unwrap(),
             token
-                .allowance(trader.address(), onchain.contracts().allowance)
+                .balanceOf(trader.address().into_alloy())
+                .call()
+                .await
+                .unwrap(),
+            token
+                .allowance(
+                    trader.address().into_alloy(),
+                    onchain.contracts().allowance.into_alloy()
+                )
                 .call()
                 .await
                 .unwrap(),
         ),
-        (U256::zero(), U256::zero()),
+        (
+            ::alloy::primitives::U256::ZERO,
+            ::alloy::primitives::U256::ZERO
+        ),
     );
     let response = services
         .submit_quote(&OrderQuoteRequest {
             from: trader.address(),
-            sell_token: token.address(),
+            sell_token: token.address().into_legacy(),
             buy_token: weth.address(),
             side: OrderQuoteSide::Sell {
                 sell_amount: SellAmount::BeforeFee {
@@ -422,7 +449,7 @@ async fn verified_quote_with_simulated_balance(web3: Web3) {
         .submit_quote(&OrderQuoteRequest {
             from: trader.address(),
             sell_token: weth.address(),
-            buy_token: token.address(),
+            buy_token: token.address().into_legacy(),
             side: OrderQuoteSide::Sell {
                 sell_amount: SellAmount::BeforeFee {
                     value: to_wei(1).try_into().unwrap(),
@@ -440,7 +467,7 @@ async fn verified_quote_with_simulated_balance(web3: Web3) {
         .submit_quote(&OrderQuoteRequest {
             from: H160::zero(),
             sell_token: weth.address(),
-            buy_token: token.address(),
+            buy_token: token.address().into_legacy(),
             side: OrderQuoteSide::Sell {
                 sell_amount: SellAmount::BeforeFee {
                     value: to_wei(1).try_into().unwrap(),
@@ -458,7 +485,7 @@ async fn verified_quote_with_simulated_balance(web3: Web3) {
         .submit_quote(&OrderQuoteRequest {
             from: H160::zero(),
             sell_token: weth.address(),
-            buy_token: token.address(),
+            buy_token: token.address().into_legacy(),
             side: OrderQuoteSide::Sell {
                 sell_amount: SellAmount::BeforeFee {
                     value: to_wei(1).try_into().unwrap(),

--- a/crates/e2e/tests/e2e/quoting.rs
+++ b/crates/e2e/tests/e2e/quoting.rs
@@ -4,7 +4,6 @@ use {
         tx,
         tx_value,
     },
-    ethcontract::prelude::U256,
     futures::FutureExt,
     model::{
         order::{OrderCreation, OrderCreationAppData, OrderKind},

--- a/crates/e2e/tests/e2e/quoting.rs
+++ b/crates/e2e/tests/e2e/quoting.rs
@@ -4,6 +4,11 @@ use {
         tx,
         tx_value,
     },
+    ethrpc::alloy::{
+        ProviderExt,
+        ProviderSignerExt,
+        conversions::{IntoAlloy, IntoLegacy, TryIntoAlloyAsync},
+    },
     futures::FutureExt,
     model::{
         order::{OrderCreation, OrderCreationAppData, OrderKind},
@@ -73,7 +78,7 @@ async fn test(web3: Web3) {
     let request = OrderQuoteRequest {
         from: trader.address(),
         sell_token: onchain.contracts().weth.address(),
-        buy_token: token.address(),
+        buy_token: token.address().into_legacy(),
         side: OrderQuoteSide::Sell {
             sell_amount: SellAmount::BeforeFee {
                 value: NonZeroU256::try_from(to_wei(1)).unwrap(),
@@ -206,7 +211,7 @@ async fn uses_stale_liquidity(web3: Web3) {
     let quote = OrderQuoteRequest {
         from: trader.address(),
         sell_token: onchain.contracts().weth.address(),
-        buy_token: token.address(),
+        buy_token: token.address().into_legacy(),
         side: OrderQuoteSide::Sell {
             sell_amount: SellAmount::AfterFee {
                 value: NonZeroU256::new(to_wei(1)).unwrap(),
@@ -266,14 +271,14 @@ async fn quote_timeout(web3: Web3) {
                 name: "test_solver".into(),
                 account: solver.clone(),
                 endpoint: mock_solver.url.clone(),
-                base_tokens: vec![sell_token.address()],
+                base_tokens: vec![sell_token.address().into_legacy()],
                 merge_solutions: true,
             },
             SolverEngine {
                 name: "test_quoter".into(),
                 account: solver.clone(),
                 endpoint: mock_solver.url.clone(),
-                base_tokens: vec![sell_token.address()],
+                base_tokens: vec![sell_token.address().into_legacy()],
                 merge_solutions: true,
             },
         ],
@@ -307,7 +312,7 @@ async fn quote_timeout(web3: Web3) {
     let quote_request = |timeout| OrderQuoteRequest {
         from: trader.address(),
         sell_token: onchain.contracts().weth.address(),
-        buy_token: sell_token.address(),
+        buy_token: sell_token.address().into_legacy(),
         side: OrderQuoteSide::Sell {
             sell_amount: SellAmount::BeforeFee {
                 value: NonZeroU256::try_from(to_wei(1)).unwrap(),
@@ -329,7 +334,9 @@ async fn quote_timeout(web3: Web3) {
 
     // native token price requests are also capped to the max timeout
     let start = std::time::Instant::now();
-    let res = services.get_native_price(&sell_token.address()).await;
+    let res = services
+        .get_native_price(&sell_token.address().into_legacy())
+        .await;
     assert!(res.unwrap_err().1.contains("NoLiquidity"));
     assert_within_variance(start, MAX_QUOTE_TIME_MS);
 
@@ -359,13 +366,23 @@ async fn quote_timeout(web3: Web3) {
 
     // set up trader to pass balance checks during order creation
     sell_token.mint(trader.address(), to_wei(1)).await;
-    tx!(
-        trader.account(),
-        sell_token.approve(onchain.contracts().allowance, to_wei(1))
-    );
+    let tx = sell_token
+        .approve(
+            onchain.contracts().allowance.into_alloy(),
+            to_wei(1).into_alloy(),
+        )
+        .from(trader.address().into_alloy())
+        .into_transaction_request();
+    onchain
+        .web3()
+        .alloy
+        .with_signer(trader.account().clone().try_into_alloy().await.unwrap())
+        .send_and_watch(tx)
+        .await
+        .unwrap();
 
     let order = OrderCreation {
-        sell_token: sell_token.address(),
+        sell_token: sell_token.address().into_legacy(),
         sell_amount: to_wei(1),
         buy_token: Default::default(),
         buy_amount: to_wei(1),

--- a/crates/e2e/tests/e2e/refunder.rs
+++ b/crates/e2e/tests/e2e/refunder.rs
@@ -3,7 +3,11 @@ use {
     chrono::{TimeZone, Utc},
     e2e::{nodes::local_node::TestNodeApi, setup::*},
     ethcontract::{H160, U256},
-    ethrpc::{Web3, block_stream::timestamp_of_current_block_in_seconds},
+    ethrpc::{
+        Web3,
+        alloy::conversions::IntoLegacy,
+        block_stream::timestamp_of_current_block_in_seconds,
+    },
     model::quote::{OrderQuoteRequest, OrderQuoteSide, QuoteSigningScheme, Validity},
     number::nonzero::U256 as NonZeroU256,
     refunder::refund_service::RefundService,
@@ -29,7 +33,7 @@ async fn refunder_tx(web3: Web3) {
     services.start_protocol(solver).await;
 
     // Get quote id for order placement
-    let buy_token = token.address();
+    let buy_token = token.address().into_legacy();
     let receiver = Some(H160([42; 20]));
     let sell_amount = U256::from("3000000000000000");
 

--- a/crates/e2e/tests/e2e/replace_order.rs
+++ b/crates/e2e/tests/e2e/replace_order.rs
@@ -1,6 +1,11 @@
 use {
     e2e::{nodes::local_node::TestNodeApi, setup::*, tx},
     ethcontract::prelude::U256,
+    ethrpc::alloy::{
+        ProviderExt,
+        ProviderSignerExt,
+        conversions::{IntoAlloy, IntoLegacy, TryIntoAlloyAsync},
+    },
     model::{
         order::{OrderCreation, OrderCreationAppData, OrderKind, OrderStatus},
         signature::EcdsaSigningScheme,
@@ -51,30 +56,44 @@ async fn try_replace_unreplaceable_order_test(web3: Web3) {
     token_b.mint(solver.address(), to_wei(1000)).await;
     tx!(
         solver.account(),
-        onchain
-            .contracts()
-            .uniswap_v2_factory
-            .create_pair(token_a.address(), token_b.address())
-    );
-    tx!(
-        solver.account(),
-        token_a.approve(
-            onchain.contracts().uniswap_v2_router.address(),
-            to_wei(1000)
+        onchain.contracts().uniswap_v2_factory.create_pair(
+            token_a.address().into_legacy(),
+            token_b.address().into_legacy()
         )
     );
-    tx!(
-        solver.account(),
-        token_b.approve(
-            onchain.contracts().uniswap_v2_router.address(),
-            to_wei(1000)
+    let tx = token_a
+        .approve(
+            onchain.contracts().uniswap_v2_router.address().into_alloy(),
+            to_wei(1000).into_alloy(),
         )
-    );
+        .from(solver.address().into_alloy())
+        .into_transaction_request();
+    onchain
+        .web3()
+        .alloy
+        .with_signer(solver.account().clone().try_into_alloy().await.unwrap())
+        .send_and_watch(tx)
+        .await
+        .unwrap();
+    let tx = token_b
+        .approve(
+            onchain.contracts().uniswap_v2_router.address().into_alloy(),
+            to_wei(1000).into_alloy(),
+        )
+        .from(solver.address().into_alloy())
+        .into_transaction_request();
+    onchain
+        .web3()
+        .alloy
+        .with_signer(solver.account().clone().try_into_alloy().await.unwrap())
+        .send_and_watch(tx)
+        .await
+        .unwrap();
     tx!(
         solver.account(),
         onchain.contracts().uniswap_v2_router.add_liquidity(
-            token_a.address(),
-            token_b.address(),
+            token_a.address().into_legacy(),
+            token_b.address().into_legacy(),
             to_wei(1000),
             to_wei(1000),
             0_u64.into(),
@@ -85,10 +104,20 @@ async fn try_replace_unreplaceable_order_test(web3: Web3) {
     );
 
     // Approve GPv2 for trading
-    tx!(
-        trader.account(),
-        token_a.approve(onchain.contracts().allowance, to_wei(15))
-    );
+    let tx = token_a
+        .approve(
+            onchain.contracts().allowance.into_alloy(),
+            to_wei(15).into_alloy(),
+        )
+        .from(trader.address().into_alloy())
+        .into_transaction_request();
+    onchain
+        .web3()
+        .alloy
+        .with_signer(trader.account().clone().try_into_alloy().await.unwrap())
+        .send_and_watch(tx)
+        .await
+        .unwrap();
 
     // disable auto mining to prevent order being immediately executed
     web3.api::<TestNodeApi<_>>()
@@ -101,9 +130,9 @@ async fn try_replace_unreplaceable_order_test(web3: Web3) {
     services.start_protocol(solver).await;
 
     let order = OrderCreation {
-        sell_token: token_a.address(),
+        sell_token: token_a.address().into_legacy(),
         sell_amount: to_wei(10),
-        buy_token: token_b.address(),
+        buy_token: token_b.address().into_legacy(),
         buy_amount: to_wei(5),
         valid_to: model::time::now_in_epoch_seconds() + 300,
         kind: OrderKind::Sell,
@@ -114,7 +143,11 @@ async fn try_replace_unreplaceable_order_test(web3: Web3) {
         &onchain.contracts().domain_separator,
         SecretKeyRef::from(&SecretKey::from_slice(trader.private_key()).unwrap()),
     );
-    let balance_before = token_a.balance_of(trader.address()).call().await.unwrap();
+    let balance_before = token_a
+        .balanceOf(trader.address().into_alloy())
+        .call()
+        .await
+        .unwrap();
     onchain.mint_block().await;
     let order_id = services.create_order(&order).await.unwrap();
 
@@ -132,9 +165,9 @@ async fn try_replace_unreplaceable_order_test(web3: Web3) {
 
     // Replace order
     let new_order = OrderCreation {
-        sell_token: token_a.address(),
+        sell_token: token_a.address().into_legacy(),
         sell_amount: to_wei(3),
-        buy_token: token_b.address(),
+        buy_token: token_b.address().into_legacy(),
         buy_amount: to_wei(1),
         valid_to: model::time::now_in_epoch_seconds() + 300,
         kind: OrderKind::Sell,
@@ -174,8 +207,12 @@ async fn try_replace_unreplaceable_order_test(web3: Web3) {
 
     tracing::info!("Waiting for the old order to be executed");
     wait_for_condition(TIMEOUT, || async {
-        let balance_after = token_a.balance_of(trader.address()).call().await.unwrap();
-        balance_before.saturating_sub(balance_after) == to_wei(10)
+        let balance_after = token_a
+            .balanceOf(trader.address().into_alloy())
+            .call()
+            .await
+            .unwrap();
+        balance_before.saturating_sub(balance_after) == to_wei(10).into_alloy()
             && !services.get_trades(&order_id).await.unwrap().is_empty()
     })
     .await
@@ -216,30 +253,44 @@ async fn try_replace_someone_else_order_test(web3: Web3) {
     token_b.mint(solver.address(), to_wei(1000)).await;
     tx!(
         solver.account(),
-        onchain
-            .contracts()
-            .uniswap_v2_factory
-            .create_pair(token_a.address(), token_b.address())
-    );
-    tx!(
-        solver.account(),
-        token_a.approve(
-            onchain.contracts().uniswap_v2_router.address(),
-            to_wei(1000)
+        onchain.contracts().uniswap_v2_factory.create_pair(
+            token_a.address().into_legacy(),
+            token_b.address().into_legacy()
         )
     );
-    tx!(
-        solver.account(),
-        token_b.approve(
-            onchain.contracts().uniswap_v2_router.address(),
-            to_wei(1000)
+    let tx = token_a
+        .approve(
+            onchain.contracts().uniswap_v2_router.address().into_alloy(),
+            to_wei(1000).into_alloy(),
         )
-    );
+        .from(solver.address().into_alloy())
+        .into_transaction_request();
+    onchain
+        .web3()
+        .alloy
+        .with_signer(solver.account().clone().try_into_alloy().await.unwrap())
+        .send_and_watch(tx)
+        .await
+        .unwrap();
+    let tx = token_b
+        .approve(
+            onchain.contracts().uniswap_v2_router.address().into_alloy(),
+            to_wei(1000).into_alloy(),
+        )
+        .from(solver.address().into_alloy())
+        .into_transaction_request();
+    onchain
+        .web3()
+        .alloy
+        .with_signer(solver.account().clone().try_into_alloy().await.unwrap())
+        .send_and_watch(tx)
+        .await
+        .unwrap();
     tx!(
         solver.account(),
         onchain.contracts().uniswap_v2_router.add_liquidity(
-            token_a.address(),
-            token_b.address(),
+            token_a.address().into_legacy(),
+            token_b.address().into_legacy(),
             to_wei(1000),
             to_wei(1000),
             0_u64.into(),
@@ -250,14 +301,34 @@ async fn try_replace_someone_else_order_test(web3: Web3) {
     );
 
     // Approve GPv2 for trading
-    tx!(
-        trader_a.account(),
-        token_a.approve(onchain.contracts().allowance, to_wei(15))
-    );
-    tx!(
-        trader_b.account(),
-        token_a.approve(onchain.contracts().allowance, to_wei(15))
-    );
+    let tx = token_a
+        .approve(
+            onchain.contracts().allowance.into_alloy(),
+            to_wei(15).into_alloy(),
+        )
+        .from(trader_a.address().into_alloy())
+        .into_transaction_request();
+    onchain
+        .web3()
+        .alloy
+        .with_signer(trader_a.account().clone().try_into_alloy().await.unwrap())
+        .send_and_watch(tx)
+        .await
+        .unwrap();
+    let tx = token_a
+        .approve(
+            onchain.contracts().allowance.into_alloy(),
+            to_wei(15).into_alloy(),
+        )
+        .from(trader_b.address().into_alloy())
+        .into_transaction_request();
+    onchain
+        .web3()
+        .alloy
+        .with_signer(trader_b.account().clone().try_into_alloy().await.unwrap())
+        .send_and_watch(tx)
+        .await
+        .unwrap();
 
     // Place Orders
     let services = Services::new(&onchain).await;
@@ -266,9 +337,9 @@ async fn try_replace_someone_else_order_test(web3: Web3) {
     onchain.mint_block().await;
 
     let order = OrderCreation {
-        sell_token: token_a.address(),
+        sell_token: token_a.address().into_legacy(),
         sell_amount: to_wei(10),
-        buy_token: token_b.address(),
+        buy_token: token_b.address().into_legacy(),
         buy_amount: to_wei(5),
         valid_to: model::time::now_in_epoch_seconds() + 300,
         partially_fillable: false,
@@ -284,9 +355,9 @@ async fn try_replace_someone_else_order_test(web3: Web3) {
 
     // Replace order
     let new_order = OrderCreation {
-        sell_token: token_a.address(),
+        sell_token: token_a.address().into_legacy(),
         sell_amount: to_wei(3),
-        buy_token: token_b.address(),
+        buy_token: token_b.address().into_legacy(),
         buy_amount: to_wei(1),
         valid_to: model::time::now_in_epoch_seconds() + 300,
         kind: OrderKind::Sell,
@@ -303,7 +374,11 @@ async fn try_replace_someone_else_order_test(web3: Web3) {
         &onchain.contracts().domain_separator,
         SecretKeyRef::from(&SecretKey::from_slice(trader_b.private_key()).unwrap()),
     );
-    let balance_before = token_a.balance_of(trader_a.address()).call().await.unwrap();
+    let balance_before = token_a
+        .balanceOf(trader_a.address().into_alloy())
+        .call()
+        .await
+        .unwrap();
     let response = services.create_order(&new_order).await;
     let (error_code, _) = response.err().unwrap();
     assert_eq!(error_code, StatusCode::UNAUTHORIZED);
@@ -311,8 +386,12 @@ async fn try_replace_someone_else_order_test(web3: Web3) {
     // Drive solution
     tracing::info!("Waiting for trade.");
     wait_for_condition(TIMEOUT, || async {
-        let balance_after = token_a.balance_of(trader_a.address()).call().await.unwrap();
-        balance_before.saturating_sub(balance_after) == to_wei(10)
+        let balance_after = token_a
+            .balanceOf(trader_a.address().into_alloy())
+            .call()
+            .await
+            .unwrap();
+        balance_before.saturating_sub(balance_after) == to_wei(10).into_alloy()
     })
     .await
     .unwrap();
@@ -335,30 +414,44 @@ async fn single_replace_order_test(web3: Web3) {
     token_b.mint(solver.address(), to_wei(1000)).await;
     tx!(
         solver.account(),
-        onchain
-            .contracts()
-            .uniswap_v2_factory
-            .create_pair(token_a.address(), token_b.address())
-    );
-    tx!(
-        solver.account(),
-        token_a.approve(
-            onchain.contracts().uniswap_v2_router.address(),
-            to_wei(1000)
+        onchain.contracts().uniswap_v2_factory.create_pair(
+            token_a.address().into_legacy(),
+            token_b.address().into_legacy()
         )
     );
-    tx!(
-        solver.account(),
-        token_b.approve(
-            onchain.contracts().uniswap_v2_router.address(),
-            to_wei(1000)
+    let tx = token_a
+        .approve(
+            onchain.contracts().uniswap_v2_router.address().into_alloy(),
+            to_wei(1000).into_alloy(),
         )
-    );
+        .from(solver.address().into_alloy())
+        .into_transaction_request();
+    onchain
+        .web3()
+        .alloy
+        .with_signer(solver.account().clone().try_into_alloy().await.unwrap())
+        .send_and_watch(tx)
+        .await
+        .unwrap();
+    let tx = token_b
+        .approve(
+            onchain.contracts().uniswap_v2_router.address().into_alloy(),
+            to_wei(1000).into_alloy(),
+        )
+        .from(solver.address().into_alloy())
+        .into_transaction_request();
+    onchain
+        .web3()
+        .alloy
+        .with_signer(solver.account().clone().try_into_alloy().await.unwrap())
+        .send_and_watch(tx)
+        .await
+        .unwrap();
     tx!(
         solver.account(),
         onchain.contracts().uniswap_v2_router.add_liquidity(
-            token_a.address(),
-            token_b.address(),
+            token_a.address().into_legacy(),
+            token_b.address().into_legacy(),
             to_wei(1000),
             to_wei(1000),
             0_u64.into(),
@@ -369,10 +462,20 @@ async fn single_replace_order_test(web3: Web3) {
     );
 
     // Approve GPv2 for trading
-    tx!(
-        trader.account(),
-        token_a.approve(onchain.contracts().allowance, to_wei(15))
-    );
+    let tx = token_a
+        .approve(
+            onchain.contracts().allowance.into_alloy(),
+            to_wei(15).into_alloy(),
+        )
+        .from(trader.address().into_alloy())
+        .into_transaction_request();
+    onchain
+        .web3()
+        .alloy
+        .with_signer(trader.account().clone().try_into_alloy().await.unwrap())
+        .send_and_watch(tx)
+        .await
+        .unwrap();
 
     // disble solver to prevent orders from being settled while we
     // want to replace them
@@ -392,11 +495,15 @@ async fn single_replace_order_test(web3: Web3) {
         )
         .await;
 
-    let balance_before = token_a.balance_of(trader.address()).call().await.unwrap();
+    let balance_before = token_a
+        .balanceOf(trader.address().into_alloy())
+        .call()
+        .await
+        .unwrap();
     let order = OrderCreation {
-        sell_token: token_a.address(),
+        sell_token: token_a.address().into_legacy(),
         sell_amount: to_wei(10),
-        buy_token: token_b.address(),
+        buy_token: token_b.address().into_legacy(),
         buy_amount: to_wei(5),
         valid_to: model::time::now_in_epoch_seconds() + 300,
         kind: OrderKind::Sell,
@@ -423,9 +530,9 @@ async fn single_replace_order_test(web3: Web3) {
 
     // Replace order
     let new_order = OrderCreation {
-        sell_token: token_a.address(),
+        sell_token: token_a.address().into_legacy(),
         sell_amount: to_wei(3),
-        buy_token: token_b.address(),
+        buy_token: token_b.address().into_legacy(),
         buy_amount: to_wei(1),
         valid_to: model::time::now_in_epoch_seconds() + 300,
         kind: OrderKind::Sell,
@@ -471,9 +578,13 @@ async fn single_replace_order_test(web3: Web3) {
     // Drive solution to verify that new order can be settled
     tracing::info!("Waiting for trade.");
     wait_for_condition(TIMEOUT, || async {
-        let balance_after = token_a.balance_of(trader.address()).call().await.unwrap();
+        let balance_after = token_a
+            .balanceOf(trader.address().into_alloy())
+            .call()
+            .await
+            .unwrap();
         onchain.mint_block().await;
-        balance_before.saturating_sub(balance_after) == to_wei(3)
+        balance_before.saturating_sub(balance_after) == to_wei(3).into_alloy()
     })
     .await
     .unwrap();

--- a/crates/e2e/tests/e2e/solver_competition.rs
+++ b/crates/e2e/tests/e2e/solver_competition.rs
@@ -1,9 +1,11 @@
 use {
-    e2e::{
-        setup::{colocation::SolverEngine, mock::Mock, *},
-        tx,
+    ::alloy::primitives::U256,
+    e2e::setup::{colocation::SolverEngine, mock::Mock, *},
+    ethrpc::alloy::{
+        ProviderExt,
+        ProviderSignerExt,
+        conversions::{IntoAlloy, IntoLegacy, TryIntoAlloyAsync},
     },
-    ethcontract::prelude::U256,
     model::{
         order::{OrderCreation, OrderKind},
         signature::EcdsaSigningScheme,
@@ -47,10 +49,20 @@ async fn solver_competition(web3: Web3) {
     token_a.mint(solver.address(), to_wei(1000)).await;
 
     // Approve GPv2 for trading
-    tx!(
-        trader.account(),
-        token_a.approve(onchain.contracts().allowance, to_wei(100))
-    );
+    let tx = token_a
+        .approve(
+            onchain.contracts().allowance.into_alloy(),
+            to_wei(100).into_alloy(),
+        )
+        .from(trader.address().into_alloy())
+        .into_transaction_request();
+    onchain
+        .web3()
+        .alloy
+        .with_signer(trader.account().clone().try_into_alloy().await.unwrap())
+        .send_and_watch(tx)
+        .await
+        .unwrap();
 
     // Start system
     colocation::start_driver(
@@ -94,7 +106,7 @@ async fn solver_competition(web3: Web3) {
 
     // Place Order
     let order = OrderCreation {
-        sell_token: token_a.address(),
+        sell_token: token_a.address().into_legacy(),
         sell_amount: to_wei(10),
         buy_token: onchain.contracts().weth.address(),
         buy_amount: to_wei(5),
@@ -111,8 +123,14 @@ async fn solver_competition(web3: Web3) {
     onchain.mint_block().await;
 
     tracing::info!("waiting for trade");
-    let trade_happened =
-        || async { token_a.balance_of(trader.address()).call().await.unwrap() == U256::zero() };
+    let trade_happened = || async {
+        token_a
+            .balanceOf(trader.address().into_alloy())
+            .call()
+            .await
+            .unwrap()
+            == U256::ZERO
+    };
     wait_for_condition(TIMEOUT, trade_happened).await.unwrap();
 
     let indexed_trades = || async {
@@ -170,14 +188,34 @@ async fn wrong_solution_submission_address(web3: Web3) {
         .await;
 
     // Approve GPv2 for trading
-    tx!(
-        trader_a.account(),
-        token_a.approve(onchain.contracts().allowance, to_wei(100))
-    );
-    tx!(
-        trader_b.account(),
-        token_b.approve(onchain.contracts().allowance, to_wei(100))
-    );
+    let tx = token_a
+        .approve(
+            onchain.contracts().allowance.into_alloy(),
+            to_wei(100).into_alloy(),
+        )
+        .from(trader_a.address().into_alloy())
+        .into_transaction_request();
+    onchain
+        .web3()
+        .alloy
+        .with_signer(trader_a.account().clone().try_into_alloy().await.unwrap())
+        .send_and_watch(tx)
+        .await
+        .unwrap();
+    let tx = token_b
+        .approve(
+            onchain.contracts().allowance.into_alloy(),
+            to_wei(100).into_alloy(),
+        )
+        .from(trader_b.address().into_alloy())
+        .into_transaction_request();
+    onchain
+        .web3()
+        .alloy
+        .with_signer(trader_b.account().clone().try_into_alloy().await.unwrap())
+        .send_and_watch(tx)
+        .await
+        .unwrap();
 
     // Start system, with two solvers, one that knows about base_a and one that
     // knows about base_b
@@ -188,7 +226,7 @@ async fn wrong_solution_submission_address(web3: Web3) {
                 "test_solver".into(),
                 solver.clone(),
                 onchain.contracts().weth.address(),
-                vec![base_a.address()],
+                vec![base_a.address().into_legacy()],
                 1,
                 true,
             )
@@ -197,7 +235,7 @@ async fn wrong_solution_submission_address(web3: Web3) {
                 "solver2".into(),
                 solver.clone(),
                 onchain.contracts().weth.address(),
-                vec![base_b.address()],
+                vec![base_b.address().into_legacy()],
                 1,
                 true,
             )
@@ -224,7 +262,7 @@ async fn wrong_solution_submission_address(web3: Web3) {
 
     // Place Orders
     let order_a = OrderCreation {
-        sell_token: token_a.address(),
+        sell_token: token_a.address().into_legacy(),
         sell_amount: to_wei(10),
         buy_token: onchain.contracts().weth.address(),
         buy_amount: to_wei(5),
@@ -242,7 +280,7 @@ async fn wrong_solution_submission_address(web3: Web3) {
     onchain.mint_block().await;
 
     let order_b = OrderCreation {
-        sell_token: token_b.address(),
+        sell_token: token_b.address().into_legacy(),
         sell_amount: to_wei(10),
         buy_token: onchain.contracts().weth.address(),
         buy_amount: to_wei(5),
@@ -304,10 +342,20 @@ async fn store_filtered_solutions(web3: Web3) {
 
     // set up trader for their order
     token_a.mint(trader.address(), to_wei(2)).await;
-    tx!(
-        trader.account(),
-        token_a.approve(onchain.contracts().allowance, to_wei(2))
-    );
+    let tx = token_a
+        .approve(
+            onchain.contracts().allowance.into_alloy(),
+            to_wei(2).into_alloy(),
+        )
+        .from(trader.address().into_alloy())
+        .into_transaction_request();
+    onchain
+        .web3()
+        .alloy
+        .with_signer(trader.account().clone().try_into_alloy().await.unwrap())
+        .send_and_watch(tx)
+        .await
+        .unwrap();
 
     let services = Services::new(&onchain).await;
 
@@ -315,7 +363,11 @@ async fn store_filtered_solutions(web3: Web3) {
     let bad_solver = Mock::default();
 
     // Start system
-    let base_tokens = vec![token_a.address(), token_b.address(), token_c.address()];
+    let base_tokens = vec![
+        token_a.address().into_legacy(),
+        token_b.address().into_legacy(),
+        token_c.address().into_legacy(),
+    ];
     colocation::start_driver(
         onchain.contracts(),
         vec![
@@ -372,9 +424,9 @@ async fn store_filtered_solutions(web3: Web3) {
 
     // Place order
     let order_ab = OrderCreation {
-        sell_token: token_a.address(),
+        sell_token: token_a.address().into_legacy(),
         sell_amount: to_wei(1),
-        buy_token: token_b.address(),
+        buy_token: token_b.address().into_legacy(),
         buy_amount: to_wei(1),
         valid_to: model::time::now_in_epoch_seconds() + 300,
         kind: OrderKind::Sell,
@@ -387,9 +439,9 @@ async fn store_filtered_solutions(web3: Web3) {
     );
 
     let order_ac = OrderCreation {
-        sell_token: token_a.address(),
+        sell_token: token_a.address().into_legacy(),
         sell_amount: to_wei(1),
-        buy_token: token_c.address(),
+        buy_token: token_c.address().into_legacy(),
         buy_amount: to_wei(1),
         valid_to: model::time::now_in_epoch_seconds() + 300,
         kind: OrderKind::Sell,
@@ -417,8 +469,8 @@ async fn store_filtered_solutions(web3: Web3) {
     good_solver.configure_solution(Some(Solution {
         id: 0,
         prices: HashMap::from([
-            (token_a.address(), to_wei(3)),
-            (token_b.address(), to_wei(1)),
+            (token_a.address().into_legacy(), to_wei(3)),
+            (token_b.address().into_legacy(), to_wei(1)),
         ]),
         trades: vec![solvers_dto::solution::Trade::Fulfillment(
             solvers_dto::solution::Fulfillment {
@@ -440,9 +492,9 @@ async fn store_filtered_solutions(web3: Web3) {
     bad_solver.configure_solution(Some(Solution {
         id: 0,
         prices: HashMap::from([
-            (token_a.address(), to_wei(2)),
-            (token_b.address(), to_wei(1)),
-            (token_c.address(), to_wei(1)),
+            (token_a.address().into_legacy(), to_wei(2)),
+            (token_b.address().into_legacy(), to_wei(1)),
+            (token_c.address().into_legacy(), to_wei(1)),
         ]),
         trades: vec![
             solvers_dto::solution::Trade::Fulfillment(solvers_dto::solution::Fulfillment {

--- a/crates/e2e/tests/e2e/solver_participation_guard.rs
+++ b/crates/e2e/tests/e2e/solver_participation_guard.rs
@@ -14,7 +14,14 @@ use {
         },
         tx,
     },
-    ethrpc::Web3,
+    ethrpc::{
+        Web3,
+        alloy::{
+            ProviderExt,
+            ProviderSignerExt,
+            conversions::{IntoAlloy, IntoLegacy, TryIntoAlloyAsync},
+        },
+    },
     model::{
         order::{OrderClass, OrderCreation, OrderKind},
         signature::EcdsaSigningScheme,
@@ -251,30 +258,44 @@ async fn setup(
     token_b.mint(solver.address(), to_wei(1000)).await;
     tx!(
         solver.account(),
-        onchain
-            .contracts()
-            .uniswap_v2_factory
-            .create_pair(token_a.address(), token_b.address())
-    );
-    tx!(
-        solver.account(),
-        token_a.approve(
-            onchain.contracts().uniswap_v2_router.address(),
-            to_wei(1000)
+        onchain.contracts().uniswap_v2_factory.create_pair(
+            token_a.address().into_legacy(),
+            token_b.address().into_legacy()
         )
     );
-    tx!(
-        solver.account(),
-        token_b.approve(
-            onchain.contracts().uniswap_v2_router.address(),
-            to_wei(1000)
+    let tx = token_a
+        .approve(
+            onchain.contracts().uniswap_v2_router.address().into_alloy(),
+            to_wei(1000).into_alloy(),
         )
-    );
+        .from(solver.address().into_alloy())
+        .into_transaction_request();
+    onchain
+        .web3()
+        .alloy
+        .with_signer(solver.account().clone().try_into_alloy().await.unwrap())
+        .send_and_watch(tx)
+        .await
+        .unwrap();
+    let tx = token_b
+        .approve(
+            onchain.contracts().uniswap_v2_router.address().into_alloy(),
+            to_wei(1000).into_alloy(),
+        )
+        .from(solver.address().into_alloy())
+        .into_transaction_request();
+    onchain
+        .web3()
+        .alloy
+        .with_signer(solver.account().clone().try_into_alloy().await.unwrap())
+        .send_and_watch(tx)
+        .await
+        .unwrap();
     tx!(
         solver.account(),
         onchain.contracts().uniswap_v2_router.add_liquidity(
-            token_a.address(),
-            token_b.address(),
+            token_a.address().into_legacy(),
+            token_b.address().into_legacy(),
             to_wei(1000),
             to_wei(1000),
             0_u64.into(),
@@ -285,10 +306,20 @@ async fn setup(
     );
 
     // Approve GPv2 for trading
-    tx!(
-        trader_a.account(),
-        token_a.approve(onchain.contracts().allowance, to_wei(1000))
-    );
+    let tx = token_a
+        .approve(
+            onchain.contracts().allowance.into_alloy(),
+            to_wei(1000).into_alloy(),
+        )
+        .from(trader_a.address().into_alloy())
+        .into_transaction_request();
+    onchain
+        .web3()
+        .alloy
+        .with_signer(trader_a.account().clone().try_into_alloy().await.unwrap())
+        .send_and_watch(tx)
+        .await
+        .unwrap();
 
     (trader_a, token_a, token_b)
 }
@@ -325,9 +356,9 @@ async fn execute_order(
     services: &Services<'_>,
 ) -> anyhow::Result<()> {
     let order = OrderCreation {
-        sell_token: token_a.address(),
+        sell_token: token_a.address().into_legacy(),
         sell_amount: to_wei(10),
-        buy_token: token_b.address(),
+        buy_token: token_b.address().into_legacy(),
         buy_amount: to_wei(5),
         valid_to: model::time::now_in_epoch_seconds() + 300,
         kind: OrderKind::Sell,
@@ -338,7 +369,11 @@ async fn execute_order(
         &onchain.contracts().domain_separator,
         SecretKeyRef::from(&SecretKey::from_slice(trader_a.private_key()).unwrap()),
     );
-    let balance_before = token_b.balance_of(trader_a.address()).call().await.unwrap();
+    let balance_before = token_b
+        .balanceOf(trader_a.address().into_alloy())
+        .call()
+        .await
+        .unwrap();
     let order_id = services.create_order(&order).await.unwrap();
     onchain.mint_block().await;
     let limit_order = services.get_order(&order_id).await.unwrap();
@@ -348,8 +383,13 @@ async fn execute_order(
     // Drive solution
     tracing::info!("Waiting for trade.");
     wait_for_condition(TIMEOUT, || async {
-        let balance_after = token_b.balance_of(trader_a.address()).call().await.unwrap();
-        let balance_changes = balance_after.checked_sub(balance_before).unwrap() >= to_wei(5);
+        let balance_after = token_b
+            .balanceOf(trader_a.address().into_alloy())
+            .call()
+            .await
+            .unwrap();
+        let balance_changes =
+            balance_after.checked_sub(balance_before).unwrap() >= to_wei(5).into_alloy();
         let auction_ids_after =
             fetch_last_settled_auction_ids(services.db()).await.len() > auction_ids_before;
         balance_changes && auction_ids_after

--- a/crates/e2e/tests/e2e/submission.rs
+++ b/crates/e2e/tests/e2e/submission.rs
@@ -1,6 +1,8 @@
 use {
+    ::alloy::primitives::U256,
     e2e::{nodes::local_node::TestNodeApi, setup::*, tx, tx_value},
     ethcontract::{BlockId, H160, H256},
+    ethrpc::alloy::conversions::{IntoAlloy, IntoLegacy},
     futures::{Stream, StreamExt},
     model::{
         order::{OrderCreation, OrderKind},
@@ -52,12 +54,16 @@ async fn test_cancel_on_expiry(web3: Web3) {
         .expect("Must be able to disable automine");
 
     tracing::info!("Placing order");
-    let balance = token.balance_of(trader.address()).call().await.unwrap();
-    assert_eq!(balance, 0.into());
+    let balance = token
+        .balanceOf(trader.address().into_alloy())
+        .call()
+        .await
+        .unwrap();
+    assert_eq!(balance, U256::ZERO);
     let order = OrderCreation {
         sell_token: onchain.contracts().weth.address(),
         sell_amount: to_wei(2),
-        buy_token: token.address(),
+        buy_token: token.address().into_legacy(),
         buy_amount: to_wei(1),
         valid_to: model::time::now_in_epoch_seconds() + 300,
         kind: OrderKind::Buy,

--- a/crates/e2e/tests/e2e/submission.rs
+++ b/crates/e2e/tests/e2e/submission.rs
@@ -1,6 +1,6 @@
 use {
     e2e::{nodes::local_node::TestNodeApi, setup::*, tx, tx_value},
-    ethcontract::{BlockId, H160, H256, U256},
+    ethcontract::{BlockId, H160, H256},
     futures::{Stream, StreamExt},
     model::{
         order::{OrderCreation, OrderKind},

--- a/crates/e2e/tests/e2e/tracking_insufficient_funds.rs
+++ b/crates/e2e/tests/e2e/tracking_insufficient_funds.rs
@@ -1,6 +1,7 @@
 use {
     database::order_events::{OrderEvent, OrderEventLabel},
     e2e::{setup::*, tx, tx_value},
+    ethrpc::alloy::conversions::IntoLegacy,
     model::{
         order::{OrderCreation, OrderKind},
         signature::EcdsaSigningScheme,
@@ -59,7 +60,7 @@ async fn test(web3: Web3) {
     let order_a = OrderCreation {
         sell_token: onchain.contracts().weth.address(),
         sell_amount: to_wei(2),
-        buy_token: token.address(),
+        buy_token: token.address().into_legacy(),
         buy_amount: to_wei(1),
         valid_to: model::time::now_in_epoch_seconds() + 300,
         kind: OrderKind::Buy,
@@ -73,7 +74,7 @@ async fn test(web3: Web3) {
     let order_b = OrderCreation {
         sell_token: onchain.contracts().weth.address(),
         sell_amount: to_wei(2),
-        buy_token: token.address(),
+        buy_token: token.address().into_legacy(),
         buy_amount: to_wei(1),
         valid_to: model::time::now_in_epoch_seconds() + 300,
         kind: OrderKind::Buy,

--- a/crates/e2e/tests/e2e/tracking_insufficient_funds.rs
+++ b/crates/e2e/tests/e2e/tracking_insufficient_funds.rs
@@ -1,7 +1,6 @@
 use {
     database::order_events::{OrderEvent, OrderEventLabel},
     e2e::{setup::*, tx, tx_value},
-    ethcontract::U256,
     model::{
         order::{OrderCreation, OrderKind},
         signature::EcdsaSigningScheme,

--- a/crates/e2e/tests/e2e/uncovered_order.rs
+++ b/crates/e2e/tests/e2e/uncovered_order.rs
@@ -1,5 +1,6 @@
 use {
     e2e::{setup::*, tx, tx_value},
+    ethrpc::alloy::conversions::IntoLegacy,
     model::{
         order::{OrderCreation, OrderKind},
         signature::EcdsaSigningScheme,
@@ -43,7 +44,7 @@ async fn test(web3: Web3) {
         sell_token: weth.address(),
         sell_amount: to_wei(2),
         fee_amount: 0.into(),
-        buy_token: token.address(),
+        buy_token: token.address().into_legacy(),
         buy_amount: to_wei(1),
         valid_to: model::time::now_in_epoch_seconds() + 300,
         kind: OrderKind::Sell,

--- a/crates/e2e/tests/e2e/uncovered_order.rs
+++ b/crates/e2e/tests/e2e/uncovered_order.rs
@@ -1,6 +1,5 @@
 use {
     e2e::{setup::*, tx, tx_value},
-    ethcontract::U256,
     model::{
         order::{OrderCreation, OrderKind},
         signature::EcdsaSigningScheme,

--- a/crates/e2e/tests/e2e/vault_balances.rs
+++ b/crates/e2e/tests/e2e/vault_balances.rs
@@ -1,6 +1,5 @@
 use {
     e2e::{setup::*, tx},
-    ethcontract::prelude::U256,
     model::{
         order::{OrderCreation, OrderKind, SellTokenSource},
         signature::EcdsaSigningScheme,

--- a/crates/e2e/tests/e2e/vault_balances.rs
+++ b/crates/e2e/tests/e2e/vault_balances.rs
@@ -1,5 +1,10 @@
 use {
     e2e::{setup::*, tx},
+    ethrpc::alloy::{
+        ProviderExt,
+        ProviderSignerExt,
+        conversions::{IntoAlloy, IntoLegacy, TryIntoAlloyAsync},
+    },
     model::{
         order::{OrderCreation, OrderKind, SellTokenSource},
         signature::EcdsaSigningScheme,
@@ -27,10 +32,20 @@ async fn vault_balances(web3: Web3) {
     token.mint(trader.address(), to_wei(10)).await;
 
     // Approve GPv2 for trading
-    tx!(
-        trader.account(),
-        token.approve(onchain.contracts().balancer_vault.address(), to_wei(10))
-    );
+    let tx = token
+        .approve(
+            onchain.contracts().balancer_vault.address().into_alloy(),
+            to_wei(10).into_alloy(),
+        )
+        .from(trader.address().into_alloy())
+        .into_transaction_request();
+    onchain
+        .web3()
+        .alloy
+        .with_signer(trader.account().clone().try_into_alloy().await.unwrap())
+        .send_and_watch(tx)
+        .await
+        .unwrap();
     tx!(
         trader.account(),
         onchain.contracts().balancer_vault.set_relayer_approval(
@@ -46,7 +61,7 @@ async fn vault_balances(web3: Web3) {
     // Place Orders
     let order = OrderCreation {
         kind: OrderKind::Sell,
-        sell_token: token.address(),
+        sell_token: token.address().into_legacy(),
         sell_amount: to_wei(10),
         sell_token_balance: SellTokenSource::External,
         buy_token: onchain.contracts().weth.address(),
@@ -73,7 +88,7 @@ async fn vault_balances(web3: Web3) {
     tracing::info!("Waiting for trade.");
     wait_for_condition(TIMEOUT, || async {
         let token_balance = token
-            .balance_of(trader.address())
+            .balanceOf(trader.address().into_alloy())
             .call()
             .await
             .expect("Couldn't fetch token balance");

--- a/crates/ethrpc/Cargo.toml
+++ b/crates/ethrpc/Cargo.toml
@@ -11,7 +11,16 @@ path = "src/lib.rs"
 doctest = false
 
 [dependencies]
-alloy = { workspace = true, default-features = false, features = ["json-rpc", "providers", "rpc-client", "transports", "reqwest", "signers", "signer-aws", "signer-local"] }
+alloy = { workspace = true, default-features = false, features = [
+    "json-rpc",
+    "providers",
+    "rpc-client",
+    "transports",
+    "reqwest",
+    "signers",
+    "signer-aws",
+    "signer-local",
+] }
 anyhow = { workspace = true }
 async-trait = { workspace = true }
 futures = { workspace = true }

--- a/crates/ethrpc/Cargo.toml
+++ b/crates/ethrpc/Cargo.toml
@@ -11,16 +11,7 @@ path = "src/lib.rs"
 doctest = false
 
 [dependencies]
-alloy = { workspace = true, default-features = false, features = [
-    "json-rpc",
-    "providers",
-    "rpc-client",
-    "transports",
-    "reqwest",
-    "signers",
-    "signer-aws",
-    "signer-local",
-] }
+alloy = { workspace = true, default-features = false, features = ["json-rpc", "providers", "rpc-client", "transports", "reqwest", "signers", "signer-aws", "signer-local"] }
 anyhow = { workspace = true }
 async-trait = { workspace = true }
 futures = { workspace = true }

--- a/crates/ethrpc/src/alloy/mod.rs
+++ b/crates/ethrpc/src/alloy/mod.rs
@@ -7,9 +7,17 @@ use alloy::providers::mock;
 use {
     crate::AlloyProvider,
     alloy::{
-        network::EthereumWallet,
-        providers::{Provider, ProviderBuilder},
-        rpc::client::{ClientBuilder, RpcClient},
+        contract::{CallBuilder, CallDecoder},
+        network::{EthereumWallet, Network},
+        primitives::FixedBytes,
+        providers::{
+            Provider,
+            ProviderBuilder,
+        },
+        rpc::{
+            client::{ClientBuilder, RpcClient},
+            types::TransactionRequest,
+        },
     },
     buffering::BatchCallLayer,
     instrumentation::{InstrumentationLayer, LabelingLayer},
@@ -56,5 +64,35 @@ impl ProviderSignerExt for AlloyProvider {
             .wallet(wallet)
             .connect_client(client)
             .erased()
+    }
+}
+
+pub trait ProviderExt {
+    /// Sends a transaction and watches it for completion.
+    fn send_and_watch(
+        &self,
+        tx: TransactionRequest,
+    ) -> impl Future<Output = anyhow::Result<FixedBytes<32>>>;
+}
+
+impl ProviderExt for AlloyProvider {
+    fn send_and_watch(
+        &self,
+        tx: TransactionRequest,
+    ) -> impl Future<Output = anyhow::Result<FixedBytes<32>>> {
+        async move { Ok(self.send_transaction(tx).await?.watch().await?) }
+    }
+}
+
+pub trait CallBuilderExt<N>
+where
+    N: Network,
+{
+    fn send_and_watch(&self) -> impl Future<Output = anyhow::Result<FixedBytes<32>>>;
+}
+
+impl<P: Provider<N>, D: CallDecoder, N: Network> CallBuilderExt<N> for CallBuilder<P, D, N> {
+    fn send_and_watch(&self) -> impl Future<Output = anyhow::Result<FixedBytes<32>>> {
+        async { Ok(self.send().await?.watch().await?) }
     }
 }


### PR DESCRIPTION
# Description
As the title states, migrates the ERC20Mintable contract to alloy-rs

# Changes

- [ ] Add a bunch of places where nonces must be queried first
- [ ] Constantly replace the provider with one that runs the right signature

## How to test
1. Run the e2e tests

