### PR TITLE
Use alloy's SimpleNonceManager

### DIFF
--- a/crates/ethrpc/src/alloy/mod.rs
+++ b/crates/ethrpc/src/alloy/mod.rs
@@ -22,7 +22,12 @@ pub fn provider(url: &str) -> AlloyProvider {
         .layer(InstrumentationLayer)
         .layer(BatchCallLayer::new(Default::default()))
         .http(url.parse().unwrap());
-    ProviderBuilder::new().connect_client(rpc).erased()
+    ProviderBuilder::new()
+        // will query the node for the nonce every time that it is needed
+        // adds overhead but makes working with alloy/ethcontract at the same time much simpler
+        .with_simple_nonce_management()
+        .connect_client(rpc)
+        .erased()
 }
 
 pub trait ProviderSignerExt {
@@ -44,6 +49,7 @@ impl ProviderSignerExt for AlloyProvider {
 
         ProviderBuilder::new()
             .wallet(wallet)
+            .with_simple_nonce_management()
             .connect_client(client)
             .erased()
     }


### PR DESCRIPTION
# Description
Uses alloy's SimpleNonceManager to avoid needing to keep track of the nonces manually and basically do the same thing the nonce manager does.

# Changes

- [ ] Makes alloy providers use the SimpleNonceManager

## How to test
N/A

<!--
## Related Issues

Fixes #
-->