### PR TITLE
Add Claude PR review workflow

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -28,14 +28,15 @@ jobs:
         github.event.pull_request.draft == false &&
         github.event.pull_request.user.type != 'Bot' &&
         !contains(github.event.pull_request.labels.*.name, 'skip-claude-review') &&
-        contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.pull_request.author_association)
+        contains(fromJSON('["OWNER", "MEMBER"]'), github.event.pull_request.author_association)
       ) || (
         github.event_name == 'issue_comment' &&
         github.event.issue.pull_request != null &&
         contains(github.event.comment.body, '@claude') &&
-        contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)
+        contains(fromJSON('["OWNER", "MEMBER"]'), github.event.comment.author_association)
       )
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -1,0 +1,55 @@
+name: Claude PR Review
+on:
+  pull_request:
+    types: [opened, ready_for_review]
+  issue_comment:
+    types: [created]
+
+# Cancel an in-flight review if another trigger fires on the same PR (e.g.
+# back-to-back `@claude` comments, or a draft→ready transition while an
+# earlier run is still going). Note: `synchronize` is not in the trigger
+# list, so plain pushes do not trigger or cancel anything.
+concurrency:
+  group: claude-review-${{ github.event.pull_request.number || github.event.issue.number }}
+  cancel-in-progress: true
+
+jobs:
+  review:
+    # Gate the job so it only runs when:
+    #   (a) a non-draft PR is opened or marked ready-for-review, OR
+    #   (b) someone posts an `@claude` comment on a PR (not on an issue).
+    # Also skip bot authors and PRs explicitly labelled `skip-claude-review`,
+    # so authors have an escape hatch for trivial changes.
+    if: >
+      (
+        github.event_name == 'pull_request' &&
+        github.event.pull_request.draft == false &&
+        github.event.pull_request.user.type != 'Bot' &&
+        !contains(github.event.pull_request.labels.*.name, 'skip-claude-review')
+      ) || (
+        github.event_name == 'issue_comment' &&
+        github.event.issue.pull_request != null &&
+        contains(github.event.comment.body, '@claude')
+      )
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+      id-token: write
+      actions: read
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          # Full history lets the action compute an accurate diff vs the base
+          # branch instead of just the latest commit.
+          fetch-depth: 0
+
+      - uses: anthropics/claude-code-action@51ea8ea73a139f2a74ff649e3092c25a904aed7e # v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          trigger_phrase: "@claude"
+          claude_args: |
+            --model claude-opus-4-7
+            --max-turns 10
+          prompt: "Review this PR"

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -20,16 +20,20 @@ jobs:
     #   (b) someone posts an `@claude` comment on a PR (not on an issue).
     # Also skip bot authors and PRs explicitly labelled `skip-claude-review`,
     # so authors have an escape hatch for trivial changes.
+    # External contributors are excluded from both triggers by requiring an
+    # internal `author_association` (OWNER/MEMBER/COLLABORATOR).
     if: >
       (
         github.event_name == 'pull_request' &&
         github.event.pull_request.draft == false &&
         github.event.pull_request.user.type != 'Bot' &&
-        !contains(github.event.pull_request.labels.*.name, 'skip-claude-review')
+        !contains(github.event.pull_request.labels.*.name, 'skip-claude-review') &&
+        contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.pull_request.author_association)
       ) || (
         github.event_name == 'issue_comment' &&
         github.event.issue.pull_request != null &&
-        contains(github.event.comment.body, '@claude')
+        contains(github.event.comment.body, '@claude') &&
+        contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)
       )
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
# Description

Re-introduces an automated Claude code review after #4381 dropped the previous version for cost reasons (~$10-15 per PR). 

# Key changes from the old workflow:

- Drops the `/code-review` plugin's multi-agent fanout. A single agent with a plain "Review this PR" prompt is enough and avoids the parallel subagent context (which leads to spend similar to the integrated Claude review that's currently running)
- Caps the agent loop with `--max-turns 10`.
- Adds a `concurrency` group so back-to-back `@claude` comments cancel the previous in-flight run instead of paying twice.
- Adds a `skip-claude-review` label escape hatch and skips bot-authored PRs (we may want to inverse this logic later and make it review only certain PRs).

Not using https://github.com/colbymchenry/codegraph for now, because:
- the static syntax parsing is not super useful for Rust (no trait/macro/generic resolution)
- the index would need rebuilding or caching on every CI run (complexity)
- the model choice and turn cap seem far bigger cost levers here than exploration tokens

Only people that are part of our org can trigger the review.

## How to test
Monitor API key spend
