### PR TITLE
Opt-out of quote verification

### DIFF
--- a/crates/e2e/tests/e2e/quote_verification.rs
+++ b/crates/e2e/tests/e2e/quote_verification.rs
@@ -141,6 +141,7 @@ async fn test_bypass_verification_for_rfq_quotes(web3: Web3) {
         onchain.contracts().gp_settlement.address(),
         onchain.contracts().weth.address(),
         BigDecimal::zero(),
+        Default::default(),
     )
     .await
     .unwrap();

--- a/crates/shared/src/price_estimation/factory.rs
+++ b/crates/shared/src/price_estimation/factory.rs
@@ -125,6 +125,7 @@ impl<'a> PriceEstimatorFactory<'a> {
             network.settlement,
             network.native_token,
             args.quote_inaccuracy_limit.clone(),
+            args.tokens_without_verification.iter().cloned().collect(),
         )
         .await?;
         Ok(Some(Arc::new(verifier)))

--- a/crates/shared/src/price_estimation/mod.rs
+++ b/crates/shared/src/price_estimation/mod.rs
@@ -262,6 +262,13 @@ pub struct Arguments {
         value_parser = parse_tuple::<H160, H160>
     )]
     pub native_price_approximation_tokens: Vec<(H160, H160)>,
+
+    /// Tokens for which quote verification should not be attempted. This is an
+    /// escapte hatch when there is a very bad but verifiable liquidity source
+    /// that would win against a very good but unverifiable liquidity source
+    /// (e.g. private liquidity that exists but can't be verified).
+    #[clap(long, env, value_delimiter = ',')]
+    pub tokens_without_verification: Vec<H160>,
 }
 
 /// Custom Clap parser for tuple pair
@@ -354,6 +361,7 @@ impl Display for Arguments {
             quote_timeout,
             balance_overrides,
             native_price_approximation_tokens,
+            tokens_without_verification,
         } = self;
 
         display_option(
@@ -422,6 +430,10 @@ impl Display for Arguments {
         writeln!(
             f,
             "native_price_approximation_tokens: {native_price_approximation_tokens:?}"
+        )?;
+        writeln!(
+            f,
+            "tokens_without_verification: {tokens_without_verification:?}"
         )?;
 
         Ok(())


### PR DESCRIPTION
# Description
This PR is really stupid but unfortunately necessary at the moment...
Some tokens are weird to route optimally and only few solvers support them. However, anybody can create a uniswap pool for these tokens which may cause any good solver to be able to route these tokens automatically.
This is generally a good thing except in one particular edge case:
If the "good" solver is not able to provide calldata with their quote that can be verified but the "bad" solver's calldata verifies just fine we'll currently show the quote from the bad solver despite having very high confidence that the other solver is actually better and knows how to route the tokens.

To avoid showing terrible prices in this VERY specific scenario we need an escape hatch to conditionally bypass the quote verification. I decided to go for a simple token list. If either the sell or the buy token show up in the list that we define we'll skip the quote verification altogether.
That way quote from all solvers (good and bad) will be unverified which levels the playing field and we again pick the quote based on the highest out amount.