### PR TITLE
[EASY] Allow overriding flashloans-enabled per solver

### DIFF
--- a/crates/driver/src/infra/config/file/load.rs
+++ b/crates/driver/src/infra/config/file/load.rs
@@ -130,7 +130,9 @@ pub async fn load(chain: Chain, path: &Path) -> infra::Config {
                         .metrics_strategy_gc_max_age,
                 },
                 settle_queue_size: solver_config.settle_queue_size,
-                flashloans_enabled: config.flashloans_enabled,
+                flashloans_enabled: solver_config
+                    .flashloans_enabled
+                    .unwrap_or(config.flashloans_enabled),
                 fetch_liquidity_at_block: match config.liquidity.fetch_at_block {
                     file::AtBlock::Latest => liquidity::AtBlock::Latest,
                     file::AtBlock::Finalized => liquidity::AtBlock::Finalized,

--- a/crates/driver/src/infra/config/file/mod.rs
+++ b/crates/driver/src/infra/config/file/mod.rs
@@ -306,6 +306,11 @@ struct SolverConfig {
     #[serde(default = "default_settle_queue_size")]
     settle_queue_size: usize,
 
+    /// Whether flashloan orders should be sent to this solver. If not
+    /// specified, falls back to the top-level `flashloans-enabled` setting.
+    #[serde(default)]
+    flashloans_enabled: Option<bool>,
+
     /// Haircut in basis points (0-10000). Applied to solver-reported
     /// economics to make bids more conservative by adjusting clearing prices
     /// to report lower surplus. Useful for solvers prone to negative slippage.


### PR DESCRIPTION
# Description
The zeroex solver on polygon generates a high volume of failing solutions for flashloan orders it has never successfully settled. These orders (11 long-lived WBTC limit orders with flashloan hints) fail 100% at encoding because the flashloan repayment reverts, triggering the `GnosisDriverRunErrorRateTooHigh` alert. Currently `flashloans-enabled` is a top-level driver config that applies to all solvers, so flashloans cannot be disabled for a single solver without affecting others.

# Changes
- Added optional per-solver `flashloans-enabled` config in the `[[solver]]` TOML section
- Falls back to the top-level `flashloans-enabled` value when not specified per solver, so existing behavior is unchanged

# How to test
Existing tests. After merging, set `flashloans-enabled = false` in the zeroex solver config in the infrastructure repo to stop flashloan orders from being sent to it. This can also be disabled for all the gnosis solvers, since I couldn't find a single flashloan order settled by them.