### PR TITLE
Ignore `RUSTSEC-2026-0001`

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -60,4 +60,9 @@ ignore = [
     # model crate - data race in Shared (RUSTSEC-2020-0140)
     # Internal crate issue (tracked in #3338)
     "RUSTSEC-2020-0140",
+
+    # rust_decimal - depends on rkyv v0.7, which has a critical vulnerability.
+    # The fix requires upgrading to rkyv v0.8, which has breaking changes.
+    # More details: <https://github.com/paupino/rust-decimal/issues/766>
+    "RUSTSEC-2026-0001",
 ]


### PR DESCRIPTION
Ignores the RUSTSEC-2026-0001 vulnerability in the rkyv v0.7 crate, since there is no safe way to upgrade to v0.8 without introducing breaking changes.

More details: https://github.com/paupino/rust-decimal/issues/766

Otherwise, the cargo audit CI job fails https://github.com/cowprotocol/services/actions/runs/20718955210/job/59477209280?pr=4010