### PR TITLE
Migrate shared crate off of ethcontract

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6058,7 +6058,6 @@ dependencies = [
  "database",
  "derivative",
  "derive_more 1.0.0",
- "ethcontract",
  "ethrpc",
  "futures",
  "gas-estimation",

--- a/crates/ethrpc/src/mock.rs
+++ b/crates/ethrpc/src/mock.rs
@@ -4,6 +4,7 @@ use {
     crate::{Web3, alloy::MutWallet},
     alloy::providers::{Provider, ProviderBuilder, mock::Asserter},
     ethcontract::{
+        dyns::DynTransport,
         futures::future::{self, Ready},
         jsonrpc::{Call, Id, MethodCall, Params},
         web3::{self, BatchTransport, RequestId, Transport},
@@ -31,6 +32,17 @@ impl Web3<MockTransport> {
                 .connect_mocked_client(asserter)
                 .erased(),
             wallet: MutWallet::default(),
+        }
+    }
+
+    // HACK(jmg-duarte): used to convert a MockTransport -> DynTransport so we can
+    // remove ethcontract imports from shared should be fixed in a follow up PR,
+    // removing web3 from ethrpc
+    pub fn erased(self) -> Web3<DynTransport> {
+        Web3 {
+            legacy: web3::Web3::new(DynTransport::new(self.legacy.transport().clone())),
+            alloy: self.alloy,
+            wallet: self.wallet,
         }
     }
 }

--- a/crates/shared/Cargo.toml
+++ b/crates/shared/Cargo.toml
@@ -24,7 +24,6 @@ dashmap = { workspace = true }
 database = { workspace = true }
 derive_more = { workspace = true }
 derivative = { workspace = true }
-ethcontract = { workspace = true }
 ethrpc = { workspace = true }
 futures = { workspace = true }
 gas-estimation = { workspace = true }

--- a/crates/shared/src/price_estimation/trade_verifier/balance_overrides/mod.rs
+++ b/crates/shared/src/price_estimation/trade_verifier/balance_overrides/mod.rs
@@ -542,16 +542,7 @@ mod tests {
         let balance_overrides = BalanceOverrides {
             hardcoded: Default::default(),
             detector: Some((
-                Detector::new(
-                    ethrpc::Web3 {
-                        legacy: web3::Web3::new(ethcontract::transport::DynTransport::new(
-                            mock::MockTransport::new(),
-                        )),
-                        alloy: mock_web3.alloy,
-                        wallet: mock_web3.wallet,
-                    },
-                    60,
-                ),
+                Detector::new(mock_web3.erased(), 60),
                 Mutex::new(SizedCache::with_size(100)),
             )),
         };
@@ -599,16 +590,7 @@ mod tests {
         let balance_overrides = BalanceOverrides {
             hardcoded: Default::default(),
             detector: Some((
-                Detector::new(
-                    ethrpc::Web3 {
-                        legacy: web3::Web3::new(ethcontract::transport::DynTransport::new(
-                            mock::MockTransport::new(),
-                        )),
-                        alloy: mock_web3.alloy,
-                        wallet: mock_web3.wallet,
-                    },
-                    60,
-                ),
+                Detector::new(mock_web3.erased(), 60),
                 Mutex::new(SizedCache::with_size(100)),
             )),
         };

--- a/crates/shared/src/recent_block_cache.rs
+++ b/crates/shared/src/recent_block_cache.rs
@@ -29,7 +29,6 @@ use {
     alloy::eips::BlockId,
     anyhow::{Context, Result},
     cached::{Cached, SizedCache},
-    ethcontract::BlockNumber,
     ethrpc::block_stream::CurrentBlockWatcher,
     futures::{FutureExt, StreamExt},
     itertools::Itertools,
@@ -73,16 +72,6 @@ pub enum Block {
     Recent,
     Number(u64),
     Finalized,
-}
-
-impl From<Block> for BlockNumber {
-    fn from(val: Block) -> Self {
-        match val {
-            Block::Recent => BlockNumber::Latest,
-            Block::Number(number) => BlockNumber::Number(number.into()),
-            Block::Finalized => BlockNumber::Finalized,
-        }
-    }
 }
 
 impl From<Block> for BlockId {

--- a/crates/shared/src/sources/swapr.rs
+++ b/crates/shared/src/sources/swapr.rs
@@ -2,10 +2,10 @@
 
 use {
     crate::sources::uniswap_v2::pool_fetching::{DefaultPoolReader, Pool, PoolReading},
+    alloy::eips::BlockId,
     anyhow::Result,
     contracts::alloy::ISwaprPair,
-    ethcontract::BlockId,
-    ethrpc::alloy::{conversions::IntoAlloy, errors::ignore_non_node_error},
+    ethrpc::alloy::errors::ignore_non_node_error,
     futures::{FutureExt as _, future::BoxFuture},
     model::TokenPair,
     num::rational::Ratio,
@@ -27,7 +27,7 @@ impl PoolReading for SwaprPoolReader {
 
         async move {
             let pair_contract = ISwaprPair::Instance::new(pair_address, self.0.web3.alloy.clone());
-            let fetch_fee = pair_contract.swapFee().block(block.into_alloy());
+            let fetch_fee = pair_contract.swapFee().block(block);
 
             let (pool, fee) = futures::join!(fetch_pool, fetch_fee.call().into_future());
             handle_results(pool, fee)

--- a/crates/shared/src/sources/uniswap_v2/pool_fetching.rs
+++ b/crates/shared/src/sources/uniswap_v2/pool_fetching.rs
@@ -1,18 +1,17 @@
 use {
     super::pair_provider::PairProvider,
     crate::{baseline_solver::BaselineSolvable, ethrpc::Web3, recent_block_cache::Block},
-    alloy::primitives::Address,
+    alloy::{
+        eips::BlockId,
+        primitives::{Address, U256},
+    },
     anyhow::Result,
     cached::{Cached, TimedCache},
     contracts::alloy::{
         ERC20,
         IUniswapLikePair::{self, IUniswapLikePair::getReservesReturn},
     },
-    ethcontract::{BlockId, U256},
-    ethrpc::alloy::{
-        conversions::{IntoAlloy, IntoLegacy},
-        errors::ignore_non_node_error,
-    },
+    ethrpc::alloy::errors::ignore_non_node_error,
     futures::{
         FutureExt as _,
         future::{self, BoxFuture},
@@ -145,7 +144,7 @@ impl Pool {
         let denominator = reserve_out
             .checked_sub(amount_out)?
             .checked_mul(U256::from(self.fee.denom().checked_sub(*self.fee.numer())?))?;
-        let amount_in = numerator.checked_div(denominator)?.checked_add(1.into())?;
+        let amount_in = numerator.checked_div(denominator)?.checked_add(U256::ONE)?;
 
         check_final_reserves(amount_in, amount_out, reserve_in, reserve_out)?;
         Some(amount_in)
@@ -172,24 +171,24 @@ impl BaselineSolvable for Pool {
     async fn get_amount_out(
         &self,
         out_token: Address,
-        (in_amount, in_token): (alloy::primitives::U256, Address),
-    ) -> Option<alloy::primitives::U256> {
-        self.get_amount_out(in_token, in_amount.into_legacy())
+        (in_amount, in_token): (U256, Address),
+    ) -> Option<U256> {
+        self.get_amount_out(in_token, in_amount)
             .map(|(out_amount, token)| {
                 assert_eq!(token, out_token);
-                out_amount.into_alloy()
+                out_amount
             })
     }
 
     async fn get_amount_in(
         &self,
         in_token: Address,
-        (out_amount, out_token): (alloy::primitives::U256, Address),
-    ) -> Option<alloy::primitives::U256> {
-        self.get_amount_in(out_token, out_amount.into_legacy())
+        (out_amount, out_token): (U256, Address),
+    ) -> Option<U256> {
+        self.get_amount_in(out_token, out_amount)
             .map(|(in_amount, token)| {
                 assert_eq!(token, in_token);
-                in_amount.into_alloy()
+                in_amount
             })
     }
 
@@ -226,10 +225,9 @@ where
             let mut non_existent_pools = self.non_existent_pools.write().unwrap();
             token_pairs.retain(|pair| non_existent_pools.cache_get(pair).is_none());
         }
-        let block = BlockId::Number(at_block.into());
         let futures = token_pairs
             .iter()
-            .map(|pair| self.pool_reader.read_state(*pair, block))
+            .map(|pair| self.pool_reader.read_state(*pair, at_block.into()))
             .collect::<Vec<_>>();
 
         let results = future::try_join_all(futures).await?;
@@ -280,12 +278,12 @@ impl PoolReading for DefaultPoolReader {
         let token1 = ERC20::Instance::new(pair.get().1, self.web3.alloy.clone());
 
         async move {
-            let fetch_token0_balance = token0.balanceOf(pair_address).block(block.into_alloy());
-            let fetch_token1_balance = token1.balanceOf(pair_address).block(block.into_alloy());
+            let fetch_token0_balance = token0.balanceOf(pair_address).block(block);
+            let fetch_token1_balance = token1.balanceOf(pair_address).block(block);
 
             let pair_contract =
                 IUniswapLikePair::Instance::new(pair_address, self.web3.alloy.clone());
-            let fetch_reserves = pair_contract.getReserves().block(block.into_alloy());
+            let fetch_reserves = pair_contract.getReserves().block(block);
 
             let (reserves, token0_balance, token1_balance) = futures::join!(
                 fetch_reserves.call().into_future(),
@@ -310,8 +308,8 @@ impl PoolReading for DefaultPoolReader {
 struct FetchedPool {
     pair: TokenPair,
     reserves: Result<getReservesReturn, alloy::contract::Error>,
-    token0_balance: Result<alloy::primitives::U256, alloy::contract::Error>,
-    token1_balance: Result<alloy::primitives::U256, alloy::contract::Error>,
+    token0_balance: Result<U256, alloy::contract::Error>,
+    token1_balance: Result<U256, alloy::contract::Error>,
 }
 
 fn handle_results(fetched_pool: FetchedPool, address: Address) -> Result<Option<Pool>> {
@@ -335,9 +333,7 @@ fn handle_results(fetched_pool: FetchedPool, address: Address) -> Result<Option<
         // benefit by withdrawing the excess from the pool without selling anything).
         // We therefore exclude all pools where the pool's token balance of either token
         // in the pair is less than the cached reserve.
-        if alloy::primitives::U256::from(r0) > token0_balance?
-            || alloy::primitives::U256::from(r1) > token1_balance?
-        {
+        if U256::from(r0) > token0_balance? || U256::from(r1) > token1_balance? {
             return None;
         }
         // Errors here should never happen because reserves are uint<112, 2>
@@ -391,16 +387,16 @@ mod tests {
             (100, 100),
         );
         assert_eq!(
-            pool.get_amount_out(sell_token, 10.into()),
-            Some((9.into(), buy_token))
+            pool.get_amount_out(sell_token, U256::from(10)),
+            Some((U256::from(9), buy_token))
         );
         assert_eq!(
-            pool.get_amount_out(sell_token, 100.into()),
-            Some((49.into(), buy_token))
+            pool.get_amount_out(sell_token, U256::from(100)),
+            Some((U256::from(49), buy_token))
         );
         assert_eq!(
-            pool.get_amount_out(sell_token, 1000.into()),
-            Some((90.into(), buy_token))
+            pool.get_amount_out(sell_token, U256::from(1000)),
+            Some((U256::from(90), buy_token))
         );
 
         //Uneven Pool
@@ -410,16 +406,16 @@ mod tests {
             (200, 50),
         );
         assert_eq!(
-            pool.get_amount_out(sell_token, 10.into()),
-            Some((2.into(), buy_token))
+            pool.get_amount_out(sell_token, U256::from(10)),
+            Some((U256::from(2), buy_token))
         );
         assert_eq!(
-            pool.get_amount_out(sell_token, 100.into()),
-            Some((16.into(), buy_token))
+            pool.get_amount_out(sell_token, U256::from(100)),
+            Some((U256::from(16), buy_token))
         );
         assert_eq!(
-            pool.get_amount_out(sell_token, 1000.into()),
-            Some((41.into(), buy_token))
+            pool.get_amount_out(sell_token, U256::from(1000)),
+            Some((U256::from(41), buy_token))
         );
 
         // Large Numbers
@@ -429,12 +425,12 @@ mod tests {
             (1u128 << 90, 1u128 << 90),
         );
         assert_eq!(
-            pool.get_amount_out(sell_token, 10u128.pow(20).into()),
-            Some((99_699_991_970_459_889_807u128.into(), buy_token))
+            pool.get_amount_out(sell_token, U256::from(10u128.pow(20))),
+            Some((U256::from(99_699_991_970_459_889_807u128), buy_token))
         );
 
         // Overflow
-        assert_eq!(pool.get_amount_out(sell_token, U256::max_value()), None);
+        assert_eq!(pool.get_amount_out(sell_token, U256::MAX), None);
     }
 
     #[test]
@@ -449,17 +445,17 @@ mod tests {
             (100, 100),
         );
         assert_eq!(
-            pool.get_amount_in(buy_token, 10.into()),
-            Some((12.into(), sell_token))
+            pool.get_amount_in(buy_token, U256::from(10)),
+            Some((U256::from(12), sell_token))
         );
         assert_eq!(
-            pool.get_amount_in(buy_token, 99.into()),
-            Some((9930.into(), sell_token))
+            pool.get_amount_in(buy_token, U256::from(99)),
+            Some((U256::from(9930), sell_token))
         );
 
         // Buying more than possible
-        assert_eq!(pool.get_amount_in(buy_token, 100.into()), None);
-        assert_eq!(pool.get_amount_in(buy_token, 1000.into()), None);
+        assert_eq!(pool.get_amount_in(buy_token, U256::from(100)), None);
+        assert_eq!(pool.get_amount_in(buy_token, U256::from(1000)), None);
 
         //Uneven Pool
         let pool = Pool::uniswap(
@@ -468,12 +464,12 @@ mod tests {
             (200, 50),
         );
         assert_eq!(
-            pool.get_amount_in(buy_token, 10.into()),
-            Some((51.into(), sell_token))
+            pool.get_amount_in(buy_token, U256::from(10)),
+            Some((U256::from(51), sell_token))
         );
         assert_eq!(
-            pool.get_amount_in(buy_token, 49.into()),
-            Some((9830.into(), sell_token))
+            pool.get_amount_in(buy_token, U256::from(49)),
+            Some((U256::from(9830), sell_token))
         );
 
         // Large Numbers
@@ -483,27 +479,41 @@ mod tests {
             (1u128 << 90, 1u128 << 90),
         );
         assert_eq!(
-            pool.get_amount_in(buy_token, 10u128.pow(20).into()),
-            Some((100_300_910_810_367_424_267u128.into(), sell_token)),
+            pool.get_amount_in(buy_token, U256::from(10u128.pow(20))),
+            Some((U256::from(100_300_910_810_367_424_267u128), sell_token)),
         );
     }
 
     #[test]
     fn computes_final_reserves() {
         assert_eq!(
-            check_final_reserves(1.into(), 2.into(), 1_000_000.into(), 2_000_000.into(),).unwrap(),
-            (1_000_001.into(), 1_999_998.into()),
+            check_final_reserves(
+                U256::ONE,
+                U256::from(2),
+                U256::from(1_000_000),
+                U256::from(2_000_000),
+            )
+            .unwrap(),
+            (U256::from(1_000_001), U256::from(1_999_998)),
         );
     }
 
     #[test]
     fn check_final_reserve_limits() {
         // final out reserve too low
-        assert!(check_final_reserves(0.into(), 1.into(), 1_000_000.into(), 0.into()).is_none());
+        assert!(
+            check_final_reserves(U256::ZERO, U256::ONE, U256::from(1_000_000), U256::ZERO)
+                .is_none()
+        );
         // final in reserve too high
         assert!(
-            check_final_reserves(1.into(), 0.into(), *POOL_MAX_RESERVES, 1_000_000.into())
-                .is_none()
+            check_final_reserves(
+                U256::ONE,
+                U256::ZERO,
+                *POOL_MAX_RESERVES,
+                U256::from(1_000_000)
+            )
+            .is_none()
         );
     }
 
@@ -512,8 +522,8 @@ mod tests {
         let fetched_pool = FetchedPool {
             reserves: Err(testing_alloy_node_error()),
             pair: Default::default(),
-            token0_balance: Ok(alloy::primitives::U256::from(1)),
-            token1_balance: Ok(alloy::primitives::U256::from(1)),
+            token0_balance: Ok(U256::ONE),
+            token1_balance: Ok(U256::ONE),
         };
         let pool_address = Default::default();
         assert!(handle_results(fetched_pool, pool_address).is_err());
@@ -524,8 +534,8 @@ mod tests {
         let fetched_pool = FetchedPool {
             reserves: Err(testing_alloy_contract_error()),
             pair: Default::default(),
-            token0_balance: Ok(alloy::primitives::U256::from(1)),
-            token1_balance: Ok(alloy::primitives::U256::from(1)),
+            token0_balance: Ok(U256::ONE),
+            token1_balance: Ok(U256::ONE),
         };
         let pool_address = Default::default();
         assert!(


### PR DESCRIPTION
# Description
Migrates the shared crate off of ethcontract, dependency becomes based on ethrpc (which will be changed next)

Had to add an extra function to make this last one work before removing that API and others related to the old web3 library.

# Changes

- [ ] Migrate the last APIs on shared to alloy
- [ ] Added `erased` to ethrpc to ease the transition — will be removed later

## How to test
Existing tests