### PR TITLE
Filter out solutions with a score of 0

### DIFF
--- a/crates/autopilot/src/domain/competition/winner_selection.rs
+++ b/crates/autopilot/src/domain/competition/winner_selection.rs
@@ -913,6 +913,54 @@ mod tests {
         TestCase::from_json(case).validate().await;
     }
 
+    /// A solution settling no orders gets a score of 0 which disqualifies it
+    /// from the competition.
+    #[tokio::test]
+    async fn discards_solutions_with_zero_score() {
+        let case = json!({
+            "tokens": [
+                ["Token A", address(0)],
+                ["Token B", address(1)],
+            ],
+            "auction": {
+                "orders": {
+                    "Order 1": {
+                        "side": "sell",
+                        "sell_token": "Token A",
+                        "sell_amount": "32375066190000000000000000",
+                        "buy_token": "Token B",
+                        "buy_amount": "2161512119"
+                    }
+                },
+                "prices": {
+                    "Token A": "32429355240",
+                    "Token B": "480793239987749750742974464"
+                }
+            },
+            "solutions": {
+                "Solution 1": {
+                    "solver": "Solver 1",
+                    "trades": {},
+                },
+                "Solution 2": {
+                    "solver": "Solver 2",
+                    "trades": {
+                        "Order 1": {
+                            "sell_amount": "32375066190000000000000000",
+                            "buy_amount": "2205267875"
+                        }
+                    }
+                }
+            },
+            "expected_fair_solutions": ["Solution 2"],
+            "expected_winners": ["Solution 2"],
+            "expected_reference_scores": {
+                "Solver 2": "0",
+            },
+        });
+        TestCase::from_json(case).validate().await;
+    }
+
     #[serde_as]
     #[derive(Deserialize, Debug)]
     struct TestCase {

--- a/crates/winner-selection/src/arbitrator.rs
+++ b/crates/winner-selection/src/arbitrator.rs
@@ -68,6 +68,9 @@ impl Arbitrator {
         let (mut solutions, scores_by_solution) =
             self.compute_scores_by_solution(solutions, context);
 
+        // Discard any solutions with a score of 0 as they are invalid
+        solutions.retain(|solution| !solution.score().is_zero());
+
         // Sort by score descending
         solutions.sort_by_key(|solution| Reverse(solution.score()));
 


### PR DESCRIPTION
# Description
When a driver submits an empty solution due to a bug it can currently be marked as a winner which is clearly incorrect (also formally specified in the [docs](https://docs.cow.fi/cow-protocol/reference/core/auctions/competition-rules#off-chain-protocol).

An example of this happening is [here](https://api.cow.fi/arbitrum_one/api/v2/solver_competition/7212824).

# Changes
winner selection algorithm explicitly filters out solutions with a score of 0.

## How to test
Added a unit test where 1 solver submits a solution with no trades.