### PR TITLE
Ensure CoinGecko API key is set

### DIFF
--- a/crates/shared/src/price_estimation/factory.rs
+++ b/crates/shared/src/price_estimation/factory.rs
@@ -228,7 +228,7 @@ impl<'a> PriceEstimatorFactory<'a> {
             NativePriceEstimatorSource::CoinGecko => {
                 anyhow::ensure!(
                     self.args.coin_gecko.coin_gecko_api_key.is_some(),
-                    "coin_gecko_api_key must be set when CoinGecko is used as a native price estimator"
+                    "coin_gecko_api_key must be set when CoinGecko is used as native price                     estimator"
                 );
 
                 let name = "CoinGecko".to_string();


### PR DESCRIPTION
# Description

We ran into an issue where CoinGecko was enabled as native price estimator, but there the necessary env var with API key was not set. To prevent this in the future we want to have the service not start instead. Otherwise one gets weird behaviour when the service runs where sometimes we get native prices when some solvers decide to quote them, but not always and that leads to order that would otherwise be solved never get created in the first place as one can't get a quote ("no liquidity" error).