### PR TITLE
Detect false positive reverts

### DIFF
--- a/crates/driver/src/domain/mempools.rs
+++ b/crates/driver/src/domain/mempools.rs
@@ -278,7 +278,7 @@ impl Mempools {
                             // Since the autopilot only distributes orders while no one else is
                             // trying to submit txs for it this error is extremely likely a false
                             // positive so we ignore it.
-                            if err.revert_bytes().is_none_or(|bytes| &bytes != ORDER_FILLED) {
+                            if err.revert_bytes().is_some_and(|bytes| &bytes == ORDER_FILLED) {
                                 tracing::debug!(?err, "ignoring revert as it's likely a false positive");
                             } else if err.is_revert() {
                                 tracing::info!(

--- a/crates/driver/src/domain/mempools.rs
+++ b/crates/driver/src/domain/mempools.rs
@@ -264,7 +264,23 @@ impl Mempools {
                         }
                         // Check if transaction still simulates
                         if let Err(err) = self.ethereum.estimate_gas(tx.clone()).await {
-                            if err.is_revert() {
+                            /// Revert data encoding `GPv2: order filled`
+                            const ORDER_FILLED: &[u8] = &alloy::hex!("08c379a0\
+                                0000000000000000000000000000000000000000000000000000000000000020\
+                                0000000000000000000000000000000000000000000000000000000000000012\
+                                475076323a206f726465722066696c6c65640000000000000000000000000000");
+
+                            // We want to simulate on the `pending` block to be able to react to an
+                            // incoming revert BEFORE it happens. However, the tx we submitted earlier
+                            // which is already sitting in the mempool can cause this simulation to
+                            // fail. If the simulation fails because our pending tx interfered with
+                            // us the revert will complain about the order already being filled.
+                            // Since the autopilot only distributes orders while no one else is
+                            // trying to submit txs for it this error is extremely likely a false
+                            // positive so we ignore it.
+                            if err.revert_bytes().is_none_or(|bytes| &bytes != ORDER_FILLED) {
+                                tracing::debug!(?err, "ignoring revert as it's likely a false positive");
+                            } else if err.is_revert() {
                                 tracing::info!(
                                     settle_tx_hash = ?hash,
                                     ?err,

--- a/crates/driver/src/infra/blockchain/mod.rs
+++ b/crates/driver/src/infra/blockchain/mod.rs
@@ -330,11 +330,11 @@ impl Error {
     }
 
     pub fn revert_bytes(&self) -> Option<Bytes> {
-        let Error::Rpc(err) = self else {
-            return None;
-        };
-
-        err.as_error_resp().and_then(|err| err.as_revert_data())
+        match self {
+            Error::ContractRpc(err) => err.as_revert_data(),
+            Error::Rpc(err) => err.as_error_resp().and_then(|err| err.as_revert_data()),
+            _ => None,
+        }
     }
 }
 

--- a/crates/driver/src/infra/blockchain/mod.rs
+++ b/crates/driver/src/infra/blockchain/mod.rs
@@ -4,6 +4,7 @@ use {
     alloy::{
         eips::eip1559::Eip1559Estimation,
         network::TransactionBuilder,
+        primitives::Bytes,
         providers::Provider,
         rpc::types::{TransactionReceipt, TransactionRequest},
         transports::TransportErrorKind,
@@ -326,6 +327,14 @@ impl Error {
                 is_revert
             }
         }
+    }
+
+    pub fn revert_bytes(&self) -> Option<Bytes> {
+        let Error::Rpc(err) = self else {
+            return None;
+        };
+
+        err.as_error_resp().and_then(|err| err.as_revert_data())
     }
 }
 


### PR DESCRIPTION
# Description
When the driver submits a tx it checks on every new block whether the tx was mined and if the tx would still work or cause a revert by now. In order to detect a revert as early as possible we simulate on the `pending` block as that already includes the state changes of txs that would be applied BEFORE our tx.
However, since our tx is already sitting in the mempool we now have 2 txs that are conflicting with each other. This seems to be only an issue for public mempools as it stands to reason that private mempools would not implement simulations on `pending` correctly as that would leak information about pending privately submitted txs.

# Changes
The easiest solution would be to just simulate the txs on the `latest` block. However, that was already tried a while back and lead to a lot of reverts since the driver would no longer detect when our tx would be rendered impossible if some other higher priced pending tx would already take advantage of an crucial arbitrage opportunity for example.

Instead this PR explicitly detects `order filled` reverts as those are basically guaranteed to be false positives originating from those conflicting `pending` simulations. The reason is that the `autopilot` only gives the right to execute an order to 1 solver at a time until the submission deadline expires. So while it's technically possible that some solver is not cancelling their txs or settling orders out of competition this is extremely rare and the benefits vastly outweigh the costs.

This also has another nice benefit.
Especially on `avalanche` it appears to be the case that the node informs us about a new block before it fully processed all included transactions. This leads to this sequence:
1. new block appears
2. we can't find the receipt for our tx
3. we check if our tx would still work
4. since the tx was actually mined we see the `order filled` error
5. we try to submit a cancellation
6. cancellation fails with `nonce too low` because the nonce of the original tx was actually already used

With this PR is as follows:
1. new block appears
2. we can't find the receipt for our tx
3. we check if our tx would still work
4. since the tx was actually mined we see the `order filled` error
5. we do nothing and wait for the next block
6. new block appears
7. now we find the tx receipt

## How to test
Verified that on avalanche the submissions with `ignoring revert as it's likely a false positive` ultimately lead to a successful submission.
Time to happy Moo on polygon recovered to 90%.