### PR TITLE
[TRIVIAL] Remove dummy alloy provider

### DIFF
--- a/crates/ethrpc/Cargo.toml
+++ b/crates/ethrpc/Cargo.toml
@@ -42,6 +42,3 @@ testlib = { workspace = true }
 
 [lints]
 workspace = true
-
-[features]
-test-util = []

--- a/crates/ethrpc/src/alloy/mod.rs
+++ b/crates/ethrpc/src/alloy/mod.rs
@@ -2,8 +2,6 @@ mod buffering;
 pub mod conversions;
 mod instrumentation;
 
-#[cfg(any(test, feature = "test-util"))]
-use alloy::providers::mock;
 use {
     crate::AlloyProvider,
     alloy::{
@@ -25,14 +23,6 @@ pub fn provider(url: &str) -> AlloyProvider {
         .layer(BatchCallLayer::new(Default::default()))
         .http(url.parse().unwrap());
     ProviderBuilder::new().connect_client(rpc).erased()
-}
-
-#[cfg(any(test, feature = "test-util"))]
-pub fn dummy_provider() -> AlloyProvider {
-    let asserter = mock::Asserter::new();
-    ProviderBuilder::new()
-        .connect_mocked_client(asserter)
-        .erased()
 }
 
 pub trait ProviderSignerExt {

--- a/crates/solver/Cargo.toml
+++ b/crates/solver/Cargo.toml
@@ -40,7 +40,6 @@ web3 = { workspace = true }
 
 [dev-dependencies]
 derivative = { workspace = true }
-ethrpc = { workspace = true, features = ["test-util"] }
 tokio = { workspace = true, features = ["test-util"] }
 testlib = { workspace = true }
 

--- a/crates/solver/src/liquidity/zeroex.rs
+++ b/crates/solver/src/liquidity/zeroex.rs
@@ -254,7 +254,7 @@ pub mod tests {
     use {
         super::*,
         crate::interactions::allowances::Approval,
-        ethrpc::{alloy, alloy::conversions::IntoAlloy},
+        ethrpc::alloy::conversions::IntoAlloy,
         maplit::hashmap,
         shared::{
             baseline_solver::BaseTokens,
@@ -397,7 +397,7 @@ pub mod tests {
         let sell_token = H160::from_low_u64_be(1);
         let zeroex = Arc::new(IZeroex::Instance::new(
             H160::default().into_alloy(),
-            alloy::dummy_provider(),
+            ethrpc::mock::web3().alloy,
         ));
         let allowances = Allowances::new(
             zeroex.address().into_legacy(),
@@ -445,7 +445,7 @@ pub mod tests {
         let sell_token = H160::from_low_u64_be(1);
         let zeroex = Arc::new(IZeroex::Instance::new(
             H160::default().into_alloy(),
-            alloy::dummy_provider(),
+            ethrpc::mock::web3().alloy,
         ));
         let allowances = Allowances::new(
             zeroex.address().into_legacy(),


### PR DESCRIPTION
Removes the dummy alloy provider since it was overseen that a similar function already exists in `ethrpc::mock::web()` funciton. 