### PR TITLE
Add pr-context-synthesis skill

### DIFF
--- a/.claude/commands/pr-synthesis.md
+++ b/.claude/commands/pr-synthesis.md
@@ -1,5 +1,5 @@
 ---
-description: Produce a tight 1–3 paragraph what / why / how synthesis of a single PR. Fetches title, body, linked issue, and diff scope; outputs per `docs/skills/pr-context-synthesis.md`. Useful as a standalone summary or as a building block for review / incident-investigation flows. Read-only.
+description: Produce a tight 1–3 paragraph what / why / how synthesis of a single PR. Fetches title, body, linked issue, and diff scope; outputs per `docs/skills/pr-context-synthesis.md`. Read-only.
 ---
 
 Synthesise PR: $ARGUMENTS
@@ -8,7 +8,7 @@ Synthesise PR: $ARGUMENTS
 
 Accept any of:
 
-- A PR number: `4267`
+- A PR number: `4267`/`#4267`
 - A full URL: `https://github.com/cowprotocol/services/pull/4267`
 - An `owner/repo#N` form: `cowprotocol/services#4267`
 
@@ -26,14 +26,15 @@ and abort.
 
 ## Procedure
 
-Fetch in parallel:
+Fetch in this order — context first, then diff. Lets the synthesis read the diff with the author's intent already in mind, and lets `gh pr view` report `additions`/`deletions` so the diff fetch can be sized appropriately.
+
+**Step 1 — PR metadata + closing issues.** Cheap; bounded size.
 
 ```bash
-gh pr view <N> -R <owner>/<repo> --json title,body,files,labels,baseRefName,headRefName,closingIssuesReferences
-gh pr diff <N> -R <owner>/<repo>
+gh pr view <N> -R <owner>/<repo> --json title,body,files,additions,deletions,labels,baseRefName,headRefName,closingIssuesReferences
 ```
 
