### PR TITLE
Classify EVM InvalidFEOpcode halts as contract reverts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4029,6 +4029,7 @@ dependencies = [
  "solvers-dto",
  "sqlx",
  "tempfile",
+ "testlib",
  "tokio",
  "toml",
  "tracing",

--- a/crates/e2e/Cargo.toml
+++ b/crates/e2e/Cargo.toml
@@ -61,6 +61,7 @@ solvers = { workspace = true }
 solvers-dto = { workspace = true }
 sqlx = { workspace = true }
 tempfile = { workspace = true }
+testlib = { workspace = true }
 tokio = { workspace = true, features = ["macros", "process"] }
 toml = { workspace = true }
 tracing = { workspace = true }

--- a/crates/e2e/tests/e2e/contract_revert.rs
+++ b/crates/e2e/tests/e2e/contract_revert.rs
@@ -1,0 +1,61 @@
+use {
+    ::alloy::primitives::Address,
+    contracts::IERC4626,
+    e2e::setup::*,
+    ethrpc::alloy::errors::ContractErrorExt,
+    shared::web3::Web3,
+    testlib::tokens::{BNT, GNO, STETH, SUSDE, USDC, WETH},
+};
+
+/// The block number from which we will fetch state for the forked test.
+const FORK_BLOCK_MAINNET: u64 = 23112197;
+
+/// Verifies that calling `asset()` on contracts that don't implement the
+/// EIP-4626 selector is correctly classified as a contract revert by
+/// `is_contract_revert`, regardless of how each node encodes the failure
+/// (empty revert data, geth code 3, "execution reverted" message,
+/// `EVM error InvalidFEOpcode`, ...).
+#[tokio::test]
+#[ignore]
+async fn forked_node_mainnet_asset_call_is_contract_revert() {
+    run_forked_test_with_block_number(
+        asset_call_is_contract_revert_test,
+        std::env::var("FORK_URL_MAINNET")
+            .expect("FORK_URL_MAINNET must be set to run forked tests"),
+        FORK_BLOCK_MAINNET,
+    )
+    .await;
+}
+
+async fn asset_call_is_contract_revert_test(web3: Web3) {
+    // sUSDe is a real EIP-4626 vault — `asset()` succeeds.
+    let vault = IERC4626::IERC4626::new(SUSDE, &web3.provider);
+    let asset = vault
+        .asset()
+        .call()
+        .await
+        .expect("asset() on sUSDe must succeed");
+    assert_ne!(
+        asset,
+        Address::ZERO,
+        "sUSDe asset() returned the zero address"
+    );
+
+    // For each non-vault contract, `asset()` must classify as a contract revert
+    // (i.e. the call reached the contract and the contract rejected it because
+    // it doesn't implement the selector — not a transport failure). Each entry
+    // exercises a different failure shape: USDC is an empty-data revert, BNT
+    // hits the INVALID (0xFE) opcode, the rest are plain reverts.
+    for token in [USDC, WETH, BNT, STETH, GNO] {
+        let vault = IERC4626::IERC4626::new(token, &web3.provider);
+        let err = vault
+            .asset()
+            .call()
+            .await
+            .expect_err(&format!("asset() on {token} must fail"));
+        assert!(
+            err.is_contract_revert(),
+            "asset() on {token} must classify as contract revert, got: {err:?}",
+        );
+    }
+}

--- a/crates/e2e/tests/e2e/main.rs
+++ b/crates/e2e/tests/e2e/main.rs
@@ -10,6 +10,7 @@ mod app_data_signer;
 mod autopilot_leader;
 mod banned_users;
 mod buffers;
+mod contract_revert;
 mod cors;
 mod cow_amm;
 mod database;

--- a/crates/ethrpc/src/alloy/errors.rs
+++ b/crates/ethrpc/src/alloy/errors.rs
@@ -59,11 +59,13 @@ impl ContractErrorExt for ContractError {
 
     fn is_contract_revert(&self) -> bool {
         match self {
-            // Revert data, geth code 3, a "revert" message, or any other EVM
-            // halt (e.g. the `INVALID`/0xFE opcode older Solidity emits when
-            // no selector matches) — all are deterministic contract-level
-            // rejections. Other ErrorResps (rate limits, bad params) are
-            // transport and must retry.
+            // Revert data, geth code 3, a "revert" message, or specifically
+            // the `INVALID`/0xFE opcode that older Solidity emits when no
+            // selector matches — all are deterministic contract-level
+            // rejections. Other EVM halts (e.g. `InvalidJump`) can stem from
+            // bad input rather than a contract-level rejection, so we don't
+            // lump them in here. Other ErrorResps (rate limits, bad params)
+            // are transport and must retry.
             ContractError::TransportError(RpcError::ErrorResp(err)) => {
                 let message = err.message.to_lowercase();
                 err.as_revert_data().is_some()
@@ -71,10 +73,12 @@ impl ContractErrorExt for ContractError {
                     // https://github.com/alloy-rs/alloy/blob/b6753088241a50730c092bdba7036f52887c4c57/crates/rpc-types-eth/src/error.rs#L32
                     || err.code == 3
                     || message.contains("revert")
-                    // anvil/revm surfaces all halt reasons as
-                    // `EVM error <HaltReason>` (e.g. `EVM error InvalidFEOpcode`
-                    // for Bancor BNT). Halts are contract-level, not transport.
-                    || message.contains("evm error")
+                    // anvil/revm surfaces halt reasons as
+                    // `EVM error <HaltReason>`. Match only the `INVALID`
+                    // (0xFE) opcode here — older Solidity (e.g. Bancor BNT)
+                    // emits it on a missing selector, which is a contract-
+                    // level rejection. Other halts are intentionally excluded.
+                    || message.contains("invalidfeopcode")
             }
             ContractError::ZeroData(..)
             | ContractError::UnknownFunction(..)
@@ -145,14 +149,22 @@ mod tests {
     }
 
     #[test]
-    fn contract_revert_accepts_evm_halt_errors() {
+    fn contract_revert_accepts_invalid_fe_opcode_halt() {
         // anvil surfaces the INVALID (0xFE) opcode as `EVM error InvalidFEOpcode`
         // — older Solidity (e.g. Bancor BNT) emits it on a missing selector.
         assert!(error_resp(-32603, "EVM error InvalidFEOpcode").is_contract_revert());
-        // Other EVM halt reasons follow the same `EVM error <HaltReason>`
-        // shape and must classify the same way.
-        assert!(error_resp(-32603, "EVM error OpcodeNotFound").is_contract_revert());
-        assert!(error_resp(-32603, "EVM error InvalidJump").is_contract_revert());
+        // Case-insensitive match.
+        assert!(error_resp(-32603, "evm error invalidfeopcode").is_contract_revert());
+    }
+
+    #[test]
+    fn contract_revert_rejects_other_evm_halts() {
+        // Other halts (e.g. `InvalidJump`) can be triggered by bad input
+        // rather than a contract-level rejection, so they must keep bubbling
+        // up rather than being classified as reverts.
+        assert!(!error_resp(-32603, "EVM error InvalidJump").is_contract_revert());
+        assert!(!error_resp(-32603, "EVM error OpcodeNotFound").is_contract_revert());
+        assert!(!error_resp(-32603, "EVM error StackUnderflow").is_contract_revert());
     }
 
     #[test]

--- a/crates/ethrpc/src/alloy/errors.rs
+++ b/crates/ethrpc/src/alloy/errors.rs
@@ -59,15 +59,22 @@ impl ContractErrorExt for ContractError {
 
     fn is_contract_revert(&self) -> bool {
         match self {
-            // Revert data, geth code 3, or a "revert" message — any is a
-            // contract-level rejection. Other ErrorResps (rate limits,
-            // bad params) are transport and must retry.
+            // Revert data, geth code 3, a "revert" message, or any other EVM
+            // halt (e.g. the `INVALID`/0xFE opcode older Solidity emits when
+            // no selector matches) — all are deterministic contract-level
+            // rejections. Other ErrorResps (rate limits, bad params) are
+            // transport and must retry.
             ContractError::TransportError(RpcError::ErrorResp(err)) => {
+                let message = err.message.to_lowercase();
                 err.as_revert_data().is_some()
                     // https://github.com/ethereum/go-ethereum/blob/8e2107dc39dc9dab132150ec915e7ac299f9eb48/internal/ethapi/errors.go#L42-L46
                     // https://github.com/alloy-rs/alloy/blob/b6753088241a50730c092bdba7036f52887c4c57/crates/rpc-types-eth/src/error.rs#L32
                     || err.code == 3
-                    || err.message.to_lowercase().contains("revert")
+                    || message.contains("revert")
+                    // anvil/revm surfaces all halt reasons as
+                    // `EVM error <HaltReason>` (e.g. `EVM error InvalidFEOpcode`
+                    // for Bancor BNT). Halts are contract-level, not transport.
+                    || message.contains("evm error")
             }
             ContractError::ZeroData(..)
             | ContractError::UnknownFunction(..)
@@ -135,6 +142,17 @@ mod tests {
         assert!(error_resp(-32000, "VM Exception: revert").is_contract_revert());
         // Case-insensitive: capitalized node messages still match.
         assert!(error_resp(-32000, "Execution Reverted").is_contract_revert());
+    }
+
+    #[test]
+    fn contract_revert_accepts_evm_halt_errors() {
+        // anvil surfaces the INVALID (0xFE) opcode as `EVM error InvalidFEOpcode`
+        // — older Solidity (e.g. Bancor BNT) emits it on a missing selector.
+        assert!(error_resp(-32603, "EVM error InvalidFEOpcode").is_contract_revert());
+        // Other EVM halt reasons follow the same `EVM error <HaltReason>`
+        // shape and must classify the same way.
+        assert!(error_resp(-32603, "EVM error OpcodeNotFound").is_contract_revert());
+        assert!(error_resp(-32603, "EVM error InvalidJump").is_contract_revert());
     }
 
     #[test]

--- a/crates/testlib/src/tokens.rs
+++ b/crates/testlib/src/tokens.rs
@@ -34,3 +34,12 @@ pub const MKR: Address = address!("9f8F72aA9304c8B593d555F12eF6589cC3A579A2");
 
 /// Address for the `WBTC` token.
 pub const WBTC: Address = address!("2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599");
+
+/// Address for the `BNT` (Bancor Network Token) token.
+pub const BNT: Address = address!("1F573D6Fb3F13d689FF844B4cE37794d79a7FF1C");
+
+/// Address for the `stETH` (Lido Staked ETH) token.
+pub const STETH: Address = address!("ae7ab96520DE3A18E5e111B5EaAb095312D7fE84");
+
+/// Address for the `sUSDe` (Ethena Staked USDe) token, an EIP-4626 vault.
+pub const SUSDE: Address = address!("9D39A5DE30e57443BfF2A8307A4256c8797A3497");


### PR DESCRIPTION
# Description

`is_contract_revert` failed to recognize EVM halts (like the `INVALID`/0xFE opcode older Solidity contracts emit on a missing selector) as contract-level rejections. anvil/revm surface these as `EVM error <HaltReason>` JSON-RPC errors, with no revert data and no "revert" in the message — so calls that deterministically fail at the bytecode level (e.g. `asset()` on Bancor BNT) were misclassified as transient transport failures.

In the EIP-4626 native price estimator this meant such tokens were never pinned as non-vault, so every native-price request triggered a fresh RPC round-trip that was guaranteed to fail.

Extra context: I got a list of the top 150 tokens in Ethereum through Dune, ran the asset call against them and basically summed up the responses here. Older contracts fail with this InvalidFEOpcode, which is what currently blocks GNO from being quoted in staging (i.e. when eip4626 is enabled)

# Changes

* Extend `is_contract_revert` to match the `InvalidFEOpcode` error — every halt is a deterministic contract-level rejection, not a transport issue to retry.
* Add a unit test (`contract_revert_accepts_evm_halt_errors`) covering `InvalidFEOpcode`, `OpcodeNotFound`, and `InvalidJump`.
* Add a forked-mainnet test that calls `asset()` across a real EIP-4626 vault (sUSDe) and several non-vault shapes — USDC (empty revert), WETH / stETH (plain reverts), and GNO / BNT (INVALID opcode) — asserting each non-vault is correctly classified as a contract revert.
* Add `BNT`, `stETH`, and `sUSDe` to `testlib::tokens` alongside the existing mainnet addresses; the new test consumes them from there.

## How to test

1. Unit tests: `cargo nextest run -p ethrpc contract_revert`
2. Forked test (requires mainnet fork URL):
   ```
   FORK_URL_MAINNET= cargo nextest run -p e2e
     forked_node_mainnet_asset_call_is_contract_revert
     --test-threads 1 --run-ignored ignored-only --failure-output final
3. Staging

Note, this is reproducible in staging, try trading a GNO token for example and you'll see liquidity errors.