### PR TITLE
Use stored Aave liquidityIndex for aToken balance override

### DIFF
--- a/crates/balance-overrides/src/aave.rs
+++ b/crates/balance-overrides/src/aave.rs
@@ -133,24 +133,10 @@ pub async fn probe_aave_token(web3: &Web3, token: Address) -> Option<(Address, A
 }
 
 /// Builds a state override that makes `balanceOf(holder)` on the aToken
-/// report at least `amount`. Writes into the canonical `_userState` slot
-/// (`USER_STATE_SLOT`) shared by all Aave v3 aTokens. Returns `None` if we
-/// can't reach the pool or the math overflows.
-///
-/// Uses `getReserveData(underlying).liquidityIndex` (the stored index)
-/// rather than `getReserveNormalizedIncome(underlying)` (stored × linear
-/// accrual to `block.timestamp`) on purpose: the stored index is a
-/// monotone lower bound for whatever Aave will compute at simulation time.
-/// With the accrued value, the override was calibrated on the 1-wei
-/// boundary and any block-of-drift between the RPC that returned the
-/// index and the block Tenderly pins the sim to left `balanceOf` exactly
-/// `amount - 1`, which made Aave's internal `UserState.balance -=
-/// rayDiv(amount, sim_index)` underflow inside the donor's transfer to
-/// the trader, surfacing to the verifier as
-/// `execution reverted: trader does not have enough sell token`.
-/// With the stored index the sim's index is always `>=` our compute
-/// index, so `rayMul(scaled, sim_index) >= amount` and the transfer goes
-/// through.
+/// report at least `amount`. Scales against the stored `liquidityIndex`
+/// so that Aave's accrued index at sim time (stored plus linear accrual)
+/// is always a monotone upper bound, guaranteeing `rayMul(scaled, idx)
+/// >= amount` regardless of which block the sim lands on.
 pub async fn build_override(
     web3: &Web3,
     a_token: Address,

--- a/crates/balance-overrides/src/aave.rs
+++ b/crates/balance-overrides/src/aave.rs
@@ -133,9 +133,24 @@ pub async fn probe_aave_token(web3: &Web3, token: Address) -> Option<(Address, A
 }
 
 /// Builds a state override that makes `balanceOf(holder)` on the aToken
-/// report approximately `amount`. Writes into the canonical `_userState`
-/// slot (`USER_STATE_SLOT`) shared by all Aave v3 aTokens. Returns `None`
-/// if we can't reach the pool or the math overflows.
+/// report at least `amount`. Writes into the canonical `_userState` slot
+/// (`USER_STATE_SLOT`) shared by all Aave v3 aTokens. Returns `None` if we
+/// can't reach the pool or the math overflows.
+///
+/// Uses `getReserveData(underlying).liquidityIndex` (the stored index)
+/// rather than `getReserveNormalizedIncome(underlying)` (stored × linear
+/// accrual to `block.timestamp`) on purpose: the stored index is a
+/// monotone lower bound for whatever Aave will compute at simulation time.
+/// With the accrued value, the override was calibrated on the 1-wei
+/// boundary and any block-of-drift between the RPC that returned the
+/// index and the block Tenderly pins the sim to left `balanceOf` exactly
+/// `amount - 1`, which made Aave's internal `UserState.balance -=
+/// rayDiv(amount, sim_index)` underflow inside the donor's transfer to
+/// the trader, surfacing to the verifier as
+/// `execution reverted: trader does not have enough sell token`.
+/// With the stored index the sim's index is always `>=` our compute
+/// index, so `rayMul(scaled, sim_index) >= amount` and the transfer goes
+/// through.
 pub async fn build_override(
     web3: &Web3,
     a_token: Address,
@@ -144,18 +159,15 @@ pub async fn build_override(
     holder: Address,
     amount: U256,
 ) -> Option<(Address, AccountOverride)> {
-    let Ok(index) = IAaveV3Pool::new(pool, web3.provider.clone())
-        .getReserveNormalizedIncome(underlying)
+    let Ok(reserve) = IAaveV3Pool::new(pool, web3.provider.clone())
+        .getReserveData(underlying)
         .call()
         .await
     else {
-        tracing::warn!(
-            ?pool,
-            ?underlying,
-            "failed to fetch Aave reserve normalized income"
-        );
+        tracing::warn!(?pool, ?underlying, "failed to fetch Aave reserve data");
         return None;
     };
+    let index = U256::from(reserve.liquidityIndex);
 
     let Some(scaled) = ray_div(amount, index) else {
         // Either `amount * RAY` overflowed U256 (only possible for an

--- a/crates/balance-overrides/src/detector.rs
+++ b/crates/balance-overrides/src/detector.rs
@@ -398,7 +398,7 @@ impl Detector {
 fn verified_balance_matches(strategy: &Strategy, balance: U256, test_balance: U256) -> bool {
     match strategy {
         Strategy::AaveV3AToken { .. } => {
-            balance.abs_diff(test_balance) <= test_balance / U256::from(100u64)
+            balance.abs_diff(test_balance) * U256::from(100u64) <= test_balance
         }
         _ => balance == test_balance,
     }

--- a/crates/balance-overrides/src/detector.rs
+++ b/crates/balance-overrides/src/detector.rs
@@ -394,12 +394,24 @@ impl Detector {
 }
 
 /// Is the `balance` returned by `balanceOf` after applying the override
-/// consistent with the `test_balance` we wrote? For `AaveV3AToken` we tolerate
-/// 1 wei of difference because Aave's ray-div / ray-mul round-trip is not
-/// identity by construction; every other strategy must match exactly.
+/// consistent with the `test_balance` we wrote? Every strategy except
+/// `AaveV3AToken` must match exactly.
+///
+/// For `AaveV3AToken` the override is calibrated against the stored
+/// `liquidityIndex` so that Aave's `rayMul(scaled, accrued_idx) >=
+/// test_balance` always holds at call time. The call-time accrued index
+/// equals `stored + linear_accrual_to_block.timestamp`, which overshoots
+/// the stored value by `rate * elapsed_since_lastUpdateTimestamp`. That
+/// gives a realistic overshoot on the order of a few ppm per hour of pool
+/// inactivity. Accept anything within 1% either way: wide enough to cover
+/// realistic accrual drift and the 1-wei `rayDiv` round-trip at the
+/// stored-index boundary, still tight enough that an unrelated slot
+/// returning garbage is rejected.
 fn verified_balance_matches(strategy: &Strategy, balance: U256, test_balance: U256) -> bool {
     match strategy {
-        Strategy::AaveV3AToken { .. } => balance.abs_diff(test_balance) <= U256::ONE,
+        Strategy::AaveV3AToken { .. } => {
+            balance.abs_diff(test_balance) <= test_balance / U256::from(100u64)
+        }
         _ => balance == test_balance,
     }
 }

--- a/crates/balance-overrides/src/detector.rs
+++ b/crates/balance-overrides/src/detector.rs
@@ -393,20 +393,8 @@ impl Detector {
     }
 }
 
-/// Is the `balance` returned by `balanceOf` after applying the override
-/// consistent with the `test_balance` we wrote? Every strategy except
-/// `AaveV3AToken` must match exactly.
-///
-/// For `AaveV3AToken` the override is calibrated against the stored
-/// `liquidityIndex` so that Aave's `rayMul(scaled, accrued_idx) >=
-/// test_balance` always holds at call time. The call-time accrued index
-/// equals `stored + linear_accrual_to_block.timestamp`, which overshoots
-/// the stored value by `rate * elapsed_since_lastUpdateTimestamp`. That
-/// gives a realistic overshoot on the order of a few ppm per hour of pool
-/// inactivity. Accept anything within 1% either way: wide enough to cover
-/// realistic accrual drift and the 1-wei `rayDiv` round-trip at the
-/// stored-index boundary, still tight enough that an unrelated slot
-/// returning garbage is rejected.
+/// `AaveV3AToken` allows 1% of drift because the override is calibrated
+/// against the stored `liquidityIndex` and `balanceOf` accrues on top.
 fn verified_balance_matches(strategy: &Strategy, balance: U256, test_balance: U256) -> bool {
     match strategy {
         Strategy::AaveV3AToken { .. } => {

--- a/crates/balance-overrides/src/lib.rs
+++ b/crates/balance-overrides/src/lib.rs
@@ -266,8 +266,10 @@ impl BalanceOverriding for DummyOverrider {
 mod tests {
     use {
         super::*,
-        crate::aave::{pack_user_state, ray_div},
+        crate::aave::{RAY, ReserveConfigurationMap, ReserveData, pack_user_state, ray_div},
         alloy_primitives::{address, b256},
+        alloy_provider::mock::Asserter,
+        alloy_sol_types::SolValue,
         ethrpc::mock,
         maplit::hashmap,
     };
@@ -535,7 +537,6 @@ mod tests {
     /// used to bite at the boundary).
     #[test]
     fn aave_v3_a_token_override_round_trips_against_accrued_index() {
-        use crate::aave::RAY;
         fn ray_mul(a: U256, b: U256) -> U256 {
             (a * b + (RAY >> 1)) / RAY
         }
@@ -588,12 +589,6 @@ mod tests {
 
     #[tokio::test]
     async fn aave_v3_a_token_override_scales_amount_and_writes_low_128() {
-        use {
-            crate::aave::{ReserveConfigurationMap, ReserveData},
-            alloy_provider::mock::Asserter,
-            alloy_sol_types::SolValue,
-        };
-
         // aEthWETH mainnet triple.
         let a_token = address!("4d5F47FA6A74757f35C14fD3a6Ef8E3C9BC514E8");
         let pool = address!("87870bca3f3fd6335c3f4ce8392d69350b4fa4e2");

--- a/crates/balance-overrides/src/lib.rs
+++ b/crates/balance-overrides/src/lib.rs
@@ -530,6 +530,50 @@ mod tests {
         );
     }
 
+    /// Regression test for the `trader does not have enough sell token`
+    /// revert seen on prod aEthWETH quotes. The override used to scale
+    /// `amount` against `getReserveNormalizedIncome` (stored × linear
+    /// accrual to `block.timestamp`), which calibrated `balanceOf` on the
+    /// 1-wei boundary: when the sim was pinned to a block whose timestamp
+    /// was older than the one the RPC serving our read saw, `rayMul(scaled,
+    /// sim_index)` rounded down to `amount - 1` wei and Aave's internal
+    /// scaled-balance subtraction inside the donor's `transfer` underflowed.
+    ///
+    /// Scaling against the stored `liquidityIndex` instead makes the sim's
+    /// effective index a monotone upper bound (`>= stored`), so
+    /// `rayMul(scaled, sim_index) >= amount` holds across the entire range
+    /// of blocks the sim might end up pinned to.
+    #[test]
+    fn aave_v3_a_token_override_round_trips_against_accrued_index() {
+        use crate::aave::RAY;
+        fn ray_mul(a: U256, b: U256) -> U256 {
+            (a * b + (RAY >> 1)) / RAY
+        }
+
+        // Realistic aEthWETH stored liquidity index (around block 24944163).
+        let stored_idx = U256::from_str_radix("1063627933131483960000000000", 10).unwrap();
+        let amount = U256::from(100_000_000_000_000_000u128); // 0.1 aEthWETH
+
+        let scaled = ray_div(amount, stored_idx).unwrap();
+
+        // Sample the sim-time index across zero accrual (sim pins to the
+        // exact block the stored value was set) through several blocks
+        // forward. Aave's index is monotone non-decreasing, so every one
+        // of these is a valid sim-time value.
+        //
+        // 1 ppb ≈ 1 second of WETH accrual at current rates; stepping up
+        // to 10 ppm (~= 10 minutes) covers realistic Tenderly fork lag.
+        for accrual_ppb in [0u64, 1, 10, 100, 10_000, 10_000_000] {
+            let sim_idx =
+                stored_idx + stored_idx / U256::from(1_000_000_000u64) * U256::from(accrual_ppb);
+            let balance = ray_mul(scaled, sim_idx);
+            assert!(
+                balance >= amount,
+                "balance {balance} < amount {amount} at accrual {accrual_ppb} ppb"
+            );
+        }
+    }
+
     #[test]
     fn pack_user_state_leaves_additional_data_intact() {
         let balance = U256::from(0x1234_5678u64);
@@ -566,7 +610,11 @@ mod tests {
 
     #[tokio::test]
     async fn aave_v3_a_token_override_scales_amount_and_writes_low_128() {
-        use alloy_provider::mock::Asserter;
+        use {
+            crate::aave::{ReserveConfigurationMap, ReserveData},
+            alloy_provider::mock::Asserter,
+            alloy_sol_types::SolValue,
+        };
 
         // aEthWETH mainnet triple.
         let a_token = address!("4d5F47FA6A74757f35C14fD3a6Ef8E3C9BC514E8");
@@ -576,10 +624,30 @@ mod tests {
         let amount = U256::from(1_000_000_000_000_000_000u128); // 1 aEthWETH
 
         let asserter = Asserter::new();
-        // The mock responds to our `eth_call` with the encoded `uint256`
-        // normalized income — a ray value just above 1.063.
-        let index = U256::from_str_radix("1063000000000000000000000000", 10).unwrap();
-        asserter.push_success(&format!("0x{:064x}", index));
+        // The mock responds to our `eth_call` with a ReserveData struct
+        // whose `liquidityIndex` is a ray value just above 1.063.
+        let index_u128 = 1_063_000_000_000_000_000_000_000_000u128;
+        let reserve = ReserveData {
+            configuration: ReserveConfigurationMap { data: U256::ZERO },
+            liquidityIndex: index_u128,
+            currentLiquidityRate: 0,
+            variableBorrowIndex: 0,
+            currentVariableBorrowRate: 0,
+            currentStableBorrowRate: 0,
+            lastUpdateTimestamp: alloy_primitives::Uint::ZERO,
+            id: 0,
+            aTokenAddress: a_token,
+            stableDebtTokenAddress: Address::ZERO,
+            variableDebtTokenAddress: Address::ZERO,
+            interestRateStrategyAddress: Address::ZERO,
+            accruedToTreasury: 0,
+            unbacked: 0,
+            isolationModeTotalDebt: 0,
+        };
+        asserter.push_success(&alloy_primitives::hex::encode_prefixed(
+            reserve.abi_encode(),
+        ));
+        let index = U256::from(index_u128);
 
         let balance_overrides = BalanceOverrides {
             hardcoded: hashmap! {

--- a/crates/balance-overrides/src/lib.rs
+++ b/crates/balance-overrides/src/lib.rs
@@ -530,19 +530,9 @@ mod tests {
         );
     }
 
-    /// Regression test for the `trader does not have enough sell token`
-    /// revert seen on prod aEthWETH quotes. The override used to scale
-    /// `amount` against `getReserveNormalizedIncome` (stored × linear
-    /// accrual to `block.timestamp`), which calibrated `balanceOf` on the
-    /// 1-wei boundary: when the sim was pinned to a block whose timestamp
-    /// was older than the one the RPC serving our read saw, `rayMul(scaled,
-    /// sim_index)` rounded down to `amount - 1` wei and Aave's internal
-    /// scaled-balance subtraction inside the donor's `transfer` underflowed.
-    ///
-    /// Scaling against the stored `liquidityIndex` instead makes the sim's
-    /// effective index a monotone upper bound (`>= stored`), so
-    /// `rayMul(scaled, sim_index) >= amount` holds across the entire range
-    /// of blocks the sim might end up pinned to.
+    /// `rayMul(scaled, sim_index) >= amount` must hold at any sim-time
+    /// index `>= stored`, not just `== stored` (1-wei rayDiv rounding
+    /// used to bite at the boundary).
     #[test]
     fn aave_v3_a_token_override_round_trips_against_accrued_index() {
         use crate::aave::RAY;
@@ -550,27 +540,15 @@ mod tests {
             (a * b + (RAY >> 1)) / RAY
         }
 
-        // Realistic aEthWETH stored liquidity index (around block 24944163).
         let stored_idx = U256::from_str_radix("1063627933131483960000000000", 10).unwrap();
-        let amount = U256::from(100_000_000_000_000_000u128); // 0.1 aEthWETH
-
+        let amount = U256::from(100_000_000_000_000_000u128);
         let scaled = ray_div(amount, stored_idx).unwrap();
 
-        // Sample the sim-time index across zero accrual (sim pins to the
-        // exact block the stored value was set) through several blocks
-        // forward. Aave's index is monotone non-decreasing, so every one
-        // of these is a valid sim-time value.
-        //
-        // 1 ppb ≈ 1 second of WETH accrual at current rates; stepping up
-        // to 10 ppm (~= 10 minutes) covers realistic Tenderly fork lag.
         for accrual_ppb in [0u64, 1, 10, 100, 10_000, 10_000_000] {
             let sim_idx =
                 stored_idx + stored_idx / U256::from(1_000_000_000u64) * U256::from(accrual_ppb);
             let balance = ray_mul(scaled, sim_idx);
-            assert!(
-                balance >= amount,
-                "balance {balance} < amount {amount} at accrual {accrual_ppb} ppb"
-            );
+            assert!(balance >= amount, "balance {balance} < amount {amount}");
         }
     }
 
@@ -624,8 +602,6 @@ mod tests {
         let amount = U256::from(1_000_000_000_000_000_000u128); // 1 aEthWETH
 
         let asserter = Asserter::new();
-        // The mock responds to our `eth_call` with a ReserveData struct
-        // whose `liquidityIndex` is a ray value just above 1.063.
         let index_u128 = 1_063_000_000_000_000_000_000_000_000u128;
         let reserve = ReserveData {
             configuration: ReserveConfigurationMap { data: U256::ZERO },

--- a/crates/e2e/tests/e2e/quote_verification.rs
+++ b/crates/e2e/tests/e2e/quote_verification.rs
@@ -873,8 +873,13 @@ async fn aave_atoken_quote_verification(web3: Web3) {
     assert_eq!(target, a_eth_weth);
 
     // Apply the override to a live `balanceOf` call via the forked node and
-    // make sure the contract now reports the requested amount (± 1 wei of
-    // ray rounding).
+    // make sure the contract now reports at least the requested amount.
+    // The override is built against the stored `liquidityIndex`, so
+    // `balanceOf` overshoots `amount` by the linear accrual that Aave
+    // applies between `lastUpdateTimestamp` and the call's
+    // `block.timestamp`. A 1% relative cap still catches a slot that
+    // isn't actually controlling the balance while accepting any
+    // realistic accrual window.
     let overrides: StateOverride = [(target, override_)].into_iter().collect();
     let a_token_contract = ERC20::Instance::new(a_eth_weth, web3.provider.clone());
     let reported = a_token_contract
@@ -884,10 +889,12 @@ async fn aave_atoken_quote_verification(web3: Web3) {
         .await
         .unwrap();
 
-    let diff = reported.abs_diff(amount);
+    let overshoot = reported.saturating_sub(amount);
+    let tolerance = amount / U256::from(100u64);
     assert!(
-        diff <= U256::from(1u64),
-        "balanceOf after override returned {reported}, expected ~{amount} (diff {diff} wei)",
+        reported >= amount && overshoot <= tolerance,
+        "balanceOf after override returned {reported}, expected >= {amount} with overshoot <= \
+         {tolerance} wei (got overshoot {overshoot} wei)",
     );
 }
 

--- a/crates/e2e/tests/e2e/quote_verification.rs
+++ b/crates/e2e/tests/e2e/quote_verification.rs
@@ -884,11 +884,10 @@ async fn aave_atoken_quote_verification(web3: Web3) {
         .unwrap();
 
     let overshoot = reported.saturating_sub(amount);
-    let tolerance = amount / U256::from(100u64);
     assert!(
-        reported >= amount && overshoot <= tolerance,
-        "balanceOf after override returned {reported}, expected >= {amount} with overshoot <= \
-         {tolerance} wei (got overshoot {overshoot} wei)",
+        reported >= amount && overshoot * U256::from(100u64) <= amount,
+        "balanceOf after override returned {reported}, expected >= {amount} with overshoot within \
+         1% (got overshoot {overshoot} wei)",
     );
 }
 

--- a/crates/e2e/tests/e2e/quote_verification.rs
+++ b/crates/e2e/tests/e2e/quote_verification.rs
@@ -872,14 +872,8 @@ async fn aave_atoken_quote_verification(web3: Web3) {
         .expect("override computed");
     assert_eq!(target, a_eth_weth);
 
-    // Apply the override to a live `balanceOf` call via the forked node and
-    // make sure the contract now reports at least the requested amount.
-    // The override is built against the stored `liquidityIndex`, so
-    // `balanceOf` overshoots `amount` by the linear accrual that Aave
-    // applies between `lastUpdateTimestamp` and the call's
-    // `block.timestamp`. A 1% relative cap still catches a slot that
-    // isn't actually controlling the balance while accepting any
-    // realistic accrual window.
+    // Override is built against stored `liquidityIndex`, so `balanceOf`
+    // overshoots `amount` by Aave's linear accrual. Cap at 1%.
     let overrides: StateOverride = [(target, override_)].into_iter().collect();
     let a_token_contract = ERC20::Instance::new(a_eth_weth, web3.provider.clone());
     let reported = a_token_contract


### PR DESCRIPTION
# Problem

Quote verification for small Aave v3 aToken sell amounts intermittently failed in prod with `execution reverted: trader does not have enough sell token`: [0.1 aEthWETH quote](https://victorialogs.dev.cow.fi/explore?schemaVersion=1&panes=%7B%22vdl%22%3A%7B%22datasource%22%3A%22vm-auth-prod%22%2C%22queries%22%3A%5B%7B%22refId%22%3A%22A%22%2C%22datasource%22%3A%7B%22type%22%3A%22victoriametrics-logs-datasource%22%2C%22uid%22%3A%22vm-auth-prod%22%7D%2C%22editorMode%22%3A%22code%22%2C%22expr%22%3A%22container%3A%21controller%20AND%20network%3Amainnet%20AND%20all%3A40880b4ceb2f4dbe7a25aa1877279ddd%22%2C%22queryType%22%3A%22range%22%7D%5D%2C%22range%22%3A%7B%22from%22%3A%221776965400000%22%2C%22to%22%3A%221776965700000%22%7D%2C%22panelsState%22%3A%7B%22logs%22%3A%7B%22visualisationType%22%3A%22logs%22%7D%7D%2C%22compact%22%3Afalse%7D%7D&orgId=1) failed, [1 aEthWETH quote](https://victorialogs.dev.cow.fi/explore?schemaVersion=1&panes=%7B%22vdl%22%3A%7B%22datasource%22%3A%22vm-auth-prod%22%2C%22queries%22%3A%5B%7B%22refId%22%3A%22A%22%2C%22datasource%22%3A%7B%22type%22%3A%22victoriametrics-logs-datasource%22%2C%22uid%22%3A%22vm-auth-prod%22%7D%2C%22editorMode%22%3A%22code%22%2C%22expr%22%3A%22container%3A%21controller%20AND%20network%3Amainnet%20AND%20all%3A98c568a44d1b6ce7ea068648fdfc7c94%22%2C%22queryType%22%3A%22range%22%7D%5D%2C%22range%22%3A%7B%22from%22%3A%221776965400000%22%2C%22to%22%3A%221776965700000%22%7D%2C%22panelsState%22%3A%7B%22logs%22%3A%7B%22visualisationType%22%3A%22logs%22%7D%7D%2C%22compact%22%3Afalse%7D%7D&orgId=1) minutes earlier passed.

Aave's aToken does not store a balance directly. It stores a deposit and a growth factor. `balanceOf() = deposit * growth_factor`, and the factor ticks up every second as interest accrues.

Quote verification fakes a donor balance by writing a deposit value. We can only write to the deposit slot, not to `balanceOf()`, so we reverse the math: `deposit = amount / growth_factor`.

The bug: we make two separate `eth_call`s to our RPC node. The first reads `growth_factor` at the node's current head and we use it to compute the deposit. The second runs the simulation pinned to a block number we captured earlier in the flow. If the node's head ticked forward between those calls (or the pinned block is otherwise behind the head the read saw), the sim's `growth_factor` is smaller than the one we divided by. `balanceOf()` rounds down to `amount - 1 wei`, the transfer tries to pull the full `amount`, Aave's internal scaled-balance subtraction underflows, revert.

Reproducible on Tenderly with the same logged override payload (Tenderly is only used for debug replays, not for prod verification): [reverts at block 24944162](https://dashboard.tenderly.co/cow-protocol/production/simulator/3ba7d4af-c1ef-4ba4-9302-b2767d33c991), [passes at 24944163](https://dashboard.tenderly.co/cow-protocol/production/simulator/701d213d-c93a-4f9e-b520-036ed3456f6b). Same payload, one block apart.

# Fix

Aave also stores the growth factor as it stood at the last pool write (deposit, borrow, etc). Call it `base`. The current factor is always `base + non_negative_accrual`, because interest only adds on top.

Divide by `base` instead of the current factor: `deposit = amount / base`. Then in the sim:

```
balanceOf() = deposit * sim_factor
            = (amount / base) * (base + accrual)
            >= amount       # because accrual >= 0
```

The donor has at least `amount` at any sim block. The old code needed two separate reads of the growth factor to agree exactly. The new code does not.

Inside the simulation itself everything runs at one block, so Aave's own factor read is self-consistent there. The disagreement is with our pre-sim `build_override` call, which is a separate RPC round-trip. Pinning that call to the sim's block would also fix it, but it requires threading the block through `build_override` and relies on the two calls staying coordinated across every future refactor. The stored-factor approach does not need the coupling.

# Changes

- `aave.rs`: `getReserveNormalizedIncome` to `getReserveData().liquidityIndex` (the stored `base`).
- `detector.rs`: `AaveV3AToken` tolerance 1 wei to 1% relative (overshoot is now one-sided).
- `lib.rs`: update mock, add round-trip regression test.
- `quote_verification.rs`: widen e2e assertion to match.