### PR TITLE
[TRIVIAL] Remove `enforce-when-possible` quote verification mode

### DIFF
--- a/crates/autopilot/src/run.rs
+++ b/crates/autopilot/src/run.rs
@@ -472,8 +472,6 @@ pub async fn run(config: Configuration, shutdown_controller: ShutdownController)
             )
             .unwrap(),
         },
-        balance_fetcher.clone(),
-        config.price_estimation.quote_verification,
         config.price_estimation.quote_timeout,
         config.price_estimation.max_quote_timeout,
     ));

--- a/crates/configs/src/price_estimation.rs
+++ b/crates/configs/src/price_estimation.rs
@@ -18,9 +18,6 @@ pub enum QuoteVerificationMode {
     /// Quotes get verified whenever possible and verified
     /// quotes are preferred over unverified ones.
     Prefer,
-    /// Quotes get discarded if they can't be verified.
-    /// Some scenarios like missing sell token balance are exempt.
-    EnforceWhenPossible,
 }
 
 const fn default_quote_timeout() -> Duration {
@@ -148,7 +145,7 @@ impl crate::test_util::TestDefault for PriceEstimation {
                 1_000_000_000_000_000_000u64,
             )),
             quote_timeout: Duration::from_secs(10),
-            quote_verification: QuoteVerificationMode::EnforceWhenPossible,
+            quote_verification: QuoteVerificationMode::Prefer,
             ..Default::default()
         }
     }
