### PR TITLE
Documentation for SignatureCheck::requires_setup

### DIFF
--- a/crates/shared/src/signature_validator/mod.rs
+++ b/crates/shared/src/signature_validator/mod.rs
@@ -25,6 +25,18 @@ pub struct SignatureCheck {
 }
 
 impl SignatureCheck {
+    /// A signature check requires setup when there are interactions to be taken
+    /// into account or when the balance override is set.
+    ///
+    /// Interactions require setup because a trader may not be able to trade
+    /// without the pre-interaction, consider a case where, through the
+    /// pre-interaction, the trader claims an airdrop, giving them enough
+    /// balance to perform the trade; thus we need to simulate the
+    /// pre-interaction first to validate whether the trader can actually
+    /// perform the trade.
+    ///
+    /// The balance override is a simple way to test for things like flashloans,
+    /// where we simply assume the user will have X funds.
     fn requires_setup(&self) -> bool {
         !self.interactions.is_empty() || self.balance_override.is_some()
     }


### PR DESCRIPTION
# Description
Adds a doc string to the SignatureCheck::requires_setup function explaining when it is true, and why the conditions make it so — i.e. why the conditions mean they require setup.

## Context

I'm learning about order validation and this is part of that path.

@anxolin shared the following insight into signature checking:
<details><summary>Details</summary>
<p>

* Orderbook API doesn't accept unsigned orders
* Orders can be signed with:
	* Your EOA (ERC702) --> this is well understood. Easy to verify the order and the signature match the expected owner
	* Pre-sign --> this is well understood. Easy to verify the state of the settlement contract has in its storage pre-approved a orderUid matching the order.
	* ERC1271 --> The backend needs to ask the owner contract (the one that has the funds) if the order in question is signed (isValidSignature(..)).
* Signing is not enough!
	* you need allowance
	* you need balance
* One problem, imagine an order with a pre-hook that claims an airdrop of DUMPY token.
	* At order placing time, the owner the pre-hook has 0 DUMPY (claiming didn't happen, is a pre-hook)
	* If we just naively check the balance of the owner, we think they can't trade, but they can trade because before executing the swap we need to execute the pre-hook, inmediatly getting the tokens
	* Therefore, we need some kind of simulation of the pre-hook and observe if that changes things enabling the swap. After including the hook call as part of the simulation we have 1,000 DUMPY , so now the order becomes OPEN!
* If we aim to have verified quotes, we need to take the above into account
* Are we good with this then? No quite. Similar to hooks, now orders can include a new hint (flashloan hints).
	* It signals you want magic internet money in an address of your choosing (normally the trader, so it has tokens to dump)
	* Now, when doing simulations you need to be more imaginative. You need to pretend the money is there
	* There's multiple ways to do that, one being state overrides which is a RPC feature allowing you to mock some balances
	* Flashloans have more complexities, but for now, this is good enouh

There's also this other conversation here: <see below>

Why do we care about simulations:
* Without them we can't "verify quotes". Therefore, we can tell if a solver proposal is bullshit or not
* Without them we can't properly estimate the gas
	* At quote time --> Order quote is too good to be true
	* At solving time --> Solver will have a loss

</p>
</details> 

From the mentioned conversation, the relevant part is:

<details><summary>Details</summary>
<p>

But Carlos suggested it’s probably enough to use the existing simulation logic and just fake taking out the flashloan by giving the flashloan target the tokens via storage overrides.

</p>
</details> 

# Changes
<!-- List of detailed changes (how the change is accomplished) -->

- [ ] Add docstring

## How to test
N/A

<!--
## Related Issues

Fixes #
-->