### PR TITLE
Support multiple alloy sc events

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -548,9 +548,12 @@ dependencies = [
  "alloy-primitives",
  "alloy-signer",
  "async-trait",
+ "coins-bip32",
+ "coins-bip39",
  "k256",
  "rand 0.8.5",
  "thiserror 2.0.12",
+ "zeroize",
 ]
 
 [[package]]
@@ -1571,6 +1574,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 
 [[package]]
+name = "bech32"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d86b93f97252c47b41663388e6d155714a9d0c398b99f1005cbc5f978b29f445"
+
+[[package]]
 name = "bigdecimal"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1683,6 +1692,16 @@ dependencies = [
  "quote",
  "syn 2.0.104",
  "syn_derive",
+]
+
+[[package]]
+name = "bs58"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
+dependencies = [
+ "sha2",
+ "tinyvec",
 ]
 
 [[package]]
@@ -1865,6 +1884,57 @@ name = "clap_lex"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b82cf0babdbd58558212896d1a4272303a57bdb245c2bf1147185fb45640e70"
+
+[[package]]
+name = "coins-bip32"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2073678591747aed4000dd468b97b14d7007f7936851d3f2f01846899f5ebf08"
+dependencies = [
+ "bs58",
+ "coins-core",
+ "digest 0.10.7",
+ "hmac",
+ "k256",
+ "serde",
+ "sha2",
+ "thiserror 1.0.61",
+]
+
+[[package]]
+name = "coins-bip39"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74b169b26623ff17e9db37a539fe4f15342080df39f129ef7631df7683d6d9d4"
+dependencies = [
+ "bitvec",
+ "coins-bip32",
+ "hmac",
+ "once_cell",
+ "pbkdf2",
+ "rand 0.8.5",
+ "sha2",
+ "thiserror 1.0.61",
+]
+
+[[package]]
+name = "coins-core"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62b962ad8545e43a28e14e87377812ba9ae748dd4fd963f4c10e9fcc6d13475b"
+dependencies = [
+ "base64 0.21.7",
+ "bech32",
+ "bs58",
+ "const-hex",
+ "digest 0.10.7",
+ "generic-array",
+ "ripemd",
+ "serde",
+ "sha2",
+ "sha3",
+ "thiserror 1.0.61",
+]
 
 [[package]]
 name = "colorchoice"
