### PR TITLE
Remove driver CoW AMM indexer

### DIFF
--- a/crates/autopilot/src/domain/auction/mod.rs
+++ b/crates/autopilot/src/domain/auction/mod.rs
@@ -15,7 +15,7 @@ pub struct RawAuctionData {
     pub block: u64,
     pub orders: Vec<Order>,
     pub prices: Prices,
-    pub surplus_capturing_jit_order_owners: Vec<eth::Address>,
+    pub surplus_capturing_jit_order_owners_by_helper: HashMap<eth::Address, Vec<eth::Address>>,
 }
 
 pub type Id = i64;
@@ -26,7 +26,7 @@ pub struct Auction {
     pub block: u64,
     pub orders: Vec<Order>,
     pub prices: Prices,
-    pub surplus_capturing_jit_order_owners: Vec<eth::Address>,
+    pub surplus_capturing_jit_order_owners_by_helper: HashMap<eth::Address, Vec<eth::Address>>,
 }
 
 impl PartialEq for Auction {
@@ -34,7 +34,8 @@ impl PartialEq for Auction {
         self.block == other.block
             && self.orders == other.orders
             && self.prices == other.prices
-            && self.surplus_capturing_jit_order_owners == other.surplus_capturing_jit_order_owners
+            && self.surplus_capturing_jit_order_owners_by_helper
+                == other.surplus_capturing_jit_order_owners_by_helper
     }
 }
 

--- a/crates/autopilot/src/domain/competition/winner_selection.rs
+++ b/crates/autopilot/src/domain/competition/winner_selection.rs
@@ -385,8 +385,9 @@ impl<'a> From<&'a domain::Auction> for Auction<'a> {
                 .collect(),
             native_prices: &original.prices,
             surplus_capturing_jit_order_owners: original
-                .surplus_capturing_jit_order_owners
-                .iter()
+                .surplus_capturing_jit_order_owners_by_helper
+                .values()
+                .flatten()
                 .cloned()
                 .collect(),
         }
@@ -1349,7 +1350,7 @@ mod tests {
             block: 0,
             orders,
             prices,
-            surplus_capturing_jit_order_owners: vec![],
+            surplus_capturing_jit_order_owners_by_helper: Default::default(),
         }
     }
 

--- a/crates/autopilot/src/infra/persistence/dto/auction.rs
+++ b/crates/autopilot/src/infra/persistence/dto/auction.rs
@@ -24,10 +24,15 @@ pub fn from_domain(auction: domain::RawAuctionData) -> RawAuctionData {
             .into_iter()
             .map(|(key, value)| (key.into(), value.get().into()))
             .collect(),
-        surplus_capturing_jit_order_owners: auction
-            .surplus_capturing_jit_order_owners
+        surplus_capturing_jit_order_owners_by_helper: auction
+            .surplus_capturing_jit_order_owners_by_helper
             .into_iter()
-            .map(Into::into)
+            .map(|(helper, owners)| {
+                (
+                    helper.into(),
+                    owners.into_iter().map(Into::into).collect::<Vec<_>>(),
+                )
+            })
             .collect(),
     }
 }
@@ -41,7 +46,7 @@ pub struct RawAuctionData {
     #[serde_as(as = "BTreeMap<_, HexOrDecimalU256>")]
     pub prices: BTreeMap<H160, U256>,
     #[serde(default)]
-    pub surplus_capturing_jit_order_owners: Vec<H160>,
+    pub surplus_capturing_jit_order_owners_by_helper: Vec<(H160, Vec<H160>)>,
 }
 
 pub type AuctionId = i64;
@@ -74,11 +79,16 @@ impl Auction {
                     Price::try_new(value.into()).map(|price| (eth::TokenAddress(key), price))
                 })
                 .collect::<Result<_, _>>()?,
-            surplus_capturing_jit_order_owners: self
+            surplus_capturing_jit_order_owners_by_helper: self
                 .auction
-                .surplus_capturing_jit_order_owners
+                .surplus_capturing_jit_order_owners_by_helper
                 .into_iter()
-                .map(Into::into)
+                .map(|(helper, owners)| {
+                    (
+                        helper.into(),
+                        owners.into_iter().map(Into::into).collect::<Vec<_>>(),
+                    )
+                })
                 .collect(),
         })
     }

