### PR TITLE
[TRIVIAL] Persist cow amm factory address instead of helper in DB

### DIFF
--- a/crates/cow-amm/src/amm.rs
+++ b/crates/cow-amm/src/amm.rs
@@ -87,12 +87,12 @@ impl Amm {
     pub fn try_to_db_type(
         &self,
         block_number: u64,
-        helper: Address,
+        factory_address: Address,
         tx_hash: TxHash,
     ) -> Result<database::cow_amms::CowAmm> {
         Ok(database::cow_amms::CowAmm {
             address: ByteArray(self.address.0.0),
-            factory_address: ByteArray(helper.0.0),
+            factory_address: ByteArray(factory_address.0.0),
             tradeable_tokens: self
                 .tradeable_tokens
                 .iter()

--- a/crates/cow-amm/src/cache.rs
+++ b/crates/cow-amm/src/cache.rs
@@ -188,7 +188,7 @@ impl EventStoring<(CowAmmEvent, Log)> for Storage {
                 .iter()
                 .filter_map(|(block_number, tx_hash, amm)| {
                     amm.as_ref()
-                        .try_to_db_type(*block_number, *self.0.helper.address(), *tx_hash)
+                        .try_to_db_type(*block_number, self.0.factory_address, *tx_hash)
                         .inspect_err(|err| {
                             tracing::warn!(
                                 ?err,


### PR DESCRIPTION
# Description
Currently we store the cow amm's helper contract as its factory address. But when we [load](https://github.com/cowprotocol/services/blob/main/crates/cow-amm/src/cache.rs#L56) them from the DB to init the cache we search for them by the factory address.

This was not caught by tests because we don't have a test that:
1. indexes new cow amms
2. shuts down the autopilot
3. restarts the autopilot
4. inits the autopilot's cow amm cache from the DB

# Changes
This PR fixes the issue by correctly using the factory address for storing and loading.

I fixed the incorrect DB entries and after restarting the autopilot pods all cow AMMs got loaded correctly.