### PR TITLE
Use `FuturesUnordered` when fetching COW AMM balances

### DIFF
--- a/crates/cow-amm/src/maintainers.rs
+++ b/crates/cow-amm/src/maintainers.rs
@@ -69,7 +69,7 @@ impl Maintaining for EmptyPoolRemoval {
                 }
             })
             .collect::<FuturesUnordered<_>>()
-            .filter_map(|addr| async move { addr })
+            .filter_map(std::future::ready)
             .collect()
             .await;
         if !empty_amms.is_empty() {


### PR DESCRIPTION
# Description
Fetching COW AMM token balances takes a lot of time on base due to a high number of AMMs. In order to speed things up a bit, it is suggested to use `FuturesUnordered`, which is a better approach than `FuturesOrdered`, which is used by `futures_util::future::join_all` when the number of futures exceeds 30.

## How to test
Staging
