### PR TITLE
Remove quote verification flag (#2394)

### DIFF
--- a/crates/autopilot/src/run.rs
+++ b/crates/autopilot/src/run.rs
@@ -509,7 +509,6 @@ pub async fn run(args: Arguments, shutdown_controller: ShutdownController) {
             .unwrap(),
         },
         balance_fetcher.clone(),
-        args.price_estimation.quote_verification,
         args.price_estimation.quote_timeout,
     ));
 

--- a/crates/e2e/src/setup/services.rs
+++ b/crates/e2e/src/setup/services.rs
@@ -235,7 +235,6 @@ impl<'a> Services<'a> {
         let args: Vec<_> = [
             "orderbook".to_string(),
             "--quote-timeout=10s".to_string(),
-            "--quote-verification=enforce-when-possible".to_string(),
         ]
         .into_iter()
         .chain(self.api_autopilot_solver_arguments())

--- a/crates/e2e/tests/e2e/replace_order.rs
+++ b/crates/e2e/tests/e2e/replace_order.rs
@@ -433,9 +433,8 @@ async fn single_replace_order_test(web3: Web3) {
         .start_protocol_with_args(
             ExtraServiceArgs {
                 // To avoid race conditions we have to start the protocol
-                // with the solver being banned. To allow us to still create
-                // orders we override the quote verification to be disabled.
-                api: vec!["--quote-verification=prefer".into()],
+                // with the solver being banned.
+                api: vec![],
                 ..Default::default()
             },
             solver.clone(),

--- a/crates/shared/src/order_quoting.rs
+++ b/crates/shared/src/order_quoting.rs
@@ -10,7 +10,7 @@ use {
         db_order_conversions::order_kind_from,
         fee::FeeParameters,
         order_validation::PreOrderData,
-        price_estimation::{Estimate, QuoteVerificationMode, Verification},
+        price_estimation::{Estimate, Verification},
         trade_finding::external::dto,
     },
     anyhow::{Context, Result},
@@ -412,7 +412,6 @@ pub struct OrderQuoter {
     now: Arc<dyn Now>,
     validity: Validity,
     balance_fetcher: Arc<dyn BalanceFetching>,
-    quote_verification: QuoteVerificationMode,
     default_quote_timeout: std::time::Duration,
 }
 
@@ -425,7 +424,6 @@ impl OrderQuoter {
         storage: Arc<dyn QuoteStoring>,
         validity: Validity,
         balance_fetcher: Arc<dyn BalanceFetching>,
-        quote_verification: QuoteVerificationMode,
         default_quote_timeout: std::time::Duration,
     ) -> Self {
         Self {
@@ -436,7 +434,6 @@ impl OrderQuoter {
             now: Arc::new(Utc::now),
             validity,
             balance_fetcher,
-            quote_verification,
             default_quote_timeout,
         }
     }
@@ -528,13 +525,8 @@ impl OrderQuoter {
         parameters: &QuoteParameters,
         sell_amount: U256,
     ) -> Result<(), CalculateQuoteError> {
-        if estimate.verified
-            || !matches!(
-                self.quote_verification,
-                QuoteVerificationMode::EnforceWhenPossible
-            )
-        {
-            // verification was successful or not strictly required
+        // Always prefer verified quotes - accept both verified and unverified
+        if estimate.verified {
             return Ok(());
         }
 
@@ -926,7 +918,6 @@ mod tests {
             storage: Arc::new(storage),
             now: Arc::new(now),
             validity: super::Validity::default(),
-            quote_verification: QuoteVerificationMode::Unverified,
             balance_fetcher: mock_balance_fetcher(),
             default_quote_timeout: HEALTHY_PRICE_ESTIMATION_TIME,
         };
@@ -1067,7 +1058,6 @@ mod tests {
             storage: Arc::new(storage),
             now: Arc::new(now),
             validity: Validity::default(),
-            quote_verification: QuoteVerificationMode::Unverified,
             balance_fetcher: mock_balance_fetcher(),
             default_quote_timeout: HEALTHY_PRICE_ESTIMATION_TIME,
         };
@@ -1203,7 +1193,6 @@ mod tests {
             storage: Arc::new(storage),
             now: Arc::new(now),
             validity: Validity::default(),
-            quote_verification: QuoteVerificationMode::Unverified,
             balance_fetcher: mock_balance_fetcher(),
             default_quote_timeout: HEALTHY_PRICE_ESTIMATION_TIME,
         };
@@ -1302,7 +1291,6 @@ mod tests {
             storage: Arc::new(MockQuoteStoring::new()),
             now: Arc::new(Utc::now),
             validity: Validity::default(),
-            quote_verification: QuoteVerificationMode::Unverified,
             balance_fetcher: mock_balance_fetcher(),
             default_quote_timeout: HEALTHY_PRICE_ESTIMATION_TIME,
         };
@@ -1376,7 +1364,6 @@ mod tests {
             storage: Arc::new(MockQuoteStoring::new()),
             now: Arc::new(Utc::now),
             validity: Validity::default(),
-            quote_verification: QuoteVerificationMode::Unverified,
             balance_fetcher: mock_balance_fetcher(),
             default_quote_timeout: HEALTHY_PRICE_ESTIMATION_TIME,
         };
@@ -1437,7 +1424,6 @@ mod tests {
             storage: Arc::new(storage),
             now: Arc::new(now),
             validity: Validity::default(),
-            quote_verification: QuoteVerificationMode::Unverified,
             balance_fetcher: mock_balance_fetcher(),
             default_quote_timeout: HEALTHY_PRICE_ESTIMATION_TIME,
         };
@@ -1520,7 +1506,6 @@ mod tests {
             storage: Arc::new(storage),
             now: Arc::new(now),
             validity: Validity::default(),
-            quote_verification: QuoteVerificationMode::Unverified,
             balance_fetcher: mock_balance_fetcher(),
             default_quote_timeout: HEALTHY_PRICE_ESTIMATION_TIME,
         };
@@ -1605,7 +1590,6 @@ mod tests {
             storage: Arc::new(storage),
             now: Arc::new(now),
             validity: Validity::default(),
-            quote_verification: QuoteVerificationMode::Unverified,
             balance_fetcher: mock_balance_fetcher(),
             default_quote_timeout: HEALTHY_PRICE_ESTIMATION_TIME,
         };
@@ -1678,7 +1662,6 @@ mod tests {
             storage: Arc::new(storage),
             now: Arc::new(now),
             validity: Validity::default(),
-            quote_verification: QuoteVerificationMode::Unverified,
             balance_fetcher: mock_balance_fetcher(),
             default_quote_timeout: HEALTHY_PRICE_ESTIMATION_TIME,
         };
@@ -1709,7 +1692,6 @@ mod tests {
             storage: Arc::new(storage),
             now: Arc::new(Utc::now),
             validity: Validity::default(),
-            quote_verification: QuoteVerificationMode::Unverified,
             balance_fetcher: mock_balance_fetcher(),
             default_quote_timeout: HEALTHY_PRICE_ESTIMATION_TIME,
         };

--- a/crates/shared/src/price_estimation/competition/mod.rs
+++ b/crates/shared/src/price_estimation/competition/mod.rs
@@ -49,17 +49,7 @@ impl<T: Send + Sync + 'static> CompetitionEstimator<T> {
             stages,
             usable_results_for_early_return: NonZeroUsize::MAX,
             ranking,
-            verification_mode: QuoteVerificationMode::Unverified,
-        }
-    }
-
-    /// Configures if verified price estimates should be ranked higher than
-    /// unverified ones even if the price is worse.
-    /// Per default verified quotes do not get preferred.
-    pub fn with_verification(self, mode: QuoteVerificationMode) -> Self {
-        Self {
-            verification_mode: mode,
-            ..self
+            verification_mode: QuoteVerificationMode::Prefer,
         }
     }
 
@@ -585,7 +575,7 @@ mod tests {
             ],
             usable_results_for_early_return: NonZeroUsize::new(2).unwrap(),
             ranking: PriceRanking::MaxOutAmount,
-            verification_mode: QuoteVerificationMode::Unverified,
+            verification_mode: QuoteVerificationMode::Prefer,
         };
 
         racing.estimate(query).await.unwrap();

--- a/crates/shared/src/price_estimation/competition/quote.rs
+++ b/crates/shared/src/price_estimation/competition/quote.rs
@@ -154,7 +154,6 @@ mod tests {
             gas_price_estimation::FakeGasPriceEstimator,
             price_estimation::{
                 MockPriceEstimating,
-                QuoteVerificationMode,
                 native::MockNativePriceEstimating,
             },
         },
@@ -202,7 +201,6 @@ mod tests {
         ranking: PriceRanking,
         kind: OrderKind,
         estimates: Vec<PriceEstimateResult>,
-        verification: QuoteVerificationMode,
     ) -> PriceEstimateResult {
         fn estimator(estimate: PriceEstimateResult) -> Arc<dyn PriceEstimating> {
             let mut estimator = MockPriceEstimating::new();
@@ -222,8 +220,7 @@ mod tests {
                     .collect(),
             ],
             ranking.clone(),
-        )
-        .with_verification(verification);
+        );
 
         priority
             .estimate(Arc::new(Query {
@@ -249,7 +246,6 @@ mod tests {
                 // User effectively receives `99_999` `buy_token`.
                 price(107_999, 2_000),
             ],
-            QuoteVerificationMode::Unverified,
         )
         .await;
         assert_eq!(best, price(104_000, 1_000));
@@ -263,7 +259,6 @@ mod tests {
                 // User effectively pays `100_002` `sell_token`.
                 price(92_002, 2_000),
             ],
-            QuoteVerificationMode::Unverified,
         )
         .await;
         assert_eq!(best, price(96_000, 1_000));
@@ -287,7 +282,6 @@ mod tests {
                 // gets discarded because it quotes 0 gas.
                 price(104_000, 0),
             ],
-            QuoteVerificationMode::Unverified,
         )
         .await;
         assert_eq!(best, price(104_000, 1_000));
@@ -304,7 +298,6 @@ mod tests {
                 // gets discarded because it quotes 0 gas.
                 price(99_000, 0),
             ],
-            QuoteVerificationMode::Unverified,
         )
         .await;
         assert_eq!(best, price(96_000, 1_000));
@@ -322,7 +315,6 @@ mod tests {
                 error(PriceEstimationError::RateLimited),
                 error(PriceEstimationError::ProtocolInternal(anyhow::anyhow!("!"))),
             ],
-            QuoteVerificationMode::Unverified,
         )
         .await;
         assert_eq!(best, error(PriceEstimationError::RateLimited));
@@ -338,7 +330,6 @@ mod tests {
                 price(1, 1_000_000),
                 error(PriceEstimationError::RateLimited),
             ],
-            QuoteVerificationMode::Unverified,
         )
         .await;
         assert_eq!(best, price(1, 1_000_000));
