### PR TITLE
Respect settle queue size

### DIFF
--- a/crates/driver/src/domain/competition/mod.rs
+++ b/crates/driver/src/domain/competition/mod.rs
@@ -741,14 +741,14 @@ impl Competition {
             Error::TooManyPendingSettlements
         })?;
 
+        if self.eth.current_block().borrow().number >= submission_deadline.0 {
+            return Err(DeadlineExceeded.into());
+        }
+
         let this = Arc::clone(self);
         let tracing_span = tracing::Span::current();
         let handle = tokio::spawn(
             async move {
-                if this.eth.current_block().borrow().number >= submission_deadline.0 {
-                    return Err(DeadlineExceeded.into());
-                }
-
                 let result = this
                     .process_settle_request(auction_id, solution_id, submission_deadline)
                     .await;

--- a/crates/driver/src/domain/competition/mod.rs
+++ b/crates/driver/src/domain/competition/mod.rs
@@ -229,7 +229,6 @@ pub struct Competition {
     /// bad token and orders detector
     pub risk_detector: Arc<risk_detector::Detector>,
     fetcher: Arc<pre_processing::DataAggregator>,
-    settle_queue: mpsc::Sender<SettleRequest>,
     order_sorting_strategies: Vec<Arc<dyn sorting::SortingStrategy>>,
     submitter_pool: SubmitterPool,
 }
@@ -257,10 +256,8 @@ impl Competition {
         let settle_queue_size = solver.settle_queue_size();
         let submitter_pool =
             SubmitterPool::new(solver.address(), submission_accounts, settle_queue_size);
-        let queue_size = submitter_pool.admission.available_permits();
-        let (settle_sender, settle_receiver) = mpsc::channel(queue_size);
 
-        let competition = Arc::new(Self {
+        Arc::new(Self {
             solver,
             eth,
             liquidity,
@@ -268,21 +265,11 @@ impl Competition {
             simulator,
             mempools,
             settlements: Default::default(),
-            settle_queue: settle_sender,
             risk_detector,
             fetcher,
             order_sorting_strategies,
             submitter_pool,
-        });
-
-        let competition_clone = Arc::clone(&competition);
-        tokio::spawn(async move {
-            competition_clone
-                .process_settle_requests(settle_receiver)
-                .await;
-        });
-
-        competition
+        })
     }
 
     /// Solve an auction as part of this competition.
@@ -747,7 +734,7 @@ impl Competition {
     /// Execute the solution generated as part of this competition. Use
     /// [`Competition::solve`] to generate the solution.
     pub async fn settle(
-        &self,
+        self: &Arc<Self>,
         auction_id: auction::Id,
         solution_id: u64,
         submission_deadline: BlockNo,
@@ -757,24 +744,27 @@ impl Competition {
             Error::TooManyPendingSettlements
         })?;
 
-        let (response_sender, response_receiver) = oneshot::channel();
+        let (mut response_sender, response_receiver) = oneshot::channel();
 
-        let request = SettleRequest {
-            auction_id,
-            solution_id,
-            submission_deadline,
-            response_sender,
-            tracing_span: tracing::Span::current(),
-            admission_permit,
-        };
-
-        self.settle_queue.try_send(request).map_err(|err| {
-            tracing::warn!(?err, "Failed to enqueue /settle request");
-            Error::TooManyPendingSettlements
-        })?;
+        let this = Arc::clone(self);
+        let tracing_span = tracing::Span::current();
+        tokio::spawn(async move {
+            let result = this
+                .execute_settle(
+                    auction_id,
+                    solution_id,
+                    submission_deadline,
+                    &mut response_sender,
+                )
+                .instrument(tracing_span)
+                .await;
+            observe::settled(this.solver.name(), &result);
+            let _ = response_sender.send(result);
+            drop(admission_permit);
+        });
 
         response_receiver.await.map_err(|err| {
-            tracing::error!(?err, "Failed to dequeue /settle response");
+            tracing::error!(?err, "settle task terminated unexpectedly");
             Error::SubmissionError
         })?
     }
@@ -788,68 +778,35 @@ impl Competition {
         }
     }
 
-    async fn process_settle_requests(
-        self: Arc<Self>,
-        mut settle_receiver: mpsc::Receiver<SettleRequest>,
-    ) {
-        while let Some(request) = settle_receiver.recv().await {
-            // When only the direct solver EOA slot exists and no delegated accounts are set
-            // up, the pool's acquire() blocks until the slot is free,  serializing
-            // settlements.
-            let this = Arc::clone(&self);
-            tokio::spawn(async move {
-                this.handle_settle_request(request).await;
-            });
+    async fn execute_settle(
+        &self,
+        auction_id: auction::Id,
+        solution_id: u64,
+        submission_deadline: BlockNo,
+        response_sender: &mut oneshot::Sender<Result<Settled, Error>>,
+    ) -> Result<Settled, Error> {
+        if self.eth.current_block().borrow().number >= submission_deadline.0 {
+            return Err(DeadlineExceeded.into());
         }
-    }
 
-    async fn handle_settle_request(self: &Arc<Self>, request: SettleRequest) {
-        let SettleRequest {
-            auction_id,
-            solution_id,
-            submission_deadline,
-            mut response_sender,
-            tracing_span,
-            admission_permit,
-        } = request;
-        async {
-            if self.eth.current_block().borrow().number >= submission_deadline.0 {
-                if let Err(err) = response_sender.send(Err(DeadlineExceeded.into())) {
-                    tracing::error!(
-                        ?err,
-                        "settle deadline exceeded. unable to return a response"
-                    );
-                }
-                return;
+        let settle_fut =
+            Box::pin(self.process_settle_request(auction_id, solution_id, submission_deadline));
+        let closed_fut = Box::pin(response_sender.closed());
+        match futures::future::select(closed_fut, settle_fut).await {
+            // Cancel the settlement task if the caller disconnected (e.g.
+            // autopilot gave up). Grace period lets the driver cancel a
+            // pending tx if needed.
+            Either::Left((_closed, settle_fut)) => {
+                tracing::debug!("autopilot terminated settle call");
+                tokio::time::timeout(Duration::from_secs(1), settle_fut)
+                    .await
+                    .unwrap_or_else(|_| {
+                        tracing::error!("didn't finish tx submission within grace period");
+                        Err(DeadlineExceeded.into())
+                    })
             }
-
-            observe::settling();
-            let settle_fut =
-                Box::pin(self.process_settle_request(auction_id, solution_id, submission_deadline));
-            let closed_fut = Box::pin(response_sender.closed());
-            let result = match futures::future::select(closed_fut, settle_fut).await {
-                // Cancel the settlement task if the sender is closed (client likely
-                // disconnected). This is a fallback to recover from issues
-                // like a stuck driver (e.g., stalled block stream).
-                Either::Left((_closed, settle_fut)) => {
-                    tracing::debug!("autopilot terminated settle call");
-                    // Add a grace period to give driver the last chance to cancel the
-                    // tx if needed.
-                    tokio::time::timeout(Duration::from_secs(1), settle_fut)
-                        .await
-                        .unwrap_or_else(|_| {
-                            tracing::error!("didn't finish tx submission within grace period");
-                            Err(DeadlineExceeded.into())
-                        })
-                }
-                Either::Right((res, _)) => res,
-            };
-            observe::settled(self.solver.name(), &result);
-            let _ = response_sender.send(result);
-            drop(admission_permit);
+            Either::Right((res, _)) => res,
         }
-        .instrument(tracing_span)
-        .await
     }
 
     async fn process_settle_request(
@@ -998,17 +955,6 @@ fn merge(
         )
     });
     merged
-}
-
-struct SettleRequest {
-    auction_id: auction::Id,
-    solution_id: u64,
-    submission_deadline: BlockNo,
-    response_sender: oneshot::Sender<Result<Settled, Error>>,
-    tracing_span: tracing::Span,
-    /// Held for the lifetime of the request; released on drop so the pool
-    /// knows a slot has freed up.
-    admission_permit: tokio::sync::OwnedSemaphorePermit,
 }
 
 /// Solution information sent to the protocol by the driver before the solution

--- a/crates/driver/src/domain/competition/mod.rs
+++ b/crates/driver/src/domain/competition/mod.rs
@@ -23,19 +23,16 @@ use {
     anyhow::Context as _,
     axum::{body::Body, http::Request},
     eth_domain_types as eth,
-    futures::{FutureExt, StreamExt, future::Either, stream::FuturesUnordered},
+    futures::{FutureExt, StreamExt, stream::FuturesUnordered},
     itertools::Itertools,
     simulator::{RevertError, Simulator, SimulatorError},
     std::{
         cmp::Reverse,
         collections::{HashMap, HashSet, VecDeque},
         sync::{Arc, Mutex},
-        time::{Duration, Instant},
+        time::Instant,
     },
-    tokio::{
-        sync::{mpsc, oneshot},
-        task,
-    },
+    tokio::{sync::mpsc, task},
     tracing::{Instrument, instrument},
 };
 
@@ -104,7 +101,11 @@ impl SubmitterPool {
             })
         };
         let total_slots = 1 + num_delegated;
-        let admission_capacity = total_slots + settle_queue_size;
+        let admission_capacity = if num_delegated > 0 {
+            total_slots
+        } else {
+            total_slots + settle_queue_size
+        };
         Self {
             direct_slot: Arc::new(tokio::sync::Semaphore::new(1)),
             delegated,
@@ -744,27 +745,26 @@ impl Competition {
             Error::TooManyPendingSettlements
         })?;
 
-        let (mut response_sender, response_receiver) = oneshot::channel();
-
         let this = Arc::clone(self);
         let tracing_span = tracing::Span::current();
-        tokio::spawn(async move {
-            let result = this
-                .execute_settle(
-                    auction_id,
-                    solution_id,
-                    submission_deadline,
-                    &mut response_sender,
-                )
-                .instrument(tracing_span)
-                .await;
-            observe::settled(this.solver.name(), &result);
-            let _ = response_sender.send(result);
-            drop(admission_permit);
-        });
+        let handle = tokio::spawn(
+            async move {
+                if this.eth.current_block().borrow().number >= submission_deadline.0 {
+                    return Err(DeadlineExceeded.into());
+                }
 
-        response_receiver.await.map_err(|err| {
-            tracing::error!(?err, "settle task terminated unexpectedly");
+                let result = this
+                    .process_settle_request(auction_id, solution_id, submission_deadline)
+                    .await;
+                observe::settled(this.solver.name(), &result);
+                drop(admission_permit);
+                result
+            }
+            .instrument(tracing_span),
+        );
+
+        handle.await.map_err(|err| {
+            tracing::error!(?err, "settle task panicked");
             Error::SubmissionError
         })?
     }
@@ -775,37 +775,6 @@ impl Competition {
             Err(Error::TooManyPendingSettlements)
         } else {
             Ok(())
-        }
-    }
-
-    async fn execute_settle(
-        &self,
-        auction_id: auction::Id,
-        solution_id: u64,
-        submission_deadline: BlockNo,
-        response_sender: &mut oneshot::Sender<Result<Settled, Error>>,
-    ) -> Result<Settled, Error> {
-        if self.eth.current_block().borrow().number >= submission_deadline.0 {
-            return Err(DeadlineExceeded.into());
-        }
-
-        let settle_fut =
-            Box::pin(self.process_settle_request(auction_id, solution_id, submission_deadline));
-        let closed_fut = Box::pin(response_sender.closed());
-        match futures::future::select(closed_fut, settle_fut).await {
-            // Cancel the settlement task if the caller disconnected (e.g.
-            // autopilot gave up). Grace period lets the driver cancel a
-            // pending tx if needed.
-            Either::Left((_closed, settle_fut)) => {
-                tracing::debug!("autopilot terminated settle call");
-                tokio::time::timeout(Duration::from_secs(1), settle_fut)
-                    .await
-                    .unwrap_or_else(|_| {
-                        tracing::error!("didn't finish tx submission within grace period");
-                        Err(DeadlineExceeded.into())
-                    })
-            }
-            Either::Right((res, _)) => res,
         }
     }
 

--- a/crates/driver/src/domain/competition/mod.rs
+++ b/crates/driver/src/domain/competition/mod.rs
@@ -104,7 +104,11 @@ impl SubmitterPool {
             })
         };
         let total_slots = 1 + num_delegated;
