### PR TITLE
Post-processing improvements

### DIFF
--- a/crates/driver/src/domain/competition/mod.rs
+++ b/crates/driver/src/domain/competition/mod.rs
@@ -23,7 +23,7 @@ use {
     anyhow::Context as _,
     axum::{body::Body, http::Request},
     eth_domain_types as eth,
-    futures::{FutureExt, StreamExt, stream::FuturesUnordered},
+    futures::{FutureExt, StreamExt},
     itertools::Itertools,
     simulator::{RevertError, Simulator, SimulatorError},
     std::{
@@ -421,9 +421,7 @@ impl Competition {
             SolutionMerging::Forbidden => solutions.collect(),
         };
 
-        // Encode solutions into settlements (streamed).
-        let encoded = all_solutions
-            .into_iter()
+        let encoded = futures::stream::iter(all_solutions)
             .map(|solution| async move {
                 observe::encoding(solution.id());
                 let settlement = solution
@@ -437,7 +435,7 @@ impl Competition {
                     .await;
                 (solution, settlement)
             })
-            .collect::<FuturesUnordered<_>>()
+            .buffer_unordered(1)
             .filter_map(|(solution, result)| async move {
                 let id = solution.id().clone();
                 let orders: Vec<_> = solution

--- a/crates/driver/src/domain/competition/mod.rs
+++ b/crates/driver/src/domain/competition/mod.rs
@@ -435,7 +435,7 @@ impl Competition {
                     .await;
                 (solution, settlement)
             })
-            .buffer_unordered(1)
+            .buffer_unordered(5)
             .filter_map(|(solution, result)| async move {
                 let id = solution.id().clone();
                 let orders: Vec<_> = solution

--- a/crates/driver/src/domain/competition/mod.rs
+++ b/crates/driver/src/domain/competition/mod.rs
@@ -435,7 +435,7 @@ impl Competition {
                     .await;
                 (solution, settlement)
             })
-            .buffer_unordered(5)
+            .buffer_unordered(self.solver.config().post_processing_concurrency_limit.get())
             .filter_map(|(solution, result)| async move {
                 let id = solution.id().clone();
                 let orders: Vec<_> = solution

--- a/crates/driver/src/domain/competition/mod.rs
+++ b/crates/driver/src/domain/competition/mod.rs
@@ -939,7 +939,7 @@ impl Competition {
     /// Returns whether the settlement can be executed or would revert.
     async fn simulate_settlement(&self, settlement: &Settlement) -> Result<(), simulator::Error> {
         let tx = settlement.transaction(settlement::Internalization::Enable);
-        let gas_needed_for_tx = self.simulator.gas(tx).await?;
+        let gas_needed_for_tx = self.simulator.gas(tx.clone()).await?;
         if gas_needed_for_tx > settlement.gas.limit {
             return Err(simulator::Error::Revert(RevertError {
                 err: SimulatorError::GasExceeded(gas_needed_for_tx, settlement.gas.limit),

--- a/crates/driver/src/domain/competition/solution/mod.rs
+++ b/crates/driver/src/domain/competition/solution/mod.rs
@@ -316,28 +316,25 @@ impl Solution {
             try_join_all(self.allowances(internalization).map(|required| async move {
                 let erc20_token = ERC20::new(required.0.token.into(), &eth.web3().provider);
 
-                let current_allowance =
-                    erc20_token.allowance(settlement_contract, required.0.spender);
-
-                let approval = erc20_token
-                    .approve(required.0.spender, required.0.amount)
-                    .from(settlement_contract);
-
-                // since this code is on the hotpath we run both futures
-                // concurrently to reduce latency even if the second future
-                // might not be needed often
-                let (current_allowance, regular_approval) = tokio::join!(
-                    current_allowance.call().into_future(),
-                    approval.call().into_future(),
-                );
+                let current_allowance = erc20_token
+                    .allowance(settlement_contract, required.0.spender)
+                    .call()
+                    .await?;
 
                 // if the current allowance is sufficient we can skip that interaction
-                if current_allowance? >= required.0.amount {
+                if current_allowance >= required.0.amount {
                     return Ok::<_, blockchain::Error>(vec![]);
                 }
 
+                let regular_approval_succeeds = erc20_token
+                    .approve(required.0.spender, required.0.amount)
+                    .from(settlement_contract)
+                    .call()
+                    .await
+                    .is_ok();
+
                 let approval = eth::allowance::Approval(required.0);
-                if regular_approval.is_ok() {
+                if regular_approval_succeeds {
                     Ok(vec![approval])
                 } else {
                     // setting the desired approval reverts so we assume we are

--- a/crates/driver/src/domain/competition/solution/mod.rs
+++ b/crates/driver/src/domain/competition/solution/mod.rs
@@ -316,25 +316,28 @@ impl Solution {
             try_join_all(self.allowances(internalization).map(|required| async move {
                 let erc20_token = ERC20::new(required.0.token.into(), &eth.web3().provider);
 
-                let current_allowance = erc20_token
-                    .allowance(settlement_contract, required.0.spender)
-                    .call()
-                    .await?;
+                let current_allowance =
+                    erc20_token.allowance(settlement_contract, required.0.spender);
+
+                let approval = erc20_token
+                    .approve(required.0.spender, required.0.amount)
+                    .from(settlement_contract);
+
+                // since this code is on the hotpath we run both futures
+                // concurrently to reduce latency even if the second future
+                // might not be needed often
+                let (current_allowance, regular_approval) = tokio::join!(
+                    current_allowance.call().into_future(),
+                    approval.call().into_future(),
+                );
 
                 // if the current allowance is sufficient we can skip that interaction
-                if current_allowance >= required.0.amount {
+                if current_allowance? >= required.0.amount {
                     return Ok::<_, blockchain::Error>(vec![]);
                 }
 
-                let regular_approval_succeeds = erc20_token
-                    .approve(required.0.spender, required.0.amount)
-                    .from(settlement_contract)
-                    .call()
-                    .await
-                    .is_ok();
-
                 let approval = eth::allowance::Approval(required.0);
-                if regular_approval_succeeds {
+                if regular_approval.is_ok() {
                     Ok(vec![approval])
                 } else {
                     // setting the desired approval reverts so we assume we are

--- a/crates/driver/src/domain/competition/solution/settlement.rs
+++ b/crates/driver/src/domain/competition/solution/settlement.rs
@@ -110,13 +110,18 @@ impl Settlement {
             return Err(Error::NonBufferableTokensUsed(untrusted_tokens));
         }
 
+        let (internalized, uninternalized) = futures::try_join!(
+            solution.approvals(eth, Internalization::Enable),
+            solution.approvals(eth, Internalization::Disable),
+        )?;
+
         // Encode the solution into a settlement.
         let tx = SettlementTx {
             internalized: encoding::tx(
                 auction,
                 &solution,
                 eth.contracts(),
-                solution.approvals(eth, Internalization::Enable).await?,
+                internalized,
                 Internalization::Enable,
                 solver_native_token,
             )?,
@@ -124,7 +129,7 @@ impl Settlement {
                 auction,
                 &solution,
                 eth.contracts(),
-                solution.approvals(eth, Internalization::Disable).await?,
+                uninternalized,
                 Internalization::Disable,
                 solver_native_token,
             )?,

--- a/crates/driver/src/domain/competition/solution/settlement.rs
+++ b/crates/driver/src/domain/competition/solution/settlement.rs
@@ -68,9 +68,9 @@ struct SettlementTx {
 }
 
 impl SettlementTx {
-    fn set_access_list(&mut self, access_list: eth::AccessList) {
-        self.internalized.set_access_list(access_list.clone());
-        self.uninternalized.set_access_list(access_list);
+    fn set_access_list(&mut self, access_list: RequiredAccessList) {
+        self.internalized.set_access_list(access_list.0.clone());
+        self.uninternalized.set_access_list(access_list.0);
     }
 }
 
@@ -159,7 +159,7 @@ impl Settlement {
         // `Some(..)` means at least one trade strictly requires an access list;
         // `None` means it is purely a gas optimization for this settlement, so a
         // non-revert fetch failure below can be tolerated.
-        let partial_access_list: Option<eth::AccessList> = try_join_all(
+        let partial_access_list: Option<RequiredAccessList> = try_join_all(
             solution
                 .user_trades()
                 .map(|trade| partial_access_list_for(trade, &solution, eth, simulator)),
@@ -168,7 +168,8 @@ impl Settlement {
         .into_iter()
         .flatten()
         .map(|required| required.0)
-        .reduce(|acc, list| acc.merge(list));
+        .reduce(|acc, list| acc.merge(list))
+        .map(RequiredAccessList);
 
         if let Some(access_list) = partial_access_list {
             transaction.set_access_list(access_list.clone());

--- a/crates/driver/src/domain/competition/solution/settlement.rs
+++ b/crates/driver/src/domain/competition/solution/settlement.rs
@@ -19,7 +19,7 @@ use {
     },
     alloy::primitives::U256,
     eth_domain_types as eth,
-    futures::future::try_join_all,
+    futures::{TryFutureExt, future::try_join_all},
     simulator::{self, Simulator},
     std::collections::{BTreeSet, HashMap, HashSet},
     tracing::instrument,
@@ -198,22 +198,23 @@ impl Settlement {
         let gas_used_fut = simulator.gas(transaction.internalized.clone());
 
         // run everything concurrently to minimize latency added through RPC roundtrips
-        let (internalized_tx_check, gas_used, gas_price, solver_eth) = tokio::join!(
-            internalized_tx_check,
-            gas_used_fut,
-            eth.gas_price(),
+        // for the internalization check we don't need the Ok result - we only need to
+        // know it doesn't return an error
+        let (_internalized_tx_check, gas_used, gas_price, solver_eth) = tokio::try_join!(
+            internalized_tx_check.map_err(Error::from),
+            gas_used_fut.map_err(Error::from),
+            eth.gas_price().map_err(Error::from),
             eth.balance(solution.solver().address())
-        );
-
-        internalized_tx_check?; // just ensure the check passed
+                .map_err(Error::from)
+        )?;
 
         // Ensure that the solver has sufficient balance for the settlement to be mined
         // even if the gas price keeps climbing during the tx submission.
-        let gas = Gas::new(gas_used?, eth.block_gas_limit(), eth.tx_gas_limit())?;
+        let gas = Gas::new(gas_used, eth.block_gas_limit(), eth.tx_gas_limit())?;
         let required_eth_balance =
             // Converting to U256 first avoids possible overflow
-            gas.required_balance(U256::from(gas_price?.max_fee_per_gas).saturating_mul(U256::from(2)));
-        if solver_eth? < required_eth_balance {
+            gas.required_balance(U256::from(gas_price.max_fee_per_gas).saturating_mul(U256::from(2)));
+        if solver_eth < required_eth_balance {
             return Err(Error::SolverAccountInsufficientBalance(
                 required_eth_balance,
             ));

--- a/crates/driver/src/domain/competition/solution/settlement.rs
+++ b/crates/driver/src/domain/competition/solution/settlement.rs
@@ -15,7 +15,7 @@ use {
                 solution::{self, Interaction, Trade, error},
             },
         },
-        infra::{blockchain::Ethereum, observe, solver::ManageNativeToken},
+        infra::{blockchain::Ethereum, solver::ManageNativeToken},
     },
     alloy::primitives::U256,
     eth_domain_types as eth,
@@ -68,12 +68,9 @@ struct SettlementTx {
 }
 
 impl SettlementTx {
-    fn with_access_list(self, access_list: eth::AccessList) -> Self {
-        Self {
-            internalized: self.internalized.set_access_list(access_list.clone()),
-            uninternalized: self.uninternalized.set_access_list(access_list),
-            ..self
-        }
+    fn set_access_list(&mut self, access_list: eth::AccessList) {
+        self.internalized.set_access_list(access_list.clone());
+        self.uninternalized.set_access_list(access_list);
     }
 }
 
@@ -143,7 +140,7 @@ impl Settlement {
     async fn new(
         auction_id: auction::Id,
         solution: Solution,
-        transaction: SettlementTx,
+        mut transaction: SettlementTx,
         eth: &Ethereum,
         simulator: &Simulator,
     ) -> Result<Self, Error> {
@@ -162,7 +159,7 @@ impl Settlement {
         // `Some(..)` means at least one trade strictly requires an access list;
         // `None` means it is purely a gas optimization for this settlement, so a
         // non-revert fetch failure below can be tolerated.
-        let partial_access_list: Option<RequiredAccessList> = try_join_all(
+        let partial_access_list: Option<eth::AccessList> = try_join_all(
             solution
                 .user_trades()
                 .map(|trade| partial_access_list_for(trade, &solution, eth, simulator)),
@@ -171,102 +168,62 @@ impl Settlement {
         .into_iter()
         .flatten()
         .map(|required| required.0)
-        .reduce(|acc, list| acc.merge(list))
-        .map(RequiredAccessList);
+        .reduce(|acc, list| acc.merge(list));
 
-        // Simulate the settlement and get the access list and gas.
-        let (access_list, gas) = Self::simulate(
-            transaction.internalized.clone(),
-            partial_access_list.as_ref(),
-            eth,
-            simulator,
-        )
-        .await?;
-        let price = eth.gas_price().await?;
-        let gas = Gas::new(gas, eth.block_gas_limit(), eth.tx_gas_limit())?;
+        if let Some(access_list) = partial_access_list {
+            transaction.set_access_list(access_list.clone());
+        }
+
+        let internalized_tx_check = async {
+            if solution
+                .interactions()
+                .iter()
+                .any(|interaction| interaction.internalize())
+            {
+                // Some rules which are enforced by the settlement contract for non-internalized
+                // interactions are not enforced for internalized interactions (in order to save
+                // gas). However, publishing a settlement with interactions that violate
+                // these rules constitutes a punishable offense for the solver, even if
+                // the interactions are internalized. To ensure that this doesn't happen, check
+                // that the settlement simulates even when internalizations are disabled.
+                simulator
+                    .gas(transaction.uninternalized.clone())
+                    .await
+                    .map(|_| ())
+            } else {
+                Ok(())
+            }
+        };
+        let gas_used_fut = simulator.gas(transaction.internalized.clone());
+
+        // run everything concurrently to minimize latency added through RPC roundtrips
+        let (internalized_tx_check, gas_used, gas_price, solver_eth) = tokio::join!(
+            internalized_tx_check,
+            gas_used_fut,
+            eth.gas_price(),
+            eth.balance(solution.solver().address())
+        );
+
+        internalized_tx_check?; // just ensure the check passed
 
         // Ensure that the solver has sufficient balance for the settlement to be mined
         // even if the gas price keeps climbing during the tx submission.
+        let gas = Gas::new(gas_used?, eth.block_gas_limit(), eth.tx_gas_limit())?;
         let required_eth_balance =
             // Converting to U256 first avoids possible overflow
-            gas.required_balance(U256::from(price.max_fee_per_gas).saturating_mul(U256::from(2)));
-        if eth.balance(solution.solver().address()).await? < required_eth_balance {
+            gas.required_balance(U256::from(gas_price?.max_fee_per_gas).saturating_mul(U256::from(2)));
+        if solver_eth? < required_eth_balance {
             return Err(Error::SolverAccountInsufficientBalance(
                 required_eth_balance,
             ));
         }
 
-        // Is at least one interaction internalized?
-        if solution
-            .interactions()
-            .iter()
-            .any(|interaction| interaction.internalize())
-        {
-            // Some rules which are enforced by the settlement contract for non-internalized
-            // interactions are not enforced for internalized interactions (in order to save
-            // gas). However, publishing a settlement with interactions that violate
-            // these rules constitutes a punishable offense for the solver, even if
-            // the interactions are internalized. To ensure that this doesn't happen, check
-            // that the settlement simulates even when internalizations are disabled.
-            Self::simulate(
-                transaction.uninternalized.clone(),
-                partial_access_list.as_ref(),
-                eth,
-                simulator,
-            )
-            .await?;
-        }
-
         Ok(Self {
             auction_id,
             solution,
-            transaction: transaction.with_access_list(access_list),
+            transaction,
             gas,
         })
-    }
-
-    /// Simulate executing this settlement on the blockchain. This process
-    /// ensures that the settlement does not revert, and calculates the
-    /// access list and gas needed to settle the solution.
-    #[instrument(name = "simulate_settlement", skip_all)]
-    async fn simulate(
-        tx: eth::Tx,
-        partial_access_list: Option<&RequiredAccessList>,
-        eth: &Ethereum,
-        simulator: &Simulator,
-    ) -> Result<(eth::AccessList, eth::Gas), Error> {
-        // Add the partial access list to the settlement tx.
-        let tx = tx.set_access_list(
-            partial_access_list
-                .map(|required| required.0.clone())
-                .unwrap_or_default(),
-        );
-
-        // Simulate the full access list, passing the partial access
-        // list into the simulation. When no trade strictly requires the
-        // access-list workaround, a non-revert failure (transport,
-        // deserialization, ...) shouldn't abort the settlement: we can't
-        // reason about the outcome, but the on-chain tx would still succeed
-        // without the access list. Revert errors are propagated either way
-        // since they signal a real problem with the settlement.
-        let access_list = match simulator.access_list(&tx).await {
-            Ok(list) => list,
-            Err(simulator::Error::Other(err)) if partial_access_list.is_none() => {
-                tracing::warn!(
-                    ?err,
-                    "access list estimation failed, falling back to empty list"
-                );
-                eth::AccessList::default()
-            }
-            Err(err) => return Err(err.into()),
-        };
-        let tx = tx.set_access_list(access_list.clone());
-
-        // Simulate the settlement using the full access list and get the gas used.
-        let gas = simulator.gas(&tx).await;
-
-        observe::simulated(eth, &tx, &gas);
-        Ok((access_list, gas?))
     }
 
     /// The calldata for this settlement.

--- a/crates/driver/src/domain/competition/solution/settlement.rs
+++ b/crates/driver/src/domain/competition/solution/settlement.rs
@@ -144,17 +144,21 @@ impl Settlement {
         eth: &Ethereum,
         simulator: &Simulator,
     ) -> Result<Self, Error> {
-        // The settlement contract will fail if the receiver is a smart contract.
-        // Because of this, if the receiver is a smart contract and we try to
-        // estimate the access list, the access list estimation will also fail.
+        // <address payable>.transfer(ETH) is allowed to use at most 2300 gas units (
+        // see <https://fravoll.github.io/solidity-patterns/secure_ether_transfer.html>).
+        // This is not enough when the receiver is a smart contract wallet which does
+        // non-trivial work in the `fallback` handler.
+        // To support sending native ETH to SC wallets we use access lists which
+        // effectively move the cost of accessing storage out of the critical section
+        // and into the tx's initial gas cost.
+        // While correctly built access lists provide a very minor net cost
+        // reduction an access list with unused storage slots increases the cost
+        // significantly. Since the risk is high and the reward is very low we only
+        // compute access list items which are absolutely necessary for the tx to work.
         //
-        // This failure happens because the Ethereum protocol sets a hard gas limit
-        // on transferring ETH into a smart contract, which some contracts exceed unless
-        // the access list is already specified.
-
-        // The solution is to do access list estimation in two steps: first, simulate
-        // moving 1 wei into every smart contract to get a partial access list, and then
-        // use that partial access list to calculate the final access list.
+        // We compute those access lists by using `eth_createAccessList` for a call
+        // sending 1 wei to each SC wallet that is supposed to get ETH during the
+        // settlement. Those lists get merged and added to the settlement transaction.
         //
         // `Some(..)` means at least one trade strictly requires an access list;
         // `None` means it is purely a gas optimization for this settlement, so a

--- a/crates/driver/src/domain/competition/solution/settlement.rs
+++ b/crates/driver/src/domain/competition/solution/settlement.rs
@@ -19,7 +19,7 @@ use {
     },
     alloy::primitives::U256,
     eth_domain_types as eth,
-    futures::future::try_join_all,
+    futures::{FutureExt, future::try_join_all},
     simulator::{self, Simulator},
     std::collections::{BTreeSet, HashMap, HashSet},
     tracing::instrument,
@@ -179,7 +179,15 @@ impl Settlement {
             transaction.set_access_list(access_list.clone());
         }
 
-        let gas_used_fut = simulator.gas(transaction.internalized.clone());
+        let gas_used_fut = simulator
+            .gas(transaction.internalized.clone())
+            .inspect(|res| {
+                tracing::debug!(
+                    block = eth.current_block().borrow().number,
+                    ?res,
+                    "simulated settlement"
+                )
+            });
 
         // run everything concurrently to minimize latency added through RPC roundtrips
         let (gas_used, gas_price, solver_eth) = tokio::join!(

--- a/crates/driver/src/domain/competition/solution/settlement.rs
+++ b/crates/driver/src/domain/competition/solution/settlement.rs
@@ -179,31 +179,10 @@ impl Settlement {
             transaction.set_access_list(access_list.clone());
         }
 
-        let internalized_tx_check = async {
-            if solution
-                .interactions()
-                .iter()
-                .any(|interaction| interaction.internalize())
-            {
-                // Some rules which are enforced by the settlement contract for non-internalized
-                // interactions are not enforced for internalized interactions (in order to save
-                // gas). However, publishing a settlement with interactions that violate
-                // these rules constitutes a punishable offense for the solver, even if
-                // the interactions are internalized. To ensure that this doesn't happen, check
-                // that the settlement simulates even when internalizations are disabled.
-                simulator
-                    .gas(transaction.uninternalized.clone())
-                    .await
-                    .map(|_| ())
-            } else {
-                Ok(())
-            }
-        };
         let gas_used_fut = simulator.gas(transaction.internalized.clone());
 
         // run everything concurrently to minimize latency added through RPC roundtrips
-        let (internalized_tx_check, gas_used, gas_price, solver_eth) = tokio::join!(
-            internalized_tx_check,
+        let (gas_used, gas_price, solver_eth) = tokio::join!(
             gas_used_fut,
             eth.gas_price(),
             eth.balance(solution.solver().address()),
@@ -220,8 +199,6 @@ impl Settlement {
                 required_eth_balance,
             ));
         }
-
-        internalized_tx_check?; // make sure the check passed
 
         Ok(Self {
             auction_id,

--- a/crates/driver/src/domain/competition/solution/settlement.rs
+++ b/crates/driver/src/domain/competition/solution/settlement.rs
@@ -19,7 +19,7 @@ use {
     },
     alloy::primitives::U256,
     eth_domain_types as eth,
-    futures::{TryFutureExt, future::try_join_all},
+    futures::future::try_join_all,
     simulator::{self, Simulator},
     std::collections::{BTreeSet, HashMap, HashSet},
     tracing::instrument,
@@ -198,27 +198,26 @@ impl Settlement {
         let gas_used_fut = simulator.gas(transaction.internalized.clone());
 
         // run everything concurrently to minimize latency added through RPC roundtrips
-        // for the internalization check we don't need the Ok result - we only need to
-        // know it doesn't return an error
-        let (_internalized_tx_check, gas_used, gas_price, solver_eth) = tokio::try_join!(
-            internalized_tx_check.map_err(Error::from),
-            gas_used_fut.map_err(Error::from),
-            eth.gas_price().map_err(Error::from),
-            eth.balance(solution.solver().address())
-                .map_err(Error::from)
-        )?;
+        let (internalized_tx_check, gas_used, gas_price, solver_eth) = tokio::join!(
+            internalized_tx_check,
+            gas_used_fut,
+            eth.gas_price(),
+            eth.balance(solution.solver().address()),
+        );
 
         // Ensure that the solver has sufficient balance for the settlement to be mined
         // even if the gas price keeps climbing during the tx submission.
-        let gas = Gas::new(gas_used, eth.block_gas_limit(), eth.tx_gas_limit())?;
+        let gas = Gas::new(gas_used?, eth.block_gas_limit(), eth.tx_gas_limit())?;
         let required_eth_balance =
             // Converting to U256 first avoids possible overflow
-            gas.required_balance(U256::from(gas_price.max_fee_per_gas).saturating_mul(U256::from(2)));
-        if solver_eth < required_eth_balance {
+            gas.required_balance(U256::from(gas_price?.max_fee_per_gas).saturating_mul(U256::from(2)));
+        if solver_eth? < required_eth_balance {
             return Err(Error::SolverAccountInsufficientBalance(
                 required_eth_balance,
             ));
         }
+
+        internalized_tx_check?; // make sure the check passed
 
         Ok(Self {
             auction_id,

--- a/crates/driver/src/infra/config/file/load.rs
+++ b/crates/driver/src/infra/config/file/load.rs
@@ -145,6 +145,7 @@ pub async fn load(chain: Chain, path: &Path) -> infra::Config {
                 )
                 .await,
                 max_solutions_to_propose: solver_config.max_solutions_to_propose,
+                post_processing_concurrency_limit: solver_config.post_processing_concurrency_limit,
             }
         }))
         .await,

--- a/crates/driver/src/infra/config/file/mod.rs
+++ b/crates/driver/src/infra/config/file/mod.rs
@@ -238,6 +238,10 @@ fn default_max_solutions_to_propose() -> NonZeroUsize {
     NonZeroUsize::new(1).unwrap()
 }
 
+fn default_post_processing_concurrency_limit() -> NonZeroUsize {
+    NonZeroUsize::MAX
+}
+
 #[serde_as]
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "kebab-case", deny_unknown_fields)]
@@ -329,6 +333,13 @@ struct SolverConfig {
     /// to start otherwise.
     #[serde(default = "default_max_solutions_to_propose")]
     max_solutions_to_propose: NonZeroUsize,
+
+    /// How many solutions the driver may post-process (i.e. validate)
+    /// concurrently. When the RPC node is experiencing very high latency
+    /// this number can be lowered if the usual throughput can not be
+    /// sustained anymore.
+    #[serde(default = "default_post_processing_concurrency_limit")]
+    post_processing_concurrency_limit: NonZeroUsize,
 }
 
 #[derive(Clone, Copy, Debug, Default, Deserialize, PartialEq, Serialize)]

--- a/crates/driver/src/infra/observe/mod.rs
+++ b/crates/driver/src/infra/observe/mod.rs
@@ -4,7 +4,7 @@
 //! and update the metrics, if the event is worth measuring.
 
 use {
-    super::{Ethereum, Mempool, solver::Timeouts},
+    super::{Mempool, solver::Timeouts},
     crate::{
         boundary,
         domain::{
@@ -22,7 +22,7 @@ use {
         infra::solver,
         util::http,
     },
-    eth_domain_types::{self as eth, Gas},
+    eth_domain_types as eth,
     ethrpc::block_stream::BlockInfo,
     std::{
         collections::{BTreeMap, HashSet},
@@ -455,13 +455,4 @@ pub fn order_excluded_from_auction(
     reason: OrderExcludedFromAuctionReason,
 ) {
     tracing::trace!(uid=?order.uid, ?reason, "order excluded from auction");
-}
-
-/// Observe that a settlement was simulated
-pub fn simulated(eth: &Ethereum, tx: &eth::Tx, gas: &Result<Gas, simulator::Error>) {
-    let block: eth::BlockNo = eth.current_block().borrow().number.into();
-    match gas {
-        Ok(gas) => tracing::debug!(block = ?block, gas = ?gas.0, ?tx, "simulated settlement"),
-        Err(err) => tracing::debug!(block = ?block, ?err, "simulated settlement"),
-    }
 }

--- a/crates/driver/src/infra/solver/mod.rs
+++ b/crates/driver/src/infra/solver/mod.rs
@@ -219,6 +219,8 @@ pub struct Config {
     /// Maximum number of solutions the driver proposes to the autopilot per
     /// auction. When 1 (the default), only the best-scoring solution is sent.
     pub max_solutions_to_propose: std::num::NonZeroUsize,
+    /// How many solutions the driver is allowed to post-process concurrently.
+    pub post_processing_concurrency_limit: std::num::NonZeroUsize,
 }
 
 impl Config {
@@ -607,6 +609,7 @@ mod tests {
             haircut_bps: 0,
             submission_accounts: vec![],
             max_solutions_to_propose: NonZeroUsize::new(1).unwrap(),
+            post_processing_concurrency_limit: NonZeroUsize::MAX,
         }
     }
 

--- a/crates/eth-domain-types/src/lib.rs
+++ b/crates/eth-domain-types/src/lib.rs
@@ -134,11 +134,8 @@ pub struct Tx {
 }
 
 impl Tx {
-    pub fn set_access_list(self, access_list: AccessList) -> Self {
-        Self {
-            access_list,
-            ..self
-        }
+    pub fn set_access_list(&mut self, access_list: AccessList) {
+        self.access_list = access_list;
     }
 }
 

--- a/crates/simulator/src/lib.rs
+++ b/crates/simulator/src/lib.rs
@@ -92,7 +92,7 @@ impl Simulator {
     }
 
     /// Simulate the gas needed by a transaction.
-    pub async fn gas(&self, tx: &eth::Tx) -> Result<eth::Gas, Error> {
+    pub async fn gas(&self, tx: eth::Tx) -> Result<eth::Gas, Error> {
         if let Some(gas) = self.disable_gas {
             return Ok(gas);
         }
@@ -103,14 +103,14 @@ impl Simulator {
                     .simulate(tx.clone(), block, tenderly::GenerateAccessList::No)
                     .measure("tenderly_simulate_gas")
                     .await
-                    .map_err(with(tx.clone(), block))?
+                    .map_err(with(tx, block))?
                     .gas
             }
             Inner::Ethereum => self
                 .eth
                 .estimate_gas(tx.clone())
                 .await
-                .map_err(with(tx.clone(), block))?,
+                .map_err(with(tx, block))?,
         })
     }
 }


### PR DESCRIPTION
# Description
Recently BNB RPC nodes had a (so far) unexplained latency increase. That caused many solutions to be discarded since they could not be post-processed fast enough. This PR contains the changes I deployed ad-hoc to alleviate the situation.

# Changes
- configurable post-processing concurrency limit (defaults to unlimited concurrency like before the PR)
- run RPC requests in `Settlement::new` concurrently to avoid round trips
- removed handling of optional access lists (those don't provide significant cost savings anyway so let's remove the complexity)
- removed simulation to verify that internalized interactions actually work since this is actually no longer needed as confirmed by the solver team