### PR TITLE
Overhaul SettlementSimulator / SimulationBuilder API

### DIFF
--- a/crates/driver/src/domain/competition/pre_processing.rs
+++ b/crates/driver/src/domain/competition/pre_processing.rs
@@ -144,7 +144,7 @@ impl DataAggregator {
                 vault_relayer: *eth.contracts().vault_relayer(),
                 signatures: eth.contracts().signatures().clone(),
             },
-            eth.balance_overrider(),
+            eth.state_overrider(),
         );
 
         let cow_amm_helper_by_factory = eth

--- a/crates/driver/src/infra/blockchain/mod.rs
+++ b/crates/driver/src/infra/blockchain/mod.rs
@@ -90,7 +90,7 @@ struct Inner {
     gas: Arc<GasPriceEstimator>,
     current_block: CurrentBlockWatcher,
     balance_simulator: BalanceSimulator,
-    balance_overrider: Arc<dyn StateOverriding>,
+    state_overrider: Arc<dyn StateOverriding>,
     tx_gas_limit: eth::Gas,
 }
 
@@ -117,13 +117,13 @@ impl Ethereum {
         let contracts = Contracts::new(&web3, chain, addresses)
             .await
             .expect("could not initialize important smart contracts");
-        let balance_overrider = Arc::new(BalanceOverrides::new(web3.clone()));
+        let state_overrider = Arc::new(BalanceOverrides::new(web3.clone()));
         let balance_simulator = BalanceSimulator::new(
             contracts.settlement().clone(),
             contracts.balance_helper().clone(),
             *contracts.vault_relayer(),
             Some(*contracts.vault().address()),
-            balance_overrider.clone(),
+            state_overrider.clone(),
         );
 
         Self {
@@ -133,7 +133,7 @@ impl Ethereum {
                 contracts,
                 gas,
                 balance_simulator,
-                balance_overrider,
+                state_overrider,
                 tx_gas_limit,
             }),
             web3,
@@ -148,8 +148,8 @@ impl Ethereum {
         &self.inner.balance_simulator
     }
 
-    pub fn balance_overrider(&self) -> Arc<dyn StateOverriding> {
-        Arc::clone(&self.inner.balance_overrider)
+    pub fn state_overrider(&self) -> Arc<dyn StateOverriding> {
+        Arc::clone(&self.inner.state_overrider)
     }
 
     /// Clones self and returns an instance that captures metrics extended with

--- a/crates/price-estimation/src/trade_verifier/mod.rs
+++ b/crates/price-estimation/src/trade_verifier/mod.rs
@@ -253,28 +253,17 @@ impl TradeVerifier {
             .new_simulation_builder()
             .with_orders(std::iter::once(fake_order).chain(jit_orders))
             .from_solver(SimulationSolver::OriginUnaltered(solver_address))
-            .with_pre_interactions(pre_interactions)
-            .with_main_interactions(main_interactions)
-            .with_post_interactions(post_interactions)
+            .append_pre_interactions(pre_interactions)
+            .append_main_interactions(main_interactions)
+            .append_post_interactions(post_interactions)
             .with_overrides(override_requests)
             .build()
             .await?;
 
         // after assembling the state overrides and settlement call data we need to
         // craft a call that takes the settle call data as an argument.
-        let settlement_target = eth_call_inputs
-            .request
-            .to
-            .as_ref()
-            .and_then(|t| t.to())
-            .copied()
-            .expect("settlement target is always set");
-        let calldata: Bytes = eth_call_inputs
-            .request
-            .input
-            .input
-            .clone()
-            .unwrap_or_default();
+        let settlement_target = eth_call_inputs.to;
+        let calldata: Bytes = eth_call_inputs.calldata.clone();
 
         let solver_contract = Solver::Instance::new(solver_address, self.simulator.provider());
         let swap_call = solver_contract

--- a/crates/simulator/src/encoding.rs
+++ b/crates/simulator/src/encoding.rs
@@ -12,11 +12,8 @@ use {
         Solver,
         WrapperConfig,
     },
-    alloy_primitives::{Address, B256, Bytes, U256, keccak256},
-    alloy_rpc_types::{
-        TransactionRequest,
-        state::{AccountOverride, StateOverride},
-    },
+    alloy_primitives::{Address, B256, Bytes, U256, b256, keccak256},
+    alloy_rpc_types::state::{AccountOverride, StateOverride},
     alloy_sol_types::SolCall,
     app_data::AppDataHash,
     balance_overrides::{BalanceOverrideRequest, StateOverriding},
@@ -409,6 +406,19 @@ pub(crate) async fn finish_simulation_builder(
         }
     }
 
+    if builder.presign_orders {
+        builder.account_override_requests.extend(
+            builder
+                .orders
+                .iter()
+                .filter(|o| matches!(o.signature, Signature::PreSign))
+                .map(|o| {
+                    let uid = o.data.uid(&builder.simulator.0.domain_separator, o.owner);
+                    AccountOverrideRequest::PreSignature(uid)
+                }),
+        );
+    }
+
     // Encode every order as a trade, then collect all their interactions.
     let mut trades = Vec::with_capacity(n);
     for (i, (order, exec)) in builder.orders.iter().zip(&executed_amounts).enumerate() {
@@ -442,7 +452,7 @@ pub(crate) async fn finish_simulation_builder(
     };
 
     let wrapper = builder.wrapper;
-    let (to, input) = match wrapper {
+    let (to, calldata) = match wrapper {
         WrapperConfig::Custom(wrappers) if !wrappers.is_empty() => {
             encode_wrapper_settlement(&wrappers, settle_calldata).expect("wrappers is non-empty")
         }
@@ -482,19 +492,16 @@ pub(crate) async fn finish_simulation_builder(
     };
     let state_overrides = build_final_state_overrides(
         builder.account_override_requests,
-        builder.simulator.0.balance_overrides.as_ref(),
+        builder.simulator.0.state_overrides.as_ref(),
         builder.simulator.0.authenticator,
+        *builder.simulator.0.settlement.address(),
     )
     .await;
 
     Ok(EthCallInputs {
-        request: TransactionRequest {
-            from: Some(from),
-            to: Some(to.into()),
-            input: input.into(),
-            gas: Some(builder.simulator.0.max_gas_limit),
-            ..Default::default()
-        },
+        from,
+        to,
+        calldata,
         state_overrides,
         block,
         simulator: builder.simulator,
@@ -542,8 +549,9 @@ async fn executed_amount(
 /// than aborting the whole build.
 async fn build_final_state_overrides(
     requests: Vec<AccountOverrideRequest>,
-    balance_overrides: &dyn StateOverriding,
+    state_overrides: &dyn StateOverriding,
     authenticator: Address,
+    settlement_contract: Address,
 ) -> StateOverride {
     let futures = requests.into_iter().map(|request| async move {
         match request {
@@ -571,7 +579,7 @@ async fn build_final_state_overrides(
                 token,
                 amount,
             } => {
-                let result = balance_overrides
+                let result = state_overrides
                     .balance_override(BalanceOverrideRequest {
                         token,
                         holder,
@@ -590,6 +598,26 @@ async fn build_final_state_overrides(
                     ..Default::default()
                 },
             )),
+            AccountOverrideRequest::PreSignature(order) => {
+                // GPv2Settlement stores the `mapping(bytes => uint256) public preSignature` at
+                // storage slot 0.
+                // Solidity mapping key: keccak256(order_uid_without_padding ++ slot_padded).
+                // <https://github.com/cowprotocol/contracts/blob/main/src/contracts/mixins/GPv2Signing.sol#L57C1-L57C51>
+                let mut buf = [0u8; 56 + 32];
+                buf[0..56].copy_from_slice(order.0.as_slice());
+                // no need to copy anything for storage slot 0 since the array gets 0 initialized.
+                let slot = keccak256(buf);
+
+                // Sentinel value expected by the settlement contract to indicate that the order
+                // was pre-signed by the user.
+                // See <https://github.com/cowprotocol/contracts/blob/main/src/contracts/mixins/GPv2Signing.sol#L44-L46>
+                const PRE_SIGN_SENTINEL: B256 = b256!("f59c009283ff87aa78203fc4d9c2df025ee851130fb69cc3e068941f6b5e2d6f");
+                Some((
+                    settlement_contract,
+                    AccountOverride::default()
+                        .with_state_diff(std::iter::once((slot, PRE_SIGN_SENTINEL))),
+                ))
+            }
             AccountOverrideRequest::Custom { account, state } => Some((account, state)),
         }
     });

--- a/crates/simulator/src/encoding.rs
+++ b/crates/simulator/src/encoding.rs
@@ -602,7 +602,7 @@ async fn build_final_state_overrides(
                 // GPv2Settlement stores the `mapping(bytes => uint256) public preSignature` at
                 // storage slot 0.
                 // Solidity mapping key: keccak256(order_uid_without_padding ++ slot_padded).
-                // <https://github.com/cowprotocol/contracts/blob/main/src/contracts/mixins/GPv2Signing.sol#L57C1-L57C51>
+                // <https://github.com/cowprotocol/contracts/blob/c6b61ce75841ce4c25ab126def9cc981c568e6c6/src/contracts/mixins/GPv2Signing.sol#L57>
                 let mut buf = [0u8; 56 + 32];
                 buf[0..56].copy_from_slice(order.0.as_slice());
                 // no need to copy anything for storage slot 0 since the array gets 0 initialized.
@@ -610,7 +610,7 @@ async fn build_final_state_overrides(
 
                 // Sentinel value expected by the settlement contract to indicate that the order
                 // was pre-signed by the user.
-                // See <https://github.com/cowprotocol/contracts/blob/main/src/contracts/mixins/GPv2Signing.sol#L44-L46>
+                // See <https://github.com/cowprotocol/contracts/blob/c6b61ce75841ce4c25ab126def9cc981c568e6c6/src/contracts/mixins/GPv2Signing.sol#L44-L46>
                 const PRE_SIGN_SENTINEL: B256 = b256!("f59c009283ff87aa78203fc4d9c2df025ee851130fb69cc3e068941f6b5e2d6f");
                 Some((
                     settlement_contract,

--- a/crates/simulator/src/simulation_builder.rs
+++ b/crates/simulator/src/simulation_builder.rs
@@ -312,7 +312,7 @@ pub struct EthCallInputs {
 }
 
 impl EthCallInputs {
-    pub fn to_transaction_request(&self) -> TransactionRequest {
+    pub fn as_transaction_request(&self) -> TransactionRequest {
         TransactionRequest {
             from: Some(self.from),
             to: Some(self.to.into()),
@@ -329,7 +329,7 @@ impl EthCallInputs {
             .0
             .provider
             .clone()
-            .call(self.to_transaction_request())
+            .call(self.as_transaction_request())
             .overrides(self.state_overrides)
             .block(self.block.into())
             .await
@@ -369,7 +369,10 @@ impl EthCallInputs {
             // happened at the very end of the given block. This could be achieved in
             // tenderly with `transaction_index: -1` but this is extremely costly to
             // simulate which is why we craft the request to simulate the tx on the very
-            // first index of the **next** block.
+            // first index of the **next** block. In practice the different will be that
+            // tenderly's simulation will already use the block number and timestamp of
+            // the **next** block that would be mined which is arguably more correct than
+            // the original simulation.
             block_number: Some(self.block + 1),
             transaction_index: Some(0),
             network_id: self.simulator.0.chain_id.to_string(),

--- a/crates/simulator/src/simulation_builder.rs
+++ b/crates/simulator/src/simulation_builder.rs
@@ -1,6 +1,6 @@
 use {
     crate::{encoding::WrapperCall, tenderly},
-    alloy_primitives::{Address, B256, Bytes, TxKind, U256},
+    alloy_primitives::{Address, B256, Bytes, U256},
     alloy_provider::{DynProvider, Provider},
     alloy_rpc_types::{
         TransactionRequest,
@@ -14,7 +14,7 @@ use {
     model::{
         DomainSeparator,
         interaction::InteractionData,
-        order::OrderData,
+        order::{OrderData, OrderUid},
         signature::{Signature, SigningScheme},
     },
     std::sync::Arc,
@@ -29,11 +29,12 @@ pub struct SettlementSimulator(pub(crate) Arc<Inner>);
 pub(crate) struct Inner {
     pub(crate) settlement: contracts::GPv2Settlement::Instance,
     pub(crate) authenticator: Address,
+    pub(crate) vault_relayer: Address,
     pub(crate) flash_loan_router: Address,
     pub(crate) hooks_trampoline: Address,
     pub(crate) native_token: Address,
     pub(crate) max_gas_limit: u64,
-    pub(crate) balance_overrides: Arc<dyn StateOverriding>,
+    pub(crate) state_overrides: Arc<dyn StateOverriding>,
     pub(crate) provider: DynProvider,
     pub(crate) domain_separator: DomainSeparator,
     pub(crate) chain_id: u64,
@@ -49,22 +50,24 @@ impl SettlementSimulator {
         hooks_trampoline: Address,
         native_token: Address,
         max_gas_limit: u64,
-        balance_overrides: Arc<dyn StateOverriding>,
+        state_overrides: Arc<dyn StateOverriding>,
         current_block: CurrentBlockWatcher,
         tenderly: Option<Arc<dyn tenderly::Api>>,
     ) -> Result<Self> {
         let authenticator = settlement.authenticator().call().await?;
+        let vault_relayer = Address(settlement.vaultRelayer().call().await?.0);
         let domain_separator = DomainSeparator(settlement.domainSeparator().call().await?.0);
         let provider = settlement.provider().clone();
         let chain_id = provider.get_chain_id().await?;
         Ok(Self(Arc::new(Inner {
             settlement,
             authenticator,
+            vault_relayer,
             flash_loan_router,
             hooks_trampoline,
             native_token,
             max_gas_limit,
-            balance_overrides,
+            state_overrides,
             provider,
             domain_separator,
             chain_id,
@@ -93,6 +96,10 @@ impl SettlementSimulator {
         self.0.authenticator
     }
 
+    pub fn vault_relayer_address(&self) -> Address {
+        self.0.vault_relayer
+    }
+
     pub fn new_simulation_builder(&self) -> SimulationBuilder {
         SimulationBuilder {
             simulator: self.clone(),
@@ -105,6 +112,7 @@ impl SettlementSimulator {
             auction_id: None,
             account_override_requests: vec![],
             provide_buy_tokens: false,
+            presign_orders: false,
             block: Block::Latest,
         }
     }
@@ -136,6 +144,7 @@ pub struct SimulationBuilder {
     pub(crate) simulator: SettlementSimulator,
     pub(crate) account_override_requests: Vec<AccountOverrideRequest>,
     pub(crate) provide_buy_tokens: bool,
+    pub(crate) presign_orders: bool,
     pub(crate) block: Block,
 }
 
@@ -145,7 +154,7 @@ impl SimulationBuilder {
         self
     }
 
-    pub fn with_pre_interactions(
+    pub fn append_pre_interactions(
         mut self,
         interactions: impl IntoIterator<Item = InteractionData>,
     ) -> Self {
@@ -153,7 +162,7 @@ impl SimulationBuilder {
         self
     }
 
-    pub fn with_main_interactions(
+    pub fn append_main_interactions(
         mut self,
         interactions: impl IntoIterator<Item = InteractionData>,
     ) -> Self {
@@ -161,7 +170,7 @@ impl SimulationBuilder {
         self
     }
 
-    pub fn with_post_interactions(
+    pub fn append_post_interactions(
         mut self,
         interactions: impl IntoIterator<Item = InteractionData>,
     ) -> Self {
@@ -261,6 +270,15 @@ impl SimulationBuilder {
         self
     }
 
+    /// For every order with signature scheme presign the simulation will
+    /// contains state overrides to provide the signatures.
+    /// This is useful when you have to author an order on behalf of an account
+    /// you don't control.
+    pub fn presign_orders(mut self) -> Self {
+        self.presign_orders = true;
+        self
+    }
+
     /// Queues [`AccountOverrideRequest`]s to be resolved and applied during
     /// [`build`](Self::build). Multiple requests may target the same address
     /// and will be applied on a best-effort basis (failure to compute balance
@@ -282,16 +300,28 @@ impl SimulationBuilder {
     }
 }
 
-/// The output of [`SimulationBuilder::build`]: a transaction request and state
-/// overrides ready to be passed to an alloy provider for simulation.
+/// The output of [`SimulationBuilder::build`]: inputs ready to be passed to an
+/// alloy provider for simulation.
 pub struct EthCallInputs {
-    pub request: TransactionRequest,
+    pub from: Address,
+    pub to: Address,
+    pub calldata: Bytes,
     pub state_overrides: StateOverride,
     pub simulator: SettlementSimulator,
     pub block: u64,
 }
 
 impl EthCallInputs {
+    pub fn to_transaction_request(&self) -> TransactionRequest {
+        TransactionRequest {
+            from: Some(self.from),
+            to: Some(self.to.into()),
+            input: self.calldata.clone().into(),
+            gas: Some(self.simulator.0.max_gas_limit),
+            ..Default::default()
+        }
+    }
+
     /// Runs the generated simulation using an `eth_call` and returns the
     /// response bytes if there are any.
     pub async fn simulate(self) -> Result<Bytes, RpcError<alloy_transport::TransportErrorKind>> {
@@ -299,7 +329,7 @@ impl EthCallInputs {
             .0
             .provider
             .clone()
-            .call(self.request)
+            .call(self.to_transaction_request())
             .overrides(self.state_overrides)
             .block(self.block.into())
             .await
@@ -334,25 +364,20 @@ impl EthCallInputs {
     /// tenderly.
     pub fn to_tenderly_request(&self) -> Result<tenderly::dto::Request, ConversionError> {
         Ok(tenderly::dto::Request {
-            // By default tenderly simulates calls at the start of the block. So if we simulate
-            // something when the latest block is `n` we need to tell tenderly to simulate at
-            // block `n+1` to still have all of block n's txs happen before our simulation runs.
+            // By default, tenderly simulates the given transaction as if it happened somewhere in
+            // the given block number, while nodes simulate the transaction as if it
+            // happened at the very end of the given block. This could be achieved in
+            // tenderly with `transaction_index: -1` but this is extremely costly to
+            // simulate which is why we craft the request to simulate the tx on the very
+            // first index of the **next** block.
             block_number: Some(self.block + 1),
+            transaction_index: Some(0),
             network_id: self.simulator.0.chain_id.to_string(),
-            from: self.request.from.unwrap_or_default(),
-            to: match &self.request.to.ok_or(ConversionError::MissingTo)? {
-                TxKind::Create => Default::default(),
-                TxKind::Call(to) => *to,
-            },
-            input: self
-                .request
-                .input
-                .input
-                .as_ref()
-                .map(|bytes| bytes.to_vec())
-                .unwrap_or_default(),
-            gas: self.request.gas,
-            value: self.request.value,
+            from: self.from,
+            to: self.to,
+            input: self.calldata.to_vec(),
+            gas: Some(self.simulator.0.max_gas_limit),
+            value: None,
             simulation_type: Some(tenderly::dto::SimulationType::Full),
             state_objects: Some(
                 self.state_overrides
@@ -366,11 +391,10 @@ impl EthCallInputs {
                     })
                     .collect::<Result<_, ConversionError>>()?,
             ),
-            access_list: self.request.access_list.as_ref().map(Into::into),
+            access_list: None,
             save: Some(true),
             gas_price: None,
             save_if_fails: Some(true),
-            transaction_index: None,
             generate_access_list: None,
         })
     }
@@ -504,15 +528,14 @@ pub enum AccountOverrideRequest {
         account: Address,
         state: AccountOverride,
     },
-    // TODO: add Allowance
+    /// Pre-signs the given order such that the pre-sign signature check passes.
+    PreSignature(OrderUid),
 }
 
 /// Error returned when a built eth_call simulation could not be converted
 /// into a tenderly simulation request.
 #[derive(Debug, thiserror::Error)]
 pub enum ConversionError {
-    #[error("simulation does not have a target")]
-    MissingTo,
     #[error("could not convert state overrides")]
     StateOverrides,
 }


### PR DESCRIPTION
# Description
Implements a few changes to make the `SimulationBuilder` slightly nicer to use in the upcoming trade verifier refactor.

# Changes
- a bit more appropriate names for some function
- rename member variables
- support for computing state overrides for pre-signatures
- store (`to`, `from`, `calldata` directly in the simulator instead of a full `TransactionRequest`)
- expose `vault_relayer` for use in trade verifier
- comment on tenderly request parameters