### PR TITLE
Build auction in new function to avoid unnecessary allocations

### DIFF
--- a/crates/driver/src/domain/competition/auction.rs
+++ b/crates/driver/src/domain/competition/auction.rs
@@ -9,7 +9,10 @@ use {
     },
     alloy::primitives::U256,
     eth_domain_types::{self as eth, GasPrice},
-    std::{collections::{HashMap, HashSet}, sync::Arc},
+    std::{
+        collections::{HashMap, HashSet},
+        sync::Arc,
+    },
     thiserror::Error,
 };
 

--- a/crates/driver/src/domain/competition/auction.rs
+++ b/crates/driver/src/domain/competition/auction.rs
@@ -9,7 +9,7 @@ use {
     },
     alloy::primitives::U256,
     eth_domain_types::{self as eth, GasPrice},
-    std::collections::{HashMap, HashSet},
+    std::{collections::{HashMap, HashSet}, sync::Arc},
     thiserror::Error,
 };
 
@@ -23,10 +23,10 @@ pub struct Auction {
     /// See the [`Self::orders`] method.
     pub(crate) orders: Vec<competition::Order>,
     /// The tokens that are used in the orders of this auction.
-    pub(crate) tokens: Tokens,
+    pub(crate) tokens: Arc<Tokens>,
     pub(crate) gas_price: eth::GasPrice,
     pub(crate) deadline: chrono::DateTime<chrono::Utc>,
-    pub(crate) surplus_capturing_jit_order_owners: HashSet<eth::Address>,
+    pub(crate) surplus_capturing_jit_order_owners: Arc<HashSet<eth::Address>>,
 }
 
 impl Auction {
@@ -68,10 +68,10 @@ impl Auction {
         Ok(Self {
             id,
             orders,
-            tokens,
+            tokens: Arc::new(tokens),
             gas_price,
             deadline,
-            surplus_capturing_jit_order_owners,
+            surplus_capturing_jit_order_owners: Arc::new(surplus_capturing_jit_order_owners),
         })
     }
 

--- a/crates/driver/src/domain/competition/mod.rs
+++ b/crates/driver/src/domain/competition/mod.rs
@@ -7,7 +7,11 @@ use {
     },
     crate::{
         domain::{
-            competition::{solution::Settlement, sorting::SortingStrategy},
+            competition::{
+                pre_processing::DataFetchingTasks,
+                solution::Settlement,
+                sorting::SortingStrategy,
+            },
             time::DeadlineExceeded,
         },
         infra::{
@@ -324,43 +328,16 @@ impl Competition {
                 tracing::error!(?err, "pre-processing auction failed");
                 Error::MalformedRequest
             })?;
-        let mut auction = Arc::unwrap_or_clone(tasks.auction.await);
 
-        let solver_address = self.solver.address();
-        let order_sorting_strategies = self.order_sorting_strategies.clone();
+        let auction = self.assemble_auction(&tasks).await;
 
-        // Add the CoW AMM orders to the auction
-        let cow_amm_orders = tasks.cow_amm_orders.await;
-        auction.orders.extend(cow_amm_orders.iter().cloned());
-
-        let sort_orders_future = Self::run_blocking_with_timer("sort_orders", move || {
-            // Use spawn_blocking() because a lot of CPU bound computations are happening
-            // and we don't want to block the runtime for too long.
-            Self::sort_orders(auction, solver_address, order_sorting_strategies)
-        });
-
-        // We can sort the orders and fetch auction data in parallel
-        let (auction, balances, app_data) =
-            tokio::join!(sort_orders_future, tasks.balances, tasks.app_data);
-
-        let auction = Self::run_blocking_with_timer("update_orders", move || {
-            // Same as before with sort_orders, we use spawn_blocking() because a lot of CPU
-            // bound computations are happening and we want to avoid blocking
-            // the runtime.
-            Self::update_orders(auction, balances, app_data, cow_amm_orders)
-        })
+        let liquidity = async {
+            match self.solver.liquidity() {
+                solver::Liquidity::Fetch => tasks.liquidity.await,
+                solver::Liquidity::Skip => Arc::new(Vec::new()),
+            }
+        }
         .await;
-
-        // We can run bad token filtering and liquidity fetching in parallel
-        let (liquidity, auction) = tokio::join!(
-            async {
-                match self.solver.liquidity() {
-                    solver::Liquidity::Fetch => tasks.liquidity.await,
-                    solver::Liquidity::Skip => Arc::new(Vec::new()),
-                }
-            },
-            self.without_unsupported_orders(auction)
-        );
 
         let elapsed = start.elapsed();
         metrics::get()
@@ -634,6 +611,52 @@ impl Competition {
             );
         }
         Some(solved.id.get())
+    }
+
+    async fn assemble_auction(&self, tasks: &DataFetchingTasks) -> Auction {
+        let (base_auction, cow_amm_orders) =
+            tokio::join!(tasks.auction.clone(), tasks.cow_amm_orders.clone());
+
+        let auction = Auction {
+            id: base_auction.id,
+            orders: base_auction
+                .orders
+                .iter()
+                .cloned()
+                .chain(cow_amm_orders.iter().cloned())
+                .collect(),
+            tokens: base_auction.tokens.clone(),
+            gas_price: base_auction.gas_price,
+            deadline: base_auction.deadline,
+            surplus_capturing_jit_order_owners: base_auction
+                .surplus_capturing_jit_order_owners
+                .clone(),
+        };
+
+        let solver_address = self.solver.address();
+        let order_sorting_strategies = self.order_sorting_strategies.clone();
+
+        let sort_orders_future = Self::run_blocking_with_timer("sort_orders", move || {
+            // Use spawn_blocking() because a lot of CPU bound computations are happening
+            // and we don't want to block the runtime for too long.
+            Self::sort_orders(auction, solver_address, order_sorting_strategies)
+        });
+
+        // We can sort the orders and fetch auction data in parallel
+        let (auction, balances, app_data) = tokio::join!(
+            sort_orders_future,
+            tasks.balances.clone(),
+            tasks.app_data.clone()
+        );
+
+        let auction = Self::run_blocking_with_timer("update_orders", move || {
+            // Same as before with sort_orders, we use spawn_blocking() because a lot of CPU
+            // bound computations are happening and we want to avoid blocking
+            // the runtime.
+            Self::update_orders(auction, balances, app_data, cow_amm_orders)
+        })
+        .await;
+        self.without_unsupported_orders(auction).await
     }
 
     // Oders already need to be sorted from most relevant to least relevant so that


### PR DESCRIPTION
# Description
This PR applies 3 optimizations.
First it moves the creation of the auction into a separate function which cuts down the size of the original function and makes the code easier to read.
Secondly it avoids `Arc::unwrap_or_clone(auction)` and instead "manually" constructs the auction. That way we can avoid 1 expensive re-allocation when we push the cow amm orders into the fully cloned auction. Since the majority of the memory used by the auctions are used by orders and `Vec` grows by 2x this should significantly reduce the total memory footprint since we only have a few cow amm orders anyway.
Lastly it wraps `tokens` and `surplus_capturing_jit_order_owners` into `Arc`s as this data does not need to be modified by solvers individually so they can just share the same allocation.