### PR TITLE
Remove deprecated Goerli chain

### DIFF
--- a/crates/chain/src/lib.rs
+++ b/crates/chain/src/lib.rs
@@ -9,7 +9,6 @@ use {
 #[repr(u64)]
 pub enum Chain {
     Mainnet = 1,
-    Goerli = 5,
     Gnosis = 100,
     Sepolia = 11155111,
     ArbitrumOne = 42161,
@@ -36,7 +35,6 @@ impl Chain {
         // https://chainid.network/chains.json
         match &self {
             Self::Mainnet => "Ethereum / Mainnet",
-            Self::Goerli => "Ethereum / Goerli",
             Self::Gnosis => "xDAI",
             Self::Sepolia => "Ethereum / Sepolia",
             Self::ArbitrumOne => "Arbitrum One",
@@ -56,7 +54,6 @@ impl Chain {
     pub fn default_amount_to_estimate_native_prices_with(&self) -> U256 {
         match &self {
             Self::Mainnet
-            | Self::Goerli
             | Self::Sepolia
             | Self::ArbitrumOne
             | Self::Base
@@ -76,7 +73,6 @@ impl Chain {
     pub fn block_time_in_ms(&self) -> Duration {
         match self {
             Self::Mainnet => Duration::from_millis(12_000),
-            Self::Goerli => Duration::from_millis(12_000),
             Self::Gnosis => Duration::from_millis(5_000),
             Self::Sepolia => Duration::from_millis(12_000),
             Self::ArbitrumOne => Duration::from_millis(250),
@@ -107,7 +103,6 @@ impl TryFrom<u64> for Chain {
     fn try_from(value: u64) -> Result<Self, Self::Error> {
         let network = match value {
             x if x == Self::Mainnet as u64 => Self::Mainnet,
-            x if x == Self::Goerli as u64 => Self::Goerli,
             x if x == Self::Gnosis as u64 => Self::Gnosis,
             x if x == Self::Sepolia as u64 => Self::Sepolia,
             x if x == Self::ArbitrumOne as u64 => Self::ArbitrumOne,
@@ -193,7 +188,6 @@ mod test {
 
         assert_eq!(Chain::Mainnet.blocks_in(TARGET_AGE).round(), 1800.0);
         assert_eq!(Chain::Sepolia.blocks_in(TARGET_AGE).round(), 1800.0);
-        assert_eq!(Chain::Goerli.blocks_in(TARGET_AGE).round(), 1800.0);
         assert_eq!(Chain::Gnosis.blocks_in(TARGET_AGE).round(), 4320.0);
         assert_eq!(Chain::Base.blocks_in(TARGET_AGE).round(), 10800.0);
         assert_eq!(Chain::ArbitrumOne.blocks_in(TARGET_AGE).round(), 86400.0);
@@ -205,10 +199,6 @@ mod test {
         let json_data = "1"; // Should deserialize to Network::Mainnet
         let network: Chain = serde_json::from_str(json_data).unwrap();
         assert_eq!(network, Chain::Mainnet);
-
-        let json_data = "5"; // Should deserialize to Network::Goerli
-        let network: Chain = serde_json::from_str(json_data).unwrap();
-        assert_eq!(network, Chain::Goerli);
 
         let json_data = "100"; // Should deserialize to Network::Gnosis
         let network: Chain = serde_json::from_str(json_data).unwrap();
@@ -226,10 +216,6 @@ mod test {
         let json_data = "\"1\""; // Should parse to u64 1 and then to Network::Mainnet
         let network: Chain = serde_json::from_str(json_data).unwrap();
         assert_eq!(network, Chain::Mainnet);
-
-        let json_data = "\"5\""; // Should parse to u64 5 and then to Network::Goerli
-        let network: Chain = serde_json::from_str(json_data).unwrap();
-        assert_eq!(network, Chain::Goerli);
 
         let json_data = "\"100\""; // Should parse to u64 100 and then to Network::Gnosis
         let network: Chain = serde_json::from_str(json_data).unwrap();

--- a/crates/liquidity-sources/src/lib.rs
+++ b/crates/liquidity-sources/src/lib.rs
@@ -39,11 +39,6 @@ pub fn defaults_for_network(chain: &Chain) -> Vec<BaselineSource> {
             BaselineSource::ZeroEx,
             BaselineSource::UniswapV3,
         ],
-        Chain::Goerli => vec![
-            BaselineSource::UniswapV2,
-            BaselineSource::SushiSwap,
-            BaselineSource::BalancerV2,
-        ],
         Chain::Gnosis => vec![
             BaselineSource::Honeyswap,
             BaselineSource::SushiSwap,

--- a/crates/price-estimation/src/native/coingecko.rs
+++ b/crates/price-estimation/src/native/coingecko.rs
@@ -81,7 +81,7 @@ impl CoinGecko {
             Chain::Linea => "linea".to_string(),
             Chain::Plasma => "plasma".to_string(),
             Chain::Ink => "ink".to_string(),
-            Chain::Sepolia | Chain::Goerli | Chain::Hardhat => {
+            Chain::Sepolia | Chain::Hardhat => {
                 anyhow::bail!("unsupported network {}", chain.name())
             }
         };

--- a/crates/solvers/src/domain/eth/chain.rs
+++ b/crates/solvers/src/domain/eth/chain.rs
@@ -4,7 +4,6 @@ use {serde::Deserialize, std::str::FromStr};
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum ChainId {
     Mainnet = 1,
-    Goerli = 5,
     Gnosis = 100,
     Base = 8453,
     ArbitrumOne = 42161,
@@ -21,7 +20,6 @@ impl ChainId {
     pub fn new(value: u64) -> Result<Self, UnsupportedChain> {
         match value {
             1 => Ok(Self::Mainnet),
-            5 => Ok(Self::Goerli),
             100 => Ok(Self::Gnosis),
             8453 => Ok(Self::Base),
             42161 => Ok(Self::ArbitrumOne),
@@ -40,7 +38,6 @@ impl ChainId {
     pub fn network_id(self) -> &'static str {
         match self {
             ChainId::Mainnet => "1",
-            ChainId::Goerli => "5",
             ChainId::Gnosis => "100",
             ChainId::Base => "8453",
             ChainId::ArbitrumOne => "42161",
@@ -104,10 +101,6 @@ mod tests {
             ChainId::Mainnet
         );
         assert_eq!(
-            serde_json::from_value::<ChainId>(5.into()).unwrap(),
-            ChainId::Goerli
-        );
-        assert_eq!(
             serde_json::from_value::<ChainId>(100.into()).unwrap(),
             ChainId::Gnosis
         );
@@ -150,10 +143,6 @@ mod tests {
         assert_eq!(
             serde_json::from_str::<ChainId>("1").unwrap(),
             ChainId::Mainnet
-        );
-        assert_eq!(
-            serde_json::from_str::<ChainId>("5").unwrap(),
-            ChainId::Goerli
         );
         assert_eq!(
             serde_json::from_str::<ChainId>("100").unwrap(),

--- a/playground/Dockerfile.cowswap
+++ b/playground/Dockerfile.cowswap
@@ -8,7 +8,6 @@ RUN corepack enable \
 
 # RPC URL args
 ARG REACT_APP_NETWORK_URL_1=https://rpc.mevblocker.io
-ARG REACT_APP_NETWORK_URL_5=https://ethereum-goerli.publicnode.com
 ARG REACT_APP_NETWORK_URL_100=https://gnosis.publicnode.com
 ARG REACT_APP_EXPLORER_URL_DEV=http://localhost:8001
 
@@ -16,7 +15,7 @@ ARG REACT_APP_EXPLORER_URL_DEV=http://localhost:8001
 ARG REACT_APP_BLOCK_EXPLORER_URL=http://localhost:8003
 
 # Orderbook URL args
-ARG REACT_APP_ORDER_BOOK_URLS='{"1":"https://api.cow.fi/mainnet","100":"https://api.cow.fi/goerli","5":"https://api.cow.fi/xdai"}'
+ARG REACT_APP_ORDER_BOOK_URLS='{"1":"https://api.cow.fi/mainnet","100":"https://api.cow.fi/xdai"}'
 
 # Install system dependencies
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked apt-get update && \
@@ -38,7 +37,6 @@ ENV ETH_RPC_URL="$ETH_RPC_URL"
 
 # Set default environment variables for network and order book URLs
 ENV REACT_APP_NETWORK_URL_1="$REACT_APP_NETWORK_URL_1"
-ENV REACT_APP_NETWORK_URL_5="$REACT_APP_NETWORK_URL_5"
 ENV REACT_APP_NETWORK_URL_100="$REACT_APP_NETWORK_URL_100"
 ENV REACT_APP_ORDER_BOOK_URLS="$REACT_APP_ORDER_BOOK_URLS"
 ENV REACT_APP_EXPLORER_URL_DEV="$REACT_APP_EXPLORER_URL_DEV"
@@ -52,20 +50,15 @@ RUN set -e; \
                 REACT_APP_NETWORK_URL_1="$ETH_RPC_URL"; \
                 REACT_APP_ORDER_BOOK_URLS=$(echo "$REACT_APP_ORDER_BOOK_URLS" | jq --arg chain "1" '.[$chain]="http://127.0.0.1:8080"'); \
                 ;; \
-            5) \
-                REACT_APP_NETWORK_URL_5="$ETH_RPC_URL"; \
-                REACT_APP_ORDER_BOOK_URLS=$(echo "$REACT_APP_ORDER_BOOK_URLS" | jq --arg chain "5" '.[$chain]="http://127.0.0.1:8080"'); \
-                ;; \
             100) \
                 REACT_APP_NETWORK_URL_100="$ETH_RPC_URL"; \
                 REACT_APP_ORDER_BOOK_URLS=$(echo "$REACT_APP_ORDER_BOOK_URLS" | jq --arg chain "100" '.[$chain]="http://127.0.0.1:8080"'); \
                 ;; \
         esac; \
     fi; \
-    export REACT_APP_NETWORK_URL_1 REACT_APP_NETWORK_URL_5 REACT_APP_NETWORK_URL_100 REACT_APP_ORDER_BOOK_URLS REACT_APP_EXPLORER_URL_DEV REACT_APP_BLOCK_EXPLORER_URL; \
+    export REACT_APP_NETWORK_URL_1 REACT_APP_NETWORK_URL_100 REACT_APP_ORDER_BOOK_URLS REACT_APP_EXPLORER_URL_DEV REACT_APP_BLOCK_EXPLORER_URL; \
     NODE_OPTIONS="--max-old-space-size=4096" NX_NO_CLOUD=true pnpm run build \
         --env REACT_APP_NETWORK_URL_1="$REACT_APP_NETWORK_URL_1" \
-        --env REACT_APP_NETWORK_URL_5="$REACT_APP_NETWORK_URL_5" \
         --env REACT_APP_NETWORK_URL_100="$REACT_APP_NETWORK_URL_100" \
         --env REACT_APP_ORDER_BOOK_URLS="$REACT_APP_ORDER_BOOK_URLS" \
         --env REACT_APP_EXPLORER_URL_DEV="$REACT_APP_EXPLORER_URL_DEV" \


### PR DESCRIPTION
Goerli is no longer up. Removes the variant and all match arms across the chain, solvers, liquidity-sources, and price-estimation crates. Extracted from #4422 for independent review.

Original comment: https://github.com/cowprotocol/services/pull/4422#discussion_r3258103970