### PR TITLE
Hide competition until deadline passes

### DIFF
--- a/crates/configs/src/orderbook/mod.rs
+++ b/crates/configs/src/orderbook/mod.rs
@@ -128,6 +128,11 @@ pub struct Configuration {
     /// Order simulation configuration. If `None`, the endpoint is disabled.
     #[serde(default)]
     pub order_simulation: Option<OrderSimulationConfig>,
+
+    /// When enabled, solver competition endpoints return 404 until the
+    /// auction's submission deadline block has been reached.
+    #[serde(default)]
+    pub hide_competition_before_deadline: bool,
 }
 
 impl Configuration {
@@ -224,6 +229,7 @@ pub mod test_util {
                     gas_limit: U256::try_from(16777215).expect("u64 can be converted to U256"),
                     tenderly: None,
                 }),
+                hide_competition_before_deadline: false,
             }
         }
     }
@@ -248,6 +254,7 @@ mod tests {
         active-order-competition-threshold = 10
         unsupported-tokens = ["0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2"]
         eip1271-skip-creation-validation = true
+        hide-competition-before-deadline = true
 
         [banned-users]
         addresses = ["0xdead000000000000000000000000000000000000"]
@@ -285,6 +292,7 @@ mod tests {
         assert_eq!(config.unsupported_tokens.len(), 1);
         assert_eq!(config.banned_users.addresses.len(), 1);
         assert!(config.eip1271_skip_creation_validation);
+        assert!(config.hide_competition_before_deadline);
         assert_eq!(
             config.order_simulation.map(|config| config.gas_limit),
             Some(U256::from(123456789u64))
@@ -350,6 +358,7 @@ mod tests {
         assert!(config.unsupported_tokens.is_empty());
         assert!(config.banned_users.addresses.is_empty());
         assert!(!config.eip1271_skip_creation_validation);
+        assert!(!config.hide_competition_before_deadline);
     }
 
     #[test]
@@ -382,6 +391,7 @@ mod tests {
             ],
             banned_users: Default::default(),
             eip1271_skip_creation_validation: true,
+            hide_competition_before_deadline: true,
             native_price_estimation: NativePriceConfig {
                 estimators: NativePriceEstimators::new(vec![vec![NativePriceEstimator::CoinGecko]]),
                 fallback_estimators: None,
@@ -421,6 +431,10 @@ mod tests {
         assert_eq!(
             config.eip1271_skip_creation_validation,
             deserialized.eip1271_skip_creation_validation
+        );
+        assert_eq!(
+            config.hide_competition_before_deadline,
+            deserialized.hide_competition_before_deadline
         );
         assert_eq!(config.http_client.timeout, deserialized.http_client.timeout)
     }

--- a/crates/database/src/solver_competition.rs
+++ b/crates/database/src/solver_competition.rs
@@ -118,7 +118,7 @@ FROM solver_competitions sc
 JOIN settlements s ON sc.id = s.auction_id
 LEFT JOIN competition_auctions ca ON sc.id = ca.id
 WHERE sc.id = (SELECT id FROM competition) AND s.solution_uid IS NOT NULL
-    AND ($2::bigint IS NULL OR ca.deadline < $2)
+    AND ($2::bigint IS NULL OR ca.deadline <= $2)
 GROUP BY sc.id
     ;"#;
     sqlx::query_as(QUERY)

--- a/crates/database/src/solver_competition.rs
+++ b/crates/database/src/solver_competition.rs
@@ -50,51 +50,61 @@ pub async fn auction_start_block(
 pub async fn load_by_id(
     ex: &mut PgConnection,
     id: AuctionId,
+    after_block: Option<i64>,
 ) -> Result<Option<LoadCompetition>, sqlx::Error> {
     const QUERY: &str = r#"
 SELECT sc.json, sc.id, COALESCE(ARRAY_AGG(s.tx_hash) FILTER (WHERE s.solution_uid IS NOT NULL), '{}') AS tx_hashes
 FROM solver_competitions sc
 -- outer joins because the data might not have been indexed yet
 LEFT OUTER JOIN settlements s ON sc.id = s.auction_id
--- exclude settlements from another environment for which observation is guaranteed to not exist
-WHERE sc.id = $1
+LEFT JOIN competition_auctions ca ON sc.id = ca.id
+WHERE sc.id = $1 AND ($2::bigint IS NULL OR ca.deadline < $2)
 GROUP BY sc.id
     ;"#;
-    sqlx::query_as(QUERY).bind(id).fetch_optional(ex).await
+    sqlx::query_as(QUERY)
+        .bind(id)
+        .bind(after_block)
+        .fetch_optional(ex)
+        .await
 }
 
 #[instrument(skip_all)]
 pub async fn load_latest_competitions(
     ex: &mut PgConnection,
     latest_competitions_count: u32,
+    after_block: Option<i64>,
 ) -> Result<Vec<LoadCompetition>, sqlx::Error> {
     const QUERY: &str = r#"
 SELECT sc.json, sc.id, COALESCE(ARRAY_AGG(s.tx_hash) FILTER (WHERE s.solution_uid IS NOT NULL), '{}') AS tx_hashes
 FROM solver_competitions sc
 -- outer joins because the data might not have been indexed yet
 LEFT OUTER JOIN settlements s ON sc.id = s.auction_id
+LEFT JOIN competition_auctions ca ON sc.id = ca.id
+WHERE ($2::bigint IS NULL OR ca.deadline < $2)
 GROUP BY sc.id
 ORDER BY sc.id DESC
 LIMIT $1
     ;"#;
     sqlx::query_as(QUERY)
         .bind(i64::from(latest_competitions_count))
+        .bind(after_block)
         .fetch_all(ex)
         .await
 }
 
 pub async fn load_latest_competition(
     ex: &mut PgConnection,
+    after_block: Option<i64>,
 ) -> Result<Option<LoadCompetition>, sqlx::Error> {
-    let competitions = load_latest_competitions(ex, 1).await?;
-    let latest = competitions.into_iter().next();
-    Ok(latest)
+    let competitions = load_latest_competitions(ex, 1, after_block).await?;
+    Ok(competitions.into_iter().next())
 }
 
 #[instrument(skip_all)]
 pub async fn load_by_tx_hash(
     ex: &mut PgConnection,
     tx_hash: &TransactionHash,
+    after_block: Option<i64>,
 ) -> Result<Option<LoadCompetition>, sqlx::Error> {
     const QUERY: &str = r#"
 WITH competition AS (
@@ -106,10 +116,16 @@ WITH competition AS (
 SELECT sc.json, sc.id, COALESCE(ARRAY_AGG(s.tx_hash) FILTER (WHERE s.solution_uid IS NOT NULL), '{}') AS tx_hashes
 FROM solver_competitions sc
 JOIN settlements s ON sc.id = s.auction_id
+LEFT JOIN competition_auctions ca ON sc.id = ca.id
 WHERE sc.id = (SELECT id FROM competition) AND s.solution_uid IS NOT NULL
+    AND ($2::bigint IS NULL OR ca.deadline < $2)
 GROUP BY sc.id
     ;"#;
-    sqlx::query_as(QUERY).bind(tx_hash).fetch_optional(ex).await
+    sqlx::query_as(QUERY)
+        .bind(tx_hash)
+        .bind(after_block)
+        .fetch_optional(ex)
+        .await
 }
 
 #[cfg(test)]
@@ -142,24 +158,27 @@ mod tests {
         assert_eq!(value_, "1234");
 
         // load by id works
-        let value_ = load_by_id(&mut db, 0).await.unwrap().unwrap();
+        let value_ = load_by_id(&mut db, 0, None).await.unwrap().unwrap();
         assert_eq!(value, value_.json);
         assert!(value_.tx_hashes.is_empty());
 
         // load as latest works
-        let value_ = load_latest_competition(&mut db).await.unwrap().unwrap();
+        let value_ = load_latest_competition(&mut db, None)
+            .await
+            .unwrap()
+            .unwrap();
         assert_eq!(value, value_.json);
         assert!(value_.tx_hashes.is_empty());
         // load by tx doesn't work, as there is no settlement yet
         assert!(
-            load_by_tx_hash(&mut db, &ByteArray([0u8; 32]))
+            load_by_tx_hash(&mut db, &ByteArray([0u8; 32]), None)
                 .await
                 .unwrap()
                 .is_none()
         );
 
         // non-existent auction returns none
-        assert!(load_by_id(&mut db, 1).await.unwrap().is_none());
+        assert!(load_by_id(&mut db, 1, None).await.unwrap().is_none());
 
         // insert three settlement events for the same auction id, with one of them not
         // having solution UID (in practice, usually meaning it's from a different
@@ -221,26 +240,29 @@ mod tests {
             .unwrap();
 
         // load by id works, and finds two hashes
-        let value_ = load_by_id(&mut db, 0).await.unwrap().unwrap();
+        let value_ = load_by_id(&mut db, 0, None).await.unwrap().unwrap();
         assert!(value_.tx_hashes.len() == 2);
 
         // load as latest works, and finds two hashes
-        let value_ = load_latest_competition(&mut db).await.unwrap().unwrap();
-        assert!(value_.tx_hashes.len() == 2);
-
-        // load by tx works, and finds two hashes, no matter which tx hash is used
-        let value_ = load_by_tx_hash(&mut db, &ByteArray([0u8; 32]))
+        let value_ = load_latest_competition(&mut db, None)
             .await
             .unwrap()
             .unwrap();
         assert!(value_.tx_hashes.len() == 2);
-        let value_ = load_by_tx_hash(&mut db, &ByteArray([1u8; 32]))
+
+        // load by tx works, and finds two hashes, no matter which tx hash is used
+        let value_ = load_by_tx_hash(&mut db, &ByteArray([0u8; 32]), None)
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(value_.tx_hashes.len() == 2);
+        let value_ = load_by_tx_hash(&mut db, &ByteArray([1u8; 32]), None)
             .await
             .unwrap()
             .unwrap();
         assert!(value_.tx_hashes.len() == 2);
         // this one should not find any hashes since it's from another environment
-        let value_ = load_by_tx_hash(&mut db, &ByteArray([2u8; 32]))
+        let value_ = load_by_tx_hash(&mut db, &ByteArray([2u8; 32]), None)
             .await
             .unwrap();
         assert!(value_.is_none());

--- a/crates/database/src/solver_competition.rs
+++ b/crates/database/src/solver_competition.rs
@@ -58,7 +58,7 @@ FROM solver_competitions sc
 -- outer joins because the data might not have been indexed yet
 LEFT OUTER JOIN settlements s ON sc.id = s.auction_id
 LEFT JOIN competition_auctions ca ON sc.id = ca.id
-WHERE sc.id = $1 AND ($2::bigint IS NULL OR ca.deadline < $2)
+WHERE sc.id = $1 AND ($2::bigint IS NULL OR ca.deadline <= $2)
 GROUP BY sc.id
     ;"#;
     sqlx::query_as(QUERY)

--- a/crates/database/src/solver_competition.rs
+++ b/crates/database/src/solver_competition.rs
@@ -80,7 +80,7 @@ FROM solver_competitions sc
 -- outer joins because the data might not have been indexed yet
 LEFT OUTER JOIN settlements s ON sc.id = s.auction_id
 LEFT JOIN competition_auctions ca ON sc.id = ca.id
-WHERE ($2::bigint IS NULL OR ca.deadline < $2)
+WHERE ($2::bigint IS NULL OR ca.deadline <= $2)
 GROUP BY sc.id
 ORDER BY sc.id DESC
 LIMIT $1

--- a/crates/database/src/solver_competition_v2.rs
+++ b/crates/database/src/solver_competition_v2.rs
@@ -100,7 +100,7 @@ pub async fn load_latest(
     const FETCH_AUCTION_ID: &str = r#"
         SELECT id
         FROM competition_auctions
-        WHERE ($1::bigint IS NULL OR deadline < $1)
+        WHERE ($1::bigint IS NULL OR deadline <= $1)
         ORDER BY id DESC
         LIMIT 1;
     "#;

--- a/crates/database/src/solver_competition_v2.rs
+++ b/crates/database/src/solver_competition_v2.rs
@@ -123,7 +123,7 @@ pub async fn load_by_id(
     const FETCH_AUCTION: &str = r#"
         SELECT id, order_uids, price_tokens, price_values, block, deadline
         FROM competition_auctions
-        WHERE id = $1 AND ($2::bigint IS NULL OR deadline < $2);
+        WHERE id = $1 AND ($2::bigint IS NULL OR deadline <= $2);
     "#;
     let auction: Option<Auction> = sqlx::query_as(FETCH_AUCTION)
         .bind(id)

--- a/crates/database/src/solver_competition_v2.rs
+++ b/crates/database/src/solver_competition_v2.rs
@@ -111,8 +111,7 @@ pub async fn load_latest(
     let Some(auction_id) = auction_id else {
         return Ok(None);
     };
-    // No need to pass after_block here — we already filtered by deadline.
-    load_by_id(ex.deref_mut(), auction_id, None).await
+    load_by_id(ex.deref_mut(), auction_id, after_block).await
 }
 
 #[instrument(skip_all)]

--- a/crates/database/src/solver_competition_v2.rs
+++ b/crates/database/src/solver_competition_v2.rs
@@ -75,6 +75,7 @@ pub struct SolverCompetition {
 pub async fn load_by_tx_hash(
     mut ex: &mut PgConnection,
     tx_hash: TransactionHash,
+    after_block: Option<i64>,
 ) -> Result<Option<SolverCompetition>, sqlx::Error> {
     const FETCH_AUCTION_ID: &str = r#"
         SELECT s.auction_id
@@ -88,40 +89,46 @@ pub async fn load_by_tx_hash(
     let Some(auction_id) = auction_id else {
         return Ok(None);
     };
-    load_by_id(ex.deref_mut(), auction_id).await
+    load_by_id(ex.deref_mut(), auction_id, after_block).await
 }
 
 #[instrument(skip_all)]
 pub async fn load_latest(
     mut ex: &mut PgConnection,
+    after_block: Option<i64>,
 ) -> Result<Option<SolverCompetition>, sqlx::Error> {
     const FETCH_AUCTION_ID: &str = r#"
         SELECT id
         FROM competition_auctions
+        WHERE ($1::bigint IS NULL OR deadline < $1)
         ORDER BY id DESC
         LIMIT 1;
     "#;
     let auction_id: Option<i64> = sqlx::query_scalar(FETCH_AUCTION_ID)
+        .bind(after_block)
         .fetch_optional(ex.deref_mut())
         .await?;
     let Some(auction_id) = auction_id else {
         return Ok(None);
     };
-    load_by_id(ex.deref_mut(), auction_id).await
+    // No need to pass after_block here — we already filtered by deadline.
+    load_by_id(ex.deref_mut(), auction_id, None).await
 }
 
 #[instrument(skip_all)]
 pub async fn load_by_id(
     mut ex: &mut PgConnection,
     id: AuctionId,
+    after_block: Option<i64>,
 ) -> Result<Option<SolverCompetition>, sqlx::Error> {
     const FETCH_AUCTION: &str = r#"
         SELECT id, order_uids, price_tokens, price_values, block, deadline
         FROM competition_auctions
-        WHERE id = $1;
+        WHERE id = $1 AND ($2::bigint IS NULL OR deadline < $2);
     "#;
     let auction: Option<Auction> = sqlx::query_as(FETCH_AUCTION)
         .bind(id)
+        .bind(after_block)
         .fetch_optional(ex.deref_mut())
         .await?;
     let Some(auction) = auction else {
@@ -643,10 +650,10 @@ mod tests {
             .await
             .unwrap();
 
-        let solver_competition = load_by_tx_hash(&mut db, tx_hash).await.unwrap();
+        let solver_competition = load_by_tx_hash(&mut db, tx_hash, None).await.unwrap();
         assert!(solver_competition.is_none());
 
-        let solver_competition = load_by_tx_hash(&mut db, tx_hash).await.unwrap();
+        let solver_competition = load_by_tx_hash(&mut db, tx_hash, None).await.unwrap();
         assert!(solver_competition.is_none());
 
         // update settlements
@@ -669,7 +676,7 @@ mod tests {
         };
         auction::save(&mut db, auction).await.unwrap();
 
-        let solver_competition = load_by_tx_hash(&mut db, tx_hash).await.unwrap();
+        let solver_competition = load_by_tx_hash(&mut db, tx_hash, None).await.unwrap();
         assert!(solver_competition.is_some());
         let solver_competition = solver_competition.unwrap();
         assert_eq!(solver_competition.settlements.len(), 1);
@@ -690,7 +697,7 @@ mod tests {
         let log_index = 0;
         let auction_id = 1;
 
-        let solver_competition = load_by_id(&mut db, auction_id).await.unwrap();
+        let solver_competition = load_by_id(&mut db, auction_id, None).await.unwrap();
         assert!(solver_competition.is_none());
 
         // example order
@@ -715,7 +722,7 @@ mod tests {
         };
         auction::save(&mut db, auction).await.unwrap();
 
-        let solver_competition = load_by_id(&mut db, auction_id).await.unwrap();
+        let solver_competition = load_by_id(&mut db, auction_id, None).await.unwrap();
         assert!(solver_competition.is_some());
 
         // settlements
@@ -733,14 +740,14 @@ mod tests {
             .unwrap();
 
         // Check before the joined table is populated
-        let solver_competition = load_by_id(&mut db, auction_id).await.unwrap();
+        let solver_competition = load_by_id(&mut db, auction_id, None).await.unwrap();
         assert!(solver_competition.is_some());
         let solver_competition = solver_competition.unwrap();
         assert!(solver_competition.settlements.is_empty());
         assert_eq!(solver_competition.auction.id, 1);
 
         // Check after the joined table is populated
-        let solver_competition = load_by_id(&mut db, auction_id).await.unwrap();
+        let solver_competition = load_by_id(&mut db, auction_id, None).await.unwrap();
         assert!(solver_competition.is_some());
         let solver_competition = solver_competition.unwrap();
         assert!(solver_competition.settlements.is_empty());
@@ -761,7 +768,7 @@ mod tests {
         .unwrap();
 
         // Check after both tables are linked
-        let solver_competition = load_by_id(&mut db, auction_id).await.unwrap();
+        let solver_competition = load_by_id(&mut db, auction_id, None).await.unwrap();
         assert!(solver_competition.is_some());
         let solver_competition = solver_competition.unwrap();
         assert_eq!(solver_competition.settlements.len(), 1);
@@ -825,7 +832,7 @@ mod tests {
         .await
         .unwrap();
 
-        let solver_competition = load_by_id(&mut db, auction_id).await.unwrap();
+        let solver_competition = load_by_id(&mut db, auction_id, None).await.unwrap();
         assert!(solver_competition.is_some());
         let solver_competition = solver_competition.unwrap();
         assert_eq!(solver_competition.settlements.len(), 1);

--- a/crates/e2e/tests/e2e/solver_competition.rs
+++ b/crates/e2e/tests/e2e/solver_competition.rs
@@ -16,6 +16,7 @@ use {
         signature::EcdsaSigningScheme,
     },
     number::units::EthUnit,
+    reqwest::StatusCode,
     shared::web3::Web3,
     solvers_dto::solution::Solution,
     std::{collections::HashMap, str::FromStr},
@@ -91,6 +92,7 @@ async fn solver_competition(web3: Web3) {
 
     let services = Services::new(&onchain).await;
 
+    let base_config = Configuration::test_no_drivers();
     services
         .start_autopilot(
             None,
@@ -103,12 +105,17 @@ async fn solver_competition(web3: Web3) {
                     ExternalSolver::new("test_quoter", "http://localhost:11088/test_solver"),
                     ExternalSolver::new("solver2", "http://localhost:11088/solver2"),
                 ]),
-                ..Configuration::test_no_drivers()
+                run_loop: RunLoopConfig {
+                    submission_deadline: 3,
+                    ..base_config.run_loop
+                },
+                ..base_config
             },
         )
         .await;
     services
         .start_api(configs::orderbook::Configuration {
+            hide_competition_before_deadline: true,
             order_quoting: OrderQuoting::test_with_drivers(vec![
                 ExternalSolver::new("test_quoter", "http://localhost:11088/test_solver"),
                 ExternalSolver::new("solver2", "http://localhost:11088/solver2"),
@@ -146,6 +153,16 @@ async fn solver_competition(web3: Web3) {
     };
     wait_for_condition(TIMEOUT, trade_happened).await.unwrap();
 
+    // Competition data is saved before the settlement tx, so it is already in
+    // the DB. The deadline hasn't passed yet → 404.
+    assert_eq!(
+        services.get_latest_solver_competition().await.unwrap_err(),
+        StatusCode::NOT_FOUND,
+    );
+
+    // The indexed_trades poll mints a block on every iteration, which will
+    // advance past the 3-block deadline while also waiting for the event
+    // indexer to pick up the settlement.
     let indexed_trades = || async {
         onchain.mint_block().await;
         match services.get_trades(&uid).await.unwrap().first() {

--- a/crates/orderbook/src/api.rs
+++ b/crates/orderbook/src/api.rs
@@ -75,13 +75,12 @@ pub struct AppState {
 }
 
 impl AppState {
-    /// Returns `true` if competition data for an auction with the given
-    /// deadline block should be visible to API consumers.
-    pub(crate) fn is_competition_visible(&self, deadline_block: i64) -> bool {
-        if !self.hide_competition_before_deadline {
-            return true;
-        }
-        self.current_block_stream.borrow().number.cast_signed() > deadline_block
+    /// When the feature is enabled, returns the current block number so DB
+    /// queries can hide competition data whose deadline hasn't passed yet.
+    /// Returns `None` when the feature is off (no filtering).
+    pub(crate) fn hide_competition_before_block(&self) -> Option<i64> {
+        self.hide_competition_before_deadline
+            .then(|| self.current_block_stream.borrow().number.cast_signed())
     }
 }
 

--- a/crates/orderbook/src/api.rs
+++ b/crates/orderbook/src/api.rs
@@ -14,6 +14,7 @@ use {
         response::{IntoResponse, Json, Response},
         routing::{delete, get, post, put},
     },
+    ethrpc::block_stream::CurrentBlockWatcher,
     observe::tracing::distributed::axum::{make_span, record_trace_id},
     price_estimation::{PriceEstimationError, native::NativePriceEstimating},
     serde::{Deserialize, Serialize},
@@ -69,6 +70,19 @@ pub struct AppState {
     pub app_data: Arc<app_data::Registry>,
     pub native_price_estimator: Arc<dyn NativePriceEstimating>,
     pub quote_timeout: Duration,
+    pub current_block_stream: CurrentBlockWatcher,
+    pub hide_competition_before_deadline: bool,
+}
+
+impl AppState {
+    /// Returns `true` if competition data for an auction with the given
+    /// deadline block should be visible to API consumers.
+    pub(crate) fn is_competition_visible(&self, deadline_block: i64) -> bool {
+        if !self.hide_competition_before_deadline {
+            return true;
+        }
+        self.current_block_stream.borrow().number.cast_signed() > deadline_block
+    }
 }
 
 async fn summarize_request(req: Request<axum::body::Body>, next: Next) -> Response {
@@ -138,6 +152,7 @@ async fn with_matched_path_metric(req: Request<axum::body::Body>, next: Next) ->
 
 const MAX_JSON_BODY_PAYLOAD: u64 = 1024 * 16;
 
+#[expect(clippy::too_many_arguments)]
 pub fn handle_all_routes(
     database_write: Postgres,
     database_read: Postgres,
@@ -146,6 +161,8 @@ pub fn handle_all_routes(
     app_data: Arc<app_data::Registry>,
     native_price_estimator: Arc<dyn NativePriceEstimating>,
     quote_timeout: Duration,
+    current_block_stream: CurrentBlockWatcher,
+    hide_competition_before_deadline: bool,
 ) -> Router {
     let app_data_size_limit = app_data.size_limit();
 
@@ -157,6 +174,8 @@ pub fn handle_all_routes(
         app_data,
         native_price_estimator,
         quote_timeout,
+        current_block_stream,
+        hide_competition_before_deadline,
     });
 
     let routes = [

--- a/crates/orderbook/src/api/get_solver_competition.rs
+++ b/crates/orderbook/src/api/get_solver_competition.rs
@@ -23,51 +23,42 @@ pub async fn get_solver_competition_by_id_handler(
     if auction_id >= AuctionId::MAX.cast_unsigned() {
         return Err(LoadSolverCompetitionError::NotFound);
     }
-    let competition = db(&state)
-        .load_competition(Identifier::Id(auction_id.cast_signed()))
-        .await?;
-    filter_by_deadline(&state, competition).await.map(Json)
+    // Uses database_write (not read replica) because the replication lag is
+    // not acceptable when the circuit breaker checks if a tx was out of
+    // competition.
+    state
+        .database_write
+        .load_competition(
+            Identifier::Id(auction_id.cast_signed()),
+            state.hide_competition_before_block(),
+        )
+        .await
+        .map(Json)
 }
 
 pub async fn get_solver_competition_by_hash_handler(
     State(state): State<Arc<AppState>>,
     Path(tx_hash): Path<B256>,
 ) -> Result<Json<SolverCompetitionAPI>, LoadSolverCompetitionError> {
-    let competition = db(&state)
-        .load_competition(Identifier::Transaction(tx_hash))
-        .await?;
-    filter_by_deadline(&state, competition).await.map(Json)
+    state
+        .database_write
+        .load_competition(
+            Identifier::Transaction(tx_hash),
+            state.hide_competition_before_block(),
+        )
+        .await
+        .map(Json)
 }
 
 pub async fn get_solver_competition_latest_handler(
     State(state): State<Arc<AppState>>,
 ) -> Result<Json<SolverCompetitionAPI>, LoadSolverCompetitionError> {
-    let competition = db(&state).load_latest_competition().await?;
-    filter_by_deadline(&state, competition).await.map(Json)
-}
-
-async fn filter_by_deadline(
-    state: &AppState,
-    competition: SolverCompetitionAPI,
-) -> Result<SolverCompetitionAPI, LoadSolverCompetitionError> {
-    if state.hide_competition_before_deadline
-        && let Some(deadline) = state
-            .database_write
-            .get_auction_deadline(competition.auction_id)
-            .await?
-        && !state.is_competition_visible(deadline)
-    {
-        return Err(LoadSolverCompetitionError::NotFound);
-    }
-    Ok(competition)
-}
-
-fn db(state: &AppState) -> &dyn SolverCompetitionStoring {
-    // While these queries actually don't write to the DB
-    // the latency incurred by the DB replication process
-    // is not acceptable in some cases (e.g. when the circuit
-    // breaker needs to decide whether an tx was out of competition).
-    &state.database_write
+    SolverCompetitionStoring::load_latest_competition(
+        &state.database_write,
+        state.hide_competition_before_block(),
+    )
+    .await
+    .map(Json)
 }
 
 #[cfg(test)]

--- a/crates/orderbook/src/api/get_solver_competition.rs
+++ b/crates/orderbook/src/api/get_solver_competition.rs
@@ -23,27 +23,27 @@ pub async fn get_solver_competition_by_id_handler(
     if auction_id >= AuctionId::MAX.cast_unsigned() {
         return Err(LoadSolverCompetitionError::NotFound);
     }
-    let c = db(&state)
+    let competition = db(&state)
         .load_competition(Identifier::Id(auction_id.cast_signed()))
         .await?;
-    filter_by_deadline(&state, c).await.map(Json)
+    filter_by_deadline(&state, competition).await.map(Json)
 }
 
 pub async fn get_solver_competition_by_hash_handler(
     State(state): State<Arc<AppState>>,
     Path(tx_hash): Path<B256>,
 ) -> Result<Json<SolverCompetitionAPI>, LoadSolverCompetitionError> {
-    let c = db(&state)
+    let competition = db(&state)
         .load_competition(Identifier::Transaction(tx_hash))
         .await?;
-    filter_by_deadline(&state, c).await.map(Json)
+    filter_by_deadline(&state, competition).await.map(Json)
 }
 
 pub async fn get_solver_competition_latest_handler(
     State(state): State<Arc<AppState>>,
 ) -> Result<Json<SolverCompetitionAPI>, LoadSolverCompetitionError> {
-    let c = db(&state).load_latest_competition().await?;
-    filter_by_deadline(&state, c).await.map(Json)
+    let competition = db(&state).load_latest_competition().await?;
+    filter_by_deadline(&state, competition).await.map(Json)
 }
 
 async fn filter_by_deadline(

--- a/crates/orderbook/src/api/get_solver_competition.rs
+++ b/crates/orderbook/src/api/get_solver_competition.rs
@@ -1,7 +1,7 @@
 use {
     crate::{
         api::AppState,
-        solver_competition::{Identifier, SolverCompetitionStoring},
+        solver_competition::{Identifier, LoadSolverCompetitionError, SolverCompetitionStoring},
     },
     alloy::primitives::B256,
     axum::{
@@ -24,28 +24,55 @@ pub async fn get_solver_competition_by_id_handler(
         return crate::solver_competition::LoadSolverCompetitionError::NotFound.into_response();
     }
 
-    db(&state)
+    match db(&state)
         .load_competition(Identifier::Id(auction_id.cast_signed()))
         .await
-        .map(Json)
-        .into_response()
+    {
+        Ok(c) => filter_by_deadline(&state, c)
+            .await
+            .map(Json)
+            .into_response(),
+        Err(e) => e.into_response(),
+    }
 }
 
 pub async fn get_solver_competition_by_hash_handler(
     State(state): State<Arc<AppState>>,
     Path(tx_hash): Path<B256>,
 ) -> Response {
-    db(&state)
+    match db(&state)
         .load_competition(Identifier::Transaction(tx_hash))
         .await
-        .map(Json)
-        .into_response()
+    {
+        Ok(c) => filter_by_deadline(&state, c)
+            .await
+            .map(Json)
+            .into_response(),
+        Err(e) => e.into_response(),
+    }
 }
 
 pub async fn get_solver_competition_latest_handler(
     State(state): State<Arc<AppState>>,
 ) -> Result<Json<SolverCompetitionAPI>, crate::solver_competition::LoadSolverCompetitionError> {
-    db(&state).load_latest_competition().await.map(Json)
+    let competition = db(&state).load_latest_competition().await?;
+    filter_by_deadline(&state, competition).await.map(Json)
+}
+
+async fn filter_by_deadline(
+    state: &AppState,
+    competition: SolverCompetitionAPI,
+) -> Result<SolverCompetitionAPI, LoadSolverCompetitionError> {
+    if state.hide_competition_before_deadline
+        && let Some(deadline) = state
+            .database_write
+            .get_auction_deadline(competition.auction_id)
+            .await?
+        && !state.is_competition_visible(deadline)
+    {
+        return Err(LoadSolverCompetitionError::NotFound);
+    }
+    Ok(competition)
 }
 
 fn db(state: &AppState) -> &dyn SolverCompetitionStoring {

--- a/crates/orderbook/src/api/get_solver_competition.rs
+++ b/crates/orderbook/src/api/get_solver_competition.rs
@@ -6,7 +6,7 @@ use {
     alloy::primitives::B256,
     axum::{
         extract::{Path, State},
-        response::{IntoResponse, Json, Response},
+        response::Json,
     },
     model::{AuctionId, solver_competition::SolverCompetitionAPI},
     std::sync::Arc,
@@ -15,48 +15,31 @@ use {
 pub async fn get_solver_competition_by_id_handler(
     State(state): State<Arc<AppState>>,
     Path(auction_id): Path<u64>,
-) -> Response {
-    // We use u64 to ensure that negative numbers are returned as BAD_REQUEST
-    // however, there's a gap between u64::MAX and i64::MAX, numbers beyond i64::MAX
-    // will be marked as NOT_FOUND as they're positive (and as such, valid) but
-    // they are not covered by our system
+) -> Result<Json<SolverCompetitionAPI>, LoadSolverCompetitionError> {
     if auction_id >= AuctionId::MAX.cast_unsigned() {
-        return crate::solver_competition::LoadSolverCompetitionError::NotFound.into_response();
+        return Err(LoadSolverCompetitionError::NotFound);
     }
-
-    match db(&state)
+    let c = db(&state)
         .load_competition(Identifier::Id(auction_id.cast_signed()))
-        .await
-    {
-        Ok(c) => filter_by_deadline(&state, c)
-            .await
-            .map(Json)
-            .into_response(),
-        Err(e) => e.into_response(),
-    }
+        .await?;
+    filter_by_deadline(&state, c).await.map(Json)
 }
 
 pub async fn get_solver_competition_by_hash_handler(
     State(state): State<Arc<AppState>>,
     Path(tx_hash): Path<B256>,
-) -> Response {
-    match db(&state)
+) -> Result<Json<SolverCompetitionAPI>, LoadSolverCompetitionError> {
+    let c = db(&state)
         .load_competition(Identifier::Transaction(tx_hash))
-        .await
-    {
-        Ok(c) => filter_by_deadline(&state, c)
-            .await
-            .map(Json)
-            .into_response(),
-        Err(e) => e.into_response(),
-    }
+        .await?;
+    filter_by_deadline(&state, c).await.map(Json)
 }
 
 pub async fn get_solver_competition_latest_handler(
     State(state): State<Arc<AppState>>,
-) -> Result<Json<SolverCompetitionAPI>, crate::solver_competition::LoadSolverCompetitionError> {
-    let competition = db(&state).load_latest_competition().await?;
-    filter_by_deadline(&state, competition).await.map(Json)
+) -> Result<Json<SolverCompetitionAPI>, LoadSolverCompetitionError> {
+    let c = db(&state).load_latest_competition().await?;
+    filter_by_deadline(&state, c).await.map(Json)
 }
 
 async fn filter_by_deadline(

--- a/crates/orderbook/src/api/get_solver_competition.rs
+++ b/crates/orderbook/src/api/get_solver_competition.rs
@@ -23,11 +23,8 @@ pub async fn get_solver_competition_by_id_handler(
     if auction_id >= AuctionId::MAX.cast_unsigned() {
         return Err(LoadSolverCompetitionError::NotFound);
     }
-    // Uses database_write (not read replica) because the replication lag is
-    // not acceptable when the circuit breaker checks if a tx was out of
-    // competition.
-    state
-        .database_write
+
+    db(&state)
         .load_competition(
             Identifier::Id(auction_id.cast_signed()),
             state.hide_competition_before_block(),
@@ -40,8 +37,7 @@ pub async fn get_solver_competition_by_hash_handler(
     State(state): State<Arc<AppState>>,
     Path(tx_hash): Path<B256>,
 ) -> Result<Json<SolverCompetitionAPI>, LoadSolverCompetitionError> {
-    state
-        .database_write
+    db(&state)
         .load_competition(
             Identifier::Transaction(tx_hash),
             state.hide_competition_before_block(),
@@ -54,11 +50,19 @@ pub async fn get_solver_competition_latest_handler(
     State(state): State<Arc<AppState>>,
 ) -> Result<Json<SolverCompetitionAPI>, LoadSolverCompetitionError> {
     SolverCompetitionStoring::load_latest_competition(
-        &state.database_write,
+        db(&state),
         state.hide_competition_before_block(),
     )
     .await
     .map(Json)
+}
+
+fn db(state: &AppState) -> &dyn SolverCompetitionStoring {
+    // While these queries actually don't write to the DB
+    // the latency incurred by the DB replication process
+    // is not acceptable in some cases (e.g. when the circuit
+    // breaker needs to decide whether an tx was out of competition).
+    &state.database_write
 }
 
 #[cfg(test)]

--- a/crates/orderbook/src/api/get_solver_competition.rs
+++ b/crates/orderbook/src/api/get_solver_competition.rs
@@ -16,6 +16,10 @@ pub async fn get_solver_competition_by_id_handler(
     State(state): State<Arc<AppState>>,
     Path(auction_id): Path<u64>,
 ) -> Result<Json<SolverCompetitionAPI>, LoadSolverCompetitionError> {
+    // We use u64 to ensure that negative numbers are returned as BAD_REQUEST
+    // however, there's a gap between u64::MAX and i64::MAX, numbers beyond i64::MAX
+    // will be marked as NOT_FOUND as they're positive (and as such, valid) but
+    // they are not covered by our system
     if auction_id >= AuctionId::MAX.cast_unsigned() {
         return Err(LoadSolverCompetitionError::NotFound);
     }

--- a/crates/orderbook/src/api/get_solver_competition_v2.rs
+++ b/crates/orderbook/src/api/get_solver_competition_v2.rs
@@ -24,6 +24,7 @@ pub async fn get_solver_competition_by_id_handler(
     db(&state)
         .load_competition_by_id(auction_id.cast_signed())
         .await
+        .and_then(|r| filter_by_deadline(&state, r))
         .map(Json)
         .into_response()
 }
@@ -35,6 +36,7 @@ pub async fn get_solver_competition_by_hash_handler(
     db(&state)
         .load_competition_by_tx_hash(tx_hash)
         .await
+        .and_then(|r| filter_by_deadline(&state, r))
         .map(Json)
         .into_response()
 }
@@ -42,7 +44,18 @@ pub async fn get_solver_competition_by_hash_handler(
 pub async fn get_solver_competition_latest_handler(
     State(state): State<Arc<AppState>>,
 ) -> Result<Json<CompetitionResponse>, LoadSolverCompetitionError> {
-    db(&state).load_latest_competition().await.map(Json)
+    let response = db(&state).load_latest_competition().await?;
+    filter_by_deadline(&state, response).map(Json)
+}
+
+fn filter_by_deadline(
+    state: &AppState,
+    response: CompetitionResponse,
+) -> Result<CompetitionResponse, LoadSolverCompetitionError> {
+    if !state.is_competition_visible(response.auction_deadline_block) {
+        return Err(LoadSolverCompetitionError::NotFound);
+    }
+    Ok(response)
 }
 
 fn db(state: &AppState) -> &Postgres {

--- a/crates/orderbook/src/api/get_solver_competition_v2.rs
+++ b/crates/orderbook/src/api/get_solver_competition_v2.rs
@@ -22,9 +22,11 @@ pub async fn get_solver_competition_by_id_handler(
     }
 
     db(&state)
-        .load_competition_by_id(auction_id.cast_signed())
+        .load_competition_by_id(
+            auction_id.cast_signed(),
+            state.hide_competition_before_block(),
+        )
         .await
-        .and_then(|r| filter_by_deadline(&state, r))
         .map(Json)
         .into_response()
 }
@@ -34,9 +36,8 @@ pub async fn get_solver_competition_by_hash_handler(
     Path(tx_hash): Path<B256>,
 ) -> Response {
     db(&state)
-        .load_competition_by_tx_hash(tx_hash)
+        .load_competition_by_tx_hash(tx_hash, state.hide_competition_before_block())
         .await
-        .and_then(|r| filter_by_deadline(&state, r))
         .map(Json)
         .into_response()
 }
@@ -44,18 +45,10 @@ pub async fn get_solver_competition_by_hash_handler(
 pub async fn get_solver_competition_latest_handler(
     State(state): State<Arc<AppState>>,
 ) -> Result<Json<CompetitionResponse>, LoadSolverCompetitionError> {
-    let response = db(&state).load_latest_competition().await?;
-    filter_by_deadline(&state, response).map(Json)
-}
-
-fn filter_by_deadline(
-    state: &AppState,
-    response: CompetitionResponse,
-) -> Result<CompetitionResponse, LoadSolverCompetitionError> {
-    if !state.is_competition_visible(response.auction_deadline_block) {
-        return Err(LoadSolverCompetitionError::NotFound);
-    }
-    Ok(response)
+    db(&state)
+        .load_latest_competition(state.hide_competition_before_block())
+        .await
+        .map(Json)
 }
 
 fn db(state: &AppState) -> &Postgres {

--- a/crates/orderbook/src/database/solver_competition.rs
+++ b/crates/orderbook/src/database/solver_competition.rs
@@ -38,21 +38,11 @@ impl SolverCompetitionStoring for Postgres {
             .start_timer();
 
         let mut ex = self.pool.acquire().await.map_err(anyhow::Error::from)?;
-        let competition = match id {
-            Identifier::Id(id) => database::solver_competition::load_by_id(&mut ex, id)
-                .await
-                .context("solver_competition::load_by_id")?
-                .map(|row| {
-                    deserialize_solver_competition(
-                        row.json,
-                        row.id,
-                        row.tx_hashes.iter().map(|hash| B256::new(hash.0)).collect(),
-                    )
-                }),
-            Identifier::Transaction(hash) => {
-                database::solver_competition::load_by_tx_hash(&mut ex, &ByteArray(hash.0))
+        match id {
+            Identifier::Id(id) => {
+                database::solver_competition::load_by_id(&mut ex, id, after_block)
                     .await
-                    .context("solver_competition::load_by_tx_hash")?
+                    .context("solver_competition::load_by_id")?
                     .map(|row| {
                         deserialize_solver_competition(
                             row.json,
@@ -61,9 +51,22 @@ impl SolverCompetitionStoring for Postgres {
                         )
                     })
             }
+            Identifier::Transaction(hash) => database::solver_competition::load_by_tx_hash(
+                &mut ex,
+                &ByteArray(hash.0),
+                after_block,
+            )
+            .await
+            .context("solver_competition::load_by_tx_hash")?
+            .map(|row| {
+                deserialize_solver_competition(
+                    row.json,
+                    row.id,
+                    row.tx_hashes.iter().map(|hash| B256::new(hash.0)).collect(),
+                )
+            }),
         }
-        .ok_or(LoadSolverCompetitionError::NotFound)??;
-        hide_before_deadline(&mut ex, competition, after_block).await
+        .ok_or(LoadSolverCompetitionError::NotFound)?
     }
 
     async fn load_latest_competition(
@@ -76,7 +79,7 @@ impl SolverCompetitionStoring for Postgres {
             .start_timer();
 
         let mut ex = self.pool.acquire().await.map_err(anyhow::Error::from)?;
-        let competition = database::solver_competition::load_latest_competition(&mut ex)
+        database::solver_competition::load_latest_competition(&mut ex, after_block)
             .await
             .context("solver_competition::load_latest_competition")?
             .map(|row| {
@@ -86,8 +89,7 @@ impl SolverCompetitionStoring for Postgres {
                     row.tx_hashes.iter().map(|hash| B256::new(hash.0)).collect(),
                 )
             })
-            .ok_or(LoadSolverCompetitionError::NotFound)??;
-        hide_before_deadline(&mut ex, competition, after_block).await
+            .ok_or(LoadSolverCompetitionError::NotFound)?
     }
 
     async fn load_latest_competitions(
@@ -104,6 +106,7 @@ impl SolverCompetitionStoring for Postgres {
         let latest_competitions = database::solver_competition::load_latest_competitions(
             &mut ex,
             latest_competitions_count,
+            None,
         )
         .await
         .context("solver_competition::load_latest_competitions")?
@@ -119,27 +122,6 @@ impl SolverCompetitionStoring for Postgres {
 
         Ok(latest_competitions)
     }
-}
-
-/// V1 competitions don't store the deadline in the legacy JSON format, so we
-/// check it via a separate query against `competition_auctions`.
-async fn hide_before_deadline(
-    ex: &mut sqlx::PgConnection,
-    competition: SolverCompetitionAPI,
-    after_block: Option<i64>,
-) -> Result<SolverCompetitionAPI, LoadSolverCompetitionError> {
-    if let Some(block) = after_block {
-        let deadline: Option<i64> =
-            sqlx::query_scalar("SELECT deadline FROM competition_auctions WHERE id = $1")
-                .bind(competition.auction_id)
-                .fetch_optional(&mut *ex)
-                .await
-                .map_err(|e| LoadSolverCompetitionError::Other(e.into()))?;
-        if deadline.is_some_and(|d| d >= block) {
-            return Err(LoadSolverCompetitionError::NotFound);
-        }
-    }
-    Ok(competition)
 }
 
 #[cfg(test)]

--- a/crates/orderbook/src/database/solver_competition.rs
+++ b/crates/orderbook/src/database/solver_competition.rs
@@ -30,6 +30,7 @@ impl SolverCompetitionStoring for Postgres {
     async fn load_competition(
         &self,
         id: Identifier,
+        after_block: Option<i64>,
     ) -> Result<SolverCompetitionAPI, LoadSolverCompetitionError> {
         let _timer = super::Metrics::get()
             .database_queries
@@ -37,7 +38,7 @@ impl SolverCompetitionStoring for Postgres {
             .start_timer();
 
         let mut ex = self.pool.acquire().await.map_err(anyhow::Error::from)?;
-        match id {
+        let competition = match id {
             Identifier::Id(id) => database::solver_competition::load_by_id(&mut ex, id)
                 .await
                 .context("solver_competition::load_by_id")?
@@ -61,11 +62,13 @@ impl SolverCompetitionStoring for Postgres {
                     })
             }
         }
-        .ok_or(LoadSolverCompetitionError::NotFound)?
+        .ok_or(LoadSolverCompetitionError::NotFound)??;
+        hide_before_deadline(&mut ex, competition, after_block).await
     }
 
     async fn load_latest_competition(
         &self,
+        after_block: Option<i64>,
     ) -> Result<SolverCompetitionAPI, LoadSolverCompetitionError> {
         let _timer = super::Metrics::get()
             .database_queries
@@ -73,7 +76,7 @@ impl SolverCompetitionStoring for Postgres {
             .start_timer();
 
         let mut ex = self.pool.acquire().await.map_err(anyhow::Error::from)?;
-        database::solver_competition::load_latest_competition(&mut ex)
+        let competition = database::solver_competition::load_latest_competition(&mut ex)
             .await
             .context("solver_competition::load_latest_competition")?
             .map(|row| {
@@ -83,7 +86,8 @@ impl SolverCompetitionStoring for Postgres {
                     row.tx_hashes.iter().map(|hash| B256::new(hash.0)).collect(),
                 )
             })
-            .ok_or(LoadSolverCompetitionError::NotFound)?
+            .ok_or(LoadSolverCompetitionError::NotFound)??;
+        hide_before_deadline(&mut ex, competition, after_block).await
     }
 
     async fn load_latest_competitions(
@@ -117,6 +121,27 @@ impl SolverCompetitionStoring for Postgres {
     }
 }
 
+/// V1 competitions don't store the deadline in the legacy JSON format, so we
+/// check it via a separate query against `competition_auctions`.
+async fn hide_before_deadline(
+    ex: &mut sqlx::PgConnection,
+    competition: SolverCompetitionAPI,
+    after_block: Option<i64>,
+) -> Result<SolverCompetitionAPI, LoadSolverCompetitionError> {
+    if let Some(block) = after_block {
+        let deadline: Option<i64> =
+            sqlx::query_scalar("SELECT deadline FROM competition_auctions WHERE id = $1")
+                .bind(competition.auction_id)
+                .fetch_optional(&mut *ex)
+                .await
+                .map_err(|e| LoadSolverCompetitionError::Other(e.into()))?;
+        if deadline.is_some_and(|d| d >= block) {
+            return Err(LoadSolverCompetitionError::NotFound);
+        }
+    }
+    Ok(competition)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -128,7 +153,7 @@ mod tests {
         database::clear_DANGER(&db.pool).await.unwrap();
 
         let result = db
-            .load_competition(Identifier::Transaction(Default::default()))
+            .load_competition(Identifier::Transaction(Default::default()), None)
             .await
             .unwrap_err();
         assert!(matches!(result, LoadSolverCompetitionError::NotFound));

--- a/crates/orderbook/src/database/solver_competition_v2.rs
+++ b/crates/orderbook/src/database/solver_competition_v2.rs
@@ -60,6 +60,20 @@ impl Postgres {
             .map(try_into_dto)
             .ok_or(LoadSolverCompetitionError::NotFound)?
     }
+
+    /// Returns the submission deadline block for the given auction, or `None`
+    /// if the auction doesn't exist in `competition_auctions`.
+    pub async fn get_auction_deadline(
+        &self,
+        auction_id: i64,
+    ) -> Result<Option<i64>, LoadSolverCompetitionError> {
+        let mut ex = self.pool.acquire().await.map_err(anyhow::Error::from)?;
+        sqlx::query_scalar("SELECT deadline FROM competition_auctions WHERE id = $1")
+            .bind(auction_id)
+            .fetch_optional(&mut *ex)
+            .await
+            .map_err(|e| LoadSolverCompetitionError::Other(e.into()))
+    }
 }
 
 fn try_into_dto(value: DbResponse) -> Result<ApiResponse, LoadSolverCompetitionError> {

--- a/crates/orderbook/src/database/solver_competition_v2.rs
+++ b/crates/orderbook/src/database/solver_competition_v2.rs
@@ -13,9 +13,12 @@ use {
 };
 
 impl Postgres {
+    /// When `current_block` is `Some`, competitions whose deadline hasn't
+    /// passed yet are filtered out at the SQL level.
     pub async fn load_competition_by_id(
         &self,
         auction_id: i64,
+        current_block: Option<i64>,
     ) -> Result<ApiResponse, LoadSolverCompetitionError> {
         let _timer = super::Metrics::get()
             .database_queries
@@ -23,7 +26,7 @@ impl Postgres {
             .start_timer();
 
         let mut ex = self.pool.acquire().await.map_err(anyhow::Error::from)?;
-        database::solver_competition_v2::load_by_id(&mut ex, auction_id)
+        database::solver_competition_v2::load_by_id(&mut ex, auction_id, current_block)
             .await
             .context("solver_competition_v2::load_by_id")?
             .map(try_into_dto)
@@ -33,6 +36,7 @@ impl Postgres {
     pub async fn load_competition_by_tx_hash(
         &self,
         tx_hash: B256,
+        current_block: Option<i64>,
     ) -> Result<ApiResponse, LoadSolverCompetitionError> {
         let _timer = super::Metrics::get()
             .database_queries
@@ -40,39 +44,32 @@ impl Postgres {
             .start_timer();
 
         let mut ex = self.pool.acquire().await.map_err(anyhow::Error::from)?;
-        database::solver_competition_v2::load_by_tx_hash(&mut ex, ByteArray(tx_hash.0))
-            .await
-            .context("solver_competition_v2::load_by_tx_hash")?
-            .map(try_into_dto)
-            .ok_or(LoadSolverCompetitionError::NotFound)?
+        database::solver_competition_v2::load_by_tx_hash(
+            &mut ex,
+            ByteArray(tx_hash.0),
+            current_block,
+        )
+        .await
+        .context("solver_competition_v2::load_by_tx_hash")?
+        .map(try_into_dto)
+        .ok_or(LoadSolverCompetitionError::NotFound)?
     }
 
-    pub async fn load_latest_competition(&self) -> Result<ApiResponse, LoadSolverCompetitionError> {
+    pub async fn load_latest_competition(
+        &self,
+        current_block: Option<i64>,
+    ) -> Result<ApiResponse, LoadSolverCompetitionError> {
         let _timer = super::Metrics::get()
             .database_queries
             .with_label_values(&["load_latest_solver_competition_v2"])
             .start_timer();
 
         let mut ex = self.pool.acquire().await.map_err(anyhow::Error::from)?;
-        database::solver_competition_v2::load_latest(&mut ex)
+        database::solver_competition_v2::load_latest(&mut ex, current_block)
             .await
             .context("solver_competition_v2::load_latest")?
             .map(try_into_dto)
             .ok_or(LoadSolverCompetitionError::NotFound)?
-    }
-
-    /// Returns the submission deadline block for the given auction, or `None`
-    /// if the auction doesn't exist in `competition_auctions`.
-    pub async fn get_auction_deadline(
-        &self,
-        auction_id: i64,
-    ) -> Result<Option<i64>, LoadSolverCompetitionError> {
-        let mut ex = self.pool.acquire().await.map_err(anyhow::Error::from)?;
-        sqlx::query_scalar("SELECT deadline FROM competition_auctions WHERE id = $1")
-            .bind(auction_id)
-            .fetch_optional(&mut *ex)
-            .await
-            .map_err(|e| LoadSolverCompetitionError::Other(e.into()))
     }
 }
 

--- a/crates/orderbook/src/database/solver_competition_v2.rs
+++ b/crates/orderbook/src/database/solver_competition_v2.rs
@@ -13,8 +13,6 @@ use {
 };
 
 impl Postgres {
-    /// When `current_block` is `Some`, competitions whose deadline hasn't
-    /// passed yet are filtered out at the SQL level.
     pub async fn load_competition_by_id(
         &self,
         auction_id: i64,

--- a/crates/orderbook/src/orderbook.rs
+++ b/crates/orderbook/src/orderbook.rs
@@ -563,9 +563,10 @@ impl Orderbook {
         };
 
         let latest_competition = async {
-            let competition = SolverCompetitionStoring::load_latest_competition(&self.database)
-                .await
-                .map_err(Into::<OrderStatusError>::into)?;
+            let competition =
+                SolverCompetitionStoring::load_latest_competition(&self.database, None)
+                    .await
+                    .map_err(Into::<OrderStatusError>::into)?;
             Ok::<_, OrderStatusError>(solutions(competition))
         };
 
@@ -586,7 +587,7 @@ impl Orderbook {
             Some(Some(tx_hash)) => {
                 let competition = self
                     .database
-                    .load_competition(Identifier::Transaction(tx_hash))
+                    .load_competition(Identifier::Transaction(tx_hash), None)
                     .await?;
                 return Ok(dto::order::Status::Traded(solutions(competition)));
             }

--- a/crates/orderbook/src/run.rs
+++ b/crates/orderbook/src/run.rs
@@ -482,6 +482,8 @@ pub async fn run(config: Configuration) {
         },
         native_price_estimator,
         config.price_estimation.quote_timeout,
+        current_block_stream,
+        config.hide_competition_before_deadline,
     );
 
     let mut metrics_address = config.bind_address;
@@ -554,6 +556,8 @@ fn serve_api(
     shutdown_receiver: impl Future<Output = ()> + Send + 'static,
     native_price_estimator: Arc<dyn NativePriceEstimating>,
     quote_timeout: Duration,
+    current_block_stream: ethrpc::block_stream::CurrentBlockWatcher,
+    hide_competition_before_deadline: bool,
 ) -> JoinHandle<()> {
     let app = api::handle_all_routes(
         database,
@@ -563,6 +567,8 @@ fn serve_api(
         app_data,
         native_price_estimator,
         quote_timeout,
+        current_block_stream,
+        hide_competition_before_deadline,
     );
     tracing::info!(%address, "serving order book");
 

--- a/crates/orderbook/src/solver_competition.rs
+++ b/crates/orderbook/src/solver_competition.rs
@@ -21,16 +21,22 @@ pub trait SolverCompetitionStoring: Send + Sync {
     ///
     /// Returns a `NotFound` error if no solver competition with that ID could
     /// be found.
+    /// When `after_block` is `Some`, competitions whose deadline hasn't
+    /// passed are treated as not found.
     async fn load_competition(
         &self,
         identifier: Identifier,
+        after_block: Option<i64>,
     ) -> Result<SolverCompetitionAPI, crate::solver_competition::LoadSolverCompetitionError>;
 
     /// Retrieves the solver competition for the most recent auction.
     ///
     /// Returns a `NotFound` error if no solver competition could be found.
+    /// When `after_block` is `Some`, only auctions whose deadline has passed
+    /// are considered.
     async fn load_latest_competition(
         &self,
+        after_block: Option<i64>,
     ) -> Result<SolverCompetitionAPI, crate::solver_competition::LoadSolverCompetitionError>;
 
     /// Retrieves the solver competitions for the most recent auctions.


### PR DESCRIPTION
# Description

Hides solver competition API data until the auction's submission deadline block has passed. Feature-gated via hide-competition-before-deadline (default off) to avoid breaking external solver monitoring that depends on these endpoints.

# Changes

- Added hide-competition-before-deadline bool to orderbook config (default false)                  
- Wired CurrentBlockWatcher into AppState so handlers can check the current block                                       
- Return 404 while deadline hasn't passed               
- E2E test updated to exercise both the 404 and the post-deadline visibility      

## How to test

```
cargo test -p e2e 'solver_competition::local_node_solver_competition' -- --exact --ignored 
```