### PR TITLE
Add verified-only-pairs config for per-pair strict quote verification

### DIFF
--- a/crates/autopilot/src/run.rs
+++ b/crates/autopilot/src/run.rs
@@ -469,6 +469,7 @@ pub async fn run(config: Configuration, shutdown_controller: ShutdownController)
         },
         balance_fetcher.clone(),
         config.price_estimation.quote_verification,
+        config.price_estimation.verified_only_pairs.clone(),
         config.price_estimation.quote_timeout,
     ));
 

--- a/crates/configs/src/price_estimation.rs
+++ b/crates/configs/src/price_estimation.rs
@@ -73,6 +73,16 @@ pub struct PriceEstimation {
     #[serde(default)]
     pub tokens_without_verification: HashSet<Address>,
 
+    /// Token pairs for which an unverified quote must never be returned.
+    /// Matched symmetrically (order of sell/buy does not matter). This is
+    /// stronger than `quote-verification = "enforce-when-possible"`: the
+    /// pair-level check has no balance-based exemption and applies even when
+    /// the global mode is `unverified` or `prefer`. Intended for pairs we
+    /// know are mispriced by solvers (e.g. aTokens whose underlying reserve
+    /// is drained) and can't safely settle at the quoted rate.
+    #[serde(default)]
+    pub verified_only_pairs: HashSet<(Address, Address)>,
+
     /// How much gas a single tx may consume at most. Any quote using more than
     /// this will fail during the verification.
     /// Defaults to the maximum transaction gas limit Ethereum introduced in the
@@ -123,6 +133,7 @@ impl Default for PriceEstimation {
             quote_timeout: default_quote_timeout(),
             balance_overrides: Default::default(),
             tokens_without_verification: Default::default(),
+            verified_only_pairs: Default::default(),
             max_gas_per_tx: default_max_gas_per_tx(),
             min_gas_amount_for_unverified_quotes: 0,
             max_gas_amount_for_unverified_quotes: u32::MAX,
@@ -323,6 +334,7 @@ mod tests {
         assert_eq!(config.balance_overrides.probing_depth, 60);
         assert_eq!(config.balance_overrides.cache_size, 1000);
         assert!(config.tokens_without_verification.is_empty());
+        assert!(config.verified_only_pairs.is_empty());
         assert_eq!(config.min_gas_amount_for_unverified_quotes, 0);
         assert_eq!(config.max_gas_amount_for_unverified_quotes, u32::MAX);
     }
@@ -334,6 +346,9 @@ mod tests {
         quote-verification = "enforce-when-possible"
         quote-timeout = "10s"
         tokens-without-verification = ["0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2"]
+        verified-only-pairs = [
+            ["0x4d5f47fa6a74757f35c14fd3a6ef8e3c9bc514e8", "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2"],
+        ]
         amount-to-estimate-prices-with = "1000000000000000000"
         min-gas-amount-for-unverified-quotes = 400000
         max-gas-amount-for-unverified-quotes = 800000
@@ -398,6 +413,7 @@ mod tests {
         assert_eq!(config.balance_overrides.probing_depth, 30);
         assert_eq!(config.balance_overrides.cache_size, 500);
         assert_eq!(config.tokens_without_verification.len(), 1);
+        assert_eq!(config.verified_only_pairs.len(), 1);
         assert_eq!(config.min_gas_amount_for_unverified_quotes, 400_000);
         assert_eq!(config.max_gas_amount_for_unverified_quotes, 800_000);
     }

--- a/crates/e2e/tests/e2e/quote_verification.rs
+++ b/crates/e2e/tests/e2e/quote_verification.rs
@@ -25,6 +25,7 @@ use {
         trade_finding::{Interaction, LegacyTrade, QuoteExecution, TradeKind},
         trade_verifier::{PriceQuery, TradeVerifier, TradeVerifying},
     },
+    reqwest::StatusCode,
     serde_json::json,
     simulator::swap_simulator::SwapSimulator,
     std::sync::Arc,
@@ -82,6 +83,12 @@ async fn forked_node_mainnet_usdt_quote() {
         23112197,
     )
     .await;
+}
+
+#[tokio::test]
+#[ignore]
+async fn local_node_verified_only_pairs_enforcement() {
+    run_test(verified_only_pairs_enforcement).await;
 }
 
 /// Verified quotes work as expected.
@@ -533,6 +540,133 @@ async fn verified_quote_with_simulated_balance(web3: Web3) {
                     }
                 })
                 .to_string(),
