### PR TITLE
[TRIVIAL] fix playground driver config

### DIFF
--- a/configs/local/driver.toml
+++ b/configs/local/driver.toml
@@ -1,4 +1,4 @@
-tx-gas-limit = 45000000
+tx-gas-limit = "45000000"
 
 [[solver]]
 name = "baseline" # Arbitrary name given to this solver, must be unique


### PR DESCRIPTION
# Description
The recently introduced `tx-gas-limit` argument expects a big integer so a hex or decimal encoded string instead of an integers literal. This currently causes the playground to not work.
As a reference see this [configuration](https://github.com/cowprotocol/services/blob/main/crates/e2e/src/setup/colocation.rs#L179) in the e2e tests that work correctly.