### PR TITLE
Detect packed-balance storage layout for balance overrides

### DIFF
--- a/crates/balance-overrides/src/balance/aave.rs
+++ b/crates/balance-overrides/src/balance/aave.rs
@@ -83,6 +83,14 @@ const RAY: U256 = U256::from_limbs([0x9fd0803ce8000000, 0x33b2e3c, 0, 0]);
 /// Source: <https://github.com/aave-dao/aave-v3-origin/blob/main/src/contracts/protocol/tokenization/base/IncentivizedERC20.sol>
 const USER_STATE_SLOT: u64 = 52;
 
+/// Small sentinel for verifying an aToken override, the counterpart to the
+/// detector's full-width sentinel. aTokens scale the balance and pack it into a
+/// `uint128` (see `pack_user_state`), so the full-width value would overflow
+/// the ray multiply and not fit the slot. This stays small enough to round-trip
+/// through both.
+pub(crate) const SENTINEL: [u8; 32] =
+    alloy_primitives::hex!("0x0000000000000000000000000000000000000000000000000102030405060708");
+
 /// Ray-division: `(a * RAY + b/2) / b`, round-half-up. Matches Aave's
 /// `WadRayMath.rayDiv` bit-for-bit so the scaled amount we write into
 /// storage equals the one Aave will itself compute during a subsequent

--- a/crates/balance-overrides/src/balance/mod.rs
+++ b/crates/balance-overrides/src/balance/mod.rs
@@ -103,6 +103,15 @@ pub(crate) enum Strategy {
         target_contract: Address,
         slot: B256,
     },
