### PR TITLE
Fix rate calculation for the EIP4626 tokens

### DIFF
--- a/crates/e2e/tests/e2e/eip4626.rs
+++ b/crates/e2e/tests/e2e/eip4626.rs
@@ -42,6 +42,10 @@ const WETH: Address = address!("C02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2");
 /// revert with *empty* revert data — the regression case below.
 const USDC: Address = address!("A0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48");
 
+/// DAI on mainnet — 18-decimal counterpart to USDC for testing the
+/// `6-decimal vault wrapping 18-decimal asset` direction.
+const DAI: Address = address!("6B175474E89094C44Da98b954EedeAC495271d0F");
+
 #[tokio::test]
 #[ignore]
 async fn forked_node_mainnet_eip4626_native_price() {
@@ -246,6 +250,118 @@ async fn eip4626_recursive_native_price_test(web3: Web3) {
     assert!(
         (ratio - 2.0 / 9.0).abs() / (2.0 / 9.0) < 0.01,
         "wrapper (1/3) price ratio to baseline (3/2) should be 2/9: got {ratio:.6}",
+    );
+}
+
+/// Vault and underlying decimals must be threaded through `conversion_rate`
+/// correctly in both directions. Native prices are atomic-to-atomic, so the
+/// wrapper's price must equal the underlying's scaled by
+/// `10^(asset_decimals - vault_decimals)`. Exercises both asymmetries:
+///   - 18-decimal vault wrapping 6-decimal USDC → ratio = `10^-12` (lands the
+///     vault in DAI's `~10^-4 wei/atomic` range, not USDC's `~10^8
+///     wei/atomic`).
+///   - 6-decimal vault wrapping 18-decimal DAI → ratio = `10^12` (vice versa).
+#[tokio::test]
+#[ignore]
+async fn forked_node_mainnet_eip4626_decimal_mismatch_native_price() {
+    run_forked_test_with_block_number(
+        eip4626_decimal_mismatch_native_price_test,
+        std::env::var("FORK_URL_MAINNET")
+            .expect("FORK_URL_MAINNET must be set to run forked tests"),
+        FORK_BLOCK_MAINNET,
+    )
+    .await;
+}
+
+async fn eip4626_decimal_mismatch_native_price_test(web3: Web3) {
+    let mut onchain = OnchainComponents::deployed(web3.clone()).await;
+
+    let [solver] = onchain.make_solvers_forked(1u64.eth()).await;
+
+    // 18-decimal wrapper of 6-decimal USDC at a 1:1 whole-token rate.
+    // `convertToAssets(10^18) = 10^18 / 10^12 = 10^6` (= 1 whole USDC in
+    // atomic units), so the atomic-to-atomic factor is `10^-12`.
+    let wrapper_18_over_6 = contracts::test::MockERC4626Wrapper::Instance::deploy(
+        web3.provider.clone(),
+        USDC,
+        18u8,
+        U256::from(1u64),
+        U256::from(1_000_000_000_000u64),
+    )
+    .await
+    .unwrap();
+    let wrapper_18_over_6_addr = *wrapper_18_over_6.address();
+
+    // 6-decimal wrapper of 18-decimal DAI at a 1:1 whole-token rate.
+    // `convertToAssets(10^6) = 10^6 * 10^12 = 10^18` (= 1 whole DAI in atomic
+    // units), so the atomic-to-atomic factor is `10^12`.
+    let wrapper_6_over_18 = contracts::test::MockERC4626Wrapper::Instance::deploy(
+        web3.provider.clone(),
+        DAI,
+        6u8,
+        U256::from(1_000_000_000_000u64),
+        U256::from(1u64),
+    )
+    .await
+    .unwrap();
+    let wrapper_6_over_18_addr = *wrapper_6_over_18.address();
+
+    let driver_url: url::Url = "http://localhost:11088/test_solver".parse().unwrap();
+    let autopilot_config = Configuration {
+        native_price_estimation: NativePriceConfig {
+            eip4626: true,
+            estimators: NativePriceEstimators::new(vec![vec![NativePriceEstimator::driver(
+                "test_quoter".to_string(),
+                driver_url,
+            )]]),
+            shared: configs::native_price::NativePriceConfig {
+                results_required: 1.try_into().unwrap(),
+                ..Default::default()
+            },
+            ..NativePriceConfig::test_default()
+        },
+        ..Configuration::test("test_solver", solver.address())
+    };
+
+    let services = Services::new(&onchain).await;
+    services
+        .start_protocol_with_args(
+            autopilot_config,
+            configs::orderbook::Configuration::test_default(),
+            solver,
+        )
+        .await;
+
+    onchain.mint_block().await;
+
+    let fetch_price = async |addr: &Address, label: &str| -> f64 {
+        wait_for_condition(TIMEOUT, || async {
+            services.get_native_price(addr).await.is_ok()
+        })
+        .await
+        .unwrap_or_else(|_| panic!("native price for {label} should be available"));
+        services.get_native_price(addr).await.unwrap().price
+    };
+
+    let usdc_price = fetch_price(&USDC, "USDC").await;
+    let dai_price = fetch_price(&DAI, "DAI").await;
+
+    // 18→6: wrapper should be priced like an 18-decimal stablecoin (DAI's
+    // range), so `wrapper_price / usdc_price ≈ 10^-12`.
+    let wrapper_18_over_6_price = fetch_price(&wrapper_18_over_6_addr, "18→6 wrapper").await;
+    let ratio = wrapper_18_over_6_price / usdc_price;
+    assert!(
+        (ratio - 1e-12).abs() / 1e-12 < 0.01,
+        "18→6 wrapper / USDC ratio should be 1e-12, got {ratio:e}",
+    );
+
+    // 6→18: wrapper should be priced like a 6-decimal stablecoin (USDC's
+    // range), so `wrapper_price / dai_price ≈ 10^12`.
+    let wrapper_6_over_18_price = fetch_price(&wrapper_6_over_18_addr, "6→18 wrapper").await;
+    let ratio = wrapper_6_over_18_price / dai_price;
+    assert!(
+        (ratio - 1e12).abs() / 1e12 < 0.01,
+        "6→18 wrapper / DAI ratio should be 1e12, got {ratio:e}",
     );
 }
 

--- a/crates/e2e/tests/e2e/eip4626.rs
+++ b/crates/e2e/tests/e2e/eip4626.rs
@@ -254,13 +254,14 @@ async fn eip4626_recursive_native_price_test(web3: Web3) {
 }
 
 /// Vault and underlying decimals must be threaded through `conversion_rate`
-/// correctly in both directions. Native prices are atomic-to-atomic, so the
-/// wrapper's price must equal the underlying's scaled by
+/// correctly in both directions. Native prices are quoted per *atom*, so a
+/// wrapper whose whole-share rate is 1:1 with its underlying must still be
+/// priced differently when their decimals differ — by exactly
 /// `10^(asset_decimals - vault_decimals)`. Exercises both asymmetries:
-///   - 18-decimal vault wrapping 6-decimal USDC → ratio = `10^-12` (lands the
-///     vault in DAI's `~10^-4 wei/atomic` range, not USDC's `~10^8
-///     wei/atomic`).
-///   - 6-decimal vault wrapping 18-decimal DAI → ratio = `10^12` (vice versa).
+///   - 18-decimal vault wrapping 6-decimal USDC → per-atom factor = `10^-12`
+///     (lands the vault in DAI's `~10^-4` wei/atom range, not USDC's `~10^8`).
+///   - 6-decimal vault wrapping 18-decimal DAI → per-atom factor = `10^12`
+///     (vice versa).
 #[tokio::test]
 #[ignore]
 async fn forked_node_mainnet_eip4626_decimal_mismatch_native_price() {
@@ -278,29 +279,36 @@ async fn eip4626_decimal_mismatch_native_price_test(web3: Web3) {
 
     let [solver] = onchain.make_solvers_forked(1u64.eth()).await;
 
+    // `MockERC4626Wrapper` implements `convertToAssets(shares) = shares * num
+    // / den`. Setting `num` and `den` to the atom-count of one whole asset
+    // and one whole vault token (respectively) yields a 1:1 *whole-token*
+    // rate — `convertToAssets(one_whole_vault) = one_whole_asset`.
+    let one_whole_6_dec = 1u64.matom(); // 10^6 atoms = 1 whole 6-decimal token
+    let one_whole_18_dec = 1u64.eth(); //  10^18 atoms = 1 whole 18-decimal token
+
     // 18-decimal wrapper of 6-decimal USDC at a 1:1 whole-token rate.
-    // `convertToAssets(10^18) = 10^18 / 10^12 = 10^6` (= 1 whole USDC in
-    // atomic units), so the atomic-to-atomic factor is `10^-12`.
+    // `convertToAssets(10^18) = 10^18 * 10^6 / 10^18 = 10^6` (= 1 whole USDC
+    // in atoms), so the per-atom factor is `10^-12`.
     let wrapper_18_over_6 = contracts::test::MockERC4626Wrapper::Instance::deploy(
         web3.provider.clone(),
         USDC,
         18u8,
-        U256::from(1u64),
-        U256::from(1_000_000_000_000u64),
+        one_whole_6_dec,  // num: atoms in 1 whole asset (USDC)
+        one_whole_18_dec, // den: atoms in 1 whole vault share
     )
     .await
     .unwrap();
     let wrapper_18_over_6_addr = *wrapper_18_over_6.address();
 
     // 6-decimal wrapper of 18-decimal DAI at a 1:1 whole-token rate.
-    // `convertToAssets(10^6) = 10^6 * 10^12 = 10^18` (= 1 whole DAI in atomic
-    // units), so the atomic-to-atomic factor is `10^12`.
+    // `convertToAssets(10^6) = 10^6 * 10^18 / 10^6 = 10^18` (= 1 whole DAI in
+    // atoms), so the per-atom factor is `10^12`.
     let wrapper_6_over_18 = contracts::test::MockERC4626Wrapper::Instance::deploy(
         web3.provider.clone(),
         DAI,
         6u8,
-        U256::from(1_000_000_000_000u64),
-        U256::from(1u64),
+        one_whole_18_dec, // num: atoms in 1 whole asset (DAI)
+        one_whole_6_dec,  // den: atoms in 1 whole vault share
     )
     .await
     .unwrap();
@@ -346,7 +354,7 @@ async fn eip4626_decimal_mismatch_native_price_test(web3: Web3) {
     let usdc_price = fetch_price(&USDC, "USDC").await;
     let dai_price = fetch_price(&DAI, "DAI").await;
 
-    // 18→6: wrapper should be priced like an 18-decimal stablecoin (DAI's
+    // 18→6: wrapper is priced per-atom like an 18-decimal stablecoin (DAI's
     // range), so `wrapper_price / usdc_price ≈ 10^-12`.
     let wrapper_18_over_6_price = fetch_price(&wrapper_18_over_6_addr, "18→6 wrapper").await;
     let ratio = wrapper_18_over_6_price / usdc_price;
@@ -355,7 +363,7 @@ async fn eip4626_decimal_mismatch_native_price_test(web3: Web3) {
         "18→6 wrapper / USDC ratio should be 1e-12, got {ratio:e}",
     );
 
-    // 6→18: wrapper should be priced like a 6-decimal stablecoin (USDC's
+    // 6→18: wrapper is priced per-atom like a 6-decimal stablecoin (USDC's
     // range), so `wrapper_price / dai_price ≈ 10^12`.
     let wrapper_6_over_18_price = fetch_price(&wrapper_6_over_18_addr, "6→18 wrapper").await;
     let ratio = wrapper_6_over_18_price / dai_price;

--- a/crates/price-estimation/src/native/eip4626.rs
+++ b/crates/price-estimation/src/native/eip4626.rs
@@ -15,10 +15,13 @@ use {
 
 /// Estimates the native price of EIP-4626 vault tokens by:
 /// 1. Querying `asset()` and `decimals()` on the vault
-/// 2. Querying `convertToAssets(10^vault_decimals)` and `decimals()` on the
-///    underlying asset
-/// 3. Computing the conversion rate accounting for decimal differences
+/// 2. Querying `convertToAssets(10^vault_decimals)` on the vault to learn how
+///    many atomic underlying units correspond to one whole vault token
+/// 3. Dividing that result by `10^vault_decimals` to obtain the
+///    atomic-to-atomic conversion factor — i.e. `atomic_asset / atomic_vault`
 /// 4. Delegating to an inner estimator for the underlying token's native price
+///    (`wei_native / atomic_asset`) and multiplying by the factor above to
+///    produce the vault's native price (`wei_native / atomic_vault`)
 ///
 /// For non-vault tokens, delegates directly to the inner estimator
 /// (pass-through).
@@ -101,10 +104,8 @@ impl Eip4626 {
             tracing::debug!(%token, "eip4626: classified as non-vault");
             return Ok(None);
         };
-        let (assets, asset_decimals) = self
-            .fetch_conversion_data(token, asset, vault_decimals)
-            .await?;
-        let rate = conversion_rate(assets, asset_decimals)
+        let assets = self.fetch_conversion_data(token, vault_decimals).await?;
+        let rate = conversion_rate(assets, vault_decimals)
             .context("conversion rate is not representable as f64")
             .map_err(PriceEstimationError::EstimatorInternal)?;
         tracing::debug!(%token, %asset, rate, "eip4626: unwrapped vault layer");
@@ -149,14 +150,12 @@ impl Eip4626 {
     }
 
     /// Fetches `convertToAssets(10^vault_decimals)` — how many atomic units of
-    /// the underlying asset correspond to one full vault token — and the
-    /// asset's decimals.
+    /// the underlying asset correspond to one full vault token.
     async fn fetch_conversion_data(
         &self,
         token: Address,
-        asset: Address,
         vault_decimals: u8,
-    ) -> Result<(U256, u8), PriceEstimationError> {
+    ) -> Result<U256, PriceEstimationError> {
         let one_token = U256::from(10u64)
             .checked_pow(U256::from(vault_decimals))
             .ok_or_else(|| {
@@ -166,14 +165,15 @@ impl Eip4626 {
             })?;
 
         let vault = IERC4626::IERC4626::new(token, &self.provider);
-        let asset_erc20 = ERC20::ERC20::new(asset, &self.provider);
-        let convert_call = vault.convertToAssets(one_token);
-        let asset_decimals_call = asset_erc20.decimals();
-        tokio::try_join!(convert_call.call(), asset_decimals_call.call()).map_err(|err| {
-            PriceEstimationError::EstimatorInternal(anyhow::anyhow!(
-                "failed to call convertToAssets()/decimals() on {token}: {err}"
-            ))
-        })
+        vault
+            .convertToAssets(one_token)
+            .call()
+            .await
+            .map_err(|err| {
+                PriceEstimationError::EstimatorInternal(anyhow::anyhow!(
+                    "failed to call convertToAssets() on {token}: {err}"
+                ))
+            })
     }
 }
 
@@ -187,15 +187,21 @@ impl NativePriceEstimating for Eip4626 {
     }
 }
 
-/// Computes the full-asset-tokens per full-vault-token conversion rate.
+/// Computes the atomic-asset-per-atomic-vault conversion factor.
 ///
 /// `assets` is the return value of `convertToAssets(10^vault_decimals)` — i.e.
-/// asset-atomic-units for exactly 1 full vault token. Dividing by
-/// `10^asset_decimals` converts to full asset tokens.
+/// asset-atomic-units for `10^vault_decimals` vault-atomic-units (= 1 full
+/// vault token). Dividing by `10^vault_decimals` yields the per-atomic factor,
+/// which is what we need: native prices are denominated in
+/// `wei_native / atomic_token`, so the vault's native price is the
+/// underlying's native price times this atomic-to-atomic factor. Note this
+/// matches the whole-to-whole share rate iff the vault and asset have the
+/// same decimals — otherwise they differ by `10^(asset_decimals -
+/// vault_decimals)`.
 ///
 /// Returns `None` when the result is not representable as `f64`.
-fn conversion_rate(assets: U256, asset_decimals: u8) -> Option<f64> {
-    let denominator = BigRational::from_integer(BigInt::from(10u64).pow(asset_decimals as u32));
+fn conversion_rate(assets: U256, vault_decimals: u8) -> Option<f64> {
+    let denominator = BigRational::from_integer(BigInt::from(10u64).pow(vault_decimals as u32));
     (u256_to_big_rational(&assets) / denominator).to_f64()
 }
 
@@ -234,7 +240,9 @@ mod tests {
     #[test]
     fn rate_math_same_decimals() {
         // 18-decimal vault wrapping 18-decimal asset, 1 share = 1.5 asset tokens.
-        // convertToAssets(10^18) = 1.5 * 10^18 asset-atomic-units
+        // convertToAssets(10^18) = 1.5 * 10^18 asset-atomic-units. When the
+        // decimals match, the atomic-to-atomic factor equals the whole-to-whole
+        // share rate (1.5).
         let assets = U256::from(15u64) * U256::from(10u64).pow(U256::from(17u64));
         let rate = conversion_rate(assets, 18).unwrap();
         assert!((rate - 1.5).abs() < 1e-9, "rate={rate}");
@@ -243,19 +251,22 @@ mod tests {
     #[test]
     fn rate_math_vault_18_asset_6() {
         // 18-decimal vault wrapping 6-decimal USDC, 1 share = 1.5 USDC.
-        // convertToAssets(10^18) = 1_500_000 asset-atomic-units (1.5 * 10^6)
+        // convertToAssets(10^18) = 1_500_000 asset-atomic-units (1.5 * 10^6).
+        // Atomic-to-atomic factor = 1_500_000 / 10^18 = 1.5e-12 — i.e. the
+        // whole-share rate (1.5) scaled by 10^(asset_decimals - vault_decimals).
         let assets = U256::from(1_500_000u64);
-        let rate = conversion_rate(assets, 6).unwrap();
-        assert!((rate - 1.5).abs() < 1e-9, "rate={rate}");
+        let rate = conversion_rate(assets, 18).unwrap();
+        assert!((rate - 1.5e-12).abs() < 1e-21, "rate={rate}");
     }
 
     #[test]
     fn rate_math_vault_6_asset_18() {
         // 6-decimal vault wrapping 18-decimal asset, 1 share = 2 asset tokens.
-        // convertToAssets(10^6) = 2 * 10^18 asset-atomic-units
+        // convertToAssets(10^6) = 2 * 10^18 asset-atomic-units. Atomic-to-atomic
+        // factor = 2 * 10^18 / 10^6 = 2e12.
         let assets = U256::from(2u64) * U256::from(10u64).pow(U256::from(18u64));
-        let rate = conversion_rate(assets, 18).unwrap();
-        assert!((rate - 2.0).abs() < 1e-9, "rate={rate}");
+        let rate = conversion_rate(assets, 6).unwrap();
+        assert!((rate - 2e12).abs() / 2e12 < 1e-12, "rate={rate}");
     }
 
     /// Tests two (related) things:

--- a/crates/price-estimation/src/native/eip4626.rs
+++ b/crates/price-estimation/src/native/eip4626.rs
@@ -1,3 +1,19 @@
+//! Native price estimation for EIP-4626 vault tokens.
+//!
+//! The protocol's inner native price estimators only know about plain
+//! ERC-20s, so this module wraps one and adds support for vaults: it asks
+//! the vault for its underlying asset and conversion rate, prices the
+//! underlying through the inner estimator, then rescales by the vault's
+//! per-atom factor. Non-vault tokens pass through unchanged. See
+//! [`Eip4626`] for the step-by-step derivation.
+//!
+//! # Terminology
+//! - an *atom* is one U256 of a token — its smallest indivisible unit
+//! - a *whole* token is `10^decimals` atoms (e.g. one whole USDC = `10^6`
+//!   atoms)
+//! - a *native price* is denominated in **wei per atom** of the priced token,
+//!   where wei is one atom of the chain's native asset
+
 use {
     super::{NativePriceEstimateResult, NativePriceEstimating},
     crate::PriceEstimationError,
@@ -13,18 +29,29 @@ use {
     std::time::{Duration, Instant},
 };
 
-/// Estimates the native price of EIP-4626 vault tokens by:
-/// 1. Querying `asset()` and `decimals()` on the vault
-/// 2. Querying `convertToAssets(10^vault_decimals)` on the vault to learn how
-///    many atomic underlying units correspond to one whole vault token
-/// 3. Dividing that result by `10^vault_decimals` to obtain the
-///    atomic-to-atomic conversion factor — i.e. `atomic_asset / atomic_vault`
-/// 4. Delegating to an inner estimator for the underlying token's native price
-///    (`wei_native / atomic_asset`) and multiplying by the factor above to
-///    produce the vault's native price (`wei_native / atomic_vault`)
+/// Estimates the native price of EIP-4626 vault tokens.
 ///
-/// For non-vault tokens, delegates directly to the inner estimator
-/// (pass-through).
+/// To price one atom of a vault we need to know how many atoms of the
+/// underlying that atom is worth, then multiply by the underlying's own
+/// native price. The steps are:
+///
+/// 1. Call `asset()` and `decimals()` on the vault to identify the underlying
+///    asset and the vault's whole-token size.
+/// 2. Call `convertToAssets(10^vault_decimals)` to learn how many *atoms* of
+///    the underlying *one whole* vault token is worth.
+/// 3. Divide that result by `10^vault_decimals` to get the per-atom conversion
+///    factor.
+/// 4. Multiply by the underlying's native price (from the inner estimator) to
+///    obtain the vault's native price.
+///
+/// Worked example — `ynUSDx`, an 18-decimal yield-bearing vault wrapping
+/// USDC (6 decimals). The share price grows as yield accrues, so the rate is
+/// a snapshot at query time; assume here that 1 whole ynUSDx is currently
+/// worth 1.1 whole USDC at the queried block:
+/// - `ynUSDx.asset() == USDC`, `ynUSDx.decimals() == 18`
+/// - `convertToAssets(10^18) == 1_100_000` (= 1.1 whole USDC, in atoms)
+/// - per-atom factor: `1_100_000 / 10^18 == 1.1e-12`
+/// - if USDC's native price is `x`, then ynUSDx's is `x * 1.1e-12`
 ///
 /// Tokens whose `asset()` call reverts are remembered in a negative cache so
 /// subsequent requests skip the RPC and go straight to the inner estimator.
@@ -187,17 +214,13 @@ impl NativePriceEstimating for Eip4626 {
     }
 }
 
-/// Computes the atomic-asset-per-atomic-vault conversion factor.
+/// Converts the result of `convertToAssets(10^vault_decimals)` into the
+/// per-atom factor (atoms of underlying per atom of vault) by dividing by
+/// `10^vault_decimals`. See the module docstring for the full derivation.
 ///
-/// `assets` is the return value of `convertToAssets(10^vault_decimals)` — i.e.
-/// asset-atomic-units for `10^vault_decimals` vault-atomic-units (= 1 full
-/// vault token). Dividing by `10^vault_decimals` yields the per-atomic factor,
-/// which is what we need: native prices are denominated in
-/// `wei_native / atomic_token`, so the vault's native price is the
-/// underlying's native price times this atomic-to-atomic factor. Note this
-/// matches the whole-to-whole share rate iff the vault and asset have the
-/// same decimals — otherwise they differ by `10^(asset_decimals -
-/// vault_decimals)`.
+/// This differs from the intuitive whole-to-whole share rate by
+/// `10^(asset_decimals - vault_decimals)` — they only coincide when vault
+/// and asset decimals match.
 ///
 /// Returns `None` when the result is not representable as `f64`.
 fn conversion_rate(assets: U256, vault_decimals: u8) -> Option<f64> {
@@ -237,36 +260,58 @@ mod tests {
         std::borrow::Cow,
     };
 
+    const TOLERANCE: f64 = 1e-9;
+
+    /// Asserts `computed_rate` is within a `tolerance` of `expected_rate`.
+    fn assert_rate_close(computed_rate: f64, expected_rate: f64, tolerance: f64) {
+        let slack = expected_rate.abs() * tolerance;
+        let expected_range = (expected_rate - slack)..(expected_rate + slack);
+        assert!(
+            expected_range.contains(&computed_rate),
+            "computed_rate={computed_rate}, expected_rate={expected_rate}, tolerance={tolerance}",
+        );
+    }
+
     #[test]
     fn rate_math_same_decimals() {
-        // 18-decimal vault wrapping 18-decimal asset, 1 share = 1.5 asset tokens.
-        // convertToAssets(10^18) = 1.5 * 10^18 asset-atomic-units. When the
-        // decimals match, the atomic-to-atomic factor equals the whole-to-whole
-        // share rate (1.5).
+        // 18-decimal vault wrapping 18-decimal asset:
+        // 1 whole share = 1.5 whole asset tokens.
+        // - vault.decimals() = 18, asset.decimals() = 18
+        // - convertToAssets(10^18) = 1.5 * 10^18 (in asset atoms)
+        // - per-atom factor = 1.5 * 10^18 / 10^18 = 1.5
+        // - matches the whole-to-whole rate exactly when decimals align.
         let assets = U256::from(15u64) * U256::from(10u64).pow(U256::from(17u64));
-        let rate = conversion_rate(assets, 18).unwrap();
-        assert!((rate - 1.5).abs() < 1e-9, "rate={rate}");
+        let computed_rate = conversion_rate(assets, 18).unwrap();
+
+        assert_rate_close(computed_rate, 1.5, TOLERANCE);
     }
 
     #[test]
     fn rate_math_vault_18_asset_6() {
-        // 18-decimal vault wrapping 6-decimal USDC, 1 share = 1.5 USDC.
-        // convertToAssets(10^18) = 1_500_000 asset-atomic-units (1.5 * 10^6).
-        // Atomic-to-atomic factor = 1_500_000 / 10^18 = 1.5e-12 — i.e. the
-        // whole-share rate (1.5) scaled by 10^(asset_decimals - vault_decimals).
+        // 18-decimal vault wrapping 6-decimal USDC:
+        // 1 whole share = 1.5 whole USDC.
+        // - vault.decimals() = 18, asset.decimals() = 6
+        // - convertToAssets(10^18) = 1_500_000 (= 1.5 whole USDC, in atoms)
+        // - per-atom factor = 1_500_000 / 10^18 = 1.5e-12
+        // - = whole-share rate (1.5) scaled by 10^(asset_dec - vault_dec) = 10^-12.
         let assets = U256::from(1_500_000u64);
-        let rate = conversion_rate(assets, 18).unwrap();
-        assert!((rate - 1.5e-12).abs() < 1e-21, "rate={rate}");
+        let computed_rate = conversion_rate(assets, 18).unwrap();
+
+        assert_rate_close(computed_rate, 1.5e-12, TOLERANCE);
     }
 
     #[test]
     fn rate_math_vault_6_asset_18() {
-        // 6-decimal vault wrapping 18-decimal asset, 1 share = 2 asset tokens.
-        // convertToAssets(10^6) = 2 * 10^18 asset-atomic-units. Atomic-to-atomic
-        // factor = 2 * 10^18 / 10^6 = 2e12.
+        // 6-decimal vault wrapping 18-decimal asset:
+        // 1 whole share = 2 whole asset tokens.
+        // - vault.decimals() = 6, asset.decimals() = 18
+        // - convertToAssets(10^6) = 2 * 10^18 (= 2 whole tokens, in atoms)
+        // - per-atom factor = 2 * 10^18 / 10^6 = 2e12
+        // - = whole-share rate (2) scaled by 10^(asset_dec - vault_dec) = 10^12.
         let assets = U256::from(2u64) * U256::from(10u64).pow(U256::from(18u64));
-        let rate = conversion_rate(assets, 6).unwrap();
-        assert!((rate - 2e12).abs() / 2e12 < 1e-12, "rate={rate}");
+        let computed_rate = conversion_rate(assets, 6).unwrap();
+
+        assert_rate_close(computed_rate, 2e12, TOLERANCE);
     }
 
     /// Tests two (related) things:


### PR DESCRIPTION
# Description
Fixes the rate calculation issue found by Haris and Felix; described in https://nomevlabs.slack.com/archives/C0375NV72SC/p1779181463853999

# Changes

* Use the vault decimals not asset for scale
	* For example, if the vault has 18 decimals and an underlying asset with 6 decimals: 
	* we call convertToAsset(10^18), expecting to receive a value in the order of ~10^6 (as in; N * 10^6; where N is somewhere between 0 and 1)
	* by later dividing back with 10^18, we get the actual conversion rate of X * 10^-12
* Add E2E covering wrapper 18 -> 6 and 6 -> 18 decimals


## How to test
E2E tests + staging

#### ynUSDx (fixed):

**Before**
<img width="907" height="122" alt="Screenshot 2026-05-19 at 14 56 32" src="https://github.com/user-attachments/assets/db402c15-5508-4601-bd9a-f3981ecfe468" />

**After**
<img width="969" height="121" alt="Screenshot 2026-05-19 at 14 41 41" src="https://github.com/user-attachments/assets/dcee0682-d6b4-47f2-935a-d743371c13c1" />


#### USDC (stays the same):

**Before**
<img width="917" height="115" alt="Screenshot 2026-05-19 at 14 55 34" src="https://github.com/user-attachments/assets/e0eee535-a48c-4fda-87ed-0e184f2d1c19" />

**After**
<img width="961" height="115" alt="Screenshot 2026-05-19 at 14 45 13" src="https://github.com/user-attachments/assets/a6632ed0-ad3d-4d53-801c-a5a54fb4d8ff" />
