### PR TITLE
Log the block number on fetching failure

### DIFF
--- a/crates/ethrpc/src/block_stream/mod.rs
+++ b/crates/ethrpc/src/block_stream/mod.rs
@@ -466,7 +466,7 @@ pub async fn block_number_to_block_number_hash(
     let block = provider
         .get_block_by_number(block_number)
         .await?
-        .context("block should exists")?;
+        .with_context(|| format!("failed to find block {}", block_number))?;
     Ok((block.header.number, block.header.hash.into_legacy()))
 }
 


### PR DESCRIPTION
# Description
On BNB the block fetching started to fail, having the block number would be useful to understand how far back the fetcher is.

# Changes
<!-- List of detailed changes (how the change is accomplished) -->

- [ ] Added more textual context to the error context
- [ ] ...

## How to test
NA

<!--
## Related Issues

Fixes #
-->