### PR TITLE
Speed up saving solver_competitions

### DIFF
--- a/crates/autopilot/src/infra/persistence/mod.rs
+++ b/crates/autopilot/src/infra/persistence/mod.rs
@@ -119,7 +119,7 @@ impl Persistence {
     /// Saves the competition data to the DB
     pub async fn save_competition(
         &self,
-        competition: &boundary::Competition,
+        competition: boundary::Competition,
     ) -> Result<(), DatabaseError> {
         self.postgres
             .save_competition(competition)

--- a/crates/autopilot/src/run_loop.rs
+++ b/crates/autopilot/src/run_loop.rs
@@ -508,7 +508,7 @@ impl RunLoop {
         tracing::trace!(?competition, "saving competition");
         futures::try_join!(
             self.persistence
-                .save_competition(&competition)
+                .save_competition(competition)
                 .map_err(|e| e.0.context("failed to save competition")),
             self.persistence
                 .save_surplus_capturing_jit_order_owners(

--- a/crates/database/src/solver_competition.rs
+++ b/crates/database/src/solver_competition.rs
@@ -14,13 +14,17 @@ use {
 pub async fn save(
     ex: &mut PgConnection,
     id: AuctionId,
-    data: &JsonValue,
+    json_string: &str,
 ) -> Result<(), sqlx::Error> {
     const QUERY: &str = r#"
 INSERT INTO solver_competitions (id, json)
-VALUES ($1, $2)
+VALUES ($1, $2::jsonb)
     ;"#;
-    sqlx::query(QUERY).bind(id).bind(data).execute(ex).await?;
+    sqlx::query(QUERY)
+        .bind(id)
+        .bind(json_string)
+        .execute(ex)
+        .await?;
     Ok(())
 }
 
@@ -117,7 +121,8 @@ mod tests {
         crate::clear_DANGER_(&mut db).await.unwrap();
 
         let value = JsonValue::Bool(true);
-        save(&mut db, 0, &value).await.unwrap();
+        let value_str = serde_json::to_string(&value).unwrap();
+        save(&mut db, 0, &value_str).await.unwrap();
 
         // load by id works
         let value_ = load_by_id(&mut db, 0).await.unwrap().unwrap();


### PR DESCRIPTION
# Description
Currently saving solver competitions is quite slow (100ms-500ms with outliers going over 3s!). AFAICS the way we handle uploading the JSON is very suboptimal:
1. we do `serde_json::to_value()` while `sqlx` later does `serde_json::to_string()` - we might as well directly do the conversion to string ourselves
2. we block the runtime while we serialize the solver competition JSON. Instead we can offload the serialization to a blocking task and let it already do work while we continue with the other DB queries.

<img width="1190" height="297" alt="Screenshot 2025-09-12 at 22 03 01" src="https://github.com/user-attachments/assets/963f710e-ac74-4f92-bc68-da4bcad2fd51" />


# Changes
Upload the JSON by inserting a JSON string directly.
Offload the serialization to a blocking task and do the solver competition at the very end so we can already finish all the other DB queries in the mean time.
This required me to take the `SolverCompetition` as an owned value which also enabled me to turn some `.iter()` into `.into_iter()` which gives the optimized more opportunities to avoid cloning memory.

## How to test
updated the `roundtrip` test to work with the string approach