### PR TITLE
[TRIVIAL] Log gas price of tx submission

### DIFF
--- a/crates/driver/src/domain/mempools.rs
+++ b/crates/driver/src/domain/mempools.rs
@@ -138,7 +138,13 @@ impl Mempools {
             .submit(tx.clone(), settlement.gas, solver, nonce)
             .await?;
         let submitted_at_block = self.ethereum.current_block().borrow().number;
-        tracing::debug!(?hash, current_block = ?submitted_at_block, "submitted tx to the mempool");
+        tracing::debug!(
+            ?hash,
+            current_block = ?submitted_at_block,
+            max_fee_per_gas = ?settlement.gas.price.max(),
+            priority_fee_per_gas = ?settlement.gas.price.tip(),
+            "submitted tx to the mempool"
+        );
 
         // Wait for the transaction to be mined, expired or failing.
         let result = async {


### PR DESCRIPTION
# Description
Currently our transaction submission logs are not very good when it comes to figuring out why a transaction was not mined in a timely manner. We are already able to recover the calldata of a transaction to look for reverts but if the issue is a too low gas price we currently wouldn't know.

# Changes
Also logs the `max_fee_per_gas` and `priority_fee_per_gas` after we submitted a transaction to the mempool.