### PR TITLE
Separate banned address backends from caches

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6145,6 +6145,7 @@ version = "0.1.0"
 dependencies = [
  "alloy-contract",
  "alloy-primitives",
+ "async-trait",
  "const-hex",
  "contracts",
  "futures",
@@ -6152,6 +6153,7 @@ dependencies = [
  "moka",
  "reqwest 0.13.2",
  "sha2",
+ "thiserror 1.0.69",
  "tokio",
  "tracing",
  "url",

--- a/crates/order-validation/Cargo.toml
+++ b/crates/order-validation/Cargo.toml
@@ -8,6 +8,7 @@ license = "MIT OR Apache-2.0"
 [dependencies]
 alloy-contract = { workspace = true }
 alloy-primitives = { workspace = true }
+async-trait = { workspace = true }
 const-hex = { workspace = true }
 contracts = { workspace = true }
 futures = { workspace = true }
@@ -15,6 +16,7 @@ hmac = { workspace = true }
 moka = { workspace = true, features = ["sync"] }
 reqwest = { workspace = true, features = ["json"] }
 sha2 = { workspace = true }
+thiserror = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }
 url = { workspace = true }

--- a/crates/order-validation/src/banned/cached.rs
+++ b/crates/order-validation/src/banned/cached.rs
@@ -9,7 +9,7 @@ use {
     moka::sync::Cache,
     std::{
         collections::HashSet,
-        sync::Arc,
+        sync::{Arc, Weak},
         time::{Duration, Instant},
     },
 };
@@ -31,7 +31,7 @@ pub(super) enum BackendError {
     Chainalysis(#[from] alloy_contract::Error),
 
     #[error("hermod lookup failed")]
-    Hermod(#[from] super::hermod::HermodError),
+    Hermod(#[from] super::hermod::Error),
 }
 
 /// Pure banned-address fetcher; caching and refresh live in [`Cached`].
@@ -59,7 +59,7 @@ impl Cached {
             backends,
             cache: Cache::builder().max_capacity(max_capacity).build(),
         });
-        cached.clone().spawn_maintenance_task();
+        cached.spawn_maintenance_task();
         Some(cached)
     }
 
@@ -84,7 +84,8 @@ impl Cached {
             .await;
 
         let now = Instant::now();
-        for (address, is_banned) in fetched.into_iter().flat_map(|(a, r)| r.map(|b| (a, b))) {
+        for (address, is_banned) in fetched {
+            let Some(is_banned) = is_banned else { continue };
             self.cache.insert(
                 address,
                 Entry {
@@ -143,24 +144,27 @@ impl Cached {
     }
 
     /// Spawns a background task that periodically refreshes near-expiry cache
-    /// entries so callers rarely observe a cold miss.
-    fn spawn_maintenance_task(self: Arc<Self>) {
+    /// entries so callers rarely observe a cold miss. Holds a [`Weak`] handle
+    /// so the task exits once the last external [`Arc`] is dropped.
+    fn spawn_maintenance_task(self: &Arc<Self>) {
+        let weak: Weak<Self> = Arc::downgrade(self);
         tokio::task::spawn(async move {
             let mut interval = tokio::time::interval(MAINTENANCE_TIMEOUT);
             interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
             loop {
                 interval.tick().await;
+                let Some(this) = weak.upgrade() else { return };
                 let now = Instant::now();
-                let expired = self.expired(now);
+                let expired = this.expired(now);
 
                 let refreshed: Vec<_> = stream::iter(expired)
-                    .map(|address| self.refresh(*address))
+                    .map(|address| this.refresh(*address))
                     .buffer_unordered(MAX_CONCURRENT_LOOKUPS)
                     .collect()
                     .await;
 
                 for (address, entry) in refreshed.into_iter().flatten() {
-                    self.cache.insert(address, entry);
+                    this.cache.insert(address, entry);
                 }
             }
         });

--- a/crates/order-validation/src/banned/cached.rs
+++ b/crates/order-validation/src/banned/cached.rs
@@ -1,10 +1,6 @@
-//! Shared cache that sits in front of every configured remote banned-user
-//! backend.
-//!
-//! `Users::banned` answers a single question — "is this address banned by any
-//! of our sources?" — so the cache stores one entry per address rather than
-//! one per (address, backend). Backends remain pure fetchers; this module is
-//! the only layer that knows about caching, batching, or background refresh.
+//! Shared cache fronting every configured banned-user backend. Stores one
+//! entry per address (not per address × backend) since callers only ask
+//! "banned by anyone?"; backends stay as pure fetchers.
 
 use {
     alloy_primitives::Address,
@@ -18,8 +14,7 @@ use {
     },
 };
 
-/// Caps the number of in-flight per-address fetches so a large batch of cache
-/// misses (or a large maintenance refresh) does not burst the backends.
+/// Caps in-flight fetches so a large miss batch can't burst the backends.
 const MAX_CONCURRENT_LOOKUPS: usize = 10;
 const CACHE_EXPIRY: Duration = Duration::from_secs(60 * 60);
 const MAINTENANCE_TIMEOUT: Duration = Duration::from_secs(60);
@@ -30,8 +25,6 @@ struct Entry {
     last_updated: Instant,
 }
 
-/// Union of every backend's native error type. `#[from]` lets each impl
-/// `?`-propagate its own error into this enum without manual conversion.
 #[derive(Debug, thiserror::Error)]
 pub(super) enum BackendError {
     #[error("chainalysis lookup failed")]
@@ -41,15 +34,11 @@ pub(super) enum BackendError {
     Hermod(#[from] super::hermod::HermodError),
 }
 
-/// Pure banned-address fetcher. Implementations only need to know how to ask
-/// their underlying source — caching, batching, and refresh are handled by
-/// the surrounding [`Cached`] layer.
+/// Pure banned-address fetcher; caching and refresh live in [`Cached`].
 #[async_trait]
 pub(super) trait Backend: Send + Sync + 'static {
     async fn fetch(&self, address: Address) -> Result<bool, BackendError>;
 
-    /// Short identifier used as a log tag to distinguish failures across
-    /// backends.
     fn name(&self) -> &'static str;
 }
 
@@ -61,8 +50,7 @@ pub(super) struct Cached {
 }
 
 impl Cached {
-    /// Returns `None` if no backends are configured — caching makes no sense
-    /// without something to cache.
+    /// Returns `None` when no backends are configured.
     pub(super) fn new(backends: Vec<Box<dyn Backend>>, max_capacity: u64) -> Option<Arc<Self>> {
         if backends.is_empty() {
             return None;
@@ -75,9 +63,8 @@ impl Cached {
         Some(cached)
     }
 
-    /// Returns the subset of `addresses` that any configured backend reports
-    /// as banned. Cache hits are served immediately; misses are fetched
-    /// concurrently and written back.
+    /// Returns the subset reported as banned by any backend. Misses fan out
+    /// to backends concurrently.
     pub(super) async fn check(&self, addresses: &HashSet<Address>) -> HashSet<Address> {
         let mut banned = HashSet::new();
         let mut need_lookup = Vec::new();
@@ -113,16 +100,18 @@ impl Cached {
         banned
     }
 
-    /// Queries every configured backend for this address in parallel. Returns
-    /// `Some(is_banned)` only if every backend reported successfully; if any
-    /// failed, returns `None` so a partial result doesn't get cached and
-    /// mask a hit from the failing source.
+    /// `Some(true)` as soon as any backend confirms a ban — a failure
+    /// elsewhere must not mask a positive hit. `None` means no confirmation
+    /// and at least one failure, so the caller skips caching.
     async fn fetch_all(&self, address: Address) -> Option<bool> {
-        join_all(self.backends.iter().map(|b| fetch_one(b.as_ref(), address)))
-            .await
-            .into_iter()
-            .collect::<Option<Vec<bool>>>()
-            .map(|results| results.into_iter().any(|banned| banned))
+        let results = join_all(self.backends.iter().map(|b| fetch_one(b.as_ref(), address))).await;
+        if results.iter().any(|r| matches!(r, Some(true))) {
+            Some(true)
+        } else if results.iter().any(Option::is_none) {
+            None
+        } else {
+            Some(false)
+        }
     }
 
     /// Collects cache entries close enough to expiry that the next maintenance
@@ -140,9 +129,8 @@ impl Cached {
             .collect()
     }
 
-    /// Re-queries every backend for an address. Returns `None` (and leaves
-    /// the existing entry alone) when any configured backend fails, so a
-    /// transient outage doesn't poison the cache.
+    /// `None` (existing entry preserved) when `fetch_all` is uncertain — no
+    /// positive confirmation and at least one backend failed.
     async fn refresh(&self, address: Address) -> Option<(Address, Entry)> {
         let is_banned = self.fetch_all(address).await?;
         Some((
@@ -179,8 +167,7 @@ impl Cached {
     }
 }
 
-/// Calls one backend and logs (but swallows) the error so the caller can OR
-/// successful results together without dealing with per-backend error types.
+/// Logs and swallows backend errors so callers can OR successful results.
 async fn fetch_one(backend: &dyn Backend, address: Address) -> Option<bool> {
     match backend.fetch(address).await {
         Ok(banned) => Some(banned),

--- a/crates/order-validation/src/banned/cached.rs
+++ b/crates/order-validation/src/banned/cached.rs
@@ -1,0 +1,197 @@
+//! Shared cache that sits in front of every configured remote banned-user
+//! backend.
+//!
+//! `Users::banned` answers a single question — "is this address banned by any
+//! of our sources?" — so the cache stores one entry per address rather than
+//! one per (address, backend). Backends remain pure fetchers; this module is
+//! the only layer that knows about caching, batching, or background refresh.
+
+use {
+    alloy_primitives::Address,
+    async_trait::async_trait,
+    futures::{StreamExt, future::join_all, stream},
+    moka::sync::Cache,
+    std::{
+        collections::HashSet,
+        sync::Arc,
+        time::{Duration, Instant},
+    },
+};
+
+/// Caps the number of in-flight per-address fetches so a large batch of cache
+/// misses (or a large maintenance refresh) does not burst the backends.
+const MAX_CONCURRENT_LOOKUPS: usize = 10;
+const CACHE_EXPIRY: Duration = Duration::from_secs(60 * 60);
+const MAINTENANCE_TIMEOUT: Duration = Duration::from_secs(60);
+
+#[derive(Clone)]
+struct Entry {
+    is_banned: bool,
+    last_updated: Instant,
+}
+
+/// Union of every backend's native error type. `#[from]` lets each impl
+/// `?`-propagate its own error into this enum without manual conversion.
+#[derive(Debug, thiserror::Error)]
+pub(super) enum BackendError {
+    #[error("chainalysis lookup failed")]
+    Chainalysis(#[from] alloy_contract::Error),
+
+    #[error("hermod lookup failed")]
+    Hermod(#[from] super::hermod::HermodError),
+}
+
+/// Pure banned-address fetcher. Implementations only need to know how to ask
+/// their underlying source — caching, batching, and refresh are handled by
+/// the surrounding [`Cached`] layer.
+#[async_trait]
+pub(super) trait Backend: Send + Sync + 'static {
+    async fn fetch(&self, address: Address) -> Result<bool, BackendError>;
+
+    /// Short identifier used as a log tag to distinguish failures across
+    /// backends.
+    fn name(&self) -> &'static str;
+}
+
+/// Single cache fronting every configured backend. A miss fans out to every
+/// backend in parallel and stores the OR of the results.
+pub(super) struct Cached {
+    backends: Vec<Box<dyn Backend>>,
+    cache: Cache<Address, Entry>,
+}
+
+impl Cached {
+    /// Returns `None` if no backends are configured — caching makes no sense
+    /// without something to cache.
+    pub(super) fn new(backends: Vec<Box<dyn Backend>>, max_capacity: u64) -> Option<Arc<Self>> {
+        if backends.is_empty() {
+            return None;
+        }
+        let cached = Arc::new(Self {
+            backends,
+            cache: Cache::builder().max_capacity(max_capacity).build(),
+        });
+        cached.clone().spawn_maintenance_task();
+        Some(cached)
+    }
+
+    /// Returns the subset of `addresses` that any configured backend reports
+    /// as banned. Cache hits are served immediately; misses are fetched
+    /// concurrently and written back.
+    pub(super) async fn check(&self, addresses: &HashSet<Address>) -> HashSet<Address> {
+        let mut banned = HashSet::new();
+        let mut need_lookup = Vec::new();
+        for address in addresses {
+            match self.cache.get(address) {
+                Some(entry) => {
+                    entry.is_banned.then(|| banned.insert(*address));
+                }
+                None => need_lookup.push(*address),
+            }
+        }
+
+        let fetched: Vec<_> = stream::iter(need_lookup)
+            .map(|address| async move { (address, self.fetch_all(address).await) })
+            .buffer_unordered(MAX_CONCURRENT_LOOKUPS)
+            .collect()
+            .await;
+
+        let now = Instant::now();
+        for (address, is_banned) in fetched.into_iter().flat_map(|(a, r)| r.map(|b| (a, b))) {
+            self.cache.insert(
+                address,
+                Entry {
+                    is_banned,
+                    last_updated: now,
+                },
+            );
+            if is_banned {
+                banned.insert(address);
+            }
+        }
+
+        banned
+    }
+
+    /// Queries every configured backend for this address in parallel. Returns
+    /// `Some(is_banned)` only if every backend reported successfully; if any
+    /// failed, returns `None` so a partial result doesn't get cached and
+    /// mask a hit from the failing source.
+    async fn fetch_all(&self, address: Address) -> Option<bool> {
+        join_all(self.backends.iter().map(|b| fetch_one(b.as_ref(), address)))
+            .await
+            .into_iter()
+            .collect::<Option<Vec<bool>>>()
+            .map(|results| results.into_iter().any(|banned| banned))
+    }
+
+    /// Collects cache entries close enough to expiry that the next maintenance
+    /// tick may miss the window.
+    fn expired(&self, now: Instant) -> Vec<Arc<Address>> {
+        self.cache
+            .iter()
+            .filter_map(|(address, entry)| {
+                let due = now
+                    .checked_duration_since(entry.last_updated)
+                    .unwrap_or_default()
+                    >= CACHE_EXPIRY - MAINTENANCE_TIMEOUT;
+                due.then_some(address)
+            })
+            .collect()
+    }
+
+    /// Re-queries every backend for an address. Returns `None` (and leaves
+    /// the existing entry alone) when any configured backend fails, so a
+    /// transient outage doesn't poison the cache.
+    async fn refresh(&self, address: Address) -> Option<(Address, Entry)> {
+        let is_banned = self.fetch_all(address).await?;
+        Some((
+            address,
+            Entry {
+                is_banned,
+                last_updated: Instant::now(),
+            },
+        ))
+    }
+
+    /// Spawns a background task that periodically refreshes near-expiry cache
+    /// entries so callers rarely observe a cold miss.
+    fn spawn_maintenance_task(self: Arc<Self>) {
+        tokio::task::spawn(async move {
+            let mut interval = tokio::time::interval(MAINTENANCE_TIMEOUT);
+            interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+            loop {
+                interval.tick().await;
+                let now = Instant::now();
+                let expired = self.expired(now);
+
+                let refreshed: Vec<_> = stream::iter(expired)
+                    .map(|address| self.refresh(*address))
+                    .buffer_unordered(MAX_CONCURRENT_LOOKUPS)
+                    .collect()
+                    .await;
+
+                for (address, entry) in refreshed.into_iter().flatten() {
+                    self.cache.insert(address, entry);
+                }
+            }
+        });
+    }
+}
+
+/// Calls one backend and logs (but swallows) the error so the caller can OR
+/// successful results together without dealing with per-backend error types.
+async fn fetch_one(backend: &dyn Backend, address: Address) -> Option<bool> {
+    match backend.fetch(address).await {
+        Ok(banned) => Some(banned),
+        Err(err) => {
+            tracing::warn!(
+                backend = backend.name(),
+                ?address,
+                ?err,
+                "failed to fetch banned status",
+            );
+            None
+        }
+    }
+}

--- a/crates/order-validation/src/banned/hermod.rs
+++ b/crates/order-validation/src/banned/hermod.rs
@@ -5,21 +5,15 @@
 //! Chainalysis `Onchain` checker: same cache, same background refresh task.
 
 use {
-    super::{Backend, MAX_CONCURRENT_LOOKUPS, UserMetadata},
+    super::{Backend, UserMetadata},
     alloy_primitives::Address,
-    futures::{StreamExt, stream},
     hmac::{Hmac, Mac},
     moka::sync::Cache,
     sha2::Sha256,
-    std::{
-        sync::Arc,
-        time::{Duration, Instant},
-    },
+    std::{sync::Arc, time::Duration},
     url::Url,
 };
 
-const CACHE_EXPIRY: Duration = Duration::from_secs(60 * 60);
-const MAINTENANCE_TIMEOUT: Duration = Duration::from_secs(60);
 const REQUEST_TIMEOUT: Duration = Duration::from_secs(5);
 
 /// Configuration for the Hermod (zeroShadow) sanctioned-address checker.
@@ -78,78 +72,6 @@ impl Hermod {
         hermod.clone().spawn_maintenance_task();
 
         hermod
-    }
-
-    fn expired_data(&self, start: Instant) -> Vec<(Arc<Address>, UserMetadata)> {
-        self.cache
-            .iter()
-            .filter_map(|(address, metadata)| {
-                let expired = start
-                    .checked_duration_since(metadata.last_updated)
-                    .unwrap_or_default()
-                    >= CACHE_EXPIRY - MAINTENANCE_TIMEOUT;
-                expired.then_some((address, metadata))
-            })
-            .collect()
-    }
-
-    async fn determine_status(
-        &self,
-        address: Address,
-        metadata: UserMetadata,
-    ) -> Option<(Address, UserMetadata)> {
-        match self.fetch(address).await {
-            Ok(is_banned) => Some((
-                address,
-                UserMetadata {
-                    is_banned,
-                    ..metadata
-                },
-            )),
-            Err(err) => {
-                tracing::warn!(
-                    ?address,
-                    ?err,
-                    "unable to determine hermod banned status in the background task",
-                );
-                None
-            }
-        }
-    }
-
-    fn insert_many_into_cache(&self, addresses: impl Iterator<Item = (Address, UserMetadata)>) {
-        let now = Instant::now();
-        for (address, metadata) in addresses {
-            self.cache.insert(
-                address,
-                UserMetadata {
-                    last_updated: now,
-                    ..metadata
-                },
-            );
-        }
-    }
-
-    fn spawn_maintenance_task(self: Arc<Self>) {
-        tokio::task::spawn(async move {
-            let mut interval = tokio::time::interval(MAINTENANCE_TIMEOUT);
-            interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
-            loop {
-                interval.tick().await;
-                let start = Instant::now();
-                let expired_data = self.expired_data(start);
-
-                let results = stream::iter(expired_data)
-                    .map(|(address, metadata)| self.determine_status(*address, metadata))
-                    .buffer_unordered(MAX_CONCURRENT_LOOKUPS)
-                    .collect::<Vec<_>>()
-                    .await
-                    .into_iter()
-                    .flatten();
-
-                self.insert_many_into_cache(results);
-            }
-        });
     }
 
     /// HMAC-SHA256 of the address textual payload, encoded as lowercase hex.

--- a/crates/order-validation/src/banned/hermod.rs
+++ b/crates/order-validation/src/banned/hermod.rs
@@ -1,8 +1,5 @@
-//! Hermod (zeroShadow) sanctioned-address fetcher.
-//!
-//! Queries are HMAC-SHA256-signed using a per-customer key; a hit returns
-//! HTTP 200 and a miss returns HTTP 404. Pure fetcher — caching and
-//! background refresh are provided by the [`super::cached::Cached`] wrapper.
+//! Hermod (zeroShadow) sanctioned-address fetcher. Queries are
+//! HMAC-SHA256-signed; hit = HTTP 200, miss = HTTP 404.
 
 use {
     super::cached::{Backend, BackendError},
@@ -64,8 +61,7 @@ impl Hermod {
 
     /// HMAC-SHA256 of the address textual payload, encoded as lowercase hex.
     fn sign(&self, address: Address) -> String {
-        // The payload is the lowercase `0x`-prefixed 40-character (42 characters
-        // total). As defined by Hermod's documentation.
+        // Hermod expects the lowercase `0x`-prefixed address (42 chars).
         let payload = const_hex::encode_prefixed(address);
         let mut mac = Hmac::<Sha256>::new_from_slice(&self.hmac_key)
             .expect("HMAC accepts keys of any length");
@@ -73,9 +69,6 @@ impl Hermod {
         const_hex::encode(mac.finalize().into_bytes())
     }
 
-    /// Inner fetch in `HermodError` so the body can `?`-propagate request
-    /// errors directly; the `Backend::fetch` impl wraps the result into the
-    /// trait-wide `BackendError`.
     async fn fetch_status(&self, address: Address) -> Result<bool, HermodError> {
         let signature = self.sign(address);
         let endpoint = self

--- a/crates/order-validation/src/banned/hermod.rs
+++ b/crates/order-validation/src/banned/hermod.rs
@@ -1,16 +1,16 @@
-//! Hermod (zeroShadow) sanctioned-address checker.
+//! Hermod (zeroShadow) sanctioned-address fetcher.
 //!
 //! Queries are HMAC-SHA256-signed using a per-customer key; a hit returns
-//! HTTP 200 and a miss returns HTTP 404. Mirrors the structure of the
-//! Chainalysis `Onchain` checker: same cache, same background refresh task.
+//! HTTP 200 and a miss returns HTTP 404. Pure fetcher — caching and
+//! background refresh are provided by the [`super::cached::Cached`] wrapper.
 
 use {
-    super::{Backend, UserMetadata},
+    super::cached::{Backend, BackendError},
     alloy_primitives::Address,
+    async_trait::async_trait,
     hmac::{Hmac, Mac},
-    moka::sync::Cache,
     sha2::Sha256,
-    std::{sync::Arc, time::Duration},
+    std::time::Duration,
     url::Url,
 };
 
@@ -27,30 +27,23 @@ pub struct HermodConfig {
     pub api_key: Option<String>,
 }
 
-#[expect(dead_code, reason = "fields are used in Debug for logs")]
-#[derive(Debug)]
-pub(super) enum FetchError {
-    Request(reqwest::Error),
+#[derive(Debug, thiserror::Error)]
+pub(super) enum HermodError {
+    #[error("request failed")]
+    Request(#[from] reqwest::Error),
+    #[error("unexpected status code: {0}")]
     UnexpectedStatus(reqwest::StatusCode),
 }
 
-impl From<reqwest::Error> for FetchError {
-    fn from(err: reqwest::Error) -> Self {
-        Self::Request(err)
-    }
-}
-
-/// Hermod banned user checker with caching and background refresh.
 pub(super) struct Hermod {
     client: reqwest::Client,
     url: Url,
     hmac_key: Vec<u8>,
     api_key: Option<String>,
-    cache: Cache<Address, UserMetadata>,
 }
 
 impl Hermod {
-    pub(super) fn new(config: HermodConfig, cache_max_size: u64) -> Arc<Self> {
+    pub(super) fn new(config: HermodConfig) -> Self {
         // Make sure the URL ends with a slash so joining `addresses/<sig>`
         // appends rather than replaces the last path segment.
         let mut url = config.url;
@@ -58,7 +51,7 @@ impl Hermod {
             let with_slash = format!("{}/", url.path());
             url.set_path(&with_slash);
         }
-        let hermod = Arc::new(Self {
+        Self {
             client: reqwest::Client::builder()
                 .timeout(REQUEST_TIMEOUT)
                 .build()
@@ -66,12 +59,7 @@ impl Hermod {
             url,
             hmac_key: config.hmac_key.into_bytes(),
             api_key: config.api_key,
-            cache: Cache::builder().max_capacity(cache_max_size).build(),
-        });
-
-        hermod.clone().spawn_maintenance_task();
-
-        hermod
+        }
     }
 
     /// HMAC-SHA256 of the address textual payload, encoded as lowercase hex.
@@ -84,12 +72,11 @@ impl Hermod {
         mac.update(payload.as_bytes());
         const_hex::encode(mac.finalize().into_bytes())
     }
-}
 
-impl Backend for Hermod {
-    type Error = FetchError;
-
-    async fn fetch(&self, address: Address) -> Result<bool, Self::Error> {
+    /// Inner fetch in `HermodError` so the body can `?`-propagate request
+    /// errors directly; the `Backend::fetch` impl wraps the result into the
+    /// trait-wide `BackendError`.
+    async fn fetch_status(&self, address: Address) -> Result<bool, HermodError> {
         let signature = self.sign(address);
         let endpoint = self
             .url
@@ -104,12 +91,15 @@ impl Backend for Hermod {
         match response.status() {
             reqwest::StatusCode::OK => Ok(true),
             reqwest::StatusCode::NOT_FOUND => Ok(false),
-            status => Err(FetchError::UnexpectedStatus(status)),
+            status => Err(HermodError::UnexpectedStatus(status)),
         }
     }
+}
 
-    fn cache(&self) -> &Cache<Address, UserMetadata> {
-        &self.cache
+#[async_trait]
+impl Backend for Hermod {
+    async fn fetch(&self, address: Address) -> Result<bool, BackendError> {
+        Ok(self.fetch_status(address).await?)
     }
 
     fn name(&self) -> &'static str {
@@ -121,15 +111,12 @@ impl Backend for Hermod {
 mod tests {
     use {super::*, alloy_primitives::address};
 
-    fn backend() -> Arc<Hermod> {
-        Hermod::new(
-            HermodConfig {
-                url: "http://hermod:3000".parse().unwrap(),
-                hmac_key: "key".to_string(),
-                api_key: None,
-            },
-            10,
-        )
+    fn backend() -> Hermod {
+        Hermod::new(HermodConfig {
+            url: "http://hermod:3000".parse().unwrap(),
+            hmac_key: "key".to_string(),
+            api_key: None,
+        })
     }
 
     #[tokio::test]
@@ -142,14 +129,11 @@ mod tests {
 
     #[tokio::test]
     async fn base_url_without_trailing_slash_is_normalised() {
-        let hermod = Hermod::new(
-            HermodConfig {
-                url: "http://hermod:3000/v1".parse().unwrap(),
-                hmac_key: "key".to_string(),
-                api_key: None,
-            },
-            10,
-        );
+        let hermod = Hermod::new(HermodConfig {
+            url: "http://hermod:3000/v1".parse().unwrap(),
+            hmac_key: "key".to_string(),
+            api_key: None,
+        });
         assert!(hermod.url.as_str().ends_with('/'));
         let joined = hermod.url.join("addresses/abc").unwrap();
         assert_eq!(joined.as_str(), "http://hermod:3000/v1/addresses/abc");

--- a/crates/order-validation/src/banned/hermod.rs
+++ b/crates/order-validation/src/banned/hermod.rs
@@ -15,7 +15,7 @@ const REQUEST_TIMEOUT: Duration = Duration::from_secs(5);
 
 /// Configuration for the Hermod (zeroShadow) sanctioned-address checker.
 #[derive(Debug, Clone)]
-pub struct HermodConfig {
+pub struct Config {
     /// Base URL of the Hermod agent (e.g. `http://hermod:3000`).
     pub url: Url,
     /// Per-customer HMAC key used to obfuscate addresses before sending.
@@ -25,22 +25,22 @@ pub struct HermodConfig {
 }
 
 #[derive(Debug, thiserror::Error)]
-pub(super) enum HermodError {
+pub(super) enum Error {
     #[error("request failed")]
     Request(#[from] reqwest::Error),
     #[error("unexpected status code: {0}")]
     UnexpectedStatus(reqwest::StatusCode),
 }
 
-pub(super) struct Hermod {
+pub(super) struct Client {
     client: reqwest::Client,
     url: Url,
     hmac_key: Vec<u8>,
     api_key: Option<String>,
 }
 
-impl Hermod {
-    pub(super) fn new(config: HermodConfig) -> Self {
+impl Client {
+    pub(super) fn new(config: Config) -> Self {
         // Make sure the URL ends with a slash so joining `addresses/<sig>`
         // appends rather than replaces the last path segment.
         let mut url = config.url;
@@ -69,7 +69,7 @@ impl Hermod {
         const_hex::encode(mac.finalize().into_bytes())
     }
 
-    async fn fetch_status(&self, address: Address) -> Result<bool, HermodError> {
+    async fn fetch_status(&self, address: Address) -> Result<bool, Error> {
         let signature = self.sign(address);
         let endpoint = self
             .url
@@ -84,13 +84,13 @@ impl Hermod {
         match response.status() {
             reqwest::StatusCode::OK => Ok(true),
             reqwest::StatusCode::NOT_FOUND => Ok(false),
-            status => Err(HermodError::UnexpectedStatus(status)),
+            status => Err(Error::UnexpectedStatus(status)),
         }
     }
 }
 
 #[async_trait]
-impl Backend for Hermod {
+impl Backend for Client {
     async fn fetch(&self, address: Address) -> Result<bool, BackendError> {
         Ok(self.fetch_status(address).await?)
     }
@@ -104,8 +104,8 @@ impl Backend for Hermod {
 mod tests {
     use {super::*, alloy_primitives::address};
 
-    fn backend() -> Hermod {
-        Hermod::new(HermodConfig {
+    fn backend() -> Client {
+        Client::new(Config {
             url: "http://hermod:3000".parse().unwrap(),
             hmac_key: "key".to_string(),
             api_key: None,
@@ -122,7 +122,7 @@ mod tests {
 
     #[tokio::test]
     async fn base_url_without_trailing_slash_is_normalised() {
-        let hermod = Hermod::new(HermodConfig {
+        let hermod = Client::new(Config {
             url: "http://hermod:3000/v1".parse().unwrap(),
             hmac_key: "key".to_string(),
             api_key: None,

--- a/crates/order-validation/src/banned/mod.rs
+++ b/crates/order-validation/src/banned/mod.rs
@@ -5,11 +5,11 @@ mod cached;
 mod hermod;
 mod onchain;
 
-pub use hermod::HermodConfig;
+pub use hermod::Config as HermodConfig;
 use {
     self::{
         cached::{Backend, Cached},
-        hermod::Hermod,
+        hermod::Client as Hermod,
         onchain::Onchain,
     },
     alloy_primitives::Address,

--- a/crates/order-validation/src/banned/mod.rs
+++ b/crates/order-validation/src/banned/mod.rs
@@ -6,9 +6,11 @@
 //! background refresh every 60 seconds.
 
 mod hermod;
+mod onchain;
 
 pub use hermod::HermodConfig;
 use {
+    self::onchain::Onchain,
     alloy_primitives::Address,
     contracts::ChainalysisOracle,
     futures::{
@@ -106,30 +108,11 @@ pub(crate) trait Backend: Send + Sync + 'static {
             }
         }
     }
-}
 
-/// Onchain banned user checker using Chainalysis Oracle with caching and
-/// background refresh. Maintains a size-bounded LRU cache with periodic
-/// maintenance to refresh expired entries.
-struct Onchain {
-    contract: ChainalysisOracle::Instance,
-    cache: Cache<Address, UserMetadata>,
-}
-
-impl Onchain {
-    pub fn new(contract: ChainalysisOracle::Instance, cache_max_size: u64) -> Arc<Self> {
-        let onchain = Arc::new(Self {
-            contract,
-            cache: Cache::builder().max_capacity(cache_max_size).build(),
-        });
-
-        onchain.clone().spawn_maintenance_task();
-
-        onchain
-    }
-
+    /// Collects cache entries that are close enough to expiry that the next
+    /// maintenance tick may miss the window.
     fn expired_data(&self, start: Instant) -> Vec<(Arc<Address>, UserMetadata)> {
-        self.cache
+        self.cache()
             .iter()
             .filter_map(|(address, metadata)| {
                 let expired = start
@@ -141,34 +124,44 @@ impl Onchain {
             .collect()
     }
 
-    async fn determine_status(
+    /// Refreshes the ban status for a single cached entry, preserving the
+    /// previous metadata if the lookup fails.
+    fn determine_status(
         &self,
         address: Address,
         metadata: UserMetadata,
-    ) -> Option<(Address, UserMetadata)> {
-        match self.fetch(address).await {
-            Ok(is_banned) => Some((
-                address,
-                UserMetadata {
-                    is_banned,
-                    ..metadata
-                },
-            )),
-            Err(err) => {
-                tracing::warn!(
-                    ?address,
-                    ?err,
-                    "unable to determine banned status in the background task",
-                );
-                None
+    ) -> impl Future<Output = Option<(Address, UserMetadata)>> + Send {
+        async move {
+            match self.fetch(address).await {
+                Ok(is_banned) => Some((
+                    address,
+                    UserMetadata {
+                        is_banned,
+                        ..metadata
+                    },
+                )),
+                Err(err) => {
+                    tracing::warn!(
+                        backend = self.name(),
+                        ?address,
+                        ?err,
+                        "unable to determine banned status in the background task",
+                    );
+                    None
+                }
             }
         }
     }
 
-    fn insert_many_into_cache(&self, addresses: impl Iterator<Item = (Address, UserMetadata)>) {
+    /// Writes the refreshed entries back into the cache, stamping each with
+    /// the current time.
+    fn insert_many_into_cache<I>(&self, addresses: I)
+    where
+        I: IntoIterator<Item = (Address, UserMetadata)>,
+    {
         let now = Instant::now();
         for (address, metadata) in addresses {
-            self.cache.insert(
+            self.cache().insert(
                 address,
                 UserMetadata {
                     last_updated: now,
@@ -178,7 +171,12 @@ impl Onchain {
         }
     }
 
-    fn spawn_maintenance_task(self: Arc<Self>) {
+    /// Spawns a background task that periodically refreshes near-expiry cache
+    /// entries so callers rarely observe a cold miss.
+    fn spawn_maintenance_task(self: Arc<Self>)
+    where
+        Self: Sized,
+    {
         tokio::task::spawn(async move {
             let mut interval = tokio::time::interval(MAINTENANCE_TIMEOUT);
             interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
@@ -198,22 +196,6 @@ impl Onchain {
                 self.insert_many_into_cache(results);
             }
         });
-    }
-}
-
-impl Backend for Onchain {
-    type Error = alloy_contract::Error;
-
-    async fn fetch(&self, address: Address) -> Result<bool, Self::Error> {
-        self.contract.isSanctioned(address).call().await
-    }
-
-    fn cache(&self) -> &Cache<Address, UserMetadata> {
-        &self.cache
-    }
-
-    fn name(&self) -> &'static str {
-        "chainalysis"
     }
 }
 

--- a/crates/order-validation/src/banned/mod.rs
+++ b/crates/order-validation/src/banned/mod.rs
@@ -1,10 +1,5 @@
-//! Banned user detection for order validation.
-//!
-//! Checks if addresses are banned using a hardcoded list and optionally the
-//! Chainalysis Oracle on-chain registry and/or the Hermod (zeroShadow) agent.
-//! Remote sources sit behind a single shared cache layer ([`cached::Cached`])
-//! which provides LRU caching with 1-hour expiry and a background refresh
-//! task.
+//! Banned user detection: hardcoded list + optional Chainalysis Oracle
+//! and/or Hermod (zeroShadow). Remote sources share one cache layer.
 
 mod cached;
 mod hermod;
@@ -29,9 +24,7 @@ pub struct Users {
 }
 
 impl Users {
-    /// Creates a new `Users` instance that checks the hardcoded list and uses
-    /// the given `web3` instance to determine whether an onchain registry of
-    /// banned addresses is available.
+    /// Builds the validator from a hardcoded list and optional remote backends.
     pub fn new(
         contract: Option<ChainalysisOracle::Instance>,
         hermod: Option<HermodConfig>,
@@ -65,10 +58,8 @@ impl Users {
         Self { list, remote: None }
     }
 
-    /// Returns a subset of addresses from the input iterator which are banned.
-    ///
-    /// On cache-misses, it will use the Chainalysis oracle and/or the Hermod
-    /// agent to determine status.
+    /// Returns the subset of `addresses` that are banned. Cache misses hit
+    /// the configured remote sources.
     pub async fn banned(&self, addresses: impl IntoIterator<Item = Address>) -> HashSet<Address> {
         let mut banned = HashSet::new();
 

--- a/crates/order-validation/src/banned/mod.rs
+++ b/crates/order-validation/src/banned/mod.rs
@@ -2,201 +2,30 @@
 //!
 //! Checks if addresses are banned using a hardcoded list and optionally the
 //! Chainalysis Oracle on-chain registry and/or the Hermod (zeroShadow) agent.
-//! Remote check results are cached (1-hour expiry, LRU eviction) with
-//! background refresh every 60 seconds.
+//! Remote sources sit behind a single shared cache layer ([`cached::Cached`])
+//! which provides LRU caching with 1-hour expiry and a background refresh
+//! task.
 
+mod cached;
 mod hermod;
 mod onchain;
 
 pub use hermod::HermodConfig;
 use {
-    self::onchain::Onchain,
+    self::{
+        cached::{Backend, Cached},
+        hermod::Hermod,
+        onchain::Onchain,
+    },
     alloy_primitives::Address,
     contracts::ChainalysisOracle,
-    futures::{
-        FutureExt,
-        StreamExt,
-        future::{BoxFuture, join_all},
-        stream,
-    },
-    moka::sync::Cache,
-    std::{
-        collections::HashSet,
-        fmt::Debug,
-        future::Future,
-        sync::Arc,
-        time::{Duration, Instant},
-    },
+    std::{collections::HashSet, sync::Arc},
 };
-
-/// Caps the number of in-flight per-address fetches so a large batch of cache
-/// misses (or a large maintenance refresh) does not burst the backend.
-pub(crate) const MAX_CONCURRENT_LOOKUPS: usize = 10;
-const CACHE_EXPIRY: Duration = Duration::from_secs(60 * 60);
-const MAINTENANCE_TIMEOUT: Duration = Duration::from_secs(60);
 
 /// A list of banned users and optional registries that can be checked.
 pub struct Users {
     list: HashSet<Address>,
-    onchain: Option<Arc<Onchain>>,
-    hermod: Option<Arc<hermod::Hermod>>,
-}
-
-#[derive(Clone)]
-pub(crate) struct UserMetadata {
-    pub(crate) is_banned: bool,
-    pub(crate) last_updated: Instant,
-}
-
-/// A remote banned-user source backed by a cache. Each implementation only
-/// needs to provide the underlying lookup; the shared `check` flow takes
-/// care of cache hit/miss handling and writing fresh results back.
-pub(crate) trait Backend: Send + Sync + 'static {
-    type Error: Debug + Send;
-
-    /// Asks the underlying source whether the given address is banned.
-    fn fetch(&self, address: Address) -> impl Future<Output = Result<bool, Self::Error>> + Send;
-
-    fn cache(&self) -> &Cache<Address, UserMetadata>;
-
-    fn name(&self) -> &'static str;
-
-    /// Checks the given addresses against this backend and inserts any
-    /// reported hits into `banned`. Addresses already in `banned` are skipped
-    /// to avoid an unnecessary lookup.
-    async fn check(&self, addresses: &HashSet<Address>, banned: &mut HashSet<Address>) {
-        let mut need_lookup = Vec::new();
-        for address in addresses {
-            if banned.contains(address) {
-                continue;
-            }
-            match self.cache().get(address) {
-                Some(metadata) => {
-                    metadata.is_banned.then(|| banned.insert(*address));
-                }
-                None => need_lookup.push(*address),
-            }
-        }
-
-        let to_cache: Vec<_> = stream::iter(need_lookup)
-            .map(|address| async move { (address, self.fetch(address).await) })
-            .buffer_unordered(MAX_CONCURRENT_LOOKUPS)
-            .collect()
-            .await;
-
-        let now = Instant::now();
-        for (address, result) in to_cache {
-            match result {
-                Ok(is_banned) => {
-                    self.cache().insert(
-                        address,
-                        UserMetadata {
-                            is_banned,
-                            last_updated: now,
-                        },
-                    );
-                    is_banned.then(|| banned.insert(address));
-                }
-                Err(err) => {
-                    tracing::warn!(
-                        backend = self.name(),
-                        ?err,
-                        ?address,
-                        "failed to fetch banned status",
-                    );
-                }
-            }
-        }
-    }
-
-    /// Collects cache entries that are close enough to expiry that the next
-    /// maintenance tick may miss the window.
-    fn expired_data(&self, start: Instant) -> Vec<(Arc<Address>, UserMetadata)> {
-        self.cache()
-            .iter()
-            .filter_map(|(address, metadata)| {
-                let expired = start
-                    .checked_duration_since(metadata.last_updated)
-                    .unwrap_or_default()
-                    >= CACHE_EXPIRY - MAINTENANCE_TIMEOUT;
-                expired.then_some((address, metadata))
-            })
-            .collect()
-    }
-
-    /// Refreshes the ban status for a single cached entry, preserving the
-    /// previous metadata if the lookup fails.
-    fn determine_status(
-        &self,
-        address: Address,
-        metadata: UserMetadata,
-    ) -> impl Future<Output = Option<(Address, UserMetadata)>> + Send {
-        async move {
-            match self.fetch(address).await {
-                Ok(is_banned) => Some((
-                    address,
-                    UserMetadata {
-                        is_banned,
-                        ..metadata
-                    },
-                )),
-                Err(err) => {
-                    tracing::warn!(
-                        backend = self.name(),
-                        ?address,
-                        ?err,
-                        "unable to determine banned status in the background task",
-                    );
-                    None
-                }
-            }
-        }
-    }
-
-    /// Writes the refreshed entries back into the cache, stamping each with
-    /// the current time.
-    fn insert_many_into_cache<I>(&self, addresses: I)
-    where
-        I: IntoIterator<Item = (Address, UserMetadata)>,
-    {
-        let now = Instant::now();
-        for (address, metadata) in addresses {
-            self.cache().insert(
-                address,
-                UserMetadata {
-                    last_updated: now,
-                    ..metadata
-                },
-            );
-        }
-    }
-
-    /// Spawns a background task that periodically refreshes near-expiry cache
-    /// entries so callers rarely observe a cold miss.
-    fn spawn_maintenance_task(self: Arc<Self>)
-    where
-        Self: Sized,
-    {
-        tokio::task::spawn(async move {
-            let mut interval = tokio::time::interval(MAINTENANCE_TIMEOUT);
-            interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
-            loop {
-                interval.tick().await;
-                let start = Instant::now();
-                let expired_data = self.expired_data(start);
-
-                let results = stream::iter(expired_data)
-                    .map(|(address, metadata)| self.determine_status(*address, metadata))
-                    .buffer_unordered(MAX_CONCURRENT_LOOKUPS)
-                    .collect::<Vec<_>>()
-                    .await
-                    .into_iter()
-                    .flatten();
-
-                self.insert_many_into_cache(results);
-            }
-        });
-    }
+    remote: Option<Arc<Cached>>,
 }
 
 impl Users {
@@ -209,10 +38,16 @@ impl Users {
         banned_users: Vec<Address>,
         cache_max_size: u64,
     ) -> Self {
+        let mut backends: Vec<Box<dyn Backend>> = Vec::new();
+        if let Some(contract) = contract {
+            backends.push(Box::new(Onchain::new(contract)));
+        }
+        if let Some(config) = hermod {
+            backends.push(Box::new(Hermod::new(config)));
+        }
         Self {
             list: HashSet::from_iter(banned_users),
-            onchain: contract.map(|instance| Onchain::new(instance, cache_max_size)),
-            hermod: hermod.map(|config| hermod::Hermod::new(config, cache_max_size)),
+            remote: Cached::new(backends, cache_max_size),
         }
     }
 
@@ -220,19 +55,14 @@ impl Users {
     pub fn none() -> Self {
         Self {
             list: HashSet::new(),
-            onchain: None,
-            hermod: None,
+            remote: None,
         }
     }
 
     /// Creates a new `Users` instance that passes all addresses except for the
     /// ones in `list`.
     pub fn from_set(list: HashSet<Address>) -> Self {
-        Self {
-            list,
-            onchain: None,
-            hermod: None,
-        }
+        Self { list, remote: None }
     }
 
     /// Returns a subset of addresses from the input iterator which are banned.
@@ -255,30 +85,10 @@ impl Users {
             // Need to collect here to make sure filter gets executed and we insert addresses
             .collect::<HashSet<_>>();
 
-        let lookups: Vec<BoxFuture<'_, HashSet<Address>>> = [
-            self.onchain
-                .as_deref()
-                .map(|b| check_into_new(b, &need_lookup).boxed()),
-            self.hermod
-                .as_deref()
-                .map(|b| check_into_new(b, &need_lookup).boxed()),
-        ]
-        .into_iter()
-        .flatten()
-        .collect();
-
-        for found in join_all(lookups).await {
-            banned.extend(found);
+        if let Some(remote) = &self.remote {
+            banned.extend(remote.check(&need_lookup).await);
         }
 
         banned
     }
-}
-
-/// Runs `backend.check` against a fresh result set so multiple backends can be
-/// driven concurrently without sharing a `&mut HashSet`.
-async fn check_into_new<B: Backend>(backend: &B, addresses: &HashSet<Address>) -> HashSet<Address> {
-    let mut out = HashSet::new();
-    backend.check(addresses, &mut out).await;
-    out
 }

--- a/crates/order-validation/src/banned/onchain.rs
+++ b/crates/order-validation/src/banned/onchain.rs
@@ -1,46 +1,29 @@
-//! Chainalysis Oracle-backed sanctioned-address checker.
+//! Chainalysis Oracle-backed sanctioned-address fetcher.
 //!
-//! Queries the on-chain `isSanctioned` view. Mirrors the structure of the
-//! Hermod checker: same cache, same background refresh task.
+//! Queries the on-chain `isSanctioned` view. Pure fetcher — caching and
+//! background refresh are provided by the [`super::cached::Cached`] wrapper.
 
 use {
-    super::{Backend, UserMetadata},
+    super::cached::{Backend, BackendError},
     alloy_primitives::Address,
+    async_trait::async_trait,
     contracts::ChainalysisOracle,
-    moka::sync::Cache,
-    std::sync::Arc,
 };
 
-/// Onchain banned user checker using Chainalysis Oracle with caching and
-/// background refresh. Maintains a size-bounded LRU cache with periodic
-/// maintenance to refresh expired entries.
 pub(super) struct Onchain {
     contract: ChainalysisOracle::Instance,
-    cache: Cache<Address, UserMetadata>,
 }
 
 impl Onchain {
-    pub(super) fn new(contract: ChainalysisOracle::Instance, cache_max_size: u64) -> Arc<Self> {
-        let onchain = Arc::new(Self {
-            contract,
-            cache: Cache::builder().max_capacity(cache_max_size).build(),
-        });
-
-        onchain.clone().spawn_maintenance_task();
-
-        onchain
+    pub(super) fn new(contract: ChainalysisOracle::Instance) -> Self {
+        Self { contract }
     }
 }
 
+#[async_trait]
 impl Backend for Onchain {
-    type Error = alloy_contract::Error;
-
-    async fn fetch(&self, address: Address) -> Result<bool, Self::Error> {
-        self.contract.isSanctioned(address).call().await
-    }
-
-    fn cache(&self) -> &Cache<Address, UserMetadata> {
-        &self.cache
+    async fn fetch(&self, address: Address) -> Result<bool, BackendError> {
+        Ok(self.contract.isSanctioned(address).call().await?)
     }
 
     fn name(&self) -> &'static str {

--- a/crates/order-validation/src/banned/onchain.rs
+++ b/crates/order-validation/src/banned/onchain.rs
@@ -1,0 +1,49 @@
+//! Chainalysis Oracle-backed sanctioned-address checker.
+//!
+//! Queries the on-chain `isSanctioned` view. Mirrors the structure of the
+//! Hermod checker: same cache, same background refresh task.
+
+use {
+    super::{Backend, UserMetadata},
+    alloy_primitives::Address,
+    contracts::ChainalysisOracle,
+    moka::sync::Cache,
+    std::sync::Arc,
+};
+
+/// Onchain banned user checker using Chainalysis Oracle with caching and
+/// background refresh. Maintains a size-bounded LRU cache with periodic
+/// maintenance to refresh expired entries.
+pub(super) struct Onchain {
+    contract: ChainalysisOracle::Instance,
+    cache: Cache<Address, UserMetadata>,
+}
+
+impl Onchain {
+    pub(super) fn new(contract: ChainalysisOracle::Instance, cache_max_size: u64) -> Arc<Self> {
+        let onchain = Arc::new(Self {
+            contract,
+            cache: Cache::builder().max_capacity(cache_max_size).build(),
+        });
+
+        onchain.clone().spawn_maintenance_task();
+
+        onchain
+    }
+}
+
+impl Backend for Onchain {
+    type Error = alloy_contract::Error;
+
+    async fn fetch(&self, address: Address) -> Result<bool, Self::Error> {
+        self.contract.isSanctioned(address).call().await
+    }
+
+    fn cache(&self) -> &Cache<Address, UserMetadata> {
+        &self.cache
+    }
+
+    fn name(&self) -> &'static str {
+        "chainalysis"
+    }
+}


### PR DESCRIPTION
# Description
Separates the cache layer from the remote backends in the banned-user validator. Chainalysis and Hermod previously each owned their own caching; this consolidates it into one shared layer with pure fetchers behind it.

# Changes
* Split `banned.rs` into a `banned/` module: `mod.rs` (public `Users` API), `cached.rs` (shared cache + refresh), `onchain.rs` (Chainalysis), `hermod.rs` (zeroShadow).
* Added a `Backend` trait — backends only implement `fetch(address)` and `name()`; caching/batching/refresh is no longer their concern.
* Single cache entry per address (not per address × backend); a miss fans out to all backends in parallel and ORs the results.
* Background refresh runs from one place; transient backend failures are discarded instead of poisoning the cache.
* Per-backend errors unified into a `BackendError` enum with `#[from]` conversions.

## How to test
1. `cargo nextest run -p order-validation`
2. `cargo clippy --locked --workspace --all-features --all-targets -- -D warnings`
