### PR TITLE
[TRIVIAL] Add another variant of .env.claude to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 **/testing.*.toml
 /playground/.env
 .env.claude
+.env.*.claude


### PR DESCRIPTION
# Description
I use `.env.staging.claude` for example, this would help with that — I can change to another format, just want a bit more flexibility

# Changes

* Add `.env.*.claude` to gitignore
