### PR TITLE
Encode `debug_traceTransaction` without additional arguments

### DIFF
--- a/crates/autopilot/src/infra/blockchain/mod.rs
+++ b/crates/autopilot/src/infra/blockchain/mod.rs
@@ -5,7 +5,7 @@ use {
         providers::{Provider, ext::DebugApi},
         rpc::types::{
             TransactionReceipt,
-            trace::geth::{CallConfig, GethDebugTracingOptions, GethTrace},
+            trace::geth::{GethDebugBuiltInTracerType, GethDebugTracingOptions, GethTrace},
         },
     },
     anyhow::bail,
@@ -118,7 +118,7 @@ impl Ethereum {
             // batched debug calls.
             self.unbuffered_web3.alloy.debug_trace_transaction(
                 hash.0,
-                GethDebugTracingOptions::call_tracer(CallConfig::default()),
+                GethDebugTracingOptions::new_tracer(GethDebugBuiltInTracerType::CallTracer),
             )
         )?;
 


### PR DESCRIPTION
# Description
https://github.com/cowprotocol/services/pull/3982 introduced a small change that caused the settlement indexing to fail on lens.
The `debug_traceTransaction` calls are now failing with the error `Alloy(ErrorResp(ErrorPayload { code: -32602, message: "Invalid params", data: Some(RawValue("missing field `onlyTopCall` at line 1 column 40")) }))`.
Previously we encoded a call with the arguments `{"tracer": "callTracer"}` (see [here](https://github.com/cowprotocol/services/pull/3245/changes#diff-14f392497ccc8b1cd579aa0a4ea9e7643073d80a9b328e9dd838216d1cbdbaadR116-R119)) but now due to how alloy's internal logic works we encode arguments like `{"tracer": "callTracer", "tracerConfig": {}}`. Alloy only skips encoding the `tracer_config` argument when it's null (see [here](https://github.com/alloy-rs/alloy/blob/main/crates/rpc-types-trace/src/geth/mod.rs#L521)) but `GethDebugTracingOptions::call_tracer(CallConfig::default())` ends up putting an empty JSON object into `tracer_config` instead of `null`.

# Changes
Update `debug_traceTransaction` arguments to not encode any `tracerConfig`.

## How to test
Confirmed hypothesis with `cast`.
Current call:
```
cast rpc -r <LENS_RPC> debug_traceTransaction 0x4c1900589b428950ebd17008eecf5b6ca6e9698c5c02b450a8868fd94a30fb7c '{"tracer": "callTracer", "tracerConfig": {}}'
Error: server returned an error response: error code -32602: Invalid params, data: "missing field `onlyTopCall` at line 1 column 40"
```

Without additional `tracerConfig`:
```
cast rpc -r <LENS_RPC> debug_traceTransaction 0x4c1900589b428950ebd17008eecf5b6ca6e9698c5c02b450a8868fd94a30fb7c '{"tracer": "callTracer"}'
{"type":"call","from":"0x0000000000000000000000000000000000000000","to":"0x0000000000000000000000000000000000008001","gas":"0x3126b4","gasUsed":"0xf8d38"....
```