### PR TITLE
Drop tx.origin = 0x0000 bypass for ZeroEx RFQ quotes

### DIFF
--- a/crates/autopilot/src/run.rs
+++ b/crates/autopilot/src/run.rs
@@ -472,8 +472,6 @@ pub async fn run(config: Configuration, shutdown_controller: ShutdownController)
             )
             .unwrap(),
         },
-        balance_fetcher.clone(),
-        config.price_estimation.quote_verification,
         config.price_estimation.quote_timeout,
         config.price_estimation.max_quote_timeout,
     ));

--- a/crates/configs/src/price_estimation.rs
+++ b/crates/configs/src/price_estimation.rs
@@ -18,9 +18,6 @@ pub enum QuoteVerificationMode {
     /// Quotes get verified whenever possible and verified
     /// quotes are preferred over unverified ones.
     Prefer,
-    /// Quotes get discarded if they can't be verified.
-    /// Some scenarios like missing sell token balance are exempt.
-    EnforceWhenPossible,
 }
 
 const fn default_quote_timeout() -> Duration {
@@ -148,7 +145,7 @@ impl crate::test_util::TestDefault for PriceEstimation {
                 1_000_000_000_000_000_000u64,
             )),
             quote_timeout: Duration::from_secs(10),
-            quote_verification: QuoteVerificationMode::EnforceWhenPossible,
+            quote_verification: QuoteVerificationMode::Prefer,
             ..Default::default()
         }
     }
