### PR TITLE
Log driver API request deserialization errors

### DIFF
--- a/crates/driver/src/domain/competition/pre_processing.rs
+++ b/crates/driver/src/domain/competition/pre_processing.rs
@@ -235,7 +235,11 @@ impl Utilities {
                 observe::metrics::metrics().on_auction_overhead_start("driver", "parse_dto");
             // deserialization takes tens of milliseconds so run it on a blocking task
             tokio::task::spawn_blocking(move || {
-                serde_json::from_slice(&solve_request).context("could not parse solve request")
+                serde_json::from_slice(&solve_request)
+                    .inspect_err(|err| {
+                        tracing::warn!(?err, "failed to parse /solve request body");
+                    })
+                    .context("could not parse solve request")
             })
             .await
             .context("failed to await blocking task")??

--- a/crates/driver/src/infra/api/extract.rs
+++ b/crates/driver/src/infra/api/extract.rs
@@ -1,0 +1,65 @@
+//! Axum extractors that emit a `warn` log when request deserialization
+//! fails, then delegate to the stock extractor's rejection so the HTTP
+//! response shape is unchanged.
+
+use {
+    axum::{
+        extract::{
+            FromRequest,
+            FromRequestParts,
+            Request,
+            rejection::{JsonRejection, QueryRejection},
+        },
+        http::request::Parts,
+    },
+    serde::de::DeserializeOwned,
+};
+
+pub struct LoggingJson<T>(pub T);
+
+impl<S, T> FromRequest<S> for LoggingJson<T>
+where
+    S: Send + Sync,
+    T: DeserializeOwned,
+{
+    type Rejection = JsonRejection;
+
+    async fn from_request(req: Request, state: &S) -> Result<Self, Self::Rejection> {
+        match axum::Json::<T>::from_request(req, state).await {
+            Ok(axum::Json(value)) => Ok(Self(value)),
+            Err(rejection) => {
+                tracing::warn!(
+                    err = %rejection,
+                    target = std::any::type_name::<T>(),
+                    "failed to deserialize JSON request body",
+                );
+                Err(rejection)
+            }
+        }
+    }
+}
+
+pub struct LoggingQuery<T>(pub T);
+
+impl<S, T> FromRequestParts<S> for LoggingQuery<T>
+where
+    S: Send + Sync,
+    T: DeserializeOwned,
+{
+    type Rejection = QueryRejection;
+
+    async fn from_request_parts(parts: &mut Parts, state: &S) -> Result<Self, Self::Rejection> {
+        match axum::extract::Query::<T>::from_request_parts(parts, state).await {
+            Ok(axum::extract::Query(value)) => Ok(Self(value)),
+            Err(rejection) => {
+                tracing::warn!(
+                    err = %rejection,
+                    target = std::any::type_name::<T>(),
+                    query = parts.uri.query().unwrap_or_default(),
+                    "failed to deserialize query string",
+                );
+                Err(rejection)
+            }
+        }
+    }
+}

--- a/crates/driver/src/infra/api/extract.rs
+++ b/crates/driver/src/infra/api/extract.rs
@@ -15,6 +15,8 @@ use {
     serde::de::DeserializeOwned,
 };
 
+/// JSON extractor that wraps Axum's native one and logs deserialization
+/// errors.
 pub struct LoggingJson<T>(pub T);
 
 impl<S, T> FromRequest<S> for LoggingJson<T>
@@ -39,6 +41,8 @@ where
     }
 }
 
+/// Query extractor that wraps Axum's native one and logs deserialization
+/// errors.
 pub struct LoggingQuery<T>(pub T);
 
 impl<S, T> FromRequestParts<S> for LoggingQuery<T>

--- a/crates/driver/src/infra/api/mod.rs
+++ b/crates/driver/src/infra/api/mod.rs
@@ -28,6 +28,7 @@ use {
 };
 
 mod error;
+mod extract;
 pub mod routes;
 
 pub struct Api {

--- a/crates/driver/src/infra/api/routes/quote/mod.rs
+++ b/crates/driver/src/infra/api/routes/quote/mod.rs
@@ -1,6 +1,6 @@
 use {
     crate::infra::{
-        api::{Error, State},
+        api::{Error, State, extract::LoggingQuery},
         observe,
     },
     tracing::Instrument,
@@ -16,10 +16,10 @@ pub(in crate::infra::api) fn quote(router: axum::Router<State>) -> axum::Router<
 
 async fn route(
     state: axum::extract::State<State>,
-    order: axum::extract::Query<dto::Order>,
+    LoggingQuery(order): LoggingQuery<dto::Order>,
 ) -> Result<axum::Json<dto::Quote>, (axum::http::StatusCode, axum::Json<Error>)> {
     let handle_request = async {
-        let order = order.0.into_domain();
+        let order = order.into_domain();
         observe::quoting(&order);
         let quote = order
             .quote(

--- a/crates/driver/src/infra/api/routes/reveal/mod.rs
+++ b/crates/driver/src/infra/api/routes/reveal/mod.rs
@@ -4,7 +4,7 @@ use {
     crate::{
         domain::competition::auction,
         infra::{
-            api::{self, Error, State},
+            api::{self, Error, State, extract::LoggingJson},
             observe,
         },
     },
@@ -17,7 +17,7 @@ pub(in crate::infra::api) fn reveal(router: axum::Router<State>) -> axum::Router
 
 async fn route(
     state: axum::extract::State<State>,
-    req: axum::Json<dto::RevealRequest>,
+    LoggingJson(req): LoggingJson<dto::RevealRequest>,
 ) -> Result<axum::Json<dto::RevealResponse>, (axum::http::StatusCode, axum::Json<Error>)> {
     let auction_id =
         auction::Id::try_from(req.auction_id).map_err(api::routes::AuctionError::from)?;

--- a/crates/driver/src/infra/api/routes/settle/mod.rs
+++ b/crates/driver/src/infra/api/routes/settle/mod.rs
@@ -4,7 +4,7 @@ use {
     crate::{
         domain::competition::auction,
         infra::{
-            api::{self, Error, State},
+            api::{self, Error, State, extract::LoggingJson},
             observe,
         },
     },
@@ -17,7 +17,7 @@ pub(in crate::infra::api) fn settle(router: axum::Router<State>) -> axum::Router
 
 async fn route(
     state: axum::extract::State<State>,
-    req: axum::Json<dto::SettleRequest>,
+    LoggingJson(req): LoggingJson<dto::SettleRequest>,
 ) -> Result<(), (axum::http::StatusCode, axum::Json<Error>)> {
     let auction_id =
         auction::Id::try_from(req.auction_id).map_err(api::routes::AuctionError::from)?;


### PR DESCRIPTION
# Description
Axum returns a terse 400 when a request body or query string fails to deserialize, which makes malformed caller payloads invisible in production.

# Changes
- Added `LoggingJson` and `LoggingQuery` extractors that emit a `tracing::warn!` with the serde error and the target type, then delegate to axum's stock rejection (HTTP response shape unchanged).
- Wired the new extractors into `/settle`, `/reveal`, and `/quote`.
- Added a `tracing::warn!` on `/solve` body parse failures in `pre_processing.rs`.

# How to test
Existing tests.