@@ -2547,6 +2617,7 @@ dependencies = [
  "sqlx",
  "tempfile",
  "tokio",
+ "toml",
  "tracing",
  "warp",
  "web3",
@@ -3786,6 +3857,7 @@ dependencies = [
  "once_cell",
  "serdect",
  "sha2",
+ "signature",
 ]
 
 [[package]]
@@ -4625,6 +4697,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
+name = "pbkdf2"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
+dependencies = [
+ "digest 0.10.7",
+ "hmac",
+]
+
+[[package]]
 name = "pem-rfc7468"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5327,6 +5409,15 @@ dependencies = [
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "ripemd"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd124222d17ad93a644ed9d011a40f4fb64aa54275c08cc216524a9ea82fb09f"
+dependencies = [
+ "digest 0.10.7",
 ]
 
 [[package]]

--- a/crates/autopilot/src/infra/persistence/mod.rs
+++ b/crates/autopilot/src/infra/persistence/mod.rs
@@ -119,7 +119,7 @@ impl Persistence {
     /// Saves the competition data to the DB
     pub async fn save_competition(
         &self,
-        competition: &boundary::Competition,
+        competition: boundary::Competition,
     ) -> Result<(), DatabaseError> {
         self.postgres
             .save_competition(competition)

--- a/crates/autopilot/src/run_loop.rs
+++ b/crates/autopilot/src/run_loop.rs
@@ -508,7 +508,7 @@ impl RunLoop {
         tracing::trace!(?competition, "saving competition");
         futures::try_join!(
             self.persistence
-                .save_competition(&competition)
+                .save_competition(competition)
                 .map_err(|e| e.0.context("failed to save competition")),
             self.persistence
                 .save_surplus_capturing_jit_order_owners(

--- a/crates/contracts/build.rs
+++ b/crates/contracts/build.rs
@@ -303,7 +303,6 @@ fn main() {
         builder.add_network_str(GNOSIS, "0x6093AeBAC87d62b1A5a4cEec91204e35020E38bE")
     });
     generate_contract("ERC20");
-    generate_contract("ERC20Mintable");
     generate_contract("ERC3156FlashLoanSolverWrapper");
     generate_contract_with_config("FlashLoanRouter", |builder| {
         let mut builder = builder;

--- a/crates/contracts/src/alloy.rs
+++ b/crates/contracts/src/alloy.rs
@@ -42,6 +42,8 @@ crate::bindings!(
     }
 );
 
+crate::bindings!(ERC20Mintable);
+
 crate::bindings!(GnosisSafe);
 crate::bindings!(GnosisSafeCompatibilityFallbackHandler);
 crate::bindings!(GnosisSafeProxy);

--- a/crates/contracts/src/lib.rs
+++ b/crates/contracts/src/lib.rs
@@ -63,7 +63,6 @@ include_contracts! {
     CowProtocolToken;
     ERC1271SignatureValidator;
     ERC20;
-    ERC20Mintable;
     ERC3156FlashLoanSolverWrapper;
     FlashLoanRouter;
     GPv2AllowListAuthentication;

--- a/crates/database/src/solver_competition.rs
+++ b/crates/database/src/solver_competition.rs
@@ -14,13 +14,17 @@ use {
 pub async fn save(
     ex: &mut PgConnection,
     id: AuctionId,
-    data: &JsonValue,
+    json_string: &str,
 ) -> Result<(), sqlx::Error> {
     const QUERY: &str = r#"
 INSERT INTO solver_competitions (id, json)
-VALUES ($1, $2)
+VALUES ($1, $2::jsonb)
     ;"#;
-    sqlx::query(QUERY).bind(id).bind(data).execute(ex).await?;
+    sqlx::query(QUERY)
+        .bind(id)
+        .bind(json_string)
+        .execute(ex)
+        .await?;
     Ok(())
 }
 
@@ -117,7 +121,8 @@ mod tests {
         crate::clear_DANGER_(&mut db).await.unwrap();
 
         let value = JsonValue::Bool(true);
-        save(&mut db, 0, &value).await.unwrap();
+        let value_str = serde_json::to_string(&value).unwrap();
+        save(&mut db, 0, &value_str).await.unwrap();
 
         // load by id works
         let value_ = load_by_id(&mut db, 0).await.unwrap().unwrap();

--- a/crates/driver/Cargo.toml
+++ b/crates/driver/Cargo.toml
@@ -84,6 +84,8 @@ maplit = { workspace = true }
 mockall = { workspace = true }
 tokio = { workspace = true, features = ["test-util", "process"] }
 tempfile = { workspace = true }
+ethrpc = {workspace = true, features = ["test-util"]}
+contracts = { workspace = true , features  = ["test-util"]}
 
 [build-dependencies]
 anyhow = { workspace = true }

--- a/crates/driver/src/domain/competition/order/mod.rs
+++ b/crates/driver/src/domain/competition/order/mod.rs
@@ -350,7 +350,7 @@ impl From<BuyTokenDestination> for BuyTokenBalance {
 
 /// The address which placed the order.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Into)]
-pub struct Trader(eth::Address);
+pub struct Trader(pub eth::Address);
 
 /// A just-in-time order. JIT orders are added at solving time by the solver to
 /// generate a more optimal solution for the auction. Very similar to a regular

--- a/crates/driver/src/run.rs
+++ b/crates/driver/src/run.rs
@@ -103,7 +103,6 @@ async fn run_with(args: cli::Args, addr_sender: Option<oneshot::Sender<SocketAdd
         },
         config.order_priority_strategies,
         app_data_retriever,
-        config.disable_access_list_simulation,
     );
 
     drop(startup_span_guard);

--- a/crates/driver/src/tests/setup/blockchain.rs
+++ b/crates/driver/src/tests/setup/blockchain.rs
@@ -7,8 +7,16 @@ use {
         },
         tests::{self, boundary, cases::EtherExt},
     },
+    alloy::{primitives::U256, signers::local::PrivateKeySigner},
+    contracts::alloy::ERC20Mintable,
     ethcontract::PrivateKey,
-    ethrpc::Web3,
+    ethrpc::{
+        Web3,
+        alloy::{
+            CallBuilderExt,
+            conversions::{IntoAlloy, IntoLegacy},
+        },
+    },
     futures::Future,
     secp256k1::SecretKey,
     serde_json::json,
@@ -33,7 +41,7 @@ pub struct Blockchain {
     pub trader_secret_key: SecretKey,
     pub web3: Web3,
     pub web3_url: String,
-    pub tokens: HashMap<&'static str, contracts::ERC20Mintable>,
+    pub tokens: HashMap<&'static str, ERC20Mintable::Instance>,
     pub weth: contracts::WETH9,
     pub settlement: contracts::GPv2Settlement,
     pub balances: contracts::support::Balances,
@@ -211,14 +219,16 @@ impl Blockchain {
         // TODO All these various deployments that are happening from the trader account
         // should be happening from the primary_account of the node, will do this
         // later
-
         let node = Node::new(&config.rpc_args).await;
-        let web3 = Web3::new_from_url(&node.url());
+        let mut web3 = Web3::new_from_url(&node.url());
 
+        let private_key = config.main_trader_secret_key.as_ref();
         let main_trader_account = ethcontract::Account::Offline(
-            ethcontract::PrivateKey::from_slice(config.main_trader_secret_key.as_ref()).unwrap(),
+            ethcontract::PrivateKey::from_slice(private_key).unwrap(),
             None,
         );
+        let signer = PrivateKeySigner::from_slice(private_key).unwrap();
+        web3.wallet.register_signer(signer);
 
         // Use the primary account to fund the trader, cow amm and the solver with ETH.
         let balance = web3
@@ -397,8 +407,12 @@ impl Blockchain {
             .unwrap();
 
             if !config.balance.is_zero() {
+                let private_key = config.private_key.as_ref();
+                let signer = PrivateKeySigner::from_slice(private_key).unwrap();
+                web3.wallet.register_signer(signer);
+
                 let trader_account = ethcontract::Account::Offline(
-                    ethcontract::PrivateKey::from_slice(config.private_key.as_ref()).unwrap(),
+                    ethcontract::PrivateKey::from_slice(private_key).unwrap(),
                     None,
                 );
                 trader_accounts.push(trader_account);
@@ -412,25 +426,15 @@ impl Blockchain {
         let mut tokens = HashMap::new();
         for pool in config.pools.iter() {
             if pool.reserve_a.token != "WETH" && !tokens.contains_key(pool.reserve_a.token) {
-                let token = wait_for(
-                    &web3,
-                    contracts::ERC20Mintable::builder(&web3)
-                        .from(main_trader_account.clone())
-                        .deploy(),
-                )
-                .await
-                .unwrap();
+                let token = ERC20Mintable::Instance::deploy(web3.alloy.clone())
+                    .await
+                    .unwrap();
                 tokens.insert(pool.reserve_a.token, token);
             }
             if pool.reserve_b.token != "WETH" && !tokens.contains_key(pool.reserve_b.token) {
-                let token = wait_for(
-                    &web3,
-                    contracts::ERC20Mintable::builder(&web3)
-                        .from(main_trader_account.clone())
-                        .deploy(),
-                )
-                .await
-                .unwrap();
+                let token = ERC20Mintable::Instance::deploy(web3.alloy.clone())
+                    .await
+                    .unwrap();
                 tokens.insert(pool.reserve_b.token, token);
             }
         }
@@ -452,12 +456,20 @@ impl Blockchain {
             let token_a = if pool.reserve_a.token == "WETH" {
                 weth.address()
             } else {
-                tokens.get(pool.reserve_a.token).unwrap().address()
+                tokens
+                    .get(pool.reserve_a.token)
+                    .unwrap()
+                    .address()
+                    .into_legacy()
             };
             let token_b = if pool.reserve_b.token == "WETH" {
                 weth.address()
             } else {
-                tokens.get(pool.reserve_b.token).unwrap().address()
+                tokens
+                    .get(pool.reserve_b.token)
+                    .unwrap()
+                    .address()
+                    .into_legacy()
             };
             // Create the pair.
             wait_for(
@@ -514,54 +526,53 @@ impl Blockchain {
             } else {
                 for trader_account in trader_accounts.iter() {
                     let vault_relayer = settlement.vault_relayer().call().await.unwrap();
-                    wait_for(
-                        &web3,
-                        tokens
-                            .get(pool.reserve_a.token)
-                            .unwrap()
-                            .approve(vault_relayer, ethcontract::U256::max_value())
-                            .from(trader_account.clone())
-                            .send(),
-                    )
-                    .await
-                    .unwrap();
+
+                    tokens
+                        .get(pool.reserve_a.token)
+                        .unwrap()
+                        .approve(vault_relayer.into_alloy(), U256::MAX)
+                        .from(trader_account.address().into_alloy())
+                        .send_and_watch()
+                        .await
+                        .unwrap();
                 }
 
-                wait_for(
-                    &web3,
-                    tokens
-                        .get(pool.reserve_a.token)
-                        .unwrap()
-                        .mint(pair.address(), pool.reserve_a.amount)
-                        .from(main_trader_account.clone())
-                        .send(),
-                )
-                .await
-                .unwrap();
-                wait_for(
-                    &web3,
-                    tokens
-                        .get(pool.reserve_a.token)
-                        .unwrap()
-                        .mint(settlement.address(), pool.reserve_a.amount)
-                        .from(main_trader_account.clone())
-                        .send(),
-                )
-                .await
-                .unwrap();
-
-                for trader_account in trader_accounts.iter() {
-                    wait_for(
-                        &web3,
-                        tokens
-                            .get(pool.reserve_a.token)
-                            .unwrap()
-                            .mint(trader_account.address(), pool.reserve_a.amount)
-                            .from(main_trader_account.clone())
-                            .send(),
+                tokens
+                    .get(pool.reserve_a.token)
+                    .unwrap()
+                    .mint(
+                        pair.address().into_alloy(),
+                        pool.reserve_a.amount.into_alloy(),
                     )
+                    .from(main_trader_account.address().into_alloy())
+                    .send_and_watch()
                     .await
                     .unwrap();
+
+                tokens
+                    .get(pool.reserve_a.token)
+                    .unwrap()
+                    .mint(
+                        settlement.address().into_alloy(),
+                        pool.reserve_a.amount.into_alloy(),
+                    )
+                    .from(main_trader_account.address().into_alloy())
+                    .send_and_watch()
+                    .await
+                    .unwrap();
+
+                for trader_account in trader_accounts.iter() {
+                    tokens
+                        .get(pool.reserve_a.token)
+                        .unwrap()
+                        .mint(
+                            trader_account.address().into_alloy(),
+                            pool.reserve_a.amount.into_alloy(),
+                        )
+                        .from(main_trader_account.address().into_alloy())
+                        .send_and_watch()
+                        .await
+                        .unwrap();
                 }
             }
             if pool.reserve_b.token == "WETH" {
@@ -594,53 +605,52 @@ impl Blockchain {
             } else {
                 for trader_account in trader_accounts.iter() {
                     let vault_relayer = settlement.vault_relayer().call().await.unwrap();
-                    wait_for(
-                        &web3,
-                        tokens
-                            .get(pool.reserve_b.token)
-                            .unwrap()
-                            .approve(vault_relayer, ethcontract::U256::max_value())
-                            .from(trader_account.clone())
-                            .send(),
-                    )
-                    .await
-                    .unwrap();
+
+                    tokens
+                        .get(pool.reserve_b.token)
+                        .unwrap()
+                        .approve(vault_relayer.into_alloy(), U256::MAX)
+                        .from(trader_account.address().into_alloy())
+                        .send_and_watch()
+                        .await
+                        .unwrap();
                 }
 
-                wait_for(
-                    &web3,
-                    tokens
-                        .get(pool.reserve_b.token)
-                        .unwrap()
-                        .mint(pair.address(), pool.reserve_b.amount)
-                        .from(main_trader_account.clone())
-                        .send(),
-                )
-                .await
-                .unwrap();
-                wait_for(
-                    &web3,
-                    tokens
-                        .get(pool.reserve_b.token)
-                        .unwrap()
-                        .mint(settlement.address(), pool.reserve_b.amount)
-                        .from(main_trader_account.clone())
-                        .send(),
-                )
-                .await
-                .unwrap();
-                for trader_account in trader_accounts.iter() {
-                    wait_for(
-                        &web3,
-                        tokens
-                            .get(pool.reserve_b.token)
-                            .unwrap()
-                            .mint(trader_account.address(), pool.reserve_b.amount)
-                            .from(main_trader_account.clone())
-                            .send(),
+                tokens
+                    .get(pool.reserve_b.token)
+                    .unwrap()
+                    .mint(
+                        pair.address().into_alloy(),
+                        pool.reserve_b.amount.into_alloy(),
                     )
+                    .from(main_trader_account.address().into_alloy())
+                    .send_and_watch()
                     .await
                     .unwrap();
+
+                tokens
+                    .get(pool.reserve_b.token)
+                    .unwrap()
+                    .mint(
+                        settlement.address().into_alloy(),
+                        pool.reserve_b.amount.into_alloy(),
+                    )
+                    .from(main_trader_account.address().into_alloy())
+                    .send_and_watch()
+                    .await
+                    .unwrap();
+                for trader_account in trader_accounts.iter() {
+                    tokens
+                        .get(pool.reserve_b.token)
+                        .unwrap()
+                        .mint(
+                            trader_account.address().into_alloy(),
+                            pool.reserve_b.amount.into_alloy(),
+                        )
+                        .from(main_trader_account.address().into_alloy())
+                        .send_and_watch()
+                        .await
+                        .unwrap();
                 }
             }
             wait_for(
@@ -791,35 +801,30 @@ impl Blockchain {
             if order.sell_token == "WETH" {
                 todo!("deposit trader funds into the weth contract, none of the tests do this yet")
             } else if order.funded {
-                wait_for(
-                    &self.web3,
-                    self.tokens
-                        .get(order.sell_token)
-                        .unwrap()
-                        .mint(
-                            trader_account.address(),
-                            "1e-7".ether().into_wei() * execution.sell,
-                        )
-                        .from(trader_account.clone())
-                        .send(),
-                )
-                .await
-                .unwrap();
+                self.tokens
+                    .get(order.sell_token)
+                    .unwrap()
+                    .mint(
+                        trader_account.address().into_alloy(),
+                        ("1e-7".ether().into_wei() * execution.sell).into_alloy(),
+                    )
+                    .from(trader_account.address().into_alloy())
+                    .send_and_watch()
+                    .await
+                    .unwrap();
             }
 
             // Approve the tokens needed for the solution.
             let vault_relayer = self.settlement.vault_relayer().call().await.unwrap();
-            wait_for(
-                &self.web3,
-                self.tokens
-                    .get(order.sell_token)
-                    .unwrap()
-                    .approve(vault_relayer, ethcontract::U256::max_value())
-                    .from(trader_account.clone())
-                    .send(),
-            )
-            .await
-            .unwrap();
+
+            self.tokens
+                .get(order.sell_token)
+                .unwrap()
+                .approve(vault_relayer.into_alloy(), U256::MAX)
+                .from(trader_account.address().into_alloy())
+                .send_and_watch()
+                .await
+                .unwrap();
 
             // Create the interactions fulfilling the order.
             let transfer_interaction = sell_token
@@ -899,7 +904,7 @@ impl Blockchain {
         match token {
             "WETH" => self.weth.address(),
             "ETH" => eth::ETH_TOKEN.into(),
-            _ => self.tokens.get(token).unwrap().address(),
+            _ => self.tokens.get(token).unwrap().address().into_legacy(),
         }
     }
 
@@ -908,7 +913,7 @@ impl Blockchain {
     pub fn get_token_wrapped(&self, token: &str) -> eth::H160 {
         match token {
             "WETH" | "ETH" => self.weth.address(),
-            _ => self.tokens.get(token).unwrap().address(),
+            _ => self.tokens.get(token).unwrap().address().into_legacy(),
         }
     }
 

--- a/crates/driver/src/tests/setup/mod.rs
+++ b/crates/driver/src/tests/setup/mod.rs
@@ -4,7 +4,7 @@ use {
     self::{driver::Driver, solver::Solver as SolverInstance},
     crate::{
         domain::{
-            competition::{order, order::app_data::AppData},
+            competition::order::{self, app_data::AppData},
             eth,
             time,
         },
@@ -40,6 +40,7 @@ use {
     },
     bigdecimal::{BigDecimal, FromPrimitive},
     ethcontract::dyns::DynTransport,
+    ethrpc::alloy::conversions::{IntoAlloy, IntoLegacy},
     futures::future::join_all,
     hyper::StatusCode,
     model::order::{BuyTokenDestination, SellTokenSource},
@@ -1187,10 +1188,11 @@ impl Test {
         let mut balances = HashMap::new();
         for (token, contract) in self.blockchain.tokens.iter() {
             let balance = contract
-                .balance_of(self.trader_address)
+                .balanceOf(self.trader_address.into_alloy())
                 .call()
                 .await
-                .unwrap();
+                .unwrap()
+                .into_legacy();
             balances.insert(*token, balance);
         }
         balances.insert(

--- a/crates/e2e/Cargo.toml
+++ b/crates/e2e/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2024"
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-alloy = { workspace = true, default-features = false, features = ["json-rpc", "providers", "rpc-client", "rpc-types", "transports", "reqwest", "signers", "signer-local"] }
+alloy = { workspace = true, default-features = false, features = ["json-rpc", "providers", "rpc-client", "rpc-types", "transports", "reqwest", "signers", "signer-local", "signer-mnemonic"] }
 app-data = { workspace = true }
 anyhow = { workspace = true }
 autopilot = { workspace = true }
@@ -40,6 +40,7 @@ solvers-dto = { workspace = true }
 sqlx = { workspace = true }
 tempfile = { workspace = true }
 tokio = { workspace = true, features = ["macros", "process"] }
+toml = { workspace = true }
 tracing = { workspace = true }
 warp = { workspace = true }
 web3 = { workspace = true, features = ["http"] }

--- a/crates/e2e/src/setup/colocation.rs
+++ b/crates/e2e/src/setup/colocation.rs
@@ -6,6 +6,8 @@ use {
     tokio::task::JoinHandle,
 };
 
+pub mod utils;
+
 pub struct SolverEngine {
     pub name: String,
     pub endpoint: Url,
@@ -108,6 +110,22 @@ pub fn start_driver(
     liquidity: LiquidityProvider,
     quote_using_limit_orders: bool,
 ) -> JoinHandle<()> {
+    start_driver_with_config_override(
+        contracts,
+        solvers,
+        liquidity,
+        quote_using_limit_orders,
+        None,
+    )
+}
+
+pub fn start_driver_with_config_override(
+    contracts: &Contracts,
+    solvers: Vec<SolverEngine>,
+    liquidity: LiquidityProvider,
+    quote_using_limit_orders: bool,
+    config_override: Option<&str>,
+) -> JoinHandle<()> {
     let base_tokens: HashSet<_> = solvers
         .iter()
         .flat_map(|solver| solver.base_tokens.iter())
@@ -208,7 +226,7 @@ factory = "{:?}"
         })
         .unwrap_or_default();
 
-    let config_file = config_tmp_file(format!(
+    let base_config = format!(
         r#"
 app-data-fetching-enabled = true
 orderbook-url = "http://localhost:8080"
@@ -246,7 +264,15 @@ mempool = "public"
         contracts.weth.address(),
         contracts.balances.address(),
         contracts.signatures.address(),
-    ));
+    );
+
+    let final_config = if let Some(override_str) = config_override {
+        utils::toml::merge_raw(&base_config, override_str).expect("Failed to merge driver config")
+    } else {
+        base_config
+    };
+
+    let config_file = config_tmp_file(final_config);
     let args = vec![
         "driver".to_string(),
         format!("--config={}", config_file.display()),

--- a/crates/e2e/src/setup/colocation/utils.rs
+++ b/crates/e2e/src/setup/colocation/utils.rs
@@ -1,0 +1,1 @@
+pub mod toml;

--- a/crates/e2e/src/setup/colocation/utils/toml.rs
+++ b/crates/e2e/src/setup/colocation/utils/toml.rs
@@ -1,0 +1,156 @@
+use {
+    anyhow::{Context, Result},
+    toml::{Table, Value},
+};
+
+/// Merge two TOML strings, with the override taking precedence
+///
+/// # Arguments
+/// * `base` - The base TOML configuration as a string
+/// * `overlay` - The override TOML configuration as a string
+///
+/// # Returns
+/// A merged TOML configuration string where override values take precedence
+/// over base values. Tables are merged recursively, while arrays and primitive
+/// values are replaced entirely.
+pub fn merge_raw(base: &str, overlay: &str) -> Result<String> {
+    // Parse base config
+    let mut base_table: Table = toml::from_str(base).context("Failed to parse base TOML config")?;
+
+    // Parse overlay config
+    let overlay_table: Table =
+        toml::from_str(overlay).context("Failed to parse overlay TOML config")?;
+
+    // Apply overlay to base
+    merge_tables(&mut base_table, &overlay_table);
+
+    // Serialize back to string
+    toml::to_string_pretty(&base_table).context("Failed to serialize TOML config")
+}
+
+/// Recursively merge two TOML tables
+fn merge_tables(base: &mut Table, overlay: &Table) {
+    for (key, value) in overlay {
+        match (base.get_mut(key), value) {
+            (Some(Value::Table(base_table)), Value::Table(overlay_table)) => {
+                // Both are tables, merge recursively
+                merge_tables(base_table, overlay_table);
+            }
+            _ => {
+                // Replace value entirely (including arrays)
+                base.insert(key.clone(), value.clone());
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_field_override() {
+        let base_config = r#"
+orderbook-url = "http://localhost:8080"
+"#;
+
+        let raw_override = r#"
+orderbook-url = "http://remotehost:8080"
+"#;
+
+        let result = merge_raw(base_config, raw_override).unwrap();
+
+        let parsed: Table = toml::from_str(&result).unwrap();
+
+        // Check that field was overridden
+        let orderbook_url = parsed.get("orderbook-url").unwrap().as_str().unwrap();
+        assert_eq!(orderbook_url, "http://remotehost:8080");
+    }
+
+    #[test]
+    fn test_section_override() {
+        let base_config = r#"
+[database]
+host = "localhost"
+port = 5432
+
+[logging]
+level = "info"
+"#;
+
+        let raw_override = r#"
+[database]
+host = "remote-host"
+port = 3306
+ssl = true
+
+[metrics]
+enabled = true
+port = 9090
+"#;
+
+        let result = merge_raw(base_config, raw_override).unwrap();
+
+        let parsed: Table = toml::from_str(&result).unwrap();
+
+        // Check that database section was merged
+        let database = parsed.get("database").unwrap().as_table().unwrap();
+        assert_eq!(
+            database.get("host").unwrap().as_str().unwrap(),
+            "remote-host"
+        );
+        assert_eq!(database.get("port").unwrap().as_integer().unwrap(), 3306);
+        assert!(database.get("ssl").unwrap().as_bool().unwrap());
+
+        // Check that new metrics section was added
+        let metrics = parsed.get("metrics").unwrap().as_table().unwrap();
+        assert!(metrics.get("enabled").unwrap().as_bool().unwrap());
+        assert_eq!(metrics.get("port").unwrap().as_integer().unwrap(), 9090);
+
+        // Check that logging section remains unchanged
+        let logging = parsed.get("logging").unwrap().as_table().unwrap();
+        assert_eq!(logging.get("level").unwrap().as_str().unwrap(), "info");
+    }
+
+    #[test]
+    fn test_array_override() {
+        let base_config = r#"
+[[servers]]
+name = "server1"
+port = 8080
+
+[config]
+active = true
+"#;
+
+        let raw_override = r#"
+[[servers]]
+name = "new-server1"
+port = 9000
+
+[[servers]]
+name = "new-server2"
+port = 9001
+"#;
+
+        let result = merge_raw(base_config, raw_override).unwrap();
+
+        let parsed: Table = toml::from_str(&result).unwrap();
+
+        // Arrays are replaced entirely, not merged
+        let servers = parsed.get("servers").unwrap().as_array().unwrap();
+        assert_eq!(servers.len(), 2);
+        assert_eq!(
+            servers[0].get("name").unwrap().as_str().unwrap(),
+            "new-server1"
+        );
+        assert_eq!(
+            servers[1].get("name").unwrap().as_str().unwrap(),
+            "new-server2"
+        );
+
+        // Other sections remain
+        let config = parsed.get("config").unwrap().as_table().unwrap();
+        assert!(config.get("active").unwrap().as_bool().unwrap());
+    }
+}

--- a/crates/e2e/src/setup/mod.rs
+++ b/crates/e2e/src/setup/mod.rs
@@ -8,6 +8,7 @@ mod solver;
 
 use {
     crate::nodes::{NODE_HOST, Node},
+    ::alloy::signers::local::{MnemonicBuilder, coins_bip39::English},
     anyhow::{Result, anyhow},
     ethcontract::futures::FutureExt,
     ethrpc::Web3,
@@ -212,7 +213,20 @@ async fn run<F, Fut, T>(
         let _ = node_panic_handle.lock().unwrap().take();
     }));
 
-    let web3 = Web3::new_from_url(NODE_HOST);
+    let mut web3 = Web3::new_from_url(NODE_HOST);
+    let phrase = "test test test test test test test test test test test junk";
+    let signers = (0..10).map(|i| {
+        MnemonicBuilder::<English>::default()
+            .phrase(phrase)
+            .index(i)
+            .unwrap()
+            .build()
+            .unwrap()
+    });
+
+    for signer in signers {
+        web3.wallet.register_signer(signer);
+    }
 
     services::clear_database().await;
     // Hack: the closure may actually be unwind unsafe; moreover, `catch_unwind`

--- a/crates/e2e/src/setup/onchain_components/mod.rs
+++ b/crates/e2e/src/setup/onchain_components/mod.rs
@@ -3,8 +3,10 @@ use {
         nodes::forked_node::ForkedNodeApi,
         setup::{DeployedContracts, deploy::Contracts},
     },
+    ::alloy::signers::local::PrivateKeySigner,
     app_data::Hook,
-    contracts::{CowProtocolToken, ERC20Mintable},
+    contracts::{CowProtocolToken, alloy::ERC20Mintable},
+    core::panic,
     ethcontract::{
         Account,
         Bytes,
@@ -12,6 +14,10 @@ use {
         PrivateKey,
         U256,
         transaction::{TransactionBuilder, TransactionResult},
+    },
+    ethrpc::alloy::{
+        CallBuilderExt,
+        conversions::{IntoAlloy, IntoLegacy},
     },
     hex_literal::hex,
     model::{
@@ -168,18 +174,23 @@ impl Iterator for AccountGenerator {
 
 #[derive(Debug)]
 pub struct MintableToken {
-    contract: ERC20Mintable,
+    contract: ERC20Mintable::Instance,
     minter: Account,
 }
 
 impl MintableToken {
     pub async fn mint(&self, to: H160, amount: U256) {
-        tx!(self.minter, self.contract.mint(to, amount));
+        self.contract
+            .mint(to.into_alloy(), amount.into_alloy())
+            .from(self.minter.address().into_alloy())
+            .send_and_watch()
+            .await
+            .unwrap();
     }
 }
 
 impl Deref for MintableToken {
-    type Target = ERC20Mintable;
+    type Target = ERC20Mintable::Instance;
 
     fn deref(&self) -> &Self::Target {
         &self.contract
@@ -286,6 +297,9 @@ impl OnchainComponents {
         assert_eq!(res.len(), N);
 
         for account in &res {
+            let signer = PrivateKeySigner::from_slice(account.private_key()).unwrap();
+            self.web3.wallet.register_signer(signer);
+
             self.send_wei(account.address(), with_wei).await;
         }
 
@@ -298,6 +312,10 @@ impl OnchainComponents {
         let solvers = self.make_accounts::<N>(with_wei).await;
 
         for solver in &solvers {
+            self.web3
+                .wallet
+                .register_signer(PrivateKeySigner::from_slice(solver.private_key()).unwrap());
+
             self.contracts
                 .gp_authenticator
                 .add_solver(solver.address())
@@ -381,12 +399,16 @@ impl OnchainComponents {
     /// Deploy `N` tokens without any onchain liquidity
     pub async fn deploy_tokens<const N: usize>(&self, minter: &Account) -> [MintableToken; N] {
         let mut res = Vec::with_capacity(N);
+
         for _ in 0..N {
-            let contract = ERC20Mintable::builder(&self.web3)
-                .from(minter.clone())
+            let contract_address = ERC20Mintable::Instance::deploy_builder(self.web3.alloy.clone())
+                // We can't escape the .from here because we need to ensure Minter permissions later on
+                .from(minter.address().into_alloy())
                 .deploy()
                 .await
-                .expect("MintableERC20 deployment failed");
+                .expect("ERC20Mintable deployment failed");
+            let contract = ERC20Mintable::Instance::new(contract_address, self.web3.alloy.clone());
+
             res.push(MintableToken {
                 contract,
                 minter: minter.clone(),
@@ -423,19 +445,32 @@ impl OnchainComponents {
         weth_amount: U256,
     ) {
         for MintableToken { contract, minter } in tokens {
-            tx!(minter, contract.mint(minter.address(), token_amount));
+            contract
+                .mint(minter.address().into_alloy(), token_amount.into_alloy())
+                .from(minter.address().into_alloy())
+                .send_and_watch()
+                .await
+                .unwrap();
             tx_value!(minter, weth_amount, self.contracts.weth.deposit());
 
             tx!(
                 minter,
-                self.contracts
-                    .uniswap_v2_factory
-                    .create_pair(contract.address(), self.contracts.weth.address())
+                self.contracts.uniswap_v2_factory.create_pair(
+                    contract.address().into_legacy(),
+                    self.contracts.weth.address()
+                )
             );
-            tx!(
-                minter,
-                contract.approve(self.contracts.uniswap_v2_router.address(), token_amount)
-            );
+
+            contract
+                .approve(
+                    self.contracts.uniswap_v2_router.address().into_alloy(),
+                    token_amount.into_alloy(),
+                )
+                .from(minter.address().into_alloy())
+                .send_and_watch()
+                .await
+                .unwrap();
+
             tx!(
                 minter,
                 self.contracts
@@ -445,7 +480,7 @@ impl OnchainComponents {
             tx!(
                 minter,
                 self.contracts.uniswap_v2_router.add_liquidity(
-                    contract.address(),
+                    contract.address().into_legacy(),
                     self.contracts.weth.address(),
                     token_amount,
                     weth_amount,
@@ -469,27 +504,38 @@ impl OnchainComponents {
 
         tx!(
             lp,
-            self.contracts
-                .uniswap_v2_factory
-                .create_pair(asset_a.0.address(), asset_b.0.address())
+            self.contracts.uniswap_v2_factory.create_pair(
+                asset_a.0.address().into_legacy(),
+                asset_b.0.address().into_legacy()
+            )
         );
-        tx!(
-            lp,
-            asset_a
-                .0
-                .approve(self.contracts.uniswap_v2_router.address(), asset_a.1)
-        );
-        tx!(
-            lp,
-            asset_b
-                .0
-                .approve(self.contracts.uniswap_v2_router.address(), asset_b.1)
-        );
+
+        asset_a
+            .0
+            .approve(
+                self.contracts.uniswap_v2_router.address().into_alloy(),
+                asset_a.1.into_alloy(),
+            )
+            .from(lp.address().into_alloy())
+            .send_and_watch()
+            .await
+            .unwrap();
+
+        asset_b
+            .0
+            .approve(
+                self.contracts.uniswap_v2_router.address().into_alloy(),
+                asset_b.1.into_alloy(),
+            )
+            .from(lp.address().into_alloy())
+            .send_and_watch()
+            .await
+            .unwrap();
         tx!(
             lp,
             self.contracts.uniswap_v2_router.add_liquidity(
-                asset_a.0.address(),
-                asset_b.0.address(),
+                asset_a.0.address().into_legacy(),
+                asset_b.0.address().into_legacy(),
                 asset_a.1,
                 asset_b.1,
                 0_u64.into(),
@@ -508,7 +554,7 @@ impl OnchainComponents {
             &self.web3,
             self.contracts
                 .uniswap_v2_factory
-                .get_pair(self.contracts.weth.address(), token.address())
+                .get_pair(self.contracts.weth.address(), token.address().into_legacy())
                 .call()
                 .await
                 .expect("failed to get Uniswap V2 pair"),
@@ -518,16 +564,17 @@ impl OnchainComponents {
         // Mint amount + 1 to the pool, and then swap out 1 of the minted token
         // in order to force it to update its K-value.
         token.mint(pair.address(), amount + 1).await;
-        let (out0, out1) = if TokenPair::new(self.contracts.weth.address(), token.address())
-            .unwrap()
-            .get()
-            .0
-            == token.address()
-        {
-            (1, 0)
-        } else {
-            (0, 1)
-        };
+        let (out0, out1) =
+            if TokenPair::new(self.contracts.weth.address(), token.address().into_legacy())
+                .unwrap()
+                .get()
+                .0
+                == token.address().into_legacy()
+            {
+                (1, 0)
+            } else {
+                (0, 1)
+            };
         pair.swap(
             out0.into(),
             out1.into(),

--- a/crates/e2e/src/setup/onchain_components/safe.rs
+++ b/crates/e2e/src/setup/onchain_components/safe.rs
@@ -14,10 +14,7 @@ use {
     ethcontract::transaction::TransactionBuilder,
     ethrpc::{
         AlloyProvider,
-        alloy::{
-            ProviderSignerExt,
-            conversions::{IntoAlloy, TryIntoAlloyAsync},
-        },
+        alloy::{CallBuilderExt, conversions::IntoAlloy},
     },
     hex_literal::hex,
     model::{
@@ -39,37 +36,15 @@ pub struct Infrastructure {
 
 impl Infrastructure {
     pub async fn new(provider: AlloyProvider) -> Self {
-        let first_account = *provider.get_accounts().await.unwrap().first().unwrap();
-
-        let singleton = {
-            let deployed_address = GnosisSafe::Instance::deploy_builder(provider.clone())
-                .from(first_account)
-                .deploy()
-                .await
-                .unwrap();
-            GnosisSafe::Instance::new(deployed_address, provider.clone())
-        };
-        let fallback = {
-            let deployed_address =
-                GnosisSafeCompatibilityFallbackHandler::Instance::deploy_builder(provider.clone())
-                    .from(first_account)
-                    .deploy()
-                    .await
-                    .unwrap();
-            GnosisSafeCompatibilityFallbackHandler::Instance::new(
-                deployed_address,
-                provider.clone(),
-            )
-        };
-        let factory = {
-            let deployed_address =
-                GnosisSafeProxyFactory::Instance::deploy_builder(provider.clone())
-                    .from(first_account)
-                    .deploy()
-                    .await
-                    .unwrap();
-            GnosisSafeProxyFactory::Instance::new(deployed_address, provider.clone())
-        };
+        let singleton = GnosisSafe::Instance::deploy(provider.clone())
+            .await
+            .unwrap();
+        let fallback = GnosisSafeCompatibilityFallbackHandler::Instance::deploy(provider.clone())
+            .await
+            .unwrap();
+        let factory = GnosisSafeProxyFactory::Instance::deploy(provider.clone())
+            .await
+            .unwrap();
 
         Self {
             singleton,
@@ -84,15 +59,14 @@ impl Infrastructure {
         owners: Vec<TestAccount>,
         threshold: usize,
     ) -> GnosisSafe::Instance {
-        let provider = self
-            .provider
-            .with_signer(owners[0].account().clone().try_into_alloy().await.unwrap());
-        let safe_proxy =
-            GnosisSafeProxy::Instance::deploy_builder(provider.clone(), *self.singleton.address())
-                .deploy()
-                .await
-                .unwrap();
-        let safe = GnosisSafe::Instance::new(safe_proxy, provider.clone());
+        let safe_proxy = GnosisSafeProxy::Instance::deploy_builder(
+            self.provider.clone(),
+            *self.singleton.address(),
+        )
+        .deploy()
+        .await
+        .unwrap();
+        let safe = GnosisSafe::Instance::new(safe_proxy, self.provider.clone());
 
         contracts::alloy::tx!(
             safe.setup(
@@ -148,8 +122,8 @@ impl Safe {
     }
 
     async fn exec_alloy_tx(&self, to: Address, value: U256, calldata: Bytes) {
-        contracts::alloy::tx!(
-            self.contract.execTransaction(
+        self.contract
+            .execTransaction(
                 to,
                 value,
                 calldata,
@@ -162,9 +136,11 @@ impl Safe {
                 crate::setup::safe::gnosis_safe_prevalidated_signature(
                     self.owner.address().into_alloy(),
                 ),
-            ),
-            self.owner.address().into_alloy()
-        );
+            )
+            .from(self.owner.address().into_alloy())
+            .send_and_watch()
+            .await
+            .unwrap();
     }
 
     pub async fn exec_call<T: ethcontract::tokens::Tokenize>(

--- a/crates/e2e/tests/e2e/app_data.rs
+++ b/crates/e2e/tests/e2e/app_data.rs
@@ -1,6 +1,10 @@
 use {
     app_data::{AppDataHash, hash_full_app_data},
-    e2e::{setup::*, tx},
+    e2e::setup::*,
+    ethrpc::alloy::{
+        CallBuilderExt,
+        conversions::{IntoAlloy, IntoLegacy},
+    },
     model::{
         order::{OrderCreation, OrderCreationAppData, OrderKind},
         quote::{OrderQuoteRequest, OrderQuoteSide, SellAmount},
@@ -35,18 +39,24 @@ async fn app_data(web3: Web3) {
         .await;
 
     token_a.mint(trader.address(), to_wei(10)).await;
-    tx!(
-        trader.account(),
-        token_a.approve(onchain.contracts().allowance, to_wei(10))
-    );
+
+    token_a
+        .approve(
+            onchain.contracts().allowance.into_alloy(),
+            to_wei(10).into_alloy(),
+        )
+        .from(trader.address().into_alloy())
+        .send_and_watch()
+        .await
+        .unwrap();
 
     let mut valid_to: u32 = model::time::now_in_epoch_seconds() + 300;
     let mut create_order = |app_data| {
         let order = OrderCreation {
             app_data,
-            sell_token: token_a.address(),
+            sell_token: token_a.address().into_legacy(),
             sell_amount: to_wei(2),
-            buy_token: token_b.address(),
+            buy_token: token_b.address().into_legacy(),
             buy_amount: to_wei(1),
             valid_to,
             kind: OrderKind::Sell,
@@ -194,18 +204,24 @@ async fn app_data_full_format(web3: Web3) {
         .await;
 
     token_a.mint(trader.address(), to_wei(10)).await;
-    tx!(
-        trader.account(),
-        token_a.approve(onchain.contracts().allowance, to_wei(10))
-    );
+
+    token_a
+        .approve(
+            onchain.contracts().allowance.into_alloy(),
+            to_wei(10).into_alloy(),
+        )
+        .from(trader.address().into_alloy())
+        .send_and_watch()
+        .await
+        .unwrap();
 
     let mut valid_to: u32 = model::time::now_in_epoch_seconds() + 300;
     let mut create_order = |app_data| {
         let order = OrderCreation {
             app_data,
-            sell_token: token_a.address(),
+            sell_token: token_a.address().into_legacy(),
             sell_amount: to_wei(2),
-            buy_token: token_b.address(),
+            buy_token: token_b.address().into_legacy(),
             buy_amount: to_wei(1),
             valid_to,
             kind: OrderKind::Sell,

--- a/crates/e2e/tests/e2e/hooks.rs
+++ b/crates/e2e/tests/e2e/hooks.rs
@@ -17,7 +17,10 @@ use {
         tx_value,
     },
     ethcontract::U256,
-    ethrpc::alloy::conversions::{IntoAlloy, IntoLegacy},
+    ethrpc::alloy::{
+        CallBuilderExt,
+        conversions::{IntoAlloy, IntoLegacy},
+    },
     model::{
         order::{OrderCreation, OrderCreationAppData, OrderKind},
         quote::{OrderQuoteRequest, OrderQuoteSide, SellAmount},
@@ -297,14 +300,16 @@ async fn signature(web3: Web3) {
 
     // Sign an approval transaction for trading. This will be at nonce 0 because
     // it is the first transaction evah!
+    let approval_call_data = token
+        .approve(
+            onchain.contracts().allowance.into_alloy(),
+            to_wei(5).into_alloy(),
+        )
+        .calldata()
+        .to_vec();
     let approval_builder = safe.sign_transaction(
-        token.address().into_alloy(),
-        token
-            .approve(onchain.contracts().allowance, to_wei(5))
-            .tx
-            .data
-            .unwrap()
-            .0,
+        *token.address(),
+        approval_call_data,
         alloy::primitives::U256::ZERO,
     );
     let call_data = approval_builder.calldata().to_vec();
@@ -337,7 +342,7 @@ async fn signature(web3: Web3) {
         // `from` currently has.
         sell_amount: to_wei(6),
         partially_fillable: true,
-        sell_token: token.address(),
+        sell_token: token.address().into_legacy(),
         buy_token: onchain.contracts().weth.address(),
         buy_amount: to_wei(3),
         valid_to: model::time::now_in_epoch_seconds() + 300,
@@ -363,10 +368,11 @@ async fn signature(web3: Web3) {
     onchain.mint_block().await;
 
     let balance = token
-        .balance_of(safe.address().into_legacy())
+        .balanceOf(safe.address())
         .call()
         .await
-        .unwrap();
+        .unwrap()
+        .into_legacy();
     assert_eq!(balance, to_wei(5));
 
     // Check that the Safe really hasn't been deployed yet.
@@ -380,7 +386,7 @@ async fn signature(web3: Web3) {
     tracing::info!("Waiting for trade.");
     let trade_happened = || async {
         token
-            .balance_of(safe.address().into_legacy())
+            .balanceOf(safe.address())
             .call()
             .await
             .unwrap()
@@ -448,7 +454,7 @@ async fn partial_fills(web3: Web3) {
     let order = OrderCreation {
         sell_token: onchain.contracts().weth.address(),
         sell_amount: to_wei(2),
-        buy_token: token.address(),
+        buy_token: token.address().into_legacy(),
         buy_amount: to_wei(1),
         valid_to: model::time::now_in_epoch_seconds() + 300,
         kind: OrderKind::Sell,
@@ -546,8 +552,7 @@ async fn quote_verification(web3: Web3) {
             .clone(),
     );
     let safe_address = safe_creation_builder.clone().call().await.unwrap();
-    let first_account = *web3.alloy.get_accounts().await.unwrap().first().unwrap();
-    contracts::alloy::tx!(safe_creation_builder, first_account);
+    contracts::alloy::tx!(safe_creation_builder);
 
     let safe = Safe::deployed(
         chain_id,
@@ -559,21 +564,25 @@ async fn quote_verification(web3: Web3) {
         .deploy_tokens_with_weth_uni_v2_pools(to_wei(100_000), to_wei(100_000))
         .await;
     token.mint(safe.address().into_legacy(), to_wei(5)).await;
-    tx!(
-        trader.account(),
-        token.approve(onchain.contracts().allowance, to_wei(5))
-    );
+
+    token
+        .approve(
+            onchain.contracts().allowance.into_alloy(),
+            to_wei(5).into_alloy(),
+        )
+        .from(trader.address().into_alloy())
+        .send_and_watch()
+        .await
+        .unwrap();
 
     // Sign transaction transferring 5 token from the safe to the trader
     // to fund the trade in a pre-hook.
     let transfer_builder = safe.sign_transaction(
-        token.address().into_alloy(),
+        *token.address(),
         token
-            .transfer(trader.address(), to_wei(5))
-            .tx
-            .data
-            .unwrap()
-            .0,
+            .transfer(trader.address().into_alloy(), to_wei(5).into_alloy())
+            .calldata()
+            .to_vec(),
         alloy::primitives::U256::ZERO,
     );
     let call_data = transfer_builder.calldata().to_vec();
@@ -597,7 +606,7 @@ async fn quote_verification(web3: Web3) {
     let quote = services
         .submit_quote(&OrderQuoteRequest {
             from: trader.address(),
-            sell_token: token.address(),
+            sell_token: token.address().into_legacy(),
             buy_token: onchain.contracts().weth.address(),
             side: OrderQuoteSide::Sell {
                 sell_amount: SellAmount::BeforeFee {

--- a/crates/e2e/tests/e2e/order_cancellation.rs
+++ b/crates/e2e/tests/e2e/order_cancellation.rs
@@ -1,6 +1,10 @@
 use {
     database::order_events::OrderEventLabel,
-    e2e::{setup::*, tx},
+    e2e::setup::*,
+    ethrpc::alloy::{
+        CallBuilderExt,
+        conversions::{IntoAlloy, IntoLegacy},
+    },
     model::{
         order::{
             CancellationPayload,
@@ -40,10 +44,16 @@ async fn order_cancellation(web3: Web3) {
     token.mint(trader.address(), to_wei(10)).await;
 
     // Approve GPv2 for trading
-    tx!(
-        trader.account(),
-        token.approve(onchain.contracts().allowance, to_wei(10))
-    );
+
+    token
+        .approve(
+            onchain.contracts().allowance.into_alloy(),
+            to_wei(10).into_alloy(),
+        )
+        .from(trader.address().into_alloy())
+        .send_and_watch()
+        .await
+        .unwrap();
 
     let services = Services::new(&onchain).await;
     colocation::start_driver(
@@ -86,7 +96,7 @@ async fn order_cancellation(web3: Web3) {
 
         let request = OrderQuoteRequest {
             from: trader.address(),
-            sell_token: token.address(),
+            sell_token: token.address().into_legacy(),
             buy_token: onchain.contracts().weth.address(),
             side: OrderQuoteSide::Sell {
                 sell_amount: SellAmount::AfterFee {

--- a/crates/e2e/tests/e2e/partially_fillable_balance.rs
+++ b/crates/e2e/tests/e2e/partially_fillable_balance.rs
@@ -1,6 +1,10 @@
 use {
+    ::alloy::primitives::U256,
     e2e::{setup::*, tx},
-    ethcontract::prelude::U256,
+    ethrpc::alloy::{
+        CallBuilderExt,
+        conversions::{IntoAlloy, IntoLegacy},
+    },
     model::{
         order::{OrderCreation, OrderKind},
         signature::EcdsaSigningScheme,
@@ -31,51 +35,62 @@ async fn test(web3: Web3) {
 
     tx!(
         solver.account(),
-        onchain
-            .contracts()
-            .uniswap_v2_factory
-            .create_pair(token_a.address(), token_b.address())
-    );
-    tx!(
-        solver.account(),
-        token_a.approve(
-            onchain.contracts().uniswap_v2_router.address(),
-            to_wei(1000)
+        onchain.contracts().uniswap_v2_factory.create_pair(
+            token_a.address().into_legacy(),
+            token_b.address().into_legacy()
         )
     );
-    tx!(
-        solver.account(),
-        token_b.approve(
-            onchain.contracts().uniswap_v2_router.address(),
-            to_wei(1000)
+
+    token_a
+        .approve(
+            onchain.contracts().uniswap_v2_router.address().into_alloy(),
+            to_wei(1000).into_alloy(),
         )
-    );
+        .from(solver.address().into_alloy())
+        .send_and_watch()
+        .await
+        .unwrap();
+
+    token_b
+        .approve(
+            onchain.contracts().uniswap_v2_router.address().into_alloy(),
+            to_wei(1000).into_alloy(),
+        )
+        .from(solver.address().into_alloy())
+        .send_and_watch()
+        .await
+        .unwrap();
     tx!(
         solver.account(),
         onchain.contracts().uniswap_v2_router.add_liquidity(
-            token_a.address(),
-            token_b.address(),
+            token_a.address().into_legacy(),
+            token_b.address().into_legacy(),
             to_wei(1000),
             to_wei(1000),
             0_u64.into(),
             0_u64.into(),
             solver.address(),
-            U256::max_value(),
+            U256::MAX.into_legacy(),
         )
     );
 
-    tx!(
-        trader_a.account(),
-        token_a.approve(onchain.contracts().allowance, to_wei(500))
-    );
+    token_a
+        .approve(
+            onchain.contracts().allowance.into_alloy(),
+            to_wei(500).into_alloy(),
+        )
+        .from(trader_a.address().into_alloy())
+        .send_and_watch()
+        .await
+        .unwrap();
 
     let services = Services::new(&onchain).await;
     services.start_protocol(solver).await;
 
     let order_a = OrderCreation {
-        sell_token: token_a.address(),
+        sell_token: token_a.address().into_legacy(),
         sell_amount: to_wei(100),
-        buy_token: token_b.address(),
+        buy_token: token_b.address().into_legacy(),
         buy_amount: to_wei(50),
         valid_to: model::time::now_in_epoch_seconds() + 300,
         kind: OrderKind::Sell,
@@ -95,7 +110,11 @@ async fn test(web3: Web3) {
 
     tracing::info!("Waiting for trade.");
     wait_for_condition(TIMEOUT, || async {
-        let balance = token_b.balance_of(trader_a.address()).call().await.unwrap();
+        let balance = token_b
+            .balanceOf(trader_a.address().into_alloy())
+            .call()
+            .await
+            .unwrap();
         !balance.is_zero()
     })
     .await
@@ -104,19 +123,20 @@ async fn test(web3: Web3) {
     // Expecting a partial fill because order sells 100 but user only has balance of
     // 50.
     let sell_balance = token_a
-        .balance_of(trader_a.address())
+        .balanceOf(trader_a.address().into_alloy())
         .call()
         .await
-        .unwrap()
-        .to_f64_lossy();
+        .unwrap();
     // Depending on how the solver works might not have sold all balance.
-    assert!((0e18..=1e18).contains(&sell_balance));
+    assert!(U256::ZERO <= sell_balance && sell_balance < U256::from(10u64.pow(18)));
     let buy_balance = token_b
-        .balance_of(trader_a.address())
+        .balanceOf(trader_a.address().into_alloy())
         .call()
         .await
-        .unwrap()
-        .to_f64_lossy();
+        .unwrap();
     // We don't know exact buy balance because of the fee.
-    assert!((45e18..=55e18).contains(&buy_balance));
+    assert!(
+        U256::from(45) * U256::from(10u64.pow(18)) <= buy_balance
+            && buy_balance <= U256::from(55) * U256::from(10u64.pow(18))
+    );
 }

--- a/crates/e2e/tests/e2e/quote_verification.rs
+++ b/crates/e2e/tests/e2e/quote_verification.rs
@@ -1,8 +1,14 @@
 use {
     bigdecimal::{BigDecimal, Zero},
-    e2e::{setup::*, tx},
+    e2e::setup::*,
     ethcontract::{H160, U256},
-    ethrpc::Web3,
+    ethrpc::{
+        Web3,
+        alloy::{
+            CallBuilderExt,
+            conversions::{IntoAlloy, IntoLegacy},
+        },
+    },
     model::{
         interaction::InteractionData,
         order::{BuyTokenDestination, OrderKind, SellTokenSource},
@@ -87,10 +93,16 @@ async fn standard_verified_quote(web3: Web3) {
         .await;
 
     token.mint(trader.address(), to_wei(1)).await;
-    tx!(
-        trader.account(),
-        token.approve(onchain.contracts().allowance, to_wei(1))
-    );
+
+    token
+        .approve(
+            onchain.contracts().allowance.into_alloy(),
+            to_wei(1).into_alloy(),
+        )
+        .from(trader.address().into_alloy())
+        .send_and_watch()
+        .await
+        .unwrap();
 
     tracing::info!("Starting services.");
     let services = Services::new(&onchain).await;
@@ -100,7 +112,7 @@ async fn standard_verified_quote(web3: Web3) {
     let response = services
         .submit_quote(&OrderQuoteRequest {
             from: trader.address(),
-            sell_token: token.address(),
+            sell_token: token.address().into_legacy(),
             buy_token: onchain.contracts().weth.address(),
             side: OrderQuoteSide::Sell {
                 sell_amount: SellAmount::BeforeFee {
@@ -141,6 +153,7 @@ async fn test_bypass_verification_for_rfq_quotes(web3: Web3) {
         onchain.contracts().gp_settlement.address(),
         onchain.contracts().weth.address(),
         BigDecimal::zero(),
+        Default::default(),
     )
     .await
     .unwrap();
@@ -192,9 +205,9 @@ async fn test_bypass_verification_for_rfq_quotes(web3: Web3) {
         verified: true,
         execution: QuoteExecution {
             interactions: vec![InteractionData {
-                target: H160::from_str("0xdef1c0ded9bec7f1a1670819833240f027b25eff").unwrap(), 
+                target: H160::from_str("0xdef1c0ded9bec7f1a1670819833240f027b25eff").unwrap(),
                 value: 0.into(),
-                call_data: hex::decode("aa77476c000000000000000000000000c02aaa39b223fe8d0a0e5c4f27ead9083c756cc20000000000000000000000002260fac5e5542a773aa44fbcfedf7c193bc2c599000000000000000000000000000000000000000000000000e357b42c3a9d8ccf0000000000000000000000000000000000000000000000000000000004d0e79e000000000000000000000000a69babef1ca67a37ffaf7a485dfff3382056e78c0000000000000000000000009008d19f58aabd9ed0d60971565aa8510560ab41000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000066360af101ffffffffffffffffffffffffffffffffffffff0f3f47f166360a8d0000003f0000000000000000000000000000000000000000000000000000000000000003000000000000000000000000000000000000000000000000000000000000001c66b3383f287dd9c85ad90e7c5a576ea4ba1bdf5a001d794a9afa379e6b2517b47e487a1aef32e75af432cbdbd301ada42754eaeac21ec4ca744afd92732f47540000000000000000000000000000000000000000000000000000000004d0c80f").unwrap() 
+                call_data: hex::decode("aa77476c000000000000000000000000c02aaa39b223fe8d0a0e5c4f27ead9083c756cc20000000000000000000000002260fac5e5542a773aa44fbcfedf7c193bc2c599000000000000000000000000000000000000000000000000e357b42c3a9d8ccf0000000000000000000000000000000000000000000000000000000004d0e79e000000000000000000000000a69babef1ca67a37ffaf7a485dfff3382056e78c0000000000000000000000009008d19f58aabd9ed0d60971565aa8510560ab41000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000066360af101ffffffffffffffffffffffffffffffffffffff0f3f47f166360a8d0000003f0000000000000000000000000000000000000000000000000000000000000003000000000000000000000000000000000000000000000000000000000000001c66b3383f287dd9c85ad90e7c5a576ea4ba1bdf5a001d794a9afa379e6b2517b47e487a1aef32e75af432cbdbd301ada42754eaeac21ec4ca744afd92732f47540000000000000000000000000000000000000000000000000000000004d0c80f").unwrap()
             }],
             pre_interactions: vec![],
             jit_orders: vec![],
@@ -250,7 +263,7 @@ async fn verified_quote_eth_balance(web3: Web3) {
         .submit_quote(&OrderQuoteRequest {
             from: trader.address(),
             sell_token: weth.address(),
-            buy_token: token.address(),
+            buy_token: token.address().into_legacy(),
             side: OrderQuoteSide::Sell {
                 sell_amount: SellAmount::BeforeFee {
                     value: to_wei(1).try_into().unwrap(),
@@ -287,7 +300,7 @@ async fn verified_quote_for_settlement_contract(web3: Web3) {
 
     let request = OrderQuoteRequest {
         sell_token: onchain.contracts().weth.address(),
-        buy_token: token.address(),
+        buy_token: token.address().into_legacy(),
         side: OrderQuoteSide::Sell {
             sell_amount: SellAmount::BeforeFee {
                 value: to_wei(3).try_into().unwrap(),
@@ -376,19 +389,29 @@ async fn verified_quote_with_simulated_balance(web3: Web3) {
     // quote where the trader has no balances or approval set from TOKEN->WETH
     assert_eq!(
         (
-            token.balance_of(trader.address()).call().await.unwrap(),
             token
-                .allowance(trader.address(), onchain.contracts().allowance)
+                .balanceOf(trader.address().into_alloy())
+                .call()
+                .await
+                .unwrap(),
+            token
+                .allowance(
+                    trader.address().into_alloy(),
+                    onchain.contracts().allowance.into_alloy()
+                )
                 .call()
                 .await
                 .unwrap(),
         ),
-        (U256::zero(), U256::zero()),
+        (
+            ::alloy::primitives::U256::ZERO,
+            ::alloy::primitives::U256::ZERO
+        ),
     );
     let response = services
         .submit_quote(&OrderQuoteRequest {
             from: trader.address(),
-            sell_token: token.address(),
+            sell_token: token.address().into_legacy(),
             buy_token: weth.address(),
             side: OrderQuoteSide::Sell {
                 sell_amount: SellAmount::BeforeFee {
@@ -422,7 +445,7 @@ async fn verified_quote_with_simulated_balance(web3: Web3) {
         .submit_quote(&OrderQuoteRequest {
             from: trader.address(),
             sell_token: weth.address(),
-            buy_token: token.address(),
+            buy_token: token.address().into_legacy(),
             side: OrderQuoteSide::Sell {
                 sell_amount: SellAmount::BeforeFee {
                     value: to_wei(1).try_into().unwrap(),
@@ -440,7 +463,7 @@ async fn verified_quote_with_simulated_balance(web3: Web3) {
         .submit_quote(&OrderQuoteRequest {
             from: H160::zero(),
             sell_token: weth.address(),
-            buy_token: token.address(),
+            buy_token: token.address().into_legacy(),
             side: OrderQuoteSide::Sell {
                 sell_amount: SellAmount::BeforeFee {
                     value: to_wei(1).try_into().unwrap(),
@@ -458,7 +481,7 @@ async fn verified_quote_with_simulated_balance(web3: Web3) {
         .submit_quote(&OrderQuoteRequest {
             from: H160::zero(),
             sell_token: weth.address(),
-            buy_token: token.address(),
+            buy_token: token.address().into_legacy(),
             side: OrderQuoteSide::Sell {
                 sell_amount: SellAmount::BeforeFee {
                     value: to_wei(1).try_into().unwrap(),

--- a/crates/e2e/tests/e2e/quoting.rs
+++ b/crates/e2e/tests/e2e/quoting.rs
@@ -4,6 +4,10 @@ use {
         tx,
         tx_value,
     },
+    ethrpc::alloy::{
+        CallBuilderExt,
+        conversions::{IntoAlloy, IntoLegacy},
+    },
     futures::FutureExt,
     model::{
         order::{OrderCreation, OrderCreationAppData, OrderKind},
@@ -73,7 +77,7 @@ async fn test(web3: Web3) {
     let request = OrderQuoteRequest {
         from: trader.address(),
         sell_token: onchain.contracts().weth.address(),
-        buy_token: token.address(),
+        buy_token: token.address().into_legacy(),
         side: OrderQuoteSide::Sell {
             sell_amount: SellAmount::BeforeFee {
                 value: NonZeroU256::try_from(to_wei(1)).unwrap(),
@@ -206,7 +210,7 @@ async fn uses_stale_liquidity(web3: Web3) {
     let quote = OrderQuoteRequest {
         from: trader.address(),
         sell_token: onchain.contracts().weth.address(),
-        buy_token: token.address(),
+        buy_token: token.address().into_legacy(),
         side: OrderQuoteSide::Sell {
             sell_amount: SellAmount::AfterFee {
                 value: NonZeroU256::new(to_wei(1)).unwrap(),
@@ -266,14 +270,14 @@ async fn quote_timeout(web3: Web3) {
                 name: "test_solver".into(),
                 account: solver.clone(),
                 endpoint: mock_solver.url.clone(),
-                base_tokens: vec![sell_token.address()],
+                base_tokens: vec![sell_token.address().into_legacy()],
                 merge_solutions: true,
             },
             SolverEngine {
                 name: "test_quoter".into(),
                 account: solver.clone(),
                 endpoint: mock_solver.url.clone(),
-                base_tokens: vec![sell_token.address()],
+                base_tokens: vec![sell_token.address().into_legacy()],
                 merge_solutions: true,
             },
         ],
@@ -307,7 +311,7 @@ async fn quote_timeout(web3: Web3) {
     let quote_request = |timeout| OrderQuoteRequest {
         from: trader.address(),
         sell_token: onchain.contracts().weth.address(),
-        buy_token: sell_token.address(),
+        buy_token: sell_token.address().into_legacy(),
         side: OrderQuoteSide::Sell {
             sell_amount: SellAmount::BeforeFee {
                 value: NonZeroU256::try_from(to_wei(1)).unwrap(),
@@ -329,7 +333,9 @@ async fn quote_timeout(web3: Web3) {
 
     // native token price requests are also capped to the max timeout
     let start = std::time::Instant::now();
-    let res = services.get_native_price(&sell_token.address()).await;
+    let res = services
+        .get_native_price(&sell_token.address().into_legacy())
+        .await;
     assert!(res.unwrap_err().1.contains("NoLiquidity"));
     assert_within_variance(start, MAX_QUOTE_TIME_MS);
 
@@ -359,13 +365,19 @@ async fn quote_timeout(web3: Web3) {
 
     // set up trader to pass balance checks during order creation
     sell_token.mint(trader.address(), to_wei(1)).await;
-    tx!(
-        trader.account(),
-        sell_token.approve(onchain.contracts().allowance, to_wei(1))
-    );
+
+    sell_token
+        .approve(
+            onchain.contracts().allowance.into_alloy(),
+            to_wei(1).into_alloy(),
+        )
+        .from(trader.address().into_alloy())
+        .send_and_watch()
+        .await
+        .unwrap();
 
     let order = OrderCreation {
-        sell_token: sell_token.address(),
+        sell_token: sell_token.address().into_legacy(),
         sell_amount: to_wei(1),
         buy_token: Default::default(),
         buy_amount: to_wei(1),

--- a/crates/e2e/tests/e2e/refunder.rs
+++ b/crates/e2e/tests/e2e/refunder.rs
@@ -3,7 +3,11 @@ use {
     chrono::{TimeZone, Utc},
     e2e::{nodes::local_node::TestNodeApi, setup::*},
     ethcontract::{H160, U256},
-    ethrpc::{Web3, block_stream::timestamp_of_current_block_in_seconds},
+    ethrpc::{
+        Web3,
+        alloy::conversions::IntoLegacy,
+        block_stream::timestamp_of_current_block_in_seconds,
+    },
     model::quote::{OrderQuoteRequest, OrderQuoteSide, QuoteSigningScheme, Validity},
     number::nonzero::U256 as NonZeroU256,
     refunder::refund_service::RefundService,
@@ -29,7 +33,7 @@ async fn refunder_tx(web3: Web3) {
     services.start_protocol(solver).await;
 
     // Get quote id for order placement
-    let buy_token = token.address();
+    let buy_token = token.address().into_legacy();
     let receiver = Some(H160([42; 20]));
     let sell_amount = U256::from("3000000000000000");
 

--- a/crates/e2e/tests/e2e/solver_participation_guard.rs
+++ b/crates/e2e/tests/e2e/solver_participation_guard.rs
@@ -14,7 +14,13 @@ use {
         },
         tx,
     },
-    ethrpc::Web3,
+    ethrpc::{
+        Web3,
+        alloy::{
+            CallBuilderExt,
+            conversions::{IntoAlloy, IntoLegacy},
+        },
+    },
     model::{
         order::{OrderClass, OrderCreation, OrderKind},
         signature::EcdsaSigningScheme,
@@ -251,30 +257,36 @@ async fn setup(
     token_b.mint(solver.address(), to_wei(1000)).await;
     tx!(
         solver.account(),
-        onchain
-            .contracts()
-            .uniswap_v2_factory
-            .create_pair(token_a.address(), token_b.address())
-    );
-    tx!(
-        solver.account(),
-        token_a.approve(
-            onchain.contracts().uniswap_v2_router.address(),
-            to_wei(1000)
+        onchain.contracts().uniswap_v2_factory.create_pair(
+            token_a.address().into_legacy(),
+            token_b.address().into_legacy()
         )
     );
-    tx!(
-        solver.account(),
-        token_b.approve(
-            onchain.contracts().uniswap_v2_router.address(),
-            to_wei(1000)
+
+    token_a
+        .approve(
+            onchain.contracts().uniswap_v2_router.address().into_alloy(),
+            to_wei(1000).into_alloy(),
         )
-    );
+        .from(solver.address().into_alloy())
+        .send_and_watch()
+        .await
+        .unwrap();
+
+    token_b
+        .approve(
+            onchain.contracts().uniswap_v2_router.address().into_alloy(),
+            to_wei(1000).into_alloy(),
+        )
+        .from(solver.address().into_alloy())
+        .send_and_watch()
+        .await
+        .unwrap();
     tx!(
         solver.account(),
         onchain.contracts().uniswap_v2_router.add_liquidity(
-            token_a.address(),
-            token_b.address(),
+            token_a.address().into_legacy(),
+            token_b.address().into_legacy(),
             to_wei(1000),
             to_wei(1000),
             0_u64.into(),
@@ -285,10 +297,16 @@ async fn setup(
     );
 
     // Approve GPv2 for trading
-    tx!(
-        trader_a.account(),
-        token_a.approve(onchain.contracts().allowance, to_wei(1000))
-    );
+
+    token_a
+        .approve(
+            onchain.contracts().allowance.into_alloy(),
+            to_wei(1000).into_alloy(),
+        )
+        .from(trader_a.address().into_alloy())
+        .send_and_watch()
+        .await
+        .unwrap();
 
     (trader_a, token_a, token_b)
 }
@@ -325,9 +343,9 @@ async fn execute_order(
     services: &Services<'_>,
 ) -> anyhow::Result<()> {
     let order = OrderCreation {
-        sell_token: token_a.address(),
+        sell_token: token_a.address().into_legacy(),
         sell_amount: to_wei(10),
-        buy_token: token_b.address(),
+        buy_token: token_b.address().into_legacy(),
         buy_amount: to_wei(5),
         valid_to: model::time::now_in_epoch_seconds() + 300,
         kind: OrderKind::Sell,
@@ -338,7 +356,11 @@ async fn execute_order(
         &onchain.contracts().domain_separator,
         SecretKeyRef::from(&SecretKey::from_slice(trader_a.private_key()).unwrap()),
     );
-    let balance_before = token_b.balance_of(trader_a.address()).call().await.unwrap();
+    let balance_before = token_b
+        .balanceOf(trader_a.address().into_alloy())
+        .call()
+        .await
+        .unwrap();
     let order_id = services.create_order(&order).await.unwrap();
     onchain.mint_block().await;
     let limit_order = services.get_order(&order_id).await.unwrap();
@@ -348,8 +370,13 @@ async fn execute_order(
     // Drive solution
     tracing::info!("Waiting for trade.");
     wait_for_condition(TIMEOUT, || async {
-        let balance_after = token_b.balance_of(trader_a.address()).call().await.unwrap();
-        let balance_changes = balance_after.checked_sub(balance_before).unwrap() >= to_wei(5);
+        let balance_after = token_b
+            .balanceOf(trader_a.address().into_alloy())
+            .call()
+            .await
+            .unwrap();
+        let balance_changes =
+            balance_after.checked_sub(balance_before).unwrap() >= to_wei(5).into_alloy();
         let auction_ids_after =
             fetch_last_settled_auction_ids(services.db()).await.len() > auction_ids_before;
         balance_changes && auction_ids_after

--- a/crates/e2e/tests/e2e/submission.rs
+++ b/crates/e2e/tests/e2e/submission.rs
@@ -1,6 +1,8 @@
 use {
+    ::alloy::primitives::U256,
     e2e::{nodes::local_node::TestNodeApi, setup::*, tx, tx_value},
     ethcontract::{BlockId, H160, H256},
+    ethrpc::alloy::conversions::{IntoAlloy, IntoLegacy},
     futures::{Stream, StreamExt},
     model::{
         order::{OrderCreation, OrderKind},
@@ -52,12 +54,16 @@ async fn test_cancel_on_expiry(web3: Web3) {
         .expect("Must be able to disable automine");
 
     tracing::info!("Placing order");
-    let balance = token.balance_of(trader.address()).call().await.unwrap();
-    assert_eq!(balance, 0.into());
+    let balance = token
+        .balanceOf(trader.address().into_alloy())
+        .call()
+        .await
+        .unwrap();
+    assert_eq!(balance, U256::ZERO);
     let order = OrderCreation {
         sell_token: onchain.contracts().weth.address(),
         sell_amount: to_wei(2),
-        buy_token: token.address(),
+        buy_token: token.address().into_legacy(),
         buy_amount: to_wei(1),
         valid_to: model::time::now_in_epoch_seconds() + 300,
         kind: OrderKind::Buy,

--- a/crates/e2e/tests/e2e/tracking_insufficient_funds.rs
+++ b/crates/e2e/tests/e2e/tracking_insufficient_funds.rs
@@ -1,6 +1,7 @@
 use {
     database::order_events::{OrderEvent, OrderEventLabel},
     e2e::{setup::*, tx, tx_value},
+    ethrpc::alloy::conversions::IntoLegacy,
     model::{
         order::{OrderCreation, OrderKind},
         signature::EcdsaSigningScheme,
@@ -59,7 +60,7 @@ async fn test(web3: Web3) {
     let order_a = OrderCreation {
         sell_token: onchain.contracts().weth.address(),
         sell_amount: to_wei(2),
-        buy_token: token.address(),
+        buy_token: token.address().into_legacy(),
         buy_amount: to_wei(1),
         valid_to: model::time::now_in_epoch_seconds() + 300,
         kind: OrderKind::Buy,
@@ -73,7 +74,7 @@ async fn test(web3: Web3) {
     let order_b = OrderCreation {
         sell_token: onchain.contracts().weth.address(),
         sell_amount: to_wei(2),
-        buy_token: token.address(),
+        buy_token: token.address().into_legacy(),
         buy_amount: to_wei(1),
         valid_to: model::time::now_in_epoch_seconds() + 300,
         kind: OrderKind::Buy,

--- a/crates/e2e/tests/e2e/uncovered_order.rs
+++ b/crates/e2e/tests/e2e/uncovered_order.rs
@@ -1,5 +1,6 @@
 use {
     e2e::{setup::*, tx, tx_value},
+    ethrpc::alloy::conversions::IntoLegacy,
     model::{
         order::{OrderCreation, OrderKind},
         signature::EcdsaSigningScheme,
@@ -43,7 +44,7 @@ async fn test(web3: Web3) {
         sell_token: weth.address(),
         sell_amount: to_wei(2),
         fee_amount: 0.into(),
-        buy_token: token.address(),
+        buy_token: token.address().into_legacy(),
         buy_amount: to_wei(1),
         valid_to: model::time::now_in_epoch_seconds() + 300,
         kind: OrderKind::Sell,

--- a/crates/ethrpc/Cargo.toml
+++ b/crates/ethrpc/Cargo.toml
@@ -29,7 +29,7 @@ reqwest = { workspace = true, features = ["cookies"] }
 scopeguard = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
-tokio = { workspace = true, features = [] }
+tokio = { workspace = true, features = ["rt", "rt-multi-thread"] }
 tokio-stream = { workspace = true }
 tower = { workspace = true }
 tracing = { workspace = true }

--- a/crates/ethrpc/src/alloy/wallet.rs
+++ b/crates/ethrpc/src/alloy/wallet.rs
@@ -1,0 +1,135 @@
+use {
+    alloy::{
+        consensus::{TxEnvelope, TypedTransaction},
+        network::{Ethereum, EthereumWallet, Network, NetworkWallet, TxSigner},
+        primitives::Address,
+        signers::Signature,
+        transports::impl_future,
+    },
+    std::{sync::Arc, thread},
+    tokio::sync::RwLock,
+};
+
+/// A mutable version of [`EthereumWallet`], cheaply cloneable (through
+/// [`Arc`]).
+///
+/// Requires a tokio runtime to be present, otherwise operations will panic.
+#[derive(Debug, Clone, Default)]
+pub struct MutWallet(Arc<RwLock<EthereumWallet>>);
+
+impl MutWallet {
+    pub fn new(wallet: EthereumWallet) -> Self {
+        Self(Arc::new(RwLock::new(wallet)))
+    }
+}
+
+impl MutWallet {
+    /// Calls the inner [`EthereumWallet`]'s
+    /// [`register_signer`](EthereumWallet::register_signer), if no default
+    /// signer has been setup (i.e. the wallet was created using
+    /// [`MutWallet::default`]) it will register one.
+    pub fn register_signer<S>(&mut self, signer: S)
+    where
+        S: TxSigner<Signature> + Send + Sync + 'static,
+    {
+        self.handle_blocking_operation(move |wallet| {
+            // If the wallet is created using MutWallet::default(), there will not be
+            // default signer; this stops us from *not* using `.from` (since it
+            // is filled with the default signer). At the same time, we can't
+            // constantly register new default signers, because it breaks the caller's
+            // expectations. As such, if the current default signer address is
+            // the default address (0x000...000) we register the signer as the
+            // default one.
+            let register_default = {
+                let r_lock = wallet.0.blocking_read();
+                let default_address =
+                    <EthereumWallet as NetworkWallet<Ethereum>>::default_signer_address(&r_lock);
+
+                default_address == Address::default()
+            };
+
+            let mut w_lock = wallet.0.blocking_write();
+            if register_default {
+                w_lock.register_default_signer(signer);
+            } else {
+                w_lock.register_signer(signer);
+            }
+        });
+    }
+
+    /// Handles blocking operations such as the
+    /// [`blocking_read`](RwLock::blocking_read)
+    /// and [`blocking_write`](RwLock::blocking_write).
+    ///
+    /// This function *will panic* in case there is no runtime present, or the
+    /// runtime flavor is not `current_thread` or `multi_thread`.
+    // This function is necessary to handle the blocking lock operations under
+    // required by synchronous function calls which are problematic when the runtime
+    // flavour is `current_thread` (which will panic when blocked by certain
+    // operations).
+    fn handle_blocking_operation<F, R>(&self, f: F) -> R
+    where
+        F: FnOnce(Self) -> R + Send + 'static,
+        R: Send + 'static,
+    {
+        let wallet = self.clone();
+        let rt = tokio::runtime::Handle::current();
+
+        match rt.runtime_flavor() {
+            tokio::runtime::RuntimeFlavor::CurrentThread => thread::spawn(move || f(wallet))
+                .join()
+                .expect("failed to join thread"),
+            tokio::runtime::RuntimeFlavor::MultiThread => {
+                tokio::task::block_in_place(move || f(wallet))
+            }
+            _ => panic!("unsupported runtime flavor"),
+        }
+    }
+}
+
+impl<N> NetworkWallet<N> for MutWallet
+where
+    N: Network<UnsignedTx = TypedTransaction, TxEnvelope = TxEnvelope>,
+{
+    /// Get the default signer address. This address should be used
+    /// in [`NetworkWallet::sign_transaction_from`] when no specific signer is
+    /// specified.
+    fn default_signer_address(&self) -> Address {
+        self.handle_blocking_operation(|wallet| {
+            let r_lock = wallet.0.blocking_read();
+            <EthereumWallet as NetworkWallet<N>>::default_signer_address(&r_lock)
+        })
+    }
+
+    /// Return true if the signer contains a credential for the given address.
+    fn has_signer_for(&self, address: &Address) -> bool {
+        let address = *address;
+        self.handle_blocking_operation(move |wallet| {
+            let r_lock = wallet.0.blocking_read();
+            <EthereumWallet as NetworkWallet<N>>::has_signer_for(&r_lock, &address)
+        })
+    }
+
+    /// Return an iterator of all signer addresses.
+    fn signer_addresses(&self) -> impl Iterator<Item = Address> {
+        self.handle_blocking_operation(move |wallet| {
+            let r_lock = wallet.0.blocking_read();
+            <EthereumWallet as NetworkWallet<N>>::signer_addresses(&r_lock).collect::<Vec<_>>()
+        })
+        .into_iter()
+    }
+
+    /// Asynchronously sign an unsigned transaction, with a specified
+    /// credential.
+    #[doc(alias = "sign_tx_from")]
+    fn sign_transaction_from(
+        &self,
+        sender: Address,
+        tx: N::UnsignedTx,
+    ) -> impl_future!(<Output = alloy::signers::Result<N::TxEnvelope>>) {
+        async move {
+            let r_lock = self.0.read().await;
+            <EthereumWallet as NetworkWallet<N>>::sign_transaction_from(&r_lock, sender, tx).await
+        }
+    }
+}

--- a/crates/ethrpc/src/block_stream/mod.rs
+++ b/crates/ethrpc/src/block_stream/mod.rs
@@ -125,10 +125,12 @@ pub async fn current_block_stream(
         url.clone(),
         "block_stream".into(),
     )));
+    let (alloy, wallet) = crate::alloy::provider(url.as_str());
     let web3 = crate::Web3 {
         legacy: web3,
         // TODO: replace this with an unbuffered alloy provider
-        alloy: crate::alloy::provider(url.as_str()),
+        alloy,
+        wallet,
     };
     let web3 = instrument_with_label(&web3, "base_currentBlockStream".into());
 

--- a/crates/ethrpc/src/instrumented.rs
+++ b/crates/ethrpc/src/instrumented.rs
@@ -81,6 +81,7 @@ pub fn instrument_with_label(web3: &crate::Web3, label: String) -> crate::Web3 {
     crate::Web3 {
         legacy: web3::Web3::new(DynTransport::new(instrumented)),
         alloy: web3.alloy.labeled(label),
+        wallet: web3.wallet.clone(),
     }
 }
 

--- a/crates/ethrpc/src/mock.rs
+++ b/crates/ethrpc/src/mock.rs
@@ -1,7 +1,7 @@
 //! Mockable Web3 transport implementation.
 
 use {
-    crate::Web3,
+    crate::{Web3, alloy::MutWallet},
     alloy::providers::{Provider, ProviderBuilder, mock::Asserter},
     ethcontract::{
         futures::future::{self, Ready},
@@ -29,6 +29,7 @@ pub fn web3() -> Web3<MockTransport> {
         alloy: ProviderBuilder::new()
             .connect_mocked_client(Asserter::new())
             .erased(),
+        wallet: MutWallet::default(),
     }
 }
 

--- a/crates/shared/src/event_handling.rs
+++ b/crates/shared/src/event_handling.rs
@@ -100,12 +100,10 @@ pub trait EthcontractEventRetrieving {
 pub trait AlloyEventRetrieving {
     type Event: SolEventInterface + Send + Sync + 'static;
 
-    // fn topics_filter(&self) -> Vec<B256>;
-    //
-    // fn address_filter(&self) -> Vec<alloy::primitives::Address>;
+    /// Returns a filter that is used to query for the events of interest.
+    fn filter(&self) -> Filter;
 
     fn provider(&self) -> &DynProvider;
-    fn filter(&self) -> Filter;
 }
 
 /// A thin wrapper to avoid conflicts with EthcontractEventRetrieving

--- a/crates/shared/src/price_estimation/factory.rs
+++ b/crates/shared/src/price_estimation/factory.rs
@@ -125,6 +125,7 @@ impl<'a> PriceEstimatorFactory<'a> {
             network.settlement,
             network.native_token,
             args.quote_inaccuracy_limit.clone(),
+            args.tokens_without_verification.iter().cloned().collect(),
         )
         .await?;
         Ok(Some(Arc::new(verifier)))

--- a/crates/shared/src/price_estimation/mod.rs
+++ b/crates/shared/src/price_estimation/mod.rs
@@ -262,6 +262,13 @@ pub struct Arguments {
         value_parser = parse_tuple::<H160, H160>
     )]
     pub native_price_approximation_tokens: Vec<(H160, H160)>,
+
+    /// Tokens for which quote verification should not be attempted. This is an
+    /// escape hatch when there is a very bad but verifiable liquidity source
+    /// that would win against a very good but unverifiable liquidity source
+    /// (e.g. private liquidity that exists but can't be verified).
+    #[clap(long, env, value_delimiter = ',')]
+    pub tokens_without_verification: Vec<H160>,
 }
 
 /// Custom Clap parser for tuple pair
@@ -354,6 +361,7 @@ impl Display for Arguments {
             quote_timeout,
             balance_overrides,
             native_price_approximation_tokens,
+            tokens_without_verification,
         } = self;
 
         display_option(
@@ -422,6 +430,10 @@ impl Display for Arguments {
         writeln!(
             f,
             "native_price_approximation_tokens: {native_price_approximation_tokens:?}"
+        )?;
+        writeln!(
+            f,
+            "tokens_without_verification: {tokens_without_verification:?}"
         )?;
 
         Ok(())

--- a/crates/shared/src/sources/balancer_v2/pool_fetching/registry.rs
+++ b/crates/shared/src/sources/balancer_v2/pool_fetching/registry.rs
@@ -4,7 +4,7 @@
 use {
     super::{internal::InternalPoolFetching, pool_storage::PoolStorage},
     crate::{
-        event_handling::{EventHandler, EventRetrieving, EventStream},
+        event_handling::{AlloyEventRetriever, AlloyEventRetrieving, EventHandler},
         maintenance::Maintaining,
         recent_block_cache::Block,
         sources::balancer_v2::{
@@ -12,10 +12,7 @@ use {
             pools::{FactoryIndexing, Pool, PoolStatus, common::PoolInfoFetching},
         },
     },
-    alloy::{
-        primitives::{B256, b256},
-        rpc::types::Log,
-    },
+    alloy::{contract::Event, providers::DynProvider, rpc::types::Log},
     anyhow::Result,
     contracts::{
         alloy::{
@@ -25,72 +22,32 @@ use {
         errors::EthcontractErrorType,
     },
     ethcontract::{BlockId, H256, errors::MethodError},
-    ethrpc::{
-        alloy::conversions::{IntoAlloy, IntoLegacy},
-        block_stream::{BlockNumberHash, BlockRetrieving, RangeInclusive},
-    },
-    futures::{TryStreamExt, future},
-    itertools::Itertools,
+    ethrpc::block_stream::{BlockNumberHash, BlockRetrieving},
+    futures::future,
     model::TokenPair,
     std::{collections::HashSet, sync::Arc},
     tokio::sync::Mutex,
-    web3::types::Address,
 };
 
 pub struct BasePoolFactoryContract(BalancerV2BasePoolFactory::Instance);
 
-const POOL_CREATED_TOPIC: B256 =
-    b256!("83a48fbcfc991335314e74d0496aab6a1987e992ddc85dddbcc4d6dd6ef2e9fc");
-
 #[async_trait::async_trait]
-impl EventRetrieving for BasePoolFactoryContract {
-    type Event = (PoolCreated, Log);
+impl AlloyEventRetrieving for BasePoolFactoryContract {
+    type Event = PoolCreated;
 
-    async fn get_events_by_block_hash(&self, block_hash: H256) -> Result<Vec<Self::Event>> {
-        self.0
-            .event_filter()
-            .address(*self.0.address())
-            .topic1(POOL_CREATED_TOPIC)
-            .at_block_hash(block_hash.into_alloy())
-            .query()
-            .await
-            .map_err(anyhow::Error::from)
-    }
-
-    async fn get_events_by_block_range(
-        &self,
-        block_range: &RangeInclusive<u64>,
-    ) -> Result<EventStream<Self::Event>> {
-        let stream = self
-            .0
-            .event_filter::<PoolCreated>()
-            .address(*self.0.address())
-            .topic1(POOL_CREATED_TOPIC)
-            .from_block(*block_range.start())
-            .to_block(*block_range.end())
-            .watch()
-            .await
-            .map_err(anyhow::Error::from)?
-            .into_stream()
-            .map_err(anyhow::Error::from);
-
-        Ok(Box::pin(stream))
-    }
-
-    fn address(&self) -> Vec<Address> {
-        self.0
-            .event_filter::<PoolCreated>()
-            .filter
-            .address
-            .iter()
-            .map(|addr| addr.into_legacy())
-            .collect_vec()
+    fn get_events(&self) -> Event<&DynProvider, Self::Event> {
+        self.0.PoolCreated_filter()
     }
 }
 
 /// Type alias for the internal event updater type.
-type PoolUpdater<Factory> =
-    Mutex<EventHandler<BasePoolFactoryContract, PoolStorage<Factory>, (PoolCreated, Log)>>;
+type PoolUpdater<Factory> = Mutex<
+    EventHandler<
+        AlloyEventRetriever<BasePoolFactoryContract>,
+        PoolStorage<Factory>,
+        (PoolCreated, Log),
+    >,
+>;
 
 /// The Pool Registry maintains an event handler for each of the Balancer Pool
 /// Factory contracts and maintains a `PoolStorage` for each.
@@ -120,7 +77,7 @@ where
     ) -> Self {
         let updater = Mutex::new(EventHandler::new(
             block_retreiver,
-            BasePoolFactoryContract(base_pool_factory(factory_instance)),
+            AlloyEventRetriever(BasePoolFactoryContract(base_pool_factory(factory_instance))),
             PoolStorage::new(initial_pools, fetcher.clone()),
             start_sync_at_block,
         ));

--- a/playground/Dockerfile.cowswap
+++ b/playground/Dockerfile.cowswap
@@ -1,5 +1,5 @@
 # Stage 1: Build the frontend
-FROM docker.io/node:22-bullseye-slim as node-build
+FROM docker.io/node:22-bookworm-slim AS node-build
 WORKDIR /usr/src/app
 
 # RPC URL args

--- a/playground/Dockerfile.explorer
+++ b/playground/Dockerfile.explorer
@@ -1,5 +1,5 @@
 # Stage 1: Build the frontend
-FROM --platform=linux/amd64 docker.io/node:16-bullseye-slim as node-build
+FROM docker.io/node:22-bookworm-slim as node-build
 WORKDIR /usr/src/app
 
 # RPC URL args
@@ -12,11 +12,10 @@ ARG REACT_APP_ORDER_BOOK_URLS='{"1":"https://api.cow.fi/mainnet","100":"https://
 
 # Install dependencies
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked apt-get update && \
-    apt-get install -y git libssl-dev pkg-config git autoconf automake file g++ libtool make nasm libpng-dev optipng
-
+    apt-get install -y git libssl-dev pkg-config git autoconf automake file g++ libtool make python3
 
 # Clone the repo to the present working directory
-RUN git clone https://github.com/cowprotocol/explorer . && \
+RUN git clone https://github.com/cowprotocol/cowswap . && \
     git submodule update --init --recursive
 
 # Install npm dependencies
@@ -56,10 +55,10 @@ RUN if [ -n "$ETH_RPC_URL" ]; then \
     fi
 
 # Build the frontend
-RUN APP_ID=1 yarn build
+RUN APP_ID=1 yarn build:explorer
 
 # Stage 2: Copy the frontend to the nginx container
-FROM docker.io/nginx:1.21-alpine as frontend
-COPY --from=node-build /usr/src/app/dist /usr/share/nginx/html
+FROM docker.io/nginx:1.21-alpine AS frontend
+COPY --from=node-build /usr/src/app/build/explorer /usr/share/nginx/html
 EXPOSE 80
 CMD ["nginx", "-g", "daemon off;"]

--- a/playground/README.md
+++ b/playground/README.md
@@ -40,6 +40,7 @@ Now with Rabby configured, and the services started, you can browse to http://lo
 > Initially you will start with 10000 ETH, to run proper transaction you will need to wrap some ETH first.
 > The EthFlow is not configured by default, the next section explains how to set it up.
 > You can follow along with watching the logs of the `autopilot`, `driver`, and `baseline` solver to see how the Protocol interacts.
+> The CoW Explorer is avialable at http://localhost:8001 to see more information about transaction status
 
 ### Resetting the playground
 

--- a/playground/docker-compose.fork.yml
+++ b/playground/docker-compose.fork.yml
@@ -99,7 +99,7 @@ services:
     restart: always
     environment:
       - DB_URL=postgres://db:5432/?user=${POSTGRES_USER}&password=${POSTGRES_PASSWORD}
-      - LOG_FILTER=warn,autopilot=trace,shared=info,shared::price_estimation=debug
+      - LOG_FILTER=warn,autopilot=info,shared=info,shared::price_estimation=info
       - NODE_URL=http://chain:8545
       - SIMULATION_NODE_URL=http://chain:8545
       - SETTLE_INTERVAL=15s


### PR DESCRIPTION
# Description
In #3653, the `AlloyEventRetrieving` interface was implemented in a way to support subscription to a single SC event type. While this works fine with BalancerV2 SC, it is not the case for other SCs, such as UniV3, etc. This PR changes the `AlloyEventRetrieving` interface in a way that explicit `Filter` is provided. While this is less convinient approach for SC with a single event, it scales well for other SCs with multiple event types. That is the most concise approach I've found so far. The alloy team asked to open an issue to find or implement a better workaround.

## How to test
Existing tests. Mainnet shadow.