### PR TITLE
[hotfix] Revert "Speed up settlement indexing (#3654)"

### DIFF
--- a/crates/autopilot/src/domain/auction/mod.rs
+++ b/crates/autopilot/src/domain/auction/mod.rs
@@ -1,6 +1,5 @@
 use {
     super::{Order, eth},
-    serde::Deserialize,
     std::collections::HashMap,
 };
 
@@ -41,7 +40,7 @@ impl PartialEq for Auction {
 
 /// The price of a token in wei. This represents how much wei is needed to buy
 /// 10**18 of another token.
-#[derive(Debug, Clone, Copy, PartialEq, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub struct Price(eth::Ether);
 
 impl Price {

--- a/crates/autopilot/src/domain/auction/order.rs
+++ b/crates/autopilot/src/domain/auction/order.rs
@@ -1,8 +1,9 @@
 use {
-    crate::domain::{self, eth, fee},
+    crate::{
+        domain,
+        domain::{eth, fee},
+    },
     primitive_types::{H160, H256, U256},
-    serde::Deserialize,
-    serde_with::serde_as,
     std::fmt::{self, Debug, Display, Formatter},
 };
 
@@ -31,9 +32,8 @@ pub struct Order {
 }
 
 // uid as 56 bytes: 32 for orderDigest, 20 for ownerAddress and 4 for validTo
-#[serde_as]
-#[derive(Copy, Clone, PartialEq, Hash, Eq, Deserialize)]
-pub struct OrderUid(#[serde_as(as = "bytes_hex::BytesHex")] pub [u8; 56]);
+#[derive(Copy, Clone, PartialEq, Hash, Eq)]
+pub struct OrderUid(pub [u8; 56]);
 
 impl OrderUid {
     pub fn owner(&self) -> eth::Address {

--- a/crates/autopilot/src/domain/eth/mod.rs
+++ b/crates/autopilot/src/domain/eth/mod.rs
@@ -2,9 +2,6 @@ pub use primitive_types::{H160, H256, U256};
 use {
     crate::{domain, util::conv::U256Ext},
     derive_more::{Display, From, Into},
-    number::serialization::HexOrDecimalU256,
-    serde::Deserialize,
-    serde_with::serde_as,
 };
 
 /// ERC20 token address for ETH. In reality, ETH is not an ERC20 token because
@@ -16,24 +13,12 @@ pub const NATIVE_TOKEN: TokenAddress = TokenAddress(H160([0xee; 20]));
 
 /// An address. Can be an EOA or a smart contract address.
 #[derive(
-    Debug,
-    Default,
-    Clone,
-    Copy,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Hash,
-    From,
-    Into,
-    Display,
-    Deserialize,
+    Debug, Default, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, From, Into, Display,
 )]
 pub struct Address(pub H160);
 
 /// Block number.
-#[derive(Debug, Copy, Clone, From, PartialEq, PartialOrd, Default, Deserialize)]
+#[derive(Debug, Copy, Clone, From, PartialEq, PartialOrd, Default)]
 pub struct BlockNo(pub u64);
 
 /// Adding blocks to a block number.
@@ -52,7 +37,7 @@ pub struct TxId(pub H256);
 /// An ERC20 token address.
 ///
 /// https://eips.ethereum.org/EIPS/eip-20
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, From, Into, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, From, Into)]
 pub struct TokenAddress(pub H160);
 
 impl TokenAddress {
@@ -267,7 +252,6 @@ pub struct Asset {
 }
 
 /// An amount of native Ether tokens denominated in wei.
-#[serde_as]
 #[derive(
     Clone,
     Copy,
@@ -282,9 +266,8 @@ pub struct Asset {
     Default,
     derive_more::Add,
     derive_more::Sub,
-    Deserialize,
 )]
-pub struct Ether(#[serde_as(as = "HexOrDecimalU256")] pub U256);
+pub struct Ether(pub U256);
 
 impl num::Saturating for Ether {
     fn saturating_add(self, v: Self) -> Self {

--- a/crates/autopilot/src/domain/fee/mod.rs
+++ b/crates/autopilot/src/domain/fee/mod.rs
@@ -16,7 +16,6 @@ use {
     derive_more::Into,
     primitive_types::{H160, U256},
     rust_decimal::Decimal,
-    serde::Deserialize,
     std::{collections::HashSet, str::FromStr},
 };
 
@@ -267,8 +266,7 @@ impl ProtocolFees {
     }
 }
 
-#[derive(Debug, Copy, Clone, PartialEq, Deserialize)]
-#[serde(tag = "type")]
+#[derive(Debug, Copy, Clone, PartialEq)]
 pub enum Policy {
     /// If the order receives more than limit price, take the protocol fee as a
     /// percentage of the difference. The fee is taken in `sell` token for
@@ -303,7 +301,7 @@ pub enum Policy {
     },
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Into, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Into)]
 pub struct FeeFactor(f64);
 
 /// TryFrom implementation for the cases we want to enforce the constrain [0, 1)
@@ -327,7 +325,7 @@ impl FromStr for FeeFactor {
     }
 }
 
-#[derive(Debug, Copy, Clone, PartialEq, Deserialize)]
+#[derive(Debug, Copy, Clone, PartialEq)]
 pub struct Quote {
     /// The amount of the sell token.
     pub sell_amount: U256,

--- a/crates/autopilot/src/domain/settlement/auction.rs
+++ b/crates/autopilot/src/domain/settlement/auction.rs
@@ -2,15 +2,10 @@
 
 use {
     crate::domain::{self},
-    serde::Deserialize,
     std::collections::{HashMap, HashSet},
 };
 
-/// Auction data that is relevant for processing a specific onchain
-/// transaction. e.g. `prices` will contain only prices for tokens
-/// that were actually traded in the transaction - not ALL the prices
-/// that were provided in the original auction.
-#[derive(Debug, Deserialize)]
+#[derive(Debug)]
 pub struct Auction {
     pub id: domain::auction::Id,
     /// The block on top of which the auction was created.

--- a/crates/autopilot/src/infra/persistence/mod.rs
+++ b/crates/autopilot/src/infra/persistence/mod.rs
@@ -2,7 +2,7 @@ use {
     crate::{
         boundary,
         database::{Postgres, order_events::store_order_events},
-        domain::{self, eth, settlement::transaction::EncodedTrade},
+        domain::{self, eth},
         infra::persistence::dto::AuctionId,
     },
     anyhow::Context,
@@ -27,8 +27,7 @@ use {
         SigningScheme as DomainSigningScheme,
     },
     futures::{StreamExt, TryStreamExt},
-    itertools::Itertools,
-    number::conversions::{u256_to_big_decimal, u256_to_big_uint},
+    number::conversions::{big_decimal_to_u256, u256_to_big_decimal, u256_to_big_uint},
     primitive_types::H256,
     shared::db_order_conversions::full_order_into_model_order,
     std::{
@@ -326,147 +325,124 @@ impl Persistence {
         Ok(ex.commit().await?)
     }
 
-    /// Returns only auction data that is relevant for processing the
-    /// settled trades. e.g. only native prices for traded tokens are
-    /// included - not ALL native prices provided in the auction.
+    /// Get auction data.
     pub async fn get_auction(
         &self,
-        trades: &[EncodedTrade],
-        auction_id: AuctionId,
+        auction_id: domain::auction::Id,
     ) -> Result<domain::settlement::Auction, error::Auction> {
         let _timer = Metrics::get()
             .database_queries
             .with_label_values(&["get_auction"])
             .start_timer();
 
-        const QUERY: &str = r#"
-            WITH
+        let mut ex = self
+            .postgres
+            .pool
+            .begin()
+            .await
+            .map_err(error::Auction::DatabaseError)?;
 
-            -- only the native prices of tokens that were traded
-            prices AS (
-                SELECT '0x' || encode(token, 'hex') as token, price::text
-                FROM auction_prices
-                WHERE auction_id = $1
-                  AND token = ANY($2)
-            ),
+        let surplus_capturing_jit_order_owners =
+            database::surplus_capturing_jit_order_owners::fetch(&mut ex, auction_id)
+                .await
+                .map_err(error::Auction::DatabaseError)?
+                .ok_or(error::Auction::NotFound)?
+                .into_iter()
+                .map(|owner| eth::H160(owner.0).into())
+                .collect();
 
-            -- only jit order owners that traded in the settlement
-            jit_owners AS (
-                SELECT ARRAY (
-                    SELECT unnest(owners)
-                    INTERSECT
-                    SELECT unnest($3)
-                ) as addresses
-                FROM surplus_capturing_jit_order_owners
-                WHERE auction_id = $1
-            ),
+        let prices = database::auction_prices::fetch(&mut ex, auction_id)
+            .await
+            .map_err(error::Auction::DatabaseError)?
+            .into_iter()
+            .map(|price| {
+                let token = eth::H160(price.token.0).into();
+                let price = big_decimal_to_u256(&price.price)
+                    .ok_or(domain::auction::InvalidPrice)
+                    .and_then(|p| domain::auction::Price::try_new(p.into()))
+                    .map_err(|_err| error::Auction::InvalidPrice(token));
+                price.map(|price| (token, price))
+            })
+            .collect::<Result<_, _>>()?;
 
-            -- only fee policies of orders that were settled
-            fee_policies_json AS (
-                SELECT
-                    fp.order_uid as order_uid,
-                    jsonb_agg(
-                        CASE fp.kind
-                            WHEN 'surplus' THEN
-                                jsonb_build_object(
-                                    'type', 'Surplus',
-                                    'factor', fp.surplus_factor,
-                                    'max_volume_factor', fp.surplus_max_volume_factor
-                                )
-                            WHEN 'volume' THEN
-                                jsonb_build_object(
-                                    'type', 'Volume',
-                                    'factor', fp.volume_factor
-                                )
-                            WHEN 'priceimprovement' THEN
-                                jsonb_build_object(
-                                    'type', 'PriceImprovement',
-                                    'factor', fp.price_improvement_factor,
-                                    'max_volume_factor', fp.price_improvement_max_volume_factor,
-                                    'quote', jsonb_build_object(
-                                        'sell_amount', oq.sell_amount::text,
-                                        'buy_amount', oq.buy_amount::text,
-                                        'fee', trunc(oq.gas_amount * oq.gas_price / oq.sell_token_price)::text,
-                                        'solver', '0x' || encode(oq.solver, 'hex')
-                                    )
-                                )
-                        END
-                    ) as fee_policy
-                FROM fee_policies fp
-                LEFT JOIN order_quotes oq
-                    ON oq.order_uid = fp.order_uid
-                    -- only fetch quotes for orders that need it for the fee policy
-                    AND fp.kind = 'priceimprovement'
-                WHERE fp.auction_id = $1
-                  AND fp.order_uid = ANY($4)
-                GROUP BY fp.order_uid
-            ),
+        let orders = {
+            // get all orders from a competition auction
+            let auction_orders = database::auction_orders::fetch(&mut ex, auction_id)
+                .await
+                .map_err(error::Auction::DatabaseError)?
+                .ok_or(error::Auction::NotFound)?
+                .into_iter()
+                .map(|order| domain::OrderUid(order.0))
+                .collect::<HashSet<_>>();
 
-            -- ensure orders that don't have fee policies get an entry with an empty array
-            all_orders AS (
-                SELECT
-                    '0x' || encode(order_uid, 'hex') as order_uid,
-                    COALESCE(
-                        (SELECT fee_policy FROM fee_policies_json fpj WHERE fpj.order_uid = input.order_uid),
-                        '[]'::jsonb
-                    ) as fee_policy
-                FROM unnest($4) AS input(order_uid)
-                -- make sure that we only create entries for orders we actually had
-                -- in the database
-                JOIN orders o
-                    ON o.uid = input.order_uid
-            ),
-
-            -- start block of the auction
-            competition AS (
-                SELECT json->>'auctionStartBlock' AS block
-                FROM solver_competitions
-                WHERE id = $1
+            // get fee policies for all orders that were part of the competition auction
+            let fee_policies = database::fee_policies::fetch_all(
+                &mut ex,
+                auction_orders
+                    .iter()
+                    .map(|o| (auction_id, ByteArray(o.0)))
+                    .collect::<Vec<_>>()
+                    .as_slice(),
             )
+            .await
+            .map_err(error::Auction::DatabaseError)?
+            .into_iter()
+            .map(|((_, order), policies)| (domain::OrderUid(order.0), policies))
+            .collect::<HashMap<_, _>>();
 
-            -- assemble final JSON response
-            SELECT jsonb_build_object(
-                'id', $1,
-                'prices', (SELECT coalesce(jsonb_object_agg(token, price), '{}') FROM prices),
-                'block', (SELECT block::int FROM competition),
-                'orders', (SELECT coalesce(jsonb_object_agg(ao.order_uid, ao.fee_policy), '{}') FROM all_orders ao),
-                'surplus_capturing_jit_order_owners', COALESCE((
-                    SELECT jsonb_agg('0x' || encode(address, 'hex')) 
-                    FROM unnest((SELECT addresses FROM jit_owners)) AS address
-                ), '[]'::jsonb)
-            )
-        "#;
+            // get quotes for all orders with PriceImprovement fee policy
+            let quotes = self
+                .postgres
+                .read_quotes(fee_policies.iter().filter_map(|(order_uid, policies)| {
+                    policies
+                        .iter()
+                        .any(|policy| {
+                            matches!(
+                                policy.kind,
+                                database::fee_policies::FeePolicyKind::PriceImprovement
+                            )
+                        })
+                        .then_some(order_uid)
+                }))
+                .await
+                .map_err(error::Auction::DatabaseError)?;
 
-        let mut traded_tokens = HashSet::with_capacity(trades.len() * 2);
-        let mut order_uids = Vec::with_capacity(trades.len());
-        let mut traders = Vec::with_capacity(trades.len());
-        for trade in trades {
-            traded_tokens.insert(ByteArray(trade.sell.token.0.0));
-            traded_tokens.insert(ByteArray(trade.buy.token.0.0));
-            order_uids.push(ByteArray(trade.uid.0));
-            traders.push(ByteArray(trade.uid.owner().0.0));
-        }
-        let traded_tokens = traded_tokens.into_iter().collect_vec();
+            // compile order data
+            let mut orders = HashMap::new();
+            for order in auction_orders.iter() {
+                let order_policies = match fee_policies.get(order) {
+                    Some(policies) => policies
+                        .iter()
+                        .cloned()
+                        .map(|policy| {
+                            dto::fee_policy::try_into_domain(policy, quotes.get(order))
+                                .map_err(|err| error::Auction::InvalidFeePolicy(err, *order))
+                        })
+                        .collect::<Result<Vec<_>, _>>()?,
+                    None => vec![],
+                };
+                orders.insert(*order, order_policies);
+            }
+            orders
+        };
 
-        let mut tx = self.postgres.pool.acquire().await?;
-        let res: sqlx::types::JsonValue = sqlx::query_scalar(QUERY)
-            .bind(auction_id)
-            .bind(&traded_tokens)
-            .bind(&traders)
-            .bind(&order_uids)
-            .fetch_one(tx.deref_mut())
-            .await?;
+        let block = {
+            let competition = database::solver_competition::load_by_id(&mut ex, auction_id)
+                .await?
+                .ok_or(error::Auction::NotFound)?;
+            serde_json::from_value::<boundary::SolverCompetitionDB>(competition.json)
+                .map_err(|_| error::Auction::NotFound)?
+                .auction_start_block
+                .into()
+        };
 
-        if res.get("block").is_none_or(|val| val.is_null()) {
-            tracing::error!(auction_id, "could not find the auction");
-            return Err(error::Auction::NotFound);
-        }
-        let res = serde_json::from_value(res).map_err(|err| {
-            tracing::error!(auction_id, ?err, "failed to deserialize auction");
-            error::Auction::NotFound
-        })?;
-
-        Ok(res)
+        Ok(domain::settlement::Auction {
+            id: auction_id,
+            block,
+            orders,
+            prices,
+            surplus_capturing_jit_order_owners,
+        })
     }
 
     /// Computes solvable orders based on the latest observed block number,

--- a/crates/bytes-hex/src/lib.rs
+++ b/crates/bytes-hex/src/lib.rs
@@ -1,12 +1,7 @@
 //! Serialization of Vec<u8> to 0x prefixed hex string
 
 use {
-    serde::{
-        Deserialize,
-        Deserializer,
-        Serializer,
-        de::{self, Error},
-    },
+    serde::{Deserialize, Deserializer, Serializer, de::Error},
     serde_with::{DeserializeAs, SerializeAs},
     std::borrow::Cow,
 };
@@ -56,49 +51,6 @@ impl<'de> DeserializeAs<'de, Vec<u8>> for BytesHex {
         D: Deserializer<'de>,
     {
         deserialize(deserializer)
-    }
-}
-
-impl<'de, const N: usize> DeserializeAs<'de, [u8; N]> for BytesHex {
-    fn deserialize_as<D: Deserializer<'de>>(deserializer: D) -> Result<[u8; N], D::Error> {
-        struct Visitor<const N: usize> {
-            result: [u8; N],
-        }
-
-        impl<const N: usize> de::Visitor<'_> for Visitor<N> {
-            type Value = [u8; N];
-
-            fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
-                write!(
-                    formatter,
-                    "a hex-encoded string starting with \"0x\" containing {N} bytes",
-                )
-            }
-
-            fn visit_str<E>(mut self, s: &str) -> Result<Self::Value, E>
-            where
-                E: de::Error,
-            {
-                if !s.starts_with("0x") {
-                    return Err(de::Error::custom(format!(
-                        "failed to decode {s:?} as a hex string: missing \"0x\" prefix",
-                    )));
-                }
-                let decoded = hex::decode(&s[2..]).map_err(|err| {
-                    de::Error::custom(format!("failed to decode {s:?} as a hex string: {err}",))
-                })?;
-                if decoded.len() != N {
-                    return Err(de::Error::custom(format!(
-                        "failed to decode {s:?} as a hex string: expected {N} bytes, got {}",
-                        decoded.len()
-                    )));
-                }
-                self.result.copy_from_slice(&decoded);
-                Ok(self.result)
-            }
-        }
-
-        deserializer.deserialize_str(Visitor { result: [0; N] })
     }
 }
 


### PR DESCRIPTION
This reverts commit adb9dc668b0ad6dd9f4f823214bd45191a0fcf23.

# Description

After today's deployment we started having issues where transaction hashes are not present for settlements. This PR is a suspect. 

More context: https://cowservices.slack.com/archives/C0361CDD1FZ/p1759252600242209