### PR TITLE
Rewrite migration V100 to be optional

### DIFF
--- a/database/sql/V100__add_auction_deadline.sql
+++ b/database/sql/V100__add_auction_deadline.sql
@@ -1,2 +1,2 @@
 -- adds index on the deadline of an auction to quickly look up inflight orders from the db
-CREATE INDEX CONCURRENTLY competition_auction_deadline ON competition_auctions USING BTREE(deadline);
+CREATE INDEX CONCURRENTLY IF NOT EXISTS competition_auction_deadline ON competition_auctions USING BTREE(deadline);


### PR DESCRIPTION
# Description
The migration V100 creates index on competition_auction_deadline on competition_auctions. To make the prod deployment viable  it needs to be optional (IF NOT EXISTS) which will enable to apply it manually beforehand.

# Changes
Update the V100 migration to specify IF NOT EXISTS.

## How to test
Will apply the migration manually and deploy on staging to verify.