### PR TITLE
Run cheap rejection checks before shadow simulation

### DIFF
--- a/crates/shared/src/order_validation.rs
+++ b/crates/shared/src/order_validation.rs
@@ -822,6 +822,10 @@ impl OrderValidating for OrderValidator {
         };
         let uid = data.uid(domain_separator, owner);
 
+        // Cheap in-memory rejection checks run before the eth_call-driven
+        // verification step below so banned users, forbidden tokens, and
+        // zero-amount orders fail fast without consuming a simulation-node
+        // round-trip.
         if data.buy_amount.is_zero() || data.sell_amount.is_zero() {
             return Err(ValidationError::ZeroAmount);
         }

--- a/crates/shared/src/order_validation.rs
+++ b/crates/shared/src/order_validation.rs
@@ -822,6 +822,16 @@ impl OrderValidating for OrderValidator {
         };
         let uid = data.uid(domain_separator, owner);
 
+        if data.buy_amount.is_zero() || data.sell_amount.is_zero() {
+            return Err(ValidationError::ZeroAmount);
+        }
+
+        let pre_order = PreOrderData::from_order_creation(owner, &data, signing_scheme);
+        let class = pre_order.class;
+        self.partial_validate(pre_order)
+            .await
+            .map_err(ValidationError::Partial)?;
+
         let verification_gas_limit = self
             .calculate_verification_gas_limit(
                 &order,
@@ -832,16 +842,6 @@ impl OrderValidating for OrderValidator {
                 uid,
             )
             .await?;
-
-        if data.buy_amount.is_zero() || data.sell_amount.is_zero() {
-            return Err(ValidationError::ZeroAmount);
-        }
-
-        let pre_order = PreOrderData::from_order_creation(owner, &data, signing_scheme);
-        let class = pre_order.class;
-        self.partial_validate(pre_order)
-            .await
-            .map_err(ValidationError::Partial)?;
 
         let verification = Verification {
             from: owner,


### PR DESCRIPTION
# Description
`validate_and_construct_order` invokes `calculate_verification_gas_limit` first, which fires the EIP-1271 signature eth_call and the shadow-sim eth_call. Only afterwards does it run `partial_validate` (banned users, validTo bounds, token allow/deny rules) and the zero-amount check. Orders rejected by those cheap in-memory rules still pay for at least one simulation-node eth_call before failing.

Reordering moves the cheap checks ahead so those orders fail fast without touching the RPC.

# Changes
- Moved the `ZeroAmount` check, `PreOrderData` construction, and `partial_validate` call above `calculate_verification_gas_limit` in `validate_and_construct_order`. Behavior for accepted orders is unchanged. Rejected orders matching cheap-validation rules now skip the simulator eth_call entirely.

# How to test
Existing unit tests.