### PR TITLE
[TRIVIAL] pin postgres version to 16

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -2,7 +2,7 @@ version: '3.1'
 
 services:
   db:
-    image: postgres
+    image: postgres:16
     restart: always
     environment:
       POSTGRES_HOST_AUTH_METHOD: trust


### PR DESCRIPTION
# Description
Our `postgres` version is currently not pinned so it's using `latest`. postgres 18 was released which uses a different directory structure which in turn causes the DB to not work correctly. This causes our CI to fail.

credit goes to @mateipopa 🙇 

# Changes
Since we use postgres 16 in the prod infra I pinned it to this version instead of 17 (which was the last working version).

## How to test
CI should work again