### PR TITLE
Add uni v3 defaults on gnosis chain

### DIFF
--- a/contracts/generated/contracts-generated/iuniswapv3factory/src/lib.rs
+++ b/contracts/generated/contracts-generated/iuniswapv3factory/src/lib.rs
@@ -1313,6 +1313,10 @@ pub const fn deployment_info(chain_id: u64) -> Option<(Address, Option<u64>)> {
             ::alloy_primitives::address!("0xdB1d10011AD0Ff90774D0C6Bb92e5C5c8b4461F7"),
             None,
         )),
+        100u64 => Some((
+            ::alloy_primitives::address!("0xe32F7dD7e3f098D518ff19A22d5f028e076489B1"),
+            None,
+        )),
         137u64 => Some((
             ::alloy_primitives::address!("0x1F98431c8aD98523631AE4a59f267346ea31F984"),
             None,

--- a/contracts/generated/contracts-generated/uniswapv3quoterv2/src/lib.rs
+++ b/contracts/generated/contracts-generated/uniswapv3quoterv2/src/lib.rs
@@ -2654,6 +2654,10 @@ pub const fn deployment_info(chain_id: u64) -> Option<(Address, Option<u64>)> {
             ::alloy_primitives::address!("0x78D78E420Da98ad378D7799bE8f4AF69033EB077"),
             None,
         )),
+        100u64 => Some((
+            ::alloy_primitives::address!("0x7E9cB3499A6cee3baBe5c8a3D328EA7FD36578f4"),
+            None,
+        )),
         137u64 => Some((
             ::alloy_primitives::address!("0x61fFE014bA17989E743c5F6cB21bF9697530B21e"),
             None,

--- a/contracts/generated/contracts-generated/uniswapv3swaprouterv2/src/lib.rs
+++ b/contracts/generated/contracts-generated/uniswapv3swaprouterv2/src/lib.rs
@@ -1011,6 +1011,10 @@ pub const fn deployment_info(chain_id: u64) -> Option<(Address, Option<u64>)> {
             ::alloy_primitives::address!("0xB971eF87ede563556b2ED4b1C0b0019111Dd85d2"),
             None,
         )),
+        100u64 => Some((
+            ::alloy_primitives::address!("0xc6D25285D5C5b62b7ca26D6092751A145D50e9Be"),
+            None,
+        )),
         137u64 => Some((
             ::alloy_primitives::address!("0x68b3465833fb72A70ecDF485E0e4C7bD8665Fc45"),
             None,

--- a/contracts/src/main.rs
+++ b/contracts/src/main.rs
@@ -327,6 +327,7 @@ fn build_module() -> Module {
         .add_contract(Contract::new("UniswapV3Pool"))
         .add_contract(Contract::new("UniswapV3QuoterV2").with_networks(networks![
             MAINNET => "0x61fFE014bA17989E743c5F6cB21bF9697530B21e",
+            GNOSIS => "0x7E9cB3499A6cee3baBe5c8a3D328EA7FD36578f4",
             ARBITRUM_ONE => "0x61fFE014bA17989E743c5F6cB21bF9697530B21e",
             BASE => "0x3d4e44Eb1374240CE5F1B871ab261CD16335B76a",
             AVALANCHE => "0xbe0F5544EC67e9B3b2D979aaA43f18Fd87E6257F",
@@ -341,6 +342,7 @@ fn build_module() -> Module {
             Contract::new("UniswapV3SwapRouterV2").with_networks(networks![
                 ARBITRUM_ONE => "0x68b3465833fb72A70ecDF485E0e4C7bD8665Fc45",
                 MAINNET => "0x68b3465833fb72A70ecDF485E0e4C7bD8665Fc45",
+                GNOSIS => "0xc6D25285D5C5b62b7ca26D6092751A145D50e9Be",
                 POLYGON => "0x68b3465833fb72A70ecDF485E0e4C7bD8665Fc45",
                 OPTIMISM => "0x68b3465833fb72A70ecDF485E0e4C7bD8665Fc45",
                 BASE => "0x2626664c2603336E57B271c5C0b26F421741e481",
@@ -353,6 +355,7 @@ fn build_module() -> Module {
         )
         .add_contract(Contract::new("IUniswapV3Factory").with_networks(networks![
             MAINNET => "0x1F98431c8aD98523631AE4a59f267346ea31F984",
+            GNOSIS => "0xe32F7dD7e3f098D518ff19A22d5f028e076489B1",
             SEPOLIA => "0x1F98431c8aD98523631AE4a59f267346ea31F984",
             ARBITRUM_ONE => "0x1F98431c8aD98523631AE4a59f267346ea31F984",
             BASE => "0x33128a8fC17869897dcE68Ed026d694621f6FDfD",

--- a/crates/liquidity-sources/src/lib.rs
+++ b/crates/liquidity-sources/src/lib.rs
@@ -49,6 +49,7 @@ pub fn defaults_for_network(chain: &Chain) -> Vec<BaselineSource> {
             BaselineSource::SushiSwap,
             BaselineSource::Baoswap,
             BaselineSource::Swapr,
+            BaselineSource::UniswapV3,
         ],
         Chain::ArbitrumOne => vec![
             BaselineSource::UniswapV2,


### PR DESCRIPTION
# Description
By now there is an official uniswap v3 deployment on gnosis chain so we can now add all the default values. Values were taken from [here](https://gov.uniswap.org/t/official-uniswap-v3-deployments-list/24323/3#p-53385-gnosis-7).
Note, that uniswap v3 so far was manually configured in the driver but having defaults for all those contracts is just nicer.

This issue was surfaced by @daveai on slack.

# Changes
- added addresses for router, quoter, and factory
    - also re-generated the rust code
- added uni v3 to list of default liquidity sources (this is actually not used anymore and should be removed but since it makes more sense to delete it in a follow up PR it seemed proper to still add the value for gnosis to not leave the code base in an inconsistent state - it's just 1 line anyway)