+            },
+            ..Default::default()
+        })
+        .await
+        .unwrap();
+    assert!(response.verified);
+}
+
+/// Covers both rejection and pass-through behaviour of the
+/// `verified_only_pairs` gate:
+///
+/// * listed pair + unverified estimate → rejected (both trade directions), even
+///   when the user has no balance (which would normally exempt them from
+///   `EnforceWhenPossible`);
+/// * listed pair + verified estimate → passes through unchanged;
+/// * unlisted pair + unverified estimate → passes (gate not applicable).
+async fn verified_only_pairs_enforcement(web3: Web3) {
+    tracing::info!("Setting up chain state.");
+    let mut onchain = OnchainComponents::deploy(web3).await;
+
+    let [solver] = onchain.make_solvers(10u64.eth()).await;
+    let [trader] = onchain.make_accounts(1u64.eth()).await;
+    let [token_a, token_b, token_c] = onchain
+        .deploy_tokens_with_weth_uni_v2_pools(1_000u64.eth(), 1_000u64.eth())
+        .await;
+
+    // token_c is set up with a real balance and approval so that its quote
+    // against WETH verifies successfully — that's how we prove the gate
+    // lets verified quotes through even when their pair is listed.
+    token_c.mint(trader.address(), 1u64.eth()).await;
+    token_c
+        .approve(onchain.contracts().allowance, 1u64.eth())
+        .from(trader.address())
+        .send_and_watch()
+        .await
+        .unwrap();
+
+    tracing::info!("Starting services.");
+    let services = Services::new(&onchain).await;
+    let orderbook_config = configs::orderbook::Configuration {
+        price_estimation: configs::price_estimation::PriceEstimation {
+            // Forcing every token_a quote to come back unverified is what
+            // lets us exercise the rejection side of the gate without
+            // depending on a natural verification failure.
+            tokens_without_verification: [*token_a.address()].into_iter().collect(),
+            // Two listed pairs: one that will always be unverified
+            // (token_a/token_b) and one that will naturally verify
+            // (token_c/weth).
+            verified_only_pairs: [
+                (*token_a.address(), *token_b.address()),
+                (*token_c.address(), *onchain.contracts().weth.address()),
+            ]
+            .into_iter()
+            .collect(),
+            ..configs::orderbook::Configuration::test_default().price_estimation
+        },
+        ..configs::orderbook::Configuration::test_default()
+    };
+    services
+        .start_protocol_with_args(
+            Configuration::test("test_solver", solver.address()),
+            orderbook_config,
+            solver,
+        )
+        .await;
+
+    let sell_amount = NonZeroU256::try_from(1u64.eth()).unwrap();
+
+    // Unlisted pair + unverified estimate → passes. The trader has no
+    // token_a balance so `EnforceWhenPossible` exempts them, and the
+    // pair-level gate doesn't fire because (token_a, weth) isn't listed.
+    let response = services
+        .submit_quote(&OrderQuoteRequest {
+            from: trader.address(),
+            sell_token: *token_a.address(),
+            buy_token: *onchain.contracts().weth.address(),
+            side: OrderQuoteSide::Sell {
+                sell_amount: SellAmount::BeforeFee { value: sell_amount },
+            },
+            ..Default::default()
+        })
+        .await
+        .unwrap();
+    assert!(!response.verified);
+
+    // Listed pair + unverified estimate → rejected.
+    let (status, body) = services
+        .submit_quote(&OrderQuoteRequest {
+            from: trader.address(),
+            sell_token: *token_a.address(),
+            buy_token: *token_b.address(),
+            side: OrderQuoteSide::Sell {
+                sell_amount: SellAmount::BeforeFee { value: sell_amount },
+            },
+            ..Default::default()
+        })
+        .await
+        .unwrap_err();
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+    assert!(body.contains("QuoteNotVerified"));
+
+    // Reverse direction also rejected: pair matching is symmetric.
+    let (status, body) = services
+        .submit_quote(&OrderQuoteRequest {
+            from: trader.address(),
+            sell_token: *token_b.address(),
+            buy_token: *token_a.address(),
+            side: OrderQuoteSide::Sell {
+                sell_amount: SellAmount::BeforeFee { value: sell_amount },
+            },
+            ..Default::default()
+        })
+        .await
+        .unwrap_err();
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+    assert!(body.contains("QuoteNotVerified"));
+
+    // Listed pair + verified estimate → passes. Being listed doesn't
+    // block verified quotes; the gate only exists to catch ones we
+    // couldn't verify.
+    let response = services
+        .submit_quote(&OrderQuoteRequest {
+            from: trader.address(),
+            sell_token: *token_c.address(),
+            buy_token: *onchain.contracts().weth.address(),
+            side: OrderQuoteSide::Sell {
+                sell_amount: SellAmount::BeforeFee { value: sell_amount },
             },
             ..Default::default()
         })

--- a/crates/orderbook/src/run.rs
+++ b/crates/orderbook/src/run.rs
@@ -361,14 +361,15 @@ pub async fn run(config: Configuration) {
             },
             balance_fetcher.clone(),
             verification,
+            config.price_estimation.verified_only_pairs.clone(),
             config.price_estimation.quote_timeout,
         ))
     };
     let optimal_quoter = create_quoter(price_estimator, config.price_estimation.quote_verification);
