### PR TITLE
[Trivial] Log decoded settlement tx to simulation log during /solve

### DIFF
--- a/crates/driver/src/domain/competition/solution/settlement.rs
+++ b/crates/driver/src/domain/competition/solution/settlement.rs
@@ -184,6 +184,7 @@ impl Settlement {
             .inspect(|res| {
                 tracing::debug!(
                     block = eth.current_block().borrow().number,
+                    transaction = ?transaction.internalized,
                     ?res,
                     "simulated settlement"
                 )


### PR DESCRIPTION
# Description

I'd like to see how a non-winning, non-colocated solver would have settled a transaction in case they had won. I believe this is currently not possible (we only log the transaction when a solver was selected for winning). This information shouldn't be publicly available (solvers only want to commit to a solution if they win), but logging it for debugging purposes should be fine.

I only log the internalized representation, because this is the one that would make it on-chain. Since we simplified buffer accounting (solver takes the risk), we probably no longer need to look at uninternalized calldata.

# Changes
* add a tx field to the simulation log