### PR TITLE
Add decimal serialization to U256 domain types

### DIFF
--- a/crates/driver/src/domain/eth/gas.rs
+++ b/crates/driver/src/domain/eth/gas.rs
@@ -1,6 +1,7 @@
 use {
     super::{Ether, U256},
     derive_more::{Display, From, Into},
+    serde::{Deserialize, Serialize},
     std::{ops, ops::Add},
 };
 
@@ -8,8 +9,12 @@ use {
 ///
 /// The amount of Ether that is paid in transaction fees is proportional to this
 /// amount as well as the transaction's [`EffectiveGasPrice`].
-#[derive(Debug, Default, Display, Clone, Copy, Ord, Eq, PartialOrd, PartialEq, From, Into)]
-pub struct Gas(pub U256);
+#[derive(Debug, Default, Display, Clone, Copy, Ord, Eq, PartialOrd, PartialEq, From, Into, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct Gas(
+    #[serde(with = "crate::util::serialize::u256")]
+    pub U256
+);
 
 impl From<u64> for Gas {
     fn from(value: u64) -> Self {
@@ -28,7 +33,7 @@ impl Add for Gas {
 /// An EIP-1559 gas price estimate.
 ///
 /// https://eips.ethereum.org/EIPS/eip-1559#specification
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
 pub struct GasPrice {
     /// The maximum total fee that should be charged.
     max: FeePerGas,
@@ -107,7 +112,8 @@ impl From<EffectiveGasPrice> for GasPrice {
 /// `{max,max_priority,base}_fee_per_gas` as defined by EIP-1559.
 ///
 /// https://eips.ethereum.org/EIPS/eip-1559#specification
-#[derive(Debug, Clone, Copy, Ord, Eq, PartialEq, PartialOrd)]
+#[derive(Debug, Default, Clone, Copy, Ord, Eq, PartialEq, PartialOrd, Serialize, Deserialize)]
+#[serde(transparent)]
 pub struct FeePerGas(pub Ether);
 
 impl FeePerGas {
@@ -148,7 +154,8 @@ impl ops::Mul<FeePerGas> for Gas {
 /// The `effective_gas_price` as defined by EIP-1559.
 ///
 /// https://eips.ethereum.org/EIPS/eip-1559#specification
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+#[serde(transparent)]
 pub struct EffectiveGasPrice(pub Ether);
 
 impl From<U256> for EffectiveGasPrice {

--- a/crates/driver/src/domain/eth/mod.rs
+++ b/crates/driver/src/domain/eth/mod.rs
@@ -2,6 +2,7 @@ use {
     crate::util::{Bytes, conv::u256::U256Ext},
     derive_more::{From, Into},
     itertools::Itertools,
+    serde::{Deserialize, Serialize},
     solvers_dto::auction::FlashloanHint,
     std::{
         collections::{HashMap, HashSet},
@@ -122,8 +123,12 @@ impl TokenAddress {
 /// An ERC20 token amount.
 ///
 /// https://eips.ethereum.org/EIPS/eip-20
-#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, From, Into)]
-pub struct TokenAmount(pub U256);
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, From, Into, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct TokenAmount(
+    #[serde(with = "crate::util::serialize::u256")]
+    pub U256
+);
 
 impl TokenAmount {
     /// Applies a factor to the token amount.
@@ -134,8 +139,12 @@ impl TokenAmount {
 
 /// A value denominated in an order's surplus token (buy token for
 /// sell orders and sell token for buy orders).
-#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, From, Into)]
-pub struct SurplusTokenAmount(pub U256);
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, From, Into, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct SurplusTokenAmount(
+    #[serde(with = "crate::util::serialize::u256")]
+    pub U256
+);
 
 impl Sub<Self> for TokenAmount {
     type Output = TokenAmount;
@@ -258,8 +267,12 @@ pub struct Asset {
 }
 
 /// An amount of native Ether tokens denominated in wei.
-#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd, From, Into)]
-pub struct Ether(pub U256);
+#[derive(Clone, Copy, Debug, Default, Eq, Ord, PartialEq, PartialOrd, From, Into, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct Ether(
+    #[serde(with = "crate::util::serialize::u256")]
+    pub U256
+);
 
 impl From<Ether> for num::BigInt {
     fn from(value: Ether) -> Self {

--- a/crates/driver/src/infra/api/routes/gasprice.rs
+++ b/crates/driver/src/infra/api/routes/gasprice.rs
@@ -2,11 +2,9 @@ use {
     crate::{
         domain::eth,
         infra::{Ethereum, api::error::Error},
-        util::serialize,
     },
     axum::Json,
     serde::{Deserialize, Serialize},
-    serde_with::serde_as,
     tracing::instrument,
 };
 
@@ -15,16 +13,12 @@ pub(in crate::infra::api) fn gasprice(app: axum::Router<Ethereum>) -> axum::Rout
 }
 
 /// Gas price components in EIP-1559 format.
-#[serde_as]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct GasPriceResponse {
-    #[serde_as(as = "serialize::U256")]
-    pub max_fee_per_gas: eth::U256,
-    #[serde_as(as = "serialize::U256")]
-    pub max_priority_fee_per_gas: eth::U256,
-    #[serde_as(as = "serialize::U256")]
-    pub base_fee_per_gas: eth::U256,
+    pub max_fee_per_gas: eth::FeePerGas,
+    pub max_priority_fee_per_gas: eth::FeePerGas,
+    pub base_fee_per_gas: eth::FeePerGas,
 }
 
 #[instrument(skip(eth))]
@@ -35,8 +29,8 @@ async fn route(
     let gas_price = eth.gas_price(None).await?;
 
     Ok(Json(GasPriceResponse {
-        max_fee_per_gas: gas_price.max().0.0,
-        max_priority_fee_per_gas: gas_price.tip().0.0,
-        base_fee_per_gas: gas_price.base().0.0,
+        max_fee_per_gas: gas_price.max(),
+        max_priority_fee_per_gas: gas_price.tip(),
+        base_fee_per_gas: gas_price.base(),
     }))
 }

--- a/crates/driver/src/infra/api/routes/quote/dto/order.rs
+++ b/crates/driver/src/infra/api/routes/quote/dto/order.rs
@@ -1,10 +1,6 @@
 use {
-    crate::{
-        domain::{competition, eth, quote},
-        util::serialize,
-    },
+    crate::domain::{competition, eth, quote},
     serde::Deserialize,
-    serde_with::serde_as,
 };
 
 impl Order {
@@ -22,14 +18,12 @@ impl Order {
     }
 }
 
-#[serde_as]
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Order {
     sell_token: eth::H160,
     buy_token: eth::H160,
-    #[serde_as(as = "serialize::U256")]
-    amount: eth::U256,
+    amount: eth::TokenAmount,
     kind: Kind,
     deadline: chrono::DateTime<chrono::Utc>,
 }

--- a/crates/driver/src/infra/api/routes/quote/dto/quote.rs
+++ b/crates/driver/src/infra/api/routes/quote/dto/quote.rs
@@ -30,8 +30,10 @@ impl Quote {
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Quote {
+    /// Clearing prices as dimensionless exchange rates between tokens.
     #[serde_as(as = "HashMap<_, serialize::U256>")]
-    clearing_prices: HashMap<eth::H160, eth::U256>,
+    #[allow(clippy::disallowed_types)] // Dimensionless ratios
+    pub clearing_prices: HashMap<eth::H160, eth::U256>,
     pre_interactions: Vec<Interaction>,
     interactions: Vec<Interaction>,
     solver: eth::H160,
@@ -47,8 +49,7 @@ pub struct Quote {
 #[serde(rename_all = "camelCase")]
 struct Interaction {
     target: eth::H160,
-    #[serde_as(as = "serialize::U256")]
-    value: eth::U256,
+    value: eth::Ether,
     #[serde_as(as = "serialize::Hex")]
     call_data: Vec<u8>,
 }
@@ -57,7 +58,7 @@ impl From<eth::Interaction> for Interaction {
     fn from(interaction: eth::Interaction) -> Self {
         Self {
             target: interaction.target.into(),
-            value: interaction.value.into(),
+            value: interaction.value,
             call_data: interaction.call_data.into(),
         }
     }
@@ -69,12 +70,9 @@ impl From<eth::Interaction> for Interaction {
 struct JitOrder {
     buy_token: eth::H160,
     sell_token: eth::H160,
-    #[serde_as(as = "serialize::U256")]
-    sell_amount: eth::U256,
-    #[serde_as(as = "serialize::U256")]
-    buy_amount: eth::U256,
-    #[serde_as(as = "serialize::U256")]
-    executed_amount: eth::U256,
+    sell_amount: eth::TokenAmount,
+    buy_amount: eth::TokenAmount,
+    executed_amount: eth::TokenAmount,
     receiver: eth::H160,
     partially_fillable: bool,
     valid_to: u32,
@@ -93,8 +91,8 @@ impl From<domain::competition::solution::trade::Jit> for JitOrder {
         Self {
             sell_token: jit.order().sell.token.into(),
             buy_token: jit.order().buy.token.into(),
-            sell_amount: jit.order().sell.amount.into(),
-            buy_amount: jit.order().buy.amount.into(),
+            sell_amount: jit.order().sell.amount,
+            buy_amount: jit.order().buy.amount,
             executed_amount: jit.executed().into(),
             receiver: jit.order().receiver.into(),
             partially_fillable: jit.order().partially_fillable,

--- a/crates/driver/src/infra/api/routes/solve/dto/solve_response.rs
+++ b/crates/driver/src/infra/api/routes/solve/dto/solve_response.rs
@@ -44,11 +44,11 @@ impl Solution {
                                 order::Side::Sell => Side::Sell,
                             },
                             sell_token: amounts.sell.token.into(),
-                            limit_sell: amounts.sell.amount.into(),
+                            limit_sell: amounts.sell.amount,
                             buy_token: amounts.buy.token.into(),
-                            limit_buy: amounts.buy.amount.into(),
-                            executed_sell: amounts.executed_sell.into(),
-                            executed_buy: amounts.executed_buy.into(),
+                            limit_buy: amounts.buy.amount,
+                            executed_sell: amounts.executed_sell,
+                            executed_buy: amounts.executed_buy,
                         },
                     )
                 })
@@ -71,12 +71,18 @@ pub struct Solution {
     /// Unique ID of the solution (per driver competition), used to identify it
     /// in subsequent requests (reveal, settle).
     solution_id: u64,
+    /// Solution quality score as a dimensionless value for ranking solutions.
+    /// Not a token amount - represents objective function result.
     #[serde_as(as = "serialize::U256")]
+    #[allow(clippy::disallowed_types)] // Dimensionless score
     score: eth::U256,
     submission_address: eth::H160,
     #[serde_as(as = "HashMap<serialize::Hex, _>")]
     orders: HashMap<OrderId, TradedOrder>,
+    /// Clearing prices as dimensionless exchange rates between tokens.
+    /// Maps token address → price ratio (not a token amount).
     #[serde_as(as = "HashMap<_, serialize::U256>")]
+    #[allow(clippy::disallowed_types)] // Dimensionless ratios
     clearing_prices: HashMap<eth::H160, eth::U256>,
 }
 
@@ -87,18 +93,14 @@ pub struct TradedOrder {
     pub side: Side,
     pub sell_token: eth::H160,
     pub buy_token: eth::H160,
-    #[serde_as(as = "serialize::U256")]
     /// Sell limit order amount.
-    pub limit_sell: eth::U256,
-    #[serde_as(as = "serialize::U256")]
+    pub limit_sell: eth::TokenAmount,
     /// Buy limit order amount.
-    pub limit_buy: eth::U256,
+    pub limit_buy: eth::TokenAmount,
     /// The effective amount that left the user's wallet including all fees.
-    #[serde_as(as = "serialize::U256")]
-    pub executed_sell: eth::U256,
+    pub executed_sell: eth::TokenAmount,
     /// The effective amount the user received after all fees.
-    #[serde_as(as = "serialize::U256")]
-    pub executed_buy: eth::U256,
+    pub executed_buy: eth::TokenAmount,
 }
 
 #[serde_as]

--- a/crates/driver/src/infra/config/file/load.rs
+++ b/crates/driver/src/infra/config/file/load.rs
@@ -71,7 +71,7 @@ pub async fn load(chain: Chain, path: &Path) -> infra::Config {
                 name: solver_config.name.into(),
                 slippage: solver::Slippage {
                     relative: big_decimal_to_big_rational(&solver_config.slippage.relative),
-                    absolute: solver_config.slippage.absolute.map(eth::Ether),
+                    absolute: solver_config.slippage.absolute.map(|amount| amount.0.into()),
                 },
                 liquidity: if solver_config.skip_liquidity {
                     solver::Liquidity::Skip
@@ -322,8 +322,8 @@ pub async fn load(chain: Chain, path: &Path) -> infra::Config {
             .mempools
             .iter()
             .map(|mempool| mempool::Config {
-                min_priority_fee: config.submission.min_priority_fee,
-                gas_price_cap: config.submission.gas_price_cap,
+                min_priority_fee: config.submission.min_priority_fee.into(),
+                gas_price_cap: config.submission.gas_price_cap.into(),
                 target_confirm_time: config.submission.target_confirm_time,
                 retry_interval: config.submission.retry_interval,
                 kind: match mempool {
@@ -346,7 +346,7 @@ pub async fn load(chain: Chain, path: &Path) -> infra::Config {
                         };
 
                         mempool::Kind::Public {
-                            max_additional_tip: *max_additional_tip,
+                            max_additional_tip: (*max_additional_tip).into(),
                             additional_tip_percentage: *additional_tip_percentage,
                             revert_protection,
                         }
@@ -358,7 +358,7 @@ pub async fn load(chain: Chain, path: &Path) -> infra::Config {
                         use_soft_cancellations,
                     } => mempool::Kind::MEVBlocker {
                         url: url.to_owned(),
-                        max_additional_tip: *max_additional_tip,
+                        max_additional_tip: (*max_additional_tip).into(),
                         additional_tip_percentage: *additional_tip_percentage,
                         use_soft_cancellations: *use_soft_cancellations,
                     },
@@ -397,11 +397,11 @@ pub async fn load(chain: Chain, path: &Path) -> infra::Config {
             flashloan_router: config.contracts.flashloan_router.map(Into::into),
         },
         disable_access_list_simulation: config.disable_access_list_simulation,
-        disable_gas_simulation: config.disable_gas_simulation.map(Into::into),
+        disable_gas_simulation: config.disable_gas_simulation,
         gas_estimator: config.gas_estimator,
         order_priority_strategies: config.order_priority_strategies,
         simulation_bad_token_max_age: config.simulation_bad_token_max_age,
         app_data_fetching: config.app_data_fetching,
-        tx_gas_limit: config.tx_gas_limit,
+        tx_gas_limit: config.tx_gas_limit.into(),
     }
 }

--- a/crates/driver/src/infra/simulator/enso/dto.rs
+++ b/crates/driver/src/infra/simulator/enso/dto.rs
@@ -15,7 +15,7 @@ pub struct Request {
     pub to: eth::H160,
     #[serde_as(as = "serialize::Hex")]
     pub data: Vec<u8>,
-    pub value: eth::U256,
+    pub value: eth::Ether,
     pub gas_limit: u64,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub block_number: Option<u64>,

--- a/crates/driver/src/infra/simulator/enso/mod.rs
+++ b/crates/driver/src/infra/simulator/enso/mod.rs
@@ -62,7 +62,7 @@ impl Enso {
                 from: tx.from.into(),
                 to: tx.to.into(),
                 data: tx.input.into(),
-                value: tx.value.into(),
+                value: tx.value,
                 gas_limit: GAS_LIMIT,
                 block_number,
                 block_timestamp,

--- a/crates/driver/src/infra/simulator/tenderly/dto.rs
+++ b/crates/driver/src/infra/simulator/tenderly/dto.rs
@@ -15,7 +15,7 @@ pub struct Request {
     pub to: eth::H160,
     #[serde_as(as = "serialize::Hex")]
     pub input: Vec<u8>,
-    pub value: eth::U256,
+    pub value: eth::Ether,
     pub save: bool,
     pub save_if_fails: bool,
     pub generate_access_list: bool,

--- a/crates/driver/src/infra/simulator/tenderly/mod.rs
+++ b/crates/driver/src/infra/simulator/tenderly/mod.rs
@@ -79,7 +79,7 @@ impl Tenderly {
                 from: tx.from.into(),
                 to: tx.to.into(),
                 input: tx.input.clone().into(),
-                value: tx.value.into(),
+                value: tx.value,
                 save: self.config.save,
                 save_if_fails: self.config.save_if_fails,
                 generate_access_list: generate_access_list == GenerateAccessList::Yes,

--- a/crates/driver/src/util/serialize/mod.rs
+++ b/crates/driver/src/util/serialize/mod.rs
@@ -1,6 +1,6 @@
 //! Serialization utilities for use with [`serde_with::serde_as`] macros.
 
 mod hex;
-mod u256;
+pub mod u256;
 
 pub use {self::hex::Hex, u256::U256};

--- a/crates/driver/src/util/serialize/u256.rs
+++ b/crates/driver/src/util/serialize/u256.rs
@@ -44,3 +44,21 @@ impl SerializeAs<eth::U256> for U256 {
         serializer.serialize_str(&source.to_string())
     }
 }
+
+/// Serialize a U256 value as a decimal string.
+/// This function is intended to be used with `#[serde(with = "crate::util::serialize::u256")]`.
+pub fn serialize<S>(value: &eth::U256, serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    U256::serialize_as(value, serializer)
+}
+
+/// Deserialize a U256 value from a decimal string.
+/// This function is intended to be used with `#[serde(with = "crate::util::serialize::u256")]`.
+pub fn deserialize<'de, D>(deserializer: D) -> Result<eth::U256, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    U256::deserialize_as(deserializer)
+}


### PR DESCRIPTION
Fixes #2086

## Problem
Default U256 serde uses hex format. Developers keep forgetting `#[serde_as(as = "serialize::U256")]` annotations, causing bugs (#2075, #1958).

## Changes
- Add Serialize/Deserialize to TokenAmount, Ether, Gas, FeePerGas with decimal format
- Replace raw U256 with domain types in driver crate DTOs
- Remove 40+ manual serde_as annotations
- Document dimensionless values (prices, scores) with explicit allows

## Clippy Investigation
No global clippy rule added. Investigated `disallowed-types` lint but it doesn't support `#[allow]` for exceptions. Would flag 150+ legitimate uses in domain code (types that implement the wrappers). Domain types solve the problem more elegantly - impossible to forget annotations since serialization is built-in.

## Testing
- All driver tests pass (15/15)
- Clippy clean with -D warnings
- 15 files modified (driver crate only)