### PR TITLE
Send `eth_createAccessList` lists RPC requests with the `latest` block tag

### DIFF
--- a/crates/driver/src/infra/blockchain/mod.rs
+++ b/crates/driver/src/infra/blockchain/mod.rs
@@ -188,7 +188,7 @@ impl Ethereum {
             .transport()
             .execute(
                 "eth_createAccessList",
-                vec![serde_json::to_value(&tx).unwrap()],
+                vec![serde_json::to_value(&tx).unwrap(), "latest".into()],
             )
             .await?;
         if let Some(err) = json.get("error") {


### PR DESCRIPTION
@ahhda noticed that `eth_createAccessList` calls have started to fail on Erigon and DRPC nodes when the block tag param is not provided, even though the official documentation states this param is optional https://ethereum.github.io/execution-apis/api-documentation/

By default, "latest" is used, so this PR shouldn't hurt.