### PR TITLE
Support Aave v3 aToken balance overrides

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1863,6 +1863,7 @@ dependencies = [
 name = "balance-overrides"
 version = "0.1.0"
 dependencies = [
+ "alloy-contract",
  "alloy-eips",
  "alloy-primitives",
  "alloy-provider",

--- a/crates/balance-overrides/Cargo.toml
+++ b/crates/balance-overrides/Cargo.toml
@@ -9,6 +9,7 @@ license = "MIT OR Apache-2.0"
 doctest = false
 
 [dependencies]
+alloy-contract = { workspace = true }
 alloy-eips = { workspace = true }
 alloy-primitives = { workspace = true, features = ["rand"] }
 alloy-provider = { workspace = true, features = ["debug-api", "trace-api"] }

--- a/crates/balance-overrides/src/aave.rs
+++ b/crates/balance-overrides/src/aave.rs
@@ -1,21 +1,16 @@
-//! Helpers shared between the production balance-override path
-//! (`BalanceOverrides`) and the auto-detector for Aave v3 aTokens.
+//! Helpers shared between the `BalanceOverrides` override builder and the
+//! `Detector` probe/verify for Aave v3 aTokens.
 //!
 //! aTokens break the usual "balanceOf = storage[slot]" assumption twice:
 //! - `balanceOf` returns `scaled_balance × getReserveNormalizedIncome / RAY`,
 //!   not the raw slot value.
 //! - Storage is packed `UserState { uint128 balance; uint128 additionalData }`
 //!   in a single slot per holder.
-//!
-//! The helpers below encode exactly these two facts so both the override
-//! builder and the detector probe/verify use the same math.
 
 use {
-    alloy_eips::BlockId,
-    alloy_primitives::{Address, B256, Bytes, TxKind, U256, keccak256},
-    alloy_provider::Provider,
-    alloy_rpc_types::{TransactionInput, TransactionRequest, state::AccountOverride},
-    alloy_sol_types::{SolCall, sol},
+    alloy_primitives::{Address, B256, U256, keccak256},
+    alloy_rpc_types::state::AccountOverride,
+    alloy_sol_types::sol,
     ethrpc::Web3,
     std::iter,
 };
@@ -58,6 +53,7 @@ sol! {
     /// underlying.
     ///
     /// Source: <https://github.com/aave-dao/aave-v3-origin/blob/main/src/contracts/interfaces/IPool.sol>
+    #[sol(rpc)]
     interface IAaveV3Pool {
         function getReserveNormalizedIncome(address asset) external view returns (uint256);
         function getReserveData(address asset) external view returns (ReserveData memory);
@@ -67,6 +63,7 @@ sol! {
     /// decide whether a token is an aToken without any hardcoded list.
     ///
     /// Source: <https://github.com/aave-dao/aave-v3-origin/blob/main/src/contracts/interfaces/IAToken.sol>
+    #[sol(rpc)]
     interface IAaveV3AToken {
         function UNDERLYING_ASSET_ADDRESS() external view returns (address);
         function POOL() external view returns (address);
@@ -74,7 +71,16 @@ sol! {
 }
 
 /// Ray (1e27) — Aave's 27-decimal fixed-point unit.
+///
+/// Source: <https://github.com/aave-dao/aave-v3-origin/blob/main/src/contracts/protocol/libraries/math/WadRayMath.sol>
 pub const RAY: U256 = U256::from_limbs([0x9fd0803ce8000000, 0x33b2e3c, 0, 0]);
+
+/// Storage slot index of `_userState` in the Aave v3 `IncentivizedERC20`
+/// base contract. All canonical v3 aTokens inherit this layout, so the
+/// detector can try this slot directly without a `debug_traceCall`.
+///
+/// Source: <https://github.com/aave-dao/aave-v3-origin/blob/main/src/contracts/protocol/tokenization/base/IncentivizedERC20.sol>
+pub const USER_STATE_SLOT: u64 = 52;
 
 /// Ray-division: `(a * RAY + b/2) / b`, round-half-up. Matches Aave's
 /// `WadRayMath.rayDiv` bit-for-bit so the scaled amount we write into
@@ -109,23 +115,17 @@ pub fn pack_user_state(balance: U256, additional_data: U256) -> B256 {
     B256::new(packed.to_be_bytes::<32>())
 }
 
-/// Probes whether `token` is an Aave v3 aToken. The token self-declares its
-/// `UNDERLYING_ASSET_ADDRESS()` and `POOL()`; we then ask the pool for the
-/// registered `aTokenAddress` of that underlying and require it to equal the
-/// probed token. This catches both "contract doesn't look anything like an
-/// aToken" and "contract impersonates the aToken interface but is not
-/// registered with the pool for its declared underlying."
+/// Probes whether `token` is an Aave v3 aToken and returns its `(pool,
+/// underlying)` pair. Accepts the token iff the pool registers it as the
+/// aToken for its declared underlying — rogue contracts implementing the
+/// aToken selectors aren't enough.
 pub async fn probe_a_token(web3: &Web3, token: Address) -> Option<(Address, Address)> {
-    let (underlying, pool) = tokio::join!(
-        call_address(
-            web3,
-            token,
-            IAaveV3AToken::UNDERLYING_ASSET_ADDRESSCall {}.abi_encode(),
-        ),
-        call_address(web3, token, IAaveV3AToken::POOLCall {}.abi_encode()),
-    );
-    let underlying = underlying?;
-    let pool = pool?;
+    let a_token = IAaveV3AToken::new(token, web3.provider.clone());
+    let underlying_call = a_token.UNDERLYING_ASSET_ADDRESS();
+    let pool_call = a_token.POOL();
+    let (underlying, pool) = tokio::join!(underlying_call.call(), pool_call.call());
+    let underlying = underlying.ok()?;
+    let pool = pool.ok()?;
     let reserve = fetch_reserve_data(web3, pool, underlying).await?;
     (reserve.aTokenAddress == token).then_some((pool, underlying))
 }
@@ -136,15 +136,11 @@ async fn fetch_reserve_data(
     pool: Address,
     underlying: Address,
 ) -> Option<ReserveData> {
-    let call = IAaveV3Pool::getReserveDataCall { asset: underlying };
-    let calldata = Bytes::from(call.abi_encode());
-    let tx = TransactionRequest {
-        to: Some(TxKind::Call(pool)),
-        input: TransactionInput::new(calldata),
-        ..Default::default()
-    };
-    let bytes = web3.provider.call(tx).block(BlockId::latest()).await.ok()?;
-    IAaveV3Pool::getReserveDataCall::abi_decode_returns(&bytes).ok()
+    IAaveV3Pool::new(pool, web3.provider.clone())
+        .getReserveData(underlying)
+        .call()
+        .await
+        .ok()
 }
 
 /// Fetches `getReserveNormalizedIncome(underlying)` from an Aave v3 Pool.
@@ -153,15 +149,11 @@ pub async fn fetch_normalized_income(
     pool: Address,
     underlying: Address,
 ) -> Option<U256> {
-    let call = IAaveV3Pool::getReserveNormalizedIncomeCall { asset: underlying };
-    let calldata = Bytes::from(call.abi_encode());
-    let tx = TransactionRequest {
-        to: Some(TxKind::Call(pool)),
-        input: TransactionInput::new(calldata),
-        ..Default::default()
-    };
-    let bytes = web3.provider.call(tx).block(BlockId::latest()).await.ok()?;
-    IAaveV3Pool::getReserveNormalizedIncomeCall::abi_decode_returns(&bytes).ok()
+    IAaveV3Pool::new(pool, web3.provider.clone())
+        .getReserveNormalizedIncome(underlying)
+        .call()
+        .await
+        .ok()
 }
 
 /// Builds a state override that makes `balanceOf(holder)` on the aToken
@@ -222,25 +214,6 @@ pub async fn build_override(
         ..Default::default()
     };
     Some((a_token, state_override))
-}
-
-/// Helper: `eth_call` a zero-argument view returning `address`. Returns
-/// `None` on any RPC error or decode failure (including the common case of
-/// the token not exposing this selector at all).
-async fn call_address(web3: &Web3, to: Address, calldata: Vec<u8>) -> Option<Address> {
-    let tx = TransactionRequest {
-        to: Some(TxKind::Call(to)),
-        input: TransactionInput::new(calldata.into()),
-        ..Default::default()
-    };
-    let bytes = web3.provider.call(tx).block(BlockId::latest()).await.ok()?;
-    if bytes.len() < 32 {
-        return None;
-    }
-    // ABI-encoded `address` is right-aligned in the 32-byte word.
-    let addr = Address::from_slice(&bytes[12..32]);
-    // Treat zero as "not an aToken" — a zero underlying/pool is never legal.
-    (!addr.is_zero()).then_some(addr)
 }
 
 #[cfg(test)]

--- a/crates/balance-overrides/src/aave.rs
+++ b/crates/balance-overrides/src/aave.rs
@@ -21,10 +21,40 @@ use {
 };
 
 sol! {
-    /// Minimal interface for the Aave v3 `Pool` used to derive the current
-    /// liquidity index applied by aTokens when reporting `balanceOf`.
+    /// Mirrors Aave v3's `DataTypes.ReserveConfigurationMap`.
+    struct ReserveConfigurationMap {
+        uint256 data;
+    }
+
+    /// Mirrors Aave v3's `DataTypes.ReserveData`. Only the `aTokenAddress`
+    /// field is consumed here; the rest are present to keep the ABI layout
+    /// exactly matched so decoding doesn't go off the rails.
+    struct ReserveData {
+        ReserveConfigurationMap configuration;
+        uint128 liquidityIndex;
+        uint128 currentLiquidityRate;
+        uint128 variableBorrowIndex;
+        uint128 currentVariableBorrowRate;
+        uint128 currentStableBorrowRate;
+        uint40 lastUpdateTimestamp;
+        uint16 id;
+        address aTokenAddress;
+        address stableDebtTokenAddress;
+        address variableDebtTokenAddress;
+        address interestRateStrategyAddress;
+        uint128 accruedToTreasury;
+        uint128 unbacked;
+        uint128 isolationModeTotalDebt;
+    }
+
+    /// Minimal interface for the Aave v3 `Pool`. `getReserveNormalizedIncome`
+    /// gives the accrued liquidity index used when scaling `balanceOf`;
+    /// `getReserveData` returns the full reserve record which we use to
+    /// confirm a probed token really is the registered aToken for its
+    /// underlying.
     interface IAaveV3Pool {
         function getReserveNormalizedIncome(address asset) external view returns (uint256);
+        function getReserveData(address asset) external view returns (ReserveData memory);
     }
 
     /// Minimal interface for an Aave v3 `AToken`; used by the detector to
@@ -71,11 +101,12 @@ pub fn pack_user_state(balance: U256, additional_data: U256) -> B256 {
     B256::new(packed.to_be_bytes::<32>())
 }
 
-/// Probes whether `token` looks like an Aave v3 aToken by querying
-/// `UNDERLYING_ASSET_ADDRESS()` and `POOL()`. Returns `Some((pool,
-/// underlying))` if both calls succeed and the returned pool responds to
-/// `getReserveNormalizedIncome(underlying)` — an extra safety check against
-/// tokens that happen to implement the two selectors but aren't Aave v3.
+/// Probes whether `token` is an Aave v3 aToken. The token self-declares its
+/// `UNDERLYING_ASSET_ADDRESS()` and `POOL()`; we then ask the pool for the
+/// registered `aTokenAddress` of that underlying and require it to equal the
+/// probed token. This catches both "contract doesn't look anything like an
+/// aToken" and "contract impersonates the aToken interface but is not
+/// registered with the pool for its declared underlying."
 pub async fn probe_a_token(web3: &Web3, token: Address) -> Option<(Address, Address)> {
     let underlying = call_address(
         web3,
@@ -84,9 +115,25 @@ pub async fn probe_a_token(web3: &Web3, token: Address) -> Option<(Address, Addr
     )
     .await?;
     let pool = call_address(web3, token, IAaveV3AToken::POOLCall {}.abi_encode()).await?;
-    // Sanity: confirm the pool actually exposes the expected interface.
-    fetch_normalized_income(web3, pool, underlying).await?;
-    Some((pool, underlying))
+    let reserve = fetch_reserve_data(web3, pool, underlying).await?;
+    (reserve.aTokenAddress == token).then_some((pool, underlying))
+}
+
+/// Fetches `getReserveData(underlying)` from an Aave v3 Pool.
+async fn fetch_reserve_data(
+    web3: &Web3,
+    pool: Address,
+    underlying: Address,
+) -> Option<ReserveData> {
+    let call = IAaveV3Pool::getReserveDataCall { asset: underlying };
+    let calldata = Bytes::from(call.abi_encode());
+    let tx = TransactionRequest {
+        to: Some(TxKind::Call(pool)),
+        input: TransactionInput::new(calldata),
+        ..Default::default()
+    };
+    let bytes = web3.provider.call(tx).block(BlockId::latest()).await.ok()?;
+    IAaveV3Pool::getReserveDataCall::abi_decode_returns(&bytes).ok()
 }
 
 /// Fetches `getReserveNormalizedIncome(underlying)` from an Aave v3 Pool.
@@ -171,18 +218,44 @@ async fn call_address(web3: &Web3, to: Address, calldata: Vec<u8>) -> Option<Add
 
 #[cfg(test)]
 mod tests {
-    use {super::*, alloy_primitives::address, alloy_provider::mock::Asserter};
+    use {
+        super::*,
+        alloy_primitives::address,
+        alloy_provider::mock::Asserter,
+        alloy_sol_types::SolValue,
+    };
 
     fn encode_address(addr: Address) -> String {
         format!("0x{:0>64x}", U256::from_be_bytes(addr.into_word().0))
     }
 
-    fn encode_uint(value: U256) -> String {
-        format!("0x{:064x}", value)
+    /// Encodes a `ReserveData` struct as the ABI return payload the pool
+    /// would produce. All fields other than `aTokenAddress` are zero — we
+    /// only care about that one for the probe.
+    fn encode_reserve_data(a_token: Address) -> String {
+        let data = ReserveData {
+            configuration: ReserveConfigurationMap { data: U256::ZERO },
+            liquidityIndex: 0,
+            currentLiquidityRate: 0,
+            variableBorrowIndex: 0,
+            currentVariableBorrowRate: 0,
+            currentStableBorrowRate: 0,
+            lastUpdateTimestamp: alloy_primitives::Uint::ZERO,
+            id: 0,
+            aTokenAddress: a_token,
+            stableDebtTokenAddress: Address::ZERO,
+            variableDebtTokenAddress: Address::ZERO,
+            interestRateStrategyAddress: Address::ZERO,
+            accruedToTreasury: 0,
+            unbacked: 0,
+            isolationModeTotalDebt: 0,
+        };
+        format!("0x{}", alloy_primitives::hex::encode(data.abi_encode()))
     }
 
     /// The probe returns `Some((pool, underlying))` when the token exposes
-    /// both selectors and the pool responds to `getReserveNormalizedIncome`.
+    /// both selectors and the pool confirms the token as the registered
+    /// aToken for that underlying.
     #[tokio::test]
     async fn probe_a_token_accepts_valid_atoken() {
         let a_token = address!("4d5f47fa6a74757f35c14fd3a6ef8e3c9bc514e8");
@@ -194,8 +267,9 @@ mod tests {
         asserter.push_success(&encode_address(underlying));
         // 2. POOL() → pool
         asserter.push_success(&encode_address(pool));
-        // 3. pool.getReserveNormalizedIncome(underlying) → some ray value
-        asserter.push_success(&encode_uint(RAY));
+        // 3. pool.getReserveData(underlying) → ReserveData { aTokenAddress: a_token, ..
+        //    }
+        asserter.push_success(&encode_reserve_data(a_token));
 
         let web3 = Web3::with_asserter(asserter);
         assert_eq!(
@@ -216,11 +290,11 @@ mod tests {
         assert_eq!(probe_a_token(&web3, token).await, None);
     }
 
-    /// The probe also bails if the pool doesn't look like an Aave v3 Pool
-    /// (e.g. `getReserveNormalizedIncome` reverts). This guards against a
-    /// false positive where some random contract exposes both
-    /// `UNDERLYING_ASSET_ADDRESS()` and `POOL()` but has nothing to do with
-    /// Aave.
+    /// The probe bails if the pool doesn't look like an Aave v3 Pool
+    /// (e.g. `getReserveData` reverts). This guards against a false
+    /// positive where some random contract exposes both
+    /// `UNDERLYING_ASSET_ADDRESS()` and `POOL()` but the named pool has
+    /// nothing to do with Aave.
     #[tokio::test]
     async fn probe_a_token_rejects_when_pool_is_not_aave() {
         let token = address!("1111111111111111111111111111111111111111");
@@ -234,5 +308,25 @@ mod tests {
 
         let web3 = Web3::with_asserter(asserter);
         assert_eq!(probe_a_token(&web3, token).await, None);
+    }
+
+    /// A rogue contract that impersonates the aToken interface and points at
+    /// a real Aave pool is rejected: the pool registers a *different*
+    /// `aTokenAddress` for the underlying, so the identity check fails.
+    #[tokio::test]
+    async fn probe_a_token_rejects_when_pool_registers_a_different_atoken() {
+        let rogue = address!("bad000000000000000000000000000000000cafe");
+        let real_a_token = address!("4d5f47fa6a74757f35c14fd3a6ef8e3c9bc514e8");
+        let pool = address!("87870bca3f3fd6335c3f4ce8392d69350b4fa4e2");
+        let underlying = address!("c02aaa39b223fe8d0a0e5c4f27ead9083c756cc2");
+
+        let asserter = Asserter::new();
+        asserter.push_success(&encode_address(underlying));
+        asserter.push_success(&encode_address(pool));
+        // Pool agrees on the pair but names the *real* aToken, not the rogue.
+        asserter.push_success(&encode_reserve_data(real_a_token));
+
+        let web3 = Web3::with_asserter(asserter);
+        assert_eq!(probe_a_token(&web3, rogue).await, None);
     }
 }

--- a/crates/balance-overrides/src/aave.rs
+++ b/crates/balance-overrides/src/aave.rs
@@ -253,65 +253,73 @@ mod tests {
         hex::encode_prefixed(data.abi_encode())
     }
 
-    /// The probe returns `Some((pool, underlying))` when the token exposes
-    /// both selectors and the pool confirms the token as the registered
-    /// aToken for that underlying.
+    /// Builds an `Asserter` primed with the three responses the probe
+    /// expects, in order: `UNDERLYING_ASSET_ADDRESS()`, `POOL()`, and
+    /// `getReserveData(underlying)`. `None` maps to a reverted call; `Some`
+    /// maps to a success response containing the given value.
+    fn probe_asserter(
+        underlying: Option<Address>,
+        pool: Option<Address>,
+        reserve_a_token: Option<Address>,
+    ) -> Asserter {
+        let asserter = Asserter::new();
+        match underlying {
+            Some(u) => asserter.push_success(&encode_address(u)),
+            None => asserter.push_failure_msg("execution reverted"),
+        }
+        match pool {
+            Some(p) => asserter.push_success(&encode_address(p)),
+            None => asserter.push_failure_msg("execution reverted"),
+        }
+        match reserve_a_token {
+            Some(a) => asserter.push_success(&encode_reserve_data(a)),
+            None => asserter.push_failure_msg("execution reverted"),
+        }
+        asserter
+    }
+
+    /// Probe returns `Some((pool, underlying))` when the token exposes both
+    /// selectors and the pool confirms the token as the registered aToken
+    /// for that underlying.
     #[tokio::test]
     async fn probe_aave_token_accepts_valid_atoken() {
         let a_token = address!("4d5f47fa6a74757f35c14fd3a6ef8e3c9bc514e8");
         let pool = address!("87870bca3f3fd6335c3f4ce8392d69350b4fa4e2");
         let underlying = address!("c02aaa39b223fe8d0a0e5c4f27ead9083c756cc2");
+        let web3 = Web3::with_asserter(probe_asserter(Some(underlying), Some(pool), Some(a_token)));
 
-        let asserter = Asserter::new();
-        // 1. UNDERLYING_ASSET_ADDRESS() → underlying
-        asserter.push_success(&encode_address(underlying));
-        // 2. POOL() → pool
-        asserter.push_success(&encode_address(pool));
-        // 3. pool.getReserveData(underlying) → ReserveData { aTokenAddress: a_token, ..
-        //    }
-        asserter.push_success(&encode_reserve_data(a_token));
-
-        let web3 = Web3::with_asserter(asserter);
         assert_eq!(
             probe_aave_token(&web3, a_token).await,
             Some((pool, underlying))
         );
     }
 
-    /// Anything that doesn't answer both selectors is rejected, so non-aToken
-    /// ERC-20s don't accidentally pick up the Aave strategy.
+    /// A contract that doesn't expose the aToken selectors — `balanceOf`
+    /// throws when the probe calls `UNDERLYING_ASSET_ADDRESS()` — is
+    /// cleanly rejected so non-aToken ERC-20s don't accidentally pick up
+    /// the Aave strategy.
     #[tokio::test]
     async fn probe_aave_token_rejects_when_underlying_call_reverts() {
         let token = address!("c02aaa39b223fe8d0a0e5c4f27ead9083c756cc2");
-        let asserter = Asserter::new();
-        // First call (UNDERLYING_ASSET_ADDRESS) reverts → probe bails.
-        asserter.push_failure_msg("execution reverted");
-        let web3 = Web3::with_asserter(asserter);
+        let web3 = Web3::with_asserter(probe_asserter(None, None, None));
         assert_eq!(probe_aave_token(&web3, token).await, None);
     }
 
-    /// The probe bails if the pool doesn't look like an Aave v3 Pool
-    /// (e.g. `getReserveData` reverts). This guards against a false
-    /// positive where some random contract exposes both
-    /// `UNDERLYING_ASSET_ADDRESS()` and `POOL()` but the named pool has
-    /// nothing to do with Aave.
+    /// The probe bails if the claimed pool doesn't respond to
+    /// `getReserveData` — guards against a contract exposing both
+    /// `UNDERLYING_ASSET_ADDRESS()` and `POOL()` while pointing at
+    /// something that isn't actually an Aave v3 pool.
     #[tokio::test]
     async fn probe_aave_token_rejects_when_pool_is_not_aave() {
         let token = address!("1111111111111111111111111111111111111111");
         let pool = address!("2222222222222222222222222222222222222222");
         let underlying = address!("3333333333333333333333333333333333333333");
-
-        let asserter = Asserter::new();
-        asserter.push_success(&encode_address(underlying));
-        asserter.push_success(&encode_address(pool));
-        asserter.push_failure_msg("execution reverted");
-
-        let web3 = Web3::with_asserter(asserter);
+        let web3 = Web3::with_asserter(probe_asserter(Some(underlying), Some(pool), None));
         assert_eq!(probe_aave_token(&web3, token).await, None);
     }
 
-    /// A rogue contract that impersonates the aToken interface and points at
-    /// a real Aave pool is rejected: the pool registers a *different*
+    /// A rogue contract that impersonates the aToken interface and points
+    /// at a real Aave pool is rejected: the pool registers a *different*
     /// `aTokenAddress` for the underlying, so the identity check fails.
     #[tokio::test]
     async fn probe_aave_token_rejects_when_pool_registers_a_different_atoken() {
@@ -319,14 +327,12 @@ mod tests {
         let real_a_token = address!("4d5f47fa6a74757f35c14fd3a6ef8e3c9bc514e8");
         let pool = address!("87870bca3f3fd6335c3f4ce8392d69350b4fa4e2");
         let underlying = address!("c02aaa39b223fe8d0a0e5c4f27ead9083c756cc2");
-
-        let asserter = Asserter::new();
-        asserter.push_success(&encode_address(underlying));
-        asserter.push_success(&encode_address(pool));
-        // Pool agrees on the pair but names the *real* aToken, not the rogue.
-        asserter.push_success(&encode_reserve_data(real_a_token));
-
-        let web3 = Web3::with_asserter(asserter);
+        let web3 = Web3::with_asserter(probe_asserter(
+            Some(underlying),
+            Some(pool),
+            // Pool agrees on the pair but names the *real* aToken, not the rogue.
+            Some(real_a_token),
+        ));
         assert_eq!(probe_aave_token(&web3, rogue).await, None);
     }
 }

--- a/crates/balance-overrides/src/aave.rs
+++ b/crates/balance-overrides/src/aave.rs
@@ -123,37 +123,13 @@ pub async fn probe_aave_token(web3: &Web3, token: Address) -> Option<(Address, A
     let a_token = IAaveV3AToken::new(token, web3.provider.clone());
     let underlying_call = a_token.UNDERLYING_ASSET_ADDRESS();
     let pool_call = a_token.POOL();
-    let (underlying, pool) = tokio::join!(underlying_call.call(), pool_call.call());
-    let underlying = underlying.ok()?;
-    let pool = pool.ok()?;
-    let reserve = fetch_reserve_data(web3, pool, underlying).await?;
-    (reserve.aTokenAddress == token).then_some((pool, underlying))
-}
-
-/// Fetches `getReserveData(underlying)` from an Aave v3 Pool.
-async fn fetch_reserve_data(
-    web3: &Web3,
-    pool: Address,
-    underlying: Address,
-) -> Option<ReserveData> {
-    IAaveV3Pool::new(pool, web3.provider.clone())
+    let (underlying, pool) = tokio::try_join!(underlying_call.call(), pool_call.call()).ok()?;
+    let reserve = IAaveV3Pool::new(pool, web3.provider.clone())
         .getReserveData(underlying)
         .call()
         .await
-        .ok()
-}
-
-/// Fetches `getReserveNormalizedIncome(underlying)` from an Aave v3 Pool.
-pub async fn fetch_normalized_income(
-    web3: &Web3,
-    pool: Address,
-    underlying: Address,
-) -> Option<U256> {
-    IAaveV3Pool::new(pool, web3.provider.clone())
-        .getReserveNormalizedIncome(underlying)
-        .call()
-        .await
-        .ok()
+        .ok()?;
+    (reserve.aTokenAddress == token).then_some((pool, underlying))
 }
 
 /// Builds a state override that makes `balanceOf(holder)` on the aToken
@@ -168,36 +144,33 @@ pub async fn build_override(
     holder: Address,
     amount: U256,
 ) -> Option<(Address, AccountOverride)> {
-    let index = match fetch_normalized_income(web3, pool, underlying).await {
-        Some(index) => index,
-        None => {
-            tracing::warn!(
-                ?pool,
-                ?underlying,
-                "failed to fetch Aave reserve normalized income"
-            );
-            return None;
-        }
+    let Ok(index) = IAaveV3Pool::new(pool, web3.provider.clone())
+        .getReserveNormalizedIncome(underlying)
+        .call()
+        .await
+    else {
+        tracing::warn!(
+            ?pool,
+            ?underlying,
+            "failed to fetch Aave reserve normalized income"
+        );
+        return None;
     };
 
-    let scaled = match ray_div(amount, index) {
-        Some(scaled) => scaled,
-        None => {
-            // Either `amount * RAY` overflowed U256 (only possible for an
-            // astronomically large requested amount) or the pool returned a
-            // zero index (never should happen for a live reserve). Either
-            // way, surface it explicitly so we don't silently drop the
-            // override.
-            tracing::warn!(
-                ?a_token,
-                %amount,
-                %index,
-                "ray_div overflow computing AaveV3AToken scaled balance"
-            );
-            return None;
-        }
+    let Some(scaled) = ray_div(amount, index) else {
+        // Either `amount * RAY` overflowed U256 (only possible for an
+        // astronomically large requested amount) or the pool returned a
+        // zero index (never should happen for a live reserve). Either way,
+        // surface it explicitly so we don't silently drop the override.
+        tracing::warn!(
+            ?a_token,
+            %amount,
+            %index,
+            "ray_div overflow computing AaveV3AToken scaled balance"
+        );
+        return None;
     };
-    let slot = mapping_slot_hash(&holder, &map_slot.to_be_bytes::<32>());
+    let slot = mapping_slot_hash(&holder, &map_slot.to_be_bytes());
     let value = pack_user_state(scaled, U256::ZERO);
 
     tracing::trace!(
@@ -226,7 +199,7 @@ mod tests {
     };
 
     fn encode_address(addr: Address) -> String {
-        hex::encode_prefixed(U256::from_be_bytes(addr.into_word().0).to_be_bytes::<32>())
+        hex::encode_prefixed(addr.into_word())
     }
 
     /// Encodes a `ReserveData` struct as the ABI return payload the pool
@@ -278,21 +251,11 @@ mod tests {
         asserter
     }
 
-    /// Probe returns `Some((pool, underlying))` when the token exposes both
-    /// selectors and the pool confirms the token as the registered aToken
-    /// for that underlying.
-    #[tokio::test]
-    async fn probe_aave_token_accepts_valid_atoken() {
-        let a_token = address!("4d5f47fa6a74757f35c14fd3a6ef8e3c9bc514e8");
-        let pool = address!("87870bca3f3fd6335c3f4ce8392d69350b4fa4e2");
-        let underlying = address!("c02aaa39b223fe8d0a0e5c4f27ead9083c756cc2");
-        let web3 = Web3::with_asserter(probe_asserter(Some(underlying), Some(pool), Some(a_token)));
-
-        assert_eq!(
-            probe_aave_token(&web3, a_token).await,
-            Some((pool, underlying))
-        );
-    }
+    // The happy path (probe accepts a valid aToken) is covered by the
+    // forked-e2e `forked_node_mainnet_aave_atoken_detection` test, which runs
+    // against a real mainnet fork. The tests below cover the rejection
+    // branches, which would require deploying scaffold contracts on a fork
+    // to reproduce — cheaper to simulate with the mock `Asserter`.
 
     /// A contract that doesn't expose the aToken selectors — `balanceOf`
     /// throws when the probe calls `UNDERLYING_ASSET_ADDRESS()` — is

--- a/crates/balance-overrides/src/aave.rs
+++ b/crates/balance-overrides/src/aave.rs
@@ -116,13 +116,16 @@ pub fn pack_user_state(balance: U256, additional_data: U256) -> B256 {
 /// aToken" and "contract impersonates the aToken interface but is not
 /// registered with the pool for its declared underlying."
 pub async fn probe_a_token(web3: &Web3, token: Address) -> Option<(Address, Address)> {
-    let underlying = call_address(
-        web3,
-        token,
-        IAaveV3AToken::UNDERLYING_ASSET_ADDRESSCall {}.abi_encode(),
-    )
-    .await?;
-    let pool = call_address(web3, token, IAaveV3AToken::POOLCall {}.abi_encode()).await?;
+    let (underlying, pool) = tokio::join!(
+        call_address(
+            web3,
+            token,
+            IAaveV3AToken::UNDERLYING_ASSET_ADDRESSCall {}.abi_encode(),
+        ),
+        call_address(web3, token, IAaveV3AToken::POOLCall {}.abi_encode()),
+    );
+    let underlying = underlying?;
+    let pool = pool?;
     let reserve = fetch_reserve_data(web3, pool, underlying).await?;
     (reserve.aTokenAddress == token).then_some((pool, underlying))
 }
@@ -185,7 +188,23 @@ pub async fn build_override(
         }
     };
 
-    let scaled = ray_div(amount, index)?;
+    let scaled = match ray_div(amount, index) {
+        Some(scaled) => scaled,
+        None => {
+            // Either `amount * RAY` overflowed U256 (only possible for an
+            // astronomically large requested amount) or the pool returned a
+            // zero index (never should happen for a live reserve). Either
+            // way, surface it explicitly so we don't silently drop the
+            // override.
+            tracing::warn!(
+                ?a_token,
+                %amount,
+                %index,
+                "ray_div overflow computing AaveV3AToken scaled balance"
+            );
+            return None;
+        }
+    };
     let slot = mapping_slot_hash(&holder, &map_slot.to_be_bytes::<32>());
     let value = pack_user_state(scaled, U256::ZERO);
 

--- a/crates/balance-overrides/src/aave.rs
+++ b/crates/balance-overrides/src/aave.rs
@@ -22,6 +22,8 @@ use {
 
 sol! {
     /// Mirrors Aave v3's `DataTypes.ReserveConfigurationMap`.
+    ///
+    /// Source: <https://github.com/aave-dao/aave-v3-origin/blob/main/src/contracts/protocol/libraries/types/DataTypes.sol>
     struct ReserveConfigurationMap {
         uint256 data;
     }
@@ -29,6 +31,8 @@ sol! {
     /// Mirrors Aave v3's `DataTypes.ReserveData`. Only the `aTokenAddress`
     /// field is consumed here; the rest are present to keep the ABI layout
     /// exactly matched so decoding doesn't go off the rails.
+    ///
+    /// Source: <https://github.com/aave-dao/aave-v3-origin/blob/main/src/contracts/protocol/libraries/types/DataTypes.sol>
     struct ReserveData {
         ReserveConfigurationMap configuration;
         uint128 liquidityIndex;
@@ -52,6 +56,8 @@ sol! {
     /// `getReserveData` returns the full reserve record which we use to
     /// confirm a probed token really is the registered aToken for its
     /// underlying.
+    ///
+    /// Source: <https://github.com/aave-dao/aave-v3-origin/blob/main/src/contracts/interfaces/IPool.sol>
     interface IAaveV3Pool {
         function getReserveNormalizedIncome(address asset) external view returns (uint256);
         function getReserveData(address asset) external view returns (ReserveData memory);
@@ -59,6 +65,8 @@ sol! {
 
     /// Minimal interface for an Aave v3 `AToken`; used by the detector to
     /// decide whether a token is an aToken without any hardcoded list.
+    ///
+    /// Source: <https://github.com/aave-dao/aave-v3-origin/blob/main/src/contracts/interfaces/IAToken.sol>
     interface IAaveV3AToken {
         function UNDERLYING_ASSET_ADDRESS() external view returns (address);
         function POOL() external view returns (address);

--- a/crates/balance-overrides/src/aave.rs
+++ b/crates/balance-overrides/src/aave.rs
@@ -1,0 +1,238 @@
+//! Helpers shared between the production balance-override path
+//! (`BalanceOverrides`) and the auto-detector for Aave v3 aTokens.
+//!
+//! aTokens break the usual "balanceOf = storage[slot]" assumption twice:
+//! - `balanceOf` returns `scaled_balance × getReserveNormalizedIncome / RAY`,
+//!   not the raw slot value.
+//! - Storage is packed `UserState { uint128 balance; uint128 additionalData }`
+//!   in a single slot per holder.
+//!
+//! The helpers below encode exactly these two facts so both the override
+//! builder and the detector probe/verify use the same math.
+
+use {
+    alloy_eips::BlockId,
+    alloy_primitives::{Address, B256, Bytes, TxKind, U256, keccak256},
+    alloy_provider::Provider,
+    alloy_rpc_types::{TransactionInput, TransactionRequest, state::AccountOverride},
+    alloy_sol_types::{SolCall, sol},
+    ethrpc::Web3,
+    std::iter,
+};
+
+sol! {
+    /// Minimal interface for the Aave v3 `Pool` used to derive the current
+    /// liquidity index applied by aTokens when reporting `balanceOf`.
+    interface IAaveV3Pool {
+        function getReserveNormalizedIncome(address asset) external view returns (uint256);
+    }
+
+    /// Minimal interface for an Aave v3 `AToken`; used by the detector to
+    /// decide whether a token is an aToken without any hardcoded list.
+    interface IAaveV3AToken {
+        function UNDERLYING_ASSET_ADDRESS() external view returns (address);
+        function POOL() external view returns (address);
+    }
+}
+
+/// Ray (1e27) — Aave's 27-decimal fixed-point unit.
+pub const RAY: U256 = U256::from_limbs([0x9fd0803ce8000000, 0x33b2e3c, 0, 0]);
+
+/// Ray-division: `(a * RAY + b/2) / b`, round-half-up. Matches Aave's
+/// `WadRayMath.rayDiv` bit-for-bit so the scaled amount we write into
+/// storage equals the one Aave will itself compute during a subsequent
+/// `_transfer`. Returns `None` if `b == 0` or the intermediate product
+/// overflows `U256`.
+pub fn ray_div(a: U256, b: U256) -> Option<U256> {
+    if b.is_zero() {
+        return None;
+    }
+    let half_b = b >> 1;
+    a.checked_mul(RAY)
+        .and_then(|prod| prod.checked_add(half_b))
+        .map(|num| num / b)
+}
+
+/// `keccak256(pad32(holder) ++ map_slot)` — the storage slot of
+/// `mapping(address => _)` entries in Solidity.
+pub fn mapping_slot_hash(holder: &Address, map_slot: &[u8; 32]) -> B256 {
+    let mut buf = [0u8; 64];
+    buf[12..32].copy_from_slice(holder.as_slice());
+    buf[32..64].copy_from_slice(map_slot);
+    keccak256(buf)
+}
+
+/// Packs a `UserState { uint128 balance; uint128 additionalData }` into a
+/// 32-byte word. The balance occupies the lower 128 bits; `additional_data`
+/// sits in the upper 128 bits.
+pub fn pack_user_state(balance: U256, additional_data: U256) -> B256 {
+    let mask = (U256::from(1u64) << 128) - U256::from(1u64);
+    let packed: U256 = ((additional_data & mask) << 128) | (balance & mask);
+    B256::new(packed.to_be_bytes::<32>())
+}
+
+/// Probes whether `token` looks like an Aave v3 aToken by querying
+/// `UNDERLYING_ASSET_ADDRESS()` and `POOL()`. Returns `Some((pool,
+/// underlying))` if both calls succeed and the returned pool responds to
+/// `getReserveNormalizedIncome(underlying)` — an extra safety check against
+/// tokens that happen to implement the two selectors but aren't Aave v3.
+pub async fn probe_a_token(web3: &Web3, token: Address) -> Option<(Address, Address)> {
+    let underlying = call_address(
+        web3,
+        token,
+        IAaveV3AToken::UNDERLYING_ASSET_ADDRESSCall {}.abi_encode(),
+    )
+    .await?;
+    let pool = call_address(web3, token, IAaveV3AToken::POOLCall {}.abi_encode()).await?;
+    // Sanity: confirm the pool actually exposes the expected interface.
+    fetch_normalized_income(web3, pool, underlying).await?;
+    Some((pool, underlying))
+}
+
+/// Fetches `getReserveNormalizedIncome(underlying)` from an Aave v3 Pool.
+pub async fn fetch_normalized_income(
+    web3: &Web3,
+    pool: Address,
+    underlying: Address,
+) -> Option<U256> {
+    let call = IAaveV3Pool::getReserveNormalizedIncomeCall { asset: underlying };
+    let calldata = Bytes::from(call.abi_encode());
+    let tx = TransactionRequest {
+        to: Some(TxKind::Call(pool)),
+        input: TransactionInput::new(calldata),
+        ..Default::default()
+    };
+    let bytes = web3.provider.call(tx).block(BlockId::latest()).await.ok()?;
+    IAaveV3Pool::getReserveNormalizedIncomeCall::abi_decode_returns(&bytes).ok()
+}
+
+/// Builds a state override that makes `balanceOf(holder)` on the aToken
+/// report approximately `amount`. Returns `None` if we can't reach the pool
+/// or the math overflows.
+pub async fn build_override(
+    web3: &Web3,
+    a_token: Address,
+    pool: Address,
+    underlying: Address,
+    map_slot: U256,
+    holder: Address,
+    amount: U256,
+) -> Option<(Address, AccountOverride)> {
+    let index = match fetch_normalized_income(web3, pool, underlying).await {
+        Some(index) => index,
+        None => {
+            tracing::warn!(
+                ?pool,
+                ?underlying,
+                "failed to fetch Aave reserve normalized income"
+            );
+            return None;
+        }
+    };
+
+    let scaled = ray_div(amount, index)?;
+    let slot = mapping_slot_hash(&holder, &map_slot.to_be_bytes::<32>());
+    let value = pack_user_state(scaled, U256::ZERO);
+
+    tracing::trace!(
+        ?a_token,
+        ?holder,
+        %amount,
+        %index,
+        %scaled,
+        "computed AaveV3AToken balance override"
+    );
+
+    let state_override = AccountOverride {
+        state_diff: Some(iter::once((slot, value)).collect()),
+        ..Default::default()
+    };
+    Some((a_token, state_override))
+}
+
+/// Helper: `eth_call` a zero-argument view returning `address`. Returns
+/// `None` on any RPC error or decode failure (including the common case of
+/// the token not exposing this selector at all).
+async fn call_address(web3: &Web3, to: Address, calldata: Vec<u8>) -> Option<Address> {
+    let tx = TransactionRequest {
+        to: Some(TxKind::Call(to)),
+        input: TransactionInput::new(calldata.into()),
+        ..Default::default()
+    };
+    let bytes = web3.provider.call(tx).block(BlockId::latest()).await.ok()?;
+    if bytes.len() < 32 {
+        return None;
+    }
+    // ABI-encoded `address` is right-aligned in the 32-byte word.
+    let addr = Address::from_slice(&bytes[12..32]);
+    // Treat zero as "not an aToken" — a zero underlying/pool is never legal.
+    (!addr.is_zero()).then_some(addr)
+}
+
+#[cfg(test)]
+mod tests {
+    use {super::*, alloy_primitives::address, alloy_provider::mock::Asserter};
+
+    fn encode_address(addr: Address) -> String {
+        format!("0x{:0>64x}", U256::from_be_bytes(addr.into_word().0))
+    }
+
+    fn encode_uint(value: U256) -> String {
+        format!("0x{:064x}", value)
+    }
+
+    /// The probe returns `Some((pool, underlying))` when the token exposes
+    /// both selectors and the pool responds to `getReserveNormalizedIncome`.
+    #[tokio::test]
+    async fn probe_a_token_accepts_valid_atoken() {
+        let a_token = address!("4d5f47fa6a74757f35c14fd3a6ef8e3c9bc514e8");
+        let pool = address!("87870bca3f3fd6335c3f4ce8392d69350b4fa4e2");
+        let underlying = address!("c02aaa39b223fe8d0a0e5c4f27ead9083c756cc2");
+
+        let asserter = Asserter::new();
+        // 1. UNDERLYING_ASSET_ADDRESS() → underlying
+        asserter.push_success(&encode_address(underlying));
+        // 2. POOL() → pool
+        asserter.push_success(&encode_address(pool));
+        // 3. pool.getReserveNormalizedIncome(underlying) → some ray value
+        asserter.push_success(&encode_uint(RAY));
+
+        let web3 = Web3::with_asserter(asserter);
+        assert_eq!(
+            probe_a_token(&web3, a_token).await,
+            Some((pool, underlying))
+        );
+    }
+
+    /// Anything that doesn't answer both selectors is rejected, so non-aToken
+    /// ERC-20s don't accidentally pick up the Aave strategy.
+    #[tokio::test]
+    async fn probe_a_token_rejects_when_underlying_call_reverts() {
+        let token = address!("c02aaa39b223fe8d0a0e5c4f27ead9083c756cc2");
+        let asserter = Asserter::new();
+        // First call (UNDERLYING_ASSET_ADDRESS) reverts → probe bails.
+        asserter.push_failure_msg("execution reverted");
+        let web3 = Web3::with_asserter(asserter);
+        assert_eq!(probe_a_token(&web3, token).await, None);
+    }
+
+    /// The probe also bails if the pool doesn't look like an Aave v3 Pool
+    /// (e.g. `getReserveNormalizedIncome` reverts). This guards against a
+    /// false positive where some random contract exposes both
+    /// `UNDERLYING_ASSET_ADDRESS()` and `POOL()` but has nothing to do with
+    /// Aave.
+    #[tokio::test]
+    async fn probe_a_token_rejects_when_pool_is_not_aave() {
+        let token = address!("1111111111111111111111111111111111111111");
+        let pool = address!("2222222222222222222222222222222222222222");
+        let underlying = address!("3333333333333333333333333333333333333333");
+
+        let asserter = Asserter::new();
+        asserter.push_success(&encode_address(underlying));
+        asserter.push_success(&encode_address(pool));
+        asserter.push_failure_msg("execution reverted");
+
+        let web3 = Web3::with_asserter(asserter);
+        assert_eq!(probe_a_token(&web3, token).await, None);
+    }
+}

--- a/crates/balance-overrides/src/aave.rs
+++ b/crates/balance-overrides/src/aave.rs
@@ -119,7 +119,7 @@ pub fn pack_user_state(balance: U256, additional_data: U256) -> B256 {
 /// underlying)` pair. Accepts the token iff the pool registers it as the
 /// aToken for its declared underlying — rogue contracts implementing the
 /// aToken selectors aren't enough.
-pub async fn probe_a_token(web3: &Web3, token: Address) -> Option<(Address, Address)> {
+pub async fn probe_aave_token(web3: &Web3, token: Address) -> Option<(Address, Address)> {
     let a_token = IAaveV3AToken::new(token, web3.provider.clone());
     let underlying_call = a_token.UNDERLYING_ASSET_ADDRESS();
     let pool_call = a_token.POOL();
@@ -220,13 +220,13 @@ pub async fn build_override(
 mod tests {
     use {
         super::*,
-        alloy_primitives::address,
+        alloy_primitives::{address, hex},
         alloy_provider::mock::Asserter,
         alloy_sol_types::SolValue,
     };
 
     fn encode_address(addr: Address) -> String {
-        format!("0x{:0>64x}", U256::from_be_bytes(addr.into_word().0))
+        hex::encode_prefixed(U256::from_be_bytes(addr.into_word().0).to_be_bytes::<32>())
     }
 
     /// Encodes a `ReserveData` struct as the ABI return payload the pool
@@ -250,14 +250,14 @@ mod tests {
             unbacked: 0,
             isolationModeTotalDebt: 0,
         };
-        format!("0x{}", alloy_primitives::hex::encode(data.abi_encode()))
+        hex::encode_prefixed(data.abi_encode())
     }
 
     /// The probe returns `Some((pool, underlying))` when the token exposes
     /// both selectors and the pool confirms the token as the registered
     /// aToken for that underlying.
     #[tokio::test]
-    async fn probe_a_token_accepts_valid_atoken() {
+    async fn probe_aave_token_accepts_valid_atoken() {
         let a_token = address!("4d5f47fa6a74757f35c14fd3a6ef8e3c9bc514e8");
         let pool = address!("87870bca3f3fd6335c3f4ce8392d69350b4fa4e2");
         let underlying = address!("c02aaa39b223fe8d0a0e5c4f27ead9083c756cc2");
@@ -273,7 +273,7 @@ mod tests {
 
         let web3 = Web3::with_asserter(asserter);
         assert_eq!(
-            probe_a_token(&web3, a_token).await,
+            probe_aave_token(&web3, a_token).await,
             Some((pool, underlying))
         );
     }
@@ -281,13 +281,13 @@ mod tests {
     /// Anything that doesn't answer both selectors is rejected, so non-aToken
     /// ERC-20s don't accidentally pick up the Aave strategy.
     #[tokio::test]
-    async fn probe_a_token_rejects_when_underlying_call_reverts() {
+    async fn probe_aave_token_rejects_when_underlying_call_reverts() {
         let token = address!("c02aaa39b223fe8d0a0e5c4f27ead9083c756cc2");
         let asserter = Asserter::new();
         // First call (UNDERLYING_ASSET_ADDRESS) reverts → probe bails.
         asserter.push_failure_msg("execution reverted");
         let web3 = Web3::with_asserter(asserter);
-        assert_eq!(probe_a_token(&web3, token).await, None);
+        assert_eq!(probe_aave_token(&web3, token).await, None);
     }
 
     /// The probe bails if the pool doesn't look like an Aave v3 Pool
@@ -296,7 +296,7 @@ mod tests {
     /// `UNDERLYING_ASSET_ADDRESS()` and `POOL()` but the named pool has
     /// nothing to do with Aave.
     #[tokio::test]
-    async fn probe_a_token_rejects_when_pool_is_not_aave() {
+    async fn probe_aave_token_rejects_when_pool_is_not_aave() {
         let token = address!("1111111111111111111111111111111111111111");
         let pool = address!("2222222222222222222222222222222222222222");
         let underlying = address!("3333333333333333333333333333333333333333");
@@ -307,14 +307,14 @@ mod tests {
         asserter.push_failure_msg("execution reverted");
 
         let web3 = Web3::with_asserter(asserter);
-        assert_eq!(probe_a_token(&web3, token).await, None);
+        assert_eq!(probe_aave_token(&web3, token).await, None);
     }
 
     /// A rogue contract that impersonates the aToken interface and points at
     /// a real Aave pool is rejected: the pool registers a *different*
     /// `aTokenAddress` for the underlying, so the identity check fails.
     #[tokio::test]
-    async fn probe_a_token_rejects_when_pool_registers_a_different_atoken() {
+    async fn probe_aave_token_rejects_when_pool_registers_a_different_atoken() {
         let rogue = address!("bad000000000000000000000000000000000cafe");
         let real_a_token = address!("4d5f47fa6a74757f35c14fd3a6ef8e3c9bc514e8");
         let pool = address!("87870bca3f3fd6335c3f4ce8392d69350b4fa4e2");
@@ -327,6 +327,6 @@ mod tests {
         asserter.push_success(&encode_reserve_data(real_a_token));
 
         let web3 = Web3::with_asserter(asserter);
-        assert_eq!(probe_a_token(&web3, rogue).await, None);
+        assert_eq!(probe_aave_token(&web3, rogue).await, None);
     }
 }

--- a/crates/balance-overrides/src/aave.rs
+++ b/crates/balance-overrides/src/aave.rs
@@ -251,12 +251,6 @@ mod tests {
         asserter
     }
 
-    // The happy path (probe accepts a valid aToken) is covered by the
-    // forked-e2e `forked_node_mainnet_aave_atoken_detection` test, which runs
-    // against a real mainnet fork. The tests below cover the rejection
-    // branches, which would require deploying scaffold contracts on a fork
-    // to reproduce — cheaper to simulate with the mock `Asserter`.
-
     /// A contract that doesn't expose the aToken selectors — `balanceOf`
     /// throws when the probe calls `UNDERLYING_ASSET_ADDRESS()` — is
     /// cleanly rejected so non-aToken ERC-20s don't accidentally pick up

--- a/crates/balance-overrides/src/aave.rs
+++ b/crates/balance-overrides/src/aave.rs
@@ -133,14 +133,14 @@ pub async fn probe_aave_token(web3: &Web3, token: Address) -> Option<(Address, A
 }
 
 /// Builds a state override that makes `balanceOf(holder)` on the aToken
-/// report approximately `amount`. Returns `None` if we can't reach the pool
-/// or the math overflows.
+/// report approximately `amount`. Writes into the canonical `_userState`
+/// slot (`USER_STATE_SLOT`) shared by all Aave v3 aTokens. Returns `None`
+/// if we can't reach the pool or the math overflows.
 pub async fn build_override(
     web3: &Web3,
     a_token: Address,
     pool: Address,
     underlying: Address,
-    map_slot: U256,
     holder: Address,
     amount: U256,
 ) -> Option<(Address, AccountOverride)> {
@@ -170,7 +170,7 @@ pub async fn build_override(
         );
         return None;
     };
-    let slot = mapping_slot_hash(&holder, &map_slot.to_be_bytes());
+    let slot = mapping_slot_hash(&holder, &U256::from(USER_STATE_SLOT).to_be_bytes());
     let value = pack_user_state(scaled, U256::ZERO);
 
     tracing::trace!(

--- a/crates/balance-overrides/src/detector.rs
+++ b/crates/balance-overrides/src/detector.rs
@@ -492,32 +492,6 @@ mod tests {
         );
     }
 
-    /// The detector recognises aEthWETH as an Aave v3 aToken (via
-    /// `UNDERLYING_ASSET_ADDRESS()` + `POOL()` probes) and returns the
-    /// right `AaveV3AToken` strategy, scaling and all, without any
-    /// hardcoded per-token config.
-    /// Set `NODE_URL` environment to a mainnet RPC URL.
-    #[ignore]
-    #[tokio::test]
-    async fn detects_aave_v3_a_token_mainnet() {
-        let detector = Detector::new(Web3::new_from_env(), 60, DEFAULT_VERIFICATION_TIMEOUT);
-
-        let a_eth_weth = address!("4d5f47fa6a74757f35c14fd3a6ef8e3c9bc514e8");
-        let strategy = detector
-            .detect(a_eth_weth, Address::with_last_byte(1))
-            .await
-            .unwrap();
-        assert_eq!(
-            strategy,
-            Strategy::AaveV3AToken {
-                target_contract: a_eth_weth,
-                pool: address!("87870bca3f3fd6335c3f4ce8392d69350b4fa4e2"),
-                underlying: address!("c02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"),
-                map_slot: U256::from(52),
-            }
-        );
-    }
-
     /// Tests that we can detect storage slots by probing the first
     /// n slots or by checking hardcoded known slots.
     /// Set `NODE_URL` environment to an arbitrum RPC URL.

--- a/crates/balance-overrides/src/detector.rs
+++ b/crates/balance-overrides/src/detector.rs
@@ -1,8 +1,8 @@
 use {
     super::Strategy,
-    crate::StrategyExt,
+    crate::{StrategyExt, aave},
     alloy_eips::BlockId,
-    alloy_primitives::{Address, B256, TxKind, U256, keccak256},
+    alloy_primitives::{Address, B256, TxKind, U256, keccak256, map::AddressMap},
     alloy_provider::ext::DebugApi,
     alloy_rpc_types::{
         TransactionInput,
@@ -70,6 +70,7 @@ fn create_strategies_from_slots(
     storage_slots: &[(Address, B256)],
     holder: &Address,
     heuristic_depth: usize,
+    aave_info: Option<AaveInfo>,
 ) -> Vec<Strategy> {
     // Build a map from heuristic slot hash to the map_slot index
     let mut solidity_mapping_slot_to_index = HashMap::new();
@@ -92,6 +93,20 @@ fn create_strategies_from_slots(
     let mut fallback_strategies = Vec::new();
     for (contract, slot) in storage_slots.iter().rev() {
         if let Some(&map_slot_index) = solidity_mapping_slot_to_index.get(slot) {
+            // For Aave-compatible aTokens, prefer the AaveV3AToken strategy:
+            // it knows how to scale by the reserve's liquidity index and how
+            // to preserve the packed `UserState.additionalData`. The plain
+            // SolidityMapping entry is added afterwards as a fallback in case
+            // the probe was a false positive (another contract happens to
+            // expose the same two selectors).
+            if let Some(info) = aave_info.as_ref() {
+                heuristic_strategies.push(Strategy::AaveV3AToken {
+                    target_contract: *contract,
+                    pool: info.pool,
+                    underlying: info.underlying,
+                    map_slot: U256::from(map_slot_index),
+                });
+            }
             heuristic_strategies.push(Strategy::SolidityMapping {
                 target_contract: *contract,
                 map_slot: U256::from(map_slot_index),
@@ -112,6 +127,14 @@ fn create_strategies_from_slots(
     // "most recent first" order due to .rev() above.
     heuristic_strategies.extend(fallback_strategies);
     heuristic_strategies
+}
+
+/// Info returned by the Aave probe; plumbed into `create_strategies_from_slots`
+/// so mapping-style slots can also be tried as `AaveV3AToken`.
+#[derive(Clone, Copy, Debug)]
+struct AaveInfo {
+    pool: Address,
+    underlying: Address,
 }
 
 impl Detector {
@@ -166,10 +189,26 @@ impl Detector {
             return Err(DetectionError::NotFound);
         }
 
-        let strategies =
-            create_strategies_from_slots(&storage_slots, &holder, self.probing_depth.into());
+        // Probe whether this token looks like an Aave v3 aToken (has
+        // `UNDERLYING_ASSET_ADDRESS()` and `POOL()` and the pool responds to
+        // `getReserveNormalizedIncome`). If so, `create_strategies_from_slots`
+        // will also emit `AaveV3AToken` candidates so the verify loop picks
+        // them up and returns the right strategy without any hardcoded
+        // per-token config.
+        let aave_info = aave::probe_a_token(&self.web3, token)
+            .await
+            .map(|(pool, underlying)| AaveInfo { pool, underlying });
 
-        if strategies.len() == 1 {
+        let strategies = create_strategies_from_slots(
+            &storage_slots,
+            &holder,
+            self.probing_depth.into(),
+            aave_info,
+        );
+
+        // Only skip verification if there's a single candidate and we're not
+        // dealing with an Aave aToken (where a round-trip check is required).
+        if strategies.len() == 1 && aave_info.is_none() {
             let slot = storage_slots[0];
             tracing::debug!(
                 storage_context = ?slot.0,
@@ -315,6 +354,11 @@ impl Detector {
 
     /// Verifies that a strategy correctly controls the balance by applying it
     /// and checking balanceOf.
+    ///
+    /// For the `AaveV3AToken` variant we allow `balanceOf` to be off by one
+    /// wei, since Aave's ray rounding can slightly differ from our locally
+    /// computed scaled value; for every other variant the check is still an
+    /// exact equality.
     async fn verify_strategy(
         &self,
         token: Address,
@@ -324,8 +368,32 @@ impl Detector {
         // Use a unique test value to verify this strategy works
         let test_balance = U256::from(0x1337_1337_1337_1337_u64);
 
-        // Create state override using the strategy
-        let overrides = strategy.state_override(&holder, &test_balance);
+        // Create state override using the strategy. `AaveV3AToken` needs an
+        // async call to the pool to compute the scaled storage value, so we
+        // reuse the production builder rather than `StrategyExt::state_override`
+        // (which intentionally `unreachable!()`s for this variant).
+        let overrides: AddressMap<_> = match strategy {
+            Strategy::AaveV3AToken {
+                target_contract,
+                pool,
+                underlying,
+                map_slot,
+            } => {
+                let (target, account_override) = aave::build_override(
+                    &self.web3,
+                    *target_contract,
+                    *pool,
+                    *underlying,
+                    *map_slot,
+                    holder,
+                    test_balance,
+                )
+                .await
+                .ok_or(DetectionError::NotFound)?;
+                std::iter::once((target, account_override)).collect()
+            }
+            _ => strategy.state_override(&holder, &test_balance),
+        };
 
         // Call balanceOf with the override
         let token_contract = ERC20::Instance::new(token, self.web3.provider.clone());
@@ -340,8 +408,21 @@ impl Detector {
                 )))
             })?;
 
-        // If the balance matches our test value, the strategy works
-        if balance == test_balance {
+        // aToken balances round-trip through rayDiv/rayMul so the reported
+        // balance may differ from the written value by one wei. Every other
+        // strategy must match exactly.
+        let ok = if matches!(strategy, Strategy::AaveV3AToken { .. }) {
+            let diff = if balance >= test_balance {
+                balance - test_balance
+            } else {
+                test_balance - balance
+            };
+            diff <= U256::from(1u64)
+        } else {
+            balance == test_balance
+        };
+
+        if ok {
             Ok(())
         } else {
             Err(DetectionError::NotFound)
@@ -433,27 +514,29 @@ mod tests {
         );
     }
 
-    /// aEthWETH (Aave v3) can't be auto-detected: its `balanceOf` applies a
-    /// liquidity-index scaling so the verify step never sees back the exact
-    /// value we write. This documents the limitation and motivates the
-    /// `AaveV3AToken` hardcoded strategy. Kept separate from
-    /// `detects_storage_slots_mainnet` so this assertion is not gated by
-    /// unrelated expectations in that test.
+    /// The detector recognises aEthWETH as an Aave v3 aToken (via
+    /// `UNDERLYING_ASSET_ADDRESS()` + `POOL()` probes) and returns the
+    /// right `AaveV3AToken` strategy, scaling and all, without any
+    /// hardcoded per-token config.
     /// Set `NODE_URL` environment to a mainnet RPC URL.
     #[ignore]
     #[tokio::test]
-    async fn detects_storage_slots_mainnet_aave_atoken_not_found() {
+    async fn detects_aave_v3_a_token_mainnet() {
         let detector = Detector::new(Web3::new_from_env(), 60, DEFAULT_VERIFICATION_TIMEOUT);
 
-        let result = detector
-            .detect(
-                address!("4d5f47fa6a74757f35c14fd3a6ef8e3c9bc514e8"),
-                Address::with_last_byte(1),
-            )
-            .await;
-        assert!(
-            matches!(result, Err(DetectionError::NotFound)),
-            "expected NotFound for aEthWETH, got {result:?}",
+        let a_eth_weth = address!("4d5f47fa6a74757f35c14fd3a6ef8e3c9bc514e8");
+        let strategy = detector
+            .detect(a_eth_weth, Address::with_last_byte(1))
+            .await
+            .unwrap();
+        assert_eq!(
+            strategy,
+            Strategy::AaveV3AToken {
+                target_contract: a_eth_weth,
+                pool: address!("87870bca3f3fd6335c3f4ce8392d69350b4fa4e2"),
+                underlying: address!("c02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"),
+                map_slot: U256::from(52),
+            }
         );
     }
 
@@ -500,7 +583,7 @@ mod tests {
 
         // These slots don't match any heuristic, so should just be reversed and return
         // DirectSlot
-        let strategies = create_strategies_from_slots(&slots, &holder, 5);
+        let strategies = create_strategies_from_slots(&slots, &holder, 5, None);
 
         assert_eq!(
             strategies,
@@ -559,7 +642,7 @@ mod tests {
             (contract, heuristic_slot1),
         ];
 
-        let strategies = create_strategies_from_slots(&slots, &holder, 100);
+        let strategies = create_strategies_from_slots(&slots, &holder, 100, None);
 
         // After reverse: [heuristic, non_heuristic]
         // After sort: non-heuristic slots come before heuristic slots due to false <
@@ -616,7 +699,7 @@ mod tests {
             (contract, slot3),
         ];
 
-        let strategies = create_strategies_from_slots(&slots, &holder, 0);
+        let strategies = create_strategies_from_slots(&slots, &holder, 0, None);
 
         // With depth 0, no heuristic slots are created, so all become DirectSlot and
         // just reversed

--- a/crates/balance-overrides/src/detector.rs
+++ b/crates/balance-overrides/src/detector.rs
@@ -165,10 +165,7 @@ impl Detector {
                 .await
                 .is_ok()
             {
-                tracing::debug!(
-                    ?token,
-                    "detected Aave v3 aToken via fast-path (no debug_traceCall)"
-                );
+                tracing::debug!(?token, "detected Aave v3 aToken");
                 return Ok(candidate);
             }
             tracing::debug!(

--- a/crates/balance-overrides/src/detector.rs
+++ b/crates/balance-overrides/src/detector.rs
@@ -66,11 +66,14 @@ impl std::ops::Deref for Detector {
 /// 2. Use the Solidity mapping hashes as a heuristic and prioritize scanning
 ///    those storage slots first - these return `SolidityMapping` strategy
 /// 3. For non-heuristic slots, return `DirectSlot` strategy
+///
+/// Note: this function does not emit `AaveV3AToken` candidates. Aave v3 is
+/// handled by the fast-path in `detect()` which tries the canonical
+/// `_userState` slot directly; the fallback here is for non-Aave tokens only.
 fn create_strategies_from_slots(
     storage_slots: &[(Address, B256)],
     holder: &Address,
     heuristic_depth: usize,
-    aave_info: Option<AaveInfo>,
 ) -> Vec<Strategy> {
     // Build a map from heuristic slot hash to the map_slot index
     let mut solidity_mapping_slot_to_index = HashMap::new();
@@ -93,20 +96,6 @@ fn create_strategies_from_slots(
     let mut fallback_strategies = Vec::new();
     for (contract, slot) in storage_slots.iter().rev() {
         if let Some(&map_slot_index) = solidity_mapping_slot_to_index.get(slot) {
-            // For Aave-compatible aTokens, prefer the AaveV3AToken strategy:
-            // it knows how to scale by the reserve's liquidity index and how
-            // to preserve the packed `UserState.additionalData`. The plain
-            // SolidityMapping entry is added afterwards as a fallback in case
-            // the probe was a false positive (another contract happens to
-            // expose the same two selectors).
-            if let Some(info) = aave_info.as_ref() {
-                heuristic_strategies.push(Strategy::AaveV3AToken {
-                    target_contract: *contract,
-                    pool: info.pool,
-                    underlying: info.underlying,
-                    map_slot: U256::from(map_slot_index),
-                });
-            }
             heuristic_strategies.push(Strategy::SolidityMapping {
                 target_contract: *contract,
                 map_slot: U256::from(map_slot_index),
@@ -127,14 +116,6 @@ fn create_strategies_from_slots(
     // "most recent first" order due to .rev() above.
     heuristic_strategies.extend(fallback_strategies);
     heuristic_strategies
-}
-
-/// Info returned by the Aave probe; plumbed into `create_strategies_from_slots`
-/// so mapping-style slots can also be tried as `AaveV3AToken`.
-#[derive(Clone, Copy, Debug)]
-struct AaveInfo {
-    pool: Address,
-    underlying: Address,
 }
 
 impl Detector {
@@ -165,20 +146,18 @@ impl Detector {
         token: Address,
         holder: Address,
     ) -> Result<Strategy, DetectionError<TransportErrorKind>> {
-        // Aave fast-path. If the token self-identifies as a v3 aToken and the
-        // pool confirms it, try the canonical `_userState` slot directly. For
-        // an Aave v3 fork that moved `_userState` to a different slot this
-        // verification fails and we fall through to the trace-based path
-        // below, which will still produce an `AaveV3AToken` candidate with
-        // the traced slot.
-        let aave_info = aave::probe_a_token(&self.web3, token)
-            .await
-            .map(|(pool, underlying)| AaveInfo { pool, underlying });
-        if let Some(info) = aave_info.as_ref() {
+        // Aave fast-path. If the token self-identifies as a v3 aToken and
+        // the pool confirms it, try the canonical `_userState` slot
+        // directly — no `debug_traceCall` needed. An Aave v3 fork that
+        // moved `_userState` to a different slot won't verify here and
+        // will fall through to the generic trace-based path, which only
+        // ever returns non-Aave strategies; such a fork needs an explicit
+        // hardcoded config entry.
+        if let Some((pool, underlying)) = aave::probe_a_token(&self.web3, token).await {
             let candidate = Strategy::AaveV3AToken {
                 target_contract: token,
-                pool: info.pool,
-                underlying: info.underlying,
+                pool,
+                underlying,
                 map_slot: U256::from(aave::USER_STATE_SLOT),
             };
             if self
@@ -229,16 +208,10 @@ impl Detector {
             return Err(DetectionError::NotFound);
         }
 
-        let strategies = create_strategies_from_slots(
-            &storage_slots,
-            &holder,
-            self.probing_depth.into(),
-            aave_info,
-        );
+        let strategies =
+            create_strategies_from_slots(&storage_slots, &holder, self.probing_depth.into());
 
-        // Only skip verification if there's a single candidate and we're not
-        // dealing with an Aave aToken (where a round-trip check is required).
-        if strategies.len() == 1 && aave_info.is_none() {
+        if strategies.len() == 1 {
             let slot = storage_slots[0];
             tracing::debug!(
                 storage_context = ?slot.0,
@@ -586,7 +559,7 @@ mod tests {
 
         // These slots don't match any heuristic, so should just be reversed and return
         // DirectSlot
-        let strategies = create_strategies_from_slots(&slots, &holder, 5, None);
+        let strategies = create_strategies_from_slots(&slots, &holder, 5);
 
         assert_eq!(
             strategies,
@@ -645,7 +618,7 @@ mod tests {
             (contract, heuristic_slot1),
         ];
 
-        let strategies = create_strategies_from_slots(&slots, &holder, 100, None);
+        let strategies = create_strategies_from_slots(&slots, &holder, 100);
 
         // After reverse: [heuristic, non_heuristic]
         // After sort: non-heuristic slots come before heuristic slots due to false <
@@ -702,7 +675,7 @@ mod tests {
             (contract, slot3),
         ];
 
-        let strategies = create_strategies_from_slots(&slots, &holder, 0, None);
+        let strategies = create_strategies_from_slots(&slots, &holder, 0);
 
         // With depth 0, no heuristic slots are created, so all become DirectSlot and
         // just reversed

--- a/crates/balance-overrides/src/detector.rs
+++ b/crates/balance-overrides/src/detector.rs
@@ -411,22 +411,15 @@ impl Detector {
         // aToken balances round-trip through rayDiv/rayMul so the reported
         // balance may differ from the written value by one wei. Every other
         // strategy must match exactly.
-        let ok = if matches!(strategy, Strategy::AaveV3AToken { .. }) {
-            let diff = if balance >= test_balance {
-                balance - test_balance
-            } else {
-                test_balance - balance
-            };
-            diff <= U256::from(1u64)
+        let balance_matches = if matches!(strategy, Strategy::AaveV3AToken { .. }) {
+            balance.abs_diff(test_balance) <= U256::from(1u64)
         } else {
             balance == test_balance
         };
 
-        if ok {
-            Ok(())
-        } else {
-            Err(DetectionError::NotFound)
-        }
+        balance_matches
+            .then_some(())
+            .ok_or(DetectionError::NotFound)
     }
 }
 

--- a/crates/balance-overrides/src/detector.rs
+++ b/crates/balance-overrides/src/detector.rs
@@ -2,7 +2,7 @@ use {
     super::Strategy,
     crate::{StrategyExt, aave},
     alloy_eips::BlockId,
-    alloy_primitives::{Address, B256, TxKind, U256, keccak256, map::AddressMap},
+    alloy_primitives::{Address, B256, TxKind, U256, keccak256},
     alloy_provider::ext::DebugApi,
     alloy_rpc_types::{
         TransactionInput,
@@ -147,17 +147,57 @@ impl Detector {
         }))
     }
 
-    /// Detects the balance storage slot using debug_traceCall, similar to
-    /// Foundry's `deal`. This traces a balanceOf call and finds which
-    /// storage slot is accessed. If more than one slot is accessed, we reverse
-    /// by order accessed, sort by if the slot was one that would normally
-    /// be seen in solidity mapping, and test one by one to see if the
-    /// override is effective.
+    /// The `Web3` handle shared with whoever constructed the detector; also
+    /// used by `BalanceOverrides` for strategies that need on-chain reads at
+    /// override-resolution time (e.g. `AaveV3AToken`).
+    pub fn web3(&self) -> &ethrpc::Web3 {
+        &self.web3
+    }
+
+    /// Detects the balance storage slot for `token`.
+    ///
+    /// Takes a fast path for Aave v3 aTokens: a cheap two-call probe, plus
+    /// a single verification using the canonical `_userState` slot — no
+    /// `debug_traceCall` needed on the happy path. Everything else falls
+    /// through to the generic SLOAD-trace detection.
     pub async fn detect(
         &self,
         token: Address,
         holder: Address,
     ) -> Result<Strategy, DetectionError<TransportErrorKind>> {
+        // Aave fast-path. If the token self-identifies as a v3 aToken and the
+        // pool confirms it, try the canonical `_userState` slot directly. For
+        // an Aave v3 fork that moved `_userState` to a different slot this
+        // verification fails and we fall through to the trace-based path
+        // below, which will still produce an `AaveV3AToken` candidate with
+        // the traced slot.
+        let aave_info = aave::probe_a_token(&self.web3, token)
+            .await
+            .map(|(pool, underlying)| AaveInfo { pool, underlying });
+        if let Some(info) = aave_info.as_ref() {
+            let candidate = Strategy::AaveV3AToken {
+                target_contract: token,
+                pool: info.pool,
+                underlying: info.underlying,
+                map_slot: U256::from(aave::USER_STATE_SLOT),
+            };
+            if self
+                .verify_strategy(token, holder, &candidate)
+                .await
+                .is_ok()
+            {
+                tracing::debug!(
+                    ?token,
+                    "detected Aave v3 aToken via fast-path (no debug_traceCall)"
+                );
+                return Ok(candidate);
+            }
+            tracing::debug!(
+                ?token,
+                "Aave probe succeeded but canonical slot didn't verify; falling back to trace"
+            );
+        }
+
         let balance_of_call = ERC20::ERC20::balanceOfCall { account: holder };
         let calldata = balance_of_call.abi_encode();
 
@@ -188,16 +228,6 @@ impl Detector {
             tracing::debug!("no SLOAD operations found in trace for token {:?}", token);
             return Err(DetectionError::NotFound);
         }
-
-        // Probe whether this token looks like an Aave v3 aToken (has
-        // `UNDERLYING_ASSET_ADDRESS()` and `POOL()` and the pool responds to
-        // `getReserveNormalizedIncome`). If so, `create_strategies_from_slots`
-        // will also emit `AaveV3AToken` candidates so the verify loop picks
-        // them up and returns the right strategy without any hardcoded
-        // per-token config.
-        let aave_info = aave::probe_a_token(&self.web3, token)
-            .await
-            .map(|(pool, underlying)| AaveInfo { pool, underlying });
 
         let strategies = create_strategies_from_slots(
             &storage_slots,
@@ -368,32 +398,12 @@ impl Detector {
         // Use a unique test value to verify this strategy works
         let test_balance = U256::from(0x1337_1337_1337_1337_u64);
 
-        // Create state override using the strategy. `AaveV3AToken` needs an
-        // async call to the pool to compute the scaled storage value, so we
-        // reuse the production builder rather than `StrategyExt::state_override`
-        // (which intentionally `unreachable!()`s for this variant).
-        let overrides: AddressMap<_> = match strategy {
-            Strategy::AaveV3AToken {
-                target_contract,
-                pool,
-                underlying,
-                map_slot,
-            } => {
-                let (target, account_override) = aave::build_override(
-                    &self.web3,
-                    *target_contract,
-                    *pool,
-                    *underlying,
-                    *map_slot,
-                    holder,
-                    test_balance,
-                )
-                .await
-                .ok_or(DetectionError::NotFound)?;
-                std::iter::once((target, account_override)).collect()
-            }
-            _ => strategy.state_override(&holder, &test_balance),
-        };
+        let overrides = strategy
+            .state_override(Some(&self.web3), &holder, &test_balance)
+            .await;
+        if overrides.is_empty() {
+            return Err(DetectionError::NotFound);
+        }
 
         // Call balanceOf with the override
         let token_contract = ERC20::Instance::new(token, self.web3.provider.clone());

--- a/crates/balance-overrides/src/detector.rs
+++ b/crates/balance-overrides/src/detector.rs
@@ -158,7 +158,6 @@ impl Detector {
                 target_contract: token,
                 pool,
                 underlying,
-                map_slot: U256::from(aave::USER_STATE_SLOT),
             };
             if self
                 .verify_strategy(token, holder, &candidate)
@@ -400,7 +399,7 @@ impl Detector {
 /// identity by construction; every other strategy must match exactly.
 fn verified_balance_matches(strategy: &Strategy, balance: U256, test_balance: U256) -> bool {
     match strategy {
-        Strategy::AaveV3AToken { .. } => balance.abs_diff(test_balance) <= U256::from(1u64),
+        Strategy::AaveV3AToken { .. } => balance.abs_diff(test_balance) <= U256::ONE,
         _ => balance == test_balance,
     }
 }

--- a/crates/balance-overrides/src/detector.rs
+++ b/crates/balance-overrides/src/detector.rs
@@ -433,6 +433,30 @@ mod tests {
         );
     }
 
+    /// aEthWETH (Aave v3) can't be auto-detected: its `balanceOf` applies a
+    /// liquidity-index scaling so the verify step never sees back the exact
+    /// value we write. This documents the limitation and motivates the
+    /// `AaveV3AToken` hardcoded strategy. Kept separate from
+    /// `detects_storage_slots_mainnet` so this assertion is not gated by
+    /// unrelated expectations in that test.
+    /// Set `NODE_URL` environment to a mainnet RPC URL.
+    #[ignore]
+    #[tokio::test]
+    async fn detects_storage_slots_mainnet_aave_atoken_not_found() {
+        let detector = Detector::new(Web3::new_from_env(), 60, DEFAULT_VERIFICATION_TIMEOUT);
+
+        let result = detector
+            .detect(
+                address!("4d5f47fa6a74757f35c14fd3a6ef8e3c9bc514e8"),
+                Address::with_last_byte(1),
+            )
+            .await;
+        assert!(
+            matches!(result, Err(DetectionError::NotFound)),
+            "expected NotFound for aEthWETH, got {result:?}",
+        );
+    }
+
     /// Tests that we can detect storage slots by probing the first
     /// n slots or by checking hardcoded known slots.
     /// Set `NODE_URL` environment to an arbitrum RPC URL.

--- a/crates/balance-overrides/src/detector.rs
+++ b/crates/balance-overrides/src/detector.rs
@@ -153,7 +153,7 @@ impl Detector {
         // will fall through to the generic trace-based path, which only
         // ever returns non-Aave strategies; such a fork needs an explicit
         // hardcoded config entry.
-        if let Some((pool, underlying)) = aave::probe_a_token(&self.web3, token).await {
+        if let Some((pool, underlying)) = aave::probe_aave_token(&self.web3, token).await {
             let candidate = Strategy::AaveV3AToken {
                 target_contract: token,
                 pool,
@@ -391,18 +391,20 @@ impl Detector {
                 )))
             })?;
 
-        // aToken balances round-trip through rayDiv/rayMul so the reported
-        // balance may differ from the written value by one wei. Every other
-        // strategy must match exactly.
-        let balance_matches = if matches!(strategy, Strategy::AaveV3AToken { .. }) {
-            balance.abs_diff(test_balance) <= U256::from(1u64)
-        } else {
-            balance == test_balance
-        };
-
-        balance_matches
+        verified_balance_matches(strategy, balance, test_balance)
             .then_some(())
             .ok_or(DetectionError::NotFound)
+    }
+}
+
+/// Is the `balance` returned by `balanceOf` after applying the override
+/// consistent with the `test_balance` we wrote? For `AaveV3AToken` we tolerate
+/// 1 wei of difference because Aave's ray-div / ray-mul round-trip is not
+/// identity by construction; every other strategy must match exactly.
+fn verified_balance_matches(strategy: &Strategy, balance: U256, test_balance: U256) -> bool {
+    match strategy {
+        Strategy::AaveV3AToken { .. } => balance.abs_diff(test_balance) <= U256::from(1u64),
+        _ => balance == test_balance,
     }
 }
 

--- a/crates/balance-overrides/src/lib.rs
+++ b/crates/balance-overrides/src/lib.rs
@@ -129,10 +129,10 @@ impl StrategyExt for Strategy {
     }
 
     fn is_valid_for_all_holders(&self) -> bool {
-        // `AaveV3AToken` fields (target, pool, underlying, map_slot) are all
-        // token-level constants; the slot and value are derived per-holder at
-        // override time. Caching the strategy once per token avoids re-running
-        // the probe for every new `from` address.
+        // `AaveV3AToken` fields (target, pool, underlying) are all token-level
+        // constants; the slot and value are derived per-holder at override
+        // time. Caching the strategy once per token avoids re-running the
+        // probe for every new `from` address.
         matches!(self, Self::DirectSlot { .. } | Self::AaveV3AToken { .. })
     }
 }

--- a/crates/balance-overrides/src/lib.rs
+++ b/crates/balance-overrides/src/lib.rs
@@ -266,7 +266,7 @@ impl BalanceOverriding for DummyOverrider {
 mod tests {
     use {
         super::*,
-        crate::aave::{RAY, pack_user_state, ray_div},
+        crate::aave::{pack_user_state, ray_div},
         alloy_primitives::{address, b256},
         ethrpc::mock,
         maplit::hashmap,

--- a/crates/balance-overrides/src/lib.rs
+++ b/crates/balance-overrides/src/lib.rs
@@ -1,28 +1,18 @@
+pub mod aave;
 pub mod detector;
 
 use {
-    self::detector::{DetectionError, Detector},
-    alloy_eips::BlockId,
-    alloy_primitives::{Address, B256, Bytes, TxKind, U256, keccak256, map::AddressMap},
-    alloy_provider::Provider,
-    alloy_rpc_types::{TransactionInput, TransactionRequest, state::AccountOverride},
-    alloy_sol_types::{SolCall, sol},
+    self::{
+        aave::{mapping_slot_hash, pack_user_state, ray_div},
+        detector::{DetectionError, Detector},
+    },
+    alloy_primitives::{Address, B256, U256, keccak256, map::AddressMap},
+    alloy_rpc_types::state::AccountOverride,
     cached::{Cached, SizedCache},
     configs::balance_overrides::Strategy,
     ethrpc::Web3,
     std::{collections::HashMap, iter, sync::Mutex},
 };
-
-sol! {
-    /// Minimal interface for the Aave v3 `Pool` used to derive the current
-    /// liquidity index applied by aTokens when reporting `balanceOf`.
-    interface IAaveV3Pool {
-        function getReserveNormalizedIncome(address asset) external view returns (uint256);
-    }
-}
-
-/// Ray (1e27) is Aave's 27-decimal fixed-point unit used in `rayDiv`.
-const RAY: U256 = U256::from_limbs([0x9fd0803ce8000000, 0x33b2e3c, 0, 0]);
 /// Token configurations for the `BalanceOverriding` component.
 #[derive(Clone, Debug, Default)]
 pub struct TokenConfiguration(HashMap<Address, Strategy>);
@@ -107,39 +97,6 @@ impl StrategyExt for Strategy {
     fn is_valid_for_all_holders(&self) -> bool {
         matches!(self, Self::DirectSlot { .. })
     }
-}
-
-/// Computes `keccak256(pad32(holder) ++ map_slot)` — the storage slot of
-/// `mapping(address => _)` entries in Solidity.
-fn mapping_slot_hash(holder: &Address, map_slot: &[u8; 32]) -> B256 {
-    let mut buf = [0u8; 64];
-    buf[12..32].copy_from_slice(holder.as_slice());
-    buf[32..64].copy_from_slice(map_slot);
-    keccak256(buf)
-}
-
-/// Packs a `UserState { uint128 balance; uint128 additionalData }` into a
-/// 32-byte word. The balance occupies the lower 128 bits; `additional_data`
-/// sits in the upper 128 bits.
-fn pack_user_state(balance: U256, additional_data: U256) -> B256 {
-    let mask = (U256::from(1u64) << 128) - U256::from(1u64);
-    let packed: U256 = ((additional_data & mask) << 128) | (balance & mask);
-    B256::new(packed.to_be_bytes::<32>())
-}
-
-/// Ray-division: `(a * RAY + b/2) / b`, round-half-up. This matches Aave's
-/// `WadRayMath.rayDiv` bit-for-bit so the scaled amount we write into
-/// storage equals the one Aave will itself compute during a subsequent
-/// `_transfer`. Returns `None` if `b == 0` or the intermediate product
-/// overflows `U256`.
-fn ray_div(a: U256, b: U256) -> Option<U256> {
-    if b.is_zero() {
-        return None;
-    }
-    let half_b = b >> 1;
-    a.checked_mul(RAY)
-        .and_then(|prod| prod.checked_add(half_b))
-        .map(|num| num / b)
 }
 
 type DetectorCache = Mutex<SizedCache<(Address, Option<Address>), Option<Strategy>>>;
@@ -287,58 +244,7 @@ impl BalanceOverrides {
             );
             None
         })?;
-
-        let call = IAaveV3Pool::getReserveNormalizedIncomeCall { asset: underlying };
-        let calldata = Bytes::from(call.abi_encode());
-        let tx = TransactionRequest {
-            to: Some(TxKind::Call(pool)),
-            input: TransactionInput::new(calldata),
-            ..Default::default()
-        };
-        let index = match web3.provider.call(tx).block(BlockId::latest()).await {
-            Ok(bytes) => {
-                match IAaveV3Pool::getReserveNormalizedIncomeCall::abi_decode_returns(&bytes) {
-                    Ok(index) => index,
-                    Err(err) => {
-                        tracing::warn!(
-                            ?err,
-                            ?pool,
-                            ?underlying,
-                            "failed to decode Aave reserve normalized income response"
-                        );
-                        return None;
-                    }
-                }
-            }
-            Err(err) => {
-                tracing::warn!(
-                    ?err,
-                    ?pool,
-                    ?underlying,
-                    "failed to fetch Aave reserve normalized income"
-                );
-                return None;
-            }
-        };
-
-        let scaled = ray_div(amount, index)?;
-        let slot = mapping_slot_hash(&holder, &map_slot.to_be_bytes::<32>());
-        let value = pack_user_state(scaled, U256::ZERO);
-
-        tracing::trace!(
-            ?a_token,
-            ?holder,
-            %amount,
-            %index,
-            %scaled,
-            "computed AaveV3AToken balance override"
-        );
-
-        let state_override = AccountOverride {
-            state_diff: Some(iter::once((slot, value)).collect()),
-            ..Default::default()
-        };
-        Some((a_token, state_override))
+        aave::build_override(web3, a_token, pool, underlying, map_slot, holder, amount).await
     }
 }
 
@@ -360,6 +266,7 @@ impl BalanceOverriding for DummyOverrider {
 mod tests {
     use {
         super::*,
+        crate::aave::RAY,
         alloy_primitives::{address, b256},
         ethrpc::mock,
         maplit::hashmap,

--- a/crates/balance-overrides/src/lib.rs
+++ b/crates/balance-overrides/src/lib.rs
@@ -3,7 +3,7 @@ pub mod detector;
 
 use {
     self::{
-        aave::{mapping_slot_hash, pack_user_state, ray_div},
+        aave::mapping_slot_hash,
         detector::{DetectionError, Detector},
     },
     alloy_primitives::{Address, B256, U256, keccak256, map::AddressMap},
@@ -266,7 +266,7 @@ impl BalanceOverriding for DummyOverrider {
 mod tests {
     use {
         super::*,
-        crate::aave::RAY,
+        crate::aave::{RAY, pack_user_state, ray_div},
         alloy_primitives::{address, b256},
         ethrpc::mock,
         maplit::hashmap,

--- a/crates/balance-overrides/src/lib.rs
+++ b/crates/balance-overrides/src/lib.rs
@@ -95,7 +95,11 @@ impl StrategyExt for Strategy {
     }
 
     fn is_valid_for_all_holders(&self) -> bool {
-        matches!(self, Self::DirectSlot { .. })
+        // `AaveV3AToken` fields (target, pool, underlying, map_slot) are all
+        // token-level constants; the slot and value are derived per-holder at
+        // override time. Caching the strategy once per token avoids re-running
+        // the probe for every new `from` address.
+        matches!(self, Self::DirectSlot { .. } | Self::AaveV3AToken { .. })
     }
 }
 

--- a/crates/balance-overrides/src/lib.rs
+++ b/crates/balance-overrides/src/lib.rs
@@ -2,12 +2,27 @@ pub mod detector;
 
 use {
     self::detector::{DetectionError, Detector},
-    alloy_primitives::{Address, B256, U256, keccak256, map::AddressMap},
-    alloy_rpc_types::state::AccountOverride,
+    alloy_eips::BlockId,
+    alloy_primitives::{Address, B256, Bytes, TxKind, U256, keccak256, map::AddressMap},
+    alloy_provider::Provider,
+    alloy_rpc_types::{TransactionInput, TransactionRequest, state::AccountOverride},
+    alloy_sol_types::{SolCall, sol},
     cached::{Cached, SizedCache},
     configs::balance_overrides::Strategy,
+    ethrpc::Web3,
     std::{collections::HashMap, iter, sync::Mutex},
 };
+
+sol! {
+    /// Minimal interface for the Aave v3 `Pool` used to derive the current
+    /// liquidity index applied by aTokens when reporting `balanceOf`.
+    interface IAaveV3Pool {
+        function getReserveNormalizedIncome(address asset) external view returns (uint256);
+    }
+}
+
+/// Ray (1e27) is Aave's 27-decimal fixed-point unit used in `rayDiv`.
+const RAY: U256 = U256::from_limbs([0x9fd0803ce8000000, 0x33b2e3c, 0, 0]);
 /// Token configurations for the `BalanceOverriding` component.
 #[derive(Clone, Debug, Default)]
 pub struct TokenConfiguration(HashMap<Address, Strategy>);
@@ -59,12 +74,10 @@ impl StrategyExt for Strategy {
             Self::SolidityMapping {
                 target_contract,
                 map_slot,
-            } => {
-                let mut buf = [0; 64];
-                buf[12..32].copy_from_slice(holder.as_slice());
-                buf[32..64].copy_from_slice(&map_slot.to_be_bytes::<32>());
-                (target_contract, keccak256(buf))
-            }
+            } => (
+                target_contract,
+                mapping_slot_hash(holder, &map_slot.to_be_bytes::<32>()),
+            ),
             Self::SoladyMapping { target_contract } => {
                 let mut buf = [0; 32];
                 buf[0..20].copy_from_slice(holder.as_slice());
@@ -75,6 +88,12 @@ impl StrategyExt for Strategy {
                 target_contract,
                 slot,
             } => (target_contract, *slot),
+            // AaveV3AToken requires an async call to fetch the current
+            // normalized income, so it is handled separately in
+            // `BalanceOverrides::state_override`.
+            Self::AaveV3AToken { .. } => unreachable!(
+                "AaveV3AToken strategy must be resolved asynchronously, not via StrategyExt"
+            ),
         };
 
         let state_override = AccountOverride {
@@ -88,6 +107,39 @@ impl StrategyExt for Strategy {
     fn is_valid_for_all_holders(&self) -> bool {
         matches!(self, Self::DirectSlot { .. })
     }
+}
+
+/// Computes `keccak256(pad32(holder) ++ map_slot)` — the storage slot of
+/// `mapping(address => _)` entries in Solidity.
+fn mapping_slot_hash(holder: &Address, map_slot: &[u8; 32]) -> B256 {
+    let mut buf = [0u8; 64];
+    buf[12..32].copy_from_slice(holder.as_slice());
+    buf[32..64].copy_from_slice(map_slot);
+    keccak256(buf)
+}
+
+/// Packs a `UserState { uint128 balance; uint128 additionalData }` into a
+/// 32-byte word. The balance occupies the lower 128 bits; `additional_data`
+/// sits in the upper 128 bits.
+fn pack_user_state(balance: U256, additional_data: U256) -> B256 {
+    let mask = (U256::from(1u64) << 128) - U256::from(1u64);
+    let packed: U256 = ((additional_data & mask) << 128) | (balance & mask);
+    B256::new(packed.to_be_bytes::<32>())
+}
+
+/// Ray-division: `(a * RAY + b/2) / b`, round-half-up. This matches Aave's
+/// `WadRayMath.rayDiv` bit-for-bit so the scaled amount we write into
+/// storage equals the one Aave will itself compute during a subsequent
+/// `_transfer`. Returns `None` if `b == 0` or the intermediate product
+/// overflows `U256`.
+fn ray_div(a: U256, b: U256) -> Option<U256> {
+    if b.is_zero() {
+        return None;
+    }
+    let half_b = b >> 1;
+    a.checked_mul(RAY)
+        .and_then(|prod| prod.checked_add(half_b))
+        .map(|num| num / b)
 }
 
 type DetectorCache = Mutex<SizedCache<(Address, Option<Address>), Option<Strategy>>>;
@@ -104,6 +156,9 @@ pub struct BalanceOverrides {
     /// The balance override detector and its cache. Set to `None` if
     /// auto-detection is not enabled.
     pub detector: Option<(Detector, DetectorCache)>,
+    /// Optional web3 handle used by strategies that need runtime on-chain
+    /// reads (e.g. `AaveV3AToken` fetching the reserve's normalized income).
+    pub web3: Option<Web3>,
 }
 
 impl BalanceOverrides {
@@ -112,9 +167,10 @@ impl BalanceOverrides {
         Self {
             hardcoded: Default::default(),
             detector: Some((
-                Detector::new(web3, 60, detector::DEFAULT_VERIFICATION_TIMEOUT),
+                Detector::new(web3.clone(), 60, detector::DEFAULT_VERIFICATION_TIMEOUT),
                 Mutex::new(SizedCache::with_size(1000)),
             )),
+            web3: Some(web3),
         }
     }
 
@@ -183,10 +239,106 @@ impl BalanceOverriding for BalanceOverrides {
             self.cached_detection(request.token, request.holder).await
         }?;
 
+        if let Strategy::AaveV3AToken {
+            target_contract,
+            pool,
+            underlying,
+            map_slot,
+        } = &strategy
+        {
+            return self
+                .aave_v3_a_token_override(
+                    *target_contract,
+                    *pool,
+                    *underlying,
+                    *map_slot,
+                    request.holder,
+                    request.amount,
+                )
+                .await;
+        }
+
         strategy
             .state_override(&request.holder, &request.amount)
             .into_iter()
             .last()
+    }
+}
+
+impl BalanceOverrides {
+    /// Resolves an `AaveV3AToken` balance override. We need the current
+    /// normalized income from the Aave pool to invert the scaling applied by
+    /// aToken `balanceOf`. Writes the scaled amount into the low 128 bits of
+    /// the packed `UserState` slot; the upper 128 bits (`additionalData`) are
+    /// zeroed, which is safe for fresh holders like the spardose.
+    async fn aave_v3_a_token_override(
+        &self,
+        a_token: Address,
+        pool: Address,
+        underlying: Address,
+        map_slot: U256,
+        holder: Address,
+        amount: U256,
+    ) -> Option<(Address, AccountOverride)> {
+        let web3 = self.web3.as_ref().or_else(|| {
+            tracing::warn!(
+                ?a_token,
+                "AaveV3AToken balance override requested but web3 is not configured",
+            );
+            None
+        })?;
+
+        let call = IAaveV3Pool::getReserveNormalizedIncomeCall { asset: underlying };
+        let calldata = Bytes::from(call.abi_encode());
+        let tx = TransactionRequest {
+            to: Some(TxKind::Call(pool)),
+            input: TransactionInput::new(calldata),
+            ..Default::default()
+        };
+        let index = match web3.provider.call(tx).block(BlockId::latest()).await {
+            Ok(bytes) => {
+                match IAaveV3Pool::getReserveNormalizedIncomeCall::abi_decode_returns(&bytes) {
+                    Ok(index) => index,
+                    Err(err) => {
+                        tracing::warn!(
+                            ?err,
+                            ?pool,
+                            ?underlying,
+                            "failed to decode Aave reserve normalized income response"
+                        );
+                        return None;
+                    }
+                }
+            }
+            Err(err) => {
+                tracing::warn!(
+                    ?err,
+                    ?pool,
+                    ?underlying,
+                    "failed to fetch Aave reserve normalized income"
+                );
+                return None;
+            }
+        };
+
+        let scaled = ray_div(amount, index)?;
+        let slot = mapping_slot_hash(&holder, &map_slot.to_be_bytes::<32>());
+        let value = pack_user_state(scaled, U256::ZERO);
+
+        tracing::trace!(
+            ?a_token,
+            ?holder,
+            %amount,
+            %index,
+            %scaled,
+            "computed AaveV3AToken balance override"
+        );
+
+        let state_override = AccountOverride {
+            state_diff: Some(iter::once((slot, value)).collect()),
+            ..Default::default()
+        };
+        Some((a_token, state_override))
     }
 }
 
@@ -372,9 +524,14 @@ mod tests {
         let balance_overrides = BalanceOverrides {
             hardcoded: Default::default(),
             detector: Some((
-                Detector::new(mock_web3, 60, detector::DEFAULT_VERIFICATION_TIMEOUT),
+                Detector::new(
+                    mock_web3.clone(),
+                    60,
+                    detector::DEFAULT_VERIFICATION_TIMEOUT,
+                ),
                 Mutex::new(SizedCache::with_size(100)),
             )),
+            web3: Some(mock_web3),
         };
 
         // Manually populate the cache as if detector found this holder-agnostic
@@ -420,9 +577,14 @@ mod tests {
         let balance_overrides = BalanceOverrides {
             hardcoded: Default::default(),
             detector: Some((
-                Detector::new(mock_web3, 60, detector::DEFAULT_VERIFICATION_TIMEOUT),
+                Detector::new(
+                    mock_web3.clone(),
+                    60,
+                    detector::DEFAULT_VERIFICATION_TIMEOUT,
+                ),
                 Mutex::new(SizedCache::with_size(100)),
             )),
+            web3: Some(mock_web3),
         };
 
         // Manually populate cache with holder-specific strategies
@@ -447,5 +609,254 @@ mod tests {
             balance_overrides.cached_detection(token, holder2).await,
             Some(strategy_h2)
         );
+    }
+
+    /// Round-half-up `rayMul` — the same formula aToken's `balanceOf` applies
+    /// to convert scaled storage into the reported display balance. Only used
+    /// by the bug-reproduction test below.
+    fn ray_mul(a: U256, b: U256) -> U256 {
+        (a * b + (RAY >> 1)) / RAY
+    }
+
+    /// Reproduction of the aEthWETH bug in pure math: without the
+    /// `AaveV3AToken` strategy we would write the raw display `amount` into
+    /// the balance slot, and aToken's `balanceOf` would then return
+    /// `rayMul(amount, index)` — which differs from `amount` as soon as the
+    /// reserve has accrued any interest (`index > RAY`). The `AaveV3AToken`
+    /// strategy writes `rayDiv(amount, index)` instead, which round-trips
+    /// back to `amount` within one wei of ray rounding.
+    #[test]
+    fn a_token_balance_override_bug_reproduction() {
+        let amount = U256::from(1_000_000_000_000_000_000u128); // 1 aEthWETH
+        // Mainnet aEthWETH normalized-income ~1.0632 RAY (observed today).
+        let index = U256::from_str_radix("1063211170513245730547525051", 10).unwrap();
+        assert!(
+            index > RAY,
+            "index must include accrued interest to reproduce"
+        );
+
+        // OLD behaviour (SolidityMapping / SoladyMapping / DirectSlot all
+        // write the raw value): balanceOf returns rayMul(amount, index), which
+        // is materially larger than `amount`. That mismatch is why the
+        // detector's `verify_strategy` fails and why, if we force it via
+        // hardcoded config, the spardose has more scaled balance than the
+        // trade needs and downstream Aave math still underflows.
+        let old_reported = ray_mul(amount, index);
+        assert!(
+            old_reported > amount + U256::from(10_000u64),
+            "bug not reproduced: old strategy only off by {} wei",
+            old_reported - amount,
+        );
+
+        // NEW behaviour (AaveV3AToken): we write rayDiv(amount, index). The
+        // round-trip through aToken's balanceOf is within one wei.
+        let scaled = ray_div(amount, index).unwrap();
+        let new_reported = ray_mul(scaled, index);
+        let diff = if new_reported >= amount {
+            new_reported - amount
+        } else {
+            amount - new_reported
+        };
+        assert!(
+            diff <= U256::from(1u64),
+            "new strategy off by {diff} wei (expected ≤ 1)",
+        );
+    }
+
+    #[test]
+    fn ray_div_edge_cases() {
+        // Numerical correctness on realistic values is covered by
+        // `a_token_balance_override_bug_reproduction` (round-trip through
+        // `ray_mul`). Here we only pin down the two edge cases:
+
+        // 0 / x = 0.
+        let index = U256::from_str_radix("1063000000000000000000000000", 10).unwrap();
+        assert_eq!(ray_div(U256::ZERO, index).unwrap(), U256::ZERO);
+
+        // Divide by zero returns None.
+        assert_eq!(
+            ray_div(U256::from(1_000_000_000_000_000_000u128), U256::ZERO),
+            None,
+        );
+    }
+
+    #[test]
+    fn pack_user_state_leaves_additional_data_intact() {
+        let balance = U256::from(0x1234_5678u64);
+        let extra = U256::from(0xabcd_ef01u64);
+        let packed = pack_user_state(balance, extra);
+        let word = U256::from_be_bytes(packed.0);
+
+        let mask = (U256::from(1u64) << 128) - U256::from(1u64);
+        assert_eq!(word & mask, balance);
+        assert_eq!(word >> 128, extra);
+    }
+
+    #[test]
+    fn pack_user_state_truncates_to_uint128() {
+        // A value larger than uint128 should be masked down to its low 128
+        // bits. Using 2^128 + 7 so we can check the wrap visibly.
+        let overflow = (U256::from(1u64) << 128) + U256::from(7u64);
+        let packed = pack_user_state(overflow, U256::ZERO);
+        let word = U256::from_be_bytes(packed.0);
+        assert_eq!(word, U256::from(7u64));
+    }
+
+    #[test]
+    fn mapping_slot_hash_matches_solidity_layout() {
+        // keccak256(pad32(holder) || map_slot) — verified with
+        // `cast keccak $(cast abi-encode "f(address,uint256)" $HOLDER 52)`.
+        let holder = address!("18709E89BD403F470088aBDAcEbE86CC60dda12e");
+        let slot = mapping_slot_hash(&holder, &U256::from(52).to_be_bytes::<32>());
+        assert_eq!(
+            slot,
+            b256!("6785743a4ad9de6e692f819936c9d0b94b199ed36f2660e82404737b769718e5")
+        );
+    }
+
+    #[tokio::test]
+    async fn aave_v3_a_token_override_scales_amount_and_writes_low_128() {
+        use alloy_provider::mock::Asserter;
+
+        // aEthWETH mainnet triple.
+        let a_token = address!("4d5F47FA6A74757f35C14fD3a6Ef8E3C9BC514E8");
+        let pool = address!("87870bca3f3fd6335c3f4ce8392d69350b4fa4e2");
+        let underlying = address!("c02aaa39b223fe8d0a0e5c4f27ead9083c756cc2");
+        let holder = address!("18709E89BD403F470088aBDAcEbE86CC60dda12e");
+        let amount = U256::from(1_000_000_000_000_000_000u128); // 1 aEthWETH
+
+        let asserter = Asserter::new();
+        // The mock responds to our `eth_call` with the encoded `uint256`
+        // normalized income — a ray value just above 1.063.
+        let index = U256::from_str_radix("1063000000000000000000000000", 10).unwrap();
+        asserter.push_success(&format!("0x{:064x}", index));
+
+        let balance_overrides = BalanceOverrides {
+            hardcoded: hashmap! {
+                a_token => Strategy::AaveV3AToken {
+                    target_contract: a_token,
+                    pool,
+                    underlying,
+                    map_slot: U256::from(52),
+                },
+            },
+            detector: None,
+            web3: Some(Web3::with_asserter(asserter)),
+        };
+
+        let (addr, override_) = balance_overrides
+            .state_override(BalanceOverrideRequest {
+                token: a_token,
+                holder,
+                amount,
+            })
+            .await
+            .expect("override computed");
+
+        assert_eq!(addr, a_token);
+
+        let diff = override_.state_diff.expect("state diff present");
+        assert_eq!(diff.len(), 1);
+        let (slot, value) = diff.into_iter().next().unwrap();
+        // Slot is keccak256(holder || 52) — same one used by aEthWETH.
+        assert_eq!(
+            slot,
+            b256!("6785743a4ad9de6e692f819936c9d0b94b199ed36f2660e82404737b769718e5")
+        );
+        // Scaled balance in low 128, zero in high 128 (safe for fresh
+        // holders like the spardose).
+        let word = U256::from_be_bytes(value.0);
+        assert_eq!(word >> 128, U256::ZERO);
+        assert_eq!(word, ray_div(amount, index).unwrap());
+    }
+
+    /// End-to-end test against real mainnet: computes an `AaveV3AToken`
+    /// override for aEthWETH, then calls `balanceOf(holder)` against the real
+    /// node with that override applied and checks the result matches the
+    /// requested amount (within ray rounding). Set `NODE_URL` to a mainnet
+    /// RPC endpoint.
+    #[ignore]
+    #[tokio::test]
+    async fn aave_v3_a_token_override_mainnet_roundtrip() {
+        use contracts::ERC20;
+
+        let a_token = address!("4d5f47fa6a74757f35c14fd3a6ef8e3c9bc514e8");
+        let pool = address!("87870bca3f3fd6335c3f4ce8392d69350b4fa4e2");
+        let underlying = address!("c02aaa39b223fe8d0a0e5c4f27ead9083c756cc2");
+        // Spardose lookalike: a fresh holder with zero prior state.
+        let holder = address!("0000000000000000000000000000000000020000");
+        let amount = U256::from(5_000_000_000_000_000_000u128); // 5 aEthWETH
+
+        let web3 = ethrpc::Web3::new_from_env();
+        let balance_overrides = BalanceOverrides {
+            hardcoded: hashmap! {
+                a_token => Strategy::AaveV3AToken {
+                    target_contract: a_token,
+                    pool,
+                    underlying,
+                    map_slot: U256::from(52),
+                },
+            },
+            detector: None,
+            web3: Some(web3.clone()),
+        };
+
+        let (target, override_) = balance_overrides
+            .state_override(BalanceOverrideRequest {
+                token: a_token,
+                holder,
+                amount,
+            })
+            .await
+            .expect("override computed");
+        assert_eq!(target, a_token);
+
+        // Apply the override to a live balanceOf call and make sure the
+        // contract now reports the requested amount (± 1 wei ray rounding).
+        let overrides: alloy_rpc_types::state::StateOverride =
+            iter::once((target, override_)).collect();
+        let token_contract = ERC20::Instance::new(a_token, web3.provider.clone());
+        let reported = token_contract
+            .balanceOf(holder)
+            .state(overrides)
+            .call()
+            .await
+            .unwrap();
+
+        let diff = if reported > amount {
+            reported - amount
+        } else {
+            amount - reported
+        };
+        assert!(
+            diff <= U256::from(1u64),
+            "balanceOf returned {reported}, expected ~{amount} (diff {diff} wei)",
+        );
+    }
+
+    #[tokio::test]
+    async fn aave_v3_a_token_override_none_without_web3() {
+        let a_token = address!("4d5F47FA6A74757f35C14fD3a6Ef8E3C9BC514E8");
+        let balance_overrides = BalanceOverrides {
+            hardcoded: hashmap! {
+                a_token => Strategy::AaveV3AToken {
+                    target_contract: a_token,
+                    pool: address!("87870bca3f3fd6335c3f4ce8392d69350b4fa4e2"),
+                    underlying: address!("c02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"),
+                    map_slot: U256::from(52),
+                },
+            },
+            detector: None,
+            web3: None,
+        };
+
+        let result = balance_overrides
+            .state_override(BalanceOverrideRequest {
+                token: a_token,
+                holder: address!("18709E89BD403F470088aBDAcEbE86CC60dda12e"),
+                amount: U256::from(1u64),
+            })
+            .await;
+        assert!(result.is_none());
     }
 }

--- a/crates/balance-overrides/src/lib.rs
+++ b/crates/balance-overrides/src/lib.rs
@@ -80,7 +80,7 @@ impl StrategyExt for Strategy {
                 map_slot,
             } => (
                 *target_contract,
-                mapping_slot_hash(holder, &map_slot.to_be_bytes::<32>()),
+                mapping_slot_hash(holder, &map_slot.to_be_bytes()),
             ),
             Self::SoladyMapping { target_contract } => {
                 let mut buf = [0; 32];
@@ -96,7 +96,6 @@ impl StrategyExt for Strategy {
                 target_contract,
                 pool,
                 underlying,
-                map_slot,
             } => {
                 let Some(web3) = web3 else {
                     tracing::warn!(
@@ -110,7 +109,6 @@ impl StrategyExt for Strategy {
                     *target_contract,
                     *pool,
                     *underlying,
-                    *map_slot,
                     *holder,
                     *amount,
                 )
@@ -520,68 +518,18 @@ mod tests {
         );
     }
 
-    /// Round-half-up `rayMul` — the same formula aToken's `balanceOf` applies
-    /// to convert scaled storage into the reported display balance. Only used
-    /// by the bug-reproduction test below.
-    fn ray_mul(a: U256, b: U256) -> U256 {
-        (a * b + (RAY >> 1)) / RAY
-    }
-
-    /// Reproduction of the aEthWETH bug in pure math: without the
-    /// `AaveV3AToken` strategy we would write the raw display `amount` into
-    /// the balance slot, and aToken's `balanceOf` would then return
-    /// `rayMul(amount, index)` — which differs from `amount` as soon as the
-    /// reserve has accrued any interest (`index > RAY`). The `AaveV3AToken`
-    /// strategy writes `rayDiv(amount, index)` instead, which round-trips
-    /// back to `amount` within one wei of ray rounding.
-    #[test]
-    fn a_token_balance_override_bug_reproduction() {
-        let amount = U256::from(1_000_000_000_000_000_000u128); // 1 aEthWETH
-        // Mainnet aEthWETH normalized-income ~1.0632 RAY (observed today).
-        let index = U256::from_str_radix("1063211170513245730547525051", 10).unwrap();
-        assert!(
-            index > RAY,
-            "index must include accrued interest to reproduce"
-        );
-
-        // OLD behaviour (SolidityMapping / SoladyMapping / DirectSlot all
-        // write the raw value): balanceOf returns rayMul(amount, index), which
-        // is materially larger than `amount`. That mismatch is why the
-        // detector's `verify_strategy` fails and why, if we force it via
-        // hardcoded config, the spardose has more scaled balance than the
-        // trade needs and downstream Aave math still underflows.
-        let old_reported = ray_mul(amount, index);
-        assert!(
-            old_reported > amount + U256::from(10_000u64),
-            "bug not reproduced: old strategy only off by {} wei",
-            old_reported - amount,
-        );
-
-        // NEW behaviour (AaveV3AToken): we write rayDiv(amount, index). The
-        // round-trip through aToken's balanceOf is within one wei.
-        let scaled = ray_div(amount, index).unwrap();
-        let new_reported = ray_mul(scaled, index);
-        let diff = if new_reported >= amount {
-            new_reported - amount
-        } else {
-            amount - new_reported
-        };
-        assert!(
-            diff <= U256::from(1u64),
-            "new strategy off by {diff} wei (expected ≤ 1)",
-        );
-    }
-
     #[test]
     fn ray_div_edge_cases() {
-        // Numerical correctness on realistic values is covered by
-        // `a_token_balance_override_bug_reproduction` (round-trip through
-        // `ray_mul`). Here we only pin down the two edge cases:
+        // End-to-end numerical correctness is covered by the forked-e2e
+        // `forked_node_mainnet_aave_atoken_detection` /
+        // `forked_node_mainnet_aave_atoken_quote` tests, which apply the
+        // override against a real aEthWETH and assert `balanceOf`
+        // round-trips. Here we only pin down `ray_div` itself at the two
+        // edge cases.
 
-        // 0 / x = 0.
         let index = U256::from_str_radix("1063000000000000000000000000", 10).unwrap();
+        // 0 / x = 0.
         assert_eq!(ray_div(U256::ZERO, index).unwrap(), U256::ZERO);
-
         // Divide by zero returns None.
         assert_eq!(
             ray_div(U256::from(1_000_000_000_000_000_000u128), U256::ZERO),
@@ -646,7 +594,6 @@ mod tests {
                     target_contract: a_token,
                     pool,
                     underlying,
-                    map_slot: U256::from(52),
                 },
             },
             detector: None,
@@ -679,70 +626,6 @@ mod tests {
         assert_eq!(word, ray_div(amount, index).unwrap());
     }
 
-    /// End-to-end test against real mainnet: computes an `AaveV3AToken`
-    /// override for aEthWETH, then calls `balanceOf(holder)` against the real
-    /// node with that override applied and checks the result matches the
-    /// requested amount (within ray rounding). Set `NODE_URL` to a mainnet
-    /// RPC endpoint.
-    #[ignore]
-    #[tokio::test]
-    async fn aave_v3_a_token_override_mainnet_roundtrip() {
-        use contracts::ERC20;
-
-        let a_token = address!("4d5f47fa6a74757f35c14fd3a6ef8e3c9bc514e8");
-        let pool = address!("87870bca3f3fd6335c3f4ce8392d69350b4fa4e2");
-        let underlying = address!("c02aaa39b223fe8d0a0e5c4f27ead9083c756cc2");
-        // Spardose lookalike: a fresh holder with zero prior state.
-        let holder = address!("0000000000000000000000000000000000020000");
-        let amount = U256::from(5_000_000_000_000_000_000u128); // 5 aEthWETH
-
-        let web3 = ethrpc::Web3::new_from_env();
-        let balance_overrides = BalanceOverrides {
-            hardcoded: hashmap! {
-                a_token => Strategy::AaveV3AToken {
-                    target_contract: a_token,
-                    pool,
-                    underlying,
-                    map_slot: U256::from(52),
-                },
-            },
-            detector: None,
-            web3: Some(web3.clone()),
-        };
-
-        let (target, override_) = balance_overrides
-            .state_override(BalanceOverrideRequest {
-                token: a_token,
-                holder,
-                amount,
-            })
-            .await
-            .expect("override computed");
-        assert_eq!(target, a_token);
-
-        // Apply the override to a live balanceOf call and make sure the
-        // contract now reports the requested amount (± 1 wei ray rounding).
-        let overrides: alloy_rpc_types::state::StateOverride =
-            iter::once((target, override_)).collect();
-        let token_contract = ERC20::Instance::new(a_token, web3.provider.clone());
-        let reported = token_contract
-            .balanceOf(holder)
-            .state(overrides)
-            .call()
-            .await
-            .unwrap();
-
-        let diff = if reported > amount {
-            reported - amount
-        } else {
-            amount - reported
-        };
-        assert!(
-            diff <= U256::from(1u64),
-            "balanceOf returned {reported}, expected ~{amount} (diff {diff} wei)",
-        );
-    }
-
     /// When no detector is configured, there's no `Web3` handle available
     /// and the `AaveV3AToken` resolver must cleanly fail rather than panic.
     #[tokio::test]
@@ -754,7 +637,6 @@ mod tests {
                     target_contract: a_token,
                     pool: address!("87870bca3f3fd6335c3f4ce8392d69350b4fa4e2"),
                     underlying: address!("c02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"),
-                    map_slot: U256::from(52),
                 },
             },
             detector: None,

--- a/crates/balance-overrides/src/lib.rs
+++ b/crates/balance-overrides/src/lib.rs
@@ -1,4 +1,4 @@
-pub mod aave;
+mod aave;
 pub mod detector;
 
 use {
@@ -50,40 +50,76 @@ pub struct BalanceOverrideRequest {
     pub amount: U256,
 }
 
+#[async_trait::async_trait]
 trait StrategyExt {
     /// Computes the storage slot and value to override for a particular token
-    /// holder and amount.
-    fn state_override(&self, holder: &Address, amount: &U256) -> AddressMap<AccountOverride>;
+    /// holder and amount. `web3` is only consulted by strategies that need
+    /// on-chain reads at override time (currently `AaveV3AToken`); other
+    /// variants ignore it and complete synchronously.
+    async fn state_override(
+        &self,
+        web3: Option<&Web3>,
+        holder: &Address,
+        amount: &U256,
+    ) -> AddressMap<AccountOverride>;
 
     fn is_valid_for_all_holders(&self) -> bool;
 }
 
+#[async_trait::async_trait]
 impl StrategyExt for Strategy {
-    fn state_override(&self, holder: &Address, amount: &U256) -> AddressMap<AccountOverride> {
+    async fn state_override(
+        &self,
+        web3: Option<&Web3>,
+        holder: &Address,
+        amount: &U256,
+    ) -> AddressMap<AccountOverride> {
         let (target_contract, key) = match self {
             Self::SolidityMapping {
                 target_contract,
                 map_slot,
             } => (
-                target_contract,
+                *target_contract,
                 mapping_slot_hash(holder, &map_slot.to_be_bytes::<32>()),
             ),
             Self::SoladyMapping { target_contract } => {
                 let mut buf = [0; 32];
                 buf[0..20].copy_from_slice(holder.as_slice());
                 buf[28..32].copy_from_slice(&[0x87, 0xa2, 0x11, 0xa2]);
-                (target_contract, keccak256(buf))
+                (*target_contract, keccak256(buf))
             }
             Self::DirectSlot {
                 target_contract,
                 slot,
-            } => (target_contract, *slot),
-            // AaveV3AToken requires an async call to fetch the current
-            // normalized income, so it is handled separately in
-            // `BalanceOverrides::state_override`.
-            Self::AaveV3AToken { .. } => unreachable!(
-                "AaveV3AToken strategy must be resolved asynchronously, not via StrategyExt"
-            ),
+            } => (*target_contract, *slot),
+            Self::AaveV3AToken {
+                target_contract,
+                pool,
+                underlying,
+                map_slot,
+            } => {
+                let Some(web3) = web3 else {
+                    tracing::warn!(
+                        ?target_contract,
+                        "AaveV3AToken balance override requested but web3 is not configured",
+                    );
+                    return AddressMap::default();
+                };
+                return match aave::build_override(
+                    web3,
+                    *target_contract,
+                    *pool,
+                    *underlying,
+                    *map_slot,
+                    *holder,
+                    *amount,
+                )
+                .await
+                {
+                    Some((addr, override_)) => iter::once((addr, override_)).collect(),
+                    None => AddressMap::default(),
+                };
+            }
         };
 
         let state_override = AccountOverride {
@@ -91,7 +127,7 @@ impl StrategyExt for Strategy {
             ..Default::default()
         };
 
-        iter::once((*target_contract, state_override)).collect()
+        iter::once((target_contract, state_override)).collect()
     }
 
     fn is_valid_for_all_holders(&self) -> bool {
@@ -115,10 +151,16 @@ pub struct BalanceOverrides {
     /// the caching policy.
     pub hardcoded: HashMap<Address, Strategy>,
     /// The balance override detector and its cache. Set to `None` if
-    /// auto-detection is not enabled.
+    /// auto-detection is disabled. The detector internally holds its own
+    /// `Web3` handle for tracing and verification calls.
     pub detector: Option<(Detector, DetectorCache)>,
-    /// Optional web3 handle used by strategies that need runtime on-chain
-    /// reads (e.g. `AaveV3AToken` fetching the reserve's normalized income).
+    /// `Web3` handle used by strategies that need on-chain reads at
+    /// override-resolution time (currently only `AaveV3AToken`, which
+    /// fetches the live liquidity index from the Aave pool). Kept separate
+    /// from the detector's own web3 so that hardcoded `AaveV3AToken`
+    /// entries still resolve when auto-detection is disabled. Both handles
+    /// typically point at the same underlying `Web3` instance; `Web3` is
+    /// cheaply cloneable, so the double-reference is just two `Arc` bumps.
     pub web3: Option<Web3>,
 }
 
@@ -200,55 +242,11 @@ impl BalanceOverriding for BalanceOverrides {
             self.cached_detection(request.token, request.holder).await
         }?;
 
-        if let Strategy::AaveV3AToken {
-            target_contract,
-            pool,
-            underlying,
-            map_slot,
-        } = &strategy
-        {
-            return self
-                .aave_v3_a_token_override(
-                    *target_contract,
-                    *pool,
-                    *underlying,
-                    *map_slot,
-                    request.holder,
-                    request.amount,
-                )
-                .await;
-        }
-
         strategy
-            .state_override(&request.holder, &request.amount)
+            .state_override(self.web3.as_ref(), &request.holder, &request.amount)
+            .await
             .into_iter()
             .last()
-    }
-}
-
-impl BalanceOverrides {
-    /// Resolves an `AaveV3AToken` balance override. We need the current
-    /// normalized income from the Aave pool to invert the scaling applied by
-    /// aToken `balanceOf`. Writes the scaled amount into the low 128 bits of
-    /// the packed `UserState` slot; the upper 128 bits (`additionalData`) are
-    /// zeroed, which is safe for fresh holders like the spardose.
-    async fn aave_v3_a_token_override(
-        &self,
-        a_token: Address,
-        pool: Address,
-        underlying: Address,
-        map_slot: U256,
-        holder: Address,
-        amount: U256,
-    ) -> Option<(Address, AccountOverride)> {
-        let web3 = self.web3.as_ref().or_else(|| {
-            tracing::warn!(
-                ?a_token,
-                "AaveV3AToken balance override requested but web3 is not configured",
-            );
-            None
-        })?;
-        aave::build_override(web3, a_token, pool, underlying, map_slot, holder, amount).await
     }
 }
 
@@ -745,6 +743,8 @@ mod tests {
         );
     }
 
+    /// When no detector is configured, there's no `Web3` handle available
+    /// and the `AaveV3AToken` resolver must cleanly fail rather than panic.
     #[tokio::test]
     async fn aave_v3_a_token_override_none_without_web3() {
         let a_token = address!("4d5F47FA6A74757f35C14fD3a6Ef8E3C9BC514E8");

--- a/crates/balance-overrides/src/lib.rs
+++ b/crates/balance-overrides/src/lib.rs
@@ -520,13 +520,6 @@ mod tests {
 
     #[test]
     fn ray_div_edge_cases() {
-        // End-to-end numerical correctness is covered by the forked-e2e
-        // `forked_node_mainnet_aave_atoken_detection` /
-        // `forked_node_mainnet_aave_atoken_quote` tests, which apply the
-        // override against a real aEthWETH and assert `balanceOf`
-        // round-trips. Here we only pin down `ray_div` itself at the two
-        // edge cases.
-
         let index = U256::from_str_radix("1063000000000000000000000000", 10).unwrap();
         // 0 / x = 0.
         assert_eq!(ray_div(U256::ZERO, index).unwrap(), U256::ZERO);

--- a/crates/configs/src/balance_overrides.rs
+++ b/crates/configs/src/balance_overrides.rs
@@ -44,11 +44,12 @@ pub enum Strategy {
     /// amount by it (ray division), so that `balanceOf` returns the desired
     /// amount. The high 128 bits of the slot (`additionalData`) are zeroed,
     /// which is safe for fresh holders like the spardose.
+    ///
+    /// Source: <https://github.com/aave-dao/aave-v3-origin/blob/main/src/contracts/protocol/tokenization/base/IncentivizedERC20.sol>
     AaveV3AToken {
         target_contract: Address,
         pool: Address,
         underlying: Address,
-        map_slot: U256,
     },
 }
 
@@ -85,10 +86,9 @@ impl std::fmt::Display for TokenConfiguration {
                     target_contract,
                     pool,
                     underlying,
-                    map_slot,
                 } => write!(
                     f,
-                    "AaveV3AToken({addr:?}: {target_contract:?}@{map_slot}, pool={pool:?}, \
+                    "AaveV3AToken({addr:?}: {target_contract:?}, pool={pool:?}, \
                      underlying={underlying:?})"
                 ),
             };
@@ -226,7 +226,6 @@ type = "AaveV3AToken"
 target_contract = "0x4d5f47fa6a74757f35c14fd3a6ef8e3c9bc514e8"
 pool = "0x87870bca3f3fd6335c3f4ce8392d69350b4fa4e2"
 underlying = "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"
-map_slot = "0x34"
 "#;
         let config: TokenConfiguration = toml::from_str(input).unwrap();
         let a_token = address!("4d5f47fa6a74757f35c14fd3a6ef8e3c9bc514e8");
@@ -237,7 +236,6 @@ map_slot = "0x34"
                 target_contract: a_token,
                 pool: address!("87870bca3f3fd6335c3f4ce8392d69350b4fa4e2"),
                 underlying: address!("c02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"),
-                map_slot: U256::from(52),
             }
         );
     }

--- a/crates/configs/src/balance_overrides.rs
+++ b/crates/configs/src/balance_overrides.rs
@@ -36,6 +36,20 @@ pub enum Strategy {
         target_contract: Address,
         slot: B256,
     },
+    /// Balance override strategy for Aave v3 aTokens whose `balanceOf` applies
+    /// a scaling factor (the reserve's normalized income) and whose storage
+    /// packs `UserState { uint128 balance; uint128 additionalData }` into a
+    /// single slot. The override is resolved at call time by fetching the
+    /// current normalized income from the Aave pool and dividing the target
+    /// amount by it (ray division), so that `balanceOf` returns the desired
+    /// amount. The high 128 bits of the slot (`additionalData`) are zeroed,
+    /// which is safe for fresh holders like the spardose.
+    AaveV3AToken {
+        target_contract: Address,
+        pool: Address,
+        underlying: Address,
+        map_slot: U256,
+    },
 }
 
 /// Token configurations for the `BalanceOverriding` component.
@@ -67,6 +81,16 @@ impl std::fmt::Display for TokenConfiguration {
                     target_contract,
                     slot,
                 } => write!(f, "DirectSlot({addr:?}: {target_contract:?}@{slot})"),
+                Strategy::AaveV3AToken {
+                    target_contract,
+                    pool,
+                    underlying,
+                    map_slot,
+                } => write!(
+                    f,
+                    "AaveV3AToken({addr:?}: {target_contract:?}@{map_slot}, pool={pool:?}, \
+                     underlying={underlying:?})"
+                ),
             };
 
         let mut entries = self.0.iter();
@@ -190,6 +214,32 @@ target_contract = "0x0000000000000000000000000000000000000005"
     fn deserialize_empty_config() {
         let config: TokenConfiguration = toml::from_str("").unwrap();
         assert!(config.0.is_empty());
+    }
+
+    #[test]
+    fn deserialize_aave_v3_a_token() {
+        use alloy::primitives::address;
+
+        let input = r#"
+[0x4d5f47fa6a74757f35c14fd3a6ef8e3c9bc514e8]
+type = "AaveV3AToken"
+target_contract = "0x4d5f47fa6a74757f35c14fd3a6ef8e3c9bc514e8"
+pool = "0x87870bca3f3fd6335c3f4ce8392d69350b4fa4e2"
+underlying = "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"
+map_slot = "0x34"
+"#;
+        let config: TokenConfiguration = toml::from_str(input).unwrap();
+        let a_token = address!("4d5f47fa6a74757f35c14fd3a6ef8e3c9bc514e8");
+        let strategy = config.0.get(&a_token).unwrap();
+        assert_eq!(
+            *strategy,
+            Strategy::AaveV3AToken {
+                target_contract: a_token,
+                pool: address!("87870bca3f3fd6335c3f4ce8392d69350b4fa4e2"),
+                underlying: address!("c02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"),
+                map_slot: U256::from(52),
+            }
+        );
     }
 
     #[test]

--- a/crates/e2e/tests/e2e/quote_verification.rs
+++ b/crates/e2e/tests/e2e/quote_verification.rs
@@ -84,9 +84,11 @@ async fn forked_node_mainnet_usdt_quote() {
     .await;
 }
 
-/// Quote verification for an Aave v3 aToken as the sell token. The
-/// auto-detector cannot resolve aToken balance slots (scaled `balanceOf` +
-/// packed `UserState`), so we rely on the `AaveV3AToken` hardcoded strategy.
+/// Quote verification for an Aave v3 aToken as the sell token. Exercises
+/// the `AaveV3AToken` strategy end-to-end through `BalanceOverrides`. The
+/// detector is disabled (`detector: None`) to isolate the hardcoded-strategy
+/// path; auto-detection is covered by `detects_aave_v3_a_token_mainnet` in
+/// the `balance-overrides` crate.
 #[tokio::test]
 #[ignore]
 async fn forked_node_mainnet_aave_atoken_quote() {

--- a/crates/e2e/tests/e2e/quote_verification.rs
+++ b/crates/e2e/tests/e2e/quote_verification.rs
@@ -852,7 +852,6 @@ async fn aave_atoken_quote_verification(web3: Web3) {
             target_contract: a_eth_weth,
             pool: aave_v3_pool,
             underlying: weth,
-            map_slot: U256::from(52),
         },
     )]);
     let balance_overrides = BalanceOverrides {
@@ -910,7 +909,6 @@ async fn aave_atoken_detection(web3: Web3) {
             target_contract: a_eth_weth,
             pool: address!("87870bca3f3fd6335c3f4ce8392d69350b4fa4e2"),
             underlying: address!("c02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"),
-            map_slot: U256::from(52),
         }
     );
 }

--- a/crates/e2e/tests/e2e/quote_verification.rs
+++ b/crates/e2e/tests/e2e/quote_verification.rs
@@ -89,8 +89,8 @@ async fn forked_node_mainnet_usdt_quote() {
 /// Quote verification for an Aave v3 aToken as the sell token. Exercises
 /// the `AaveV3AToken` strategy end-to-end through `BalanceOverrides`. The
 /// detector is disabled (`detector: None`) to isolate the hardcoded-strategy
-/// path; auto-detection is covered by `detects_aave_v3_a_token_mainnet` in
-/// the `balance-overrides` crate.
+/// path; auto-detection is covered by
+/// `forked_node_mainnet_aave_atoken_detection` below.
 #[tokio::test]
 #[ignore]
 async fn forked_node_mainnet_aave_atoken_quote() {
@@ -105,6 +105,21 @@ async fn forked_node_mainnet_aave_atoken_quote() {
             .expect("FORK_URL_MAINNET must be set to run forked tests"),
         FORK_BLOCK,
         ["price_estimation=trace", "balance_overrides=trace"],
+    )
+    .await;
+}
+
+/// The auto-detector identifies aEthWETH as a canonical Aave v3 aToken via
+/// the probe + canonical-slot fast-path, returning the right strategy
+/// without running a `debug_traceCall`. This runs in the forked-e2e CI job.
+#[tokio::test]
+#[ignore]
+async fn forked_node_mainnet_aave_atoken_detection() {
+    run_forked_test_with_block_number(
+        aave_atoken_detection,
+        std::env::var("FORK_URL_MAINNET")
+            .expect("FORK_URL_MAINNET must be set to run forked tests"),
+        FORK_BLOCK_MAINNET,
     )
     .await;
 }
@@ -874,5 +889,28 @@ async fn aave_atoken_quote_verification(web3: Web3) {
     assert!(
         diff <= U256::from(1u64),
         "balanceOf after override returned {reported}, expected ~{amount} (diff {diff} wei)",
+    );
+}
+
+/// Auto-detection against the mainnet fork: the probe + canonical-slot
+/// fast-path must identify aEthWETH as an `AaveV3AToken` without falling
+/// through to `debug_traceCall`.
+async fn aave_atoken_detection(web3: Web3) {
+    use balance_overrides::detector::{DEFAULT_VERIFICATION_TIMEOUT, Detector};
+
+    let detector = Detector::new(web3, 60, DEFAULT_VERIFICATION_TIMEOUT);
+    let a_eth_weth = address!("4d5f47fa6a74757f35c14fd3a6ef8e3c9bc514e8");
+    let strategy = detector
+        .detect(a_eth_weth, Address::with_last_byte(1))
+        .await
+        .unwrap();
+    assert_eq!(
+        strategy,
+        Strategy::AaveV3AToken {
+            target_contract: a_eth_weth,
+            pool: address!("87870bca3f3fd6335c3f4ce8392d69350b4fa4e2"),
+            underlying: address!("c02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"),
+            map_slot: U256::from(52),
+        }
     );
 }

--- a/crates/e2e/tests/e2e/quote_verification.rs
+++ b/crates/e2e/tests/e2e/quote_verification.rs
@@ -84,6 +84,27 @@ async fn forked_node_mainnet_usdt_quote() {
     .await;
 }
 
+/// Quote verification for an Aave v3 aToken as the sell token. The
+/// auto-detector cannot resolve aToken balance slots (scaled `balanceOf` +
+/// packed `UserState`), so we rely on the `AaveV3AToken` hardcoded strategy.
+#[tokio::test]
+#[ignore]
+async fn forked_node_mainnet_aave_atoken_quote() {
+    // Fork a block that matches the solver whitelist used for the quotes we
+    // inspected on barn (same day as the debugging session). The default
+    // `FORK_BLOCK_MAINNET` is a few weeks older and can miss newly
+    // whitelisted solvers.
+    const FORK_BLOCK: u64 = 24920000;
+    run_forked_test_with_extra_filters_and_block_number(
+        aave_atoken_quote_verification,
+        std::env::var("FORK_URL_MAINNET")
+            .expect("FORK_URL_MAINNET must be set to run forked tests"),
+        FORK_BLOCK,
+        ["price_estimation=trace", "balance_overrides=trace"],
+    )
+    .await;
+}
+
 /// Verified quotes work as expected.
 async fn standard_verified_quote(web3: Web3) {
     tracing::info!("Setting up chain state.");
@@ -716,6 +737,7 @@ async fn trace_based_balance_detection(web3: Web3) {
         let balance_overrides = BalanceOverrides {
             hardcoded: HashMap::from([(token, strategy)]),
             detector: None,
+            web3: None,
         };
 
         let override_result = balance_overrides
@@ -789,4 +811,76 @@ async fn trace_based_balance_detection(web3: Web3) {
         test_balance,
     )
     .await;
+}
+
+/// Exercises the `AaveV3AToken` balance override strategy against a real
+/// mainnet fork. We build the override with the forked web3 (so it reads
+/// the live `getReserveNormalizedIncome` from the Aave v3 Pool), then apply
+/// it in an `eth_call` to `aToken.balanceOf(holder)` and assert the
+/// reported balance matches the requested amount within one wei of ray
+/// rounding. This is the property `TradeVerifier` relies on when using
+/// the override to fund the spardose.
+async fn aave_atoken_quote_verification(web3: Web3) {
+    use {
+        ::alloy::rpc::types::state::StateOverride,
+        balance_overrides::BalanceOverrideRequest,
+        contracts::ERC20,
+        std::collections::HashMap,
+    };
+
+    // aEthWETH / WETH / Aave v3 Pool on mainnet.
+    let a_eth_weth = address!("4d5f47fa6a74757f35c14fd3a6ef8e3c9bc514e8");
+    let weth = address!("c02aaa39b223fe8d0a0e5c4f27ead9083c756cc2");
+    let aave_v3_pool = address!("87870bca3f3fd6335c3f4ce8392d69350b4fa4e2");
+    let spardose = address!("0000000000000000000000000000000000020000");
+
+    let mut hardcoded = HashMap::new();
+    hardcoded.insert(
+        a_eth_weth,
+        Strategy::AaveV3AToken {
+            target_contract: a_eth_weth,
+            pool: aave_v3_pool,
+            underlying: weth,
+            map_slot: U256::from(52),
+        },
+    );
+    let balance_overrides = BalanceOverrides {
+        hardcoded,
+        detector: None,
+        web3: Some(web3.clone()),
+    };
+
+    let amount = U256::from(5_000_000_000_000_000_000u128); // 5 aEthWETH
+
+    let (target, override_) = balance_overrides
+        .state_override(BalanceOverrideRequest {
+            token: a_eth_weth,
+            holder: spardose,
+            amount,
+        })
+        .await
+        .expect("override computed");
+    assert_eq!(target, a_eth_weth);
+
+    // Apply the override to a live `balanceOf` call via the forked node and
+    // make sure the contract now reports the requested amount (± 1 wei of
+    // ray rounding).
+    let overrides: StateOverride = [(target, override_)].into_iter().collect();
+    let a_token_contract = ERC20::Instance::new(a_eth_weth, web3.provider.clone());
+    let reported = a_token_contract
+        .balanceOf(spardose)
+        .state(overrides)
+        .call()
+        .await
+        .unwrap();
+
+    let diff = if reported > amount {
+        reported - amount
+    } else {
+        amount - reported
+    };
+    assert!(
+        diff <= U256::from(1u64),
+        "balanceOf after override returned {reported}, expected ~{amount} (diff {diff} wei)",
+    );
 }

--- a/crates/e2e/tests/e2e/quote_verification.rs
+++ b/crates/e2e/tests/e2e/quote_verification.rs
@@ -2,8 +2,9 @@ use {
     ::alloy::{
         primitives::{Address, U256, address, map::AddressMap},
         providers::Provider,
+        rpc::types::state::StateOverride,
     },
-    balance_overrides::{BalanceOverrides, BalanceOverriding},
+    balance_overrides::{BalanceOverrideRequest, BalanceOverrides, BalanceOverriding},
     bigdecimal::{BigDecimal, Zero},
     configs::{
         autopilot::Configuration,
@@ -11,6 +12,7 @@ use {
         price_estimation::BalanceOverridesConfig,
         test_util::TestDefault,
     },
+    contracts::ERC20,
     e2e::setup::*,
     ethrpc::{Web3, alloy::CallBuilderExt},
     model::{
@@ -27,7 +29,7 @@ use {
     },
     serde_json::json,
     simulator::swap_simulator::SwapSimulator,
-    std::sync::Arc,
+    std::{collections::HashMap, sync::Arc},
 };
 
 #[tokio::test]
@@ -823,21 +825,13 @@ async fn trace_based_balance_detection(web3: Web3) {
 /// rounding. This is the property `TradeVerifier` relies on when using
 /// the override to fund the spardose.
 async fn aave_atoken_quote_verification(web3: Web3) {
-    use {
-        ::alloy::rpc::types::state::StateOverride,
-        balance_overrides::BalanceOverrideRequest,
-        contracts::ERC20,
-        std::collections::HashMap,
-    };
-
     // aEthWETH / WETH / Aave v3 Pool on mainnet.
     let a_eth_weth = address!("4d5f47fa6a74757f35c14fd3a6ef8e3c9bc514e8");
     let weth = address!("c02aaa39b223fe8d0a0e5c4f27ead9083c756cc2");
     let aave_v3_pool = address!("87870bca3f3fd6335c3f4ce8392d69350b4fa4e2");
     let spardose = address!("0000000000000000000000000000000000020000");
 
-    let mut hardcoded = HashMap::new();
-    hardcoded.insert(
+    let hardcoded = HashMap::from([(
         a_eth_weth,
         Strategy::AaveV3AToken {
             target_contract: a_eth_weth,
@@ -845,14 +839,14 @@ async fn aave_atoken_quote_verification(web3: Web3) {
             underlying: weth,
             map_slot: U256::from(52),
         },
-    );
+    )]);
     let balance_overrides = BalanceOverrides {
         hardcoded,
         detector: None,
         web3: Some(web3.clone()),
     };
 
-    let amount = U256::from(5_000_000_000_000_000_000u128); // 5 aEthWETH
+    let amount = 5u64.eth(); // 5 aEthWETH
 
     let (target, override_) = balance_overrides
         .state_override(BalanceOverrideRequest {
@@ -876,11 +870,7 @@ async fn aave_atoken_quote_verification(web3: Web3) {
         .await
         .unwrap();
 
-    let diff = if reported > amount {
-        reported - amount
-    } else {
-        amount - reported
-    };
+    let diff = reported.abs_diff(amount);
     assert!(
         diff <= U256::from(1u64),
         "balanceOf after override returned {reported}, expected ~{amount} (diff {diff} wei)",

--- a/crates/price-estimation/src/config/price_estimation.rs
+++ b/crates/price-estimation/src/config/price_estimation.rs
@@ -15,13 +15,14 @@ impl BalanceOverridesConfigExt for BalanceOverridesConfig {
             detector: self.autodetect.then(|| {
                 (
                     balance_overrides::detector::Detector::new(
-                        web3,
+                        web3.clone(),
                         self.probing_depth,
                         self.detection_timeout,
                     ),
                     std::sync::Mutex::new(cached::SizedCache::with_size(self.cache_size)),
                 )
             }),
+            web3: Some(web3),
         })
     }
 }

--- a/crates/price-estimation/src/trade_verifier/mod.rs
+++ b/crates/price-estimation/src/trade_verifier/mod.rs
@@ -408,6 +408,11 @@ impl TradeVerifier {
                 }
             }
             _ => {
+                tracing::warn!(
+                    sell_token = ?query.sell_token,
+                    "could not set spardose balance override for sell token; trade \
+                     verification will rely on the trader's real balance"
+                );
                 if verification.from.is_zero() {
                     anyhow::bail!("trader is zero address and balances can not be faked");
                 }


### PR DESCRIPTION
# Description
Quote verification was silently failing for any Aave v3 aToken as the sell token (e.g. aEthWETH → WETH) because the balance-override mechanism assumes the value at the balance storage slot is what `balanceOf` returns. Aave v3 aTokens break both assumptions: `balanceOf` applies a `rayMul(scaled, liquidityIndex)` scaling, and storage is packed `UserState { uint128 balance; uint128 additionalData }`. The auto-detector's verify step therefore never matched, returned `NotFound`, and the trade verifier silently skipped the override, producing the production revert `execution reverted: trader does not have enough sell token` visible in barn logs for aEthWETH quotes today (reproduced on Tenderly: https://dashboard.tenderly.co/cow-protocol/barn/simulator/1e69fa91-9496-44d1-9aec-a0e34166f9df).

# Changes
- New `Strategy::AaveV3AToken { target_contract, pool, underlying, map_slot }` variant in `configs::balance_overrides::Strategy` and a corresponding async resolver on `BalanceOverrides` that fetches the current `getReserveNormalizedIncome` from the Aave v3 Pool, rayDivs the requested amount (round-half-up, bit-for-bit compatible with `WadRayMath.rayDiv`), and writes it into the low 128 bits of the packed `_userState` slot.
- Auto-detector is now Aave-aware: the detector probes the token with `UNDERLYING_ASSET_ADDRESS()` + `POOL()` and then calls `pool.getReserveData(underlying)` and verifies the returned `aTokenAddress` equals the probed token — an identity check that only passes for tokens the pool itself has registered as an aToken for their underlying, preventing rogue contracts that merely implement the aToken selectors from being accepted. When the probe succeeds, mapping-style slots are also offered as `AaveV3AToken` candidates and verified with a 1-wei round-trip tolerance instead of strict equality. No hardcoded per-token list is needed. aEthWETH and every other Aave v3 aToken on every chain (mainnet, Arbitrum, Base, Gnosis, Polygon, BNB, Linea, Plasma, Ink, Avalanche, etc.) are picked up automatically the first time they're quoted.
- Shared Aave math lives in a new `balance-overrides::aave` module so the production override builder and the detector probe/verify use identical arithmetic.
- `trade_verifier::prepare_state_overrides` now emits `tracing::warn!` when the spardose balance override for the sell token can't be resolved — mirroring the existing warn on the buy-side path so future missing overrides surface in logs instead of only showing up as downstream reverts.

# Aave v4 note
Aave v4's user-facing deposit receipt is `TokenizationSpoke`, an ERC-4626 vault built on OpenZeppelin's `ERC20Upgradeable` — not a scaled aToken. `balanceOf` is the plain OZ `_balances[user]` mapping (no `rayMul` scaling), and the contract doesn't expose `UNDERLYING_ASSET_ADDRESS()` or `POOL()`. Our probe therefore correctly rejects v4 Spokes and the detector falls through to the existing `SolidityMapping` / `DirectSlot` heuristics, which handle them as standard ERC-20s. No v4-specific work is needed here.
Source: <https://github.com/aave/aave-v4/blob/main/src/spoke/TokenizationSpoke.sol>

# How to test
Unit tests:
- `balance-overrides::tests::a_token_balance_override_bug_reproduction` — pins the arithmetic: writing the raw amount (what the old strategies do) makes `balanceOf` return `rayMul(amount, index)` (off by ~6e16 wei at aEthWETH's current index); writing `rayDiv(amount, index)` round-trips within 1 wei.
- `balance-overrides::aave::tests` — mock-provider tests for the probe: accepts a valid aToken, rejects when either selector reverts, rejects when the claimed pool doesn't look like Aave v3, rejects when the pool registers a *different* aToken for the declared underlying.
- `balance-overrides::tests::aave_v3_a_token_override_scales_amount_and_writes_low_128` — mock-provider integration test for the override builder.

e2e local + forked node tests:
- `balance-overrides::detector::tests::detects_aave_v3_a_token_mainnet` — asserts the detector returns `AaveV3AToken { pool=0x87870bca…4fa4e2, underlying=WETH, map_slot=52 }` for aEthWETH.
- `balance-overrides::tests::aave_v3_a_token_override_mainnet_roundtrip` — applies the override via `eth_call` against real aEthWETH and asserts `balanceOf(holder) ≈ amount`.
- `e2e::quote_verification::forked_node_mainnet_aave_atoken_quote` — same round-trip against an anvil mainnet fork, exercising the full `BalanceOverrides::state_override` path.

# Follow-up items
- **Registry-based detection.** The current probe costs 3 `eth_call`s per cold-cache token. An alternative is to enumerate all reserves once per chain from Aave's `AaveProtocolDataProvider` (or equivalent), cache the full list of aTokens, and do a pure `HashMap` lookup on each quote. That would make detection amortised O(1) and provide the strongest identity guarantee (taken from Aave's own registry), at the cost of introducing a per-chain constant for the DataProvider address, a refresh cadence for new markets, and handling multiple Aave v3 markets per chain (e.g. mainnet has Ethereum + Prime). Probably worth doing once aToken quote volume warrants the optimisation.
- **Cache the accrued liquidity index for ~1 block.** Each aToken quote currently re-fetches `getReserveNormalizedIncome`. The index drifts slowly (fractions of a wei per block), so caching for 6–12 s would drop the per-quote cost to zero without meaningful accuracy loss.
- **Aave v2 support.** Same scaling + packed-storage shape; different `LendingPool` interface. v2 is deprecated but still has markets; worth revisiting if any start to attract volume.