@@ -341,7 +338,7 @@ mod tests {
     fn deserialize_full() {
         let toml = r#"
         quote-inaccuracy-limit = "0.01"
-        quote-verification = "enforce-when-possible"
+        quote-verification = "prefer"
         quote-timeout = "10s"
         max-quote-timeout = "20s"
         tokens-without-verification = ["0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2"]
@@ -402,7 +399,7 @@ mod tests {
         assert_eq!(config.quote_inaccuracy_limit.to_string(), "0.01");
         assert!(matches!(
             config.quote_verification,
-            QuoteVerificationMode::EnforceWhenPossible
+            QuoteVerificationMode::Prefer
         ));
         assert_eq!(config.quote_timeout, Duration::from_secs(10));
         assert_eq!(config.max_quote_timeout, Duration::from_secs(20));

--- a/crates/orderbook/src/run.rs
+++ b/crates/orderbook/src/run.rs
@@ -33,7 +33,6 @@ use {
     order_validation,
     price_estimation::{
         PriceEstimating,
-        QuoteVerificationMode,
         config::price_estimation::BalanceOverridesConfigExt,
         factory::{self, PriceEstimatorFactory},
         native::{FallbackNativePriceEstimator, NativePriceEstimating},
@@ -347,8 +346,7 @@ pub async fn run(config: Configuration) {
         max_limit: config.order_validation.max_limit_order_validity_period,
     };
 
-    let create_quoter = |price_estimator: Arc<dyn PriceEstimating>,
-                         verification: QuoteVerificationMode| {
+    let create_quoter = |price_estimator: Arc<dyn PriceEstimating>| {
         Arc::new(OrderQuoter::new(
             price_estimator,
             native_price_estimator.clone(),
@@ -368,18 +366,16 @@ pub async fn run(config: Configuration) {
                 )
                 .unwrap(),
             },
-            balance_fetcher.clone(),
-            verification,
             config.price_estimation.quote_timeout,
             config.price_estimation.max_quote_timeout,
         ))
     };
-    let optimal_quoter = create_quoter(price_estimator, config.price_estimation.quote_verification);
+    let optimal_quoter = create_quoter(price_estimator);
     // Fast quoting is able to return early and if none of the produced quotes are
     // verifiable we are left with no quote at all. Since fast estimates don't
     // make any promises on correctness we can just skip quote verification for
     // them.
-    let fast_quoter = create_quoter(fast_price_estimator, QuoteVerificationMode::Unverified);
+    let fast_quoter = create_quoter(fast_price_estimator);
 
     let app_data_validator = Validator::new(config.app_data_size_limit);
     let chainalysis_oracle = ChainalysisOracle::Instance::deployed(&web3.provider)

--- a/crates/price-estimation/src/competition/quote.rs
+++ b/crates/price-estimation/src/competition/quote.rs
@@ -381,18 +381,6 @@ mod tests {
                 better_unverified_quote.clone(),
                 worse_verified_quote.clone(),
             ],
-            QuoteVerificationMode::EnforceWhenPossible,
-        )
-        .await;
-        assert_eq!(best, worse_verified_quote.clone());
-
-        let best = best_response(
-            PriceRanking::MaxOutAmount,
-            OrderKind::Sell,
-            vec![
-                better_unverified_quote.clone(),
-                worse_verified_quote.clone(),
-            ],
             QuoteVerificationMode::Unverified,
         )
         .await;

--- a/crates/shared/src/order_quoting.rs
+++ b/crates/shared/src/order_quoting.rs
@@ -4,7 +4,6 @@ use {
         fee::FeeParameters,
         order_validation::PreOrderData,
     },
-    account_balances::{BalanceFetching, Query},
     alloy::primitives::{Address, U256, U512, ruint::UintTryFrom},
     anyhow::{Context, Result},
     chrono::{DateTime, Duration, Utc},
@@ -20,10 +19,8 @@ use {
     number::conversions::big_decimal_to_u256,
     price_estimation::{
         self,
-        Estimate,
         PriceEstimating,
         PriceEstimationError,
-        QuoteVerificationMode,
         Verification,
         native::NativePriceEstimating,
         trade_finding::external::dto,
@@ -419,22 +416,17 @@ pub struct OrderQuoter {
     storage: Arc<dyn QuoteStoring>,
     now: Arc<dyn Now>,
     validity: Validity,
-    balance_fetcher: Arc<dyn BalanceFetching>,
-    quote_verification: QuoteVerificationMode,
     default_quote_timeout: std::time::Duration,
     max_quote_timeout: std::time::Duration,
 }
 
 impl OrderQuoter {
-    #[expect(clippy::too_many_arguments)]
     pub fn new(
         price_estimator: Arc<dyn PriceEstimating>,
         native_price_estimator: Arc<dyn NativePriceEstimating>,
         gas_estimator: Arc<dyn GasPriceEstimating>,
         storage: Arc<dyn QuoteStoring>,
         validity: Validity,
-        balance_fetcher: Arc<dyn BalanceFetching>,
-        quote_verification: QuoteVerificationMode,
         default_quote_timeout: std::time::Duration,
         max_quote_timeout: std::time::Duration,
     ) -> Self {
@@ -449,8 +441,6 @@ impl OrderQuoter {
             storage,
             now: Arc::new(Utc::now),
             validity,
-            balance_fetcher,
-            quote_verification,
             default_quote_timeout,
             max_quote_timeout,
         }
@@ -512,9 +502,6 @@ impl OrderQuoter {
             sell_token_price,
         };
 
-        self.verify_quote(&trade_estimate, parameters, quoted_sell_amount)
-            .await?;
-
         let quote_kind = quote_kind_from_signing_scheme(&parameters.signing_scheme);
         let quote = QuoteData {
             sell_token: parameters.sell_token,
@@ -536,64 +523,6 @@ impl OrderQuoter {
         };
 
         Ok(quote)
-    }
-
-    /// Makes sure a quote was verified according to the configured rule.
-    async fn verify_quote(
-        &self,
-        estimate: &Estimate,
-        parameters: &QuoteParameters,
-        sell_amount: U256,
-    ) -> Result<(), CalculateQuoteError> {
-        if estimate.verified
-            || !matches!(
-                self.quote_verification,
-                QuoteVerificationMode::EnforceWhenPossible
-            )
-        {
-            // verification was successful or not strictly required
-            return Ok(());
-        }
-
-        let balance = match self
-            .get_balance(&parameters.verification, parameters.sell_token)
-            .await
-        {
-            Ok(balance) => balance,
-            Err(err) => {
-                tracing::warn!(?err, "could not fetch balance for verification");
-                return Err(CalculateQuoteError::QuoteNotVerified);
-            }
-        };
-
-        if balance >= sell_amount {
-            // Quote could not be verified although user has the required balance.
-            // This likely indicates a weird token that solvers are not able to handle.
-            return Err(CalculateQuoteError::QuoteNotVerified);
-        }
-
-        Ok(())
-    }
-
-    async fn get_balance(&self, verification: &Verification, token: Address) -> Result<U256> {
-        let query = Query {
-            owner: verification.from,
-            token,
-            source: verification.sell_token_source,
-            interactions: verification
-                .pre_interactions
-                .iter()
-                .map(|i| InteractionData {
-                    target: i.target,
-                    value: i.value,
-                    call_data: i.data.clone(),
-                })
-                .collect(),
-            // quote verification already tries to auto-fake missing balances
-            balance_override: None,
-        };
-        let mut balances = self.balance_fetcher.get_balances(&[query]).await;
-        balances.pop().context("missing balance result")?
     }
 }
 
@@ -798,7 +727,6 @@ mod tests {
         super::*,
         Address,
         U256 as AlloyU256,
-        account_balances::MockBalanceFetching,
         alloy::eips::eip1559::Eip1559Estimation,
         chrono::Utc,
         futures::FutureExt,
@@ -812,13 +740,6 @@ mod tests {
             native::MockNativePriceEstimating,
         },
     };
-
-    fn mock_balance_fetcher() -> Arc<dyn BalanceFetching> {
-        let mut mock = MockBalanceFetching::new();
-        mock.expect_get_balances()
-            .returning(|addresses| addresses.iter().map(|_| Ok(U256::MAX)).collect());
-        Arc::new(mock)
-    }
 
     #[test]
     fn pre_order_data_from_quote_request() {
@@ -946,8 +867,6 @@ mod tests {
             storage: Arc::new(storage),
             now: Arc::new(now),
             validity: super::Validity::default(),
-            quote_verification: QuoteVerificationMode::Unverified,
-            balance_fetcher: mock_balance_fetcher(),
             default_quote_timeout: HEALTHY_PRICE_ESTIMATION_TIME,
             max_quote_timeout: HEALTHY_PRICE_ESTIMATION_TIME,
         };
@@ -1087,8 +1006,6 @@ mod tests {
             storage: Arc::new(storage),
             now: Arc::new(now),
             validity: Validity::default(),
-            quote_verification: QuoteVerificationMode::Unverified,
-            balance_fetcher: mock_balance_fetcher(),
             default_quote_timeout: HEALTHY_PRICE_ESTIMATION_TIME,
             max_quote_timeout: HEALTHY_PRICE_ESTIMATION_TIME,
         };
@@ -1223,8 +1140,6 @@ mod tests {
             storage: Arc::new(storage),
             now: Arc::new(now),
             validity: Validity::default(),
-            quote_verification: QuoteVerificationMode::Unverified,
-            balance_fetcher: mock_balance_fetcher(),
             default_quote_timeout: HEALTHY_PRICE_ESTIMATION_TIME,
             max_quote_timeout: HEALTHY_PRICE_ESTIMATION_TIME,
         };
@@ -1322,8 +1237,6 @@ mod tests {
             storage: Arc::new(MockQuoteStoring::new()),
             now: Arc::new(Utc::now),
             validity: Validity::default(),
-            quote_verification: QuoteVerificationMode::Unverified,
-            balance_fetcher: mock_balance_fetcher(),
             default_quote_timeout: HEALTHY_PRICE_ESTIMATION_TIME,
             max_quote_timeout: HEALTHY_PRICE_ESTIMATION_TIME,
         };
@@ -1396,8 +1309,6 @@ mod tests {
             storage: Arc::new(MockQuoteStoring::new()),
             now: Arc::new(Utc::now),
             validity: Validity::default(),
-            quote_verification: QuoteVerificationMode::Unverified,
-            balance_fetcher: mock_balance_fetcher(),
             default_quote_timeout: HEALTHY_PRICE_ESTIMATION_TIME,
             max_quote_timeout: HEALTHY_PRICE_ESTIMATION_TIME,
         };
@@ -1458,8 +1369,6 @@ mod tests {
             storage: Arc::new(storage),
             now: Arc::new(now),
             validity: Validity::default(),
-            quote_verification: QuoteVerificationMode::Unverified,
-            balance_fetcher: mock_balance_fetcher(),
             default_quote_timeout: HEALTHY_PRICE_ESTIMATION_TIME,
             max_quote_timeout: HEALTHY_PRICE_ESTIMATION_TIME,
         };
@@ -1542,8 +1451,6 @@ mod tests {
             storage: Arc::new(storage),
             now: Arc::new(now),
             validity: Validity::default(),
-            quote_verification: QuoteVerificationMode::Unverified,
-            balance_fetcher: mock_balance_fetcher(),
             default_quote_timeout: HEALTHY_PRICE_ESTIMATION_TIME,
             max_quote_timeout: HEALTHY_PRICE_ESTIMATION_TIME,
         };
@@ -1628,8 +1535,6 @@ mod tests {
             storage: Arc::new(storage),
             now: Arc::new(now),
             validity: Validity::default(),
-            quote_verification: QuoteVerificationMode::Unverified,
-            balance_fetcher: mock_balance_fetcher(),
             default_quote_timeout: HEALTHY_PRICE_ESTIMATION_TIME,
             max_quote_timeout: HEALTHY_PRICE_ESTIMATION_TIME,
         };
@@ -1702,8 +1607,6 @@ mod tests {
             storage: Arc::new(storage),
             now: Arc::new(now),
             validity: Validity::default(),
-            quote_verification: QuoteVerificationMode::Unverified,
-            balance_fetcher: mock_balance_fetcher(),
             default_quote_timeout: HEALTHY_PRICE_ESTIMATION_TIME,
             max_quote_timeout: HEALTHY_PRICE_ESTIMATION_TIME,
         };
@@ -1734,8 +1637,6 @@ mod tests {
             storage: Arc::new(storage),
             now: Arc::new(Utc::now),
             validity: Validity::default(),
-            quote_verification: QuoteVerificationMode::Unverified,
-            balance_fetcher: mock_balance_fetcher(),
             default_quote_timeout: HEALTHY_PRICE_ESTIMATION_TIME,
             max_quote_timeout: HEALTHY_PRICE_ESTIMATION_TIME,
         };


### PR DESCRIPTION
# Description
`enforce-when-possible` is a quote verification mode that is not used in practice. In preparation for a larger refactor of the underlying quote verification logic it makes sense to remove this to reduce the surface area of code we need to fit the new logic into.

# Changes
- dropped `enforce-when-possible` mode that completely rejected unverified quotes when the user had the required balance