### PR TITLE
Migrate remaining e2e test utilities to alloy primitives

### DIFF
--- a/crates/e2e/src/setup/mod.rs
+++ b/crates/e2e/src/setup/mod.rs
@@ -11,8 +11,8 @@ use {
     crate::nodes::{NODE_HOST, Node},
     ::alloy::signers::local::{MnemonicBuilder, coins_bip39::English},
     anyhow::{Result, anyhow},
-    ethcontract::futures::FutureExt,
     ethrpc::Web3,
+    futures::FutureExt,
     std::{
         future::Future,
         io::Write,

--- a/crates/e2e/tests/e2e/liquidity.rs
+++ b/crates/e2e/tests/e2e/liquidity.rs
@@ -1,6 +1,6 @@
 use {
     alloy::{
-        primitives::{Address, address},
+        primitives::{Address, B256, address},
         providers::{
             Provider,
             ext::{AnvilApi, ImpersonateConfig},
@@ -21,11 +21,7 @@ use {
             wait_for_condition,
         },
     },
-    ethcontract::H256,
-    ethrpc::{
-        Web3,
-        alloy::{CallBuilderExt, conversions::IntoLegacy},
-    },
+    ethrpc::{Web3, alloy::CallBuilderExt},
     model::{
         order::{OrderCreation, OrderKind},
         signature::EcdsaSigningScheme,
@@ -403,7 +399,7 @@ async fn fill_or_kill_zeroex_limit_order(
     zeroex: &IZeroex::Instance,
     zeroex_order: &shared::zeroex_api::OrderRecord,
     from: Address,
-) -> anyhow::Result<H256> {
+) -> anyhow::Result<B256> {
     let order = zeroex_order.order();
     let tx_hash = zeroex
         .fillOrKillLimitOrder(
@@ -435,5 +431,5 @@ async fn fill_or_kill_zeroex_limit_order(
         .watch()
         .await?;
 
-    Ok(tx_hash.into_legacy())
+    Ok(tx_hash)
 }


### PR DESCRIPTION
# Description

Migrates internal `ethcontract` types to `alloy` primitives within the `e2e` crate, reducing reliance on legacy types.

# Changes

- [x] Replace `ethcontract::primitives` with `alloy::primitives`
- [x] Simplify impersonate() function. `Account` return was unused; alloy handles impersonation via provider without wallet + `.from(address)`; now returning unit (), since function's return value wasn't being used.
- [x] Remove unnecessary `into_legacy()`/`into_alloy()` conversions

Note: `ethcontract` dependency remains for shared crate compatibility.

## How to test

1. `cargo check -p e2e --tests`
2. Run e2e tests