### PR TITLE
Fix remaining sell error reporting for order simulation

### DIFF
--- a/crates/orderbook/src/order_simulator.rs
+++ b/crates/orderbook/src/order_simulator.rs
@@ -116,7 +116,7 @@ impl OrderSimulator {
             self.remaining_amounts(order, block.map(Into::into)).await?;
         let query = Query {
             sell_amount: NonZeroU256::try_from(remaining_sell).map_err(|err| {
-                Error::MalformedInput(anyhow!("sell_amount `{}`: {err}", order.data.sell_amount))
+                Error::MalformedInput(anyhow!("sell_amount `{}`: {err}", remaining_sell))
             })?,
             sell_token: order.data.sell_token,
             buy_amount: remaining_buy,


### PR DESCRIPTION
# Description
Simulating fully filled order (the remaining amount equals 0) errors out when creating NonZeroU256 from said amount. The error message is incorrect, as it uses order.data.sell_amount instead of the remaining_sell which is actually used.

# Changes
Change the error message to properly reflect which value is being used.

## How to test
Query any filled order and observe correct error message.