@@ -366,7 +357,6 @@ mod tests {
                 better_unverified_quote.clone(),
                 worse_verified_quote.clone(),
             ],
-            QuoteVerificationMode::Prefer,
         )
         .await;
         assert_eq!(best, worse_verified_quote.clone());
@@ -378,7 +368,6 @@ mod tests {
                 better_unverified_quote.clone(),
                 worse_verified_quote.clone(),
             ],
-            QuoteVerificationMode::EnforceWhenPossible,
         )
         .await;
         assert_eq!(best, worse_verified_quote.clone());
@@ -390,7 +379,6 @@ mod tests {
                 better_unverified_quote.clone(),
                 worse_verified_quote.clone(),
             ],
-            QuoteVerificationMode::Unverified,
         )
         .await;
         assert_eq!(best, better_unverified_quote);

--- a/crates/shared/src/price_estimation/factory.rs
+++ b/crates/shared/src/price_estimation/factory.rs
@@ -312,8 +312,7 @@ impl<'a> PriceEstimatorFactory<'a> {
         let competition_estimator = CompetitionEstimator::new(
             vec![estimators],
             PriceRanking::BestBangForBuck { native, gas },
-        )
-        .with_verification(self.args.quote_verification);
+        );
         Ok(Arc::new(self.sanitized(Arc::new(competition_estimator))))
     }
 
