### PR TITLE
[TRIVIAL] log only cow-amm order uids

### DIFF
--- a/crates/driver/src/domain/competition/pre_processing.rs
+++ b/crates/driver/src/domain/competition/pre_processing.rs
@@ -530,9 +530,9 @@ impl Utilities {
             .collect();
 
         if !orders.is_empty() {
-            tracing::trace!(?orders, "generated cow amm template orders");
-            let only_uids = Lazy(|| orders.iter().map(|o| format!("{:?}", o.uid)).collect_vec());
-            tracing::debug!(orders = ?only_uids, "generated cow amm template orders");
+            tracing::trace!(?orders, "generated cow amm template orders (details)");
+            let orders = Lazy(|| orders.iter().map(|o| o.uid).collect_vec());
+            tracing::debug!(?orders, "generated cow amm template orders");
         }
 
         Arc::new(orders)

--- a/crates/driver/src/domain/competition/pre_processing.rs
+++ b/crates/driver/src/domain/competition/pre_processing.rs
@@ -25,6 +25,7 @@ use {
         order::{OrderKind, SellTokenSource},
         signature::Signature,
     },
+    observe::tracing::lazy::Lazy,
     signature_validator::SignatureValidating,
     std::{
         collections::HashMap,
@@ -529,7 +530,9 @@ impl Utilities {
             .collect();
 
         if !orders.is_empty() {
-            tracing::debug!(?orders, "generated cow amm template orders");
+            tracing::trace!(?orders, "generated cow amm template orders");
+            let only_uids = Lazy(|| orders.iter().map(|o| format!("{:?}", o.uid)).collect_vec());
+            tracing::debug!(orders = ?only_uids, "generated cow amm template orders");
         }
 
         Arc::new(orders)


### PR DESCRIPTION
# Description
In some of the captured heap memory profiles a surprising amount of memory is allocated for logging the generated cow amm orders. This is because we currently log all of their fields. This was somewhat useful when the feature was just introduced and still needed to be debugged but by now nobody actually looks at all those order details.
This PR changes the code to only log the order_uids. To still allow debugging the order details when it's necessary the original log was not deleted but only downgraded to the `trace` level.

<img width="1124" height="818" alt="Screenshot 2026-06-15 at 07 18 42" src="https://github.com/user-attachments/assets/b37f8ea3-48c1-4f5c-9b37-c27aab017908" />