### PR TITLE
Remove batching delay

### DIFF
--- a/crates/ethrpc/src/alloy/mod.rs
+++ b/crates/ethrpc/src/alloy/mod.rs
@@ -5,7 +5,7 @@ mod instrumentation;
 mod wallet;
 
 use {
-    crate::AlloyProvider,
+    crate::{AlloyProvider, Config},
     alloy::{
         network::EthereumWallet,
         providers::{Provider, ProviderBuilder},
@@ -13,6 +13,7 @@ use {
     },
     buffering::BatchCallLayer,
     instrumentation::{InstrumentationLayer, LabelingLayer},
+    std::time::Duration,
 };
 pub use {conversions::Account, instrumentation::ProviderLabelingExt, wallet::MutWallet};
 
@@ -24,7 +25,10 @@ fn rpc(url: &str) -> RpcClient {
             label: "main".into(),
         })
         .layer(InstrumentationLayer)
-        .layer(BatchCallLayer::new(Default::default()))
+        .layer(BatchCallLayer::new(Config {
+            ethrpc_batch_delay: Duration::ZERO,
+            ..Default::default()
+        }))
         .http(url.parse().unwrap())
 }
 


### PR DESCRIPTION
# Description
When testing balances, removing the batching delay lowered latency on fetch_balances from ~80ms to ~60ms, furthermore, this change makes alloy match the ethcontract settings

The ethcontract delay was 0 to avoid the delay

Below is the graph before, during and after the balances changes
<img width="1792" height="394" alt="image" src="https://github.com/user-attachments/assets/aeeb5d41-51fa-4a70-b252-a13cff9ea374" />


# Changes
<!-- List of detailed changes (how the change is accomplished) -->

- [ ] Removes the batching delay from alloy

## How to test
Staging 🤷‍♂️

<!--
## Related Issues

Fixes #
-->