### PR TITLE
[TRIVIAL] Consistent format for logging transmission latency

### DIFF
--- a/crates/autopilot/src/infra/solvers/byte_stream.rs
+++ b/crates/autopilot/src/infra/solvers/byte_stream.rs
@@ -56,8 +56,8 @@ impl Stream for ByteStream {
             let _span = this.span.enter();
             let first_poll = this.first_polled_at.expect("initialized at first poll");
             tracing::debug!(
-                to_transmission_start_ms = ?first_poll.duration_since(this.created_at).as_millis(),
-                transmission_ms = ?first_poll.elapsed().as_millis(),
+                to_transmission_start_ms = first_poll.duration_since(this.created_at).as_millis(),
+                transmission_ms = first_poll.elapsed().as_millis(),
                 "finished streaming http request body"
             );
             Poll::Ready(None)

--- a/crates/autopilot/src/infra/solvers/byte_stream.rs
+++ b/crates/autopilot/src/infra/solvers/byte_stream.rs
@@ -56,8 +56,8 @@ impl Stream for ByteStream {
             let _span = this.span.enter();
             let first_poll = this.first_polled_at.expect("initialized at first poll");
             tracing::debug!(
-                to_transmission_start = ?first_poll.duration_since(this.created_at),
-                transmission = ?first_poll.elapsed(),
+                to_transmission_start_ms = ?first_poll.duration_since(this.created_at).as_millis(),
+                transmission_ms = ?first_poll.elapsed().as_millis(),
                 "finished streaming http request body"
             );
             Poll::Ready(None)


### PR DESCRIPTION
# Description
Being able to log the transmission latency is already quite useful but the current format (which can switch between `ms` and `s`) is a bit annoying to for dashboards.

# Changes
switch to always logging latency in milliseconds
