### PR TITLE
Fix EIP-4626 contract revert classification

### DIFF
--- a/crates/e2e/tests/e2e/eip4626.rs
+++ b/crates/e2e/tests/e2e/eip4626.rs
@@ -11,9 +11,15 @@ use {
     contracts::ERC20,
     e2e::setup::*,
     ethrpc::alloy::CallBuilderExt,
+    futures::{FutureExt, future::BoxFuture},
     model::quote::{OrderQuoteRequest, OrderQuoteSide, SellAmount},
     number::units::EthUnit,
+    price_estimation::{
+        HEALTHY_PRICE_ESTIMATION_TIME,
+        native::{Eip4626, NativePriceEstimateResult, NativePriceEstimating},
+    },
     shared::web3::Web3,
+    std::time::Duration,
 };
 
 /// The block number from which we will fetch state for the forked test.
@@ -27,6 +33,10 @@ const SDAI_WHALE: Address = address!("4C612E3B15b96Ff9A6faED838F8d07d479a8dD4c")
 
 /// WETH on mainnet.
 const WETH: Address = address!("C02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2");
+
+/// USDC on mainnet. The proxy has no `asset()` selector, so calls to it
+/// revert with *empty* revert data — the regression case below.
+const USDC: Address = address!("A0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48");
 
 #[tokio::test]
 #[ignore]
@@ -233,4 +243,44 @@ async fn eip4626_recursive_native_price_test(web3: Web3) {
         (ratio - 2.0 / 9.0).abs() / (2.0 / 9.0) < 0.01,
         "wrapper (1/3) price ratio to baseline (3/2) should be 2/9: got {ratio:.6}",
     );
+}
+
+/// Regression: tokens that revert `asset()` with empty data (e.g. USDC) must
+/// classify as non-vault, not abort as a transport failure.
+#[tokio::test]
+#[ignore]
+async fn forked_node_mainnet_eip4626_empty_revert_terminal_token() {
+    run_forked_test_with_block_number(
+        eip4626_empty_revert_terminal_token_test,
+        std::env::var("FORK_URL_MAINNET")
+            .expect("FORK_URL_MAINNET must be set to run forked tests"),
+        FORK_BLOCK_MAINNET,
+    )
+    .await;
+}
+
+async fn eip4626_empty_revert_terminal_token_test(web3: Web3) {
+    // USDC is expected to classify as non-vault, so `inner`'s price round-trips
+    // unchanged — any fixed value works.
+    let expected_price = 0.0001;
+    let inner = FixedPrice(expected_price);
+    let estimator = Eip4626::new(Box::new(inner), web3.provider);
+    let price = estimator
+        .estimate_native_price(USDC, HEALTHY_PRICE_ESTIMATION_TIME)
+        .await
+        .expect("empty-revert on terminal token must not abort the unwrap");
+    assert_eq!(price, expected_price);
+}
+
+struct FixedPrice(f64);
+
+impl NativePriceEstimating for FixedPrice {
+    fn estimate_native_price(
+        &self,
+        _token: Address,
+        _timeout: Duration,
+    ) -> BoxFuture<'_, NativePriceEstimateResult> {
+        let price = self.0;
+        async move { Ok(price) }.boxed()
+    }
 }

--- a/crates/ethrpc/src/alloy/errors.rs
+++ b/crates/ethrpc/src/alloy/errors.rs
@@ -64,10 +64,14 @@ impl ContractErrorExt for ContractError {
             // bad params) are transport and must retry.
             ContractError::TransportError(RpcError::ErrorResp(err)) => {
                 err.as_revert_data().is_some()
+                    // https://github.com/ethereum/go-ethereum/blob/8e2107dc39dc9dab132150ec915e7ac299f9eb48/internal/ethapi/errors.go#L42-L46
+                    // https://github.com/alloy-rs/alloy/blob/b6753088241a50730c092bdba7036f52887c4c57/crates/rpc-types-eth/src/error.rs#L32
                     || err.code == 3
                     || err.message.to_lowercase().contains("revert")
             }
-            ContractError::ZeroData(..) => true,
+            ContractError::ZeroData(..)
+            | ContractError::UnknownFunction(..)
+            | ContractError::UnknownSelector(..) => true,
             _ => false,
         }
     }
