### PR TITLE
Drop `auction_orders` table in DB

### DIFF
--- a/database/sql/V092___drop_auction_orders_table.sql
+++ b/database/sql/V092___drop_auction_orders_table.sql
@@ -1,0 +1,2 @@
+-- Drop auction_orders table
+DROP TABLE IF EXISTS auction_orders;


### PR DESCRIPTION
Actually drops the table from the DB. More details can be found in [the previous PR](https://github.com/cowprotocol/services/pull/3751). Should be released separately from the previously mentioned PR.