### PR TITLE
Add CLI flag for filtering orders in autopilot

### DIFF
--- a/crates/autopilot/src/arguments.rs
+++ b/crates/autopilot/src/arguments.rs
@@ -248,8 +248,8 @@ pub struct Arguments {
 
     /// Configures whether the autopilot is supposed to do any non-trivial
     /// order filtering (e.g. based on balances or EIP-1271 signature validity).
-    #[clap(long, env, default_value = "true", action = clap::ArgAction::Set)]
-    pub enable_order_filtering: bool,
+    #[clap(long, env, default_value = "false", action = clap::ArgAction::Set)]
+    pub disable_order_filtering: bool,
 }
 
 #[derive(Debug, clap::Parser)]
@@ -378,7 +378,7 @@ impl std::fmt::Display for Arguments {
             archive_node_url,
             max_solutions_per_solver,
             db_based_solver_participation_guard,
-            enable_order_filtering,
+            disable_order_filtering,
         } = self;
 
         write!(f, "{shared}")?;
@@ -449,7 +449,7 @@ impl std::fmt::Display for Arguments {
             f,
             "db_based_solver_participation_guard: {db_based_solver_participation_guard:?}"
         )?;
-        writeln!(f, "enable_order_filtering: {enable_order_filtering}")?;
+        writeln!(f, "disable_order_filtering: {disable_order_filtering}")?;
         Ok(())
     }
 }

--- a/crates/autopilot/src/run.rs
+++ b/crates/autopilot/src/run.rs
@@ -513,7 +513,7 @@ pub async fn run(args: Arguments) {
         cow_amm_registry.clone(),
         args.run_loop_native_price_timeout,
         eth.contracts().settlement().address(),
-        args.enable_order_filtering,
+        args.disable_order_filtering,
     );
 
     let liveness = Arc::new(Liveness::new(args.max_auction_age));

--- a/crates/autopilot/src/solvable_orders.rs
+++ b/crates/autopilot/src/solvable_orders.rs
@@ -100,7 +100,7 @@ pub struct SolvableOrdersCache {
     cow_amm_registry: cow_amm::Registry,
     native_price_timeout: Duration,
     settlement_contract: H160,
-    filter_orders: bool,
+    disable_order_filters: bool,
 }
 
 type Balances = HashMap<Query, U256>;
@@ -126,7 +126,7 @@ impl SolvableOrdersCache {
         cow_amm_registry: cow_amm::Registry,
         native_price_timeout: Duration,
         settlement_contract: H160,
-        filter_orders: bool,
+        disable_order_filters: bool,
     ) -> Arc<Self> {
         Arc::new(Self {
             min_order_validity_period,
@@ -144,7 +144,7 @@ impl SolvableOrdersCache {
             cow_amm_registry,
             native_price_timeout,
             settlement_contract,
-            filter_orders,
+            disable_order_filters,
         })
     }
 
@@ -314,7 +314,7 @@ impl SolvableOrdersCache {
                 self.balance_fetcher.get_balances(&queries),
             )
             .await;
-        if !self.filter_orders {
+        if self.disable_order_filters {
             return Default::default();
         }
 
@@ -381,7 +381,7 @@ impl SolvableOrdersCache {
         invalid_order_uids: &mut HashSet<OrderUid>,
     ) -> Vec<Order> {
         let filter_invalid_signatures = async {
-            if !self.filter_orders {
+            if self.disable_order_filters {
                 return Default::default();
             }
             find_invalid_signature_orders(&orders, self.signature_validator.as_ref()).await


### PR DESCRIPTION
# Description
Currently the autopilot filters out tons of orders from the current auction as an optimization.
In order to be less opinionated on what orders can be settled at any point in time these checks should not happen on a protocol level (i.e. in the autopilot). However, since things like balance checking make sense in the grand scheme of things these checks how happen in the reference driver.

So effectively disabling order filtering on the autopilot side should only have an impact on colocated drivers that are connected to the autopilot.
Since it's not trivial to see what would happen if this check were to be removed right away I decided to feature gate the logic. That way we can test temporarily on prod to see if anything bad happens and revert quickly if it does.

# Changes
- introduce a flag that makes order filtering optional