### PR TITLE
Avoid false-positive settlement cancellations during node receipt lag

### DIFF
--- a/crates/driver/src/domain/mempools.rs
+++ b/crates/driver/src/domain/mempools.rs
@@ -264,30 +264,35 @@ impl Mempools {
                         }
                         // A node can report a new block before its receipt index catches up,
                         // so re-simulating reverts on our own already-applied tx. Tell that
-                        // apart from a real revert with two signals: our `Settlement` event on
-                        // the latest block (which `eth_getLogs` sees even while the receipt
-                        // lags), and the signer's pending nonce (which still covers our tx
-                        // while it sits in the mempool).
+                        // apart from a real revert with two signals: our `Settlement` event in
+                        // any block since submission (which `eth_getLogs` sees even while the
+                        // receipt lags), and the signer's pending nonce (which still covers our
+                        // tx while it sits in the mempool).
                         let (gas, mined, pending_nonce) = futures::join!(
                             self.ethereum.estimate_gas(tx.clone()),
-                            self.ethereum.contains_successful_tx(hash, block.number),
+                            self.ethereum.successful_settlement_block(
+                                hash,
+                                submission_block.0,
+                                block.number,
+                            ),
                             self.ethereum.pending_transaction_count(signer),
                         );
 
-                        if matches!(mined, Ok(true)) {
-                            // Our event is in this block (we queried it by number), so the tx
-                            // mined here even though transaction_status has not confirmed it
-                            // yet. Report success now rather than wait on the receipt and risk
-                            // the deadline.
+                        if let Ok(Some(included_in_block)) = mined {
+                            // Found on-chain in [submission_block, head]. The receipt-by-hash
+                            // lookup is just lagging, and scanning the whole range catches it
+                            // even if the block stream coalesced past the block it mined in.
+                            // Report success now rather than wait on the receipt and risk the
+                            // deadline.
                             tracing::info!(
                                 ?hash,
-                                included_in_block = block.number,
+                                ?included_in_block,
                                 "settlement found on-chain via getLogs, treating as success"
                             );
                             return Ok(SubmissionSuccess {
                                 tx_hash: hash,
                                 submitted_at_block: submission_block,
-                                included_in_block: block.number.into(),
+                                included_in_block,
                             });
                         }
 

--- a/crates/driver/src/domain/mempools.rs
+++ b/crates/driver/src/domain/mempools.rs
@@ -664,9 +664,9 @@ impl Error {
 }
 
 /// What to do with a submitted settlement whose receipt is not yet available. A
-/// node can report a block before its receipt index catches up, so re-simulation
-/// reverts on an already-mined tx. We disambiguate with our `Settlement` event
-/// on `latest` and `pending`.
+/// node can report a block before its receipt index catches up, so
+/// re-simulation reverts on an already-mined tx. We disambiguate with our
+/// `Settlement` event on `latest` and `pending`.
 #[derive(Debug)]
 enum ResimOutcome {
     /// Our settlement is already mined in this block. The receipt is just
@@ -682,8 +682,8 @@ enum ResimOutcome {
 
 /// Decides what to do when a submitted settlement's receipt is not yet
 /// available. `in_latest` / `in_pending` are the blocks our `Settlement` event
-/// was found in, if any. `resimulation_reverted` is whether re-simulating the tx
-/// reverted.
+/// was found in, if any. `resimulation_reverted` is whether re-simulating the
+/// tx reverted.
 fn classify_resimulation(
     in_latest: Option<BlockNo>,
     in_pending: Option<BlockNo>,

--- a/crates/driver/src/domain/mempools.rs
+++ b/crates/driver/src/domain/mempools.rs
@@ -663,10 +663,10 @@ impl Error {
 }
 
 /// Whether a submitted settlement whose receipt is missing should be cancelled.
-/// Cancel only on positive evidence it will not land: re-simulation reverted and
-/// both `latest` and `pending` confirm our `Settlement` event is absent. A failed
-/// lookup counts as "unknown", so we keep waiting rather than cancel a tx that may
-/// have mined.
+/// Cancel only on positive evidence it will not land: re-simulation reverted
+/// and both `latest` and `pending` confirm our `Settlement` event is absent. A
+/// failed lookup counts as "unknown", so we keep waiting rather than cancel a
+/// tx that may have mined.
 fn requires_cancellation<E>(
     resimulation_reverted: bool,
     in_latest: &Result<bool, E>,

--- a/crates/driver/src/domain/mempools.rs
+++ b/crates/driver/src/domain/mempools.rs
@@ -266,61 +266,60 @@ impl Mempools {
                                 submission_deadline,
                             });
                         }
-                        // A node can report a new block before its receipt index catches up.
-                        // Re-simulating then reverts on our own already-applied tx, a false
-                        // positive. Tell it apart from a real revert with our `Settlement` event
-                        // on `latest` (mined) and `pending` (about to mine).
+                        // A node can report a new block before its receipt index catches up,
+                        // so re-simulating reverts on our own already-applied tx. Before
+                        // treating that as a real revert, check whether our `Settlement` event
+                        // is already on `latest` (mined) or `pending` (about to mine).
                         let (gas, in_latest, in_pending) = futures::join!(
                             self.ethereum.estimate_gas(tx.clone()),
-                            self.ethereum.settlement_block(hash, BlockNumberOrTag::Latest),
-                            self.ethereum.settlement_block(hash, BlockNumberOrTag::Pending),
+                            self.ethereum.contains_successful_tx(hash, BlockNumberOrTag::Latest),
+                            self.ethereum.contains_successful_tx(hash, BlockNumberOrTag::Pending),
                         );
 
+                        // A lookup error is not evidence of non-inclusion. A `latest` failure is
+                        // unusual, a `pending` one is expected on nodes without pending-log
+                        // support, so they log at different levels.
+                        if let Err(err) = &in_latest {
+                            tracing::warn!(?hash, ?err, "settlement lookup on latest failed");
+                        }
+                        if let Err(err) = &in_pending {
+                            tracing::debug!(?hash, ?err, "settlement lookup on pending failed");
+                        }
+
+                        if matches!(&in_latest, Ok(true)) {
+                            // Mined already, the receipt is just lagging. Report success now
+                            // instead of risking the receipt arriving after the deadline.
+                            tracing::info!(
+                                ?hash,
+                                included_in_block = block.number,
+                                "settlement mined, treating as success despite a missing receipt"
+                            );
+                            return Ok(SubmissionSuccess {
+                                tx_hash: hash,
+                                submitted_at_block: submission_block,
+                                included_in_block: block.number.into(),
+                            });
+                        }
+
                         let resimulation_reverted = matches!(&gas, Err(err) if err.is_revert());
-                        match classify_resimulation(
-                            in_latest.unwrap_or_default(),
-                            in_pending.unwrap_or_default(),
-                            resimulation_reverted,
-                        ) {
-                            ResimOutcome::AlreadyMined(included_in_block) => {
-                                tracing::info!(
-                                    ?hash,
-                                    ?included_in_block,
-                                    "settlement found on-chain, treating as success despite a \
-                                     missing receipt"
-                                );
-                                return Ok(SubmissionSuccess {
-                                    tx_hash: hash,
-                                    submitted_at_block: submission_block,
-                                    included_in_block,
-                                });
-                            }
-                            ResimOutcome::PendingWillSucceed => {
-                                tracing::debug!(
-                                    ?hash,
-                                    "settlement present on the pending block, waiting for \
-                                     inclusion"
-                                );
-                            }
-                            ResimOutcome::Revert => {
-                                tracing::info!(
-                                    settle_tx_hash = ?hash,
-                                    err = ?gas.as_ref().err(),
-                                    "tx started failing in mempool, cancelling"
-                                );
-                                let _ = self
-                                    .cancel(mempool, final_gas_price, signer, nonce)
-                                    .await;
-                                return Err(Error::SimulationRevert {
-                                    submitted_at_block: submission_block,
-                                    reverted_at_block: block.number.into(),
-                                });
-                            }
-                            ResimOutcome::Inconclusive => {
-                                if let Err(err) = &gas {
-                                    tracing::warn!(?hash, ?err, "couldn't re-simulate tx");
-                                }
-                            }
+                        if requires_cancellation(resimulation_reverted, &in_latest, &in_pending) {
+                            tracing::info!(
+                                settle_tx_hash = ?hash,
+                                err = ?gas.as_ref().err(),
+                                "tx started failing in mempool, cancelling"
+                            );
+                            let _ = self.cancel(mempool, final_gas_price, signer, nonce).await;
+                            return Err(Error::SimulationRevert {
+                                submitted_at_block: submission_block,
+                                reverted_at_block: block.number.into(),
+                            });
+                        } else if matches!(&in_pending, Ok(true)) {
+                            tracing::debug!(
+                                ?hash,
+                                "settlement in the pending block, waiting for inclusion"
+                            );
+                        } else if let Err(err) = &gas {
+                            tracing::warn!(?hash, ?err, "couldn't re-simulate tx");
                         }
                     }
                 }
@@ -332,8 +331,8 @@ impl Mempools {
         .await;
 
         if result.is_err() {
-            // Do one last attempt to see if the transaction was confirmed (in case of race
-            // conditions or misclassified errors like `OrderFilled` simulation failures).
+            // One last check in case the tx landed after the loop exited, e.g. the
+            // receipt finally caught up to a block we had already processed.
             if let Ok(TxStatus::Executed { block_number }) =
                 self.ethereum.transaction_status(&hash).await
             {
@@ -663,41 +662,17 @@ impl Error {
     }
 }
 
-/// What to do with a submitted settlement whose receipt is not yet available. A
-/// node can report a block before its receipt index catches up, so
-/// re-simulation reverts on an already-mined tx. We disambiguate with our
-/// `Settlement` event on `latest` and `pending`.
-#[derive(Debug)]
-enum ResimOutcome {
-    /// Our settlement is already mined in this block. The receipt is just
-    /// lagging, so treat it as a success.
-    AlreadyMined(BlockNo),
-    /// Our settlement is in the pending block and will succeed once mined.
-    PendingWillSucceed,
-    /// Our settlement is on neither block and re-simulation reverted. Cancel.
-    Revert,
-    /// Re-simulation did not revert and our settlement is not on-chain yet.
-    Inconclusive,
-}
-
-/// Decides what to do when a submitted settlement's receipt is not yet
-/// available. `in_latest` / `in_pending` are the blocks our `Settlement` event
-/// was found in, if any. `resimulation_reverted` is whether re-simulating the
-/// tx reverted.
-fn classify_resimulation(
-    in_latest: Option<BlockNo>,
-    in_pending: Option<BlockNo>,
+/// Whether a submitted settlement whose receipt is missing should be cancelled.
+/// Cancel only on positive evidence it will not land: re-simulation reverted and
+/// both `latest` and `pending` confirm our `Settlement` event is absent. A failed
+/// lookup counts as "unknown", so we keep waiting rather than cancel a tx that may
+/// have mined.
+fn requires_cancellation<E>(
     resimulation_reverted: bool,
-) -> ResimOutcome {
-    if let Some(block) = in_latest {
-        ResimOutcome::AlreadyMined(block)
-    } else if in_pending.is_some() {
-        ResimOutcome::PendingWillSucceed
-    } else if resimulation_reverted {
-        ResimOutcome::Revert
-    } else {
-        ResimOutcome::Inconclusive
-    }
+    in_latest: &Result<bool, E>,
+    in_pending: &Result<bool, E>,
+) -> bool {
+    resimulation_reverted && matches!(in_latest, Ok(false)) && matches!(in_pending, Ok(false))
 }
 
 #[cfg(test)]
@@ -739,40 +714,27 @@ mod tests {
         assert_eq!(prepared.input, Bytes::from(expected));
     }
 
+    const PRESENT: Result<bool, ()> = Ok(true);
+    const ABSENT: Result<bool, ()> = Ok(false);
+    const LOOKUP_FAILED: Result<bool, ()> = Err(());
+
     #[test]
-    fn classify_prefers_already_mined() {
-        match classify_resimulation(Some(BlockNo(10)), None, true) {
-            ResimOutcome::AlreadyMined(block) => assert_eq!(block.0, 10),
-            other => panic!("expected AlreadyMined, got {other:?}"),
-        }
-        // `latest` wins even when `pending` also has it and re-simulation reverted.
-        assert!(matches!(
-            classify_resimulation(Some(BlockNo(10)), Some(BlockNo(10)), true),
-            ResimOutcome::AlreadyMined(_)
-        ));
+    fn cancels_only_on_revert_with_both_blocks_absent() {
+        assert!(requires_cancellation(true, &ABSENT, &ABSENT));
+        // Re-simulation still succeeds, so we wait instead of cancelling.
+        assert!(!requires_cancellation(false, &ABSENT, &ABSENT));
+        // Already present on one of the blocks, so it will land.
+        assert!(!requires_cancellation(true, &PRESENT, &ABSENT));
+        assert!(!requires_cancellation(true, &ABSENT, &PRESENT));
     }
 
     #[test]
-    fn classify_waits_when_only_pending_has_settlement() {
-        assert!(matches!(
-            classify_resimulation(None, Some(BlockNo(11)), true),
-            ResimOutcome::PendingWillSucceed
-        ));
-    }
-
-    #[test]
-    fn classify_cancels_on_genuine_revert() {
-        assert!(matches!(
-            classify_resimulation(None, None, true),
-            ResimOutcome::Revert
-        ));
-    }
-
-    #[test]
-    fn classify_inconclusive_when_not_reverted_and_not_on_chain() {
-        assert!(matches!(
-            classify_resimulation(None, None, false),
-            ResimOutcome::Inconclusive
-        ));
+    fn failed_lookup_is_never_treated_as_absent() {
+        // A failed lookup is unknown and must never trigger a cancel, even on a
+        // revert. Otherwise a flaky or unsupported log query reverts to the
+        // original bug: cancelling a tx that may have mined.
+        assert!(!requires_cancellation(true, &LOOKUP_FAILED, &LOOKUP_FAILED));
+        assert!(!requires_cancellation(true, &ABSENT, &LOOKUP_FAILED));
+        assert!(!requires_cancellation(true, &LOOKUP_FAILED, &ABSENT));
     }
 }

--- a/crates/driver/src/domain/mempools.rs
+++ b/crates/driver/src/domain/mempools.rs
@@ -4,11 +4,7 @@ use {
         domain::{blockchain::TxStatus, competition::solution::Settlement},
         infra::{self, Ethereum, observe},
     },
-    alloy::{
-        consensus::Transaction,
-        eips::eip1559::Eip1559Estimation,
-        primitives::Bytes,
-    },
+    alloy::{consensus::Transaction, eips::eip1559::Eip1559Estimation, primitives::Bytes},
     anyhow::{Context, anyhow},
     eth_domain_types::{self as eth, BlockNo, TxId},
     ethrpc::block_stream::into_stream,
@@ -274,12 +270,13 @@ impl Mempools {
                         // while it sits in the mempool).
                         let (gas, mined, pending_nonce) = futures::join!(
                             self.ethereum.estimate_gas(tx.clone()),
-                            self.ethereum.contains_successful_tx(hash),
+                            self.ethereum.contains_successful_tx(hash, block.number),
                             self.ethereum.pending_transaction_count(signer),
                         );
 
                         if matches!(mined, Ok(true)) {
-                            // Mined already, the receipt is just lagging. Report success now
+                            // Our event is in this block (we queried it by number), so the tx
+                            // mined here and the receipt is just lagging. Report success now
                             // instead of risking the receipt arriving after the deadline.
                             tracing::info!(
                                 ?hash,
@@ -574,9 +571,9 @@ fn delegated_calldata(target: eth::Address, calldata: &Bytes) -> Bytes {
 
 pub struct SubmissionSuccess {
     pub tx_hash: eth::TxId,
-    /// At which block we started to submit the transaction.
-    pub included_in_block: eth::BlockNo,
     /// In which block the transaction actually appeared onchain.
+    pub included_in_block: eth::BlockNo,
+    /// At which block we started to submit the transaction.
     pub submitted_at_block: eth::BlockNo,
 }
 
@@ -663,9 +660,10 @@ impl Error {
 /// Whether a submitted settlement whose receipt is missing should be cancelled.
 /// We cancel only when the re-simulation reverts and the signer's pending nonce
 /// shows our tx is gone from the mempool (`pending_nonce <= submission_nonce`,
-/// so it was neither mined nor is it still queued). While the tx is still queued
-/// the revert is just our own pending tx re-applied, a false positive, so we
-/// keep waiting. A failed nonce lookup counts as "unknown" and never cancels.
+/// so it was neither mined nor is it still queued). While the tx is still
+/// queued the revert is just our own pending tx re-applied, a false positive,
+/// so we keep waiting. A failed nonce lookup counts as "unknown" and never
+/// cancels.
 fn requires_cancellation<E>(
     resimulation_reverted: bool,
     pending_nonce: &Result<u64, E>,
@@ -723,7 +721,11 @@ mod tests {
         // Reverted and the tx is no longer queued: a real revert, cancel.
         assert!(requires_cancellation(true, &DROPPED, SUBMISSION_NONCE));
         // Reverted but still queued: the revert is our own pending tx, so wait.
-        assert!(!requires_cancellation(true, &STILL_QUEUED, SUBMISSION_NONCE));
+        assert!(!requires_cancellation(
+            true,
+            &STILL_QUEUED,
+            SUBMISSION_NONCE
+        ));
         // Re-simulation still succeeds: wait regardless of the nonce.
         assert!(!requires_cancellation(false, &DROPPED, SUBMISSION_NONCE));
     }
@@ -733,6 +735,10 @@ mod tests {
         // An unknown pending nonce must never trigger a cancel, even on a revert.
         // Otherwise a flaky nonce lookup reverts to the original bug: cancelling a
         // tx that may have mined or is still queued.
-        assert!(!requires_cancellation(true, &NONCE_LOOKUP_FAILED, SUBMISSION_NONCE));
+        assert!(!requires_cancellation(
+            true,
+            &NONCE_LOOKUP_FAILED,
+            SUBMISSION_NONCE
+        ));
     }
 }

--- a/crates/driver/src/domain/mempools.rs
+++ b/crates/driver/src/domain/mempools.rs
@@ -4,7 +4,11 @@ use {
         domain::{blockchain::TxStatus, competition::solution::Settlement},
         infra::{self, Ethereum, observe},
     },
-    alloy::{consensus::Transaction, eips::eip1559::Eip1559Estimation, primitives::Bytes},
+    alloy::{
+        consensus::Transaction,
+        eips::{BlockNumberOrTag, eip1559::Eip1559Estimation},
+        primitives::Bytes,
+    },
     anyhow::{Context, anyhow},
     eth_domain_types::{self as eth, BlockNo, TxId},
     ethrpc::block_stream::into_stream,
@@ -262,28 +266,46 @@ impl Mempools {
                                 submission_deadline,
                             });
                         }
-                        // Check if transaction still simulates
-                        if let Err(err) = self.ethereum.estimate_gas(tx.clone()).await {
-                            /// Revert data encoding `GPv2: order filled`
-                            const ORDER_FILLED: &[u8] = &alloy::hex!("08c379a0\
-                                0000000000000000000000000000000000000000000000000000000000000020\
-                                0000000000000000000000000000000000000000000000000000000000000012\
-                                475076323a206f726465722066696c6c65640000000000000000000000000000");
+                        // A node can report a new block before its receipt index catches up.
+                        // Re-simulating then reverts on our own already-applied tx, a false
+                        // positive. Tell it apart from a real revert with our `Settlement` event
+                        // on `latest` (mined) and `pending` (about to mine).
+                        let (gas, in_latest, in_pending) = futures::join!(
+                            self.ethereum.estimate_gas(tx.clone()),
+                            self.ethereum.settlement_block(hash, BlockNumberOrTag::Latest),
+                            self.ethereum.settlement_block(hash, BlockNumberOrTag::Pending),
+                        );
 
-                            // We want to simulate on the `pending` block to be able to react to an
-                            // incoming revert BEFORE it happens. However, the tx we submitted earlier
-                            // which is already sitting in the mempool can cause this simulation to
-                            // fail. If the simulation fails because our pending tx interfered with
-                            // us the revert will complain about the order already being filled.
-                            // Since the autopilot only distributes orders while no one else is
-                            // trying to submit txs for it this error is extremely likely a false
-                            // positive so we ignore it.
-                            if err.revert_bytes().is_some_and(|bytes| &bytes == ORDER_FILLED) {
-                                tracing::debug!(?err, "ignoring revert as it's likely a false positive");
-                            } else if err.is_revert() {
+                        let resimulation_reverted = matches!(&gas, Err(err) if err.is_revert());
+                        match classify_resimulation(
+                            in_latest.unwrap_or_default(),
+                            in_pending.unwrap_or_default(),
+                            resimulation_reverted,
+                        ) {
+                            ResimOutcome::AlreadyMined(included_in_block) => {
+                                tracing::info!(
+                                    ?hash,
+                                    ?included_in_block,
+                                    "settlement found on-chain, treating as success despite a \
+                                     missing receipt"
+                                );
+                                return Ok(SubmissionSuccess {
+                                    tx_hash: hash,
+                                    submitted_at_block: submission_block,
+                                    included_in_block,
+                                });
+                            }
+                            ResimOutcome::PendingWillSucceed => {
+                                tracing::debug!(
+                                    ?hash,
+                                    "settlement present on the pending block, waiting for \
+                                     inclusion"
+                                );
+                            }
+                            ResimOutcome::Revert => {
                                 tracing::info!(
                                     settle_tx_hash = ?hash,
-                                    ?err,
+                                    err = ?gas.as_ref().err(),
                                     "tx started failing in mempool, cancelling"
                                 );
                                 let _ = self
@@ -293,8 +315,11 @@ impl Mempools {
                                     submitted_at_block: submission_block,
                                     reverted_at_block: block.number.into(),
                                 });
-                            } else {
-                                tracing::warn!(?hash, ?err, "couldn't re-simulate tx");
+                            }
+                            ResimOutcome::Inconclusive => {
+                                if let Err(err) = &gas {
+                                    tracing::warn!(?hash, ?err, "couldn't re-simulate tx");
+                                }
                             }
                         }
                     }
@@ -638,6 +663,43 @@ impl Error {
     }
 }
 
+/// What to do with a submitted settlement whose receipt is not yet available. A
+/// node can report a block before its receipt index catches up, so re-simulation
+/// reverts on an already-mined tx. We disambiguate with our `Settlement` event
+/// on `latest` and `pending`.
+#[derive(Debug)]
+enum ResimOutcome {
+    /// Our settlement is already mined in this block. The receipt is just
+    /// lagging, so treat it as a success.
+    AlreadyMined(BlockNo),
+    /// Our settlement is in the pending block and will succeed once mined.
+    PendingWillSucceed,
+    /// Our settlement is on neither block and re-simulation reverted. Cancel.
+    Revert,
+    /// Re-simulation did not revert and our settlement is not on-chain yet.
+    Inconclusive,
+}
+
+/// Decides what to do when a submitted settlement's receipt is not yet
+/// available. `in_latest` / `in_pending` are the blocks our `Settlement` event
+/// was found in, if any. `resimulation_reverted` is whether re-simulating the tx
+/// reverted.
+fn classify_resimulation(
+    in_latest: Option<BlockNo>,
+    in_pending: Option<BlockNo>,
+    resimulation_reverted: bool,
+) -> ResimOutcome {
+    if let Some(block) = in_latest {
+        ResimOutcome::AlreadyMined(block)
+    } else if in_pending.is_some() {
+        ResimOutcome::PendingWillSucceed
+    } else if resimulation_reverted {
+        ResimOutcome::Revert
+    } else {
+        ResimOutcome::Inconclusive
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use {
@@ -675,5 +737,42 @@ mod tests {
         assert_eq!(prepared.from, SUBMITTER);
         assert_eq!(prepared.to, SOLVER);
         assert_eq!(prepared.input, Bytes::from(expected));
+    }
+
+    #[test]
+    fn classify_prefers_already_mined() {
+        match classify_resimulation(Some(BlockNo(10)), None, true) {
+            ResimOutcome::AlreadyMined(block) => assert_eq!(block.0, 10),
+            other => panic!("expected AlreadyMined, got {other:?}"),
+        }
+        // `latest` wins even when `pending` also has it and re-simulation reverted.
+        assert!(matches!(
+            classify_resimulation(Some(BlockNo(10)), Some(BlockNo(10)), true),
+            ResimOutcome::AlreadyMined(_)
+        ));
+    }
+
+    #[test]
+    fn classify_waits_when_only_pending_has_settlement() {
+        assert!(matches!(
+            classify_resimulation(None, Some(BlockNo(11)), true),
+            ResimOutcome::PendingWillSucceed
+        ));
+    }
+
+    #[test]
+    fn classify_cancels_on_genuine_revert() {
+        assert!(matches!(
+            classify_resimulation(None, None, true),
+            ResimOutcome::Revert
+        ));
+    }
+
+    #[test]
+    fn classify_inconclusive_when_not_reverted_and_not_on_chain() {
+        assert!(matches!(
+            classify_resimulation(None, None, false),
+            ResimOutcome::Inconclusive
+        ));
     }
 }

--- a/crates/driver/src/domain/mempools.rs
+++ b/crates/driver/src/domain/mempools.rs
@@ -270,11 +270,8 @@ impl Mempools {
                         // tx while it sits in the mempool).
                         let (gas, mined, pending_nonce) = futures::join!(
                             self.ethereum.estimate_gas(tx.clone()),
-                            self.ethereum.successful_settlement_block(
-                                hash,
-                                submission_block.0,
-                                block.number,
-                            ),
+                            self.ethereum
+                                .successful_settlement_block(hash, submission_block.0),
                             self.ethereum.pending_transaction_count(signer),
                         );
 
@@ -301,7 +298,7 @@ impl Mempools {
                             tracing::info!(
                                 settle_tx_hash = ?hash,
                                 err = ?gas.as_ref().err(),
-                                "tx dropped from the mempool without mining, cancelling"
+                                "tx started failing in mempool, cancelling"
                             );
                             let _ = self.cancel(mempool, final_gas_price, signer, nonce).await;
                             return Err(Error::SimulationRevert {
@@ -317,7 +314,8 @@ impl Mempools {
                         } else if resimulation_reverted {
                             tracing::debug!(
                                 ?hash,
-                                "tx still queued in the mempool, waiting for inclusion"
+                                "detected false positive revert (already pending tx conflicted \
+                                 with our simulation), waiting for next block"
                             );
                         } else if let Err(err) = &gas {
                             tracing::warn!(?hash, ?err, "couldn't re-simulate tx");

--- a/crates/driver/src/domain/mempools.rs
+++ b/crates/driver/src/domain/mempools.rs
@@ -276,12 +276,13 @@ impl Mempools {
 
                         if matches!(mined, Ok(true)) {
                             // Our event is in this block (we queried it by number), so the tx
-                            // mined here and the receipt is just lagging. Report success now
-                            // instead of risking the receipt arriving after the deadline.
+                            // mined here even though transaction_status has not confirmed it
+                            // yet. Report success now rather than wait on the receipt and risk
+                            // the deadline.
                             tracing::info!(
                                 ?hash,
                                 included_in_block = block.number,
-                                "settlement mined, treating as success despite a missing receipt"
+                                "settlement found on-chain via getLogs, treating as success"
                             );
                             return Ok(SubmissionSuccess {
                                 tx_hash: hash,

--- a/crates/driver/src/domain/mempools.rs
+++ b/crates/driver/src/domain/mempools.rs
@@ -6,7 +6,7 @@ use {
     },
     alloy::{
         consensus::Transaction,
-        eips::{BlockNumberOrTag, eip1559::Eip1559Estimation},
+        eips::eip1559::Eip1559Estimation,
         primitives::Bytes,
     },
     anyhow::{Context, anyhow},
@@ -267,26 +267,18 @@ impl Mempools {
                             });
                         }
                         // A node can report a new block before its receipt index catches up,
-                        // so re-simulating reverts on our own already-applied tx. Before
-                        // treating that as a real revert, check whether our `Settlement` event
-                        // is already on `latest` (mined) or `pending` (about to mine).
-                        let (gas, in_latest, in_pending) = futures::join!(
+                        // so re-simulating reverts on our own already-applied tx. Tell that
+                        // apart from a real revert with two signals: our `Settlement` event on
+                        // the latest block (which `eth_getLogs` sees even while the receipt
+                        // lags), and the signer's pending nonce (which still covers our tx
+                        // while it sits in the mempool).
+                        let (gas, mined, pending_nonce) = futures::join!(
                             self.ethereum.estimate_gas(tx.clone()),
-                            self.ethereum.contains_successful_tx(hash, BlockNumberOrTag::Latest),
-                            self.ethereum.contains_successful_tx(hash, BlockNumberOrTag::Pending),
+                            self.ethereum.contains_successful_tx(hash),
+                            self.ethereum.pending_transaction_count(signer),
                         );
 
-                        // A lookup error is not evidence of non-inclusion. A `latest` failure is
-                        // unusual, a `pending` one is expected on nodes without pending-log
-                        // support, so they log at different levels.
-                        if let Err(err) = &in_latest {
-                            tracing::warn!(?hash, ?err, "settlement lookup on latest failed");
-                        }
-                        if let Err(err) = &in_pending {
-                            tracing::debug!(?hash, ?err, "settlement lookup on pending failed");
-                        }
-
-                        if matches!(&in_latest, Ok(true)) {
+                        if matches!(mined, Ok(true)) {
                             // Mined already, the receipt is just lagging. Report success now
                             // instead of risking the receipt arriving after the deadline.
                             tracing::info!(
@@ -302,21 +294,27 @@ impl Mempools {
                         }
 
                         let resimulation_reverted = matches!(&gas, Err(err) if err.is_revert());
-                        if requires_cancellation(resimulation_reverted, &in_latest, &in_pending) {
+                        if requires_cancellation(resimulation_reverted, &pending_nonce, nonce) {
                             tracing::info!(
                                 settle_tx_hash = ?hash,
                                 err = ?gas.as_ref().err(),
-                                "tx started failing in mempool, cancelling"
+                                "tx dropped from the mempool without mining, cancelling"
                             );
                             let _ = self.cancel(mempool, final_gas_price, signer, nonce).await;
                             return Err(Error::SimulationRevert {
                                 submitted_at_block: submission_block,
                                 reverted_at_block: block.number.into(),
                             });
-                        } else if matches!(&in_pending, Ok(true)) {
+                        } else if let Err(err) = &pending_nonce {
+                            tracing::warn!(
+                                ?hash,
+                                ?err,
+                                "couldn't fetch the pending nonce, not cancelling"
+                            );
+                        } else if resimulation_reverted {
                             tracing::debug!(
                                 ?hash,
-                                "settlement in the pending block, waiting for inclusion"
+                                "tx still queued in the mempool, waiting for inclusion"
                             );
                         } else if let Err(err) = &gas {
                             tracing::warn!(?hash, ?err, "couldn't re-simulate tx");
@@ -663,16 +661,17 @@ impl Error {
 }
 
 /// Whether a submitted settlement whose receipt is missing should be cancelled.
-/// Cancel only on positive evidence it will not land: re-simulation reverted
-/// and both `latest` and `pending` confirm our `Settlement` event is absent. A
-/// failed lookup counts as "unknown", so we keep waiting rather than cancel a
-/// tx that may have mined.
+/// We cancel only when the re-simulation reverts and the signer's pending nonce
+/// shows our tx is gone from the mempool (`pending_nonce <= submission_nonce`,
+/// so it was neither mined nor is it still queued). While the tx is still queued
+/// the revert is just our own pending tx re-applied, a false positive, so we
+/// keep waiting. A failed nonce lookup counts as "unknown" and never cancels.
 fn requires_cancellation<E>(
     resimulation_reverted: bool,
-    in_latest: &Result<bool, E>,
-    in_pending: &Result<bool, E>,
+    pending_nonce: &Result<u64, E>,
+    submission_nonce: u64,
 ) -> bool {
-    resimulation_reverted && matches!(in_latest, Ok(false)) && matches!(in_pending, Ok(false))
+    resimulation_reverted && matches!(pending_nonce, Ok(n) if *n <= submission_nonce)
 }
 
 #[cfg(test)]
@@ -714,27 +713,26 @@ mod tests {
         assert_eq!(prepared.input, Bytes::from(expected));
     }
 
-    const PRESENT: Result<bool, ()> = Ok(true);
-    const ABSENT: Result<bool, ()> = Ok(false);
-    const LOOKUP_FAILED: Result<bool, ()> = Err(());
+    const SUBMISSION_NONCE: u64 = 7;
+    const STILL_QUEUED: Result<u64, ()> = Ok(8); // pending advanced past our nonce
+    const DROPPED: Result<u64, ()> = Ok(7); // pending still at our nonce, tx is gone
+    const NONCE_LOOKUP_FAILED: Result<u64, ()> = Err(());
 
     #[test]
-    fn cancels_only_on_revert_with_both_blocks_absent() {
-        assert!(requires_cancellation(true, &ABSENT, &ABSENT));
-        // Re-simulation still succeeds, so we wait instead of cancelling.
-        assert!(!requires_cancellation(false, &ABSENT, &ABSENT));
-        // Already present on one of the blocks, so it will land.
-        assert!(!requires_cancellation(true, &PRESENT, &ABSENT));
-        assert!(!requires_cancellation(true, &ABSENT, &PRESENT));
+    fn cancels_only_when_reverted_and_tx_left_the_mempool() {
+        // Reverted and the tx is no longer queued: a real revert, cancel.
+        assert!(requires_cancellation(true, &DROPPED, SUBMISSION_NONCE));
+        // Reverted but still queued: the revert is our own pending tx, so wait.
+        assert!(!requires_cancellation(true, &STILL_QUEUED, SUBMISSION_NONCE));
+        // Re-simulation still succeeds: wait regardless of the nonce.
+        assert!(!requires_cancellation(false, &DROPPED, SUBMISSION_NONCE));
     }
 
     #[test]
-    fn failed_lookup_is_never_treated_as_absent() {
-        // A failed lookup is unknown and must never trigger a cancel, even on a
-        // revert. Otherwise a flaky or unsupported log query reverts to the
-        // original bug: cancelling a tx that may have mined.
-        assert!(!requires_cancellation(true, &LOOKUP_FAILED, &LOOKUP_FAILED));
-        assert!(!requires_cancellation(true, &ABSENT, &LOOKUP_FAILED));
-        assert!(!requires_cancellation(true, &LOOKUP_FAILED, &ABSENT));
+    fn failed_nonce_lookup_never_cancels() {
+        // An unknown pending nonce must never trigger a cancel, even on a revert.
+        // Otherwise a flaky nonce lookup reverts to the original bug: cancelling a
+        // tx that may have mined or is still queued.
+        assert!(!requires_cancellation(true, &NONCE_LOOKUP_FAILED, SUBMISSION_NONCE));
     }
 }

--- a/crates/driver/src/infra/blockchain/mod.rs
+++ b/crates/driver/src/infra/blockchain/mod.rs
@@ -271,30 +271,34 @@ impl Ethereum {
             .map_err(Into::into)
     }
 
-    /// Whether `tx_hash`'s successful `Settlement` event is present in `block`.
-    /// Only a successful settle emits it, and `eth_getLogs` carries the tx
-    /// hash, so this finds the tx even while the receipt-by-hash lookup
-    /// still lags.
-    ///
-    /// `block` may be `Pending`, which not every node supports for log queries:
-    /// some error, others treat it as `latest`. Callers must read an error as
-    /// "unknown", never as "absent".
-    pub async fn contains_successful_tx(
-        &self,
-        tx_hash: eth::TxId,
-        block: alloy::eips::BlockNumberOrTag,
-    ) -> Result<bool, Error> {
+    /// Whether `tx_hash`'s successful `Settlement` event is in the latest block.
+    /// Only a successful settle emits it, and `eth_getLogs` reads a block's logs
+    /// even while the receipt-by-hash lookup still lags, so this sees a freshly
+    /// mined settlement that `eth_getTransactionReceipt` would still miss.
+    pub async fn contains_successful_tx(&self, tx_hash: eth::TxId) -> Result<bool, Error> {
         let logs = self
             .contracts()
             .settlement()
             .event_filter::<::contracts::GPv2Settlement::GPv2Settlement::Settlement>()
-            .from_block(block)
-            .to_block(block)
+            .from_block(alloy::eips::BlockNumberOrTag::Latest)
+            .to_block(alloy::eips::BlockNumberOrTag::Latest)
             .query()
             .await?;
         Ok(logs
             .iter()
             .any(|(_, log)| log.transaction_hash == Some(tx_hash.0)))
+    }
+
+    /// The signer's transaction count including the mempool (the `pending` tag).
+    /// When this exceeds the nonce we submitted with, our tx is still queued in
+    /// the mempool. When it equals that nonce, the tx is no longer there.
+    pub async fn pending_transaction_count(&self, address: eth::Address) -> Result<u64, Error> {
+        self.web3
+            .provider
+            .get_transaction_count(address)
+            .pending()
+            .await
+            .map_err(Into::into)
     }
 
     #[instrument(skip(self), ret(level = Level::DEBUG))]

--- a/crates/driver/src/infra/blockchain/mod.rs
+++ b/crates/driver/src/infra/blockchain/mod.rs
@@ -272,8 +272,9 @@ impl Ethereum {
     }
 
     /// Whether `tx_hash`'s successful `Settlement` event is present in `block`.
-    /// Only a successful settle emits it, and `eth_getLogs` carries the tx hash,
-    /// so this finds the tx even while the receipt-by-hash lookup still lags.
+    /// Only a successful settle emits it, and `eth_getLogs` carries the tx
+    /// hash, so this finds the tx even while the receipt-by-hash lookup
+    /// still lags.
     ///
     /// `block` may be `Pending`, which not every node supports for log queries:
     /// some error, others treat it as `latest`. Callers must read an error as

--- a/crates/driver/src/infra/blockchain/mod.rs
+++ b/crates/driver/src/infra/blockchain/mod.rs
@@ -4,7 +4,6 @@ use {
     alloy::{
         eips::eip1559::Eip1559Estimation,
         network::TransactionBuilder,
-        primitives::Bytes,
         providers::Provider,
         rpc::types::{TransactionReceipt, TransactionRequest},
         transports::TransportErrorKind,
@@ -370,14 +369,6 @@ impl Error {
                 tracing::trace!(is_revert, ?err, "classified error");
                 is_revert
             }
-        }
-    }
-
-    pub fn revert_bytes(&self) -> Option<Bytes> {
-        match self {
-            Error::ContractRpc(err) => err.as_revert_data(),
-            Error::Rpc(err) => err.as_error_resp().and_then(|err| err.as_revert_data()),
-            _ => None,
         }
     }
 }

--- a/crates/driver/src/infra/blockchain/mod.rs
+++ b/crates/driver/src/infra/blockchain/mod.rs
@@ -271,17 +271,25 @@ impl Ethereum {
             .map_err(Into::into)
     }
 
-    /// Whether `tx_hash`'s successful `Settlement` event is in the latest block.
-    /// Only a successful settle emits it, and `eth_getLogs` reads a block's logs
-    /// even while the receipt-by-hash lookup still lags, so this sees a freshly
+    /// Whether `tx_hash`'s successful `Settlement` event is in `block`. Only a
+    /// successful settle emits it, and `eth_getLogs` reads a block's logs even
+    /// while the receipt-by-hash lookup still lags, so this sees a freshly
     /// mined settlement that `eth_getTransactionReceipt` would still miss.
-    pub async fn contains_successful_tx(&self, tx_hash: eth::TxId) -> Result<bool, Error> {
+    /// The caller pins `block` to the number it got from the block stream,
+    /// so the query cannot race ahead to a later `latest` that the tx is
+    /// not in.
+    pub async fn contains_successful_tx(
+        &self,
+        tx_hash: eth::TxId,
+        block: u64,
+    ) -> Result<bool, Error> {
+        let block = alloy::eips::BlockNumberOrTag::Number(block);
         let logs = self
             .contracts()
             .settlement()
             .event_filter::<::contracts::GPv2Settlement::GPv2Settlement::Settlement>()
-            .from_block(alloy::eips::BlockNumberOrTag::Latest)
-            .to_block(alloy::eips::BlockNumberOrTag::Latest)
+            .from_block(block)
+            .to_block(block)
             .query()
             .await?;
         Ok(logs
@@ -289,9 +297,11 @@ impl Ethereum {
             .any(|(_, log)| log.transaction_hash == Some(tx_hash.0)))
     }
 
-    /// The signer's transaction count including the mempool (the `pending` tag).
-    /// When this exceeds the nonce we submitted with, our tx is still queued in
-    /// the mempool. When it equals that nonce, the tx is no longer there.
+    /// The signer's transaction count including the mempool (the `pending`
+    /// tag). A count above the nonce we submitted with means our tx is
+    /// still queued in the mempool or has already mined (the count stays at
+    /// `nonce + 1` once it mines). A count equal to that nonce means the tx
+    /// left the mempool without mining.
     pub async fn pending_transaction_count(&self, address: eth::Address) -> Result<u64, Error> {
         self.web3
             .provider

--- a/crates/driver/src/infra/blockchain/mod.rs
+++ b/crates/driver/src/infra/blockchain/mod.rs
@@ -271,14 +271,18 @@ impl Ethereum {
             .map_err(Into::into)
     }
 
-    /// Returns the block our `Settlement` event for `tx_hash` was found in, if
-    /// any. The event is only emitted on a successful settle, and `eth_getLogs`
-    /// carries the tx hash, so this sees it even when the receipt lookup lags.
-    pub async fn settlement_block(
+    /// Whether `tx_hash`'s successful `Settlement` event is present in `block`.
+    /// Only a successful settle emits it, and `eth_getLogs` carries the tx hash,
+    /// so this finds the tx even while the receipt-by-hash lookup still lags.
+    ///
+    /// `block` may be `Pending`, which not every node supports for log queries:
+    /// some error, others treat it as `latest`. Callers must read an error as
+    /// "unknown", never as "absent".
+    pub async fn contains_successful_tx(
         &self,
         tx_hash: eth::TxId,
         block: alloy::eips::BlockNumberOrTag,
-    ) -> Result<Option<eth::BlockNo>, Error> {
+    ) -> Result<bool, Error> {
         let logs = self
             .contracts()
             .settlement()
@@ -288,10 +292,8 @@ impl Ethereum {
             .query()
             .await?;
         Ok(logs
-            .into_iter()
-            .find(|(_, log)| log.transaction_hash == Some(tx_hash.0))
-            .and_then(|(_, log)| log.block_number)
-            .map(eth::BlockNo))
+            .iter()
+            .any(|(_, log)| log.transaction_hash == Some(tx_hash.0)))
     }
 
     #[instrument(skip(self), ret(level = Level::DEBUG))]

--- a/crates/driver/src/infra/blockchain/mod.rs
+++ b/crates/driver/src/infra/blockchain/mod.rs
@@ -271,6 +271,29 @@ impl Ethereum {
             .map_err(Into::into)
     }
 
+    /// Returns the block our `Settlement` event for `tx_hash` was found in, if
+    /// any. The event is only emitted on a successful settle, and `eth_getLogs`
+    /// carries the tx hash, so this sees it even when the receipt lookup lags.
+    pub async fn settlement_block(
+        &self,
+        tx_hash: eth::TxId,
+        block: alloy::eips::BlockNumberOrTag,
+    ) -> Result<Option<eth::BlockNo>, Error> {
+        let logs = self
+            .contracts()
+            .settlement()
+            .event_filter::<::contracts::GPv2Settlement::GPv2Settlement::Settlement>()
+            .from_block(block)
+            .to_block(block)
+            .query()
+            .await?;
+        Ok(logs
+            .into_iter()
+            .find(|(_, log)| log.transaction_hash == Some(tx_hash.0))
+            .and_then(|(_, log)| log.block_number)
+            .map(eth::BlockNo))
+    }
+
     #[instrument(skip(self), ret(level = Level::DEBUG))]
     pub(super) async fn simulation_gas_price(&self) -> Option<u128> {
         let base_fee = self.current_block().borrow().base_fee;

--- a/crates/driver/src/infra/blockchain/mod.rs
+++ b/crates/driver/src/infra/blockchain/mod.rs
@@ -271,30 +271,33 @@ impl Ethereum {
             .map_err(Into::into)
     }
 
-    /// Whether `tx_hash`'s successful `Settlement` event is in `block`. Only a
-    /// successful settle emits it, and `eth_getLogs` reads a block's logs even
-    /// while the receipt-by-hash lookup still lags, so this sees a freshly
-    /// mined settlement that `eth_getTransactionReceipt` would still miss.
-    /// The caller pins `block` to the number it got from the block stream,
-    /// so the query cannot race ahead to a later `latest` that the tx is
-    /// not in.
-    pub async fn contains_successful_tx(
+    /// The block our successful `Settlement` event for `tx_hash` landed in,
+    /// searching `[from_block, to_block]` inclusive, or `None` if it is not in
+    /// that range. Only a successful settle emits the event, and `eth_getLogs`
+    /// reads block logs even while the receipt-by-hash lookup still lags, so
+    /// this sees a freshly mined settlement that `eth_getTransactionReceipt`
+    /// would still miss. Scanning a range rather than a single block means a
+    /// block the (coalescing) block stream skipped on a fast chain is still
+    /// covered.
+    pub async fn successful_settlement_block(
         &self,
         tx_hash: eth::TxId,
-        block: u64,
-    ) -> Result<bool, Error> {
-        let block = alloy::eips::BlockNumberOrTag::Number(block);
+        from_block: u64,
+        to_block: u64,
+    ) -> Result<Option<eth::BlockNo>, Error> {
         let logs = self
             .contracts()
             .settlement()
             .event_filter::<::contracts::GPv2Settlement::GPv2Settlement::Settlement>()
-            .from_block(block)
-            .to_block(block)
+            .from_block(alloy::eips::BlockNumberOrTag::Number(from_block))
+            .to_block(alloy::eips::BlockNumberOrTag::Number(to_block))
             .query()
             .await?;
         Ok(logs
-            .iter()
-            .any(|(_, log)| log.transaction_hash == Some(tx_hash.0)))
+            .into_iter()
+            .find(|(_, log)| log.transaction_hash == Some(tx_hash.0))
+            .and_then(|(_, log)| log.block_number)
+            .map(eth::BlockNo))
     }
 
     /// The signer's transaction count including the mempool (the `pending`

--- a/crates/driver/src/infra/blockchain/mod.rs
+++ b/crates/driver/src/infra/blockchain/mod.rs
@@ -283,14 +283,15 @@ impl Ethereum {
         &self,
         tx_hash: eth::TxId,
         from_block: u64,
-        to_block: u64,
     ) -> Result<Option<eth::BlockNo>, Error> {
         let logs = self
             .contracts()
             .settlement()
             .event_filter::<::contracts::GPv2Settlement::GPv2Settlement::Settlement>()
             .from_block(alloy::eips::BlockNumberOrTag::Number(from_block))
-            .to_block(alloy::eips::BlockNumberOrTag::Number(to_block))
+            // `Latest` rather than the stream's head: the node may already be a block
+            // or two ahead, and querying up to its real tip narrows the race window.
+            .to_block(alloy::eips::BlockNumberOrTag::Latest)
             .query()
             .await?;
         Ok(logs


### PR DESCRIPTION
# Description

On some chains (Avalanche especially) the node reports a new block before its by-hash receipt lookup catches up. Right after our settlement mines, the driver asks "did my tx land?" by hash, gets "not found", and re-simulates the tx against the pending state to check it still works. That state already includes our just-mined (or still-queued) settlement, so the re-run reverts (`GPv2: order filled` on a full fill, `transfer amount exceeds balance` on a partial). The driver reads that as a real revert, cancels (the cancel then fails with `nonce too low`), and reports the settlement as failed even though it landed. This is the main source of the Avalanche "too many failing settlements" alert, and the settlements actually succeed on-chain.

Instead of trusting the lagging by-hash lookup, the driver now leans on two signals that do not lag:

- Our `Settlement` event in the latest block. The contract emits it only on a successful settle, and `eth_getLogs` reads block logs directly, so it sees the event while the receipt-by-hash lookup is still catching up. If it is there, the tx mined, so report success.
- The signer's pending nonce (`eth_getTransactionCount` with the `pending` tag). While our tx is still in the mempool the pending nonce sits above the nonce we submitted with, so the re-simulation revert is just our own queued tx re-applied, a false positive, and we keep waiting. Only when the pending nonce shows our tx has left the mempool, and the re-simulation still reverts, do we cancel.

An earlier version of this PR used `eth_getLogs` on the `pending` block for the second signal, but measuring our nodes showed `pending` log queries are rejected on 4 of 11 chains (polygon, bnb, arbitrum, linea, with "pending logs are not supported"). `eth_getTransactionCount` on `pending` is accepted on all 11, and since the re-simulation already runs against the `pending` state, the two signals read the same state.

Old code cancelled whenever the re-simulation reverted, minus a brittle `GPv2: order filled` string match that only caught full fills. New code cancels only when the tx is provably gone from the mempool, so a settlement that is mined-but-receipt-lagging or still queued is never cancelled.

# Changes

- Added `Ethereum::contains_successful_tx`, which checks for our `Settlement` event in the latest block via `eth_getLogs`.
- Added `Ethereum::pending_transaction_count`, the signer's nonce including the mempool.
- Reworked the submission loop: report success when the settlement event is already in the latest block, and cancel only when the re-simulation reverts and the pending nonce shows the tx has left the mempool. Anything else keeps waiting.
- Dropped the old `GPv2: order filled` revert-byte special case.

# How to test

New unit tests cover the cancel decision (`requires_cancellation`): a revert with the tx gone from the mempool cancels, a revert while the tx is still queued waits, and an unknown pending nonce never cancels.

The log and nonce lookups and the receipt-lag race itself have no automated coverage. The e2e harness runs anvil, which returns receipts immediately, so it cannot reproduce the lag. Verify on Avalanche: settlements that land on-chain should stop being counted as `driver_settlements{result="SubmissionError"}` and should stop logging a cancel right after a re-simulation revert, while still showing up as on-chain settlements.
