### PR TITLE
[Hotfix] Use old hooks trampoline on Gnosis

### DIFF
--- a/crates/contracts/src/alloy.rs
+++ b/crates/contracts/src/alloy.rs
@@ -447,7 +447,8 @@ crate::bindings!(
     // <https://github.com/cowprotocol/hooks-trampoline/blob/993427166ade6c65875b932f853776299290ac4b/networks.json>
     crate::deployments! {
         MAINNET  => address!("0x60Bf78233f48eC42eE3F101b9a05eC7878728006"),
-        GNOSIS  => address!("0x60Bf78233f48eC42eE3F101b9a05eC7878728006"),
+        // Gnosis is using the old instance of the hook trampoline since it's hardcoded in gnosis pay rebalance integration.
+        GNOSIS  => address!("0x01DcB88678aedD0C4cC9552B20F4718550250574"),
         SEPOLIA  => address!("0x60Bf78233f48eC42eE3F101b9a05eC7878728006"),
         ARBITRUM_ONE  => address!("0x60Bf78233f48eC42eE3F101b9a05eC7878728006"),
         BASE  => address!("0x60Bf78233f48eC42eE3F101b9a05eC7878728006"),


### PR DESCRIPTION
# Description

In https://github.com/cowprotocol/services/pull/3709 we used the wrong address for the Hooks Trampoline contract on Gnosis.  