### PR TITLE
replace AlloyU256 alias with U256

### DIFF
--- a/crates/price-estimation/src/sanitized.rs
+++ b/crates/price-estimation/src/sanitized.rs
@@ -153,7 +153,7 @@ mod tests {
     use {
         super::*,
         crate::{HEALTHY_PRICE_ESTIMATION_TIME, MockPriceEstimating},
-        alloy::primitives::{Address, U256 as AlloyU256},
+        alloy::primitives::{Address, U256},
         model::order::OrderKind,
         number::nonzero::NonZeroU256,
     };
@@ -180,7 +180,7 @@ mod tests {
                     timeout: HEALTHY_PRICE_ESTIMATION_TIME,
                 },
                 Ok(Estimate {
-                    out_amount: AlloyU256::ONE,
+                    out_amount: U256::ONE,
                     gas: 100,
                     solver: Default::default(),
                     verified: false,
@@ -201,7 +201,7 @@ mod tests {
                     timeout: HEALTHY_PRICE_ESTIMATION_TIME,
                 },
                 Ok(Estimate {
-                    out_amount: AlloyU256::ONE,
+                    out_amount: U256::ONE,
                     //sanitized_estimator will add ETH_UNWRAP_COST to the gas of any
                     //Query with ETH as the buy_token.
                     gas: GAS_PER_WETH_UNWRAP + 100,
@@ -239,7 +239,7 @@ mod tests {
                     timeout: HEALTHY_PRICE_ESTIMATION_TIME,
                 },
                 Ok(Estimate {
-                    out_amount: AlloyU256::ONE,
+                    out_amount: U256::ONE,
                     //sanitized_estimator will add ETH_WRAP_COST to the gas of any
                     //Query with ETH as the sell_token.
                     gas: GAS_PER_WETH_WRAP + 100,
@@ -261,7 +261,7 @@ mod tests {
                     timeout: HEALTHY_PRICE_ESTIMATION_TIME,
                 },
                 Ok(Estimate {
-                    out_amount: AlloyU256::ONE,
+                    out_amount: U256::ONE,
                     gas: 0,
                     solver: Default::default(),
                     verified: true,
@@ -280,7 +280,7 @@ mod tests {
                     timeout: HEALTHY_PRICE_ESTIMATION_TIME,
                 },
                 Ok(Estimate {
-                    out_amount: AlloyU256::ONE,
+                    out_amount: U256::ONE,
                     gas: 0,
                     solver: Default::default(),
                     verified: true,
@@ -299,7 +299,7 @@ mod tests {
                     timeout: HEALTHY_PRICE_ESTIMATION_TIME,
                 },
                 Ok(Estimate {
-                    out_amount: AlloyU256::ONE,
+                    out_amount: U256::ONE,
                     // Sanitized estimator will report a 1:1 estimate when unwrapping native token.
                     gas: GAS_PER_WETH_UNWRAP + SETTLEMENT_OVERHEAD,
                     solver: Default::default(),
@@ -319,7 +319,7 @@ mod tests {
                     timeout: HEALTHY_PRICE_ESTIMATION_TIME,
                 },
                 Ok(Estimate {
-                    out_amount: AlloyU256::ONE,
+                    out_amount: U256::ONE,
                     // Sanitized estimator will report a 1:1 estimate when wrapping native token.
                     gas: GAS_PER_WETH_WRAP + SETTLEMENT_OVERHEAD,
                     solver: Default::default(),
@@ -387,7 +387,7 @@ mod tests {
             .returning(|_| {
                 async {
                     Ok(Estimate {
-                        out_amount: AlloyU256::ONE,
+                        out_amount: U256::ONE,
                         gas: 100,
                         solver: Default::default(),
                         verified: false,
@@ -403,7 +403,7 @@ mod tests {
             .returning(|_| {
                 async {
                     Ok(Estimate {
-                        out_amount: AlloyU256::ONE,
+                        out_amount: U256::ONE,
                         gas: 100,
                         solver: Default::default(),
                         verified: false,
@@ -419,7 +419,7 @@ mod tests {
             .returning(|_| {
                 async {
                     Ok(Estimate {
-                        out_amount: AlloyU256::ONE,
+                        out_amount: U256::ONE,
                         gas: u64::MAX,
                         solver: Default::default(),
                         verified: false,
@@ -435,7 +435,7 @@ mod tests {
             .returning(|_| {
                 async {
                     Ok(Estimate {
-                        out_amount: AlloyU256::ONE,
+                        out_amount: U256::ONE,
                         gas: 100,
                         solver: Default::default(),
                         verified: false,
@@ -478,7 +478,7 @@ mod tests {
                     timeout: HEALTHY_PRICE_ESTIMATION_TIME,
                 },
                 Ok(Estimate {
-                    out_amount: AlloyU256::ONE,
+                    out_amount: U256::ONE,
                     gas: 100,
                     solver: Default::default(),
                     verified: true,
@@ -496,7 +496,7 @@ mod tests {
                     timeout: HEALTHY_PRICE_ESTIMATION_TIME,
                 },
                 Ok(Estimate {
-                    out_amount: AlloyU256::ONE,
+                    out_amount: U256::ONE,
                     gas: 100,
                     solver: Default::default(),
                     verified: true,
@@ -521,7 +521,7 @@ mod tests {
             .returning(|_| {
                 async {
                     Ok(Estimate {
-                        out_amount: AlloyU256::ONE,
+                        out_amount: U256::ONE,
                         gas: 100,
                         solver: Default::default(),
                         verified: true,
@@ -537,7 +537,7 @@ mod tests {
             .returning(|_| {
                 async {
                     Ok(Estimate {
-                        out_amount: AlloyU256::ONE,
+                        out_amount: U256::ONE,
                         gas: 100,
                         solver: Default::default(),
                         verified: true,

--- a/crates/shared/src/order_quoting.rs
+++ b/crates/shared/src/order_quoting.rs
@@ -725,9 +725,10 @@ pub struct QuoteMetadataV1 {
 mod tests {
     use {
         super::*,
-        Address,
-        U256 as AlloyU256,
-        alloy::eips::eip1559::Eip1559Estimation,
+        alloy::{
+            eips::eip1559::Eip1559Estimation,
+            primitives::{Address, U256},
+        },
         chrono::Utc,
         futures::FutureExt,
         gas_price_estimation::FakeGasPriceEstimator,
@@ -810,7 +811,7 @@ mod tests {
             .returning(|_| {
                 async {
                     Ok(price_estimation::Estimate {
-                        out_amount: AlloyU256::from(42),
+                        out_amount: U256::from(42),
                         gas: 3,
                         solver: Address::repeat_byte(1),
                         verified: false,
@@ -949,7 +950,7 @@ mod tests {
             .returning(|_| {
                 async {
                     Ok(price_estimation::Estimate {
-                        out_amount: AlloyU256::from(42),
+                        out_amount: U256::from(42),
                         gas: 3,
                         solver: Address::repeat_byte(1),
                         verified: false,
@@ -1083,7 +1084,7 @@ mod tests {
             .returning(|_| {
                 async {
                     Ok(price_estimation::Estimate {
-                        out_amount: AlloyU256::from(100),
+                        out_amount: U256::from(100),
                         gas: 3,
                         solver: Address::repeat_byte(1),
                         verified: false,
@@ -1202,7 +1203,7 @@ mod tests {
         price_estimator.expect_estimate().returning(|_| {
             async {
                 Ok(price_estimation::Estimate {
-                    out_amount: AlloyU256::from(100),
+                    out_amount: U256::from(100),
                     gas: 200,
                     solver: Address::repeat_byte(1),
                     verified: false,
@@ -1274,7 +1275,7 @@ mod tests {
         price_estimator.expect_estimate().returning(|_| {
             async {
                 Ok(price_estimation::Estimate {
-                    out_amount: AlloyU256::from(100),
+                    out_amount: U256::from(100),
                     gas: 200,
                     solver: Address::repeat_byte(1),
                     verified: false,


### PR DESCRIPTION
# Description
Removes the `AlloyU256` alias.

# Changes
* Replace `U256 as AlloyU256` import alias with plain `U256` in `price-estimation/src/sanitized.rs` and `shared/src/order_quoting.rs`

Fixes #4502 