-    // Fast quoting is able to return early and if none of the produced quotes are
-    // verifiable we are left with no quote at all. Since fast estimates don't
-    // make any promises on correctness we can just skip quote verification for
-    // them.
+    // Fast quoting normally skips the global EnforceWhenPossible gate because it
+    // returns early and could otherwise produce no quote at all. The per-pair
+    // strict list, however, is still honoured — those are pairs we know are
+    // systematically mispriced, so even a fast quote must not leak.
     let fast_quoter = create_quoter(fast_price_estimator, QuoteVerificationMode::Unverified);
 
     let app_data_validator = Validator::new(config.app_data_size_limit);

--- a/crates/shared/src/order_quoting.rs
+++ b/crates/shared/src/order_quoting.rs
@@ -5,7 +5,7 @@ use {
         order_validation::PreOrderData,
     },
     account_balances::{BalanceFetching, Query},
-    alloy::primitives::{Address, U256, U512, ruint::UintTryFrom},
+    alloy::primitives::{Address, U256, U512, map::HashSet, ruint::UintTryFrom},
     anyhow::{Context, Result},
     chrono::{DateTime, Duration, Utc},
     database::quotes::{Quote as QuoteRow, QuoteKind},
@@ -420,6 +420,10 @@ pub struct OrderQuoter {
     validity: Validity,
     balance_fetcher: Arc<dyn BalanceFetching>,
     quote_verification: QuoteVerificationMode,
+    /// Symmetric set of (sell, buy) token pairs for which an unverified quote
+    /// must never be returned. Stored pre-expanded in both orderings so that
+    /// lookup is a single `contains` call regardless of trade direction.
+    verified_only_pairs: HashSet<(Address, Address)>,
     default_quote_timeout: std::time::Duration,
 }
 
