### PR TITLE
fix flaky test: `local_node_non_settling_solver`

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -258,7 +258,7 @@ jobs:
 
   run-flaky-test:
     # to debug a flaky test set `if` to true and configure the flaky test in the `run` step
-    if: ${{ true }}
+    if: ${{ false }}
     timeout-minutes: 60
     runs-on: ubuntu-latest
     env:
@@ -296,7 +296,7 @@ jobs:
           attempt=1
           while true; do
             echo "Running test attempt #$attempt"
-            if ! just test-e2e local_node_non_settling_solver; then
+            if ! just test-e2e forked_node_mainnet_repay_debt_with_collateral_of_safe; then
               exit 1
             fi
             attempt=$((attempt+1))


### PR DESCRIPTION
# Description
This test appears to be flaky due to a bug in the new auction notficiation logic. It was introduced to avoid busy looping. Now we only start new auctions when we see a new block or a new order. However, so far we first updated the caches and then waited for the notification. This doesn't make a lot of sense since the notification indicates that the cache needs to be updated.
This resulted in test runs where we:
1. update the cache
2. see new order
3. start auction
4. skip empty auction because cache didn't include the order of step `2`

# Changes
Updated the autopilot to only update the cache after receiving the signal to start a new auction

## How to test
Run flaky test runner on `local_node_non_settling_solver` ([run](https://github.com/cowprotocol/services/actions/runs/20094727528/job/57650185851?pr=3962))