### PR TITLE
Speed up settlement indexing

### DIFF
--- a/crates/autopilot/src/domain/auction/mod.rs
+++ b/crates/autopilot/src/domain/auction/mod.rs
@@ -1,5 +1,6 @@
 use {
     super::{Order, eth},
+    serde::Deserialize,
     std::collections::HashMap,
 };
 
@@ -40,7 +41,7 @@ impl PartialEq for Auction {
 
 /// The price of a token in wei. This represents how much wei is needed to buy
 /// 10**18 of another token.
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, Deserialize)]
 pub struct Price(eth::Ether);
 
 impl Price {

--- a/crates/autopilot/src/domain/auction/order.rs
+++ b/crates/autopilot/src/domain/auction/order.rs
@@ -1,9 +1,8 @@
 use {
-    crate::{
-        domain,
-        domain::{eth, fee},
-    },
+    crate::domain::{self, eth, fee},
     primitive_types::{H160, H256, U256},
+    serde::Deserialize,
+    serde_with::serde_as,
     std::fmt::{self, Debug, Display, Formatter},
 };
 
@@ -32,8 +31,9 @@ pub struct Order {
 }
 
 // uid as 56 bytes: 32 for orderDigest, 20 for ownerAddress and 4 for validTo
-#[derive(Copy, Clone, PartialEq, Hash, Eq)]
-pub struct OrderUid(pub [u8; 56]);
+#[serde_as]
+#[derive(Copy, Clone, PartialEq, Hash, Eq, Deserialize)]
+pub struct OrderUid(#[serde_as(as = "bytes_hex::BytesHex")] pub [u8; 56]);
 
 impl OrderUid {
     pub fn owner(&self) -> eth::Address {

--- a/crates/autopilot/src/domain/eth/mod.rs
+++ b/crates/autopilot/src/domain/eth/mod.rs
@@ -2,6 +2,9 @@ pub use primitive_types::{H160, H256, U256};
 use {
     crate::{domain, util::conv::U256Ext},
     derive_more::{Display, From, Into},
+    number::serialization::HexOrDecimalU256,
+    serde::Deserialize,
+    serde_with::serde_as,
 };
 
 /// ERC20 token address for ETH. In reality, ETH is not an ERC20 token because
@@ -13,12 +16,24 @@ pub const NATIVE_TOKEN: TokenAddress = TokenAddress(H160([0xee; 20]));
 
 /// An address. Can be an EOA or a smart contract address.
 #[derive(
-    Debug, Default, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, From, Into, Display,
+    Debug,
+    Default,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash,
+    From,
+    Into,
+    Display,
+    Deserialize,
 )]
 pub struct Address(pub H160);
 
 /// Block number.
-#[derive(Debug, Copy, Clone, From, PartialEq, PartialOrd, Default)]
+#[derive(Debug, Copy, Clone, From, PartialEq, PartialOrd, Default, Deserialize)]
 pub struct BlockNo(pub u64);
 
 /// Adding blocks to a block number.
@@ -37,7 +52,7 @@ pub struct TxId(pub H256);
 /// An ERC20 token address.
 ///
 /// https://eips.ethereum.org/EIPS/eip-20
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, From, Into)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, From, Into, Deserialize)]
 pub struct TokenAddress(pub H160);
 
 impl TokenAddress {
@@ -252,6 +267,7 @@ pub struct Asset {
 }
 
 /// An amount of native Ether tokens denominated in wei.
+#[serde_as]
 #[derive(
     Clone,
     Copy,
@@ -266,8 +282,9 @@ pub struct Asset {
     Default,
     derive_more::Add,
     derive_more::Sub,
+    Deserialize,
 )]
