### PR TITLE
Filter UniV3 LPs based on raw liquidity

### DIFF
--- a/crates/shared/src/sources/uniswap_v3/graph_api.rs
+++ b/crates/shared/src/sources/uniswap_v3/graph_api.rs
@@ -123,7 +123,7 @@ impl UniV3SubgraphClient {
             .paginated_query(query, variables)
             .await?
             .into_iter()
-            .filter(|pool: &PoolData| !pool.liquidity.is_zero())
+            .filter(|pool: &PoolData| pool.liquidity > U256::zero())
             .collect())
     }
 

--- a/crates/shared/src/sources/uniswap_v3/graph_api.rs
+++ b/crates/shared/src/sources/uniswap_v3/graph_api.rs
@@ -43,7 +43,6 @@ const ALL_POOLS_QUERY: &str = r#"
             liquidity
             sqrtPrice
             tick
-            totalValueLockedETH
         }
     }
 "#;
@@ -75,7 +74,6 @@ const POOLS_BY_IDS_QUERY: &str = r#"
             liquidity
             sqrtPrice
             tick
-            totalValueLockedETH
         }
     }
 "#;
@@ -125,7 +123,7 @@ impl UniV3SubgraphClient {
             .paginated_query(query, variables)
             .await?
             .into_iter()
-            .filter(|pool: &PoolData| pool.total_value_locked_eth.is_normal())
+            .filter(|pool: &PoolData| !pool.liquidity.is_zero())
             .collect())
     }
 
@@ -254,9 +252,6 @@ pub struct PoolData {
     pub sqrt_price: U256,
     #[serde_as(as = "DisplayFromStr")]
     pub tick: BigInt,
-    #[serde_as(as = "DisplayFromStr")]
-    #[serde(rename = "totalValueLockedETH")]
-    pub total_value_locked_eth: f64,
     pub ticks: Option<Vec<TickData>>,
 }
 
@@ -344,7 +339,6 @@ mod tests {
                       "feeTier": "10000",
                       "liquidity": "303015134493562686441",
                       "tick": "-92110",
-                      "totalValueLockedETH": "1.0",
                       "sqrtPrice": "792216481398733702759960397"
                     },
                     {
@@ -362,7 +356,6 @@ mod tests {
                       "feeTier": "3000",
                       "liquidity": "3125586395511534995",
                       "tick": "-189822",
-                      "totalValueLockedETH": "1.0",
                       "sqrtPrice": "5986323062404391218190509"
                     }
                 ],
@@ -387,7 +380,6 @@ mod tests {
                         sqrt_price: U256::from_dec_str("792216481398733702759960397").unwrap(),
                         tick: BigInt::from(-92110),
                         ticks: None,
-                        total_value_locked_eth: 1.0
                     },
                     PoolData {
                         id: H160::from_str("0x0002e63328169d7feea121f1e32e4f620abf0352").unwrap(),
@@ -406,7 +398,6 @@ mod tests {
                         sqrt_price: U256::from_dec_str("5986323062404391218190509").unwrap(),
                         tick: BigInt::from(-189822),
                         ticks: None,
-                        total_value_locked_eth: 1.0
                     },
                 ],
             }

--- a/crates/shared/src/sources/uniswap_v3/pool_fetching.rs
+++ b/crates/shared/src/sources/uniswap_v3/pool_fetching.rs
@@ -139,7 +139,7 @@ impl PoolsCheckpointHandler {
     ) -> Result<Self> {
         let graph_api =
             UniV3SubgraphClient::from_subgraph_url(subgraph_url, client, max_pools_per_tick_query)?;
-        let registered_pools = graph_api.get_registered_pools().await?;
+        let mut registered_pools = graph_api.get_registered_pools().await?;
         tracing::debug!(
             block = %registered_pools.fetched_block_number, pools = %registered_pools.pools.len(),
             "initialized registered pools",
@@ -155,8 +155,12 @@ impl PoolsCheckpointHandler {
         // can't fetch the state of all pools in constructor for performance reasons,
         // so let's fetch the top `max_pools_to_initialize_cache` pools with the highest
         // liquidity
+        registered_pools
+            .pools
+            .sort_unstable_by(|a, b| a.liquidity.partial_cmp(&b.liquidity).unwrap());
         let pool_ids = registered_pools
             .pools
+            .clone()
             .into_iter()
             .map(|pool| pool.id)
             .rev()

--- a/crates/shared/src/sources/uniswap_v3/pool_fetching.rs
+++ b/crates/shared/src/sources/uniswap_v3/pool_fetching.rs
@@ -139,7 +139,7 @@ impl PoolsCheckpointHandler {
     ) -> Result<Self> {
         let graph_api =
             UniV3SubgraphClient::from_subgraph_url(subgraph_url, client, max_pools_per_tick_query)?;
-        let mut registered_pools = graph_api.get_registered_pools().await?;
+        let registered_pools = graph_api.get_registered_pools().await?;
         tracing::debug!(
             block = %registered_pools.fetched_block_number, pools = %registered_pools.pools.len(),
             "initialized registered pools",
@@ -155,11 +155,6 @@ impl PoolsCheckpointHandler {
         // can't fetch the state of all pools in constructor for performance reasons,
         // so let's fetch the top `max_pools_to_initialize_cache` pools with the highest
         // liquidity
-        registered_pools.pools.sort_unstable_by(|a, b| {
-            a.total_value_locked_eth
-                .partial_cmp(&b.total_value_locked_eth)
-                .unwrap()
-        });
         let pool_ids = registered_pools
             .pools
             .clone()

--- a/crates/shared/src/sources/uniswap_v3/pool_fetching.rs
+++ b/crates/shared/src/sources/uniswap_v3/pool_fetching.rs
@@ -157,7 +157,6 @@ impl PoolsCheckpointHandler {
         // liquidity
         let pool_ids = registered_pools
             .pools
-            .clone()
             .into_iter()
             .map(|pool| pool.id)
             .rev()


### PR DESCRIPTION
# Description
We currently filter UniV3 LPs based on `totalValueLockedETH`, which basically denominates raw `liquidity` in native token. For some of the pools, the subgraph shows `totalValueLockedETH=0`, which means that it can't find a path to denominate some tokens from the pool in the native token. That keeps some of the non-empty LPs unindexed.

# Changes
Instead, rely on the raw `liquidity` value. We currently check for `totalValueLockedETH.is_normal()`, which allows up to the smallest possible f64, which is `~2.2250738585072014 × 10⁻³⁰⁸`, so using the raw liquidity amount shouldn't change any logic.

## How to test
Existing tests.
