### PR TITLE
upgrade strum, remove unused ethabi, update sqlformat

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4716,7 +4716,7 @@ dependencies = [
  "serde_with",
  "shared",
  "sqlx",
- "strum_macros",
+ "strum",
  "thiserror 1.0.61",
  "tokio",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -91,7 +91,6 @@ shared = { path = "crates/shared" }
 solver = { path = "crates/solver" }
 solvers = { path = "crates/solvers" }
 solvers-dto = { path = "crates/solvers-dto" }
-strum_macros = "0.27.2"
 testlib = { path = "crates/testlib" }
 time = "0.3.37"
 tiny-keccak = "2.0.2"

--- a/crates/orderbook/Cargo.toml
+++ b/crates/orderbook/Cargo.toml
@@ -49,7 +49,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 serde_with = { workspace = true }
 shared = { workspace = true }
-strum_macros = { workspace = true }
+strum = { workspace = true }
 sqlx = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread", "signal", "sync", "time"] }

--- a/crates/orderbook/src/orderbook.rs
+++ b/crates/orderbook/src/orderbook.rs
@@ -40,7 +40,7 @@ use {
         },
     },
     std::{borrow::Cow, sync::Arc},
-    strum_macros::Display,
+    strum::Display,
     thiserror::Error,
     tracing::instrument,
 };


### PR DESCRIPTION
# Description
Ok last one before I go back to alloy migrations.

I noticed that we were using two versions of strum, which takes (consistently) 1.5s to compile on my PC.
Syncing the version with alloy doesn't hurt and gives those 1.5s to other packages to be compiled.

I also noticed that ethabi was unused so I removed it

And finally, doing another experiment sqlformat got a minor bump which removes its itertools deps, one less dependency on the itertools list

# Changes
<!-- List of detailed changes (how the change is accomplished) -->

- [ ] Upgrade strum to 0.27.2
- [ ] Remove unused ethabi
- [ ] Minor bump sqlformat 0.2.3 -> 0.2.6

## How to test
<!--- Include details of how to test your changes, including any pre-requisites. If no unit tests are included, please explain why and how to test manually
1.
2.
3.
-->

<!--
## Related Issues

Fixes #
-->