### PR TITLE
Retry mechanism for settlement indexing

### DIFF
--- a/crates/autopilot/src/domain/settlement/mod.rs
+++ b/crates/autopilot/src/domain/settlement/mod.rs
@@ -58,6 +58,10 @@ pub struct Settlement {
 }
 
 impl Settlement {
+    pub fn auction_id(&self) -> i64 {
+        self.auction.id
+    }
+
     pub fn solver(&self) -> eth::Address {
         self.solver
     }

--- a/crates/autopilot/src/domain/settlement/observer.rs
+++ b/crates/autopilot/src/domain/settlement/observer.rs
@@ -57,7 +57,7 @@ impl Observer {
                 }
                 Ok(IndexSuccess::SkippedInvalidTransaction) => {
                     tracing::warn!("stored default values for unindexable transaction");
-                    break;
+                    continue;
                 }
                 Err(err) => {
                     tracing::debug!(?err, "encountered retryable error");

--- a/crates/autopilot/src/domain/settlement/observer.rs
+++ b/crates/autopilot/src/domain/settlement/observer.rs
@@ -12,16 +12,25 @@
 
 use {
     crate::{
-        domain::settlement::{self},
+        domain::{
+            eth,
+            settlement::{self, Settlement},
+        },
         infra,
     },
-    anyhow::{Result, anyhow},
+    anyhow::{Context, Result, anyhow},
 };
 
 #[derive(Clone)]
 pub struct Observer {
     eth: infra::Ethereum,
     persistence: infra::Persistence,
+}
+
+enum IndexSuccess {
+    NothingToDo,
+    IndexedSettlement,
+    SkippedInvalidTransaction,
 }
 
 impl Observer {
@@ -37,18 +46,22 @@ impl Observer {
     pub async fn update(&self) {
         loop {
             match self.single_update().await {
-                Ok(true) => {
+                Ok(IndexSuccess::IndexedSettlement) => {
                     tracing::debug!("on settlement event updater ran and processed event");
                     // There might be more pending updates, continue immediately.
                     continue;
                 }
-                Ok(false) => {
+                Ok(IndexSuccess::NothingToDo) => {
                     tracing::debug!("on settlement event updater ran without update");
                     break;
                 }
-                Err(err) => {
-                    tracing::error!(?err, "on settlement event update task failed");
+                Ok(IndexSuccess::SkippedInvalidTransaction) => {
+                    tracing::warn!("stored default values for unindexable transaction");
                     break;
+                }
+                Err(err) => {
+                    tracing::debug!(?err, "encountered retryable error");
+                    continue;
                 }
             }
         }
@@ -57,16 +70,41 @@ impl Observer {
     /// Update database for settlement events that have not been processed yet.
     ///
     /// Returns whether an update was performed.
-    async fn single_update(&self) -> Result<bool> {
+    async fn single_update(&self) -> Result<IndexSuccess> {
         // Find a settlement event that has not been processed yet.
-        let Some(event) = self.persistence.get_settlement_without_auction().await? else {
-            return Ok(false);
+        let Some(event) = self
+            .persistence
+            .get_settlement_without_auction()
+            .await
+            .context("failed to fetch unprocessed tx from DB")?
+        else {
+            return Ok(IndexSuccess::NothingToDo);
         };
 
-        tracing::debug!(tx = ?event.transaction, "updating settlement details");
+        tracing::debug!(tx = ?event.transaction, "found unprocessed settlement");
 
-        // Reconstruct the settlement transaction based on the transaction hash
-        let transaction = match self.eth.transaction(event.transaction).await {
+        let settlement_data = self
+            .fetch_auction_data_for_transaction(event.transaction)
+            .await?;
+        self.persistence
+            .save_settlement(event, settlement_data.as_ref())
+            .await
+            .context("failed to update settlement")?;
+
+        match settlement_data {
+            None => Ok(IndexSuccess::SkippedInvalidTransaction),
+            Some(_) => Ok(IndexSuccess::IndexedSettlement),
+        }
+    }
+
+    /// Inspects the calldata of the transaction, decodes the arguments, and
+    /// finds off-chain data associated with it based on the attached auction_id
+    /// bytes.
+    async fn fetch_auction_data_for_transaction(
+        &self,
+        tx: eth::TxId,
+    ) -> Result<Option<Settlement>> {
+        let transaction = match self.eth.transaction(tx).await {
             Ok(transaction) => {
                 let separator = self.eth.contracts().settlement_domain_separator();
                 let settlement_contract = self.eth.contracts().settlement().address().into();
@@ -79,66 +117,50 @@ impl Observer {
                 .await
             }
             Err(err) => {
-                tracing::warn!(hash = ?event.transaction, ?err, "no tx found");
-                return Ok(false);
+                return Err(anyhow!(format!(
+                    "node could not find the transaction - tx: {tx:?}, err: {err:?}",
+                )));
             }
         };
 
-        // Build the <auction_id, settlement> association
-        let (auction_id, settlement) = match transaction {
+        match transaction {
             Ok(transaction) => {
                 let auction_id = transaction.auction_id;
-                let settlement = match settlement::Settlement::new(
-                    transaction,
-                    &self.persistence,
-                    self.eth.chain(),
-                )
-                .await
+                match settlement::Settlement::new(transaction, &self.persistence, self.eth.chain())
+                    .await
                 {
-                    Ok(settlement) => Some(settlement),
-                    Err(err) if retryable(&err) => return Err(err.into()),
+                    Ok(settlement) => Ok(Some(settlement)),
+                    Err(err) if retryable(&err) => Err(err.into()),
                     Err(err) => {
-                        tracing::warn!(hash = ?event.transaction, ?auction_id, ?err, "invalid settlement");
-                        None
+                        tracing::warn!(?tx, ?auction_id, ?err, "invalid settlement");
+                        Ok(None)
                     }
-                };
-                (auction_id, settlement)
+                }
             }
             Err(err) => {
                 match err {
                     settlement::transaction::Error::MissingCalldata => {
-                        tracing::error!(hash = ?event.transaction, ?err, "invalid settlement transaction")
+                        tracing::error!(?tx, ?err, "invalid settlement transaction");
+                        Ok(None)
                     }
                     settlement::transaction::Error::MissingAuctionId
                     | settlement::transaction::Error::Decoding(_)
                     | settlement::transaction::Error::SignatureRecover(_)
                     | settlement::transaction::Error::OrderUidRecover(_)
                     | settlement::transaction::Error::MissingSolver => {
-                        tracing::warn!(hash = ?event.transaction, ?err, "invalid settlement transaction")
+                        tracing::warn!(?tx, ?err, "invalid settlement transaction");
+                        Ok(None)
                     }
                     settlement::transaction::Error::Authentication(_) => {
-                        tracing::warn!(hash = ?event.transaction, ?err, "failed authentication")
+                        // This has to be a temporary error because the settlement contract
+                        // guarantees that SOME allow listed contract executed the transaction.
+                        Err(anyhow!(format!(
+                            "could not determing solver address - err: {err:?}"
+                        )))
                     }
                 }
-                // default values so we don't get stuck on invalid settlement transactions
-                (0.into(), None)
             }
-        };
-
-        tracing::debug!(hash = ?event.transaction, ?auction_id, "saving settlement details for tx");
-
-        if let Err(err) = self
-            .persistence
-            .save_settlement(event, auction_id, settlement.as_ref())
-            .await
-        {
-            return Err(anyhow!(
-                "save settlement: {:?}, {auction_id}, {err}",
-                event.transaction
-            ));
         }
-
-        Ok(true)
     }
 }
 

--- a/crates/autopilot/src/infra/persistence/mod.rs
+++ b/crates/autopilot/src/infra/persistence/mod.rs
@@ -637,7 +637,6 @@ impl Persistence {
     pub async fn save_settlement(
         &self,
         event: domain::eth::SettlementEvent,
-        auction_id: domain::auction::Id,
         settlement: Option<&domain::settlement::Settlement>,
     ) -> Result<(), DatabaseError> {
         let _timer = Metrics::get()
@@ -649,6 +648,8 @@ impl Persistence {
 
         let block_number = i64::try_from(event.block.0).context("block overflow")?;
         let log_index = i64::try_from(event.log_index).context("log index overflow")?;
+        let auction_id = settlement.map(|s| s.auction_id()).unwrap_or_default();
+        tracing::debug!(hash = ?event.transaction, ?auction_id, "saving settlement details for tx");
 
         database::settlements::update_settlement_auction(
             &mut ex,


### PR DESCRIPTION
# Description
Recently Haris reported that a few settlements were not fully indexed on base. The investigation showed that there were temporary nodes issues that caused the RPC requests to time out.
Due to the lack of a retry mechanism we aborted the indexing process of these auctions fully.

# Changes
- moved logic to aggregate the necessary settlement data into a separate function
- replaced `Result<bool>` with `Result<IndexingSuccess>` to make it clearer in the caller what happened
- propagated all temporary errors (DB or RPC issues) as retryable errors

## How to test
not clear - the error cases are very tedious to mock