-pub struct Ether(pub U256);
+pub struct Ether(#[serde_as(as = "HexOrDecimalU256")] pub U256);
 
 impl num::Saturating for Ether {
     fn saturating_add(self, v: Self) -> Self {

--- a/crates/autopilot/src/domain/fee/mod.rs
+++ b/crates/autopilot/src/domain/fee/mod.rs
@@ -16,6 +16,7 @@ use {
     derive_more::Into,
     primitive_types::{H160, U256},
     rust_decimal::Decimal,
+    serde::Deserialize,
     std::{collections::HashSet, str::FromStr},
 };
 
@@ -266,7 +267,8 @@ impl ProtocolFees {
     }
 }
 
-#[derive(Debug, Copy, Clone, PartialEq)]
+#[derive(Debug, Copy, Clone, PartialEq, Deserialize)]
+#[serde(tag = "type")]
 pub enum Policy {
     /// If the order receives more than limit price, take the protocol fee as a
     /// percentage of the difference. The fee is taken in `sell` token for
@@ -301,7 +303,7 @@ pub enum Policy {
     },
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Into)]
+#[derive(Debug, Clone, Copy, PartialEq, Into, Deserialize)]
 pub struct FeeFactor(f64);
 
 /// TryFrom implementation for the cases we want to enforce the constrain [0, 1)
@@ -325,7 +327,7 @@ impl FromStr for FeeFactor {
     }
 }
 
