### PR TITLE
Migrate DomainSeparator to alloy

### DIFF
--- a/crates/autopilot/src/run.rs
+++ b/crates/autopilot/src/run.rs
@@ -610,10 +610,7 @@ pub async fn run(args: Arguments, shutdown_controller: ShutdownController) {
             web3.clone(),
             quoter.clone(),
             Box::new(custom_ethflow_order_parser),
-            DomainSeparator::new(
-                chain_id,
-                eth.contracts().settlement().address().into_legacy(),
-            ),
+            DomainSeparator::new(chain_id, *eth.contracts().settlement().address()),
             eth.contracts().settlement().address().into_legacy(),
             eth.contracts().trampoline().clone(),
         );

--- a/crates/model/Cargo.toml
+++ b/crates/model/Cargo.toml
@@ -9,7 +9,7 @@ license = "MIT OR Apache-2.0"
 doctest = false
 
 [dependencies]
-alloy = { workspace = true }
+alloy = { workspace = true, features = ["sol-types"] }
 anyhow = { workspace = true }
 app-data = { workspace = true }
 bigdecimal = { workspace = true }

--- a/crates/orderbook/src/run.rs
+++ b/crates/orderbook/src/run.rs
@@ -171,8 +171,7 @@ pub async fn run(args: Arguments) {
     verify_deployed_contract_constants(&settlement_contract, chain_id)
         .await
         .expect("Deployed contract constants don't match the ones in this binary");
-    let domain_separator =
-        DomainSeparator::new(chain_id, settlement_contract.address().into_legacy());
+    let domain_separator = DomainSeparator::new(chain_id, *settlement_contract.address());
     let postgres_write =
         Postgres::try_new(args.db_write_url.as_str()).expect("failed to create database");
 
@@ -590,7 +589,7 @@ async fn verify_deployed_contract_constants(
             .0,
     );
 
-    let domain_separator = DomainSeparator::new(chain_id, contract.address().into_legacy());
+    let domain_separator = DomainSeparator::new(chain_id, *contract.address());
     if !bytecode.contains(&const_hex::encode(domain_separator.0)) {
         return Err(anyhow!("Bytecode did not contain domain separator"));
     }


### PR DESCRIPTION
# Description
Implements the existing `DomainSeparator` using `alloy`. We can also consider to use `alloy`'s `Domain` type directly but it probably makes more sense to do that in a later PR.

## How to test
existing e2e and unit tests
If there is a bug in this code none of the signatures generated for orders would work