### PR TITLE
Log appCode and from address in orderbook request_summary

### DIFF
--- a/crates/model/src/order.rs
+++ b/crates/model/src/order.rs
@@ -484,6 +484,24 @@ impl OrderCreationAppData {
             }
         }
     }
+
+    /// Returns the `appCode` field from the full app data JSON, if present.
+    /// Returns `None` when only the hash is provided, when parsing fails, or
+    /// when the field is absent.
+    pub fn app_code(&self) -> Option<String> {
+        #[derive(Deserialize)]
+        struct AppCodeOnly {
+            #[serde(rename = "appCode")]
+            app_code: Option<String>,
+        }
+        let full = match self {
+            Self::Hash { .. } => return None,
+            Self::Full { full } | Self::Both { full, .. } => full,
+        };
+        serde_json::from_str::<AppCodeOnly>(full)
+            .ok()
+            .and_then(|r| r.app_code)
+    }
 }
 
 #[derive(Debug)]
@@ -1070,6 +1088,36 @@ mod tests {
         serde_json::json,
         testlib::assert_json_matches,
     };
+
+    #[test]
+    fn app_code_is_extracted_from_full_app_data() {
+        let full = r#"{"appCode":"CoW Swap","metadata":{}}"#.to_string();
+        let app_data = OrderCreationAppData::Full { full };
+        assert_eq!(app_data.app_code().as_deref(), Some("CoW Swap"));
+    }
+
+    #[test]
+    fn app_code_is_none_for_hash_only() {
+        let app_data = OrderCreationAppData::Hash {
+            hash: AppDataHash([0; 32]),
+        };
+        assert_eq!(app_data.app_code(), None);
+    }
+
+    #[test]
+    fn app_code_is_none_when_field_absent() {
+        let full = r#"{"metadata":{}}"#.to_string();
+        let app_data = OrderCreationAppData::Full { full };
+        assert_eq!(app_data.app_code(), None);
+    }
+
+    #[test]
+    fn app_code_is_none_on_invalid_json() {
+        let app_data = OrderCreationAppData::Full {
+            full: "not json".to_string(),
+        };
+        assert_eq!(app_data.app_code(), None);
+    }
 
     #[test]
     fn deserialization_and_back() {

--- a/crates/orderbook/src/api.rs
+++ b/crates/orderbook/src/api.rs
@@ -71,6 +71,18 @@ pub struct AppState {
     pub quote_timeout: Duration,
 }
 
+/// Per-request metadata that handlers can attach to their response so the
+/// `summarize_request` middleware can include it in the structured log line.
+///
+/// Used by `post_quote` and `post_order` to surface the `appCode` (from
+/// `appData`) and the `from` address of the request. This lets us attribute
+/// traffic to specific integrators without resorting to WAF-layer inspection.
+#[derive(Clone, Default)]
+pub struct RequestMetadata {
+    pub app_code: Option<String>,
+    pub from: Option<String>,
+}
+
 async fn summarize_request(req: Request<axum::body::Body>, next: Next) -> Response {
     let method = req.method().to_string();
     let uri = req.uri().to_string();
@@ -86,10 +98,20 @@ async fn summarize_request(req: Request<axum::body::Body>, next: Next) -> Respon
     let response = next.run(req).await;
     let status = response.status().as_u16();
 
+    let meta = response
+        .extensions()
+        .get::<RequestMetadata>()
+        .cloned()
+        .unwrap_or_default();
+    let app_code = meta.app_code.as_deref().unwrap_or("unset");
+    let from = meta.from.as_deref().unwrap_or("unset");
+
     tracing::info!(
         method,
         uri,
         user_agent,
+        app_code,
+        from,
         status,
         elapsed = ?timer.elapsed(),
         "request_summary",

--- a/crates/orderbook/src/api/post_order.rs
+++ b/crates/orderbook/src/api/post_order.rs
@@ -1,6 +1,6 @@
 use {
     crate::{
-        api::{AppState, error},
+        api::{AppState, RequestMetadata, error},
         orderbook::{AddOrderError, OrderReplacementError},
     },
     axum::{
@@ -26,7 +26,11 @@ pub async fn post_order_handler(
     State(state): State<Arc<AppState>>,
     Json(order): Json<OrderCreation>,
 ) -> Response {
-    state
+    let metadata = RequestMetadata {
+        app_code: order.app_data.app_code(),
+        from: order.from.map(|a| format!("{a:?}")),
+    };
+    let mut response = state
         .orderbook
         .add_order(order.clone())
         .await
@@ -39,7 +43,9 @@ pub async fn post_order_handler(
         .inspect_err(|err| {
             tracing::debug!(?order, ?err, "error creating order");
         })
-        .into_response()
+        .into_response();
+    response.extensions_mut().insert(metadata);
+    response
 }
 
 pub struct PartialValidationErrorWrapper(pub PartialValidationError);

--- a/crates/orderbook/src/api/post_quote.rs
+++ b/crates/orderbook/src/api/post_quote.rs
@@ -1,7 +1,7 @@
 use {
     super::post_order::{AppDataValidationErrorWrapper, PartialValidationErrorWrapper},
     crate::{
-        api::{AppState, error, rich_error},
+        api::{AppState, RequestMetadata, error, rich_error},
         quoter::OrderQuoteError,
     },
     axum::{
@@ -19,13 +19,19 @@ pub async fn post_quote_handler(
     State(state): State<Arc<AppState>>,
     Json(request): Json<OrderQuoteRequest>,
 ) -> Response {
-    state
+    let metadata = RequestMetadata {
+        app_code: request.app_data.app_code(),
+        from: Some(format!("{:?}", request.from)),
+    };
+    let mut response = state
         .quotes
         .calculate_quote(&request)
         .await
         .map(Json)
         .inspect_err(|err| tracing::warn!(%err, ?request, "post_quote error"))
-        .into_response()
+        .into_response();
+    response.extensions_mut().insert(metadata);
+    response
 }
 
 impl IntoResponse for OrderQuoteError {


### PR DESCRIPTION
# Description
When investigating traffic spikes on `/api/v1/quote` there's no way to tell whether elevated traffic is from a known integrator because the partner-identifying fields (`appCode` in `appData`, and the `from` address) live inside the POST body and aren't captured in the `request_summary` log. WAF CloudWatch logs also don't capture POST body, so today the only way to attribute traffic to a partner is to ask them directly. This change adds both fields to `request_summary` so future DDoS investigations can be completed entirely in Victoria Logs.

# Changes
- Added `OrderCreationAppData::app_code()` helper that extracts the `appCode` field from the full app data JSON
- Added `RequestMetadata` attached to responses from `post_quote_handler` and `post_order_handler`
- `summarize_request` middleware now logs `app_code` and `from` fields (both default to `unset` for endpoints that don't carry them)

# How to test
New unit tests. Then, use CloudWatch with the updated query.