### PR TITLE
Generate tendery link on simulation

### DIFF
--- a/crates/configs/src/orderbook/mod.rs
+++ b/crates/configs/src/orderbook/mod.rs
@@ -53,6 +53,12 @@ pub struct VolumeFeeConfig {
 #[serde(rename_all = "kebab-case", deny_unknown_fields)]
 pub struct OrderSimulationConfig {
     pub gas_limit: U256,
+
+    /// Optional Tenderly configuration. When set, simulations are automatically
+    /// submitted and shared on Tenderly, and the response includes a dashboard
+    /// URL.
+    #[serde(default)]
+    pub tenderly: Option<crate::simulator::TenderlyConfig>,
 }
 
 /// Top-level orderbook service configuration.
@@ -216,6 +222,7 @@ pub mod test_util {
                 // Enable order simulation for testing
                 order_simulation: Some(OrderSimulationConfig {
                     gas_limit: U256::try_from(16777215).expect("u64 can be converted to U256"),
+                    tenderly: None,
                 }),
             }
         }

--- a/crates/orderbook/src/dto/mod.rs
+++ b/crates/orderbook/src/dto/mod.rs
@@ -57,9 +57,13 @@ pub struct OrderSimulationRequest {
 /// and full Tenderly API request that can be used to resimulate
 /// and debug using Tenderly
 #[derive(Clone, Deserialize, Serialize, Debug)]
+#[serde(rename_all = "camelCase")]
 pub struct OrderSimulationResult {
     /// Full request object that can be used directly with the Tenderly API
     pub tenderly_request: tenderly::dto::Request,
+    /// Shared Tenderly simulation URL for debugging in the dashboard
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tenderly_url: Option<String>,
     /// Any error that might have been reported during order simulation
     pub error: Option<String>,
 }

--- a/crates/orderbook/src/order_simulator.rs
+++ b/crates/orderbook/src/order_simulator.rs
@@ -15,11 +15,13 @@ use {
     simulator::{
         encoding::InteractionEncoding,
         swap_simulator::{EncodedSwap, Query, SwapSimulator, TradeEncoding},
+        tenderly,
     },
     thiserror::Error,
 };
 pub struct OrderSimulator {
     simulator: SwapSimulator,
+    tenderly: Option<Box<dyn tenderly::Api>>,
     chain_id: String,
 }
 
@@ -32,9 +34,14 @@ pub enum Error {
 }
 
 impl OrderSimulator {
-    pub fn new(simulator: SwapSimulator, chain_id: String) -> Self {
+    pub fn new(
+        simulator: SwapSimulator,
+        chain_id: String,
+        tenderly: Option<Box<dyn tenderly::Api>>,
+    ) -> Self {
         Self {
             simulator,
+            tenderly,
             chain_id,
         }
     }
@@ -174,8 +181,20 @@ impl OrderSimulator {
             .map_err(|err| Error::Other(anyhow!(err)))?
         };
 
+        let tenderly_url = match &self.tenderly {
+            Some(api) => match api.simulate_and_share(tenderly_request.clone()).await {
+                Ok(url) => Some(url),
+                Err(err) => {
+                    tracing::warn!(?err, "failed to create Tenderly simulation");
+                    None
+                }
+            },
+            None => None,
+        };
+
         Ok(OrderSimulationResult {
             tenderly_request,
+            tenderly_url,
             error: result.result.err().map(|err| err.to_string()),
         })
     }

--- a/crates/orderbook/src/run.rs
+++ b/crates/orderbook/src/run.rs
@@ -412,6 +412,14 @@ pub async fn run(config: Configuration) {
     ));
 
     let order_simulator = if let Some(config) = config.order_simulation {
+        let tenderly: Option<Box<dyn simulator::tenderly::Api>> =
+            config.tenderly.as_ref().map(|tenderly_config| {
+                Box::new(simulator::tenderly::TenderlyApi::new(
+                    tenderly_config,
+                    &http_factory,
+                    chain.id().to_string(),
+                )) as _
+            });
         Some(Arc::new(OrderSimulator::new(
             SwapSimulator::new(
                 balance_overrider.clone(),
@@ -427,6 +435,7 @@ pub async fn run(config: Configuration) {
             .await
             .expect("failed to create SwapSimulator"),
             chain.id().to_string(),
+            tenderly,
         )))
     } else {
         None

--- a/crates/simulator/src/tenderly/mod.rs
+++ b/crates/simulator/src/tenderly/mod.rs
@@ -31,7 +31,9 @@ pub struct Tenderly {
 
 #[derive(Debug, Clone)]
 pub struct TenderlyApi {
-    simulation_endpoint: Url,
+    /// Base URL for the Tenderly API project, e.g.
+    /// `https://api.tenderly.co/api/v1/account/{user}/project/{project}`
+    api_base: Url,
     client: reqwest::Client,
     dashboard: Url,
     chain_id: String,
@@ -47,6 +49,9 @@ pub trait Api: Send + Sync + 'static {
     ) -> Result<()>;
 
     async fn simulate(&self, request: dto::Request) -> Result<dto::Response>;
+
+    /// Submits a simulation, shares it, and returns the shared Tenderly URL.
+    async fn simulate_and_share(&self, request: dto::Request) -> Result<String>;
 }
 
 impl Tenderly {
@@ -111,8 +116,8 @@ impl TenderlyApi {
             "application/json".parse().unwrap(),
         );
         Self {
-            simulation_endpoint: Url::parse(&format!(
-                "{url}/v1/account/{user}/project/{project}/simulate",
+            api_base: Url::parse(&format!(
+                "{url}/v1/account/{user}/project/{project}/",
                 url = config
                     .url
                     .as_ref()
@@ -164,18 +169,15 @@ impl Api for TenderlyApi {
             save_if_fails: Some(true),
             ..prepare_request(self.chain_id.clone(), &tx, overrides, block)?
         };
-        log_simulation_request(&self.simulation_endpoint, &self.dashboard, request)
+        let simulate_url = crate::utils::join_url(&self.api_base, "simulate");
+        log_simulation_request(&simulate_url, &self.dashboard, request)
     }
 
     async fn simulate(&self, request: dto::Request) -> Result<dto::Response> {
         let body = serde_json::to_string(&request).map_err(|err| Error::Other(anyhow!(err)))?;
 
-        let response = self
-            .client
-            .post(self.simulation_endpoint.clone())
-            .body(body)
-            .send()
-            .await?;
+        let simulate_url = crate::utils::join_url(&self.api_base, "simulate");
+        let response = self.client.post(simulate_url).body(body).send().await?;
 
         let ok = response.error_for_status_ref().map(|_| ());
         let status = response.status();
@@ -188,6 +190,25 @@ impl Api for TenderlyApi {
 
         Ok(serde_json::from_str::<dto::Response>(&body)?)
     }
+
+    async fn simulate_and_share(&self, request: dto::Request) -> Result<String> {
+        let response = self.simulate(request).await?;
+        let id = &response.simulation.id;
+        self.share_simulation(id).await?;
+        Ok(shared_simulation_url(id))
+    }
+}
+
+impl TenderlyApi {
+    async fn share_simulation(&self, id: &str) -> Result<()> {
+        let url = crate::utils::join_url(&self.api_base, &format!("simulations/{id}/share"));
+        self.client.post(url).send().await?.error_for_status()?;
+        Ok(())
+    }
+}
+
+fn shared_simulation_url(id: &str) -> String {
+    format!("{DASHBOARD_URL}/shared/simulation/{id}")
 }
 
 pub fn prepare_request(
@@ -301,6 +322,10 @@ impl Api for Instrumented {
         block: Option<BlockNo>,
     ) -> Result<()> {
         self.inner.log_simulation_command(tx, overrides, block)
+    }
+
+    async fn simulate_and_share(&self, request: dto::Request) -> Result<String> {
+        self.inner.simulate_and_share(request).await
     }
 }
 


### PR DESCRIPTION
# Description

The debug simulation endpoint (/api/v1/debug/simulation/{uid}) currently returns a raw Tenderly API request object that you have to manually POST to Tenderly to debug. This adds automatic submission + sharing so the response includes a clickable tenderlyUrl link.

# Changes

- Add simulate_and_share to the Tenderly Api trait - submits a simulation, shares it, and returns the public dashboard URL                                                                                         
- Refactor TenderlyApi to store api_base URL instead of the full /simulate endpoint, appending paths as needed
- Add optional tenderly config to OrderSimulationConfig - when set, simulations are auto-submitted                                                                                                                 
- Return tenderlyUrl field in OrderSimulationResult (omitted from JSON when Tenderly is not configured)                                                                                                             

## How to test

I ran the orderbook locally with tenderly config, hit the API and got a tenderly link.
