### PR TITLE
Add Bitget buy-order support via reverse-quote endpoint

### DIFF
--- a/crates/solvers/src/domain/dex/slippage.rs
+++ b/crates/solvers/src/domain/dex/slippage.rs
@@ -81,6 +81,11 @@ impl Slippage {
         bps.to_u32().and_then(|v| v.try_into().ok())
     }
 
+    /// Returns the slippage as a percentage. e.g. 0.01 → 1.0.
+    pub fn as_percent(&self) -> Option<f64> {
+        (&self.0 * BigDecimal::from(100)).to_f64()
+    }
+
     /// Rounds the slippage to the specified number of decimal places.
     pub fn round(&self, decimals: i64) -> Self {
         Self(self.0.round(decimals))

--- a/crates/solvers/src/infra/config/dex/bitget/file.rs
+++ b/crates/solvers/src/infra/config/dex/bitget/file.rs
@@ -28,7 +28,8 @@ struct Config {
     partner_code: String,
 
     /// Whether buy orders should be served via the reverse-quote endpoint.
-    /// Off by default, see the Rust struct doc for caveats.
+    /// Off by default, see [`bitget::Config::enable_buy_orders`] for
+    /// caveats.
     #[serde(default)]
     enable_buy_orders: bool,
 }

--- a/crates/solvers/src/infra/config/dex/bitget/file.rs
+++ b/crates/solvers/src/infra/config/dex/bitget/file.rs
@@ -26,6 +26,11 @@ struct Config {
     /// Partner code sent in the `Partner-Code` header.
     #[serde(default = "default_partner_code")]
     partner_code: String,
+
+    /// Whether buy orders should be served via the reverse-quote endpoint.
+    /// Off by default, see the Rust struct doc for caveats.
+    #[serde(default)]
+    enable_buy_orders: bool,
 }
 
 #[derive(Deserialize)]
@@ -72,6 +77,7 @@ pub async fn load(path: &Path) -> super::Config {
             partner_code: config.partner_code,
             block_stream: base.block_stream.clone(),
             settlement_contract: base.contracts.settlement,
+            enable_buy_orders: config.enable_buy_orders,
         },
         base,
     }

--- a/crates/solvers/src/infra/dex/bitget/dto.rs
+++ b/crates/solvers/src/infra/dex/bitget/dto.rs
@@ -143,6 +143,112 @@ impl SwapTransaction {
     }
 }
 
+/// A Bitget API reverse-swap request (`requestMode = "minAmountOut"`).
+///
+/// Used for buy orders. The `amount` field carries the desired minimum amount
+/// of `to_contract` to receive, and the API returns the input amount of
+/// `from_contract` required (computed via reverse quoting).
+///
+/// See [API](https://web3.bitget.com/en/docs/trading/instruction-mode#reverse-quote-swap-api).
+#[serde_as]
+#[derive(Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ReverseSwapRequest {
+    /// Source token contract address.
+    pub from_contract: eth::Address,
+
+    /// Target token contract address.
+    pub to_contract: eth::Address,
+
+    /// Source chain name. The reverse-quote endpoint is single-chain only.
+    pub from_chain: ChainName,
+
+    /// For `requestMode = "minAmountOut"` this is the desired minimum output
+    /// amount in human-readable decimal units of `to_contract`.
+    #[serde_as(as = "serde_with::DisplayFromStr")]
+    pub amount: BigDecimal,
+
+    /// Always `"minAmountOut"` here. We do not use this endpoint in
+    /// `"exactIn"` mode since the dedicated `/swap` endpoint covers that.
+    pub request_mode: String,
+
+    /// Debit address.
+    pub from_address: eth::Address,
+
+    /// Recipient address.
+    pub to_address: eth::Address,
+
+    /// Slippage tolerance percentage, sent as a string per the docs (e.g.
+    /// `"0.5"` for 0.5%).
+    #[serde_as(as = "serde_with::DisplayFromStr")]
+    pub slippage: f64,
+
+    /// Fee rate in per mille. Must be 0 or between 0.001 and 0.2.
+    pub fee_rate: f64,
+}
+
+impl ReverseSwapRequest {
+    pub fn from_order(
+        order: &dex::Order,
+        chain_name: ChainName,
+        settlement_contract: eth::Address,
+        slippage: &dex::Slippage,
+        buy_decimals: u8,
+    ) -> Self {
+        Self {
+            from_contract: order.sell.0,
+            to_contract: order.buy.0,
+            from_chain: chain_name,
+            amount: super::wei_to_decimal(order.amount.get(), buy_decimals),
+            request_mode: "minAmountOut".to_string(),
+            from_address: settlement_contract,
+            to_address: settlement_contract,
+            slippage: slippage.as_factor().to_f64().unwrap_or_default() * 100.0,
+            fee_rate: 0.0,
+        }
+    }
+}
+
+/// A Bitget API reverse-swap response.
+#[serde_as]
+#[derive(Deserialize, Clone, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct ReverseSwapResponse {
+    /// Input amount the recursion converged on, in decimal units of the
+    /// `from_contract` token.
+    #[serde_as(as = "serde_with::DisplayFromStr")]
+    pub amount_in: BigDecimal,
+
+    /// Expected output amount, in decimal units of the `to_contract` token.
+    /// Slightly above the requested `amount` (the on-chain minimum).
+    #[serde_as(as = "serde_with::DisplayFromStr")]
+    pub expected_amount_out: BigDecimal,
+
+    /// Transactions to execute. Typically a single entry.
+    pub txs: Vec<ReverseSwapTx>,
+}
+
+#[serde_as]
+#[derive(Deserialize, Clone, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct ReverseSwapTx {
+    /// Target contract address (router/spender).
+    pub to: eth::Address,
+
+    /// Hex-encoded calldata with "0x" prefix.
+    pub calldata: String,
+
+    /// Gas limit estimate.
+    #[serde_as(as = "serde_with::DisplayFromStr")]
+    pub gas_limit: u64,
+}
+
+impl ReverseSwapTx {
+    pub fn decode_calldata(&self) -> Result<Vec<u8>, const_hex::FromHexError> {
+        const_hex::decode(&self.calldata)
+    }
+}
+
 /// A Bitget API response wrapper.
 ///
 /// On success `status` is 0 and `data` contains the result.

--- a/crates/solvers/src/infra/dex/bitget/dto.rs
+++ b/crates/solvers/src/infra/dex/bitget/dto.rs
@@ -3,7 +3,7 @@
 
 use {
     crate::domain::{dex, eth},
-    bigdecimal::{BigDecimal, ToPrimitive},
+    bigdecimal::BigDecimal,
     serde::{Deserialize, Serialize},
     serde_with::serde_as,
 };
@@ -98,7 +98,7 @@ impl SwapRequest {
             to_address: settlement_contract,
             // as per a suggestion by the BitGet team for the best routes on EVM chains
             market: "bgwevmaggregator".to_string(),
-            slippage: slippage.as_factor().to_f64().unwrap_or_default() * 100.0,
+            slippage: slippage.as_percent().unwrap_or_default(),
             request_mod: "rich".to_string(),
             fee_rate: Some(0.0),
         }
@@ -198,7 +198,7 @@ impl ReverseSwapRequest {
             request_mode: "minAmountOut".to_string(),
             from_address: settlement_contract,
             to_address: settlement_contract,
-            slippage: slippage.as_factor().to_f64().unwrap_or_default() * 100.0,
+            slippage: slippage.as_percent().unwrap_or_default(),
             fee_rate: 0.0,
         }
     }

--- a/crates/solvers/src/infra/dex/bitget/dto.rs
+++ b/crates/solvers/src/infra/dex/bitget/dto.rs
@@ -4,15 +4,9 @@
 use {
     crate::domain::{dex, eth},
     bigdecimal::{BigDecimal, ToPrimitive},
-    serde::{Deserialize, Serialize, de},
+    serde::{Deserialize, Serialize},
     serde_with::serde_as,
 };
-
-/// Decode a `"0x..."` hex string straight into bytes during deserialization.
-fn deserialize_hex_bytes<'de, D: de::Deserializer<'de>>(d: D) -> Result<Vec<u8>, D::Error> {
-    let s = <&str>::deserialize(d)?;
-    const_hex::decode(s).map_err(de::Error::custom)
-}
 
 /// Bitget chain name used in API requests.
 #[derive(Clone, Copy, Serialize)]
@@ -140,7 +134,7 @@ pub struct SwapTransaction {
     /// Contract address (router/spender).
     pub to: eth::Address,
     /// Decoded calldata bytes (Bitget sends a `"0x..."` hex string).
-    #[serde(deserialize_with = "deserialize_hex_bytes")]
+    #[serde(deserialize_with = "bytes_hex::deserialize")]
     pub data: Vec<u8>,
 }
 
