### PR TITLE
[EASY] Do not register signer if already exists

### DIFF
--- a/crates/ethrpc/src/alloy/wallet.rs
+++ b/crates/ethrpc/src/alloy/wallet.rs
@@ -6,7 +6,7 @@ use {
         signers::Signature,
         transports::impl_future,
     },
-    std::{sync::Arc, thread},
+    std::{fmt::Debug, sync::Arc, thread},
     tokio::sync::RwLock,
 };
 
@@ -42,6 +42,14 @@ impl MutWallet {
             // default one.
             let register_default = {
                 let r_lock = wallet.0.blocking_read();
+                if <EthereumWallet as NetworkWallet<Ethereum>>::has_signer_for(
+                    &r_lock,
+                    &signer.address(),
+                ) {
+                    // Signer already registered, no need to change anything
+                    return;
+                }
+
                 let default_address =
                     <EthereumWallet as NetworkWallet<Ethereum>>::default_signer_address(&r_lock);
 


### PR DESCRIPTION
A tiny optimization, mostly for better readability, that avoids registering signers that are already present in the wallet. 

The underlying data structure uses a HashMap, but this avoids a redundant insert operation + creating a new Arc instance.