### PR TITLE
Fix review action

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -4,13 +4,22 @@ on:
     types: [opened, ready_for_review]
   issue_comment:
     types: [created]
+  # Manual trigger so workflow changes can be exercised from a feature branch
+  # without merging. Pick the feature branch in the Actions UI and pass the
+  # PR number to review.
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: "PR number to review"
+        required: true
+        type: string
 
 # Cancel an in-flight review if another trigger fires on the same PR (e.g.
 # back-to-back `@claude` comments, or a draft→ready transition while an
 # earlier run is still going). Note: `synchronize` is not in the trigger
 # list, so plain pushes do not trigger or cancel anything.
 concurrency:
-  group: claude-review-${{ github.event.pull_request.number || github.event.issue.number }}
+  group: claude-review-${{ github.event.pull_request.number || github.event.issue.number || inputs.pr_number }}
   cancel-in-progress: true
 
 jobs:
@@ -34,7 +43,7 @@ jobs:
         github.event.issue.pull_request != null &&
         contains(github.event.comment.body, '@claude') &&
         contains(fromJSON('["OWNER", "MEMBER"]'), github.event.comment.author_association)
-      )
+      ) || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:
@@ -58,4 +67,5 @@ jobs:
           claude_args: |
             --model claude-opus-4-7
             --max-turns 30
-          prompt: "Review this PR. Use the pr-review skill if available."
+          prompt: |
+            ${{ github.event_name == 'workflow_dispatch' && format('Review PR #{0}. ', inputs.pr_number) || 'Review this PR.' }} Use the pr-review skill if available.

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -21,7 +21,7 @@ jobs:
     # Also skip bot authors and PRs explicitly labelled `skip-claude-review`,
     # so authors have an escape hatch for trivial changes.
     # External contributors are excluded from both triggers by requiring an
-    # internal `author_association` (OWNER/MEMBER/COLLABORATOR).
+    # internal `author_association` (OWNER/MEMBER).
     if: >
       (
         github.event_name == 'pull_request' &&

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -54,7 +54,8 @@ jobs:
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           trigger_phrase: "@claude"
+          track_progress: true
           claude_args: |
             --model claude-opus-4-7
-            --max-turns 10
-          prompt: "Review this PR"
+            --max-turns 30
+          prompt: "Review this PR. Use the pr-review skill if available."


### PR DESCRIPTION
# Description
The current action is frequently running out of turns (costs are very reasonable) and doesn't seem to comment.

# Changes
* Increase max turns
* Tell it track progress (which should make it comment)
* Slightly adjust the prompt so we can later on add a review skill according to our needs (I'd like for this action be generic enough so that it can be used in other repos)
* Make the action testable on a feature branch by adding a `dispatch_workflow` trigger (can be removed once stable)

## How to test

I cannot run the modified action before merging it (will be better once it can be triggered via dispatch)