### PR TITLE
Add DB config to the CoW AMM indexer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2117,6 +2117,7 @@ dependencies = [
  "hex-literal",
  "model",
  "shared",
+ "sqlx",
  "tokio",
  "tracing",
 ]
@@ -2561,6 +2562,7 @@ dependencies = [
  "shared",
  "solver",
  "solvers-dto",
+ "sqlx",
  "tap",
  "tempfile",
  "thiserror 1.0.61",

--- a/crates/autopilot/src/run.rs
+++ b/crates/autopilot/src/run.rs
@@ -460,15 +460,10 @@ pub async fn run(args: Arguments) {
         boundary::web3_client(url, &args.shared.ethrpc)
     });
 
-    let mut cow_amm_registry = cow_amm::Registry::new(archive_node_web3);
+    let mut cow_amm_registry = cow_amm::Registry::new(archive_node_web3, db.pool.clone());
     for config in &args.cow_amm_configs {
         cow_amm_registry
-            .add_listener(
-                config.index_start,
-                config.factory,
-                config.helper,
-                db.pool.clone(),
-            )
+            .add_listener(config.index_start, config.factory, config.helper)
             .await;
     }
 

--- a/crates/autopilot/src/run.rs
+++ b/crates/autopilot/src/run.rs
@@ -463,7 +463,12 @@ pub async fn run(args: Arguments) {
     let mut cow_amm_registry = cow_amm::Registry::new(archive_node_web3);
     for config in &args.cow_amm_configs {
         cow_amm_registry
-            .add_listener(config.index_start, config.factory, config.helper)
+            .add_listener(
+                config.index_start,
+                config.factory,
+                config.helper,
+                db.pool.clone(),
+            )
             .await;
     }
 

--- a/crates/cow-amm/Cargo.toml
+++ b/crates/cow-amm/Cargo.toml
@@ -12,6 +12,7 @@ ethcontract = { workspace = true }
 ethrpc = { workspace = true }
 model = { workspace = true }
 shared = { workspace = true }
+sqlx = { workspace = true }
 tokio = { workspace = true, features = [] }
 tracing = { workspace = true }
 hex = { workspace = true }

--- a/crates/cow-amm/src/cache.rs
+++ b/crates/cow-amm/src/cache.rs
@@ -4,7 +4,6 @@ use {
     ethcontract::{Address, errors::ExecutionError},
     ethrpc::block_stream::RangeInclusive,
     shared::event_handling::EventStoring,
-    sqlx::PgPool,
     std::{collections::BTreeMap, sync::Arc},
     tokio::sync::RwLock,
 };
@@ -13,10 +12,9 @@ use {
 pub(crate) struct Storage(Arc<Inner>);
 
 impl Storage {
-    pub(crate) fn new(deployment_block: u64, helper: CowAmmLegacyHelper, db: PgPool) -> Self {
+    pub(crate) fn new(deployment_block: u64, helper: CowAmmLegacyHelper) -> Self {
         Self(Arc::new(Inner {
             cache: Default::default(),
-            db,
             // make sure to start 1 block **before** the deployment to get all the events
             start_of_index: deployment_block - 1,
             helper,
@@ -44,9 +42,6 @@ struct Inner {
     /// That type erasure allows us to index multiple concrete contracts
     /// in a single Registry to make for a nicer user facing API.
     cache: RwLock<BTreeMap<u64, Vec<Arc<Amm>>>>,
-    /// Database connection to persist CoW AMMs and the last indexed block.
-    #[allow(dead_code)]
-    db: PgPool,
     /// The earliest block where indexing the contract makes sense.
     /// The contract did not emit any events before this block.
     start_of_index: u64,

--- a/crates/cow-amm/src/cache.rs
+++ b/crates/cow-amm/src/cache.rs
@@ -4,6 +4,7 @@ use {
     ethcontract::{Address, errors::ExecutionError},
     ethrpc::block_stream::RangeInclusive,
     shared::event_handling::EventStoring,
+    sqlx::PgPool,
     std::{collections::BTreeMap, sync::Arc},
     tokio::sync::RwLock,
 };
@@ -12,9 +13,10 @@ use {
 pub(crate) struct Storage(Arc<Inner>);
 
 impl Storage {
-    pub(crate) fn new(deployment_block: u64, helper: CowAmmLegacyHelper) -> Self {
+    pub(crate) fn new(deployment_block: u64, helper: CowAmmLegacyHelper, db: PgPool) -> Self {
         Self(Arc::new(Inner {
             cache: Default::default(),
+            db,
             // make sure to start 1 block **before** the deployment to get all the events
             start_of_index: deployment_block - 1,
             helper,
@@ -42,6 +44,9 @@ struct Inner {
     /// That type erasure allows us to index multiple concrete contracts
     /// in a single Registry to make for a nicer user facing API.
     cache: RwLock<BTreeMap<u64, Vec<Arc<Amm>>>>,
+    /// Database connection to persist CoW AMMs and the last indexed block.
+    #[allow(dead_code)]
+    db: PgPool,
     /// The earliest block where indexing the contract makes sense.
     /// The contract did not emit any events before this block.
     start_of_index: u64,

--- a/crates/cow-amm/src/registry.rs
+++ b/crates/cow-amm/src/registry.rs
@@ -39,10 +39,12 @@ impl Registry {
         deployment_block: u64,
         factory: Address,
         helper_contract: Address,
+        db: sqlx::PgPool,
     ) {
         let storage = Storage::new(
             deployment_block,
             CowAmmLegacyHelper::at(&self.web3, helper_contract),
+            db,
         );
         self.storage.write().await.push(storage.clone());
 

--- a/crates/driver/Cargo.toml
+++ b/crates/driver/Cargo.toml
@@ -50,6 +50,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 serde_with = { workspace = true }
 solvers-dto = { path = "../solvers-dto" }
+sqlx = { workspace = true }
 tap = "1.0.1"
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread", "signal", "time"] }

--- a/crates/driver/example.toml
+++ b/crates/driver/example.toml
@@ -1,4 +1,5 @@
-db-url = "postgres://"
+## Currently only required for CoW AMMs
+#db-url = "postgres://"
 
 [[solver]]
 name = "mysolver" # Arbitrary name given to this solver, must be unique
@@ -44,13 +45,14 @@ flashloan-router = "0x0000000000000000000000000000000000000000"
 lender = "0x0000000000000000000000000000000000000000"
 helper-contract = "0x0000000000000000000000000000000000000000"
 
-[[contracts.cow-amms]]
-# address of factory creating new CoW AMMs
-factory = "0x86f3df416979136cb4fdea2c0886301b911c163b"
-# address of contract to help interfacing with the created CoW AMMs
-helper = "0x86f3df416979136cb4fdea2c0886301b911c163b"
-# at which block the driver should start indexing the factory (1 block before deployment)
-index-start = 20188649
+## This config requires db-url to be configured on the top level
+#[[contracts.cow-amms]]
+## address of factory creating new CoW AMMs
+#factory = "0x86f3df416979136cb4fdea2c0886301b911c163b"
+## address of contract to help interfacing with the created CoW AMMs
+#helper = "0x86f3df416979136cb4fdea2c0886301b911c163b"
+## at which block the driver should start indexing the factory (1 block before deployment)
+#index-start = 20188649
 
 [liquidity]
 base-tokens = [

--- a/crates/driver/example.toml
+++ b/crates/driver/example.toml
@@ -1,3 +1,5 @@
+db-url = "postgres://"
+
 [[solver]]
 name = "mysolver" # Arbitrary name given to this solver, must be unique
 endpoint = "http://0.0.0.0:7872"

--- a/crates/driver/src/domain/competition/pre_processing.rs
+++ b/crates/driver/src/domain/competition/pre_processing.rs
@@ -338,7 +338,7 @@ impl Utilities {
 
     async fn cow_amm_orders(self: Arc<Self>, auction: Arc<Auction>) -> Arc<Vec<Order>> {
         let _timer = metrics::get().processing_stage_timer("cow_amm_orders");
-        let cow_amms = self.eth.contracts().cow_amm_registry().amms().await;
+        let cow_amms = self.eth.contracts().cow_amms().await;
         let domain_separator = self.eth.contracts().settlement_domain_separator();
         let domain_separator = model::DomainSeparator(domain_separator.0);
         let validator = self.signature_validator.as_ref();

--- a/crates/driver/src/infra/config/file/load.rs
+++ b/crates/driver/src/infra/config/file/load.rs
@@ -410,6 +410,7 @@ pub async fn load(chain: Chain, path: &Path) -> infra::Config {
         gas_estimator: config.gas_estimator,
         order_priority_strategies: config.order_priority_strategies,
         archive_node_url: config.archive_node_url,
+        db_url: config.db_url,
         simulation_bad_token_max_age: config.simulation_bad_token_max_age,
         app_data_fetching: config.app_data_fetching,
     }

--- a/crates/driver/src/infra/config/file/mod.rs
+++ b/crates/driver/src/infra/config/file/mod.rs
@@ -67,6 +67,9 @@ struct Config {
     /// Archive node URL used to index CoW AMM
     archive_node_url: Option<Url>,
 
+    /// Database URL used to store indexed CoW AMMs
+    db_url: Option<Url>,
+
     /// How long should the token quality computed by the simulation
     /// based logic be cached.
     #[serde(

--- a/crates/driver/src/infra/config/mod.rs
+++ b/crates/driver/src/infra/config/mod.rs
@@ -29,6 +29,7 @@ pub struct Config {
     pub contracts: blockchain::contracts::Addresses,
     pub order_priority_strategies: Vec<OrderPriorityStrategy>,
     pub archive_node_url: Option<Url>,
+    pub db_url: Option<Url>,
     pub simulation_bad_token_max_age: Duration,
     pub app_data_fetching: AppDataFetching,
 }

--- a/crates/driver/src/run.rs
+++ b/crates/driver/src/run.rs
@@ -174,6 +174,7 @@ async fn ethereum(config: &infra::Config, ethrpc: blockchain::Rpc) -> Ethereum {
         config.contracts.clone(),
         gas,
         config.archive_node_url.as_ref(),
+        config.db_url.as_ref(),
     )
     .await
 }

--- a/crates/driver/src/tests/setup/solver.rs
+++ b/crates/driver/src/tests/setup/solver.rs
@@ -492,6 +492,7 @@ impl Solver {
             },
             gas,
             None,
+            None,
         )
         .await;
 

--- a/crates/e2e/src/setup/colocation.rs
+++ b/crates/e2e/src/setup/colocation.rs
@@ -226,7 +226,7 @@ factory = "{:?}"
         })
         .unwrap_or_default();
 
-    let db_url = contracts
+    let db_url_config = contracts
         .cow_amm_helper
         .as_ref()
         .map(|_| format!("db-url = \"{LOCAL_DB_URL}\""))
@@ -237,7 +237,7 @@ factory = "{:?}"
 app-data-fetching-enabled = true
 orderbook-url = "http://localhost:8080"
 flashloans-enabled = true
-{db_url}
+{db_url_config}
 
 [gas-estimator]
 estimator = "web3"

--- a/crates/e2e/src/setup/colocation.rs
+++ b/crates/e2e/src/setup/colocation.rs
@@ -231,6 +231,7 @@ factory = "{:?}"
 app-data-fetching-enabled = true
 orderbook-url = "http://localhost:8080"
 flashloans-enabled = true
+db-url = "{LOCAL_DB_URL}"
 
 [gas-estimator]
 estimator = "web3"

--- a/crates/e2e/src/setup/colocation.rs
+++ b/crates/e2e/src/setup/colocation.rs
@@ -226,12 +226,18 @@ factory = "{:?}"
         })
         .unwrap_or_default();
 
+    let db_url = contracts
+        .cow_amm_helper
+        .as_ref()
+        .map(|_| format!("db-url = \"{LOCAL_DB_URL}\")"))
+        .unwrap_or_default();
+
     let base_config = format!(
         r#"
 app-data-fetching-enabled = true
 orderbook-url = "http://localhost:8080"
 flashloans-enabled = true
-db-url = "{LOCAL_DB_URL}"
+{db_url}
 
 [gas-estimator]
 estimator = "web3"

--- a/crates/e2e/src/setup/colocation.rs
+++ b/crates/e2e/src/setup/colocation.rs
@@ -229,7 +229,7 @@ factory = "{:?}"
     let db_url = contracts
         .cow_amm_helper
         .as_ref()
-        .map(|_| format!("db-url = \"{LOCAL_DB_URL}\")"))
+        .map(|_| format!("db-url = \"{LOCAL_DB_URL}\""))
         .unwrap_or_default();
 
     let base_config = format!(

--- a/crates/e2e/src/setup/services.rs
+++ b/crates/e2e/src/setup/services.rs
@@ -36,7 +36,7 @@ pub const AUCTION_ENDPOINT: &str = "/api/v1/auction";
 pub const TRADES_ENDPOINT: &str = "/api/v1/trades";
 pub const VERSION_ENDPOINT: &str = "/api/v1/version";
 pub const SOLVER_COMPETITION_ENDPOINT: &str = "/api/v2/solver_competition";
-const LOCAL_DB_URL: &str = "postgresql://";
+pub const LOCAL_DB_URL: &str = "postgresql://";
 
 fn order_status_endpoint(uid: &OrderUid) -> String {
     format!("/api/v1/orders/{uid}/status")


### PR DESCRIPTION
# Description
Adds a DB instance to the CoW AMM storage that is required to start storing the indexed AMMs in the DB, together with the last indexed block. The instance remains unused, since the functionality will be implemented in future PRs.