### PR TITLE
Log Tenderly request payload and instrument shadow simulator span

### DIFF
--- a/crates/shared/src/order_creation_simulation.rs
+++ b/crates/shared/src/order_creation_simulation.rs
@@ -60,7 +60,7 @@ impl OrderCreationSimulator {
 
 #[async_trait]
 impl OrderSimulating for OrderCreationSimulator {
-    #[tracing::instrument(skip_all)]
+    #[tracing::instrument(skip_all, fields(order_uid = %order.metadata.uid))]
     async fn simulate(
         &self,
         order: &Order,

--- a/crates/shared/src/order_creation_simulation.rs
+++ b/crates/shared/src/order_creation_simulation.rs
@@ -2,13 +2,16 @@ use {
     anyhow::anyhow,
     async_trait::async_trait,
     model::order::Order,
-    simulator::simulation_builder::{
-        self,
-        Block,
-        ExecutionAmount,
-        PriceEncoding,
-        SettlementSimulator,
-        Solver,
+    simulator::{
+        simulation_builder::{
+            self,
+            Block,
+            ExecutionAmount,
+            PriceEncoding,
+            SettlementSimulator,
+            Solver,
+        },
+        tenderly,
     },
 };
 
@@ -17,9 +20,15 @@ use {
 pub enum OrderSimulationError {
     /// The simulation ran and the transaction reverted. `reason` is the
     /// revert string returned by the EVM (or a Tenderly reason string).
+    /// `tenderly_request` carries the full payload (calldata, state
+    /// overrides, block) needed to replay the simulation manually or against
+    /// Tenderly's API, independent of whether `tenderly_url` was produced.
+    /// Boxed because the request DTO is large enough that an inline copy
+    /// would blow up `Result<(), OrderSimulationError>`'s stack footprint.
     Reverted {
         reason: String,
         tenderly_url: Option<String>,
+        tenderly_request: Option<Box<tenderly::dto::Request>>,
     },
     /// The simulation could not run (RPC failure, Tenderly error, malformed
     /// input, timeout). Treated as fail-open.
@@ -51,6 +60,7 @@ impl OrderCreationSimulator {
 
 #[async_trait]
 impl OrderSimulating for OrderCreationSimulator {
+    #[tracing::instrument(skip_all)]
     async fn simulate(
         &self,
         order: &Order,
@@ -84,13 +94,14 @@ impl OrderSimulating for OrderCreationSimulator {
         let Err(err) = inputs.simulate().await else {
             return Ok(());
         };
-        let tenderly_url = match (tenderly, tenderly_request) {
-            (Some(api), Some(req)) => api.simulate_and_share(req).await.ok(),
+        let tenderly_url = match (tenderly, tenderly_request.as_ref()) {
+            (Some(api), Some(req)) => api.simulate_and_share(req.clone()).await.ok(),
             _ => None,
         };
         Err(OrderSimulationError::Reverted {
             reason: err.to_string(),
             tenderly_url,
+            tenderly_request: tenderly_request.map(Box::new),
         })
     }
 }

--- a/crates/shared/src/order_validation.rs
+++ b/crates/shared/src/order_validation.rs
@@ -84,6 +84,7 @@ fn log_simulation_outcome(
             Err(OrderSimulationError::Reverted {
                 reason,
                 tenderly_url,
+                tenderly_request,
             }),
         ) => tracing::warn!(
             ?order_uid,
@@ -93,6 +94,7 @@ fn log_simulation_outcome(
             ?order_signature,
             ?reason,
             ?tenderly_url,
+            ?tenderly_request,
             "order simulation disagreement: signature passed, simulation reverted",
         ),
         (Err(SignatureValidationError::Invalid), Ok(())) => tracing::warn!(
@@ -2916,6 +2918,7 @@ mod tests {
                     Sim::Reverted => Err(OrderSimulationError::Reverted {
                         reason: "hook reverted".into(),
                         tenderly_url: None,
+                        tenderly_request: None,
                     }),
                 });
             let validator =
@@ -2973,6 +2976,7 @@ mod tests {
             Err(OrderSimulationError::Reverted {
                 reason: "x".into(),
                 tenderly_url: None,
+                tenderly_request: None,
             })
         });
         let validator = build_1271_validator(signature_validator, Some(order_simulator(sim)), true);

--- a/crates/shared/src/order_validation.rs
+++ b/crates/shared/src/order_validation.rs
@@ -87,12 +87,6 @@ fn log_simulation_outcome(
                 tenderly_request,
             }),
         ) => {
-            // `Debug` would print the calldata `Vec<u8>` as decimal bytes and
-            // the state-override map as a verbose struct dump. The request
-            // already derives `Serialize` with hex-encoded calldata, so a
-            // single JSON serialization gives a compact, replayable payload.
-            // Empty string indicates "no request available" (e.g. when the
-            // simulation builder failed to produce one before the revert).
             let tenderly_request_json = tenderly_request
                 .as_deref()
                 .and_then(|r| serde_json::to_string(r).ok())

--- a/crates/shared/src/order_validation.rs
+++ b/crates/shared/src/order_validation.rs
@@ -86,17 +86,29 @@ fn log_simulation_outcome(
                 tenderly_url,
                 tenderly_request,
             }),
-        ) => tracing::warn!(
-            ?order_uid,
-            ?owner,
-            ?order_data,
-            full_app_data,
-            ?order_signature,
-            ?reason,
-            ?tenderly_url,
-            ?tenderly_request,
-            "order simulation disagreement: signature passed, simulation reverted",
-        ),
+        ) => {
+            // `Debug` would print the calldata `Vec<u8>` as decimal bytes and
+            // the state-override map as a verbose struct dump. The request
+            // already derives `Serialize` with hex-encoded calldata, so a
+            // single JSON serialization gives a compact, replayable payload.
+            // Empty string indicates "no request available" (e.g. when the
+            // simulation builder failed to produce one before the revert).
+            let tenderly_request_json = tenderly_request
+                .as_deref()
+                .and_then(|r| serde_json::to_string(r).ok())
+                .unwrap_or_default();
+            tracing::warn!(
+                ?order_uid,
+                ?owner,
+                ?order_data,
+                full_app_data,
+                ?order_signature,
+                ?reason,
+                ?tenderly_url,
+                tenderly_request = %tenderly_request_json,
+                "order simulation disagreement: signature passed, simulation reverted",
+            );
+        }
         (Err(SignatureValidationError::Invalid), Ok(())) => tracing::warn!(
             ?order_uid,
             ?owner,


### PR DESCRIPTION
# Description
When a shadow-mode order simulation reverts, today's `order simulation disagreement` warn carries only a `tenderly_url` field. The URL is `None` whenever Tenderly is not configured for the env or the share call fails, leaving the operator with no concrete replay payload. The same warn also doesn't surface the simulator's own wallclock cost, so triaging `POST /api/v1/orders` latency on barn/prod requires inferring the simulator duration from sibling spans.

This PR adds the replay payload and a dedicated span. Tenderly stays revert-only and best-effort, the new behaviour does not change the simulator's outcome or hot path.

# Changes
- `OrderSimulationError::Reverted` now carries `tenderly_request: Option<Box<tenderly::dto::Request>>`, populated from `inputs.to_tenderly_request()` regardless of whether the Tenderly share call returned a URL. Boxed to keep `Result<(), OrderSimulationError>` small enough to satisfy `result_large_err`.
- `log_simulation_outcome` emits the new field on the disagreement warn alongside `tenderly_url`, so every revert log contains the full eth_call inputs (calldata, state overrides, block number).
- `OrderCreationSimulator::simulate` is annotated with `#[tracing::instrument(skip_all)]`. The new `simulate` span shows up under `validate_and_construct_order` in Tempo with the simulator's wallclock duration.

# How to test
Updated unit tests.