### PR TITLE
feat(renovate): add renovatebot config for github actions in .github/renovate.json5 🤖

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,5 @@
+# GitHub Actions workflows
+.github/workflows/ @cowprotocol/devops
+
 * @cowprotocol/backend
 

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,2 @@
-# GitHub Actions workflows
-.github/workflows/ @cowprotocol/devops
-
 * @cowprotocol/backend
-
+.github/workflows/ @cowprotocol/devops @cowprotocol/backend

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,0 +1,27 @@
+// This file follows JSON5 syntax, to make it
+// easier to maintain.
+{
+  $schema: "https://docs.renovatebot.com/renovate-schema.json",
+  // Disable every built-in manager (npm, dockerfile, ...) except github-actions.
+  enabledManagers: ["github-actions"],
+  // PR titles use Conventional Commits: `deps(<action>): ...`
+  semanticCommits: "enabled",
+  semanticCommitType: "deps",
+  packageRules: [
+    // GitHub Actions updates: run weekly, skip releases newer than 2 weeks
+    // to avoid picking up freshly published versions that may be unstable or
+    // compromised, and pin to full commit SHAs (with the version as a
+    // trailing comment) rather than mutable tags.
+    // When both major and minor releases exist, propose only the latest bump
+    // (typically major) instead of a separate minor PR.
+    {
+      matchManagers: ["github-actions"],
+      schedule: ["on monday"],
+      minimumReleaseAge: "14 days",
+      pinDigests: true,
+      separateMajorMinor: false,
+      semanticCommitScope: "{{depName}}",
+      commitMessageTopic: "{{depName}}",
+    },
+  ],
+}


### PR DESCRIPTION
## What
- Configure renovatebot to manage github actions dependencies
- Schedule updates weekly on Monday
- Introduce 14-day minimum release age for stability
- Pin github actions to full commit shas
- Disable separate major/minor prs for github actions

## Proposed Updates
### Regenerate

```bash
export RENOVATE_GITHUB_COM_TOKEN="$(gh auth token)"
cd "$(git rev-parse --show-toplevel)"
npx renovate@39 --platform=local --dry-run=lookup
```

- `RENOVATE_GITHUB_COM_TOKEN` is required; without it Renovate extracts deps but cannot resolve updates.
- For a scannable list in logs, use `LOG_LEVEL=debug` and inspect `packageFiles with updates` / branch summaries.

### Packages that would be updated

| Action | Current | New | Update type |
|--------|---------|-----|-------------|
| `actions/add-to-project` | v1.0.2 | v2.0.0 | major |
| `actions/checkout` | v4.x | v6.0.2 | major |
| `actions/github-script` | v7.0.1 | v9.0.0 | major |
| `actions/stale` | v9.1.0 | v10.2.0 | major |
| `actions/upload-artifact` | v4.6.2 | v7.0.1 | major |
| `actions-rs/toolchain` | v1.0.6 | v1.0.7 | patch |
| `anthropics/claude-code-action` | v1 (pinned SHA) | digest refresh | digest |
| `aquasecurity/trivy-action` | v0.35.0 | v0.36.0 | minor |
| `docker/build-push-action` | v6.18.0 | v7.1.0 | major |
| `docker/login-action` | v3.4.0 | v4.1.0 | major |
| `docker/metadata-action` | v5.7.0 | v6.0.0 | major |
| `foundry-rs/foundry-toolchain` | v1.4.0 | v1.8.0 | minor |
| `github/codeql-action` | v3.29.x | v4.35.5 | major |
| `slackapi/slack-github-action` | v2.1.1 | v3.0.3 | major |
| `Swatinem/rust-cache` | v2.8.0 | v2.9.1 | minor |
| `taiki-e/install-action` | pinned SHA | digest refresh | digest |
| `tombi-toml/setup-tombi` | v1.0.8 | v1.0.11 | patch |

*Snapshot from dry-run (2026-06-03, [renovate.json5](renovate.json5)); re-run the command above to refresh before merge if config or workflows change.*
