### PR TITLE
Revert #3679 and #3685

### DIFF
--- a/crates/contracts/build.rs
+++ b/crates/contracts/build.rs
@@ -585,6 +585,7 @@ fn main() {
     });
     generate_contract("IAavePool");
     generate_contract("IFlashLoanSolverWrapper");
+    generate_contract("IUniswapLikePair");
     // EIP-1271 contract - SignatureValidator
     generate_contract("ERC1271SignatureValidator");
     generate_contract_with_config("UniswapV3SwapRouterV2", |builder| {

--- a/crates/contracts/build.rs
+++ b/crates/contracts/build.rs
@@ -585,6 +585,7 @@ fn main() {
     });
     generate_contract("IAavePool");
     generate_contract("IFlashLoanSolverWrapper");
+    generate_contract("IUniswapLikeRouter");
     generate_contract("IUniswapLikePair");
     // EIP-1271 contract - SignatureValidator
     generate_contract("ERC1271SignatureValidator");

--- a/crates/contracts/src/alloy.rs
+++ b/crates/contracts/src/alloy.rs
@@ -439,7 +439,6 @@ crate::bindings!(
     }
 );
 crate::bindings!(IUniswapLikeRouter);
-crate::bindings!(IUniswapLikePair);
 
 pub use alloy::providers::DynProvider as Provider;
 

--- a/crates/contracts/src/alloy.rs
+++ b/crates/contracts/src/alloy.rs
@@ -438,7 +438,6 @@ crate::bindings!(
         // Not available on Lens
     }
 );
-crate::bindings!(IUniswapLikeRouter);
 
 pub use alloy::providers::DynProvider as Provider;
 

--- a/crates/contracts/src/errors.rs
+++ b/crates/contracts/src/errors.rs
@@ -57,14 +57,9 @@ pub fn testing_contract_error() -> MethodError {
     }
 }
 
-/// Create an arbitrary alloy error that will convert into a "contract" error. Useful for testing.
+/// Create an arbitrary alloy error. Useful for testing.
 pub fn testing_alloy_contract_error() -> alloy::contract::Error {
     alloy::contract::Error::NotADeploymentTransaction
-}
-
-/// Create an arbitrary alloy error that will convert into a "node" error. Useful for testing.
-pub fn testing_alloy_node_error() -> alloy::contract::Error {
-    alloy::contract::Error::TransportError(alloy::transports::TransportError::NullResp)
 }
 
 #[cfg(test)]