+    /// Like `DirectSlot`, but the balance is packed above lower-order fields in
+    /// the slot, so it must be written left-shifted by `shift_bits`. E.g. AUSD
+    /// stores `{ bool isFrozen; uint248 balance }` in one slot, putting the
+    /// balance in the high 248 bits, so `shift_bits == 8`.
+    PackedSlot {
+        target_contract: Address,
+        slot: B256,
+        shift_bits: u32,
+    },
     AaveV3AToken {
         target_contract: Address,
         pool: Address,
@@ -117,24 +126,34 @@ impl Strategy {
         holder: &Address,
         amount: &U256,
     ) -> AddressMap<AccountOverride> {
-        let (target_contract, key) = match self {
+        let (target_contract, key, value) = match self {
             Self::SolidityMapping {
                 target_contract,
                 map_slot,
             } => (
                 *target_contract,
                 mapping_slot_hash(holder, &map_slot.to_be_bytes()),
+                *amount,
             ),
             Self::SoladyMapping { target_contract } => {
                 let mut buf = [0; 32];
                 buf[0..20].copy_from_slice(holder.as_slice());
                 buf[28..32].copy_from_slice(&[0x87, 0xa2, 0x11, 0xa2]);
-                (*target_contract, keccak256(buf))
+                (*target_contract, keccak256(buf), *amount)
             }
             Self::DirectSlot {
                 target_contract,
                 slot,
-            } => (*target_contract, *slot),
+            } => (*target_contract, *slot, *amount),
+            Self::PackedSlot {
+                target_contract,
+                slot,
+                shift_bits,
+            } => match packed_value(*amount, *shift_bits) {
+                Some(value) => (*target_contract, *slot, value),
+                // Balance doesn't fit at this bit offset, nothing to override.
+                None => return AddressMap::default(),
+            },
             Self::AaveV3AToken {
                 target_contract,
                 pool,
@@ -158,7 +177,7 @@ impl Strategy {
         };
 
         let state_override = AccountOverride {
-            state_diff: Some(iter::once((key, B256::new(amount.to_be_bytes::<32>()))).collect()),
+            state_diff: Some(iter::once((key, B256::new(value.to_be_bytes::<32>()))).collect()),
             ..Default::default()
         };
 
@@ -169,7 +188,7 @@ impl Strategy {
     /// override for any given holder or if it only works for the original
     /// holder it was generated for.
     pub(crate) fn can_be_applied_to_any_holder(&self) -> bool {
-        !matches!(self, Self::DirectSlot { .. })
+        !matches!(self, Self::DirectSlot { .. } | Self::PackedSlot { .. })
     }
 }
 
@@ -207,6 +226,18 @@ impl PartialEq for Strategy {
                     slot: s2,
                 },
             ) => tc1 == tc2 && s1 == s2,
+            (
+                Self::PackedSlot {
+                    target_contract: tc1,
+                    slot: s1,
+                    shift_bits: sb1,
+                },
+                Self::PackedSlot {
+                    target_contract: tc2,
+                    slot: s2,
+                    shift_bits: sb2,
+                },
+            ) => tc1 == tc2 && s1 == s2 && sb1 == sb2,
             (
                 Self::AaveV3AToken {
                     target_contract: tc1,
@@ -437,6 +468,57 @@ impl Detector {
             }
         }
 
+        // Fallback for packed balances. The whole-slot overrides above read
+        // back shifted (so they never verify) when the balance is stored above
+        // lower-order fields in the same slot, e.g. AUSD packs
+        // `{ bool isFrozen; uint248 balance }`, so `balanceOf == slot >> 8`.
+        // Probe each candidate slot with a positional sentinel: if `balanceOf`
+        // returns a byte-shifted view of it, the slot holds the balance and we
+        // can write it pre-shifted.
+        let probe = U256::from(0x0102_0304_0506_0708_090a_0b0c_0d0e_0f10_u128);
+        for (contract, slot) in &storage_slots {
+            let probe_override = Strategy::DirectSlot {
+                target_contract: *contract,
+                slot: *slot,
+            }
+            .state_override(&holder, &probe)
+            .await;
+            if probe_override.is_empty() {
+                continue;
+            }
+            let observed = match ERC20::Instance::new(token, self.web3.provider.clone())
+                .balanceOf(holder)
+                .state(probe_override)
+                .call()
+                .await
+            {
+                Ok(balance) => balance,
+                Err(_) => continue,
+            };
+            let Some(shift_bits) = detect_byte_shift(probe, observed) else {
+                continue;
+            };
+            let candidate = Strategy::PackedSlot {
+                target_contract: *contract,
+                slot: *slot,
+                shift_bits,
+            };
+            if self
+                .verify_strategy(token, holder, &candidate)
+                .await
+                .is_ok()
+            {
+                tracing::debug!(
+                    ?token,
+                    ?holder,
+                    ?slot,
+                    shift_bits,
+                    "detected packed balance slot"
+                );
+                return Ok(candidate);
+            }
+        }
+
         tracing::debug!(
             "none of the SLOAD slots appear to be the balance slot for token {:?}",
             token
@@ -503,9 +585,58 @@ fn verified_balance_matches(strategy: &Strategy, balance: U256, test_balance: U2
     }
 }
 
+/// Left-shifts `amount` into a packed balance's bit position. Returns `None`
+/// if the shift would drop high bits (the balance doesn't fit at this offset).
+fn packed_value(amount: U256, shift_bits: u32) -> Option<U256> {
+    if shift_bits == 0 {
+        return Some(amount);
+    }
+    if shift_bits >= 256 || amount > (U256::MAX >> shift_bits as usize) {
+        return None;
+    }
+    Some(amount << shift_bits as usize)
+}
+
+/// If `observed` equals `probe` right-shifted by a whole number of bytes,
+/// returns that shift in bits (always `> 0`). Detects a balance packed above
+/// lower-order fields in the same slot, where `balanceOf` reads back
+/// `slot >> shift` (e.g. AUSD packs `isFrozen` in the low byte and keeps the
+/// balance in the high 248 bits, so `balanceOf == slot >> 8`).
+fn detect_byte_shift(probe: U256, observed: U256) -> Option<u32> {
+    (1..32u32)
+        .map(|bytes| bytes * 8)
+        .find(|&shift| probe >> shift as usize == observed)
+}
+
 #[cfg(test)]
 mod tests {
     use {super::*, alloy_primitives::address};
+
+    #[test]
+    fn packed_value_shifts_and_guards_overflow() {
+        assert_eq!(
+            packed_value(U256::from(1000u64), 0),
+            Some(U256::from(1000u64))
+        );
+        assert_eq!(
+            packed_value(U256::from(1000u64), 8),
+            Some(U256::from(1000u64) << 8usize),
+        );
+        // A balance that no longer fits once shifted is rejected.
+        assert_eq!(packed_value(U256::MAX, 8), None);
+    }
+
+    #[test]
+    fn detect_byte_shift_recognizes_packed_balance() {
+        let probe = U256::from(0x0102_0304_0506_0708_090a_0b0c_0d0e_0f10_u128);
+        // AUSD-style: isFrozen in the low byte, balance in the high bits.
+        assert_eq!(detect_byte_shift(probe, probe >> 8usize), Some(8));
+        assert_eq!(detect_byte_shift(probe, probe >> 24usize), Some(24));
+        // Shift 0 is the plain DirectSlot case, not a packed one.
+        assert_eq!(detect_byte_shift(probe, probe), None);
+        // Unrelated value is not a byte-shifted view of the probe.
+        assert_eq!(detect_byte_shift(probe, U256::from(0xdeadu64)), None);
+    }
 
     #[test]
     fn test_create_strategies_reverses_order() {

--- a/crates/balance-overrides/src/balance/mod.rs
+++ b/crates/balance-overrides/src/balance/mod.rs
@@ -23,6 +23,16 @@ use {
 /// https://github.com/Vectorized/solady/blob/main/src/tokens/ERC20.sol#L81
 const BALANCE_SLOT_SEED: &[u8] = &[0x87, 0xa2, 0x11, 0xa2];
 
+/// Distinct-byte value used both to verify a balance override (write it, expect
+/// `balanceOf` to return it) and to recover a packed balance's bit offset from
+/// how far `balanceOf` shifts it down (see `detect_byte_shift`). The bytes are
+/// distinct so the detected shift is unambiguous, and it is kept to 64 bits so
+/// it fits narrow balance types (e.g. `uint64`) without being masked during
+/// verification. The 64-bit width caps detectable shifts at 56 bits, which
+/// covers "small flag below the balance" packings like AUSD (`shift_bits ==
+/// 8`).
+const SENTINEL: u64 = 0x0102_0304_0506_0708;
+
 /// Used by Detector when there are multiple slots to increase the chances we
 /// find the correct storage slot quickly.
 ///
@@ -470,12 +480,9 @@ impl Detector {
 
         // Fallback for packed-balance tokens (see `Strategy::PackedSlot`): the
         // whole-slot overrides above read the balance back shifted and never
-        // verify, so recover the shift from how far `balanceOf` moves a probe.
-        //
-        // Probe bytes are all distinct (0x01..=0x10) so the shift is
-        // unambiguous; a repeating value (e.g. 0x1337...) aliases across shifts
-        // (`x >> 32 == x & 0xffff_ffff`) and would be mis-detected.
-        let probe = U256::from(0x0102_0304_0506_0708_090a_0b0c_0d0e_0f10_u128);
+        // verify, so recover the shift from how far `balanceOf` moves the
+        // sentinel.
+        let probe = U256::from(SENTINEL);
         for (contract, slot) in &storage_slots {
             let probe_override = Strategy::DirectSlot {
                 target_contract: *contract,
@@ -540,7 +547,7 @@ impl Detector {
         holder: Address,
         strategy: &Strategy,
     ) -> Result<(), DetectionError<TransportErrorKind>> {
-        let test_balance = U256::from(0x1337_1337_1337_1337_u64);
+        let test_balance = U256::from(SENTINEL);
 
         let overrides = strategy.state_override(&holder, &test_balance).await;
         if overrides.is_empty() {
@@ -602,6 +609,11 @@ fn packed_value(amount: U256, shift_bits: usize) -> Option<U256> {
 /// (see `Strategy::PackedSlot`). `probe` must have distinct bytes for the match
 /// to be unique.
 fn detect_byte_shift(probe: U256, observed: U256) -> Option<usize> {
+    // A zero readback is never a balance shifted into place, and would
+    // otherwise match a shift that pushes the whole probe out of the slot.
+    if observed == U256::ZERO {
+        return None;
+    }
     (1..32usize)
         .map(|bytes| bytes * 8)
         .find(|&shift| probe >> shift == observed)
@@ -627,12 +639,14 @@ mod tests {
 
     #[test]
     fn detect_byte_shift_recognizes_packed_balance() {
-        let probe = U256::from(0x0102_0304_0506_0708_090a_0b0c_0d0e_0f10_u128);
+        let probe = U256::from(SENTINEL);
         // AUSD-style: isFrozen in the low byte, balance in the high bits.
         assert_eq!(detect_byte_shift(probe, probe >> 8usize), Some(8));
         assert_eq!(detect_byte_shift(probe, probe >> 24usize), Some(24));
         // Shift 0 is the plain DirectSlot case, not a packed one.
         assert_eq!(detect_byte_shift(probe, probe), None);
+        // A zero readback is never a valid packed balance.
+        assert_eq!(detect_byte_shift(probe, U256::ZERO), None);
         // Unrelated value is not a byte-shifted view of the probe.
         assert_eq!(detect_byte_shift(probe, U256::from(0xdeadu64)), None);
     }

--- a/crates/balance-overrides/src/balance/mod.rs
+++ b/crates/balance-overrides/src/balance/mod.rs
@@ -110,7 +110,7 @@ pub(crate) enum Strategy {
     PackedSlot {
         target_contract: Address,
         slot: B256,
-        shift_bits: u8,
+        shift_bits: usize,
     },
     AaveV3AToken {
         target_contract: Address,
@@ -587,15 +587,14 @@ fn verified_balance_matches(strategy: &Strategy, balance: U256, test_balance: U2
 
 /// Left-shifts `amount` into a packed balance's bit position. Returns `None`
 /// if the shift would drop high bits (the balance doesn't fit at this offset).
-fn packed_value(amount: U256, shift_bits: u8) -> Option<U256> {
+fn packed_value(amount: U256, shift_bits: usize) -> Option<U256> {
     if shift_bits == 0 {
         return Some(amount);
     }
-    let shift = usize::from(shift_bits);
-    if amount > (U256::MAX >> shift) {
+    if amount > (U256::MAX >> shift_bits) {
         return None;
     }
-    Some(amount << shift)
+    Some(amount << shift_bits)
 }
 
 /// If `observed` equals `probe` right-shifted by a whole number of bytes,
@@ -603,10 +602,10 @@ fn packed_value(amount: U256, shift_bits: u8) -> Option<U256> {
 /// lower-order fields in the same slot, where `balanceOf` reads back
 /// `slot >> shift` (e.g. AUSD packs `isFrozen` in the low byte and keeps the
 /// balance in the high 248 bits, so `balanceOf == slot >> 8`).
-fn detect_byte_shift(probe: U256, observed: U256) -> Option<u8> {
-    (1..32u8)
+fn detect_byte_shift(probe: U256, observed: U256) -> Option<usize> {
+    (1..32usize)
         .map(|bytes| bytes * 8)
-        .find(|&shift| probe >> usize::from(shift) == observed)
+        .find(|&shift| probe >> shift == observed)
 }
 
 #[cfg(test)]

--- a/crates/balance-overrides/src/balance/mod.rs
+++ b/crates/balance-overrides/src/balance/mod.rs
@@ -568,13 +568,10 @@ fn packed_value(amount: U256, shift_bits: usize) -> Option<U256> {
 /// the shift, and a readback that is not a slice means the slot is not the
 /// balance. Returns the left-shift in bits (0 for an unpacked balance).
 fn detect_shift(observed: U256) -> Option<usize> {
-    // A zero readback means our write never reached `balanceOf` (wrong slot).
-    if observed == U256::ZERO {
-        return None;
-    }
     // Strip leading zero bytes to get the field's bytes. The field is a slice of
     // the all-non-zero sentinel, so its top byte is non-zero and trimming never
-    // eats into it.
+    // eats into it. An all-zero readback has no non-zero byte (the write never
+    // reached `balanceOf`), so `position` returns None and we bail.
     let bytes = observed.to_be_bytes::<32>();
     let needle = &bytes[bytes.iter().position(|&b| b != 0)?..];
     let start = SENTINEL.windows(needle.len()).position(|w| w == needle)?;

--- a/crates/balance-overrides/src/balance/mod.rs
+++ b/crates/balance-overrides/src/balance/mod.rs
@@ -110,7 +110,7 @@ pub(crate) enum Strategy {
     PackedSlot {
         target_contract: Address,
         slot: B256,
-        shift_bits: u32,
+        shift_bits: u8,
     },
     AaveV3AToken {
         target_contract: Address,
@@ -587,14 +587,15 @@ fn verified_balance_matches(strategy: &Strategy, balance: U256, test_balance: U2
 
 /// Left-shifts `amount` into a packed balance's bit position. Returns `None`
 /// if the shift would drop high bits (the balance doesn't fit at this offset).
-fn packed_value(amount: U256, shift_bits: u32) -> Option<U256> {
+fn packed_value(amount: U256, shift_bits: u8) -> Option<U256> {
     if shift_bits == 0 {
         return Some(amount);
     }
-    if shift_bits >= 256 || amount > (U256::MAX >> shift_bits as usize) {
+    let shift = usize::from(shift_bits);
+    if amount > (U256::MAX >> shift) {
         return None;
     }
-    Some(amount << shift_bits as usize)
+    Some(amount << shift)
 }
 
 /// If `observed` equals `probe` right-shifted by a whole number of bytes,
@@ -602,10 +603,10 @@ fn packed_value(amount: U256, shift_bits: u32) -> Option<U256> {
 /// lower-order fields in the same slot, where `balanceOf` reads back
 /// `slot >> shift` (e.g. AUSD packs `isFrozen` in the low byte and keeps the
 /// balance in the high 248 bits, so `balanceOf == slot >> 8`).
-fn detect_byte_shift(probe: U256, observed: U256) -> Option<u32> {
-    (1..32u32)
+fn detect_byte_shift(probe: U256, observed: U256) -> Option<u8> {
+    (1..32u8)
         .map(|bytes| bytes * 8)
-        .find(|&shift| probe >> shift as usize == observed)
+        .find(|&shift| probe >> usize::from(shift) == observed)
 }
 
 #[cfg(test)]

--- a/crates/balance-overrides/src/balance/mod.rs
+++ b/crates/balance-overrides/src/balance/mod.rs
@@ -32,16 +32,8 @@ const BALANCE_SLOT_SEED: &[u8] = &[0x87, 0xa2, 0x11, 0xa2];
 /// the slot is not the balance. The full 32 bytes cover any byte-aligned shift,
 /// including narrow fields: a `uint96` balance (UNI, COMP) reads back as the
 /// low-byte suffix and resolves to `shift_bits == 0`.
-const SENTINEL: [u8; 32] = [
-    0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10,
-    0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18, 0x19, 0x1a, 0x1b, 0x1c, 0x1d, 0x1e, 0x1f, 0x20,
-];
-
-/// Small probe for the `AaveV3AToken` path. aTokens are never packed and store
-/// their scaled balance in a `uint128` after ray-scaling, so the full
-/// [`SENTINEL`] would overflow the ray multiply and not fit the slot. We probe
-/// with this small value and check the round-trip instead.
-const AAVE_PROBE: U256 = U256::from_limbs([0x0102_0304_0506_0708, 0, 0, 0]);
+const SENTINEL: [u8; 32] =
+    alloy_primitives::hex!("0x0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20");
 
 /// Used by Detector when there are multiple slots to increase the chances we
 /// find the correct storage slot quickly.
@@ -193,9 +185,17 @@ impl Strategy {
             }
         };
 
-        // Pack the balance into its slot position. `None` means it doesn't fit
-        // at this bit offset, so there's nothing to override.
-        let Some(value) = packed_value(*amount, shift_bits) else {
+        // Pack the balance into its slot position. `checked_shl` returns `None`
+        // only when the balance is too large to fit above the lower-order
+        // fields, which a real balance never is, so log it if it ever happens.
+        let Some(value) = amount.checked_shl(shift_bits) else {
+            tracing::warn!(
+                ?target_contract,
+                ?holder,
+                %amount,
+                shift_bits,
+                "balance does not fit packed slot, skipping override",
+            );
             return AddressMap::default();
         };
 
@@ -489,14 +489,14 @@ impl Detector {
         Err(DetectionError::NotFound)
     }
 
-    /// Verifies that a strategy controls the balance by writing a probe to its
-    /// slot and reading `balanceOf` back, returning the confirmed strategy.
+    /// Verifies that a strategy controls the balance by writing a sentinel to
+    /// its slot and reading `balanceOf` back, returning the confirmed strategy.
     ///
     /// Generic strategies use the full [`SENTINEL`]: `detect_shift` finds the
     /// readback as a byte-slice of it, which verifies the slot and recovers the
     /// packing shift (0 when unpacked) from the same readback, no extra RPC.
     /// The `AaveV3AToken` variant never packs and stores its scaled balance
-    /// in a `uint128`, so it uses the small [`AAVE_PROBE`] and accepts a
+    /// in a `uint128`, so it uses the small [`aave::SENTINEL`] and accepts a
     /// round-trip within 1 wei of Aave's ray rounding.
     async fn verify_strategy(
         &self,
@@ -505,13 +505,13 @@ impl Detector {
         strategy: Strategy,
     ) -> Result<Strategy, DetectionError<TransportErrorKind>> {
         let is_aave = matches!(strategy, Strategy::AaveV3AToken { .. });
-        let probe = if is_aave {
-            AAVE_PROBE
+        let sentinel = if is_aave {
+            U256::from_be_bytes(aave::SENTINEL)
         } else {
             U256::from_be_bytes(SENTINEL)
         };
 
-        let overrides = strategy.state_override(&holder, &probe).await;
+        let overrides = strategy.state_override(&holder, &sentinel).await;
         if overrides.is_empty() {
             return Err(DetectionError::NotFound);
         }
@@ -530,7 +530,7 @@ impl Detector {
         if is_aave {
             // Aave's ray-div / ray-mul round-trip is not identity, so allow 1
             // wei of difference.
-            return (balance.abs_diff(probe) <= U256::ONE)
+            return (balance.abs_diff(sentinel) <= U256::ONE)
                 .then_some(strategy)
                 .ok_or(DetectionError::NotFound);
         }
@@ -554,14 +554,6 @@ impl std::fmt::Debug for Detector {
     }
 }
 
-/// Left-shifts `amount` into a packed balance's bit position. Returns `None` if
-/// the balance doesn't fit at this offset. Unlike `u64::checked_shl`, alloy's
-/// `checked_shl` returns `None` exactly when the shifted-out bits are non-zero,
-/// which is precisely the "doesn't fit above the lower-order fields" check.
-fn packed_value(amount: U256, shift_bits: usize) -> Option<U256> {
-    amount.checked_shl(shift_bits)
-}
-
 /// Recovers the packing shift by locating the `balanceOf` readback as a
 /// contiguous byte-slice of [`SENTINEL`]. The sentinel's bytes are distinct and
 /// non-zero, so the slice is unique: the number of bytes sitting below it is
@@ -575,26 +567,12 @@ fn detect_shift(observed: U256) -> Option<usize> {
     let bytes = observed.to_be_bytes::<32>();
     let needle = &bytes[bytes.iter().position(|&b| b != 0)?..];
     let start = SENTINEL.windows(needle.len()).position(|w| w == needle)?;
-    Some((SENTINEL.len() - start - needle.len()) * 8)
+    Some(SENTINEL.len().checked_sub(start + needle.len())? * 8)
 }
 
 #[cfg(test)]
 mod tests {
     use {super::*, alloy_primitives::address};
-
-    #[test]
-    fn packed_value_shifts_and_guards_overflow() {
-        assert_eq!(
-            packed_value(U256::from(1000u64), 0),
-            Some(U256::from(1000u64))
-        );
-        assert_eq!(
-            packed_value(U256::from(1000u64), 8),
-            Some(U256::from(1000u64) << 8usize),
-        );
-        // A balance that no longer fits once shifted is rejected.
-        assert_eq!(packed_value(U256::MAX, 8), None);
-    }
 
     #[test]
     fn detect_shift_locates_packed_balance() {
@@ -609,6 +587,10 @@ mod tests {
         // suffix, still resolve to shift 0.
         let mask96 = (U256::from(1u64) << 96) - U256::from(1u64);
         assert_eq!(detect_shift(sentinel & mask96), Some(0));
+        // Middle field: a 96-bit balance at bit offset 8 (lower-order fields
+        // below, more above). balanceOf reads it shifted down to the low bits,
+        // so the readback is `(slot >> 8) & mask`, recovered as shift 8.
+        assert_eq!(detect_shift((sentinel >> 8usize) & mask96), Some(8));
         // A zero readback means the write never reached `balanceOf`.
         assert_eq!(detect_shift(U256::ZERO), None);
         // Unrelated value is not a byte-slice of the sentinel.

--- a/crates/balance-overrides/src/balance/mod.rs
+++ b/crates/balance-overrides/src/balance/mod.rs
@@ -23,15 +23,25 @@ use {
 /// https://github.com/Vectorized/solady/blob/main/src/tokens/ERC20.sol#L81
 const BALANCE_SLOT_SEED: &[u8] = &[0x87, 0xa2, 0x11, 0xa2];
 
-/// Distinct-byte value used both to verify a balance override (write it, expect
-/// `balanceOf` to return it) and to recover a packed balance's bit offset from
-/// how far `balanceOf` shifts it down (see `detect_byte_shift`). The bytes are
-/// distinct so the detected shift is unambiguous. It is kept to 64 bits so it
-/// fits narrow balance fields (e.g. UNI and COMP store balances as `uint96`)
-/// without being masked during verification, which would otherwise reject those
-/// tokens. The 64-bit width caps detectable shifts at 56 bits, which covers
-/// "small flag below the balance" packings like AUSD (`shift_bits == 8`).
-const SENTINEL: u64 = 0x0102_0304_0506_0708;
+/// Distinct-byte sentinel written to a candidate balance slot during
+/// verification. Every byte is distinct and non-zero, so the value `balanceOf`
+/// reads back is a unique contiguous byte-slice of it (see `detect_shift`). Its
+/// position gives the packing shift for a balance stored above lower-order
+/// fields, e.g. AUSD packs `isFrozen` in the low byte, so the balance is the
+/// high 248 bits and `shift_bits == 8`. A readback that is not a slice means
+/// the slot is not the balance. The full 32 bytes cover any byte-aligned shift,
+/// including narrow fields: a `uint96` balance (UNI, COMP) reads back as the
+/// low-byte suffix and resolves to `shift_bits == 0`.
+const SENTINEL: [u8; 32] = [
+    0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10,
+    0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18, 0x19, 0x1a, 0x1b, 0x1c, 0x1d, 0x1e, 0x1f, 0x20,
+];
+
+/// Small probe for the `AaveV3AToken` path. aTokens are never packed and store
+/// their scaled balance in a `uint128` after ray-scaling, so the full
+/// [`SENTINEL`] would overflow the ray multiply and not fit the slot. We probe
+/// with this small value and check the round-trip instead.
+const AAVE_PROBE: U256 = U256::from_limbs([0x0102_0304_0506_0708, 0, 0, 0]);
 
 /// Used by Detector when there are multiple slots to increase the chances we
 /// find the correct storage slot quickly.
@@ -105,9 +115,8 @@ pub struct BalanceOverrideRequest {
 /// `{ bool isFrozen; uint248 balance }` in one slot, so the balance is the high
 /// 248 bits and `shift_bits == 8`. It is `0` for the common unpacked case.
 ///
-/// The `AaveV3AToken` variant owns a cloned `Web3` handle so it can compute
-/// the override fully autonomously — no external web3 reference needs to be
-/// threaded through.
+/// The `AaveV3AToken` variant owns a cloned `Web3` handle, so it computes its
+/// override without an external web3 reference threaded through.
 #[derive(Clone, Debug)]
 pub(crate) enum Strategy {
     SolidityMapping {
@@ -480,25 +489,29 @@ impl Detector {
         Err(DetectionError::NotFound)
     }
 
-    /// Verifies that a strategy controls the balance by writing the sentinel to
-    /// its slot and reading `balanceOf` back, returning the confirmed strategy.
+    /// Verifies that a strategy controls the balance by writing a probe to its
+    /// slot and reading `balanceOf` back, returning the confirmed strategy.
     ///
-    /// If the sentinel reads back unshifted the strategy is correct as-is. If
-    /// it reads back byte-shifted, the balance is packed above lower-order
-    /// fields in the slot (e.g. AUSD packs `isFrozen` in the low byte, so
-    /// the balance is the high 248 bits), and the detected shift is applied
-    /// to the returned strategy from the same readback — no extra RPC. The
-    /// `AaveV3AToken` variant is never packed and tolerates 1 wei of Aave
-    /// ray-rounding difference.
+    /// Generic strategies use the full [`SENTINEL`]: `detect_shift` finds the
+    /// readback as a byte-slice of it, which verifies the slot and recovers the
+    /// packing shift (0 when unpacked) from the same readback, no extra RPC.
+    /// The `AaveV3AToken` variant never packs and stores its scaled balance
+    /// in a `uint128`, so it uses the small [`AAVE_PROBE`] and accepts a
+    /// round-trip within 1 wei of Aave's ray rounding.
     async fn verify_strategy(
         &self,
         token: Address,
         holder: Address,
         strategy: Strategy,
     ) -> Result<Strategy, DetectionError<TransportErrorKind>> {
-        let test_balance = U256::from(SENTINEL);
+        let is_aave = matches!(strategy, Strategy::AaveV3AToken { .. });
+        let probe = if is_aave {
+            AAVE_PROBE
+        } else {
+            U256::from_be_bytes(SENTINEL)
+        };
 
-        let overrides = strategy.state_override(&holder, &test_balance).await;
+        let overrides = strategy.state_override(&holder, &probe).await;
         if overrides.is_empty() {
             return Err(DetectionError::NotFound);
         }
@@ -514,18 +527,18 @@ impl Detector {
                 )))
             })?;
 
-        // The slot holds the balance unshifted.
-        if verified_balance_matches(&strategy, balance, test_balance) {
-            return Ok(strategy);
+        if is_aave {
+            // Aave's ray-div / ray-mul round-trip is not identity, so allow 1
+            // wei of difference.
+            return (balance.abs_diff(probe) <= U256::ONE)
+                .then_some(strategy)
+                .ok_or(DetectionError::NotFound);
         }
-        // Aave is never packed, so a mismatch there is a genuine miss.
-        if matches!(strategy, Strategy::AaveV3AToken { .. }) {
-            return Err(DetectionError::NotFound);
-        }
-        // Otherwise the balance may be packed above lower-order fields, so
-        // `balanceOf` reads the sentinel back byte-shifted. Recover the shift
-        // from the same readback and apply it.
-        match detect_byte_shift(test_balance, balance) {
+
+        // Locate the readback as a contiguous byte-slice of the sentinel. Its
+        // position gives the packing shift, 0 when unpacked. A non-match means
+        // this slot is not the balance.
+        match detect_shift(balance) {
             Some(shift_bits) => Ok(strategy.with_shift(shift_bits)),
             None => Err(DetectionError::NotFound),
         }
@@ -541,17 +554,6 @@ impl std::fmt::Debug for Detector {
     }
 }
 
-/// Is the `balance` returned by `balanceOf` after applying the override
-/// consistent with the `test_balance` we wrote? For `AaveV3AToken` we tolerate
-/// 1 wei of difference because Aave's ray-div / ray-mul round-trip is not
-/// identity by construction; every other strategy must match exactly.
-fn verified_balance_matches(strategy: &Strategy, balance: U256, test_balance: U256) -> bool {
-    match strategy {
-        Strategy::AaveV3AToken { .. } => balance.abs_diff(test_balance) <= U256::ONE,
-        _ => balance == test_balance,
-    }
-}
-
 /// Left-shifts `amount` into a packed balance's bit position. Returns `None` if
 /// the balance doesn't fit at this offset. Unlike `u64::checked_shl`, alloy's
 /// `checked_shl` returns `None` exactly when the shifted-out bits are non-zero,
@@ -560,20 +562,23 @@ fn packed_value(amount: U256, shift_bits: usize) -> Option<U256> {
     amount.checked_shl(shift_bits)
 }
 
-/// Returns the byte-aligned left-shift for which `probe >> shift == observed`,
-/// i.e. the bit offset of a balance packed above lower-order fields in its slot
-/// (e.g. AUSD's high-248-bit balance gives a shift of 8). `probe` must have
-/// distinct bytes for the match to be unique.
-fn detect_byte_shift(probe: U256, observed: U256) -> Option<usize> {
-    // A zero readback means our write never reached `balanceOf` (wrong slot),
-    // which is not a shift — and would otherwise match a shift that pushes the
-    // whole probe out of the slot.
+/// Recovers the packing shift by locating the `balanceOf` readback as a
+/// contiguous byte-slice of [`SENTINEL`]. The sentinel's bytes are distinct and
+/// non-zero, so the slice is unique: the number of bytes sitting below it is
+/// the shift, and a readback that is not a slice means the slot is not the
+/// balance. Returns the left-shift in bits (0 for an unpacked balance).
+fn detect_shift(observed: U256) -> Option<usize> {
+    // A zero readback means our write never reached `balanceOf` (wrong slot).
     if observed == U256::ZERO {
         return None;
     }
-    (1..32usize)
-        .map(|bytes| bytes * 8)
-        .find(|&shift| probe >> shift == observed)
+    // Strip leading zero bytes to get the field's bytes. The field is a slice of
+    // the all-non-zero sentinel, so its top byte is non-zero and trimming never
+    // eats into it.
+    let bytes = observed.to_be_bytes::<32>();
+    let needle = &bytes[bytes.iter().position(|&b| b != 0)?..];
+    let start = SENTINEL.windows(needle.len()).position(|w| w == needle)?;
+    Some((SENTINEL.len() - start - needle.len()) * 8)
 }
 
 #[cfg(test)]
@@ -595,17 +600,22 @@ mod tests {
     }
 
     #[test]
-    fn detect_byte_shift_recognizes_packed_balance() {
-        let probe = U256::from(SENTINEL);
-        // AUSD-style: isFrozen in the low byte, balance in the high bits.
-        assert_eq!(detect_byte_shift(probe, probe >> 8usize), Some(8));
-        assert_eq!(detect_byte_shift(probe, probe >> 24usize), Some(24));
-        // Shift 0 is the plain DirectSlot case, not a packed one.
-        assert_eq!(detect_byte_shift(probe, probe), None);
-        // A zero readback is never a valid packed balance.
-        assert_eq!(detect_byte_shift(probe, U256::ZERO), None);
-        // Unrelated value is not a byte-shifted view of the probe.
-        assert_eq!(detect_byte_shift(probe, U256::from(0xdeadu64)), None);
+    fn detect_shift_locates_packed_balance() {
+        let sentinel = U256::from_be_bytes(SENTINEL);
+        // Unpacked: the full sentinel reads back as-is.
+        assert_eq!(detect_shift(sentinel), Some(0));
+        // AUSD-style: isFrozen in the low byte, balance in the high 248 bits, so
+        // `balanceOf == slot >> 8`.
+        assert_eq!(detect_shift(sentinel >> 8usize), Some(8));
+        assert_eq!(detect_shift(sentinel >> 24usize), Some(24));
+        // Narrow uint96 field (UNI/COMP): the low 12 bytes, the sentinel's
+        // suffix, still resolve to shift 0.
+        let mask96 = (U256::from(1u64) << 96) - U256::from(1u64);
+        assert_eq!(detect_shift(sentinel & mask96), Some(0));
+        // A zero readback means the write never reached `balanceOf`.
+        assert_eq!(detect_shift(U256::ZERO), None);
+        // Unrelated value is not a byte-slice of the sentinel.
+        assert_eq!(detect_shift(U256::from(0xdeadu64)), None);
     }
 
     #[test]

--- a/crates/balance-overrides/src/balance/mod.rs
+++ b/crates/balance-overrides/src/balance/mod.rs
@@ -880,4 +880,34 @@ mod tests {
             }
         );
     }
+
+    // AUSD packs `{ bool isFrozen; uint248 balance }` into one slot, so the
+    // balance is the high 248 bits and `balanceOf == slot >> 8`. The detector
+    // must fall back to a `PackedSlot` with an 8-bit shift. Requires an
+    // avalanche node (set the node URL `Web3::new_from_env` reads).
+    #[ignore]
+    #[tokio::test]
+    async fn detects_packed_balance_slot_avalanche() {
+        use crate::detector::DEFAULT_VERIFICATION_TIMEOUT;
+
+        let ausd = address!("00000000efe302beaa2b3e6e1b18d08d69a9012a");
+        let detector = Detector::new(Web3::new_from_env(), 60, DEFAULT_VERIFICATION_TIMEOUT, 100);
+
+        let strategy = detector
+            .detect(ausd, Address::with_last_byte(1))
+            .await
+            .unwrap();
+
+        match strategy {
+            Strategy::PackedSlot {
+                target_contract,
+                shift_bits,
+                ..
+            } => {
+                assert_eq!(target_contract, ausd);
+                assert_eq!(shift_bits, 8);
+            }
+            other => panic!("expected PackedSlot, got {other:?}"),
+        }
+    }
 }

--- a/crates/balance-overrides/src/balance/mod.rs
+++ b/crates/balance-overrides/src/balance/mod.rs
@@ -468,13 +468,13 @@ impl Detector {
             }
         }
 
-        // Fallback for packed balances. The whole-slot overrides above read
-        // back shifted (so they never verify) when the balance is stored above
-        // lower-order fields in the same slot, e.g. AUSD packs
-        // `{ bool isFrozen; uint248 balance }`, so `balanceOf == slot >> 8`.
-        // Probe each candidate slot with a positional sentinel: if `balanceOf`
-        // returns a byte-shifted view of it, the slot holds the balance and we
-        // can write it pre-shifted.
+        // Fallback for packed-balance tokens (see `Strategy::PackedSlot`): the
+        // whole-slot overrides above read the balance back shifted and never
+        // verify, so recover the shift from how far `balanceOf` moves a probe.
+        //
+        // Probe bytes are all distinct (0x01..=0x10) so the shift is
+        // unambiguous; a repeating value (e.g. 0x1337...) aliases across shifts
+        // (`x >> 32 == x & 0xffff_ffff`) and would be mis-detected.
         let probe = U256::from(0x0102_0304_0506_0708_090a_0b0c_0d0e_0f10_u128);
         for (contract, slot) in &storage_slots {
             let probe_override = Strategy::DirectSlot {
@@ -597,11 +597,10 @@ fn packed_value(amount: U256, shift_bits: usize) -> Option<U256> {
     Some(amount << shift_bits)
 }
 
-/// If `observed` equals `probe` right-shifted by a whole number of bytes,
-/// returns that shift in bits (always `> 0`). Detects a balance packed above
-/// lower-order fields in the same slot, where `balanceOf` reads back
-/// `slot >> shift` (e.g. AUSD packs `isFrozen` in the low byte and keeps the
-/// balance in the high 248 bits, so `balanceOf == slot >> 8`).
+/// Returns the byte-aligned shift for which `probe >> shift == observed`, i.e.
+/// the bit offset of a balance packed above lower-order fields in its slot
+/// (see `Strategy::PackedSlot`). `probe` must have distinct bytes for the match
+/// to be unique.
 fn detect_byte_shift(probe: U256, observed: U256) -> Option<usize> {
     (1..32usize)
         .map(|bytes| bytes * 8)

--- a/crates/balance-overrides/src/balance/mod.rs
+++ b/crates/balance-overrides/src/balance/mod.rs
@@ -26,11 +26,11 @@ const BALANCE_SLOT_SEED: &[u8] = &[0x87, 0xa2, 0x11, 0xa2];
 /// Distinct-byte value used both to verify a balance override (write it, expect
 /// `balanceOf` to return it) and to recover a packed balance's bit offset from
 /// how far `balanceOf` shifts it down (see `detect_byte_shift`). The bytes are
-/// distinct so the detected shift is unambiguous, and it is kept to 64 bits so
-/// it fits narrow balance types (e.g. `uint64`) without being masked during
-/// verification. The 64-bit width caps detectable shifts at 56 bits, which
-/// covers "small flag below the balance" packings like AUSD (`shift_bits ==
-/// 8`).
+/// distinct so the detected shift is unambiguous. It is kept to 64 bits so it
+/// fits narrow balance fields (e.g. UNI and COMP store balances as `uint96`)
+/// without being masked during verification, which would otherwise reject those
+/// tokens. The 64-bit width caps detectable shifts at 56 bits, which covers
+/// "small flag below the balance" packings like AUSD (`shift_bits == 8`).
 const SENTINEL: u64 = 0x0102_0304_0506_0708;
 
 /// Used by Detector when there are multiple slots to increase the chances we
@@ -67,15 +67,18 @@ pub(crate) fn find_plausible_strategies_for_slots(
             heuristic_strategies.push(Strategy::SolidityMapping {
                 target_contract: *contract,
                 map_slot: U256::from(map_slot_index),
+                shift_bits: 0,
             });
         } else if *slot == solady_slot {
             heuristic_strategies.push(Strategy::SoladyMapping {
                 target_contract: *contract,
+                shift_bits: 0,
             });
         } else {
             fallback_strategies.push(Strategy::DirectSlot {
                 target_contract: *contract,
                 slot: *slot,
+                shift_bits: 0,
             });
         };
     }
@@ -97,6 +100,11 @@ pub struct BalanceOverrideRequest {
 
 /// Resolved balance override strategy.
 ///
+/// `shift_bits` is how far the balance is left-shifted within its slot, for
+/// tokens that pack the balance above lower-order fields. E.g. AUSD stores
+/// `{ bool isFrozen; uint248 balance }` in one slot, so the balance is the high
+/// 248 bits and `shift_bits == 8`. It is `0` for the common unpacked case.
+///
 /// The `AaveV3AToken` variant owns a cloned `Web3` handle so it can compute
 /// the override fully autonomously — no external web3 reference needs to be
 /// threaded through.
@@ -105,19 +113,13 @@ pub(crate) enum Strategy {
     SolidityMapping {
         target_contract: Address,
         map_slot: U256,
+        shift_bits: usize,
     },
     SoladyMapping {
         target_contract: Address,
+        shift_bits: usize,
     },
     DirectSlot {
-        target_contract: Address,
-        slot: B256,
-    },
-    /// Like `DirectSlot`, but the balance is packed above lower-order fields in
-    /// the slot, so it must be written left-shifted by `shift_bits`. E.g. AUSD
-    /// stores `{ bool isFrozen; uint248 balance }` in one slot, putting the
-    /// balance in the high 248 bits, so `shift_bits == 8`.
-    PackedSlot {
         target_contract: Address,
         slot: B256,
         shift_bits: usize,
@@ -136,34 +138,30 @@ impl Strategy {
         holder: &Address,
         amount: &U256,
     ) -> AddressMap<AccountOverride> {
-        let (target_contract, key, value) = match self {
+        let (target_contract, key, shift_bits) = match self {
             Self::SolidityMapping {
                 target_contract,
                 map_slot,
+                shift_bits,
             } => (
                 *target_contract,
                 mapping_slot_hash(holder, &map_slot.to_be_bytes()),
-                *amount,
+                *shift_bits,
             ),
-            Self::SoladyMapping { target_contract } => {
+            Self::SoladyMapping {
+                target_contract,
+                shift_bits,
+            } => {
                 let mut buf = [0; 32];
                 buf[0..20].copy_from_slice(holder.as_slice());
                 buf[28..32].copy_from_slice(&[0x87, 0xa2, 0x11, 0xa2]);
-                (*target_contract, keccak256(buf), *amount)
+                (*target_contract, keccak256(buf), *shift_bits)
             }
             Self::DirectSlot {
                 target_contract,
                 slot,
-            } => (*target_contract, *slot, *amount),
-            Self::PackedSlot {
-                target_contract,
-                slot,
                 shift_bits,
-            } => match packed_value(*amount, *shift_bits) {
-                Some(value) => (*target_contract, *slot, value),
-                // Balance doesn't fit at this bit offset, nothing to override.
-                None => return AddressMap::default(),
-            },
+            } => (*target_contract, *slot, *shift_bits),
             Self::AaveV3AToken {
                 target_contract,
                 pool,
@@ -186,6 +184,12 @@ impl Strategy {
             }
         };
 
+        // Pack the balance into its slot position. `None` means it doesn't fit
+        // at this bit offset, so there's nothing to override.
+        let Some(value) = packed_value(*amount, shift_bits) else {
+            return AddressMap::default();
+        };
+
         let state_override = AccountOverride {
             state_diff: Some(iter::once((key, B256::new(value.to_be_bytes::<32>()))).collect()),
             ..Default::default()
@@ -198,7 +202,19 @@ impl Strategy {
     /// override for any given holder or if it only works for the original
     /// holder it was generated for.
     pub(crate) fn can_be_applied_to_any_holder(&self) -> bool {
-        !matches!(self, Self::DirectSlot { .. } | Self::PackedSlot { .. })
+        !matches!(self, Self::DirectSlot { .. })
+    }
+
+    /// Sets the packing shift on a balance strategy. No-op for `AaveV3AToken`,
+    /// which is never packed.
+    fn with_shift(mut self, shift_bits: usize) -> Self {
+        match &mut self {
+            Self::SolidityMapping { shift_bits: s, .. }
+            | Self::SoladyMapping { shift_bits: s, .. }
+            | Self::DirectSlot { shift_bits: s, .. } => *s = shift_bits,
+            Self::AaveV3AToken { .. } => {}
+        }
+        self
     }
 }
 
@@ -212,37 +228,31 @@ impl PartialEq for Strategy {
                 Self::SolidityMapping {
                     target_contract: tc1,
                     map_slot: ms1,
+                    shift_bits: sb1,
                 },
                 Self::SolidityMapping {
                     target_contract: tc2,
                     map_slot: ms2,
+                    shift_bits: sb2,
                 },
-            ) => tc1 == tc2 && ms1 == ms2,
+            ) => tc1 == tc2 && ms1 == ms2 && sb1 == sb2,
             (
                 Self::SoladyMapping {
                     target_contract: tc1,
+                    shift_bits: sb1,
                 },
                 Self::SoladyMapping {
                     target_contract: tc2,
+                    shift_bits: sb2,
                 },
-            ) => tc1 == tc2,
+            ) => tc1 == tc2 && sb1 == sb2,
             (
                 Self::DirectSlot {
-                    target_contract: tc1,
-                    slot: s1,
-                },
-                Self::DirectSlot {
-                    target_contract: tc2,
-                    slot: s2,
-                },
-            ) => tc1 == tc2 && s1 == s2,
-            (
-                Self::PackedSlot {
                     target_contract: tc1,
                     slot: s1,
                     shift_bits: sb1,
                 },
-                Self::PackedSlot {
+                Self::DirectSlot {
                     target_contract: tc2,
                     slot: s2,
                     shift_bits: sb2,
@@ -368,13 +378,9 @@ impl Detector {
                 underlying,
                 web3: self.web3.clone(),
             };
-            if self
-                .verify_strategy(token, holder, &candidate)
-                .await
-                .is_ok()
-            {
+            if let Ok(resolved) = self.verify_strategy(token, holder, candidate).await {
                 tracing::debug!(?token, "detected Aave v3 aToken");
-                return Ok(candidate);
+                return Ok(resolved);
             }
             tracing::debug!(
                 ?token,
@@ -415,22 +421,10 @@ impl Detector {
         let strategies =
             find_plausible_strategies_for_slots(&storage_slots, &holder, self.probing_depth.into());
 
-        if strategies.len() == 1 {
-            let slot = storage_slots[0];
-            tracing::debug!(
-                storage_context = ?slot.0,
-                slot = ?slot.1,
-                ?slot,
-                iterations = 0,
-                "detected balance slot via trace (single SLOAD) for token",
-            );
-            return Ok(strategies.into_iter().next().unwrap());
-        }
-
         tracing::debug!(
             ?token,
             total = storage_slots.len(),
-            "multiple SLOAD operations, testing each one",
+            "testing candidate balance slots",
         );
 
         for (i, strategy) in strategies.into_iter().enumerate() {
@@ -442,21 +436,21 @@ impl Detector {
             // slow slot from blocking the entire detection.
             let result = tokio::time::timeout(
                 self.verification_timeout,
-                self.verify_strategy(token, holder, &strategy),
+                self.verify_strategy(token, holder, strategy.clone()),
             )
             .await;
 
             match result {
-                Ok(Ok(())) => {
+                Ok(Ok(verified)) => {
                     tracing::debug!(
                         ?token,
                         ?holder,
-                        ?strategy,
+                        strategy = ?verified,
                         iterations = i + 1,
                         total = storage_slots.len(),
                         "verified balance strategy via testing",
                     );
-                    return Ok(strategy.clone());
+                    return Ok(verified);
                 }
                 Err(_) => {
                     tracing::warn!(
@@ -478,54 +472,6 @@ impl Detector {
             }
         }
 
-        // Fallback for packed-balance tokens (see `Strategy::PackedSlot`): the
-        // whole-slot overrides above read the balance back shifted and never
-        // verify, so recover the shift from how far `balanceOf` moves the
-        // sentinel.
-        let probe = U256::from(SENTINEL);
-        for (contract, slot) in &storage_slots {
-            let probe_override = Strategy::DirectSlot {
-                target_contract: *contract,
-                slot: *slot,
-            }
-            .state_override(&holder, &probe)
-            .await;
-            if probe_override.is_empty() {
-                continue;
-            }
-            let observed = match ERC20::Instance::new(token, self.web3.provider.clone())
-                .balanceOf(holder)
-                .state(probe_override)
-                .call()
-                .await
-            {
-                Ok(balance) => balance,
-                Err(_) => continue,
-            };
-            let Some(shift_bits) = detect_byte_shift(probe, observed) else {
-                continue;
-            };
-            let candidate = Strategy::PackedSlot {
-                target_contract: *contract,
-                slot: *slot,
-                shift_bits,
-            };
-            if self
-                .verify_strategy(token, holder, &candidate)
-                .await
-                .is_ok()
-            {
-                tracing::debug!(
-                    ?token,
-                    ?holder,
-                    ?slot,
-                    shift_bits,
-                    "detected packed balance slot"
-                );
-                return Ok(candidate);
-            }
-        }
-
         tracing::debug!(
             "none of the SLOAD slots appear to be the balance slot for token {:?}",
             token
@@ -534,19 +480,22 @@ impl Detector {
         Err(DetectionError::NotFound)
     }
 
-    /// Verifies that a strategy correctly controls the balance by applying it
-    /// and checking balanceOf.
+    /// Verifies that a strategy controls the balance by writing the sentinel to
+    /// its slot and reading `balanceOf` back, returning the confirmed strategy.
     ///
-    /// For the `AaveV3AToken` variant we allow `balanceOf` to be off by one
-    /// wei, since Aave's ray rounding can slightly differ from our locally
-    /// computed scaled value; for every other variant the check is still an
-    /// exact equality.
+    /// If the sentinel reads back unshifted the strategy is correct as-is. If
+    /// it reads back byte-shifted, the balance is packed above lower-order
+    /// fields in the slot (e.g. AUSD packs `isFrozen` in the low byte, so
+    /// the balance is the high 248 bits), and the detected shift is applied
+    /// to the returned strategy from the same readback — no extra RPC. The
+    /// `AaveV3AToken` variant is never packed and tolerates 1 wei of Aave
+    /// ray-rounding difference.
     async fn verify_strategy(
         &self,
         token: Address,
         holder: Address,
-        strategy: &Strategy,
-    ) -> Result<(), DetectionError<TransportErrorKind>> {
+        strategy: Strategy,
+    ) -> Result<Strategy, DetectionError<TransportErrorKind>> {
         let test_balance = U256::from(SENTINEL);
 
         let overrides = strategy.state_override(&holder, &test_balance).await;
@@ -554,8 +503,7 @@ impl Detector {
             return Err(DetectionError::NotFound);
         }
 
-        let token_contract = ERC20::Instance::new(token, self.web3.provider.clone());
-        let balance = token_contract
+        let balance = ERC20::Instance::new(token, self.web3.provider.clone())
             .balanceOf(holder)
             .state(overrides)
             .call()
@@ -566,9 +514,21 @@ impl Detector {
                 )))
             })?;
 
-        verified_balance_matches(strategy, balance, test_balance)
-            .then_some(())
-            .ok_or(DetectionError::NotFound)
+        // The slot holds the balance unshifted.
+        if verified_balance_matches(&strategy, balance, test_balance) {
+            return Ok(strategy);
+        }
+        // Aave is never packed, so a mismatch there is a genuine miss.
+        if matches!(strategy, Strategy::AaveV3AToken { .. }) {
+            return Err(DetectionError::NotFound);
+        }
+        // Otherwise the balance may be packed above lower-order fields, so
+        // `balanceOf` reads the sentinel back byte-shifted. Recover the shift
+        // from the same readback and apply it.
+        match detect_byte_shift(test_balance, balance) {
+            Some(shift_bits) => Ok(strategy.with_shift(shift_bits)),
+            None => Err(DetectionError::NotFound),
+        }
     }
 }
 
@@ -592,25 +552,22 @@ fn verified_balance_matches(strategy: &Strategy, balance: U256, test_balance: U2
     }
 }
 
-/// Left-shifts `amount` into a packed balance's bit position. Returns `None`
-/// if the shift would drop high bits (the balance doesn't fit at this offset).
+/// Left-shifts `amount` into a packed balance's bit position. Returns `None` if
+/// the balance doesn't fit at this offset. Unlike `u64::checked_shl`, alloy's
+/// `checked_shl` returns `None` exactly when the shifted-out bits are non-zero,
+/// which is precisely the "doesn't fit above the lower-order fields" check.
 fn packed_value(amount: U256, shift_bits: usize) -> Option<U256> {
-    if shift_bits == 0 {
-        return Some(amount);
-    }
-    if amount > (U256::MAX >> shift_bits) {
-        return None;
-    }
-    Some(amount << shift_bits)
+    amount.checked_shl(shift_bits)
 }
 
-/// Returns the byte-aligned shift for which `probe >> shift == observed`, i.e.
-/// the bit offset of a balance packed above lower-order fields in its slot
-/// (see `Strategy::PackedSlot`). `probe` must have distinct bytes for the match
-/// to be unique.
+/// Returns the byte-aligned left-shift for which `probe >> shift == observed`,
+/// i.e. the bit offset of a balance packed above lower-order fields in its slot
+/// (e.g. AUSD's high-248-bit balance gives a shift of 8). `probe` must have
+/// distinct bytes for the match to be unique.
 fn detect_byte_shift(probe: U256, observed: U256) -> Option<usize> {
-    // A zero readback is never a balance shifted into place, and would
-    // otherwise match a shift that pushes the whole probe out of the slot.
+    // A zero readback means our write never reached `balanceOf` (wrong slot),
+    // which is not a shift — and would otherwise match a shift that pushes the
+    // whole probe out of the slot.
     if observed == U256::ZERO {
         return None;
     }
@@ -675,22 +632,27 @@ mod tests {
                 Strategy::DirectSlot {
                     target_contract: contract2,
                     slot: slot1,
+                    shift_bits: 0,
                 },
                 Strategy::DirectSlot {
                     target_contract: contract,
                     slot: slot3,
+                    shift_bits: 0,
                 },
                 Strategy::DirectSlot {
                     target_contract: contract,
                     slot: slot2,
+                    shift_bits: 0,
                 },
                 Strategy::DirectSlot {
                     target_contract: contract2,
                     slot: slot3,
+                    shift_bits: 0,
                 },
                 Strategy::DirectSlot {
                     target_contract: contract,
                     slot: slot1,
+                    shift_bits: 0,
                 },
             ]
         );
@@ -733,25 +695,31 @@ mod tests {
                 Strategy::SolidityMapping {
                     target_contract: contract,
                     map_slot: U256::ZERO,
+                    shift_bits: 0,
                 },
                 Strategy::SoladyMapping {
                     target_contract: contract,
+                    shift_bits: 0,
                 },
                 Strategy::SolidityMapping {
                     target_contract: contract,
                     map_slot: U256::from(5),
+                    shift_bits: 0,
                 },
                 Strategy::DirectSlot {
                     target_contract: contract,
                     slot: slot2,
+                    shift_bits: 0,
                 },
                 Strategy::DirectSlot {
                     target_contract: contract,
                     slot: slot3,
+                    shift_bits: 0,
                 },
                 Strategy::DirectSlot {
                     target_contract: contract,
                     slot: slot1,
+                    shift_bits: 0,
                 },
             ]
         );
@@ -786,18 +754,22 @@ mod tests {
                 Strategy::DirectSlot {
                     target_contract: contract,
                     slot: slot3,
+                    shift_bits: 0,
                 },
                 Strategy::DirectSlot {
                     target_contract: contract,
                     slot: heuristic_slot,
+                    shift_bits: 0,
                 },
                 Strategy::DirectSlot {
                     target_contract: contract,
                     slot: slot2,
+                    shift_bits: 0,
                 },
                 Strategy::DirectSlot {
                     target_contract: contract,
                     slot: slot1,
+                    shift_bits: 0,
                 },
             ]
         );
@@ -824,7 +796,8 @@ mod tests {
             storage,
             Strategy::SolidityMapping {
                 target_contract: address!("c02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"),
-                map_slot: U256::from(3)
+                map_slot: U256::from(3),
+                shift_bits: 0,
             }
         );
 
@@ -840,6 +813,7 @@ mod tests {
             Strategy::SolidityMapping {
                 target_contract: address!("4956b52ae2ff65d74ca2d61207523288e4528f96"),
                 map_slot: <U256 as From<_>>::from(OPEN_ZEPPELIN_ERC20_UPGRADEABLE),
+                shift_bits: 0,
             }
         );
 
@@ -853,7 +827,8 @@ mod tests {
         assert_eq!(
             storage,
             Strategy::SoladyMapping {
-                target_contract: address!("0000000000c5dc95539589fbd24be07c6c14eca4")
+                target_contract: address!("0000000000c5dc95539589fbd24be07c6c14eca4"),
+                shift_bits: 0,
             }
         );
     }
@@ -876,15 +851,17 @@ mod tests {
             storage,
             Strategy::SolidityMapping {
                 target_contract: address!("ff970a61a04b1ca14834a43f5de4533ebddb5cc8"),
-                map_slot: U256::from(51)
+                map_slot: U256::from(51),
+                shift_bits: 0,
             }
         );
     }
 
     // AUSD packs `{ bool isFrozen; uint248 balance }` into one slot, so the
-    // balance is the high 248 bits and `balanceOf == slot >> 8`. The detector
-    // must fall back to a `PackedSlot` with an 8-bit shift. Requires an
-    // avalanche node (set the node URL `Web3::new_from_env` reads).
+    // balance is the high 248 bits and `balanceOf == slot >> 8`. Its balance
+    // lives at an ERC-7201-namespaced base slot, so the detector resolves it to
+    // a `DirectSlot` and verification recovers the 8-bit packing shift. Requires
+    // an avalanche node (set the node URL `Web3::new_from_env` reads).
     #[ignore]
     #[tokio::test]
     async fn detects_packed_balance_slot_avalanche() {
@@ -899,7 +876,7 @@ mod tests {
             .unwrap();
 
         match strategy {
-            Strategy::PackedSlot {
+            Strategy::DirectSlot {
                 target_contract,
                 shift_bits,
                 ..
@@ -907,7 +884,7 @@ mod tests {
                 assert_eq!(target_contract, ausd);
                 assert_eq!(shift_bits, 8);
             }
-            other => panic!("expected PackedSlot, got {other:?}"),
+            other => panic!("expected DirectSlot with shift, got {other:?}"),
         }
     }
 }

--- a/crates/balance-overrides/src/lib.rs
+++ b/crates/balance-overrides/src/lib.rs
@@ -134,6 +134,7 @@ mod tests {
         let strategy = Strategy::SolidityMapping {
             target_contract: cow,
             map_slot: U256::from(0),
+            shift_bits: 0,
         };
 
         let result = strategy
@@ -185,6 +186,7 @@ mod tests {
         let amount = U256::from(0x42);
         let strategy = Strategy::SoladyMapping {
             target_contract: address!("0000000000c5dc95539589fbd24be07c6c14eca4"),
+            shift_bits: 0,
         };
 
         let result = strategy
@@ -224,6 +226,7 @@ mod tests {
         let strategy = Strategy::SolidityMapping {
             target_contract,
             map_slot: U256::from(3),
+            shift_bits: 0,
         };
 
         let mock_web3 = mock::web3();
@@ -264,10 +267,12 @@ mod tests {
         let strategy_h1 = Strategy::DirectSlot {
             target_contract,
             slot: B256::repeat_byte(1),
+            shift_bits: 0,
         };
         let strategy_h2 = Strategy::DirectSlot {
             target_contract,
             slot: B256::repeat_byte(2),
+            shift_bits: 0,
         };
 
         let mock_web3 = mock::web3();


### PR DESCRIPTION
# Description
Balance overrides silently fail for tokens that pack the balance above other fields in the same storage slot, which blocks order creation for orders that need a balance override (flashloan orders in particular). AUSD on avalanche is the live case: it stores `struct { bool isFrozen; uint248 balance; }` in one slot, so the balance lives in the high 248 bits and `balanceOf` returns `slot >> 8`. Our override writes the amount into the whole slot, `balanceOf` then reads it back shifted, the verification check (`balanceOf == amount`) fails, and the token is marked unsupported. The result was that every AUSD AAVE-collateral-swap flashloan order on avalanche was rejected at creation (0 created in days, all logged as "signature invalid, simulation passed" because the creation-time signature check couldn't fund the borrowed AUSD).

Slot-finding itself already works (we find the right proxy slot); the only gap is computing the correct override value when the balance is packed and shifted.

# Changes
- Add a `PackedSlot { slot, shift_bits }` balance-override strategy that writes the balance left-shifted into its bit position, leaving lower-order fields (e.g. `isFrozen`) zero.
- After the normal detection fails, probe each candidate slot with a distinct-byte sentinel; if `balanceOf` returns a byte-shifted view of it, infer the shift and verify a `PackedSlot` override.

# Limitations
The shift is measured empirically (not hardcoded to AUSD's types), so it covers any "small field below the balance" packing where the balance is the high, byte-aligned field with a shift up to 56 bits. Out of scope and left unsupported: sub-byte fields (balance not on a byte boundary), shifts above 56 bits (balance above a field wider than 7 bytes). Unsupported tokens fail open exactly as before, the override is skipped, never written wrong, since every candidate is confirmed by writing it and re-reading `balanceOf`.

# How to test
Unit tests cover the shift math (`packed_value`, `detect_byte_shift`). Added a forked `Detector` test (`detects_packed_balance_slot_avalanche`) that runs the full detect path against AUSD and asserts a `PackedSlot { shift_bits: 8 }`.

Validated green against real AUSD bytecode: AUSD is deployed at the same address (`0x00000000efe302beaa2b3e6e1b18d08d69a9012a`) with identical packing on mainnet and avalanche, so I ran the test with `NODE_URL` pointing at a mainnet node and it passes (the full trace -> find slots -> sentinel probe -> detect shift 8 -> verify path runs and verifies on-chain). The forked balance-override tests are `#[ignore]`d and run per-chain via `NODE_URL`.
