### PR TITLE
[TRIVIAL] Fix run-loop solve deadline default

### DIFF
--- a/crates/configs/src/autopilot/run_loop.rs
+++ b/crates/configs/src/autopilot/run_loop.rs
@@ -24,7 +24,7 @@ const fn default_max_settlement_transaction_wait() -> Duration {
 }
 
 const fn default_solve_deadline() -> Duration {
-    Duration::from_mins(15)
+    Duration::from_secs(15)
 }
 
 /// Configuration for the autopilot run loop timing.


### PR DESCRIPTION
# Description
During the migration the default was changed from 15s to 15m ([`540bc76`](https://github.com/cowprotocol/services/commit/ddc8a53e22e8591905fb01e9920078d7e#diff-4b71ca4a48e3f3d282d11323f4249dc0c457e315ee6706653f24a0aa8cdb4d1dL101-L108)), since all our networks run with a custom value under 15s, we weren't affected; however, when working through the upgrade with AAVE this was breaking the whole playground.

# Changes

* Change the default from minutes back to seconds

## How to test
Run the playground without run-loop settings before and after; before it should be stuck, after it should work