### PR TITLE
Split the SimulationRevert metric label from on-chain Revert

### DIFF
--- a/crates/driver/src/domain/mempools.rs
+++ b/crates/driver/src/domain/mempools.rs
@@ -472,8 +472,16 @@ impl From<&Result<SubmissionSuccess, Error>> for Outcome {
                 blocks_passed: s.blocks_passed(),
             },
             Err(Error::Disabled) => Outcome::Disabled,
-            Err(err @ (Error::Revert { .. } | Error::SimulationRevert { .. })) => Outcome::Failed {
+            // Real on-chain revert: the tx mined and reverted.
+            Err(err @ Error::Revert { .. }) => Outcome::Failed {
                 reason: "Revert",
+                blocks_passed: err.blocks_passed(),
+            },
+            // Simulation reverted so we never landed the tx (pre-submission check or
+            // a re-simulation while pending). Separate label from on-chain `Revert`
+            // so alerts can tell a driver-side skip from a real on-chain revert.
+            Err(err @ Error::SimulationRevert { .. }) => Outcome::Failed {
+                reason: "SimulationRevert",
                 blocks_passed: err.blocks_passed(),
             },
             Err(err @ Error::Expired { .. }) => Outcome::Failed {


### PR DESCRIPTION
# Description

The `driver_mempool_submission{result}` metric lumped pre-emptive simulation reverts together with genuine on-chain reverts under one `result="Revert"` label. That left alerting unable to tell a driver-side skip or cancel (simulation said the tx would revert, so we never landed it) from a settlement that actually mined and reverted on-chain. Those are different problems with different owners: a false-positive-cancel regression on our side versus solver or order quality. Splitting the label lets the alerts distinguish them.

# Changes

- Give `Error::SimulationRevert` its own `result="SimulationRevert"` label on `driver_mempool_submission`, separate from the on-chain `result="Revert"`.

# How to test

Existing tests. After deploy, `driver_mempool_submission` shows `result="SimulationRevert"` as a series distinct from `result="Revert"`.
