### PR TITLE
Pre-cache BUY_ETH_ADDRESS as non-vault

### DIFF
--- a/crates/e2e/tests/e2e/eip4626.rs
+++ b/crates/e2e/tests/e2e/eip4626.rs
@@ -12,7 +12,10 @@ use {
     e2e::setup::*,
     ethrpc::alloy::CallBuilderExt,
     futures::{FutureExt, future::BoxFuture},
-    model::quote::{OrderQuoteRequest, OrderQuoteSide, SellAmount},
+    model::{
+        order::BUY_ETH_ADDRESS,
+        quote::{OrderQuoteRequest, OrderQuoteSide, SellAmount},
+    },
     number::units::EthUnit,
     price_estimation::{
         HEALTHY_PRICE_ESTIMATION_TIME,
@@ -20,6 +23,7 @@ use {
     },
     shared::web3::Web3,
     std::time::Duration,
+    testlib::tokens::GNO,
 };
 
 /// The block number from which we will fetch state for the forked test.
@@ -265,11 +269,14 @@ async fn eip4626_empty_revert_terminal_token_test(web3: Web3) {
     let expected_price = 0.0001;
     let inner = FixedPrice(expected_price);
     let estimator = Eip4626::new(Box::new(inner), web3.provider);
-    let price = estimator
-        .estimate_native_price(USDC, HEALTHY_PRICE_ESTIMATION_TIME)
-        .await
-        .expect("empty-revert on terminal token must not abort the unwrap");
-    assert_eq!(price, expected_price);
+
+    for token in [BUY_ETH_ADDRESS, USDC, GNO] {
+        let price = estimator
+            .estimate_native_price(token, HEALTHY_PRICE_ESTIMATION_TIME)
+            .await
+            .expect("empty-revert on terminal token must not abort the unwrap");
+        assert_eq!(price, expected_price);
+    }
 }
 
 struct FixedPrice(f64);

--- a/crates/price-estimation/Cargo.toml
+++ b/crates/price-estimation/Cargo.toml
@@ -55,13 +55,13 @@ tracing = { workspace = true }
 url = { workspace = true }
 
 [dev-dependencies]
+ethrpc = { workspace = true, features = ["test-util"] }
 hex-literal = { workspace = true }
 maplit = { workspace = true }
 mockall = { workspace = true }
 testlib = { workspace = true }
 token-info = { workspace = true, features = ["test-util"] }
 toml = { workspace = true }
-ethrpc = {workspace = true, features = ["test-util"]}
 
 [features]
 test-util = ["dep:mockall"]

--- a/crates/price-estimation/Cargo.toml
+++ b/crates/price-estimation/Cargo.toml
@@ -61,6 +61,7 @@ mockall = { workspace = true }
 testlib = { workspace = true }
 token-info = { workspace = true, features = ["test-util"] }
 toml = { workspace = true }
+ethrpc = {workspace = true, features = ["test-util"]}
 
 [features]
 test-util = ["dep:mockall"]

--- a/crates/price-estimation/src/native/eip4626.rs
+++ b/crates/price-estimation/src/native/eip4626.rs
@@ -7,6 +7,7 @@ use {
     dashmap::DashSet,
     ethrpc::{AlloyProvider, alloy::errors::ContractErrorExt},
     futures::{FutureExt, future::BoxFuture},
+    model::order::BUY_ETH_ADDRESS,
     num::{BigInt, BigRational, ToPrimitive},
     number::conversions::u256_to_big_rational,
     std::time::{Duration, Instant},
@@ -37,7 +38,7 @@ impl Eip4626 {
         Self {
             inner,
             provider,
-            non_vault_tokens: DashSet::new(),
+            non_vault_tokens: DashSet::from_iter([BUY_ETH_ADDRESS]),
         }
     }
 

--- a/crates/price-estimation/src/native/eip4626.rs
+++ b/crates/price-estimation/src/native/eip4626.rs
@@ -259,8 +259,10 @@ mod tests {
     }
 
     /// Tests two (related) things:
-    /// * Cached tokens bypass the EIP-4626 provider calls — i.e. calling decimals, assets, etc
-    /// * That the BUY_ETH_ADDRESS is cached by default (and the previous applies to it)
+    /// * Cached tokens bypass the EIP-4626 provider calls — i.e. calling
+    ///   decimals, assets, etc
+    /// * That the BUY_ETH_ADDRESS is cached by default (and the previous
+    ///   applies to it)
     #[tokio::test]
     async fn buy_eth_address_bypasses_eth_calls() {
         let mut inner = MockNativePriceEstimating::new();

--- a/crates/price-estimation/src/native/eip4626.rs
+++ b/crates/price-estimation/src/native/eip4626.rs
@@ -38,6 +38,8 @@ impl Eip4626 {
         Self {
             inner,
             provider,
+            // BUY_ETH_ADDRESS is not ERC-20, but it is a valid estimation address
+            // so we need to make sure it bypasses the EIP-4626 estimator
             non_vault_tokens: DashSet::from_iter([BUY_ETH_ADDRESS]),
         }
     }
@@ -225,6 +227,8 @@ mod tests {
     use {
         super::*,
         crate::{HEALTHY_PRICE_ESTIMATION_TIME, native::MockNativePriceEstimating},
+        alloy::providers::mock::Asserter,
+        std::borrow::Cow,
     };
 
     #[test]
@@ -252,6 +256,39 @@ mod tests {
         let assets = U256::from(2u64) * U256::from(10u64).pow(U256::from(18u64));
         let rate = conversion_rate(assets, 18).unwrap();
         assert!((rate - 2.0).abs() < 1e-9, "rate={rate}");
+    }
+
+    /// Tests two (related) things:
+    /// * Cached tokens bypass the EIP-4626 provider calls — i.e. calling decimals, assets, etc
+    /// * That the BUY_ETH_ADDRESS is cached by default (and the previous applies to it)
+    #[tokio::test]
+    async fn buy_eth_address_bypasses_eth_calls() {
+        let mut inner = MockNativePriceEstimating::new();
+        let token = BUY_ETH_ADDRESS;
+        let expected_price = 1.5;
+        inner
+            .expect_estimate_native_price()
+            .withf(move |t, _| *t == token)
+            .returning(move |_, _| Box::pin(async move { Ok(expected_price) }));
+
+        let asserter = Asserter::new();
+        asserter.push_failure_msg(Cow::from("calls are not being bypassed"));
+        let web3 = ethrpc::Web3::with_asserter(asserter);
+
+        let estimator = Eip4626::new(Box::new(inner), web3.provider);
+
+        let result = estimator
+            .estimate(token, HEALTHY_PRICE_ESTIMATION_TIME)
+            .await;
+        assert_eq!(result.unwrap(), expected_price);
+
+        let result = estimator
+            .estimate(Address::random(), HEALTHY_PRICE_ESTIMATION_TIME)
+            .await;
+        assert!(
+            matches!(result, Err(PriceEstimationError::EstimatorInternal(_))),
+            "{result:?}"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
# Description
Pre-caches BUY_ETH_ADDRESS as a non-vault token at the EIP-4626 estimator level.
Given that BUY_ETH_ADDRESS does not have code deployed to it, this makes it a "valid-enough" token to be ignored by EIP-4626 when enabled and passed on to the rest of the estimation pipeline.

# Changes

* Pre-caches BUY_ETH_ADDRESS as a non-vault token at the EIP-4626 estimator level.
* Adds tests for said usage

## How to test
Regular tests