### PR TITLE
Remove duplicate NATIVE_PRICE_ESTIMATORS from docker-compose.fork.yml

### DIFF
--- a/playground/docker-compose.fork.yml
+++ b/playground/docker-compose.fork.yml
@@ -116,13 +116,12 @@ services:
       - SETTLE_INTERVAL=15s
       - GAS_ESTIMATORS=Native,Web3
       - PRICE_ESTIMATORS=None
-      - NATIVE_PRICE_ESTIMATORS=baseline
       - BLOCK_STREAM_POLL_INTERVAL=1s
       - NATIVE_PRICE_CACHE_MAX_UPDATE_SIZE=100
       - NATIVE_PRICE_CACHE_MAX_AGE=20m
       - SOLVER_TIME_LIMIT=5
       - PRICE_ESTIMATION_DRIVERS=baseline|http://driver/baseline
-      - NATIVE_PRICE_ESTIMATORS=baseline|http://driver/baseline
+      - NATIVE_PRICE_ESTIMATORS=Driver|baseline|http://driver/baseline
       - DRIVERS=baseline|http://driver/baseline|0xa0Ee7A142d267C1f36714E4a8F75612F20a79720
       - SKIP_EVENT_SYNC=true
       - BASELINE_SOURCES=None


### PR DESCRIPTION
# Description

Autopilot flag `NATIVE_PRICE_ESTIMATORS` set with 2 different values in docker-compose.fork.yml. 

# Changes

- [ ] Remove duplicate NATIVE_PRICE_ESTIMATORS from docker-compose

## Related Issues

https://github.com/cowprotocol/services/issues/4063
