### PR TITLE
Reduce uni v3 memory footprint

### DIFF
--- a/crates/liquidity-sources/src/uniswap_v3/pool_fetching.rs
+++ b/crates/liquidity-sources/src/uniswap_v3/pool_fetching.rs
@@ -126,7 +126,7 @@ struct PoolsCheckpoint {
 struct PoolsCheckpointHandler {
     graph_api: UniV3SubgraphClient,
     /// Address is pool id while TokenPair is a pair or tokens for each pool.
-    pools_by_token_pair: HashMap<TokenPair, HashSet<Address>>,
+    pools_by_token_pair: HashMap<TokenPair, Vec<Address>>,
     /// Pools state on a specific block number in history considered reorg safe
     pools_checkpoint: Mutex<PoolsCheckpoint>,
 }
@@ -150,12 +150,25 @@ impl PoolsCheckpointHandler {
             "initialized registered pools",
         );
 
-        let mut pools_by_token_pair: HashMap<TokenPair, HashSet<Address>> = HashMap::new();
-        for pool in &registered_pools.pools {
-            let pair =
-                TokenPair::new(pool.token0.id, pool.token1.id).context("cant create pair")?;
-            pools_by_token_pair.entry(pair).or_default().insert(pool.id);
-        }
+        let pools_by_token_pair = {
+            let mut pools_by_token_pair: HashMap<TokenPair, Vec<Address>> = HashMap::new();
+            for pool in &registered_pools.pools {
+                let pair =
+                    TokenPair::new(pool.token0.id, pool.token1.id).context("cant create pair")?;
+                // we store addresses in a `Vec` instead of a `HashSet` to safe on memory but
+                // we still want to ensure there are no duplicated pools.
+                let pools = pools_by_token_pair.entry(pair).or_default();
+                if !pools.contains(&pool.id) {
+                    pools.push(pool.id);
+                }
+            }
+            // shrink used memory as much as possible
+            pools_by_token_pair
+                .values_mut()
+                .for_each(|bucket| bucket.shrink_to_fit());
+            pools_by_token_pair.shrink_to_fit();
+            pools_by_token_pair
+        };
 
         // can't fetch the state of all pools in constructor for performance reasons,
         // so let's fetch the top `max_pools_to_initialize_cache` pools with the highest

--- a/crates/liquidity-sources/src/uniswap_v3/pool_fetching.rs
+++ b/crates/liquidity-sources/src/uniswap_v3/pool_fetching.rs
@@ -155,7 +155,7 @@ impl PoolsCheckpointHandler {
             for pool in &registered_pools.pools {
                 let pair =
                     TokenPair::new(pool.token0.id, pool.token1.id).context("cant create pair")?;
-                // we store addresses in a `Vec` instead of a `HashSet` to safe on memory but
+                // we store addresses in a `Vec` instead of a `HashSet` to save on memory but
                 // we still want to ensure there are no duplicated pools.
                 let pools = pools_by_token_pair.entry(pair).or_default();
                 if !pools.contains(&pool.id) {

--- a/crates/liquidity-sources/src/uniswap_v3/pool_fetching.rs
+++ b/crates/liquidity-sources/src/uniswap_v3/pool_fetching.rs
@@ -151,18 +151,17 @@ impl PoolsCheckpointHandler {
         );
 
         let pools_by_token_pair = {
+            // we store addresses in a `Vec` instead of a `HashSet` to save on memory but
+            // we still ensure there are no duplicated pools.
             let mut pools_by_token_pair: HashMap<TokenPair, Vec<Address>> = HashMap::new();
             for pool in &registered_pools.pools {
                 let pair =
                     TokenPair::new(pool.token0.id, pool.token1.id).context("cant create pair")?;
-                // we store addresses in a `Vec` instead of a `HashSet` to save on memory but
-                // we still want to ensure there are no duplicated pools.
                 let pools = pools_by_token_pair.entry(pair).or_default();
                 if !pools.contains(&pool.id) {
                     pools.push(pool.id);
                 }
             }
-            // shrink used memory as much as possible
             pools_by_token_pair
                 .values_mut()
                 .for_each(|bucket| bucket.shrink_to_fit());


### PR DESCRIPTION
# Description
In the heap memory profiles of the driver 10-13% belong to the cache storing all known uni v3 pools.

# Changes
This PR applies 2 simple optimizations:
1. turn cache from `HashMap<K, HashSet<Address>>` to `HashMap<K, Vec<Address>>`. HashSets require significantly more memory than vectors because they have more bookkeeping and also always leave some slots empty to manage hash collisions. And since we never need random access of those sets vector will do just fine.
2. call `.shrink_to_fit()` on the cache and all it's values to minimize the used memory. This cache will never be updated so any memory that is there to accommodate future growth is just wasted.

<img width="1728" height="507" alt="Screenshot 2026-06-15 at 19 51 08" src="https://github.com/user-attachments/assets/1dbca7f9-1702-4565-914a-0760690b7970" />
