### PR TITLE
Stop counting unused appdata

### DIFF
--- a/crates/autopilot/src/database/mod.rs
+++ b/crates/autopilot/src/database/mod.rs
@@ -77,10 +77,6 @@ impl Postgres {
             metrics.table_rows.with_label_values(&[table]).set(count);
         }
 
-        // update unused app data metric
-        let count = count_unused_app_data(&mut ex).await?;
-        metrics.unused_app_data.set(count);
-
         Ok(())
     }
 
@@ -109,31 +105,11 @@ async fn analyze_table(ex: &mut PgConnection, table: &str) -> sqlx::Result<()> {
     ex.execute(sqlx::query(&query)).await.map(|_| ())
 }
 
-async fn count_unused_app_data(ex: &mut PgConnection) -> sqlx::Result<i64> {
-    let query = r#"
-        SELECT
-            COUNT(*)
-        FROM app_data AS a
-        LEFT JOIN orders o
-            ON a.contract_app_data = o.app_data
-        WHERE
-            o.app_data IS NULL
-        ;
-    "#;
-    sqlx::query_scalar(query).fetch_one(ex).await
-}
-
 #[derive(prometheus_metric_storage::MetricStorage)]
 struct Metrics {
     /// Number of rows in db tables.
     #[metric(labels("table"))]
     table_rows: prometheus::IntGaugeVec,
-
-    /// Number of unused app data entries.
-    ///
-    /// These are entries in the `app_data` table that do not have a
-    /// corresponding order in the `orders` table.
-    unused_app_data: prometheus::IntGauge,
 
     /// Timing of db queries.
     #[metric(


### PR DESCRIPTION
# Description
According to RDS metrics a relatively high amount of DB load gets caused by a query counting how many appdatas have never been used in an order.
This query takes ~4s on the read replica. While I originally worked on speeding up the query (a simple index produced good results) I think it probably makes more sense to remove this logic altogether.
We've never paid attention to this metric so why pay with DB load for something we don't use?

# Changes
Dropped code to count unused appdatas in the DB metrics.