### PR TITLE
Replace to_wei(amount).into_alloy() calls to eth(amount)

### DIFF
--- a/crates/e2e/src/setup/onchain_components/mod.rs
+++ b/crates/e2e/src/setup/onchain_components/mod.rs
@@ -80,6 +80,13 @@ pub fn to_wei(base: u32) -> U256 {
     to_wei_with_exp(base, 18)
 }
 
+/// Returns the provided Eth amount in wei.
+///
+/// Equivalent to `amount * 10^18`.
+pub fn eth(amount: u32) -> ::alloy::primitives::U256 {
+    ::alloy::primitives::U256::from(amount) * ::alloy::primitives::utils::Unit::ETHER.wei()
+}
+
 pub async fn hook_for_transaction<T>(tx: TransactionBuilder<T>) -> Hook
 where
     T: web3::Transport,

--- a/crates/e2e/tests/e2e/app_data.rs
+++ b/crates/e2e/tests/e2e/app_data.rs
@@ -1,6 +1,6 @@
 use {
     app_data::{AppDataHash, hash_full_app_data},
-    e2e::setup::*,
+    e2e::setup::{eth, *},
     ethrpc::alloy::{
         CallBuilderExt,
         conversions::{IntoAlloy, IntoLegacy},
@@ -41,10 +41,7 @@ async fn app_data(web3: Web3) {
     token_a.mint(trader.address(), to_wei(10)).await;
 
     token_a
-        .approve(
-            onchain.contracts().allowance.into_alloy(),
-            to_wei(10).into_alloy(),
-        )
+        .approve(onchain.contracts().allowance.into_alloy(), eth(10))
         .from(trader.address().into_alloy())
         .send_and_watch()
         .await
@@ -206,10 +203,7 @@ async fn app_data_full_format(web3: Web3) {
     token_a.mint(trader.address(), to_wei(10)).await;
 
     token_a
-        .approve(
-            onchain.contracts().allowance.into_alloy(),
-            to_wei(10).into_alloy(),
-        )
+        .approve(onchain.contracts().allowance.into_alloy(), eth(10))
         .from(trader.address().into_alloy())
         .send_and_watch()
         .await

--- a/crates/e2e/tests/e2e/app_data_signer.rs
+++ b/crates/e2e/tests/e2e/app_data_signer.rs
@@ -1,6 +1,6 @@
 use {
     alloy::primitives::Address,
-    e2e::setup::{OnchainComponents, Services, TestAccount, run_test, safe::Safe, to_wei},
+    e2e::setup::{OnchainComponents, Services, TestAccount, eth, run_test, safe::Safe, to_wei},
     ethrpc::alloy::{
         CallBuilderExt,
         conversions::{IntoAlloy, IntoLegacy},
@@ -31,10 +31,7 @@ async fn order_creation_checks_metadata_signer(web3: Web3) {
     token_a.mint(trader.address(), to_wei(10)).await;
 
     token_a
-        .approve(
-            onchain.contracts().allowance.into_alloy(),
-            to_wei(10).into_alloy(),
-        )
+        .approve(onchain.contracts().allowance.into_alloy(), eth(10))
         .from(trader.address().into_alloy())
         .send_and_watch()
         .await
@@ -42,10 +39,7 @@ async fn order_creation_checks_metadata_signer(web3: Web3) {
     token_a.mint(adversary.address(), to_wei(10)).await;
 
     token_a
-        .approve(
-            onchain.contracts().allowance.into_alloy(),
-            to_wei(10).into_alloy(),
-        )
+        .approve(onchain.contracts().allowance.into_alloy(), eth(10))
         .from(adversary.address().into_alloy())
         .send_and_watch()
         .await
@@ -108,10 +102,7 @@ async fn order_creation_checks_metadata_signer(web3: Web3) {
     token_a.mint(safe.address().into_legacy(), to_wei(10)).await;
     safe.exec_alloy_call(
         token_a
-            .approve(
-                onchain.contracts().allowance.into_alloy(),
-                to_wei(10).into_alloy(),
-            )
+            .approve(onchain.contracts().allowance.into_alloy(), eth(10))
             .into_transaction_request(),
     )
     .await;

--- a/crates/e2e/tests/e2e/buffers.rs
+++ b/crates/e2e/tests/e2e/buffers.rs
@@ -1,6 +1,6 @@
 use {
     ::alloy::primitives::U256,
-    e2e::setup::*,
+    e2e::setup::{eth, *},
     ethrpc::alloy::{
         CallBuilderExt,
         conversions::{IntoAlloy, IntoLegacy},
@@ -40,10 +40,7 @@ async fn onchain_settlement_without_liquidity(web3: Web3) {
     // Approve GPv2 for trading
 
     token_a
-        .approve(
-            onchain.contracts().allowance.into_alloy(),
-            to_wei(100).into_alloy(),
-        )
+        .approve(onchain.contracts().allowance.into_alloy(), eth(100))
         .from(trader.address().into_alloy())
         .send_and_watch()
         .await

--- a/crates/e2e/tests/e2e/cow_amm.rs
+++ b/crates/e2e/tests/e2e/cow_amm.rs
@@ -14,6 +14,7 @@ use {
             Services,
             TIMEOUT,
             colocation::{self, SolverEngine},
+            eth,
             mock::Mock,
             run_forked_test_with_block_number,
             run_test,
@@ -89,14 +90,11 @@ async fn cow_amm_jit(web3: Web3) {
     // Fund cow amm owner with 2_000 dai and allow factory take them
     dai.mint(cow_amm_owner.address(), to_wei(2_000)).await;
 
-    dai.approve(
-        cow_amm_factory.address().into_alloy(),
-        to_wei(2_000).into_alloy(),
-    )
-    .from(cow_amm_owner.address().into_alloy())
-    .send_and_watch()
-    .await
-    .unwrap();
+    dai.approve(cow_amm_factory.address().into_alloy(), eth(2_000))
+        .from(cow_amm_owner.address().into_alloy())
+        .send_and_watch()
+        .await
+        .unwrap();
     // Fund cow amm owner with 1 WETH and allow factory take them
     tx_value!(
         cow_amm_owner.account(),
@@ -712,14 +710,11 @@ async fn cow_amm_opposite_direction(web3: Web3) {
     // them
     dai.mint(cow_amm_owner.address(), to_wei(2_000)).await;
 
-    dai.approve(
-        cow_amm_factory.address().into_alloy(),
-        to_wei(2_000).into_alloy(),
-    )
-    .from(cow_amm_owner.address().into_alloy())
-    .send_and_watch()
-    .await
-    .unwrap();
+    dai.approve(cow_amm_factory.address().into_alloy(), eth(2_000))
+        .from(cow_amm_owner.address().into_alloy())
+        .send_and_watch()
+        .await
+        .unwrap();
 
     tx_value!(
         cow_amm_owner.account(),

--- a/crates/e2e/tests/e2e/eth_integration.rs
+++ b/crates/e2e/tests/e2e/eth_integration.rs
@@ -1,5 +1,5 @@
 use {
-    e2e::setup::*,
+    e2e::setup::{eth, *},
     ethcontract::prelude::Address,
     ethrpc::alloy::{
         CallBuilderExt,
@@ -38,20 +38,14 @@ async fn eth_integration(web3: Web3) {
     // Approve GPv2 for trading
 
     token
-        .approve(
-            onchain.contracts().allowance.into_alloy(),
-            to_wei(51).into_alloy(),
-        )
+        .approve(onchain.contracts().allowance.into_alloy(), eth(51))
         .from(trader_a.address().into_alloy())
         .send_and_watch()
         .await
         .unwrap();
 
     token
-        .approve(
-            onchain.contracts().allowance.into_alloy(),
-            to_wei(51).into_alloy(),
-        )
+        .approve(onchain.contracts().allowance.into_alloy(), eth(51))
         .from(trader_b.address().into_alloy())
         .send_and_watch()
         .await

--- a/crates/e2e/tests/e2e/eth_safe.rs
+++ b/crates/e2e/tests/e2e/eth_safe.rs
@@ -4,6 +4,7 @@ use {
         OnchainComponents,
         Services,
         TIMEOUT,
+        eth,
         run_test,
         safe::Safe,
         to_wei,
@@ -40,20 +41,14 @@ async fn test(web3: Web3) {
     token.mint(trader.address(), to_wei(4)).await;
     safe.exec_alloy_call(
         token
-            .approve(
-                onchain.contracts().allowance.into_alloy(),
-                to_wei(4).into_alloy(),
-            )
+            .approve(onchain.contracts().allowance.into_alloy(), eth(4))
             .into_transaction_request(),
     )
     .await;
     token.mint(safe.address().into_legacy(), to_wei(4)).await;
 
     token
-        .approve(
-            onchain.contracts().allowance.into_alloy(),
-            to_wei(4).into_alloy(),
-        )
+        .approve(onchain.contracts().allowance.into_alloy(), eth(4))
         .from(trader.address().into_alloy())
         .send_and_watch()
         .await

--- a/crates/e2e/tests/e2e/ethflow.rs
+++ b/crates/e2e/tests/e2e/ethflow.rs
@@ -14,6 +14,7 @@ use {
             TIMEOUT,
             TRADES_ENDPOINT,
             TestAccount,
+            eth,
             run_test,
             to_wei,
             wait_for_condition,
@@ -115,7 +116,7 @@ async fn eth_flow_tx(web3: Web3) {
     services.start_protocol(solver).await;
 
     let approve_call_data = {
-        let call_builder = dai.approve(trader.address().into_alloy(), to_wei(10).into_alloy());
+        let call_builder = dai.approve(trader.address().into_alloy(), eth(10));
         let calldata = call_builder.calldata();
         format!("0x{}", hex::encode(calldata))
     };
@@ -223,7 +224,7 @@ async fn eth_flow_tx(web3: Web3) {
         .call()
         .await
         .unwrap();
-    assert_eq!(allowance, to_wei(10).into_alloy());
+    assert_eq!(allowance, eth(10));
 
     let allowance = onchain
         .contracts()

--- a/crates/e2e/tests/e2e/hooks.rs
+++ b/crates/e2e/tests/e2e/hooks.rs
@@ -6,6 +6,7 @@ use {
             OnchainComponents,
             Services,
             TIMEOUT,
+            eth,
             hook_for_transaction,
             onchain_components,
             run_test,
@@ -301,10 +302,7 @@ async fn signature(web3: Web3) {
     // Sign an approval transaction for trading. This will be at nonce 0 because
     // it is the first transaction evah!
     let approval_call_data = token
-        .approve(
-            onchain.contracts().allowance.into_alloy(),
-            to_wei(5).into_alloy(),
-        )
+        .approve(onchain.contracts().allowance.into_alloy(), eth(5))
         .calldata()
         .to_vec();
     let approval_builder = safe.sign_transaction(
@@ -566,10 +564,7 @@ async fn quote_verification(web3: Web3) {
     token.mint(safe.address().into_legacy(), to_wei(5)).await;
 
     token
-        .approve(
-            onchain.contracts().allowance.into_alloy(),
-            to_wei(5).into_alloy(),
-        )
+        .approve(onchain.contracts().allowance.into_alloy(), eth(5))
         .from(trader.address().into_alloy())
         .send_and_watch()
         .await
@@ -580,7 +575,7 @@ async fn quote_verification(web3: Web3) {
     let transfer_builder = safe.sign_transaction(
         *token.address(),
         token
-            .transfer(trader.address().into_alloy(), to_wei(5).into_alloy())
+            .transfer(trader.address().into_alloy(), eth(5))
             .calldata()
             .to_vec(),
         alloy::primitives::U256::ZERO,

--- a/crates/e2e/tests/e2e/jit_orders.rs
+++ b/crates/e2e/tests/e2e/jit_orders.rs
@@ -1,6 +1,6 @@
 use {
     e2e::{
-        setup::{colocation::SolverEngine, mock::Mock, solution::JitOrder, *},
+        setup::{colocation::SolverEngine, eth, mock::Mock, solution::JitOrder, *},
         tx,
         tx_value,
     },
@@ -206,11 +206,11 @@ async fn single_limit_order_test(web3: Web3) {
             .unwrap();
 
         let trader_balance_increased =
-            trader_balance_after.saturating_sub(trader_balance_before) >= to_wei(5).into_alloy();
+            trader_balance_after.saturating_sub(trader_balance_before) >= eth(5);
         // Since the fee is 0 in the custom solution, the balance difference has to be
         // exactly 10 wei
         let solver_balance_decreased =
-            solver_balance_before.saturating_sub(solver_balance_after) == to_wei(10).into_alloy();
+            solver_balance_before.saturating_sub(solver_balance_after) == eth(10);
         trader_balance_increased && solver_balance_decreased
     })
     .await

--- a/crates/e2e/tests/e2e/limit_orders.rs
+++ b/crates/e2e/tests/e2e/limit_orders.rs
@@ -4,7 +4,11 @@ use {
     contracts::ERC20,
     database::byte_array::ByteArray,
     driver::domain::eth::NonZeroU256,
-    e2e::{nodes::forked_node::ForkedNodeApi, setup::*, tx},
+    e2e::{
+        nodes::forked_node::ForkedNodeApi,
+        setup::{eth, *},
+        tx,
+    },
     ethcontract::{H160, prelude::U256},
     ethrpc::alloy::{
         CallBuilderExt,
@@ -121,7 +125,7 @@ async fn single_limit_order_test(web3: Web3) {
     token_a
         .approve(
             onchain.contracts().uniswap_v2_router.address().into_alloy(),
-            to_wei(1000).into_alloy(),
+            eth(1000),
         )
         .from(solver.address().into_alloy())
         .send_and_watch()
@@ -131,7 +135,7 @@ async fn single_limit_order_test(web3: Web3) {
     token_b
         .approve(
             onchain.contracts().uniswap_v2_router.address().into_alloy(),
-            to_wei(1000).into_alloy(),
+            eth(1000),
         )
         .from(solver.address().into_alloy())
         .send_and_watch()
@@ -154,10 +158,7 @@ async fn single_limit_order_test(web3: Web3) {
     // Approve GPv2 for trading
 
     token_a
-        .approve(
-            onchain.contracts().allowance.into_alloy(),
-            to_wei(10).into_alloy(),
-        )
+        .approve(onchain.contracts().allowance.into_alloy(), eth(10))
         .from(trader_a.address().into_alloy())
         .send_and_watch()
         .await
@@ -207,7 +208,7 @@ async fn single_limit_order_test(web3: Web3) {
             .call()
             .await
             .unwrap();
-        balance_after.checked_sub(balance_before).unwrap() >= to_wei(5).into_alloy()
+        balance_after.checked_sub(balance_before).unwrap() >= eth(5)
     })
     .await
     .unwrap();
@@ -249,7 +250,7 @@ async fn two_limit_orders_test(web3: Web3) {
     token_a
         .approve(
             onchain.contracts().uniswap_v2_router.address().into_alloy(),
-            to_wei(1000).into_alloy(),
+            eth(1000),
         )
         .from(solver.address().into_alloy())
         .send_and_watch()
@@ -259,7 +260,7 @@ async fn two_limit_orders_test(web3: Web3) {
     token_b
         .approve(
             onchain.contracts().uniswap_v2_router.address().into_alloy(),
-            to_wei(1000).into_alloy(),
+            eth(1000),
         )
         .from(solver.address().into_alloy())
         .send_and_watch()
@@ -282,20 +283,14 @@ async fn two_limit_orders_test(web3: Web3) {
     // Approve GPv2 for trading
 
     token_a
-        .approve(
-            onchain.contracts().allowance.into_alloy(),
-            to_wei(10).into_alloy(),
-        )
+        .approve(onchain.contracts().allowance.into_alloy(), eth(10))
         .from(trader_a.address().into_alloy())
         .send_and_watch()
         .await
         .unwrap();
 
     token_b
-        .approve(
-            onchain.contracts().allowance.into_alloy(),
-            to_wei(10).into_alloy(),
-        )
+        .approve(onchain.contracts().allowance.into_alloy(), eth(10))
         .from(trader_b.address().into_alloy())
         .send_and_watch()
         .await
@@ -369,10 +364,8 @@ async fn two_limit_orders_test(web3: Web3) {
             .call()
             .await
             .unwrap();
-        let order_a_settled =
-            balance_after_a.saturating_sub(balance_before_a) >= to_wei(5).into_alloy();
-        let order_b_settled =
-            balance_after_b.saturating_sub(balance_before_b) >= to_wei(2).into_alloy();
+        let order_a_settled = balance_after_a.saturating_sub(balance_before_a) >= eth(5);
+        let order_b_settled = balance_after_b.saturating_sub(balance_before_b) >= eth(2);
         order_a_settled && order_b_settled
     })
     .await
@@ -409,20 +402,14 @@ async fn two_limit_orders_multiple_winners_test(web3: Web3) {
     // Approve GPv2 for trading
 
     token_a
-        .approve(
-            onchain.contracts().allowance.into_alloy(),
-            to_wei(100).into_alloy(),
-        )
+        .approve(onchain.contracts().allowance.into_alloy(), eth(100))
         .from(trader_a.address().into_alloy())
         .send_and_watch()
         .await
         .unwrap();
 
     token_b
-        .approve(
-            onchain.contracts().allowance.into_alloy(),
-            to_wei(100).into_alloy(),
-        )
+        .approve(onchain.contracts().allowance.into_alloy(), eth(100))
         .from(trader_b.address().into_alloy())
         .send_and_watch()
         .await
@@ -641,10 +628,7 @@ async fn too_many_limit_orders_test(web3: Web3) {
     // Approve GPv2 for trading
 
     token_a
-        .approve(
-            onchain.contracts().allowance.into_alloy(),
-            to_wei(101).into_alloy(),
-        )
+        .approve(onchain.contracts().allowance.into_alloy(), eth(101))
         .from(trader.address().into_alloy())
         .send_and_watch()
         .await
@@ -726,10 +710,7 @@ async fn limit_does_not_apply_to_in_market_orders_test(web3: Web3) {
     // Approve GPv2 for trading
 
     token
-        .approve(
-            onchain.contracts().allowance.into_alloy(),
-            to_wei(101).into_alloy(),
-        )
+        .approve(onchain.contracts().allowance.into_alloy(), eth(101))
         .from(trader.address().into_alloy())
         .send_and_watch()
         .await
@@ -1063,10 +1044,7 @@ async fn no_liquidity_limit_order(web3: Web3) {
     // Approve GPv2 for trading
 
     token_a
-        .approve(
-            onchain.contracts().allowance.into_alloy(),
-            to_wei(10).into_alloy(),
-        )
+        .approve(onchain.contracts().allowance.into_alloy(), eth(10))
         .from(trader_a.address().into_alloy())
         .send_and_watch()
         .await

--- a/crates/e2e/tests/e2e/order_cancellation.rs
+++ b/crates/e2e/tests/e2e/order_cancellation.rs
@@ -1,6 +1,6 @@
 use {
     database::order_events::OrderEventLabel,
-    e2e::setup::*,
+    e2e::setup::{eth, *},
     ethrpc::alloy::{
         CallBuilderExt,
         conversions::{IntoAlloy, IntoLegacy},
@@ -46,10 +46,7 @@ async fn order_cancellation(web3: Web3) {
     // Approve GPv2 for trading
 
     token
-        .approve(
-            onchain.contracts().allowance.into_alloy(),
-            to_wei(10).into_alloy(),
-        )
+        .approve(onchain.contracts().allowance.into_alloy(), eth(10))
         .from(trader.address().into_alloy())
         .send_and_watch()
         .await

--- a/crates/e2e/tests/e2e/partially_fillable_balance.rs
+++ b/crates/e2e/tests/e2e/partially_fillable_balance.rs
@@ -1,6 +1,9 @@
 use {
     ::alloy::primitives::U256,
-    e2e::{setup::*, tx},
+    e2e::{
+        setup::{eth, *},
+        tx,
+    },
     ethrpc::alloy::{
         CallBuilderExt,
         conversions::{IntoAlloy, IntoLegacy},
@@ -44,7 +47,7 @@ async fn test(web3: Web3) {
     token_a
         .approve(
             onchain.contracts().uniswap_v2_router.address().into_alloy(),
-            to_wei(1000).into_alloy(),
+            eth(1000),
         )
         .from(solver.address().into_alloy())
         .send_and_watch()
@@ -54,7 +57,7 @@ async fn test(web3: Web3) {
     token_b
         .approve(
             onchain.contracts().uniswap_v2_router.address().into_alloy(),
-            to_wei(1000).into_alloy(),
+            eth(1000),
         )
         .from(solver.address().into_alloy())
         .send_and_watch()
@@ -75,10 +78,7 @@ async fn test(web3: Web3) {
     );
 
     token_a
-        .approve(
-            onchain.contracts().allowance.into_alloy(),
-            to_wei(500).into_alloy(),
-        )
+        .approve(onchain.contracts().allowance.into_alloy(), eth(500))
         .from(trader_a.address().into_alloy())
         .send_and_watch()
         .await

--- a/crates/e2e/tests/e2e/partially_fillable_pool.rs
+++ b/crates/e2e/tests/e2e/partially_fillable_pool.rs
@@ -1,5 +1,8 @@
 use {
-    e2e::{setup::*, tx},
+    e2e::{
+        setup::{eth, *},
+        tx,
+    },
     ethcontract::prelude::U256,
     ethrpc::alloy::{
         CallBuilderExt,
@@ -43,7 +46,7 @@ async fn test(web3: Web3) {
     token_a
         .approve(
             onchain.contracts().uniswap_v2_router.address().into_alloy(),
-            to_wei(1000).into_alloy(),
+            eth(1000),
         )
         .from(solver.address().into_alloy())
         .send_and_watch()
@@ -53,7 +56,7 @@ async fn test(web3: Web3) {
     token_b
         .approve(
             onchain.contracts().uniswap_v2_router.address().into_alloy(),
-            to_wei(1000).into_alloy(),
+            eth(1000),
         )
         .from(solver.address().into_alloy())
         .send_and_watch()
@@ -74,10 +77,7 @@ async fn test(web3: Web3) {
     );
 
     token_a
-        .approve(
-            onchain.contracts().allowance.into_alloy(),
-            to_wei(500).into_alloy(),
-        )
+        .approve(onchain.contracts().allowance.into_alloy(), eth(500))
         .from(trader_a.address().into_alloy())
         .send_and_watch()
         .await

--- a/crates/e2e/tests/e2e/protocol_fee.rs
+++ b/crates/e2e/tests/e2e/protocol_fee.rs
@@ -2,7 +2,7 @@ use {
     driver::domain::eth::NonZeroU256,
     e2e::{
         assert_approximately_eq,
-        setup::{fee::*, *},
+        setup::{eth, fee::*, *},
         tx,
         tx_value,
     },
@@ -98,7 +98,7 @@ async fn combined_protocol_fees(web3: Web3) {
         token
             .approve(
                 onchain.contracts().uniswap_v2_router.address().into_alloy(),
-                to_wei(1000).into_alloy(),
+                eth(1000),
             )
             .from(solver.address().into_alloy())
             .send_and_watch()
@@ -108,7 +108,7 @@ async fn combined_protocol_fees(web3: Web3) {
         token
             .approve(
                 onchain.contracts().uniswap_v2_router.address().into_alloy(),
-                to_wei(100).into_alloy(),
+                eth(100),
             )
             .from(trader.address().into_alloy())
             .send_and_watch()
@@ -434,7 +434,7 @@ async fn surplus_partner_fee(web3: Web3) {
     token
         .approve(
             onchain.contracts().uniswap_v2_router.address().into_alloy(),
-            to_wei(1000).into_alloy(),
+            eth(1000),
         )
         .from(solver.address().into_alloy())
         .send_and_watch()
@@ -444,7 +444,7 @@ async fn surplus_partner_fee(web3: Web3) {
     token
         .approve(
             onchain.contracts().uniswap_v2_router.address().into_alloy(),
-            to_wei(100).into_alloy(),
+            eth(100),
         )
         .from(trader.address().into_alloy())
         .send_and_watch()
@@ -655,7 +655,7 @@ async fn volume_fee_buy_order_test(web3: Web3) {
     token_gno
         .approve(
             onchain.contracts().uniswap_v2_router.address().into_alloy(),
-            to_wei(1000).into_alloy(),
+            eth(1000),
         )
         .from(solver.address().into_alloy())
         .send_and_watch()
@@ -665,7 +665,7 @@ async fn volume_fee_buy_order_test(web3: Web3) {
     token_dai
         .approve(
             onchain.contracts().uniswap_v2_router.address().into_alloy(),
-            to_wei(1000).into_alloy(),
+            eth(1000),
         )
         .from(solver.address().into_alloy())
         .send_and_watch()
@@ -688,10 +688,7 @@ async fn volume_fee_buy_order_test(web3: Web3) {
     // Approve GPv2 for trading
 
     token_gno
-        .approve(
-            onchain.contracts().allowance.into_alloy(),
-            to_wei(100).into_alloy(),
-        )
+        .approve(onchain.contracts().allowance.into_alloy(), eth(100))
         .from(trader.address().into_alloy())
         .send_and_watch()
         .await

--- a/crates/e2e/tests/e2e/quote_verification.rs
+++ b/crates/e2e/tests/e2e/quote_verification.rs
@@ -1,6 +1,6 @@
 use {
     bigdecimal::{BigDecimal, Zero},
-    e2e::setup::*,
+    e2e::setup::{eth, *},
     ethcontract::{H160, U256},
     ethrpc::{
         Web3,
@@ -95,10 +95,7 @@ async fn standard_verified_quote(web3: Web3) {
     token.mint(trader.address(), to_wei(1)).await;
 
     token
-        .approve(
-            onchain.contracts().allowance.into_alloy(),
-            to_wei(1).into_alloy(),
-        )
+        .approve(onchain.contracts().allowance.into_alloy(), eth(1))
         .from(trader.address().into_alloy())
         .send_and_watch()
         .await

--- a/crates/e2e/tests/e2e/quoting.rs
+++ b/crates/e2e/tests/e2e/quoting.rs
@@ -1,6 +1,6 @@
 use {
     e2e::{
-        setup::{colocation::SolverEngine, mock::Mock, *},
+        setup::{colocation::SolverEngine, eth, mock::Mock, *},
         tx,
         tx_value,
     },
@@ -367,10 +367,7 @@ async fn quote_timeout(web3: Web3) {
     sell_token.mint(trader.address(), to_wei(1)).await;
 
     sell_token
-        .approve(
-            onchain.contracts().allowance.into_alloy(),
-            to_wei(1).into_alloy(),
-        )
+        .approve(onchain.contracts().allowance.into_alloy(), eth(1))
         .from(trader.address().into_alloy())
         .send_and_watch()
         .await

--- a/crates/e2e/tests/e2e/replace_order.rs
+++ b/crates/e2e/tests/e2e/replace_order.rs
@@ -1,5 +1,9 @@
 use {
-    e2e::{nodes::local_node::TestNodeApi, setup::*, tx},
+    e2e::{
+        nodes::local_node::TestNodeApi,
+        setup::{eth, *},
+        tx,
+    },
     ethcontract::prelude::U256,
     ethrpc::alloy::{
         CallBuilderExt,
@@ -64,7 +68,7 @@ async fn try_replace_unreplaceable_order_test(web3: Web3) {
     token_a
         .approve(
             onchain.contracts().uniswap_v2_router.address().into_alloy(),
-            to_wei(1000).into_alloy(),
+            eth(1000),
         )
         .from(solver.address().into_alloy())
         .send_and_watch()
@@ -74,7 +78,7 @@ async fn try_replace_unreplaceable_order_test(web3: Web3) {
     token_b
         .approve(
             onchain.contracts().uniswap_v2_router.address().into_alloy(),
-            to_wei(1000).into_alloy(),
+            eth(1000),
         )
         .from(solver.address().into_alloy())
         .send_and_watch()
@@ -97,10 +101,7 @@ async fn try_replace_unreplaceable_order_test(web3: Web3) {
     // Approve GPv2 for trading
 
     token_a
-        .approve(
-            onchain.contracts().allowance.into_alloy(),
-            to_wei(15).into_alloy(),
-        )
+        .approve(onchain.contracts().allowance.into_alloy(), eth(15))
         .from(trader.address().into_alloy())
         .send_and_watch()
         .await
@@ -199,7 +200,7 @@ async fn try_replace_unreplaceable_order_test(web3: Web3) {
             .call()
             .await
             .unwrap();
-        balance_before.saturating_sub(balance_after) == to_wei(10).into_alloy()
+        balance_before.saturating_sub(balance_after) == eth(10)
             && !services.get_trades(&order_id).await.unwrap().is_empty()
     })
     .await
@@ -249,7 +250,7 @@ async fn try_replace_someone_else_order_test(web3: Web3) {
     token_a
         .approve(
             onchain.contracts().uniswap_v2_router.address().into_alloy(),
-            to_wei(1000).into_alloy(),
+            eth(1000),
         )
         .from(solver.address().into_alloy())
         .send_and_watch()
@@ -259,7 +260,7 @@ async fn try_replace_someone_else_order_test(web3: Web3) {
     token_b
         .approve(
             onchain.contracts().uniswap_v2_router.address().into_alloy(),
-            to_wei(1000).into_alloy(),
+            eth(1000),
         )
         .from(solver.address().into_alloy())
         .send_and_watch()
@@ -282,20 +283,14 @@ async fn try_replace_someone_else_order_test(web3: Web3) {
     // Approve GPv2 for trading
 
     token_a
-        .approve(
-            onchain.contracts().allowance.into_alloy(),
-            to_wei(15).into_alloy(),
-        )
+        .approve(onchain.contracts().allowance.into_alloy(), eth(15))
         .from(trader_a.address().into_alloy())
         .send_and_watch()
         .await
         .unwrap();
 
     token_a
-        .approve(
-            onchain.contracts().allowance.into_alloy(),
-            to_wei(15).into_alloy(),
-        )
+        .approve(onchain.contracts().allowance.into_alloy(), eth(15))
         .from(trader_b.address().into_alloy())
         .send_and_watch()
         .await
@@ -362,7 +357,7 @@ async fn try_replace_someone_else_order_test(web3: Web3) {
             .call()
             .await
             .unwrap();
-        balance_before.saturating_sub(balance_after) == to_wei(10).into_alloy()
+        balance_before.saturating_sub(balance_after) == eth(10)
     })
     .await
     .unwrap();
@@ -394,7 +389,7 @@ async fn single_replace_order_test(web3: Web3) {
     token_a
         .approve(
             onchain.contracts().uniswap_v2_router.address().into_alloy(),
-            to_wei(1000).into_alloy(),
+            eth(1000),
         )
         .from(solver.address().into_alloy())
         .send_and_watch()
@@ -404,7 +399,7 @@ async fn single_replace_order_test(web3: Web3) {
     token_b
         .approve(
             onchain.contracts().uniswap_v2_router.address().into_alloy(),
-            to_wei(1000).into_alloy(),
+            eth(1000),
         )
         .from(solver.address().into_alloy())
         .send_and_watch()
@@ -427,10 +422,7 @@ async fn single_replace_order_test(web3: Web3) {
     // Approve GPv2 for trading
 
     token_a
-        .approve(
-            onchain.contracts().allowance.into_alloy(),
-            to_wei(15).into_alloy(),
-        )
+        .approve(onchain.contracts().allowance.into_alloy(), eth(15))
         .from(trader.address().into_alloy())
         .send_and_watch()
         .await
@@ -543,7 +535,7 @@ async fn single_replace_order_test(web3: Web3) {
             .await
             .unwrap();
         onchain.mint_block().await;
-        balance_before.saturating_sub(balance_after) == to_wei(3).into_alloy()
+        balance_before.saturating_sub(balance_after) == eth(3)
     })
     .await
     .unwrap();

--- a/crates/e2e/tests/e2e/smart_contract_orders.rs
+++ b/crates/e2e/tests/e2e/smart_contract_orders.rs
@@ -1,6 +1,6 @@
 use {
     e2e::{
-        setup::{safe::Safe, *},
+        setup::{eth, safe::Safe, *},
         tx,
     },
     ethcontract::{Bytes, H160, U256},
@@ -41,10 +41,7 @@ async fn smart_contract_orders(web3: Web3) {
     // Approve GPv2 for trading
     safe.exec_alloy_call(
         token
-            .approve(
-                onchain.contracts().allowance.into_alloy(),
-                to_wei(10).into_alloy(),
-            )
+            .approve(onchain.contracts().allowance.into_alloy(), eth(10))
             .into_transaction_request(),
     )
     .await;

--- a/crates/e2e/tests/e2e/solver_competition.rs
+++ b/crates/e2e/tests/e2e/solver_competition.rs
@@ -1,6 +1,6 @@
 use {
     ::alloy::primitives::U256,
-    e2e::setup::{colocation::SolverEngine, mock::Mock, *},
+    e2e::setup::{colocation::SolverEngine, eth, mock::Mock, *},
     ethrpc::alloy::{
         CallBuilderExt,
         conversions::{IntoAlloy, IntoLegacy},
@@ -50,10 +50,7 @@ async fn solver_competition(web3: Web3) {
     // Approve GPv2 for trading
 
     token_a
-        .approve(
-            onchain.contracts().allowance.into_alloy(),
-            to_wei(100).into_alloy(),
-        )
+        .approve(onchain.contracts().allowance.into_alloy(), eth(100))
         .from(trader.address().into_alloy())
         .send_and_watch()
         .await
@@ -185,20 +182,14 @@ async fn wrong_solution_submission_address(web3: Web3) {
     // Approve GPv2 for trading
 
     token_a
-        .approve(
-            onchain.contracts().allowance.into_alloy(),
-            to_wei(100).into_alloy(),
-        )
+        .approve(onchain.contracts().allowance.into_alloy(), eth(100))
         .from(trader_a.address().into_alloy())
         .send_and_watch()
         .await
         .unwrap();
 
     token_b
-        .approve(
-            onchain.contracts().allowance.into_alloy(),
-            to_wei(100).into_alloy(),
-        )
+        .approve(onchain.contracts().allowance.into_alloy(), eth(100))
         .from(trader_b.address().into_alloy())
         .send_and_watch()
         .await
@@ -331,10 +322,7 @@ async fn store_filtered_solutions(web3: Web3) {
     token_a.mint(trader.address(), to_wei(2)).await;
 
     token_a
-        .approve(
-            onchain.contracts().allowance.into_alloy(),
-            to_wei(2).into_alloy(),
-        )
+        .approve(onchain.contracts().allowance.into_alloy(), eth(2))
         .from(trader.address().into_alloy())
         .send_and_watch()
         .await

--- a/crates/e2e/tests/e2e/solver_participation_guard.rs
+++ b/crates/e2e/tests/e2e/solver_participation_guard.rs
@@ -8,6 +8,7 @@ use {
             Services,
             TIMEOUT,
             TestAccount,
+            eth,
             run_test,
             to_wei,
             wait_for_condition,
@@ -266,7 +267,7 @@ async fn setup(
     token_a
         .approve(
             onchain.contracts().uniswap_v2_router.address().into_alloy(),
-            to_wei(1000).into_alloy(),
+            eth(1000),
         )
         .from(solver.address().into_alloy())
         .send_and_watch()
@@ -276,7 +277,7 @@ async fn setup(
     token_b
         .approve(
             onchain.contracts().uniswap_v2_router.address().into_alloy(),
-            to_wei(1000).into_alloy(),
+            eth(1000),
         )
         .from(solver.address().into_alloy())
         .send_and_watch()
@@ -299,10 +300,7 @@ async fn setup(
     // Approve GPv2 for trading
 
     token_a
-        .approve(
-            onchain.contracts().allowance.into_alloy(),
-            to_wei(1000).into_alloy(),
-        )
+        .approve(onchain.contracts().allowance.into_alloy(), eth(1000))
         .from(trader_a.address().into_alloy())
         .send_and_watch()
         .await
@@ -375,8 +373,7 @@ async fn execute_order(
             .call()
             .await
             .unwrap();
-        let balance_changes =
-            balance_after.checked_sub(balance_before).unwrap() >= to_wei(5).into_alloy();
+        let balance_changes = balance_after.checked_sub(balance_before).unwrap() >= eth(5);
         let auction_ids_after =
             fetch_last_settled_auction_ids(services.db()).await.len() > auction_ids_before;
         balance_changes && auction_ids_after

--- a/crates/e2e/tests/e2e/univ2.rs
+++ b/crates/e2e/tests/e2e/univ2.rs
@@ -1,7 +1,11 @@
 use {
     ::alloy::primitives::U256,
     database::order_events::{OrderEvent, OrderEventLabel},
-    e2e::{setup::*, tx, tx_value},
+    e2e::{
+        setup::{eth, *},
+        tx,
+        tx_value,
+    },
     ethrpc::alloy::conversions::{IntoAlloy, IntoLegacy},
     model::{
         order::{OrderCreation, OrderKind},
@@ -104,7 +108,7 @@ async fn test(web3: Web3) {
         .call()
         .await
         .unwrap();
-    assert_eq!(balance, to_wei(1).into_alloy());
+    assert_eq!(balance, eth(1));
 
     let all_events_registered = || async {
         let events = crate::database::events_of_order(services.db(), &uid).await;

--- a/crates/e2e/tests/e2e/vault_balances.rs
+++ b/crates/e2e/tests/e2e/vault_balances.rs
@@ -1,5 +1,8 @@
 use {
-    e2e::{setup::*, tx},
+    e2e::{
+        setup::{eth, *},
+        tx,
+    },
     ethrpc::alloy::{
         CallBuilderExt,
         conversions::{IntoAlloy, IntoLegacy},
@@ -35,7 +38,7 @@ async fn vault_balances(web3: Web3) {
     token
         .approve(
             onchain.contracts().balancer_vault.address().into_alloy(),
-            to_wei(10).into_alloy(),
+            eth(10),
         )
         .from(trader.address().into_alloy())
         .send_and_watch()


### PR DESCRIPTION
# Description
Replaces the old `to_wei` function with a new `eth` function that returns the Eth value in wei.

If you have `comby` here's a command to help migrate in the future:
```
comby 'to_wei(:[1]).into_alloy()' 'eth(:[1])' -matcher .rs -match-newline-at-toplevel -d crates -i
```

# Changes
- [ ] to_wei -> eth!

## How to test
Run tests suites

<!--
## Related Issues

Fixes #
-->