### PR TITLE
Overshoot Spardose fake balance by 1%

### DIFF
--- a/crates/price-estimation/src/trade_verifier/mod.rs
+++ b/crates/price-estimation/src/trade_verifier/mod.rs
@@ -383,20 +383,21 @@ impl TradeVerifier {
         // not alter solver balances which may be used during settlement. We use
         // a similar strategy for determining whether or not to set approvals on
         // behalf of the trader.
+        let needed = match query.kind {
+            OrderKind::Sell => query.in_amount.get(),
+            OrderKind::Buy => trade.out_amount(
+                &query.buy_token,
+                &query.sell_token,
+                &query.in_amount.get(),
+                &query.kind,
+            )?,
+        };
         match self
             .balance_overrides
             .state_override(BalanceOverrideRequest {
                 token: query.sell_token,
                 holder: Self::SPARDOSE,
-                amount: match query.kind {
-                    OrderKind::Sell => query.in_amount.get(),
-                    OrderKind::Buy => trade.out_amount(
-                        &query.buy_token,
-                        &query.sell_token,
-                        &query.in_amount.get(),
-                        &query.kind,
-                    )?,
-                },
+                amount: spardose_amount_with_buffer(needed),
             })
             .await
         {
@@ -852,9 +853,35 @@ enum Error {
     SimulationFailed(#[from] anyhow::Error),
 }
 
+/// Spardose gets `needed` plus a 1% headroom. The buffer is absorbed by
+/// tokens with boundary-rounding or per-block accrual (aToken, rebasing,
+/// tiny fee-on-transfer) so the sim at a slightly different block than
+/// our state_override read still has enough funds. Spardose is a
+/// throwaway donor, so overshoot has no cost.
+fn spardose_amount_with_buffer(needed: U256) -> U256 {
+    needed.saturating_add(needed / U256::from(100u64))
+}
+
 #[cfg(test)]
 mod tests {
     use {super::*, U256, maplit::hashmap, std::str::FromStr};
+
+    #[test]
+    fn spardose_amount_applies_1pct_overshoot() {
+        assert_eq!(
+            spardose_amount_with_buffer(U256::from(1_000_000_000_000_000_000u128)),
+            U256::from(1_010_000_000_000_000_000u128)
+        );
+        // Tiny amounts floor to 0% headroom (1 / 100 == 0 in integer math),
+        // which is fine for these magnitudes no real order sits this low.
+        assert_eq!(
+            spardose_amount_with_buffer(U256::from(50u64)),
+            U256::from(50u64)
+        );
+        assert_eq!(spardose_amount_with_buffer(U256::ZERO), U256::ZERO);
+        // Saturates at U256::MAX instead of overflowing.
+        assert_eq!(spardose_amount_with_buffer(U256::MAX), U256::MAX);
+    }
 
     #[test]
     fn discards_inaccurate_quotes() {

--- a/crates/price-estimation/src/trade_verifier/mod.rs
+++ b/crates/price-estimation/src/trade_verifier/mod.rs
@@ -853,13 +853,18 @@ enum Error {
     SimulationFailed(#[from] anyhow::Error),
 }
 
-/// Spardose gets `needed` plus a 1% headroom. The buffer is absorbed by
-/// tokens with boundary-rounding or per-block accrual (aToken, rebasing,
-/// tiny fee-on-transfer) so the sim at a slightly different block than
-/// our state_override read still has enough funds. Spardose is a
-/// throwaway donor, so overshoot has no cost.
+/// Spardose gets `needed` plus a 1% headroom, floored at 1 wei so the
+/// 1-wei boundary is still covered for small amounts where `needed / 100`
+/// truncates to 0. The buffer absorbs rounding or per-block accrual
+/// (aToken, rebasing, tiny fee-on-transfer) between our state_override
+/// read and the sim's execution. Spardose is a throwaway donor, so
+/// overshoot has no cost.
 fn spardose_amount_with_buffer(needed: U256) -> U256 {
-    needed.saturating_add(needed / U256::from(100u64))
+    if needed.is_zero() {
+        return U256::ZERO;
+    }
+    let buffer = std::cmp::max(U256::from(1u64), needed / U256::from(100u64));
+    needed.saturating_add(buffer)
 }
 
 #[cfg(test)]
@@ -872,12 +877,18 @@ mod tests {
             spardose_amount_with_buffer(U256::from(1_000_000_000_000_000_000u128)),
             U256::from(1_010_000_000_000_000_000u128)
         );
-        // Tiny amounts floor to 0% headroom (1 / 100 == 0 in integer math),
-        // which is fine for these magnitudes no real order sits this low.
+        // Amounts below 100 still get at least 1 wei of headroom, so the
+        // boundary stays covered when integer division would otherwise
+        // round the 1% buffer to 0.
         assert_eq!(
-            spardose_amount_with_buffer(U256::from(50u64)),
-            U256::from(50u64)
+            spardose_amount_with_buffer(U256::from(99u64)),
+            U256::from(100u64)
         );
+        assert_eq!(
+            spardose_amount_with_buffer(U256::from(1u64)),
+            U256::from(2u64)
+        );
+        // Zero needed means no trade, no donor funds needed.
         assert_eq!(spardose_amount_with_buffer(U256::ZERO), U256::ZERO);
         // Saturates at U256::MAX instead of overflowing.
         assert_eq!(spardose_amount_with_buffer(U256::MAX), U256::MAX);

--- a/crates/price-estimation/src/trade_verifier/mod.rs
+++ b/crates/price-estimation/src/trade_verifier/mod.rs
@@ -860,10 +860,7 @@ enum Error {
 /// read and the sim's execution. Spardose is a throwaway donor, so
 /// overshoot has no cost.
 fn spardose_amount_with_buffer(needed: U256) -> U256 {
-    if needed.is_zero() {
-        return U256::ZERO;
-    }
-    let buffer = std::cmp::max(U256::from(1u64), needed / U256::from(100u64));
+    let buffer = std::cmp::max(U256::ONE, needed / U256::from(100u64));
     needed.saturating_add(buffer)
 }
 
@@ -884,12 +881,8 @@ mod tests {
             spardose_amount_with_buffer(U256::from(99u64)),
             U256::from(100u64)
         );
-        assert_eq!(
-            spardose_amount_with_buffer(U256::from(1u64)),
-            U256::from(2u64)
-        );
-        // Zero needed means no trade, no donor funds needed.
-        assert_eq!(spardose_amount_with_buffer(U256::ZERO), U256::ZERO);
+        assert_eq!(spardose_amount_with_buffer(U256::ONE), U256::from(2u64));
+        assert_eq!(spardose_amount_with_buffer(U256::ZERO), U256::ONE);
         // Saturates at U256::MAX instead of overflowing.
         assert_eq!(spardose_amount_with_buffer(U256::MAX), U256::MAX);
     }


### PR DESCRIPTION
# Problem

Quote verification for small aToken sell amounts intermittently failed in prod with `execution reverted: trader does not have enough sell token`: [0.1 aEthWETH quote](https://victorialogs.dev.cow.fi/explore?schemaVersion=1&panes=%7B%22vdl%22%3A%7B%22datasource%22%3A%22vm-auth-prod%22%2C%22queries%22%3A%5B%7B%22refId%22%3A%22A%22%2C%22datasource%22%3A%7B%22type%22%3A%22victoriametrics-logs-datasource%22%2C%22uid%22%3A%22vm-auth-prod%22%7D%2C%22editorMode%22%3A%22code%22%2C%22expr%22%3A%22container%3A%21controller%20AND%20network%3Amainnet%20AND%20all%3A40880b4ceb2f4dbe7a25aa1877279ddd%22%2C%22queryType%22%3A%22range%22%7D%5D%2C%22range%22%3A%7B%22from%22%3A%221776965400000%22%2C%22to%22%3A%221776965700000%22%7D%2C%22panelsState%22%3A%7B%22logs%22%3A%7B%22visualisationType%22%3A%22logs%22%7D%7D%2C%22compact%22%3Afalse%7D%7D&orgId=1) failed, [1 aEthWETH quote](https://victorialogs.dev.cow.fi/explore?schemaVersion=1&panes=%7B%22vdl%22%3A%7B%22datasource%22%3A%22vm-auth-prod%22%2C%22queries%22%3A%5B%7B%22refId%22%3A%22A%22%2C%22datasource%22%3A%7B%22type%22%3A%22victoriametrics-logs-datasource%22%2C%22uid%22%3A%22vm-auth-prod%22%7D%2C%22editorMode%22%3A%22code%22%2C%22expr%22%3A%22container%3A%21controller%20AND%20network%3Amainnet%20AND%20all%3A98c568a44d1b6ce7ea068648fdfc7c94%22%2C%22queryType%22%3A%22range%22%7D%5D%2C%22range%22%3A%7B%22from%22%3A%221776965400000%22%2C%22to%22%3A%221776965700000%22%7D%2C%22panelsState%22%3A%7B%22logs%22%3A%7B%22visualisationType%22%3A%22logs%22%7D%7D%2C%22compact%22%3Afalse%7D%7D&orgId=1) minutes earlier passed.

aToken does not store a balance directly. It stores a deposit and a growth factor, where `balanceOf() = deposit * growth_factor`. The factor ticks up every second as interest accrues.

Quote verification writes a fake deposit into the Spardose (our donor contract) so the sim can pretend the trader has funds. The old code sized the fake deposit from a pre-sim `getReserveNormalizedIncome` RPC read. The sim then re-read the growth factor inside the EVM at its own pinned block. Those two reads can disagree by one block, leaving the Spardose's `balanceOf` one wei below `amount` when it tries to fund the trader. Aave's internal scaled-balance subtraction underflows, revert.

The same kind of boundary issue could in principle hit other tokens (rebasing, tiny fee-on-transfer, future weird ones).

# Fix

Bump the Spardose's fake balance by 1% before passing it to the override:

```
spardose_amount = needed + needed / 100
```

Spardose ends up slightly richer than the sim will ever transfer. Any rounding, accrual, or per-block drift is absorbed by the buffer. The Spardose is a throwaway donor, overshoot costs nothing: no gas difference, no side effects, only the trader-requested `amount` actually moves.

Generic by construction. Fixes aToken and covers any future token with similar near-boundary math.

# Context

Supersedes #4361, which took an Aave-specific approach (scale against the stored `liquidityIndex` instead of the accrued one). Replaced with this generic overshoot per [Martin's review](https://github.com/cowprotocol/services/pull/4361#pullrequestreview-4168763147).

# Changes

- `price-estimation/trade_verifier`: 1% overshoot on the amount passed to the Spardose balance override.
- Unit test covering the overshoot helper.

# How to test

`cargo test -p price-estimation trade_verifier`. Existing tests pass plus the new `spardose_amount_applies_1pct_overshoot`.