### PR TITLE
Fix refunder wallet

### DIFF
--- a/crates/refunder/src/submitter.rs
+++ b/crates/refunder/src/submitter.rs
@@ -82,12 +82,11 @@ impl Submitter {
         self.gas_parameters_of_last_tx = Some(gas_price);
         self.nonce_of_last_submission = Some(nonce);
 
-        let ethflow_contract = CoWSwapEthFlow::Instance::new(
-            ethflow_contract,
-            self.web3
-                .alloy
-                .with_signer(self.account.clone().try_into_alloy().await?),
-        );
+        let provider = self
+            .web3
+            .alloy
+            .with_signer(self.account.clone().try_into_alloy().await?);
+        let ethflow_contract = CoWSwapEthFlow::Instance::new(ethflow_contract, provider);
         let tx_result = ethflow_contract
             .invalidateOrdersIgnoringNotAllowed(encoded_ethflow_orders)
             // Gas conversions are lossy but technically the should not have decimal points even though they're floats


### PR DESCRIPTION
# Description
After the CoWSwapEthFlow SC was migrated to alloy, we've started receiving the following errors:
```
2025-10-14T16:46:08.171Z  WARN refunder: Error while refunding ethflow orders: local usage error: Missing signing credential for 0x0214aE5fD178986fA18ff792e0b995Dc6a78cD56  
Caused by:     Missing signing credential for 0x0214aE5fD178986fA18ff792e0b995Dc6a78cD56
```
That basically means that our refunder doesn't work.

The reason for that is that the refunder's private key wasn't set properly in the alloy provider. This PR fixes it.

## How to test
Probably not easy.
