### PR TITLE
driver: Deadline-based cancellation to terminate stale auction work early

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3965,6 +3965,7 @@ dependencies = [
  "tikv-jemallocator",
  "token-info",
  "tokio",
+ "tokio-util",
  "toml",
  "tower 0.5.3",
  "tower-http",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -136,8 +136,8 @@ tikv-jemallocator = { version = "0.6", features = ["profiling", "unprefixed_mall
 time = "0.3.47"
 token-info = { path = "crates/token-info" }
 tokio = { version = "1.38.0", features = ["tracing"] }
-tokio-util = { version = "0.7.18" }
 tokio-stream = { version = "0.1.15", features = ["sync"] }
+tokio-util = { version = "0.7.18" }
 toml = "0.8.14"
 tower = "0.5"
 tower-http = "0.6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -136,6 +136,7 @@ tikv-jemallocator = { version = "0.6", features = ["profiling", "unprefixed_mall
 time = "0.3.47"
 token-info = { path = "crates/token-info" }
 tokio = { version = "1.38.0", features = ["tracing"] }
+tokio-util = { version = "0.7.18" }
 tokio-stream = { version = "0.1.15", features = ["sync"] }
 toml = "0.8.14"
 tower = "0.5"

--- a/crates/driver/Cargo.toml
+++ b/crates/driver/Cargo.toml
@@ -71,6 +71,7 @@ thiserror = { workspace = true }
 tikv-jemallocator = { workspace = true }
 token-info = { workspace = true }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread", "signal", "time"] }
+tokio-util = { workspace = true }
 toml = { workspace = true }
 tower = { workspace = true }
 tower-http = { workspace = true, features = ["decompression-br", "limit", "trace"] }

--- a/crates/driver/src/domain/competition/deadline_cancellation.rs
+++ b/crates/driver/src/domain/competition/deadline_cancellation.rs
@@ -1,0 +1,78 @@
+use {
+    crate::domain::time::Remaining,
+    chrono::{DateTime, Utc},
+    tokio::task::JoinHandle,
+    tokio_util::sync::CancellationToken,
+};
+
+/// Struct used to cancel a token when the auction driver deadline is reached.
+#[derive(Debug)]
+pub struct DeadlineCancellation {
+    // The cancellation token
+    token: CancellationToken,
+    // Task that cancels the cancellation token
+    guard: JoinHandle<()>,
+}
+
+impl DeadlineCancellation {
+    /// Spawns a task that cancels the token at `deadline`.
+    pub fn new(deadline: DateTime<Utc>) -> Self {
+        let token = CancellationToken::new();
+        let cancel = token.clone();
+
+        let guard = tokio::spawn(async move {
+            if let Ok(remaining) = deadline.remaining() {
+                tokio::time::sleep(remaining).await;
+            }
+
+            cancel.cancel();
+        });
+
+        Self { token, guard }
+    }
+
+    /// Returns the cancellation token.
+    pub fn token(&self) -> CancellationToken {
+        self.token.clone()
+    }
+}
+
+impl Drop for DeadlineCancellation {
+    fn drop(&mut self) {
+        self.guard.abort();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use {chrono::Utc, std::time::Duration};
+    use crate::domain::competition::deadline_cancellation::DeadlineCancellation;
+
+    #[tokio::test]
+    async fn cancels_after_deadline() {
+        let deadline = Utc::now() + chrono::Duration::milliseconds(20);
+        let cancellation = DeadlineCancellation::new(deadline);
+
+        tokio::time::timeout(Duration::from_secs(1), cancellation.token().cancelled())
+            .await
+            .expect("deadline cancellation");
+    }
+
+    #[tokio::test]
+    async fn not_cancelled_before_deadline() {
+        let deadline = Utc::now() + chrono::Duration::seconds(60);
+        let cancellation = DeadlineCancellation::new(deadline);
+
+        assert!(!cancellation.token().is_cancelled());
+    }
+
+    #[tokio::test]
+    async fn cancels_immediately_when_expired() {
+        let deadline = Utc::now() - chrono::Duration::milliseconds(1);
+        let cancellation = DeadlineCancellation::new(deadline);
+
+        tokio::time::timeout(Duration::from_secs(1), cancellation.token().cancelled())
+            .await
+            .expect("expired deadline should cancel");
+    }
+}

--- a/crates/driver/src/domain/competition/deadline_cancellation.rs
+++ b/crates/driver/src/domain/competition/deadline_cancellation.rs
@@ -45,8 +45,11 @@ impl Drop for DeadlineCancellation {
 
 #[cfg(test)]
 mod tests {
-    use {chrono::Utc, std::time::Duration};
-    use crate::domain::competition::deadline_cancellation::DeadlineCancellation;
+    use {
+        crate::domain::competition::deadline_cancellation::DeadlineCancellation,
+        chrono::Utc,
+        std::time::Duration,
+    };
 
     #[tokio::test]
     async fn cancels_after_deadline() {

--- a/crates/driver/src/domain/competition/deadline_cancellation.rs
+++ b/crates/driver/src/domain/competition/deadline_cancellation.rs
@@ -5,7 +5,8 @@ use {
     tokio_util::sync::CancellationToken,
 };
 
-/// Struct used to cancel a token when the auction driver deadline is reached.
+/// Cancels a token when the configured deadline is reached, if dropped before
+/// the deadline is reached, will not trigger token cancellation.
 #[derive(Debug)]
 pub struct DeadlineCancellation {
     // The cancellation token
@@ -18,16 +19,19 @@ impl DeadlineCancellation {
     /// Spawns a task that cancels the token at `deadline`.
     pub fn new(deadline: DateTime<Utc>) -> Self {
         let token = CancellationToken::new();
-        let cancel = token.clone();
-
-        let guard = tokio::spawn(async move {
-            if let Ok(remaining) = deadline.remaining() {
-                tokio::time::sleep(remaining).await;
+        let guard = match deadline.remaining() {
+            Ok(remaining) => {
+                let cancel = token.clone();
+                tokio::spawn(async move {
+                    tokio::time::sleep(remaining).await;
+                    cancel.cancel();
+                })
             }
-
-            cancel.cancel();
-        });
-
+            Err(_) => {
+                token.cancel();
+                tokio::spawn(async {}) // no-op
+            }
+        };
         Self { token, guard }
     }
 
@@ -53,10 +57,10 @@ mod tests {
 
     #[tokio::test]
     async fn cancels_after_deadline() {
-        let deadline = Utc::now() + chrono::Duration::milliseconds(20);
+        let deadline = Utc::now() + chrono::Duration::seconds(1);
         let cancellation = DeadlineCancellation::new(deadline);
 
-        tokio::time::timeout(Duration::from_secs(1), cancellation.token().cancelled())
+        tokio::time::timeout(Duration::from_secs(2), cancellation.token().cancelled())
             .await
             .expect("deadline cancellation");
     }
@@ -74,8 +78,17 @@ mod tests {
         let deadline = Utc::now() - chrono::Duration::milliseconds(1);
         let cancellation = DeadlineCancellation::new(deadline);
 
-        tokio::time::timeout(Duration::from_secs(1), cancellation.token().cancelled())
-            .await
-            .expect("expired deadline should cancel");
+        assert!(cancellation.token().is_cancelled());
+    }
+
+    #[tokio::test]
+    async fn drop_aborts_timer_without_cancelling_token() {
+        let deadline = Utc::now() + chrono::Duration::seconds(1);
+        let cancellation = DeadlineCancellation::new(deadline);
+        let token = cancellation.token();
+        drop(cancellation);
+        tokio::time::sleep(Duration::from_secs(2)).await;
+
+        assert!(!token.is_cancelled());
     }
 }

--- a/crates/driver/src/domain/competition/mod.rs
+++ b/crates/driver/src/domain/competition/mod.rs
@@ -1,3 +1,4 @@
+use tokio_util::sync::CancellationToken;
 use {
     self::solution::settlement,
     super::{
@@ -331,6 +332,11 @@ impl Competition {
             Err(err) => return Err(err.into()),
         };
 
+        let deadline = auction.deadline(self.solver.timeouts()).driver();
+        let deadline_cancellation =
+            deadline_cancellation::DeadlineCancellation::new(deadline);
+        let deadline_cancel = deadline_cancellation.token();
+
         let solver_address = self.solver.address();
         let order_sorting_strategies = self.order_sorting_strategies.clone();
 
@@ -338,10 +344,12 @@ impl Competition {
         let cow_amm_orders = tasks.cow_amm_orders.await?;
         auction.orders.extend(cow_amm_orders.iter().cloned());
 
+        let sort_cancel = deadline_cancel.clone();
+
         let sort_orders_future = Self::run_blocking_with_timer("sort_orders", move || {
             // Use spawn_blocking() because a lot of CPU bound computations are happening
             // and we don't want to block the runtime for too long.
-            Self::sort_orders(auction, solver_address, order_sorting_strategies)
+            Self::sort_orders(auction, solver_address, order_sorting_strategies, sort_cancel)
         });
 
         // We can sort the orders and fetch auction data in parallel
@@ -350,10 +358,17 @@ impl Competition {
 
         let balances = balances?;
         let app_data = app_data?;
+        let auction = auction?;
 
+        let update_cancel = deadline_cancel.clone();
         let auction = Self::run_blocking_with_timer("update_orders", move || {
-            Self::update_orders(auction, balances, app_data, cow_amm_orders)
+            // Same as before with sort_orders, we use spawn_blocking() because a lot of CPU
+            // bound computations are happening and we want to avoid blocking
+            // the runtime
+            Self::update_orders(auction, balances, app_data, cow_amm_orders, update_cancel)
         }).await;
+
+        let auction = auction?;
 
         // We can run bad token filtering and liquidity fetching in parallel
         let (liquidity, auction) = tokio::join!(
@@ -643,36 +658,48 @@ impl Competition {
         Some(solved.id.get())
     }
 
-    // Oders already need to be sorted from most relevant to least relevant so that
-    // we allocate balances for the most relevants first.
+    /// Orders already need to be sorted from most relevant to the least relevant so that
+    /// we allocate balances for the most relevant first.
+    /// Returns `DeadlineExceeded` if cancel has been triggered.
     fn sort_orders(
         mut auction: Auction,
         solver: eth::Address,
         order_sorting_strategies: Vec<Arc<dyn SortingStrategy>>,
-    ) -> Auction {
+        cancel: CancellationToken,
+    ) -> Result<Auction, DeadlineExceeded> {
         sorting::sort_orders(
             &mut auction.orders,
             &auction.tokens,
             &solver,
             &order_sorting_strategies,
-        );
-        auction
+            &cancel,
+        )?;
+
+        Ok(auction)
     }
 
     /// Removes orders that cannot be filled due to missing funds of the owner
     /// and updates the fetched app data.
     /// It allocates available funds from left to right so the orders should
     /// already be sorted by priority going in.
+    /// Returns `DeadlineExceeded` if cancel has been triggered.
     fn update_orders(
         mut auction: Auction,
         balances: Arc<Balances>,
         app_data: Arc<HashMap<order::app_data::AppDataHash, Arc<app_data::ValidatedAppData>>>,
         cow_amm_orders: Arc<Vec<Order>>,
-    ) -> Auction {
+        cancel: CancellationToken,
+    ) -> Result<Auction, DeadlineExceeded> {
+        if cancel.is_cancelled() {
+            return Err(DeadlineExceeded);
+        }
+
         // Clone balances since we only aggregate data once but each solver needs
         // to use and modify the data individually.
         let mut balances = balances.as_ref().clone();
         let cow_amms: HashSet<_> = cow_amm_orders.iter().map(|o| o.uid).collect();
+
+        let mut cancelled = false;
 
         // The auction that we receive from the `autopilot` assumes that there
         // is sufficient balance to completely cover all the orders. **This is
@@ -683,6 +710,11 @@ impl Competition {
         // down in case the available user balance is only enough to partially
         // cover the rest of the order.
         auction.orders.retain_mut(|order| {
+            if cancel.is_cancelled() {
+                cancelled = true;
+                return false;
+            }
+
             if cow_amms.contains(&order.uid) {
                 // cow amm orders already get constructed fully initialized
                 // so we don't have to handle them here anymore.
@@ -767,7 +799,11 @@ impl Competition {
             true
         });
 
-        auction
+        if cancelled || cancel.is_cancelled() {
+            return Err(DeadlineExceeded);
+        }
+
+        Ok(auction)
     }
 
     /// Runs a blocking function on a background thread, timing it using the
@@ -1082,4 +1118,62 @@ pub enum Error {
     NoValidOrdersFound,
     #[error("could not parse the request")]
     MalformedRequest,
+}
+
+#[cfg(test)]
+mod deadline_cancellation_tests {
+    use {
+        super::*,
+        crate::domain::time::DeadlineExceeded,
+        std::time::Duration,
+        tokio_util::sync::CancellationToken,
+    };
+
+    #[tokio::test]
+    async fn run_blocking_with_deadline_exceeded() {
+        let result = Competition::run_blocking_with_timer("deadline", || {
+            Err::<(), _>(DeadlineExceeded)
+        })
+            .await;
+
+        assert!(matches!(result, Err(DeadlineExceeded)));
+    }
+
+    #[tokio::test]
+    async fn run_blocking_returns_success() {
+        let result = Competition::run_blocking_with_timer("success", || {
+            Ok::<_, DeadlineExceeded>(42)
+        })
+            .await;
+
+        assert_eq!(result.expect("blocking succeed"), 42);
+    }
+
+    #[tokio::test]
+    async fn blocking_stage_cooperates_cancellation_token() {
+        let cancel = CancellationToken::new();
+        let cancel_for_blocking = cancel.clone();
+
+        let handle = tokio::spawn(async move {
+            Competition::run_blocking_with_timer("cancel", move || {
+                loop {
+                    if cancel_for_blocking.is_cancelled() {
+                        return Err::<(), _>(DeadlineExceeded);
+                    }
+
+                    std::thread::sleep(Duration::from_millis(5));
+                }
+            })
+                .await
+        });
+
+        cancel.cancel();
+
+        let result = tokio::time::timeout(Duration::from_secs(1), handle)
+            .await
+            .expect("blocking cancellation")
+            .expect("join succeeded");
+
+        assert!(matches!(result, Err(DeadlineExceeded)));
+    }
 }

--- a/crates/driver/src/domain/competition/mod.rs
+++ b/crates/driver/src/domain/competition/mod.rs
@@ -1,10 +1,6 @@
 use {
     self::solution::settlement,
-    super::{
-        Mempools,
-        mempools::SubmissionMode,
-        time::{self, Remaining},
-    },
+    super::{Mempools, mempools::SubmissionMode},
     crate::{
         domain::{
             competition::{solution::Settlement, sorting::SortingStrategy},
@@ -326,24 +322,29 @@ impl Competition {
                 tracing::error!(?err, "pre-processing auction failed");
                 Error::MalformedRequest
             })?;
-
         let mut auction = match tasks.auction.await {
             Ok(auction) => Arc::unwrap_or_clone(auction),
+            // Infallible: Keep arm for same shared deadline result type as
+            // the other preprocessing tasks
             Err(DeadlineExceeded) => {
-                observe::auction_cancelled("auction", "deadline");
-                return Ok(vec![]);
+                observe::auction_cancelled("auction", "already_expired");
+                return Err(Error::DeadlineExceeded(DeadlineExceeded));
             }
         };
 
         let deadlines = auction.deadline(self.solver.timeouts());
-        if deadlines.auction() <= chrono::Utc::now() {
+        let auction_deadline = deadlines.auction();
+        let driver_deadline = deadlines.driver();
+        let effective_deadline = std::cmp::min(auction_deadline, driver_deadline);
+        if effective_deadline <= chrono::Utc::now() {
             observe::auction_cancelled("auction", "deadline");
             return Ok(vec![]);
         }
-        let driver_deadline = deadlines.driver();
 
+        // Keep this guard alive for the whole solve path. Dropping it aborts the timer
+        // so all clones and references of `deadline_cancel` depend on this value.
         let deadline_cancellation =
-            deadline_cancellation::DeadlineCancellation::new(driver_deadline);
+            deadline_cancellation::DeadlineCancellation::new(effective_deadline);
         let deadline_cancel = deadline_cancellation.token();
 
         let solver_address = self.solver.address();
@@ -351,80 +352,80 @@ impl Competition {
 
         // Add the CoW AMM orders to the auction
         let cow_amm_orders = tokio::select! {
-        result = tasks.cow_amm_orders => match result {
-            Ok(cow_amm_orders) => cow_amm_orders,
-            Err(DeadlineExceeded) => {
-            observe::auction_cancelled("cow_amm_orders", "deadline");
-            return Ok(vec![]);
-            }
-        },
-        _ = deadline_cancel.cancelled() => {
-            observe::auction_cancelled("cow_amm_orders", "deadline");
-            return Ok(vec![]);
+            result = tasks.cow_amm_orders => match result {
+                Ok(cow_amm_orders) => cow_amm_orders,
+                Err(DeadlineExceeded) => {
+                    observe::auction_cancelled("cow_amm_orders", "deadline");
+                    return Ok(vec![]);
+                }
+            },
+            _ = deadline_cancel.cancelled() => {
+                observe::auction_cancelled("cow_amm_orders", "deadline");
+                return Ok(vec![]);
             }
         };
         auction.orders.extend(cow_amm_orders.iter().cloned());
 
         let sort_cancel = deadline_cancel.clone();
-
         let sort_orders_future = Self::run_blocking_with_timer("sort_orders", move || {
             // Use spawn_blocking() because a lot of CPU bound computations are happening
             // and we don't want to block the runtime for too long.
+            if sort_cancel.is_cancelled() {
+                return Err(DeadlineExceeded);
+            }
+
             Self::sort_orders(
                 auction,
                 solver_address,
                 order_sorting_strategies,
-                sort_cancel,
+                &sort_cancel,
             )
         });
 
-        // We can sort the orders and fetch auction data in parallel
-        let (auction, balances, app_data) = tokio::select! {
+        // We can sort the orders and fetch auction data in parallel.
+        let (auction_result, balances_result, app_data_result) = tokio::select! {
             result = async {
                 tokio::join!(sort_orders_future, tasks.balances, tasks.app_data)
-            } => {
-                let (auction, balances, app_data) = result;
-
-                let auction = match auction {
-                    Ok(auction) => auction,
-                    Err(DeadlineExceeded) => {
-                        observe::auction_cancelled("sort_orders", "deadline");
-                        return Ok(vec![]);
-                    }
-                };
-
-                let balances = match balances {
-                    Ok(balances) => balances,
-                    Err(DeadlineExceeded) => {
-                        observe::auction_cancelled("balances", "deadline");
-                        return Ok(vec![]);
-                    }
-                };
-
-                let app_data = match app_data {
-                    Ok(app_data) => app_data,
-                    Err(DeadlineExceeded) => {
-                        observe::auction_cancelled("app_data", "deadline");
-                        return Ok(vec![]);
-                    }
-                };
-
-                (auction, balances, app_data)
-            }
+            } => result,
             _ = deadline_cancel.cancelled() => {
-                observe::auction_cancelled("pre_processing", "deadline");
+                observe::auction_cancelled("preprocessing", "deadline");
+                return Ok(vec![]);
+            }
+        };
+
+        let (auction, balances, app_data) = match (auction_result, balances_result, app_data_result)
+        {
+            (Ok(auction), Ok(balances), Ok(app_data)) => (auction, balances, app_data),
+            (Err(DeadlineExceeded), _, _) => {
+                observe::auction_cancelled("sort_orders", "deadline");
+                return Ok(vec![]);
+            }
+            (_, Err(DeadlineExceeded), _) => {
+                observe::auction_cancelled("balances", "deadline");
+                return Ok(vec![]);
+            }
+            (_, _, Err(DeadlineExceeded)) => {
+                observe::auction_cancelled("app_data", "deadline");
                 return Ok(vec![]);
             }
         };
 
         let update_cancel = deadline_cancel.clone();
-        let auction = Self::run_blocking_with_timer("update_orders", move || {
-            // Same as before with sort_orders, we use spawn_blocking() because a lot of CPU
-            // bound computations are happening and we want to avoid blocking
-            // the runtime
-            Self::update_orders(auction, balances, app_data, cow_amm_orders, update_cancel)
-        })
-        .await;
+        let auction = tokio::select! {
+            result = Self::run_blocking_with_timer("update_orders", move || {
+                // Same as before with sort_orders, we use spawn_blocking() because a lot of CPU
+                // bound computations are happening, and we want to avoid blocking
+                // the runtime.
+                if update_cancel.is_cancelled() {
+                    return Err(DeadlineExceeded);
+                }
+                Self::update_orders(auction, balances, app_data, cow_amm_orders, &update_cancel)
+            }) => result,
+            _ = deadline_cancel.cancelled() => {
+                observe::auction_cancelled("update_orders", "deadline");
+                return Ok(vec![]);
+            }
+        };
 
         let auction = match auction {
             Ok(auction) => auction,
@@ -444,7 +445,7 @@ impl Competition {
                             solver::Liquidity::Skip => Ok(Arc::new(Vec::new())),
                         }
                     },
-                    self.without_unsupported_orders(auction)
+                    self.without_unsupported_orders(auction, &deadline_cancel)
                 )
             } => {
                 let (liquidity, auction) = result;
@@ -453,6 +454,14 @@ impl Competition {
                     Ok(liquidity) => liquidity,
                     Err(DeadlineExceeded) => {
                         observe::auction_cancelled("liquidity", "deadline");
+                        return Ok(vec![]);
+                    }
+                };
+
+                let auction = match auction {
+                    Ok(auction) => auction,
+                    Err(DeadlineExceeded) => {
+                        observe::auction_cancelled("unsupported_order_filtering", "deadline");
                         return Ok(vec![]);
                     }
                 };
@@ -583,24 +592,23 @@ impl Competition {
         // Encode settlements as they arrive until there are no more new settlements or
         // timeout is reached.
         let mut settlements = Vec::new();
-        let mut postprocessing_cancelled = false;
-
         let mut encoded = std::pin::pin!(encoded);
+        'encoding: loop {
+            tokio::select! {
+                settlement = encoded.next() => {
+                    let Some(settlement) = settlement else {
+                        break 'encoding;
+                    };
 
-        while let Some(settlement) = tokio::select! {
-            settlement = encoded.next() => settlement,
-            _ = deadline_cancel.cancelled() => {
-                observe::auction_cancelled("encoding", "deadline");
-                postprocessing_cancelled = true;
-                None
+                    settlements.push(settlement);
+                }
+                _ = deadline_cancel.cancelled() => {
+                    observe::auction_cancelled("encoding", "deadline");
+                    observe::postprocessing_timed_out(&settlements);
+                    notify::postprocessing_timed_out(&self.solver, auction.id());
+                    break 'encoding;
+                }
             }
-        } {
-            settlements.push(settlement);
-        }
-
-        if postprocessing_cancelled {
-            observe::postprocessing_timed_out(&settlements);
-            notify::postprocessing_timed_out(&self.solver, auction.id())
         }
 
         // Score the settlements.
@@ -678,42 +686,47 @@ impl Competition {
         }
 
         if !deadline_cancel.is_cancelled() {
-            if let Ok(remaining) = driver_deadline.remaining() {
-                let _ = tokio::select! {
-                    result = tokio::time::timeout(
-                        remaining,
-                        self.resimulate_until_revert(&mut scored, auction),
-                    ) => result,
-                    _ = deadline_cancel.cancelled() => {
-                        observe::auction_cancelled("resimulation", "deadline");
-                        Ok(Ok(()))
-                    }
-                };
-            }
+            let _ = self
+                .resimulate_until_revert(&mut scored, auction, &deadline_cancel)
+                .await;
         }
 
         Ok(scored.into_iter().map(|(solved, _)| solved).collect())
     }
 
     /// Re-simulate all proposed solutions on every new block and drop any
-    /// that start reverting. Returns once every solution has reverted;
-    /// otherwise runs forever and the caller must impose a deadline.
+    /// that start reverting. Returns once every solution has reverted or
+    /// the `cancel` token is triggered
     /// Mutates `scored` and the cached settlements in place.
     async fn resimulate_until_revert(
         &self,
         scored: &mut Vec<(Solved, Settlement)>,
         auction: &Auction,
+        cancel: &CancellationToken,
     ) -> anyhow::Result<()> {
         let mut stream = ethrpc::block_stream::into_stream(self.eth.current_block().clone());
-        while let Some(block) = stream.next().await {
-            let voided_ids: HashSet<u64> =
-                futures::future::join_all(scored.iter().map(|(solved, settlement)| {
+        loop {
+            let Some(block) = tokio::select!(
+                block = stream.next() => block,
+                _ = cancel.cancelled() => {
+                    observe::auction_cancelled("resimulation", "deadline");
+                    return Ok(());
+                }
+            ) else {
+                return Ok(());
+            };
+
+            let voided_ids: HashSet<u64> = tokio::select! {
+                voided_ids = futures::future::join_all(scored.iter().map(|(solved, settlement)| {
                     self.reverts_on_block(block, solved, settlement, auction)
-                }))
-                .await
-                .into_iter()
-                .flatten()
-                .collect();
+                })) => {
+                    voided_ids.into_iter().flatten().collect()
+                }
+                _ = cancel.cancelled() => {
+                    observe::auction_cancelled("resimulation", "deadline");
+                    return Ok(());
+                }
+            };
 
             if voided_ids.is_empty() {
                 continue;
@@ -730,7 +743,6 @@ impl Competition {
                 return Ok(());
             }
         }
-        Ok(())
     }
 
     /// Re-simulate a single solution and return its id if it started
@@ -768,16 +780,15 @@ impl Competition {
         mut auction: Auction,
         solver: eth::Address,
         order_sorting_strategies: Vec<Arc<dyn SortingStrategy>>,
-        cancel: CancellationToken,
+        cancel: &CancellationToken,
     ) -> Result<Auction, DeadlineExceeded> {
         sorting::sort_orders(
             &mut auction.orders,
             &auction.tokens,
             &solver,
             &order_sorting_strategies,
-            &cancel,
+            cancel,
         )?;
-
         Ok(auction)
     }
 
@@ -791,7 +802,7 @@ impl Competition {
         balances: Arc<Balances>,
         app_data: Arc<HashMap<order::app_data::AppDataHash, Arc<app_data::ValidatedAppData>>>,
         cow_amm_orders: Arc<Vec<Order>>,
-        cancel: CancellationToken,
+        cancel: &CancellationToken,
     ) -> Result<Auction, DeadlineExceeded> {
         if cancel.is_cancelled() {
             return Err(DeadlineExceeded);
@@ -800,18 +811,10 @@ impl Competition {
         // Clone balances since we only aggregate data once but each solver needs
         // to use and modify the data individually.
         let mut balances = balances.as_ref().clone();
-
-        if cancel.is_cancelled() {
-            return Err(DeadlineExceeded);
-        }
-
         let cow_amms: HashSet<_> = cow_amm_orders.iter().map(|o| o.uid).collect();
 
-        if cancel.is_cancelled() {
-            return Err(DeadlineExceeded);
-        }
-
-        let mut cancelled = false;
+        let orders = std::mem::take(&mut auction.orders);
+        let mut updated_orders = Vec::with_capacity(orders.len());
 
         // The auction that we receive from the `autopilot` assumes that there
         // is sufficient balance to completely cover all the orders. **This is
@@ -821,10 +824,9 @@ impl Competition {
         // to each order, and potentially scaling the order's `available` amount
         // down in case the available user balance is only enough to partially
         // cover the rest of the order.
-        auction.orders.retain_mut(|order| {
+        for mut order in orders {
             if cancel.is_cancelled() {
-                cancelled = true;
-                return false;
+                return Err(DeadlineExceeded);
             }
 
             if cow_amms.contains(&order.uid) {
@@ -833,7 +835,8 @@ impl Competition {
                 // Without this short circuiting logic they would get filtered
                 // out later because we don't bother fetching their balances
                 // for performance reasons.
-                return true;
+                updated_orders.push(order);
+                continue;
             }
 
             // Update order app data if it was fetched.
@@ -844,12 +847,14 @@ impl Competition {
             // Flashloan orders get their sell tokens from the flashloan at
             // settlement time, so skip the balance check.
             if order.app_data.flashloan().is_some() {
-                return true;
+                updated_orders.push(order);
+                continue;
             }
 
             // wrappers can produce the required funds at settlement time
             if !order.app_data.wrappers().is_empty() {
-                return true;
+                updated_orders.push(order);
+                continue;
             }
 
             let remaining_balance = match balances.get_mut(&(
@@ -860,8 +865,8 @@ impl Competition {
                 Some(balance) => balance,
                 None => {
                     let reason = observe::OrderExcludedFromAuctionReason::CouldNotFetchBalance;
-                    observe::order_excluded_from_auction(order, reason);
-                    return false;
+                    observe::order_excluded_from_auction(&order, reason);
+                    continue;
                 }
             };
 
@@ -874,12 +879,11 @@ impl Competition {
             };
             if allocated_balance.0.is_zero() {
                 observe::order_excluded_from_auction(
-                    order,
+                    &order,
                     observe::OrderExcludedFromAuctionReason::InsufficientBalance,
                 );
-                return false;
+                continue;
             }
-
             // We need to scale the available amount in the order based on
             // allocated balance. We cannot naively just set the `available`
             // amount to equal the `allocated_balance` because of two reasons:
@@ -898,28 +902,28 @@ impl Competition {
                         .unwrap_or_default(),
                 );
             }
+
             if order.available().is_zero() {
                 observe::order_excluded_from_auction(
-                    order,
+                    &order,
                     observe::OrderExcludedFromAuctionReason::OrderWithZeroAmountRemaining,
                 );
-                return false;
+                continue;
             }
 
             remaining_balance.0 -= allocated_balance.0;
-
-            true
-        });
-
-        if cancelled || cancel.is_cancelled() {
-            return Err(DeadlineExceeded);
+            updated_orders.push(order);
         }
-
+        auction.orders = updated_orders;
         Ok(auction)
     }
 
     /// Runs a blocking function on a background thread, timing it using the
-    /// given stage name.
+    /// given stage name. This helper does not cancel or abort the blocking
+    /// closure itself. Any deadline handling must be implemented by the
+    /// closure using a `CancellationToken`. If the async caller returns
+    /// early, it may still continue running until it reaches
+    /// its own cancellation check or completes.
     pub async fn run_blocking_with_timer<T, F>(stage: &'static str, f: F) -> T
     where
         F: FnOnce() -> T + Send + 'static,
@@ -1106,12 +1110,25 @@ impl Competition {
     }
 
     #[instrument(skip_all)]
-    async fn without_unsupported_orders(&self, mut auction: Auction) -> Auction {
+    async fn without_unsupported_orders(
+        &self,
+        mut auction: Auction,
+        cancel: &CancellationToken,
+    ) -> Result<Auction, DeadlineExceeded> {
+        if cancel.is_cancelled() {
+            return Err(DeadlineExceeded);
+        }
+
         if !self.solver.config().flashloans_enabled {
             auction.orders.retain(|o| o.app_data.flashloan().is_none());
         }
+
+        if cancel.is_cancelled() {
+            return Err(DeadlineExceeded);
+        }
+
         self.risk_detector
-            .filter_unsupported_orders_in_auction(auction)
+            .filter_unsupported_orders_in_auction(auction, cancel)
             .await
     }
 }
@@ -1219,7 +1236,7 @@ pub enum Error {
     )]
     SolutionNotAvailable,
     #[error("{0:?}")]
-    DeadlineExceeded(#[from] time::DeadlineExceeded),
+    DeadlineExceeded(#[from] DeadlineExceeded),
     #[error("solver error: {0:?}")]
     Solver(#[from] solver::Error),
     #[error("failed to submit the solution")]
@@ -1237,12 +1254,29 @@ mod deadline_cancellation_tests {
     use {
         super::*,
         crate::domain::time::DeadlineExceeded,
-        std::time::Duration,
+        std::{collections::HashMap, hint::spin_loop, sync::Arc},
+        tokio::sync::oneshot,
         tokio_util::sync::CancellationToken,
     };
 
+    // Helper to create a dummy auction purely for test
+    fn empty_auction() -> Auction {
+        Auction {
+            id: None,
+            orders: Vec::new(),
+            tokens: auction::Tokens::default(),
+            gas_price: eth::GasPrice::new(
+                alloy::primitives::U256::ZERO.into(),
+                alloy::primitives::U256::ZERO.into(),
+                0,
+            ),
+            deadline: chrono::Utc::now(),
+            surplus_capturing_jit_order_owners: Default::default(),
+        }
+    }
+
     #[tokio::test]
-    async fn run_blocking_with_deadline_exceeded() {
+    async fn blocking_with_deadline_exceeded() {
         let result =
             Competition::run_blocking_with_timer("deadline", || Err::<(), _>(DeadlineExceeded))
                 .await;
@@ -1251,39 +1285,153 @@ mod deadline_cancellation_tests {
     }
 
     #[tokio::test]
-    async fn run_blocking_returns_success() {
+    async fn blocking_returns_success() {
         let result =
             Competition::run_blocking_with_timer("success", || Ok::<_, DeadlineExceeded>("ok"))
                 .await;
 
-        assert_eq!(result.expect("blocking succeed"), "ok");
+        assert_eq!(result.expect("success"), "ok");
     }
 
     #[tokio::test]
-    async fn blocking_stage_cooperates_cancellation_token() {
+    async fn blocking_stage_cooperates_cancellation() {
         let cancel = CancellationToken::new();
         let cancel_for_blocking = cancel.clone();
+        let (entered_sender, entered_receiver) = oneshot::channel();
 
         let handle = tokio::spawn(async move {
             Competition::run_blocking_with_timer("cancel", move || {
+                let _ = entered_sender.send(());
+
                 loop {
                     if cancel_for_blocking.is_cancelled() {
                         return Err::<(), _>(DeadlineExceeded);
                     }
 
-                    std::thread::sleep(Duration::from_millis(5));
+                    spin_loop();
                 }
             })
             .await
         });
 
+        entered_receiver.await.expect("should start");
+
         cancel.cancel();
 
-        let result = tokio::time::timeout(Duration::from_secs(1), handle)
-            .await
-            .expect("blocking cancellation")
-            .expect("join succeeded");
+        let result = handle.await.expect("joined");
 
         assert!(matches!(result, Err(DeadlineExceeded)));
+    }
+
+    #[tokio::test]
+    async fn blocking_returns_immediately_if_cancelled() {
+        let cancel = CancellationToken::new();
+        cancel.cancel();
+
+        let result = Competition::run_blocking_with_timer("pre_cancelled", move || {
+            if cancel.is_cancelled() {
+                return Err::<(), _>(DeadlineExceeded);
+            }
+
+            unreachable!("it's cancelled");
+        })
+        .await;
+
+        assert!(matches!(result, Err(DeadlineExceeded)));
+    }
+
+    #[test]
+    fn sort_orders_returns_deadline_exceeded_when_cancelled() {
+        let cancel = CancellationToken::new();
+        cancel.cancel();
+
+        let auction = empty_auction();
+
+        let result = Competition::sort_orders(
+            auction,
+            eth::Address::default(),
+            Vec::<Arc<dyn SortingStrategy>>::new(),
+            &cancel,
+        );
+
+        assert!(matches!(result, Err(DeadlineExceeded)));
+    }
+
+    #[test]
+    fn update_orders_returns_deadline_exceeded_when_cancelled() {
+        let cancel = CancellationToken::new();
+        cancel.cancel();
+
+        let auction = empty_auction();
+
+        let result = Competition::update_orders(
+            auction,
+            Arc::new(HashMap::new()),
+            Arc::new(HashMap::new()),
+            Arc::new(Vec::new()),
+            &cancel,
+        );
+
+        assert!(matches!(result, Err(DeadlineExceeded)));
+    }
+
+    #[test]
+    fn update_orders_accepts_empty_auction_not_cancelled() {
+        let cancel = CancellationToken::new();
+
+        let auction = empty_auction();
+
+        let result = Competition::update_orders(
+            auction,
+            Arc::new(HashMap::new()),
+            Arc::new(HashMap::new()),
+            Arc::new(Vec::new()),
+            &cancel,
+        );
+
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn blocking_stage_can_return_before_blocking_work_finishes() {
+        let cancel = CancellationToken::new();
+        let cancel_for_blocking = cancel.clone();
+
+        let (entered_sender, entered_receiver) = oneshot::channel();
+        let (release_sender, release_receiver) = std::sync::mpsc::channel::<()>();
+        let (finished_sender, mut finished_receiver) = oneshot::channel();
+
+        let handle = tokio::spawn(async move {
+            Competition::run_blocking_with_timer("slow", move || {
+                let _ = entered_sender.send(());
+
+                while !cancel_for_blocking.is_cancelled() {
+                    spin_loop();
+                }
+
+                release_receiver.recv().expect("should release");
+
+                let _ = finished_sender.send(());
+
+                Ok::<_, DeadlineExceeded>(())
+            })
+            .await
+        });
+
+        entered_receiver.await.expect("should start");
+
+        cancel.cancel();
+
+        let result = tokio::select! {
+            result = handle => result.expect("should not panic"),
+            _ = cancel.cancelled() => Err(DeadlineExceeded),
+        };
+
+        assert!(matches!(result, Err(DeadlineExceeded)));
+        assert!(finished_receiver.try_recv().is_err());
+
+        release_sender.send(()).expect("still be alive");
+
+        finished_receiver.await.expect("finish after released");
     }
 }

--- a/crates/driver/src/domain/competition/mod.rs
+++ b/crates/driver/src/domain/competition/mod.rs
@@ -42,6 +42,7 @@ mod pre_processing;
 pub mod risk_detector;
 pub mod solution;
 pub mod sorting;
+pub mod deadline_cancellation;
 
 use {
     crate::infra::notify::liquidity_sources::LiquiditySourceNotifying,

--- a/crates/driver/src/domain/competition/mod.rs
+++ b/crates/driver/src/domain/competition/mod.rs
@@ -319,19 +319,23 @@ impl Competition {
 
         let tasks = self
             .fetcher
-            .start_or_get_tasks_for_auction(request)
+            .start_or_get_tasks_for_auction(request, self.solver.timeouts())
             .await
             .map_err(|err| {
                 tracing::error!(?err, "pre-processing auction failed");
                 Error::MalformedRequest
             })?;
-        let mut auction = Arc::unwrap_or_clone(tasks.auction.await);
+
+        let mut auction = match tasks.auction.await {
+            Ok(auction) => Arc::unwrap_or_clone(auction),
+            Err(err) => return Err(err.into()),
+        };
 
         let solver_address = self.solver.address();
         let order_sorting_strategies = self.order_sorting_strategies.clone();
 
         // Add the CoW AMM orders to the auction
-        let cow_amm_orders = tasks.cow_amm_orders.await;
+        let cow_amm_orders = tasks.cow_amm_orders.await?;
         auction.orders.extend(cow_amm_orders.iter().cloned());
 
         let sort_orders_future = Self::run_blocking_with_timer("sort_orders", move || {
@@ -344,20 +348,19 @@ impl Competition {
         let (auction, balances, app_data) =
             tokio::join!(sort_orders_future, tasks.balances, tasks.app_data);
 
+        let balances = balances?;
+        let app_data = app_data?;
+
         let auction = Self::run_blocking_with_timer("update_orders", move || {
-            // Same as before with sort_orders, we use spawn_blocking() because a lot of CPU
-            // bound computations are happening and we want to avoid blocking
-            // the runtime.
             Self::update_orders(auction, balances, app_data, cow_amm_orders)
-        })
-        .await;
+        }).await;
 
         // We can run bad token filtering and liquidity fetching in parallel
         let (liquidity, auction) = tokio::join!(
             async {
                 match self.solver.liquidity() {
                     solver::Liquidity::Fetch => tasks.liquidity.await,
-                    solver::Liquidity::Skip => Arc::new(Vec::new()),
+                    solver::Liquidity::Skip => Ok(Arc::new(Vec::new())),
                 }
             },
             self.without_unsupported_orders(auction)
@@ -377,6 +380,7 @@ impl Competition {
         }
 
         let auction = &auction;
+        let liquidity = liquidity?;
 
         // Fetch the solutions from the solver.
         let solutions = self

--- a/crates/driver/src/domain/competition/mod.rs
+++ b/crates/driver/src/domain/competition/mod.rs
@@ -1,4 +1,3 @@
-use tokio_util::sync::CancellationToken;
 use {
     self::solution::settlement,
     super::{
@@ -34,16 +33,17 @@ use {
         time::Instant,
     },
     tokio::{sync::mpsc, task},
+    tokio_util::sync::CancellationToken,
     tracing::{Instrument, instrument},
 };
 
 pub mod auction;
+pub mod deadline_cancellation;
 pub mod order;
 mod pre_processing;
 pub mod risk_detector;
 pub mod solution;
 pub mod sorting;
-pub mod deadline_cancellation;
 
 use {
     crate::infra::notify::liquidity_sources::LiquiditySourceNotifying,
@@ -329,19 +329,33 @@ impl Competition {
 
         let mut auction = match tasks.auction.await {
             Ok(auction) => Arc::unwrap_or_clone(auction),
-            Err(err) => return Err(err.into()),
+            Err(DeadlineExceeded) => {
+                observe::auction_cancelled("auction", "deadline");
+                return Ok(vec![]);
+            }
         };
 
         let deadline = auction.deadline(self.solver.timeouts()).driver();
-        let deadline_cancellation =
-            deadline_cancellation::DeadlineCancellation::new(deadline);
+        let deadline_cancellation = deadline_cancellation::DeadlineCancellation::new(deadline);
         let deadline_cancel = deadline_cancellation.token();
 
         let solver_address = self.solver.address();
         let order_sorting_strategies = self.order_sorting_strategies.clone();
 
         // Add the CoW AMM orders to the auction
-        let cow_amm_orders = tasks.cow_amm_orders.await?;
+        let cow_amm_orders = tokio::select! {
+        result = tasks.cow_amm_orders => match result {
+            Ok(cow_amm_orders) => cow_amm_orders,
+            Err(DeadlineExceeded) => {
+            observe::auction_cancelled("cow_amm_orders", "deadline");
+            return Ok(vec![]);
+            }
+        },
+        _ = deadline_cancel.cancelled() => {
+            observe::auction_cancelled("cow_amm_orders", "deadline");
+            return Ok(vec![]);
+            }
+        };
         auction.orders.extend(cow_amm_orders.iter().cloned());
 
         let sort_cancel = deadline_cancel.clone();
@@ -349,16 +363,52 @@ impl Competition {
         let sort_orders_future = Self::run_blocking_with_timer("sort_orders", move || {
             // Use spawn_blocking() because a lot of CPU bound computations are happening
             // and we don't want to block the runtime for too long.
-            Self::sort_orders(auction, solver_address, order_sorting_strategies, sort_cancel)
+            Self::sort_orders(
+                auction,
+                solver_address,
+                order_sorting_strategies,
+                sort_cancel,
+            )
         });
 
         // We can sort the orders and fetch auction data in parallel
-        let (auction, balances, app_data) =
-            tokio::join!(sort_orders_future, tasks.balances, tasks.app_data);
+        let (auction, balances, app_data) = tokio::select! {
+            result = async {
+                tokio::join!(sort_orders_future, tasks.balances, tasks.app_data)
+            } => {
+                let (auction, balances, app_data) = result;
 
-        let balances = balances?;
-        let app_data = app_data?;
-        let auction = auction?;
+                let auction = match auction {
+                    Ok(auction) => auction,
+                    Err(DeadlineExceeded) => {
+                        observe::auction_cancelled("sort_orders", "deadline");
+                        return Ok(vec![]);
+                    }
+                };
+
+                let balances = match balances {
+                    Ok(balances) => balances,
+                    Err(DeadlineExceeded) => {
+                        observe::auction_cancelled("balances", "deadline");
+                        return Ok(vec![]);
+                    }
+                };
+
+                let app_data = match app_data {
+                    Ok(app_data) => app_data,
+                    Err(DeadlineExceeded) => {
+                        observe::auction_cancelled("app_data", "deadline");
+                        return Ok(vec![]);
+                    }
+                };
+
+                (auction, balances, app_data)
+            }
+            _ = deadline_cancel.cancelled() => {
+                observe::auction_cancelled("pre_processing", "deadline");
+                return Ok(vec![]);
+            }
+        };
 
         let update_cancel = deadline_cancel.clone();
         let auction = Self::run_blocking_with_timer("update_orders", move || {
@@ -366,20 +416,41 @@ impl Competition {
             // bound computations are happening and we want to avoid blocking
             // the runtime
             Self::update_orders(auction, balances, app_data, cow_amm_orders, update_cancel)
-        }).await;
+        })
+        .await;
 
         let auction = auction?;
 
         // We can run bad token filtering and liquidity fetching in parallel
-        let (liquidity, auction) = tokio::join!(
-            async {
-                match self.solver.liquidity() {
-                    solver::Liquidity::Fetch => tasks.liquidity.await,
-                    solver::Liquidity::Skip => Ok(Arc::new(Vec::new())),
-                }
-            },
-            self.without_unsupported_orders(auction)
-        );
+        let (liquidity, auction) = tokio::select! {
+            result = async {
+                tokio::join!(
+                    async {
+                        match self.solver.liquidity() {
+                            solver::Liquidity::Fetch => tasks.liquidity.await,
+                            solver::Liquidity::Skip => Ok(Arc::new(Vec::new())),
+                        }
+                    },
+                    self.without_unsupported_orders(auction)
+                )
+            } => {
+                let (liquidity, auction) = result;
+
+                let liquidity = match liquidity {
+                    Ok(liquidity) => liquidity,
+                    Err(DeadlineExceeded) => {
+                        observe::auction_cancelled("liquidity", "deadline");
+                        return Ok(vec![]);
+                    }
+                };
+
+                (liquidity, auction)
+            }
+            _ = deadline_cancel.cancelled() => {
+                observe::auction_cancelled("liquidity_filtering", "deadline");
+                return Ok(vec![]);
+            }
+        };
 
         let elapsed = start.elapsed();
         metrics::get()
@@ -395,18 +466,21 @@ impl Competition {
         }
 
         let auction = &auction;
-        let liquidity = liquidity?;
 
         // Fetch the solutions from the solver.
-        let solutions = self
-            .solver
-            .solve(auction, &liquidity)
-            .await
-            .inspect_err(|err| {
-                if err.is_timeout() {
-                    notify::solver_timeout(&self.solver, auction.id());
-                }
-            })?;
+        let solutions = tokio::select! {
+            result = self.solver.solve(auction, &liquidity) => {
+                result.inspect_err(|err| {
+                    if err.is_timeout() {
+                        notify::solver_timeout(&self.solver, auction.id());
+                    }
+                })?
+            }
+            _ = deadline_cancel.cancelled() => {
+                observe::auction_cancelled("solver", "deadline");
+                return Ok(vec![]);
+            }
+        };
 
         let deadline = auction.deadline(self.solver.timeouts()).driver();
         observe::postprocessing(&solutions, deadline);
@@ -493,16 +567,22 @@ impl Competition {
         // Encode settlements as they arrive until there are no more new settlements or
         // timeout is reached.
         let mut settlements = Vec::new();
-        let future = async {
-            let mut encoded = std::pin::pin!(encoded);
-            while let Some(settlement) = encoded.next().await {
-                settlements.push(settlement);
+        let mut postprocessing_cancelled = false;
+
+        let mut encoded = std::pin::pin!(encoded);
+
+        while let Some(settlement) = tokio::select! {
+            settlement = encoded.next() => settlement,
+            _ = deadline_cancel.cancelled() => {
+                observe::auction_cancelled("encoding", "deadline");
+                postprocessing_cancelled = true;
+                None
             }
-        };
-        if tokio::time::timeout(deadline.remaining().unwrap_or_default(), future)
-            .await
-            .is_err()
-        {
+        } {
+            settlements.push(settlement);
+        }
+
+        if postprocessing_cancelled {
             observe::postprocessing_timed_out(&settlements);
             notify::postprocessing_timed_out(&self.solver, auction.id())
         }
@@ -581,12 +661,19 @@ impl Competition {
             lock.truncate(max_to_propose * MAX_CONCURRENT_AUCTIONS);
         }
 
-        if let Ok(remaining) = deadline.remaining() {
-            let _ = tokio::time::timeout(
-                remaining,
-                self.resimulate_until_revert(&mut scored, auction),
-            )
-            .await;
+        if !deadline_cancel.is_cancelled() {
+            if let Ok(remaining) = deadline.remaining() {
+                let _ = tokio::select! {
+                    result = tokio::time::timeout(
+                        remaining,
+                        self.resimulate_until_revert(&mut scored, auction),
+                    ) => result,
+                    _ = deadline_cancel.cancelled() => {
+                        observe::auction_cancelled("resimulation", "deadline");
+                        Ok(Ok(()))
+                    }
+                };
+            }
         }
 
         Ok(scored.into_iter().map(|(solved, _)| solved).collect())
@@ -658,8 +745,8 @@ impl Competition {
         Some(solved.id.get())
     }
 
-    /// Orders already need to be sorted from most relevant to the least relevant so that
-    /// we allocate balances for the most relevant first.
+    /// Orders already need to be sorted from most relevant to the least
+    /// relevant so that we allocate balances for the most relevant first.
     /// Returns `DeadlineExceeded` if cancel has been triggered.
     fn sort_orders(
         mut auction: Auction,
@@ -1131,22 +1218,19 @@ mod deadline_cancellation_tests {
 
     #[tokio::test]
     async fn run_blocking_with_deadline_exceeded() {
-        let result = Competition::run_blocking_with_timer("deadline", || {
-            Err::<(), _>(DeadlineExceeded)
-        })
-            .await;
+        let result =
+            Competition::run_blocking_with_timer("deadline", || Err::<(), _>(DeadlineExceeded))
+                .await;
 
         assert!(matches!(result, Err(DeadlineExceeded)));
     }
 
     #[tokio::test]
     async fn run_blocking_returns_success() {
-        let result = Competition::run_blocking_with_timer("success", || {
-            Ok::<_, DeadlineExceeded>(42)
-        })
-            .await;
+        let result =
+            Competition::run_blocking_with_timer("success", || Ok::<_, DeadlineExceeded>("ok")).await;
 
-        assert_eq!(result.expect("blocking succeed"), 42);
+        assert_eq!(result.expect("blocking succeed"), "ok");
     }
 
     #[tokio::test]
@@ -1164,7 +1248,7 @@ mod deadline_cancellation_tests {
                     std::thread::sleep(Duration::from_millis(5));
                 }
             })
-                .await
+            .await
         });
 
         cancel.cancel();

--- a/crates/driver/src/domain/competition/mod.rs
+++ b/crates/driver/src/domain/competition/mod.rs
@@ -320,7 +320,7 @@ impl Competition {
 
         let tasks = self
             .fetcher
-            .start_or_get_tasks_for_auction(request, self.solver.timeouts())
+            .start_or_get_tasks_for_auction(request)
             .await
             .map_err(|err| {
                 tracing::error!(?err, "pre-processing auction failed");
@@ -335,8 +335,15 @@ impl Competition {
             }
         };
 
-        let deadline = auction.deadline(self.solver.timeouts()).driver();
-        let deadline_cancellation = deadline_cancellation::DeadlineCancellation::new(deadline);
+        let deadlines = auction.deadline(self.solver.timeouts());
+        if deadlines.auction() <= chrono::Utc::now() {
+            observe::auction_cancelled("auction", "deadline");
+            return Ok(vec![]);
+        }
+        let driver_deadline = deadlines.driver();
+
+        let deadline_cancellation =
+            deadline_cancellation::DeadlineCancellation::new(driver_deadline);
         let deadline_cancel = deadline_cancellation.token();
 
         let solver_address = self.solver.address();
@@ -419,7 +426,13 @@ impl Competition {
         })
         .await;
 
-        let auction = auction?;
+        let auction = match auction {
+            Ok(auction) => auction,
+            Err(DeadlineExceeded) => {
+                observe::auction_cancelled("update_orders", "deadline");
+                return Ok(vec![]);
+            }
+        };
 
         // We can run bad token filtering and liquidity fetching in parallel
         let (liquidity, auction) = tokio::select! {
@@ -470,11 +483,15 @@ impl Competition {
         // Fetch the solutions from the solver.
         let solutions = tokio::select! {
             result = self.solver.solve(auction, &liquidity) => {
-                result.inspect_err(|err| {
-                    if err.is_timeout() {
+                match result {
+                    Ok(solutions) => solutions,
+                    Err(err) if err.is_timeout() => {
                         notify::solver_timeout(&self.solver, auction.id());
+                        observe::auction_cancelled("solver", "timeout");
+                        return Ok(vec![]);
                     }
-                })?
+                    Err(err) => return Err(err.into()),
+                }
             }
             _ = deadline_cancel.cancelled() => {
                 observe::auction_cancelled("solver", "deadline");
@@ -482,8 +499,7 @@ impl Competition {
             }
         };
 
-        let deadline = auction.deadline(self.solver.timeouts()).driver();
-        observe::postprocessing(&solutions, deadline);
+        observe::postprocessing(&solutions, driver_deadline);
 
         // Discard solutions that don't have unique ID.
         let mut ids = HashSet::new();
@@ -662,7 +678,7 @@ impl Competition {
         }
 
         if !deadline_cancel.is_cancelled() {
-            if let Ok(remaining) = deadline.remaining() {
+            if let Ok(remaining) = driver_deadline.remaining() {
                 let _ = tokio::select! {
                     result = tokio::time::timeout(
                         remaining,
@@ -784,7 +800,16 @@ impl Competition {
         // Clone balances since we only aggregate data once but each solver needs
         // to use and modify the data individually.
         let mut balances = balances.as_ref().clone();
+
+        if cancel.is_cancelled() {
+            return Err(DeadlineExceeded);
+        }
+
         let cow_amms: HashSet<_> = cow_amm_orders.iter().map(|o| o.uid).collect();
+
+        if cancel.is_cancelled() {
+            return Err(DeadlineExceeded);
+        }
 
         let mut cancelled = false;
 
@@ -1228,7 +1253,8 @@ mod deadline_cancellation_tests {
     #[tokio::test]
     async fn run_blocking_returns_success() {
         let result =
-            Competition::run_blocking_with_timer("success", || Ok::<_, DeadlineExceeded>("ok")).await;
+            Competition::run_blocking_with_timer("success", || Ok::<_, DeadlineExceeded>("ok"))
+                .await;
 
         assert_eq!(result.expect("blocking succeed"), "ok");
     }

--- a/crates/driver/src/domain/competition/pre_processing.rs
+++ b/crates/driver/src/domain/competition/pre_processing.rs
@@ -2,11 +2,22 @@ use {
     super::{Auction, Order, order},
     crate::{
         domain::{
-            competition::order::{SellTokenBalance, app_data::AppData},
+            competition::{
+                MAX_CONCURRENT_AUCTIONS,
+                deadline_cancellation::DeadlineCancellation,
+                order::{SellTokenBalance, app_data::AppData},
+            },
             cow_amm,
             liquidity,
+            time::DeadlineExceeded,
         },
-        infra::{self, api::routes::solve::dto::SolveRequest, observe::metrics, tokens},
+        infra::{
+            self,
+            api::routes::solve::dto::SolveRequest,
+            observe::metrics,
+            solver::Timeouts,
+            tokens,
+        },
     },
     account_balances::{BalanceFetching, Query},
     alloy::primitives::{Bytes, FixedBytes},
@@ -27,7 +38,7 @@ use {
     },
     signature_validator::SignatureValidating,
     std::{
-        collections::HashMap,
+        collections::{HashMap, VecDeque},
         future::Future,
         sync::Arc,
         time::{Duration, Instant},
@@ -36,8 +47,7 @@ use {
     tracing::{Instrument, instrument},
 };
 
-type Shared<T> = futures::future::Shared<BoxFuture<'static, T>>;
-
+type Shared<T> = futures::future::Shared<BoxFuture<'static, Result<T, DeadlineExceeded>>>;
 type BalanceGroup = (order::Trader, eth::TokenAddress, order::SellTokenBalance);
 type Balances = HashMap<BalanceGroup, order::SellAmount>;
 
@@ -77,12 +87,16 @@ impl std::fmt::Debug for Utilities {
 
 /// All the data used to ensure that we only run 1 instance of
 /// [`DataFetchingTasks`] per auction shared by all the connected solvers.
-#[derive(Debug)]
+///
+/// Multiple auctions can overlap, so this stores preprocessing by auction
+/// id instead of keeping only the latest auction.
+#[derive(Debug, Default)]
 struct ControlBlock {
-    /// Auction for which the data aggregation task was spawned.
-    auction_id: i64,
-    /// Data aggregation task.
-    tasks: DataFetchingTasks,
+    /// Per-auction preprocessing tasks.
+    tasks: HashMap<i64, DataFetchingTasks>,
+
+    /// Access order used to evict old preprocessing handles.
+    order: VecDeque<i64>,
 }
 
 #[derive(Debug)]
@@ -93,15 +107,13 @@ pub struct DataAggregator {
 
 impl DataAggregator {
     /// Aggregates all the data that is needed to pre-process the given auction.
-    /// Uses a shared futures internally to make sure that the works happens
-    /// only once for all connected solvers to share.
+    /// Uses shared futures internally to make sure that the work happens only
+    /// once per auction for all connected solvers to share.
     pub async fn start_or_get_tasks_for_auction(
         &self,
         request: Request<Body>,
+        timeouts: Timeouts,
     ) -> Result<DataFetchingTasks> {
-        let mut lock = self.control.lock().await;
-        let current_auction = &lock.auction_id;
-
         // Figure out for which auction this `/solve` request was issued
         // by looking at the `X-Auction-Id` header.
         let request_auction_id: i64 = request
@@ -113,19 +125,44 @@ impl DataAggregator {
             .parse()
             .context("could not parse X-Auction-Id header as i64")?;
 
+        let mut lock = self.control.lock().await;
+
         // Some other driver is already doing the pre-processing for this
         // auction. Stop processing here and just await the existing task.
-        if request_auction_id == *current_auction {
+        if let Some(tasks) = lock.tasks.get(&request_auction_id).cloned() {
             init_auction_id_in_span(Some(request_auction_id));
             tracing::debug!("await running data aggregation task");
-            return Ok(lock.tasks.clone());
+
+            lock.order.retain(|id| *id != request_auction_id);
+            lock.order.push_back(request_auction_id);
+
+            return Ok(tasks);
         }
 
-        let tasks = self.assemble_tasks(request).await?;
+        let tasks = self.assemble_tasks(request, timeouts).await?;
 
         tracing::debug!("started new data aggregation task");
-        lock.auction_id = request_auction_id;
-        lock.tasks = tasks.clone();
+
+        lock.tasks.insert(request_auction_id, tasks.clone());
+        lock.order.push_back(request_auction_id);
+
+        while lock.tasks.len() > MAX_CONCURRENT_AUCTIONS {
+            let Some(evicted_auction_id) = lock.order.pop_front() else {
+                break;
+            };
+
+            if evicted_auction_id == request_auction_id {
+                lock.order.push_back(evicted_auction_id);
+                continue;
+            }
+
+            if lock.tasks.remove(&evicted_auction_id).is_some() {
+                tracing::debug!(
+                    auction_id = evicted_auction_id,
+                    "evicted preprocessing handle"
+                );
+            }
+        }
 
         Ok(tasks)
     }
@@ -166,37 +203,41 @@ impl DataAggregator {
                 balance_fetcher,
                 cow_amm_cache,
             }),
-            control: Mutex::new(ControlBlock {
-                auction_id: Default::default(),
-                tasks: DataFetchingTasks {
-                    auction: futures::future::pending().boxed().shared(),
-                    balances: futures::future::pending().boxed().shared(),
-                    app_data: futures::future::pending().boxed().shared(),
-                    cow_amm_orders: futures::future::pending().boxed().shared(),
-                    liquidity: futures::future::pending().boxed().shared(),
-                },
-            }),
+            control: Mutex::new(Default::default()),
         }
     }
 
-    async fn assemble_tasks(&self, request: Request<Body>) -> Result<DataFetchingTasks> {
+    async fn assemble_tasks(
+        &self,
+        request: Request<Body>,
+        timeouts: Timeouts,
+    ) -> Result<DataFetchingTasks> {
         let auction = self.utilities.parse_request(request).await?;
+        let deadline = auction.deadline(timeouts).driver();
+        let deadline_cancellation = Arc::new(DeadlineCancellation::new(deadline));
 
-        let balances =
-            Self::spawn_shared(Arc::clone(&self.utilities).fetch_balances(Arc::clone(&auction)));
+        let balances = Self::spawn_shared(
+            deadline_cancellation.clone(),
+            Arc::clone(&self.utilities).fetch_balances(Arc::clone(&auction)),
+        );
 
         let app_data = Self::spawn_shared(
+            deadline_cancellation.clone(),
             Arc::clone(&self.utilities).collect_orders_app_data(Arc::clone(&auction)),
         );
 
-        let cow_amm_orders =
-            Self::spawn_shared(Arc::clone(&self.utilities).cow_amm_orders(Arc::clone(&auction)));
+        let cow_amm_orders = Self::spawn_shared(
+            deadline_cancellation.clone(),
+            Arc::clone(&self.utilities).cow_amm_orders(Arc::clone(&auction)),
+        );
 
-        let liquidity =
-            Self::spawn_shared(Arc::clone(&self.utilities).fetch_liquidity(Arc::clone(&auction)));
+        let liquidity = Self::spawn_shared(
+            deadline_cancellation,
+            Arc::clone(&self.utilities).fetch_liquidity(Arc::clone(&auction)),
+        );
 
         Ok(DataFetchingTasks {
-            auction: futures::future::ready(auction).boxed().shared(),
+            auction: futures::future::ready(Ok(auction)).boxed().shared(),
             balances,
             app_data,
             cow_amm_orders,
@@ -208,14 +249,28 @@ impl DataAggregator {
     /// Errors are not handled as we are deferring all error handling to where
     /// the shared future is awaited.
     /// The future is being started immediately and polled in the background so
-    /// the caller doen't have to manage data dependencies directly.
-    fn spawn_shared<T>(fut: impl Future<Output = T> + Send + 'static) -> Shared<T>
+    /// the caller doesn't have to manage data dependencies directly.
+    fn spawn_shared<T>(
+        deadline: Arc<DeadlineCancellation>,
+        fut: impl Future<Output = T> + Send + 'static,
+    ) -> Shared<T>
     where
         T: Send + Sync + Clone + 'static,
     {
-        let shared = fut.instrument(tracing::Span::current()).boxed().shared();
+        let cancel = deadline.token();
 
-        // Start the computation in the background
+        let shared = async move {
+            let _deadline = deadline;
+
+            tokio::select! {
+                result = fut => Ok(result),
+                _ = cancel.cancelled() => Err(DeadlineExceeded),
+            }
+        }
+        .instrument(tracing::Span::current())
+        .boxed()
+        .shared();
+
         tokio::spawn(shared.clone());
 
         shared
@@ -574,4 +629,111 @@ async fn collect_request_body(request: Request<Body>) -> Result<body::Bytes> {
     let duration = start.elapsed();
     tracing::debug!(?duration, "finished streaming request body");
     Ok(body_bytes)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::Utc;
+    use std::time::Duration;
+    use std::sync::Arc;
+
+    /// fake DataFetchingTasks for tests
+    fn dummy_tasks() -> DataFetchingTasks {
+        DataFetchingTasks {
+            auction: futures::future::pending::<Result<Arc<Auction>, DeadlineExceeded>>()
+                .boxed()
+                .shared(),
+            balances: futures::future::pending::<Result<Arc<Balances>, DeadlineExceeded>>()
+                .boxed()
+                .shared(),
+            app_data:  futures::future::pending::<Result<Arc<HashMap<order::app_data::AppDataHash, Arc<app_data::ValidatedAppData>>>, DeadlineExceeded>>()
+                .boxed()
+                .shared(),
+            cow_amm_orders: futures::future::pending::<Result<Arc<Vec<Order>>, DeadlineExceeded>>()
+                .boxed()
+                .shared(),
+            liquidity:  futures::future::pending::<Result<Arc<Vec<liquidity::Liquidity>>, DeadlineExceeded>>()
+                .boxed()
+                .shared(),
+        }
+    }
+
+    #[tokio::test]
+    async fn reuses_existing_tasks_for_same_auction() {
+        let mut control = ControlBlock::default();
+
+        let tasks = dummy_tasks();
+
+        control.tasks.insert(1, tasks.clone());
+        control.order.push_back(1);
+
+        // Simulate lookup
+        let reused = control.tasks.get(&1).cloned();
+
+        assert!(reused.is_some());
+    }
+
+    #[tokio::test]
+    async fn stores_multiple_auctions() {
+        let mut control = ControlBlock::default();
+
+        control.tasks.insert(1, dummy_tasks());
+        control.tasks.insert(2, dummy_tasks());
+
+        assert_eq!(control.tasks.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn evicts_oldest_when_capacity_exceeded() {
+        let mut control = ControlBlock::default();
+
+        // Fill up to capacity
+        for i in 0..MAX_CONCURRENT_AUCTIONS {
+            control.tasks.insert(i as i64, dummy_tasks());
+            control.order.push_back(i as i64);
+        }
+
+        // should evict oldest
+        control.tasks.insert(999, dummy_tasks());
+        control.order.push_back(999);
+
+        while control.tasks.len() > MAX_CONCURRENT_AUCTIONS {
+            if let Some(old) = control.order.pop_front() {
+                control.tasks.remove(&old);
+            }
+        }
+
+        assert_eq!(control.tasks.len(), MAX_CONCURRENT_AUCTIONS);
+        assert!(!control.tasks.contains_key(&0));
+    }
+
+    #[tokio::test]
+    async fn cache_eviction_removes_handle_only() {
+        let mut control = ControlBlock::default();
+
+        control.tasks.insert(1, dummy_tasks());
+        control.order.push_back(1);
+
+        let evicted = control.tasks.remove(&1);
+
+        assert!(evicted.is_some());
+        assert!(!control.tasks.contains_key(&1));
+    }
+
+    #[tokio::test]
+    async fn deadline_cancels_shared_future() {
+        let deadline = Utc::now() + chrono::Duration::milliseconds(20);
+        let deadline = Arc::new(DeadlineCancellation::new(deadline));
+
+        let shared = DataAggregator::spawn_shared(deadline, async {
+            futures::future::pending::<Arc<()>>().await
+        });
+
+        let result = tokio::time::timeout(Duration::from_secs(1), shared)
+            .await
+            .expect("future resolved");
+
+        assert!(matches!(result, Err(DeadlineExceeded)));
+    }
 }

--- a/crates/driver/src/domain/competition/pre_processing.rs
+++ b/crates/driver/src/domain/competition/pre_processing.rs
@@ -88,9 +88,28 @@ impl std::fmt::Debug for Utilities {
 struct ControlBlock {
     /// Per-auction preprocessing tasks.
     tasks: HashMap<i64, DataFetchingTasks>,
-
     /// Access order used to evict old preprocessing handles.
     order: VecDeque<i64>,
+}
+
+impl ControlBlock {
+    fn touch(&mut self, auction_id: i64) {
+        self.order.retain(|id| *id != auction_id);
+        self.order.push_back(auction_id);
+    }
+
+    fn evict_oldest_except(&mut self, protected_auction_id: i64) {
+        while self.tasks.len() > MAX_CONCURRENT_AUCTIONS {
+            let Some(evicted_auction_id) = self.order.pop_front() else {
+                break;
+            };
+            if evicted_auction_id == protected_auction_id {
+                self.order.push_back(evicted_auction_id);
+                continue;
+            }
+            self.tasks.remove(&evicted_auction_id);
+        }
+    }
 }
 
 #[derive(Debug)]
@@ -119,44 +138,22 @@ impl DataAggregator {
             .context("could not parse X-Auction-Id header as i64")?;
 
         let mut lock = self.control.lock().await;
-
         // Some other driver is already doing the pre-processing for this
         // auction. Stop processing here and just await the existing task.
         if let Some(tasks) = lock.tasks.get(&request_auction_id).cloned() {
             init_auction_id_in_span(Some(request_auction_id));
             tracing::debug!("await running data aggregation task");
-
-            lock.order.retain(|id| *id != request_auction_id);
-            lock.order.push_back(request_auction_id);
-
+            lock.touch(request_auction_id);
             return Ok(tasks);
         }
 
+        // Keep the control lock while creating the tasks so concurrent requests for
+        // the same auction cannot start duplicate preprocessing work.
         let tasks = self.assemble_tasks(request).await?;
-
         tracing::debug!("started new data aggregation task");
-
         lock.tasks.insert(request_auction_id, tasks.clone());
-        lock.order.push_back(request_auction_id);
-
-        while lock.tasks.len() > MAX_CONCURRENT_AUCTIONS {
-            let Some(evicted_auction_id) = lock.order.pop_front() else {
-                break;
-            };
-
-            if evicted_auction_id == request_auction_id {
-                lock.order.push_back(evicted_auction_id);
-                continue;
-            }
-
-            if lock.tasks.remove(&evicted_auction_id).is_some() {
-                tracing::debug!(
-                    auction_id = evicted_auction_id,
-                    "evicted preprocessing handle"
-                );
-            }
-        }
-
+        lock.touch(request_auction_id);
+        lock.evict_oldest_except(request_auction_id);
         Ok(tasks)
     }
 
@@ -202,6 +199,8 @@ impl DataAggregator {
 
     async fn assemble_tasks(&self, request: Request<Body>) -> Result<DataFetchingTasks> {
         let auction = self.utilities.parse_request(request).await?;
+        // Keep this alive for the whole solve path, dropping it will abort the timer
+        // task.
         let deadline_cancellation = Arc::new(DeadlineCancellation::new(auction.deadline));
 
         let balances = Self::spawn_shared(
@@ -238,6 +237,8 @@ impl DataAggregator {
     /// the shared future is awaited.
     /// The future is being started immediately and polled in the background so
     /// the caller doesn't have to manage data dependencies directly.
+    /// The `DeadlineCancellation` guard is moved into the shared future so the
+    /// deadline timer stays alive until the shared task completes.
     fn spawn_shared<T>(
         deadline: Arc<DeadlineCancellation>,
         fut: impl Future<Output = T> + Send + 'static,
@@ -246,10 +247,10 @@ impl DataAggregator {
         T: Send + Sync + Clone + 'static,
     {
         let cancel = deadline.token();
-
         let shared = async move {
-            let _deadline = deadline;
-
+            // Keep the deadline guard alive so its background task can cancel the token
+            // when the deadline is reached.
+            let _deadline_guard = deadline;
             tokio::select! {
                 result = fut => Ok(result),
                 _ = cancel.cancelled() => Err(DeadlineExceeded),
@@ -258,7 +259,7 @@ impl DataAggregator {
         .instrument(tracing::Span::current())
         .boxed()
         .shared();
-
+        // Start the computation in the background
         tokio::spawn(shared.clone());
 
         shared
@@ -268,7 +269,7 @@ impl DataAggregator {
 impl Utilities {
     /// Parses the JSON body of the `/solve` request during the unified
     /// auction pre-processing since eagerly deserializing these requests
-    /// is surprisingly costly because their are so big.
+    /// is surprisingly costly because they are so big.
     async fn parse_request(&self, solve_request: Request<Body>) -> Result<Arc<Auction>> {
         let solve_request = collect_request_body(solve_request).await?;
 
@@ -474,7 +475,7 @@ impl Utilities {
             cow_amms
                 .into_iter()
                 // Only generate orders where the auction provided the required
-                // reference prices. Otherwise there will be an error during the
+                // reference prices. Otherwise, there will be an error during the
                 // surplus calculation which will also result in 0 surplus for
                 // this order.
                 .filter_map(|amm| {
@@ -624,6 +625,7 @@ mod tests {
     use {
         super::*,
         chrono::Utc,
+        futures::future,
         std::{sync::Arc, time::Duration},
     };
 
@@ -656,7 +658,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn reuses_existing_tasks_for_same_auction() {
+    async fn reuses_existing_tasks_for_auction() {
         let mut control = ControlBlock::default();
 
         let tasks = dummy_tasks();
@@ -681,31 +683,29 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn evicts_oldest_when_capacity_exceeded() {
+    async fn evicts_oldest_when_capacity_maxed() {
         let mut control = ControlBlock::default();
 
-        // Fill up to capacity
+        // Fill up to capacity.
         for i in 0..MAX_CONCURRENT_AUCTIONS {
-            control.tasks.insert(i as i64, dummy_tasks());
-            control.order.push_back(i as i64);
+            let i = i64::try_from(i).unwrap();
+            control.tasks.insert(i, dummy_tasks());
+            control.touch(i);
         }
 
-        // should evict oldest
-        control.tasks.insert(999, dummy_tasks());
-        control.order.push_back(999);
-
-        while control.tasks.len() > MAX_CONCURRENT_AUCTIONS {
-            if let Some(old) = control.order.pop_front() {
-                control.tasks.remove(&old);
-            }
-        }
+        // Adding another auction should evict the oldest handle.
+        let new_auction_id = 999_i64;
+        control.tasks.insert(new_auction_id, dummy_tasks());
+        control.touch(new_auction_id);
+        control.evict_oldest_except(new_auction_id);
 
         assert_eq!(control.tasks.len(), MAX_CONCURRENT_AUCTIONS);
         assert!(!control.tasks.contains_key(&0));
+        assert!(control.tasks.contains_key(&new_auction_id));
     }
 
     #[tokio::test]
-    async fn cache_eviction_removes_handle_only() {
+    async fn cache_eviction_removes_handle() {
         let mut control = ControlBlock::default();
 
         control.tasks.insert(1, dummy_tasks());
@@ -718,18 +718,48 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn deadline_cancels_shared_future() {
-        let deadline = Utc::now() + chrono::Duration::milliseconds(20);
+    async fn deadline_cancels_shared() {
+        let deadline = Utc::now() + chrono::Duration::seconds(3);
         let deadline = Arc::new(DeadlineCancellation::new(deadline));
 
         let shared = DataAggregator::spawn_shared(deadline, async {
             futures::future::pending::<Arc<()>>().await
         });
 
-        let result = tokio::time::timeout(Duration::from_secs(1), shared)
+        let result = tokio::time::timeout(Duration::from_secs(5), shared)
             .await
-            .expect("future resolved");
+            .expect("resolved");
 
         assert!(matches!(result, Err(DeadlineExceeded)));
+    }
+
+    #[tokio::test]
+    async fn spawn_shared_keeps_deadline_alive() {
+        let deadline = Arc::new(DeadlineCancellation::new(
+            Utc::now() + chrono::Duration::milliseconds(20),
+        ));
+
+        let token = deadline.token();
+        let shared = DataAggregator::spawn_shared(deadline, future::pending::<()>());
+
+        tokio::time::timeout(Duration::from_secs(1), shared)
+            .await
+            .expect("should complete")
+            .expect_err("should be cancelled");
+
+        assert!(token.is_cancelled());
+    }
+
+    #[tokio::test]
+    async fn spawn_shared_returns_result_before_deadline() {
+        let deadline = Arc::new(DeadlineCancellation::new(
+            Utc::now() + chrono::Duration::seconds(60),
+        ));
+
+        let shared = DataAggregator::spawn_shared(deadline, async { "ok" });
+
+        let result = shared.await.expect("should complete");
+
+        assert_eq!(result, "ok");
     }
 }

--- a/crates/driver/src/domain/competition/pre_processing.rs
+++ b/crates/driver/src/domain/competition/pre_processing.rs
@@ -11,13 +11,7 @@ use {
             liquidity,
             time::DeadlineExceeded,
         },
-        infra::{
-            self,
-            api::routes::solve::dto::SolveRequest,
-            observe::metrics,
-            solver::Timeouts,
-            tokens,
-        },
+        infra::{self, api::routes::solve::dto::SolveRequest, observe::metrics, tokens},
     },
     account_balances::{BalanceFetching, Query},
     alloy::primitives::{Bytes, FixedBytes},
@@ -112,7 +106,6 @@ impl DataAggregator {
     pub async fn start_or_get_tasks_for_auction(
         &self,
         request: Request<Body>,
-        timeouts: Timeouts,
     ) -> Result<DataFetchingTasks> {
         // Figure out for which auction this `/solve` request was issued
         // by looking at the `X-Auction-Id` header.
@@ -139,7 +132,7 @@ impl DataAggregator {
             return Ok(tasks);
         }
 
-        let tasks = self.assemble_tasks(request, timeouts).await?;
+        let tasks = self.assemble_tasks(request).await?;
 
         tracing::debug!("started new data aggregation task");
 
@@ -207,14 +200,9 @@ impl DataAggregator {
         }
     }
 
-    async fn assemble_tasks(
-        &self,
-        request: Request<Body>,
-        timeouts: Timeouts,
-    ) -> Result<DataFetchingTasks> {
+    async fn assemble_tasks(&self, request: Request<Body>) -> Result<DataFetchingTasks> {
         let auction = self.utilities.parse_request(request).await?;
-        let deadline = auction.deadline(timeouts).driver();
-        let deadline_cancellation = Arc::new(DeadlineCancellation::new(deadline));
+        let deadline_cancellation = Arc::new(DeadlineCancellation::new(auction.deadline));
 
         let balances = Self::spawn_shared(
             deadline_cancellation.clone(),

--- a/crates/driver/src/domain/competition/pre_processing.rs
+++ b/crates/driver/src/domain/competition/pre_processing.rs
@@ -633,10 +633,11 @@ async fn collect_request_body(request: Request<Body>) -> Result<body::Bytes> {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use chrono::Utc;
-    use std::time::Duration;
-    use std::sync::Arc;
+    use {
+        super::*,
+        chrono::Utc,
+        std::{sync::Arc, time::Duration},
+    };
 
     /// fake DataFetchingTasks for tests
     fn dummy_tasks() -> DataFetchingTasks {
@@ -647,15 +648,22 @@ mod tests {
             balances: futures::future::pending::<Result<Arc<Balances>, DeadlineExceeded>>()
                 .boxed()
                 .shared(),
-            app_data:  futures::future::pending::<Result<Arc<HashMap<order::app_data::AppDataHash, Arc<app_data::ValidatedAppData>>>, DeadlineExceeded>>()
-                .boxed()
-                .shared(),
+            app_data: futures::future::pending::<
+                Result<
+                    Arc<HashMap<order::app_data::AppDataHash, Arc<app_data::ValidatedAppData>>>,
+                    DeadlineExceeded,
+                >,
+            >()
+            .boxed()
+            .shared(),
             cow_amm_orders: futures::future::pending::<Result<Arc<Vec<Order>>, DeadlineExceeded>>()
                 .boxed()
                 .shared(),
-            liquidity:  futures::future::pending::<Result<Arc<Vec<liquidity::Liquidity>>, DeadlineExceeded>>()
-                .boxed()
-                .shared(),
+            liquidity: futures::future::pending::<
+                Result<Arc<Vec<liquidity::Liquidity>>, DeadlineExceeded>,
+            >()
+            .boxed()
+            .shared(),
         }
     }
 

--- a/crates/driver/src/domain/competition/risk_detector/mod.rs
+++ b/crates/driver/src/domain/competition/risk_detector/mod.rs
@@ -6,20 +6,25 @@
 //! was simply built with a buggy compiler which makes it incompatible
 //! with the settlement contract (see <https://github.com/cowprotocol/services/pull/781>).
 //!
-//! Additionally there are some heuristics to detect when an
+//! Additionally, there are some heuristics to detect when an
 //! order itself is somehow broken or causes issues and slipped through
 //! other detection mechanisms. One big error case is orders adjusting
-//! debt postions in lending protocols. While pre-checks might correctly
+//! debt positions in lending protocols. While pre-checks might correctly
 //! detect that the EIP 1271 signature is valid the transfer of the token
 //! would fail because the user's debt position is not collateralized enough.
 //! In other words the bad order detection is a last fail safe in case
 //! we were not able to predict issues with orders and pre-emptively
 //! filter them out of the auction.
+
 use {
-    crate::domain::competition::{Auction, order::Uid},
+    crate::domain::{
+        competition::{Auction, order::Uid},
+        time::DeadlineExceeded,
+    },
     eth_domain_types as eth,
     futures::{StreamExt, stream::FuturesUnordered},
     std::{collections::HashMap, fmt, time::Instant},
+    tokio_util::sync::CancellationToken,
 };
 
 pub mod bad_orders;
@@ -81,7 +86,15 @@ impl Detector {
     }
 
     /// Removes all unsupported orders from the auction.
-    pub async fn filter_unsupported_orders_in_auction(&self, mut auction: Auction) -> Auction {
+    pub async fn filter_unsupported_orders_in_auction(
+        &self,
+        mut auction: Auction,
+        cancel: &CancellationToken,
+    ) -> Result<Auction, DeadlineExceeded> {
+        // Early exit before doing any work if already cancelled
+        if cancel.is_cancelled() {
+            return Err(DeadlineExceeded);
+        }
         let now = Instant::now();
 
         // reuse the original allocation
@@ -128,11 +141,22 @@ impl Detector {
             })
             .collect();
 
-        while let Some((order, quality)) = token_quality_checks.next().await {
-            if quality == Quality::Supported {
-                supported_orders.push(order);
-            } else {
-                removed_uids.push(order.uid);
+        // Process async checks with cancellation
+        loop {
+            tokio::select! {
+                _ = cancel.cancelled() => {
+                    return Err(DeadlineExceeded);
+                }
+                result = token_quality_checks.next() => {
+                    let Some((order, quality)) = result else {
+                        break;
+                    };
+                    if quality == Quality::Supported {
+                        supported_orders.push(order);
+                    } else {
+                        removed_uids.push(order.uid);
+                    }
+                }
             }
         }
 
@@ -145,7 +169,7 @@ impl Detector {
             detector.evict_outdated_entries();
         }
 
-        auction
+        Ok(auction)
     }
 
     /// Updates the tokens quality metric for successful operation.
@@ -180,5 +204,41 @@ impl fmt::Debug for Detector {
         f.debug_struct("Detector")
             .field("hardcoded", &self.hardcoded)
             .finish()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use {
+        super::*,
+        crate::domain::competition::auction::{Auction, Tokens},
+        chrono::Utc,
+        std::collections::HashSet,
+    };
+
+    #[tokio::test]
+    async fn filter_unsupported_orders_in_auction_cancels() {
+        let detector = Detector::default();
+        let cancel = CancellationToken::new();
+        cancel.cancel();
+
+        let auction = Auction {
+            id: None,
+            orders: Default::default(),
+            tokens: Tokens::default(),
+            gas_price: eth::GasPrice::new(
+                alloy::primitives::U256::ZERO.into(),
+                alloy::primitives::U256::ZERO.into(),
+                0,
+            ),
+            deadline: Utc::now(),
+            surplus_capturing_jit_order_owners: HashSet::new(),
+        };
+
+        let result = detector
+            .filter_unsupported_orders_in_auction(auction, &cancel)
+            .await;
+
+        assert!(matches!(result, Err(DeadlineExceeded)));
     }
 }

--- a/crates/driver/src/domain/competition/sorting.rs
+++ b/crates/driver/src/domain/competition/sorting.rs
@@ -148,21 +148,17 @@ pub fn sort_orders(
     }
 
     let now = chrono::Utc::now();
-
     let mut keyed = Vec::with_capacity(orders.len());
-
     for (index, order) in orders.iter().enumerate() {
         if cancel.is_cancelled() {
             return Err(DeadlineExceeded);
         }
-
         let key = std::cmp::Reverse(
             order_comparators
                 .iter()
                 .map(|cmp| cmp.key(order, tokens, solver, now))
                 .collect::<Vec<_>>(),
         );
-
         keyed.push((key, index));
     }
 
@@ -170,6 +166,8 @@ pub fn sort_orders(
         return Err(DeadlineExceeded);
     }
 
+    // Once this has started it runs to completion before cancellation can be
+    // observed again.
     keyed.sort_by_key(|(key, _)| key.clone());
 
     if cancel.is_cancelled() {
@@ -180,9 +178,7 @@ pub fn sort_orders(
         .into_iter()
         .map(|(_, index)| orders[index].clone())
         .collect::<Vec<_>>();
-
     orders.clone_from_slice(&sorted);
-
     Ok(())
 }
 
@@ -203,5 +199,19 @@ mod tests {
         let result = sort_orders(&mut orders, &tokens, &solver, &strategies, &cancel);
 
         assert!(matches!(result, Err(DeadlineExceeded)));
+    }
+
+    #[test]
+    fn sort_orders_empty_input_succeeds_when_not_cancelled() {
+        let cancel = CancellationToken::new();
+
+        let mut orders = Vec::new();
+        let tokens = Tokens::default();
+        let solver = eth::Address::default();
+        let strategies = Vec::<Arc<dyn SortingStrategy>>::new();
+
+        let result = sort_orders(&mut orders, &tokens, &solver, &strategies, &cancel);
+
+        assert!(result.is_ok());
     }
 }

--- a/crates/driver/src/domain/competition/sorting.rs
+++ b/crates/driver/src/domain/competition/sorting.rs
@@ -1,3 +1,4 @@
+use tokio_util::sync::CancellationToken;
 use {
     crate::{
         domain::competition::{auction::Tokens, order},
@@ -7,6 +8,7 @@ use {
     eth_domain_types as eth,
     std::{fmt::Debug, sync::Arc},
 };
+use crate::domain::time::DeadlineExceeded;
 
 #[derive(PartialEq, Eq, PartialOrd, Ord)]
 pub enum SortingKey {
@@ -130,13 +132,20 @@ impl SortingStrategy for OwnQuotes {
 
 /// Sort orders based on the provided comparators. Reverse ordering is used to
 /// ensure that the most important element comes first.
+/// Returns `DeadlineExceeded` if cancel has been triggered.
 pub fn sort_orders(
     orders: &mut [order::Order],
     tokens: &Tokens,
     solver: &eth::Address,
     order_comparators: &[Arc<dyn SortingStrategy>],
-) {
+    cancel: &CancellationToken,
+) -> Result<(), DeadlineExceeded> {
+    if cancel.is_cancelled() {
+        return Err(DeadlineExceeded);
+    }
+
     let now = chrono::Utc::now();
+
     orders.sort_by_cached_key(|order| {
         std::cmp::Reverse(
             order_comparators
@@ -145,4 +154,10 @@ pub fn sort_orders(
                 .collect::<Vec<_>>(),
         )
     });
+
+    if cancel.is_cancelled() {
+        return Err(DeadlineExceeded);
+    }
+
+    Ok(())
 }

--- a/crates/driver/src/domain/competition/sorting.rs
+++ b/crates/driver/src/domain/competition/sorting.rs
@@ -12,7 +12,7 @@ use {
     tokio_util::sync::CancellationToken,
 };
 
-#[derive(PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub enum SortingKey {
     Float(OrdFloat),
     Timestamp(Option<util::Timestamp>),
@@ -63,6 +63,7 @@ impl SortingStrategy for ExternalPrice {
 /// We use a wrapper around [f64] to make it sortable
 /// which is significantly faster than the
 /// [num::BigRational] we used before.
+#[derive(Clone)]
 pub struct OrdFloat(f64);
 impl PartialOrd for OrdFloat {
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
@@ -148,26 +149,46 @@ pub fn sort_orders(
 
     let now = chrono::Utc::now();
 
-    orders.sort_by_cached_key(|order| {
-        std::cmp::Reverse(
+    let mut keyed = Vec::with_capacity(orders.len());
+
+    for (index, order) in orders.iter().enumerate() {
+        if cancel.is_cancelled() {
+            return Err(DeadlineExceeded);
+        }
+
+        let key = std::cmp::Reverse(
             order_comparators
                 .iter()
                 .map(|cmp| cmp.key(order, tokens, solver, now))
                 .collect::<Vec<_>>(),
-        )
-    });
+        );
+
+        keyed.push((key, index));
+    }
 
     if cancel.is_cancelled() {
         return Err(DeadlineExceeded);
     }
+
+    keyed.sort_by_key(|(key, _)| key.clone());
+
+    if cancel.is_cancelled() {
+        return Err(DeadlineExceeded);
+    }
+
+    let sorted = keyed
+        .into_iter()
+        .map(|(_, index)| orders[index].clone())
+        .collect::<Vec<_>>();
+
+    orders.clone_from_slice(&sorted);
 
     Ok(())
 }
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use tokio_util::sync::CancellationToken;
+    use {super::*, tokio_util::sync::CancellationToken};
 
     #[test]
     fn sort_orders_cancelled() {

--- a/crates/driver/src/domain/competition/sorting.rs
+++ b/crates/driver/src/domain/competition/sorting.rs
@@ -1,14 +1,16 @@
-use tokio_util::sync::CancellationToken;
 use {
     crate::{
-        domain::competition::{auction::Tokens, order},
+        domain::{
+            competition::{auction::Tokens, order},
+            time::DeadlineExceeded,
+        },
         util,
     },
     chrono::Duration,
     eth_domain_types as eth,
     std::{fmt::Debug, sync::Arc},
+    tokio_util::sync::CancellationToken,
 };
-use crate::domain::time::DeadlineExceeded;
 
 #[derive(PartialEq, Eq, PartialOrd, Ord)]
 pub enum SortingKey {

--- a/crates/driver/src/domain/competition/sorting.rs
+++ b/crates/driver/src/domain/competition/sorting.rs
@@ -163,3 +163,24 @@ pub fn sort_orders(
 
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tokio_util::sync::CancellationToken;
+
+    #[test]
+    fn sort_orders_cancelled() {
+        let cancel = CancellationToken::new();
+        cancel.cancel();
+
+        let mut orders = Vec::new();
+        let tokens = Tokens::default();
+        let solver = eth::Address::default();
+        let strategies = Vec::<Arc<dyn SortingStrategy>>::new();
+
+        let result = sort_orders(&mut orders, &tokens, &solver, &strategies, &cancel);
+
+        assert!(matches!(result, Err(DeadlineExceeded)));
+    }
+}

--- a/crates/driver/src/domain/quote.rs
+++ b/crates/driver/src/domain/quote.rs
@@ -18,6 +18,7 @@ use {
     chrono::Utc,
     eth_domain_types as eth,
     std::collections::{HashMap, HashSet},
+    tokio_util::sync::CancellationToken,
 };
 
 /// A quote describing the expected outcome of an order.
@@ -145,9 +146,10 @@ impl Order {
         let auction = self
             .fake_auction(eth, tokens, solver.quote_using_limit_orders())
             .await?;
+        let cancel = CancellationToken::new(); // no deadline
         let auction = risk_detector
-            .filter_unsupported_orders_in_auction(auction)
-            .await;
+            .filter_unsupported_orders_in_auction(auction, &cancel)
+            .await?;
         if auction.orders.is_empty() {
             return Err(QuotingFailed::UnsupportedToken.into());
         }

--- a/crates/driver/src/domain/time.rs
+++ b/crates/driver/src/domain/time.rs
@@ -71,6 +71,6 @@ impl Remaining for chrono::DateTime<chrono::Utc> {
     }
 }
 
-#[derive(Debug, Error)]
+#[derive(Clone, Copy, Debug, Eq, Error, PartialEq)]
 #[error("the deadline has been exceeded")]
 pub struct DeadlineExceeded;

--- a/crates/driver/src/infra/observe/metrics.rs
+++ b/crates/driver/src/infra/observe/metrics.rs
@@ -58,6 +58,10 @@ pub struct Metrics {
         )
     )]
     pub used_solve_time: prometheus::HistogramVec,
+
+    /// Auction work canceled before producing a result.
+    #[metric(labels("stage", "reason"))]
+    pub auction_cancellations: prometheus::IntCounterVec,
 }
 
 impl Metrics {

--- a/crates/driver/src/infra/observe/metrics.rs
+++ b/crates/driver/src/infra/observe/metrics.rs
@@ -58,7 +58,6 @@ pub struct Metrics {
         )
     )]
     pub used_solve_time: prometheus::HistogramVec,
-
     /// Auction work canceled before producing a result.
     #[metric(labels("stage", "reason"))]
     pub auction_cancellations: prometheus::IntCounterVec,

--- a/crates/driver/src/infra/observe/mod.rs
+++ b/crates/driver/src/infra/observe/mod.rs
@@ -497,3 +497,12 @@ pub fn simulated(eth: &Ethereum, tx: &eth::Tx, gas: &Result<Gas, simulator::Erro
         Err(err) => tracing::debug!(block = ?block, ?err, "simulated settlement"),
     }
 }
+
+/// Observe that auction work was canceled.
+pub fn auction_cancelled(stage: &'static str, reason: &'static str) {
+    tracing::debug!(stage, reason, "cancelled auction work");
+    metrics::get()
+        .auction_cancellations
+        .with_label_values(&[stage, reason])
+        .inc();
+}

--- a/crates/driver/src/tests/cases/auction_deadline_exceeded.rs
+++ b/crates/driver/src/tests/cases/auction_deadline_exceeded.rs
@@ -15,7 +15,7 @@ async fn solve_returns_no_solutions_when_request_arrives_after_deadline() {
 #[tokio::test]
 async fn solve_returns_solution_when_within_deadline() {
     let test = setup()
-        .set_deadline(crate::infra::time::now() + chrono::Duration::seconds(5))
+        .set_deadline(crate::infra::time::now() + chrono::Duration::seconds(8))
         .pool(weth_pool())
         .order(eth_order())
         .solution(eth_solution())
@@ -26,14 +26,14 @@ async fn solve_returns_solution_when_within_deadline() {
 }
 
 #[tokio::test]
-async fn solve_returns_no_solutions_when_solver_outlives_deadline() {
+async fn solve_returns_no_solutions_when_solver_after_deadline() {
     let test = setup()
-        .set_deadline(crate::infra::time::now() + chrono::Duration::milliseconds(500))
+        .set_deadline(crate::infra::time::now() + chrono::Duration::seconds(3))
         .pool(weth_pool())
         .order(eth_order())
         .solution(eth_solution())
         .solvers(vec![
-            test_solver().solve_delay(std::time::Duration::from_secs(1)),
+            test_solver().solve_delay(std::time::Duration::from_secs(4)),
         ])
         .done()
         .await;
@@ -42,19 +42,19 @@ async fn solve_returns_no_solutions_when_solver_outlives_deadline() {
 }
 
 #[tokio::test]
-async fn solve_returns_no_solutions_when_all_solvers_outlive_deadline() {
+async fn solve_returns_no_solutions_when_all_solvers_after_deadline() {
     let test = setup()
-        .set_deadline(crate::infra::time::now() + chrono::Duration::milliseconds(500))
+        .set_deadline(crate::infra::time::now() + chrono::Duration::seconds(3))
         .pool(weth_pool())
         .order(eth_order())
         .solution(eth_solution())
         .solvers(vec![
             test_solver()
                 .name("solver1")
-                .solve_delay(std::time::Duration::from_secs(1)),
+                .solve_delay(std::time::Duration::from_secs(4)),
             test_solver()
                 .name("solver2")
-                .solve_delay(std::time::Duration::from_secs(2)),
+                .solve_delay(std::time::Duration::from_secs(5)),
         ])
         .done()
         .await;
@@ -69,16 +69,16 @@ async fn solve_returns_no_solutions_when_all_solvers_outlive_deadline() {
 }
 
 #[tokio::test]
-async fn solve_returns_fast_solver_solution_when_slow_solver_outlives_deadline() {
+async fn solve_returns_fast_solver_solution_slow_solver_empty_after_deadline() {
     let test = setup()
-        .set_deadline(crate::infra::time::now() + chrono::Duration::seconds(3))
+        .set_deadline(crate::infra::time::now() + chrono::Duration::seconds(5))
         .pool(weth_pool())
         .order(eth_order())
         .solution(eth_solution())
         .solvers(vec![
             test_solver()
                 .name("slow")
-                .solve_delay(std::time::Duration::from_secs(4)),
+                .solve_delay(std::time::Duration::from_secs(8)),
             test_solver().name("fast"),
         ])
         .done()

--- a/crates/driver/src/tests/cases/auction_deadline_exceeded.rs
+++ b/crates/driver/src/tests/cases/auction_deadline_exceeded.rs
@@ -1,0 +1,94 @@
+use crate::tests::setup::{eth_order, eth_solution, setup, test_solver, weth_pool};
+#[tokio::test]
+async fn solve_returns_no_solutions_when_request_arrives_after_deadline() {
+    let test = setup()
+        .set_deadline(crate::infra::time::now() - chrono::Duration::milliseconds(50))
+        .pool(weth_pool())
+        .order(eth_order())
+        .solution(eth_solution())
+        .done()
+        .await;
+
+    test.solve().await.ok().empty();
+}
+
+#[tokio::test]
+async fn solve_returns_solution_when_within_deadline() {
+    let test = setup()
+        .set_deadline(crate::infra::time::now() + chrono::Duration::seconds(5))
+        .pool(weth_pool())
+        .order(eth_order())
+        .solution(eth_solution())
+        .done()
+        .await;
+
+    test.solve().await.ok().solution();
+}
+
+#[tokio::test]
+async fn solve_returns_no_solutions_when_solver_outlives_deadline() {
+    let test = setup()
+        .set_deadline(crate::infra::time::now() + chrono::Duration::milliseconds(500))
+        .pool(weth_pool())
+        .order(eth_order())
+        .solution(eth_solution())
+        .solvers(vec![
+            test_solver().solve_delay(std::time::Duration::from_secs(1)),
+        ])
+        .done()
+        .await;
+
+    test.solve().await.ok().empty();
+}
+
+#[tokio::test]
+async fn solve_returns_no_solutions_when_all_solvers_outlive_deadline() {
+    let test = setup()
+        .set_deadline(crate::infra::time::now() + chrono::Duration::milliseconds(500))
+        .pool(weth_pool())
+        .order(eth_order())
+        .solution(eth_solution())
+        .solvers(vec![
+            test_solver()
+                .name("solver1")
+                .solve_delay(std::time::Duration::from_secs(1)),
+            test_solver()
+                .name("solver2")
+                .solve_delay(std::time::Duration::from_secs(2)),
+        ])
+        .done()
+        .await;
+
+    let (solver1, solver2) = tokio::join!(
+        test.solve_with_solver("solver1"),
+        test.solve_with_solver("solver2"),
+    );
+
+    solver1.ok().empty();
+    solver2.ok().empty();
+}
+
+#[tokio::test]
+async fn solve_returns_fast_solver_solution_when_slow_solver_outlives_deadline() {
+    let test = setup()
+        .set_deadline(crate::infra::time::now() + chrono::Duration::seconds(3))
+        .pool(weth_pool())
+        .order(eth_order())
+        .solution(eth_solution())
+        .solvers(vec![
+            test_solver()
+                .name("slow")
+                .solve_delay(std::time::Duration::from_secs(4)),
+            test_solver().name("fast"),
+        ])
+        .done()
+        .await;
+
+    let (fast, slow) = tokio::join!(
+        test.solve_with_solver("fast"),
+        test.solve_with_solver("slow"),
+    );
+
+    fast.ok().solution();
+    slow.ok().empty();
+}

--- a/crates/driver/src/tests/cases/mod.rs
+++ b/crates/driver/src/tests/cases/mod.rs
@@ -8,6 +8,7 @@ use {
     std::str::FromStr,
 };
 
+mod auction_deadline_exceeded;
 pub mod buy_eth;
 pub mod example_config;
 pub mod fees;

--- a/crates/driver/src/tests/setup/mod.rs
+++ b/crates/driver/src/tests/setup/mod.rs
@@ -1,5 +1,4 @@
 //! Framework for setting up tests.
-
 use {
     self::{driver::Driver, solver::Solver as SolverInstance},
     crate::{
@@ -365,6 +364,8 @@ pub struct Solver {
     max_solutions_to_propose: usize,
     /// Additional submission accounts for EIP-7702 parallel settlement.
     submission_accounts: Vec<eth::Address>,
+    /// Delay the solver
+    solver_delay: Option<std::time::Duration>,
 }
 
 #[derive(Debug, Clone)]
@@ -394,6 +395,7 @@ pub fn test_solver() -> Solver {
         haircut_bps: 0,
         max_solutions_to_propose: 1,
         submission_accounts: vec![],
+        solver_delay: None,
     }
 }
 
@@ -447,6 +449,11 @@ impl Solver {
 
     pub fn submission_account(mut self, address: eth::Address) -> Self {
         self.submission_accounts.push(address);
+        self
+    }
+
+    pub fn solve_delay(mut self, delay: std::time::Duration) -> Self {
+        self.solver_delay = Some(delay);
         self
     }
 }
@@ -517,6 +524,7 @@ pub fn setup() -> Setup {
         auction_id: 1,
         settle_submission_deadline: 3,
         flashloans_enabled: true,
+        deadline: None,
         ..Default::default()
     }
 }
@@ -560,6 +568,8 @@ pub struct Setup {
     settle_submission_deadline: u64,
     /// Should flashloan-hint orders be accepted by the driver? True by default.
     flashloans_enabled: bool,
+    /// Deadline
+    deadline: Option<chrono::DateTime<chrono::Utc>>,
 }
 
 /// The validity of a solution.
@@ -915,6 +925,12 @@ impl Setup {
         self
     }
 
+    /// Sets the deadline
+    pub fn set_deadline(mut self, deadline: chrono::DateTime<chrono::Utc>) -> Self {
+        self.deadline = Some(deadline);
+        self
+    }
+
     /// Create the test: set up onchain contracts and pools, start a mock HTTP
     /// server for the solver and start the HTTP server for the driver.
     pub async fn done(self) -> Test {
@@ -1008,6 +1024,7 @@ impl Setup {
                 expected_surplus_capturing_jit_order_owners: surplus_capturing_jit_order_owners
                     .clone(),
                 allow_multiple_solve_requests: self.allow_multiple_solve_requests,
+                solver_delay: solver.solver_delay,
             })
             .await;
 
@@ -1060,7 +1077,8 @@ impl Setup {
     }
 
     fn deadline(&self) -> chrono::DateTime<chrono::Utc> {
-        crate::infra::time::now() + chrono::Duration::seconds(2)
+        self.deadline
+            .unwrap_or_else(|| crate::infra::time::now() + chrono::Duration::seconds(2))
     }
 
     pub fn allow_multiple_solve_requests(mut self) -> Self {

--- a/crates/driver/src/tests/setup/solver.rs
+++ b/crates/driver/src/tests/setup/solver.rs
@@ -505,7 +505,6 @@ impl Solver {
                         "surplusCapturingJitOrderOwners": config.expected_surplus_capturing_jit_order_owners,
                     });
                     check_solve_request(req, expected);
-
                     {
                         let mut state = state.0.lock().unwrap();
                         assert!(
@@ -514,11 +513,9 @@ impl Solver {
                         );
                         state.called = true;
                     }
-
                     if let Some(delay) = config.solver_delay {
                         tokio::time::sleep(delay).await;
                     }
-
                     axum::response::Json(json!({
                         "solutions": solutions_json,
                     }))

--- a/crates/driver/src/tests/setup/solver.rs
+++ b/crates/driver/src/tests/setup/solver.rs
@@ -48,6 +48,7 @@ pub struct Config<'a> {
     pub private_key: PrivateKeySigner,
     pub expected_surplus_capturing_jit_order_owners: Vec<Address>,
     pub allow_multiple_solve_requests: bool,
+    pub solver_delay: Option<std::time::Duration>,
 }
 
 impl Solver {
@@ -504,12 +505,20 @@ impl Solver {
                         "surplusCapturingJitOrderOwners": config.expected_surplus_capturing_jit_order_owners,
                     });
                     check_solve_request(req, expected);
-                    let mut state = state.0.lock().unwrap();
-                    assert!(
-                        !state.called || state.allow_multiple_solve_requests,
-                        "can't call /solve multiple times"
-                    );
-                    state.called = true;
+
+                    {
+                        let mut state = state.0.lock().unwrap();
+                        assert!(
+                            !state.called || state.allow_multiple_solve_requests,
+                            "can't call /solve multiple times"
+                        );
+                        state.called = true;
+                    }
+
+                    if let Some(delay) = config.solver_delay {
+                        tokio::time::sleep(delay).await;
+                    }
+
                     axum::response::Json(json!({
                         "solutions": solutions_json,
                     }))


### PR DESCRIPTION
# Description

Currently, deadlines are observed only when results are finalized, but work that is already in progress can continue running after the auction deadline has passed.
This includes shared preprocessing, blocking order processing, order filtering, encoding, and re-simulation.

This PR introduces a cancellation token bound to the deadline and propagates it through the auction path. It also applies cooperative cancellation to blocking tasks, allowing it to terminate early as well.

Work that has become stale and can no longer contribute to the auction can now observe expiry and terminate early, reducing unnecessary execution and freeing resources for subsequent auctions.

This change does not change how results are produced.

# Changes

- Adds `DeadlineCancellation` struct, wrapping a `CancellationToken` and a Tokio task:
  - Cancels automatically when the configured deadline is reached.
  - Cancels immediately for expired deadlines.
  - Dropping aborts the timed task, does not cancel the token later.

- Add `DeadlineCancellation` to `spawn_shared`:
  - Shared tasks in pre-processing observes cancellation.
  - Deadline guard kept alive throughout shared preprocessing tasks.
  - return `DeadlineExceeded` when shared task is cancelled.

- Make auction processing observe auction deadline:
  - Shared pre-processing
  - CoW AMM order fetching
  - Order sorting
  - Order updating
  - Liquidity fetching
  - Order filtering
  - Settlement encoding
  - Re-simulation

- Add co-operative cancellation to blocking tasks:
  - Pass `CancellationToken` into blocking tasks ("sort_orders", "update_orders").
  - Add cancellation checks.
  - Return `DeadlineExceeded` on cancellation.

- Update order filtering:
  - Pass `CancellationToken` into `filter_unsupported_orders_in_auction`.
  - Stop processing token-quality checks when cancellation is triggered.

- Update quote:
  - Pass plain cancellation token (with no deadline) when reusing `filter_unsupported_orders_in_auction` for quotes, this can be refactored out in later PRs.

- Add prometheus metric:
  - Add `auction_cancellations` metric (stage, reason).
  - Update metric when cancellation is observed.

- Update pre-processing task storage:
  - Store `DataFetchingTasks` tasks per `auction_id`.
  - Evict older task handles once `MAX_CONCURRENT_AUCTIONS` is exceeded.

- Add tests, coverage should be comprehensive.  

## How to test

   cargo test -p driver
   
   cargo nextest run