-#[derive(Debug, Copy, Clone, PartialEq)]
+#[derive(Debug, Copy, Clone, PartialEq, Deserialize)]
 pub struct Quote {
     /// The amount of the sell token.
     pub sell_amount: U256,

--- a/crates/autopilot/src/domain/settlement/auction.rs
+++ b/crates/autopilot/src/domain/settlement/auction.rs
@@ -2,10 +2,15 @@
 
 use {
     crate::domain::{self},
+    serde::Deserialize,
     std::collections::{HashMap, HashSet},
 };
 
-#[derive(Debug)]
+/// Auction data that is relevant for processing a specific onchain
+/// transaction. e.g. `prices` will contain only prices for tokens
+/// that were actually traded in the transaction - not ALL the prices
+/// that were provided in the original auction.
+#[derive(Debug, Deserialize)]
 pub struct Auction {
     pub id: domain::auction::Id,
     /// The block on top of which the auction was created.

--- a/crates/autopilot/src/domain/settlement/mod.rs
+++ b/crates/autopilot/src/domain/settlement/mod.rs
@@ -124,21 +124,24 @@ impl Settlement {
         self.trades
             .iter()
             .map(|trade| {
-                let fee_breakdown = trade.fee_breakdown(&self.auction).unwrap_or_else(|err| {
-                    tracing::warn!(
-                        ?err,
-                        trade = %trade.uid(),
-                        "possible incomplete fee breakdown calculation",
-                    );
-                    trade::FeeBreakdown {
-                        total: eth::Asset {
-                            // TODO surplus token
-                            token: trade.sell_token(),
-                            amount: num::zero(),
-                        },
-                        protocol: vec![],
-                    }
-                });
+                let fee_breakdown =
+                    trade
+                        .fee_breakdown(&self.auction.orders)
+                        .unwrap_or_else(|err| {
+                            tracing::warn!(
+                                ?err,
+                                trade = %trade.uid(),
+                                "possible incomplete fee breakdown calculation",
+                            );
+                            trade::FeeBreakdown {
+                                total: eth::Asset {
+                                    // TODO surplus token
+                                    token: trade.sell_token(),
+                                    amount: num::zero(),
+                                },
+                                protocol: vec![],
+                            }
+                        });
                 (*trade.uid(), fee_breakdown)
             })
             .collect()
@@ -159,7 +162,7 @@ impl Settlement {
     ) -> Result<Self, Error> {
         let (auction, solver_winning_solutions) = tokio::try_join!(
             persistence
-                .get_auction(settled.auction_id)
+                .get_auction(&settled.trades, settled.auction_id)
                 .map_err(Error::from),
             persistence
                 .get_solver_winning_solutions(settled.auction_id, settled.solver)
@@ -898,11 +901,6 @@ mod tests {
             trade.surplus_in_ether(&auction.prices).unwrap().0,
             eth::U256::from(384509480572312u128)
         );
-
-        assert_eq!(
-            trade.score(&auction).unwrap().0,
-            eth::U256::from(769018961144625u128) // 2 x surplus
-        );
     }
 
     // https://etherscan.io/tx/0x24ea2ea3d70db3e864935008d14170389bda124c786ca90dfb745278db9d24ee
@@ -1257,14 +1255,18 @@ mod tests {
         };
         let jit_trade = super::trade::Trade::new(transaction.trades[1].clone(), &auction, 0);
         assert_eq!(jit_trade.fee_in_ether(&auction.prices).unwrap().0, 0.into());
-        assert_eq!(jit_trade.score(&auction).unwrap().0, 0.into());
         assert_eq!(
-            jit_trade.fee_breakdown(&auction).unwrap().total.amount.0,
+            jit_trade
+                .fee_breakdown(&auction.orders)
+                .unwrap()
+                .total
+                .amount
+                .0,
             0.into()
         );
         assert!(
             jit_trade
-                .fee_breakdown(&auction)
+                .fee_breakdown(&auction.orders)
                 .unwrap()
                 .protocol
                 .is_empty()

--- a/crates/autopilot/src/domain/settlement/mod.rs
+++ b/crates/autopilot/src/domain/settlement/mod.rs
@@ -162,7 +162,7 @@ impl Settlement {
     ) -> Result<Self, Error> {
         let (auction, solver_winning_solutions) = tokio::try_join!(
             persistence
-                .get_auction(&settled.trades, settled.auction_id)
+                .get_auction_comparison(settled.auction_id, &settled.trades)
                 .map_err(Error::from),
             persistence
                 .get_solver_winning_solutions(settled.auction_id, settled.solver)

--- a/crates/autopilot/src/domain/settlement/mod.rs
+++ b/crates/autopilot/src/domain/settlement/mod.rs
@@ -162,7 +162,7 @@ impl Settlement {
     ) -> Result<Self, Error> {
         let (auction, solver_winning_solutions) = tokio::try_join!(
             persistence
-                .get_auction_comparison(settled.auction_id, &settled.trades)
+                .get_auction(&settled.trades, settled.auction_id)
                 .map_err(Error::from),
             persistence
                 .get_solver_winning_solutions(settled.auction_id, settled.solver)

--- a/crates/autopilot/src/domain/settlement/trade/mod.rs
+++ b/crates/autopilot/src/domain/settlement/trade/mod.rs
@@ -1,5 +1,5 @@
 use {
-    super::{transaction, transaction::Prices},
+    super::transaction::{self, Prices},
     crate::domain::{
         self,
         auction::{self, order},
@@ -7,6 +7,7 @@ use {
         fee,
     },
     bigdecimal::Zero,
+    std::collections::HashMap,
 };
 
 pub mod math;
@@ -40,11 +41,6 @@ impl Trade {
         }
     }
 
-    /// CIP38 score defined as surplus + protocol fee
-    pub fn score(&self, auction: &super::Auction) -> Result<eth::Ether, math::Error> {
-        math::Trade::from(self).score(&auction.orders, &auction.prices)
-    }
-
     /// Surplus of a trade.
     pub fn surplus_in_ether(&self, prices: &auction::Prices) -> Result<eth::Ether, math::Error> {
         match self {
@@ -68,10 +64,13 @@ impl Trade {
     }
 
     /// All fees broke down into protocol fees per policy and total fee.
-    pub fn fee_breakdown(&self, auction: &super::Auction) -> Result<FeeBreakdown, math::Error> {
+    pub fn fee_breakdown(
+        &self,
+        fee_policies: &HashMap<domain::OrderUid, impl AsRef<[fee::Policy]>>,
+    ) -> Result<FeeBreakdown, math::Error> {
         let trade = math::Trade::from(self);
         let total = trade.fee_in_sell_token()?;
-        let protocol = trade.protocol_fees(&auction.orders)?;
+        let protocol = trade.protocol_fees(fee_policies)?;
         Ok(FeeBreakdown {
             total: eth::Asset {
                 token: self.sell_token(),

--- a/crates/autopilot/src/infra/persistence/mod.rs
+++ b/crates/autopilot/src/infra/persistence/mod.rs
@@ -28,7 +28,7 @@ use {
     },
     futures::{StreamExt, TryStreamExt},
     itertools::Itertools,
-    number::conversions::{u256_to_big_decimal, u256_to_big_uint},
+    number::conversions::{big_decimal_to_u256, u256_to_big_decimal, u256_to_big_uint},
     primitive_types::H256,
     shared::db_order_conversions::full_order_into_model_order,
     std::{
@@ -280,6 +280,26 @@ impl Persistence {
         .map(|hash| H256(hash.0).into()))
     }
 
+    pub async fn get_auction_comparison(
+        &self,
+        auction_id: domain::auction::Id,
+        trades: &[EncodedTrade],
+    ) -> Result<domain::settlement::Auction, error::Auction> {
+        let original = async {
+            let start = std::time::Instant::now();
+            let res = self.get_auction(auction_id).await;
+            (start.elapsed(), res)
+        };
+        let optimized = async {
+            let start = std::time::Instant::now();
+            let res = self.get_auction_optimized(trades, auction_id).await;
+            (start.elapsed(), res)
+        };
+        let (original, optimized) = tokio::join!(original, optimized);
+        tracing::debug!(original = ?original.0, optimized = ?optimized.0, "get auction finished");
+        original.1
+    }
+
     /// Save auction related data to the database.
     pub async fn save_auction(
         &self,
@@ -326,10 +346,130 @@ impl Persistence {
         Ok(ex.commit().await?)
     }
 
-    /// Returns only auction data that is relevant for processing the
+    /// Get auction data.
+    pub async fn get_auction(
+        &self,
+        auction_id: domain::auction::Id,
+    ) -> Result<domain::settlement::Auction, error::Auction> {
+        let _timer = Metrics::get()
+            .database_queries
+            .with_label_values(&["get_auction"])
+            .start_timer();
+
+        let mut ex = self
+            .postgres
+            .pool
+            .begin()
+            .await
+            .map_err(error::Auction::DatabaseError)?;
+
+        let surplus_capturing_jit_order_owners =
+            database::surplus_capturing_jit_order_owners::fetch(&mut ex, auction_id)
+                .await
+                .map_err(error::Auction::DatabaseError)?
+                .ok_or(error::Auction::NotFound)?
+                .into_iter()
+                .map(|owner| eth::H160(owner.0).into())
+                .collect();
+
+        let prices = database::auction_prices::fetch(&mut ex, auction_id)
+            .await
+            .map_err(error::Auction::DatabaseError)?
+            .into_iter()
+            .map(|price| {
+                let token = eth::H160(price.token.0).into();
+                let price = big_decimal_to_u256(&price.price)
+                    .ok_or(domain::auction::InvalidPrice)
+                    .and_then(|p| domain::auction::Price::try_new(p.into()))
+                    .map_err(|_err| error::Auction::InvalidPrice(token));
+                price.map(|price| (token, price))
+            })
+            .collect::<Result<_, _>>()?;
+
+        let orders = {
+            // get all orders from a competition auction
+            let auction_orders = database::auction_orders::fetch(&mut ex, auction_id)
+                .await
+                .map_err(error::Auction::DatabaseError)?
+                .ok_or(error::Auction::NotFound)?
+                .into_iter()
+                .map(|order| domain::OrderUid(order.0))
+                .collect::<HashSet<_>>();
+
+            // get fee policies for all orders that were part of the competition auction
+            let fee_policies = database::fee_policies::fetch_all(
+                &mut ex,
+                auction_orders
+                    .iter()
+                    .map(|o| (auction_id, ByteArray(o.0)))
+                    .collect::<Vec<_>>()
+                    .as_slice(),
+            )
+            .await
+            .map_err(error::Auction::DatabaseError)?
+            .into_iter()
+            .map(|((_, order), policies)| (domain::OrderUid(order.0), policies))
+            .collect::<HashMap<_, _>>();
+
+            // get quotes for all orders with PriceImprovement fee policy
+            let quotes = self
+                .postgres
+                .read_quotes(fee_policies.iter().filter_map(|(order_uid, policies)| {
+                    policies
+                        .iter()
+                        .any(|policy| {
+                            matches!(
+                                policy.kind,
+                                database::fee_policies::FeePolicyKind::PriceImprovement
+                            )
+                        })
+                        .then_some(order_uid)
+                }))
+                .await
+                .map_err(error::Auction::DatabaseError)?;
+
+            // compile order data
+            let mut orders = HashMap::new();
+            for order in auction_orders.iter() {
+                let order_policies = match fee_policies.get(order) {
+                    Some(policies) => policies
+                        .iter()
+                        .cloned()
+                        .map(|policy| {
+                            dto::fee_policy::try_into_domain(policy, quotes.get(order))
+                                .map_err(|err| error::Auction::InvalidFeePolicy(err, *order))
+                        })
+                        .collect::<Result<Vec<_>, _>>()?,
+                    None => vec![],
+                };
+                orders.insert(*order, order_policies);
+            }
+            orders
+        };
+
+        let block = {
+            let competition = database::solver_competition::load_by_id(&mut ex, auction_id)
+                .await?
+                .ok_or(error::Auction::NotFound)?;
+            serde_json::from_value::<boundary::SolverCompetitionDB>(competition.json)
+                .map_err(|_| error::Auction::NotFound)?
+                .auction_start_block
+                .into()
+        };
+
+        Ok(domain::settlement::Auction {
+            id: auction_id,
+            block,
+            orders,
+            prices,
+            surplus_capturing_jit_order_owners,
+        })
+    }
+
+    /// Returns only auction data that is relvant for processing the
     /// settled trades. e.g. only native prices for traded tokens are
     /// included - not ALL native prices provided in the auction.
-    pub async fn get_auction(
+    pub async fn get_auction_optimized(
         &self,
         trades: &[EncodedTrade],
         auction_id: AuctionId,

--- a/crates/bytes-hex/src/lib.rs
+++ b/crates/bytes-hex/src/lib.rs
@@ -1,7 +1,12 @@
 //! Serialization of Vec<u8> to 0x prefixed hex string
 
 use {
-    serde::{Deserialize, Deserializer, Serializer, de::Error},
+    serde::{
+        Deserialize,
+        Deserializer,
+        Serializer,
+        de::{self, Error},
+    },
     serde_with::{DeserializeAs, SerializeAs},
     std::borrow::Cow,
 };
@@ -51,6 +56,49 @@ impl<'de> DeserializeAs<'de, Vec<u8>> for BytesHex {
         D: Deserializer<'de>,
     {
         deserialize(deserializer)
+    }
+}
+
+impl<'de, const N: usize> DeserializeAs<'de, [u8; N]> for BytesHex {
+    fn deserialize_as<D: Deserializer<'de>>(deserializer: D) -> Result<[u8; N], D::Error> {
+        struct Visitor<const N: usize> {
+            result: [u8; N],
+        }
+
+        impl<const N: usize> de::Visitor<'_> for Visitor<N> {
+            type Value = [u8; N];
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+                write!(
+                    formatter,
+                    "a hex-encoded string starting with \"0x\" containing {N} bytes",
+                )
+            }
+
+            fn visit_str<E>(mut self, s: &str) -> Result<Self::Value, E>
+            where
+                E: de::Error,
+            {
+                if !s.starts_with("0x") {
+                    return Err(de::Error::custom(format!(
+                        "failed to decode {s:?} as a hex string: missing \"0x\" prefix",
+                    )));
+                }
+                let decoded = hex::decode(&s[2..]).map_err(|err| {
+                    de::Error::custom(format!("failed to decode {s:?} as a hex string: {err}",))
+                })?;
+                if decoded.len() != N {
+                    return Err(de::Error::custom(format!(
+                        "failed to decode {s:?} as a hex string: expected {N} bytes, got {}",
+                        decoded.len()
+                    )));
+                }
+                self.result.copy_from_slice(&decoded);
+                Ok(self.result)
+            }
+        }
+
+        deserializer.deserialize_str(Visitor { result: [0; N] })
     }
 }
 


### PR DESCRIPTION
# Description
Currently the autopilot's maintenance tasks that it runs between 2 auctions is very slow. The biggest time sink is currently indexing new settlement events. After some investigation it became apparent that the DB query we do to get all the necessary data for post-processing the auction is very slow (250ms - 500ms).
There are 2 reasons for that:
1. we fetch all the data from the given auction - not just what we actually need
2. we do multiple DB queries instead of doing 1 big query

<img width="1189" height="343" alt="Screenshot 2025-09-12 at 13 41 17" src="https://github.com/user-attachments/assets/c3078575-16a3-4fa4-8b9a-72b62e9f5a96" />
<img width="1189" height="300" alt="Screenshot 2025-09-12 at 13 41 54" src="https://github.com/user-attachments/assets/9d5bd008-c88a-49ee-b1af-9b5425f08c95" />

Because this is a very important query I didn't go ahead and tested the performance in the actual cluster yet. ☝️ is just the status quo.


# Changes
This PR addresses both of these issues. So far I only tested it with a few hand crafted test queries but they were in the ball bark of 1-2ms execution time.
Because we return data with a lot of different cardinalities and structures I decided to return the data as a JSON string and parse it into our domain object. That made the query a bit difficult to read but I think the performance improvement should still be worth it.

## How to test
Given that this query if fundamental for indexing events which almost all of the e2e tests have some form of assertion on I think running the e2e tests in CI should be sufficient for the correctness.