### PR TITLE
Use a common prefix for internal endpoints

### DIFF
--- a/.claude/commands/debug-order.md
+++ b/.claude/commands/debug-order.md
@@ -10,7 +10,7 @@ Key steps:
 1. Parse the order UID and network from arguments (default: mainnet)
 2. **Start with the debug endpoint** — fetch the comprehensive debug report first:
    ```bash
-   source .env.claude && curl -s -H "X-API-Key: $COW_DEBUG_API_KEY" "https://partners.cow.fi/$NETWORK/api/v1/debug/order/$ORDER_UID" | jq .
+   source .env.claude && curl -s -H "X-API-Key: $COW_DEBUG_API_KEY" "https://partners.cow.fi/$NETWORK/api/internal/v1/debug/order/$ORDER_UID" | jq .
    ```
    This returns order details, lifecycle events, auction participation, proposed solutions, executions, trades, and settlement attempts — all in one call.
 3. Analyze the debug report — key event meanings:

--- a/.claude/commands/debug-order.md
+++ b/.claude/commands/debug-order.md
@@ -10,7 +10,7 @@ Key steps:
 1. Parse the order UID and network from arguments (default: mainnet)
 2. **Start with the debug endpoint** — fetch the comprehensive debug report first:
    ```bash
-   source .env.claude && curl -s -H "X-API-Key: $COW_DEBUG_API_KEY" "https://partners.cow.fi/$NETWORK/api/internal/v1/debug/order/$ORDER_UID" | jq .
+   source .env.claude && curl -s -H "X-API-Key: $COW_DEBUG_API_KEY" "https://partners.cow.fi/$NETWORK/restricted/api/v1/debug/order/$ORDER_UID" | jq .
    ```
    This returns order details, lifecycle events, auction participation, proposed solutions, executions, trades, and settlement attempts — all in one call.
 3. Analyze the debug report — key event meanings:

