### PR TITLE
Disallow span guard across .await points

### DIFF
--- a/.clippy.toml
+++ b/.clippy.toml
@@ -3,3 +3,7 @@ disallowed-methods = [
     { path = "alloy::rpc::client::RpcClient::new_batch", reason = "There is no need to manually send batched requests because the alloy transport layer batches requests automatically under the hood." },
     { path = "alloy::rpc::client::BatchRequest::new", reason = "There is no need to manually send batched requests because the alloy transport layer batches requests automatically under the hood." },
 ]
+await-holding-invalid-types = [
+  "tracing::span::Entered",
+  "tracing::span::EnteredSpan",
+]

--- a/crates/autopilot/src/run.rs
+++ b/crates/autopilot/src/run.rs
@@ -153,10 +153,6 @@ pub async fn start(args: impl Iterator<Item = String>) {
 /// Assumes tracing and metrics registry have already been set up.
 pub async fn run(args: Arguments, shutdown_controller: ShutdownController) {
     assert!(args.shadow.is_none(), "cannot run in shadow mode");
-    // Start a new span that measures the initialization phase of the autopilot
-    let startup_span = info_span!("autopilot_startup");
-    let startup_span_guard = startup_span.enter();
-
     let db_write = Postgres::new(args.db_write_url.as_str(), args.insert_batch_size)
         .await
         .unwrap();
@@ -676,7 +672,6 @@ pub async fn run(args: Arguments, shutdown_controller: ShutdownController) {
         Arc::new(maintenance),
         competition_updates_sender,
     );
-    drop(startup_span_guard);
     run.run_forever(shutdown_controller).await;
 }
 

--- a/crates/driver/src/run.rs
+++ b/crates/driver/src/run.rs
@@ -46,10 +46,6 @@ pub async fn run(
 /// Run the driver. This function exists to avoid multiple monomorphizations of
 /// the `run` code, which bloats the binaries and increases compile times.
 async fn run_with(args: cli::Args, addr_sender: Option<oneshot::Sender<SocketAddr>>) {
-    // Start a new span that measures the initialization phase of the driver
-    let startup_span = tracing::info_span!("driver_startup");
-    let startup_span_guard = startup_span.enter();
-
     infra::observe::init(observe::Config::new(
         &args.log,
         args.stderr_threshold,
@@ -105,7 +101,6 @@ async fn run_with(args: cli::Args, addr_sender: Option<oneshot::Sender<SocketAdd
         app_data_retriever,
     );
 
-    drop(startup_span_guard);
     futures::pin_mut!(serve);
     tokio::select! {
         result = &mut serve => panic!("serve task exited: {result:?}"),

--- a/crates/orderbook/src/run.rs
+++ b/crates/orderbook/src/run.rs
@@ -73,9 +73,6 @@ pub async fn start(args: impl Iterator<Item = String>) {
 }
 
 pub async fn run(args: Arguments) {
-    // Start a new span that measures the initialization phase of the orderbook
-    let startup_span = tracing::info_span!("orderbook_startup");
-    let startup_span_guard = startup_span.enter();
     let http_factory = HttpClientFactory::new(&args.http_client);
 
     let web3 = shared::ethrpc::web3(
@@ -461,7 +458,6 @@ pub async fn run(args: Arguments) {
     tracing::info!(%metrics_address, "serving metrics");
     let metrics_task = serve_metrics(orderbook, metrics_address, Default::default());
 
-    drop(startup_span_guard);
     futures::pin_mut!(serve_api);
     tokio::select! {
         result = &mut serve_api => panic!("API task exited {result:?}"),

--- a/crates/solvers/src/domain/solver.rs
+++ b/crates/solvers/src/domain/solver.rs
@@ -21,6 +21,7 @@ use {
     ethereum_types::U256,
     reqwest::Url,
     std::{cmp, collections::HashSet, sync::Arc},
+    tracing::Instrument,
 };
 
 pub struct Solver(Arc<Inner>);
@@ -121,8 +122,7 @@ impl Solver {
         let inner = self.0.clone();
         let span = tracing::Span::current();
         let background_work = async move {
-            let _entered = span.enter();
-            inner.solve(auction, sender).await;
+            inner.solve(auction, sender).instrument(span).await;
         };
 
         let mut handle = tokio::spawn(background_work);


### PR DESCRIPTION
# Description
This is an attempt to address our memory leak that seems to be related to `tracing` based on multiple memory dumps collected by @squadgazzz. I remembered this [article](https://onesignal.com/blog/solving-memory-leaks-in-rust/) which describes an incorrect `tracing` pattern that led to high memory usage for that company as well.

Overall it makes sense to avoid this pattern but I'm not sure it explains why we suddenly got significantly higher memory usage (specifically in the orderbook) with release https://github.com/cowprotocol/services/releases/tag/v2.327.0 as that does not introduce these issues.
What I think it may explain is why the baseline solver shows the memory leak only (IIRC?) when uniswap v3 is enabled. Although we hold the span guard across an `.await` point all liquidity sources except uni v3 don't actually do anything `async` deep down so there would be no reason for the task to yield and AFAIU only the switching of tasks is actually causing issues.

# Changes
- removed extra span for the startup sequence since that doesn't work correctly anyway (even after the startup sequence is finished we still see logs with that span attached to it)
- replace problematic patter in baseline solver with `.instruments(span)` which is appropriate for async tasks (it just wraps the future in a task that enters the span before every poll and exits if afterwards which solves the context switching problem)
- introduced a clippy lint to warn about this pattern

## How to test
deploy to the cluster and see how it affects the memory usage