### PR TITLE
Add duration histogram for order creation shadow simulation

### DIFF
--- a/crates/shared/src/order_validation.rs
+++ b/crates/shared/src/order_validation.rs
@@ -58,11 +58,11 @@ pub struct OrderSimulator {
 }
 
 #[derive(prometheus_metric_storage::MetricStorage)]
+#[metric(subsystem = "onchain_orders")]
 struct Metrics {
     /// Wall-clock time of a single shadow order simulation, labelled by
     /// outcome.
     #[metric(
-        name = "order_simulation_duration_seconds",
         labels("outcome"),
         buckets(0.05, 0.1, 0.25, 0.5, 0.75, 1.0, 1.5, 2.0, 3.0, 4.0, 5.0, 6.0, 8.0)
     )]

--- a/crates/shared/src/order_validation.rs
+++ b/crates/shared/src/order_validation.rs
@@ -60,8 +60,7 @@ pub struct OrderSimulator {
 #[derive(prometheus_metric_storage::MetricStorage)]
 #[metric(subsystem = "onchain_orders")]
 struct Metrics {
-    /// Wall-clock time of a single shadow order simulation, labelled by
-    /// outcome.
+    /// Wall-clock time of a single order simulation, labelled by outcome.
     #[metric(
         labels("outcome"),
         buckets(0.05, 0.1, 0.25, 0.5, 0.75, 1.0, 1.5, 2.0, 3.0, 4.0, 5.0, 6.0, 8.0)

--- a/crates/shared/src/order_validation.rs
+++ b/crates/shared/src/order_validation.rs
@@ -42,7 +42,10 @@ use {
     },
     price_estimation::{PriceEstimationError, Verification},
     signature_validator::{SignatureCheck, SignatureValidating, SignatureValidationError},
-    std::{sync::Arc, time::Duration},
+    std::{
+        sync::Arc,
+        time::{Duration, Instant},
+    },
     tracing::instrument,
 };
 
@@ -54,15 +57,52 @@ pub struct OrderSimulator {
     pub timeout: Duration,
 }
 
+#[derive(prometheus_metric_storage::MetricStorage)]
+struct Metrics {
+    /// Wall-clock time of a single shadow order simulation, labelled by
+    /// outcome.
+    #[metric(
+        name = "order_simulation_duration_seconds",
+        labels("outcome"),
+        buckets(0.05, 0.1, 0.25, 0.5, 0.75, 1.0, 1.5, 2.0, 3.0, 4.0, 5.0, 6.0, 8.0)
+    )]
+    duration_seconds: prometheus::HistogramVec,
+}
+
+impl Metrics {
+    fn get() -> &'static Self {
+        Self::instance(observe::metrics::get_storage_registry()).unwrap()
+    }
+}
+
 impl OrderSimulator {
     pub async fn simulate_with_timeout(
         &self,
         order: &Order,
         full_app_data: &str,
     ) -> Result<(), OrderSimulationError> {
-        tokio::time::timeout(self.timeout, self.simulator.simulate(order, full_app_data))
-            .await
-            .map_err(|_| OrderSimulationError::Infra(anyhow!("order simulation timeout")))?
+        let start = Instant::now();
+        let (outcome, result) =
+            match tokio::time::timeout(self.timeout, self.simulator.simulate(order, full_app_data))
+                .await
+            {
+                Ok(r @ Ok(())) => ("ok", r),
+                Ok(r @ Err(OrderSimulationError::Reverted { .. })) => ("reverted", r),
+                Ok(r @ Err(OrderSimulationError::Infra(_))) => ("infra", r),
+                Err(_) => (
+                    "timeout",
+                    Err(OrderSimulationError::Infra(anyhow!(
+                        "order simulation timeout"
+                    ))),
+                ),
+            };
+
+        Metrics::get()
+            .duration_seconds
+            .with_label_values(&[outcome])
+            .observe(start.elapsed().as_secs_f64());
+
+        result
     }
 }
 


### PR DESCRIPTION
# Description
We currently only know how often the shadow simulator times out, not how close successful sims get to the budget. Without a real duration distribution, sizing the timeout budget is guesswork. This adds a Prometheus histogram so we can pick the next budget from p99 data instead of guessing.

TraceQL Metrics are disabled, so I couldn't use Tempo to collect those metrics.

# Changes
- Add `order_simulation_duration_seconds` histogram labelled by outcome (ok, reverted, timeout, infra) on the shadow order simulator

# How to test
Existing tests. After deploy, `order_simulation_duration_seconds_*` should be exposed by the orderbook pods with the four outcome label values.
