### PR TITLE
Add `exec_alloy_call` to Safe

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -103,11 +103,14 @@ dependencies = [
  "alloy-network",
  "alloy-provider",
  "alloy-rpc-client",
+ "alloy-rpc-types",
+ "alloy-serde",
  "alloy-signer",
  "alloy-signer-aws",
  "alloy-signer-local",
  "alloy-transport",
  "alloy-transport-http",
+ "alloy-trie",
 ]
 
 [[package]]
@@ -443,6 +446,18 @@ dependencies = [
  "tracing",
  "url",
  "wasmtimer",
+]
+
+[[package]]
+name = "alloy-rpc-types"
+version = "1.0.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39676beaa50db545cf15447fc94ec5513b64e85a48357a0625b9a04aef08a910"
+dependencies = [
+ "alloy-primitives",
+ "alloy-rpc-types-eth",
+ "alloy-serde",
+ "serde",
 ]
 
 [[package]]

--- a/crates/e2e/Cargo.toml
+++ b/crates/e2e/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2024"
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-alloy = { workspace = true, default-features = false, features = ["json-rpc", "providers", "rpc-client", "transports", "reqwest", "signers", "signer-local"] }
+alloy = { workspace = true, default-features = false, features = ["json-rpc", "providers", "rpc-client", "rpc-types", "transports", "reqwest", "signers", "signer-local"] }
 app-data = { workspace = true }
 anyhow = { workspace = true }
 autopilot = { workspace = true }


### PR DESCRIPTION
# Description
Adds an alloy version of the existing `exec_call`, required because DynMethodBuilder <-/-> alloy::CallBuilder.

# Changes
- [ ] Add inner exec_alloy_tx 
- [ ] Add exec_alloy_call

## How to test
N/A

<!--
## Related Issues

Fixes #
-->