### PR TITLE
Probe mempool on nonce mismatch and guard submission updates

### DIFF
--- a/crates/driver/src/domain/mempools.rs
+++ b/crates/driver/src/domain/mempools.rs
@@ -4,7 +4,7 @@ use {
         domain::{blockchain::TxStatus, competition::solution::Settlement},
         infra::{self, Ethereum, observe},
     },
-    alloy::{consensus::Transaction, eips::eip1559::Eip1559Estimation, sol_types::SolCall},
+    alloy::{eips::eip1559::Eip1559Estimation, sol_types::SolCall},
     anyhow::Context,
     contracts::CowSettlementForwarder::CowSettlementForwarder,
     eth_domain_types::{self as eth, BlockNo, TxId},
@@ -337,9 +337,12 @@ impl Mempools {
             .await
     }
 
-    /// Computes minimum price to replace the last tx that was submitted
-    /// with the given nonce. Returns `None` if no tx was submitted with
-    /// that nonce yet.
+    /// Computes the minimum gas price required to replace any tx currently
+    /// pending at `(signer, next_nonce)`. If the in-memory cache has no entry
+    /// for `signer` or the cached nonce differs from `next_nonce`, queries the
+    /// node directly via `txpool_content_from`. The in-memory map is
+    /// per-signer only and overwrites on every `submit()`, so a cached nonce
+    /// that differs from `next_nonce` does not imply nothing is pending.
     #[tracing::instrument(skip_all)]
     async fn minimum_replacement_gas_price(
         &self,
@@ -347,33 +350,26 @@ impl Mempools {
         signer: eth::Address,
         next_nonce: u64,
     ) -> Option<Eip1559Estimation> {
-        if let Some(last_submission) = mempool.last_submission(signer) {
-            if last_submission.nonce == next_nonce {
-                Some(last_submission.gas_price.scaled_by_pct(GAS_PRICE_BUMP_PCT))
-            } else {
-                None
-            }
-        } else {
-            // If we don't have the last submission in-memory (i.e. first submission
-            // attempt after a restart) we try to inspect the nodes transaction mempool.
-            // This is only done as a backup since it can incur significant latency and
-            // is generally not very widely supported.
-            let pending_tx = mempool
-                .find_pending_tx_in_mempool(signer, next_nonce)
-                .await
-                .inspect_err(|err| tracing::debug!(?err, "could not inspect tx mempool"))
-                .ok()??;
-
-            let pending_tx_gas_price = Eip1559Estimation {
-                max_fee_per_gas: pending_tx.max_fee_per_gas(),
-                max_priority_fee_per_gas: pending_tx.max_priority_fee_per_gas().or_else(|| {
-                    tracing::error!(tx = ?pending_tx.inner.tx_hash(), "pending tx is not EIP 1559");
-                    None
-                })?,
-            };
-
-            Some(pending_tx_gas_price.scaled_by_pct(GAS_PRICE_BUMP_PCT))
+        if let Some(last_submission) = mempool.last_submission(signer)
+            && last_submission.nonce == next_nonce
+        {
+            return Some(last_submission.gas_price.scaled_by_pct(GAS_PRICE_BUMP_PCT));
         }
+
+        let pending_gas = mempool.probe_pending_gas(signer, next_nonce).await?;
+
+        tracing::info!(
+            ?signer,
+            nonce = next_nonce,
+            gas = ?pending_gas,
+            "probed pending tx from mempool"
+        );
+
+        // Promote the probed gas into the fast-path lookup so subsequent
+        // `/settle` calls for the same `(signer, nonce)` skip the RPC probe.
+        mempool.record_observed(signer, next_nonce, pending_gas);
+
+        Some(pending_gas.scaled_by_pct(GAS_PRICE_BUMP_PCT))
     }
 }
 

--- a/crates/driver/src/infra/mempool/mod.rs
+++ b/crates/driver/src/infra/mempool/mod.rs
@@ -14,7 +14,13 @@ use {
     anyhow::Context,
     dashmap::DashMap,
     eth_domain_types as eth,
-    std::sync::Arc,
+    std::{
+        sync::{
+            Arc,
+            atomic::{AtomicU64, Ordering},
+        },
+        time::{Duration, SystemTime, UNIX_EPOCH},
+    },
     url::Url,
 };
 
@@ -67,6 +73,11 @@ pub enum RevertProtection {
 pub struct Mempool {
     transport: Web3,
     config: Config,
+    /// Best-known gas floor per signer at their currently-pending nonce.
+    /// Source may be a prior `submit()` or a `txpool_content_from` probe
+    /// ([`Mempool::record_observed`]). Updates are gated by
+    /// [`Submission::supersedes`] so an out-of-order or stale write cannot
+    /// regress a fresher entry under intra-process races.
     last_submissions: Arc<DashMap<Address, Submission>>,
 }
 
@@ -74,6 +85,23 @@ pub struct Mempool {
 pub struct Submission {
     pub nonce: u64,
     pub gas_price: Eip1559Estimation,
+}
+
+impl Submission {
+    /// Returns `true` if `self` should replace `other` in `last_submissions`.
+    ///
+    /// Ordering is tuple-monotonic on `(nonce, max_priority_fee_per_gas)`:
+    /// - a higher nonce always wins;
+    /// - same nonce with a higher priority fee wins (meaning a speed-up);
+    /// - otherwise no-op.
+    ///
+    /// The ordering is safe against intra-process races where two `submit()`
+    /// or `record_observed()` calls arrive out of order: only a higher nonce
+    /// or a higher priority fee can overwrite an existing entry.
+    fn supersedes(&self, other: &Submission) -> bool {
+        (self.nonce, self.gas_price.max_priority_fee_per_gas)
+            > (other.nonce, other.gas_price.max_priority_fee_per_gas)
+    }
 }
 
 impl std::fmt::Display for Mempool {
@@ -158,8 +186,7 @@ impl Mempool {
                     ?signer,
                     "successfully submitted tx to mempool"
                 );
-                self.last_submissions
-                    .insert(signer, Submission { nonce, gas_price });
+                self.update_submission(signer, Submission { nonce, gas_price });
                 Ok(eth::TxId(*tx.tx_hash()))
             }
             Err(err) => {
@@ -204,11 +231,91 @@ impl Mempool {
         Ok(pending_tx)
     }
 
+    /// Probes the node for a pending tx at `(signer, nonce)` and returns its
+    /// gas price. Returns `None` if no pending tx exists at that nonce or if
+    /// the probe times out, errors, or encounters a non-EIP-1559 tx.
+    ///
+    /// A slow node cannot block `/settle` — the probe has a 500ms hard
+    /// deadline. If the probe fails (timeout or RPC error), a process-wide
+    /// cooldown skips further probes for 30 seconds; `Ok(None)` (no pending
+    /// tx at that nonce) is not a failure and does not trigger the cooldown.
+    pub async fn probe_pending_gas(
+        &self,
+        signer: eth::Address,
+        nonce: u64,
+    ) -> Option<Eip1559Estimation> {
+        /// Hard latency cap on the probe so a slow node cannot block `/settle`.
+        const TIMEOUT: Duration = Duration::from_millis(500);
+        /// How long to suppress probes after a failure (timeout / RPC error).
+        /// `txpool_*` support is an RPC-level property, so a single
+        /// process-wide cooldown stops us paying the timeout cost on every
+        /// `/settle` against an endpoint that doesn't expose the namespace.
+        const COOLDOWN: Duration = Duration::from_secs(30);
+        /// Unix-ms of the last probe failure; `0` means none recorded yet.
+        static LAST_FAILURE_MS: AtomicU64 = AtomicU64::new(0);
+
+        let now_ms = now_unix_ms();
+        let last_failure_ms = LAST_FAILURE_MS.load(Ordering::Relaxed);
+        if last_failure_ms != 0
+            && now_ms.saturating_sub(last_failure_ms) < COOLDOWN.as_millis() as u64
+        {
+            tracing::debug!("skipping mempool probe due to recent failure");
+            return None;
+        }
+
+        let pending_tx =
+            match tokio::time::timeout(TIMEOUT, self.find_pending_tx_in_mempool(signer, nonce))
+                .await
+            {
+                Err(_) => {
+                    LAST_FAILURE_MS.store(now_unix_ms(), Ordering::Relaxed);
+                    tracing::debug!("mempool probe timed out");
+                    return None;
+                }
+                Ok(Err(err)) => {
+                    LAST_FAILURE_MS.store(now_unix_ms(), Ordering::Relaxed);
+                    tracing::debug!(?err, "could not inspect tx mempool");
+                    return None;
+                }
+                Ok(Ok(None)) => return None,
+                Ok(Ok(Some(tx))) => tx,
+            };
+
+        Some(Eip1559Estimation {
+            max_fee_per_gas: pending_tx.max_fee_per_gas(),
+            max_priority_fee_per_gas: pending_tx.max_priority_fee_per_gas().or_else(|| {
+                tracing::error!(tx = ?pending_tx.inner.tx_hash(), "pending tx is not EIP 1559");
+                None
+            })?,
+        })
+    }
+
     /// Looks up the last tx that was submitted for that signer.
     pub fn last_submission(&self, signer: eth::Address) -> Option<Submission> {
         self.last_submissions
             .get(&signer)
             .map(|entry| entry.value().clone())
+    }
+
+    /// Records a pending tx observed externally (from a `txpool_content_from`
+    /// probe) so subsequent lookups for `(signer, nonce)` skip the RPC probe.
+    /// The map tracks the best-known gas floor for each signer at their
+    /// current pending nonce, regardless of source.
+    pub fn record_observed(&self, signer: eth::Address, nonce: u64, gas_price: Eip1559Estimation) {
+        self.update_submission(signer, Submission { nonce, gas_price });
+    }
+
+    /// Updates `last_submissions[signer]` to `new` only if `new` is fresher
+    /// than the existing entry, per [`Submission::supersedes`].
+    fn update_submission(&self, signer: eth::Address, new: Submission) {
+        self.last_submissions
+            .entry(signer)
+            .and_modify(|cur| {
+                if new.supersedes(cur) {
+                    *cur = new.clone();
+                }
+            })
+            .or_insert(new);
     }
 
     pub fn config(&self) -> &Config {
@@ -220,5 +327,112 @@ impl Mempool {
             self.config.revert_protection,
             infra::mempool::RevertProtection::Disabled
         )
+    }
+}
+
+fn now_unix_ms() -> u64 {
+    // `Err` only when the system clock is before 1970 — unreachable in
+    // practice. `0` is the sentinel for \"no failure recorded\", so a broken
+    // clock degrades to \"throttle disabled\" rather than panic.
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn gas(max_priority_fee_per_gas: u128, max_fee_per_gas: u128) -> Eip1559Estimation {
+        Eip1559Estimation {
+            max_fee_per_gas,
+            max_priority_fee_per_gas,
+        }
+    }
+
+    fn sub(nonce: u64, prio: u128) -> Submission {
+        Submission {
+            nonce,
+            gas_price: gas(prio, prio * 10),
+        }
+    }
+
+    #[test]
+    fn supersedes() {
+        assert!(sub(11, 100).supersedes(&sub(10, 200)), "higher nonce wins");
+        assert!(
+            sub(10, 200).supersedes(&sub(10, 100)),
+            "same nonce, higher priority fee wins"
+        );
+        assert!(
+            !sub(9, 1_000).supersedes(&sub(10, 100)),
+            "lower nonce never wins"
+        );
+        assert!(
+            !sub(10, 50).supersedes(&sub(10, 100)),
+            "same nonce, lower priority fee never wins"
+        );
+        assert!(
+            !sub(10, 100).supersedes(&sub(10, 100)),
+            "identical is a no-op"
+        );
+    }
+
+    fn empty_mempool() -> Mempool {
+        let url = Url::parse("http://localhost:0").unwrap();
+        Mempool::new(Config::test_config(url), Vec::new())
+    }
+
+    #[test]
+    fn update_submission_speed_up() {
+        let mempool = empty_mempool();
+        let signer = Address::repeat_byte(0xab);
+
+        mempool.update_submission(signer, sub(10, 100));
+        mempool.update_submission(signer, sub(10, 200));
+
+        let stored = mempool.last_submission(signer).unwrap();
+        assert_eq!(stored.nonce, 10);
+        assert_eq!(stored.gas_price.max_priority_fee_per_gas, 200);
+    }
+
+    #[test]
+    fn update_submission_advances_to_higher_nonce() {
+        let mempool = empty_mempool();
+        let signer = Address::repeat_byte(0xab);
+
+        mempool.update_submission(signer, sub(10, 500));
+        mempool.update_submission(signer, sub(11, 100));
+
+        let stored = mempool.last_submission(signer).unwrap();
+        assert_eq!(stored.nonce, 11);
+        assert_eq!(stored.gas_price.max_priority_fee_per_gas, 100);
+    }
+
+    #[test]
+    fn update_submission_rejects_stale_arrivals() {
+        let mempool = empty_mempool();
+        let signer = Address::repeat_byte(0xab);
+
+        mempool.update_submission(signer, sub(11, 100));
+        // Stale insert from an out-of-order submit lands later.
+        mempool.update_submission(signer, sub(10, 9_999));
+
+        let stored = mempool.last_submission(signer).unwrap();
+        assert_eq!(stored.nonce, 11);
+        assert_eq!(stored.gas_price.max_priority_fee_per_gas, 100);
+    }
+
+    #[test]
+    fn update_submission_rejects_same_nonce_lower_fee() {
+        let mempool = empty_mempool();
+        let signer = Address::repeat_byte(0xab);
+
+        mempool.update_submission(signer, sub(10, 200));
+        mempool.update_submission(signer, sub(10, 100));
+
+        let stored = mempool.last_submission(signer).unwrap();
+        assert_eq!(stored.gas_price.max_priority_fee_per_gas, 200);
     }
 }


### PR DESCRIPTION
Fixes a stale-cache issue in driver tx replacement, possibly the cause of unexpected submission rejections. The per-signer `last_submissions` map overwrites on every `submit()`, so a cached entry whose nonce does not match the next nonce did not mean "nothing pending". The old code treated it that way and returned `None`, skipping the gas bump and risking a `nonce too low` rejection.

Now: on cache miss or nonce mismatch, probe the node via `txpool_content_from` and persist the result. The probe has a 500ms timeout and a 30s process-wide cooldown after failure, so a slow or unsupported RPC won't block `/settle`. Cache writes go through `supersedes` (tuple-monotonic on `(nonce, max_priority_fee)`), so concurrent submits or probes cannot regress a fresher entry.

---

## New Functions

Files: `crates/driver/src/domain/mempools.rs`, `crates/driver/src/infra/mempool/mod.rs`

## `Submission::supersedes` (infra/mempool/mod.rs)

Guard for cache writes. Prior code inserted without confirmation on every `submit()`, so out-of-order writes from concurrent submits or probes could regress a fresher entry. Tuple ordering `(nonce, max_priority_fee_per_gas)` means only a higher nonce or a speed-up wins.

## `Mempool::update_submission`

Single funnel for `last_submissions` writes. Wraps `entry().and_modify().or_insert()` gated by `supersedes`. Replaces direct `insert` in `submit()` and is reused by `record_observed`.

## `Mempool::probe_pending_gas`

Bounded `txpool_content_from` probe. Old code called `find_pending_tx_in_mempool` only when cache was empty (first submit after restart). New requirement: probe also when cached nonce differs from `next_nonce` (cache stale, tx still pending). RPC is slow and not universally supported, so there is a 500ms hard timeout to avoid blocking `/settle`, and a 30s process-wide cooldown after failure to avoid repeated timeouts on endpoints without `txpool_*` namespace. `Ok(None)` is not a failure and does not trigger cooldown.

## `Mempool::record_observed`

Persists probe result back into `last_submissions` so next `/settle` skips the RPC. Routes through `update_submission` for the same supersede guard.

## `now_unix_ms`

Unix-ms for cooldown timestamp in `AtomicU64`. `0` sentinel means "no failure recorded". Clock before 1970 degrades to "throttle disabled" rather than panic.

## Call-site rewrite: `minimum_replacement_gas_price` (domain/mempools.rs)

Not a new function, but rewritten to use the probe.

Old logic: cache-miss probes; cache-hit-with-wrong-nonce returns `None`. 

The issue: per-signer map overwrites on every submit, so a wrong-nonce cache entry does not mean nothing is pending. 

New logic: cache-hit-matching-nonce bumps cached price; otherwise probe plus `record_observed` plus bump.
