### PR TITLE
Stop enforcing body size limit

### DIFF
--- a/crates/driver/src/infra/api/mod.rs
+++ b/crates/driver/src/infra/api/mod.rs
@@ -31,7 +31,7 @@ use {
 mod error;
 pub mod routes;
 
-pub const REQUEST_BODY_LIMIT: usize = 10 * 1024 * 1024;
+const REQUEST_BODY_LIMIT: usize = 10 * 1024 * 1024;
 
 pub struct Api {
     pub solvers: Vec<Solver>,


### PR DESCRIPTION
# Description
The shadow competition broke because the driver is now rejecting `/solve` requests that are too large due to this new [code](https://github.com/cowprotocol/services/pull/4082/changes#diff-b997d6f696c5591860aef8658bb56d2a03fc4fa6b37b5e0432ce8e5e4e356aa9R61-R64).
This was surprising to me because that code was added specifically because the new handler is bypassing the original content length limiting layer so I would have expected huge requests to already cause issues.

During the investigation I confirmed using the `/solve` requests stored on S3 that recent auctions are indeed larger than. 10MB. Afterwards I spun up a driver locally and sent that solve request to the original code to confirm that it's indeed not throwing any errors.
I further investigated and concluded that the issue is how we build the driver's http router. The size limiting layer is the first thing that gets added to the router but it should actually be the last. This caused the size limit to never go into effect.

# Changes
To resolve the issue quickly and remove this breaking change ASAP I simply removed the new size limiting logic from the `/solve` request.
In a follow up PR I'll make the size limit configurable and fix the router.

## How to test
manual test