### PR TITLE
Fix RUSTSEC issues

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -369,7 +369,7 @@ dependencies = [
  "keccak-asm",
  "paste",
  "proptest",
- "rand 0.9.2",
+ "rand 0.9.4",
  "rapidhash",
  "ruint",
  "rustc-hash",
@@ -1246,7 +1246,7 @@ dependencies = [
  "price-estimation",
  "prometheus",
  "prometheus-metric-storage",
- "rand 0.8.5",
+ "rand 0.9.4",
  "reqwest 0.13.2",
  "rust_decimal",
  "s3",
@@ -3692,7 +3692,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ab67060fc6b8ef687992d439ca0fa36e7ed17e9a0b16b25b601e8757df720de"
 dependencies = [
  "data-encoding",
- "syn 1.0.109",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -3886,7 +3886,7 @@ dependencies = [
  "price-estimation",
  "prometheus",
  "prometheus-metric-storage",
- "rand 0.8.5",
+ "rand 0.9.4",
  "request-sharing",
  "reqwest 0.13.2",
  "s3",
@@ -4122,7 +4122,7 @@ dependencies = [
  "observe",
  "prometheus",
  "prometheus-metric-storage",
- "rand 0.8.5",
+ "rand 0.9.4",
  "reqwest 0.13.2",
  "scopeguard",
  "serde",
@@ -4899,7 +4899,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.1",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -5975,7 +5975,7 @@ dependencies = [
  "futures-util",
  "opentelemetry",
  "percent-encoding",
- "rand 0.9.2",
+ "rand 0.9.4",
  "thiserror 2.0.17",
 ]
 
@@ -6345,7 +6345,7 @@ dependencies = [
  "observe",
  "prometheus",
  "prometheus-metric-storage",
- "rand 0.8.5",
+ "rand 0.9.4",
  "rate-limit",
  "request-sharing",
  "reqwest 0.13.2",
@@ -6460,7 +6460,7 @@ dependencies = [
  "bit-vec",
  "bitflags 2.10.0",
  "num-traits",
- "rand 0.9.2",
+ "rand 0.9.4",
  "rand_chacha 0.9.0",
  "rand_xorshift",
  "regex-syntax",
@@ -6602,7 +6602,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.5.10",
+ "socket2 0.6.1",
  "thiserror 2.0.17",
  "tokio",
  "tracing",
@@ -6619,7 +6619,7 @@ dependencies = [
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
- "rand 0.9.2",
+ "rand 0.9.4",
  "ring",
  "rustc-hash",
  "rustls",
@@ -6640,7 +6640,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.1",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -6686,9 +6686,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
@@ -6749,7 +6749,7 @@ version = "4.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d8b5b858a440a0bc02625b62dd95131b9201aa9f69f411195dd4a7cfb1de3d7"
 dependencies = [
- "rand 0.9.2",
+ "rand 0.9.4",
  "rustversion",
 ]
 
@@ -6832,7 +6832,7 @@ dependencies = [
  "observe",
  "prometheus",
  "prometheus-metric-storage",
- "rand 0.8.5",
+ "rand 0.9.4",
  "rstest",
  "shared",
  "sqlx",
@@ -7091,7 +7091,7 @@ dependencies = [
  "primitive-types",
  "proptest",
  "rand 0.8.5",
- "rand 0.9.2",
+ "rand 0.9.4",
  "rlp",
  "ruint-macro",
  "serde_core",
@@ -7232,9 +7232,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -7651,7 +7651,7 @@ dependencies = [
  "price-estimation",
  "prometheus",
  "prometheus-metric-storage",
- "rand 0.8.5",
+ "rand 0.9.4",
  "rate-limit",
  "regex",
  "request-sharing",
@@ -8901,7 +8901,7 @@ dependencies = [
  "http 1.4.0",
  "httparse",
  "log",
- "rand 0.9.2",
+ "rand 0.9.4",
  "rustls",
  "rustls-pki-types",
  "sha1",
@@ -9309,7 +9309,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,7 +96,7 @@ proc-macro2 = "1.0.103"
 prometheus = "0.14"
 prometheus-metric-storage = "0.6"
 quote = "1.0.41"
-rand = "0.8.5"
+rand = "0.9.4"
 rate-limit = { path = "crates/rate-limit" }
 refunder = { path = "crates/refunder" }
 regex = "1.10.4"

--- a/crates/autopilot/src/domain/settlement/observer.rs
+++ b/crates/autopilot/src/domain/settlement/observer.rs
@@ -18,7 +18,7 @@ use {
     anyhow::{Context, Result, anyhow},
     eth_domain_types as eth,
     futures::StreamExt,
-    rand::Rng,
+    rand::Rng as _,
     std::time::Duration,
 };
 
@@ -177,7 +177,7 @@ impl Observer {
                     errors.push(err);
                     tries += 1;
                     // wait a little to give temporary errors a chance to resolve themselves
-                    let timeout_with_jitter = 50u64 + rand::thread_rng().gen_range(0..=50);
+                    let timeout_with_jitter = 50u64 + rand::rng().random_range(0..=50);
                     tokio::time::sleep(Duration::from_millis(timeout_with_jitter)).await;
                 }
             }

--- a/crates/autopilot/src/run_loop.rs
+++ b/crates/autopilot/src/run_loop.rs
@@ -612,7 +612,7 @@ impl RunLoop {
         });
 
         // Shuffle so that sorting randomly splits ties.
-        bids.shuffle(&mut rand::thread_rng());
+        bids.shuffle(&mut rand::rng());
         bids
     }
 

--- a/crates/driver/src/tests/setup/driver.rs
+++ b/crates/driver/src/tests/setup/driver.rs
@@ -70,7 +70,7 @@ pub fn solve_req(test: &Test) -> serde_json::Value {
     // The orders are shuffled before being sent to the driver, to ensure that the
     // driver sorts them correctly before forwarding them to the solver.
     let mut quotes = test.quoted_orders.clone();
-    quotes.shuffle(&mut rand::thread_rng());
+    quotes.shuffle(&mut rand::rng());
     for quote in quotes.iter() {
         let mut order = json!({
             "uid": quote.order_uid(&test.blockchain),

--- a/crates/price-estimation/src/native_price_cache.rs
+++ b/crates/price-estimation/src/native_price_cache.rs
@@ -165,7 +165,7 @@ struct CacheInner {
 
 impl Cache {
     pub fn new(max_age: Duration, initial_prices: HashMap<Address, BigDecimal>) -> Self {
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
         let now = std::time::Instant::now();
 
         let data = moka::sync::Cache::builder()
@@ -197,7 +197,7 @@ impl Cache {
     /// in the past, to avoid spikes of expired prices all being fetched at
     /// once.
     fn random_updated_at(max_age: Duration, now: Instant, rng: &mut impl Rng) -> Instant {
-        let percent_expired = rng.gen_range(50..=90);
+        let percent_expired = rng.random_range(50..=90);
         let age = max_age.as_secs() * percent_expired / 100;
         now - Duration::from_secs(age)
     }


### PR DESCRIPTION
# Description

                                                                                                     
Fixed (vulnerabilities):                                  
- RUSTSEC-2026-0098 & RUSTSEC-2026-0099: rustls-webpki 0.103.10 → 0.103.12 (lockfile update only)   
                                                                                                      
Fixed (unsound warning):                                                                            
- RUSTSEC-2026-0097: rand 0.9.2 → 0.9.4 (lockfile update only)                                      
- RUSTSEC-2026-0097: Workspace rand dependency bumped from 0.8.5 → 0.9.4 in Cargo.toml, with code updates to use the new API (thread_rng() → rng(), gen_range() → random_range())  

