### PR TITLE
Add Linea network to orderbook OpenAPI spec

### DIFF
--- a/crates/orderbook/openapi.yml
+++ b/crates/orderbook/openapi.yml
@@ -31,6 +31,10 @@ servers:
     url: "https://api.cow.fi/lens"
   - description: Lens (Staging)
     url: "https://barn.api.cow.fi/lens"
+  - description: Linea (Prod)
+    url: "https://api.cow.fi/linea"
+  - description: Linea (Staging)
+    url: "https://barn.api.cow.fi/linea"
   - description: BNB (Prod)
     url: "https://api.cow.fi/bnb"
   - description: BNB (Staging)


### PR DESCRIPTION
# Description

Add Linea network endpoints to the orderbook OpenAPI specification.

# Changes

- Added Linea server endpoint: `https://api.cow.fi/linea` and `https://barn.api.cow.fi/linea` (prod/staging) into openapi

<img width="694" height="746" alt="image" src="https://github.com/user-attachments/assets/184c6d53-f60d-4d33-bbeb-467a44beff67" />


## How to test

1. `ruby -ryaml -e "YAML.load_file('crates/orderbook/openapi.yml')"` - validate yaml syntax
2. `npx @redocly/cli lint crates/orderbook/openapi.yml` - scheme 
3.  https://editor.swagger.io/ - Linea appears in the server dropdown