--- a/crates/e2e/tests/e2e/debug_order.rs
+++ b/crates/e2e/tests/e2e/debug_order.rs
@@ -88,7 +88,7 @@ async fn debug_order(web3: Web3) {
     // Helper to fetch the debug report.
     let fetch_debug_report = || async {
         let response = client
-            .get(format!("{API_HOST}/api/internal/v1/debug/order/{uid}"))
+            .get(format!("{API_HOST}/restricted/api/v1/debug/order/{uid}"))
             .send()
             .await
             .unwrap();
@@ -151,7 +151,9 @@ async fn debug_order(web3: Web3) {
     // Non-existent order -> 404.
     let fake_uid = "0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef";
     let response = client
-        .get(format!("{API_HOST}/api/internal/v1/debug/order/{fake_uid}"))
+        .get(format!(
+            "{API_HOST}/restricted/api/v1/debug/order/{fake_uid}"
+        ))
         .send()
         .await
         .unwrap();
@@ -232,7 +234,7 @@ async fn debug_order_filter_reason(web3: Web3) {
     let has_invalid_event = || async {
         onchain.mint_block().await;
         let response = client
-            .get(format!("{API_HOST}/api/internal/v1/debug/order/{uid}"))
+            .get(format!("{API_HOST}/restricted/api/v1/debug/order/{uid}"))
             .send()
             .await
             .unwrap();
@@ -247,7 +249,7 @@ async fn debug_order_filter_reason(web3: Web3) {
         .unwrap();
 
     let response = client
-        .get(format!("{API_HOST}/api/internal/v1/debug/order/{uid}"))
+        .get(format!("{API_HOST}/restricted/api/v1/debug/order/{uid}"))
         .send()
         .await
         .unwrap();

--- a/crates/e2e/tests/e2e/debug_order.rs
+++ b/crates/e2e/tests/e2e/debug_order.rs
@@ -88,7 +88,7 @@ async fn debug_order(web3: Web3) {
     // Helper to fetch the debug report.
     let fetch_debug_report = || async {
         let response = client
-            .get(format!("{API_HOST}/api/v1/debug/order/{uid}"))
+            .get(format!("{API_HOST}/api/internal/v1/debug/order/{uid}"))
             .send()
             .await
             .unwrap();
@@ -151,7 +151,7 @@ async fn debug_order(web3: Web3) {
     // Non-existent order -> 404.
     let fake_uid = "0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef";
     let response = client
-        .get(format!("{API_HOST}/api/v1/debug/order/{fake_uid}"))
+        .get(format!("{API_HOST}/api/internal/v1/debug/order/{fake_uid}"))
         .send()
         .await
         .unwrap();
@@ -232,7 +232,7 @@ async fn debug_order_filter_reason(web3: Web3) {
     let has_invalid_event = || async {
         onchain.mint_block().await;
         let response = client
-            .get(format!("{API_HOST}/api/v1/debug/order/{uid}"))
+            .get(format!("{API_HOST}/api/internal/v1/debug/order/{uid}"))
             .send()
             .await
             .unwrap();
@@ -247,7 +247,7 @@ async fn debug_order_filter_reason(web3: Web3) {
         .unwrap();
 
     let response = client
-        .get(format!("{API_HOST}/api/v1/debug/order/{uid}"))
+        .get(format!("{API_HOST}/api/internal/v1/debug/order/{uid}"))
         .send()
         .await
         .unwrap();

--- a/crates/e2e/tests/e2e/malformed_requests.rs
+++ b/crates/e2e/tests/e2e/malformed_requests.rs
@@ -347,7 +347,9 @@ async fn http_validation(web3: Web3) {
 
     // Malformed UID → 400
     let response = client
-        .get(format!("{API_HOST}/api/internal/v1/debug/simulation/bad_uid"))
+        .get(format!(
+            "{API_HOST}/api/internal/v1/debug/simulation/bad_uid"
+        ))
         .send()
         .await
         .unwrap();

--- a/crates/e2e/tests/e2e/malformed_requests.rs
+++ b/crates/e2e/tests/e2e/malformed_requests.rs
@@ -343,11 +343,11 @@ async fn http_validation(web3: Web3) {
 
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
 
-    // GET /api/v1/debug/simulation/{uid} error cases
+    // GET /api/internal/v1/debug/simulation/{uid} error cases
 
     // Malformed UID → 400
     let response = client
-        .get(format!("{API_HOST}/api/v1/debug/simulation/bad_uid"))
+        .get(format!("{API_HOST}/api/internal/v1/debug/simulation/bad_uid"))
         .send()
         .await
         .unwrap();
@@ -360,7 +360,7 @@ async fn http_validation(web3: Web3) {
     // Valid UID but order not found → 404
     let response = client
         .get(format!(
-            "{API_HOST}/api/v1/debug/simulation/{VALID_ORDER_UID}"
+            "{API_HOST}/api/internal/v1/debug/simulation/{VALID_ORDER_UID}"
         ))
         .send()
         .await
@@ -377,7 +377,7 @@ async fn http_validation(web3: Web3) {
     // Invalid block_number query param → 400
     let response = client
         .get(format!(
-            "{API_HOST}/api/v1/debug/simulation/{VALID_ORDER_UID}?block_number=notanumber"
+            "{API_HOST}/api/internal/v1/debug/simulation/{VALID_ORDER_UID}?block_number=notanumber"
         ))
         .send()
         .await
@@ -388,11 +388,11 @@ async fn http_validation(web3: Web3) {
         "non-numeric block_number should return 400"
     );
 
-    // POST /api/v1/debug/simulation error cases
+    // POST /api/internal/v1/debug/simulation error cases
 
     // Invalid JSON body → 400
     let response = client
-        .post(format!("{API_HOST}/api/v1/debug/simulation"))
+        .post(format!("{API_HOST}/api/internal/v1/debug/simulation"))
         .header("Content-Type", "application/json")
         .body("{invalid json}")
         .send()
@@ -406,7 +406,7 @@ async fn http_validation(web3: Web3) {
 
     // Missing required fields → 422
     let response = client
-        .post(format!("{API_HOST}/api/v1/debug/simulation"))
+        .post(format!("{API_HOST}/api/internal/v1/debug/simulation"))
         .json(&json!({}))
         .send()
         .await
@@ -419,7 +419,7 @@ async fn http_validation(web3: Web3) {
 
     // Invalid field type (bad address) → 422
     let response = client
-        .post(format!("{API_HOST}/api/v1/debug/simulation"))
+        .post(format!("{API_HOST}/api/internal/v1/debug/simulation"))
         .json(&json!({
             "sellToken": "not-an-address",
             "buyToken": VALID_ADDRESS,
@@ -439,7 +439,7 @@ async fn http_validation(web3: Web3) {
 
     // Zero sellAmount (NonZeroU256 rejects zero at deserialization) → 422
     let response = client
-        .post(format!("{API_HOST}/api/v1/debug/simulation"))
+        .post(format!("{API_HOST}/api/internal/v1/debug/simulation"))
         .json(&json!({
             "sellToken": VALID_ADDRESS,
             "buyToken": VALID_ADDRESS,
@@ -459,7 +459,7 @@ async fn http_validation(web3: Web3) {
 
     // Invalid kind enum value → 422
     let response = client
-        .post(format!("{API_HOST}/api/v1/debug/simulation"))
+        .post(format!("{API_HOST}/api/internal/v1/debug/simulation"))
         .json(&json!({
             "sellToken": VALID_ADDRESS,
             "buyToken": VALID_ADDRESS,
@@ -480,7 +480,7 @@ async fn http_validation(web3: Web3) {
     // Invalid appData (non-JSON string triggers MalformedInput) → 400
     let bad_app_data = "not valid json";
     let response = client
-        .post(format!("{API_HOST}/api/v1/debug/simulation"))
+        .post(format!("{API_HOST}/api/internal/v1/debug/simulation"))
         .json(&json!({
             "sellToken": VALID_ADDRESS,
             "buyToken": VALID_ADDRESS,
@@ -539,7 +539,7 @@ async fn simulation_not_enabled(web3: Web3) {
     // GET → 405 when simulation is not enabled
     let response = client
         .get(format!(
-            "{API_HOST}/api/v1/debug/simulation/{VALID_ORDER_UID}"
+            "{API_HOST}/api/internal/v1/debug/simulation/{VALID_ORDER_UID}"
         ))
         .send()
         .await
@@ -552,7 +552,7 @@ async fn simulation_not_enabled(web3: Web3) {
 
     // POST → 405 when simulation is not enabled
     let response = client
-        .post(format!("{API_HOST}/api/v1/debug/simulation"))
+        .post(format!("{API_HOST}/api/internal/v1/debug/simulation"))
         .json(&json!({
             "sellToken": VALID_ADDRESS,
             "buyToken": VALID_ADDRESS,

--- a/crates/e2e/tests/e2e/malformed_requests.rs
+++ b/crates/e2e/tests/e2e/malformed_requests.rs
@@ -343,12 +343,12 @@ async fn http_validation(web3: Web3) {
 
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
 
-    // GET /api/internal/v1/debug/simulation/{uid} error cases
+    // GET /restricted/api/v1/debug/simulation/{uid} error cases
 
     // Malformed UID → 400
     let response = client
         .get(format!(
-            "{API_HOST}/api/internal/v1/debug/simulation/bad_uid"
+            "{API_HOST}/restricted/api/v1/debug/simulation/bad_uid"
         ))
         .send()
         .await
@@ -362,7 +362,7 @@ async fn http_validation(web3: Web3) {
     // Valid UID but order not found → 404
     let response = client
         .get(format!(
-            "{API_HOST}/api/internal/v1/debug/simulation/{VALID_ORDER_UID}"
+            "{API_HOST}/restricted/api/v1/debug/simulation/{VALID_ORDER_UID}"
         ))
         .send()
         .await
@@ -379,7 +379,8 @@ async fn http_validation(web3: Web3) {
     // Invalid block_number query param → 400
     let response = client
         .get(format!(
-            "{API_HOST}/api/internal/v1/debug/simulation/{VALID_ORDER_UID}?block_number=notanumber"
+            "{API_HOST}/restricted/api/v1/debug/simulation/{VALID_ORDER_UID}?\
+             block_number=notanumber"
         ))
         .send()
         .await
@@ -390,11 +391,11 @@ async fn http_validation(web3: Web3) {
         "non-numeric block_number should return 400"
     );
 
-    // POST /api/internal/v1/debug/simulation error cases
+    // POST /restricted/api/v1/debug/simulation error cases
 
     // Invalid JSON body → 400
     let response = client
-        .post(format!("{API_HOST}/api/internal/v1/debug/simulation"))
+        .post(format!("{API_HOST}/restricted/api/v1/debug/simulation"))
         .header("Content-Type", "application/json")
         .body("{invalid json}")
         .send()
@@ -408,7 +409,7 @@ async fn http_validation(web3: Web3) {
 
     // Missing required fields → 422
     let response = client
-        .post(format!("{API_HOST}/api/internal/v1/debug/simulation"))
+        .post(format!("{API_HOST}/restricted/api/v1/debug/simulation"))
         .json(&json!({}))
         .send()
         .await
@@ -421,7 +422,7 @@ async fn http_validation(web3: Web3) {
 
     // Invalid field type (bad address) → 422
     let response = client
-        .post(format!("{API_HOST}/api/internal/v1/debug/simulation"))
+        .post(format!("{API_HOST}/restricted/api/v1/debug/simulation"))
         .json(&json!({
             "sellToken": "not-an-address",
             "buyToken": VALID_ADDRESS,
@@ -441,7 +442,7 @@ async fn http_validation(web3: Web3) {
 
     // Zero sellAmount (NonZeroU256 rejects zero at deserialization) → 422
     let response = client
-        .post(format!("{API_HOST}/api/internal/v1/debug/simulation"))
+        .post(format!("{API_HOST}/restricted/api/v1/debug/simulation"))
         .json(&json!({
             "sellToken": VALID_ADDRESS,
             "buyToken": VALID_ADDRESS,
@@ -461,7 +462,7 @@ async fn http_validation(web3: Web3) {
 
     // Invalid kind enum value → 422
     let response = client
-        .post(format!("{API_HOST}/api/internal/v1/debug/simulation"))
+        .post(format!("{API_HOST}/restricted/api/v1/debug/simulation"))
         .json(&json!({
             "sellToken": VALID_ADDRESS,
             "buyToken": VALID_ADDRESS,
@@ -482,7 +483,7 @@ async fn http_validation(web3: Web3) {
     // Invalid appData (non-JSON string triggers MalformedInput) → 400
     let bad_app_data = "not valid json";
     let response = client
-        .post(format!("{API_HOST}/api/internal/v1/debug/simulation"))
+        .post(format!("{API_HOST}/restricted/api/v1/debug/simulation"))
         .json(&json!({
             "sellToken": VALID_ADDRESS,
             "buyToken": VALID_ADDRESS,
@@ -541,7 +542,7 @@ async fn simulation_not_enabled(web3: Web3) {
     // GET → 405 when simulation is not enabled
     let response = client
         .get(format!(
-            "{API_HOST}/api/internal/v1/debug/simulation/{VALID_ORDER_UID}"
+            "{API_HOST}/restricted/api/v1/debug/simulation/{VALID_ORDER_UID}"
         ))
         .send()
         .await
@@ -554,7 +555,7 @@ async fn simulation_not_enabled(web3: Web3) {
 
     // POST → 405 when simulation is not enabled
     let response = client
-        .post(format!("{API_HOST}/api/internal/v1/debug/simulation"))
+        .post(format!("{API_HOST}/restricted/api/v1/debug/simulation"))
         .json(&json!({
             "sellToken": VALID_ADDRESS,
             "buyToken": VALID_ADDRESS,

--- a/crates/e2e/tests/e2e/order_simulation.rs
+++ b/crates/e2e/tests/e2e/order_simulation.rs
@@ -63,7 +63,7 @@ async fn custom_order_simulation(web3: Web3) {
 
     // Trader has no sell tokens — simulation should revert.
     let response = client
-        .post(format!("{API_HOST}/api/v1/debug/simulation"))
+        .post(format!("{API_HOST}/api/internal/v1/debug/simulation"))
         .json(&request)
         .send()
         .await
@@ -87,7 +87,7 @@ async fn custom_order_simulation(web3: Web3) {
 
     // Simulation should now succeed.
     let response = client
-        .post(format!("{API_HOST}/api/v1/debug/simulation"))
+        .post(format!("{API_HOST}/api/internal/v1/debug/simulation"))
         .json(&request)
         .send()
         .await
@@ -183,7 +183,7 @@ async fn order_simulation(web3: Web3) {
     // Simulation at the block where the trader had no WETH must fail.
     let response = client
         .get(format!(
-            "{API_HOST}/api/v1/debug/simulation/{uid}?block_number={block_no_funds}"
+            "{API_HOST}/api/internal/v1/debug/simulation/{uid}?block_number={block_no_funds}"
         ))
         .send()
         .await
@@ -199,7 +199,7 @@ async fn order_simulation(web3: Web3) {
     // Simulation at the block where the trader has WETH must succeed.
     let response = client
         .get(format!(
-            "{API_HOST}/api/v1/debug/simulation/{uid}?block_number={block_with_funds}"
+            "{API_HOST}/api/internal/v1/debug/simulation/{uid}?block_number={block_with_funds}"
         ))
         .send()
         .await
@@ -215,7 +215,7 @@ async fn order_simulation(web3: Web3) {
     // Simulation at the latest block (block_number parameter omitted), must
     // succeed.
     let response = client
-        .get(format!("{API_HOST}/api/v1/debug/simulation/{uid}"))
+        .get(format!("{API_HOST}/api/internal/v1/debug/simulation/{uid}"))
         .send()
         .await
         .unwrap();
@@ -313,7 +313,7 @@ async fn order_simulation_partial_fill(web3: Web3) {
 
     // filledAmount=0 on-chain; full 4 WETH needed; trader only has 1 → must fail.
     let response = client
-        .get(format!("{API_HOST}/api/v1/debug/simulation/{uid}"))
+        .get(format!("{API_HOST}/api/internal/v1/debug/simulation/{uid}"))
         .send()
         .await
         .unwrap();
@@ -356,7 +356,7 @@ async fn order_simulation_partial_fill(web3: Web3) {
     // Without reading on-chain fill state the simulator would need the full
     // 4 WETH from the trader (who only holds ~2) and revert.
     let response = client
-        .get(format!("{API_HOST}/api/v1/debug/simulation/{uid}"))
+        .get(format!("{API_HOST}/api/internal/v1/debug/simulation/{uid}"))
         .send()
         .await
         .unwrap();

--- a/crates/e2e/tests/e2e/order_simulation.rs
+++ b/crates/e2e/tests/e2e/order_simulation.rs
@@ -63,7 +63,7 @@ async fn custom_order_simulation(web3: Web3) {
 
     // Trader has no sell tokens — simulation should revert.
     let response = client
-        .post(format!("{API_HOST}/api/internal/v1/debug/simulation"))
+        .post(format!("{API_HOST}/restricted/api/v1/debug/simulation"))
         .json(&request)
         .send()
         .await
@@ -87,7 +87,7 @@ async fn custom_order_simulation(web3: Web3) {
 
     // Simulation should now succeed.
     let response = client
-        .post(format!("{API_HOST}/api/internal/v1/debug/simulation"))
+        .post(format!("{API_HOST}/restricted/api/v1/debug/simulation"))
         .json(&request)
         .send()
         .await
@@ -183,7 +183,7 @@ async fn order_simulation(web3: Web3) {
     // Simulation at the block where the trader had no WETH must fail.
     let response = client
         .get(format!(
-            "{API_HOST}/api/internal/v1/debug/simulation/{uid}?block_number={block_no_funds}"
+            "{API_HOST}/restricted/api/v1/debug/simulation/{uid}?block_number={block_no_funds}"
         ))
         .send()
         .await
@@ -199,7 +199,7 @@ async fn order_simulation(web3: Web3) {
     // Simulation at the block where the trader has WETH must succeed.
     let response = client
         .get(format!(
-            "{API_HOST}/api/internal/v1/debug/simulation/{uid}?block_number={block_with_funds}"
+            "{API_HOST}/restricted/api/v1/debug/simulation/{uid}?block_number={block_with_funds}"
         ))
         .send()
         .await
@@ -215,7 +215,9 @@ async fn order_simulation(web3: Web3) {
     // Simulation at the latest block (block_number parameter omitted), must
     // succeed.
     let response = client
-        .get(format!("{API_HOST}/api/internal/v1/debug/simulation/{uid}"))
+        .get(format!(
+            "{API_HOST}/restricted/api/v1/debug/simulation/{uid}"
+        ))
         .send()
         .await
         .unwrap();
@@ -313,7 +315,9 @@ async fn order_simulation_partial_fill(web3: Web3) {
 
     // filledAmount=0 on-chain; full 4 WETH needed; trader only has 1 → must fail.
     let response = client
-        .get(format!("{API_HOST}/api/internal/v1/debug/simulation/{uid}"))
+        .get(format!(
+            "{API_HOST}/restricted/api/v1/debug/simulation/{uid}"
+        ))
         .send()
         .await
         .unwrap();
@@ -356,7 +360,9 @@ async fn order_simulation_partial_fill(web3: Web3) {
     // Without reading on-chain fill state the simulator would need the full
     // 4 WETH from the trader (who only holds ~2) and revert.
     let response = client
-        .get(format!("{API_HOST}/api/internal/v1/debug/simulation/{uid}"))
+        .get(format!(
+            "{API_HOST}/restricted/api/v1/debug/simulation/{uid}"
+        ))
         .send()
         .await
         .unwrap();

--- a/crates/orderbook/openapi.yml
+++ b/crates/orderbook/openapi.yml
@@ -765,7 +765,7 @@ paths:
                 $ref: "#/components/schemas/TotalSurplus"
         "400":
           description: Invalid address.
-  "/api/v1/debug/simulation":
+  "/api/internal/v1/debug/simulation":
     post:
       operationId: debugSimulationPost
       summary: Simulate an arbitrary order.
@@ -797,7 +797,7 @@ paths:
             wrong field type, zero `sellAmount`, or unrecognised `kind` value.
         "500":
           description: Internal error.
-  "/api/v1/debug/simulation/{uid}":
+  "/api/internal/v1/debug/simulation/{uid}":
     get:
       operationId: debugSimulation
       summary: Get Tenderly simulation request for an order.
@@ -836,7 +836,7 @@ paths:
           description: Order simulation endpoint is not enabled.
         "500":
           description: Internal error.
-  "/api/v1/debug/order/{uid}":
+  "/api/internal/v1/debug/order/{uid}":
     get:
       operationId: debugOrder
       summary: Debug an order's lifecycle.

--- a/crates/orderbook/openapi.yml
+++ b/crates/orderbook/openapi.yml
@@ -765,7 +765,7 @@ paths:
                 $ref: "#/components/schemas/TotalSurplus"
         "400":
           description: Invalid address.
-  "/api/internal/v1/debug/simulation":
+  "/restricted/api/v1/debug/simulation":
     post:
       operationId: debugSimulationPost
       summary: Simulate an arbitrary order.
@@ -797,7 +797,7 @@ paths:
             wrong field type, zero `sellAmount`, or unrecognised `kind` value.
         "500":
           description: Internal error.
-  "/api/internal/v1/debug/simulation/{uid}":
+  "/restricted/api/v1/debug/simulation/{uid}":
     get:
       operationId: debugSimulation
       summary: Get Tenderly simulation request for an order.
@@ -836,7 +836,7 @@ paths:
           description: Order simulation endpoint is not enabled.
         "500":
           description: Internal error.
-  "/api/internal/v1/debug/order/{uid}":
+  "/restricted/api/v1/debug/order/{uid}":
     get:
       operationId: debugOrder
       summary: Debug an order's lifecycle.

--- a/crates/orderbook/src/api.rs
+++ b/crates/orderbook/src/api.rs
@@ -281,17 +281,17 @@ pub fn handle_all_routes(
         ("GET", "/api/v1/version", get(version::version_handler)),
         (
             "GET",
-            "/api/v1/debug/order/{uid}",
+            "/api/internal/v1/debug/order/{uid}",
             get(debug_order::debug_order_handler),
         ),
         (
             "GET",
-            "/api/v1/debug/simulation/{uid}",
+            "/api/internal/v1/debug/simulation/{uid}",
             get(debug_simulation::debug_simulation_handler),
         ),
         (
             "POST",
-            "/api/v1/debug/simulation",
+            "/api/internal/v1/debug/simulation",
             post(debug_simulation::debug_simulation_post_handler),
         ),
         // V2 routes

--- a/crates/orderbook/src/api.rs
+++ b/crates/orderbook/src/api.rs
@@ -279,19 +279,22 @@ pub fn handle_all_routes(
             get(get_total_surplus::get_total_surplus_handler),
         ),
         ("GET", "/api/v1/version", get(version::version_handler)),
+        // Routes under `/restricted/api/` are not exposed publicly. WAF and
+        // infra rules restrict access to authenticated partners.
+        // New internal-only endpoints MUST use this prefix.
         (
             "GET",
-            "/api/internal/v1/debug/order/{uid}",
+            "/restricted/api/v1/debug/order/{uid}",
             get(debug_order::debug_order_handler),
         ),
         (
             "GET",
-            "/api/internal/v1/debug/simulation/{uid}",
+            "/restricted/api/v1/debug/simulation/{uid}",
             get(debug_simulation::debug_simulation_handler),
         ),
         (
             "POST",
-            "/api/internal/v1/debug/simulation",
+            "/restricted/api/v1/debug/simulation",
             post(debug_simulation::debug_simulation_post_handler),
         ),
         // V2 routes

--- a/crates/orderbook/src/dto/mod.rs
+++ b/crates/orderbook/src/dto/mod.rs
@@ -15,7 +15,7 @@ pub use {
     order::Order,
 };
 
-/// Request body for the POST /api/internal/v1/debug/simulation endpoint.
+/// Request body for the POST /restricted/api/v1/debug/simulation endpoint.
 #[serde_as]
 #[derive(Serialize, Deserialize, Debug, Default)]
 #[serde(rename_all = "camelCase")]

--- a/crates/orderbook/src/dto/mod.rs
+++ b/crates/orderbook/src/dto/mod.rs
@@ -15,7 +15,7 @@ pub use {
     order::Order,
 };
 
-/// Request body for the POST /api/v1/debug/simulation endpoint.
+/// Request body for the POST /api/internal/v1/debug/simulation endpoint.
 #[serde_as]
 #[derive(Serialize, Deserialize, Debug, Default)]
 #[serde(rename_all = "camelCase")]


### PR DESCRIPTION
# Description

We now have a few endpoints that we don't want to expose to the public and every single one of them has a) a rule in WAF b) a rule on the infra level that exposes it to partners with an API key. 

Instead of setting these every time we create a new internal endpoint we can use the same rules for all endpoints with the `/api/internal` prefix. 

# How to test

Existing e2e tests.