### PR TITLE
Same token policy buy support

### DIFF
--- a/crates/configs/src/orderbook/order_validation.rs
+++ b/crates/configs/src/orderbook/order_validation.rs
@@ -13,8 +13,8 @@ pub enum SameTokensPolicy {
     Disallow,
     /// Allow sell orders where buy token equals sell token.
     AllowSell,
-    // Allow, TODO: Allow sell and buy orders with the same tokens
-    // (https://github.com/cowprotocol/services/issues/3963)
+    /// Allow both sell and buy orders where buy token equals sell token.
+    Allow,
 }
 
 const fn default_min_order_validity_period() -> Duration {

--- a/crates/e2e/tests/e2e/submission.rs
+++ b/crates/e2e/tests/e2e/submission.rs
@@ -687,9 +687,6 @@ async fn test_execute_same_sell_and_buy_native_token_buy_order(web3: Web3) {
         },
         ..Default::default()
     };
-    // EXPECTED FAILURE POINT (today): Buy same-token orders are rejected during
-    // quote-time validation, so this `unwrap()` panics with a BAD_REQUEST /
-    // "SameBuyAndSellToken" error.
     let quote_response = services.submit_quote(&quote_request).await.unwrap();
     tracing::info!(?quote_response);
     assert!(quote_response.id.is_some());

