### PR TITLE
Round protocol fee up in quote computation

### DIFF
--- a/crates/orderbook/src/quoter.rs
+++ b/crates/orderbook/src/quoter.rs
@@ -248,10 +248,7 @@ fn get_vol_fee_adjusted_quote_data(
     if scale.is_zero() {
         return Err(anyhow::anyhow!("volume fee calculation division by zero"));
     }
-    // Round protocol fee UP to be pessimistic: never undercharge users on the
-    // fee, mirroring the `ceil` rounding used for the network fee in
-    // `FeeParameters::fee_with_additional_cost`. For SELL this means a slightly smaller
-    // adjusted buy_amount; for BUY a slightly larger adjusted sell_amount.
+    // Round the fee up so we never undercharge the user.
     let (adjusted_sell_amount, adjusted_buy_amount) = match side {
         OrderQuoteSide::Sell { .. } => {
             // For SELL orders, fee is calculated on buy amount
@@ -585,10 +582,7 @@ mod tests {
 
     #[test]
     fn test_volume_fee_rounds_up_sell_order() {
-        // Pick amounts so the protocol fee has a non-zero remainder and we can
-        // observe the ceiling. factor 0.0001 -> high_precision = 100, scale =
-        // 1_000_000, so fee = buy_amount * 100 / 1_000_000 = buy_amount / 10_000.
-        // Use buy_amount = 12345 so 12345 / 10000 = 1.2345 -> ceil = 2.
+        // factor 0.0001, buy_amount 12345: fee = 12345/10000 = 1.2345 -> ceil 2.
         let volume_fee = FeeFactor::try_from(0.0001).unwrap();
         let volume_fee_config = VolumeFeeConfig {
             factor: Some(volume_fee),
@@ -613,15 +607,14 @@ mod tests {
         )
         .unwrap();
 
-        // Fee rounds up from 1.2345 to 2.
         assert_eq!(result.sell_amount, U256::from(100u64));
         assert_eq!(result.buy_amount, U256::from(12345u64 - 2));
     }
 
     #[test]
     fn test_volume_fee_rounds_up_buy_order() {
-        // factor 0.0001 -> fee = (sell + network_fee) / 10_000.
-        // sell = 12345, network fee = 0 -> 12345/10000 = 1.2345 -> ceil = 2.
+        // factor 0.0001, sell_amount 12345, network fee 0: 12345/10000 = 1.2345 -> ceil
+        // 2.
         let volume_fee = FeeFactor::try_from(0.0001).unwrap();
         let volume_fee_config = VolumeFeeConfig {
             factor: Some(volume_fee),
@@ -645,7 +638,6 @@ mod tests {
         )
         .unwrap();
 
-        // Fee rounds up from 1.2345 to 2.
         assert_eq!(result.sell_amount, U256::from(12345u64 + 2));
         assert_eq!(result.buy_amount, U256::from(100u64));
     }

--- a/crates/orderbook/src/quoter.rs
+++ b/crates/orderbook/src/quoter.rs
@@ -245,7 +245,7 @@ fn get_vol_fee_adjusted_quote_data(
     // BPS)
     let scaled_factor = U256::from(factor.to_high_precision());
     let scale = U512::from(FeeFactor::HIGH_PRECISION_SCALE);
-    // Round the fee up so we never undercharge the user.
+    // Round the fee up so we never overpromise the user.
     let (adjusted_sell_amount, adjusted_buy_amount) = match side {
         OrderQuoteSide::Sell { .. } => {
             // For SELL orders, fee is calculated on buy amount

--- a/crates/orderbook/src/quoter.rs
+++ b/crates/orderbook/src/quoter.rs
@@ -250,7 +250,7 @@ fn get_vol_fee_adjusted_quote_data(
     }
     // Round protocol fee UP to be pessimistic: never undercharge users on the
     // fee, mirroring the `ceil` rounding used for the network fee in
-    // `crates/shared/src/fee.rs`. For SELL this means a slightly smaller
+    // `FeeParameters::fee_with_additional_cost`. For SELL this means a slightly smaller
     // adjusted buy_amount; for BUY a slightly larger adjusted sell_amount.
     let (adjusted_sell_amount, adjusted_buy_amount) = match side {
         OrderQuoteSide::Sell { .. } => {

--- a/crates/orderbook/src/quoter.rs
+++ b/crates/orderbook/src/quoter.rs
@@ -245,9 +245,6 @@ fn get_vol_fee_adjusted_quote_data(
     // BPS)
     let scaled_factor = U256::from(factor.to_high_precision());
     let scale = U512::from(FeeFactor::HIGH_PRECISION_SCALE);
-    if scale.is_zero() {
-        return Err(anyhow::anyhow!("volume fee calculation division by zero"));
-    }
     // Round the fee up so we never undercharge the user.
     let (adjusted_sell_amount, adjusted_buy_amount) = match side {
         OrderQuoteSide::Sell { .. } => {

--- a/crates/orderbook/src/quoter.rs
+++ b/crates/orderbook/src/quoter.rs
@@ -262,7 +262,7 @@ fn get_vol_fee_adjusted_quote_data(
             // For BUY orders, fee is calculated on sell amount + network fee.
             // Network fee is already in sell token, so it is added to get the total volume.
             let total_sell_volume = quote.sell_amount.saturating_add(quote.fee_amount);
-            let numerator: Uint<512, 8> = total_sell_volume.widening_mul(scaled_factor);
+            let numerator = total_sell_volume.widening_mul(scaled_factor);
             let protocol_fee = U256::uint_try_from(numerator.div_ceil(scale))
                 .map_err(|_| anyhow::anyhow!("volume fee calculation overflow"))?;
 

--- a/crates/orderbook/src/quoter.rs
+++ b/crates/orderbook/src/quoter.rs
@@ -245,17 +245,19 @@ fn get_vol_fee_adjusted_quote_data(
     // BPS)
     let scaled_factor = U256::from(factor.to_high_precision());
     let scale = U512::from(FeeFactor::HIGH_PRECISION_SCALE);
+    if scale.is_zero() {
+        return Err(anyhow::anyhow!("volume fee calculation division by zero"));
+    }
+    // Round protocol fee UP to be pessimistic: never undercharge users on the
+    // fee, mirroring the `ceil` rounding used for the network fee in
+    // `crates/shared/src/fee.rs`. For SELL this means a slightly smaller
+    // adjusted buy_amount; for BUY a slightly larger adjusted sell_amount.
     let (adjusted_sell_amount, adjusted_buy_amount) = match side {
         OrderQuoteSide::Sell { .. } => {
             // For SELL orders, fee is calculated on buy amount
-            let protocol_fee = U256::uint_try_from(
-                quote
-                    .buy_amount
-                    .widening_mul(scaled_factor)
-                    .checked_div(scale)
-                    .ok_or_else(|| anyhow::anyhow!("volume fee calculation division by zero"))?,
-            )
-            .map_err(|_| anyhow::anyhow!("volume fee calculation overflow"))?;
+            let numerator = quote.buy_amount.widening_mul(scaled_factor);
+            let protocol_fee = U256::uint_try_from(numerator.div_ceil(scale))
+                .map_err(|_| anyhow::anyhow!("volume fee calculation overflow"))?;
 
             // Reduce buy amount by protocol fee
             let adjusted_buy = quote.buy_amount.saturating_sub(protocol_fee);
@@ -266,13 +268,9 @@ fn get_vol_fee_adjusted_quote_data(
             // For BUY orders, fee is calculated on sell amount + network fee.
             // Network fee is already in sell token, so it is added to get the total volume.
             let total_sell_volume = quote.sell_amount.saturating_add(quote.fee_amount);
-            let volume_scaled: Uint<512, 8> = total_sell_volume.widening_mul(scaled_factor);
-            let protocol_fee = U256::uint_try_from(
-                volume_scaled
-                    .checked_div(scale)
-                    .ok_or_else(|| anyhow::anyhow!("volume fee calculation division by zero"))?,
-            )
-            .map_err(|_| anyhow::anyhow!("volume fee calculation overflow"))?;
+            let numerator: Uint<512, 8> = total_sell_volume.widening_mul(scaled_factor);
+            let protocol_fee = U256::uint_try_from(numerator.div_ceil(scale))
+                .map_err(|_| anyhow::anyhow!("volume fee calculation overflow"))?;
 
             // Increase sell amount by protocol fee
             let adjusted_sell = quote.sell_amount.saturating_add(protocol_fee);
@@ -583,6 +581,73 @@ mod tests {
         assert_eq!(result.sell_amount, 100u64.eth());
         assert_eq!(result.buy_amount, 100u64.eth());
         assert_eq!(result.protocol_fee_bps, None);
+    }
+
+    #[test]
+    fn test_volume_fee_rounds_up_sell_order() {
+        // Pick amounts so the protocol fee has a non-zero remainder and we can
+        // observe the ceiling. factor 0.0001 -> high_precision = 100, scale =
+        // 1_000_000, so fee = buy_amount * 100 / 1_000_000 = buy_amount / 10_000.
+        // Use buy_amount = 12345 so 12345 / 10000 = 1.2345 -> ceil = 2.
+        let volume_fee = FeeFactor::try_from(0.0001).unwrap();
+        let volume_fee_config = VolumeFeeConfig {
+            factor: Some(volume_fee),
+            effective_from_timestamp: None,
+        };
+        let volume_fee_policy = VolumeFeePolicy::new(vec![], Some(volume_fee), false);
+
+        let quote = create_test_quote(U256::from(100u64), U256::from(12345u64));
+        let side = OrderQuoteSide::Sell {
+            sell_amount: model::quote::SellAmount::BeforeFee {
+                value: number::nonzero::NonZeroU256::try_from(U256::from(100u64)).unwrap(),
+            },
+        };
+
+        let result = get_vol_fee_adjusted_quote_data(
+            &quote,
+            &side,
+            Some(&volume_fee_config),
+            &volume_fee_policy,
+            TEST_BUY_TOKEN,
+            TEST_SELL_TOKEN,
+        )
+        .unwrap();
+
+        // Fee rounds up from 1.2345 to 2.
+        assert_eq!(result.sell_amount, U256::from(100u64));
+        assert_eq!(result.buy_amount, U256::from(12345u64 - 2));
+    }
+
+    #[test]
+    fn test_volume_fee_rounds_up_buy_order() {
+        // factor 0.0001 -> fee = (sell + network_fee) / 10_000.
+        // sell = 12345, network fee = 0 -> 12345/10000 = 1.2345 -> ceil = 2.
+        let volume_fee = FeeFactor::try_from(0.0001).unwrap();
+        let volume_fee_config = VolumeFeeConfig {
+            factor: Some(volume_fee),
+            effective_from_timestamp: None,
+        };
+        let volume_fee_policy = VolumeFeePolicy::new(vec![], Some(volume_fee), false);
+
+        let quote = create_test_quote(U256::from(12345u64), U256::from(100u64));
+        let side = OrderQuoteSide::Buy {
+            buy_amount_after_fee: number::nonzero::NonZeroU256::try_from(U256::from(100u64))
+                .unwrap(),
+        };
+
+        let result = get_vol_fee_adjusted_quote_data(
+            &quote,
+            &side,
+            Some(&volume_fee_config),
+            &volume_fee_policy,
+            TEST_BUY_TOKEN,
+            TEST_SELL_TOKEN,
+        )
+        .unwrap();
+
+        // Fee rounds up from 1.2345 to 2.
+        assert_eq!(result.sell_amount, U256::from(12345u64 + 2));
+        assert_eq!(result.buy_amount, U256::from(100u64));
     }
 
     #[test]

--- a/crates/orderbook/src/quoter.rs
+++ b/crates/orderbook/src/quoter.rs
@@ -610,7 +610,8 @@ mod tests {
 
     #[test]
     fn test_volume_fee_rounds_up_buy_order() {
-        // factor 0.0001, sell 10_000, network fee 5: ceil((10000 + 5)/10000) = ceil(1.0005) = 2
+        // factor 0.0001, sell 10_000, network fee 5: ceil((10000 + 5)/10000) =
+        // ceil(1.0005) = 2
         let volume_fee = FeeFactor::try_from(0.0001).unwrap();
         let volume_fee_config = VolumeFeeConfig {
             factor: Some(volume_fee),

--- a/crates/orderbook/src/quoter.rs
+++ b/crates/orderbook/src/quoter.rs
@@ -1,6 +1,6 @@
 use {
     crate::app_data,
-    alloy::primitives::{U256, U512, Uint, ruint::UintTryFrom},
+    alloy::primitives::{U256, U512, ruint::UintTryFrom},
     bigdecimal::{BigDecimal, FromPrimitive},
     chrono::{TimeZone, Utc},
     configs::{fee_factor::FeeFactor, orderbook::VolumeFeeConfig},
@@ -610,8 +610,7 @@ mod tests {
 
     #[test]
     fn test_volume_fee_rounds_up_buy_order() {
-        // factor 0.0001, sell_amount 12345, network fee 0: 12345/10000 = 1.2345 -> ceil
-        // 2.
+        // factor 0.0001, sell 10_000, network fee 5: ceil((10000 + 5)/10000) = ceil(1.0005) = 2
         let volume_fee = FeeFactor::try_from(0.0001).unwrap();
         let volume_fee_config = VolumeFeeConfig {
             factor: Some(volume_fee),
@@ -619,7 +618,9 @@ mod tests {
         };
         let volume_fee_policy = VolumeFeePolicy::new(vec![], Some(volume_fee), false);
 
-        let quote = create_test_quote(U256::from(12345u64), U256::from(100u64));
+        let mut quote = create_test_quote(U256::from(10_000u64), U256::from(100u64));
+        quote.fee_amount = U256::from(5u64);
+
         let side = OrderQuoteSide::Buy {
             buy_amount_after_fee: number::nonzero::NonZeroU256::try_from(U256::from(100u64))
                 .unwrap(),
@@ -635,7 +636,7 @@ mod tests {
         )
         .unwrap();
 
-        assert_eq!(result.sell_amount, U256::from(12345u64 + 2));
+        assert_eq!(result.sell_amount, U256::from(10_000u64 + 2));
         assert_eq!(result.buy_amount, U256::from(100u64));
     }
 


### PR DESCRIPTION
## Summary
Make fee rounding consistent. 

Takes a pessimistic approach, the one who yields a:
- `buyAmount` for sell orders, which allows solvers to keep all fees and still fulfill the order. If we round it down, we might be promising the user one 1wei more, so when the solver takes the fee, the order might not be fillable.
- `sellAmount` for buy orders should also round fees up, which makes the user to sign 1wei more so we can fill the order after taking the fees

## Context
I noticed a small divergence between what the quote endpoint returns, and what debug.cow.fi thinks it return based on its own calculations. 

See this order: `0xd129e1a85ec79443540264ee8bb37841c9c4d5850c9b1c5ea6e1d764e8aff3e7cfe5660d6c55906ec8c488a466bd4f77f77eec8869fdbaeb`

<img width="814" height="582" alt="image" src="https://github.com/user-attachments/assets/a769ec83-cacd-4cc2-a547-300bed562378" />

The tool calculates the amount at slippage=0, which is basically what the API returns. In this case, returns `63774986`, but if you check the logs you see `63774987` (it overpromises by 1 wei). See https://victorialogs.dev.cow.fi/goto/aflg4t470vz7kc?orgId=1


## Details
The volume-based protocol fee applied during quote computation in `crates/orderbook/src/quoter.rs` previously used floor division (`checked_div`), while the network fee in `crates/shared/src/fee.rs` uses ceiling. This PR aligns both to the same pessimistic policy: **always round protocol fee UP**.

Effect at the wei level on inexact divisions:
- **Sell orders**: adjusted `buy_amount = quote.buy_amount − ceil(buy * factor / scale)` — user receives slightly less buy, never more than the protocol can cover.
- **Buy orders**: adjusted `sell_amount = quote.sell_amount + ceil((sell + network_fee) * factor / scale)` — user pays slightly more sell, never less than required.

The change touches only quote-time amounts shown to users; settlement-time fee accounting is unchanged.

## Test plan

- [x] `cargo test -p orderbook quoter::tests` — 9/9 pass, including two new tests (`test_volume_fee_rounds_up_sell_order`, `test_volume_fee_rounds_up_buy_order`) that exercise non-exact divisions where floor and ceil diverge (`12345 * 100 / 1_000_000 = 1.2345 → ceil = 2`).
- [x] `cargo check -p orderbook`
- [x] CI green