@@ -341,7 +338,7 @@ mod tests {
     fn deserialize_full() {
         let toml = r#"
         quote-inaccuracy-limit = "0.01"
-        quote-verification = "enforce-when-possible"
+        quote-verification = "prefer"
         quote-timeout = "10s"
         max-quote-timeout = "20s"
         tokens-without-verification = ["0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2"]
@@ -402,7 +399,7 @@ mod tests {
         assert_eq!(config.quote_inaccuracy_limit.to_string(), "0.01");
         assert!(matches!(
             config.quote_verification,
-            QuoteVerificationMode::EnforceWhenPossible
+            QuoteVerificationMode::Prefer
         ));
         assert_eq!(config.quote_timeout, Duration::from_secs(10));
         assert_eq!(config.max_quote_timeout, Duration::from_secs(20));

--- a/crates/e2e/tests/e2e/quote_verification.rs
+++ b/crates/e2e/tests/e2e/quote_verification.rs
@@ -5,49 +5,25 @@ use {
         rpc::types::state::StateOverride,
     },
     balance_overrides::{BalanceOverrideRequest, BalanceOverrides, BalanceOverriding},
-    bigdecimal::{BigDecimal, Zero},
     configs::{
         autopilot::Configuration,
         balance_overrides::Strategy,
         price_estimation::BalanceOverridesConfig,
         test_util::TestDefault,
     },
-    contracts::{ERC20, GPv2Settlement},
+    contracts::ERC20,
     e2e::setup::*,
     ethrpc::{Web3, alloy::CallBuilderExt},
-    model::{
-        interaction::InteractionData,
-        order::{BuyTokenDestination, OrderKind, SellTokenSource},
-        quote::{OrderQuoteRequest, OrderQuoteSide, SellAmount},
-    },
-    number::{nonzero::NonZeroU256, units::EthUnit},
-    price_estimation::{
-        Estimate,
-        Verification,
-        trade_finding::{Interaction, LegacyTrade, QuoteExecution, TradeKind},
-        trade_verifier::{PriceQuery, TradeVerifier, TradeVerifying},
-    },
+    model::quote::{OrderQuoteRequest, OrderQuoteSide, SellAmount},
+    number::units::EthUnit,
     serde_json::json,
-    simulator::simulation_builder::SettlementSimulator,
-    std::{collections::HashMap, sync::Arc},
+    std::collections::HashMap,
 };
 
 #[tokio::test]
 #[ignore]
 async fn local_node_standard_verified_quote() {
     run_test(standard_verified_quote).await;
-}
-
-#[tokio::test]
-#[ignore]
-async fn forked_node_bypass_verification_for_rfq_quotes() {
-    run_forked_test_with_block_number(
-        test_bypass_verification_for_rfq_quotes,
-        std::env::var("FORK_URL_MAINNET")
-            .expect("FORK_URL_MAINNET must be set to run forked tests"),
-        FORK_BLOCK_MAINNET,
-    )
-    .await;
 }
 
 #[tokio::test]
@@ -168,122 +144,6 @@ async fn standard_verified_quote(web3: Web3) {
 
 /// The block number from which we will fetch state for the forked tests.
 const FORK_BLOCK_MAINNET: u64 = 24843565;
-
-/// Tests that quotes requesting `tx_origin: 0x0000` bypass the verification
-/// because those are currently used by some solvers to provide market maker
-/// integrations. Based on an RFQ quote we saw on prod:
-/// https://www.tdly.co/shared/simulation/7402de5e-e524-4e24-9af8-50d0a38c105b
-async fn test_bypass_verification_for_rfq_quotes(web3: Web3) {
-    // This RPC node should support websockets
-    let mut url: url::Url = std::env::var("FORK_URL_MAINNET")
-        .expect("FORK_URL_MAINNET must be set to run forked tests")
-        .parse()
-        .unwrap();
-    match url.scheme() {
-        "http" => url.set_scheme("ws").unwrap(),
-        "https" => url.set_scheme("wss").unwrap(),
-        _ => unreachable!("unexpected scheme"),
-    }
-    let block_stream = ethrpc::block_stream::current_block_ws_stream(web3.provider.clone(), url)
-        .await
-        .unwrap();
-    let onchain = OnchainComponents::deployed(web3.clone()).await;
-    let balance_overrides = Arc::new(BalanceOverrides::default());
-    let gas_limit = 12_000_000u64;
-    let settlement_contract = GPv2Settlement::GPv2Settlement::new(
-        *onchain.contracts().gp_settlement.address(),
-        web3.provider.clone(),
-    );
-    let simulator = SettlementSimulator::new(
-        settlement_contract,
-        Default::default(),
-        Default::default(),
-        *onchain.contracts().weth.address(),
-        gas_limit,
-        balance_overrides,
-        block_stream.clone(),
-        None,
-    )
-    .await
-    .unwrap();
-
-    let verifier = TradeVerifier::new(
-        simulator,
-        None,
-        Arc::new(web3.clone()),
-        BigDecimal::zero(),
-        Default::default(),
-        0,
-        u32::MAX,
-    );
-
-    let verify_trade = |tx_origin| {
-        let verifier = verifier.clone();
-        async move {
-            verifier
-                .verify(
-                    &PriceQuery {
-                        sell_token: address!("0x2260fac5e5542a773aa44fbcfedf7c193bc2c599"),
-                        buy_token: address!("0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"),
-                        kind: OrderKind::Sell,
-                        in_amount: NonZeroU256::new(U256::from(12)).unwrap(),
-                    },
-                    &Verification {
-                        from: address!("0x73688c2b34bf6c09c125fed02fe92d17a94b897a"),
-                        receiver: address!("0x73688c2b34bf6c09c125fed02fe92d17a94b897a"),
-                        pre_interactions: vec![],
-                        post_interactions: vec![],
-                        sell_token_source: SellTokenSource::Erc20,
-                        buy_token_destination: BuyTokenDestination::Erc20,
-                    },
-                    TradeKind::Legacy(LegacyTrade {
-                        out_amount: U256::from(16380122291179526144u128),
-                        gas_estimate: Some(225000),
-                        interactions: vec![Interaction {
-                            target: address!("0xdef1c0ded9bec7f1a1670819833240f027b25eff"),
-                            data: const_hex::decode("aa77476c000000000000000000000000c02aaa39b223fe8d0a0e5c4f27ead9083c756cc20000000000000000000000002260fac5e5542a773aa44fbcfedf7c193bc2c599000000000000000000000000000000000000000000000000e357b42c3a9d8ccf0000000000000000000000000000000000000000000000000000000004d0e79e000000000000000000000000a69babef1ca67a37ffaf7a485dfff3382056e78c0000000000000000000000009008d19f58aabd9ed0d60971565aa8510560ab41000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000066360af101ffffffffffffffffffffffffffffffffffffff0f3f47f166360a8d0000003f0000000000000000000000000000000000000000000000000000000000000003000000000000000000000000000000000000000000000000000000000000001c66b3383f287dd9c85ad90e7c5a576ea4ba1bdf5a001d794a9afa379e6b2517b47e487a1aef32e75af432cbdbd301ada42754eaeac21ec4ca744afd92732f47540000000000000000000000000000000000000000000000000000000004d0c80f").unwrap(),
-                            value: U256::ZERO,
-                        }],
-                        solver: address!("e3067c7c27c1038de4e8ad95a83b927d23dfbd99"),
-                        tx_origin,
-                    }),
-                )
-                .await
-        }
-    };
-
-    let verified_quote = Estimate {
-        out_amount: U256::from(16380122291179526144u128),
-        gas: 225000,
-        solver: address!("0xe3067c7c27c1038de4e8ad95a83b927d23dfbd99"),
-        verified: true,
-        execution: QuoteExecution {
-            interactions: vec![InteractionData {
-                target: address!("0xdef1c0ded9bec7f1a1670819833240f027b25eff"),
-                value: U256::ZERO,
-                call_data: const_hex::decode("aa77476c000000000000000000000000c02aaa39b223fe8d0a0e5c4f27ead9083c756cc20000000000000000000000002260fac5e5542a773aa44fbcfedf7c193bc2c599000000000000000000000000000000000000000000000000e357b42c3a9d8ccf0000000000000000000000000000000000000000000000000000000004d0e79e000000000000000000000000a69babef1ca67a37ffaf7a485dfff3382056e78c0000000000000000000000009008d19f58aabd9ed0d60971565aa8510560ab41000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000066360af101ffffffffffffffffffffffffffffffffffffff0f3f47f166360a8d0000003f0000000000000000000000000000000000000000000000000000000000000003000000000000000000000000000000000000000000000000000000000000001c66b3383f287dd9c85ad90e7c5a576ea4ba1bdf5a001d794a9afa379e6b2517b47e487a1aef32e75af432cbdbd301ada42754eaeac21ec4ca744afd92732f47540000000000000000000000000000000000000000000000000000000004d0c80f").unwrap()
-            }],
-            pre_interactions: vec![],
-            jit_orders: vec![],
-        },
-    };
-
-    // `tx_origin: 0x0000` is currently used to bypass quote verification due to an
-    // implementation detail of zeroex RFQ orders.
-    // TODO: remove with #2693
-    let verification = verify_trade(Some(Address::ZERO)).await;
-    assert_eq!(&verification.unwrap(), &verified_quote);
-
-    // Trades using any other `tx_origin` can not bypass the verification.
-    let verification = verify_trade(None).await;
-    assert_eq!(
-        verification.unwrap(),
-        Estimate {
-            verified: false,
-            ..verified_quote
-        }
-    );
-}
 
 /// Verified quotes work as for WETH trades without wrapping or approvals.
 async fn verified_quote_eth_balance(web3: Web3) {

--- a/crates/orderbook/src/run.rs
+++ b/crates/orderbook/src/run.rs
@@ -33,7 +33,6 @@ use {
     order_validation,
     price_estimation::{
         PriceEstimating,
-        QuoteVerificationMode,
         config::price_estimation::BalanceOverridesConfigExt,
         factory::{self, PriceEstimatorFactory},
         native::{FallbackNativePriceEstimator, NativePriceEstimating},
@@ -347,8 +346,7 @@ pub async fn run(config: Configuration) {
         max_limit: config.order_validation.max_limit_order_validity_period,
     };
 
-    let create_quoter = |price_estimator: Arc<dyn PriceEstimating>,
-                         verification: QuoteVerificationMode| {
+    let create_quoter = |price_estimator: Arc<dyn PriceEstimating>| {
         Arc::new(OrderQuoter::new(
             price_estimator,
             native_price_estimator.clone(),
@@ -368,18 +366,16 @@ pub async fn run(config: Configuration) {
                 )
                 .unwrap(),
             },
-            balance_fetcher.clone(),
-            verification,
             config.price_estimation.quote_timeout,
             config.price_estimation.max_quote_timeout,
         ))
     };
-    let optimal_quoter = create_quoter(price_estimator, config.price_estimation.quote_verification);
+    let optimal_quoter = create_quoter(price_estimator);
     // Fast quoting is able to return early and if none of the produced quotes are
     // verifiable we are left with no quote at all. Since fast estimates don't
     // make any promises on correctness we can just skip quote verification for
     // them.
-    let fast_quoter = create_quoter(fast_price_estimator, QuoteVerificationMode::Unverified);
+    let fast_quoter = create_quoter(fast_price_estimator);
 
     let app_data_validator = Validator::new(config.app_data_size_limit);
     let chainalysis_oracle = ChainalysisOracle::Instance::deployed(&web3.provider)

--- a/crates/price-estimation/src/competition/quote.rs
+++ b/crates/price-estimation/src/competition/quote.rs
@@ -381,18 +381,6 @@ mod tests {
                 better_unverified_quote.clone(),
                 worse_verified_quote.clone(),
             ],
-            QuoteVerificationMode::EnforceWhenPossible,
-        )
-        .await;
-        assert_eq!(best, worse_verified_quote.clone());
-
-        let best = best_response(
-            PriceRanking::MaxOutAmount,
-            OrderKind::Sell,
-            vec![
-                better_unverified_quote.clone(),
-                worse_verified_quote.clone(),
-            ],
             QuoteVerificationMode::Unverified,
         )
         .await;

--- a/crates/price-estimation/src/trade_verifier/mod.rs
+++ b/crates/price-estimation/src/trade_verifier/mod.rs
@@ -307,37 +307,6 @@ impl TradeVerifier {
             .context("failed to simulate quote")
             .map_err(Error::SimulationFailed);
 
-        // TODO remove when quoters stop signing zeroex RFQ orders for `tx.origin:
-        // 0x0000` (#2693)
-        if let Err(err) = &output {
-            // Currently we know that if a trade requests to be simulated from `tx.origin:
-            // 0x0000` it's because the solver signs zeroex RFQ orders which
-            // require that origin. However, setting this `tx.origin` actually
-            // results in invalid RFQ orders and until the solver signs orders
-            // for a different `tx.origin` we need to pretend these
-            // quotes actually simulated successfully to not lose these competitive quotes
-            // when we enable quote verification in prod.
-            if trade.tx_origin() == Some(Address::ZERO) {
-                let estimate = Estimate {
-                    out_amount: *out_amount,
-                    gas: trade.gas_estimate().context("no gas estimate")?,
-                    solver: trade.solver(),
-                    verified: true,
-                    execution: QuoteExecution {
-                        interactions: map_interactions_data(trade.interactions()),
-                        pre_interactions: map_interactions_data(trade.pre_interactions()),
-                        jit_orders: trade.jit_orders().cloned().collect(),
-                    },
-                };
-                tracing::warn!(
-                    ?estimate,
-                    ?err,
-                    "quote used invalid zeroex RFQ order; pass verification anyway"
-                );
-                return Ok(estimate);
-            }
-        };
-
         let mut summary = SettleOutput::from_swap(output?, query.kind, &tokens)?;
 
         {

--- a/crates/shared/src/order_quoting.rs
+++ b/crates/shared/src/order_quoting.rs
@@ -4,7 +4,6 @@ use {
         fee::FeeParameters,
         order_validation::PreOrderData,
     },
-    account_balances::{BalanceFetching, Query},
     alloy::primitives::{Address, U256, U512, ruint::UintTryFrom},
     anyhow::{Context, Result},
     chrono::{DateTime, Duration, Utc},
@@ -20,10 +19,8 @@ use {
     number::conversions::big_decimal_to_u256,
     price_estimation::{
         self,
-        Estimate,
         PriceEstimating,
         PriceEstimationError,
-        QuoteVerificationMode,
         Verification,
         native::NativePriceEstimating,
         trade_finding::external::dto,
@@ -419,22 +416,17 @@ pub struct OrderQuoter {
     storage: Arc<dyn QuoteStoring>,
     now: Arc<dyn Now>,
     validity: Validity,
-    balance_fetcher: Arc<dyn BalanceFetching>,
-    quote_verification: QuoteVerificationMode,
     default_quote_timeout: std::time::Duration,
     max_quote_timeout: std::time::Duration,
 }
 
 impl OrderQuoter {
-    #[expect(clippy::too_many_arguments)]
     pub fn new(
         price_estimator: Arc<dyn PriceEstimating>,
         native_price_estimator: Arc<dyn NativePriceEstimating>,
         gas_estimator: Arc<dyn GasPriceEstimating>,
         storage: Arc<dyn QuoteStoring>,
         validity: Validity,
-        balance_fetcher: Arc<dyn BalanceFetching>,
-        quote_verification: QuoteVerificationMode,
         default_quote_timeout: std::time::Duration,
         max_quote_timeout: std::time::Duration,
     ) -> Self {
@@ -449,8 +441,6 @@ impl OrderQuoter {
             storage,
             now: Arc::new(Utc::now),
             validity,
-            balance_fetcher,
-            quote_verification,
             default_quote_timeout,
             max_quote_timeout,
         }
@@ -512,9 +502,6 @@ impl OrderQuoter {
             sell_token_price,
         };
 
-        self.verify_quote(&trade_estimate, parameters, quoted_sell_amount)
-            .await?;
-
         let quote_kind = quote_kind_from_signing_scheme(&parameters.signing_scheme);
         let quote = QuoteData {
             sell_token: parameters.sell_token,
@@ -536,64 +523,6 @@ impl OrderQuoter {
         };
 
         Ok(quote)
-    }
-
-    /// Makes sure a quote was verified according to the configured rule.
-    async fn verify_quote(
-        &self,
-        estimate: &Estimate,
-        parameters: &QuoteParameters,
-        sell_amount: U256,
-    ) -> Result<(), CalculateQuoteError> {
-        if estimate.verified
-            || !matches!(
-                self.quote_verification,
-                QuoteVerificationMode::EnforceWhenPossible
-            )
-        {
-            // verification was successful or not strictly required
-            return Ok(());
-        }
-
-        let balance = match self
-            .get_balance(&parameters.verification, parameters.sell_token)
-            .await
-        {
-            Ok(balance) => balance,
-            Err(err) => {
-                tracing::warn!(?err, "could not fetch balance for verification");
-                return Err(CalculateQuoteError::QuoteNotVerified);
-            }
-        };
-
-        if balance >= sell_amount {
-            // Quote could not be verified although user has the required balance.
-            // This likely indicates a weird token that solvers are not able to handle.
-            return Err(CalculateQuoteError::QuoteNotVerified);
-        }
-
-        Ok(())
-    }
-
-    async fn get_balance(&self, verification: &Verification, token: Address) -> Result<U256> {
-        let query = Query {
-            owner: verification.from,
-            token,
-            source: verification.sell_token_source,
-            interactions: verification
-                .pre_interactions
-                .iter()
-                .map(|i| InteractionData {
-                    target: i.target,
-                    value: i.value,
-                    call_data: i.data.clone(),
-                })
-                .collect(),
-            // quote verification already tries to auto-fake missing balances
-            balance_override: None,
-        };
-        let mut balances = self.balance_fetcher.get_balances(&[query]).await;
-        balances.pop().context("missing balance result")?
     }
 }
 
@@ -798,7 +727,6 @@ mod tests {
         super::*,
         Address,
         U256 as AlloyU256,
-        account_balances::MockBalanceFetching,
         alloy::eips::eip1559::Eip1559Estimation,
         chrono::Utc,
         futures::FutureExt,
@@ -812,13 +740,6 @@ mod tests {
             native::MockNativePriceEstimating,
         },
     };
-
-    fn mock_balance_fetcher() -> Arc<dyn BalanceFetching> {
-        let mut mock = MockBalanceFetching::new();
-        mock.expect_get_balances()
-            .returning(|addresses| addresses.iter().map(|_| Ok(U256::MAX)).collect());
-        Arc::new(mock)
-    }
 
     #[test]
     fn pre_order_data_from_quote_request() {
@@ -946,8 +867,6 @@ mod tests {
             storage: Arc::new(storage),
             now: Arc::new(now),
             validity: super::Validity::default(),
-            quote_verification: QuoteVerificationMode::Unverified,
-            balance_fetcher: mock_balance_fetcher(),
             default_quote_timeout: HEALTHY_PRICE_ESTIMATION_TIME,
             max_quote_timeout: HEALTHY_PRICE_ESTIMATION_TIME,
         };
@@ -1087,8 +1006,6 @@ mod tests {
             storage: Arc::new(storage),
             now: Arc::new(now),
             validity: Validity::default(),
-            quote_verification: QuoteVerificationMode::Unverified,
-            balance_fetcher: mock_balance_fetcher(),
             default_quote_timeout: HEALTHY_PRICE_ESTIMATION_TIME,
             max_quote_timeout: HEALTHY_PRICE_ESTIMATION_TIME,
         };
@@ -1223,8 +1140,6 @@ mod tests {
             storage: Arc::new(storage),
             now: Arc::new(now),
             validity: Validity::default(),
-            quote_verification: QuoteVerificationMode::Unverified,
-            balance_fetcher: mock_balance_fetcher(),
             default_quote_timeout: HEALTHY_PRICE_ESTIMATION_TIME,
             max_quote_timeout: HEALTHY_PRICE_ESTIMATION_TIME,
         };
@@ -1322,8 +1237,6 @@ mod tests {
             storage: Arc::new(MockQuoteStoring::new()),
             now: Arc::new(Utc::now),
             validity: Validity::default(),
-            quote_verification: QuoteVerificationMode::Unverified,
-            balance_fetcher: mock_balance_fetcher(),
             default_quote_timeout: HEALTHY_PRICE_ESTIMATION_TIME,
             max_quote_timeout: HEALTHY_PRICE_ESTIMATION_TIME,
         };
@@ -1396,8 +1309,6 @@ mod tests {
             storage: Arc::new(MockQuoteStoring::new()),
             now: Arc::new(Utc::now),
             validity: Validity::default(),
-            quote_verification: QuoteVerificationMode::Unverified,
-            balance_fetcher: mock_balance_fetcher(),
             default_quote_timeout: HEALTHY_PRICE_ESTIMATION_TIME,
             max_quote_timeout: HEALTHY_PRICE_ESTIMATION_TIME,
         };
@@ -1458,8 +1369,6 @@ mod tests {
             storage: Arc::new(storage),
             now: Arc::new(now),
             validity: Validity::default(),
-            quote_verification: QuoteVerificationMode::Unverified,
-            balance_fetcher: mock_balance_fetcher(),
             default_quote_timeout: HEALTHY_PRICE_ESTIMATION_TIME,
             max_quote_timeout: HEALTHY_PRICE_ESTIMATION_TIME,
         };
@@ -1542,8 +1451,6 @@ mod tests {
             storage: Arc::new(storage),
             now: Arc::new(now),
             validity: Validity::default(),
-            quote_verification: QuoteVerificationMode::Unverified,
-            balance_fetcher: mock_balance_fetcher(),
             default_quote_timeout: HEALTHY_PRICE_ESTIMATION_TIME,
             max_quote_timeout: HEALTHY_PRICE_ESTIMATION_TIME,
         };
@@ -1628,8 +1535,6 @@ mod tests {
             storage: Arc::new(storage),
             now: Arc::new(now),
             validity: Validity::default(),
-            quote_verification: QuoteVerificationMode::Unverified,
-            balance_fetcher: mock_balance_fetcher(),
             default_quote_timeout: HEALTHY_PRICE_ESTIMATION_TIME,
             max_quote_timeout: HEALTHY_PRICE_ESTIMATION_TIME,
         };
@@ -1702,8 +1607,6 @@ mod tests {
             storage: Arc::new(storage),
             now: Arc::new(now),
             validity: Validity::default(),
-            quote_verification: QuoteVerificationMode::Unverified,
-            balance_fetcher: mock_balance_fetcher(),
             default_quote_timeout: HEALTHY_PRICE_ESTIMATION_TIME,
             max_quote_timeout: HEALTHY_PRICE_ESTIMATION_TIME,
         };
@@ -1734,8 +1637,6 @@ mod tests {
             storage: Arc::new(storage),
             now: Arc::new(Utc::now),
             validity: Validity::default(),
-            quote_verification: QuoteVerificationMode::Unverified,
-            balance_fetcher: mock_balance_fetcher(),
             default_quote_timeout: HEALTHY_PRICE_ESTIMATION_TIME,
             max_quote_timeout: HEALTHY_PRICE_ESTIMATION_TIME,
         };


### PR DESCRIPTION
# Description
We needed to introduce a loop hole to consider some quotes verified even though the simulation failed. However, for a long time now no solver actually used this edge case anymore.

# Changes
In order to simplify the quote verification wherever possible this PR drops this edge case and its test.