### PR TITLE
[Trivial] Fix linter on main

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -25,6 +25,8 @@ jobs:
         with:
           just-version: 1.39.0
       - uses: tombi-toml/setup-tombi@cebfd308ba02edadfcee148b7473536990950c92 # v1.0.8
+        with:
+          version: "0.11.5"
       - run: |
           rustup --version
           rustup show
@@ -316,6 +318,8 @@ jobs:
         with:
           just-version: 1.39.0
       - uses: tombi-toml/setup-tombi@cebfd308ba02edadfcee148b7473536990950c92 # v1.0.8
+        with:
+          version: "0.11.5"
       - name: Verify the code hasn't been tampered with by generating contracts again and making sure there has been no changes
         run: |
           just generate-contracts


### PR DESCRIPTION
# Description
tombi v0.11.6 (released 2026-05-21 16:45 UTC) shipped a breaking change that defaults Cargo.toml to TOML v1.1.0. This is breaking our CI.

# Changes
* Pin plugin to last working version

## How to test
CI

## Alternatives considered
Reformat using newest version, however we should probably not have our build being broken by new releases of a dependency so pinning seemed more correct imo.