@@ -433,8 +437,13 @@ impl OrderQuoter {
         validity: Validity,
         balance_fetcher: Arc<dyn BalanceFetching>,
         quote_verification: QuoteVerificationMode,
+        verified_only_pairs: HashSet<(Address, Address)>,
         default_quote_timeout: std::time::Duration,
     ) -> Self {
+        let verified_only_pairs = verified_only_pairs
+            .into_iter()
+            .flat_map(|(a, b)| [(a, b), (b, a)])
+            .collect();
         Self {
             price_estimator,
             native_price_estimator,
@@ -444,6 +453,7 @@ impl OrderQuoter {
             validity,
             balance_fetcher,
             quote_verification,
+            verified_only_pairs,
             default_quote_timeout,
         }
     }
@@ -536,13 +546,27 @@ impl OrderQuoter {
         parameters: &QuoteParameters,
         sell_amount: U256,
     ) -> Result<(), CalculateQuoteError> {
-        if estimate.verified
-            || !matches!(
-                self.quote_verification,
-                QuoteVerificationMode::EnforceWhenPossible
-            )
+        if estimate.verified {
+            // verification was successful
+            return Ok(());
+        }
+
+        if self
+            .verified_only_pairs
+            .contains(&(parameters.sell_token, parameters.buy_token))
         {
-            // verification was successful or not strictly required
+            // Pair is on the strict list: reject unverified unconditionally,
+            // with no balance-based exemption. This targets pairs where we
+            // know unverified quotes are systematically wrong (e.g. aTokens
+            // whose underlying reserve is drained).
+            return Err(CalculateQuoteError::QuoteNotVerified);
+        }
+
+        if !matches!(
+            self.quote_verification,
+            QuoteVerificationMode::EnforceWhenPossible
+        ) {
+            // verification was not strictly required
             return Ok(());
         }
 
@@ -790,7 +814,7 @@ mod tests {
         Address,
         U256 as AlloyU256,
         account_balances::MockBalanceFetching,
-        alloy::eips::eip1559::Eip1559Estimation,
+        alloy::{eips::eip1559::Eip1559Estimation, primitives::map::HashSet},
         chrono::Utc,
         futures::FutureExt,
         gas_price_estimation::FakeGasPriceEstimator,
@@ -938,6 +962,7 @@ mod tests {
             now: Arc::new(now),
             validity: super::Validity::default(),
             quote_verification: QuoteVerificationMode::Unverified,
+            verified_only_pairs: Default::default(),
             balance_fetcher: mock_balance_fetcher(),
             default_quote_timeout: HEALTHY_PRICE_ESTIMATION_TIME,
         };
@@ -1078,6 +1103,7 @@ mod tests {
             now: Arc::new(now),
             validity: Validity::default(),
             quote_verification: QuoteVerificationMode::Unverified,
+            verified_only_pairs: Default::default(),
             balance_fetcher: mock_balance_fetcher(),
             default_quote_timeout: HEALTHY_PRICE_ESTIMATION_TIME,
         };
@@ -1213,6 +1239,7 @@ mod tests {
             now: Arc::new(now),
             validity: Validity::default(),
             quote_verification: QuoteVerificationMode::Unverified,
+            verified_only_pairs: Default::default(),
             balance_fetcher: mock_balance_fetcher(),
             default_quote_timeout: HEALTHY_PRICE_ESTIMATION_TIME,
         };
@@ -1311,6 +1338,7 @@ mod tests {
             now: Arc::new(Utc::now),
             validity: Validity::default(),
             quote_verification: QuoteVerificationMode::Unverified,
+            verified_only_pairs: Default::default(),
             balance_fetcher: mock_balance_fetcher(),
             default_quote_timeout: HEALTHY_PRICE_ESTIMATION_TIME,
         };
@@ -1384,6 +1412,7 @@ mod tests {
             now: Arc::new(Utc::now),
             validity: Validity::default(),
             quote_verification: QuoteVerificationMode::Unverified,
+            verified_only_pairs: Default::default(),
             balance_fetcher: mock_balance_fetcher(),
             default_quote_timeout: HEALTHY_PRICE_ESTIMATION_TIME,
         };
@@ -1445,6 +1474,7 @@ mod tests {
             now: Arc::new(now),
             validity: Validity::default(),
             quote_verification: QuoteVerificationMode::Unverified,
+            verified_only_pairs: Default::default(),
             balance_fetcher: mock_balance_fetcher(),
             default_quote_timeout: HEALTHY_PRICE_ESTIMATION_TIME,
         };
@@ -1528,6 +1558,7 @@ mod tests {
             now: Arc::new(now),
             validity: Validity::default(),
             quote_verification: QuoteVerificationMode::Unverified,
+            verified_only_pairs: Default::default(),
             balance_fetcher: mock_balance_fetcher(),
             default_quote_timeout: HEALTHY_PRICE_ESTIMATION_TIME,
         };
@@ -1613,6 +1644,7 @@ mod tests {
             now: Arc::new(now),
             validity: Validity::default(),
             quote_verification: QuoteVerificationMode::Unverified,
+            verified_only_pairs: Default::default(),
             balance_fetcher: mock_balance_fetcher(),
             default_quote_timeout: HEALTHY_PRICE_ESTIMATION_TIME,
         };
@@ -1686,6 +1718,7 @@ mod tests {
             now: Arc::new(now),
             validity: Validity::default(),
             quote_verification: QuoteVerificationMode::Unverified,
+            verified_only_pairs: Default::default(),
             balance_fetcher: mock_balance_fetcher(),
             default_quote_timeout: HEALTHY_PRICE_ESTIMATION_TIME,
         };
@@ -1717,6 +1750,7 @@ mod tests {
             now: Arc::new(Utc::now),
             validity: Validity::default(),
             quote_verification: QuoteVerificationMode::Unverified,
+            verified_only_pairs: Default::default(),
             balance_fetcher: mock_balance_fetcher(),
             default_quote_timeout: HEALTHY_PRICE_ESTIMATION_TIME,
         };
@@ -1846,5 +1880,189 @@ mod tests {
                 assert_eq!(v1.jit_orders.len(), 2);
             }
         }
+    }
+
+    /// Build an OrderQuoter populated with throw-away mocks for every
+    /// dependency except the two that `verify_quote` actually consults
+    /// (balance fetcher and the verification knobs).
+    fn quoter_for_verify_tests(
+        quote_verification: QuoteVerificationMode,
+        verified_only_pairs: HashSet<(Address, Address)>,
+        balance_fetcher: Arc<dyn BalanceFetching>,
+    ) -> OrderQuoter {
+        OrderQuoter::new(
+            Arc::new(MockPriceEstimating::new()),
+            Arc::new(MockNativePriceEstimating::new()),
+            Arc::new(FakeGasPriceEstimator::default()),
+            Arc::new(MockQuoteStoring::new()),
+            Validity::default(),
+            balance_fetcher,
+            quote_verification,
+            verified_only_pairs,
+            HEALTHY_PRICE_ESTIMATION_TIME,
+        )
+    }
+
+    fn params_for(sell: Address, buy: Address, from: Address) -> QuoteParameters {
+        QuoteParameters {
+            sell_token: sell,
+            buy_token: buy,
+            side: OrderQuoteSide::Sell {
+                sell_amount: SellAmount::BeforeFee {
+                    value: NonZeroU256::try_from(100).unwrap(),
+                },
+            },
+            verification: Verification {
+                from,
+                ..Default::default()
+            },
+            signing_scheme: QuoteSigningScheme::Eip712,
+            additional_gas: 0,
+            timeout: None,
+        }
+    }
+
+    fn unverified_estimate() -> Estimate {
+        Estimate {
+            out_amount: AlloyU256::from(42),
+            gas: 3,
+            solver: Address::repeat_byte(1),
+            verified: false,
+            execution: Default::default(),
+        }
+    }
+
+    fn verified_estimate() -> Estimate {
+        Estimate {
+            verified: true,
+            ..unverified_estimate()
+        }
+    }
+
+    /// Balance fetcher that refuses to answer. Any code path that consults it
+    /// will fail the test — lets us assert that the pair-level gate short-
+    /// circuits before the balance-exemption logic.
+    fn panicking_balance_fetcher() -> Arc<dyn BalanceFetching> {
+        let mut mock = MockBalanceFetching::new();
+        mock.expect_get_balances()
+            .returning(|_| panic!("balance fetcher must not be called for verified-only pairs"));
+        Arc::new(mock)
+    }
+
+    #[tokio::test]
+    async fn verify_quote_rejects_unverified_for_listed_pair() {
+        let sell = Address::from([0xaa; 20]);
+        let buy = Address::from([0xbb; 20]);
+        let quoter = quoter_for_verify_tests(
+            // Even the most permissive global mode must not leak the pair.
+            QuoteVerificationMode::Unverified,
+            [(sell, buy)].into_iter().collect(),
+            panicking_balance_fetcher(),
+        );
+
+        let err = quoter
+            .verify_quote(
+                &unverified_estimate(),
+                &params_for(sell, buy, Address::from([3; 20])),
+                U256::from(100),
+            )
+            .await
+            .unwrap_err();
+        assert!(matches!(err, CalculateQuoteError::QuoteNotVerified));
+    }
+
+    #[tokio::test]
+    async fn verify_quote_accepts_verified_for_listed_pair() {
+        let sell = Address::from([0xaa; 20]);
+        let buy = Address::from([0xbb; 20]);
+        let quoter = quoter_for_verify_tests(
+            QuoteVerificationMode::Unverified,
+            [(sell, buy)].into_iter().collect(),
+            panicking_balance_fetcher(),
+        );
+
+        quoter
+            .verify_quote(
+                &verified_estimate(),
+                &params_for(sell, buy, Address::from([3; 20])),
+                U256::from(100),
+            )
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn verify_quote_pair_match_is_symmetric() {
+        let sell = Address::from([0xaa; 20]);
+        let buy = Address::from([0xbb; 20]);
+        // Config lists (sell, buy); trade queries the reverse direction.
+        let quoter = quoter_for_verify_tests(
+            QuoteVerificationMode::Unverified,
+            [(sell, buy)].into_iter().collect(),
+            panicking_balance_fetcher(),
+        );
+
+        let err = quoter
+            .verify_quote(
+                &unverified_estimate(),
+                &params_for(buy, sell, Address::from([3; 20])),
+                U256::from(100),
+            )
+            .await
+            .unwrap_err();
+        assert!(matches!(err, CalculateQuoteError::QuoteNotVerified));
+    }
+
+    #[tokio::test]
+    async fn verify_quote_passes_unrelated_pair_in_unverified_mode() {
+        let quoter = quoter_for_verify_tests(
+            QuoteVerificationMode::Unverified,
+            [(Address::from([0xaa; 20]), Address::from([0xbb; 20]))]
+                .into_iter()
+                .collect(),
+            panicking_balance_fetcher(),
+        );
+
+        quoter
+            .verify_quote(
+                &unverified_estimate(),
+                &params_for(
+                    Address::from([1; 20]),
+                    Address::from([2; 20]),
+                    Address::from([3; 20]),
+                ),
+                U256::from(100),
+            )
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn verify_quote_listed_pair_rejects_even_when_user_has_no_balance() {
+        // EnforceWhenPossible exempts users without the sell-token balance
+        // (the "get a quote, then deposit" flow). The pair-level gate must
+        // reject anyway, because the quote itself is known-broken.
+        let sell = Address::from([0xaa; 20]);
+        let buy = Address::from([0xbb; 20]);
+
+        let mut mock = MockBalanceFetching::new();
+        mock.expect_get_balances()
+            .returning(|addrs| addrs.iter().map(|_| Ok(U256::ZERO)).collect());
+
+        let quoter = quoter_for_verify_tests(
+            QuoteVerificationMode::EnforceWhenPossible,
+            [(sell, buy)].into_iter().collect(),
+            Arc::new(mock),
+        );
+
+        let err = quoter
+            .verify_quote(
+                &unverified_estimate(),
+                &params_for(sell, buy, Address::from([3; 20])),
+                U256::from(100),
+            )
+            .await
+            .unwrap_err();
+        assert!(matches!(err, CalculateQuoteError::QuoteNotVerified));
     }
 }


### PR DESCRIPTION
# Description
On 2026-04-19, `aEthWETH → WETH` quotes on mainnet were returning ~1:1 rates (`verified: false`) because solvers assumed an Aave `withdraw()` at face value, while Aave's WETH reserve was fully drained (utilization ≈ 100.0002%). Users signing against those quotes hit settlement failures (`timeout` / `failedtosubmit`). Mainnet runs `quote-verification = "prefer"`, which collapses to `unverified` behaviour when every solver returns unverified (as happens here); flipping globally to `enforce-when-possible` would reject legit unverified quotes across mainnet's long tail of tokens. A per-pair strict list is the surgical alternative.

This PR is a **fail-fast guardrail, not a functional fix** — it stops misleading quotes from reaching the UI, but doesn't enable any trade that currently can't settle. Small trades that fit within whatever Aave headroom exists at a given moment are also blocked. The upstream fix is either the reserve refilling or solvers producing verified quotes that reflect actual available liquidity; this PR just prevents the silent-misleading-UX part of the problem until then.

# Changes
- Added `verified-only-pairs` config field on `PriceEstimation` (symmetric sell/buy pair list).
- Gated unverified quotes on listed pairs inside `OrderQuoter::verify_quote`, unconditionally and with no balance-based exemption.
- Threaded the list through both `orderbook` quote paths (optimal and fast) and `autopilot`'s quoter so neither can leak the bad rate.

# How to test
New unit tests and an e2e test (`local_node_verified_only_pairs_enforcement`) covering: listed pair + unverified estimate → rejected in both trade directions (symmetric matching) and even when the trader has no sell-token balance (no exemption); listed pair + verified estimate → passes through unchanged; unlisted pair + unverified estimate → passes. After deploy with a populated list (see cowprotocol/infrastructure#5197), verify `/api/v1/quote` returns `QuoteNotVerified` for listed pairs and leaves unrelated pairs unaffected.