### PR TITLE
Remove AlloyEventRetriever wrapper type

### DIFF
--- a/crates/autopilot/src/maintenance.rs
+++ b/crates/autopilot/src/maintenance.rs
@@ -19,7 +19,7 @@ use {
         IntCounterVec,
         core::{AtomicU64, GenericGauge},
     },
-    shared::{event_handling::AlloyEventRetriever, maintenance::Maintaining},
+    shared::maintenance::Maintaining,
     std::{
         future::Future,
         sync::Arc,
@@ -32,7 +32,7 @@ use {
 /// to ensure a consistent view of the system.
 pub struct Maintenance {
     /// Indexes and persists all events emited by the settlement contract.
-    settlement_indexer: EventUpdater<Indexer, AlloyEventRetriever<GPv2SettlementContract>>,
+    settlement_indexer: EventUpdater<Indexer, GPv2SettlementContract>,
     /// Used for periodic cleanup tasks to not have the DB overflow with old
     /// data.
     db_cleanup: Postgres,
@@ -49,7 +49,7 @@ pub struct Maintenance {
 
 impl Maintenance {
     pub fn new(
-        settlement_indexer: EventUpdater<Indexer, AlloyEventRetriever<GPv2SettlementContract>>,
+        settlement_indexer: EventUpdater<Indexer, GPv2SettlementContract>,
         db_cleanup: Postgres,
         timeout: Duration,
     ) -> Self {
@@ -161,10 +161,8 @@ impl Maintenance {
     }
 }
 
-type EthflowIndexer = EventUpdater<
-    OnchainOrderParser<EthFlowData, EthFlowDataForDb>,
-    AlloyEventRetriever<CoWSwapOnchainOrdersContract>,
->;
+type EthflowIndexer =
+    EventUpdater<OnchainOrderParser<EthFlowData, EthFlowDataForDb>, CoWSwapOnchainOrdersContract>;
 
 #[derive(prometheus_metric_storage::MetricStorage)]
 #[metric(subsystem = "autopilot_maintenance")]

--- a/crates/autopilot/src/run.rs
+++ b/crates/autopilot/src/run.rs
@@ -45,7 +45,6 @@ use {
         },
         baseline_solver::BaseTokens,
         code_fetching::CachedCodeFetcher,
-        event_handling::AlloyEventRetriever,
         http_client::HttpClientFactory,
         maintenance::ServiceMaintenance,
         order_quoting::{self, OrderQuoter},
@@ -449,10 +448,10 @@ pub async fn run(args: Arguments, shutdown_controller: ShutdownController) {
         }
     };
     let settlement_event_indexer = EventUpdater::new(
-        AlloyEventRetriever(boundary::events::settlement::GPv2SettlementContract::new(
+        boundary::events::settlement::GPv2SettlementContract::new(
             web3.alloy.clone(),
             *eth.contracts().settlement().address(),
-        )),
+        ),
         boundary::events::settlement::Indexer::new(
             db_write.clone(),
             settlement_observer,
@@ -595,10 +594,7 @@ pub async fn run(args: Arguments, shutdown_controller: ShutdownController) {
         let refund_event_handler = EventUpdater::new_skip_blocks_before(
             // This cares only about ethflow refund events because all the other ethflow
             // events are already indexed by the OnchainOrderParser.
-            AlloyEventRetriever(EthFlowRefundRetriever::new(
-                web3.clone(),
-                args.ethflow_contracts.clone(),
-            )),
+            EthFlowRefundRetriever::new(web3.clone(), args.ethflow_contracts.clone()),
             db_write.clone(),
             block_retriever.clone(),
             ethflow_refund_start_block,
@@ -630,10 +626,7 @@ pub async fn run(args: Arguments, shutdown_controller: ShutdownController) {
         let onchain_order_indexer = EventUpdater::new_skip_blocks_before(
             // The events from the ethflow contract are read with the more generic contract
             // interface called CoWSwapOnchainOrders.
-            AlloyEventRetriever(CoWSwapOnchainOrdersContract::new(
-                web3.clone(),
-                args.ethflow_contracts,
-            )),
+            CoWSwapOnchainOrdersContract::new(web3.clone(), args.ethflow_contracts),
             onchain_order_event_parser,
             block_retriever,
             ethflow_start_block,

--- a/crates/cow-amm/src/registry.rs
+++ b/crates/cow-amm/src/registry.rs
@@ -4,7 +4,7 @@ use {
     contracts::alloy::cow_amm::CowAmmLegacyHelper,
     ethrpc::{Web3, block_stream::CurrentBlockWatcher},
     shared::{
-        event_handling::{AlloyEventRetriever, EventHandler},
+        event_handling::EventHandler,
         maintenance::{Maintaining, ServiceMaintenance},
     },
     sqlx::PgPool,
@@ -56,12 +56,8 @@ impl Registry {
             web3: self.web3.clone(),
             address: factory,
         };
-        let event_handler = EventHandler::new(
-            Arc::new(self.web3.alloy.clone()),
-            AlloyEventRetriever(indexer),
-            storage,
-            None,
-        );
+        let event_handler =
+            EventHandler::new(Arc::new(self.web3.alloy.clone()), indexer, storage, None);
         let token_balance_maintainer =
             EmptyPoolRemoval::new(self.storage.clone(), self.web3.clone());
 

--- a/crates/shared/src/sources/balancer_v2/pool_fetching/registry.rs
+++ b/crates/shared/src/sources/balancer_v2/pool_fetching/registry.rs
@@ -4,7 +4,7 @@
 use {
     super::{internal::InternalPoolFetching, pool_storage::PoolStorage},
     crate::{
-        event_handling::{AlloyEventRetriever, AlloyEventRetrieving, EventHandler},
+        event_handling::{AlloyEventRetrieving, EventHandler},
         maintenance::Maintaining,
         recent_block_cache::Block,
         sources::balancer_v2::{
@@ -51,7 +51,7 @@ impl AlloyEventRetrieving for BasePoolFactoryContract {
 /// Type alias for the internal event updater type.
 type PoolUpdater<Factory> = Mutex<
     EventHandler<
-        AlloyEventRetriever<BasePoolFactoryContract>,
+        BasePoolFactoryContract,
         PoolStorage<Factory>,
         (BalancerV2BasePoolFactoryEvents, Log),
     >,
@@ -85,7 +85,7 @@ where
     ) -> Self {
         let updater = Mutex::new(EventHandler::new(
             block_retreiver,
-            AlloyEventRetriever(BasePoolFactoryContract(base_pool_factory(factory_instance))),
+            BasePoolFactoryContract(base_pool_factory(factory_instance)),
             PoolStorage::new(initial_pools, fetcher.clone()),
             start_sync_at_block,
         ));

--- a/crates/shared/src/sources/uniswap_v3/pool_fetching.rs
+++ b/crates/shared/src/sources/uniswap_v3/pool_fetching.rs
@@ -4,7 +4,7 @@ use {
         graph_api::{PoolData, Token, UniV3SubgraphClient},
     },
     crate::{
-        event_handling::{AlloyEventRetriever, EventHandler, EventStoring, MAX_REORG_BLOCK_COUNT},
+        event_handling::{EventHandler, EventStoring, MAX_REORG_BLOCK_COUNT},
         maintenance::Maintaining,
         recent_block_cache::Block,
         sources::uniswap_v3::event_fetching::WithAddress,
@@ -274,11 +274,7 @@ pub struct UniswapV3PoolFetcher {
     /// Recent events used on top of pools_checkpoint to get the `latest_block`
     /// pools state.
     events: tokio::sync::Mutex<
-        EventHandler<
-            AlloyEventRetriever<UniswapV3PoolEventFetcher>,
-            RecentEventsCache,
-            (AlloyUniswapV3PoolEvents, Log),
-        >,
+        EventHandler<UniswapV3PoolEventFetcher, RecentEventsCache, (AlloyUniswapV3PoolEvents, Log)>,
     >,
 }
 
@@ -305,7 +301,7 @@ impl UniswapV3PoolFetcher {
 
         let events = tokio::sync::Mutex::new(EventHandler::new(
             block_retriever,
-            AlloyEventRetriever(UniswapV3PoolEventFetcher(web3.alloy)),
+            UniswapV3PoolEventFetcher(web3.alloy),
             RecentEventsCache::default(),
             Some(init_block),
         ));


### PR DESCRIPTION
# Description
Removes the AlloyEventRetriever wrapper, at this point, we've migrated all contracts, etc, it's no longer needed.

# Changes

- [ ] Removes the AlloyEventRetriver
- [ ] Updates call sites accordingly

## How to test
Existing tests