@@ -93,9 +97,7 @@ pub fn testing_alloy_node_error() -> alloy_contract::Error {
 mod tests {
     use {
         crate::alloy::errors::{
-            ContractErrorExt,
-            testing_alloy_contract_error,
-            testing_alloy_node_error,
+            ContractErrorExt, testing_alloy_contract_error, testing_alloy_node_error,
         },
         alloy_contract::Error as ContractError,
         alloy_json_rpc::ErrorPayload,

--- a/crates/ethrpc/src/alloy/errors.rs
+++ b/crates/ethrpc/src/alloy/errors.rs
@@ -97,7 +97,9 @@ pub fn testing_alloy_node_error() -> alloy_contract::Error {
 mod tests {
     use {
         crate::alloy::errors::{
-            ContractErrorExt, testing_alloy_contract_error, testing_alloy_node_error,
+            ContractErrorExt,
+            testing_alloy_contract_error,
+            testing_alloy_node_error,
         },
         alloy_contract::Error as ContractError,
         alloy_json_rpc::ErrorPayload,

--- a/crates/ethrpc/src/alloy/errors.rs
+++ b/crates/ethrpc/src/alloy/errors.rs
@@ -16,6 +16,23 @@ pub trait ContractErrorExt {
 
     /// Returns whether a given error is a node error.
     fn is_node_error(&self) -> bool;
+
+    /// Less strict variant of [`is_contract_error`]: also classifies reverts
+    /// with *empty* revert data as contract errors.
+    ///
+    /// [`is_contract_error`] requires the error payload to carry decodable
+    /// revert data, which misses a real class of contract behaviour: when a
+    /// call hits a missing selector (e.g. probing `asset()` on a non-ERC-4626
+    /// token like USDC), the EVM raw-reverts and the RPC surfaces it as an
+    /// `ErrorResp` with code 3 / message "execution reverted" and no `data`.
+    /// Strict classification treats this as a transport failure, which causes
+    /// callers to retry indefinitely or cache transient-looking errors.
+    ///
+    /// Use this predicate when you want "did the call reach the chain and
+    /// the contract rejected it?" semantics — e.g. when probing whether a
+    /// token implements an optional interface. It still rejects genuine
+    /// transport issues (timeouts, connection drops, rate limits).
+    fn is_contract_revert(&self) -> bool;
 }
 
 impl ContractErrorExt for ContractError {
@@ -50,6 +67,31 @@ impl ContractErrorExt for ContractError {
             _ => false,
         }
     }
+
+    fn is_contract_revert(&self) -> bool {
+        match self {
+            ContractError::TransportError(RpcError::ErrorResp(err)) => {
+                // Accept three signals that the node executed the call and
+                // the contract reverted:
+                //  - revert data is present (the strict case)
+                //  - geth/reth/erigon's canonical code for "execution reverted"
+                //  - message mentions revert (catch-all for non-standard codes)
+                //
+                // Other `ErrorResp`s (rate limits, bad params, internal
+                // errors) fall through to `false` so they can be retried
+                // instead of being cached as a contract outcome.
+                err.as_revert_data().is_some()
+                    || err.code == 3
+                    || err.message.to_lowercase().contains("revert")
+            }
+            // Connection-level failures: not a contract revert.
+            ContractError::TransportError(_) => false,
+            // Decoding / ABI / local usage errors: the node responded and the
+            // contract executed, we just couldn't interpret the result.
+            // Treat as contract-level.
+            _ => true,
+        }
+    }
 }
 
 /// Create an arbitrary alloy error that will convert into a "contract" error.
@@ -70,11 +112,24 @@ pub fn testing_alloy_node_error() -> alloy_contract::Error {
 
 #[cfg(test)]
 mod tests {
-    use crate::alloy::errors::{
-        ContractErrorExt,
-        testing_alloy_contract_error,
-        testing_alloy_node_error,
+    use {
+        crate::alloy::errors::{
+            ContractErrorExt,
+            testing_alloy_contract_error,
+            testing_alloy_node_error,
+        },
+        alloy_contract::Error as ContractError,
+        alloy_json_rpc::ErrorPayload,
+        alloy_transport::TransportError,
     };
+
+    fn error_resp(code: i64, message: &'static str) -> ContractError {
+        ContractError::TransportError(TransportError::ErrorResp(ErrorPayload {
+            code,
+            message: message.into(),
+            data: None,
+        }))
+    }
 
     #[test]
     fn test_contract_error() {
@@ -86,5 +141,32 @@ mod tests {
     fn test_node_error() {
         assert!(!testing_alloy_contract_error().is_node_error());
         assert!(testing_alloy_node_error().is_node_error());
+    }
+
+    #[test]
+    fn contract_revert_accepts_empty_data_reverts() {
+        // Geth-family "execution reverted" with no data — the USDC case.
+        assert!(error_resp(3, "execution reverted").is_contract_revert());
+        // Non-standard code but unmistakable message.
+        assert!(error_resp(-32000, "execution reverted at pc=...").is_contract_revert());
+        assert!(error_resp(-32000, "VM Exception: revert").is_contract_revert());
+        // Case-insensitive: capitalized node messages still match.
+        assert!(error_resp(-32000, "Execution Reverted").is_contract_revert());
+    }
+
+    #[test]
+    fn contract_revert_rejects_transport_failures() {
+        // Generic internal error without revert context — likely transport.
+        assert!(!testing_alloy_node_error().is_contract_revert());
+        // Rate-limit-like codes without a revert message.
+        assert!(!error_resp(429, "too many requests").is_contract_revert());
+        assert!(!error_resp(-32005, "daily request count exceeded").is_contract_revert());
+    }
+
+    #[test]
+    fn contract_revert_accepts_non_transport_contract_errors() {
+        // Non-transport contract errors (decoding, abi) are still
+        // considered contract-level by this predicate.
+        assert!(testing_alloy_contract_error().is_contract_revert());
     }
 }

--- a/crates/ethrpc/src/alloy/errors.rs
+++ b/crates/ethrpc/src/alloy/errors.rs
@@ -17,21 +17,10 @@ pub trait ContractErrorExt {
     /// Returns whether a given error is a node error.
     fn is_node_error(&self) -> bool;
 
-    /// Less strict variant of [`is_contract_error`]: also classifies reverts
-    /// with *empty* revert data as contract errors.
-    ///
-    /// [`is_contract_error`] requires the error payload to carry decodable
-    /// revert data, which misses a real class of contract behaviour: when a
-    /// call hits a missing selector (e.g. probing `asset()` on a non-ERC-4626
-    /// token like USDC), the EVM raw-reverts and the RPC surfaces it as an
-    /// `ErrorResp` with code 3 / message "execution reverted" and no `data`.
-    /// Strict classification treats this as a transport failure, which causes
-    /// callers to retry indefinitely or cache transient-looking errors.
-    ///
-    /// Use this predicate when you want "did the call reach the chain and
-    /// the contract rejected it?" semantics — e.g. when probing whether a
-    /// token implements an optional interface. It still rejects genuine
-    /// transport issues (timeouts, connection drops, rate limits).
+    /// Contract-level rejection of the call: an explicit revert (including
+    /// empty-data reverts from missing selectors, which [`is_contract_error`]
+    /// misses) or a `0x` response. Transport failures and caller-side bugs
+    /// return `false` so they keep bubbling up for retry.
     fn is_contract_revert(&self) -> bool;
 }
 
@@ -70,26 +59,16 @@ impl ContractErrorExt for ContractError {
 
     fn is_contract_revert(&self) -> bool {
         match self {
+            // Revert data, geth code 3, or a "revert" message — any is a
+            // contract-level rejection. Other ErrorResps (rate limits,
+            // bad params) are transport and must retry.
             ContractError::TransportError(RpcError::ErrorResp(err)) => {
-                // Accept three signals that the node executed the call and
-                // the contract reverted:
-                //  - revert data is present (the strict case)
-                //  - geth/reth/erigon's canonical code for "execution reverted"
-                //  - message mentions revert (catch-all for non-standard codes)
-                //
-                // Other `ErrorResp`s (rate limits, bad params, internal
-                // errors) fall through to `false` so they can be retried
-                // instead of being cached as a contract outcome.
                 err.as_revert_data().is_some()
                     || err.code == 3
                     || err.message.to_lowercase().contains("revert")
             }
-            // Connection-level failures: not a contract revert.
-            ContractError::TransportError(_) => false,
-            // Decoding / ABI / local usage errors: the node responded and the
-            // contract executed, we just couldn't interpret the result.
-            // Treat as contract-level.
-            _ => true,
+            ContractError::ZeroData(..) => true,
+            _ => false,
         }
     }
 }
@@ -164,9 +143,9 @@ mod tests {
     }
 
     #[test]
-    fn contract_revert_accepts_non_transport_contract_errors() {
-        // Non-transport contract errors (decoding, abi) are still
-        // considered contract-level by this predicate.
-        assert!(testing_alloy_contract_error().is_contract_revert());
+    fn contract_revert_rejects_caller_usage_bugs() {
+        // `NotADeploymentTransaction` and siblings are local-usage errors,
+        // not contract behaviour — must not be classified as reverts.
+        assert!(!testing_alloy_contract_error().is_contract_revert());
     }
 }

--- a/crates/price-estimation/src/native/eip4626.rs
+++ b/crates/price-estimation/src/native/eip4626.rs
@@ -86,12 +86,14 @@ impl Eip4626 {
         token: Address,
     ) -> Result<Option<(Address, f64)>, PriceEstimationError> {
         if self.non_vault_tokens.contains(&token) {
+            tracing::debug!(%token, "eip4626: cached non-vault, stop unwrapping");
             return Ok(None);
         }
 
         let Some((asset, vault_decimals)) = self.fetch_vault_info(token).await? else {
             self.non_vault_tokens.insert(token);
             metrics::non_vault_cache_size(self.non_vault_tokens.len());
+            tracing::debug!(%token, "eip4626: classified as non-vault");
             return Ok(None);
         };
         let (assets, asset_decimals) = self
@@ -100,6 +102,7 @@ impl Eip4626 {
         let rate = conversion_rate(assets, asset_decimals)
             .context("conversion rate is not representable as f64")
             .map_err(PriceEstimationError::EstimatorInternal)?;
+        tracing::debug!(%token, %asset, rate, "eip4626: unwrapped vault layer");
         Ok(Some((asset, rate)))
     }
 

--- a/crates/price-estimation/src/native/eip4626.rs
+++ b/crates/price-estimation/src/native/eip4626.rs
@@ -224,12 +224,6 @@ mod tests {
     use {
         super::*,
         crate::{HEALTHY_PRICE_ESTIMATION_TIME, native::MockNativePriceEstimating},
-        alloy::{
-            providers::{Provider, ProviderBuilder},
-            sol_types::SolCall,
-            transports::mock::Asserter,
-        },
-        contracts::{ERC20, IERC4626},
     };
 
     #[test]
@@ -283,57 +277,5 @@ mod tests {
             .estimate(token, HEALTHY_PRICE_ESTIMATION_TIME)
             .await;
         assert_eq!(result.unwrap(), expected_price);
-    }
-
-    /// Regression test: USDC-like terminal tokens revert their non-existent
-    /// `asset()` selector with *empty* revert data. The classification must
-    /// treat that as "non-vault" (loop terminates cleanly), not as a transport
-    /// failure that aborts the unwrap chain.
-    #[tokio::test]
-    async fn terminal_token_reverting_without_data_classified_as_non_vault() {
-        let vault = Address::repeat_byte(0x11);
-        let usdc = Address::repeat_byte(0x22);
-
-        // Responses are FIFO and must match the argument order of the
-        // `tokio::join!` / `try_join!` inside `fetch_vault_info` and
-        // `fetch_conversion_data`.
-        let asserter = Asserter::new();
-
-        // --- unwrap_vault_layer(vault) ---
-        // fetch_vault_info: asset() → usdc, decimals() → 6
-        asserter.push_success(&IERC4626::IERC4626::assetCall::abi_encode_returns(&usdc));
-        asserter.push_success(&ERC20::ERC20::decimalsCall::abi_encode_returns(&6u8));
-        // fetch_conversion_data: convertToAssets(1e6) → 1_500_000, usdc.decimals() → 6
-        // → rate = 1_500_000 / 10^6 = 1.5
-        asserter.push_success(
-            &IERC4626::IERC4626::convertToAssetsCall::abi_encode_returns(&U256::from(1_500_000u64)),
-        );
-        asserter.push_success(&ERC20::ERC20::decimalsCall::abi_encode_returns(&6u8));
-
-        // --- unwrap_vault_layer(usdc) — the branch under test ---
-        // asset() reverts with NO revert data (simulates calling a missing
-        // selector on a proxy like USDC). decimals() still works, which is
-        // what proves the RPC is healthy and the contract is ERC-20.
-        asserter.push_failure_msg("execution reverted");
-        asserter.push_success(&ERC20::ERC20::decimalsCall::abi_encode_returns(&6u8));
-
-        let mut inner = MockNativePriceEstimating::new();
-        inner
-            .expect_estimate_native_price()
-            .withf(move |t, _| *t == usdc)
-            .returning(|_, _| Box::pin(async { Ok(0.0001) }));
-
-        let provider = ProviderBuilder::new()
-            .connect_mocked_client(asserter)
-            .erased();
-        let estimator = Eip4626::new(Box::new(inner), provider);
-
-        let price = estimator
-            .estimate(vault, HEALTHY_PRICE_ESTIMATION_TIME)
-            .await
-            .expect("empty-revert on terminal token must not abort the unwrap");
-
-        // 0.0001 (usdc native price) * 1.5 (vault → usdc rate) = 0.00015
-        assert!((price - 0.00015).abs() < 1e-15, "price = {price}");
     }
 }

--- a/crates/price-estimation/src/native/eip4626.rs
+++ b/crates/price-estimation/src/native/eip4626.rs
@@ -130,9 +130,13 @@ impl Eip4626 {
                 })?;
                 Ok(Some((asset, vault_decimals)))
             }
-            // `asset()` reverted but the contract is a valid ERC-20 (decimals()
-            // succeeded). Classify as non-vault.
-            Err(err) if err.is_contract_error() && decimals_result.is_ok() => Ok(None),
+            // Classify as non-vault only when `asset()` produced a genuine
+            // contract-level revert (including empty-data reverts from tokens
+            // like USDC that don't implement the selector) AND `decimals()`
+            // succeeded. Transient transport errors (rate limits, timeouts)
+            // must still propagate so we retry instead of pinning the token
+            // as non-vault for the life of the process.
+            Err(err) if err.is_contract_revert() && decimals_result.is_ok() => Ok(None),
             Err(err) => Err(PriceEstimationError::EstimatorInternal(anyhow::anyhow!(
                 "failed to call asset() on {token}: {err}"
             ))),
@@ -271,5 +275,66 @@ mod tests {
             .estimate(token, HEALTHY_PRICE_ESTIMATION_TIME)
             .await;
         assert_eq!(result.unwrap(), expected_price);
+    }
+
+    /// Regression test: USDC-like terminal tokens revert their non-existent
+    /// `asset()` selector with *empty* revert data. The classification must
+    /// treat that as "non-vault" (loop terminates cleanly), not as a transport
+    /// failure that aborts the unwrap chain.
+    #[tokio::test]
+    async fn terminal_token_reverting_without_data_classified_as_non_vault() {
+        use {
+            alloy::{
+                providers::{Provider, ProviderBuilder},
+                sol_types::SolCall,
+                transports::mock::Asserter,
+            },
+            contracts::{ERC20, IERC4626},
+        };
+
+        let vault = Address::repeat_byte(0x11);
+        let usdc = Address::repeat_byte(0x22);
+
+        // Responses are FIFO and must match the argument order of the
+        // `tokio::join!` / `try_join!` inside `fetch_vault_info` and
+        // `fetch_conversion_data`.
+        let asserter = Asserter::new();
+
+        // --- unwrap_vault_layer(vault) ---
+        // fetch_vault_info: asset() → usdc, decimals() → 6
+        asserter.push_success(&IERC4626::IERC4626::assetCall::abi_encode_returns(&usdc));
+        asserter.push_success(&ERC20::ERC20::decimalsCall::abi_encode_returns(&6u8));
+        // fetch_conversion_data: convertToAssets(1e6) → 1_500_000, usdc.decimals() → 6
+        // → rate = 1_500_000 / 10^6 = 1.5
+        asserter.push_success(
+            &IERC4626::IERC4626::convertToAssetsCall::abi_encode_returns(&U256::from(1_500_000u64)),
+        );
+        asserter.push_success(&ERC20::ERC20::decimalsCall::abi_encode_returns(&6u8));
+
+        // --- unwrap_vault_layer(usdc) — the branch under test ---
+        // asset() reverts with NO revert data (simulates calling a missing
+        // selector on a proxy like USDC). decimals() still works, which is
+        // what proves the RPC is healthy and the contract is ERC-20.
+        asserter.push_failure_msg("execution reverted");
+        asserter.push_success(&ERC20::ERC20::decimalsCall::abi_encode_returns(&6u8));
+
+        let mut inner = MockNativePriceEstimating::new();
+        inner
+            .expect_estimate_native_price()
+            .withf(move |t, _| *t == usdc)
+            .returning(|_, _| Box::pin(async { Ok(0.0001) }));
+
+        let provider = ProviderBuilder::new()
+            .connect_mocked_client(asserter)
+            .erased();
+        let estimator = Eip4626::new(Box::new(inner), provider);
+
+        let price = estimator
+            .estimate(vault, HEALTHY_PRICE_ESTIMATION_TIME)
+            .await
+            .expect("empty-revert on terminal token must not abort the unwrap");
+
+        // 0.0001 (usdc native price) * 1.5 (vault → usdc rate) = 0.00015
+        assert!((price - 0.00015).abs() < 1e-15, "price = {price}");
     }
 }

--- a/crates/price-estimation/src/native/eip4626.rs
+++ b/crates/price-estimation/src/native/eip4626.rs
@@ -135,12 +135,9 @@ impl Eip4626 {
                 })?;
                 Ok(Some((asset, vault_decimals)))
             }
-            // Classify as non-vault only when `asset()` produced a genuine
-            // contract-level revert (including empty-data reverts from tokens
-            // like USDC that don't implement the selector) AND `decimals()`
-            // succeeded. Transient transport errors (rate limits, timeouts)
-            // must still propagate so we retry instead of pinning the token
-            // as non-vault for the life of the process.
+            // Contract-level revert on `asset()` + working `decimals()` =
+            // plain ERC-20. Transient transport failures propagate so they
+            // retry instead of pinning the token as non-vault.
             Err(err) if err.is_contract_revert() && decimals_result.is_ok() => Ok(None),
             Err(err) => Err(PriceEstimationError::EstimatorInternal(anyhow::anyhow!(
                 "failed to call asset() on {token}: {err}"
@@ -227,6 +224,12 @@ mod tests {
     use {
         super::*,
         crate::{HEALTHY_PRICE_ESTIMATION_TIME, native::MockNativePriceEstimating},
+        alloy::{
+            providers::{Provider, ProviderBuilder},
+            sol_types::SolCall,
+            transports::mock::Asserter,
+        },
+        contracts::{ERC20, IERC4626},
     };
 
     #[test]
@@ -288,15 +291,6 @@ mod tests {
     /// failure that aborts the unwrap chain.
     #[tokio::test]
     async fn terminal_token_reverting_without_data_classified_as_non_vault() {
-        use {
-            alloy::{
-                providers::{Provider, ProviderBuilder},
-                sol_types::SolCall,
-                transports::mock::Asserter,
-            },
-            contracts::{ERC20, IERC4626},
-        };
-
         let vault = Address::repeat_byte(0x11);
         let usdc = Address::repeat_byte(0x22);
 

--- a/crates/price-estimation/src/native/eip4626.rs
+++ b/crates/price-estimation/src/native/eip4626.rs
@@ -57,7 +57,9 @@ impl Eip4626 {
             .inner
             .estimate_native_price(underlying, remaining)
             .await?;
-        Ok(asset_price * cumulative_rate)
+        let estimate = asset_price * cumulative_rate;
+        tracing::debug!(%token, estimate, "eip4626: estimated native price");
+        Ok(estimate)
     }
 
     /// Follows the vault chain (e.g. vault → vault → asset) until reaching a


### PR DESCRIPTION
# Description
Testing the Euler vault tokens I found that the revert condition is a bit too strict for the Eip4626 purposes and it would think that the underlying asset was *not* valid because `asset()` failed; even though that's the expected behavior.

This PR adds a new condition for a revert caused by a lack of selector, specifically for this case.

Tested in staging, results can be seen in — https://victorialogs.dev.cow.fi/goto/ffjuyxx1tk6psc?orgId=1
native_price requests were done for `0x53afe3343f322c4189ab69e0d048efd154259419`

# Changes

* More logs, helps tracing through the layer peeling
* Less strict variant of is_contract_error, including empty reverts as contract errors

## How to test
Call the native_price endpoint with a Euler vault address (ensure that staging has them enabled)