@@ -358,7 +357,6 @@ impl<'a> PriceEstimatorFactory<'a> {
 
         let competition_estimator =
             CompetitionEstimator::new(estimators, PriceRanking::MaxOutAmount)
-                .with_verification(self.args.quote_verification)
                 .with_early_return(results_required);
         let native_estimator = Arc::new(CachingNativePriceEstimator::new(
             Box::new(competition_estimator),

--- a/crates/shared/src/price_estimation/mod.rs
+++ b/crates/shared/src/price_estimation/mod.rs
@@ -225,16 +225,6 @@ pub struct Arguments {
     #[clap(long, env, default_value = "1.")]
     pub quote_inaccuracy_limit: BigDecimal,
 
-    /// How strict quote verification should be.
-    #[clap(
-        long,
-        env,
-        default_value = "unverified",
-        value_enum,
-        verbatim_doc_comment
-    )]
-    pub quote_verification: QuoteVerificationMode,
-
     /// Default timeout for quote requests.
     #[clap(
         long,
@@ -357,7 +347,6 @@ impl Display for Arguments {
             one_inch_url,
             coin_gecko,
             quote_inaccuracy_limit,
-            quote_verification,
             quote_timeout,
             balance_overrides,
             native_price_approximation_tokens,
@@ -424,7 +413,6 @@ impl Display for Arguments {
             ),
         )?;
         writeln!(f, "quote_inaccuracy_limit: {quote_inaccuracy_limit}")?;
-        writeln!(f, "quote_verification: {quote_verification:?}")?;
         writeln!(f, "quote_timeout: {quote_timeout:?}")?;
         write!(f, "{balance_overrides}")?;
         writeln!(


### PR DESCRIPTION
Fixes #2394

The quote verification flag has been stabilized and can now be removed. The flag was previously used to configure whether verified quotes should be preferred over unverified ones.

The implementation removes the --quote-verification CLI flag from all services and hardcodes the behavior to always prefer verified quotes. This affects 9 files across shared libraries, orderbook, autopilot, and e2e tests.

Changes include:
- Removed quote_verification field from Arguments struct in price_estimation/mod.rs
- Hardcoded QuoteVerificationMode::Prefer in CompetitionEstimator constructor
- Removed with_verification() configuration method from CompetitionEstimator
- Updated OrderQuoter to remove quote_verification parameter
- Simplified verify_quote() logic to always prefer verified quotes
- Updated orderbook and autopilot service initialization
- Fixed e2e tests that referenced the removed flag