### PR TITLE
Add E2E test to ensure flashloan filtering is performed correctly

### DIFF
--- a/crates/driver/src/tests/cases/flashloan_hints.rs
+++ b/crates/driver/src/tests/cases/flashloan_hints.rs
@@ -82,6 +82,55 @@ async fn solutions_without_flashloan() {
     test.solve().await.ok();
 }
 
+/// A flashloan-hint order is only visible as a flashloan order after
+/// `update_orders` promotes its `AppData` from `Hash` to `Full`. If the
+/// `flashloans_enabled=false` retain runs *before* promotion (as in the buggy
+/// parallelized ordering), the driver sees `AppData::Hash(_).flashloan() ==
+/// None` and the order survives. When the bug regresses, the flashloan order
+/// reaches the solver mock and the `/solve` body `assert_eq!` panics.
+#[tokio::test]
+#[ignore]
+async fn flashloan_order_filtered_when_flashloans_disabled() {
+    let flashloan = Flashloan {
+        liquidity_provider: Address::from_slice(&[1; 20]),
+        receiver: Address::from_slice(&[2; 20]),
+        token: Address::from_slice(&[3; 20]),
+        protocol_adapter: Address::from_slice(&[4; 20]),
+        amount: ::alloy::primitives::U256::from(3),
+    };
+    let protocol_app_data = ProtocolAppData {
+        flashloan: Some(flashloan),
+        ..Default::default()
+    };
+    let app_data = AppData::Full(Arc::new(protocol_app_data_into_validated(
+        protocol_app_data,
+    )));
+
+    let test = setup()
+        .flashloans_enabled(false)
+        .pool(ab_pool())
+        // Normal order: expected to reach the solver and settle.
+        .order(ab_order())
+        // Flashloan-hint order: the driver must drop this before /solve. The
+        // mock orderbook indexes it by hash; the driver only sees the hash on
+        // /solve and must fetch + promote it before the retain runs.
+        .order(
+            ab_order()
+                .rename("flashloan-ab")
+                .app_data(app_data)
+                .filtered(),
+        )
+        .solution(ab_solution())
+        .done()
+        .await;
+
+    // If the ordering bug regresses, the flashloan order reaches the solver
+    // and the solver mock's `check_solve_request` panics with
+    // "/solve request body does not match expectation" plus an orders-array
+    // diff.
+    test.solve().await.ok();
+}
+
 fn protocol_app_data_into_validated(protocol: ProtocolAppData) -> app_data::ValidatedAppData {
     let root = app_data::Root::new(Some(protocol.clone()));
     let document = serde_json::to_string(&root).unwrap();

--- a/crates/driver/src/tests/setup/driver.rs
+++ b/crates/driver/src/tests/setup/driver.rs
@@ -20,6 +20,7 @@ pub struct Config {
     pub mempools: Vec<Mempool>,
     pub order_priority_strategies: Vec<OrderPriorityStrategy>,
     pub orderbook: Orderbook,
+    pub flashloans_enabled: bool,
 }
 
 pub struct Driver {
@@ -219,7 +220,7 @@ async fn create_config_file(
         config.orderbook.addr
     )
     .unwrap();
-    writeln!(file, "flashloans-enabled = true").unwrap();
+    writeln!(file, "flashloans-enabled = {}", config.flashloans_enabled).unwrap();
     writeln!(file, "tx-gas-limit = \"45000000\"").unwrap();
     write!(
         file,

--- a/crates/driver/src/tests/setup/mod.rs
+++ b/crates/driver/src/tests/setup/mod.rs
@@ -500,6 +500,7 @@ pub fn setup() -> Setup {
         allow_multiple_solve_requests: false,
         auction_id: 1,
         settle_submission_deadline: 3,
+        flashloans_enabled: true,
         ..Default::default()
     }
 }
@@ -541,6 +542,8 @@ pub struct Setup {
     /// The maximum number of blocks to wait for a settlement to appear on
     /// chain.
     settle_submission_deadline: u64,
+    /// Should flashloan-hint orders be accepted by the driver? True by default.
+    flashloans_enabled: bool,
 }
 
 /// The validity of a solution.
@@ -890,6 +893,12 @@ impl Setup {
         self
     }
 
+    /// Toggle acceptance of flashloan-hint orders at the driver level.
+    pub fn flashloans_enabled(mut self, flashloans_enabled: bool) -> Self {
+        self.flashloans_enabled = flashloans_enabled;
+        self
+    }
+
     /// Create the test: set up onchain contracts and pools, start a mock HTTP
     /// server for the solver and start the HTTP server for the driver.
     pub async fn done(self) -> Test {
@@ -997,6 +1006,7 @@ impl Setup {
                 mempools: self.mempools,
                 order_priority_strategies: self.order_priority_strategies,
                 orderbook,
+                flashloans_enabled: self.flashloans_enabled,
             },
             &solvers_with_address,
             &blockchain,


### PR DESCRIPTION
# Description
While reviewing #4309 I noticed a super small bug that would have been a pain in the ass to debug.
The implemented parallelization strategy changed the order of the flashloan filter, it essentially was filtering flashloans without full information on them, meaning some flashloan orders would be sent to solvers that explicitly don't support them.

This PR adds a test to ensure it doesn't break unexpectedly 

# Changes

* Add flashloan support configuration to driver tests
* Add test to ensure flashloans are correctly filtered

## How to test
Run test as is and merge this PR's branch into https://github.com/cowprotocol/services/pull/4309 and check it fails