### PR TITLE
support e2e tests out of the box in devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/devcontainers/base:bullseye
+FROM mcr.microsoft.com/devcontainers/base:bookworm
 
 RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
     # Remove imagemagick due to https://security-tracker.debian.org/tracker/CVE-2019-10131

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -16,7 +16,7 @@
         },
         "ghcr.io/devcontainers/features/rust:1": {},
 		"ghcr.io/devcontainers/features/git:1": {},
-		"ghcr.io/nlordell/features/foundry": {},
+		"ghcr.io/nlordell/features/foundry": { "version": "v1.7.1" },
 		"ghcr.io/devcontainers/features/docker-in-docker:2": {
             "dockerDashComposeVersion": "v2"
         },
@@ -37,7 +37,11 @@
         "PGHOST": "localhost",
         "PGPORT": "5432",
         "PGUSER": "vscode",
-        "PGDATABASE": "vscode"
+        "PGDATABASE": "vscode",
+        // Drop debug info from dev/test builds: the e2e test binary's debug info
+        // is large enough to get the linker OOM-killed on a stock setup.
+        "CARGO_PROFILE_DEV_DEBUG": "0",
+        "CARGO_PROFILE_TEST_DEBUG": "0"
     },
 
     "customizations": {
@@ -58,7 +62,7 @@
 
 	// Use 'postCreateCommand' to run commands after the container is created.
 	// "postCreateCommand": "rustc --version",
-	"postCreateCommand": "rustup toolchain install nightly --component rustfmt && cargo install flamegraph && cargo install cargo-nextest --locked && bash .devcontainer/setup-e2e.sh",
+	"postCreateCommand": "rustup toolchain install nightly --component rustfmt && cargo install flamegraph && cargo install cargo-nextest --locked && cargo install just --locked && bash .devcontainer/setup-e2e.sh",
 
 	// (Re)start the local Postgres cluster on every container start.
 	"postStartCommand": "bash .devcontainer/start-postgres.sh",

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -33,6 +33,13 @@
         "seccomp=unconfined"
     ],
 
