### PR TITLE
fix: account for solver gas fee override in settlement balance check

### DIFF
--- a/crates/driver/src/domain/competition/solution/settlement.rs
+++ b/crates/driver/src/domain/competition/solution/settlement.rs
@@ -197,12 +197,15 @@ impl Settlement {
             eth.balance(solution.solver().address()),
         );
 
-        // Ensure that the solver has sufficient balance for the settlement to be mined
-        // even if the gas price keeps climbing during the tx submission.
+        // Ensure the solver can cover the gas the node reserves to admit the settlement
+        // tx, which is `gas_limit * max_fee_per_gas` at whichever price we submit with.
         let gas = Gas::new(gas_used?, eth.block_gas_limit(), eth.tx_gas_limit())?;
-        let required_eth_balance =
-            // Converting to U256 first avoids possible overflow
-            gas.required_balance(U256::from(gas_price?.max_fee_per_gas).saturating_mul(U256::from(2)));
+        let required_eth_balance = gas.required_balance(submission_max_fee_per_gas(
+            gas_price?.max_fee_per_gas,
+            solution
+                .gas_fee_override()
+                .map(|gas_override| gas_override.max_fee_per_gas),
+        ));
         if solver_eth? < required_eth_balance {
             return Err(Error::SolverAccountInsufficientBalance(
                 required_eth_balance,
@@ -432,6 +435,20 @@ impl Gas {
     }
 }
 
+/// The `max_fee_per_gas` the settlement will be submitted with, used to size
+/// the solver's required balance. Mirrors `apply_gas_fee_override`: with an
+/// override we submit at that value, otherwise at the driver estimate doubled
+/// to absorb the gas price climbing during submission. The override is the
+/// solver's own choice, so we take it as is.
+fn submission_max_fee_per_gas(
+    driver_max_fee_per_gas: u128,
+    override_max_fee_per_gas: Option<u128>,
+) -> U256 {
+    override_max_fee_per_gas
+        .map(U256::from)
+        .unwrap_or_else(|| U256::from(driver_max_fee_per_gas).saturating_mul(U256::from(2)))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -500,5 +517,15 @@ mod tests {
             solution::Error::GasLimitExceeded(_, limit) => assert_eq!(limit, gas(60_000_000)),
             other => panic!("unexpected error: {other:?}"),
         }
+    }
+
+    #[test]
+    fn submission_fee_prefers_override_over_driver_estimate() {
+        // No override: driver estimate, doubled.
+        assert_eq!(submission_max_fee_per_gas(100, None), U256::from(200));
+        // Override above the doubled estimate: use the override.
+        assert_eq!(submission_max_fee_per_gas(100, Some(500)), U256::from(500));
+        // Override below the doubled estimate: still the override, not driver * 2.
+        assert_eq!(submission_max_fee_per_gas(100, Some(50)), U256::from(50));
     }
 }


### PR DESCRIPTION
# Description
Before submitting a winning settlement, the driver checks that the solver has enough ETH to cover gas. It sizes that check against its own gas price estimate. Since #4299, a solver can override the gas price for its solution with a higher `maxFeePerGas`, and the settlement is then submitted at that override. An Ethereum node reserves `gas_limit * maxFeePerGas` of the sender's balance when it accepts a transaction, so a solver funded for the driver's cheap estimate but not for its own higher override passes the check, wins the auction, then gets rejected at submission with `insufficient funds`.

This happened on base on 2026-06-11. Solver `zurui-solve` set `maxFeePerGas = 10 gwei`, roughly 1900x the driver's ~0.005 gwei estimate on base, while holding ~0.0046 ETH. The balance check passed, the solver won two auctions, and both settlements were rejected by every mempool (`have 4618974035905571 want 8438180000000000`, where `want = gas_limit * 10 gwei`). Before #4299 the check price and the submitted price were the same, so insufficient funds only surfaced at simulation time on nearly empty wallets.

# Changes
- Size the pre-submission balance check to the `maxFeePerGas` the tx will actually be submitted with: the solver's gas fee override when set, otherwise the driver's estimate doubled. This mirrors `apply_gas_fee_override`, which submits at the override directly when one is present. Behavior is unchanged when no override is set.

# How to test
New unit test covering the fee selection (override when set, else driver estimate doubled, including an override below the doubled estimate). An underfunded solver that sets a high `maxFeePerGas` override is now rejected at settlement encoding with `SolverAccountInsufficientBalance` instead of winning and failing to broadcast. The existing `settle_with_gas_fee_override` integration test still covers the funded happy path.
