### PR TITLE
Fix flaky liquidity_source_notification test (#3748)

### DIFF
--- a/crates/e2e/tests/e2e/liquidity_source_notification.rs
+++ b/crates/e2e/tests/e2e/liquidity_source_notification.rs
@@ -332,6 +332,13 @@ http-timeout = "10s"
     assert!(trade.is_some());
 
     // Ensure that notification was delivered to Liquorice API
+    wait_for_condition(TIMEOUT, || async {
+        let state = liquorice_api.get_state().await;
+        Some(!state.notification_requests.is_empty())
+    })
+    .await
+    .unwrap();
+
     let notification = liquorice_api
         .get_state()
         .await


### PR DESCRIPTION
Fixes #3748

## Problem
Test `forked_node_liquidity_source_notification_mainnet` was flaky due to race condition - checked `notification_requests` immediately after trade completed, but driver's async notifier task might not have delivered yet.

## Solution
Wrapped notification check in `wait_for_condition` to wait until `notification_requests` is non-empty before asserting.

## Changes
- Lines 335-340: Added wait loop before retrieving notification
- Follows same pattern as trade verification (line 319)

## Testing Note
**Requires internal infrastructure** - forked mainnet tests need archive node RPC (block 23326100), deployed contracts, whale accounts, and full service stack. Fix compiles cleanly and follows established patterns.

## Verification
- ✅ Compiles: `cargo build -p e2e`
- ✅ No warnings: `cargo clippy -p e2e`
- ✅ Logic matches existing pattern