+    "containerEnv": {
+        "PGHOST": "localhost",
+        "PGPORT": "5432",
+        "PGUSER": "vscode",
+        "PGDATABASE": "vscode"
+    },
+
     "customizations": {
         "vscode": {
             "settings": {
@@ -51,7 +58,10 @@
 
 	// Use 'postCreateCommand' to run commands after the container is created.
 	// "postCreateCommand": "rustc --version",
-	"postCreateCommand": "rustup toolchain install nightly && cargo install flamegraph",
+	"postCreateCommand": "rustup toolchain install nightly && cargo install flamegraph && cargo install cargo-nextest --locked && bash .devcontainer/setup-e2e.sh",
+
+	// (Re)start the local Postgres cluster on every container start.
+	"postStartCommand": "bash .devcontainer/start-postgres.sh",
 
 	// Set `remoteUser` to `root` to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
 	"remoteUser": "vscode"

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -58,7 +58,7 @@
 
 	// Use 'postCreateCommand' to run commands after the container is created.
 	// "postCreateCommand": "rustc --version",
-	"postCreateCommand": "rustup toolchain install nightly && cargo install flamegraph && cargo install cargo-nextest --locked && bash .devcontainer/setup-e2e.sh",
+	"postCreateCommand": "rustup toolchain install nightly --component rustfmt && cargo install flamegraph && cargo install cargo-nextest --locked && bash .devcontainer/setup-e2e.sh",
 
 	// (Re)start the local Postgres cluster on every container start.
 	"postStartCommand": "bash .devcontainer/start-postgres.sh",

--- a/.devcontainer/setup-e2e.sh
+++ b/.devcontainer/setup-e2e.sh
@@ -1,42 +1,19 @@
 #!/usr/bin/env bash
 #
-# Provisions the tools the e2e test suite needs but that the base image can't
+# Provisions the one thing the e2e test suite needs but the base image can't
 # provide out of the box:
-#
-#   * anvil  – the prebuilt binary from the foundry devcontainer feature requires
-#              glibc >= 2.32, but the bullseye base image ships glibc 2.31, so the
-#              prebuilt aborts at startup. We build anvil from source against the
-#              local glibc instead (pinned to the same commit the feature uses).
 #
 #   * Postgres server – the Docker daemon can't start in this container, so the
 #              docker-compose Postgres isn't available. We run a native server and
 #              apply the flyway migrations the harness expects to already exist.
 #
+# anvil/forge come from the foundry devcontainer feature; their prebuilt binaries
+# run directly on the bookworm base image (glibc >= 2.32), so nothing to do here.
+#
 # Runs as `postCreateCommand` (once, when the container is created).
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-
-# Commit the foundry feature pins; building it from source keeps anvil's version
-# identical to what the rest of the toolchain expects.
-ANVIL_COMMIT="1fd6466f96e4f52cea01093ae0f5772ddf3a6795"
-
-# -----------------------------------------------------------------------------
-echo "==> anvil"
-if anvil --version >/dev/null 2>&1; then
-    echo "    anvil already works: $(anvil --version | head -1)"
-else
-    echo "    prebuilt anvil is unusable (glibc mismatch); building from source..."
-    build_dir="$(mktemp -d)"
-    git -C "$build_dir" init -q
-    git -C "$build_dir" remote add origin https://github.com/foundry-rs/foundry
-    git -C "$build_dir" fetch -q --depth 1 origin "$ANVIL_COMMIT"
-    git -C "$build_dir" checkout -q FETCH_HEAD
-    ( cd "$build_dir" && cargo build --release --bin anvil )
-    sudo cp "$build_dir/target/release/anvil" /usr/local/bin/anvil
-    rm -rf "$build_dir"
-    echo "    installed $(anvil --version | head -1)"
-fi
 
 # -----------------------------------------------------------------------------
 echo "==> postgres"
@@ -50,8 +27,12 @@ fi
 PG_VERSION="$(ls /etc/postgresql | sort -n | tail -1)"
 echo "    using cluster ${PG_VERSION}/main"
 
-# Start the cluster (there is no init system to do it for us).
-sudo pg_ctlcluster "$PG_VERSION" main start 2>/dev/null || true
+# Start the cluster (there is no init system to do it for us). `start` errors if
+# the cluster is already running, so only start it when it isn't online; a
+# genuine start failure then surfaces instead of being swallowed.
+if ! pg_lsclusters -h "$PG_VERSION" main | grep -q online; then
+    sudo pg_ctlcluster "$PG_VERSION" main start
+fi
 
 # Trust auth for local connections (development container only).
 HBA="/etc/postgresql/${PG_VERSION}/main/pg_hba.conf"
@@ -86,4 +67,4 @@ else
     done
 fi
 
-echo "==> e2e environment ready (anvil + postgres)"
+echo "==> e2e environment ready (postgres)"

--- a/.devcontainer/setup-e2e.sh
+++ b/.devcontainer/setup-e2e.sh
@@ -3,9 +3,10 @@
 # Provisions the one thing the e2e test suite needs but the base image can't
 # provide out of the box:
 #
-#   * Postgres server – the Docker daemon can't start in this container, so the
-#              docker-compose Postgres isn't available. We run a native server and
-#              apply the flyway migrations the harness expects to already exist.
+#   * Postgres server – we run a native server (rather than the docker-compose
+#              one) so it survives container restarts and is up before any test
+#              runs, then apply the flyway migrations the harness expects to
+#              already exist.
 #
 # anvil/forge come from the foundry devcontainer feature; their prebuilt binaries
 # run directly on the bookworm base image (glibc >= 2.32), so nothing to do here.
@@ -27,12 +28,8 @@ fi
 PG_VERSION="$(ls /etc/postgresql | sort -n | tail -1)"
 echo "    using cluster ${PG_VERSION}/main"
 
-# Start the cluster (there is no init system to do it for us). `start` errors if
-# the cluster is already running, so only start it when it isn't online; a
-# genuine start failure then surfaces instead of being swallowed.
-if ! pg_lsclusters -h "$PG_VERSION" main | grep -q online; then
-    sudo pg_ctlcluster "$PG_VERSION" main start
-fi
+# Start the cluster (shared with postStart so the two can't drift).
+bash "$REPO_ROOT/.devcontainer/start-postgres.sh"
 
 # Trust auth for local connections (development container only).
 HBA="/etc/postgresql/${PG_VERSION}/main/pg_hba.conf"
@@ -44,27 +41,29 @@ EOF
 sudo pg_ctlcluster "$PG_VERSION" main reload
 
 # The e2e harness connects with the bare url `postgresql://`, which resolves to a
-# role and database named after the OS user (see containerEnv in devcontainer.json
-# and DatabasePoolConfig::test_default).
+# role and database named after $PGUSER/$PGDATABASE (see containerEnv in
+# devcontainer.json and DatabasePoolConfig::test_default).
 psql -h 127.0.0.1 -U postgres -d postgres -tAc \
-    "SELECT 1 FROM pg_roles WHERE rolname='${USER}'" | grep -q 1 \
+    "SELECT 1 FROM pg_roles WHERE rolname='${PGUSER}'" | grep -q 1 \
     || psql -h 127.0.0.1 -U postgres -d postgres -c \
-        "CREATE ROLE \"${USER}\" LOGIN SUPERUSER;"
+        "CREATE ROLE \"${PGUSER}\" LOGIN SUPERUSER;"
 psql -h 127.0.0.1 -U postgres -d postgres -tAc \
-    "SELECT 1 FROM pg_database WHERE datname='${USER}'" | grep -q 1 \
+    "SELECT 1 FROM pg_database WHERE datname='${PGDATABASE}'" | grep -q 1 \
     || psql -h 127.0.0.1 -U postgres -d postgres -c \
-        "CREATE DATABASE \"${USER}\" OWNER \"${USER}\";"
+        "CREATE DATABASE \"${PGDATABASE}\" OWNER \"${PGUSER}\";"
 
-# Apply the flyway migrations once (the harness only truncates tables, it does not
-# create the schema). Skip if the schema is already present.
-if psql -h 127.0.0.1 -U "$USER" -d "$USER" -tAc \
-        "SELECT to_regclass('public.orders')" | grep -q orders; then
-    echo "    schema already present, skipping migrations"
-else
-    echo "    applying $(ls "$REPO_ROOT"/database/sql/V*.sql | wc -l) migrations..."
-    for f in $(ls "$REPO_ROOT"/database/sql/V*.sql | sort); do
-        psql -v ON_ERROR_STOP=1 -q -h 127.0.0.1 -U "$USER" -d "$USER" -f "$f"
-    done
-fi
+# Apply the migrations with the same flyway image the rest of the repo uses
+# (see docker-compose.yaml). Flyway tracks what it has already applied, so this is
+# incremental and idempotent: re-running only applies new migrations and fails
+# loudly if one is incompatible with the current schema. The native server runs
+# on the host network namespace, so `--network=host` lets flyway reach it on
+# 127.0.0.1:${PGPORT}.
+echo "    applying flyway migrations..."
+docker run --rm --network=host \
+    -v "$REPO_ROOT/database/sql:/flyway/sql:ro" \
+    -v "$REPO_ROOT/database/conf:/flyway/conf:ro" \
+    flyway/flyway:10.7.1 \
+    -url="jdbc:postgresql://127.0.0.1:${PGPORT}/${PGDATABASE}?user=${PGUSER}&password=" \
+    migrate
 
 echo "==> e2e environment ready (postgres)"

--- a/.devcontainer/setup-e2e.sh
+++ b/.devcontainer/setup-e2e.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+#
+# Provisions the tools the e2e test suite needs but that the base image can't
+# provide out of the box:
+#
+#   * anvil  – the prebuilt binary from the foundry devcontainer feature requires
+#              glibc >= 2.32, but the bullseye base image ships glibc 2.31, so the
+#              prebuilt aborts at startup. We build anvil from source against the
+#              local glibc instead (pinned to the same commit the feature uses).
+#
+#   * Postgres server – the Docker daemon can't start in this container, so the
+#              docker-compose Postgres isn't available. We run a native server and
+#              apply the flyway migrations the harness expects to already exist.
+#
+# Runs as `postCreateCommand` (once, when the container is created).
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+# Commit the foundry feature pins; building it from source keeps anvil's version
+# identical to what the rest of the toolchain expects.
+ANVIL_COMMIT="1fd6466f96e4f52cea01093ae0f5772ddf3a6795"
+
+# -----------------------------------------------------------------------------
+echo "==> anvil"
+if anvil --version >/dev/null 2>&1; then
+    echo "    anvil already works: $(anvil --version | head -1)"
+else
+    echo "    prebuilt anvil is unusable (glibc mismatch); building from source..."
+    build_dir="$(mktemp -d)"
+    git -C "$build_dir" init -q
+    git -C "$build_dir" remote add origin https://github.com/foundry-rs/foundry
+    git -C "$build_dir" fetch -q --depth 1 origin "$ANVIL_COMMIT"
+    git -C "$build_dir" checkout -q FETCH_HEAD
+    ( cd "$build_dir" && cargo build --release --bin anvil )
+    sudo cp "$build_dir/target/release/anvil" /usr/local/bin/anvil
+    rm -rf "$build_dir"
+    echo "    installed $(anvil --version | head -1)"
+fi
+
+# -----------------------------------------------------------------------------
+echo "==> postgres"
+# Install a server only if no cluster exists yet (fresh container). Reuse whatever
+# version is already present otherwise, so this is safe to re-run.
+if ! ls -d /etc/postgresql/*/main >/dev/null 2>&1; then
+    echo "    installing postgresql-16..."
+    sudo apt-get update -qq
+    sudo DEBIAN_FRONTEND=noninteractive apt-get install -y -qq postgresql-16
+fi
+PG_VERSION="$(ls /etc/postgresql | sort -n | tail -1)"
+echo "    using cluster ${PG_VERSION}/main"
+
+# Start the cluster (there is no init system to do it for us).
+sudo pg_ctlcluster "$PG_VERSION" main start 2>/dev/null || true
+
+# Trust auth for local connections (development container only).
+HBA="/etc/postgresql/${PG_VERSION}/main/pg_hba.conf"
+sudo tee "$HBA" >/dev/null <<'EOF'
+local   all   all                  trust
+host    all   all   127.0.0.1/32   trust
+host    all   all   ::1/128        trust
+EOF
+sudo pg_ctlcluster "$PG_VERSION" main reload
+
+# The e2e harness connects with the bare url `postgresql://`, which resolves to a
+# role and database named after the OS user (see containerEnv in devcontainer.json
+# and DatabasePoolConfig::test_default).
+psql -h 127.0.0.1 -U postgres -d postgres -tAc \
+    "SELECT 1 FROM pg_roles WHERE rolname='${USER}'" | grep -q 1 \
+    || psql -h 127.0.0.1 -U postgres -d postgres -c \
+        "CREATE ROLE \"${USER}\" LOGIN SUPERUSER;"
+psql -h 127.0.0.1 -U postgres -d postgres -tAc \
+    "SELECT 1 FROM pg_database WHERE datname='${USER}'" | grep -q 1 \
+    || psql -h 127.0.0.1 -U postgres -d postgres -c \
+        "CREATE DATABASE \"${USER}\" OWNER \"${USER}\";"
+
+# Apply the flyway migrations once (the harness only truncates tables, it does not
+# create the schema). Skip if the schema is already present.
+if psql -h 127.0.0.1 -U "$USER" -d "$USER" -tAc \
+        "SELECT to_regclass('public.orders')" | grep -q orders; then
+    echo "    schema already present, skipping migrations"
+else
+    echo "    applying $(ls "$REPO_ROOT"/database/sql/V*.sql | wc -l) migrations..."
+    for f in $(ls "$REPO_ROOT"/database/sql/V*.sql | sort); do
+        psql -v ON_ERROR_STOP=1 -q -h 127.0.0.1 -U "$USER" -d "$USER" -f "$f"
+    done
+fi
+
+echo "==> e2e environment ready (anvil + postgres)"

--- a/.devcontainer/start-postgres.sh
+++ b/.devcontainer/start-postgres.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+#
+# Starts the local Postgres cluster on every container start. There is no init
+# system in the container, so the cluster does not come up on its own after a
+# stop/start. Provisioning (install, role, db, migrations) is done once by
+# setup-e2e.sh; this only (re)starts what already exists.
+#
+# Runs as `postStartCommand`.
+set -euo pipefail
+
+PG_VERSION="$(ls /etc/postgresql 2>/dev/null | sort -n | tail -1 || true)"
+if [ -n "$PG_VERSION" ]; then
+    sudo pg_ctlcluster "$PG_VERSION" main start 2>/dev/null || true
+fi

--- a/.devcontainer/start-postgres.sh
+++ b/.devcontainer/start-postgres.sh
@@ -8,7 +8,10 @@
 # Runs as `postStartCommand`.
 set -euo pipefail
 
-PG_VERSION="$(ls /etc/postgresql 2>/dev/null | sort -n | tail -1 || true)"
-if [ -n "$PG_VERSION" ]; then
-    sudo pg_ctlcluster "$PG_VERSION" main start 2>/dev/null || true
+PG_VERSION="$(ls /etc/postgresql | sort -n | tail -1)"
+
+# `start` errors if the cluster is already running, so only start it when it
+# isn't online; a genuine start failure then surfaces instead of being swallowed.
+if ! pg_lsclusters -h "$PG_VERSION" main | grep -q online; then
+    sudo pg_ctlcluster "$PG_VERSION" main start
 fi


### PR DESCRIPTION
This now adds support out of the box in the devcontainer setup for:
* anvil
* cargo-nextest
* postgres

This allows to run e2e tests straight away.