### PR TITLE
Don't solve empty auctions

### DIFF
--- a/crates/driver/src/domain/competition/mod.rs
+++ b/crates/driver/src/domain/competition/mod.rs
@@ -185,6 +185,11 @@ impl Competition {
         drop(timer);
         tracing::debug!(?elapsed, "auction task execution time");
 
+        if auction.orders.is_empty() {
+            tracing::info!("no orders left after pre-processing; skipping solving");
+            return Ok(None);
+        }
+
         let auction = &auction;
 
         // Fetch the solutions from the solver.


### PR DESCRIPTION
There is a chance that after preprocessing, the auction can become empty due to filtering out orders for specific reasons. It doesn't make sense to send this kind of auction to solvers. One of the solvers already reported about this on BNB.