### PR TITLE
Bounds check `Solver::swap` return in trade verifier

### DIFF
--- a/crates/price-estimation/src/trade_verifier.rs
+++ b/crates/price-estimation/src/trade_verifier.rs
@@ -644,6 +644,15 @@ impl SettleOutput {
     ) -> Result<Self> {
         // The balances are stored in the following order:
         // [...tokens_before, user_balance_before, user_balance_after, ...tokens_after]
+        let expected_len = tokens_vec.len() * 2 + 2;
+        anyhow::ensure!(
+            queriedBalances.len() == expected_len,
+            "Solver returned {} balances, expected {} (tokens={})",
+            queriedBalances.len(),
+            expected_len,
+            tokens_vec.len(),
+        );
+
         let mut i = 0;
         let mut tokens_lost = HashMap::new();
         // Get settlement contract balances before the trade
@@ -980,5 +989,39 @@ mod tests {
         let estimate =
             ensure_quote_accuracy(&low_threshold, &query, &Default::default(), &pay_out_less);
         assert!(estimate.is_ok());
+    }
+
+    /// Regression test: when the on-chain `Solver` helper returns fewer
+    /// balance entries than expected (observed for wrapper-bearing orders
+    /// that revert inside the helper), `from_swap` must return an error
+    /// instead of panicking with `index out of bounds`.
+    #[test]
+    fn from_swap_returns_error_on_short_balances() {
+        let tokens_vec = vec![Address::repeat_byte(1), Address::repeat_byte(2)];
+        // Expected length is `2 * tokens.len() + 2 = 6`. We feed 4, which is
+        // what the verifier observed in production for a wrapper order.
+        let swap_return = Solver::Solver::swapReturn {
+            gasUsed: U256::ZERO,
+            queriedBalances: vec![U256::ZERO; 4],
+        };
+        let err = SettleOutput::from_swap(swap_return, OrderKind::Sell, &tokens_vec)
+            .expect_err("from_swap must surface a short response as an error rather than panic");
+        let msg = err.to_string();
+        assert!(msg.contains("4"), "error must mention actual length: {msg}");
+        assert!(
+            msg.contains("6"),
+            "error must mention expected length: {msg}"
+        );
+    }
+
+    #[test]
+    fn from_swap_accepts_expected_length() {
+        let tokens_vec = vec![Address::repeat_byte(1), Address::repeat_byte(2)];
+        let swap_return = Solver::Solver::swapReturn {
+            gasUsed: U256::ZERO,
+            queriedBalances: vec![U256::ZERO; 6],
+        };
+        SettleOutput::from_swap(swap_return, OrderKind::Sell, &tokens_vec)
+            .expect("well-formed response must parse");
     }
 }


### PR DESCRIPTION
# Description
`TradeVerifier::SettleOutput::from_swap` indexes the `queriedBalances` array returned from the on-chain `Solver` helper without checking its length. The function expects `2 * tokens.len() + 2` entries laid out as `[...tokens_before, user_before, user_after, ...tokens_after]`. When the helper returns fewer entries the indexing panics with `index out of bounds: the len is 4 but the index is 4`, killing the orderbook tokio worker.

The panic was observed on barn while submitting a wrapper-bearing order: `POST /api/v1/orders` re-runs the quoter via `get_quote_and_check_fee`, the verified estimator drives `TradeVerifier::verify_inner` and crashes inside `from_swap`. The container restart loop surfaces as 502s and looks like OOM in metrics.

A separate investigation is needed for **why** the helper returns a short response for wrapper-bearing orders (Bug B). This PR addresses only the panic so the verifier fails soft.

# Changes
- Validate `queriedBalances.len()` against the expected `2 * tokens.len() + 2` at the top of `SettleOutput::from_swap` and return a descriptive `anyhow` error if the shape is unexpected. Callers up the stack already surface this as `Error::SimulationFailed` (unverified quote) instead of panicking.

# How to test
New unit tests cover both the error path (short response) and the happy path.