### PR TITLE
Enforce EIP-7825 per-tx gas cap on settlement

### DIFF
--- a/crates/driver/src/domain/competition/solution/settlement.rs
+++ b/crates/driver/src/domain/competition/solution/settlement.rs
@@ -513,6 +513,9 @@ mod tests {
         let tx_gas_limit = gas(EIP_7825_MAINNET_TX_GAS_CAP);
         let result = Gas::new(tx_gas_limit, block_limit, tx_gas_limit).unwrap();
         assert_eq!(result.estimate, tx_gas_limit);
+        // The 2x buffer would otherwise push limit to 2 * tx_gas_limit; the
+        // min(max_gas, ...) clamp must keep it at the configured cap.
+        assert_eq!(result.limit, tx_gas_limit);
     }
 
     #[test]

--- a/crates/driver/src/domain/competition/solution/settlement.rs
+++ b/crates/driver/src/domain/competition/solution/settlement.rs
@@ -178,7 +178,7 @@ impl Settlement {
         )
         .await?;
         let price = eth.gas_price().await?;
-        let gas = Gas::new(gas, eth.block_gas_limit())?;
+        let gas = Gas::new(gas, eth.block_gas_limit(), eth.tx_gas_limit())?;
 
         // Ensure that the solver has sufficient balance for the settlement to be mined
         // even if the gas price keeps climbing during the tx submission.
