### PR TITLE
Enable TCP KeepAlive

### DIFF
--- a/crates/autopilot/src/infra/solvers/mod.rs
+++ b/crates/autopilot/src/infra/solvers/mod.rs
@@ -74,7 +74,7 @@ impl Driver {
             fairness_threshold,
             client: Client::builder()
                 .timeout(RESPONSE_TIME_LIMIT)
-                .tcp_keepalive(Duration::from_secs(15))
+                .tcp_keepalive(Duration::from_secs(60))
                 .build()
                 .map_err(Error::FailedToBuildClient)?,
             submission_address,

--- a/crates/driver/src/domain/competition/order/app_data.rs
+++ b/crates/driver/src/domain/competition/order/app_data.rs
@@ -35,7 +35,7 @@ impl AppDataRetriever {
     pub fn new(orderbook_url: Url, cache_size: u64) -> Self {
         Self(Arc::new(Inner {
             client: reqwest::Client::builder()
-                .tcp_keepalive(Duration::from_secs(15))
+                .tcp_keepalive(Duration::from_secs(60))
                 .build()
                 .expect("reqwest client built correctly"),
             base_url: orderbook_url,

--- a/crates/driver/src/infra/solver/mod.rs
+++ b/crates/driver/src/infra/solver/mod.rs
@@ -208,7 +208,7 @@ impl Solver {
         Ok(Self {
             client: reqwest::ClientBuilder::new()
                 .default_headers(headers)
-                .tcp_keepalive(Duration::from_secs(15))
+                .tcp_keepalive(Duration::from_secs(60))
                 .build()?,
             config,
             eth,

--- a/crates/shared/src/http_client.rs
+++ b/crates/shared/src/http_client.rs
@@ -40,7 +40,7 @@ impl HttpClientFactory {
     pub fn builder(&self) -> ClientBuilder {
         ClientBuilder::new()
             .timeout(self.timeout)
-            .tcp_keepalive(Duration::from_secs(15))
+            .tcp_keepalive(Duration::from_secs(60))
             .user_agent(USER_AGENT)
     }
 }


### PR DESCRIPTION
# Description
We had a few reports for either slow requests, or requests not arriving at all. One suggestion was to use `tcp_keepalive()` for the http conntection. This was actually enabled by default in [`v0.12.23`](https://github.com/seanmonstar/reqwest/releases/tag/v0.12.23) but since we are currently stuck with `v0.11` until our `warp -> axum 0.6 -> axum 0.8` migration is complete I added `.tcp_keepalive()` where it makes sense with the same default value `reqwest` picked.

# Changes
added `tcp_keepalive(Duration::from_secs(15))` where it makes sense

Related to https://github.com/cowprotocol/services/issues/4066 cc @xozzslip