### PR TITLE
Migrate alerter to alloy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -64,6 +64,7 @@ dependencies = [
 name = "alerter"
 version = "0.1.0"
 dependencies = [
+ "alloy",
  "anyhow",
  "clap",
  "humantime",
@@ -71,7 +72,6 @@ dependencies = [
  "model",
  "number",
  "observe",
- "primitive-types",
  "prometheus",
  "reqwest 0.11.27",
  "serde",

--- a/crates/alerter/Cargo.toml
+++ b/crates/alerter/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2024"
 license = "MIT OR Apache-2.0"
 
 [dependencies]
+alloy = { workspace = true }
 anyhow = { workspace = true }
 clap = { workspace = true }
 humantime = { workspace = true }
@@ -13,7 +14,6 @@ observe = { workspace = true }
 mimalloc = { workspace = true }
 model = { workspace = true }
 number = { workspace = true }
-primitive-types = { workspace = true }
 prometheus = { workspace = true }
 reqwest = { workspace = true, features = ["json"] }
 serde_with = { workspace = true }

--- a/crates/alerter/src/lib.rs
+++ b/crates/alerter/src/lib.rs
@@ -4,11 +4,11 @@
 // price api (0x). If this is the case it alerts.
 
 use {
+    alloy::primitives::{Address, U256, address},
     anyhow::{Context, Result},
     clap::Parser,
     model::order::{BUY_ETH_ADDRESS, OrderClass, OrderKind, OrderStatus, OrderUid},
     number::serialization::HexOrDecimalU256,
-    primitive_types::{H160, U256},
     prometheus::IntGauge,
     reqwest::Client,
     serde_with::serde_as,
@@ -24,10 +24,10 @@ use {
 #[serde(rename_all = "camelCase")]
 struct Order {
     kind: OrderKind,
-    buy_token: H160,
+    buy_token: Address,
     #[serde_as(as = "HexOrDecimalU256")]
     buy_amount: U256,
-    sell_token: H160,
+    sell_token: Address,
     #[serde_as(as = "HexOrDecimalU256")]
     sell_amount: U256,
     uid: OrderUid,
@@ -90,12 +90,10 @@ impl OrderBookApi {
 
 // Converts the eth placeholder address to weth. Leaves other addresses
 // untouched.
-fn convert_eth_to_weth(token: H160) -> H160 {
-    let weth: H160 = "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2"
-        .parse()
-        .unwrap();
-    if token == BUY_ETH_ADDRESS {
-        weth
+fn convert_eth_to_weth(token: Address) -> Address {
+    const WETH: Address = address!("0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2");
+    if token == Address::from_slice(&BUY_ETH_ADDRESS.0) {
+        WETH
     } else {
         token
     }


### PR DESCRIPTION
# Description
Migrate alerter to alloy

# Changes
<!-- List of detailed changes (how the change is accomplished) -->

- [ ] Replaces primitive_types with alloy
- [ ] Adds serialization for alloy's U256

## How to test
compiler

<!--
## Related Issues

Fixes #
-->