### PR TITLE
Fix openapi.yml's FeePolicy modelling

### DIFF
--- a/crates/orderbook/openapi.yml
+++ b/crates/orderbook/openapi.yml
@@ -2290,11 +2290,27 @@ components:
         - maxVolumeFactor
         - quote
     FeePolicy:
-      description: Defines the ways to calculate the protocol fee.
+      description: >
+        Defines the ways to calculate the protocol fee.
       oneOf:
-        - $ref: "#/components/schemas/Surplus"
-        - $ref: "#/components/schemas/Volume"
-        - $ref: "#/components/schemas/PriceImprovement"
+        - type: object
+          properties:
+            surplus:
+              $ref: "#/components/schemas/Surplus"
+          required:
+            - surplus
+        - type: object
+          properties:
+            volume:
+              $ref: "#/components/schemas/Volume"
+          required:
+            - volume
+        - type: object
+          properties:
+            priceImprovement:
+              $ref: "#/components/schemas/PriceImprovement"
+          required:
+            - priceImprovement
     ExecutedProtocolFee:
       type: object
       properties:


### PR DESCRIPTION
# Description
While I was adding the fee breakdown to the frontend I noticed that the FeePolicy in the openapi.yml does not match what is generated by the backend; this is noticeable in the cow-sdk/cowswap because this flows downstream directly there.

The existing spec expects something like
```
    "executedProtocolFees": [
      {
        "policy": { "factor": 0.5, "maxVolumeFactor": 0.01 },
        "amount": "1234567890000000000",
        "token": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"
      }
    ]
```
However, what the server returns is:
```
    "executedProtocolFees": [
      {
        "policy": {
          "volume": {
            "factor": 0.0002
          }
        },
        "amount": "2373279949333",
        "token": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"
      }
    ]
```

Which leads to the `policy` being parsed incorrectly, thus making this important information unavailable to the frontend.

You can validate the current return with 

```
curl -s "https://barn.api.cow.fi/mainnet/api/v2/trades?orderUid=0x34ce7c3c6b4c762663d087b2c6ffba30fc966d9bf98039eee98ad1722e79805309fbad1ea29c36dfe4f8f7baa87c5edf85e0d9f369fc62fe" | jq
```

# Changes

* Correct the OpenAPI spec

## How to test

Assuming you have a VSCode with TS working

1. Clone https://github.com/cowprotocol/cow-sdk & install
2. Add this under packages/order-book/scripts/whatever-name.ts

<details><summary> <code>whatever-name.ts</code> </summary>
<p>

```
import type { Trade } from '../src/generated'

const trades: Trade[] = [
  {
    blockNumber: 25042283,
    logIndex: 353,
    orderUid:
      '0x34ce7c3c6b4c762663d087b2c6ffba30fc966d9bf98039eee98ad1722e79805309fbad1ea29c36dfe4f8f7baa87c5edf85e0d9f369fc62fe',
    buyAmount: '11864026466720155',
    sellAmount: '216786455134611929',
    sellAmountBeforeFees: '216786455134611929',
    owner: '0x09fbad1ea29c36dfe4f8f7baa87c5edf85e0d9f3',
    buyToken: '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2',
    sellToken: '0x6810e776880c02933d47db1b9fc05908e5386b96',
    txHash: '0xa1f7df6ecc94ae23876a8285dfd63032f2592af4a174d231ed158b2d8703e01f',
    executedProtocolFees: [
      {
        policy: {
          priceImprovement: {
            factor: 0.5,
            maxVolumeFactor: 0.0098,
            quote: {
              sellAmount: '216786455134611929',
              buyAmount: '12235786988922214',
              fee: '4641802420121500',
            },
          },
        },
        amount: '0',
        token: '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2',
      },
      {
        policy: { volume: { factor: 0.0002 } },
        amount: '2373279949333',
        token: '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2',
      },
    ],
  },
]

void trades
```

</p>
</details> 

3. It should show compiler errors
4. Replace the commit hash of `swagger:codegen` in packages/order-book/package.json with `451344e17aa9623d0ea160064af19beae83c848a`
5. Run the codegen again, there should be no compilation errors

Demo:


https://github.com/user-attachments/assets/fd91e1f2-b825-4a50-915c-c22f82e2e7dc



<details><summary>Generated code before/after</summary>
<p>

Before:
```
export type FeePolicy = (Surplus | Volume | PriceImprovement);
```

After:
```
export type FeePolicy = ({
    surplus: Surplus;
} | {
    volume: Volume;
} | {
    priceImprovement: PriceImprovement;
});
```

</p>
</details> 