### PR TITLE
[TRIVIAL] Bring back DB metrics

### DIFF
--- a/crates/autopilot/src/infra/persistence/mod.rs
+++ b/crates/autopilot/src/infra/persistence/mod.rs
@@ -334,6 +334,11 @@ impl Persistence {
         trades: &[EncodedTrade],
         auction_id: AuctionId,
     ) -> Result<domain::settlement::Auction, error::Auction> {
+        let _timer = Metrics::get()
+            .database_queries
+            .with_label_values(&["get_auction"])
+            .start_timer();
+
         const QUERY: &str = r#"
             WITH
 


### PR DESCRIPTION
# Description
I accidentally removed one useful metric in https://github.com/cowprotocol/services/pull/3654 see [here](https://github.com/cowprotocol/services/pull/3654/files#diff-2aa96c62abd5673078cf88346c59920ddf3563f6e6b2a8644dd3871c6431576dL333-L336).

# Changes
Brings back the histogram timer for the `get_auction` DB query