### PR TITLE
Support reading TenderlyConfig api_key from environment variable

### DIFF
--- a/crates/configs/src/simulator.rs
+++ b/crates/configs/src/simulator.rs
@@ -64,7 +64,12 @@ pub struct TenderlyConfig {
 
     /// Tenderly requires api key to work. Optional since Tenderly could be
     /// skipped in access lists estimators.
-    #[serde(default)]
+    /// Supports reading from an environment variable with the `%ENV_VAR`
+    /// format.
+    #[serde(
+        default,
+        deserialize_with = "crate::deserialize_env::deserialize_string_from_env"
+    )]
     pub api_key: String,
 
     /// The URL of the Tenderly API.


### PR DESCRIPTION
# Description
The `TenderlyConfig.api_key` field currently deserializes as a plain string from TOML config. This means it cannot use the `%ENV_VAR` pattern to read secrets from environment variables at runtime, unlike `CoinGeckoConfig.api_key` which already supports this.

Since PR #4225 moved price estimation into a separate crate and removed the old CLI `--tenderly-*` arguments, the only way to configure Tenderly for the trade verifier is via the TOML `[price-estimation.tenderly]` section. Without env var support on the `api-key` field, the API key would need to be hardcoded in the ConfigMap, which is a security concern.

# Changes
- Added `deserialize_string_from_env` to `TenderlyConfig.api_key` so it supports the `%ENV_VAR` pattern (same as `CoinGeckoConfig.api_key`)

# How to test
Existing tests.