### PR TITLE
Migrate mocked test to alloy

### DIFF
--- a/crates/solver/src/interactions/allowances.rs
+++ b/crates/solver/src/interactions/allowances.rs
@@ -390,7 +390,7 @@ mod tests {
         // Poor man's assert + get
         let allowances = allowances
             .get(&spender)
-            .expect(&format!("should have a spender key {:?}", spender));
+            .unwrap_or_else(|| panic!("should have a spender key {:?}", spender));
         assert_eq!(allowances.spender, spender);
         // We don't check which of the two (0x11, 0x22) got the error vs the result
         // because it's order dependent and without a custom mock transport just for


### PR DESCRIPTION
# Description
Migrates the fetch_skips_failed_allowance_calls test to alloy, directly addressing this comment
https://github.com/cowprotocol/services/pull/3927#discussion_r2571030002

# Changes
<!-- List of detailed changes (how the change is accomplished) -->

- [ ] Migrates the fetch_skips_failed_allowance_calls test to alloy
- [ ] Removes the last usages of ethcontract/web3 for crates/solver/src/interactions/allowances.rs

## How to test
Existing tests

<!--
## Related Issues

Fixes #
-->