### PR TITLE
Move order outside market log to callsites

### DIFF
--- a/crates/shared/src/order_validation.rs
+++ b/crates/shared/src/order_validation.rs
@@ -755,6 +755,7 @@ impl OrderValidating for OrderValidator {
                             },
                             data.kind,
                         ) {
+                            tracing::debug!(%uid, ?owner, ?class, "order being flagged as outside market price");
                             self.check_max_limit_orders(owner).await?;
                         }
                         (class, Some(quote))
@@ -786,6 +787,7 @@ impl OrderValidating for OrderValidator {
                     },
                     data.kind,
                 ) {
+                    tracing::debug!(%uid, ?owner, ?class, "order being flagged as outside market price");
                     self.check_max_limit_orders(owner).await?;
                 }
                 (OrderClass::Limit, None)
@@ -1002,14 +1004,7 @@ pub fn is_order_outside_market_price(
         }
     };
 
-    check().unwrap_or_else(|| {
-        tracing::warn!(
-            ?order,
-            ?quote,
-            "failed to check if order is outside market price"
-        );
-        true
-    })
+    check().unwrap_or(true)
 }
 
 pub struct InvalidSigningScheme;


### PR DESCRIPTION
# Description
The log inside the unwrap does not provide an actionable info, the lack or order ID, from address, quote ID, make it extremely hard to follow up on.

More context in https://cowservices.slack.com/archives/C0375NV72SC/p1769440848303459

# Changes
- [ ] Remove the log from the unwrap
- [ ] Place it in the (seemingly) more relevant callsites

## How to test
NA