-For each entry in `closingIssuesReferences` (GitHub's own parsing of `Fixes #N` / `Closes #N` / `Resolves #N`, more reliable than regexing the body), fetch the issue:
+**Step 2 — linked issues.** For each entry in `closingIssuesReferences` (GitHub's own parsing of `Fixes #N` / `Closes #N` / `Resolves #N`, more reliable than regexing the body, and follows cross-repo references correctly), fetch the issue:
 
 ```bash
 gh issue view <issue.number> -R <issue.repository.owner>/<issue.repository.name> --json title,body,labels,state
@@ -41,17 +42,35 @@ gh issue view <issue.number> -R <issue.repository.owner>/<issue.repository.name>
 
 If `closingIssuesReferences` is empty, proceed without a linked issue — never invent one.
 
+**Step 3 — diff fetch (size-gated).** Use `additions + deletions` from step 1 to decide:
+
+- **`additions + deletions <= 2000`** — fetch the full diff:
+
+  ```bash
+  gh pr diff <N> -R <owner>/<repo>
+  ```
+
+- **`additions + deletions > 2000`** — *do not* fetch the full diff. It can blow the context window (e.g. PR #4217 = 376k lines). Get the complete per-file list via the paginated REST endpoint — `gh pr view --json files` silently caps at 100 files, which underreports scope on big PRs:
+
+  ```bash
+  gh api --paginate "repos/<owner>/<repo>/pulls/<N>/files" \
+    --jq '.[] | {filename, status, additions, deletions}'
+  ```
+
+  Build `<diff_summary>` from these per-file records (`filename`, `additions`, `deletions`, `status` — added / modified / renamed / removed). Bucket lockfiles, generated bindings, vendored artifacts, and codegen output — call them out as a single line each, not file-by-file. State in the synthesis that the diff was summarised at file-scope only.
+
 Build:
 
+- `<diff_summary>` = full hunks (small PR) or per-file scope buckets (large PR). The ground truth.
 - `<pr_text>` = title + body
-- `<linked_issue>` = the fetched issue, if any
-- `<diff_summary>` = a per-file note of the change scope (path + brief description, drawn from the diff hunks)
+- `<linked_issue>` = fetched issue(s), if any
 
 Then follow `docs/skills/pr-context-synthesis.md` Rules and Shape. Output the synthesis verbatim — no header, no metadata, no separator lines. The caller pastes this directly into a review thread, an incident report, or a Slack message.
 
 ## Rules
 
 - **Read-only.** `gh pr view`, `gh pr diff`, `gh issue view`, `gh api` GET-only. No `gh pr review`, no `gh pr comment`, no mutating `gh api` verbs.
+- **Don't fetch a diff you can't read.** The 2000-line gate above is a hard preflight, not a suggestion. Above the gate, the per-file scope is enough to write the synthesis honestly; trying to swallow a 100k-line diff just truncates the context and corrupts the output silently.
 - **Synthesise, don't copy-paste.** If `<pr_text>` is sparse, say so plainly: *"description is minimal; intent inferred from diff"*.
 - **No vague verbs.** *"This PR updates something"* is a failure. Name the component, the change, and the mechanism. The anti-vague-verb rule from the skill doc applies verbatim.
-- **Watch for description-vs-diff drift.** `<pr_text>` must describe `<diff_summary>`'s current state. If a claim is no longer true of the diff, note it in the synthesis as *"description claims X; diff shows Y"*.
+- **Watch for description-vs-diff drift.** `<pr_text>` must describe `<diff_summary>`'s current state. If a claim is no longer true of the diff, note it in the synthesis as *"description claims X; diff shows Y"*. Fetching the issue + metadata before the diff is what lets you spot these — read the intent first, then check whether the diff matches.

--- a/.claude/commands/pr-synthesis.md
+++ b/.claude/commands/pr-synthesis.md
@@ -1,0 +1,57 @@
+---
+description: Produce a tight 1–3 paragraph what / why / how synthesis of a single PR. Fetches title, body, linked issue, and diff scope; outputs per `docs/skills/pr-context-synthesis.md`. Useful as a standalone summary or as a building block for review / incident-investigation flows. Read-only.
+---
+
+Synthesise PR: $ARGUMENTS
+
+## Parse $ARGUMENTS
+
+Accept any of:
+
+- A PR number: `4267`
+- A full URL: `https://github.com/cowprotocol/services/pull/4267`
+- An `owner/repo#N` form: `cowprotocol/services#4267`
+
+Default `owner/repo` to `cowprotocol/services` when only a number is given.
+
+If `$ARGUMENTS` is empty or unparseable, print:
+
+```
+Usage: /pr-synthesis <PR_NUMBER>
+       /pr-synthesis https://github.com/owner/repo/pull/<N>
+       /pr-synthesis owner/repo#<N>
+```
+
+and abort.
+
+## Procedure
+
+Fetch in parallel:
+
+```bash
+gh pr view <N> -R <owner>/<repo> --json title,body,files,labels,baseRefName,headRefName
+gh pr diff <N> -R <owner>/<repo>
+```
+
+Parse the PR body for `Fixes #N` / `Closes #N` / `Resolves #N` (case-insensitive) and fetch each linked issue:
+
+```bash
+gh issue view <N> -R <owner>/<repo> --json title,body,labels,state
+```
+
+If no linked issue is referenced, proceed without one — never invent one.
+
+Build:
+
+- `<pr_text>` = title + body
+- `<linked_issue>` = the fetched issue, if any
+- `<diff_summary>` = a per-file note of the change scope (path + brief description, drawn from the diff hunks)
+
+Then follow `docs/skills/pr-context-synthesis.md` Rules and Shape. Output the synthesis verbatim — no header, no metadata, no separator lines. The caller pastes this directly into a review thread, an incident report, or a Slack message.
+
+## Rules
+
+- **Read-only.** `gh pr view`, `gh pr diff`, `gh issue view`, `gh api` GET-only. No `gh pr review`, no `gh pr comment`, no mutating `gh api` verbs.
+- **Synthesise, don't copy-paste.** If `<pr_text>` is sparse, say so plainly: *"description is minimal; intent inferred from diff"*.
+- **No vague verbs.** *"This PR updates something"* is a failure. Name the component, the change, and the mechanism. The anti-vague-verb rule from the skill doc applies verbatim.
+- **Watch for description-vs-diff drift.** `<pr_text>` must describe `<diff_summary>`'s current state. If a claim is no longer true of the diff, note it in the synthesis as *"description claims X; diff shows Y"*.

--- a/.claude/commands/pr-synthesis.md
+++ b/.claude/commands/pr-synthesis.md
@@ -29,17 +29,17 @@ and abort.
 Fetch in parallel:
 
 ```bash
-gh pr view <N> -R <owner>/<repo> --json title,body,files,labels,baseRefName,headRefName
+gh pr view <N> -R <owner>/<repo> --json title,body,files,labels,baseRefName,headRefName,closingIssuesReferences
 gh pr diff <N> -R <owner>/<repo>
 ```
 
-Parse the PR body for `Fixes #N` / `Closes #N` / `Resolves #N` (case-insensitive) and fetch each linked issue:
+For each entry in `closingIssuesReferences` (GitHub's own parsing of `Fixes #N` / `Closes #N` / `Resolves #N`, more reliable than regexing the body), fetch the issue:
 
 ```bash
-gh issue view <N> -R <owner>/<repo> --json title,body,labels,state
+gh issue view <issue.number> -R <issue.repository.owner>/<issue.repository.name> --json title,body,labels,state
 ```
 
-If no linked issue is referenced, proceed without one — never invent one.
+If `closingIssuesReferences` is empty, proceed without a linked issue — never invent one.
 
 Build:
 

--- a/docs/skills/pr-context-synthesis.md
+++ b/docs/skills/pr-context-synthesis.md
@@ -18,7 +18,7 @@ Two ways:
 ## Rules
 
 1. **Synthesize, don't copy-paste.** If `<pr_text>` is five words, say so plainly: *"description is minimal; intent inferred from diff"*. Don't pad to look thorough.
-2. **Watch for description-vs-diff drift.** `<pr_text>` must describe `<diff_summary>`'s *current* state, not the author's iteration history. If a claim is no longer true of the diff, raise a finding with `Action: update the PR description to match the current diff`. Do **not** flag the absence of a changelog of removed/superseded behaviour — that belongs in commit history, not the description.
+2. **Watch for description-vs-diff drift.** `<pr_text>` must describe `<diff_summary>`'s *current* state, not the author's iteration history. If a claim is no longer true of the diff, note it in the synthesis as *"description claims X; diff shows Y"*. Don't raise an `Action:` finding here — this skill reports facts; the consumer (e.g. `/review-pr`) decides whether to escalate. Do **not** flag the absence of a changelog of removed/superseded behaviour either — that belongs in commit history, not the description.
 3. **No vague verbs.** *"This PR updates something"* is a failure. Name the component, the change, and the mechanism.
 
 ## Shape

--- a/docs/skills/pr-context-synthesis.md
+++ b/docs/skills/pr-context-synthesis.md
@@ -2,6 +2,13 @@
 
 Use to produce a tight 1–3 paragraph *what / why / how* block for a single PR (or PR-shaped change). Consumed by the PR review report's CONTEXT section and by [`pr-blame-walk`](pr-blame-walk.md), which calls this skill once per candidate PR before scoring.
 
+## How to invoke
+
+Two ways:
+
+- **Procedurally** — follow the rules below when you need a tight 1–3 paragraph synthesis (CONTEXT block of `/review-pr`, per-candidate block in `pr-blame-walk`, ad-hoc *"summarise this PR for me"*).
+- **Via slash command** — `/pr-synthesis <N|owner/repo#N|url>` fetches the PR, linked issue, and diff for you and prints the synthesis verbatim.
+
 ## Inputs
 
 - `<pr_text>` — PR title and body. If there is no PR yet (e.g. local-diff mode), substitute the branch name plus the relevant commit messages.
@@ -19,6 +26,20 @@ Use to produce a tight 1–3 paragraph *what / why / how* block for a single PR 
 - **Paragraph 1** — *what* changed. Component + concrete change, drawn from `<diff_summary>`.
 - **Paragraph 2** — *why*. Drawn from `<pr_text>` and `<linked_issue>`. If both are thin, say so.
 - **Paragraph 3** (only if warranted) — *how*. The approach, not a line-by-line walkthrough.
+
+## Example
+
+Inputs (real PR — cowprotocol/services#4371):
+
+- `<pr_text>` — *"Enforce EIP-7825 per-tx gas cap on settlement"*; body explains the Fusaka mempool cap and references the existing quote-side enforcement (#4261).
+- `<linked_issue>` — #4368, *"Driver doesn't enforce the EIP-7825 per-tx gas cap"* (labels: bug, good first issue).
+- `<diff_summary>` — +58 −1 in `settlement.rs`; new const `EIP_7825_TX_GAS_CAP`, `Gas::new` capped via `min(half_block, EIP_7825)`, three tests.
+
+Output:
+
+> Fusaka introduced EIP-7825, capping any single tx at 2^24 − 1 gas. The driver's `Gas::new` was applying only the older `block_limit/2` heuristic; a solution between the EIP-7825 cap and that heuristic could pass validation in `/solve` and never settle. Issue #4368 flagged this as theoretical (no production hits); the fix ports the same idea PR #4261 applied to the quote path.
+>
+> Mechanically: `max_gas = min(half_block, EIP_7825)`, preserving inclusion-economics on chains with low block gas limits via the `min`.
 
 ## When to skip
 

--- a/docs/skills/pr-context-synthesis.md
+++ b/docs/skills/pr-context-synthesis.md
@@ -1,19 +1,21 @@
 # Skill — PR context synthesis
 
-Use to produce a tight 1–3 paragraph *what / why / how* block for a single PR (or PR-shaped change). Consumed by the PR review report's CONTEXT section and by [`pr-blame-walk`](pr-blame-walk.md), which calls this skill once per candidate PR before scoring.
+Use to produce a tight 1–3 paragraph *what / why / how* block for a single PR (or PR-shaped change). Consumed by the PR review report's CONTEXT section and by other workflows that need a per-PR summary (e.g. ad-hoc *"summarise this PR for me"* or per-candidate context in an incident-investigation walk).
 
 ## How to invoke
 
 Two ways:
 
-- **Procedurally** — follow the rules below when you need a tight 1–3 paragraph synthesis (CONTEXT block of `/review-pr`, per-candidate block in `pr-blame-walk`, ad-hoc *"summarise this PR for me"*).
+- **Procedurally** — follow the rules below when you need a tight 1–3 paragraph synthesis (CONTEXT block of `/review-pr`, ad-hoc *"summarise this PR for me"*, per-candidate context for an investigation).
 - **Via slash command** — `/pr-synthesis <N|owner/repo#N|url>` fetches the PR, linked issue, and diff for you and prints the synthesis verbatim.
 
 ## Inputs
 
-- `<pr_text>` — PR title and body. If there is no PR yet (e.g. local-diff mode), substitute the branch name plus the relevant commit messages.
+Listed ground-truth-first; downstream items are interpreted relative to the diff.
+
+- `<diff_summary>` — file scope plus a codemap or per-file note of the actual change. The ground truth the synthesis must stay anchored to. For large PRs this may be file-scope only (paths + ±counts + change type), without hunks — `/pr-synthesis` falls back to that when the diff is too big to fetch in full.
+- `<pr_text>` — PR title and body. If there is no PR yet (e.g. local-diff mode), use the current branch name and the relevant commit messages (i.e. diff against `main`).
 - `<linked_issue>` — title and body of any issue referenced via `Fixes #N` / `Closes #N` / `Resolves #N`. May be empty.
-- `<diff_summary>` — file scope plus a codemap or per-file note of the actual change. The ground truth the synthesis must stay anchored to.
 
 ## Rules
 

--- a/docs/skills/pr-context-synthesis.md
+++ b/docs/skills/pr-context-synthesis.md
@@ -1,0 +1,26 @@
+# Skill — PR context synthesis
+
+Use to produce a tight 1–3 paragraph *what / why / how* block for a single PR (or PR-shaped change). Consumed by the PR review report's CONTEXT section and by [`pr-blame-walk`](pr-blame-walk.md), which calls this skill once per candidate PR before scoring.
+
+## Inputs
+
+- `<pr_text>` — PR title and body. If there is no PR yet (e.g. local-diff mode), substitute the branch name plus the relevant commit messages.
+- `<linked_issue>` — title and body of any issue referenced via `Fixes #N` / `Closes #N` / `Resolves #N`. May be empty.
+- `<diff_summary>` — file scope plus a codemap or per-file note of the actual change. The ground truth the synthesis must stay anchored to.
+
+## Rules
+
+1. **Synthesize, don't copy-paste.** If `<pr_text>` is five words, say so plainly: *"description is minimal; intent inferred from diff"*. Don't pad to look thorough.
+2. **Watch for description-vs-diff drift.** `<pr_text>` must describe `<diff_summary>`'s *current* state, not the author's iteration history. If a claim is no longer true of the diff, raise a finding with `Action: update the PR description to match the current diff`. Do **not** flag the absence of a changelog of removed/superseded behaviour — that belongs in commit history, not the description.
+3. **No vague verbs.** *"This PR updates something"* is a failure. Name the component, the change, and the mechanism.
+
+## Shape
+
+- **Paragraph 1** — *what* changed. Component + concrete change, drawn from `<diff_summary>`.
+- **Paragraph 2** — *why*. Drawn from `<pr_text>` and `<linked_issue>`. If both are thin, say so.
+- **Paragraph 3** (only if warranted) — *how*. The approach, not a line-by-line walkthrough.
+
+## When to skip
+
+- Trivial changes (docs typo, single-line dep bump, lockfile-only). One sentence is enough; don't force the three-paragraph shape.
+- `<pr_text>` and `<linked_issue>` are both empty *and* `<diff_summary>` already speaks for itself (e.g. a single-file rename). One sentence noting that the diff is self-explanatory is the correct output.


### PR DESCRIPTION
# What this is

A primitive for producing a tight 1–3 paragraph what / why / how synthesis of a single PR (or PR-shaped change). Stays anchored to the actual diff and refuses vague verbs.

Ships with `/pr-synthesis <N|owner/repo#N|url>`, a slash command that fetches PR metadata, linked issue, and diff and prints the synthesis verbatim.

# Why split out

Extracted from #4351 because the synthesis primitive is reusable beyond a single review report — review and incident-investigation flows both want the same per-PR summary shape. Splitting keeps the contract small.

# Files

- `docs/skills/pr-context-synthesis.md` — rules + output shape.
- `.claude/commands/pr-synthesis.md` — slash command wrapping the procedure.

### Worked examples

#### Example 1: PR #4243

Boundary case: just over the gate. Generated bindings dominate the line count; the substantive change is a 275-line estimator + a 236-line e2e test.

Adds a new `Eip4626` native price estimator to the price-estimation stack at `crates/price-estimation/src/native/eip4626.rs`. The estimator unwraps an EIP-4626 vault token by calling `asset()` and `convertToAssets(10^decimals)` on-chain, then delegates pricing of the underlying token to the next estimator in the configured stage. New contract bindings (`IERC4626`, `MockERC4626Wrapper`) ship as pre-generated alloy crates; an e2e forked-mainnet test covers a single vault and a recursive vault chain.

Vault tokens like sDAI often lack direct DEX liquidity, which makes the existing native-price estimators fall over. This change lets the orderbook quote vault tokens by reducing them to their underlying. (No linked issue; intent inferred from the PR body and the new test names.)

Mechanically: a `Mutex<HashSet<Address>>` negative cache short-circuits subsequent requests for tokens whose `asset()` reverts (cleared on restart); each on-chain RPC is bounded by `tokio::time::timeout`, with the leftover budget forwarded to the inner estimator so total wall-clock stays inside the caller's timeout — important for nested vaults. A configurable `depth` parameter (default 1) controls recursion, wired in `factory.rs::create_native_estimator`. Config deserialisation rejects stages where `Eip4626` is the last entry, since it must be followed by another estimator to price the underlying.

*Diff summarised at file-scope only — total +4,411 / −21 across 24 files exceeds the 2k full-diff threshold. Generated bindings (`ierc4626/src/lib.rs` +648, `mockerc4626wrapper/src/lib.rs` +2,768) and the `MockERC4626Wrapper.json` artifact (+240) account for ~83% of additions; the substantive Rust changes are the 275-line estimator, 236-line e2e test, and 14 small wiring edits.*

#### Example 2: PR #4217

Stress case: two orders of magnitude over the gate. Demonstrates that the per-file bucket summary is genuinely **more useful than the full diff would be** — 96% of the lines are mechanical codegen output, and the substantive change hides in a 116-file `+213/−1,531` workspace bucket of import-path edits.

Moves the `contracts` crate from `crates/contracts` to a standalone `contracts/` directory at repo root, and replaces its `build.rs` runtime code-generation with 148 pre-generated per-contract Alloy binding crates under `contracts/generated/contracts-generated/`. A new `contracts-facade` crate re-exports the bindings so consumers see a single import surface. All 116 workspace crates that previously depended on `crates/contracts` are rewired to import from the new generated crates. Codegen still exists, but is now a separate `cargo run -p contracts` step rather than an implicit cost on every workspace build.

Driver: `build.rs` was the longest critical-path step in the workspace build. The PR description's flame graphs claim ~15 s shaved off cold builds (from ~60 s to ~45 s) and visibly higher CPU utilisation since the build no longer serialises behind a single codegen blocker. Pre-generated bindings are also independently version-controllable and reviewable — historically the only way to inspect a binding diff was to rerun the build.

*Diff summarised at file-scope only — +375,175 / −1,654 across 384 files is two orders of magnitude over the 2k full-diff threshold. Bucketed: generated bindings 148 files / +292,618 (mechanical, alloy-codegen output); contract artifacts 74 files / +7,278 (JSON ABI moves); workspace crates 116 files / +213 / −1,531 (overwhelmingly import-path edits and removal of the old `crates/contracts/`); Cargo.lock 3 files / +7,747; contracts tooling 38 files / +1,192. Almost everything except the 116 workspace-crate imports is mechanically generated or moved.*

## Reviewing this in isolation

The skill body is self-contained. The intro mentions consumers (`/review-pr`, ad-hoc summaries, future incident walks) but doesn't link to anything that doesn't exist on `main`. Rules, Shape, and Example stand on their own.

# How to try it

```
/pr-synthesis 4371
```