@@ -428,14 +428,13 @@ pub struct Gas {
 }
 
 impl Gas {
-    /// EIP-7825 per-transaction gas cap (2^24 - 1) introduced in Fusaka.
-    /// Any transaction exceeding this will be rejected by the mempool, so a
-    /// solution requiring more gas can never be settled on chain.
-    const EIP_7825_TX_GAS_CAP: u64 = (1 << 24) - 1;
-
     /// Computes settlement gas parameters given estimates for gas and gas
     /// price.
-    pub fn new(estimate: eth::Gas, block_limit: eth::Gas) -> Result<Self, solution::Error> {
+    pub fn new(
+        estimate: eth::Gas,
+        block_limit: eth::Gas,
+        tx_gas_limit: eth::Gas,
+    ) -> Result<Self, solution::Error> {
         // We don't allow for solutions to take up more than half of the block's gas
         // limit. This is to ensure that block producers attempt to include the
         // settlement transaction in the next block as long as it is reasonably
@@ -446,13 +445,11 @@ impl Gas {
         // will not exceed the remaining space in the block next and ignore transactions
         // whose gas limit exceed the remaining space (without simulating the actual
         // gas required).
-        // Additionally cap by the EIP-7825 per-tx gas limit: even if half the
-        // block limit is higher, the mempool will reject any tx above the cap,
-        // so the settlement could never be mined.
-        let max_gas = std::cmp::min(
-            eth::Gas(block_limit.0 / eth::U256::from(2)),
-            eth::Gas(eth::U256::from(Self::EIP_7825_TX_GAS_CAP)),
-        );
+        // Additionally cap by the configured per-tx gas limit. Operators set
+        // this per chain (e.g. to EIP-7825's 16,777,215 cap on Fusaka chains)
+        // so the mempool can't reject the settlement for exceeding the per-tx
+        // ceiling.
+        let max_gas = std::cmp::min(eth::Gas(block_limit.0 / eth::U256::from(2)), tx_gas_limit);
         if estimate > max_gas {
             return Err(solution::Error::GasLimitExceeded(estimate, max_gas));
         }
@@ -487,39 +484,61 @@ mod tests {
         eth::Gas(eth::U256::from(value))
     }
 
+    /// EIP-7825 per-transaction gas cap (2^24 - 1) introduced in Fusaka.
+    /// Used in tests as a representative value for the configurable
+    /// `tx_gas_limit` knob on Fusaka chains.
+    const EIP_7825_TX_GAS_CAP: u64 = (1 << 24) - 1;
+
     #[test]
-    fn rejects_solution_above_eip_7825_cap() {
+    fn rejects_solution_above_tx_gas_limit() {
         // Block limit (120M) is high enough that half the block (60M) exceeds
-        // the EIP-7825 per-tx cap (16,777,215). The per-tx cap must win.
+        // the configured per-tx limit (EIP-7825 cap, 16,777,215). The per-tx
+        // limit must win.
         let block_limit = gas(120_000_000);
+        let tx_gas_limit = gas(EIP_7825_TX_GAS_CAP);
         let estimate = gas(20_000_000);
-        let err = Gas::new(estimate, block_limit).unwrap_err();
+        let err = Gas::new(estimate, block_limit, tx_gas_limit).unwrap_err();
         match err {
             solution::Error::GasLimitExceeded(used, limit) => {
                 assert_eq!(used, estimate);
-                assert_eq!(limit, gas(Gas::EIP_7825_TX_GAS_CAP));
+                assert_eq!(limit, tx_gas_limit);
             }
             other => panic!("unexpected error: {other:?}"),
         }
     }
 
     #[test]
-    fn accepts_solution_at_eip_7825_cap() {
+    fn accepts_solution_at_tx_gas_limit() {
         let block_limit = gas(120_000_000);
-        let estimate = gas(Gas::EIP_7825_TX_GAS_CAP);
-        let result = Gas::new(estimate, block_limit).unwrap();
-        assert_eq!(result.estimate, estimate);
+        let tx_gas_limit = gas(EIP_7825_TX_GAS_CAP);
+        let result = Gas::new(tx_gas_limit, block_limit, tx_gas_limit).unwrap();
+        assert_eq!(result.estimate, tx_gas_limit);
     }
 
     #[test]
     fn small_block_limit_still_caps_at_half() {
         // On chains with a low block gas limit, the half-block cap is tighter
-        // than the EIP-7825 cap and must keep applying.
+        // than the configured per-tx limit and must keep applying.
         let block_limit = gas(10_000_000);
+        let tx_gas_limit = gas(EIP_7825_TX_GAS_CAP);
         let estimate = gas(6_000_000);
-        let err = Gas::new(estimate, block_limit).unwrap_err();
+        let err = Gas::new(estimate, block_limit, tx_gas_limit).unwrap_err();
         match err {
             solution::Error::GasLimitExceeded(_, limit) => assert_eq!(limit, gas(5_000_000)),
+            other => panic!("unexpected error: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn high_tx_gas_limit_lets_half_block_bind() {
+        // Non-Fusaka chain: tx_gas_limit configured well above half the block,
+        // so the half-block cap is the binding limit.
+        let block_limit = gas(120_000_000);
+        let tx_gas_limit = gas(100_000_000);
+        let estimate = gas(70_000_000);
+        let err = Gas::new(estimate, block_limit, tx_gas_limit).unwrap_err();
+        match err {
+            solution::Error::GasLimitExceeded(_, limit) => assert_eq!(limit, gas(60_000_000)),
             other => panic!("unexpected error: {other:?}"),
         }
     }

--- a/crates/driver/src/domain/competition/solution/settlement.rs
+++ b/crates/driver/src/domain/competition/solution/settlement.rs
@@ -428,6 +428,11 @@ pub struct Gas {
 }
 
 impl Gas {
+    /// EIP-7825 per-transaction gas cap (2^24 - 1) introduced in Fusaka.
+    /// Any transaction exceeding this will be rejected by the mempool, so a
+    /// solution requiring more gas can never be settled on chain.
+    pub const EIP_7825_TX_GAS_CAP: u64 = (1 << 24) - 1;
+
     /// Computes settlement gas parameters given estimates for gas and gas
     /// price.
     pub fn new(estimate: eth::Gas, block_limit: eth::Gas) -> Result<Self, solution::Error> {
@@ -441,7 +446,13 @@ impl Gas {
         // will not exceed the remaining space in the block next and ignore transactions
         // whose gas limit exceed the remaining space (without simulating the actual
         // gas required).
-        let max_gas = eth::Gas(block_limit.0 / eth::U256::from(2));
+        // Additionally cap by the EIP-7825 per-tx gas limit: even if half the
+        // block limit is higher, the mempool will reject any tx above the cap,
+        // so the settlement could never be mined.
+        let max_gas = std::cmp::min(
+            eth::Gas(block_limit.0 / eth::U256::from(2)),
+            eth::Gas(eth::U256::from(Self::EIP_7825_TX_GAS_CAP)),
+        );
         if estimate > max_gas {
             return Err(solution::Error::GasLimitExceeded(estimate, max_gas));
         }
@@ -465,5 +476,51 @@ impl Gas {
     /// parameters.
     pub fn required_balance(&self, max_fee_per_gas: U256) -> eth::Ether {
         self.limit * max_fee_per_gas.into()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn gas(value: u64) -> eth::Gas {
+        eth::Gas(eth::U256::from(value))
+    }
+
+    #[test]
+    fn rejects_solution_above_eip_7825_cap() {
+        // 120M block (well above the EIP-7825 cap of 16,777,215). Half the
+        // block is 60M, but the per-tx cap must still apply.
+        let block_limit = gas(120_000_000);
+        let estimate = gas(20_000_000);
+        let err = Gas::new(estimate, block_limit).unwrap_err();
+        match err {
+            solution::Error::GasLimitExceeded(used, limit) => {
+                assert_eq!(used, estimate);
+                assert_eq!(limit, gas(Gas::EIP_7825_TX_GAS_CAP));
+            }
+            other => panic!("unexpected error: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn accepts_solution_at_eip_7825_cap() {
+        let block_limit = gas(120_000_000);
+        let estimate = gas(Gas::EIP_7825_TX_GAS_CAP);
+        let result = Gas::new(estimate, block_limit).unwrap();
+        assert_eq!(result.estimate, estimate);
+    }
+
+    #[test]
+    fn small_block_limit_still_caps_at_half() {
+        // On chains with a low block gas limit, the half-block cap is tighter
+        // than the EIP-7825 cap and must keep applying.
+        let block_limit = gas(10_000_000);
+        let estimate = gas(6_000_000);
+        let err = Gas::new(estimate, block_limit).unwrap_err();
+        match err {
+            solution::Error::GasLimitExceeded(_, limit) => assert_eq!(limit, gas(5_000_000)),
+            other => panic!("unexpected error: {other:?}"),
+        }
     }
 }

--- a/crates/driver/src/domain/competition/solution/settlement.rs
+++ b/crates/driver/src/domain/competition/solution/settlement.rs
@@ -431,7 +431,7 @@ impl Gas {
     /// EIP-7825 per-transaction gas cap (2^24 - 1) introduced in Fusaka.
     /// Any transaction exceeding this will be rejected by the mempool, so a
     /// solution requiring more gas can never be settled on chain.
-    pub const EIP_7825_TX_GAS_CAP: u64 = (1 << 24) - 1;
+    const EIP_7825_TX_GAS_CAP: u64 = (1 << 24) - 1;
 
     /// Computes settlement gas parameters given estimates for gas and gas
     /// price.
@@ -489,8 +489,8 @@ mod tests {
 
     #[test]
     fn rejects_solution_above_eip_7825_cap() {
-        // 120M block (well above the EIP-7825 cap of 16,777,215). Half the
-        // block is 60M, but the per-tx cap must still apply.
+        // Block limit (120M) is high enough that half the block (60M) exceeds
+        // the EIP-7825 per-tx cap (16,777,215). The per-tx cap must win.
         let block_limit = gas(120_000_000);
         let estimate = gas(20_000_000);
         let err = Gas::new(estimate, block_limit).unwrap_err();

--- a/crates/driver/src/domain/competition/solution/settlement.rs
+++ b/crates/driver/src/domain/competition/solution/settlement.rs
@@ -446,7 +446,7 @@ impl Gas {
         // whose gas limit exceed the remaining space (without simulating the actual
         // gas required).
         // Additionally cap by the configured per-tx gas limit. Operators set
-        // this per chain (e.g. to EIP-7825's 16,777,215 cap on Fusaka chains)
+        // this per chain (e.g. to EIP-7825's 16,777,215 cap on Mainnet Fusaka)
         // so the mempool can't reject the settlement for exceeding the per-tx
         // ceiling.
         let max_gas = std::cmp::min(eth::Gas(block_limit.0 / eth::U256::from(2)), tx_gas_limit);
@@ -484,10 +484,10 @@ mod tests {
         eth::Gas(eth::U256::from(value))
     }
 
-    /// EIP-7825 per-transaction gas cap (2^24 - 1) introduced in Fusaka.
-    /// Used in tests as a representative value for the configurable
-    /// `tx_gas_limit` knob on Fusaka chains.
-    const EIP_7825_TX_GAS_CAP: u64 = (1 << 24) - 1;
+    /// EIP-7825 per-transaction gas cap (2^24 - 1) introduced in Mainnet's
+    /// Fusaka hardfork. Used in tests as a representative value for the
+    /// configurable `tx_gas_limit` knob on Mainnet.
+    const EIP_7825_MAINNET_TX_GAS_CAP: u64 = (1 << 24) - 1;
 
     #[test]
     fn rejects_solution_above_tx_gas_limit() {
@@ -495,7 +495,7 @@ mod tests {
         // the configured per-tx limit (EIP-7825 cap, 16,777,215). The per-tx
         // limit must win.
         let block_limit = gas(120_000_000);
-        let tx_gas_limit = gas(EIP_7825_TX_GAS_CAP);
+        let tx_gas_limit = gas(EIP_7825_MAINNET_TX_GAS_CAP);
         let estimate = gas(20_000_000);
         let err = Gas::new(estimate, block_limit, tx_gas_limit).unwrap_err();
         match err {
@@ -510,7 +510,7 @@ mod tests {
     #[test]
     fn accepts_solution_at_tx_gas_limit() {
         let block_limit = gas(120_000_000);
-        let tx_gas_limit = gas(EIP_7825_TX_GAS_CAP);
+        let tx_gas_limit = gas(EIP_7825_MAINNET_TX_GAS_CAP);
         let result = Gas::new(tx_gas_limit, block_limit, tx_gas_limit).unwrap();
         assert_eq!(result.estimate, tx_gas_limit);
     }
@@ -520,7 +520,7 @@ mod tests {
         // On chains with a low block gas limit, the half-block cap is tighter
         // than the configured per-tx limit and must keep applying.
         let block_limit = gas(10_000_000);
-        let tx_gas_limit = gas(EIP_7825_TX_GAS_CAP);
+        let tx_gas_limit = gas(EIP_7825_MAINNET_TX_GAS_CAP);
         let estimate = gas(6_000_000);
         let err = Gas::new(estimate, block_limit, tx_gas_limit).unwrap_err();
         match err {

--- a/crates/driver/src/infra/blockchain/mod.rs
+++ b/crates/driver/src/infra/blockchain/mod.rs
@@ -91,6 +91,7 @@ struct Inner {
     current_block: CurrentBlockWatcher,
     balance_simulator: BalanceSimulator,
     balance_overrider: Arc<dyn BalanceOverriding>,
+    tx_gas_limit: eth::Gas,
 }
 
 impl Ethereum {
@@ -105,6 +106,7 @@ impl Ethereum {
         addresses: contracts::Addresses,
         gas: Arc<GasPriceEstimator>,
         current_block_args: &shared::current_block::Arguments,
+        tx_gas_limit: eth::Gas,
     ) -> Self {
         let Rpc { web3, chain, args } = rpc;
         let current_block_stream = current_block_args
@@ -132,6 +134,7 @@ impl Ethereum {
                 gas,
                 balance_simulator,
                 balance_overrider,
+                tx_gas_limit,
             }),
             web3,
         }
@@ -188,6 +191,12 @@ impl Ethereum {
 
     pub fn block_gas_limit(&self) -> eth::Gas {
         self.inner.current_block.borrow().gas_limit.into()
+    }
+
+    /// Per-transaction gas limit configured for this driver. Operators set
+    /// this per chain (e.g. EIP-7825's 16,777,215 cap on Fusaka chains).
+    pub fn tx_gas_limit(&self) -> eth::Gas {
+        self.inner.tx_gas_limit
     }
 
     /// Returns the current [`eth::Ether`] balance of the specified account.

--- a/crates/driver/src/run.rs
+++ b/crates/driver/src/run.rs
@@ -16,6 +16,7 @@ use {
         },
     },
     clap::Parser,
+    eth_domain_types as eth,
     futures::future::join_all,
     http_client::HttpClientFactory,
     shared::arguments::tracing_config,
@@ -195,7 +196,14 @@ async fn ethereum(
             .await
             .expect("initialize gas price estimator"),
     );
-    Ethereum::new(ethrpc, config.contracts.clone(), gas, current_block_args).await
+    Ethereum::new(
+        ethrpc,
+        config.contracts.clone(),
+        gas,
+        current_block_args,
+        eth::Gas(config.tx_gas_limit),
+    )
+    .await
 }
 
 async fn solvers(config: &config::Config, eth: &Ethereum) -> Vec<Solver> {

--- a/crates/driver/src/tests/setup/solver.rs
+++ b/crates/driver/src/tests/setup/solver.rs
@@ -479,6 +479,7 @@ impl Solver {
                 block_stream_poll_interval: None,
                 node_ws_url: Some(config.blockchain.web3_ws_url.parse().unwrap()),
             },
+            eth_domain_types::Gas(eth_domain_types::U256::from(45_000_000u64)),
         )
         .await;
 


### PR DESCRIPTION
# Description

The driver caps a settlement's gas estimate at half the block gas limit (e.g. 60M on a 120M block). Fusaka introduced the EIP-7825 per-transaction gas cap of `2^24 - 1 = 16,777,215` on Mainnet; any tx exceeding this is rejected by the mempool. Without this check a solution above the cap can still be returned by `/solve` and forwarded to `/settle`, where it could never be mined. The cap is already enforced on the quote-verification path (#4261) but was never ported to settlement submission.

Note: EIP-7825 is not strictly followed by all chains, some chains picked different per-tx limits (e.g. Arbitrum One uses 32M), so the driver reuses the existing `tx_gas_limit` config knob (#3780) rather than hardcoding a single value. Operators set the per-chain ceiling — `16,777,215` on Mainnet Fusaka, higher elsewhere — and `Gas::new` enforces `min(block_limit / 2, tx_gas_limit)`.

# Changes

* Plumb the `tx_gas_limit` config value through `infra::blockchain::Ethereum` (new `tx_gas_limit()` accessor).
* In `Gas::new`, cap the per-settlement maximum at `min(block_limit / 2, tx_gas_limit)` so over-sized solutions fail fast through the existing `GasLimitExceeded` error.
* Chains with a block gas limit below `2 * tx_gas_limit` keep the tighter half-block behaviour.
* Add unit tests covering the configured-cap path, the boundary case (asserting both `estimate` and the clamped `limit`), the small-block-limit path, and the non-Fusaka case where the half-block cap binds.

## How to test

```
cargo nextest run -p driver settlement::tests
```

All four new tests pass; existing driver tests are unchanged.

Fixes #4368