--- a/crates/e2e/tests/e2e/submission.rs
+++ b/crates/e2e/tests/e2e/submission.rs
@@ -742,10 +742,11 @@ async fn test_execute_same_sell_and_buy_native_token_buy_order(web3: Web3) {
         sell_token: weth_address,
         buy_token: BUY_ETH_ADDRESS,
         quote_id: quote_response.id,
-        // A buy order must commit enough sell tokens to cover the quoted amount
-        // *plus* the fee, otherwise the solver has no headroom to take its fee
-        // and produces no solution (the bare quoted `sell_amount` equals
-        // `buy_amount` at the 1:1 WETH<->ETH price).
+        // Sell and buy are the same asset priced 1:1, so the quoted `sell_amount`
+        // equals `buy_amount`; the fee is the only extra the trader pays. We sign
+        // `sell_amount + fee` (a (1 + fee):1 limit) so the solver has headroom to
+        // take its fee — without it the limit would be exactly 1:1 and no solution
+        // could cover the fee.
         sell_amount: quote_response.quote.sell_amount + quote_response.quote.fee_amount,
         buy_amount: quote_buy_amount,
         valid_to: model::time::now_in_epoch_seconds() + 300,

--- a/crates/e2e/tests/e2e/submission.rs
+++ b/crates/e2e/tests/e2e/submission.rs
@@ -49,6 +49,12 @@ async fn local_node_execute_same_sell_and_buy_native_token() {
     run_test(test_execute_same_sell_and_buy_native_token).await;
 }
 
+#[tokio::test]
+#[ignore]
+async fn local_node_execute_same_sell_and_buy_native_token_buy_order() {
+    run_test(test_execute_same_sell_and_buy_native_token_buy_order).await;
+}
+
 async fn test_cancel_on_expiry(web3: Web3) {
     let mut onchain = OnchainComponents::deploy(web3.clone()).await;
 
@@ -541,6 +547,210 @@ async fn test_execute_same_sell_and_buy_native_token(web3: Web3) {
         quote_id: quote_response.id,
         sell_amount: quote_sell_amount,
         buy_amount: quote_response.quote.buy_amount,
+        valid_to: model::time::now_in_epoch_seconds() + 300,
+        ..Default::default()
+    }
+    .sign(
+        EcdsaSigningScheme::Eip712,
+        &onchain.contracts().domain_separator,
+        &trader.signer,
+    );
+    assert!(services.create_order(&order).await.is_ok());
+
+    // Start tracking confirmed blocks so we can find the transaction later
+    let block_stream = web3
+        .provider
+        .watch_blocks()
+        .await
+        .expect("must be able to create blocks filter")
+        .into_stream();
+
+    tracing::info!("Waiting for trade.");
+    onchain.mint_block().await;
+
+    // Wait for settlement tx to appear in txpool
+    wait_for_condition(TIMEOUT, || async {
+        get_pending_tx(solver.address(), &web3).await.is_some()
+    })
+    .await
+    .unwrap();
+
+    // Continue mining to confirm the settlement
+    web3.provider
+        .evm_set_automine(true)
+        .await
+        .expect("Must be able to enable automine");
+
+    // Wait for the settlement to be confirmed on chain
+    let tx = tokio::time::timeout(
+        Duration::from_secs(5),
+        get_confirmed_transaction(solver.address(), &web3, block_stream),
+    )
+    .await
+    .unwrap();
+
+    // Verify the transaction is to the settlement contract (not a cancellation)
+    assert_eq!(tx.to, Some(*onchain.contracts().gp_settlement.address()));
+
+    // Verify that the WETH balance decreased (sell happened on chain)
+    let trade_happened = || async {
+        let balance = onchain
+            .contracts()
+            .weth
+            .balanceOf(trader.address())
+            .call()
+            .await
+            .unwrap();
+        balance != initial_balance
+    };
+    wait_for_condition(TIMEOUT, trade_happened).await.unwrap();
+
+    let final_balance = onchain
+        .contracts()
+        .weth
+        .balanceOf(trader.address())
+        .call()
+        .await
+        .unwrap();
+    tracing::info!(?initial_balance, ?final_balance, "Trade completed");
+
+    assert!(
+        final_balance < initial_balance,
+        "Final WETH balance should be smaller than initial balance due to sell"
+    );
+}
+
+/// Native-equivalent same-token **Buy** order (sell WETH, buy native ETH via
+/// `BUY_ETH_ADDRESS`), mirroring `test_execute_same_sell_and_buy_native_token`
+/// but with `OrderKind::Buy`.
+///
+/// Exercises buy-side support for same sell/buy token orders enabled by
+/// `SameTokensPolicy::Allow` (issue #3963,
+/// https://github.com/cowprotocol/services/issues/3963). The order commits
+/// `sell_amount + fee` so the solver has the headroom to settle it.
+async fn test_execute_same_sell_and_buy_native_token_buy_order(web3: Web3) {
+    let mut onchain = OnchainComponents::deploy(web3.clone()).await;
+
+    let [solver] = onchain.make_solvers(10u64.eth()).await;
+    let [trader] = onchain.make_accounts(10u64.eth()).await;
+
+    onchain
+        .contracts()
+        .weth
+        .deposit()
+        .from(trader.address())
+        .value(5u64.eth())
+        .send_and_watch()
+        .await
+        .unwrap();
+
+    onchain
+        .contracts()
+        .weth
+        .approve(onchain.contracts().allowance, 5u64.eth())
+        .from(trader.address())
+        .send_and_watch()
+        .await
+        .unwrap();
+
+    tracing::info!("Starting services.");
+    let services = Services::new(&onchain).await;
+    services
+        .start_protocol_with_args(
+            Configuration::test("test_solver", solver.address()),
+            configs::orderbook::Configuration {
+                order_validation: OrderValidationConfig {
+                    same_tokens_policy: shared::order_validation::SameTokensPolicy::Allow,
+                    ..Default::default()
+                },
+                ..configs::orderbook::Configuration::test_default()
+            },
+            solver.clone(),
+        )
+        .await;
+
+    // Disable auto-mine so we don't accidentally mine a settlement
+    web3.provider
+        .evm_set_automine(false)
+        .await
+        .expect("Must be able to disable automine");
+
+    tracing::info!("Quoting");
+    let quote_buy_amount = 1u64.eth();
+    let weth_address = *onchain.contracts().weth.address();
+    let quote_request = OrderQuoteRequest {
+        from: trader.address(),
+        sell_token: weth_address,
+        buy_token: BUY_ETH_ADDRESS,
+        side: OrderQuoteSide::Buy {
+            buy_amount_after_fee: NonZeroU256::try_from(quote_buy_amount).unwrap(),
+        },
+        ..Default::default()
+    };
+    // EXPECTED FAILURE POINT (today): Buy same-token orders are rejected during
+    // quote-time validation, so this `unwrap()` panics with a BAD_REQUEST /
+    // "SameBuyAndSellToken" error.
+    let quote_response = services.submit_quote(&quote_request).await.unwrap();
+    tracing::info!(?quote_response);
+    assert!(quote_response.id.is_some());
+    assert!(quote_response.verified);
+    // For a Buy order the trader pays (sell_amount + fee) more than the
+    // `buy_amount` they receive. At a 1:1 WETH<->ETH price the bare `sell_amount`
+    // equals `buy_amount`; the cost difference is carried in `fee_amount`.
+    assert!(quote_response.quote.sell_amount + quote_response.quote.fee_amount > quote_buy_amount);
+
+    // check that a different receiver does not affect the quoted amount
+    let quote_request_different_receiver = OrderQuoteRequest {
+        receiver: Some(Address::repeat_byte(0x01)),
+        ..quote_request
+    };
+    let quote_response_different_receiver = services
+        .submit_quote(&quote_request_different_receiver)
+        .await
+        .unwrap();
+
+    tracing::info!(?quote_response_different_receiver);
+    assert!(quote_response_different_receiver.id.is_some());
+    assert!(quote_response_different_receiver.verified);
+    assert!(
+        quote_response_different_receiver
+            .quote
+            .buy_amount
+            .is_approx_eq(&quote_response.quote.buy_amount, Some(0.0001))
+    );
+    assert!(
+        quote_response_different_receiver
+            .quote
+            .sell_amount
+            .is_approx_eq(&quote_response.quote.sell_amount, Some(0.0001))
+    );
+
+    let quote_metadata =
+        crate::database::quote_metadata(services.db(), quote_response.id.unwrap()).await;
+    assert!(quote_metadata.is_some());
+    tracing::debug!(?quote_metadata);
+
+    tracing::info!("Placing order");
+    let initial_balance = onchain
+        .contracts()
+        .weth
+        .balanceOf(trader.address())
+        .call()
+        .await
+        .unwrap();
+    assert_eq!(initial_balance, 5u64.eth());
+
+    let order = OrderCreation {
+        kind: OrderKind::Buy,
+        sell_token: weth_address,
+        buy_token: BUY_ETH_ADDRESS,
+        quote_id: quote_response.id,
+        // A buy order must commit enough sell tokens to cover the quoted amount
+        // *plus* the fee, otherwise the solver has no headroom to take its fee
+        // and produces no solution (the bare quoted `sell_amount` equals
+        // `buy_amount` at the 1:1 WETH<->ETH price).
+        sell_amount: quote_response.quote.sell_amount + quote_response.quote.fee_amount,
+        buy_amount: quote_buy_amount,
         valid_to: model::time::now_in_epoch_seconds() + 300,
         ..Default::default()
     }

--- a/crates/price-estimation/src/trade_verifier.rs
+++ b/crates/price-estimation/src/trade_verifier.rs
@@ -225,7 +225,12 @@ impl TradeVerifier {
             .sum::<u64>();
         summary.gas_used += U256::from(21_000) + U256::from(call_data_cost);
 
-        self.post_process_summary(summary, query, verification)
+        Self::post_process_summary(
+            self.simulator.settlement_address(),
+            summary,
+            query,
+            verification,
+        )
     }
 
     /// Generates the calldata for the underlying `settle()` call as well as all
@@ -314,7 +319,7 @@ impl TradeVerifier {
     /// * trader or receiver is the settlement contrat itself
     /// * sell_token == buy_token
     fn post_process_summary(
-        &self,
+        settlement_address: Address,
         mut summary: SettleOutput,
         query: &PriceQuery,
         verification: &Verification,
@@ -329,7 +334,7 @@ impl TradeVerifier {
 
         // It looks like the contract lost a lot of sell tokens but only because it was
         // the trader and had to pay for the trade. Adjust tokens lost downward.
-        if verification.from == self.simulator.settlement_address() {
+        if verification.from == settlement_address {
             summary
                 .tokens_lost
                 .entry(query.sell_token)
@@ -338,7 +343,7 @@ impl TradeVerifier {
         // It looks like the contract gained a lot of buy tokens (negative loss) but
         // only because it was the receiver and got the payout. Adjust the tokens lost
         // upward.
-        if verification.receiver == self.simulator.settlement_address() {
+        if verification.receiver == settlement_address {
             summary
                 .tokens_lost
                 .entry(query.buy_token)
@@ -1023,5 +1028,83 @@ mod tests {
         };
         SettleOutput::from_swap(swap_return, OrderKind::Sell, &tokens_vec)
             .expect("well-formed response must parse");
+    }
+
+    /// Regression test for same sell==buy token verification, which buy orders
+    /// can now reach via `SameTokensPolicy::Allow` (issue #3963). When the
+    /// trader is also the receiver the simulated balance only ever shrinks, so
+    /// `from_swap` reports the *net* change. The `query.in_amount + out_amount`
+    /// correction must recover the gross amount the trader perceives, for both
+    /// order kinds.
+    #[test]
+    fn post_process_same_token_recovers_gross_amount() {
+        let token = Address::repeat_byte(1);
+        let trader = Address::repeat_byte(2);
+        // A settlement address that is neither trader nor receiver, so the
+        // buffer adjustments stay untouched and we isolate the same-token fix.
+        let settlement = Address::repeat_byte(0xff);
+        // Zero receiver means the trader is also the receiver.
+        let verification = Verification {
+            from: trader,
+            receiver: Address::ZERO,
+            app_data: Default::default(),
+        };
+        let summary = |out_amount: I512| SettleOutput {
+            gas_used: U256::ZERO,
+            out_amount,
+            tokens_lost: hashmap! { token => BigRational::from_integer(0.into()) },
+        };
+
+        // Buy 100 of `token` back into the same account: the trader pays 103
+        // gross, so the simulation measures a net change of 103 - 100 = 3. The
+        // correction must report the 103 actually sold.
+        let buy_query = PriceQuery {
+            in_amount: 100.try_into().unwrap(),
+            kind: OrderKind::Buy,
+            sell_token: token,
+            buy_token: token,
+        };
+        let out = TradeVerifier::post_process_summary(
+            settlement,
+            summary(I512::try_from(3).unwrap()),
+            &buy_query,
+            &verification,
+        )
+        .unwrap();
+        assert_eq!(out.out_amount, I512::try_from(103).unwrap());
+
+        // Sell 100 of `token` back into the same account: the trader nets 98,
+        // so the simulation measures 98 - 100 = -2. The correction must report
+        // the 98 actually received.
+        let sell_query = PriceQuery {
+            in_amount: 100.try_into().unwrap(),
+            kind: OrderKind::Sell,
+            sell_token: token,
+            buy_token: token,
+        };
+        let out = TradeVerifier::post_process_summary(
+            settlement,
+            summary(I512::ZERO - I512::try_from(2).unwrap()),
+            &sell_query,
+            &verification,
+        )
+        .unwrap();
+        assert_eq!(out.out_amount, I512::try_from(98).unwrap());
+
+        // Sanity: with distinct tokens the correction must NOT fire, so a
+        // negative out amount is still rejected as the buffers paying the order.
+        let distinct_query = PriceQuery {
+            in_amount: 100.try_into().unwrap(),
+            kind: OrderKind::Buy,
+            sell_token: token,
+            buy_token: Address::repeat_byte(3),
+        };
+        let err = TradeVerifier::post_process_summary(
+            settlement,
+            summary(I512::ZERO - I512::try_from(2).unwrap()),
+            &distinct_query,
+            &verification,
+        );
+        assert!(matches!(err, Err(Error::BuffersPayForOrder)));
     }
 }

--- a/crates/price-estimation/src/trade_verifier.rs
+++ b/crates/price-estimation/src/trade_verifier.rs
@@ -1038,7 +1038,8 @@ mod tests {
     /// order kinds.
     #[test]
     fn post_process_same_token_recovers_gross_amount() {
-        let token = Address::repeat_byte(1);
+        let token_a = Address::repeat_byte(1);
+        let token_b = Address::repeat_byte(3);
         let trader = Address::repeat_byte(2);
         // A settlement address that is neither trader nor receiver, so the
         // buffer adjustments stay untouched and we isolate the same-token fix.
@@ -1052,7 +1053,7 @@ mod tests {
         let summary = |out_amount: I512| SettleOutput {
             gas_used: U256::ZERO,
             out_amount,
-            tokens_lost: hashmap! { token => BigRational::from_integer(0.into()) },
+            tokens_lost: hashmap! { token_a => BigRational::from_integer(0.into()) },
         };
 
         // Buy 100 of `token` back into the same account: the trader pays 103
@@ -1061,8 +1062,8 @@ mod tests {
         let buy_query = PriceQuery {
             in_amount: 100.try_into().unwrap(),
             kind: OrderKind::Buy,
-            sell_token: token,
-            buy_token: token,
+            sell_token: token_a,
+            buy_token: token_a,
         };
         let out = TradeVerifier::post_process_summary(
             settlement,
@@ -1079,8 +1080,8 @@ mod tests {
         let sell_query = PriceQuery {
             in_amount: 100.try_into().unwrap(),
             kind: OrderKind::Sell,
-            sell_token: token,
-            buy_token: token,
+            sell_token: token_a,
+            buy_token: token_a,
         };
         let out = TradeVerifier::post_process_summary(
             settlement,
@@ -1096,8 +1097,8 @@ mod tests {
         let distinct_query = PriceQuery {
             in_amount: 100.try_into().unwrap(),
             kind: OrderKind::Buy,
-            sell_token: token,
-            buy_token: Address::repeat_byte(3),
+            sell_token: token_a,
+            buy_token: token_b,
         };
         let err = TradeVerifier::post_process_summary(
             settlement,

--- a/crates/shared/src/order_validation.rs
+++ b/crates/shared/src/order_validation.rs
@@ -341,7 +341,7 @@ fn validate_same_sell_and_buy_token(
     }
 
     match (policy, order.kind) {
-        // (SameTokensPolicy::Allow, _) | To be implemented in https://github.com/cowprotocol/services/issues/3963
+        (SameTokensPolicy::Allow, _) => Ok(()),
         (SameTokensPolicy::AllowSell, OrderKind::Sell) => Ok(()),
         _ => Err(PartialValidationError::SameBuyAndSellToken),
     }
@@ -1572,6 +1572,67 @@ mod tests {
                 .await
                 .is_ok()
         );
+    }
+
+    #[tokio::test]
+    async fn pre_validate_same_tokens_allow() {
+        let native_token =
+            WETH9::Instance::new(Address::repeat_byte(0xef), ethrpc::mock::web3().provider);
+        let validity_configuration = OrderValidPeriodConfiguration {
+            min: Duration::from_secs(1),
+            max_market: Duration::from_secs(100),
+            max_limit: Duration::from_secs(200),
+        };
+
+        let mut limit_order_counter = MockLimitOrderCounting::new();
+        limit_order_counter.expect_count().returning(|_| Ok(0u64));
+        let validator = OrderValidator::new(
+            native_token.clone(),
+            Arc::new(order_validation::banned::Users::none()),
+            validity_configuration,
+            false,
+            Default::default(),
+            HooksTrampoline::Instance::new(
+                Address::repeat_byte(0xcf),
+                ProviderBuilder::new()
+                    .connect_mocked_client(Asserter::new())
+                    .erased(),
+            ),
+            Arc::new(MockOrderQuoting::new()),
+            Arc::new(MockBalanceFetching::new()),
+            Arc::new(MockSignatureValidating::new()),
+            None,
+            Arc::new(limit_order_counter),
+            0,
+            Default::default(),
+            u64::MAX,
+            SameTokensPolicy::Allow,
+        );
+
+        let valid_to =
+            || time::now_in_epoch_seconds() + validity_configuration.min.as_secs() as u32 + 2;
+
+        // `Allow` permits same-token orders of either side, including the
+        // native-equivalent (sell WETH, buy native ETH) case.
+        for (sell_token, buy_token) in [
+            (Address::with_last_byte(2), Address::with_last_byte(2)),
+            (*native_token.address(), BUY_ETH_ADDRESS),
+        ] {
+            for kind in [OrderKind::Buy, OrderKind::Sell] {
+                assert!(
+                    validator
+                        .partial_validate(PreOrderData {
+                            kind,
+                            sell_token,
+                            buy_token,
+                            valid_to: valid_to(),
+                            ..Default::default()
+                        })
+                        .await
+                        .is_ok()
+                );
+            }
+        }
     }
 
     #[tokio::test]

--- a/crates/shared/src/order_validation.rs
+++ b/crates/shared/src/order_validation.rs
@@ -1619,13 +1619,14 @@ mod tests {
             (*native_token.address(), BUY_ETH_ADDRESS),
         ] {
             for kind in [OrderKind::Buy, OrderKind::Sell] {
+				let valid_to = time::now_in_epoch_seconds() + validity_configuration.min.as_secs() as u32 + 2;
                 assert!(
                     validator
                         .partial_validate(PreOrderData {
                             kind,
                             sell_token,
                             buy_token,
-                            valid_to: valid_to(),
+                            valid_to,
                             ..Default::default()
                         })
                         .await

--- a/crates/shared/src/order_validation.rs
+++ b/crates/shared/src/order_validation.rs
@@ -1610,7 +1610,7 @@ mod tests {
         );
 
         let valid_to =
-            || time::now_in_epoch_seconds() + validity_configuration.min.as_secs() as u32 + 2;
+            time::now_in_epoch_seconds() + validity_configuration.min.as_secs() as u32 + 2;
 
         // `Allow` permits same-token orders of either side, including the
         // native-equivalent (sell WETH, buy native ETH) case.
@@ -1619,7 +1619,6 @@ mod tests {
             (*native_token.address(), BUY_ETH_ADDRESS),
         ] {
             for kind in [OrderKind::Buy, OrderKind::Sell] {
-				let valid_to = time::now_in_epoch_seconds() + validity_configuration.min.as_secs() as u32 + 2;
                 assert!(
                     validator
                         .partial_validate(PreOrderData {

--- a/crates/shared/src/order_validation.rs
+++ b/crates/shared/src/order_validation.rs
@@ -1612,8 +1612,11 @@ mod tests {
         let valid_to =
             time::now_in_epoch_seconds() + validity_configuration.min.as_secs() as u32 + 2;
 
-        // `Allow` permits same-token orders of either side, including the
-        // native-equivalent (sell WETH, buy native ETH) case.
+        // `Allow` permits same-token orders of either side. The second pair is the
+        // native-equivalent case: `validate_same_sell_and_buy_token` treats selling
+        // WETH for `BUY_ETH_ADDRESS` (native ETH) as a sell==buy order. The rejection
+        // side is covered by `pre_validate_err` (Disallow) and
+        // `pre_validate_same_tokens_allow_sell` (AllowSell).
         for (sell_token, buy_token) in [
             (Address::with_last_byte(2), Address::with_last_byte(2)),
             (*native_token.address(), BUY_ETH_ADDRESS),


### PR DESCRIPTION
# Description

Adds buy-side support for orders whose buy token equals the sell token (part of
#3963) via a new `SameTokensPolicy::Allow` variant. `AllowSell` only permitted
sell orders, so buy same-token quotes were rejected at validation.

This only adds the capability and test coverage — the default policy stays
`Disallow` and shipped configs keep `AllowSell`, so there is no production
behavior change until a config opts into `allow`.

# Changes

* Add the `SameTokensPolicy::Allow` variant and handle it in order validation.
* Add a buy-side e2e test settling a same-token (WETH→ETH) order end to end.
* Add unit coverage for `Allow` validation and for the same-token `out_amount`
  correction in the trade verifier, which buy quotes can now reach.

# How to test

```
cargo nextest run -p shared -p configs -p price-estimation
cargo nextest run -p e2e local_node --run-ignored ignored-only --test-threads 1 --failure-output final
```
