### PR TITLE
Remove alloy version of tx! macro

### DIFF
--- a/crates/contracts/Cargo.toml
+++ b/crates/contracts/Cargo.toml
@@ -19,7 +19,6 @@ bin = [
     "tracing",
     "tracing-subscriber",
 ]
-test-util = []
 
 [dependencies]
 alloy = { workspace = true, features = ["sol-types", "json", "contract", "json-abi"] }

--- a/crates/contracts/src/alloy.rs
+++ b/crates/contracts/src/alloy.rs
@@ -1,6 +1,3 @@
-#[cfg(feature = "test-util")]
-pub use crate::{tx, tx_value};
-
 pub mod networks {
     pub const MAINNET: u64 = 1;
     pub const GNOSIS: u64 = 100;
@@ -236,41 +233,6 @@ macro_rules! bindings {
             }
         }
     };
-}
-
-#[cfg(feature = "test-util")]
-#[macro_export]
-macro_rules! tx_value {
-    ($call:expr, $value:expr) => {{
-        const NAME: &str = stringify!($call);
-        $call
-            .value($value)
-            .send()
-            .await
-            .expect(&format!("failed to send: {}", NAME))
-            .watch()
-            .await
-            .expect(&format!("failed to get confirmations for: {}", NAME))
-    }};
-    ($call:expr, $value:expr, $acc:expr) => {{
-        const NAME: &str = stringify!($call);
-        $call
-            .from($acc)
-            .value($value)
-            .send()
-            .await
-            .expect(&format!("failed to send: {}", NAME))
-            .watch()
-            .await
-            .expect(&format!("failed to get confirmations for: {}", NAME))
-    }};
-}
-
-#[cfg(feature = "test-util")]
-#[macro_export]
-macro_rules! tx {
-    ($call:expr) => {{ $crate::tx_value!($call, ::alloy::primitives::U256::ZERO) }};
-    ($call:expr, $acc:expr) => {{ $crate::tx_value!($call, ::alloy::primitives::U256::ZERO, $acc) }};
 }
 
 #[cfg(test)]

--- a/crates/driver/Cargo.toml
+++ b/crates/driver/Cargo.toml
@@ -85,7 +85,7 @@ mockall = { workspace = true }
 tokio = { workspace = true, features = ["test-util", "process"] }
 tempfile = { workspace = true }
 ethrpc = {workspace = true, features = ["test-util"]}
-contracts = { workspace = true , features  = ["test-util"]}
+contracts = { workspace = true }
 
 [build-dependencies]
 anyhow = { workspace = true }

--- a/crates/e2e/Cargo.toml
+++ b/crates/e2e/Cargo.toml
@@ -17,7 +17,7 @@ axum = { workspace = true }
 bigdecimal = { workspace = true }
 chrono = { workspace = true }
 clap = { workspace = true }
-contracts = { workspace = true, features = ["test-util"] }
+contracts = { workspace = true }
 database = { workspace = true }
 driver = { workspace = true }
 ethcontract = { workspace = true }

--- a/crates/e2e/src/setup/onchain_components/safe.rs
+++ b/crates/e2e/src/setup/onchain_components/safe.rs
@@ -68,21 +68,22 @@ impl Infrastructure {
         .unwrap();
         let safe = GnosisSafe::Instance::new(safe_proxy, self.provider.clone());
 
-        contracts::alloy::tx!(
-            safe.setup(
-                owners
-                    .into_iter()
-                    .map(|owner| owner.address().into_alloy())
-                    .collect(),
-                U256::from(threshold),
-                Address::default(), // delegate call
-                Bytes::default(),   // delegate call bytes
-                *self.fallback.address(),
-                Address::default(), // relayer payment token
-                U256::ZERO,         // relayer payment amount
-                Address::default(), // relayer address
-            )
-        );
+        safe.setup(
+            owners
+                .into_iter()
+                .map(|owner| owner.address().into_alloy())
+                .collect(),
+            U256::from(threshold),
+            Address::default(), // delegate call
+            Bytes::default(),   // delegate call bytes
+            *self.fallback.address(),
+            Address::default(), // relayer payment token
+            U256::ZERO,         // relayer payment amount
+            Address::default(), // relayer address
+        )
+        .send_and_watch()
+        .await
+        .unwrap();
 
         safe
     }

--- a/crates/e2e/tests/e2e/hooks.rs
+++ b/crates/e2e/tests/e2e/hooks.rs
@@ -552,7 +552,7 @@ async fn quote_verification(web3: Web3) {
             .clone(),
     );
     let safe_address = safe_creation_builder.clone().call().await.unwrap();
-    contracts::alloy::tx!(safe_creation_builder);
+    safe_creation_builder.send_and_watch().await.unwrap();
 
     let safe = Safe::deployed(
         chain_id,


### PR DESCRIPTION
# Description
As the name states. The send_and_watch function shortens it enough that the macro doesn't provide as much value in face of the cost of maintenance.

# Changes

- [ ] Removes the tx! macro (and it's tx_value! friend)
- [ ] Updates the affected callsites

## How to test
Run the existing tests

<!--
## Related Issues

Fixes #
-->