### PR TITLE
fix: Access list not being taken into account in the shared balance simulator #3749

### DIFF
--- a/crates/shared/src/account_balances/simulation.rs
+++ b/crates/shared/src/account_balances/simulation.rs
@@ -4,14 +4,15 @@
 
 use {
     super::{BalanceFetching, Query, TransferSimulationError},
-    crate::account_balances::BalanceSimulator,
-    anyhow::Result,
+    crate::account_balances::{BalanceSimulator, SimulationError},
+    anyhow::{Context, Result},
     contracts::{BalancerV2Vault, erc20::Contract},
-    ethcontract::{H160, U256},
+    ethcontract::{Bytes, H160, U256, contract::MethodBuilder, dyns::DynTransport},
     ethrpc::Web3,
     futures::future,
     model::order::SellTokenSource,
     tracing::instrument,
+    web3::{Transport, types::CallRequest},
 };
 
 pub struct Balances {
@@ -45,18 +46,7 @@ impl Balances {
     }
 
     async fn tradable_balance_simulated(&self, query: &Query) -> Result<U256> {
-        let simulation = self
-            .balance_simulator
-            .simulate(
-                query.owner,
-                query.token,
-                query.source,
-                &query.interactions,
-                None,
-                |delegate_call| async move { delegate_call },
-                query.balance_override.clone(),
-            )
-            .await?;
+        let simulation = self.simulate_with_access_list(query, None).await?;
         Ok(if simulation.can_transfer {
             simulation.effective_balance
         } else {
@@ -106,6 +96,108 @@ impl Balances {
         };
         Ok(usable_balance)
     }
+
+    async fn simulate_with_access_list(
+        &self,
+        query: &Query,
+        amount: Option<U256>,
+    ) -> std::result::Result<crate::account_balances::Simulation, SimulationError> {
+        let should_add_access_list = !query.interactions.is_empty();
+        let web3 = self.web3.clone();
+
+        self.balance_simulator
+            .simulate(
+                query.owner,
+                query.token,
+                query.source,
+                &query.interactions,
+                amount,
+                move |delegate_call| {
+                    let web3 = web3.clone();
+                    async move {
+                        if should_add_access_list {
+                            Self::apply_access_list(web3, delegate_call).await
+                        } else {
+                            delegate_call
+                        }
+                    }
+                },
+                query.balance_override.clone(),
+            )
+            .await
+    }
+
+    async fn apply_access_list(
+        web3: Web3,
+        delegate_call: MethodBuilder<DynTransport, Bytes<Vec<u8>>>,
+    ) -> MethodBuilder<DynTransport, Bytes<Vec<u8>>> {
+        match Self::fetch_access_list(web3, &delegate_call).await {
+            Ok(Some(access_list)) if !access_list.is_empty() => {
+                delegate_call.access_list(access_list)
+            }
+            Ok(_) => delegate_call,
+            Err(err) => {
+                tracing::debug!(
+                    ?err,
+                    "failed to generate access list for balance simulation"
+                );
+                delegate_call
+            }
+        }
+    }
+
+    async fn fetch_access_list(
+        web3: Web3,
+        delegate_call: &MethodBuilder<DynTransport, Bytes<Vec<u8>>>,
+    ) -> Result<Option<web3::types::AccessList>> {
+        let request = Self::call_request(delegate_call);
+        let params = serde_json::to_value(&request)
+            .context("serialize delegate call for eth_createAccessList")?;
+        let response = web3
+            .transport()
+            .execute("eth_createAccessList", vec![params])
+            .await
+            .context("eth_createAccessList RPC call failed")?;
+
+        if let Some(error) = response.get("error") {
+            anyhow::bail!("eth_createAccessList returned error: {error}");
+        }
+
+        response
+            .get("accessList")
+            .cloned()
+            .map(|value| {
+                serde_json::from_value(value)
+                    .context("failed to deserialize eth_createAccessList response")
+            })
+            .transpose()
+    }
+
+    fn call_request(delegate_call: &MethodBuilder<DynTransport, Bytes<Vec<u8>>>) -> CallRequest {
+        let resolved_gas_price = delegate_call
+            .tx
+            .gas_price
+            .map(|gas_price| gas_price.resolve_for_transaction())
+            .unwrap_or_default();
+
+        CallRequest {
+            from: delegate_call
+                .tx
+                .from
+                .as_ref()
+                .map(|account| account.address()),
+            to: delegate_call.tx.to,
+            gas: delegate_call.tx.gas,
+            gas_price: resolved_gas_price.gas_price,
+            value: delegate_call.tx.value,
+            data: delegate_call.tx.data.clone(),
+            transaction_type: resolved_gas_price.transaction_type,
+            access_list: delegate_call.tx.access_list.clone(),
+            max_fee_per_gas: resolved_gas_price.max_fee_per_gas,
+            max_priority_fee_per_gas: resolved_gas_price.max_priority_fee_per_gas,
+            ..Default::default()
+        }
+    }
 }
 
 #[async_trait::async_trait]
@@ -134,16 +226,7 @@ impl BalanceFetching for Balances {
         amount: U256,
     ) -> Result<(), TransferSimulationError> {
         let simulation = self
-            .balance_simulator
-            .simulate(
-                query.owner,
-                query.token,
-                query.source,
-                &query.interactions,
-                Some(amount),
-                |delegate_call| async move { delegate_call },
-                query.balance_override.clone(),
-            )
+            .simulate_with_access_list(query, Some(amount))
             .await
             .map_err(|err| TransferSimulationError::Other(err.into()))?;
 
@@ -166,10 +249,200 @@ mod tests {
     use {
         super::*,
         crate::price_estimation::trade_verifier::balance_overrides::DummyOverrider,
-        ethrpc::Web3,
+        ethcontract::common::abi::{Function, StateMutability},
+        ethcontract::{
+            contract::MethodBuilder,
+            dyns::DynTransport,
+            transaction::{Account, GasPrice},
+        },
+        ethrpc::{
+            Web3,
+            mock::{self, MockTransport},
+        },
         model::order::SellTokenSource,
+        primitive_types::H256,
+        serde_json::{Value, json},
         std::sync::Arc,
+        web3::types::{AccessListItem, Bytes as Web3Bytes, CallRequest, U64},
     };
+
+    const ACCESS_LIST_ADDRESS: H160 = H160([0x11; 20]);
+
+    fn dummy_function() -> Function {
+        #[allow(deprecated)]
+        {
+            Function {
+                name: "dummy".into(),
+                inputs: vec![],
+                outputs: vec![],
+                constant: None,
+                state_mutability: StateMutability::NonPayable,
+            }
+        }
+    }
+
+    fn method_builder(transport: &MockTransport) -> MethodBuilder<DynTransport, Bytes<Vec<u8>>> {
+        let dyn_transport = DynTransport::new(transport.clone());
+        let method_web3 = web3::Web3::new(dyn_transport);
+        MethodBuilder::new(
+            method_web3,
+            dummy_function(),
+            ACCESS_LIST_ADDRESS,
+            Web3Bytes(vec![0xde, 0xad, 0xbe, 0xef]),
+        )
+    }
+
+    fn mock_web3_with_transport() -> (Web3, MockTransport) {
+        let mock = mock::web3();
+        let transport = mock.legacy.transport().clone();
+        let dyn_transport = DynTransport::new(transport.clone());
+        (
+            Web3 {
+                legacy: web3::Web3::new(dyn_transport),
+                alloy: mock.alloy,
+                wallet: mock.wallet,
+            },
+            transport,
+        )
+    }
+
+    fn expect_access_list_request(
+        transport: &MockTransport,
+        expected_request: CallRequest,
+        response: Value,
+    ) {
+        transport
+            .mock()
+            .expect_execute()
+            .once()
+            .returning(move |method, params| {
+                assert_eq!(method, "eth_createAccessList");
+                assert_eq!(params.len(), 1);
+                let actual: CallRequest = serde_json::from_value(params[0].clone()).unwrap();
+                assert_eq!(actual, expected_request);
+                Ok(response.clone())
+            });
+    }
+
+    #[test]
+    fn call_request_copies_transaction_fields() {
+        let transport = MockTransport::new();
+        let from = H160([0x22; 20]);
+        let delegate_call = method_builder(&transport)
+            .from(Account::Local(from, None))
+            .gas(123.into())
+            .gas_price(GasPrice::Eip1559 {
+                max_fee_per_gas: 50.into(),
+                max_priority_fee_per_gas: 4.into(),
+            })
+            .value(456.into())
+            .nonce(789.into())
+            .access_list(vec![AccessListItem {
+                address: H160([0x33; 20]),
+                storage_keys: vec![H256::from_low_u64_be(1)],
+            }]);
+
+        let request = Balances::call_request(&delegate_call);
+        assert_eq!(request.from, Some(from));
+        assert_eq!(request.to, Some(ACCESS_LIST_ADDRESS));
+        assert_eq!(request.gas, Some(123.into()));
+        assert_eq!(request.value, Some(456.into()));
+        assert_eq!(request.data, delegate_call.tx.data.clone());
+        assert_eq!(
+            request.access_list,
+            Some(vec![AccessListItem {
+                address: H160([0x33; 20]),
+                storage_keys: vec![H256::from_low_u64_be(1)],
+            }])
+        );
+        assert_eq!(request.transaction_type, Some(U64::from(2))); // EIP-1559
+        assert_eq!(request.max_fee_per_gas, Some(50.into()));
+        assert_eq!(request.max_priority_fee_per_gas, Some(4.into()));
+        assert_eq!(request.gas_price, None); // Should be None for EIP-1559
+    }
+
+    #[tokio::test]
+    async fn fetch_access_list_deserializes_response() {
+        let (web3, transport) = mock_web3_with_transport();
+        let delegate_transport = MockTransport::new();
+        let delegate_call = method_builder(&delegate_transport).access_list(vec![AccessListItem {
+            address: H160([0x44; 20]),
+            storage_keys: vec![H256::from_low_u64_be(2)],
+        }]);
+        let expected_request = Balances::call_request(&delegate_call);
+        let expected_access_list = vec![AccessListItem {
+            address: H160([0x55; 20]),
+            storage_keys: vec![H256::from_low_u64_be(3)],
+        }];
+        let response = json!({ "accessList": expected_access_list });
+
+        expect_access_list_request(&transport, expected_request, response);
+
+        let result = Balances::fetch_access_list(web3, &delegate_call)
+            .await
+            .expect("rpc call succeeds");
+        assert_eq!(result, Some(expected_access_list));
+    }
+
+    #[tokio::test]
+    async fn fetch_access_list_propagates_rpc_errors() {
+        let (web3, transport) = mock_web3_with_transport();
+        let delegate_call = method_builder(&MockTransport::new());
+        let expected_request = Balances::call_request(&delegate_call);
+        let error_response = json!({ "error": "boom" });
+
+        expect_access_list_request(&transport, expected_request, error_response);
+
+        let err = Balances::fetch_access_list(web3, &delegate_call)
+            .await
+            .expect_err("error is propagated");
+        assert!(
+            err.to_string()
+                .contains("eth_createAccessList returned error")
+        );
+    }
+
+    #[tokio::test]
+    async fn apply_access_list_sets_non_empty_result() {
+        let (web3, transport) = mock_web3_with_transport();
+        let delegate_call = method_builder(&MockTransport::new());
+        let expected_request = Balances::call_request(&delegate_call);
+        let expected_access_list = vec![AccessListItem {
+            address: H160([0x66; 20]),
+            storage_keys: vec![H256::from_low_u64_be(4)],
+        }];
+        let response = json!({ "accessList": expected_access_list.clone() });
+
+        expect_access_list_request(&transport, expected_request, response);
+
+        let updated = Balances::apply_access_list(web3, delegate_call).await;
+        assert_eq!(updated.tx.access_list, Some(expected_access_list));
+    }
+
+    #[tokio::test]
+    async fn apply_access_list_ignores_empty_or_failed_lists() {
+        let (web3_empty, transport_empty) = mock_web3_with_transport();
+        let delegate_call_empty = method_builder(&MockTransport::new());
+        let expected_request_empty = Balances::call_request(&delegate_call_empty);
+        expect_access_list_request(
+            &transport_empty,
+            expected_request_empty,
+            json!({ "accessList": [] }),
+        );
+        let updated_empty = Balances::apply_access_list(web3_empty, delegate_call_empty).await;
+        assert!(updated_empty.tx.access_list.is_none());
+
+        let (web3_error, transport_error) = mock_web3_with_transport();
+        let delegate_call_error = method_builder(&MockTransport::new());
+        let expected_request_error = Balances::call_request(&delegate_call_error);
+        expect_access_list_request(
+            &transport_error,
+            expected_request_error,
+            json!({ "error": "nope" }),
+        );
+        let updated_error = Balances::apply_access_list(web3_error, delegate_call_error).await;
+        assert!(updated_error.tx.access_list.is_none());
+    }
 
     #[ignore]
     #[tokio::test]


### PR DESCRIPTION
# Description
1/ Added a shared balance simulation helper that generates access lists via eth_createAccessList and applies them to the settlement delegate call when pre-interactions are present, ensuring storage warm-up is mirrored in simulations.
2/ Reused the helper in both simulated balance retrieval and transfer validation so access lists consistently influence tradable balance checks.
3/ Added comprehensive unit tests around balance simulation access list handling, covering call serialization, RPC responses, and builder helpers to ensure eth_createAccessList requests are formed as expected.
4/ Exercised apply_access_list with non-empty, empty, and error responses to confirm only valid access lists modify the delegate call configuration.

# Changes

## How to test
`cargo test`

```
...
e_interactions: [], post_interactions: [], sell_token_source: Erc20, buy_token_destination: Erc20 }, block_dependent: false, tim
eout: 5s } result=Err(UnsupportedToken { token: 0x0000000000000000000000000000000000000000, reason: "" }) estimator="second"
test price_estimation::competition::tests::works ... ok
test price_estimation::instrumented::tests::records_metrics_for_each_query ... ok
test price_estimation::native::coingecko::tests::prices_adjusted_for_token_with_fewer_decimals ... ignored
test price_estimation::native::coingecko::tests::prices_adjusted_for_token_with_more_decimals ... ignored
test price_estimation::native::coingecko::tests::unknown_token_does_not_ruin_batch ... ignored
test price_estimation::native::coingecko::tests::works ... ignored
test price_estimation::native::coingecko::tests::works_multiple_tokens ... ignored
test price_estimation::native::coingecko::tests::works_xdai ... ignored
test price_estimation::native::oneinch::tests::works ... ignored
test price_estimation::native::tests::computes_price_from_normalized_price ... ok
test price_estimation::native::tests::computes_u256_prices_normalized_to_1e18 ... ok
test price_estimation::native::tests::errors_get_propagated ... ok
test price_estimation::native::tests::normalize_prices_fail_when_outside_valid_input_range ... ok
test price_estimation::native::tests::prices_dont_get_modified ... ok
test price_estimation::native_price_cache::tests::caches_approximated_estimates_use ... ok
test price_estimation::native_price_cache::tests::caches_nonrecoverable_failed_estimates ... ok
test price_estimation::native_price_cache::tests::caches_successful_estimates ... ok
2025-10-09T06:57:11.305Z DEBUG shared::price_estimation::competition: new price estimate query=Query { sell_token: 0x00000000000
00000000000000000000000000000, buy_token: 0x0000000000000000000000000100000000000000, in_amount: U256(1), kind: Buy, verificatio
n: Verification { from: 0x0000000000000000000000000000000000000000, receiver: 0x0000000000000000000000000000000000000000, pre_in
teractions: [], post_interactions: [], sell_token_source: Erc20, buy_token_destination: Erc20 }, block_dependent: false, timeout
: 5s } result=Ok(Estimate { out_amount: 1, gas: 1, solver: 0x0000000000000000000000000000000000000000, verified: false, executio
n: QuoteExecution { interactions: [], pre_interactions: [], jit_orders: [] } }) estimator="second" requests=1 results=1 elapsed=
11.603852ms
2025-10-09T06:57:11.305Z DEBUG shared::price_estimation::competition: winning price estimate query=Query { sell_token: 0x0000000
000000000000000000000000000000000, buy_token: 0x0000000000000000000000000100000000000000, in_amount: U256(1), kind: Buy, verific
ation: Verification { from: 0x0000000000000000000000000000000000000000, receiver: 0x0000000000000000000000000000000000000000, pr
e_interactions: [], post_interactions: [], sell_token_source: Erc20, buy_token_destination: Erc20 }, block_dependent: false, tim
eout: 5s } result=Ok(Estimate { out_amount: 1, gas: 1, solver: 0x0000000000000000000000000000000000000000, verified: false, exec
ution: QuoteExecution { interactions: [], pre_interactions: [], jit_orders: [] } }) estimator="second"
test price_estimation::competition::tests::racing_estimator_returns_early ... ok
test price_estimation::native_price_cache::tests::caches_successful_estimates_with_loaded_prices ... ok
test price_estimation::native_price_cache::tests::does_not_cache_recoverable_failed_estimates ... ok
test price_estimation::native_price_cache::tests::maintenance_can_limit_update_size_to_n ... ok
test price_estimation::native_price_cache::tests::maintenance_can_update_all_old_queries ... ok
test price_estimation::native_price_cache::tests::outdated_entries_prioritized ... ok
test price_estimation::native_price_cache::tests::properly_caches_accumulative_errors ... ok
2025-10-09T06:57:11.494Z DEBUG shared::price_estimation::sanitized: estimate price for buying native asset query=Query { sell_to
ken: 0x0000000000000000000000000100000000000000, buy_token: 0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee, in_amount: U256(1), kind
: Buy, verification: Verification { from: 0x0000000000000000000000000000000000000000, receiver: 0x000000000000000000000000000000
0000000000, pre_interactions: [], post_interactions: [], sell_token_source: Erc20, buy_token_destination: Erc20 }, block_depende
nt: false, timeout: 5s }
2025-10-09T06:57:11.494Z DEBUG shared::price_estimation::sanitized: added cost of converting native asset to price estimation qu
ery=Query { sell_token: 0x0000000000000000000000000100000000000000, buy_token: 0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee, in_am
ount: U256(1), kind: Buy, verification: Verification { from: 0x0000000000000000000000000000000000000000, receiver: 0x00000000000
00000000000000000000000000000, pre_interactions: [], post_interactions: [], sell_token_source: Erc20, buy_token_destination: Erc
20 }, block_dependent: false, timeout: 5s } estimate=Estimate { out_amount: 1, gas: 9323, solver: 0x0000000000000000000000000000
000000000000, verified: false, execution: QuoteExecution { interactions: [], pre_interactions: [], jit_orders: [] } }
2025-10-09T06:57:11.494Z DEBUG shared::price_estimation::sanitized: estimate price for buying native asset query=Query { sell_to
ken: 0x0000000000000000000000000100000000000000, buy_token: 0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee, in_amount: U256(11579208
9237316195423570985008687907853269984665640564039457584007913129639935), kind: Buy, verification: Verification { from: 0x0000000
000000000000000000000000000000000, receiver: 0x0000000000000000000000000000000000000000, pre_interactions: [], post_interactions
: [], sell_token_source: Erc20, buy_token_destination: Erc20 }, block_dependent: false, timeout: 5s }
2025-10-09T06:57:11.494Z DEBUG shared::price_estimation::sanitized: estimate price for selling native asset query=Query { sell_t
oken: 0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee, buy_token: 0x0000000000000000000000000100000000000000, in_amount: U256(1), kin
d: Buy, verification: Verification { from: 0x0000000000000000000000000000000000000000, receiver: 0x00000000000000000000000000000
00000000000, pre_interactions: [], post_interactions: [], sell_token_source: Erc20, buy_token_destination: Erc20 }, block_depend
ent: false, timeout: 5s }
2025-10-09T06:57:11.495Z DEBUG shared::price_estimation::sanitized: added cost of converting native asset to price estimation qu
ery=Query { sell_token: 0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee, buy_token: 0x0000000000000000000000000100000000000000, in_am
ount: U256(1), kind: Buy, verification: Verification { from: 0x0000000000000000000000000000000000000000, receiver: 0x00000000000
00000000000000000000000000000, pre_interactions: [], post_interactions: [], sell_token_source: Erc20, buy_token_destination: Erc
20 }, block_dependent: false, timeout: 5s } estimate=Estimate { out_amount: 1, gas: 24138, solver: 0x000000000000000000000000000
0000000000000, verified: false, execution: QuoteExecution { interactions: [], pre_interactions: [], jit_orders: [] } }
2025-10-09T06:57:11.495Z DEBUG shared::price_estimation::sanitized: generate trivial price estimation query=Query { sell_token:
0x0000000000000000000000000100000000000000, buy_token: 0x0000000000000000000000000100000000000000, in_amount: U256(1), kind: Sel
l, verification: Verification { from: 0x0000000000000000000000000000000000000000, receiver: 0x0000000000000000000000000000000000
000000, pre_interactions: [], post_interactions: [], sell_token_source: Erc20, buy_token_destination: Erc20 }, block_dependent:
false, timeout: 5s } estimation=Estimate { out_amount: 1, gas: 0, solver: 0x0000000000000000000000000000000000000000, verified:
true, execution: QuoteExecution { interactions: [], pre_interactions: [], jit_orders: [] } }
2025-10-09T06:57:11.495Z DEBUG shared::price_estimation::sanitized: generate trivial price estimation query=Query { sell_token:
0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee, buy_token: 0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee, in_amount: U256(1), kind: Sel
l, verification: Verification { from: 0x0000000000000000000000000000000000000000, receiver: 0x0000000000000000000000000000000000
000000, pre_interactions: [], post_interactions: [], sell_token_source: Erc20, buy_token_destination: Erc20 }, block_dependent:
false, timeout: 5s } estimation=Estimate { out_amount: 1, gas: 0, solver: 0x0000000000000000000000000000000000000000, verified:
true, execution: QuoteExecution { interactions: [], pre_interactions: [], jit_orders: [] } }
2025-10-09T06:57:11.495Z DEBUG shared::price_estimation::sanitized: generate trivial unwrap estimation query=Query { sell_token:
 0x0000000000000000000000002a00000000000000, buy_token: 0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee, in_amount: U256(1), kind: Se
ll, verification: Verification { from: 0x0000000000000000000000000000000000000000, receiver: 0x000000000000000000000000000000000
0000000, pre_interactions: [], post_interactions: [], sell_token_source: Erc20, buy_token_destination: Erc20 }, block_dependent:
 false, timeout: 5s } estimation=Estimate { out_amount: 1, gas: 9223, solver: 0x0000000000000000000000000000000000000000, verifi
ed: true, execution: QuoteExecution { interactions: [], pre_interactions: [], jit_orders: [] } }
2025-10-09T06:57:11.495Z DEBUG shared::price_estimation::sanitized: generate trivial wrap estimation query=Query { sell_token: 0
xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee, buy_token: 0x0000000000000000000000002a00000000000000, in_amount: U256(1), kind: Sell
, verification: Verification { from: 0x0000000000000000000000000000000000000000, receiver: 0x00000000000000000000000000000000000
00000, pre_interactions: [], post_interactions: [], sell_token_source: Erc20, buy_token_destination: Erc20 }, block_dependent: f
alse, timeout: 5s } estimation=Estimate { out_amount: 1, gas: 24038, solver: 0x0000000000000000000000000000000000000000, verifie
d: true, execution: QuoteExecution { interactions: [], pre_interactions: [], jit_orders: [] } }
test price_estimation::sanitized::tests::handles_trivial_estimates_on_its_own ... ok
test price_estimation::tests::enable_coin_gecko_buffered ... ok
test price_estimation::tests::string_repr_round_trip_native_price_estimators ... ok
test price_estimation::tests::test_invalid_partial_buffered_present ... ok
test price_estimation::tests::test_parse_tuple ... ok
test price_estimation::tests::test_without_buffered_present ... ok
test price_estimation::trade_verifier::balance_overrides::detector::tests::detects_storage_slots_arbitrum ... ignored
test price_estimation::trade_verifier::balance_overrides::detector::tests::detects_storage_slots_mainnet ... ignored
test price_estimation::trade_verifier::balance_overrides::tests::balance_override_computation ... ok
test price_estimation::trade_verifier::balance_overrides::tests::balance_override_computation_solady ... ok
test price_estimation::trade_verifier::balance_overrides::tests::balance_overrides_none_for_unknown_tokens ... ok
test price_estimation::trade_verifier::tests::discards_inaccurate_quotes ... ok
2025-10-09T06:57:11.503Z DEBUG shared::recent_block_cache: automatically updating 2 entries
2025-10-09T06:57:11.503Z DEBUG shared::recent_block_cache: dropping blocks older than 10 from cache
2025-10-09T06:57:11.503Z DEBUG shared::recent_block_cache: cache was updated and now contains entries=4 items=4
test recent_block_cache::tests::auto_updates_recently_used ... ok
test recent_block_cache::tests::cache_hit_and_miss ... ok
2025-10-09T06:57:11.505Z DEBUG shared::recent_block_cache: automatically updating 2 entries
2025-10-09T06:57:11.505Z DEBUG shared::recent_block_cache: dropping blocks older than 10 from cache
2025-10-09T06:57:11.505Z DEBUG shared::recent_block_cache: cache was updated and now contains entries=10 items=10
2025-10-09T06:57:11.505Z DEBUG shared::recent_block_cache: automatically updating 2 entries
2025-10-09T06:57:11.505Z DEBUG shared::recent_block_cache: dropping blocks older than 11 from cache
2025-10-09T06:57:11.505Z DEBUG shared::recent_block_cache: cache was updated and now contains entries=4 items=4
2025-10-09T06:57:11.505Z DEBUG shared::recent_block_cache: automatically updating 2 entries
2025-10-09T06:57:11.505Z DEBUG shared::recent_block_cache: dropping blocks older than 12 from cache
2025-10-09T06:57:11.506Z DEBUG shared::recent_block_cache: cache was updated and now contains entries=2 items=2
test recent_block_cache::tests::evicts_old_blocks_from_cache ... ok
test recent_block_cache::tests::marks_recently_used ... ok
test recent_block_cache::tests::respects_max_age_limit_for_recent ... ok
test recent_block_cache::tests::uses_most_recent_cached_for_latest_block ... ok
test remaining_amounts::tests::computes_remaining_order_amounts ... ok
test remaining_amounts::tests::remaining_amount_errors ... ok
test remaining_amounts::tests::scale_order_by_available_balance ... ok
test remaining_amounts::tests::support_scaling_for_large_orders_with_partial_balance ... ok
...
             at /rustc/1159e78c4747b02ef996e55082b704c09b970588/library/core/src/panic/unwind_safe.rs:272:9
  25: std::panicking::catch_unwind::do_call
             at /rustc/1159e78c4747b02ef996e55082b704c09b970588/library/std/src/panicking.rs:589:40
  26: std::panicking::catch_unwind
             at /rustc/1159e78c4747b02ef996e55082b704c09b970588/library/std/src/panicking.rs:552:19
  27: std::panic::catch_unwind
             at /rustc/1159e78c4747b02ef996e55082b704c09b970588/library/std/src/panic.rs:359:14
  28: std::thread::Builder::spawn_unchecked_::{{closure}}
             at /rustc/1159e78c4747b02ef996e55082b704c09b970588/library/std/src/thread/mod.rs:557:30
  29: core::ops::function::FnOnce::call_once{{vtable.shim}}
             at /rustc/1159e78c4747b02ef996e55082b704c09b970588/library/core/src/ops/function.rs:253:5
  30: <alloc::boxed::Box<F,A> as core::ops::function::FnOnce<Args>>::call_once
             at /rustc/1159e78c4747b02ef996e55082b704c09b970588/library/alloc/src/boxed.rs:1971:9
  31: std::sys::pal::unix::thread::Thread::new::thread_start
             at /rustc/1159e78c4747b02ef996e55082b704c09b970588/library/std/src/sys/pal/unix/thread.rs:107:17
  32: <unknown>
  33: <unknown>

test sources::balancer_v2::swap::fixed_point::logexpmath::tests::constant_x_20_panic - should panic ... ok
test sources::balancer_v2::swap::fixed_point::logexpmath::tests::exp_error ... ok
test sources::balancer_v2::swap::fixed_point::logexpmath::tests::exp_success ... ok
test sources::balancer_v2::swap::fixed_point::logexpmath::tests::logexpmath_contract_constants_20 ... ok
test sources::balancer_v2::swap::fixed_point::logexpmath::tests::pow_alternate_routes ... ok
test sources::balancer_v2::swap::fixed_point::logexpmath::tests::logexpmath_contract_constants_18 ... ok
test sources::balancer_v2::swap::fixed_point::logexpmath::tests::pow_error ... ok
test sources::balancer_v2::swap::fixed_point::tests::add ... ok
test sources::balancer_v2::swap::fixed_point::tests::bfp_big_rational_round_trip ... ok
test sources::balancer_v2::swap::fixed_point::logexpmath::tests::pow_success ... ok
test sources::balancer_v2::swap::fixed_point::tests::bfp_debug ... ok
test sources::balancer_v2::swap::fixed_point::tests::bfp_exp10 ... ok
test sources::balancer_v2::swap::fixed_point::tests::bfp_from_string ... ok
test sources::balancer_v2::swap::fixed_point::tests::bfp_to_big_rational ... ok
test sources::balancer_v2::swap::fixed_point::tests::big_rational_to_bfp_non_representable ... ok
test sources::balancer_v2::swap::fixed_point::tests::big_rational_to_bfp_overflow ... ok
test sources::balancer_v2::swap::fixed_point::tests::complement ... ok
test sources::balancer_v2::swap::fixed_point::tests::div ... ok
test sources::balancer_v2::swap::fixed_point::tests::big_rational_to_bfp ... ok
test sources::balancer_v2::swap::fixed_point::tests::mul ... ok
test sources::balancer_v2::swap::fixed_point::tests::parsing ... ok
test sources::balancer_v2::swap::fixed_point::tests::sub ... ok
test sources::balancer_v2::swap::math::tests::badd_tests ... ok
test sources::balancer_v2::swap::fixed_point::tests::pow_up ... ok
test sources::balancer_v2::swap::math::tests::bmul_tests ... ok
test sources::balancer_v2::swap::math::tests::bsub_tests ... ok
test sources::balancer_v2::swap::math::tests::div_down_tests ... ok
test sources::balancer_v2::swap::math::tests::div_up_tests ... ok
test sources::balancer_v2::swap::stable_math::tests::in_given_out_three_tokens ... ok
test sources::balancer_v2::swap::stable_math::tests::in_given_out_two_tokens ... ok
test sources::balancer_v2::swap::stable_math::tests::invariant_three_tokens_ok ... ok
test sources::balancer_v2::swap::stable_math::tests::invariant_two_tokens_ok ... ok
test sources::balancer_v2::swap::stable_math::tests::invariant_converges_at_extreme_values ... ok
test sources::balancer_v2::swap::stable_math::tests::out_given_in_three_tokens ... ok
test sources::balancer_v2::swap::stable_math::tests::out_given_in_two_tokens ... ok
test sources::balancer_v2::swap::tests::downscale ... ok
test sources::balancer_v2::swap::tests::construct_balances_and_token_indices ... ok
test sources::balancer_v2::swap::tests::stable_get_amount_out ... ok
test sources::balancer_v2::swap::tests::stable_get_amount_in ... ok
test sources::balancer_v2::swap::tests::weighted_get_amount_in ... ok
test sources::balancer_v2::swap::tests::weighted_get_amount_out ... ok
test sources::balancer_v2::swap::weighted_math::tests::calc_in_given_out_err ... ok
test sources::balancer_v2::swap::weighted_math::tests::calc_in_given_out_ok ... ok
test sources::balancer_v2::swap::weighted_math::tests::calc_out_given_in_err ... ok
test sources::balancer_v2::swap::weighted_math::tests::calc_out_given_in_ok ... ok
test sources::swapr::tests::fetch_swapr_pool ... ignored
test sources::swapr::tests::ignores_contract_errors_when_reading_fee ... ok
test sources::swapr::tests::sets_fee ... ok
test sources::balancer_v2::swap::weighted_math::tests::stops_large_trades ... ok
test sources::uniswap_v2::pair_provider::tests::test_create2_mainnet ... ok
test sources::uniswap_v2::pool_fetching::tests::check_final_reserve_limits ... ok
test sources::uniswap_v2::pool_fetching::tests::computes_final_reserves ... ok
test sources::uniswap_v2::pool_fetching::tests::pool_fetcher_forwards_node_error ... ok
test sources::uniswap_v2::pool_fetching::tests::pool_fetcher_skips_contract_error ... ok
test sources::uniswap_v2::pool_fetching::tests::test_get_amounts_in ... ok
test sources::uniswap_v2::tests::baseline_mainnet ... ignored
test sources::uniswap_v2::tests::baseline_sepolia ... ignored
test sources::uniswap_v2::tests::baseline_xdai ... ignored
test sources::uniswap_v2::tests::fetch_baoswap_pool ... ignored
test sources::uniswap_v2::tests::fetch_honeyswap_pool ... ignored
test sources::uniswap_v2::pool_fetching::tests::test_get_amounts_out ... ok
test sources::uniswap_v2::tests::parse_address_init ... ok
test sources::uniswap_v2::tests::parse_pool_reading ... ok
test sources::uniswap_v3::event_fetching::tests::get_events_test ... ok
test sources::uniswap_v3::event_fetching::tests::get_events_test_empty ... ok
test sources::uniswap_v3::event_fetching::tests::append_events_test ... ok
test sources::uniswap_v3::event_fetching::tests::last_event_block_test ... ok
test sources::uniswap_v3::event_fetching::tests::remove_events_newer_than_block_test ... ok
test sources::uniswap_v3::event_fetching::tests::remove_events_newer_than_block_test_empty ... ok
test sources::uniswap_v3::event_fetching::tests::last_event_block_test_empty ... ok
test sources::uniswap_v3::event_fetching::tests::remove_events_older_than_block_test ... ok
test sources::uniswap_v3::event_fetching::tests::remove_events_older_than_block_test_empty ... ok
test sources::uniswap_v3::graph_api::tests::decode_block_number_data ... ok
test sources::uniswap_v3::graph_api::tests::decode_ticks_data ... ok
test sources::uniswap_v3::graph_api::tests::decode_pools_data ... ok
test sources::uniswap_v3::pool_fetching::tests::append_events_test_burn ... ok
test sources::uniswap_v3::pool_fetching::tests::append_events_test_empty ... ok
test sources::uniswap_v3::pool_fetching::tests::append_events_test_mint ... ok
test sources::uniswap_v3::pool_fetching::tests::append_events_test_swap ... ok
test sources::uniswap_v3::pool_fetching::tests::encode_decode_pool_info ... ok
test subgraph::tests::deserialize_error_response ... ok
test sources::uniswap_v3_pair_provider::tests::mainnet_pool ... ok
test subgraph::tests::deserialize_invalid_response ... ok
2025-10-09T06:57:12.050Z  WARN shared::subgraph: additional GraphQL error: bar
test subgraph::tests::deserialize_multi_error_response ... ok
test subgraph::tests::deserialize_successful_response ... ok
test subgraph::tests::serialize_query ... ok
test tenderly_api::tests::serialize_deserialize_simulation_request ... ok
test tenderly_api::tests::simulate_transaction ... ignored
test token_info::tests::cached_token_info_fetcher ... ok
test token_list::tests::cow_list ... ignored
test token_list::tests::test_deserialization ... ok
test trace_many::tests::ok_false ... ok
test trace_many::tests::ok_true ... ok
test trade_finding::tests::test_debug_interaction ... ok
test url::tests::split_and_join ... ok
test zeroex_api::tests::compute_remaining_maker_amount ... ok
test zeroex_api::tests::deserialize_orders_response ... ok
test zeroex_api::tests::test_determining_end_of_paginated_results ... ok
test zeroex_api::tests::test_get_orders ... ignored
test zeroex_api::tests::test_get_orders_paginated_with_empty_result ... ignored
test zeroex_api::tests::test_retaining_valid_orders ... ok
test token_list::tests::test_creation_with_chain_id ... ok

test result: ok. 284 passed; 0 failed; 33 ignored; 0 measured; 0 filtered out; finished in 1.31s
```



## Related Issues

Fixes #3749
