### PR TITLE
[TRIVIAL] Fix disable order filtering flag

### DIFF
--- a/crates/autopilot/src/solvable_orders.rs
+++ b/crates/autopilot/src/solvable_orders.rs
@@ -193,12 +193,13 @@ impl SolvableOrdersCache {
             let orders = orders_with_balance(orders, &balances, self.settlement_contract);
             let removed = counter.checkpoint("insufficient_balance", &orders);
             invalid_order_uids.extend(removed);
+
+            let orders = filter_dust_orders(orders, &balances);
+            let removed = counter.checkpoint("dust_order", &orders);
+            filtered_order_events.extend(removed);
+
             orders
         };
-
-        let orders = filter_dust_orders(orders, &balances);
-        let removed = counter.checkpoint("dust_order", &orders);
-        filtered_order_events.extend(removed);
 
         let cow_amm_tokens = cow_amms
             .iter()

--- a/crates/autopilot/src/solvable_orders.rs
+++ b/crates/autopilot/src/solvable_orders.rs
@@ -187,9 +187,14 @@ impl SolvableOrdersCache {
             )
         };
 
-        let orders = orders_with_balance(orders, &balances, self.settlement_contract);
-        let removed = counter.checkpoint("insufficient_balance", &orders);
-        invalid_order_uids.extend(removed);
+        let orders = if self.disable_order_filters {
+            orders
+        } else {
+            let orders = orders_with_balance(orders, &balances, self.settlement_contract);
+            let removed = counter.checkpoint("insufficient_balance", &orders);
+            invalid_order_uids.extend(removed);
+            orders
+        };
 
         let orders = filter_dust_orders(orders, &balances);
         let removed = counter.checkpoint("dust_order", &orders);


### PR DESCRIPTION
# Description
There was a small issue in https://github.com/cowprotocol/services/pull/3688. It only shortcutted the task to fetch the balances but it didn't adjust the logic that uses the now un-fetched balances to filter out orders.

# Changes
now we actually don't run the order filtering logic based on balances depending on the new flag.