### PR TITLE
fix: validate every wrapper has code before simulating

### DIFF
--- a/crates/simulator/src/encoding.rs
+++ b/crates/simulator/src/encoding.rs
@@ -342,19 +342,22 @@ pub fn encode_wrapper_data(wrappers: &[WrapperCall]) -> Bytes {
     wrapper_data.into()
 }
 
-/// Ensures every wrapper address in the chain has code deployed on-chain.
-/// A `call` to a code-less address returns success with empty output, so the
-/// inner settlement (and the `storeBalance` interactions that record trader
-/// balances) would silently no-op. The trade verifier expects a fixed-shape
-/// response and reads garbage when the helper short-circuits this way.
+/// Ensures every wrapper address in the chain has code deployed at the
+/// simulation block. A `call` to a code-less address returns success with
+/// empty output, so the inner settlement (and the `storeBalance` interactions
+/// that record trader balances) would silently no-op. The trade verifier
+/// expects a fixed-shape response and reads garbage when the helper
+/// short-circuits this way.
 async fn ensure_wrappers_have_code(
     provider: &DynProvider,
     wrappers: &[WrapperCall],
+    block: u64,
 ) -> Result<(), BuildError> {
     let lookups = wrappers.iter().map(|w| async move {
         let address = w.address;
         let code = provider
             .get_code_at(address)
+            .block_id(block.into())
             .await
             .map_err(|source| BuildError::WrapperCodeFetch { address, source })?;
         if code.is_empty() {
@@ -480,7 +483,7 @@ pub(crate) async fn finish_simulation_builder(
     let wrapper = builder.wrapper;
     let (to, calldata) = match wrapper {
         WrapperConfig::Custom(wrappers) if !wrappers.is_empty() => {
-            ensure_wrappers_have_code(&builder.simulator.0.provider, &wrappers).await?;
+            ensure_wrappers_have_code(&builder.simulator.0.provider, &wrappers, block).await?;
             encode_wrapper_settlement(&wrappers, settle_calldata).expect("wrappers is non-empty")
         }
         WrapperConfig::Flashloan(loans) => {
@@ -787,7 +790,7 @@ mod tests {
         let provider =
             provider_returning_codes(&[Bytes::from_static(&[0x60]), Bytes::from_static(&[0x60])]);
 
-        ensure_wrappers_have_code(&provider, &wrappers)
+        ensure_wrappers_have_code(&provider, &wrappers, 0)
             .await
             .expect("all wrappers have code");
     }
@@ -798,7 +801,7 @@ mod tests {
         // First wrapper has code, second is an EOA (empty code).
         let provider = provider_returning_codes(&[Bytes::from_static(&[0x60]), Bytes::new()]);
 
-        let err = ensure_wrappers_have_code(&provider, &wrappers)
+        let err = ensure_wrappers_have_code(&provider, &wrappers, 0)
             .await
             .expect_err("inner EOA wrapper must be rejected");
 
@@ -815,7 +818,7 @@ mod tests {
         let wrappers = [wrapper(0xCC)];
         let provider = provider_returning_codes(&[Bytes::new()]);
 
-        let err = ensure_wrappers_have_code(&provider, &wrappers)
+        let err = ensure_wrappers_have_code(&provider, &wrappers, 0)
             .await
             .expect_err("outer EOA wrapper must be rejected");
 

--- a/crates/simulator/src/encoding.rs
+++ b/crates/simulator/src/encoding.rs
@@ -13,6 +13,7 @@ use {
         WrapperConfig,
     },
     alloy_primitives::{Address, B256, Bytes, U256, b256, keccak256},
+    alloy_provider::{DynProvider, Provider},
     alloy_rpc_types::state::{AccountOverride, StateOverride},
     alloy_sol_types::SolCall,
     app_data::AppDataHash,
@@ -341,6 +342,31 @@ pub fn encode_wrapper_data(wrappers: &[WrapperCall]) -> Bytes {
     wrapper_data.into()
 }
 
+/// Ensures every wrapper address in the chain has code deployed on-chain.
+/// A `call` to a code-less address returns success with empty output, so the
+/// inner settlement (and the `storeBalance` interactions that record trader
+/// balances) would silently no-op. The trade verifier expects a fixed-shape
+/// response and reads garbage when the helper short-circuits this way.
+async fn ensure_wrappers_have_code(
+    provider: &DynProvider,
+    wrappers: &[WrapperCall],
+) -> Result<(), BuildError> {
+    let lookups = wrappers.iter().map(|w| async move {
+        let address = w.address;
+        let code = provider
+            .get_code_at(address)
+            .await
+            .map_err(|source| BuildError::WrapperCodeFetch { address, source })?;
+        if code.is_empty() {
+            Err(BuildError::WrapperHasNoCode { address })
+        } else {
+            Ok(())
+        }
+    });
+    futures::future::try_join_all(lookups).await?;
+    Ok(())
+}
+
 pub(crate) async fn finish_simulation_builder(
     mut builder: SimulationBuilder,
 ) -> Result<EthCallInputs, BuildError> {
@@ -454,6 +480,7 @@ pub(crate) async fn finish_simulation_builder(
     let wrapper = builder.wrapper;
     let (to, calldata) = match wrapper {
         WrapperConfig::Custom(wrappers) if !wrappers.is_empty() => {
+            ensure_wrappers_have_code(&builder.simulator.0.provider, &wrappers).await?;
             encode_wrapper_settlement(&wrappers, settle_calldata).expect("wrappers is non-empty")
         }
         WrapperConfig::Flashloan(loans) => {
@@ -727,5 +754,74 @@ fn apply_account_override(
     } else {
         overrides.insert(address, new);
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use {
+        super::*,
+        alloy_provider::{ProviderBuilder, mock::Asserter},
+    };
+
+    fn wrapper(address: u8) -> WrapperCall {
+        WrapperCall {
+            address: Address::repeat_byte(address),
+            data: Bytes::new(),
+        }
+    }
+
+    fn provider_returning_codes(codes: &[Bytes]) -> DynProvider {
+        let asserter = Asserter::new();
+        for code in codes {
+            asserter.push_success(code);
+        }
+        ProviderBuilder::new()
+            .connect_mocked_client(asserter)
+            .erased()
+    }
+
+    #[tokio::test]
+    async fn accepts_wrappers_with_code() {
+        let wrappers = [wrapper(1), wrapper(2)];
+        let provider =
+            provider_returning_codes(&[Bytes::from_static(&[0x60]), Bytes::from_static(&[0x60])]);
+
+        ensure_wrappers_have_code(&provider, &wrappers)
+            .await
+            .expect("all wrappers have code");
+    }
+
+    #[tokio::test]
+    async fn rejects_inner_wrapper_without_code() {
+        let wrappers = [wrapper(0xAA), wrapper(0xBB)];
+        // First wrapper has code, second is an EOA (empty code).
+        let provider = provider_returning_codes(&[Bytes::from_static(&[0x60]), Bytes::new()]);
+
+        let err = ensure_wrappers_have_code(&provider, &wrappers)
+            .await
+            .expect_err("inner EOA wrapper must be rejected");
+
+        match err {
+            BuildError::WrapperHasNoCode { address } => {
+                assert_eq!(address, Address::repeat_byte(0xBB));
+            }
+            other => panic!("expected WrapperHasNoCode, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn rejects_outer_wrapper_without_code() {
+        let wrappers = [wrapper(0xCC)];
+        let provider = provider_returning_codes(&[Bytes::new()]);
+
+        let err = ensure_wrappers_have_code(&provider, &wrappers)
+            .await
+            .expect_err("outer EOA wrapper must be rejected");
+
+        assert!(matches!(
+            err,
+            BuildError::WrapperHasNoCode { address } if address == Address::repeat_byte(0xCC)
+        ));
     }
 }

--- a/crates/simulator/src/simulation_builder.rs
+++ b/crates/simulator/src/simulation_builder.rs
@@ -692,6 +692,14 @@ pub enum BuildError {
     AppDataParse(#[from] serde_json::Error),
     #[error("both wrappers and flashloans cannot be encoded in the same settlement")]
     FlashloanWrappersIncompatible,
+    #[error("wrapper {address} has no code on-chain")]
+    WrapperHasNoCode { address: Address },
+    #[error("failed to fetch wrapper code for {address}: {source}")]
+    WrapperCodeFetch {
+        address: Address,
+        #[source]
+        source: alloy_transport::TransportError,
+    },
 }
 
 /// Error returned when two [`AccountOverride`]s set the same field for the same


### PR DESCRIPTION
# Description

Follow-up to #4434 and #4432. The trade verifier sets `settleCallTarget` to the first wrapper. Any further wrappers are packed into `wrapperData` bytes and called from inside the chain. A low-level `call` to an EOA returns success with empty output, so if any wrapper in the chain has no code, the inner settlement and its `storeBalance` interactions silently no-op and the helper returns a short `queriedBalances` array.

#4432 added a defensive bounds check that prevents the panic but reports a generic shape mismatch. #4434 added a Solidity `require` that only catches the outermost wrapper, as @MartinquaXD pointed out in [this comment](https://github.com/cowprotocol/services/pull/4434#discussion_r3302219962).

This PR moves the check to Rust and validates every wrapper address in `finish_simulation_builder` before `encode_wrapper_settlement`. Catches outer and inner EOA wrappers, surfaces `BuildError::WrapperHasNoCode { address }`, and is intended to replace the Solidity-side fix in #4434.

# Changes

- `BuildError::WrapperHasNoCode` and `BuildError::WrapperCodeFetch` variants
- `ensure_wrappers_have_code` helper that runs one `eth_getCode` per wrapper in parallel
- Called from `finish_simulation_builder` when wrappers are configured

# How to test

New unit tests.