--- a/crates/contracts/src/lib.rs
+++ b/crates/contracts/src/lib.rs
@@ -71,6 +71,7 @@ include_contracts! {
     IAavePool;
     IFlashLoanSolverWrapper;
     IUniswapLikePair;
+    IUniswapLikeRouter;
     IUniswapV3Factory;
     Permit2;
     UniswapV3Pool;

--- a/crates/contracts/src/lib.rs
+++ b/crates/contracts/src/lib.rs
@@ -70,6 +70,7 @@ include_contracts! {
     HooksTrampoline;
     IAavePool;
     IFlashLoanSolverWrapper;
+    IUniswapLikePair;
     IUniswapV3Factory;
     Permit2;
     UniswapV3Pool;

--- a/crates/driver/src/boundary/liquidity/uniswap/v2.rs
+++ b/crates/driver/src/boundary/liquidity/uniswap/v2.rs
@@ -8,12 +8,8 @@ use {
         infra::{self, blockchain::Ethereum},
     },
     async_trait::async_trait,
-    contracts::{GPv2Settlement, alloy::IUniswapLikeRouter},
-    ethrpc::{
-        Web3,
-        alloy::conversions::{IntoAlloy, IntoLegacy},
-        block_stream::CurrentBlockWatcher,
-    },
+    contracts::{GPv2Settlement, IUniswapLikeRouter},
+    ethrpc::{Web3, block_stream::CurrentBlockWatcher},
     shared::{
         http_solver::model::TokenAmount,
         sources::uniswap_v2::{
@@ -54,13 +50,13 @@ pub fn to_domain(id: liquidity::Id, pool: ConstantProductOrder) -> Result<liquid
 }
 
 pub fn router(pool: &ConstantProductOrder) -> eth::ContractAddress {
-    let address = pool
-        .settlement_handling
+    pool.settlement_handling
         .as_any()
         .downcast_ref::<uniswap_v2::Inner>()
         .expect("downcast uniswap settlement handler")
-        .router();
-    eth::ContractAddress::from(address.into_legacy())
+        .router()
+        .address()
+        .into()
 }
 
 pub(in crate::boundary::liquidity) fn to_domain_pool(
@@ -98,7 +94,7 @@ pub fn to_interaction(
     receiver: &eth::Address,
 ) -> eth::Interaction {
     let handler = uniswap_v2::Inner::new(
-        pool.router.0.into_alloy(),
+        IUniswapLikeRouter::at(&ethrpc::dummy::web3(), pool.router.into()),
         GPv2Settlement::at(&ethrpc::dummy::web3(), receiver.0),
         Mutex::new(Allowances::empty(receiver.0)),
     );
@@ -136,13 +132,12 @@ where
     R: PoolReading + Send + Sync + 'static,
     F: FnOnce(Web3, PairProvider) -> R,
 {
-    let router =
-        IUniswapLikeRouter::Instance::new(config.router.0.into_alloy(), eth.web3().alloy.clone());
+    let router = eth.contract_at::<IUniswapLikeRouter>(config.router);
     let settlement = eth.contracts().settlement().clone();
     let pool_fetcher = {
         let factory = router.factory().call().await?;
         let pair_provider = PairProvider {
-            factory: factory.into_legacy(),
+            factory,
             init_code_digest: config.pool_code.into(),
         };
 
@@ -160,7 +155,7 @@ where
     };
 
     Ok(Box::new(UniswapLikeLiquidity::with_allowances(
-        *router.address(),
+        router,
         settlement,
         Box::new(NoAllowanceManaging),
         pool_fetcher,

--- a/crates/driver/src/infra/blockchain/contracts.rs
+++ b/crates/driver/src/infra/blockchain/contracts.rs
@@ -251,6 +251,12 @@ pub trait ContractAt {
     fn at(eth: &Ethereum, address: eth::ContractAddress) -> Self;
 }
 
+impl ContractAt for contracts::IUniswapLikeRouter {
+    fn at(eth: &Ethereum, address: eth::ContractAddress) -> Self {
+        Self::at(&eth.web3, address.0)
+    }
+}
+
 impl ContractAt for contracts::ERC20 {
     fn at(eth: &Ethereum, address: eth::ContractAddress) -> Self {
         Self::at(&eth.web3, address.into())

--- a/crates/driver/src/tests/setup/blockchain.rs
+++ b/crates/driver/src/tests/setup/blockchain.rs
@@ -31,7 +31,7 @@ use {
 pub struct Pair {
     token_a: &'static str,
     token_b: &'static str,
-    contract: contracts::alloy::IUniswapLikePair::Instance,
+    contract: contracts::IUniswapLikePair,
     pool: Pool,
 }
 
@@ -480,13 +480,14 @@ impl Blockchain {
                 .await
                 .unwrap();
             // Fund the pair and the settlement contract.
-            let pair = contracts::alloy::IUniswapLikePair::Instance::new(
+            let pair = contracts::IUniswapLikePair::at(
+                &web3,
                 uniswap_factory
                     .getPair(token_a.into_alloy(), token_b.into_alloy())
                     .call()
                     .await
-                    .unwrap(),
-                web3.alloy.clone(),
+                    .unwrap()
+                    .into_legacy(),
             );
             pairs.push(Pair {
                 token_a: pool.reserve_a.token,
@@ -497,7 +498,7 @@ impl Blockchain {
             if pool.reserve_a.token == "WETH" {
                 wait_for(
                     &web3,
-                    weth.transfer(pair.address().into_legacy(), pool.reserve_a.amount)
+                    weth.transfer(pair.address(), pool.reserve_a.amount)
                         .from(primary_account(&web3).await)
                         .send(),
                 )
@@ -538,7 +539,10 @@ impl Blockchain {
                 tokens
                     .get(pool.reserve_a.token)
                     .unwrap()
-                    .mint(*pair.address(), pool.reserve_a.amount.into_alloy())
+                    .mint(
+                        pair.address().into_alloy(),
+                        pool.reserve_a.amount.into_alloy(),
+                    )
                     .from(main_trader_account.address().into_alloy())
                     .send_and_watch()
                     .await
@@ -573,7 +577,7 @@ impl Blockchain {
             if pool.reserve_b.token == "WETH" {
                 wait_for(
                     &web3,
-                    weth.transfer(pair.address().into_legacy(), pool.reserve_b.amount)
+                    weth.transfer(pair.address(), pool.reserve_b.amount)
                         .from(primary_account(&web3).await)
                         .send(),
                 )
@@ -614,7 +618,10 @@ impl Blockchain {
                 tokens
                     .get(pool.reserve_b.token)
                     .unwrap()
-                    .mint(*pair.address(), pool.reserve_b.amount.into_alloy())
+                    .mint(
+                        pair.address().into_alloy(),
+                        pool.reserve_b.amount.into_alloy(),
+                    )
                     .from(main_trader_account.address().into_alloy())
                     .send_and_watch()
                     .await
@@ -645,11 +652,16 @@ impl Blockchain {
                         .unwrap();
                 }
             }
-            pair.mint(::alloy::primitives::address!(
-                "0x8270bA71b28CF60859B547A2346aCDE824D6ed40"
-            ))
-            .from(main_trader_account.address().into_alloy())
-            .send_and_watch()
+            wait_for(
+                &web3,
+                pair.mint(
+                    "0x8270bA71b28CF60859B547A2346aCDE824D6ed40"
+                        .parse()
+                        .unwrap(),
+                )
+                .from(main_trader_account.clone())
+                .send(),
+            )
             .await
             .unwrap();
         }
@@ -815,7 +827,7 @@ impl Blockchain {
 
             // Create the interactions fulfilling the order.
             let transfer_interaction = sell_token
-                .transfer(pair.contract.address().into_legacy(), execution.sell)
+                .transfer(pair.contract.address(), execution.sell)
                 .tx
                 .data
                 .unwrap()
@@ -835,13 +847,15 @@ impl Blockchain {
             let swap_interaction = pair
                 .contract
                 .swap(
-                    amount_0_out.into_alloy(),
-                    amount_1_out.into_alloy(),
-                    self.settlement.address().into_alloy(),
+                    amount_0_out,
+                    amount_1_out,
+                    self.settlement.address(),
                     Default::default(),
                 )
-                .calldata()
-                .to_vec();
+                .tx
+                .data
+                .unwrap()
+                .0;
             fulfillments.push(Fulfillment {
                 quoted_order: self.quote(order),
                 execution: execution.clone(),
@@ -860,7 +874,7 @@ impl Blockchain {
                         internalize: false,
                     },
                     Interaction {
-                        address: pair.contract.address().into_legacy(),
+                        address: pair.contract.address(),
                         calldata: match solution.calldata {
                             super::Calldata::Valid { .. } => swap_interaction,
                             super::Calldata::Invalid => {

--- a/crates/e2e/src/setup/onchain_components/mod.rs
+++ b/crates/e2e/src/setup/onchain_components/mod.rs
@@ -567,20 +567,21 @@ impl OnchainComponents {
     ///
     /// This can be used to modify the pool reserves during a test.
     pub async fn mint_token_to_weth_uni_v2_pool(&self, token: &MintableToken, amount: U256) {
-        let pair = contracts::alloy::IUniswapLikePair::Instance::new(
+        let pair = contracts::IUniswapLikePair::at(
+            &self.web3,
             self.contracts
                 .uniswap_v2_factory
                 .getPair(self.contracts.weth.address().into_alloy(), *token.address())
                 .call()
                 .await
-                .expect("failed to get Uniswap V2 pair"),
-            self.web3.alloy.clone(),
+                .expect("failed to get Uniswap V2 pair")
+                .into_legacy(),
         );
         assert!(!pair.address().is_zero(), "Uniswap V2 pair is not deployed");
 
         // Mint amount + 1 to the pool, and then swap out 1 of the minted token
         // in order to force it to update its K-value.
-        token.mint(pair.address().into_legacy(), amount + 1).await;
+        token.mint(pair.address(), amount + 1).await;
         let (out0, out1) =
             if TokenPair::new(self.contracts.weth.address(), token.address().into_legacy())
                 .unwrap()
@@ -593,13 +594,13 @@ impl OnchainComponents {
                 (0, 1)
             };
         pair.swap(
-            ::alloy::primitives::U256::from(out0),
-            ::alloy::primitives::U256::from(out1),
-            token.minter.address().into_alloy(),
+            out0.into(),
+            out1.into(),
+            token.minter.address(),
             Default::default(),
         )
-        .from(token.minter.address().into_alloy())
-        .send_and_watch()
+        .from(token.minter.clone())
+        .send()
         .await
         .expect("Uniswap V2 pair couldn't mint");
     }

--- a/crates/shared/src/sources/uniswap_v2/mod.rs
+++ b/crates/shared/src/sources/uniswap_v2/mod.rs
@@ -14,9 +14,9 @@ use {
         sources::{BaselineSource, swapr::SwaprPoolReader},
     },
     anyhow::{Context, Result},
-    contracts::alloy::IUniswapLikeRouter,
+    contracts::IUniswapLikeRouter,
     ethcontract::{H160, H256},
-    ethrpc::alloy::conversions::{IntoAlloy, IntoLegacy},
+    ethrpc::alloy::conversions::IntoLegacy,
     hex_literal::hex,
     std::{fmt::Display, str::FromStr, sync::Arc},
 };
@@ -56,7 +56,7 @@ enum PoolReadingStyle {
 }
 
 pub struct UniV2BaselineSource {
-    pub router: IUniswapLikeRouter::Instance,
+    pub router: IUniswapLikeRouter,
     pub pair_provider: PairProvider,
     pub pool_fetching: Arc<dyn PoolFetching>,
 }
@@ -110,13 +110,10 @@ impl UniV2BaselineSourceParameters {
 
     pub async fn into_source(&self, web3: &Web3) -> Result<UniV2BaselineSource> {
         let web3 = ethrpc::instrumented::instrument_with_label(web3, "uniswapV2".into());
-        let router = contracts::alloy::IUniswapLikeRouter::Instance::new(
-            self.router.into_alloy(),
-            web3.alloy.clone(),
-        );
+        let router = contracts::IUniswapLikeRouter::at(&web3, self.router);
         let factory = router.factory().call().await.context("factory")?;
         let pair_provider = pair_provider::PairProvider {
-            factory: factory.into_legacy(),
+            factory,
             init_code_digest: self.init_code_digest.0,
         };
         let pool_reader = DefaultPoolReader::new(web3.clone(), pair_provider);

--- a/crates/shared/src/sources/uniswap_v2/pool_fetching.rs
+++ b/crates/shared/src/sources/uniswap_v2/pool_fetching.rs
@@ -1,16 +1,10 @@
 use {
     super::pair_provider::PairProvider,
     crate::{baseline_solver::BaselineSolvable, ethrpc::Web3, recent_block_cache::Block},
-    alloy::sol_types::GenericContractError,
     anyhow::Result,
     cached::{Cached, TimedCache},
-    contracts::{
-        ERC20,
-        alloy::IUniswapLikePair::{self, IUniswapLikePair::getReservesReturn},
-        errors::EthcontractErrorType,
-    },
+    contracts::{ERC20, IUniswapLikePair, errors::EthcontractErrorType},
     ethcontract::{BlockId, H160, U256, errors::MethodError},
-    ethrpc::alloy::conversions::IntoAlloy,
     futures::{
         FutureExt as _,
         future::{self, BoxFuture},
@@ -273,6 +267,9 @@ impl PoolReading for DefaultPoolReader {
     fn read_state(&self, pair: TokenPair, block: BlockId) -> BoxFuture<'_, Result<Option<Pool>>> {
         let pair_address = self.pair_provider.pair_address(&pair);
 
+        let pair_contract = IUniswapLikePair::at(&self.web3, pair_address);
+        let fetch_reserves = pair_contract.get_reserves().block(block).call();
+
         // Fetch ERC20 token balances of the pools to sanity check with reserves
         let token0 = ERC20::at(&self.web3, pair.get().0);
         let token1 = ERC20::at(&self.web3, pair.get().1);
@@ -281,16 +278,8 @@ impl PoolReading for DefaultPoolReader {
         let fetch_token1_balance = token1.balance_of(pair_address).block(block).call();
 
         async move {
-            let pair_contract =
-                IUniswapLikePair::Instance::new(pair_address.into_alloy(), self.web3.alloy.clone());
-            let fetch_reserves = pair_contract.getReserves().block(block.into_alloy());
-
-            let (reserves, token0_balance, token1_balance) = futures::join!(
-                fetch_reserves.call().into_future(),
-                fetch_token0_balance,
-                fetch_token1_balance
-            );
-
+            let (reserves, token0_balance, token1_balance) =
+                futures::join!(fetch_reserves, fetch_token0_balance, fetch_token1_balance);
             handle_results(
                 FetchedPool {
                     pair,
@@ -307,7 +296,7 @@ impl PoolReading for DefaultPoolReader {
 
 struct FetchedPool {
     pair: TokenPair,
-    reserves: Result<getReservesReturn, alloy::contract::Error>,
+    reserves: Result<(u128, u128, u32), MethodError>,
     token0_balance: Result<U256, MethodError>,
     token1_balance: Result<U256, MethodError>,
 }
@@ -324,35 +313,12 @@ pub fn handle_contract_error<T>(result: Result<T, MethodError>) -> Result<Option
     }
 }
 
-/// Node errors should be bubbled up but contract errors should lead to the pool
-/// being skipped.
-// Based on `handle_contract_error`.
-pub fn handle_alloy_contract_error<T>(
-    result: Result<T, alloy::contract::Error>,
-) -> Result<Option<T>> {
-    match result {
-        Ok(result) => Ok(Some(result)),
-        // Alloy "hides" the contract execution errors under the transport error
-        Err(err @ alloy::contract::Error::TransportError(_)) => {
-            // So we need to try to decode the error as a generic contract error,
-            // we return in case it isn't a contract error
-            match err.try_decode_into_interface_error::<GenericContractError>() {
-                Ok(_) => Ok(None), // contract error
-                Err(err) => Err(err)?,
-            }
-        }
-        Err(_) => Ok(None),
-    }
-}
-
 fn handle_results(fetched_pool: FetchedPool, address: H160) -> Result<Option<Pool>> {
-    let reserves = handle_alloy_contract_error(fetched_pool.reserves)?;
+    let reserves = handle_contract_error(fetched_pool.reserves)?;
     let token0_balance = handle_contract_error(fetched_pool.token0_balance)?;
     let token1_balance = handle_contract_error(fetched_pool.token1_balance)?;
 
     let pool = reserves.and_then(|reserves| {
-        let r0 = u128::try_from(reserves.reserve0).ok()?;
-        let r1 = u128::try_from(reserves.reserve1).ok()?;
         // Some ERC20s (e.g. AMPL) have an elastic supply and can thus reduce the
         // balance of their owners without any transfer or other interaction ("rebase").
         // Such behavior can implicitly change the *k* in the pool's constant product
@@ -366,12 +332,14 @@ fn handle_results(fetched_pool: FetchedPool, address: H160) -> Result<Option<Poo
         // benefit by withdrawing the excess from the pool without selling anything).
         // We therefore exclude all pools where the pool's token balance of either token
         // in the pair is less than the cached reserve.
-        if U256::from(r0) > token0_balance? || U256::from(r1) > token1_balance? {
+        if U256::from(reserves.0) > token0_balance? || U256::from(reserves.1) > token1_balance? {
             return None;
         }
-        // Errors here should never happen because reserves are uint<112, 2>
-        // meaning they'll always fit in u128, but panicking here is not a good idea
-        Some(Pool::uniswap(address, fetched_pool.pair, (r0, r1)))
+        Some(Pool::uniswap(
+            address,
+            fetched_pool.pair,
+            (reserves.0, reserves.1),
+        ))
     });
 
     Ok(pool)
@@ -405,7 +373,7 @@ pub mod test_util {
 mod tests {
     use {
         super::*,
-        contracts::errors::{testing_alloy_contract_error, testing_alloy_node_error},
+        contracts::errors::{testing_contract_error, testing_node_error},
     };
 
     #[test]
@@ -539,7 +507,7 @@ mod tests {
     #[test]
     fn pool_fetcher_forwards_node_error() {
         let fetched_pool = FetchedPool {
-            reserves: Err(testing_alloy_node_error()),
+            reserves: Err(testing_node_error()),
             pair: Default::default(),
             token0_balance: Ok(1.into()),
             token1_balance: Ok(1.into()),
@@ -551,7 +519,7 @@ mod tests {
     #[test]
     fn pool_fetcher_skips_contract_error() {
         let fetched_pool = FetchedPool {
-            reserves: Err(testing_alloy_contract_error()),
+            reserves: Err(testing_contract_error()),
             pair: Default::default(),
             token0_balance: Ok(1.into()),
             token1_balance: Ok(1.into()),


### PR DESCRIPTION
This reverts #3679 and #3685, which introduced a bug when using pancake-swap UniV2 liquidity source on BNB. The stacktrace is not clear, but disabling this liquidity source resolved the issue. It is not reproduced on other UniV2 presets, other than pancake-swap. So it needs to be investigated separately what causes those panics.

```
2025-09-22T08:58:12.122Z ERROR observe::tracing: thread 'main' panicked at /src/crates/driver/src/run.rs:197:10:
initialize liquidity fetcher: Boundary(failed to receive response from batching layer background task: Canceled

Caused by:
    failed to receive response from batching layer background task: Canceled)
stack backtrace:
   0: observe::tracing::tracing_panic_hook
             at ./src/crates/observe/src/tracing.rs:183:21
   1: <alloc::boxed::Box<F,A> as core::ops::function::Fn<Args>>::call
             at ./rustc/1159e78c4747b02ef996e55082b704c09b970588/library/alloc/src/boxed.rs:1985:9
   2: std::panicking::rust_panic_with_hook
             at ./rustc/1159e78c4747b02ef996e55082b704c09b970588/library/std/src/panicking.rs:841:13
   3: std::panicking::begin_panic_handler::{{closure}}
             at ./rustc/1159e78c4747b02ef996e55082b704c09b970588/library/std/src/panicking.rs:706:13
   4: std::sys::backtrace::__rust_end_short_backtrace
             at ./rustc/1159e78c4747b02ef996e55082b704c09b970588/library/std/src/sys/backtrace.rs:174:18
   5: __rustc::rust_begin_unwind
             at ./rustc/1159e78c4747b02ef996e55082b704c09b970588/library/std/src/panicking.rs:697:5
   6: core::panicking::panic_fmt
             at ./rustc/1159e78c4747b02ef996e55082b704c09b970588/library/core/src/panicking.rs:75:14
   7: core::result::unwrap_failed
             at ./rustc/1159e78c4747b02ef996e55082b704c09b970588/library/core/src/result.rs:1765:5
   8: core::result::Result<T,E>::expect
             at ./rustc/1159e78c4747b02ef996e55082b704c09b970588/library/core/src/result.rs:1119:23
   9: driver::run::liquidity::{{closure}}
             at ./src/crates/driver/src/run.rs:197:10
  10: driver::run::run_with::{{closure}}
             at ./src/crates/driver/src/run.rs:79:45
  11: driver::run::start::{{closure}}
             at ./src/crates/driver/src/run.rs:30:26
  12: driver::main::{{closure}}
             at ./src/crates/driver/src/main.rs:6:37
  13: <tracing::instrument::Instrumented<T> as core::future::future::Future>::poll
             at ./usr/local/cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tracing-0.1.41/src/instrument.rs:321:15
  14: tokio::runtime::park::CachedParkThread::block_on::{{closure}}
             at ./usr/local/cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.47.1/src/runtime/park.rs:285:71
  15: tokio::task::coop::with_budget
             at ./usr/local/cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.47.1/src/task/coop/mod.rs:167:5
  16: tokio::task::coop::budget
             at ./usr/local/cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.47.1/src/task/coop/mod.rs:133:5
  17: tokio::runtime::park::CachedParkThread::block_on
             at ./usr/local/cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.47.1/src/runtime/park.rs:285:31
  18: tokio::runtime::context::blocking::BlockingRegionGuard::block_on
             at ./usr/local/cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.47.1/src/runtime/context/blocking.rs:66:14
  19: tokio::runtime::scheduler::multi_thread::MultiThread::block_on::{{closure}}
             at ./usr/local/cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.47.1/src/runtime/scheduler/multi_thread/mod.rs:87:22
  20: tokio::runtime::context::runtime::enter_runtime
             at ./usr/local/cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.47.1/src/runtime/context/runtime.rs:65:16
  21: tokio::runtime::scheduler::multi_thread::MultiThread::block_on
             at ./usr/local/cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.47.1/src/runtime/scheduler/multi_thread/mod.rs:86:9
  22: tokio::runtime::runtime::Runtime::block_on_inner
             at ./usr/local/cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.47.1/src/runtime/runtime.rs:358:50
  23: tokio::runtime::runtime::Runtime::block_on
             at ./usr/local/cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.47.1/src/runtime/runtime.rs:330:18
  24: driver::main
             at ./src/crates/driver/src/main.rs:6:42
  25: core::ops::function::FnOnce::call_once
             at ./rustc/1159e78c4747b02ef996e55082b704c09b970588/library/core/src/ops/function.rs:253:5
  26: std::sys::backtrace::__rust_begin_short_backtrace
             at ./rustc/1159e78c4747b02ef996e55082b704c09b970588/library/std/src/sys/backtrace.rs:158:18
  27: std::rt::lang_start::{{closure}}
             at ./rustc/1159e78c4747b02ef996e55082b704c09b970588/library/std/src/rt.rs:206:18
  28: core::ops::function::impls::<impl core::ops::function::FnOnce<A> for &F>::call_once
             at ./rustc/1159e78c4747b02ef996e55082b704c09b970588/library/core/src/ops/function.rs:290:21
  29: std::panicking::catch_unwind::do_call
             at ./rustc/1159e78c4747b02ef996e55082b704c09b970588/library/std/src/panicking.rs:589:40
  30: std::panicking::catch_unwind
             at ./rustc/1159e78c4747b02ef996e55082b704c09b970588/library/std/src/panicking.rs:552:19
  31: std::panic::catch_unwind
             at ./rustc/1159e78c4747b02ef996e55082b704c09b970588/library/std/src/panic.rs:359:14
  32: std::rt::lang_start_internal::{{closure}}
             at ./rustc/1159e78c4747b02ef996e55082b704c09b970588/library/std/src/rt.rs:175:24
  33: std::panicking::catch_unwind::do_call
             at ./rustc/1159e78c4747b02ef996e55082b704c09b970588/library/std/src/panicking.rs:589:40
  34: std::panicking::catch_unwind
             at ./rustc/1159e78c4747b02ef996e55082b704c09b970588/library/std/src/panicking.rs:552:19
  35: std::panic::catch_unwind
             at ./rustc/1159e78c4747b02ef996e55082b704c09b970588/library/std/src/panic.rs:359:14
  36: std::rt::lang_start_internal
             at ./rustc/1159e78c4747b02ef996e55082b704c09b970588/library/std/src/rt.rs:171:5
  37: main
  38: <unknown>
  39: __libc_start_main
  40: _start
```