-        let admission_capacity = total_slots + settle_queue_size;
+        let admission_capacity = if num_delegated > 0 {
+            total_slots
+        } else {
+            total_slots + settle_queue_size
+        };
         Self {
             direct_slot: Arc::new(tokio::sync::Semaphore::new(1)),
             delegated,

--- a/crates/driver/src/domain/competition/mod.rs
+++ b/crates/driver/src/domain/competition/mod.rs
@@ -765,7 +765,7 @@ impl Competition {
             submission_deadline,
             response_sender,
             tracing_span: tracing::Span::current(),
-            _admission_permit: admission_permit,
+            admission_permit,
         };
 
         self.settle_queue.try_send(request).map_err(|err| {
@@ -810,7 +810,7 @@ impl Competition {
             submission_deadline,
             mut response_sender,
             tracing_span,
-            _admission_permit,
+            admission_permit,
         } = request;
         async {
             if self.eth.current_block().borrow().number >= submission_deadline.0 {
@@ -846,6 +846,7 @@ impl Competition {
             };
             observe::settled(self.solver.name(), &result);
             let _ = response_sender.send(result);
+            drop(admission_permit);
         }
         .instrument(tracing_span)
         .await
@@ -1007,7 +1008,7 @@ struct SettleRequest {
     tracing_span: tracing::Span,
     /// Held for the lifetime of the request; released on drop so the pool
     /// knows a slot has freed up.
-    _admission_permit: tokio::sync::OwnedSemaphorePermit,
+    admission_permit: tokio::sync::OwnedSemaphorePermit,
 }
 
 /// Solution information sent to the protocol by the driver before the solution

--- a/crates/driver/src/domain/competition/mod.rs
+++ b/crates/driver/src/domain/competition/mod.rs
@@ -101,11 +101,7 @@ impl SubmitterPool {
             })
         };
         let total_slots = 1 + num_delegated;
-        let admission_capacity = if num_delegated > 0 {
-            total_slots
-        } else {
-            total_slots + settle_queue_size
-        };
+        let admission_capacity = total_slots + settle_queue_size;
         Self {
             direct_slot: Arc::new(tokio::sync::Semaphore::new(1)),
             delegated,

--- a/crates/driver/src/domain/competition/mod.rs
+++ b/crates/driver/src/domain/competition/mod.rs
@@ -213,6 +213,40 @@ impl Drop for SubmitterGuard {
     }
 }
 
+/// Wrapper around a spawned settlement task's [`JoinHandle`]. When dropped
+/// (e.g. because the HTTP handler was cancelled by the autopilot), the task is
+/// aborted after a short grace period to allow cleanup (e.g. cancelling a
+/// pending mempool tx).
+struct SettleTaskHandle(task::JoinHandle<Result<Settled, Error>>);
+
+impl std::future::Future for SettleTaskHandle {
+    type Output = Result<Settled, Error>;
+
+    fn poll(
+        mut self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Self::Output> {
+        std::pin::Pin::new(&mut self.0).poll(cx).map(|join_result| {
+            join_result.map_err(|err| {
+                tracing::error!(?err, "settle task panicked");
+                Error::SubmissionError
+            })?
+        })
+    }
+}
+
+impl Drop for SettleTaskHandle {
+    fn drop(&mut self) {
+        if !self.0.is_finished() {
+            let handle = self.0.abort_handle();
+            tokio::spawn(async move {
+                tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+                handle.abort();
+            });
+        }
+    }
+}
+
 #[derive(Debug)]
 pub struct Competition {
     pub solver: Solver,
@@ -747,6 +781,9 @@ impl Competition {
 
         let this = Arc::clone(self);
         let tracing_span = tracing::Span::current();
+        // Spawn as a separate task to enable concurrent EIP-7702 submissions.
+        // SettleTaskHandle aborts the task (with a grace period) if the caller
+        // disconnects.
         let handle = tokio::spawn(
             async move {
                 let result = this
@@ -758,11 +795,7 @@ impl Competition {
             }
             .instrument(tracing_span),
         );
-
-        handle.await.map_err(|err| {
-            tracing::error!(?err, "settle task panicked");
-            Error::SubmissionError
-        })?
+        SettleTaskHandle(handle).await
     }
 
     pub fn ensure_settle_queue_capacity(&self) -> Result<(), Error> {

--- a/crates/driver/src/domain/competition/mod.rs
+++ b/crates/driver/src/domain/competition/mod.rs
@@ -104,11 +104,7 @@ impl SubmitterPool {
             })
         };
         let total_slots = 1 + num_delegated;
-        let admission_capacity = if num_delegated > 0 {
-            total_slots
-        } else {
-            total_slots + settle_queue_size
-        };
+        let admission_capacity = total_slots + settle_queue_size;
         Self {
             direct_slot: Arc::new(tokio::sync::Semaphore::new(1)),
             delegated,

--- a/crates/driver/src/domain/competition/mod.rs
+++ b/crates/driver/src/domain/competition/mod.rs
@@ -737,7 +737,7 @@ impl Competition {
         submission_deadline: BlockNo,
     ) -> Result<Settled, Error> {
         let admission_permit = self.submitter_pool.try_admit().ok_or_else(|| {
-            tracing::warn!("no idle submission slots; settle request rejected");
+            tracing::warn!("too many pending settlements; settle request rejected");
             Error::TooManyPendingSettlements
         })?;
 

--- a/crates/driver/src/domain/competition/mod.rs
+++ b/crates/driver/src/domain/competition/mod.rs
@@ -70,6 +70,10 @@ struct SubmitterPool {
     direct_slot: Arc<tokio::sync::Semaphore>,
     /// EIP-7702 submission accounts. `None` in legacy single-EOA mode.
     delegated: Option<DelegatedSlots>,
+    /// Limits total in-flight settle requests (including those waiting for a
+    /// pool slot). This replaces the old settle-queue-based admission check
+    /// and allows buffering requests beyond the number of physical slots.
+    admission: Arc<tokio::sync::Semaphore>,
     solver_address: eth::Address,
 }
 
@@ -80,7 +84,12 @@ struct DelegatedSlots {
 }
 
 impl SubmitterPool {
-    fn new(solver_address: eth::Address, submission_accounts: Vec<Account>) -> Self {
+    fn new(
+        solver_address: eth::Address,
+        submission_accounts: Vec<Account>,
+        settle_queue_size: usize,
+    ) -> Self {
+        let num_delegated = submission_accounts.len();
         let delegated = if submission_accounts.is_empty() {
             None
         } else {
@@ -94,9 +103,12 @@ impl SubmitterPool {
                 acquire: tokio::sync::Mutex::new(rx),
             })
         };
+        let total_slots = 1 + num_delegated;
+        let admission_capacity = total_slots + settle_queue_size;
         Self {
             direct_slot: Arc::new(tokio::sync::Semaphore::new(1)),
             delegated,
+            admission: Arc::new(tokio::sync::Semaphore::new(admission_capacity)),
             solver_address,
         }
     }
@@ -152,21 +164,10 @@ impl SubmitterPool {
         })
     }
 
-    fn total_slots(&self) -> usize {
-        // 1 slot for solver EOA + number of delegated EIP7702 accounts (if any)
-        1 + self
-            .delegated
-            .as_ref()
-            .map_or(0, |d| d.release.max_capacity())
-    }
-
-    fn has_capacity(&self) -> bool {
-        if self.direct_slot.available_permits() > 0 {
-            return true;
-        }
-        self.delegated
-            .as_ref()
-            .is_some_and(|d| d.release.capacity() < d.release.max_capacity())
+    /// Try to reserve an admission permit without blocking. Returns `None` if
+    /// the maximum number of in-flight settle requests has been reached.
+    fn try_admit(&self) -> Option<tokio::sync::OwnedSemaphorePermit> {
+        Arc::clone(&self.admission).try_acquire_owned().ok()
     }
 }
 
@@ -253,8 +254,10 @@ impl Competition {
                 "EIP-7702 parallel submission enabled"
             );
         }
-        let submitter_pool = SubmitterPool::new(solver.address(), submission_accounts);
-        let queue_size = submitter_pool.total_slots().max(solver.settle_queue_size());
+        let settle_queue_size = solver.settle_queue_size();
+        let submitter_pool =
+            SubmitterPool::new(solver.address(), submission_accounts, settle_queue_size);
+        let queue_size = submitter_pool.admission.available_permits();
         let (settle_sender, settle_receiver) = mpsc::channel(queue_size);
 
         let competition = Arc::new(Self {
@@ -749,6 +752,11 @@ impl Competition {
         solution_id: u64,
         submission_deadline: BlockNo,
     ) -> Result<Settled, Error> {
+        let admission_permit = self.submitter_pool.try_admit().ok_or_else(|| {
+            tracing::warn!("no idle submission slots; settle request rejected");
+            Error::TooManyPendingSettlements
+        })?;
+
         let (response_sender, response_receiver) = oneshot::channel();
 
         let request = SettleRequest {
@@ -757,6 +765,7 @@ impl Competition {
             submission_deadline,
             response_sender,
             tracing_span: tracing::Span::current(),
+            _admission_permit: admission_permit,
         };
 
         self.settle_queue.try_send(request).map_err(|err| {
@@ -771,7 +780,7 @@ impl Competition {
     }
 
     pub fn ensure_settle_queue_capacity(&self) -> Result<(), Error> {
-        if !self.submitter_pool.has_capacity() {
+        if self.submitter_pool.admission.available_permits() == 0 {
             tracing::warn!("no idle submission slots; auction is rejected");
             Err(Error::TooManyPendingSettlements)
         } else {
@@ -801,6 +810,7 @@ impl Competition {
             submission_deadline,
             mut response_sender,
             tracing_span,
+            _admission_permit,
         } = request;
         async {
             if self.eth.current_block().borrow().number >= submission_deadline.0 {
@@ -995,6 +1005,9 @@ struct SettleRequest {
     submission_deadline: BlockNo,
     response_sender: oneshot::Sender<Result<Settled, Error>>,
     tracing_span: tracing::Span,
+    /// Held for the lifetime of the request; released on drop so the pool
+    /// knows a slot has freed up.
+    _admission_permit: tokio::sync::OwnedSemaphorePermit,
 }
 
 /// Solution information sent to the protocol by the driver before the solution

--- a/crates/driver/src/infra/api/mod.rs
+++ b/crates/driver/src/infra/api/mod.rs
@@ -195,7 +195,7 @@ impl State {
         &self.0.solver
     }
 
-    fn competition(&self) -> &domain::Competition {
+    fn competition(&self) -> &Arc<domain::Competition> {
         &self.0.competition
     }
 

--- a/crates/driver/src/tests/cases/settle.rs
+++ b/crates/driver/src/tests/cases/settle.rs
@@ -143,9 +143,15 @@ async fn does_not_bid_huge_solution() {
     test.solve().await.ok().empty();
 }
 
+/// Verifies the admission semaphore correctly limits in-flight settle requests
+/// to `pool_slots + settle_queue_size` (default 1 + 2 = 3). We can submit as
+/// many bids as we want as long as there is at least 1 settle queue spot
+/// available, but once the queue is full, new /solve requests are rejected.
+/// After the settlements complete, capacity is restored and new bids can be
+/// submitted.
 #[tokio::test]
 #[ignore]
-async fn discards_excess_settle_and_solve_requests() {
+async fn settle_queue_capacity_is_respected() {
     let test = Arc::new(
         tests::setup()
             .allow_multiple_solve_requests()
@@ -173,196 +179,28 @@ async fn discards_excess_settle_and_solve_requests() {
 
     let unique_solutions_count = solution_ids.iter().unique().count();
     assert_eq!(unique_solutions_count, solution_ids.len());
-
-    // Disable auto mining to accumulate all the settlement requests.
-    test.set_auto_mining(false).await;
-
-    // To avoid race conditions with the settlement queue processing, a
-    // `/settle` request needs to be sent first, so it is dequeued, and it's
-    // execution is paused before any subsequent request is received.
-    let test_clone = Arc::clone(&test);
-    let first_solution_id = solution_ids[0];
-    let first_settlement_fut =
-        tokio::spawn(async move { test_clone.settle(first_solution_id).await });
-    // Make sure the first settlement gets dequeued before sending the remaining
-    // requests.
-    tokio::time::sleep(Duration::from_millis(100)).await;
-    let remaining_solutions = solution_ids[1..].to_vec();
-    let remaining_settlements = {
-        let test_clone = Arc::clone(&test);
-        remaining_solutions.into_iter().map(move |id| {
-            let test_clone = Arc::clone(&test_clone);
-            async move { test_clone.settle(id).await }
-        })
-    };
-    let remaining_settlements_fut = tokio::spawn(join_all(remaining_settlements));
-
-    // Sleep for a bit to make sure all the settlement requests are queued.
-    tokio::time::sleep(Duration::from_millis(500)).await;
-
-    // While there is no room in the settlement queue, `/solve` requests must be
-    // rejected.
-    test.solve().await.err().kind("TooManyPendingSettlements");
-
-    // Enable auto mining to process all the settlement requests.
-    // *Note that processing the settlement requests will change the gas estimates!*
-    test.set_auto_mining(true).await;
-
-    // The first settlement must be successful.
-    let first_settlement = first_settlement_fut.await.unwrap();
-    first_settlement.ok().await.ab_order_executed(&test).await;
-
-    let remaining_settlements = remaining_settlements_fut.await.unwrap();
-    assert_eq!(remaining_settlements.len(), 4);
-
-    for (idx, result) in remaining_settlements.into_iter().enumerate() {
-        match idx {
-            // The next 2 settlements failed to submit due to the framework's limitation(unable to
-            // fulfill the same order again).
-            0 | 1 => result.err().kind("FailedToSubmit"),
-            // All the subsequent settlements rejected due to the settlement queue being full.
-            2 | 3 => result.err().kind("TooManyPendingSettlements"),
-            _ => unreachable!(),
-        }
-    }
-
-    // `/solve` works again.
-    test.solve().await.ok();
-}
-
-#[tokio::test]
-#[ignore]
-async fn accepts_new_settle_requests_after_timeout() {
-    let test = Arc::new(
-        tests::setup()
-            .allow_multiple_solve_requests()
-            .pool(ab_pool())
-            .order(ab_order())
-            .solution(ab_solution())
-            .settle_submission_deadline(6)
-            .done()
-            .await,
-    );
-
-    // MAX_SOLUTION_STORAGE = 5. Since this is hardcoded, no more solutions can be
-    // stored.
-    let solution_ids = join_all(vec![
-        test.solve(),
-        test.solve(),
-        test.solve(),
-        test.solve(),
-        test.solve(),
-    ])
-    .await
-    .into_iter()
-    .map(|res| res.ok().id())
-    .collect::<Vec<_>>();
-
-    let unique_solutions_count = solution_ids.iter().unique().count();
-    assert_eq!(unique_solutions_count, solution_ids.len());
-
-    // Disable auto mining to accumulate all the settlement requests.
-    test.set_auto_mining(false).await;
-
-    // To avoid race conditions with the settlement queue processing, a
-    // `/settle` request needs to be sent first, so it is dequeued, and it's
-    // execution is paused before any subsequent request is received.
-    let test_clone = Arc::clone(&test);
-    let first_solution_id = solution_ids[0];
-    let first_settlement_fut =
-        tokio::spawn(async move { test_clone.settle(first_solution_id).await });
-    // Make sure the first settlement gets dequeued before sending the remaining
-    // requests.
-    tokio::time::sleep(Duration::from_millis(100)).await;
-    // Send only 3 more settle requests.
-    let additional_solutions = solution_ids[1..4].to_vec();
-    let additional_settlements = {
-        let test_clone = Arc::clone(&test);
-        additional_solutions.into_iter().map(move |id| {
-            let test_clone = Arc::clone(&test_clone);
-            async move { test_clone.settle(id).await }
-        })
-    };
-    let additional_settlements_fut = tokio::spawn(join_all(additional_settlements));
-
-    // Sleep for a bit to make sure all the settlement requests are queued.
-    tokio::time::sleep(Duration::from_millis(500)).await;
-    test.set_auto_mining(true).await;
-
-    let first_settlement = first_settlement_fut.await.unwrap();
-    // The first settlement must be successful.
-    first_settlement.ok().await.ab_order_executed(&test).await;
-
-    let additional_settlements = additional_settlements_fut.await.unwrap();
-    assert_eq!(additional_settlements.len(), 3);
-
-    for (idx, result) in additional_settlements.into_iter().enumerate() {
-        match idx {
-            // The next 2 settlements failed to submit due to the framework's limitation(unable to
-            // fulfill the same order again).
-            0 | 1 => result.err().kind("FailedToSubmit"),
-            // The next request gets rejected due to the settlement queue being full.
-            2 => result.err().kind("TooManyPendingSettlements"),
-            _ => unreachable!(),
-        }
-    }
-
-    // Now we send the last settlement request. It fails due to the framework's
-    // limitation(unable to fulfill the same order again).
-    test.settle(solution_ids[4])
-        .await
-        .err()
-        .kind("FailedToSubmit");
-}
-
-/// Verifies that the admission semaphore correctly limits in-flight settle
-/// requests to `pool_slots + settle_queue_size` (default 1 + 2 = 3).
-#[tokio::test]
-#[ignore]
-async fn admission_capacity_is_respected() {
-    let test = Arc::new(
-        tests::setup()
-            .allow_multiple_solve_requests()
-            .pool(ab_pool())
-            .order(ab_order())
-            .solution(ab_solution())
-            .settle_submission_deadline(6)
-            .done()
-            .await,
-    );
-
-    let solution_ids = join_all(vec![
-        test.solve(),
-        test.solve(),
-        test.solve(),
-        test.solve(),
-        test.solve(),
-    ])
-    .await
-    .into_iter()
-    .map(|res| res.ok().id())
-    .collect::<Vec<_>>();
 
     // Disable auto mining so settlements block on confirmation.
     test.set_auto_mining(false).await;
 
-    let settle_futs: Vec<_> = solution_ids
-        .iter()
-        .map(|&id| {
-            let test_clone = Arc::clone(&test);
-            tokio::spawn(async move { test_clone.settle(id).await })
-        })
-        .collect();
+    // Send settle requests one at a time so admission is deterministic.
+    // Admission capacity = 1 (pool slot) + 2 (settle_queue_size) = 3.
+    let mut settle_futs = Vec::new();
+    for &id in &solution_ids {
+        let test_clone = Arc::clone(&test);
+        settle_futs.push(tokio::spawn(async move { test_clone.settle(id).await }));
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
 
     // Wait for all requests to be either in-flight or rejected.
     tokio::time::sleep(Duration::from_millis(200)).await;
 
-    // Admission capacity = 1 (pool slot) + 2 (settle_queue_size) = 3.
-    // The first 3 settle calls should be admitted; the solve endpoint must
-    // reject while capacity is exhausted.
+    // While all admission slots are taken, /solve requests must be rejected.
     test.solve().await.err().kind("TooManyPendingSettlements");
 
-    // Enable auto mining so the in-flight settlements complete.
+    // Enable auto mining to process all the settlement requests.
+    // *Note that processing the settlement requests will change the gas
+    // estimates!*
     test.set_auto_mining(true).await;
 
     let results: Vec<_> = join_all(settle_futs)
@@ -371,23 +209,27 @@ async fn admission_capacity_is_respected() {
         .map(|r| r.unwrap())
         .collect();
 
-    let mut admitted = 0;
-    let mut rejected = 0;
-    for result in &results {
-        match result.error_kind().as_deref() {
-            None | Some("FailedToSubmit") => admitted += 1,
-            Some("TooManyPendingSettlements") => rejected += 1,
-            Some(other) => panic!("unexpected error kind: {other}"),
+    let mut results = results.into_iter();
+
+    // The first settle should succeed on-chain.
+    results
+        .next()
+        .unwrap()
+        .ok()
+        .await
+        .ab_order_executed(&test)
+        .await;
+
+    for (idx, result) in results.enumerate() {
+        match idx {
+            // Admitted but can't fulfill the same order again.
+            0 | 1 => result.err().kind("FailedToSubmit"),
+            // Rejected by the admission semaphore.
+            2 | 3 => result.err().kind("TooManyPendingSettlements"),
+            _ => unreachable!(),
         }
     }
 
-    // Exactly 3 admitted (1 slot + 2 buffer), 2 rejected.
-    assert_eq!(
-        admitted, 3,
-        "expected 3 admitted (pool slot + settle queue)"
-    );
-    assert_eq!(rejected, 2, "expected 2 rejected");
-
-    // Capacity is restored after settlements complete.
+    // Capacity is restored — /solve works again.
     test.solve().await.ok();
 }

--- a/crates/driver/src/tests/cases/settle.rs
+++ b/crates/driver/src/tests/cases/settle.rs
@@ -231,6 +231,8 @@ async fn settle_queue_capacity_is_respected() {
         }
     }
 
-    // Capacity is restored — /solve works again.
-    test.solve().await.ok();
+    // Capacity is restored — new solve and settle work again (settle fails
+    // on-chain because the order is already fulfilled, but it's admitted).
+    let id = test.solve().await.ok().id();
+    test.settle(id).await.err().kind("FailedToSubmit");
 }

--- a/crates/driver/src/tests/cases/settle.rs
+++ b/crates/driver/src/tests/cases/settle.rs
@@ -314,3 +314,80 @@ async fn accepts_new_settle_requests_after_timeout() {
         .err()
         .kind("FailedToSubmit");
 }
+
+/// Verifies that the admission semaphore correctly limits in-flight settle
+/// requests to `pool_slots + settle_queue_size` (default 1 + 2 = 3).
+#[tokio::test]
+#[ignore]
+async fn admission_capacity_is_respected() {
+    let test = Arc::new(
+        tests::setup()
+            .allow_multiple_solve_requests()
+            .pool(ab_pool())
+            .order(ab_order())
+            .solution(ab_solution())
+            .settle_submission_deadline(6)
+            .done()
+            .await,
+    );
+
+    let solution_ids = join_all(vec![
+        test.solve(),
+        test.solve(),
+        test.solve(),
+        test.solve(),
+        test.solve(),
+    ])
+    .await
+    .into_iter()
+    .map(|res| res.ok().id())
+    .collect::<Vec<_>>();
+
+    // Disable auto mining so settlements block on confirmation.
+    test.set_auto_mining(false).await;
+
+    let settle_futs: Vec<_> = solution_ids
+        .iter()
+        .map(|&id| {
+            let test_clone = Arc::clone(&test);
+            tokio::spawn(async move { test_clone.settle(id).await })
+        })
+        .collect();
+
+    // Wait for all requests to be either in-flight or rejected.
+    tokio::time::sleep(Duration::from_millis(200)).await;
+
+    // Admission capacity = 1 (pool slot) + 2 (settle_queue_size) = 3.
+    // The first 3 settle calls should be admitted; the solve endpoint must
+    // reject while capacity is exhausted.
+    test.solve().await.err().kind("TooManyPendingSettlements");
+
+    // Enable auto mining so the in-flight settlements complete.
+    test.set_auto_mining(true).await;
+
+    let results: Vec<_> = join_all(settle_futs)
+        .await
+        .into_iter()
+        .map(|r| r.unwrap())
+        .collect();
+
+    let mut admitted = 0;
+    let mut rejected = 0;
+    for result in &results {
+        match result.error_kind().as_deref() {
+            None | Some("FailedToSubmit") => admitted += 1,
+            Some("TooManyPendingSettlements") => rejected += 1,
+            Some(other) => panic!("unexpected error kind: {other}"),
+        }
+    }
+
+    // Exactly 3 admitted (1 slot + 2 buffer), 2 rejected.
+    assert_eq!(
+        admitted, 3,
+        "expected 3 admitted (pool slot + settle queue)"
+    );
+    assert_eq!(rejected, 2, "expected 2 rejected");
+
+    // Capacity is restored after settlements complete.
+    test.solve().await.ok();
+}

--- a/crates/driver/src/tests/cases/settle.rs
+++ b/crates/driver/src/tests/cases/settle.rs
@@ -163,8 +163,9 @@ async fn settle_queue_capacity_is_respected() {
             .await,
     );
 
-    // MAX_SOLUTION_STORAGE = 5. Since this is hardcoded, no more solutions can be
-    // stored.
+    // Admission permits are only consumed by /settle, not /solve, so we can
+    // generate as many bids as we want. MAX_SOLUTION_STORAGE = 5 is the only
+    // cap here.
     let solution_ids = join_all(vec![
         test.solve(),
         test.solve(),

--- a/crates/driver/src/tests/cases/settle.rs
+++ b/crates/driver/src/tests/cases/settle.rs
@@ -231,8 +231,11 @@ async fn settle_queue_capacity_is_respected() {
         }
     }
 
-    // Capacity is restored — new solve and settle work again (settle fails
-    // on-chain because the order is already fulfilled, but it's admitted).
-    let id = test.solve().await.ok().id();
-    test.settle(id).await.err().kind("FailedToSubmit");
+    // Capacity is restored — settle works again. Use an existing solution ID
+    // (it was already removed from cache by the first settle, so this returns
+    // SolutionNotAvailable — but it proves admission doesn't reject).
+    test.settle(solution_ids[0])
+        .await
+        .err()
+        .kind("SolutionNotAvailable");
 }

--- a/crates/driver/src/tests/setup/mod.rs
+++ b/crates/driver/src/tests/setup/mod.rs
@@ -1694,6 +1694,18 @@ pub struct SettleErr {
 }
 
 impl Settle {
+    /// Returns the error kind string if this is an error response, or `None`
+    /// if the settlement succeeded.
+    pub fn error_kind(&self) -> Option<String> {
+        match &self.status {
+            SettleStatus::Ok => None,
+            SettleStatus::Err { body, .. } => {
+                let parsed: serde_json::Value = serde_json::from_str(body).unwrap();
+                Some(parsed["kind"].as_str().unwrap().to_string())
+            }
+        }
+    }
+
     /// Expect the /settle endpoint to have returned a 200 OK response.
     pub async fn ok(self) -> SettleOk {
         // Ensure that the response is OK.

--- a/crates/driver/src/tests/setup/mod.rs
+++ b/crates/driver/src/tests/setup/mod.rs
@@ -1694,18 +1694,6 @@ pub struct SettleErr {
 }
 
 impl Settle {
-    /// Returns the error kind string if this is an error response, or `None`
-    /// if the settlement succeeded.
-    pub fn error_kind(&self) -> Option<String> {
-        match &self.status {
-            SettleStatus::Ok => None,
-            SettleStatus::Err { body, .. } => {
-                let parsed: serde_json::Value = serde_json::from_str(body).unwrap();
-                Some(parsed["kind"].as_str().unwrap().to_string())
-            }
-        }
-    }
-
     /// Expect the /settle endpoint to have returned a 200 OK response.
     pub async fn ok(self) -> SettleOk {
         // Ensure that the response is OK.


### PR DESCRIPTION
# Description

The reference driver rejects new solutions when there is already a backlog of solutions that still need to be submitted because they will most likely not be mined in time. This is intended to protect very competitive solvers from penalties when they win too much but can't submit fast enough.
https://github.com/cowprotocol/services/pull/4167 introduced a bug where the check whether to reject the `/solve` request only looks at the available tx submission slots but not the settle queue.
This has the consequence that a solver with only a single submission EOA that won an auction will reject `/solve` requests until the previous solution was submitted.

# Changes

Add a semaphore with capacity equal to queue size to mimic missing queue behavior. 


