### PR TITLE
Use labels in alloy transport

### DIFF
--- a/crates/ethrpc/src/alloy/mod.rs
+++ b/crates/ethrpc/src/alloy/mod.rs
@@ -19,10 +19,10 @@ pub use {conversions::Account, instrumentation::ProviderLabelingExt, wallet::Mut
 
 /// Creates an [`RpcClient`] from the given URL with [`LabelingLayer`],
 /// [`InstrumentationLayer`] and [`BatchCallLayer`].
-fn rpc(url: &str) -> RpcClient {
+fn rpc(url: &str, label: &str) -> RpcClient {
     ClientBuilder::default()
         .layer(LabelingLayer {
-            label: "main".into(),
+            label: label.into(),
         })
         .layer(InstrumentationLayer)
         .layer(BatchCallLayer::new(Config {
@@ -35,8 +35,8 @@ fn rpc(url: &str) -> RpcClient {
 /// Creates a provider with the provided URL and an empty [`MutWallet`].
 ///
 /// Returns a copy of the [`MutWallet`] so the caller can modify it later.
-pub fn provider(url: &str) -> (AlloyProvider, MutWallet) {
-    let rpc = rpc(url);
+pub fn provider(url: &str, label: &str) -> (AlloyProvider, MutWallet) {
+    let rpc = rpc(url, label);
     let wallet = MutWallet::default();
     let provider = ProviderBuilder::new()
         .wallet(wallet.clone())

--- a/crates/ethrpc/src/block_stream/mod.rs
+++ b/crates/ethrpc/src/block_stream/mod.rs
@@ -125,7 +125,7 @@ pub async fn current_block_stream(
         url.clone(),
         "block_stream".into(),
     )));
-    let (alloy, wallet) = crate::alloy::provider(url.as_str());
+    let (alloy, wallet) = crate::alloy::provider(url.as_str(), "block_stream");
     let web3 = crate::Web3 {
         legacy: web3,
         // TODO: replace this with an unbuffered alloy provider

--- a/crates/ethrpc/src/lib.rs
+++ b/crates/ethrpc/src/lib.rs
@@ -53,7 +53,7 @@ impl Web3<DynTransport> {
     pub fn new_from_url(url: &str) -> Self {
         let legacy_transport = create_test_transport(url);
         let web3 = web3::Web3::new(legacy_transport);
-        let (alloy, wallet) = crate::alloy::provider(url);
+        let (alloy, wallet) = crate::alloy::provider(url, "test");
         Self {
             legacy: web3,
             alloy,
@@ -119,7 +119,7 @@ pub fn web3(
         None => Web3Transport::new(http),
     };
     let instrumented = instrumented::InstrumentedTransport::new(name.to_string(), transport);
-    let (alloy, wallet) = alloy::provider(url.as_str());
+    let (alloy, wallet) = alloy::provider(url.as_str(), name.to_string().as_str());
     Web3 {
         legacy: web3::Web3::new(Web3Transport::new(instrumented)),
         alloy,


### PR DESCRIPTION
# Description
The legacy web3 transport uses labels for better visibility in logs. The same should apply to alloy's transport. This PR fixes that.

## How to test
Observe logs.
