### PR TITLE
Include block number in logged Tenderly simulation command

### DIFF
--- a/crates/orderbook/src/order_simulator.rs
+++ b/crates/orderbook/src/order_simulator.rs
@@ -176,7 +176,7 @@ impl OrderSimulator {
                 self.chain_id.clone(),
                 &result.tx,
                 result.overrides,
-                Some(BlockNo(block_number)),
+                BlockNo(block_number),
             )
             .map_err(|err| Error::Other(anyhow!(err)))?
         };

--- a/crates/price-estimation/src/trade_verifier/mod.rs
+++ b/crates/price-estimation/src/trade_verifier/mod.rs
@@ -234,11 +234,8 @@ impl TradeVerifier {
             .await?;
 
         if let Some(tenderly) = &self.tenderly
-            && let Err(err) = tenderly.log_simulation_command(
-                output.tx,
-                output.overrides,
-                Some(block.number.into()),
-            )
+            && let Err(err) =
+                tenderly.log_simulation_command(output.tx, output.overrides, block.number.into())
         {
             tracing::debug!(?err, "could not log tenderly simulation command");
         }

--- a/crates/price-estimation/src/trade_verifier/mod.rs
+++ b/crates/price-estimation/src/trade_verifier/mod.rs
@@ -227,15 +227,20 @@ impl TradeVerifier {
                 &self.simulator.domain_separator,
             )?);
         }
-        let output = self.simulator.simulate_swap_with_solver(swap).await?;
+        let block = *self.simulator.current_block.borrow();
+        let output = self
+            .simulator
+            .simulate_swap_with_solver(swap, block)
+            .await?;
 