--- a/crates/autopilot/src/infra/persistence/mod.rs
+++ b/crates/autopilot/src/infra/persistence/mod.rs
@@ -195,13 +195,17 @@ impl Persistence {
     pub async fn save_surplus_capturing_jit_order_owners(
         &self,
         auction_id: AuctionId,
-        surplus_capturing_jit_order_owners: &[domain::eth::Address],
+        surplus_capturing_jit_order_owners_by_helper: &HashMap<
+            domain::eth::Address,
+            Vec<domain::eth::Address>,
+        >,
     ) -> Result<(), DatabaseError> {
         self.postgres
             .save_surplus_capturing_jit_order_owners(
                 auction_id,
-                &surplus_capturing_jit_order_owners
-                    .iter()
+                &surplus_capturing_jit_order_owners_by_helper
+                    .values()
+                    .flatten()
                     .map(|address| ByteArray(address.0.into()))
                     .collect::<Vec<_>>(),
             )
@@ -308,8 +312,9 @@ impl Persistence {
                     .map(|price| u256_to_big_decimal(&price.get().0))
                     .collect(),
                 surplus_capturing_jit_order_owners: auction
-                    .surplus_capturing_jit_order_owners
-                    .iter()
+                    .surplus_capturing_jit_order_owners_by_helper
+                    .values()
+                    .flatten()
                     .map(|owner| ByteArray(owner.0.0))
                     .collect(),
             },

--- a/crates/autopilot/src/infra/solvers/dto/solve.rs
+++ b/crates/autopilot/src/infra/solvers/dto/solve.rs
@@ -61,9 +61,15 @@ impl Request {
                 .collect(),
             deadline: Utc::now() + chrono::Duration::from_std(time_limit).unwrap(),
             surplus_capturing_jit_order_owners: auction
-                .surplus_capturing_jit_order_owners
-                .iter()
+                .surplus_capturing_jit_order_owners_by_helper
+                .values()
+                .flatten()
                 .map(|address| address.0)
+                .collect::<Vec<_>>(),
+            surplus_capturing_jit_order_owners_by_helper: auction
+                .surplus_capturing_jit_order_owners_by_helper
+                .iter()
+                .map(|(helper, owners)| (helper.0, owners.iter().map(|owner| owner.0).collect()))
                 .collect::<Vec<_>>(),
         };
         Self(Arc::from(serde_json::value::to_raw_value(&helper).expect(
@@ -93,6 +99,7 @@ struct RequestHelper {
     pub orders: Vec<Order>,
     pub deadline: DateTime<Utc>,
     pub surplus_capturing_jit_order_owners: Vec<H160>,
+    pub surplus_capturing_jit_order_owners_by_helper: Vec<(H160, Vec<H160>)>,
 }
 
 #[serde_as]

--- a/crates/cow-amm/src/amm.rs
+++ b/crates/cow-amm/src/amm.rs
@@ -20,10 +20,7 @@ pub struct Amm {
 }
 
 impl Amm {
-    pub(crate) async fn new(
-        address: Address,
-        helper: &CowAmmLegacyHelper,
-    ) -> Result<Self, MethodError> {
+    pub async fn new(address: Address, helper: &CowAmmLegacyHelper) -> Result<Self, MethodError> {
         let tradeable_tokens = helper.tokens(address).call().await?;
 
         Ok(Self {

--- a/crates/cow-amm/src/amm.rs
+++ b/crates/cow-amm/src/amm.rs
@@ -39,6 +39,11 @@ impl Amm {
         &self.tradeable_tokens
     }
 
+    /// Returns the address of the helper contract used by this AMM.
+    pub fn helper_address(&self) -> Address {
+        self.helper.address()
+    }
+
     /// Returns an order to rebalance the AMM based on the provided reference
     /// prices. `prices` need to be computed using a common denominator and
     /// need to be supplied in the same order as `traded_tokens` returns

--- a/crates/driver/example.toml
+++ b/crates/driver/example.toml
@@ -42,14 +42,6 @@ flashloan-router = "0x0000000000000000000000000000000000000000"
 lender = "0x0000000000000000000000000000000000000000"
 helper-contract = "0x0000000000000000000000000000000000000000"
 
-[[contracts.cow-amms]]
-# address of factory creating new CoW AMMs
-factory = "0x86f3df416979136cb4fdea2c0886301b911c163b"
-# address of contract to help interfacing with the created CoW AMMs
-helper = "0x86f3df416979136cb4fdea2c0886301b911c163b"
-# at which block the driver should start indexing the factory (1 block before deployment)
-index-start = 20188649
-
 [liquidity]
 base-tokens = [
     "0xDEf1CA1fb7FBcDC777520aa7f396b4E015F497aB",

--- a/crates/driver/openapi.yml
+++ b/crates/driver/openapi.yml
@@ -464,14 +464,24 @@ components:
             Information about tokens used in the auction.
         deadline:
           $ref: "#/components/schemas/DateTime"
-        surplusCapturingJitOrderOwners:
+        surplusCapturingJitOrderOwnersByHelper:
           type: array
           items:
-            $ref: "#/components/schemas/Address"
+            type: array
+            items:
+              oneOf:
+                - $ref: "#/components/schemas/Address"
+                - type: array
+                  items:
+                    $ref: "#/components/schemas/Address"
+            minItems: 2
+            maxItems: 2
+            description: Tuple of [helper_address, [amm_addresses]]
           description: >
-            List of addresses on whose surplus will count towards the objective
-            value of their solution (unlike other orders that were created by
-            the solver).
+            Array of tuples where each tuple contains a helper contract address
+            and an array of CoW AMM addresses using that helper. This provides
+            more detailed information than surplusCapturingJitOrderOwners by
+            grouping AMMs by their helper contracts.
     SolveResponse:
       description: |
         Response of the solve endpoint.

--- a/crates/driver/src/domain/competition/auction.rs
+++ b/crates/driver/src/domain/competition/auction.rs
@@ -25,7 +25,7 @@ pub struct Auction {
     pub(crate) tokens: Tokens,
     pub(crate) gas_price: eth::GasPrice,
     pub(crate) deadline: chrono::DateTime<chrono::Utc>,
-    pub(crate) surplus_capturing_jit_order_owners: HashSet<eth::Address>,
+    pub(crate) surplus_capturing_jit_order_owners_with_helper: HashMap<eth::Address, eth::Address>,
 }
 
 impl Auction {
@@ -35,7 +35,7 @@ impl Auction {
         tokens: impl Iterator<Item = Token>,
         deadline: chrono::DateTime<chrono::Utc>,
         eth: &Ethereum,
-        surplus_capturing_jit_order_owners: HashSet<eth::Address>,
+        surplus_capturing_jit_order_owners_with_helper: HashMap<eth::Address, eth::Address>,
     ) -> Result<Self, Error> {
         let tokens = Tokens(tokens.map(|token| (token.address, token)).collect());
         let weth = eth.contracts().weth_address();
@@ -62,7 +62,7 @@ impl Auction {
             tokens,
             gas_price: eth.gas_price(None).await?,
             deadline,
-            surplus_capturing_jit_order_owners,
+            surplus_capturing_jit_order_owners_with_helper,
         })
     }
 
@@ -116,8 +116,10 @@ impl Auction {
             .collect()
     }
 
-    pub fn surplus_capturing_jit_order_owners(&self) -> &HashSet<eth::Address> {
-        &self.surplus_capturing_jit_order_owners
+    pub fn surplus_capturing_jit_order_owners_with_helper(
+        &self,
+    ) -> &HashMap<eth::Address, eth::Address> {
+        &self.surplus_capturing_jit_order_owners_with_helper
     }
 }
 

--- a/crates/driver/src/domain/competition/mod.rs
+++ b/crates/driver/src/domain/competition/mod.rs
@@ -208,7 +208,7 @@ impl Competition {
 
         // Discard empty solutions.
         let solutions = solutions.filter(|solution| {
-            if solution.is_empty(auction.surplus_capturing_jit_order_owners()) {
+            if solution.is_empty(auction.surplus_capturing_jit_order_owners_with_helper()) {
                 observe::empty_solution(self.solver.name(), solution.id());
                 notify::empty_solution(&self.solver, auction.id(), solution.id().clone());
                 false
@@ -284,7 +284,7 @@ impl Competition {
                 (
                     settlement.score(
                         &auction.native_prices(),
-                        auction.surplus_capturing_jit_order_owners(),
+                        auction.surplus_capturing_jit_order_owners_with_helper(),
                     ),
                     settlement,
                 )
@@ -775,7 +775,7 @@ fn merge(
             solution
                 .scoring(
                     &auction.native_prices(),
-                    auction.surplus_capturing_jit_order_owners(),
+                    auction.surplus_capturing_jit_order_owners_with_helper(),
                 )
                 .map(|score| score.0)
                 .unwrap_or_default(),

--- a/crates/driver/src/domain/competition/pre_processing.rs
+++ b/crates/driver/src/domain/competition/pre_processing.rs
@@ -348,7 +348,7 @@ impl Utilities {
                 // Only generate orders for cow amms the auction told us about.
                 // Otherwise the solver would expect the order to get surplus but
                 // the autopilot would actually not count it.
-                .filter(|amm| auction.surplus_capturing_jit_order_owners.contains(&eth::Address(*amm.address())))
+                .filter(|amm| auction.surplus_capturing_jit_order_owners_with_helper.contains_key(&eth::Address(*amm.address())))
                 // Only generate orders where the auction provided the required
                 // reference prices. Otherwise there will be an error during the
                 // surplus calculation which will also result in 0 surplus for

--- a/crates/driver/src/domain/competition/solution/mod.rs
+++ b/crates/driver/src/domain/competition/solution/mod.rs
@@ -70,7 +70,7 @@ impl Solution {
         weth: eth::WethAddress,
         gas: Option<eth::Gas>,
         fee_handler: FeeHandler,
-        surplus_capturing_jit_order_owners: &HashSet<eth::Address>,
+        surplus_capturing_jit_order_owners_with_helper: &HashMap<eth::Address, eth::Address>,
         flashloans: HashMap<order::Uid, Flashloan>,
     ) -> Result<Self, error::Solution> {
         // Surplus capturing JIT orders behave like Fulfillment orders. They capture
@@ -79,7 +79,9 @@ impl Solution {
         // right away.
         for trade in &mut trades {
             let Trade::Jit(jit) = trade else { continue };
-            if !surplus_capturing_jit_order_owners.contains(&jit.order().signature.signer) {
+            if !surplus_capturing_jit_order_owners_with_helper
+                .contains_key(&jit.order().signature.signer)
+            {
                 continue;
             }
 
@@ -210,13 +212,12 @@ impl Solution {
     fn trade_count_for_scorable(
         &self,
         trade: &Trade,
-        surplus_capturing_jit_order_owners: &HashSet<eth::Address>,
+        surplus_capturing_jit_order_owners_with_helper: &HashMap<eth::Address, eth::Address>,
     ) -> bool {
         match trade {
             Trade::Fulfillment(_) => true,
-            Trade::Jit(jit) => {
-                surplus_capturing_jit_order_owners.contains(&jit.order().signature.signer)
-            }
+            Trade::Jit(jit) => surplus_capturing_jit_order_owners_with_helper
+                .contains_key(&jit.order().signature.signer),
         }
     }
 
@@ -224,11 +225,11 @@ impl Solution {
     pub fn scoring(
         &self,
         native_prices: &auction::Prices,
-        surplus_capturing_jit_order_owners: &HashSet<eth::Address>,
+        surplus_capturing_jit_order_owners_with_helper: &HashMap<eth::Address, eth::Address>,
     ) -> Result<eth::Ether, error::Scoring> {
         let mut trades = Vec::with_capacity(self.trades.len());
         for trade in self.trades().iter().filter(|trade| {
-            self.trade_count_for_scorable(trade, surplus_capturing_jit_order_owners)
+            self.trade_count_for_scorable(trade, surplus_capturing_jit_order_owners_with_helper)
         }) {
             // Solver generated fulfillment does not include the fee in the executed amount
             // for sell orders.
@@ -282,7 +283,10 @@ impl Solution {
 
     /// An empty solution has no trades which is allowed to capture surplus and
     /// a score of 0.
-    pub fn is_empty(&self, surplus_capturing_jit_order_owners: &HashSet<eth::Address>) -> bool {
+    pub fn is_empty(
+        &self,
+        surplus_capturing_jit_order_owners: &HashMap<eth::Address, eth::Address>,
+    ) -> bool {
         !self
             .trades
             .iter()

--- a/crates/driver/src/domain/competition/solution/settlement.rs
+++ b/crates/driver/src/domain/competition/solution/settlement.rs
@@ -13,7 +13,7 @@ use {
         infra::{Simulator, blockchain::Ethereum, observe, solver::ManageNativeToken},
     },
     futures::future::try_join_all,
-    std::collections::{BTreeSet, HashMap, HashSet},
+    std::collections::{BTreeSet, HashMap},
     tracing::instrument,
 };
 
@@ -250,10 +250,10 @@ impl Settlement {
     pub fn score(
         &self,
         prices: &auction::Prices,
-        surplus_capturing_jit_order_owners: &HashSet<eth::Address>,
+        surplus_capturing_jit_order_owners_with_helper: &HashMap<eth::Address, eth::Address>,
     ) -> Result<eth::Ether, solution::error::Scoring> {
         self.solution
-            .scoring(prices, surplus_capturing_jit_order_owners)
+            .scoring(prices, surplus_capturing_jit_order_owners_with_helper)
     }
 
     /// The solution encoded in this settlement.

--- a/crates/driver/src/domain/cow_amm.rs
+++ b/crates/driver/src/domain/cow_amm.rs
@@ -1,0 +1,86 @@
+use {
+    crate::domain::eth,
+    contracts::CowAmmLegacyHelper,
+    cow_amm::Amm,
+    std::{collections::HashMap, sync::Arc},
+    tokio::sync::RwLock,
+};
+
+/// Cache for CoW AMM data to avoid using the registry dependency.
+/// Maps AMM address to the corresponding Amm instance.
+pub struct Cache {
+    inner: RwLock<HashMap<eth::Address, Arc<Amm>>>,
+    web3: ethrpc::Web3,
+}
+
+impl Cache {
+    pub fn new(web3: ethrpc::Web3) -> Self {
+        Self {
+            inner: RwLock::new(HashMap::new()),
+            web3,
+        }
+    }
+
+    /// Gets or creates AMM instances for the given surplus capturing JIT order
+    /// owners with their helpers. Returns a list of AMM instances that were
+    /// successfully created or retrieved from cache.
+    pub async fn get_or_create_amms(
+        &self,
+        surplus_capturing_jit_order_owners_with_helper: &HashMap<eth::Address, eth::Address>,
+    ) -> Vec<Arc<Amm>> {
+        let mut cached_amms = Vec::new();
+        let mut missing_amms = Vec::new();
+
+        {
+            let cache = self.inner.read().await;
+            for (amm_address, helper_address) in surplus_capturing_jit_order_owners_with_helper {
+                if let Some(amm) = cache.get(amm_address) {
+                    cached_amms.push(amm.clone());
+                } else {
+                    missing_amms.push((*amm_address, *helper_address));
+                }
+            }
+        }
+
+        if missing_amms.is_empty() {
+            return cached_amms;
+        }
+
+        let fetch_futures = missing_amms
+            .into_iter()
+            .map(|(amm_address, helper_address)| {
+                let web3 = self.web3.clone();
+                async move {
+                    let helper = CowAmmLegacyHelper::at(&web3, helper_address.0);
+                    match Amm::new(amm_address.0, &helper).await {
+                        Ok(amm) => Some((amm_address, Arc::new(amm))),
+                        Err(err) => {
+                            tracing::warn!(
+                                ?err,
+                                amm_address = ?amm_address.0,
+                                helper_address = ?helper_address.0,
+                                "failed to create CoW AMM instance"
+                            );
+                            None
+                        }
+                    }
+                }
+            });
+
+        let fetched_results = futures::future::join_all(fetch_futures).await;
+
+        // Update cache with newly fetched AMMs
+        let mut newly_created_amms = Vec::new();
+        {
+            let mut cache = self.inner.write().await;
+            for (amm_address, amm) in fetched_results.into_iter().flatten() {
+                cache.insert(amm_address, amm.clone());
+                newly_created_amms.push(amm);
+            }
+        }
+
+        // Combine cached and newly created AMMs
+        cached_amms.extend(newly_created_amms);
+        cached_amms
+    }
+}

--- a/crates/driver/src/domain/mod.rs
+++ b/crates/driver/src/domain/mod.rs
@@ -1,4 +1,5 @@
 pub mod competition;
+pub mod cow_amm;
 pub mod eth;
 pub mod liquidity;
 pub mod mempools;

--- a/crates/driver/src/domain/quote.rs
+++ b/crates/driver/src/domain/quote.rs
@@ -107,7 +107,9 @@ impl Order {
             // first solution
             solutions
                 .into_iter()
-                .find(|solution| !solution.is_empty(auction.surplus_capturing_jit_order_owners()))
+                .find(|solution| {
+                    !solution.is_empty(auction.surplus_capturing_jit_order_owners_with_helper())
+                })
                 .ok_or(QuotingFailed::NoSolutions)?,
         )
     }
@@ -175,7 +177,7 @@ impl Order {
             .into_iter(),
             self.deadline,
             eth,
-            HashSet::default(),
+            HashMap::default(),
         )
         .await
         .map_err(|err| match err {

--- a/crates/driver/src/infra/blockchain/contracts.rs
+++ b/crates/driver/src/infra/blockchain/contracts.rs
@@ -46,7 +46,6 @@ pub struct Addresses {
     pub signatures: Option<eth::ContractAddress>,
     pub weth: Option<eth::ContractAddress>,
     pub balances: Option<eth::ContractAddress>,
-    pub cow_amms: Vec<CowAmmConfig>,
     pub flashloan_wrappers: Vec<config::file::FlashloanWrapperConfig>,
     pub flashloan_router: Option<eth::ContractAddress>,
     pub flashloan_default_lender: Option<eth::ContractAddress>,

--- a/crates/driver/src/infra/blockchain/mod.rs
+++ b/crates/driver/src/infra/blockchain/mod.rs
@@ -88,7 +88,6 @@ impl Ethereum {
         rpc: Rpc,
         addresses: contracts::Addresses,
         gas: Arc<GasPriceEstimator>,
-        archive_node_url: Option<&Url>,
     ) -> Self {
         let Rpc { web3, chain, args } = rpc;
 
@@ -99,19 +98,9 @@ impl Ethereum {
         .await
         .expect("couldn't initialize current block stream");
 
-        let contracts = Contracts::new(
-            &web3,
-            chain,
-            addresses,
-            current_block_stream.clone(),
-            archive_node_url.map(|url| RpcArgs {
-                url: url.clone(),
-                max_batch_size: args.max_batch_size,
-                max_concurrent_requests: args.max_concurrent_requests,
-            }),
-        )
-        .await
-        .expect("could not initialize important smart contracts");
+        let contracts = Contracts::new(&web3, chain, addresses)
+            .await
+            .expect("could not initialize important smart contracts");
         let balance_simulator = BalanceSimulator::new(
             contracts.settlement().clone(),
             contracts.balance_helper().clone(),

--- a/crates/driver/src/infra/config/file/load.rs
+++ b/crates/driver/src/infra/config/file/load.rs
@@ -409,7 +409,6 @@ pub async fn load(chain: Chain, path: &Path) -> infra::Config {
         disable_gas_simulation: config.disable_gas_simulation.map(Into::into),
         gas_estimator: config.gas_estimator,
         order_priority_strategies: config.order_priority_strategies,
-        archive_node_url: config.archive_node_url,
         simulation_bad_token_max_age: config.simulation_bad_token_max_age,
         app_data_fetching: config.app_data_fetching,
     }

--- a/crates/driver/src/infra/config/file/load.rs
+++ b/crates/driver/src/infra/config/file/load.rs
@@ -376,16 +376,6 @@ pub async fn load(chain: Chain, path: &Path) -> infra::Config {
             weth: config.contracts.weth.map(Into::into),
             balances: config.contracts.balances.map(Into::into),
             signatures: config.contracts.signatures.map(Into::into),
-            cow_amms: config
-                .contracts
-                .cow_amms
-                .into_iter()
-                .map(|cfg| blockchain::contracts::CowAmmConfig {
-                    index_start: cfg.index_start,
-                    factory: cfg.factory,
-                    helper: cfg.helper,
-                })
-                .collect(),
             flashloan_default_lender: {
                 // Make sure flashloan default lender exists in the flashloan wrappers
                 if let Some(default_lender) = config.contracts.flashloan_default_lender

--- a/crates/driver/src/infra/config/file/mod.rs
+++ b/crates/driver/src/infra/config/file/mod.rs
@@ -64,9 +64,6 @@ struct Config {
     )]
     order_priority_strategies: Vec<OrderPriorityStrategy>,
 
-    /// Archive node URL used to index CoW AMM
-    archive_node_url: Option<Url>,
-
     /// How long should the token quality computed by the simulation
     /// based logic be cached.
     #[serde(

--- a/crates/driver/src/infra/config/file/mod.rs
+++ b/crates/driver/src/infra/config/file/mod.rs
@@ -370,11 +370,6 @@ struct ContractsConfig {
     /// Override the default address of the Signatures contract.
     signatures: Option<eth::H160>,
 
-    /// List of all cow amm factories the driver should generate
-    /// rebalancing orders for.
-    #[serde(default)]
-    cow_amms: Vec<CowAmmConfig>,
-
     /// Flashloan wrapper-related configs.
     #[serde(default)]
     flashloan_wrappers: Vec<FlashloanWrapperConfig>,
@@ -399,17 +394,6 @@ pub struct FlashloanWrapperConfig {
     /// Flashloan fee in bps.
     #[serde(default)]
     pub fee_in_bps: eth::U256,
-}
-
-#[derive(Debug, Clone, Deserialize)]
-#[serde(rename_all = "kebab-case", deny_unknown_fields)]
-pub struct CowAmmConfig {
-    /// Which contract to index for CoW AMM deployment events.
-    pub factory: eth::H160,
-    /// Which helper contract to use for interfacing with the indexed CoW AMMs.
-    pub helper: eth::H160,
-    /// At which block indexing should start on the factory.
-    pub index_start: u64,
 }
 
 #[derive(Debug, Deserialize)]

--- a/crates/driver/src/infra/config/mod.rs
+++ b/crates/driver/src/infra/config/mod.rs
@@ -11,7 +11,6 @@ use {
         },
     },
     std::time::Duration,
-    url::Url,
 };
 
 pub mod file;
@@ -28,7 +27,6 @@ pub struct Config {
     pub mempools: Vec<mempool::Config>,
     pub contracts: blockchain::contracts::Addresses,
     pub order_priority_strategies: Vec<OrderPriorityStrategy>,
-    pub archive_node_url: Option<Url>,
     pub simulation_bad_token_max_age: Duration,
     pub app_data_fetching: AppDataFetching,
 }

--- a/crates/driver/src/infra/observe/mod.rs
+++ b/crates/driver/src/infra/observe/mod.rs
@@ -25,7 +25,7 @@ use {
     },
     ethrpc::block_stream::BlockInfo,
     std::{
-        collections::{BTreeMap, HashSet},
+        collections::{BTreeMap, HashMap},
         time::Duration,
     },
     url::Url,
@@ -75,11 +75,11 @@ pub fn duplicated_solution_id(solver: &solver::Name, id: &solution::Id) {
 /// Observe the solutions returned by the solver.
 pub fn solutions(
     solutions: &[Solution],
-    surplus_capturing_jit_order_owners: &HashSet<eth::Address>,
+    surplus_capturing_jit_order_owners_with_helper: &HashMap<eth::Address, eth::Address>,
 ) {
     if solutions
         .iter()
-        .any(|s| !s.is_empty(surplus_capturing_jit_order_owners))
+        .any(|s| !s.is_empty(surplus_capturing_jit_order_owners_with_helper))
     {
         tracing::info!(?solutions, "computed solutions");
     } else {

--- a/crates/driver/src/infra/solver/dto/auction.rs
+++ b/crates/driver/src/infra/solver/dto/auction.rs
@@ -313,8 +313,8 @@ pub fn new(
         effective_gas_price: auction.gas_price().effective().into(),
         deadline,
         surplus_capturing_jit_order_owners: auction
-            .surplus_capturing_jit_order_owners()
-            .iter()
+            .surplus_capturing_jit_order_owners_with_helper()
+            .keys()
             .cloned()
             .map(Into::into)
             .collect::<Vec<_>>(),

--- a/crates/driver/src/infra/solver/dto/solution.rs
+++ b/crates/driver/src/infra/solver/dto/solution.rs
@@ -207,7 +207,7 @@ impl Solutions {
                     weth,
                     solution.gas.map(|gas| eth::Gas(gas.into())),
                     solver.config().fee_handler,
-                    auction.surplus_capturing_jit_order_owners(),
+                    auction.surplus_capturing_jit_order_owners_with_helper(),
                     solution.flashloans
                         // convert the flashloan info provided by the solver
                         .map(|f| f.iter().map(|(order, loan)|(order.into(), loan.into())).collect())

--- a/crates/driver/src/infra/solver/mod.rs
+++ b/crates/driver/src/infra/solver/mod.rs
@@ -299,7 +299,10 @@ impl Solver {
             &flashloan_hints,
         )?;
 
-        super::observe::solutions(&solutions, auction.surplus_capturing_jit_order_owners());
+        super::observe::solutions(
+            &solutions,
+            auction.surplus_capturing_jit_order_owners_with_helper(),
+        );
         Ok(solutions)
     }
 

--- a/crates/driver/src/run.rs
+++ b/crates/driver/src/run.rs
@@ -169,13 +169,7 @@ async fn ethereum(config: &infra::Config, ethrpc: blockchain::Rpc) -> Ethereum {
             .await
             .expect("initialize gas price estimator"),
     );
-    Ethereum::new(
-        ethrpc,
-        config.contracts.clone(),
-        gas,
-        config.archive_node_url.as_ref(),
-    )
-    .await
+    Ethereum::new(ethrpc, config.contracts.clone(), gas).await
 }
 
 async fn solvers(config: &config::Config, eth: &Ethereum) -> Vec<Solver> {

--- a/crates/driver/src/tests/setup/solver.rs
+++ b/crates/driver/src/tests/setup/solver.rs
@@ -485,7 +485,6 @@ impl Solver {
                 weth: Some(config.blockchain.weth.address().into()),
                 balances: Some(config.blockchain.balances.address().into()),
                 signatures: Some(config.blockchain.signatures.address().into()),
-                cow_amms: vec![],
                 flashloan_default_lender: flashloan_wrappers.first().map(|w| w.lender.into()),
                 flashloan_wrappers,
                 flashloan_router: Some(config.blockchain.flashloan_wrapper.address().into()),

--- a/crates/driver/src/tests/setup/solver.rs
+++ b/crates/driver/src/tests/setup/solver.rs
@@ -491,7 +491,6 @@ impl Solver {
                 flashloan_router: Some(config.blockchain.flashloan_wrapper.address().into()),
             },
             gas,
-            None,
         )
         .await;
 


### PR DESCRIPTION
# Description
Currently, both autopilot and driver use the same CoW AMM indexer functionality in parallel to serve different purposes: autopilot needs to fill out surplus capturing jit order owners in the auction and driver uses it to fetch tradable tokens and then prepare cow amm orders. Since autopilot already sends CoW AMM addresses within each auction, the only missing part is the mapping between CoW AMM and the corresponding helper address. Once this data is provided, the driver can create an instance of Amm struct and use it the same way it currently does without even indexing anything. This PR implements it.

# Changes

- [ ] Autopilot now sends to the driver a `HashMap<Address, Vec<Address>>`, where key is the helper SC address and values are all the related AMMs. That way, it saves some space compared to sending a list of 1:1 tuples.
- [ ] To avoid breaking changes, it currently sends the new data structure together with the old list of CoW AMM addresses.
- [ ] The old hashset is replaced with the new hashmap everywhere possible except the request itself.
- [ ] The driver now accepts only the new data structure.
- [ ] Once the driver starts using this data, it creates an `Amm` instance that contains a helper SC instance and tradable tokens and permanently stores them in the in-memory cache. As a result, on each restart, it doesn't need to index tons of blocks anymore and just fetches AMM tokens per auction.
- [ ] CoW AMMs config is removed from the driver.
- [ ] `openapi.yaml` is updated accordingly.

## How to test
Existing e2e tests.