### PR TITLE
Enable UniswapV3 baseline source for Plasma chain

### DIFF
--- a/crates/shared/src/sources/mod.rs
+++ b/crates/shared/src/sources/mod.rs
@@ -70,7 +70,7 @@ pub fn defaults_for_network(chain: &Chain) -> Vec<BaselineSource> {
         ],
         Chain::Lens => vec![BaselineSource::UniswapV3],
         Chain::Linea => vec![BaselineSource::UniswapV3],
-        Chain::Plasma => vec![],
+        Chain::Plasma => vec![BaselineSource::UniswapV3],
         Chain::Sepolia => vec![BaselineSource::TestnetUniswapV2],
         Chain::Hardhat => panic!("unsupported baseline sources for Hardhat"),
     }

--- a/crates/shared/src/sources/uniswap_v3/graph_api.rs
+++ b/crates/shared/src/sources/uniswap_v3/graph_api.rs
@@ -307,7 +307,7 @@ pub struct PoolData {
 
 impl ContainsId for PoolData {
     fn get_id(&self) -> String {
-        self.id.to_string()
+        format!("{:#x}", self.id)
     }
 }
 


### PR DESCRIPTION
Fixes subgraph pagination failure when fetching UniswapV3 pools from Goldsky-hosted subgraph on Plasma.


The driver was failing to initialize UniswapV3 liquidity with error:
```
Failed to decode `Bytes` value: `Odd number of digits`
```

This error originated from the subgraph (not our Rust code) when processing paginated queries.

### Root Cause

`PoolData::get_id()` in `crates/shared/src/sources/uniswap_v3/graph_api.rs:308:4-311:5` used `H160::to_string()` which produces a truncated display format:
```
0xe67f…018c
```

When this truncated ID was passed as `lastId` for pagination (`id_gt: $lastId`), the subgraph failed to parse it as a valid `Bytes` type due to the ellipsis creating an odd number of hex digits.

### Fix

Changed `self.id.to_string()` to `format!("{:#x}", self.id)` which produces the full 42-character hex string:
```
0xe67f889fddb48845add87a8d59bc805d853d018c
```

### Testing

- Driver successfully initializes 930 pools from Goldsky subgraph
- Quote requests return valid estimates via UniswapV3 liquidity