### PR TITLE
Simulate txs on the `latest` block instead of `pending`

### DIFF
--- a/crates/driver/src/infra/blockchain/mod.rs
+++ b/crates/driver/src/infra/blockchain/mod.rs
@@ -205,7 +205,10 @@ impl Ethereum {
         token::Erc20::new(self, address)
     }
 
-    /// Estimate gas used by a transaction.
+    /// Estimate gas used by a transaction with `eth_estimateGas` on the `latest`
+    /// block. We use the `latest` instead of `pending` to avoid false positive
+    /// reverts that happen when we re-check the tx on a later block after we
+    /// already submitted the tx to the mempool.
     pub async fn estimate_gas(&self, tx: eth::Tx) -> Result<eth::Gas, Error> {
         let tx = TransactionRequest::default()
             .from(tx.from)
@@ -223,7 +226,7 @@ impl Ethereum {
             .web3
             .provider
             .estimate_gas(tx)
-            .pending()
+            .latest()
             .await
             .map_err(Error::Rpc)?
             .into();

--- a/crates/driver/src/infra/blockchain/mod.rs
+++ b/crates/driver/src/infra/blockchain/mod.rs
@@ -205,10 +205,10 @@ impl Ethereum {
         token::Erc20::new(self, address)
     }
 
-    /// Estimate gas used by a transaction with `eth_estimateGas` on the `latest`
-    /// block. We use the `latest` instead of `pending` to avoid false positive
-    /// reverts that happen when we re-check the tx on a later block after we
-    /// already submitted the tx to the mempool.
+    /// Estimate gas used by a transaction with `eth_estimateGas` on the
+    /// `latest` block. We use the `latest` instead of `pending` to avoid
+    /// false positive reverts that happen when we re-check the tx on a
+    /// later block after we already submitted the tx to the mempool.
     pub async fn estimate_gas(&self, tx: eth::Tx) -> Result<eth::Gas, Error> {
         let tx = TransactionRequest::default()
             .from(tx.from)


### PR DESCRIPTION
# Description
Currently the reference driver struggles to get transactions mined reliably. I think the reason is that we simulate the tx on the `pending` block instead of `latest`.
For context `latest` means simulate my tx on top of the last mined block while `pending` means simulating on the latest block AND all txs in the mempool that have a higher gas price than my tx.

I think this together with our logic that re-checks the tx on every new block (to detect reverts early and mine a cheaper cancellation tx instead of a more expensive revert) leads to seeing false reverts.
If we submit our tx on block `n` and it's not included in block `n+1` it would still be in the mempool for block `n+2`. So if we re-simulate on `pending` at block `n+1` our previously submitted tx would already be in the set of pending txs that get applied before our simulation happens and since both txs touch the same state the second one will revert.

Technically the optimal approach would be:
1. lock in gas price we want to use for the whole duration of the submission
2. before submitting anything simulate tx on `pending` with the locked in gas price
3. on subsequent blocks simulate on `latest` to avoid txs interfering with each other.

But for the sake of simplicity I think it makes sense to first go with always using `latest` instead to see if this even has the desired impact in the first place.

# Changes
Always simulate txs on the `latest` block.

## How to test
Temporarily deploy this to prod to see how this effects inclusion times / rates.