### PR TITLE
optimize `/solve` body serialization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3918,6 +3918,7 @@ dependencies = [
  "bad-tokens",
  "balance-overrides",
  "bigdecimal",
+ "bytes",
  "bytes-hex",
  "chain",
  "chrono",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7397,6 +7397,7 @@ dependencies = [
  "anyhow",
  "aws-config",
  "aws-sdk-s3",
+ "bytes",
  "chrono",
  "flate2",
  "serde",

--- a/crates/driver/Cargo.toml
+++ b/crates/driver/Cargo.toml
@@ -26,6 +26,7 @@ axum = { workspace = true }
 bad-tokens = { workspace = true }
 balance-overrides = { workspace = true }
 bigdecimal = { workspace = true }
+bytes = { workspace = true }
 bytes-hex = { workspace = true }  # may get marked as unused but it's used with serde
 chain = { workspace = true }
 chrono = { workspace = true, default-features = false, features = ["clock"] }

--- a/crates/driver/src/infra/observe/mod.rs
+++ b/crates/driver/src/infra/observe/mod.rs
@@ -24,6 +24,7 @@ use {
     },
     eth_domain_types as eth,
     ethrpc::block_stream::BlockInfo,
+    observe::tracing::lazy::Lazy,
     std::{
         collections::{BTreeMap, HashSet},
         time::Duration,
@@ -332,7 +333,8 @@ pub fn mounting_solver(solver: &solver::Name, path: &str) {
 }
 
 /// Observe that a request is about to be sent to the solver.
-pub fn solver_request(endpoint: &Url, req: &str) {
+pub fn solver_request(endpoint: &Url, req: impl AsRef<[u8]>) {
+    let req = Lazy(|| String::from_utf8_lossy(req.as_ref()));
     tracing::trace!(%endpoint, %req, "sending request to solver");
 }
 

--- a/crates/driver/src/infra/persistence/mod.rs
+++ b/crates/driver/src/infra/persistence/mod.rs
@@ -3,8 +3,7 @@ use {
         domain::competition::auction::Id,
         infra::{config::file, solver::Config},
     },
-    serde::Serialize,
-    serde_json::to_value,
+    bytes::Bytes,
     std::sync::Arc,
     tracing::Instrument,
 };
@@ -55,20 +54,16 @@ impl Persistence {
 
     /// Saves the given auction with liquidity with fire and forget mentality
     /// (non-blocking operation)
-    pub fn archive_auction(&self, auction_id: Id, body: impl Serialize) {
+    pub fn archive_auction(&self, auction_id: Id, body: Bytes) {
         let Some(uploader) = self.s3.clone() else {
             return;
         };
-        let body = match to_value(body) {
-            Ok(body) => body,
-            Err(err) => {
-                tracing::error!(?err, "failed to parse the auction with liquidity to JSON");
-                return;
-            }
-        };
         tokio::spawn(
             async move {
-                match uploader.upload(auction_id.to_string(), body).await {
+                match uploader
+                    .upload_json_bytes(auction_id.to_string(), body)
+                    .await
+                {
                     Ok(key) => {
                         tracing::debug!(?key, "uploaded auction with liquidity to s3");
                     }

--- a/crates/driver/src/infra/solver/mod.rs
+++ b/crates/driver/src/infra/solver/mod.rs
@@ -27,6 +27,7 @@ use {
         signers::{Signature, aws::AwsSigner, local::PrivateKeySigner},
     },
     anyhow::Result,
+    bytes::Bytes,
     derive_more::{From, Into},
     eth_domain_types as eth,
     num::BigRational,
@@ -374,31 +375,32 @@ impl Solver {
 
         // Fetch the solutions from the solver.
         let weth = self.eth.contracts().weth_address();
-        let auction_dto = dto::auction::new(
-            auction,
-            liquidity,
-            weth,
-            self.config.fee_handler,
-            self.config.solver_native_token,
-            &flashloan_hints,
-            &wrappers,
-            auction.deadline(self.timeouts()).solvers(),
-            self.config.haircut_bps,
-        );
 
         let body = {
+            let auction_dto = dto::auction::new(
+                auction,
+                liquidity,
+                weth,
+                self.config.fee_handler,
+                self.config.solver_native_token,
+                &flashloan_hints,
+                &wrappers,
+                auction.deadline(self.timeouts()).solvers(),
+                self.config.haircut_bps,
+            );
+
             // pre-allocate a big enough buffer to avoid re-allocating memory
             // as the request gets serialized
             const BYTES_PER_ORDER: usize = 1_300;
             let mut buffer = Vec::with_capacity(auction.orders().len() * BYTES_PER_ORDER);
             serde_json::to_writer(&mut buffer, &auction_dto).unwrap();
-            String::from_utf8(buffer).expect("serde_json only writes valid utf8")
+            Bytes::from(buffer)
         };
 
         if let Some(id) = auction.id() {
             // Only auctions with IDs are real auctions (/quote requests don't have an ID).
             // Only for those it makes sense to archive them and measure the execution time.
-            self.persistence.archive_auction(id, &auction_dto);
+            self.persistence.archive_auction(id, body.clone());
             ::observe::metrics::metrics().measure_auction_overhead(
                 start,
                 "driver",

--- a/crates/s3/Cargo.toml
+++ b/crates/s3/Cargo.toml
@@ -8,6 +8,7 @@ license = "MIT OR Apache-2.0"
 [dependencies]
 anyhow = { workspace = true }
 aws-config = { workspace = true, features = ["behavior-version-latest"] }
+bytes = { workspace = true }
 aws-sdk-s3 = { workspace = true, features = ["default-https-client", "rt-tokio"] }
 flate2 = { workspace = true }
 serde = { workspace = true }

--- a/crates/s3/Cargo.toml
+++ b/crates/s3/Cargo.toml
@@ -8,8 +8,8 @@ license = "MIT OR Apache-2.0"
 [dependencies]
 anyhow = { workspace = true }
 aws-config = { workspace = true, features = ["behavior-version-latest"] }
-bytes = { workspace = true }
 aws-sdk-s3 = { workspace = true, features = ["default-https-client", "rt-tokio"] }
+bytes = { workspace = true }
 flate2 = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/s3/src/lib.rs
+++ b/crates/s3/src/lib.rs
@@ -2,7 +2,10 @@
 
 use {
     anyhow::{Context, Result, anyhow},
-    aws_sdk_s3::{Client, primitives::ByteStream},
+    aws_sdk_s3::{
+        Client,
+        primitives::{ByteStream, SdkBody},
+    },
     flate2::{Compression, bufread::GzEncoder},
     serde::Serialize,
     std::io::Read,
@@ -46,7 +49,15 @@ impl Uploader {
         })
         .await
         .context("compression task panicked")??;
+        self.upload_json_bytes(id, encoded).await
+    }
 
+    /// Uploads bytes which are expected to be valid JSON to the configured S3
+    /// bucket. Returns the key under which the file can be queried
+    pub async fn upload_json_bytes<T>(&self, id: String, content: T) -> Result<String>
+    where
+        SdkBody: From<T>,
+    {
         let key = std::path::Path::new(&self.filename_prefix)
             .join(format!("{id}.json"))
             .to_str()
@@ -56,7 +67,7 @@ impl Uploader {
             .put_object()
             .bucket(self.bucket.clone())
             .key(key.clone())
-            .body(ByteStream::new(encoded.into()))
+            .body(ByteStream::new(content.into()))
             .content_encoding("gzip")
             .content_type("application/json")
             .send()

--- a/crates/s3/src/lib.rs
+++ b/crates/s3/src/lib.rs
@@ -55,7 +55,7 @@ impl Uploader {
     /// bucket. Compresses the bytes before uploading. Returns the key under
     /// which the file can be queried.
     pub async fn upload_json_bytes(&self, id: String, content: Bytes) -> Result<String> {
-        let compressed = tokio::task::spawn_blocking(move || Self::gzip(content))
+        let compressed = tokio::task::spawn_blocking(move || Self::gzip(&content))
             .await
             .context("compression task panicked")??;
         let key = std::path::Path::new(&self.filename_prefix)
@@ -95,8 +95,8 @@ impl Uploader {
     }
 
     /// Compresses the input bytes using Gzip.
-    fn gzip(bytes: Bytes) -> Result<Vec<u8>> {
-        let mut encoder = GzEncoder::new(bytes.as_ref(), Compression::new(3));
+    fn gzip(bytes: &[u8]) -> Result<Vec<u8>> {
+        let mut encoder = GzEncoder::new(bytes, Compression::new(3));
         let mut encoded: Vec<u8> = Vec::with_capacity(bytes.len());
         encoder.read_to_end(&mut encoded).context("gzip encoding")?;
         Ok(encoded)

--- a/crates/s3/src/lib.rs
+++ b/crates/s3/src/lib.rs
@@ -6,6 +6,7 @@ use {
         Client,
         primitives::{ByteStream, SdkBody},
     },
+    bytes::Bytes,
     flate2::{Compression, bufread::GzEncoder},
     serde::Serialize,
     std::io::Read,
@@ -43,21 +44,20 @@ impl Uploader {
         id: String,
         content: impl Serialize + Send + Sync + 'static,
     ) -> Result<String> {
-        let encoded = tokio::task::spawn_blocking(move || {
-            let bytes = serde_json::to_vec(&content)?;
-            Self::gzip(&bytes)
-        })
-        .await
-        .context("compression task panicked")??;
-        self.upload_json_bytes(id, encoded).await
+        let bytes =
+            tokio::task::spawn_blocking(move || serde_json::to_vec(&content).map(Bytes::from))
+                .await
+                .context("serialization task panicked")??;
+        self.upload_json_bytes(id, bytes).await
     }
 
     /// Uploads bytes which are expected to be valid JSON to the configured S3
-    /// bucket. Returns the key under which the file can be queried
-    pub async fn upload_json_bytes<T>(&self, id: String, content: T) -> Result<String>
-    where
-        SdkBody: From<T>,
-    {
+    /// bucket. Compresses the bytes before uploading. Returns the key under
+    /// which the file can be queried.
+    pub async fn upload_json_bytes(&self, id: String, content: Bytes) -> Result<String> {
+        let compressed = tokio::task::spawn_blocking(move || Self::gzip(content))
+            .await
+            .context("compression task panicked")??;
         let key = std::path::Path::new(&self.filename_prefix)
             .join(format!("{id}.json"))
             .to_str()
@@ -67,7 +67,7 @@ impl Uploader {
             .put_object()
             .bucket(self.bucket.clone())
             .key(key.clone())
-            .body(ByteStream::new(content.into()))
+            .body(ByteStream::new(SdkBody::from(compressed)))
             .content_encoding("gzip")
             .content_type("application/json")
             .send()
@@ -95,8 +95,8 @@ impl Uploader {
     }
 
     /// Compresses the input bytes using Gzip.
-    fn gzip(bytes: &[u8]) -> Result<Vec<u8>> {
-        let mut encoder = GzEncoder::new(bytes, Compression::new(3));
+    fn gzip(bytes: Bytes) -> Result<Vec<u8>> {
+        let mut encoder = GzEncoder::new(bytes.as_ref(), Compression::new(3));
         let mut encoded: Vec<u8> = Vec::with_capacity(bytes.len());
         encoder.read_to_end(&mut encoded).context("gzip encoding")?;
         Ok(encoded)


### PR DESCRIPTION
# Description
This PR applies a few optimizations for memory usage while the driver sends the `/solve` request.

# Changes
First I adjusted the `s3` machinery to allow you to upload already serialized `Bytes` instead of having it re-serialize the data again. Since `Bytes` is internally ref-counted and compatible with `reqwest` we can serialize the request once and then use the same data for the HTTP request and for the S3 upload.

That also allows us to move the creation of the `DTO` into the scope of the request serialization so the `DTO` already gets deallocated before we even send the request (instead of sticking around until we processed the results).