@@ -237,7 +231,7 @@ pub struct ReverseSwapTx {
     pub to: eth::Address,
 
     /// Decoded calldata bytes (Bitget sends a `"0x..."` hex string).
-    #[serde(deserialize_with = "deserialize_hex_bytes")]
+    #[serde(deserialize_with = "bytes_hex::deserialize")]
     pub calldata: Vec<u8>,
 
     /// Function name. Observed values include `"swap"`. Other values

--- a/crates/solvers/src/infra/dex/bitget/dto.rs
+++ b/crates/solvers/src/infra/dex/bitget/dto.rs
@@ -238,6 +238,12 @@ pub struct ReverseSwapTx {
     /// Hex-encoded calldata with "0x" prefix.
     pub calldata: String,
 
+    /// Function name. Observed values include `"swap"`. Other values
+    /// (e.g. `"approve"`) likely appear for setup transactions in
+    /// multi-tx responses.
+    #[serde(default)]
+    pub function: String,
+
     /// Gas limit estimate.
     #[serde_as(as = "serde_with::DisplayFromStr")]
     pub gas_limit: u64,

--- a/crates/solvers/src/infra/dex/bitget/dto.rs
+++ b/crates/solvers/src/infra/dex/bitget/dto.rs
@@ -4,9 +4,15 @@
 use {
     crate::domain::{dex, eth},
     bigdecimal::{BigDecimal, ToPrimitive},
-    serde::{Deserialize, Serialize},
+    serde::{Deserialize, Serialize, de},
     serde_with::serde_as,
 };
+
+/// Decode a `"0x..."` hex string straight into bytes during deserialization.
+fn deserialize_hex_bytes<'de, D: de::Deserializer<'de>>(d: D) -> Result<Vec<u8>, D::Error> {
+    let s = <&str>::deserialize(d)?;
+    const_hex::decode(s).map_err(de::Error::custom)
+}
 
 /// Bitget chain name used in API requests.
 #[derive(Clone, Copy, Serialize)]
@@ -133,14 +139,9 @@ pub struct GasFee {
 pub struct SwapTransaction {
     /// Contract address (router/spender).
     pub to: eth::Address,
-    /// Hex-encoded calldata with "0x" prefix.
-    pub data: String,
-}
-
-impl SwapTransaction {
-    pub fn decode_calldata(&self) -> Result<Vec<u8>, const_hex::FromHexError> {
-        const_hex::decode(&self.data)
-    }
+    /// Decoded calldata bytes (Bitget sends a `"0x..."` hex string).
+    #[serde(deserialize_with = "deserialize_hex_bytes")]
+    pub data: Vec<u8>,
 }
 
 /// A Bitget API reverse-swap request (`requestMode = "minAmountOut"`).
@@ -235,8 +236,9 @@ pub struct ReverseSwapTx {
     /// Target contract address (router/spender).
     pub to: eth::Address,
 
-    /// Hex-encoded calldata with "0x" prefix.
-    pub calldata: String,
+    /// Decoded calldata bytes (Bitget sends a `"0x..."` hex string).
+    #[serde(deserialize_with = "deserialize_hex_bytes")]
+    pub calldata: Vec<u8>,
 
     /// Function name. Observed values include `"swap"`. Other values
     /// (e.g. `"approve"`) likely appear for setup transactions in
@@ -247,12 +249,6 @@ pub struct ReverseSwapTx {
     /// Gas limit estimate.
     #[serde_as(as = "serde_with::DisplayFromStr")]
     pub gas_limit: u64,
-}
-
-impl ReverseSwapTx {
-    pub fn decode_calldata(&self) -> Result<Vec<u8>, const_hex::FromHexError> {
-        const_hex::decode(&self.calldata)
-    }
 }
 
 /// A Bitget API response wrapper.

--- a/crates/solvers/src/infra/dex/bitget/mod.rs
+++ b/crates/solvers/src/infra/dex/bitget/mod.rs
@@ -252,16 +252,18 @@ impl Bitget {
             .send_post_request(SWAP_REVERSE_PATH, &swap_request)
             .await?;
 
-        // Bitget can return a sequence of txs (approve + swap + ...). The
-        // CoW settlement contract already handles approvals via
-        // `dex::Allowance`, and executing unknown setup calls as raw
-        // interactions is risky (wrong spender, double-approve, native
-        // value transfers). Until we observe and classify multi-tx
-        // responses in the wild, only handle the single-swap case.
-        let tx = match response.txs.as_slice() {
-            [tx] => tx,
-            txs => return Err(Error::MultiTxResponse(txs.len())),
-        };
+        // Bitget's reverse-quote builds an EOA-style flow: any setup txs
+        // (typically `approve(router, amount)`) come first and the final
+        // tx is the actual swap. The CoW settlement contract handles its
+        // own approvals via `dex::Allowance`, so we drop the prefix and
+        // execute only the last tx.
+        let tx = response.txs.last().ok_or(Error::NotFound)?;
+        if response.txs.len() > 1 {
+            tracing::debug!(
+                count = response.txs.len(),
+                "Bitget reverse-quote returned multi-tx response, using last as the swap"
+            );
+        }
         let calldata = tx.decode_calldata().map_err(|_| Error::InvalidCalldata)?;
         let contract = tx.to;
 
@@ -437,8 +439,6 @@ pub enum Error {
     GasCalculationFailed,
     #[error("unable to find a quote")]
     NotFound,
-    #[error("expected single tx in reverse-quote response, got {0}")]
-    MultiTxResponse(usize),
     #[error("order type is not supported")]
     OrderNotSupported,
     #[error("rate limited")]

--- a/crates/solvers/src/infra/dex/bitget/mod.rs
+++ b/crates/solvers/src/infra/dex/bitget/mod.rs
@@ -252,7 +252,22 @@ impl Bitget {
             .send_post_request(SWAP_REVERSE_PATH, &swap_request)
             .await?;
 
-        let tx = response.txs.first().ok_or(Error::NotFound)?;
+        // Bitget can return a sequence of txs (approve + swap + ...). The
+        // CoW settlement contract already handles approvals via
+        // `dex::Allowance`, and executing unknown setup calls as raw
+        // interactions is risky (wrong spender, double-approve, native
+        // value transfers). Until we observe and classify multi-tx
+        // responses in the wild, only handle the single-swap case.
+        let tx = match response.txs.as_slice() {
+            [tx] => tx,
+            txs => {
+                tracing::warn!(
+                    count = txs.len(),
+                    "Bitget reverse-quote returned multi-tx response, skipping",
+                );
+                return Err(Error::NotFound);
+            }
+        };
         let calldata = tx.decode_calldata().map_err(|_| Error::InvalidCalldata)?;
         let contract = tx.to;
 

--- a/crates/solvers/src/infra/dex/bitget/mod.rs
+++ b/crates/solvers/src/infra/dex/bitget/mod.rs
@@ -255,14 +255,15 @@ impl Bitget {
         // Bitget's reverse-quote builds an EOA-style flow: a typical
         // multi-tx response is `[approve(router, amountIn), swap(...)]`.
         // The CoW settlement contract handles its own approvals via
-        // `dex::Allowance`, so we drop any `approve` entries and execute
-        // only the actual swap. Iterate in reverse so we pick the last
-        // non-approve tx in case the array order changes.
+        // `dex::Allowance`, so we pick the actual swap tx by function
+        // name and ignore everything else. Positive match on `"swap"` so
+        // that any future setup tx types (`permit`, `wrap`, etc.) are
+        // dropped automatically instead of silently picked up.
         let tx = response
             .txs
             .iter()
             .rev()
-            .find(|tx| !tx.function.eq_ignore_ascii_case("approve"))
+            .find(|tx| tx.function.eq_ignore_ascii_case("swap"))
             .ok_or(Error::NotFound)?;
         let calldata = tx.decode_calldata().map_err(|_| Error::InvalidCalldata)?;
         let contract = tx.to;

--- a/crates/solvers/src/infra/dex/bitget/mod.rs
+++ b/crates/solvers/src/infra/dex/bitget/mod.rs
@@ -103,16 +103,9 @@ pub struct Config {
     /// The stream that yields every new block.
     pub block_stream: Option<CurrentBlockWatcher>,
 
-    /// Whether buy orders should be served via the reverse-quote endpoint.
-    ///
-    /// Disabled by default. Bitget's reverse-quote enforces only a minimum
-    /// output on chain, so the swap typically overshoots the requested
-    /// amount. CoW exact-out semantics still deliver the user only what
-    /// they signed for, and the overshoot accrues to GPv2Settlement's
-    /// internal token balance (the protocol's "buffer", used to internalize
-    /// future swaps). This means up to the configured slippage of user
-    /// surplus is captured by the protocol rather than the user, so we
-    /// keep the path off until the operator opts in.
+    /// Whether to serve buy orders via the reverse-quote endpoint.
+    /// Disabled by default. See [`Bitget::handle_buy_order`] for the
+    /// surplus tradeoff that motivates the opt-in.
     pub enable_buy_orders: bool,
 }
 
@@ -239,9 +232,19 @@ impl Bitget {
 
     /// Handle buy orders via the reverse-quote endpoint.
     ///
-    /// Bitget computes the required input amount server-side using a recursive
-    /// search on top of sell quotes. The response calldata enforces
-    /// `minAmountOut` on chain, so the swap reverts if it underdelivers.
+    /// Bitget computes the required input amount server-side using a
+    /// recursive search on top of sell quotes. The response calldata
+    /// enforces `minAmountOut` on chain, so the swap reverts if it
+    /// underdelivers.
+    ///
+    /// Surplus tradeoff: the swap typically overshoots the requested
+    /// amount because Bitget's recursion converges from above. The user
+    /// receives exactly the buy amount they signed for (CoW exact-out
+    /// semantics), and the overshoot accrues to GPv2Settlement's internal
+    /// token balance (the "buffer", reused to internalize future swaps).
+    /// In effect, up to the configured slippage of user surplus is
+    /// captured by the protocol rather than the user, which is why this
+    /// path is gated behind `enable_buy_orders`.
     async fn handle_buy_order(
         &self,
         order: &dex::Order,

--- a/crates/solvers/src/infra/dex/bitget/mod.rs
+++ b/crates/solvers/src/infra/dex/bitget/mod.rs
@@ -260,13 +260,7 @@ impl Bitget {
         // responses in the wild, only handle the single-swap case.
         let tx = match response.txs.as_slice() {
             [tx] => tx,
-            txs => {
-                tracing::warn!(
-                    count = txs.len(),
-                    "Bitget reverse-quote returned multi-tx response, skipping",
-                );
-                return Err(Error::NotFound);
-            }
+            txs => return Err(Error::MultiTxResponse(txs.len())),
         };
         let calldata = tx.decode_calldata().map_err(|_| Error::InvalidCalldata)?;
         let contract = tx.to;
@@ -278,18 +272,13 @@ impl Bitget {
             .ok_or(Error::GasCalculationFailed)?;
 
         let input_amount = decimal_to_wei(&response.amount_in, sell_decimals, Round::Up)?;
-        let expected_out =
-            decimal_to_wei(&response.expected_amount_out, buy_decimals, Round::Down)?;
 
         // CoW buy orders require the executed buy amount to equal the order's
-        // buy amount exactly. BitGet's reverse-quote enforces a *minimum*
-        // output on chain, so the swap may deliver slightly more, but we
-        // report the exact buy amount here so `Fulfillment::new` accepts the
-        // solution. The slight on-chain overshoot accrues to the settlement
-        // contract buffer as positive surplus.
-        if expected_out < order.amount.get() {
-            return Err(Error::NotFound);
-        }
+        // buy amount exactly. The calldata's on-chain `minAmountOut` check
+        // enforces this, with any overshoot accruing to the settlement
+        // buffer as positive surplus. We don't second-guess `expected_out`
+        // here: it's an estimate, and a strict comparison against
+        // `order.amount.get()` runs into base-unit rounding noise.
         let output_amount = order.amount.get();
 
         Ok(dex::Swap {
@@ -439,6 +428,8 @@ pub enum Error {
     GasCalculationFailed,
     #[error("unable to find a quote")]
     NotFound,
+    #[error("expected single tx in reverse-quote response, got {0}")]
+    MultiTxResponse(usize),
     #[error("order type is not supported")]
     OrderNotSupported,
     #[error("rate limited")]

--- a/crates/solvers/src/infra/dex/bitget/mod.rs
+++ b/crates/solvers/src/infra/dex/bitget/mod.rs
@@ -24,10 +24,14 @@ fn wei_to_decimal(amount: U256, decimals: u8) -> BigDecimal {
 }
 
 /// Convert a decimal amount (from API response) to U256 wei.
-/// e.g., "1964.365496" with 6 decimals → 1964365496
+/// e.g., "1964.365496" with 6 decimals → 1964365496.
+///
+/// `with_scale(0)` rounds away digits past the token's precision. Bitget
+/// sometimes returns more (e.g. `"1.1234567"` for 6-decimal USDC), and
+/// `big_decimal_to_u256` rejects non-integer values.
 fn decimal_to_wei(amount: &BigDecimal, decimals: u8) -> Result<U256, Error> {
     let scaled = amount * BigDecimal::new(1.into(), -i64::from(decimals));
-    big_decimal_to_u256(&scaled).ok_or(Error::AmountConversionFailed)
+    big_decimal_to_u256(&scaled.with_scale(0)).ok_or(Error::AmountConversionFailed)
 }
 
 mod dto;

--- a/crates/solvers/src/infra/dex/bitget/mod.rs
+++ b/crates/solvers/src/infra/dex/bitget/mod.rs
@@ -273,12 +273,21 @@ impl Bitget {
 
         let input_amount = decimal_to_wei(&response.amount_in, sell_decimals, Round::Up)?;
 
+        // Sanity check before we submit anything to the simulator: if Bitget's
+        // own expected output is below the requested buy amount, the
+        // recursion under-converged and the on-chain swap is likely to
+        // revert. Round::Up here so a borderline value (e.g. expected
+        // output exactly equal to the requested amount, with sub-base-unit
+        // dust) doesn't trigger a false rejection.
+        let expected_out = decimal_to_wei(&response.expected_amount_out, buy_decimals, Round::Up)?;
+        if expected_out < order.amount.get() {
+            return Err(Error::NotFound);
+        }
+
         // CoW buy orders require the executed buy amount to equal the order's
         // buy amount exactly. The calldata's on-chain `minAmountOut` check
         // enforces this, with any overshoot accruing to the settlement
-        // buffer as positive surplus. We don't second-guess `expected_out`
-        // here: it's an estimate, and a strict comparison against
-        // `order.amount.get()` runs into base-unit rounding noise.
+        // buffer as positive surplus.
         let output_amount = order.amount.get();
 
         Ok(dex::Swap {

--- a/crates/solvers/src/infra/dex/bitget/mod.rs
+++ b/crates/solvers/src/infra/dex/bitget/mod.rs
@@ -5,7 +5,7 @@ use {
     },
     alloy::primitives::{Address, U256},
     base64::prelude::*,
-    bigdecimal::BigDecimal,
+    bigdecimal::{BigDecimal, RoundingMode},
     ethrpc::block_stream::CurrentBlockWatcher,
     hmac::{Hmac, Mac},
     number::conversions::{big_decimal_to_u256, u256_to_big_uint},
@@ -23,15 +23,34 @@ fn wei_to_decimal(amount: U256, decimals: u8) -> BigDecimal {
     BigDecimal::new(u256_to_big_uint(&amount).into(), i64::from(decimals)).normalized()
 }
 
-/// Convert a decimal amount (from API response) to U256 wei.
-/// e.g., "1964.365496" with 6 decimals → 1964365496.
+/// Rounding direction for converting Bitget's decimal responses to wei.
 ///
-/// `with_scale(0)` rounds away digits past the token's precision. Bitget
-/// sometimes returns more (e.g. `"1.1234567"` for 6-decimal USDC), and
-/// `big_decimal_to_u256` rejects non-integer values.
-fn decimal_to_wei(amount: &BigDecimal, decimals: u8) -> Result<U256, Error> {
+/// Bitget can return more decimal digits than the token has (e.g.
+/// `"1.1234567"` for 6-decimal USDC), so we have to round to the nearest
+/// base unit. The right direction depends on what the value represents:
+/// pick the side that produces positive (not negative) imbalance in the
+/// settlement buffer.
+#[derive(Clone, Copy)]
+enum Round {
+    /// For input amounts (what we pay/approve). Round away from zero so
+    /// the allowance and pulled funds always cover the swap's actual
+    /// input. Under-pulling causes a settlement revert.
+    Up,
+    /// For output amounts (what we report as received). Round toward zero
+    /// so we never claim more buy tokens than the swap delivered.
+    /// Over-claiming causes a settlement revert.
+    Down,
+}
+
+/// Convert a decimal amount (from API response) to U256 wei using the given
+/// rounding direction. e.g., "1964.365496" with 6 decimals → 1964365496.
+fn decimal_to_wei(amount: &BigDecimal, decimals: u8, round: Round) -> Result<U256, Error> {
     let scaled = amount * BigDecimal::new(1.into(), -i64::from(decimals));
-    big_decimal_to_u256(&scaled.with_scale(0)).ok_or(Error::AmountConversionFailed)
+    let mode = match round {
+        Round::Up => RoundingMode::Up,
+        Round::Down => RoundingMode::Down,
+    };
+    big_decimal_to_u256(&scaled.with_scale_round(0, mode)).ok_or(Error::AmountConversionFailed)
 }
 
 mod dto;
@@ -187,7 +206,7 @@ impl Bitget {
             .checked_add(gas_limit / U256::from(2))
             .ok_or(Error::GasCalculationFailed)?;
 
-        let output_amount = decimal_to_wei(&response.out_amount, buy_decimals)?;
+        let output_amount = decimal_to_wei(&response.out_amount, buy_decimals, Round::Down)?;
 
         Ok(dex::Swap {
             calls: vec![dex::Call {
@@ -243,8 +262,9 @@ impl Bitget {
             .checked_add(gas_limit / U256::from(2))
             .ok_or(Error::GasCalculationFailed)?;
 
-        let input_amount = decimal_to_wei(&response.amount_in, sell_decimals)?;
-        let expected_out = decimal_to_wei(&response.expected_amount_out, buy_decimals)?;
+        let input_amount = decimal_to_wei(&response.amount_in, sell_decimals, Round::Up)?;
+        let expected_out =
+            decimal_to_wei(&response.expected_amount_out, buy_decimals, Round::Down)?;
 
         // CoW buy orders require the executed buy amount to equal the order's
         // buy amount exactly. BitGet's reverse-quote enforces a *minimum*

--- a/crates/solvers/src/infra/dex/bitget/mod.rs
+++ b/crates/solvers/src/infra/dex/bitget/mod.rs
@@ -284,12 +284,20 @@ impl Bitget {
 
         let input_amount = decimal_to_wei(&response.amount_in, sell_decimals, Round::Up)?;
 
+        // Sanity check: if Bitget's own estimated output is below what we
+        // asked for, the recursion under-converged and the on-chain swap
+        // (which strictly enforces the requested `minAmountOut`) would
+        // revert. Bail early so we don't waste a simulator roundtrip.
+        // Compare the raw BigDecimals so the check doesn't depend on
+        // rounding direction.
+        let requested_out = wei_to_decimal(order.amount.get(), buy_decimals);
+        if response.expected_amount_out < requested_out {
+            return Err(Error::NotFound);
+        }
+
         // CoW buy orders require the executed buy amount to equal the order's
-        // buy amount exactly. The on-chain `minAmountOut` check in Bitget's
-        // calldata reverts the swap if it would underdeliver, and the
-        // driver simulates settlement before submission, so any genuinely
-        // bad quote is caught downstream. We just report the exact buy
-        // amount here; any overshoot accrues to the settlement buffer.
+        // buy amount exactly. Bitget's calldata enforces this on chain, and
+        // any overshoot accrues to the settlement buffer.
         let output_amount = order.amount.get();
 
         Ok(dex::Swap {

--- a/crates/solvers/src/infra/dex/bitget/mod.rs
+++ b/crates/solvers/src/infra/dex/bitget/mod.rs
@@ -56,6 +56,7 @@ pub struct Bitget {
     partner_code: String,
     chain_name: dto::ChainName,
     settlement_contract: Address,
+    enable_buy_orders: bool,
 }
 
 pub struct Config {
@@ -74,6 +75,12 @@ pub struct Config {
 
     /// The stream that yields every new block.
     pub block_stream: Option<CurrentBlockWatcher>,
+
+    /// Whether buy orders should be served via the reverse-quote endpoint.
+    /// Disabled by default since the on-chain overshoot accrues to the
+    /// settlement buffer rather than to the user, costing up to the
+    /// configured slippage in user surplus.
+    pub enable_buy_orders: bool,
 }
 
 pub struct BitgetCredentialsConfig {
@@ -101,6 +108,7 @@ impl Bitget {
             partner_code: config.partner_code,
             chain_name,
             settlement_contract: config.settlement_contract,
+            enable_buy_orders: config.enable_buy_orders,
         })
     }
 
@@ -110,6 +118,10 @@ impl Bitget {
         slippage: &dex::Slippage,
         tokens: &auction::Tokens,
     ) -> Result<dex::Swap, Error> {
+        if order.side == order::Side::Buy && !self.enable_buy_orders {
+            return Err(Error::OrderNotSupported);
+        }
+
         let sell_decimals = tokens
             .get(&order.sell)
             .and_then(|t| t.decimals)

--- a/crates/solvers/src/infra/dex/bitget/mod.rs
+++ b/crates/solvers/src/infra/dex/bitget/mod.rs
@@ -103,9 +103,9 @@ pub struct Config {
     /// The stream that yields every new block.
     pub block_stream: Option<CurrentBlockWatcher>,
 
-    /// Whether to serve buy orders via the reverse-quote endpoint.
-    /// Disabled by default. See [`Bitget::handle_buy_order`] for the
-    /// surplus tradeoff that motivates the opt-in.
+    /// Whether to serve buy orders via the reverse-quote endpoint. Off by
+    /// default so operators can keep the new path opt-in until they're
+    /// confident in it. See [`Bitget::handle_buy_order`] for behavior.
     pub enable_buy_orders: bool,
 }
 
@@ -237,14 +237,15 @@ impl Bitget {
     /// enforces `minAmountOut` on chain, so the swap reverts if it
     /// underdelivers.
     ///
-    /// Surplus tradeoff: the swap typically overshoots the requested
-    /// amount because Bitget's recursion converges from above. The user
-    /// receives exactly the buy amount they signed for (CoW exact-out
-    /// semantics), and the overshoot accrues to GPv2Settlement's internal
-    /// token balance (the "buffer", reused to internalize future swaps).
-    /// In effect, up to the configured slippage of user surplus is
-    /// captured by the protocol rather than the user, which is why this
-    /// path is gated behind `enable_buy_orders`.
+    /// Note that Bitget's recursion typically converges from above, so
+    /// the swap usually delivers slightly more than the requested buy
+    /// amount. CoW exact-out semantics still deliver the user only what
+    /// they signed for, and the overshoot accrues to GPv2Settlement's
+    /// internal token balance (the "buffer", reused to internalize
+    /// future swaps).
+    ///
+    /// This path is feature-gated via `enable_buy_orders` so it can be
+    /// turned off quickly if anything misbehaves on Bitget's side.
     async fn handle_buy_order(
         &self,
         order: &dex::Order,

--- a/crates/solvers/src/infra/dex/bitget/mod.rs
+++ b/crates/solvers/src/infra/dex/bitget/mod.rs
@@ -27,23 +27,27 @@ fn wei_to_decimal(amount: U256, decimals: u8) -> BigDecimal {
 ///
 /// Bitget can return more decimal digits than the token has (e.g.
 /// `"1.1234567"` for 6-decimal USDC), so we have to round to the nearest
-/// base unit. The right direction depends on what the value represents:
-/// pick the side that produces positive (not negative) imbalance in the
-/// settlement buffer.
+/// base unit. We pick the direction that, when our reported amount and
+/// the swap's actual amount disagree, leaves the GPv2Settlement contract
+/// holding *more* tokens than it owes (rather than fewer). Holding fewer
+/// would cause an ERC20 transfer to revert during settlement.
 #[derive(Clone, Copy)]
 enum Round {
-    /// For input amounts (what we pay/approve). Round away from zero so
-    /// the allowance and pulled funds always cover the swap's actual
-    /// input. Under-pulling causes a settlement revert.
+    /// For input amounts (what we pay/approve). Rounds 1.1234567 USDC up
+    /// to 1123457 base units (vs. 1123456 for `Down`), so the allowance
+    /// and pulled funds cover the swap's actual input. Under-pulling
+    /// causes a settlement revert.
     Up,
-    /// For output amounts (what we report as received). Round toward zero
-    /// so we never claim more buy tokens than the swap delivered.
-    /// Over-claiming causes a settlement revert.
+    /// For output amounts (what we report as received). Rounds 1.1234567
+    /// USDC down to 1123456 base units (vs. 1123457 for `Up`), so we
+    /// don't claim more buy tokens than the swap delivered. Over-claiming
+    /// causes a settlement revert.
     Down,
 }
 
-/// Convert a decimal amount (from API response) to U256 wei using the given
-/// rounding direction. e.g., "1964.365496" with 6 decimals → 1964365496.
+/// Convert a decimal amount (from an API response) to U256 wei using the
+/// given rounding direction. e.g.
+/// `decimal_to_wei("1964.365496", 6, Down) → 1964365496`.
 fn decimal_to_wei(amount: &BigDecimal, decimals: u8, round: Round) -> Result<U256, Error> {
     let scaled = amount * BigDecimal::new(1.into(), -i64::from(decimals));
     let mode = match round {
@@ -100,9 +104,15 @@ pub struct Config {
     pub block_stream: Option<CurrentBlockWatcher>,
 
     /// Whether buy orders should be served via the reverse-quote endpoint.
-    /// Disabled by default since the on-chain overshoot accrues to the
-    /// settlement buffer rather than to the user, costing up to the
-    /// configured slippage in user surplus.
+    ///
+    /// Disabled by default. Bitget's reverse-quote enforces only a minimum
+    /// output on chain, so the swap typically overshoots the requested
+    /// amount. CoW exact-out semantics still deliver the user only what
+    /// they signed for, and the overshoot accrues to GPv2Settlement's
+    /// internal token balance (the protocol's "buffer", used to internalize
+    /// future swaps). This means up to the configured slippage of user
+    /// surplus is captured by the protocol rather than the user, so we
+    /// keep the path off until the operator opts in.
     pub enable_buy_orders: bool,
 }
 
@@ -175,9 +185,10 @@ impl Bitget {
 
     /// Handle sell orders with a single enriched swap API call.
     ///
-    /// Uses `requestMod = "rich"` so the swap endpoint returns both quote
-    /// data (output amount, gas) and calldata in a single response,
-    /// eliminating the race condition window of the previous two-call flow.
+    /// Uses `requestMod = "rich"` so `/swap` returns the quote (output
+    /// amount, gas) and the swap calldata in the same response. Quoting
+    /// and calldata-building share the same block, so the price the
+    /// solver scores is the same price the calldata would execute at.
     async fn handle_sell_order(
         &self,
         order: &dex::Order,
@@ -194,10 +205,7 @@ impl Bitget {
         );
         let response: dto::SwapResponse = self.send_post_request(SWAP_PATH, &swap_request).await?;
 
-        let calldata = response
-            .swap_transaction
-            .decode_calldata()
-            .map_err(|_| Error::InvalidCalldata)?;
+        let calldata = response.swap_transaction.data;
         let contract = response.swap_transaction.to;
 
         // Increase gas estimate by 50% for safety margin, similar to OKX.
@@ -265,7 +273,7 @@ impl Bitget {
             .rev()
             .find(|tx| tx.function.eq_ignore_ascii_case("swap"))
             .ok_or(Error::NotFound)?;
-        let calldata = tx.decode_calldata().map_err(|_| Error::InvalidCalldata)?;
+        let calldata = tx.calldata.clone();
         let contract = tx.to;
 
         // Increase gas estimate by 50% for safety margin, similar to OKX.
@@ -276,21 +284,12 @@ impl Bitget {
 
         let input_amount = decimal_to_wei(&response.amount_in, sell_decimals, Round::Up)?;
 
-        // Sanity check before we submit anything to the simulator: if Bitget's
-        // own expected output is below the requested buy amount, the
-        // recursion under-converged and the on-chain swap is likely to
-        // revert. Round::Up here so a borderline value (e.g. expected
-        // output exactly equal to the requested amount, with sub-base-unit
-        // dust) doesn't trigger a false rejection.
-        let expected_out = decimal_to_wei(&response.expected_amount_out, buy_decimals, Round::Up)?;
-        if expected_out < order.amount.get() {
-            return Err(Error::NotFound);
-        }
-
         // CoW buy orders require the executed buy amount to equal the order's
-        // buy amount exactly. The calldata's on-chain `minAmountOut` check
-        // enforces this, with any overshoot accruing to the settlement
-        // buffer as positive surplus.
+        // buy amount exactly. The on-chain `minAmountOut` check in Bitget's
+        // calldata reverts the swap if it would underdeliver, and the
+        // driver simulates settlement before submission, so any genuinely
+        // bad quote is caught downstream. We just report the exact buy
+        // amount here; any overshoot accrues to the settlement buffer.
         let output_amount = order.amount.get();
 
         Ok(dex::Swap {
@@ -444,8 +443,6 @@ pub enum Error {
     OrderNotSupported,
     #[error("rate limited")]
     RateLimited,
-    #[error("invalid calldata in response")]
-    InvalidCalldata,
     #[error("failed to convert amount between decimal and U256")]
     AmountConversionFailed,
     #[error("decimals are missing for the swapped tokens")]

--- a/crates/solvers/src/infra/dex/bitget/mod.rs
+++ b/crates/solvers/src/infra/dex/bitget/mod.rs
@@ -252,18 +252,18 @@ impl Bitget {
             .send_post_request(SWAP_REVERSE_PATH, &swap_request)
             .await?;
 
-        // Bitget's reverse-quote builds an EOA-style flow: any setup txs
-        // (typically `approve(router, amount)`) come first and the final
-        // tx is the actual swap. The CoW settlement contract handles its
-        // own approvals via `dex::Allowance`, so we drop the prefix and
-        // execute only the last tx.
-        let tx = response.txs.last().ok_or(Error::NotFound)?;
-        if response.txs.len() > 1 {
-            tracing::debug!(
-                count = response.txs.len(),
-                "Bitget reverse-quote returned multi-tx response, using last as the swap"
-            );
-        }
+        // Bitget's reverse-quote builds an EOA-style flow: a typical
+        // multi-tx response is `[approve(router, amountIn), swap(...)]`.
+        // The CoW settlement contract handles its own approvals via
+        // `dex::Allowance`, so we drop any `approve` entries and execute
+        // only the actual swap. Iterate in reverse so we pick the last
+        // non-approve tx in case the array order changes.
+        let tx = response
+            .txs
+            .iter()
+            .rev()
+            .find(|tx| !tx.function.eq_ignore_ascii_case("approve"))
+            .ok_or(Error::NotFound)?;
         let calldata = tx.decode_calldata().map_err(|_| Error::InvalidCalldata)?;
         let contract = tx.to;
 

--- a/crates/solvers/src/infra/dex/bitget/mod.rs
+++ b/crates/solvers/src/infra/dex/bitget/mod.rs
@@ -40,8 +40,12 @@ pub const DEFAULT_ENDPOINT: &str = "https://bopenapi.bgwapi.io/bgw-pro/swapx/pro
 /// expects in the signature.
 const SIGNATURE_API_PATH: &str = "/bgw-pro/swapx/pro/";
 
-/// Bitget API path for getting swap calldata.
+/// Bitget API path for getting swap calldata (sell orders, exact-in).
 const SWAP_PATH: &str = "swap";
+
+/// Bitget API path for the reverse-quote swap endpoint (buy orders,
+/// `requestMode = "minAmountOut"`).
+const SWAP_REVERSE_PATH: &str = "swapr";
 
 /// Bindings to the Bitget swap API.
 pub struct Bitget {
@@ -106,11 +110,6 @@ impl Bitget {
         slippage: &dex::Slippage,
         tokens: &auction::Tokens,
     ) -> Result<dex::Swap, Error> {
-        // Bitget only supports sell orders (exactIn).
-        if order.side == order::Side::Buy {
-            return Err(Error::OrderNotSupported);
-        }
-
         let sell_decimals = tokens
             .get(&order.sell)
             .and_then(|t| t.decimals)
@@ -123,17 +122,47 @@ impl Bitget {
         // Set up a tracing span to make debugging of API requests easier.
         static ID: AtomicU64 = AtomicU64::new(0);
         let id = ID.fetch_add(1, atomic::Ordering::Relaxed);
+        let span = tracing::trace_span!("swap", id = %id);
 
-        let response = self
-            .handle_sell_order(order, slippage, sell_decimals)
-            .instrument(tracing::trace_span!("swap", id = %id))
-            .await?;
+        match order.side {
+            order::Side::Sell => {
+                self.handle_sell_order(order, slippage, sell_decimals, buy_decimals)
+                    .instrument(span)
+                    .await
+            }
+            order::Side::Buy => {
+                self.handle_buy_order(order, slippage, sell_decimals, buy_decimals)
+                    .instrument(span)
+                    .await
+            }
+        }
+    }
+
+    /// Handle sell orders with a single enriched swap API call.
+    ///
+    /// Uses `requestMod = "rich"` so the swap endpoint returns both quote
+    /// data (output amount, gas) and calldata in a single response,
+    /// eliminating the race condition window of the previous two-call flow.
+    async fn handle_sell_order(
+        &self,
+        order: &dex::Order,
+        slippage: &dex::Slippage,
+        sell_decimals: u8,
+        buy_decimals: u8,
+    ) -> Result<dex::Swap, Error> {
+        let swap_request = dto::SwapRequest::from_order(
+            order,
+            self.chain_name,
+            self.settlement_contract,
+            slippage,
+            sell_decimals,
+        );
+        let response: dto::SwapResponse = self.send_post_request(SWAP_PATH, &swap_request).await?;
 
         let calldata = response
             .swap_transaction
             .decode_calldata()
             .map_err(|_| Error::InvalidCalldata)?;
-
         let contract = response.swap_transaction.to;
 
         // Increase gas estimate by 50% for safety margin, similar to OKX.
@@ -165,26 +194,72 @@ impl Bitget {
         })
     }
 
-    /// Handle sell orders with a single enriched swap API call.
+    /// Handle buy orders via the reverse-quote endpoint.
     ///
-    /// Uses `requestMod = "rich"` so the swap endpoint returns both quote
-    /// data (output amount, gas) and calldata in a single response,
-    /// eliminating the race condition window of the previous two-call flow.
-    async fn handle_sell_order(
+    /// Bitget computes the required input amount server-side using a recursive
+    /// search on top of sell quotes. The response calldata enforces
+    /// `minAmountOut` on chain, so the swap reverts if it underdelivers.
+    async fn handle_buy_order(
         &self,
         order: &dex::Order,
         slippage: &dex::Slippage,
         sell_decimals: u8,
-    ) -> Result<dto::SwapResponse, Error> {
-        let swap_request = dto::SwapRequest::from_order(
+        buy_decimals: u8,
+    ) -> Result<dex::Swap, Error> {
+        let swap_request = dto::ReverseSwapRequest::from_order(
             order,
             self.chain_name,
             self.settlement_contract,
             slippage,
-            sell_decimals,
+            buy_decimals,
         );
+        let response: dto::ReverseSwapResponse = self
+            .send_post_request(SWAP_REVERSE_PATH, &swap_request)
+            .await?;
 
-        self.send_post_request(SWAP_PATH, &swap_request).await
+        let tx = response.txs.first().ok_or(Error::NotFound)?;
+        let calldata = tx.decode_calldata().map_err(|_| Error::InvalidCalldata)?;
+        let contract = tx.to;
+
+        // Increase gas estimate by 50% for safety margin, similar to OKX.
+        let gas_limit = U256::from(tx.gas_limit);
+        let gas = gas_limit
+            .checked_add(gas_limit / U256::from(2))
+            .ok_or(Error::GasCalculationFailed)?;
+
+        let input_amount = decimal_to_wei(&response.amount_in, sell_decimals)?;
+        let expected_out = decimal_to_wei(&response.expected_amount_out, buy_decimals)?;
+
+        // CoW buy orders require the executed buy amount to equal the order's
+        // buy amount exactly. BitGet's reverse-quote enforces a *minimum*
+        // output on chain, so the swap may deliver slightly more, but we
+        // report the exact buy amount here so `Fulfillment::new` accepts the
+        // solution. The slight on-chain overshoot accrues to the settlement
+        // contract buffer as positive surplus.
+        if expected_out < order.amount.get() {
+            return Err(Error::NotFound);
+        }
+        let output_amount = order.amount.get();
+
+        Ok(dex::Swap {
+            calls: vec![dex::Call {
+                to: contract,
+                calldata,
+            }],
+            input: eth::Asset {
+                token: order.sell,
+                amount: input_amount,
+            },
+            output: eth::Asset {
+                token: order.buy,
+                amount: output_amount,
+            },
+            allowance: dex::Allowance {
+                spender: contract,
+                amount: dex::Amount::new(input_amount),
+            },
+            gas: eth::Gas(gas),
+        })
     }
 
     /// Generate HMAC-SHA256 signature for the Bitget API.

--- a/crates/solvers/src/tests/bitget/api_calls.rs
+++ b/crates/solvers/src/tests/bitget/api_calls.rs
@@ -84,6 +84,7 @@ async fn swap_sell_all_chains() {
             partner_code: "cowswap".to_string(),
             settlement_contract: address!("0x9008d19f58aabd9ed0d60971565aa8510560ab41"),
             block_stream: None,
+            enable_buy_orders: false,
         };
 
         let order = Order {
@@ -164,6 +165,7 @@ async fn swap_buy_all_chains() {
             partner_code: "cowswap".to_string(),
             settlement_contract: address!("0x9008d19f58aabd9ed0d60971565aa8510560ab41"),
             block_stream: None,
+            enable_buy_orders: true,
         };
 
         // Flip sell/buy so that we probe `buy_token = WETH` for a fixed amount,
@@ -228,4 +230,40 @@ async fn swap_buy_all_chains() {
             order.amount().amount
         );
     }
+}
+
+#[tokio::test]
+async fn swap_buy_disabled() {
+    // With `enable_buy_orders` off (the default), buy orders must short-circuit
+    // to `OrderNotSupported` without touching the API.
+    let config = bitget_dex::Config {
+        endpoint: reqwest::Url::parse(bitget_dex::DEFAULT_ENDPOINT).unwrap(),
+        chain_id: crate::domain::eth::ChainId::Mainnet,
+        credentials: bitget_dex::BitgetCredentialsConfig {
+            api_key: String::new(),
+            api_secret: String::new(),
+        },
+        partner_code: "cowswap".to_string(),
+        settlement_contract: address!("0x9008d19f58aabd9ed0d60971565aa8510560ab41"),
+        block_stream: None,
+        enable_buy_orders: false,
+    };
+
+    let order = Order {
+        buy: TokenAddress::from(address!("0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2")),
+        sell: TokenAddress::from(address!("0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48")),
+        side: crate::domain::order::Side::Buy,
+        amount: Amount::new(U256::from(1000000000_u128)),
+        owner: address!("0x6f9ffea7370310cd0f890dfde5e0e061059dcfb8"),
+    };
+
+    let slippage = Slippage::one_percent();
+    let tokens = auction::Tokens(HashMap::new());
+
+    let bitget = bitget_dex::Bitget::try_new(config).unwrap();
+    let swap_response = bitget.swap(&order, &slippage, &tokens).await;
+    assert!(matches!(
+        swap_response.unwrap_err(),
+        bitget_dex::Error::OrderNotSupported
+    ));
 }

--- a/crates/solvers/src/tests/bitget/api_calls.rs
+++ b/crates/solvers/src/tests/bitget/api_calls.rs
@@ -145,35 +145,87 @@ async fn swap_sell_all_chains() {
     }
 }
 
+#[ignore]
 #[tokio::test]
-async fn swap_buy_not_supported() {
-    let config = bitget_dex::Config {
-        endpoint: reqwest::Url::parse(bitget_dex::DEFAULT_ENDPOINT).unwrap(),
-        chain_id: crate::domain::eth::ChainId::Mainnet,
-        credentials: bitget_dex::BitgetCredentialsConfig {
-            api_key: String::new(),
-            api_secret: String::new(),
-        },
-        partner_code: "cowswap".to_string(),
-        settlement_contract: address!("0x9008d19f58aabd9ed0d60971565aa8510560ab41"),
-        block_stream: None,
-    };
+// To run this test, set the following environment variables accordingly to your
+// Bitget setup: BITGET_API_KEY, BITGET_API_SECRET
+async fn swap_buy_all_chains() {
+    let api_key = env::var("BITGET_API_KEY").unwrap();
+    let api_secret = env::var("BITGET_API_SECRET").unwrap();
 
-    let order = Order {
-        buy: TokenAddress::from(address!("0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2")),
-        sell: TokenAddress::from(address!("0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48")),
-        side: crate::domain::order::Side::Buy,
-        amount: Amount::new(U256::from(1000000000_u128)),
-        owner: address!("0x6f9ffea7370310cd0f890dfde5e0e061059dcfb8"),
-    };
+    for tc in TEST_CASES {
+        let config = bitget_dex::Config {
+            endpoint: reqwest::Url::parse(bitget_dex::DEFAULT_ENDPOINT).unwrap(),
+            chain_id: tc.chain_id,
+            credentials: bitget_dex::BitgetCredentialsConfig {
+                api_key: api_key.clone(),
+                api_secret: api_secret.clone(),
+            },
+            partner_code: "cowswap".to_string(),
+            settlement_contract: address!("0x9008d19f58aabd9ed0d60971565aa8510560ab41"),
+            block_stream: None,
+        };
 
-    let slippage = Slippage::one_percent();
-    let tokens = auction::Tokens(HashMap::new());
+        // Flip sell/buy so that we probe `buy_token = WETH` for a fixed amount,
+        // mirroring the native-price probe shape.
+        let buy_amount = tc.sell_amount;
+        let order = Order {
+            sell: TokenAddress::from(tc.buy_token),
+            buy: TokenAddress::from(tc.sell_token),
+            side: crate::domain::order::Side::Buy,
+            amount: Amount::new(U256::from(buy_amount)),
+            owner: address!("0x6f9ffea7370310cd0f890dfde5e0e061059dcfb8"),
+        };
 
-    let bitget = bitget_dex::Bitget::try_new(config).unwrap();
-    let swap_response = bitget.swap(&order, &slippage, &tokens).await;
-    assert!(matches!(
-        swap_response.unwrap_err(),
-        bitget_dex::Error::OrderNotSupported
-    ));
+        let slippage = Slippage::one_percent();
+
+        let mut token_map = HashMap::new();
+        token_map.insert(
+            order.sell,
+            auction::Token {
+                decimals: Some(tc.buy_decimals),
+                symbol: None,
+                reference_price: None,
+                available_balance: U256::ZERO,
+                trusted: false,
+            },
+        );
+        token_map.insert(
+            order.buy,
+            auction::Token {
+                decimals: Some(tc.sell_decimals),
+                symbol: None,
+                reference_price: None,
+                available_balance: U256::ZERO,
+                trusted: false,
+            },
+        );
+        let tokens = auction::Tokens(token_map);
+
+        let bitget = bitget_dex::Bitget::try_new(config).unwrap();
+        let swap = bitget
+            .swap(&order, &slippage, &tokens)
+            .await
+            .unwrap_or_else(|e| panic!("[{}] swap failed: {e}", tc.name));
+
+        assert_eq!(
+            swap.input.token, order.sell,
+            "[{}] input token mismatch",
+            tc.name
+        );
+        assert_eq!(
+            swap.output.token, order.buy,
+            "[{}] output token mismatch",
+            tc.name
+        );
+        // Reverse-quote should produce a swap whose expected output meets or
+        // exceeds the requested buy amount.
+        assert!(
+            swap.output.amount >= order.amount().amount,
+            "[{}] expected output {} < requested {}",
+            tc.name,
+            swap.output.amount,
+            order.amount().amount
+        );
+    }
 }

--- a/crates/solvers/src/tests/bitget/api_calls.rs
+++ b/crates/solvers/src/tests/bitget/api_calls.rs
@@ -68,24 +68,26 @@ const TEST_CASES: &[TestCase] = &[
     },
 ];
 
-#[ignore]
-#[tokio::test]
 // To run this test, set the following environment variables accordingly to your
 // Bitget setup: BITGET_API_KEY, BITGET_API_SECRET
+#[ignore]
+#[tokio::test]
 async fn swap_sell_all_chains() {
     let api_key = env::var("BITGET_API_KEY").unwrap();
     let api_secret = env::var("BITGET_API_SECRET").unwrap();
+    let endpoint = reqwest::Url::parse(bitget_dex::DEFAULT_ENDPOINT).unwrap();
+    const SETTLEMENT: Address = address!("0x9008d19f58aabd9ed0d60971565aa8510560ab41");
 
     for tc in TEST_CASES {
         let config = bitget_dex::Config {
-            endpoint: reqwest::Url::parse(bitget_dex::DEFAULT_ENDPOINT).unwrap(),
+            endpoint: endpoint.clone(),
             chain_id: tc.chain_id,
             credentials: bitget_dex::BitgetCredentialsConfig {
                 api_key: api_key.clone(),
                 api_secret: api_secret.clone(),
             },
             partner_code: "cowswap".to_string(),
-            settlement_contract: address!("0x9008d19f58aabd9ed0d60971565aa8510560ab41"),
+            settlement_contract: SETTLEMENT,
             block_stream: None,
             enable_buy_orders: false,
         };
@@ -151,24 +153,26 @@ async fn swap_sell_all_chains() {
     }
 }
 
-#[ignore]
-#[tokio::test]
 // To run this test, set the following environment variables accordingly to your
 // Bitget setup: BITGET_API_KEY, BITGET_API_SECRET
+#[ignore]
+#[tokio::test]
 async fn swap_buy_all_chains() {
     let api_key = env::var("BITGET_API_KEY").unwrap();
     let api_secret = env::var("BITGET_API_SECRET").unwrap();
+    let endpoint = reqwest::Url::parse(bitget_dex::DEFAULT_ENDPOINT).unwrap();
+    const SETTLEMENT: Address = address!("0x9008d19f58aabd9ed0d60971565aa8510560ab41");
 
     for tc in TEST_CASES {
         let config = bitget_dex::Config {
-            endpoint: reqwest::Url::parse(bitget_dex::DEFAULT_ENDPOINT).unwrap(),
+            endpoint: endpoint.clone(),
             chain_id: tc.chain_id,
             credentials: bitget_dex::BitgetCredentialsConfig {
                 api_key: api_key.clone(),
                 api_secret: api_secret.clone(),
             },
             partner_code: "cowswap".to_string(),
-            settlement_contract: address!("0x9008d19f58aabd9ed0d60971565aa8510560ab41"),
+            settlement_contract: SETTLEMENT,
             block_stream: None,
             enable_buy_orders: true,
         };

--- a/crates/solvers/src/tests/bitget/api_calls.rs
+++ b/crates/solvers/src/tests/bitget/api_calls.rs
@@ -10,6 +10,10 @@ use {
 /// Pause between chain iterations to stay under Bitget's per-IP rate limit.
 const RATE_LIMIT_PAUSE: Duration = Duration::from_secs(1);
 
+/// CoW Protocol GPv2Settlement contract, same address on every supported
+/// chain.
+const SETTLEMENT: Address = address!("0x9008d19f58aabd9ed0d60971565aa8510560ab41");
+
 struct TestCase {
     name: &'static str,
     chain_id: ChainId,
@@ -76,7 +80,6 @@ async fn swap_sell_all_chains() {
     let api_key = env::var("BITGET_API_KEY").unwrap();
     let api_secret = env::var("BITGET_API_SECRET").unwrap();
     let endpoint = reqwest::Url::parse(bitget_dex::DEFAULT_ENDPOINT).unwrap();
-    const SETTLEMENT: Address = address!("0x9008d19f58aabd9ed0d60971565aa8510560ab41");
 
     for tc in TEST_CASES {
         let config = bitget_dex::Config {
@@ -161,7 +164,6 @@ async fn swap_buy_all_chains() {
     let api_key = env::var("BITGET_API_KEY").unwrap();
     let api_secret = env::var("BITGET_API_SECRET").unwrap();
     let endpoint = reqwest::Url::parse(bitget_dex::DEFAULT_ENDPOINT).unwrap();
-    const SETTLEMENT: Address = address!("0x9008d19f58aabd9ed0d60971565aa8510560ab41");
 
     for tc in TEST_CASES {
         let config = bitget_dex::Config {

--- a/crates/solvers/src/tests/bitget/api_calls.rs
+++ b/crates/solvers/src/tests/bitget/api_calls.rs
@@ -4,8 +4,11 @@ use {
         infra::dex::bitget as bitget_dex,
     },
     alloy::primitives::{Address, address},
-    std::{collections::HashMap, env},
+    std::{collections::HashMap, env, time::Duration},
 };
+
+/// Pause between chain iterations to stay under Bitget's per-IP rate limit.
+const RATE_LIMIT_PAUSE: Duration = Duration::from_secs(1);
 
 struct TestCase {
     name: &'static str,
@@ -143,6 +146,8 @@ async fn swap_sell_all_chains() {
             "[{}] output token mismatch",
             tc.name
         );
+
+        tokio::time::sleep(RATE_LIMIT_PAUSE).await;
     }
 }
 
@@ -229,6 +234,8 @@ async fn swap_buy_all_chains() {
             swap.output.amount,
             order.amount().amount
         );
+
+        tokio::time::sleep(RATE_LIMIT_PAUSE).await;
     }
 }
 

--- a/crates/solvers/src/tests/bitget/market_order.rs
+++ b/crates/solvers/src/tests/bitget/market_order.rs
@@ -211,7 +211,8 @@ async fn buy() {
     ])
     .await;
 
-    let engine = tests::SolverEngine::new("bitget", super::config(&api.address)).await;
+    let engine =
+        tests::SolverEngine::new("bitget", super::config_with_buy_orders(&api.address)).await;
 
     let solution = engine
         .solve(json!({
@@ -316,4 +317,66 @@ async fn buy() {
            ]
         }),
     );
+}
+
+#[tokio::test]
+async fn buy_disabled() {
+    // Default config has `enable-buy-orders` off, so the solver must not call
+    // either swap endpoint and must produce no solution for a buy order.
+    let api = mock::http::setup(vec![]).await;
+
+    let engine = tests::SolverEngine::new("bitget", super::config(&api.address)).await;
+
+    let solution = engine
+        .solve(json!({
+            "id": "1",
+            "tokens": {
+                "0xe41d2489571d322189246dafa5ebde1f4699f498": {
+                    "decimals": 18,
+                    "symbol": "ZRX",
+                    "referencePrice": "4327903683155778",
+                    "availableBalance": "1583034704488033979459",
+                    "trusted": true,
+                },
+                "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2": {
+                    "decimals": 18,
+                    "symbol": "WETH",
+                    "referencePrice": "1000000000000000000",
+                    "availableBalance": "482725140468789680",
+                    "trusted": true,
+                },
+            },
+            "orders": [
+                {
+                    "uid": "0x2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a\
+                              2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a\
+                              2a2a2a2a",
+                    "sellToken": "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
+                    "buyToken": "0xe41d2489571d322189246dafa5ebde1f4699f498",
+                    "sellAmount": "1000000000000000000",
+                    "buyAmount": "200000000000000000000",
+                    "fullSellAmount": "1000000000000000000",
+                    "fullBuyAmount": "200000000000000000000",
+                    "kind": "buy",
+                    "partiallyFillable": false,
+                    "class": "market",
+                    "sellTokenSource": "erc20",
+                    "buyTokenDestination": "erc20",
+                    "preInteractions": [],
+                    "postInteractions": [],
+                    "owner": "0x5b1e2c2762667331bc91648052f646d1b0d35984",
+                    "validTo": 0,
+                    "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
+                    "signingScheme": "presign",
+                    "signature": "0x",
+                }
+            ],
+            "liquidity": [],
+            "effectiveGasPrice": "15000000000",
+            "deadline": "2106-01-01T00:00:00.000Z",
+            "surplusCapturingJitOrderOwners": []
+        }))
+        .await;
+
+    assert_eq!(solution, json!({ "solutions": [] }));
 }

--- a/crates/solvers/src/tests/bitget/market_order.rs
+++ b/crates/solvers/src/tests/bitget/market_order.rs
@@ -156,8 +156,60 @@ async fn sell() {
 }
 
 #[tokio::test]
-async fn buy_not_supported() {
-    let api = mock::http::setup(vec![]).await;
+async fn buy() {
+    let api = mock::http::setup(vec![
+        mock::http::Expectation::Post {
+            path: mock::http::Path::exact("bgw-pro/swapx/pro/swapr"),
+            req: mock::http::RequestBody::Partial(
+                json!({
+                    "fromContract": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+                    "toContract": "0xe41d2489571d322189246dafa5ebde1f4699f498",
+                    "fromChain": "eth",
+                    "amount": "200",
+                    "requestMode": "minAmountOut",
+                    "slippage": "1",
+                    "feeRate": 0.0
+                }),
+                vec!["fromAddress", "toAddress"],
+            ),
+            // Mock the reverse-quote response. `expectedAmountOut` is a small
+            // overshoot above the requested 200, simulating BitGet's recursion
+            // landing slightly above the target. We report the exact buy
+            // amount in the solution (CoW exact-out semantics) and the
+            // overshoot becomes positive surplus on chain.
+            res: json!({
+                "status": 0,
+                "data": {
+                    "amountIn": "0.99",
+                    "expectedAmountOut": "200.5",
+                    "minAmountOut": "200",
+                    "priceImpact": "0",
+                    "recommendSlippage": 0.5,
+                    "expiresAt": 0,
+                    "market": "bgwevmaggregator",
+                    "txs": [
+                        {
+                            "chainId": 1,
+                            "to": "0x7D0CcAa3Fac1e5A943c5168b6CEd828691b46B36",
+                            "calldata": "0x0d5f0e3b00000000000000000001a0cf2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a\
+                                 0000000000000000000000000000000000000000000000000de0b6b3a7640000\
+                                 00000000000000000000000000000000000000000000015fdc8278903f7f31c1\
+                                 0000000000000000000000000000000000000000000000000000000000000080\
+                                 0000000000000000000000000000000000000000000000000000000000000001\
+                                 00000000000000000000000014424eeecbff345b38187d0b8b749e56faa68539",
+                            "function": "swap",
+                            "gasLimit": "202500",
+                            "gasPrice": "0",
+                            "nonce": 0,
+                            "value": "0"
+                        }
+                    ],
+                    "fee": {}
+                }
+            }),
+        },
+    ])
+    .await;
 
     let engine = tests::SolverEngine::new("bitget", super::config(&api.address)).await;
 
@@ -212,6 +264,56 @@ async fn buy_not_supported() {
         }))
         .await;
 
-    // Buy orders are not supported by Bitget.
-    assert_eq!(solution, json!({ "solutions": [] }),);
+    assert_eq!(
+        solution,
+        json!({
+           "solutions":[
+              {
+                 "gas": 410141,
+                 "id": 0,
+                 "interactions":[
+                    {
+                       "allowances":[
+                          {
+                             "amount": "990000000000000000",
+                             "spender": "0x7d0ccaa3fac1e5a943c5168b6ced828691b46b36",
+                             "token": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"
+                          }
+                       ],
+                       "callData": "0x0d5f0e3b00000000000000000001a0cf2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a0000000000000000000000000000000000000000000000000de0b6b3a764000000000000000000000000000000000000000000000000015fdc8278903f7f31c10000000000000000000000000000000000000000000000000000000000000080000000000000000000000000000000000000000000000000000000000000000100000000000000000000000014424eeecbff345b38187d0b8b749e56faa68539",
+                       "inputs":[
+                          {
+                             "amount": "990000000000000000",
+                             "token": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"
+                          }
+                       ],
+                       "internalize": true,
+                       "kind": "custom",
+                       "outputs":[
+                          {
+                             "amount": "200000000000000000000",
+                             "token": "0xe41d2489571d322189246dafa5ebde1f4699f498"
+                          }
+                       ],
+                       "target": "0x7d0ccaa3fac1e5a943c5168b6ced828691b46b36",
+                       "value": "0"
+                    }
+                 ],
+                 "postInteractions": [],
+                 "preInteractions": [],
+                 "prices":{
+                    "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2": "200000000000000000000",
+                    "0xe41d2489571d322189246dafa5ebde1f4699f498": "990000000000000000"
+                 },
+                 "trades":[
+                    {
+                       "executedAmount": "200000000000000000000",
+                       "kind": "fulfillment",
+                       "order": "0x2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a"
+                    }
+                 ]
+              }
+           ]
+        }),
+    );
 }

--- a/crates/solvers/src/tests/bitget/mod.rs
+++ b/crates/solvers/src/tests/bitget/mod.rs
@@ -5,7 +5,8 @@ mod market_order;
 mod not_found;
 mod out_of_price;
 
-/// Creates a temporary file containing the config of the given solver.
+/// Creates a temporary file containing the default config (buy orders
+/// disabled).
 pub fn config(solver_addr: &SocketAddr) -> tests::Config {
     tests::Config::String(format!(
         r"
@@ -13,6 +14,22 @@ node-url = 'http://localhost:8545'
 [dex]
 chain-id = '1'
 endpoint = 'http://{solver_addr}/bgw-pro/swapx/pro/'
+[dex.credentials]
+api-key = 'test-api-key'
+api-secret = 'test-api-secret-1234'
+",
+    ))
+}
+
+/// Creates a config with buy orders enabled via the reverse-quote endpoint.
+pub fn config_with_buy_orders(solver_addr: &SocketAddr) -> tests::Config {
+    tests::Config::String(format!(
+        r"
+node-url = 'http://localhost:8545'
+[dex]
+chain-id = '1'
+endpoint = 'http://{solver_addr}/bgw-pro/swapx/pro/'
+enable-buy-orders = true
 [dex.credentials]
 api-key = 'test-api-key'
 api-secret = 'test-api-secret-1234'


### PR DESCRIPTION
# Description
Bitget's `/swapr` endpoint supports buy quotes (`requestMode = "minAmountOut"`) by running a recursion server-side on top of sell quotes. Wiring this up unlocks Bitget as a native-price source for the long tail of tokens that other estimators cover poorly. Today the integration only supports sell orders.

The reverse-quote on real auction buy orders is correct end-to-end (positive overshoot accrues to the settlement buffer, the user receives exactly their signed buy amount, GPv2Settlement does no expected-vs-actual interaction-output check), but it can cost the user up to the configured slippage in surplus, so it's gated behind a config flag and off by default.

# Changes
- New `Side::Buy` code path in the Bitget integration, calling `/bgw-pro/swapx/pro/swapr` with `requestMode = "minAmountOut"`
- Caps the reported swap output to `order.buy.amount` so CoW exact-out fulfillment passes
- New `enable-buy-orders` config flag, off by default, gating the buy path
- `decimal_to_wei` now rounds to the token's precision (Bitget can return more decimal digits than the token has)
- Rate-limit pause between iterations in the live multi-chain test

# How to test
Existing tests plus new mock + ignored live tests. Run the live one with credentials:

```
BITGET_API_KEY=... BITGET_API_SECRET=... \
  cargo nextest run -p solvers --run-ignored only swap_buy_all_chains
```