### PR TITLE
Correctly encode approval interactions for USDT-like tokens

### DIFF
--- a/crates/driver/src/domain/competition/solution/mod.rs
+++ b/crates/driver/src/domain/competition/solution/mod.rs
@@ -13,10 +13,10 @@ use {
             solver::{ManageNativeToken, Solver},
         },
     },
-    alloy::{network::TxSigner, primitives::ruint::aliases::U256},
+    alloy::network::TxSigner,
     chrono::Utc,
     contracts::ERC20::ERC20,
-    eth_domain_types::{self as eth, Address, Allowance, TokenAddress},
+    eth_domain_types::{self as eth, TokenAddress},
     futures::future::try_join_all,
     itertools::Itertools,
     num::{BigRational, One},
@@ -307,44 +307,30 @@ impl Solution {
         eth: &Ethereum,
         internalization: settlement::Internalization,
     ) -> Result<impl Iterator<Item = eth::allowance::Approval> + use<>, Error> {
-        // first reduce the approvals to only the highest values in case the solver
-        // already provided approval resets for USDT-like tokens
-        let mut requested_allowances = HashMap::<(Address, TokenAddress), U256>::default();
-        for allowance in self.allowances(internalization) {
-            let needed = requested_allowances
-                .entry((allowance.0.spender, allowance.0.token))
-                .or_default();
-            *needed = std::cmp::max(*needed, allowance.0.amount);
-        }
-
         let settlement_contract = *eth.contracts().settlement().address();
-        let allowances = try_join_all(requested_allowances.into_iter().map(
-            |((spender, token), amount)| async move {
-                let approval = eth::allowance::Approval(Allowance {
-                    token,
-                    spender,
-                    amount,
-                });
-                let erc20_token = ERC20::new(token.into(), &eth.web3().provider);
+        let allowances =
+            try_join_all(self.allowances(internalization).map(|required| async move {
+                let erc20_token = ERC20::new(required.0.token.into(), &eth.web3().provider);
 
                 let current_allowance = erc20_token
-                    .allowance(settlement_contract, spender)
+                    .allowance(settlement_contract, required.0.spender)
                     .call()
                     .await
                     .map_err(blockchain::Error::ContractRpc)?;
 
                 // if the current allowance is sufficient we can skip that interaction
-                if current_allowance >= amount {
-                    return Ok::<_, blockchain::Error>(vec![approval]);
+                if current_allowance >= required.0.amount {
+                    return Ok::<_, blockchain::Error>(vec![]);
                 }
 
                 let regular_approval_succeeds = erc20_token
-                    .approve(spender, amount)
+                    .approve(required.0.spender, required.0.amount)
                     .from(settlement_contract)
                     .call()
                     .await
                     .is_ok();
 
+                let approval = eth::allowance::Approval(required.0);
                 if regular_approval_succeeds {
                     Ok(vec![approval])
                 } else {
@@ -353,9 +339,8 @@ impl Solution {
                     // approval reset to 0 first
                     Ok(vec![approval.revoke(), approval])
                 }
-            },
-        ))
-        .await?;
+            }))
+            .await?;
         Ok(allowances.into_iter().flatten())
     }
 

--- a/crates/driver/src/domain/competition/solution/mod.rs
+++ b/crates/driver/src/domain/competition/solution/mod.rs
@@ -13,9 +13,10 @@ use {
             solver::{ManageNativeToken, Solver},
         },
     },
-    alloy::network::TxSigner,
+    alloy::{network::TxSigner, primitives::ruint::aliases::U256},
     chrono::Utc,
-    eth_domain_types::{self as eth, TokenAddress},
+    contracts::ERC20::ERC20,
+    eth_domain_types::{self as eth, Address, Allowance, TokenAddress},
     futures::future::try_join_all,
     itertools::Itertools,
     num::{BigRational, One},
@@ -298,24 +299,64 @@ impl Solution {
     }
 
     /// Approval interactions necessary for encoding the settlement.
+    /// This function handles approvals correctly for tokens like USDT which
+    /// first need to have the allowance set to 0 before it can be increased
+    /// again. See <https://github.com/ethereum/EIPs/issues/20#issuecomment-263524729>
     pub async fn approvals(
         &self,
         eth: &Ethereum,
         internalization: settlement::Internalization,
     ) -> Result<impl Iterator<Item = eth::allowance::Approval> + use<>, Error> {
-        let settlement_contract = &eth.contracts().settlement();
-        let allowances =
-            try_join_all(self.allowances(internalization).map(|required| async move {
-                eth.erc20(required.0.token)
-                    .allowance(*settlement_contract.address(), required.0.spender)
+        // first reduce the approvals to only the highest values in case the solver
+        // already provided approval resets for USDT-like tokens
+        let mut requested_allowances = HashMap::<(Address, TokenAddress), U256>::default();
+        for allowance in self.allowances(internalization) {
+            let needed = requested_allowances
+                .entry((allowance.0.spender, allowance.0.token))
+                .or_default();
+            *needed = std::cmp::max(*needed, allowance.0.amount);
+        }
+
+        let settlement_contract = *eth.contracts().settlement().address();
+        let allowances = try_join_all(requested_allowances.into_iter().map(
+            |((spender, token), amount)| async move {
+                let approval = eth::allowance::Approval(Allowance {
+                    token,
+                    spender,
+                    amount,
+                });
+                let erc20_token = ERC20::new(token.into(), &eth.web3().provider);
+
+                let current_allowance = erc20_token
+                    .allowance(settlement_contract, spender)
+                    .call()
                     .await
-                    .map(|existing| (required, existing))
-            }))
-            .await?;
-        let approvals = allowances
-            .into_iter()
-            .filter_map(|(required, existing)| required.approval(&existing));
-        Ok(approvals)
+                    .map_err(blockchain::Error::ContractRpc)?;
+
+                // if the current allowance is sufficient we can skip that interaction
+                if current_allowance >= amount {
+                    return Ok::<_, blockchain::Error>(vec![approval]);
+                }
+
+                let regular_approval_succeeds = erc20_token
+                    .approve(spender, amount)
+                    .from(settlement_contract)
+                    .call()
+                    .await
+                    .is_ok();
+
+                if regular_approval_succeeds {
+                    Ok(vec![approval])
+                } else {
+                    // setting the desired approval reverts so we assume we are
+                    // dealing with a USDT-like token that needs to have the
+                    // approval reset to 0 first
+                    Ok(vec![approval.revoke(), approval])
+                }
+            },
+        ))
+        .await?;
+        Ok(allowances.into_iter().flatten())
     }
 
     /// An empty solution has no trades which is allowed to capture surplus and

--- a/crates/driver/src/domain/competition/solution/mod.rs
+++ b/crates/driver/src/domain/competition/solution/mod.rs
@@ -319,8 +319,7 @@ impl Solution {
                 let current_allowance = erc20_token
                     .allowance(settlement_contract, required.0.spender)
                     .call()
-                    .await
-                    .map_err(blockchain::Error::ContractRpc)?;
+                    .await?;
 
                 // if the current allowance is sufficient we can skip that interaction
                 if current_allowance >= required.0.amount {

--- a/crates/driver/src/domain/competition/solution/mod.rs
+++ b/crates/driver/src/domain/competition/solution/mod.rs
@@ -299,9 +299,13 @@ impl Solution {
     }
 
     /// Approval interactions necessary for encoding the settlement.
-    /// This function handles approvals correctly for tokens like USDT which
-    /// first need to have the allowance set to 0 before it can be increased
-    /// again. See <https://github.com/ethereum/EIPs/issues/20#issuecomment-263524729>
+    /// To support tokens like USDT which first need to have their allowance
+    /// set to 0 before it can be set to the desired value we simulate each
+    /// `approve()` call and inject additional `approve(0)` interactions when
+    /// we encounter a revert.
+    /// Whenever the needed allowance is less the current allowance no
+    /// `approve()` interactions get encoded to save on gas.
+    /// See <https://github.com/ethereum/EIPs/issues/20#issuecomment-263524729>
     pub async fn approvals(
         &self,
         eth: &Ethereum,

--- a/crates/e2e/tests/e2e/limit_orders.rs
+++ b/crates/e2e/tests/e2e/limit_orders.rs
@@ -102,8 +102,8 @@ async fn local_node_buy_order_with_haircut() {
 
 /// The block number from which we will fetch state for the forked tests.
 const FORK_BLOCK_MAINNET: u64 = 24843565;
-/// USDC whale address as per [FORK_BLOCK_MAINNET].
-const USDC_WHALE_MAINNET: Address = address!("28c6c06298d514db089934071355e5743bf21d60");
+/// USDT whale address as per [FORK_BLOCK_MAINNET].
+const USDT_WHALE_MAINNET: Address = address!("F977814e90dA44bFA03b6295A0616a897441aceC");
 
 #[tokio::test]
 #[ignore]
@@ -981,12 +981,12 @@ async fn forked_mainnet_single_limit_order_test(web3: Web3) {
         web3.provider.clone(),
     );
 
-    // Give trader some USDC
+    // Give trader some USDT
     web3.provider
         .anvil_send_impersonated_transaction_with_config(
-            token_usdc
+            token_usdt
                 .transfer(trader.address(), 1000u64.matom())
-                .from(USDC_WHALE_MAINNET)
+                .from(USDT_WHALE_MAINNET)
                 .into_transaction_request(),
             ImpersonateConfig {
                 fund_amount: None,
@@ -1000,7 +1000,7 @@ async fn forked_mainnet_single_limit_order_test(web3: Web3) {
         .unwrap();
 
     // Approve GPv2 for trading
-    token_usdc
+    token_usdt
         .approve(onchain.contracts().allowance, 1000u64.matom())
         .from(trader.address())
         .send_and_watch()
@@ -1014,9 +1014,9 @@ async fn forked_mainnet_single_limit_order_test(web3: Web3) {
     onchain.mint_block().await;
 
     let order = OrderCreation {
-        sell_token: *token_usdc.address(),
+        sell_token: *token_usdt.address(),
         sell_amount: 1000u64.matom(),
-        buy_token: *token_usdt.address(),
+        buy_token: *token_usdc.address(),
         buy_amount: 500u64.matom(),
         valid_to: model::time::now_in_epoch_seconds() + 300,
         kind: OrderKind::Sell,
@@ -1032,8 +1032,8 @@ async fn forked_mainnet_single_limit_order_test(web3: Web3) {
     // may time out)
     let _ = services
         .submit_quote(&OrderQuoteRequest {
-            sell_token: *token_usdc.address(),
-            buy_token: *token_usdt.address(),
+            sell_token: *token_usdt.address(),
+            buy_token: *token_usdc.address(),
             side: OrderQuoteSide::Sell {
                 sell_amount: SellAmount::BeforeFee {
                     value: (1000u64.matom()).try_into().unwrap(),
@@ -1043,8 +1043,8 @@ async fn forked_mainnet_single_limit_order_test(web3: Web3) {
         })
         .await;
 
-    let sell_token_balance_before = token_usdc.balanceOf(trader.address()).call().await.unwrap();
-    let buy_token_balance_before = token_usdt.balanceOf(trader.address()).call().await.unwrap();
+    let sell_token_balance_before = token_usdt.balanceOf(trader.address()).call().await.unwrap();
+    let buy_token_balance_before = token_usdc.balanceOf(trader.address()).call().await.unwrap();
     let order_id = services.create_order(&order).await.unwrap();
     let limit_order = services.get_order(&order_id).await.unwrap();
     assert_eq!(limit_order.metadata.class, OrderClass::Limit);
@@ -1054,8 +1054,8 @@ async fn forked_mainnet_single_limit_order_test(web3: Web3) {
 
     wait_for_condition(TIMEOUT, || async {
         onchain.mint_block().await;
-        let sell_token_balance_after = token_usdc.balanceOf(trader.address()).call().await.unwrap();
-        let buy_token_balance_after = token_usdt.balanceOf(trader.address()).call().await.unwrap();
+        let sell_token_balance_after = token_usdt.balanceOf(trader.address()).call().await.unwrap();
+        let buy_token_balance_after = token_usdc.balanceOf(trader.address()).call().await.unwrap();
 
         (sell_token_balance_before > sell_token_balance_after)
             && (buy_token_balance_after >= buy_token_balance_before + 500u64.matom())


### PR DESCRIPTION
# Description
Alternative to https://github.com/cowprotocol/services/pull/4340

USDT is a bit special because it is one of very few tokens where the `approve()` function requires you to set the allowance back to 0 before you can alter it again to avoid a vulnerability (see [here](https://github.com/ethereum/EIPs/issues/20#issuecomment-263524729)).

# Changes
This PR adjusts the driver's approval encoding logic such that it checks whether the regular `approve()` call would revert. In case that happens it encodes an `approve(0)` and `approve(desired_value)` to be compatible with this security measure / quirk.
That way we support all those tokens on all chains without needing any extra configuration parameters or hardcoded values. The downside is 1 extra RPC call every time we have to increase an approval which is extremely rare so it's fine.

## How to test
Converted an existing `USDC -> USDT` order fork test to be a `USDT -> USDC` test. This test fails without the PR's change.