### PR TITLE
verify balance and approval strategies concurrently

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1900,6 +1900,7 @@ dependencies = [
  "configs",
  "contracts",
  "ethrpc",
+ "futures",
  "maplit",
  "moka",
  "serde",

--- a/crates/balance-overrides/Cargo.toml
+++ b/crates/balance-overrides/Cargo.toml
@@ -22,6 +22,7 @@ clap = { workspace = true }
 configs = { workspace = true }
 contracts = { workspace = true }
 ethrpc = { workspace = true }
+futures = { workspace = true }
 moka = { workspace = true, features = ["sync"] }
 serde = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/balance-overrides/src/approval/mod.rs
+++ b/crates/balance-overrides/src/approval/mod.rs
@@ -14,7 +14,7 @@ use {
     contracts::ERC20,
     ethrpc::Web3,
     moka::sync::Cache,
-    std::{iter, time::Duration},
+    std::{iter, sync::Arc, time::Duration},
 };
 
 /// These are the solady magic bytes for user allowances
@@ -202,6 +202,7 @@ pub(crate) struct Detector {
     web3: Web3,
     probing_depth: u8,
     verification_timeout: Duration,
+    concurrency_limit: usize,
     pub(crate) cache: Cache<OverrideDetectorCacheKey, Option<ApprovalStrategy>>,
 }
 
@@ -210,12 +211,14 @@ impl Detector {
         web3: Web3,
         probing_depth: u8,
         verification_timeout: Duration,
+        concurrency_limit: usize,
         cache_size: u64,
     ) -> Self {
         Self {
             web3,
             probing_depth,
             verification_timeout,
+            concurrency_limit,
             cache: Cache::builder().max_capacity(cache_size).build(),
         }
     }
@@ -307,42 +310,75 @@ impl Detector {
             return Err(DetectionError::NotFound);
         }
 
-        let strategies = find_plausible_strategies_for_slots(
+        // Limit to probing_depth since find_plausible_strategies_for_slots returns one
+        // candidate per observed slot
+        let mut candidates = find_plausible_strategies_for_slots(
             &storage_slots,
             &owner,
             &spender,
             self.probing_depth.into(),
         );
+        candidates.truncate(self.probing_depth.into());
 
-        for (i, strategy) in strategies
-            .iter()
-            .take(self.probing_depth.into())
-            .enumerate()
+        if candidates.is_empty() {
+            tracing::debug!(?token, "no approval slot found for token");
+            return Err(DetectionError::NotFound);
+        }
+
+        let concurrency = std::cmp::min(candidates.len(), self.concurrency_limit);
+        let n = candidates.len();
+        let candidates = Arc::new(candidates);
+
+        let make_fut = move |idx: usize| -> std::pin::Pin<
+            Box<dyn std::future::Future<Output = (usize, Option<ApprovalStrategy>)> + Send>,
+        > {
+            let strategy = candidates[idx].clone();
+            let timeout = self.verification_timeout;
+            Box::pin(async move {
+                match tokio::time::timeout(
+                    timeout,
+                    self.verify_approval_strategy(token, owner, spender, &strategy),
+                )
+                .await
+                {
+                    Ok(Ok(())) => (idx, Some(strategy)),
+                    Ok(Err(err)) => {
+                        tracing::trace!(
+                            ?token,
+                            ?owner,
+                            ?spender,
+                            ?strategy,
+                            ?err,
+                            "approval strategy was not correct"
+                        );
+                        (idx, None)
+                    }
+                    Err(_) => {
+                        tracing::warn!(
+                            ?token,
+                            ?owner,
+                            ?spender,
+                            ?strategy,
+                            "approval strategy verification timed out, skipping"
+                        );
+                        (idx, None)
+                    }
+                }
+            })
+        };
+
+        if let Some((idx, strategy)) =
+            crate::detector::find_first_ordered_concurrent(n, concurrency, make_fut).await
         {
-            let fut = self.verify_approval_strategy(token, owner, spender, strategy);
-            let result = tokio::time::timeout(self.verification_timeout, fut).await;
-
-            match result {
-                Ok(Ok(())) => {
-                    tracing::debug!(
-                        ?token,
-                        ?owner,
-                        ?spender,
-                        ?strategy,
-                        iterations = i + 1,
-                        "verified approval strategy",
-                    );
-                    return Ok(strategy.clone());
-                }
-                Err(_) => {
-                    tracing::warn!(
-                        ?token,
-                        ?strategy,
-                        "approval strategy verification timed out, skipping",
-                    );
-                }
-                Ok(Err(_)) => {}
-            }
+            tracing::debug!(
+                ?token,
+                ?owner,
+                ?spender,
+                ?strategy,
+                candidate_rank = idx + 1,
+                "verified approval strategy",
+            );
+            return Ok(strategy);
         }
 
         tracing::debug!(?token, "no approval slot found for token");

--- a/crates/balance-overrides/src/balance/mod.rs
+++ b/crates/balance-overrides/src/balance/mod.rs
@@ -16,7 +16,7 @@ use {
     contracts::ERC20,
     ethrpc::Web3,
     moka::sync::Cache,
-    std::{collections::HashMap, iter, time::Duration},
+    std::{collections::HashMap, iter, sync::Arc, time::Duration},
 };
 
 /// These are the solady magic bytes for user balances
@@ -297,6 +297,7 @@ pub(crate) struct Detector {
     web3: Web3,
     probing_depth: u8,
     verification_timeout: Duration,
+    concurrency_limit: usize,
     pub(crate) cache: Cache<(Address, Option<Address>), Option<Strategy>>,
 }
 
@@ -305,12 +306,14 @@ impl Detector {
         web3: Web3,
         probing_depth: u8,
         verification_timeout: Duration,
+        concurrency_limit: usize,
         cache_size: u64,
     ) -> Self {
         Self {
             web3,
             probing_depth,
             verification_timeout,
+            concurrency_limit,
             cache: Cache::builder().max_capacity(cache_size).build(),
         }
     }
@@ -427,49 +430,65 @@ impl Detector {
             "testing candidate balance slots",
         );
 
-        for (i, strategy) in strategies.into_iter().enumerate() {
-            // Some tokens (e.g. reflection tokens like LuckyBlock) have
-            // `balanceOf` implementations that iterate over storage arrays.
-            // During verification we override storage slots with a test value —
-            // if that value lands on an array-length slot the EVM loops until
-            // the node's execution timeout. A per-strategy timeout prevents one
-            // slow slot from blocking the entire detection.
-            let result = tokio::time::timeout(
-                self.verification_timeout,
-                self.verify_strategy(token, holder, strategy.clone()),
-            )
-            .await;
+        let mut candidates = strategies;
+        candidates.truncate(self.probing_depth.into());
 
-            match result {
-                Ok(Ok(verified)) => {
-                    tracing::debug!(
-                        ?token,
-                        ?holder,
-                        strategy = ?verified,
-                        iterations = i + 1,
-                        total = storage_slots.len(),
-                        "verified balance strategy via testing",
-                    );
-                    return Ok(verified);
+        if candidates.is_empty() {
+            tracing::debug!(?token, "no balance slot candidates for token");
+            return Err(DetectionError::NotFound);
+        }
+
+        let n = candidates.len();
+        let concurrency = std::cmp::min(n, self.concurrency_limit);
+        let candidates = Arc::new(candidates);
+        let make_fut = move |idx: usize| -> std::pin::Pin<
+            Box<dyn std::future::Future<Output = (usize, Option<Strategy>)> + Send>,
+        > {
+            let strategy = candidates[idx].clone();
+            let timeout = self.verification_timeout;
+            Box::pin(async move {
+                match tokio::time::timeout(
+                    timeout,
+                    self.verify_strategy(token, holder, strategy.clone()),
+                )
+                .await
+                {
+                    Ok(Ok(verified)) => (idx, Some(verified)),
+                    Ok(Err(err)) => {
+                        tracing::trace!(
+                            ?token,
+                            ?holder,
+                            ?strategy,
+                            ?err,
+                            "balance override strategy was not correct"
+                        );
+                        (idx, None)
+                    }
+                    Err(_) => {
+                        tracing::warn!(
+                            ?token,
+                            ?holder,
+                            ?strategy,
+                            "balance override strategy verification timed out, skipping"
+                        );
+                        (idx, None)
+                    }
                 }
-                Err(_) => {
-                    tracing::warn!(
-                        ?token,
-                        ?holder,
-                        ?strategy,
-                        "balance override strategy verification timed out, skipping",
-                    );
-                }
-                Ok(Err(err)) => {
-                    tracing::trace!(
-                        ?token,
-                        ?holder,
-                        ?strategy,
-                        ?err,
-                        "balance override strategy was not correct",
-                    );
-                }
-            }
+            })
+        };
+
+        if let Some((idx, verified)) =
+            crate::detector::find_first_ordered_concurrent(n, concurrency, make_fut).await
+        {
+            tracing::debug!(
+                ?token,
+                ?holder,
+                strategy = ?verified,
+                candidate_rank = idx + 1,
+                total = storage_slots.len(),
+                "verified balance strategy via testing",
+            );
+            return Ok(verified);
         }
 
         tracing::debug!(
@@ -763,7 +782,13 @@ mod tests {
     async fn detects_storage_slots_mainnet() {
         use crate::detector::DEFAULT_VERIFICATION_TIMEOUT;
 
-        let detector = Detector::new(Web3::new_from_env(), 60, DEFAULT_VERIFICATION_TIMEOUT, 100);
+        let detector = Detector::new(
+            Web3::new_from_env(),
+            60,
+            DEFAULT_VERIFICATION_TIMEOUT,
+            crate::detector::DEFAULT_CONCURRENCY_LIMIT,
+            100,
+        );
 
         let storage = detector
             .detect(
@@ -818,7 +843,13 @@ mod tests {
     async fn detects_storage_slots_arbitrum() {
         use crate::detector::DEFAULT_VERIFICATION_TIMEOUT;
 
-        let detector = Detector::new(Web3::new_from_env(), 60, DEFAULT_VERIFICATION_TIMEOUT, 100);
+        let detector = Detector::new(
+            Web3::new_from_env(),
+            60,
+            DEFAULT_VERIFICATION_TIMEOUT,
+            crate::detector::DEFAULT_CONCURRENCY_LIMIT,
+            100,
+        );
 
         let storage = detector
             .detect(
@@ -848,7 +879,13 @@ mod tests {
         use crate::detector::DEFAULT_VERIFICATION_TIMEOUT;
 
         let ausd = address!("00000000efe302beaa2b3e6e1b18d08d69a9012a");
-        let detector = Detector::new(Web3::new_from_env(), 60, DEFAULT_VERIFICATION_TIMEOUT, 100);
+        let detector = Detector::new(
+            Web3::new_from_env(),
+            60,
+            DEFAULT_VERIFICATION_TIMEOUT,
+            crate::detector::DEFAULT_CONCURRENCY_LIMIT,
+            100,
+        );
 
         let strategy = detector
             .detect(ausd, Address::with_last_byte(1))

--- a/crates/balance-overrides/src/detector.rs
+++ b/crates/balance-overrides/src/detector.rs
@@ -8,6 +8,7 @@ use {
 };
 
 pub(crate) const DEFAULT_VERIFICATION_TIMEOUT: Duration = Duration::from_secs(1);
+pub(crate) const DEFAULT_CONCURRENCY_LIMIT: usize = 4;
 
 #[derive(Debug, Error)]
 pub enum SimulationError {
@@ -93,4 +94,81 @@ pub(crate) fn mapping_slot_hash(holder: &Address, map_slot: &[u8; 32]) -> B256 {
     buf[12..32].copy_from_slice(holder.as_slice());
     buf[32..64].copy_from_slice(map_slot);
     keccak256(buf)
+}
+
+/// Returns first successful result in priority order, verifying candidates
+/// concurrently up to `concurrency` limit.
+pub(crate) async fn find_first_ordered_concurrent<'a, T, F>(
+    n: usize,
+    concurrency: usize,
+    make_fut: F,
+) -> Option<(usize, T)>
+where
+    F: Fn(
+        usize,
+    )
+        -> std::pin::Pin<Box<dyn std::future::Future<Output = (usize, Option<T>)> + Send + 'a>>,
+    T: Send + 'a,
+{
+    use futures::stream::{FuturesUnordered, StreamExt};
+
+    type BoxFuture<'a, T> =
+        std::pin::Pin<Box<dyn std::future::Future<Output = (usize, Option<T>)> + Send + 'a>>;
+
+    if n == 0 {
+        return None;
+    }
+    let concurrency = concurrency.max(1);
+    let mut results: Vec<Option<Option<T>>> = (0..n).map(|_| None).collect();
+    let mut in_flight: FuturesUnordered<BoxFuture<'a, T>> = FuturesUnordered::new();
+    let mut dispatch_cursor = 0usize;
+    let mut drain_cursor = 0usize;
+    let mut earliest_success: Option<usize> = None;
+
+    while dispatch_cursor < n && in_flight.len() < concurrency {
+        in_flight.push(make_fut(dispatch_cursor));
+        dispatch_cursor += 1;
+    }
+
+    while let Some((idx, outcome)) = in_flight.next().await {
+        let is_success = outcome.is_some();
+        results[idx] = Some(outcome);
+
+        if is_success {
+            earliest_success = Some(match earliest_success {
+                Some(prev) => prev.min(idx),
+                None => idx,
+            });
+        }
+
+        // Stop dispatching beyond earliest success since we only care about
+        // higher-priority candidates
+        let should_dispatch = match earliest_success {
+            None => true,
+            Some(success_idx) => dispatch_cursor < success_idx,
+        };
+
+        if should_dispatch && dispatch_cursor < n && in_flight.len() < concurrency {
+            in_flight.push(make_fut(dispatch_cursor));
+            dispatch_cursor += 1;
+        }
+
+        // Return first successful result once all higher-priority candidates have
+        // settled
+        while drain_cursor < n {
+            match results[drain_cursor] {
+                None => break,
+                Some(Some(_)) => {
+                    if let Some(Some(value)) = results[drain_cursor].take() {
+                        return Some((drain_cursor, value));
+                    }
+                }
+                Some(None) => {
+                    drain_cursor += 1;
+                }
+            }
+        }
+    }
+
+    None
 }

--- a/crates/balance-overrides/src/lib.rs
+++ b/crates/balance-overrides/src/lib.rs
@@ -51,12 +51,14 @@ impl StateOverrides {
                 web3.clone(),
                 probing_depth,
                 verification_timeout,
+                crate::detector::DEFAULT_CONCURRENCY_LIMIT,
                 cache_size,
             ),
             approval_detector: approval::Detector::new(
                 web3,
                 probing_depth,
                 verification_timeout,
+                crate::detector::DEFAULT_CONCURRENCY_LIMIT,
                 cache_size,
             ),
         }


### PR DESCRIPTION
# Description
Improves detection latency by verifying balance and approval strategy candidates concurrently instead of sequentially. With high RPC latency or timeouts, this reduces worst-case detection time from ~60s to ~15s (assuming all 60 candidates time out at the 1s limit) while preserving priority ordering and avoiding RPC node overload.

# Changes
* Add `find_first_ordered_concurrent` helper for bounded concurrent verification with priority preservation
* Add `concurrency_limit` field (default: 4) to both `balance::Detector` and `approval::Detector`
* Replace sequential verification loops with concurrent execution using `FuturesUnordered`
* Stop dispatching lower-priority candidates once a higher-priority success is already in hand; in-flight 
  higher-priority candidates are still awaited to ensure the best result is returned
* Add `futures` crate dependency for stream utilities

> **Note:** `concurrency_limit` defaults to 4 and is hardcoded for now.
> A follow-up can expose this via environment variable
> if tuning is needed in production.