### PR TITLE
Migrate HoneyswapRouter to alloy

### DIFF
--- a/crates/contracts/src/alloy.rs
+++ b/crates/contracts/src/alloy.rs
@@ -325,6 +325,12 @@ crate::bindings!(
        GNOSIS => (address!("0x6093AeBAC87d62b1A5a4cEec91204e35020E38bE"))
     }
 );
+crate::bindings!(
+    HoneyswapRouter,
+    crate::deployments! {
+        GNOSIS => (address!("0x1C232F01118CB8B424793ae03F870aa7D0ac7f77"))
+    }
+);
 
 pub use alloy::providers::DynProvider as Provider;
 
@@ -503,6 +509,7 @@ mod tests {
     #[test]
     fn test_has_address() {
         assert!(BaoswapRouter::deployment_address(&GNOSIS).is_some());
+        assert!(HoneyswapRouter::deployment_address(&GNOSIS).is_some());
     }
 
     #[test]

--- a/crates/contracts/src/lib.rs
+++ b/crates/contracts/src/lib.rs
@@ -67,7 +67,6 @@ include_contracts! {
     FlashLoanRouter;
     GPv2AllowListAuthentication;
     GPv2Settlement;
-    HoneyswapRouter;
     HooksTrampoline;
     IAavePool;
     IFlashLoanSolverWrapper;
@@ -227,9 +226,6 @@ mod tests {
         for network in &[MAINNET, GNOSIS, ARBITRUM_ONE] {
             assert_has_deployment_address!(SwaprRouter for *network);
         }
-
-        // only gnosis
-        assert_has_deployment_address!(HoneyswapRouter for GNOSIS);
 
         // only sepolia
         assert_has_deployment_address!(TestnetUniswapV2Router02 for SEPOLIA);

--- a/crates/driver/src/infra/liquidity/config.rs
+++ b/crates/driver/src/infra/liquidity/config.rs
@@ -1,6 +1,6 @@
 use {
     crate::{
-        domain::{eth, eth::ContractAddress},
+        domain::eth::{self, ContractAddress},
         infra::blockchain::contracts::deployment_address,
     },
     alloy::primitives::Address,
@@ -9,7 +9,7 @@ use {
     ethrpc::alloy::conversions::IntoLegacy,
     hex_literal::hex,
     reqwest::Url,
-    shared::sources::uniswap_v2::BAOSWAP_INIT,
+    shared::sources::uniswap_v2::{BAOSWAP_INIT, HONEYSWAP_INIT},
     std::{collections::HashSet, time::Duration},
 };
 
@@ -78,9 +78,10 @@ impl UniswapV2 {
     /// Returns the liquidity configuration for Honeyswap.
     pub fn honeyswap(chain: Chain) -> Option<Self> {
         Some(Self {
-            router: deployment_address(contracts::HoneyswapRouter::raw_contract(), chain)?,
-            pool_code: hex!("3f88503e8580ab941773b59034fb4b2a63e86dbc031b3633a925533ad3ed2b93")
-                .into(),
+            router: ContractAddress::from(
+                contracts::alloy::BaoswapRouter::deployment_address(&chain.id())?.into_legacy(),
+            ),
+            pool_code: HONEYSWAP_INIT.into(),
             missing_pool_cache_time: Duration::from_secs(60 * 60),
         })
     }

--- a/crates/shared/src/sources/swapr.rs
+++ b/crates/shared/src/sources/swapr.rs
@@ -57,13 +57,8 @@ mod tests {
             recent_block_cache::Block,
             sources::{BaselineSource, uniswap_v2},
         },
-        alloy::{
-            primitives::{Address, address},
-            providers::Provider,
-        },
         contracts::errors::testing_contract_error,
         ethcontract::H160,
-        ethrpc::alloy::conversions::{IntoAlloy, IntoLegacy},
         maplit::hashset,
     };
 
@@ -103,47 +98,6 @@ mod tests {
             )
             .unwrap()
             .is_none()
-        );
-    }
-
-    const GNOSIS_CHAIN_WETH: Address = address!("6A023CCd1ff6F2045C3309768eAd9E68F978f6e1");
-    const GNOSIS_CHAIN_WXDAI: Address = address!("e91D153E0b41518A2Ce8Dd3D7944Fa863463a97d");
-
-    #[tokio::test]
-    #[ignore]
-    async fn fetch_baoswap_pool() {
-        let web3 = Web3::new_from_env();
-        let version = web3.alloy.get_chain_id().await.unwrap().to_string();
-        let pool_fetcher = uniswap_v2::UniV2BaselineSourceParameters::from_baseline_source(
-            BaselineSource::Baoswap,
-            &version,
-        )
-        .unwrap()
-        .into_source(&web3)
-        .await
-        .unwrap()
-        .pool_fetching;
-        let pool = pool_fetcher
-            .fetch(
-                hashset! {
-                    TokenPair::new(
-                        GNOSIS_CHAIN_WETH.into_legacy(),
-                        GNOSIS_CHAIN_WXDAI.into_legacy(),
-                    )
-                    .unwrap(),
-                },
-                Block::Recent,
-            )
-            .await
-            .unwrap()
-            .into_iter()
-            .next()
-            .unwrap();
-
-        println!("WETH <> wxDAI pool: {pool:#?}");
-        assert_eq!(
-            pool.address.into_alloy(),
-            address!("8c36f7ca02d50bf8e705f582328b873acbe9438d")
         );
     }
 

--- a/crates/shared/src/sources/uniswap_v2/mod.rs
+++ b/crates/shared/src/sources/uniswap_v2/mod.rs
@@ -65,6 +65,8 @@ impl UniV2BaselineSourceParameters {
     pub fn from_baseline_source(source: BaselineSource, chain: &str) -> Option<Self> {
         use BaselineSource as BS;
 
+        let chain_id = chain.parse::<u64>().expect("chain id should be an integer");
+
         let (contract, init_code_digest, pool_reading) = match source {
             BS::None | BS::BalancerV2 | BS::ZeroEx | BS::UniswapV3 => None,
             BS::UniswapV2 => Some((
@@ -72,11 +74,14 @@ impl UniV2BaselineSourceParameters {
                 UNISWAP_INIT,
                 PoolReadingStyle::Default,
             )),
-            BS::Honeyswap => Some((
-                contracts::HoneyswapRouter::raw_contract(),
-                HONEYSWAP_INIT,
-                PoolReadingStyle::Default,
-            )),
+            BS::Honeyswap => {
+                return Some(Self {
+                    router: contracts::alloy::HoneyswapRouter::deployment_address(&chain_id)
+                        .map(IntoLegacy::into_legacy)?,
+                    init_code_digest: H256(HONEYSWAP_INIT),
+                    pool_reading: PoolReadingStyle::Default,
+                });
+            }
             BS::SushiSwap => Some((
                 contracts::SushiSwapRouter::raw_contract(),
                 SUSHISWAP_INIT,
@@ -94,10 +99,8 @@ impl UniV2BaselineSourceParameters {
             )),
             BS::Baoswap => {
                 return Some(Self {
-                    router: contracts::alloy::BaoswapRouter::deployment_address(
-                        &chain.parse::<u64>().expect("chain id should be an integer"),
-                    )
-                    .map(|address| address.into_legacy())?,
+                    router: contracts::alloy::BaoswapRouter::deployment_address(&chain_id)
+                        .map(IntoLegacy::into_legacy)?,
                     init_code_digest: H256(BAOSWAP_INIT),
                     pool_reading: PoolReadingStyle::Default,
                 });
@@ -173,7 +176,17 @@ impl FromStr for UniV2BaselineSourceParameters {
 
 #[cfg(test)]
 mod tests {
-    use {super::*, model::TokenPair};
+    use {
+        super::*,
+        crate::recent_block_cache::Block,
+        alloy::{
+            primitives::{Address, address},
+            providers::Provider,
+        },
+        ethrpc::alloy::conversions::IntoAlloy,
+        maplit::hashset,
+        model::TokenPair,
+    };
 
     #[test]
     fn parse_address_init() {
@@ -295,5 +308,82 @@ mod tests {
             addr!("4505b262dc053998c10685dc5f9098af8ae5c8ad"),
         )
         .await;
+    }
+
+    const GNOSIS_CHAIN_WETH: Address = address!("6A023CCd1ff6F2045C3309768eAd9E68F978f6e1");
+    const GNOSIS_CHAIN_WXDAI: Address = address!("e91D153E0b41518A2Ce8Dd3D7944Fa863463a97d");
+
+    #[tokio::test]
+    #[ignore]
+    async fn fetch_baoswap_pool() {
+        let web3 = Web3::new_from_env();
+        let version = web3.alloy.get_chain_id().await.unwrap().to_string();
+        let pool_fetcher =
+            UniV2BaselineSourceParameters::from_baseline_source(BaselineSource::Baoswap, &version)
+                .unwrap()
+                .into_source(&web3)
+                .await
+                .unwrap()
+                .pool_fetching;
+        let pool = pool_fetcher
+            .fetch(
+                hashset! {
+                    TokenPair::new(
+                        GNOSIS_CHAIN_WETH.into_legacy(),
+                        GNOSIS_CHAIN_WXDAI.into_legacy(),
+                    )
+                    .unwrap(),
+                },
+                Block::Recent,
+            )
+            .await
+            .unwrap()
+            .into_iter()
+            .next()
+            .unwrap();
+
+        println!("WETH <> wxDAI pool: {pool:#?}");
+        assert_eq!(
+            pool.address.into_alloy(),
+            address!("8c36f7ca02d50bf8e705f582328b873acbe9438d")
+        );
+    }
+
+    #[tokio::test]
+    #[ignore]
+    async fn fetch_honeyswap_pool() {
+        let web3 = Web3::new_from_env();
+        let version = web3.alloy.get_chain_id().await.unwrap().to_string();
+        let pool_fetcher = UniV2BaselineSourceParameters::from_baseline_source(
+            BaselineSource::Honeyswap,
+            &version,
+        )
+        .unwrap()
+        .into_source(&web3)
+        .await
+        .unwrap()
+        .pool_fetching;
+        let pool = pool_fetcher
+            .fetch(
+                hashset! {
+                    TokenPair::new(
+                        GNOSIS_CHAIN_WETH.into_legacy(),
+                        GNOSIS_CHAIN_WXDAI.into_legacy(),
+                    )
+                    .unwrap(),
+                },
+                Block::Recent,
+            )
+            .await
+            .unwrap()
+            .into_iter()
+            .next()
+            .unwrap();
+
+        println!("WETH <> wxDAI pool: {pool:#?}");
+        assert_eq!(
+            pool.address.into_alloy(),
+            address!("7bea4af5d425f2d4485bdad1859c88617df31a67")
+        );
     }
 }


### PR DESCRIPTION
# Description
Migrates the HoneyswapRouter SC to alloy

# Changes
- [ ] Moves the previous baoswap test (it was in the swapr context which is wrong)
- [ ] Adds a similar test for the HoneyswapRouter
- [ ] Migrates the HoneyswapRouter bindings to alloy

## How to test
`fetch_honeyswap_pool` & the other tests

<!--
## Related Issues

Fixes #
-->