### PR TITLE
Migrate UniswapV2Router02 to alloy

### DIFF
--- a/crates/contracts/build.rs
+++ b/crates/contracts/build.rs
@@ -589,21 +589,6 @@ fn main() {
     generate_contract("IUniswapLikePair");
     // EIP-1271 contract - SignatureValidator
     generate_contract("ERC1271SignatureValidator");
-    generate_contract_with_config("UniswapV2Router02", |builder| {
-        // <https://docs.uniswap.org/contracts/v2/reference/smart-contracts/router-02>
-        builder
-            .add_network_str(MAINNET, "0x7a250d5630B4cF539739dF2C5dAcb4c659F2488D")
-            .add_network_str(GOERLI, "0x7a250d5630B4cF539739dF2C5dAcb4c659F2488D")
-            .add_network_str(GNOSIS, "0x1C232F01118CB8B424793ae03F870aa7D0ac7f77")
-            .add_network_str(ARBITRUM_ONE, "0x4752ba5dbc23f44d87826276bf6fd6b1c372ad24")
-            .add_network_str(BASE, "0x4752ba5dbc23f44d87826276bf6fd6b1c372ad24")
-            .add_network_str(SEPOLIA, "0xeE567Fe1712Faf6149d80dA1E6934E354124CfE3")
-            .add_network_str(AVALANCHE, "0x4752ba5dbc23f44d87826276bf6fd6b1c372ad24")
-            .add_network_str(BNB, "0x4752ba5dbc23f44d87826276bf6fd6b1c372ad24")
-            .add_network_str(OPTIMISM, "0x4A7b5Da61326A6379179b40d00F57E5bbDC962c2")
-            .add_network_str(POLYGON, "0xedf6066a2b290C185783862C7F4776A2C8077AD1")
-        // Not available on Lens
-    });
     generate_contract_with_config("UniswapV3SwapRouterV2", |builder| {
         // <https://github.com/Uniswap/v3-periphery/blob/697c2474757ea89fec12a4e6db16a574fe259610/deploys.md>
         builder

--- a/crates/contracts/src/alloy.rs
+++ b/crates/contracts/src/alloy.rs
@@ -413,6 +413,31 @@ crate::bindings!(
         // Not available on Lens
     }
 );
+crate::bindings!(
+    UniswapV2Router02,
+    // <https://docs.uniswap.org/contracts/v2/reference/smart-contracts/router-02>
+    crate::deployments! {
+        // <https://etherscan.io/tx/0x4fc1580e7f66c58b7c26881cce0aab9c3509afe6e507527f30566fbf8039bcd0>
+        MAINNET => address!("0x7a250d5630B4cF539739dF2C5dAcb4c659F2488D"),
+        // <https://gnosisscan.io/tx/0xfcc495cdb313b48bbb0cd0a25cb2e8fd512eb8fb0b15f75947a9d5668e47a918>
+        GNOSIS => address!("0x1C232F01118CB8B424793ae03F870aa7D0ac7f77"),
+        // <https://arbiscan.io/tx/0x630cd9d56a85e1bac7795d254fef861304a6838e28869badef19f19defb48ba6>
+        ARBITRUM_ONE => address!("0x4752ba5dbc23f44d87826276bf6fd6b1c372ad24"),
+        // <https://basescan.org/tx/0x039224ce16ebe5574f51da761acbdfbd21099d6230c39fcd8ff566bbfd6a50a9>
+        BASE => address!("0x4752ba5dbc23f44d87826276bf6fd6b1c372ad24"),
+        // <https://sepolia.etherscan.io/tx/0x92674b51681d2e99e71e03bd387bc0f0e79f2412302b49ed5626d1fa2311bab9>
+        SEPOLIA => address!("0xeE567Fe1712Faf6149d80dA1E6934E354124CfE3"),
+        // <https://snowtrace.io/tx/0x7372f1eedf9d32fb4185d486911f44542723dae766eea04bc3f14724bae9552e>
+        AVALANCHE => address!("0x4752ba5dbc23f44d87826276bf6fd6b1c372ad24"),
+        // <https://bscscan.com/tx/0x9e940f846abea7dcc1f0bd5c261f405c104628c855346f8cac966f52905ee0fa>
+        BNB => address!("0x4752ba5dbc23f44d87826276bf6fd6b1c372ad24"),
+        // <https://optimistic.etherscan.io/tx/0x2dcb9a76100e5be49e89085b87bd447b1966a9d823d5985e1a8197834c60e6bd>
+        OPTIMISM => address!("0x4A7b5Da61326A6379179b40d00F57E5bbDC962c2"),
+        // <https://polygonscan.com/tx/0x66186e0cacd2f6b3ad2eae586bd331daafd0572eb80bf71be694181858198025>
+        POLYGON => address!("0xedf6066a2b290C185783862C7F4776A2C8077AD1"),
+        // Not available on Lens
+    }
+);
 
 pub use alloy::providers::DynProvider as Provider;
 
@@ -628,6 +653,7 @@ mod tests {
             POLYGON,
         ] {
             assert!(UniswapV2Factory::deployment_address(chain_id).is_some());
+            assert!(UniswapV2Router02::deployment_address(chain_id).is_some());
         }
     }
 

--- a/crates/contracts/src/lib.rs
+++ b/crates/contracts/src/lib.rs
@@ -74,7 +74,6 @@ include_contracts! {
     IUniswapLikeRouter;
     IUniswapV3Factory;
     Permit2;
-    UniswapV2Router02;
     UniswapV3Pool;
     UniswapV3QuoterV2;
     UniswapV3SwapRouterV2;
@@ -178,9 +177,6 @@ mod tests {
         }
         for network in &[MAINNET, GNOSIS, SEPOLIA] {
             assert_has_deployment_address!(CowProtocolToken for *network);
-        }
-        for network in &[MAINNET, GNOSIS, ARBITRUM_ONE] {
-            assert_has_deployment_address!(UniswapV2Router02 for *network);
         }
         for network in &[
             MAINNET,

--- a/crates/driver/src/infra/liquidity/config.rs
+++ b/crates/driver/src/infra/liquidity/config.rs
@@ -15,6 +15,7 @@ use {
         SUSHISWAP_INIT,
         SWAPR_INIT,
         TESTNET_UNISWAP_INIT,
+        UNISWAP_INIT,
     },
     std::{collections::HashSet, time::Duration},
 };
@@ -64,9 +65,10 @@ impl UniswapV2 {
     #[allow(clippy::self_named_constructors)]
     pub fn uniswap_v2(chain: Chain) -> Option<Self> {
         Some(Self {
-            router: deployment_address(contracts::UniswapV2Router02::raw_contract(), chain)?,
-            pool_code: hex!("96e8ac4277198ff8b6f785478aa9a39f403cb768dd02cbee326c3e7da348845f")
-                .into(),
+            router: ContractAddress::from(
+                contracts::alloy::UniswapV2Router02::deployment_address(&chain.id())?.into_legacy(),
+            ),
+            pool_code: UNISWAP_INIT.into(),
             missing_pool_cache_time: Duration::from_secs(60 * 60),
         })
     }

--- a/crates/e2e/tests/e2e/limit_orders.rs
+++ b/crates/e2e/tests/e2e/limit_orders.rs
@@ -1,5 +1,6 @@
 use {
     crate::database::AuctionTransaction,
+    ::alloy::primitives::U256,
     bigdecimal::BigDecimal,
     contracts::ERC20,
     database::byte_array::ByteArray,
@@ -9,7 +10,7 @@ use {
         setup::{eth, *},
         tx,
     },
-    ethcontract::{H160, prelude::U256},
+    ethcontract::H160,
     ethrpc::alloy::{
         CallBuilderExt,
         conversions::{IntoAlloy, IntoLegacy},
@@ -124,37 +125,35 @@ async fn single_limit_order_test(web3: Web3) {
         .unwrap();
 
     token_a
-        .approve(
-            onchain.contracts().uniswap_v2_router.address().into_alloy(),
-            eth(1000),
-        )
+        .approve(*onchain.contracts().uniswap_v2_router.address(), eth(1000))
         .from(solver.address().into_alloy())
         .send_and_watch()
         .await
         .unwrap();
 
     token_b
-        .approve(
-            onchain.contracts().uniswap_v2_router.address().into_alloy(),
+        .approve(*onchain.contracts().uniswap_v2_router.address(), eth(1000))
+        .from(solver.address().into_alloy())
+        .send_and_watch()
+        .await
+        .unwrap();
+    onchain
+        .contracts()
+        .uniswap_v2_router
+        .addLiquidity(
+            *token_a.address(),
+            *token_b.address(),
             eth(1000),
+            eth(1000),
+            U256::ZERO,
+            U256::ZERO,
+            solver.address().into_alloy(),
+            U256::MAX,
         )
         .from(solver.address().into_alloy())
         .send_and_watch()
         .await
         .unwrap();
-    tx!(
-        solver.account(),
-        onchain.contracts().uniswap_v2_router.add_liquidity(
-            token_a.address().into_legacy(),
-            token_b.address().into_legacy(),
-            to_wei(1000),
-            to_wei(1000),
-            0_u64.into(),
-            0_u64.into(),
-            solver.address(),
-            U256::max_value(),
-        )
-    );
 
     // Approve GPv2 for trading
 
@@ -250,37 +249,35 @@ async fn two_limit_orders_test(web3: Web3) {
         .unwrap();
 
     token_a
-        .approve(
-            onchain.contracts().uniswap_v2_router.address().into_alloy(),
-            eth(1000),
-        )
+        .approve(*onchain.contracts().uniswap_v2_router.address(), eth(1000))
         .from(solver.address().into_alloy())
         .send_and_watch()
         .await
         .unwrap();
 
     token_b
-        .approve(
-            onchain.contracts().uniswap_v2_router.address().into_alloy(),
+        .approve(*onchain.contracts().uniswap_v2_router.address(), eth(1000))
+        .from(solver.address().into_alloy())
+        .send_and_watch()
+        .await
+        .unwrap();
+    onchain
+        .contracts()
+        .uniswap_v2_router
+        .addLiquidity(
+            *token_a.address(),
+            *token_b.address(),
             eth(1000),
+            eth(1000),
+            U256::ZERO,
+            U256::ZERO,
+            solver.address().into_alloy(),
+            U256::MAX,
         )
         .from(solver.address().into_alloy())
         .send_and_watch()
         .await
         .unwrap();
-    tx!(
-        solver.account(),
-        onchain.contracts().uniswap_v2_router.add_liquidity(
-            token_a.address().into_legacy(),
-            token_b.address().into_legacy(),
-            to_wei(1000),
-            to_wei(1000),
-            0_u64.into(),
-            0_u64.into(),
-            solver.address(),
-            U256::max_value(),
-        )
-    );
 
     // Approve GPv2 for trading
 

--- a/crates/e2e/tests/e2e/partially_fillable_balance.rs
+++ b/crates/e2e/tests/e2e/partially_fillable_balance.rs
@@ -1,9 +1,6 @@
 use {
     ::alloy::primitives::U256,
-    e2e::{
-        setup::{eth, *},
-        tx,
-    },
+    e2e::setup::{eth, *},
     ethrpc::alloy::{
         CallBuilderExt,
         conversions::{IntoAlloy, IntoLegacy},
@@ -46,37 +43,35 @@ async fn test(web3: Web3) {
         .unwrap();
 
     token_a
-        .approve(
-            onchain.contracts().uniswap_v2_router.address().into_alloy(),
-            eth(1000),
-        )
+        .approve(*onchain.contracts().uniswap_v2_router.address(), eth(1000))
         .from(solver.address().into_alloy())
         .send_and_watch()
         .await
         .unwrap();
 
     token_b
-        .approve(
-            onchain.contracts().uniswap_v2_router.address().into_alloy(),
+        .approve(*onchain.contracts().uniswap_v2_router.address(), eth(1000))
+        .from(solver.address().into_alloy())
+        .send_and_watch()
+        .await
+        .unwrap();
+    onchain
+        .contracts()
+        .uniswap_v2_router
+        .addLiquidity(
+            *token_a.address(),
+            *token_b.address(),
             eth(1000),
+            eth(1000),
+            U256::ZERO,
+            U256::ZERO,
+            solver.address().into_alloy(),
+            U256::MAX,
         )
         .from(solver.address().into_alloy())
         .send_and_watch()
         .await
         .unwrap();
-    tx!(
-        solver.account(),
-        onchain.contracts().uniswap_v2_router.add_liquidity(
-            token_a.address().into_legacy(),
-            token_b.address().into_legacy(),
-            to_wei(1000),
-            to_wei(1000),
-            0_u64.into(),
-            0_u64.into(),
-            solver.address(),
-            U256::MAX.into_legacy(),
-        )
-    );
 
     token_a
         .approve(onchain.contracts().allowance.into_alloy(), eth(500))

--- a/crates/e2e/tests/e2e/partially_fillable_pool.rs
+++ b/crates/e2e/tests/e2e/partially_fillable_pool.rs
@@ -1,9 +1,6 @@
 use {
-    e2e::{
-        setup::{eth, *},
-        tx,
-    },
-    ethcontract::prelude::U256,
+    ::alloy::primitives::U256,
+    e2e::setup::{eth, *},
     ethrpc::alloy::{
         CallBuilderExt,
         conversions::{IntoAlloy, IntoLegacy},
@@ -45,37 +42,35 @@ async fn test(web3: Web3) {
         .unwrap();
 
     token_a
-        .approve(
-            onchain.contracts().uniswap_v2_router.address().into_alloy(),
-            eth(1000),
-        )
+        .approve(*onchain.contracts().uniswap_v2_router.address(), eth(1000))
         .from(solver.address().into_alloy())
         .send_and_watch()
         .await
         .unwrap();
 
     token_b
-        .approve(
-            onchain.contracts().uniswap_v2_router.address().into_alloy(),
+        .approve(*onchain.contracts().uniswap_v2_router.address(), eth(1000))
+        .from(solver.address().into_alloy())
+        .send_and_watch()
+        .await
+        .unwrap();
+    onchain
+        .contracts()
+        .uniswap_v2_router
+        .addLiquidity(
+            *token_a.address(),
+            *token_b.address(),
             eth(1000),
+            eth(1000),
+            U256::ZERO,
+            U256::ZERO,
+            solver.address().into_alloy(),
+            U256::MAX,
         )
         .from(solver.address().into_alloy())
         .send_and_watch()
         .await
         .unwrap();
-    tx!(
-        solver.account(),
-        onchain.contracts().uniswap_v2_router.add_liquidity(
-            token_a.address().into_legacy(),
-            token_b.address().into_legacy(),
-            to_wei(1000),
-            to_wei(1000),
-            0_u64.into(),
-            0_u64.into(),
-            solver.address(),
-            U256::max_value(),
-        )
-    );
 
     token_a
         .approve(onchain.contracts().allowance.into_alloy(), eth(500))

--- a/crates/e2e/tests/e2e/protocol_fee.rs
+++ b/crates/e2e/tests/e2e/protocol_fee.rs
@@ -96,20 +96,14 @@ async fn combined_protocol_fees(web3: Web3) {
         token.mint(solver.address(), to_wei(1000)).await;
 
         token
-            .approve(
-                onchain.contracts().uniswap_v2_router.address().into_alloy(),
-                eth(1000),
-            )
+            .approve(*onchain.contracts().uniswap_v2_router.address(), eth(1000))
             .from(solver.address().into_alloy())
             .send_and_watch()
             .await
             .unwrap();
 
         token
-            .approve(
-                onchain.contracts().uniswap_v2_router.address().into_alloy(),
-                eth(100),
-            )
+            .approve(*onchain.contracts().uniswap_v2_router.address(), eth(100))
             .from(trader.address().into_alloy())
             .send_and_watch()
             .await
@@ -130,10 +124,14 @@ async fn combined_protocol_fees(web3: Web3) {
     );
     tx!(
         solver.account(),
-        onchain
-            .contracts()
-            .weth
-            .approve(onchain.contracts().uniswap_v2_router.address(), to_wei(200))
+        onchain.contracts().weth.approve(
+            onchain
+                .contracts()
+                .uniswap_v2_router
+                .address()
+                .into_legacy(),
+            to_wei(200)
+        )
     );
 
     let autopilot_config = vec![
@@ -432,20 +430,14 @@ async fn surplus_partner_fee(web3: Web3) {
     token.mint(solver.address(), to_wei(1000)).await;
 
     token
-        .approve(
-            onchain.contracts().uniswap_v2_router.address().into_alloy(),
-            eth(1000),
-        )
+        .approve(*onchain.contracts().uniswap_v2_router.address(), eth(1000))
         .from(solver.address().into_alloy())
         .send_and_watch()
         .await
         .unwrap();
 
     token
-        .approve(
-            onchain.contracts().uniswap_v2_router.address().into_alloy(),
-            eth(100),
-        )
+        .approve(*onchain.contracts().uniswap_v2_router.address(), eth(100))
         .from(trader.address().into_alloy())
         .send_and_watch()
         .await
@@ -464,10 +456,14 @@ async fn surplus_partner_fee(web3: Web3) {
     );
     tx!(
         solver.account(),
-        onchain
-            .contracts()
-            .weth
-            .approve(onchain.contracts().uniswap_v2_router.address(), to_wei(200))
+        onchain.contracts().weth.approve(
+            onchain
+                .contracts()
+                .uniswap_v2_router
+                .address()
+                .into_legacy(),
+            to_wei(200)
+        )
     );
 
     let services = Services::new(&onchain).await;
@@ -654,37 +650,35 @@ async fn volume_fee_buy_order_test(web3: Web3) {
         .unwrap();
 
     token_gno
-        .approve(
-            onchain.contracts().uniswap_v2_router.address().into_alloy(),
-            eth(1000),
-        )
+        .approve(*onchain.contracts().uniswap_v2_router.address(), eth(1000))
         .from(solver.address().into_alloy())
         .send_and_watch()
         .await
         .unwrap();
 
     token_dai
-        .approve(
-            onchain.contracts().uniswap_v2_router.address().into_alloy(),
+        .approve(*onchain.contracts().uniswap_v2_router.address(), eth(1000))
+        .from(solver.address().into_alloy())
+        .send_and_watch()
+        .await
+        .unwrap();
+    onchain
+        .contracts()
+        .uniswap_v2_router
+        .addLiquidity(
+            *token_gno.address(),
+            *token_dai.address(),
             eth(1000),
+            eth(1000),
+            ::alloy::primitives::U256::ZERO,
+            ::alloy::primitives::U256::ZERO,
+            solver.address().into_alloy(),
+            ::alloy::primitives::U256::MAX,
         )
         .from(solver.address().into_alloy())
         .send_and_watch()
         .await
         .unwrap();
-    tx!(
-        solver.account(),
-        onchain.contracts().uniswap_v2_router.add_liquidity(
-            token_gno.address().into_legacy(),
-            token_dai.address().into_legacy(),
-            to_wei(1000),
-            to_wei(1000),
-            0_u64.into(),
-            0_u64.into(),
-            solver.address(),
-            U256::max_value(),
-        )
-    );
 
     // Approve GPv2 for trading
 

--- a/crates/e2e/tests/e2e/replace_order.rs
+++ b/crates/e2e/tests/e2e/replace_order.rs
@@ -1,10 +1,9 @@
 use {
+    ::alloy::primitives::U256,
     e2e::{
         nodes::local_node::TestNodeApi,
         setup::{eth, *},
-        tx,
     },
-    ethcontract::prelude::U256,
     ethrpc::alloy::{
         CallBuilderExt,
         conversions::{IntoAlloy, IntoLegacy},
@@ -67,37 +66,35 @@ async fn try_replace_unreplaceable_order_test(web3: Web3) {
         .unwrap();
 
     token_a
-        .approve(
-            onchain.contracts().uniswap_v2_router.address().into_alloy(),
-            eth(1000),
-        )
+        .approve(*onchain.contracts().uniswap_v2_router.address(), eth(1000))
         .from(solver.address().into_alloy())
         .send_and_watch()
         .await
         .unwrap();
 
     token_b
-        .approve(
-            onchain.contracts().uniswap_v2_router.address().into_alloy(),
+        .approve(*onchain.contracts().uniswap_v2_router.address(), eth(1000))
+        .from(solver.address().into_alloy())
+        .send_and_watch()
+        .await
+        .unwrap();
+    onchain
+        .contracts()
+        .uniswap_v2_router
+        .addLiquidity(
+            *token_a.address(),
+            *token_b.address(),
             eth(1000),
+            eth(1000),
+            U256::ZERO,
+            U256::ZERO,
+            solver.address().into_alloy(),
+            U256::MAX,
         )
         .from(solver.address().into_alloy())
         .send_and_watch()
         .await
         .unwrap();
-    tx!(
-        solver.account(),
-        onchain.contracts().uniswap_v2_router.add_liquidity(
-            token_a.address().into_legacy(),
-            token_b.address().into_legacy(),
-            to_wei(1000),
-            to_wei(1000),
-            0_u64.into(),
-            0_u64.into(),
-            solver.address(),
-            U256::max_value(),
-        )
-    );
 
     // Approve GPv2 for trading
 
@@ -250,37 +247,35 @@ async fn try_replace_someone_else_order_test(web3: Web3) {
         .unwrap();
 
     token_a
-        .approve(
-            onchain.contracts().uniswap_v2_router.address().into_alloy(),
-            eth(1000),
-        )
+        .approve(*onchain.contracts().uniswap_v2_router.address(), eth(1000))
         .from(solver.address().into_alloy())
         .send_and_watch()
         .await
         .unwrap();
 
     token_b
-        .approve(
-            onchain.contracts().uniswap_v2_router.address().into_alloy(),
+        .approve(*onchain.contracts().uniswap_v2_router.address(), eth(1000))
+        .from(solver.address().into_alloy())
+        .send_and_watch()
+        .await
+        .unwrap();
+    onchain
+        .contracts()
+        .uniswap_v2_router
+        .addLiquidity(
+            *token_a.address(),
+            *token_b.address(),
             eth(1000),
+            eth(1000),
+            U256::ZERO,
+            U256::ZERO,
+            solver.address().into_alloy(),
+            U256::MAX,
         )
         .from(solver.address().into_alloy())
         .send_and_watch()
         .await
         .unwrap();
-    tx!(
-        solver.account(),
-        onchain.contracts().uniswap_v2_router.add_liquidity(
-            token_a.address().into_legacy(),
-            token_b.address().into_legacy(),
-            to_wei(1000),
-            to_wei(1000),
-            0_u64.into(),
-            0_u64.into(),
-            solver.address(),
-            U256::max_value(),
-        )
-    );
 
     // Approve GPv2 for trading
 
@@ -390,37 +385,35 @@ async fn single_replace_order_test(web3: Web3) {
         .unwrap();
 
     token_a
-        .approve(
-            onchain.contracts().uniswap_v2_router.address().into_alloy(),
-            eth(1000),
-        )
+        .approve(*onchain.contracts().uniswap_v2_router.address(), eth(1000))
         .from(solver.address().into_alloy())
         .send_and_watch()
         .await
         .unwrap();
 
     token_b
-        .approve(
-            onchain.contracts().uniswap_v2_router.address().into_alloy(),
+        .approve(*onchain.contracts().uniswap_v2_router.address(), eth(1000))
+        .from(solver.address().into_alloy())
+        .send_and_watch()
+        .await
+        .unwrap();
+    onchain
+        .contracts()
+        .uniswap_v2_router
+        .addLiquidity(
+            *token_a.address(),
+            *token_b.address(),
             eth(1000),
+            eth(1000),
+            U256::ZERO,
+            U256::ZERO,
+            solver.address().into_alloy(),
+            U256::MAX,
         )
         .from(solver.address().into_alloy())
         .send_and_watch()
         .await
         .unwrap();
-    tx!(
-        solver.account(),
-        onchain.contracts().uniswap_v2_router.add_liquidity(
-            token_a.address().into_legacy(),
-            token_b.address().into_legacy(),
-            to_wei(1000),
-            to_wei(1000),
-            0_u64.into(),
-            0_u64.into(),
-            solver.address(),
-            U256::max_value(),
-        )
-    );
 
     // Approve GPv2 for trading
 

--- a/crates/e2e/tests/e2e/solver_participation_guard.rs
+++ b/crates/e2e/tests/e2e/solver_participation_guard.rs
@@ -1,19 +1,17 @@
 use {
-    e2e::{
-        setup::{
-            Db,
-            ExtraServiceArgs,
-            MintableToken,
-            OnchainComponents,
-            Services,
-            TIMEOUT,
-            TestAccount,
-            eth,
-            run_test,
-            to_wei,
-            wait_for_condition,
-        },
-        tx,
+    alloy::primitives::U256,
+    e2e::setup::{
+        Db,
+        ExtraServiceArgs,
+        MintableToken,
+        OnchainComponents,
+        Services,
+        TIMEOUT,
+        TestAccount,
+        eth,
+        run_test,
+        to_wei,
+        wait_for_condition,
     },
     ethrpc::{
         Web3,
@@ -29,10 +27,7 @@ use {
     secp256k1::SecretKey,
     sqlx::Row,
     std::time::Instant,
-    web3::{
-        signing::SecretKeyRef,
-        types::{H160, U256},
-    },
+    web3::{signing::SecretKeyRef, types::H160},
 };
 
 #[tokio::test]
@@ -266,37 +261,35 @@ async fn setup(
         .unwrap();
 
     token_a
-        .approve(
-            onchain.contracts().uniswap_v2_router.address().into_alloy(),
-            eth(1000),
-        )
+        .approve(*onchain.contracts().uniswap_v2_router.address(), eth(1000))
         .from(solver.address().into_alloy())
         .send_and_watch()
         .await
         .unwrap();
 
     token_b
-        .approve(
-            onchain.contracts().uniswap_v2_router.address().into_alloy(),
+        .approve(*onchain.contracts().uniswap_v2_router.address(), eth(1000))
+        .from(solver.address().into_alloy())
+        .send_and_watch()
+        .await
+        .unwrap();
+    onchain
+        .contracts()
+        .uniswap_v2_router
+        .addLiquidity(
+            *token_a.address(),
+            *token_b.address(),
             eth(1000),
+            eth(1000),
+            U256::ZERO,
+            U256::ZERO,
+            solver.address().into_alloy(),
+            U256::MAX,
         )
         .from(solver.address().into_alloy())
         .send_and_watch()
         .await
         .unwrap();
-    tx!(
-        solver.account(),
-        onchain.contracts().uniswap_v2_router.add_liquidity(
-            token_a.address().into_legacy(),
-            token_b.address().into_legacy(),
-            to_wei(1000),
-            to_wei(1000),
-            0_u64.into(),
-            0_u64.into(),
-            solver.address(),
-            U256::max_value(),
-        )
-    );
 
     // Approve GPv2 for trading
 

--- a/crates/shared/src/sources/uniswap_v2/mod.rs
+++ b/crates/shared/src/sources/uniswap_v2/mod.rs
@@ -67,61 +67,45 @@ impl UniV2BaselineSourceParameters {
 
         let chain_id = chain.parse::<u64>().expect("chain id should be an integer");
 
-        let (contract, init_code_digest, pool_reading) = match source {
+        match source {
             BS::None | BS::BalancerV2 | BS::ZeroEx | BS::UniswapV3 => None,
-            BS::UniswapV2 => Some((
-                contracts::UniswapV2Router02::raw_contract(),
-                UNISWAP_INIT,
-                PoolReadingStyle::Default,
-            )),
-            BS::Honeyswap => {
-                return Some(Self {
-                    router: contracts::alloy::HoneyswapRouter::deployment_address(&chain_id)
-                        .map(IntoLegacy::into_legacy)?,
-                    init_code_digest: H256(HONEYSWAP_INIT),
-                    pool_reading: PoolReadingStyle::Default,
-                });
-            }
-            BS::SushiSwap => {
-                return Some(Self {
-                    router: contracts::alloy::SushiSwapRouter::deployment_address(&chain_id)
-                        .map(IntoLegacy::into_legacy)?,
-                    init_code_digest: SUSHISWAP_INIT.into(),
-                    pool_reading: PoolReadingStyle::Default,
-                });
-            }
-            BS::Swapr => {
-                return Some(Self {
-                    router: contracts::alloy::SwaprRouter::deployment_address(&chain_id)
-                        .map(IntoLegacy::into_legacy)?,
-                    init_code_digest: SWAPR_INIT.into(),
-                    pool_reading: PoolReadingStyle::Swapr,
-                });
-            }
-            BS::TestnetUniswapV2 => {
-                return Some(Self {
-                    router: contracts::alloy::TestnetUniswapV2Router02::deployment_address(
-                        &chain_id,
-                    )
+            BS::UniswapV2 => Some(Self {
+                router: contracts::alloy::UniswapV2Router02::deployment_address(&chain_id)
                     .map(IntoLegacy::into_legacy)?,
-                    init_code_digest: TESTNET_UNISWAP_INIT.into(),
-                    pool_reading: PoolReadingStyle::Default,
-                });
-            }
-            BS::Baoswap => {
-                return Some(Self {
-                    router: contracts::alloy::BaoswapRouter::deployment_address(&chain_id)
-                        .map(IntoLegacy::into_legacy)?,
-                    init_code_digest: H256(BAOSWAP_INIT),
-                    pool_reading: PoolReadingStyle::Default,
-                });
-            }
-        }?;
-        Some(Self {
-            router: contract.networks.get(chain)?.address,
-            init_code_digest: H256(init_code_digest),
-            pool_reading,
-        })
+                init_code_digest: UNISWAP_INIT.into(),
+                pool_reading: PoolReadingStyle::Default,
+            }),
+            BS::Honeyswap => Some(Self {
+                router: contracts::alloy::HoneyswapRouter::deployment_address(&chain_id)
+                    .map(IntoLegacy::into_legacy)?,
+                init_code_digest: HONEYSWAP_INIT.into(),
+                pool_reading: PoolReadingStyle::Default,
+            }),
+            BS::SushiSwap => Some(Self {
+                router: contracts::alloy::SushiSwapRouter::deployment_address(&chain_id)
+                    .map(IntoLegacy::into_legacy)?,
+                init_code_digest: SUSHISWAP_INIT.into(),
+                pool_reading: PoolReadingStyle::Default,
+            }),
+            BS::Swapr => Some(Self {
+                router: contracts::alloy::SwaprRouter::deployment_address(&chain_id)
+                    .map(IntoLegacy::into_legacy)?,
+                init_code_digest: SWAPR_INIT.into(),
+                pool_reading: PoolReadingStyle::Swapr,
+            }),
+            BS::TestnetUniswapV2 => Some(Self {
+                router: contracts::alloy::TestnetUniswapV2Router02::deployment_address(&chain_id)
+                    .map(IntoLegacy::into_legacy)?,
+                init_code_digest: TESTNET_UNISWAP_INIT.into(),
+                pool_reading: PoolReadingStyle::Default,
+            }),
+            BS::Baoswap => Some(Self {
+                router: contracts::alloy::BaoswapRouter::deployment_address(&chain_id)
+                    .map(IntoLegacy::into_legacy)?,
+                init_code_digest: BAOSWAP_INIT.into(),
+                pool_reading: PoolReadingStyle::Default,
+            }),
+        }
     }
 
     pub async fn into_source(&self, web3: &Web3) -> Result<UniV2BaselineSource> {


### PR DESCRIPTION
# Description
Migrates the UniswapV2Router02 to alloy

PR is a bit fat but was not able to put it on a diet, most of the changes are tests though.

# Changes
<!-- List of detailed changes (how the change is accomplished) -->

- [ ] Removes the old bindings
- [ ] Adds the new bindings
- [ ] Migrates a bunch of tests

## How to test
Existing tests

<!--
## Related Issues

Fixes #
-->