### PR TITLE
[TRIVIAL] Log original quote when a new one gets computed

### DIFF
--- a/crates/shared/src/order_validation.rs
+++ b/crates/shared/src/order_validation.rs
@@ -972,7 +972,11 @@ async fn get_or_create_quote(
                 .await
                 .map_err(ValidationError::Other)?;
 
-            tracing::debug!(quote_id =? quote.id, "computed fresh quote for order creation");
+            tracing::debug!(
+                original_quote_id = ?quote_id,
+                quote_id =? quote.id,
+                "computed fresh quote for order creation"
+            );
             quote
         }
     };


### PR DESCRIPTION
# Description
Today we debugged an order which expired because it was placed right before the price changed a lot.

# Changes
Debugging this was quite tedious. To make this simpler we now log the original and the new quote id when we have to compute a new one.