### PR TITLE
Drop V092 Flyway migration

### DIFF
--- a/database/sql/V092___drop_auction_orders_table.sql
+++ b/database/sql/V092___drop_auction_orders_table.sql
@@ -1,2 +1,0 @@
--- Drop auction_orders table
-DROP TABLE IF EXISTS auction_orders;


### PR DESCRIPTION
In #3747, the `auction_orders` table is dropped, but since we now run 2 autopilots in parallel on each service restart, dropping the table right away would cause panics in the currently active autopilot, which is not aware of the latest changes. This PR drops the migration that would need to be added only in the next release.

Since the previous PR was already merged, it has been applied on staging already, which now requires manually altering the `flyway_schema_history` on each chain before merging this PR 😓 