### PR TITLE
[TRIVIAL] merge score handling loops to avoid allocations

### DIFF
--- a/crates/driver/src/domain/competition/mod.rs
+++ b/crates/driver/src/domain/competition/mod.rs
@@ -486,37 +486,31 @@ impl Competition {
         }
 
         // Score the settlements.
-        let scores = settlements
+        let scored: Vec<(Solved, Settlement)> = settlements
             .into_iter()
             .filter_map(|settlement| {
                 observe::scoring(&settlement);
-                settlement
-                    .score(
-                        &auction.native_prices(),
-                        auction.surplus_capturing_jit_order_owners(),
-                    )
-                    .inspect_err(|err| {
-                        observe::scoring_failed(self.solver.name(), err);
+                let score = settlement.score(
+                    &auction.native_prices(),
+                    auction.surplus_capturing_jit_order_owners(),
+                );
+                match score {
+                    Ok(score) => {
+                        observe::score(&settlement, &score);
+                        Some((score, settlement))
+                    }
+                    Err(err) => {
+                        observe::scoring_failed(self.solver.name(), &err);
                         notify::scoring_failed(
                             &self.solver,
                             auction.id(),
                             settlement.solution(),
-                            err,
+                            &err,
                         );
-                    })
-                    .ok()
-                    .map(|score| (score, settlement))
+                        None
+                    }
+                }
             })
-            .collect_vec();
-
-        // Observe the scores.
-        for (score, settlement) in scores.iter() {
-            observe::score(settlement, score);
-        }
-
-        // Build scored settlements sorted best-first.
-        let scored: Vec<(Solved, Settlement)> = scores
-            .into_iter()
             .sorted_by_key(|(score, _)| Reverse(*score))
             .map(|(score, settlement)| {
                 let solved = Solved {

--- a/crates/driver/src/domain/competition/mod.rs
+++ b/crates/driver/src/domain/competition/mod.rs
@@ -488,23 +488,13 @@ impl Competition {
         // Score the settlements.
         let scores = settlements
             .into_iter()
-            .map(|settlement| {
+            .filter_map(|settlement| {
                 observe::scoring(&settlement);
-                (
-                    settlement.score(
+                settlement
+                    .score(
                         &auction.native_prices(),
                         auction.surplus_capturing_jit_order_owners(),
-                    ),
-                    settlement,
-                )
-            })
-            .collect_vec();
-
-        // Filter out settlements which failed scoring.
-        let scores = scores
-            .into_iter()
-            .filter_map(|(result, settlement)| {
-                result
+                    )
                     .inspect_err(|err| {
                         observe::scoring_failed(self.solver.name(), err);
                         notify::scoring_failed(


### PR DESCRIPTION
# Description
The current score handling logic is quite confusing as it first creates intermediate collections which are unnecessary and splits logic across multiple iterator variables instead of chaining.

This PR merges all score related handling into 1 (IMO more readable) iterator chain which avoids allocations as much as possible (no intermediate `collect_vec`)