-        if let Some(tenderly) = &self.tenderly {
-            let block = self.simulator.current_block.borrow().number.into();
-            if let Err(err) =
-                tenderly.log_simulation_command(output.tx, output.overrides, Some(block))
-            {
-                tracing::debug!(?err, "could not log tenderly simulation command");
-            }
+        if let Some(tenderly) = &self.tenderly
+            && let Err(err) = tenderly.log_simulation_command(
+                output.tx,
+                output.overrides,
+                Some(block.number.into()),
+            )
+        {
+            tracing::debug!(?err, "could not log tenderly simulation command");
         }
         let output = output
             .result

--- a/crates/price-estimation/src/trade_verifier/mod.rs
+++ b/crates/price-estimation/src/trade_verifier/mod.rs
@@ -229,10 +229,13 @@ impl TradeVerifier {
         }
         let output = self.simulator.simulate_swap_with_solver(swap).await?;
 
-        if let Some(tenderly) = &self.tenderly
-            && let Err(err) = tenderly.log_simulation_command(output.tx, output.overrides, None)
-        {
-            tracing::debug!(?err, "could not log tenderly simulation command");
+        if let Some(tenderly) = &self.tenderly {
+            let block = self.simulator.current_block.borrow().number.into();
+            if let Err(err) =
+                tenderly.log_simulation_command(output.tx, output.overrides, Some(block))
+            {
+                tracing::debug!(?err, "could not log tenderly simulation command");
+            }
         }
         let output = output
             .result

--- a/crates/simulator/src/swap_simulator.rs
+++ b/crates/simulator/src/swap_simulator.rs
@@ -224,6 +224,7 @@ impl SwapSimulator {
         let result = swap
             .call()
             .overrides(overrides.clone())
+            .block(block.number.into())
             .await
             .map_err(|err| anyhow!(err))
             .context("failed to simulate swap");

--- a/crates/simulator/src/swap_simulator.rs
+++ b/crates/simulator/src/swap_simulator.rs
@@ -19,7 +19,10 @@ use {
         support::Solver::{self, Solver::swapReturn},
     },
     eth_domain_types::NonZeroU256,
-    ethrpc::{Web3, block_stream::CurrentBlockWatcher},
+    ethrpc::{
+        Web3,
+        block_stream::{BlockInfo, CurrentBlockWatcher},
+    },
     model::{
         DomainSeparator,
         order::{BUY_ETH_ADDRESS, BuyTokenDestination, OrderData, OrderKind, SellTokenSource},
@@ -192,12 +195,16 @@ impl SwapSimulator {
     /// Simulates a solver call to settlement contract with the provided swap
     /// data. The swap call result is contained in the returned
     /// SwapSimulation struct, along with the original TransactionRequest
-    /// and State overrides (if needed to be logged, or processed elsewhere)
+    /// and State overrides (if needed to be logged, or processed elsewhere).
+    ///
+    /// The caller supplies the `block` so the gas-price computation, the
+    /// pinned `.call()` block, and any downstream logging all reference the
+    /// same snapshot of chain state.
     pub async fn simulate_swap_with_solver(
         &self,
         swap: EncodedSwap,
+        block: BlockInfo,
     ) -> Result<SwapSimulation<swapReturn>> {
-        let block = *self.current_block.borrow();
         let (settlement_target, calldata) = self.get_target_and_calldata(&swap);
         let solver = Solver::Instance::new(swap.solver, self.web3.provider.clone());
         let overrides = swap.overrides;

--- a/crates/simulator/src/tenderly/mod.rs
+++ b/crates/simulator/src/tenderly/mod.rs
@@ -45,7 +45,7 @@ pub trait Api: Send + Sync + 'static {
         &self,
         tx: TransactionRequest,
         overrides: StateOverride,
-        block: Option<BlockNo>,
+        block: BlockNo,
     ) -> Result<()>;
 
     async fn simulate(&self, request: dto::Request) -> Result<dto::Response>;
@@ -85,7 +85,7 @@ impl Tenderly {
                 self.eth.chain().id().to_string(),
                 &tx,
                 Default::default(),
-                Some(block),
+                block,
             )?
         };
 
@@ -162,7 +162,7 @@ impl Api for TenderlyApi {
         &self,
         tx: TransactionRequest,
         overrides: StateOverride,
-        block: Option<BlockNo>,
+        block: BlockNo,
     ) -> Result<()> {
         let request = dto::Request {
             save: Some(true),
@@ -215,16 +215,14 @@ pub fn prepare_request(
     chain_id: String,
     tx: &TransactionRequest,
     overrides: StateOverride,
-    block: Option<BlockNo>,
+    block: BlockNo,
 ) -> Result<dto::Request, Error> {
     Ok(dto::Request {
-        block_number: block.map(|block| block.0),
+        block_number: Some(block.0),
         // By default, tenderly simulates on the top of the specified block, whereas regular
         // nodes simulate at the end of the specified block. This is to make
         // simulation results match in case critical state changed within the block.
-        // Tenderly rejects `transaction_index` when no block is specified (pending),
-        // so only set it when we pin to a concrete block.
-        transaction_index: block.map(|_| -1),
+        transaction_index: Some(-1),
         network_id: chain_id,
         from: tx.from.unwrap_or_default(),
         to: tx.to.and_then(TxKind::into_to).unwrap_or_default(),
@@ -321,7 +319,7 @@ impl Api for Instrumented {
         &self,
         tx: TransactionRequest,
         overrides: StateOverride,
-        block: Option<BlockNo>,
+        block: BlockNo,
     ) -> Result<()> {
         self.inner.log_simulation_command(tx, overrides, block)
     }

--- a/crates/simulator/src/tenderly/mod.rs
+++ b/crates/simulator/src/tenderly/mod.rs
@@ -222,7 +222,9 @@ pub fn prepare_request(
         // By default, tenderly simulates on the top of the specified block, whereas regular
         // nodes simulate at the end of the specified block. This is to make
         // simulation results match in case critical state changed within the block.
-        transaction_index: Some(-1),
+        // Tenderly rejects `transaction_index` when no block is specified (pending),
+        // so only set it when we pin to a concrete block.
+        transaction_index: block.map(|_| -1),
         network_id: chain_id,
         from: tx.from.unwrap_or_default(),
         to: tx.to.and_then(TxKind::into_to).unwrap_or_default(),


### PR DESCRIPTION
# Description
The Tenderly simulation command logged during quote verification cannot be replayed as-is: Tenderly rejects it with `Transaction index is not allowed when block number is pending`. The verifier passed `block: None` to `log_simulation_command`, which leaves `block_number` null in the JSON body (Tenderly treats this as pending) while `prepare_request` still set `transaction_index: -1`, and that combination is invalid. On top of that, `simulate_swap_with_solver` did not pin `.call()` to a specific block, so the node picked "latest" at request time and the logged block could diverge from what was actually simulated.

# Changes
- `simulate_swap_with_solver` now takes the block as a parameter and pins `.call()` to it. The caller (`trade_verifier`) snapshots `current_block` once and passes the same value to the simulator and to `log_simulation_command`, so the gas-price computation, the simulation, and the logged curl all reference identical chain state.
- `log_simulation_command` and `prepare_request` now require a `BlockNo` (no longer `Option<BlockNo>`), reflecting that every caller already supplies one and eliminating the pending-block edge case at the type level.

# How to test
Existing tests. After deploy, copy the curl command from the quote-verification log and run it — Tenderly should return a simulation instead of the validation error, and the result should match the driver's simulation for that block.